### PR TITLE
fix(founder-review): clarify action queue intent

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/page.tsx
@@ -7,7 +7,7 @@
 // Server component; queries Prisma directly.
 
 import Link from "next/link";
-import { prisma } from "@dpf/db";
+import { Prisma, prisma } from "@dpf/db";
 
 import { WikiPageList, type WikiPageListItem } from "@/components/wiki/WikiPageList";
 import { DecisionDisciplineHub } from "@/components/wiki/DecisionDisciplineHub";
@@ -18,6 +18,13 @@ import {
 } from "@/lib/decision/caller-context";
 import { resolveOrgProfileId } from "@/lib/decision-perspective/material";
 import { PROFESSION_REGISTRY } from "@/lib/decision-perspective/resolve-profession-profile";
+import {
+  dedupeFounderReviewCandidates,
+  isAgentInternalFounderReviewNoise,
+  isBlankFounderReviewQuestion,
+  projectFounderReviewCandidate,
+  type DecisionInteractionQueueRow,
+} from "@/lib/founder-review/queue";
 
 export const dynamic = "force-dynamic";
 
@@ -31,6 +38,49 @@ type SearchParams = Promise<{
 }>;
 
 const UNRESOLVED = ["defer", "escalate"];
+
+function openDecisionReviewWhere(
+  profileId?: Prisma.DecisionInteractionWhereInput["profileId"],
+): Prisma.DecisionInteractionWhereInput {
+  return {
+    outcomeType: { in: UNRESOLVED },
+    humanOutcome: { equals: Prisma.DbNull },
+    question: { not: "" },
+    NOT: [
+      {
+        buildId: null,
+        taskRunId: null,
+        OR: [
+          { routeContext: { startsWith: "mcp:principle_decide" } },
+          { domainClass: "kernel-consult" },
+        ],
+      },
+    ],
+    ...(profileId !== undefined ? { profileId } : {}),
+  };
+}
+
+const openDecisionReviewSelect = {
+  interactionId: true,
+  question: true,
+  options: true,
+  outcomeType: true,
+  outcomePayload: true,
+  buildId: true,
+  taskRunId: true,
+  routeContext: true,
+  domainClass: true,
+  createdAt: true,
+  profile: { select: { profileId: true, name: true, kind: true } },
+} satisfies Prisma.DecisionInteractionSelect;
+
+function countUniqueOpenReviews(rows: DecisionInteractionQueueRow[]): number {
+  const candidates = rows
+    .filter((row) => !isBlankFounderReviewQuestion(row))
+    .filter((row) => !isAgentInternalFounderReviewNoise(row))
+    .map((row) => projectFounderReviewCandidate(row));
+  return dedupeFounderReviewCandidates(candidates).length;
+}
 
 export default async function WikiBrowsePage({
   searchParams,
@@ -79,10 +129,10 @@ export default async function WikiBrowsePage({
     kernelPrincipleCount,
     kernelHeuristicCount,
     orgStanceMaterialCount,
-    wwmdOpenReviews,
-    wwwdOpenReviews,
+    wwmdOpenReviewRows,
+    wwwdOpenReviewRows,
     wsidActiveProfiles,
-    wsidOpenReviews,
+    wsidOpenReviewRows,
     wwmdDecisions30d,
     wwwdDecisions30d,
     wsidDecisions30d,
@@ -120,17 +170,20 @@ export default async function WikiBrowsePage({
     prisma.perspectiveMaterial.count({
       where: { profileId: { in: wwwdProfileIds } },
     }),
-    prisma.decisionInteraction.count({
-      where: { outcomeType: { in: UNRESOLVED }, profileId: WWMD_PLATFORM_PROFILE_ID },
+    prisma.decisionInteraction.findMany({
+      where: openDecisionReviewWhere(WWMD_PLATFORM_PROFILE_ID),
+      select: openDecisionReviewSelect,
     }),
-    prisma.decisionInteraction.count({
-      where: { outcomeType: { in: UNRESOLVED }, profileId: { in: wwwdProfileIds } },
+    prisma.decisionInteraction.findMany({
+      where: openDecisionReviewWhere({ in: wwwdProfileIds }),
+      select: openDecisionReviewSelect,
     }),
     prisma.decisionPerspectiveProfile.count({
       where: { kind: "profession", status: "active" },
     }),
-    prisma.decisionInteraction.count({
-      where: { outcomeType: { in: UNRESOLVED }, profileId: { startsWith: "wsid-" } },
+    prisma.decisionInteraction.findMany({
+      where: openDecisionReviewWhere({ startsWith: "wsid-" }),
+      select: openDecisionReviewSelect,
     }),
     // Ledger usage per tier (30d) — the audit signal behind each card's
     // usage chip; a zero surfaces "no decisions recorded" so a dormant gate
@@ -145,6 +198,10 @@ export default async function WikiBrowsePage({
       where: { profile: { kind: "profession" }, createdAt: { gte: decisionWindow } },
     }),
   ]);
+
+  const wwmdOpenReviews = countUniqueOpenReviews(wwmdOpenReviewRows as DecisionInteractionQueueRow[]);
+  const wwwdOpenReviews = countUniqueOpenReviews(wwwdOpenReviewRows as DecisionInteractionQueueRow[]);
+  const wsidOpenReviews = countUniqueOpenReviews(wsidOpenReviewRows as DecisionInteractionQueueRow[]);
 
   const disciplineCards = buildDisciplineCards({
     kernelPrincipleCount,

--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
@@ -297,7 +297,7 @@ export default async function AgentDetailPage({
             { label: "Model & priority grid", href: "/platform/ai/assignments" },
             { label: "Authority & audit", href: "/platform/audit" },
             ...(profession.profileId
-              ? [{ label: "Decision review inbox", href: `/platform/ai/founder-review?profile=${profession.profileId}` }]
+              ? [{ label: "Open Needs you", href: "/workspace/inbox" }]
               : []),
           ]}
         />

--- a/apps/web/app/(shell)/platform/ai/founder-review/page.test.tsx
+++ b/apps/web/app/(shell)/platform/ai/founder-review/page.test.tsx
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
 vi.mock("@dpf/db", () => ({
+  Prisma: {
+    DbNull: "DbNull",
+  },
   prisma: {
     decisionInteraction: {
       findMany: vi.fn(),
@@ -33,6 +36,7 @@ describe("FounderReviewPage", () => {
         buildId: "FB-1",
         taskRunId: "TR-1",
         routeContext: "/build",
+        domainClass: "plan-readiness",
         createdAt: new Date("2026-05-26T12:00:00.000Z"),
         profile: {
           profileId: "profile-mark",
@@ -46,6 +50,18 @@ describe("FounderReviewPage", () => {
     const html = renderToStaticMarkup(await FounderReviewPage({}));
 
     expect(html).toContain("Founder Review");
+    expect(html).toContain("Open Needs you");
+    expect(html).toContain('href="/workspace/inbox"');
+    expect(html).toContain("Where work lives");
+    expect(html).toContain("You do not need to patrol every queue");
+    expect(html).toContain("My queue");
+    expect(html).toContain('href="/workspace/my-queue"');
+    expect(html).toContain("Build Studio");
+    expect(html).toContain('href="/build"');
+    expect(html).toContain("Decision Governance");
+    expect(html).toContain('href="/coworker-decisions/review"');
+    expect(html).toContain("These cards are created when an AI decision is deferred or escalated");
+    expect(html).toContain("Showing 1 distinct review item from 1 unresolved AI decision row");
     expect(html).toContain("Principle gap");
     expect(html).toContain("Clarify founder principle");
     expect(html).toContain("Should the interface hide raw traces?");
@@ -53,13 +69,25 @@ describe("FounderReviewPage", () => {
     expect(html).toContain('href="/platform/ai/decisions/DI-1"');
     expect(html).toContain('href="/build?buildId=FB-1"');
     expect(html).toContain('href="/platform/ai/history?taskRunId=TR-1"');
-    expect(html).toContain("Record outcome");
-    expect(html).toContain("WWMD MCP Sprint 1");
+    expect(html).toContain("Review evidence");
+    expect(html).not.toContain("Record outcome");
+    expect(html).not.toContain("WWMD MCP Sprint 1");
     expect(html).not.toContain("DecisionInteraction");
     expect(html).not.toContain("outcomePayload");
     expect(html).not.toContain("principle_decide");
     expect(html).not.toContain("dpf-compare-options");
     expect(html).not.toContain("mcp");
+    expect(prisma.decisionInteraction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          outcomeType: { in: ["defer", "escalate"] },
+          humanOutcome: { equals: "DbNull" },
+        }),
+        select: expect.objectContaining({
+          domainClass: true,
+        }),
+      }),
+    );
   });
 
   it("renders owner/operator wording for WWWD review cards", async () => {
@@ -73,6 +101,7 @@ describe("FounderReviewPage", () => {
         buildId: null,
         taskRunId: null,
         routeContext: "/storefront",
+        domainClass: "risk-assessment",
         createdAt: new Date("2026-05-26T12:00:00.000Z"),
         profile: {
           profileId: "profile-org",
@@ -94,5 +123,108 @@ describe("FounderReviewPage", () => {
     expect(html).toContain("Clarify operating policy");
     expect(html).toContain('href="/platform/ai/decisions/DI-ORG"');
     expect(html).not.toContain("Clarify founder principle");
+  });
+
+  it("suppresses blank rows and agent-internal kernel consults in the visible lens", async () => {
+    vi.mocked(prisma.decisionInteraction.findMany).mockResolvedValue([
+      {
+        interactionId: "DI-BLANK",
+        question: "   ",
+        options: [],
+        outcomeType: "escalate",
+        outcomePayload: { unresolvedReason: "principle-gap" },
+        buildId: null,
+        taskRunId: null,
+        routeContext: "/coworker-business",
+        domainClass: "risk-assessment",
+        createdAt: new Date("2026-05-26T12:00:00.000Z"),
+        profile: null,
+      },
+      {
+        interactionId: "DI-KERNEL",
+        question: "Should an internal kernel consult show here?",
+        options: [],
+        outcomeType: "escalate",
+        outcomePayload: { unresolvedReason: "principle-gap" },
+        buildId: null,
+        taskRunId: null,
+        routeContext: "mcp:principle_decide",
+        domainClass: "kernel-consult",
+        createdAt: new Date("2026-05-26T12:00:00.000Z"),
+        profile: null,
+      },
+      {
+        interactionId: "DI-REAL",
+        question: "Should the owner change the refund policy?",
+        options: ["Change", "Keep"],
+        outcomeType: "escalate",
+        outcomePayload: { unresolvedReason: "principle-gap" },
+        buildId: null,
+        taskRunId: null,
+        routeContext: "/coworker-business",
+        domainClass: "risk-assessment",
+        createdAt: new Date("2026-05-26T12:00:00.000Z"),
+        profile: {
+          profileId: "profile-org",
+          name: "WWWD Organization",
+          kind: "organization",
+        },
+      },
+    ] as never);
+
+    const { default: FounderReviewPage } = await import("./page");
+    const html = renderToStaticMarkup(await FounderReviewPage({}));
+
+    expect(html).toContain("Should the owner change the refund policy?");
+    expect(html).not.toContain("Should an internal kernel consult show here?");
+    expect(html).not.toContain("DI-BLANK");
+    expect(html).toContain("1 waiting");
+  });
+
+  it("deduplicates repeated open reviews with the same question and profile", async () => {
+    vi.mocked(prisma.decisionInteraction.findMany).mockResolvedValue([
+      {
+        interactionId: "DI-DUP-NEW",
+        question: "Should we prioritize fixing quality issues?",
+        options: ["Yes", "No"],
+        outcomeType: "escalate",
+        outcomePayload: { unresolvedReason: "principle-gap" },
+        buildId: null,
+        taskRunId: null,
+        routeContext: "/coworker-business",
+        domainClass: "risk-assessment",
+        createdAt: new Date("2026-05-27T12:00:00.000Z"),
+        profile: {
+          profileId: "profile-org",
+          name: "WWWD Organization",
+          kind: "organization",
+        },
+      },
+      {
+        interactionId: "DI-DUP-OLD",
+        question: "  Should we prioritize fixing quality issues?  ",
+        options: ["Yes", "No"],
+        outcomeType: "escalate",
+        outcomePayload: { unresolvedReason: "principle-gap" },
+        buildId: null,
+        taskRunId: null,
+        routeContext: "/coworker-business",
+        domainClass: "risk-assessment",
+        createdAt: new Date("2026-05-26T12:00:00.000Z"),
+        profile: {
+          profileId: "profile-org",
+          name: "WWWD Organization",
+          kind: "organization",
+        },
+      },
+    ] as never);
+
+    const { default: FounderReviewPage } = await import("./page");
+    const html = renderToStaticMarkup(await FounderReviewPage({}));
+
+    expect(html).toContain("Should we prioritize fixing quality issues?");
+    expect(html).toContain('href="/platform/ai/decisions/DI-DUP-NEW"');
+    expect(html).not.toContain("DI-DUP-OLD");
+    expect(html).toContain("1 waiting");
   });
 });

--- a/apps/web/app/(shell)/platform/ai/founder-review/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/founder-review/page.tsx
@@ -1,7 +1,10 @@
-import { prisma } from "@dpf/db";
+import { Prisma, prisma } from "@dpf/db";
 import Link from "next/link";
 import {
+  dedupeFounderReviewCandidates,
   groupFounderReviewCandidates,
+  isAgentInternalFounderReviewNoise,
+  isBlankFounderReviewQuestion,
   projectFounderReviewCandidate,
   type DecisionInteractionQueueRow,
 } from "@/lib/founder-review/queue";
@@ -23,6 +26,29 @@ function titleForMode(mode: WikiPerspective | null) {
   return "Founder Review";
 }
 
+const WORK_QUEUE_GUIDE = [
+  {
+    title: "Needs you",
+    href: "/workspace/inbox",
+    description: "Start here for approvals, paused coworkers, escalations, and anything blocking a human outcome.",
+  },
+  {
+    title: "My queue",
+    href: "/workspace/my-queue",
+    description: "Your assigned work cases: things you or a teammate own through completion.",
+  },
+  {
+    title: "Build Studio",
+    href: "/build",
+    description: "Product/build work in flight, including build-specific “Needs you” moments.",
+  },
+  {
+    title: "Decision Governance",
+    href: "/coworker-decisions/review",
+    description: "Review and improve WWMD, WWWD, and role-craft decision rules after evidence is clear.",
+  },
+] as const;
+
 export default async function FounderReviewPage({ searchParams }: PageProps) {
   const resolvedSearchParams = await (searchParams ?? Promise.resolve({} as { mode?: string; profile?: string }));
   const mode = normalizeMode(resolvedSearchParams.mode);
@@ -33,6 +59,7 @@ export default async function FounderReviewPage({ searchParams }: PageProps) {
   const rows = await prisma.decisionInteraction.findMany({
     where: {
       outcomeType: { in: ["defer", "escalate"] },
+      humanOutcome: { equals: Prisma.DbNull },
       ...(profileFilter ? { profileId: profileFilter } : {}),
     },
     orderBy: { createdAt: "desc" },
@@ -46,6 +73,7 @@ export default async function FounderReviewPage({ searchParams }: PageProps) {
       buildId: true,
       taskRunId: true,
       routeContext: true,
+      domainClass: true,
       createdAt: true,
       profile: {
         select: {
@@ -58,9 +86,12 @@ export default async function FounderReviewPage({ searchParams }: PageProps) {
   });
 
   const candidates = rows
+    .filter((row) => !isBlankFounderReviewQuestion(row))
+    .filter((row) => !isAgentInternalFounderReviewNoise(row))
     .map((row) => projectFounderReviewCandidate(row as DecisionInteractionQueueRow))
     .filter((candidate) => !mode || candidate.perspective === mode);
-  const groups = groupFounderReviewCandidates(candidates);
+  const visibleCandidates = dedupeFounderReviewCandidates(candidates);
+  const groups = groupFounderReviewCandidates(visibleCandidates);
   const title = titleForMode(mode);
 
   return (
@@ -68,8 +99,23 @@ export default async function FounderReviewPage({ searchParams }: PageProps) {
       <div>
         <h1 className="text-lg font-semibold">{title}</h1>
         <p className="mt-1 text-sm text-[var(--dpf-muted)]">
-          Unresolved decisions that need a principle, evidence, owner, or judgment call.
+          Filtered AI decision residue. Use Needs you as the main inbox for all approvals,
+          paused coworkers, and decisions waiting on a person.
         </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Link
+            href="/workspace/inbox"
+            className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-bg)]"
+          >
+            Open Needs you
+          </Link>
+          <Link
+            href="/coworker-decisions/review"
+            className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
+          >
+            Review decision governance
+          </Link>
+        </div>
         {profileFilter ? (
           <p className="mt-1 text-xs text-[var(--dpf-muted)]">
             Filtered to profile <code>{profileFilter}</code> ·{" "}
@@ -80,10 +126,44 @@ export default async function FounderReviewPage({ searchParams }: PageProps) {
         ) : null}
       </div>
 
+      <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold">Where work lives</h2>
+            <p className="mt-1 max-w-prose text-sm text-[var(--dpf-muted)]">
+              You do not need to patrol every queue. Treat Needs you as the front door; use
+              the other pages when you are already in that kind of work.
+            </p>
+          </div>
+          <p className="text-xs text-[var(--dpf-muted)]">
+            Showing {visibleCandidates.length} distinct review {visibleCandidates.length === 1 ? "item" : "items"}
+            {" "}from {rows.length} unresolved AI decision {rows.length === 1 ? "row" : "rows"}.
+          </p>
+        </div>
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          {WORK_QUEUE_GUIDE.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-bg)] p-3"
+            >
+              <span className="text-sm font-medium text-[var(--dpf-text)]">{item.title}</span>
+              <span className="mt-1 block text-xs text-[var(--dpf-muted)]">{item.description}</span>
+            </Link>
+          ))}
+        </div>
+        <p className="mt-3 text-xs text-[var(--dpf-muted)]">
+          These cards are created when an AI decision is deferred or escalated. Resolved
+          history, blank questions, internal consults, and duplicate asks are hidden here.
+        </p>
+      </section>
+
       {groups.length === 0 ? (
         <section className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
           <h2 className="text-sm font-semibold">No review items waiting</h2>
-          <p className="mt-1 text-sm text-[var(--dpf-muted)]">Build Studio has no unresolved decision requests.</p>
+          <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+            No unresolved AI decision residue matches this lens. The main attention queue is Needs you.
+          </p>
         </section>
       ) : (
         <div className="space-y-5">
@@ -104,13 +184,16 @@ export default async function FounderReviewPage({ searchParams }: PageProps) {
                         <p className="text-sm font-medium">{item.question}</p>
                         <p className="mt-1 text-xs text-[var(--dpf-muted)]">{item.profileLabel}</p>
                         <p className="mt-2 text-sm text-[var(--dpf-muted)]">{item.primaryActionLabel}</p>
+                        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                          Open the evidence, then record the outcome from the owning workflow.
+                        </p>
                       </div>
                       <div className="flex shrink-0 flex-wrap gap-2">
                         <Link
                           className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-text)]"
                           href={item.links.decisionCanvasHref}
                         >
-                          View Decision Canvas
+                          Review evidence
                         </Link>
                         {item.links.buildHref ? (
                           <Link
@@ -128,14 +211,6 @@ export default async function FounderReviewPage({ searchParams }: PageProps) {
                             Open task
                           </Link>
                         ) : null}
-                        <button
-                          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)]"
-                          disabled
-                          title="Record outcome is gated on the WWMD MCP Sprint 1 handler."
-                          type="button"
-                        >
-                          Record outcome
-                        </button>
                       </div>
                     </div>
                   </article>

--- a/apps/web/components/platform/coworker-record/panels.tsx
+++ b/apps/web/components/platform/coworker-record/panels.tsx
@@ -671,7 +671,7 @@ export function DecisionsPanel({ record }: { record: CoworkerRecord }) {
     <div>
       <Section
         title="Decision signals (30d)"
-        action={profession.profileId ? deepLink(`/platform/ai/founder-review?profile=${profession.profileId}`, "Review inbox") : null}
+        action={profession.profileId ? deepLink("/workspace/inbox", "Open Needs you") : null}
       >
         {decisions.total > 0 ? (
           <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>

--- a/apps/web/lib/attention/sources/ai-decision.ts
+++ b/apps/web/lib/attention/sources/ai-decision.ts
@@ -72,6 +72,7 @@ function residueFor(row: DecisionInteractionRow): ResidueReason {
 /** Pure projection of one unresolved decision into an attention item. */
 export function aiDecisionToAttentionItem(row: DecisionInteractionRow): AttentionItem {
   const blast = row.buildId ? `build ${row.buildId}` : row.taskRunId ? "a coworker task" : undefined;
+  const decisionHref = `/platform/ai/decisions/${encodeURIComponent(row.interactionId)}`;
   return {
     id: `ai-decision:${row.interactionId}`,
     source: "ai-decision",
@@ -88,9 +89,9 @@ export function aiDecisionToAttentionItem(row: DecisionInteractionRow): Attentio
     },
     createdAtIso: row.createdAt.toISOString(),
     actions: [
-      { kind: "open-in-context", label: "Review decision", href: "/platform/ai/founder-review" },
+      { kind: "open-in-context", label: "Review evidence", href: decisionHref },
     ],
-    deepLink: "/platform/ai/founder-review",
+    deepLink: decisionHref,
     audience: { operator: true },
   };
 }

--- a/apps/web/lib/attention/sources/sources.test.ts
+++ b/apps/web/lib/attention/sources/sources.test.ts
@@ -91,7 +91,11 @@ describe("aiDecisionToAttentionItem", () => {
     expect(item.riskClass).toBe("high-risk");
     expect(item.triage.residueReason).toBe("high-risk-gate");
     expect(item.triage.blastRadius).toBe("build FB-3");
-    expect(item.deepLink).toBe("/platform/ai/founder-review");
+    expect(item.deepLink).toBe("/platform/ai/decisions/DI-1");
+    expect(item.actions[0]).toMatchObject({
+      label: "Review evidence",
+      href: "/platform/ai/decisions/DI-1",
+    });
   });
 
   it("maps a principle conflict ahead of the outcome type", () => {

--- a/apps/web/lib/founder-review/queue.ts
+++ b/apps/web/lib/founder-review/queue.ts
@@ -24,6 +24,7 @@ export type DecisionInteractionQueueRow = {
   buildId: string | null;
   taskRunId: string | null;
   routeContext: string | null;
+  domainClass?: string | null;
   createdAt: Date;
   profile?: {
     profileId: string;
@@ -57,6 +58,42 @@ const KNOWN_REASONS = new Set<FounderReviewUnresolvedReason>([
   "ownership-gap",
   "volunteers-dilemma",
 ]);
+
+export function isBlankFounderReviewQuestion(row: Pick<DecisionInteractionQueueRow, "question">): boolean {
+  return row.question.trim().length === 0;
+}
+
+export function isAgentInternalFounderReviewNoise(row: Pick<
+  DecisionInteractionQueueRow,
+  "buildId" | "taskRunId" | "routeContext" | "domainClass"
+>): boolean {
+  const linked = Boolean(row.buildId || row.taskRunId);
+  if (linked) return false;
+  const route = (row.routeContext ?? "").trim().toLowerCase();
+  if (route === "mcp:principle_decide" || route.startsWith("mcp:principle_decide")) return true;
+  const domain = (row.domainClass ?? "").trim().toLowerCase();
+  return domain === "kernel-consult";
+}
+
+function normalizeFounderReviewQuestion(question: string): string {
+  return question.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+export function dedupeFounderReviewCandidates<T extends FounderReviewCandidate>(candidates: T[]): T[] {
+  const seen = new Set<string>();
+  const unique: T[] = [];
+  for (const candidate of candidates) {
+    const key = [
+      candidate.perspective ?? "unknown",
+      candidate.profileLabel.trim().toLowerCase(),
+      normalizeFounderReviewQuestion(candidate.question),
+    ].join("|");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(candidate);
+  }
+  return unique;
+}
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};

--- a/apps/web/lib/mcp/packs/founder-review-pack.test.ts
+++ b/apps/web/lib/mcp/packs/founder-review-pack.test.ts
@@ -5,6 +5,7 @@ const prismaMock = vi.hoisted(() => ({
   organizationFindFirst: vi.fn(),
 }));
 vi.mock("@dpf/db", () => ({
+  Prisma: { DbNull: "DbNull" },
   prisma: {
     decisionInteraction: {
       findMany: (...args: unknown[]) => prismaMock.decisionInteractionFindMany(...args),
@@ -36,6 +37,7 @@ function reviewRow(over: Record<string, unknown> = {}) {
     buildId: null,
     taskRunId: null,
     routeContext: "/build",
+    domainClass: null,
     createdAt: new Date("2026-07-01T00:00:00.000Z"),
     profile: { profileId: "mark-dpf-platform", name: "WWMD Platform", kind: "platform" },
     deferralCapture: null,
@@ -92,12 +94,61 @@ describe("founder-review pack — list_open_decision_reviews", () => {
     );
 
     const args = prismaMock.decisionInteractionFindMany.mock.calls[0][0] as {
-      where: { profileId?: unknown; outcomeType?: unknown };
+      where: { profileId?: unknown; outcomeType?: unknown; humanOutcome?: unknown; question?: unknown; NOT?: unknown };
       take: number;
     };
     expect(args.where.profileId).toEqual({ startsWith: "wsid-" });
     expect(args.where.outcomeType).toEqual({ in: ["defer", "escalate"] });
+    expect(args.where.humanOutcome).toEqual({ equals: "DbNull" });
+    expect(args.where.question).toEqual({ not: "" });
+    expect(args.where.NOT).toEqual([
+      {
+        buildId: null,
+        taskRunId: null,
+        OR: [
+          { routeContext: { startsWith: "mcp:principle_decide" } },
+          { domainClass: "kernel-consult" },
+        ],
+      },
+    ]);
     expect(args.take).toBe(50);
+  });
+
+  it("suppresses blank and agent-internal kernel consult rows from coworker-readable reviews", async () => {
+    prismaMock.decisionInteractionFindMany.mockResolvedValue([
+      reviewRow({ interactionId: "DI-BLANK", question: " " }),
+      reviewRow({
+        interactionId: "DI-INTERNAL",
+        question: "Should the kernel consult itself?",
+        routeContext: "mcp:principle_decide",
+        domainClass: "kernel-consult",
+      }),
+      reviewRow({ interactionId: "DI-REAL", question: "Should the owner approve this exception?" }),
+    ]);
+
+    const res = await founderReviewPack.handlers.list_open_decision_reviews!({}, "user-1");
+
+    expect(res.success).toBe(true);
+    expect(res.data?.count).toBe(1);
+    const reviews = res.data?.reviews as Array<Record<string, unknown>>;
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].interactionId).toBe("DI-REAL");
+    expect(String(res.message)).toContain("owning workflow");
+  });
+
+  it("deduplicates repeated open reviews before returning the coworker-readable queue", async () => {
+    prismaMock.decisionInteractionFindMany.mockResolvedValue([
+      reviewRow({ interactionId: "DI-DUP-NEW", question: "Should we fix quality issues first?" }),
+      reviewRow({ interactionId: "DI-DUP-OLD", question: "  Should we fix quality issues first? " }),
+      reviewRow({ interactionId: "DI-OTHER", question: "Should we launch the new offering?" }),
+    ]);
+
+    const res = await founderReviewPack.handlers.list_open_decision_reviews!({}, "user-1");
+
+    expect(res.success).toBe(true);
+    expect(res.data?.count).toBe(2);
+    const reviews = res.data?.reviews as Array<Record<string, unknown>>;
+    expect(reviews.map((review) => review.interactionId)).toEqual(["DI-DUP-NEW", "DI-OTHER"]);
   });
 
   it("prefers the deferral gapReason for a deferred review", async () => {

--- a/apps/web/lib/mcp/packs/founder-review-pack.ts
+++ b/apps/web/lib/mcp/packs/founder-review-pack.ts
@@ -4,14 +4,16 @@
 // DecisionInteraction rows (outcomeType defer/escalate) awaiting a human — but no
 // coworker-callable tool surfaced them, so a coworker asked "what should we do
 // about these open reviews?" had nothing to read and told the user to paste the
-// screen. This pack exposes the SAME queue the Founder Review workspace renders
+// screen. This pack exposes the same filtered "open review" residue that the
+// Founder Review workspace renders
 // (apps/web/lib/founder-review/queue.ts + apps/web/app/(shell)/platform/ai/
 // founder-review/page.tsx) as a read tool, so the coworker can name each review,
 // its unresolved reason and gap detail, and recommend a resolution.
 //
 // Read-only by design. Resolving a deferred/escalated decision is a human action
-// (Human-in-the-Loop at Phase Boundaries) taken in the Founder Review workspace /
-// Decision Canvas; a coworker recommends, the human confirms. The gating grant is
+// (Human-in-the-Loop at Phase Boundaries) taken in the owning workflow after the
+// human reviews the Decision Canvas evidence; a coworker recommends, the human
+// confirms. The gating grant is
 // `registry_read` (a coworker-read baseline), so every coworker inherits it — the
 // pack mirrors agent-grants.ts TOOL_TO_GRANTS, which stays the gating source.
 
@@ -32,7 +34,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "list_open_decision_reviews",
     description:
-      "List the OPEN DECISION REVIEWS shown on the /wiki Decision Governance hub — decisions your AI workforce deferred or escalated to a human and that are still unresolved. Returns each review's question, discipline (WWMD platform / WWWD business / WSID craft), why it is unresolved, the gap detail, a suggested next action, and a decision-canvas link. Use this to answer 'what should we do about these open reviews?' by reading and recommending on the actual queue instead of asking the user to paste the screen. Read-only: resolving a review is a human action taken in the Founder Review workspace; this tool lets you understand and recommend.",
+      "List the OPEN DECISION REVIEWS shown on the /wiki Decision Governance hub — decisions your AI workforce deferred or escalated to a human and that are still unresolved. Returns each review's question, discipline (WWMD platform / WWWD business / WSID craft), why it is unresolved, the gap detail, a suggested next action, and a decision-canvas link. Use this to answer 'what should we do about these open reviews?' by reading and recommending on the actual queue instead of asking the user to paste the screen. Read-only: resolving a review is a human action taken in the owning workflow after reviewing the Decision Canvas evidence; this tool lets you understand and recommend.",
     inputSchema: {
       type: "object",
       properties: {
@@ -58,8 +60,13 @@ const definitions: ToolDefinition[] = [
 async function listOpenDecisionReviews(
   params: Record<string, unknown>,
 ): Promise<ToolResult> {
-  const { prisma } = await import("@dpf/db");
-  const { projectFounderReviewCandidate } = await import("@/lib/founder-review/queue");
+  const { Prisma, prisma } = await import("@dpf/db");
+  const {
+    dedupeFounderReviewCandidates,
+    isAgentInternalFounderReviewNoise,
+    isBlankFounderReviewQuestion,
+    projectFounderReviewCandidate,
+  } = await import("@/lib/founder-review/queue");
   const { WWMD_PLATFORM_PROFILE_ID, WWWD_ORGANIZATION_PROFILE_ID } = await import(
     "@/lib/decision/caller-context"
   );
@@ -93,6 +100,18 @@ async function listOpenDecisionReviews(
   const rows = await prisma.decisionInteraction.findMany({
     where: {
       outcomeType: { in: UNRESOLVED_OUTCOMES },
+      humanOutcome: { equals: Prisma.DbNull },
+      question: { not: "" },
+      NOT: [
+        {
+          buildId: null,
+          taskRunId: null,
+          OR: [
+            { routeContext: { startsWith: "mcp:principle_decide" } },
+            { domainClass: "kernel-consult" },
+          ],
+        },
+      ],
       ...(profileFilter !== undefined ? { profileId: profileFilter } : {}),
     },
     orderBy: { createdAt: "desc" },
@@ -106,6 +125,7 @@ async function listOpenDecisionReviews(
       buildId: true,
       taskRunId: true,
       routeContext: true,
+      domainClass: true,
       createdAt: true,
       profile: { select: { profileId: true, name: true, kind: true } },
       deferralCapture: { select: { gapReason: true, domain: true, suggestedSourceTypes: true } },
@@ -113,30 +133,39 @@ async function listOpenDecisionReviews(
     },
   });
 
-  const reviews = rows.map((row) => {
-    const candidate = projectFounderReviewCandidate(row);
-    const gapDetail = row.deferralCapture?.gapReason ?? row.escalationCapture?.prompt ?? null;
-    return {
-      interactionId: candidate.id,
-      question: truncate(candidate.question),
-      discipline: candidate.perspective, // "wwmd" | "wwwd" | null
-      profileLabel: candidate.profileLabel,
-      outcomeType: row.outcomeType,
-      unresolvedReason: candidate.unresolvedReasonLabel,
-      gapDetail: truncate(gapDetail),
-      suggestedAction: candidate.primaryActionLabel,
-      options: candidate.options,
-      suggestedSourceTypes: row.deferralCapture?.suggestedSourceTypes ?? [],
-      decisionCanvasHref: candidate.links.decisionCanvasHref,
-      createdAt: candidate.createdAt,
-    };
-  });
+  const candidates = rows
+    .filter((row) => !isBlankFounderReviewQuestion(row))
+    .filter((row) => !isAgentInternalFounderReviewNoise(row))
+    .map((row) => ({ row, candidate: projectFounderReviewCandidate(row) }));
+  const uniqueIds = new Set(
+    dedupeFounderReviewCandidates(candidates.map((item) => item.candidate)).map((candidate) => candidate.id),
+  );
+  const reviews = candidates
+    .filter((item) => uniqueIds.has(item.candidate.id))
+    .map((row) => {
+      const candidate = row.candidate;
+      const gapDetail = row.row.deferralCapture?.gapReason ?? row.row.escalationCapture?.prompt ?? null;
+      return {
+        interactionId: candidate.id,
+        question: truncate(candidate.question),
+        discipline: candidate.perspective, // "wwmd" | "wwwd" | null
+        profileLabel: candidate.profileLabel,
+        outcomeType: row.row.outcomeType,
+        unresolvedReason: candidate.unresolvedReasonLabel,
+        gapDetail: truncate(gapDetail),
+        suggestedAction: candidate.primaryActionLabel,
+        options: candidate.options,
+        suggestedSourceTypes: row.row.deferralCapture?.suggestedSourceTypes ?? [],
+        decisionCanvasHref: candidate.links.decisionCanvasHref,
+        createdAt: candidate.createdAt,
+      };
+    });
 
   const scopeLabel = discipline === "all" ? "" : ` in ${discipline.toUpperCase()}`;
   return {
     success: true,
     message: reviews.length
-      ? `${reviews.length} open decision review${reviews.length === 1 ? "" : "s"} awaiting a human${scopeLabel}. Read each one's gap detail and suggested action, then recommend a resolution — the human confirms it in the Founder Review workspace (/platform/ai/founder-review).`
+      ? `${reviews.length} open decision review${reviews.length === 1 ? "" : "s"} awaiting a human${scopeLabel}. Read each one's gap detail and suggested action, then recommend a resolution — the human confirms it in the owning workflow after reviewing the Decision Canvas evidence.`
       : `No open decision reviews${scopeLabel}.`,
     data: { count: reviews.length, discipline, reviews },
   };

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -231,8 +231,8 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
 
   // Open decision reviews — the /wiki governance hub's queue of deferred/escalated
   // decisions awaiting a human. Read-only tool on the `registry_read` baseline: any
-  // coworker may read and recommend on the queue; resolving stays a human action in
-  // the Founder Review workspace (Human-in-the-Loop at Phase Boundaries).
+  // coworker may read and recommend on the queue; resolving stays a human action
+  // in the owning workflow after reviewing Decision Canvas evidence.
   list_open_decision_reviews: ["registry_read"],
 
   // Backlog triage and Build Studio promotion (spec 2026-04-21)

--- a/apps/web/lib/tak/decision-governance-route-context.ts
+++ b/apps/web/lib/tak/decision-governance-route-context.ts
@@ -1,0 +1,155 @@
+import { Prisma, prisma } from "@dpf/db";
+import {
+  WWMD_PLATFORM_PROFILE_ID,
+  WWWD_ORGANIZATION_PROFILE_ID,
+} from "@/lib/decision/caller-context";
+import { resolveOrgProfileId } from "@/lib/decision-perspective/material";
+import {
+  dedupeFounderReviewCandidates,
+  isAgentInternalFounderReviewNoise,
+  isBlankFounderReviewQuestion,
+  projectFounderReviewCandidate,
+  type DecisionInteractionQueueRow,
+} from "@/lib/founder-review/queue";
+
+// EP-0AF96937 / BI-C888E1B6. The /coworker-decisions landing is the Decision
+// Governance hub: WWMD, WWWD, and WSID open reviews awaiting a human.
+const WIKI_UNRESOLVED_OUTCOMES = ["defer", "escalate"];
+
+function openDecisionReviewWhere(
+  profileId?: Prisma.DecisionInteractionWhereInput["profileId"],
+): Prisma.DecisionInteractionWhereInput {
+  return {
+    outcomeType: { in: WIKI_UNRESOLVED_OUTCOMES },
+    humanOutcome: { equals: Prisma.DbNull },
+    question: { not: "" },
+    NOT: [
+      {
+        buildId: null,
+        taskRunId: null,
+        OR: [
+          { routeContext: { startsWith: "mcp:principle_decide" } },
+          { domainClass: "kernel-consult" },
+        ],
+      },
+    ],
+    ...(profileId !== undefined ? { profileId } : {}),
+  };
+}
+
+const openDecisionReviewSelect = {
+  interactionId: true,
+  question: true,
+  options: true,
+  outcomeType: true,
+  outcomePayload: true,
+  buildId: true,
+  taskRunId: true,
+  routeContext: true,
+  domainClass: true,
+  createdAt: true,
+  profile: { select: { profileId: true, name: true, kind: true } },
+} satisfies Prisma.DecisionInteractionSelect;
+
+function countUniqueOpenReviews(rows: DecisionInteractionQueueRow[]): number {
+  const candidates = rows
+    .filter((row) => !isBlankFounderReviewQuestion(row))
+    .filter((row) => !isAgentInternalFounderReviewNoise(row))
+    .map((row) => projectFounderReviewCandidate(row));
+  return dedupeFounderReviewCandidates(candidates).length;
+}
+
+export async function getWikiGovernanceContext(): Promise<string> {
+  const decisionWindow = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const organization = await prisma.organization.findFirst({ select: { id: true } });
+  const organizationId = organization?.id ?? null;
+  const orgProfileId = organizationId
+    ? await resolveOrgProfileId({ db: prisma, organizationId })
+    : null;
+  const wwwdProfileIds = orgProfileId
+    ? [orgProfileId, WWWD_ORGANIZATION_PROFILE_ID]
+    : [WWWD_ORGANIZATION_PROFILE_ID];
+
+  const [
+    kernelPrincipleCount,
+    kernelHeuristicCount,
+    wsidActiveProfiles,
+    wwmdOpenReviewRows,
+    wwwdOpenReviewRows,
+    wsidOpenReviewRows,
+    wwmdDecisions30d,
+    wwwdDecisions30d,
+    wsidDecisions30d,
+    topOpenReviews,
+  ] = await Promise.all([
+    prisma.wikiPage.count({
+      where: { organizationId: null, pageKind: "principle", status: "published" },
+    }),
+    prisma.wikiPage.count({
+      where: { organizationId: null, pageKind: "heuristic", status: "published" },
+    }),
+    prisma.decisionPerspectiveProfile.count({
+      where: { kind: "profession", status: "active" },
+    }),
+    prisma.decisionInteraction.findMany({
+      where: openDecisionReviewWhere(WWMD_PLATFORM_PROFILE_ID),
+      select: openDecisionReviewSelect,
+    }),
+    prisma.decisionInteraction.findMany({
+      where: openDecisionReviewWhere({ in: wwwdProfileIds }),
+      select: openDecisionReviewSelect,
+    }),
+    prisma.decisionInteraction.findMany({
+      where: openDecisionReviewWhere({ startsWith: "wsid-" }),
+      select: openDecisionReviewSelect,
+    }),
+    prisma.decisionInteraction.count({
+      where: { profileId: WWMD_PLATFORM_PROFILE_ID, createdAt: { gte: decisionWindow } },
+    }),
+    prisma.decisionInteraction.count({
+      where: { profileId: { in: wwwdProfileIds }, createdAt: { gte: decisionWindow } },
+    }),
+    prisma.decisionInteraction.count({
+      where: { profileId: { startsWith: "wsid-" }, createdAt: { gte: decisionWindow } },
+    }),
+    prisma.decisionInteraction.findMany({
+      where: openDecisionReviewWhere(),
+      orderBy: { createdAt: "desc" },
+      take: 8,
+      select: openDecisionReviewSelect,
+    }),
+  ]);
+
+  const wwmdOpenReviews = countUniqueOpenReviews(wwmdOpenReviewRows as DecisionInteractionQueueRow[]);
+  const wwwdOpenReviews = countUniqueOpenReviews(wwwdOpenReviewRows as DecisionInteractionQueueRow[]);
+  const wsidOpenReviews = countUniqueOpenReviews(wsidOpenReviewRows as DecisionInteractionQueueRow[]);
+  const totalOpenReviews = wwmdOpenReviews + wwwdOpenReviews + wsidOpenReviews;
+  const plural = (n: number) => `${n} open review${n === 1 ? "" : "s"}`;
+
+  const reviewCandidates = (topOpenReviews as DecisionInteractionQueueRow[])
+    .filter((row) => !isBlankFounderReviewQuestion(row))
+    .filter((row) => !isAgentInternalFounderReviewNoise(row))
+    .map((row) => projectFounderReviewCandidate(row));
+  const reviewLines = dedupeFounderReviewCandidates(reviewCandidates)
+    .map((c) => `- [${c.profileLabel}] "${c.question}" — ${c.unresolvedReasonLabel}; suggested action: ${c.primaryActionLabel}; open evidence at ${c.links.decisionCanvasHref}`);
+
+  return [
+    "\nPAGE DATA — Decision Governance (/coworker-decisions):",
+    "This page is the decision-governance hub. Three disciplines govern every call your AI workforce makes: WWMD (What Would Mark Do — platform doctrine), WWWD (What Would We Do — this business's own stance), and WSID (What Should I Do — each role's craft). An \"open review\" is an unresolved decision (deferred or escalated) awaiting a human.",
+    "",
+    `OPEN REVIEWS awaiting a human: ${totalOpenReviews} total`,
+    `- WWMD (platform): ${plural(wwmdOpenReviews)}`,
+    `- WWWD (business): ${plural(wwwdOpenReviews)}`,
+    `- WSID (craft): ${plural(wsidOpenReviews)}`,
+    "",
+    `DECISIONS RECORDED (last 30 days): WWMD ${wwmdDecisions30d}, WWWD ${wwwdDecisions30d}, WSID ${wsidDecisions30d}`,
+    `GOVERNING MATERIAL: ${kernelPrincipleCount} kernel principles, ${kernelHeuristicCount} heuristics, ${wsidActiveProfiles} active role families.`,
+    "",
+    totalOpenReviews > 0
+      ? "TOP OPEN REVIEWS (most recent unresolved — you can act on these, do NOT ask the user to paste them):"
+      : "There are no open reviews right now.",
+    ...reviewLines,
+    "",
+    "To act: call list_open_decision_reviews for the full queue with each item's unresolved reason and gap detail, read them, and recommend a resolution. The human reviews each Decision Canvas at /platform/ai/decisions/<interactionId> and records the outcome in the owning workflow; Founder Review is only a filtered residue lens, not the main action inbox.",
+  ].join("\n");
+}

--- a/apps/web/lib/tak/route-context.test.ts
+++ b/apps/web/lib/tak/route-context.test.ts
@@ -41,7 +41,7 @@ const {
   mockResolveOrgProfileId: vi.fn(),
 }));
 
-vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
+vi.mock("@dpf/db", () => ({ Prisma: { DbNull: "DbNull" }, prisma: mockPrisma }));
 vi.mock("@/lib/tak/marketing-playbooks", () => ({ getPlaybook: mockGetPlaybook }));
 vi.mock("@/lib/storefront/archetype-vocabulary", () => ({ getVocabulary: mockGetVocabulary }));
 vi.mock("@/lib/decision-perspective/material", () => ({ resolveOrgProfileId: mockResolveOrgProfileId }));
@@ -357,21 +357,14 @@ describe("getRouteDataContext", () => {
     expect(mockPrisma.runtimeTarget.findMany).toHaveBeenCalled();
   });
 
-  it("gives /wiki the decision-governance open-review counts + named reviews, not a generic blurb (BI-C888E1B6)", async () => {
-    // Counts keyed off the where clause so each discipline gets a distinct number.
+  it("gives /coworker-decisions the decision-governance open-review counts + named reviews, not a generic blurb (BI-C888E1B6)", async () => {
     mockPrisma.decisionInteraction.count.mockImplementation(async (args: {
-      where: { outcomeType?: unknown; profileId?: unknown };
+      where: { profileId?: unknown };
     }) => {
       const { where } = args;
       const pid = where.profileId;
       const isWsid = typeof pid === "object" && pid !== null && "startsWith" in pid;
       const isWwmd = pid === "mark-dpf-platform";
-      if (where.outcomeType) {
-        // open-review counts
-        if (isWwmd) return 17;
-        if (isWsid) return 0;
-        return 1; // wwwd
-      }
       // 30-day decision counts
       if (isWwmd) return 46;
       if (isWsid) return 0;
@@ -381,24 +374,45 @@ describe("getRouteDataContext", () => {
       args.where.pageKind === "principle" ? 158 : 33,
     );
     mockPrisma.decisionPerspectiveProfile.count.mockResolvedValue(23);
-    mockPrisma.decisionInteraction.findMany.mockResolvedValue([
-      {
-        interactionId: "DI-ABC123",
-        question: "Should we prioritize the migration or the new feature?",
-        options: [{ id: "migrate" }, { id: "feature" }],
-        outcomeType: "escalate",
-        outcomePayload: { unresolvedReason: "principle-gap" },
-        buildId: null,
-        taskRunId: null,
-        routeContext: "/build",
-        createdAt: new Date("2026-07-01T00:00:00.000Z"),
-        profile: { profileId: "mark-dpf-platform", name: "WWMD Platform", kind: "platform" },
-      },
-    ]);
+    const review = (interactionId: string, profileId: string, question = `Review ${interactionId}`) => ({
+      interactionId,
+      question,
+      options: [{ id: "migrate" }, { id: "feature" }],
+      outcomeType: "escalate",
+      outcomePayload: { unresolvedReason: "principle-gap" },
+      buildId: null,
+      taskRunId: null,
+      routeContext: "/build",
+      domainClass: "architecture",
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      profile: { profileId, name: "WWMD Platform", kind: "platform" },
+    });
+    mockPrisma.decisionInteraction.findMany.mockImplementation(async (args: {
+      where: { profileId?: unknown };
+      take?: number;
+    }) => {
+      if (args.take === 8) {
+        return [
+          review(
+            "DI-ABC123",
+            "mark-dpf-platform",
+            "Should we prioritize the migration or the new feature?",
+          ),
+        ];
+      }
+      const pid = args.where.profileId;
+      if (pid === "mark-dpf-platform") {
+        return Array.from({ length: 17 }, (_, i) => review(`DI-WWMD-${i}`, "mark-dpf-platform"));
+      }
+      if (typeof pid === "object" && pid !== null && "startsWith" in pid) {
+        return [];
+      }
+      return [review("DI-WWWD-1", "wwd-org")];
+    });
 
     const context = await getRouteDataContext("/coworker-decisions", "user-1");
 
-    expect(context).toContain("PAGE DATA — Decision Governance (/wiki):");
+    expect(context).toContain("PAGE DATA — Decision Governance (/coworker-decisions):");
     expect(context).toContain("OPEN REVIEWS awaiting a human: 18 total");
     expect(context).toContain("WWMD (platform): 17 open reviews");
     expect(context).toContain("WWWD (business): 1 open review");

--- a/apps/web/lib/tak/route-context.ts
+++ b/apps/web/lib/tak/route-context.ts
@@ -10,15 +10,7 @@ import {
   isManagedServiceProviderProfile,
   readActivationProfile,
 } from "@/lib/storefront/archetype-activation";
-import {
-  WWMD_PLATFORM_PROFILE_ID,
-  WWWD_ORGANIZATION_PROFILE_ID,
-} from "@/lib/decision/caller-context";
-import { resolveOrgProfileId } from "@/lib/decision-perspective/material";
-import {
-  projectFounderReviewCandidate,
-  type DecisionInteractionQueueRow,
-} from "@/lib/founder-review/queue";
+import { getWikiGovernanceContext } from "@/lib/tak/decision-governance-route-context";
 
 type RouteContextResult = string | null;
 
@@ -44,11 +36,11 @@ const ROUTE_CONTEXT_PROVIDERS: Record<string, (userId: string, routeContext: str
   "/build": getBuildContext,
   "/storefront": getStorefrontMarketingContext,
   "/customer/funnel": getCustomerFunnelContext,
-  // /wiki is the Decision Governance hub (WWMD/WWWD/WSID). Without its own
-  // provider the coworker fell outside this allow-list and saw only the generic
-  // business blurb — so asked "what should we do about these open reviews?" it
-  // had no idea the page even showed reviews and told the user to paste the
-  // screen (BI-C888E1B6 / EP-0AF96937).
+  // /coworker-decisions is the Decision Governance hub (WWMD/WWWD/WSID).
+  // Without its own provider the coworker fell outside this allow-list and saw
+  // only the generic business blurb — so asked "what should we do about these
+  // open reviews?" it had no idea the page even showed reviews and told the user
+  // to paste the screen (BI-C888E1B6 / EP-0AF96937).
   "/coworker-decisions": getWikiGovernanceContext,
 };
 
@@ -1154,122 +1146,6 @@ async function getStorefrontMarketingContext(): Promise<string> {
     `Engagements: ${engagementSummary || "none"}`,
     `Opportunities: ${opportunitySummary || "none"}`,
   ].join("\n");
-}
-
-// ─── Decision Governance Context (/wiki) ─────────────────────────────────
-
-// EP-0AF96937 / BI-C888E1B6. The /wiki landing is the Decision Governance hub:
-// WWMD (platform doctrine), WWWD (this business's stance), WSID (each role's
-// craft), each carrying a count of "open reviews" — unresolved DecisionInteraction
-// rows (outcomeType defer/escalate) awaiting a human. This mirrors the counts the
-// hub renders (see apps/web/lib/wiki/decision-governance-hub.ts and the /wiki
-// page query) AND lists the most recent open reviews via the shared founder-review
-// projector, so the coworker can name and deep-link each one — and act on them via
-// the list_open_decision_reviews / resolve_decision_review tools — instead of
-// asking the user to paste the screen.
-const WIKI_UNRESOLVED_OUTCOMES = ["defer", "escalate"];
-
-async function getWikiGovernanceContext(): Promise<string> {
-  const decisionWindow = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-
-  // WWWD health reads off the org's OWN profile (seeded at onboarding) plus the
-  // platform fallback id — mirror /wiki page.tsx so the counts match the screen.
-  const organization = await prisma.organization.findFirst({ select: { id: true } });
-  const organizationId = organization?.id ?? null;
-  const orgProfileId = organizationId
-    ? await resolveOrgProfileId({ db: prisma, organizationId })
-    : null;
-  const wwwdProfileIds = orgProfileId
-    ? [orgProfileId, WWWD_ORGANIZATION_PROFILE_ID]
-    : [WWWD_ORGANIZATION_PROFILE_ID];
-
-  const [
-    kernelPrincipleCount,
-    kernelHeuristicCount,
-    wsidActiveProfiles,
-    wwmdOpenReviews,
-    wwwdOpenReviews,
-    wsidOpenReviews,
-    wwmdDecisions30d,
-    wwwdDecisions30d,
-    wsidDecisions30d,
-    topOpenReviews,
-  ] = await Promise.all([
-    prisma.wikiPage.count({
-      where: { organizationId: null, pageKind: "principle", status: "published" },
-    }),
-    prisma.wikiPage.count({
-      where: { organizationId: null, pageKind: "heuristic", status: "published" },
-    }),
-    prisma.decisionPerspectiveProfile.count({
-      where: { kind: "profession", status: "active" },
-    }),
-    prisma.decisionInteraction.count({
-      where: { outcomeType: { in: WIKI_UNRESOLVED_OUTCOMES }, profileId: WWMD_PLATFORM_PROFILE_ID },
-    }),
-    prisma.decisionInteraction.count({
-      where: { outcomeType: { in: WIKI_UNRESOLVED_OUTCOMES }, profileId: { in: wwwdProfileIds } },
-    }),
-    prisma.decisionInteraction.count({
-      where: { outcomeType: { in: WIKI_UNRESOLVED_OUTCOMES }, profileId: { startsWith: "wsid-" } },
-    }),
-    prisma.decisionInteraction.count({
-      where: { profileId: WWMD_PLATFORM_PROFILE_ID, createdAt: { gte: decisionWindow } },
-    }),
-    prisma.decisionInteraction.count({
-      where: { profileId: { in: wwwdProfileIds }, createdAt: { gte: decisionWindow } },
-    }),
-    prisma.decisionInteraction.count({
-      where: { profileId: { startsWith: "wsid-" }, createdAt: { gte: decisionWindow } },
-    }),
-    prisma.decisionInteraction.findMany({
-      where: { outcomeType: { in: WIKI_UNRESOLVED_OUTCOMES } },
-      orderBy: { createdAt: "desc" },
-      take: 8,
-      select: {
-        interactionId: true,
-        question: true,
-        options: true,
-        outcomeType: true,
-        outcomePayload: true,
-        buildId: true,
-        taskRunId: true,
-        routeContext: true,
-        createdAt: true,
-        profile: { select: { profileId: true, name: true, kind: true } },
-      },
-    }),
-  ]);
-
-  const totalOpenReviews = wwmdOpenReviews + wwwdOpenReviews + wsidOpenReviews;
-  const plural = (n: number) => `${n} open review${n === 1 ? "" : "s"}`;
-
-  const reviewLines = (topOpenReviews as DecisionInteractionQueueRow[]).map((row) => {
-    const c = projectFounderReviewCandidate(row);
-    return `- [${c.profileLabel}] "${c.question}" — ${c.unresolvedReasonLabel}; suggested action: ${c.primaryActionLabel}; open at ${c.links.decisionCanvasHref}`;
-  });
-
-  return [
-    "\nPAGE DATA — Decision Governance (/wiki):",
-    "This page is the decision-governance hub. Three disciplines govern every call your AI workforce makes: WWMD (What Would Mark Do — platform doctrine), WWWD (What Would We Do — this business's own stance), and WSID (What Should I Do — each role's craft). An \"open review\" is an unresolved decision (deferred or escalated) awaiting a human.",
-    "",
-    `OPEN REVIEWS awaiting a human: ${totalOpenReviews} total`,
-    `- WWMD (platform): ${plural(wwmdOpenReviews)}`,
-    `- WWWD (business): ${plural(wwwdOpenReviews)}`,
-    `- WSID (craft): ${plural(wsidOpenReviews)}`,
-    "",
-    `DECISIONS RECORDED (last 30 days): WWMD ${wwmdDecisions30d}, WWWD ${wwwdDecisions30d}, WSID ${wsidDecisions30d}`,
-    `GOVERNING MATERIAL: ${kernelPrincipleCount} kernel principles, ${kernelHeuristicCount} heuristics, ${wsidActiveProfiles} active role families.`,
-    "",
-    totalOpenReviews > 0
-      ? "TOP OPEN REVIEWS (most recent unresolved — you can act on these, do NOT ask the user to paste them):"
-      : "There are no open reviews right now.",
-    ...reviewLines,
-    "",
-    "To act: call list_open_decision_reviews for the full queue with each item's unresolved reason and gap detail, read them, and recommend a resolution. Resolving a review is a human action taken in the Founder Review workspace (/platform/ai/founder-review); each item's decision canvas is /platform/ai/decisions/<interactionId>.",
-  ]
-    .filter((line) => line !== null && line !== undefined)
-    .join("\n");
 }
 
 // ─── Universal Business Context ───────────────────────────────────────────

--- a/apps/web/lib/wiki/decision-governance-hub.test.ts
+++ b/apps/web/lib/wiki/decision-governance-hub.test.ts
@@ -73,14 +73,12 @@ describe("buildDisciplineCards", () => {
     expect(wwmd?.chips.find((c) => c.label.includes("review"))?.tone).toBe("warning");
   });
 
-  it("pluralizes the WSID corpus chip and links every card to its review queue", () => {
+  it("pluralizes the WSID corpus chip and links every card to Decision Governance review", () => {
     const cards = buildDisciplineCards({ ...base, wsidActiveProfiles: 3 });
     const wsid = cards.find((c) => c.key === "wsid");
     expect(wsid?.chips.map((c) => c.label)).toContain("3 corpora active");
     for (const card of cards) {
-      expect(
-        card.actions.some((a) => a.href.startsWith("/platform/ai/founder-review")),
-      ).toBe(true);
+      expect(card.actions.some((a) => a.href === "/coworker-decisions/review")).toBe(true);
     }
   });
 

--- a/apps/web/lib/wiki/decision-governance-hub.ts
+++ b/apps/web/lib/wiki/decision-governance-hub.ts
@@ -79,7 +79,7 @@ export function buildDisciplineCards(
     actions: [
       { label: "Governing material", href: "#governing-material" },
       { label: "Decision log", href: "/coworker-decisions/decisions?tier=wwmd" },
-      { label: "Review decisions", href: "/platform/ai/founder-review?mode=wwmd" },
+      { label: "Review decisions", href: "/coworker-decisions/review" },
     ],
   };
 
@@ -101,7 +101,7 @@ export function buildDisciplineCards(
     actions: [
       { label: "Manage stance", href: "/coworker-decisions/stance", emphasis: true },
       { label: "Decision log", href: "/coworker-decisions/decisions?tier=wwwd" },
-      { label: "Review decisions", href: "/platform/ai/founder-review?mode=wwwd" },
+      { label: "Review decisions", href: "/coworker-decisions/review" },
     ],
   };
 
@@ -127,7 +127,7 @@ export function buildDisciplineCards(
     actions: [
       { label: "Role craft", href: "/coworker-decisions/craft", emphasis: true },
       { label: "Decision log", href: "/coworker-decisions/decisions?tier=wsid" },
-      { label: "Review decisions", href: "/platform/ai/founder-review" },
+      { label: "Review decisions", href: "/coworker-decisions/review" },
     ],
   };
 


### PR DESCRIPTION
## Summary
- Reframes Founder Review as a filtered AI decision-residue lens instead of the main human-action inbox.
- Filters resolved, blank, internal kernel-consult, and duplicate decision cards so the page shows actionable residue instead of noisy historical asks.
- Adds an in-page “Where work lives” guide so operators know when to use Needs you, My queue, Build Studio, Decision Governance, and Founder Review.
- Points operators and coworkers toward the right queues: Needs you for human action, Decision Governance for review stewardship, and Decision Canvas for evidence.

## Test plan
- [x] Focused Vitest: `app/(shell)/platform/ai/founder-review/page.test.tsx`, `lib/attention/sources/sources.test.ts`, `lib/wiki/decision-governance-hub.test.ts`, `lib/mcp/packs/founder-review-pack.test.ts`, `lib/tak/route-context.test.ts` — 47 passed
- [x] Module Size Guard: `node scripts/check-module-size.mjs`
- [x] Typecheck: `pnpm --filter web typecheck`
- [x] Production build: `pnpm --filter web build`
- [x] Local-CI merged gate: lease `NPEL-F9810105BA`, evidence `cmrigh5el01ov01l41vaji0r0`; merged against `origin/main`, migrations clean, full web Vitest 15,877 passed, typecheck passed, Next build passed
- [x] UX verification: branch preview showed 5 cards, no duplicate titles, no disabled Record outcome button, clear Needs you / Decision Governance links, and Review evidence actions

## UX fit review
- Decision: fits-with-guardrails; guardrails folded into this PR.
- Owning area: Platform AI / Workspace attention.
- Route family: `/platform/ai/founder-review`, `/workspace/inbox`, `/workspace/my-queue`, `/build`, `/coworker-decisions/review`.
- Primary persona: non-technical founder/operator deciding “where do I go for what activity?”
- Navigation layer touched: local page orientation and contextual actions only; no new global nav.
- Source truth: `DecisionInteraction` unresolved defer/escalate rows; Attention source adapters feed Needs you; WorkItems feed My queue.
- Empty/failure behavior: Founder Review now explains that Needs you is the main queue when no residue exists.
- AI boundary: cards open evidence; no prompt is sent and no disabled action is shown.

## Notes
- Overlap sweep: open PRs #2904 and #2895 are BET-4 ToolPack work and do not overlap this Founder Review/Decision Governance UX change.
- Existing Next Edge-runtime warnings remain pre-existing build warnings; the build completed successfully.