### PR TITLE
fix(voice): kill phantom VoiceServiceDown — probe/sidecar health-path contract + guard (BI-7988DAD8)

### DIFF
--- a/apps/web/lib/voice-synthesis/service-status.test.ts
+++ b/apps/web/lib/voice-synthesis/service-status.test.ts
@@ -38,6 +38,29 @@ describe("voice service-status helper", () => {
     )
   })
 
+  it("falls back to the base URL when /health 404s (legacy sidecar) — BI-7988DAD8", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) =>
+      String(url).endsWith("/health")
+        ? new Response("Not Found", { status: 404 })
+        : new Response(JSON.stringify({ status: "ok", model: "chatterbox" }), { status: 200 }),
+    ) as typeof fetch
+    const s = await resolveTtsServiceUp()
+    expect(s).toEqual({ provider: "chatterbox", up: true, reason: null })
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+    expect(String(vi.mocked(global.fetch).mock.calls[1][0])).toBe("http://dpf-tts:8000/")
+  })
+
+  it("still reports not-ready when both /health and the base URL fail", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) =>
+      String(url).endsWith("/health")
+        ? new Response("Not Found", { status: 404 })
+        : new Response("boom", { status: 500 }),
+    ) as typeof fetch
+    const s = await resolveTtsServiceUp()
+    expect(s.up).toBe(false)
+    expect(s.reason).toMatch(/not ready/i)
+  })
+
   it("reports down when the sidecar is unreachable", async () => {
     global.fetch = vi.fn(async () => {
       throw new Error("ECONNREFUSED")

--- a/apps/web/lib/voice-synthesis/service-status.ts
+++ b/apps/web/lib/voice-synthesis/service-status.ts
@@ -45,7 +45,14 @@ export async function resolveTtsServiceUp(): Promise<TtsServiceStatus> {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS)
   try {
-    const res = await fetch(healthUrl, { signal: controller.signal })
+    let res = await fetch(healthUrl, { signal: controller.signal })
+    if (res.status === 404) {
+      // Sidecars provisioned before /health existed serve their health check
+      // at "/" only (BI-7988DAD8). A 404 means "reachable but wrong path",
+      // not "down" — retry at the base URL instead of firing a phantom
+      // VoiceServiceDown on a healthy service.
+      res = await fetch(new URL("/", healthUrl), { signal: controller.signal })
+    }
     if (!res.ok) {
       return { provider, up: false, reason: "The text-to-speech service is reachable but not ready." }
     }

--- a/apps/web/lib/voice-synthesis/tts-health-contract.test.ts
+++ b/apps/web/lib/voice-synthesis/tts-health-contract.test.ts
@@ -1,0 +1,52 @@
+// TTS health-probe contract guard (BI-7988DAD8).
+//
+// The 2026-06/07 phantom-VoiceServiceDown incident: the portal probe requested
+// GET /health, but the chatterbox sidecar served its health check at "/" only.
+// Each side had green unit tests — the probe's tests MOCKED the server and the
+// server had no CI-run tests at all — so the contract mismatch lived for weeks
+// as a permanently-firing alert on a healthy install. The probe and the server
+// are different languages in different runtimes; this test is the one place CI
+// pins them to the same contract, source-to-source (same genre as the
+// Dockerfile build-context guard).
+
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const repoRoot = resolve(__dirname, "../../../..")
+
+function read(rel: string): string {
+  return readFileSync(resolve(repoRoot, rel), "utf8")
+}
+
+describe("TTS health-probe contract", () => {
+  it("chatterbox sidecar serves the /health path the portal probe requests", () => {
+    const server = read("scripts/tts/chatterbox_server.py")
+    expect(server).toContain('@app.get("/health")')
+    // The probe's 404 fallback target must also exist for sidecars provisioned
+    // before /health was added.
+    expect(server).toContain('@app.get("/")')
+  })
+
+  it("probe requests /health and falls back to the base URL on 404", () => {
+    const probe = read("apps/web/lib/voice-synthesis/service-status.ts")
+    expect(probe).toContain("/health")
+    // Fallback is what covers legacy chatterbox installs AND the mlx sidecar
+    // (mlx_audio.server has no /health but serves "/" with 200).
+    expect(probe).toMatch(/status === 404[\s\S]*new URL\("\/", healthUrl\)/)
+  })
+
+  it("macOS overlay wires host-native TTS env on EVERY service exporting voice gauges", () => {
+    const overlay = read("docker-compose.macos.yml")
+    // Both portal and sandbox run the web app and export dpf_voice_tts_*.
+    // Missing either one re-creates the phantom VoiceServiceDown{job="sandbox"}:
+    // the base compose defaults to dpf-tts:8000, which macOS installs never run.
+    for (const service of ["portal:", "sandbox:"]) {
+      const idx = overlay.indexOf(`  ${service}`)
+      expect(idx, `${service} service missing from macOS overlay`).toBeGreaterThan(-1)
+      const nextService = overlay.slice(idx + 2).search(/\n {2}[a-z-]+:/)
+      const block = overlay.slice(idx, nextService === -1 ? undefined : idx + 2 + nextService)
+      expect(block, `${service} block must set DPF_TTS_URL`).toContain("DPF_TTS_URL")
+    }
+  })
+})

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -70,6 +70,16 @@ services:
       DPF_TTS_URL: ${DPF_TTS_URL:-http://host.docker.internal:8771}
       DPF_TTS_REFERENCE_HOST_ROOT: ${DPF_TTS_REFERENCE_HOST_ROOT:-}
 
+  sandbox:
+    environment:
+      # Same host-native TTS wiring as the portal (BI-7988DAD8): the sandbox
+      # exports the dpf_voice_tts_* gauges too, and without this it probes the
+      # base compose's dpf-tts:8000 default — a service macOS installs never
+      # run — so VoiceServiceDown{job="sandbox"} fired forever on a healthy
+      # install.
+      TTS_PROVIDER: ${TTS_PROVIDER:-mlx}
+      DPF_TTS_URL: ${DPF_TTS_URL:-http://host.docker.internal:8771}
+
   browser-use:
     environment:
       LLM_BASE_URL: ${LLM_BASE_URL:-http://model-runner.docker.internal/v1}

--- a/docs/operations/observability-coverage.md
+++ b/docs/operations/observability-coverage.md
@@ -37,6 +37,15 @@ boot-time fail-loud for desired-state drift.
 | `dpf_dependency_up{service="stt"}` | same | gauge only (see follow-ups) |
 | `dpf_http_unhandled_errors_total` | `instrumentation.ts` `onRequestError` | `UnhandledServerErrors` |
 
+TTS probe contract (BI-7988DAD8): the probe requests `GET <DPF_TTS_URL>/health`
+and falls back to the base URL when `/health` 404s, because sidecars provisioned
+before the `/health` alias existed serve their health check at `/` only — a 404
+means "reachable, wrong path", not "down". Both the portal AND the sandbox
+export these gauges, so `docker-compose.macos.yml` sets the host-native
+`DPF_TTS_URL` on both services; without it the sandbox probes the base
+compose's `dpf-tts:8000` default (never running on macOS) and fires a phantom
+`VoiceServiceDown{job="sandbox"}`.
+
 ## Platform split — Linux vs Windows host/infra alerts
 
 The `dpf_infrastructure` Container*/Host* rules key on **cAdvisor (`container_*`)**
@@ -76,6 +85,30 @@ keep the `node_*` rules; Windows installs get the `windows_*` rules.
   security/governance boundary. First-run actuation is owned by the installer
   (BI-3C812E4E, GPU-gated auto-start); a governed runtime host-action rail is the
   proper future path if runtime auto-recovery is ever wanted.
+
+## New-alert checklist — a detector is a feature; verify it functionally
+
+The phantom-VoiceServiceDown incident (BI-7988DAD8): the probe requested
+`/health`, the sidecar served `/`, the probe's unit tests mocked the server and
+asserted the wrong path back to itself, the sidecar had no CI-run tests, and the
+alert fired for weeks on a healthy install while voice synthesis WORKED the
+whole time. The detector shipped as part of the fix for the previous incident
+(voice dead a month while the page said "ready", BI-B2E777EB) — a false-OK was
+traded for a false-ALARM because the detector itself was never functionally
+verified. Before merging any new alert or portal-side probe:
+
+1. **Prove it fires**: induce the failure on a live install (stop the service)
+   and watch the alert reach `firing` end-to-end (gauge → rule → header dot).
+2. **Prove it clears**: restore the service and watch it resolve. A detector
+   that was never seen GREEN against the real counterpart is unverified.
+3. **Never mock the counterparty's contract**: unit tests that stub the probed
+   service encode your assumption, not its API. Pin cross-component/
+   cross-language contracts with a source-level guard test
+   (`apps/web/lib/voice-synthesis/tts-health-contract.test.ts` is the pattern)
+   or probe an endpoint the real feature path already uses.
+4. **Check every gauge exporter**: portal AND sandbox export the portal-side
+   gauges; env wiring (compose overlays) must cover both or the second instance
+   fires a phantom.
 
 ## Alert delivery
 

--- a/scripts/tts/chatterbox_server.py
+++ b/scripts/tts/chatterbox_server.py
@@ -63,6 +63,14 @@ def root():
     return {"status": "ok", "model": "chatterbox", "device": DEVICE}
 
 
+@app.get("/health")
+def health():
+    # Alias of "/" — the portal's TTS liveness probe requests /health
+    # (BI-7988DAD8); serving it only at "/" made a healthy sidecar fire
+    # VoiceServiceDown forever.
+    return {"status": "ok", "model": "chatterbox", "device": DEVICE}
+
+
 @app.get("/v1/models")
 def models():
     return {"object": "list", "data": [{"id": "chatterbox", "object": "model"}]}


### PR DESCRIPTION
## What

Kills the phantom `VoiceServiceDown` warning (BI-7988DAD8) — the WARNING in the founder's Platform Health header that fired on a **healthy** install, and prevents the whole class from recurring.

## Root cause (verified live)

Two independent probe/contract mismatches, both producing "down" verdicts against services that were fine:

1. **Path mismatch**: the portal probe requests `GET /health`; the chatterbox TTS sidecar serves its health at `/` only → 404 → `dpf_voice_tts_up=0` → permanent alert. Each side had green tests — the probe's tests **mocked the server**, the server script had **no CI-run tests** — so no gate could see the cross-runtime disagreement.
2. **Overlay gap**: on macOS the `portal` service gets `DPF_TTS_URL` pointing at the host-native sidecar, but the `sandbox` service (which runs the same web app and exports the same voice gauges) never did — it probes the compose default `dpf-tts:8000`, which macOS installs never run → `VoiceServiceDown{job="sandbox"}` fires forever. This exact alert is firing on the live install right now while the sidecar answers 200 on both paths.

## Fix — both sides + a drift guard

- `service-status.ts`: 404 = "reachable, wrong path" → retry at the base URL (covers legacy chatterbox and the mlx sidecar, which serves `/` only)
- `chatterbox_server.py`: adds `@app.get("/health")` so new installs match the probe's primary path
- `docker-compose.macos.yml`: wires `DPF_TTS_URL` on **both** web-app services (portal AND sandbox)
- **`tts-health-contract.test.ts`** — the prevention: a source-to-source contract guard (same genre as the Dockerfile build-context guard) pinning the probe path, the sidecar routes, and the overlay wiring together in one CI-run test. The probe and the server are different languages in different runtimes; this is the one place CI makes them agree.
- `observability-coverage.md`: documents the contract and the incident pattern

## Verification

- 59 voice-synthesis tests green including the new contract guard; `web` typecheck green (8GB)
- Live: sidecar answers 200 on `/health` AND `/` from inside `dpf-portal-1` while `VoiceServiceDown{job="sandbox"}` fires — confirming both root causes
- Local pregate could not claim its lease (portal quiescing for self-upgrade) — CI is authoritative here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
