### PR TITLE
feat(build): one-shot feature lane — single-pass eligibility for the low-risk tail (BI-417AE8E9)

### DIFF
--- a/apps/web/lib/build/one-shot-lane.test.ts
+++ b/apps/web/lib/build/one-shot-lane.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { isOneShotEligible, oneShotLaneDecision, type OneShotLaneInput } from "./one-shot-lane";
+
+const base: OneShotLaneInput = {
+  workType: "feature",
+  effortSize: "small",
+  sensitivity: "low",
+  gateOutcome: "recommend",
+  oraclesGreen: true,
+};
+
+describe("isOneShotEligible", () => {
+  it("is true for the ideal case (small low-sens feature, gate recommends, oracles green)", () => {
+    expect(isOneShotEligible(base)).toBe(true);
+    expect(isOneShotEligible({ ...base, effortSize: "medium" })).toBe(true);
+    expect(isOneShotEligible({ ...base, workType: "fix" })).toBe(true);
+    expect(isOneShotEligible({ ...base, gateOutcome: "arbitrate" })).toBe(true);
+  });
+
+  it("disqualifies large/xlarge sizes", () => {
+    expect(isOneShotEligible({ ...base, effortSize: "large" })).toBe(false);
+    expect(isOneShotEligible({ ...base, effortSize: "xlarge" })).toBe(false);
+  });
+
+  it("disqualifies non-feature/fix work", () => {
+    expect(isOneShotEligible({ ...base, workType: "chore" })).toBe(false);
+    expect(isOneShotEligible({ ...base, workType: "doc" })).toBe(false);
+  });
+
+  it("disqualifies any non-low sensitivity", () => {
+    expect(isOneShotEligible({ ...base, sensitivity: "elevated" })).toBe(false);
+    expect(isOneShotEligible({ ...base, sensitivity: "high" })).toBe(false);
+  });
+
+  it("disqualifies when oracles are not green", () => {
+    expect(isOneShotEligible({ ...base, oraclesGreen: false })).toBe(false);
+  });
+
+  it("disqualifies when the gate does not auto-proceed", () => {
+    expect(isOneShotEligible({ ...base, gateOutcome: "escalate" })).toBe(false);
+    expect(isOneShotEligible({ ...base, gateOutcome: "defer" })).toBe(false);
+  });
+
+  it("is fail-safe on missing fields", () => {
+    expect(isOneShotEligible({ ...base, workType: null })).toBe(false);
+    expect(isOneShotEligible({ ...base, effortSize: null })).toBe(false);
+  });
+});
+
+describe("oneShotLaneDecision", () => {
+  it("selects one-shot with a reason for the ideal case", () => {
+    const d = oneShotLaneDecision(base);
+    expect(d.lane).toBe("one-shot");
+    expect(d.reason).toContain("auto-proceeds");
+  });
+
+  it("names the first failing precondition", () => {
+    expect(oneShotLaneDecision({ ...base, effortSize: "large" }).reason).toContain("size");
+    expect(oneShotLaneDecision({ ...base, sensitivity: "high" }).reason).toContain("sensitivity");
+    expect(oneShotLaneDecision({ ...base, oraclesGreen: false }).reason).toContain("oracles");
+    expect(oneShotLaneDecision({ ...base, gateOutcome: "escalate" }).reason).toContain("auto-proceed");
+    expect(oneShotLaneDecision({ ...base, workType: "chore" }).reason).toContain("work type");
+  });
+
+  it("defaults to the standard lane (never one-shot) when any precondition fails", () => {
+    expect(oneShotLaneDecision({ ...base, oraclesGreen: false }).lane).toBe("standard");
+  });
+});

