### PR TITLE
feat(work-mgmt): plain customer change summary, never the raw diff (EP-WORK-CONVERGENCE, BI-5EA94BD1)

### DIFF
--- a/apps/web/lib/build/customer-change-summary.test.ts
+++ b/apps/web/lib/build/customer-change-summary.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { customerChangeSummaryText } from "./customer-change-summary";
+
+const narrative = {
+  headline: "Repeat customers now get an automatic 10% discount.",
+  bullets: ["Discount applies at checkout", "No code needed"],
+  whyItMatters: "It rewards loyalty without manual work.",
+  generatedAt: "2026-07-11T00:00:00.000Z",
+  model: "test",
+};
+
+describe("customerChangeSummaryText (BI-5EA94BD1)", () => {
+  it("composes the plain summary from the change narrative headline + why-it-matters", () => {
+    expect(customerChangeSummaryText({ changeNarrative: narrative })).toBe(
+      "Repeat customers now get an automatic 10% discount. It rewards loyalty without manual work.",
+    );
+  });
+
+  it("returns just the headline when there is no why-it-matters", () => {
+    expect(
+      customerChangeSummaryText({ changeNarrative: { ...narrative, whyItMatters: "" } }),
+    ).toBe("Repeat customers now get an automatic 10% discount.");
+  });
+
+  it("returns null (not a raw diff) when there is no narrative — so the plain layer shows 'no summary yet'", () => {
+    expect(customerChangeSummaryText({ changeNarrative: null })).toBeNull();
+    expect(customerChangeSummaryText({})).toBeNull();
+    expect(customerChangeSummaryText({ changeNarrative: { ...narrative, headline: "  " } })).toBeNull();
+  });
+
+  it("cannot leak the raw diff: diffSummary is not part of the input signature", () => {
+    // Passing a diffSummary-looking field has no effect — it is not read.
+    const out = customerChangeSummaryText({
+      changeNarrative: null,
+      // @ts-expect-error diffSummary is intentionally absent from the input type
+      diffSummary: "diff --git a/x b/x\n+lots of code",
+    });
+    expect(out).toBeNull();
+  });
+});

--- a/apps/web/lib/build/customer-change-summary.ts
+++ b/apps/web/lib/build/customer-change-summary.ts
@@ -1,0 +1,25 @@
+// BI-5EA94BD1 (EP-WORK-CONVERGENCE): the customer-facing "what changed" text for
+// the plain overseer layer must come from the plain-language changeNarrative
+// (Band 2), NEVER from diffSummary — which is a raw diff prefix
+// (fullDiff.slice(0, 500)) mislabeled as a summary. `diffSummary` is deliberately
+// absent from this function's input, so the truncated diff can't leak into the
+// customer view by construction. When there is no narrative this returns null and
+// the plain layer should say "no plain summary yet" rather than show a misleading
+// slice of the patch.
+//
+// Pure + unit-testable. Flipping Build Studio's default first-viewport to the
+// plain layer and demoting ProcessGraph/raw-diff behind the Engineer-view toggle
+// is the deferred React slice (needs live-portal verification).
+
+import type { BuildChangeNarrative } from "@/lib/explore/feature-build-types";
+
+export function customerChangeSummaryText(build: {
+  changeNarrative?: BuildChangeNarrative | null;
+}): string | null {
+  const narrative = build.changeNarrative;
+  const headline = narrative?.headline?.trim();
+  if (!headline) return null;
+
+  const whyItMatters = narrative?.whyItMatters?.trim();
+  return whyItMatters ? `${headline} ${whyItMatters}` : headline;
+}

--- a/docs/superpowers/plans/2026-07-11-bi-5ea94bd1-plain-summary-plan.md
+++ b/docs/superpowers/plans/2026-07-11-bi-5ea94bd1-plain-summary-plan.md
@@ -1,0 +1,16 @@
+# Implementation Plan — BI-5EA94BD1: Build Studio IA reframe (plain layer default)
+
+**BI:** BI-5EA94BD1 (epic EP-WORK-CONVERGENCE) · **Date:** 2026-07-11 · **Status:** "Kill the fake summary" pure core implemented; IA default-flip deferred (live-portal).
+
+## Gap
+Build Studio still shows `diffSummary` (= `fullDiff.slice(0, 500)`) in a `<pre>` labeled as a summary — a truncated raw patch mislabeled as plain language (Spec 4 §3, "worse than nothing"). And the plain overseer band layer is not yet the default first-viewport.
+
+## This slice (pure, unit-testable)
+- `apps/web/lib/build/customer-change-summary.ts` — `customerChangeSummaryText(build)` composes the customer-facing "what changed" from the plain `changeNarrative` (headline + whyItMatters) and, **by construction, cannot leak the raw diff**: `diffSummary` is absent from the input signature (a `@ts-expect-error` test asserts it). Returns null when there is no narrative, so the plain layer shows "no plain summary yet" instead of a misleading diff slice.
+
+## Verification
+- 4 unit tests (compose headline+why; headline-only; null when no narrative; diff cannot leak). Typecheck clean.
+
+## Deferred (needs live-portal verification, per operator — validate at epic completion)
+- Make the plain overseer band layer the DEFAULT first-viewport; demote ProcessGraph / raw diff / taskResults / buildExecState behind the single `engineerView` toggle (`BuildStudio.tsx:196`).
+- Replace the in-drawer `diffSummary` `<pre>` render with `customerChangeSummaryText` in the plain view.


### PR DESCRIPTION
## What
Build Studio showed `diffSummary` (= `fullDiff.slice(0,500)`) in a `<pre>` labeled as a summary — a truncated raw patch mislabeled as plain language. This adds the pure helper that yields the customer-facing 'what changed' from the plain `changeNarrative`.

## Changes
- `lib/build/customer-change-summary.ts` — `customerChangeSummaryText(build)` composes headline + why-it-matters; **by construction cannot leak the raw diff** (`diffSummary` is absent from the input signature; a `@ts-expect-error` test asserts it). Returns null when no narrative → plain layer shows 'no summary yet', not a misleading diff slice.

## Verification
- 4 unit tests. Typecheck clean.
- **Deferred (live-portal per operator):** flip the plain band layer to the DEFAULT first-viewport + demote ProcessGraph/raw-diff behind the `engineerView` toggle; wire the helper into the drawer render.

Plan: `docs/superpowers/plans/2026-07-11-bi-5ea94bd1-plain-summary-plan.md`.

**Local-CI-Override:** verified locally (4 tests, tsc 0 errors); local-CI `next build` OOM (143) — env limit; GitHub CI authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)