### PR TITLE
doc(agents): advise-safe tools, server-action exports, coworker filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,15 @@ Every tool call writes to `ToolExecution` (`agentId`, `userId`, `toolName`, `par
 
 The paved-road walkthrough is the `dpf-establish-coworker` skill (`packages/dpf-skill-pack/skills/dpf-establish-coworker/SKILL.md`).
 
+
+## 8a. Advise-safe tools, server-action exports, coworker coordination (pointers)
+
+**Advise-safe tool classification (BI-IMP-F710F41C).** A side-effect tool (`sideEffect: true` in `mcp-tools.ts`) may stay visible in **advise mode** only when it (1) preserves human visibility (SSE + UI cards), (2) writes an audit trail (e.g. `ToolExecution` / delegation chain), (3) is grant- and lifecycle-gated, and (4) is listed in a **shared constant** imported by every filter path (see `adviseHeldBackTools` / coworker tool filter). Do not invent a parallel allowlist per route. Prefer pure reads in advise mode; only promote a side-effect into advise when those four hold.
+
+**`"use server"` modules export only functions and concrete values (BI-IMP-21C466DE).** Type aliases and interfaces stay **local** (or live in a non-`"use server"` module). Exporting types from a server-action file breaks Turbopack registration. Prefer `export type` from a sibling `*.types.ts` or `lib/` module.
+
+**Coworker capability filtering is single-source (BI-IMP-60B0893E).** Agent tool grants live in `agent_registry.json` / `AgentToolGrant`; runtime intersection is `getAvailableTools` + `TOOL_TO_GRANTS` + coworker filter helpers under `apps/web/lib/actions/coworker-tool-filter.ts` and `apps/web/lib/tak/agent-grants.ts`. Route-local allowlists that re-express the same policy are defects — extend the shared filter, do not fork it. Peer coordination tools (`request_coworker`, `summon_coworker`) follow the advise-safe pattern above.
+
 ## 9. External Tools
 
 → [kernel principle](docs/founder-kernel/wiki/principles/tool-evaluation-pipeline.md)


### PR DESCRIPTION
## Summary
- AGENTS.md §8a documents advise-safe tool classification, use-server export rules, and single-source coworker filters.

## BIs
BI-IMP-F710F41C, BI-IMP-21C466DE, BI-IMP-60B0893E