### PR TITLE
fix(build-studio): surface the WIP-cap message instead of a generic render crash

### DIFF
--- a/apps/web/components/admin/EmailSettingsPanel.tsx
+++ b/apps/web/components/admin/EmailSettingsPanel.tsx
@@ -6,8 +6,8 @@ import {
   saveEmailConfig,
   sendTestEmail,
   suggestEmailProvider,
-  type EmailProviderSuggestion,
 } from "@/lib/actions/email-config";
+import type { EmailProviderSuggestion } from "@/lib/shared/email-config-core";
 
 type Props = {
   status: {

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -543,7 +543,15 @@ export function BuildStudio({
     setCreateError(null);
     setCreating(true);
     try {
-      const { buildId } = await createFeatureBuild({ title });
+      const result = await createFeatureBuild({ title });
+      if (!result.ok) {
+        // Expected domain error (e.g. WIP cap reached) — the action returns it as
+        // a value so the plain-English message survives to here instead of being
+        // stripped to a generic production digest.
+        setCreateError(result.error);
+        return;
+      }
+      const { buildId } = result;
       setActiveBuild({
         id: "",
         buildId,

--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -254,6 +254,7 @@ describe("governed build start approvals", () => {
       description: "Keep portal-started development inside governed work.",
     });
 
+    if (!result.ok) throw new Error(`expected success, got: ${result.error}`);
     expect(result.buildId).toMatch(/^FB-[A-F0-9]{8}$/);
     expect(mockPrisma.workCapsule.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -298,6 +299,7 @@ describe("governed build start approvals", () => {
     process.on("unhandledRejection", onUnhandled);
     try {
       const result = await createFeatureBuild({ title: "Drain-safe build" });
+      if (!result.ok) throw new Error(`expected success, got: ${result.error}`);
       expect(result.buildId).toMatch(/^FB-[A-F0-9]{8}$/);
       // Flush microtasks + one macrotask so that, were the `.catch` missing, the
       // QuiescingError would surface as an unhandledRejection here before we
@@ -311,6 +313,24 @@ describe("governed build start approvals", () => {
     // The drain gate refuses the start before any DB write — the cost-tracking
     // upsert never runs.
     expect(mockPrisma.buildPhaseRun.upsert).not.toHaveBeenCalled();
+  });
+
+  it("createFeatureBuild RETURNS (not throws) the WIP-cap error so its message reaches the client", async () => {
+    // In production, a thrown Server-Action error has its message stripped to a
+    // generic digest, so the operator would never see "you already have 3 builds
+    // in progress" — they'd see a scary render error. Locking in the returned-value
+    // contract keeps the plain-English message intact across the RSC boundary.
+    mockPrisma.featureBuild.count.mockResolvedValue(3); // at the cap (BUILD_WIP_CAP)
+
+    const result = await createFeatureBuild({ title: "One build too many" });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected the WIP cap to reject the build");
+    expect(result.code).toBe("BUILD_WIP_CAP_REACHED");
+    expect(result.error).toContain("3 builds in progress");
+    // Rejected before any DB write — no build row, no work capsule.
+    expect(mockPrisma.featureBuild.create).not.toHaveBeenCalled();
+    expect(mockPrisma.workCapsule.create).not.toHaveBeenCalled();
   });
 
   it("updateFeatureBrief writes the legacy brief and backfills the BusinessBuildBrief contract", async () => {

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -64,22 +64,37 @@ function businessBriefJsonPayload(
 
 // ─── Create Feature Build ────────────────────────────────────────────────────
 
+// Discriminated result so EXPECTED domain errors (empty title, WIP cap) carry a
+// plain-English message all the way to the client. A thrown Error would have its
+// message stripped at the Server-Action boundary in production ("An error
+// occurred in the Server Components render … message omitted in production"),
+// so the operator would see a scary generic digest instead of "you already have
+// 3 builds in progress". Unexpected failures (DB errors) still throw.
+export type CreateFeatureBuildResult =
+  | { ok: true; buildId: string }
+  | { ok: false; error: string; code?: string };
+
 export async function createFeatureBuild(input: {
   title: string;
   description?: string;
   portfolioId?: string;
-}): Promise<{ buildId: string }> {
+}): Promise<CreateFeatureBuildResult> {
   const userId = await requireBuildAccess();
 
-  if (!input.title.trim()) throw new Error("Title is required");
+  if (!input.title.trim()) return { ok: false, error: "Title is required" };
 
   // WIP cap: don't let a new build start while too many are unfinished
-  // (all builds share one sandbox). Surfaces a plain-English message.
-  const { assertWipCapacity, TERMINAL_BUILD_PHASES } = await import("@/lib/build/wip-cap");
+  // (all builds share one sandbox). Returned (not thrown) so the plain-English
+  // message survives the Server-Action → client boundary in production.
+  const { wipCapReached, BUILD_WIP_CAP, BuildWipCapError, TERMINAL_BUILD_PHASES } =
+    await import("@/lib/build/wip-cap");
   const activeBuilds = await prisma.featureBuild.count({
     where: { phase: { notIn: [...TERMINAL_BUILD_PHASES] }, abandonedAt: null, parentEpicId: null },
   });
-  assertWipCapacity(activeBuilds);
+  if (wipCapReached(activeBuilds)) {
+    const err = new BuildWipCapError(activeBuilds, BUILD_WIP_CAP);
+    return { ok: false, error: err.message, code: err.code };
+  }
 
   const buildId = generateBuildId();
 
@@ -113,7 +128,7 @@ export async function createFeatureBuild(input: {
   const { startBuildPhaseRun } = await import("@/lib/integrate/build-phase-run");
   void startBuildPhaseRun(result.buildId, "ideate").catch(() => {});
 
-  return result;
+  return { ok: true, buildId: result.buildId };
 }
 
 export async function approveBuildStart(buildId: string): Promise<{ approvedAt: Date }> {

--- a/apps/web/lib/actions/email-config.ts
+++ b/apps/web/lib/actions/email-config.ts
@@ -11,11 +11,14 @@ import {
   type EmailProviderSuggestion,
 } from "@/lib/shared/email-config-core";
 
-// Re-export the input/result types for the settings panel + callers. The
-// auth-free logic lives in the server-only core (lib/shared/email-config-core);
-// this module is the "use server" surface that adds the operator-capability
-// guard so the client-callable actions can't bypass authorization.
-export type { EmailConfigInput, EmailProviderSuggestion };
+// NOTE: every export of a "use server" module must be an async function — the
+// server-action compiler collects ALL exports into ensureServerEntryExports([...])
+// as runtime values, so a re-exported *type* (erased at runtime) becomes a
+// `ReferenceError: X is not defined` that poisons the whole co-bundled actions
+// chunk. Callers import EmailConfigInput/EmailProviderSuggestion directly from
+// the server-only core (lib/shared/email-config-core) instead. The core holds
+// the auth-free logic; this module is the "use server" surface that adds the
+// operator-capability guard so the client-callable actions can't bypass authz.
 
 // Admin → Settings → Email. Same guard the adjacent platform-key / social-auth
 // panels use (manage_provider_connections) — SMTP is an outbound-email provider

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -19,8 +19,8 @@ apps/web/lib/actions/agent-coworker-external.test.ts	866
 apps/web/lib/actions/agent-coworker.ts	2712
 apps/web/lib/actions/agent-task-scheduler.test.ts	1083
 apps/web/lib/actions/ai-providers.ts	915
-apps/web/lib/actions/build-governed.test.ts	1114
-apps/web/lib/actions/build.ts	1770
+apps/web/lib/actions/build-governed.test.ts	1134
+apps/web/lib/actions/build.ts	1785
 apps/web/lib/actions/compliance.ts	1064
 apps/web/lib/actions/crm.ts	1423
 apps/web/lib/actions/ea.ts	1055


### PR DESCRIPTION
## What the operator hit

Submitting a new feature from Build Studio's **Start a new build** box errored out with the generic *"An error occurred in the Server Components render. The specific message is omitted in production builds…"* digest — no clue what went wrong.

## Root cause (from live `dpf-portal-1` logs)

The operator already had **3 builds in progress** (Working 2 + Parked 1), which is exactly the Build Studio WIP cap (`BUILD_WIP_CAP = 3`; all builds share one sandbox). `createFeatureBuild` **threw** `BuildWipCapError` — a helpful, plain-English error.

But **Next.js strips the message of any error thrown across the Server Action boundary in production**, replacing it with the generic "message omitted in production" digest. `BuildStudio.handleCreate`'s `catch` shows `err.message`, which was now that stripped placeholder. The operator never saw *"You already have 3 builds in progress."*

## Fix

**Commit 1 — `createFeatureBuild` returns expected errors instead of throwing.** Expected domain errors (empty title, WIP cap) are returned as a discriminated result (`{ ok: true; buildId } | { ok: false; error; code? }`). Returned values are never stripped, so the message survives to the client. Unexpected failures (DB errors) still throw → generic catch. Regression test locks in the returned-value contract at the cap.

**Commit 2 — latent SSR render crash found while investigating.** `lib/actions/email-config.ts` (a `"use server"` module) re-exported two **types** (`export type { EmailConfigInput, EmailProviderSuggestion }`). The server-action compiler collects *every* export into `ensureServerEntryExports([...])` as runtime values, so the erased type names threw `ReferenceError: EmailConfigInput is not defined` at module eval (digest `3736449589`) during SSR — poisoning the co-bundled root server chunk. Removed the type re-export; the one consumer (`EmailSettingsPanel`) now imports the type from the server-only core module directly.

## Verification

- `vitest run lib/actions/build-governed.test.ts` — 21 passed (incl. new WIP-cap regression test)
- `vitest run lib/build/wip-cap.test.ts` — 6 passed
- `tsc --noEmit` across `apps/web` — exit 0, 0 errors

Functional confirmation on the live portal requires a redeploy (the running :3000 image is the baked standalone build); CI gates are authoritative here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)