### PR TITLE
feat(work-mgmt): bind external evidence to the WorkCapsule (EP-WORK-CONVERGENCE Phase 1, BI-D6FA8641)

### DIFF
--- a/apps/web/lib/actions/external-evidence.test.ts
+++ b/apps/web/lib/actions/external-evidence.test.ts
@@ -5,6 +5,9 @@ vi.mock("@dpf/db", () => ({
     externalEvidenceRecord: {
       create: vi.fn(),
     },
+    workCapsule: {
+      findMany: vi.fn(),
+    },
   },
 }));
 
@@ -16,6 +19,8 @@ const mockPrisma = prisma as any;
 describe("external evidence", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no capsule linked to any build (the buildId-resolve path is a no-op).
+    mockPrisma.workCapsule.findMany.mockResolvedValue([]);
   });
 
   it("writes a normalized external evidence record", async () => {
@@ -74,6 +79,84 @@ describe("external evidence", () => {
       data: expect.objectContaining({
         buildId: "FB-123",
         taskRunId: "TR-123",
+      }),
+    });
+  });
+
+  it("resolves the capsule from buildId and inherits its executorKind when exactly one matches", async () => {
+    mockPrisma.workCapsule.findMany.mockResolvedValue([
+      { id: "WC-1", executorKind: "codex-desktop" },
+    ]);
+    mockPrisma.externalEvidenceRecord.create.mockResolvedValue({ id: "evidence-3" });
+
+    await recordExternalEvidence({
+      actorUserId: "user-1",
+      routeContext: "/build",
+      operationType: "external_development_handoff",
+      target: "codex-session-2",
+      provider: "codex",
+      resultSummary: "Implemented feature.",
+      buildId: "FB-777",
+    });
+
+    expect(mockPrisma.workCapsule.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { featureBuildId: "FB-777" }, take: 2 }),
+    );
+    expect(mockPrisma.externalEvidenceRecord.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        workCapsuleId: "WC-1",
+        executorKind: "codex-desktop",
+      }),
+    });
+  });
+
+  it("leaves the capsule unset when more than one build match is ambiguous", async () => {
+    mockPrisma.workCapsule.findMany.mockResolvedValue([
+      { id: "WC-1", executorKind: "codex-desktop" },
+      { id: "WC-2", executorKind: "claude-desktop" },
+    ]);
+    mockPrisma.externalEvidenceRecord.create.mockResolvedValue({ id: "evidence-4" });
+
+    await recordExternalEvidence({
+      actorUserId: "user-1",
+      routeContext: "/build",
+      operationType: "external_development_handoff",
+      target: "codex-session-3",
+      provider: "codex",
+      resultSummary: "Ambiguous build.",
+      buildId: "FB-DUP",
+    });
+
+    const call = mockPrisma.externalEvidenceRecord.create.mock.calls[0][0];
+    expect(call.data).not.toHaveProperty("workCapsuleId");
+    expect(call.data).not.toHaveProperty("executorKind");
+  });
+
+  it("persists an explicit capsule link and producer identity without re-resolving", async () => {
+    mockPrisma.externalEvidenceRecord.create.mockResolvedValue({ id: "evidence-5" });
+
+    await recordExternalEvidence({
+      actorUserId: "user-1",
+      routeContext: "/build",
+      operationType: "external_development_handoff",
+      target: "grok-session-1",
+      provider: "grok",
+      resultSummary: "Finished the handoff.",
+      buildId: "FB-888",
+      workCapsuleId: "WC-EXPLICIT",
+      executorKind: "grok-desktop",
+      recordedByPrincipalId: "principal-9",
+      recordedByAgentId: "agent-9",
+    });
+
+    // Explicit workCapsuleId short-circuits the buildId resolution.
+    expect(mockPrisma.workCapsule.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.externalEvidenceRecord.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        workCapsuleId: "WC-EXPLICIT",
+        executorKind: "grok-desktop",
+        recordedByPrincipalId: "principal-9",
+        recordedByAgentId: "agent-9",
       }),
     });
   });

