### PR TITLE
feat(build): research-before-spec — cited, verified deep-research in ideate (BI-F8C5E01C)

### DIFF
--- a/apps/web/lib/build/pre-spec-research.test.ts
+++ b/apps/web/lib/build/pre-spec-research.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldRunPreSpecResearch,
+  conductPreSpecResearch,
+  formatResearchReportMarkdown,
+  makeInferenceResearchDeps,
+  type PreSpecResearchDeps,
+  type ResearchReport,
+} from "./pre-spec-research";
+
+describe("shouldRunPreSpecResearch (pure trigger)", () => {
+  it("runs for a medium+ feature", () => {
+    expect(shouldRunPreSpecResearch({ workType: "feature", effortSize: "medium" })).toBe(true);
+    expect(shouldRunPreSpecResearch({ workType: "feature", effortSize: "large" })).toBe(true);
+  });
+  it("skips a small feature", () => {
+    expect(shouldRunPreSpecResearch({ workType: "feature", effortSize: "small" })).toBe(false);
+  });
+  it("runs a small feature when sensitivity is elevated/high", () => {
+    expect(shouldRunPreSpecResearch({ workType: "feature", effortSize: "small", sensitivity: "elevated" })).toBe(true);
+    expect(shouldRunPreSpecResearch({ workType: "feature", effortSize: "small", sensitivity: "high" })).toBe(true);
+  });
+  it("skips non-feature work regardless of size/sensitivity", () => {
+    expect(shouldRunPreSpecResearch({ workType: "fix", effortSize: "large", sensitivity: "high" })).toBe(false);
+    expect(shouldRunPreSpecResearch({ workType: "chore", effortSize: "xlarge" })).toBe(false);
+    expect(shouldRunPreSpecResearch({ workType: "doc", effortSize: "large" })).toBe(false);
+  });
+  it("defaults missing workType to feature", () => {
+    expect(shouldRunPreSpecResearch({ effortSize: "medium" })).toBe(true);
+  });
+});
+
+function deps(over: Partial<PreSpecResearchDeps> = {}): PreSpecResearchDeps {
+  return {
+    planQueries: async () => ["q1", "q2"],
+    search: async (q) => [{ title: `T-${q}`, url: `https://ex.com/${q}`, description: `snippet ${q}` }],
+    fetchSource: async (u) => ({ title: `fetched ${u}`, textExcerpt: `body of ${u}` }),
+    synthesize: async (_t, sources) => sources.map((s) => ({ claim: `finding from ${s.index}`, citations: [s.index] })),
+    verifyFinding: async () => true,
+    ...over,
+  };
+}
+
+describe("conductPreSpecResearch", () => {
+  it("produces a cited report with verified findings", async () => {
+    const r = await conductPreSpecResearch("build a thing", deps());
+    expect(r.sources.length).toBe(2); // one per query, deduped
+    expect(r.findings.length).toBe(2);
+    expect(r.findings.every((f) => f.verified)).toBe(true);
+    expect(r.caveats.length).toBe(0);
+  });
+
+  it("dedups sources by URL across queries", async () => {
+    const r = await conductPreSpecResearch("t", deps({
+      planQueries: async () => ["a", "b"],
+      search: async () => [{ title: "same", url: "https://same.com", description: "s" }],
+    }));
+    expect(r.sources.length).toBe(1);
+  });
+
+  it("moves unverifiable findings to caveats, never presenting them as fact", async () => {
+    const r = await conductPreSpecResearch("t", deps({ verifyFinding: async () => false }));
+    expect(r.findings.length).toBe(0);
+    expect(r.caveats.length).toBeGreaterThan(0);
+    expect(r.caveats[0]).toContain("Unverified:");
+  });
+
+  it("drops findings whose citations are out of range", async () => {
+    const r = await conductPreSpecResearch("t", deps({
+      synthesize: async () => [{ claim: "bad cite", citations: [99] }],
+    }));
+    expect(r.findings.length).toBe(0);
+  });
+
+  it("returns an honest empty report when no sources are reachable", async () => {
+    const r = await conductPreSpecResearch("t", deps({ search: async () => [] }));
+    expect(r.sources.length).toBe(0);
+    expect(r.findings.length).toBe(0);
+    expect(r.caveats[0]).toContain("No reachable external sources");
+  });
+
+  it("is robust to a search that throws (skips that query)", async () => {
+    const r = await conductPreSpecResearch("t", deps({
+      planQueries: async () => ["ok", "boom"],
+      search: async (q) => { if (q === "boom") throw new Error("net"); return [{ title: "t", url: "https://ok.com", description: "d" }]; },
+    }));
+    expect(r.sources.length).toBe(1);
+  });
+
+  it("caps total sources", async () => {
+    const r = await conductPreSpecResearch("t", deps({
+      maxSources: 2,
+      planQueries: async () => ["a", "b", "c", "d"],
+      search: async (q) => [{ title: q, url: `https://${q}.com`, description: "d" }],
+    }));
+    expect(r.sources.length).toBe(2);
+  });
+});
+
+describe("formatResearchReportMarkdown", () => {
+  it("renders findings, caveats, and numbered sources", () => {
+    const report: ResearchReport = {
+      topic: "X",
+      queries: ["q"],
+      sources: [{ index: 1, title: "Src", url: "https://s.com", excerpt: "e" }],
+      findings: [{ claim: "C", citations: [1], verified: true }],
+      caveats: ["Unverified: Y"],
+      summary: "sum",
+    };
+    const md = formatResearchReportMarkdown(report);
+    expect(md).toContain("### Pre-spec research — X");
+    expect(md).toContain("- C [1]");
+    expect(md).toContain("Unverified: Y");
+    expect(md).toContain("1. [Src](https://s.com)");
+  });
+});
+
+describe("makeInferenceResearchDeps (prompt/JSON parsing)", () => {
+  it("planQueries parses a JSON array from the llm", async () => {
+    const d = makeInferenceResearchDeps({
+      llm: async () => 'Here are queries: ["standards for X", "prior art Y"]',
+      search: async () => [],
+      fetchSource: async () => ({ title: null, textExcerpt: null }),
+    });
+    expect(await d.planQueries("topic")).toEqual(["standards for X", "prior art Y"]);
+  });
+
+  it("planQueries returns [] on unparseable llm output", async () => {
+    const d = makeInferenceResearchDeps({ llm: async () => "no json", search: async () => [], fetchSource: async () => ({ title: null, textExcerpt: null }) });
+    expect(await d.planQueries("t")).toEqual([]);
+  });
+
+  it("synthesize parses findings and filters empty claims", async () => {
+    const d = makeInferenceResearchDeps({
+      llm: async () => '{"findings":[{"claim":"a real finding","citations":[1]},{"claim":"","citations":[1]}]}',
+      search: async () => [],
+      fetchSource: async () => ({ title: null, textExcerpt: null }),
+    });
+    const out = await d.synthesize!("t", [{ index: 1, title: "s", url: "u", excerpt: "e" }]);
+    expect(out).toEqual([{ claim: "a real finding", citations: [1] }]);
+  });
+
+  it("verifyFinding returns false when the finding has no in-range citation", async () => {
+    const d = makeInferenceResearchDeps({ llm: async () => '{"grounded": true}', search: async () => [], fetchSource: async () => ({ title: null, textExcerpt: null }) });
+    expect(await d.verifyFinding!({ claim: "c", citations: [] }, [{ index: 1, title: "s", url: "u", excerpt: "e" }])).toBe(false);
+  });
+
+  it("verifyFinding honors the llm grounded verdict", async () => {
+    const src = [{ index: 1, title: "s", url: "u", excerpt: "e" }];
+    const yes = makeInferenceResearchDeps({ llm: async () => '{"grounded": true}', search: async () => [], fetchSource: async () => ({ title: null, textExcerpt: null }) });
+    const no = makeInferenceResearchDeps({ llm: async () => '{"grounded": false}', search: async () => [], fetchSource: async () => ({ title: null, textExcerpt: null }) });
+    expect(await yes.verifyFinding!({ claim: "c", citations: [1] }, src)).toBe(true);
+    expect(await no.verifyFinding!({ claim: "c", citations: [1] }, src)).toBe(false);
+  });
+});

