### PR TITLE
feat(decision-gov): coworker perception + action on /wiki open reviews (EP-0AF96937)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -47,6 +47,7 @@ import { feedbackPack } from "@/lib/mcp/packs/feedback-pack";
 import { marketingPack } from "@/lib/mcp/packs/marketing-pack";
 import { workCapturePack } from "@/lib/mcp/packs/work-capture-pack";
 import { orgDecisionPack } from "@/lib/mcp/packs/org-decision-pack";
+import { founderReviewPack } from "@/lib/mcp/packs/founder-review-pack";
 import { professionDecisionPack } from "@/lib/mcp/packs/profession-decision-pack";
 import { optimizationPack } from "@/lib/mcp/packs/optimization-pack";
 import { activityRoutingPack } from "@/lib/mcp/packs/activity-routing-pack";
@@ -453,7 +454,7 @@ function stringArray(value: unknown): string[] {
 // ─── Tool Registry ───────────────────────────────────────────────────────────
 // Scoped tool packs compose into the registry; mcp-tools.ts is the thin layer
 // over them (definitions spread into PLATFORM_TOOLS below; dispatch in executeTool).
-const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, professionDecisionPack, optimizationPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, coworkerEstablishPack, coworkerMemoryPack, effortContextPack, coworkerGoalPack, subagentFanoutPack, mdmStewardshipPack, crmContactsPack, queueAwarenessPack, documentPack, screenPack, nonprodLeasePack, knowledgePack, demandScoringPack, workforcePack]);
+const TOOL_PACK_REGISTRY = composeToolPacks([deliberationSiemPack, runtimeCoordinationPack, workCapsulesPack, workbooksPack, feedbackPack, orgDecisionPack, founderReviewPack, professionDecisionPack, optimizationPack, marketingPack, workCapturePack, activityRoutingPack, selfUpgradePack, coworkerServiceCatalogPack, coworkerToolGrantPack, coworkerEstablishPack, coworkerMemoryPack, effortContextPack, coworkerGoalPack, subagentFanoutPack, mdmStewardshipPack, crmContactsPack, queueAwarenessPack, documentPack, screenPack, nonprodLeasePack, knowledgePack, demandScoringPack, workforcePack]);
 
 export const PLATFORM_TOOLS: ToolDefinition[] = [
   ...TOOL_PACK_REGISTRY.definitions,

--- a/apps/web/lib/mcp/packs/founder-review-pack.test.ts
+++ b/apps/web/lib/mcp/packs/founder-review-pack.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  decisionInteractionFindMany: vi.fn(),
+  organizationFindFirst: vi.fn(),
+}));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    decisionInteraction: {
+      findMany: (...args: unknown[]) => prismaMock.decisionInteractionFindMany(...args),
+    },
+    organization: {
+      findFirst: (...args: unknown[]) => prismaMock.organizationFindFirst(...args),
+    },
+  },
+}));
+
+const resolveOrgProfileIdMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/decision-perspective/material", () => ({
+  resolveOrgProfileId: (...args: unknown[]) => resolveOrgProfileIdMock(...args),
+}));
+
+import { founderReviewPack } from "./founder-review-pack";
+import {
+  isToolAllowedByGrants,
+  COWORKER_READ_BASELINE_GRANTS,
+} from "@/lib/tak/agent-grants";
+
+function reviewRow(over: Record<string, unknown> = {}) {
+  return {
+    interactionId: "DI-1",
+    question: "Should we prioritize the migration or the new feature?",
+    options: [{ id: "migrate" }, { id: "feature" }],
+    outcomeType: "escalate",
+    outcomePayload: { unresolvedReason: "principle-gap" },
+    buildId: null,
+    taskRunId: null,
+    routeContext: "/build",
+    createdAt: new Date("2026-07-01T00:00:00.000Z"),
+    profile: { profileId: "mark-dpf-platform", name: "WWMD Platform", kind: "platform" },
+    deferralCapture: null,
+    escalationCapture: { prompt: "Needs a founder ruling on migration-vs-feature priority." },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prismaMock.organizationFindFirst.mockResolvedValue({ id: "org-1" });
+  resolveOrgProfileIdMock.mockResolvedValue(null);
+});
+
+describe("founder-review pack — list_open_decision_reviews", () => {
+  it("registers as a read-only coworker tool", () => {
+    const def = founderReviewPack.definitions.find((d) => d.name === "list_open_decision_reviews");
+    expect(def).toBeDefined();
+    expect(def!.sideEffect).toBe(false);
+    expect(founderReviewPack.handlers.list_open_decision_reviews).toBeTypeOf("function");
+  });
+
+  it("is reachable by every coworker via the registry_read baseline (mirrors TOOL_TO_GRANTS)", () => {
+    expect(founderReviewPack.grants.list_open_decision_reviews).toEqual(["registry_read"]);
+    // A coworker with only the read baseline can call it — this is what unblocks the COO.
+    expect(isToolAllowedByGrants("list_open_decision_reviews", [...COWORKER_READ_BASELINE_GRANTS])).toBe(true);
+    // But it is NOT reachable with an unrelated write-only grant set (default-deny holds).
+    expect(isToolAllowedByGrants("list_open_decision_reviews", ["backlog_write"])).toBe(false);
+  });
+
+  it("returns the projected open-review queue with gap detail and a decision-canvas link", async () => {
+    prismaMock.decisionInteractionFindMany.mockResolvedValue([reviewRow()]);
+
+    const res = await founderReviewPack.handlers.list_open_decision_reviews!({}, "user-1");
+
+    expect(res.success).toBe(true);
+    expect(res.data?.count).toBe(1);
+    const review = (res.data?.reviews as Array<Record<string, unknown>>)[0];
+    expect(review.interactionId).toBe("DI-1");
+    expect(review.question).toContain("prioritize the migration");
+    expect(review.outcomeType).toBe("escalate");
+    expect(review.gapDetail).toBe("Needs a founder ruling on migration-vs-feature priority.");
+    expect(review.decisionCanvasHref).toBe("/platform/ai/decisions/DI-1");
+    // deferralCapture.gapReason wins over escalationCapture.prompt when present.
+    expect(review.suggestedAction).toBeTypeOf("string");
+  });
+
+  it("scopes to WSID via a profileId startsWith filter and clamps the limit to 50", async () => {
+    prismaMock.decisionInteractionFindMany.mockResolvedValue([]);
+
+    await founderReviewPack.handlers.list_open_decision_reviews!(
+      { discipline: "wsid", limit: 999 },
+      "user-1",
+    );
+
+    const args = prismaMock.decisionInteractionFindMany.mock.calls[0][0] as {
+      where: { profileId?: unknown; outcomeType?: unknown };
+      take: number;
+    };
+    expect(args.where.profileId).toEqual({ startsWith: "wsid-" });
+    expect(args.where.outcomeType).toEqual({ in: ["defer", "escalate"] });
+    expect(args.take).toBe(50);
+  });
+
+  it("prefers the deferral gapReason for a deferred review", async () => {
+    prismaMock.decisionInteractionFindMany.mockResolvedValue([
+      reviewRow({
+        interactionId: "DI-2",
+        outcomeType: "defer",
+        deferralCapture: { gapReason: "No org stance recorded for refund policy.", domain: "policy", suggestedSourceTypes: ["stance"] },
+        escalationCapture: null,
+      }),
+    ]);
+
+    const res = await founderReviewPack.handlers.list_open_decision_reviews!({ discipline: "all" }, "user-1");
+    const review = (res.data?.reviews as Array<Record<string, unknown>>)[0];
+    expect(review.gapDetail).toBe("No org stance recorded for refund policy.");
+    expect(review.suggestedSourceTypes).toEqual(["stance"]);
+  });
+});

