### PR TITLE
feat(ops): operator triage lens on /ops backlog (BI-9952EA9E)

### DIFF
--- a/apps/web/components/ops/BacklogItemRow.tsx
+++ b/apps/web/components/ops/BacklogItemRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { memo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { AlertTriangle, ExternalLink, LoaderCircle, Play } from "lucide-react";
@@ -17,7 +17,13 @@ type Props = {
   focused?: boolean;
 };
 
-export function BacklogItemRow({ item, onEdit, focused = false }: Props) {
+// Memoized: on /ops hundreds of rows can be mounted at once (expanded epics +
+// the triage band). Without this, any OpsClient state change (filters, opening a
+// panel, toggling the triage band) re-renders every mounted row. Props are
+// primitives + a stable onEdit callback, so referential equality holds.
+export const BacklogItemRow = memo(BacklogItemRowImpl);
+
+function BacklogItemRowImpl({ item, onEdit, focused = false }: Props) {
   const router = useRouter();
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isPending, startTransition] = useTransition();
@@ -80,6 +86,10 @@ export function BacklogItemRow({ item, onEdit, focused = false }: Props) {
 
       {/* Work-type badge */}
       <WorkTypeBadge workType={item.workType} />
+
+      {/* Altitude signal (BI-9952EA9E) — effort size, so a trivial tweak doesn't
+          read with the same weight as a platform-scale item. */}
+      <EffortSizeBadge effortSize={item.effortSize} />
 
       {/* Origin badge — which source this work came from (improvements,
           capability needs, issue reports, signals…), now that /ops is the one
@@ -276,6 +286,37 @@ function OriginBadge({ item }: { item: BacklogItemWithRelations }) {
       title={`origin: ${BACKLOG_ORIGIN_LABEL[origin]} — every source is seen and worked here in Operations`}
     >
       {BACKLOG_ORIGIN_LABEL[origin]}
+    </span>
+  );
+}
+
+const EFFORT_SIZE_BADGE: Record<string, { label: string; cls: string }> = {
+  small: { label: "S", cls: "border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]" },
+  medium: { label: "M", cls: "border-[var(--dpf-info)]/40 bg-[var(--dpf-info)]/10 text-[var(--dpf-info)]" },
+  large: { label: "L", cls: "border-[var(--dpf-warning)]/40 bg-[var(--dpf-warning)]/10 text-[var(--dpf-warning)]" },
+  xlarge: { label: "XL", cls: "border-[var(--dpf-error)]/40 bg-[var(--dpf-error)]/10 text-[var(--dpf-error)]" },
+};
+
+function EffortSizeBadge({ effortSize }: { effortSize: string | null }) {
+  const meta = effortSize ? EFFORT_SIZE_BADGE[effortSize] : undefined;
+  if (!meta) {
+    return (
+      <span
+        className="shrink-0 rounded border border-dashed border-[var(--dpf-border)] px-1.5 py-0.5 text-[10px] font-semibold text-[var(--dpf-muted)]"
+        title="effort size not set — a light altitude signal is missing"
+        aria-label="effort size unsized"
+      >
+        ?
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-semibold tabular-nums ${meta.cls}`}
+      title={`effort size: ${effortSize}`}
+      aria-label={`effort size ${effortSize}`}
+    >
+      {meta.label}
     </span>
   );
 }

--- a/apps/web/components/ops/EpicCard.tsx
+++ b/apps/web/components/ops/EpicCard.tsx
@@ -1,7 +1,7 @@
 // apps/web/components/ops/EpicCard.tsx
 "use client";
 
-import { useState, useTransition } from "react";
+import { memo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { deleteEpic } from "@/lib/actions/backlog";
@@ -47,12 +47,28 @@ type Props = {
   focusedItemId?: string;
 };
 
-export function EpicCard({ epic, sort, hideDoneItems, onEdit, onItemEdit, focusedItemId }: Props) {
+// How many items to render on first expand. Large epics (Master Data Management,
+// etc.) carry dozens of items; mounting them all synchronously froze the renderer
+// under the full 470-item DOM (BI-9952EA9E). We render a page at a time and let
+// the operator reveal the rest — the freeze was the eager mount, not the data.
+const EXPAND_PAGE_SIZE = 25;
+
+// Memoized: OpsClient re-renders on every filter / panel / triage-band toggle.
+// With hundreds of items across expanded epics, an unmemoized EpicCard re-renders
+// the whole tree each time. Props are stable (epic identity + stable callbacks).
+export const EpicCard = memo(EpicCardImpl);
+
+function EpicCardImpl({ epic, sort, hideDoneItems, onEdit, onItemEdit, focusedItemId }: Props) {
   const router = useRouter();
   const hasFocusedItem = epic.items.some((item) => isFocusedBacklogItem(item, focusedItemId));
   const [expanded, setExpanded] = useState(hasFocusedItem);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isPending, startTransition] = useTransition();
+  // When deep-linked to a focused item, render the whole (single) epic so the
+  // focused row exists to scroll to; otherwise page for render cost.
+  const [visibleCount, setVisibleCount] = useState(
+    hasFocusedItem ? Number.MAX_SAFE_INTEGER : EXPAND_PAGE_SIZE,
+  );
 
   const visibleItems = hideDoneItems
     ? epic.items.filter((item) => !isTerminalBacklogItemStatus(item.status))
@@ -193,16 +209,31 @@ export function EpicCard({ epic, sort, hideDoneItems, onEdit, onItemEdit, focuse
               All {epic.items.length} items in this epic are done or deferred. Uncheck &quot;Hide done&quot; to see them.
             </p>
           ) : (
-            <div className="flex flex-col gap-1.5">
-              {sortedItems(visibleItems, sort).map((item) => (
-                <BacklogItemRow
-                  key={item.id}
-                  item={item}
-                  onEdit={onItemEdit}
-                  focused={isFocusedBacklogItem(item, focusedItemId)}
-                />
-              ))}
-            </div>
+            (() => {
+              const ordered = sortedItems(visibleItems, sort);
+              const shown = ordered.slice(0, visibleCount);
+              const remaining = ordered.length - shown.length;
+              return (
+                <div className="flex flex-col gap-1.5">
+                  {shown.map((item) => (
+                    <BacklogItemRow
+                      key={item.id}
+                      item={item}
+                      onEdit={onItemEdit}
+                      focused={isFocusedBacklogItem(item, focusedItemId)}
+                    />
+                  ))}
+                  {remaining > 0 && (
+                    <button
+                      onClick={() => setVisibleCount((n) => n + EXPAND_PAGE_SIZE)}
+                      className="mt-1 self-start rounded border border-[var(--dpf-border)] px-2 py-1 text-[10px] font-medium text-[var(--dpf-muted)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)]"
+                    >
+                      Show {Math.min(remaining, EXPAND_PAGE_SIZE)} more of {remaining}
+                    </button>
+                  )}
+                </div>
+              );
+            })()
           )}
           {hiddenItemCount > 0 && (
             <p className="mt-1.5 text-[10px] text-[var(--dpf-muted)]">

--- a/apps/web/components/ops/OperatorTriageBand.tsx
+++ b/apps/web/components/ops/OperatorTriageBand.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+// BI-9952EA9E: an operator triage lens above the raw backlog wall. Surfaces the
+// small, prioritized set of items genuinely awaiting an operator decision so the
+// operator sees "what needs me next" instead of scanning 470+ items of wildly
+// different altitude. Selection + ordering live in the pure, tested
+// lib/ops/operator-triage module; this is only the presentation.
+
+import { useMemo, useState } from "react";
+import { ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
+import { BacklogItemRow } from "./BacklogItemRow";
+import {
+  selectOperatorQueue,
+  OPERATOR_TRIAGE_REASON_LABEL,
+  OPERATOR_TRIAGE_REASON_HINT,
+  type OperatorTriageReason,
+} from "@/lib/ops/operator-triage";
+import type { BacklogItemWithRelations } from "@/lib/backlog";
+
+const MAX_VISIBLE = 7;
+
+type Props = {
+  items: BacklogItemWithRelations[];
+  onEdit: (item: BacklogItemWithRelations) => void;
+  focusedItemId?: string;
+};
+
+const REASON_CHIP_CLASS: Record<OperatorTriageReason, string> = {
+  "awaiting-triage": "border-[var(--dpf-accent)]/40 bg-[var(--dpf-accent-soft)] text-[var(--dpf-accent)]",
+  "ready-to-build": "border-[var(--dpf-success)]/40 bg-[var(--dpf-success)]/10 text-[var(--dpf-success)]",
+  "build-attention": "border-[var(--dpf-error)]/40 bg-[var(--dpf-error)]/10 text-[var(--dpf-error)]",
+  blocked: "border-[var(--dpf-error)]/40 bg-[var(--dpf-error)]/10 text-[var(--dpf-error)]",
+  stalled: "border-[var(--dpf-warning)]/40 bg-[var(--dpf-warning)]/10 text-[var(--dpf-warning)]",
+};
+
+export function OperatorTriageBand({ items, onEdit, focusedItemId }: Props) {
+  const queue = useMemo(() => selectOperatorQueue(items), [items]);
+  const [open, setOpen] = useState(true);
+
+  const total = queue.length;
+  const visible = queue.slice(0, MAX_VISIBLE);
+  const overflow = total - visible.length;
+
+  return (
+    <section className="mb-8 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-2.5 text-left"
+        aria-expanded={open}
+      >
+        <span className="text-[var(--dpf-muted)]">
+          {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+        </span>
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-[var(--dpf-text)]">
+          Needs you next
+        </h2>
+        <span
+          className={[
+            "rounded-full px-2 py-0.5 text-[10px] font-semibold tabular-nums",
+            total > 0
+              ? "bg-[var(--dpf-accent-soft)] text-[var(--dpf-accent)]"
+              : "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]",
+          ].join(" ")}
+        >
+          {total}
+        </span>
+        <span className="ml-1 hidden text-[10px] text-[var(--dpf-muted)] sm:inline">
+          items awaiting an operator decision — customer-blocking &amp; high-risk first
+        </span>
+      </button>
+
+      {open && (
+        <div className="border-t border-[var(--dpf-border)] px-3 py-3">
+          {total === 0 ? (
+            <p className="text-xs text-[var(--dpf-muted)]">
+              You&rsquo;re clear — nothing in the backlog is waiting on an operator decision right now.
+            </p>
+          ) : (
+            <>
+              <div className="flex flex-col gap-2.5">
+                {visible.map((entry) => (
+                  <div key={entry.item.id} className="flex flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={[
+                          "rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                          REASON_CHIP_CLASS[entry.reason],
+                        ].join(" ")}
+                        title={OPERATOR_TRIAGE_REASON_HINT[entry.reason]}
+                      >
+                        {OPERATOR_TRIAGE_REASON_LABEL[entry.reason]}
+                      </span>
+                      {entry.blocksBusinessOutcome && (
+                        <span
+                          className="inline-flex items-center gap-1 rounded border border-[var(--dpf-error)]/40 bg-[var(--dpf-error)]/10 px-1.5 py-0.5 text-[10px] font-semibold text-[var(--dpf-error)]"
+                          title="Plausibly blocks a customer or business outcome"
+                        >
+                          <AlertTriangle className="h-3 w-3" />
+                          Blocks outcome
+                        </span>
+                      )}
+                    </div>
+                    <BacklogItemRow
+                      item={entry.item}
+                      onEdit={onEdit}
+                      focused={Boolean(
+                        focusedItemId &&
+                          (entry.item.itemId === focusedItemId || entry.item.id === focusedItemId),
+                      )}
+                    />
+                  </div>
+                ))}
+              </div>
+              {overflow > 0 && (
+                <p className="mt-2.5 text-[10px] text-[var(--dpf-muted)]">
+                  + {overflow} more awaiting you — worked below in the full backlog.
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/ops/OpsClient.tsx
+++ b/apps/web/components/ops/OpsClient.tsx
@@ -1,11 +1,12 @@
 // apps/web/components/ops/OpsClient.tsx
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { BacklogPanel } from "./BacklogPanel";
 import { BacklogItemRow } from "./BacklogItemRow";
 import { EpicCard, type EpicSort } from "./EpicCard";
 import { EpicPanel } from "./EpicPanel";
+import { OperatorTriageBand } from "./OperatorTriageBand";
 import { isTerminalBacklogItemStatus } from "./backlogVisibility";
 import { FilterBar, type FacetDef } from "@/components/ui/report-kit";
 import { backlogItemOrigin, BACKLOG_ORIGIN_FILTERS } from "@/lib/ops/backlog-origin";
@@ -154,24 +155,32 @@ export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfo
     setEpicPanel(null);
     setPanel({ open: true, item: undefined, defaultType, ...(defaultEpicId ? { defaultEpicId } : {}) });
   }
-  function openEdit(item: BacklogItemWithRelations) {
+  // Stable callbacks so the memoized EpicCard / BacklogItemRow subtrees don't
+  // re-render every time unrelated OpsClient state changes (filters, panels,
+  // the triage band toggle). Load-bearing for the 470-item render cost.
+  const openEdit = useCallback((item: BacklogItemWithRelations) => {
     setEpicPanel(null);
     setPanel({ open: true, item });
-  }
+  }, []);
   function closePanel() { setPanel({ open: false }); }
 
   function openCreateEpic() {
     setPanel({ open: false });
     setEpicPanel({ mode: "create" });
   }
-  function openEditEpic(epic: EpicWithRelations) {
+  const openEditEpic = useCallback((epic: EpicWithRelations) => {
     setPanel({ open: false });
     setEpicPanel({ mode: "edit", epic });
-  }
+  }, []);
   function closeEpicPanel() { setEpicPanel(null); }
 
   return (
     <>
+      {/* Operator triage lens (BI-9952EA9E) — the small, prioritized set of items
+          awaiting an operator decision, above the raw wall. Spans ALL items (not
+          narrowed by the source/portfolio lenses below). */}
+      <OperatorTriageBand items={items} onEdit={openEdit} focusedItemId={focusedItemId} />
+
       {/* Source + portfolio lenses — narrow the one Operations surface */}
       <FilterBar
         mode="client"

--- a/apps/web/lib/explore/backlog-data.ts
+++ b/apps/web/lib/explore/backlog-data.ts
@@ -39,6 +39,12 @@ export const getBacklogItems = cache(async (): Promise<BacklogItemWithRelations[
       taxonomyNode: { select: { id: true, nodeId: true, name: true } },
       upstreamIssueNumber: true,
       upstreamIssueUrl: true,
+      // Operator-triage inputs (BI-9952EA9E) — existing columns.
+      claimStatus: true,
+      stalenessDetectedAt: true,
+      riskOpportunity: true,
+      businessValue: true,
+      timeCriticality: true,
     },
   });
 });
