### PR TITLE
fix(portfolio): seed Workforce taxonomy root label

### DIFF
--- a/docs/superpowers/specs/2026-06-07-business-operating-model-portfolio-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-07-business-operating-model-portfolio-wiring-design.md
@@ -133,6 +133,8 @@ Mark's reframe: "Employees" is too narrow because it excludes the AI agent workf
 
 **2026-07-06 terminology amendment.** The `for_employees` root now renders as **Workforce** in the portfolio registry. "For Employees" remains a legacy alias and standards cross-reference only; the canonical slug stays `for_employees` to avoid data churn. This aligns the platform with the standards-facing proposal in [`docs/architecture/2026-07-06-it4it-dppm-workforce-portfolio-white-paper.md`](../../architecture/2026-07-06-it4it-dppm-workforce-portfolio-white-paper.md): the internal portfolio should account for employees, contractors, AI coworkers, robots, non-human identities, and any other accountable actor that performs or approves work.
 
+**2026-07-10 seed invariant.** Root taxonomy-node display names are seeded from `portfolio_registry.json`, not from the legacy `taxonomy_v3.json` row label. The taxonomy keeps stable `for_employees` paths and the legacy "For Employees" cross-reference, while the platform-facing root renders as **Workforce** after self-upgrade reseeds the live install.
+
 ### 4.3 Facets C & D — Foundational and Manufacturing & Delivery (the dependency floor)
 
 Out of primary scope for this spec, but named because the two business facets **decompose into them** (the DPPM dependency chain). Each offering in Facet A and each workforce capability in Facet B declares what Foundational and Manufacturing & Delivery elements it depends on. This reuses the maturity spec's `dependsOn` DAG discipline (§10.3) at the *business* layer: an offer's effective deliverability is bounded by the maturity of the foundational + delivery elements it rests on.

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -74,6 +74,7 @@ import { seedAgentControlPlaneMaturity } from "./seed-agent-control-plane-maturi
 import { seedCoworkerServiceCatalog } from "./coworker-service-catalog-seed.js";
 import { syncCapabilities } from "./sync-capabilities.js";
 import { defaultGovernanceFor } from "./taxonomy-governance-defaults.js";
+import { buildTaxonomyNodeEntries, type TaxonomySeedRow } from "./taxonomy-seed-entries.js";
 import { AGENT_MODEL_CONFIG_DEFAULTS } from "./agent-model-defaults.js";
 import { toModelProfileSeedCreateData } from "./model-profile-seed.js";
 import { deriveLocalModelCapabilityPrior, localInputModalities } from "./local-model-capabilities.js";
