### PR TITLE
feat(coworker-memory): promote durable org facts into the WWWD corpus (EP-27FD96BC P5)

### DIFF
--- a/apps/web/lib/queue/functions/memory-consolidation-nightly.ts
+++ b/apps/web/lib/queue/functions/memory-consolidation-nightly.ts
@@ -20,6 +20,7 @@ import {
   expireStaleUserFacts,
   pruneSummarizedThreadMessages,
 } from "@/lib/tak/memory-expiry-runner";
+import { promoteOrgFactsToCorpus } from "@/lib/tak/memory-corpus-promotion";
 
 /** 04:20 UTC daily — off-peak, clear of the 03:00 backup + 04:00 retention slots. */
 export const MEMORY_CONSOLIDATION_CRON = "20 4 * * *";
@@ -33,6 +34,7 @@ export interface MemoryConsolidationResult {
   factsExpired: number;
   threadsPruned: number;
   messagesPruned: number;
+  factsPromotedToCorpus: number;
 }
 
 /**
@@ -50,6 +52,7 @@ export async function runMemoryConsolidationSweep(): Promise<MemoryConsolidation
     factsExpired: 0,
     threadsPruned: 0,
     messagesPruned: 0,
+    factsPromotedToCorpus: 0,
   };
 
   // Coworkers with at least one active note.
@@ -82,6 +85,17 @@ export async function runMemoryConsolidationSweep(): Promise<MemoryConsolidation
     } catch (err) {
       console.warn(`[autoDream] user ${userId} sweep failed:`, err);
     }
+  }
+
+  // Promote durable org-scoped facts into the WWWD org corpus (BI-BC37727B).
+  // Runs AFTER dedupe/expire so a promoted fact is the settled, non-duplicate
+  // survivor. Install-wide (one org); lands corpus drafts a human reviews. One
+  // failure inside the pass is logged there and never aborts the sweep.
+  try {
+    const promotion = await promoteOrgFactsToCorpus();
+    result.factsPromotedToCorpus += promotion.promoted;
+  } catch (err) {
+    console.warn("[autoDream] org-fact corpus promotion failed:", err);
   }
 
   // Prune raw messages already folded into a durable checkpoint and older than

--- a/apps/web/lib/tak/memory-corpus-promotion.test.ts
+++ b/apps/web/lib/tak/memory-corpus-promotion.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  isPromotableFact,
+  buildFactCorpusInput,
+  promoteOrgFactsToCorpus,
+  type PromotableFact,
+} from "./memory-corpus-promotion";
+
+function fact(overrides: Partial<PromotableFact> = {}): PromotableFact {
+  return {
+    id: "UF-1",
+    category: "domain_context",
+    key: "shipping_regions",
+    value: "EU only, Tuesdays",
+    scope: "org",
+    sensitivity: "normal",
+    supersededAt: null,
+    corpusPromotedAt: null,
+    ...overrides,
+  };
+}
+
+describe("isPromotableFact", () => {
+  it("promotes a durable org-scoped normal business fact", () => {
+    expect(isPromotableFact(fact())).toBe(true);
+    expect(isPromotableFact(fact({ category: "decision" }))).toBe(true);
+    expect(isPromotableFact(fact({ category: "constraint" }))).toBe(true);
+  });
+
+  it("rejects user-scoped, sensitive, superseded, or already-promoted facts", () => {
+    expect(isPromotableFact(fact({ scope: "user" }))).toBe(false);
+    expect(isPromotableFact(fact({ sensitivity: "sensitive" }))).toBe(false);
+    expect(isPromotableFact(fact({ supersededAt: new Date() }))).toBe(false);
+    expect(isPromotableFact(fact({ corpusPromotedAt: new Date() }))).toBe(false);
+  });
+
+  it("never promotes preference facts (per-user relationship memory, not org knowledge)", () => {
+    expect(isPromotableFact(fact({ category: "preference" }))).toBe(false);
+  });
+});
+
+describe("buildFactCorpusInput", () => {
+  it("maps a fact onto the enrichOrgCorpus contract with qa/first-party provenance", () => {
+    const input = buildFactCorpusInput(fact(), "ORG-1");
+    expect(input.organizationId).toBe("ORG-1");
+    expect(input.text).toBe("shipping_regions: EU only, Tuesdays");
+    expect(input.trust).toBe("first-party");
+    expect(input.provenance.sourceType).toBe("qa");
+  });
+
+  it("keys sourceRef on the stable fact key so re-promotion upserts the same page", () => {
+    const a = buildFactCorpusInput(fact({ id: "UF-1", value: "old" }), "ORG-1");
+    const b = buildFactCorpusInput(fact({ id: "UF-2", value: "new" }), "ORG-1");
+    // Same key → identical sourceRef → same derived sourceKey downstream.
+    expect(a.provenance.sourceRef).toEqual(b.provenance.sourceRef);
+    expect(a.provenance.sourceRef).toMatchObject({ factKey: "shipping_regions" });
+  });
+});
+
+describe("promoteOrgFactsToCorpus", () => {
+  function makeDb(facts: PromotableFact[], org: { id: string } | null = { id: "ORG-1" }) {
+    const updates: Array<{ id: string; corpusPromotedAt: unknown }> = [];
+    return {
+      updates,
+      db: {
+        organization: { findFirst: vi.fn(async (_args: unknown) => org) },
+        userFact: {
+          findMany: vi.fn(async (_args: unknown) => facts),
+          update: vi.fn(async (args: unknown) => {
+            const { where, data } = args as {
+              where: { id: string };
+              data: { corpusPromotedAt: unknown };
+            };
+            updates.push({ id: where.id, corpusPromotedAt: data.corpusPromotedAt });
+            return {};
+          }),
+        },
+      },
+    };
+  }
+
+  it("promotes each eligible fact and stamps corpusPromotedAt", async () => {
+    const { db, updates } = makeDb([fact({ id: "UF-1" }), fact({ id: "UF-2" })]);
+    const enrich = vi.fn(async () => ({}));
+    const res = await promoteOrgFactsToCorpus({ db, enrich });
+    expect(res.promoted).toBe(2);
+    expect(res.failed).toBe(0);
+    expect(enrich).toHaveBeenCalledTimes(2);
+    expect(updates.map((u) => u.id)).toEqual(["UF-1", "UF-2"]);
+    expect(updates[0]!.corpusPromotedAt).toBeInstanceOf(Date);
+  });
+
+  it("no-ops when the install has no organization", async () => {
+    const { db } = makeDb([fact()], null);
+    const enrich = vi.fn(async () => ({}));
+    const res = await promoteOrgFactsToCorpus({ db, enrich });
+    expect(res).toEqual({ promoted: 0, failed: 0 });
+    expect(enrich).not.toHaveBeenCalled();
+  });
+
+  it("isolates a per-fact failure and continues (never aborts the pass)", async () => {
+    const { db, updates } = makeDb([fact({ id: "UF-1" }), fact({ id: "UF-2" })]);
+    const enrich = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("inference blip"))
+      .mockResolvedValueOnce({});
+    const res = await promoteOrgFactsToCorpus({ db, enrich });
+    expect(res.promoted).toBe(1);
+    expect(res.failed).toBe(1);
+    // Only the successful fact is stamped promoted.
+    expect(updates.map((u) => u.id)).toEqual(["UF-2"]);
+  });
+
+  it("does not stamp a fact whose enrich succeeded but update is skipped when ineligible", async () => {
+    // A preference fact slipping through the query is still rejected by the guard.
+    const { db, updates } = makeDb([fact({ id: "UF-1", category: "preference" })]);
+    const enrich = vi.fn(async () => ({}));
+    const res = await promoteOrgFactsToCorpus({ db, enrich });
+    expect(res.promoted).toBe(0);
+    expect(enrich).not.toHaveBeenCalled();
+    expect(updates).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/tak/memory-corpus-promotion.ts
+++ b/apps/web/lib/tak/memory-corpus-promotion.ts
@@ -1,0 +1,157 @@
+// EP-27FD96BC · P5 (BI-BC37727B) — memory → corpus automatic promotion.
+//
+// The coworker memory stores and the WWWD org corpus were two disconnected
+// planes: enrichOrgCorpus was fed only by onboarding + AI research, never by the
+// facts a coworker learns in conversation. Yet a UserFact already carries the
+// exact signal that a fact belongs to the organization: scope="org" (a durable
+// business fact, readable across every employee) + sensitivity="normal" (safe to
+// share). Those facts ARE org corpus material — they were just never routed there.
+//
+// This is the memory-source adapter: a nightly promoter that maps durable
+// org-scoped facts through the existing enrichOrgCorpus façade. Kernel decision
+// (DI, principle_decide 2026-07-11): BATCH-NIGHTLY over real-time fire-and-forget
+// (composite 8.94 vs 7.04, high confidence) — keeps LLM inference off the
+// interactive write path and matches the proof-point "a fact learned in chat
+// appears in the corpus next day."
+//
+// enrichOrgCorpus lands everything DRAFT-by-default (a human reviews before it
+// becomes authoritative), so promotion never silently rewrites the org's stance.
+// The corpusPromotedAt marker makes the pass idempotent: a promoted fact is never
+// re-inferred, and a superseded fact's replacement row starts NULL, so a changed
+// value re-promotes and refreshes the same corpus page (sourceRef is keyed on the
+// stable fact key).
+
+import { prisma } from "@dpf/db";
+import {
+  enrichOrgCorpus,
+  type EnrichOrgCorpusInput,
+  type EnrichmentProvenance,
+} from "@/lib/wiki/enrich-org-corpus";
+import { createProductionInference } from "@/lib/wiki/inference-adapter";
+
+/** The fact fields the promoter reads. Structural so tests need no Prisma. */
+export interface PromotableFact {
+  id: string;
+  category: string; // preference | decision | constraint | domain_context
+  key: string;
+  value: string;
+  scope: string;
+  sensitivity: string;
+  supersededAt: Date | null;
+  corpusPromotedAt: Date | null;
+}
+
+// Preference facts are per-user relationship memory ("likes terse replies"), not
+// organizational knowledge — they never belong in the org corpus even when the
+// scope classifier marks them org. The durable business categories (decision,
+// constraint, domain_context) do.
+export const NON_CORPUS_CATEGORIES: ReadonlySet<string> = new Set(["preference"]);
+
+/**
+ * A fact promotes iff it is a durable, shareable, not-yet-promoted org fact of a
+ * business category. Pure.
+ */
+export function isPromotableFact(fact: PromotableFact): boolean {
+  return (
+    fact.scope === "org" &&
+    fact.sensitivity === "normal" &&
+    fact.supersededAt == null &&
+    fact.corpusPromotedAt == null &&
+    !NON_CORPUS_CATEGORIES.has(fact.category)
+  );
+}
+
+/**
+ * Map a durable fact onto the enrichOrgCorpus contract. sourceRef is keyed on the
+ * stable fact key so a re-promotion (after supersession) upserts the SAME corpus
+ * page rather than orphaning it. Pure — the caller supplies `infer`.
+ */
+export function buildFactCorpusInput(
+  fact: PromotableFact,
+  organizationId: string,
+): Omit<EnrichOrgCorpusInput, "infer"> {
+  const provenance: EnrichmentProvenance = {
+    sourceType: "qa", // learned in an employee's conversation with a coworker
+    sourceRef: { factKey: fact.key, category: fact.category },
+  };
+  return {
+    organizationId,
+    text: `${fact.key}: ${fact.value}`,
+    provenance,
+    // An employee stated it directly to the coworker → first-party evidence.
+    trust: "first-party",
+    title: `Business fact — ${fact.key}`,
+  };
+}
+
+export interface PromoteOrgFactsDeps {
+  db?: {
+    organization: { findFirst: (args: unknown) => Promise<{ id: string } | null> };
+    userFact: {
+      findMany: (args: unknown) => Promise<PromotableFact[]>;
+      update: (args: unknown) => Promise<unknown>;
+    };
+  };
+  /** Injectable for tests; production maps a fact through enrichOrgCorpus. */
+  enrich?: (input: Omit<EnrichOrgCorpusInput, "infer">) => Promise<unknown>;
+  /** Max facts promoted per pass (keeps the nightly window bounded). */
+  limit?: number;
+}
+
+export interface PromoteOrgFactsResult {
+  promoted: number;
+  failed: number;
+}
+
+/**
+ * Promote durable org-scoped facts into the WWWD org corpus. One install = one
+ * organization, so this is an install-wide pass. Each fact is handled
+ * independently; one failure is logged and does not abort the pass.
+ */
+export async function promoteOrgFactsToCorpus(
+  deps: PromoteOrgFactsDeps = {},
+): Promise<PromoteOrgFactsResult> {
+  const db = deps.db ?? (prisma as unknown as NonNullable<PromoteOrgFactsDeps["db"]>);
+  const limit = deps.limit ?? 50;
+  const enrich =
+    deps.enrich ??
+    ((input: Omit<EnrichOrgCorpusInput, "infer">) =>
+      enrichOrgCorpus({
+        ...input,
+        infer: createProductionInference({ taskType: "wiki_proposal" }),
+      }));
+
+  const org = await db.organization.findFirst({ select: { id: true } });
+  if (!org) return { promoted: 0, failed: 0 };
+
+  const candidates = await db.userFact.findMany({
+    where: {
+      scope: "org",
+      sensitivity: "normal",
+      supersededAt: null,
+      corpusPromotedAt: null,
+      category: { notIn: Array.from(NON_CORPUS_CATEGORIES) },
+    },
+    orderBy: [{ confidence: "desc" }, { createdAt: "asc" }],
+    take: limit,
+  });
+
+  let promoted = 0;
+  let failed = 0;
+  for (const fact of candidates) {
+    // Defensive: the query already filters, but keep the pure guard authoritative.
+    if (!isPromotableFact(fact)) continue;
+    try {
+      await enrich(buildFactCorpusInput(fact, org.id));
+      await db.userFact.update({
+        where: { id: fact.id },
+        data: { corpusPromotedAt: new Date() },
+      });
+      promoted += 1;
+    } catch (err) {
+      console.warn(`[memory-corpus] promote fact ${fact.id} failed:`, err);
+      failed += 1;
+    }
+  }
+  return { promoted, failed };
+}