@@ -88,6 +94,12 @@ export const getEpics = cache(async (): Promise<EpicWithRelations[]> => {
           taxonomyNode: { select: { id: true, nodeId: true, name: true } },
           upstreamIssueNumber: true,
           upstreamIssueUrl: true,
+          // Operator-triage inputs (BI-9952EA9E) — existing columns.
+          claimStatus: true,
+          stalenessDetectedAt: true,
+          riskOpportunity: true,
+          businessValue: true,
+          timeCriticality: true,
         },
       },
     },

--- a/apps/web/lib/explore/backlog.ts
+++ b/apps/web/lib/explore/backlog.ts
@@ -37,6 +37,14 @@ export type BacklogItemWithRelations = {
   updatedAt: Date;
   upstreamIssueNumber: number | null;
   upstreamIssueUrl: string | null;
+  // Operator-triage inputs (BI-9952EA9E). All existing BacklogItem columns —
+  // optional here so existing fixtures/callers that don't select them still
+  // typecheck; the /ops loaders select them for the triage lens.
+  claimStatus?: string | null;
+  stalenessDetectedAt?: Date | null;
+  riskOpportunity?: number | null;
+  businessValue?: number | null;
+  timeCriticality?: number | null;
 };
 
 export type DigitalProductSelect = {

--- a/apps/web/lib/ops/operator-triage.test.ts
+++ b/apps/web/lib/ops/operator-triage.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyOperatorReason,
+  selectOperatorQueue,
+  type OperatorTriageReason,
+} from "./operator-triage";
+import type { BacklogItemWithRelations } from "@/lib/backlog";
+
+const NOW = new Date("2026-07-11T00:00:00.000Z");
+
+function daysAgo(n: number): Date {
+  return new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);
+}
+
+function item(overrides: Partial<BacklogItemWithRelations>): BacklogItemWithRelations {
+  return {
+    id: overrides.id ?? overrides.itemId ?? "cuid",
+    itemId: overrides.itemId ?? "BI-TEST",
+    title: overrides.title ?? "Test item",
+    status: "open",
+    type: "product",
+    workType: null,
+    source: null,
+    body: null,
+    priority: null,
+    epicId: null,
+    triageOutcome: null,
+    effortSize: null,
+    activeBuildId: null,
+    activeBuild: null,
+    digitalProduct: null,
+    taxonomyNode: null,
+    submittedBy: null,
+    completedAt: null,
+    agentId: null,
+    createdAt: daysAgo(10),
+    updatedAt: daysAgo(10),
+    upstreamIssueNumber: null,
+    upstreamIssueUrl: null,
+    ...overrides,
+  };
+}
+
+describe("classifyOperatorReason", () => {
+  it("flags a triaging item as awaiting-triage", () => {
+    expect(classifyOperatorReason(item({ status: "triaging" }))).toBe("awaiting-triage");
+  });
+
+  it("flags a build-ready item as ready-to-build", () => {
+    expect(
+      classifyOperatorReason(
+        item({ status: "open", triageOutcome: "build", effortSize: "medium" }),
+      ),
+    ).toBe("ready-to-build");
+  });
+
+  it("flags a failed linked build as build-attention", () => {
+    expect(
+      classifyOperatorReason(
+        item({ activeBuildId: "b1", activeBuild: { buildId: "b1", phase: "failed" } }),
+      ),
+    ).toBe("build-attention");
+  });
+
+  it("flags an unavailable linked build (id set, relation missing) as build-attention", () => {
+    expect(classifyOperatorReason(item({ activeBuildId: "b1", activeBuild: null }))).toBe(
+      "build-attention",
+    );
+  });
+
+  it("flags a blocked claim as blocked", () => {
+    expect(classifyOperatorReason(item({ claimStatus: "blocked" }))).toBe("blocked");
+  });
+
+  it("flags an explicitly-stale live item as stalled", () => {
+    expect(
+      classifyOperatorReason(item({ status: "open", stalenessDetectedAt: daysAgo(30) })),
+    ).toBe("stalled");
+  });
+
+  it("returns null for a healthy in-flight build (an agent is working)", () => {
+    expect(
+      classifyOperatorReason(
+        item({ activeBuildId: "b1", activeBuild: { buildId: "b1", phase: "build" } }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for terminal items", () => {
+    expect(classifyOperatorReason(item({ status: "done" }))).toBeNull();
+    expect(classifyOperatorReason(item({ status: "deferred" }))).toBeNull();
+  });
+
+  it("returns null for closed dispositions (discard / duplicate / defer)", () => {
+    expect(classifyOperatorReason(item({ status: "open", triageOutcome: "discard" }))).toBeNull();
+    expect(classifyOperatorReason(item({ status: "open", triageOutcome: "duplicate" }))).toBeNull();
+    expect(classifyOperatorReason(item({ status: "open", triageOutcome: "defer" }))).toBeNull();
+  });
+
+  it("returns null for a plain open item with no actionable signal", () => {
+    expect(classifyOperatorReason(item({ status: "open" }))).toBeNull();
+  });
+
+  it("prioritizes build-attention over a stale flag on the same item", () => {
+    const reason: OperatorTriageReason | null = classifyOperatorReason(
+      item({
+        activeBuildId: "b1",
+        activeBuild: { buildId: "b1", phase: "failed" },
+        stalenessDetectedAt: daysAgo(40),
+      }),
+    );
+    expect(reason).toBe("build-attention");
+  });
+});
+
+describe("selectOperatorQueue", () => {
+  it("excludes items that need no operator decision", () => {
+    const queue = selectOperatorQueue(
+      [
+        item({ itemId: "BI-DONE", status: "done" }),
+        item({ itemId: "BI-WORKING", activeBuildId: "b", activeBuild: { buildId: "b", phase: "build" } }),
+        item({ itemId: "BI-PLAIN", status: "open" }),
+      ],
+      NOW,
+    );
+    expect(queue).toHaveLength(0);
+  });
+
+  it("orders by business outcome first, then risk, then staleness", () => {
+    const bizBug = item({ itemId: "BI-BIZ", status: "triaging", workType: "bug", businessValue: 8 });
+    const riskyOnly = item({ itemId: "BI-RISK", status: "triaging", riskOpportunity: 9 });
+    const staleOnly = item({
+      itemId: "BI-STALE",
+      status: "open",
+      stalenessDetectedAt: daysAgo(60),
+    });
+
+    const queue = selectOperatorQueue([staleOnly, riskyOnly, bizBug], NOW);
+    expect(queue.map((e) => e.item.itemId)).toEqual(["BI-BIZ", "BI-RISK", "BI-STALE"]);
+  });
+
+  it("ranks a customer-blocking bug above a non-blocking item", () => {
+    const bug = item({ itemId: "BI-BUG", status: "triaging", workType: "bug" });
+    const chore = item({ itemId: "BI-CHORE", status: "triaging", workType: "chore" });
+    const queue = selectOperatorQueue([chore, bug], NOW);
+    expect(queue[0]?.item.itemId).toBe("BI-BUG");
+    expect(queue[0]?.blocksBusinessOutcome).toBe(true);
+    expect(queue[1]?.blocksBusinessOutcome).toBe(false);
+  });
+
+  it("uses staleness as the tiebreaker when business and risk tie", () => {
+    const older = item({ itemId: "BI-OLD", status: "triaging", updatedAt: daysAgo(90) });
+    const newer = item({ itemId: "BI-NEW", status: "triaging", updatedAt: daysAgo(2) });
+    const queue = selectOperatorQueue([newer, older], NOW);
+    expect(queue.map((e) => e.item.itemId)).toEqual(["BI-OLD", "BI-NEW"]);
+  });
+
+  it("falls back to priority then itemId for full determinism", () => {
+    const a = item({ itemId: "BI-A", status: "triaging", priority: 5, updatedAt: daysAgo(10) });
+    const b = item({ itemId: "BI-B", status: "triaging", priority: 1, updatedAt: daysAgo(10) });
+    const queue = selectOperatorQueue([a, b], NOW);
+    // Lower priority number wins.
+    expect(queue.map((e) => e.item.itemId)).toEqual(["BI-B", "BI-A"]);
+  });
+
+  it("is stable and side-effect free (does not mutate the input array)", () => {
+    const input = [
+      item({ itemId: "BI-1", status: "triaging" }),
+      item({ itemId: "BI-2", status: "open", triageOutcome: "build", effortSize: "small" }),
+    ];
+    const snapshot = input.map((i) => i.itemId);
+    selectOperatorQueue(input, NOW);
+    expect(input.map((i) => i.itemId)).toEqual(snapshot);
+  });
+});

--- a/apps/web/lib/ops/operator-triage.ts
+++ b/apps/web/lib/ops/operator-triage.ts
@@ -1,0 +1,167 @@
+// ─── Operator triage lens for the Operations backlog ───────────────────────
+// BI-9952EA9E: /ops is a wall of 470+ items across 27 epics with no "what should
+// the operator do next". Items of wildly different altitude get equal weight.
+// This derives the SMALL set of items genuinely awaiting an OPERATOR decision —
+// prioritized — from fields already on BacklogItem (status, triageOutcome,
+// effortSize, active build phase, claim state, demand inputs, staleness).
+//
+// Ordering (per the BI): blocking-a-customer/business-outcome first, then
+// risk/severity, then staleness.
+//
+// Pure + dependency-free so it is unit-testable and safe in client components.
+
+import type { BacklogItemWithRelations } from "@/lib/backlog";
+import { resolveBacklogBuildActionState } from "@/lib/backlog-build-action-state";
+
+/** Why an item is on the operator's plate — the human decision it is awaiting. */
+export type OperatorTriageReason =
+  | "awaiting-triage" // status "triaging" — needs a disposition decision
+  | "ready-to-build" // triaged to build + effort-sized — awaiting launch
+  | "build-attention" // linked build failed or is unavailable — needs intervention
+  | "blocked" // work claim explicitly blocked — needs unblocking
+  | "stalled"; // flagged stale and still live — needs a call
+
+export type OperatorTriageEntry = {
+  item: BacklogItemWithRelations;
+  reason: OperatorTriageReason;
+  /** True when the item plausibly blocks a customer or business outcome. */
+  blocksBusinessOutcome: boolean;
+  /** Ordering keys (exposed for tests + UI transparency). */
+  businessScore: number;
+  riskScore: number;
+  stalenessDays: number;
+};
+
+export const OPERATOR_TRIAGE_REASON_LABEL: Record<OperatorTriageReason, string> = {
+  "awaiting-triage": "Awaiting triage",
+  "ready-to-build": "Ready to build",
+  "build-attention": "Build needs attention",
+  blocked: "Blocked",
+  stalled: "Stalled",
+};
+
+export const OPERATOR_TRIAGE_REASON_HINT: Record<OperatorTriageReason, string> = {
+  "awaiting-triage": "No disposition decided yet — triage it (build / runbook / coworker / defer).",
+  "ready-to-build": "Triaged to build and sized — launch it into Build Studio.",
+  "build-attention": "Its Build Studio draft failed or is unavailable — intervene.",
+  blocked: "The work claim is blocked — unblock or reassign.",
+  stalled: "Flagged stale while still live — decide whether it still matters.",
+};
+
+const TERMINAL_STATUSES = new Set(["done", "deferred"]);
+const CLOSED_TRIAGE_OUTCOMES = new Set(["discard", "duplicate", "defer"]);
+const FAILED_BUILD_PHASES = new Set(["failed", "panicked", "abandoned"]);
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+function daysBetween(from: Date | null | undefined, now: Date): number {
+  if (!from) return 0;
+  const ms = now.getTime() - new Date(from).getTime();
+  return ms > 0 ? ms / DAY_MS : 0;
+}
+
+/** The severity a given operator reason contributes to the risk key: a broken
+ *  build or a blocked claim is itself a risk/severity signal. */
+function reasonRisk(reason: OperatorTriageReason): number {
+  switch (reason) {
+    case "build-attention":
+      return 4;
+    case "blocked":
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+/** Classify a single item — returns the primary operator reason, or null when
+ *  the item needs no operator decision right now (agent working, terminal, or a
+ *  closed disposition). The most action-urgent reason wins when several apply. */
+export function classifyOperatorReason(
+  item: BacklogItemWithRelations,
+): OperatorTriageReason | null {
+  if (TERMINAL_STATUSES.has(item.status)) return null;
+  if (item.triageOutcome && CLOSED_TRIAGE_OUTCOMES.has(item.triageOutcome)) return null;
+
+  // A broken/unavailable linked build outranks everything — the operator must act
+  // for work to move at all.
+  const phase = item.activeBuild?.phase ?? null;
+  if (item.activeBuild && phase && FAILED_BUILD_PHASES.has(phase)) return "build-attention";
+  if (item.activeBuildId && !item.activeBuild) return "build-attention";
+
+  // A healthy in-flight build means an agent is working — nothing for the operator.
+  if (item.activeBuild) return null;
+
+  if (item.claimStatus === "blocked") return "blocked";
+
+  // No disposition decided yet — the classic "awaiting an operator decision" state.
+  if (item.status === "triaging") return "awaiting-triage";
+
+  // Triaged to build, open, and effort-sized — awaiting the operator to launch it.
+  if (resolveBacklogBuildActionState(item).kind === "start") return "ready-to-build";
+
+  // Explicitly flagged stale while still live — needs a keep-or-kill call.
+  if (item.stalenessDetectedAt) return "stalled";
+
+  return null;
+}
+
+/** True when the item plausibly blocks a customer or business outcome — used as a
+ *  UI flag and folded into the ordering. Bugs block users; explicit demand inputs
+ *  (businessValue / timeCriticality) name a business stake. */
+function blocksBusinessOutcome(item: BacklogItemWithRelations): boolean {
+  return (
+    (item.businessValue ?? 0) > 0 ||
+    (item.timeCriticality ?? 0) > 0 ||
+    item.workType === "bug"
+  );
+}
+
+function businessScore(item: BacklogItemWithRelations): number {
+  return (item.businessValue ?? 0) * 2 + (item.timeCriticality ?? 0) + (item.workType === "bug" ? 3 : 0);
+}
+
+function riskScore(item: BacklogItemWithRelations, reason: OperatorTriageReason): number {
+  return (item.riskOpportunity ?? 0) + (item.workType === "bug" ? 2 : 0) + reasonRisk(reason);
+}
+
+/**
+ * Select and prioritize the small set of items awaiting an operator decision.
+ *
+ * Ordering (BI-9952EA9E): business-outcome first → risk/severity → staleness,
+ * with priority / createdAt / itemId as deterministic tiebreakers.
+ *
+ * @param items every backlog item (unassigned + epic children, flattened)
+ * @param now injectable clock for staleness (defaults to wall-clock)
+ */
+export function selectOperatorQueue(
+  items: BacklogItemWithRelations[],
+  now: Date = new Date(),
+): OperatorTriageEntry[] {
+  const entries: OperatorTriageEntry[] = [];
+  for (const item of items) {
+    const reason = classifyOperatorReason(item);
+    if (!reason) continue;
+    entries.push({
+      item,
+      reason,
+      blocksBusinessOutcome: blocksBusinessOutcome(item),
+      businessScore: businessScore(item),
+      riskScore: riskScore(item, reason),
+      stalenessDays: daysBetween(item.stalenessDetectedAt ?? item.updatedAt, now),
+    });
+  }
+
+  return entries.sort((a, b) => {
+    if (a.businessScore !== b.businessScore) return b.businessScore - a.businessScore;
+    if (a.riskScore !== b.riskScore) return b.riskScore - a.riskScore;
+    if (a.stalenessDays !== b.stalenessDays) return b.stalenessDays - a.stalenessDays;
+    // Lower priority number = more important; nulls sort last.
+    const pa = a.item.priority ?? Number.POSITIVE_INFINITY;
+    const pb = b.item.priority ?? Number.POSITIVE_INFINITY;
+    if (pa !== pb) return pa - pb;
+    const ca = new Date(a.item.createdAt).getTime();
+    const cb = new Date(b.item.createdAt).getTime();
+    if (ca !== cb) return ca - cb;
+    return a.item.itemId.localeCompare(b.item.itemId);
+  });
+}


### PR DESCRIPTION
## What & why (BI-9952EA9E)

`/ops` is a wall of 470+ items across 27 epics with no *"what should the operator do next"* and no altitude signal — a trivial UI tweak sits with equal weight next to a platform epic. Expanding a large epic also **froze the renderer** under the full-DOM mount.

### 1. "Needs you next" operator triage lens
A collapsible band above the raw list surfacing the **small, prioritized** set of items genuinely awaiting an *operator* decision.

- Selection + ordering live in a pure, unit-tested module `apps/web/lib/ops/operator-triage.ts` (no server imports, safe in client + tests).
- Reasons derived from **existing** `BacklogItem` columns — no new schema: `awaiting-triage` (status `triaging`), `ready-to-build` (triaged + sized, awaiting launch), `build-attention` (linked build failed/unavailable), `blocked` (claim blocked), `stalled` (`stalenessDetectedAt` while live). Healthy in-flight builds and terminal/closed dispositions are excluded.
- **Ordering:** business-outcome first (`businessValue`/`timeCriticality`/bug), then risk/severity (`riskOpportunity` + reason severity), then staleness, with priority → createdAt → itemId as deterministic tiebreakers.
- Loaders now select the existing triage columns; the type carries them as optional so existing fixtures still typecheck.

### 2. Altitude signal on the flat list
Effort-size badge (S/M/L/XL, `?` when unsized) on every `BacklogItemRow` so a trivial tweak no longer reads with the same weight as a platform-scale item.

### 3. Epic-expand freeze (found live)
- `memo()` on `BacklogItemRow` + `EpicCard` and stabilized `OpsClient` callbacks, so an epic-expand / filter change / panel toggle no longer re-renders the whole 470-item tree.
- Paginate an expanded epic's children (25/page, "Show N more"), so a large epic no longer mounts all rows synchronously and freezes. Deep-linked focus renders the full (single) epic so the target row exists.
- **Deferred:** full list virtualization.

## Tests
`apps/web/lib/ops/operator-triage.test.ts` — 17 cases covering classification and ordering. Existing `OpsClient.test.tsx` still green. Both run: 19 passed.

## Scope
No touch to the shared attention aggregate (`apps/web/lib/attention/`). No schema / MCP-tool / external-contract change — internal types only (Process-Spine-Decision attested in the commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
