### PR TITLE
feat(coworker-memory): shared multi-coworker effort context (BI-23A65B81)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -57,6 +57,7 @@ import { coworkerServiceCatalogPack } from "@/lib/mcp/packs/coworker-service-cat
 import { coworkerToolGrantPack } from "@/lib/mcp/packs/coworker-tool-grant-pack";
 import { coworkerEstablishPack } from "@/lib/mcp/packs/coworker-establish-pack";
 import { coworkerMemoryPack } from "@/lib/mcp/packs/coworker-memory-pack";
+import { effortContextPack } from "@/lib/mcp/packs/effort-context-pack";
 import { coworkerGoalPack } from "@/lib/mcp/packs/coworker-goal-pack";
 import { subagentFanoutPack } from "@/lib/mcp/packs/subagent-fanout-pack";
 import { queueAwarenessPack } from "@/lib/mcp/packs/queue-awareness-pack";
@@ -456,7 +457,7 @@ async function resolveDocumentActorPrincipalId(userId: string, agentId?: string)
 // ─── Tool Registry ───────────────────────────────────────────────────────────
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, professionDecisionPack, optimizationPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, coworkerEstablishPack, coworkerMemoryPack, coworkerGoalPack, subagentFanoutPack, mdmStewardshipPack, crmContactsPack, queueAwarenessPack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, professionDecisionPack, optimizationPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, coworkerEstablishPack, coworkerMemoryPack, effortContextPack, coworkerGoalPack, subagentFanoutPack, mdmStewardshipPack, crmContactsPack, queueAwarenessPack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,

--- a/apps/web/lib/mcp/packs/effort-context-pack.test.ts
+++ b/apps/web/lib/mcp/packs/effort-context-pack.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/tak/coworker-tool-grant-core", () => ({
+  resolveCoworkerAgent: vi.fn(),
+}));
+vi.mock("@/lib/tak/effort-context-runner", () => ({
+  recordEffortEntry: vi.fn(),
+  loadEffortContext: vi.fn(),
+}));
+
+import { resolveCoworkerAgent } from "@/lib/tak/coworker-tool-grant-core";
+import { recordEffortEntry, loadEffortContext } from "@/lib/tak/effort-context-runner";
+import { effortContextPack } from "./effort-context-pack";
+
+const asMock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+const SCOUT = { id: "cuid-scout", agentId: "AGT-WS-SCOUT", slugId: "scout", displayName: "Scout" };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("effortContextPack shape", () => {
+  it("owns both tools ungated with a handler each", () => {
+    expect(effortContextPack.definitions.map((d) => d.name).sort()).toEqual([
+      "read_effort_context",
+      "record_effort_context",
+    ]);
+    expect(effortContextPack.grants).toEqual({});
+    for (const def of effortContextPack.definitions) {
+      expect(effortContextPack.handlers[def.name], def.name).toBeTypeOf("function");
+    }
+  });
+
+  it("keeps tool descriptions provenance-free (matches the hygiene guard)", () => {
+    // Same patterns as apps/web/lib/tool-description-hygiene.test.ts.
+    for (const def of effortContextPack.definitions) {
+      expect(def.description).not.toMatch(/\bPhase\s+\d+[a-z]?\b/i);
+      expect(def.description).not.toMatch(/\bBI-[0-9A-Fa-f]{6,}\b/i);
+      expect(def.description).not.toMatch(/\bEP-[0-9A-Fa-f]{6,}\b/i);
+    }
+  });
+});
+
+describe("record_effort_context", () => {
+  it("rejects an unknown kind before writing", async () => {
+    const res = await effortContextPack.handlers["record_effort_context"](
+      { effortKey: "epic:EP-1", kind: "blocker", content: "x" },
+      "user-1",
+      { agentId: "AGT-WS-SCOUT" },
+    );
+    expect(res.success).toBe(false);
+    expect(recordEffortEntry).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing effortKey and empty content", async () => {
+    const a = await effortContextPack.handlers["record_effort_context"](
+      { kind: "note", content: "x" },
+      "user-1",
+      { agentId: "AGT-WS-SCOUT" },
+    );
+    expect(a.success).toBe(false);
+    const b = await effortContextPack.handlers["record_effort_context"](
+      { effortKey: "epic:EP-1", kind: "note", content: "   " },
+      "user-1",
+      { agentId: "AGT-WS-SCOUT" },
+    );
+    expect(b.success).toBe(false);
+  });
+
+  it("appends with the resolved calling coworker as author", async () => {
+    asMock(resolveCoworkerAgent).mockResolvedValue(SCOUT);
+    asMock(recordEffortEntry).mockResolvedValue({
+      effortKey: "epic:EP-1",
+      title: null,
+      epicId: null,
+      backlogItemId: null,
+      decisions: ["use TDD"],
+      openQuestions: [],
+      notes: [],
+      participantAgentIds: ["cuid-scout"],
+    });
+    const res = await effortContextPack.handlers["record_effort_context"](
+      { effortKey: "epic:EP-1", kind: "decision", content: "use TDD" },
+      "user-1",
+      { agentId: "AGT-WS-SCOUT" },
+    );
+    expect(res.success).toBe(true);
+    expect(recordEffortEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ effortKey: "epic:EP-1", kind: "decision", content: "use TDD", agentId: "cuid-scout" }),
+    );
+  });
+});
+
+describe("read_effort_context", () => {
+  it("returns an empty shape when the effort has no context yet", async () => {
+    asMock(loadEffortContext).mockResolvedValue(null);
+    const res = await effortContextPack.handlers["read_effort_context"](
+      { effortKey: "epic:EP-404" },
+      "user-1",
+      {},
+    );
+    expect(res.success).toBe(true);
+    expect(res.data).toMatchObject({ decisions: [], openQuestions: [], notes: [] });
+  });
+
+  it("returns the shared context when present", async () => {
+    asMock(loadEffortContext).mockResolvedValue({
+      effortKey: "epic:EP-1",
+      title: "Billing",
+      epicId: null,
+      backlogItemId: null,
+      decisions: ["use TDD"],
+      openQuestions: ["which db?"],
+      notes: [],
+      participantAgentIds: ["cuid-scout"],
+    });
+    const res = await effortContextPack.handlers["read_effort_context"](
+      { effortKey: "epic:EP-1" },
+      "user-1",
+      {},
+    );
+    expect(res.success).toBe(true);
+    expect(res.data).toMatchObject({
+      decisions: ["use TDD"],
+      openQuestions: ["which db?"],
+      participants: ["cuid-scout"],
+    });
+  });
+});

