### PR TITLE
refactor(governance): extract keyed-findings reconciler + AssuranceRun ledger (BET-12 increment 2, BI-7CD647B0)

### DIFF
--- a/apps/web/lib/assurance/bom-job.ts
+++ b/apps/web/lib/assurance/bom-job.ts
@@ -2,6 +2,7 @@ import { lazyFsPromises, lazyPath } from "@/lib/shared/lazy-node";
 import type { Prisma } from "@dpf/db";
 import { generateCycloneDxBom } from "./cyclonedx-generator";
 import { persistGeneratedBom } from "./bom-persistence";
+import { createAssuranceRun } from "./with-assurance-run";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 
 type BomJobDb = {
@@ -74,12 +75,6 @@ function addDays(date: Date, days: number): Date {
   return result;
 }
 
-function createRunId(buildId: string, toolExecutionId: string): string {
-  const buildPart = buildId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
-  const executionPart = toolExecutionId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
-  return `assurance_bom_${buildPart}_${executionPart}`;
-}
-
 export async function generateAndPersistBuildBom(input: GenerateAndPersistBuildBomInput): Promise<GenerateAndPersistBuildBomResult> {
   const build = await input.db.featureBuild.findUnique({
     where: { buildId: input.buildId },
@@ -150,25 +145,20 @@ export async function generateAndPersistBuildBom(input: GenerateAndPersistBuildB
     },
   });
 
-  const assuranceRun = await db.assuranceRun.create({
-    data: {
-      runId: createRunId(build.buildId, toolExecution.id),
-      scopeType: "build",
-      scopeId: build.buildId,
-      adapterKey: "cyclonedx-pnpm-lock",
-      adapterVersion: "1.0.0",
-      status: "passed",
-      summary: {
-        documentDigest: generatedBom.documentDigest,
-        componentCount: generatedBom.components.length,
-      } satisfies Prisma.InputJsonValue,
-      startedAt: input.now,
-      completedAt: input.now,
-      buildId: build.buildId,
-      digitalProductId: build.digitalProductId,
-      toolExecutionId: toolExecution.id,
-      toolExecutionReceiptId: receipt.id,
-    },
+  const assuranceRun = await createAssuranceRun(db, {
+    prefix: "assurance_bom_",
+    buildId: build.buildId,
+    digitalProductId: build.digitalProductId,
+    adapterKey: "cyclonedx-pnpm-lock",
+    adapterVersion: "1.0.0",
+    status: "passed",
+    summary: {
+      documentDigest: generatedBom.documentDigest,
+      componentCount: generatedBom.components.length,
+    } satisfies Prisma.InputJsonValue,
+    toolExecutionId: toolExecution.id,
+    toolExecutionReceiptId: receipt.id,
+    now: input.now,
   });
 
   const persisted = await persistGeneratedBom(db, {

--- a/apps/web/lib/assurance/scan-job.ts
+++ b/apps/web/lib/assurance/scan-job.ts
@@ -7,6 +7,7 @@ import {
   type PnpmAuditComponentLookup,
 } from "./pnpm-audit-adapter";
 import { persistAssuranceFindings, type AssuranceFindingPersistenceDb } from "./finding-persistence";
+import { createAssuranceRun } from "./with-assurance-run";
 import { autoFileFindingsFromScan } from "./auto-file-findings";
 import { loadReconcileContext } from "./advisory-context";
 import { emptyDispositionTotals, type ReconcileContext } from "./finding-reconcile";
@@ -165,12 +166,6 @@ function deriveStatus(findingCount: number, blockingCount: number): "passed" | "
   return "passed";
 }
 
-function createRunId(buildId: string, toolExecutionId: string): string {
-  const buildPart = buildId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
-  const executionPart = toolExecutionId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
-  return `assurance_scan_${buildPart}_${executionPart}`;
-}
-
 function addDays(date: Date, days: number): Date {
   const result = new Date(date);
   result.setUTCDate(result.getUTCDate() + days);
@@ -265,22 +260,17 @@ export async function runBuildAssuranceScan(input: RunBuildScanInput): Promise<R
     },
   });
 
-  const assuranceRun = await input.db.assuranceRun.create({
-    data: {
-      runId: createRunId(build.buildId, toolExecution.id),
-      scopeType: "build",
-      scopeId: build.buildId,
-      adapterKey: PNPM_AUDIT_ADAPTER_KEY,
-      adapterVersion: PNPM_AUDIT_ADAPTER_VERSION,
-      status,
-      summary: adapterOutput.summary as Prisma.InputJsonValue,
-      startedAt: input.now,
-      completedAt: input.now,
-      buildId: build.buildId,
-      digitalProductId: build.digitalProductId,
-      toolExecutionId: toolExecution.id,
-      toolExecutionReceiptId: receipt.id,
-    },
+  const assuranceRun = await createAssuranceRun(input.db, {
+    prefix: "assurance_scan_",
+    buildId: build.buildId,
+    digitalProductId: build.digitalProductId,
+    adapterKey: PNPM_AUDIT_ADAPTER_KEY,
+    adapterVersion: PNPM_AUDIT_ADAPTER_VERSION,
+    status,
+    summary: adapterOutput.summary as Prisma.InputJsonValue,
+    toolExecutionId: toolExecution.id,
+    toolExecutionReceiptId: receipt.id,
+    now: input.now,
   });
 
   const persistResult = await persistAssuranceFindings(input.db, {

--- a/apps/web/lib/assurance/with-assurance-run.test.ts
+++ b/apps/web/lib/assurance/with-assurance-run.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { assuranceRunId, createAssuranceRun } from "./with-assurance-run";
+
+describe("assuranceRunId", () => {
+  it("joins prefix + sanitized buildId + sanitized toolExecutionId", () => {
+    expect(assuranceRunId("assurance_scan_", "BUILD-1", "tool-1")).toBe("assurance_scan_BUILD-1_tool-1");
+    expect(assuranceRunId("assurance_bom_", "BUILD-1", "tool-1")).toBe("assurance_bom_BUILD-1_tool-1");
+  });
+
+  it("replaces disallowed characters with underscores", () => {
+    expect(assuranceRunId("p_", "a/b c.d", "x:y")).toBe("p_a_b_c_d_x_y");
+  });
+
+  it("caps each id part at 64 characters", () => {
+    const long = "z".repeat(100);
+    const runId = assuranceRunId("p_", long, long);
+    // prefix + 64 chars + "_" + 64 chars
+    expect(runId).toBe(`p_${"z".repeat(64)}_${"z".repeat(64)}`);
+  });
+});
+
+describe("createAssuranceRun", () => {
+  it("passes the fixed contract + varying fields through to assuranceRun.create", async () => {
+    const now = new Date("2026-07-09T12:00:00.000Z");
+    const created = { id: "run-db-1", runId: "assurance_scan_BUILD-1_tool-1" };
+    const create = vi.fn(async () => created);
+    const db = { assuranceRun: { create } };
+
+    const summary = { blockingCount: 2 };
+    const result = await createAssuranceRun(db, {
+      prefix: "assurance_scan_",
+      buildId: "BUILD-1",
+      digitalProductId: "product-1",
+      adapterKey: "pnpm-audit",
+      adapterVersion: "1.2.3",
+      status: "failed",
+      summary,
+      toolExecutionId: "tool-1",
+      toolExecutionReceiptId: "receipt-1",
+      now,
+    });
+
+    expect(result).toBe(created);
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        runId: "assurance_scan_BUILD-1_tool-1",
+        scopeType: "build",
+        scopeId: "BUILD-1",
+        adapterKey: "pnpm-audit",
+        adapterVersion: "1.2.3",
+        status: "failed",
+        summary,
+        startedAt: now,
+        completedAt: now,
+        buildId: "BUILD-1",
+        digitalProductId: "product-1",
+        toolExecutionId: "tool-1",
+        toolExecutionReceiptId: "receipt-1",
+      },
+    });
+  });
+
+  it("threads the injected `now` into both startedAt and completedAt", async () => {
+    const now = new Date("2020-01-02T03:04:05.000Z");
+    const create = vi.fn(async (_args: { data: Record<string, unknown> }) => ({
+      id: "run-db-2",
+      runId: "assurance_bom_B_T",
+    }));
+    const db = { assuranceRun: { create } };
+
+    await createAssuranceRun(db, {
+      prefix: "assurance_bom_",
+      buildId: "B",
+      digitalProductId: null,
+      adapterKey: "cyclonedx-pnpm-lock",
+      adapterVersion: "1.0.0",
+      status: "passed",
+      summary: { componentCount: 3 },
+      toolExecutionId: "T",
+      toolExecutionReceiptId: "R",
+      now,
+    });
+
+    const data = create.mock.calls[0][0].data;
+    expect(data.startedAt).toBe(now);
+    expect(data.completedAt).toBe(now);
+    expect(data.scopeType).toBe("build");
+    expect(data.scopeId).toBe("B");
+    expect(data.digitalProductId).toBeNull();
+  });
+});

--- a/apps/web/lib/assurance/with-assurance-run.ts
+++ b/apps/web/lib/assurance/with-assurance-run.ts
@@ -1,0 +1,70 @@
+// apps/web/lib/assurance/with-assurance-run.ts — EP-8DC217EB BET-12
+//
+// Shared AssuranceRun ledger writer. Both the BOM job and the vulnerability-scan
+// job open a build-scoped AssuranceRun with an identical field layout — only the
+// runId prefix, adapter, status, and summary vary. This collapses that duplicated
+// block (and the two copies of the runId builder) into one place so the fixed
+// contract (scopeType "build", scopeId = buildId, startedAt = completedAt = now)
+// lives once.
+
+import type { Prisma } from "@dpf/db";
+
+/** Minimal client shape: just the assuranceRun.create delegate this writer needs. */
+export type AssuranceRunCreateClient = {
+  assuranceRun: {
+    create(args: unknown): Promise<{ id: string; runId: string }>;
+  };
+};
+
+/**
+ * Build a deterministic AssuranceRun id: `<prefix><buildId>_<toolExecutionId>`,
+ * with each id part sanitized to `[a-zA-Z0-9_-]` and capped at 64 chars.
+ * `prefix` carries the per-adapter namespace, e.g. `assurance_scan_` / `assurance_bom_`.
+ */
+export function assuranceRunId(prefix: string, buildId: string, toolExecutionId: string): string {
+  const buildPart = buildId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+  const executionPart = toolExecutionId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+  return `${prefix}${buildPart}_${executionPart}`;
+}
+
+export interface CreateAssuranceRunParams {
+  /** runId namespace, e.g. `assurance_scan_` or `assurance_bom_`. */
+  prefix: string;
+  buildId: string;
+  digitalProductId: string | null;
+  adapterKey: string;
+  adapterVersion: string;
+  status: string;
+  summary: Prisma.InputJsonValue;
+  toolExecutionId: string;
+  toolExecutionReceiptId: string;
+  now: Date;
+}
+
+/**
+ * Create the build-scoped AssuranceRun ledger row. The varying fields come from
+ * `params`; the fixed contract (scopeType "build", scopeId = buildId,
+ * startedAt = completedAt = now) is applied here.
+ */
+export async function createAssuranceRun(
+  db: AssuranceRunCreateClient,
+  params: CreateAssuranceRunParams,
+): Promise<{ id: string; runId: string }> {
+  return db.assuranceRun.create({
+    data: {
+      runId: assuranceRunId(params.prefix, params.buildId, params.toolExecutionId),
+      scopeType: "build",
+      scopeId: params.buildId,
+      adapterKey: params.adapterKey,
+      adapterVersion: params.adapterVersion,
+      status: params.status,
+      summary: params.summary,
+      startedAt: params.now,
+      completedAt: params.now,
+      buildId: params.buildId,
+      digitalProductId: params.digitalProductId,
+      toolExecutionId: params.toolExecutionId,
+      toolExecutionReceiptId: params.toolExecutionReceiptId,
+    },
+  });
+}

--- a/apps/web/lib/ea/conformance-issue-reconciler.ts
+++ b/apps/web/lib/ea/conformance-issue-reconciler.ts
@@ -3,6 +3,18 @@
 // Steward-style detectors should emit stable issue keys. This helper owns the
 // create/update/auto-resolve contract so each steward does not re-implement the
 // same fragile persistence loop.
+//
+// It is now a thin adapter over the generic `governance/reconcile-keyed-findings`
+// loop: this file only plugs in the `eaConformanceIssue` delegate, the
+// `detailsJson.issueKey` key extraction, and the message/severity/detailsJson
+// change detection. The exported signature and `{created, updated, resolved}`
+// return shape are unchanged, so the stewards that call it need no changes.
+
+import {
+  reconcileKeyedFindings,
+  stableStringify,
+  type ReconcileKeyedFindingsResult,
+} from "@/lib/governance/reconcile-keyed-findings";
 
 export type ConformanceIssueClient = {
   eaConformanceIssue: {
@@ -30,10 +42,14 @@ export type ConformanceFinding = {
   elementId?: string | null;
 };
 
-export type ConformanceIssueReconcileResult = {
-  created: number;
-  updated: number;
-  resolved: number;
+export type ConformanceIssueReconcileResult = ReconcileKeyedFindingsResult;
+
+type ConformanceRow = {
+  id: string;
+  issueType: string;
+  message: string;
+  severity: string;
+  detailsJson: unknown;
 };
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -45,18 +61,13 @@ function issueKeyOf(detailsJson: unknown): string | null {
   return typeof key === "string" ? key : null;
 }
 
-function stable(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(stable);
-  if (!value || typeof value !== "object") return value;
-  return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>)
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([key, item]) => [key, stable(item)]),
-  );
+/** The stored details always carry the stable issueKey alongside the finding detail. */
+function effectiveDetails(finding: ConformanceFinding): Record<string, unknown> {
+  return { ...(finding.detailsJson ?? {}), issueKey: finding.issueKey };
 }
 
 function detailsChanged(a: unknown, b: Record<string, unknown>): boolean {
-  return JSON.stringify(stable(asRecord(a))) !== JSON.stringify(stable(b));
+  return stableStringify(asRecord(a)) !== stableStringify(b);
 }
 
 export async function reconcileConformanceIssues(
@@ -66,62 +77,44 @@ export async function reconcileConformanceIssues(
     findings: ConformanceFinding[];
   },
 ): Promise<ConformanceIssueReconcileResult> {
-  const existing = await db.eaConformanceIssue.findMany({
-    where: { issueType: { in: opts.issueTypes }, status: "open" },
-    select: { id: true, issueType: true, message: true, severity: true, detailsJson: true },
-  });
+  const keyed = opts.findings.map((finding) => ({ ...finding, key: finding.issueKey }));
 
-  const existingByKey = new Map<string, (typeof existing)[number]>();
-  for (const row of existing) {
-    const key = issueKeyOf(row.detailsJson);
-    if (key) existingByKey.set(key, row);
-  }
-
-  const findingByKey = new Map<string, ConformanceFinding>(opts.findings.map((f) => [f.issueKey, f]));
-  let created = 0;
-  let updated = 0;
-  let resolved = 0;
-
-  for (const finding of opts.findings) {
-    const match = existingByKey.get(finding.issueKey);
-    const detailsJson = { ...(finding.detailsJson ?? {}), issueKey: finding.issueKey };
-    if (!match) {
+  return reconcileKeyedFindings<ConformanceRow, (typeof keyed)[number]>({
+    loadOpen: () =>
+      db.eaConformanceIssue.findMany({
+        where: { issueType: { in: opts.issueTypes }, status: "open" },
+        select: { id: true, issueType: true, message: true, severity: true, detailsJson: true },
+      }),
+    keyOf: (row) => issueKeyOf(row.detailsJson),
+    findings: keyed,
+    hasChanged: (row, finding) =>
+      row.message !== finding.message ||
+      row.severity !== finding.severity ||
+      detailsChanged(row.detailsJson, effectiveDetails(finding)),
+    create: async (finding) => {
       const data: Record<string, unknown> = {
         issueType: finding.issueType,
         severity: finding.severity,
         status: "open",
         message: finding.message,
-        detailsJson,
+        detailsJson: effectiveDetails(finding),
       };
       if ("viewId" in finding) data.viewId = finding.viewId;
       if ("elementId" in finding) data.elementId = finding.elementId;
-      await db.eaConformanceIssue.create({
-        data,
-      });
-      created += 1;
-    } else if (
-      match.message !== finding.message ||
-      match.severity !== finding.severity ||
-      detailsChanged(match.detailsJson, detailsJson)
-    ) {
+      await db.eaConformanceIssue.create({ data });
+    },
+    update: async (row, finding) => {
       await db.eaConformanceIssue.update({
-        where: { id: match.id },
+        where: { id: row.id },
         data: {
           message: finding.message,
           severity: finding.severity,
-          detailsJson,
+          detailsJson: effectiveDetails(finding),
         },
       });
-      updated += 1;
-    }
-  }
-
-  for (const [key, row] of existingByKey) {
-    if (!findingByKey.has(key)) {
+    },
+    resolve: async (row) => {
       await db.eaConformanceIssue.update({ where: { id: row.id }, data: { status: "resolved" } });
-      resolved += 1;
-    }
-  }
-
-  return { created, updated, resolved };
+    },
+  });
 }

--- a/apps/web/lib/governance/reconcile-keyed-findings.test.ts
+++ b/apps/web/lib/governance/reconcile-keyed-findings.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  reconcileKeyedFindings,
+  stableStringify,
+  type KeyedFinding,
+} from "./reconcile-keyed-findings";
+
+type Row = { id: string; key: string | null; message: string };
+type Finding = KeyedFinding & { message: string };
+
+function harness(rows: Row[]) {
+  const create = vi.fn(async (_f: Finding) => undefined);
+  const update = vi.fn(async (_r: Row, _f: Finding) => undefined);
+  const resolve = vi.fn(async (_r: Row) => undefined);
+  const run = (findings: Finding[]) =>
+    reconcileKeyedFindings<Row, Finding>({
+      loadOpen: async () => rows,
+      keyOf: (row) => row.key,
+      findings,
+      hasChanged: (row, finding) => row.message !== finding.message,
+      create,
+      update,
+      resolve,
+    });
+  return { create, update, resolve, run };
+}
+
+describe("reconcileKeyedFindings", () => {
+  it("creates findings that have no matching open row", async () => {
+    const h = harness([]);
+    const result = await h.run([{ key: "a", message: "new" }]);
+
+    expect(h.create).toHaveBeenCalledTimes(1);
+    expect(h.create).toHaveBeenCalledWith({ key: "a", message: "new" });
+    expect(h.update).not.toHaveBeenCalled();
+    expect(h.resolve).not.toHaveBeenCalled();
+    expect(result).toEqual({ created: 1, updated: 0, resolved: 0 });
+  });
+
+  it("updates a matched row only when hasChanged reports a difference", async () => {
+    const h = harness([
+      { id: "r-same", key: "same", message: "unchanged" },
+      { id: "r-diff", key: "diff", message: "old" },
+    ]);
+    const result = await h.run([
+      { key: "same", message: "unchanged" },
+      { key: "diff", message: "new" },
+    ]);
+
+    expect(h.create).not.toHaveBeenCalled();
+    expect(h.update).toHaveBeenCalledTimes(1);
+    expect(h.update).toHaveBeenCalledWith(
+      { id: "r-diff", key: "diff", message: "old" },
+      { key: "diff", message: "new" },
+    );
+    expect(result).toEqual({ created: 0, updated: 1, resolved: 0 });
+  });
+
+  it("resolves open rows whose key vanished from the findings", async () => {
+    const h = harness([
+      { id: "r-keep", key: "keep", message: "m" },
+      { id: "r-gone", key: "gone", message: "m" },
+    ]);
+    const result = await h.run([{ key: "keep", message: "m" }]);
+
+    expect(h.resolve).toHaveBeenCalledTimes(1);
+    expect(h.resolve).toHaveBeenCalledWith({ id: "r-gone", key: "gone", message: "m" });
+    expect(result).toEqual({ created: 0, updated: 0, resolved: 1 });
+  });
+
+  it("skips rows with a null key (cannot be matched or resolved)", async () => {
+    const h = harness([{ id: "r-null", key: null, message: "m" }]);
+    const result = await h.run([{ key: "a", message: "m" }]);
+
+    // The null-key row is never keyed, so it is neither matched nor resolved.
+    expect(h.create).toHaveBeenCalledTimes(1);
+    expect(h.resolve).not.toHaveBeenCalled();
+    expect(result).toEqual({ created: 1, updated: 0, resolved: 0 });
+  });
+});
+
+describe("stableStringify", () => {
+  it("is insensitive to object key order", () => {
+    expect(stableStringify({ a: 1, b: 2 })).toBe(stableStringify({ b: 2, a: 1 }));
+  });
+
+  it("sorts nested object keys recursively but preserves array order", () => {
+    expect(stableStringify({ outer: { z: 1, a: [{ y: 2, x: 1 }] } })).toBe(
+      stableStringify({ outer: { a: [{ x: 1, y: 2 }], z: 1 } }),
+    );
+    // Array element order is meaningful and preserved.
+    expect(stableStringify([1, 2])).not.toBe(stableStringify([2, 1]));
+  });
+
+  it("distinguishes genuinely different values", () => {
+    expect(stableStringify({ a: 1 })).not.toBe(stableStringify({ a: 2 }));
+  });
+});

--- a/apps/web/lib/governance/reconcile-keyed-findings.ts
+++ b/apps/web/lib/governance/reconcile-keyed-findings.ts
@@ -1,0 +1,102 @@
+// apps/web/lib/governance/reconcile-keyed-findings.ts — EP-8DC217EB BET-12
+//
+// The generic keyed-findings reconcile loop shared by the governance finding
+// streams. A detector emits a set of stable-keyed findings; this helper owns the
+// create-new / update-changed / auto-resolve-absent contract against a set of
+// currently-open rows, so each stream does not re-implement the same fragile
+// persistence loop.
+//
+// It is deliberately storage-agnostic: the caller supplies the row loader, the
+// key extractors, the change comparator, and the create/update/resolve writers.
+// `ea/conformance-issue-reconciler.ts` is the first thin adapter over it; the
+// other streams (wiki-lint, assurance, security) can plug in later without
+// touching this loop.
+
+/** A finding carries a stable per-stream key; everything else is stream-specific. */
+export interface KeyedFinding {
+  key: string;
+}
+
+export interface ReconcileKeyedFindingsOptions<TRow, TFinding extends KeyedFinding> {
+  /** Load the currently-open rows this reconcile should consider. */
+  loadOpen: () => Promise<TRow[]>;
+  /** Stable key for an existing row; a null key skips the row (it can't be matched). */
+  keyOf: (row: TRow) => string | null;
+  /** Desired findings, each with a stable `key`. */
+  findings: TFinding[];
+  /** True when a matched row differs from its finding and needs an update. */
+  hasChanged: (row: TRow, finding: TFinding) => boolean;
+  /** Persist a brand-new finding (no matching open row). */
+  create: (finding: TFinding) => Promise<unknown>;
+  /** Update the matched row to reflect the (changed) finding. */
+  update: (row: TRow, finding: TFinding) => Promise<unknown>;
+  /** Resolve an open row whose key is no longer among the findings. */
+  resolve: (row: TRow) => Promise<unknown>;
+}
+
+export interface ReconcileKeyedFindingsResult {
+  created: number;
+  updated: number;
+  resolved: number;
+}
+
+/**
+ * Reconcile a set of stable-keyed findings against the currently-open rows:
+ * create findings with no open row, update matched rows whose content changed,
+ * and resolve open rows whose key vanished from the findings.
+ */
+export async function reconcileKeyedFindings<TRow, TFinding extends KeyedFinding>(
+  opts: ReconcileKeyedFindingsOptions<TRow, TFinding>,
+): Promise<ReconcileKeyedFindingsResult> {
+  const existing = await opts.loadOpen();
+
+  const existingByKey = new Map<string, TRow>();
+  for (const row of existing) {
+    const key = opts.keyOf(row);
+    if (key) existingByKey.set(key, row);
+  }
+
+  const findingKeys = new Set(opts.findings.map((f) => f.key));
+  let created = 0;
+  let updated = 0;
+  let resolved = 0;
+
+  for (const finding of opts.findings) {
+    const match = existingByKey.get(finding.key);
+    if (!match) {
+      await opts.create(finding);
+      created += 1;
+    } else if (opts.hasChanged(match, finding)) {
+      await opts.update(match, finding);
+      updated += 1;
+    }
+  }
+
+  for (const [key, row] of existingByKey) {
+    if (!findingKeys.has(key)) {
+      await opts.resolve(row);
+      resolved += 1;
+    }
+  }
+
+  return { created, updated, resolved };
+}
+
+/**
+ * Deterministic JSON string with object keys sorted recursively, so two payloads
+ * that differ only in key order compare equal. Shared change-detection primitive
+ * for adapters that diff a stored JSON blob against a freshly-derived one.
+ */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(stableize(value));
+}
+
+function stableize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableize);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, item]) => [key, stableize(item)]),
+  );
+}

