### PR TITLE
fix(coworker): proactivity control tells the truth — only enforced effects listed (BI-AB7CD55B)

### DIFF
--- a/apps/web/components/agent/CoworkerProfilePanel.test.tsx
+++ b/apps/web/components/agent/CoworkerProfilePanel.test.tsx
@@ -5,9 +5,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentInfo } from "@/lib/agent-coworker-types";
 
 const getProactivityPreference = vi.fn();
+const getSelfTaskCadenceInfo = vi.fn();
 
 vi.mock("@/lib/actions/proactivity", () => ({
   getCoworkerProactivityPreference: (agentId: string) => getProactivityPreference(agentId),
+  getCoworkerSelfTaskCadenceInfo: (agentId: string) => getSelfTaskCadenceInfo(agentId),
+  saveCoworkerProactivityPreference: vi.fn(async () => ({ ok: true })),
 }));
 
 import { CoworkerProfilePanel } from "./CoworkerProfilePanel";
@@ -15,6 +18,7 @@ import { CoworkerProfilePanel } from "./CoworkerProfilePanel";
 afterEach(() => {
   cleanup();
   getProactivityPreference.mockReset();
+  getSelfTaskCadenceInfo.mockReset();
 });
 
 function makeAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
@@ -31,8 +35,9 @@ function makeAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
 }
 
 describe("CoworkerProfilePanel", () => {
-  it("shows the effective proactivity plan and boundaries", () => {
+  it("shows only ENFORCED proactivity effects — no monitoring/approval/escalation promises (BI-AB7CD55B)", async () => {
     getProactivityPreference.mockResolvedValue(null);
+    getSelfTaskCadenceInfo.mockResolvedValue({ registered: false, cadence: null });
     render(<CoworkerProfilePanel agent={makeAgent()} onClose={vi.fn()} />);
 
     // Two "Proactivity" texts are expected since EP-26E528F5: the section
@@ -40,15 +45,28 @@ describe("CoworkerProfilePanel", () => {
     expect(screen.getAllByText("Proactivity").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Balanced").length).toBeGreaterThan(0);
     expect(screen.getByText(/Balanced is the default proactivity level/i)).toBeTruthy();
-    expect(screen.getByText(/Monitoring: Standard/i)).toBeTruthy();
-    expect(screen.getByText(/Approval: Asks first/i)).toBeTruthy();
-    expect(screen.queryByText(/Spend: standard/i)).toBeNull();
-    expect(screen.queryByText(/Boundary: propose/i)).toBeNull();
+    // The honest effects list: real runtime consumers only.
+    expect(screen.getByText("Opening briefing")).toBeTruthy();
+    expect(await screen.findByText(/Not available for this coworker yet/i)).toBeTruthy();
+    // The old advertised-but-unenforced chips must be gone.
+    expect(screen.queryByText(/Monitoring:/i)).toBeNull();
+    expect(screen.queryByText(/Approval:/i)).toBeNull();
+    expect(screen.queryByText(/Escalates to:/i)).toBeNull();
     expect(screen.queryByText(/proactivity:scheduled-task:balanced/i)).toBeNull();
+  });
+
+  it("shows the real self-task cadence for registered coworkers", async () => {
+    getProactivityPreference.mockResolvedValue("assertive");
+    getSelfTaskCadenceInfo.mockResolvedValue({ registered: true, cadence: { balanced: "weekly", assertive: "daily" } });
+    render(<CoworkerProfilePanel agent={makeAgent()} onClose={vi.fn()} />);
+
+    expect(await screen.findByText("Daily")).toBeTruthy();
+    expect(screen.getByText("Scheduled self-tasks")).toBeTruthy();
   });
 
   it("loads the saved coworker proactivity preference for the profile summary", async () => {
     getProactivityPreference.mockResolvedValue("assertive");
+    getSelfTaskCadenceInfo.mockResolvedValue({ registered: false, cadence: null });
 
     render(<CoworkerProfilePanel agent={makeAgent()} onClose={vi.fn()} />);
 

--- a/apps/web/components/agent/CoworkerProfilePanel.tsx
+++ b/apps/web/components/agent/CoworkerProfilePanel.tsx
@@ -2,9 +2,17 @@
 
 import { useEffect, useState } from "react";
 import type { AgentInfo, AgentSkill } from "@/lib/agent-coworker-types";
-import { getCoworkerProactivityPreference, saveCoworkerProactivityPreference } from "@/lib/actions/proactivity";
+import {
+  getCoworkerProactivityPreference,
+  getCoworkerSelfTaskCadenceInfo,
+  saveCoworkerProactivityPreference,
+} from "@/lib/actions/proactivity";
 import { ProactivityLevelControl } from "@/components/proactivity/ProactivityLevelControl";
 import { resolveProactivityPlan, resolveProactivityPlanForLevel } from "@/lib/proactivity/proactivity-resolver";
+import {
+  describeProactivityEffects,
+  type CoworkerSelfTaskCadenceInfo,
+} from "@/lib/proactivity/proactivity-effects";
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
 
 type Props = {
@@ -63,30 +71,15 @@ const categoryLabels: Record<string, string> = {
   general: "General",
 };
 
-function formatProactivitySpend(spendClass: string): string {
-  if (spendClass === "minimal") return "Light";
-  if (spendClass === "elevated") return "Elevated";
-  return "Standard";
-}
-
-function formatProactivityBoundary(actionBoundary: string): string {
-  if (actionBoundary === "advise") return "Advises only";
-  if (actionBoundary === "preauthorized") return "Pre-approved actions";
-  return "Asks first";
-}
-
-function formatProactivityEscalation(escalationTarget: string): string {
-  if (escalationTarget === "attention-surface") return "Needs you";
-  if (escalationTarget === "platform-operator") return "Platform operator";
-  if (escalationTarget === "dispatcher") return "Dispatcher";
-  if (escalationTarget === "owner") return "Owner";
-  if (escalationTarget === "role") return "Responsible role";
-  return "Needs you";
-}
-
 export function CoworkerProfilePanel({ agent, onClose }: Props) {
   const [expandedSkill, setExpandedSkill] = useState<string | null>(null);
   const [savedProactivityLevel, setSavedProactivityLevel] = useState<ProactivityLevel | null>(null);
+  // BI-AB7CD55B: whether this coworker actually self-drives (curated registry)
+  // — the effects list must not promise scheduled work that doesn't exist.
+  const [selfTaskInfo, setSelfTaskInfo] = useState<CoworkerSelfTaskCadenceInfo>({
+    registered: false,
+    cadence: null,
+  });
   const grouped = groupSkillsByCategory(agent.skills);
   const proactivityInput = {
     activityFamily: "scheduled-task",
@@ -95,12 +88,18 @@ export function CoworkerProfilePanel({ agent, onClose }: Props) {
   const proactivityPlan = savedProactivityLevel
     ? resolveProactivityPlanForLevel(proactivityInput, savedProactivityLevel, "user-override")
     : resolveProactivityPlan(proactivityInput);
+  const proactivityEffects = describeProactivityEffects(proactivityPlan.resolvedLevel, selfTaskInfo);
 
   useEffect(() => {
     let alive = true;
     getCoworkerProactivityPreference(agent.agentId)
       .then((level) => {
         if (alive) setSavedProactivityLevel(level);
+      })
+      .catch(() => {});
+    getCoworkerSelfTaskCadenceInfo(agent.agentId)
+      .then((info) => {
+        if (alive) setSelfTaskInfo(info);
       })
       .catch(() => {});
     return () => {
@@ -215,16 +214,17 @@ export function CoworkerProfilePanel({ agent, onClose }: Props) {
             <div style={{ fontSize: 10, color: "var(--dpf-muted)", marginTop: 6, lineHeight: 1.45 }}>
               {proactivityPlan.explanation}
             </div>
-            <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 8 }}>
-              <span style={{ ...tagStyle, fontSize: 10 }}>
-                Monitoring: {formatProactivitySpend(proactivityPlan.spendClass)}
-              </span>
-              <span style={{ ...tagStyle, fontSize: 10 }}>
-                Approval: {formatProactivityBoundary(proactivityPlan.actionBoundary)}
-              </span>
-              <span style={{ ...tagStyle, fontSize: 10 }}>
-                Escalates to: {formatProactivityEscalation(proactivityPlan.escalationTarget)}
-              </span>
+            {/* BI-AB7CD55B: list ONLY what the dial actually changes at runtime
+                (chat effort, opening briefing, registered self-tasks, failed-task
+                urgency). The old Monitoring/Approval/Escalates-to chips promised
+                enforcement no code performs — enforcement is tracked on the epic. */}
+            <div style={{ display: "flex", flexDirection: "column", gap: 3, marginTop: 8 }}>
+              {proactivityEffects.map((effect) => (
+                <div key={effect.label} style={{ display: "flex", gap: 6, fontSize: 10, lineHeight: 1.4 }}>
+                  <span style={{ color: "var(--dpf-muted)", flex: "0 0 auto", minWidth: 118 }}>{effect.label}</span>
+                  <span style={{ color: "var(--dpf-text-secondary)" }}>{effect.value}</span>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/apps/web/components/platform/coworker-record/CoworkerProactivitySetting.tsx
+++ b/apps/web/components/platform/coworker-record/CoworkerProactivitySetting.tsx
@@ -3,15 +3,30 @@
 // control the chat dock uses (CoworkerPriorityDock), wired to the SAME per-user
 // preference actions — one behavior, one component, two altitudes. Proactivity
 // is a per-viewer UserFact, not an org-global, so the label says "your" setting.
+// BI-AB7CD55B: below the dial, list ONLY what the level actually changes at
+// runtime for THIS coworker — no advertised-but-unenforced monitoring/approval/
+// escalation promises.
 import { useEffect, useRef, useState } from "react";
 
-import { getCoworkerProactivityPreference, saveCoworkerProactivityPreference } from "@/lib/actions/proactivity";
+import {
+  getCoworkerProactivityPreference,
+  getCoworkerSelfTaskCadenceInfo,
+  saveCoworkerProactivityPreference,
+} from "@/lib/actions/proactivity";
 import { ProactivityLevelControl } from "@/components/proactivity/ProactivityLevelControl";
 import { getProactivityLevelCopy } from "@/lib/proactivity/proactivity-copy";
+import {
+  describeProactivityEffects,
+  type CoworkerSelfTaskCadenceInfo,
+} from "@/lib/proactivity/proactivity-effects";
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
 
 export function CoworkerProactivitySetting({ agentId }: { agentId: string }) {
   const [level, setLevel] = useState<ProactivityLevel>("balanced");
+  const [selfTaskInfo, setSelfTaskInfo] = useState<CoworkerSelfTaskCadenceInfo>({
+    registered: false,
+    cadence: null,
+  });
   // Don't let the async load overwrite a choice made while it was in flight —
   // the same clobber guard the chat dock carries (founder report 2026-07-06).
   const editedRef = useRef(false);
@@ -21,6 +36,11 @@ export function CoworkerProactivitySetting({ agentId }: { agentId: string }) {
     getCoworkerProactivityPreference(agentId)
       .then((saved) => {
         if (alive && saved && !editedRef.current) setLevel(saved);
+      })
+      .catch(() => {});
+    getCoworkerSelfTaskCadenceInfo(agentId)
+      .then((info) => {
+        if (alive) setSelfTaskInfo(info);
       })
       .catch(() => {});
     return () => {
@@ -35,23 +55,40 @@ export function CoworkerProactivitySetting({ agentId }: { agentId: string }) {
   }
 
   const copy = getProactivityLevelCopy(level);
+  const effects = describeProactivityEffects(level, selfTaskInfo);
 
   return (
     <div
       style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 12,
         border: "1px solid var(--dpf-border)",
         borderRadius: 8,
         background: "color-mix(in srgb, var(--dpf-surface-2) 70%, transparent)",
         maxWidth: 680,
       }}
     >
-      <ProactivityLevelControl value={level} onChange={onChange} />
-      <span style={{ fontSize: 11, color: "var(--dpf-muted)", lineHeight: 1.45, padding: "8px 12px 8px 0" }}>
-        {copy.description}
-      </span>
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <ProactivityLevelControl value={level} onChange={onChange} />
+        <span style={{ fontSize: 11, color: "var(--dpf-muted)", lineHeight: 1.45, padding: "8px 12px 8px 0" }}>
+          {copy.description}
+        </span>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 3,
+          padding: "0 12px 10px",
+          borderTop: "1px solid var(--dpf-border)",
+          paddingTop: 8,
+        }}
+      >
+        {effects.map((effect) => (
+          <div key={effect.label} style={{ display: "flex", gap: 8, fontSize: 11, lineHeight: 1.4 }}>
+            <span style={{ color: "var(--dpf-muted)", flex: "0 0 auto", minWidth: 140 }}>{effect.label}</span>
+            <span style={{ color: "var(--dpf-text)" }}>{effect.value}</span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/lib/actions/proactivity.ts
+++ b/apps/web/lib/actions/proactivity.ts
@@ -12,7 +12,11 @@ import {
 } from "@/lib/proactivity/proactivity-override-preferences";
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
 import { isProactivityLevel } from "@/lib/proactivity/proactivity-types";
-import { reconcileCoworkerSelfTask } from "@/lib/operate/scheduled-jobs/coworker-self-tasks";
+import {
+  coworkerSelfTaskCadenceInfo,
+  reconcileCoworkerSelfTask,
+} from "@/lib/operate/scheduled-jobs/coworker-self-tasks";
+import type { CoworkerSelfTaskCadenceInfo } from "@/lib/proactivity/proactivity-effects";
 
 type ManualProactivityPreferenceValue = {
   scope: "agent";
@@ -22,6 +26,16 @@ type ManualProactivityPreferenceValue = {
   acknowledgedByUserId: string;
   acknowledgedAt: string;
 };
+
+/** Whether this coworker has a registered autonomous self-task and its
+ *  per-level cadence — feeds the truthful effects list (BI-AB7CD55B). */
+export async function getCoworkerSelfTaskCadenceInfo(
+  agentId: string,
+): Promise<CoworkerSelfTaskCadenceInfo> {
+  const user = await currentUser();
+  if (!user || !agentId) return { registered: false, cadence: null };
+  return coworkerSelfTaskCadenceInfo(agentId);
+}
 
 export async function getCoworkerProactivityPreference(agentId: string): Promise<ProactivityLevel | null> {
   const user = await currentUser();

--- a/apps/web/lib/governance/action-proposal-presentation.test.ts
+++ b/apps/web/lib/governance/action-proposal-presentation.test.ts
@@ -30,7 +30,7 @@ describe("projectActionProposalPresentation", () => {
     expect(presentation.shortLabel).toBe("Customer update");
     expect(presentation.summary).toBe("Why now: Customer appointment timing is operationally load-bearing.");
     expect(presentation.details).toContainEqual({ label: "Proactivity", value: "Assertive" });
-    expect(presentation.details).toContainEqual({ label: "Approval", value: "Asks first" });
+    expect(presentation.details).toContainEqual({ label: "Approval", value: "Requires your approval" });
     expect(presentation.summary).not.toMatch(/AP-|queue|diagnostic/i);
   });
 

--- a/apps/web/lib/governance/action-proposal-presentation.ts
+++ b/apps/web/lib/governance/action-proposal-presentation.ts
@@ -35,7 +35,6 @@ export function projectActionProposalPresentation(
     const whyNow = readString(parameters?.whyNow);
     const proactivity = asRecord(parameters?.proactivity);
     const level = readString(proactivity?.resolvedLevel);
-    const boundary = readString(proactivity?.actionBoundary);
 
     return {
       title: recommendedAction ?? "Send customer update",
@@ -43,7 +42,9 @@ export function projectActionProposalPresentation(
       summary: `Why now: ${whyNow ?? "A customer-visible dispatch commitment needs attention."}`,
       details: [
         { label: "Proactivity", value: level ? readableProactivityLevel(level) : "Balanced" },
-        { label: "Approval", value: readableActionBoundary(boundary) },
+        // BI-AB7CD55B: every proposal is human-gated regardless of the plan's
+        // actionBoundary — say the truth instead of "Pre-approved actions".
+        { label: "Approval", value: "Requires your approval" },
       ],
     };
   }
@@ -105,12 +106,6 @@ function readableProactivityLevel(level: string): string {
     return getProactivityLevelCopy(level).label;
   }
   return humanizeActionType(level);
-}
-
-function readableActionBoundary(boundary: string | null): string {
-  if (boundary === "advise") return "Advises only";
-  if (boundary === "preauthorized") return "Pre-approved actions";
-  return "Asks first";
 }
 
 function readableScope(scope: string, scopeRef?: string | null): string {

--- a/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
+++ b/apps/web/lib/operate/scheduled-jobs/coworker-self-tasks.ts
@@ -152,6 +152,32 @@ export const COWORKER_SELF_TASKS: Record<string, CoworkerSelfTask> = {
   },
 };
 
+/** Friendly cadence label from a registry cron — "daily", "weekly", or
+ *  "twice weekly" by the day-of-week field. Feeds the honest what-this-dial-
+ *  changes lines (BI-AB7CD55B); a wrong guess degrades to a label, not behavior. */
+function friendlyCadence(cron: string): string {
+  const dayOfWeek = cron.trim().split(/\s+/)[4] ?? "*";
+  if (dayOfWeek === "*") return "daily";
+  return dayOfWeek.includes(",") ? "twice weekly" : "weekly";
+}
+
+/** Whether this coworker self-drives, and at what per-level cadence — the
+ *  truthful self-task line for the proactivity control's effects list. */
+export function coworkerSelfTaskCadenceInfo(agentId: string): {
+  registered: boolean;
+  cadence: { balanced: string; assertive: string } | null;
+} {
+  const entry = COWORKER_SELF_TASKS[agentId];
+  if (!entry) return { registered: false, cadence: null };
+  return {
+    registered: true,
+    cadence: {
+      balanced: friendlyCadence(entry.cadence.balanced),
+      assertive: friendlyCadence(entry.cadence.assertive),
+    },
+  };
+}
+
 /** Deterministic per-(agent, owner) taskId so reconcile is idempotent. */
 export function coworkerSelfTaskId(agentId: string, userId: string): string {
   return `self-${agentId}-${userId}`;

--- a/apps/web/lib/proactivity/proactivity-effects.test.ts
+++ b/apps/web/lib/proactivity/proactivity-effects.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { describeProactivityEffects } from "./proactivity-effects";
+
+const registered = {
+  registered: true,
+  cadence: { balanced: "weekly", assertive: "daily" } as const,
+};
+const unregistered = { registered: false, cadence: null };
+
+describe("describeProactivityEffects", () => {
+  it("lists only enforced consumers — never monitoring/approval/escalation", () => {
+    for (const level of ["quiet", "balanced", "assertive"] as const) {
+      const labels = describeProactivityEffects(level, registered).map((l) => l.label);
+      expect(labels).toEqual(["In chat", "Opening briefing", "Scheduled self-tasks", "If its task fails"]);
+      const text = JSON.stringify(describeProactivityEffects(level, registered)).toLowerCase();
+      // The BI-AB7CD55B mislabel surface: these were displayed but nothing enforces them.
+      expect(text).not.toContain("monitoring");
+      expect(text).not.toContain("approval");
+      expect(text).not.toContain("escalat");
+    }
+  });
+
+  it("maps self-task cadence per level for registered coworkers", () => {
+    expect(describeProactivityEffects("quiet", registered).find((l) => l.label === "Scheduled self-tasks")?.value).toBe("Off");
+    expect(describeProactivityEffects("balanced", registered).find((l) => l.label === "Scheduled self-tasks")?.value).toBe("Weekly");
+    expect(describeProactivityEffects("assertive", registered).find((l) => l.label === "Scheduled self-tasks")?.value).toBe("Daily");
+  });
+
+  it("is honest when a coworker has no self-task registration", () => {
+    const line = describeProactivityEffects("assertive", unregistered).find((l) => l.label === "Scheduled self-tasks");
+    expect(line?.value).toBe("Not available for this coworker yet");
+  });
+
+  it("gates the opening briefing by level", () => {
+    expect(describeProactivityEffects("quiet", unregistered).find((l) => l.label === "Opening briefing")?.value).toBe("Silent on open");
+    expect(describeProactivityEffects("assertive", unregistered).find((l) => l.label === "Opening briefing")?.value).toContain("Always briefs");
+  });
+});

--- a/apps/web/lib/proactivity/proactivity-effects.ts
+++ b/apps/web/lib/proactivity/proactivity-effects.ts
@@ -1,0 +1,78 @@
+// BI-AB7CD55B (EP-B9DD37C7 truthfulness): the honest "what this dial actually
+// changes" projection for the proactivity level. Every line here corresponds to
+// a REAL runtime consumer of the level; nothing is listed that no code enforces.
+// The resolver also computes monitoring/approval/escalation fields, but those
+// are display-only today — rendering them as effects was the mislabel this
+// module replaces (enforcement is tracked separately on the epic).
+import type { ProactivityLevel } from "./proactivity-types";
+
+export type CoworkerSelfTaskCadenceInfo = {
+  /** True when the coworker is registered in COWORKER_SELF_TASKS. */
+  registered: boolean;
+  /** Friendly cadence per level when registered, e.g. "weekly", "daily",
+   *  "twice weekly" (quiet is always "off"). */
+  cadence: { balanced: string; assertive: string } | null;
+};
+
+export type ProactivityEffectLine = { label: string; value: string };
+
+/** One line per real consumer of the level, in user language. */
+export function describeProactivityEffects(
+  level: ProactivityLevel,
+  selfTask: CoworkerSelfTaskCadenceInfo,
+): ProactivityEffectLine[] {
+  const lines: ProactivityEffectLine[] = [];
+
+  // Consumer: buildInitiativeBlock → the coworker's in-chat effort posture.
+  lines.push({
+    label: "In chat",
+    value:
+      level === "quiet"
+        ? "Answers what you ask, no extra follow-up"
+        : level === "assertive"
+          ? "Volunteers next steps and follow-ups"
+          : "Follows up when it's useful",
+  });
+
+  // Consumer: opening-briefing loader/composer — presence of the greeting brief.
+  lines.push({
+    label: "Opening briefing",
+    value:
+      level === "quiet"
+        ? "Silent on open"
+        : level === "assertive"
+          ? "Always briefs, even the all-clear"
+          : "Speaks only when something needs you",
+  });
+
+  // Consumer: reconcileCoworkerSelfTask — real cron-backed scheduled work, but
+  // only for coworkers registered in COWORKER_SELF_TASKS. Say so honestly.
+  if (selfTask.registered && selfTask.cadence) {
+    lines.push({
+      label: "Scheduled self-tasks",
+      value: level === "quiet" ? "Off" : capitalize(selfTask.cadence[level]),
+    });
+  } else {
+    lines.push({
+      label: "Scheduled self-tasks",
+      value: "Not available for this coworker yet",
+    });
+  }
+
+  // Consumer: attention source for failed scheduled tasks — urgency of the alert.
+  lines.push({
+    label: "If its task fails",
+    value:
+      level === "quiet"
+        ? "Stays out of your attention list"
+        : level === "assertive"
+          ? "Flags it urgently, due today"
+          : "Shows in your attention list",
+  });
+
+  return lines;
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/docs/superpowers/plans/2026-07-11-proactivity-truth-labels.md
+++ b/docs/superpowers/plans/2026-07-11-proactivity-truth-labels.md
@@ -1,0 +1,22 @@
+# Plan — Proactivity truth-in-labeling (BI-AB7CD55B, EP-B9DD37C7)
+
+**Evidence (2026-07-11 sweep of main):** the claim "proactivity is prompt-only" is stale — the level drives real behavior: `saveCoworkerProactivityPreference` → `reconcileCoworkerSelfTask` creates/reschedules/cancels cron-backed self-tasks for coworkers registered in `COWORKER_SELF_TASKS` (quiet=off, balanced=weekly, assertive=daily/twice-weekly); the opening briefing is gated by level; failed-scheduled-task attention urgency scales with level; and `buildInitiativeBlock` sets in-chat effort for all coworkers. The real defect is a **copy-vs-wiring gap**: `CoworkerProfilePanel` rendered Monitoring/Approval/Escalates-to chips (from the resolver's `spendClass`/`actionBoundary`/`escalationTarget`) and the field-dispatch proposal card rendered `actionBoundary`, but **no runtime code enforces any of those fields** — `channelPolicy`/`followUpCadenceMinutes`/`maxAttempts` are parsed and never read, and `delegated-posture.ts` (the would-be authority enforcer) is dead code with zero production call sites.
+
+**Kernel decision:** hybrid-label-now-file-enforcement (principle_decide 2026-07-11, external_coding_agent; low-confidence tie between the two label-now variants — the hybrid is a superset of the same action, adopted with ledger reported).
+
+## Changes (this PR)
+
+1. `apps/web/lib/proactivity/proactivity-effects.ts` (new, pure): `describeProactivityEffects(level, selfTaskInfo)` — one line per REAL consumer (in-chat effort, opening briefing, registered self-task cadence or an honest "not available for this coworker yet", failed-task urgency). Unit-tested that monitoring/approval/escalation never appear.
+2. `coworker-self-tasks.ts`: `coworkerSelfTaskCadenceInfo(agentId)` — registration + friendly per-level cadence from the registry crons.
+3. `lib/actions/proactivity.ts`: `getCoworkerSelfTaskCadenceInfo` server action (session-gated).
+4. `CoworkerProfilePanel`: unenforced Monitoring/Approval/Escalates-to chips → the honest effects list.
+5. `CoworkerProactivitySetting` (coworker record): same effects list under the dial — both altitudes tell the same true story.
+6. `action-proposal-presentation.ts`: proposal "Approval" detail is now the static truth — "Requires your approval" (every proposal is human-gated regardless of `actionBoundary`).
+
+## Deferred (filed on EP-B9DD37C7)
+
+Enforcement BI: make `actionBoundary`/`escalationTarget`/`followUpCadenceMinutes`/`channelPolicy`/`maxAttempts` real (tool-filter gate, escalation routing, follow-up scheduler) and wire or delete dead `delegated-posture.ts`; until then those fields stay display-suppressed. Self-task coverage beyond the 3 registered coworkers is BI-E962B9CD.
+
+## Gates
+
+Worktree typecheck + scoped vitest; `pnpm run pregate`; UX check of the panel + record on the leased contributor preview if warranted (copy-level change); PR with `UX-Fit-Decision:` trailer citing the kernel ledger.


### PR DESCRIPTION
## Proactivity control tells the truth (BI-AB7CD55B, EP-B9DD37C7)

An evidence sweep found the BI's original claim ("prompt-only") **stale**: the proactivity level genuinely drives self-task cadence for registered coworkers (quiet=off / balanced=weekly / assertive=daily or twice-weekly via `reconcileCoworkerSelfTask`), gates the opening briefing, scales failed-task attention urgency, and sets in-chat effort. What WAS false is what the UI advertised: the chat profile panel's **Monitoring / Approval / Escalates-to** chips and the proposal card's `actionBoundary` label promise enforcement that **no runtime code performs** — `followUpCadenceMinutes`/`channelPolicy`/`maxAttempts` are parsed and never read, and `delegated-posture.ts` is dead code with zero production call sites.

### Changes
- New pure `describeProactivityEffects(level, selfTaskInfo)` — one line per **real** consumer, unit-tested to never mention monitoring/approval/escalation.
- `coworkerSelfTaskCadenceInfo` + `getCoworkerSelfTaskCadenceInfo` action — honest per-coworker "Scheduled self-tasks: Off/Weekly/Daily" or "Not available for this coworker yet".
- `CoworkerProfilePanel` (chat) and `CoworkerProactivitySetting` (coworker record) render the same truthful effects list at both altitudes.
- Proposal card "Approval" detail → **"Requires your approval"** (every proposal is human-gated regardless of the plan's `actionBoundary`).

### Deferred, filed
- **BI-754C9E82** (EP-B9DD37C7): enforce the advertised fields (boundary gate, escalation routing, follow-up scheduler, wire-or-delete `delegated-posture`) so the display can return.
- Self-task coverage beyond the 3 registered coworkers remains BI-E962B9CD.

### Verification
- Local-CI convergence sandbox gate green for this head (typecheck + 15,437 tests + production build). One retry was needed for a vitest worker `EnvironmentTeardownError` teardown flake (15,437/15,437 tests passed on the flaked run too).
- Plan: `docs/superpowers/plans/2026-07-11-proactivity-truth-labels.md`.

UX-Fit-Decision: hybrid-label-now-file-enforcement — principle_decide 2026-07-11, external_coding_agent profile (9.97; low-confidence tie between two label-now variants, hybrid superset adopted); truth-in-labeling reduces human_cognitive_load by removing promises the runtime does not keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
