### PR TITLE
feat(hive): govern seed contribution fit and merge eligibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,32 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: node scripts/check-ux-fit-decision.mjs
 
+  seed-fit-gate:
+    name: Seed Contribution Fit Gate
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    # Canonical seed sources are fleet defaults, so a PR that changes them must
+    # carry one reviewed applicability decision. The gate reads evidence from
+    # the PR body/labels and the changed paths; it does not trust contributor
+    # provenance or infer approval from a successful build.
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+      - name: Test seed-fit decision contract
+        run: node --test scripts/check-seed-fit-decision.test.mjs
+      - name: Enforce seed-fit evidence
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: node scripts/check-seed-fit-decision.mjs
+
   spec-plan-doc-gate:
     name: Spec/Plan/Doc Gate
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels) }}
         run: node scripts/check-seed-fit-decision.mjs
 
   spec-plan-doc-gate:

--- a/apps/web/app/(shell)/admin/hive/page.tsx
+++ b/apps/web/app/(shell)/admin/hive/page.tsx
@@ -1,13 +1,15 @@
 import { AdminTabNav } from "@/components/admin/AdminTabNav";
 import { HiveContributionsPanel } from "@/components/admin/HiveContributionsPanel";
+import { SeedContributionReviewTable } from "@/components/admin/SeedContributionReviewTable";
+import { StatusBadge, type Intent } from "@/components/ui/report-kit";
 import { getHiveContributionsView } from "@/lib/actions/hive-contributions";
 