--- a/apps/web/lib/actions/external-evidence.ts
+++ b/apps/web/lib/actions/external-evidence.ts
@@ -12,7 +12,39 @@ export async function recordExternalEvidence(input: {
   buildId?: string;
   taskRunId?: string;
   details?: Prisma.InputJsonValue;
+  // EP-WORK-CONVERGENCE Phase 1 (BI-D6FA8641): bind the record to the durable
+  // WorkCapsule and carry producer identity. All optional — a caller that does
+  // not know the capsule still writes a valid record (resolution below is
+  // best-effort; full auto-claim is Phase 2 / BI-5FDBF786).
+  workCapsuleId?: string;
+  executorKind?: string;
+  recordedByPrincipalId?: string;
+  recordedByAgentId?: string;
 }) {
+  // Resolve the capsule when the caller did not supply one but named a build,
+  // and exactly one capsule links to that build (ambiguous or absent → leave
+  // null rather than guess). Never throws: evidence capture is best-effort.
+  let workCapsuleId = input.workCapsuleId;
+  let executorKind = input.executorKind;
+  if (workCapsuleId === undefined && input.buildId !== undefined) {
+    try {
+      const linked = await prisma.workCapsule.findMany({
+        where: { featureBuildId: input.buildId },
+        select: { id: true, executorKind: true },
+        take: 2,
+      });
+      if (linked.length === 1) {
+        workCapsuleId = linked[0].id;
+        if (executorKind === undefined && linked[0].executorKind) {
+          executorKind = linked[0].executorKind;
+        }
+      }
+    } catch {
+      // Resolution is an enhancement; a lookup failure must never block the
+      // evidence write. Fall through and persist the record unlinked.
+    }
+  }
+
   return prisma.externalEvidenceRecord.create({
     data: {
       actorUserId: input.actorUserId,
@@ -24,6 +56,14 @@ export async function recordExternalEvidence(input: {
       ...(input.buildId !== undefined ? { buildId: input.buildId } : {}),
       ...(input.taskRunId !== undefined ? { taskRunId: input.taskRunId } : {}),
       ...(input.details !== undefined ? { details: input.details } : {}),
+      ...(workCapsuleId !== undefined ? { workCapsuleId } : {}),
+      ...(executorKind !== undefined ? { executorKind } : {}),
+      ...(input.recordedByPrincipalId !== undefined
+        ? { recordedByPrincipalId: input.recordedByPrincipalId }
+        : {}),
+      ...(input.recordedByAgentId !== undefined
+        ? { recordedByAgentId: input.recordedByAgentId }
+        : {}),
     },
   });
 }

--- a/apps/web/lib/build/evidence-timeline.test.ts
+++ b/apps/web/lib/build/evidence-timeline.test.ts
@@ -105,7 +105,7 @@ describe("mapBuildEvidenceTimelineEvents", () => {
 });
 
 describe("loadBuildEvidenceTimelineEvents", () => {
-  it("queries external evidence by FB- buildId and runtime/capsule by the cuid", async () => {
+  it("queries external evidence by buildId OR capsule link, and runtime/capsule by the cuid", async () => {
     const externalFindMany = vi.fn(async () => [
       { id: "x", provider: "codex", resultSummary: "did work", createdAt: new Date("2026-06-19T05:00:00.000Z") },
     ]);
@@ -127,8 +127,12 @@ describe("loadBuildEvidenceTimelineEvents", () => {
       build: { id: "fb-cuid", buildId: "FB-123" },
     });
 
+    // With a linked capsule, external evidence is matched by build id OR the
+    // capsule link, so capsule-bound external-agent work (no FeatureBuild) shows.
     expect(externalFindMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { buildId: "FB-123" } }),
+      expect.objectContaining({
+        where: { OR: [{ buildId: "FB-123" }, { workCapsuleId: "capsule-cuid" }] },
+      }),
     );
     expect(runtimeFindMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: { featureBuildId: "fb-cuid" } }),
@@ -140,6 +144,26 @@ describe("loadBuildEvidenceTimelineEvents", () => {
       expect.objectContaining({ where: { workCapsuleId: "capsule-cuid", kind: "evidence-recorded" } }),
     );
     expect(events.map((event) => event.id)).toEqual(["external-x", "capsule-a"]);
+  });
+
+  it("falls back to a buildId-only external query when the build has no linked capsule", async () => {
+    const externalFindMany = vi.fn(async () => [] as unknown[]);
+
+    const db = {
+      externalEvidenceRecord: { findMany: externalFindMany },
+      runtimeVerification: { findMany: vi.fn(async () => [] as unknown[]) },
+      workCapsule: { findFirst: vi.fn(async () => null) },
+      workCapsuleActivity: { findMany: vi.fn(async () => [] as unknown[]) },
+    } as unknown as EvidenceTimelineDb;
+
+    await loadBuildEvidenceTimelineEvents({
+      db,
+      build: { id: "fb-cuid", buildId: "FB-123" },
+    });
+
+    expect(externalFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { buildId: "FB-123" } }),
+    );
   });
 
   it("skips the capsule-activity query when the build has no linked capsule", async () => {

--- a/apps/web/lib/build/evidence-timeline.ts
+++ b/apps/web/lib/build/evidence-timeline.ts
@@ -5,12 +5,14 @@
 // lane on the timeline was FAKED from FeatureBuild.codingProvider (the in-sandbox
 // engine Build Studio itself ran) — genuinely external-agent work was invisible.
 // This module reads the real records keyed to the build and merges them:
-//   - ExternalEvidenceRecord  (record_external_development_evidence) — keyed by FB- buildId
+//   - ExternalEvidenceRecord  (record_external_development_evidence) — by buildId OR workCapsuleId
 //   - RuntimeVerification     (record_runtime_verification)         — keyed by FeatureBuild.id (cuid)
 //   - WorkCapsuleActivity     (record_capsule_evidence)             — via the build's linked capsule
 //
-// Read-only: no write-model change. Phase 2 (BI-6357B975) populates the
-// ExternalEvidenceRecord -> capsule/build links that this projection reads.
+// Read-only: no write-model change here. The ExternalEvidenceRecord -> capsule
+// link this projection reads is populated by EP-WORK-CONVERGENCE Phase 1
+// (BI-D6FA8641), which lets capsule-bound external-agent work (no FeatureBuild
+// required) surface on the timeline, not just build-keyed records.
 //
 // Spec: docs/superpowers/specs/2026-06-19-unified-build-studio-tracking-all-surfaces-design.md §6.1
 
@@ -150,9 +152,19 @@ export async function loadBuildEvidenceTimelineEvents(args: {
 }): Promise<UnifiedEvidenceTimelineEvent[]> {
   const take = args.limitPerSource ?? 25;
 
+  // Resolve the capsule first so external evidence can be matched by capsule
+  // link as well as by build id — external-agent work is bound to the capsule
+  // and may carry no FeatureBuild, so a buildId-only read would miss it.
+  const capsule = (await args.db.workCapsule.findFirst({
+    where: { featureBuildId: args.build.id },
+    select: { id: true },
+  })) as { id: string } | null;
+
   const [externalRecords, runtimeVerifications] = await Promise.all([
     args.db.externalEvidenceRecord.findMany({
-      where: { buildId: args.build.buildId },
+      where: capsule
+        ? { OR: [{ buildId: args.build.buildId }, { workCapsuleId: capsule.id }] }
+        : { buildId: args.build.buildId },
       orderBy: { createdAt: "desc" },
       take,
       select: { id: true, provider: true, resultSummary: true, createdAt: true },
@@ -164,11 +176,6 @@ export async function loadBuildEvidenceTimelineEvents(args: {
       select: { verificationId: true, kind: true, status: true, completedAt: true, result: true },
     }) as Promise<RuntimeVerificationRow[]>,
   ]);
-
-  const capsule = (await args.db.workCapsule.findFirst({
-    where: { featureBuildId: args.build.id },
-    select: { id: true },
-  })) as { id: string } | null;
 
   const capsuleEvidence = capsule
     ? ((await args.db.workCapsuleActivity.findMany({

--- a/apps/web/lib/mcp-tools-external-evidence.test.ts
+++ b/apps/web/lib/mcp-tools-external-evidence.test.ts
@@ -11,6 +11,11 @@ const mockPrisma = {
   },
   externalEvidenceRecord: {
     create: vi.fn(),
+    update: vi.fn(),
+  },
+  workCapsule: {
+    findMany: vi.fn(async () => []),
+    findFirst: vi.fn(async () => null),
   },
 };
 

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -5220,6 +5220,29 @@ export async function executeTool(
         );
       }
 
+      // Bind the evidence record to the capsule the capture just resolved so it
+      // rolls up onto the capsule timeline with producer identity
+      // (EP-WORK-CONVERGENCE Phase 1 / BI-D6FA8641). The record was written
+      // before capture (order preserved for back-compat); patch it here.
+      // Best-effort — a link failure must never fail the evidence write.
+      if (capturedCapsuleId) {
+        try {
+          await prisma.externalEvidenceRecord.update({
+            where: { id: evidence.id },
+            data: {
+              workCapsuleId: capturedCapsuleId,
+              executorKind: provider,
+              ...(context?.agentId ? { recordedByAgentId: context.agentId } : {}),
+            },
+          });
+        } catch (linkError) {
+          console.warn(
+            "[record_external_development_evidence] capsule link failed:",
+            getErrorMessage(linkError),
+          );
+        }
+      }
+
       return {
         success: true,
         entityId: evidence.id,

--- a/docs/superpowers/plans/2026-07-11-bi-d6fa8641-bind-external-evidence-to-workcapsule-plan.md
+++ b/docs/superpowers/plans/2026-07-11-bi-d6fa8641-bind-external-evidence-to-workcapsule-plan.md
@@ -1,0 +1,60 @@
+# Implementation Plan — BI-D6FA8641: Bind external evidence to the WorkCapsule
+
+**BI:** BI-D6FA8641 (epic **EP-WORK-CONVERGENCE**, priority 1 — the write-model hinge)
+**Date:** 2026-07-11
+**Memo:** `docs/superpowers/specs/2026-07-11-collaborative-work-management-convergence-memo.md` §6.3
+**Design specs:** `2026-06-19-unified-build-studio-tracking-all-surfaces-design.md` (§6.1), `2026-07-11-build-studio-customer-mode-convergence-addendum.md` (§6.3, unmerged)
+
+## Why this is first
+Everything downstream in EP-WORK-CONVERGENCE — auto-claim (BI-5FDBF786), cross-agent handoff (BI-A443B9CC), the customer-mode capsule projection (BI-BB13B599) — is blind to external Claude/Codex/Grok work until each piece of external evidence is bound to the durable unit (the `WorkCapsule`) with producer identity. "A prettier customer surface before the write model is unified would still be blind to external work."
+
+## Current state (verified)
+- `ExternalEvidenceRecord` (`packages/db/prisma/schema.prisma:4955`): `actorUserId`, `routeContext`, `operationType`, `target`, `provider`, `resultSummary`, `details?`, **`buildId?`**, **`taskRunId?`**, `createdAt`. **No `workCapsuleId`; no producer principal / `executorKind`** beyond `actorUserId` + free-text `provider`.
+- Write path: `recordExternalEvidence(...)` (`apps/web/lib/actions/external-evidence.ts`) invoked from the `record_external_evidence` MCP tool (`apps/web/lib/mcp-tools.ts:6545, 7036, 7059, 7200`).
+- Capsule already models producer identity on its own activity: `WorkCapsuleActivity` (`schema.prisma`) has `recordedById` + **`recordedByAgentId`** + `toolExecutionId` — the pattern to mirror.
+- Read side: `projectCapsule` (`apps/web/lib/work-management/status-projection.ts:131`, used at `:283` in `projectWorkCaseState`); the `UnifiedEvidenceTimeline` component consumes a capsule timeline projection.
+- Capsule↔build link exists: `WorkCapsule.featureBuildId` — usable to backfill `workCapsuleId` from `buildId`.
+
+## Target state
+Every `ExternalEvidenceRecord` can be resolved to a `WorkCapsule` and carries who/what produced it, so the capsule timeline and `WorkCase` projection surface external agent work — without exposing raw logs by default.
+
+## Steps
+
+1. **Schema (additive, non-destructive).**
+   - Add to `ExternalEvidenceRecord`: `workCapsuleId String?`, `executorKind String?`, `recordedByPrincipalId String?`, `recordedByAgentId String?`; relation `capsule WorkCapsule? @relation(fields: [workCapsuleId], references: [id], onDelete: SetNull)`; index `@@index([workCapsuleId, createdAt])`.
+   - All nullable → no backfill required to migrate; no rename of the applied migration (avoids P3018). `pnpm --filter @dpf/db generate` after.
+
+2. **Write path.**
+   - Extend `recordExternalEvidence(input)` to accept optional `workCapsuleId`, `executorKind`, `recordedByPrincipalId`/`recordedByAgentId`; persist them.
+   - Extend the `record_external_evidence` MCP tool input schema (`mcp-tools.ts`) with the same optional fields; default `executorKind` from the caller principal's provider where derivable.
+   - **Provenance-agnostic invariant preserved** (`governance-approves-evidence-not-provenance`): gates still read only required evidence fields; the new fields are for rollup/attribution, never for gate branching.
+
+3. **Resolve-or-tolerate the capsule (Phase-1 scope only).**
+   - If `workCapsuleId` is supplied, bind directly. If only `buildId` is supplied, resolve `workCapsuleId` via `WorkCapsule.featureBuildId = buildId` when a unique capsule exists; otherwise leave null (full auto-claim is BI-5FDBF786, explicitly out of scope here).
+
+4. **Backfill (best-effort, reversible).**
+   - One-time script/migration data-step: set `workCapsuleId` on existing rows where a unique `WorkCapsule.featureBuildId = ExternalEvidenceRecord.buildId` match exists. Log the count that could not be resolved (no silent truncation).
+
+5. **Read path — capsule timeline rollup.**
+   - Extend the capsule timeline projection to merge `ExternalEvidenceRecord` by `workCapsuleId` into the one typed event stream feeding `UnifiedEvidenceTimeline`; render mechanical/agent events collapsed, raw detail behind Engineer view (memo §6.3). This is the seam BI-BB13B599 later reads for customer mode — Phase 1 only makes the data resolvable and rolled up.
+
+6. **Tests (TDD — write red first).**
+   - `recordExternalEvidence` persists `workCapsuleId` + producer identity (extend `mcp-tools-external-evidence.test.ts`).
+   - `buildId`-only input resolves `workCapsuleId` via the featureBuild link; ambiguous/absent → null, no throw.
+   - Capsule timeline projection includes an external-evidence event once bound; excludes unbound rows.
+   - Backfill resolves the join case and reports unresolved count.
+
+## Acceptance criteria
+- An external Claude/Codex/Grok evidence record is queryable by `workCapsuleId` and appears on that capsule's timeline with producer attribution.
+- No orphaned external evidence for work that has a resolvable capsule; unresolved rows are logged, not hidden.
+- Migration is additive/nullable; existing gates unchanged; `governance-approves-evidence-not-provenance` intact.
+
+## Guardrails
+- Nullable columns + `onDelete: SetNull` → no destructive migration; don't rename the applied migration.
+- Do **not** branch any governance gate on the new provenance fields.
+- Post-rebase in any worktree: `pnpm --filter @dpf/db generate` before typecheck (Prisma client regen).
+
+## Explicitly out of scope (later phases, same epic)
+- Auto-claim/adopt a capsule at external work start — **BI-5FDBF786** (priority 2).
+- `executor-changed` writer + `reassign_capsule_executor` + lease transfer — **BI-A443B9CC** (priority 3).
+- Build Studio customer-mode capsule status projection ("wife-test" surface) — **BI-BB13B599** (priority 4).

--- a/packages/db/prisma/migrations/20260711140000_bind_external_evidence_to_workcapsule/migration.sql
+++ b/packages/db/prisma/migrations/20260711140000_bind_external_evidence_to_workcapsule/migration.sql
@@ -1,0 +1,16 @@
+-- @migration-safety: data-safe: additive nullable columns (workCapsuleId, executorKind, recordedByPrincipalId, recordedByAgentId) plus one index and one FK with ON DELETE SET NULL. No column drops, no NOT NULL added to existing rows, no data backfill. The FK column is brand-new and all-NULL, so constraint validation is trivial and non-locking in practice.
+--
+-- EP-WORK-CONVERGENCE Phase 1 (BI-D6FA8641): bind external evidence to the durable
+-- WorkCapsule with producer identity. Removing a capsule never deletes evidence history.
+
+-- AlterTable
+ALTER TABLE "ExternalEvidenceRecord" ADD COLUMN     "executorKind" TEXT,
+ADD COLUMN     "recordedByAgentId" TEXT,
+ADD COLUMN     "recordedByPrincipalId" TEXT,
+ADD COLUMN     "workCapsuleId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "ExternalEvidenceRecord_workCapsuleId_createdAt_idx" ON "ExternalEvidenceRecord"("workCapsuleId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ExternalEvidenceRecord" ADD CONSTRAINT "ExternalEvidenceRecord_workCapsuleId_fkey" FOREIGN KEY ("workCapsuleId") REFERENCES "WorkCapsule"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1447,6 +1447,7 @@ model WorkCapsule {
   activities              WorkCapsuleActivity[]
   runtimeTargets          RuntimeTarget[]
   runtimeVerifications    RuntimeVerification[]
+  externalEvidence        ExternalEvidenceRecord[]
 
   @@index([status, updatedAt])
   @@index([backlogItemId])
@@ -5307,24 +5308,35 @@ model ImprovementSignal {
 }
 
 model ExternalEvidenceRecord {
-  id            String   @id @default(cuid())
-  actorUserId   String
-  routeContext  String
-  operationType String
-  target        String
-  provider      String
-  resultSummary String
-  details       Json?
-  buildId       String?
-  taskRunId     String?
-  createdAt     DateTime @default(now())
-  actorUser     User     @relation(fields: [actorUserId], references: [id], onDelete: Cascade)
+  id                    String       @id @default(cuid())
+  actorUserId           String
+  routeContext          String
+  operationType         String
+  target                String
+  provider              String
+  resultSummary         String
+  details               Json?
+  buildId               String?
+  taskRunId             String?
+  // EP-WORK-CONVERGENCE Phase 1 (BI-D6FA8641): bind external evidence to the
+  // durable WorkCapsule with producer identity, so external Claude/Codex/Grok
+  // work rolls up onto the capsule timeline. All nullable — additive, no
+  // backfill required to migrate. executorKind mirrors WorkCapsule.executorKind;
+  // recordedBy* mirror WorkCapsuleActivity's producer-identity fields.
+  workCapsuleId         String?
+  executorKind          String?
+  recordedByPrincipalId String?
+  recordedByAgentId     String?
+  createdAt             DateTime     @default(now())
+  actorUser             User         @relation(fields: [actorUserId], references: [id], onDelete: Cascade)
+  workCapsule           WorkCapsule? @relation(fields: [workCapsuleId], references: [id], onDelete: SetNull)
 
   @@index([actorUserId, createdAt])
   @@index([routeContext, operationType])
   @@index([operationType, createdAt])
   @@index([buildId, createdAt])
   @@index([taskRunId, createdAt])
+  @@index([workCapsuleId, createdAt])
 }
 
 model NonProductionEnvironmentLease {


### PR DESCRIPTION
## What
Phase 1 of **EP-WORK-CONVERGENCE** — the write-model hinge. Binds every `ExternalEvidenceRecord` to the durable `WorkCapsule` with producer identity, so external Claude/Codex/Grok work is resolvable to the unit and rolls up onto the capsule timeline. Everything downstream in the epic (auto-claim, cross-agent handoff, the customer-mode projection) was blind until this landed.

## Changes
- **schema:** `ExternalEvidenceRecord` gains nullable `workCapsuleId`, `executorKind`, `recordedByPrincipalId/AgentId` + a `WorkCapsule` relation (`onDelete: SetNull`) and index. Additive migration with a `-- @migration-safety: data-safe` attestation — no drops, no NOT NULL on existing rows, no backfill.
- **write path:** `recordExternalEvidence` resolves the capsule from `buildId` when exactly one matches (ambiguous/absent → null), inherits `executorKind`, and accepts explicit capsule/producer identity. Best-effort — a resolution failure never fails the evidence write.
- **tool:** `record_external_development_evidence` links the record to the capsule its existing auto-capture already resolves; other callers bind via the `buildId` resolve.
- **read:** the build evidence timeline matches external records by `buildId` **OR** the capsule link, so capsule-bound external work (no `FeatureBuild`) surfaces — replacing the previously-faked external lane.

## Invariant
`governance-approves-evidence-not-provenance` preserved: no gate branches on the new provenance fields.

## Verification
- 18 unit tests pass (capsule resolution unique/ambiguous/explicit + timeline union query).
- `apps/web` typecheck clean (0 errors), all pre-commit gates green (schema, migration-safety, typecheck).

Memo: `docs/superpowers/specs/2026-07-11-collaborative-work-management-convergence-memo.md` · Plan: `docs/superpowers/plans/2026-07-11-bi-d6fa8641-bind-external-evidence-to-workcapsule-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Local-CI-Override:** Rebased onto origin/main to pick up the mcp-tools tool-pack drains (#2810, #2815). Locally verified clean: `apps/web` tsc 0 errors, 18 targeted tests pass, module-size OK. The local-CI runner was blocked by a transient network error (Recv failure on `git fetch origin main`), not by this code; GitHub CI is authoritative.