### PR TITLE
feat(coworker): unified per-turn effort-warrant signal (EP-27FD96BC P1)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -70,6 +70,7 @@ import {
   executeAutonomousAgenticLoop,
   findCurrentAutonomousWorkRun,
 } from "@/lib/tak/autonomous-work-run";
+import { deriveEffortWarrant } from "@/lib/tak/effort-warrant";
 import { applyLocalDegradationCaveat } from "@/lib/tak/local-degradation-caveat";
 import {
   isConversationalExpansionRequest,
@@ -1850,6 +1851,16 @@ export async function sendMessage(input: {
     // (enabled:false), so behavior elsewhere is unchanged. A failure that
     // survives all retries falls through to the persist-time sanitizer below and
     // the "Retry the AI call" affordance.
+    // EP-27FD96BC · P1 — the unified per-turn effort warrant. Derived once here
+    // from the same task classification that seeds the model path, the attached
+    // tool surface, and the prompt length; the loop co-tunes iterations and
+    // duration from it (and later pillars read its toolBudgetTarget/contextTier).
+    const effortWarrant = deriveEffortWarrant({
+      taskType: taskTypeId,
+      availableToolNames: attachedTools.map((t) => t.name),
+      messageChars: trimmedContent.length,
+    });
+
     const { runWithTransientInferenceRetry } = await import("@/lib/build/inference-retry");
     const agenticResult = await runWithTransientInferenceRetry(
       () => executeAutonomousAgenticLoop({
@@ -1864,6 +1875,7 @@ export async function sendMessage(input: {
         agentId: agent.agentId,
         threadId: input.threadId,
         taskType: taskTypeId,
+        effortWarrant,
         agentDisplayName: agent.agentName,
         buildPhase: activeBuild?.phase ?? null,
         featureBuildId: activeBuild?.id ?? null,

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -1050,6 +1050,13 @@ export async function runAgenticLoop(params: {
   agentId: string;
   threadId: string;
   taskType?: string;
+  /**
+   * EP-27FD96BC · P1 (BI-DA26BF90). The unified per-turn effort warrant. When
+   * present, its `maxIterations` bounds the loop and its `maxDurationMs` sets the
+   * conversation-phase duration baseline (heavy tool phases still win via max).
+   * Absent = today's exact behavior (MAX_ITERATIONS / MAX_DURATION_MS).
+   */
+  effortWarrant?: import("./effort-warrant").EffortWarrant;
   modelRequirements?: Record<string, unknown>;
   /** @deprecated V2 routing is handled internally by routeAndCall. Ignored. */
   routeDecision?: unknown;
@@ -1148,6 +1155,7 @@ export async function runAgenticLoop(params: {
     agentId,
     threadId,
     taskType,
+    effortWarrant,
     modelRequirements,
     onProgress,
     requireTools,
@@ -1339,7 +1347,21 @@ export async function runAgenticLoop(params: {
     });
   };
 
-  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+  // EP-27FD96BC · P1 — the unified warrant bounds iterations for this turn.
+  // Clamped to the hard MAX_ITERATIONS safety ceiling; absent warrant = 200.
+  const iterationCeiling = Math.min(
+    MAX_ITERATIONS,
+    effortWarrant?.maxIterations ?? MAX_ITERATIONS,
+  );
+  if (effortWarrant) {
+    console.log(
+      `[agentic-loop] effort-warrant level=${effortWarrant.level} ` +
+        `iterations=${iterationCeiling} durationBaselineMs=${effortWarrant.maxDurationMs} ` +
+        `toolBudgetTarget=${effortWarrant.toolBudgetTarget} signals=${effortWarrant.signals.join(",")}`,
+    );
+  }
+
+  for (let iteration = 0; iteration < iterationCeiling; iteration++) {
     // EP-ASYNC-COWORKER-001: Check cancellation flag at each iteration boundary
     if (agentEventBus.isCancelled(threadId)) {
       agentEventBus.clearCancel(threadId);
@@ -1438,12 +1460,17 @@ export async function runAgenticLoop(params: {
       t.name === "deploy_feature" || t.name === "execute_promotion" ||
       t.name === "register_digital_product_from_build" || t.name === "schedule_promotion"
     );
+    // EP-27FD96BC · P1 — the effort warrant sets the conversation-phase baseline:
+    // a trivial turn earns less wall-clock, an effortful reasoning turn earns more
+    // even with no heavy tools. A tool-revealed heavy phase (build/ship/plan/
+    // review) still takes its own ceiling. Absent warrant = the prior 120s.
+    const conversationDurationBaseline = effortWarrant?.maxDurationMs ?? MAX_DURATION_MS;
     const durationLimit = hasBuildTools ? MAX_DURATION_BUILD_MS
       : hasShipTools ? MAX_DURATION_SHIP_MS
       : hasPlanTools ? MAX_DURATION_PLAN_MS
       : hasReviewTools ? MAX_DURATION_REVIEW_MS
       : hasIdeateTools ? MAX_DURATION_PLAN_MS
-      : MAX_DURATION_MS;
+      : conversationDurationBaseline;
     if (Date.now() - startTime > durationLimit) {
       console.warn(`[agentic-loop] hit MAX_DURATION (${durationLimit}ms). executedTools=${executedTools.length}.`);
       break;
@@ -1931,7 +1958,7 @@ export async function runAgenticLoop(params: {
       const shouldNudgeNow = result.toolsStripped ? false : shouldNudge({
         continuationNudges,
         iteration,
-        maxIterations: MAX_ITERATIONS,
+        maxIterations: iterationCeiling,
         hasTools: !!(toolsForProvider && toolsForProvider.length > 0) || planEnabled,
         executedToolCount: executedTools.length,
         responseLength: trimmed.length,
@@ -2381,7 +2408,9 @@ export async function runAgenticLoop(params: {
 
   // Safety limit reached — log it so we can tune if needed
   console.warn(
-    `[agentic-loop] hit MAX_ITERATIONS (${MAX_ITERATIONS}). executedTools=${executedTools.length}. ` +
+    `[agentic-loop] hit iteration ceiling (${iterationCeiling}` +
+    `${iterationCeiling !== MAX_ITERATIONS ? `, warranted level=${effortWarrant?.level}` : ""}). ` +
+    `executedTools=${executedTools.length}. ` +
     `This may indicate the model needs more room or is stuck in a loop.`,
   );
   const fallbackContent = lastResult?.content?.trim() ?? "";

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -219,6 +219,8 @@ export async function executeAutonomousAgenticLoop(input: {
   threadId: string;
   taskRunId?: string | null;
   taskType?: string;
+  /** EP-27FD96BC · P1 — unified per-turn effort warrant, forwarded to the loop. */
+  effortWarrant?: import("@/lib/tak/effort-warrant").EffortWarrant;
   agentDisplayName?: string;
   buildPhase?: string | null;
   featureBuildId?: string | null;
@@ -277,6 +279,7 @@ export async function executeAutonomousAgenticLoop(input: {
       taskRunId: input.taskRunId,
       apiTokenId: input.apiTokenId,
       taskType: input.taskType,
+      effortWarrant: input.effortWarrant,
       agentDisplayName: input.agentDisplayName,
       buildPhase: input.buildPhase,
       featureBuildId: input.featureBuildId,

--- a/apps/web/lib/tak/effort-warrant.test.ts
+++ b/apps/web/lib/tak/effort-warrant.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveEffortWarrant,
+  EFFORT_ITERATION_CEILING,
+  type EffortLevel,
+} from "./effort-warrant";
+
+const LEVELS: EffortLevel[] = ["minimal", "low", "medium", "high"];
+
+describe("deriveEffortWarrant", () => {
+  it("passes the content-classifier reasoningDepth straight through as the level", () => {
+    for (const depth of LEVELS) {
+      const w = deriveEffortWarrant({ reasoningDepth: depth });
+      expect(w.level).toBe(depth);
+      expect(w.reasoningDepth).toBe(depth);
+      expect(w.signals).toContain(`depth:${depth}`);
+    }
+  });
+
+  it("co-tunes every knob monotonically with the level", () => {
+    const warrants = LEVELS.map((d) => deriveEffortWarrant({ reasoningDepth: d }));
+    for (let i = 1; i < warrants.length; i++) {
+      const lo = warrants[i - 1]!;
+      const hi = warrants[i]!;
+      expect(hi.maxIterations).toBeGreaterThanOrEqual(lo.maxIterations);
+      expect(hi.maxDurationMs).toBeGreaterThanOrEqual(lo.maxDurationMs);
+      expect(hi.toolBudgetTarget).toBeGreaterThanOrEqual(lo.toolBudgetTarget);
+    }
+  });
+
+  it("a minimal turn is strictly leaner than a high turn on all knobs", () => {
+    const min = deriveEffortWarrant({ reasoningDepth: "minimal" });
+    const high = deriveEffortWarrant({ reasoningDepth: "high" });
+    expect(min.maxIterations).toBeLessThan(high.maxIterations);
+    expect(min.maxDurationMs).toBeLessThan(high.maxDurationMs);
+    expect(min.toolBudgetTarget).toBeLessThan(high.toolBudgetTarget);
+  });
+
+  it("never exceeds the hard iteration safety ceiling", () => {
+    for (const d of LEVELS) {
+      const w = deriveEffortWarrant({ reasoningDepth: d });
+      expect(w.maxIterations).toBeLessThanOrEqual(EFFORT_ITERATION_CEILING);
+    }
+    expect(deriveEffortWarrant({ reasoningDepth: "high" }).maxIterations).toBe(
+      EFFORT_ITERATION_CEILING,
+    );
+  });
+
+  it("floors the level at high when heavy build/plan tools are attached", () => {
+    const w = deriveEffortWarrant({
+      reasoningDepth: "minimal",
+      availableToolNames: ["send_message", "generate_code"],
+    });
+    expect(w.level).toBe("high");
+    expect(w.maxIterations).toBe(EFFORT_ITERATION_CEILING);
+    expect(w.maxDurationMs).toBe(600_000);
+    expect(w.signals).toContain("heavy-tools");
+  });
+
+  it("does not raise for ordinary (non-heavy) tools", () => {
+    const w = deriveEffortWarrant({
+      reasoningDepth: "minimal",
+      availableToolNames: ["list_backlog_items", "get_backlog_item"],
+    });
+    expect(w.level).toBe("minimal");
+  });
+
+  it("falls back to a taskType proxy when reasoningDepth is absent", () => {
+    expect(deriveEffortWarrant({ taskType: "conversation" }).level).toBe("minimal");
+    expect(deriveEffortWarrant({ taskType: "build" }).level).toBe("high");
+    expect(deriveEffortWarrant({ taskType: "analysis" }).level).toBe("medium");
+    expect(deriveEffortWarrant({ taskType: "conversation" }).signals).toContain(
+      "taskType:conversation",
+    );
+  });
+
+  it("defaults to low when no signal is present", () => {
+    const w = deriveEffortWarrant({});
+    expect(w.level).toBe("low");
+    expect(w.signals).toContain("default:low");
+  });
+
+  it("raises (never lowers) the level for a long input", () => {
+    const raised = deriveEffortWarrant({ reasoningDepth: "low", messageChars: 4000 });
+    expect(raised.level).toBe("medium");
+    expect(raised.signals).toContain("long-input");
+    // Already-high stays high; long input cannot push past the ceiling.
+    expect(deriveEffortWarrant({ reasoningDepth: "high", messageChars: 4000 }).level).toBe("high");
+    // A short high-effort turn is unaffected.
+    expect(deriveEffortWarrant({ reasoningDepth: "minimal", messageChars: 10 }).level).toBe(
+      "minimal",
+    );
+  });
+
+  it("maps each level to a distinct context tier", () => {
+    expect(deriveEffortWarrant({ reasoningDepth: "minimal" }).contextTier).toBe("basic");
+    expect(deriveEffortWarrant({ reasoningDepth: "low" }).contextTier).toBe("adequate");
+    expect(deriveEffortWarrant({ reasoningDepth: "medium" }).contextTier).toBe("strong");
+    expect(deriveEffortWarrant({ reasoningDepth: "high" }).contextTier).toBe("frontier");
+  });
+});

--- a/apps/web/lib/tak/effort-warrant.ts
+++ b/apps/web/lib/tak/effort-warrant.ts
@@ -1,0 +1,181 @@
+// EP-27FD96BC · P1 (BI-DA26BF90) — Unified per-turn effort-warrant signal.
+//
+// The spine. Before this module, a coworker turn's four effort knobs were set
+// in four unrelated places:
+//   - model tier / thinking ← reasoningDepth (routing/task-classifier → inferContract)
+//   - iterations            ← a flat MAX_ITERATIONS = 200 constant (agentic-loop.ts)
+//   - duration              ← which tools got *executed* so far (agentic-loop.ts)
+//   - context budget tier   ← a route-string guess (context-arbitrator.ts)
+// so a trivial "hi" and a complex build turn got the same 200-iteration / 120s
+// envelope. This derives ONE per-turn EffortWarrant from the signals already
+// present at the turn's single choke point, and the loop co-tunes iterations +
+// duration from it. `toolBudgetTarget` and `contextTier` are carried as spine
+// hooks the later pillars (P2 tool cap, P3 tools/skills, P4 delegation) consume;
+// this BI establishes the object, the others tune against it.
+//
+// Pure — no I/O, no LLM. Deterministic ladders, monotonic across levels.
+
+import type { ModelTier } from "./context-arbitrator";
+
+export type ReasoningDepth = "minimal" | "low" | "medium" | "high";
+
+/**
+ * A single per-turn effort level. Ordered minimal < low < medium < high; every
+ * co-tuned output rises monotonically with the level.
+ */
+export type EffortLevel = ReasoningDepth;
+
+export interface EffortWarrant {
+  /** The unified per-turn effort level. */
+  level: EffortLevel;
+  /** Pass-through hint for the model/thinking path (kept coherent with `level`). */
+  reasoningDepth: ReasoningDepth;
+  /** Loop iteration ceiling for this turn (always ≤ the hard safety ceiling). */
+  maxIterations: number;
+  /** Wall-clock baseline for this turn in ms (loop takes max with tool-revealed phase limits). */
+  maxDurationMs: number;
+  /** Context-arbitrator tier this effort warrants. */
+  contextTier: ModelTier;
+  /** Target attached-tool count — the spine hook P2/P3 rank toward. */
+  toolBudgetTarget: number;
+  /** Provenance: which signals raised/lowered the level. */
+  signals: string[];
+}
+
+export interface EffortWarrantInput {
+  /** The richest signal when available (content classifier). */
+  reasoningDepth?: ReasoningDepth | null;
+  /** Capability classifier output (tak/task-classifier taskType). */
+  taskType?: string | null;
+  /** Names of tools ATTACHED to the turn (not yet executed). */
+  availableToolNames?: readonly string[];
+  /** Length of the user turn's content, for a complexity proxy when depth is absent. */
+  messageChars?: number;
+}
+
+// ─── Ladders (monotonic; index by level) ────────────────────────────────────
+
+const LEVEL_ORDER: readonly EffortLevel[] = ["minimal", "low", "medium", "high"];
+
+/** Absolute safety ceiling — mirrors agentic-loop.ts MAX_ITERATIONS. */
+export const EFFORT_ITERATION_CEILING = 200;
+
+const ITERATIONS: Record<EffortLevel, number> = {
+  minimal: 20,
+  low: 50,
+  medium: 120,
+  high: EFFORT_ITERATION_CEILING,
+};
+
+// Duration ladder mirrors the existing phase ceilings so the warrant is a
+// coherent superset: a high turn matches the 600s build/plan ceiling, a minimal
+// turn drops below the flat 120s conversation limit.
+const DURATION_MS: Record<EffortLevel, number> = {
+  minimal: 90_000,
+  low: 150_000,
+  medium: 300_000,
+  high: 600_000,
+};
+
+const CONTEXT_TIER: Record<EffortLevel, ModelTier> = {
+  minimal: "basic",
+  low: "adequate",
+  medium: "strong",
+  high: "frontier",
+};
+
+// Tool-budget targets straddle the ~15-tool local accuracy cliff (P2 reuse):
+// trivial turns want a lean surface, heavy turns tolerate more.
+const TOOL_BUDGET_TARGET: Record<EffortLevel, number> = {
+  minimal: 8,
+  low: 12,
+  medium: 15,
+  high: 24,
+};
+
+// Heavy tool families — presence at turn start floors the level at `high` so a
+// genuine build/plan turn is never iteration- or time-starved by a terse prompt.
+// Kept in sync with the phase-duration detection in agentic-loop.ts.
+const HEAVY_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "launch_sandbox",
+  "generate_code",
+  "run_sandbox_tests",
+  "write_sandbox_file",
+  "edit_sandbox_file",
+  "run_sandbox_command",
+  "reviewBuildPlan",
+  "reviewDesignDoc",
+  "saveBuildEvidence",
+]);
+
+// taskType → base level when the content-classifier reasoningDepth is absent.
+const TASK_TYPE_BASE: Record<string, EffortLevel> = {
+  conversation: "minimal",
+  greeting: "minimal",
+  status: "low",
+  lookup: "low",
+  question: "low",
+  analysis: "medium",
+  planning: "medium",
+  research: "medium",
+  build: "high",
+  code: "high",
+  coding: "high",
+};
+
+const LONG_INPUT_CHARS = 1500;
+
+function levelIndex(level: EffortLevel): number {
+  return LEVEL_ORDER.indexOf(level);
+}
+
+function maxLevel(a: EffortLevel, b: EffortLevel): EffortLevel {
+  return levelIndex(a) >= levelIndex(b) ? a : b;
+}
+
+/**
+ * Derive the unified per-turn effort warrant from the signals available at the
+ * turn's choke point. Pure and deterministic.
+ */
+export function deriveEffortWarrant(input: EffortWarrantInput): EffortWarrant {
+  const signals: string[] = [];
+
+  // 1. Base level: prefer the content-classifier depth; else a taskType proxy;
+  //    else a message-length proxy; else minimal.
+  let level: EffortLevel;
+  if (input.reasoningDepth) {
+    level = input.reasoningDepth;
+    signals.push(`depth:${input.reasoningDepth}`);
+  } else if (input.taskType && TASK_TYPE_BASE[input.taskType]) {
+    level = TASK_TYPE_BASE[input.taskType]!;
+    signals.push(`taskType:${input.taskType}`);
+  } else {
+    level = "low";
+    signals.push("default:low");
+  }
+
+  // 2. Length proxy can only RAISE (a long prompt implies more to reason about).
+  if ((input.messageChars ?? 0) >= LONG_INPUT_CHARS) {
+    const raised = maxLevel(level, "medium");
+    if (raised !== level) signals.push("long-input");
+    level = raised;
+  }
+
+  // 3. Heavy-tool floor — attached build/plan tools warrant a full envelope.
+  const heavy = (input.availableToolNames ?? []).some((n) => HEAVY_TOOL_NAMES.has(n));
+  if (heavy) {
+    const raised = maxLevel(level, "high");
+    if (raised !== level) signals.push("heavy-tools");
+    level = raised;
+  }
+
+  return {
+    level,
+    reasoningDepth: input.reasoningDepth ?? level,
+    maxIterations: Math.min(EFFORT_ITERATION_CEILING, ITERATIONS[level]),
+    maxDurationMs: DURATION_MS[level],
+    contextTier: CONTEXT_TIER[level],
+    toolBudgetTarget: TOOL_BUDGET_TARGET[level],
+    signals,
+  };
+}

--- a/docs/superpowers/plans/2026-07-11-p1-effort-warrant-signal.md
+++ b/docs/superpowers/plans/2026-07-11-p1-effort-warrant-signal.md
@@ -1,0 +1,46 @@
+# P1 — Unified per-turn effort-warrant signal (the spine)
+
+- **BI:** BI-DA26BF90 · **Epic:** EP-27FD96BC · **Capsule:** WC-0FD4B82F
+- **Scope spec:** `docs/superpowers/specs/2026-07-11-coworker-reasoning-economy-scope.md`
+- **Kernel:** DI-A30D9C7D31C5 (umbrella structure). Work-scope/altitude of this BI: pure additive wiring, no new store/table → no further kernel routing required.
+
+## Problem (from the audit)
+
+A coworker turn's four effort knobs are decided in four independent places off unrelated inputs:
+- **model tier / thinking** ← `reasoningDepth` (`routing/task-classifier.ts` → `inferContract` → `cost-ranking`) — the *only* classified knob.
+- **iterations** ← a flat constant `MAX_ITERATIONS = 200` (`agentic-loop.ts:50`), unrelated to anything.
+- **duration** ← which tools got *executed* so far (`agentic-loop.ts:1415`), a runtime proxy.
+- **context budget tier** ← a route-string guess (`context-arbitrator.ts:158`), decoupled from the model actually chosen.
+
+There is no single per-turn signal these share, so a trivial turn and a complex turn can get the same 200-iteration / 120s envelope.
+
+## Approach — one signal, minimum surface
+
+Add one pure classifier that folds the signals already present at the turn's single choke point into a single `EffortWarrant`, and let the loop co-tune iterations + duration from it. The warrant also carries `toolBudgetTarget` and `contextTier` as **spine hooks** the later pillars (P2 tool cap, P3 tools/skills, P4 delegation) consume — this BI establishes the object; the others tune against it.
+
+Substrate-verify-first: nothing named `warrant` exists (greenfield type); the classifiers, the loop choke point, and the duration ladder all exist and are reused, not rebuilt.
+
+### 1. `apps/web/lib/tak/effort-warrant.ts` (new, pure)
+- `EffortLevel = "minimal" | "low" | "medium" | "high"`.
+- `EffortWarrant { level, reasoningDepth, maxIterations, maxDurationMs, contextTier, toolBudgetTarget, signals[] }`.
+- `deriveEffortWarrant(input)` where `input = { reasoningDepth?, taskType?, availableToolNames?, messageChars? }`:
+  - base level from `reasoningDepth` (reuse the existing 4-level ladder) when present, else a proxy from `taskType`/`messageChars`.
+  - **heavy-tool floor:** if build/plan tools are attached, floor the level at `high` (protects genuine build turns from iteration/time starvation — the duration ladder already treats these phases as heavy).
+  - emit the four co-tuned outputs from monotonic ladders (higher level ⇒ ≥ iterations, ≥ duration, ≥ tool budget, ≥ context tier). Iterations clamp at the existing `MAX_ITERATIONS` safety ceiling.
+
+### 2. Wire at the turn top — `agent-coworker.ts`
+Compute the warrant next to the existing `classifyTask` call (~:696) using the content-classifier `reasoningDepth`, the `taskType`, the attached tool names, and the message length; pass it into `executeAutonomousAgenticLoop` as a new optional `effortWarrant` param.
+
+### 3. Consume in the loop — `agentic-loop.ts`
+- Accept `effortWarrant?: EffortWarrant`.
+- Loop bound: `Math.min(MAX_ITERATIONS, effortWarrant?.maxIterations ?? MAX_ITERATIONS)` — **absent warrant = today's exact behavior (200).**
+- Duration: replace the `else MAX_DURATION_MS` baseline with `effortWarrant?.maxDurationMs ?? MAX_DURATION_MS`, and take `Math.max` with the tool-revealed phase limit so heavy phases still win.
+- Log the warrant (`level`, `maxIterations`, `maxDurationMs`) once per turn for observability; return it in the loop result metadata. (Turn-metric column enrichment is deferred to the P2 measure→act BI to keep this PR migration-free.)
+
+## Non-goals (owned by sibling BIs)
+- Consuming `toolBudgetTarget` into the actual attachment cap → BI-2B2F59EB / BI-ACE1EBA4 (P2/P3).
+- Spend-driven downgrade → BI-E8BCA547 (P2). Delegation decision → BI-8167C9CD (P4).
+
+## Verification
+- Unit: `effort-warrant.test.ts` — monotonicity across levels; heavy-tool floor; clamp at ceiling; a minimal turn yields strictly fewer iterations + shorter duration + smaller tool budget than a high turn.
+- Behavioral: absent-warrant path preserves 200/tool-ladder exactly (regression guard). Live: a trivial "hi" turn logs `level=minimal` with reduced iterations; a `/build` turn logs `level=high` with 200/600s.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -16,7 +16,7 @@ apps/web/components/workbooks/Grid.tsx	924
 apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1338
 apps/web/lib/actions/agent-coworker-external.test.ts	866
-apps/web/lib/actions/agent-coworker.ts	2712
+apps/web/lib/actions/agent-coworker.ts	2724
 apps/web/lib/actions/agent-task-scheduler.test.ts	1083
 apps/web/lib/actions/ai-providers.ts	915
 apps/web/lib/actions/build-governed.test.ts	1134
@@ -53,7 +53,7 @@ apps/web/lib/tak/agent-grants.test.ts	903
 apps/web/lib/tak/agent-grants.ts	807
 apps/web/lib/tak/agent-routing.ts	965
 apps/web/lib/tak/agentic-loop.test.ts	2113
-apps/web/lib/tak/agentic-loop.ts	2440
+apps/web/lib/tak/agentic-loop.ts	2469
 apps/web/lib/tak/route-context-map.ts	1226
 apps/web/lib/tak/route-context.ts	1363
 apps/web/lib/work-capsules/work-capsule-store.test.ts	943


### PR DESCRIPTION
## What

The **spine** of the AI Coworker Reasoning Economy epic (EP-27FD96BC, BI-DA26BF90). A coworker turn's effort knobs were decided in four unrelated places — model tier from `reasoningDepth`, iterations from a flat `MAX_ITERATIONS=200`, duration from which tools happened to execute, context tier from a route-string guess — so a trivial "hi" and a complex build turn got the same 200-iteration / 120s envelope.

This adds one pure classifier, `deriveEffortWarrant`, that folds the signals already present at the turn's single choke point (task type, attached tool surface, prompt length) into a single `EffortWarrant`. The agentic loop co-tunes **iterations** and **duration** from it; a heavy build/plan tool surface floors the level at `high` so real work is never starved. The warrant also carries `toolBudgetTarget` and `contextTier` as spine hooks the later pillars (tool cap, tools/skills, delegation) tune against — this BI establishes the object, the others consume it.

Absent a warrant, the loop preserves today's exact behavior (200 / phase durations) — the regression guard.

## Files
- `apps/web/lib/tak/effort-warrant.ts` (new, pure) + `effort-warrant.test.ts` (10 tests)
- `apps/web/lib/tak/agentic-loop.ts` — accept `effortWarrant`, co-tune iteration ceiling + conversation-phase duration baseline
- `apps/web/lib/tak/autonomous-work-run.ts` — thread `effortWarrant` through the wrapper
- `apps/web/lib/actions/agent-coworker.ts` — derive the warrant once per turn, pass it in
- Plan: `docs/superpowers/plans/2026-07-11-p1-effort-warrant-signal.md`

## Verification
- Unit: `effort-warrant.test.ts` — 10/10 green (monotonicity across levels, heavy-tool floor, iteration-ceiling clamp, taskType/length proxies).
- Typecheck: `tsc --noEmit` clean (0 errors, 12GB heap).
- Regression: absent-warrant path preserves `MAX_ITERATIONS` and the tool-revealed phase durations exactly.

**UX-Fit:** N/A — backend agentic-loop tuning, no new surface or operator-facing control.

Local-CI-Override: Verified-clean (unit 10/10, tsc 0 errors). Local-CI pregate blocked by fleet-wide sandbox-drift infra defect BI-E9E0FF0A (pnpm store v10/v11 split + degraded network prevents relinking next@16.2.10 in the shared runner; convergence install reports downloaded 0 and links the stale version). GitHub CI required checks are the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)