--- a/docs/superpowers/specs/2026-07-09-governance-finding-contract-design.md
+++ b/docs/superpowers/specs/2026-07-09-governance-finding-contract-design.md
@@ -1,6 +1,6 @@
 # Governance findings plane — one contract + one severity ladder (opener)
 
-_Status: implemented with BI-7CD647B0 · EP-8DC217EB BET-12 (opener) · 2026-07-09_
+_Status: opener + increment 2 landed under BI-7CD647B0 · EP-8DC217EB BET-12 · 2026-07-09_
 _Parent plan: [`2026-07-07-vertical-integration-inward-plan.md`](../plans/2026-07-07-vertical-integration-inward-plan.md) §4 BET-12_
 
 ## The gap
@@ -29,17 +29,37 @@ can render or roll them up together.
   persistence/detector modules), so this stays a leaf with no new deps and no
   hot-zone touch.
 
+## Landed in increment 2 (BI-7CD647B0 · behavior-preserving)
+
+Two duplication-collapsing extractions, no observable-behavior change; existing
+tests stayed green and new unit tests cover the helpers:
+
+1. **`lib/governance/reconcile-keyed-findings.ts`** — the generic keyed-upsert +
+   auto-resolve loop (`reconcileKeyedFindings<TRow, TFinding>` +
+   `stableStringify`), storage-agnostic via caller-supplied
+   `loadOpen` / `keyOf` / `hasChanged` / `create` / `update` / `resolve`.
+   `ea/conformance-issue-reconciler.ts` is now a **thin adapter** over it —
+   plugging in the `eaConformanceIssue` delegate, the `detailsJson.issueKey` key
+   extraction, and the message/severity/detailsJson change detection. Its
+   exported signature and `{created, updated, resolved}` return shape are
+   unchanged, so **the stewards that call it need zero changes** (architecture-
+   parity, data-architecture-steward-apply, consolidation-parity). The other
+   streams (wiki-lint, assurance, security) can adopt the loop later without
+   touching it. (`reconcile-it4it-coverage.ts` keeps its own parallel
+   `detailsJson.key` loop for now — a future adoption candidate, left untouched.)
+2. **`lib/assurance/with-assurance-run.ts`** — `assuranceRunId(prefix, buildId,
+   toolExecutionId)` (shared sanitize + `slice(0,64)`) and `createAssuranceRun`,
+   which applies the fixed AssuranceRun contract (scopeType `build`,
+   scopeId = buildId, startedAt = completedAt = injected `now`) and takes the
+   varying fields as params. `scan-job.ts` and `bom-job.ts` call it and deleted
+   their duplicated local `createRunId` copies; the runId strings, field values,
+   and `summary as Prisma.InputJsonValue` cast are byte-for-byte preserved.
+
 ## Deliberately deferred (later BET-12 increments)
 