--- a/apps/web/lib/mcp/packs/effort-context-pack.ts
+++ b/apps/web/lib/mcp/packs/effort-context-pack.ts
@@ -1,0 +1,144 @@
+// Shared effort-context pack — BI-23A65B81 (EP-8C706944 P3).
+//
+// The door to a multi-coworker, multi-session EFFORT's shared working context:
+//   • record_effort_context — append a decision / open-question / note to an effort
+//   • read_effort_context   — read the shared context to rehydrate a fresh session
+//
+// A coworker working a cross-cutting effort names it by a stable effortKey (e.g.
+// "epic:EP-XXX" or "bi:BI-YYY"); every participating coworker reads and appends to
+// the same context, so work handed between coworkers and across sessions keeps a
+// shared memory. Appends are attributed to the calling coworker (context.agentId).
+// Ungated like the working-memory pack — appending a collaborative note to an
+// effort you are working on cannot exceed authority; it is a shared scratchpad,
+// not a privileged action.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+import { EFFORT_ENTRY_KINDS, isKnownEffortEntryKind } from "@/lib/tak/effort-context";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "record_effort_context",
+    description:
+      "Append to the SHARED working context of a multi-coworker effort — a decision made, an open question, or a working note. Name the effort with a stable key (e.g. 'epic:EP-1234' or 'bi:1234'). Every coworker working that effort reads and appends to the same context, so work handed between coworkers and across sessions keeps a shared memory. Use this to coordinate an effort that spans more than one coworker or session.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        effortKey: {
+          type: "string",
+          description: "Stable identifier for the effort (e.g. 'epic:EP-1234', 'bi:1234').",
+        },
+        kind: {
+          type: "string",
+          enum: [...EFFORT_ENTRY_KINDS],
+          description: "decision | open-question | note.",
+        },
+        content: { type: "string", description: "The entry, in one or two sentences." },
+        title: {
+          type: "string",
+          description: "Optional human title for the effort (set on first write).",
+        },
+      },
+      required: ["effortKey", "kind", "content"],
+    },
+    requiredCapability: null,
+    sideEffect: true,
+  },
+  {
+    name: "read_effort_context",
+    description:
+      "Read the SHARED working context of a multi-coworker effort by its key — the decisions, open questions, working notes, and participating coworkers. Use this at the start of work on an effort to rehydrate what other coworkers and earlier sessions established.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        effortKey: { type: "string", description: "The effort's stable identifier." },
+      },
+      required: ["effortKey"],
+    },
+    requiredCapability: null,
+    sideEffect: false,
+  },
+];
+
+async function resolveCallerCuid(agentId: string | undefined): Promise<string | null> {
+  if (!agentId) return null;
+  const { resolveCoworkerAgent } = await import("@/lib/tak/coworker-tool-grant-core");
+  const target = await resolveCoworkerAgent(agentId);
+  return target?.id ?? null;
+}
+
+async function recordEffortContextHandler(
+  params: Record<string, unknown>,
+  _userId: string,
+  context?: { agentId?: string },
+): Promise<ToolResult> {
+  const effortKey = String(params["effortKey"] ?? "").trim();
+  const kind = String(params["kind"] ?? "").trim();
+  const content = String(params["content"] ?? "").trim();
+  if (!effortKey) return { success: false, error: "missing_effort_key", message: "effortKey is required." };
+  if (!isKnownEffortEntryKind(kind)) {
+    return { success: false, error: "unknown_kind", message: `kind must be one of: ${EFFORT_ENTRY_KINDS.join(", ")}.` };
+  }
+  if (!content) return { success: false, error: "empty_content", message: "content must not be empty." };
+
+  const agentCuid = await resolveCallerCuid(context?.agentId);
+  const { recordEffortEntry } = await import("@/lib/tak/effort-context-runner");
+  const view = await recordEffortEntry({
+    effortKey,
+    kind,
+    content,
+    agentId: agentCuid,
+    title: params["title"] != null ? String(params["title"]) : null,
+  });
+  return {
+    success: true,
+    message: "Recorded to the shared effort context.",
+    data: {
+      effortKey: view.effortKey,
+      decisions: view.decisions.length,
+      openQuestions: view.openQuestions.length,
+      notes: view.notes.length,
+      participants: view.participantAgentIds.length,
+    },
+  };
+}
+
+async function readEffortContextHandler(
+  params: Record<string, unknown>,
+  _userId: string,
+  _context?: { agentId?: string },
+): Promise<ToolResult> {
+  const effortKey = String(params["effortKey"] ?? "").trim();
+  if (!effortKey) return { success: false, error: "missing_effort_key", message: "effortKey is required." };
+  const { loadEffortContext } = await import("@/lib/tak/effort-context-runner");
+  const ctx = await loadEffortContext(effortKey);
+  if (!ctx) {
+    return {
+      success: true,
+      message: `No shared context yet for effort '${effortKey}'.`,
+      data: { effortKey, decisions: [], openQuestions: [], notes: [], participants: [] },
+    };
+  }
+  return {
+    success: true,
+    message: `Shared context for '${ctx.title ?? effortKey}'.`,
+    data: {
+      effortKey: ctx.effortKey,
+      title: ctx.title,
+      decisions: ctx.decisions,
+      openQuestions: ctx.openQuestions,
+      notes: ctx.notes,
+      participants: ctx.participantAgentIds,
+    },
+  };
+}
+
+export const effortContextPack: ToolPack = {
+  packId: "effort-context",
+  definitions,
+  handlers: {
+    record_effort_context: (params, userId, context) => recordEffortContextHandler(params, userId, context),
+    read_effort_context: (params, userId, context) => readEffortContextHandler(params, userId, context),
+  },
+  grants: {},
+};

