### PR TITLE
feat(demand-mgmt): investment buckets + portfolio balance (EP-DEMAND-MGMT Phase 3)

### DIFF
--- a/apps/web/components/ops/DemandBoard.tsx
+++ b/apps/web/components/ops/DemandBoard.tsx
@@ -12,6 +12,7 @@ import {
   type DemandItemView,
 } from "@/lib/demand/board";
 import type { ValueEffortQuadrant } from "@/lib/demand/scoring";
+import { bucketBalance, BUCKET_LABELS, computeBucketMix } from "@/lib/demand/buckets";
 
 const VALUE_BAND_LABEL: Record<ReturnType<typeof valueBand>, string> = {
   high: "High value",
@@ -148,7 +149,69 @@ function MatrixView({ items }: { items: DemandItemView[] }) {
   );
 }
 
-type Tab = "funnel" | "matrix";
+function BalanceView({ items }: { items: DemandItemView[] }) {
+  const rows = useMemo(() => {
+    const mix = computeBucketMix(
+      items.map((i) => ({
+        investmentBucket: i.investmentBucket,
+        workType: i.workType,
+        weight: itemEffort(i),
+      })),
+    );
+    return { mix, balance: bucketBalance(mix, null) };
+  }, [items]);
+
+  if (rows.mix.total === 0) {
+    return (
+      <p className="text-sm text-[var(--dpf-muted)]">
+        No classified demand yet. Score items (bucket auto-derives from work-type) to see the balance.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        {rows.balance.map((r) => (
+          <div key={r.bucket} className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2">
+            <div className="mb-1 flex items-center gap-2 text-sm">
+              <span className="font-medium text-[var(--dpf-text)]">{BUCKET_LABELS[r.bucket]}</span>
+              {r.starved && (
+                <span className="rounded px-1.5 py-0.5 text-[10px] font-medium text-[var(--dpf-warning)]">
+                  Starved
+                </span>
+              )}
+              <span className="ml-auto text-xs text-[var(--dpf-muted)]">
+                {r.actualPct}% actual · {r.targetPct}% target
+              </span>
+            </div>
+            <div className="relative h-2 w-full overflow-hidden rounded bg-[var(--dpf-surface-2)]">
+              <div
+                className="absolute left-0 top-0 h-full rounded"
+                style={{
+                  width: `${Math.min(100, r.actualPct)}%`,
+                  backgroundColor: r.starved ? "var(--dpf-warning)" : "var(--dpf-accent)",
+                }}
+              />
+              <div
+                className="absolute top-0 h-full w-px bg-[var(--dpf-text)]"
+                style={{ left: `${Math.min(100, r.targetPct)}%` }}
+                title={`Target ${r.targetPct}%`}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs text-[var(--dpf-muted)]">
+        Effort-weighted mix across {rows.mix.total} point(s) of demand vs the default 70/20/10 target (the black
+        tick). A bucket &gt;5% below target is flagged Starved.
+        {rows.mix.unclassified > 0 && ` ${rows.mix.unclassified} point(s) unclassified.`}
+      </p>
+    </div>
+  );
+}
+
+type Tab = "funnel" | "matrix" | "balance";
 
 export function DemandBoard({ items }: { items: DemandItemView[] }) {
   const [tab, setTab] = useState<Tab>("funnel");
@@ -169,7 +232,7 @@ export function DemandBoard({ items }: { items: DemandItemView[] }) {
     <div className="space-y-3">
       <div className="flex items-center gap-2">
         <div className="inline-flex rounded-md border border-[var(--dpf-border)] p-0.5">
-          {(["funnel", "matrix"] as const).map((t) => (
+          {(["funnel", "matrix", "balance"] as const).map((t) => (
             <button
               key={t}
               type="button"
@@ -180,7 +243,7 @@ export function DemandBoard({ items }: { items: DemandItemView[] }) {
                   : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
               }`}
             >
-              {t === "funnel" ? "Funnel" : "Value × effort"}
+              {t === "funnel" ? "Funnel" : t === "matrix" ? "Value × effort" : "Balance"}
             </button>
           ))}
         </div>
@@ -188,7 +251,13 @@ export function DemandBoard({ items }: { items: DemandItemView[] }) {
           {scored} of {items.length} scored
         </span>
       </div>
-      {tab === "funnel" ? <FunnelView items={items} /> : <MatrixView items={items} />}
+      {tab === "funnel" ? (
+        <FunnelView items={items} />
+      ) : tab === "matrix" ? (
+        <MatrixView items={items} />
+      ) : (
+        <BalanceView items={items} />
+      )}
     </div>
   );
 }

--- a/apps/web/lib/demand/board.test.ts
+++ b/apps/web/lib/demand/board.test.ts
@@ -20,6 +20,7 @@ function item(partial: Partial<DemandItemView> & { itemId: string }): DemandItem
     effortSize: null,
     jobSize: null,
     impact: null,
+    investmentBucket: null,
     ...partial,
   };
 }

--- a/apps/web/lib/demand/board.ts
+++ b/apps/web/lib/demand/board.ts
@@ -20,6 +20,7 @@ export type DemandItemView = {
   effortSize: string | null;
   jobSize: number | null;
   impact: number | null;
+  investmentBucket: string | null;
 };
 
 export type FunnelColumn = {

--- a/apps/web/lib/demand/buckets.test.ts
+++ b/apps/web/lib/demand/buckets.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  bucketBalance,
+  computeBucketMix,
+  DEFAULT_BUCKET_TARGETS,
+  deriveBucket,
+  type BucketWeightedItem,
+} from "./buckets";
+
+describe("deriveBucket", () => {
+  it("maps work-type to a default bucket", () => {
+    expect(deriveBucket("bug")).toBe("run");
+    expect(deriveBucket("chore")).toBe("run");
+    expect(deriveBucket("refactor")).toBe("run");
+    expect(deriveBucket("feature")).toBe("grow");
+    expect(deriveBucket("doc")).toBeNull();
+    expect(deriveBucket(null)).toBeNull();
+  });
+});
+
+describe("computeBucketMix", () => {
+  it("effort-weights the mix and computes shares", () => {
+    const items: BucketWeightedItem[] = [
+      { investmentBucket: "run", workType: null, weight: 70 },
+      { investmentBucket: "grow", workType: null, weight: 20 },
+      { investmentBucket: "transform", workType: null, weight: 10 },
+    ];
+    const mix = computeBucketMix(items);
+    expect(mix.total).toBe(100);
+    expect(mix.sharePct).toEqual({ run: 70, grow: 20, transform: 10 });
+  });
+
+  it("falls back to derived bucket and weight 1", () => {
+    const mix = computeBucketMix([
+      { investmentBucket: null, workType: "bug" }, // -> run, weight 1
+      { investmentBucket: null, workType: "feature" }, // -> grow, weight 1
+      { investmentBucket: null, workType: "doc" }, // unclassified
+    ]);
+    expect(mix.byBucket.run).toBe(1);
+    expect(mix.byBucket.grow).toBe(1);
+    expect(mix.unclassified).toBe(1);
+    expect(mix.total).toBe(2);
+    expect(mix.sharePct.run).toBe(50);
+  });
+
+  it("explicit bucket overrides the work-type derivation", () => {
+    const mix = computeBucketMix([{ investmentBucket: "transform", workType: "bug", weight: 5 }]);
+    expect(mix.byBucket.transform).toBe(5);
+    expect(mix.byBucket.run).toBe(0);
+  });
+});
+
+describe("bucketBalance", () => {
+  it("flags a starved bucket against the default target", () => {
+    // All effort in Run — Transform is 0% vs a 10% target => starved.
+    const mix = computeBucketMix([{ investmentBucket: "run", workType: null, weight: 100 }]);
+    const rows = bucketBalance(mix, null);
+    const transform = rows.find((r) => r.bucket === "transform")!;
+    expect(transform.targetPct).toBe(DEFAULT_BUCKET_TARGETS.transform);
+    expect(transform.actualPct).toBe(0);
+    expect(transform.deltaPct).toBe(-10);
+    expect(transform.starved).toBe(true);
+    const run = rows.find((r) => r.bucket === "run")!;
+    expect(run.starved).toBe(false); // over-invested, not starved
+  });
+
+  it("honors an operator-set target and is not starved when balanced", () => {
+    const mix = computeBucketMix([
+      { investmentBucket: "run", workType: null, weight: 50 },
+      { investmentBucket: "transform", workType: null, weight: 50 },
+    ]);
+    const rows = bucketBalance(mix, { run: 50, grow: 0, transform: 50 });
+    expect(rows.every((r) => !r.starved)).toBe(true);
+  });
+
+  it("reports no starvation on an empty set", () => {
+    const rows = bucketBalance(computeBucketMix([]), null);
+    expect(rows.every((r) => !r.starved)).toBe(true);
+  });
+});

--- a/apps/web/lib/demand/buckets.ts
+++ b/apps/web/lib/demand/buckets.ts
@@ -1,0 +1,120 @@
+// Pure investment-bucket helpers — no server imports. Safe in tests and client
+// components. EP-DEMAND-MGMT Phase 3.
+//
+// Run / Grow / Transform is the strategic-balance axis: demand is prioritized
+// against a target allocation so near-term work can't silently consume the whole
+// budget. Spec: docs/superpowers/specs/2026-07-10-demand-management-design.md §8.
+
+import { INVESTMENT_BUCKET_VALUES, type InvestmentBucket } from "../explore/backlog";
+
+/** Default allocation when a portfolio hasn't set its own (the 70/20/10 split). */
+export const DEFAULT_BUCKET_TARGETS: Record<InvestmentBucket, number> = {
+  run: 70,
+  grow: 20,
+  transform: 10,
+};
+
+export const BUCKET_LABELS: Record<InvestmentBucket, string> = {
+  run: "Run",
+  grow: "Grow",
+  transform: "Transform",
+};
+
+/**
+ * Default bucket for an item from its work-type: keep-the-lights-on work (bug /
+ * chore / refactor) is Run; new capability (feature) is Grow; everything else is
+ * left unclassified for an operator to place.
+ */
+export function deriveBucket(workType: string | null | undefined): InvestmentBucket | null {
+  switch (workType) {
+    case "bug":
+    case "chore":
+    case "refactor":
+      return "run";
+    case "feature":
+      return "grow";
+    default:
+      return null;
+  }
+}
+
+export type BucketWeightedItem = {
+  investmentBucket: string | null;
+  workType: string | null;
+  /** Effort weight (points). Falls back to 1 so unsized items still count once. */
+  weight?: number | null;
+};
+
+export type BucketMix = {
+  /** Effort-weighted total per bucket. */
+  byBucket: Record<InvestmentBucket, number>;
+  total: number;
+  /** Actual share (percent, 0..100) per bucket. */
+  sharePct: Record<InvestmentBucket, number>;
+  /** Items with no derivable bucket. */
+  unclassified: number;
+};
+
+function normalizeBucket(item: BucketWeightedItem): InvestmentBucket | null {
+  const explicit = (INVESTMENT_BUCKET_VALUES as readonly string[]).includes(item.investmentBucket ?? "")
+    ? (item.investmentBucket as InvestmentBucket)
+    : null;
+  return explicit ?? deriveBucket(item.workType);
+}
+
+/** Effort-weighted actual mix across a set of items. */
+export function computeBucketMix(items: BucketWeightedItem[]): BucketMix {
+  const byBucket: Record<InvestmentBucket, number> = { run: 0, grow: 0, transform: 0 };
+  let unclassified = 0;
+  for (const item of items) {
+    const bucket = normalizeBucket(item);
+    const weight = typeof item.weight === "number" && item.weight > 0 ? item.weight : 1;
+    if (bucket === null) {
+      unclassified += weight;
+      continue;
+    }
+    byBucket[bucket] += weight;
+  }
+  const total = byBucket.run + byBucket.grow + byBucket.transform;
+  const sharePct: Record<InvestmentBucket, number> = { run: 0, grow: 0, transform: 0 };
+  if (total > 0) {
+    for (const b of INVESTMENT_BUCKET_VALUES) {
+      sharePct[b] = Math.round((byBucket[b] / total) * 1000) / 10;
+    }
+  }
+  return { byBucket, total, sharePct, unclassified };
+}
+
+export type BucketBalanceRow = {
+  bucket: InvestmentBucket;
+  actualPct: number;
+  targetPct: number;
+  /** actual - target (negative = under-invested vs target). */
+  deltaPct: number;
+  starved: boolean;
+};
+
+/**
+ * Compare the actual mix against targets. A bucket is "starved" when it is more
+ * than `tolerancePct` below its target — the signal that near-term work is
+ * crowding out (typically) Transform.
+ */
+export function bucketBalance(
+  mix: BucketMix,
+  targets: Partial<Record<InvestmentBucket, number>> | null | undefined,
+  tolerancePct = 5,
+): BucketBalanceRow[] {
+  const resolvedTargets = { ...DEFAULT_BUCKET_TARGETS, ...(targets ?? {}) };
+  return INVESTMENT_BUCKET_VALUES.map((bucket) => {
+    const actualPct = mix.sharePct[bucket];
+    const targetPct = resolvedTargets[bucket];
+    const deltaPct = Math.round((actualPct - targetPct) * 10) / 10;
+    return {
+      bucket,
+      actualPct,
+      targetPct,
+      deltaPct,
+      starved: mix.total > 0 && deltaPct < -tolerancePct,
+    };
+  });
+}

--- a/apps/web/lib/demand/demand-data.ts
+++ b/apps/web/lib/demand/demand-data.ts
@@ -21,6 +21,7 @@ export const getDemandItems = cache(async (): Promise<DemandItemView[]> => {
       effortSize: true,
       jobSize: true,
       impact: true,
+      investmentBucket: true,
       epic: { select: { epicId: true } },
     },
   });
@@ -36,5 +37,6 @@ export const getDemandItems = cache(async (): Promise<DemandItemView[]> => {
     effortSize: r.effortSize,
     jobSize: r.jobSize,
     impact: r.impact,
+    investmentBucket: r.investmentBucket,
   }));
 });

--- a/apps/web/lib/explore/backlog.ts
+++ b/apps/web/lib/explore/backlog.ts
@@ -175,6 +175,13 @@ export type DemandStage = (typeof DEMAND_STAGE_VALUES)[number];
 export const DEMAND_SCORE_FRAMEWORKS = ["rice", "wsjf", "value_effort", "weighted"] as const;
 export type DemandScoreFramework = (typeof DEMAND_SCORE_FRAMEWORKS)[number];
 
+// Investment buckets (EP-DEMAND-MGMT Phase 3): the strategic-balance axis so
+// demand is prioritized against a target allocation (Run/Grow/Transform, aka
+// McKinsey 3 Horizons). WWMD-confirmed label set (ledger DI-8E489A791375).
+// Adding a value requires updating this enum AND the mirror in mcp-tools.ts.
+export const INVESTMENT_BUCKET_VALUES = ["run", "grow", "transform"] as const;
+export type InvestmentBucket = (typeof INVESTMENT_BUCKET_VALUES)[number];
+
 /** Returns null if valid, or an error message if invalid. */
 export function validateEpicInput(input: EpicInput): string | null {
   if (!input.title.trim()) return "Title is required";

--- a/apps/web/lib/mcp/packs/demand-scoring-pack.ts
+++ b/apps/web/lib/mcp/packs/demand-scoring-pack.ts
@@ -8,7 +8,7 @@
 // source); tool-registry.test asserts no drift.
 
 import { prisma } from "@dpf/db";
-import { DEMAND_SCORE_FRAMEWORKS, DEMAND_STAGE_VALUES } from "@/lib/explore/backlog";
+import { DEMAND_SCORE_FRAMEWORKS, DEMAND_STAGE_VALUES, INVESTMENT_BUCKET_VALUES } from "@/lib/explore/backlog";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack } from "../tool-pack";
 
@@ -30,6 +30,7 @@ const definitions: ToolDefinition[] = [
         riskOpportunity: { type: "integer", description: "WSJF Cost-of-Delay term — relative risk reduction / opportunity enablement." },
         jobSize: { type: "number", description: "Effort denominator (relative points). Falls back to the effortSize t-shirt map (small=1,medium=3,large=8,xlarge=20)." },
         demandStage: { type: "string", enum: [...DEMAND_STAGE_VALUES], description: "Optional explicit funnel stage override (raw|screened|shaped|ready). Normally derived." },
+        investmentBucket: { type: "string", enum: [...INVESTMENT_BUCKET_VALUES], description: "Optional investment bucket (run|grow|transform). Auto-derived from workType when omitted (bug/chore/refactor=run, feature=grow)." },
       },
       required: ["itemId"],
     },
@@ -74,6 +75,13 @@ async function scoreDemandItemHandler(params: Record<string, unknown>): Promise<
   const currentIdx = item.demandStage ? stageOrder.indexOf(item.demandStage) : -1;
   const derivedIdx = stageOrder.indexOf(derivedStage);
   const nextStage = explicitStage ?? (derivedIdx > currentIdx ? derivedStage : item.demandStage ?? derivedStage);
+  // Investment bucket: explicit override, else keep what's set, else derive from
+  // work-type (bug/chore/refactor=run, feature=grow, else unclassified).
+  const { deriveBucket } = await import("@/lib/demand/buckets");
+  const explicitBucket = (INVESTMENT_BUCKET_VALUES as readonly string[]).includes(String(params["investmentBucket"]))
+    ? (params["investmentBucket"] as (typeof INVESTMENT_BUCKET_VALUES)[number])
+    : null;
+  const nextBucket = explicitBucket ?? item.investmentBucket ?? deriveBucket(item.workType);
   await prisma.backlogItem.update({
     where: { itemId },
     data: {
@@ -88,6 +96,7 @@ async function scoreDemandItemHandler(params: Record<string, unknown>): Promise<
       demandScoreFramework: framework,
       demandScoreComputedAt: new Date(),
       demandStage: nextStage,
+      investmentBucket: nextBucket,
     },
   });
   return {

--- a/docs/superpowers/plans/2026-07-10-demand-management.md
+++ b/docs/superpowers/plans/2026-07-10-demand-management.md
@@ -47,9 +47,9 @@ The keystone. Everything downstream depends on a computed, explainable score exi
 
 **Acceptance:** a non-technical operator sees what's asked, how valuable, how big, and what to fund next in one surface, with no raw framework token on the front.
 
-### Phase 3 — Investment buckets & portfolio balance (BI-E5526151)
+### Phase 3 — Investment buckets & portfolio balance (BI-E5526151) — ✅ LANDED
 
-`investmentBucket String?` (`run|grow|transform`, default derived from `workType`: bug/chore/refactor→run, feature→grow) on `BacklogItem`/`Epic`; `Portfolio.bucketTargets Json?` (allocation %). Portfolio-balance tab: actual-vs-target bucket mix, flag when near-term work starves Transform; coarse `jobSize`-summed-vs-`budgetKUsd` capacity read. Lightweight themes via org-overlay WWWD `stance` `WikiPage` (`themePageId`), rolled up per portfolio. Depends on Phase 1.
+**Landed:** `investmentBucket String?` (`run|grow|transform`) on `BacklogItem`/`Epic` + `Portfolio.bucketTargets Json?` (migration `20260711120000`, additive-nullable → fleet-safe); `INVESTMENT_BUCKET_VALUES` enum + pure `lib/demand/buckets.ts` (`deriveBucket` from workType, effort-weighted `computeBucketMix`, `bucketBalance` with Transform-starvation flag against a default 70/20/10 target) unit-tested (7); `score_demand_item` auto-classifies the bucket (explicit override supported); a **Balance** tab on the Demand board (effort-weighted actual-vs-target bars with a target tick + Starved flag). Deferred to follow-ups: per-portfolio target editing UI + `jobSize`-vs-`budgetKUsd` capacity read + WWWD `themePageId` linkage (the balance view is currently platform-wide against the default split).
 
 **Acceptance:** portfolio views show actual-vs-target investment balance; demand rolls up by theme.
 

--- a/packages/db/prisma/migrations/20260711120000_add_investment_buckets/migration.sql
+++ b/packages/db/prisma/migrations/20260711120000_add_investment_buckets/migration.sql
@@ -1,0 +1,7 @@
+-- EP-DEMAND-MGMT Phase 3: investment-bucket (run|grow|transform) strategic-balance
+-- axis on BacklogItem + Epic, and a per-portfolio target allocation.
+-- @migration-safety: data-safe: all columns are nullable additions; no existing
+-- row can violate any constraint.
+ALTER TABLE "BacklogItem" ADD COLUMN "investmentBucket" TEXT;
+ALTER TABLE "Epic" ADD COLUMN "investmentBucket" TEXT;
+ALTER TABLE "Portfolio" ADD COLUMN "bucketTargets" JSONB;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -659,6 +659,9 @@ model Portfolio {
   createdAt                     DateTime                       @default(now())
   updatedAt                     DateTime                       @updatedAt
   budgetKUsd                    Int?
+  // Target investment-bucket allocation (EP-DEMAND-MGMT Phase 3), e.g.
+  // { "run": 70, "grow": 20, "transform": 10 }. null = use the default split.
+  bucketTargets                 Json?
   agents                        Agent[]
   products                      DigitalProduct[]
   coworkerServices              CoworkerService[]              @relation("CoworkerServicePortfolio")
@@ -1331,6 +1334,10 @@ model BacklogItem {
   demandScore             Float?
   demandScoreFramework    String?
   demandScoreComputedAt   DateTime?
+  // Investment bucket (EP-DEMAND-MGMT Phase 3): run | grow | transform. The
+  // strategic-balance dimension so demand is prioritized against a target
+  // allocation, not a flat list. Default derived from workType. §8.
+  investmentBucket        String?
   activeBuildId           String?                       @unique
   activeEpicId            String?                       @unique
   duplicateOfId           String?
@@ -1548,6 +1555,8 @@ model Epic {
   description              String?
   status                   String                   @default("open")
   priority                 Int?
+  // Investment bucket (EP-DEMAND-MGMT Phase 3): run | grow | transform.
+  investmentBucket         String?
   createdAt                DateTime                 @default(now())
   updatedAt                DateTime                 @updatedAt
   submittedById            String?


### PR DESCRIPTION
## What

Phase 3 of **EP-DEMAND-MGMT** — the strategic-balance axis on top of Phases 1–2 (#2762, #2791). Demand is now prioritized against a **target allocation** (Run / Grow / Transform, aka McKinsey 3 Horizons), not just a flat value rank, so near-term work can't silently crowd out Transform.

## Changes

- **Schema** — additive nullable `investmentBucket` on `BacklogItem` + `Epic`, and `Portfolio.bucketTargets Json?` (migration `20260711120000` — all-nullable additive, fleet-safe).
- **`INVESTMENT_BUCKET_VALUES`** enum (`run|grow|transform`, mirrored in the demand pack).
- **`lib/demand/buckets.ts`** (pure, tested) — `deriveBucket(workType)` (bug/chore/refactor→run, feature→grow), effort-weighted `computeBucketMix`, and `bucketBalance` flagging a bucket >5% below target as **Starved** against a default 70/20/10 split. 7 unit tests.
- **`score_demand_item`** now auto-classifies `investmentBucket` from work-type (explicit override supported); the loader returns it.
- **Demand board** — a **Balance** tab: effort-weighted actual-vs-target bars with a target tick and a Starved flag.

## UX-Fit-Decision

One added tab on the existing Demand board (no new route/nav). Plain bucket labels (Run/Grow/Transform) + a single **Starved** signal; bars use `--dpf-*` tokens. Label set WWMD-confirmed (ledger `DI-8E489A791375`).

## Verification

- `lib/demand/buckets.test.ts` (7) + full demand/registry/grants suite (196) green locally; module-size clean.
- Migration is three additive `ADD COLUMN` statements (same fleet-safe pattern as Phase 1). **Local-CI-Override:** the local gate runner has been environment-flaky this session; GitHub CI here runs the authoritative Typecheck / Production Build / Unit Tests.

## Deferred (follow-ups)

Per-portfolio target-editing UI; `jobSize`-summed-vs-`budgetKUsd` capacity read; WWWD `themePageId` linkage (the balance view is currently platform-wide against the default split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)