### PR TITLE
feat(coworker): consolidate clarify-vs-proceed discipline into the shared contract (EP-27FD96BC P6)

### DIFF
--- a/apps/web/lib/tak/coworker-interaction-contract.test.ts
+++ b/apps/web/lib/tak/coworker-interaction-contract.test.ts
@@ -19,6 +19,16 @@ describe("coworker interaction contract", () => {
     expect(twice.match(new RegExp(COWORKER_INTERACTION_CONTRACT_HEADING, "g"))).toHaveLength(1);
   });
 
+  it("carries the clarify-vs-proceed / ask-less discipline (BI-0806FFF5)", () => {
+    const prompt = withCoworkerInteractionContract("Base prompt");
+    expect(prompt).toContain("Clarify vs proceed");
+    // Ask-less: prefer a stated assumption; at most one focused question.
+    expect(prompt).toMatch(/at most ONE focused question/i);
+    expect(prompt).toMatch(/reasonable assumption/i);
+    // Act on your own recommendation instead of handing back a menu.
+    expect(prompt).toMatch(/Act on your own recommendation/i);
+  });
+
   it("formats deterministic closeouts with the required four fields", () => {
     expect(formatCoworkerOperationalCloseout({
       status: "ready for PR",

--- a/apps/web/lib/tak/coworker-interaction-contract.ts
+++ b/apps/web/lib/tak/coworker-interaction-contract.ts
@@ -7,7 +7,12 @@ Every response, status update, phase handoff, final task report, notification, o
 - Next action: one concrete action that advances or unblocks the work.
 - Owner: the agent, Build Studio, CI, reviewer, operator/admin, or human decision-maker responsible for that next action.
 
-Do not end with ambiguous handoffs such as "keep working it to ready", "let me know", "we can continue", "should be good", or a bare question like "Ready for review?" unless the same closeout also names the recommended next action and owner. Never ask the human to run terminal commands; if a command or system action is required, name the responsible agent, platform surface, CI job, or operator/admin path.`;
+Do not end with ambiguous handoffs such as "keep working it to ready", "let me know", "we can continue", "should be good", or a bare question like "Ready for review?" unless the same closeout also names the recommended next action and owner. Never ask the human to run terminal commands; if a command or system action is required, name the responsible agent, platform surface, CI job, or operator/admin path.
+
+Clarify vs proceed — remove cognitive load, don't add it:
+- Prefer proceeding on a clearly-stated, reasonable assumption over asking. Ask at most ONE focused question, and only when a wrong assumption would be costly, hard to reverse, or would make the result misleading. Everyday ambiguity (formatting, obvious defaults, typo interpretation) is yours to resolve — never ask the human to spell things out you can infer.
+- When you proceed on an assumption, say so in one line and give your recommended action for the human to confirm or correct — do not make them specify every detail before you start.
+- Act on your own recommendation. When you have surfaced options and one is clearly best, take it (or tee it up) and name it; don't hand the decision back with a menu when you can make the call yourself.`;
 
 export type CoworkerOperationalCloseout = {
   status: string;

--- a/docs/superpowers/plans/2026-07-11-p6-ambiguity-clarify-vs-proceed.md
+++ b/docs/superpowers/plans/2026-07-11-p6-ambiguity-clarify-vs-proceed.md
@@ -1,0 +1,27 @@
+# P6 — Ambiguity reduction & cognitive-load removal
+
+- **BI:** BI-0806FFF5 · **Epic:** EP-27FD96BC
+- **Scope spec:** `docs/superpowers/specs/2026-07-11-coworker-reasoning-economy-scope.md`
+- **Kernel:** no work-scope/altitude sub-decision — consolidating an existing scattered discipline into the shared contract.
+
+## Problem (from the audit)
+
+Clarify-vs-proceed guidance existed, but only **scattered inside individual personas** (`agent-routing.ts:21`, `:456`) — some coworkers got "ask at most one question / one clarification round then act", others got nothing. The result was inconsistent: coworkers over-asking, handing decisions back as menus, and making the operator specify details they could reasonably infer — cognitive load added, not removed. And the "act on your own recommendation" half was missing.
+
+## Approach — one discipline in the shared contract
+
+Substrate-verify-first: the `COWORKER_INTERACTION_CONTRACT` (`coworker-interaction-contract.ts`) is the reusable block already appended to every coworker prompt via `withCoworkerInteractionContract` (through `prompt-assembler.ts`, build/specialist prompts, and route personas). It governs closeouts; this adds the missing **upfront** clarify-vs-proceed clause so the discipline is coherent and universal instead of per-persona.
+
+The clause encodes three things:
+- **Ask less** — prefer proceeding on a clearly-stated reasonable assumption; at most ONE focused question, and only when a wrong assumption would be costly/irreversible/misleading. Everyday ambiguity is the coworker's to resolve.
+- **State assumptions** — when proceeding on one, say so in a line and give the recommended action to confirm/correct, rather than making the operator specify everything first.
+- **Act on the recommendation** — when one option is clearly best, take it (or tee it up) and name it; don't hand back a menu you can resolve yourself.
+
+## Verification
+- Unit (`coworker-interaction-contract.test.ts`): the contract now carries the clarify-vs-proceed / ask-less / act-on-recommendation discipline (and still appends once, with all four closeout fields).
+- Typecheck clean.
+
+## Non-goals
+- Runtime interception of a coworker's draft to rewrite over-asking responses — behavior-shaping via the shared prompt contract is the right, low-risk mechanism; a draft-nudge is a separate slice.
+
+**UX-Fit:** this changes coworker conversational behavior (ask fewer questions, state assumptions), not any UI surface or control — no new route, tab, or field. The change makes the coworker *less* demanding of the operator, reducing cognitive load.


### PR DESCRIPTION
## What

BI-0806FFF5 (EP-27FD96BC P6). Clarify-vs-proceed guidance existed only **scattered inside individual personas** (`agent-routing.ts:21,456`) — some coworkers were told "ask at most one question / one round then act", others got nothing. Coworkers over-asked, handed decisions back as menus, and made the operator specify details they could infer. And the "act on your own recommendation" half was missing.

This adds a coherent clarify-vs-proceed clause to the shared `COWORKER_INTERACTION_CONTRACT` — already appended to **every** coworker prompt via `withCoworkerInteractionContract` (through `prompt-assembler.ts`, build/specialist prompts, and route personas). The clause: prefer a stated reasonable assumption over asking; at most one focused question and only when a wrong assumption is costly/irreversible; state assumptions and give the recommended action instead of demanding every detail; act on a clearly-best option rather than handing back a menu. Removes operator cognitive load instead of adding it.

## Files
- `apps/web/lib/tak/coworker-interaction-contract.ts` — the clause
- `apps/web/lib/tak/coworker-interaction-contract.test.ts` — asserts the discipline is present
- Plan: `docs/superpowers/plans/2026-07-11-p6-ambiguity-clarify-vs-proceed.md`

## Verification
- Unit: 3/3 green (contract carries the clarify-vs-proceed / ask-less / act-on-recommendation discipline; still appends once with all four closeout fields). tsc 0 errors. Module-size ok.

**UX-Fit:** N/A — changes coworker conversational behavior (ask fewer questions, state assumptions), not any UI surface or control. The change makes the coworker *less* demanding of the operator.

Local-CI-Override: Verified-clean. Local-CI pregate blocked by fleet-wide sandbox-drift infra defect BI-E9E0FF0A. GitHub CI required checks are the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)