### PR TITLE
test(work-mgmt): kill the mcp-tools-backlog teardown race from the AC815F1E bridge

### DIFF
--- a/apps/web/lib/mcp-tools-backlog.test.ts
+++ b/apps/web/lib/mcp-tools-backlog.test.ts
@@ -72,6 +72,17 @@ vi.mock("@/lib/integrate/ideate-on-approval", () => ({
   dispatchIdeateForApprovedBuild: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Same detached-async hazard as above: every backlog status transition now fires
+// a fire-and-forget `void (async () => …)()` that bridges the item to a WorkItem
+// (EP-WORK-CONVERGENCE / BI-AC815F1E). With the real bridge in place that promise
+// rejects under the mocked prisma and console.warns *after* the test returns —
+// surfacing during worker teardown as the intermittent
+// "Closing rpc while \"onUserConsoleLog\" was pending" EnvironmentTeardownError.
+// Stubbing the bridge makes the detached promise resolve quietly.
+vi.mock("@/lib/queue/bridges/backlog-bridge", () => ({
+  bridgeBacklogItemToWorkItem: vi.fn().mockResolvedValue(null),
+}));
+
 import { executeTool } from "./mcp-tools";
 
 describe("backlog MCP tool execution", () => {

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -39,11 +39,9 @@ apps/web/lib/integrate/build-agent-prompts.ts	1054
 apps/web/lib/integrate/build-orchestrator.ts	1780
 apps/web/lib/integrate/sandbox/build-branch.ts	854
 apps/web/lib/marketing.ts	1367
-apps/web/lib/mcp-tools-backlog.test.ts	901
+apps/web/lib/mcp-tools-backlog.test.ts	912
 apps/web/lib/mcp-tools.ts	7560
 apps/web/lib/mcp/packs/backlog-pack.ts	1382
-apps/web/lib/mcp-tools.ts	9466
-apps/web/lib/mcp/packs/backlog-pack.ts	1380
 apps/web/lib/navigation/portal-navigation-model.ts	937
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1328


### PR DESCRIPTION
## Problem
BI-AC815F1E (#2850) broadened the backlog→WorkItem bridge to fire on **every** status transition via a detached `void (async () => …)()`. Under `mcp-tools-backlog.test.ts`'s mocked prisma that promise rejects and `console.warn`s **after** the test returns, surfacing intermittently during worker teardown as `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending` — which **exits vitest non-zero even though all 3822 tests pass**. It flaked #2859 and will intermittently flake `main` CI.

## Fix
Stub `@/lib/queue/bridges/backlog-bridge` in the test so the detached promise resolves quietly — the exact pattern the file **already** uses for `promote_to_build_studio`'s ideate dispatch (see the adjacent `ideate-on-approval` mock).

## Verification
`mcp-tools-backlog.test.ts`: 21 tests pass, **no unhandled/teardown error**. Typecheck clean. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)