### PR TITLE
feat(work-mgmt): render the Build Studio customer-mode status band (EP-WORK-CONVERGENCE, BI-BB13B599)

### DIFF
--- a/apps/web/app/(shell)/build/page.tsx
+++ b/apps/web/app/(shell)/build/page.tsx
@@ -7,6 +7,7 @@ import { businessBuildBriefFromRecord } from "@/lib/build/business-build-brief";
 import { BuildStudio } from "@/components/build/BuildStudio";
 import { BuildStudioV2 } from "@/components/build-studio/BuildStudioV2";
 import { loadBuildStudioCapability } from "@/lib/build/build-studio-capability";
+import { loadBuildStudioCustomerStatuses } from "@/lib/build/customer-status-loader";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
 import { can } from "@/lib/govern/permissions";
 import { EnableRunnerButton } from "@/components/build/EnableRunnerButton";
@@ -229,6 +230,18 @@ export default async function BuildPage({ searchParams }: PageProps) {
   const initialActiveBuild = buildId && !builds.some((build) => build.buildId === buildId)
     ? await getFeatureBuildById(buildId)
     : null;
+  // BI-BB13B599: project each build (+ any out-of-list initial build) into its
+  // plain, capsule-derived customer-mode status so BuildStudio can render the
+  // first-viewport "wife-test" status band without pulling the projection into
+  // the client bundle.
+  const customerStatuses = await loadBuildStudioCustomerStatuses(
+    prisma,
+    [...builds, ...(initialActiveBuild ? [initialActiveBuild] : [])].map((build) => ({
+      id: build.id,
+      title: build.title,
+      phase: build.phase,
+    })),
+  );
   const portalContext = await resolvePortalContextEnvelope(
     {
       pathname: "/build",
@@ -272,6 +285,7 @@ export default async function BuildPage({ searchParams }: PageProps) {
         initialBuildId={buildId}
         portalContext={portalContext}
         initialActiveBuild={initialActiveBuild}
+        customerStatuses={customerStatuses}
       />
     </section>
   );

--- a/apps/web/components/build/BuildCustomerStatusBand.test.tsx
+++ b/apps/web/components/build/BuildCustomerStatusBand.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { BuildCustomerStatusBand } from "./BuildCustomerStatusBand";
+import type { BuildStudioCustomerStatus } from "@/lib/build/customer-status-projection";
+
+// BI-BB13B599 — render checks via renderToStaticMarkup (band-test convention).
+
+function status(over: Partial<BuildStudioCustomerStatus> = {}): BuildStudioCustomerStatus {
+  return {
+    whatIsBeingBuilt: "Add invoicing",
+    lifecyclePosition: "In progress",
+    worker: "Work in progress",
+    needsYou: false,
+    ...over,
+  };
+}
+
+describe("BuildCustomerStatusBand", () => {
+  it("renders the plain lifecycle position and worker phrasing", () => {
+    const html = renderToStaticMarkup(<BuildCustomerStatusBand status={status()} />);
+    expect(html).toContain("In progress");
+    expect(html).toContain("Work in progress");
+  });
+
+  it("shows the 'Needs you' pill only when the work needs the operator", () => {
+    const withPill = renderToStaticMarkup(<BuildCustomerStatusBand status={status({ needsYou: true })} />);
+    expect(withPill).toContain("Needs you");
+
+    const withoutPill = renderToStaticMarkup(<BuildCustomerStatusBand status={status({ needsYou: false })} />);
+    expect(withoutPill).not.toContain("Needs you");
+  });
+
+  it("never leaks an executor name — worker phrasing is business-safe", () => {
+    const html = renderToStaticMarkup(<BuildCustomerStatusBand status={status()} />);
+    expect(html).not.toMatch(/claude|codex|grok/i);
+  });
+});

--- a/apps/web/components/build/BuildCustomerStatusBand.tsx
+++ b/apps/web/components/build/BuildCustomerStatusBand.tsx
@@ -1,0 +1,33 @@
+// BI-BB13B599 (EP-WORK-CONVERGENCE): the plain, business-safe customer-mode
+// status band. Reads the capsule-derived projection (projectBuildStudioCustomerStatus)
+// so external Claude/Codex/Grok work carried on the WorkCapsule is reflected in
+// one plain lifecycle line — never a raw phase, never an executor name. This is
+// the first-viewport "wife-test" status: what is being built, where it is, and
+// whether it needs the operator.
+import type { BuildStudioCustomerStatus } from "@/lib/build/customer-status-projection";
+
+const NEEDS_YOU_PILL =
+  "inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold leading-none " +
+  "border-[var(--dpf-warning)] bg-[var(--dpf-state-warning)] text-[var(--dpf-warning)]";
+
+export function BuildCustomerStatusBand({ status }: { status: BuildStudioCustomerStatus }) {
+  return (
+    <div
+      className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-4 py-3"
+      data-testid="build-customer-status-band"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="m-0 text-[11px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">Status</p>
+          <p className="m-0 mt-0.5 text-sm font-semibold text-[var(--dpf-text)]">{status.lifecyclePosition}</p>
+          <p className="m-0 mt-0.5 text-xs text-[var(--dpf-muted)]">{status.worker}</p>
+        </div>
+        {status.needsYou && (
+          <span className={NEEDS_YOU_PILL} data-testid="build-customer-status-needs-you">
+            Needs you
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -39,6 +39,8 @@ import { deriveBuildStudioCustodianPrompt, type BuildStudioCustodianPrompt } fro
 import { BuildDecisionLedgerBand } from "./BuildDecisionLedgerBand";
 import { BuildChangeSummaryBand } from "./BuildChangeSummaryBand";
 import { BuildSolutionSummaryBand } from "./BuildSolutionSummaryBand";
+import { BuildCustomerStatusBand } from "./BuildCustomerStatusBand";
+import type { BuildStudioCustomerStatus } from "@/lib/build/customer-status-projection";
 import { BuildOperatorHeaderDetails, BuildWorkRequestStrip, formatOperatorPhaseLabel } from "./BuildOperatorContext";
 import { resolveBuildStudioBranchBadge } from "./build-studio-branch-badge";
 import { createFeatureBuild, deleteFeatureBuild } from "@/lib/actions/build";
@@ -89,6 +91,13 @@ type Props = {
   initialBuildId?: string | null;
   portalContext?: PortalContextEnvelope | null;
   initialActiveBuild?: FeatureBuildRow | null;
+  /**
+   * BI-BB13B599: plain, capsule-derived customer-mode status per build, keyed by
+   * the build's cuid `id`. Projected server-side so the active build's status
+   * band reads the WorkCapsule projection (capturing external Claude/Codex/Grok
+   * work) without pulling the projection into the client bundle.
+   */
+  customerStatuses?: Record<string, BuildStudioCustomerStatus>;
 };
 
 const MISSING_BOM_SUMMARY: BomSummary = {
@@ -162,6 +171,7 @@ export function BuildStudio({
   initialBuildId,
   portalContext,
   initialActiveBuild,
+  customerStatuses = {},
 }: Props) {
   const router = useRouter();
   const buildRows = Array.isArray(builds) ? builds : [];
@@ -836,6 +846,15 @@ export function BuildStudio({
                   </div>
                 </div>
               </div>
+
+              {/* BI-BB13B599: plain customer-mode status band — the first-viewport
+                  "wife-test" line. Reads the capsule projection so external
+                  Claude/Codex/Grok work is reflected in one plain lifecycle
+                  status, never a raw phase or executor name. Always visible
+                  (not behind engineer view). */}
+              {customerStatuses[activeBuild.id] && (
+                <BuildCustomerStatusBand status={customerStatuses[activeBuild.id]} />
+              )}
 
               {/* Error banner for failed builds */}
               {activeBuild.phase === "failed" && (

--- a/apps/web/lib/build/customer-status-loader.test.ts
+++ b/apps/web/lib/build/customer-status-loader.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { loadBuildStudioCustomerStatuses } from "@/lib/build/customer-status-loader";
+
+function dbWith(rows: Array<{ featureBuildId: string | null; capsuleId: string; status: string }>) {
+  const findMany = vi.fn().mockResolvedValue(rows);
+  return { db: { workCapsule: { findMany } }, findMany };
+}
+
+describe("loadBuildStudioCustomerStatuses (BI-BB13B599)", () => {
+  it("projects the capsule-derived status when a capsule is linked to the build", async () => {
+    const { db, findMany } = dbWith([
+      { featureBuildId: "cuid-1", capsuleId: "WC-1", status: "working" },
+    ]);
+
+    const statuses = await loadBuildStudioCustomerStatuses(db, [
+      { id: "cuid-1", title: "Add invoicing", phase: "build" },
+    ]);
+
+    // queried by the cuid ids
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { featureBuildId: { in: ["cuid-1"] } } }),
+    );
+    // a "working" capsule projects to the active WorkCase state — not the
+    // phase-only fallback ("Building it") — proving the capsule path is taken.
+    expect(statuses["cuid-1"]).toEqual(
+      expect.objectContaining({ whatIsBeingBuilt: "Add invoicing", lifecyclePosition: "In progress" }),
+    );
+  });
+
+  it("surfaces needsYou from the capsule projection when the capsule is blocked", async () => {
+    const { db } = dbWith([
+      { featureBuildId: "cuid-b", capsuleId: "WC-B", status: "blocked" },
+    ]);
+
+    const statuses = await loadBuildStudioCustomerStatuses(db, [
+      { id: "cuid-b", title: "Wire webhook", phase: "build" },
+    ]);
+
+    expect(statuses["cuid-b"].needsYou).toBe(true);
+  });
+
+  it("degrades to the phase-only fallback when no capsule is linked", async () => {
+    const { db } = dbWith([]);
+
+    const statuses = await loadBuildStudioCustomerStatuses(db, [
+      { id: "cuid-2", title: "Fix login", phase: "failed" },
+    ]);
+
+    expect(statuses["cuid-2"]).toEqual(
+      expect.objectContaining({
+        whatIsBeingBuilt: "Fix login",
+        lifecyclePosition: "Hit a problem",
+        needsYou: true,
+      }),
+    );
+  });
+
+  it("returns an empty map and skips the query when there are no builds", async () => {
+    const { db, findMany } = dbWith([]);
+
+    const statuses = await loadBuildStudioCustomerStatuses(db, []);
+
+    expect(statuses).toEqual({});
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("dedupes build ids before querying", async () => {
+    const { db, findMany } = dbWith([]);
+
+    await loadBuildStudioCustomerStatuses(db, [
+      { id: "cuid-3", title: "A", phase: "plan" },
+      { id: "cuid-3", title: "A", phase: "plan" },
+    ]);
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { featureBuildId: { in: ["cuid-3"] } } }),
+    );
+  });
+});

--- a/apps/web/lib/build/customer-status-loader.ts
+++ b/apps/web/lib/build/customer-status-loader.ts
@@ -1,0 +1,61 @@
+// BI-BB13B599 (EP-WORK-CONVERGENCE): server loader that fetches the WorkCapsule
+// linked to each Build Studio build (WorkCapsule.featureBuildId === FeatureBuild.id,
+// set on every build via attachBuildStudioWorkCapsule) and projects each into the
+// plain, business-safe customer-mode status. Returns a map keyed by the build's
+// cuid `id` so the client can look up the active build's status without pulling
+// the capsule projection into the client bundle. Pure aside from the single
+// findMany — unit-testable with a mock delegate.
+import type { BuildPhase } from "@/lib/explore/feature-build-types";
+import {
+  projectBuildStudioCustomerStatus,
+  type BuildStudioCustomerStatus,
+} from "@/lib/build/customer-status-projection";
+
+interface CapsuleFindManyDelegate {
+  workCapsule: {
+    findMany: (args: {
+      where: { featureBuildId: { in: string[] } };
+      select: { featureBuildId: true; capsuleId: true; status: true };
+    }) => Promise<Array<{ featureBuildId: string | null; capsuleId: string; status: string }>>;
+  };
+}
+
+/** Minimal build shape the projection needs — the cuid id, title, and phase. */
+export interface CustomerStatusBuild {
+  id: string;
+  title: string;
+  phase: BuildPhase;
+}
+
+/**
+ * Fetch the linked capsule for each build in one query and project each build
+ * into its plain customer-mode status. Builds with no linked capsule degrade to
+ * the phase-only fallback inside projectBuildStudioCustomerStatus.
+ */
+export async function loadBuildStudioCustomerStatuses(
+  db: CapsuleFindManyDelegate,
+  builds: ReadonlyArray<CustomerStatusBuild>,
+): Promise<Record<string, BuildStudioCustomerStatus>> {
+  const ids = Array.from(new Set(builds.map((b) => b.id)));
+  const byBuild = new Map<string, { capsuleId: string; status: string }>();
+  if (ids.length > 0) {
+    const capsules = await db.workCapsule.findMany({
+      where: { featureBuildId: { in: ids } },
+      select: { featureBuildId: true, capsuleId: true, status: true },
+    });
+    for (const capsule of capsules) {
+      if (capsule.featureBuildId) {
+        byBuild.set(capsule.featureBuildId, { capsuleId: capsule.capsuleId, status: capsule.status });
+      }
+    }
+  }
+
+  const statuses: Record<string, BuildStudioCustomerStatus> = {};
+  for (const build of builds) {
+    statuses[build.id] = projectBuildStudioCustomerStatus({
+      build: { title: build.title, phase: build.phase },
+      capsule: byBuild.get(build.id) ?? null,
+    });
+  }
+  return statuses;
+}

--- a/docs/superpowers/plans/2026-07-11-bi-bb13b599-bs-customer-status-plan.md
+++ b/docs/superpowers/plans/2026-07-11-bi-bb13b599-bs-customer-status-plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan — BI-BB13B599: Build Studio customer-mode status from the capsule projection
 
-**BI:** BI-BB13B599 (epic EP-WORK-CONVERGENCE) · **Date:** 2026-07-11 · **Status:** Pure projection slice implemented; render wiring deferred (live-portal).
+**BI:** BI-BB13B599 (epic EP-WORK-CONVERGENCE) · **Date:** 2026-07-11 (render delivered 2026-07-12) · **Status:** DELIVERED — pure projection slice (#2857) + render wiring (this PR).
 
 ## Gap
 Build Studio's bands read `FeatureBuild.phase` directly (`BuildStudio.tsx`) and are blind to the WorkCapsule projection, so external Claude/Codex/Grok progress carried on the capsule is invisible in customer mode.
@@ -12,6 +12,10 @@ Build Studio's bands read `FeatureBuild.phase` directly (`BuildStudio.tsx`) and 
 ## Verification
 - 7 unit tests (capsule status → plain state/needsYou; phase-only fallback; failed→needs-you; business-safety guard). Typecheck clean (0 errors post-typegen). No DB, no React.
 
-## Deferred (needs live-portal verification, per operator — validate at epic completion)
-- The server-side fetch `workCapsule.findFirst({ where: { featureBuildId: build.id } })` (join precedent: `evidence-timeline.ts:168`).
-- Rendering the customer status in `BuildStudio.tsx` (band/rail).
+## Render slice (delivered 2026-07-12)
+- `apps/web/lib/build/customer-status-loader.ts` — `loadBuildStudioCustomerStatuses(db, builds)` fetches every linked capsule in one `workCapsule.findMany({ where: { featureBuildId: { in } }})` (the capsule is attached to every build via `attachBuildStudioWorkCapsule`, `build.ts:112`) and projects each build into its plain status, keyed by the build's cuid `id`. Server-side so the projection never enters the client bundle. 5 unit tests (capsule path, phase-only fallback, empty, dedupe, needsYou-from-blocked).
+- `apps/web/components/build/BuildCustomerStatusBand.tsx` — the plain first-viewport band: lifecycle line + business-safe worker phrasing + a "Needs you" pill. Always visible (not behind engineer view). 3 render tests (renderToStaticMarkup; needs-you pill conditional; no executor-name leak).
+- `app/(shell)/build/page.tsx` — computes `customerStatuses` server-side and passes it to `<BuildStudio>`; `BuildStudio.tsx` renders `<BuildCustomerStatusBand>` for the active build right below the header.
+
+## Verification
+- Pure/loader/band: 15 unit tests total across projection + loader + band. `apps/web` typecheck clean (0 errors post-typegen). Live-validated on the Contributor preview (:3001): the customer status band renders the plain lifecycle line + business-safe worker phrasing for the active build, with no executor name or raw phase leaking.


### PR DESCRIPTION
## What
Wires the merged pure projection (`projectBuildStudioCustomerStatus`, #2857) into Build Studio's UI — the deferred render slice of BI-BB13B599. Build Studio's bands read `FeatureBuild.phase` directly and were blind to the WorkCapsule projection; this surfaces one plain, capsule-derived customer-mode status as the first-viewport "wife-test" band.

## Changes
- **`lib/build/customer-status-loader.ts`** — `loadBuildStudioCustomerStatuses(db, builds)` fetches every linked capsule in one `workCapsule.findMany({ where: { featureBuildId: { in } } })` (a capsule is attached to every build via `attachBuildStudioWorkCapsule`) and projects each build to a plain status keyed by the build's cuid `id`. Runs server-side so the projection never enters the client bundle.
- **`components/build/BuildCustomerStatusBand.tsx`** — the plain band: lifecycle line + business-safe worker phrasing + a "Needs you" pill. Always visible (not behind engineer view). Business-safe by construction — the executor is never in the projection signature, so no "Claude/Codex/Grok" can leak to the customer view.
- **`app/(shell)/build/page.tsx`** — computes `customerStatuses` server-side and passes it to `<BuildStudio>`, which renders the band below the header for the active build.

## Verification
- 15 unit tests green across projection + loader + band (loader: capsule path / phase-only fallback / empty / dedupe / needsYou-from-blocked; band: render / conditional pill / no-executor-leak). `apps/web` typecheck clean (0 errors post-typegen). Module-size clean.
- **Live-validated on the Contributor preview (:3001)** against real data — build `FB-4591D1EB` (capsule status `working`): the band renders **"In progress / Work in progress"** below the header, no raw phase or executor name.

Plan: `docs/superpowers/plans/2026-07-11-bi-bb13b599-bs-customer-status-plan.md`.

**Local-CI-Override:** Verified locally (15 tests, tsc clean post-typegen, module-size clean) and live-validated on :3001. Local-CI `next build` OOMs (env limit); GitHub Production Build authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)