### PR TITLE
fix(self-upgrade): build-failure classifier prioritizes fatal marker over NFT warnings

### DIFF
--- a/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
@@ -39,6 +39,27 @@ Error: Turbopack build failed with 2 errors:
 ./packages/integration-shared/src/oauth-refresh.ts:1:1
 Module not found: Can't resolve 'undici'`;
 
+// Reconstructed from self-upgrade run SUR-BCFB72BB (2026-07-11, BI-062CFB41).
+// Structurally IDENTICAL to BUNDLE_BOUNDARY_UNEXPECTED_NFT_LOG — a Turbopack NFT
+// "whole project traced unintentionally" WARNING whose trace fingerprints the
+// host-only self-upgrade barrel, printed ABOVE the fatal — EXCEPT the fatal is a
+// relative path escaping to a repo-root dir (config/), not a bare specifier.
+// That single difference must flip the class to the build-context miss, so this
+// asserts the fatal marker wins over the NFT warning above it.
+const DOCKER_CONTEXT_MISS_LOG = `#30 [build 7/8] RUN pnpm --filter web build
+#30 12.40   ▲ Next.js 15.3.0 (Turbopack)
+#30 40.10 ./apps/web/next.config.mjs
+#30 40.11 Encountered unexpected file in NFT list
+#30 40.11 A file was traced that indicates that the whole project was traced unintentionally.
+#30 40.12 Import trace:
+#30 40.12     ./apps/web/lib/self-upgrade/promoter.ts
+#30 40.12     ./apps/web/lib/actions/promotions.ts
+#30 52.73  ⨯ Build error occurred
+#30 52.73 Error: Module not found: Can't resolve '../../../../config/seed-content-paths.json'
+#30 52.73     at lib/integrate/seed-contribution-fit.ts:4:1
+#30 52.90 Next.js build worker exited with code: 1
+#30 ERROR: process "/bin/sh -c pnpm --filter web build" did not complete successfully: exit code: 1`;
+
 const UNKNOWN_LOG = `error: connect ECONNREFUSED 127.0.0.1:5432
 prisma migrate failed`;
 
@@ -91,6 +112,30 @@ describe("classifyBuildFailure", () => {
     expect(c.isMainDefectVsEnvironment).toBe("main-defect");
   });
 
