### PR TITLE
fix(coworker): let advise-mode coworkers delegate to named peers (BI-7EB4AE2C)

### DIFF
--- a/apps/web/lib/actions/coworker-tool-filter.test.ts
+++ b/apps/web/lib/actions/coworker-tool-filter.test.ts
@@ -15,6 +15,9 @@ const READ = tool({ name: "list_backlog_items" });
 const WRITE = tool({ name: "create_backlog_item", sideEffect: true });
 const PROVISION = tool({ name: "manage_coworker_tool_grant", sideEffect: true });
 const ARTIFACT = tool({ name: "save_marketing_review", sideEffect: true, coworkerArtifact: true });
+// Coworker→coworker delegation: side-effecting but advise-safe coordination.
+const REQUEST_PEER = tool({ name: "request_coworker", sideEffect: true, adviseCoordination: true });
+const SUMMON_PEER = tool({ name: "summon_coworker", sideEffect: true, adviseCoordination: true });
 
 const MERGED = [READ, WRITE, PROVISION, ARTIFACT];
 
@@ -22,6 +25,26 @@ describe("filterToolsForCoworkerRuntime — advise rule", () => {
   it("strips side-effect tools but keeps reads and coworker artifacts in advise mode", () => {
     const kept = filterToolsForCoworkerRuntime(MERGED, { coworkerMode: "advise", activeBuildPhase: null }).map((t) => t.name);
     expect(kept).toEqual(["list_backlog_items", "save_marketing_review"]);
+  });
+
+  it("keeps coworker→coworker delegation in advise mode but still strips destructive writes", () => {
+    // BI-7EB4AE2C: an advise-mode coworker must be able to hand a scoped sub-task
+    // to a named peer (coordination), while a genuinely destructive write stays muzzled.
+    const merged = [READ, WRITE, REQUEST_PEER, SUMMON_PEER];
+    const kept = filterToolsForCoworkerRuntime(merged, {
+      coworkerMode: "advise",
+      activeBuildPhase: null,
+    }).map((t) => t.name);
+    expect(kept).toContain("request_coworker");
+    expect(kept).toContain("summon_coworker");
+    // The destructive write is still stripped — the exemption is targeted, not blanket.
+    expect(kept).not.toContain("create_backlog_item");
+    expect(kept).toEqual(["list_backlog_items", "request_coworker", "summon_coworker"]);
+  });
+
+  it("does not list delegation tools as advise-held-back (they are not muzzled)", () => {
+    const held = adviseHeldBackTools([WRITE, REQUEST_PEER, SUMMON_PEER]).map((t) => t.name);
+    expect(held).toEqual(["create_backlog_item"]);
   });
 
   it("keeps everything in act mode", () => {

--- a/apps/web/lib/actions/coworker-tool-filter.ts
+++ b/apps/web/lib/actions/coworker-tool-filter.ts
@@ -23,10 +23,17 @@ const TERMINAL_BUILD_TOOLS = new Set<string>([
  *
  * Advise mode is the default for non-/build routes. It strips side-effect
  * tools so the coworker cannot act on the outside world without explicit
- * "act" intent. Tools flagged as `coworkerArtifact` persist the coworker's
- * own recommendation as an internal artifact (e.g. `save_marketing_review`)
- * and stay available — saving the advice the user explicitly asked for is
- * part of the advisory workflow, not an external action.
+ * "act" intent. Two classes of side-effect tool are exempt because they are
+ * not actions ON the outside world:
+ *   - `coworkerArtifact` persists the coworker's own recommendation as an
+ *     internal artifact (e.g. `save_marketing_review`) — saving the advice the
+ *     user explicitly asked for is part of the advisory workflow.
+ *   - `adviseCoordination` hands a scoped sub-task to a NAMED peer coworker
+ *     (`request_coworker` / `summon_coworker`) — routing work to the right
+ *     teammate is coordination, not an external action, and is exactly how an
+ *     advisor gets the user a better answer. Without this exemption an
+ *     advise-mode coworker can name the right peer but the delegation is
+ *     muzzled, dead-ending the sub-task back to the human (BI-7EB4AE2C).
  *
  * Build-phase filtering only applies inside an active build. Terminal builds
  * keep only navigation/inspection tools so the coworker can help the operator
@@ -40,7 +47,13 @@ export function filterToolsForCoworkerRuntime(
   input: { coworkerMode?: "advise" | "act"; activeBuildPhase: string | null },
 ): ToolDefinition[] {
   return tools.filter((tool) => {
-    if (input.coworkerMode === "advise" && tool.sideEffect && !tool.coworkerArtifact) return false;
+    if (
+      input.coworkerMode === "advise" &&
+      tool.sideEffect &&
+      !tool.coworkerArtifact &&
+      !tool.adviseCoordination
+    )
+      return false;
     if (input.activeBuildPhase) {
       if (TERMINAL_BUILD_PHASES.has(input.activeBuildPhase)) {
         return TERMINAL_BUILD_TOOLS.has(tool.name);
@@ -55,9 +68,12 @@ export function filterToolsForCoworkerRuntime(
 
 /**
  * The tools that Advise mode holds back — the exact set `filterToolsForCoworkerRuntime`
- * removes for its `coworkerMode === "advise"` rule (side-effecting, non-artifact).
- * The coworker HOLDS authority for these (they passed grant + capability gating to
- * reach the merged set); advise mode is disabling them, not a missing permission.
+ * removes for its `coworkerMode === "advise"` rule (side-effecting, non-artifact,
+ * non-coordination). The coworker HOLDS authority for these (they passed grant +
+ * capability gating to reach the merged set); advise mode is disabling them, not a
+ * missing permission. Must mirror the filter's exemptions exactly — otherwise the
+ * prompt would tell the user "switch to Act mode and I can delegate" when delegation
+ * (`adviseCoordination`) already works in advise mode.
  *
  * Surfaced into the coworker's prompt so it can name the specific enabler ("switch
  * me to Act mode and I can …") per the limitation-response contract, instead of
@@ -66,5 +82,7 @@ export function filterToolsForCoworkerRuntime(
  * Pass the FULL merged (authorized) tool set — not the already-filtered set.
  */
 export function adviseHeldBackTools(mergedTools: ToolDefinition[]): ToolDefinition[] {
-  return mergedTools.filter((tool) => tool.sideEffect && !tool.coworkerArtifact);
+  return mergedTools.filter(
+    (tool) => tool.sideEffect && !tool.coworkerArtifact && !tool.adviseCoordination,
+  );
 }

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -144,6 +144,21 @@ export type ToolDefinition = {
    * memory; this flag only exempts it from the advise-mode runtime filter.
    */
   coworkerArtifact?: boolean;
+  /**
+   * Tool hands a scoped sub-task to a NAMED peer coworker (delegation /
+   * summon). Like `coworkerArtifact`, this is an advise-safe exemption: it
+   * remains `sideEffect: true` for MCP annotations and tool-execution memory,
+   * but is NOT stripped by the advise-mode runtime filter. Rationale
+   * (BI-7EB4AE2C): naming the right peer and handing off a scoped sub-task —
+   * with a visible handoff card the user sees inline — is COORDINATION, not an
+   * irreversible action on the outside world. The advise/act line guards
+   * against acting externally; routing work to a teammate is how an advisor
+   * gets the user a better answer. Without this flag an advise-mode coworker
+   * can NAME the right peer but the delegation is muzzled, so the sub-task
+   * dead-ends back to the human. Genuinely destructive writes stay
+   * `sideEffect: true` WITHOUT this flag and remain stripped in advise mode.
+   */
+  adviseCoordination?: boolean;
   /** When set, tool is only available during these build phases.
    *  Null/undefined = available in all phases (non-build tools). */
   buildPhases?: BuildPhaseTag[] | null;
@@ -3299,6 +3314,11 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
     requiredCapability: null,
     sideEffect: true,
+    // Delegation is advise-safe coordination — an advisor may route a scoped
+    // sub-task to a named peer with a visible handoff without leaving advise
+    // mode. Kept sideEffect:true for annotations; adviseCoordination exempts it
+    // from the advise-mode runtime filter (BI-7EB4AE2C).
+    adviseCoordination: true,
   },
   {
     name: "summon_coworker",
@@ -3315,6 +3335,11 @@ export const PLATFORM_TOOLS: ToolDefinition[] = [
     },
     requiredCapability: null,
     sideEffect: true,
+    // Bringing a named peer into the conversation is advise-safe coordination —
+    // the advisor decides which teammate to pull in; the handoff is visible and
+    // reversible. Kept sideEffect:true for annotations; adviseCoordination
+    // exempts it from the advise-mode runtime filter (BI-7EB4AE2C).
+    adviseCoordination: true,
   },
   {
     name: "trigger_contributor_inventory_sync",


### PR DESCRIPTION
## Problem (BI-7EB4AE2C)

Advise-mode AI coworkers can NAME the right peer to hand a sub-task to, but the delegation was stripped so it dead-ended back to the human.

`request_coworker` and `summon_coworker` are `sideEffect: true`. The authoritative coworker advise-mode filter — `filterToolsForCoworkerRuntime` in `apps/web/lib/actions/coworker-tool-filter.ts` — strips **every** side-effect tool in advise mode (the `getAvailableTools` path deliberately skips mode-filtering and applies it here on the merged set). So an advise-mode coworker could reason to the right peer, but the handoff tool was muzzled.

## Fix

Handing a scoped sub-task to a **named** peer with a **visible** handoff card is coordination, not an irreversible action on the outside world — it is how an advisor gets the user a better answer.

- New `adviseCoordination` flag on `ToolDefinition`, mirroring the existing `coworkerArtifact` exemption precedent. Flagged tools keep `sideEffect: true` (correct MCP annotations / tool-execution memory) but are **not** stripped by the advise-mode runtime filter.
- `request_coworker` and `summon_coworker` carry `adviseCoordination: true` (with an explaining code comment).
- `filterToolsForCoworkerRuntime` and `adviseHeldBackTools` both honor the flag, so the prompt no longer offers 'switch to Act mode and I can delegate' when delegation already works in advise mode.

The exemption is **targeted**: genuinely destructive writes (e.g. `create_backlog_item`, `manage_coworker_tool_grant`) lack the flag and remain stripped in advise mode.

## Tests

Extended `apps/web/lib/actions/coworker-tool-filter.test.ts`:
- In advise mode, `request_coworker`/`summon_coworker` ARE present while a destructive write (`create_backlog_item`) is still stripped.
- Delegation tools are NOT listed by `adviseHeldBackTools`.

`pnpm exec vitest run lib/actions/coworker-tool-filter.test.ts` -> 7 passed. Sibling `agent-coworker-tool-filter.test.ts` still green. Module-size guard passes (no baseline change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)