### PR TITLE
feat(admin): Archetype Catalog — central view of enabled + not-enabled configurations (EP-LIVING-BUSINESS-VIZ P1.5)

### DIFF
--- a/apps/web/app/(shell)/admin/archetypes/page.tsx
+++ b/apps/web/app/(shell)/admin/archetypes/page.tsx
@@ -1,0 +1,108 @@
+import { prisma } from "@dpf/db";
+import {
+  ALL_ARCHETYPES,
+  deriveTwinProfile,
+  type ArchetypeDefinition,
+} from "@dpf/storefront-templates";
+import { AdminTabNav } from "@/components/admin/AdminTabNav";
+import { industryLabel } from "@/lib/storefront/industries";
+import {
+  ArchetypeCatalogTable,
+  type ArchetypeCatalogRow,
+} from "@/components/admin/ArchetypeCatalogTable";
+
+// Central, read-only catalog of every archetype configuration installed on the
+// platform — including the ones that have NOT been enabled. The setup wizard
+// (/storefront/setup) redirects away the moment an archetype is chosen, so once
+// a business is live there is no in-product surface that lists the alternatives.
+// This is an administrative view because the choice "affects the entire
+// business": it sets the org's industry SSOT (StorefrontConfig.archetypeId) and,
+// through it, the operational twin, vocabulary, and value stream.
+
+// The seeded definitions carry the full leaf typing (schedulingDefaults,
+// fieldDispatch, twinProfile overrides) that deriveTwinProfile reads; index them
+// so each installed DB row derives its twin from the canonical definition.
+const DEFS_BY_ID = new Map<string, ArchetypeDefinition>(
+  ALL_ARCHETYPES.map((a) => [a.archetypeId, a]),
+);
+
+export default async function AdminArchetypesPage() {
+  const [installed, config] = await Promise.all([
+    prisma.storefrontArchetype.findMany({
+      where: { isActive: true },
+      select: {
+        archetypeId: true,
+        name: true,
+        category: true,
+        ctaType: true,
+        tags: true,
+        isBuiltIn: true,
+        activationProfile: true,
+      },
+      orderBy: [{ category: "asc" }, { name: "asc" }],
+    }),
+    // StorefrontConfig.archetypeId is the FK (StorefrontArchetype.id, a cuid) —
+    // the enabled *slug* lives on the relation, so read it there.
+    prisma.storefrontConfig.findFirst({
+      select: { archetype: { select: { archetypeId: true } } },
+    }),
+  ]);
+
+  const enabledId = config?.archetype?.archetypeId ?? null;
+
+  const rows: ArchetypeCatalogRow[] = installed.map((a) => {
+    // Prefer the canonical seeded definition (full leaf overrides); fall back to
+    // a definition synthesized from the DB row for any custom/installed leaf
+    // that has no compiled counterpart. deriveTwinProfile only reads
+    // category/ctaType/tags/activationProfile + the optional leaf overrides.
+    const def: ArchetypeDefinition =
+      DEFS_BY_ID.get(a.archetypeId) ??
+      ({
+        archetypeId: a.archetypeId,
+        name: a.name,
+        category: a.category,
+        ctaType: a.ctaType,
+        tags: a.tags,
+        itemTemplates: [],
+        sectionTemplates: [],
+        formSchema: [],
+        // activationProfile is stored as JSON; deriveTwinProfile normalizes it
+        // through readActivationProfile, so the raw shape is safe to pass.
+        activationProfile:
+          a.activationProfile as unknown as ArchetypeDefinition["activationProfile"],
+      } as ArchetypeDefinition);
+
+    const twin = deriveTwinProfile(def);
+
+    return {
+      archetypeId: a.archetypeId,
+      name: a.name,
+      category: a.category,
+      categoryLabel: industryLabel(a.category) || a.category,
+      ctaType: a.ctaType,
+      isBuiltIn: a.isBuiltIn,
+      twinTemplate: twin.template,
+      twinVariant: twin.variant ?? null,
+      twinPhysical: twin.physical,
+      enabled: enabledId != null && a.archetypeId === enabledId,
+    };
+  });
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Admin</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          Archetype catalog — every business configuration installed on the platform,
+          including the {rows.filter((r) => !r.enabled).length} not currently enabled.
+        </p>
+      </div>
+
+      <AdminTabNav />
+
+      <div className="mt-6">
+        <ArchetypeCatalogTable rows={rows} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/admin/ArchetypeCatalogTable.tsx
+++ b/apps/web/components/admin/ArchetypeCatalogTable.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  DataTable,
+  FilterBar,
+  StatCard,
+  StatusBadge,
+  type Column,
+  type FacetDef,
+} from "@/components/ui/report-kit";
+
+export interface ArchetypeCatalogRow {
+  archetypeId: string;
+  name: string;
+  category: string;
+  categoryLabel: string;
+  ctaType: string;
+  isBuiltIn: boolean;
+  twinTemplate: string;
+  twinVariant: string | null;
+  twinPhysical: boolean;
+  enabled: boolean;
+}
+
+interface Props {
+  rows: ArchetypeCatalogRow[];
+}
+
+const STATUS_FACET = "status";
+const CATEGORY_FACET = "category";
+const TWIN_FACET = "twin";
+const SEARCH_FACET = "q";
+
+function statusFacetOptions() {
+  return [
+    { value: "enabled", label: "Enabled" },
+    { value: "available", label: "Available" },
+  ];
+}
+
+export function ArchetypeCatalogTable({ rows }: Props) {
+  const [filters, setFilters] = useState<Record<string, string>>({});
+
+  const categoryOptions = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const r of rows) if (!seen.has(r.category)) seen.set(r.category, r.categoryLabel);
+    return [...seen.entries()]
+      .map(([value, label]) => ({ value, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [rows]);
+
+  const twinOptions = useMemo(() => {
+    const seen = new Set<string>();
+    for (const r of rows) seen.add(r.twinTemplate);
+    return [...seen]
+      .sort((a, b) => a.localeCompare(b))
+      .map((value) => ({ value, label: value }));
+  }, [rows]);
+
+  const filtered = useMemo(() => {
+    const q = (filters[SEARCH_FACET] ?? "").trim().toLowerCase();
+    return rows.filter((r) => {
+      if (filters[STATUS_FACET] === "enabled" && !r.enabled) return false;
+      if (filters[STATUS_FACET] === "available" && r.enabled) return false;
+      if (filters[CATEGORY_FACET] && r.category !== filters[CATEGORY_FACET]) return false;
+      if (filters[TWIN_FACET] && r.twinTemplate !== filters[TWIN_FACET]) return false;
+      if (
+        q &&
+        !r.name.toLowerCase().includes(q) &&
+        !r.archetypeId.toLowerCase().includes(q) &&
+        !r.categoryLabel.toLowerCase().includes(q)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [rows, filters]);
+
+  const facets: FacetDef[] = [
+    { kind: "search", key: SEARCH_FACET, placeholder: "Search name, id, category…" },
+    { kind: "pills", key: STATUS_FACET, label: "Status", options: statusFacetOptions() },
+    { kind: "select", key: CATEGORY_FACET, label: "Category", options: categoryOptions },
+    { kind: "select", key: TWIN_FACET, label: "Twin", options: twinOptions },
+  ];
+
+  const columns: Column<ArchetypeCatalogRow>[] = [
+    {
+      key: "name",
+      header: "Archetype",
+      sortAccessor: (r) => r.name,
+      cell: (r) => (
+        <div className="flex flex-col">
+          <span className="font-medium text-[var(--dpf-text)]">{r.name}</span>
+          <span className="font-mono text-[11px] text-[var(--dpf-muted)]">{r.archetypeId}</span>
+        </div>
+      ),
+    },
+    {
+      key: "category",
+      header: "Category",
+      sortAccessor: (r) => r.categoryLabel,
+      cell: (r) => <span className="text-sm text-[var(--dpf-text)]">{r.categoryLabel}</span>,
+    },
+    {
+      key: "cta",
+      header: "CTA",
+      sortAccessor: (r) => r.ctaType,
+      cell: (r) => <span className="text-sm text-[var(--dpf-muted)]">{r.ctaType}</span>,
+    },
+    {
+      key: "twin",
+      header: "Operational twin",
+      sortAccessor: (r) => r.twinTemplate,
+      cell: (r) => (
+        <div className="flex items-center gap-2">
+          <StatusBadge
+            intent={r.twinPhysical ? "accent" : "info"}
+            label={r.twinTemplate}
+            variant="soft"
+          />
+          {r.twinVariant ? (
+            <span className="text-[11px] text-[var(--dpf-muted)]">{r.twinVariant}</span>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      align: "right",
+      sortAccessor: (r) => (r.enabled ? 0 : 1),
+      cell: (r) =>
+        r.enabled ? (
+          <StatusBadge intent="success" label="Enabled" variant="soft" />
+        ) : (
+          <StatusBadge intent="neutral" label="Available" variant="outline" />
+        ),
+    },
+  ];
+
+  const enabledRow = rows.find((r) => r.enabled) ?? null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <StatCard label="Configurations" value={rows.length} />
+        <StatCard
+          label="Enabled"
+          value={enabledRow ? 1 : 0}
+          intent="success"
+          hint={enabledRow ? enabledRow.name : "None enabled yet"}
+        />
+        <StatCard
+          label="Available"
+          value={rows.filter((r) => !r.enabled).length}
+          intent="neutral"
+          hint="Not currently enabled"
+        />
+        <StatCard label="Categories" value={categoryOptions.length} intent="info" />
+      </div>
+
+      <FilterBar
+        facets={facets}
+        value={filters}
+        onChange={setFilters}
+        resultCount={filtered.length}
+      />
+
+      <DataTable
+        columns={columns}
+        rows={filtered}
+        getRowKey={(r) => r.archetypeId}
+        initialSort={{ key: "status", dir: "asc" }}
+        pageSize={25}
+        empty={
+          <span className="text-sm text-[var(--dpf-muted)]">
+            No archetype configurations match these filters.
+          </span>
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/components/admin/admin-nav.ts
+++ b/apps/web/components/admin/admin-nav.ts
@@ -43,6 +43,7 @@ export const ADMIN_FAMILIES: AdminFamily[] = [
       "/admin/reference-data",
       "/admin/data-stewardship",
       "/admin/business-models",
+      "/admin/archetypes",
       "/admin/operating-hours",
     ],
     subItems: [
@@ -50,6 +51,7 @@ export const ADMIN_FAMILIES: AdminFamily[] = [
       { label: "Reference Data", href: "/admin/reference-data" },
       { label: "Data Stewardship", href: "/admin/data-stewardship" },
       { label: "Business Models", href: "/admin/business-models" },
+      { label: "Archetypes", href: "/admin/archetypes" },
     ],
   },
   {

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 545,
+  "routeCount": 546,
   "routes": [
     {
       "routePath": "/",
@@ -28,6 +28,16 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/admin/page.tsx"
+    },
+    {
+      "routePath": "/admin/archetypes",
+      "kind": "page",
+      "segments": [
+        "admin",
+        "archetypes"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/admin/archetypes/page.tsx"
     },
     {
       "routePath": "/admin/backlog",

--- a/docs/superpowers/plans/2026-07-12-archetype-catalog-admin-view-execution.md
+++ b/docs/superpowers/plans/2026-07-12-archetype-catalog-admin-view-execution.md
@@ -1,0 +1,70 @@
+# Archetype Catalog admin view — execution plan
+
+**Parent:** [2026-07-12-operational-twin-framework-execution.md](2026-07-12-operational-twin-framework-execution.md)
+**Design:** [2026-07-12-operational-twin-framework-design.md](../specs/2026-07-12-operational-twin-framework-design.md), [2026-07-11-living-business-workforce-visualization-design.md](../specs/2026-07-11-living-business-workforce-visualization-design.md)
+**Epic:** EP-LIVING-BUSINESS-VIZ
+**Started:** 2026-07-12
+
+## Problem
+
+There is no in-product surface that lists the archetype configurations a business
+has **not** enabled. The setup wizard (`/storefront/setup`) is the only page that
+renders the full catalog, and its first line redirects away the moment a
+`StorefrontConfig` exists (`if (existing) redirect("/storefront")`) — so once a
+business is live, the ~94 seeded configurations become invisible. An operator
+asking "what else could this business have been / what does each configuration
+imply?" has nowhere to look. This is an **administrative** concern: the archetype
+is the org's industry SSOT (`StorefrontConfig.archetypeId`) and, through it, drives
+the operational twin, vocabulary, playbook, and value stream — it "affects the
+entire business."
+
+## Decision
+
+A read-only **Archetype Catalog** at `/admin/archetypes`, in the admin
+**Configuration** family (alongside Business Models, Reference Data, Data
+Stewardship) — the family for "global settings, reference data, operating rules."
+It is a *catalog/reference* surface, not an activation control: switching the live
+archetype stays the setup/onboarding flow's job. Read-only keeps the blast radius
+of a whole-business setting off a general admin table.
+
+## Shape
+
+- **`apps/web/app/(shell)/admin/archetypes/page.tsx`** (server) — queries
+  `storefrontArchetype` (installed, `isActive`) for the catalog and
+  `storefrontConfig.archetype.archetypeId` for the one enabled slug (the config's
+  own `archetypeId` column is the cuid FK, so the slug is read through the
+  relation). Each row joins to the canonical seeded definition in `ALL_ARCHETYPES`
+  (full leaf overrides) and runs the merged **`deriveTwinProfile`** to surface the
+  operational-twin template/variant per configuration — making this the first
+  product surface to *show* the twin framework. Falls back to a definition
+  synthesized from the DB row for any installed leaf with no compiled counterpart.
+- **`apps/web/components/admin/ArchetypeCatalogTable.tsx`** (client) — composed
+  entirely from **report-kit** primitives (`StatCard`, `FilterBar`, `DataTable`,
+  `StatusBadge`) per the `compose-report-kit-for-reporting-ux` principle. Columns:
+  Archetype (name + mono id), Category, CTA, Operational twin (template badge +
+  variant), Status (Enabled / Available). Filters: search, Status pills, Category
+  and Twin selects. Summary tiles: Configurations / Enabled / Available /
+  Categories.
+- **`apps/web/components/admin/admin-nav.ts`** — adds the `Archetypes` sub-item and
+  match-prefix to the Configuration family.
+- **`apps/web/lib/ea/route-manifest.json`** — regenerated for the new route.
+
+## Verification
+
+- `pnpm --filter web typecheck` — clean.
+- `pnpm --filter web check:route-manifest` — up to date after regeneration.
+- `deriveTwinProfile` totality over all seeded archetypes is already covered by the
+  merged `packages/storefront-templates/src/twin-profile.test.ts` (P1).
+
+## UX-fit
+
+Recorded as a `UX-Fit-Decision:` attestation on the PR: progressive disclosure via
+a single default-sorted table (Enabled first) with optional facets, zero raw/numeric
+operator inputs, all metric/status rendering delegated to report-kit rather than
+bespoke tiles. See §12 of AGENTS.md.
+
+## Not in scope
+
+Activating/switching the archetype from this view (stays the onboarding flow),
+editing configurations, and the composed-archetype (`StorefrontArchetypeComposition`)
+case — deferred with the framework plan.

--- a/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
+++ b/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
@@ -26,6 +26,14 @@ The pure, DB-free foundation: `deriveTwinProfile(archetype)` picks a template an
 ### Non-physical coverage (this PR)
 The derivation covers all non-physical categories via the board family, and a **board-twin prototype** demonstrates them with the same operating-twin grammar (presence + cog + queues + attributed feed): `docs/superpowers/specs/assets/2026-07-12-living-business-board-twin-prototype.html` — SaaS (TENANTS), professional-services (PIPELINE), nonprofit (PROGRAMS), banking (TENANTS/portfolio), media (PIPELINE/timeline). Tap a queue item → the cog routes it to the best owner by the archetype's signal (health-score/CSM-load, utilization, engagement, banker workload, editor availability) → tap to confirm; humans and AI coworkers act on one shared board with an attributed feed.
 
+## P1.5 — Archetype Catalog admin view · DONE
+
+The first product surface to *consume* `deriveTwinProfile`: a read-only
+`/admin/archetypes` catalog (admin Configuration family) that lists every installed
+archetype configuration — including the ones **not enabled**, which the
+setup-wizard redirect otherwise hides — with each row's derived operational-twin
+template. Plan: [2026-07-12-archetype-catalog-admin-view-execution.md](2026-07-12-archetype-catalog-admin-view-execution.md). Composed from report-kit; no render kit yet (that is P2).
+
 ## P2 — the grammar kit · NEXT
 The ten primitives as React components on the token/report-kit substrate (`apps/web/components/twin/`), lifted from the four prototypes: capacity chips, zone, resource unit, work item (with blocked-on-external state), queue, cog banner, utility band, presence row, attributed feed, needs-you quests. Each rendered through `--dpf-*` tokens, reduced-motion-safe, dynamic text via a safe helper (no innerHTML). A fixture page per primitive. Requires a recorded `UX-Fit-Decision` (§12) for the metric/status components.
 


### PR DESCRIPTION
## Summary

Adds a read-only **Archetype Catalog** at `/admin/archetypes` (admin **Configuration** family) — the central place to see every archetype configuration installed on the platform, **including the ones that have not been enabled**. The setup wizard (`/storefront/setup`) is the only surface that lists the full catalog, and its first line redirects away the moment a `StorefrontConfig` exists — so once a business is live, the not-enabled configurations become invisible. This is an **administrative** view because the archetype is the org's industry SSOT (`StorefrontConfig.archetypeId`) and, through it, drives the operational twin, vocabulary, playbook, and value stream — it affects the entire business. It's also the first product surface to *consume* the merged `deriveTwinProfile` (P1, #2875): each row shows its derived operational-twin template.

## Changes

- **`apps/web/app/(shell)/admin/archetypes/page.tsx`** (server) — lists installed `storefrontArchetype` rows (`isActive`), marks the one **enabled** slug (read via the `config → archetype` relation, since the config's own `archetypeId` column is the cuid FK), joins each row to the canonical `ALL_ARCHETYPES` definition, and runs `deriveTwinProfile` per configuration. Falls back to a definition synthesized from the DB row for any installed leaf with no compiled counterpart.
- **`apps/web/components/admin/ArchetypeCatalogTable.tsx`** (client) — composed entirely from **report-kit** primitives (`StatCard` / `FilterBar` / `DataTable` / `StatusBadge`). Columns: Archetype (name + mono id), Category, CTA, Operational twin (template badge + variant), Status (Enabled / Available). Facets: search, Status pills, Category + Twin selects. Summary tiles: Configurations / Enabled / Available / Categories.
- **`apps/web/components/admin/admin-nav.ts`** — `Archetypes` sub-item + match-prefix in the Configuration family.
- **`apps/web/lib/ea/route-manifest.json`** — regenerated for the new route (546 routes).
- **Plan** `docs/superpowers/plans/2026-07-12-archetype-catalog-admin-view-execution.md` + a P1.5 cross-reference in the parent framework plan.

## Test plan

- [x] **Runtime-bound change** (new `/admin/archetypes` route + client table)
  - [x] `pnpm --filter web typecheck` — clean
  - [x] `pnpm --filter web check:route-manifest` — up to date after regeneration
  - [ ] Functional verification against the canonical runtime — CI (deps unavailable as a full runtime in this worktree; the route renders through the admin layout's `view_admin` guard)

- [x] **Verification-harness limitation acknowledged** — the worktree is source-control isolation, not a full runtime (AGENTS.md §5); `deriveTwinProfile` totality over all seeded archetypes is covered by the merged `packages/storefront-templates/src/twin-profile.test.ts` (P1), which runs in CI Unit Tests.

### Verification evidence

```
$ pnpm --filter web typecheck
✓ Types generated successfully   (tsc --noEmit clean)

$ pnpm --filter web check:route-manifest
[route-manifest] up to date (546 routes)
```

The page inherits the `(shell)/admin` layout guard (`can(..., "view_admin")` → `notFound()` otherwise), so it's admin-gated like every other admin surface. The table is read-only — it never mutates the whole-business archetype setting; switching the live archetype stays the onboarding flow's job.

## Related issues / Epic

- **EP-LIVING-BUSINESS-VIZ** P1.5. Consumes `deriveTwinProfile` from P1 (#2875, merged). Design: [operational-twin-framework](docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md) / [living-business-viz](docs/superpowers/specs/2026-07-11-living-business-workforce-visualization-design.md).

## Overlap sweep

New admin page + client table; no in-flight overlap. Reuses the existing report-kit palette, the admin Configuration nav family, and the merged `deriveTwinProfile` rather than introducing a parallel mechanism. (An existing `/api/storefront/admin/archetypes` API is unrelated — setup-wizard refinement, not a catalog view.)

## Notes for the reviewer

- **UX-Fit-Decision:** read-only reporting surface composed from report-kit primitives (`compose-report-kit-for-reporting-ux`); progressive disclosure via a single Enabled-first table with optional search/status/category/twin facets; zero raw or numeric operator inputs; no bespoke metric/status components. Also recorded as a trailer in the commit message.
- Read-only by design — no activation control here (a whole-business setting stays off a general admin table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ko4H8pkFGNvgnbz5j3wVF8)_