### PR TITLE
feat(work-mgmt): Build Studio customer-mode status from the capsule projection (EP-WORK-CONVERGENCE, BI-BB13B599)

### DIFF
--- a/apps/web/lib/build/customer-status-projection.test.ts
+++ b/apps/web/lib/build/customer-status-projection.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { projectBuildStudioCustomerStatus } from "./customer-status-projection";
+
+const build = { title: "Add a dark-mode toggle", phase: "build" as const };
+
+describe("projectBuildStudioCustomerStatus (BI-BB13B599)", () => {
+  it("derives a plain customer status from the linked capsule (blocked → automated work, needs you)", () => {
+    const status = projectBuildStudioCustomerStatus({
+      build,
+      capsule: { capsuleId: "WC-1", status: "blocked" },
+    });
+    expect(status.whatIsBeingBuilt).toBe("Add a dark-mode toggle");
+    expect(status.lifecyclePosition).toBe("Automated work in progress");
+    expect(status.worker).toBe("Automated build in progress");
+    expect(status.needsYou).toBe(true);
+  });
+
+  it("maps an active capsule to plain in-progress language, no attention needed", () => {
+    const status = projectBuildStudioCustomerStatus({
+      build,
+      capsule: { capsuleId: "WC-1", status: "working" },
+    });
+    expect(status.lifecyclePosition).toBe("In progress");
+    expect(status.worker).toBe("Work in progress");
+    expect(status.needsYou).toBe(false);
+  });
+
+  it("maps a completed capsule to Done / Finished", () => {
+    const status = projectBuildStudioCustomerStatus({
+      build,
+      capsule: { capsuleId: "WC-1", status: "complete" },
+    });
+    expect(status.lifecyclePosition).toBe("Done");
+    expect(status.worker).toBe("Finished");
+    expect(status.needsYou).toBe(false);
+  });
+
+  it("maps a verifying capsule to checking-the-work", () => {
+    const status = projectBuildStudioCustomerStatus({
+      build,
+      capsule: { capsuleId: "WC-1", status: "verifying" },
+    });
+    expect(status.lifecyclePosition).toBe("Checking the work");
+    expect(status.worker).toBe("Reviewing the work");
+  });
+
+  it("falls back to a phase-only plain status when no capsule is linked", () => {
+    const status = projectBuildStudioCustomerStatus({ build, capsule: null });
+    expect(status.lifecyclePosition).toBe("Building it");
+    expect(status.worker).toBe("Work in progress");
+    expect(status.needsYou).toBe(false);
+  });
+
+  it("surfaces needs-you on a failed phase-only build", () => {
+    const status = projectBuildStudioCustomerStatus({
+      build: { title: "x", phase: "failed" },
+      capsule: null,
+    });
+    expect(status.needsYou).toBe(true);
+    expect(status.worker).toBe("Hit a problem");
+  });
+
+  it("is business-safe by construction — never leaks an executor name to the customer", () => {
+    for (const status of ["working", "blocked", "verifying", "complete", "ready", "draft", "abandoned"]) {
+      const out = projectBuildStudioCustomerStatus({ build, capsule: { capsuleId: "WC-1", status } });
+      const combined = `${out.whatIsBeingBuilt} ${out.lifecyclePosition} ${out.worker}`;
+      expect(combined).not.toMatch(/claude|codex|grok|opencode/i);
+    }
+  });
+});

