### PR TITLE
feat(integrate): shared OAuth refresh_token exchange in @dpf/integration-shared (BET-3 opener, BI-ABC88965)

### DIFF
--- a/apps/web/lib/integrate/google-marketing-intelligence/token-client.ts
+++ b/apps/web/lib/integrate/google-marketing-intelligence/token-client.ts
@@ -1,4 +1,5 @@
-import { request, type Dispatcher } from "undici";
+import { refreshOAuthToken } from "@dpf/integration-shared";
+import { type Dispatcher } from "undici";
 
 export interface ExchangeGoogleRefreshTokenParams {
   clientId: string;
@@ -31,78 +32,30 @@ export function resolveGoogleTokenEndpoint(): string {
 export async function exchangeGoogleRefreshToken(
   params: ExchangeGoogleRefreshTokenParams,
 ): Promise<ExchangeGoogleRefreshTokenResult> {
-  let response: Dispatcher.ResponseData;
-  try {
-    response = await request(resolveGoogleTokenEndpoint(), {
-      method: "POST",
-      dispatcher: params.dispatcher,
-      headers: {
-        accept: "application/json",
-        "content-type": "application/x-www-form-urlencoded",
-      },
-      body: new URLSearchParams({
-        client_id: params.clientId,
-        client_secret: params.clientSecret,
-        refresh_token: params.refreshToken,
-        grant_type: "refresh_token",
-      }).toString(),
-    });
-  } catch {
-    throw new GoogleMarketingAuthError(
-      "Google token exchange failed — check network reachability and try again.",
-    );
-  }
-
-  if (response.statusCode === 400 || response.statusCode === 401 || response.statusCode === 403) {
-    await safelyDrainBody(response.body);
-    throw new GoogleMarketingAuthError("invalid Google credentials", {
-      statusCode: response.statusCode,
-    });
-  }
-
-  if (response.statusCode !== 200) {
-    await safelyDrainBody(response.body);
-    throw new GoogleMarketingAuthError(
-      `Google token exchange failed with status ${response.statusCode}`,
-      { statusCode: response.statusCode },
-    );
-  }
-
-  let payload: Record<string, unknown>;
-  try {
-    payload = await response.body.json() as Record<string, unknown>;
-  } catch {
-    throw new GoogleMarketingAuthError("Google token response was not valid JSON", {
-      statusCode: response.statusCode,
-    });
-  }
-
-  const accessToken = typeof payload.access_token === "string" ? payload.access_token : null;
-  if (!accessToken) {
-    throw new GoogleMarketingAuthError("Google token exchange did not return an access token", {
-      statusCode: response.statusCode,
-    });
-  }
-
-  const expiresIn =
-    typeof payload.expires_in === "number"
-      ? payload.expires_in
-      : typeof payload.expires_in === "string"
-        ? Number(payload.expires_in)
-        : 3600;
+  const result = await refreshOAuthToken({
+    endpoint: resolveGoogleTokenEndpoint(),
+    clientId: params.clientId,
+    clientSecret: params.clientSecret,
+    refreshToken: params.refreshToken,
+    credentialPlacement: "body",
+    dispatcher: params.dispatcher,
+    makeError: (message, opts) => new GoogleMarketingAuthError(message, opts),
+    // Google returns 400 (invalid_grant) for a bad refresh token in addition
+    // to the standard 401/403.
+    authErrorStatuses: [400, 401, 403],
+    networkErrorMessage: "Google token exchange failed — check network reachability and try again.",
+    invalidCredsMessage: "invalid Google credentials",
+    missingTokenMessage: "Google token exchange did not return an access token",
+    invalidJsonMessage: "Google token response was not valid JSON",
+    unexpectedStatusMessage: (statusCode) => `Google token exchange failed with status ${statusCode}`,
+  });
 
   return {
-    accessToken,
-    tokenType: typeof payload.token_type === "string" ? payload.token_type : "Bearer",
-    expiresAt: new Date(Date.now() + Math.max(1, expiresIn) * 1000),
-    scope: typeof payload.scope === "string" ? payload.scope : "",
+    accessToken: result.accessToken,
+    tokenType: result.tokenType,
+    expiresAt: result.expiresAt,
+    // Google does not rotate the refresh token; preserve the historic ""
+    // default when the response omits scope.
+    scope: result.scope ?? "",
   };
-}
-
-async function safelyDrainBody(body: { text: () => Promise<string> }): Promise<void> {
-  try {
-    await body.text();
-  } catch {
-    // ignore
-  }
 }

--- a/apps/web/lib/integrate/quickbooks/token-client.ts
+++ b/apps/web/lib/integrate/quickbooks/token-client.ts
@@ -1,4 +1,5 @@
-import { request, type Dispatcher } from "undici";
+import { refreshOAuthToken } from "@dpf/integration-shared";
+import { type Dispatcher } from "undici";
 
 export interface ExchangeRefreshTokenParams {
   clientId: string;
@@ -32,85 +33,34 @@ export function resolveTokenEndpoint(): string {
 export async function exchangeRefreshToken(
   params: ExchangeRefreshTokenParams,
 ): Promise<ExchangeRefreshTokenResult> {
-  const authorization = Buffer.from(`${params.clientId}:${params.clientSecret}`, "utf8").toString("base64");
+  const result = await refreshOAuthToken({
+    endpoint: resolveTokenEndpoint(),
+    clientId: params.clientId,
+    clientSecret: params.clientSecret,
+    refreshToken: params.refreshToken,
+    credentialPlacement: "basic-header",
+    dispatcher: params.dispatcher,
+    makeError: (message, opts) => new QuickBooksAuthError(message, opts),
+    requireRefreshToken: true,
+    serverErrorMessage: "QuickBooks token endpoint returned a server error — retry later.",
+    networkErrorMessage: "QuickBooks token exchange failed — check network reachability and try again.",
+    invalidCredsMessage: "invalid QuickBooks credentials",
+    missingTokenMessage: "QuickBooks token response missing access_token",
+    invalidJsonMessage: "QuickBooks token response was not valid JSON",
+    unexpectedStatusMessage: (statusCode) => `QuickBooks token exchange failed with status ${statusCode}`,
+  });
 
-  let response: Dispatcher.ResponseData;
-  try {
-    response = await request(resolveTokenEndpoint(), {
-      method: "POST",
-      dispatcher: params.dispatcher,
-      headers: {
-        authorization: `Basic ${authorization}`,
-        accept: "application/json",
-        "content-type": "application/x-www-form-urlencoded",
-      },
-      body: new URLSearchParams({
-        grant_type: "refresh_token",
-        refresh_token: params.refreshToken,
-      }).toString(),
-    });
-  } catch {
-    throw new QuickBooksAuthError("QuickBooks token exchange failed — check network reachability and try again.");
-  }
-
-  const { statusCode, body } = response;
-
-  if (statusCode === 401 || statusCode === 403) {
-    await safelyDrainBody(body);
-    throw new QuickBooksAuthError("invalid QuickBooks credentials", { statusCode });
-  }
-
-  if (statusCode >= 500) {
-    await safelyDrainBody(body);
-    throw new QuickBooksAuthError("QuickBooks token endpoint returned a server error — retry later.", { statusCode });
-  }
-
-  if (statusCode !== 200) {
-    await safelyDrainBody(body);
-    throw new QuickBooksAuthError(`QuickBooks token exchange failed with status ${statusCode}`, { statusCode });
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = await body.json();
-  } catch {
-    throw new QuickBooksAuthError("QuickBooks token response was not valid JSON", { statusCode });
-  }
-
-  if (!isTokenResponse(parsed)) {
-    throw new QuickBooksAuthError("QuickBooks token response missing access_token", { statusCode });
+  // requireRefreshToken guarantees a rotated refresh token; narrow for the
+  // caller-facing result type without a non-null assertion.
+  const { refreshToken } = result;
+  if (refreshToken === null) {
+    throw new QuickBooksAuthError("QuickBooks token response missing access_token");
   }
 
   return {
-    accessToken: parsed.access_token,
-    refreshToken: parsed.refresh_token,
-    tokenType: parsed.token_type,
-    expiresAt: new Date(Date.now() + parsed.expires_in * 1000),
+    accessToken: result.accessToken,
+    refreshToken,
+    tokenType: result.tokenType,
+    expiresAt: result.expiresAt,
   };
-}
-
-interface TokenResponse {
-  access_token: string;
-  refresh_token: string;
-  token_type: string;
-  expires_in: number;
-}
-
-function isTokenResponse(value: unknown): value is TokenResponse {
-  if (typeof value !== "object" || value === null) return false;
-  const candidate = value as Record<string, unknown>;
-  return (
-    typeof candidate.access_token === "string" &&
-    typeof candidate.refresh_token === "string" &&
-    typeof candidate.token_type === "string" &&
-    typeof candidate.expires_in === "number"
-  );
-}
-
-async function safelyDrainBody(body: { text: () => Promise<string> }): Promise<void> {
-  try {
-    await body.text();
-  } catch {
-    // ignore
-  }
 }

--- a/docs/superpowers/specs/2026-07-09-shared-oauth-refresh-design.md
+++ b/docs/superpowers/specs/2026-07-09-shared-oauth-refresh-design.md
@@ -1,0 +1,113 @@
+# Shared OAuth `refresh_token` exchange — design
+
+- **Epic / BI:** EP-8DC217EB BET-3 opener · BI-ABC88965
+- **Date:** 2026-07-09
+- **Status:** implemented (opener increment)
+- **Blessed home:** `@dpf/integration-shared` (`packages/integration-shared/src/oauth-refresh.ts`)
+
+## Problem
+
+Provider integrations each hand-rolled their own `token-client.ts`: a ~110–150 LOC
+module implementing the identical RFC-6749 `refresh_token` grant over undici
+`request` — build a form-encoded body, POST it, walk the same status ladder,
+guard JSON + payload, and map to `{ accessToken, refreshToken, tokenType,
+expiresAt }`. The exchange logic was copy-pasted; only a handful of axes actually
+differed between providers. Copy N+1 was the default, and a fix to the exchange
+had to be applied N times.
+
+## What consolidated (2 refresh clones → 1 canonical home)
+
+The refresh-token exchange now has a single home:
+
+```ts
+import { refreshOAuthToken } from "@dpf/integration-shared";
+```
+
+Migrated onto it as thin wrappers (exported names, param/result interfaces,
+error classes, and `resolveXTokenEndpoint()` all unchanged — callers untouched):
+
+- `apps/web/lib/integrate/quickbooks/token-client.ts`
+- `apps/web/lib/integrate/google-marketing-intelligence/token-client.ts`
+
+Each vendor file now declares only its own `XAuthError` class, its endpoint
+resolver, and a wrapper that passes a `makeError` factory + the vendor's exact
+message wording into `refreshOAuthToken`, then maps the generic result to its
+own result shape. The raw undici request, status ladder, and payload mapping are
+gone from the vendor files.
+
+> **Scope note.** The prompt framed this as "5 near-clone refresh_token clients",
+> but reading the files showed only **2** implement the `refresh_token` grant
+> (QuickBooks, Google). The other three — `microsoft365-communications`,
+> `apps/web` ADP, and the `services/adp` port — implement the **`client_credentials`**
+> grant: a different flow with no refresh token, and (for ADP) mTLS dispatcher
+> construction, harness-transport headers, and network-error `errorCode`
+> extraction. Forcing them through a `refreshToken`-required, `grant_type=refresh_token`
+> helper would break the contract or change behavior, so they are a **sibling
+> increment**, not this one. `provider-oauth.ts` also refreshes tokens but over
+> `fetch` (not undici) as a provider-agnostic DB flow — out of scope.
+
+## The config-object variation axes
+
+`OAuthRefreshConfig` captures every axis that legitimately differed:
+
+| Axis | Field | QuickBooks | Google |
+| --- | --- | --- | --- |
+| Credential placement | `credentialPlacement` | `basic-header` (Base64 `id:secret`) | `body` (`client_id`/`client_secret` params) |
+| Invalid-credential statuses | `authErrorStatuses` (default `[401,403]`) | default | `[400,401,403]` |
+| Distinct ≥500 branch | `serverErrorMessage` | set (distinct message) | omitted (falls to generic non-200) |
+| Rotated refresh token required | `requireRefreshToken` (default false) | `true` | `false` (result maps to `null`) |
+| Scope returned | (result `scope: string \| null`) | ignored | mapped, `null → ""` preserved |
+| Endpoint (+ env override) | `endpoint` (resolver stays in vendor file) | `QUICKBOOKS_TOKEN_ENDPOINT_URL` | `GOOGLE_TOKEN_ENDPOINT_URL` |
+| Error class + wording | `makeError` + `*Message` fields | `QuickBooksAuthError` | `GoogleMarketingAuthError` |
+| Extra body params | `extraBodyParams` | — | — |
+
+Constant, non-varying behavior lives in the helper: the exact status-handling
+order (network → auth → ≥500 → non-200 → JSON → payload), `safelyDrainBody` on
+every status-based error path, tolerant `expires_in` parse (`number` |
+numeric-string | default `3600`, then `Math.max(1, …)`), and default
+`token_type` of `"Bearer"`.
+
+## Behavior-preservation constraint
+
+No caller-observable behavior changes. Each vendor keeps its own `Error`
+subclass (via `makeError`) and its exact message strings; the wrappers map the
+generic `OAuthRefreshResult` back to each vendor's historic result shape
+(QuickBooks keeps `refreshToken`; Google keeps `scope` with its `""` default and
+drops the refresh token). All four existing vendor `token-client.test.ts` suites
+and the QuickBooks/Google-business-profile connect-action + preview suites stay
+green untouched.
+
+One extension over the prompt's interface sketch: an `unexpectedStatusMessage(statusCode)`
+field was added, because both vendors emit a provider-prefixed
+"`<Vendor>` token exchange failed with status N" message on the generic non-200
+branch and the sketched interface had no field for it.
+
+Two intentional leniency unifications (prescribed by the shared-result contract,
+unreachable in tested/realistic inputs): under the shared helper QuickBooks now
+defaults an absent `token_type`/`expires_in` instead of rejecting, and rejects a
+literal empty-string `access_token`. No caller or test exercises these edges.
+
+## The ratchet
+
+`scripts/check-no-local-oauth-refresh.mjs` (+ `.test.mjs` self-test) freezes the
+copy count. A file is a violation when it BOTH builds a `grant_type=refresh_token`
+body AND calls undici `request`, anywhere in `apps/web/lib` / `services` /
+`packages` outside the canonical `packages/integration-shared/src/oauth-refresh.ts`.
+The `client_credentials` grant and `fetch`-based refresh are not matched. The
+`ALLOWLIST` is **empty** — the migrated wrappers no longer hold a raw request.
+The BI-3B0AD9CF guard loop auto-discovers `scripts/check-no-*.mjs`; no ci.yml or
+package.json edit is needed.
+
+## Remaining BET-3 tail (later increments under BI-ABC88965)
+
+- **`client_credentials` consolidation** — a sibling `exchangeClientCredentials`
+  helper absorbing `microsoft365-communications`, `apps/web` ADP, and the
+  `services/adp` port (the latter carries mTLS + harness-transport specifics).
+- **~16 `*ApiError` classes** — the per-vendor error class is itself a clone
+  family; a shared base (still per-vendor `name`) is a candidate.
+- **~20 undici clients** — the accounting/probe/list clients repeat the same
+  request + status-ladder + JSON-guard shape.
+- **12 connect-actions** — the connect/validate/persist server-action shape
+  repeats per provider.
+- **credential-crypto implemented twice** — `@dpf/integration-shared`
+  credential-crypto vs `apps/web/lib/govern/credential-crypto.ts`.

--- a/packages/integration-shared/src/index.ts
+++ b/packages/integration-shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./credential-crypto.js";
+export * from "./oauth-refresh.js";
 export * from "./redact.js";
 export * from "./tool-call-audit.js";

--- a/packages/integration-shared/src/oauth-refresh.test.ts
+++ b/packages/integration-shared/src/oauth-refresh.test.ts
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MockAgent } from "undici";
+
+import { refreshOAuthToken, type OAuthRefreshConfig } from "./oauth-refresh";
+
+class TestAuthError extends Error {
+  readonly statusCode: number | undefined;
+  constructor(message: string, opts?: { statusCode?: number }) {
+    super(message);
+    this.name = "TestAuthError";
+    this.statusCode = opts?.statusCode;
+  }
+}
+
+const ENDPOINT = "https://token.example.com/oauth/token";
+
+function baseConfig(
+  overrides: Partial<OAuthRefreshConfig> & Pick<OAuthRefreshConfig, "dispatcher">,
+): OAuthRefreshConfig {
+  return {
+    endpoint: ENDPOINT,
+    clientId: "client-id",
+    clientSecret: "client-secret",
+    refreshToken: "refresh-token-123",
+    credentialPlacement: "basic-header",
+    makeError: (message, opts) => new TestAuthError(message, opts),
+    networkErrorMessage: "network unreachable",
+    invalidCredsMessage: "invalid credentials",
+    missingTokenMessage: "missing access token",
+    invalidJsonMessage: "invalid json",
+    unexpectedStatusMessage: (statusCode) => `unexpected status ${statusCode}`,
+    ...overrides,
+  };
+}
+
+describe("refreshOAuthToken", () => {
+  let mockAgent: MockAgent;
+
+  beforeEach(() => {
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+  });
+
+  afterEach(async () => {
+    await mockAgent.close();
+  });
+
+  function pool() {
+    return mockAgent.get("https://token.example.com");
+  }
+
+  describe("credential placement", () => {
+    it("sends Basic-auth header and no client creds in the body", async () => {
+      let seenAuth = "";
+      let seenBody = "";
+      pool()
+        .intercept({
+          path: "/oauth/token",
+          method: "POST",
+          headers: (headers) => {
+            seenAuth = String(headers.authorization ?? "");
+            return true;
+          },
+          body: (body) => {
+            seenBody = String(body);
+            return true;
+          },
+        })
+        .reply(200, { access_token: "a", refresh_token: "r", token_type: "bearer", expires_in: 3600 });
+
+      await refreshOAuthToken(baseConfig({ dispatcher: mockAgent, credentialPlacement: "basic-header" }));
+
+      expect(seenAuth.startsWith("Basic ")).toBe(true);
+      const decoded = Buffer.from(seenAuth.slice("Basic ".length), "base64").toString("utf8");
+      expect(decoded).toBe("client-id:client-secret");
+      const params = new URLSearchParams(seenBody);
+      expect(params.get("grant_type")).toBe("refresh_token");
+      expect(params.get("refresh_token")).toBe("refresh-token-123");
+      expect(params.get("client_id")).toBeNull();
+      expect(params.get("client_secret")).toBeNull();
+    });
+
+    it("puts client creds in the body and sends no Basic header", async () => {
+      let seenAuth: string | undefined = "unset";
+      let seenBody = "";
+      pool()
+        .intercept({
+          path: "/oauth/token",
+          method: "POST",
+          headers: (headers) => {
+            seenAuth = headers.authorization as string | undefined;
+            return true;
+          },
+          body: (body) => {
+            seenBody = String(body);
+            return true;
+          },
+        })
+        .reply(200, { access_token: "a", token_type: "Bearer", expires_in: 3600 });
+
+      await refreshOAuthToken(baseConfig({ dispatcher: mockAgent, credentialPlacement: "body" }));
+
+      expect(seenAuth).toBeUndefined();
+      const params = new URLSearchParams(seenBody);
+      expect(params.get("client_id")).toBe("client-id");
+      expect(params.get("client_secret")).toBe("client-secret");
+      expect(params.get("grant_type")).toBe("refresh_token");
+    });
+
+    it("merges extraBodyParams", async () => {
+      let seenBody = "";
+      pool()
+        .intercept({
+          path: "/oauth/token",
+          method: "POST",
+          body: (body) => {
+            seenBody = String(body);
+            return true;
+          },
+        })
+        .reply(200, { access_token: "a", expires_in: 3600 });
+
+      await refreshOAuthToken(
+        baseConfig({ dispatcher: mockAgent, extraBodyParams: { audience: "https://api.example.com" } }),
+      );
+
+      expect(new URLSearchParams(seenBody).get("audience")).toBe("https://api.example.com");
+    });
+  });
+
+  describe("success mapping", () => {
+    it("returns the rotated refresh token, token type, scope and raw payload", async () => {
+      pool()
+        .intercept({ path: "/oauth/token", method: "POST" })
+        .reply(200, {
+          access_token: "access-1",
+          refresh_token: "rotated-1",
+          token_type: "bearer",
+          expires_in: 3600,
+          scope: "read write",
+        });
+
+      const result = await refreshOAuthToken(baseConfig({ dispatcher: mockAgent }));
+
+      expect(result.accessToken).toBe("access-1");
+      expect(result.refreshToken).toBe("rotated-1");
+      expect(result.tokenType).toBe("bearer");
+      expect(result.scope).toBe("read write");
+      expect(result.raw.access_token).toBe("access-1");
+      expect(result.expiresAt).toBeInstanceOf(Date);
+    });
+
+    it("returns null refreshToken and null scope when the response omits them", async () => {
+      pool()
+        .intercept({ path: "/oauth/token", method: "POST" })
+        .reply(200, { access_token: "access-1", expires_in: 3600 });
+
+      const result = await refreshOAuthToken(baseConfig({ dispatcher: mockAgent }));
+
+      expect(result.refreshToken).toBeNull();
+      expect(result.scope).toBeNull();
+    });
+
+    it("defaults token_type to Bearer when absent", async () => {
+      pool()
+        .intercept({ path: "/oauth/token", method: "POST" })
+        .reply(200, { access_token: "access-1", expires_in: 3600 });
+
+      const result = await refreshOAuthToken(baseConfig({ dispatcher: mockAgent }));
+
+      expect(result.tokenType).toBe("Bearer");
+    });
+  });
+
+  describe("expires_in tolerance", () => {
+    it("parses a numeric expires_in", async () => {
+      pool()
+        .intercept({ path: "/oauth/token", method: "POST" })
+        .reply(200, { access_token: "a", expires_in: 120 });
+
+      const before = Date.now();
+      const result = await refreshOAuthToken(baseConfig({ dispatcher: mockAgent }));
+      const after = Date.now();
+
+      expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 120 * 1000);
+      expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after + 120 * 1000);
+    });
+
+    it("parses a numeric-string expires_in", async () => {
+      pool()
+        .intercept({ path: "/oauth/token", method: "POST" })
+        .reply(200, { access_token: "a", expires_in: "120" });
+
+      const before = Date.now();
+      const result = await refreshOAuthToken(baseConfig({ dispatcher: mockAgent }));
+      const after = Date.now();
+
+      expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 120 * 1000);
+      expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after + 120 * 1000);
+    });
+
+    it("defaults expires_in to 3600 when absent", async () => {
+      pool()
+        .intercept({ path: "/oauth/token", method: "POST" })
+        .reply(200, { access_token: "a" });
+
+      const before = Date.now();
+      const result = await refreshOAuthToken(baseConfig({ dispatcher: mockAgent }));
+      const after = Date.now();
+
+      expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 3600 * 1000);
+      expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after + 3600 * 1000);
+    });
+  });
+
+  describe("auth-error statuses", () => {
+    it("throws invalid-creds on default 401", async () => {
+      pool().intercept({ path: "/oauth/token", method: "POST" }).reply(401, { error: "invalid_client" });
+
+      await expect(refreshOAuthToken(baseConfig({ dispatcher: mockAgent }))).rejects.toThrow(
+        "invalid credentials",
+      );
+    });
+
+    it("throws invalid-creds on default 403", async () => {
+      pool().intercept({ path: "/oauth/token", method: "POST" }).reply(403, { error: "forbidden" });
+
+      await expect(refreshOAuthToken(baseConfig({ dispatcher: mockAgent }))).rejects.toThrow(
+        "invalid credentials",
+      );
+    });
+
+    it("treats a custom status (Google's 400) as invalid-creds", async () => {
+      pool().intercept({ path: "/oauth/token", method: "POST" }).reply(400, { error: "invalid_grant" });
+
+      await expect(
+        refreshOAuthToken(baseConfig({ dispatcher: mockAgent, authErrorStatuses: [400, 401, 403] })),
+      ).rejects.toThrow("invalid credentials");
+    });
+
+    it("carries the statusCode on the thrown error", async () => {
+      pool().intercept({ path: "/oauth/token", method: "POST" }).reply(401, { error: "invalid_client" });
+
+      const err = await refreshOAuthToken(baseConfig({ dispatcher: mockAgent })).catch((e) => e);
+      expect((err as TestAuthError).statusCode).toBe(401);
+    });
+  });
+
+  describe("server-error branch", () => {
+    it("throws the distinct server-error message on 500 when serverErrorMessage is set", async () => {
+      pool().intercept({ path: "/oauth/token", method: "POST" }).reply(500, "boom");
+
+      await expect(
+        refreshOAuthToken(baseConfig({ dispatcher: mockAgent, serverErrorMessage: "server exploded" })),
+      ).rejects.toThrow("server exploded");
+    });
+
+    it("falls into the generic non-200 branch on 500 when serverErrorMessage is absent", async () => {
+      pool().intercept({ path: "/oauth/token", method: "POST" }).reply(500, "boom");
+
+      await expect(refreshOAuthToken(baseConfig({ dispatcher: mockAgent }))).rejects.toThrow(
+        "unexpected status 500",
+      );
+    });
+  });
+
+  describe("unexpected status", () => {
+    it("throws the unexpected-status message with the status code", async () => {
+      pool().intercept({ path: "/oauth/token", method: "POST" }).reply(302, "redirect");
+
+      await expect(refreshOAuthToken(baseConfig({ dispatcher: mockAgent }))).rejects.toThrow(
+        "unexpected status 302",
+      );
+    });
+  });
+
+  describe("requireRefreshToken", () => {
+    it("throws missing-token when a required refresh_token is absent", async () => {
+      pool()
+        .intercept({ path: "/oauth/token", method: "POST" })
+        .reply(200, { access_token: "a", token_type: "bearer", expires_in: 3600 });
+
+      await expect(
+        refreshOAuthToken(baseConfig({ dispatcher: mockAgent, requireRefreshToken: true })),
+      ).rejects.toThrow("missing access token");
+    });
+
+    it("succeeds when a required refresh_token is present", async () => {
+      pool()
+        .intercept({ path: "/oauth/token", method: "POST" })
+        .reply(200, { access_token: "a", refresh_token: "r", token_type: "bearer", expires_in: 3600 });
+
+      const result = await refreshOAuthToken(
+        baseConfig({ dispatcher: mockAgent, requireRefreshToken: true }),
+      );
+      expect(result.refreshToken).toBe("r");
+    });
+
+    it("does not require a refresh_token when requireRefreshToken is false", async () => {
+      pool()
+        .intercept({ path: "/oauth/token", method: "POST" })
+        .reply(200, { access_token: "a", expires_in: 3600 });
+
+      const result = await refreshOAuthToken(baseConfig({ dispatcher: mockAgent }));
+      expect(result.accessToken).toBe("a");
+      expect(result.refreshToken).toBeNull();
+    });
+  });
+
+  describe("payload guards", () => {
+    it("throws missing-token when access_token is absent", async () => {
+      pool()
+        .intercept({ path: "/oauth/token", method: "POST" })
+        .reply(200, { refresh_token: "r" });
+
+      await expect(refreshOAuthToken(baseConfig({ dispatcher: mockAgent }))).rejects.toThrow(
+        "missing access token",
+      );
+    });
+
+    it("throws invalid-json when the body is not JSON", async () => {
+      pool()
+        .intercept({ path: "/oauth/token", method: "POST" })
+        .reply(200, "not-json", { headers: { "content-type": "application/json" } });
+
+      await expect(refreshOAuthToken(baseConfig({ dispatcher: mockAgent }))).rejects.toThrow(
+        "invalid json",
+      );
+    });
+  });
+
+  describe("network failure", () => {
+    it("throws the network message and does not attach a statusCode", async () => {
+      // No intercept registered + net connect disabled → the request rejects.
+      const err = await refreshOAuthToken(baseConfig({ dispatcher: mockAgent })).catch((e) => e);
+      expect((err as TestAuthError).message).toBe("network unreachable");
+      expect((err as TestAuthError).statusCode).toBeUndefined();
+    });
+  });
+
+  describe("secret redaction", () => {
+    it("never leaks the client secret into a thrown error", async () => {
+      pool().intercept({ path: "/oauth/token", method: "POST" }).reply(401, { error: "invalid_client" });
+
+      const err = await refreshOAuthToken(
+        baseConfig({ dispatcher: mockAgent, clientSecret: "super-secret-do-not-leak" }),
+      ).catch((e) => e);
+      expect((err as Error).message).not.toContain("super-secret-do-not-leak");
+    });
+  });
+});

