### PR TITLE
refactor(adp): converge the ADP sidecar onto pg, dropping the second Postgres driver (BI-C0CEB377)

### DIFF
--- a/docs/superpowers/specs/2026-07-09-adp-postgres-driver-dedup-design.md
+++ b/docs/superpowers/specs/2026-07-09-adp-postgres-driver-dedup-design.md
@@ -1,0 +1,57 @@
+# ADP sidecar Postgres driver dedup — `postgres` → `pg`
+
+_Status: implemented with BI-C0CEB377 · EP-8DC217EB BET-14 (opener) · 2026-07-09_
+_Parent plan: [`2026-07-07-vertical-integration-inward-plan.md`](../plans/2026-07-07-vertical-integration-inward-plan.md) §4 BET-14 (external-surface rationalization, "dual pg drivers")_
+
+## What & why
+
+The platform carried **two** Postgres drivers: `pg` (node-postgres) in
+`apps/web` + `packages/db`, and `postgres` (porsager) used by exactly one
+file — the ADP sidecar's `services/adp/src/lib/db.ts`. Per the rent-not-own
+doctrine, converging two implementations of one part onto the standard is a
+**pure dedup** (step 2, no own/retire — both endpoints are `KEEP_EXTERNAL`),
+so it needs no WWMD gate.
+
+This removes the `postgres` dependency from the SBOM entirely.
+
+## Change (1 source file + manifest + allowlist)
+
+- `services/adp/src/lib/db.ts` — swap `import postgres from "postgres"` →
+  `import { Pool } from "pg"`. `Sql` type becomes `pg.Pool`. The three raw-SQL
+  functions (`loadAdpCredential`, `updateTokenCache`, `insertToolCallLog`)
+  convert from porsager tagged-templates to `pool.query(text, params)` with
+  positional `$n` placeholders. Column identifiers keep their quoted camelCase,
+  so the returned `result.rows` objects still match the row interfaces — no
+  caller change. `getSql()`/`setSqlForTesting()` keep their signatures; pool
+  options map 1:1 (`max`, `idleTimeoutMillis`, `connectionTimeoutMillis`).
+- `services/adp/package.json` — drop `postgres`, add `pg ^8.22.0` (matching
+  apps/web + packages/db) and dev `@types/pg`.
+- `sbom/dependency-allowlist.json` — remove the `postgres` entry; add
+  `services/adp` to `pg`'s workspaces (112 → 111 acknowledged direct deps).
+
+## Blast radius
+
+Confined to `db.ts`. No consumer writes raw SQL (`grep` for `` sql` `` outside
+db.ts is empty) — `creds.ts` and the four tool modules only pass the handle to
+db.ts functions or mock `../lib/db.js` at the module boundary. Touches none of
+the Inside-Out hot-zones (`schema.prisma`, `lib/tak`, `lib/govern`,
+`lib/routing`, `lib/queue`); the one `lib/queue` `pg` importer
+(`model-discovery-refresh.ts`) is the survivor side, untouched.
+
+## Verification
+
+- ADP service: `pnpm --filter dpf-adp-mcp typecheck` exit 0; `test` → 35 passed / 11 skipped.
+- `node scripts/sbom/check-new-dependencies.mjs` → OK (111 acknowledged).
+- Full web `vitest run` → 14874 passed, 0 failed (the lone unhandled-rejection
+  in `lib/voice/transcribe.test.ts` is a pre-existing teardown flake, unrelated).
+- Guard loop 12 green.
+
+## Follow-on (BET-14 tail, WWMD-gated — NOT in this PR)
+
+The remaining BET-14 own-candidates each need their own `principle_decide`
+before code: `nanoid` → a `newId` façade (17 files / 39 sites, no
+custom-alphabet), `dotenv` → Node `--env-file` (3 files), `picomatch` (1 dev
+test). `undici`→native-fetch is low-payoff (primary surface is `request` +
+`MockAgent` + custom-TLS `Agent`) and `undici` is `KEEP_EXTERNAL`; `gray-matter`
+is the sole frontmatter parser (own decision, pulls `yaml`). These are tracked
+under BI-C0CEB377 as subsequent increments.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,9 +545,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.4
         version: 1.29.0(zod@4.4.3)
-      postgres:
-        specifier: ^3.4.9
-        version: 3.4.9
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -561,6 +561,9 @@ importers:
       '@types/node':
         specifier: ^26.0.1
         version: 26.1.0
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -7812,6 +7815,9 @@ packages:
     peerDependencies:
       pg: '>=8.0'
 
+  pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+
   pg-protocol@1.15.0:
     resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
 
@@ -7999,10 +8005,6 @@ packages:
 
   postgres@3.4.7:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
-    engines: {node: '>=12'}
-
-  postgres@3.4.9:
-    resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
     engines: {node: '>=12'}
 
   postman-collection@4.5.0:
@@ -13850,13 +13852,13 @@ snapshots:
   '@types/pg@8.15.6':
     dependencies:
       '@types/node': 26.1.0
-      pg-protocol: 1.15.0
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
 
   '@types/pg@8.20.0':
     dependencies:
       '@types/node': 26.1.0
-      pg-protocol: 1.15.0
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
 
   '@types/picomatch@4.0.3': {}
@@ -17976,6 +17978,8 @@ snapshots:
     dependencies:
       pg: 8.22.0
 
+  pg-protocol@1.14.0: {}
+
   pg-protocol@1.15.0: {}
 
   pg-types@2.2.0:
@@ -18165,8 +18169,6 @@ snapshots:
       xtend: 4.0.2
 
   postgres@3.4.7: {}
-
-  postgres@3.4.9: {}
 
   postman-collection@4.5.0:
     dependencies:

--- a/sbom/dependency-allowlist.json
+++ b/sbom/dependency-allowlist.json
@@ -854,7 +854,8 @@
       "added": "2026-06-21",
       "workspaces": [
         "apps/web",
-        "packages/db"
+        "packages/db",
+        "services/adp"
       ],
       "kinds": [
         "prod"
@@ -888,16 +889,6 @@
       ],
       "kinds": [
         "dev"
-      ],
-      "note": "bootstrap — pre-existing dependency, acknowledged in bulk"
-    },
-    "postgres": {
-      "added": "2026-06-21",
-      "workspaces": [
-        "services/adp"
-      ],
-      "kinds": [
-        "prod"
       ],
       "note": "bootstrap — pre-existing dependency, acknowledged in bulk"
     },

--- a/services/adp/package.json
+++ b/services/adp/package.json
@@ -14,13 +14,14 @@
   "dependencies": {
     "@dpf/integration-shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.0.4",
-    "postgres": "^3.4.9",
+    "pg": "^8.22.0",
     "prom-client": "^15.1.3",
     "undici": "^8.5.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^26.0.1",
+    "@types/pg": "^8.20.0",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/services/adp/src/lib/db.ts
+++ b/services/adp/src/lib/db.ts
@@ -1,13 +1,19 @@
 // Thin Postgres accessor for the adp service.
 //
-// services/adp is a standalone Node app (not a pnpm workspace member), so it
-// doesn't share Prisma with the portal. We only touch three tables and only
-// a handful of columns, so raw SQL via `postgres` is simpler than bundling a
-// duplicate Prisma schema. All writes are additive (UPDATE tokenCacheEnc,
-// INSERT audit rows) — the portal's /api/integrations/adp/connect still owns
-// credential creation and error-state writes.
+// services/adp is a pnpm workspace member but does not share Prisma with the
+// portal. We only touch three tables and a handful of columns, so raw SQL is
+// simpler than bundling a duplicate Prisma schema. All writes are additive
+// (UPDATE tokenCacheEnc, INSERT audit rows) — the portal's
+// /api/integrations/adp/connect still owns credential creation and
+// error-state writes.
+//
+// Uses `pg` (node-postgres), the platform's single canonical Postgres driver
+// (apps/web + packages/db), rather than a second driver — EP-8DC217EB BET-14
+// dep dedup (BI-C0CEB377). `pg` parameterizes with positional `$n`
+// placeholders; column identifiers keep their quoted camelCase so the returned
+// row objects match the interfaces below.
 
-import postgres from "postgres";
+import { Pool } from "pg";
 
 export interface IntegrationCredentialRow {
   id: string;
@@ -32,7 +38,8 @@ export interface IntegrationToolCallLogInsert {
   errorMessage: string | null;
 }
 
-export type Sql = ReturnType<typeof postgres>;
+/** The service's Postgres handle. A `pg` connection pool. */
+export type Sql = Pool;
 
 let _sql: Sql | null = null;
 
@@ -46,22 +53,23 @@ function getConnectionString(): string {
 
 export function getSql(): Sql {
   if (_sql) return _sql;
-  _sql = postgres(getConnectionString(), {
+  _sql = new Pool({
+    connectionString: getConnectionString(),
     max: 4,
-    idle_timeout: 30,
-    connect_timeout: 10,
-    prepare: false,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 10_000,
   });
   return _sql;
 }
 
-// For tests: inject a mock sql instance.
+// For tests: inject a mock pool instance.
 export function setSqlForTesting(sql: Sql | null): void {
   _sql = sql;
 }
 
 export async function loadAdpCredential(sql: Sql): Promise<IntegrationCredentialRow | null> {
-  const rows = await sql<IntegrationCredentialRow[]>`
+  const result = await sql.query<IntegrationCredentialRow>(
+    `
     SELECT
       id,
       "integrationId",
@@ -73,8 +81,9 @@ export async function loadAdpCredential(sql: Sql): Promise<IntegrationCredential
     FROM "IntegrationCredential"
     WHERE "integrationId" = 'adp-workforce-now'
     LIMIT 1
-  `;
-  return rows[0] ?? null;
+  `,
+  );
+  return result.rows[0] ?? null;
 }
 
 export async function updateTokenCache(
@@ -82,38 +91,43 @@ export async function updateTokenCache(
   id: string,
   tokenCacheEnc: string,
 ): Promise<void> {
-  await sql`
+  await sql.query(
+    `
     UPDATE "IntegrationCredential"
-    SET "tokenCacheEnc" = ${tokenCacheEnc}, "updatedAt" = NOW()
-    WHERE id = ${id}
-  `;
+    SET "tokenCacheEnc" = $1, "updatedAt" = NOW()
+    WHERE id = $2
+  `,
+    [tokenCacheEnc, id],
+  );
 }
 
 export async function insertToolCallLog(
   sql: Sql,
   row: IntegrationToolCallLogInsert,
 ): Promise<void> {
-  await sql`
+  await sql.query(
+    `
     INSERT INTO "IntegrationToolCallLog" (
       id, "calledAt", integration, "coworkerId", "userId", "toolName",
       "argsHash", "responseKind", "resultCount", "durationMs",
       "errorCode", "errorMessage"
     )
-    VALUES (
-      ${cuid()},
-      NOW(),
-      ${row.integration},
-      ${row.coworkerId},
-      ${row.userId},
-      ${row.toolName},
-      ${row.argsHash},
-      ${row.responseKind},
-      ${row.resultCount},
-      ${row.durationMs},
-      ${row.errorCode},
-      ${row.errorMessage}
-    )
-  `;
+    VALUES ($1, NOW(), $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+  `,
+    [
+      cuid(),
+      row.integration,
+      row.coworkerId,
+      row.userId,
+      row.toolName,
+      row.argsHash,
+      row.responseKind,
+      row.resultCount,
+      row.durationMs,
+      row.errorCode,
+      row.errorMessage,
+    ],
+  );
 }
 
 // Minimal cuid-style ID generator. Real cuids are 25 chars starting with 'c'.


### PR DESCRIPTION
## What

EP-8DC217EB **BET-14 opener** (BI-C0CEB377). The platform carried **two** Postgres drivers: `pg` (node-postgres) in `apps/web` + `packages/db`, and `postgres` (porsager) used by exactly one file — the ADP sidecar's `services/adp/src/lib/db.ts`. Converging onto the standard is a **pure dedup** (rent-not-own step 2; both endpoints are `KEEP_EXTERNAL`, so no WWMD gate), and it removes the `postgres` dependency from the SBOM.

- `services/adp/src/lib/db.ts` — `import { Pool } from "pg"`; `Sql = pg.Pool`; the three raw-SQL functions convert from porsager tagged-templates to `pool.query(text, params)` with positional `$n` placeholders. Quoted camelCase identifiers preserved → `result.rows` still match the row interfaces, no caller change. `getSql`/`setSqlForTesting` unchanged; pool options map 1:1.
- `services/adp/package.json` — drop `postgres`, add `pg ^8.22.0` + dev `@types/pg`.
- `sbom/dependency-allowlist.json` — remove `postgres`; add `services/adp` to `pg`'s workspaces (112 → 111 acknowledged).
- Spec: `docs/superpowers/specs/2026-07-09-adp-postgres-driver-dedup-design.md`.

Blast radius = `db.ts` only — no consumer writes raw SQL (tests mock `../lib/db.js` at the boundary). No Inside-Out hot-zone touched; the one `lib/queue` `pg` importer is the survivor side.

## Verification

- `pnpm --filter dpf-adp-mcp typecheck` → **exit 0**; `test` → **35 passed / 11 skipped**
- `node scripts/sbom/check-new-dependencies.mjs` → **OK (111 acknowledged)**
- Full web `vitest run` → **14874 passed, 0 failed** (the lone unhandled-rejection in `lib/voice/transcribe.test.ts` is a pre-existing teardown flake, unrelated)
- Guard loop **12 green**

## Local-CI-Override

Pre-push sandbox gate skipped (`DPF_SKIP_PREPUSH_GATE=1`, source-local worktree): adp typecheck + adp tests + new-deps gate + full web vitest (0 failed) + guard loop green. CI is the canonical run.

## Follow-on (WWMD-gated, not here)

BET-14 own-candidates each need their own `principle_decide`: `nanoid`→`newId` (17 files), `dotenv`→`--env-file` (3 files), `picomatch` (1 dev test). Tracked under BI-C0CEB377 as later increments.

Process-Spine-Decision: EP-8DC217EB plan §4 BET-14 dual-pg-driver dedup; rent-not-own step 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)