### PR TITLE
docs(dev-model): reconcile development-process doc authority (BI-7BAFE6A9)

### DIFF
--- a/docs/architecture/autonomy-and-wwmd.md
+++ b/docs/architecture/autonomy-and-wwmd.md
@@ -5,6 +5,15 @@ description: How DPF uses the founder-kernel wiki, principle vectors, decision p
 
 DPF is not trying to make AI coworkers autonomous by removing humans from the loop. It is trying to make autonomy gradual, inspectable, and recoverable.
 
+> **Scope note (2026-07-12).** This page predates the **three-scope** partition of the decision
+> substrate and uses "WWMD" loosely for all of it. The current frame (kernel principle
+> [`decisions-belong-to-their-scope`](../founder-kernel/wiki/principles/decisions-belong-to-their-scope.md);
+> spec [`2026-07-04-decision-governance-surface-redesign-design.md`](../superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md))
+> separates three scopes that do not inherit each other's authority: **WWMD** (platform/founder
+> doctrine — `principle_decide`), **WWWD** (an organization's own business stance — the org Decision
+> Perspective Gate), and **WSID** (a profession's craft). Where this page says "WWMD" for a customer's
+> business call, read **WWWD**; the mechanics below (gate, confidence, ledger) are common to all three.
+
 WWMD is the working name for that decision substrate: "What Would Mark Do?" In product terms, it is a Decision Perspective Gate that lets a coworker ask the governed wiki how to resolve an ambiguity, then return an outcome with confidence, sources, and an audit record.
 
 The important architectural point is that the judgment is no longer trapped in chat. It becomes a reusable platform capability that can be called by Build Studio, in-product coworkers, and external MCP clients under the same governance rules.

--- a/docs/superpowers/specs/2026-05-19-ai-cost-governance.md
+++ b/docs/superpowers/specs/2026-05-19-ai-cost-governance.md
@@ -1,6 +1,16 @@
 # AI Cost Governance — Observability, Model Tiering, Context Compaction, and Budget Enforcement
 
-> **Status: DRAFT spec** — covers all four areas of the AI cost governance initiative.
+> **⚠️ SUPERSEDED (2026-07-12) — never left DRAFT; the domain was carried by other specs.** The four
+> areas here were realized elsewhere: cost/quality/time posture is owned by
+> [`docs/design/golden-triangle-design.md`](../../design/golden-triangle-design.md); context/token
+> economy by the four `2026-06-20-*` context-economy specs and
+> [`docs/architecture/context-engineering-standards.md`](../../architecture/context-engineering-standards.md);
+> model tiering by the quality-first right-sizing spec (`getModelTier`). Cost **strategy** is now
+> stated in [`2026-07-12-dpf-development-model-and-frontier-harness-positioning-design.md`](2026-07-12-dpf-development-model-and-frontier-harness-positioning-design.md)
+> §6. Retain this file for the original problem framing only; do not treat any mechanism here as
+> authoritative or unbuilt-but-planned.
+>
+> **Status: DRAFT spec (historical)** — covers all four areas of the AI cost governance initiative.
 > Feeds `writing-plans` for phased execution.
 > Epic: Create **EP-COST-001** in the backlog before the plan is written. EP-GOVERN already exists
 > (EP-GOVERN-002 is the Tool Evaluation Pipeline). AI cost governance is a distinct domain — a

--- a/docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md
+++ b/docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md
@@ -22,6 +22,16 @@ externalReferences:
   - https://docs.microsoft.com/en-us/azure/devops/boards/work-items/guidance/agile-process
 ---
 
+> **⚠️ SUPERSEDED (2026-07-12).** The `(work-type, size)` matrix landed and is authoritative in code
+> (`apps/web/lib/explore/build-process-matrix.ts`), but the *defaults and axes* described here were
+> reversed and extended by [`2026-06-23-quality-first-risk-aware-build-rightsizing-design.md`](2026-06-23-quality-first-risk-aware-build-rightsizing-design.md):
+> this draft leans **cheap-by-default**; the quality-first spec makes **quality the default** and
+> adds the **deliverable-sensitivity** and **golden-triangle** axes. Model-tier routing (once its own
+> [`2026-06-22-build-studio-model-tier-routing-design.md`](2026-06-22-build-studio-model-tier-routing-design.md))
+> is folded into `getModelTier` under the quality-first flag. Read this spec for the matrix *mechanism*
+> only; for current defaults and axes, follow the quality-first spec and the code. Narrative map:
+> [`2026-07-12-dpf-development-model-and-frontier-harness-positioning-design.md`](2026-07-12-dpf-development-model-and-frontier-harness-positioning-design.md) §11.
+
 # Build Studio Right-Sizing — Lifecycle as a Function of (Work Type, Size)
 
 | Field | Value |

--- a/docs/superpowers/specs/2026-06-22-build-studio-model-tier-routing-design.md
+++ b/docs/superpowers/specs/2026-06-22-build-studio-model-tier-routing-design.md
@@ -1,5 +1,14 @@
 # Build Studio — Capability-Matched Model-Tier Routing & Parallel Track
 
+> **⚠️ SUPERSEDED / FOLDED (2026-07-12).** Model-tier routing shipped and is authoritative in code as
+> `getModelTier` (`apps/web/lib/explore/build-process-matrix.ts`), gated by
+> `DPF_BUILD_MODEL_TIER_ROUTING`. Its *policy* is now owned by
+> [`2026-06-23-quality-first-risk-aware-build-rightsizing-design.md`](2026-06-23-quality-first-risk-aware-build-rightsizing-design.md)
+> (robust everywhere except the trivial small doc/chore tail; high sensitivity ⇒ frontier floor).
+> Keep this spec for the capability-matching *rationale* (local-30B context/VRAM limits observed
+> 2026-06-21/22); for current routing policy follow the quality-first spec and the code. Narrative map:
+> [`2026-07-12-dpf-development-model-and-frontier-harness-positioning-design.md`](2026-07-12-dpf-development-model-and-frontier-harness-positioning-design.md) §11.
+
 - **Status:** Design
 - **Date:** 2026-06-22
 - **Author:** Platform coworker (operator-directed)


### PR DESCRIPTION
## Summary

Closes BI-7BAFE6A9 (EP-1155CEF3). Makes the §11 authority appendix of the 2026-07-12 consolidated strategy doc truthful by marking the three divergent right-sizing/cost drafts as superseded and re-scoping `autonomy-and-wwmd.md`.

- **2026-05-30-build-studio-right-sizing-design.md** → SUPERSEDED banner: cheap-default reversed + sensitivity/golden-triangle axes added by the 06-23 quality-first spec; matrix mechanism still valid, code (`build-process-matrix.ts`) is truth.
- **2026-06-22-build-studio-model-tier-routing-design.md** → FOLDED: `getModelTier` policy owned by the quality-first spec; kept for capability-matching rationale.
- **2026-05-19-ai-cost-governance.md** → SUPERSEDED (never left DRAFT): realized by golden-triangle + context-economy specs; cost strategy now in the 07-12 doc §6.
- **docs/architecture/autonomy-and-wwmd.md** → scope note: predates the WWMD/WWWD/WSID three-scope partition; scopes do not inherit each other's authority.

All cross-links verified to resolve. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)