### PR TITLE
chore(compose): pin remaining third-party :latest tags (BI-5C45394F)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -675,7 +675,7 @@ services:
   # Captures EVERY container's stdout/stderr with 14-day retention so errors
   # stop scrolling out of the ephemeral Docker buffer unseen.
   loki:
-    image: grafana/loki:latest
+    image: grafana/loki:3.4.3
     restart: unless-stopped
     logging: *default-logging
     ports:
@@ -694,7 +694,7 @@ services:
     # scrapes it and the portal's log-issues panel talks to its API.
 
   alloy:
-    image: grafana/alloy:latest
+    image: grafana/alloy:v1.7.5
     restart: unless-stopped
     logging: *default-logging
     volumes:
@@ -721,7 +721,7 @@ services:
   # should use docker-compose.linux.yml, which also mounts the matching
   # Prometheus scrape config for these exporter targets.
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
     restart: unless-stopped
     logging: *default-logging
     profiles: ["linux-monitoring"]
@@ -734,7 +734,7 @@ services:
     privileged: true
 
   node-exporter:
-    image: prom/node-exporter:latest
+    image: prom/node-exporter:v1.9.1
     restart: unless-stopped
     logging: *default-logging
     profiles: ["linux-monitoring"]
@@ -923,7 +923,7 @@ services:
   #
   # Opt-in: docker compose --profile tts up
   dpf-tts:
-    image: ${DPF_TTS_IMAGE:-travisvn/chatterbox-tts-api:latest}
+    image: ${DPF_TTS_IMAGE:-travisvn/chatterbox-tts-api:v0.1.0}
     profiles: ["tts"]
     restart: unless-stopped
     logging: *default-logging


### PR DESCRIPTION
## Summary
- Pin loki, alloy, cadvisor, node-exporter, and TTS default away from `:latest`.

## BI
BI-5C45394F

Process-Spine-Decision: supply-chain pin hygiene.