### PR TITLE
feat(coworker): make the tool-attachment cap accuracy-cliff-aware (EP-27FD96BC P2)

### DIFF
--- a/apps/web/lib/actions/coworker-tool-budget.test.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.test.ts
@@ -11,17 +11,16 @@ import {
 } from "./coworker-tool-budget";
 
 describe("deriveCoworkerToolCap", () => {
-  it("keeps the full 48 ceiling at a 32k window (unchanged behavior)", () => {
+  it("keeps the full 48 ceiling at a 32k window (capable-model line)", () => {
     expect(deriveCoworkerToolCap(32_768)).toBe(MAX_COWORKER_ATTACHED_TOOLS);
   });
 
-  it("shrinks the cap on a VRAM-constrained 24,576 window so a long thread fits", () => {
-    // (24576 - 12000 reserve) / 330 ≈ 38 — below 48, leaving room for prompt+history+reply.
+  it("caps a cliff-prone 24,576 window at the 15-tool accuracy cliff (BI-2B2F59EB)", () => {
+    // Window-fit alone would allow ~38 tools ((24576-12000)/330), well past the
+    // ~15-tool cliff where a small local model's selection accuracy collapses.
     const cap = deriveCoworkerToolCap(24_576);
-    expect(cap).toBeLessThan(MAX_COWORKER_ATTACHED_TOOLS);
-    expect(cap).toBe(38);
-    // The observed overflow (49 tools → 24,730 prompt) now fits: 38 tools is ~3.6k
-    // fewer tokens, dropping the prompt well under the 24,576 window.
+    expect(cap).toBe(15);
+    // Still well within the window (prompt+history+reply fit comfortably).
     expect(cap * 330).toBeLessThan(24_576 - 8_000);
   });
 
@@ -38,6 +37,13 @@ describe("deriveCoworkerToolCap", () => {
 
   it("never exceeds the 48 ceiling even for a huge cloud window", () => {
     expect(deriveCoworkerToolCap(200_000)).toBe(MAX_COWORKER_ATTACHED_TOOLS);
+  });
+
+  it("applies the accuracy-cliff ceiling only below the capable-model line", () => {
+    // Just below 32k: cliff-prone → bounded at 15 despite window-fit allowing more.
+    expect(deriveCoworkerToolCap(31_999)).toBe(15);
+    // At/above 32k: capable → full window-fit ceiling.
+    expect(deriveCoworkerToolCap(32_768)).toBe(MAX_COWORKER_ATTACHED_TOOLS);
   });
 
   it("is monotonic — a larger window never yields fewer tools", () => {

--- a/apps/web/lib/actions/coworker-tool-budget.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.ts
@@ -22,6 +22,7 @@
 import type { ToolDefinition } from "@/lib/mcp-tools";
 import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
 import { CORE_MCP_TOOL_NAMES } from "@/lib/mcp/tool-tier";
+import { LOCAL_TOOL_SELECTION_CLIFF } from "@/lib/tak/context-economy-metrics";
 
 /**
  * Default ceiling on the NON-essential (role/core/breadth) tool schemas attached
@@ -50,26 +51,46 @@ export const COWORKER_NON_TOOL_RESERVE_TOKENS = 12_000;
 export const MIN_COWORKER_ATTACHED_TOOLS = 12;
 
 /**
+ * A small local model's tool-SELECTION accuracy collapses once it is handed more
+ * than ~15 tools (`LOCAL_TOOL_SELECTION_CLIFF`) — a soft quality cliff that the
+ * window-fit math alone doesn't see (a 24,576 window fits ~38 schemas, well past
+ * the cliff). Below this served-context line the model is the cliff-prone small
+ * local class, so the attachment cap is bounded by the cliff, not just the window.
+ * At/above it the model is capable enough to select from the full window-fit set.
+ */
+export const ACCURACY_CLIFF_PRONE_MAX_CONTEXT = 32_768;
+
+/**
  * Derive the per-turn tool-attachment cap from the served context window of the
- * model that will run the turn. The hardcoded 48 was sized for a ~32k window;
- * on a VRAM-constrained local model served at 24,576 tokens, 48 tool schemas
- * (~16k tokens) plus a long conversation overflow `exceed_context_size_error`.
- * This scales the cap down so the tool block always leaves room for the prompt,
- * history, and reply — and back up to the 48 ceiling once the window is large.
+ * model that will run the turn. Two ceilings apply, whichever is smaller:
+ *   1. WINDOW-FIT — the hardcoded 48 was sized for a ~32k window; on a
+ *      VRAM-constrained local model served at 24,576 tokens, 48 tool schemas
+ *      (~16k tokens) plus a long conversation overflow `exceed_context_size_error`.
+ *   2. ACCURACY-CLIFF (BI-2B2F59EB) — for a cliff-prone small local window
+ *      (< 32k), bound the cap at the ~15-tool selection cliff so a small model
+ *      isn't handed a surface it can't select from. Deferred tools stay
+ *      authorized and loadable via load_tools, so this caps accuracy cost, never
+ *      capability.
  *
  * It binds on the LOCAL model's served context even when a cloud provider is
  * preferred, because the cloud→local FALLBACK path is exactly where these
- * overflows happen; the cost on a cloud turn is only a few extra load_tools
- * round-trips, never a failure. `null`/unknown (no small-context local model)
- * → the full 48.
+ * overflows/cliffs happen; the cost on a cloud turn is only a few extra
+ * load_tools round-trips, never a failure. `null`/unknown (no small-context
+ * local model) → the full 48.
  *
- *   32_768 → 48 (ceiling; unchanged)   24_576 → 38   16_000 → 12 (floor)   null → 48
+ *   32_768 → 48 (capable; ceiling)   24_576 → 15 (accuracy cliff)   16_000 → 12 (floor)   null → 48
  */
 export function deriveCoworkerToolCap(servedContextTokens: number | null | undefined): number {
   if (!servedContextTokens || servedContextTokens <= 0) return MAX_COWORKER_ATTACHED_TOOLS;
   const toolBudgetTokens = servedContextTokens - COWORKER_NON_TOOL_RESERVE_TOKENS;
   const fitted = Math.floor(toolBudgetTokens / TOOL_SCHEMA_TOKEN_ESTIMATE);
-  return Math.max(MIN_COWORKER_ATTACHED_TOOLS, Math.min(MAX_COWORKER_ATTACHED_TOOLS, fitted));
+  // A cliff-prone small local model also caps at the selection cliff, not just
+  // the window fit. Larger/capable windows keep the full window-fit ceiling.
+  const ceiling =
+    servedContextTokens < ACCURACY_CLIFF_PRONE_MAX_CONTEXT
+      ? Math.min(MAX_COWORKER_ATTACHED_TOOLS, LOCAL_TOOL_SELECTION_CLIFF)
+      : MAX_COWORKER_ATTACHED_TOOLS;
+  return Math.max(MIN_COWORKER_ATTACHED_TOOLS, Math.min(ceiling, fitted));
 }
 
 /** Name of the meta-tool that lets a coworker pull deferred tools back on demand. */

--- a/docs/superpowers/plans/2026-07-11-p2-accuracy-cliff-tool-cap.md
+++ b/docs/superpowers/plans/2026-07-11-p2-accuracy-cliff-tool-cap.md
@@ -1,0 +1,30 @@
+# P2 — Accuracy-cliff-aware tool cap
+
+- **BI:** BI-2B2F59EB · **Epic:** EP-27FD96BC
+- **Scope spec:** `docs/superpowers/specs/2026-07-11-coworker-reasoning-economy-scope.md`
+- **Kernel:** no work-scope/altitude sub-decision — implementing the audit's named fix (bound the cap toward the ~15 cliff); no architecturally-distinct options.
+
+## Problem (from the audit)
+
+Two independent numbers existed and never met:
+- The per-turn **attachment cap** (`deriveCoworkerToolCap`, `coworker-tool-budget.ts`) sized purely by **window fit** — a 24,576 local window fits ~38 tool schemas, so up to 38 were attached.
+- The **accuracy cliff** (`LOCAL_TOOL_SELECTION_CLIFF = 15`, `context-economy-metrics.ts`) — a small local model's tool-*selection* accuracy collapses once handed more than ~15 tools. It only coloured observability zones and skipped the local fallback; **nothing fed it back into the attachment cap.**
+
+So a small local model was routinely handed ~38 tools — well past the cliff — and picked worse, even though the window had room.
+
+## Approach — the smaller of two ceilings
+
+Substrate-verify-first: reuse `deriveCoworkerToolCap` and the existing `LOCAL_TOOL_SELECTION_CLIFF` constant; no new store, no new module.
+
+`deriveCoworkerToolCap` now takes the min of two ceilings:
+1. **window-fit** (unchanged) — never overflow the served window.
+2. **accuracy-cliff** (new) — for a cliff-prone small local window (`< ACCURACY_CLIFF_PRONE_MAX_CONTEXT = 32_768`), bound the cap at `LOCAL_TOOL_SELECTION_CLIFF`. At/above 32k the model is capable enough to select from the full window-fit set.
+
+Deferred tools stay authorized and loadable via `load_tools`, so this caps accuracy cost, not capability. Result: `24_576 → 15` (was 38); `32_768`+ and `null` unchanged at 48; `<16k` still floors at 12.
+
+## Verification
+- Unit (`coworker-tool-budget.test.ts`, 18/18): 24,576 caps at 15; the 32k capable line stays 48; floor and monotonicity preserved (12,12,12,15,15,15,48,48 across the window sweep); a boundary test at 31,999 vs 32,768.
+- Typecheck clean.
+
+## Relationship to siblings
+- P1's `EffortWarrant.toolBudgetTarget` and P3's task-intent ranking (BI-ACE1EBA4) *rank* which tools survive the cap; this BI sets the *cap*. They compose — this is the ceiling those tune against.


### PR DESCRIPTION
## What

BI-2B2F59EB (EP-27FD96BC P2). The per-turn tool-attachment cap (`deriveCoworkerToolCap`) was sized purely by **window fit** — a 24,576 local window fits ~38 schemas, so up to 38 tools were attached. But a small local model's tool-**selection** accuracy collapses past ~15 tools (`LOCAL_TOOL_SELECTION_CLIFF`), which only coloured observability and skipped the local fallback — it never fed back into the cap. So a small model was routinely handed ~38 tools and picked worse, with room to spare in the window.

The cap now takes the **smaller of two ceilings**: window-fit (unchanged) and, for a cliff-prone small local window (`< 32k`), the ~15 accuracy cliff. At/above 32k the model is capable enough for the full window-fit set. Deferred tools stay authorized and loadable via `load_tools`, so this caps accuracy cost, **not capability**.

`24_576 → 15` (was 38); `32_768`+ and `null` unchanged at 48; `<16k` still floors at 12.

## Files
- `apps/web/lib/actions/coworker-tool-budget.ts` — `deriveCoworkerToolCap` bounds by the cliff; new `ACCURACY_CLIFF_PRONE_MAX_CONTEXT`
- `apps/web/lib/actions/coworker-tool-budget.test.ts` — updated + boundary tests (18/18)
- Plan: `docs/superpowers/plans/2026-07-11-p2-accuracy-cliff-tool-cap.md`

## Verification
- Unit: 18/18 green (24,576→15; 32k capable line→48; floor + monotonicity preserved; 31,999 vs 32,768 boundary). tsc 0 errors. Module-size ok (no growth).

**UX-Fit:** N/A — backend tool-budgeting; no surface.

Local-CI-Override: Verified-clean. Local-CI pregate blocked by fleet-wide sandbox-drift infra defect BI-E9E0FF0A. GitHub CI required checks are the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)