+  it("prioritizes the fatal Module-not-found over an NFT warning above it (SUR-BCFB72BB)", () => {
+    const c = classifyBuildFailure({ log: DOCKER_CONTEXT_MISS_LOG });
+    // The escaping relative-path fatal wins — NOT bundle-boundary, even though a
+    // "whole project traced unintentionally" warning fingerprinting the
+    // self-upgrade barrel (the exact BUNDLE_BOUNDARY_UNEXPECTED_NFT signature)
+    // sits above it. This is the mislabel BI-062CFB41 was filed against.
+    expect(c.class).toBe("docker-build-context-missing-path");
+    expect(c.class).not.toBe("bundle-boundary-static-import");
+    expect(c.summary).toContain("config/");
+    expect(c.summary).toContain("#2786");
+    expect(c.playbookLink).toMatch(/dockerfile-build-context\.guard\.test\.ts/);
+    expect(c.failingTrace).toContain(
+      "Can't resolve '../../../../config/seed-content-paths.json'",
+    );
+    expect(c.isMainDefectVsEnvironment).toBe("main-defect");
+  });
+
+  it("keeps a bare-specifier miss with an NFT host-only trace on bundle-boundary, not build-context", () => {
+    // Guards the discriminator: 'undici' is a bare specifier, not a relative
+    // escape, so the existing bundle-boundary heuristic must still own it.
+    const c = classifyBuildFailure({ log: BUNDLE_BOUNDARY_UNEXPECTED_NFT_LOG });
+    expect(c.class).toBe("bundle-boundary-static-import");
+  });
+
   it("classifies the SUR-73668D5C bare RUN-line install failure as retryable environment", () => {
     const c = classifyBuildFailure({ log: PNPM_INSTALL_RUNLINE_LOG });
     expect(c.class).toBe("pnpm-install-failure");
@@ -126,7 +171,7 @@ describe("classifyBuildFailure", () => {
   });
 
   it("is total — every input yields a populated summary and playbook", () => {
-    for (const log of [HOIST_LOG, NFT_LOG, BUNDLE_BOUNDARY_LOG, UNKNOWN_LOG, ""]) {
+    for (const log of [HOIST_LOG, NFT_LOG, BUNDLE_BOUNDARY_LOG, DOCKER_CONTEXT_MISS_LOG, UNKNOWN_LOG, ""]) {
       const c = classifyBuildFailure({ log });
       expect(c.summary.length).toBeGreaterThan(0);
       expect(c.playbookLink.length).toBeGreaterThan(0);

--- a/apps/web/lib/self-upgrade/build-failure-classifier.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.ts
@@ -35,6 +35,15 @@ export type BuildFailureClass =
   // upgrade before diagnosing anything (SUR-73668D5C, 2026-07-05: one flaky
   // smol-toml fetch failed the upgrade; the identical tree built clean on retry).
   | "pnpm-install-failure"
+  // A build-time import uses a RELATIVE path that climbs OUT of apps/web into a
+  // repo-root directory (config/, docs/, packages/ data JSON, …) that the
+  // production Dockerfile's narrow COPY allowlist never copies into the build
+  // context. The file resolves on the full host/CI checkout (plain `next build`
+  // → green) but 404s inside the narrower Docker image — only exercised at
+  // self-upgrade / tag-release. Distinct from a bare-specifier hoist and from a
+  // bundle-boundary lazy-import issue; fixed by adding the missing `COPY <dir>/`
+  // (see PR #2786 + the dockerfile-build-context guard).
+  | "docker-build-context-missing-path"
   | "unknown";
 
 export type BuildFailureClassification = {
@@ -63,6 +72,10 @@ export type BuildFailureInput = {
 
 const SPEC = "docs/superpowers/specs/2026-06-06-procedural-functional-verification-design.md";
 const HOIST_PLAYBOOK = "docs/triage/2026-05-24-portal-prisma-generate-rebuild-failure.md";
+// The guard PR #2786 added: it derives the build-stage COPY allowlist from the
+// Dockerfile and fails Unit Tests if an apps/web static import escapes into an
+// un-COPYed repo dir. Adding the missing `COPY <dir>/` auto-satisfies it.
+const DOCKER_CONTEXT_PLAYBOOK = "apps/web/lib/verify/dockerfile-build-context.guard.test.ts";
 
 // Docker-only / host-only modules that must never be statically imported into a
 // route/page/action/Inngest bundle. Their presence in a Turbopack/NFT trace is
@@ -71,6 +84,10 @@ const HOST_ONLY_MODULE = /(promoter|self-upgrade|child_process|node:child_proces
 const DUPLICATE_ASSET = /(duplicate\s+emitted\s+asset|multiple\s+assets\s+emit|conflict:.*emit|emit[^\n]*to the same (file|filename))/i;
 const UNEXPECTED_NFT_PROJECT_TRACE = /encountered unexpected file in NFT list|whole project was traced unintentionally/i;
 const MODULE_NOT_FOUND = /(cannot find module ['"]([^'"]+)['"]|module not found:\s*can't resolve ['"]([^'"]+)['"])/i;
+// A relative import climbing OUT of the importing package (one or more "../"),
+// e.g. '../../../../config/seed-content-paths.json'. The first non-".." segment
+// ('config') is the repo-root dir the Docker COPY allowlist is missing.
+const RELATIVE_ESCAPE = /^\.\.\/(?:\.\.\/)*([^/'"]+)/;
 
 // The Dockerfile RUN line for a dependency install that exited non-zero —
 // present even when the builder's step output (pnpm's own error text) was lost.
@@ -96,6 +113,31 @@ export function classifyBuildFailure(
   input: BuildFailureInput,
 ): BuildFailureClassification {
   const log = input.log ?? "";
+
+  // Fatal-marker priority for the most specific case. A "Module not found" whose
+  // missing spec is a RELATIVE path climbing out of the package
+  // ('../../../../config/…') is a Docker build-context miss: the file exists on
+  // the full checkout but its repo-root dir is not COPYed into the image.
+  // Turbopack/NFT "whole project traced unintentionally" WARNINGS routinely
+  // print ABOVE this fatal and fingerprint a host-only module, so the
+  // bundle-boundary heuristic below would otherwise steal the class —
+  // SUR-BCFB72BB was mislabeled `bundle-boundary-static-import` for exactly this
+  // reason, sending its corrective BI to the wrong playbook. Classify the
+  // escaping fatal FIRST. (A bare-specifier miss like 'undici' is NOT this class
+  // and falls through to the bundle-boundary / hoist paths below unchanged.)
+  const earlyMiss = log.match(MODULE_NOT_FOUND);
+  const earlyMissSpec = earlyMiss ? earlyMiss[2] || earlyMiss[3] || "" : "";
+  const escape = earlyMissSpec.match(RELATIVE_ESCAPE);
+  if (escape) {
+    const rootDir = escape[1];
+    return {
+      class: "docker-build-context-missing-path",
+      summary: `Docker build cannot resolve '${earlyMissSpec}' — a relative import climbing out of apps/web into the repo-root '${rootDir}/' directory, which the production Dockerfile's narrow COPY allowlist never copies into the build context (plain \`next build\` on the full checkout stays green; only the Docker image, built at self-upgrade/tag-release, 404s). Add \`COPY ${rootDir}/\` to the build (and init) stage — see PR #2786 and the dockerfile-build-context guard. NOT a bundle-boundary issue.`,
+      playbookLink: DOCKER_CONTEXT_PLAYBOOK,
+      failingTrace: traceAround(log, MODULE_NOT_FOUND),
+      isMainDefectVsEnvironment: "main-defect",
+    };
+  }
 
   // Most specific first: a Turbopack/NFT error whose trace fingerprints a
   // host-only module is a bundle-boundary violation, not a generic NFT cascade


### PR DESCRIPTION
## Problem

Self-upgrade run **SUR-BCFB72BB** failed at docker-build with a Turbopack fatal:

```
⨯ Build error occurred
Error: Module not found: Can't resolve '../../../../config/seed-content-paths.json'
```

The real cause was a **Docker build-context miss** — PR #2776 added `config/seed-content-paths.json` at the repo root and imported it from `apps/web`, but the production Dockerfile's narrow `COPY` allowlist never copies `config/` (fixed separately in #2786).

But `classifyBuildFailure` tagged it **`bundle-boundary-static-import`**, because a *non-fatal* NFT `"whole project traced unintentionally"` **WARNING** — which fingerprints the host-only `self-upgrade` barrel — printed **above** the fatal and won the `(UNEXPECTED_NFT_PROJECT_TRACE || DUPLICATE_ASSET) && HOST_ONLY_MODULE` heuristic. That sent corrective **BI-062CFB41** to the wrong playbook (the #1555 lazy-import boundary) instead of the missing-`COPY` fix.

## Fix

Classify the **fatal marker first**. A `Module not found` whose missing spec is a **relative path escaping to a repo-root dir** (`../../../../config/…`) is now a new class **`docker-build-context-missing-path`**, returned *before* the NFT bundle-boundary heuristic and pointing at the #2786 `dockerfile-build-context.guard.test.ts` guard.

The discriminator is surgical — a **bare specifier** (e.g. `undici`) is *not* this class and still falls through to the existing bundle-boundary / hoist paths, so prior NFT-boundary behavior (including the existing `BUNDLE_BOUNDARY_UNEXPECTED_NFT_LOG` test) is preserved untouched.

## Tests

- New: replays the SUR-BCFB72BB log (NFT host-only warning **above** a relative-escaping module-not-found fatal) → asserts `docker-build-context-missing-path`, **not** `bundle-boundary-static-import`.
- New guard: a bare-specifier (`undici`) NFT host-only trace **stays** on `bundle-boundary-static-import`.
- Full file: **13/13 green**; `tsc --noEmit` clean (8 GB heap).

## Out of band

- **BI-062CFB41** reclassified (title + body) from `bundle-boundary-static-import` → `docker-build-context-missing-path`, repointed at the #2786 guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)