### PR TITLE
fix(ops): Inngest config hardening — cron audit, TTL invariant, pin 1.36 (BI-915C40C6)

### DIFF
--- a/apps/web/lib/operate/inngest-retention/constants.test.ts
+++ b/apps/web/lib/operate/inngest-retention/constants.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  INNGEST_HISTORY_RETENTION_DAYS,
+  INNGEST_REDIS_RUN_STATE_TTL_HOURS_CEILING,
+  ORPHAN_REAP_AGE_HOURS,
+  nextInngestRetentionRunAt,
+} from "./constants";
+
+describe("Inngest retention TTL alignment (BI-915C40C6)", () => {
+  it("reaps orphans only after Redis run-state has certainly expired", () => {
+    // Generator bound: Postgres unfinished rows outliving Redis {estate} TTL
+    // are corpses. Reap age must sit strictly above the observed Redis ceiling
+    // so a live run is never deleted while state may still exist.
+    expect(ORPHAN_REAP_AGE_HOURS).toBeGreaterThan(INNGEST_REDIS_RUN_STATE_TTL_HOURS_CEILING);
+  });
+
+  it("keeps history retention longer than the orphan reap window", () => {
+    // Finished history is operational telemetry; keep more of it than the
+    // orphan window so a reaped corpse is still diagnosable in finished tables.
+    expect(INNGEST_HISTORY_RETENTION_DAYS * 24).toBeGreaterThan(ORPHAN_REAP_AGE_HOURS);
+  });
+
+  it("schedules the next 6h slot at :17 past the block", () => {
+    // 2026-07-11T12:00:00Z is exactly a block start → next slot is 12:17 same day.
+    const from = new Date("2026-07-11T12:00:00.000Z");
+    expect(nextInngestRetentionRunAt(from).toISOString()).toBe("2026-07-11T12:17:00.000Z");
+  });
+});

--- a/apps/web/lib/operate/inngest-retention/constants.ts
+++ b/apps/web/lib/operate/inngest-retention/constants.ts
@@ -41,12 +41,25 @@ const MS_PER_DAY = 86_400_000;
 const SIX_HOURS_MS = 6 * MS_PER_HOUR;
 
 /**
+ * Observed ceiling for self-hosted Inngest Redis {estate} run-state TTL
+ * (BI-915C40C6 / BI-0AB96FE7). Inngest owns this TTL internally — DPF cannot
+ * set it from portal env without forking the server image. The durable bound
+ * is therefore the orphan reap below: once Redis state is gone, Postgres rows
+ * that still claim the run are corpses and must be deleted so the executor
+ * stops retrying them.
+ */
+export const INNGEST_REDIS_RUN_STATE_TTL_HOURS_CEILING = 16;
+
+/**
  * Age past which an UNFINISHED function_runs row is a genuine orphan: its Redis
  * {estate} state has certainly TTL-expired (observed TTLs ~12–16h), so the run
  * can never complete and the executor is only retrying a corpse. 24h sits
  * comfortably above the TTL ceiling AND above any legitimate long-running
  * function (self-upgrade < 1h; quiescence waits are budget-bounded), so nothing
  * live is ever reaped.
+ *
+ * Invariant (enforced by constants.test): ORPHAN_REAP_AGE_HOURS >
+ * INNGEST_REDIS_RUN_STATE_TTL_HOURS_CEILING.
  */
 export const ORPHAN_REAP_AGE_HOURS = 24;
 

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -193,8 +193,11 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     name: "Alert delivery bridge",
     purpose:
       "Delivers firing Prometheus/Loki alerts into the quality-issue inbox (the platform runs no Alertmanager). If it stops, firing alerts evaluate but never reach an operator — silent blindness. Core-locked for that reason.",
-    cron: "*/1 * * * *",
-    cadence: "Every minute",
+    // BI-915C40C6: every-minute was an orphan-accumulation multiplier (1440/day).
+    // 5-minute poll keeps operator latency acceptable; taskrun-watchdog alone
+    // stays every-minute as the deliberate liveness guard.
+    cron: "*/5 * * * *",
+    cadence: "Every 5 minutes",
     category: "core",
     tracksRunData: false,
     runNowEvent: null,

--- a/apps/web/lib/queue/functions/alert-delivery-bridge.ts
+++ b/apps/web/lib/queue/functions/alert-delivery-bridge.ts
@@ -122,8 +122,12 @@ export async function runAlertDeliveryScan(): Promise<AlertDeliveryResult> {
   return { firing: firingAll.length, delivered, resolved, capped, sourcesReached: reached };
 }
 
+// BI-915C40C6: every-minute crons multiply orphan accumulation (1440 runs/day).
+// Alert delivery does not need 60s latency — Prometheus/Loki already debounce
+// with `for:` windows — so poll every 5 minutes. taskrun-watchdog remains the
+// sole deliberate every-minute liveness guard (see catalog allowlist test).
 export const alertDeliveryBridge = inngest.createFunction(
-  { id: "ops/alert-delivery-bridge", retries: 2, triggers: [cron("*/1 * * * *")] },
+  { id: "ops/alert-delivery-bridge", retries: 2, triggers: [cron("*/5 * * * *")] },
   async ({ step }) => {
     const gate = await gateAtEntry(step);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };

--- a/apps/web/lib/queue/functions/index.test.ts
+++ b/apps/web/lib/queue/functions/index.test.ts
@@ -47,3 +47,24 @@ describe("scheduled cron <-> catalog parity (drift guard)", () => {
     expect(orphaned).toEqual([]);
   });
 });
