### PR TITLE
docs(decision-gov): reconcile stance-onboarding to shipped + bind stance substrate into the operational-twin spec

### DIFF
--- a/docs/superpowers/plans/2026-07-11-wwwd-stance-onboarding-build.md
+++ b/docs/superpowers/plans/2026-07-11-wwwd-stance-onboarding-build.md
@@ -32,18 +32,33 @@
 - `/wiki/review`: "Waiting on your call" section listing unresolved org-business decisions with the
   inline answer + make-standing control; stance form gains the decision-area picker + Publish.
 
-## Phase 3 — "How you decide" setup step (BI-D6DC2432) ✅ this PR
+## Phase 3 — "How you decide" setup step (BI-D6DC2432) ✅ shipped (PR #2837)
 
 - `SETUP_STEPS` entry `how-you-decide` after `business-context`; 5 archetype-prefilled scenario
   cards (resolveStanceVectors), Confirm-all fast path; confirm upgrades the vector's bundle via
   `promoteStanceMaterial(confirmed)`; skip leaves B/0.6. Same card components mounted in
-  `/wiki/stance`. UX-Fit-Decision trailer on the PR.
+  `/wiki/stance`. UX-Fit-Decision trailer on the PR (DI-0FA7D451EA32).
 
-## Phase 4 — Local delivery & live verification
+## Phase 4 — Local delivery & live verification ✅ done (2026-07-12)
 
-- Merge PRs → redeploy the local live portal from clean main.
-- Re-run `seedOrgWwwdCorpus` for the existing org (idempotent; new vector pages + retags land).
-- Author BI-EBBBD275's two founder-ruled stances through the capture path (A/1.0, embedded).
-- Re-run `evaluate_org_business_decision` live on the billing-goodwill and quality-vs-offering
-  questions; expected: resolve (recommend/arbitrate per posture) instead of defer/escalate; verify
-  a high-risk probe still escalates.
+- ✅ Merged all three build PRs; redeployed the local live portal from clean main (worktree-build +
+  root-clone-recreate; portal healthy at the merge SHA).
+- ✅ Shape-aware boot backfill re-primed the existing org idempotently — the WWWD corpus now carries
+  archetype-default material in all four decision classes (was: 4 materials, plan-readiness only).
+- ✅ Live `evaluate_org_business_decision` probes reproduce the **pre-confirmation rung** exactly:
+  billing-goodwill `escalate @ 0.35` and quality-vs-offering `escalate @ 0.45`, both now **from the
+  org's own profile**; high-risk probe still escalates (invariant holds).
+- ⏳ **Owner action, not engineering** (BI-EBBBD275 stays open): the two founder-ruled stances land at
+  A/1.0 the moment the owner answers them via the live `/wiki/review` capture loop, or confirms the
+  corresponding cards at `/wiki/stance` (A/0.9). The AI does not self-confirm — that is the design, and
+  it is why the final "resolve instead of escalate" step waits on one owner click rather than a build.
+
+---
+
+## Adjacency: Operational Twin Framework (2026-07-12)
+
+The `resolveStanceVectors` archetype derivation added in Phase 1 is a sibling of the
+`deriveTwinProfile` family in [the Operational Twin spec](../specs/2026-07-12-operational-twin-framework-design.md).
+The two meet at the twin's **cog**: an allocation confirm that carries a business judgment is an
+`evaluate_org_business_decision` call, and an escalation is a needs-you quest answerable via the capture
+loop shipped here. The twin spec's §5.1 (added alongside this reconciliation) records the binding.

--- a/docs/superpowers/specs/2026-07-11-wwwd-stance-onboarding-design.md
+++ b/docs/superpowers/specs/2026-07-11-wwwd-stance-onboarding-design.md
@@ -2,10 +2,11 @@
 
 - **Epic:** EP-0AF96937 — Decision Governance Surface (extends it: the *first-run* leg of the see → adjust → review loop)
 - **Related BI:** BI-EBBBD275 (author the two escalated stances — the tactical instance of the gap this design closes systemically)
