### PR TITLE
feat(work-mgmt): external agents register a tracked session at work-start (EP-WORK-CONVERGENCE, BI-5FDBF786)

### DIFF
--- a/apps/web/lib/mcp/packs/work-capsules-pack.ts
+++ b/apps/web/lib/mcp/packs/work-capsules-pack.ts
@@ -269,6 +269,27 @@ const definitions: ToolDefinition[] = [
     requiredCapability: "manage_backlog",
     sideEffect: true,
   },
+  {
+    name: "start_external_work",
+    description:
+      "Register that you are STARTING work on an external session — before any evidence — so a tracked Work Capsule exists immediately and the session is visible to other agents instead of appearing only after the first result. Idempotent per session (or per repo+branch when a worktree is supplied); summary is optional at start.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        provider: { type: "string", description: "Provider string (claude, codex, grok, opencode) — mapped to the closest executor kind." },
+        externalSessionId: { type: "string", description: "Stable id for this external session (the capsule executorRef)." },
+        summary: { type: "string", description: "Optional short description of the work being started." },
+        backlogItemId: { type: "string", description: "Optional BacklogItem id (BI-*) this session works." },
+        worktreePath: { type: "string", description: "Optional local worktree path (enables the adopt path keyed on repo+branch)." },
+        branchName: { type: "string", description: "Optional branch (head) — required with worktreePath for the adopt path." },
+        repositoryFullName: { type: "string", description: "Optional GitHub repository full name; defaults to the platform repo." },
+        baseBranch: { type: "string", description: "Optional base branch (defaults to main)." },
+      },
+      required: ["provider", "externalSessionId"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
 ];
 
 const HANDLERS = () => import("@/lib/work-capsules/mcp-handlers");
@@ -289,6 +310,7 @@ export const workCapsulesPack: ToolPack = {
     release_capsule_scope: (params, userId, context) => HANDLERS().then((m) => m.releaseCapsuleScopeTool(params, userId, context)),
     record_capsule_evidence: (params, userId, context) => HANDLERS().then((m) => m.recordCapsuleEvidenceTool(params, userId, context)),
     reassign_capsule_executor: (params, userId, context) => HANDLERS().then((m) => m.reassignCapsuleExecutorTool(params, userId, context)),
+    start_external_work: (params, userId, context) => HANDLERS().then((m) => m.startExternalWorkTool(params, userId, context)),
   },
   grants: {
     list_work_capsules: ["work_capsule_read"],
@@ -303,5 +325,6 @@ export const workCapsulesPack: ToolPack = {
     release_capsule_scope: ["work_capsule_write"],
     record_capsule_evidence: ["work_capsule_write"],
     reassign_capsule_executor: ["work_capsule_write"],
+    start_external_work: ["work_capsule_adopt"],
   },
 };

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -187,6 +187,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   plan_capsule_worktree: ["work_capsule_write"],
   adopt_worktree: ["work_capsule_adopt"],
   claim_backlog_item_for_work: ["work_capsule_adopt"],
+  start_external_work: ["work_capsule_adopt"],
   claim_capsule_scope: ["work_capsule_write"],
   record_capsule_evidence: ["work_capsule_write"],
   heartbeat_capsule: ["work_capsule_write"],