--- a/apps/web/lib/tak/effort-context-runner.ts
+++ b/apps/web/lib/tak/effort-context-runner.ts
@@ -1,0 +1,116 @@
+// apps/web/lib/tak/effort-context-runner.ts
+// Server-side read/write for the shared effort context (BI-23A65B81). Binds
+// prisma to the pure apply/format logic. Upsert-by-effortKey so any participating
+// coworker in any session appends to the same shared context.
+
+import { prisma } from "@dpf/db";
+import {
+  applyEffortEntry,
+  formatEffortContextBriefing,
+  type EffortContextState,
+  type EffortEntryKind,
+} from "./effort-context";
+
+export type EffortContextView = EffortContextState & {
+  effortKey: string;
+  title: string | null;
+  epicId: string | null;
+  backlogItemId: string | null;
+};
+
+function toState(row: {
+  decisions: string[];
+  openQuestions: string[];
+  notes: string[];
+  participantAgentIds: string[];
+}): EffortContextState {
+  return {
+    decisions: row.decisions,
+    openQuestions: row.openQuestions,
+    notes: row.notes,
+    participantAgentIds: row.participantAgentIds,
+  };
+}
+
+/** Load the shared context for an effort, or null when none exists yet. */
+export async function loadEffortContext(effortKey: string): Promise<EffortContextView | null> {
+  const row = await prisma.effortContext.findUnique({ where: { effortKey } });
+  if (!row) return null;
+  return {
+    effortKey: row.effortKey,
+    title: row.title,
+    epicId: row.epicId,
+    backlogItemId: row.backlogItemId,
+    ...toState(row),
+  };
+}
+
+/** Load the effort context rendered as a rehydration briefing message (or null). */
+export async function loadEffortContextBriefing(
+  effortKey: string,
+): Promise<{ role: "user"; content: string } | null> {
+  const ctx = await loadEffortContext(effortKey);
+  if (!ctx) return null;
+  const briefing = formatEffortContextBriefing(ctx.effortKey, ctx.title, ctx);
+  return briefing ? { role: "user", content: `[${briefing}]` } : null;
+}
+
+/**
+ * Append an entry to an effort's shared context, creating the context on first
+ * write. Any participating coworker may append; the author is recorded in the
+ * participant set.
+ */
+export async function recordEffortEntry(params: {
+  effortKey: string;
+  kind: EffortEntryKind;
+  content: string;
+  agentId?: string | null;
+  title?: string | null;
+  epicId?: string | null;
+  backlogItemId?: string | null;
+}): Promise<EffortContextView> {
+  const existing = await prisma.effortContext.findUnique({ where: { effortKey: params.effortKey } });
+  const baseState: EffortContextState = existing
+    ? toState(existing)
+    : { decisions: [], openQuestions: [], notes: [], participantAgentIds: [] };
+
+  const next = applyEffortEntry(baseState, {
+    kind: params.kind,
+    content: params.content,
+    agentId: params.agentId ?? null,
+  });
+
+  const row = await prisma.effortContext.upsert({
+    where: { effortKey: params.effortKey },
+    create: {
+      effortKey: params.effortKey,
+      title: params.title ?? null,
+      epicId: params.epicId ?? null,
+      backlogItemId: params.backlogItemId ?? null,
+      decisions: next.decisions,
+      openQuestions: next.openQuestions,
+      notes: next.notes,
+      participantAgentIds: next.participantAgentIds,
+    },
+    update: {
+      // Only fill title/links if provided and not already set.
+      ...(params.title && !existing?.title ? { title: params.title } : {}),
+      ...(params.epicId && !existing?.epicId ? { epicId: params.epicId } : {}),
+      ...(params.backlogItemId && !existing?.backlogItemId
+        ? { backlogItemId: params.backlogItemId }
+        : {}),
+      decisions: next.decisions,
+      openQuestions: next.openQuestions,
+      notes: next.notes,
+      participantAgentIds: next.participantAgentIds,
+    },
+  });
+
+  return {
+    effortKey: row.effortKey,
+    title: row.title,
+    epicId: row.epicId,
+    backlogItemId: row.backlogItemId,
+    ...toState(row),
+  };
+}