--- a/apps/web/lib/build/customer-status-projection.ts
+++ b/apps/web/lib/build/customer-status-projection.ts
@@ -1,0 +1,108 @@
+// BI-BB13B599 (EP-WORK-CONVERGENCE): translate a Build Studio build + its linked
+// WorkCapsule into a plain, business-safe customer-mode status. Build Studio's
+// bands read FeatureBuild.phase directly and are blind to the capsule projection,
+// so external Claude/Codex/Grok work carried on the capsule is invisible. This
+// pure function reuses the WorkCase projection (projectWorkCaseState) and never
+// takes the executor in its signature — business-safety (no "Claude"/"Codex"/
+// "Grok" leaking to the customer) is guaranteed by construction.
+//
+// Pure + unit-testable. The DB fetch (workCapsule.findFirst by featureBuildId)
+// and the BuildStudio.tsx render are a deferred follow-up (need live-portal
+// verification).
+
+import { projectWorkCaseState } from "@/lib/work-management/status-projection";
+import type { WorkCaseState } from "@/lib/work-management/case-types";
+import type { BuildPhase } from "@/lib/explore/feature-build-types";
+
+export interface BuildStudioCustomerStatus {
+  /** Plain restatement of what is being built (the build title). */
+  whatIsBeingBuilt: string;
+  /** Plain-language lifecycle position, safe for a nontechnical requester. */
+  lifecyclePosition: string;
+  /** Who/what is working, translated to business-safe language — never an executor name. */
+  worker: string;
+  /** True when the work is waiting on the human (surfaces "Needs you"). */
+  needsYou: boolean;
+}
+
+const NEEDS_YOU_STATES: ReadonlySet<WorkCaseState> = new Set([
+  "waiting-on-person",
+  "awaiting-decision",
+  "waiting-on-system",
+]);
+
+/** Capsule-derived WorkCaseState → plain lifecycle label. */
+const STATE_PLAIN: Record<WorkCaseState, string> = {
+  intake: "Getting started",
+  triage: "Getting started",
+  active: "In progress",
+  "waiting-on-person": "Waiting for you",
+  "waiting-on-system": "Automated work in progress",
+  "awaiting-decision": "Waiting for your decision",
+  verifying: "Checking the work",
+  resolved: "Done",
+  closed: "Closed",
+  cancelled: "Stopped",
+};
+
+/** Phase-only fallback label when no capsule is linked yet. */
+const PHASE_PLAIN: Record<BuildPhase, string> = {
+  ideate: "Figuring out what to build",
+  plan: "Planning the work",
+  build: "Building it",
+  review: "Reviewing the work",
+  ship: "Getting ready to ship",
+  complete: "Done",
+  failed: "Hit a problem",
+  abandoned: "Stopped",
+};
+
+/** Business-safe worker phrasing — deliberately never names Claude/Codex/Grok. */
+function workerLabel(state: WorkCaseState): string {
+  switch (state) {
+    case "waiting-on-system":
+      return "Automated build in progress";
+    case "active":
+      return "Work in progress";
+    case "verifying":
+      return "Reviewing the work";
+    case "waiting-on-person":
+    case "awaiting-decision":
+      return "Waiting for you";
+    case "resolved":
+    case "closed":
+      return "Finished";
+    case "cancelled":
+      return "Stopped";
+    default:
+      return "Getting started";
+  }
+}
+
+export function projectBuildStudioCustomerStatus(args: {
+  build: { title: string; phase: BuildPhase };
+  capsule: { capsuleId: string; status: string } | null;
+}): BuildStudioCustomerStatus {
+  if (args.capsule) {
+    const projection = projectWorkCaseState({ capsule: args.capsule });
+    return {
+      whatIsBeingBuilt: args.build.title,
+      lifecyclePosition: STATE_PLAIN[projection.state],
+      worker: workerLabel(projection.state),
+      needsYou: NEEDS_YOU_STATES.has(projection.state),
+    };
+  }
+
+  // No capsule linked yet: degrade to a phase-only plain status.
+  return {
+    whatIsBeingBuilt: args.build.title,
+    lifecyclePosition: PHASE_PLAIN[args.build.phase],
+    worker:
+      args.build.phase === "complete"
+        ? "Finished"
+        : args.build.phase === "failed"
+          ? "Hit a problem"
+          : "Work in progress",
+    needsYou: args.build.phase === "failed",
+  };
+}

--- a/docs/superpowers/plans/2026-07-11-bi-bb13b599-bs-customer-status-plan.md
+++ b/docs/superpowers/plans/2026-07-11-bi-bb13b599-bs-customer-status-plan.md
@@ -1,0 +1,17 @@
+# Implementation Plan — BI-BB13B599: Build Studio customer-mode status from the capsule projection
+
+**BI:** BI-BB13B599 (epic EP-WORK-CONVERGENCE) · **Date:** 2026-07-11 · **Status:** Pure projection slice implemented; render wiring deferred (live-portal).
+
+## Gap
+Build Studio's bands read `FeatureBuild.phase` directly (`BuildStudio.tsx`) and are blind to the WorkCapsule projection, so external Claude/Codex/Grok progress carried on the capsule is invisible in customer mode.
+
+## This slice (pure, unit-testable)
+- `apps/web/lib/build/customer-status-projection.ts` — `projectBuildStudioCustomerStatus({ build, capsule })` returns a business-safe `{ whatIsBeingBuilt, lifecyclePosition, worker, needsYou }`. Reuses `projectWorkCaseState` (does not re-implement the status map); combines with `build.phase`; falls back to a phase-only plain status when no capsule is linked.
+- **Business-safe by construction:** the executor is NOT in the signature, and `worker` labels never name Claude/Codex/Grok/opencode — a unit test asserts the output never matches `/claude|codex|grok|opencode/i`.
+
+## Verification
+- 7 unit tests (capsule status → plain state/needsYou; phase-only fallback; failed→needs-you; business-safety guard). Typecheck clean (0 errors post-typegen). No DB, no React.
+
+## Deferred (needs live-portal verification, per operator — validate at epic completion)
+- The server-side fetch `workCapsule.findFirst({ where: { featureBuildId: build.id } })` (join precedent: `evidence-timeline.ts:168`).
+- Rendering the customer status in `BuildStudio.tsx` (band/rail).


### PR DESCRIPTION
## What
Build Studio's bands read `FeatureBuild.phase` directly and are blind to the WorkCapsule projection, so external Claude/Codex/Grok progress is invisible in customer mode. This adds the pure projection that turns a build + its linked capsule into a **business-safe plain status**.

## Changes
- `lib/build/customer-status-projection.ts` — `projectBuildStudioCustomerStatus({ build, capsule })` reuses `projectWorkCaseState` + `build.phase`; returns `{ whatIsBeingBuilt, lifecyclePosition, worker, needsYou }`. **Business-safe by construction:** the executor isn't in the signature and `worker` labels never name Claude/Codex/Grok/opencode (asserted by test).

## Verification
- 7 unit tests (capsule status → plain state/needsYou; phase-only fallback; failed→needs-you; business-safety guard). Typecheck clean. Pure — no DB, no React.
- **Deferred (live-portal validation per operator):** the `workCapsule.findFirst` fetch + `BuildStudio.tsx` render.

Plan: `docs/superpowers/plans/2026-07-11-bi-bb13b599-bs-customer-status-plan.md`.

**Local-CI-Override:** Off fresh `origin/main`; verified locally (7 tests, tsc 0 errors). Local-CI `next build` OOM (143) — env limit; GitHub Production Build authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)