### PR TITLE
fix(build-studio): leaked deliberation stall no longer fails a healthy build

### DIFF
--- a/apps/web/lib/observability/watchdog-detect.test.ts
+++ b/apps/web/lib/observability/watchdog-detect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { decideStall, type WatchdogCandidate } from "./watchdog-detect";
+import { decideStall, shouldSurfaceBuildFailure, type WatchdogCandidate } from "./watchdog-detect";
 import type { ResolvedThreshold } from "./threshold-lookup";
 
 const NOW = new Date("2026-05-20T00:00:00Z");
@@ -9,7 +9,11 @@ const TH: ResolvedThreshold = {
   totalPhaseTimeoutSeconds: 900,
 };
 
-function candidate(opts: { startedAgoMs: number; heartbeatAgoMs: number | null }): WatchdogCandidate {
+function candidate(opts: {
+  startedAgoMs: number;
+  heartbeatAgoMs: number | null;
+  source?: string | null;
+}): WatchdogCandidate {
   return {
     taskRunId: "TR-X",
     buildId: "FB-X",
@@ -17,8 +21,40 @@ function candidate(opts: { startedAgoMs: number; heartbeatAgoMs: number | null }
     startedAt: new Date(NOW.getTime() - opts.startedAgoMs),
     lastHeartbeatAt:
       opts.heartbeatAgoMs === null ? null : new Date(NOW.getTime() - opts.heartbeatAgoMs),
+    source: opts.source ?? "build",
   };
 }
+
+describe("shouldSurfaceBuildFailure", () => {
+  const base = { buildId: "FB-1", phase: "build", source: "build" };
+
+  it("surfaces a build failure for the real build-execution run (source=build) in the build phase", () => {
+    expect(shouldSurfaceBuildFailure(base, true)).toBe(true);
+  });
+
+  it("does NOT fail the build when a leaked deliberation run stalls (source=proactive)", () => {
+    // The exact FB-B7BA303E regression: codex finished correct code, but a
+    // leaked "Deliberation: review" run (source=proactive, same buildId) stalled
+    // while the build was in phase=build. It must NOT mark the build failed.
+    expect(shouldSurfaceBuildFailure({ ...base, source: "proactive" }, true)).toBe(false);
+  });
+
+  it("does NOT fail the build for a null-source run", () => {
+    expect(shouldSurfaceBuildFailure({ ...base, source: null }, true)).toBe(false);
+  });
+
+  it("does NOT surface for non-build phases even for a build-source run", () => {
+    expect(shouldSurfaceBuildFailure({ ...base, phase: "ideate" }, true)).toBe(false);
+  });
+
+  it("does NOT surface when the FeatureBuild row is gone (buildId dangling)", () => {
+    expect(shouldSurfaceBuildFailure(base, false)).toBe(false);
+  });
+
+  it("does NOT surface when buildId is null", () => {
+    expect(shouldSurfaceBuildFailure({ ...base, buildId: null }, true)).toBe(false);
+  });
+});
 
 describe("decideStall", () => {
   it("returns null when heartbeat is recent and wall-clock is within budget", () => {

--- a/apps/web/lib/observability/watchdog-detect.ts
+++ b/apps/web/lib/observability/watchdog-detect.ts
@@ -16,6 +16,39 @@ export interface WatchdogCandidate {
   phase: string | null;
   startedAt: Date;
   lastHeartbeatAt: Date | null;
+  /**
+   * TaskRun.source. Distinguishes the real build-execution run (source="build")
+   * from ancillary runs that also carry a buildId — notably the "proactive"
+   * deliberation runs (design/plan review) that leak in the `working` state
+   * after the review completes. Only a stalled source="build" run may surface a
+   * build-phase FAILURE; a stalled deliberation run must not fail the build it
+   * happens to be tagged with. See taskrun-watchdog.ts stallSurface gate.
+   */
+  source: string | null;
+}
+
+/**
+ * Whether a stalled candidate may surface a build-phase FAILURE (a failed
+ * checkpoint on the FeatureBuild). True ONLY for the real build-execution
+ * TaskRun (source="build") of a build currently in the "build" phase.
+ *
+ * A leaked deliberation run (source="proactive", "Deliberation: review") carries
+ * the same buildId but is NOT the build's execution — failing the build on its
+ * stall marks a HEALTHY build failed after codegen but before commit, which is
+ * what stranded builds with correct-but-uncommitted code (the empty-diff
+ * symptom). The stalled run is still marked stalled + audited by the caller;
+ * this guard only decides whether it corrupts the build's exec state.
+ */
+export function shouldSurfaceBuildFailure(
+  candidate: Pick<WatchdogCandidate, "buildId" | "phase" | "source">,
+  hasBuildRow: boolean,
+): boolean {
+  return (
+    Boolean(candidate.buildId) &&
+    hasBuildRow &&
+    candidate.phase === "build" &&
+    candidate.source === "build"
+  );
 }
 
 export type StallReason =

--- a/apps/web/lib/queue/functions/taskrun-watchdog.ts
+++ b/apps/web/lib/queue/functions/taskrun-watchdog.ts
@@ -18,7 +18,12 @@
  */
 import { cron } from "inngest";
 import { inngest } from "../inngest-client";
-import { decideStall, type WatchdogCandidate, type StallDecision } from "@/lib/observability/watchdog-detect";
+import {
+  decideStall,
+  shouldSurfaceBuildFailure,
+  type WatchdogCandidate,
+  type StallDecision,
+} from "@/lib/observability/watchdog-detect";
 import { buildStallSurface, mergeVerificationPatch } from "@/lib/observability/stall-surface";
 import { isStallWatchdogEnabled } from "@/lib/shared/feature-flags";
 import { reapInertStuckBuilds } from "@/lib/build/inert-build-reaper";
@@ -284,7 +289,8 @@ export const taskrunWatchdog = inngest.createFunction(
              tr."buildId" AS "buildId",
              fb.phase AS "phase",
              tr."startedAt" AS "startedAt",
-             tr."lastHeartbeatAt" AS "lastHeartbeatAt"
+             tr."lastHeartbeatAt" AS "lastHeartbeatAt",
+             tr."source" AS "source"
       FROM "TaskRun" tr
       LEFT JOIN "FeatureBuild" fb ON tr."buildId" = fb."buildId"
       -- Catches both the canonical "working" state AND the legacy "active"
@@ -356,8 +362,18 @@ export const taskrunWatchdog = inngest.createFunction(
       // checkpoint + failureAxis) so the build no longer sits silently quiet —
       // the FB-69231490 symptom. Only the build phase: other phases own their
       // own recovery flows.
+      //
+      // GUARD (shouldSurfaceBuildFailure): only the actual build-execution
+      // TaskRun (source="build") may fail the build. Deliberation runs
+      // (source="proactive", "Deliberation: review") carry the same buildId and
+      // leak in the `working` state after the review passes; while the build is
+      // in phase="build" they would otherwise trip this surface and mark a
+      // HEALTHY build failed — after codegen but before commit — which stranded
+      // builds with correct-but-uncommitted code (the empty-diff symptom). The
+      // stalled deliberation run is still marked stalled + audited below; it
+      // just no longer corrupts the build's exec state.
       const stallSurface =
-        d.candidate.buildId && buildRow && d.candidate.phase === "build"
+        buildRow && shouldSurfaceBuildFailure(d.candidate, true)
           ? buildStallSurface({
               reason: d.reason as import("@/lib/observability/stall-surface").StallReason,
               phase: d.candidate.phase,


### PR DESCRIPTION
## The bug behind "months of no successful builds"

Build Studio's pipeline actually works — but nearly every build died with an **empty diff / "build went quiet"**. Root cause, observed live on **FB-B7BA303E** ("greet operator by first name"):

1. Ideate → design doc ✅ (codex), plan → 4-task TDD plan ✅, build → **codex wrote correct, tested code** (14 generated tests passing) ✅
2. The **only** build-phase TaskRuns were two `Deliberation: review` runs (`source="proactive"`) that the deliberation orchestrator **leaks in the `working` state** after review passes — they heartbeat once at start, then go silent.
3. The stall watchdog surfaces a build **FAILURE** for *any* `buildId`-tagged TaskRun that stalls while the build is in `phase="build"` ([taskrun-watchdog.ts:360](apps/web/lib/queue/functions/taskrun-watchdog.ts)) — so a leaked deliberation run marked the **healthy** build's `buildExecState` failed **after codegen but before commit**.
4. Result: correct code left uncommitted → empty diff → deploy refused ("working tree dirty").

## Fix

Only the real build-execution TaskRun (`source="build"`, written by [build-execute-helpers.ts:104](apps/web/lib/integrate/build-execute-helpers.ts)) may surface a build-phase failure. A stalled deliberation run is still marked stalled + audited (StallEvent + BuildActivity) — it just no longer corrupts the build's exec state.

- Added `source` to the watchdog candidate (SQL `SELECT` + `WatchdogCandidate`).
- Extracted the guard into a pure `shouldSurfaceBuildFailure()` with **6 regression tests**, including the exact deliberation-source case.

## Verification

- `vitest run lib/observability/watchdog-detect.test.ts` — **12 passed** (6 new + 6 existing), run on `main` in the sandbox toolchain.

## Follow-up (separate)

The deliberation orchestrator should also settle its bootstrap TaskRun instead of leaking it (existing BI *"Deliberation orchestrator leaks its bootstrap TaskRun (never settled)"*). This fix makes builds robust to the leak either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)