### PR TITLE
feat(build-studio): activate quality-first cost flags behind evidence (EP-27FD96BC BI-9E0595E7)

### DIFF
--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -475,7 +475,7 @@ async function stepGenerateCode(
   // risk axis; Cost/Speed cannot discount a sensitive deliverable below its floor).
   // Off-flag → plain size-based routing (byte-identical).
   let modelTier: "local" | "robust";
-  if (isQualityFirstRightsizingEnabled()) {
+  if (await isQualityFirstRightsizingEnabled()) {
     const { resolveBuildSizing, coerceBuildPosture } = await import("@/lib/explore/build-rightsizing-dial");
     const riskPosture = await prisma.businessContext
       .findFirst({ select: { riskPosture: true } })

--- a/apps/web/lib/integrate/build-studio-config.ts
+++ b/apps/web/lib/integrate/build-studio-config.ts
@@ -131,29 +131,70 @@ async function resolveBaseBuildStudioConfig(): Promise<BuildStudioDispatchConfig
   return autoDetectConfig();
 }
 
-/**
- * EP-MODEL-TIER-ROUTING: tier routing is opt-in (default off) so the change
- * merges inert and the operator enables it via env after a robust-tier
- * smoke-test. Set DPF_BUILD_MODEL_TIER_ROUTING=1 to route large/xlarge builds
- * to the configured robust (frontier) provider.
- */
-export function isModelTierRoutingEnabled(): boolean {
-  const v = process.env.DPF_BUILD_MODEL_TIER_ROUTING;
-  return v === "1" || v === "true";
+// EP-27FD96BC · BI-9E0595E7 — activate the dormant Build Studio cost flags.
+// The quality-first routing machinery (posture compiler + sensitivity floor +
+// robust-engine fallback) is fully built; it was gated behind default-off env
+// vars so it could merge inert. Activation makes it operator-governed and ON by
+// default, driven by the evidence the machinery already reads (the golden-
+// triangle posture, pinned to Quality) — not a hidden env var.
+//
+// Precedence, per flag: an explicit env var is the operator's emergency
+// kill-switch/override (0/false → off, 1/true → on); otherwise the PlatformConfig
+// row decides (explicit false → off), defaulting ON when absent. Fail-open to the
+// default (on) mirrors getBuildGoldenTrianglePosture — a config read blip must not
+// silently regress substantive builds back to the local tier.
+export const BUILD_MODEL_TIER_ROUTING_KEY = "BUILD_MODEL_TIER_ROUTING";
+export const BUILD_QUALITY_FIRST_RIGHTSIZING_KEY = "BUILD_QUALITY_FIRST_RIGHTSIZING";
+
+/** Env override → PlatformConfig row → default. Pure except the injected config read. */
+export function resolveActivationFlag(
+  envValue: string | undefined,
+  configValue: unknown,
+  defaultOn = true,
+): boolean {
+  if (envValue === "0" || envValue === "false") return false;
+  if (envValue === "1" || envValue === "true") return true;
+  if (configValue === false || configValue === "false" || configValue === "0") return false;
+  if (configValue === true || configValue === "true" || configValue === "1") return true;
+  return defaultOn;
+}
+
+async function readPlatformFlag(key: string): Promise<unknown> {
+  try {
+    const cfg = await prisma.platformConfig.findUnique({ where: { key } });
+    return cfg?.value ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /**
- * EP-QUALITY-RIGHTSIZING: quality-first defaults + the deliverable-sensitivity
- * risk axis are opt-in (default off) so the change merges inert and byte-identical
- * to today. Set DPF_BUILD_QUALITY_FIRST_RIGHTSIZING=1 to route substantive work
- * to the robust tier by default (local only for the trivial doc/chore tail) and
- * to let a HIGH-sensitivity deliverable escalate its build process regardless of
- * size. Honored in tandem with DPF_BUILD_MODEL_TIER_ROUTING — the tier decision
- * is still only acted on when routing is enabled + a robust engine is configured.
+ * EP-MODEL-TIER-ROUTING (activated by BI-9E0595E7): route large/xlarge builds to
+ * the configured robust (frontier) provider. ON by default; an operator disables
+ * it via the `BUILD_MODEL_TIER_ROUTING` PlatformConfig row or
+ * `DPF_BUILD_MODEL_TIER_ROUTING=0`. Falls back to local when no robust engine is
+ * configured, so a local-only install is unaffected.
  */
-export function isQualityFirstRightsizingEnabled(): boolean {
-  const v = process.env.DPF_BUILD_QUALITY_FIRST_RIGHTSIZING;
-  return v === "1" || v === "true";
+export async function isModelTierRoutingEnabled(): Promise<boolean> {
+  return resolveActivationFlag(
+    process.env.DPF_BUILD_MODEL_TIER_ROUTING,
+    await readPlatformFlag(BUILD_MODEL_TIER_ROUTING_KEY),
+  );
+}
+
+/**
+ * EP-QUALITY-RIGHTSIZING (activated by BI-9E0595E7): route substantive work to the
+ * robust tier by default (local only for the trivial doc/chore tail) and let a
+ * HIGH-sensitivity deliverable escalate its build process regardless of size. ON
+ * by default; disable via the `BUILD_QUALITY_FIRST_RIGHTSIZING` PlatformConfig row
+ * or `DPF_BUILD_QUALITY_FIRST_RIGHTSIZING=0`. The tier decision is still only acted
+ * on when a robust engine is configured (see isModelTierRoutingEnabled).
+ */
+export async function isQualityFirstRightsizingEnabled(): Promise<boolean> {
+  return resolveActivationFlag(
+    process.env.DPF_BUILD_QUALITY_FIRST_RIGHTSIZING,
+    await readPlatformFlag(BUILD_QUALITY_FIRST_RIGHTSIZING_KEY),
+  );
 }
 
 /** PlatformConfig key for the global build Cost/Quality/Time posture (P2). */
@@ -206,7 +247,7 @@ export async function getBuildStudioConfig(
   opts?: { modelTier?: BuildModelTier },
 ): Promise<BuildStudioDispatchConfig> {
   const base = await resolveBaseBuildStudioConfig();
-  if (opts?.modelTier === "robust" && isModelTierRoutingEnabled()) {
+  if (opts?.modelTier === "robust" && (await isModelTierRoutingEnabled())) {
     const robust = await resolveRobustProvider();
     if (robust) {
       const idField =

--- a/apps/web/lib/integrate/build-studio-cost-flags.test.ts
+++ b/apps/web/lib/integrate/build-studio-cost-flags.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { resolveActivationFlag } from "./build-studio-config";
+
+describe("resolveActivationFlag — cost-flag activation precedence (BI-9E0595E7)", () => {
+  it("defaults ON when neither env nor config is set (activation)", () => {
+    expect(resolveActivationFlag(undefined, null)).toBe(true);
+  });
+
+  it("env kill-switch (0/false) wins over everything, including a true config", () => {
+    expect(resolveActivationFlag("0", true)).toBe(false);
+    expect(resolveActivationFlag("false", "true")).toBe(false);
+  });
+
+  it("env force-on (1/true) wins over a false config", () => {
+    expect(resolveActivationFlag("1", false)).toBe(true);
+    expect(resolveActivationFlag("true", "false")).toBe(true);
+  });
+
+  it("PlatformConfig disables when env is unset and config is explicitly false", () => {
+    expect(resolveActivationFlag(undefined, false)).toBe(false);
+    expect(resolveActivationFlag(undefined, "false")).toBe(false);
+    expect(resolveActivationFlag(undefined, "0")).toBe(false);
+  });
+
+  it("PlatformConfig can also explicitly enable", () => {
+    expect(resolveActivationFlag(undefined, true)).toBe(true);
+    expect(resolveActivationFlag(undefined, "1")).toBe(true);
+  });
+
+  it("fails open to the default (ON) on a malformed/absent config value", () => {
+    expect(resolveActivationFlag(undefined, "garbage")).toBe(true);
+    expect(resolveActivationFlag(undefined, {})).toBe(true);
+    expect(resolveActivationFlag(undefined, null)).toBe(true);
+  });
+
+  it("respects an explicit non-default (off) baseline when requested", () => {
+    expect(resolveActivationFlag(undefined, null, false)).toBe(false);
+    // env/config still override the baseline.
+    expect(resolveActivationFlag("1", null, false)).toBe(true);
+    expect(resolveActivationFlag(undefined, true, false)).toBe(true);
+  });
+});

--- a/apps/web/lib/integrate/ideate-on-approval.test.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.test.ts
@@ -22,7 +22,7 @@ vi.mock("./ideate-dispatch", () => ({
 
 vi.mock("@/lib/integrate/build-studio-config", () => ({
   getBuildStudioConfig: mockGetBuildStudioConfig,
-  isModelTierRoutingEnabled: () => false,
+  isModelTierRoutingEnabled: async () => false,
 }));
 
 vi.mock("@/lib/mcp-tools", () => ({

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -202,7 +202,7 @@ export async function dispatchIdeateForApprovedBuild(params: {
     // to cloud; otherwise it gracefully stays local).
     const { getModelTier } = await import("@/lib/explore/build-process-matrix");
     const { isModelTierRoutingEnabled } = await import("@/lib/integrate/build-studio-config");
-    const modelTier = isModelTierRoutingEnabled()
+    const modelTier = (await isModelTierRoutingEnabled())
       ? getModelTier(null, bi.effortSize) // tier is size-derived (P1); build.kind isn't in this select
       : undefined;
 

--- a/apps/web/lib/integrate/plan-on-approval.ts
+++ b/apps/web/lib/integrate/plan-on-approval.ts
@@ -336,7 +336,7 @@ export async function dispatchPlanForApprovedBuild(params: {
     // DPF_BUILD_MODEL_TIER_ROUTING is on.
     const { getModelTier } = await import("@/lib/explore/build-process-matrix");
     const { isModelTierRoutingEnabled } = await import("./build-studio-config");
-    const planModelTier = isModelTierRoutingEnabled()
+    const planModelTier = (await isModelTierRoutingEnabled())
       ? getModelTier(build.kind, biEffortSize)
       : undefined;
 

--- a/apps/web/lib/integrate/ship-on-review-approval.ts
+++ b/apps/web/lib/integrate/ship-on-review-approval.ts
@@ -232,7 +232,7 @@ export async function advanceReviewedBuildToShip(
   // blast radius warrants. Non-blocking + fail-open; gated on the same flag.
   try {
     const { isQualityFirstRightsizingEnabled } = await import("./build-studio-config");
-    if (isQualityFirstRightsizingEnabled()) {
+    if (await isQualityFirstRightsizingEnabled()) {
       const { deriveBlastRadiusSensitivity } = await import("./change-impact");
       const { deriveDeliverableSensitivity, DELIVERABLE_SENSITIVITIES } = await import(
         "@/lib/explore/build-process-matrix"

--- a/docs/superpowers/plans/2026-07-11-activate-build-cost-flags.md
+++ b/docs/superpowers/plans/2026-07-11-activate-build-cost-flags.md
@@ -1,0 +1,26 @@
+# Activate Build Studio cost flags behind evidence
+
+- **BI:** BI-9E0595E7 · **Epic:** EP-27FD96BC
+- **Kernel:** activation altitude routed via `principle_decide` 2026-07-11 → **platformconfig-operator-gated** (composite 9.241 over 9.033 default-on-env; near-tie, decided by consistency with the existing `getBuildGoldenTrianglePosture` config pattern and confirmed zero async-ripple — all four call sites are already async and the pure `build-process-matrix.ts` does not read these flags).
+
+## Problem
+
+Two Build Studio cost/quality levers were shipped **inert** behind default-off env vars so they'd merge byte-identical:
+- `isModelTierRoutingEnabled()` — routes large/xlarge builds to the robust (frontier) engine.
+- `isQualityFirstRightsizingEnabled()` — compiles the operator's golden-triangle posture (a PlatformConfig row **pinned to Quality**) floored by deliverable sensitivity into a model tier.
+
+The whole machinery is built and wired; only the flags are off. So the operator's Quality posture has no effect and every build routes purely by size. This BI activates them behind the evidence the machinery already reads.
+
+## Approach
+
+Make both flags **operator-governed and ON by default**, mirroring `getBuildGoldenTrianglePosture`:
+- New pure `resolveActivationFlag(env, config, defaultOn=true)` — precedence: explicit env (`0/false`→off, `1/true`→on) is the emergency kill-switch/override; else the PlatformConfig row (`false`→off); else default ON. Fail-open to the default so a config-read blip never silently regresses substantive builds back to local.
+- `isModelTierRoutingEnabled()` / `isQualityFirstRightsizingEnabled()` become async, reading new PlatformConfig keys `BUILD_MODEL_TIER_ROUTING` / `BUILD_QUALITY_FIRST_RIGHTSIZING`.
+- Await at the four call sites (build-pipeline, ideate-on-approval, plan-on-approval, ship-on-review-approval) — all already async.
+
+Safety: model-tier routing still falls back to local when no robust engine is configured, so a local-only install is unaffected; a HIGH-sensitivity deliverable can only escalate, never discount below its sensitivity floor.
+
+## Verification
+- Unit (`build-studio-cost-flags.test.ts`): the precedence table — default-on, env kill-switch wins, config disable, fail-open on malformed config, explicit-baseline override.
+- Regression: the ideate-on-approval mock updated to async; existing suite green.
+- Behavioral: with the default (no env, no config row) a substantive build on an install with a robust engine routes to the robust tier; setting the `BUILD_MODEL_TIER_ROUTING` config row (or env `=0`) returns it to size-based routing.


### PR DESCRIPTION
## What

Activates two dormant Build Studio cost/quality levers, operator-governed and **ON by default**:
- **model-tier routing** — large/xlarge builds route to the configured robust (frontier) engine (falls back to local when none is configured).
- **quality-first rightsizing** — compiles the operator's golden-triangle posture (a PlatformConfig row **pinned to Quality**) floored by deliverable sensitivity into a model tier.

Both machineries were fully built and wired; only the default-off env flags kept them inert, so the operator's Quality posture had no effect and every build routed purely by size.

## How

- New pure `resolveActivationFlag(env, config, defaultOn=true)` — precedence: explicit env var is the emergency kill-switch/override → PlatformConfig row (`BUILD_MODEL_TIER_ROUTING` / `BUILD_QUALITY_FIRST_RIGHTSIZING`) → default ON. Fail-open to the default so a config-read blip never silently regresses substantive builds to local.
- Flag readers become async; the four call sites (build-pipeline, ideate/plan/ship-on-approval) already ran in async scope. The pure `build-process-matrix.ts` does not read these flags — no async ripple.

## Governance
- Activation altitude routed via `principle_decide` → **platformconfig-operator-gated** (composite 9.24), consistent with the existing `getBuildGoldenTrianglePosture` config pattern.
- Plan doc: `docs/superpowers/plans/2026-07-11-activate-build-cost-flags.md`.

## Verification
- Unit: `build-studio-cost-flags.test.ts` (precedence table: default-on, env kill-switch wins, config disable, fail-open, baseline override) + updated `ideate-on-approval` mock — 25 tests green.
- Typecheck clean; repo guards + module-size + style-drift baselines green.

## Safe by construction
Model-tier routing degrades to local without a robust engine; a HIGH-sensitivity deliverable can only escalate, never discount below its floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)