+
+describe("every-minute cron allowlist (BI-915C40C6)", () => {
+  // 1440 runs/day each is the orphan-accumulation multiplier. Only deliberate
+  // liveness guards may stay every-minute; everything else must be wider.
+  const EVERY_MINUTE = new Set(["* * * * *", "*/1 * * * *"]);
+  const ALLOWED_EVERY_MINUTE_INNGEST_IDS = new Set([
+    "ops/taskrun-watchdog", // deliberate stall/liveness guard — do not widen
+  ]);
+
+  it("catalog has no every-minute cron outside the deliberate allowlist", () => {
+    const offenders = SCHEDULED_JOB_CATALOG.filter(
+      (e) => EVERY_MINUTE.has(e.cron) && !ALLOWED_EVERY_MINUTE_INNGEST_IDS.has(e.inngestId),
+    ).map((e) => e.inngestId);
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps the taskrun-watchdog on the every-minute liveness cadence", () => {
+    const watchdog = SCHEDULED_JOB_CATALOG.find((e) => e.inngestId === "ops/taskrun-watchdog");
+    expect(watchdog?.cron).toBe("* * * * *");
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -804,19 +804,19 @@ services:
     # validated on a throwaway DB copy (v7→v10, clean). Pin to keep :latest
     # from silently regressing again. BI-C8164664.
     #
+    # BI-915C40C6 (2026-07-11): bump pin 1.30 → 1.36 for orphan-reconciliation
+    # / dup-span handling improvements in newer releases. Redis {estate} TTL is
+    # still server-internal (~12–16h observed); DPF bounds corpses via the
+    # retention/orphan janitor (ORPHAN_REAP_AGE_HOURS=24), not by setting Redis.
+    #
     # IMPORTANT (2026-06-18): the version bump only stops NEW poison items from
     # being enqueued (1.28+ sets envID). It does NOT drain items already enqueued
     # by the 1.26-era bug — those live in the Redis queue store (INNGEST_REDIS_URI
     # below), not Postgres, so the goose history migration never touched them.
-    # v1.30 still rejects them at the lease-constraint check (nil wsID/envID), and
-    # because the failure is PRE-attempt the items never increment `atts`, never
-    # exhaust maxAtts, and never dead-letter — the scanner re-reads them forever.
-    # A backlog of ~22k such items re-scanned at ~135 lines/sec grew the container
-    # log to 5.8 GB ("logs scrolling like crazy"). One-time remediation after this
-    # pin: drain the stuck `{queue}:queue:sorted:<fnID>` partitions from the
-    # Inngest-dedicated Redis (see scripts/drain-inngest-poison-queue.sh). The
-    # `<<: *default-logging` cap below bounds the blast radius if it ever recurs.
-    image: inngest/inngest:v1.30.0
+    # Pre-1.28 poison items still need a one-time drain of stuck
+    # `{queue}:queue:sorted:<fnID>` partitions (scripts/drain-inngest-poison-queue.sh).
+    # The `<<: *default-logging` cap below bounds the blast radius if it ever recurs.
+    image: inngest/inngest:v1.36.0
     restart: unless-stopped
     logging: *default-logging
     command: "inngest start"

--- a/scripts/check-compose-image-pins.sh
+++ b/scripts/check-compose-image-pins.sh
@@ -27,7 +27,7 @@ ALLOWLIST=(
   "grafana/alloy"                 # observability profile — not exercised in CI; pin when validated
   "gcr.io/cadvisor/cadvisor"      # observability profile — not exercised in CI; pin when validated
   "prom/node-exporter"            # observability profile — not exercised in CI; pin when validated
-  "inngest/inngest"               # pinned to v1.30.0 by PR #2048; remove this entry once merged
+  "inngest/inngest"               # pinned (v1.36.0 as of BI-915C40C6); never :latest (BI-C8164664)
 )
 
 is_allowlisted() {

--- a/scripts/drain-inngest-poison-queue.sh
+++ b/scripts/drain-inngest-poison-queue.sh
@@ -5,7 +5,7 @@
 # -------
 # inngest/inngest 1.26 (the version :latest drifted onto) enqueued queue items
 # with a nil environment/workspace id (wsID = 00000000-0000-0000-0000-000000000000).
-# Newer Inngest (1.28+, and the pinned v1.30.0) reject those items at the
+# Newer Inngest (1.28+, and the pinned v1.36.0) reject those items at the
 # capacity-lease CONSTRAINT check with `invalid request: ... missing envID`.
 # Because that rejection happens BEFORE the attempt counter increments, the items
 # never exhaust `maxAtts` and never dead-letter — the scheduler re-scans them


### PR DESCRIPTION
## Summary
Slice 3 of BI-0AB96FE7 (janitor #2708 already bounds the symptom):
- **TTL:** Document Redis `{estate}` run-state TTL ceiling (16h observed). Orphan reap (24h) is enforced strictly above it — DPF cannot set server-internal Redis TTL; the janitor remains the generator bound.
- **Cron audit:** Widen `alert-delivery-bridge` from every-minute → every 5 minutes. Keep `taskrun-watchdog` every-minute as the sole deliberate liveness guard. Catalog allowlist test prevents regression (1440 runs/day multiplier).
- **Version pin:** `inngest/inngest:v1.30.0` → `v1.36.0` for newer orphan/dup-span handling.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/operate/inngest-retention/constants.test.ts lib/operate/inngest-retention/execute.test.ts lib/queue/functions/index.test.ts` — 19 passed
- [x] `bash scripts/check-compose-image-pins.sh` — green
- [ ] After merge: self-upgrade / compose pin lands; confirm Inngest comes up on 1.36 and scheduled jobs catalog shows alert bridge at 5 min

## Trailers
Process-Spine-Decision: ops hardening with unit guards; no new substrate
UX-Fit-Decision: no-new-control — operator kill switch already exists for retention
Local-CI-Override: 19 unit tests green (retention constants, execute, cron allowlist); compose pin check green