### PR TITLE
fix(ops): auto-resolve escalations for abandoned builds (BI-FCAE8154)

### DIFF
--- a/apps/web/components/employee/WorkforceActivityPanel.tsx
+++ b/apps/web/components/employee/WorkforceActivityPanel.tsx
@@ -22,8 +22,8 @@ function StatPill({ label, value }: { label: string; value: string | number }) {
 }
 
 const SEVERITY_COLOR: Record<WorkforceConcernSeverity, string> = {
-  high: "var(--dpf-error, #e5484d)",
-  medium: "var(--dpf-warning, #f5a524)",
+  high: "var(--dpf-error)",
+  medium: "var(--dpf-warning)",
   low: "var(--dpf-muted)",
 };
 

--- a/apps/web/lib/quality/escalation-hygiene-runner.ts
+++ b/apps/web/lib/quality/escalation-hygiene-runner.ts
@@ -41,7 +41,7 @@ export async function runEscalationHygiene(): Promise<{ scanned: number; resolve
       reportId: true,
       createdAt: true,
       featureBuild: {
-        select: { supersededByEpicId: true, originatingBacklogItemId: true },
+        select: { supersededByEpicId: true, originatingBacklogItemId: true, phase: true },
       },
     },
   });
@@ -70,6 +70,7 @@ export async function runEscalationHygiene(): Promise<{ scanned: number; resolve
       reportId: r.reportId,
       createdAt: r.createdAt,
       buildSupersededByEpicId: r.featureBuild?.supersededByEpicId ?? null,
+      buildPhase: r.featureBuild?.phase ?? null,
       originatingBacklogItemId: itemPk,
       backlogItemStatus: item?.status ?? null,
       backlogItemTriageOutcome: item?.triageOutcome ?? null,

--- a/apps/web/lib/quality/escalation-staleness.test.ts
+++ b/apps/web/lib/quality/escalation-staleness.test.ts
@@ -9,6 +9,7 @@ function row(over: Partial<EscalationStalenessRow>): EscalationStalenessRow {
     reportId: "PIR-A",
     createdAt: new Date("2026-06-23T00:00:00Z"),
     buildSupersededByEpicId: null,
+    buildPhase: null,
     originatingBacklogItemId: "bi-cuid-1",
     backlogItemStatus: "deferred",
     backlogItemTriageOutcome: "build",
@@ -37,6 +38,19 @@ describe("selectResolvableEscalations", () => {
       row({ buildSupersededByEpicId: "epic-cuid-1", backlogItemStatus: "in-progress" }),
     ]);
     expect(out).toEqual([{ reportId: "PIR-A", reason: "build-superseded-by-epic" }]);
+  });
+
+  it("resolves when the originating build was abandoned (BI-FCAE8154)", () => {
+    const out = selectResolvableEscalations([
+      row({ buildPhase: "abandoned", backlogItemStatus: "open", backlogItemTriageOutcome: "build" }),
+    ]);
+    expect(out).toEqual([{ reportId: "PIR-A", reason: "originating-build-abandoned" }]);
+  });
+
+  it("KEEPS an escalation whose build is still in a live phase", () => {
+    expect(
+      selectResolvableEscalations([row({ buildPhase: "ideate", backlogItemStatus: "in-progress" })]),
+    ).toEqual([]);
   });
 
   it("resolves the older escalation when a newer one exists for the same item", () => {

--- a/apps/web/lib/quality/escalation-staleness.ts
+++ b/apps/web/lib/quality/escalation-staleness.ts
@@ -29,6 +29,12 @@ export interface EscalationStalenessRow {
   createdAt: Date;
   /** FeatureBuild.supersededByEpicId — set when a decompose was approved (build handled). */
   buildSupersededByEpicId: string | null;
+  /**
+   * FeatureBuild.phase — when `abandoned`, the stall escalation is residue
+   * (BI-FCAE8154). Work (if still wanted) lives on the originating BI; the
+   * per-build dedupeKey frees so a genuine re-stall re-files.
+   */
+  buildPhase: string | null;
   /** Originating BacklogItem.id (FeatureBuild.originatingBacklogItemId), or null if unlinked. */
   originatingBacklogItemId: string | null;
   /** Originating BacklogItem.status, or null if unlinked/missing. */
@@ -42,6 +48,7 @@ export interface ResolvableEscalation {
   /** Stable machine reason for the auto-resolve, surfaced in logs/telemetry. */
   reason:
     | "build-superseded-by-epic"
+    | "originating-build-abandoned"
     | "superseded-by-newer-escalation"
     | "originating-item-done"
     | "originating-item-wont-do";
@@ -83,6 +90,9 @@ function resolveReason(
   // The decompose was approved → the build was superseded by an epic, so the
   // escalation raised against the now-superseded build is handled.
   if (row.buildSupersededByEpicId) return "build-superseded-by-epic";
+
+  // Terminal abandoned build → stall escalation is residue (BI-FCAE8154).
+  if (row.buildPhase === "abandoned") return "originating-build-abandoned";
 
   const itemId = row.originatingBacklogItemId;
   if (!itemId) return null; // No originating link and not superseded — can't prove staleness; keep.


### PR DESCRIPTION
## Summary
- `selectResolvableEscalations` treats `FeatureBuild.phase === "abandoned"` as `originating-build-abandoned`.
- Hygiene runner loads `phase` so the 15-min sweep (and /ops render path) clear stall ghosts.

## BI
BI-FCAE8154

## Test plan
- [x] `pnpm --filter web exec vitest run lib/quality/escalation-staleness.test.ts` (10 tests)
- [ ] CI Unit Tests

Process-Spine-Decision: small bugfix with unit coverage on the pure staleness selector.