### PR TITLE
feat(twin): deriveTwinProfile — every archetype gets an operational twin (EP-LIVING-BUSINESS-VIZ P1)

### DIFF
--- a/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
+++ b/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
@@ -1,0 +1,44 @@
+# Operational Twin Framework — execution plan
+
+**Spec:** [2026-07-12-operational-twin-framework-design.md](../specs/2026-07-12-operational-twin-framework-design.md)
+**Parent:** [2026-07-11-living-business-workforce-visualization-design.md](../specs/2026-07-11-living-business-workforce-visualization-design.md)
+**Epic:** EP-LIVING-BUSINESS-VIZ (proposed)
+**Started:** 2026-07-12
+
+Delivering the framework that gives *every* archetype — physical and non-physical — a working operational twin, from one grammar + ~12 templates + a derived `TwinProfile`.
+
+## P1 — the derivation (this PR) · DONE
+
+The pure, DB-free foundation: `deriveTwinProfile(archetype)` picks a template and binds its nouns/zones/queues/cog from the archetype's operating-model axes, `schedulingDefaults`, derived `FieldDispatchProfile`, and category — the fourth member of DPF's derive-with-override family (OVSM, media-profile, field-dispatch ADR-4).
+
+- `packages/storefront-templates/src/twin-profile.ts` — types (`TwinTemplate` ×12, `TwinVariant`, `TwinCogKind`, `TwinProfile`, `TwinProfileOverride`), the `TEMPLATE_DEFAULTS` grammar map, `chooseTemplate` (priority: dispatch → rental → board family → physical categories → safety net), and `deriveTwinProfile` with the leaf-override escape hatch.
+- `packages/storefront-templates/src/types.ts` — `twinProfile?: TwinProfileOverride` added to `ArchetypeDefinition` (optional leaf override, mirroring `fieldDispatch?`/`mediaProfile?`; type-only circular import, same pattern as `FieldDispatchProfileOverride`).
+- `packages/storefront-templates/src/index.ts` — re-export.
+- `packages/storefront-templates/src/twin-profile.test.ts` — totality (every seeded archetype → a complete, deterministic twin), the board↔physical invariant, axis-over-category taxonomy, the signature mappings, the leaf override, and coverage breadth.
+
+**Key design correction found during P1 (verified against the live catalog):** *category is not destiny — the physical axes win.* A land-surveying or field-inspection **professional-services** firm is dispatch-native → TERRITORY; an equipment-pooling **co-op** (nonprofit) is reservation-and-return → YARD; a member-owned **credit union** (banking) → TENANTS/portfolio, not the donor PROGRAMS board. The derivation checks dispatch/rental axes and category-specific board mappings before generic governance, so a physically-operating business in a "non-physical" category correctly gets a physical twin, and vice versa.
+
+### P1 verification evidence (source-local — pure, DB-free package; §5)
+- **Typecheck:** `tsc` compiles all package sources clean (exit 0), including the new `twinProfile?` leaf field and the type-only circular import.
+- **Logic over the live catalog:** `deriveTwinProfile` exercised over all **94** seeded archetypes via a compiled Node harness — every archetype derives a complete twin (zones, queue, chips, nouns, cog+signals, physical flag); deterministic; the board↔physical invariant holds for all 94; dispatch-native archetypes bind the field-dispatch resource noun; the clearly-determined category mappings (banking→TENANTS/portfolio, media→PIPELINE/timeline, food→FLOOR, hoa→TERRITORY/unit-portfolio, construction→TERRITORY/job-sites, rental→YARD) all hold; the leaf override replaces template/variant/nouns with fall-through. **10 of 12 templates** are exercised by the seeded catalog (BAYS and COUNTER are reachable-by-derivation — fixed-shop automotive and permit-counter public-sector — but no seeded leaf currently lands there; both are covered by category/override).
+- Every `twin-profile.test.ts` assertion was replicated against the compiled output and passes (0 failures). The vitest run itself is the canonical gate — it executes in CI's Unit Tests job (deps unavailable in this source-only worktree; harness limitation, not a product defect, §5).
+
+### Non-physical coverage (this PR)
+The derivation covers all non-physical categories via the board family, and a **board-twin prototype** demonstrates them with the same operating-twin grammar (presence + cog + queues + attributed feed): `docs/superpowers/specs/assets/2026-07-12-living-business-board-twin-prototype.html` — SaaS (TENANTS), professional-services (PIPELINE), nonprofit (PROGRAMS), banking (TENANTS/portfolio), media (PIPELINE/timeline). Tap a queue item → the cog routes it to the best owner by the archetype's signal (health-score/CSM-load, utilization, engagement, banker workload, editor availability) → tap to confirm; humans and AI coworkers act on one shared board with an attributed feed.
+
+## P2 — the grammar kit · NEXT
+The ten primitives as React components on the token/report-kit substrate (`apps/web/components/twin/`), lifted from the four prototypes: capacity chips, zone, resource unit, work item (with blocked-on-external state), queue, cog banner, utility band, presence row, attributed feed, needs-you quests. Each rendered through `--dpf-*` tokens, reduced-motion-safe, dynamic text via a safe helper (no innerHTML). A fixture page per primitive. Requires a recorded `UX-Fit-Decision` (§12) for the metric/status components.
+
+## P3 — first templates live
+FLOOR, TERRITORY, YARD as template compositions bound via `TwinProfile`, replacing the three hand-built prototypes with framework-rendered equivalents wired to `LivingBusinessSnapshot` + `agent-event-bus` (parent spec P1–P2). Registers as a workspace-home contribution per archetype.
+
+## P4 — remaining templates by install demand
+BOOK, BAYS, ROOMS, STORE, VENUE, COUNTER + the TENANTS/PIPELINE/PROGRAMS boards, each a template + bindings (not a bespoke build). Certification: a golden-journey per template exercising queue → cog → confirm. PHI-class ROOMS (healthcare) gets the presence/feed redaction mode (role, not patient identity) keyed off `privacyClass` (open question §9.2).
+
+## P5 — simulator coverage
+Business Activity Simulator archetype factories (its P2) emit per-template scenarios so every twin can be demonstrated live on a test install.
+
+## Risks / decisions carried forward
+- **BAYS/COUNTER have no seeded leaf** — reachable by category/override; a fixed-shop automotive or permit-counter public-sector archetype (or a leaf override) exercises them. Not a gap in the derivation.
+- **TERRITORY nouns for non-dispatch physical categories** (HOA/construction/trades routed by category, not field-dispatch) fall back to the generic "technician" default; render-time vocabulary resolves the operator label ("vendor"/"crew"). A follow-up can specialize per-variant default nouns.
+- **Hybrid archetypes** (retail+online, telehealth) set `hybridBoard`; the composed-archetype case (`StorefrontArchetypeComposition`) is deferred to the first real composed install (§9.3).

