### PR TITLE
fix(self-upgrade): COPY config/ into Docker build + guard against build-context divergence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,15 @@ COPY scripts/set-hooks-path.mjs ./scripts/
 COPY apps/web/ ./apps/web/
 COPY packages/ ./packages/
 COPY docs/professions/ ./docs/professions/
+# Root-level config data statically imported at build time — e.g.
+# apps/web/lib/integrate/seed-contribution-fit.ts imports
+# ../../../../config/seed-content-paths.json. Without this COPY the Next.js build
+# fails "Module not found" inside the image even though plain `next build` (CI)
+# passes, because CI builds the full checkout while the image build only sees this
+# narrow allowlist. This detonated self-upgrade SUR-BCFB72BB (BI-062CFB41); the
+# dockerfile-build-context.guard.test.ts guard now fails CI if any build-time
+# import escapes into a repo dir this stage doesn't COPY. Mirrors docs/professions.
+COPY config/ ./config/
 COPY docker-entrypoint.sh ./
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @dpf/db exec prisma generate
@@ -88,6 +97,11 @@ COPY docs/founder-kernel/ ./docs/founder-kernel/
 # lib/decision-perspective/resolve-profession-profile.ts (WSID/EP-WSID corpus).
 # Without this COPY the Next.js build fails: "Cannot find module docs/professions/registry.json".
 COPY docs/professions/ ./docs/professions/
+# Root-level config data statically imported by the tool graph loaded at build
+# time here — generate-tools-snapshot.js → mcp-tools.ts → contribution-review.ts
+# → seed-contribution-fit.ts → config/seed-content-paths.json. Mirrors the build
+# stage; see the dockerfile-build-context guard note there.
+COPY config/ ./config/
 # IT4IT functional criteria workbook is read at seed time by
 # seed-ea-reference-models.ts. The rest of docs/Reference/ is large
 # binary content not needed in the image.

