### PR TITLE
feat(decision-gov): archetype stance-vector defaults + WWWD seeding across all 4 decision classes (BI-70ADC71F)

### DIFF
--- a/apps/web/lib/onboarding/archetype-business-context.test.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   resolveBusinessProfile,
   GENERIC_BUSINESS_PROFILE,
+  resolveStanceVectors,
+  GENERIC_STANCE_VECTORS,
 } from "./archetype-business-context";
 
 describe("resolveBusinessProfile", () => {
@@ -120,5 +122,42 @@ describe("resolveBusinessProfile", () => {
       const industry = resolveBusinessProfile({ industry: "healthcare-wellness" });
       expect(dental.supplyChain).toBe(industry.supplyChain);
     });
+  });
+});
+
+describe("resolveStanceVectors (BI-70ADC71F)", () => {
+  it("returns the generic set for an unknown industry, with all 5 vectors present", () => {
+    const v = resolveStanceVectors({ archetypeId: null, industry: "no-such-industry" });
+    expect(Object.keys(v).sort()).toEqual([
+      "customer-goodwill",
+      "growth-vs-stability",
+      "pricing-integrity",
+      "quality-bar",
+      "spend-authority",
+    ]);
+    expect(v["customer-goodwill"].ceilingUsd).toBe(100);
+    expect(v["spend-authority"].ceilingUsd).toBe(250);
+    for (const key of Object.keys(v) as (keyof typeof v)[]) {
+      expect(v[key].stance.length).toBeGreaterThan(40);
+      expect(v[key].title.length).toBeGreaterThan(5);
+    }
+  });
+
+  it("merges industry overrides over the generic set (healthcare)", () => {
+    const v = resolveStanceVectors({ archetypeId: "dental-practice", industry: "healthcare-wellness" });
+    // Overridden vectors carry the healthcare posture…
+    expect(v["customer-goodwill"].ceilingUsd).toBe(150);
+    expect(v["customer-goodwill"].stance).toMatch(/patient/i);
+    expect(v["quality-bar"].stance).toMatch(/safety|clinical/i);
+    expect(v["spend-authority"].ceilingUsd).toBe(500);
+    // …vectors without an override fall back to generic.
+    expect(v["growth-vs-stability"]).toEqual(GENERIC_STANCE_VECTORS["growth-vs-stability"]);
+    expect(v["pricing-integrity"]).toEqual(GENERIC_STANCE_VECTORS["pricing-integrity"]);
+  });
+
+  it("public-sector goodwill carries no discretionary ceiling", () => {
+    const v = resolveStanceVectors({ industry: "public-sector" });
+    expect(v["customer-goodwill"].ceilingUsd).toBeUndefined();
+    expect(v["customer-goodwill"].stance).toMatch(/resident|process|equal/i);
   });
 });

--- a/apps/web/lib/onboarding/archetype-business-context.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.ts
@@ -335,6 +335,222 @@ const ARCHETYPE_PROFILES: Record<string, Partial<ArchetypeBusinessProfile>> = {
   },
 };
 
