### PR TITLE
feat(observability): fix silent admin_restart_service failure + wire remaining tell-only surfaces to the coworker (BI-01EA3EBE)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/page.tsx
@@ -5,6 +5,7 @@ import { prisma } from "@dpf/db";
 import { getProviders, getTokenSpendByProvider, getTokenSpendByAgent, getScheduledJobs, groupByEndpointTypeAndCategory, getProviderModelSummaries } from "@/lib/ai-provider-data";
 import { syncProviderRegistry, detectMcpServers, runProviderCatalogReconciliationIfDue } from "@/lib/actions/ai-providers";
 import { DetectedServicesBanner } from "@/components/platform/DetectedServicesBanner";
+import { AskCoworkerButton } from "@/components/agent/AskCoworkerButton";
 import { checkBundledProviders } from "@/lib/ollama";
 import { TokenSpendPanel } from "@/components/platform/TokenSpendPanel";
 import { ScheduledJobsTable } from "@/components/platform/ScheduledJobsTable";
@@ -217,7 +218,18 @@ function ProviderCatalogStatus({ lastSyncAt }: { lastSyncAt: Date | null }) {
           "Updates automatically"
         )}
       </div>
-      <div>Ask AI Coworker if this status looks wrong.</div>
+      <div>
+        <AskCoworkerButton
+          prompt={`I'm on the AI Providers page. The provider catalog shows ${
+            lastSyncAt
+              ? `it was last updated ${lastSyncAt.toISOString()}`
+              : "no recorded catalog sync"
+          }. Please check the provider/catalog status, tell me in plain language whether anything is wrong, and give me the exact next step if action is needed.`}
+          routeContext="/platform"
+          label="Ask AI Coworker if this status looks wrong."
+          className="text-[var(--dpf-accent)] hover:underline underline-offset-2"
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
@@ -14,6 +14,7 @@ import {
   type FlagSeverity,
 } from "@/lib/inference/phase-model-resolution";
 import { LocalTime } from "@/components/ui/LocalTime";
+import { AskCoworkerButton } from "@/components/agent/AskCoworkerButton";
 import { AiReadinessHeaderLink } from "@/components/platform/AiReadinessHeaderLink";
 import { QueueHealthSection } from "@/components/queue/QueueHealthSection";
 import { readQueueSnapshots } from "@/lib/queue/queue-snapshot-service";
@@ -26,6 +27,17 @@ const SEVERITY_STYLE: Record<FlagSeverity, { bg: string; fg: string; label: stri
   warning: { bg: "var(--dpf-state-warning)", fg: "var(--dpf-warning)", label: "Warning" },
   info: { bg: "var(--dpf-state-info)", fg: "var(--dpf-info)", label: "Info" },
 };
+
+// Server-composed handoff prompt: carries the error flags' own messages and
+// remediations so the coworker starts from the facts, not a screenshot.
+function buildRuntimeHealthPrompt(overview: ModelSelectionOverview): string {
+  const errors = overview.flags.filter((f) => f.severity === "error").slice(0, 8);
+  return [
+    `I'm on the AI Runtime Health page. Verdict: "${overview.summary}" with ${errors.length} error flag(s):`,
+    ...errors.map((f) => `- [${f.phase}] ${f.code}: ${f.message} (suggested: ${f.remediation})`),
+    "Please diagnose what's actually wrong, explain the impact in plain language, and either fix it if you have a safe way to do so or walk me through the exact next step.",
+  ].join("\n");
+}
 
 const VERDICT_COPY: Record<ModelSelectionOverview["verdict"], { tone: string; title: string }> = {
   "all-local": { tone: "var(--dpf-success)", title: "All phases run locally" },
@@ -164,6 +176,14 @@ export default async function RuntimeHealthPage() {
                 <Chip bg={SEVERITY_STYLE.error.bg} fg={SEVERITY_STYLE.error.fg}>
                   {errorCount} error(s)
                 </Chip>
+              )}
+              {errorCount > 0 && (
+                <AskCoworkerButton
+                  prompt={buildRuntimeHealthPrompt(overview)}
+                  routeContext="/platform"
+                  label="Ask coworker to investigate"
+                  className="text-[var(--dpf-accent)] hover:underline underline-offset-2 text-xs"
+                />
               )}
             </div>
             <p style={{ fontSize: 12, color: "var(--dpf-text)", marginTop: 8, marginBottom: 0 }}>