@@ -382,75 +383,9 @@ async function seedPortfolios(): Promise<void> {
 
 async function seedTaxonomyNodes(): Promise<void> {
   const DATA_PATH = join(__dirname, "..", "data", "taxonomy_v3.json");
-  type Row = {
-    portfolio: string;
-    portfolio_id: string;
-    level_1: string;
-    level_2: string;
-    level_3: string;
-    definition?: string;
-    notes?: string;
-    enrichment?: Record<string, unknown>;
-  };
-  const rows: Row[] = JSON.parse(readFileSync(DATA_PATH, "utf-8"));
-
-  function slugify(s: string): string {
-    return s.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
-  }
-
-  // Collect all unique nodes in insertion order (root → L1 → L2 → L3)
-  const seen = new Set<string>();
-  type NodeEntry = {
-    nodeId: string;
-    name: string;
-    parentNodeId: string | null;
-    portfolioId: string;
-    description: string | null;
-    enrichment: Record<string, unknown> | null;
-  };
-
-  const entries: NodeEntry[] = [];
-
-  for (const row of rows) {
-    const pid = row.portfolio_id;
-    if (!seen.has(pid)) {
-      seen.add(pid);
-      entries.push({ nodeId: pid, name: row.portfolio, parentNodeId: null, portfolioId: pid, description: null, enrichment: null });
-    }
-    if (!row.level_1) continue;
-    const l1id = `${pid}/${slugify(row.level_1)}`;
-    if (!seen.has(l1id)) {
-      seen.add(l1id);
-      // L1 nodes get description/enrichment only if this row IS an L1 leaf (no L2)
-      const isL1Leaf = !row.level_2;
-      entries.push({
-        nodeId: l1id, name: row.level_1, parentNodeId: pid, portfolioId: pid,
-        description: isL1Leaf ? (row.definition || null) : null,
-        enrichment: isL1Leaf && row.enrichment && Object.keys(row.enrichment).length > 0 ? row.enrichment : null,
-      });
-    }
-    if (!row.level_2) continue;
-    const l2id = `${l1id}/${slugify(row.level_2)}`;
-    if (!seen.has(l2id)) {
-      seen.add(l2id);
-      const isL2Leaf = !row.level_3;
-      entries.push({
-        nodeId: l2id, name: row.level_2, parentNodeId: l1id, portfolioId: pid,
-        description: isL2Leaf ? (row.definition || null) : null,
-        enrichment: isL2Leaf && row.enrichment && Object.keys(row.enrichment).length > 0 ? row.enrichment : null,
-      });
-    }
-    if (!row.level_3) continue;
-    const l3id = `${l2id}/${slugify(row.level_3)}`;
-    if (!seen.has(l3id)) {
-      seen.add(l3id);
-      entries.push({
-        nodeId: l3id, name: row.level_3, parentNodeId: l2id, portfolioId: pid,
-        description: row.definition || null,
-        enrichment: row.enrichment && Object.keys(row.enrichment).length > 0 ? row.enrichment : null,
-      });
-    }
-  }
+  const rows: TaxonomySeedRow[] = JSON.parse(readFileSync(DATA_PATH, "utf-8"));
+  const registry = readJson<{ portfolios: Array<{ id: string; name: string }> }>("portfolio_registry.json");
+  const entries = buildTaxonomyNodeEntries(rows, registry.portfolios);
 
   // Look up Portfolio.id values by portfolioId slug
   const portfolios = await prisma.portfolio.findMany({ select: { id: true, slug: true } });

--- a/packages/db/src/taxonomy-seed-entries.test.ts
+++ b/packages/db/src/taxonomy-seed-entries.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildTaxonomyNodeEntries, type TaxonomySeedRow } from "./taxonomy-seed-entries";
+
+const taxonomyPath = join(__dirname, "..", "data", "taxonomy_v3.json");
+const portfolioRegistryPath = join(__dirname, "..", "data", "portfolio_registry.json");
+
+const taxonomyRows = JSON.parse(readFileSync(taxonomyPath, "utf8")) as TaxonomySeedRow[];
+const portfolioRegistry = JSON.parse(readFileSync(portfolioRegistryPath, "utf8")) as {
+  portfolios: Array<{ id: string; name: string }>;
+};
+
+describe("taxonomy seed entries", () => {
+  it("uses portfolio registry names for root taxonomy labels", () => {
+    const entries = buildTaxonomyNodeEntries(taxonomyRows, portfolioRegistry.portfolios);
+
+    expect(entries.find((entry) => entry.nodeId === "for_employees")?.name).toBe("Workforce");
+    expect(
+      new Set(
+        taxonomyRows
+          .filter((row) => row.portfolio_id === "for_employees")
+          .map((row) => row.portfolio),
+      ),
+    ).toEqual(new Set(["For Employees"]));
+  });
+});

--- a/packages/db/src/taxonomy-seed-entries.ts
+++ b/packages/db/src/taxonomy-seed-entries.ts
@@ -1,0 +1,95 @@
+export type TaxonomySeedRow = {
+  portfolio: string;
+  portfolio_id: string;
+  level_1: string;
+  level_2: string;
+  level_3: string;
+  definition?: string;
+  notes?: string;
+  enrichment?: Record<string, unknown>;
+};
+
+export type TaxonomySeedPortfolio = {
+  id: string;
+  name: string;
+};
+
+export type TaxonomySeedNodeEntry = {
+  nodeId: string;
+  name: string;
+  parentNodeId: string | null;
+  portfolioId: string;
+  description: string | null;
+  enrichment: Record<string, unknown> | null;
+};
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
+}
+
+export function buildTaxonomyNodeEntries(
+  rows: TaxonomySeedRow[],
+  portfolios: TaxonomySeedPortfolio[],
+): TaxonomySeedNodeEntry[] {
+  const portfolioNameBySlug = new Map(portfolios.map((portfolio) => [portfolio.id, portfolio.name]));
+  const seen = new Set<string>();
+  const entries: TaxonomySeedNodeEntry[] = [];
+
+  for (const row of rows) {
+    const pid = row.portfolio_id;
+    if (!seen.has(pid)) {
+      seen.add(pid);
+      entries.push({
+        nodeId: pid,
+        name: portfolioNameBySlug.get(pid) ?? row.portfolio,
+        parentNodeId: null,
+        portfolioId: pid,
+        description: null,
+        enrichment: null,
+      });
+    }
+    if (!row.level_1) continue;
+    const l1id = `${pid}/${slugify(row.level_1)}`;
+    if (!seen.has(l1id)) {
+      seen.add(l1id);
+      const isL1Leaf = !row.level_2;
+      entries.push({
+        nodeId: l1id,
+        name: row.level_1,
+        parentNodeId: pid,
+        portfolioId: pid,
+        description: isL1Leaf ? (row.definition || null) : null,
+        enrichment: isL1Leaf && row.enrichment && Object.keys(row.enrichment).length > 0 ? row.enrichment : null,
+      });
+    }
+    if (!row.level_2) continue;
+    const l2id = `${l1id}/${slugify(row.level_2)}`;
+    if (!seen.has(l2id)) {
+      seen.add(l2id);
+      const isL2Leaf = !row.level_3;
+      entries.push({
+        nodeId: l2id,
+        name: row.level_2,
+        parentNodeId: l1id,
+        portfolioId: pid,
+        description: isL2Leaf ? (row.definition || null) : null,
+        enrichment: isL2Leaf && row.enrichment && Object.keys(row.enrichment).length > 0 ? row.enrichment : null,
+      });
+    }
+    if (!row.level_3) continue;
+    const l3id = `${l2id}/${slugify(row.level_3)}`;
+    if (!seen.has(l3id)) {
+      seen.add(l3id);
+      entries.push({
+        nodeId: l3id,
+        name: row.level_3,
+        parentNodeId: l2id,
+        portfolioId: pid,
+        description: row.definition || null,
+        enrichment: row.enrichment && Object.keys(row.enrichment).length > 0 ? row.enrichment : null,
+      });
+    }
+  }
+
+  return entries;
+}


### PR DESCRIPTION
## Summary
- Seed root `TaxonomyNode` display names from `portfolio_registry.json`, so `for_employees` renders as `Workforce` while keeping stable taxonomy paths.
- Extract the taxonomy seed-entry builder and add a regression test against the real registry/taxonomy fixtures.
- Document the seed invariant in the Business Operating Model portfolio wiring spec.

## Evidence
- Live DB read evidence before fix: `Portfolio.slug=for_employees` was `Workforce`, while `TaxonomyNode.nodeId=for_employees` was still `For Employees`.
- `pnpm --filter @dpf/db exec vitest run src/taxonomy-seed-entries.test.ts src/digital-product-registry.test.ts` passed: 2 files, 4 tests.
- `git diff --check` passed.

## Not Run
- Full package typecheck, production build, and local-CI sandbox gate were not run in this source-only worktree. The DPF MCP local-CI lease tools were not exposed in this Codex session, and I did not start another runtime.

Local-CI-Override: Focused seed regression tests passed; DPF MCP local-CI lease tools were unavailable in this Codex session, so broader sandbox gate is deferred to CI/self-upgrade validation.