--- a/apps/web/lib/tak/effort-context.test.ts
+++ b/apps/web/lib/tak/effort-context.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyEffortEntry,
+  formatEffortContextBriefing,
+  isKnownEffortEntryKind,
+  EFFORT_LIST_CAP,
+  type EffortContextState,
+} from "./effort-context";
+
+const empty = (): EffortContextState => ({
+  decisions: [],
+  openQuestions: [],
+  notes: [],
+  participantAgentIds: [],
+});
+
+describe("isKnownEffortEntryKind", () => {
+  it("accepts the closed vocabulary and rejects others", () => {
+    expect(isKnownEffortEntryKind("decision")).toBe(true);
+    expect(isKnownEffortEntryKind("open-question")).toBe(true);
+    expect(isKnownEffortEntryKind("note")).toBe(true);
+    expect(isKnownEffortEntryKind("blocker")).toBe(false);
+  });
+});
+
+describe("applyEffortEntry", () => {
+  it("routes each kind to its list and records the author as a participant", () => {
+    let s = empty();
+    s = applyEffortEntry(s, { kind: "decision", content: "use TDD", agentId: "AGT-A" });
+    s = applyEffortEntry(s, { kind: "open-question", content: "which db?", agentId: "AGT-B" });
+    s = applyEffortEntry(s, { kind: "note", content: "auth lives in lib/auth", agentId: "AGT-A" });
+    expect(s.decisions).toEqual(["use TDD"]);
+    expect(s.openQuestions).toEqual(["which db?"]);
+    expect(s.notes).toEqual(["auth lives in lib/auth"]);
+    expect(s.participantAgentIds).toEqual(["AGT-A", "AGT-B"]);
+  });
+
+  it("is idempotent for an identical entry (case-insensitive)", () => {
+    let s = empty();
+    s = applyEffortEntry(s, { kind: "decision", content: "Use TDD" });
+    s = applyEffortEntry(s, { kind: "decision", content: "use tdd" });
+    expect(s.decisions).toEqual(["Use TDD"]);
+  });
+
+  it("does not duplicate a participant", () => {
+    let s = empty();
+    s = applyEffortEntry(s, { kind: "note", content: "a", agentId: "AGT-A" });
+    s = applyEffortEntry(s, { kind: "note", content: "b", agentId: "AGT-A" });
+    expect(s.participantAgentIds).toEqual(["AGT-A"]);
+  });
+
+  it("caps each list, dropping the oldest", () => {
+    let s = empty();
+    for (let i = 0; i < EFFORT_LIST_CAP + 5; i++) {
+      s = applyEffortEntry(s, { kind: "note", content: `note ${i}` });
+    }
+    expect(s.notes).toHaveLength(EFFORT_LIST_CAP);
+    expect(s.notes[0]).toBe("note 5"); // first 5 dropped
+    expect(s.notes[s.notes.length - 1]).toBe(`note ${EFFORT_LIST_CAP + 4}`);
+  });
+});
+
+describe("formatEffortContextBriefing", () => {
+  it("returns null for an empty context (strict no-op)", () => {
+    expect(formatEffortContextBriefing("epic:EP-1", null, empty())).toBeNull();
+  });
+
+  it("renders sections and participants under the title", () => {
+    const s: EffortContextState = {
+      decisions: ["use TDD"],
+      openQuestions: ["which db?"],
+      notes: ["auth in lib/auth"],
+      participantAgentIds: ["AGT-A", "AGT-B"],
+    };
+    const out = formatEffortContextBriefing("epic:EP-1", "Billing revamp", s)!;
+    expect(out).toContain("EFFORT CONTEXT — Billing revamp");
+    expect(out).toContain("Participants: AGT-A, AGT-B");
+    expect(out).toContain("Decisions:");
+    expect(out).toContain("- use TDD");
+    expect(out).toContain("Open questions:");
+    expect(out).toContain("- which db?");
+    expect(out).toContain("Working notes:");
+  });
+
+  it("falls back to the effortKey when no title is set", () => {
+    const s = applyEffortEntry(empty(), { kind: "decision", content: "x" });
+    const out = formatEffortContextBriefing("bi:BI-9", null, s)!;
+    expect(out).toContain("EFFORT CONTEXT — bi:BI-9");
+  });
+});

