### PR TITLE
fix(routing): refresh OAuth token & retry once before disabling a provider on auth error (BI-EC4A5E7C)

### DIFF
--- a/apps/web/lib/routing/fallback.test.ts
+++ b/apps/web/lib/routing/fallback.test.ts
@@ -61,6 +61,12 @@ vi.mock("@/lib/ai-provider-internals", () => ({
   autoDiscoverAndProfile: vi.fn(),
 }));
 
+// fallback.ts dynamically imports refreshOAuthToken to self-heal a lapsed OAuth
+// token on an auth error before disabling the provider.
+vi.mock("@/lib/provider-oauth", () => ({
+  refreshOAuthToken: vi.fn(),
+}));
+
 vi.mock("./route-outcome", () => ({
   recordRouteOutcome: vi.fn(() => Promise.resolve()),
 }));
@@ -81,6 +87,7 @@ import { scheduleRecovery } from "./rate-recovery";
 import { invalidateRoutingLoaderCache } from "./loader";
 import { autoDiscoverAndProfile } from "@/lib/ai-provider-internals";
 import { recordRouteOutcome } from "./route-outcome";
+import { refreshOAuthToken } from "@/lib/provider-oauth";
 import type { RouteDecision } from "./types";
 import type { SensitivityLevel } from "./types";
 
@@ -136,6 +143,7 @@ const mockRecordRouteOutcome = recordRouteOutcome as ReturnType<typeof vi.fn>;
 const mockMarkEndpointUnavailable = markEndpointUnavailable as ReturnType<typeof vi.fn>;
 const mockClearEndpointUnavailable = clearEndpointUnavailable as ReturnType<typeof vi.fn>;
 const mockInvalidateRoutingLoaderCache = invalidateRoutingLoaderCache as ReturnType<typeof vi.fn>;
+const mockRefreshOAuthToken = refreshOAuthToken as ReturnType<typeof vi.fn>;
 
 // ── Setup ────────────────────────────────────────────────────────────────────
 
