### PR TITLE
fix(attention): never render a blank NEEDS-YOU row — fallback title for empty-question decisions (BI-D35DE119)

### DIFF
--- a/apps/web/lib/attention/sources/ai-decision.ts
+++ b/apps/web/lib/attention/sources/ai-decision.ts
@@ -46,13 +46,36 @@ function residueFor(row: DecisionInteractionRow): ResidueReason {
   return "high-risk-gate"; // escalate: the cascade escalated on risk/low-confidence
 }
 
+// Some escalated/deferred decisions reach founder-review with an empty
+// `question` (the cascade recorded the residue but not a prose prompt). Without
+// a fallback the attention row renders with a BLANK title — an un-triageable
+// "high risk · Open →" the operator cannot act on (BI-D35DE119, F1). Derive a
+// short, honest title from the residue reason + blast radius so every row says
+// what it is and where it came from.
+function titleFor(row: DecisionInteractionRow): string {
+  const q = row.question?.trim();
+  if (q) return clip(q);
+  const reasonLabel =
+    residueFor(row) === "principle-conflict"
+      ? "a principle conflict"
+      : row.outcomeType === "defer"
+        ? "a coverage gap"
+        : "a high-risk gate";
+  const where = row.buildId
+    ? ` on build ${row.buildId}`
+    : row.taskRunId
+      ? " on a coworker task"
+      : "";
+  return `AI decision needs your review — ${reasonLabel}${where}`;
+}
+
 /** Pure projection of one unresolved decision into an attention item. */
 export function aiDecisionToAttentionItem(row: DecisionInteractionRow): AttentionItem {
   const blast = row.buildId ? `build ${row.buildId}` : row.taskRunId ? "a coworker task" : undefined;
   return {
     id: `ai-decision:${row.interactionId}`,
     source: "ai-decision",
-    title: clip(row.question),
+    title: titleFor(row),
     context: row.rationale ?? "The governed scopes could not resolve this decision.",
     decisionClass: { scorability: "unscorable" },
     riskClass: riskFromTier(row.riskTier),

--- a/apps/web/lib/attention/sources/sources.test.ts
+++ b/apps/web/lib/attention/sources/sources.test.ts
@@ -72,6 +72,27 @@ describe("aiDecisionToAttentionItem", () => {
     expect(item.triage.residueReason).toBe("coverage-gap");
     expect(item.riskClass).toBe("bounded-write");
   });
+
+  it("uses the verbatim question as the title when present", () => {
+    expect(aiDecisionToAttentionItem(base).title).toBe(base.question);
+  });
+
+  it("never renders a blank title — falls back to residue + blast when question is empty (BI-D35DE119)", () => {
+    // escalate on a build with no prose question → high-risk-gate fallback
+    const onBuild = aiDecisionToAttentionItem({ ...base, question: "   " });
+    expect(onBuild.title).toBe("AI decision needs your review — a high-risk gate on build FB-3");
+
+    // defer with no build/task and no question → coverage-gap, no location suffix
+    const bare = aiDecisionToAttentionItem({
+      ...base,
+      question: "",
+      outcomeType: "defer",
+      buildId: null,
+      taskRunId: null,
+    });
+    expect(bare.title).toBe("AI decision needs your review — a coverage gap");
+    expect(bare.title.trim().length).toBeGreaterThan(0);
+  });
 });
 
 describe("pausedAiToAttentionItem", () => {


### PR DESCRIPTION
## Problem (operator dogfood, F1)
Two `NEEDS YOU` rows on the workspace home rendered **blank** — only `high risk · Open →`, no title, no context — so the operator literally cannot decide whether to open them (decision time = infinite). There are **9** such rows: escalated/deferred `DecisionInteraction`s that reached founder-review with an empty `question`, and `aiDecisionToAttentionItem` set `title: clip(row.question)` with no fallback.

## Fix
When the question is empty, derive a short honest title from the residue reason + blast radius, e.g.:
- `AI decision needs your review — a high-risk gate on build FB-3`
- `AI decision needs your review — a coverage gap`

Every attention row now says what it is and where it came from. Inline `titleFor()` keeps the verbatim question when present.

## Tests
`sources.test.ts` — 16 pass, incl. two new cases: verbatim-question title, and the empty-question fallback (both the on-build and bare forms).

First of the EP-OPERATOR-COCKPIT attention-integrity items (BI-D35DE119). The self-contradiction (F2) and urgency ranking (F7) parts are tracked in the same BI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)