### PR TITLE
feat(observability): plain-language health alerts + coworker handoff + attention projection (BI-2F778C13)

### DIFF
--- a/apps/web/components/attention/AttentionInbox.tsx
+++ b/apps/web/components/attention/AttentionInbox.tsx
@@ -28,6 +28,7 @@ const SOURCE_LABEL: Record<AttentionSource, string> = {
   "compliance-submission": "Compliance",
   "research-proposal": "Research",
   "ai-readiness-blocker": "AI readiness",
+  "platform-health": "Platform health",
 };
 
 export function AttentionInbox({

--- a/apps/web/components/monitoring/AlertBanner.tsx
+++ b/apps/web/components/monitoring/AlertBanner.tsx
@@ -3,6 +3,11 @@
 import { useState } from "react";
 
 import { TONE_COLOR, getActiveAlerts } from "./health-summary";
+import {
+  HEALTH_COWORKER_ROUTE_CONTEXT,
+  buildHealthAlertCoworkerPrompt,
+  humanizeHealthAlert,
+} from "./alert-humanize";
 import { useAlertQuery } from "./useAlertQuery";
 
 type Props = {
@@ -31,7 +36,7 @@ export function AlertBanner({ className = "", suppressSummaries = [] }: Props) {
       {visibleAlerts.map((alert) => {
         const name = alert.labels.alertname ?? "Unknown";
         const severity = alert.labels.severity ?? "warning";
-        const summary = alert.annotations.summary ?? name;
+        const humanized = humanizeHealthAlert(alert);
         const isCritical = severity === "critical";
         const tone = isCritical ? "critical" : "warning";
         const color = TONE_COLOR[tone];
@@ -48,14 +53,32 @@ export function AlertBanner({ className = "", suppressSummaries = [] }: Props) {
           >
             <span>
               <span className="font-semibold uppercase mr-2">{severity}</span>
-              {summary}
+              <span className="font-medium">{humanized.title}</span>
+              <span className="opacity-80"> — {humanized.explanation}</span>
             </span>
-            <button
-              onClick={() => setDismissed((prev) => new Set(prev).add(name))}
-              className="ml-2 opacity-60 hover:opacity-100 transition-opacity"
-            >
-              Dismiss
-            </button>
+            <span className="ml-2 flex shrink-0 items-center gap-2">
+              <button
+                onClick={() =>
+                  document.dispatchEvent(
+                    new CustomEvent("open-agent-panel", {
+                      detail: {
+                        autoMessage: buildHealthAlertCoworkerPrompt([alert]),
+                        routeContext: HEALTH_COWORKER_ROUTE_CONTEXT,
+                      },
+                    }),
+                  )
+                }
+                className="font-medium underline-offset-2 hover:underline"
+              >
+                Ask coworker
+              </button>
+              <button
+                onClick={() => setDismissed((prev) => new Set(prev).add(name))}
+                className="opacity-60 hover:opacity-100 transition-opacity"
+              >
+                Dismiss
+              </button>
+            </span>
           </div>
         );
       })}

--- a/apps/web/components/monitoring/PlatformHealthIndicator.test.ts
+++ b/apps/web/components/monitoring/PlatformHealthIndicator.test.ts
@@ -8,4 +8,17 @@ describe("PlatformHealthIndicator", () => {
     expect(source).toContain("z-[90]");
     expect(source).not.toContain("mt-1 z-50 w-72");
   });
+
+  it("speaks plain language and offers the coworker handoff, not just raw alert names (BI-2F778C13)", () => {
+    const source = readFileSync(new URL("./PlatformHealthIndicator.tsx", import.meta.url), "utf8");
+
+    // Humanized title/explanation render instead of the bare alertname…
+    expect(source).toContain("humanizeHealthAlert");
+    expect(source).toContain("humanized.title");
+    expect(source).toContain("humanized.explanation");
+    // …and every alert list ends in an actionable coworker handoff.
+    expect(source).toContain("open-agent-panel");
+    expect(source).toContain("buildHealthAlertCoworkerPrompt");
+    expect(source).toContain("Ask coworker for help");
+  });
 });

--- a/apps/web/components/monitoring/PlatformHealthIndicator.tsx
+++ b/apps/web/components/monitoring/PlatformHealthIndicator.tsx
@@ -10,6 +10,11 @@ import {
   type MonitoringAlert,
   type Tone,
 } from "./health-summary";
+import {
+  HEALTH_COWORKER_ROUTE_CONTEXT,
+  buildHealthAlertCoworkerPrompt,
+  humanizeHealthAlert,
+} from "./alert-humanize";
 import { useAlertQuery } from "./useAlertQuery";
 
 type HealthState = "healthy" | "warning" | "critical" | "offline";
@@ -80,6 +85,7 @@ export function PlatformHealthIndicator() {
                 {alerts.map((alert, i) => {
                   const severity = alertDisplaySeverity(alert);
                   const tone = severity === "critical" ? "critical" : "warning";
+                  const humanized = humanizeHealthAlert(alert);
                   return (
                     <div
                       key={i}
@@ -93,16 +99,38 @@ export function PlatformHealthIndicator() {
                           {severity}
                         </span>
                         <span className="text-xs text-[var(--dpf-text)]">
-                          {alert.labels.alertname}
+                          {humanized.title}
                         </span>
                       </div>
                       <p className="text-[10px] text-[var(--dpf-muted)] mt-0.5">
-                        {alert.annotations.summary ?? ""}
+                        {humanized.explanation}
+                      </p>
+                      <p className="text-[9px] text-[var(--dpf-muted)] opacity-60 mt-0.5">
+                        {humanized.alertName}
                       </p>
                     </div>
                   );
                 })}
               </div>
+            )}
+
+            {alerts.length > 0 && (
+              <button
+                onClick={() => {
+                  document.dispatchEvent(
+                    new CustomEvent("open-agent-panel", {
+                      detail: {
+                        autoMessage: buildHealthAlertCoworkerPrompt(alerts),
+                        routeContext: HEALTH_COWORKER_ROUTE_CONTEXT,
+                      },
+                    }),
+                  );
+                  setOpen(false);
+                }}
+                className="block w-full text-left px-3 py-2 text-xs font-medium text-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)] border-t border-[var(--dpf-border)]"
+              >
+                Ask coworker for help
+              </button>
             )}
 
             <a

--- a/apps/web/components/monitoring/alert-humanize.test.ts
+++ b/apps/web/components/monitoring/alert-humanize.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildHealthAlertCoworkerPrompt,
+  friendlyServiceName,
+  humanizeHealthAlert,
+} from "./alert-humanize";
+import type { MonitoringAlert } from "./health-summary";
+
+function alert(
+  labels: Record<string, string>,
+  annotations: Record<string, string> = {},
+): MonitoringAlert {
+  return { labels, annotations, state: "firing", activeAt: "2026-07-10T18:00:00Z" };
+}
+
+describe("humanizeHealthAlert", () => {
+  it("translates ContainerDown on the sandbox into plain language", () => {
+    const h = humanizeHealthAlert(alert({ alertname: "ContainerDown", job: "sandbox", severity: "critical" }));
+    expect(h.title).toBe("Sandbox is offline");
+    expect(h.explanation).toContain("Builds");
+    expect(h.alertName).toBe("ContainerDown");
+    expect(h.serviceName).toBe("Sandbox");
+  });
+
+  it("translates VoiceServiceDown without needing a service label", () => {
+    const h = humanizeHealthAlert(alert({ alertname: "VoiceServiceDown", severity: "warning" }));
+    expect(h.title).toBe("Voice narration is unavailable");
+    expect(h.explanation).toContain("speech service");
+  });
+
+  it("falls back to a de-camel-cased title + summary for unknown alerts", () => {
+    const h = humanizeHealthAlert(
+      alert({ alertname: "SomeNewRule" }, { summary: "Something is odd" }),
+    );
+    expect(h.title).toBe("Some New Rule");
+    expect(h.explanation).toBe("Something is odd");
+  });
+
+  it("uses the generic impact line for ContainerDown on an unmapped job", () => {
+    const h = humanizeHealthAlert(alert({ alertname: "ContainerDown", job: "new-service" }));
+    expect(h.title).toBe("new-service is offline");
+    expect(h.explanation).toContain("won't work until it's back");
+  });
+});
+
+describe("friendlyServiceName", () => {
+  it("prefers the JOB_PRESENTATION friendly name", () => {
+    expect(friendlyServiceName({ job: "postgres" })).toBe("PostgreSQL");
+  });
+
+  it("falls back to the instance host when no job label exists", () => {
+    expect(friendlyServiceName({ instance: "sandbox:3000" })).toBe("sandbox");
+  });
+
+  it("returns null when nothing identifies a service", () => {
+    expect(friendlyServiceName({})).toBeNull();
+  });
+});
+
+describe("buildHealthAlertCoworkerPrompt", () => {
+  it("carries the raw alert facts so the user never transcribes jargon", () => {
+    const prompt = buildHealthAlertCoworkerPrompt([
+      alert(
+        { alertname: "ContainerDown", job: "sandbox", severity: "critical" },
+        { summary: "Service sandbox is down" },
+      ),
+      alert({ alertname: "VoiceServiceDown", severity: "warning" }),
+    ]);
+    expect(prompt).toContain("Sandbox is offline");
+    expect(prompt).toContain("alert: ContainerDown");
+    expect(prompt).toContain("service: Sandbox");
+    expect(prompt).toContain("Service sandbox is down");
+    expect(prompt).toContain("[critical]");
+    expect(prompt).toContain("Voice narration is unavailable");
+    expect(prompt).toContain("next step");
+  });
+});

--- a/apps/web/components/monitoring/alert-humanize.ts
+++ b/apps/web/components/monitoring/alert-humanize.ts
@@ -1,0 +1,230 @@
+// Plain-language translation of health alerts (BI-2F778C13).
+//
+// The Platform Health surfaces used to render raw Prometheus vocabulary —
+// "CRITICAL ContainerDown / Service sandbox is down" — at a business user who
+// cannot act on it. This module is the single dictionary that turns an alert
+// (alertname + labels) into a human title, a what-this-means line, and a
+// context-rich coworker prompt, so every surface (header dropdown, alert
+// banner, attention inbox) speaks the same plain language while keeping the
+// raw alert name available as small-print diagnostics.
+//
+// Pure module: no React, no client/server directives — imported by client
+// components AND the server-side attention source.
+
+import { JOB_PRESENTATION, type MonitoringAlert } from "./health-summary";
+
+export type HumanizedAlert = {
+  /** Plain-language headline, e.g. "Build sandbox is offline". */
+  title: string;
+  /** What this means for the user — the "so what" line. */
+  explanation: string;
+  /** Raw alertname kept for diagnostics small-print. */
+  alertName: string;
+  /** Friendly service name when the alert names one, else null. */
+  serviceName: string | null;
+};
+
+/** Friendly service name from the alert's job/service/instance labels. */
+export function friendlyServiceName(labels: Record<string, string | undefined>): string | null {
+  const job = labels.service || labels.job || null;
+  if (job && JOB_PRESENTATION[job]) return JOB_PRESENTATION[job].name;
+  if (job) return job;
+  const instance = labels.instance;
+  if (!instance) return null;
+  const colon = instance.indexOf(":");
+  return colon === -1 ? instance : instance.slice(0, colon);
+}
+
+// What breaks when a monitored service is down — keyed by scrape job.
+const SERVICE_DOWN_IMPACT: Record<string, string> = {
+  portal: "The web portal is not responding — most of the platform is unavailable.",
+  sandbox: "Builds and AI coworker development work can't run until it's back.",
+  postgres: "The platform database is unreachable — most features will fail.",
+  qdrant: "AI memory and semantic search lookups will fail.",
+  inngest: "Background jobs and scheduled coworker work are paused.",
+  redis: "Work queues and caching are unavailable.",
+  neo4j: "The knowledge graph is unavailable.",
+  adp: "Document processing is unavailable.",
+  "dev-portal": "The contributor preview (a contributor-only surface) is down.",
+  prometheus: "Health monitoring itself is down — alert data may be stale.",
+};
+
+const GENERIC_DOWN_IMPACT = "Features that depend on this service won't work until it's back.";
+
+type AlertTranslation = {
+  title: (serviceName: string | null, labels: Record<string, string | undefined>) => string;
+  explanation: (serviceName: string | null, labels: Record<string, string | undefined>) => string;
+};
+
+// One entry per alert rule in monitoring/prometheus/alerts.yml and
+// monitoring/loki/rules/dpf-log-alerts.yml. Unknown alert names fall back to
+// a de-camel-cased title + the rule's own summary annotation.
+const ALERT_TRANSLATIONS: Record<string, AlertTranslation> = {
+  ContainerDown: {
+    title: (s) => `${s ?? "A platform service"} is offline`,
+    explanation: (_s, labels) =>
+      SERVICE_DOWN_IMPACT[labels.service || labels.job || ""] ?? GENERIC_DOWN_IMPACT,
+  },
+  ContainerRestarting: {
+    title: (s) => `${s ?? "A platform service"} keeps restarting`,
+    explanation: () =>
+      "The service is crashing and coming back in a loop, so it can't be relied on right now.",
+  },
+  ContainerHighCPU: {
+    title: (s) => `${s ?? "A platform service"} is under heavy load`,
+    explanation: () => "The service is using most of its processing power — things may feel slow.",
+  },
+  ContainerHighMemory: {
+    title: (s) => `${s ?? "A platform service"} is running low on memory`,
+    explanation: () => "If it runs out, the service may crash and restart.",
+  },
+  HostHighCPU: {
+    title: () => "This computer is under heavy load",
+    explanation: () => "The machine running the platform is near its processing limit — everything may feel slow.",
+  },
+  HostHighMemory: {
+    title: () => "This computer is running low on memory",
+    explanation: () => "The machine running the platform is near its memory limit — services may become unstable.",
+  },
+  HostDiskPressure: {
+    title: () => "Disk space is getting low",
+    explanation: () => "The machine running the platform is filling up — free some space before it becomes a problem.",
+  },
+  HostDiskCritical: {
+    title: () => "Disk space is critically low",
+    explanation: () => "The platform can stop working when the disk fills completely — free up space now.",
+  },
+  HostNetworkInterfaceDown: {
+    title: () => "A network connection is down",
+    explanation: () => "The machine running the platform lost one of its network links.",
+  },
+  PostgresDown: {
+    title: () => "The platform database is down",
+    explanation: () => SERVICE_DOWN_IMPACT.postgres,
+  },
+  PostgresConnectionSaturation: {
+    title: () => "The database is nearly out of connections",
+    explanation: () => "If connections run out, pages and coworkers will start failing.",
+  },
+  QdrantDown: {
+    title: () => "AI memory search is down",
+    explanation: () => SERVICE_DOWN_IMPACT.qdrant,
+  },
+  Neo4jDown: {
+    title: () => "The knowledge graph is down",
+    explanation: () => SERVICE_DOWN_IMPACT.neo4j,
+  },
+  ModelRunnerDown: {
+    title: () => "Local AI is unavailable",
+    explanation: () => "The local AI engine isn't responding — AI features fall back to cloud providers or fail.",
+  },
+  SttDown: {
+    title: () => "Voice input is unavailable",
+    explanation: () => "The speech-to-text service isn't responding — dictation won't work.",
+  },
+  VoiceServiceDown: {
+    title: () => "Voice narration is unavailable",
+    explanation: () =>
+      "Voice narration is turned on, but its speech service isn't running — narration and voice previews won't play.",
+  },
+  ServiceFlapping: {
+    title: (s) => `${s ?? "A platform service"} is unstable`,
+    explanation: () => "It keeps switching between up and down, so it can't be relied on right now.",
+  },
+  AIInferenceHighLatency: {
+    title: () => "AI responses are slow",
+    explanation: () => "The AI engine is taking much longer than normal to answer.",
+  },
+  SemanticMemoryStoreFailures: {
+    title: () => "AI memory is failing to save",
+    explanation: () => "New knowledge isn't being stored — coworkers may forget recent context.",
+  },
+  UnhandledServerErrors: {
+    title: () => "The portal is hitting unexpected errors",
+    explanation: () => "Some pages or actions are failing with server errors.",
+  },
+  LogIngestionThrottled: {
+    title: () => "Diagnostic logging is falling behind",
+    explanation: () => "Log collection is throttled — troubleshooting data may be incomplete.",
+  },
+  ContainerErrorLogSpike: {
+    title: (s) => `${s ?? "A platform service"} is logging repeated errors`,
+    explanation: () => "Something inside the service is failing repeatedly — it may still work, but needs a look.",
+  },
+  ContainerErrorLogStorm: {
+    title: (s) => `${s ?? "A platform service"} is flooding with errors`,
+    explanation: () => "The service is failing hard and fast — expect broken features until it's fixed.",
+  },
+  WindowsHostHighCPU: {
+    title: () => "This computer is under heavy load",
+    explanation: () => "The machine running the platform is near its processing limit — everything may feel slow.",
+  },
+  WindowsHostHighMemory: {
+    title: () => "This computer is running low on memory",
+    explanation: () => "The machine running the platform is near its memory limit — services may become unstable.",
+  },
+  WindowsHostDiskPressure: {
+    title: () => "Disk space is getting low",
+    explanation: () => "The machine running the platform is filling up — free some space before it becomes a problem.",
+  },
+  WindowsHostDiskCritical: {
+    title: () => "Disk space is critically low",
+    explanation: () => "The platform can stop working when the disk fills completely — free up space now.",
+  },
+};
+
+/** "ContainerDown" → "Container Down" for alert names outside the dictionary. */
+function deCamel(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1 $2");
+}
+
+export function humanizeHealthAlert(alert: {
+  labels: Record<string, string | undefined>;
+  annotations?: Record<string, string | undefined>;
+}): HumanizedAlert {
+  const alertName = alert.labels.alertname ?? "Unknown alert";
+  const labels = alert.labels as Record<string, string>;
+  const serviceName = friendlyServiceName(alert.labels);
+  const translation = ALERT_TRANSLATIONS[alertName];
+  if (translation) {
+    return {
+      title: translation.title(serviceName, labels),
+      explanation: translation.explanation(serviceName, labels),
+      alertName,
+      serviceName,
+    };
+  }
+  return {
+    title: serviceName ? `${deCamel(alertName)}: ${serviceName}` : deCamel(alertName),
+    explanation: alert.annotations?.summary ?? "A platform health rule is firing.",
+    alertName,
+    serviceName,
+  };
+}
+
+/**
+ * Context-rich prompt for the coworker handoff (the `open-agent-panel`
+ * autoMessage). Carries the raw alert facts the coworker needs to diagnose —
+ * the human never has to transcribe jargon — and asks for a diagnosis plus a
+ * concrete next step, matching the admin-assistant's "check system health"
+ * skill surface.
+ */
+export function buildHealthAlertCoworkerPrompt(alerts: MonitoringAlert[]): string {
+  const lines = alerts.map((alert) => {
+    const humanized = humanizeHealthAlert(alert);
+    const severity = alert.labels.severity ?? "warning";
+    const since = alert.activeAt ? ` since ${alert.activeAt}` : "";
+    const summary = alert.annotations.summary ? ` — ${alert.annotations.summary}` : "";
+    return `- [${severity}] ${humanized.title} (alert: ${humanized.alertName}${
+      humanized.serviceName ? `, service: ${humanized.serviceName}` : ""
+    }${since})${summary}`;
+  });
+  return [
+    "I'm looking at the Platform Health warning and need help with these firing alerts:",
+    ...lines,
+    "Please diagnose what's actually wrong (check container status and recent logs where you can), explain the impact in plain language, and either fix it if you have a safe way to do so or give me the exact next step to resolve it.",
+  ].join("\n");
+}
+
+/** The routeContext for the coworker handoff — the System Admin owns platform health. */
+export const HEALTH_COWORKER_ROUTE_CONTEXT = "/admin";

--- a/apps/web/lib/attention/aggregate.ts
+++ b/apps/web/lib/attention/aggregate.ts
@@ -11,6 +11,7 @@ import { loadAiDecisionItems } from "./sources/ai-decision";
 import { loadPausedAiItems } from "./sources/paused-ai";
 import { loadScheduledTaskItems } from "./sources/scheduled-task";
 import { loadAgentProposalItems } from "./sources/agent-proposal";
+import { loadPlatformHealthItems } from "./sources/platform-health";
 import {
   loadOutboundItems,
   loadBillItems,
@@ -87,6 +88,7 @@ export async function loadAttentionItems(
     { source: "approval-expense", load: () => loadExpenseItems(db) },
     { source: "compliance-submission", load: () => loadRegulatoryItems(db) },
     { source: "research-proposal", load: () => loadResearchItems(db) },
+    { source: "platform-health", load: () => loadPlatformHealthItems(db) },
   ];
   if (opts.aiReadinessUserId) {
     loaders.push({

--- a/apps/web/lib/attention/sources/platform-health.test.ts
+++ b/apps/web/lib/attention/sources/platform-health.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { healthAlertToAttentionItem, type OpenHealthAlertIssue } from "./platform-health";
+
+describe("healthAlertToAttentionItem", () => {
+  const base: OpenHealthAlertIssue = {
+    issueKey: "health-alert-ContainerDown:sandbox",
+    severity: "error",
+    summary: "Service sandbox is down",
+    details: {
+      alertName: "ContainerDown",
+      labels: { alertname: "ContainerDown", job: "sandbox", severity: "critical" },
+      source: "prometheus",
+    },
+    firstDetectedAt: new Date("2026-07-07T09:00:00.000Z"),
+  };
+
+  it("projects a critical health alert in plain language, not Prometheus jargon", () => {
+    const item = healthAlertToAttentionItem(base);
+    expect(item.id).toBe("platform-health:health-alert-ContainerDown:sandbox");
+    expect(item.source).toBe("platform-health");
+    expect(item.title).toBe("Sandbox is offline");
+    expect(item.context).toContain("Builds");
+    expect(item.riskClass).toBe("high-risk");
+    expect(item.triage.residueReason).toBe("no-self-heal");
+    expect(item.triage.blastRadius).toBe("Sandbox");
+    expect(item.deepLink).toBe("/ops/health");
+    expect(item.createdAtIso).toBe("2026-07-07T09:00:00.000Z");
+    expect(item.audience.operator).toBe(true);
+  });
+
+  it("maps warn severity to bounded-write risk", () => {
+    const item = healthAlertToAttentionItem({
+      ...base,
+      issueKey: "health-alert-VoiceServiceDown",
+      severity: "warn",
+      summary: "Voice narration enabled but the TTS service is down",
+      details: {
+        alertName: "VoiceServiceDown",
+        labels: { alertname: "VoiceServiceDown", severity: "warning" },
+        source: "prometheus",
+      },
+    });
+    expect(item.riskClass).toBe("bounded-write");
+    expect(item.title).toBe("Voice narration is unavailable");
+  });
+
+  it("survives details rows without labels (falls back to the stored summary)", () => {
+    const item = healthAlertToAttentionItem({
+      ...base,
+      details: null,
+      summary: "Something is degraded",
+    });
+    expect(item.title).toBe("Unknown alert");
+    expect(item.context).toBe("Something is degraded");
+  });
+});

--- a/apps/web/lib/attention/sources/platform-health.ts
+++ b/apps/web/lib/attention/sources/platform-health.ts
@@ -1,0 +1,84 @@
+// Platform-health source (BI-2F778C13) — firing health alerts, projected from
+// the PortfolioQualityIssue inbox rows the alert-delivery-bridge cron already
+// maintains (issueType=health_alert, auto-resolved when the alert clears).
+//
+// This closes the "tell-don't-act" half of the proactivity gap: the blinking
+// header dot told the user "ContainerDown" and stopped. Projecting the same
+// rows into the attention read-model means the coworker's opening briefing
+// (BI-DED493BA) names the outage in plain language the moment the panel opens,
+// the Needs-you inbox lists it, and the deep link lands on System Health.
+// Read-only projection — the row's lifecycle stays owned by the bridge cron.
+
+import type { prisma } from "@dpf/db";
+import { humanizeHealthAlert } from "@/components/monitoring/alert-humanize";
+import type { AttentionItem } from "../types";
+
+type Db = typeof prisma;
+
+export type OpenHealthAlertIssue = {
+  issueKey: string;
+  severity: string;
+  summary: string;
+  details: unknown;
+  firstDetectedAt: Date;
+};
+
+function labelsFromDetails(details: unknown): Record<string, string> {
+  if (details && typeof details === "object" && "labels" in details) {
+    const labels = (details as { labels?: unknown }).labels;
+    if (labels && typeof labels === "object") {
+      return labels as Record<string, string>;
+    }
+  }
+  return {};
+}
+
+/** Pure projection of one open health-alert issue into an attention item. */
+export function healthAlertToAttentionItem(issue: OpenHealthAlertIssue): AttentionItem {
+  const labels = labelsFromDetails(issue.details);
+  const humanized = humanizeHealthAlert({
+    labels,
+    annotations: { summary: issue.summary },
+  });
+  return {
+    id: `platform-health:${issue.issueKey}`,
+    source: "platform-health",
+    title: humanized.title,
+    context: humanized.explanation,
+    decisionClass: { scorability: "unscorable" }, // an outage is a fact, not a scored call
+    riskClass: issue.severity === "error" ? "high-risk" : "bounded-write",
+    triage: {
+      timeToAct: "none", // ordered by risk → age, same as the other keystone sources
+      residueReason: "no-self-heal",
+      blastRadius: humanized.serviceName ?? undefined,
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: issue.firstDetectedAt.toISOString(),
+    actions: [
+      { kind: "open-in-context", label: "Open System Health", href: "/ops/health" },
+    ],
+    deepLink: "/ops/health",
+    audience: { operator: true },
+  };
+}
+
+/**
+ * Load open self-monitoring health alerts. Customer-scoped rows (MSP
+ * federation) are excluded — they route through the customer estate queue,
+ * not the operator's own platform-health attention.
+ */
+export async function loadPlatformHealthItems(db: Db): Promise<AttentionItem[]> {
+  const rows = await db.portfolioQualityIssue.findMany({
+    where: { issueType: "health_alert", status: "open", customerAccountId: null },
+    select: {
+      issueKey: true,
+      severity: true,
+      summary: true,
+      details: true,
+      firstDetectedAt: true,
+    },
+    orderBy: { firstDetectedAt: "asc" },
+  });
+  return rows.map(healthAlertToAttentionItem);
+}

--- a/apps/web/lib/attention/triage.ts
+++ b/apps/web/lib/attention/triage.ts
@@ -104,6 +104,7 @@ const RESIDUE_LABEL: Record<ResidueReason, string> = {
   "input-required": "a coworker needs your input to continue",
   "needs-credential": "a credential or authority is missing",
   "policy-approval": "an agent action is awaiting your approval",
+  "no-self-heal": "a platform service is degraded and cannot repair itself",
 };
 
 /** Human label for the residue reason — the honest "why it's here" line. Pure. */

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -20,7 +20,8 @@ export type AttentionSource =
   | "approval-expense" // ExpenseClaim submitted
   | "compliance-submission" // RegulatorySubmission draft (carries a dueDate)
   | "research-proposal" // ResearchProposal pending
-  | "ai-readiness-blocker"; // AI Readiness blocked domain requiring operator action
+  | "ai-readiness-blocker" // AI Readiness blocked domain requiring operator action
+  | "platform-health"; // PortfolioQualityIssue issueType=health_alert, status=open (BI-2F778C13)
 
 /** Risk vocabulary aligned with the paused-work plan (a2aMetadata.riskClass). */
 export type AttentionRiskClass = "read" | "bounded-write" | "high-risk" | "unknown";
@@ -39,7 +40,8 @@ export type ResidueReason =
   | "self-fix-exhausted" // Build Studio could not self-repair (escalation)
   | "input-required" // a coworker needs human input to continue (TaskRun)
   | "needs-credential" // missing credential / authority, NOT judgment (TaskRun auth-required)
-  | "policy-approval"; // an agent action awaits approval (AgentActionProposal)
+  | "policy-approval" // an agent action awaits approval (AgentActionProposal)
+  | "no-self-heal"; // a platform service is degraded and has no automated repair path (health_alert)
 
 /** How much the human must do. The human_cognitive_load cost axis. */
 export type DecideEffort = "one-tap" | "review" | "judgment";

--- a/docs/superpowers/plans/2026-07-10-health-alerts-actionable-plan.md
+++ b/docs/superpowers/plans/2026-07-10-health-alerts-actionable-plan.md
@@ -1,0 +1,89 @@
+# Platform Health alerts: tell → help (BI-2F778C13)
+
+**Date:** 2026-07-10 · **BI:** BI-2F778C13 · **Branch:** `feat/health-alerts-actionable`
+
+## Problem
+
+The blinking Platform Health indicator shows raw Prometheus vocabulary —
+"CRITICAL ContainerDown / Service sandbox is down" — to a business user, with no
+action beyond a link to a read-only dashboard. Founder dogfood (2026-07-10): the
+sandbox sat unhealthy for days with a diagnosable cause (health endpoint 500)
+while the user had no idea what to do and the AI coworker neither noticed nor
+helped. The gap generalizes: the detection substrate is mature (alert rules →
+`alert-delivery-bridge` cron → `PortfolioQualityIssue` `health_alert` rows →
+header dot + dashboards) but every consumer is tell-only.
+
+Session research established:
+
+- The `open-agent-panel` autoMessage handoff is live (Build Studio, admin issue
+  reports, finance) — **no health surface dispatches it**; the providers page
+  even renders unwired "Ask AI Coworker…" plain text.
+- The proactivity model already has `activityFamily: "platform-health"`
+  (degraded/offline → assertive, `escalationTarget: "platform-operator"`) —
+  never invoked from the alert path.
+- `admin-assistant` owns "platform health" with `admin_view_logs` /
+  `admin_query_db` / `admin_restart_service` skills.
+- The coworker opening briefing (BI-DED493BA) composes deterministically from
+  the attention read-model — so an attention source IS a proactive coworker
+  voice, with no LLM call and no fabrication risk.
+
+## Kernel decision
+
+`principle_decide` (external_coding_agent): `coworker-detector` 6.857 vs
+`full-slice` 6.783 — statistical tie (margin 0.074 < tieMargin 0.2), no
+commandment conflict; `one-click-remediation` (4.32) and `ui-handoff` alone
+(5.21) rejected. Tie broken by the founder's complaint naming both halves
+("little I can do from reading these" + "coworker is not being very helpful").
+**Chosen: full-slice, advise-first** — no new side-effect tools; governed
+remediation actuation is a deliberate follow-up.
+
+## Phases
+
+### Phase 1 — plain-language dictionary (shipped in this PR)
+
+`apps/web/components/monitoring/alert-humanize.ts`: pure module translating
+every alert rule in `monitoring/prometheus/alerts.yml` +
+`monitoring/loki/rules/dpf-log-alerts.yml` into a human title + "what this
+means" line (service impact keyed by scrape job, reusing `JOB_PRESENTATION`),
+with a de-camel-case fallback for unknown rules, plus
+`buildHealthAlertCoworkerPrompt` — the context-rich coworker handoff prompt.
+
+### Phase 2 — coworker handoff on the leakage surfaces (shipped in this PR)
+
+- `PlatformHealthIndicator.tsx`: humanized title/explanation per alert (raw
+  alertname kept as small-print diagnostics) + **"Ask coworker for help"**
+  dispatching `open-agent-panel` with the prompt and `routeContext: "/admin"`
+  (the System Admin owns platform health).
+- `AlertBanner.tsx`: humanized wording + per-alert **"Ask coworker"** beside
+  Dismiss (previously dismiss-only).
+
+### Phase 3 — proactive attention source (shipped in this PR)
+
+`apps/web/lib/attention/sources/platform-health.ts`: read-only projection of
+open self-monitoring `health_alert` `PortfolioQualityIssue` rows into
+`AttentionItem`s (`residueReason: "no-self-heal"`, severity → risk class,
+deep-link to System Health). Wired into `aggregate.ts`, so:
+
+- the coworker **opening briefing** names the outage the moment the panel
+  opens (BI-DED493BA composes from this read-model, gated by proactivity);
+- the Needs-you inbox lists it under a "Platform health" chip;
+- customer-scoped (MSP) rows stay in the customer estate queue.
+
+### Phase 4 — follow-ups (deliberately out of scope)
+
+- Governed remediation actuation: surface `recover_sandbox`-class actions
+  (today fenced inside Build Studio) as operator one-click + coworker act-mode
+  tools — needs its own grants/boundary decision (the voice self-heal was
+  deferred BY DESIGN for the same host-exec boundary, BI-264565A4).
+- Wire the unwired "Ask AI Coworker…" text on `/platform/ai/providers` and the
+  Loki-jargon `LogIssuesPanel` to the same handoff.
+- `notifyAttentionLive` push for newly-opened critical health alerts.
+
+## Verification
+
+- Unit: `alert-humanize.test.ts`, `platform-health.test.ts`, extended
+  `PlatformHealthIndicator.test.ts`; full `lib/attention` +
+  `components/monitoring` suites green (107 tests).
+- UX-fit: kernel-scored on `human_cognitive_load` (cost axis) — the change
+  removes jargon load and adds one justified control per surface, reusing the
+  existing panel mechanism (`UX-Fit-Decision` trailer on the PR).


### PR DESCRIPTION
## What

Closes the Platform Health "tell-don't-act" gap (BI-2F778C13). The blinking header dot showed raw Prometheus jargon — `CRITICAL ContainerDown / Service sandbox is down` — with no action beyond a read-only dashboard link, and the AI coworker neither noticed nor helped (founder dogfood, 2026-07-10, while the sandbox sat unhealthy for days with a diagnosable cause).

Three pieces, advise-first (no new side-effect tools):

1. **Plain language** — `apps/web/components/monitoring/alert-humanize.ts`: one dictionary translating every rule in `monitoring/prometheus/alerts.yml` + the Loki log rules into a human title + "what this means" line (service impact keyed by scrape job via `JOB_PRESENTATION`), with a de-camel-case fallback for unknown rules. Raw alertname stays as small-print diagnostics.
2. **Coworker handoff** — `PlatformHealthIndicator` dropdown gains **"Ask coworker for help"**, and `AlertBanner` (previously dismiss-only) gains per-alert **"Ask coworker"** — both dispatch the existing `open-agent-panel` event with a context-rich `autoMessage` (alert facts included, so the user never transcribes jargon) and `routeContext: /admin` (the System Admin persona owns platform health and holds the diagnostic tools).
3. **Proactive noticing** — `apps/web/lib/attention/sources/platform-health.ts`: open self-monitoring `health_alert` `PortfolioQualityIssue` rows (already maintained by the alert-delivery-bridge cron) projected into the attention read-model (`residueReason: no-self-heal`, severity → risk). The coworker opening briefing (BI-DED493BA) now names the outage in plain language the moment the panel opens, and the Needs-you inbox lists it under a "Platform health" chip. Customer-scoped (MSP) rows stay in the customer estate queue.

## Why this shape

Kernel-scored (`principle_decide`, external_coding_agent): `coworker-detector` 6.857 vs `full-slice` 6.783 — statistical tie (margin 0.074 < tieMargin 0.2, no commandment conflict); `one-click-remediation` (4.32) and `ui-handoff` alone (5.21) rejected. Tie broken by the founder complaint naming both halves ("little I can do from reading these" + "the coworker is not being very helpful").

Remediation **actuation** is deliberately deferred (plan Phase 4): `recover_sandbox` exists but is fenced inside the Build Studio lifecycle, and the voice self-heal was deferred by design for the same host-exec governance boundary (BI-264565A4).

Plan: `docs/superpowers/plans/2026-07-10-health-alerts-actionable-plan.md`

## Verification

- New: `alert-humanize.test.ts`, `platform-health.test.ts`; extended `PlatformHealthIndicator.test.ts` pins the humanized rendering + handoff.
- Full `lib/attention` + `components/attention` + `components/monitoring` suites green (107 tests).
- `web` typecheck green (local, 8 GB heap); module-size guard green.
- Live-data check: the two currently-firing alerts project as "Sandbox is offline — Builds and AI coworker development work can't run until it's back" and "Voice narration is unavailable — …".

UX-Fit-Decision: full-slice advise-first (principle_decide, human_cognitive_load cost axis — replaces jargon with plain language; one justified control per surface reusing the existing open-agent-panel mechanism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
