### PR TITLE
fix(build): stop a code comment from breaking the dev-portal CSS build

### DIFF
--- a/apps/web/lib/build/ui-quality-checks.ts
+++ b/apps/web/lib/build/ui-quality-checks.ts
@@ -38,8 +38,9 @@ export type UiQualityReport = {
 // rare in generated code; we scan raw source lines.
 const HEX_RE = /#[0-9a-fA-F]{3,8}\b/;
 // Tailwind color utility with a numeric shade: bg-green-400, text-red-500,
-// border-slate-200, ring-blue-600, from-indigo-500. Excludes token classes like
-// bg-[var(--dpf-...)] and semantic non-color utilities.
+// border-slate-200, ring-blue-600, from-indigo-500. Excludes DPF token classes
+// (arbitrary-value utilities that reference the var(--dpf-*) design tokens) and
+// semantic non-color utilities.
 const TW_COLOR_RE = /\b(?:bg|text|border|ring|from|to|via|fill|stroke|divide|outline|decoration|shadow|caret|accent|placeholder)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|grey|zinc|neutral|stone)-\d{2,3}\b/;
 // Inline rgb/rgba/hsl literal.
 const RGB_RE = /\b(?:rgba?|hsla?)\s*\(/;


### PR DESCRIPTION
## Problem
The Contributor preview (`:3001`) 500s on **every page** with a CSS parse error:

```
./apps/web/app/globals.css:2458:33  Parsing CSS source code failed
  background-color: var(--dpf-...);   Unexpected token Delim('.')
```

## Root cause
A comment in `apps/web/lib/build/ui-quality-checks.ts` (added by #2881) contained the literal string `bg-[var(--dpf-...)]`. Tailwind v4's dev content scanner extracts arbitrary-value utility classes from **all** scanned source text — comments included — so it generated `.bg-[var(--dpf-...)] { background-color: var(--dpf-...) }`. `var(--dpf-...)` (literal ellipsis) is invalid CSS and fails PostCSS parsing, taking down the whole stylesheet.

The Live portal (`:3000`) is unaffected because it serves a pre-built production image; only the dev hot-reload scanner hits this.

## Fix
Reword the comment so it no longer contains an extractable `bg-[…]` token. No behavior change — the module is a pure static scanner and only a comment changed. Verified by a clean `:3001` recompile (page renders 200; CSS error gone).

**Local-CI-Override:** Comment-only change; verified by a clean dev-portal CSS recompile on :3001. Local-CI `next build` OOMs (env limit); GitHub Production Build authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)