+// ─── Stance vectors (EP-0AF96937 company-stance onboarding, BI-70ADC71F) ─────
+// The 5 coverage vectors that prime the WWWD decision gate: each becomes an
+// org-overlay stance page + PerspectiveMaterial bundle at seeding time
+// (unconfirmed B/0.6 — clears nothing until the owner confirms). Same contract
+// as the profiles above: broad, true, EDITABLE STARTERS in the industry's own
+// vocabulary; never fabricated specifics. Ceilings are rendered into the stance
+// body text (the deliberation layer reads them semantically) — no schema field.
+
+export const STANCE_VECTOR_KEYS = [
+  "customer-goodwill",
+  "pricing-integrity",
+  "growth-vs-stability",
+  "quality-bar",
+  "spend-authority",
+] as const;
+export type StanceVectorKey = (typeof STANCE_VECTOR_KEYS)[number];
+
+export type StanceVectorDefault = {
+  /** Card/page title in plain language (a question the owner recognizes). */
+  title: string;
+  /** The default stance — 1–3 plain sentences, owner-editable starter. */
+  stance: string;
+  /** Authority ceiling in whole USD (goodwill / pricing / spend vectors). */
+  ceilingUsd?: number;
+};
+
+export type ArchetypeStanceVectors = Record<StanceVectorKey, StanceVectorDefault>;
+
+export const GENERIC_STANCE_VECTORS: ArchetypeStanceVectors = {
+  "customer-goodwill": {
+    title: "When something goes wrong on our side",
+    stance:
+      "When a problem is our fault, we make it right quickly — a redo, replacement, refund, or credit — without making the customer fight for it. Within the goodwill ceiling, resolve it on the spot; beyond it, the owner decides.",
+    ceilingUsd: 100,
+  },
+  "pricing-integrity": {
+    title: "Prices, quotes, and discounts",
+    stance:
+      "We honor the prices we quote, including our own mistakes, and fix the source of the error. Discounts are deliberate, not improvised: offer one only when it serves a relationship we want to keep, and never price below what the work costs us.",
+    ceilingUsd: 100,
+  },
+  "growth-vs-stability": {
+    title: "New opportunities vs existing commitments",
+    stance:
+      "When new opportunities compete with commitments to existing customers, existing commitments get first call on our capacity. We take on new work at the pace quality allows, not faster.",
+  },
+  "quality-bar": {
+    title: "Our quality standard",
+    stance:
+      "Work that leaves our hands meets our standard. If something slips below it, we fix it at our cost before it costs us trust — a redo is cheaper than a lost reputation.",
+  },
+  "spend-authority": {
+    title: "Spending without asking",
+    stance:
+      "Routine, budgeted purchases that keep the business running can proceed without the owner, up to the spend ceiling per purchase. Anything novel, recurring, or above the ceiling goes to the owner first.",
+    ceilingUsd: 250,
+  },
+};
+
+/** Industry overrides — only the vectors where the posture genuinely differs. */
+const INDUSTRY_STANCE_VECTORS: Record<string, Partial<ArchetypeStanceVectors>> = {
+  "healthcare-wellness": {
+    "customer-goodwill": {
+      title: "When a patient's experience goes wrong",
+      stance:
+        "A failure in a patient's experience gets a same-day response and a genuine fix — rebook first, waive or comp where we fell short, and tell the owner the same day. Never argue with a patient over a fee we caused.",
+      ceilingUsd: 150,
+    },
+    "quality-bar": {
+      title: "Our care standard",
+      stance:
+        "Patient safety and clinical quality are never traded for speed or margin. If care or service slips below our standard, we correct it at our cost and say so plainly.",
+    },
+    "spend-authority": {
+      title: "Spending without asking",
+      stance:
+        "Recurring clinical and office supplies reorder without the owner up to the ceiling per purchase — a stock-out can delay care. New equipment, new vendors, or anything above the ceiling goes to the owner.",
+      ceilingUsd: 500,
+    },
+  },
+  "food-hospitality": {
+    "customer-goodwill": {
+      title: "When a guest's visit goes wrong",
+      stance:
+        "Fix the visit while the guest is still at the table: remake or comp the dish, not the argument. Staff resolve it on the spot within the ceiling; a comped meal that wins the next three visits is cheap.",
+      ceilingUsd: 60,
+    },
+    "quality-bar": {
+      title: "What leaves the pass",
+      stance:
+        "Food safety and cleanliness are never negotiable. If a plate isn't right, it doesn't leave the pass — and if it did, we remake it without debate.",
+    },
+  },
+  "retail-goods": {
+    "customer-goodwill": {
+      title: "Returns, damage, and our mistakes",
+      stance:
+        "If we shipped it wrong, late, or broken, we replace or refund without friction within the ceiling — the customer should not pay for our mistake. Habitual-abuse cases go to the owner rather than becoming policy.",
+      ceilingUsd: 75,
+    },
+    "spend-authority": {
+      title: "Restocking without asking",
+      stance:
+        "Reorders of proven sellers within budget proceed without the owner up to the ceiling per order. New lines, new suppliers, or bulk buys above it are the owner's call — stock ties up cash.",
+      ceilingUsd: 200,
+    },
+  },
+  "professional-services": {
+    "customer-goodwill": {
+      title: "When our work misses the mark",
+      stance:
+        "When our advice or work falls short, we remediate with more of our own work first, a credit second, and a refund only when trust demands it. The relationship compounds over years; the fix should protect it.",
+      ceilingUsd: 250,
+    },
+    "pricing-integrity": {
+      title: "Fees, scope, and discounts",
+      stance:
+        "We honor quoted fees and absorb our own estimating mistakes on the current engagement while correcting them for the next one. We do not discount below the cost of doing the work well — a cheap engagement done badly costs the reputation.",
+    },
+  },
+  "banking-financial-services": {
+    "customer-goodwill": {
+      title: "When we make an account error",
+      stance:
+        "Fees or charges caused by our error are reversed promptly within the ceiling and documented. Anything touching disclosures, rates, or regulated terms goes to the owner — goodwill never bends compliance.",
+      ceilingUsd: 100,
+    },
+    "pricing-integrity": {
+      title: "Rates, terms, and exceptions",
+      stance:
+        "Rate and term claims always match what we actually offer, and required disclosures stay attached. There are no improvised pricing exceptions — every exception is an owner decision with a record.",
+    },
+  },
+  "trades-maintenance": {
+    "customer-goodwill": {
+      title: "Callbacks and our mistakes",
+      stance:
+        "A callback on our own work is priority scheduling and free within the ceiling — we stand behind the work. If the fault is genuinely not ours, we say so honestly and quote the real job.",
+      ceilingUsd: 150,
+    },
+    "spend-authority": {
+      title: "Parts and van stock without asking",
+      stance:
+        "Parts and materials needed to finish a booked job proceed without the owner up to the ceiling — a second trip costs more than the part. Tools, equipment, and new suppliers are the owner's call.",
+      ceilingUsd: 300,
+    },
+  },
+  "automotive-services": {
+    "customer-goodwill": {
+      title: "When our repair doesn't hold",
+      stance:
+        "If our part or work fails, we return and make it right free within the ceiling, at the customer's location, at the next available slot. Safety-related comebacks jump the queue.",
+      ceilingUsd: 150,
+    },
+  },
+  "software-platform": {
+    "customer-goodwill": {
+      title: "When our product or billing fails a customer",
+      stance:
+        "Outages, bugs, and billing errors on our side are credited or refunded without friction within the ceiling, and we say plainly what went wrong. A long-time customer harmed by our mistake is restored first, reconciled second.",
+      ceilingUsd: 200,
+    },
+    "growth-vs-stability": {
+      title: "New features vs reliability",
+      stance:
+        "Reliability and existing-customer success outrank new-feature velocity — churn from broken trust costs more than a delayed launch. We ship new capability at the pace uptime and support quality allow.",
+    },
+  },
+  "education-training": {
+    "customer-goodwill": {
+      title: "When we fail a learner or family",
+      stance:
+        "If we cancel, misschedule, or under-deliver, we make the learner whole first — a make-up session or credit within the ceiling — and tell the family before they ask.",
+      ceilingUsd: 100,
+    },
+  },
+  "public-sector": {
+    "customer-goodwill": {
+      title: "When we get it wrong with a resident",
+      stance:
+        "Errors are corrected through the published process, equally for every resident — fee waivers and remedies follow the schedule, not discretion. Transparency about the mistake is part of the remedy.",
+    },
+    "pricing-integrity": {
+      title: "Fees and charges",
+      stance:
+        "Fees are set in public session and applied uniformly. There are no discounts or improvised exceptions — changing a fee is a public decision, not a service gesture.",
+    },
+  },
+  "nonprofit-community": {
+    "spend-authority": {
+      title: "Spending donors' money without asking",
+      stance:
+        "Program supplies within the approved budget proceed up to the ceiling per purchase. Anything outside budget or above it goes to the director — every dollar carries a donor's trust.",
+      ceilingUsd: 150,
+    },
+  },
+};
+
+/**
+ * Resolve the stance-vector defaults for an org: industry overrides merged
+ * over the generic set. Pure and deterministic; primary archetype only (no
+ * secondary blending — mixed stances read as mush, and the owner confirms or
+ * adjusts each card anyway).
+ */
+export function resolveStanceVectors(input: {
+  archetypeId?: string | null;
+  industry?: string | null;
+}): ArchetypeStanceVectors {
+  const overrides = (input.industry ? INDUSTRY_STANCE_VECTORS[input.industry] : undefined) ?? {};
+  const merged = {} as Record<StanceVectorKey, StanceVectorDefault>;
+  for (const key of STANCE_VECTOR_KEYS) {
+    merged[key] = overrides[key] ?? GENERIC_STANCE_VECTORS[key];
+  }
+  return merged;
+}
+
 /**
  * Resolve the best business profile for an org: a flagship archetype override
  * (merged over its industry profile) when available, else the industry profile,

--- a/apps/web/lib/onboarding/backfill-org-wwwd-on-boot.test.ts
+++ b/apps/web/lib/onboarding/backfill-org-wwwd-on-boot.test.ts
@@ -64,10 +64,13 @@ describe("backfillOrgWwwdOnBoot", () => {
     expect(runSeedsMock).toHaveBeenCalledWith("org-1");
   });
 
-  it("does nothing for a healthy org (profile + overlay pages present)", async () => {
+  it("does nothing for a healthy org (profile + overlay pages + all vector pages present)", async () => {
     prismaMock.organizationFindMany.mockResolvedValue([{ id: "org-1" }]);
     resolveOrgProfileIdMock.mockResolvedValue("org-perspective-org-1");
-    prismaMock.wikiPageCount.mockResolvedValue(4);
+    // First count = all overlay pages, second (slug-filtered) = vector pages.
+    prismaMock.wikiPageCount.mockImplementation(async (args: any) =>
+      args?.where?.slug ? 5 : 9,
+    );
 
     const res = await backfillOrgWwwdOnBoot(silent);
 
@@ -75,6 +78,22 @@ describe("backfillOrgWwwdOnBoot", () => {
     expect(runSeedsMock).not.toHaveBeenCalled();
     // Presence path must not even consult the setup-progress guard.
     expect(prismaMock.setupProgressFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("re-seeds a pre-stance-vector install (profile + old pages, but no vector pages)", async () => {
+    // The 2026-07-11 upgrade path (BI-70ADC71F): installs seeded with only the
+    // original 4 plan-readiness pages get the vector redistribution on boot.
+    prismaMock.organizationFindMany.mockResolvedValue([{ id: "org-1" }]);
+    resolveOrgProfileIdMock.mockResolvedValue("org-perspective-org-1");
+    prismaMock.wikiPageCount.mockImplementation(async (args: any) =>
+      args?.where?.slug ? 0 : 4,
+    );
+    prismaMock.setupProgressFindFirst.mockResolvedValue({ id: "setup-1" });
+
+    const res = await backfillOrgWwwdOnBoot(silent);
+
+    expect(res).toEqual({ seeded: 1, present: 0, skipped: 0 });
+    expect(runSeedsMock).toHaveBeenCalledWith("org-1");
   });
 
   it("re-seeds when the profile exists but the overlay pages are missing", async () => {

--- a/apps/web/lib/onboarding/backfill-org-wwwd-on-boot.ts
+++ b/apps/web/lib/onboarding/backfill-org-wwwd-on-boot.ts
@@ -19,6 +19,8 @@
 
 import { prisma } from "@dpf/db";
 import { resolveOrgProfileId } from "@/lib/decision-perspective/material";
+import { STANCE_VECTOR_KEYS } from "./archetype-business-context";
+import { stanceVectorSlug } from "./seed-org-wwwd-corpus";
 import { runSetupCompletionSeeds } from "./setup-completion-seeds";
 
 export type BackfillOrgWwwdResult = {
@@ -64,11 +66,20 @@ export async function backfillOrgWwwdOnBoot(
     for (const org of orgs) {
       try {
         // Cheap presence check — a healthy install does no seed work on boot.
-        const [profileId, overlayPageCount] = await Promise.all([
+        // Shape-aware (BI-70ADC71F): "present" means the profile exists AND
+        // the corpus carries the current shape (all 5 stance-vector pages).
+        // Installs seeded before the stance-vector redistribution re-run the
+        // idempotent chain once — it adds the missing pages/materials, retags
+        // org-supply-chain, and never downgrades an owner-confirmed material.
+        const vectorSlugs = STANCE_VECTOR_KEYS.map((key) => stanceVectorSlug(key));
+        const [profileId, overlayPageCount, vectorPageCount] = await Promise.all([
           resolveOrgProfileId({ db: prisma, organizationId: org.id }),
           prisma.wikiPage.count({ where: { organizationId: org.id } }),
+          prisma.wikiPage.count({
+            where: { organizationId: org.id, slug: { in: vectorSlugs } },
+          }),
         ]);
-        if (profileId && overlayPageCount > 0) {
+        if (profileId && overlayPageCount > 0 && vectorPageCount >= vectorSlugs.length) {
           result.present++;
           continue;
         }
@@ -82,7 +93,7 @@ export async function backfillOrgWwwdOnBoot(
         await runSetupCompletionSeeds(org.id);
         result.seeded++;
         logger.log(
-          `[wwwd-backfill] org ${org.id}: seeded WWWD corpus + profile (was profile=${profileId ?? "none"}, overlayPages=${overlayPageCount})`,
+          `[wwwd-backfill] org ${org.id}: seeded WWWD corpus + profile (was profile=${profileId ?? "none"}, overlayPages=${overlayPageCount}, vectorPages=${vectorPageCount})`,
         );
       } catch (err) {
         result.skipped++;

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
@@ -147,19 +147,30 @@ describe("seedOrgWwwdCorpus", () => {
     expect(fake.versions).toHaveLength(1);
     expect(fake.versions[0]).toMatchObject({ versionId: result.versionId, versionNumber: 1 });
 
-    // Four materials, each linked to a wiki page + the version
-    expect(result.materialCount).toBe(4);
-    expect(fake.materials).toHaveLength(4);
+    // Twelve materials across all four decision classes (BI-70ADC71F)
+    expect(result.materialCount).toBe(12);
+    expect(fake.materials).toHaveLength(12);
     for (const m of fake.materials) {
       expect(m.profileVersionId).toBe(result.versionId);
-      expect(m.domainClass).toBe("plan-readiness");
       expect(m.reviewStatus).toBe("approved");
       expect(m.promotionState).toBe("promoted");
+      expect(m.evidenceGrade).toBe("B");
+      expect(m.confidenceWeight).toBe(0.6);
       expect(m.sourceRef.wikiPageId).toBeTruthy();
     }
+    const byClass = fake.materials.reduce<Record<string, number>>((acc, m) => {
+      acc[m.domainClass] = (acc[m.domainClass] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(byClass).toEqual({
+      "plan-readiness": 4,
+      "risk-assessment": 3,
+      "professional-practice": 3,
+      "architecture-tradeoff": 2,
+    });
 
-    // Four published, org-scoped, non-kernel wiki pages
-    expect(fake.wikiPages).toHaveLength(4);
+    // Nine published, org-scoped, non-kernel wiki pages (4 identity + 5 vectors)
+    expect(fake.wikiPages).toHaveLength(9);
     for (const p of fake.wikiPages) {
       expect(p.status).toBe("published");
       expect(p.organizationId).toBe(ORG);
@@ -170,6 +181,11 @@ describe("seedOrgWwwdCorpus", () => {
       "org-mission",
       "org-supply-chain",
       "org-who-we-serve",
+      "stances/customer-goodwill",
+      "stances/growth-vs-stability",
+      "stances/pricing-integrity",
+      "stances/quality-bar",
+      "stances/spend-authority",
     ]);
 
     // Captured mission lands in the mission page body
@@ -179,9 +195,9 @@ describe("seedOrgWwwdCorpus", () => {
     expect(mission!.pageKind).toBe("principle");
 
     // Every published page was embedded into Qdrant
-    expect(embed).toHaveBeenCalledTimes(4);
+    expect(embed).toHaveBeenCalledTimes(9);
     expect(result.embedded).toBe(true);
-    expect(result.wikiPageIds).toHaveLength(4);
+    expect(result.wikiPageIds).toHaveLength(9);
   });
 
   it("is idempotent — re-running produces no duplicate profile/version/material/page rows", async () => {
@@ -202,11 +218,11 @@ describe("seedOrgWwwdCorpus", () => {
     // Fallback + org profile, each upserted once (no duplicates on re-run).
     expect(fake.profiles).toHaveLength(2);
     expect(fake.versions).toHaveLength(1);
-    expect(fake.materials).toHaveLength(4);
-    expect(fake.wikiPages).toHaveLength(4);
+    expect(fake.materials).toHaveLength(12);
+    expect(fake.wikiPages).toHaveLength(9);
     // Body unchanged on the 2nd run → no extra revision, no re-embed
-    expect(fake.revisions).toHaveLength(4);
-    expect(embed).toHaveBeenCalledTimes(4);
+    expect(fake.revisions).toHaveLength(9);
+    expect(embed).toHaveBeenCalledTimes(9);
   });
 
   it("still seeds a non-empty corpus when no mission was captured (archetype fallback)", async () => {
@@ -218,7 +234,7 @@ describe("seedOrgWwwdCorpus", () => {
 
     const result = await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
 
-    expect(result.materialCount).toBe(4);
+    expect(result.materialCount).toBe(12);
     const mission = fake.wikiPages.find((p) => p.slug === "org-mission");
     expect(mission).toBeDefined();
     expect(mission!.body.trim().length).toBeGreaterThan(20);
@@ -237,8 +253,8 @@ describe("seedOrgWwwdCorpus", () => {
 
     expect(result.embedded).toBe(false);
     // DB rows still created despite embedding failure
-    expect(fake.wikiPages).toHaveLength(4);
-    expect(fake.materials).toHaveLength(4);
+    expect(fake.wikiPages).toHaveLength(9);
+    expect(fake.materials).toHaveLength(12);
   });
 
   it("seeds an archetype-aware org-supply-chain stance page + material", async () => {
@@ -271,7 +287,8 @@ describe("seedOrgWwwdCorpus", () => {
     const material = fake.materials.find((m) => m.materialId === `${result.profileId}:org-supply-chain`);
     expect(material).toBeDefined();
     expect(material!.sourceType).toBe("stance");
-    expect(material!.domainClass).toBe("plan-readiness");
+    // Retagged (BI-70ADC71F): supplier posture governs structural vendor choices.
+    expect(material!.domainClass).toBe("architecture-tradeoff");
     expect(material!.direction).toBe("support");
     expect(material!.evidenceGrade).toBe("B");
     expect(material!.reviewStatus).toBe("approved");
@@ -296,5 +313,67 @@ describe("seedOrgWwwdCorpus", () => {
     expect(page!.pageKind).toBe("stance");
     // Generic body is intentionally short / honest — no fabricated specifics.
     expect(page!.body.toLowerCase()).not.toMatch(/perish|cold[- ]chain|dropship/);
+  });
+});
+
+describe("seedOrgWwwdCorpus stance vectors (BI-70ADC71F)", () => {
+  it("seeds archetype-aware vector pages with the authority ceiling in the body", async () => {
+    const embed = vi.fn<EmbedFn>(async () => true);
+    const fake = makeFakeDb({
+      businessContext: {
+        mission: "Keep smiles healthy.",
+        description: "A dental practice.",
+        targetMarket: "families",
+        industry: "healthcare-wellness",
+      },
+      archetype: { name: "Dental Practice", category: "healthcare-wellness" },
+      orgName: "Bright Smiles",
+    });
+
+    const result = await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
+
+    const goodwill = fake.wikiPages.find((p) => p.slug === "stances/customer-goodwill");
+    expect(goodwill).toBeDefined();
+    expect(goodwill!.pageKind).toBe("stance");
+    expect(goodwill!.body).toMatch(/patient/i);
+    expect(goodwill!.body).toContain("up to $150");
+
+    // Goodwill bundles into risk-assessment (primary) + professional-practice (echo)
+    const primary = fake.materials.find(
+      (m) => m.materialId === `${result.profileId}:stances/customer-goodwill`,
+    );
+    const echo = fake.materials.find(
+      (m) => m.materialId === `${result.profileId}:stances/customer-goodwill:professional-practice`,
+    );
+    expect(primary).toBeDefined();
+    expect(primary!.domainClass).toBe("risk-assessment");
+    expect(echo).toBeDefined();
+    expect(echo!.domainClass).toBe("professional-practice");
+    expect(echo!.sourceRef.wikiPageId).toBe(goodwill!.id);
+  });
+
+  it("re-seeding never downgrades an owner-confirmed material (update omits grade/weight/review)", async () => {
+    const embed = vi.fn<EmbedFn>(async () => true);
+    const fake = makeFakeDb({
+      businessContext: { mission: "M", description: null, targetMarket: null, industry: "retail-goods" },
+      archetype: { name: "Shop", category: "retail-goods" },
+      orgName: "Shop",
+    });
+
+    const result = await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
+
+    // Simulate the owner confirming the goodwill stance (Phase 2 upgrade).
+    const confirmed = fake.materials.find(
+      (m) => m.materialId === `${result.profileId}:stances/customer-goodwill`,
+    )!;
+    confirmed.evidenceGrade = "A";
+    confirmed.confidenceWeight = 0.9;
+
+    await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
+
+    expect(confirmed.evidenceGrade).toBe("A");
+    expect(confirmed.confidenceWeight).toBe(0.9);
+    // …while retag-relevant fields still refresh.
+    expect(confirmed.freshness).toBe("current");
   });
 });

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
@@ -21,16 +21,51 @@
 // stable ids, wiki pages are upserted by (organizationId, slug), and a new
 // revision + re-embed only happen when the page body actually changes.
 // Safe to re-run on re-completion or replay.
+//
+// 2026-07-11 (BI-70ADC71F, stance-onboarding design): seeding now covers ALL
+// FOUR decision classes, not just plan-readiness — 4 identity pages plus 5
+// archetype-default stance-vector pages (goodwill, pricing, growth-vs-
+// stability, quality bar, spend authority), each landing PerspectiveMaterial
+// in its class bundle at unconfirmed B/0.6. Unconfirmed defaults still clear
+// nothing (effective 0.45 < every band) — the "How you decide" step upgrades
+// confirmed bundles to A/0.9. Re-seeding an existing install retags the
+// org-supply-chain material into architecture-tradeoff and never downgrades
+// an owner-confirmed or human-ruled material.
 
 import { prisma } from "@dpf/db";
 import { upsertWikiPage, appendRevision } from "@dpf/db/wiki-store";
 import { storeWikiPage, type StoreWikiPageInput } from "@/lib/wiki/embeddings";
+import { DECISION_DOMAIN_CLASSES, type DecisionDomainClass } from "@/lib/decision-perspective/types";
 import { suggestMission } from "./mission-suggestion";
-import { resolveBusinessProfile } from "./archetype-business-context";
+import {
+  resolveBusinessProfile,
+  resolveStanceVectors,
+  STANCE_VECTOR_KEYS,
+  type StanceVectorKey,
+} from "./archetype-business-context";
 
 /** Platform fallback our org profile chains to (material.ts:14). */
 export const ORG_PERSPECTIVE_FALLBACK_PROFILE_ID = "dpf-organizational-principles";
 const PLAN_READINESS_DOMAIN_CLASS = "plan-readiness";
