### PR TITLE
test(scheduler): kill time-of-day flake in proactivity retry test

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler-proactivity.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler-proactivity.test.ts
@@ -1,7 +1,7 @@
 // BI-754C9E82 — proactivity plan ENFORCEMENT on scheduled runs. Split from
 // agent-task-scheduler.test.ts (module-size ratchet): same mock harness, only
 // the enforcement describe block lives here.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   auth: vi.fn(),
@@ -88,8 +88,27 @@ vi.mock("@/lib/optimization/self-optimization-sweep", () => ({
 
 import { executeScheduledAgentTask } from "./agent-task-scheduler";
 
+// Pin the wall clock. The daily-cron re-arm assertion below compares
+// nextRunAt against Date.now(), so a real clock makes it time-of-day
+// dependent: the `7 14 * * *` schedule's next tick can fall <60min out when
+// the suite runs shortly before the daily tick. computeNextCronRun resolves
+// "14:07" with host-LOCAL Date methods (setHours/getDate), so the danger
+// window is local time-of-day — a UTC-instant pin would still land inside it
+// on a host whose local clock reads ~13:xx. Constructing FIXED_NOW from local
+// components keeps the local time-of-day fixed at 09:00 on ANY host timezone,
+// leaving the next 14:07 tick ~5h out. Only Date is faked (not timers) so real
+// setTimeout/await in the code under test still resolves.
+// (Month is 0-indexed: 6 = July.)
+const FIXED_NOW = new Date(2026, 6, 12, 9, 0, 0, 0);
+
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(FIXED_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 // Marketing Strategist coworker self-task fixture (mirrors the sibling file's


### PR DESCRIPTION
## Problem

`agent-task-scheduler-proactivity.test.ts` has a wall-clock-dependent flake. The test **"re-arms the normal cron and resets attempts when the retry budget is exhausted"** asserts the daily-cron re-arm delta is > 60 minutes:

```ts
const deltaMinutes = (data.nextRunAt.getTime() - before) / 60_000;
expect(deltaMinutes).toBeGreaterThan(60);
```

`nextRunAt` comes from `computeNextCronRun("7 14 * * *", now)`, which resolves the next tick with **host-LOCAL** `Date` methods (`setHours`/`getDate`/`getDay`). When the suite runs shortly before 14:07 *local* time, the next tick lands < 60 min out and the assertion fails (observed: `expected 58.05 to be greater than 60`).

Reproduces on clean `origin/main` (verified 2026-07-12), so it is pre-existing and unrelated to the tool-pack drains.

## Fix

Freeze the wall clock in this file's `beforeEach`:

```ts
vi.useFakeTimers({ toFake: ["Date"] });
vi.setSystemTime(FIXED_NOW);
```

- `FIXED_NOW` is built from **local components** (`new Date(2026, 6, 12, 9, 0, 0, 0)` → 09:00 local on any host TZ). Because the cron is interpreted in local time, a UTC-instant pin would still be fragile on a host whose local clock reads ~13:xx — local-component construction keeps the local time-of-day fixed regardless of host timezone, leaving the next 14:07 tick ~5h out.
- Only `Date` is faked (`toFake: ["Date"]`), so real `setTimeout`/`await` in the code under test still resolves.
- `afterEach` restores real timers.

## Verification

`pnpm --filter web exec vitest run lib/actions/agent-task-scheduler-proactivity.test.ts` — **6/6 passing** across every host timezone tested, including ones that would defeat a UTC-instant pin:

| TZ | Result |
|----|--------|
| UTC | 6 passed |
| America/Chicago (−5) | 6 passed |
| Asia/Karachi (+5) | 6 passed |
| Asia/Kolkata (+5:30) | 6 passed |
| Pacific/Kiritimati (+14) | 6 passed |

Module-size gate: OK (test file 335 LOC, under the 800 soft ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)