--- a/apps/web/lib/tak/effort-context.ts
+++ b/apps/web/lib/tak/effort-context.ts
@@ -1,0 +1,101 @@
+// apps/web/lib/tak/effort-context.ts
+// Shared multi-coworker effort working context — BI-23A65B81 (EP-8C706944 P3).
+//
+// Work spanning many coworkers and sessions outside Build Studio was stitched
+// only by shared FKs (backlogItemId / epicId); no object held the shared working
+// context — decisions made, open questions, scratch notes — readable and
+// writable by every participant. This is that object's pure logic: apply an
+// append entry to the context arrays (dedupe + cap) and render the context as a
+// rehydration briefing (Linear's artifact-as-memory). Deterministic, no DB.
+
+/** The kind of entry a coworker appends to a shared effort context. */
+export const EFFORT_ENTRY_KINDS = ["decision", "open-question", "note"] as const;
+export type EffortEntryKind = (typeof EFFORT_ENTRY_KINDS)[number];
+
+export function isKnownEffortEntryKind(kind: string): kind is EffortEntryKind {
+  return (EFFORT_ENTRY_KINDS as readonly string[]).includes(kind);
+}
+
+/** The mutable arrays of an effort context. */
+export type EffortContextState = {
+  decisions: string[];
+  openQuestions: string[];
+  notes: string[];
+  participantAgentIds: string[];
+};
+
+/** Keep each list bounded so an effort context can never balloon the prompt. */
+export const EFFORT_LIST_CAP = 50;
+
+function appendCapped(list: string[], value: string): string[] {
+  const trimmed = value.trim();
+  // Idempotent: an identical entry is a no-op (case-insensitive).
+  if (list.some((x) => x.trim().toLowerCase() === trimmed.toLowerCase())) return list;
+  const next = [...list, trimmed];
+  return next.length > EFFORT_LIST_CAP ? next.slice(next.length - EFFORT_LIST_CAP) : next;
+}
+
+/**
+ * Apply one append entry to the effort context state. Pure — returns the new
+ * arrays; the runner persists them. `agentId` (the authoring coworker) is added
+ * to the participant set.
+ */
+export function applyEffortEntry(
+  state: EffortContextState,
+  entry: { kind: EffortEntryKind; content: string; agentId?: string | null },
+): EffortContextState {
+  const next: EffortContextState = {
+    decisions: state.decisions,
+    openQuestions: state.openQuestions,
+    notes: state.notes,
+    participantAgentIds: state.participantAgentIds,
+  };
+  if (entry.kind === "decision") next.decisions = appendCapped(state.decisions, entry.content);
+  else if (entry.kind === "open-question")
+    next.openQuestions = appendCapped(state.openQuestions, entry.content);
+  else next.notes = appendCapped(state.notes, entry.content);
+
+  if (entry.agentId && !state.participantAgentIds.includes(entry.agentId)) {
+    next.participantAgentIds = [...state.participantAgentIds, entry.agentId];
+  }
+  return next;
+}
+
+/** Cap on the rendered briefing so a large effort context can't dominate context. */
+export const EFFORT_BRIEFING_CHAR_CAP = 3000;
+
+/**
+ * Render the effort context as a rehydration briefing block, or null when the
+ * context is empty (strict no-op). This is what briefs a coworker joining the
+ * effort in a fresh session.
+ */
+export function formatEffortContextBriefing(
+  effortKey: string,
+  title: string | null,
+  state: EffortContextState,
+): string | null {
+  const hasContent =
+    state.decisions.length > 0 || state.openQuestions.length > 0 || state.notes.length > 0;
+  if (!hasContent) return null;
+
+  const lines: string[] = [`EFFORT CONTEXT — ${title ?? effortKey}`];
+  if (state.participantAgentIds.length > 0) {
+    lines.push(`Participants: ${state.participantAgentIds.join(", ")}`);
+  }
+  if (state.decisions.length > 0) {
+    lines.push("Decisions:");
+    for (const d of state.decisions) lines.push(`- ${d}`);
+  }
+  if (state.openQuestions.length > 0) {
+    lines.push("Open questions:");
+    for (const q of state.openQuestions) lines.push(`- ${q}`);
+  }
+  if (state.notes.length > 0) {
+    lines.push("Working notes:");
+    for (const n of state.notes) lines.push(`- ${n}`);
+  }
+  const content = lines.join("\n");
+  return content.length > EFFORT_BRIEFING_CHAR_CAP
+    ? content.slice(0, EFFORT_BRIEFING_CHAR_CAP)
+    : content;
+}

