### PR TITLE
fix(build): park resume when intake incomplete after design pass (BI-E212CAE2)

### DIFF
--- a/apps/web/lib/integrate/resume-pre-build-phase.test.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.test.ts
@@ -180,6 +180,32 @@ describe("resumePreBuildPhase (BI-9257CF19)", () => {
     expect(out).toMatchObject({ kind: "resumed", via: "dispatchDesignReviewFixLoop" });
   });
 
+
+  it("parks when design PASSed but persisted happyPath intake is still incomplete (BI-E212CAE2)", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { problemStatement: "p" },
+      buildPlan: null,
+      designReview: { decision: "pass", sizeAssessment: { decision: "ok" } },
+      plan: {
+        happyPathState: {
+          intake: {
+            taxonomyNodeId: null,
+            backlogItemId: "BI-X",
+            epicId: "EP-X",
+            constrainedGoal: null,
+            status: "blocked",
+            failureReason: "Intake is incomplete",
+          },
+        },
+      },
+    });
+    const out = await resumePreBuildPhase({ buildId: "FB-INTAKE", phase: "ideate", userId: "uI" });
+    expect(executeToolMock).not.toHaveBeenCalled();
+    expect(dispatchIdeateMock).not.toHaveBeenCalled();
+    expect(out.kind).toBe("skipped");
+    expect((out as { reason: string }).reason).toContain("intake is incomplete");
+  });
+
   it("returns failed (never throws) when the build row is missing", async () => {
     findUniqueMock.mockResolvedValue(null);
     const out = await resumePreBuildPhase({ buildId: "FB-6", phase: "plan", userId: "u6" });

--- a/apps/web/lib/integrate/resume-pre-build-phase.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.ts
@@ -38,6 +38,10 @@
 // the actor for the dispatch/review calls.
 
 import { prisma } from "@dpf/db";
+import {
+  isHappyPathIntakeReady,
+  normalizeHappyPathState,
+} from "@/lib/feature-build-types";
 
 export type ResumePreBuildOutcome =
   | { kind: "resumed"; phase: string; via: string; detail: string }
@@ -118,7 +122,7 @@ export async function resumePreBuildPhase(params: {
 
     const build = await prisma.featureBuild.findUnique({
       where: { buildId },
-      select: { designDoc: true, buildPlan: true, planReview: true, designReview: true },
+      select: { designDoc: true, buildPlan: true, planReview: true, designReview: true, plan: true },
     });
     if (!build) {
       return { kind: "failed", phase, error: "build not found" };
@@ -194,6 +198,28 @@ export async function resumePreBuildPhase(params: {
         const { dispatchDesignReviewFixLoop } = await import("@/lib/integrate/ideate-on-approval");
         const outcome = await dispatchDesignReviewFixLoop({ buildId, userId });
         return { kind: "resumed", phase, via: "dispatchDesignReviewFixLoop", detail: outcome.kind };
+      }
+      // BI-E212CAE2: when review already PASSed and plan.happyPathState is
+      // present but still incomplete, re-running reviewDesignDoc cannot clear a
+      // STATIC completeness gate — park for the operator instead of looping
+      // (burned cloud quota on FB-A500CCE6). If happyPathState is absent, re-run
+      // review so auto-intake can populate epic/backlog/goal/taxonomy once.
+      const designPassed =
+        (build.designReview as { decision?: string } | null)?.decision === "pass";
+      if (designPassed) {
+        const planRec = (build as { plan?: unknown }).plan as Record<string, unknown> | null | undefined;
+        const rawHps = planRec?.happyPathState;
+        if (rawHps != null) {
+          const happy = normalizeHappyPathState(rawHps);
+          if (!isHappyPathIntakeReady(happy)) {
+            return {
+              kind: "skipped",
+              phase,
+              reason:
+                "design passed review but intake is incomplete (taxonomy/backlog/epic/goal) — parked for operator (NOT re-running reviewDesignDoc; static gate).",
+            };
+          }
+        }
       }
       const { executeTool } = await import("@/lib/mcp-tools");
       const result = await executeTool("reviewDesignDoc", { buildId }, userId, { featureBuildId: buildId });


### PR DESCRIPTION
## Summary
- After design review already `pass`es, if `plan.happyPathState` exists but intake is still incomplete, skip re-running `reviewDesignDoc`.
- Parks for operator instead of infinite resume loops.

## BI
BI-E212CAE2

## Test plan
- [x] `resume-pre-build-phase.test.ts` — 14 tests incl. BI-E212CAE2 park case
- [ ] CI Unit Tests

Process-Spine-Decision: small resume hygiene fix with unit test.