--- a/apps/web/lib/build/one-shot-lane.ts
+++ b/apps/web/lib/build/one-shot-lane.ts
@@ -1,0 +1,83 @@
+// One-shot feature lane — single-pass governed dispatch + auto-ship for the
+// low-risk tail of the backlog.
+//
+// BI-417AE8E9 (EP-27FD96BC). The user's goal: lower cost while holding quality
+// by "one-shotting new features" — not whole products. The 2026 evidence says a
+// single-pass build is safe ONLY when success is machine-checkable and the
+// change is low-stakes (greenfield-simple, tests-as-oracle). So the one-shot
+// lane is deliberately narrow: a SMALL/MEDIUM, LOW-sensitivity feature/fix whose
+// graduated gate auto-proceeds (BI-D996C238) and whose oracles (typecheck +
+// tests) are green skips the multi-round deliberation and auto-ships; everything
+// else stays on the standard multi-round lane. This is the composition point the
+// graduated ship gate feeds — it does not invent new autonomy, it narrows WHERE
+// existing auto-proceed applies.
+//
+// Pure predicate + decision; no DB, no dispatch — unit-testable. The build
+// pipeline consults it to pick a lane; the actual single-pass dispatch and
+// auto-ship are gated by DPF_BUILD_ONE_SHOT_LANE and the (phase-2) ship gate.
+
+import type { DeliverableSensitivity } from "@/lib/explore/build-process-matrix";
+import { graduatedGateOutcome } from "@/lib/decision-perspective/graduated-autonomy";
+import type { DecisionOutcomeType } from "@/lib/decision-perspective/types";
+
+/** Work types eligible for one-shot — a feature or a fix (a chore/doc is either
+ *  already trivial or not a "feature" to one-shot). */
+const ONE_SHOT_WORK_TYPES: ReadonlySet<string> = new Set(["feature", "fix", "bug"]);
+/** Sizes eligible — small and medium only. large/xlarge always take the full
+ *  lane (they are decomposed / thoroughly reviewed). */
+const ONE_SHOT_SIZES: ReadonlySet<string> = new Set(["small", "medium"]);
+
+export type OneShotLaneInput = {
+  workType?: string | null;
+  effortSize?: string | null;
+  sensitivity: DeliverableSensitivity;
+  /** The gate outcome for this build's advancement (from the graduated gate). */
+  gateOutcome: DecisionOutcomeType;
+  /** Machine oracles: typecheck + tests are green in the sandbox. */
+  oraclesGreen: boolean;
+};
+
+export type OneShotLaneDecision = {
+  lane: "one-shot" | "standard";
+  /** Human/machine-readable reason the lane was (not) chosen. */
+  reason: string;
+};
+
+/**
+ * PURE. True iff every one-shot precondition holds: a small/medium feature-or-fix
+ * that is LOW sensitivity, whose graduated gate auto-proceeds, with green oracles.
+ * Any single failing precondition disqualifies — the lane is fail-safe (defaults
+ * to the standard lane), never fail-open.
+ */
+export function isOneShotEligible(input: OneShotLaneInput): boolean {
+  if (!ONE_SHOT_WORK_TYPES.has(input.workType ?? "")) return false;
+  if (!ONE_SHOT_SIZES.has(input.effortSize ?? "")) return false;
+  if (input.sensitivity !== "low") return false;
+  if (!input.oraclesGreen) return false;
+  return graduatedGateOutcome(input.gateOutcome).autoProceed;
+}
+
+/**
+ * PURE. Resolve the lane with a reason for the audit trail. Returns "one-shot"
+ * only when isOneShotEligible; otherwise "standard" with the first failing
+ * precondition named (so the operator sees WHY a build stayed on the full lane).
+ */
+export function oneShotLaneDecision(input: OneShotLaneInput): OneShotLaneDecision {
+  if (!ONE_SHOT_WORK_TYPES.has(input.workType ?? "")) {
+    return { lane: "standard", reason: `work type "${input.workType ?? "?"}" is not one-shot-eligible (feature/fix only)` };
+  }
+  if (!ONE_SHOT_SIZES.has(input.effortSize ?? "")) {
+    return { lane: "standard", reason: `size "${input.effortSize ?? "?"}" is not one-shot-eligible (small/medium only)` };
+  }
+  if (input.sensitivity !== "low") {
+    return { lane: "standard", reason: `${input.sensitivity} deliverable sensitivity requires the full review lane` };
+  }
+  if (!input.oraclesGreen) {
+    return { lane: "standard", reason: "oracles (typecheck/tests) are not green" };
+  }
+  const outcome = graduatedGateOutcome(input.gateOutcome);
+  if (!outcome.autoProceed) {
+    return { lane: "standard", reason: `governance did not auto-proceed (${outcome.reason})` };
+  }
+  return { lane: "one-shot", reason: "small/medium low-sensitivity feature, gate auto-proceeds, oracles green" };
+}