--- a/docs/superpowers/plans/2026-07-11-p5-memory-corpus-promotion.md
+++ b/docs/superpowers/plans/2026-07-11-p5-memory-corpus-promotion.md
@@ -1,0 +1,32 @@
+# P5 — Memory → corpus automatic promotion
+
+- **BI:** BI-BC37727B · **Epic:** EP-27FD96BC
+- **Scope spec:** `docs/superpowers/specs/2026-07-11-coworker-reasoning-economy-scope.md`
+- **Kernel:** approach routed via `principle_decide` 2026-07-11 (guard off on the source branch). **Batch-nightly** over real-time fire-and-forget — composite 8.94 vs 7.04, high confidence; governing profile: platform. Rationale: keep LLM inference off the interactive write path; match the proof-point "a fact learned in chat appears in the corpus next day."
+
+## Problem (from the audit)
+
+Two information planes never touched. `enrichOrgCorpus` (the WWWD org-corpus façade) is fed only by onboarding market-context, business-document upload, and AI research (`EnrichmentSourceType` has `qa`/`data-entry` values but no feeder uses them). Coworker memory (`UserFact`) captures durable business facts in conversation but never routes them to the corpus. So a fact an employee tells a coworker ("we only ship to the EU on Tuesdays") stays private memory and never becomes reviewable org knowledge.
+
+## The signal already exists
+
+`UserFact.scope="org"` + `sensitivity="normal"` (set at write time by the memory-scope classifier, EP-8C706944 P4) is *exactly* "a durable business fact that belongs to the organization, readable across every employee." Those facts are org-corpus material — they were simply never promoted. No new classifier is needed; this BI is the missing adapter.
+
+## Approach — a nightly promoter through the existing façade
+
+Substrate-verify-first: reuse `enrichOrgCorpus` (draft-by-default, idempotent on sourceKey, embeds to Qdrant, links `PerspectiveMaterial`) and the existing nightly `runMemoryConsolidationSweep` (04:20 UTC, quiescence-gated). No new store, no new scheduler.
+
+1. **Schema** — one additive, nullable column `UserFact.corpusPromotedAt DateTime?` (migration `20260711130000_add_user_fact_corpus_promoted`). NULL = not yet promoted. Makes the pass idempotent (never re-infer a promoted fact) and lets a superseded fact's replacement row (fresh NULL) re-promote and refresh the same corpus page.
+2. **`apps/web/lib/tak/memory-corpus-promotion.ts`** (new):
+   - `isPromotableFact` (pure): `scope==="org" && sensitivity==="normal" && !supersededAt && !corpusPromotedAt && category ∉ {preference}`. Preference facts are per-user relationship memory, not org knowledge.
+   - `buildFactCorpusInput` (pure): fact → `enrichOrgCorpus` input; `sourceType:"qa"`, `trust:"first-party"`, `sourceRef` keyed on the stable `factKey` so a re-promotion upserts the same page.
+   - `promoteOrgFactsToCorpus(deps)`: install-wide (one org), bounded per pass, per-fact isolated (one failure logged, pass continues), stamps `corpusPromotedAt` on success. Deps injectable for tests.
+3. **Wire** — call it in `runMemoryConsolidationSweep` *after* the dedupe/expire pass, so the promoted fact is the settled survivor. Add `factsPromotedToCorpus` to the result.
+
+## Non-goals
+- Publishing corpus pages (stays draft — humans review via the existing overlay-draft affordance).
+- Promoting per-user (`scope="user"`) or `sensitive` facts — those never leave their originating user.
+
+## Verification
+- Unit (`memory-corpus-promotion.test.ts`): the guard (org+normal+unpromoted+business-category only; rejects user-scope, sensitive, superseded, already-promoted, preference); the mapping (statement text, qa/first-party provenance, stable factKey sourceRef); the promoter (promotes eligible, stamps `corpusPromotedAt`, skips ineligible, survives a per-fact failure, no-op when no org).
+- Behavioral: an org-scoped normal fact written today has `corpusPromotedAt` set and a draft WWWD overlay page after the nightly pass; re-running is a no-op (idempotent).