--- a/docs/superpowers/specs/assets/2026-07-12-living-business-board-twin-prototype.html
+++ b/docs/superpowers/specs/assets/2026-07-12-living-business-board-twin-prototype.html
@@ -1,0 +1,294 @@
+<title>The Living Business - board twin (non-physical archetypes)</title>
+<style>
+  /* DPF tokens (globals.css). Both themes. STATIC-FIRST (renders without JS).
+     Interactivity (route a queued item to the best owner) is progressive
+     enhancement. Dynamic text via textContent only (never innerHTML - XSS-safe).
+     Glyphs are numeric entities (charset-safe). The BOARD twin - the operating
+     twin for NON-PHYSICAL archetypes (TENANTS / PIPELINE / PROGRAMS templates),
+     complement to the physical floor/map/yard twins. Same grammar. */
+  :root{
+    --dpf-bg:#fafafa;--dpf-surface-1:#ffffff;--dpf-surface-2:#f4f4f6;--dpf-surface-3:#eeeef2;
+    --dpf-text:#1a1a2e;--dpf-text-secondary:#4a4a5e;--dpf-accent:#2563eb;--dpf-border:#d4d4dc;
+    --dpf-border-strong:#c8c8d4;--dpf-muted:#6b7280;--dpf-success:#16a34a;--dpf-warning:#d97706;
+    --dpf-error:#dc2626;--dpf-info:#0284c7;
+    --board: color-mix(in srgb, var(--dpf-accent) 4%, var(--dpf-bg));
+    --font-display:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+    --font-mono:ui-monospace,"SF Mono","Cascadia Mono",Menlo,Consolas,monospace;
+    --radius:10px;--sh:0 1px 2px color-mix(in srgb,var(--dpf-text) 8%,transparent);
+    --sh2:0 8px 26px color-mix(in srgb,var(--dpf-text) 16%,transparent);
+  }
+  @media (prefers-color-scheme: dark){:root{
+    --dpf-bg:#0f0f1a;--dpf-surface-1:#1a1a2e;--dpf-surface-2:#161625;--dpf-surface-3:#121220;
+    --dpf-text:#e2e2f0;--dpf-text-secondary:#b8b8cc;--dpf-accent:#7c8cf8;--dpf-border:#2a2a40;
+    --dpf-border-strong:#3a3a55;--dpf-muted:#8888a0;--dpf-success:#4ade80;--dpf-warning:#fbbf24;
+    --dpf-error:#f87171;--dpf-info:#38bdf8;}}
+  :root[data-theme="light"]{--dpf-bg:#fafafa;--dpf-surface-1:#ffffff;--dpf-surface-2:#f4f4f6;--dpf-surface-3:#eeeef2;--dpf-text:#1a1a2e;--dpf-text-secondary:#4a4a5e;--dpf-accent:#2563eb;--dpf-border:#d4d4dc;--dpf-border-strong:#c8c8d4;--dpf-muted:#6b7280;--dpf-success:#16a34a;--dpf-warning:#d97706;--dpf-error:#dc2626;--dpf-info:#0284c7;}
+  :root[data-theme="dark"]{--dpf-bg:#0f0f1a;--dpf-surface-1:#1a1a2e;--dpf-surface-2:#161625;--dpf-surface-3:#121220;--dpf-text:#e2e2f0;--dpf-text-secondary:#b8b8cc;--dpf-accent:#7c8cf8;--dpf-border:#2a2a40;--dpf-border-strong:#3a3a55;--dpf-muted:#8888a0;--dpf-success:#4ade80;--dpf-warning:#fbbf24;--dpf-error:#f87171;--dpf-info:#38bdf8;}
+
+  *{box-sizing:border-box;} html,body{margin:0;}
+  body{background:var(--dpf-bg);color:var(--dpf-text);font-family:var(--font-display);font-size:15px;line-height:1.45;-webkit-font-smoothing:antialiased;}
+  .tnum{font-variant-numeric:tabular-nums;font-family:var(--font-mono);}
+  .shell{display:flex;flex-direction:column;min-height:100%;}
+  .topbar{display:flex;align-items:center;gap:10px 14px;padding:11px 16px;background:var(--dpf-surface-1);border-bottom:1px solid var(--dpf-border);flex-wrap:wrap;}
+  .eyebrow{font-size:10.5px;letter-spacing:0.16em;text-transform:uppercase;color:var(--dpf-muted);font-weight:600;}
+  .brand{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;} .brand h1{font-size:18px;font-weight:700;letter-spacing:-0.02em;margin:0;} .brand .biz{font-size:13px;color:var(--dpf-muted);}
+  .spacer{flex:1 1 auto;}
+  .pill{display:inline-flex;align-items:center;gap:7px;background:var(--dpf-surface-2);border:1px solid var(--dpf-border);border-radius:999px;padding:5px 11px;font-size:12.5px;color:var(--dpf-text);cursor:pointer;}
+  .pill select{background:transparent;border:none;color:var(--dpf-text);font:inherit;outline:none;cursor:pointer;} .pill select option{background:var(--dpf-surface-2);color:var(--dpf-text);}
+
+  .caps{display:flex;gap:8px;flex-wrap:wrap;padding:10px 16px;background:var(--dpf-surface-1);border-bottom:1px solid var(--dpf-border);}
+  .cap{display:flex;align-items:baseline;gap:6px;background:var(--dpf-surface-2);border:1px solid var(--dpf-border);border-radius:999px;padding:4px 12px;}
+  .cap .cv{font-family:var(--font-mono);font-weight:700;font-size:14px;} .cap .cl{font-size:10.5px;color:var(--dpf-muted);text-transform:uppercase;letter-spacing:.04em;}
+  .cap.hot .cv{color:var(--dpf-warning);} .cap.bad .cv{color:var(--dpf-error);} .cap.good .cv{color:var(--dpf-success);}
+
+  /* presence: humans + AI coworkers co-inhabiting the operating twin */
+  .presence{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:8px 16px;background:var(--dpf-surface-1);border-bottom:1px solid var(--dpf-border);}
+  .presence .plbl{font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--dpf-muted);font-weight:700;}
+  .who{display:flex;align-items:center;gap:7px;background:var(--dpf-surface-2);border:1px solid var(--dpf-border);border-radius:999px;padding:3px 11px 3px 4px;}
+  .who .wa{width:22px;height:22px;border-radius:50%;display:grid;place-items:center;font-size:8px;font-weight:700;color:#fff;background:var(--dpf-accent);position:relative;}
+  .who.ai .wa{background:color-mix(in srgb,var(--dpf-accent) 18%,var(--dpf-surface-1));color:var(--dpf-accent);border:2px solid var(--dpf-accent);}
+  .who .wa::after{content:"";position:absolute;right:-1px;bottom:-1px;width:7px;height:7px;border-radius:50%;background:var(--dpf-success);border:1.5px solid var(--dpf-surface-2);}
+  .who .wn{font-size:11px;font-weight:600;} .who .ww{font-size:9.5px;color:var(--dpf-text-secondary);white-space:nowrap;}
+
+  .banner{display:none;align-items:center;gap:10px;padding:9px 16px;background:color-mix(in srgb,var(--dpf-accent) 12%,var(--dpf-surface-1));border-bottom:1px solid var(--dpf-border);font-size:13px;}
+  .banner.on{display:flex;} .banner .x{margin-left:auto;cursor:pointer;color:var(--dpf-muted);font-size:12px;}
+  .toast{position:fixed;left:50%;bottom:20px;transform:translateX(-50%);background:var(--dpf-text);color:var(--dpf-bg);font-size:13px;font-weight:600;padding:9px 16px;border-radius:999px;box-shadow:var(--sh2);opacity:0;pointer-events:none;transition:opacity .25s;z-index:50;}
+  .toast.on{opacity:1;}
+
+  .wrap{padding:12px;display:flex;flex-direction:column;gap:12px;background:var(--board);}
+  .zone{background:var(--dpf-surface-1);border:1px solid var(--dpf-border);border-radius:var(--radius);box-shadow:var(--sh);}
+  .zone > .zh{display:flex;align-items:center;gap:8px;padding:8px 12px;border-bottom:1px solid var(--dpf-border);flex-wrap:wrap;}
+  .zone .zt{font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--dpf-muted);font-weight:700;} .zone .zsub{font-size:11px;color:var(--dpf-muted);}
+
+  /* the work queue (interactive) - items needing an owner */
+  .qlist{display:flex;gap:8px;overflow-x:auto;padding:10px 12px;}
+  .qcard{flex:0 0 auto;min-width:210px;background:var(--dpf-surface-1);border:1px solid var(--dpf-border);border-left:3px solid var(--dpf-warning);border-radius:10px;padding:8px 11px;cursor:pointer;}
+  .qcard.crit{border-left-color:var(--dpf-error);} .qcard.info{border-left-color:var(--dpf-info);}
+  .qcard.sel{box-shadow:0 0 0 2px color-mix(in srgb,var(--dpf-accent) 30%,transparent);border-color:var(--dpf-accent);}
+  .qcard .qt{font-size:12.5px;font-weight:600;display:flex;justify-content:space-between;gap:8px;}
+  .qcard .qtag{font-family:var(--font-mono);font-size:8.5px;font-weight:700;border-radius:4px;padding:0 5px;color:var(--dpf-warning);border:1px solid color-mix(in srgb,var(--dpf-warning) 45%,var(--dpf-border));}
+  .qcard.crit .qtag{color:var(--dpf-error);border-color:color-mix(in srgb,var(--dpf-error) 45%,var(--dpf-border));}
+  .qcard .qm{font-size:10.5px;color:var(--dpf-muted);margin-top:3px;} .qcard .sug{font-size:10px;color:var(--dpf-success);font-weight:600;margin-top:5px;}
+
+  /* the board: lanes of cards */
+  .lanes{display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:10px;padding:11px;}
+  .lane{background:var(--dpf-surface-2);border:1px solid var(--dpf-border);border-radius:9px;padding:8px;min-height:60px;}
+  .lane .lh{font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--dpf-muted);font-weight:700;display:flex;justify-content:space-between;margin-bottom:7px;}
+  .lane.risk .lh{color:var(--dpf-error);} .lane.watch .lh{color:var(--dpf-warning);} .lane.ok .lh{color:var(--dpf-success);}
+  .item{background:var(--dpf-surface-1);border:1px solid var(--dpf-border);border-radius:7px;padding:6px 8px;margin-bottom:6px;}
+  .item .in{font-size:12px;font-weight:600;} .item .im{font-size:10px;color:var(--dpf-muted);margin-top:1px;}
+  .item .own{font-size:9.5px;color:var(--dpf-accent);font-weight:600;margin-top:3px;display:flex;align-items:center;gap:4px;}
+  .item .own .od{width:6px;height:6px;border-radius:50%;background:var(--dpf-accent);} .item .own.none{color:var(--dpf-muted);} .item .own.none .od{background:var(--dpf-muted);}
+  .item .meter{height:4px;border-radius:999px;background:var(--dpf-surface-3);margin-top:4px;overflow:hidden;} .item .meter i{display:block;height:100%;}
+  .item.g .meter i{background:var(--dpf-success);width:82%;} .item.a .meter i{background:var(--dpf-warning);width:52%;} .item.r .meter i{background:var(--dpf-error);width:26%;}
+
+  /* roster (owners) - assignment targets */
+  .roster{display:grid;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));gap:8px;padding:10px 12px;}
+  .owner{display:flex;align-items:center;gap:9px;background:var(--dpf-surface-2);border:1px solid var(--dpf-border);border-radius:10px;padding:7px 10px;}
+  .owner .oav{width:26px;height:26px;flex:0 0 auto;border-radius:50%;display:grid;place-items:center;font-size:8.5px;font-weight:700;color:#fff;background:var(--dpf-accent);}
+  .owner.ai .oav{background:color-mix(in srgb,var(--dpf-accent) 18%,var(--dpf-surface-1));color:var(--dpf-accent);border:2px solid var(--dpf-accent);}
+  .owner .oi{min-width:0;flex:1;} .owner .on{font-size:12px;font-weight:600;} .owner .ow{font-size:10px;color:var(--dpf-text-secondary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+  .owner .load{flex:0 0 54px;height:6px;border-radius:999px;background:var(--dpf-surface-3);overflow:hidden;} .owner .load i{display:block;height:100%;background:var(--dpf-accent);}
+  .owner.eligible{border-color:var(--dpf-success);box-shadow:0 0 0 2px color-mix(in srgb,var(--dpf-success) 25%,transparent);cursor:pointer;}
+  .owner.suggest{border-color:var(--dpf-success);box-shadow:0 0 0 2px color-mix(in srgb,var(--dpf-success) 45%,transparent);cursor:pointer;}
+
+  .feed .flist{padding:6px 12px 10px;max-height:170px;overflow-y:auto;}
+  .fitem{display:flex;gap:9px;align-items:baseline;padding:5px 0;border-bottom:1px solid var(--dpf-border);} .fitem:last-child{border-bottom:none;}
+  .fitem .fa{flex:0 0 auto;font-size:8.5px;font-weight:700;border-radius:5px;padding:1px 6px;white-space:nowrap;}
+  .fitem.human .fa{color:#fff;background:var(--dpf-accent);} .fitem.ai .fa{color:var(--dpf-accent);border:1px solid var(--dpf-accent);} .fitem.staff .fa{color:var(--dpf-text-secondary);border:1px solid var(--dpf-border-strong);}
+  .fitem .fx{flex:1;min-width:0;font-size:12px;} .fitem .ft{flex:0 0 auto;font-family:var(--font-mono);font-size:9.5px;color:var(--dpf-muted);}
+
+  .hud{border-top:1px solid var(--dpf-border);background:var(--dpf-surface-1);padding:12px 16px 18px;}
+  .hud .hd{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--dpf-muted);font-weight:700;margin-bottom:9px;}
+  .need{display:flex;gap:9px;align-items:flex-start;padding:8px 10px;border:1px solid var(--dpf-border);border-left-width:3px;border-radius:var(--radius);margin-bottom:8px;max-width:660px;}
+  .need.warn{border-left-color:var(--dpf-warning);} .need.error{border-left-color:var(--dpf-error);} .need.info{border-left-color:var(--dpf-info);}
+  .need .nb{flex:1;} .need .nt{font-weight:600;font-size:13px;} .need .nm{font-size:11px;color:var(--dpf-muted);margin-top:2px;}
+  .need .na{flex:0 0 auto;align-self:center;font-size:12px;font-weight:600;color:#fff;background:var(--dpf-accent);border:none;border-radius:7px;padding:5px 10px;cursor:pointer;}
+  .foot{font-size:11px;color:var(--dpf-muted);padding:0 16px 20px;} .foot code{font-family:var(--font-mono);font-size:10.5px;color:var(--dpf-text-secondary);}
+</style>
+
+<div class="shell">
+  <header class="topbar">
+    <div class="brand"><span class="eyebrow">DPF Workspace</span><h1>The Living Business</h1><span class="biz" id="biz">GridSignal &#183; B2B Analytics SaaS</span></div>
+    <div class="spacer"></div>
+    <label class="pill" title="Non-physical archetype (board twin)"><span class="eyebrow">Archetype</span>
+      <select id="archetype" aria-label="Archetype">
+        <option value="saas">SaaS &#183; TENANTS board</option>
+        <option value="prosvc">Professional services &#183; PIPELINE</option>
+        <option value="nonprofit">Nonprofit &#183; PROGRAMS</option>
+        <option value="banking">Banking &#183; TENANTS portfolio</option>
+        <option value="media">Media production &#183; PIPELINE timeline</option>
+      </select>
+    </label>
+    <button class="pill" id="routeNext">&#9654; Route next</button>
+    <button class="pill" id="themeToggle" aria-label="Toggle theme">&#9680; Theme</button>
+  </header>
+
+  <div class="caps" id="caps"></div>
+  <div class="presence" id="presence"></div>
+  <div class="banner" id="banner"><span id="bannerText"></span><span class="x" id="bannerX">cancel (Esc)</span></div>
+
+  <div class="wrap">
+    <div class="zone">
+      <div class="zh"><span class="zt" id="queueTitle">Work queue</span><span class="zsub" id="queueSub">tap an item &#8594; the cog suggests the best owner &#8594; tap the owner to route it</span></div>
+      <div class="qlist" id="queue"></div>
+    </div>
+    <div class="zone">
+      <div class="zh"><span class="zt" id="boardTitle">Board</span><span class="zsub" id="boardSub"></span></div>
+      <div class="lanes" id="lanes"></div>
+    </div>
+    <div class="zone">
+      <div class="zh"><span class="zt" id="rosterTitle">Team &#183; on shift</span><span class="zsub">each anchored to live work &#183; staff = work owned</span></div>
+      <div class="roster" id="roster"></div>
+    </div>
+    <div class="zone feed">
+      <div class="zh"><span class="zt">Live activity &#183; who did what</span><span class="zsub">humans and AI coworkers acting on the same twin, in real time</span></div>
+      <div class="flist" id="feed"></div>
+    </div>
+  </div>
+
+  <div class="hud">
+    <div class="hd">What needs you now</div>
+    <div id="needs"></div>
+  </div>
+
+  <div class="foot" id="foot"></div>
+</div>
+<div class="toast" id="toast"></div>
+
+<script>
+(() => {
+  "use strict";
+  const $=id=>document.getElementById(id), $$=s=>Array.prototype.slice.call(document.querySelectorAll(s));
+  const GEAR=String.fromCharCode(9881), ARR=String.fromCharCode(8594);
+  let sel=null; // selected queue item element
+
+  // Board-twin data per non-physical archetype. Same grammar (caps, presence,
+  // queue, lanes, roster, cog, feed) - different nouns. TENANTS = health lanes;
+  // PIPELINE/PROGRAMS = stage lanes. Cog = route by the archetype's signal.
+  const A = {
+    saas:{ biz:"GridSignal - B2B Analytics SaaS", template:"TENANTS", itemNoun:"account", ownerNoun:"CSM",
+      caps:[["bad","3","at-risk accounts"],["hot","11","renewals in 90d"],["good","94%","net retention"],["","61","accounts / CSM"]],
+      presence:[["ai","AI Success","watching health scores"],["ai","AI Renewals","tracking 90-day window"],["human","You","operator"],["human","Priya","CSM lead"]],
+      lanes:[["ok","Healthy","g"],["watch","Watch","a"],["risk","At risk","r"]],
+      board:{Healthy:[["Contoso","$48k ARR","Priya","g"],["Globex","$31k ARR","Devon","g"],["Initech","$22k ARR","Priya","g"]],Watch:[["Umbrella","usage -18%","Devon","a"],["Soylent","champion left","Priya","a"]],"At risk":[["Northwind","usage -40%","","r"],["Acme Co","renewal 12d, no exec","","r"]]},
+      queue:[["crit","Northwind","usage down 40% - renews in 21d","route-at-risk"],["crit","Acme Co","renewal in 12 days, no exec sponsor","route-at-risk"],["","Umbrella","champion left - re-engage","route-at-risk"]],
+      owners:[["Priya","CSM lead",70],["Devon","CSM",55],["AI Success","auto-playbook",30]],
+      cog:"health-score + CSM load", need:[["error","Northwind renewal at risk","usage -40%, renews in 21d - assign a CSM + exec playbook","Route"],["warn","11 renewals in the 90-day window","3 lack a success plan","Review"]],
+      bind:"agent-event-bus + usage signals (LivingBusinessSnapshot); route-at-risk cog reasons over health-score drop + CSM book-of-business" },
+    prosvc:{ biz:"Meridian - Accounting & Advisory", template:"PIPELINE", itemNoun:"engagement", ownerNoun:"accountant",
+      caps:[["bad","4","unassigned matters"],["hot","6","deadlines this week"],["","68%","utilization"],["","$41k","unbilled WIP"]],
+      presence:[["ai","AI Resourcing","balancing utilization"],["ai","AI Review","queuing work for review"],["human","You","partner"],["human","Sam","senior"]],
+      lanes:[["","Intake",""],["","Active",""],["watch","Awaiting review",""],["ok","Delivered",""]],
+      board:{Intake:[["Lattice LLC","year-end close","",""],["Volt Retail","R&D credit","",""]],Active:[["Cedar Homes","audit","Sam",""],["Nimbus Inc","advisory","Ava",""]],"Awaiting review":[["Orion Ltd","tax return","Sam",""]],Delivered:[["Pine & Co","payroll","Ava",""]]},
+      queue:[["crit","Volt Retail R&D credit","filing deadline in 3 days","assign-by-utilization"],["","Lattice year-end close","10-day turnaround","assign-by-utilization"],["","Harbor Freight review","awaiting senior review","assign-by-utilization"]],
+      owners:[["Sam","senior - 82% util",82],["Ava","manager - 61% util",61],["Wei","staff - 44% util",44]],
+      cog:"utilization + skill + deadline", need:[["error","R&D credit filing due in 3 days","unassigned - lowest-utilization qualified: Wei (44%)","Assign"],["warn","$41k unbilled WIP aging","2 engagements >30d unbilled","Bill"]],
+      bind:"matters/engagements + timesheets; assign-by-utilization cog reasons over fee-earner utilization, skill, and deadline" },
+    nonprofit:{ biz:"Open Table - Community Meals", template:"PROGRAMS", itemNoun:"donor", ownerNoun:"development staff",
+      caps:[["good","$182k","of $250k goal"],["bad","23","lapsing donors"],["hot","2","grant deadlines"],["","140","volunteer hrs/wk"]],
+      presence:[["ai","AI Development","scoring lapse risk"],["ai","AI Grants","tracking report deadlines"],["human","You","ED"],["human","Rosa","dev director"]],
+      lanes:[["","Identify",""],["","Cultivate",""],["watch","Ask",""],["ok","Steward",""]],
+      board:{Identify:[["New donor pool","42 first-gifts","",""]],Cultivate:[["Harding Fdn","site visit set","Rosa",""],["A. Chen","event guest","Rosa",""]],Ask:[["Bell Trust","$50k proposal","Rosa",""],["Major-gift list","8 ready","",""]],Steward:[["Legacy circle","thank-yous due","",""]]},
+      queue:[["crit","23 lapsing donors","gave last year, silent 13mo","allocate-to-program"],["crit","City grant report","due in 6 days","allocate-to-program"],["","Bell Trust proposal","$50k ask ready to send","allocate-to-program"]],
+      owners:[["Rosa","dev director",65],["Marcus","grants",40],["AI Development","auto-stewardship",25]],
+      cog:"engagement score + staff capacity", need:[["error","City grant report due in 6 days","unassigned - Marcus (grants) has capacity","Assign"],["warn","23 donors lapsing","batch a re-engagement series before the gala","Launch"]],
+      bind:"donors/gifts/grants/programs; allocate-to-program cog reasons over engagement score and staff capacity" },
+    banking:{ biz:"Cedar Ridge Credit Union", template:"TENANTS", itemNoun:"member household", ownerNoun:"banker",
+      caps:[["bad","5","apps awaiting decision"],["hot","9","maturities in 30d"],["","1,240","households / banker"],["good","OK","exceptions"]],
+      presence:[["ai","AI Underwriting","pre-screening apps"],["ai","AI Maturities","tracking the tickler"],["human","You","branch lead"],["human","Tom","loan officer"]],
+      lanes:[["","Application",""],["watch","Underwriting",""],["","Closing",""],["ok","Booked",""]],
+      board:{Application:[["Ruiz household","auto loan","",""],["Okafor LLC","LOC","",""]],Underwriting:[["Chen mortgage","docs outstanding","Tom",""]],Closing:[["Bell HELOC","funds Fri","Tom",""]],Booked:[["Diaz refi","complete","Ana",""]]},
+      queue:[["crit","Okafor LLC line of credit","member since 2011, decision SLA today","route-at-risk"],["","Ruiz auto loan","clean file, ready to decision","route-at-risk"],["","9 CDs maturing in 30d","retention calls needed","route-at-risk"]],
+      owners:[["Tom","loan officer",75],["Ana","loan officer",50],["AI Underwriting","auto pre-screen",35]],
+      cog:"workload + licensing authority", need:[["error","Okafor LOC decision SLA today","route to a licensed officer - Ana (50%) has authority","Route"],["warn","9 maturities in 30 days","assign retention outreach","Assign"]],
+      bind:"households/loans/policies + maturity ticklers; portfolio cog routes by banker workload + licensing authority ('Members' vocabulary)" },
+    media:{ biz:"Rooftop Films - Production Co.", template:"PIPELINE", itemNoun:"production", ownerNoun:"editor",
+      caps:[["bad","3","cuts awaiting client"],["hot","4","delivery deadlines"],["","2","edit suites free"],["","5","shoot days this wk"]],
+      presence:[["ai","AI Post","routing cuts to editors"],["ai","AI Delivery","tracking deadlines"],["human","You","EP"],["human","Kai","lead editor"]],
+      lanes:[["","Shoot",""],["","Edit",""],["watch","Client review",""],["ok","Deliver",""]],
+      board:{Shoot:[["Acme spot","2-day shoot","",""]],Edit:[["Nova doc","rough cut","Kai",""],["Lumen ad","v3","Mara",""]],"Client review":[["Vertex promo","v2 - waiting on client","Kai",""]],Deliver:[["Halo trailer","master out","Mara",""]]},
+      queue:[["crit","Vertex promo v3","client notes in, deadline Fri","assign-by-utilization"],["","Acme spot edit","footage ingested, ready to cut","assign-by-utilization"],["","Nova doc review","rough cut awaiting EP review","assign-by-utilization"]],
+      owners:[["Kai","lead editor",80],["Mara","editor",55],["Jo","assistant",40]],
+      cog:"editor availability + deadline", need:[["error","Vertex promo due Fri","client notes in, unassigned - Mara (55%) free","Assign"],["warn","3 cuts waiting on client","nudge for approvals before the weekend","Nudge"]],
+      bind:"productions/versions/bookings; timeline cog routes edits by editor availability + deadline, with a waiting-on-client state" },
+  };
+
+  function esc(){} // (unused) - all dynamic writes use textContent
+  function render(key){
+    const c=A[key]; if(!c) return; clearSel();
+    $("biz").textContent=c.biz;
+    // caps
+    $("caps").textContent="";
+    c.caps.forEach(([kind,v,l])=>{const e=document.createElement("div");e.className="cap "+kind;const cv=document.createElement("span");cv.className="cv tnum";cv.textContent=v;const cl=document.createElement("span");cl.className="cl";cl.textContent=l;e.appendChild(cv);e.appendChild(cl);$("caps").appendChild(e);});
+    // presence
+    const pres=$("presence");pres.textContent="";const pl=document.createElement("span");pl.className="plbl";pl.textContent="In this twin now";pres.appendChild(pl);
+    c.presence.forEach(([kind,name,doing])=>{const w=document.createElement("span");w.className="who "+kind;const wa=document.createElement("span");wa.className="wa";wa.textContent=kind==="ai"?"AI":name.slice(0,3).toUpperCase();const wt=document.createElement("span");const wn=document.createElement("span");wn.className="wn";wn.textContent=name;const ww=document.createElement("span");ww.className="ww";ww.textContent=" "+doing;wt.appendChild(wn);wt.appendChild(ww);w.appendChild(wa);w.appendChild(wt);pres.appendChild(w);});
+    // titles
+    $("boardTitle").textContent=c.template==="TENANTS"?"Account health board":"Pipeline";
+    $("boardSub").textContent=c.template+" template";
+    $("queueTitle").textContent=c.template==="TENANTS"?"Attention queue":c.template==="PROGRAMS"?"Moves & deadlines":"Work queue";
+    $("rosterTitle").textContent="Team - on shift";
+    // lanes + items
+    const lanes=$("lanes");lanes.textContent="";
+    c.lanes.forEach(([kind,label])=>{const L=document.createElement("div");L.className="lane "+kind;const lh=document.createElement("div");lh.className="lh";const ls=document.createElement("span");ls.textContent=label;const lc=document.createElement("span");const items=c.board[label]||[];lc.textContent=String(items.length);lh.appendChild(ls);lh.appendChild(lc);L.appendChild(lh);
+      items.forEach(([name,meta,owner,tier])=>{const it=document.createElement("div");it.className="item "+(tier||"");const inn=document.createElement("div");inn.className="in";inn.textContent=name;const im=document.createElement("div");im.className="im";im.textContent=meta;const ow=document.createElement("div");ow.className="own"+(owner?"":" none");const od=document.createElement("span");od.className="od";const ot=document.createElement("span");ot.textContent=owner?owner:"unassigned";ow.appendChild(od);ow.appendChild(ot);it.appendChild(inn);it.appendChild(im);it.appendChild(ow);if(tier){const mt=document.createElement("div");mt.className="meter";mt.appendChild(document.createElement("i"));it.appendChild(mt);}L.appendChild(it);});
+      lanes.appendChild(L);});
+    // queue
+    const q=$("queue");q.textContent="";
+    c.queue.forEach((row,idx)=>{const [kind,title,meta]=row;const card=document.createElement("div");card.className="qcard "+kind;card.dataset.idx=String(idx);const qt=document.createElement("div");qt.className="qt";const qn=document.createElement("span");qn.textContent=title;const tag=document.createElement("span");tag.className="qtag";tag.textContent=kind==="crit"?"URGENT":"QUEUED";qt.appendChild(qn);qt.appendChild(tag);const qm=document.createElement("div");qm.className="qm";qm.textContent=meta;const sug=document.createElement("div");sug.className="sug";card.appendChild(qt);card.appendChild(qm);card.appendChild(sug);card.addEventListener("click",()=>selectItem(card));q.appendChild(card);});
+    // roster
+    const r=$("roster");r.textContent="";
+    c.owners.forEach((o,idx)=>{const [name,role,load]=o;const isAi=/^AI/.test(name);const el=document.createElement("div");el.className="owner"+(isAi?" ai":"");el.dataset.idx=String(idx);el.dataset.name=name;el.dataset.load=String(load);const av=document.createElement("span");av.className="oav";av.textContent=isAi?"AI":name.slice(0,2).toUpperCase();const oi=document.createElement("div");oi.className="oi";const on=document.createElement("div");on.className="on";on.textContent=name;const ow=document.createElement("div");ow.className="ow";ow.textContent=role;oi.appendChild(on);oi.appendChild(ow);const ld=document.createElement("span");ld.className="load";const li=document.createElement("i");li.style.width=load+"%";li.style.background=load>75?"var(--dpf-warning)":"var(--dpf-accent)";ld.appendChild(li);el.appendChild(av);el.appendChild(oi);el.appendChild(ld);el.addEventListener("click",()=>assign(el));r.appendChild(el);});
+    // needs
+    const nd=$("needs");nd.textContent="";
+    c.need.forEach(([kind,t,m,a])=>{const e=document.createElement("div");e.className="need "+kind;const nb=document.createElement("div");nb.className="nb";const nt=document.createElement("div");nt.className="nt";nt.textContent=t;const nm=document.createElement("div");nm.className="nm";nm.textContent=m;nb.appendChild(nt);nb.appendChild(nm);const na=document.createElement("button");na.className="na";na.textContent=a;na.addEventListener("click",()=>$("routeNext").click());e.appendChild(nb);e.appendChild(na);nd.appendChild(e);});
+    // foot
+    $("foot").textContent="Board twin (operating twin for non-physical archetypes). Template: "+c.template+". Interactive: tap a queue item -> the cog ("+c.cog+") suggests the best owner -> tap the owner to route it. Binds to "+c.bind+".";
+    // seed feed
+    const feed=$("feed");feed.textContent="";
+    [["ai","AI HOST","cog ready - suggestions computed from live "+c.cog,"just now"],["human","YOU","reviewing the "+c.template+" board","1m"]].forEach(([k,who,text,t])=>logSeed(k,who,text,t));
+    _cfg=c;
+  }
+  let _cfg=null;
+
+  function logSeed(kind,actor,text,t){const feed=$("feed");const it=document.createElement("div");it.className="fitem "+kind;const fa=document.createElement("span");fa.className="fa";fa.textContent=actor;const fx=document.createElement("span");fx.className="fx";fx.textContent=text;const ft=document.createElement("span");ft.className="ft";ft.textContent=t;it.appendChild(fa);it.appendChild(fx);it.appendChild(ft);feed.appendChild(it);}
+  function logFeed(kind,actor,text){const feed=$("feed");const it=document.createElement("div");it.className="fitem "+kind;const fa=document.createElement("span");fa.className="fa";fa.textContent=actor;const fx=document.createElement("span");fx.className="fx";fx.textContent=text;const ft=document.createElement("span");ft.className="ft";ft.textContent="just now";it.appendChild(fa);it.appendChild(fx);it.appendChild(ft);feed.insertBefore(it,feed.firstChild);while(feed.children.length>8)feed.removeChild(feed.lastChild);}
+
+  let toastT=null;
+  function toast(m){const el=$("toast");el.textContent=m;el.classList.add("on");clearTimeout(toastT);toastT=setTimeout(()=>el.classList.remove("on"),2600);}
+
+  // cog: lowest-load eligible owner (proxy for the archetype's real signal:
+  // CSM book / utilization / staff capacity / banker workload / editor availability).
+  function suggest(){const owners=$$("#roster .owner");let best=null,bl=1e9;owners.forEach(o=>{const l=parseFloat(o.dataset.load)||0;if(l<bl){bl=l;best=o;}});return best;}
+
+  function clearSel(){if(sel)sel.classList.remove("sel");sel=null;$("banner").classList.remove("on");$$("#roster .owner").forEach(o=>o.classList.remove("eligible","suggest"));}
+  function selectItem(card){
+    if(sel===card){clearSel();return;}
+    clearSel();sel=card;card.classList.add("sel");
+    const owners=$$("#roster .owner");owners.forEach(o=>o.classList.add("eligible"));
+    const s=suggest();const title=card.querySelector(".qt span").textContent;
+    if(s){s.classList.remove("eligible");s.classList.add("suggest");}
+    $("bannerText").textContent="Routing "+title+" - tap an owner."+(s?" Cog suggests "+s.dataset.name+" (lowest load).":"");
+    $("banner").classList.add("on");
+  }
+  function assign(owner){
+    if(!sel||!(owner.classList.contains("eligible")||owner.classList.contains("suggest")))return;
+    const title=sel.querySelector(".qt span").textContent, who=owner.dataset.name;
+    sel.remove();clearSel();
+    logFeed("human","YOU","Routed "+title+" to "+who);
+    setTimeout(()=>logFeed("ai","AI HOST","Updated the "+ (_cfg?_cfg.template:"") +" board and re-ranked the queue"),600);
+    toast("Routed "+title+" "+ARR+" "+who);
+    const remaining=$$("#queue .qcard").length; $("queueSub").textContent = remaining? "tap an item, then an owner to route it" : "queue clear - all routed";
+  }
+
+  $$("#queue .qcard"); // no-op to satisfy linters on first paint
+  $("routeNext").addEventListener("click",()=>{const cards=$$("#queue .qcard");if(!cards.length){toast("Queue is clear");return;}const crit=cards.find(c=>c.classList.contains("crit"))||cards[0];selectItem(crit);const s=suggest();if(s)assign(s);});
+  $("archetype").addEventListener("change",e=>render(e.target.value));
+  $("bannerX").addEventListener("click",clearSel);
+  document.addEventListener("keydown",e=>{if(e.key==="Escape")clearSel();});
+  $("themeToggle").addEventListener("click",()=>{const cur=document.documentElement.getAttribute("data-theme")||(matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");document.documentElement.setAttribute("data-theme",cur==="dark"?"light":"dark");});
+
+  render("saas");
+})();
+</script>

--- a/docs/superpowers/specs/assets/2026-07-12-living-business-board-twin-prototype.html
+++ b/docs/superpowers/specs/assets/2026-07-12-living-business-board-twin-prototype.html
@@ -214,9 +214,8 @@
       bind:"productions/versions/bookings; timeline cog routes edits by editor availability + deadline, with a waiting-on-client state" },
   };
 
-  function esc(){} // (unused) - all dynamic writes use textContent
   function render(key){
-    const c=A[key]; if(!c) return; clearSel();
+    const c=A[key]; if(!c) return; clearSel(); _cfg=c;
     $("biz").textContent=c.biz;
     // caps
     $("caps").textContent="";
@@ -243,12 +242,13 @@
     // needs
     const nd=$("needs");nd.textContent="";
     c.need.forEach(([kind,t,m,a])=>{const e=document.createElement("div");e.className="need "+kind;const nb=document.createElement("div");nb.className="nb";const nt=document.createElement("div");nt.className="nt";nt.textContent=t;const nm=document.createElement("div");nm.className="nm";nm.textContent=m;nb.appendChild(nt);nb.appendChild(nm);const na=document.createElement("button");na.className="na";na.textContent=a;na.addEventListener("click",()=>$("routeNext").click());e.appendChild(nb);e.appendChild(na);nd.appendChild(e);});
+    // cog suggestion on each queue card (roster is now in the DOM)
+    refreshQueueSuggestions();
     // foot
     $("foot").textContent="Board twin (operating twin for non-physical archetypes). Template: "+c.template+". Interactive: tap a queue item -> the cog ("+c.cog+") suggests the best owner -> tap the owner to route it. Binds to "+c.bind+".";
     // seed feed
     const feed=$("feed");feed.textContent="";
     [["ai","AI HOST","cog ready - suggestions computed from live "+c.cog,"just now"],["human","YOU","reviewing the "+c.template+" board","1m"]].forEach(([k,who,text,t])=>logSeed(k,who,text,t));
-    _cfg=c;
   }
   let _cfg=null;
 
@@ -261,6 +261,9 @@
   // cog: lowest-load eligible owner (proxy for the archetype's real signal:
   // CSM book / utilization / staff capacity / banker workload / editor availability).
   function suggest(){const owners=$$("#roster .owner");let best=null,bl=1e9;owners.forEach(o=>{const l=parseFloat(o.dataset.load)||0;if(l<bl){bl=l;best=o;}});return best;}
+
+  // show the cog's proposed owner on each queued item (textContent - XSS-safe).
+  function refreshQueueSuggestions(){const s=suggest();$$("#queue .qcard").forEach(card=>{const el=card.querySelector(".sug");if(el)el.textContent=s?GEAR+" route to "+s.dataset.name+" ("+(_cfg?_cfg.cog:"best fit")+")":"";});}
 
   function clearSel(){if(sel)sel.classList.remove("sel");sel=null;$("banner").classList.remove("on");$$("#roster .owner").forEach(o=>o.classList.remove("eligible","suggest"));}
   function selectItem(card){

--- a/packages/storefront-templates/src/index.ts
+++ b/packages/storefront-templates/src/index.ts
@@ -8,4 +8,5 @@ export * from "./composition";
 export * from "./archetypes/index";
 export * from "./media-profile";
 export * from "./operational-value-stream";
+export * from "./twin-profile";
 export * from "./sections/schemas";

--- a/packages/storefront-templates/src/twin-profile.test.ts
+++ b/packages/storefront-templates/src/twin-profile.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import { ALL_ARCHETYPES } from "./archetypes/index";
+import { deriveTwinProfile, type TwinTemplate } from "./twin-profile";
+import type { ArchetypeDefinition } from "./types";
+import { deriveFieldDispatchProfile } from "./field-dispatch";
+import { readActivationProfile } from "./activation-profile";
+
+const ALL_TEMPLATES: TwinTemplate[] = [
+  "FLOOR",
+  "TERRITORY",
+  "YARD",
+  "BAYS",
+  "BOOK",
+  "ROOMS",
+  "STORE",
+  "VENUE",
+  "COUNTER",
+  "TENANTS",
+  "PIPELINE",
+  "PROGRAMS",
+];
+const BOARD_TEMPLATES: TwinTemplate[] = ["TENANTS", "PIPELINE", "PROGRAMS"];
+const NON_PHYSICAL_CATEGORIES = new Set([
+  "software-platform",
+  "banking-financial-services",
+  "professional-services",
+  "media-production",
+  "nonprofit-community",
+]);
+
+const byCategory = (category: string): ArchetypeDefinition[] =>
+  ALL_ARCHETYPES.filter((a) => a.category === category);
+
+/** Whether an archetype's own axes make it physically dispatch-native or a
+ *  reservation-and-return rental pool — the two ways a "non-physical" *category*
+ *  legitimately earns a physical twin (a land-surveyor prof-svcs firm dispatches;
+ *  an equipment co-op pools assets). Category is not destiny; axes win. */
+function isPhysicalByAxes(a: ArchetypeDefinition): boolean {
+  const axes = readActivationProfile(a.activationProfile)?.axes;
+  if (!axes) return a.fieldDispatch?.enabled === true;
+  if (axes.provisioning === "reservation-and-return") return true;
+  if (a.fieldDispatch?.enabled === true) return true;
+  if (a.fieldDispatch?.enabled === false) return false;
+  return deriveFieldDispatchProfile(axes, a.archetypeId, a.fieldDispatch) !== null;
+}
+
+describe("deriveTwinProfile — totality", () => {
+  it("returns a valid, complete twin for EVERY seeded archetype", () => {
+    for (const a of ALL_ARCHETYPES) {
+      const twin = deriveTwinProfile(a);
+      expect(ALL_TEMPLATES, `${a.archetypeId} → unknown template`).toContain(twin.template);
+      expect(twin.zones.length, `${a.archetypeId} needs zones`).toBeGreaterThan(0);
+      expect(twin.queues.length, `${a.archetypeId} needs a queue`).toBeGreaterThan(0);
+      expect(twin.capacityChips.length, `${a.archetypeId} needs capacity chips`).toBeGreaterThan(0);
+      expect(twin.resourceNoun.singular, `${a.archetypeId} resource noun`).toBeTruthy();
+      expect(twin.resourceNoun.plural, `${a.archetypeId} resource plural`).toBeTruthy();
+      expect(twin.workItemNoun.singular, `${a.archetypeId} work-item noun`).toBeTruthy();
+      expect(twin.cog.kind, `${a.archetypeId} needs a cog`).toBeTruthy();
+      expect(twin.cog.signals.length, `${a.archetypeId} cog needs signals`).toBeGreaterThan(0);
+      expect(typeof twin.physical).toBe("boolean");
+    }
+  });
+
+  it("is deterministic (same archetype → same profile)", () => {
+    for (const a of ALL_ARCHETYPES) {
+      expect(deriveTwinProfile(a)).toEqual(deriveTwinProfile(a));
+    }
+  });
+
+  it("physical flag exactly matches the template class for every archetype", () => {
+    for (const a of ALL_ARCHETYPES) {
+      const twin = deriveTwinProfile(a);
+      expect(twin.physical, `${a.archetypeId}`).toBe(!BOARD_TEMPLATES.includes(twin.template));
+    }
+  });
+});
+
+describe("deriveTwinProfile — physical vs non-physical taxonomy (axes win over category)", () => {
+  it("desk-bound work in a non-physical category → a board; field/rental work in the same category → a physical twin", () => {
+    for (const category of NON_PHYSICAL_CATEGORIES) {
+      for (const a of byCategory(category)) {
+        const twin = deriveTwinProfile(a);
+        if (isPhysicalByAxes(a)) {
+          // e.g. land-surveying (professional-services) or an equipment co-op (nonprofit) —
+          // legitimately physical; category does not force a board.
+          expect(twin.physical, `${a.archetypeId} is physical by axes`).toBe(true);
+        } else {
+          expect(BOARD_TEMPLATES, `${a.archetypeId} (${category}) should be a board`).toContain(twin.template);
+          expect(twin.physical).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("every seeded software-platform archetype is the TENANTS board", () => {
+    const saas = byCategory("software-platform");
+    expect(saas.length).toBeGreaterThan(0);
+    for (const a of saas) expect(deriveTwinProfile(a).template).toBe("TENANTS");
+  });
+});
+
+describe("deriveTwinProfile — signature mappings", () => {
+  it("routes dispatch-native archetypes to TERRITORY with the field-dispatch resource noun", () => {
+    for (const a of ALL_ARCHETYPES) {
+      const axes = readActivationProfile(a.activationProfile)?.axes;
+      if (!axes || a.fieldDispatch?.enabled === false) continue;
+      const fd = deriveFieldDispatchProfile(axes, a.archetypeId, a.fieldDispatch);
+      if (fd) {
+        const twin = deriveTwinProfile(a);
+        expect(twin.template, `${a.archetypeId} is dispatch-native`).toBe("TERRITORY");
+        expect(twin.resourceNoun.singular, `${a.archetypeId} binds the FD resource`).toBe(fd.resource.noun);
+      }
+    }
+  });
+
+  it("routes rental (asset-rental) to YARD with a forward horizon", () => {
+    for (const a of byCategory("asset-rental")) {
+      const twin = deriveTwinProfile(a);
+      expect(twin.template).toBe("YARD");
+      expect(twin.forwardHorizon).toBe(true);
+    }
+  });
+
+  it("maps the clearly-determined categories to their template + variant", () => {
+    const expectAll = (category: string, pred: (t: ReturnType<typeof deriveTwinProfile>) => boolean) => {
+      const list = byCategory(category);
+      for (const a of list) expect(pred(deriveTwinProfile(a)), `${a.archetypeId}`).toBe(true);
+    };
+    expectAll("banking-financial-services", (t) => t.template === "TENANTS" && t.variant === "portfolio");
+    expectAll("media-production", (t) => t.template === "PIPELINE" && t.variant === "timeline");
+    expectAll("food-hospitality", (t) => t.template === "FLOOR");
+    expectAll("retail-goods", (t) => t.template === "STORE" || t.template === "TERRITORY");
+    expectAll("hoa-property-management", (t) => t.template === "TERRITORY" && t.variant === "unit-portfolio");
+    expectAll("real-estate-construction", (t) => t.template === "TERRITORY" && t.variant === "job-sites");
+    expectAll("live-events-venues", (t) => t.template === "VENUE");
+  });
+});
+
+describe("deriveTwinProfile — leaf override (ADR-4 escape hatch)", () => {
+  it("lets a leaf override the template, variant, and nouns; unspecified nouns fall through", () => {
+    const base = byCategory("food-hospitality")[0] ?? ALL_ARCHETYPES[0];
+    const overridden: ArchetypeDefinition = {
+      ...base,
+      twinProfile: {
+        template: "STORE",
+        resourceNoun: { singular: "counter" },
+        cog: { kind: "restock-and-pick" },
+      },
+    };
+    const twin = deriveTwinProfile(overridden);
+    expect(twin.template).toBe("STORE");
+    expect(twin.resourceNoun.singular).toBe("counter");
+    expect(twin.resourceNoun.plural).toBeTruthy(); // plural falls through from the STORE default
+    expect(twin.cog.kind).toBe("restock-and-pick");
+  });
+});
+
+describe("deriveTwinProfile — coverage breadth", () => {
+  it("the seeded catalog exercises a broad set of templates (>= 8 of 12)", () => {
+    const seen = new Set(ALL_ARCHETYPES.map((a) => deriveTwinProfile(a).template));
+    expect(seen.size).toBeGreaterThanOrEqual(8);
+  });
+
+  it("produces both physical twins and board twins across the catalog", () => {
+    const templates = ALL_ARCHETYPES.map((a) => deriveTwinProfile(a).template);
+    expect(templates.some((t) => !BOARD_TEMPLATES.includes(t))).toBe(true);
+    expect(templates.some((t) => BOARD_TEMPLATES.includes(t))).toBe(true);
+  });
+});

--- a/packages/storefront-templates/src/twin-profile.ts
+++ b/packages/storefront-templates/src/twin-profile.ts
@@ -1,0 +1,488 @@
+import type { ArchetypeCategory, ArchetypeDefinition } from "./types";
+import { readActivationProfile, type NormalizedOperatingModelAxes } from "./activation-profile";
+import { deriveFieldDispatchProfile } from "./field-dispatch";
+
+/**
+ * Operational Twin Framework — the derived per-archetype twin configuration.
+ *
+ * The three hand-built prototypes (restaurant floor, field-service dispatch,
+ * rental yard) converged on one grammar with different nouns. Rather than
+ * building 53 bespoke twins, `deriveTwinProfile` picks one of ~12 templates and
+ * binds its nouns from the operating-model axes, `schedulingDefaults`, the
+ * derived `FieldDispatchProfile`, and the archetype's category — the fourth
+ * member of DPF's derive-with-override family (OVSM, media-profile,
+ * field-dispatch ADR-4). Derive, never author; a leaf `twinProfile` override is
+ * the escape hatch for a genuine exception.
+ *
+ * Design: docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md
+ * Parent: docs/superpowers/specs/2026-07-11-living-business-workforce-visualization-design.md §3
+ *
+ * PURE + DB-free (mirrors operational-value-stream.ts). Nouns here are sensible
+ * defaults; final operator-facing labels resolve through the vocabulary system
+ * at render time (a credit union's board says "Members", a clinic redacts to
+ * role not patient) — this profile just says which template and which nouns.
+ */
+
+/** The 12 twin templates. Physical templates render *space*; board templates
+ *  (TENANTS/PIPELINE/PROGRAMS) render *portfolio state* for non-physical work. */
+export type TwinTemplate =
+  | "FLOOR" // tables/stations + seats on a floor plan (food-hospitality)
+  | "TERRITORY" // fleet/techs/posts/units on a zone map (dispatch-native)
+  | "YARD" // pooled assets in bays (reservation-and-return)
+  | "BAYS" // work orders on lifts/bays/benches (fixed-location repair)
+  | "BOOK" // providers x chairs/rooms on a day grid (appointment services)
+  | "ROOMS" // rooms/beds/kennels occupancy board (overnight/occupancy)
+  | "STORE" // shelves/stock + POS lanes + fulfilment (point-of-sale retail)
+  | "VENUE" // seat/space map + run-of-show timeline (ticketed events)
+  | "COUNTER" // service counters/case stations (statutory/public services)
+  | "TENANTS" // accounts/tenants x health/usage/seats (board — SaaS/banking)
+  | "PIPELINE" // matters/engagements/productions x stage (board — prof-svcs/media)
+  | "PROGRAMS"; // programs/funds/donors/campaigns (board — nonprofit)
+
+export type TwinVariant =
+  | "fleet"
+  | "posts"
+  | "job-sites"
+  | "unit-portfolio"
+  | "provider-chair"
+  | "provider-x-room"
+  | "class-grid"
+  | "portfolio"
+  | "timeline";
+
+/** The allocation decision the twin's AI "cog" assists (constraint→proposal→confirm). */
+export type TwinCogKind =
+  | "seat-from-dwell"
+  | "nearest-resource"
+  | "best-asset-by-readiness"
+  | "bay-and-tech"
+  | "provider-slot"
+  | "room-assignment"
+  | "restock-and-pick"
+  | "space-and-date"
+  | "next-in-line"
+  | "route-at-risk-account"
+  | "assign-by-utilization"
+  | "allocate-to-program";
+
+export type TwinCogSignal =
+  | "dwell-time"
+  | "turn-time"
+  | "travel-time"
+  | "skill"
+  | "proximity"
+  | "availability"
+  | "readiness"
+  | "class-fit"
+  | "parts"
+  | "labor-hours"
+  | "utilization"
+  | "deadline"
+  | "health-score"
+  | "workload"
+  | "licensing"
+  | "date-range"
+  | "sla-clock"
+  | "engagement-score";
+
+export interface TwinNoun {
+  singular: string;
+  plural: string;
+}
+
+export interface TwinZoneSpec {
+  key: string;
+  label: string;
+}
+
+export interface TwinQueueSpec {
+  key: string;
+  label: string;
+}
+
+export interface TwinCogSpec {
+  kind: TwinCogKind;
+  signals: TwinCogSignal[];
+}
+
+export interface TwinProfile {
+  template: TwinTemplate;
+  variant?: TwinVariant;
+  /** True for spatial twins; false for the board family (TENANTS/PIPELINE/PROGRAMS). */
+  physical: boolean;
+  /** Named regions of the operation. */
+  zones: TwinZoneSpec[];
+  /** The countable resource units (tables/vans/bays/chairs/rooms/accounts). */
+  resourceNoun: TwinNoun;
+  /** The units of demand processed through the twin (tickets/jobs/agreements/matters). */
+  workItemNoun: TwinNoun;
+  /** Ordered demand awaiting allocation — the heartbeat (waitlist/dispatch/renewals). */
+  queues: TwinQueueSpec[];
+  /** The AI-coworker allocation decision the twin assists. */
+  cog: TwinCogSpec;
+  /** Which live constraints headline as capacity chips. */
+  capacityChips: string[];
+  /** Some businesses default to *now* but carry a short forward-availability
+   *  horizon (occupancy calendars — yard/rooms/venue). */
+  forwardHorizon?: boolean;
+  /** Hybrid archetypes (physical + digital) get a secondary board lens. */
+  hybridBoard?: TwinTemplate;
+}
+
+/** Leaf-level override of the derived profile — the ADR-4 escape hatch. Mirrors
+ *  `FieldDispatchProfileOverride`/`MediaProfile` override pattern. Set only for a
+ *  genuine exception the derivation cannot express. */
+export interface TwinProfileOverride {
+  template?: TwinTemplate;
+  variant?: TwinVariant;
+  physical?: boolean;
+  zones?: TwinZoneSpec[];
+  resourceNoun?: Partial<TwinNoun>;
+  workItemNoun?: Partial<TwinNoun>;
+  queues?: TwinQueueSpec[];
+  cog?: Partial<TwinCogSpec>;
+  capacityChips?: string[];
+  forwardHorizon?: boolean;
+  hybridBoard?: TwinTemplate;
+}
+
+const PHYSICAL_TEMPLATES: ReadonlySet<TwinTemplate> = new Set<TwinTemplate>([
+  "FLOOR",
+  "TERRITORY",
+  "YARD",
+  "BAYS",
+  "BOOK",
+  "ROOMS",
+  "STORE",
+  "VENUE",
+  "COUNTER",
+]);
+
+const n = (singular: string, plural: string): TwinNoun => ({ singular, plural });
+const z = (key: string, label: string): TwinZoneSpec => ({ key, label });
+const q = (key: string, label: string): TwinQueueSpec => ({ key, label });
+
+/** Per-template defaults for the grammar primitives. Variant + field-dispatch
+ *  nouns refine these; the leaf override wins over everything. */
+const TEMPLATE_DEFAULTS: Record<
+  TwinTemplate,
+  Omit<TwinProfile, "template" | "physical" | "variant" | "hybridBoard">
+> = {
+  FLOOR: {
+    zones: [z("kitchen", "Kitchen / the pass"), z("floor", "Dining room"), z("entrance", "Entrance / waitlist")],
+    resourceNoun: n("table", "tables"),
+    workItemNoun: n("ticket", "tickets"),
+    queues: [q("waitlist", "Waitlist"), q("reservations", "Reservations")],
+    cog: { kind: "seat-from-dwell", signals: ["dwell-time", "turn-time"] },
+    capacityChips: ["tables seated", "seats filled", "parties waiting"],
+  },
+  TERRITORY: {
+    zones: [z("map", "Territory map"), z("base", "Yard / depot")],
+    resourceNoun: n("technician", "technicians"),
+    workItemNoun: n("job", "jobs"),
+    queues: [q("dispatch", "Dispatch queue")],
+    cog: { kind: "nearest-resource", signals: ["travel-time", "skill", "availability", "parts"] },
+    capacityChips: ["available", "en-route", "in dispatch queue"],
+  },
+  YARD: {
+    zones: [z("ready", "Ready line"), z("returns", "Returns & inspection"), z("maintenance", "Maintenance bay"), z("out", "Out on rent")],
+    resourceNoun: n("asset", "assets"),
+    workItemNoun: n("agreement", "agreements"),
+    queues: [q("reservations", "Reservations to fill")],
+    cog: { kind: "best-asset-by-readiness", signals: ["readiness", "date-range"] },
+    capacityChips: ["assets on rent", "utilization", "overdue"],
+    forwardHorizon: true,
+  },
+  BAYS: {
+    zones: [z("intake", "Intake"), z("bays", "Bays / lifts"), z("waiting", "Awaiting parts"), z("ready", "Ready for pickup")],
+    resourceNoun: n("bay", "bays"),
+    workItemNoun: n("work order", "work orders"),
+    queues: [q("intake", "Awaiting approval"), q("promised", "Promised-by")],
+    cog: { kind: "bay-and-tech", signals: ["labor-hours", "parts", "skill"] },
+    capacityChips: ["bays in use", "awaiting parts", "billable hours"],
+  },
+  BOOK: {
+    zones: [z("grid", "Day grid")],
+    resourceNoun: n("provider", "providers"),
+    workItemNoun: n("appointment", "appointments"),
+    queues: [q("requests", "Appointment requests"), q("walkins", "Walk-ins / waitlist")],
+    cog: { kind: "provider-slot", signals: ["availability", "skill", "class-fit"] },
+    capacityChips: ["provider-hours", "booked", "gaps"],
+  },
+  ROOMS: {
+    zones: [z("board", "Occupancy board")],
+    resourceNoun: n("room", "rooms"),
+    workItemNoun: n("stay", "stays"),
+    queues: [q("checkins", "Check-ins"), q("waitlist", "Waitlist")],
+    cog: { kind: "room-assignment", signals: ["availability", "date-range"] },
+    capacityChips: ["occupancy", "arrivals", "departures"],
+    forwardHorizon: true,
+  },
+  STORE: {
+    zones: [z("floor", "Store floor"), z("back", "Back room"), z("online", "Online channel")],
+    resourceNoun: n("shelf", "shelves"),
+    workItemNoun: n("order", "orders"),
+    queues: [q("pickups", "Pickups / online orders"), q("restock", "Low-stock / restock")],
+    cog: { kind: "restock-and-pick", signals: ["availability", "workload"] },
+    capacityChips: ["low-stock items", "open carts", "on-hand value"],
+  },
+  VENUE: {
+    zones: [z("calendar", "Space / date calendar"), z("runofshow", "Run of show")],
+    resourceNoun: n("space", "spaces"),
+    workItemNoun: n("event", "events"),
+    queues: [q("holds", "Holds awaiting contract"), q("tickets", "Ticket sales")],
+    cog: { kind: "space-and-date", signals: ["date-range", "availability"] },
+    capacityChips: ["holds", "seats/covers", "events this week"],
+    forwardHorizon: true,
+  },
+  COUNTER: {
+    zones: [z("queue", "Service queue"), z("review", "Case review"), z("inspections", "Inspections")],
+    resourceNoun: n("reviewer", "reviewers"),
+    workItemNoun: n("case", "cases"),
+    queues: [q("intake", "Intake"), q("review", "Review by department"), q("inspections", "Inspections today")],
+    cog: { kind: "next-in-line", signals: ["sla-clock", "workload", "skill"] },
+    capacityChips: ["in queue", "SLA at risk", "reviewer-days"],
+  },
+  TENANTS: {
+    zones: [z("board", "Account health board")],
+    resourceNoun: n("account", "accounts"),
+    workItemNoun: n("engagement", "engagements"),
+    queues: [q("renewals", "Renewals at risk"), q("atrisk", "At-risk accounts"), q("ctas", "Open CTAs")],
+    cog: { kind: "route-at-risk-account", signals: ["health-score", "workload", "deadline"] },
+    capacityChips: ["at-risk", "renewals ≤90d", "book of business"],
+  },
+  PIPELINE: {
+    zones: [z("pipeline", "Engagement pipeline")],
+    resourceNoun: n("professional", "professionals"),
+    workItemNoun: n("matter", "matters"),
+    queues: [q("deadlines", "Deadlines"), q("review", "Awaiting review"), q("wip", "Unbilled WIP")],
+    cog: { kind: "assign-by-utilization", signals: ["utilization", "skill", "deadline"] },
+    capacityChips: ["utilization", "unbilled WIP", "deadlines this week"],
+  },
+  PROGRAMS: {
+    zones: [z("programs", "Programs"), z("moves", "Moves management")],
+    resourceNoun: n("program", "programs"),
+    workItemNoun: n("campaign", "campaigns"),
+    queues: [q("lapsing", "Lapsing donors"), q("grants", "Grant deadlines"), q("shifts", "Volunteer shifts")],
+    cog: { kind: "allocate-to-program", signals: ["engagement-score", "availability", "deadline"] },
+    capacityChips: ["goal progress", "lapse-risk", "volunteer hours"],
+  },
+};
+
+/** TERRITORY variant + resource noun depend on category and the field-dispatch profile. */
+function territoryVariant(category: ArchetypeCategory): TwinVariant {
+  switch (category) {
+    case "security-services":
+      return "posts";
+    case "hoa-property-management":
+      return "unit-portfolio";
+    case "real-estate-construction":
+      return "job-sites";
+    default:
+      return "fleet"; // trades, moving-and-logistics, mobile automotive
+  }
+}
+
+interface TemplateChoice {
+  template: TwinTemplate;
+  variant?: TwinVariant;
+}
+
+/**
+ * Choose the template + variant. Priority order (per design §5): explicit
+ * dispatch/rental axes first, then the board family for non-physical work, then
+ * the physical-category mappings, with axes refining category where they can.
+ */
+function chooseTemplate(
+  archetype: ArchetypeDefinition,
+  axes: NormalizedOperatingModelAxes | null,
+  fieldDispatchEnabled: boolean,
+): TemplateChoice {
+  const category = archetype.category;
+  const commercialModel = axes?.commercialModel;
+  const provisioning = axes?.provisioning;
+  const delivery = axes?.delivery;
+  const platform = axes?.platform;
+  const governance = axes?.governance;
+  const schedulingPattern = archetype.schedulingDefaults?.schedulingPattern;
+  const tags = archetype.tags ?? [];
+  const hasTag = (...needles: string[]) =>
+    tags.some((t) => needles.some((needle) => t.toLowerCase().includes(needle)));
+
+  // 1. Dispatch-native → TERRITORY (trades, moving, security, mobile automotive,
+  //    field property mgmt / construction). Wins over category fallbacks.
+  if (fieldDispatchEnabled) {
+    return { template: "TERRITORY", variant: territoryVariant(category) };
+  }
+
+  // 2. Reservation-and-return pooled assets → YARD.
+  if (provisioning === "reservation-and-return" || category === "asset-rental") {
+    return { template: "YARD" };
+  }
+
+  // 3. Non-physical → the board family (SaaS/banking/prof-svcs/media/nonprofit).
+  //    Category-specific board checks come BEFORE the generic member-owned rule so
+  //    a member-owned credit union → TENANTS/portfolio (with "Members" vocabulary),
+  //    not the donor/campaign PROGRAMS board.
+  if (category === "software-platform") {
+    return { template: "TENANTS" };
+  }
+  if (category === "banking-financial-services") {
+    return { template: "TENANTS", variant: "portfolio" };
+  }
+  if (category === "professional-services") {
+    return { template: "PIPELINE" }; // field prof-svcs (surveying/inspection) already caught in step 1
+  }
+  if (category === "media-production") {
+    return { template: "PIPELINE", variant: "timeline" };
+  }
+  if (category === "nonprofit-community" || governance === "member-owned") {
+    return { template: "PROGRAMS" }; // physical co-ops (rental/dispatch) already caught in steps 1-2
+  }
+  // Axis-driven board fallback for any other purely-digital service.
+  if (delivery === "digital") {
+    if (platform && platform !== "no") return { template: "TENANTS" };
+    if (commercialModel === "subscription" || commercialModel === "usage-based" || commercialModel === "account-based-fees") {
+      return { template: "TENANTS" };
+    }
+    return { template: "PIPELINE" };
+  }
+
+  // 4. Physical categories.
+  if (category === "food-hospitality") {
+    return { template: "FLOOR" };
+  }
+  if (category === "retail-goods" || commercialModel === "point-of-sale") {
+    return { template: "STORE" };
+  }
+  if (category === "live-events-venues") {
+    return { template: "VENUE" };
+  }
+  if (category === "public-sector" || commercialModel === "statutory-fees-and-levies") {
+    return { template: "COUNTER" };
+  }
+  // Property, construction, and trades are spatial even when their axes don't set
+  // the dispatch channel — a work-order board / job-site map / crew board, not an
+  // appointment book. Map by category so they don't fall through to BOOK/PIPELINE.
+  if (category === "hoa-property-management") {
+    return { template: "TERRITORY", variant: "unit-portfolio" };
+  }
+  if (category === "real-estate-construction") {
+    return { template: "TERRITORY", variant: "job-sites" };
+  }
+  if (category === "trades-maintenance") {
+    return { template: "TERRITORY", variant: "fleet" };
+  }
+  if (category === "automotive-services") {
+    return { template: "BAYS" }; // dispatch-native (mobile) automotive already caught in step 1
+  }
+  if (category === "pet-services") {
+    return hasTag("board", "kennel", "daycare", "lodging", "hotel")
+      ? { template: "ROOMS" }
+      : { template: "BOOK", variant: "provider-chair" };
+  }
+  if (category === "healthcare-wellness") {
+    return hasTag("hospital", "inpatient", "ward", "bed")
+      ? { template: "ROOMS" }
+      : { template: "BOOK", variant: "provider-x-room" };
+  }
+  if (category === "beauty-personal-care") {
+    return { template: "BOOK", variant: "provider-chair" };
+  }
+  if (category === "fitness-recreation" || category === "education-training" || schedulingPattern === "class") {
+    return { template: "BOOK", variant: "class-grid" };
+  }
+
+  // 5. Final safety net — never return undefined.
+  if (schedulingPattern === "slot") return { template: "BOOK", variant: "provider-chair" };
+  if (axes?.form === "goods") return { template: "STORE" };
+  return { template: "PIPELINE" };
+}
+
+function applyOverride(base: TwinProfile, override: TwinProfileOverride | undefined): TwinProfile {
+  if (!override) return base;
+  return {
+    ...base,
+    ...(override.template ? { template: override.template } : {}),
+    ...(override.variant ? { variant: override.variant } : {}),
+    ...(override.physical !== undefined ? { physical: override.physical } : {}),
+    ...(override.zones ? { zones: override.zones } : {}),
+    resourceNoun: { ...base.resourceNoun, ...override.resourceNoun },
+    workItemNoun: { ...base.workItemNoun, ...override.workItemNoun },
+    ...(override.queues ? { queues: override.queues } : {}),
+    cog: { ...base.cog, ...override.cog },
+    ...(override.capacityChips ? { capacityChips: override.capacityChips } : {}),
+    ...(override.forwardHorizon !== undefined ? { forwardHorizon: override.forwardHorizon } : {}),
+    ...(override.hybridBoard ? { hybridBoard: override.hybridBoard } : {}),
+  };
+}
+
+/** Board lens paired to a physical template for a hybrid (physical + digital) archetype. */
+function hybridBoardFor(template: TwinTemplate): TwinTemplate | undefined {
+  switch (template) {
+    case "STORE":
+      return "TENANTS"; // retail-with-online
+    case "BOOK":
+      return "PIPELINE"; // e.g. telehealth alongside in-person
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Derive the operational-twin configuration for an archetype. Pure, total
+ * (always returns a valid template), and override-respecting. This is the
+ * single source of truth for "which twin does this archetype get, with which
+ * nouns" — consumed by the twin render kit and the workspace-home registry.
+ */
+export function deriveTwinProfile(archetype: ArchetypeDefinition): TwinProfile {
+  const activation = readActivationProfile(archetype.activationProfile);
+  const axes = activation?.axes ?? null;
+
+  // Field-dispatch enablement: axes drive it (needsFieldDispatch), but an
+  // explicit inline `fieldDispatch.enabled` forces the outcome either way.
+  let fieldDispatchEnabled = false;
+  let fdResource: TwinNoun | undefined;
+  if (archetype.fieldDispatch?.enabled === true) {
+    fieldDispatchEnabled = true;
+  } else if (archetype.fieldDispatch?.enabled === false) {
+    fieldDispatchEnabled = false;
+  } else if (axes) {
+    const fd = deriveFieldDispatchProfile(axes, archetype.archetypeId, archetype.fieldDispatch);
+    fieldDispatchEnabled = fd !== null;
+    if (fd) fdResource = n(fd.resource.noun, fd.resource.nounPlural);
+  }
+  // Recover the resource noun when enablement was forced on without axes.
+  if (fieldDispatchEnabled && !fdResource && axes) {
+    const fd = deriveFieldDispatchProfile(axes, archetype.archetypeId, {
+      ...archetype.fieldDispatch,
+      enabled: true,
+    });
+    if (fd) fdResource = n(fd.resource.noun, fd.resource.nounPlural);
+  }
+
+  const { template, variant } = chooseTemplate(archetype, axes, fieldDispatchEnabled);
+  const defaults = TEMPLATE_DEFAULTS[template];
+
+  const base: TwinProfile = {
+    template,
+    ...(variant ? { variant } : {}),
+    physical: PHYSICAL_TEMPLATES.has(template),
+    zones: defaults.zones.map((zone) => ({ ...zone })),
+    resourceNoun:
+      template === "TERRITORY" && fdResource ? fdResource : { ...defaults.resourceNoun },
+    workItemNoun: { ...defaults.workItemNoun },
+    queues: defaults.queues.map((queue) => ({ ...queue })),
+    cog: { kind: defaults.cog.kind, signals: [...defaults.cog.signals] },
+    capacityChips: [...defaults.capacityChips],
+    ...(defaults.forwardHorizon ? { forwardHorizon: true } : {}),
+  };
+
+  // Hybrid archetypes get a secondary board lens (physical + digital).
+  if (axes?.delivery === "hybrid") {
+    const secondary = hybridBoardFor(template);
+    if (secondary) base.hybridBoard = secondary;
+  }
+
+  return applyOverride(base, archetype.twinProfile);
+}

--- a/packages/storefront-templates/src/types.ts
+++ b/packages/storefront-templates/src/types.ts
@@ -1,4 +1,5 @@
 import type { FieldDispatchProfileOverride } from "./field-dispatch";
+import type { TwinProfileOverride } from "./twin-profile";
 
 export type CtaType = "booking" | "purchase" | "inquiry" | "donation" | "rental";
 
@@ -585,4 +586,14 @@ export interface ArchetypeDefinition {
    * docs/superpowers/specs/2026-06-13-field-dispatch-capability-design.md ADR-4.
    */
   fieldDispatch?: FieldDispatchProfileOverride;
+  /**
+   * Optional override of the derived operational-twin configuration. Left unset
+   * for the common case — `deriveTwinProfile` (twin-profile.ts) picks the
+   * template and binds its nouns from this archetype's axes, scheduling,
+   * field-dispatch profile, and category. Set only for a genuine exception the
+   * derivation cannot express (the ADR-4 escape hatch, mirroring `fieldDispatch`
+   * / `mediaProfile`). See
+   * docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md §5.
+   */
+  twinProfile?: TwinProfileOverride;
 }


### PR DESCRIPTION
## Summary

Delivers **P1 of the Operational Twin Framework** ([design](docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md), merged in #2841): the pure, DB-free derivation that gives **every archetype — physical and non-physical — a working operational twin** from one grammar + 12 templates. `deriveTwinProfile(archetype)` is the fourth member of DPF's derive-with-override family (`deriveOperationalValueStream`, `deriveMediaProfile`, `deriveFieldDispatchProfile` / ADR-4): it picks a template and binds its nouns/zones/queues/cog from the archetype's operating-model axes, `schedulingDefaults`, derived `FieldDispatchProfile`, and category, with a leaf `twinProfile` override for genuine exceptions. Verified over all **94** seeded archetypes.

## Changes

- **`packages/storefront-templates/src/twin-profile.ts`** (new) — `TwinTemplate` (×12: FLOOR/TERRITORY/YARD/BAYS/BOOK/ROOMS/STORE/VENUE/COUNTER + TENANTS/PIPELINE/PROGRAMS boards), `TwinVariant`, `TwinCogKind`/`TwinCogSignal`, `TwinProfile`, `TwinProfileOverride`; the `TEMPLATE_DEFAULTS` grammar map; `chooseTemplate` (priority: dispatch → rental → board family → physical categories → safety net); and `deriveTwinProfile` with the leaf-override escape hatch.
- **`types.ts`** — optional `twinProfile?: TwinProfileOverride` on `ArchetypeDefinition` (mirrors `fieldDispatch?`/`mediaProfile?`; type-only circular import, same pattern as `FieldDispatchProfileOverride`).
- **`index.ts`** — re-export.
- **`twin-profile.test.ts`** (new) — totality (every seeded archetype → a complete, deterministic twin), the board↔physical invariant, axis-over-category taxonomy, signature mappings, leaf override, coverage breadth.
- **Board-twin prototype** `docs/superpowers/specs/assets/2026-07-12-living-business-board-twin-prototype.html` — demonstrates the **non-physical** archetypes (SaaS/TENANTS, professional-services/PIPELINE, nonprofit/PROGRAMS, banking/TENANTS-portfolio, media/PIPELINE-timeline) with the same operating-twin grammar (presence + cog + queues + attributed feed): route a queued item to the best owner by the archetype's signal; static-first, charset-safe, `textContent`-only.
- **Plan** `docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md`.

**Design correction found + verified during P1:** *category is not destiny — the physical axes win.* A land-surveying/field-inspection **professional-services** firm is dispatch-native → TERRITORY; an equipment-pooling **co-op** (nonprofit) → YARD; a member-owned **credit union** (banking) → TENANTS/portfolio, not the donor PROGRAMS board. Fixed the member-owned→PROGRAMS ordering and added explicit HOA/construction/trades → TERRITORY category mappings.

## Test plan

- [x] **Source-only change** (pure, DB-free `@dpf/storefront-templates` derivation + tests; doc + self-contained HTML prototype)
  - [x] `tsc` compiles all package sources clean (exit 0), incl. the new `twinProfile?` leaf field and the type-only circular import
  - [x] Targeted logic run — `deriveTwinProfile` exercised over all 94 seeded archetypes (see evidence)
  - [ ] `pnpm --filter @dpf/storefront-templates test` (vitest) — runs in the CI **Unit Tests** job; deps unavailable in this source-only worktree (harness limitation, not a product defect — AGENTS.md §5)

- [x] **Verification-harness limitation acknowledged** — vitest deps aren't installed in the worktree; the canonical unit-test gate runs in CI. Logic was verified via a compiled Node harness instead (below).

### Verification evidence (source-local; pure DB-free package, §5)

```
compile exit 0
ALL TEST ASSERTIONS PASS (94 archetypes)
```

Compiled the package sources with `tsc` (clean) and ran a Node harness over `ALL_ARCHETYPES`: every archetype derives a complete twin (zones, queue, chips, resource/work nouns, cog + signals, physical flag); deterministic; the **board↔physical invariant holds for all 94**; dispatch-native archetypes bind the field-dispatch resource noun; the clearly-determined category mappings hold (banking→TENANTS/portfolio, media→PIPELINE/timeline, food→FLOOR, hoa→TERRITORY/unit-portfolio, construction→TERRITORY/job-sites, rental→YARD); the leaf override replaces template/variant/nouns with fall-through. Every `twin-profile.test.ts` assertion was replicated against the compiled output — **0 failures**. 10 of 12 templates are exercised by the seeded catalog (BAYS/COUNTER are reachable-by-derivation — fixed-shop automotive / permit-counter public-sector — but no seeded leaf currently lands there).

## Related issues / Epic

- **EP-LIVING-BUSINESS-VIZ** P1. Design landed in #2841 (merged): the Living Business paradigm + the Operational Twin Framework spec with the 21-category market research.

## Overlap sweep

New pure module in `@dpf/storefront-templates`; no in-flight overlap. Reuses the existing derive-with-override pattern and the `readActivationProfile`/`deriveFieldDispatchProfile` helpers rather than introducing a parallel mechanism.

## Notes for the reviewer

- **This is the derivation only (P1)** — no UI render kit yet (P2), no route changes, no migration. Pure `@dpf/storefront-templates` + tests + a doc prototype. Safe, source-only.
- The `twinProfile?` leaf field is optional; every existing archetype literal stays valid and unchanged.
- P2 (the React grammar kit under `apps/web/components/twin/`) will carry the required `UX-Fit-Decision` for the metric/status components — none needed here (no product UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ko4H8pkFGNvgnbz5j3wVF8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ko4H8pkFGNvgnbz5j3wVF8)_