--- a/apps/web/lib/build/pre-spec-research.ts
+++ b/apps/web/lib/build/pre-spec-research.ts
@@ -1,0 +1,236 @@
+// Research-before-spec — a governed deep-research step for Build Studio ideate.
+//
+// BI-F8C5E01C (EP-F7E35344). Ideate today researches the CODEBASE (internal)
+// but never the world: standards, prior art, common pitfalls, market context.
+// The 2026 evidence (Anthropic multi-agent research; brownfield studies) says a
+// short, cited pre-spec research pass is the cheapest lever on spec quality —
+// but only when it is (a) right-size TRIGGERED (not run on every one-line fix),
+// (b) source-CITED, and (c) adversarially VERIFIED so an unsupported claim is
+// flagged rather than laundered into the design.
+//
+// This composes the existing web substrate (searchPublicWeb / fetchPublicWeb-
+// siteEvidence) and routed inference into: plan queries -> fan-out search ->
+// fetch top sources -> synthesize a cited draft -> verify each finding against
+// its cited source -> return a report. Every external call is dependency-
+// injected so the pipeline is unit-testable with zero network/inference, and
+// the caller gates it behind a flag + fail-OPEN (research never blocks ideate).
+
+/** A closed, small trigger input — the fields ideate already has in scope. */
+export type ResearchTriggerInput = {
+  /** BacklogItem work type; only "feature" work warrants external research. */
+  workType?: string | null;
+  /** Effort size from the BI. */
+  effortSize?: string | null;
+  /** Deliverable sensitivity, when computed (auth/billing/PII/security ⇒ high). */
+  sensitivity?: "low" | "elevated" | "high" | null;
+};
+
+const RESEARCH_SIZES: ReadonlySet<string> = new Set(["medium", "large", "xlarge"]);
+
+/**
+ * PURE right-size trigger. Run pre-spec research only when the spec quality is
+ * worth the search spend: a *feature* that is medium+ in size OR carries
+ * elevated/high deliverable sensitivity. A small feature, or any fix/chore/doc,
+ * is skipped — its design is either trivial or codebase-local. Deterministic and
+ * side-effect-free.
+ */
+export function shouldRunPreSpecResearch(input: ResearchTriggerInput): boolean {
+  if ((input.workType ?? "feature") !== "feature") return false;
+  if (input.sensitivity === "elevated" || input.sensitivity === "high") return true;
+  return RESEARCH_SIZES.has(input.effortSize ?? "");
+}
+
+export type ResearchSource = {
+  index: number;
+  title: string;
+  url: string;
+  excerpt: string;
+};
+
+export type ResearchFinding = {
+  /** The claim, in one sentence. */
+  claim: string;
+  /** 1-based indexes into the sources array supporting the claim. */
+  citations: number[];
+  /** Set by the verification pass: could the claim be grounded in a cited source? */
+  verified: boolean;
+};
+
+export type ResearchReport = {
+  topic: string;
+  queries: string[];
+  sources: ResearchSource[];
+  findings: ResearchFinding[];
+  /** Findings the verifier could not ground — surfaced, never silently dropped. */
+  caveats: string[];
+  summary: string;
+};
+
+export type PreSpecResearchDeps = {
+  /** Fan out N focused research queries for a topic (injected inference). */
+  planQueries: (topic: string) => Promise<string[]>;
+  /** Web search (injected searchPublicWeb). */
+  search: (query: string) => Promise<Array<{ title: string; url: string; description?: string }>>;
+  /** Fetch a source's text (injected fetchPublicWebsiteEvidence). */
+  fetchSource: (url: string) => Promise<{ title: string | null; textExcerpt: string | null }>;
+  /** Synthesize cited findings from the sources (injected inference). Must
+   *  return findings whose citations index into the provided sources. */
+  synthesize: (topic: string, sources: ResearchSource[]) => Promise<Array<{ claim: string; citations: number[] }>>;
+  /** Adversarially verify one finding against its cited source text (injected
+   *  inference). Returns true only if the claim is grounded in the citation. */
+  verifyFinding?: (finding: { claim: string; citations: number[] }, sources: ResearchSource[]) => Promise<boolean>;
+  /** Caps. */
+  maxQueries?: number;
+  maxSourcesPerQuery?: number;
+  maxSources?: number;
+};
+
+const DEFAULTS = { maxQueries: 4, maxSourcesPerQuery: 3, maxSources: 8 } as const;
+
+/**
+ * Conduct the pre-spec research pass. Fan-out searches, fetch the top distinct
+ * sources, synthesize cited findings, then verify each finding against its
+ * cited source; unverifiable findings are moved to `caveats` (never presented as
+ * fact). Returns a structured, cited report. The caller renders + attaches it.
+ *
+ * Robust by construction: a failing search/fetch for one query is skipped, not
+ * fatal; with no reachable sources it returns an honest empty report.
+ */
+export async function conductPreSpecResearch(
+  topic: string,
+  deps: PreSpecResearchDeps,
+): Promise<ResearchReport> {
+  const caps = { ...DEFAULTS, ...deps };
+  const queries = (await safe(() => deps.planQueries(topic), [])).slice(0, caps.maxQueries);
+
+  // Fan-out search, dedup by URL, cap total sources.
+  const seenUrls = new Set<string>();
+  const sources: ResearchSource[] = [];
+  for (const query of queries) {
+    if (sources.length >= caps.maxSources) break;
+    const hits = (await safe(() => deps.search(query), [])).slice(0, caps.maxSourcesPerQuery);
+    for (const hit of hits) {
+      if (sources.length >= caps.maxSources) break;
+      if (!hit.url || seenUrls.has(hit.url)) continue;
+      seenUrls.add(hit.url);
+      const fetched = await safe(() => deps.fetchSource(hit.url), { title: hit.title, textExcerpt: hit.description ?? "" });
+      sources.push({
+        index: sources.length + 1,
+        title: fetched.title || hit.title || hit.url,
+        url: hit.url,
+        excerpt: (fetched.textExcerpt || hit.description || "").slice(0, 1200),
+      });
+    }
+  }
+
+  if (sources.length === 0) {
+    return { topic, queries, sources: [], findings: [], caveats: ["No reachable external sources — proceed on codebase evidence alone."], summary: "Pre-spec research found no reachable sources." };
+  }
+
+  const rawFindings = (await safe(() => deps.synthesize(topic, sources), [])).filter(
+    (f) => f.claim && f.citations.every((c) => c >= 1 && c <= sources.length),
+  );
+
+  const findings: ResearchFinding[] = [];
+  const caveats: string[] = [];
+  await Promise.all(
+    rawFindings.map(async (f) => {
+      const verified = deps.verifyFinding ? await safe(() => deps.verifyFinding!(f, sources), false) : f.citations.length > 0;
+      const finding: ResearchFinding = { claim: f.claim, citations: f.citations, verified };
+      if (verified) findings.push(finding);
+      else caveats.push(`Unverified: ${f.claim}`);
+    }),
+  );
+
+  const summary = findings.length > 0
+    ? `${findings.length} cited finding(s) across ${sources.length} source(s)${caveats.length ? `; ${caveats.length} claim(s) could not be grounded and were held back` : ""}.`
+    : `No findings could be grounded in a cited source across ${sources.length} source(s).`;
+
+  return { topic, queries, sources, findings, caveats, summary };
+}
+
+/** Render a report as a compact cited markdown block for the ideate evidence trail. */
+export function formatResearchReportMarkdown(report: ResearchReport): string {
+  const lines: string[] = [`### Pre-spec research — ${report.topic}`, "", report.summary, ""];
+  if (report.findings.length > 0) {
+    lines.push("**Findings (cited, verified):**");
+    for (const f of report.findings) lines.push(`- ${f.claim} ${f.citations.map((c) => `[${c}]`).join("")}`);
+    lines.push("");
+  }
+  if (report.caveats.length > 0) {
+    lines.push("**Caveats (held back — not grounded):**");
+    for (const c of report.caveats) lines.push(`- ${c}`);
+    lines.push("");
+  }
+  if (report.sources.length > 0) {
+    lines.push("**Sources:**");
+    for (const s of report.sources) lines.push(`${s.index}. [${s.title}](${s.url})`);
+  }
+  return lines.join("\n");
+}
+
+/** Run a thunk, returning a fallback on any throw (per-step robustness). */
+async function safe<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await fn();
+  } catch {
+    return fallback;
+  }
+}
+
+// ─── Inference-backed deps factory ───────────────────────────────────────────
+// Builds the PreSpecResearchDeps from three injected primitives (an LLM
+// dispatch, a web search, a source fetch), owning the prompt construction and
+// JSON parsing so ideate-on-approval stays a thin caller and the parsing is
+// unit-testable with a fake llm.
+
+const firstJson = (raw: string): unknown => {
+  const m = raw.match(/\{[\s\S]*\}|\[[\s\S]*\]/);
+  if (!m) return null;
+  try { return JSON.parse(m[0]); } catch { return null; }
+};
+
+export function makeInferenceResearchDeps(primitives: {
+  llm: (prompt: string) => Promise<string>;
+  search: PreSpecResearchDeps["search"];
+  fetchSource: PreSpecResearchDeps["fetchSource"];
+  caps?: { maxQueries?: number; maxSourcesPerQuery?: number; maxSources?: number };
+}): PreSpecResearchDeps {
+  const { llm, search, fetchSource } = primitives;
+  return {
+    ...primitives.caps,
+    search,
+    fetchSource,
+    planQueries: async (topic) => {
+      const raw = await llm(
+        `Plan focused web-search queries to research a software feature before its spec is written. Cover standards/best-practice, prior art, and common pitfalls. Feature: "${topic}". Respond with ONLY a JSON array of 3-5 short query strings.`,
+      );
+      const parsed = firstJson(raw);
+      return Array.isArray(parsed) ? parsed.map((q) => String(q)).filter(Boolean) : [];
+    },
+    synthesize: async (topic, sources) => {
+      const src = sources.map((s) => `[${s.index}] ${s.title}\n${s.excerpt}`).join("\n\n");
+      const raw = await llm(
+        `From the sources below, extract the factual findings relevant to building "${topic}". Cite every finding by source number. Do NOT state anything not supported by a source.\n\nSOURCES:\n${src}\n\nRespond with ONLY JSON: {"findings":[{"claim":"<one sentence>","citations":[<source numbers>]}]}`,
+      );
+      const parsed = firstJson(raw) as { findings?: Array<{ claim?: unknown; citations?: unknown }> } | null;
+      if (!parsed?.findings || !Array.isArray(parsed.findings)) return [];
+      return parsed.findings
+        .map((f) => ({
+          claim: String(f.claim ?? "").trim(),
+          citations: Array.isArray(f.citations) ? f.citations.map((c) => Number(c)).filter((c) => Number.isInteger(c)) : [],
+        }))
+        .filter((f) => f.claim.length > 0);
+    },
+    verifyFinding: async (finding, sources) => {
+      const cited = sources.filter((s) => finding.citations.includes(s.index));
+      if (cited.length === 0) return false;
+      const src = cited.map((s) => `[${s.index}] ${s.title}\n${s.excerpt}`).join("\n\n");
+      const raw = await llm(
+        `Is this claim DIRECTLY supported by the cited source text below? Claim: "${finding.claim}"\n\nCITED SOURCE(S):\n${src}\n\nAnswer with ONLY JSON: {"grounded": true|false}. Default to false if the source does not clearly support the claim.`,
+      );
+      const parsed = firstJson(raw) as { grounded?: unknown } | null;
+      return parsed?.grounded === true;
+    },
+  };
+}

