### PR TITLE
feat(coworker-memory): memory transparency + audit UI (BI-DC8B03AB)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/memory/MyMemoryAuditClient.tsx
+++ b/apps/web/app/(shell)/platform/ai/memory/MyMemoryAuditClient.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { DataTable, StatusBadge, type Column } from "@/components/ui/report-kit";
+import { LocalTime } from "@/components/ui/LocalTime";
+import { confirmDialog } from "@/components/ui/Dialog";
+import { forgetMyFact } from "@/lib/actions/memory-audit";
+import type { MemoryAuditRow } from "@/lib/actions/memory-audit-shape";
+
+// Self-serve "what your coworker remembers about you" table with a per-item
+// Forget affordance (BI-DC8B03AB). Destructive step goes through the themed
+// confirmDialog — never a native window.confirm (AGENTS.md §12).
+
+export function MyMemoryAuditClient({ rows }: { rows: MemoryAuditRow[] }) {
+  const router = useRouter();
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  async function onForget(row: MemoryAuditRow) {
+    const ok = await confirmDialog({
+      title: "Forget this?",
+      message: `Your coworker will forget "${row.label}: ${row.value}". This can't be undone.`,
+      tone: "danger",
+      confirmLabel: "Forget",
+    });
+    if (!ok) return;
+    setBusyId(row.id);
+    try {
+      await forgetMyFact(row.id);
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const columns: Column<MemoryAuditRow>[] = [
+    {
+      key: "label",
+      header: "What it remembers",
+      cell: (row) => (
+        <span className="text-[var(--dpf-text)]">
+          {row.label}: {row.value}
+        </span>
+      ),
+      sortAccessor: (row) => row.label,
+    },
+    {
+      key: "scope",
+      header: "Visible to",
+      cell: (row) =>
+        row.scope === "org" ? (
+          <StatusBadge intent="info" label="Your team" />
+        ) : (
+          <StatusBadge intent="neutral" label="Just you" />
+        ),
+      sortAccessor: (row) => row.scope,
+    },
+    {
+      key: "sensitive",
+      header: "Sensitive",
+      cell: (row) =>
+        row.sensitive ? <StatusBadge intent="warning" label="Sensitive" /> : <span className="text-[var(--dpf-muted)]">—</span>,
+    },
+    {
+      key: "provenance",
+      header: "Source",
+      cell: (row) => <span className="text-[var(--dpf-muted)] text-xs">{row.provenance}</span>,
+    },
+    {
+      key: "createdAt",
+      header: "Since",
+      cell: (row) => <LocalTime value={row.createdAt} />,
+      sortAccessor: (row) => row.createdAt.getTime(),
+    },
+    {
+      key: "actions",
+      header: "",
+      cell: (row) => (
+        <button
+          type="button"
+          onClick={() => onForget(row)}
+          disabled={busyId === row.id}
+          data-dialog-action="forget"
+          className="text-xs px-2 py-1 rounded border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] disabled:opacity-50"
+        >
+          {busyId === row.id ? "Forgetting…" : "Forget"}
+        </button>
+      ),
+    },
+  ];
+
+  return <DataTable rows={rows} columns={columns} getRowKey={(row) => row.id} />;
+}

--- a/apps/web/app/(shell)/platform/ai/memory/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/memory/page.tsx
@@ -1,0 +1,82 @@
+import { StatCard } from "@/components/ui/report-kit";
+import { can } from "@/lib/govern/permissions";
+import { auth } from "@/lib/auth";
+import { loadMyMemoryAudit, loadOrgMemoryAudit } from "@/lib/actions/memory-audit";
+import { MyMemoryAuditClient } from "./MyMemoryAuditClient";
+
+// Coworker memory transparency (BI-DC8B03AB, EP-8C706944 P4). Self-serve view of
+// what a coworker remembers about you, with a per-item Forget; admins also see
+// org-shared facts + coworker working notes. Kernel UX-fit: self-serve settings
+// panel + admin section (DI-94083410B6F1) — progressive disclosure, plain groups,
+// sensitive items badged, no raw token/config inputs.
+
+export default async function CoworkerMemoryPage() {
+  const session = await auth();
+  const isAdmin = can(
+    { platformRole: session?.user?.platformRole ?? null, isSuperuser: session?.user?.isSuperuser ?? false },
+    "manage_agents",
+  );
+
+  const mine = await loadMyMemoryAudit();
+  const org = isAdmin ? await loadOrgMemoryAudit() : null;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">What your coworker remembers</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
+          Everything a coworker has learned about you across conversations. Forget anything you don&apos;t want kept.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 mb-6">
+        <StatCard label="Things remembered" value={mine.summary.total} intent="neutral" />
+        <StatCard
+          label="Shared with your team"
+          value={mine.summary.orgShared}
+          intent={mine.summary.orgShared > 0 ? "info" : "neutral"}
+          hint="Business facts your teammates' coworkers can use"
+        />
+        <StatCard
+          label="Sensitive"
+          value={mine.summary.sensitive}
+          intent={mine.summary.sensitive > 0 ? "warning" : "neutral"}
+          hint="Kept private to you"
+        />
+      </div>
+
+      {mine.groups.length === 0 ? (
+        <p className="text-sm text-[var(--dpf-muted)]">
+          Your coworker hasn&apos;t remembered anything about you yet.
+        </p>
+      ) : (
+        mine.groups.map((group) => (
+          <section key={group.category} className="mb-6">
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-2">{group.label}</h2>
+            <MyMemoryAuditClient rows={group.rows} />
+          </section>
+        ))
+      )}
+
+      {org ? (
+        <section className="mt-10 pt-6 border-t border-[var(--dpf-border)]">
+          <h2 className="text-lg font-bold text-[var(--dpf-text)]">Organization memory (admin)</h2>
+          <p className="text-sm text-[var(--dpf-muted)] mt-0.5 mb-4">
+            Org-shared business facts across the workforce and each coworker&apos;s working notes. Read-only.
+          </p>
+          <div className="grid grid-cols-3 gap-3 mb-6">
+            <StatCard label="Org-shared facts" value={org.summary.total} intent="info" />
+            <StatCard label="Coworker notes" value={org.notes.length} intent="neutral" />
+            <StatCard label="Sensitive (excluded)" value={0} intent="neutral" hint="Sensitive facts never leave their user" />
+          </div>
+          {org.facts.map((group) => (
+            <section key={`org-${group.category}`} className="mb-6">
+              <h3 className="text-sm font-semibold text-[var(--dpf-text)] mb-2">{group.label}</h3>
+              <MyMemoryAuditClient rows={group.rows} />
+            </section>
+          ))}
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/actions/memory-audit-shape.test.ts
+++ b/apps/web/lib/actions/memory-audit-shape.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  toAuditRow,
+  groupAuditRows,
+  summarizeAudit,
+  categoryLabel,
+  humanizeKey,
+  type MemoryAuditFact,
+} from "./memory-audit-shape";
+
+function fact(over: Partial<MemoryAuditFact>): MemoryAuditFact {
+  return {
+    id: "f1",
+    category: "preference",
+    key: "review_style",
+    value: "bullets",
+    scope: "user",
+    sensitivity: "normal",
+    sourceRoute: "/workspace",
+    createdAt: new Date("2026-07-01"),
+    lastAccessedAt: null,
+    ...over,
+  };
+}
+
+describe("humanizeKey / categoryLabel", () => {
+  it("humanizes keys and labels categories in plain language", () => {
+    expect(humanizeKey("cloud_provider")).toBe("cloud provider");
+    expect(categoryLabel("domain_context")).toBe("About your work");
+    expect(categoryLabel("preference")).toBe("Preference");
+    expect(categoryLabel("unknown_cat")).toBe("unknown cat");
+  });
+});
+
+describe("toAuditRow", () => {
+  it("maps scope, sensitivity, and provenance without raw enum ids", () => {
+    const row = toAuditRow(fact({ scope: "org", sensitivity: "sensitive", sourceRoute: "/build" }));
+    expect(row.scope).toBe("org");
+    expect(row.sensitive).toBe(true);
+    expect(row.provenance).toBe("Learned in /build");
+    expect(row.label).toBe("review style");
+  });
+
+  it("falls back to a generic provenance when no route", () => {
+    expect(toAuditRow(fact({ sourceRoute: null })).provenance).toBe("Learned in conversation");
+  });
+});
+
+describe("groupAuditRows", () => {
+  it("groups by category in display order, newest-first within a group", () => {
+    const groups = groupAuditRows([
+      fact({ id: "a", category: "domain_context", key: "stack", createdAt: new Date("2026-07-01") }),
+      fact({ id: "b", category: "preference", key: "p1", createdAt: new Date("2026-07-02") }),
+      fact({ id: "c", category: "preference", key: "p2", createdAt: new Date("2026-07-05") }),
+    ]);
+    expect(groups.map((g) => g.category)).toEqual(["preference", "domain_context"]);
+    // preference group newest-first
+    expect(groups[0].rows.map((r) => r.id)).toEqual(["c", "b"]);
+  });
+
+  it("appends unknown categories after the known order", () => {
+    const groups = groupAuditRows([
+      fact({ id: "x", category: "misc", key: "k" }),
+      fact({ id: "y", category: "preference", key: "k" }),
+    ]);
+    expect(groups.map((g) => g.category)).toEqual(["preference", "misc"]);
+  });
+
+  it("returns no groups for no facts", () => {
+    expect(groupAuditRows([])).toEqual([]);
+  });
+});
+
+describe("summarizeAudit", () => {
+  it("counts total, org-shared, and sensitive", () => {
+    const s = summarizeAudit([
+      fact({ scope: "org", sensitivity: "normal" }),
+      fact({ scope: "user", sensitivity: "sensitive" }),
+      fact({ scope: "user", sensitivity: "normal" }),
+    ]);
+    expect(s).toEqual({ total: 3, orgShared: 1, sensitive: 1 });
+  });
+});

--- a/apps/web/lib/actions/memory-audit-shape.ts
+++ b/apps/web/lib/actions/memory-audit-shape.ts
@@ -1,0 +1,132 @@
+// apps/web/lib/actions/memory-audit-shape.ts
+// Pure shaping for the coworker memory transparency surface — BI-DC8B03AB
+// (EP-8C706944 Phase 4). Groups + labels the raw fact/note rows for the audit UI
+// so the surface has no logic of its own. Deterministic, unit-testable.
+
+export type MemoryAuditFact = {
+  id: string;
+  category: string;
+  key: string;
+  value: string;
+  scope: string;
+  sensitivity: string;
+  sourceRoute: string | null;
+  createdAt: Date;
+  lastAccessedAt: Date | null;
+};
+
+export type MemoryAuditRow = {
+  id: string;
+  category: string;
+  label: string;
+  value: string;
+  scope: "user" | "org";
+  sensitive: boolean;
+  provenance: string;
+  createdAt: Date;
+};
+
+/** Plain-language category labels — never raw enum ids in primary copy. */
+const CATEGORY_LABEL: Record<string, string> = {
+  preference: "Preference",
+  decision: "Decision",
+  constraint: "Constraint",
+  domain_context: "About your work",
+};
+
+export function categoryLabel(category: string): string {
+  return CATEGORY_LABEL[category] ?? category.replace(/_/g, " ");
+}
+
+/** Turn a stored key into a human label ("cloud_provider" → "cloud provider"). */
+export function humanizeKey(key: string): string {
+  return key.replace(/[_-]+/g, " ").trim();
+}
+
+/** Shape a fact row for display (no raw enum ids, provenance summarized). */
+export function toAuditRow(fact: MemoryAuditFact): MemoryAuditRow {
+  return {
+    id: fact.id,
+    category: fact.category,
+    label: humanizeKey(fact.key),
+    value: fact.value,
+    scope: fact.scope === "org" ? "org" : "user",
+    sensitive: fact.sensitivity === "sensitive",
+    provenance: fact.sourceRoute ? `Learned in ${fact.sourceRoute}` : "Learned in conversation",
+    createdAt: fact.createdAt,
+  };
+}
+
+export type MemoryAuditGroup = {
+  category: string;
+  label: string;
+  rows: MemoryAuditRow[];
+};
+
+/**
+ * Group facts by category for the progressive-disclosure view (3–5 plain groups),
+ * each group's rows newest-first, groups ordered by the display order below.
+ */
+const CATEGORY_ORDER = ["preference", "decision", "constraint", "domain_context"];
+
+export function groupAuditRows(facts: MemoryAuditFact[]): MemoryAuditGroup[] {
+  const byCategory = new Map<string, MemoryAuditRow[]>();
+  for (const f of facts) {
+    const rows = byCategory.get(f.category) ?? [];
+    rows.push(toAuditRow(f));
+    byCategory.set(f.category, rows);
+  }
+  const groups: MemoryAuditGroup[] = [];
+  const seen = new Set<string>();
+  for (const category of CATEGORY_ORDER) {
+    const rows = byCategory.get(category);
+    if (rows && rows.length > 0) {
+      rows.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      groups.push({ category, label: categoryLabel(category), rows });
+      seen.add(category);
+    }
+  }
+  // Any unrecognized categories after the known order.
+  for (const [category, rows] of byCategory) {
+    if (seen.has(category)) continue;
+    rows.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    groups.push({ category, label: categoryLabel(category), rows });
+  }
+  return groups;
+}
+
+export type MemoryAuditSummary = {
+  total: number;
+  orgShared: number;
+  sensitive: number;
+};
+
+// Server-action return shapes live here (not in the "use server" module, which
+// may export only async functions — a type export there 500s the route).
+export type MyMemoryAudit = {
+  groups: MemoryAuditGroup[];
+  summary: MemoryAuditSummary;
+};
+
+export type OrgMemoryAuditNote = {
+  id: string;
+  agentId: string;
+  noteKind: string;
+  noteKey: string;
+  content: string;
+  createdAt: Date;
+};
+
+export type OrgMemoryAudit = {
+  facts: MemoryAuditGroup[];
+  summary: MemoryAuditSummary;
+  notes: OrgMemoryAuditNote[];
+};
+
+export function summarizeAudit(facts: MemoryAuditFact[]): MemoryAuditSummary {
+  return {
+    total: facts.length,
+    orgShared: facts.filter((f) => f.scope === "org").length,
+    sensitive: facts.filter((f) => f.sensitivity === "sensitive").length,
+  };
+}

--- a/apps/web/lib/actions/memory-audit.ts
+++ b/apps/web/lib/actions/memory-audit.ts
@@ -1,0 +1,84 @@
+"use server";
+
+// apps/web/lib/actions/memory-audit.ts
+// Server actions for the coworker memory transparency surface — BI-DC8B03AB
+// (EP-8C706944 Phase 4). A user can see and forget what a coworker remembers
+// about them; an admin can review org-shared facts + coworker working notes. All
+// shaping lives in the pure memory-audit-shape module; these actions only guard,
+// query, and mutate.
+
+import { prisma } from "@dpf/db";
+import { requireUserId, requireCapability } from "@/lib/actions/shared/guards";
+import {
+  groupAuditRows,
+  summarizeAudit,
+  type MemoryAuditFact,
+  type MyMemoryAudit,
+  type OrgMemoryAudit,
+} from "./memory-audit-shape";
+
+const FACT_SELECT = {
+  id: true,
+  category: true,
+  key: true,
+  value: true,
+  scope: true,
+  sensitivity: true,
+  sourceRoute: true,
+  createdAt: true,
+  lastAccessedAt: true,
+} as const;
+
+/** What does my coworker remember about me — the calling user's active facts. */
+export async function loadMyMemoryAudit(): Promise<MyMemoryAudit> {
+  const userId = await requireUserId();
+  const facts = (await prisma.userFact.findMany({
+    where: { userId, supersededAt: null },
+    orderBy: { createdAt: "desc" },
+    select: FACT_SELECT,
+  })) as MemoryAuditFact[];
+  return { groups: groupAuditRows(facts), summary: summarizeAudit(facts) };
+}
+
+/**
+ * Forget one fact the calling user owns (supersede, never a hard delete — the
+ * provenance chain survives; it just stops being injected). Ownership is enforced
+ * by scoping the update to the caller's userId.
+ */
+export async function forgetMyFact(factId: string): Promise<{ ok: boolean }> {
+  const userId = await requireUserId();
+  const res = await prisma.userFact.updateMany({
+    where: { id: factId, userId, supersededAt: null },
+    data: { supersededAt: new Date() },
+  });
+  return { ok: res.count > 0 };
+}
+
+/**
+ * Admin view: org-shared (non-sensitive) facts across the workforce + every
+ * coworker's active working notes. Read-only; requires the admin AI-management
+ * capability.
+ */
+export async function loadOrgMemoryAudit(): Promise<OrgMemoryAudit> {
+  await requireCapability("manage_agents");
+  const [orgFacts, notes] = await Promise.all([
+    prisma.userFact.findMany({
+      where: { scope: "org", sensitivity: "normal", supersededAt: null },
+      orderBy: { createdAt: "desc" },
+      take: 500,
+      select: FACT_SELECT,
+    }),
+    prisma.coworkerMemoryNote.findMany({
+      where: { supersededAt: null },
+      orderBy: { createdAt: "desc" },
+      take: 500,
+      select: { id: true, agentId: true, noteKind: true, noteKey: true, content: true, createdAt: true },
+    }),
+  ]);
+  const facts = orgFacts as MemoryAuditFact[];
+  return {
+    facts: groupAuditRows(facts),
+    summary: summarizeAudit(facts),
+    notes,
+  };
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 543,
+  "routeCount": 544,
   "routes": [
     {
       "routePath": "/",
@@ -4722,6 +4722,17 @@
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/platform/ai/history/page.tsx",
       "redirectTo": "/platform/audit/ledger"
+    },
+    {
+      "routePath": "/platform/ai/memory",
+      "kind": "page",
+      "segments": [
+        "platform",
+        "ai",
+        "memory"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/platform/ai/memory/page.tsx"
     },
     {
       "routePath": "/platform/ai/model-assignment",

--- a/docs/superpowers/plans/2026-07-09-memory-audit-ui-plan.md
+++ b/docs/superpowers/plans/2026-07-09-memory-audit-ui-plan.md
@@ -1,0 +1,32 @@
+# Coworker memory transparency / audit UI — implementation plan
+
+- **BI:** BI-DC8B03AB (EP-8C706944 — AI Coworker Memory & Context Architecture, Phase 4)
+- **Date:** 2026-07-09
+- **Kernel ledger:** DI-F69AE978B70C (program); **UX-fit ledger DI-94083410B6F1** (high confidence)
+- **Status:** Server actions + self-serve page + admin section (this PR)
+
+## Problem
+
+No surface showed a human what a coworker remembers about them, and there was no per-item delete — the trust lesson from Cursor shipping then retracting invisible auto-memory, and the standard ChatGPT/Grok/Copilot memory-manager pattern. With two-scope memory (BI-1772D0B7) now tagging facts org/user + sensitive, transparency is a requirement, not a nicety.
+
+## UX-fit decision (§12 gate)
+
+`principle_decide` on `human_cognitive_load` (ledger **DI-94083410B6F1**, high confidence, margin 1.96) chose **self-serve settings panel + admin section** over a power "Memory console" or chat-only. Progressive disclosure: 3–5 plain category groups, sensitive items badged, scope shown as "Just you" / "Your team", no raw token/config inputs. `UX-Fit-Decision` trailer on the PR.
+
+## Design
+
+1. **Pure shaping** `memory-audit-shape.ts`: `groupAuditRows` (by category, display order, newest-first), `toAuditRow` (plain labels, scope/sensitivity, humanized provenance — no raw enum ids), `summarizeAudit` (total / org-shared / sensitive). 7 unit tests.
+2. **Server actions** `memory-audit.ts` (`"use server"`): `loadMyMemoryAudit` (the caller's active facts, `requireUserId`), `forgetMyFact` (ownership-scoped **supersede, never a hard delete** — provenance survives), `loadOrgMemoryAudit` (`requireCapability("manage_agents")` — org-shared non-sensitive facts + coworker working notes, read-only).
+3. **Page** `(shell)/platform/ai/memory/page.tsx` (server component): StatCards + per-category report-kit `DataTable`s of the caller's memories with a per-item **Forget** (themed `confirmDialog`, never `window.confirm` — §12); admins additionally see the org section. Route manifest regenerated (`build-route-manifest.ts`).
+
+## Non-goals (follow-ups)
+
+- Nav entry: the peer `/platform/ai/browser-sessions` route is likewise not nav-linked; nav-linking (and the nav-teleport gate) is a follow-up so this PR doesn't couple to nav registration. Route is reachable by URL.
+- Correcting (vs forgetting) a fact inline — Forget + re-state via chat covers it for now.
+- Org-scoped briefing display — composes with BI-A9052DCB's reserved `scope="org"`.
+
+## Verification
+
+- Unit: `memory-audit-shape.test.ts` (7 — humanize/label, row mapping, grouping order, unknown-category append, summary counts).
+- Guards: Native Dialog Guard (uses `confirmDialog`), no-hardcoded-colors (all `var(--dpf-*)`), UX-Fit Gate (trailer present).
+- Runtime (post-merge): a user opens the page, sees grouped memories with scope/sensitivity badges, clicks Forget → confirmDialog → the fact supersedes and disappears on refresh; an admin sees the org section, a non-admin does not.


### PR DESCRIPTION
## Summary
EP-8C706944 Phase 4 — **final BI (9/9)**, kernel ledger DI-F69AE978B70C.

No surface showed a human what a coworker remembers about them, and there was no per-item delete — the trust lesson from Cursor shipping then retracting invisible auto-memory. With two-scope memory (BI-1772D0B7) tagging facts org/user + sensitive, transparency is a requirement.

**UX-fit decision (§12 gate):** `principle_decide` on `human_cognitive_load` (ledger **DI-94083410B6F1**, high confidence, margin 1.96) chose a self-serve settings panel + admin section over a power "Memory console" or chat-only. Progressive disclosure — plain category groups, scope shown as "Just you"/"Your team", sensitive items badged.

- **Pure shaping** `memory-audit-shape.ts`: `groupAuditRows`/`toAuditRow` (plain labels, no raw enum ids)/`summarizeAudit` → 7 unit tests.
- **Server actions** `memory-audit.ts` (`"use server"`, async-only exports — types live in the shape module so the route doesn't 500): `loadMyMemoryAudit`, `forgetMyFact` (ownership-scoped **supersede, never a hard delete**), `loadOrgMemoryAudit` (`manage_agents`, read-only).
- **Page** `(shell)/platform/ai/memory`: StatCards + report-kit DataTables with a per-item **Forget** via themed `confirmDialog` (no native dialog, §12); admin section gated on `manage_agents`. Route manifest regenerated.

## Verification
vitest 7/7, `tsc --noEmit` exit 0, Native Dialog Guard + module-size guards green, route manifest fresh. Prod Build gate via CI.

Plan: docs/superpowers/plans/2026-07-09-memory-audit-ui-plan.md

UX-Fit-Decision: DI-94083410B6F1 — self-serve settings panel + admin section (human_cognitive_load, high confidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)