--- a/apps/web/lib/integrate/build-studio-config.ts
+++ b/apps/web/lib/integrate/build-studio-config.ts
@@ -235,6 +235,19 @@ export function isGraduatedGateAutonomyEnabled(): boolean {
   return v === "1" || v === "true";
 }
 
+/**
+ * BI-417AE8E9 (EP-27FD96BC): one-shot feature lane — a small/medium, low-
+ * sensitivity feature/fix whose graduated gate auto-proceeds and whose oracles
+ * are green takes a single-pass lane (skips multi-round deliberation) and
+ * auto-ships. Opt-in (default off) so every build stays on the standard
+ * multi-round lane until an operator enables it (and it composes the graduated
+ * gate, DPF_BUILD_GRADUATED_GATE_AUTONOMY). Set DPF_BUILD_ONE_SHOT_LANE=1.
+ */
+export function isOneShotLaneEnabled(): boolean {
+  const v = process.env.DPF_BUILD_ONE_SHOT_LANE;
+  return v === "1" || v === "true";
+}
+
 /** PlatformConfig key for the global build Cost/Quality/Time posture (P2). */
 export const BUILD_GOLDEN_TRIANGLE_POSTURE_KEY = "BUILD_GOLDEN_TRIANGLE_POSTURE";
 

--- a/docs/superpowers/specs/2026-07-12-one-shot-feature-lane-design.md
+++ b/docs/superpowers/specs/2026-07-12-one-shot-feature-lane-design.md
@@ -1,0 +1,35 @@
+# One-shot feature lane — single-pass governed dispatch for the low-risk tail
+
+- **Status:** eligibility core implemented (opt-in); single-pass dispatch + auto-ship compose the phase-2 ship gate
+- **Date:** 2026-07-12
+- **BI:** BI-417AE8E9 · **Epic:** EP-27FD96BC · **Depends on:** BI-D996C238 (graduated gate autonomy)
+- **Strategy:** [`2026-07-12-dpf-development-model-and-frontier-harness-positioning-design.md`](2026-07-12-dpf-development-model-and-frontier-harness-positioning-design.md) §3/§9-R3
+
+## Problem
+
+The user's cost goal is to **one-shot new features** (not whole products) while holding quality. Every DPF build today takes the full multi-round lane (ideate → plan → multi-round review → build → review → ship) regardless of how small and low-risk it is — the dominant cost for the long tail of small changes. The 2026 evidence (Stanford greenfield/brownfield split; Ralph-loop economics) is that a single-pass build is safe **only** when success is machine-checkable and the change is low-stakes. So a one-shot lane must be *narrow by construction*, not a blanket autonomy increase.
+
+## Design
+
+`apps/web/lib/build/one-shot-lane.ts` — pure, unit-testable:
+
+- **`isOneShotEligible(input)`** is true iff **all** hold: work type is `feature`/`fix`; size is `small`/`medium`; deliverable sensitivity is `low`; the graduated gate **auto-proceeds** (`graduatedGateOutcome(gateOutcome).autoProceed`, from BI-D996C238); and the **oracles are green** (typecheck + tests pass in the sandbox). Any single failure disqualifies — **fail-safe** to the standard lane, never fail-open.
+- **`oneShotLaneDecision(input)`** returns `{lane, reason}`, naming the first failing precondition so the operator sees *why* a build stayed on the full lane.
+
+The lane composes existing primitives rather than inventing autonomy: sensitivity from `deriveDeliverableSensitivity`, the auto-proceed decision from the graduated gate, and the oracles from the sandbox typecheck/test the build gate already runs. It only narrows **where** the graduated ship gate's auto-proceed is allowed to skip ceremony.
+
+## Wiring & flag
+
+Gated by `DPF_BUILD_ONE_SHOT_LANE` (`isOneShotLaneEnabled`, default **off**). When enabled and `oneShotLaneDecision` returns `one-shot`, the build pipeline:
+1. **skips the multi-round deliberation** — a single specialist pass, verified by the oracles;
+2. **auto-ships** via the phase-2 graduated **ship gate** (specified in the graduated-gate design) instead of parking for the operator's manual ship click.
+
+Both effects require the phase-2 ship gate; this PR lands the **eligibility core + flag + decision/reason logic** so the lane's gating is defined, tested, and inspectable. The pipeline consult (attach `oneShotLaneDecision.reason` to the build's evidence, then branch dispatch) is the follow-up that composes the ship gate — kept out of this PR because auto-ship removes a deliberate human gate and is landing under the graduated-gate phase-2 review.
+
+## Verification
+
+`one-shot-lane.test.ts` (10) — the ideal case and every disqualifier (large/xlarge, non-feature/fix, non-low sensitivity, red oracles, non-auto-proceed gate, missing fields), plus `oneShotLaneDecision` lane + first-failing-reason and the fail-safe default. All pass locally.
+
+## Non-goals
+
+Not a one-shot of a whole product (explicitly out of scope — DPF one-shots *features* inside a durable org codebase). Does not widen the graduated gate's risk floors (high sensitivity still escalates). Does not change any build when the flag is off. The single-pass dispatch mechanics and the auto-ship wiring land with the phase-2 ship gate.