-- **Date:** 2026-07-11
-- **Status:** Design (design-first; STOP for founder go/no-go before build — this changes first-run behavior for every install)
-- **Kernel routing:** both open forks routed through `principle_decide` (`callingPopulation=external_coding_agent`, surface `stance-onboarding-design`), both **high confidence, no commandment conflict** — ledgers in §6.
+- **Date:** 2026-07-11 (design) · **updated 2026-07-12** (all phases shipped)
+- **Status:** ✅ **Shipped** — founder go received 2026-07-11 ("deliver on this here locally"); all four build phases merged and live-verified on the local install. Build plan + phase→PR map: [2026-07-11-wwwd-stance-onboarding-build.md](../plans/2026-07-11-wwwd-stance-onboarding-build.md). See §12 for the shipped-state summary.
+- **Kernel routing:** both design forks routed through `principle_decide` (`callingPopulation=external_coding_agent`, surface `stance-onboarding-design`), both **high confidence, no commandment conflict** — ledgers in §6.
 - **UX-Fit:** new setup step + scenario-card capture → binds the UX-Fit gate (AGENTS.md §12/§16/§17). Reviewed in §7.4.
+- **Adjacent:** the archetype **stance-vector derivation** this spec adds (`resolveStanceVectors`) is a member of the same archetype-derivation family the [Operational Twin Framework](2026-07-12-operational-twin-framework-design.md) builds on; that spec's cog-confirm HITL + needs-you quests are governed by the WWWD gate this spec primes. Cross-reference in §13.
 
 ---
 
@@ -219,27 +220,66 @@ corrects here:
 
 ## 10. Phasing & backlog
 
-Each phase independently shippable; the operator can stop after any.
+Each phase independently shippable; the operator can stop after any. **All shipped** (2026-07-11/12);
+the design phases below map onto three build PRs (grouped in the [build plan](../plans/2026-07-11-wwwd-stance-onboarding-build.md)).
 
