### PR TITLE
fix(monitoring): humanize raw scrape-job names on the System Health summary cards (BI-6B0F792A)

### DIFF
--- a/apps/web/components/monitoring/health-summary.test.ts
+++ b/apps/web/components/monitoring/health-summary.test.ts
@@ -6,6 +6,8 @@ import {
   derivePlatformSummary,
   deriveServiceStatuses,
   deriveServiceStatusesFromTargets,
+  friendlyJobLabel,
+  humanizeJobList,
   isHostTelemetryConfigured,
   type MonitoringAlert,
   type PrometheusActiveTarget,
@@ -72,6 +74,55 @@ describe("derivePlatformSummary", () => {
     expect(summary.tone).toBe("success");
     expect(summary.detail).toContain("Required platform services are up");
   });
+
+  it("names down required services in plain language, not raw scrape-job ids", () => {
+    // postgres + sandbox down, no alert firing (so this hits the up-targets
+    // branch, the one that used to emit `postgres, sandbox down`).
+    const summary = derivePlatformSummary({
+      checked: true,
+      online: true,
+      upTargets: [up("prometheus"), up("portal"), up("postgres", "0"), up("qdrant"), up("sandbox", "0")],
+      alerts: [],
+    });
+
+    expect(summary.value).toBe("Critical");
+    expect(summary.detail).toBe("Database and Build workspace are down");
+    expect(summary.detail).not.toContain("postgres");
+    expect(summary.detail).not.toContain("sandbox");
+  });
+
+  it("uses singular grammar and 'not reporting' for a single missing required service", () => {
+    const summary = derivePlatformSummary({
+      checked: true,
+      online: true,
+      // qdrant absent entirely (not in upTargets) => missing/unknown, not down.
+      upTargets: [up("prometheus"), up("portal"), up("postgres"), up("sandbox")],
+      alerts: [],
+    });
+
+    expect(summary.value).toBe("Degraded");
+    expect(summary.detail).toBe("AI memory & search is not reporting");
+  });
+});
+
+describe("friendlyJobLabel / humanizeJobList", () => {
+  it("maps known jobs to plain-language labels", () => {
+    expect(friendlyJobLabel("postgres")).toBe("Database");
+    expect(friendlyJobLabel("qdrant")).toBe("AI memory & search");
+    expect(friendlyJobLabel("sandbox")).toBe("Build workspace");
+  });
+
+  it("falls back to the raw job id for an unmapped job (never crashes)", () => {
+    expect(friendlyJobLabel("some-new-scrape-job")).toBe("some-new-scrape-job");
+  });
+
+  it("joins with 'and'/Oxford comma", () => {
+    expect(humanizeJobList(["portal"])).toBe("Web portal");
+    expect(humanizeJobList(["portal", "postgres"])).toBe("Web portal and Database");
+    expect(humanizeJobList(["portal", "postgres", "sandbox"])).toBe(
+      "Web portal, Database, and Build workspace",
+    );
+  });
 });
 
 describe("deriveMonitoringSummary", () => {
@@ -90,7 +141,12 @@ describe("deriveMonitoringSummary", () => {
 
     expect(summary.value).toBe("Degraded");
     expect(summary.tone).toBe("warning");
-    expect(summary.detail).toContain("2 telemetry targets down");
+    // Humanized: plain "Host metrics"/"Container metrics", not raw job ids.
+    expect(summary.detail).toContain("Host metrics");
+    expect(summary.detail).toContain("Container metrics");
+    expect(summary.detail).toContain("unavailable");
+    expect(summary.detail).not.toContain("node-exporter");
+    expect(summary.detail).not.toContain("cadvisor");
   });
 
   it("reports active when Prometheus and telemetry targets are healthy", () => {

--- a/apps/web/components/monitoring/health-summary.ts
+++ b/apps/web/components/monitoring/health-summary.ts
@@ -164,7 +164,7 @@ export function derivePlatformSummary({
     return {
       value: "Critical",
       tone: "critical",
-      detail: `${downRequiredJobs.join(", ")} down`,
+      detail: `${humanizeJobList(downRequiredJobs)} ${downRequiredJobs.length === 1 ? "is" : "are"} down`,
     };
   }
 
@@ -173,7 +173,7 @@ export function derivePlatformSummary({
     return {
       value: "Degraded",
       tone: "warning",
-      detail: `${missingRequiredJobs.join(", ")} status unknown`,
+      detail: `${humanizeJobList(missingRequiredJobs)} ${missingRequiredJobs.length === 1 ? "is" : "are"} not reporting`,
     };
   }
 
@@ -213,7 +213,7 @@ export function deriveMonitoringSummary({
     return {
       value: "Degraded",
       tone: "warning",
-      detail: `${telemetryDown.length} telemetry targets down: ${telemetryDown.join(", ")}`,
+      detail: `${humanizeJobList(telemetryDown)} ${telemetryDown.length === 1 ? "is" : "are"} unavailable`,
     };
   }
 
@@ -333,6 +333,47 @@ export const JOB_PRESENTATION: Record<string, JobPresentation> = {
   cadvisor: { name: "cAdvisor", internal: true },
   prometheus: { name: "Prometheus", hidden: true }, // self-monitoring; alert-only
 };
+
+// Plain-language service names for the health SUMMARY CARDS (BI-2F778C13
+// follow-up). JOB_PRESENTATION names are the tile-grid labels and are still
+// product/tech vocabulary ("PostgreSQL", "Qdrant", "cAdvisor") — fine on the
+// detailed operator grid, but the summary-card detail line used to join the
+// RAW scrape-job strings ("portal, postgres, qdrant, sandbox down") straight
+// at a non-technical business user. This map gives those same jobs a
+// what-it-is-to-you label; the wording mirrors alert-humanize's
+// SERVICE_DOWN_IMPACT so both surfaces speak one language.
+const PLATFORM_SERVICE_LABEL: Record<string, string> = {
+  portal: "Web portal",
+  sandbox: "Build workspace",
+  postgres: "Database",
+  qdrant: "AI memory & search",
+  neo4j: "Knowledge graph",
+  inngest: "Background jobs",
+  redis: "Queues & cache",
+  adp: "Document processing",
+  prometheus: "Health monitoring",
+  "node-exporter": "Host metrics",
+  "windows-host": "Host metrics",
+  cadvisor: "Container metrics",
+  "dev-portal": "Contributor preview",
+};
+
+// A job's plainest name for the summary cards: the what-it-is-to-you label,
+// falling back to the tile-grid friendly name, then the raw job string (so a
+// newly-added scrape job is never a crash — just its raw name until labelled).
+export function friendlyJobLabel(job: string): string {
+  return PLATFORM_SERVICE_LABEL[job] ?? JOB_PRESENTATION[job]?.name ?? job;
+}
+
+// Grammatical, humanized list of jobs for a summary-card detail line, e.g.
+// ["portal","postgres"] -> "Web portal and Database". Keeps the card terse
+// (comma list, "and" before the last) instead of raw job identifiers.
+export function humanizeJobList(jobs: string[]): string {
+  const labels = jobs.map(friendlyJobLabel);
+  if (labels.length <= 1) return labels[0] ?? "";
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.slice(0, -1).join(", ")}, and ${labels[labels.length - 1]}`;
+}
 
 // Services that have no Prometheus scrape target but the user should still
 // see on the Health tab — either because they exist but ship without a


### PR DESCRIPTION
## What

Follow-up to BI-2F778C13 (**BI-6B0F792A**). After #2764 humanized the header dropdown and alert banners, the Platform / Monitoring **summary StatCards** still joined raw Prometheus scrape-job ids straight into the detail line at a non-technical business user:

- `derivePlatformSummary` → `"portal, postgres, qdrant, sandbox down"` and `"… status unknown"`
- `deriveMonitoringSummary` → `"2 telemetry targets down: node-exporter, cadvisor"`

## Fix

A plain-language service-label map + `friendlyJobLabel` / `humanizeJobList` helpers, placed next to `JOB_PRESENTATION` in `health-summary.ts` (**not** in `alert-humanize.ts` — that module already imports from `health-summary`, so the reverse would be a circular import). Wording mirrors `alert-humanize`'s `SERVICE_DOWN_IMPACT` so both surfaces speak one language: `postgres`→"Database", `qdrant`→"AI memory & search", `sandbox`→"Build workspace", `node-exporter`/`windows-host`→"Host metrics", `cadvisor`→"Container metrics".

Detail lines now read **"Database and Build workspace are down"**, **"AI memory & search is not reporting"**, **"Host metrics and Container metrics are unavailable"** — with singular/plural grammar and an Oxford "and". Unmapped jobs fall back to the tile name then the raw id, so a newly-added scrape job is never a crash.

## Verification

- `health-summary.test.ts` extended: down-required-jobs and single-missing cases assert the humanized wording **and** that no raw job id leaks; the telemetry assertion updated off the old `"2 telemetry targets down"`; unit coverage for `friendlyJobLabel`/`humanizeJobList` incl. the unmapped fallback (37 tests green).
- `web` typecheck green; local pregate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
