### PR TITLE
fix(routing): stop workbooks "use server" module from exporting the ActionResult type (500 on /ops + /employee)

### DIFF
--- a/apps/web/lib/actions/workbooks.ts
+++ b/apps/web/lib/actions/workbooks.ts
@@ -45,9 +45,14 @@ import { importRoster } from "@/lib/onboarding/roster-import-actions";
 import type { CellValue, ColumnDefinition, FieldType, FieldConfig, GridRow } from "@/lib/workbooks/types";
 import { ok, err, type ActionResult } from "@/lib/shared/action-result";
 
-// Re-exported for backwards compatibility with callers that imported the type
-// from this module before it was hoisted to the shared primitive.
-export type { ActionResult };
+// NOTE: do NOT `export type { ActionResult }` from this "use server" module.
+// Next/turbopack enumerates EVERY export of a "use server" file into the
+// runtime server-reference registry (ensureServerEntryExports /
+// registerServerReference); a type export therefore compiles to a reference to
+// an identifier that doesn't exist at runtime → `ReferenceError: ActionResult
+// is not defined` at module eval → 500 on every importing route (e.g. the
+// coworker conversation load on /ops and /employee, which pull in the Grid).
+// The type has no importers here; callers import it from @/lib/shared/action-result.
 
 async function requireUser(capability: "view_workbooks" | "manage_workbooks"): Promise<ServiceUser> {
   const session = await auth();


### PR DESCRIPTION
## Problem
The AI coworker 500s (\"Couldn't load this conversation\") on `/ops` and `/employee` — every route that imports the workbooks Grid. Server log: `ReferenceError: ActionResult is not defined` at module eval.

## Root cause — #2707 was incomplete
#2707 hoisted `ActionResult` to `@/lib/shared/action-result` but left a **re-export** in the `"use server"` module:
```ts
// apps/web/lib/actions/workbooks.ts
export type { ActionResult };
```
Next/turbopack enumerates **every** export of a `"use server"` file into the runtime server-reference registry (`ensureServerEntryExports([…, ActionResult])` + `registerServerReference(ActionResult, …)`). A type-only re-export therefore compiles to a reference to an identifier that is erased at runtime → `ReferenceError` at module eval → 500 on every importing route. **The build gate stays green** because it's a request-time module-eval failure, not a compile error — which is why it shipped in #2707 and survived a redeploy.

## Fix
Remove the dead re-export (zero importers — all callers import `ActionResult` from `@/lib/shared/action-result`), and leave a comment documenting the constraint. Verified against a fresh production image: **0 `ActionResult` tokens across all SSR chunks** (was 1 registering it), and the coworker conversation loads on `/ops` and `/employee` (previously 500).

## Follow-up
Three other `"use server"` files have the same latent dead-type-re-export pattern (`email-config.ts`, `workforce.ts`, `compliance.ts` — re-exporting `EmailConfigInput`/`EmailProviderSuggestion`/`EmployeeProfileInput`/`ComplianceActionResult`, all with zero importers). Filing a follow-up to remove those + add a lint rule banning non-async exports from `"use server"` files.

Verified live on :3000 (rebuilt image `621979be3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)