+
+/**
+ * Which decision classes each stance vector's material lands in (the "gate
+ * bundle" from the 2026-07-11 stance-onboarding design §3). The FIRST class is
+ * the primary (keeps the legacy `{profileId}:{slug}` materialId so re-seeding
+ * an existing install retags rather than duplicates); the rest are echoes.
+ */
+export const STANCE_VECTOR_BUNDLES: Record<StanceVectorKey, DecisionDomainClass[]> = {
+  "customer-goodwill": ["risk-assessment", "professional-practice"],
+  "pricing-integrity": ["risk-assessment"],
+  "growth-vs-stability": ["plan-readiness"],
+  "quality-bar": ["professional-practice"],
+  "spend-authority": ["risk-assessment", "architecture-tradeoff"],
+};
+
+/** Org-overlay slug for a stance vector page (matches the /wiki/stance prefix). */
+export function stanceVectorSlug(key: StanceVectorKey): string {
+  return `stances/${key}`;
+}
 
 const DEFAULT_AUTONOMY_POLICY = {
   allowRecommendation: true,
@@ -85,6 +120,12 @@ type SeedPage = {
   pageKind: "principle" | "stance";
   body: string;
   abstract: string;
+  /**
+   * The decision classes this page's material lands in. The first entry is the
+   * primary class (legacy `{profileId}:{slug}` materialId); additional entries
+   * become echo materials keyed `{profileId}:{slug}:{class}`.
+   */
+  bundles: DecisionDomainClass[];
   /** Set on the mission principle page so it is well-formed. */
   principle?: {
     principleTier: "core";
@@ -132,6 +173,7 @@ function buildPages(
       slug: "org-mission",
       title: "Our mission",
       pageKind: "principle",
+      bundles: ["plan-readiness"],
       body: [
         "# Our mission",
         "",
@@ -150,6 +192,7 @@ function buildPages(
       slug: "org-who-we-serve",
       title: "Who we serve",
       pageKind: "stance",
+      bundles: ["plan-readiness"],
       body: [
         "# Who we serve",
         "",
@@ -164,6 +207,9 @@ function buildPages(
       slug: "org-how-we-decide",
       title: "How we decide",
       pageKind: "stance",
+      // Echoes into professional-practice: the how-we-decide framing carries
+      // the craft/quality posture for that class alongside quality-bar.
+      bundles: ["plan-readiness", "professional-practice"],
       body: [
         "# How we decide",
         "",
@@ -177,6 +223,10 @@ function buildPages(
       slug: "org-supply-chain",
       title: "How we work with suppliers",
       pageKind: "stance",
+      // Retagged (2026-07-11 design §3): supplier posture governs structural
+      // vendor/tooling choices, not plan-readiness. Re-seeding an existing
+      // install moves the material via the upsert update clause.
+      bundles: ["architecture-tradeoff"],
       body: [
         "# How we work with suppliers",
         "",
@@ -187,6 +237,34 @@ function buildPages(
       abstract: profile.supplyChain,
     },
   ];
+
+  // The 5 coverage vectors (stance-onboarding design §3-4): archetype-default
+  // stance pages whose materials prime every decision class. Unconfirmed
+  // starters — the owner confirms/adjusts them in the "How you decide" step.
+  const vectors = resolveStanceVectors({ archetypeId, industry: industry ?? bc?.industry ?? null });
+  for (const key of STANCE_VECTOR_KEYS) {
+    const v = vectors[key];
+    const ceiling =
+      v.ceilingUsd != null && v.ceilingUsd > 0
+        ? `\nAuthority ceiling: up to $${v.ceilingUsd} per case may be resolved without the owner; above that, the owner decides.`
+        : "";
+    pages.push({
+      slug: stanceVectorSlug(key),
+      title: v.title,
+      pageKind: "stance",
+      bundles: STANCE_VECTOR_BUNDLES[key],
+      body: [
+        `# ${v.title}`,
+        "",
+        v.stance,
+        ceiling,
+        "",
+        `This is ${orgLabel}'s starting stance, derived from how this kind of business tends to operate. Confirm or adjust it — a confirmed stance lets your AI coworkers act on it.`,
+      ].join("\n"),
+      abstract: v.stance,
+    });
+  }
+
   return pages;
 }
 
@@ -249,7 +327,7 @@ export async function seedOrgWwwdCorpus(
     update: {
       name: `${orgName ?? "Organization"} perspective`,
       kind: "organization",
-      scope: { domains: [PLAN_READINESS_DOMAIN_CLASS] },
+      scope: { domains: [...DECISION_DOMAIN_CLASSES] },
       ownerOrganizationId: organizationId,
       fallbackProfileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
       defaultResolver: { type: "build-studio-owner" },
@@ -260,7 +338,7 @@ export async function seedOrgWwwdCorpus(
       profileId,
       name: `${orgName ?? "Organization"} perspective`,
       kind: "organization",
-      scope: { domains: [PLAN_READINESS_DOMAIN_CLASS] },
+      scope: { domains: [...DECISION_DOMAIN_CLASSES] },
       ownerOrganizationId: organizationId,
       fallbackProfileId: ORG_PERSPECTIVE_FALLBACK_PROFILE_ID,
       defaultResolver: { type: "build-studio-owner" },
@@ -286,6 +364,7 @@ export async function seedOrgWwwdCorpus(
   const pages = buildPages(bc, archetypeId, industry, orgName);
   const wikiPageIds: string[] = [];
   let embedded = true;
+  let materialCount = 0;
 
   for (const page of pages) {
     const existing = (await db.wikiPage.findFirst({
@@ -347,35 +426,48 @@ export async function seedOrgWwwdCorpus(
       if (!ok) embedded = false;
     }
 
-    // Material linking the version to the wiki page.
-    const materialId = `${profileId}:${page.slug}`;
-    await db.perspectiveMaterial.upsert({
-      where: { materialId },
-      update: {
-        profileVersionId: versionId,
-        sourceType: page.pageKind,
-        sourceRef: { wikiPageId: saved.id, slug: page.slug, organizationId },
-        summary: page.abstract,
-        freshness: "current",
-      },
-      create: {
-        materialId,
-        profileId,
-        profileVersionId: versionId,
-        sourceType: page.pageKind,
-        sourceRef: { wikiPageId: saved.id, slug: page.slug, organizationId },
-        scope: { domains: [PLAN_READINESS_DOMAIN_CLASS] },
-        domainClass: PLAN_READINESS_DOMAIN_CLASS,
-        direction: "support",
-        domains: [PLAN_READINESS_DOMAIN_CLASS],
-        freshness: "current",
-        evidenceGrade: "B",
-        confidenceWeight: 0.6,
-        reviewStatus: "approved",
-        promotionState: "promoted",
-        summary: page.abstract,
-      },
-    });
+    // Materials linking the version to the wiki page — one per bundle class.
+    // The primary class keeps the legacy `{profileId}:{slug}` id so re-seeding
+    // an existing install RETAGS its row (update sets domainClass) instead of
+    // duplicating; echo classes get `{profileId}:{slug}:{class}` ids.
+    // NOTE: the update clause deliberately does NOT touch evidenceGrade /
+    // confidenceWeight / reviewStatus / promotionState — an owner-confirmed
+    // (A/0.9) or human-ruled (A/1.0) upgrade must survive a re-seed.
+    for (const [bundleIndex, domainClass] of page.bundles.entries()) {
+      const materialId =
+        bundleIndex === 0 ? `${profileId}:${page.slug}` : `${profileId}:${page.slug}:${domainClass}`;
+      materialCount += 1;
+      await db.perspectiveMaterial.upsert({
+        where: { materialId },
+        update: {
+          profileVersionId: versionId,
+          sourceType: page.pageKind,
+          sourceRef: { wikiPageId: saved.id, slug: page.slug, organizationId },
+          scope: { domains: [domainClass] },
+          domainClass,
+          domains: [domainClass],
+          summary: page.abstract,
+          freshness: "current",
+        },
+        create: {
+          materialId,
+          profileId,
+          profileVersionId: versionId,
+          sourceType: page.pageKind,
+          sourceRef: { wikiPageId: saved.id, slug: page.slug, organizationId },
+          scope: { domains: [domainClass] },
+          domainClass,
+          direction: "support",
+          domains: [domainClass],
+          freshness: "current",
+          evidenceGrade: "B",
+          confidenceWeight: 0.6,
+          reviewStatus: "approved",
+          promotionState: "promoted",
+          summary: page.abstract,
+        },
+      });
+    }
   }
 
   // 4. Point the profile at v1.
@@ -388,7 +480,7 @@ export async function seedOrgWwwdCorpus(
     profileId,
     versionId,
     wikiPageIds,
-    materialCount: pages.length,
+    materialCount,
     embedded,
   };
 }

--- a/docs/superpowers/plans/2026-07-11-wwwd-stance-onboarding-build.md
+++ b/docs/superpowers/plans/2026-07-11-wwwd-stance-onboarding-build.md
@@ -1,0 +1,49 @@
+# WWWD Company-Stance Onboarding — build plan
+
+- **Spec:** [2026-07-11-wwwd-stance-onboarding-design.md](../specs/2026-07-11-wwwd-stance-onboarding-design.md) (merged; founder go received 2026-07-11 — "deliver on this here locally")
+- **Epic:** EP-0AF96937 · Related tactical BI: BI-EBBBD275
+- **Invariants every phase preserves** (simulation-backed, `stance-onboarding.simulation.test.ts`):
+  unconfirmed material clears nothing; high/critical risk always escalates; confirmation upgrades
+  whole class bundles (never mixed tiers in a class from our own writes); re-seeding never
+  downgrades an owner-confirmed or human-ruled material.
+
+## Phase 1 — Archetype stance-vector defaults + seeder redistribution (BI-70ADC71F) ✅ this PR
+
+- `archetype-business-context.ts`: `STANCE_VECTOR_KEYS`, `StanceVectorDefault` (+ per-industry
+  overrides with authority ceilings), `resolveStanceVectors` (pure; primary archetype only).
+- `seed-org-wwwd-corpus.ts`: `STANCE_VECTOR_BUNDLES` (vector → class bundle; first class = primary,
+  legacy `{profileId}:{slug}` materialId so existing installs retag instead of duplicating),
+  5 vector pages under `stances/<key>` (published + embedded), per-class materials at B/0.6,
+  `org-supply-chain` retagged to `architecture-tradeoff`, `org-how-we-decide` echoed into
+  `professional-practice`. Update clause refreshes retag fields but never grade/weight/review.
+- Result: fresh org = 9 pages / 12 materials over all 4 classes (plan-readiness 4,
+  risk-assessment 3, professional-practice 3, architecture-tradeoff 2).
+
+## Phase 2 — Stance capture & promotion loop (BI-9677364B + BI-002DEB85) — next PR
+
+- `lib/decision-perspective/stance-promotion.ts`: `promoteStanceMaterial` — the ONE write path that
+  makes a stance gate-live; tiers `confirmed` A/0.9 and `ruled` A/1.0; never downgrades.
+- `lib/actions/org-decision-capture.ts`: non-build capture for `/coworker-business` decisions —
+  EscalationCapture/DeferralCapture + `humanOutcome`, optional "standing answer" that writes a
+  published `stances/ruling-*` page (embedded) + `ruled` material in the decision's domainClass.
+- `lib/actions/business-stance.ts`: `publishBusinessStance` — publish the draft page, embed it,
+  promote `confirmed` material in the owner-picked decision area (plain-language → domainClass map
+  in `lib/wiki/business-stance.ts`).
+- `/wiki/review`: "Waiting on your call" section listing unresolved org-business decisions with the
+  inline answer + make-standing control; stance form gains the decision-area picker + Publish.
+
+## Phase 3 — "How you decide" setup step (BI-D6DC2432) — after Phase 2
+
+- `SETUP_STEPS` entry `how-you-decide` after `business-context`; 5 archetype-prefilled scenario
+  cards (resolveStanceVectors), Confirm-all fast path; confirm upgrades the vector's bundle via
+  `promoteStanceMaterial(confirmed)`; skip leaves B/0.6. Same card components mounted in
+  `/wiki/stance`. UX-Fit-Decision trailer on the PR.
+
+## Phase 4 — Local delivery & live verification
+
+- Merge PRs → redeploy the local live portal from clean main.
+- Re-run `seedOrgWwwdCorpus` for the existing org (idempotent; new vector pages + retags land).
+- Author BI-EBBBD275's two founder-ruled stances through the capture path (A/1.0, embedded).
+- Re-run `evaluate_org_business_decision` live on the billing-goodwill and quality-vs-offering
+  questions; expected: resolve (recommend/arbitrate per posture) instead of defer/escalate; verify
+  a high-risk probe still escalates.


### PR DESCRIPTION
## What

Phase 1 of the company-stance onboarding build ([spec](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-07-11-wwwd-stance-onboarding-design.md), plan added in this PR). Founder go: "deliver on this here locally".

- **5 archetype stance vectors** (customer goodwill + ceiling, pricing/discount integrity, growth-vs-stability, quality bar, spend authority) with per-industry defaults — `resolveStanceVectors` in [archetype-business-context.ts](apps/web/lib/onboarding/archetype-business-context.ts).
- **Seeder redistribution**: `seedOrgWwwdCorpus` now seeds a published+embedded stance page per vector (`stances/<key>`) and `PerspectiveMaterial` bundles across **all four decision classes** at unconfirmed B/0.6 (was: 4 materials, all `plan-readiness` — the exact arithmetic behind live escalations DI-C9F8B475B652 and DI-A190B8B3FEB7). `org-supply-chain` retags to `architecture-tradeoff`; re-seeding never downgrades an owner-confirmed material.
- **Shape-aware boot backfill**: existing installs (profile + old 4-page corpus) re-run the idempotent seed chain once on boot, so the redistribution reaches already-onboarded orgs — including this local install — without manual surgery.

## Safety

Unconfirmed defaults still clear **nothing** (effective 0.45 < every recommendation band) — no autonomy changes until the owner confirms (Phase 2 step, BI-D6DC2432). The committed simulation backtest asserts high-risk decisions always escalate regardless of corpus.

## Testing

- `lib/onboarding` suites extended: 12-material class distribution, ceilings in vector bodies, retag, never-downgrade on re-seed, shape-aware backfill upgrade path — all green (`pnpm exec vitest run lib/onboarding/`).
- Local merged-code pregate green for 8d2cb4eed.

Epic EP-0AF96937 · BI-70ADC71F

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Seed-Fit-Decision: archetype-scoped