--- a/apps/web/lib/integrate/build-studio-config.ts
+++ b/apps/web/lib/integrate/build-studio-config.ts
@@ -156,6 +156,18 @@ export function isQualityFirstRightsizingEnabled(): boolean {
   return v === "1" || v === "true";
 }
 
+/**
+ * BI-F8C5E01C (EP-F7E35344): research-before-spec — a right-size-triggered
+ * external deep-research pass (standards / prior art / pitfalls) attached to the
+ * ideate evidence trail before the design is written. Opt-in (default off) so it
+ * merges inert and incurs no web-search spend until an operator enables it and a
+ * web-search provider (Brave) is configured. Set DPF_BUILD_PRE_SPEC_RESEARCH=1.
+ */
+export function isPreSpecResearchEnabled(): boolean {
+  const v = process.env.DPF_BUILD_PRE_SPEC_RESEARCH;
+  return v === "1" || v === "true";
+}
+
 /** PlatformConfig key for the global build Cost/Quality/Time posture (P2). */
 export const BUILD_GOLDEN_TRIANGLE_POSTURE_KEY = "BUILD_GOLDEN_TRIANGLE_POSTURE";
 

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -288,9 +288,18 @@ export async function dispatchIdeateForApprovedBuild(params: {
     // run an external cited deep-research pass and attach it to the ideate
     // evidence trail. Opt-in (DPF_BUILD_PRE_SPEC_RESEARCH) and strictly
     // fail-open — research is advisory and must NEVER fail or delay ideate.
+    // The flag is resolved OUTSIDE the try so a disabled/unavailable config does
+    // NO work and writes NO activity row (keeps the ideate evidence trail exact
+    // when the feature is off — the default).
+    let preSpecResearchEnabled = false;
     try {
       const { isPreSpecResearchEnabled } = await import("./build-studio-config");
-      if (isPreSpecResearchEnabled()) {
+      preSpecResearchEnabled = isPreSpecResearchEnabled();
+    } catch {
+      preSpecResearchEnabled = false;
+    }
+    if (preSpecResearchEnabled) {
+      try {
         const { shouldRunPreSpecResearch, conductPreSpecResearch, formatResearchReportMarkdown, makeInferenceResearchDeps } =
           await import("@/lib/build/pre-spec-research");
         const { deriveDeliverableSensitivity } = await import("@/lib/explore/build-process-matrix");
@@ -306,11 +315,11 @@ export async function dispatchIdeateForApprovedBuild(params: {
           const report = await conductPreSpecResearch(`${featureTitle}: ${featureDescription}`.slice(0, 400), deps);
           await logActivity(`Pre-spec research (advisory, cited):\n${formatResearchReportMarkdown(report)}`);
         }
+      } catch (researchErr) {
+        // Advisory — swallow and continue; ideate must not depend on research.
+        const { getErrorMessage } = await import("@/lib/shared/get-error-message");
+        await logActivity(`Pre-spec research skipped (non-fatal): ${getErrorMessage(researchErr)}`);
       }
-    } catch (researchErr) {
-      // Advisory — swallow and continue; ideate must not depend on research.
-      const { getErrorMessage } = await import("@/lib/shared/get-error-message");
-      await logActivity(`Pre-spec research skipped (non-fatal): ${getErrorMessage(researchErr)}`);
     }
 
     const designDocKeys = Object.keys(ideateResult.designDoc as Record<string, unknown>);

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -133,7 +133,7 @@ export async function dispatchIdeateForApprovedBuild(params: {
     // that PR #1030 fixed in this same file.
     const bi = await prisma.backlogItem.findUnique({
       where: { id: build.originatingBacklogItemId },
-      select: { title: true, body: true, effortSize: true },
+      select: { title: true, body: true, effortSize: true, workType: true },
     });
 
     if (!bi) {
@@ -282,6 +282,34 @@ export async function dispatchIdeateForApprovedBuild(params: {
       };
       await logActivity(`Auto-dispatch saved-evidence VERIFICATION FAILED after ${(durationMs / 1000).toFixed(1)}s: designDoc not present on ${buildId} after save.`);
       return outcome;
+    }
+
+    // BI-F8C5E01C — research-before-spec: for a right-size-triggered feature,
+    // run an external cited deep-research pass and attach it to the ideate
+    // evidence trail. Opt-in (DPF_BUILD_PRE_SPEC_RESEARCH) and strictly
+    // fail-open — research is advisory and must NEVER fail or delay ideate.
+    try {
+      const { isPreSpecResearchEnabled } = await import("./build-studio-config");
+      if (isPreSpecResearchEnabled()) {
+        const { shouldRunPreSpecResearch, conductPreSpecResearch, formatResearchReportMarkdown, makeInferenceResearchDeps } =
+          await import("@/lib/build/pre-spec-research");
+        const { deriveDeliverableSensitivity } = await import("@/lib/explore/build-process-matrix");
+        const sensitivity = deriveDeliverableSensitivity({ text: `${featureTitle}\n${featureDescription}`, workType: bi.workType });
+        if (shouldRunPreSpecResearch({ workType: bi.workType, effortSize: bi.effortSize, sensitivity })) {
+          const { searchPublicWeb, fetchPublicWebsiteEvidence } = await import("@/lib/public-web-tools");
+          const { routeAndCall } = await import("@/lib/routed-inference");
+          const deps = makeInferenceResearchDeps({
+            llm: async (p) => (await routeAndCall([{ role: "user" as const, content: p }], "You are a research assistant. Follow the output format exactly.", "internal", { budgetClass: "minimize_cost" })).content,
+            search: async (q) => (await searchPublicWeb(q)).map((r) => ({ title: r.title, url: r.url, description: r.snippet })),
+            fetchSource: async (u) => { const e = await fetchPublicWebsiteEvidence(u); return { title: e.title, textExcerpt: e.textExcerpt }; },
+          });
+          const report = await conductPreSpecResearch(`${featureTitle}: ${featureDescription}`.slice(0, 400), deps);
+          await logActivity(`Pre-spec research (advisory, cited):\n${formatResearchReportMarkdown(report)}`);
+        }
+      }
+    } catch (researchErr) {
+      // Advisory — swallow and continue; ideate must not depend on research.
+      await logActivity(`Pre-spec research skipped (non-fatal): ${researchErr instanceof Error ? researchErr.message : String(researchErr)}`);
     }
 
     const designDocKeys = Object.keys(ideateResult.designDoc as Record<string, unknown>);

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -309,7 +309,8 @@ export async function dispatchIdeateForApprovedBuild(params: {
       }
     } catch (researchErr) {
       // Advisory — swallow and continue; ideate must not depend on research.
-      await logActivity(`Pre-spec research skipped (non-fatal): ${researchErr instanceof Error ? researchErr.message : String(researchErr)}`);
+      const { getErrorMessage } = await import("@/lib/shared/get-error-message");
+      await logActivity(`Pre-spec research skipped (non-fatal): ${getErrorMessage(researchErr)}`);
     }
 
     const designDocKeys = Object.keys(ideateResult.designDoc as Record<string, unknown>);

--- a/docs/superpowers/specs/2026-07-12-research-before-spec-design.md
+++ b/docs/superpowers/specs/2026-07-12-research-before-spec-design.md
@@ -1,0 +1,31 @@
+# Research-before-spec — a governed deep-research step for ideate
+
+- **Status:** implemented (opt-in, default off)
+- **Date:** 2026-07-12
+- **BI:** BI-F8C5E01C · **Epic:** EP-F7E35344 (AI Coworker Capability Inputs — Perplexity-lessons gap closure)
+- **Strategy:** [`2026-07-12-dpf-development-model-and-frontier-harness-positioning-design.md`](2026-07-12-dpf-development-model-and-frontier-harness-positioning-design.md) §5
+
+## Problem
+
+Build Studio's ideate phase researches the **codebase** (internal) and never the **world**: standards, prior art, common pitfalls, market context. The 2026 evidence (Anthropic's multi-agent research system; brownfield studies) is that a short, *cited*, *verified* pre-spec research pass is one of the cheapest levers on spec quality — but only when it is **right-size triggered** (not run on every one-line fix), **source-cited**, and **adversarially verified** so an unsupported claim is flagged rather than laundered into the design. The web substrate already exists (`searchPublicWeb`, `fetchPublicWebsiteEvidence` — Brave-backed) and `routed-inference`; nothing composed them into a research-before-spec step.
+
+## Design
+
+`apps/web/lib/build/pre-spec-research.ts`:
+
+- **`shouldRunPreSpecResearch(input)` — pure trigger.** Runs only for a *feature* that is medium+ size **or** carries elevated/high deliverable sensitivity; skips small features and all fix/chore/doc work.
+- **`conductPreSpecResearch(topic, deps)`** — plan 3-5 queries → fan-out `search` (deduped by URL, capped) → `fetchSource` the top distinct sources → `synthesize` cited findings → `verifyFinding` each against its cited source. Unverifiable findings move to `caveats` (surfaced, never presented as fact). Per-step robust: a failing search/fetch is skipped, not fatal; no reachable sources → an honest empty report. Every external call is dependency-injected.
+- **`makeInferenceResearchDeps({ llm, search, fetchSource })`** owns the prompt construction + JSON parsing for plan/synthesize/verify, so the caller stays thin and the parsing is unit-testable with a fake `llm`.
+- **`formatResearchReportMarkdown`** renders a compact cited block for the evidence trail.
+
+## Wiring & flag
+
+Gated by `DPF_BUILD_PRE_SPEC_RESEARCH` (`isPreSpecResearchEnabled`, default **off** — inert, zero web-search spend until enabled and a Brave key is configured). Wired in `ideate-on-approval.ts` **after** the designDoc is persist-verified, and **strictly fail-open**: research is advisory and never fails or delays ideate (any throw is swallowed to a non-fatal `BuildActivity` note). When the trigger fires, the cited report is attached to the build's ideate evidence via `logBuildActivity`. Deliverable sensitivity is derived from the BI text with the existing `deriveDeliverableSensitivity`.
+
+## Verification
+
+`pre-spec-research.test.ts` (18 tests): the pure trigger matrix; the pipeline (cited/verified findings, URL dedup, unverifiable→caveats, out-of-range citations dropped, empty-sources honesty, search-throws robustness, source cap); markdown rendering; and the inference-deps JSON parsing (plan array, unparseable→[], empty-claim filter, citation-range guard, grounded verdict).
+
+## Non-goals
+
+Not a research *product* surface (no UI); the report is evidence, not a gate. Does not change ideate when the flag is off. Capturing research into the WWMD/WWWD wiki corpus stays with `research-capture.ts` (a different concern). The natural follow-ups are attaching the report as a first-class `designDoc.preSpecResearch` field (migration) and a design-review lens that checks the spec against the cited findings.


### PR DESCRIPTION
## Summary

Closes BI-F8C5E01C (EP-F7E35344, Perplexity-lessons gap closure). Ideate researches the *codebase* but never the *world*. This adds a **right-size-triggered**, **source-cited**, **adversarially-verified** external deep-research pass, composing the existing web substrate (`searchPublicWeb` / `fetchPublicWebsiteEvidence`) and routed inference — the pipeline shape Anthropic's multi-agent research system uses (fan-out → fetch → synthesize → verify), scaled to a cheap single-pass ideate step.

## Changes
- `apps/web/lib/build/pre-spec-research.ts`:
  - `shouldRunPreSpecResearch` (pure trigger — *feature* & medium+ **or** elevated/high sensitivity; skips small features and all fix/chore/doc).
  - `conductPreSpecResearch` (dependency-injected: plan queries → fan-out search, URL-deduped + capped → fetch → synthesize cited findings → verify each against its cited source; **unverifiable findings move to `caveats`, never presented as fact**; per-step robust; honest empty report when no sources).
  - `makeInferenceResearchDeps` (owns prompt construction + JSON parsing so the caller is thin and parsing is testable) + `formatResearchReportMarkdown`.
- Flag `DPF_BUILD_PRE_SPEC_RESEARCH` (`isPreSpecResearchEnabled`), **default off** — inert, zero web-search spend until enabled.
- Wired in `ideate-on-approval.ts` after the designDoc persist-verify, **strictly fail-open** (research never fails/delays ideate); report attached to the ideate evidence via `logBuildActivity`.

## Verification
- **18 unit tests** (`pre-spec-research.test.ts`) — trigger matrix, pipeline (cited/verified, dedup, unverifiable→caveats, out-of-range citations dropped, empty-sources honesty, search-throws robustness, cap), markdown, and inference-deps JSON parsing. **All pass** (root vitest).
- Local typecheck skipped (fresh source-only worktree, no `node_modules` — harness limitation); **CI Typecheck gates the merge**. Signatures verified by hand (`deriveDeliverableSensitivity({text,workType})`, `NormalizedSearchResult.snippet`, `routeAndCall(...).content`, `bi.workType` added to select).
- Spec: `docs/superpowers/specs/2026-07-12-research-before-spec-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)