--- a/apps/web/components/agent/AskCoworkerButton.test.tsx
+++ b/apps/web/components/agent/AskCoworkerButton.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AskCoworkerButton } from "./AskCoworkerButton";
+
+afterEach(cleanup);
+
+describe("AskCoworkerButton", () => {
+  it("dispatches open-agent-panel with the prompt and routeContext", () => {
+    const events: CustomEvent[] = [];
+    const handler = (e: Event) => events.push(e as CustomEvent);
+    document.addEventListener("open-agent-panel", handler);
+
+    render(
+      <AskCoworkerButton prompt="Sandbox is offline — diagnose it" routeContext="/admin" />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Ask coworker" }));
+
+    document.removeEventListener("open-agent-panel", handler);
+    expect(events).toHaveLength(1);
+    expect(events[0].detail).toEqual({
+      autoMessage: "Sandbox is offline — diagnose it",
+      routeContext: "/admin",
+    });
+  });
+
+  it("omits routeContext when not given and renders custom children", () => {
+    const events: CustomEvent[] = [];
+    const handler = (e: Event) => events.push(e as CustomEvent);
+    document.addEventListener("open-agent-panel", handler);
+
+    render(
+      <AskCoworkerButton prompt="p">
+        <span>provider down — ask</span>
+      </AskCoworkerButton>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "provider down — ask" }));
+
+    document.removeEventListener("open-agent-panel", handler);
+    expect(events).toHaveLength(1);
+    expect(events[0].detail).toEqual({ autoMessage: "p" });
+  });
+});

--- a/apps/web/components/agent/AskCoworkerButton.tsx
+++ b/apps/web/components/agent/AskCoworkerButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+// Shared "hand this to the coworker" affordance (BI-01EA3EBE).
+//
+// Several surfaces report a platform problem but historically offered no route
+// to help — some even rendered dead "Ask AI Coworker…" plain text. This button
+// is the one canonical wire: it dispatches the same `open-agent-panel` event
+// Build Studio and the health surfaces use, carrying a context-rich prompt so
+// the user never transcribes jargon. Server components can import it directly
+// and pass a server-composed prompt.
+
+type Props = {
+  /** The autoMessage the coworker receives — include the facts, not just "help". */
+  prompt: string;
+  /** Route whose coworker should answer (e.g. "/admin", "/platform"). Omit to use the current route's coworker. */
+  routeContext?: string;
+  label?: string;
+  className?: string;
+  title?: string;
+  /** Custom content (e.g. a badge) instead of the text label. */
+  children?: React.ReactNode;
+};
+
+export function AskCoworkerButton({
+  prompt,
+  routeContext,
+  label = "Ask coworker",
+  className = "text-[var(--dpf-accent)] hover:underline underline-offset-2",
+  title,
+  children,
+}: Props) {
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        document.dispatchEvent(
+          new CustomEvent("open-agent-panel", {
+            detail: { autoMessage: prompt, ...(routeContext ? { routeContext } : {}) },
+          }),
+        )
+      }
+      className={className}
+      title={title}
+    >
+      {children ?? label}
+    </button>
+  );
+}

--- a/apps/web/components/monitoring/LogIssuesPanel.tsx
+++ b/apps/web/components/monitoring/LogIssuesPanel.tsx
@@ -8,6 +8,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { TONE_COLOR, type Tone } from "./health-summary";
+import { AskCoworkerButton } from "@/components/agent/AskCoworkerButton";
 import { getLogSignatureIssues } from "@/lib/actions/quality";
 
 interface LogIssue {
@@ -48,6 +49,18 @@ function lokiExploreUrl(service: string | null): string {
     },
   };
   return `${GRAFANA_BASE}/explore?schemaVersion=1&orgId=1&panes=${encodeURIComponent(JSON.stringify(panes))}`;