--- a/packages/integration-shared/src/oauth-refresh.ts
+++ b/packages/integration-shared/src/oauth-refresh.ts
@@ -1,0 +1,185 @@
+import { request, type Dispatcher } from "undici";
+
+/**
+ * BI-ABC88965 (EP-8DC217EB BET-3) — the single canonical home for the
+ * RFC-6749 `refresh_token` grant exchange over undici `request`.
+ *
+ * Before this, every provider integration hand-rolled the same ~110-LOC token
+ * client: build a form-encoded `grant_type=refresh_token` body, POST it with
+ * undici, walk the identical status ladder (401/403 → invalid creds, optional
+ * ≥500 branch, generic non-200, JSON-parse guard, missing-token guard), and
+ * map the payload to `{ accessToken, refreshToken, tokenType, expiresAt }`.
+ *
+ * The only things that legitimately varied between providers are captured as
+ * config here — credential placement (Basic-auth header vs body params), which
+ * statuses count as invalid-credentials, whether a distinct ≥500 branch exists,
+ * whether the response must carry a rotated refresh_token, and the exact
+ * provider-specific error wording. Each provider keeps its OWN error class by
+ * passing a `makeError` factory, so caller-observable behavior is unchanged.
+ *
+ * NOTE — this covers the `refresh_token` grant only. The `client_credentials`
+ * clients (Microsoft 365, ADP) are a DIFFERENT grant with their own shape
+ * (mTLS dispatcher construction, harness-transport headers, no refresh token)
+ * and consolidate under a sibling increment.
+ */
+
+export interface OAuthRefreshConfig {
+  /** Fully-resolved token endpoint URL (provider resolves its own env override). */
+  endpoint: string;
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  /** Where the client credentials go: an HTTP Basic header, or body params. */
+  credentialPlacement: "basic-header" | "body";
+  /** Optional undici dispatcher — primarily a MockAgent in tests. */
+  dispatcher?: Dispatcher;
+  /** Extra form-body params merged after the standard grant params. */
+  extraBodyParams?: Record<string, string>;
+  /** Provider error factory — preserves each vendor's Error subclass + name. */
+  makeError: (message: string, opts?: { statusCode?: number }) => Error;
+  /** HTTP statuses treated as invalid-credentials. Default [401, 403]. */
+  authErrorStatuses?: number[];
+  /** When set, statusCode ≥ 500 throws this. When omitted, ≥ 500 falls into the
+   *  generic non-200 branch (i.e. no distinct server-error message). */
+  serverErrorMessage?: string;
+  /** When true, the response MUST carry a string refresh_token. Default false. */
+  requireRefreshToken?: boolean;
+  /** Provider-specific "check network reachability" message (network failure). */
+  networkErrorMessage: string;
+  /** Provider-specific "invalid X credentials" message (auth-error statuses). */
+  invalidCredsMessage: string;
+  /** Provider-specific "did not return an access token" message. */
+  missingTokenMessage: string;
+  /** Provider-specific "response was not valid JSON" message. */
+  invalidJsonMessage: string;
+  /** Provider-specific message for an unexpected (non-200, non-auth, non-5xx)
+   *  status — receives the status code. */
+  unexpectedStatusMessage: (statusCode: number) => string;
+}
+
+export interface OAuthRefreshResult {
+  accessToken: string;
+  /** The rotated refresh token, or null for non-rotating providers. */
+  refreshToken: string | null;
+  /** token_type from the response, defaulting to "Bearer" when absent. */
+  tokenType: string;
+  expiresAt: Date;
+  /** Granted scope string, or null when the response omits it. */
+  scope: string | null;
+  /** The raw parsed token response, for provider-specific extraction. */
+  raw: Record<string, unknown>;
+}
+
+const DEFAULT_AUTH_ERROR_STATUSES = [401, 403];
+const DEFAULT_EXPIRES_IN_SECONDS = 3600;
+
+/**
+ * Perform an OAuth 2.0 `refresh_token` grant exchange. Throws — via
+ * `config.makeError` — on network failure, auth error, unexpected status,
+ * invalid JSON, or a missing/invalid token payload.
+ */
+export async function refreshOAuthToken(
+  config: OAuthRefreshConfig,
+): Promise<OAuthRefreshResult> {
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    "content-type": "application/x-www-form-urlencoded",
+  };
+
+  const params = new URLSearchParams();
+  params.set("grant_type", "refresh_token");
+  params.set("refresh_token", config.refreshToken);
+
+  if (config.credentialPlacement === "basic-header") {
+    const authorization = Buffer.from(
+      `${config.clientId}:${config.clientSecret}`,
+      "utf8",
+    ).toString("base64");
+    headers.authorization = `Basic ${authorization}`;
+  } else {
+    params.set("client_id", config.clientId);
+    params.set("client_secret", config.clientSecret);
+  }
+
+  for (const [key, value] of Object.entries(config.extraBodyParams ?? {})) {
+    params.set(key, value);
+  }
+
+  let response: Dispatcher.ResponseData;
+  try {
+    response = await request(config.endpoint, {
+      method: "POST",
+      dispatcher: config.dispatcher,
+      headers,
+      body: params.toString(),
+    });
+  } catch {
+    throw config.makeError(config.networkErrorMessage);
+  }
+
+  const { statusCode, body } = response;
+  const authErrorStatuses = config.authErrorStatuses ?? DEFAULT_AUTH_ERROR_STATUSES;
+
+  if (authErrorStatuses.includes(statusCode)) {
+    await safelyDrainBody(body);
+    throw config.makeError(config.invalidCredsMessage, { statusCode });
+  }
+
+  if (config.serverErrorMessage !== undefined && statusCode >= 500) {
+    await safelyDrainBody(body);
+    throw config.makeError(config.serverErrorMessage, { statusCode });
+  }
+
+  if (statusCode !== 200) {
+    await safelyDrainBody(body);
+    throw config.makeError(config.unexpectedStatusMessage(statusCode), { statusCode });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await body.json();
+  } catch {
+    throw config.makeError(config.invalidJsonMessage, { statusCode });
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    throw config.makeError(config.missingTokenMessage, { statusCode });
+  }
+  const raw = parsed as Record<string, unknown>;
+
+  const accessToken = typeof raw.access_token === "string" ? raw.access_token : null;
+  if (!accessToken) {
+    throw config.makeError(config.missingTokenMessage, { statusCode });
+  }
+
+  const rotatedRefreshToken =
+    typeof raw.refresh_token === "string" ? raw.refresh_token : null;
+  if (config.requireRefreshToken && rotatedRefreshToken === null) {
+    throw config.makeError(config.missingTokenMessage, { statusCode });
+  }
+
+  const rawExpiresIn = raw.expires_in;
+  const expiresIn =
+    typeof rawExpiresIn === "number"
+      ? rawExpiresIn
+      : typeof rawExpiresIn === "string"
+        ? Number(rawExpiresIn)
+        : DEFAULT_EXPIRES_IN_SECONDS;
+
+  return {
+    accessToken,
+    refreshToken: rotatedRefreshToken,
+    tokenType: typeof raw.token_type === "string" ? raw.token_type : "Bearer",
+    expiresAt: new Date(Date.now() + Math.max(1, expiresIn) * 1000),
+    scope: typeof raw.scope === "string" ? raw.scope : null,
+    raw,
+  };
+}
+
+async function safelyDrainBody(body: { text: () => Promise<string> }): Promise<void> {
+  try {
+    await body.text();
+  } catch {
+    // ignore — we don't care about the content, just need to release the socket
+  }
+}

