### PR TITLE
fix(test): silence portal-context teardown log race (BI-AE6AFE3D)

### DIFF
--- a/apps/web/lib/portal-context/portal-context.test.ts
+++ b/apps/web/lib/portal-context/portal-context.test.ts
@@ -6,6 +6,19 @@ vi.mock("./queue-awareness-resolver", () => ({
   resolveQueueAttention: vi.fn().mockResolvedValue([]),
 }));
 
+// BI-AE6AFE3D: loadBuildStudioCapability hits live Prisma (modelProfile /
+// modelProvider / buildEngine). When a sub-resolver soft-timeouts, the
+// cancelled-but-still-running promise can emit prisma:error console output
+// *after* the test returns → EnvironmentTeardownError
+// "Closing rpc while onUserConsoleLog was pending". Stub the capability
+// loader so this suite never opens a real DB connection.
+vi.mock("@/lib/build/build-studio-capability", () => ({
+  loadBuildStudioCapability: vi.fn().mockResolvedValue({
+    ok: true,
+    satisfyingProviderNames: ["test-provider"],
+  }),
+}));
+
 import {
   bucketPortalContextTimestamp,
   createPortalContextEnvelopeId,


### PR DESCRIPTION
## Summary
- Stops intermittent `EnvironmentTeardownError: Closing rpc while onUserConsoleLog was pending` on `portal-context.test.ts`.
- Root cause: soft-timeout tests left `loadBuildStudioCapability` querying live Prisma; `prisma:error` console output arrived after the test returned.
- Mock the capability loader so the suite is hermetic (same family as the mcp-tools-backlog teardown fix).

## Test plan
- [x] `pnpm --filter web exec vitest run lib/portal-context/portal-context.test.ts` — 12 passed, 5 consecutive clean runs, no post-suite prisma:error
- substrate: worktree `~/dpf-worktrees/codeql-log-injection`

## Trailers
Process-Spine-Decision: test-only flake fix; no product surface change
UX-Fit-Decision: no-new-control — test hermeticity only
Local-CI-Override: 5/5 vitest green portal-context.test.ts in worktree; test-only change