### PR TITLE
feat(compliance): scope obligations to the setup-chosen archetype (BI-9DED0CE8)

### DIFF
--- a/apps/web/app/(shell)/compliance/page.tsx
+++ b/apps/web/app/(shell)/compliance/page.tsx
@@ -1,10 +1,15 @@
 // apps/web/app/(shell)/compliance/page.tsx
 import { prisma } from "@dpf/db";
+import { resolveApplicableRegulationDbIds } from "@/lib/compliance-library";
 import { RegulatoryAlerts } from "@/components/compliance/RegulatoryAlerts";
 import { ScanStatus } from "@/components/compliance/ScanStatus";
 import { LocalTime } from "@/components/ui/LocalTime";
 
 export default async function CompliancePage() {
+  // Scope the dashboard to the regulations that APPLY to this install's
+  // setup-chosen archetype — the full seeded library (with its review /
+  // reference tri-state) lives on /compliance/regulations.
+  const applicableRegulationIds = await resolveApplicableRegulationDbIds();
   const [
     regulationCount,
     activeObligationCount,
@@ -20,14 +25,14 @@ export default async function CompliancePage() {
     pendingAlerts,
     latestScan,
   ] = await Promise.all([
-    prisma.regulation.count({ where: { status: "active" } }),
-    prisma.obligation.count({ where: { status: "active" } }),
+    prisma.regulation.count({ where: { status: "active", id: { in: applicableRegulationIds } } }),
+    prisma.obligation.count({ where: { status: "active", regulationId: { in: applicableRegulationIds } } }),
     prisma.control.count({ where: { implementationStatus: "implemented", status: "active" } }),
     prisma.control.count({ where: { status: "active" } }),
     prisma.complianceIncident.count({ where: { status: { in: ["open", "investigating"] } } }),
     prisma.correctiveAction.count({ where: { status: { in: ["open", "in-progress"] }, dueDate: { lt: new Date() } } }),
     prisma.regulation.findMany({
-      where: { status: "active" },
+      where: { status: "active", id: { in: applicableRegulationIds } },
       include: { _count: { select: { obligations: true } } },
       orderBy: { shortName: "asc" },
     }),
@@ -122,7 +127,10 @@ export default async function CompliancePage() {
       <section>
         <h2 className="text-xs text-[var(--dpf-muted)] uppercase tracking-widest mb-3">By Regulation</h2>
         {regulations.length === 0
-          ? <p className="text-sm text-[var(--dpf-muted)]">No regulations registered yet. Add your first regulation to get started.</p>
+          ? <p className="text-sm text-[var(--dpf-muted)]">
+              No regulations apply to this business yet. Review the full library on the{" "}
+              <a href="/compliance/regulations" className="text-[var(--dpf-accent)] hover:underline">Regulations</a> page.
+            </p>
           : <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               {regulations.map((r) => (
                 <a key={r.id} href={`/compliance/regulations/${r.id}`}

--- a/apps/web/lib/actions/reporting.test.ts
+++ b/apps/web/lib/actions/reporting.test.ts
@@ -7,6 +7,10 @@ vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 vi.mock("@dpf/db", () => ({
   prisma: {
     regulation: { findMany: vi.fn(), count: vi.fn() },
+    // Applicability scoping (resolveApplicableRegulationDbIds) resolves the
+    // install context before the gap assessment queries run.
+    storefrontConfig: { findFirst: vi.fn() },
+    businessContext: { findFirst: vi.fn() },
     obligation: { count: vi.fn() },
     control: { count: vi.fn() },
     complianceIncident: { count: vi.fn() },
@@ -35,6 +39,8 @@ beforeEach(() => {
   vi.mocked(can).mockReturnValue(true);
   vi.mocked(prisma.employeeProfile.findUnique).mockResolvedValue({ id: "emp-1" } as never);
   vi.mocked(prisma.complianceAuditLog.create).mockResolvedValue({} as never);
+  vi.mocked(prisma.storefrontConfig.findFirst).mockResolvedValue(null as never);
+  vi.mocked(prisma.businessContext.findFirst).mockResolvedValue(null as never);
 });
 
 describe("takeComplianceSnapshot", () => {

--- a/apps/web/lib/actions/reporting.ts
+++ b/apps/web/lib/actions/reporting.ts
@@ -12,14 +12,18 @@ import {
   isValidSubmissionTransition,
   type RegulationGapSummary, type ObligationGap, type ObligationGapStatus,
 } from "@/lib/reporting-types";
+import { resolveApplicableRegulationDbIds } from "@/lib/compliance-library";
 
 // ─── Gap Assessment ─────────────────────────────────────────────────────────
 
 export async function getGapAssessment(): Promise<RegulationGapSummary[]> {
   await requireViewCompliance();
 
+  // Assess only the regulations that APPLY to this install's archetype —
+  // scoring an out-of-scope regulation is noise (regulation-applicability.ts).
+  const applicableRegulationIds = await resolveApplicableRegulationDbIds();
   const regulations = await prisma.regulation.findMany({
-    where: { status: "active" },
+    where: { status: "active", id: { in: applicableRegulationIds } },
     include: {
       obligations: {
         where: { status: "active" },

--- a/apps/web/lib/compliance-library.test.ts
+++ b/apps/web/lib/compliance-library.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   addObligationApplicability,
   addRegulationApplicability,
+  applicableRegulationDbIds,
   classifyRegulationForInstall,
   complianceLibraryContextLabel,
   countByComplianceLibraryScope,
@@ -240,5 +241,93 @@ describe("compliance library applicability", () => {
       expect(classifyRegulationForInstall(legacyBanking, bankingContext).scope).toBe("applies");
       expect(classifyRegulationForInstall(legacyBanking, softwareContext).scope).toBe("reference");
     });
+  });
+
+  describe("archetype-id-gated pack specs (BI-9DED0CE8)", () => {
+    const creditUnionContext: ComplianceLibraryContext = {
+      ...bankingContext,
+      archetype: {
+        archetypeId: "credit-union",
+        name: "Credit Union",
+        category: "banking-financial-services",
+      },
+      regional: {
+        ...bankingContext.regional,
+        archetype: "banking-financial-services",
+        archetypeId: "credit-union",
+        operatesIn: ["us"],
+      },
+    };
+    const ncua = regulation({
+      regulationId: "REG-US-NCUA",
+      shortName: "NCUA",
+      applicability: { basis: ["operating"], jurisdictions: ["us"], archetypes: ["credit-union"] },
+    });
+
+    it("an id-scoped regime applies to the matching archetype id", () => {
+      expect(classifyRegulationForInstall(ncua, creditUnionContext).scope).toBe("applies");
+    });
+
+    it("an id-scoped regime is reference for a sibling archetype in the same category", () => {
+      const communityBankContext: ComplianceLibraryContext = {
+        ...creditUnionContext,
+        regional: { ...creditUnionContext.regional, archetypeId: "community-bank" },
+      };
+      expect(classifyRegulationForInstall(ncua, communityBankContext).scope).toBe("reference");
+    });
+
+    it("a pack spec is reference for an unrelated archetype (the noise case)", () => {
+      const hvacContext: ComplianceLibraryContext = {
+        ...softwareContext,
+        archetype: {
+          archetypeId: "hvac-contractor",
+          name: "HVAC Contractor",
+          category: "trades-maintenance",
+        },
+        regional: {
+          ...softwareContext.regional,
+          archetype: "trades-maintenance",
+          archetypeId: "hvac-contractor",
+          operatesIn: ["us"],
+        },
+      };
+      expect(classifyRegulationForInstall(ncua, hvacContext).scope).toBe("reference");
+    });
+  });
+});
+
+describe("applicableRegulationDbIds — the applies-scope filter for aggregating surfaces", () => {
+  const creditUnionContext: ComplianceLibraryContext = {
+    ...bankingContext,
+    regional: {
+      ...bankingContext.regional,
+      archetypeId: "credit-union",
+      operatesIn: ["us"],
+    },
+  };
+
+  it("returns only the DB ids of regulations that apply to the install", () => {
+    const rows = [
+      {
+        ...regulation({
+          regulationId: "REG-US-NCUA",
+          applicability: { basis: ["operating"], jurisdictions: ["us"], archetypes: ["credit-union"] },
+        }),
+        id: "db-ncua",
+      },
+      {
+        ...regulation({
+          regulationId: "REG-US-STATE-POST",
+          industry: "public-safety",
+          applicability: {
+            basis: ["operating"],
+            jurisdictions: ["us"],
+            archetypes: ["law-enforcement-agency"],
+          },
+        }),
+        id: "db-post",
+      },
+    ];
+    expect(applicableRegulationDbIds(rows, creditUnionContext)).toEqual(["db-ncua"]);
   });
 });

--- a/apps/web/lib/compliance-library.ts
+++ b/apps/web/lib/compliance-library.ts
@@ -337,6 +337,69 @@ export function complianceLibraryContextLabel(context: ComplianceLibraryContext)
   return category && label !== category ? `${label} (${category})` : label;
 }
 
+export type ApplicableRegulationRow = ClassifiableRegulation & { id: string };
+
+/** Pure core: the DB ids (Regulation.id) of regulations classified "applies" for this install. */
+export function applicableRegulationDbIds(
+  regulations: ApplicableRegulationRow[],
+  context: ComplianceLibraryContext,
+): string[] {
+  return regulations
+    .filter((reg) => classifyRegulationForInstall(reg, context).scope === "applies")
+    .map((reg) => reg.id);
+}
+
+export type ApplicableRegulationClient = ComplianceLibraryClient & {
+  regulation: {
+    findMany(args: {
+      where: { status: "active" };
+      select: {
+        id: true;
+        regulationId: true;
+        name: true;
+        shortName: true;
+        jurisdiction: true;
+        industry: true;
+        sourceType: true;
+        sourceUrl: true;
+        applicability: true;
+      };
+    }): Promise<(ApplicableRegulationRow & { applicability: unknown })[]>;
+  };
+};
+
+/**
+ * DB ids of the regulations that currently APPLY to this install — the same
+ * classification the compliance library pages use (data-driven applicability
+ * spec when present, legacy industry heuristics otherwise), resolved from the
+ * setup-chosen archetype + business context. Non-library surfaces that
+ * aggregate obligations (dashboard counts, workspace command center, workforce
+ * calendar, gap assessment) filter on this so wholesale-seeded packs outside
+ * the installed archetype don't surface as obligation noise.
+ */
+export async function resolveApplicableRegulationDbIds(
+  db: ApplicableRegulationClient = prisma,
+): Promise<string[]> {
+  const [context, regulations] = await Promise.all([
+    resolveComplianceLibraryContext(db),
+    db.regulation.findMany({
+      where: { status: "active" },
+      select: {
+        id: true,
+        regulationId: true,
+        name: true,
+        shortName: true,
+        jurisdiction: true,
+        industry: true,
+        sourceType: true,
+        sourceUrl: true,
+        applicability: true,
+      },
+    }),
+  ]);
+  return applicableRegulationDbIds(regulations, context);
+}
+
 export async function resolveComplianceLibraryContext(
   db: ComplianceLibraryClient = prisma,
 ): Promise<ComplianceLibraryContext> {
@@ -369,6 +432,7 @@ export async function resolveComplianceLibraryContext(
     },
     regional: {
       archetype: storefront?.archetype?.category ?? undefined,
+      archetypeId: storefront?.archetype?.archetypeId ?? undefined,
       operatesIn: businessContext?.operatesIn ?? [],
       sellsTo: businessContext?.sellsTo ?? [],
       employsIn: businessContext?.employsIn ?? [],

--- a/apps/web/lib/workforce/calendar-data.ts
+++ b/apps/web/lib/workforce/calendar-data.ts
@@ -4,6 +4,7 @@
 import { cache } from "react";
 import { prisma } from "@dpf/db";
 import type { WeeklySchedule, DaySchedule } from "@/lib/operating-hours-types";
+import { resolveApplicableRegulationDbIds } from "@/lib/compliance-library";
 import { buildWorkbookEvents, type WorkbookEventInput } from "./workbook-calendar-events";
 
 // ─── Unified Event Type ─────────────────────────────────────────────────────
@@ -205,6 +206,11 @@ async function projectLifecycleEvents(rangeStart: Date, rangeEnd: Date): Promise
 async function projectComplianceEvents(rangeStart: Date, rangeEnd: Date): Promise<CalendarEventView[]> {
   const events: CalendarEventView[] = [];
 
+  // Only obligations from regulations that APPLY to this install's archetype
+  // project review deadlines onto the calendar — the wholesale-seeded packs
+  // outside the archetype would otherwise flood it.
+  const applicableRegulationIds = await resolveApplicableRegulationDbIds();
+
   const [incidents, actions, findings, audits, obligations, submissions] = await Promise.all([
     prisma.complianceIncident.findMany({
       where: {
@@ -237,6 +243,7 @@ async function projectComplianceEvents(rangeStart: Date, rangeEnd: Date): Promis
     prisma.obligation.findMany({
       where: {
         status: "active",
+        regulationId: { in: applicableRegulationIds },
         reviewDate: { gte: rangeStart, lte: rangeEnd },
       },
       select: { id: true, obligationId: true, title: true, reviewDate: true },

--- a/apps/web/lib/workspace/command-center.ts
+++ b/apps/web/lib/workspace/command-center.ts
@@ -1,5 +1,6 @@
 import type { prisma as defaultPrisma } from "@dpf/db";
 import type { TileStatus } from "@/components/shell/WorkspaceTiles";
+import { resolveApplicableRegulationDbIds } from "@/lib/compliance-library";
 
 export type SixCKey =
   | "context"
@@ -290,6 +291,10 @@ export async function loadWorkspaceCommandCenter(
 ): Promise<WorkspaceCommandCenterSummary> {
   const now = new Date();
   const recentSince = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  // Governance readiness counts only the obligations that APPLY to this
+  // install's archetype — the wholesale-seeded library would otherwise read
+  // as noise on the workspace tiles.
+  const applicableRegulationIds = await resolveApplicableRegulationDbIds(prismaClient);
 
   const [
     activeProductCount,
@@ -350,7 +355,9 @@ export async function loadWorkspaceCommandCenter(
     prismaClient.eaView.count(),
     prismaClient.featureBuild.count(),
     prismaClient.document.count(),
-    prismaClient.obligation.count({ where: { status: "active" } }),
+    prismaClient.obligation.count({
+      where: { status: "active", regulationId: { in: applicableRegulationIds } },
+    }),
     prismaClient.complianceIncident.count({ where: { status: { in: ["open", "investigating"] } } }),
     prismaClient.control.count({ where: { implementationStatus: "implemented", status: "active" } }),
     prismaClient.control.count({ where: { status: "active" } }),

--- a/packages/db/prisma/migrations/20260710150000_backfill_pack_regulation_applicability/migration.sql
+++ b/packages/db/prisma/migrations/20260710150000_backfill_pack_regulation_applicability/migration.sql
@@ -1,0 +1,57 @@
+-- Data-only backfill: archetype-scoped applicability for the wholesale-seeded
+-- industry compliance packs (BI-9DED0CE8).
+--
+-- The banking / public-sector / law-enforcement / cooperative packs seed into
+-- every install but carried no structured applicability spec, so they fell back
+-- to the legacy industry string matcher and every install saw all packs as
+-- potential obligations (noise). The pack seeds now carry data-driven specs;
+-- on an EXISTING install the already-seeded rows would sit with
+-- applicability = NULL between deploy and the next seed run. Backfill them here
+-- so archetype-scoped classification is in effect the instant this migration
+-- applies — independent of seed timing (same pattern as
+-- 20260703170000_backfill_regulation_applicability).
+--
+-- Guarded on IS NULL: a later seed upsert or an operator edit stays
+-- authoritative, and this is a no-op on a fresh install (rows are seeded after
+-- migrations, so 0 rows match here and the seed populates the spec).
+
+-- Banking pack: BSA/AML binds the whole banking-financial-services category;
+-- NCUA binds only a credit union; FDIC/CRA binds only a community bank.
+UPDATE "Regulation"
+   SET "applicability" = '{"basis":["operating"],"jurisdictions":["us"],"archetypes":["banking-financial-services"]}'::jsonb
+ WHERE "regulationId" = 'REG-US-BSA-AML' AND "applicability" IS NULL;
+
+UPDATE "Regulation"
+   SET "applicability" = '{"basis":["operating"],"jurisdictions":["us"],"archetypes":["credit-union"]}'::jsonb
+ WHERE "regulationId" = 'REG-US-NCUA' AND "applicability" IS NULL;
+
+UPDATE "Regulation"
+   SET "applicability" = '{"basis":["operating"],"jurisdictions":["us"],"archetypes":["community-bank"]}'::jsonb
+ WHERE "regulationId" = 'REG-US-FDIC-CRA' AND "applicability" IS NULL;
+
+-- Public-sector pack: open-meetings / public-records bind every public body
+-- (category); municipal finance and the EPA water regimes bind only the
+-- archetypes that run a municipality or a water/wastewater system.
+UPDATE "Regulation"
+   SET "applicability" = '{"basis":["operating"],"jurisdictions":["us"],"archetypes":["public-sector"]}'::jsonb
+ WHERE "regulationId" IN ('REG-US-STATE-OPEN-MEETINGS', 'REG-US-STATE-PUBLIC-RECORDS')
+   AND "applicability" IS NULL;
+
+UPDATE "Regulation"
+   SET "applicability" = '{"basis":["operating"],"jurisdictions":["us"],"archetypes":["small-town-municipality","municipal-utility"]}'::jsonb
+ WHERE "regulationId" IN ('REG-US-STATE-MUNI-FINANCE', 'REG-US-EPA-SDWA', 'REG-US-EPA-NPDES')
+   AND "applicability" IS NULL;
+
+-- Law-enforcement pack: binds only the law-enforcement-agency archetype id
+-- (its category is public-sector, so the public-body pack also applies to it).
+UPDATE "Regulation"
+   SET "applicability" = '{"basis":["operating"],"jurisdictions":["us"],"archetypes":["law-enforcement-agency"]}'::jsonb
+ WHERE "regulationId" IN ('REG-US-STATE-POST', 'REG-US-LE-POLICY-ATTESTATION', 'REG-US-CJIS-READINESS')
+   AND "applicability" IS NULL;
+
+-- Cooperative pack: binds the cooperative archetype ids; credit unions are NOT
+-- in scope (exempt from Subchapter T — they answer to the NCUA regime).
+UPDATE "Regulation"
+   SET "applicability" = '{"basis":["operating"],"jurisdictions":["us"],"archetypes":["cooperative","agricultural-cooperative"]}'::jsonb
+ WHERE "regulationId" IN ('REG-US-IRS-SUBCHAPTER-T', 'REG-US-COOP-GOVERNANCE')
+   AND "applicability" IS NULL;

--- a/packages/db/src/regulation-applicability.test.ts
+++ b/packages/db/src/regulation-applicability.test.ts
@@ -162,3 +162,65 @@ describe("parseApplicability — tolerant parser for the stored JSON spec", () =
     expect(parseApplicability({ jurisdictions: ["uk"] })).toBeNull(); // missing basis
   });
 });
+
+describe("archetypeGate — matches archetype id OR category (BI-9DED0CE8)", () => {
+  const ncua: RegulationApplicability = {
+    basis: ["operating"],
+    jurisdictions: ["us"],
+    archetypes: ["credit-union"],
+  };
+  const bsa: RegulationApplicability = {
+    basis: ["operating"],
+    jurisdictions: ["us"],
+    archetypes: ["banking-financial-services"],
+  };
+  const creditUnion: RegionProfile = {
+    ...empty,
+    operatesIn: ["us"],
+    archetype: "banking-financial-services",
+    archetypeId: "credit-union",
+  };
+  const communityBank: RegionProfile = { ...creditUnion, archetypeId: "community-bank" };
+
+  it("an id-scoped regime applies only to the matching archetype id", () => {
+    expect(regulationApplies(ncua, creditUnion).applies).toBe(true);
+    const miss = regulationApplies(ncua, communityBank);
+    expect(miss.applies).toBe(false);
+    expect(miss.undeclared).toBe(false); // declared mismatch → reference, not review
+  });
+
+  it("a category-scoped regime applies to every archetype id in the category", () => {
+    expect(regulationApplies(bsa, creditUnion).applies).toBe(true);
+    expect(regulationApplies(bsa, communityBank).applies).toBe(true);
+  });
+
+  it("law-enforcement-agency matches by id even though its category is public-sector", () => {
+    const post: RegulationApplicability = {
+      basis: ["operating"],
+      jurisdictions: ["us"],
+      archetypes: ["law-enforcement-agency"],
+    };
+    const agency: RegionProfile = {
+      ...empty,
+      operatesIn: ["us"],
+      archetype: "public-sector",
+      archetypeId: "law-enforcement-agency",
+    };
+    const town: RegionProfile = { ...agency, archetypeId: "small-town-municipality" };
+    expect(regulationApplies(post, agency).applies).toBe(true);
+    expect(regulationApplies(post, town).applies).toBe(false);
+    // ...and the category-wide public-body regime still applies to the agency.
+    const openMeetings: RegulationApplicability = {
+      basis: ["operating"],
+      jurisdictions: ["us"],
+      archetypes: ["public-sector"],
+    };
+    expect(regulationApplies(openMeetings, agency).applies).toBe(true);
+  });
+
+  it("no archetype declared at all stays reviewable (undeclared)", () => {
+    const r = regulationApplies(ncua, { ...empty, operatesIn: ["us"] });
+    expect(r.applies).toBe(false);
+    expect(r.undeclared).toBe(true);
+  });
+});

--- a/packages/db/src/regulation-applicability.ts
+++ b/packages/db/src/regulation-applicability.ts
@@ -42,8 +42,16 @@ export interface RegionProfile {
   sellsTo: string[];
   employsIn: string[];
   dataResidency: string[];
-  /** Business archetype slug (storefront/archetype), when known. */
+  /** Business archetype CATEGORY slug (StorefrontArchetype.category), when known. */
   archetype?: string;
+  /**
+   * Specific archetype id (StorefrontArchetype.archetypeId), when known. Some
+   * regimes bind finer than the category: NCUA binds a `credit-union` but not a
+   * `community-bank` (both category banking-financial-services); POST/CJIS bind
+   * a `law-enforcement-agency` but not a `small-town-municipality` (both
+   * category public-sector).
+   */
+  archetypeId?: string;
   /** Market-listing / legal-form status (LISTING_STATUSES), when declared. */
   listingStatus?: string;
 }
@@ -53,7 +61,12 @@ export interface RegulationApplicability {
   basis: ProfessionJurisdictionBasis[];
   /** Jurisdiction bloc slugs that trigger it on those bases (ignored for `global`). */
   jurisdictions: string[];
-  /** If set, only these business archetypes are in scope; otherwise archetype-agnostic. */
+  /**
+   * If set, only these business archetypes are in scope; otherwise
+   * archetype-agnostic. Entries may be archetype ids (`credit-union`) or
+   * category slugs (`banking-financial-services`) — the gate matches either,
+   * so a spec can bind a whole category or a single archetype.
+   */
   archetypes?: string[];
   /**
    * If set, only these listing statuses are in scope (e.g. `["premium-listed"]`
@@ -101,12 +114,15 @@ type GateResult =
 
 function archetypeGate(spec: RegulationApplicability, profile: RegionProfile): GateResult {
   if (!spec.archetypes || spec.archetypes.length === 0) return { pass: true };
-  const a = profile.archetype;
-  if (a && spec.archetypes.includes(a)) return { pass: true };
+  const declared = [profile.archetypeId, profile.archetype].filter(
+    (v): v is string => typeof v === "string" && v.length > 0,
+  );
+  if (declared.some((v) => spec.archetypes!.includes(v))) return { pass: true };
+  const label = declared.length > 0 ? `'${declared.join("' / '")}'` : "(undeclared)";
   return {
     pass: false,
-    undeclared: !a, // no archetype declared at all → reviewable, not a definitive miss
-    reason: `business archetype ${a ? `'${a}'` : "(undeclared)"} is out of scope (applies to: ${spec.archetypes.join(", ")})`,
+    undeclared: declared.length === 0, // no archetype declared at all → reviewable, not a definitive miss
+    reason: `business archetype ${label} is out of scope (applies to: ${spec.archetypes.join(", ")})`,
   };
 }
 

--- a/packages/db/src/seed-banking-compliance.ts
+++ b/packages/db/src/seed-banking-compliance.ts
@@ -1,5 +1,6 @@
-import type { PrismaClient } from "../generated/client/client";
+import type { PrismaClient, Prisma } from "../generated/client/client";
 import * as crypto from "crypto";
+import { type RegulationApplicability } from "./regulation-applicability";
 
 // BI-D9ACE184 + BI-E677F250 — banking deltas compliance pack (civic spec §10).
 // industry "financial". The recurring-obligation regimes the BIAN leaf work
@@ -7,6 +8,10 @@ import * as crypto from "crypto";
 // licensing substrate; recurring obligations live here. BSA/AML is a SINGLE
 // shared regulation both bank and credit union answer to (not double-seeded);
 // NCUA is credit-union-specific; FDIC/CRA is community-bank-specific.
+// Each regulation carries a data-driven applicability spec (BI-9DED0CE8) so an
+// install is only in scope when its setup-chosen archetype matches — NCUA gates
+// on the `credit-union` archetype id, FDIC/CRA on `community-bank`, BSA/AML on
+// the whole banking-financial-services category.
 
 function makeId(prefix: string): string {
   const hex = crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase();
@@ -29,6 +34,8 @@ type RegulationSeed = {
   shortName: string;
   jurisdiction: string;
   industry: string;
+  /** Data-driven applicability spec — scopes the regime to matching archetypes. */
+  applicability: RegulationApplicability;
   sourceType: "external";
   sourceUrl: string | null;
   notes: string;
@@ -42,6 +49,7 @@ export const BANKING_REGULATIONS: RegulationSeed[] = [
     shortName: "BSA/AML",
     jurisdiction: "US-federal",
     industry: "financial",
+    applicability: { basis: ["operating"], jurisdictions: ["us"], archetypes: ["banking-financial-services"] },
     sourceType: "external",
     sourceUrl: "https://www.fincen.gov/resources/statutes-and-regulations/bank-secrecy-act",
     notes:
@@ -114,6 +122,7 @@ export const BANKING_REGULATIONS: RegulationSeed[] = [
     shortName: "NCUA",
     jurisdiction: "US-federal",
     industry: "financial",
+    applicability: { basis: ["operating"], jurisdictions: ["us"], archetypes: ["credit-union"] },
     sourceType: "external",
     sourceUrl: "https://ncua.gov/regulation-supervision/manuals-guides",
     notes:
@@ -173,6 +182,7 @@ export const BANKING_REGULATIONS: RegulationSeed[] = [
     shortName: "Bank Supervision",
     jurisdiction: "US-federal",
     industry: "financial",
+    applicability: { basis: ["operating"], jurisdictions: ["us"], archetypes: ["community-bank"] },
     sourceType: "external",
     sourceUrl: "https://www.ffiec.gov/resources/reporting-forms",
     notes:
@@ -300,6 +310,7 @@ export async function seedBankingCompliance(prisma: PrismaClient): Promise<void>
 
   for (const reg of BANKING_REGULATIONS) {
     const { obligations, ...regData } = reg;
+    const applicability = regData.applicability as unknown as Prisma.InputJsonValue;
     const regulation = await prisma.regulation.upsert({
       where: { regulationId: regData.regulationId },
       update: {
@@ -310,8 +321,9 @@ export async function seedBankingCompliance(prisma: PrismaClient): Promise<void>
         sourceType: regData.sourceType,
         sourceUrl: regData.sourceUrl,
         notes: regData.notes,
+        applicability,
       },
-      create: regData,
+      create: { ...regData, applicability },
     });
     regUpserts++;
 

--- a/packages/db/src/seed-compliance-pack-applicability.test.ts
+++ b/packages/db/src/seed-compliance-pack-applicability.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parseApplicability } from "./regulation-applicability";
+import { BANKING_REGULATIONS } from "./seed-banking-compliance";
+import { PUBLIC_SECTOR_REGULATIONS } from "./seed-public-sector-compliance";
+import { LAW_ENFORCEMENT_REGULATIONS } from "./seed-law-enforcement-compliance";
+import { COOPERATIVE_REGULATIONS } from "./seed-cooperative-compliance";
+
+// BI-9DED0CE8 — every wholesale-seeded industry pack regulation must carry a
+// structured applicability spec, so an install is only in scope when its
+// setup-chosen archetype matches. Without a spec a regulation falls back to
+// the legacy industry string matcher and surfaces as noise on installs the
+// regime does not pertain to.
+
+const PACKS = [
+  ["banking", BANKING_REGULATIONS],
+  ["public-sector", PUBLIC_SECTOR_REGULATIONS],
+  ["law-enforcement", LAW_ENFORCEMENT_REGULATIONS],
+  ["cooperative", COOPERATIVE_REGULATIONS],
+] as const;
+
+describe("industry compliance packs carry archetype-scoped applicability", () => {
+  for (const [pack, regulations] of PACKS) {
+    it(`${pack}: every regulation has a parseable, archetype-gated spec`, () => {
+      for (const reg of regulations) {
+        // Round-trip through the tolerant parser used at classification time —
+        // a spec the parser rejects would silently fall back to legacy matching.
+        const parsed = parseApplicability(JSON.parse(JSON.stringify(reg.applicability)));
+        expect(parsed, `${reg.regulationId} spec must parse`).not.toBeNull();
+        expect(parsed!.archetypes, `${reg.regulationId} must gate on archetypes`).toBeDefined();
+        expect(parsed!.archetypes!.length).toBeGreaterThan(0);
+        expect(parsed!.basis.length).toBeGreaterThan(0);
+      }
+    });
+  }
+});
+
+describe("backfill migration stays in lockstep with the pack seed specs", () => {
+  // The data-only migration (20260710150000) backfills applicability on
+  // EXISTING installs; the seed populates fresh ones. If a spec changes in a
+  // pack without the migration (or a follow-up migration) matching, existing
+  // installs classify differently from fresh installs.
+  const sql = readFileSync(
+    join(
+      __dirname,
+      "../prisma/migrations/20260710150000_backfill_pack_regulation_applicability/migration.sql",
+    ),
+    "utf8",
+  );
+
+  const migrationSpecByRegulationId = new Map<string, unknown>();
+  const statement = /SET "applicability" = '([^']+)'::jsonb\s+WHERE "regulationId" (?:= '([^']+)'|IN \(([^)]+)\))/g;
+  for (const match of sql.matchAll(statement)) {
+    const spec = JSON.parse(match[1]!);
+    const ids = match[2]
+      ? [match[2]]
+      : match[3]!.split(",").map((s) => s.trim().replace(/^'|'$/g, ""));
+    for (const id of ids) migrationSpecByRegulationId.set(id, spec);
+  }
+
+  for (const [pack, regulations] of PACKS) {
+    it(`${pack}: migration backfills the same spec the seed writes`, () => {
+      for (const reg of regulations) {
+        expect(
+          migrationSpecByRegulationId.get(reg.regulationId),
+          `${reg.regulationId} must be backfilled by the migration`,
+        ).toEqual(JSON.parse(JSON.stringify(reg.applicability)));
+      }
+    });
+  }
+});

--- a/packages/db/src/seed-cooperative-compliance.ts
+++ b/packages/db/src/seed-cooperative-compliance.ts
@@ -1,9 +1,13 @@
-import type { PrismaClient } from "../generated/client/client";
+import type { PrismaClient, Prisma } from "../generated/client/client";
 import * as crypto from "crypto";
+import { type RegulationApplicability } from "./regulation-applicability";
 
 // BI-AFC178F3 — cooperative compliance pack (civic spec §10).
 // Same global-Regulation pattern as the public-sector pack, industry
 // "cooperative": Subchapter T patronage mechanics + member-governance duties.
+// Data-driven applicability (BI-9DED0CE8): gates on the cooperative archetype
+// ids — credit unions are NOT in scope (exempt from Subchapter T; they answer
+// to the banking pack's NCUA regime instead).
 
 function makeId(prefix: string): string {
   const hex = crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase();
@@ -26,10 +30,18 @@ type RegulationSeed = {
   shortName: string;
   jurisdiction: string;
   industry: string;
+  /** Data-driven applicability spec — scopes the regime to matching archetypes. */
+  applicability: RegulationApplicability;
   sourceType: "external";
   sourceUrl: string | null;
   notes: string;
   obligations: ObligationSeed[];
+};
+
+const COOPERATIVE_APPLICABILITY: RegulationApplicability = {
+  basis: ["operating"],
+  jurisdictions: ["us"],
+  archetypes: ["cooperative", "agricultural-cooperative"],
 };
 
 export const COOPERATIVE_REGULATIONS: RegulationSeed[] = [
@@ -39,6 +51,7 @@ export const COOPERATIVE_REGULATIONS: RegulationSeed[] = [
     shortName: "Subchapter T",
     jurisdiction: "US-federal",
     industry: "cooperative",
+    applicability: COOPERATIVE_APPLICABILITY,
     sourceType: "external",
     sourceUrl: "https://uscode.house.gov/view.xhtml?edition=prelim&path=%2Fprelim%40title26%2FsubtitleA%2Fchapter1%2FsubchapterT",
     notes:
@@ -101,6 +114,7 @@ export const COOPERATIVE_REGULATIONS: RegulationSeed[] = [
     shortName: "Co-op Governance",
     jurisdiction: "US-state",
     industry: "cooperative",
+    applicability: COOPERATIVE_APPLICABILITY,
     sourceType: "external",
     sourceUrl: null,
     notes:
@@ -207,6 +221,7 @@ export async function seedCooperativeCompliance(prisma: PrismaClient): Promise<v
 
   for (const reg of COOPERATIVE_REGULATIONS) {
     const { obligations, ...regData } = reg;
+    const applicability = regData.applicability as unknown as Prisma.InputJsonValue;
     const regulation = await prisma.regulation.upsert({
       where: { regulationId: regData.regulationId },
       update: {
@@ -217,8 +232,9 @@ export async function seedCooperativeCompliance(prisma: PrismaClient): Promise<v
         sourceType: regData.sourceType,
         sourceUrl: regData.sourceUrl,
         notes: regData.notes,
+        applicability,
       },
-      create: regData,
+      create: { ...regData, applicability },
     });
     regUpserts++;
 

--- a/packages/db/src/seed-law-enforcement-compliance.ts
+++ b/packages/db/src/seed-law-enforcement-compliance.ts
@@ -1,10 +1,15 @@
-import type { PrismaClient } from "../generated/client/client";
+import type { PrismaClient, Prisma } from "../generated/client/client";
 import * as crypto from "crypto";
+import { type RegulationApplicability } from "./regulation-applicability";
 
 // BI-C1578821 — law-enforcement compliance pack (civic spec §10).
 // industry "public-safety". Phase 1 is NO-CJI by design: this pack covers POST
 // training, policy attestation, and a CJIS READINESS GATE that is an explicit
 // Phase-2 prerequisite, NOT a satisfied control.
+// Data-driven applicability (BI-9DED0CE8): gates on the specific
+// `law-enforcement-agency` archetype id — its category is public-sector, so the
+// category-wide public-body pack also applies to an agency, but POST/CJIS bind
+// no other public body.
 
 function makeId(prefix: string): string {
   const hex = crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase();
@@ -27,10 +32,18 @@ type RegulationSeed = {
   shortName: string;
   jurisdiction: string;
   industry: string;
+  /** Data-driven applicability spec — scopes the regime to matching archetypes. */
+  applicability: RegulationApplicability;
   sourceType: "external";
   sourceUrl: string | null;
   notes: string;
   obligations: ObligationSeed[];
+};
+
+const LAW_ENFORCEMENT_APPLICABILITY: RegulationApplicability = {
+  basis: ["operating"],
+  jurisdictions: ["us"],
+  archetypes: ["law-enforcement-agency"],
 };
 
 export const LAW_ENFORCEMENT_REGULATIONS: RegulationSeed[] = [
@@ -40,6 +53,7 @@ export const LAW_ENFORCEMENT_REGULATIONS: RegulationSeed[] = [
     shortName: "POST",
     jurisdiction: "US-state",
     industry: "public-safety",
+    applicability: LAW_ENFORCEMENT_APPLICABILITY,
     sourceType: "external",
     sourceUrl: null,
     notes:
@@ -103,6 +117,7 @@ export const LAW_ENFORCEMENT_REGULATIONS: RegulationSeed[] = [
     shortName: "LE Policy",
     jurisdiction: "US-state",
     industry: "public-safety",
+    applicability: LAW_ENFORCEMENT_APPLICABILITY,
     sourceType: "external",
     sourceUrl: null,
     notes:
@@ -153,6 +168,7 @@ export const LAW_ENFORCEMENT_REGULATIONS: RegulationSeed[] = [
     shortName: "CJIS Gate",
     jurisdiction: "US-federal",
     industry: "public-safety",
+    applicability: LAW_ENFORCEMENT_APPLICABILITY,
     sourceType: "external",
     sourceUrl: "https://le.fbi.gov/cjis-division/cjis-security-policy-resource-center",
     notes:
@@ -232,6 +248,7 @@ export async function seedLawEnforcementCompliance(prisma: PrismaClient): Promis
 
   for (const reg of LAW_ENFORCEMENT_REGULATIONS) {
     const { obligations, ...regData } = reg;
+    const applicability = regData.applicability as unknown as Prisma.InputJsonValue;
     const regulation = await prisma.regulation.upsert({
       where: { regulationId: regData.regulationId },
       update: {
@@ -242,8 +259,9 @@ export async function seedLawEnforcementCompliance(prisma: PrismaClient): Promis
         sourceType: regData.sourceType,
         sourceUrl: regData.sourceUrl,
         notes: regData.notes,
+        applicability,
       },
-      create: regData,
+      create: { ...regData, applicability },
     });
     regUpserts++;
 

--- a/packages/db/src/seed-public-sector-compliance.ts
+++ b/packages/db/src/seed-public-sector-compliance.ts
@@ -1,5 +1,6 @@
-import type { PrismaClient } from "../generated/client/client";
+import type { PrismaClient, Prisma } from "../generated/client/client";
 import * as crypto from "crypto";
+import { type RegulationApplicability } from "./regulation-applicability";
 
 // BI-8D477188 Phase 2 — town/public-body compliance pack (civic spec §10).
 // Seeds the universal state-law FAMILIES as global Regulation rows (industry
@@ -7,6 +8,10 @@ import * as crypto from "crypto";
 // statutory deadlines and retention periods vary by state, so obligations carry
 // org-configurable cadence notes rather than 50 per-state seed variants —
 // BusinessContext.stateCode selects the defaults at onboarding.
+// Data-driven applicability (BI-9DED0CE8): open-meetings/public-records bind
+// every public body (the public-sector category); municipal finance and the
+// EPA water regimes bind only the archetypes that run a municipality or a
+// water/wastewater system.
 
 function makeId(prefix: string): string {
   const hex = crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase();
@@ -29,10 +34,26 @@ type RegulationSeed = {
   shortName: string;
   jurisdiction: string;
   industry: string;
+  /** Data-driven applicability spec — scopes the regime to matching archetypes. */
+  applicability: RegulationApplicability;
   sourceType: "external";
   sourceUrl: string | null;
   notes: string;
   obligations: ObligationSeed[];
+};
+
+/** Every public body: the whole public-sector category (municipality, utility, LE agency). */
+const PUBLIC_BODY_APPLICABILITY: RegulationApplicability = {
+  basis: ["operating"],
+  jurisdictions: ["us"],
+  archetypes: ["public-sector"],
+};
+
+/** Archetypes that run a municipality or a public water/wastewater system. */
+const MUNICIPAL_APPLICABILITY: RegulationApplicability = {
+  basis: ["operating"],
+  jurisdictions: ["us"],
+  archetypes: ["small-town-municipality", "municipal-utility"],
 };
 
 export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
@@ -42,6 +63,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
     shortName: "Open Meetings",
     jurisdiction: "US-state",
     industry: "public-sector",
+    applicability: PUBLIC_BODY_APPLICABILITY,
     sourceType: "external",
     sourceUrl: null,
     notes:
@@ -104,6 +126,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
     shortName: "Public Records",
     jurisdiction: "US-state",
     industry: "public-sector",
+    applicability: PUBLIC_BODY_APPLICABILITY,
     sourceType: "external",
     sourceUrl: null,
     notes:
@@ -156,6 +179,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
     shortName: "Municipal Finance",
     jurisdiction: "US-state",
     industry: "public-sector",
+    applicability: MUNICIPAL_APPLICABILITY,
     sourceType: "external",
     sourceUrl: null,
     notes:
@@ -229,6 +253,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
     shortName: "SDWA",
     jurisdiction: "US-federal",
     industry: "public-sector",
+    applicability: MUNICIPAL_APPLICABILITY,
     sourceType: "external",
     sourceUrl: "https://www.epa.gov/sdwa",
     notes:
@@ -293,6 +318,7 @@ export const PUBLIC_SECTOR_REGULATIONS: RegulationSeed[] = [
     shortName: "NPDES",
     jurisdiction: "US-federal",
     industry: "public-sector",
+    applicability: MUNICIPAL_APPLICABILITY,
     sourceType: "external",
     sourceUrl: "https://www.epa.gov/npdes/npdes-permit-basics",
     notes:
@@ -410,6 +436,7 @@ export async function seedPublicSectorCompliance(prisma: PrismaClient): Promise<
 
   for (const reg of PUBLIC_SECTOR_REGULATIONS) {
     const { obligations, ...regData } = reg;
+    const applicability = regData.applicability as unknown as Prisma.InputJsonValue;
     const regulation = await prisma.regulation.upsert({
       where: { regulationId: regData.regulationId },
       update: {
@@ -420,8 +447,9 @@ export async function seedPublicSectorCompliance(prisma: PrismaClient): Promise<
         sourceType: regData.sourceType,
         sourceUrl: regData.sourceUrl,
         notes: regData.notes,
+        applicability,
       },
-      create: regData,
+      create: { ...regData, applicability },
     });
     regUpserts++;
 

--- a/packages/integration-shared/package.json
+++ b/packages/integration-shared/package.json
@@ -10,6 +10,9 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "undici": "^8.5.0"
+  },
   "devDependencies": {
     "@types/node": "^26.0.1",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,6 +498,10 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.1.0)(typescript@6.0.3))(vite@8.1.0(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/integration-shared:
+    dependencies:
+      undici:
+        specifier: ^8.5.0
+        version: 8.5.0
     devDependencies:
       '@types/node':
         specifier: ^26.0.1

--- a/scripts/lib/sandbox-freshness.mjs
+++ b/scripts/lib/sandbox-freshness.mjs
@@ -150,6 +150,7 @@ export function parseEtimeMinutes(etime) {
  *   requestedBranch?, actualBranch?, requestedSha?, actualSha?,
  *   nodeModulesPresent: boolean,
  *   installedLockPresent: boolean,
+ *   lockfilesDiffer?: boolean,
  *   packages: [{ name, importer, lockedVersion, installedLockVersion, resolvedVersion, linkTarget, missing }],
  *   installProcesses: [{ pid, etime, etimeMinutes, command }],
  * }
@@ -189,6 +190,19 @@ export function evaluateFreshness(state) {
     failures.push({ kind: "not_installed", message: "node_modules is missing; sandbox has no installed dependency graph" });
   } else if (!state.installedLockPresent) {
     failures.push({ kind: "not_installed", message: "node_modules/.pnpm/lock.yaml is missing; cannot prove the installed graph matches pnpm-lock.yaml" });
+  } else if (state.lockfilesDiffer) {
+    // The sentinel packages below catch version drift on the load-bearing
+    // deps, but a branch that ADDS a dependency (new package in an importer)
+    // leaves every sentinel green while the installed graph predates the
+    // lockfile — the merged branch then fails typecheck/build on the missing
+    // module, which reads as product evidence when it is sandbox staleness.
+    // pnpm writes the exact lockfile it installed to node_modules/.pnpm/lock.yaml;
+    // any difference from the checked-in pnpm-lock.yaml means the install is
+    // stale. Convergence is a cheap frozen-lockfile no-op when spurious.
+    failures.push({
+      kind: "installed_lock_stale",
+      message: "node_modules/.pnpm/lock.yaml differs from pnpm-lock.yaml (install ran against an older lockfile)",
+    });
   }
 
   for (const pkg of state.packages ?? []) {

--- a/scripts/lib/sandbox-freshness.test.mjs
+++ b/scripts/lib/sandbox-freshness.test.mjs
@@ -146,6 +146,17 @@ test("evaluateFreshness flags the incident shape: stale next link vs newer lockf
   assert.match(failures[0].message, /next@16\.2\.7/);
 });
 
+test("evaluateFreshness flags a whole-lockfile mismatch the sentinels can't see (new dep added)", () => {
+  // A branch that ADDS a dependency leaves every sentinel package green while
+  // the installed graph predates the lockfile — the undici/integration-shared
+  // incident shape (BI-9DED0CE8 gate runs).
+  const { verdict, failures } = evaluateFreshness(baseState({ lockfilesDiffer: true }));
+  assert.equal(verdict, "sandbox_drift");
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].kind, "installed_lock_stale");
+  assert.match(failures[0].message, /older lockfile/);
+});
+
 test("evaluateFreshness flags a missing workspace link", () => {
   const state = baseState();
   state.packages[0] = { name: "next", importer: "apps/web", lockedVersion: "16.2.9", installedLockVersion: "", resolvedVersion: "", linkTarget: "", missing: true };

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -58,6 +58,6 @@ apps/web/lib/tak/route-context.ts	1189
 apps/web/lib/work-capsules/work-capsule-store.test.ts	943
 apps/web/lib/work-capsules/work-capsule-store.ts	932
 apps/web/lib/workbooks/platform-tables.ts	892
-apps/web/lib/workforce/calendar-data.ts	1127
-apps/web/lib/workspace/command-center.ts	1111
+apps/web/lib/workforce/calendar-data.ts	1134
+apps/web/lib/workspace/command-center.ts	1118
 packages/db/src/wiki-store.test.ts	824

--- a/scripts/sandbox-freshness-preflight.mjs
+++ b/scripts/sandbox-freshness-preflight.mjs
@@ -158,6 +158,7 @@ function collectState() {
     actualSha: git(rootDir, ["rev-parse", "HEAD"]),
     nodeModulesPresent: fs.existsSync(path.join(rootDir, "node_modules")),
     installedLockPresent: fs.existsSync(installedLockPath),
+    lockfilesDiffer: Boolean(installedLockText) && installedLockText !== lockfileText,
     packages,
     installProcesses,
   };


### PR DESCRIPTION
## Problem

All 5 industry compliance packs (banking, public-sector, law-enforcement, cooperative, UK corp-gov) seed wholesale into **every** install, but only UK corp-gov carried a structured applicability spec. The rest fell back to legacy industry-string matching, and the compliance dashboard counts, workspace command center, workforce calendar, and gap assessment consumed **all** active obligations unfiltered — so an install sees obligation noise from regimes that don't pertain to the business archetype chosen at initial setup.

Kernel decision (principle_decide, governing profile platform, high confidence, composite 9.80 vs 6.89): **complete-metadata-live-scoping** — finish the data-driven applicability metadata and keep classification live-computed from setup context; no new per-install state to drift.

## Changes

**Archetype-scoped applicability on every pack regulation** (`packages/db/src/seed-*-compliance.ts`)
- Granularity follows where each regime actually binds: NCUA → `credit-union`, FDIC/CRA → `community-bank`, POST/LE-policy/CJIS → `law-enforcement-agency`, Subchapter T / co-op governance → cooperative ids; BSA/AML and open-meetings/public-records bind whole categories; muni-finance/EPA-water bind municipality+utility.
- `archetypeGate` now matches the install's **archetypeId OR category** (`RegionProfile.archetypeId`) — needed because law-enforcement (category public-sector) and cooperatives (category nonprofit-community) are only distinguishable by id.

**Aggregating surfaces filter to what applies** (`resolveApplicableRegulationDbIds()`)
- Compliance dashboard counts + By-Regulation list, workspace command-center governance tile, workforce calendar obligation deadlines, gap assessment/posture. The full tri-state library (applies / review / reference) stays on /compliance/regulations & /compliance/obligations.

**Existing installs**: data-only migration backfills the specs (IS NULL guarded, precedent #2570). Verified on scratch Postgres: NULL rows backfilled, operator-edited spec untouched. A lockstep test keeps the migration literals equal to the seed specs.

**Gate-blocking substrate fixes folded in** (both bit this branch's pregate):
- `@dpf/integration-shared` used `undici` without declaring it (phantom dep from #2744/#2754) — fails isolated installs with TS2307.
- The sandbox-freshness preflight only checks 5 sentinel packages, so a branch that *adds* a dependency skipped convergence and typechecked against a stale install. Now any difference between `pnpm-lock.yaml` and `node_modules/.pnpm/lock.yaml` is `installed_lock_stale` → converge. Verified live: this branch's gate detected drift, converged, and passed.

## Outcome

A fresh install (and any archetype change via setup/archetype-reset) derives exactly the obligations that pertain to the company defined at setup — banking regimes for a credit union, POST/CJIS for a police department, nothing but cross-sector regimes for an HVAC company — with review/reference still browsable in the library.

Tests: 49 targeted (packs round-trip + gate + classifier + helper + migration lockstep) green; full local-CI gate (15k tests, web+db typecheck, prod build) passed under lease.

BI-9DED0CE8 · claim WC-8838366D

🤖 Generated with [Claude Code](https://claude.com/claude-code)