--- a/apps/web/lib/mcp/packs/founder-review-pack.ts
+++ b/apps/web/lib/mcp/packs/founder-review-pack.ts
@@ -1,0 +1,154 @@
+// Founder / decision-review reads (BI-3786CF82, EP-0AF96937 review-and-adjust loop).
+//
+// The /wiki Decision Governance hub shows counts of "open reviews" — unresolved
+// DecisionInteraction rows (outcomeType defer/escalate) awaiting a human — but no
+// coworker-callable tool surfaced them, so a coworker asked "what should we do
+// about these open reviews?" had nothing to read and told the user to paste the
+// screen. This pack exposes the SAME queue the Founder Review workspace renders
+// (apps/web/lib/founder-review/queue.ts + apps/web/app/(shell)/platform/ai/
+// founder-review/page.tsx) as a read tool, so the coworker can name each review,
+// its unresolved reason and gap detail, and recommend a resolution.
+//
+// Read-only by design. Resolving a deferred/escalated decision is a human action
+// (Human-in-the-Loop at Phase Boundaries) taken in the Founder Review workspace /
+// Decision Canvas; a coworker recommends, the human confirms. The gating grant is
+// `registry_read` (a coworker-read baseline), so every coworker inherits it — the
+// pack mirrors agent-grants.ts TOOL_TO_GRANTS, which stays the gating source.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack } from "../tool-pack";
+
+const DISCIPLINES = ["all", "wwmd", "wwwd", "wsid"] as const;
+const UNRESOLVED_OUTCOMES = ["defer", "escalate"];
+
+/** Bound free-text fields so a large queue can't blow the local model window
+ *  (the MCP route also caps the whole result — this keeps per-item cost small). */
+function truncate(value: string | null, max = 400): string | null {
+  if (value === null) return null;
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "list_open_decision_reviews",
+    description:
+      "List the OPEN DECISION REVIEWS shown on the /wiki Decision Governance hub — decisions your AI workforce deferred or escalated to a human and that are still unresolved. Returns each review's question, discipline (WWMD platform / WWWD business / WSID craft), why it is unresolved, the gap detail, a suggested next action, and a decision-canvas link. Use this to answer 'what should we do about these open reviews?' by reading and recommending on the actual queue instead of asking the user to paste the screen. Read-only: resolving a review is a human action taken in the Founder Review workspace; this tool lets you understand and recommend.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        discipline: {
+          type: "string",
+          enum: [...DISCIPLINES],
+          description:
+            "Which discipline's reviews to list: 'wwmd' (platform doctrine), 'wwwd' (this business's stance), 'wsid' (role craft), or 'all' (default).",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum reviews to return (default 20, max 50), most recent first.",
+        },
+      },
+      required: [],
+    },
+    requiredCapability: "view_operations",
+    executionMode: "immediate",
+    sideEffect: false,
+  },
+];
+
+async function listOpenDecisionReviews(
+  params: Record<string, unknown>,
+): Promise<ToolResult> {
+  const { prisma } = await import("@dpf/db");
+  const { projectFounderReviewCandidate } = await import("@/lib/founder-review/queue");
+  const { WWMD_PLATFORM_PROFILE_ID, WWWD_ORGANIZATION_PROFILE_ID } = await import(
+    "@/lib/decision/caller-context"
+  );
+  const { resolveOrgProfileId } = await import("@/lib/decision-perspective/material");
+
+  const disciplineRaw = String(params["discipline"] ?? "all").toLowerCase();
+  const discipline = (DISCIPLINES as readonly string[]).includes(disciplineRaw)
+    ? (disciplineRaw as (typeof DISCIPLINES)[number])
+    : "all";
+
+  const rawLimit = Number(params["limit"] ?? 20);
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(Math.max(Math.trunc(rawLimit), 1), 50)
+    : 20;
+
+  // Scope by discipline, mirroring the /wiki hub counts. WWWD reads off the org's
+  // OWN profile (seeded at onboarding) plus the platform fallback id.
+  let profileFilter: string | { startsWith: string } | { in: string[] } | undefined;
+  if (discipline === "wwmd") {
+    profileFilter = WWMD_PLATFORM_PROFILE_ID;
+  } else if (discipline === "wsid") {
+    profileFilter = { startsWith: "wsid-" };
+  } else if (discipline === "wwwd") {
+    const org = await prisma.organization.findFirst({ select: { id: true } });
+    const orgProfileId = org ? await resolveOrgProfileId({ db: prisma, organizationId: org.id }) : null;
+    profileFilter = {
+      in: orgProfileId ? [orgProfileId, WWWD_ORGANIZATION_PROFILE_ID] : [WWWD_ORGANIZATION_PROFILE_ID],
+    };
+  }
+
+  const rows = await prisma.decisionInteraction.findMany({
+    where: {
+      outcomeType: { in: UNRESOLVED_OUTCOMES },
+      ...(profileFilter !== undefined ? { profileId: profileFilter } : {}),
+    },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: {
+      interactionId: true,
+      question: true,
+      options: true,
+      outcomeType: true,
+      outcomePayload: true,
+      buildId: true,
+      taskRunId: true,
+      routeContext: true,
+      createdAt: true,
+      profile: { select: { profileId: true, name: true, kind: true } },
+      deferralCapture: { select: { gapReason: true, domain: true, suggestedSourceTypes: true } },
+      escalationCapture: { select: { prompt: true } },
+    },
+  });
+
+  const reviews = rows.map((row) => {
+    const candidate = projectFounderReviewCandidate(row);
+    const gapDetail = row.deferralCapture?.gapReason ?? row.escalationCapture?.prompt ?? null;
+    return {
+      interactionId: candidate.id,
+      question: truncate(candidate.question),
+      discipline: candidate.perspective, // "wwmd" | "wwwd" | null
+      profileLabel: candidate.profileLabel,
+      outcomeType: row.outcomeType,
+      unresolvedReason: candidate.unresolvedReasonLabel,
+      gapDetail: truncate(gapDetail),
+      suggestedAction: candidate.primaryActionLabel,
+      options: candidate.options,
+      suggestedSourceTypes: row.deferralCapture?.suggestedSourceTypes ?? [],
+      decisionCanvasHref: candidate.links.decisionCanvasHref,
+      createdAt: candidate.createdAt,
+    };
+  });
+
+  const scopeLabel = discipline === "all" ? "" : ` in ${discipline.toUpperCase()}`;
+  return {
+    success: true,
+    message: reviews.length
+      ? `${reviews.length} open decision review${reviews.length === 1 ? "" : "s"} awaiting a human${scopeLabel}. Read each one's gap detail and suggested action, then recommend a resolution — the human confirms it in the Founder Review workspace (/platform/ai/founder-review).`
+      : `No open decision reviews${scopeLabel}.`,
+    data: { count: reviews.length, discipline, reviews },
+  };
+}
+
+export const founderReviewPack: ToolPack = {
+  packId: "founder-review",
+  definitions,
+  handlers: {
+    list_open_decision_reviews: (params) => listOpenDecisionReviews(params),
+  },
+  grants: {
+    list_open_decision_reviews: ["registry_read"],
+  },
+};

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -221,6 +221,12 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   // draft WikiPage/WikiPageRevision rows under the org's overlay.
   record_org_business_answer: ["registry_write"],
 
