### PR TITLE
feat(coworker-memory): session-start projection briefing (BI-A9052DCB)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -674,6 +674,22 @@ export async function sendMessage(input: {
   } catch (err) {
     console.warn("[thread-checkpoint] inject failed:", getErrorMessage(err));
   }
+
+  // BI-A9052DCB (EP-8C706944 P3): prepend the session-start projection briefing —
+  // a precomputed "what you already know about this user" block distilled offline
+  // from governed records — ahead of the recency window. Strict no-op until a
+  // briefing exists; the read lazily fire-and-forget refreshes it when stale.
+  if (user.id) {
+    try {
+      const { loadUserBriefingMessage } = await import("@/lib/tak/coworker-briefing-runner");
+      const briefingMessage = await loadUserBriefingMessage(agent.agentId, user.id);
+      if (briefingMessage) {
+        chatHistory = [briefingMessage, ...chatHistory];
+      }
+    } catch (err) {
+      console.warn("[coworker-briefing] inject failed:", getErrorMessage(err));
+    }
+  }
   const recentContentForClassification = chatHistory
     .slice(-3)
     .map((m) => typeof m.content === "string" ? m.content : JSON.stringify(m.content));

--- a/apps/web/lib/tak/coworker-briefing-runner.ts
+++ b/apps/web/lib/tak/coworker-briefing-runner.ts
@@ -1,0 +1,122 @@
+// apps/web/lib/tak/coworker-briefing-runner.ts
+// Server-side generation + read of the session-start briefing (BI-A9052DCB).
+// Gathers governed source records, assembles the block with the pure builder, and
+// upserts the CoworkerBriefing projection. Generation is offline/lazy: the read
+// path prepends the stored briefing and fire-and-forget refreshes it when stale,
+// so no session ever waits on regeneration.
+//
+// The briefing is keyed by the business agentId (Agent.agentId — the same value
+// AgentMessage/ToolExecution use), consistent with the rest of the coworker
+// surface. The notes lookup resolves the Agent row's cuid internally, since
+// CoworkerMemoryNote is keyed by Agent.id.
+
+import { prisma } from "@dpf/db";
+import {
+  buildBriefingContent,
+  briefingSourceDigest,
+  formatBriefingMessage,
+  type BriefingSources,
+} from "./coworker-briefing";
+import { loadUserFacts } from "./user-facts";
+import { loadCoworkerNotes } from "./coworker-memory";
+
+/** Refresh the briefing when it is older than this (offline projection cadence). */
+export const BRIEFING_STALE_MS = 24 * 60 * 60 * 1000;
+
+async function loadNotesForBusinessAgent(agentId: string) {
+  try {
+    const { resolveCoworkerAgent } = await import("./coworker-tool-grant-core");
+    const resolved = await resolveCoworkerAgent(agentId);
+    if (!resolved) return [];
+    return await loadCoworkerNotes(resolved.id, 6);
+  } catch {
+    return [];
+  }
+}
+
+async function gatherUserBriefingSources(
+  agentId: string,
+  userId: string,
+): Promise<BriefingSources> {
+  const [user, facts, notes, recentThread] = await Promise.all([
+    prisma.user.findUnique({ where: { id: userId }, select: { email: true } }),
+    loadUserFacts(userId, undefined, 8),
+    loadNotesForBusinessAgent(agentId),
+    // The user's most recent thread with a durable checkpoint provides a
+    // one-line "recent context" carry-forward without RAG over transcripts.
+    prisma.agentThread.findFirst({
+      where: { userId, compactedSummary: { not: null } },
+      orderBy: { updatedAt: "desc" },
+      select: { compactedSummary: true },
+    }),
+  ]);
+
+  return {
+    subjectLabel: user?.email ?? userId,
+    businessLine: null,
+    topFacts: facts.map((f) => ({ key: f.key, value: f.value })),
+    notes: notes.map((n) => ({ noteKind: n.noteKind, noteKey: n.noteKey, content: n.content })),
+    recentDecisions: recentThread?.compactedSummary ? [recentThread.compactedSummary] : [],
+    spendLine: null,
+  };
+}
+
+/**
+ * Regenerate the user-scoped briefing for (coworker, user). Skips the write when
+ * the source digest is unchanged. Returns whether it wrote.
+ */
+export async function generateUserBriefing(
+  agentId: string,
+  userId: string,
+): Promise<{ written: boolean }> {
+  const sources = await gatherUserBriefingSources(agentId, userId);
+  const content = buildBriefingContent(sources);
+  const digest = briefingSourceDigest(sources);
+  const key = { agentId_scope_scopeKey: { agentId, scope: "user", scopeKey: userId } };
+
+  const existing = await prisma.coworkerBriefing.findUnique({
+    where: key,
+    select: { sourceDigest: true },
+  });
+  if (existing && existing.sourceDigest === digest) return { written: false };
+
+  // Nothing worth briefing → remove any stale row so we stop injecting it.
+  if (content === null) {
+    if (existing) await prisma.coworkerBriefing.delete({ where: key });
+    return { written: false };
+  }
+
+  await prisma.coworkerBriefing.upsert({
+    where: key,
+    create: { agentId, scope: "user", scopeKey: userId, content, sourceDigest: digest },
+    update: { content, sourceDigest: digest, generatedAt: new Date() },
+  });
+  return { written: true };
+}
+
+/**
+ * Read the user-scoped briefing as a prependable history message, and
+ * fire-and-forget refresh it when stale/missing. Null when there is no briefing
+ * (strict no-op). Non-fatal on any error.
+ */
+export async function loadUserBriefingMessage(
+  agentId: string,
+  userId: string,
+): Promise<{ role: "user"; content: string } | null> {
+  try {
+    const row = await prisma.coworkerBriefing.findUnique({
+      where: { agentId_scope_scopeKey: { agentId, scope: "user", scopeKey: userId } },
+      select: { content: true, generatedAt: true },
+    });
+    const stale = !row || Date.now() - row.generatedAt.getTime() > BRIEFING_STALE_MS;
+    if (stale) {
+      generateUserBriefing(agentId, userId).catch((e) =>
+        console.warn("[coworker-briefing] refresh failed:", e),
+      );
+    }
+    return formatBriefingMessage(row?.content ?? null);
+  } catch (err) {
+    console.warn("[coworker-briefing] load failed:", err);
+    return null;
+  }
+}

--- a/apps/web/lib/tak/coworker-briefing.test.ts
+++ b/apps/web/lib/tak/coworker-briefing.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildBriefingContent,
+  briefingSourceDigest,
+  formatBriefingMessage,
+  BRIEFING_MAX_FACTS,
+  BRIEFING_CONTENT_CHAR_CAP,
+  type BriefingSources,
+} from "./coworker-briefing";
+
+const base: BriefingSources = {
+  subjectLabel: "dale@example.com",
+  businessLine: null,
+  topFacts: [],
+  notes: [],
+  recentDecisions: [],
+  spendLine: null,
+};
+
+describe("buildBriefingContent", () => {
+  it("returns null when there is no durable signal (strict no-op)", () => {
+    expect(buildBriefingContent(base)).toBeNull();
+  });
+
+  it("renders facts, notes, and recent decisions under a header", () => {
+    const out = buildBriefingContent({
+      ...base,
+      topFacts: [{ key: "cloud_provider", value: "AWS" }],
+      notes: [{ noteKind: "preference", noteKey: "review_style", content: "bullets" }],
+      recentDecisions: ["chose TDD for the billing module"],
+    });
+    expect(out).not.toBeNull();
+    expect(out).toContain("BRIEFING — dale@example.com");
+    expect(out).toContain("cloud_provider: AWS");
+    expect(out).toContain("[preference] review_style: bullets");
+    expect(out).toContain("chose TDD for the billing module");
+  });
+
+  it("renders a business line alone as sufficient signal", () => {
+    const out = buildBriefingContent({ ...base, businessLine: "HVAC field service" });
+    expect(out).toContain("Context: HVAC field service");
+  });
+
+  it("caps the number of facts", () => {
+    const many = Array.from({ length: BRIEFING_MAX_FACTS + 5 }, (_, i) => ({
+      key: `k${i}`,
+      value: `v${i}`,
+    }));
+    const out = buildBriefingContent({ ...base, topFacts: many })!;
+    const factLines = out.split("\n").filter((l) => l.startsWith("- k"));
+    expect(factLines).toHaveLength(BRIEFING_MAX_FACTS);
+  });
+
+  it("caps overall content length", () => {
+    const huge = Array.from({ length: 200 }, (_, i) => `decision ${i} ${"x".repeat(50)}`);
+    const out = buildBriefingContent({ ...base, recentDecisions: huge })!;
+    expect(out.length).toBeLessThanOrEqual(BRIEFING_CONTENT_CHAR_CAP);
+  });
+});
+
+describe("briefingSourceDigest", () => {
+  it("is stable for identical inputs", () => {
+    const s: BriefingSources = { ...base, topFacts: [{ key: "a", value: "1" }] };
+    expect(briefingSourceDigest(s)).toBe(briefingSourceDigest({ ...s }));
+  });
+
+  it("changes when a fact value changes", () => {
+    const a = briefingSourceDigest({ ...base, topFacts: [{ key: "a", value: "1" }] });
+    const b = briefingSourceDigest({ ...base, topFacts: [{ key: "a", value: "2" }] });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("formatBriefingMessage", () => {
+  it("returns null for empty content", () => {
+    expect(formatBriefingMessage(null)).toBeNull();
+    expect(formatBriefingMessage(undefined)).toBeNull();
+    expect(formatBriefingMessage("")).toBeNull();
+  });
+
+  it("wraps content as a user-role session-briefing message", () => {
+    const m = formatBriefingMessage("BRIEFING — x");
+    expect(m).not.toBeNull();
+    expect(m!.role).toBe("user");
+    expect(m!.content).toContain("SESSION BRIEFING");
+    expect(m!.content).toContain("BRIEFING — x");
+  });
+});

--- a/apps/web/lib/tak/coworker-briefing.ts
+++ b/apps/web/lib/tak/coworker-briefing.ts
@@ -1,0 +1,103 @@
+// apps/web/lib/tak/coworker-briefing.ts
+// Session-start projection briefing — BI-A9052DCB (EP-8C706944 Phase 3).
+//
+// Instead of RAG over transcripts, precompute a compact "what you should know"
+// block from governed records and inject it at session start (ChatGPT's
+// reference-chat-history model: derived profile sections, not transcript search).
+// This module assembles the block deterministically from already-selected source
+// data — cheap, auditable, cache-friendly, and unit-testable with no DB/model.
+
+/** The distilled inputs a briefing is assembled from. */
+export type BriefingSources = {
+  /** scope="user": display name / handle for the person; scope="org": org name. */
+  subjectLabel: string;
+  /** One-line business framing (BusinessContext.mission/valueProposition). */
+  businessLine?: string | null;
+  /** Highest-signal durable facts, already ranked (key + value). */
+  topFacts: Array<{ key: string; value: string }>;
+  /** The coworker's own role-local notes relevant to this subject. */
+  notes: Array<{ noteKind: string; noteKey: string; content: string }>;
+  /** Recent decisions/outcomes worth carrying forward. */
+  recentDecisions: string[];
+  /** Optional running spend note for spend-aware framing. */
+  spendLine?: string | null;
+};
+
+export const BRIEFING_MAX_FACTS = 8;
+export const BRIEFING_MAX_NOTES = 6;
+export const BRIEFING_MAX_DECISIONS = 5;
+export const BRIEFING_CONTENT_CHAR_CAP = 3000;
+
+function clampList<T>(items: T[], max: number): T[] {
+  return items.length > max ? items.slice(0, max) : items;
+}
+
+/**
+ * Assemble the briefing block. Returns null when there is nothing worth saying
+ * (no facts, notes, decisions, or business line) so the block is a strict no-op.
+ */
+export function buildBriefingContent(sources: BriefingSources): string | null {
+  const facts = clampList(sources.topFacts, BRIEFING_MAX_FACTS);
+  const notes = clampList(sources.notes, BRIEFING_MAX_NOTES);
+  const decisions = clampList(sources.recentDecisions, BRIEFING_MAX_DECISIONS);
+
+  const hasContent =
+    facts.length > 0 ||
+    notes.length > 0 ||
+    decisions.length > 0 ||
+    !!sources.businessLine;
+  if (!hasContent) return null;
+
+  const lines: string[] = [`BRIEFING — ${sources.subjectLabel}`];
+  if (sources.businessLine) lines.push(`Context: ${sources.businessLine}`);
+  if (sources.spendLine) lines.push(`Spend so far: ${sources.spendLine}`);
+
+  if (facts.length > 0) {
+    lines.push("Known facts:");
+    for (const f of facts) lines.push(`- ${f.key}: ${f.value}`);
+  }
+  if (notes.length > 0) {
+    lines.push("Your working notes:");
+    for (const n of notes) lines.push(`- [${n.noteKind}] ${n.noteKey}: ${n.content}`);
+  }
+  if (decisions.length > 0) {
+    lines.push("Recent decisions:");
+    for (const d of decisions) lines.push(`- ${d}`);
+  }
+
+  const content = lines.join("\n");
+  return content.length > BRIEFING_CONTENT_CHAR_CAP
+    ? content.slice(0, BRIEFING_CONTENT_CHAR_CAP)
+    : content;
+}
+
+/**
+ * A stable digest of the inputs, so the offline refresh can skip regeneration
+ * (and an unchanged write) when nothing material has changed. Order-sensitive by
+ * design — a reordering of ranked facts is a meaningful change.
+ */
+export function briefingSourceDigest(sources: BriefingSources): string {
+  const canonical = JSON.stringify({
+    s: sources.subjectLabel,
+    b: sources.businessLine ?? null,
+    f: clampList(sources.topFacts, BRIEFING_MAX_FACTS).map((f) => `${f.key}=${f.value}`),
+    n: clampList(sources.notes, BRIEFING_MAX_NOTES).map((n) => `${n.noteKind}:${n.noteKey}=${n.content}`),
+    d: clampList(sources.recentDecisions, BRIEFING_MAX_DECISIONS),
+    p: sources.spendLine ?? null,
+  });
+  // Small, dependency-free FNV-1a hash — enough to detect input change.
+  let h = 0x811c9dc5;
+  for (let i = 0; i < canonical.length; i++) {
+    h ^= canonical.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+/** Render the stored briefing as a prependable history message (no-op if empty). */
+export function formatBriefingMessage(
+  content: string | null | undefined,
+): { role: "user"; content: string } | null {
+  if (!content) return null;
+  return { role: "user", content: `[SESSION BRIEFING]\n${content}` };
+}

--- a/docs/superpowers/plans/2026-07-09-coworker-briefing-projection-plan.md
+++ b/docs/superpowers/plans/2026-07-09-coworker-briefing-projection-plan.md
@@ -1,0 +1,30 @@
+# Session-start projection briefing — implementation plan
+
+- **BI:** BI-A9052DCB (EP-8C706944 — AI Coworker Memory & Context Architecture, Phase 3)
+- **Date:** 2026-07-09
+- **Kernel ledger:** DI-F69AE978B70C
+- **Status:** Projection substrate + builder + lazy generation + injection (this PR)
+
+## Problem
+
+A coworker rehydrates cross-session context only via the recency window + vector recall. There is no precomputed "what you already know about this user" briefing, so continuity depends on RAG over transcripts — opaque, cache-unfriendly, and weak for non-technical conversational use.
+
+## Design
+
+ChatGPT's reference-chat-history model: derived profile sections refreshed offline, injected at session start — not transcript search.
+
+1. **Projection store** `CoworkerBriefing` (new table, additive migration `20260709140000_add_coworker_briefing`): keyed `(agentId, scope, scopeKey)` — `scope="user"` keyed by userId (org scope reserved for BI-1772D0B7). Holds `content`, `sourceDigest`, `generatedAt`. New table only → data-safe.
+2. **Pure builder** `coworker-briefing.ts`: `buildBriefingContent(sources)` assembles a capped, sectioned block (facts, working notes, recent context, spend) from already-selected source data, null when there is no signal; `briefingSourceDigest` (FNV-1a) lets the refresh skip an unchanged rebuild; `formatBriefingMessage` renders the prependable message. Deterministic → 9 unit tests.
+3. **Runner** `coworker-briefing-runner.ts`: `gatherUserBriefingSources` pulls governed records (user facts, the coworker's working notes via cuid resolution, the most recent thread's durable checkpoint), `generateUserBriefing` upserts the projection (skips when digest unchanged, deletes when signal drops to nothing), `loadUserBriefingMessage` reads it and fire-and-forget refreshes when older than `BRIEFING_STALE_MS` (24h) — offline/lazy so no session waits.
+4. **Injection** (`agent-coworker.ts`): prepend the briefing ahead of the recency window (same proven pattern as the BI-FDECBE0A checkpoint — strict no-op when absent, non-fatal on error).
+
+## Non-goals (own BIs)
+
+- Org-scoped briefings and the two-scope private/shared split → BI-1772D0B7 (the `scope="org"` key is reserved here).
+- Surfacing/pruning briefings in the audit UI → BI-DC8B03AB.
+- Nightly (vs lazy) regeneration — the lazy 24h refresh is self-maintaining; moving generation into the autoDream pass is a later optimization.
+
+## Verification
+
+- Unit: `coworker-briefing.test.ts` (9 — no-signal null, section rendering, business-line-only, fact cap, content cap, digest stability/change, message formatting).
+- Runtime (post-merge): a returning user's second session prepends a `[SESSION BRIEFING]` block summarizing their known facts + the coworker's notes; a brand-new relationship injects nothing; the row refreshes at most daily.

--- a/packages/db/prisma/migrations/20260709140000_add_coworker_briefing/migration.sql
+++ b/packages/db/prisma/migrations/20260709140000_add_coworker_briefing/migration.sql
@@ -1,0 +1,17 @@
+-- BI-A9052DCB (EP-8C706944 P3): session-start projection briefing cache.
+-- New table only — no constraint touches existing data.
+-- @migration-safety: data-safe: creates a new table; no existing row is affected.
+CREATE TABLE "CoworkerBriefing" (
+    "id" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "scope" TEXT NOT NULL,
+    "scopeKey" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "sourceDigest" TEXT NOT NULL,
+    "generatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CoworkerBriefing_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "CoworkerBriefing_agentId_scope_scopeKey_key" ON "CoworkerBriefing"("agentId", "scope", "scopeKey");
+CREATE INDEX "CoworkerBriefing_agentId_scope_idx" ON "CoworkerBriefing"("agentId", "scope");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4547,6 +4547,26 @@ model EffortContext {
   @@index([backlogItemId])
 }
 
+// BI-A9052DCB (EP-8C706944 P3): session-start projection briefing. A precomputed,
+// refreshable "what you should know" block distilled offline from governed records
+// (BusinessContext, top UserFacts, CoworkerMemoryNotes, recent decisions, thread
+// spend) — injected at session start instead of RAG over transcripts (ChatGPT's
+// reference-chat-history model). scope="user" keys on the userId; scope="org"
+// keys on the organizationId. sourceDigest lets the refresh skip regen when the
+// inputs are unchanged.
+model CoworkerBriefing {
+  id           String   @id @default(cuid())
+  agentId      String // Agent.id (cuid) — the coworker the briefing is for
+  scope        String // "user" | "org"
+  scopeKey     String // userId (scope=user) or organizationId (scope=org)
+  content      String
+  sourceDigest String
+  generatedAt  DateTime @default(now())
+
+  @@unique([agentId, scope, scopeKey])
+  @@index([agentId, scope])
+}
+
 model AgentActionProposal {
   id               String          @id @default(cuid())
   proposalId       String          @unique

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -16,7 +16,7 @@ apps/web/components/workbooks/Grid.tsx	924
 apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1338
 apps/web/lib/actions/agent-coworker-external.test.ts	866
-apps/web/lib/actions/agent-coworker.ts	2696
+apps/web/lib/actions/agent-coworker.ts	2712
 apps/web/lib/actions/agent-task-scheduler.test.ts	1083
 apps/web/lib/actions/ai-providers.ts	915
 apps/web/lib/actions/build-governed.test.ts	1114


### PR DESCRIPTION
## Summary
EP-8C706944 Phase 3 (6/9), kernel ledger DI-F69AE978B70C.

A coworker rehydrated cross-session context only via the recency window + vector recall — no precomputed "what you already know about this user" briefing, so continuity leaned on RAG over transcripts. This adds ChatGPT's reference-chat-history model: derived sections refreshed offline, injected at session start.

- **Projection store** `CoworkerBriefing` (new table, additive/data-safe) keyed `(agentId, scope, scopeKey)`; `scope=user` now, `scope=org` reserved for BI-1772D0B7.
- **Pure builder** `coworker-briefing.ts`: `buildBriefingContent` (capped sectioned block, null when no signal) + FNV-1a `briefingSourceDigest` (skip unchanged rebuild) + `formatBriefingMessage` → 9 unit tests, no DB/model.
- **Runner**: gather governed records (user facts, coworker working notes via cuid resolution, most recent thread's durable checkpoint), upsert projection, **lazy fire-and-forget refresh** when older than 24h so no session waits.
- **Injection**: prepend the briefing ahead of the recency window (same proven pattern as the BI-FDECBE0A checkpoint; strict no-op when absent).

## Verification
vitest 9/9, `pnpm --filter web typecheck` clean, migration-safety + collision guards green. Rebased on current main.

Plan: docs/superpowers/plans/2026-07-09-coworker-briefing-projection-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)