--- a/docs/superpowers/plans/2026-07-09-effort-context-plan.md
+++ b/docs/superpowers/plans/2026-07-09-effort-context-plan.md
@@ -1,0 +1,37 @@
+# Shared multi-coworker effort context — implementation plan
+
+- **BI:** BI-23A65B81 (EP-8C706944 — AI Coworker Memory & Context Architecture, Phase 3)
+- **Date:** 2026-07-09
+- **Kernel ledger:** DI-F69AE978B70C
+- **Status:** Substrate + core + runner + coworker door (this PR)
+
+## Problem
+
+Work spanning many coworkers and sessions **outside Build Studio** was stitched only by shared FKs (`backlogItemId` / `epicId`). No object held the shared working context — decisions made, open questions, scratch notes — readable and writable by every participant, so a coworker joining an effort in a fresh session had nothing to rehydrate from.
+
+## Substrate-first finding (mandated by the BI)
+
+- **PhaseHandoff** — NOT reusable: it is build-phase-scoped (FK to a `FeatureBuild`, `fromPhase`/`toPhase`) and is now **actively used** by the Build Studio phase machine (`build-orchestrator`, `phase-compaction-wire`, `mcp-tools`). The earlier "dead schema" note was stale.
+- **WorkCapsule** — NOT reusable: it is a single-executor, single-lease unit of WIP (one worktree, one `leaseHolderPrincipalId`); an effort spans *many* capsules. It is the natural child of an effort, not the shared context itself.
+
+Neither models context shared across many coworkers over an effort's lifetime, so the kernel decision (DI-F69AE978B70C) sanctioned **exactly one** new concept here.
+
+## Design
+
+1. **Store** `EffortContext` (new table, additive/data-safe migration `20260709150000_add_effort_context`): keyed by a free `effortKey` (e.g. `epic:EP-1234`, `bi:1234`), with append lists `decisions` / `openQuestions` / `notes` and a `participantAgentIds` set; optional `epicId` / `backlogItemId` links.
+2. **Pure core** `effort-context.ts`: `EFFORT_ENTRY_KINDS` (decision | open-question | note), `applyEffortEntry` (route to list, idempotent dedupe, cap at `EFFORT_LIST_CAP`, record author), `formatEffortContextBriefing` (rehydration block, null when empty). Deterministic → 8 unit tests.
+3. **Runner** `effort-context-runner.ts`: `recordEffortEntry` (upsert-by-effortKey so any coworker in any session appends to the same context), `loadEffortContext`, `loadEffortContextBriefing`.
+4. **Coworker door** `effort-context-pack.ts`: `record_effort_context` + `read_effort_context`, appends attributed to the calling coworker (`context.agentId`). Ungated like the working-memory pack — a collaborative append to an effort you are on cannot exceed authority. Registered in `TOOL_PACK_REGISTRY` (module-size baseline bumped for the one-line import). → 7 pack tests.
+
+Rehydration follows Linear's artifact-as-memory: the effort record briefs each session. A coworker names the effort by key at the start of work, reads the shared context, and appends as it goes.
+
+## Non-goals (own BIs / follow-ups)
+
+- Auto-associating a chat thread with an effort (so the context injects without an explicit key) — the harder half; deferred. The door gives coworkers explicit read/append now.
+- Summarizing `ToolExecution` into the effort context as an episodic trail — a later enrichment.
+- Org-vs-user visibility of effort context → composes with BI-1772D0B7.
+
+## Verification
+
+- Unit: `effort-context.test.ts` (8), `effort-context-pack.test.ts` (7, incl. the real description-hygiene patterns), `tool-registry.test.ts` green, `tool-description-hygiene.test.ts` green.
+- Runtime (post-merge): coworker A records a decision on `epic:EP-1234`; coworker B, in a separate session, reads the same effort context and sees A's decision + both as participants.

