### PR TITLE
fix(workforce): collapse dual-seed coworker alias rows on AI roster (BI-74FD6420)

### DIFF
--- a/apps/web/lib/coworker-record/roster-dedupe.test.ts
+++ b/apps/web/lib/coworker-record/roster-dedupe.test.ts
@@ -1,0 +1,74 @@
+// BI-74FD6420 — dual-seed alias rows must not appear beside their AGT-* twin.
+import { describe, expect, it } from "vitest";
+import { COWORKER_SLUG_TO_CANONICAL_AGENT_ID } from "@dpf/db/agent-identity";
+import { dropDualSeedAliasAgents } from "./roster";
+
+describe("dropDualSeedAliasAgents (BI-74FD6420)", () => {
+  it("drops known slug alias rows when the canonical AGT-* twin is present", () => {
+    const agents = [
+      { agentId: "AGT-ORCH-000", displayName: "COO" },
+      { agentId: "coo", displayName: "COO" },
+      { agentId: "AGT-WS-BUILD", displayName: "Build Lead" },
+      { agentId: "build-specialist", displayName: "Build Lead" },
+      { agentId: "AGT-WS-ADMIN", displayName: "Platform Admin" },
+      { agentId: "admin-assistant", displayName: "Platform Admin" },
+      { agentId: "AGT-WS-SCOUT", displayName: "External Catalog Scout" },
+      { agentId: "external-catalog-scout", displayName: "External Catalog Scout" },
+      { agentId: "AGT-WS-INVENTORY", displayName: "Digital Product Estate Specialist" },
+      { agentId: "inventory-specialist", displayName: "Digital Product Estate Specialist" },
+      { agentId: "storefront-advisor", displayName: "Storefront Operations Manager" }, // no twin
+    ];
+
+    const kept = dropDualSeedAliasAgents(agents);
+    const ids = kept.map((a) => a.agentId).sort();
+
+    expect(ids).toEqual(
+      [
+        "AGT-ORCH-000",
+        "AGT-WS-ADMIN",
+        "AGT-WS-BUILD",
+        "AGT-WS-INVENTORY",
+        "AGT-WS-SCOUT",
+        "storefront-advisor",
+      ].sort(),
+    );
+    // No residual dual-seed aliases for the known map keys.
+    for (const slug of Object.keys(COWORKER_SLUG_TO_CANONICAL_AGENT_ID)) {
+      if (slug === "onboarding-coo") continue; // not in fixture
+      expect(ids).not.toContain(slug);
+    }
+  });
+
+  it("keeps the slug row when its canonical twin is absent (orphan alias still usable)", () => {
+    const agents = [
+      { agentId: "coo", displayName: "COO" },
+      { agentId: "build-specialist", displayName: "Build Lead" },
+    ];
+    const kept = dropDualSeedAliasAgents(agents);
+    expect(kept.map((a) => a.agentId).sort()).toEqual(["build-specialist", "coo"]);
+  });
+
+  it("is a no-op when the roster already has only canonical rows", () => {
+    const agents = [
+      { agentId: "AGT-ORCH-000", displayName: "COO" },
+      { agentId: "AGT-WS-BUILD", displayName: "Build Lead" },
+    ];
+    expect(dropDualSeedAliasAgents(agents)).toEqual(agents);
+  });
+
+  it("covers every dual-seed pair observed on the live install", () => {
+    // Live evidence 2026-07-11: COO, Build Lead, Platform Admin, Scout,
+    // Inventory, Onboarding COO each had a slug twin beside the AGT-* row.
+    const livePairs: Array<[string, string]> = [
+      ["coo", "AGT-ORCH-000"],
+      ["build-specialist", "AGT-WS-BUILD"],
+      ["admin-assistant", "AGT-WS-ADMIN"],
+      ["external-catalog-scout", "AGT-WS-SCOUT"],
+      ["inventory-specialist", "AGT-WS-INVENTORY"],
+      ["onboarding-coo", "AGT-WS-ONBOARD"],
+    ];
+    for (const [slug, canonical] of livePairs) {
+      expect(COWORKER_SLUG_TO_CANONICAL_AGENT_ID[slug]).toBe(canonical);
+    }
+  });
+});

--- a/apps/web/lib/coworker-record/roster.ts
+++ b/apps/web/lib/coworker-record/roster.ts
@@ -9,6 +9,7 @@
 // RosterView without serialization hazards.
 
 import { prisma } from "@dpf/db";
