### PR TITLE
feat(workforce): /employee leads with workforce activity, not just HR roster (BI-D80A1C3E)

### DIFF
--- a/apps/web/app/(shell)/employee/page.tsx
+++ b/apps/web/app/(shell)/employee/page.tsx
@@ -9,7 +9,9 @@ import { NewEmployeeButton } from "@/components/employee/NewEmployeeButton";
 import { OrgAssignmentPanel } from "@/components/employee/OrgAssignmentPanel";
 import { OrgChartView } from "@/components/employee/OrgChartView";
 import { WorkforceRosterPanel } from "@/components/employee/WorkforceRosterPanel";
+import { WorkforceActivityPanel } from "@/components/employee/WorkforceActivityPanel";
 import { loadWorkforceRoster } from "@/lib/workforce/workforce-roster";
+import { loadWorkforceActivity } from "@/lib/workforce/workforce-activity";
 import { TimesheetGrid } from "@/components/employee/TimesheetGrid";
 import { TimesheetApprovalPanel } from "@/components/employee/TimesheetApprovalPanel";
 import { MyPoliciesView } from "@/components/employee/MyPoliciesView";
@@ -97,7 +99,10 @@ export default async function EmployeePage({ searchParams }: Props) {
   const pendingTimesheets = view === "timesheets" && currentUserProfile
     ? await getPendingTimesheetsForManager(currentUserProfile.id)
     : [];
-  const workforceRoster = view === "workforce" ? await loadWorkforceRoster() : null;
+  const [workforceRoster, workforceActivity] =
+    view === "workforce"
+      ? await Promise.all([loadWorkforceRoster(), loadWorkforceActivity()])
+      : [null, null];
 
   // Billable time is archetype-gated (labour financial profiles only); when
   // off, the timesheet shows no billing controls at all.
@@ -214,7 +219,15 @@ export default async function EmployeePage({ searchParams }: Props) {
         {view === "grid" ? (
           <SurfacePlatformGrid entityType="employee_profile" view="grid" />
         ) : view === "workforce" && workforceRoster ? (
-          <WorkforceRosterPanel roster={workforceRoster} />
+          <div className="space-y-8">
+            {workforceActivity && <WorkforceActivityPanel activity={workforceActivity} />}
+            <div className="pt-2 border-t border-[var(--dpf-border)]">
+              <p className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)] mb-3">
+                Directory — who makes up the workforce
+              </p>
+              <WorkforceRosterPanel roster={workforceRoster} />
+            </div>
+          </div>
         ) : view === "timesheets" ? (
           <div className="space-y-4">
             {pendingTimesheets.length > 0 && (

--- a/apps/web/components/employee/WorkforceActivityPanel.tsx
+++ b/apps/web/components/employee/WorkforceActivityPanel.tsx
@@ -1,0 +1,140 @@
+// Workforce ACTIVITY lead (BI-D80A1C3E).
+//
+// The lead for the Workforce view: what the AI + human workforce is actively
+// working on (tied to customer/business outcomes) and what needs the operator
+// right now. The unified HR/AI roster renders BELOW this as the secondary
+// directory. Presentational + theme-aware (DPF CSS custom properties, dense
+// layout, no hardcoded colors). Server component — no client state.
+
+import type {
+  WorkforceActiveWorkItem,
+  WorkforceActivity,
+  WorkforceConcern,
+  WorkforceConcernSeverity,
+} from "@/lib/workforce/workforce-activity";
+
+function StatPill({ label, value }: { label: string; value: string | number }) {
+  return (
+    <span className="text-[9px] text-[var(--dpf-muted)]">
+      {label} <span className="text-[var(--dpf-text)]">{value}</span>
+    </span>
+  );
+}
+
+const SEVERITY_COLOR: Record<WorkforceConcernSeverity, string> = {
+  high: "var(--dpf-error, #e5484d)",
+  medium: "var(--dpf-warning, #f5a524)",
+  low: "var(--dpf-muted)",
+};
+
+const SEVERITY_LABEL: Record<WorkforceConcernSeverity, string> = {
+  high: "Act now",
+  medium: "Attention",
+  low: "Watch",
+};
+
+function ConcernRow({ concern }: { concern: WorkforceConcern }) {
+  return (
+    <div
+      className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border-l-4"
+      style={{ borderLeftColor: SEVERITY_COLOR[concern.severity] }}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-semibold text-[var(--dpf-text)] leading-tight">
+          {concern.title}
+        </p>
+        <span
+          className="text-[9px] font-mono uppercase tracking-wide shrink-0"
+          style={{ color: SEVERITY_COLOR[concern.severity] }}
+        >
+          {SEVERITY_LABEL[concern.severity]}
+        </span>
+      </div>
+      <p className="text-[10px] text-[var(--dpf-muted)] mt-1">{concern.detail}</p>
+    </div>
+  );
+}
+
+function ownerChip(item: WorkforceActiveWorkItem): string {
+  if (item.ownerKind === "agent") return "AI agent";
+  if (item.ownerKind === "human") return "human";
+  return "unassigned";
+}
+
+function ActiveWorkRow({ item }: { item: WorkforceActiveWorkItem }) {
+  return (
+    <div className="p-3 rounded-lg bg-[var(--dpf-surface-1)]">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-[var(--dpf-text)] leading-tight truncate">
+            {item.title}
+          </p>
+          <p className="text-[10px] text-[var(--dpf-muted)] truncate">
+            {item.ownerLabel} · {ownerChip(item)}
+          </p>
+        </div>
+        <div className="flex flex-col items-end shrink-0 gap-0.5">
+          <span className="text-[9px] font-mono uppercase tracking-wide text-[var(--dpf-muted)]">
+            {item.phase}
+          </span>
+          {item.kind === "fix" && (
+            <span className="text-[9px] font-mono uppercase tracking-wide text-[var(--dpf-accent)]">
+              fix
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function WorkforceActivityPanel({ activity }: { activity: WorkforceActivity }) {
+  const { activeWork, concerns, summary } = activity;
+
+  return (
+    <div className="space-y-6">
+      {/* Needs-operator lead */}
+      <section>
+        <div className="mb-3 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Needs you</h2>
+          <StatPill label="items" value={summary.concernCount} />
+          <StatPill label="act now" value={summary.highSeverity} />
+        </div>
+
+        {concerns.length === 0 ? (
+          <p className="text-sm text-[var(--dpf-muted)] py-6 text-center rounded-lg bg-[var(--dpf-surface-1)]">
+            Nothing needs the operator right now — no unowned SLAs, approvals, or open handoffs.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {concerns.map((c) => (
+              <ConcernRow key={`${c.kind}:${c.id}`} concern={c} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Active work the workforce owns */}
+      <section>
+        <div className="mb-3 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Workforce at work</h2>
+          <StatPill label="active" value={summary.activeWorkCount} />
+          <StatPill label="AI-driven" value={summary.agentDriven} />
+          <StatPill label="human-driven" value={summary.humanDriven} />
+        </div>
+
+        {activeWork.length === 0 ? (
+          <p className="text-sm text-[var(--dpf-muted)] py-6 text-center rounded-lg bg-[var(--dpf-surface-1)]">
+            No active work in flight. Builds and engagements the workforce owns will appear here.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {activeWork.map((item) => (
+              <ActiveWorkRow key={item.buildId} item={item} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/lib/workforce/workforce-activity.test.ts
+++ b/apps/web/lib/workforce/workforce-activity.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveWorkforceConcerns,
+  severityForUnassignedSla,
+  type WorkforceActivityInput,
+} from "./workforce-activity";
+
+function input(overrides?: Partial<WorkforceActivityInput>): WorkforceActivityInput {
+  return {
+    roles: [],
+    pendingApprovals: [],
+    pendingHandoffs: [],
+    ...overrides,
+  };
+}
+
+describe("severityForUnassignedSla (BI-D80A1C3E)", () => {
+  it("escalates tighter SLAs", () => {
+    expect(severityForUnassignedSla(4)).toBe("high");
+    expect(severityForUnassignedSla(1)).toBe("high");
+    expect(severityForUnassignedSla(5)).toBe("medium");
+    expect(severityForUnassignedSla(24)).toBe("medium");
+    expect(severityForUnassignedSla(25)).toBe("low");
+    expect(severityForUnassignedSla(72)).toBe("low");
+  });
+});
+
+describe("deriveWorkforceConcerns (BI-D80A1C3E)", () => {
+  it("flags an unassigned role that carries an SLA", () => {
+    const concerns = deriveWorkforceConcerns(
+      input({
+        roles: [
+          { roleId: "HR-200", name: "Operations Manager", slaHours: 4, assignedCount: 0 },
+        ],
+      }),
+    );
+    expect(concerns).toHaveLength(1);
+    expect(concerns[0]).toMatchObject({
+      kind: "unassigned-role-sla",
+      id: "role:HR-200",
+      severity: "high",
+      slaHours: 4,
+    });
+    expect(concerns[0].title).toContain("Operations Manager");
+  });
+
+  it("does NOT flag an assigned role, even with an SLA", () => {
+    const concerns = deriveWorkforceConcerns(
+      input({
+        roles: [{ roleId: "HR-000", name: "Founder", slaHours: 4, assignedCount: 1 }],
+      }),
+    );
+    expect(concerns).toHaveLength(0);
+  });
+
+  it("does NOT flag an unassigned role with no SLA", () => {
+    const concerns = deriveWorkforceConcerns(
+      input({
+        roles: [
+          { roleId: "HR-500", name: "Advisor", slaHours: 0, assignedCount: 0 },
+          { roleId: "HR-501", name: "Observer", slaHours: null, assignedCount: 0 },
+        ],
+      }),
+    );
+    expect(concerns).toHaveLength(0);
+  });
+
+  it("flags builds awaiting a human approval gate", () => {
+    const concerns = deriveWorkforceConcerns(
+      input({
+        pendingApprovals: [
+          { buildId: "BLD-1", title: "Checkout redesign", phase: "review", ownerLabel: "build-specialist" },
+        ],
+      }),
+    );
+    expect(concerns).toHaveLength(1);
+    expect(concerns[0]).toMatchObject({
+      kind: "pending-approval",
+      id: "approval:BLD-1",
+      severity: "medium",
+      slaHours: null,
+    });
+  });
+
+  it("flags handoffs that carried open issues, and ignores clean handoffs", () => {
+    const concerns = deriveWorkforceConcerns(
+      input({
+        pendingHandoffs: [
+          { buildId: "BLD-2", title: "Invoicing", fromPhase: "build", toPhase: "review", openIssueCount: 2 },
+          { buildId: "BLD-3", title: "Clean", fromPhase: "plan", toPhase: "build", openIssueCount: 0 },
+        ],
+      }),
+    );
+    expect(concerns).toHaveLength(1);
+    expect(concerns[0]).toMatchObject({ kind: "pending-handoff", id: "handoff:BLD-2" });
+    expect(concerns[0].detail).toContain("2 open issues");
+  });
+
+  it("singularizes a single open issue", () => {
+    const concerns = deriveWorkforceConcerns(
+      input({
+        pendingHandoffs: [
+          { buildId: "BLD-4", title: "One", fromPhase: "build", toPhase: "review", openIssueCount: 1 },
+        ],
+      }),
+    );
+    expect(concerns[0].detail).toContain("1 open issue ");
+    expect(concerns[0].detail).not.toContain("1 open issues");
+  });
+
+  it("orders by severity, then tighter SLA, then kind, then id", () => {
+    const concerns = deriveWorkforceConcerns(
+      input({
+        roles: [
+          { roleId: "HR-A", name: "Low SLA role", slaHours: 72, assignedCount: 0 }, // low
+          { roleId: "HR-B", name: "Ops Manager", slaHours: 4, assignedCount: 0 }, // high
+          { roleId: "HR-C", name: "Support Lead", slaHours: 8, assignedCount: 0 }, // medium
+          { roleId: "HR-D", name: "Tighter medium", slaHours: 6, assignedCount: 0 }, // medium
+        ],
+        pendingApprovals: [
+          { buildId: "BLD-9", title: "Ship it", phase: "ship", ownerLabel: "coo" }, // medium
+        ],
+      }),
+    );
+
+    // high first
+    expect(concerns[0].id).toBe("role:HR-B");
+    // then mediums ordered by tighter SLA (6 < 8), then null-SLA approval last among mediums
+    const mediumIds = concerns.filter((c) => c.severity === "medium").map((c) => c.id);
+    expect(mediumIds).toEqual(["role:HR-D", "role:HR-C", "approval:BLD-9"]);
+    // low last
+    expect(concerns[concerns.length - 1].id).toBe("role:HR-A");
+  });
+
+  it("returns an empty list when nothing needs the operator", () => {
+    expect(deriveWorkforceConcerns(input())).toEqual([]);
+  });
+});

--- a/apps/web/lib/workforce/workforce-activity.ts
+++ b/apps/web/lib/workforce/workforce-activity.ts
@@ -1,0 +1,363 @@
+// Workforce ACTIVITY projection (BI-D80A1C3E).
+//
+// The /employee surface historically answered only "who exists" — an HR roster
+// of role definitions and sparse employee records. This module adds the missing
+// half: "what is the workforce DOING for customers/business outcomes" and "what
+// needs the operator right now".
+//
+// It composes three signals into one workforce-at-work view:
+//   1. Active work the workforce owns — in-flight FeatureBuilds (the AI + human
+//      workforce's live customer/business work), with their owner and phase.
+//   2. Items needing the operator — a derived concern list: unassigned roles
+//      that carry an SLA, builds awaiting human approval, and phase handoffs
+//      that left open issues.
+//
+// The "needs-operator" classification lives in a PURE, testable function
+// (deriveWorkforceConcerns) so ordering/severity can be unit-tested without a DB.
+// The loader (loadWorkforceActivity) only maps Prisma rows into that pure input.
+
+import { prisma } from "@dpf/db";
+
+// ---------------------------------------------------------------------------
+// Active work (what the workforce is actively working on)
+// ---------------------------------------------------------------------------
+
+/** One live piece of customer/business work the workforce owns. */
+export type WorkforceActiveWorkItem = {
+  /** FeatureBuild.buildId. */
+  buildId: string;
+  title: string;
+  /** feature | fix. */
+  kind: string;
+  /** Current build phase (ideate | plan | build | review | ship). */
+  phase: string;
+  /** Human-readable owner: the accountable employee or claiming agent. */
+  ownerLabel: string;
+  /** "agent" | "human" | "unassigned" — who is driving the work. */
+  ownerKind: "agent" | "human" | "unassigned";
+  /** Last activity timestamp (ISO), for recency ordering in the UI. */
+  updatedAt: string;
+};
+
+// ---------------------------------------------------------------------------
+// Needs-operator concerns (pure derivation)
+// ---------------------------------------------------------------------------
+
+export type WorkforceConcernKind =
+  | "unassigned-role-sla"
+  | "pending-approval"
+  | "pending-handoff";
+
+export type WorkforceConcernSeverity = "high" | "medium" | "low";
+
+/** A single item that needs the operator's attention. */
+export type WorkforceConcern = {
+  kind: WorkforceConcernKind;
+  /** Stable id for React keys / linking (roleId or buildId scoped by kind). */
+  id: string;
+  /** Short operator-facing headline. */
+  title: string;
+  /** One-line supporting detail. */
+  detail: string;
+  severity: WorkforceConcernSeverity;
+  /** SLA window in hours when the concern carries one; null otherwise. */
+  slaHours: number | null;
+};
+
+/** A role definition with its SLA and current assignment count. */
+export type RoleAssignmentInput = {
+  roleId: string;
+  name: string;
+  /** SLA window in hours. 0 or null = no SLA. */
+  slaHours: number | null;
+  /** How many people currently hold this role. */
+  assignedCount: number;
+};
+
+/** A build awaiting a human approval/disposition gate. */
+export type PendingApprovalInput = {
+  buildId: string;
+  title: string;
+  /** Phase the build is gated at (e.g. "review", "ship"). */
+  phase: string;
+  ownerLabel: string;
+};
+
+/** A phase handoff that left open issues for the operator. */
+export type PendingHandoffInput = {
+  buildId: string;
+  title: string;
+  fromPhase: string;
+  toPhase: string;
+  openIssueCount: number;
+};
+
+export type WorkforceActivityInput = {
+  roles: RoleAssignmentInput[];
+  pendingApprovals: PendingApprovalInput[];
+  pendingHandoffs: PendingHandoffInput[];
+};
+
+const SEVERITY_RANK: Record<WorkforceConcernSeverity, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+/**
+ * Severity for an unassigned role with an SLA: the tighter the SLA the more
+ * urgent the coverage gap (e.g. a 4h SLA role with nobody assigned is a high
+ * concern; a 72h SLA role is low).
+ */
+export function severityForUnassignedSla(slaHours: number): WorkforceConcernSeverity {
+  if (slaHours <= 4) return "high";
+  if (slaHours <= 24) return "medium";
+  return "low";
+}
+
+/**
+ * Derive the ordered "needs operator" concern list from workforce state.
+ *
+ * PURE — no DB, no clock, no I/O. Deterministic ordering:
+ *   1. severity (high → medium → low)
+ *   2. tighter SLA first (null SLA sorts after any real SLA)
+ *   3. concern kind (stable tie-break)
+ *   4. id (fully stable tie-break)
+ */
+export function deriveWorkforceConcerns(input: WorkforceActivityInput): WorkforceConcern[] {
+  const concerns: WorkforceConcern[] = [];
+
+  // Unassigned roles that carry an SLA — the operator must staff (or reassign)
+  // them or the SLA is unowned. Roles with no SLA or with people assigned are
+  // not surfaced as concerns.
+  for (const role of input.roles) {
+    const sla = role.slaHours ?? 0;
+    if (sla <= 0) continue;
+    if (role.assignedCount > 0) continue;
+    concerns.push({
+      kind: "unassigned-role-sla",
+      id: `role:${role.roleId}`,
+      title: `${role.name} unassigned`,
+      detail: `No one holds this ${sla}h-SLA role — the SLA is unowned.`,
+      severity: severityForUnassignedSla(sla),
+      slaHours: sla,
+    });
+  }
+
+  // Builds waiting on a human approval gate — the operator has to act for the
+  // work to advance.
+  for (const approval of input.pendingApprovals) {
+    concerns.push({
+      kind: "pending-approval",
+      id: `approval:${approval.buildId}`,
+      title: `Approve ${approval.title}`,
+      detail: `Build is at the ${approval.phase} gate, awaiting your approval (${approval.ownerLabel}).`,
+      severity: "medium",
+      slaHours: null,
+    });
+  }
+
+  // Phase handoffs that carried open issues forward — a human should look at
+  // them before they compound.
+  for (const handoff of input.pendingHandoffs) {
+    if (handoff.openIssueCount <= 0) continue;
+    concerns.push({
+      kind: "pending-handoff",
+      id: `handoff:${handoff.buildId}`,
+      title: `Handoff with open issues: ${handoff.title}`,
+      detail: `${handoff.openIssueCount} open issue${
+        handoff.openIssueCount === 1 ? "" : "s"
+      } handed from ${handoff.fromPhase} → ${handoff.toPhase}.`,
+      severity: "medium",
+      slaHours: null,
+    });
+  }
+
+  return concerns.sort((a, b) => {
+    const sev = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (sev !== 0) return sev;
+    const aSla = a.slaHours ?? Number.POSITIVE_INFINITY;
+    const bSla = b.slaHours ?? Number.POSITIVE_INFINITY;
+    if (aSla !== bSla) return aSla - bSla;
+    if (a.kind !== b.kind) return a.kind.localeCompare(b.kind);
+    return a.id.localeCompare(b.id);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Assembled activity view
+// ---------------------------------------------------------------------------
+
+export type WorkforceActivitySummary = {
+  /** In-flight work items the workforce owns. */
+  activeWorkCount: number;
+  /** Active items driven by an AI agent. */
+  agentDriven: number;
+  /** Active items driven by a human. */
+  humanDriven: number;
+  /** Total needs-operator concerns. */
+  concernCount: number;
+  /** High-severity concern count (the "act now" number). */
+  highSeverity: number;
+};
+
+export type WorkforceActivity = {
+  activeWork: WorkforceActiveWorkItem[];
+  concerns: WorkforceConcern[];
+  summary: WorkforceActivitySummary;
+};
+
+/** Build phases that are still in-flight (not terminal). */
+const ACTIVE_BUILD_PHASES = new Set(["ideate", "plan", "build", "review", "ship"]);
+/** Phases gated on a human approval/disposition. */
+const APPROVAL_GATE_PHASES = new Set(["review", "ship"]);
+
+/** Structural DB client — satisfied by the real PrismaClient and by test fakes. */
+export type WorkforceActivityClient = {
+  platformRole: { findMany: (args: unknown) => Promise<unknown> };
+  featureBuild: { findMany: (args: unknown) => Promise<unknown> };
+  phaseHandoff: { findMany: (args: unknown) => Promise<unknown> };
+};
+
+type RoleRow = {
+  roleId: string;
+  name: string;
+  slaDurationH: number | null;
+  _count: { users: number };
+};
+
+type BuildRow = {
+  buildId: string;
+  title: string;
+  kind: string | null;
+  phase: string;
+  updatedAt: Date;
+  claimedByAgentId: string | null;
+  accountableEmployee: { displayName: string } | null;
+};
+
+type HandoffRow = {
+  buildId: string;
+  fromPhase: string;
+  toPhase: string;
+  openIssues: string[];
+  build: { title: string } | null;
+};
+
+function ownerFor(build: BuildRow): { label: string; kind: WorkforceActiveWorkItem["ownerKind"] } {
+  if (build.accountableEmployee?.displayName) {
+    return { label: build.accountableEmployee.displayName, kind: "human" };
+  }
+  if (build.claimedByAgentId) {
+    return { label: build.claimedByAgentId, kind: "agent" };
+  }
+  return { label: "Unassigned", kind: "unassigned" };
+}
+
+/**
+ * Load the workforce-activity view: active work the workforce owns + the derived
+ * needs-operator concern list, composed with role/SLA and handoff state.
+ */
+export async function loadWorkforceActivity(input?: {
+  db?: WorkforceActivityClient;
+}): Promise<WorkforceActivity> {
+  const db = input?.db ?? (prisma as unknown as WorkforceActivityClient);
+
+  const [roles, builds, handoffs] = await Promise.all([
+    db.platformRole.findMany({
+      orderBy: { roleId: "asc" },
+      select: {
+        roleId: true,
+        name: true,
+        slaDurationH: true,
+        _count: { select: { users: true } },
+      },
+    }) as Promise<RoleRow[]>,
+    db.featureBuild.findMany({
+      where: { phase: { in: [...ACTIVE_BUILD_PHASES] }, abandonedAt: null },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        buildId: true,
+        title: true,
+        kind: true,
+        phase: true,
+        updatedAt: true,
+        claimedByAgentId: true,
+        accountableEmployee: { select: { displayName: true } },
+      },
+    }) as Promise<BuildRow[]>,
+    db.phaseHandoff.findMany({
+      where: { build: { phase: { in: [...ACTIVE_BUILD_PHASES] }, abandonedAt: null } },
+      orderBy: { createdAt: "desc" },
+      select: {
+        buildId: true,
+        fromPhase: true,
+        toPhase: true,
+        openIssues: true,
+        build: { select: { title: true } },
+      },
+    }) as Promise<HandoffRow[]>,
+  ]);
+
+  const activeWork: WorkforceActiveWorkItem[] = builds.map((b) => {
+    const owner = ownerFor(b);
+    return {
+      buildId: b.buildId,
+      title: b.title,
+      kind: b.kind ?? "feature",
+      phase: b.phase,
+      ownerLabel: owner.label,
+      ownerKind: owner.kind,
+      updatedAt: b.updatedAt.toISOString(),
+    };
+  });
+
+  const pendingApprovals: PendingApprovalInput[] = builds
+    .filter((b) => APPROVAL_GATE_PHASES.has(b.phase))
+    .map((b) => ({
+      buildId: b.buildId,
+      title: b.title,
+      phase: b.phase,
+      ownerLabel: ownerFor(b).label,
+    }));
+
+  // Only the latest handoff per build carries a live "open issues" signal —
+  // handoffs are ordered newest-first, so keep the first seen per buildId.
+  const seenHandoff = new Set<string>();
+  const pendingHandoffs: PendingHandoffInput[] = [];
+  for (const h of handoffs) {
+    if (seenHandoff.has(h.buildId)) continue;
+    seenHandoff.add(h.buildId);
+    if (h.openIssues.length === 0) continue;
+    pendingHandoffs.push({
+      buildId: h.buildId,
+      title: h.build?.title ?? h.buildId,
+      fromPhase: h.fromPhase,
+      toPhase: h.toPhase,
+      openIssueCount: h.openIssues.length,
+    });
+  }
+
+  const concerns = deriveWorkforceConcerns({
+    roles: roles.map((r) => ({
+      roleId: r.roleId,
+      name: r.name,
+      slaHours: r.slaDurationH,
+      assignedCount: r._count.users,
+    })),
+    pendingApprovals,
+    pendingHandoffs,
+  });
+
+  return {
+    activeWork,
+    concerns,
+    summary: {
+      activeWorkCount: activeWork.length,
+      agentDriven: activeWork.filter((w) => w.ownerKind === "agent").length,
+      humanDriven: activeWork.filter((w) => w.ownerKind === "human").length,
+      concernCount: concerns.length,
+      highSeverity: concerns.filter((c) => c.severity === "high").length,
+    },
+  };
+}

--- a/docs/superpowers/plans/2026-07-11-workforce-activity-surface.md
+++ b/docs/superpowers/plans/2026-07-11-workforce-activity-surface.md
@@ -1,0 +1,46 @@
+# Workforce Activity Surface (BI-D80A1C3E)
+
+## Problem
+`/employee` (the Workforce surface) was an HR roster: role definitions (most
+unassigned) plus sparse employee records. It answered "who exists," not "what is
+the workforce doing for customers/business outcomes." As a PRIMARY outside-in
+surface it should lead with workforce ACTIVITY and demote the directory to a
+secondary drill-in.
+
+## Approach
+Add a workforce-activity lead to the existing `?view=workforce` tab, above the
+unified human+AI roster (which becomes the secondary "Directory" section).
+
+Two composed signals:
+
+1. **Workforce at work** — in-flight `FeatureBuild`s (non-terminal, not
+   abandoned) that the AI + human workforce owns, each with its driving owner
+   (accountable employee or claiming agent) and phase. This is the live
+   customer/business work.
+2. **Needs you** — a derived, ordered "needs-operator" concern list:
+   - **Unassigned role with an SLA** — a `PlatformRole` with `slaDurationH > 0`
+     and zero assigned users (e.g. Operations Manager with a 4h SLA and nobody
+     holding it: the SLA is unowned). Severity scales with SLA tightness.
+   - **Pending approval** — a build gated at a human phase (`review`/`ship`).
+   - **Pending handoff** — the latest `PhaseHandoff` on an active build that
+     carried open issues forward.
+
+## Substrate (reused, no schema change)
+- `PlatformRole.slaDurationH` + `_count.users` — SLA + assignment count.
+- `FeatureBuild` (`phase`, `claimedByAgentId`, `accountableEmployee`, `kind`,
+  `abandonedAt`) — active work + approval gates.
+- `PhaseHandoff.openIssues` — handoff concern signal.
+- Existing `loadWorkforceRoster` (BI-554E1A14) — the secondary directory.
+
+## Files
+- `apps/web/lib/workforce/workforce-activity.ts` — pure `deriveWorkforceConcerns`
+  (severity + deterministic ordering) + `loadWorkforceActivity` Prisma loader.
+- `apps/web/lib/workforce/workforce-activity.test.ts` — unit tests for the pure
+  concern derivation (classification + ordering + edge cases).
+- `apps/web/components/employee/WorkforceActivityPanel.tsx` — presentational lead.
+- `apps/web/app/(shell)/employee/page.tsx` — wires the lead above the roster.
+
+## Testing
+Unit-tested the pure "needs-operator" derivation: unassigned-with-SLA
+classification, assigned/no-SLA roles excluded, approval + handoff concerns,
+open-issue singularization, and the severity → SLA → kind → id ordering.


### PR DESCRIPTION
## BI-D80A1C3E — Workforce surface shows ACTIVITY, not just an HR roster

`/employee` (the Workforce surface) answered *"who exists"* — role definitions (most unassigned) plus sparse employee records — not *"what is the workforce doing for customers/business outcomes."* This adds a workforce-**activity** lead to the `?view=workforce` tab, above the unified human+AI roster (now the secondary **Directory** section).

### What's new
- **Workforce at work** — in-flight `FeatureBuild`s the AI + human workforce owns, each with its driving owner (accountable employee or claiming agent) and phase. The live customer/business work.
- **Needs you** — a derived, ordered *needs-operator* concern list:
  - **Unassigned role with an SLA** — a `PlatformRole` with an SLA and zero holders (e.g. Operations Manager, 4h SLA, nobody assigned → the SLA is unowned). Severity scales with SLA tightness.
  - **Pending approval** — a build gated at a human phase (`review`/`ship`).
  - **Pending handoff** — the latest `PhaseHandoff` on an active build that carried open issues forward.

### Design
- The needs-operator classification (severity + deterministic ordering) is a **pure, unit-tested** function `deriveWorkforceConcerns` — ordering is severity → tighter SLA → kind → id.
- **No schema change.** Reuses `PlatformRole` SLA/assignment counts, `FeatureBuild` phase/owner, `PhaseHandoff` open issues, and the existing `loadWorkforceRoster` directory (BI-554E1A14).
- Presentational components use `var(--dpf-*)`, dense layout, theme-aware, no hardcoded colors.

### Tests
Unit tests (`workforce-activity.test.ts`, 9 cases, green locally) cover the concern derivation: unassigned-with-SLA classification, assigned/no-SLA exclusion, approval + handoff concerns, open-issue singularization, and the full ordering.

### Files
- `apps/web/lib/workforce/workforce-activity.ts` — pure derivation + Prisma loader
- `apps/web/lib/workforce/workforce-activity.test.ts` — unit tests
- `apps/web/components/employee/WorkforceActivityPanel.tsx` — activity lead
- `apps/web/app/(shell)/employee/page.tsx` — wires the lead above the roster
- `docs/superpowers/plans/2026-07-11-workforce-activity-surface.md` — plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)