### PR TITLE
style(workforce): drop hardcoded hex fallbacks (Style Drift Guard)

### DIFF
--- a/apps/web/components/employee/WorkforceActivityPanel.tsx
+++ b/apps/web/components/employee/WorkforceActivityPanel.tsx
@@ -22,8 +22,8 @@ function StatPill({ label, value }: { label: string; value: string | number }) {
 }
 
 const SEVERITY_COLOR: Record<WorkforceConcernSeverity, string> = {
-  high: "var(--dpf-error, #e5484d)",
-  medium: "var(--dpf-warning, #f5a524)",
+  high: "var(--dpf-error)",
+  medium: "var(--dpf-warning)",
   low: "var(--dpf-muted)",
 };
 


### PR DESCRIPTION
Fixes the advisory Style Drift Guard main-drift from #2829: WorkforceActivityPanel used var(--dpf-error, #hex) fallbacks; the tokens are always defined so the hex is dropped. 🤖 Generated with [Claude Code](https://claude.com/claude-code)