### PR TITLE
fix(self-upgrade): bound the promoter with a timeout + orphan cleanup (SUR-756751D1 hang)

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -3,6 +3,7 @@
 
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { sweepOrphanedPromoterContainers } from "@/lib/self-upgrade/promoter-sweep";
 
 /**
  * Logs a deprecation notice when HIVE_CONTRIBUTION_TOKEN is set in the
@@ -897,6 +898,9 @@ export async function register() {
     setInterval(
       () => {
         void reconcileSelfUpgradeRunsOnBoot(console, { staleAfterMs: 30 * 60 * 1000 });
+        // Backstop: force-remove any promoter container orphaned by a portal
+        // restart that killed runPromoter's own timeout timer (BI-3EC7FDB0).
+        void sweepOrphanedPromoterContainers({ maxAgeMs: 30 * 60 * 1000 });
       },
       20 * 60 * 1000,
     );

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -594,6 +594,10 @@ export async function runSelfUpgrade(
       healthUrl: config.healthUrl ?? process.env.PROMOTE_HEALTH_URL ?? "",
       promoterImage: config.promoterImage,
       dryRun: params.dryRun,
+      // Deterministic name so a stalled build can be force-removed by name on
+      // timeout (runPromoter) or by the watchdog backstop. docker names allow
+      // [A-Za-z0-9_.-]; runId (e.g. SUR-756751D1) is already safe.
+      containerName: `dpf-promoter-${run.runId}`,
     });
   } catch (err) {
     // The promoter failed to even spawn (e.g. docker missing). Without this

--- a/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
@@ -158,6 +158,19 @@ describe("classifyBuildFailure", () => {
     expect(c.summary).toContain("lockfile");
   });
 
+  it("classifies a promoter timeout as retryable environment, superseding earlier build noise", () => {
+    // The kill happened because nothing completed, so a half-emitted NFT trace
+    // above the marker is noise — the timeout must win.
+    const log = `#30 [build 66/105] RUN apk add --no-cache docker-cli curl nmap
+#30 40.11 (12/27) Installing docker-cli (29.5.3-r0)
+[promoter-timeout] promoter did not finish within 25m — killed and container force-removed.`;
+    const c = classifyBuildFailure({ log });
+    expect(c.class).toBe("promoter-timeout");
+    expect(c.isMainDefectVsEnvironment).toBe("environment");
+    expect(c.summary).toContain("Retry the upgrade");
+    expect(c.failingTrace).toContain("[promoter-timeout]");
+  });
+
   it("keeps a non-pnpm ECONNREFUSED (e.g. prisma → postgres) unclassified", () => {
     const c = classifyBuildFailure({ log: UNKNOWN_LOG });
     expect(c.class).toBe("unknown");

--- a/apps/web/lib/self-upgrade/build-failure-classifier.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.ts
@@ -44,6 +44,12 @@ export type BuildFailureClass =
   // bundle-boundary lazy-import issue; fixed by adding the missing `COPY <dir>/`
   // (see PR #2786 + the dockerfile-build-context guard).
   | "docker-build-context-missing-path"
+  // The promoter subprocess blew its wall-clock budget and runPromoter killed it
+  // (`[promoter-timeout]`). Almost always a transient environment stall — a
+  // `docker build` step hanging on a degraded network fetch (SUR-756751D1: an
+  // `apk add` that crawled 52 min). Retry the upgrade; only dig deeper if it
+  // times out the same way twice. Environment, not a main defect.
+  | "promoter-timeout"
   | "unknown";
 
 export type BuildFailureClassification = {
@@ -99,6 +105,8 @@ const PNPM_OUTDATED_LOCKFILE = /ERR_PNPM_(OUTDATED_)?LOCKFILE|specifiers in the 
 // failures (e.g. prisma migrate unable to reach postgres) and must stay
 // unclassified rather than misdiagnosed as a dependency fetch.
 const PNPM_FETCH_ERROR = /ERR_PNPM_FETCH|ERR_PNPM_META_FETCH_FAIL|GET https:\/\/registry\.npmjs\.org\/[^\s]+: (?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENETUNREACH|socket hang up)/i;
+// runPromoter's marker when it kills a promoter that blew its wall-clock budget.
+const PROMOTER_TIMEOUT = /\[promoter-timeout\]/i;
 
 /** Up to ~6 lines around the first matching line, capped, for the agent. */
 function traceAround(log: string, re: RegExp): string {
@@ -113,6 +121,20 @@ export function classifyBuildFailure(
   input: BuildFailureInput,
 ): BuildFailureClassification {
   const log = input.log ?? "";
+
+  // A promoter timeout supersedes whatever build output preceded it: the kill
+  // happened because nothing ever completed, so any half-emitted trace above is
+  // noise, not the cause. Check it first.
+  if (PROMOTER_TIMEOUT.test(log)) {
+    return {
+      class: "promoter-timeout",
+      summary:
+        "The promoter exceeded its wall-clock budget and was killed (its container force-removed). Almost always a transient environment stall — a docker-build step hanging on a degraded network fetch (SUR-756751D1: an `apk add` that crawled 52 min). Retry the upgrade; only dig deeper if it times out the same way twice.",
+      playbookLink: SPEC,
+      failingTrace: traceAround(log, PROMOTER_TIMEOUT),
+      isMainDefectVsEnvironment: "environment",
+    };
+  }
 
   // Fatal-marker priority for the most specific case. A "Module not found" whose
   // missing spec is a RELATIVE path climbing out of the package

--- a/apps/web/lib/self-upgrade/promoter-sweep.test.ts
+++ b/apps/web/lib/self-upgrade/promoter-sweep.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { isPromoterContainerStale } from "./promoter-sweep";
+
+describe("isPromoterContainerStale (orphaned-promoter sweep gate)", () => {
+  const now = new Date("2026-07-11T12:20:00Z");
+  const maxAge = 30 * 60 * 1000;
+
+  it("treats a promoter older than maxAge as stale (docker CreatedAt format)", () => {
+    // Started 11:41:26 UTC, now 12:20 → ~39 min old > 30 min.
+    expect(isPromoterContainerStale("2026-07-11 11:41:26 +0000 UTC", now, maxAge)).toBe(true);
+  });
+
+  it("does NOT remove a promoter still within the budget (legit in-flight swap)", () => {
+    // Started 12:05 → 15 min old < 30 min: a live upgrade must be left alone.
+    expect(isPromoterContainerStale("2026-07-11 12:05:00 +0000 UTC", now, maxAge)).toBe(false);
+  });
+
+  it("refuses to declare an unparseable stamp stale (never kill what we can't age)", () => {
+    expect(isPromoterContainerStale("", now, maxAge)).toBe(false);
+    expect(isPromoterContainerStale("not-a-date", now, maxAge)).toBe(false);
+  });
+});

--- a/apps/web/lib/self-upgrade/promoter-sweep.ts
+++ b/apps/web/lib/self-upgrade/promoter-sweep.ts
@@ -1,0 +1,69 @@
+// Defense-in-depth cleanup for orphaned promoter containers (BI-3EC7FDB0).
+//
+// runPromoter (promoter.ts) kills + force-removes a promoter that blows its
+// ~25-min budget, but that timer lives in the ORCHESTRATOR process — if the
+// portal itself is killed/restarted mid-build (the exact thing a swap does),
+// the timer dies with it and the promoter `docker run` keeps building
+// unattended. `--rm` only fires on a clean exit, so a stalled build lingers
+// (SUR-756751D1: `Up 52m`) and, worse, could eventually finish and
+// `--force-recreate` an UNEXPECTED swap for a run already failed. This periodic
+// sweep (driven from instrumentation.ts) is the cron-independent backstop.
+
+/**
+ * Whether a `docker ps` CreatedAt stamp is older than maxAgeMs. Docker renders
+ * CreatedAt as e.g. "2026-07-11 11:41:26 +0000 UTC"; the trailing " UTC" is not
+ * ISO, so strip it before parsing. Returns FALSE on any unparseable input —
+ * never claim a container is stale (and removable) when we can't prove its age.
+ */
+export function isPromoterContainerStale(
+  createdAt: string,
+  now: Date,
+  maxAgeMs: number,
+): boolean {
+  const started = Date.parse((createdAt ?? "").replace(/ UTC$/, ""));
+  if (!Number.isFinite(started)) return false;
+  return now.getTime() - started >= maxAgeMs;
+}
+
+/**
+ * Force-remove any `dpf-promoter-*` container older than `maxAgeMs` — well past
+ * both runPromoter's self-timeout and a normal ~7-min swap, so a legitimately
+ * in-flight promoter is never touched. Non-fatal; never throws.
+ */
+export async function sweepOrphanedPromoterContainers(
+  opts: { maxAgeMs?: number; now?: () => Date } = {},
+  logger: Pick<Console, "log" | "error"> = console,
+): Promise<{ removed: number } | null> {
+  const maxAgeMs = opts.maxAgeMs ?? 30 * 60 * 1000;
+  const now = opts.now?.() ?? new Date();
+  try {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const run = promisify(execFile);
+    const { stdout } = await run(
+      "docker",
+      ["ps", "--filter", "name=dpf-promoter-", "--format", "{{.Names}}\t{{.CreatedAt}}"],
+      { timeout: 15_000 },
+    );
+    let removed = 0;
+    for (const line of stdout.split("\n").map((l) => l.trim()).filter(Boolean)) {
+      const [name, createdAt] = line.split("\t");
+      if (!name) continue;
+      if (!isPromoterContainerStale(createdAt ?? "", now, maxAgeMs)) continue;
+      try {
+        await run("docker", ["rm", "-f", name], { timeout: 15_000 });
+        removed++;
+        logger.log(
+          `[promoter-sweep] force-removed orphaned promoter ${name} (age > ${Math.round(maxAgeMs / 60000)}m)`,
+        );
+      } catch (rmErr) {
+        logger.error(`[promoter-sweep] failed to remove ${name} (non-fatal):`, rmErr);
+      }
+    }
+    return { removed };
+  } catch (err) {
+    // `docker ps` unreachable (no daemon in this env) — nothing to sweep.
+    logger.error("[promoter-sweep] failed (non-fatal):", err);
+    return null;
+  }
+}

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -3,6 +3,9 @@ import {
   buildPromoterCommand,
   isJitBuildablePromoterImage,
   PROMOTER_JIT_BUILD_SCRIPT,
+  PROMOTER_TIMEOUT_EXIT_CODE,
+  resolvePromoterTimeoutMs,
+  runProcessWithBudget,
 } from "./promoter";
 
 const BASE = {
@@ -52,6 +55,16 @@ describe("buildPromoterCommand", () => {
     const { args } = buildPromoterCommand({ ...BASE, promoterImage: "ghcr.io/x/dpf-promoter:v1" });
     expect(args).toContain("ghcr.io/x/dpf-promoter:v1");
     expect(args).not.toContain("dpf-promoter");
+  });
+
+  it("names the container deterministically only when a name is provided", () => {
+    // Without a name docker assigns a random one and a stalled build can't be
+    // force-removed by the timeout path / watchdog (SUR-756751D1).
+    expect(buildPromoterCommand(BASE).args).not.toContain("--name");
+    const named = buildPromoterCommand({ ...BASE, containerName: "dpf-promoter-SUR-1" });
+    const i = named.args.indexOf("--name");
+    expect(i).toBeGreaterThan(-1);
+    expect(named.args[i + 1]).toBe("dpf-promoter-SUR-1");
   });
 
   it("appends --dry-run only when requested", () => {
@@ -129,5 +142,55 @@ describe("PROMOTER_JIT_BUILD_SCRIPT", () => {
   it("is a fixed constant with no interpolation (safe under sh -c)", () => {
     expect(PROMOTER_JIT_BUILD_SCRIPT).not.toContain("${");
     expect(PROMOTER_JIT_BUILD_SCRIPT).not.toContain("`");
+  });
+});
+
+describe("resolvePromoterTimeoutMs", () => {
+  const CLEAN = { ...BASE };
+  it("prefers an explicit param, then env, then the 25-min default", () => {
+    expect(resolvePromoterTimeoutMs({ ...CLEAN, timeoutMs: 1234 })).toBe(1234);
+    const prev = process.env.DPF_PROMOTER_TIMEOUT_MS;
+    try {
+      process.env.DPF_PROMOTER_TIMEOUT_MS = "600000";
+      expect(resolvePromoterTimeoutMs(CLEAN)).toBe(600000);
+      delete process.env.DPF_PROMOTER_TIMEOUT_MS;
+      expect(resolvePromoterTimeoutMs(CLEAN)).toBe(25 * 60 * 1000);
+    } finally {
+      if (prev === undefined) delete process.env.DPF_PROMOTER_TIMEOUT_MS;
+      else process.env.DPF_PROMOTER_TIMEOUT_MS = prev;
+    }
+  });
+
+  it("ignores a non-positive or non-numeric budget and falls through", () => {
+    expect(resolvePromoterTimeoutMs({ ...CLEAN, timeoutMs: 0 })).toBe(25 * 60 * 1000);
+    expect(resolvePromoterTimeoutMs({ ...CLEAN, timeoutMs: -5 })).toBe(25 * 60 * 1000);
+  });
+});
+
+describe("runProcessWithBudget (the runPromoter timeout path)", () => {
+  it("kills a hung process at the budget and resolves with a promoter-timeout marker", async () => {
+    // Stand in for a stalled `docker build` that never closes.
+    const started = Date.now();
+    const result = await runProcessWithBudget("sh", ["-c", "sleep 30"], { timeoutMs: 150 });
+    expect(Date.now() - started).toBeLessThan(5000); // did NOT wait 30s
+    expect(result.exitCode).toBe(PROMOTER_TIMEOUT_EXIT_CODE);
+    expect(result.stderr).toContain("[promoter-timeout]");
+  });
+
+  it("returns the real exit code + output when the process finishes within budget", async () => {
+    const result = await runProcessWithBudget(
+      "sh",
+      ["-c", "echo built; exit 0"],
+      { timeoutMs: 10_000 },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("built");
+    expect(result.stderr).not.toContain("[promoter-timeout]");
+  });
+
+  it("propagates a nonzero exit unchanged (real build failure, not a timeout)", async () => {
+    const result = await runProcessWithBudget("sh", ["-c", "exit 3"], { timeoutMs: 10_000 });
+    expect(result.exitCode).toBe(3);
+    expect(result.stderr).not.toContain("[promoter-timeout]");
   });
 });

--- a/apps/web/lib/self-upgrade/promoter.ts
+++ b/apps/web/lib/self-upgrade/promoter.ts
@@ -59,6 +59,21 @@ export type PromoterParams = {
   /** Compose project name (COMPOSE_PROJECT_NAME). Defaults to "dpf" in promote.sh. */
   composeProject?: string;
   dryRun?: boolean;
+  /**
+   * Deterministic `docker run --name` for the promoter container. Lets the
+   * timeout path (and the watchdog backstop) `docker rm -f` a hung promoter by
+   * name — without it, docker assigns a random name and a stalled build can't be
+   * targeted for cleanup (SUR-756751D1). Convention: `dpf-promoter-<runId>`.
+   */
+  containerName?: string;
+  /**
+   * Hard wall-clock budget for the promoter subprocess, ms. On expiry runPromoter
+   * kills the child, force-removes the container, and resolves nonzero with a
+   * `[promoter-timeout]` excerpt instead of awaiting forever. Defaults to
+   * DPF_PROMOTER_TIMEOUT_MS or 25 min — generous vs a normal ~7-min swap, and
+   * under the 30-min DB watchdog so the orchestrator fails cleanly first.
+   */
+  timeoutMs?: number;
 };
 
 export type PromoterResult = {
@@ -95,6 +110,16 @@ export function buildPromoterCommand(
     // Reach the recreated portal's published host port for health/sha verify.
     "--add-host",
     "host.docker.internal:host-gateway",
+  ];
+
+  // Deterministic name so a hung promoter can be force-removed by the timeout
+  // path / watchdog. `--rm` still auto-cleans a clean exit; the name only
+  // matters when the build stalls and never closes.
+  if (params.containerName && params.containerName.length > 0) {
+    args.push("--name", params.containerName);
+  }
+
+  args.push(
     // Sibling-container control: the promoter drives the daemon to rebuild
     // and recreate the portal.
     "-v",
@@ -102,7 +127,7 @@ export function buildPromoterCommand(
     // Host source tree (read-only): build context + backup source.
     "-v",
     `${params.hostInstallPath}:${PROMOTER_CONTAINER_SOURCE}:ro`,
-  ];
+  );
 
   if (params.backupHostPath && params.backupHostPath.length > 0) {
     args.push("-v", `${params.backupHostPath}:/backups`);
@@ -305,14 +330,70 @@ export async function ensurePromoterImage(
   });
 }
 
-export async function runPromoter(params: PromoterParams): Promise<PromoterResult> {
-  const { command, args } = buildPromoterCommand(params);
+/** Exit code runPromoter reports when it kills a promoter that blew its budget. */
+export const PROMOTER_TIMEOUT_EXIT_CODE = 124; // GNU `timeout` convention.
 
+/** Default hard budget for the promoter subprocess: 25 min (env-overridable). */
+export function resolvePromoterTimeoutMs(params: PromoterParams): number {
+  if (typeof params.timeoutMs === "number" && params.timeoutMs > 0) return params.timeoutMs;
+  const env = Number(process.env.DPF_PROMOTER_TIMEOUT_MS);
+  if (Number.isFinite(env) && env > 0) return env;
+  return 25 * 60 * 1000;
+}
+
+/**
+ * Force-remove a promoter container by name. Best-effort: the timeout path uses
+ * it to stop a build that stalled and never closed (killing the local `docker
+ * run` client does NOT stop the daemon-side build/container). Never throws.
+ */
+export async function forceRemovePromoterContainer(name: string): Promise<void> {
+  if (!name) return;
+  await new Promise<void>((resolve) => {
+    try {
+      const child = spawn("docker", ["rm", "-f", name], { env: { ...process.env } });
+      child.stdout?.on("data", () => {});
+      child.stderr?.on("data", () => {});
+      child.on("close", () => resolve());
+      child.on("error", () => resolve());
+    } catch {
+      resolve();
+    }
+  });
+}
+
+/**
+ * Spawn a process under a hard wall-clock budget. On expiry: kill the child,
+ * force-remove `containerName` (so a daemon-side build actually stops — killing
+ * the local client does not), and resolve nonzero with a `[promoter-timeout]`
+ * marker. Separated from runPromoter so the timeout path is unit-testable with a
+ * cheap hanging command instead of a real `docker run`.
+ */
+export async function runProcessWithBudget(
+  command: string,
+  args: string[],
+  opts: { timeoutMs: number; containerName?: string },
+): Promise<PromoterResult> {
   return new Promise((done, reject) => {
     const child = spawn(command, args, { env: { ...process.env } });
 
     let stdout = "";
     let stderr = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      const mins = Math.round(opts.timeoutMs / 60000);
+      stderr += `\n[promoter-timeout] promoter did not finish within ${mins}m — killed and container force-removed.`;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+      void forceRemovePromoterContainer(opts.containerName ?? "").finally(() => {
+        done({ exitCode: PROMOTER_TIMEOUT_EXIT_CODE, stdout, stderr });
+      });
+    }, opts.timeoutMs);
 
     child.stdout.on("data", (chunk: Buffer) => {
       stdout += chunk;
@@ -322,9 +403,29 @@ export async function runPromoter(params: PromoterParams): Promise<PromoterResul
     });
 
     child.on("close", (code: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
       done({ exitCode: code ?? 1, stdout, stderr });
     });
 
-    child.on("error", reject);
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+export async function runPromoter(params: PromoterParams): Promise<PromoterResult> {
+  const { command, args } = buildPromoterCommand(params);
+  // Hard wall-clock bound. Without it a stalled `docker build` (SUR-756751D1: an
+  // `apk add` fetch that crawled for 52 min) never closes, so `await runPromoter`
+  // blocks the orchestrator until the 30-min DB watchdog — and the orphaned
+  // container keeps building, risking a late unexpected swap.
+  return runProcessWithBudget(command, args, {
+    timeoutMs: resolvePromoterTimeoutMs(params),
+    containerName: params.containerName,
   });
 }

--- a/docs/user-guide/operations/index.md
+++ b/docs/user-guide/operations/index.md
@@ -40,3 +40,7 @@ The Promotions tab in Operations shows all features that have been through the B
 - **Rolled Back** — Deployment failed and was automatically reversed. Check the deployment log for details.
 
 When you click "Deploy Now", the platform starts the promoter service for the governed deployment workflow. The page updates automatically while deployment is in progress.
+
+### Promoter timeout
+
+The promoter builds a fresh application image and swaps the running container. That build is bounded by a hard wall-clock budget (default **25 minutes**): if a build step stalls — for example on a slow or degraded network fetch — the promoter is killed, its container is force-removed, and the deployment is marked failed with a retryable `promoter-timeout` diagnosis instead of hanging. A normal deployment completes in a few minutes; the timeout only trips on a genuine stall. Operators on unusually slow hosts can raise it by setting `DPF_PROMOTER_TIMEOUT_MS` (milliseconds) in the environment. A periodic watchdog additionally force-removes any promoter container orphaned by a mid-deployment restart, so a stalled build can never linger and cause an unexpected later swap.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -14,7 +14,7 @@ apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
 apps/web/components/storefront/SlotBookingFlow.tsx	919
 apps/web/components/workbooks/Grid.tsx	924
 apps/web/instrumentation.test.ts	826
-apps/web/instrumentation.ts	1338
+apps/web/instrumentation.ts	1342
 apps/web/lib/actions/agent-coworker-external.test.ts	866
 apps/web/lib/actions/agent-coworker.ts	2731
 apps/web/lib/actions/agent-task-scheduler.test.ts	1083


### PR DESCRIPTION
## Problem

Self-upgrade run **SUR-756751D1** "timed out" — it sat `running` for 30+ min until the DB watchdog force-failed it (`orchestrator did not complete the swap`).

**Root cause:** `runPromoter` (apps/web/lib/self-upgrade/promoter.ts) spawned the promoter `docker run` and resolved **only on child `close`** — no timeout. The promoter's image build stalled at `RUN apk add` (an Alpine package fetch that crawled for **52 minutes** on a degraded network), so `await runPromoter` never returned and the orchestrator blocked.

Two compounding gaps:
1. **No bounded timeout** → a hung build is a 30-min silent blackout before the watchdog notices, instead of a fast classified failure.
2. **No orphan cleanup** → `--rm` only fires on a *clean* exit, so the hung promoter container kept building **after** the run was `failed` (observed `Up 52m`). If it ever completed, `promote.sh` would `docker compose up -d --force-recreate` → an **unexpected swap for a failed run**. The container also had no `--name`, so nothing could target it for removal.

(Diagnosed live: the orphaned promoter `happy_williamson` was still building at step 66/105 — `apk add` — 52 min in. Cleaned up out of band.)

## Fix — kernel-chosen *both-defense-in-depth* (`principle_decide` composite 9.70, high confidence)

- **Bounded budget:** `runPromoter` now runs under a hard wall-clock timeout (default **25 min**, under the 30-min watchdog; env `DPF_PROMOTER_TIMEOUT_MS`). On expiry it kills the child, `docker rm -f`s the container (killing the local `docker run` client alone does **not** stop the daemon-side build), and resolves nonzero with a `[promoter-timeout]` marker — flowing through the existing classify + `failRun` path.
- **Named container:** `dpf-promoter-<runId>` so cleanup can target it by name.
- **New `promoter-timeout` class** (environment / retryable) that supersedes any half-emitted build noise above the marker.
- **Defense-in-depth sweep:** the periodic watchdog force-removes orphaned `dpf-promoter-*` containers older than 30 min — for the case where a portal restart kills `runPromoter`'s own timer mid-build. The age gate **refuses to remove anything it can't prove is stale**, so a live in-flight swap is never touched.

## Tests (76/76 green, `tsc` clean at 8 GB)

- `runProcessWithBudget` kills a hung `sleep` at the budget → `[promoter-timeout]`; passes real exit codes through unchanged when the process finishes.
- `buildPromoterCommand` emits `--name` only when a name is provided.
- `resolvePromoterTimeoutMs` precedence (param → env → 25-min default).
- Classifier `promoter-timeout` detection (environment, retryable).
- `isPromoterContainerStale` age gate incl. unparseable-stamp safety.

Filed as **BI-3EC7FDB0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)