### PR TITLE
fix(ui): drop hex fallbacks in WorkforceActivityPanel (style-drift)

### DIFF
--- a/apps/web/components/employee/WorkforceActivityPanel.tsx
+++ b/apps/web/components/employee/WorkforceActivityPanel.tsx
@@ -22,8 +22,8 @@ function StatPill({ label, value }: { label: string; value: string | number }) {
 }
 
 const SEVERITY_COLOR: Record<WorkforceConcernSeverity, string> = {
-  high: "var(--dpf-error, #e5484d)",
-  medium: "var(--dpf-warning, #f5a524)",
+  high: "var(--dpf-error)",
+  medium: "var(--dpf-warning)",
   low: "var(--dpf-muted)",
 };
 


### PR DESCRIPTION
## Summary
- #2829 landed `var(--dpf-error, #e5484d)` / `var(--dpf-warning, #f5a524)` fallbacks.
- Style Drift Guard treats those hex literals as new hardcoded colors and fails **every** PR merging current main.
- Switch to pure `var(--dpf-error)` / `var(--dpf-warning)`.

## Unblocks
All open PRs failing Style Drift Guard solely due to `WorkforceActivityPanel.tsx` (e.g. #2831–#2833).

Process-Spine-Decision: one-line token hygiene; no new durable artifact.