### PR TITLE
feat(decision-gov): WWWD stance capture & promotion loop — answers become gate-live doctrine (BI-9677364B, BI-002DEB85)

### DIFF
--- a/apps/web/app/(shell)/wiki/review/page.tsx
+++ b/apps/web/app/(shell)/wiki/review/page.tsx
@@ -13,6 +13,10 @@ import {
   type GapCluster,
   type ReviewFinding,
 } from "@/lib/wiki/decision-review-findings";
+import {
+  OrgDecisionCaptureList,
+  type OpenOrgDecision,
+} from "@/components/wiki/OrgDecisionCaptureList";
 import { GapAnswerForm } from "./gap-answer-form";
 
 export const dynamic = "force-dynamic";
@@ -69,7 +73,7 @@ function toGapClusters(
 }
 
 export default async function DecisionReviewPage() {
-  const [conflictRows, unresolvedRows, staleCount, orgProfile] =
+  const [conflictRows, unresolvedRows, staleCount, orgProfile, openOrgRows] =
     await Promise.all([
       prisma.decisionInteraction.findMany({
         where: { principleConflict: true },
@@ -98,7 +102,34 @@ export default async function DecisionReviewPage() {
         where: { kind: "organization" },
         select: { profileId: true },
       }),
+      // Unresolved WWWD business decisions (no build, unanswered) — the
+      // inline capture loop's inbox (BI-9677364B).
+      prisma.decisionInteraction.findMany({
+        where: {
+          outcomeType: { in: UNRESOLVED },
+          buildId: null,
+          routeContext: "/coworker-business",
+          humanOutcome: { equals: Prisma.DbNull },
+        },
+        orderBy: { createdAt: "desc" },
+        take: 20,
+        select: {
+          interactionId: true,
+          question: true,
+          riskTier: true,
+          outcomeType: true,
+          createdAt: true,
+        },
+      }),
     ]);
+
+  const openOrgDecisions: OpenOrgDecision[] = openOrgRows.map((row) => ({
+    interactionId: row.interactionId,
+    question: row.question,
+    riskTier: row.riskTier,
+    outcomeType: row.outcomeType,
+    createdAt: row.createdAt.toISOString(),
+  }));
 
   const findings = buildReviewFindings({
     conflicts: conflictRows as ConflictRow[],
@@ -126,6 +157,8 @@ export default async function DecisionReviewPage() {
           settled answer yet.
         </p>
       </header>
+
+      <OrgDecisionCaptureList decisions={openOrgDecisions} />
 
       {findings.length === 0 ? (
         <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-8 text-center">

--- a/apps/web/components/wiki/BusinessStanceForm.tsx
+++ b/apps/web/components/wiki/BusinessStanceForm.tsx
@@ -1,36 +1,42 @@
 "use client";
-// EP-0AF96937 Phase 3: the WWWD business-stance authoring form.
+// EP-0AF96937 Phase 3 + BI-002DEB85: the WWWD business-stance authoring form.
 //
 // Progressive disclosure (AGENTS.md §12): a business owner writes the question
 // they want settled and how the business decides it, in plain language. No
-// dimension vectors or tiers up front — the stance is saved as a draft
-// org-overlay page and reviewed before it becomes active doctrine.
+// dimension vectors or tiers up front. "Save as draft" keeps it inert;
+// "Publish" makes it live doctrine — the page is published + embedded and an
+// owner-confirmed material lands in the picked decision area, so the decision
+// gate can actually act on it.
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
-import { saveBusinessStance } from "@/lib/actions/business-stance";
+import { publishBusinessStance, saveBusinessStance } from "@/lib/actions/business-stance";
+import { DECISION_AREAS } from "@/lib/wiki/business-stance";
 
 export function BusinessStanceForm() {
   const router = useRouter();
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [summary, setSummary] = useState("");
+  const [decisionArea, setDecisionArea] = useState<string>(DECISION_AREAS[0].key);
   const [error, setError] = useState<string | null>(null);
-  const [savedSlug, setSavedSlug] = useState<string | null>(null);
+  const [saved, setSaved] = useState<null | { slug: string; mode: "draft" | "published" }>(null);
   const [pending, startTransition] = useTransition();
 
-  function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  function submit(mode: "draft" | "published") {
     setError(null);
-    setSavedSlug(null);
+    setSaved(null);
     startTransition(async () => {
-      const result = await saveBusinessStance({ title, body, summary });
+      const result =
+        mode === "draft"
+          ? await saveBusinessStance({ title, body, summary })
+          : await publishBusinessStance({ title, body, summary, decisionArea });
       if (!result.ok) {
         setError(result.error);
         return;
       }
-      setSavedSlug(result.slug);
+      setSaved({ slug: result.slug, mode });
       setTitle("");
       setBody("");
       setSummary("");
@@ -40,7 +46,10 @@ export function BusinessStanceForm() {
 
   return (
     <form
-      onSubmit={onSubmit}
+      onSubmit={(e) => {
+        e.preventDefault();
+        submit("draft");
+      }}
       className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
     >
       <p className="text-sm font-medium text-[var(--dpf-text)] mb-3">
@@ -83,27 +92,53 @@ export function BusinessStanceForm() {
         className="w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)] mb-3"
       />
 
+      <label className="block text-xs text-[var(--dpf-muted)] mb-1" htmlFor="stance-area">
+        What kind of decisions does this guide?
+      </label>
+      <select
+        id="stance-area"
+        value={decisionArea}
+        onChange={(e) => setDecisionArea(e.target.value)}
+        className="w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)] mb-3"
+      >
+        {DECISION_AREAS.map((area) => (
+          <option key={area.key} value={area.key}>
+            {area.label} — {area.hint}
+          </option>
+        ))}
+      </select>
+
       {error && (
         <p className="text-xs text-[var(--dpf-error)] mb-3" role="alert">
           {error}
         </p>
       )}
-      {savedSlug && (
+      {saved && (
         <p className="text-xs text-[var(--dpf-success)] mb-3">
-          Saved as a draft. Review and publish it to make it active doctrine.
+          {saved.mode === "published"
+            ? "Published. Your AI now weighs this stance when it decides."
+            : "Saved as a draft. Publish it to make it active doctrine."}
         </p>
       )}
 
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 flex-wrap">
+        <button
+          type="button"
+          onClick={() => submit("published")}
+          disabled={pending}
+          className="rounded-md border border-[var(--dpf-accent)] bg-[var(--dpf-accent-soft)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-accent)] hover:opacity-90 disabled:opacity-50"
+        >
+          {pending ? "Working…" : "Publish"}
+        </button>
         <button
           type="submit"
           disabled={pending}
-          className="rounded-md border border-[var(--dpf-accent)] px-3 py-1.5 text-sm text-[var(--dpf-accent)] hover:bg-[var(--dpf-accent-soft)] disabled:opacity-50"
+          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] disabled:opacity-50"
         >
           {pending ? "Saving…" : "Save as draft"}
         </button>
         <span className="text-xs text-[var(--dpf-muted)]">
-          Drafts don&rsquo;t affect decisions until you publish them.
+          Publishing makes this count when your AI decides; drafts don&rsquo;t.
         </span>
       </div>
     </form>

--- a/apps/web/components/wiki/OrgDecisionCaptureList.tsx
+++ b/apps/web/components/wiki/OrgDecisionCaptureList.tsx
@@ -1,0 +1,128 @@
+"use client";
+// BI-9677364B: "Waiting on your call" — unresolved WWWD business decisions,
+// answerable inline on the Review & Adjust workspace.
+//
+// Cognitive-load contract (AGENTS.md §12): one card per open decision, one
+// plain-language question, one answer box, one pre-checked "remember this"
+// toggle. Answering with the toggle on writes the ruling back as standing
+// doctrine so the equivalent decision never escalates again — the loop the
+// stance-onboarding design closes.
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { captureOrgDecisionOutcome } from "@/lib/actions/org-decision-capture";
+import { LocalTime } from "@/components/ui/LocalTime";
+
+export type OpenOrgDecision = {
+  interactionId: string;
+  question: string;
+  riskTier: string | null;
+  outcomeType: string;
+  /** ISO timestamp; rendered in the viewer's timezone via LocalTime. */
+  createdAt: string;
+};
+
+function CaptureCard({ decision }: { decision: OpenOrgDecision }) {
+  const router = useRouter();
+  const [answer, setAnswer] = useState("");
+  const [makeStanding, setMakeStanding] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<null | { standing: boolean }>(null);
+  const [pending, startTransition] = useTransition();
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    startTransition(async () => {
+      const result = await captureOrgDecisionOutcome({
+        interactionId: decision.interactionId,
+        answer,
+        makeStanding,
+      });
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setDone({ standing: result.standingPromoted === true });
+      router.refresh();
+    });
+  }
+
+  if (done) {
+    return (
+      <li className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+        <p className="text-sm text-[var(--dpf-success)]">
+          Answer recorded{done.standing ? " — and saved as your standing answer for cases like this." : "."}
+        </p>
+      </li>
+    );
+  }
+
+  return (
+    <li className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+      <div className="flex items-center gap-2 flex-wrap mb-2">
+        <span className="text-sm font-medium text-[var(--dpf-text)] min-w-0 flex-1">
+          {decision.question}
+        </span>
+        {decision.riskTier && (
+          <span className="text-xs text-[var(--dpf-muted)] shrink-0">risk: {decision.riskTier}</span>
+        )}
+        <LocalTime value={decision.createdAt} mode="date" className="text-xs text-[var(--dpf-muted)] shrink-0" />
+      </div>
+      <form onSubmit={onSubmit}>
+        <label className="sr-only" htmlFor={`answer-${decision.interactionId}`}>
+          What should the business do?
+        </label>
+        <textarea
+          id={`answer-${decision.interactionId}`}
+          value={answer}
+          onChange={(e) => setAnswer(e.target.value)}
+          rows={2}
+          placeholder="What should the business do?"
+          className="w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)] mb-2"
+        />
+        {error && (
+          <p className="text-xs text-[var(--dpf-error)] mb-2" role="alert">
+            {error}
+          </p>
+        )}
+        <div className="flex items-center gap-3 flex-wrap">
+          <button
+            type="submit"
+            disabled={pending || answer.trim().length === 0}
+            className="rounded-md border border-[var(--dpf-accent)] bg-[var(--dpf-accent-soft)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-accent)] hover:opacity-90 disabled:opacity-50"
+          >
+            {pending ? "Recording…" : "Answer"}
+          </button>
+          <label className="flex items-center gap-1.5 text-xs text-[var(--dpf-text)]">
+            <input
+              type="checkbox"
+              checked={makeStanding}
+              onChange={(e) => setMakeStanding(e.target.checked)}
+            />
+            Remember this as our standing answer
+          </label>
+        </div>
+      </form>
+    </li>
+  );
+}
+
+export function OrgDecisionCaptureList({ decisions }: { decisions: OpenOrgDecision[] }) {
+  if (decisions.length === 0) return null;
+  return (
+    <section className="mb-8">
+      <h2 className="text-lg font-semibold text-[var(--dpf-text)] mb-1">Waiting on your call</h2>
+      <p className="text-xs text-[var(--dpf-muted)] mb-3">
+        Business decisions your AI escalated because it had no settled answer. Answering with
+        &ldquo;remember this&rdquo; on teaches it — equivalent cases resolve on their own next time.
+      </p>
+      <ul className="flex flex-col gap-2">
+        {decisions.map((d) => (
+          <CaptureCard key={d.interactionId} decision={d} />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/lib/actions/business-stance.ts
+++ b/apps/web/lib/actions/business-stance.ts
@@ -10,8 +10,12 @@
 
 import { revalidatePath } from "next/cache";
 
+import { prisma } from "@dpf/db";
 import { saveWikiOverlayEdit } from "@/lib/actions/wiki-edit";
+import { promoteStanceMaterial } from "@/lib/decision-perspective/stance-promotion";
+import { storeWikiPage } from "@/lib/wiki/embeddings";
 import {
+  decisionAreaToDomainClass,
   validateBusinessStance,
   type BusinessStanceInput,
 } from "@/lib/wiki/business-stance";
@@ -50,4 +54,83 @@ export async function saveBusinessStance(
   revalidatePath("/wiki/stance");
   revalidatePath("/wiki");
   return { ok: true, slug: result.slug, status: result.status };
+}
+
+export type PublishBusinessStanceResult =
+  | { ok: true; slug: string; gateLive: boolean }
+  | { ok: false; error: string };
+
+/**
+ * Publish a WWWD business stance and make it GATE-LIVE (BI-002DEB85).
+ *
+ * Until this existed, an authored stance stayed a draft page forever — a
+ * policy document no decision path enforced. Publishing (a) publishes the
+ * org-overlay page, (b) embeds it so coworkers retrieve it as WWWD context,
+ * and (c) promotes an owner-confirmed (A/0.9) PerspectiveMaterial in the
+ * decision area the owner picked, which is what actually changes what
+ * evaluate_org_business_decision allows.
+ */
+export async function publishBusinessStance(
+  input: BusinessStanceInput & { decisionArea: string },
+): Promise<PublishBusinessStanceResult> {
+  const validated = validateBusinessStance(input);
+  if (!validated.ok) {
+    return { ok: false, error: validated.error };
+  }
+  const domainClass = decisionAreaToDomainClass(input.decisionArea);
+  if (!domainClass) {
+    return { ok: false, error: "Pick the kind of decisions this stance guides." };
+  }
+
+  const result = await saveWikiOverlayEdit({
+    slug: validated.slug,
+    pageKind: "stance",
+    title: validated.title,
+    body: validated.body,
+    status: "published",
+    abstract: validated.summary,
+    changeSummary: "Business stance published via the WWWD editor",
+  });
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
+
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) {
+    return { ok: false, error: "No organization is configured for this install." };
+  }
+
+  // Deliberation layer (best-effort): the gate-live material below is the
+  // enforcement; a failed embed only weakens retrieval context.
+  try {
+    await storeWikiPage({
+      pageId: result.pageId,
+      slug: validated.slug,
+      title: validated.title,
+      body: validated.body,
+      abstract: validated.summary,
+      pageKind: "stance",
+      status: "published",
+      isKernel: false,
+      kernelVersion: null,
+      organizationId: org.id,
+      kernelPageId: null,
+    });
+  } catch {
+    // best-effort; enforcement continues below
+  }
+
+  const promoted = await promoteStanceMaterial({
+    db: prisma,
+    organizationId: org.id,
+    wikiPageId: result.pageId,
+    slug: validated.slug,
+    summary: validated.summary ?? validated.title,
+    domainClasses: [domainClass],
+    tier: "confirmed",
+  });
+
+  revalidatePath("/wiki/stance");
+  revalidatePath("/wiki");
+  return { ok: true, slug: result.slug, gateLive: promoted.ok };
 }

--- a/apps/web/lib/actions/org-decision-capture.ts
+++ b/apps/web/lib/actions/org-decision-capture.ts
@@ -1,0 +1,216 @@
+"use server";
+// WWWD org-decision capture (BI-9677364B, EP-0AF96937 build plan Phase 2).
+//
+// The non-build counterpart to captureDecisionInteraction: business decisions
+// from the /coworker-business gate carry no buildId, so until now a founder
+// answer taught the corpus NOTHING (candidateMaterial was read nowhere). This
+// action records the owner's ruling on an escalated/deferred org decision and
+// — when asked — writes it back as a STANDING stance: a published org-overlay
+// page (embedded for the deliberation layer) plus a `ruled` (A/1.0) material
+// in the decision's domainClass, so equivalent decisions resolve next time.
+//
+// Domain errors are RETURNED as values, never thrown — Next strips thrown
+// messages in production ("use server" error-surfacing rule).
+
+import { randomUUID } from "crypto";
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@dpf/db";
+import { upsertWikiPage, appendRevision } from "@dpf/db/wiki-store";
+import { requireCapability } from "@/lib/actions/shared/guards";
+import { promoteStanceMaterial } from "@/lib/decision-perspective/stance-promotion";
+import type { DecisionDomainClass } from "@/lib/decision-perspective/types";
+import { storeWikiPage } from "@/lib/wiki/embeddings";
+import {
+  buildStandingStancePage,
+  validateOrgDecisionCapture,
+  type OrgDecisionCaptureInput,
+} from "@/lib/wiki/org-decision-capture";
+
+export type CaptureOrgDecisionResult =
+  | {
+      ok: true;
+      status: "captured" | "already-captured";
+      /** Set when a standing stance was written. */
+      standingSlug?: string;
+      /** True when the standing material is gate-live in the decision's class. */
+      standingPromoted?: boolean;
+    }
+  | { ok: false; error: string };
+
+function captureId(prefix: "ESC" | "DEF"): string {
+  return `${prefix}-${randomUUID().replace(/-/g, "").slice(0, 12).toUpperCase()}`;
+}
+
+/**
+ * Record the owner's ruling on an unresolved WWWD business decision, and
+ * optionally make it standing doctrine for the decision's class.
+ */
+export async function captureOrgDecisionOutcome(
+  input: OrgDecisionCaptureInput,
+): Promise<CaptureOrgDecisionResult> {
+  let userId: string;
+  try {
+    userId = (await requireCapability("view_platform")).userId;
+  } catch {
+    return { ok: false, error: "You do not have access to answer decisions." };
+  }
+
+  const v = validateOrgDecisionCapture(input);
+  if (!v.ok) {
+    return { ok: false, error: v.error };
+  }
+
+  const row = await prisma.decisionInteraction.findUnique({
+    where: { interactionId: v.interactionId },
+    include: {
+      escalationCapture: { select: { escalationId: true } },
+      deferralCapture: { select: { deferralId: true } },
+    },
+  });
+
+  if (!row) {
+    return { ok: false, error: "Decision not found." };
+  }
+  if (row.buildId) {
+    return { ok: false, error: "This is a build decision — answer it from the build workspace." };
+  }
+  if (row.outcomeType !== "escalate" && row.outcomeType !== "defer") {
+    return { ok: false, error: "This decision was resolved by the gate and needs no answer." };
+  }
+  if (row.humanOutcome !== null || row.escalationCapture || row.deferralCapture) {
+    return { ok: true, status: "already-captured" };
+  }
+
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) {
+    return { ok: false, error: "No organization is configured for this install." };
+  }
+
+  const capturedAt = new Date().toISOString();
+  const rationale = v.rationale ?? v.answer;
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      if (row.outcomeType === "escalate") {
+        await tx.escalationCapture.create({
+          data: {
+            escalationId: captureId("ESC"),
+            interactionId: row.id,
+            resolverUserId: userId,
+            prompt: row.question,
+            answer: v.answer,
+            criteria: [],
+            rationale,
+            objectionsResolved: [],
+            domainClass: row.domainClass,
+            candidateMaterial: v.makeStanding,
+          },
+        });
+      } else {
+        await tx.deferralCapture.create({
+          data: {
+            deferralId: captureId("DEF"),
+            interactionId: row.id,
+            domain: row.domainClass,
+            gapReason: v.answer,
+            suggestedSourceTypes: [],
+            candidateMaterial: v.makeStanding,
+          },
+        });
+      }
+      await tx.decisionInteraction.update({
+        where: { id: row.id },
+        data: {
+          humanOutcome: {
+            type: row.outcomeType === "escalate" ? "escalation" : "deferral",
+            answer: v.answer,
+            rationale,
+            candidateMaterial: v.makeStanding,
+            resolverUserId: userId,
+            capturedAt,
+            clearsGate: row.outcomeType === "escalate",
+          },
+        },
+      });
+    });
+  } catch (err) {
+    return { ok: false, error: (err as Error).message || "Could not record the answer." };
+  }
+
+  let standingSlug: string | undefined;
+  let standingPromoted: boolean | undefined;
+
+  if (v.makeStanding) {
+    const page = buildStandingStancePage({
+      interactionId: row.interactionId,
+      question: row.question,
+      domainClass: row.domainClass as DecisionDomainClass,
+      answer: v.answer,
+      rationale: v.rationale,
+      standingTitle: v.standingTitle,
+    });
+
+    try {
+      const saved = (await upsertWikiPage(prisma, {
+        organizationId: org.id,
+        slug: page.slug,
+        title: page.title,
+        body: page.body,
+        pageKind: "stance",
+        status: "published",
+        isKernel: false,
+        abstract: page.abstract,
+      })) as { id: string };
+
+      await appendRevision(prisma, {
+        pageId: saved.id,
+        title: page.title,
+        body: page.body,
+        changeKind: "manual",
+        changeSummary: `Standing answer captured from ${row.interactionId}`,
+        createdById: userId,
+      });
+
+      // Deliberation layer: embed so coworkers retrieve the ruling as WWWD
+      // context. Best-effort — the gate-live material below is the enforcement.
+      await storeWikiPage({
+        pageId: saved.id,
+        slug: page.slug,
+        title: page.title,
+        body: page.body,
+        abstract: page.abstract,
+        pageKind: "stance",
+        status: "published",
+        isKernel: false,
+        kernelVersion: null,
+        organizationId: org.id,
+        kernelPageId: null,
+      });
+
+      const promoted = await promoteStanceMaterial({
+        db: prisma,
+        organizationId: org.id,
+        wikiPageId: saved.id,
+        slug: page.slug,
+        summary: page.abstract,
+        domainClasses: page.domainClasses,
+        tier: "ruled",
+      });
+
+      standingSlug = page.slug;
+      standingPromoted = promoted.ok;
+    } catch (err) {
+      // The answer is recorded either way; report the standing-write failure
+      // as a value so the owner knows doctrine did not update.
+      return {
+        ok: false,
+        error: `Your answer was recorded, but saving it as a standing stance failed: ${(err as Error).message}`,
+      };
+    }
+  }
+
+  revalidatePath("/wiki/review");
+  revalidatePath("/wiki");
+  return { ok: true, status: "captured", standingSlug, standingPromoted };
+}

--- a/apps/web/lib/decision-perspective/stance-promotion.test.ts
+++ b/apps/web/lib/decision-perspective/stance-promotion.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  promoteStanceMaterial,
+  stanceMaterialId,
+  STANCE_TIERS,
+  type StancePromotionClient,
+} from "./stance-promotion";
+
+type Row = Record<string, any>;
+
+function makeFakeDb(opts: { profile?: Row | null; materials?: Row[] }) {
+  const materials: Row[] = opts.materials ?? [];
+  const db: StancePromotionClient = {
+    decisionPerspectiveProfile: {
+      findFirst: vi.fn(async () => opts.profile ?? null),
+    },
+    perspectiveMaterial: {
+      findUnique: vi.fn(async (args: any) => {
+        const row = materials.find((m) => m.materialId === args.where.materialId);
+        return row ?? null;
+      }),
+      upsert: vi.fn(async (args: any) => {
+        const found = materials.find((m) => m.materialId === args.where.materialId);
+        if (found) {
+          Object.assign(found, args.update);
+          return found;
+        }
+        const row = { ...args.create };
+        materials.push(row);
+        return row;
+      }),
+    },
+  };
+  return { db, materials };
+}
+
+const ORG = "org_1";
+const PROFILE = { profileId: "org-perspective-org_1", currentVersionId: "org-perspective-org_1-v1" };
+
+describe("promoteStanceMaterial", () => {
+  it("returns no-org-profile when the org has no WWWD profile", async () => {
+    const { db } = makeFakeDb({ profile: null });
+    const result = await promoteStanceMaterial({
+      db,
+      organizationId: ORG,
+      wikiPageId: "wp1",
+      slug: "stances/customer-goodwill",
+      summary: "s",
+      domainClasses: ["risk-assessment"],
+      tier: "confirmed",
+    });
+    expect(result).toEqual({ ok: false, error: "no-org-profile" });
+  });
+
+  it("writes confirmed A/0.9 materials across the bundle (primary + echo ids)", async () => {
+    const { db, materials } = makeFakeDb({ profile: PROFILE });
+    const result = await promoteStanceMaterial({
+      db,
+      organizationId: ORG,
+      wikiPageId: "wp1",
+      slug: "stances/customer-goodwill",
+      summary: "Make it right fast",
+      domainClasses: ["risk-assessment", "professional-practice"],
+      tier: "confirmed",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(materials).toHaveLength(2);
+    expect(materials[0]).toMatchObject({
+      materialId: "org-perspective-org_1:stances/customer-goodwill",
+      domainClass: "risk-assessment",
+      evidenceGrade: "A",
+      confidenceWeight: 0.9,
+      reviewStatus: "approved",
+      promotionState: "promoted",
+      direction: "support",
+    });
+    expect(materials[1]).toMatchObject({
+      materialId: "org-perspective-org_1:stances/customer-goodwill:professional-practice",
+      domainClass: "professional-practice",
+      confidenceWeight: 0.9,
+    });
+  });
+
+  it("upgrades an existing unconfirmed (B/0.6) seed row in place", async () => {
+    const seeded = {
+      materialId: "org-perspective-org_1:stances/quality-bar",
+      evidenceGrade: "B",
+      confidenceWeight: 0.6,
+    };
+    const { db, materials } = makeFakeDb({ profile: PROFILE, materials: [seeded] });
+
+    const result = await promoteStanceMaterial({
+      db,
+      organizationId: ORG,
+      wikiPageId: "wp2",
+      slug: "stances/quality-bar",
+      summary: "Meets our standard or we redo it",
+      domainClasses: ["professional-practice"],
+      tier: "confirmed",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(materials).toHaveLength(1);
+    expect(materials[0].evidenceGrade).toBe("A");
+    expect(materials[0].confidenceWeight).toBe(0.9);
+  });
+
+  it("NEVER downgrades: a ruled (A/1.0) row survives a confirmed (A/0.9) write", async () => {
+    const ruled = {
+      materialId: "org-perspective-org_1:stances/ruling-billing",
+      evidenceGrade: "A",
+      confidenceWeight: 1.0,
+    };
+    const { db, materials } = makeFakeDb({ profile: PROFILE, materials: [ruled] });
+
+    const result = await promoteStanceMaterial({
+      db,
+      organizationId: ORG,
+      wikiPageId: "wp3",
+      slug: "stances/ruling-billing",
+      summary: "s",
+      domainClasses: ["risk-assessment"],
+      tier: "confirmed",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.keptHigherTier).toEqual(["org-perspective-org_1:stances/ruling-billing"]);
+    }
+    expect(materials[0].confidenceWeight).toBe(1.0);
+  });
+
+  it("ruled tier writes A/1.0 (the human-ruled ceiling)", async () => {
+    const { db, materials } = makeFakeDb({ profile: PROFILE });
+    await promoteStanceMaterial({
+      db,
+      organizationId: ORG,
+      wikiPageId: "wp4",
+      slug: "stances/ruling-x",
+      summary: "s",
+      domainClasses: ["risk-assessment"],
+      tier: "ruled",
+    });
+    expect(materials[0].evidenceGrade).toBe("A");
+    expect(materials[0].confidenceWeight).toBe(1.0);
+  });
+
+  it("tier table matches the design ladder", () => {
+    expect(STANCE_TIERS.unconfirmed).toEqual({ evidenceGrade: "B", confidenceWeight: 0.6 });
+    expect(STANCE_TIERS.confirmed).toEqual({ evidenceGrade: "A", confidenceWeight: 0.9 });
+    expect(STANCE_TIERS.ruled).toEqual({ evidenceGrade: "A", confidenceWeight: 1.0 });
+  });
+
+  it("stanceMaterialId matches the seeder scheme", () => {
+    expect(stanceMaterialId("p", "stances/x", "risk-assessment", true)).toBe("p:stances/x");
+    expect(stanceMaterialId("p", "stances/x", "risk-assessment", false)).toBe(
+      "p:stances/x:risk-assessment",
+    );
+  });
+});

--- a/apps/web/lib/decision-perspective/stance-promotion.ts
+++ b/apps/web/lib/decision-perspective/stance-promotion.ts
@@ -1,0 +1,163 @@
+// Stance-material promotion (EP-0AF96937 stance-onboarding design §5).
+//
+// The single write path that makes an org stance GATE-LIVE: a WikiPage alone
+// is a policy document; only an approved+promoted PerspectiveMaterial row in
+// the right domainClass changes what evaluate_org_business_decision allows
+// (a documented policy without system enforcement does not change decision
+// behavior — design §9). Three authority tiers, from the confirmation ladder:
+//
+//   unconfirmed  B / 0.6  — archetype default; effective 0.45, clears nothing
+//   confirmed    A / 0.9  — owner said so; clears every low-risk class
+//   ruled        A / 1.0  — a human ruled on a real decision in this class
+//
+// Unlike the onboarding seeder (which never upgrades), this module's upsert
+// DELIBERATELY sets grade/weight on update — it exists to move material up
+// the ladder. It never moves material down: promote() refuses to write a
+// lower tier over a higher one.
+
+import type { DecisionDomainClass } from "./types";
+
+export const STANCE_TIERS = {
+  unconfirmed: { evidenceGrade: "B", confidenceWeight: 0.6 },
+  confirmed: { evidenceGrade: "A", confidenceWeight: 0.9 },
+  ruled: { evidenceGrade: "A", confidenceWeight: 1.0 },
+} as const;
+
+export type StanceTier = keyof typeof STANCE_TIERS;
+
+/** Rank for the never-downgrade guard. */
+const TIER_RANK: Record<StanceTier, number> = { unconfirmed: 0, confirmed: 1, ruled: 2 };
+
+function tierOf(row: { evidenceGrade: string; confidenceWeight: number }): StanceTier {
+  if (row.evidenceGrade === "A" && row.confidenceWeight >= 1.0) return "ruled";
+  if (row.evidenceGrade === "A" && row.confidenceWeight >= 0.9) return "confirmed";
+  return "unconfirmed";
+}
+
+/**
+ * Structural client — satisfied by the real PrismaClient and by test fakes.
+ * Method syntax (not property arrows) so PrismaClient's precisely-typed
+ * delegates remain assignable under strictFunctionTypes (bivariance),
+ * mirroring material.ts's client types.
+ */
+export type StancePromotionClient = {
+  decisionPerspectiveProfile: {
+    findFirst(args: unknown): Promise<unknown>;
+  };
+  perspectiveMaterial: {
+    findUnique(args: unknown): Promise<unknown>;
+    upsert(args: unknown): Promise<unknown>;
+  };
+};
+
+export type PromoteStanceMaterialInput = {
+  db: StancePromotionClient;
+  organizationId: string;
+  /** The org-overlay stance page backing this material. */
+  wikiPageId: string;
+  slug: string;
+  /** One-line summary used on the material row. */
+  summary: string;
+  /** The decision classes this stance governs; first is primary. */
+  domainClasses: DecisionDomainClass[];
+  tier: Exclude<StanceTier, "unconfirmed">;
+  sourceType?: "stance" | "principle";
+};
+
+export type PromoteStanceMaterialResult =
+  | {
+      ok: true;
+      profileId: string;
+      /** materialIds written (or already at an equal/higher tier). */
+      materialIds: string[];
+      /** materialIds left untouched because they already sat at a higher tier. */
+      keptHigherTier: string[];
+    }
+  | { ok: false; error: "no-org-profile" };
+
+/** materialId scheme shared with seedOrgWwwdCorpus: primary keeps the legacy id. */
+export function stanceMaterialId(profileId: string, slug: string, domainClass: string, isPrimary: boolean): string {
+  return isPrimary ? `${profileId}:${slug}` : `${profileId}:${slug}:${domainClass}`;
+}
+
+/**
+ * Upsert the stance's material rows at the given tier across its class bundle.
+ * Idempotent; never downgrades (a `ruled` row survives a later `confirmed`
+ * write — a real human ruling outranks a settings confirmation).
+ */
+export async function promoteStanceMaterial(
+  input: PromoteStanceMaterialInput,
+): Promise<PromoteStanceMaterialResult> {
+  const profile = (await input.db.decisionPerspectiveProfile.findFirst({
+    where: {
+      ownerOrganizationId: input.organizationId,
+      kind: "organization",
+      status: "active",
+    },
+    select: { profileId: true, currentVersionId: true },
+    orderBy: { createdAt: "asc" },
+  })) as { profileId: string; currentVersionId: string | null } | null;
+
+  if (!profile) {
+    return { ok: false, error: "no-org-profile" };
+  }
+
+  const tier = STANCE_TIERS[input.tier];
+  const sourceType = input.sourceType ?? "stance";
+  const materialIds: string[] = [];
+  const keptHigherTier: string[] = [];
+
+  for (const [index, domainClass] of input.domainClasses.entries()) {
+    const materialId = stanceMaterialId(profile.profileId, input.slug, domainClass, index === 0);
+    materialIds.push(materialId);
+
+    const existing = (await input.db.perspectiveMaterial.findUnique({
+      where: { materialId },
+      select: { evidenceGrade: true, confidenceWeight: true },
+    })) as { evidenceGrade: string; confidenceWeight: number } | null;
+
+    if (existing && TIER_RANK[tierOf(existing)] > TIER_RANK[input.tier]) {
+      keptHigherTier.push(materialId);
+      continue;
+    }
+
+    const sourceRef = { wikiPageId: input.wikiPageId, slug: input.slug, organizationId: input.organizationId };
+    await input.db.perspectiveMaterial.upsert({
+      where: { materialId },
+      update: {
+        sourceType,
+        sourceRef,
+        scope: { domains: [domainClass] },
+        domainClass,
+        domains: [domainClass],
+        summary: input.summary,
+        freshness: "current",
+        evidenceGrade: tier.evidenceGrade,
+        confidenceWeight: tier.confidenceWeight,
+        reviewStatus: "approved",
+        promotionState: "promoted",
+        lastValidatedAt: new Date(),
+      },
+      create: {
+        materialId,
+        profileId: profile.profileId,
+        profileVersionId: profile.currentVersionId ?? `${profile.profileId}-v1`,
+        sourceType,
+        sourceRef,
+        scope: { domains: [domainClass] },
+        domainClass,
+        direction: "support",
+        domains: [domainClass],
+        freshness: "current",
+        evidenceGrade: tier.evidenceGrade,
+        confidenceWeight: tier.confidenceWeight,
+        reviewStatus: "approved",
+        promotionState: "promoted",
+        summary: input.summary,
+        lastValidatedAt: new Date(),
+      },
+    });
+  }
+
+  return { ok: true, profileId: profile.profileId, materialIds, keptHigherTier };
+}

--- a/apps/web/lib/wiki/business-stance.test.ts
+++ b/apps/web/lib/wiki/business-stance.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  DECISION_AREAS,
+  decisionAreaToDomainClass,
   buildStanceSlug,
   validateBusinessStance,
   BUSINESS_STANCE_SLUG_PREFIX,
@@ -60,5 +62,21 @@ describe("validateBusinessStance", () => {
     const result = validateBusinessStance({ title: "Refund policy", body: "yes" });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toMatch(/how your business decides/i);
+  });
+});
+
+describe("decision areas (BI-002DEB85)", () => {
+  it("maps every plain-language area to a valid domainClass, all four classes covered", () => {
+    const classes = DECISION_AREAS.map((a) => decisionAreaToDomainClass(a.key));
+    expect(classes).toEqual([
+      "risk-assessment",
+      "plan-readiness",
+      "professional-practice",
+      "architecture-tradeoff",
+    ]);
+  });
+
+  it("returns null for an unknown area key", () => {
+    expect(decisionAreaToDomainClass("nope")).toBeNull();
   });
 });

--- a/apps/web/lib/wiki/business-stance.ts
+++ b/apps/web/lib/wiki/business-stance.ts
@@ -6,8 +6,48 @@
 // module is pure: slug derivation + input validation, unit tested. The write
 // itself goes through `saveWikiOverlayEdit` (org overlay, draft by default).
 
+import type { DecisionDomainClass } from "@/lib/decision-perspective/types";
+
 /** WWWD stance overlay pages live under this slug prefix, mirroring the kernel. */
 export const BUSINESS_STANCE_SLUG_PREFIX = "stances";
+
+// ─── Decision areas (BI-002DEB85) ────────────────────────────────────────────
+// The plain-language buckets an owner picks when publishing a stance. Each maps
+// to the gate's domainClass so a published stance becomes GATE-LIVE material in
+// the right class — never exposing the internal taxonomy to the owner.
+
+export const DECISION_AREAS = [
+  {
+    key: "customers-and-money",
+    label: "Customers & money",
+    hint: "Refunds, goodwill, discounts, spending",
+    domainClass: "risk-assessment" as DecisionDomainClass,
+  },
+  {
+    key: "priorities-and-planning",
+    label: "Priorities & planning",
+    hint: "What we take on and in what order",
+    domainClass: "plan-readiness" as DecisionDomainClass,
+  },
+  {
+    key: "quality-and-craft",
+    label: "Quality & how we work",
+    hint: "Standards, rework, commitments",
+    domainClass: "professional-practice" as DecisionDomainClass,
+  },
+  {
+    key: "vendors-and-tools",
+    label: "Vendors & tools",
+    hint: "Suppliers, tooling, structural choices",
+    domainClass: "architecture-tradeoff" as DecisionDomainClass,
+  },
+] as const;
+
+export type DecisionAreaKey = (typeof DECISION_AREAS)[number]["key"];
+
+export function decisionAreaToDomainClass(key: string): DecisionDomainClass | null {
+  return DECISION_AREAS.find((a) => a.key === key)?.domainClass ?? null;
+}
 
 /**
  * Derive a stable, kernel-style slug from a stance title.

--- a/apps/web/lib/wiki/org-decision-capture.test.ts
+++ b/apps/web/lib/wiki/org-decision-capture.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildStandingStancePage,
+  deriveStandingTitle,
+  validateOrgDecisionCapture,
+} from "./org-decision-capture";
+
+describe("validateOrgDecisionCapture", () => {
+  it("rejects a missing interaction id and a too-short answer", () => {
+    expect(
+      validateOrgDecisionCapture({ interactionId: " ", answer: "Restore the account.", makeStanding: false }),
+    ).toEqual({ ok: false, error: "Missing decision id." });
+    const short = validateOrgDecisionCapture({ interactionId: "DI-1", answer: "ok", makeStanding: false });
+    expect(short.ok).toBe(false);
+  });
+
+  it("normalizes whitespace and optionality", () => {
+    const v = validateOrgDecisionCapture({
+      interactionId: " DI-C9F8B475B652 ",
+      answer: "  Restore access immediately and waive the lapsed period. ",
+      rationale: "  ",
+      makeStanding: true,
+      standingTitle: "",
+    });
+    expect(v).toEqual({
+      ok: true,
+      interactionId: "DI-C9F8B475B652",
+      answer: "Restore access immediately and waive the lapsed period.",
+      rationale: null,
+      makeStanding: true,
+      standingTitle: null,
+    });
+  });
+});
+
+describe("deriveStandingTitle", () => {
+  it("compacts whitespace and truncates long questions", () => {
+    expect(deriveStandingTitle("Should we\n  do X?")).toBe("Should we do X?");
+    const long = "A".repeat(120);
+    const title = deriveStandingTitle(long);
+    expect(title.length).toBeLessThanOrEqual(80);
+    expect(title.endsWith("…")).toBe(true);
+  });
+});
+
+describe("buildStandingStancePage", () => {
+  it("derives a stable ruling slug, includes question + answer, targets the decision's class", () => {
+    const page = buildStandingStancePage({
+      interactionId: "DI-C9F8B475B652",
+      question:
+        "A long-time customer subscription lapsed because of a billing error on our side. Restore and waive?",
+      domainClass: "risk-assessment",
+      answer: "Restore access immediately and waive the lapsed period — the customer bears no fault.",
+      rationale: "We absorb the cost of our own billing errors.",
+      standingTitle: null,
+    });
+
+    expect(page.slug).toBe("stances/ruling-di-c9f8b475b652");
+    expect(page.domainClasses).toEqual(["risk-assessment"]);
+    expect(page.body).toContain("Our standing answer: Restore access immediately");
+    expect(page.body).toContain("Why: We absorb the cost");
+    expect(page.body).toContain("DI-C9F8B475B652");
+    expect(page.abstract).toMatch(/^Restore access/);
+    expect(page.title.length).toBeLessThanOrEqual(80);
+  });
+
+  it("honors an explicit standing title", () => {
+    const page = buildStandingStancePage({
+      interactionId: "DI-1",
+      question: "Q?",
+      domainClass: "plan-readiness",
+      answer: "Split capacity between quality and the new offering.",
+      rationale: null,
+      standingTitle: "Quality first, growth in parallel",
+    });
+    expect(page.title).toBe("Quality first, growth in parallel");
+    expect(page.body).not.toContain("Why:");
+  });
+});

--- a/apps/web/lib/wiki/org-decision-capture.ts
+++ b/apps/web/lib/wiki/org-decision-capture.ts
@@ -1,0 +1,98 @@
+// Pure helpers for the WWWD org-decision capture loop (BI-9677364B,
+// EP-0AF96937 stance-onboarding design §10 Phase 3).
+//
+// When a business decision escalates/defers at the WWWD gate and the owner
+// answers it, the answer can optionally become a STANDING stance: a published
+// org-overlay page + a `ruled` (A/1.0) material in the decision's domainClass,
+// so the next equivalent decision resolves instead of escalating. This module
+// is pure — input validation + deriving the standing-stance page shape from a
+// DecisionInteraction — so the server action stays thin and the derivation is
+// unit-tested.
+
+import type { DecisionDomainClass } from "@/lib/decision-perspective/types";
+import { BUSINESS_STANCE_SLUG_PREFIX } from "./business-stance";
+
+export type OrgDecisionCaptureInput = {
+  interactionId: string;
+  /** The owner's answer — what the business should do. */
+  answer: string;
+  /** Optional why, kept alongside the answer on the capture + stance page. */
+  rationale?: string | null;
+  /** When true, the answer also becomes a standing stance (ruled material). */
+  makeStanding: boolean;
+  /** Optional plain title for the standing stance; derived when omitted. */
+  standingTitle?: string | null;
+};
+
+export type OrgDecisionCaptureValidation =
+  | { ok: true; interactionId: string; answer: string; rationale: string | null; makeStanding: boolean; standingTitle: string | null }
+  | { ok: false; error: string };
+
+export function validateOrgDecisionCapture(
+  input: OrgDecisionCaptureInput,
+): OrgDecisionCaptureValidation {
+  const interactionId = (input.interactionId ?? "").trim();
+  const answer = (input.answer ?? "").trim();
+  if (!interactionId) {
+    return { ok: false, error: "Missing decision id." };
+  }
+  if (answer.length < 8) {
+    return { ok: false, error: "Describe what the business should do in a sentence or two." };
+  }
+  return {
+    ok: true,
+    interactionId,
+    answer,
+    rationale: (input.rationale ?? "").trim() || null,
+    makeStanding: input.makeStanding === true,
+    standingTitle: (input.standingTitle ?? "").trim() || null,
+  };
+}
+
+export type StandingStancePage = {
+  slug: string;
+  title: string;
+  body: string;
+  abstract: string;
+  domainClasses: DecisionDomainClass[];
+};
+
+/** Compact a question into a readable stance title when none is supplied. */
+export function deriveStandingTitle(question: string): string {
+  const oneLine = question.replace(/\s+/g, " ").trim();
+  return oneLine.length > 80 ? `${oneLine.slice(0, 79).trimEnd()}…` : oneLine;
+}
+
+/**
+ * Shape the standing-stance page from the decision + the owner's ruling. The
+ * slug is keyed on the interaction id — stable, collision-free, and traceable
+ * back to the ledger row that produced it.
+ */
+export function buildStandingStancePage(input: {
+  interactionId: string;
+  question: string;
+  domainClass: DecisionDomainClass;
+  answer: string;
+  rationale: string | null;
+  standingTitle: string | null;
+}): StandingStancePage {
+  const title = input.standingTitle || deriveStandingTitle(input.question);
+  const body = [
+    `# ${title}`,
+    "",
+    `When this comes up: ${input.question.trim()}`,
+    "",
+    `Our standing answer: ${input.answer}`,
+    input.rationale ? `\nWhy: ${input.rationale}` : "",
+    "",
+    `Ruled by the owner on a real decision (${input.interactionId}). Coworkers treat this as settled doctrine for equivalent cases; adjust it in Decision governance if the business changes its mind.`,
+  ].join("\n");
+
+  return {
+    slug: `${BUSINESS_STANCE_SLUG_PREFIX}/ruling-${input.interactionId.toLowerCase()}`,
+    title,
+    body,
+    abstract: input.answer,
+    domainClasses: [input.domainClass],
+  };
+}

--- a/docs/superpowers/plans/2026-07-11-wwwd-stance-onboarding-build.md
+++ b/docs/superpowers/plans/2026-07-11-wwwd-stance-onboarding-build.md
@@ -7,7 +7,7 @@
   whole class bundles (never mixed tiers in a class from our own writes); re-seeding never
   downgrades an owner-confirmed or human-ruled material.
 
-## Phase 1 — Archetype stance-vector defaults + seeder redistribution (BI-70ADC71F) ✅ this PR
+## Phase 1 — Archetype stance-vector defaults + seeder redistribution (BI-70ADC71F) ✅ shipped (PR #2800)
 
 - `archetype-business-context.ts`: `STANCE_VECTOR_KEYS`, `StanceVectorDefault` (+ per-industry
   overrides with authority ceilings), `resolveStanceVectors` (pure; primary archetype only).
@@ -19,7 +19,7 @@
 - Result: fresh org = 9 pages / 12 materials over all 4 classes (plan-readiness 4,
   risk-assessment 3, professional-practice 3, architecture-tradeoff 2).
 
-## Phase 2 — Stance capture & promotion loop (BI-9677364B + BI-002DEB85) — next PR
+## Phase 2 — Stance capture & promotion loop (BI-9677364B + BI-002DEB85) ✅ this PR
 
 - `lib/decision-perspective/stance-promotion.ts`: `promoteStanceMaterial` — the ONE write path that
   makes a stance gate-live; tiers `confirmed` A/0.9 and `ruled` A/1.0; never downgrades.


### PR DESCRIPTION
## What

Phase 2 of the [stance-onboarding build plan](docs/superpowers/plans/2026-07-11-wwwd-stance-onboarding-build.md) (EP-0AF96937). Closes the two verified-open loop gaps: a founder answer to an escalated business decision taught the corpus **nothing** (capture was build-gated; `candidateMaterial` read nowhere), and an authored `/wiki/stance` draft never became gate-live.

- **`promoteStanceMaterial`** ([stance-promotion.ts](apps/web/lib/decision-perspective/stance-promotion.ts)) — the ONE write path that makes a stance gate-live; `confirmed` A/0.9 and `ruled` A/1.0 tiers from the design's confirmation ladder; **never downgrades** (a real human ruling outranks a settings confirmation).
- **JIT capture** ([org-decision-capture.ts](apps/web/lib/actions/org-decision-capture.ts)) — the owner answers an unresolved `/coworker-business` decision from a new **'Waiting on your call'** section on `/wiki/review`; with the pre-checked 'remember this' toggle the ruling becomes a published+embedded `stances/ruling-<id>` page + `ruled` material in the decision's domainClass, so the equivalent decision resolves next time.
- **Publish = gate-live** (`publishBusinessStance`) — the stance form gains a plain-language decision-area picker (4 areas → the 4 domain classes) and a Publish button: publish + embed + owner-confirmed material. Drafts stay inert.

Domain errors returned as values, never thrown (use-server rule). Simulation-backed tier table in `stance-promotion.test.ts`.

## Testing

- New suites: stance-promotion (7), org-decision-capture (5), decision-areas (2) + existing wiki/review suites — green.
- Local merged-code pregate green.

Epic EP-0AF96937 · BI-9677364B, BI-002DEB85

UX-Fit-Decision: DI-4D0D0C120F45 (inline-cards-on-review, high confidence, margin 2.476, human_cognitive_load-weighted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)