-- **Phase 0 (this PR)** — spec + simulation backtest + BIs. No production code.
-- **Phase 1 — Archetype stance-vector defaults + seeder redistribution** (**BI-70ADC71F**): extend
-  `ArchetypeBusinessProfile` with `stanceVectors`; extend `seedOrgWwwdCorpus` to seed vector pages +
-  per-class bundles (B/0.6) and retag the existing four pages into their bundles. Includes authoring
-  BI-EBBBD275's two founder-ruled stances as the live install's first A/1.0 human-ruled materials.
-- **Phase 2 — "How you decide" setup step** (**BI-D6DC2432**): the §7 card UI + confirm/adjust/skip write
-  paths + bundle upgrade semantics; same cards mounted in `/wiki/stance` for later adjustment.
-- **Phase 3 — JIT capture write-back** (**BI-9677364B**): non-build capture path for WWWD escalations —
-  founder answers from the review queue, optional "make this our standing answer" writes the stance
-  page + A/1.0 material in the decision's class and sets `humanOutcome`. Closes the loop found open
-  in §1.
-- **Phase 4 — Stance publish → promotion** (**BI-002DEB85**): publishing a `/wiki/stance` draft flips its
-  linked `PerspectiveMaterial` to approved/promoted (A/0.9) — today an authored stance is never
-  gate-live.
+- **Phase 0** ✅ — spec + simulation backtest + BIs (PR #2784). No production code.
+- **Phase 1 — Archetype stance-vector defaults + seeder redistribution** (**BI-70ADC71F**) ✅ **PR #2800**:
+  extended `ArchetypeBusinessProfile` with `stanceVectors` (`resolveStanceVectors`); `seedOrgWwwdCorpus`
+  seeds a `stances/<key>` page + per-class `PerspectiveMaterial` bundles (B/0.6) across all four domain
+  classes and retags the original four pages into their bundles; a **shape-aware boot backfill** carries
+  the redistribution to already-onboarded installs.
+- **Phase 2 — "How you decide" setup step** (**BI-D6DC2432**) ✅ **PR #2837**: the §7 card UI
+  (`HowYouDecideCards`) + confirm/adjust/skip write paths + bundle-upgrade semantics (`confirmStanceVectors`);
+  same cards mounted in `/wiki/stance` for later adjustment.
+- **Phase 3 — JIT capture write-back** (**BI-9677364B**) ✅ **PR #2812**: `captureOrgDecisionOutcome`
+  non-build capture path for WWWD escalations — owner answers from the `/wiki/review` "Waiting on your
+  call" cards, optional "remember this" writes a ruled (A/1.0) `stances/ruling-<id>` page and sets
+  `humanOutcome`. Closes the loop found open in §1.
+- **Phase 4 — Stance publish → promotion** (**BI-002DEB85**) ✅ **PR #2812**: `publishBusinessStance`
+  publishes + embeds a `/wiki/stance` draft and promotes an owner-confirmed (A/0.9) `PerspectiveMaterial`
+  in the picked decision area — an authored stance is now gate-live instead of an inert draft.
 
-## 11. Open questions for the founder (go/no-go)
+The confirm/promote/rule write path is unified in `lib/decision-perspective/stance-promotion.ts`
+(`promoteStanceMaterial`, tiers `confirmed` A/0.9 / `ruled` A/1.0, never-downgrade).
 
-1. **Ceiling defaults per archetype** — the §4 amounts are starters; confirm or hand back a table.
-2. **Medium-risk posture story** — accept that balanced-posture orgs keep escalating medium-risk
-   decisions until a class is fully human-ruled (the honest ladder), or opt orgs into progressive
-   posture more aggressively during onboarding?
-3. **Step title** — "How you decide" vs "Your business judgment" vs other (naming is operator-owned).
+## 11. Founder go/no-go — resolved
+
+The three go/no-go questions were answered by the founder go ("deliver on this here locally", 2026-07-11)
+and are settled in the shipped code:
+
+1. **Ceiling defaults per archetype** — shipped as editable per-industry starters in
+   `INDUSTRY_STANCE_VECTORS` (goodwill/pricing/spend); the owner confirms or adjusts each via a curated
+   ceiling picker. Not free-authored.
+2. **Medium-risk posture story** — shipped as the honest ladder: balanced-posture orgs keep escalating
+   medium-risk decisions until a class is fully human-ruled (A/1.0 → recommend @ 0.9); progressive posture
+   arbitrates medium-risk from A/0.9. No aggressive auto-opt-in to progressive.
+3. **Step title** — shipped as **"How you decide"** (`STEP_LABELS["how-you-decide"]`).
+
+## 12. Shipped state (2026-07-12)
+
+- **Merged:** #2784 (design), #2800 (Phase 1), #2812 (Phases 3+4), #2837 (Phase 2). BIs BI-70ADC71F /
+  BI-D6DC2432 / BI-9677364B / BI-002DEB85 → **done**.
+- **Live-verified** on the local install (`:3000`, redeployed at the merge SHA): the org's WWWD corpus
+  now carries archetype-default material in all four decision classes; the two originally-escalated
+  decisions reproduce the pre-confirmation rung exactly — billing-goodwill `escalate @ 0.35` and
+  quality-vs-offering `escalate @ 0.45`, both now **from the org's own profile** (not platform fallback) —
+  and the high-risk probe still escalates (invariant holds).
+- **The last rung is the owner's, by design:** a Confirm-all at `/wiki/stance` (or a ruling via the
+  `/wiki/review` capture loop) upgrades the bundle to A/0.9+ and clears the low-risk classes. The AI never
+  self-confirms — consent is the mechanism, not a gap. **BI-EBBBD275** (the two specific founder rulings)
+  stays open for exactly this reason: the tooling to satisfy it is live, but authoring the two standing
+  answers is a one-click owner action, not an engineering task.
+
+## 13. Adjacency — the Operational Twin Framework
+
+The [Operational Twin Framework](2026-07-12-operational-twin-framework-design.md) derives a per-archetype
+"twin" from the archetype's operating-model surfaces. Its `deriveTwinProfile` family and the
+`resolveStanceVectors` derivation this spec added are **two consumers of the same archetype substrate**,
+and they meet at the twin's **cog**: when the cog proposes an allocation that carries a business judgment
+(comp/waive, spend, priority), that tap-to-confirm is exactly an `evaluate_org_business_decision` call,
+and an escalation is exactly a **needs-you quest** — answerable in place through the capture loop this spec
+shipped (the `/wiki/review` "Waiting on your call" pattern). See that spec's §5.1 (added by this PR) for
+how the stance-vector derivation sits in its derivation family and how the cog/quest primitives bind to the
+WWWD gate. Incorporation shape kernel-routed: `principle_decide` → additive cross-reference, high
+confidence, margin 3.59 (DI-4E2943E733A7).

--- a/docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md
+++ b/docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md
@@ -95,6 +95,42 @@ Derivation rules (in priority order), all from substrate that already exists:
 
 Nouns resolve through the existing vocabulary system (`resolveVocabularyKey`, `customVocabulary`), so a credit union's board says Members and a clinic's rooms respect the PHI privacy class already modeled on `FieldDispatchProfile.privacyClass`.
 