+}
+
+// Handoff prompt carrying the issue's own facts — the alternative was handing
+// a business user a raw Loki Explore link as the only "action".
+function buildLogIssuePrompt(issue: LogIssue, service: string | null): string {
+  return [
+    `I'm looking at the System Health "Log issues" panel. This issue needs a diagnosis:`,
+    `- [${issue.severity}] ${issue.title}${service ? ` (service: ${service})` : ""}, first seen ${issue.createdAt}${
+      issue.description ? ` — ${issue.description}` : ""
+    }`,
+    "Please check the recent logs for this service, explain what's failing and its impact in plain language, and either fix it if you have a safe way to do so or give me the exact next step.",
+  ].join("\n");
 }
 
 export function LogIssuesPanel() {
@@ -117,6 +130,11 @@ export function LogIssuesPanel() {
                     </td>
                     <td className="px-2 py-1.5 text-[var(--dpf-text)]">{issue.title}</td>
                     <td className="px-3 py-1.5 text-right whitespace-nowrap">
+                      <AskCoworkerButton
+                        prompt={buildLogIssuePrompt(issue, service)}
+                        routeContext="/admin"
+                        className="text-[var(--dpf-accent)] hover:underline mr-3"
+                      />
                       <a
                         href={lokiExploreUrl(service)}
                         target="_blank"

--- a/apps/web/components/platform/coworker-record/RosterView.tsx
+++ b/apps/web/components/platform/coworker-record/RosterView.tsx
@@ -7,6 +7,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
+import { AskCoworkerButton } from "@/components/agent/AskCoworkerButton";
 import type { RosterRow, RosterFacets } from "@/lib/coworker-record/roster";
 import { matchesFilters, kindOptions, EMPTY_FILTERS, type RosterFilters } from "@/lib/coworker-record/roster-filter";
 import { computeWorkforceSummary } from "@/lib/coworker-record/workforce-summary";
@@ -172,7 +173,16 @@ function RosterRowCard({ row }: { row: RosterRow }) {
           </Badge>
         )}
         {row.emptyCorpus && row.familyKey && <Badge tone="warning">empty corpus</Badge>}
-        {!row.providerHealthy && <Badge tone="warning">provider down</Badge>}
+        {!row.providerHealthy && (
+          <AskCoworkerButton
+            prompt={`The AI workforce roster shows "${row.displayName}" with a "provider down" warning — its AI provider isn't healthy, so this coworker may not respond. Please check the provider status, explain what's wrong in plain language, and give me the exact next step (or fix it if you have a safe way to do so).`}
+            routeContext="/platform"
+            title="This coworker's AI provider isn't healthy — click to ask what's wrong and how to fix it"
+            className=""
+          >
+            <Badge tone="warning">provider down — ask</Badge>
+          </AskCoworkerButton>
+        )}
         {row.openBlockers > 0 && <Badge tone="error">{row.openBlockers} blocker{row.openBlockers !== 1 ? "s" : ""}</Badge>}
         {row.deferRate > 0.25 && <Badge tone="warning">defer {Math.round(row.deferRate * 100)}%</Badge>}
       </span>

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -2374,7 +2374,7 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
   },
   {
     name: "admin_restart_service",
-    description: "Restart a Docker Compose service. Equivalent to 'docker compose restart <service>'.",
+    description: "Restart a platform service's container. Use when a service is down or unhealthy and a restart is the indicated remediation.",
     inputSchema: {
       type: "object",
       properties: {
@@ -15146,20 +15146,19 @@ export async function executeTool(
 
     case "admin_restart_service": {
       const service = String(params.service ?? "");
-      const ALLOWED = ["portal", "sandbox", "postgres", "neo4j", "qdrant"];
-      if (!ALLOWED.includes(service)) {
-        return { success: false, error: `Invalid service. Allowed: ${ALLOWED.join(", ")}`, message: `Unknown service "${service}".` };
-      }
+      // Label-resolved `docker restart` — the runtime image ships no compose
+      // file, so `docker compose restart` always failed here (BI-01EA3EBE).
+      const { restartPlatformService } = await import("@/lib/operate/service-restart");
       try {
         const { exec: execCb } = lazyChildProcess();
         const { promisify } = lazyUtil();
         const execAsync = promisify(execCb);
         await logAdminActivity(userId, "admin_restart_service", { service }, "success", 2, `Restarting ${service}`);
-        const { stdout } = await execAsync(`docker compose restart ${service} 2>&1`, {
-          cwd: process.env.PROJECT_ROOT || "/app",
-          timeout: 60_000,
-        });
-        return { success: true, message: `Restarted ${service}.`, data: { service, output: stdout.slice(0, 2000) } };
+        const result = await restartPlatformService(service, execAsync);
+        if (!result.success) {
+          return { success: false, error: result.error ?? result.message, message: result.message };
+        }
+        return { success: true, message: result.message, data: { service, container: result.container } };
       } catch (err) {
         const msg = (err as Error).message?.slice(0, 500) ?? "Restart failed";
         return { success: false, error: msg, message: `Failed to restart ${service}: ${msg}` };

--- a/apps/web/lib/operate/service-restart.test.ts
+++ b/apps/web/lib/operate/service-restart.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  restartPlatformService,
+  resolveOwnComposeProject,
+  type ShellExec,
+} from "./service-restart";
+
+function execScript(responses: Array<{ match: RegExp; stdout?: string; error?: string }>): {
+  exec: ShellExec;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const exec: ShellExec = async (command) => {
+    calls.push(command);
+    const hit = responses.find((r) => r.match.test(command));
+    if (!hit) throw new Error(`unexpected command: ${command}`);
+    if (hit.error) throw new Error(hit.error);
+    return { stdout: hit.stdout ?? "" };
+  };
+  return { exec, calls };
+}
+
+describe("resolveOwnComposeProject", () => {
+  it("returns the compose project label", async () => {
+    const { exec } = execScript([{ match: /docker inspect/, stdout: "dpf\n" }]);
+    expect(await resolveOwnComposeProject(exec)).toBe("dpf");
+  });
+
+  it("returns null when not running under compose", async () => {
+    const { exec } = execScript([{ match: /docker inspect/, error: "no such object" }]);
+    expect(await resolveOwnComposeProject(exec)).toBeNull();
+  });
+});
+
+describe("restartPlatformService", () => {
+  it("rejects services outside the allowlist without shelling out", async () => {
+    const { exec, calls } = execScript([]);
+    const result = await restartPlatformService("edge-node; rm -rf /", exec);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Invalid service");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("resolves the container by project+service labels and restarts it", async () => {
+    const { exec, calls } = execScript([
+      { match: /docker inspect/, stdout: "dpf\n" },
+      { match: /docker ps -a/, stdout: "a2ac543779b1\tdpf-sandbox-1\n" },
+      { match: /docker restart a2ac543779b1/, stdout: "a2ac543779b1\n" },
+    ]);
+    const result = await restartPlatformService("sandbox", exec);
+    expect(result).toEqual({
+      success: true,
+      message: "Restarted sandbox (dpf-sandbox-1).",
+      container: "dpf-sandbox-1",
+    });
+    expect(calls[1]).toContain('label=com.docker.compose.project=dpf');
+    expect(calls[1]).toContain('label=com.docker.compose.service=sandbox');
+  });
+
+  it("reports a missing container instead of pretending success", async () => {
+    const { exec } = execScript([
+      { match: /docker inspect/, stdout: "dpf\n" },
+      { match: /docker ps -a/, stdout: "\n" },
+    ]);
+    const result = await restartPlatformService("qdrant", exec);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("container_not_found");
+  });
+
+  it("refuses an ambiguous restart when project scope is unavailable", async () => {
+    const { exec, calls } = execScript([
+      { match: /docker inspect/, error: "not under compose" },
+      { match: /docker ps -a/, stdout: "aaa\tdpf-sandbox-1\nbbb\twt-sandbox-1\n" },
+    ]);
+    const result = await restartPlatformService("sandbox", exec);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("ambiguous_container");
+    // No project filter was applied (inspect failed) — that's WHY it's ambiguous.
+    expect(calls[1]).not.toContain("compose.project");
+  });
+
+  it("surfaces the docker error when the restart itself fails", async () => {
+    const { exec } = execScript([
+      { match: /docker inspect/, stdout: "dpf\n" },
+      { match: /docker ps -a/, stdout: "abc\tdpf-postgres-1\n" },
+      { match: /docker restart abc/, error: "Cannot connect to the Docker daemon" },
+    ]);
+    const result = await restartPlatformService("postgres", exec);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Cannot connect to the Docker daemon");
+  });
+});

--- a/apps/web/lib/operate/service-restart.ts
+++ b/apps/web/lib/operate/service-restart.ts
@@ -1,0 +1,116 @@
+// Governed platform-service restart (BI-01EA3EBE).
+//
+// The admin_restart_service tool shipped as `docker compose restart <service>`,
+// but the portal runtime image carries no docker-compose.yml — so every
+// invocation failed with "no configuration file provided" while the docker CLI,
+// compose plugin, and socket were all present. Kernel decision
+// (label-resolve-restart, margin 1.07): resolve the target container by the
+// compose labels Docker stamps on every compose-managed container, scoped to
+// the portal's OWN compose project (self-inspected via $(hostname), which is
+// the container id inside a compose container), then plain `docker restart`.
+// No compose file needed; multi-project hosts (contributor worktree sandboxes)
+// can't be cross-hit because of the project scope.
+
+export const RESTARTABLE_SERVICES = ["portal", "sandbox", "postgres", "neo4j", "qdrant"] as const;
+export type RestartableService = (typeof RESTARTABLE_SERVICES)[number];
+
+/** Narrow exec surface (promisified child_process.exec) so tests inject a mock. */
+export type ShellExec = (
+  command: string,
+  options: { timeout: number },
+) => Promise<{ stdout: string }>;
+
+export type RestartResult = {
+  success: boolean;
+  message: string;
+  /** Container that was restarted (name), when successful. */
+  container?: string;
+  error?: string;
+};
+
+/** The compose project this portal instance belongs to, or null when not
+ *  running under compose (e.g. unit tests, bare node). */
+export async function resolveOwnComposeProject(exec: ShellExec): Promise<string | null> {
+  try {
+    const { stdout } = await exec(
+      `docker inspect "$(hostname)" --format '{{ index .Config.Labels "com.docker.compose.project" }}'`,
+      { timeout: 10_000 },
+    );
+    const project = stdout.trim();
+    return project.length > 0 ? project : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Restart one allowlisted platform service by compose-label resolution.
+ * `docker ps -a` (not `ps`) so a crashed/exited container can be brought back
+ * with the same call — that's the case the health alert is usually about.
+ */
+export async function restartPlatformService(
+  service: string,
+  exec: ShellExec,
+): Promise<RestartResult> {
+  if (!(RESTARTABLE_SERVICES as readonly string[]).includes(service)) {
+    return {
+      success: false,
+      message: `Unknown service "${service}".`,
+      error: `Invalid service. Allowed: ${RESTARTABLE_SERVICES.join(", ")}`,
+    };
+  }
+
+  const project = await resolveOwnComposeProject(exec);
+  const projectFilter = project
+    ? ` --filter "label=com.docker.compose.project=${project}"`
+    : "";
+
+  let candidates: Array<{ id: string; name: string }>;
+  try {
+    const { stdout } = await exec(
+      `docker ps -a${projectFilter} --filter "label=com.docker.compose.service=${service}" --format '{{.ID}}\t{{.Names}}'`,
+      { timeout: 15_000 },
+    );
+    candidates = stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const [id, name] = line.split("\t");
+        return { id: id ?? "", name: name ?? id ?? "" };
+      })
+      .filter((c) => c.id);
+  } catch (err) {
+    const msg = (err as Error).message?.slice(0, 500) ?? "container lookup failed";
+    return { success: false, message: `Could not look up ${service}: ${msg}`, error: msg };
+  }
+
+  if (candidates.length === 0) {
+    return {
+      success: false,
+      message: `No container found for service "${service}"${project ? ` in project "${project}"` : ""}.`,
+      error: "container_not_found",
+    };
+  }
+  if (candidates.length > 1) {
+    const names = candidates.map((c) => c.name).join(", ");
+    return {
+      success: false,
+      message: `Multiple containers match service "${service}" (${names}) and no compose-project scope could be resolved — refusing an ambiguous restart.`,
+      error: "ambiguous_container",
+    };
+  }
+
+  const target = candidates[0];
+  try {
+    await exec(`docker restart ${target.id}`, { timeout: 60_000 });
+    return {
+      success: true,
+      message: `Restarted ${service} (${target.name}).`,
+      container: target.name,
+    };
+  } catch (err) {
+    const msg = (err as Error).message?.slice(0, 500) ?? "restart failed";
+    return { success: false, message: `Failed to restart ${service}: ${msg}`, error: msg };
+  }
+}

--- a/docs/superpowers/plans/2026-07-10-health-alerts-actionable-plan.md
+++ b/docs/superpowers/plans/2026-07-10-health-alerts-actionable-plan.md
@@ -69,15 +69,33 @@ deep-link to System Health). Wired into `aggregate.ts`, so:
 - the Needs-you inbox lists it under a "Platform health" chip;
 - customer-scoped (MSP) rows stay in the customer estate queue.
 
-### Phase 4 — follow-ups (deliberately out of scope)
+### Phase 4 — completion slice (BI-01EA3EBE, second PR)
 
-- Governed remediation actuation: surface `recover_sandbox`-class actions
-  (today fenced inside Build Studio) as operator one-click + coworker act-mode
-  tools — needs its own grants/boundary decision (the voice self-heal was
-  deferred BY DESIGN for the same host-exec boundary, BI-264565A4).
-- Wire the unwired "Ask AI Coworker…" text on `/platform/ai/providers` and the
-  Loki-jargon `LogIssuesPanel` to the same handoff.
+Delivered:
+
+- **Actuation fixed, not added.** `admin_restart_service` was already granted
+  to the admin-assistant (`admin_write`) and reachable from the Phase-2
+  handoff — but silently broken: the portal image ships no docker-compose.yml,
+  so `docker compose restart` failed on every call (verified live). Kernel
+  decision `label-resolve-restart` (margin 1.07, high confidence; shipping
+  compose files into the image and adding a separate one-click UI button both
+  rejected): `apps/web/lib/operate/service-restart.ts` resolves the target by
+  compose labels scoped to the portal's own compose project (self-inspected
+  via `$(hostname)`), then plain `docker restart` — refusing ambiguous matches
+  when project scope can't be resolved. The coworker asked via "Ask coworker
+  for help" can now actually restart a down service.
+- **Remaining tell-only surfaces wired** through a shared
+  `AskCoworkerButton` (`components/agent/AskCoworkerButton.tsx`, the canonical
+  `open-agent-panel` dispatcher): `LogIssuesPanel` rows (was Loki-link-only),
+  `/platform/ai/providers` (its "Ask AI Coworker…" text was literally unwired),
+  the runtime-health error banner, and the roster "provider down" badge.
+
+Still open (follow-up candidates):
+
 - `notifyAttentionLive` push for newly-opened critical health alerts.
+- Whether `admin_restart_service` should stay `sideEffect: false` ("Tier 2:
+  reversible" convention) — a restart survives advise-mode tool-stripping;
+  revisit if the advise/act boundary tightens.
 
 ## Verification
 


### PR DESCRIPTION
## What

Completion slice for the Platform Health "tell-don't-act" gap (follows #2764; BI-01EA3EBE). Two remaining gaps:

**1. Actuation was silently broken.** `admin_restart_service` — already granted to the System Admin coworker and reachable from the #2764 "Ask coworker for help" handoff — failed on **every** call: the portal runtime image ships no `docker-compose.yml`, so `docker compose restart <service>` found no configuration file (docker CLI, compose plugin, and socket are all present). Reproduced live via MCP before the fix.

Fix (kernel-scored `label-resolve-restart`, composite 6.68, **margin 1.07, high confidence** — shipping compose files into the image and adding a separate one-click UI button were both rejected): new `apps/web/lib/operate/service-restart.ts` resolves the target container by the compose labels Docker stamps on every compose-managed container, scoped to the portal's **own** compose project (self-inspected via `$(hostname)`), then runs plain `docker restart`. Refuses ambiguous matches when project scope can't be resolved (protects multi-project hosts with contributor worktree sandboxes). Resolution mechanics verified live inside the running portal container. The coworker you ask about a down service can now actually restart it.

**2. Remaining tell-only surfaces wired** through a shared `AskCoworkerButton` (the canonical `open-agent-panel` dispatcher):
- `LogIssuesPanel` rows — was raw log signatures with a Loki Explore deep-link as the only "action"
- `/platform/ai/providers` — its "Ask AI Coworker if this status looks wrong." text was literally **unwired plain text**
- Runtime-health verdict banner — "N error(s)" now pairs with "Ask coworker to investigate", carrying the error flags' own messages + remediations
- Roster "provider down" badge — now explains itself and opens the coworker with that coworker's provider context

## Verification

- New: `service-restart.test.ts` (allowlist injection guard, label scoping, missing/ambiguous/failed-restart paths), `AskCoworkerButton.test.tsx` (dispatch contract)
- Tool-description hygiene + tool-registry + monitoring suites green (97 tests); `web` typecheck green; module-size guard green; local pregate **passed** (full local CI incl. 15k unit tests)
- Live: broken state reproduced via MCP; fixed resolution path verified working inside `dpf-portal-1`

Plan updated in the same PR: `docs/superpowers/plans/2026-07-10-health-alerts-actionable-plan.md` (Phase 4).

UX-Fit-Decision: reuse-not-add (principle_decide; new one-click UI surface rejected — surfaces reuse the existing open-agent-panel mechanism via one shared button, replacing dead text and bare jargon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