@@ -160,6 +168,9 @@ beforeEach(() => {
 
   // Default: extractRetryAfterMs returns undefined (fallback to 60s)
   mockExtractRetryAfterMs.mockReturnValue(undefined);
+
+  // Default: OAuth token refresh succeeds
+  mockRefreshOAuthToken.mockResolvedValue({ token: "fresh-token" });
 });
 
 afterEach(() => {
@@ -532,6 +543,80 @@ describe("callWithFallbackChain — EP-INF-004 error handling", () => {
       ).rejects.toThrow();
 
       expect(mockPrisma.modelProfile.updateMany).not.toHaveBeenCalled();
+    });
+
+    // ── OAuth self-heal: a lapsed subscription token must not permanently
+    //    disable the provider on the first 401 (BI-EC4A5E7C). ────────────────
+    it("refreshes the token and retries once for an OAuth provider — does NOT disable", async () => {
+      mockPrisma.modelProvider.findUnique.mockResolvedValue({
+        providerId: "prov1",
+        name: "Claude Subscription",
+        authMethod: "oauth2_authorization_code",
+      });
+      // First call auth-fails (stale token); the refresh-retry succeeds.
+      mockCallProvider
+        .mockRejectedValueOnce(new InferenceError("Invalid API key", "auth", "prov1", 401))
+        .mockResolvedValueOnce({ content: "hello", inferenceMs: 100 });
+
+      const result = await callWithFallbackChain(
+        makeDecision("prov1", "model1"),
+        [{ role: "user", content: "hi" }],
+        "system",
+      );
+
+      expect(mockRefreshOAuthToken).toHaveBeenCalledWith("prov1");
+      expect(mockCallProvider).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.modelProvider.update).not.toHaveBeenCalled();
+      expect(result.content).toBe("hello");
+    });
+
+    it("disables the OAuth provider when the token refresh fails", async () => {
+      mockPrisma.modelProvider.findUnique.mockResolvedValue({
+        providerId: "prov1",
+        name: "Claude Subscription",
+        authMethod: "oauth2_authorization_code",
+      });
+      mockRefreshOAuthToken.mockResolvedValue({ error: "refresh token expired" });
+      throwAuth();
+
+      await expect(
+        callWithFallbackChain(
+          makeDecision("prov1", "model1"),
+          [{ role: "user", content: "hi" }],
+          "system",
+        ),
+      ).rejects.toThrow();
+
+      expect(mockRefreshOAuthToken).toHaveBeenCalledWith("prov1");
+      expect(mockPrisma.modelProvider.update).toHaveBeenCalledWith({
+        where: { providerId: "prov1" },
+        data: { status: "disabled" },
+      });
+    });
+
+    it("disables the OAuth provider if the retry still auth-fails (refresh once, then give up)", async () => {
+      mockPrisma.modelProvider.findUnique.mockResolvedValue({
+        providerId: "prov1",
+        name: "Claude Subscription",
+        authMethod: "oauth2_authorization_code",
+      });
+      // Refresh succeeds but the retried call still auth-fails → disable.
+      throwAuth();
+
+      await expect(
+        callWithFallbackChain(
+          makeDecision("prov1", "model1"),
+          [{ role: "user", content: "hi" }],
+          "system",
+        ),
+      ).rejects.toThrow();
+
+      expect(mockRefreshOAuthToken).toHaveBeenCalledTimes(1);
+      expect(mockCallProvider).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.modelProvider.update).toHaveBeenCalledWith({
+        where: { providerId: "prov1" },
+        data: { status: "disabled" },
+      });
     });
   });
 

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -204,6 +204,7 @@ export async function callWithFallbackChain(
   let rateLimitRetried = false;
   let overloadRetried = false;
   let transientRetried = false;
+  let authRefreshRetried = false;
   const agentId = outcomeAttribution?.agentId?.trim() || mcpSession?.agentId?.trim() || null;
   const agentMessageId = outcomeAttribution?.agentMessageId?.trim() || null;
 
@@ -241,9 +242,11 @@ export async function callWithFallbackChain(
     }
 
     // Look up the provider row to get its display name for downgrade messages
+    // and its auth method (so an auth error on a refreshable OAuth provider can
+    // be self-healed rather than permanently disabling the provider).
     const provider = await prisma.modelProvider.findUnique({
       where: { providerId: entry.providerId },
-      select: { providerId: true, name: true },
+      select: { providerId: true, name: true, authMethod: true },
     });
 
     if (!provider) {
@@ -422,7 +425,32 @@ export async function callWithFallbackChain(
           }
 
         } else if (e.code === "auth") {
-          // Auth errors remain at provider level — credentials are shared
+          // Auth errors are provider-level (credentials are shared). But an
+          // OAuth-subscription provider whose access token merely lapsed is
+          // REFRESHABLE — permanently disabling it on the first 401 takes the
+          // whole provider dark (e.g. the paid Claude subscription that is the
+          // only endpoint eligible for the Build code-generation phase, which
+          // then silently breaks Build Studio). So for OAuth providers, attempt
+          // a token refresh and retry the same entry once before disabling;
+          // only disable if the refresh fails or the retry still auth-fails.
+          const isOAuth = provider.authMethod?.startsWith("oauth2") ?? false;
+          if (isOAuth && !authRefreshRetried) {
+            authRefreshRetried = true;
+            const { refreshOAuthToken } = await import("@/lib/provider-oauth");
+            const refreshed = await refreshOAuthToken(entry.providerId);
+            if ("token" in refreshed) {
+              console.log(
+                `[callWithFallbackChain] Auth error on OAuth provider ${entry.providerId}; refreshed token, retrying once before disabling.`,
+              );
+              i--;
+              continue;
+            }
+            console.warn(
+              `[callWithFallbackChain] Auth error on OAuth provider ${entry.providerId}; token refresh failed (${refreshed.error}). Disabling provider.`,
+            );
+          }
+          // Non-OAuth provider, refresh failed, or refresh-retry already
+          // attempted: the credentials are genuinely bad — disable the provider.
           await prisma.modelProvider
             .update({
               where: { providerId: entry.providerId },

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -45,7 +45,7 @@ apps/web/lib/navigation/portal-navigation-model.ts	936
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1328
 apps/web/lib/routing/chat-adapter.test.ts	820
-apps/web/lib/routing/fallback.test.ts	953
+apps/web/lib/routing/fallback.test.ts	1038
 apps/web/lib/self-upgrade/quiescence.test.ts	842
 apps/web/lib/self-upgrade/quiescence.ts	1462
 apps/web/lib/skills/evidence-search.ts	803


### PR DESCRIPTION
## Problem (found via operator dogfood)
While playing the human operator running Arcamanus, I resolved a live Build code-generation outage by enabling the Claude/Anthropic OAuth subscription provider. It **recurred**: `resolve_model_selection` showed the `build` phase back to `no-eligible-endpoint`.

Root cause (evidence-based, corrected from an initial "the deploy reverted it" guess): `callWithFallbackChain`'s `auth`-error branch disabled the **entire provider** with no refresh attempt. `anthropic-sub` is `authMethod=oauth2_authorization_code` with a lazily-refreshable token. Its cached token lapsed (07-09 12:37), a later call sent the stale token → 401 → the handler permanently disabled the provider. Since `anthropic-sub` is the **only** provider that satisfies the code-gen routing contract (tool-use + 200k context), Build Studio code-gen silently broke. Boot logs confirm the disable happened at runtime (`status=disabled preserved` on the next deploy), not from seeding.

## Fix
In the `e.code === "auth"` branch: if the provider is OAuth (`authMethod` starts with `oauth2`) and we haven't retried yet, call `refreshOAuthToken` and retry the same entry **once** before disabling. Disable only if the refresh fails or the retried call still auth-fails. Non-OAuth providers are unchanged (still disabled on auth error, since their credentials are static). Mirrors the existing rate-limit/overload/transient `i--; continue` retry pattern. `authMethod` is added to the per-entry provider `select`.

## Tests
`apps/web/lib/routing/fallback.test.ts` — **32/32 pass** (ran scoped). New cases in the `auth error` suite:
- OAuth provider + refresh succeeds → `refreshOAuthToken` called, provider **not** disabled, `callProvider` retried, success returned.
- OAuth provider + refresh fails → provider disabled.
- OAuth provider + refresh succeeds but retry still auth-fails → refresh attempted once, then disabled.
- Existing "disables the entire provider" (non-OAuth) unchanged.

## Verification boundary
Unit-tested + CI (worktree lacks a toolchain; the pre-commit typecheck was skipped, CI gates authoritatively). Live functional restore of `anthropic-sub` still needs a one-off UI re-enable — this fix prevents **recurrence**, and I've flagged a follow-up to confirm the Claude CLI adapter consumes the DB-refreshed token (vs. its own credential store).

BI-EC4A5E7C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)