### PR DESCRIPTION
## Summary

Closes BI-417AE8E9 (EP-27FD96BC). The user's cost goal is to **one-shot new features** (not whole products) while holding quality. Every DPF build takes the full multi-round lane regardless of how small/low-risk it is. This adds a **narrow-by-construction** one-shot lane: a small/medium, low-sensitivity feature/fix whose graduated gate auto-proceeds and whose oracles (typecheck + tests) are green skips multi-round deliberation and (via the phase-2 ship gate) auto-ships. Any failing precondition falls back to the standard lane — **fail-safe, never fail-open**.

> **Stacked on #2885** (graduated gate autonomy, BI-D996C238) — it imports `graduatedGateOutcome`. The diff resolves to only the one-shot files once #2885 merges to main.

## Changes
- `apps/web/lib/build/one-shot-lane.ts` (pure): `isOneShotEligible` (**all of**: feature/fix, small/medium, low sensitivity, gate auto-proceeds, oracles green) + `oneShotLaneDecision` (`{lane, reason}` naming the first failing precondition for the audit trail). Composes `graduatedGateOutcome` (BI-D996C238) — invents no new autonomy, only narrows *where* auto-proceed skips ceremony.
- Flag `DPF_BUILD_ONE_SHOT_LANE` (`isOneShotLaneEnabled`), **default off**.

## Verification
- **10 unit tests** (`one-shot-lane.test.ts`) — ideal case + every disqualifier (size, work type, sensitivity, red oracles, non-auto-proceed gate, missing fields) + fail-safe default. **Pass locally.**
- Local typecheck skipped (source-only worktree); **CI gates the merge**.
- Spec: `docs/superpowers/specs/2026-07-12-one-shot-feature-lane-design.md`. Single-pass dispatch + auto-ship compose the phase-2 graduated ship gate (spec'd in #2885); this lands the eligibility core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)