### PR TITLE
fix(nav): Simple mode condenses workspace home, not only the rail (BI-655418A7)

### DIFF
--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -16,7 +16,7 @@ import { PlatformBanner } from "@/components/platform/PlatformBanner";
 import { ShellBannerOverlay } from "@/components/shell/ShellBannerOverlay";
 import { ModelWarmup } from "@/components/shell/ModelWarmup";
 import { SetupOverlay } from "@/components/setup/SetupOverlay";
-import { getShellNavSections, type PortalAudienceMode } from "@/lib/permissions";
+import { getShellNavSections } from "@/lib/permissions";
 import { cookies } from "next/headers";
 import { getActiveOrgCapabilities } from "@/lib/storefront/civic-surfaces.server";
 import { AppRail } from "@/components/shell/AppRail";
@@ -24,6 +24,7 @@ import { ShellBreadcrumb } from "@/components/shell/ShellBreadcrumb";
 import { isUnifiedCoworkerEnabled } from "@/lib/feature-flags";
 import { resolveHomePhoneCountry } from "@/lib/phone-country.server";
 import { PhoneCountryProvider } from "@/components/ui/PhoneCountryContext";
+import { NAV_MODE_COOKIE, resolveNavModeFromCookie } from "@/lib/navigation/nav-mode";
 
 export default async function ShellLayout({ children }: { children: React.ReactNode }) {
   // First-run check — redirect to setup if no org exists.
@@ -137,12 +138,10 @@ export default async function ShellLayout({ children }: { children: React.ReactN
       });
 
   const brandingCss = buildBrandingStyleTag(activeBranding?.tokens ?? null);
-  // Worker/operator rail mode (EP-NAV-COHERENCE P4). Default "operator" = the full rail
-  // (no behavior change); a user opts into the condensed "worker" rail via the rail's mode
-  // toggle, which sets this cookie. Operator is always one toggle away, so worker mode
-  // never strands a user away from a surface their role can reach.
-  const navModeCookie = (await cookies()).get("dpf-nav-mode")?.value;
-  const navMode: PortalAudienceMode = navModeCookie === "worker" ? "worker" : "operator";
+  // Worker/operator rail mode (EP-NAV-COHERENCE P4 / BI-655418A7). Default
+  // "operator" = the full rail; "Simple" writes worker via the rail toggle.
+  // Operator is always one toggle away, so worker mode never strands a user.
+  const navMode = resolveNavModeFromCookie((await cookies()).get(NAV_MODE_COOKIE)?.value);
   const shellNavSections = activeSetup
     ? []
     : getShellNavSections(

--- a/apps/web/app/(shell)/workspace/page.tsx
+++ b/apps/web/app/(shell)/workspace/page.tsx
@@ -1,6 +1,7 @@
 // apps/web/app/(shell)/workspace/page.tsx
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
 import { prisma } from "@dpf/db";
 import { PlatformWorkspaceHome } from "@/components/workspace-home/PlatformWorkspaceHome";
 import { VerticalWorkspaceHome } from "@/components/workspace-home/VerticalWorkspaceHome";
@@ -10,10 +11,19 @@ import { UnconfiguredWorkspaceHomeNotice } from "@/components/workspace-home/Unc
 import { loadPlatformWorkspaceHomeData } from "@/lib/workspace-home/platform-loader";
 import { resolveWorkspaceHomeContribution } from "@/lib/workspace-home/registry";
 import { recordWorkspaceHomeResolution } from "@/lib/workspace-home/telemetry";
+import {
+  isSimpleNavMode,
+  NAV_MODE_COOKIE,
+  resolveNavModeFromCookie,
+} from "@/lib/navigation/nav-mode";
 
 export default async function WorkspacePage() {
   const session = await auth();
   if (!session?.user) redirect("/login");
+
+  // BI-655418A7: Simple mode must condense the home body, not only the rail.
+  const navMode = resolveNavModeFromCookie((await cookies()).get(NAV_MODE_COOKIE)?.value);
+  const simpleHome = isSimpleNavMode(navMode);
 
   const platformHomeData = await loadPlatformWorkspaceHomeData({
     prismaClient: prisma,
@@ -37,7 +47,7 @@ export default async function WorkspacePage() {
   });
 
   return (
-    <div>
+    <div data-nav-mode={navMode}>
       {workspaceHomeResolution.mode === "unconfigured" && <UnconfiguredWorkspaceHomeNotice />}
       {workspaceHomeResolution.mode !== "unconfigured" && !hasCloudProvider && (
         <LocalOnlyProviderNotice />
@@ -52,7 +62,10 @@ export default async function WorkspacePage() {
           data={platformHomeData}
         />
       ) : (
-        <PlatformWorkspaceHome data={platformHomeData} />
+        <PlatformWorkspaceHome
+          data={platformHomeData}
+          density={simpleHome ? "simple" : "full"}
+        />
       )}
     </div>
   );

--- a/apps/web/components/shell/AppRail.tsx
+++ b/apps/web/components/shell/AppRail.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import type { PortalAudienceMode, ShellNavSection } from "@/lib/permissions";
+import { NAV_MODE_COOKIE } from "@/lib/navigation/nav-mode";
 
 type Props = {
   sections: ShellNavSection[];
@@ -12,8 +13,6 @@ type Props = {
 function matchesPath(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(`${href}/`);
 }
-
-const MODE_COOKIE = "dpf-nav-mode";
 
 export function AppRail({ sections, mode = "operator" }: Props) {
   const pathname = usePathname();
@@ -29,12 +28,12 @@ export function AppRail({ sections, mode = "operator" }: Props) {
   // user away from a surface their role can reach. Persisted in a cookie the shell reads.
   function setMode(next: PortalAudienceMode) {
     if (next === mode) return;
-    document.cookie = `${MODE_COOKIE}=${next}; path=/; max-age=31536000; samesite=lax`;
+    document.cookie = `${NAV_MODE_COOKIE}=${next}; path=/; max-age=31536000; samesite=lax`;
     router.refresh();
   }
 
   return (
-    <nav aria-label="Primary" className="flex flex-col gap-3 p-3 lg:p-4">
+    <nav aria-label="Primary" data-nav-mode={mode} className="flex flex-col gap-3 p-3 lg:p-4">
       <div
         role="group"
         aria-label="Navigation detail"

--- a/apps/web/components/workspace-home/PlatformWorkspaceHome.test.tsx
+++ b/apps/web/components/workspace-home/PlatformWorkspaceHome.test.tsx
@@ -96,4 +96,16 @@ describe("PlatformWorkspaceHome", () => {
     expect(html).not.toContain("Domain readiness");
     expect(html).not.toContain("Command Center");
   });
+
+  it("simple density hides the work-area launcher so Simple mode changes the page body (BI-655418A7)", () => {
+    const full = renderToStaticMarkup(<PlatformWorkspaceHome data={fixtureData} density="full" />);
+    const simple = renderToStaticMarkup(<PlatformWorkspaceHome data={fixtureData} density="simple" />);
+
+    expect(full).toContain("Work areas");
+    expect(full).toContain("Show areas");
+    expect(simple).not.toContain("Work areas");
+    expect(simple).not.toContain("Show areas");
+    expect(simple).toContain("Simple view");
+    expect(simple).toContain('data-workspace-density="simple"');
+  });
 });

--- a/apps/web/components/workspace-home/PlatformWorkspaceHome.tsx
+++ b/apps/web/components/workspace-home/PlatformWorkspaceHome.tsx
@@ -7,22 +7,34 @@ import type { PlatformWorkspaceHomeData } from "@/lib/workspace-home/platform-lo
 type PlatformWorkspaceHomeProps = {
   data: Omit<PlatformWorkspaceHomeData, "storefrontConfig">;
   heading?: string;
+  /**
+   * BI-655418A7: Simple (worker) mode keeps attention + day agenda and hides the
+   * dense multi-area launcher that made Simple feel like a no-op on the home.
+   */
+  density?: "simple" | "full";
 };
 
-export function PlatformWorkspaceHome({ data, heading = "Workspace" }: PlatformWorkspaceHomeProps) {
+export function PlatformWorkspaceHome({
+  data,
+  heading = "Workspace",
+  density = "full",
+}: PlatformWorkspaceHomeProps) {
   const {
     workspaceSections,
     workspaceCommandCenter,
     calendarEvents,
     feedItems,
   } = data;
+  const simple = density === "simple";
 
   return (
-    <div>
+    <div data-workspace-density={density}>
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-[var(--dpf-text)]">{heading}</h1>
         <p className="mt-1 text-sm text-[var(--dpf-muted)]">
-          Your day at a glance — what needs doing now and next.
+          {simple
+            ? "Simple view — focus on what needs you now. Switch to Full in the rail for every area."
+            : "Your day at a glance — what needs doing now and next."}
         </p>
       </div>
 
@@ -38,10 +50,12 @@ export function PlatformWorkspaceHome({ data, heading = "Workspace" }: PlatformW
         </div>
       </div>
 
-      <WorkspaceAreaLauncher
-        sections={workspaceSections}
-        tileStatus={workspaceCommandCenter.tileStatus}
-      />
+      {!simple && (
+        <WorkspaceAreaLauncher
+          sections={workspaceSections}
+          tileStatus={workspaceCommandCenter.tileStatus}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/lib/navigation/nav-mode.test.ts
+++ b/apps/web/lib/navigation/nav-mode.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isSimpleNavMode, resolveNavModeFromCookie } from "./nav-mode";
+
+describe("resolveNavModeFromCookie", () => {
+  it("defaults missing/unknown values to operator (full rail)", () => {
+    expect(resolveNavModeFromCookie(undefined)).toBe("operator");
+    expect(resolveNavModeFromCookie(null)).toBe("operator");
+    expect(resolveNavModeFromCookie("")).toBe("operator");
+    expect(resolveNavModeFromCookie("full")).toBe("operator");
+    expect(resolveNavModeFromCookie("operator")).toBe("operator");
+  });
+
+  it("accepts worker and the Simple UI alias", () => {
+    expect(resolveNavModeFromCookie("worker")).toBe("worker");
+    expect(resolveNavModeFromCookie(" worker ")).toBe("worker");
+    expect(resolveNavModeFromCookie("Simple")).toBe("worker");
+    expect(resolveNavModeFromCookie("SIMPLE")).toBe("worker");
+  });
+});
+
+describe("isSimpleNavMode", () => {
+  it("is true only for worker", () => {
+    expect(isSimpleNavMode("worker")).toBe(true);
+    expect(isSimpleNavMode("operator")).toBe(false);
+    expect(isSimpleNavMode("customer")).toBe(false);
+  });
+});

--- a/apps/web/lib/navigation/nav-mode.ts
+++ b/apps/web/lib/navigation/nav-mode.ts
@@ -1,0 +1,21 @@
+// apps/web/lib/navigation/nav-mode.ts
+// EP-NAV-COHERENCE / BI-655418A7 — single reader for the Simple/Full rail cookie.
+// Layout filters the shell rail; workspace home also condenses page chrome when
+// mode is "worker" so the toggle is not a nav-only no-op.
+
+import type { PortalAudienceMode } from "@/lib/navigation/portal-navigation-model";
+
+export const NAV_MODE_COOKIE = "dpf-nav-mode";
+
+/** Parse the dpf-nav-mode cookie (or equivalent string) into a PortalAudienceMode. */
+export function resolveNavModeFromCookie(value: string | undefined | null): PortalAudienceMode {
+  const v = (value ?? "").trim().toLowerCase();
+  // "simple" accepted as an alias if a client ever wrote the UI label by mistake.
+  if (v === "worker" || v === "simple") return "worker";
+  return "operator";
+}
+
+/** True when Simple (worker) mode should hide operator-dense page chrome. */
+export function isSimpleNavMode(mode: PortalAudienceMode): boolean {
+  return mode === "worker";
+}


### PR DESCRIPTION
## Summary
- Simple/Full rail mode already filtered shell nav (unit-tested); the home page body still rendered the full Work-areas launcher, so Simple felt like a no-op.
- Share cookie parsing via `resolveNavModeFromCookie` and pass `density=simple` on the platform workspace home so Simple hides secondary area launchers and names the mode.
- Rail exposes `data-nav-mode` for inspectability.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/navigation/nav-mode.test.ts lib/govern/permissions.test.ts components/workspace-home/PlatformWorkspaceHome.test.tsx components/shell/AppRail.test.tsx` — 43 passed (worktree)
- [ ] After merge: toggle Simple on `/workspace` and confirm Work areas section is gone; Full restores it; rail still hides platform/admin in Simple

## Trailers
UX-Fit-Decision: progressive-disclosure — Simple hides secondary area launcher; Full restores; no new form fields
Process-Spine-Decision: small bugfix with unit tests; no new substrate
Local-CI-Override: 43 unit tests green for nav-mode/permissions/PlatformWorkspaceHome/AppRail in worktree