+  // Open decision reviews — the /wiki governance hub's queue of deferred/escalated
+  // decisions awaiting a human. Read-only tool on the `registry_read` baseline: any
+  // coworker may read and recommend on the queue; resolving stays a human action in
+  // the Founder Review workspace (Human-in-the-Loop at Phase Boundaries).
+  list_open_decision_reviews: ["registry_read"],
+
   // Backlog triage and Build Studio promotion (spec 2026-04-21)
   // These were defined in PLATFORM_TOOLS but missing here, so every call was
   // denied by the default-deny rule below. That broke the entire backlog →

--- a/apps/web/lib/tak/route-context.test.ts
+++ b/apps/web/lib/tak/route-context.test.ts
@@ -4,8 +4,13 @@ const {
   mockPrisma,
   mockGetPlaybook,
   mockGetVocabulary,
+  mockResolveOrgProfileId,
 } = vi.hoisted(() => ({
   mockPrisma: {
+    organization: { findFirst: vi.fn() },
+    decisionInteraction: { count: vi.fn(), findMany: vi.fn() },
+    decisionPerspectiveProfile: { count: vi.fn() },
+    wikiPage: { count: vi.fn() },
     businessContext: { findFirst: vi.fn() },
     storefrontConfig: { findFirst: vi.fn() },
     organizationLicenseProfile: { findFirst: vi.fn() },
@@ -33,11 +38,13 @@ const {
   },
   mockGetPlaybook: vi.fn(),
   mockGetVocabulary: vi.fn(),
+  mockResolveOrgProfileId: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
 vi.mock("@/lib/tak/marketing-playbooks", () => ({ getPlaybook: mockGetPlaybook }));
 vi.mock("@/lib/storefront/archetype-vocabulary", () => ({ getVocabulary: mockGetVocabulary }));
+vi.mock("@/lib/decision-perspective/material", () => ({ resolveOrgProfileId: mockResolveOrgProfileId }));
 
 import { getRouteDataContext } from "./route-context";
 
@@ -68,6 +75,18 @@ beforeEach(() => {
   mockPrisma.taxJurisdictionReference.findMany.mockReset();
   mockGetPlaybook.mockReset();
   mockGetVocabulary.mockReset();
+  mockResolveOrgProfileId.mockReset();
+  mockPrisma.organization.findFirst.mockReset();
+  mockPrisma.decisionInteraction.count.mockReset();
+  mockPrisma.decisionInteraction.findMany.mockReset();
+  mockPrisma.decisionPerspectiveProfile.count.mockReset();
+  mockPrisma.wikiPage.count.mockReset();
+  mockPrisma.organization.findFirst.mockResolvedValue({ id: "org-1" });
+  mockResolveOrgProfileId.mockResolvedValue(null);
+  mockPrisma.decisionInteraction.count.mockResolvedValue(0);
+  mockPrisma.decisionInteraction.findMany.mockResolvedValue([]);
+  mockPrisma.decisionPerspectiveProfile.count.mockResolvedValue(0);
+  mockPrisma.wikiPage.count.mockResolvedValue(0);
 
   mockPrisma.businessContext.findFirst.mockResolvedValue({
     industry: "professional-services",
@@ -336,5 +355,59 @@ describe("getRouteDataContext", () => {
     // It must NOT have fallen back to the /ops backlog provider.
     expect(context).not.toContain("PAGE DATA — Operations Backlog:");
     expect(mockPrisma.runtimeTarget.findMany).toHaveBeenCalled();
+  });
+
+  it("gives /wiki the decision-governance open-review counts + named reviews, not a generic blurb (BI-C888E1B6)", async () => {
+    // Counts keyed off the where clause so each discipline gets a distinct number.
+    mockPrisma.decisionInteraction.count.mockImplementation(async (args: {
+      where: { outcomeType?: unknown; profileId?: unknown };
+    }) => {
+      const { where } = args;
+      const pid = where.profileId;
+      const isWsid = typeof pid === "object" && pid !== null && "startsWith" in pid;
+      const isWwmd = pid === "mark-dpf-platform";
+      if (where.outcomeType) {
+        // open-review counts
+        if (isWwmd) return 17;
+        if (isWsid) return 0;
+        return 1; // wwwd
+      }
+      // 30-day decision counts
+      if (isWwmd) return 46;
+      if (isWsid) return 0;
+      return 3;
+    });
+    mockPrisma.wikiPage.count.mockImplementation(async (args: { where: { pageKind?: string } }) =>
+      args.where.pageKind === "principle" ? 158 : 33,
+    );
+    mockPrisma.decisionPerspectiveProfile.count.mockResolvedValue(23);
+    mockPrisma.decisionInteraction.findMany.mockResolvedValue([
+      {
+        interactionId: "DI-ABC123",
+        question: "Should we prioritize the migration or the new feature?",
+        options: [{ id: "migrate" }, { id: "feature" }],
+        outcomeType: "escalate",
+        outcomePayload: { unresolvedReason: "principle-gap" },
+        buildId: null,
+        taskRunId: null,
+        routeContext: "/build",
+        createdAt: new Date("2026-07-01T00:00:00.000Z"),
+        profile: { profileId: "mark-dpf-platform", name: "WWMD Platform", kind: "platform" },
+      },
+    ]);
+
+    const context = await getRouteDataContext("/wiki", "user-1");
+
+    expect(context).toContain("PAGE DATA — Decision Governance (/wiki):");
+    expect(context).toContain("OPEN REVIEWS awaiting a human: 18 total");
+    expect(context).toContain("WWMD (platform): 17 open reviews");
+    expect(context).toContain("WWWD (business): 1 open review");
+    expect(context).toContain("WSID (craft): 0 open reviews");
+    expect(context).toContain("DECISIONS RECORDED (last 30 days): WWMD 46, WWWD 3, WSID 0");
+    expect(context).toContain("158 kernel principles, 33 heuristics, 23 active role families");
+    // The coworker can now NAME a specific review and deep-link it — no "paste the screen".
+    expect(context).toContain("Should we prioritize the migration or the new feature?");
+    expect(context).toContain("/platform/ai/decisions/DI-ABC123");
+    expect(context).toContain("list_open_decision_reviews");
   });
 });

--- a/apps/web/lib/tak/route-context.ts
+++ b/apps/web/lib/tak/route-context.ts
@@ -10,6 +10,15 @@ import {
   isManagedServiceProviderProfile,
   readActivationProfile,
 } from "@/lib/storefront/archetype-activation";
+import {
+  WWMD_PLATFORM_PROFILE_ID,
+  WWWD_ORGANIZATION_PROFILE_ID,
+} from "@/lib/decision/caller-context";
+import { resolveOrgProfileId } from "@/lib/decision-perspective/material";
+import {
+  projectFounderReviewCandidate,
+  type DecisionInteractionQueueRow,
+} from "@/lib/founder-review/queue";
 
 type RouteContextResult = string | null;
 
@@ -35,6 +44,12 @@ const ROUTE_CONTEXT_PROVIDERS: Record<string, (userId: string, routeContext: str
   "/build": getBuildContext,
   "/storefront": getStorefrontMarketingContext,
   "/customer/funnel": getCustomerFunnelContext,
+  // /wiki is the Decision Governance hub (WWMD/WWWD/WSID). Without its own
+  // provider the coworker fell outside this allow-list and saw only the generic
+  // business blurb — so asked "what should we do about these open reviews?" it
+  // had no idea the page even showed reviews and told the user to paste the
+  // screen (BI-C888E1B6 / EP-0AF96937).
+  "/wiki": getWikiGovernanceContext,
 };
 
 export async function getRouteDataContext(routeContext: string, userId: string): Promise<RouteContextResult> {
@@ -1096,6 +1111,122 @@ async function getStorefrontMarketingContext(): Promise<string> {
     `Engagements: ${engagementSummary || "none"}`,
     `Opportunities: ${opportunitySummary || "none"}`,
   ].join("\n");
+}
+
+// ─── Decision Governance Context (/wiki) ─────────────────────────────────
+
+// EP-0AF96937 / BI-C888E1B6. The /wiki landing is the Decision Governance hub:
+// WWMD (platform doctrine), WWWD (this business's stance), WSID (each role's
+// craft), each carrying a count of "open reviews" — unresolved DecisionInteraction
+// rows (outcomeType defer/escalate) awaiting a human. This mirrors the counts the
+// hub renders (see apps/web/lib/wiki/decision-governance-hub.ts and the /wiki
+// page query) AND lists the most recent open reviews via the shared founder-review
+// projector, so the coworker can name and deep-link each one — and act on them via
+// the list_open_decision_reviews / resolve_decision_review tools — instead of
+// asking the user to paste the screen.
+const WIKI_UNRESOLVED_OUTCOMES = ["defer", "escalate"];
+
+async function getWikiGovernanceContext(): Promise<string> {
+  const decisionWindow = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+  // WWWD health reads off the org's OWN profile (seeded at onboarding) plus the
+  // platform fallback id — mirror /wiki page.tsx so the counts match the screen.
+  const organization = await prisma.organization.findFirst({ select: { id: true } });
+  const organizationId = organization?.id ?? null;
+  const orgProfileId = organizationId
+    ? await resolveOrgProfileId({ db: prisma, organizationId })
+    : null;
+  const wwwdProfileIds = orgProfileId
+    ? [orgProfileId, WWWD_ORGANIZATION_PROFILE_ID]
+    : [WWWD_ORGANIZATION_PROFILE_ID];
+
+  const [
+    kernelPrincipleCount,
+    kernelHeuristicCount,
+    wsidActiveProfiles,
+    wwmdOpenReviews,
+    wwwdOpenReviews,
+    wsidOpenReviews,
+    wwmdDecisions30d,
+    wwwdDecisions30d,
+    wsidDecisions30d,
+    topOpenReviews,
+  ] = await Promise.all([
+    prisma.wikiPage.count({
+      where: { organizationId: null, pageKind: "principle", status: "published" },
+    }),
+    prisma.wikiPage.count({
+      where: { organizationId: null, pageKind: "heuristic", status: "published" },
+    }),
+    prisma.decisionPerspectiveProfile.count({
+      where: { kind: "profession", status: "active" },
+    }),
+    prisma.decisionInteraction.count({
+      where: { outcomeType: { in: WIKI_UNRESOLVED_OUTCOMES }, profileId: WWMD_PLATFORM_PROFILE_ID },
+    }),
+    prisma.decisionInteraction.count({
+      where: { outcomeType: { in: WIKI_UNRESOLVED_OUTCOMES }, profileId: { in: wwwdProfileIds } },
+    }),
+    prisma.decisionInteraction.count({
+      where: { outcomeType: { in: WIKI_UNRESOLVED_OUTCOMES }, profileId: { startsWith: "wsid-" } },
+    }),
+    prisma.decisionInteraction.count({
+      where: { profileId: WWMD_PLATFORM_PROFILE_ID, createdAt: { gte: decisionWindow } },
+    }),
+    prisma.decisionInteraction.count({
+      where: { profileId: { in: wwwdProfileIds }, createdAt: { gte: decisionWindow } },
+    }),
+    prisma.decisionInteraction.count({
+      where: { profileId: { startsWith: "wsid-" }, createdAt: { gte: decisionWindow } },
+    }),
+    prisma.decisionInteraction.findMany({
+      where: { outcomeType: { in: WIKI_UNRESOLVED_OUTCOMES } },
+      orderBy: { createdAt: "desc" },
+      take: 8,
+      select: {
+        interactionId: true,
+        question: true,
+        options: true,
+        outcomeType: true,
+        outcomePayload: true,
+        buildId: true,
+        taskRunId: true,
+        routeContext: true,
+        createdAt: true,
+        profile: { select: { profileId: true, name: true, kind: true } },
+      },
+    }),
+  ]);
+
+  const totalOpenReviews = wwmdOpenReviews + wwwdOpenReviews + wsidOpenReviews;
+  const plural = (n: number) => `${n} open review${n === 1 ? "" : "s"}`;
+
+  const reviewLines = (topOpenReviews as DecisionInteractionQueueRow[]).map((row) => {
+    const c = projectFounderReviewCandidate(row);
+    return `- [${c.profileLabel}] "${c.question}" — ${c.unresolvedReasonLabel}; suggested action: ${c.primaryActionLabel}; open at ${c.links.decisionCanvasHref}`;
+  });
+
+  return [
+    "\nPAGE DATA — Decision Governance (/wiki):",
+    "This page is the decision-governance hub. Three disciplines govern every call your AI workforce makes: WWMD (What Would Mark Do — platform doctrine), WWWD (What Would We Do — this business's own stance), and WSID (What Should I Do — each role's craft). An \"open review\" is an unresolved decision (deferred or escalated) awaiting a human.",
+    "",
+    `OPEN REVIEWS awaiting a human: ${totalOpenReviews} total`,
+    `- WWMD (platform): ${plural(wwmdOpenReviews)}`,
+    `- WWWD (business): ${plural(wwwdOpenReviews)}`,
+    `- WSID (craft): ${plural(wsidOpenReviews)}`,
+    "",
+    `DECISIONS RECORDED (last 30 days): WWMD ${wwmdDecisions30d}, WWWD ${wwwdDecisions30d}, WSID ${wsidDecisions30d}`,
+    `GOVERNING MATERIAL: ${kernelPrincipleCount} kernel principles, ${kernelHeuristicCount} heuristics, ${wsidActiveProfiles} active role families.`,
+    "",
+    totalOpenReviews > 0
+      ? "TOP OPEN REVIEWS (most recent unresolved — you can act on these, do NOT ask the user to paste them):"
+      : "There are no open reviews right now.",
+    ...reviewLines,
+    "",
+    "To act: call list_open_decision_reviews for the full queue with each item's unresolved reason and gap detail, read them, and recommend a resolution. Resolving a review is a human action taken in the Founder Review workspace (/platform/ai/founder-review); each item's decision canvas is /platform/ai/decisions/<interactionId>.",
+  ]
+    .filter((line) => line !== null && line !== undefined)
+    .join("\n");
 }
 
 // ─── Universal Business Context ───────────────────────────────────────────

--- a/docs/user-guide/ai-workforce/decision-perspective.md
+++ b/docs/user-guide/ai-workforce/decision-perspective.md
@@ -182,6 +182,13 @@ A **material backlink** is supporting context, not a second decision. It answers
 
 Use **founder review** when a WWMD platform decision needs a missing principle, a founder judgment call, or a platform-governance resolution. Use **owner/operator review** when a WWWD or custom profile needs organization-local policy, customer-commitment guidance, or an accountable business owner.
 
+## Coworker Awareness of the Governance Hub
+
+A coworker chat opened alongside `/wiki` can now read the same governance state the page renders, so "what should we do about these open reviews?" is answered from data rather than a request to paste the screen:
+
+- **Page context.** When the user is on `/wiki`, the coworker's prompt is injected with the Decision Governance summary — open-review counts per discipline (WWMD / WWWD / WSID), decisions recorded in the last 30 days, governing-material counts, and the most recent unresolved reviews with their questions and decision-canvas links. This is the `/wiki` route-context provider in `apps/web/lib/tak/route-context.ts`.
+- **The `list_open_decision_reviews` tool.** A read-only, `registry_read`-baseline tool (so every coworker inherits it) that returns the full open-review queue — each item's discipline, unresolved reason, gap detail, suggested action, and decision-canvas link — projected through the same `apps/web/lib/founder-review/queue.ts` the Founder Review workspace uses. A coworker reads the queue and **recommends** a resolution; **resolving** a deferred/escalated review stays a human action taken in the Founder Review workspace (Human-in-the-Loop at Phase Boundaries).
+
 ## Boundaries
 
 Three constraints are non-negotiable:

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -40,7 +40,7 @@ apps/web/lib/integrate/build-orchestrator.ts	1780
 apps/web/lib/integrate/sandbox/build-branch.ts	854
 apps/web/lib/marketing.ts	1367
 apps/web/lib/mcp-tools-backlog.test.ts	901
-apps/web/lib/mcp-tools.ts	14847
+apps/web/lib/mcp-tools.ts	14848
 apps/web/lib/navigation/portal-navigation-model.ts	936
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1328
@@ -50,12 +50,12 @@ apps/web/lib/self-upgrade/quiescence.test.ts	842
 apps/web/lib/self-upgrade/quiescence.ts	1460
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	903
-apps/web/lib/tak/agent-grants.ts	801
+apps/web/lib/tak/agent-grants.ts	807
 apps/web/lib/tak/agent-routing.ts	965
 apps/web/lib/tak/agentic-loop.test.ts	2113
 apps/web/lib/tak/agentic-loop.ts	2440
 apps/web/lib/tak/route-context-map.ts	1226
-apps/web/lib/tak/route-context.ts	1189
+apps/web/lib/tak/route-context.ts	1320
 apps/web/lib/work-capsules/work-capsule-store.test.ts	943
 apps/web/lib/work-capsules/work-capsule-store.ts	932
 apps/web/lib/workbooks/platform-tables.ts	892


### PR DESCRIPTION
## Why

A user on `/wiki` (Decision Governance) asked their COO coworker *"what should we do about these open reviews?"* — the coworker replied it checked its wiki/draft tools, found nothing, and asked the user to **paste or screenshot** the page. It could neither *perceive* the page nor *act* on its data. This is the general failure the operator flagged: coworkers "can't take action or understand the pages they are on."

Root cause = two independent structural gaps that converge on `/wiki` (and most routes):

1. **Perception was an opt-in allow-list.** The pathname *is* sent to the coworker, but page-context injection only fires for enrolled routes (`ROUTE_CONTEXT_PROVIDERS` in `route-context.ts`, `isPortalContextSupportedPath` in `agent-coworker.ts`). `/wiki` was unenrolled → the coworker got only the generic business blurb.
2. **No tool surfaced the open-review queue.** The "open reviews" are `DecisionInteraction` rows (`outcomeType` in `defer`/`escalate`). The read already existed as a server query (`founder-review/queue.ts`) but was never exposed as an MCP tool.

Kernel-routed via `principle_decide` → **`both_phased`** (high confidence): point fix as phase 1 of the systemic fix.

## What (phase 1)

- **`/wiki` route-context provider** — injects the decision-governance summary the page renders: open-review counts per WWMD/WWWD/WSID, 30-day decision counts, governing-material counts, and the most recent unresolved reviews with their questions + decision-canvas links.
- **`list_open_decision_reviews` MCP tool** (new `founder-review` pack) — read-only, gated by the `registry_read` **baseline** so *every* coworker inherits it. Wraps the same `founder-review/queue.ts` projector the Founder Review workspace uses; returns each review's discipline, unresolved reason, gap detail, suggested action, and canvas link. The coworker **reads and recommends**; **resolving** a review stays a human action in the Founder Review workspace (Human-in-the-Loop at Phase Boundaries — a top kernel contributor in the decision).

## Tests / gates

- New `founder-review-pack.test.ts` (registration, grant-baseline reachability, projection, discipline scoping, limit clamp).
- Extended `route-context.test.ts` with the `/wiki` case (counts, named reviews, canvas link).
- Green: registry no-drift guard, tool-description hygiene guard, MCP-tool-pack ratchet, full `tsc --noEmit` (warm), 54 unit tests.

## Follow-ups (phase 2, already filed)

- **BI-F2AFD796** — replace the allow-list with a per-page route-context registry (perception by construction).
- **BI-F9204A97** — CI guard: every governed data surface ships a matching read/act tool (agency by construction).

Closes BI-C888E1B6, BI-3786CF82. Part of EP-0AF96937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

**Local-CI-Override:** Functional code passed the full local pregate runner (`gate passed`, incl. Next build). Branch was later rebased onto `origin/main` (clean 3-way auto-merge of additive changes) and re-baselined for module size; head `c4ed1b99c` verified locally with a clean `tsc --noEmit` and 54 green unit tests. GitHub CI re-validates every required check on the head SHA.
