### PR TITLE
feat(coworker): activate programmatic tool calling for read-heavy specialists (EP-27FD96BC P2)

### DIFF
--- a/apps/web/components/employee/WorkforceActivityPanel.tsx
+++ b/apps/web/components/employee/WorkforceActivityPanel.tsx
@@ -1,0 +1,140 @@
+// Workforce ACTIVITY lead (BI-D80A1C3E).
+//
+// The lead for the Workforce view: what the AI + human workforce is actively
+// working on (tied to customer/business outcomes) and what needs the operator
+// right now. The unified HR/AI roster renders BELOW this as the secondary
+// directory. Presentational + theme-aware (DPF CSS custom properties, dense
+// layout, no hardcoded colors). Server component — no client state.
+
+import type {
+  WorkforceActiveWorkItem,
+  WorkforceActivity,
+  WorkforceConcern,
+  WorkforceConcernSeverity,
+} from "@/lib/workforce/workforce-activity";
+
+function StatPill({ label, value }: { label: string; value: string | number }) {
+  return (
+    <span className="text-[9px] text-[var(--dpf-muted)]">
+      {label} <span className="text-[var(--dpf-text)]">{value}</span>
+    </span>
+  );
+}
+
+const SEVERITY_COLOR: Record<WorkforceConcernSeverity, string> = {
+  high: "var(--dpf-error)",
+  medium: "var(--dpf-warning)",
+  low: "var(--dpf-muted)",
+};
+
+const SEVERITY_LABEL: Record<WorkforceConcernSeverity, string> = {
+  high: "Act now",
+  medium: "Attention",
+  low: "Watch",
+};
+
+function ConcernRow({ concern }: { concern: WorkforceConcern }) {
+  return (
+    <div
+      className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border-l-4"
+      style={{ borderLeftColor: SEVERITY_COLOR[concern.severity] }}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-semibold text-[var(--dpf-text)] leading-tight">
+          {concern.title}
+        </p>
+        <span
+          className="text-[9px] font-mono uppercase tracking-wide shrink-0"
+          style={{ color: SEVERITY_COLOR[concern.severity] }}
+        >
+          {SEVERITY_LABEL[concern.severity]}
+        </span>
+      </div>
+      <p className="text-[10px] text-[var(--dpf-muted)] mt-1">{concern.detail}</p>
+    </div>
+  );
+}
+
+function ownerChip(item: WorkforceActiveWorkItem): string {
+  if (item.ownerKind === "agent") return "AI agent";
+  if (item.ownerKind === "human") return "human";
+  return "unassigned";
+}
+
+function ActiveWorkRow({ item }: { item: WorkforceActiveWorkItem }) {
+  return (
+    <div className="p-3 rounded-lg bg-[var(--dpf-surface-1)]">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-[var(--dpf-text)] leading-tight truncate">
+            {item.title}
+          </p>
+          <p className="text-[10px] text-[var(--dpf-muted)] truncate">
+            {item.ownerLabel} · {ownerChip(item)}
+          </p>
+        </div>
+        <div className="flex flex-col items-end shrink-0 gap-0.5">
+          <span className="text-[9px] font-mono uppercase tracking-wide text-[var(--dpf-muted)]">
+            {item.phase}
+          </span>
+          {item.kind === "fix" && (
+            <span className="text-[9px] font-mono uppercase tracking-wide text-[var(--dpf-accent)]">
+              fix
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function WorkforceActivityPanel({ activity }: { activity: WorkforceActivity }) {
+  const { activeWork, concerns, summary } = activity;
+
+  return (
+    <div className="space-y-6">
+      {/* Needs-operator lead */}
+      <section>
+        <div className="mb-3 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Needs you</h2>
+          <StatPill label="items" value={summary.concernCount} />
+          <StatPill label="act now" value={summary.highSeverity} />
+        </div>
+
+        {concerns.length === 0 ? (
+          <p className="text-sm text-[var(--dpf-muted)] py-6 text-center rounded-lg bg-[var(--dpf-surface-1)]">
+            Nothing needs the operator right now — no unowned SLAs, approvals, or open handoffs.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {concerns.map((c) => (
+              <ConcernRow key={`${c.kind}:${c.id}`} concern={c} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Active work the workforce owns */}
+      <section>
+        <div className="mb-3 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Workforce at work</h2>
+          <StatPill label="active" value={summary.activeWorkCount} />
+          <StatPill label="AI-driven" value={summary.agentDriven} />
+          <StatPill label="human-driven" value={summary.humanDriven} />
+        </div>
+
+        {activeWork.length === 0 ? (
+          <p className="text-sm text-[var(--dpf-muted)] py-6 text-center rounded-lg bg-[var(--dpf-surface-1)]">
+            No active work in flight. Builds and engagements the workforce owns will appear here.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {activeWork.map((item) => (
+              <ActiveWorkRow key={item.buildId} item={item} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/lib/tak/tool-script.test.ts
+++ b/apps/web/lib/tak/tool-script.test.ts
@@ -10,9 +10,15 @@ import {
 } from "./tool-script";
 
 describe("parseProgrammaticToolCallingConfig", () => {
-  it("defaults to disabled with safe caps when no row", () => {
+  it("defaults to enabled (BI-9893614D) with safe caps when no row", () => {
     expect(parseProgrammaticToolCallingConfig(null)).toEqual(PROGRAMMATIC_TOOL_CALLING_DEFAULTS);
-    expect(PROGRAMMATIC_TOOL_CALLING_DEFAULTS.enabled).toBe(false);
+    // The feature is reachable by default; the per-agent tool_script_exec grant is
+    // the real gate. An operator can still force it off via the PlatformConfig row.
+    expect(PROGRAMMATIC_TOOL_CALLING_DEFAULTS.enabled).toBe(true);
+  });
+
+  it("lets an operator force the feature off via an explicit row", () => {
+    expect(parseProgrammaticToolCallingConfig({ enabled: false }).enabled).toBe(false);
   });
 
   it("honors explicit enabled + caps", () => {
@@ -22,7 +28,7 @@ describe("parseProgrammaticToolCallingConfig", () => {
 
   it("clamps absurd caps and ignores invalid types", () => {
     const cfg = parseProgrammaticToolCallingConfig({ enabled: "yes", maxOutputChars: 9_000_000, timeoutMs: -5 });
-    expect(cfg.enabled).toBe(false); // non-boolean → default
+    expect(cfg.enabled).toBe(true); // non-boolean → default (now enabled)
     expect(cfg.maxOutputChars).toBe(50_000); // clamped
     expect(cfg.timeoutMs).toBe(PROGRAMMATIC_TOOL_CALLING_DEFAULTS.timeoutMs); // invalid → default
   });

--- a/apps/web/lib/tak/tool-script.ts
+++ b/apps/web/lib/tak/tool-script.ts
@@ -53,7 +53,12 @@ export type ProgrammaticToolCallingConfig = {
 };
 
 export const PROGRAMMATIC_TOOL_CALLING_DEFAULTS: ProgrammaticToolCallingConfig = {
-  enabled: false,
+  // EP-27FD96BC · P2 (BI-9893614D) — the feature is now reachable by default
+  // (37–98% token cuts for read-heavy tool filtering). It stays fully gated:
+  // only agents holding the `tool_script_exec` grant can invoke it, and every
+  // callTool the script issues re-enters the kernel gate with a read-only-scoped
+  // JWT. An operator can still force it off per install via the PlatformConfig row.
+  enabled: true,
   maxOutputChars: 8_000,
   timeoutMs: 60_000,
 };

--- a/docs/superpowers/plans/2026-07-11-p2-activate-programmatic-tool-calling.md
+++ b/docs/superpowers/plans/2026-07-11-p2-activate-programmatic-tool-calling.md
@@ -1,0 +1,28 @@
+# P2 — Activate the dark token savings (programmatic tool calling)
+
+- **BI:** BI-9893614D · **Epic:** EP-27FD96BC
+- **Scope spec:** `docs/superpowers/specs/2026-07-11-coworker-reasoning-economy-scope.md`
+- **Kernel:** approach routed via `principle_decide` 2026-07-11 (guard off). **flag-on-select-grant** (reachable by default, granted only to read-heavy specialists) over broad-grant or operator-toggle-only — composite 9.03, high confidence.
+
+## Problem (from the audit)
+
+`run_tool_script` (`apps/web/lib/tak/tool-script.ts`) is fully built and governed — model-written code runs in the resource-limited Docker sandbox with a short-lived **read-only-scoped** JWT, every `callTool` re-enters the kernel gate + agent-grant checks and is audited as a `ToolExecution` row (Anthropic measures 37–98% token cuts for read-heavy filtering). But it shipped **dark** behind two default-off kill-switches, so nothing ever exercised it: the `programmatic_tool_calling` PlatformConfig flag and the per-agent `tool_script_exec` grant.
+
+## Approach — reachable by default, granted narrowly
+
+Substrate-verify-first: the mechanism, governance, and grant already exist; this only activates them.
+
+1. **Flag on by default** — `PROGRAMMATIC_TOOL_CALLING_DEFAULTS.enabled = true`, so the feature is reachable. An operator can still force it off per install via the PlatformConfig row (`getProgrammaticToolCallingConfig` honours an explicit `{enabled:false}`).
+2. **Grant `tool_script_exec` to read-heavy specialists only** in `HARDCODED_COWORKER_GRANTS`: `build-specialist` and `data-architect` (already sandbox-native), `ea-architect` (graph/architecture reads), `data-steward` (dedup sweeps over records), `platform-engineer` (telemetry/admin reads). The grant is safe regardless of an agent's other grants — the script's JWT strips every side-effecting scope, so a granted agent's script can still only *read*.
+
+## Why this is safe
+- The per-agent grant is the real gate; the flag being on changes nothing for un-granted agents.
+- The sandbox is the trust boundary (command-blocklisted, path-guarded, resource-limited); the JWT is read-only; every inner tool call is re-gated by the kernel.
+
+## Verification
+- Unit: `tool-script.test.ts` — default now enabled; an explicit `{enabled:false}` row still forces off; caps still clamp. `seed.test.ts` + conformance — grant additions valid, existing regression guards intact (19 + 14 green).
+- Live (this install, sandbox `dpf-sandbox-1` running): exercise `run_tool_script` end-to-end and confirm the sandbox executes the script and returns only the small filtered result. Recorded in the PR.
+
+## Non-goals
+- Write-capable scripts (the JWT is deliberately read-only).
+- Broad rollout to every coworker (deferred until the read-heavy set proves the savings live).

--- a/packages/db/src/workforce-seed.ts
+++ b/packages/db/src/workforce-seed.ts
@@ -249,7 +249,10 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
     "backlog_read",
     "backlog_write",
   ],
-  "ea-architect": ["ea_graph_read", "ea_graph_write", "architecture_read", "file_read", "registry_read"],
+  // tool_script_exec (EP-27FD96BC BI-9893614D): the EA architect traverses large
+  // graph/architecture reads — a prime case for programmatic filtering in the
+  // sandbox (the script's JWT is read-only-scoped regardless of these grants).
+  "ea-architect": ["ea_graph_read", "ea_graph_write", "architecture_read", "file_read", "registry_read", "tool_script_exec"],
   "hr-specialist": ["registry_read", "consumer_read", "consumer_write"],
   // The Customer Success Manager operates the CRM (accounts, pipeline, quotes),
   // so it needs crm_read/crm_write — NOT backlog_write (which let it retire live
@@ -262,7 +265,7 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
   // sweep, merges duplicates, and proposes enrichment. crm_write reaches the
   // mdm-stewardship pack tools (run_mdm_steward_sweep, merge_customer_*,
   // list_mdm_steward_tasks); web_search gates the enrich_customer_account door.
-  "data-steward": ["crm_read", "crm_write", "consumer_read", "registry_read", "backlog_read", "web_search"],
+  "data-steward": ["crm_read", "crm_write", "consumer_read", "registry_read", "backlog_read", "web_search", "tool_script_exec"],
   "marketing-specialist": ["marketing_read", "marketing_write", "consumer_read", "registry_read"],
   "storefront-advisor": [
     "consumer_read",
@@ -279,7 +282,7 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
   // issues it detects. Its runtime grants resolve from THIS map (not
   // agent_registry.json, which already intends backlog access), so backlog_read/
   // backlog_write must live here to reach its tool surface (BI-CAP-CBC41758).
-  "platform-engineer": ["agent_control_read", "admin_read", "admin_write", "registry_read", "telemetry_read", "backlog_read", "backlog_write"],
+  "platform-engineer": ["agent_control_read", "admin_read", "admin_write", "registry_read", "telemetry_read", "backlog_read", "backlog_write", "tool_script_exec"],
   "build-specialist": [
     "file_read",
     "code_graph_read",
@@ -296,8 +299,11 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
     "release_plan_read",
     "coworker_screen_read",
     "coworker_screen_drive",
+    // Already sandbox-native (sandbox_execute); code_graph/file reads are the
+    // canonical read-heavy filtering case (EP-27FD96BC BI-9893614D).
+    "tool_script_exec",
   ],
-  "data-architect": ["file_read", "sandbox_execute", "architecture_read", "registry_read"],
+  "data-architect": ["file_read", "sandbox_execute", "architecture_read", "registry_read", "tool_script_exec"],
   "admin-assistant": ["admin_read", "admin_write", "agent_control_read", "registry_read", "web_search", "file_read"],
   coo: ["portfolio_read", "registry_read", "backlog_read", "backlog_write", "agent_control_read", "email_config"],
   "doc-specialist": ["file_read", "registry_read", "portfolio_read", "document_read", "document_write", "document_publish"],


### PR DESCRIPTION
## What

BI-9893614D (EP-27FD96BC P2). `run_tool_script` was fully built and governed but shipped **dark** behind two default-off kill-switches, so the **37–98% token savings** for read-heavy tool filtering were never realized. The model writes a short script that runs in the resource-limited Docker sandbox with a **read-only-scoped JWT**; every `callTool` re-enters the kernel gate + agent-grant checks and is audited as a `ToolExecution`.

**Kernel-routed approach** (`principle_decide`, 2026-07-11): flag-on-select-grant (composite 9.03 vs 6.36 broad / 8.01 operator-toggle, high confidence) — reachable by default, but `tool_script_exec` granted only to read-heavy specialists.

## Files
- `apps/web/lib/tak/tool-script.ts` — `PROGRAMMATIC_TOOL_CALLING_DEFAULTS.enabled = true` (operator can still force off via the PlatformConfig row)
- `packages/db/src/workforce-seed.ts` — grant `tool_script_exec` to `build-specialist`, `data-architect`, `ea-architect`, `data-steward`, `platform-engineer`
- `apps/web/lib/tak/tool-script.test.ts` — default-enabled + explicit-off tests
- Plan: `docs/superpowers/plans/2026-07-11-p2-activate-programmatic-tool-calling.md`

## Why safe
The per-agent grant is the gate; the flag being on changes nothing for un-granted agents. The grant is safe regardless of an agent's other grants — the script's JWT strips every side-effecting scope, so scripts can only **read**. The sandbox (command-blocklisted, path-guarded, resource-limited) is the trust boundary.

## Verification
- Unit: `tool-script.test.ts` (19) + `seed.test.ts` (14) green; conformance intact; tsc clean.
- **Live** (this install, sandbox `dpf-sandbox-1` running): the grant gate correctly **hides** `run_tool_script` from an ungranted token and **rejects** direct invocation with the exact `tool_script_exec` scope error. Full sandbox exercise follows the granted agents post-deploy.

**UX-Fit:** N/A — backend capability activation; operator override is the existing PlatformConfig row, no new surface.

Local-CI-Override: Verified-clean. Local-CI pregate blocked by fleet-wide sandbox-drift infra defect BI-E9E0FF0A. GitHub CI required checks are the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Seed-Fit-Decision: global-default — tool_script_exec grant to platform read-heavy specialists is a global workforce default (not archetype/install-local).

UX-Fit-Decision: N/A — backend capability activation only; no new user-facing control (existing PlatformConfig override).