+import { COWORKER_SLUG_TO_CANONICAL_AGENT_ID } from "@dpf/db/agent-identity";
 import {
   PROFESSION_REGISTRY,
   findProfessionFamilyForAgentIdentity,
@@ -59,6 +60,24 @@ type FamilyCoverage = {
 };
 
 const DECISION_WINDOW_DAYS = 30;
+
+/**
+ * Drop legacy dual-seed alias rows when their canonical AGT-* twin is present
+ * (BI-74FD6420). Pure + exported for unit tests — seed retires the alias rows
+ * long-term; this is the belt-and-suspenders roster filter for installs that
+ * have not re-seeded yet.
+ */
+export function dropDualSeedAliasAgents<T extends { agentId: string }>(
+  agents: T[],
+  slugToCanonical: Readonly<Record<string, string>> = COWORKER_SLUG_TO_CANONICAL_AGENT_ID,
+): T[] {
+  const present = new Set(agents.map((a) => a.agentId));
+  return agents.filter((a) => {
+    const canonical = slugToCanonical[a.agentId];
+    if (canonical && canonical !== a.agentId && present.has(canonical)) return false;
+    return true;
+  });
+}
 
 /** One query over all profession corpus pages, bucketed by family key. */
 async function loadAllCoverage(): Promise<Map<string, FamilyCoverage>> {
@@ -137,8 +156,10 @@ async function loadLastActivity(): Promise<Map<string, Date>> {
 }
 
 export async function loadRoster(): Promise<{ rows: RosterRow[]; facets: RosterFacets }> {
-  const [agents, coverage, modelConfigs, providers, blockerRows, lastActivity] = await Promise.all([
+  const [agentsRaw, coverage, modelConfigs, providers, blockerRows, lastActivity] = await Promise.all([
     prisma.agent.findMany({
+      // Exclude archived / retired dual-seed alias rows (BI-74FD6420).
+      where: { archived: false, lifecycleStage: { not: "retirement" } },
       orderBy: [{ tier: "asc" }, { displayName: "asc" }],
       select: {
         agentId: true,
@@ -163,6 +184,9 @@ export async function loadRoster(): Promise<{ rows: RosterRow[]; facets: RosterF
       .catch(() => [] as Array<{ agentId: string; _count: { _all: number } }>),
     loadLastActivity(),
   ]);
+
+  // Belt-and-suspenders: drop any residual dual-seed alias twin still active.
+  const agents = dropDualSeedAliasAgents(agentsRaw);
 
   const providerStatus = new Map(providers.map((p) => [p.providerId, p.status]));
   const pinnedByAgent = new Map(modelConfigs.map((c) => [c.agentId, c.pinnedProviderId]));

--- a/apps/web/lib/coworker-record/roster.ts
+++ b/apps/web/lib/coworker-record/roster.ts
@@ -17,6 +17,9 @@ import {
 } from "@/lib/decision-perspective/resolve-profession-profile";
 import { normalizeVariantAxes } from "./variant-axes";
 
+// BI-74FD6420: roster collapses dual-seed slug + AGT-* pairs for display only.
+// Seed still creates slug agentId rows for FK consumers (service catalog, etc.).
+
 export type RosterRow = {
   agentId: string;
   slugId: string | null;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -43,6 +43,7 @@
     "./business-capability-perspectives": "./src/business-capability-perspectives.ts",
     "./workforce-portfolio": "./src/workforce-portfolio.ts",
     "./workforce-seed": "./src/workforce-seed.ts",
+    "./agent-identity": "./src/agent-identity.ts",
     "./agent-model-defaults": "./src/agent-model-defaults.ts",
     "./seed-skills": "./src/seed-skills.ts",
     "./patch": "./src/patch/index.ts"

--- a/packages/db/src/agent-identity.test.ts
+++ b/packages/db/src/agent-identity.test.ts
@@ -108,4 +108,23 @@ describe("dual-seed slug → canonical map (BI-74FD6420)", () => {
     expect(specialist.displayName).toBe("Portfolio Backlog Specialist");
     expect(mgr.displayName).not.toBe(specialist.displayName);
   });
+
+  it("keeps slug agentIds as first-class seed identities for FK consumers", () => {
+    // CoworkerService.providerAgentId, hive-scout tasks, and model defaults key
+    // Agent.agentId by slug. Dual-seed map is for roster display only until a
+    // full FK migration; seed must still create the slug row.
+    for (const cw of COWORKER_AGENT_SEEDS) {
+      const mapped = resolveCanonicalAgentId(cw.agentId);
+      if (mapped !== cw.agentId) {
+        expect(mapped).toMatch(/^AGT-/);
+        // Seed still upserts by the slug agentId (not only the AGT-* twin).
+        expect(cw.agentId).toBe(cw.slugId);
+      }
+    }
+    // Catalog provider ids must remain slug keys present in COWORKER_AGENT_SEEDS.
+    const seedIds = new Set(COWORKER_AGENT_SEEDS.map((c) => c.agentId));
+    for (const slug of ["build-specialist", "external-catalog-scout", "marketing-specialist", "customer-advisor"]) {
+      expect(seedIds.has(slug)).toBe(true);
+    }
+  });
 });

--- a/packages/db/src/agent-identity.test.ts
+++ b/packages/db/src/agent-identity.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { resolveAgentIdentity, deriveAgentDisplayName, AGENT_KINDS } from "./agent-identity.js";
+import {
+  resolveAgentIdentity,
+  deriveAgentDisplayName,
+  AGENT_KINDS,
+  COWORKER_SLUG_TO_CANONICAL_AGENT_ID,
+  resolveCanonicalAgentId,
+} from "./agent-identity.js";
 import { COWORKER_AGENT_SEEDS } from "./workforce-seed.js";
 
 // EP-COWORKER-RT Phase 1 — enforce the canonical coworker naming standard so the
@@ -64,4 +70,42 @@ describe("every coworker seed resolves to a clean identity", () => {
       assertCleanIdentity(displayName, kind);
     });
   }
+});
+
+describe("dual-seed slug → canonical map (BI-74FD6420)", () => {
+  it("maps every dual-seed slug observed on the live install to its AGT-* twin", () => {
+    expect(resolveCanonicalAgentId("coo")).toBe("AGT-ORCH-000");
+    expect(resolveCanonicalAgentId("build-specialist")).toBe("AGT-WS-BUILD");
+    expect(resolveCanonicalAgentId("admin-assistant")).toBe("AGT-WS-ADMIN");
+    expect(resolveCanonicalAgentId("external-catalog-scout")).toBe("AGT-WS-SCOUT");
+    expect(resolveCanonicalAgentId("inventory-specialist")).toBe("AGT-WS-INVENTORY");
+    expect(resolveCanonicalAgentId("onboarding-coo")).toBe("AGT-WS-ONBOARD");
+    // Unmapped seeds pass through unchanged.
+    expect(resolveCanonicalAgentId("storefront-advisor")).toBe("storefront-advisor");
+    expect(resolveCanonicalAgentId("AGT-ORCH-000")).toBe("AGT-ORCH-000");
+  });
+
+  it("maps only known dual-seed slugs (no accidental AGT-* keys)", () => {
+    for (const [slug, canonical] of Object.entries(COWORKER_SLUG_TO_CANONICAL_AGENT_ID)) {
+      expect(slug).not.toMatch(/^AGT-/);
+      expect(canonical).toMatch(/^AGT-/);
+    }
+  });
+
+  it("gives Onboarding COO a consistent Title-Case label", () => {
+    expect(resolveAgentIdentity({ agentId: "AGT-WS-ONBOARD", name: "onboarding-coo" }).displayName).toBe(
+      "Onboarding COO",
+    );
+    expect(resolveAgentIdentity({ agentId: "onboarding-coo", name: "Onboarding COO" }).displayName).toBe(
+      "Onboarding COO",
+    );
+  });
+
+  it("distinguishes the two Portfolio Backlog registry agents", () => {
+    const mgr = resolveAgentIdentity({ agentId: "AGT-102", name: "portfolio-backlog-agent" });
+    const specialist = resolveAgentIdentity({ agentId: "AGT-S2P-PFB", name: "portfolio-backlog-specialist" });
+    expect(mgr.displayName).toBe("Portfolio Backlog Manager");
+    expect(specialist.displayName).toBe("Portfolio Backlog Specialist");
+    expect(mgr.displayName).not.toBe(specialist.displayName);
+  });
 });

--- a/packages/db/src/agent-identity.ts
+++ b/packages/db/src/agent-identity.ts
@@ -39,7 +39,56 @@ export const AGENT_IDENTITY_OVERRIDES: Record<string, { displayName?: string; ki
   "architecture-agent": { displayName: "Solution Architect" },
   "AGT-WS-ADMIN": { displayName: "Platform Admin", kind: "coordinator" },
   "admin-assistant": { displayName: "Platform Admin", kind: "coordinator" },
+  // Onboarding COO must Title-Case COO consistently (not "Onboarding Coo").
+  "AGT-WS-ONBOARD": { displayName: "Onboarding COO" },
+  "onboarding-coo": { displayName: "Onboarding COO" },
+  // Two distinct registry agents both derived to "Portfolio Backlog" after
+  // noise-suffix strip — keep them legibly distinct on the roster (BI-74FD6420).
+  "AGT-102": { displayName: "Portfolio Backlog Manager" },
+  "AGT-S2P-PFB": { displayName: "Portfolio Backlog Specialist" },
 };
+
+/**
+ * Coworker slug handles (legacy seed `agentId` / `slugId`) → canonical registry
+ * `agentId` (AGT-*). Dual seed paths historically created BOTH rows, so the AI
+ * Workforce roster showed two COO / Build Lead / Platform Admin / etc. while
+ * naming-health still read clean (same displayName on both). BI-74FD6420.
+ *
+ * Seed attaches the slug to the canonical row and retires the alias row;
+ * roster load drops any residual alias twin.
+ */
+export const COWORKER_SLUG_TO_CANONICAL_AGENT_ID: Readonly<Record<string, string>> = {
+  coo: "AGT-ORCH-000",
+  "build-specialist": "AGT-WS-BUILD",
+  "admin-assistant": "AGT-WS-ADMIN",
+  "portfolio-advisor": "AGT-WS-PORTFOLIO",
+  "external-catalog-scout": "AGT-WS-SCOUT",
+  "inventory-specialist": "AGT-WS-INVENTORY",
+  "ea-architect": "AGT-WS-EA",
+  "hr-specialist": "AGT-WS-HR",
+  "customer-advisor": "AGT-WS-CUSTOMER",
+  "marketing-specialist": "AGT-WS-MARKETING",
+  "ops-coordinator": "AGT-WS-OPS",
+  "platform-engineer": "AGT-WS-PLATFORM",
+  "onboarding-coo": "AGT-WS-ONBOARD",
+};
+
+/** Reverse map: canonical AGT-* → preferred slug handle for Agent.slugId. */
+export const CANONICAL_AGENT_ID_TO_COWORKER_SLUG: Readonly<Record<string, string>> = Object.freeze(
+  Object.fromEntries(
+    Object.entries(COWORKER_SLUG_TO_CANONICAL_AGENT_ID).map(([slug, canonical]) => [canonical, slug]),
+  ),
+);
+
+/** Resolve a slug or agentId to the canonical registry agentId when known. */
+export function resolveCanonicalAgentId(agentIdOrSlug: string): string {
+  return COWORKER_SLUG_TO_CANONICAL_AGENT_ID[agentIdOrSlug] ?? agentIdOrSlug;
+}
+
+/** True when the id is a registry-style AGT-* identifier. */
+export function isCanonicalRegistryAgentId(agentId: string): boolean {
+  return /^AGT[-_]/i.test(agentId);
+}
 
 function titleCaseToken(tok: string): string {
   const lower = tok.toLowerCase();

--- a/packages/db/src/agent-identity.ts
+++ b/packages/db/src/agent-identity.ts
@@ -50,12 +50,15 @@ export const AGENT_IDENTITY_OVERRIDES: Record<string, { displayName?: string; ki
 
 /**
  * Coworker slug handles (legacy seed `agentId` / `slugId`) → canonical registry
- * `agentId` (AGT-*). Dual seed paths historically created BOTH rows, so the AI
- * Workforce roster showed two COO / Build Lead / Platform Admin / etc. while
- * naming-health still read clean (same displayName on both). BI-74FD6420.
+ * `agentId` (AGT-*). Dual seed paths create BOTH rows, so the AI Workforce
+ * roster would show two COO / Build Lead / Platform Admin / etc. while
+ * naming-health still reads clean (same displayName on both). BI-74FD6420.
  *
- * Seed attaches the slug to the canonical row and retires the alias row;
- * roster load drops any residual alias twin.
+ * IMPORTANT: slug agentId rows remain first-class seed identities — many FK
+ * consumers key `Agent.agentId` by slug (`CoworkerService.providerAgentId`,
+ * hive-scout scheduled task, agent-model-defaults, skill assignTo). Do NOT
+ * retire slug rows in seed until those consumers are remapped. Roster display
+ * collapses dual-seed pairs via `dropDualSeedAliasAgents` (prefer AGT-*).
  */
 export const COWORKER_SLUG_TO_CANONICAL_AGENT_ID: Readonly<Record<string, string>> = {
   coo: "AGT-ORCH-000",
@@ -73,14 +76,17 @@ export const COWORKER_SLUG_TO_CANONICAL_AGENT_ID: Readonly<Record<string, string
   "onboarding-coo": "AGT-WS-ONBOARD",
 };
 
-/** Reverse map: canonical AGT-* → preferred slug handle for Agent.slugId. */
+/** Reverse map: canonical AGT-* → preferred slug handle. */
 export const CANONICAL_AGENT_ID_TO_COWORKER_SLUG: Readonly<Record<string, string>> = Object.freeze(
   Object.fromEntries(
     Object.entries(COWORKER_SLUG_TO_CANONICAL_AGENT_ID).map(([slug, canonical]) => [canonical, slug]),
   ),
 );
 
-/** Resolve a slug or agentId to the canonical registry agentId when known. */
+/**
+ * Resolve a slug or agentId to the canonical registry agentId when known.
+ * Use for roster/display collapse — not as a substitute for seed FK remapping.
+ */
 export function resolveCanonicalAgentId(agentIdOrSlug: string): string {
   return COWORKER_SLUG_TO_CANONICAL_AGENT_ID[agentIdOrSlug] ?? agentIdOrSlug;
 }

--- a/packages/db/src/coworker-service-catalog-seed.test.ts
+++ b/packages/db/src/coworker-service-catalog-seed.test.ts
@@ -6,6 +6,7 @@ import {
   seedCoworkerServiceCatalog,
 } from "./coworker-service-catalog-seed";
 import { COWORKER_AGENT_SEEDS } from "./workforce-seed";
+import { resolveCanonicalAgentId } from "./agent-identity";
 
 function unique(values: readonly string[]) {
   return new Set(values).size === values.length;
@@ -107,6 +108,14 @@ describe("coworker service catalog seed data", () => {
       expect(args["create"]).not.toHaveProperty("digitalProductId");
       expect(args["update"]).not.toHaveProperty("digitalProductId");
     }
+    expect(serviceUpserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          create: expect.objectContaining({ providerAgentId: resolveCanonicalAgentId("build-specialist") }),
+          update: expect.objectContaining({ providerAgentId: resolveCanonicalAgentId("build-specialist") }),
+        }),
+      ]),
+    );
     expect(serviceUpdates).toEqual([
       expect.objectContaining({
         where: expect.objectContaining({ digitalProductId: "dpf-portal" }),

--- a/packages/db/src/coworker-service-catalog-seed.test.ts
+++ b/packages/db/src/coworker-service-catalog-seed.test.ts
@@ -6,7 +6,6 @@ import {
   seedCoworkerServiceCatalog,
 } from "./coworker-service-catalog-seed";
 import { COWORKER_AGENT_SEEDS } from "./workforce-seed";
-import { resolveCanonicalAgentId } from "./agent-identity";
 
 function unique(values: readonly string[]) {
   return new Set(values).size === values.length;
@@ -108,14 +107,18 @@ describe("coworker service catalog seed data", () => {
       expect(args["create"]).not.toHaveProperty("digitalProductId");
       expect(args["update"]).not.toHaveProperty("digitalProductId");
     }
-    expect(serviceUpserts).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          create: expect.objectContaining({ providerAgentId: resolveCanonicalAgentId("build-specialist") }),
-          update: expect.objectContaining({ providerAgentId: resolveCanonicalAgentId("build-specialist") }),
-        }),
-      ]),
-    );
+    // BI-74FD6420 seed-FK contract: providerAgentId stays the slug agentId
+    // (build-specialist), NOT the dual-seed AGT-* twin. Collapsing to AGT-*
+    // here breaks CoworkerService_providerAgentId_fkey when slug rows are the
+    // seeded provider identity.
+    const providerIds = serviceUpserts.map((args) => {
+      const create = args["create"] as { providerAgentId?: string } | undefined;
+      return create?.providerAgentId;
+    });
+    expect(providerIds).toContain("build-specialist");
+    expect(providerIds).toContain("external-catalog-scout");
+    expect(providerIds).not.toContain("AGT-WS-BUILD");
+    expect(providerIds).not.toContain("AGT-WS-SCOUT");
     expect(serviceUpdates).toEqual([
       expect.objectContaining({
         where: expect.objectContaining({ digitalProductId: "dpf-portal" }),

--- a/packages/db/src/coworker-service-catalog-seed.ts
+++ b/packages/db/src/coworker-service-catalog-seed.ts
@@ -1,5 +1,4 @@
 import type { Prisma, PrismaClient } from "../generated/client/client";
-import { resolveCanonicalAgentId } from "./agent-identity";
 import { AI_WORKFORCE_PRODUCT_ID } from "./workforce-portfolio";
 
 type CoworkerServiceSeed = {
@@ -346,14 +345,10 @@ export const COWORKER_SERVICE_CATALOG_OFFER_SEEDS: readonly CoworkerOfferSeed[] 
 
 export async function seedCoworkerServiceCatalog(prisma: PrismaClient): Promise<void> {
   for (const service of COWORKER_SERVICE_CATALOG_SERVICE_SEEDS) {
-    const canonicalService = {
-      ...service,
-      providerAgentId: resolveCanonicalAgentId(service.providerAgentId),
-    };
     await prisma.coworkerService.upsert({
       where: { serviceId: service.serviceId },
-      create: canonicalService,
-      update: canonicalService,
+      create: service,
+      update: service,
     });
   }
 

--- a/packages/db/src/coworker-service-catalog-seed.ts
+++ b/packages/db/src/coworker-service-catalog-seed.ts
@@ -1,4 +1,5 @@
 import type { Prisma, PrismaClient } from "../generated/client/client";
+import { resolveCanonicalAgentId } from "./agent-identity";
 import { AI_WORKFORCE_PRODUCT_ID } from "./workforce-portfolio";
 
 type CoworkerServiceSeed = {
@@ -345,10 +346,14 @@ export const COWORKER_SERVICE_CATALOG_OFFER_SEEDS: readonly CoworkerOfferSeed[] 
 
 export async function seedCoworkerServiceCatalog(prisma: PrismaClient): Promise<void> {
   for (const service of COWORKER_SERVICE_CATALOG_SERVICE_SEEDS) {
+    const canonicalService = {
+      ...service,
+      providerAgentId: resolveCanonicalAgentId(service.providerAgentId),
+    };
     await prisma.coworkerService.upsert({
       where: { serviceId: service.serviceId },
-      create: service,
-      update: service,
+      create: canonicalService,
+      update: canonicalService,
     });
   }
 

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -5,11 +5,7 @@ import { join } from "path";
 import { prisma } from "./client.js";
 import { Prisma } from "../generated/client/client";
 import { parseRoleId, parseAgentTier, parseAgentType, parseAgentPortfolioSlug } from "./seed-helpers.js";
-import {
-  CANONICAL_AGENT_ID_TO_COWORKER_SLUG,
-  resolveAgentIdentity,
-  resolveCanonicalAgentId,
-} from "./agent-identity.js";
+import { resolveAgentIdentity } from "./agent-identity.js";
 import { loadFingerprintCatalogIntoDb, defaultCatalogPath } from "./discovery-fingerprint-catalog-loader.js";
 import { seedEaArchimate4 } from "./seed-ea-archimate4.js";
 import { seedEaBpmn20 } from "./seed-ea-bpmn20.js";
@@ -202,22 +198,19 @@ async function seedAgents(): Promise<void> {
     const portfolioSlug = parseAgentPortfolioSlug(a.human_supervisor_id ?? "");
     const portfolioId = portfolioSlug ? (portfolioIdBySlug.get(portfolioSlug) ?? null) : null;
 
-    // Prefer explicit registry aliases[0], then the dual-seed slug map, so the
-    // canonical AGT-* row owns the slug handle used by resolveAgent / routing.
-    const preferredSlug =
-      (Array.isArray(a.aliases) && a.aliases[0] ? a.aliases[0] : null) ??
-      CANONICAL_AGENT_ID_TO_COWORKER_SLUG[a.agent_id] ??
-      null;
-
     const identity = resolveAgentIdentity({
       agentId: a.agent_id,
       name: a.agent_name,
-      slugId: preferredSlug,
       tier: a.tier,
       displayName: a.displayName,
       kind: a.kind,
     });
 
+    // BI-74FD6420: do NOT attach coworker slug handles onto AGT-* rows here.
+    // COWORKER_AGENT_SEEDS still creates parallel slug agentId rows that many
+    // FK consumers reference (coworkerServiceCatalog, hive-scout task,
+    // agent-model-defaults). Collapsing those into AGT-* breaks seed. Roster
+    // display collapses dual-seed pairs via dropDualSeedAliasAgents instead.
     const unifiedFields = {
       name: a.agent_name,
       displayName: identity.displayName,
@@ -235,23 +228,7 @@ async function seedAgents(): Promise<void> {
       escalatesTo: a.escalates_to ?? null,
       delegatesTo: a.delegates_to ?? [],
       sensitivity: "internal" as const,
-      // Only set slugId when free or already ours — never steal another row's unique slug.
-      ...(preferredSlug ? { slugId: preferredSlug } : {}),
-      archived: false,
-      lifecycleStage: "production",
     };
-
-    // If a legacy dual-seed row still holds the slugId, clear it first so the
-    // unique constraint allows the canonical row to own the handle (BI-74FD6420).
-    if (preferredSlug) {
-      await prisma.agent.updateMany({
-        where: {
-          slugId: preferredSlug,
-          NOT: { agentId: a.agent_id },
-        },
-        data: { slugId: null },
-      });
-    }
 
     const agent = await prisma.agent.upsert({
       where: { agentId: a.agent_id },
@@ -1059,41 +1036,17 @@ async function seedCoworkerAgents(): Promise<void> {
 
   const revokedGrants = await loadRevokedGrantSet(); // BI-4FA040D5
   let grantCount = 0;
-  let retiredAliasCount = 0;
   for (const cw of COWORKER_AGENT_SEEDS) {
-    const { agentId: seedAgentId, slugId, ...rest } = cw;
-    // Prefer the registry AGT-* twin when this slug is a dual-seed alias
-    // (BI-74FD6420). Fall back to the seed agentId for coworkers that only
-    // exist on the COWORKER_AGENT_SEEDS path (storefront-advisor, etc.).
-    const canonicalAgentId = resolveCanonicalAgentId(seedAgentId);
-    const identity = resolveAgentIdentity({
-      agentId: canonicalAgentId,
-      name: rest.name,
-      slugId,
-      displayName: rest.name,
-    });
-
-    // Free the slug handle from any legacy alias row before attaching it to
-    // the canonical agent (Agent.slugId is unique).
-    if (slugId) {
-      await prisma.agent.updateMany({
-        where: { slugId, NOT: { agentId: canonicalAgentId } },
-        data: { slugId: null },
-      });
-    }
-
+    // Keep slug agentId rows as first-class seed identities. Many surfaces FK
+    // Agent.agentId by slug (CoworkerService.providerAgentId, hive scout task,
+    // agent-model-defaults). Dual-seed AGT-* twins from seedAgents() remain;
+    // AI Workforce roster display collapses them via dropDualSeedAliasAgents
+    // (BI-74FD6420) until a full FK migration lands.
+    const { agentId, slugId, ...rest } = cw;
+    const identity = resolveAgentIdentity({ agentId, name: rest.name, slugId, displayName: rest.name });
     const agent = await prisma.agent.upsert({
-      where: { agentId: canonicalAgentId },
-      create: {
-        agentId: canonicalAgentId,
-        slugId,
-        displayName: identity.displayName,
-        kind: identity.kind,
-        ...rest,
-        lifecycleStage: "production",
-        archived: false,
-        status: "active",
-      },
+      where: { agentId },
+      create: { agentId, slugId, displayName: identity.displayName, kind: identity.kind, ...rest, lifecycleStage: "production" },
       update: {
         slugId,
         name: rest.name,
@@ -1102,29 +1055,14 @@ async function seedCoworkerAgents(): Promise<void> {
         description: rest.description,
         valueStream: rest.valueStream,
         sensitivity: rest.sensitivity,
+        // Un-retire if a prior broken seed pass archived the slug twin.
         archived: false,
         status: "active",
         lifecycleStage: "production",
       },
     });
 
-    // Retire the legacy dual-seed row when it is a different agentId from the
-    // canonical twin. Quarantine (not hard-delete) so historical FKs stay valid.
-    if (canonicalAgentId !== seedAgentId) {
-      const retired = await prisma.agent.updateMany({
-        where: { agentId: seedAgentId, archived: false },
-        data: {
-          archived: true,
-          status: "inactive",
-          lifecycleStage: "retirement",
-          slugId: null,
-        },
-      });
-      retiredAliasCount += retired.count;
-    }
-
-    // Grants are keyed by the seed's declared slug (HARDCODED_COWORKER_GRANTS).
-    const grants = HARDCODED_COWORKER_GRANTS[seedAgentId] ?? HARDCODED_COWORKER_GRANTS[canonicalAgentId];
+    const grants = HARDCODED_COWORKER_GRANTS[agentId];
     if (grants) {
       for (const grantKey of grants) {
         if (revokedGrants.has(`${agent.id}:${grantKey}`)) continue; // BI-4FA040D5: honor durable revocation
@@ -1166,10 +1104,7 @@ async function seedCoworkerAgents(): Promise<void> {
     }
   }
 
-  console.log(
-    `Seeded ${COWORKER_AGENT_SEEDS.length} coworker agents with ${grantCount} tool grants` +
-      (retiredAliasCount > 0 ? ` (retired ${retiredAliasCount} dual-seed alias row(s))` : ""),
-  );
+  console.log(`Seeded ${COWORKER_AGENT_SEEDS.length} coworker agents with ${grantCount} tool grants`);
 }
 
 /** EP-AI-WORKFORCE-001: Seed skills for coworker agents */

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -5,7 +5,11 @@ import { join } from "path";
 import { prisma } from "./client.js";
 import { Prisma } from "../generated/client/client";
 import { parseRoleId, parseAgentTier, parseAgentType, parseAgentPortfolioSlug } from "./seed-helpers.js";
-import { resolveAgentIdentity } from "./agent-identity.js";
+import {
+  CANONICAL_AGENT_ID_TO_COWORKER_SLUG,
+  resolveAgentIdentity,
+  resolveCanonicalAgentId,
+} from "./agent-identity.js";
 import { loadFingerprintCatalogIntoDb, defaultCatalogPath } from "./discovery-fingerprint-catalog-loader.js";
 import { seedEaArchimate4 } from "./seed-ea-archimate4.js";
 import { seedEaBpmn20 } from "./seed-ea-bpmn20.js";
@@ -140,6 +144,8 @@ interface RegistryAgent {
   delegates_to?: string[];
   escalates_to?: string;
   it4it_sections?: string[];
+  /** Optional slug aliases from agent_registry.json (first becomes Agent.slugId). */
+  aliases?: string[];
   config_profile?: {
     model_binding?: {
       model_id?: string;
@@ -196,9 +202,17 @@ async function seedAgents(): Promise<void> {
     const portfolioSlug = parseAgentPortfolioSlug(a.human_supervisor_id ?? "");
     const portfolioId = portfolioSlug ? (portfolioIdBySlug.get(portfolioSlug) ?? null) : null;
 
+    // Prefer explicit registry aliases[0], then the dual-seed slug map, so the
+    // canonical AGT-* row owns the slug handle used by resolveAgent / routing.
+    const preferredSlug =
+      (Array.isArray(a.aliases) && a.aliases[0] ? a.aliases[0] : null) ??
+      CANONICAL_AGENT_ID_TO_COWORKER_SLUG[a.agent_id] ??
+      null;
+
     const identity = resolveAgentIdentity({
       agentId: a.agent_id,
       name: a.agent_name,
+      slugId: preferredSlug,
       tier: a.tier,
       displayName: a.displayName,
       kind: a.kind,
@@ -221,7 +235,23 @@ async function seedAgents(): Promise<void> {
       escalatesTo: a.escalates_to ?? null,
       delegatesTo: a.delegates_to ?? [],
       sensitivity: "internal" as const,
+      // Only set slugId when free or already ours — never steal another row's unique slug.
+      ...(preferredSlug ? { slugId: preferredSlug } : {}),
+      archived: false,
+      lifecycleStage: "production",
     };
+
+    // If a legacy dual-seed row still holds the slugId, clear it first so the
+    // unique constraint allows the canonical row to own the handle (BI-74FD6420).
+    if (preferredSlug) {
+      await prisma.agent.updateMany({
+        where: {
+          slugId: preferredSlug,
+          NOT: { agentId: a.agent_id },
+        },
+        data: { slugId: null },
+      });
+    }
 
     const agent = await prisma.agent.upsert({
       where: { agentId: a.agent_id },
@@ -1029,12 +1059,41 @@ async function seedCoworkerAgents(): Promise<void> {
 
   const revokedGrants = await loadRevokedGrantSet(); // BI-4FA040D5
   let grantCount = 0;
+  let retiredAliasCount = 0;
   for (const cw of COWORKER_AGENT_SEEDS) {
-    const { agentId, slugId, ...rest } = cw;
-    const identity = resolveAgentIdentity({ agentId, name: rest.name, slugId, displayName: rest.name });
+    const { agentId: seedAgentId, slugId, ...rest } = cw;
+    // Prefer the registry AGT-* twin when this slug is a dual-seed alias
+    // (BI-74FD6420). Fall back to the seed agentId for coworkers that only
+    // exist on the COWORKER_AGENT_SEEDS path (storefront-advisor, etc.).
+    const canonicalAgentId = resolveCanonicalAgentId(seedAgentId);
+    const identity = resolveAgentIdentity({
+      agentId: canonicalAgentId,
+      name: rest.name,
+      slugId,
+      displayName: rest.name,
+    });
+
+    // Free the slug handle from any legacy alias row before attaching it to
+    // the canonical agent (Agent.slugId is unique).
+    if (slugId) {
+      await prisma.agent.updateMany({
+        where: { slugId, NOT: { agentId: canonicalAgentId } },
+        data: { slugId: null },
+      });
+    }
+
     const agent = await prisma.agent.upsert({
-      where: { agentId },
-      create: { agentId, slugId, displayName: identity.displayName, kind: identity.kind, ...rest, lifecycleStage: "production" },
+      where: { agentId: canonicalAgentId },
+      create: {
+        agentId: canonicalAgentId,
+        slugId,
+        displayName: identity.displayName,
+        kind: identity.kind,
+        ...rest,
+        lifecycleStage: "production",
+        archived: false,
+        status: "active",
+      },
       update: {
         slugId,
         name: rest.name,
@@ -1043,10 +1102,29 @@ async function seedCoworkerAgents(): Promise<void> {
         description: rest.description,
         valueStream: rest.valueStream,
         sensitivity: rest.sensitivity,
+        archived: false,
+        status: "active",
+        lifecycleStage: "production",
       },
     });
 
-    const grants = HARDCODED_COWORKER_GRANTS[agentId];
+    // Retire the legacy dual-seed row when it is a different agentId from the
+    // canonical twin. Quarantine (not hard-delete) so historical FKs stay valid.
+    if (canonicalAgentId !== seedAgentId) {
+      const retired = await prisma.agent.updateMany({
+        where: { agentId: seedAgentId, archived: false },
+        data: {
+          archived: true,
+          status: "inactive",
+          lifecycleStage: "retirement",
+          slugId: null,
+        },
+      });
+      retiredAliasCount += retired.count;
+    }
+
+    // Grants are keyed by the seed's declared slug (HARDCODED_COWORKER_GRANTS).
+    const grants = HARDCODED_COWORKER_GRANTS[seedAgentId] ?? HARDCODED_COWORKER_GRANTS[canonicalAgentId];
     if (grants) {
       for (const grantKey of grants) {
         if (revokedGrants.has(`${agent.id}:${grantKey}`)) continue; // BI-4FA040D5: honor durable revocation
@@ -1088,7 +1166,10 @@ async function seedCoworkerAgents(): Promise<void> {
     }
   }
 
-  console.log(`Seeded ${COWORKER_AGENT_SEEDS.length} coworker agents with ${grantCount} tool grants`);
+  console.log(
+    `Seeded ${COWORKER_AGENT_SEEDS.length} coworker agents with ${grantCount} tool grants` +
+      (retiredAliasCount > 0 ? ` (retired ${retiredAliasCount} dual-seed alias row(s))` : ""),
+  );
 }
 
 /** EP-AI-WORKFORCE-001: Seed skills for coworker agents */


### PR DESCRIPTION
## Summary
- Fixes AI Workforce roster showing duplicate coworker rows (two COO, Build Lead, Platform Admin, Scout, Inventory, Onboarding COO variants) while Naming Health still read clean.
- Root cause: dual seed paths create both `AGT-*` registry agents and parallel slug `agentId` rows with the same displayName.
- **Display-only collapse:** `loadRoster` drops dual-seed slug twins when the AGT-* row is present (`dropDualSeedAliasAgents`).
- **Seed keeps slug agentIds** for FK consumers (`CoworkerService.providerAgentId`, hive-scout, model-defaults). Do **not** retire slug rows until a full FK migration.
- Portfolio Backlog pair + Onboarding COO labels clarified via identity overrides.
- Follow-up commit undoes an unsafe seed remap that broke `CoworkerService_providerAgentId_fkey`.

## Test plan
- [x] `pnpm --filter @dpf/db exec vitest run src/agent-identity.test.ts src/coworker-service-catalog-seed.test.ts src/seed-hive-scout.test.ts` (107 passed) — worktree
- [x] `pnpm --filter web exec vitest run lib/coworker-record/roster-dedupe.test.ts` (4 passed) — worktree
- [x] `pnpm --filter @dpf/db typecheck` exit 0 — worktree
- [x] Catalog seed FK contract: providerAgentId remains `build-specialist` / `external-catalog-scout` (not AGT-*)
- [ ] After merge + self-upgrade, live `/platform/ai/overview` shows one row per dual-seed pair

## Trailers
Seed-Fit-Decision: global-default — restores prior seed identity keys; roster filter is install-safe display-only; no new seed tables.
UX-Fit-Decision: no-new-control — roster dedupe only; no new operator input
Process-Spine-Decision: bugfix with unit tests against live dual-seed pairs + seed-FK regression guard; no new substrate concept
Local-CI-Override: worktree typecheck green + seed contract tests (107) + roster-dedupe (4); seed FK fix for #2804