### PR TITLE
chore(stt): re-pin whisper-server digest after upstream index rotation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -864,7 +864,7 @@ services:
   # No profile gate — voice ships working on `docker compose up`.
   dpf-stt:
     # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest
-    # resolved on 2026-07-05 (the prior 10af319a… digest was deleted from the
+    # resolved on 2026-07-11 (the prior 44d7690a… digest was deleted from the
     # registry — Release Image Manifest Guard caught it again). The registry
     # owner re-pushes :latest periodically and prunes the previous index, so
     # this digest must be re-resolved every time the guard fails. Bump
@@ -874,7 +874,7 @@ services:
     # the sidecar won't start, set DPF_STT_IMAGE in .env to a reachable ref
     # (e.g. hwdsl2/whisper-server:latest) then `docker compose up -d dpf-stt`,
     # and open a PR re-resolving the digest here (this is that PR's pattern).
-    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:44d7690a05787f76d001a097513e578c51624def64e9dbc4a61132d739851e6b}
+    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:3ee18f84149389e886829e31ea4bec40b1919682d8fff7f2f0d447a278f196a6}
     restart: unless-stopped
     logging: *default-logging
     environment:

--- a/tests/release/installer-release-contract.test.mjs
+++ b/tests/release/installer-release-contract.test.mjs
@@ -3,9 +3,9 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const RETIRED_STT_DIGEST =
-  "hwdsl2/whisper-server@sha256:10af319a81e81d03535e94b364b0103e8132d205b46438b4f469da9746fa8462";
-const CURRENT_STT_DIGEST =
   "hwdsl2/whisper-server@sha256:44d7690a05787f76d001a097513e578c51624def64e9dbc4a61132d739851e6b";
+const CURRENT_STT_DIGEST =
+  "hwdsl2/whisper-server@sha256:3ee18f84149389e886829e31ea4bec40b1919682d8fff7f2f0d447a278f196a6";
 const MANIFEST_GUARD =
   "node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned";
 


### PR DESCRIPTION
Re-pin hwdsl2/whisper-server multi-arch index digest so Release Image Manifest Guard passes.

Process-Spine-Decision: release-gate unblock; no product behavior change
Local-CI-Override: STT digest re-pin only