+### 5.1 The cog is governed by the org's WWWD stance — and the stance is a sibling archetype derivation
+
+*(Added 2026-07-12 to reconcile with the shipped company-stance onboarding — [2026-07-11-wwwd-stance-onboarding-design.md](2026-07-11-wwwd-stance-onboarding-design.md), EP-0AF96937. Additive: it does not change this spec's grammar, templates, or derivation rules.)*
+
+Two connections make the twin's cog and quests concrete rather than hand-waved:
+
+**(a) The stance-vector derivation is a fourth-family member — at a different layer.** The
+`deriveTwinProfile`/`deriveOperationalValueStream`/`deriveMediaProfile`/`deriveFieldDispatchProfile`
+family lives in `packages/storefront-templates` and derives from `ArchetypeDefinition`. The WWWD
+**stance-vector** derivation (`resolveStanceVectors`, `apps/web/lib/onboarding/archetype-business-context.ts`,
+shipped in PR #2800) is the same *shape* — a pure derivation from the archetype (keyed off `archetypeId`
++ storefront `category`) with per-industry overrides and a confirm-not-author UX — but it runs one layer
+up, at onboarding, and its output is org-overlay WikiPages + `PerspectiveMaterial` (the WWWD corpus), not
+a render profile. It answers a question the twin doesn't: **for this kind of business, how much of the
+cog's judgment may run without asking, and where is the ceiling.** Treat it as a peer of `schedulingDefaults`
+in the "what an archetype carries" catalog — derived config, editable starter, no bespoke authoring.
+
+**(b) The cog's tap-to-confirm and the needs-you-quest primitive bind to the WWWD gate.** The grammar
+rule "HITL on every cog action" (§3) has a substrate now. A cog proposal splits by whether the allocation
+carries a **business judgment**:
+- Pure operational allocations (seat this party, route the nearest tech) — confirm as specified; no WWWD call.
+- Allocations that carry a business call the org has a stance on (comp/waive a charge, spend against a
+  ceiling, prioritize existing-customer quality over new work) route the confirm through
+  `evaluate_org_business_decision` (`domainClass` from the decision kind, `riskTier` from the amount/reach).
+  A `recommend`/`arbitrate` lets the cog present the pre-cleared action; an `escalate`/`defer` becomes a
+  **needs-you quest** pinned to twin context — answerable in place with the *same* capture pattern the
+  `/wiki/review` "Waiting on your call" cards use (`captureOrgDecisionOutcome`), so the operator's answer
+  can be remembered as standing doctrine (ruled A/1.0) and the equivalent cog action self-clears next time.
+
+Net: the twin is where WWWD decisions are *made in context*, the stance corpus is what lets the cog make
+the common ones without asking, and the needs-you quest is the escalation surface — one loop, already
+shipped. Nothing in this framework needs to re-implement decision governance; P3+ template work should
+pass cog actions that carry a business judgment through the gate and render escalations as quests. See the
+stance spec §13 for the reciprocal reference; incorporation shape kernel-routed (`principle_decide` →
+additive cross-reference, high confidence, margin 3.59, DI-4E2943E733A7).
+
 ## 6. Research & Benchmarking — the vertical-market evidence
 
 Per §10, each category was benchmarked against its market-leading vertical solutions (what their live-operations surface centers on, and the signature allocation decision it assists). Full briefs in §6.1; the synthesis:


### PR DESCRIPTION
## What

Documentation reconciliation after the WWWD company-stance onboarding shipped (PRs #2800/#2812/#2837, EP-0AF96937), incorporating that work into the adjacent **Operational Twin Framework** design so both are solid.

- **Stance spec** ([2026-07-11-wwwd-stance-onboarding-design.md](docs/superpowers/specs/2026-07-11-wwwd-stance-onboarding-design.md)): Status → **Shipped**; §10 phases mapped to their PRs; §11 go/no-go questions marked **resolved-in-code**; new **§12 shipped-state** (live-verified at the pre-confirmation rung; BI-EBBBD275 kept open as a one-click owner action); new **§13 twin adjacency**.
- **Build plan**: Phase 3/4 → shipped with live-verification evidence + adjacency note.
- **Operational-twin spec** ([2026-07-12](docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md)): new **additive §5.1** — names `resolveStanceVectors` as a sibling archetype derivation (accurately flagged one layer up: app-onboarding, not `packages/storefront-templates`) and binds the twin's cog tap-to-confirm HITL + needs-you quests to `evaluate_org_business_decision` + the capture loop, so P3+ template work routes business-judgment cog actions through the WWWD gate instead of re-implementing decision governance. **Additive only** — no change to the twin grammar, templates, or derivation rules.

## BIs reconciled (via MCP, out of band)

BI-70ADC71F / BI-D6DC2432 / BI-9677364B / BI-002DEB85 → **done** with resolution notes. BI-EBBBD275 **kept open** — unblocked (the two founder rulings are now a one-click owner action) but not yet satisfied; closing it would be false.

## Notes

Docs-only; local pregate green (1820 test files, full suite). Incorporation shape kernel-routed: `principle_decide` → additive cross-reference, high confidence, margin 3.59 (DI-4E2943E733A7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)