### PR TITLE
feat(work-mgmt): backlog items track through the WorkCase view with real status (EP-WORK-CONVERGENCE, BI-AC815F1E)

### DIFF
--- a/apps/web/lib/mcp/packs/backlog-pack.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.ts
@@ -1110,11 +1110,13 @@ async function updateBacklogItemStatus(
     triageOutcome: item.triageOutcome,
     hasActiveBuild: item.activeBuildId != null,
   });
-  // EP-3516E23D CWQ activation: a claim-on-start (→ in-progress) surfaces the
-  // BI as a WorkItem in the triage queue and records its arrival into queue
-  // flow-telemetry. Idempotent (no duplicate on re-claim) and best-effort —
-  // queue bridging must never fail the claim it observes.
-  if (target === "in-progress") {
+  // EP-3516E23D CWQ activation + BI-AC815F1E lifecycle sync: every backlog status
+  // transition is observed by the bridge. It materializes a WorkItem case when
+  // work starts (→ in-progress) and, on later transitions, syncs the live case's
+  // status (→ done closes it) so the unified WorkCase view tracks the item's whole
+  // lifecycle — not just the claim. Idempotent (no duplicate on re-claim) and
+  // best-effort — bridging must never fail the transition it observes.
+  {
     void (async () => {
       try {
         const { bridgeBacklogItemToWorkItem } = await import(

--- a/apps/web/lib/queue/bridges/backlog-bridge.test.ts
+++ b/apps/web/lib/queue/bridges/backlog-bridge.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const { workItem, backlogItem, workQueue, inngestSend, recordQueueTransition } = vi.hoisted(() => ({
-  workItem: { findFirst: vi.fn(), create: vi.fn() },
+  workItem: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
   backlogItem: { findUniqueOrThrow: vi.fn() },
   workQueue: { upsert: vi.fn() },
   inngestSend: vi.fn(),
@@ -17,6 +17,7 @@ import { bridgeBacklogItemToWorkItem } from "./backlog-bridge";
 beforeEach(() => {
   workItem.findFirst.mockReset();
   workItem.create.mockReset();
+  workItem.update.mockReset();
   backlogItem.findUniqueOrThrow.mockReset();
   workQueue.upsert.mockReset();
   inngestSend.mockReset();
@@ -24,17 +25,9 @@ beforeEach(() => {
 });
 
 describe("bridgeBacklogItemToWorkItem", () => {
-  it("is idempotent — returns the existing live WorkItem without creating a new one", async () => {
-    workItem.findFirst.mockResolvedValue({ itemId: "WI-existing" });
-    const id = await bridgeBacklogItemToWorkItem("BI-1");
-    expect(id).toBe("WI-existing");
-    expect(workItem.create).not.toHaveBeenCalled();
-    expect(recordQueueTransition).not.toHaveBeenCalled();
-  });
-
-  it("creates a queued WorkItem and records an enqueued transition on first claim", async () => {
+  it("creates an in-progress WorkItem and records an enqueued transition when work starts", async () => {
+    backlogItem.findUniqueOrThrow.mockResolvedValue({ title: "Do the thing", body: "details", status: "in-progress" });
     workItem.findFirst.mockResolvedValue(null);
-    backlogItem.findUniqueOrThrow.mockResolvedValue({ title: "Do the thing", body: "details" });
     workQueue.upsert.mockResolvedValue({ id: "wq-internal-id", queueId: "triage-default" });
     const created = { itemId: "WI-new", createdAt: new Date("2026-07-06T12:00:00Z") };
     workItem.create.mockResolvedValue(created);
@@ -45,22 +38,57 @@ describe("bridgeBacklogItemToWorkItem", () => {
     const createArg = workItem.create.mock.calls[0]![0];
     expect(createArg.data.sourceType).toBe("backlog-item");
     expect(createArg.data.sourceId).toBe("BI-1");
-    expect(createArg.data.status).toBe("queued");
+    // status is projected from the backlog item, not hardcoded (BI-AC815F1E)
+    expect(createArg.data.status).toBe("in-progress");
     expect(createArg.data.urgency).toBe("priority");
     expect(createArg.data.queueId).toBe("wq-internal-id");
 
     expect(recordQueueTransition).toHaveBeenCalledOnce();
     const tel = recordQueueTransition.mock.calls[0]![0];
-    expect(tel.queueKey).toBe("cwq:wq-internal-id");
-    expect(tel.itemKind).toBe("work-item");
     expect(tel.itemId).toBe("WI-new");
     expect(tel.transition).toBe("enqueued");
     expect(tel.occurredAt).toEqual(created.createdAt);
   });
 
-  it("falls back to the title when the BacklogItem has no body", async () => {
+  it("does NOT create a fresh case for a not-yet-started item (no flooding of triaging items)", async () => {
+    backlogItem.findUniqueOrThrow.mockResolvedValue({ title: "Untriaged", body: null, status: "triaging" });
     workItem.findFirst.mockResolvedValue(null);
-    backlogItem.findUniqueOrThrow.mockResolvedValue({ title: "Titled only", body: null });
+
+    const id = await bridgeBacklogItemToWorkItem("BI-triaging");
+
+    expect(id).toBeNull();
+    expect(workItem.create).not.toHaveBeenCalled();
+    expect(recordQueueTransition).not.toHaveBeenCalled();
+  });
+
+  it("syncs an existing live case's status when the backlog item advances (in-progress → done closes it)", async () => {
+    backlogItem.findUniqueOrThrow.mockResolvedValue({ title: "Do the thing", body: "details", status: "done" });
+    workItem.findFirst.mockResolvedValue({ itemId: "WI-existing", status: "in-progress", title: "Do the thing" });
+
+    const id = await bridgeBacklogItemToWorkItem("BI-1");
+
+    expect(id).toBe("WI-existing");
+    expect(workItem.create).not.toHaveBeenCalled();
+    expect(workItem.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { itemId: "WI-existing" },
+      data: expect.objectContaining({ status: "completed" }),
+    }));
+  });
+
+  it("is a no-op when the existing case already matches the backlog item's status and title", async () => {
+    backlogItem.findUniqueOrThrow.mockResolvedValue({ title: "Do the thing", body: "d", status: "in-progress" });
+    workItem.findFirst.mockResolvedValue({ itemId: "WI-existing", status: "in-progress", title: "Do the thing" });
+
+    const id = await bridgeBacklogItemToWorkItem("BI-1");
+
+    expect(id).toBe("WI-existing");
+    expect(workItem.update).not.toHaveBeenCalled();
+    expect(workItem.create).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the title when the BacklogItem has no body", async () => {
+    backlogItem.findUniqueOrThrow.mockResolvedValue({ title: "Titled only", body: null, status: "in-progress" });
+    workItem.findFirst.mockResolvedValue(null);
     workQueue.upsert.mockResolvedValue({ id: "wq", queueId: "triage-default" });
     workItem.create.mockResolvedValue({ itemId: "WI-2", createdAt: new Date() });
     await bridgeBacklogItemToWorkItem("BI-2");

--- a/apps/web/lib/queue/bridges/backlog-bridge.ts
+++ b/apps/web/lib/queue/bridges/backlog-bridge.ts
@@ -17,29 +17,69 @@ const LIVE_WORK_ITEM_STATUSES = [
 ];
 
 /**
- * Create a WorkItem from a BacklogItem so it can be tracked through the
+ * BI-AC815F1E: project a BacklogItem's lifecycle status onto a WorkItem status so
+ * the unified WorkCase view reflects the real state instead of always showing
+ * "intake". BacklogStatuses (triaging|open|in-progress|done|deferred) map onto the
+ * WorkItem statuses that projectWorkItem already collapses into WorkCase states.
+ */
+const BACKLOG_STATUS_TO_WORK_ITEM_STATUS: Record<string, string> = {
+  triaging: "queued",
+  open: "queued",
+  "in-progress": "in-progress",
+  done: "completed",
+  deferred: "deferred",
+};
+
+function mapBacklogStatusToWorkItemStatus(status: string): string {
+  return BACKLOG_STATUS_TO_WORK_ITEM_STATUS[status] ?? "queued";
+}
+
+/**
+ * Create or sync a WorkItem from a BacklogItem so it can be tracked through the
  * collaborative work queue, and record its arrival into the shared flow
  * telemetry (EP-3516E23D). Idempotent: if a live WorkItem already exists for
- * this BacklogItem, it returns that item rather than creating a duplicate — so
- * a claim → release → re-claim cycle does not spawn multiple queue entries.
+ * this BacklogItem, it SYNCS that item's status/title to the backlog item's
+ * current state and returns it rather than creating a duplicate — so a claim →
+ * release → re-claim cycle does not spawn multiple queue entries, and a
+ * triaging → in-progress → done transition is reflected on the case
+ * (BI-AC815F1E). A re-opened backlog item (its prior WorkItem now completed/
+ * cancelled) still gets a fresh live case, by design.
  */
 export async function bridgeBacklogItemToWorkItem(
   backlogItemId: string,
   urgency: WorkItemUrgency = "routine",
-): Promise<string> {
+): Promise<string | null> {
+  const item = await prisma.backlogItem.findUniqueOrThrow({
+    where: { itemId: backlogItemId },
+  });
+  const mappedStatus = mapBacklogStatusToWorkItemStatus(item.status);
+
   const existing = await prisma.workItem.findFirst({
     where: {
       sourceType: "backlog-item",
       sourceId: backlogItemId,
       status: { in: LIVE_WORK_ITEM_STATUSES },
     },
-    select: { itemId: true },
+    select: { itemId: true, status: true, title: true },
   });
-  if (existing) return existing.itemId;
+  if (existing) {
+    if (existing.status !== mappedStatus || existing.title !== item.title) {
+      await prisma.workItem.update({
+        where: { itemId: existing.itemId },
+        data: { status: mappedStatus, title: item.title, description: item.body ?? item.title },
+      });
+    }
+    return existing.itemId;
+  }
 
-  const item = await prisma.backlogItem.findUniqueOrThrow({
-    where: { itemId: backlogItemId },
-  });
+  // Only materialize a fresh case when work actually starts (in-progress). This
+  // lets the invocation fire on every backlog transition — so an existing case
+  // stays synced (above) and closes on done — without flooding the queue with a
+  // case for every triaging/open/deferred item that no one has started
+  // (BI-AC815F1E).
+  if (mappedStatus !== "in-progress") {
+    return null;
+  }
 
   const triageQueue = await prisma.workQueue.upsert({
     where: { queueId: TRIAGE_QUEUE_ID },
@@ -67,7 +107,7 @@ export async function bridgeBacklogItemToWorkItem(
       effortClass: "medium",
       workerConstraint: { workerType: "either" },
       queueId: triageQueue.id,
-      status: "queued",
+      status: mappedStatus,
     },
   });
 

--- a/docs/superpowers/plans/2026-07-11-bi-ac815f1e-backlog-projection-bridge-plan.md
+++ b/docs/superpowers/plans/2026-07-11-bi-ac815f1e-backlog-projection-bridge-plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan — BI-AC815F1E: Bridge backlog items into the WorkCase projection
+
+**BI:** BI-AC815F1E (epic **EP-WORK-CONVERGENCE**) — "bridge remaining work primitives into the WorkCase projection via source-registry". First slice: **BacklogItem**.
+**Date:** 2026-07-11
+**Status:** Implemented (bridge + invocation, this PR); live E2E is the acceptance step (see below).
+
+## Slice scope — BacklogItem first
+BacklogItem is the cleanest first bridge because most of the substrate exists: `backlog-item` is registered in `WORK_CASE_WORK_ITEM_SOURCE_TYPES`, `projectWorkItem` already maps WorkItem statuses to WorkCase states, and the workspace lens already surfaces `sourceType:"backlog-item"` rows. `bridgeBacklogItemToWorkItem` already existed and was already invoked on `→in-progress`.
+
+## Gaps closed
+1. **Status was hardcoded `queued`** (`backlog-bridge.ts`): an in-progress backlog item materialized as a WorkItem at `queued` → rendered as *intake*. Fixed with a `BacklogStatus → WorkItem.status` map (`triaging|open→queued`, `in-progress→in-progress`, `done→completed`, `deferred→deferred`); the item is now created at its projected status.
+2. **No lifecycle sync**: once created (at in-progress), later backlog transitions never updated the WorkItem, so a done item's case stayed *active*. The bridge now syncs an existing live case's status+title, so `in-progress → done` closes the case.
+3. **Invocation only fired on `→in-progress`** (`mcp-tools.ts` backlog status handler): broadened to fire on every backlog transition. To avoid flooding the queue with a case for every triaging/open item, the bridge only **creates** a fresh case on work-start (in-progress) and otherwise only **syncs** an existing case (returns null when there's nothing to materialize).
+
+## Verification
+- 5 bridge unit tests: create-at-projected-status; no-create for not-yet-started (no flooding); sync-on-advance (in-progress→done closes); no-op when already matching; body fallback. `apps/web` typecheck clean (0 errors).
+- **Live-portal acceptance (follow-up, per structural-verification-is-not-functional):** confirm on the Contributor preview (:3001) that claiming/advancing a real backlog item materializes/syncs a WorkItem and it appears at `/workspace` cases at the right state. Not claimed as done from the unit run alone.
+
+## Follow-on
+Epic, FeatureBuild, TaskRun, CoworkerEngagement, WorkEngagement each need their own source-type + registry entry + bridge + status map (their statuses differ from WorkItem's). BacklogItem is first because it skips those.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -40,8 +40,8 @@ apps/web/lib/integrate/build-orchestrator.ts	1780
 apps/web/lib/integrate/sandbox/build-branch.ts	854
 apps/web/lib/marketing.ts	1367
 apps/web/lib/mcp-tools-backlog.test.ts	901
-apps/web/lib/mcp-tools.ts	8633
-apps/web/lib/mcp/packs/backlog-pack.ts	1380
+apps/web/lib/mcp-tools.ts	8272
+apps/web/lib/mcp/packs/backlog-pack.ts	1382
 apps/web/lib/navigation/portal-navigation-model.ts	937
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1328


### PR DESCRIPTION
## What
First slice of bridging the fragmented work primitives into the unified WorkCase view — **BacklogItem**. The bridge existed but hardcoded WorkItem `status='queued'` (so an in-progress backlog item rendered as *intake*) and only fired on `→in-progress` (so a case never closed).

## Changes
- **backlog-bridge:** project `BacklogStatus → WorkItem.status` (triaging/open→queued, in-progress→in-progress, done→completed, deferred→deferred); create a case **only on work-start** (in-progress) to avoid flooding the queue with every triaging item; **sync** an existing live case's status/title on later transitions so `in-progress → done` closes it.
- **invocation:** fire the bridge on **every** backlog status transition (not only →in-progress), best-effort.

## Verification
- 5 bridge unit tests (create-at-projected-status; no-flood for not-started; sync-on-advance closes; no-op when matching; body fallback). `apps/web` typecheck clean.
- **Live-portal E2E is the acceptance step** (per structural-verification-is-not-functional): confirm on the Contributor preview that advancing a real backlog item materializes/syncs a WorkItem at `/workspace`. Not claimed done from the unit run alone.

Plan: `docs/superpowers/plans/2026-07-11-bi-ac815f1e-backlog-projection-bridge-plan.md`.

**Local-CI-Override:** Off fresh `origin/main`; verified locally (5 tests, tsc 0 errors, module-size re-baselined). Local-CI `next build` OOM (143) — env limit; GitHub Production Build authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Local-CI-Override:** Re-applied onto `main` after backlog tooling was drained into `backlog-pack.ts` (resolved the conflict). Verified locally: 5 bridge tests pass, `apps/web` tsc 0 errors (after Prisma regen). Local-CI `next build` OOMs on the shared runner (env limit); GitHub Production Build authoritative.