### PR TITLE
feat(work-mgmt): @mention parse + resolve for work-item comments (EP-WORK-CONVERGENCE, BI-B416B12A)

### DIFF
--- a/apps/web/lib/work-management/mentions.test.ts
+++ b/apps/web/lib/work-management/mentions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { parseMentions, resolveMentions } from "./mentions";
+
+describe("parseMentions (BI-B416B12A)", () => {
+  it("extracts unique handles in first-seen order, lowercased", () => {
+    expect(parseMentions("hey @Mark and @ops-coworker, ping @mark again")).toEqual([
+      "mark",
+      "ops-coworker",
+    ]);
+  });
+
+  it("returns nothing for an empty body or no mentions", () => {
+    expect(parseMentions("")).toEqual([]);
+    expect(parseMentions("no mentions here")).toEqual([]);
+  });
+
+  it("does not treat email addresses or @@ as mentions", () => {
+    expect(parseMentions("email me at me@example.com")).toEqual([]);
+    expect(parseMentions("literal @@ token")).toEqual([]);
+  });
+
+  it("matches a mention at the very start of the body", () => {
+    expect(parseMentions("@founder please review")).toEqual(["founder"]);
+  });
+});
+
+describe("resolveMentions (BI-B416B12A)", () => {
+  const roster = {
+    mark: { type: "user" as const, id: "user-1" },
+    "ops-coworker": { type: "agent" as const, id: "agent-9" },
+  };
+
+  it("resolves known handles to typed notification targets and drops unknown ones", () => {
+    const targets = resolveMentions("@mark and @nobody, cc @ops-coworker", roster);
+    expect(targets).toEqual([
+      { handle: "mark", type: "user", id: "user-1" },
+      { handle: "ops-coworker", type: "agent", id: "agent-9" },
+    ]);
+  });
+
+  it("matches roster entries case-insensitively", () => {
+    const targets = resolveMentions("hi @MARK", roster);
+    expect(targets).toEqual([{ handle: "mark", type: "user", id: "user-1" }]);
+  });
+
+  it("returns no targets when nobody is mentioned", () => {
+    expect(resolveMentions("just a comment", roster)).toEqual([]);
+  });
+});

--- a/apps/web/lib/work-management/mentions.ts
+++ b/apps/web/lib/work-management/mentions.ts
@@ -1,0 +1,61 @@
+// BI-B416B12A (EP-WORK-CONVERGENCE): @mention parsing for work-item comments.
+// Threaded comments already exist as WorkItemMessage; the missing collaboration
+// primitive is @mention → subscription/notification (the "watch fabric"). This
+// is the pure core: extract @handles from a comment body and resolve them
+// against a caller-supplied roster to notification targets. Resolution of a
+// handle to a real principal is the caller's concern (this stays DB-free and
+// unit-testable); wiring the targets into Notification is a follow-up.
+
+/**
+ * A handle is `@` followed by a letter/digit and then word chars, dot, hyphen,
+ * or underscore (max 64). Must be preceded by start-of-string or a non-word,
+ * non-`@` char so emails (`a@b`) and `@@` don't match.
+ */
+const MENTION_RE = /(?:^|[^\w@])@([a-z0-9][a-z0-9._-]{0,63})/gi;
+
+/**
+ * Extract unique @mention handles from a comment body, lowercased, in
+ * first-seen order. Pure.
+ */
+export function parseMentions(body: string): string[] {
+  if (!body) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const match of body.matchAll(MENTION_RE)) {
+    const handle = match[1]?.toLowerCase();
+    if (handle && !seen.has(handle)) {
+      seen.add(handle);
+      out.push(handle);
+    }
+  }
+  return out;
+}
+
+export interface MentionTarget {
+  handle: string;
+  type: "user" | "agent";
+  id: string;
+}
+
+export type MentionRoster = Record<string, { type: "user" | "agent"; id: string }>;
+
+/**
+ * Resolve the @mentions in a body against a roster (handle → principal) to the
+ * set of notification targets. Unknown handles are dropped (a typo'd @name does
+ * not notify anyone). Pure — the roster is supplied by the caller. Handles are
+ * matched case-insensitively (roster keys are lowercased on read).
+ */
+export function resolveMentions(body: string, roster: MentionRoster): MentionTarget[] {
+  const lowerRoster: MentionRoster = {};
+  for (const [key, value] of Object.entries(roster)) {
+    lowerRoster[key.toLowerCase()] = value;
+  }
+  const targets: MentionTarget[] = [];
+  for (const handle of parseMentions(body)) {
+    const principal = lowerRoster[handle];
+    if (principal) {
+      targets.push({ handle, type: principal.type, id: principal.id });
+    }
+  }
+  return targets;
+}

--- a/docs/superpowers/plans/2026-07-11-bi-b416b12a-mentions-plan.md
+++ b/docs/superpowers/plans/2026-07-11-bi-b416b12a-mentions-plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan — BI-B416B12A: threaded comments + @mention + presence
+
+**BI:** BI-B416B12A (epic EP-WORK-CONVERGENCE) · **Date:** 2026-07-11 · **Status:** @mention parse/resolve core implemented; comment-write wiring, presence, and UI deferred (live-portal).
+
+## Gap
+Threaded comments already exist as `WorkItemMessage` (body/channel/senderType). The missing collaboration primitives are **@mention → subscription/notification** and **presence**. This slice ships the pure @mention core.
+
+## This slice (pure, unit-testable)
+- `apps/web/lib/work-management/mentions.ts`:
+  - `parseMentions(body)` — extract unique `@handle`s (lowercased, first-seen order); email addresses and `@@` do not match.
+  - `resolveMentions(body, roster)` — resolve handles against a caller-supplied roster to typed `{ handle, type: user|agent, id }` notification targets; unknown handles dropped; case-insensitive.
+  - Pure, DB-free — the roster is the caller's concern.
+
+## Verification
+- 7 unit tests (unique/ordered/lowercased; email/@@ non-match; start-of-body; resolve known/unknown; case-insensitive). Typecheck clean.
+
+## Deferred (needs live-portal verification, per operator)
+- Wiring `resolveMentions` into the WorkItemMessage write path → create `Notification` rows for mentioned targets (the watch fabric; `notify.ts` spine).
+- Real-time presence (who is viewing/working a work item).
+- The comment/@mention/presence UI on the work-item surface.


### PR DESCRIPTION
## What
Threaded comments already exist as `WorkItemMessage`; the missing collaboration primitive is **@mention → subscription/notification**. This ships the pure core.

## Changes
- `lib/work-management/mentions.ts`: `parseMentions` (unique `@handle`s, lowercased/ordered; email + `@@` excluded) and `resolveMentions` (map handles against a caller-supplied roster to typed `{ handle, type, id }` notification targets; unknown dropped; case-insensitive). Pure, DB-free.

## Verification
- 7 unit tests. Typecheck clean.
- **Deferred (live-portal per operator):** wire `resolveMentions` into the WorkItemMessage write path → `Notification` watch fabric; presence; comment UI.

Plan: `docs/superpowers/plans/2026-07-11-bi-b416b12a-mentions-plan.md`.

**Local-CI-Override:** verified locally (7 tests, tsc 0 errors); local-CI `next build` OOM (143) — env limit; GitHub CI authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)