-const STATUS_COLORS: Record<string, string> = {
-  submitted: "var(--dpf-muted)",
-  curating: "var(--dpf-accent)",
-  accepted: "var(--dpf-success, #15803d)",
-  rejected: "var(--dpf-warning, #b45309)",
-  withdrawn: "var(--dpf-muted)",
+const STATUS_INTENTS: Record<string, Intent> = {
+  submitted: "neutral",
+  curating: "accent",
+  accepted: "success",
+  rejected: "warning",
+  withdrawn: "neutral",
 };
 
 export default async function AdminHiveContributionsPage() {
@@ -46,6 +48,15 @@ export default async function AdminHiveContributionsPage() {
         </section>
 
         <section>
+          <h2 className="text-lg font-semibold text-[var(--dpf-text)] mb-1">Seed contribution review</h2>
+          <p className="text-sm text-[var(--dpf-muted)] mb-3">
+            Seed changes are approved only for the installs, archetypes, or business verticals they actually fit.
+            Local defaults and changes that still need parameterization cannot become fleet defaults.
+          </p>
+          <SeedContributionReviewTable rows={view.seedReviews} />
+        </section>
+
+        <section>
           <h2 className="text-lg font-semibold text-[var(--dpf-text)] mb-1">Contribution ledger</h2>
           <p className="text-sm text-[var(--dpf-muted)] mb-3">
             What was shared, when, and its curation status.
@@ -75,8 +86,13 @@ export default async function AdminHiveContributionsPage() {
                       <td className="px-3 py-2 text-[var(--dpf-text)] whitespace-nowrap">{e.contributionType}</td>
                       <td className="px-3 py-2 text-[var(--dpf-text)]">{e.summary}</td>
                       <td className="px-3 py-2 text-[var(--dpf-muted)] whitespace-nowrap">{e.redactionStatus ?? "—"}</td>
-                      <td className="px-3 py-2 whitespace-nowrap" style={{ color: STATUS_COLORS[e.status] ?? "var(--dpf-muted)" }}>
-                        {e.status}
+                      <td className="px-3 py-2 whitespace-nowrap">
+                        <StatusBadge
+                          intent={STATUS_INTENTS[e.status] ?? "neutral"}
+                          label={e.status}
+                          uppercase={false}
+                          variant="soft"
+                        />
                       </td>
                       <td className="px-3 py-2 text-[var(--dpf-muted)] whitespace-nowrap">
                         {new Date(e.createdAt).toLocaleDateString()}

--- a/apps/web/components/admin/SeedContributionReviewTable.test.tsx
+++ b/apps/web/components/admin/SeedContributionReviewTable.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { SeedContributionReviewTable } from "./SeedContributionReviewTable";
+
+describe("SeedContributionReviewTable", () => {
+  it("renders the governed decision, scope, rationale, and PR", () => {
+    const html = renderToStaticMarkup(<SeedContributionReviewTable rows={[{
+      packId: "FP-1",
+      title: "Shared banking defaults",
+      decision: "vertical-scoped",
+      distributionScope: "vertical-scoped",
+      applicableScope: ["banking-financial-services"],
+      mergeEligible: true,
+      mergeReadiness: "ready",
+      changedSeedPaths: ["packages/db/src/seed-banking-compliance.ts"],
+      rationale: "Limited to the reviewed financial-services vertical.",
+      prUrl: "https://github.com/example/repo/pull/42",
+      prNumber: 42,
+      reviewedAt: "2026-07-11T00:00:00.000Z",
+    }]} />);
+
+    expect(html).toContain("Shared banking defaults");
+    expect(html).toContain("Vertical scoped");
+    expect(html).toContain("banking-financial-services");
+    expect(html).toContain("Limited to the reviewed financial-services vertical.");
+    expect(html).toContain("PR #42");
+  });
+
+  it("renders an honest empty state", () => {
+    const html = renderToStaticMarkup(<SeedContributionReviewTable rows={[]} />);
+    expect(html).toContain("No seed-changing contributions have been reviewed yet");
+  });
+});

--- a/apps/web/components/admin/SeedContributionReviewTable.tsx
+++ b/apps/web/components/admin/SeedContributionReviewTable.tsx
@@ -6,7 +6,6 @@ import {
   EmptyState,
   StatusBadge,
   type Column,
-  type Intent,
 } from "@/components/ui/report-kit";
 
 const DECISION_LABELS: Record<string, string> = {
@@ -16,15 +15,6 @@ const DECISION_LABELS: Record<string, string> = {
   "parameterize-first": "Parameterize first",
   "install-local-only": "Install local only",
   "reject-as-seed": "Reject as seed",
-};
-
-const DECISION_INTENTS: Record<string, Intent> = {
-  "global-default": "success",
-  "archetype-scoped": "accent",
-  "vertical-scoped": "info",
-  "parameterize-first": "warning",
-  "install-local-only": "neutral",
-  "reject-as-seed": "danger",
 };
 
 function scopeLabel(row: SeedContributionReviewRow): string {
@@ -51,7 +41,8 @@ const columns: Column<SeedContributionReviewRow>[] = [
     header: "Seed fit",
     cell: (row) => row.decision ? (
       <StatusBadge
-        intent={DECISION_INTENTS[row.decision] ?? "warning"}
+        domain="seedContributionFit"
+        status={row.decision}
         label={DECISION_LABELS[row.decision] ?? row.decision}
         uppercase={false}
         variant="soft"

--- a/apps/web/components/admin/SeedContributionReviewTable.tsx
+++ b/apps/web/components/admin/SeedContributionReviewTable.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import type { SeedContributionReviewRow } from "@/lib/actions/hive-contributions";
+import {
+  DataTable,
+  EmptyState,
+  StatusBadge,
+  type Column,
+  type Intent,
+} from "@/components/ui/report-kit";
+
+const DECISION_LABELS: Record<string, string> = {
+  "global-default": "Global default",
+  "archetype-scoped": "Archetype scoped",
+  "vertical-scoped": "Vertical scoped",
+  "parameterize-first": "Parameterize first",
+  "install-local-only": "Install local only",
+  "reject-as-seed": "Reject as seed",
+};
+
+const DECISION_INTENTS: Record<string, Intent> = {
+  "global-default": "success",
+  "archetype-scoped": "accent",
+  "vertical-scoped": "info",
+  "parameterize-first": "warning",
+  "install-local-only": "neutral",
+  "reject-as-seed": "danger",
+};
+
+function scopeLabel(row: SeedContributionReviewRow): string {
+  if (row.decision === "global-default") return "All installs";
+  if (row.applicableScope.length > 0) return row.applicableScope.join(", ");
+  if (row.decision === "install-local-only") return "Contributing install";
+  return "Not approved for distribution";
+}
+
+const columns: Column<SeedContributionReviewRow>[] = [
+  {
+    key: "contribution",
+    header: "Contribution",
+    cell: (row) => (
+      <div className="min-w-40">
+        <p className="font-medium text-[var(--dpf-text)]">{row.title}</p>
+        <p className="font-mono text-[10px] text-[var(--dpf-muted)]">{row.packId}</p>
+      </div>
+    ),
+    sortAccessor: (row) => row.title,
+  },
+  {
+    key: "decision",
+    header: "Seed fit",
+    cell: (row) => row.decision ? (
+      <StatusBadge
+        intent={DECISION_INTENTS[row.decision] ?? "warning"}
+        label={DECISION_LABELS[row.decision] ?? row.decision}
+        uppercase={false}
+        variant="soft"
+      />
+    ) : (
+      <StatusBadge intent="warning" label="Review required" uppercase={false} variant="soft" />
+    ),
+    sortAccessor: (row) => row.decision ?? "review-required",
+  },
+  {
+    key: "scope",
+    header: "Applies to",
+    cell: (row) => <span className="text-[var(--dpf-text)]">{scopeLabel(row)}</span>,
+  },
+  {
+    key: "paths",
+    header: "Seed paths",
+    cell: (row) => (
+      <span className="text-[var(--dpf-text)]" title={row.changedSeedPaths.join("\n")}>
+        {row.changedSeedPaths.length}
+      </span>
+    ),
+    align: "right",
+    sortAccessor: (row) => row.changedSeedPaths.length,
+  },
+  {
+    key: "rationale",
+    header: "Why",
+    cell: (row) => <p className="max-w-md text-[var(--dpf-muted)]">{row.rationale}</p>,
+  },
+  {
+    key: "reviewed",
+    header: "Reviewed",
+    cell: (row) => (
+      <div className="whitespace-nowrap text-[var(--dpf-muted)]">
+        <p>{new Date(row.reviewedAt).toLocaleDateString()}</p>
+        {row.prUrl && row.prNumber ? (
+          <a
+            href={row.prUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-[var(--dpf-accent)] hover:underline"
+          >
+            PR #{row.prNumber}
+          </a>
+        ) : null}
+      </div>
+    ),
+    sortAccessor: (row) => row.reviewedAt,
+  },
+];
+
+export function SeedContributionReviewTable({ rows }: { rows: SeedContributionReviewRow[] }) {
+  return (
+    <div className="overflow-x-auto rounded border border-[var(--dpf-border)]">
+      <DataTable
+        columns={columns}
+        rows={rows}
+        getRowKey={(row) => row.packId}
+        initialSort={{ key: "reviewed", dir: "desc" }}
+        pageSize={20}
+        empty={(
+          <EmptyState
+            title="No seed-changing contributions have been reviewed yet"
+            description="Seed applicability decisions will appear here before a contribution can become a fleet default."
+            size="sm"
+            bordered={false}
+          />
+        )}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -440,6 +440,15 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     high: "warning",
     critical: "danger",
   },
+  // Hive contribution applicability for canonical seeded content.
+  seedContributionFit: {
+    "global-default": "success",
+    "archetype-scoped": "accent",
+    "vertical-scoped": "info",
+    "parameterize-first": "warning",
+    "install-local-only": "neutral",
+    "reject-as-seed": "danger",
+  },
 };
 
 /**

--- a/apps/web/lib/actions/hive-contributions.test.ts
+++ b/apps/web/lib/actions/hive-contributions.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  platformDevConfigFindUnique,
+  hiveContributionLedgerFindMany,
+  featurePackFindMany,
+} = vi.hoisted(() => ({
+  platformDevConfigFindUnique: vi.fn(),
+  hiveContributionLedgerFindMany: vi.fn(),
+  featurePackFindMany: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    platformDevConfig: { findUnique: platformDevConfigFindUnique, upsert: vi.fn() },
+    hiveContributionLedger: { findMany: hiveContributionLedgerFindMany },
+    featurePack: { findMany: featurePackFindMany },
+  },
+  resolveHiveContributionStatuses: vi.fn(() => []),
+}));
+
+vi.mock("@/lib/actions/shared/guards", () => ({ requireCapability: vi.fn() }));
+vi.mock("@/lib/integrate/identity-privacy", () => ({
+  getDisplayPseudonym: vi.fn(async () => "contributor-123"),
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { getHiveContributionsView } from "./hive-contributions";
+
+describe("getHiveContributionsView seed reviews", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    platformDevConfigFindUnique.mockResolvedValue(null);
+    hiveContributionLedgerFindMany.mockResolvedValue([]);
+  });
+
+  it("maps reviewed seed-fit evidence from FeaturePack.reviewReport", async () => {
+    featurePackFindMany.mockResolvedValue([{ 
+      packId: "FP-1",
+      title: "Shared banking defaults",
+      prUrl: "https://github.com/example/repo/pull/42",
+      prNumber: 42,
+      mergeReadiness: "ready",
+      reviewedAt: new Date("2026-07-11T00:00:00.000Z"),
+      manifest: { files: ["packages/db/src/seed-banking-compliance.ts"] },
+      reviewReport: {
+        seedFit: {
+          touchesSeededContent: true,
+          changedSeedPaths: ["packages/db/src/seed-banking-compliance.ts"],
+          decision: "vertical-scoped",
+          distributionScope: "vertical-scoped",
+          applicableArchetypeCategories: [],
+          applicableVerticals: ["banking-financial-services"],
+          sourceVertical: "banking-financial-services",
+          rationale: "Limited to the reviewed financial-services vertical.",
+          mergeEligible: true,
+        },
+      },
+    }]);
+
+    const view = await getHiveContributionsView();
+
+    expect(view.seedReviews).toEqual([{
+      packId: "FP-1",
+      title: "Shared banking defaults",
+      decision: "vertical-scoped",
+      distributionScope: "vertical-scoped",
+      applicableScope: ["banking-financial-services"],
+      mergeEligible: true,
+      mergeReadiness: "ready",
+      changedSeedPaths: ["packages/db/src/seed-banking-compliance.ts"],
+      rationale: "Limited to the reviewed financial-services vertical.",
+      prUrl: "https://github.com/example/repo/pull/42",
+      prNumber: 42,
+      reviewedAt: "2026-07-11T00:00:00.000Z",
+    }]);
+  });
+
+  it("shows legacy seed-changing packs as requiring review", async () => {
+    featurePackFindMany.mockResolvedValue([{
+      packId: "FP-OLD",
+      title: "Legacy prompt update",
+      prUrl: null,
+      prNumber: null,
+      mergeReadiness: "ready",
+      reviewedAt: new Date("2026-06-01T00:00:00.000Z"),
+      manifest: { files: ["prompts/reviewer/code-review.prompt.md"] },
+      reviewReport: { mergeReadiness: "ready" },
+    }]);
+
+    const view = await getHiveContributionsView();
+
+    expect(view.seedReviews[0]).toMatchObject({
+      packId: "FP-OLD",
+      decision: null,
+      mergeEligible: false,
+      changedSeedPaths: ["prompts/reviewer/code-review.prompt.md"],
+      rationale: "Seed-fit evidence is unavailable; review is required.",
+    });
+  });
+});

--- a/apps/web/lib/actions/hive-contributions.test.ts
+++ b/apps/web/lib/actions/hive-contributions.test.ts
@@ -35,7 +35,7 @@ describe("getHiveContributionsView seed reviews", () => {
   });
 
   it("maps reviewed seed-fit evidence from FeaturePack.reviewReport", async () => {
-    featurePackFindMany.mockResolvedValue([{ 
+    featurePackFindMany.mockResolvedValue([{
       packId: "FP-1",
       title: "Shared banking defaults",
       prUrl: "https://github.com/example/repo/pull/42",

--- a/apps/web/lib/actions/hive-contributions.ts
+++ b/apps/web/lib/actions/hive-contributions.ts
@@ -8,6 +8,12 @@ import {
 } from "@dpf/db";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import { getDisplayPseudonym } from "@/lib/integrate/identity-privacy";
+import {
+  findCanonicalSeedContentPaths,
+  SEED_CONTRIBUTION_FIT_DECISIONS,
+  type SeedContributionFitDecision,
+  type SeedDistributionScope,
+} from "@/lib/integrate/seed-contribution-fit";
 import { revalidatePath } from "next/cache";
 
 async function requireManagePlatform(): Promise<string> {
@@ -36,7 +42,96 @@ export type HiveContributionsView = {
     redactionStatus: string | null;
     createdAt: string;
   }>;
+  seedReviews: SeedContributionReviewRow[];
 };
+
+export type SeedContributionReviewRow = {
+  packId: string;
+  title: string;
+  decision: SeedContributionFitDecision | null;
+  distributionScope: SeedDistributionScope | null;
+  applicableScope: string[];
+  mergeEligible: boolean;
+  mergeReadiness: string | null;
+  changedSeedPaths: string[];
+  rationale: string;
+  prUrl: string | null;
+  prNumber: number | null;
+  reviewedAt: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+const seedFitDecisions = new Set<string>(SEED_CONTRIBUTION_FIT_DECISIONS);
+const distributionScopes = new Set<string>(["global-default", "archetype-scoped", "vertical-scoped"]);
+
+function toSeedReview(row: {
+  packId: string;
+  title: string;
+  prUrl: string | null;
+  prNumber: number | null;
+  mergeReadiness: string | null;
+  reviewedAt: Date | null;
+  manifest: unknown;
+  reviewReport: unknown;
+}): SeedContributionReviewRow | null {
+  if (!row.reviewedAt) return null;
+
+  const manifest = asRecord(row.manifest);
+  const report = asRecord(row.reviewReport);
+  const seedFit = asRecord(report?.seedFit);
+  const manifestPaths = [
+    ...stringArray(manifest?.files),
+    ...stringArray(manifest?.migrations),
+    ...stringArray(manifest?.schemaChanges),
+  ];
+  const reviewedPaths = stringArray(seedFit?.changedSeedPaths);
+  const changedSeedPaths = reviewedPaths.length > 0
+    ? findCanonicalSeedContentPaths(reviewedPaths)
+    : findCanonicalSeedContentPaths(manifestPaths);
+  if (changedSeedPaths.length === 0) return null;
+
+  const rawDecision = typeof seedFit?.decision === "string" ? seedFit.decision : null;
+  const decision = rawDecision && seedFitDecisions.has(rawDecision)
+    ? rawDecision as SeedContributionFitDecision
+    : null;
+  const rawDistributionScope = typeof seedFit?.distributionScope === "string"
+    ? seedFit.distributionScope
+    : null;
+  const distributionScope = rawDistributionScope && distributionScopes.has(rawDistributionScope)
+    ? rawDistributionScope as SeedDistributionScope
+    : null;
+  const applicableScope = decision === "archetype-scoped"
+    ? stringArray(seedFit?.applicableArchetypeCategories)
+    : decision === "vertical-scoped"
+      ? stringArray(seedFit?.applicableVerticals)
+      : [];
+
+  return {
+    packId: row.packId,
+    title: row.title,
+    decision,
+    distributionScope,
+    applicableScope,
+    mergeEligible: decision !== null && seedFit?.mergeEligible === true,
+    mergeReadiness: row.mergeReadiness,
+    changedSeedPaths,
+    rationale: typeof seedFit?.rationale === "string"
+      ? seedFit.rationale
+      : "Seed-fit evidence is unavailable; review is required.",
+    prUrl: row.prUrl,
+    prNumber: row.prNumber,
+    reviewedAt: row.reviewedAt.toISOString(),
+  };
+}
 
 export async function getHiveContributionsView(): Promise<HiveContributionsView> {
   const row = await prisma.platformDevConfig.findUnique({
@@ -51,10 +146,27 @@ export async function getHiveContributionsView(): Promise<HiveContributionsView>
 
   const contributor = await getDisplayPseudonym().catch(() => null);
 
-  const ledgerRows = await prisma.hiveContributionLedger.findMany({
-    orderBy: { createdAt: "desc" },
-    take: 50,
-  });
+  const [ledgerRows, featurePacks] = await Promise.all([
+    prisma.hiveContributionLedger.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 50,
+    }),
+    prisma.featurePack.findMany({
+      where: { reviewedAt: { not: null } },
+      orderBy: { reviewedAt: "desc" },
+      take: 50,
+      select: {
+        packId: true,
+        title: true,
+        prUrl: true,
+        prNumber: true,
+        mergeReadiness: true,
+        reviewedAt: true,
+        manifest: true,
+        reviewReport: true,
+      },
+    }),
+  ]);
 
   type LedgerRow = {
     id: string;
@@ -81,6 +193,7 @@ export async function getHiveContributionsView(): Promise<HiveContributionsView>
       redactionStatus: r.redactionStatus,
       createdAt: r.createdAt.toISOString(),
     })),
+    seedReviews: featurePacks.map(toSeedReview).filter((row): row is SeedContributionReviewRow => row !== null),
   };
 }
 

--- a/apps/web/lib/integrate/contribution-review.test.ts
+++ b/apps/web/lib/integrate/contribution-review.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  determineContributionMergeReadiness,
+  generateReviewReport,
+  type ParameterizationReport,
+  type SanitizationReport,
+  type VerticalReport,
+} from "./contribution-review";
+import type { SeedContributionFitReport } from "./seed-contribution-fit";
+
+const sanitization: SanitizationReport = {
+  passed: true,
+  findings: [],
+  orgName: "",
+  mustFixCount: 0,
+  reviewCount: 0,
+};
+const parameterization: ParameterizationReport = {
+  scope: "already_generic",
+  checks: [],
+  overallVerdict: "pass",
+};
+const verticals: VerticalReport = {
+  sourceVertical: "unknown",
+  applicableVerticals: [],
+};
+
+function seedFit(
+  decision: SeedContributionFitReport["decision"],
+  mergeEligible: boolean,
+): SeedContributionFitReport {
+  return {
+    touchesSeededContent: decision !== null,
+    changedSeedPaths: decision ? ["packages/db/src/seed-skills.ts"] : [],
+    decision,
+    distributionScope: mergeEligible && decision !== "parameterize-first" && decision !== "install-local-only" && decision !== "reject-as-seed"
+      ? decision
+      : null,
+    applicableArchetypeCategories: [],
+    applicableVerticals: [],
+    sourceVertical: "unknown",
+    rationale: "Reviewed seed-fit rationale.",
+    mergeEligible,
+  };
+}
+
+describe("determineContributionMergeReadiness", () => {
+  it("allows reviewed fleet or scoped seed distributions", () => {
+    expect(determineContributionMergeReadiness({
+      securityPassed: true,
+      sanitization,
+      parameterization,
+      seedFit: seedFit("global-default", true),
+    })).toBe("ready");
+  });
+
+  it("requires work for parameterize-first and install-local-only seed changes", () => {
+    for (const decision of ["parameterize-first", "install-local-only"] as const) {
+      expect(determineContributionMergeReadiness({
+        securityPassed: true,
+        sanitization,
+        parameterization,
+        seedFit: seedFit(decision, false),
+      })).toBe("needs-work");
+    }
+  });
+
+  it("blocks rejected or security-failing seed changes", () => {
+    expect(determineContributionMergeReadiness({
+      securityPassed: true,
+      sanitization,
+      parameterization,
+      seedFit: seedFit("reject-as-seed", false),
+    })).toBe("blocked");
+    expect(determineContributionMergeReadiness({
+      securityPassed: false,
+      sanitization,
+      parameterization,
+      seedFit: seedFit("global-default", true),
+    })).toBe("blocked");
+  });
+});
+
+describe("generateReviewReport seed fit", () => {
+  it("makes the decision and affected seed path visible in the PR review", () => {
+    const report = generateReviewReport(
+      sanitization,
+      parameterization,
+      verticals,
+      seedFit("global-default", true),
+      true,
+      {},
+      "ready",
+    );
+
+    expect(report).toContain("### Seed Contribution Fit");
+    expect(report).toContain("**global-default**");
+    expect(report).toContain("`packages/db/src/seed-skills.ts`");
+    expect(report).toContain("`seed-fit:global-default`");
+  });
+});

--- a/apps/web/lib/integrate/contribution-review.ts
+++ b/apps/web/lib/integrate/contribution-review.ts
@@ -22,8 +22,6 @@ import {
   type SeedContributionFitReport,
 } from "./seed-contribution-fit";
 
-export { evaluateSeedContributionFit };
-
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type SanitizationFinding = {
@@ -67,6 +65,12 @@ export type VerticalApplicability = {
 export type VerticalReport = {
   sourceVertical: string;
   applicableVerticals: VerticalApplicability[];
+};
+
+type ReusabilityAnalysis = {
+  scope?: string;
+  domainEntities?: Array<{ hardcodedValue: string; parameterName: string }>;
+  contributionReadiness?: string;
 };
 
 export type MergeReadiness = "ready" | "needs-work" | "blocked";
@@ -577,6 +581,28 @@ async function setCommitStatus(
 
 // ─── Main Entry Point ───────────────────────────────────────────────────────
 
+export async function analyzeContributionSeedFit(
+  diff: string,
+  brief: Record<string, unknown> | null,
+  designDocValue: unknown,
+) {
+  const designDoc = designDocValue as Record<string, unknown> | null;
+  const reusability = designDoc?.reusabilityAnalysis as ReusabilityAnalysis | null;
+  const sanitization = await runSanitizationScan(diff);
+  const parameterization = verifyParameterization(diff, reusability);
+  const verticals = await tagBusinessVerticals(brief, diff);
+  const securityScan = scanDiffForSecurityIssues(diff);
+  const allFiles = [...diff.matchAll(/^diff --git a\/(.+) b\/.+$/gm)].map((match) => match[1]);
+  const seedFit = evaluateSeedContributionFit({
+    changedFiles: allFiles,
+    sanitization,
+    parameterization,
+    verticals,
+    securityPassed: securityScan.passed,
+  });
+  return { allFiles, sanitization, parameterization, verticals, securityScan, seedFit };
+}
+
 export async function runContributionReview(input: ReviewInput): Promise<ContributionReviewResult> {
   const { buildId, prUrl, prNumber, repoOwner, repoName, token, diff } = input;
 
@@ -597,35 +623,8 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
   });
 
   const brief = build?.brief as Record<string, unknown> | null;
-  const designDoc = build?.designDoc as Record<string, unknown> | null;
-  const reusability = designDoc?.reusabilityAnalysis as {
-    scope?: string;
-    domainEntities?: Array<{ hardcodedValue: string; parameterName: string }>;
-    contributionReadiness?: string;
-  } | null;
-
-  // Step 1: Sanitization scan
-  const sanitization = await runSanitizationScan(diff);
-
-  // Step 2: Parameterization verification
-  const parameterization = verifyParameterization(diff, reusability);
-
-  // Step 3: Business vertical tagging
-  const verticals = await tagBusinessVerticals(brief, diff);
-
-  // Security scan (reuse existing)
-  const securityResult = scanDiffForSecurityIssues(diff);
-
-  // Step 4: Seed contribution fit. This is derived from the evidence above,
-  // never from the contributor's desired outcome.
-  const changedFiles = [...diff.matchAll(/^diff --git a\/(.+) b\/.+$/gm)].map((match) => match[1]);
-  const seedFit = evaluateSeedContributionFit({
-    changedFiles,
-    sanitization,
-    parameterization,
-    verticals,
-    securityPassed: securityResult.passed,
-  });
+  const { sanitization, parameterization, verticals, securityScan, seedFit } =
+    await analyzeContributionSeedFit(diff, brief, build?.designDoc);
 
   // Build evidence chain
   const evidenceChain: Record<string, string> = {};
@@ -649,7 +648,7 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
 
   // Determine merge readiness
   const mergeReadiness = determineContributionMergeReadiness({
-    securityPassed: securityResult.passed,
+    securityPassed: securityScan.passed,
     sanitization,
     parameterization,
     seedFit,
@@ -659,7 +658,7 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
   const reportMarkdown = generateReviewReport(
     sanitization, parameterization, verticals,
     seedFit,
-    securityResult.passed, evidenceChain, mergeReadiness,
+    securityScan.passed, evidenceChain, mergeReadiness,
   );
 
   // Step 5: Post PR comment
@@ -677,7 +676,7 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
     labels.push(...primary.map((v) => `vertical:${v.category}`));
     labels.push(...applicable.map((v) => `vertical:${v.category}`));
     labels.push(mergeReadiness === "ready" ? "merge-ready" : mergeReadiness === "needs-work" ? "needs-work" : "blocked");
-    if (!securityResult.passed) labels.push("security-review-needed");
+    if (!securityScan.passed) labels.push("security-review-needed");
     if (seedFit.decision) labels.push(`seed-fit:${seedFit.decision}`);
     await setPRLabels(repoOwner, repoName, prNumber, labels, token);
   } catch (err) {
@@ -722,7 +721,7 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
     parameterization,
     verticals,
     seedFit,
-    securityPassed: securityResult.passed,
+    securityPassed: securityScan.passed,
     evidenceChain,
     reviewedAt,
   };

--- a/apps/web/lib/integrate/contribution-review.ts
+++ b/apps/web/lib/integrate/contribution-review.ts
@@ -15,6 +15,12 @@
 
 import { prisma } from "@dpf/db";
 import { scanDiffForSecurityIssues } from "./security-scan";
+import {
+  buildContributionSeedDeltaManifest,
+  evaluateSeedContributionFit,
+  formatSeedContributionFitMarkdown,
+  type SeedContributionFitReport,
+} from "./seed-contribution-fit";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -68,10 +74,27 @@ export type ContributionReviewResult = {
   sanitization: SanitizationReport;
   parameterization: ParameterizationReport;
   verticals: VerticalReport;
+  seedFit: SeedContributionFitReport;
   securityPassed: boolean;
   evidenceChain: Record<string, string>;
   reviewedAt: string;
 };
+
+export function determineContributionMergeReadiness(input: {
+  securityPassed: boolean;
+  sanitization: SanitizationReport;
+  parameterization: ParameterizationReport;
+  seedFit: SeedContributionFitReport;
+}): MergeReadiness {
+  if (!input.securityPassed) return "blocked";
+  if (!input.sanitization.passed || input.parameterization.overallVerdict === "fail") {
+    return "needs-work";
+  }
+  if (input.seedFit.touchesSeededContent && !input.seedFit.mergeEligible) {
+    return input.seedFit.decision === "reject-as-seed" ? "blocked" : "needs-work";
+  }
+  return "ready";
+}
 
 type ReviewInput = {
   buildId: string;
@@ -367,6 +390,7 @@ export function generateReviewReport(
   sanitization: SanitizationReport,
   parameterization: ParameterizationReport,
   verticals: VerticalReport,
+  seedFit: SeedContributionFitReport,
   securityPassed: boolean,
   evidenceChain: Record<string, string>,
   mergeReadiness: MergeReadiness,
@@ -405,6 +429,8 @@ export function generateReviewReport(
     }
   }
   sections.push("");
+
+  sections.push(...formatSeedContributionFitMarkdown(seedFit));
 
   // Parameterization
   sections.push("### Parameterization");
@@ -462,6 +488,7 @@ export function generateReviewReport(
   if (applicable.length > 0) labels.push(...applicable.map((v) => `vertical:${v.category}`));
   labels.push(mergeReadiness === "ready" ? "merge-ready" : mergeReadiness === "needs-work" ? "needs-work" : "blocked");
   if (parameterization.scope !== "one_off") labels.push(`reuse:${parameterization.scope}`);
+  if (seedFit.decision) labels.push(`seed-fit:${seedFit.decision}`);
 
   sections.push("### Suggested Labels");
   sections.push("");
@@ -555,6 +582,7 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
   const build = await prisma.featureBuild.findUnique({
     where: { buildId },
     select: {
+      id: true,
       title: true,
       brief: true,
       designDoc: true,
@@ -586,6 +614,17 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
   // Security scan (reuse existing)
   const securityResult = scanDiffForSecurityIssues(diff);
 
+  // Step 4: Seed contribution fit. This is derived from the evidence above,
+  // never from the contributor's desired outcome.
+  const changedFiles = [...diff.matchAll(/^diff --git a\/(.+) b\/.+$/gm)].map((match) => match[1]);
+  const seedFit = evaluateSeedContributionFit({
+    changedFiles,
+    sanitization,
+    parameterization,
+    verticals,
+    securityPassed: securityResult.passed,
+  });
+
   // Build evidence chain
   const evidenceChain: Record<string, string> = {};
   if (build?.designReview) {
@@ -607,18 +646,17 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
   }
 
   // Determine merge readiness
-  let mergeReadiness: MergeReadiness;
-  if (!securityResult.passed) {
-    mergeReadiness = "blocked";
-  } else if (!sanitization.passed || parameterization.overallVerdict === "fail") {
-    mergeReadiness = "needs-work";
-  } else {
-    mergeReadiness = "ready";
-  }
+  const mergeReadiness = determineContributionMergeReadiness({
+    securityPassed: securityResult.passed,
+    sanitization,
+    parameterization,
+    seedFit,
+  });
 
   // Step 4: Generate report
   const reportMarkdown = generateReviewReport(
     sanitization, parameterization, verticals,
+    seedFit,
     securityResult.passed, evidenceChain, mergeReadiness,
   );
 
@@ -638,6 +676,7 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
     labels.push(...applicable.map((v) => `vertical:${v.category}`));
     labels.push(mergeReadiness === "ready" ? "merge-ready" : mergeReadiness === "needs-work" ? "needs-work" : "blocked");
     if (!securityResult.passed) labels.push("security-review-needed");
+    if (seedFit.decision) labels.push(`seed-fit:${seedFit.decision}`);
     await setPRLabels(repoOwner, repoName, prNumber, labels, token);
   } catch (err) {
     console.warn("[contribution-review] Failed to set PR labels:", err);
@@ -662,7 +701,9 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
           : mergeReadiness === "needs-work" ? "failure" as const
           : "failure" as const;
         const statusDesc = mergeReadiness === "ready"
-          ? "Contribution review passed"
+          ? seedFit.decision
+            ? `Contribution review passed; seed fit: ${seedFit.decision}`
+            : "Contribution review passed"
           : `Contribution review: ${mergeReadiness}`;
         await setCommitStatus(repoOwner, repoName, commitSha, statusState, statusDesc, token);
       }
@@ -672,14 +713,16 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
   }
 
   // Step 7: Update FeaturePack
+  const reviewedAt = new Date().toISOString();
   const reviewResult: ContributionReviewResult = {
     mergeReadiness,
     sanitization,
     parameterization,
     verticals,
+    seedFit,
     securityPassed: securityResult.passed,
     evidenceChain,
-    reviewedAt: new Date().toISOString(),
+    reviewedAt,
   };
 
   try {
@@ -687,8 +730,28 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
     const applicable = verticals.applicableVerticals.filter((v) => v.relevance === "applicable");
     const allVerticals = [...primary, ...applicable].map((v) => v.category);
 
-    await prisma.featurePack.updateMany({
-      where: { buildId: build ? (await prisma.featureBuild.findUnique({ where: { buildId }, select: { id: true } }))?.id : undefined },
+    const pack = build ? await prisma.featurePack.findFirst({
+      where: { buildId: build.id },
+      orderBy: { createdAt: "desc" },
+      select: { packId: true, manifest: true },
+    }) : null;
+    if (!pack) return reviewResult;
+
+    const manifest = pack.manifest && typeof pack.manifest === "object" && !Array.isArray(pack.manifest)
+      ? pack.manifest as Record<string, unknown>
+      : {};
+    const seedDeltaManifest = seedFit.touchesSeededContent
+      ? buildContributionSeedDeltaManifest(seedFit, {
+        packId: pack.packId,
+        buildId,
+        prNumber,
+        prUrl,
+        reviewedAt,
+      })
+      : null;
+
+    await prisma.featurePack.update({
+      where: { packId: pack.packId },
       data: {
         mergeReadiness,
         applicableVerticals: allVerticals,
@@ -696,8 +759,12 @@ export async function runContributionReview(input: ReviewInput): Promise<Contrib
         reusabilityScope: parameterization.scope,
         prUrl,
         prNumber,
+        manifest: {
+          ...manifest,
+          seedDeltaManifest,
+        } as unknown as import("@dpf/db").Prisma.InputJsonValue,
         reviewReport: reviewResult as unknown as import("@dpf/db").Prisma.InputJsonValue,
-        reviewedAt: new Date(),
+        reviewedAt: new Date(reviewedAt),
       },
     });
   } catch (err) {

--- a/apps/web/lib/integrate/contribution-review.ts
+++ b/apps/web/lib/integrate/contribution-review.ts
@@ -22,6 +22,8 @@ import {
   type SeedContributionFitReport,
 } from "./seed-contribution-fit";
 
+export { evaluateSeedContributionFit };
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type SanitizationFinding = {

--- a/apps/web/lib/integrate/seed-contribution-fit.test.ts
+++ b/apps/web/lib/integrate/seed-contribution-fit.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildContributionSeedDeltaManifest,
+  evaluateSeedContributionFit,
+  findCanonicalSeedContentPaths,
+} from "./seed-contribution-fit";
+
+const cleanEvidence = {
+  sanitization: { passed: true, mustFixCount: 0 },
+  parameterization: { scope: "already_generic" as const, overallVerdict: "pass" as const },
+  verticals: {
+    sourceVertical: "unknown",
+    applicableVerticals: [],
+  },
+  securityPassed: true,
+};
+
+describe("findCanonicalSeedContentPaths", () => {
+  it("detects every canonical seed family and excludes tests", () => {
+    expect(findCanonicalSeedContentPaths([
+      "prompts/reviewer/code-review.prompt.md",
+      "skills/build/reviewer.skill.md",
+      "docs/founder-kernel/wiki/principles/never-fabricate.md",
+      "packages/dpf-skill-pack/skills/dpf-tdd/SKILL.md",
+      "packages/db/data/seed-voices/en-US.json",
+      "packages/db/src/seed-skills.ts",
+      "packages/db/src/governance-seed.ts",
+      "packages/db/src/taxonomy-seed-entries.ts",
+      "packages/db/prisma/seed-task-requirements.ts",
+      "packages/storefront-templates/src/archetypes/home-services.ts",
+      "packages/finance-templates/src/chart-of-accounts.ts",
+      "apps/web/lib/onboarding/seed-market-offer.ts",
+      "apps/web/lib/storefront/seed-booking-defaults.ts",
+      "apps/web/lib/routing/recipe-seeder.ts",
+      "packages/db/src/seed-skills.test.ts",
+      "apps/web/lib/storefront/seed-booking-defaults.test.ts",
+      "apps/web/components/CustomerTable.tsx",
+    ])).toEqual([
+      "prompts/reviewer/code-review.prompt.md",
+      "skills/build/reviewer.skill.md",
+      "docs/founder-kernel/wiki/principles/never-fabricate.md",
+      "packages/dpf-skill-pack/skills/dpf-tdd/SKILL.md",
+      "packages/db/data/seed-voices/en-US.json",
+      "packages/db/src/seed-skills.ts",
+      "packages/db/src/governance-seed.ts",
+      "packages/db/src/taxonomy-seed-entries.ts",
+      "packages/db/prisma/seed-task-requirements.ts",
+      "packages/storefront-templates/src/archetypes/home-services.ts",
+      "packages/finance-templates/src/chart-of-accounts.ts",
+      "apps/web/lib/onboarding/seed-market-offer.ts",
+      "apps/web/lib/storefront/seed-booking-defaults.ts",
+      "apps/web/lib/routing/recipe-seeder.ts",
+    ]);
+  });
+});
+
+describe("evaluateSeedContributionFit", () => {
+  it("does not require a decision for a code-only contribution", () => {
+    expect(evaluateSeedContributionFit({
+      changedFiles: ["apps/web/components/CustomerTable.tsx"],
+      ...cleanEvidence,
+    })).toMatchObject({
+      touchesSeededContent: false,
+      changedSeedPaths: [],
+      decision: null,
+      distributionScope: null,
+      mergeEligible: true,
+    });
+  });
+
+  it("allows clean generic seed content as a global default", () => {
+    expect(evaluateSeedContributionFit({
+      changedFiles: ["prompts/reviewer/code-review.prompt.md"],
+      ...cleanEvidence,
+    })).toMatchObject({
+      decision: "global-default",
+      distributionScope: "global-default",
+      mergeEligible: true,
+    });
+  });
+
+  it("scopes archetype templates to their applicable categories", () => {
+    expect(evaluateSeedContributionFit({
+      changedFiles: ["packages/storefront-templates/src/archetypes/pet-services.ts"],
+      ...cleanEvidence,
+      parameterization: { scope: "parameterizable", overallVerdict: "pass" },
+      verticals: {
+        sourceVertical: "pet-services",
+        applicableVerticals: [
+          { category: "pet-services", relevance: "primary" as const },
+          { category: "field-services", relevance: "applicable" as const },
+        ],
+      },
+    })).toMatchObject({
+      decision: "archetype-scoped",
+      distributionScope: "archetype-scoped",
+      applicableArchetypeCategories: ["pet-services", "field-services"],
+      mergeEligible: true,
+    });
+  });
+
+  it("keeps one-off seed defaults local to the contributing install", () => {
+    expect(evaluateSeedContributionFit({
+      changedFiles: ["packages/db/src/seed-storefront-archetypes.ts"],
+      ...cleanEvidence,
+      parameterization: { scope: "one_off", overallVerdict: "pass" },
+    })).toMatchObject({
+      decision: "install-local-only",
+      distributionScope: null,
+      mergeEligible: false,
+    });
+  });
+
+  it("requires parameterization when review evidence contains org-specific content", () => {
+    expect(evaluateSeedContributionFit({
+      changedFiles: ["packages/db/src/seed-skills.ts"],
+      ...cleanEvidence,
+      sanitization: { passed: false, mustFixCount: 2 },
+    })).toMatchObject({
+      decision: "parameterize-first",
+      mergeEligible: false,
+    });
+  });
+
+  it("rejects a seed delta that fails the security review", () => {
+    expect(evaluateSeedContributionFit({
+      changedFiles: ["skills/build/reviewer.skill.md"],
+      ...cleanEvidence,
+      securityPassed: false,
+    })).toMatchObject({
+      decision: "reject-as-seed",
+      mergeEligible: false,
+    });
+  });
+});
+
+describe("buildContributionSeedDeltaManifest", () => {
+  it("carries scope and source contribution evidence", () => {
+    const seedFit = evaluateSeedContributionFit({
+      changedFiles: ["packages/db/src/seed-banking-compliance.ts"],
+      ...cleanEvidence,
+      parameterization: { scope: "parameterizable", overallVerdict: "pass" },
+      verticals: {
+        sourceVertical: "financial-services",
+        applicableVerticals: [
+          { category: "financial-services", relevance: "primary" as const },
+        ],
+      },
+    });
+
+    expect(buildContributionSeedDeltaManifest(seedFit, {
+      packId: "FP-1234",
+      buildId: "FB-5678",
+      prNumber: 42,
+      prUrl: "https://github.com/example/repo/pull/42",
+      reviewedAt: "2026-07-11T00:00:00.000Z",
+    })).toEqual({
+      schemaVersion: 1,
+      changedPaths: ["packages/db/src/seed-banking-compliance.ts"],
+      distributionScope: "vertical-scoped",
+      applicableArchetypeCategories: [],
+      applicableVerticals: ["financial-services"],
+      sourceContribution: {
+        packId: "FP-1234",
+        buildId: "FB-5678",
+        prNumber: 42,
+        prUrl: "https://github.com/example/repo/pull/42",
+        sourceVertical: "financial-services",
+      },
+      seedFitDecision: "vertical-scoped",
+      mergeEligible: true,
+      reviewedAt: "2026-07-11T00:00:00.000Z",
+    });
+  });
+});

--- a/apps/web/lib/integrate/seed-contribution-fit.ts
+++ b/apps/web/lib/integrate/seed-contribution-fit.ts
@@ -1,0 +1,276 @@
+import seedContentPaths from "../../../../config/seed-content-paths.json";
+
+export const SEED_CONTRIBUTION_FIT_DECISIONS = [
+  "global-default",
+  "archetype-scoped",
+  "vertical-scoped",
+  "parameterize-first",
+  "install-local-only",
+  "reject-as-seed",
+] as const;
+
+export type SeedContributionFitDecision =
+  (typeof SEED_CONTRIBUTION_FIT_DECISIONS)[number];
+
+export type SeedDistributionScope = Extract<
+  SeedContributionFitDecision,
+  "global-default" | "archetype-scoped" | "vertical-scoped"
+>;
+
+type VerticalApplicabilityEvidence = {
+  category: string;
+  relevance: "primary" | "applicable" | "unlikely";
+};
+
+export type SeedContributionFitInput = {
+  changedFiles: string[];
+  sanitization: {
+    passed: boolean;
+    mustFixCount: number;
+  };
+  parameterization: {
+    scope: "one_off" | "parameterizable" | "already_generic";
+    overallVerdict: "pass" | "partial" | "fail";
+  };
+  verticals: {
+    sourceVertical: string;
+    applicableVerticals: VerticalApplicabilityEvidence[];
+  };
+  securityPassed: boolean;
+};
+
+export type SeedContributionFitReport = {
+  touchesSeededContent: boolean;
+  changedSeedPaths: string[];
+  decision: SeedContributionFitDecision | null;
+  distributionScope: SeedDistributionScope | null;
+  applicableArchetypeCategories: string[];
+  applicableVerticals: string[];
+  sourceVertical: string;
+  rationale: string;
+  mergeEligible: boolean;
+};
+
+export type ContributionSeedDeltaManifest = {
+  schemaVersion: 1;
+  changedPaths: string[];
+  distributionScope: SeedDistributionScope | null;
+  applicableArchetypeCategories: string[];
+  applicableVerticals: string[];
+  sourceContribution: {
+    packId: string;
+    buildId: string;
+    prNumber: number;
+    prUrl: string;
+    sourceVertical: string;
+  };
+  seedFitDecision: SeedContributionFitDecision;
+  mergeEligible: boolean;
+  reviewedAt: string;
+};
+
+const directoryPrefixes = seedContentPaths.directoryPrefixes;
+const filePatterns = seedContentPaths.filePatterns.map((pattern) => new RegExp(pattern));
+const excludePatterns = seedContentPaths.excludePatterns.map((pattern) => new RegExp(pattern));
+
+function normalizeRepoPath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "").replace(/^[ab]\//, "");
+}
+
+export function isCanonicalSeedContentPath(path: string): boolean {
+  const normalized = normalizeRepoPath(path);
+  if (!normalized || excludePatterns.some((pattern) => pattern.test(normalized))) {
+    return false;
+  }
+  return directoryPrefixes.some((prefix) => normalized.startsWith(prefix))
+    || filePatterns.some((pattern) => pattern.test(normalized));
+}
+
+export function findCanonicalSeedContentPaths(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const path of paths) {
+    const normalized = normalizeRepoPath(path);
+    if (!seen.has(normalized) && isCanonicalSeedContentPath(normalized)) {
+      seen.add(normalized);
+      result.push(normalized);
+    }
+  }
+  return result;
+}
+
+function relevantVerticals(verticals: VerticalApplicabilityEvidence[]): string[] {
+  return [...new Set(
+    verticals
+      .filter((vertical) => vertical.relevance !== "unlikely")
+      .map((vertical) => vertical.category),
+  )];
+}
+
+function report(
+  input: SeedContributionFitInput,
+  changedSeedPaths: string[],
+  decision: SeedContributionFitDecision,
+  rationale: string,
+  applicable: string[],
+): SeedContributionFitReport {
+  const distributionScope: SeedDistributionScope | null =
+    decision === "global-default"
+      || decision === "archetype-scoped"
+      || decision === "vertical-scoped"
+      ? decision
+      : null;
+  const archetypeScoped = decision === "archetype-scoped" ? applicable : [];
+  const verticalScoped = decision === "vertical-scoped" ? applicable : [];
+
+  return {
+    touchesSeededContent: true,
+    changedSeedPaths,
+    decision,
+    distributionScope,
+    applicableArchetypeCategories: archetypeScoped,
+    applicableVerticals: verticalScoped,
+    sourceVertical: input.verticals.sourceVertical,
+    rationale,
+    mergeEligible: distributionScope !== null,
+  };
+}
+
+export function evaluateSeedContributionFit(
+  input: SeedContributionFitInput,
+): SeedContributionFitReport {
+  const changedSeedPaths = findCanonicalSeedContentPaths(input.changedFiles);
+  if (changedSeedPaths.length === 0) {
+    return {
+      touchesSeededContent: false,
+      changedSeedPaths: [],
+      decision: null,
+      distributionScope: null,
+      applicableArchetypeCategories: [],
+      applicableVerticals: [],
+      sourceVertical: input.verticals.sourceVertical,
+      rationale: "The contribution does not change canonical seeded content.",
+      mergeEligible: true,
+    };
+  }
+
+  const applicable = relevantVerticals(input.verticals.applicableVerticals);
+
+  if (!input.securityPassed) {
+    return report(
+      input,
+      changedSeedPaths,
+      "reject-as-seed",
+      "Seeded content cannot be distributed while the security review is failing.",
+      applicable,
+    );
+  }
+
+  if (input.parameterization.scope === "one_off") {
+    return report(
+      input,
+      changedSeedPaths,
+      "install-local-only",
+      "The contribution is explicitly one-off, so its seed defaults stay on the contributing install.",
+      applicable,
+    );
+  }
+
+  if (!input.sanitization.passed
+    || input.sanitization.mustFixCount > 0
+    || input.parameterization.overallVerdict !== "pass") {
+    return report(
+      input,
+      changedSeedPaths,
+      "parameterize-first",
+      "The review found install-specific content or incomplete parameterization that must be separated from the reusable seed.",
+      applicable,
+    );
+  }
+
+  const changesArchetypeSeed = changedSeedPaths.some((path) =>
+    path.includes("/archetypes/") || /(?:^|[-/])archetype(?:s|[-.])/.test(path),
+  );
+  if (changesArchetypeSeed && applicable.length > 0) {
+    return report(
+      input,
+      changedSeedPaths,
+      "archetype-scoped",
+      "The clean seed delta changes archetype content and is limited to the reviewed applicable archetype categories.",
+      applicable,
+    );
+  }
+
+  if (input.parameterization.scope === "parameterizable" && applicable.length > 0) {
+    return report(
+      input,
+      changedSeedPaths,
+      "vertical-scoped",
+      "The clean parameterized seed delta is limited to the reviewed applicable business verticals.",
+      applicable,
+    );
+  }
+
+  return report(
+    input,
+    changedSeedPaths,
+    "global-default",
+    "The seed delta is clean, reusable, and has no evidence limiting it to one install, archetype, or vertical.",
+    applicable,
+  );
+}
+
+export function buildContributionSeedDeltaManifest(
+  seedFit: SeedContributionFitReport,
+  source: {
+    packId: string;
+    buildId: string;
+    prNumber: number;
+    prUrl: string;
+    reviewedAt: string;
+  },
+): ContributionSeedDeltaManifest {
+  if (!seedFit.touchesSeededContent || !seedFit.decision) {
+    throw new Error("Cannot build a seed-delta manifest for a contribution without seed changes.");
+  }
+
+  return {
+    schemaVersion: 1,
+    changedPaths: seedFit.changedSeedPaths,
+    distributionScope: seedFit.distributionScope,
+    applicableArchetypeCategories: seedFit.applicableArchetypeCategories,
+    applicableVerticals: seedFit.applicableVerticals,
+    sourceContribution: {
+      packId: source.packId,
+      buildId: source.buildId,
+      prNumber: source.prNumber,
+      prUrl: source.prUrl,
+      sourceVertical: seedFit.sourceVertical,
+    },
+    seedFitDecision: seedFit.decision,
+    mergeEligible: seedFit.mergeEligible,
+    reviewedAt: source.reviewedAt,
+  };
+}
+
+export function formatSeedContributionFitMarkdown(
+  seedFit: SeedContributionFitReport,
+): string[] {
+  const lines = ["### Seed Contribution Fit", ""];
+  if (!seedFit.touchesSeededContent) {
+    return [...lines, "- [x] No canonical seeded content changed", ""];
+  }
+
+  lines.push(
+    `- Decision: **${seedFit.decision}**`,
+    `- Fleet-seed eligible: **${seedFit.mergeEligible ? "yes" : "no"}**`,
+    `- Rationale: ${seedFit.rationale}`,
+    `- Seed paths: ${seedFit.changedSeedPaths.length}`,
+    ...seedFit.changedSeedPaths.slice(0, 15).map((path) => `  - \`${path}\``),
+  );
+  if (seedFit.changedSeedPaths.length > 15) {
+    lines.push(`  - ${seedFit.changedSeedPaths.length - 15} more`);
+  }
+  lines.push("");
+  return lines;
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -10672,11 +10672,11 @@ export async function executeTool(
         contributionReadiness?: string;
       } | null;
       const {
+        evaluateSeedContributionFit,
         runSanitizationScan,
         tagBusinessVerticals,
         verifyParameterization,
       } = await import("@/lib/integrate/contribution-review");
-      const { evaluateSeedContributionFit } = await import("@/lib/integrate/seed-contribution-fit");
       const securityScan = (await import("@/lib/security-scan")).scanDiffForSecurityIssues(shareableDiff);
       const preliminarySanitization = await runSanitizationScan(shareableDiff);
       const preliminaryParameterization = verifyParameterization(shareableDiff, reusability);

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -10662,38 +10662,11 @@ export async function executeTool(
       const includeMigrations = params.include_migrations !== false;
       const brief = build.brief as Record<string, unknown> | null;
 
-      // Analyze seed fit before opening the PR so the first CI run already has
-      // governed review metadata. runContributionReview repeats the same
-      // deterministic analysis after PR creation and persists the full report.
-      const designDoc = build.designDoc as Record<string, unknown> | null;
-      const reusability = designDoc?.reusabilityAnalysis as {
-        scope?: string;
-        domainEntities?: Array<{ hardcodedValue: string; parameterName: string }>;
-        contributionReadiness?: string;
-      } | null;
-      const {
-        evaluateSeedContributionFit,
-        runSanitizationScan,
-        tagBusinessVerticals,
-        verifyParameterization,
-      } = await import("@/lib/integrate/contribution-review");
-      const securityScan = (await import("@/lib/security-scan")).scanDiffForSecurityIssues(shareableDiff);
-      const preliminarySanitization = await runSanitizationScan(shareableDiff);
-      const preliminaryParameterization = verifyParameterization(shareableDiff, reusability);
-      const preliminaryVerticals = await tagBusinessVerticals(brief, shareableDiff);
-
       // Parse files from diff
-      const allFiles = [...diff.matchAll(/^diff --git a\/(.+) b\/.+$/gm)].map((m) => m[1]);
+      const { allFiles, seedFit, securityScan } = await (await import("@/lib/integrate/contribution-review")).analyzeContributionSeedFit(shareableDiff, brief, build.designDoc);
       const migrationFiles = allFiles.filter((f) => f.startsWith("prisma/migrations/"));
       const codeFiles = allFiles.filter((f) => !f.startsWith("prisma/migrations/"));
       const schemaFiles = allFiles.filter((f) => f.includes("schema.prisma"));
-      const seedFit = evaluateSeedContributionFit({
-        changedFiles: allFiles,
-        sanitization: preliminarySanitization,
-        parameterization: preliminaryParameterization,
-        verticals: preliminaryVerticals,
-        securityPassed: securityScan.passed,
-      });
 
       // Build manifest
       const manifest = {
@@ -10803,13 +10776,11 @@ export async function executeTool(
               "",
               "---",
               `License: Apache-2.0 (inbound=outbound)`,
-              platformId.dcoSignoff,
-              ...(seedFit.decision ? ["", `Seed-Fit-Decision: ${seedFit.decision}`] : []),
+              `${platformId.dcoSignoff}${seedFit.decision ? `\n\nSeed-Fit-Decision: ${seedFit.decision}` : ""}`,
             ].join("\n");
 
-            const labels = ["ai-contributed", "build-studio"];
+            const labels = ["ai-contributed", "build-studio", ...(seedFit.decision ? [`seed-fit:${seedFit.decision}`] : [])];
             if (!securityScan.passed) labels.push("security-review-needed");
-            if (seedFit.decision) labels.push(`seed-fit:${seedFit.decision}`);
 
             const prResult = await createBranchAndPR({
               // Phase 3: caller still passes head === base. Phase 4 will switch

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -10575,7 +10575,7 @@ export async function executeTool(
           id: true, title: true, brief: true, diffPatch: true, diffSummary: true,
           sandboxId: true, portfolioId: true, createdById: true,
           buildBranch: true, gitCommitHashes: true, updatedAt: true, buildPlan: true,
-          description: true, buildExecState: true,
+          description: true, designDoc: true, buildExecState: true,
           disposition: true, dispositionSuggestionReason: true,
           createdBy: { select: { email: true } },
         },
@@ -10662,11 +10662,38 @@ export async function executeTool(
       const includeMigrations = params.include_migrations !== false;
       const brief = build.brief as Record<string, unknown> | null;
 
+      // Analyze seed fit before opening the PR so the first CI run already has
+      // governed review metadata. runContributionReview repeats the same
+      // deterministic analysis after PR creation and persists the full report.
+      const designDoc = build.designDoc as Record<string, unknown> | null;
+      const reusability = designDoc?.reusabilityAnalysis as {
+        scope?: string;
+        domainEntities?: Array<{ hardcodedValue: string; parameterName: string }>;
+        contributionReadiness?: string;
+      } | null;
+      const {
+        runSanitizationScan,
+        tagBusinessVerticals,
+        verifyParameterization,
+      } = await import("@/lib/integrate/contribution-review");
+      const { evaluateSeedContributionFit } = await import("@/lib/integrate/seed-contribution-fit");
+      const securityScan = (await import("@/lib/security-scan")).scanDiffForSecurityIssues(shareableDiff);
+      const preliminarySanitization = await runSanitizationScan(shareableDiff);
+      const preliminaryParameterization = verifyParameterization(shareableDiff, reusability);
+      const preliminaryVerticals = await tagBusinessVerticals(brief, shareableDiff);
+
       // Parse files from diff
       const allFiles = [...diff.matchAll(/^diff --git a\/(.+) b\/.+$/gm)].map((m) => m[1]);
       const migrationFiles = allFiles.filter((f) => f.startsWith("prisma/migrations/"));
       const codeFiles = allFiles.filter((f) => !f.startsWith("prisma/migrations/"));
       const schemaFiles = allFiles.filter((f) => f.includes("schema.prisma"));
+      const seedFit = evaluateSeedContributionFit({
+        changedFiles: allFiles,
+        sanitization: preliminarySanitization,
+        parameterization: preliminaryParameterization,
+        verticals: preliminaryVerticals,
+        securityPassed: securityScan.passed,
+      });
 
       // Build manifest
       const manifest = {
@@ -10764,7 +10791,6 @@ export async function executeTool(
 
             const prTitle = `feat: ${build.title}`;
             const { submitBuildAsPR } = await import("@/lib/contribution-pipeline");
-            const securityScan = (await import("@/lib/security-scan")).scanDiffForSecurityIssues(shareableDiff);
             const prBody = [
               "## Summary",
               "",
@@ -10778,10 +10804,12 @@ export async function executeTool(
               "---",
               `License: Apache-2.0 (inbound=outbound)`,
               platformId.dcoSignoff,
+              ...(seedFit.decision ? ["", `Seed-Fit-Decision: ${seedFit.decision}`] : []),
             ].join("\n");
 
             const labels = ["ai-contributed", "build-studio"];
             if (!securityScan.passed) labels.push("security-review-needed");
+            if (seedFit.decision) labels.push(`seed-fit:${seedFit.decision}`);
 
             const prResult = await createBranchAndPR({
               // Phase 3: caller still passes head === base. Phase 4 will switch
@@ -10820,7 +10848,7 @@ export async function executeTool(
                     token: hiveToken,
                     diff: shareableDiff,
                   });
-                  logBuildActivity(buildId, "contribution_review", `Merge readiness: ${reviewResult.mergeReadiness}. Verticals: ${reviewResult.verticals.applicableVerticals.filter((v) => v.relevance !== "unlikely").map((v) => v.category).join(", ") || "none"}`);
+                  logBuildActivity(buildId, "contribution_review", `Merge readiness: ${reviewResult.mergeReadiness}. Seed fit: ${reviewResult.seedFit.decision ?? "not-applicable"}. Verticals: ${reviewResult.verticals.applicableVerticals.filter((v) => v.relevance !== "unlikely").map((v) => v.category).join(", ") || "none"}`);
                 } catch (reviewErr) {
                   console.warn("[contribute_to_hive] contribution review failed:", reviewErr);
                   prError = `Contribution review failed: ${getErrorMessage(reviewErr)}`;

--- a/config/seed-content-paths.json
+++ b/config/seed-content-paths.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "directoryPrefixes": [
+    "prompts/",
+    "skills/",
+    "docs/founder-kernel/wiki/",
+    "packages/dpf-skill-pack/skills/",
+    "packages/db/data/",
+    "packages/db/src/seed/",
+    "packages/storefront-templates/src/archetypes/",
+    "packages/finance-templates/src/"
+  ],
+  "filePatterns": [
+    "^packages/db/src/(?:seed(?:[-/].*)?\\.ts|.*-seed(?:-entries)?\\.ts)$",
+    "^packages/db/prisma/seed-.*\\.ts$",
+    "^apps/web/lib/(?:onboarding|storefront)/seed-.*\\.ts$",
+    "^apps/web/lib/routing/.*-seeder\\.ts$",
+    "^apps/web/lib/.*/.*-seed\\.ts$"
+  ],
+  "excludePatterns": [
+    "\\.(?:test|spec|stories)\\.[cm]?[jt]sx?$",
+    "(?:^|/)__tests__/"
+  ]
+}

--- a/docs/superpowers/plans/2026-07-11-seed-contribution-fit-gate.md
+++ b/docs/superpowers/plans/2026-07-11-seed-contribution-fit-gate.md
@@ -1,0 +1,147 @@
+# Governed Seed Contribution Fit Gate
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-11 |
+| Status | In progress |
+| Backlog item | `BI-FAF815CE` |
+| Work capsule | `WC-94582DB1` |
+| Design anchor | `docs/superpowers/specs/2026-05-23-governed-platform-upgrade-lifecycle-design.md` §§4.2-4.3, 5.2.4, 6.4 |
+
+## Outcome
+
+Turn the governed-upgrade seed-fit design into an enforceable first vertical
+slice. A Hive contribution that changes canonical seed sources must carry one
+reviewed applicability decision, that decision must be visible to the platform
+operator, and PR CI must fail when the evidence is missing or contradictory.
+
+This slice extends the existing `FeaturePack` contribution-review substrate. It
+does not add a second review table or attempt the later fleet-wide
+`SeedSnapshot`/customization-fingerprint migration.
+
+## Existing Substrate
+
+- `apps/web/lib/integrate/contribution-review.ts` already produces structured
+  sanitization, parameterization, vertical-applicability, security, and merge
+  readiness evidence.
+- `FeaturePack.reviewReport` stores the full structured result; the same model
+  already carries `sourceVertical`, `applicableVerticals`, `reusabilityScope`,
+  PR identity, and review timestamps.
+- `contribute_to_hive` in `apps/web/lib/mcp-tools.ts` already builds the pack
+  manifest, opens the PR, and invokes contribution review.
+- `/admin/hive` is the operator's canonical contribution-governance home.
+- `.github/workflows/ci.yml` already hosts evidence-based PR gates for UX fit
+  and process-spine documentation.
+- No seed-delta manifest generator exists on `origin/main`; this slice defines
+  the first machine-readable contribution-level contract inside the existing
+  FeaturePack manifest.
+
+## UX Fit Review
+
+- **Decision:** fits-with-guardrails.
+- **Owning area:** Platform, contribution governance.
+- **Route family:** existing `/admin/hive`; no new route or navigation item.
+- **Primary persona:** platform operator deciding whether community changes are
+  safe and broadly applicable.
+- **Navigation layer touched:** local page content only.
+- **Reuse/convergence:** use report-kit `DataTable`, `StatusBadge`, and
+  `EmptyState`; remove the page-local contribution status color map where the
+  touched table can use canonical intent semantics.
+- **Source truth:** `FeaturePack.reviewReport.seedFit` plus the embedded
+  contribution manifest seed delta.
+- **Empty/failure behavior:** explain that no seed-changing contribution has
+  been reviewed yet; malformed legacy JSON renders as unavailable evidence,
+  never as approval.
+- **AI boundary:** read-only evidence; no prompt is sent and no merge is
+  performed from this page.
+- **Guardrails:** show the decision, affected seed paths, scope, and rationale;
+  avoid exposing internal phase names or adding another dashboard.
+- **Evidence before merge:** pure contract tests, action/view tests, component
+  render tests, theme-token scan, desktop/mobile browser exercise of
+  `/admin/hive`, and production build.
+
+The design-intelligence lookup returned no more specific pattern than the
+existing DPF admin/report-kit conventions, so those repo-native patterns remain
+authoritative.
+
+## Phase 1 - Contract and Tests
+
+Create a pure contribution seed-fit module under
+`apps/web/lib/integrate/seed-contribution-fit.ts` with:
+
+- one canonical `SeedContributionFitDecision` union;
+- centralized canonical seed-path matching;
+- deterministic, conservative classification from existing sanitization,
+  parameterization, security, and vertical evidence;
+- merge-readiness policy for allowed versus remediation/rejection decisions;
+- a serializable contribution-level seed-delta manifest.
+
+Write focused Vitest coverage first and observe the expected red state before
+implementation.
+
+Verification: targeted Vitest suite passes and decision/path exhaustiveness is
+typechecked.
+
+## Phase 2 - Contribution Review Integration
+
+Extend `ContributionReviewResult` with seed-fit evidence. Include the decision
+and rationale in the GitHub review report, labels, status description, activity
+log, and `FeaturePack.reviewReport`. Merge the generated seed-delta object into
+the existing FeaturePack manifest without discarding existing manifest fields.
+
+Compute the same deterministic decision before PR creation so generated Hive
+PR bodies carry `Seed-Fit-Decision:` evidence on their first CI run. Decisions
+that require parameterization, local-only retention, or rejection prevent a
+`ready` merge-readiness result while preserving the reusable code review path.
+
+Verification: targeted contribution-review and MCP contribution tests cover
+seed and non-seed changes, including manifest preservation.
+
+## Phase 3 - Universal PR Gate
+
+Add a small pure Node library plus `scripts/check-seed-fit-decision.mjs`. The
+gate diffs changed files, reuses the canonical path vocabulary in a
+Node-compatible manifest, and accepts exactly one matching decision from PR
+body metadata or `seed-fit:<decision>` labels. It fails missing, invalid, or
+contradictory evidence.
+
+Wire the gate into `.github/workflows/ci.yml` for pull requests, passing refs,
+body, and labels as inert environment values. Non-PR events report a terminal
+success because PR review metadata does not exist there.
+
+Verification: `node --test` covers no-seed, missing, valid, duplicate, and
+contradictory cases; local CLI execution against the branch behaves as expected.
+
+## Phase 4 - Operator Visibility
+
+Extend `getHiveContributionsView()` with recent reviewed FeaturePacks and add a
+small client table composed from report-kit. The `/admin/hive` page shows the
+seed-fit decision, source PR, applicable scope, affected path count, rationale,
+and review time. Legacy reviews without seed-fit evidence remain visibly
+unclassified.
+
+Verification: action mapping test, component render test, typecheck, production
+build, and browser checks at desktop and mobile widths with no overlap.
+
+## Risk and Rollback
+
+- **False-positive seed paths:** keep matching centralized and test each path
+  family; the CI failure tells the contributor which paths triggered it.
+- **Auto-classification too permissive:** global approval requires existing
+  evidence to be generic and clean; uncertainty resolves to remediation, not
+  approval.
+- **Legacy FeaturePacks:** parsing is additive and fail-closed; old JSON remains
+  readable and is never rewritten merely by viewing the page.
+- **CI deadlock:** the contribution pipeline places metadata in the initial PR
+  body; maintainers can also provide an explicit reviewed trailer or label.
+- **Rollback:** remove the CI job first if it blocks unrelated delivery, then
+  revert UI/integration. All persisted fields are additive JSON, so no schema
+  rollback or data migration is required.
+
+## Later Work Kept Explicitly Out of Scope
+
+This PR does not claim the full governed-upgrade design is complete. The
+fleet-safe `SeedSnapshot` registry, three-way customization fingerprints,
+signed release channel manifest, automatic backup/recovery rehearsal, and
+production seed reconciliation remain separate implementation slices under the
+same design.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "check:module-size": "node scripts/check-module-size.mjs",
     "check:mcp-tool-pack": "node scripts/check-mcp-tool-pack.mjs",
     "check:guards": "node scripts/check-guards.mjs",
+    "check:seed-fit": "node scripts/check-seed-fit-decision.mjs",
     "check:architecture-parity": "pnpm --filter web exec tsx scripts/audit-architecture-parity.ts --baseline docs/superpowers/audits/2026-06-14-architecture-parity-baseline.json",
     "sbom": "node scripts/sbom/generate-platform-sbom.mjs",
     "check:sbom-drift": "node scripts/sbom/check-sbom-drift.mjs",

--- a/scripts/check-seed-fit-decision.mjs
+++ b/scripts/check-seed-fit-decision.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+import { evaluateSeedFitGate, SEED_FIT_DECISIONS } from "./lib/seed-fit-gate.mjs";
+
+const REF_RE = /^[A-Za-z0-9._\-/]{1,200}$/;
+
+function safeRef(ref, label) {
+  if (!REF_RE.test(ref) || ref.startsWith("-")) {
+    throw new Error(`[seed-fit-gate] refusing unsafe ${label}: ${JSON.stringify(ref)}`);
+  }
+  return ref;
+}
+
+function git(...args) {
+  try {
+    return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+  } catch (error) {
+    return error.stdout?.toString() ?? "";
+  }
+}
+
+if (process.env.GITHUB_EVENT_NAME && process.env.GITHUB_EVENT_NAME !== "pull_request") {
+  console.log("[seed-fit-gate] Non-PR event has no review metadata; PR gate is not applicable.");
+  process.exit(0);
+}
+
+const base = safeRef(process.env.BASE_SHA || "origin/main", "BASE_SHA");
+git("fetch", "--no-tags", "origin", "main");
+const changedFiles = git("diff", "--name-only", `${base}...HEAD`)
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+let labels = [];
+try {
+  const parsed = JSON.parse(process.env.PR_LABELS_JSON || "[]");
+  labels = Array.isArray(parsed) ? parsed.map(String) : [];
+} catch {
+  console.error("[seed-fit-gate] PR_LABELS_JSON is not a JSON array.");
+  process.exit(1);
+}
+
+const result = evaluateSeedFitGate({
+  changedFiles,
+  prBody: process.env.PR_BODY || "",
+  labels,
+});
+
+if (result.ok) {
+  if (result.reason === "no-seed-content") {
+    console.log("[seed-fit-gate] No canonical seeded-content changes; nothing to gate.");
+  } else {
+    console.log(`[seed-fit-gate] Seeded-content decision is ${result.decision}. OK.`);
+    for (const path of result.seedPaths) console.log(`  - ${path}`);
+  }
+  process.exit(0);
+}
+
+console.error(`[seed-fit-gate] FAILED: ${result.reason}.`);
+for (const path of result.seedPaths) console.error(`  - ${path}`);
+if (result.reason === "missing-decision") {
+  console.error("Add exactly one reviewed `Seed-Fit-Decision: <value>` PR-body trailer or `seed-fit:<value>` label.");
+}
+if (result.reason === "contradictory-decisions") {
+  console.error(`Conflicting decisions: ${result.decisions.join(", ")}`);
+}
+if (result.reason === "invalid-decision") {
+  console.error(`Invalid decisions: ${result.invalid.join(", ")}`);
+}
+if (result.reason === "decision-not-merge-eligible") {
+  console.error(`Decision ${result.decision} requires revision or removal of the seed delta before merge.`);
+}
+console.error(`Valid values: ${SEED_FIT_DECISIONS.join(", ")}`);
+process.exit(1);

--- a/scripts/check-seed-fit-decision.mjs
+++ b/scripts/check-seed-fit-decision.mjs
@@ -2,7 +2,11 @@
 
 import { execFileSync } from "node:child_process";
 
-import { evaluateSeedFitGate, SEED_FIT_DECISIONS } from "./lib/seed-fit-gate.mjs";
+import {
+  evaluateSeedFitGate,
+  normalizeGithubLabels,
+  SEED_FIT_DECISIONS,
+} from "./lib/seed-fit-gate.mjs";
 
 const REF_RE = /^[A-Za-z0-9._\-/]{1,200}$/;
 
@@ -36,7 +40,7 @@ const changedFiles = git("diff", "--name-only", `${base}...HEAD`)
 let labels = [];
 try {
   const parsed = JSON.parse(process.env.PR_LABELS_JSON || "[]");
-  labels = Array.isArray(parsed) ? parsed.map(String) : [];
+  labels = normalizeGithubLabels(parsed);
 } catch {
   console.error("[seed-fit-gate] PR_LABELS_JSON is not a JSON array.");
   process.exit(1);

--- a/scripts/check-seed-fit-decision.test.mjs
+++ b/scripts/check-seed-fit-decision.test.mjs
@@ -1,9 +1,17 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { evaluateSeedFitGate } from "./lib/seed-fit-gate.mjs";
+import { evaluateSeedFitGate, normalizeGithubLabels } from "./lib/seed-fit-gate.mjs";
 
 describe("seed-fit PR gate", () => {
+  it("normalizes GitHub label objects without workflow wildcards", () => {
+    assert.deepEqual(normalizeGithubLabels([
+      { id: 1, name: "seed-fit:vertical-scoped", color: "123456" },
+      "merge-ready",
+      { id: 2 },
+    ]), ["seed-fit:vertical-scoped", "merge-ready"]);
+  });
+
   it("passes code-only changes without seed-fit metadata", () => {
     assert.deepEqual(evaluateSeedFitGate({
       changedFiles: ["apps/web/components/CustomerTable.tsx"],

--- a/scripts/check-seed-fit-decision.test.mjs
+++ b/scripts/check-seed-fit-decision.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { evaluateSeedFitGate } from "./lib/seed-fit-gate.mjs";
+
+describe("seed-fit PR gate", () => {
+  it("passes code-only changes without seed-fit metadata", () => {
+    assert.deepEqual(evaluateSeedFitGate({
+      changedFiles: ["apps/web/components/CustomerTable.tsx"],
+      prBody: "",
+      labels: [],
+    }), { ok: true, reason: "no-seed-content", seedPaths: [], decision: null });
+  });
+
+  it("fails a seeded-content change with no decision", () => {
+    assert.deepEqual(evaluateSeedFitGate({
+      changedFiles: ["packages/db/src/seed-skills.ts"],
+      prBody: "",
+      labels: [],
+    }), {
+      ok: false,
+      reason: "missing-decision",
+      seedPaths: ["packages/db/src/seed-skills.ts"],
+      decision: null,
+    });
+  });
+
+  it("passes an eligible decision from the PR body", () => {
+    assert.deepEqual(evaluateSeedFitGate({
+      changedFiles: ["prompts/reviewer/code-review.prompt.md"],
+      prBody: "Seed-Fit-Decision: global-default",
+      labels: [],
+    }).ok, true);
+  });
+
+  it("passes an eligible decision from a label", () => {
+    assert.deepEqual(evaluateSeedFitGate({
+      changedFiles: ["packages/db/src/seed-skills.ts"],
+      prBody: "",
+      labels: ["seed-fit:vertical-scoped"],
+    }).ok, true);
+  });
+
+  it("fails contradictory body and label decisions", () => {
+    assert.deepEqual(evaluateSeedFitGate({
+      changedFiles: ["packages/db/src/seed-skills.ts"],
+      prBody: "Seed-Fit-Decision: global-default",
+      labels: ["seed-fit:vertical-scoped"],
+    }).reason, "contradictory-decisions");
+  });
+
+  it("fails invalid decision metadata", () => {
+    assert.deepEqual(evaluateSeedFitGate({
+      changedFiles: ["packages/db/src/seed-skills.ts"],
+      prBody: "Seed-Fit-Decision: everywhere",
+      labels: [],
+    }).reason, "invalid-decision");
+  });
+
+  it("fails decisions that explicitly require remediation or rejection", () => {
+    for (const decision of ["parameterize-first", "install-local-only", "reject-as-seed"]) {
+      assert.deepEqual(evaluateSeedFitGate({
+        changedFiles: ["packages/db/src/seed-skills.ts"],
+        prBody: `Seed-Fit-Decision: ${decision}`,
+        labels: [],
+      }).reason, "decision-not-merge-eligible");
+    }
+  });
+});

--- a/scripts/lib/seed-fit-gate.mjs
+++ b/scripts/lib/seed-fit-gate.mjs
@@ -38,6 +38,13 @@ export function findCanonicalSeedContentPaths(paths) {
   return [...new Set(paths.map(normalizeRepoPath).filter(isCanonicalSeedContentPath))];
 }
 
+export function normalizeGithubLabels(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((label) => typeof label === "string" ? label : label?.name)
+    .filter((label) => typeof label === "string");
+}
+
 function collectDecisionTokens(prBody, labels) {
   const bodyMatches = [...String(prBody).matchAll(/Seed-Fit-Decision:\s*([^\s`]+)/gi)]
     .map((match) => match[1].toLowerCase());

--- a/scripts/lib/seed-fit-gate.mjs
+++ b/scripts/lib/seed-fit-gate.mjs
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+
+const config = JSON.parse(
+  readFileSync(new URL("../../config/seed-content-paths.json", import.meta.url), "utf8"),
+);
+
+export const SEED_FIT_DECISIONS = Object.freeze([
+  "global-default",
+  "archetype-scoped",
+  "vertical-scoped",
+  "parameterize-first",
+  "install-local-only",
+  "reject-as-seed",
+]);
+
+const MERGE_ELIGIBLE = new Set([
+  "global-default",
+  "archetype-scoped",
+  "vertical-scoped",
+]);
+const DECISION_SET = new Set(SEED_FIT_DECISIONS);
+const directoryPrefixes = config.directoryPrefixes;
+const filePatterns = config.filePatterns.map((pattern) => new RegExp(pattern));
+const excludePatterns = config.excludePatterns.map((pattern) => new RegExp(pattern));
+
+function normalizeRepoPath(path) {
+  return String(path).replaceAll("\\", "/").replace(/^\.\//, "").replace(/^[ab]\//, "");
+}
+
+export function isCanonicalSeedContentPath(path) {
+  const normalized = normalizeRepoPath(path);
+  if (!normalized || excludePatterns.some((pattern) => pattern.test(normalized))) return false;
+  return directoryPrefixes.some((prefix) => normalized.startsWith(prefix))
+    || filePatterns.some((pattern) => pattern.test(normalized));
+}
+
+export function findCanonicalSeedContentPaths(paths) {
+  return [...new Set(paths.map(normalizeRepoPath).filter(isCanonicalSeedContentPath))];
+}
+
+function collectDecisionTokens(prBody, labels) {
+  const bodyMatches = [...String(prBody).matchAll(/Seed-Fit-Decision:\s*([^\s`]+)/gi)]
+    .map((match) => match[1].toLowerCase());
+  const labelMatches = labels
+    .map((label) => String(label).toLowerCase())
+    .filter((label) => label.startsWith("seed-fit:"))
+    .map((label) => label.slice("seed-fit:".length));
+  return [...bodyMatches, ...labelMatches];
+}
+
+export function evaluateSeedFitGate({ changedFiles, prBody = "", labels = [] }) {
+  const seedPaths = findCanonicalSeedContentPaths(changedFiles);
+  if (seedPaths.length === 0) {
+    return { ok: true, reason: "no-seed-content", seedPaths, decision: null };
+  }
+
+  const tokens = collectDecisionTokens(prBody, labels);
+  const invalid = tokens.filter((decision) => !DECISION_SET.has(decision));
+  if (invalid.length > 0) {
+    return { ok: false, reason: "invalid-decision", seedPaths, decision: null, invalid };
+  }
+
+  const unique = [...new Set(tokens)];
+  if (unique.length === 0) {
+    return { ok: false, reason: "missing-decision", seedPaths, decision: null };
+  }
+  if (unique.length > 1) {
+    return { ok: false, reason: "contradictory-decisions", seedPaths, decision: null, decisions: unique };
+  }
+
+  const decision = unique[0];
+  if (!MERGE_ELIGIBLE.has(decision)) {
+    return { ok: false, reason: "decision-not-merge-eligible", seedPaths, decision };
+  }
+
+  return { ok: true, reason: "eligible-decision", seedPaths, decision };
+}


### PR DESCRIPTION
## Summary

- classify contributed seed changes as global, archetype, vertical, parameterize-first, install-local, or rejected
- persist structured seed-delta review evidence and prevent non-eligible contributions from becoming merge-ready
- add a Seed Contribution Fit CI gate and expose review evidence under Admin > Hive Contributions

Backlog: BI-FAF815CE

## Verification

- governed merged-code local-CI: 1,761 test files passed; 15,074 tests passed
- web typecheck passed
- Next.js 16.2.9 production build passed; 131 static pages generated
- 375 Prisma migrations checked; no pending migrations
- focused seed-fit/UI/MCP suites: 5 files, 27 tests passed
- seed-fit gate tests: 7 passed
- module-size, reporting-composition, style-drift, and diff checks passed

## UX evidence

Verified `/admin/hive` at 1440x900 and 390x844 in the governed candidate preview. The review table exposes contribution, fit decision, applicable scope, seed paths, rationale, review date, and PR link. Mobile keeps the wide evidence table inside its own horizontal scroller with no page-level overflow.

UX-Fit-Decision: fits-with-guardrails; existing `/admin/hive`, report-kit components, read-only evidence.

## Integration evidence

Candidate `bd83b14d0cdc8b403ba60ada646c2f229ad79d14` was merged locally with main `4abd2cbdd111a7e54bf4b63a7527f7e1fa7234d8` as `dee0f4e352825eb41733a698f99ad37eb165d0ee` before the full gate.