--- a/apps/web/lib/verify/dockerfile-build-context.guard.test.ts
+++ b/apps/web/lib/verify/dockerfile-build-context.guard.test.ts
@@ -1,0 +1,160 @@
+// Guard: every build-time static import in apps/web must resolve to a path that
+// the production Dockerfile actually COPYs into the `next build` stage.
+//
+// WHY THIS EXISTS (self-upgrade failure SUR-BCFB72BB, 2026-07-11 / BI-062CFB41):
+// PR #2776 added `config/seed-content-paths.json` at the repo root and statically
+// imported it from apps/web/lib/integrate/seed-contribution-fit.ts. The production
+// Dockerfile's build stage COPYs a NARROW allowlist (apps/web/, packages/,
+// docs/professions/, a few named root files) and never copied `config/`. So:
+//   - CI's "Production Build" gate runs plain `next build` against the full
+//     checkout, where the file is on disk → GREEN.
+//   - The real Docker image build (only exercised at self-upgrade / tag-release,
+//     never on PRs) can't resolve the import → `next build` fails
+//     "Module not found" → every self-upgrade to that target detonates.
+//
+// This is a RECURRING class (cf. docs/professions/registry.json, packages/db
+// data JSON — all previously bitten). The kernel (principle_decide, 2026-07-11,
+// "Architecture Over Shortcuts") chose this cheap static guard over building the
+// real image on every PR. The guard derives the allowlist FROM the Dockerfile,
+// so adding a `COPY <dir>/ ...` line automatically satisfies it — no duplicated
+// list to drift.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve, relative, sep } from "node:path";
+import { describe, expect, it } from "vitest";
+import { extractStaticImports } from "./bundle-boundary";
+
+// apps/web/lib/verify → repo root is four levels up.
+const REPO_ROOT = resolve(__dirname, "..", "..", "..", "..");
+const APPS_WEB = join(REPO_ROOT, "apps", "web");
+const DOCKERFILE = join(REPO_ROOT, "Dockerfile");
+
+type Stage = { name: string; parent: string | null; body: string[] };
+
+/** Split the Dockerfile into named build stages, preserving FROM parentage. */
+function parseStages(dockerfile: string): Stage[] {
+  const stages: Stage[] = [];
+  let current: Stage | null = null;
+  for (const line of dockerfile.split("\n")) {
+    const from = line.match(/^\s*FROM\s+(\S+)\s+AS\s+(\S+)/i);
+    if (from) {
+      current = { name: from[2], parent: from[1], body: [] };
+      stages.push(current);
+      continue;
+    }
+    if (current) current.body.push(line);
+  }
+  return stages;
+}
+
+/**
+ * The set of build-context path prefixes available when `next build` runs —
+ * the union of COPY sources in the build stage AND every ancestor stage it
+ * FROMs (filesystem is inherited down the chain). `--from=<stage>` COPYs pull
+ * from other image stages, not the build context, so they're excluded.
+ */
+function copyAllowlistForBuildStage(stages: Stage[]): {
+  dirPrefixes: string[];
+  exactFiles: string[];
+} {
+  const byName = new Map(stages.map((s) => [s.name, s]));
+  const buildStage = stages.find((s) => s.body.some((l) => /\bnext build\b/.test(l)));
+  if (!buildStage) {
+    throw new Error("Dockerfile: could not find the stage that runs `next build`");
+  }
+
+  // Walk the FROM chain from the build stage up to the base image.
+  const chain: Stage[] = [];
+  let cursor: Stage | undefined = buildStage;
+  const seen = new Set<string>();
+  while (cursor && !seen.has(cursor.name)) {
+    seen.add(cursor.name);
+    chain.push(cursor);
+    cursor = cursor.parent ? byName.get(cursor.parent) : undefined;
+  }
+
+  const dirPrefixes: string[] = [];
+  const exactFiles: string[] = [];
+  for (const stage of chain) {
+    for (const raw of stage.body) {
+      const line = raw.trim();
+      if (!/^COPY\b/i.test(line)) continue;
+      if (/--from=/.test(line)) continue; // from another image stage, not context
+      // Tokens after COPY, minus flags, minus the final dest arg.
+      const tokens = line
+        .replace(/^COPY\s+/i, "")
+        .split(/\s+/)
+        .filter((t) => t.length > 0 && !t.startsWith("--"));
+      if (tokens.length < 2) continue; // need at least <src> <dest>
+      const sources = tokens.slice(0, -1);
+      for (const src of sources) {
+        const norm = src.replace(/^\.\//, "").replace(/\/+$/, "");
+        if (src.endsWith("/")) dirPrefixes.push(norm);
+        else exactFiles.push(norm);
+      }
+    }
+  }
+  return { dirPrefixes, exactFiles };
+}
+
+function isCovered(
+  repoRelPath: string,
+  allow: { dirPrefixes: string[]; exactFiles: string[] },
+): boolean {
+  const p = repoRelPath.split(sep).join("/");
+  if (allow.exactFiles.includes(p)) return true;
+  return allow.dirPrefixes.some((dir) => p === dir || p.startsWith(`${dir}/`));
+}
+
+/** Recursively collect production .ts/.tsx source files under apps/web. */
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".next" || entry === "dist") continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      collectSourceFiles(full, acc);
+      continue;
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue;
+    // Test/spec files are not part of the `next build` graph — their imports
+    // (fixtures, scripts/*.mjs) never enter the production bundle.
+    if (/\.(test|spec)\.(ts|tsx)$/.test(entry)) continue;
+    acc.push(full);
+  }
+  return acc;
+}
+
+describe("Dockerfile build context covers every escaping build-time import", () => {
+  const allow = copyAllowlistForBuildStage(parseStages(readFileSync(DOCKERFILE, "utf8")));
+  const files = collectSourceFiles(APPS_WEB);
+
+  it("finds a non-empty allowlist and a non-empty source set (sanity)", () => {
+    expect(allow.dirPrefixes).toContain("apps/web");
+    expect(allow.dirPrefixes).toContain("packages");
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it("every static import that escapes apps/web resolves inside a COPYed path", () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const specs = extractStaticImports(readFileSync(file, "utf8"));
+      for (const spec of specs) {
+        if (!spec.startsWith(".")) continue; // bare/package specifiers, not context files
+        const resolved = resolve(join(file, ".."), spec);
+        const repoRel = relative(REPO_ROOT, resolved);
+        // In-tree (under apps/web) is covered by the `apps/web/` prefix; escaping
+        // imports must land inside another COPYed prefix.
+        if (repoRel.startsWith("..")) continue; // outside the repo entirely — ignore
+        if (isCovered(repoRel, allow)) continue;
+        violations.push(
+          `${relative(REPO_ROOT, file)} imports "${spec}" → ${repoRel} (not COPYed into the build stage)`,
+        );
+      }
+    }
+    expect(
+      violations,
+      `These build-time imports point at repo paths the production Dockerfile never COPYs into the \`next build\` stage, so the Docker image build fails "Module not found" at self-upgrade/deploy even though plain \`next build\` (CI) passes. Fix by adding a COPY for the containing directory to the build stage of the Dockerfile:\n  ${violations.join("\n  ")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why the last self-upgrade failed

Self-upgrade run **SUR-BCFB72BB** (corrective **BI-062CFB41**) failed at the `docker-build` step:

```
Module not found: Can't resolve '../../../../config/seed-content-paths.json'
  ./apps/web/lib/integrate/seed-contribution-fit.ts:1:1
```

**Root cause.** PR #2776 added `config/seed-content-paths.json` at the **repo root** and statically imported it from `apps/web/lib/integrate/seed-contribution-fit.ts`. The production `Dockerfile` copies a **narrow allowlist** into the `next build` stage (`apps/web/`, `packages/`, `docs/professions/`, a few named root files) and **never copied `config/`**.

**Why CI didn't catch it.** The required *Production Build* gate runs `pnpm --filter web build` (plain `next build`) against the **full checkout**, where the JSON is on disk → green. The real Docker image is only built by `publish-image.yml` on `push: tags: v*` / manual dispatch — **never on PRs**. So the narrow-COPY Docker build is only exercised at self-upgrade / tag-release, and the divergence shipped green and detonated every upgrade to a target ≥ #2776.

This is a **recurring class** (cf. `docs/professions/registry.json`, `packages/db` data JSON, undici hoist — all previously bitten: BI-165756F8, BI-C0B9B7AA).

## Fix

1. **`COPY config/`** into the build stage (`next build`) and the init stage (`generate-tools-snapshot.js` loads the same `mcp-tools → contribution-review → seed-contribution-fit` graph). Mirrors the identical `docs/professions/` pattern already in both stages.
2. **`dockerfile-build-context.guard.test.ts`** — derives the build-stage COPY allowlist *from the Dockerfile* and fails the **Unit Tests** gate if any build-time static import in `apps/web` escapes into a repo dir the image never copies. Adding a `COPY <dir>/` line auto-satisfies it — no duplicated list to drift.

Approach chosen via `principle_decide` (2026-07-11) — kernel recommended the static guard (composite 1.52, high confidence, *Architecture Over Shortcuts*) over building the full image on every PR (CI cost / OOM pressure) or broadening COPY to the whole tree (image bloat).

## Verification

- Guard goes **red** on the unfixed tree (exactly 1 violation: `config/seed-content-paths.json`), **green** after the `COPY` (0 violations), across 3254 source files — all other escaping imports resolve under `packages/` / `docs/professions/` or are test-only.
- Docker `--target build` (reproduces the exact self-upgrade `next build`) run locally to confirm the module now resolves.

## Follow-up (not in this PR)

The build-failure classifier mislabeled this module-not-found as `bundle-boundary-static-import` because NFT warnings appeared above the fatal error in the log — so BI-062CFB41 points at the wrong playbook. Flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)