### PR TITLE
chore(deps): guard react-data-grid Dependabot against broken/off-channel versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,22 @@ updates:
       # mode code. Upgrade deliberately, not through Dependabot.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # react-data-grid has no stable release yet; every version is a
+      # 7.0.0-* prerelease. The maintainer ships the recommended build on
+      # the `beta` channel, while `canary` is the nightly/dev channel and
+      # `alpha` is older still. Raw semver sorts canary > beta > alpha
+      # alphabetically, so Dependabot jumps us onto the nightly channel
+      # (7.0.0-canary.49 broke Typecheck + Prod Build — see closed #2780).
+      # Block the alpha and canary channels so bumps stay on the beta line.
+      #
+      # beta.60 is ALSO blocked: it ships a broken package — lib/index.js
+      # has a bare `import "ecij";` but declares no `dependencies`, so `ecij`
+      # never installs and every consumer's runtime + Production Build fails
+      # ("Cannot find package 'ecij'"). Stay on the working beta.59 until the
+      # maintainer publishes a fixed beta (beta.61+), which Dependabot will
+      # then be free to propose.
+      - dependency-name: "react-data-grid"
+        versions: ["7.0.0-alpha.*", "7.0.0-canary.*", "7.0.0-beta.60"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Supersedes and closes #2780.

## What Dependabot proposed vs. what's actually safe

Dependabot #2780 bumped `react-data-grid` 7.0.0-beta.59 → **7.0.0-canary.49**, which failed Typecheck + Production Build. Chasing the *correct* target surfaced that **both** available "newer" versions are broken for us:

- **`7.0.0-canary.49`** — the **nightly/dev channel**. Dependabot picked it only because raw semver sorts `canary` > `beta` alphabetically. Fails Typecheck.
- **`7.0.0-beta.60`** — npm's `latest` dist-tag, but a **broken publish**: its `lib/index.js` contains a bare `import "ecij";` while its `package.json` declares **no `dependencies`**. So `ecij` never installs and every consumer's runtime + Production Build fails with `Cannot find package 'ecij'`. Reproduced locally on CI's exact `vitest run --shard=1/4` (`app/(shell)/employee/page.test.tsx`).

`react-data-grid` has no stable release yet — every version is a `7.0.0-*` prerelease — so there is **no good bump right now**.

## This PR

**Config-only** (`.github/dependabot.yml`). No version change — stays on the working `beta.59`. Adds a Dependabot `ignore` for `react-data-grid`:
- `7.0.0-alpha.*`, `7.0.0-canary.*` — off-channel (nightly/older)
- `7.0.0-beta.60` — the specific broken publish

This leaves Dependabot free to propose a fixed `beta.61+` once the maintainer republishes.

## Local-CI-Override

Full local merged-CI gate skipped as non-applicable: this is a single `.github/dependabot.yml` edit with no application code, test, or build inputs. The change was validated by reproducing the underlying react-data-grid breakage locally (see above); the PR's own CI is authoritative for the config itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)