### PR TITLE
fix(self-upgrade): always rebuild the JIT promoter image so promote.sh fixes take effect (BI-8843BD48)

### DIFF
--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildPromoterCommand,
+  decidePromoterEnsureAction,
   isJitBuildablePromoterImage,
   PROMOTER_JIT_BUILD_SCRIPT,
   PROMOTER_TIMEOUT_EXIT_CODE,
@@ -126,6 +127,29 @@ describe("isJitBuildablePromoterImage", () => {
     // building and mis-tagging it locally would masquerade as the real image.
     expect(isJitBuildablePromoterImage("ghcr.io/acme/dpf-promoter:v1")).toBe(false);
     expect(isJitBuildablePromoterImage("dpf-promoter:pinned")).toBe(false);
+  });
+});
+
+describe("decidePromoterEnsureAction", () => {
+  // BI-8843BD48: the promoter bakes promote.sh as its ENTRYPOINT, so a
+  // present-but-stale JIT image runs an OLD promote.sh and silently skips newer
+  // steps (this is why BI-A8686CFC's sandbox-refresh never fired on installs
+  // whose dpf-promoter image predated the fix). A JIT-buildable image must ALWAYS
+  // be rebuilt from the portal's freshly-baked layout — even when one is present.
+  it("rebuilds a JIT-buildable image even when a (possibly stale) one is present", () => {
+    expect(decidePromoterEnsureAction(true, true)).toBe("rebuild");
+  });
+
+  it("rebuilds a JIT-buildable image when none is present", () => {
+    expect(decidePromoterEnsureAction(false, true)).toBe("rebuild");
+  });
+
+  it("uses a present custom/registry image as-is (cannot synthesise someone else's tag)", () => {
+    expect(decidePromoterEnsureAction(true, false)).toBe("use-present");
+  });
+
+  it("cannot build a missing custom/registry image — left to the operator's pull", () => {
+    expect(decidePromoterEnsureAction(false, false)).toBe("cannot-build");
   });
 });
 

--- a/apps/web/lib/self-upgrade/promoter.ts
+++ b/apps/web/lib/self-upgrade/promoter.ts
@@ -257,29 +257,63 @@ export type EnsurePromoterResult = {
 };
 
 /**
- * Make the promoter image present, building it just-in-time if it is missing.
+ * What ensurePromoterImage should do, given whether an image is already present
+ * and whether it is JIT-buildable. Pure so the load-bearing rule is unit-tested
+ * without docker.
+ *
+ * - `rebuild`: JIT-buildable dpf-promoter — ALWAYS rebuild from the portal's
+ *   freshly-baked /promoter/ layout, EVEN when a stale image is present. The
+ *   promoter bakes promote.sh as its ENTRYPOINT (Dockerfile.promoter), so a
+ *   present-but-outdated image runs an OLD promote.sh and silently skips newer
+ *   steps — the BI-8843BD48 bug that let a stale promoter drop BI-A8686CFC's
+ *   sandbox-refresh on installs whose promoter image predated the fix. The image
+ *   is tiny (docker CLI + compose + git + the script), so rebuilding every call
+ *   is negligible and correct-by-construction beats staleness detection.
+ * - `use-present`: a custom/registry image that exists — used as-is (we can't
+ *   synthesise someone else's tag locally).
+ * - `cannot-build`: a custom/registry image that is missing — left to the
+ *   operator's pull.
+ */
+export function decidePromoterEnsureAction(
+  present: boolean,
+  jitBuildable: boolean,
+): "rebuild" | "use-present" | "cannot-build" {
+  if (jitBuildable) return "rebuild";
+  return present ? "use-present" : "cannot-build";
+}
+
+/**
+ * Make the promoter image current, (re)building it just-in-time from the inputs
+ * baked into the portal.
  *
  * This is the self-heal for the `promoter-unavailable` self-upgrade skip and the
  * body of the governed `repair_promoter_image` tool: instead of stranding a
  * non-technical operator with a `docker build` command, the platform builds the
- * image itself from the inputs already baked into the portal. Idempotent — a
- * present image returns `{ ok: true, alreadyPresent: true }` without rebuilding.
+ * image itself. For the JIT-buildable `dpf-promoter` it ALWAYS rebuilds so the
+ * promoter never runs a stale baked promote.sh (BI-8843BD48); a custom/registry
+ * image is used as-is when present and left to the operator's pull when missing.
  * Never throws (mirrors `isPromoterAvailable`); failures surface via `ok:false`
  * + `skipReason` so callers decide whether to skip, fall back, or report.
  */
 export async function ensurePromoterImage(
   promoterImage?: string,
 ): Promise<EnsurePromoterResult> {
-  if (await isPromoterAvailable(promoterImage)) {
+  const present = await isPromoterAvailable(promoterImage);
+  const action = decidePromoterEnsureAction(
+    present,
+    isJitBuildablePromoterImage(promoterImage),
+  );
+
+  if (action === "use-present") {
     return { ok: true, alreadyPresent: true, built: false };
   }
-
   // A custom/registry image can't be synthesised locally — leave it to the
   // operator's pull, and report cleanly so the caller keeps the skip.
-  if (!isJitBuildablePromoterImage(promoterImage)) {
+  if (action === "cannot-build") {
     return { ok: false, alreadyPresent: false, built: false, skipReason: "custom-image" };
   }
 
+  // action === "rebuild": always refresh the JIT-buildable promoter image.
   return await new Promise<EnsurePromoterResult>((resolve) => {
     let settled = false;
     const finish = (r: EnsurePromoterResult): void => {


### PR DESCRIPTION
## What

`Dockerfile.promoter` bakes `scripts/promote.sh` as the `dpf-promoter` image's `ENTRYPOINT`, and the promoter runs that **baked** copy. `ensurePromoterImage()` returned early when a `dpf-promoter` image was already **present** — it JIT-built only when the image was **missing** (the BI-F2C53237 self-heal). So a present-but-stale promoter image kept running an **old** `promote.sh`, and every `promote.sh` fix stayed inert until the image happened to be removed.

## Live evidence (2026-07-12)

A self-upgrade to a target whose **source** `promote.sh` contains the new `sandbox-refresh` step (BI-A8686CFC / #2878) ran to `step=done` but emitted **no** `step=sandbox-refresh` (`health → sha-verify → content-verify → cleanup → done`). The `dpf-promoter` image was dated 2026-07-09 — before #2878 — so it executed the pre-#2878 script. This is the **same stale-image class as BI-A8686CFC, one level up**, and it silently defeats #2878 itself (**BI-8843BD48**).

## Fix

Kernel-decided (`principle_decide`, **margin 2.88** — same always-rebuild rationale as #2878). Extract `decidePromoterEnsureAction(present, jitBuildable)`: for a JIT-buildable `dpf-promoter` it returns `"rebuild"` **even when a present image exists**, so the promoter is always rebuilt from the portal's freshly-baked `/promoter/` layout and always carries the current `promote.sh`. The image is tiny (docker CLI + compose + git + the script) so the rebuild is negligible; a custom/registry image is still used as-is when present and left to the operator's pull when missing. The `repair_promoter_image` tool now honestly reports "Built" rather than "already present" on a stale image.

## Verification

- Pure decision helper unit-tested (docker not required): rebuild-when-present, rebuild-when-missing, use-present-custom, cannot-build-missing-custom (23 tests green).
- `web` typecheck green; local pregate passed.
- Callers (`promotions.ts:447` self-upgrade path, `:902` repair tool) verified: `:447` only checks `.ok`; the repair tool's `alreadyPresent` branch now correctly reports the rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
