### PR TITLE
feat(deps): internalize nanoid behind an owned newId() façade (BET-14, BI-C0CEB377)

### DIFF
--- a/apps/web/app/api/storefront/admin/providers/route.ts
+++ b/apps/web/app/api/storefront/admin/providers/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 
 export async function GET() {
   const session = await auth();
@@ -43,7 +43,7 @@ export async function POST(req: NextRequest) {
 
   const provider = await prisma.serviceProvider.create({
     data: {
-      providerId: `SP-${nanoid(6).toUpperCase()}`,
+      providerId: `SP-${newId(6).toUpperCase()}`,
       storefrontId,
       name,
       email: email ?? null,

--- a/apps/web/app/api/storefront/admin/setup/route.ts
+++ b/apps/web/app/api/storefront/admin/setup/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@dpf/db";
 import { applyBusinessCapabilityPerspective } from "@dpf/db/business-capability-perspectives";
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { generateDesignSystem } from "@/lib/design-intelligence";
 import { seedBookingScheduleDefaults } from "@/lib/storefront/seed-booking-defaults";
 import {
@@ -88,7 +88,7 @@ export async function POST(req: NextRequest) {
             priceAmount?: number | null;
           }>
         ).map((t, i) => ({
-          itemId: `itm-${nanoid(8)}`,
+          itemId: `itm-${newId(8)}`,
           name: t.name,
           description: t.description ?? null,
           priceType: t.priceType,

--- a/apps/web/app/api/storefront/sign-up/route.ts
+++ b/apps/web/app/api/storefront/sign-up/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@dpf/db";
 import { hashPassword } from "@/lib/password";
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import {
   customerAccountNormalizedColumns,
   customerContactNormalizedColumns,
@@ -32,7 +32,7 @@ export async function POST(req: NextRequest) {
   const createdAccountId = await prisma.$transaction(async (tx) => {
     const account = await tx.customerAccount.create({
       data: {
-        accountId: `CA-${nanoid(10)}`,
+        accountId: `CA-${newId(10)}`,
         name: name ?? email,
         ...customerAccountNormalizedColumns({ name: name ?? email }),
         status: "prospect",

--- a/apps/web/lib/actions/ap.ts
+++ b/apps/web/lib/actions/ap.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { prisma } from "@dpf/db";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import { revalidatePath } from "next/cache";
@@ -24,7 +24,7 @@ async function requireManageFinance(): Promise<string> {
 export async function createSupplier(input: CreateSupplierInput) {
   await requireManageFinance();
 
-  const supplierId = `SUP-${nanoid(8)}`;
+  const supplierId = `SUP-${newId(8)}`;
 
   const supplier = await prisma.supplier.create({
     data: {
@@ -337,7 +337,7 @@ export async function submitBillForApproval(billId: string): Promise<void> {
   const baseUrl = resolveAppBaseUrl();
 
   for (const rule of rules) {
-    const token = nanoid(32);
+    const token = newId(32);
     await prisma.billApproval.create({
       data: {
         billId,

--- a/apps/web/lib/actions/assets.test.ts
+++ b/apps/web/lib/actions/assets.test.ts
@@ -8,8 +8,8 @@ vi.mock("@/lib/permissions", () => ({
   can: vi.fn(),
 }));
 
-vi.mock("nanoid", () => ({
-  nanoid: vi.fn().mockReturnValue("ABC12345"),
+vi.mock("@/lib/shared/new-id", () => ({
+  newId: vi.fn().mockReturnValue("ABC12345"),
 }));
 
 vi.mock("@dpf/db", () => ({

--- a/apps/web/lib/actions/assets.ts
+++ b/apps/web/lib/actions/assets.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { prisma } from "@dpf/db";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import type { CreateAssetInput, DisposeAssetInput } from "@/lib/asset-validation";
@@ -84,7 +84,7 @@ export async function calculateDepreciation(
 export async function createAsset(input: CreateAssetInput) {
   await requireManageFinance();
 
-  const assetId = `FA-${nanoid(8)}`;
+  const assetId = `FA-${newId(8)}`;
 
   const asset = await prisma.fixedAsset.create({
     data: {

--- a/apps/web/lib/actions/banking.ts
+++ b/apps/web/lib/actions/banking.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { prisma } from "@dpf/db";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import { revalidatePath } from "next/cache";
@@ -19,7 +19,7 @@ async function requireManageFinance(): Promise<string> {
 export async function createBankAccount(input: CreateBankAccountInput) {
   await requireManageFinance();
 
-  const bankAccountId = `BA-${nanoid(8)}`;
+  const bankAccountId = `BA-${newId(8)}`;
   const openingBalance = input.openingBalance ?? 0;
 
   const account = await prisma.bankAccount.create({
@@ -95,7 +95,7 @@ export async function importTransactions(
   await requireManageFinance();
 
   const parseResult = parseCSV(csvContent);
-  const batchId = nanoid(12);
+  const batchId = newId(12);
 
   // Load active bank rules for auto-categorization
   const rules = await prisma.bankRule.findMany({

--- a/apps/web/lib/actions/complaints.ts
+++ b/apps/web/lib/actions/complaints.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@dpf/db";
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { revalidatePath } from "next/cache";
 
 export type ComplaintSeverity = "low" | "medium" | "high" | "critical";
@@ -85,7 +85,7 @@ export async function createComplaint(input: {
 
   const created = await prisma.complaint.create({
     data: {
-      reference: `C-${nanoid(8).toUpperCase()}`,
+      reference: `C-${newId(8).toUpperCase()}`,
       customerName,
       description,
       severity,

--- a/apps/web/lib/actions/expenses.ts
+++ b/apps/web/lib/actions/expenses.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { prisma } from "@dpf/db";
 import { can } from "@/lib/permissions";
 import { requireCapability, requireUser } from "@/lib/actions/shared/guards";
@@ -159,7 +159,7 @@ export async function submitExpenseClaim(id: string): Promise<void> {
     throw new Error("Unauthorized");
   }
 
-  const approvalToken = nanoid(32);
+  const approvalToken = newId(32);
 
   // Find a user with manage_finance to be the approver (MVP: first match)
   const managers = await prisma.user.findMany({

--- a/apps/web/lib/actions/finance.ts
+++ b/apps/web/lib/actions/finance.ts
@@ -3,7 +3,7 @@
 import { prisma } from "@dpf/db";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import { revalidatePath } from "next/cache";
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { signInvoiceSchema } from "@/lib/finance-validation";
 import type { CreateInvoiceInput, RecordPaymentInput, SignInvoiceInput } from "@/lib/finance-validation";
 import type { INVOICE_STATUSES } from "@/lib/finance-validation";
@@ -380,7 +380,7 @@ export async function generateInvoiceFromStorefrontOrder(orderId: string) {
     const accountName = order.customerEmail.split("@")[0] ?? "Customer";
     const account = await prisma.customerAccount.create({
       data: {
-        accountId: `CA-${nanoid(8)}`,
+        accountId: `CA-${newId(8)}`,
         name: accountName,
         ...customerAccountNormalizedColumns({ name: accountName }),
         status: "prospect",
@@ -431,7 +431,7 @@ export async function sendInvoice(invoiceId: string): Promise<{ payToken: string
   });
   if (!invoice) throw new Error("Invoice not found");
 
-  const payToken = invoice.payToken ?? nanoid(32);
+  const payToken = invoice.payToken ?? newId(32);
 
   await prisma.invoice.update({
     where: { id: invoiceId },

--- a/apps/web/lib/actions/licensing-compliance.ts
+++ b/apps/web/lib/actions/licensing-compliance.ts
@@ -4,7 +4,7 @@ import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { revalidatePath } from "next/cache";
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 
 type ComplianceActionResult = { ok: boolean; message: string; id?: string };
 
@@ -164,23 +164,23 @@ function numberValue(value?: string | null) {
 }
 
 function organizationLicenseRecordId() {
-  return `LIC-ORG-${nanoid(8).toUpperCase()}`;
+  return `LIC-ORG-${newId(8).toUpperCase()}`;
 }
 
 function personLicenseRecordId() {
-  return `LIC-PER-${nanoid(8).toUpperCase()}`;
+  return `LIC-PER-${newId(8).toUpperCase()}`;
 }
 
 function displayObligationId() {
-  return `LIC-DIS-${nanoid(8).toUpperCase()}`;
+  return `LIC-DIS-${newId(8).toUpperCase()}`;
 }
 
 function feeScheduleId() {
-  return `LIC-FEE-${nanoid(8).toUpperCase()}`;
+  return `LIC-FEE-${newId(8).toUpperCase()}`;
 }
 
 function readinessIssueId() {
-  return `LIC-ISS-${nanoid(8).toUpperCase()}`;
+  return `LIC-ISS-${newId(8).toUpperCase()}`;
 }
 
 function revalidateLicensingRoutes() {

--- a/apps/web/lib/actions/recurring.test.ts
+++ b/apps/web/lib/actions/recurring.test.ts
@@ -97,7 +97,7 @@ describe("createRecurringSchedule", () => {
     expect(mockPrisma.recurringSchedule.create).toHaveBeenCalledOnce();
     const createCall = mockPrisma.recurringSchedule.create.mock.calls[0][0];
     expect(createCall.data.scheduleId).toMatch(/^REC-/);
-    expect(createCall.data.scheduleId.length).toBe(12); // REC- (4) + nanoid(8) (8)
+    expect(createCall.data.scheduleId.length).toBe(12); // REC- (4) + newId(8) (8)
   });
 
   it("calculates amount from line items including tax", async () => {

--- a/apps/web/lib/actions/recurring.ts
+++ b/apps/web/lib/actions/recurring.ts
@@ -3,7 +3,7 @@
 import { prisma } from "@dpf/db";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import { revalidatePath } from "next/cache";
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { createInvoice, sendInvoice } from "@/lib/actions/finance";
 import type { CreateRecurringScheduleInput } from "@/lib/recurring-validation";
 
@@ -26,7 +26,7 @@ export async function createRecurringSchedule(
 ): Promise<{ id: string; scheduleId: string }> {
   const userId = await requireManageFinance();
 
-  const scheduleId = `REC-${nanoid(8)}`;
+  const scheduleId = `REC-${newId(8)}`;
 
   // Calculate total amount from line items (qty * unitPrice * (1 + taxRate/100))
   const amount = input.lineItems.reduce((sum, item) => {

--- a/apps/web/lib/finance/ai-provider-finance.ts
+++ b/apps/web/lib/finance/ai-provider-finance.ts
@@ -1,4 +1,4 @@
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { prisma, type Prisma } from "@dpf/db";
 import {
   recordAiProviderSubscriptionPaymentSchema,
@@ -229,7 +229,7 @@ async function ensureSupplier(input: SeedAiProviderFinanceBridgeInput) {
 
   return prisma.supplier.create({
     data: {
-      supplierId: `SUP-${nanoid(8)}`,
+      supplierId: `SUP-${newId(8)}`,
       name: supplierName,
       paymentTerms: "Net 30",
       defaultCurrency: input.currency ?? "USD",
@@ -243,7 +243,7 @@ async function ensureSupplier(input: SeedAiProviderFinanceBridgeInput) {
 async function createFinanceWorkItem(input: CreateFinanceWorkItemInput) {
   return prisma.financeWorkItem.create({
     data: {
-      workItemId: `FWI-${nanoid(8)}`,
+      workItemId: `FWI-${newId(8)}`,
       profileId: input.profileId ?? null,
       contractId: input.contractId ?? null,
       supplierId: input.supplierId ?? null,
@@ -352,7 +352,7 @@ export async function seedAiProviderFinanceBridge(input: SeedAiProviderFinanceBr
 
   const contract = existingContract ?? sharedContract ?? (await prisma.supplierContract.create({
     data: {
-      contractId: `AIC-${nanoid(8)}`,
+      contractId: `AIC-${newId(8)}`,
       profileId: profile.id,
       supplierId: supplier.id,
       accountableEmployeeId: input.accountableEmployeeId ?? null,
@@ -429,7 +429,7 @@ export async function ensureFinanceCommitment(input: EnsureFinanceCommitmentInpu
     select: { id: true, supplierId: true },
   }) ?? await prisma.supplier.create({
     data: {
-      supplierId: `SUP-${nanoid(8)}`,
+      supplierId: `SUP-${newId(8)}`,
       name: input.supplierName,
       paymentTerms: "Net 30",
       defaultCurrency: input.currency ?? "USD",
@@ -447,7 +447,7 @@ export async function ensureFinanceCommitment(input: EnsureFinanceCommitmentInpu
   const contract = await prisma.supplierContract.upsert({
     where: { externalReference: input.externalReference },
     create: {
-      contractId: `FNC-${nanoid(8)}`,
+      contractId: `FNC-${newId(8)}`,
       profileId: input.profileId ?? null,
       supplierId: supplier.id,
       accountableEmployeeId: input.accountableEmployeeId ?? null,
@@ -551,7 +551,7 @@ export async function recordAiProviderSubscriptionPayment(input: RecordAiProvide
     select: { id: true, supplierId: true },
   }) ?? await prisma.supplier.create({
     data: {
-      supplierId: `SUP-${nanoid(8)}`,
+      supplierId: `SUP-${newId(8)}`,
       name: parsed.supplierName,
       paymentTerms: "Card on file",
       defaultCurrency: parsed.currency ?? "USD",
@@ -597,7 +597,7 @@ export async function recordAiProviderSubscriptionPayment(input: RecordAiProvide
   const contract = await prisma.supplierContract.upsert({
     where: { externalReference },
     create: {
-      contractId: `AIS-${nanoid(8)}`,
+      contractId: `AIS-${newId(8)}`,
       profileId: primaryProfile.id,
       supplierId: supplier.id,
       commitmentKind: "ai_provider",
@@ -673,7 +673,7 @@ export async function recordAiProviderSubscriptionPayment(input: RecordAiProvide
 
   const bill = existingBill ?? await prisma.bill.create({
     data: {
-      billRef: `BILL-${new Date().getUTCFullYear()}-${nanoid(6).toUpperCase()}`,
+      billRef: `BILL-${new Date().getUTCFullYear()}-${newId(6).toUpperCase()}`,
       supplierId: supplier.id,
       supplierContractId: contract.id,
       status: "paid",
@@ -1270,7 +1270,7 @@ export async function generateDraftBillForAiContract(input: {
   const totalAmount = Number(input.contract.monthlyCommittedAmount ?? 0);
   const bill = await prisma.bill.create({
     data: {
-      billRef: `BILL-${new Date().getUTCFullYear()}-${nanoid(6).toUpperCase()}`,
+      billRef: `BILL-${new Date().getUTCFullYear()}-${newId(6).toUpperCase()}`,
       supplierId: input.contract.supplierId,
       supplierContractId: input.contract.id,
       status: "draft",

--- a/apps/web/lib/finance/tax-remittance-core.ts
+++ b/apps/web/lib/finance/tax-remittance-core.ts
@@ -7,7 +7,7 @@
 // unit-testable on its own. Behavior-preserving relocation — identical bodies.
 
 import { createHash } from "crypto";
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 
 export const MANAGED_TAX_ISSUE_TYPES = new Set([
   "tax_setup_mode_unknown",
@@ -35,31 +35,31 @@ export function appendNote(existing: string | null, incoming?: string | null) {
 }
 
 export function registrationPublicId() {
-  return `TAX-REG-${nanoid(8).toUpperCase()}`;
+  return `TAX-REG-${newId(8).toUpperCase()}`;
 }
 
 export function issuePublicId() {
-  return `TAX-ISS-${nanoid(8).toUpperCase()}`;
+  return `TAX-ISS-${newId(8).toUpperCase()}`;
 }
 
 export function periodPublicId() {
-  return `TAX-PER-${nanoid(8).toUpperCase()}`;
+  return `TAX-PER-${newId(8).toUpperCase()}`;
 }
 
 export function taxMonitorTaskId() {
-  return `tax-monitor-${nanoid(8).toLowerCase()}`;
+  return `tax-monitor-${newId(8).toLowerCase()}`;
 }
 
 export function credentialPublicId() {
-  return `TAX-CRED-${nanoid(8).toUpperCase()}`;
+  return `TAX-CRED-${newId(8).toUpperCase()}`;
 }
 
 export function remittanceRunPublicId() {
-  return `TAX-RUN-${nanoid(8).toUpperCase()}`;
+  return `TAX-RUN-${newId(8).toUpperCase()}`;
 }
 
 export function taxExecutionTaskId() {
-  return `tax-run-${nanoid(8).toLowerCase()}`;
+  return `tax-run-${newId(8).toLowerCase()}`;
 }
 
 export function stableTaxEntityId(prefix: string, ...parts: Array<string | number | Date | null | undefined>) {

--- a/apps/web/lib/release/storefront-actions.test.ts
+++ b/apps/web/lib/release/storefront-actions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("nanoid", () => ({ nanoid: vi.fn(() => "TESTREF") }));
+vi.mock("@/lib/shared/new-id", () => ({ newId: vi.fn(() => "TESTREF") }));
 vi.mock("@/lib/actions/finance", () => ({
   generateInvoiceFromStorefrontOrder: vi.fn().mockResolvedValue(undefined),
 }));

--- a/apps/web/lib/release/storefront-actions.ts
+++ b/apps/web/lib/release/storefront-actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from "@dpf/db";
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { generateInvoiceFromStorefrontOrder } from "@/lib/actions/finance";
 import { isExclusionViolation } from "@/lib/db/exclusion-violation";
 
@@ -19,7 +19,7 @@ async function getPublishedStorefront(slug: string) {
 }
 
 function makeRef(prefix: string) {
-  return `${prefix}-${nanoid(8).toUpperCase()}`;
+  return `${prefix}-${newId(8).toUpperCase()}`;
 }
 
 type ActionResult =

--- a/apps/web/lib/shared/__snapshots__/index.test.ts.snap
+++ b/apps/web/lib/shared/__snapshots__/index.test.ts.snap
@@ -27,6 +27,7 @@ exports[`shared barrel export > exports all public symbols 1`] = `
   "isUnifiedCoworkerEnabled",
   "loadAllDocs",
   "loadDocPage",
+  "newId",
   "newestSignal",
   "ok",
   "parseCSV",

--- a/apps/web/lib/shared/index.ts
+++ b/apps/web/lib/shared/index.ts
@@ -2,6 +2,7 @@
 // Barrel export for the shared module.
 export * from "./action-result";
 export * from "./coerce";
+export * from "./new-id";
 export * from "./get-error-message";
 export * from "./slugify";
 export * from "./csv";

--- a/apps/web/lib/shared/new-id.test.ts
+++ b/apps/web/lib/shared/new-id.test.ts
@@ -1,0 +1,34 @@
+// apps/web/lib/shared/new-id.test.ts — EP-8DC217EB BET-14
+import { describe, it, expect } from "vitest";
+import { newId } from "./new-id";
+
+const ALPHABET =
+  "useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict";
+const ALPHABET_RE = new RegExp(
+  `^[${ALPHABET.replace(/[-\\]/g, "\\$&")}]+$`,
+);
+
+describe("newId", () => {
+  it("defaults to length 21 (nanoid's default)", () => {
+    expect(newId()).toHaveLength(21);
+  });
+
+  it("honours the requested size", () => {
+    for (const size of [1, 6, 8, 10, 12, 32, 64]) {
+      expect(newId(size)).toHaveLength(size);
+    }
+  });
+
+  it("emits only characters from the url-safe alphabet", () => {
+    for (let i = 0; i < 200; i++) {
+      expect(newId(32)).toMatch(ALPHABET_RE);
+    }
+  });
+
+  it("produces distinct ids across many calls", () => {
+    const seen = new Set<string>();
+    const n = 10_000;
+    for (let i = 0; i < n; i++) seen.add(newId());
+    expect(seen.size).toBe(n);
+  });
+});

--- a/apps/web/lib/shared/new-id.ts
+++ b/apps/web/lib/shared/new-id.ts
@@ -1,0 +1,30 @@
+// apps/web/lib/shared/new-id.ts
+//
+// Owned id generator over Node crypto — replaces the nanoid dependency
+// (EP-8DC217EB BET-14, kernel-approved own-newid-facade, HIGH, margin 3.115).
+// URL-safe, collision-resistant; matches nanoid's default alphabet semantics
+// closely enough for non-cryptographic unique ids (which is every call site).
+//
+// The ids are opaque unique strings, so exact byte-for-byte parity with nanoid
+// is not required. We deliberately keep nanoid's default 64-char url-safe
+// alphabet and its `byte & 63` mapping so the OUTPUT SHAPE (character set and
+// length) is unchanged — no downstream length/charset assumption can break.
+import { randomBytes } from "node:crypto";
+
+// nanoid's default 64-char url-safe alphabet.
+const ALPHABET =
+  "useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict";
+
+/**
+ * Generate a url-safe unique id of `size` characters (default 21, matching
+ * nanoid's default). Each character is drawn from a 64-symbol alphabet via
+ * `byte & 63`, so the distribution is uniform and no rejection loop is needed.
+ */
+export function newId(size = 21): string {
+  const bytes = randomBytes(size);
+  let id = "";
+  for (let i = 0; i < size; i++) {
+    id += ALPHABET[bytes[i] & 63];
+  }
+  return id;
+}

--- a/apps/web/lib/storefront/archetype-reset.test.ts
+++ b/apps/web/lib/storefront/archetype-reset.test.ts
@@ -14,8 +14,8 @@ vi.mock("@dpf/db", () => ({
   prisma: mockPrisma,
 }));
 
-vi.mock("nanoid", () => ({
-  nanoid: mockNanoid,
+vi.mock("@/lib/shared/new-id", () => ({
+  newId: mockNanoid,
 }));
 
 // The OVSM projection is covered by its own tests; mock it here so the reset

--- a/apps/web/lib/storefront/archetype-reset.ts
+++ b/apps/web/lib/storefront/archetype-reset.ts
@@ -1,6 +1,6 @@
 import { prisma, type Prisma } from "@dpf/db";
 import { applyBusinessCapabilityPerspective } from "@dpf/db/business-capability-perspectives";
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { projectOperationalValueStreamForArchetype } from "./project-operational-value-stream";
 import { seedBookingScheduleDefaults } from "./seed-booking-defaults";
 
@@ -209,7 +209,7 @@ export async function resetStorefrontArchetype(input: {
       const itemResult = await tx.storefrontItem.createMany({
         data: itemTemplates.map((item, index) => ({
           storefrontId: storefront.id,
-          itemId: `itm-${nanoid(8)}`,
+          itemId: `itm-${newId(8)}`,
           name: item.name,
           description: item.description ?? null,
           category: item.category ?? null,

--- a/apps/web/lib/storefront/seed-booking-defaults.test.ts
+++ b/apps/web/lib/storefront/seed-booking-defaults.test.ts
@@ -44,7 +44,7 @@ const { FIXTURE_ARCHETYPES } = vi.hoisted(() => ({
 vi.mock("@dpf/storefront-templates", () => ({ ALL_ARCHETYPES: FIXTURE_ARCHETYPES }));
 
 const mockNanoid = vi.hoisted(() => vi.fn());
-vi.mock("nanoid", () => ({ nanoid: mockNanoid }));
+vi.mock("@/lib/shared/new-id", () => ({ newId: mockNanoid }));
 
 import { seedBookingScheduleDefaults } from "./seed-booking-defaults";
 

--- a/apps/web/lib/storefront/seed-booking-defaults.ts
+++ b/apps/web/lib/storefront/seed-booking-defaults.ts
@@ -1,4 +1,4 @@
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
 
 /**
@@ -107,7 +107,7 @@ export async function seedBookingScheduleDefaults(
   if (providers.length === 0) {
     const provider = await db.serviceProvider.create({
       data: {
-        providerId: `SP-${nanoid(6).toUpperCase()}`,
+        providerId: `SP-${newId(6).toUpperCase()}`,
         storefrontId,
         name: providerName,
         isActive: true,

--- a/apps/web/lib/storefront/service-line-actions.ts
+++ b/apps/web/lib/storefront/service-line-actions.ts
@@ -3,7 +3,7 @@
 import { prisma } from "@dpf/db";
 import { auth } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
-import { nanoid } from "nanoid";
+import { newId } from "@/lib/shared/new-id";
 import { readActivationProfile, mergeActivationProfiles } from "@dpf/storefront-templates";
 
 const MAX_SECONDARY_LINES = 2;
@@ -103,7 +103,7 @@ export async function addStorefrontServiceLine(
   if (itemTemplates.length > 0) {
     await prisma.storefrontItem.createMany({
       data: itemTemplates.map((t, i) => ({
-        itemId: `itm-${nanoid(8)}`,
+        itemId: `itm-${newId(8)}`,
         storefrontId,
         name: t.name,
         description: t.description ?? null,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,7 +44,6 @@
     "libphonenumber-js": "^1.13.7",
     "lucide-react": "^1.21.0",
     "mammoth": "^1.12.0",
-    "nanoid": "^5.1.16",
     "next": "^16.2.9",
     "next-auth": "5.0.0-beta.31",
     "nodemailer": "^9.0.3",

--- a/docs/superpowers/specs/2026-07-09-nanoid-internalization-design.md
+++ b/docs/superpowers/specs/2026-07-09-nanoid-internalization-design.md
@@ -1,0 +1,84 @@
+# nanoid internalization — owned `newId()` façade over Node crypto
+
+- Epic: EP-8DC217EB (Vertical Integration Inward), BET-14
+- Backlog item: BI-C0CEB377
+- Date: 2026-07-09
+- Status: implemented
+
+## Kernel decision
+
+`principle_decide` selected **own-newid-facade** with **HIGH** confidence
+(composite 9.760, margin 3.115) over keeping the third-party `nanoid`
+dependency. The generator's job — mint short, url-safe, collision-resistant
+unique ids for business records — is squarely inside DPF's owned surface and
+needs no external package. Internalizing it removes a supply-chain edge for a
+handful of lines of code we can own outright.
+
+## Façade design
+
+`apps/web/lib/shared/new-id.ts` exports a single function:
+
+```ts
+export function newId(size = 21): string
+```
+
+- Backed by `randomBytes` from `node:crypto` — reads `size` random bytes.
+- Maps each byte to a character via `byte & 63` into **nanoid's exact default
+  64-character url-safe alphabet**
+  (`useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict`).
+- Default size 21 matches nanoid's default. `& 63` over a 64-symbol alphabet is
+  uniform, so no rejection loop is needed.
+
+Ids are opaque unique strings, so byte-for-byte parity with the old library is
+not required. We deliberately keep the same alphabet and length semantics so no
+downstream length/charset assumption can break — every migrated call site keeps
+its existing prefix and size argument unchanged (e.g. `` `FA-${newId(8)}` ``).
+
+Unit test `new-id.test.ts` asserts: default length 21; honoured custom sizes
+(1/6/8/10/12/32/64); only-alphabet characters over many draws; and distinctness
+across 10,000 calls. No wall-clock or `Math.random` pins — just the crypto call
+plus format/distinctness assertions.
+
+The façade is re-exported (extensionless) from the `lib/shared` barrel
+(`index.ts`); its barrel snapshot test was updated.
+
+## Codemod
+
+38 call sites across 17 files (`lib/actions`, `lib/storefront`, `lib/finance`,
+`lib/release`, `app/api/storefront`) migrated:
+
+- `import { nanoid } from "nanoid"` → `import { newId } from "@/lib/shared/new-id"`
+- `nanoid(n)` → `newId(n)`
+
+All call sites passed an explicit size (6/8/10/12/32); there were no arg-less
+calls and **no `customAlphabet` / custom-alphabet usage** (verified — the façade
+covers every call). No surrounding logic, prefix, or size argument was changed.
+Four test files that `vi.mock("nanoid", …)` were redirected to
+`vi.mock("@/lib/shared/new-id", …)` with the `newId` export key.
+
+## Dependency drop
+
+- `"nanoid"` removed from `apps/web/package.json` dependencies.
+- `nanoid` entry removed from `sbom/dependency-allowlist.json`.
+- Lockfile refreshed; `scripts/sbom/check-new-dependencies.mjs` reports OK
+  (nanoid no longer declared).
+
+## Ratchet
+
+`scripts/check-no-nanoid-import.mjs` (+ `.test.mjs`) bans any NEW
+`from "nanoid"` / `require("nanoid")` import across `apps/web`, `packages`, and
+`services`. The ALLOWLIST is **empty** — every site is migrated. It is
+auto-discovered by the `scripts/check-no-*.mjs` guard loop, so no `ci.yml` or
+`package.json` edit is needed. Copies the frozen-ALLOWLIST + CANONICAL-skip +
+self-test idiom from `check-no-local-isrecord.mjs`.
+
+## Remaining BET-14 own-candidate tail
+
+Other BET-14 internalization candidates each still need their **own** kernel
+decision before action — this decision only governs `nanoid`:
+
+- **dotenv → Node `--env-file`** — Node's native `--env-file` may replace the
+  `dotenv` package outright; needs a `principle_decide` on the flag-vs-package
+  trade-off and any `.env` parsing edge cases.
+- **picomatch** — glob-matching helper; evaluate whether an owned matcher or a
+  narrower built-in covers the usage before dropping it.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,9 +276,6 @@ importers:
       mammoth:
         specifier: ^1.12.0
         version: 1.12.0
-      nanoid:
-        specifier: ^5.1.16
-        version: 5.1.16
       next:
         specifier: ^16.2.9
         version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/sbom/dependency-allowlist.json
+++ b/sbom/dependency-allowlist.json
@@ -759,16 +759,6 @@
       ],
       "note": "bootstrap — pre-existing dependency, acknowledged in bulk"
     },
-    "nanoid": {
-      "added": "2026-06-21",
-      "workspaces": [
-        "apps/web"
-      ],
-      "kinds": [
-        "prod"
-      ],
-      "note": "bootstrap — pre-existing dependency, acknowledged in bulk"
-    },
     "nativewind": {
       "added": "2026-06-21",
       "workspaces": [

--- a/scripts/check-no-nanoid-import.mjs
+++ b/scripts/check-no-nanoid-import.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * BI-C0CEB377 (EP-8DC217EB BET-14) — CI ratchet: no NEW `nanoid` import.
+ *
+ * The `nanoid` dependency was internalized behind an owned façade over Node
+ * crypto (kernel-approved own-newid-facade, HIGH, margin 3.115):
+ *
+ *   import { newId } from "@/lib/shared/new-id";
+ *
+ * The dependency is dropped from apps/web/package.json. This guard freezes the
+ * import count at ZERO: every one of the 38 former call sites was migrated, so
+ * the ALLOWLIST is empty. Any NEW `from "nanoid"` (or `require("nanoid")`)
+ * import fails CI, so fresh code uses the owned generator instead of
+ * re-introducing the dropped dependency.
+ *
+ * Scope: apps/web, packages, services (source + tests). The owned façade in
+ * lib/shared/new-id.ts is the sanctioned home; it does not import nanoid so it
+ * is never flagged, but its own name mentions "nanoid" in comments — the
+ * matcher only inspects import/require SPECIFIERS, not comments, so it is safe.
+ *
+ * Run: node scripts/check-no-nanoid-import.mjs
+ */
+import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
+import { join, relative } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Roots to scan (relative to repo root). Missing roots are skipped.
+export const SCAN_ROOTS = ["apps/web", "packages", "services"];
+
+// Files that imported `nanoid` at the BI-C0CEB377 baseline. EMPTY: every site
+// was migrated to `@/lib/shared/new-id`. Do NOT add entries — new code must use
+// the owned newId() façade, never re-declare the dropped dependency.
+export const ALLOWLIST = new Set([]);
+
+// The sanctioned owned home — never flagged (it does not import nanoid).
+export const CANONICAL = "apps/web/lib/shared/new-id.ts";
+
+// An ES import or CJS require whose SPECIFIER is exactly `nanoid` (bare module).
+// Matches `from "nanoid"`, `from 'nanoid'`, `require("nanoid")`. Deliberately
+// does NOT match `nanoid/...` subpaths (none exist) or comment text.
+export const IMPORT_PATTERNS = [
+  /\bfrom\s+["']nanoid["']/,
+  /\brequire\(\s*["']nanoid["']\s*\)/,
+  /\bimport\(\s*["']nanoid["']\s*\)/,
+];
+
+function isCommentLine(line) {
+  const t = line.trim();
+  return t.startsWith("*") || t.startsWith("//") || t.startsWith("/*");
+}
+
+/** Return the 1-based line numbers + text of every nanoid import specifier. */
+export function findImportLines(body) {
+  const hits = [];
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (isCommentLine(line)) continue;
+    if (IMPORT_PATTERNS.some((p) => p.test(line))) {
+      hits.push({ line: i + 1, text: line.trim() });
+    }
+  }
+  return hits;
+}
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) {
+      if (
+        entry === "node_modules" ||
+        entry === ".next" ||
+        entry === "__snapshots__" ||
+        entry === "dist"
+      )
+        continue;
+      yield* walk(full);
+    } else if (s.isFile()) {
+      if (full.endsWith(".d.ts")) continue;
+      if (
+        !full.endsWith(".ts") &&
+        !full.endsWith(".tsx") &&
+        !full.endsWith(".js") &&
+        !full.endsWith(".jsx") &&
+        !full.endsWith(".mjs")
+      )
+        continue;
+      yield full;
+    }
+  }
+}
+
+/** Scan the SCAN_ROOTS under `root`; return imports outside the allowlist. */
+export function scanRepo(root = process.cwd()) {
+  const violations = [];
+  for (const scanRoot of SCAN_ROOTS) {
+    const dir = join(root, scanRoot);
+    if (!existsSync(dir)) continue;
+    for (const file of walk(dir)) {
+      const rel = relative(root, file).replace(/\\/g, "/");
+      if (rel === CANONICAL || ALLOWLIST.has(rel)) continue;
+      let body;
+      try {
+        body = readFileSync(file, "utf8");
+      } catch {
+        continue;
+      }
+      for (const h of findImportLines(body)) {
+        violations.push({ file: rel, ...h });
+      }
+    }
+  }
+  return violations;
+}
+
+/** Allowlisted files that no longer import nanoid — stale entries to prune. */
+export function findStaleAllowlist(root = process.cwd()) {
+  const stale = [];
+  for (const rel of ALLOWLIST) {
+    let body;
+    try {
+      body = readFileSync(join(root, rel), "utf8");
+    } catch {
+      stale.push(rel);
+      continue;
+    }
+    if (findImportLines(body).length === 0) stale.push(rel);
+  }
+  return stale;
+}
+
+function main() {
+  const violations = scanRepo();
+  const stale = findStaleAllowlist();
+
+  if (violations.length > 0) {
+    console.error("");
+    console.error("ERROR: BI-C0CEB377 — a NEW `nanoid` import was added.");
+    console.error("");
+    console.error("The nanoid dependency was internalized. Use the owned façade:");
+    console.error('  import { newId } from "@/lib/shared/new-id";');
+    console.error("");
+    console.error("Offending imports:");
+    for (const v of violations) console.error(`  ${v.file}:${v.line}  ${v.text}`);
+    console.error("");
+    process.exit(1);
+  }
+
+  if (stale.length > 0) {
+    console.error("");
+    console.error("ERROR: BI-C0CEB377 — the nanoid allowlist is stale.");
+    console.error("These files no longer import nanoid; prune them from ALLOWLIST");
+    console.error("in scripts/check-no-nanoid-import.mjs:");
+    for (const f of stale) console.error(`  ${f}`);
+    console.error("");
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ No nanoid imports (dependency internalized behind @/lib/shared/new-id; ${ALLOWLIST.size} allowlisted).`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-no-nanoid-import.test.mjs
+++ b/scripts/check-no-nanoid-import.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * BI-C0CEB377 — tests for the no-nanoid-import ratchet.
+ * Run: node --test scripts/check-no-nanoid-import.test.mjs
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ALLOWLIST,
+  CANONICAL,
+  findImportLines,
+  findStaleAllowlist,
+  scanRepo,
+} from "./check-no-nanoid-import.mjs";
+
+test("flags an ES import of nanoid", () => {
+  assert.equal(findImportLines('import { nanoid } from "nanoid";').length, 1);
+  assert.equal(findImportLines("import { nanoid } from 'nanoid';").length, 1);
+});
+
+test("flags a require / dynamic import of nanoid", () => {
+  assert.equal(findImportLines('const { nanoid } = require("nanoid");').length, 1);
+  assert.equal(findImportLines('const m = await import("nanoid");').length, 1);
+});
+
+test("does NOT flag the owned newId import", () => {
+  assert.equal(
+    findImportLines('import { newId } from "@/lib/shared/new-id";').length,
+    0,
+  );
+});
+
+test("does NOT flag a comment mentioning nanoid", () => {
+  assert.equal(findImportLines(" * replaces the nanoid dependency").length, 0);
+  assert.equal(findImportLines('// import { nanoid } from "nanoid";').length, 0);
+});
+
+test("does NOT flag a subpath specifier or unrelated module", () => {
+  assert.equal(findImportLines('import x from "nanoid-good";').length, 0);
+  assert.equal(findImportLines('import x from "@dpf/nanoid";').length, 0);
+});
+
+test("the live repo passes the guard — no nanoid imports remain", () => {
+  assert.deepEqual(scanRepo(), []);
+});
+
+test("the allowlist is empty (every site migrated) and not stale", () => {
+  assert.equal(ALLOWLIST.size, 0);
+  assert.deepEqual(findStaleAllowlist(), []);
+});
+
+test("the canonical owned home is not itself allowlisted", () => {
+  assert.equal(ALLOWLIST.has(CANONICAL), false);
+});


### PR DESCRIPTION
## What

EP-8DC217EB **BET-14** own-candidate (BI-C0CEB377), **kernel-approved** (`principle_decide`: own-newid-facade, HIGH confidence, composite 9.760, margin 3.115). Internalizes the `nanoid` dependency behind an owned `newId()` façade over Node crypto and **drops the dependency**.

- **`apps/web/lib/shared/new-id.ts`** (new) — `newId(size = 21)` over `node:crypto` `randomBytes`, using nanoid's exact default 64-char url-safe alphabet + `byte & 63` mapping, so output charset/length semantics are unchanged. Re-exported extensionless from the shared barrel (snapshot updated).
- **Codemod: 38 call sites / 17 files** (lib/actions, lib/storefront, lib/finance, lib/release, app/api/storefront) — `nanoid(n)`→`newId(n)`. No `customAlphabet` / custom-alphabet / other export existed anywhere (confirmed), so the façade covers 100% of usage. No id length/prefix/logic changed.
- **Dependency dropped:** removed from `apps/web/package.json` + `sbom/dependency-allowlist.json` (110 acknowledged, down from 111); lockfile refreshed. Remaining `nanoid` lockfile hits are transitive only.
- **Ratchet:** `scripts/check-no-nanoid-import.mjs` (+ self-test) bans any new `from "nanoid"` import; **empty allowlist**. Guard loop now at 14.
- Spec: `docs/superpowers/specs/2026-07-09-nanoid-internalization-design.md` (records the kernel decision + the remaining own-candidate tail: dotenv→`--env-file`, picomatch — each still needs its own kernel decision).

Four test files that `vi.mock`'d `"nanoid"` were re-pointed to mock `@/lib/shared/new-id`; `recurring.test.ts`'s `length === 12` assertion holds unchanged (real `newId(8)` yields exactly 8 chars).

## Verification

Substrate: source-local, worktree `bet14-nanoid` (off current origin/main):
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` → **exit 0**
- `pnpm --filter web exec vitest run` (full suite) → **1743 files passed, 0 failed** (incl. `new-id.test.ts`: default length, custom sizes, alphabet-only, uniqueness)
- `node scripts/sbom/check-new-dependencies.mjs` → **OK (110 acknowledged; nanoid no longer declared)**
- `node scripts/check-guards.mjs` → **14 guards** (incl. the nanoid ratchet self-test); module-size OK

## Local-CI-Override

Pre-push sandbox gate skipped (`DPF_SKIP_PREPUSH_GATE=1`, source-local worktree): full typecheck exit 0 + full vitest 0 failed + new-deps gate + guards green. CI is the canonical run.

> Authored by a build subagent; branch verified and reviewed by hand.

Process-Spine-Decision: EP-8DC217EB plan §4/§5 BET-14 — internalize nanoid behind an owned newId() façade (kernel-approved own-newid-facade, HIGH, margin 3.115); dep dropped, ratchet added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)