--- a/scripts/check-no-local-oauth-refresh.mjs
+++ b/scripts/check-no-local-oauth-refresh.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * BI-ABC88965 (EP-8DC217EB BET-3) — CI ratchet: no NEW hand-rolled OAuth
+ * `refresh_token` grant client.
+ *
+ * The RFC-6749 `refresh_token` exchange over undici `request` was hand-copied
+ * into a near-identical ~110-LOC `token-client.ts` per provider (QuickBooks,
+ * Google Marketing Intelligence, ...), each re-deriving the same form-encoded
+ * `grant_type=refresh_token` POST, the same status ladder, and the same payload
+ * mapping. It now has one canonical home:
+ *
+ *   import { refreshOAuthToken } from "@dpf/integration-shared";
+ *
+ * This guard freezes the copy count. A file is a violation when it BOTH builds
+ * a `grant_type=refresh_token` body AND calls undici `request` — i.e. a raw
+ * refresh-token token client — anywhere outside the canonical home. New code
+ * must call `refreshOAuthToken` instead of spawning copy N+1.
+ *
+ * Out of scope by construction: the `client_credentials` grant (Microsoft 365,
+ * ADP) is a different flow and is not matched; provider-oauth.ts refreshes over
+ * `fetch` (not undici `request`) and is a provider-agnostic DB flow, so it is
+ * not matched either.
+ *
+ * Scope: apps/web/lib, services, packages (source only, tests excluded). The
+ * canonical definition in packages/integration-shared/src/oauth-refresh.ts is
+ * the single sanctioned home and is skipped by path.
+ *
+ * Run: node scripts/check-no-local-oauth-refresh.mjs
+ */
+import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
+import { join, relative } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// The one sanctioned home for the refresh_token exchange — never flagged.
+export const CANONICAL = "packages/integration-shared/src/oauth-refresh.ts";
+
+// Source roots that may contain provider token clients.
+export const SCAN_DIRS = ["apps/web/lib", "services", "packages"];
+
+// Files that STILL hand-roll a refresh_token client at the BI-ABC88965 baseline
+// (a migration backlog — delete an entry once the file calls refreshOAuthToken).
+// Aim: empty. The migrated QuickBooks/Google wrappers no longer contain the raw
+// request, so nothing is allowlisted.
+export const ALLOWLIST = new Set([]);
+
+/** A `grant_type=refresh_token` form body — object-literal or `.set(...)` form. */
+const REFRESH_GRANT_PATTERNS = [
+  /grant_type["']?\s*:\s*["']refresh_token["']/,
+  /["']grant_type["']\s*,\s*["']refresh_token["']/,
+  /grant_type=refresh_token/,
+];
+
+/** Imports `request` from undici AND calls it. */
+function usesUndiciRequest(body) {
+  const importsRequest = /import\s*\{[^}]*\brequest\b[^}]*\}\s*from\s*["']undici["']/.test(body);
+  const callsRequest = /\brequest\s*\(/.test(body);
+  return importsRequest && callsRequest;
+}
+
+function hasRefreshTokenGrant(body) {
+  return REFRESH_GRANT_PATTERNS.some((p) => p.test(body));
+}
+
+/** True when `body` is a raw undici refresh_token token client. */
+export function isRefreshTokenGrantClient(body) {
+  return hasRefreshTokenGrant(body) && usesUndiciRequest(body);
+}
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) {
+      if (entry === "node_modules" || entry === ".next" || entry === "__snapshots__" || entry === "dist") continue;
+      yield* walk(full);
+    } else if (s.isFile()) {
+      if (full.endsWith(".test.ts") || full.endsWith(".test.tsx") || full.endsWith(".d.ts")) continue;
+      if (!full.endsWith(".ts") && !full.endsWith(".tsx")) continue;
+      yield full;
+    }
+  }
+}
+
+/** Scan SCAN_DIRS under `root`; return raw refresh-token clients outside the allowlist. */
+export function scanRepo(root = process.cwd()) {
+  const violations = [];
+  for (const dir of SCAN_DIRS) {
+    const scanDir = join(root, dir);
+    if (!existsSync(scanDir)) continue;
+    for (const file of walk(scanDir)) {
+      const rel = relative(root, file).replace(/\\/g, "/");
+      if (rel === CANONICAL || ALLOWLIST.has(rel)) continue;
+      let body;
+      try {
+        body = readFileSync(file, "utf8");
+      } catch {
+        continue;
+      }
+      if (isRefreshTokenGrantClient(body)) {
+        violations.push({ file: rel });
+      }
+    }
+  }
+  return violations;
+}
+
+/** Allowlisted files that no longer hand-roll a refresh_token client — stale entries. */
+export function findStaleAllowlist(root = process.cwd()) {
+  const stale = [];
+  for (const rel of ALLOWLIST) {
+    let body;
+    try {
+      body = readFileSync(join(root, rel), "utf8");
+    } catch {
+      stale.push(rel); // file gone
+      continue;
+    }
+    if (!isRefreshTokenGrantClient(body)) stale.push(rel);
+  }
+  return stale;
+}
+
+function main() {
+  const violations = scanRepo();
+  const stale = findStaleAllowlist();
+
+  if (violations.length > 0) {
+    console.error("");
+    console.error("ERROR: BI-ABC88965 — a NEW hand-rolled OAuth refresh_token client was added.");
+    console.error("");
+    console.error("There is one canonical refresh_token exchange. Call it instead of copying:");
+    console.error('  import { refreshOAuthToken } from "@dpf/integration-shared";');
+    console.error("");
+    console.error("Offending files (build a grant_type=refresh_token body + call undici request):");
+    for (const v of violations) console.error(`  ${v.file}`);
+    console.error("");
+    process.exit(1);
+  }
+
+  if (stale.length > 0) {
+    console.error("");
+    console.error("ERROR: BI-ABC88965 — the oauth-refresh allowlist is stale.");
+    console.error("These files no longer hand-roll a refresh_token client (migrated or removed);");
+    console.error("delete them from ALLOWLIST in scripts/check-no-local-oauth-refresh.mjs:");
+    for (const f of stale) console.error(`  ${f}`);
+    console.error("");
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ No new hand-rolled OAuth refresh_token clients (${ALLOWLIST.size} pending migration to @dpf/integration-shared).`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-no-local-oauth-refresh.test.mjs
+++ b/scripts/check-no-local-oauth-refresh.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * BI-ABC88965 — tests for the local-oauth-refresh duplication ratchet.
+ * Run: node --test scripts/check-no-local-oauth-refresh.test.mjs
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ALLOWLIST,
+  CANONICAL,
+  isRefreshTokenGrantClient,
+  findStaleAllowlist,
+  scanRepo,
+} from "./check-no-local-oauth-refresh.mjs";
+
+const RAW_CLIENT = `
+import { request, type Dispatcher } from "undici";
+export async function exchange(params) {
+  const response = await request("https://oauth.example.com/token", {
+    method: "POST",
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: params.refreshToken,
+    }).toString(),
+  });
+  return response;
+}
+`;
+
+test("flags a raw undici refresh_token client", () => {
+  assert.equal(isRefreshTokenGrantClient(RAW_CLIENT), true);
+});
+
+test("flags the .set(...) grant form too", () => {
+  const body = `
+import { request } from "undici";
+const p = new URLSearchParams();
+p.set("grant_type", "refresh_token");
+await request(url, { method: "POST", body: p.toString() });
+`;
+  assert.equal(isRefreshTokenGrantClient(body), true);
+});
+
+test("does NOT flag a thin wrapper that calls the shared helper", () => {
+  const body = `
+import { refreshOAuthToken } from "@dpf/integration-shared";
+import { type Dispatcher } from "undici";
+export async function exchange(params) {
+  return refreshOAuthToken({ endpoint, credentialPlacement: "basic-header", refreshToken: params.refreshToken });
+}
+`;
+  assert.equal(isRefreshTokenGrantClient(body), false);
+});
+
+test("does NOT flag a client_credentials client (different grant)", () => {
+  const body = `
+import { request } from "undici";
+await request(url, {
+  method: "POST",
+  body: new URLSearchParams({ grant_type: "client_credentials", client_id: id }).toString(),
+});
+`;
+  assert.equal(isRefreshTokenGrantClient(body), false);
+});
+
+test("does NOT flag a refresh_token grant sent over fetch (no undici request)", () => {
+  const body = `
+const refreshData = { grant_type: "refresh_token", refresh_token: decrypted };
+const res = await fetch(provider.tokenUrl, { method: "POST", body: new URLSearchParams(refreshData).toString() });
+`;
+  assert.equal(isRefreshTokenGrantClient(body), false);
+});
+
+test("the live repo passes the guard — no raw refresh_token clients outside the canonical home", () => {
+  assert.deepEqual(scanRepo(), []);
+});
+
+test("the allowlist is not stale — every entry still hand-rolls a client", () => {
+  assert.deepEqual(findStaleAllowlist(), []);
+});
+
+test("the canonical home is not itself allowlisted (it is the sanctioned source)", () => {
+  assert.equal(ALLOWLIST.has(CANONICAL), false);
+});


### PR DESCRIPTION
## What

EP-8DC217EB **BET-3 opener** (BI-ABC88965) — the integration/adapter substrate is the densest duplication in the codebase, and its consolidation home already exists and is blessed (`@dpf/integration-shared`). This lands the first shared primitive and migrates the clones onto it.

- **`packages/integration-shared/src/oauth-refresh.ts`** (new) — canonical `refreshOAuthToken(config)` implementing the RFC-6749 refresh_token grant once, re-exported from the package barrel.
- Migrated **quickbooks** (116→66) and **google-marketing-intelligence** (108→61) token-clients to thin wrappers (net **−97 LOC** across the two clones). Exported names, param/result interfaces, error classes, and `resolveXTokenEndpoint()` are unchanged → **callers (connect-action / preview) untouched**.
- **Ratchet:** `scripts/check-no-local-oauth-refresh.mjs` (+ self-test) bans a new file that builds a `grant_type=refresh_token` body AND calls undici `request` outside the canonical home. **Empty allowlist.** Auto-discovered by the guard loop.
- Spec: `docs/superpowers/specs/2026-07-09-shared-oauth-refresh-design.md`.

### Scope call (deliberate)
Of the 5 `token-client.ts` files, only **2 implement the refresh_token grant** (QuickBooks, Google); the other 3 (both ADP + Microsoft 365) implement **`client_credentials`** — a genuinely different flow, with mTLS/harness-transport specifics in ADP. Forcing them through a refresh-token helper would change behavior, so they're a documented **sibling increment** under BI-ABC88965 (along with the 16 `*ApiError` classes, ~20 undici clients, 12 connect-actions, and the twice-implemented credential-crypto — the rest of the BET-3 tail).

### Variation axes folded into the config object
credential placement (basic-header | body), invalid-cred statuses (default `[401,403]`; Google adds 400), distinct ≥500 branch (present/absent), refresh-token-required (QB) vs not (Google → `null`), scope returned (Google, `null→""` preserved), per-vendor endpoint/env-override + error class + message wording (via `makeError` + message fields). Constant behavior (status order, `safelyDrainBody`, tolerant `expires_in`, default `token_type`) lives in the helper.

## Verification

Substrate: source-local, worktree `bet3-oauth` (merged current origin/main incl. #2742):
- `pnpm --filter @dpf/integration-shared exec vitest run` → **29 passed** (incl. 23 new oauth-refresh tests: both cred placements, custom auth statuses, 500-branch present/absent, refresh-required true/false, missing token, invalid JSON, network failure, tolerant expires_in)
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` → **exit 0**
- `pnpm --filter web exec vitest run` (full suite) → **exit 0, 1733 files / 14874 passed, 0 failed** (no flakes triggered)
- Guard loop **13 green** (incl. the new ratchet, empty allowlist); module-size OK

## Local-CI-Override

Pre-push sandbox gate skipped (`DPF_SKIP_PREPUSH_GATE=1`, source-local worktree): full typecheck exit 0 + integration-shared + full web vitest exit 0 + guards green. CI is the canonical run.

> Authored by a build subagent; verification (post-merge re-run of all gates) and review done by hand.

Process-Spine-Decision: EP-8DC217EB plan §4 BET-3 (integration substrate opener) + §6 ratchet discipline; migration onto the blessed `@dpf/integration-shared` home, not invention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)