--- a/apps/web/lib/work-capsules/external-session-capture.test.ts
+++ b/apps/web/lib/work-capsules/external-session-capture.test.ts
@@ -1,17 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockCreate, mockRecord } = vi.hoisted(() => ({
+const { mockCreate, mockRecord, mockAdopt } = vi.hoisted(() => ({
   mockCreate: vi.fn(),
   mockRecord: vi.fn(),
+  mockAdopt: vi.fn(),
 }));
 
 vi.mock("./work-capsule-store", () => ({
   createWorkCapsule: mockCreate,
   recordWorkCapsuleEvidence: mockRecord,
+  adoptWorktreeCapsule: mockAdopt,
 }));
 
 import {
   captureExternalSessionEvidence,
+  ensureExternalSessionCapsule,
   providerToExecutorKind,
 } from "./external-session-capture";
 
@@ -77,5 +80,57 @@ describe("providerToExecutorKind", () => {
     expect(providerToExecutorKind("Codex CLI")).toBe("codex-desktop");
     expect(providerToExecutorKind("grok-4")).toBe("grok-desktop");
     expect(providerToExecutorKind("something-else")).toBe("human");
+  });
+});
+
+describe("ensureExternalSessionCapsule work-start signal (BI-5FDBF786)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreate.mockResolvedValue({ capsuleId: "WC-START", id: "row-start" });
+    mockAdopt.mockResolvedValue({ capsuleId: "WC-ADOPTED", id: "row-adopted" });
+    mockRecord.mockResolvedValue({});
+  });
+
+  it("creates a tracked capsule at start WITHOUT recording any evidence (no summary required)", async () => {
+    const capsuleId = await ensureExternalSessionCapsule({
+      db,
+      externalSessionId: "sess-start",
+      provider: "codex",
+      actor,
+    });
+
+    expect(capsuleId).toBe("WC-START");
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          idempotencyKey: "external-session:sess-start",
+          executorKind: "codex-desktop",
+          executorRef: "sess-start",
+          source: "external-adoption",
+        }),
+      }),
+    );
+    // the whole point: starting work is not recording evidence
+    expect(mockRecord).not.toHaveBeenCalled();
+  });
+
+  it("uses the adopt path (keyed on repo+branch) when a worktree location is supplied", async () => {
+    const capsuleId = await ensureExternalSessionCapsule({
+      db,
+      externalSessionId: "sess-loc",
+      provider: "grok",
+      actor,
+      worktreePath: "/tmp/wt",
+      branchName: "feat/x",
+    });
+
+    expect(capsuleId).toBe("WC-ADOPTED");
+    expect(mockAdopt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ headBranch: "feat/x", worktreePath: "/tmp/wt", executorRef: "sess-loc" }),
+      }),
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockRecord).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/work-capsules/external-session-capture.ts
+++ b/apps/web/lib/work-capsules/external-session-capture.ts
@@ -57,9 +57,45 @@ export async function captureExternalSessionEvidence(args: {
   repositoryFullName?: string | null;
   baseBranch?: string | null;
 }): Promise<string> {
+  const capsuleId = await ensureExternalSessionCapsule(args);
+
+  await recordWorkCapsuleEvidence({
+    db: args.db,
+    capsuleId,
+    evidence: {
+      kind: "note",
+      summary: args.summary.trim().slice(0, 500) || "External development evidence recorded",
+    },
+    actor: args.actor,
+  });
+
+  return capsuleId;
+}
+
+/**
+ * BI-5FDBF786: ensure an external session is a tracked WorkCapsule at WORK
+ * START — before any evidence is recorded. captureExternalSessionEvidence
+ * fires on first evidence (after work); this is the pure start signal so an
+ * external agent (Claude/Codex/Grok/opencode) that has started but not yet
+ * reported is not invisible. Idempotent per externalSessionId (create path) or
+ * per (repo, branch) (adopt path). `summary` is optional — a starting session
+ * need not describe an outcome yet.
+ */
+export async function ensureExternalSessionCapsule(args: {
+  db: CapsuleDb;
+  externalSessionId: string;
+  provider: string;
+  actor: WorkCapsuleActor;
+  summary?: string | null;
+  backlogItemId?: string | null;
+  worktreePath?: string | null;
+  branchName?: string | null;
+  repositoryFullName?: string | null;
+  baseBranch?: string | null;
+}): Promise<string> {
   const idempotencyKey = `external-session:${args.externalSessionId}`;
   const objective =
-    args.summary.trim().slice(0, 500)
+    args.summary?.trim().slice(0, 500)
     || `External ${args.provider} development session`;
   const title = `${providerLabel(args.provider)} session ${args.externalSessionId}`.slice(0, 120);
   const backlogItemId = args.backlogItemId?.trim() || null;
@@ -69,9 +105,8 @@ export async function captureExternalSessionEvidence(args: {
   // Prefer the adopt path when we have a location: it keys the capsule on
   // (repo, branch) so the session's BI, worktree, and branch are one record —
   // and late-binds the BI if the branch was already adopted without one.
-  let capsule;
   if (worktreePath && branchName) {
-    capsule = await adoptWorktreeCapsule({
+    const capsule = await adoptWorktreeCapsule({
       db: args.db,
       input: {
         title,
@@ -89,31 +124,21 @@ export async function captureExternalSessionEvidence(args: {
       },
       actor: args.actor,
     });
-  } else {
-    capsule = await createWorkCapsule({
-      db: args.db,
-      input: {
-        title,
-        objective,
-        source: "external-adoption",
-        executorKind: providerToExecutorKind(args.provider),
-        executorRef: args.externalSessionId,
-        idempotencyKey,
-        backlogItemId,
-      },
-      actor: args.actor,
-    });
+    return capsule.capsuleId;
   }
 
-  await recordWorkCapsuleEvidence({
+  const capsule = await createWorkCapsule({
     db: args.db,
-    capsuleId: capsule.capsuleId,
-    evidence: {
-      kind: "note",
-      summary: args.summary.trim().slice(0, 500) || "External development evidence recorded",
+    input: {
+      title,
+      objective,
+      source: "external-adoption",
+      executorKind: providerToExecutorKind(args.provider),
+      executorRef: args.externalSessionId,
+      idempotencyKey,
+      backlogItemId,
     },
     actor: args.actor,
   });
-
   return capsule.capsuleId;
 }

--- a/apps/web/lib/work-capsules/mcp-handlers.ts
+++ b/apps/web/lib/work-capsules/mcp-handlers.ts
@@ -42,7 +42,7 @@ import {
   type WorkCapsuleActor,
 } from "./work-capsule-store";
 import { listLocalBranches } from "./git-scanner";
-import { providerToExecutorKind } from "./external-session-capture";
+import { providerToExecutorKind, ensureExternalSessionCapsule } from "./external-session-capture";
 
 type ToolContext = {
   routeContext?: string;
@@ -798,5 +798,37 @@ export async function recordCapsuleEvidenceTool(
     entityId: renewedCapsule.capsuleId,
     message: `Recorded evidence for ${renewedCapsule.capsuleId}.`,
     data: { capsule: renewedCapsule },
+  };
+}
+
+export async function startExternalWorkTool(
+  params: Record<string, unknown>,
+  userId: string,
+  context: ToolContext,
+): Promise<ToolResult> {
+  const provider = stringParam(params, "provider");
+  const externalSessionId = stringParam(params, "externalSessionId");
+  if (!provider || !externalSessionId) {
+    return { success: false, error: "invalid_input", message: "provider and externalSessionId are required." };
+  }
+
+  const capsuleId = await ensureExternalSessionCapsule({
+    db: workCapsuleDb(),
+    externalSessionId,
+    provider,
+    actor: await actor(userId, context),
+    summary: stringParam(params, "summary"),
+    backlogItemId: stringParam(params, "backlogItemId"),
+    worktreePath: stringParam(params, "worktreePath"),
+    branchName: stringParam(params, "branchName"),
+    repositoryFullName: stringParam(params, "repositoryFullName"),
+    baseBranch: stringParam(params, "baseBranch"),
+  });
+
+  return {
+    success: true,
+    entityId: capsuleId,
+    message: `Started tracked work session ${capsuleId} for ${provider}.`,
+    data: { capsuleId },
   };
 }

--- a/docs/superpowers/plans/2026-07-11-bi-5fdbf786-workstart-autoclaim-v2-plan.md
+++ b/docs/superpowers/plans/2026-07-11-bi-5fdbf786-workstart-autoclaim-v2-plan.md
@@ -1,0 +1,14 @@
+# Implementation Plan — BI-5FDBF786: External agent work-start auto-claims a WorkCapsule
+
+**BI:** BI-5FDBF786 (epic EP-WORK-CONVERGENCE) · **Date:** 2026-07-11 · **Status:** Implemented.
+
+## Gap
+Capsule-at-start largely existed (`claim_backlog_item_for_work` creates a capsule at claim; `adopt_worktree` adopts one; `captureExternalSessionEvidence` auto-captures on first EVIDENCE). But an external agent that has STARTED without a BI, without a worktree, and before any evidence was invisible — no pure pre-evidence start signal.
+
+## What this delivers
+- Extract `ensureExternalSessionCapsule` from `captureExternalSessionEvidence` (the capsule create/adopt part, no evidence append; `summary` optional). Capture now delegates to it — behavior unchanged.
+- `start_external_work` MCP tool (pack def + handler + grant + agent-grants) — external Claude/Codex/Grok/opencode register a tracked capsule at start, before any result. Idempotent per session (create) or per repo+branch (adopt). Grant `work_capsule_adopt`; provenance-free description.
+
+## Verification
+- 4 tests: create-at-start-without-evidence; adopt path when worktree supplied; existing capture behavior preserved; drift/hygiene green. Typecheck clean (0 errors post-typegen).
+- Live-portal validation deferred (per operator: validate the whole epic at completion).

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -40,10 +40,7 @@ apps/web/lib/integrate/build-orchestrator.ts	1780
 apps/web/lib/integrate/sandbox/build-branch.ts	854
 apps/web/lib/marketing.ts	1367
 apps/web/lib/mcp-tools-backlog.test.ts	901
-apps/web/lib/mcp-tools.ts	12422
-apps/web/lib/mcp-tools.ts	12802
-apps/web/lib/mcp-tools.ts	12851
-apps/web/lib/mcp-tools.ts	12171
+apps/web/lib/mcp-tools.ts	11699
 apps/web/lib/navigation/portal-navigation-model.ts	937
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1328
@@ -53,13 +50,13 @@ apps/web/lib/self-upgrade/quiescence.test.ts	842
 apps/web/lib/self-upgrade/quiescence.ts	1460
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	903
-apps/web/lib/tak/agent-grants.ts	814
+apps/web/lib/tak/agent-grants.ts	815
 apps/web/lib/tak/agent-routing.ts	965
 apps/web/lib/tak/agentic-loop.test.ts	2183
 apps/web/lib/tak/agentic-loop.ts	2549
 apps/web/lib/tak/route-context-map.ts	1226
 apps/web/lib/tak/route-context.ts	1363
-apps/web/lib/work-capsules/mcp-handlers.ts	803
+apps/web/lib/work-capsules/mcp-handlers.ts	835
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1055
 apps/web/lib/work-capsules/work-capsule-store.ts	1003
 apps/web/lib/workbooks/platform-tables.ts	892


### PR DESCRIPTION
## What
Closes the pre-evidence work-start gap. Capsule-at-start largely existed (`claim_backlog_item_for_work`, `adopt_worktree`, auto-capture-on-evidence), but an external agent starting **without** a BI/worktree and **before** any evidence was invisible.

## Changes
- Extract `ensureExternalSessionCapsule` from `captureExternalSessionEvidence` (capsule create/adopt part; `summary` optional). Capture delegates to it — **behavior unchanged**.
- `start_external_work` MCP tool (pack def + handler + grant + agent-grants) so external Claude/Codex/Grok/opencode register a tracked capsule **at start**. Idempotent per session (create) or per repo+branch (adopt).

## Verification
- 4 tests (create-at-start-without-evidence; adopt path; capture behavior preserved) + drift/hygiene green. `apps/web` typecheck clean (0 errors post-typegen).
- Live-portal validation **deferred to epic completion** per operator.

Plan: `docs/superpowers/plans/2026-07-11-bi-5fdbf786-workstart-autoclaim-v2-plan.md`.

**Local-CI-Override:** Off fresh `origin/main`; verified locally. Local-CI `next build` OOM (143) — env limit; GitHub Production Build authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)