-Per the plan's land-order and the Inside-Out hot-zone rule, these are **not** in
-this PR:
+Per the plan's land-order and the Inside-Out hot-zone rule, these are **not** yet
+built:
 
-1. **`reconcile-keyed-findings` extraction** — generalize the keyed-upsert +
-   auto-resolve loop out of `ea/conformance-issue-reconciler.ts` (a live file
-   used by 3 stewards) into a reusable helper, refactoring the reconciler as a
-   thin adapter. Behavior-preserving refactor of a live path → its own increment.
-2. **`withAssuranceRun` wrapper** — collapse the duplicated `AssuranceRun` ledger
-   block in `assurance/scan-job.ts` + `bom-job.ts`.
 3. **case→evidence generalization** — mirror `securityCaseToEvidenceInput` for
    assurance runs so `ComplianceEvidence` is fed by more than security.
 4. **detector → `ingestBacklogItem` fan-in** — route SOC cases (which today
@@ -61,6 +81,6 @@ foundation, unit-tested against each source shape.
 The single-ladder + per-source mapper approach matches how SIEM/GRC tools
 (e.g. DefectDojo's unified finding model) normalize heterogeneous scanner
 severities onto one ordinal scale before dedup/rollup, rather than rendering
-each tool's native scale. The `reconcile-keyed-findings` target already exists
-in-repo as `reconcileConformanceIssues` — increment 1 generalizes it rather
-than inventing a parallel loop.
+each tool's native scale. The `reconcile-keyed-findings` target already existed
+in-repo as `reconcileConformanceIssues` — increment 2 generalized it in place
+rather than inventing a parallel loop.


### PR DESCRIPTION
## What

EP-8DC217EB **BET-12 increment 2** (BI-7CD647B0) — two behavior-preserving extractions continuing the governance findings/evidence plane after the opener (#2743).

- **`apps/web/lib/governance/reconcile-keyed-findings.ts`** (new) — generic `reconcileKeyedFindings<TRow,TFinding>` (loadOpen / keyOf / hasChanged / create / update / resolve) + `stableStringify`. **`ea/conformance-issue-reconciler.ts` is now a thin adapter over it** — its exported `reconcileConformanceIssues` signature + `{created,updated,resolved}` return shape are **unchanged**, so its 3 shared-reconciler callers (architecture-parity / data-architecture-steward-apply / consolidation-parity stewards) need **zero changes**. (`reconcile-it4it-coverage.ts` has its own private local variant keyed on `detailsJson.key` — never imported the shared one — left untouched; flagged as a future adoption candidate.)
- **`apps/web/lib/assurance/with-assurance-run.ts`** (new) — `assuranceRunId(prefix,buildId,toolExecutionId)` + `createAssuranceRun`, collapsing the duplicated `AssuranceRun.create` block + local `createRunId` copies in `scan-job.ts` and `bom-job.ts`. RunId strings preserved byte-for-byte (`assurance_scan_…` / `assurance_bom_…`); same fixed contract, same `summary as Prisma.InputJsonValue` cast, same ordering vs the `persistAssuranceFindings`/`persistGeneratedBom` consumers of `assuranceRun.id`.
- Spec updated (`docs/superpowers/specs/2026-07-09-governance-finding-contract-design.md`): increments 1+2 moved from Deferred → Landed.

New unit tests for both helpers (create/update/resolve-absent, null-key skip, stable-stringify order-insensitivity; both runId prefixes + sanitize/slice + exact create-data shape + `now` flow-through).

## Verification

Substrate: source-local, worktree `bet12-reconciler` (merged current origin/main incl. the new `add_coworker_briefing` migration; Prisma client regenerated):
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` → **exit 0**
- `pnpm --filter web exec vitest run` (full suite) → **exit 0, 1743 files / 14947 passed, 0 failed** (existing scan-job/bom-job/steward tests all green unchanged)
- Guard loop **13**; module-size OK. No `packages/*` barrel touched → no Turbopack risk.

## Local-CI-Override

Pre-push sandbox gate skipped (`DPF_SKIP_PREPUSH_GATE=1`, source-local worktree): full typecheck exit 0 + full vitest exit 0 + guards green. CI is the canonical run.

> Authored by a build subagent; post-merge re-verification (all gates, after Prisma regen) done by hand.

Process-Spine-Decision: EP-8DC217EB plan §4 BET-12 increment 2 — behavior-preserving extraction; conformance reconciler becomes a thin adapter, callers unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)