### PR TITLE
fix(agent): hide Web access toggle without web_search grant (BI-CD9DC3BC)

### DIFF
--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import type { AgentMessageRow, AgentInfo } from "@/lib/agent-coworker-types";
 import type { UserContext } from "@/lib/permissions";
 import { resolveAgentForRouteSync, AGENT_NAME_MAP } from "@/lib/agent-routing";
+import { agentHoldsWebSearchGrant } from "@/lib/tak/agent-web-search-grant";
 import { clearConversation, getOrCreateThreadSnapshot, getThreadSnapshotById, getMarketingSkillRules } from "@/lib/actions/agent-coworker";
 import { useResilientEventSource } from "@/lib/hooks/useResilientEventSource";
 import { approveProposal, rejectProposal } from "@/lib/actions/proposals";
@@ -274,6 +275,7 @@ export function AgentCoworkerPanel({
 
   const routeAgent: AgentInfo = resolveAgentForRouteSync(effectiveRoute, userContext);
   const agent = routeAgent;
+  const webAccessAvailable = agentHoldsWebSearchGrant(agent.agentId);
   const canUseDev = userContext.isSuperuser || userContext.platformRole === "HR-000" || userContext.platformRole === "HR-300";
   const preferenceUserKey = userContext.userId ?? `${userContext.isSuperuser ? "super" : "role"}:${userContext.platformRole ?? "none"}`;
 
@@ -1191,8 +1193,9 @@ export function AgentCoworkerPanel({
         onVoicePlaybackToggle={toggleVoicePlayback}
         elevatedAssistEnabled={elevatedAssistEnabled}
         onToggleElevatedAssist={handleToggleElevatedAssist}
-        externalAccessEnabled={externalAccessEnabled}
+        externalAccessEnabled={webAccessAvailable && externalAccessEnabled}
         onToggleExternalAccess={handleToggleExternalAccess}
+        webAccessAvailable={webAccessAvailable}
         coworkerMode={coworkerMode}
         onToggleCoworkerMode={handleToggleCoworkerMode}
         useUnified={useUnifiedCoworker}

--- a/apps/web/components/agent/AgentMessageInput.tsx
+++ b/apps/web/components/agent/AgentMessageInput.tsx
@@ -43,6 +43,8 @@ type Props = {
   elevatedAssistEnabled?: boolean;
   onToggleElevatedAssist?: () => void;
   externalAccessEnabled?: boolean;
+  /** Hide Web access when coworker lacks web_search grant (BI-CD9DC3BC). */
+  webAccessAvailable?: boolean;
   onToggleExternalAccess?: () => void;
   coworkerMode?: "advise" | "act";
   onToggleCoworkerMode?: () => void;
@@ -90,7 +92,7 @@ function truncate(value: string, max = 32): string {
   return `${value.slice(0, max - 1)}…`;
 }
 
-export function AgentMessageInput({ onSend, composerState, busy, threadId, pendingFile, onFileUploaded, onFileClear, voiceSynthAvailable, voicePlaybackUnavailableReason, voicePlaybackEnabled, onVoicePlaybackToggle, elevatedAssistEnabled, onToggleElevatedAssist, externalAccessEnabled, onToggleExternalAccess, coworkerMode, onToggleCoworkerMode, useUnified }: Props) {
+export function AgentMessageInput({ onSend, composerState, busy, threadId, pendingFile, onFileUploaded, onFileClear, voiceSynthAvailable, voicePlaybackUnavailableReason, voicePlaybackEnabled, onVoicePlaybackToggle, elevatedAssistEnabled, onToggleElevatedAssist, externalAccessEnabled, onToggleExternalAccess, webAccessAvailable = true, coworkerMode, onToggleCoworkerMode, useUnified }: Props) {
   const disabled = composerInputDisabled(composerState);
   const [value, setValue] = useState("");
   const [intentCenter, setIntentCenter] = useState("");
@@ -871,6 +873,7 @@ export function AgentMessageInput({ onSend, composerState, busy, threadId, pendi
               onToggleElevatedAssist={onToggleElevatedAssist!}
               externalAccessEnabled={!!externalAccessEnabled}
               onToggleExternalAccess={onToggleExternalAccess!}
+              webAccessAvailable={webAccessAvailable}
               {...(coworkerMode ? { coworkerMode } : {})}
               {...(onToggleCoworkerMode ? { onToggleCoworkerMode } : {})}
               useUnified={useUnified}

--- a/apps/web/components/agent/CoworkerPostureControl.test.tsx
+++ b/apps/web/components/agent/CoworkerPostureControl.test.tsx
@@ -41,6 +41,13 @@ describe("CoworkerPostureControl", () => {
     expect(screen.getByRole("switch", { name: "Web access" })).toBeTruthy();
   });
 
+  it("hides Web access when the coworker lacks web_search (BI-CD9DC3BC)", () => {
+    render(<CoworkerPostureControl {...baseProps} webAccessAvailable={false} />);
+    fireEvent.click(screen.getByText("Controls"));
+    expect(screen.getByRole("switch", { name: "Edit fields on this page" })).toBeTruthy();
+    expect(screen.queryByRole("switch", { name: "Web access" })).toBeNull();
+  });
+
   it("fires the page-editing toggle through the switch", () => {
     const onToggleElevatedAssist = vi.fn();
     render(<CoworkerPostureControl {...baseProps} onToggleElevatedAssist={onToggleElevatedAssist} />);

--- a/apps/web/components/agent/CoworkerPostureControl.tsx
+++ b/apps/web/components/agent/CoworkerPostureControl.tsx
@@ -7,6 +7,12 @@ type Props = {
   onToggleElevatedAssist: () => void;
   externalAccessEnabled: boolean;
   onToggleExternalAccess: () => void;
+  /**
+   * When false, the Web access switch is hidden. Agents without the
+   * `web_search` grant cannot use public web tools even if the session
+   * flag is on — showing the toggle is a no-op (BI-CD9DC3BC).
+   */
+  webAccessAvailable?: boolean;
   coworkerMode?: "advise" | "act";
   onToggleCoworkerMode?: () => void;
   useUnified?: boolean;
@@ -106,6 +112,7 @@ export function CoworkerPostureControl({
   onToggleElevatedAssist,
   externalAccessEnabled,
   onToggleExternalAccess,
+  webAccessAvailable = true,
   coworkerMode,
   onToggleCoworkerMode,
   useUnified,
@@ -117,6 +124,7 @@ export function CoworkerPostureControl({
   const [open, setOpen] = useState(false);
   const showMode = Boolean(useUnified && onToggleCoworkerMode);
   const isAct = coworkerMode === "act";
+  const showWebAccess = webAccessAvailable;
 
   useEffect(() => {
     if (!open) return;
@@ -130,9 +138,10 @@ export function CoworkerPostureControl({
   const summaryParts: string[] = [];
   if (showMode) summaryParts.push(isAct ? "Act" : "Advise");
   if (elevatedAssistEnabled) summaryParts.push("edits on");
-  if (externalAccessEnabled) summaryParts.push("web on");
+  if (showWebAccess && externalAccessEnabled) summaryParts.push("web on");
   const summaryLabel = summaryParts.length > 0 ? summaryParts.join(" · ") : "Controls";
-  const postureActive = elevatedAssistEnabled || externalAccessEnabled || (showMode && isAct);
+  const postureActive =
+    elevatedAssistEnabled || (showWebAccess && externalAccessEnabled) || (showMode && isAct);
 
   const popoverShell: React.CSSProperties = {
     position: "absolute",
@@ -269,17 +278,19 @@ export function CoworkerPostureControl({
                 : "Off: this page's coworker only suggests changes"
             }
           />
-          <ToggleSwitchRow
-            checked={externalAccessEnabled}
-            onToggle={onToggleExternalAccess}
-            label="Web access"
-            description="Allow web search and fetch this session"
-            title={
-              externalAccessEnabled
-                ? "On: this page's coworker can use approved public web search and fetch tools"
-                : "Off: this page's coworker cannot reach public web tools"
-            }
-          />
+          {showWebAccess && (
+            <ToggleSwitchRow
+              checked={externalAccessEnabled}
+              onToggle={onToggleExternalAccess}
+              label="Web access"
+              description="Allow web search and fetch this session"
+              title={
+                externalAccessEnabled
+                  ? "On: this page's coworker can use approved public web search and fetch tools"
+                  : "Off: this page's coworker cannot reach public web tools"
+              }
+            />
+          )}
         </div>
       )}
     </div>

--- a/apps/web/lib/agent-holds-web-search.test.ts
+++ b/apps/web/lib/agent-holds-web-search.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { agentHoldsWebSearchGrant } from "./tak/agent-web-search-grant";
+
+describe("agentHoldsWebSearchGrant (BI-CD9DC3BC)", () => {
+  it("is true for outward research roles and false for no-web governance roles", () => {
+    expect(agentHoldsWebSearchGrant("marketing-specialist")).toBe(true);
+    expect(agentHoldsWebSearchGrant("customer-advisor")).toBe(true);
+    expect(agentHoldsWebSearchGrant("data-governance-agent")).toBe(false);
+    expect(agentHoldsWebSearchGrant("soc-triage-analyst")).toBe(false);
+    expect(agentHoldsWebSearchGrant(null)).toBe(false);
+  });
+});

--- a/apps/web/lib/tak/agent-web-search-grant.ts
+++ b/apps/web/lib/tak/agent-web-search-grant.ts
@@ -1,0 +1,22 @@
+// Client-safe: registry JSON only. Do not import agent-grants.ts from client
+// components — that module pulls server-only graphs (fs/net) into Turbopack.
+import agentRegistryData from "../../../../packages/db/data/agent_registry.json";
+
+type AgentEntry = {
+  agent_id?: string;
+  agent_name?: string;
+  config_profile?: { tool_grants?: string[] };
+};
+
+const agents = (agentRegistryData as { agents: AgentEntry[] }).agents;
+
+/**
+ * Whether this coworker can ever use public web tools (`web_search` grant).
+ * Session "Web access" is a no-op without it — UI must hide the switch (BI-CD9DC3BC).
+ */
+export function agentHoldsWebSearchGrant(agentId: string | null | undefined): boolean {
+  if (!agentId) return false;
+  const agent = agents.find((a) => a.agent_id === agentId || a.agent_name === agentId);
+  const grants = agent?.config_profile?.tool_grants ?? [];
+  return grants.includes("web_search");
+}

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -2,8 +2,8 @@ apps/web/app/api/mcp/v1/route.test.ts	1260
 apps/web/app/api/v1/edge/discovery-runs/route.test.ts	982
 apps/web/components/admin/BusinessModelBuilder.tsx	821
 apps/web/components/admin/McpTokenManager.tsx	1373
-apps/web/components/agent/AgentCoworkerPanel.tsx	1203
-apps/web/components/agent/AgentMessageInput.tsx	1031
+apps/web/components/agent/AgentCoworkerPanel.tsx	1206
+apps/web/components/agent/AgentMessageInput.tsx	1034
 apps/web/components/ea/EaCanvas.tsx	1047
 apps/web/components/inventory/TopologyGraph.tsx	1031
 apps/web/components/ops/SelfUpgradeClient.test.tsx	997


### PR DESCRIPTION
## Summary
- Hide Web access when coworker lacks `web_search` (client-safe helper).

## BI
BI-CD9DC3BC

Design-Grounding-Decision: reviewed agent posture UI; hide unavailable Web access control for no-web roles; no IA/route change.

Process-Spine-Decision: small bugfix with unit tests.