--- a/packages/db/prisma/migrations/20260709150000_add_effort_context/migration.sql
+++ b/packages/db/prisma/migrations/20260709150000_add_effort_context/migration.sql
@@ -1,0 +1,22 @@
+-- BI-23A65B81 (EP-8C706944 P3): shared multi-coworker effort working context.
+-- New table only — no constraint touches existing data.
+-- @migration-safety: data-safe: creates a new table; no existing row is affected.
+CREATE TABLE "EffortContext" (
+    "id" TEXT NOT NULL,
+    "effortKey" TEXT NOT NULL,
+    "title" TEXT,
+    "epicId" TEXT,
+    "backlogItemId" TEXT,
+    "decisions" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "openQuestions" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "notes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "participantAgentIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EffortContext_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "EffortContext_effortKey_key" ON "EffortContext"("effortKey");
+CREATE INDEX "EffortContext_epicId_idx" ON "EffortContext"("epicId");
+CREATE INDEX "EffortContext_backlogItemId_idx" ON "EffortContext"("backlogItemId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4512,6 +4512,32 @@ model UserFact {
   @@index([sourceAgentId, supersededAt])
 }
 
+// BI-23A65B81 (EP-8C706944 P3): shared working context for a multi-coworker,
+// multi-session EFFORT outside Build Studio. Substrate-verify finding: PhaseHandoff
+// is build-phase-scoped (FK to a FeatureBuild) and actively used by the BS phase
+// machine; WorkCapsule is a single-executor, single-lease unit of WIP. Neither
+// models context shared across many coworkers over an effort's lifetime, so the
+// kernel decision (DI-F69AE978B70C) sanctioned exactly this one new concept.
+// Keyed by a free effortKey (e.g. "epic:EP-XXX", "bi:BI-YYY"); any participating
+// coworker appends decisions / open questions / notes, and each session reads the
+// context to rehydrate (Linear's artifact-as-memory).
+model EffortContext {
+  id                  String   @id @default(cuid())
+  effortKey           String   @unique
+  title               String?
+  epicId              String?
+  backlogItemId       String?
+  decisions           String[] @default([])
+  openQuestions       String[] @default([])
+  notes               String[] @default([])
+  participantAgentIds String[] @default([])
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  @@index([epicId])
+  @@index([backlogItemId])
+}
+
 model AgentActionProposal {
   id               String          @id @default(cuid())
   proposalId       String          @unique

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -40,14 +40,14 @@ apps/web/lib/integrate/build-orchestrator.ts	1780
 apps/web/lib/integrate/sandbox/build-branch.ts	854
 apps/web/lib/marketing.ts	1367
 apps/web/lib/mcp-tools-backlog.test.ts	901
-apps/web/lib/mcp-tools.ts	16553
+apps/web/lib/mcp-tools.ts	16554
 apps/web/lib/navigation/portal-navigation-model.ts	936
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1328
 apps/web/lib/routing/chat-adapter.test.ts	820
 apps/web/lib/routing/fallback.test.ts	953
 apps/web/lib/self-upgrade/quiescence.test.ts	842
-apps/web/lib/self-upgrade/quiescence.ts	1462
+apps/web/lib/self-upgrade/quiescence.ts	1460
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	903
 apps/web/lib/tak/agent-routing.ts	965


### PR DESCRIPTION
## Summary
EP-8C706944 Phase 3 (7/9), kernel ledger DI-F69AE978B70C.

Work spanning many coworkers and sessions **outside Build Studio** was stitched only by shared FKs (`backlogItemId`/`epicId`); no object held the shared working context (decisions, open questions, scratch) readable/writable by every participant, so a coworker joining an effort in a fresh session had nothing to rehydrate from.

**Substrate-verify (mandated by the BI):** `PhaseHandoff` is build-phase-scoped (FK to a `FeatureBuild`) and is now **actively used** by the BS phase machine — the "dead schema" note was stale; `WorkCapsule` is a single-executor/single-lease unit of WIP. Neither models shared cross-coworker effort context, so the kernel decision sanctioned exactly this one new concept.

- **Store** `EffortContext` keyed by a free `effortKey` (`epic:…`/`bi:…`), append lists + participant set (additive/data-safe migration).
- **Pure core** `effort-context.ts`: `applyEffortEntry` (route, idempotent dedupe, cap, record author) + `formatEffortContextBriefing` → 8 unit tests.
- **Runner**: `recordEffortEntry` (upsert-by-effortKey so any coworker in any session appends to the same context) + load/briefing.
- **Coworker door** `effort-context-pack.ts`: `record_effort_context` + `read_effort_context`, authored by `context.agentId`, ungated like the working-memory pack; registered in `TOOL_PACK_REGISTRY`. → 7 pack tests. Rehydration = Linear artifact-as-memory.

## Verification
vitest 15/15 (core+pack) + registry + real description-hygiene guard green, `tsc --noEmit` exit 0, migration-safety + timestamp-collision + module-size guards green.

Plan: docs/superpowers/plans/2026-07-09-effort-context-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)