### PR TITLE
docs(user-guide): explain the "Needs you" inbox, enriched from spec (EP-1155CEF3 / BI-2A5D2D5B)

### DIFF
--- a/docs/user-guide/workspace/attention-inbox.md
+++ b/docs/user-guide/workspace/attention-inbox.md
@@ -1,0 +1,46 @@
+---
+title: "The \"Needs You\" Inbox"
+area: workspace
+order: 2
+---
+
+## Overview
+
+The **"Needs you" inbox** is the one place for decisions that need *you*, right now — kept deliberately separate from the work backlog. It answers a different question than the backlog does:
+
+| | Backlog | "Needs you" inbox |
+| --- | --- | --- |
+| Holds | Work to **schedule** — features, bugs, chores | Decisions to **make now** — approvals, escalations, paused AI |
+| Answers | "What should we build next?" | "What needs *me*, and why can't the AI finish it?" |
+| Cadence | Planned, prioritized, eventually built | Blocking, time-sensitive, perishable |
+| Lives on | Operations | Your Workspace |
+
+Folding "a human must decide this now" into the backlog is a category error: the two have different owners, cadence, and half-lives. The inbox gives time-sensitive decisions their own home so they don't get buried under planned work.
+
+## Key Concepts
+
+- **Kernels-first — you see only the residue.** Every decision is routed through the platform's governed scopes first ([decision perspective](../ai-workforce/decision-perspective) — WWMD / WWWD / WSID). The inbox holds only what those scopes genuinely *cannot* resolve on their own, and only when the item is one they can honestly speak to. If the AI can decide it within your standing guidance, you never see it — that is the point.
+- **Honest "why it's here."** Every item carries the real reason it reached you — a coverage gap the governed scopes had no material for, a principle conflict the kernel was torn on, a policy that requires a human for this risk level, a coworker waiting on your input, or a missing credential. Never a fabricated confidence score.
+- **Triage, not a magic number.** Items are incommensurable — an overdue bill, a five-minute-old paused build, a compliance filing due tomorrow. The inbox makes them comparable by surfacing the *same* objective factors on every card — time to act, risk, what's blocked until you decide, and how much effort the decision takes — and orders them by a transparent, explainable rule. It never invents a single cross-axis "priority: 0.73" to rank them.
+- **A projection, not another queue.** The inbox is a read-only view *over* each area's own records; it is not a second backlog or ticket tracker. Acting on an item updates the record in its home area.
+
+## What Shows Up Here
+
+- **Escalations** — a build the AI could not self-repair, now waiting on you.
+- **Approvals** — bills and expense claims awaiting sign-off, outbound messages pending review, regulatory submissions with a filing deadline.
+- **Paused AI** — a coworker that needs your input to continue, or a missing credential (a *permission* gap, not a *judgment* one).
+- **Decisions the kernel escalated or deferred** — the residue of the governed scopes, with the honest reason attached.
+
+## What You Can Do
+
+- **Open in context** — jump straight to the item's home area to act on it with full detail.
+- **Approve / reject / request changes** — for approval items, decide directly from the card.
+- **Answer** — give a paused coworker the input it is waiting for.
+- **Snooze or dismiss** — clear an item you have handled or that no longer needs you.
+- Ask your [AI coworker](../getting-started/ai-coworker) for a briefing on what is in the inbox and why.
+
+Deadline-bearing items (bills, expenses, compliance filings) surface in the imminent tiers as their due dates approach; the rest are ordered by risk, blast radius, and age.
+
+---
+
+*Derived from the design spec [The Attention Surface — a kernels-first "Needs you" inbox](../../superpowers/specs/2026-06-23-human-attention-surface-design.md). This user guide is the operator-facing view; the spec holds the full rationale and non-goals.*

--- a/docs/user-guide/workspace/index.md
+++ b/docs/user-guide/workspace/index.md
@@ -14,6 +14,7 @@ My Workspace is your personal home base inside the platform. It gives you a cros
 - **Activity Feed** — A chronological stream of recent actions across the platform, filtered to things you're involved in or watching.
 - **Calendar** — Upcoming dates pulled from your backlog items, leave requests, deadlines, and any scheduled events in the areas you have access to.
 - **Managed Documents** — Maintained documents with lifecycle state, versions, references, and publication status.
+- **"Needs you" inbox** — The one place for decisions that need you now — approvals, escalations, and paused AI — kept separate from the work backlog. The AI routes decisions through the governed scopes first, so you only see the residue it genuinely cannot resolve.
 
 ## What You Can Do
 
@@ -23,3 +24,4 @@ My Workspace is your personal home base inside the platform. It gives you a cros
 - Access your calendar for today's events and upcoming deadlines
 - Open [Managed Documents](documents) to review document state, versions, and references
 - Use the AI coworker to get a personalized briefing on what needs your attention
+- Open the ["Needs you" inbox](attention-inbox) to act on decisions that need you — approve, answer, or open them in context


### PR DESCRIPTION
## What

First slice of the **spec→doc enrichment** stream (BI-2A5D2D5B), and it establishes the **convention** the whole stream follows: lift the good feature explanation out of a design spec into a customer-facing guide, with a *"Derived from spec X"* backref for traceability.

## The gap it fills

The Attention Surface — the **"Needs you" inbox** — is a shipped flagship feature (`/workspace/inbox`, `NeedsYouBand` + `AttentionInbox`) backed by a rich design spec, but there was **no user-guide doc** for it. The good explanation was trapped in `docs/superpowers/` (design history, not onboarding). This lifts it into the operator's guide.

## Contents
- **`docs/user-guide/workspace/attention-inbox.md`** (new) — operator-facing: the backlog-vs-attention split, *kernels-first* (you see only the residue the governed scopes can't resolve), the honest "why it's here" line, triage-without-a-fabricated-score, and what you can do. Ends with a **derived-from-spec backref** to `2026-06-23-human-attention-surface-design.md`.
- **`docs/user-guide/workspace/index.md`** — wires it into *Key Concepts* + *What You Can Do* so it's discoverable.

## Quality
- The feature was **verified shipped** before documenting (route + components exist) — no vaporware.
- **All links verified to resolve** (including Jekyll extensionless permalinks), so it stays green under the Doc Reference Integrity gate (#2871).

Audience priority per operator: **user-guide first**. This is one slice; the convention it sets (verify-shipped → lift → backref) is what the rest of the enrichment stream repeats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)