--- a/packages/db/prisma/migrations/20260711130000_add_user_fact_corpus_promoted/migration.sql
+++ b/packages/db/prisma/migrations/20260711130000_add_user_fact_corpus_promoted/migration.sql
@@ -1,0 +1,7 @@
+-- BI-BC37727B (EP-27FD96BC P5): memory→corpus automatic promotion marker.
+-- Records when a durable org-scoped UserFact was promoted into the WWWD org
+-- corpus by the nightly promoter, so the pass never re-infers an unchanged fact.
+-- Additive + nullable — every existing fact stays NULL (not yet promoted), so no
+-- existing row can violate this and no backfill runs.
+-- @migration-safety: data-safe: nullable column, no default, no backfill.
+ALTER TABLE "UserFact" ADD COLUMN "corpusPromotedAt" TIMESTAMP(3);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4529,6 +4529,10 @@ model UserFact {
   // the memory-scope classifier.
   scope                             String     @default("user")
   sensitivity                       String     @default("normal")
+  // BI-BC37727B (EP-27FD96BC P5): set by the nightly memory→corpus promoter when
+  // a durable org-scoped fact has been enriched into the WWWD corpus. NULL = not
+  // yet promoted; a superseded fact's replacement row starts NULL and re-promotes.
+  corpusPromotedAt                  DateTime?
   createdAt                         DateTime   @default(now())
   updatedAt                         DateTime   @updatedAt
   user                              User       @relation(fields: [userId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## What

BI-BC37727B (EP-27FD96BC P5). `enrichOrgCorpus` was fed only by onboarding + AI research; the durable business facts a coworker learns in conversation never reached the org corpus. But a `UserFact` with `scope="org"` + `sensitivity="normal"` (set by the memory-scope classifier) *is* org-corpus material. This adds the missing memory-source adapter.

A nightly promoter maps those facts through the existing `enrichOrgCorpus` façade — which lands everything **draft-by-default**, so a human reviews before anything becomes authoritative. Preference facts never promote (per-user relationship memory, not org knowledge).

**Kernel-routed approach** (`principle_decide`, 2026-07-11): batch-nightly over real-time fire-and-forget (composite 8.94 vs 7.04, high confidence) — keeps LLM inference off the interactive write path and matches the proof-point "a fact learned in chat appears in the corpus next day."

## Files
- `packages/db/prisma/migrations/20260711130000_add_user_fact_corpus_promoted/` + schema: `UserFact.corpusPromotedAt DateTime?` (additive, nullable). Makes the pass idempotent; a superseded fact's replacement row re-promotes and refreshes the same page (sourceRef keyed on `factKey`).
- `apps/web/lib/tak/memory-corpus-promotion.ts` (+ 9 unit tests) — pure `isPromotableFact` / `buildFactCorpusInput` + the install-wide, per-fact-isolated promoter.
- `apps/web/lib/queue/functions/memory-consolidation-nightly.ts` — wired after dedupe/expire.
- Plan: `docs/superpowers/plans/2026-07-11-p5-memory-corpus-promotion.md`

## Verification
- Unit: 9/9 green (guard rejects user-scope/sensitive/superseded/promoted/preference; mapping; promoter stamps `corpusPromotedAt`, isolates per-fact failure, no-ops without an org).
- Typecheck: 0 errors (12GB heap). Schema-regression + migration-safety guards passed at commit (additive nullable, no backfill).

**UX-Fit:** N/A — backend nightly job; promoted pages surface via the existing WWWD overlay-draft review affordance, no new surface.

Local-CI-Override: Verified-clean (unit 9/9, tsc 0). Local-CI pregate blocked by fleet-wide sandbox-drift infra defect BI-E9E0FF0A (pnpm store v10/v11 split + degraded network prevents relinking next@16.2.10). GitHub CI required checks are the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)