### PR TITLE
feat(work-mgmt): first-class Requester on the WorkCapsule (EP-WORK-CONVERGENCE, BI-B24F96D0)

### DIFF
--- a/apps/web/lib/work-capsules/work-capsule-store.test.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.test.ts
@@ -128,6 +128,50 @@ describe("work capsule store", () => {
     }));
   });
 
+  it("persists a first-class Requester distinct from the creating actor (BI-B24F96D0)", async () => {
+    db.workCapsule.findUnique.mockResolvedValueOnce(null);
+    db.workCapsule.create.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-REQ", title: "Commissioned work" });
+
+    await createWorkCapsule({
+      db: capsuleDb(),
+      input: {
+        title: "Commissioned work",
+        objective: "Build the thing the founder asked for.",
+        source: "manual",
+        idempotencyKey: "manual:commissioned",
+        requestedByPrincipalId: "principal-requester",
+      },
+      actor: { userId: "worker-1", agentId: "agent-1", principalId: "principal-worker" },
+    });
+
+    expect(db.workCapsule.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        createdByPrincipalId: "principal-worker",
+        requestedByPrincipalId: "principal-requester",
+      }),
+    }));
+  });
+
+  it("defaults the Requester to null when not supplied", async () => {
+    db.workCapsule.findUnique.mockResolvedValueOnce(null);
+    db.workCapsule.create.mockResolvedValueOnce({ id: "row-1", capsuleId: "WC-NOREQ", title: "Self-started" });
+
+    await createWorkCapsule({
+      db: capsuleDb(),
+      input: {
+        title: "Self-started",
+        objective: "Agent started this on its own.",
+        source: "manual",
+        idempotencyKey: "manual:self-started",
+      },
+      actor: { userId: "user-1", agentId: null, principalId: "principal-1" },
+    });
+
+    expect(db.workCapsule.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ requestedByPrincipalId: null }),
+    }));
+  });
+
   it("rejects invalid scope metadata before creating a capsule", async () => {
     db.workCapsule.findUnique.mockResolvedValueOnce(null);
 

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -62,6 +62,9 @@ type CapsuleCreateInput = {
   featureBuildId?: string | null;
   workspaceState?: Record<string, unknown>;
   scope?: WorkCapsuleScopeInput | null;
+  // BI-B24F96D0: principal who commissioned the work (Requester), distinct from
+  // the creating actor. Optional.
+  requestedByPrincipalId?: string | null;
 };
 
 type CapsuleAdoptionInput = {
@@ -199,6 +202,7 @@ export async function createWorkCapsule(args: {
             : null,
           leaseExpiresAt: isExternalLeaseExecutor(args.input.executorKind) ? leaseUntil(now) : null,
           createdByPrincipalId: args.actor.principalId,
+          requestedByPrincipalId: args.input.requestedByPrincipalId ?? null,
           status: args.input.status ?? (args.input.executorKind ? "ready" : "draft"),
         },
       });

--- a/packages/db/prisma/migrations/20260711150000_add_workcapsule_requester/migration.sql
+++ b/packages/db/prisma/migrations/20260711150000_add_workcapsule_requester/migration.sql
@@ -1,0 +1,7 @@
+-- @migration-safety: data-safe: additive nullable column requestedByPrincipalId + one index on WorkCapsule. No drops, no NOT NULL on existing rows, no backfill.
+-- EP-WORK-CONVERGENCE (BI-B24F96D0): first-class Requester on the WorkCapsule.
+
+-- AlterTable
+ALTER TABLE "WorkCapsule" ADD COLUMN     "requestedByPrincipalId" TEXT;
+-- CreateIndex
+CREATE INDEX "WorkCapsule_requestedByPrincipalId_idx" ON "WorkCapsule"("requestedByPrincipalId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1440,6 +1440,10 @@ model WorkCapsule {
   leaseHolderPrincipalId  String?
   leaseExpiresAt          DateTime?
   createdByPrincipalId    String?
+  // EP-WORK-CONVERGENCE (BI-B24F96D0): first-class Requester — the principal who
+  // commissioned the work, distinct from the creator/executor. Nullable; the
+  // stable human-quotable key already exists as capsuleId (WC-*).
+  requestedByPrincipalId  String?
   createdAt               DateTime              @default(now())
   updatedAt               DateTime              @updatedAt
   lastSyncedAt            DateTime?
@@ -1462,6 +1466,7 @@ model WorkCapsule {
   @@index([headBranch])
   @@index([sandboxId])
   @@index([leaseExpiresAt])
+  @@index([requestedByPrincipalId])
 }
 
 model WorkCapsuleActivity {

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -56,8 +56,8 @@ apps/web/lib/tak/agentic-loop.test.ts	2183
 apps/web/lib/tak/agentic-loop.ts	2549
 apps/web/lib/tak/route-context-map.ts	1226
 apps/web/lib/tak/route-context.ts	1363
-apps/web/lib/work-capsules/work-capsule-store.test.ts	943
-apps/web/lib/work-capsules/work-capsule-store.ts	932
+apps/web/lib/work-capsules/work-capsule-store.test.ts	987
+apps/web/lib/work-capsules/work-capsule-store.ts	936
 apps/web/lib/workbooks/platform-tables.ts	892
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace/command-center.ts	1118


### PR DESCRIPTION
## What
Completes the WorkCapsule durable-unit upgrade (EP-WORK-CONVERGENCE, BI-B24F96D0). The stable human-quotable key already exists as `capsuleId` (`WC-*`); this adds the missing half — a **first-class Requester**: the principal who commissioned the work, distinct from the creating actor/executor.

## Changes
- **schema:** `WorkCapsule.requestedByPrincipalId` (nullable) + index. Additive, data-safe migration (`-- @migration-safety: data-safe`) — no drops, no NOT NULL on existing rows, no backfill.
- **write path:** `createWorkCapsule` persists `input.requestedByPrincipalId` (defaults null), mirroring `createdByPrincipalId`.

## Verification
- 36 store tests pass (requester persisted when supplied; defaults null when self-started).
- `apps/web` typecheck clean (0 errors). Migration timestamp `20260711150000` — no collision.

**Local-CI-Override:** Cherry-picked clean onto fresh `origin/main`. Locally verified: `apps/web` tsc 0 errors, 36 tests pass, migration additive + data-safe. The local-CI `next build` was OOM-killed (exit 143) on the runner — an environment resource limit, not this 60-line additive change; GitHub's Production Build is authoritative.

Epic: EP-WORK-CONVERGENCE · builds on Phase 1 BI-D6FA8641 (#2818, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)