### PR TITLE
feat(work-mgmt): render the agent-session activity feed on the capsule page (BI-C41AB195)

### DIFF
--- a/apps/web/app/(shell)/build/work/[capsuleId]/page.tsx
+++ b/apps/web/app/(shell)/build/work/[capsuleId]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
 import { WorkCapsuleLaunchPanel } from "@/components/build/work-control/WorkCapsuleLaunchPanel";
+import { AgentSessionFeed } from "@/components/build/AgentSessionFeed";
 import { getCapsuleDetail } from "@/lib/actions/work-capsules";
 import { auth } from "@/lib/auth";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
@@ -45,6 +46,7 @@ export default async function CapsuleDetailPage({
         <div className="font-mono text-xs text-[var(--dpf-muted)]">{capsule.capsuleId}</div>
       </header>
       <PortalContextStrip envelope={portalContext} />
+      <AgentSessionFeed activities={capsule.activities} />
       <WorkCapsuleLaunchPanel steps={steps} />
     </section>
   );

--- a/apps/web/components/build/AgentSessionFeed.tsx
+++ b/apps/web/components/build/AgentSessionFeed.tsx
@@ -1,0 +1,55 @@
+// BI-C41AB195: render a WorkCapsule's activity rows as a teammate "agent session"
+// feed — what an AI coworker (or peer) is doing on the work item, in plain
+// language. Typed agent activities (thought/action/question/response/error) read
+// prominently; lifecycle plumbing is muted context.
+
+import {
+  presentAgentSession,
+  type CapsuleActivityRow,
+  type AgentSessionTone,
+} from "@/lib/work-capsules/agent-activity-presenter";
+
+const TONE_DOT: Record<AgentSessionTone, string> = {
+  thought: "var(--dpf-muted)",
+  action: "var(--dpf-accent)",
+  question: "var(--dpf-warning, #b0872e)",
+  response: "var(--dpf-accent)",
+  error: "var(--dpf-danger, #bc4a38)",
+  lifecycle: "var(--dpf-border)",
+};
+
+const ACTOR_LABEL = { agent: "AI coworker", human: "You", system: "System" } as const;
+
+export function AgentSessionFeed({ activities }: { activities: CapsuleActivityRow[] }) {
+  const entries = presentAgentSession(activities);
+
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Activity</h2>
+      {entries.length === 0 ? (
+        <p className="m-0 text-xs text-[var(--dpf-muted)]">
+          No activity yet — updates from whoever is working this item will appear here.
+        </p>
+      ) : (
+        <ol className="m-0 list-none space-y-2 p-0">
+          {entries.map((entry) => (
+            <li key={entry.id} className="flex gap-2.5">
+              <span
+                aria-hidden="true"
+                className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: TONE_DOT[entry.tone] }}
+              />
+              <div className="min-w-0">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-xs font-semibold text-[var(--dpf-text)]">{entry.label}</span>
+                  <span className="text-[11px] text-[var(--dpf-muted)]">{ACTOR_LABEL[entry.actor]}</span>
+                </div>
+                <p className="m-0 text-sm text-[var(--dpf-text)]">{entry.summary}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/web/lib/work-capsules/agent-activity-presenter.test.ts
+++ b/apps/web/lib/work-capsules/agent-activity-presenter.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { presentAgentSession, hasAgentActivity } from "./agent-activity-presenter";
+
+const at = new Date("2026-07-12T00:00:00.000Z");
+
+describe("presentAgentSession (BI-C41AB195)", () => {
+  it("gives typed agent activities a plain label, their own tone, and the agent actor", () => {
+    const [thought, action] = presentAgentSession([
+      { id: "1", kind: "thought", summary: "Deciding the approach", recordedAt: at, recordedByAgentId: "AGT-1" },
+      { id: "2", kind: "action", summary: "Edited the parser", recordedAt: at, recordedByAgentId: "AGT-1" },
+    ]);
+    expect(thought).toMatchObject({ tone: "thought", label: "Thinking", actor: "agent" });
+    expect(action).toMatchObject({ tone: "action", label: "Did", actor: "agent" });
+  });
+
+  it("tones lifecycle plumbing as 'lifecycle' with a title-cased label", () => {
+    const [entry] = presentAgentSession([
+      { id: "3", kind: "evidence-recorded", summary: "Attached a PR", recordedAt: at, recordedById: "user-1" },
+    ]);
+    expect(entry).toMatchObject({ tone: "lifecycle", label: "Evidence Recorded", actor: "human" });
+  });
+
+  it("classifies the actor: agent > human > system", () => {
+    const rows = [
+      { id: "a", kind: "response", summary: "x", recordedAt: at, recordedByAgentId: "AGT-1", recordedById: "user-1" },
+      { id: "b", kind: "response", summary: "x", recordedAt: at, recordedById: "user-1" },
+      { id: "c", kind: "created", summary: "x", recordedAt: at },
+    ].map((r) => presentAgentSession([r])[0]);
+    expect(rows.map((r) => r.actor)).toEqual(["agent", "human", "system"]);
+  });
+
+  it("preserves input order (newest-first as passed)", () => {
+    const ids = presentAgentSession([
+      { id: "new", kind: "action", summary: "x", recordedAt: at },
+      { id: "old", kind: "thought", summary: "y", recordedAt: at },
+    ]).map((e) => e.id);
+    expect(ids).toEqual(["new", "old"]);
+  });
+
+  it("hasAgentActivity is true only when a typed agent activity is present", () => {
+    expect(hasAgentActivity([{ id: "1", kind: "created", summary: "x", recordedAt: at }])).toBe(false);
+    expect(hasAgentActivity([{ id: "2", kind: "question", summary: "x", recordedAt: at }])).toBe(true);
+  });
+});

--- a/apps/web/lib/work-capsules/agent-activity-presenter.ts
+++ b/apps/web/lib/work-capsules/agent-activity-presenter.ts
@@ -1,0 +1,84 @@
+// BI-C41AB195 (EP-WORK-CONVERGENCE): present a WorkCapsule's activity rows as a
+// human-legible "agent session" feed — the teammate timeline a person reads to
+// see what an AI coworker (or a peer) is doing on the work item, instead of raw
+// logs. The typed agent activities (thought / action / question / response /
+// error, written via record_agent_activity) surface prominently; lifecycle
+// plumbing (created, adopted, evidence-recorded, …) is kept as muted context.
+// Pure + unit-testable; the React feed renders these entries.
+
+import { isAgentActivityKind, type AgentActivityKind } from "@/lib/work-capsules";
+
+export type AgentSessionTone = AgentActivityKind | "lifecycle";
+export type AgentSessionActor = "agent" | "human" | "system";
+
+export interface AgentSessionEntry {
+  id: string;
+  tone: AgentSessionTone;
+  label: string;
+  summary: string;
+  recordedAt: Date;
+  actor: AgentSessionActor;
+}
+
+const AGENT_KIND_LABEL: Record<AgentActivityKind, string> = {
+  thought: "Thinking",
+  action: "Did",
+  question: "Asked",
+  response: "Responded",
+  error: "Hit a problem",
+};
+
+function actorOf(row: {
+  recordedByAgentId?: string | null;
+  recordedById?: string | null;
+}): AgentSessionActor {
+  if (row.recordedByAgentId) return "agent";
+  if (row.recordedById) return "human";
+  return "system";
+}
+
+export interface CapsuleActivityRow {
+  id: string;
+  kind: string;
+  summary: string;
+  recordedAt: Date;
+  recordedByAgentId?: string | null;
+  recordedById?: string | null;
+}
+
+/**
+ * Map raw capsule-activity rows to session entries. Typed agent activities get a
+ * plain label and their own tone; everything else is toned "lifecycle" and
+ * labelled from its kind (e.g. "evidence-recorded" → "Evidence recorded").
+ * Input order is preserved (callers pass newest-first).
+ */
+export function presentAgentSession(rows: CapsuleActivityRow[]): AgentSessionEntry[] {
+  return rows.map((row) => {
+    if (isAgentActivityKind(row.kind)) {
+      return {
+        id: row.id,
+        tone: row.kind,
+        label: AGENT_KIND_LABEL[row.kind],
+        summary: row.summary,
+        recordedAt: row.recordedAt,
+        actor: actorOf(row),
+      };
+    }
+    return {
+      id: row.id,
+      tone: "lifecycle",
+      label: row.kind
+        .split("-")
+        .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+        .join(" "),
+      summary: row.summary,
+      recordedAt: row.recordedAt,
+      actor: actorOf(row),
+    };
+  });
+}
+
+/** True when the feed has at least one typed agent activity (vs only plumbing). */
+export function hasAgentActivity(rows: CapsuleActivityRow[]): boolean {
+  return rows.some((row) => isAgentActivityKind(row.kind));
+}

--- a/docs/superpowers/plans/2026-07-12-bi-c41ab195-agent-session-feed-render.md
+++ b/docs/superpowers/plans/2026-07-12-bi-c41ab195-agent-session-feed-render.md
@@ -1,0 +1,15 @@
+# Implementation Plan — BI-C41AB195: agent-session feed render on the capsule page
+
+**BI:** BI-C41AB195 (EP-WORK-CONVERGENCE) · **Date:** 2026-07-12 · **Status:** Render slice implemented (substrate + write tool already merged).
+
+## Gap closed
+The C41AB195 substrate shipped earlier: `AGENT_ACTIVITY_KINDS` (thought/action/question/response/error), the `recordAgentActivity` writer, and the `record_agent_activity` MCP tool. `getCapsuleDetail` already fetched `activities` — but the capsule detail page (`build/work/[capsuleId]/page.tsx`) rendered only the launch panel, so the activities were loaded and thrown away. This renders them.
+
+## This slice
+- `lib/work-capsules/agent-activity-presenter.ts` — pure `presentAgentSession(rows)`: typed agent activities get a plain label + own tone + actor (agent>human>system); lifecycle plumbing is toned "lifecycle" with a title-cased label. `hasAgentActivity` helper. Input order preserved.
+- `components/build/AgentSessionFeed.tsx` — renders the entries as a teammate timeline (tone dot + label + actor + plain summary); empty state when no activity.
+- `build/work/[capsuleId]/page.tsx` — render `<AgentSessionFeed activities={capsule.activities} />` (data already fetched).
+
+## Verification
+- Unit tests on the pure presenter (typed-vs-lifecycle, actor classification, order, hasAgentActivity). Typecheck.
+- Live-portal (deferred to the epic validation pass): confirm a `record_agent_activity` call renders on the page.


### PR DESCRIPTION
## What
The C41AB195 substrate (typed agent activities + `recordAgentActivity` + the `record_agent_activity` tool) and the `getCapsuleDetail` activities fetch already shipped, but the capsule detail page rendered only the launch panel — activities were loaded and discarded. This renders them as a teammate **agent-session feed**: what an AI coworker (or peer) is doing on the work item, in plain language.

## Changes
- `lib/work-capsules/agent-activity-presenter.ts` — pure `presentAgentSession`; typed activities get plain labels + tone + actor, lifecycle plumbing muted.
- `components/build/AgentSessionFeed.tsx` — teammate timeline + empty state.
- `build/work/[capsuleId]/page.tsx` — render the feed.

## Verification
- 5 unit tests; typecheck clean. Live-portal render validation deferred to the epic pass.

**Local-CI-Override:** verified locally (5 tests, tsc 0 errors); local-CI `next build` OOM (env); GitHub CI authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)