### PR TITLE
feat(customer): lead the Customer surface with which account needs the operator (BI-9A554B3C)

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/page.tsx
@@ -7,7 +7,15 @@ import { DuplicateAccountsPanel } from "@/components/customer/DuplicateAccountsP
 import { RevenueCockpit } from "@/components/customer/RevenueCockpit";
 import { CustomerStatusBadge } from "@/components/customer/CustomerStatusBadge";
 import { buildRevenueCockpitSummary } from "@/lib/crm/revenue-cockpit";
-import { getAccountStatusMeta } from "@/lib/crm/presentation";
+import {
+  CRM_TONE_CLASSES,
+  getAccountStatusMeta,
+  OPEN_OPPORTUNITY_STAGES,
+} from "@/lib/crm/presentation";
+import {
+  classifyAccountAttention,
+  sortAccountsByAttention,
+} from "@/lib/crm/account-attention";
 import { PlatformGridSection, parseSurfaceView } from "@/components/workbooks/PlatformGridSection";
 
 export default async function CustomerPage({
@@ -39,7 +47,29 @@ export default async function CustomerPage({
         name: true,
         status: true,
         industry: true,
+        createdAt: true,
         _count: { select: { contacts: true, opportunities: true } },
+        // Open opportunities carry the dormancy + expected-close signals.
+        opportunities: {
+          where: { stage: { in: [...OPEN_OPPORTUNITY_STAGES] } },
+          select: { stage: true, isDormant: true, expectedClose: true },
+        },
+        // Sent + expired quotes carry the commitment/at-risk signals.
+        quotes: {
+          where: { status: { in: ["sent", "expired"] } },
+          select: { status: true, validUntil: true },
+        },
+        // Unworked inbound engagements carry the follow-up signal.
+        engagements: {
+          where: { status: { in: ["new", "contacted"] } },
+          select: { status: true },
+        },
+        // Most recent logged activity drives the stale signal.
+        activities: {
+          orderBy: { createdAt: "desc" },
+          take: 1,
+          select: { createdAt: true },
+        },
       },
     }),
     prisma.engagement.groupBy({
@@ -118,6 +148,27 @@ export default async function CustomerPage({
     },
   });
 
+  // Which customer needs the operator? Classify each account from existing CRM
+  // data and lead the list with the accounts carrying an unmet signal.
+  const now = new Date();
+  const accountsWithAttention = sortAccountsByAttention(
+    accounts.map((a) => ({
+      ...a,
+      attention: classifyAccountAttention({
+        status: a.status,
+        opportunities: a.opportunities,
+        quotes: a.quotes,
+        engagements: a.engagements,
+        lastActivityAt: a.activities[0]?.createdAt ?? null,
+        createdAt: a.createdAt,
+        now,
+      }),
+    })),
+    (a) => a.attention,
+    (a) => a.name,
+  );
+  const attentionCount = accountsWithAttention.filter((a) => a.attention.signal).length;
+
   return (
     <div>
       <div className="mb-6 flex items-start justify-between">
@@ -125,6 +176,14 @@ export default async function CustomerPage({
           <h1 className="text-xl font-bold text-[var(--dpf-text)]">Customer</h1>
           <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
             {accounts.length} account{accounts.length !== 1 ? "s" : ""}
+            {attentionCount > 0 && (
+              <>
+                {" · "}
+                <span className="font-medium text-[var(--dpf-text)]">
+                  {attentionCount} need{attentionCount === 1 ? "s" : ""} attention
+                </span>
+              </>
+            )}
           </p>
         </div>
         <NewCustomerButton />
@@ -138,15 +197,19 @@ export default async function CustomerPage({
 
       {!view && (
         <>
-      {/* Account list */}
+      {/* Account list — accounts needing the operator lead the list. */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        {accounts.map((a) => {
+        {accountsWithAttention.map((a) => {
           const statusMeta = getAccountStatusMeta(a.status);
+          const attention = a.attention;
+          const borderClass = attention.signal
+            ? CRM_TONE_CLASSES[attention.tone].border
+            : "border-[var(--dpf-accent)]";
           return (
             <Link
               key={a.id}
               href={`/customer/${a.id}`}
-              className="rounded-lg border-l-4 border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-4 transition-colors hover:bg-[var(--dpf-surface-2)]"
+              className={`rounded-lg border-l-4 ${borderClass} bg-[var(--dpf-surface-1)] p-4 transition-colors hover:bg-[var(--dpf-surface-2)]`}
             >
               <p className="text-[9px] font-mono text-[var(--dpf-muted)] mb-1">
                 {a.accountId}
@@ -160,6 +223,14 @@ export default async function CustomerPage({
                   tone={statusMeta.tone}
                 />
               </div>
+              {attention.signal && (
+                <div className="mb-2 flex flex-wrap items-center gap-2">
+                  <CustomerStatusBadge label={attention.label} tone={attention.tone} />
+                  <span className="text-[10px] text-[var(--dpf-muted)]">
+                    {attention.reason}
+                  </span>
+                </div>
+              )}
               <div className="flex gap-3 text-[9px] text-[var(--dpf-muted)]">
                 <span>{a._count.contacts} contact{a._count.contacts !== 1 ? "s" : ""}</span>
                 {a._count.opportunities > 0 && (

--- a/apps/web/lib/crm/account-attention.test.ts
+++ b/apps/web/lib/crm/account-attention.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyAccountAttention,
+  sortAccountsByAttention,
+  STALE_ACTIVITY_DAYS,
+  type AccountAttentionInput,
+} from "./account-attention";
+
+const NOW = new Date("2026-07-11T12:00:00Z");
+
+function baseInput(overrides: Partial<AccountAttentionInput> = {}): AccountAttentionInput {
+  return {
+    status: "active",
+    opportunities: [],
+    quotes: [],
+    engagements: [],
+    lastActivityAt: NOW,
+    createdAt: NOW,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+function daysAgo(days: number): Date {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+function inDays(days: number): Date {
+  return new Date(NOW.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+describe("classifyAccountAttention", () => {
+  it("returns no signal for a healthy active account with no open work", () => {
+    const attention = classifyAccountAttention(baseInput());
+    expect(attention.signal).toBeNull();
+    expect(attention.severity).toBe(0);
+    expect(attention.label).toBe("");
+  });
+
+  it("flags an explicitly at-risk account as the most urgent signal", () => {
+    const attention = classifyAccountAttention(baseInput({ status: "at_risk" }));
+    expect(attention.signal).toBe("at_risk");
+    expect(attention.severity).toBe(4);
+    expect(attention.tone).toBe("danger");
+  });
+
+  it("flags an expired quote as at-risk", () => {
+    const attention = classifyAccountAttention(
+      baseInput({ quotes: [{ status: "expired", validUntil: daysAgo(5) }] }),
+    );
+    expect(attention.signal).toBe("at_risk");
+    expect(attention.reason).toContain("expired");
+  });
+
+  it("flags a dormant open opportunity as at-risk", () => {
+    const attention = classifyAccountAttention(
+      baseInput({
+        opportunities: [{ stage: "proposal", isDormant: true, expectedClose: inDays(10) }],
+      }),
+    );
+    expect(attention.signal).toBe("at_risk");
+    expect(attention.reason).toContain("dormant");
+  });
+
+  it("flags an overdue expected close as follow-up-due", () => {
+    const attention = classifyAccountAttention(
+      baseInput({
+        opportunities: [{ stage: "negotiation", isDormant: false, expectedClose: daysAgo(3) }],
+      }),
+    );
+    expect(attention.signal).toBe("follow_up_due");
+    expect(attention.severity).toBe(3);
+    expect(attention.tone).toBe("warning");
+    expect(attention.reason).toContain("past expected close");
+  });
+
+  it("flags a sent quote past its validity as follow-up-due", () => {
+    const attention = classifyAccountAttention(
+      baseInput({ quotes: [{ status: "sent", validUntil: daysAgo(1) }] }),
+    );
+    expect(attention.signal).toBe("follow_up_due");
+    expect(attention.reason).toContain("past validity");
+  });
+
+  it("flags a new unworked engagement as follow-up-due", () => {
+    const attention = classifyAccountAttention(
+      baseInput({ engagements: [{ status: "new" }] }),
+    );
+    expect(attention.signal).toBe("follow_up_due");
+    expect(attention.reason).toContain("awaiting first contact");
+  });
+
+  it("treats a live sent quote (still valid) as commitment-pending", () => {
+    const attention = classifyAccountAttention(
+      baseInput({ quotes: [{ status: "sent", validUntil: inDays(10) }] }),
+    );
+    expect(attention.signal).toBe("commitment_pending");
+    expect(attention.severity).toBe(2);
+    expect(attention.tone).toBe("accent");
+    expect(attention.reason).toContain("awaiting the customer");
+  });
+
+  it("treats an in-negotiation opportunity as commitment-pending", () => {
+    const attention = classifyAccountAttention(
+      baseInput({
+        opportunities: [{ stage: "negotiation", isDormant: false, expectedClose: inDays(20) }],
+      }),
+    );
+    expect(attention.signal).toBe("commitment_pending");
+    expect(attention.reason).toContain("negotiation");
+  });
+
+  it("flags open work with no recent activity as stale", () => {
+    const attention = classifyAccountAttention(
+      baseInput({
+        opportunities: [{ stage: "discovery", isDormant: false, expectedClose: inDays(30) }],
+        lastActivityAt: daysAgo(STALE_ACTIVITY_DAYS + 5),
+      }),
+    );
+    expect(attention.signal).toBe("stale");
+    expect(attention.severity).toBe(1);
+    expect(attention.reason).toContain("No activity");
+  });
+
+  it("does NOT flag a brand-new account with open work as stale", () => {
+    const attention = classifyAccountAttention(
+      baseInput({
+        opportunities: [{ stage: "discovery", isDormant: false, expectedClose: inDays(30) }],
+        lastActivityAt: null,
+        createdAt: daysAgo(2),
+      }),
+    );
+    expect(attention.signal).toBeNull();
+  });
+
+  it("does NOT flag a quiet account that has no open work", () => {
+    const attention = classifyAccountAttention(
+      baseInput({
+        opportunities: [{ stage: "closed_won", isDormant: false, expectedClose: daysAgo(90) }],
+        lastActivityAt: daysAgo(120),
+      }),
+    );
+    expect(attention.signal).toBeNull();
+  });
+
+  it("prefers the more urgent signal when several apply", () => {
+    // Dormant open opp (at_risk) AND an overdue close (follow_up_due) — at_risk wins.
+    const attention = classifyAccountAttention(
+      baseInput({
+        opportunities: [
+          { stage: "proposal", isDormant: true, expectedClose: daysAgo(5) },
+          { stage: "discovery", isDormant: false, expectedClose: daysAgo(5) },
+        ],
+      }),
+    );
+    expect(attention.signal).toBe("at_risk");
+  });
+
+  it("ignores closed opportunities when deciding open-work signals", () => {
+    const attention = classifyAccountAttention(
+      baseInput({
+        opportunities: [{ stage: "closed_lost", isDormant: true, expectedClose: daysAgo(10) }],
+      }),
+    );
+    expect(attention.signal).toBeNull();
+  });
+});
+
+describe("sortAccountsByAttention", () => {
+  it("orders accounts by descending severity, ties broken by name", () => {
+    const accounts = [
+      { name: "Zephyr", attention: classifyAccountAttention(baseInput()) },
+      {
+        name: "Northwind",
+        attention: classifyAccountAttention(baseInput({ status: "at_risk" })),
+      },
+      {
+        name: "Emma3D",
+        attention: classifyAccountAttention(
+          baseInput({ engagements: [{ status: "new" }] }),
+        ),
+      },
+      {
+        name: "Acme",
+        attention: classifyAccountAttention(baseInput()),
+      },
+    ];
+
+    const ordered = sortAccountsByAttention(
+      accounts,
+      (a) => a.attention,
+      (a) => a.name,
+    ).map((a) => a.name);
+
+    // at_risk (Northwind) first, then follow_up_due (Emma3D), then the two
+    // no-signal accounts in name order (Acme, Zephyr).
+    expect(ordered).toEqual(["Northwind", "Emma3D", "Acme", "Zephyr"]);
+  });
+});

--- a/apps/web/lib/crm/account-attention.ts
+++ b/apps/web/lib/crm/account-attention.ts
@@ -1,0 +1,219 @@
+import type { CrmTone } from "./presentation";
+import { isOpenOpportunityStage } from "./presentation";
+
+/**
+ * Which customer needs the operator? The account list leads with attention:
+ * accounts carrying an unmet signal are surfaced first so the operator does not
+ * have to scan a flat "Active" directory to find the one going sideways.
+ *
+ * Signals are derived from existing CRM data (opportunities, quotes,
+ * engagements, activity recency) — no new persisted state. The classifier is
+ * pure so the ordering and thresholds are unit-testable.
+ */
+export type AccountAttentionSignal =
+  | "at_risk"
+  | "follow_up_due"
+  | "commitment_pending"
+  | "stale";
+
+/** Days without a logged activity before an account with open work reads as stale. */
+export const STALE_ACTIVITY_DAYS = 30;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type AccountOpportunitySignal = {
+  stage: string;
+  isDormant: boolean;
+  expectedClose: Date | null;
+};
+
+export type AccountQuoteSignal = {
+  status: string;
+  validUntil: Date | null;
+};
+
+export type AccountEngagementSignal = {
+  status: string;
+};
+
+export type AccountAttentionInput = {
+  /** Account lifecycle status (prospect | qualified | active | at_risk | ...). */
+  status: string;
+  /** Open + closed opportunities on the account. Closed stages are ignored. */
+  opportunities: AccountOpportunitySignal[];
+  /** Quotes on the account (any status). */
+  quotes: AccountQuoteSignal[];
+  /** Engagements on the account (any status). */
+  engagements: AccountEngagementSignal[];
+  /** Most recent logged activity timestamp, or null when none exists. */
+  lastActivityAt: Date | null;
+  /** When the account record was created (used as the stale reference when no activity exists). */
+  createdAt: Date;
+  /** Evaluation clock — injected for deterministic tests. */
+  now: Date;
+};
+
+export type AccountAttention = {
+  signal: AccountAttentionSignal | null;
+  /** Higher = more urgent. 0 means nothing needs the operator. */
+  severity: number;
+  /** Short badge label. Empty when there is no signal. */
+  label: string;
+  /** One-line reason the account was flagged. Empty when there is no signal. */
+  reason: string;
+  tone: CrmTone;
+};
+
+const NO_ATTENTION: AccountAttention = {
+  signal: null,
+  severity: 0,
+  label: "",
+  reason: "",
+  tone: "neutral",
+};
+
+const OPEN_ENGAGEMENT_STATUSES = ["new", "contacted"];
+
+function isOverdue(date: Date | null, now: Date): boolean {
+  return date !== null && date.getTime() < now.getTime();
+}
+
+function daysBetween(from: Date, to: Date): number {
+  return (to.getTime() - from.getTime()) / DAY_MS;
+}
+
+/**
+ * Classify a single account into at most one attention signal, using the
+ * highest-priority match. Priority (most urgent first):
+ *   at_risk > follow_up_due > commitment_pending > stale > none.
+ */
+export function classifyAccountAttention(input: AccountAttentionInput): AccountAttention {
+  const openOpportunities = input.opportunities.filter((o) => isOpenOpportunityStage(o.stage));
+  const openEngagements = input.engagements.filter((e) =>
+    OPEN_ENGAGEMENT_STATUSES.includes(e.status),
+  );
+  const hasOpenWork = openOpportunities.length > 0 || openEngagements.length > 0;
+
+  // 1. At risk — the account is flagged, a quote lapsed, or open work went dormant.
+  const dormantOpen = openOpportunities.filter((o) => o.isDormant).length;
+  const expiredQuotes = input.quotes.filter((q) => q.status === "expired").length;
+  if (input.status === "at_risk") {
+    return {
+      signal: "at_risk",
+      severity: 4,
+      label: "At risk",
+      reason: "Account flagged at risk",
+      tone: "danger",
+    };
+  }
+  if (expiredQuotes > 0) {
+    return {
+      signal: "at_risk",
+      severity: 4,
+      label: "At risk",
+      reason: `${expiredQuotes} quote${expiredQuotes === 1 ? "" : "s"} expired without a decision`,
+      tone: "danger",
+    };
+  }
+  if (dormantOpen > 0) {
+    return {
+      signal: "at_risk",
+      severity: 4,
+      label: "At risk",
+      reason: `${dormantOpen} open opportunit${dormantOpen === 1 ? "y has" : "ies have"} gone dormant`,
+      tone: "danger",
+    };
+  }
+
+  // 2. Follow-up due — a dated commitment has lapsed or inbound interest is unworked.
+  const overdueOpps = openOpportunities.filter((o) => isOverdue(o.expectedClose, input.now)).length;
+  const lapsingSentQuotes = input.quotes.filter(
+    (q) => q.status === "sent" && isOverdue(q.validUntil, input.now),
+  ).length;
+  const newEngagements = input.engagements.filter((e) => e.status === "new").length;
+  if (overdueOpps > 0) {
+    return {
+      signal: "follow_up_due",
+      severity: 3,
+      label: "Follow-up due",
+      reason: `${overdueOpps} opportunit${overdueOpps === 1 ? "y is" : "ies are"} past expected close`,
+      tone: "warning",
+    };
+  }
+  if (lapsingSentQuotes > 0) {
+    return {
+      signal: "follow_up_due",
+      severity: 3,
+      label: "Follow-up due",
+      reason: `${lapsingSentQuotes} sent quote${lapsingSentQuotes === 1 ? "" : "s"} past validity`,
+      tone: "warning",
+    };
+  }
+  if (newEngagements > 0) {
+    return {
+      signal: "follow_up_due",
+      severity: 3,
+      label: "Follow-up due",
+      reason: `${newEngagements} new engagement${newEngagements === 1 ? "" : "s"} awaiting first contact`,
+      tone: "warning",
+    };
+  }
+
+  // 3. Commitment pending — the ball is in the customer's court; monitor it.
+  const openSentQuotes = input.quotes.filter((q) => q.status === "sent").length;
+  const negotiating = openOpportunities.filter((o) => o.stage === "negotiation").length;
+  if (openSentQuotes > 0) {
+    return {
+      signal: "commitment_pending",
+      severity: 2,
+      label: "Awaiting decision",
+      reason: `${openSentQuotes} quote${openSentQuotes === 1 ? "" : "s"} sent, awaiting the customer`,
+      tone: "accent",
+    };
+  }
+  if (negotiating > 0) {
+    return {
+      signal: "commitment_pending",
+      severity: 2,
+      label: "Awaiting decision",
+      reason: `${negotiating} opportunit${negotiating === 1 ? "y is" : "ies are"} in negotiation`,
+      tone: "accent",
+    };
+  }
+
+  // 4. Stale — live work has gone quiet with no recent activity.
+  if (hasOpenWork) {
+    const reference = input.lastActivityAt ?? input.createdAt;
+    const idleDays = daysBetween(reference, input.now);
+    if (idleDays >= STALE_ACTIVITY_DAYS) {
+      const wholeDays = Math.floor(idleDays);
+      return {
+        signal: "stale",
+        severity: 1,
+        label: "No recent activity",
+        reason: `No activity in ${wholeDays} days with open work`,
+        tone: "warning",
+      };
+    }
+  }
+
+  return { ...NO_ATTENTION };
+}
+
+/**
+ * Stable ordering: accounts needing the operator most come first (by severity),
+ * ties broken by the caller-supplied name so the list stays deterministic.
+ */
+export function sortAccountsByAttention<T>(
+  accounts: T[],
+  getAttention: (account: T) => AccountAttention,
+  getName: (account: T) => string,
+): T[] {
+  return [...accounts].sort((a, b) => {
+    const severityDiff = getAttention(b).severity - getAttention(a).severity;
+    if (severityDiff !== 0) {
+      return severityDiff;
+    }
+    return getName(a).localeCompare(getName(b));
+  });
+}

--- a/apps/web/lib/crm/revenue-cockpit.test.ts
+++ b/apps/web/lib/crm/revenue-cockpit.test.ts
@@ -106,9 +106,17 @@ describe("revenue cockpit summary", () => {
         tone: "warning",
       },
       {
-        id: "marketing-work",
-        label: "5 marketing work products are waiting",
-        href: "/customer/marketing",
+        // Campaign briefs (1) + asset tasks (3) route to the campaigns review queue.
+        id: "marketing-campaign-work",
+        label: "4 campaign work products are waiting for review",
+        href: "/customer/marketing/campaigns",
+        tone: "accent",
+      },
+      {
+        // Automation candidate (1) routes to the automation review queue.
+        id: "marketing-automation-work",
+        label: "1 automation candidate is waiting for review",
+        href: "/customer/marketing/automation",
         tone: "accent",
       },
     ]);
@@ -136,9 +144,9 @@ describe("revenue cockpit summary", () => {
         tone: "warning",
       },
       {
-        id: "marketing-work",
-        label: "1 marketing work product is waiting",
-        href: "/customer/marketing",
+        id: "marketing-campaign-work",
+        label: "1 campaign work product is waiting for review",
+        href: "/customer/marketing/campaigns",
         tone: "accent",
       },
     ]);
@@ -170,6 +178,42 @@ describe("revenue cockpit summary", () => {
     });
     expect(summary.attentionItems[2].label).toBe("3 new leads are waiting for triage");
     expect(summary.attentionItems[3].label).toBe("1 support contract renews within 30 days");
+  });
+
+  it("renders an empty pipeline as a concern, not a neutral zero", () => {
+    const summary = buildRevenueCockpitSummary({
+      engagementCounts: [],
+      opportunityCounts: [{ stage: "closed_won", count: 4, expectedValue: 40000 }],
+      quoteCounts: [],
+      orderCounts: [],
+      staleOpportunityCount: 0,
+      marketingWork: { campaignBriefsOpen: 0, assetTasksOpen: 0, automationCandidatesOpen: 0 },
+    });
+
+    const pipeline = summary.metrics.find((m) => m.id === "pipeline");
+    expect(pipeline).toEqual({
+      id: "pipeline",
+      label: "Pipeline",
+      value: "0",
+      detail: "No open pipeline — nothing in motion",
+      href: "/customer/opportunities",
+      tone: "warning",
+    });
+  });
+
+  it("keeps the pipeline tile neutral-positive when there is open pipeline", () => {
+    const summary = buildRevenueCockpitSummary({
+      engagementCounts: [],
+      opportunityCounts: [{ stage: "proposal", count: 2, expectedValue: 8000 }],
+      quoteCounts: [],
+      orderCounts: [],
+      staleOpportunityCount: 0,
+      marketingWork: { campaignBriefsOpen: 0, assetTasksOpen: 0, automationCandidatesOpen: 0 },
+    });
+
+    const pipeline = summary.metrics.find((m) => m.id === "pipeline");
+    expect(pipeline?.tone).toBe("accent");
+    expect(pipeline?.detail).toBe("$8,000 open");
   });
 
   it("omits inbox items when the optional counts are absent (back-compat)", () => {

--- a/apps/web/lib/crm/revenue-cockpit.ts
+++ b/apps/web/lib/crm/revenue-cockpit.ts
@@ -78,10 +78,7 @@ export function buildRevenueCockpitSummary(input: RevenueCockpitInput): RevenueC
   const quoteCount = countWhere(input.quoteCounts, ["draft", "sent"]);
   const sentQuotes = countWhere(input.quoteCounts, ["sent"]);
   const activeOrders = countWhere(input.orderCounts, ["confirmed", "in_progress"]);
-  const marketingWorkCount =
-    input.marketingWork.campaignBriefsOpen +
-    input.marketingWork.assetTasksOpen +
-    input.marketingWork.automationCandidatesOpen;
+  const pipelineEmpty = pipelineCount === 0;
 
   // The engagement inbox: what to work NOW, each with a plain-language why,
   // ordered by urgency (money overdue > deals stalling > new leads > renewals).
@@ -125,11 +122,24 @@ export function buildRevenueCockpitSummary(input: RevenueCockpitInput): RevenueC
     });
   }
 
-  if (marketingWorkCount > 0) {
+  // Marketing work products split by the queue that actually lists them, so the
+  // pill lands on the reviewable items — not the marketing overview hub.
+  const campaignWorkCount =
+    input.marketingWork.campaignBriefsOpen + input.marketingWork.assetTasksOpen;
+  const automationWorkCount = input.marketingWork.automationCandidatesOpen;
+  if (campaignWorkCount > 0) {
     attentionItems.push({
-      id: "marketing-work",
-      label: `${marketingWorkCount} marketing work product${marketingWorkCount === 1 ? " is" : "s are"} waiting`,
-      href: "/customer/marketing",
+      id: "marketing-campaign-work",
+      label: `${campaignWorkCount} campaign work product${campaignWorkCount === 1 ? " is" : "s are"} waiting for review`,
+      href: "/customer/marketing/campaigns",
+      tone: "accent",
+    });
+  }
+  if (automationWorkCount > 0) {
+    attentionItems.push({
+      id: "marketing-automation-work",
+      label: `${automationWorkCount} automation candidate${automationWorkCount === 1 ? " is" : "s are"} waiting for review`,
+      href: "/customer/marketing/automation",
       tone: "accent",
     });
   }
@@ -148,9 +158,12 @@ export function buildRevenueCockpitSummary(input: RevenueCockpitInput): RevenueC
         id: "pipeline",
         label: "Pipeline",
         value: String(pipelineCount),
-        detail: `${formatRevenueAmount(pipelineValue, currency)} open`,
+        // An empty pipeline is a revenue red flag, not a neutral zero — say so.
+        detail: pipelineEmpty
+          ? "No open pipeline — nothing in motion"
+          : `${formatRevenueAmount(pipelineValue, currency)} open`,
         href: "/customer/opportunities",
-        tone: "accent",
+        tone: pipelineEmpty ? "warning" : "accent",
       },
       {
         id: "quotes",


### PR DESCRIPTION
## BI-9A554B3C — Customer surface actionability

The `/customer` surface (a PRIMARY, outside-in customer-facing surface) was a flat directory. Three outside-in fixes so it leads with **which customer needs the operator**:

### F17 — per-account attention / risk signals
Accounts previously showed only "Active" + contact/opportunity counts. Now each account carries at most one attention signal, derived from existing CRM data (no new persisted state):

| Signal | Trigger | Tone |
|---|---|---|
| **At risk** | account flagged `at_risk`, an expired quote, or a dormant open opportunity | danger |
| **Follow-up due** | open opp past expected close, sent quote past validity, or a new unworked engagement | warning |
| **Awaiting decision** | a live sent quote or an in-negotiation opportunity | accent |
| **No recent activity** | open work + no logged activity for ≥30 days (new accounts excluded) | warning |

Accounts needing the operator now **sort first**, with a badge, a one-line reason, a tone-colored left border, and a "N need attention" count in the header. Classification lives in a pure, unit-tested function: `apps/web/lib/crm/account-attention.ts`.

### F18 — honest revenue tiles
An empty pipeline now renders as a **concern** (warning tone, "No open pipeline — nothing in motion") instead of a neutral `$0 open`. Tiles remain live links to the exact item lists.

### F20 — wire the marketing pill to the real queue
The "N marketing work products waiting" pill previously linked to the Marketing Overview hub. It now routes each count to the queue that actually lists those items:
- campaign briefs + asset tasks → `/customer/marketing/campaigns`
- automation candidates → `/customer/marketing/automation`

## Tests
`pnpm exec vitest run lib/crm/account-attention.test.ts lib/crm/revenue-cockpit.test.ts` — **24 passing** (classification for every signal + priority ordering + stale edge cases; empty-pipeline concern; marketing-queue routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)