### PR TITLE
fix(process): seed worktree readiness from unified bootstrap

### DIFF
--- a/docs/superpowers/plans/2026-07-14-bi-9a8e85f4-bootstrap-readiness.md
+++ b/docs/superpowers/plans/2026-07-14-bi-9a8e85f4-bootstrap-readiness.md
@@ -1,0 +1,39 @@
+# BI-9A8E85F4 — unified bootstrap worktree readiness repair
+
+Backlog item: `BI-9A8E85F4` — Agent toolchain bootstrap does not create the documented worktree readiness files.
+
+## Current-state evidence
+
+- `AGENTS.md` documents `scripts/dpf-bootstrap-agent-toolchain.sh` as the single command a linked worktree should run to get MCP config, Compose isolation, and `.dpf-worktree-readiness.json`.
+- `scripts/seed-worktree-mcp.sh` owns the actual `.env` / `COMPOSE_PROJECT_NAME` / readiness-marker implementation.
+- Running `scripts/dpf-bootstrap-agent-toolchain.sh` in a fresh linked worktree converged agent/plugin wiring but did not create `.env` or `.dpf-worktree-readiness.json`; running `scripts/seed-worktree-mcp.sh` afterward repaired those files.
+- A no-`node` PATH can still have a runnable `pnpm` wrapper, but lifecycle scripts fail unless the bundled Node `bin` directory is also on PATH.
+
+## Plan
+
+1. Add a `--core-only` mode to `scripts/seed-worktree-mcp.sh`.
+   - Deliverable: seed script can write MCP config, Compose isolation, and readiness without invoking skill-pack/bootstrap recursion.
+   - Verification: release contract test proves `--core-only` writes `.env`, `.mcp.json`, and `.dpf-worktree-readiness.json` even when `ensure-dpf-skill-pack.sh` would fail.
+
+2. Make `scripts/dpf-bootstrap-agent-toolchain.sh` delegate linked-worktree metadata to the seed script.
+   - Deliverable: bootstrap runs core seeding before toolchain work and refreshes it after normal or fallback completion.
+   - Verification: static release contract asserts bootstrap calls `seed-worktree-mcp.sh --core-only` on pre-toolchain, post-toolchain, and post-fallback paths.
+
+3. Harden POSIX bootstrap child-process PATH for bundled Node runtimes.
+   - Deliverable: if `node` is absent but a known bundled Codex Node runtime exists, bootstrap prepends it so dependency lifecycle scripts can find `node`.
+   - Verification: functional bootstrap run from a linked worktree without `node` on PATH adds the bundled runtime and completes far enough to recreate `.env` and readiness metadata.
+
+## Risks and rollback
+
+- Risk: accidental recursion between seed and bootstrap. Mitigation: `--core-only` skips skill-pack bootstrap.
+- Risk: duplicate metadata logic. Mitigation: bootstrap delegates to the seed script rather than reimplementing `.env` / readiness generation.
+- Rollback: revert this plan and the paired script/test changes; legacy `seed-worktree-mcp.sh` remains the manual repair path.
+
+## Verification commands
+
+- `PATH=/Users/markbodman/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --test tests/release/worktree-readiness-contract.test.mjs`
+- Functional check in linked worktree:
+  - remove `.env` and `.dpf-worktree-readiness.json`
+  - run `bash scripts/dpf-bootstrap-agent-toolchain.sh`
+  - verify `.env` contains non-root `COMPOSE_PROJECT_NAME`
+  - verify `.dpf-worktree-readiness.json` exists and reports the current readiness state

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -604,6 +604,7 @@ HOOK_PURPOSES = {
     "decision-routing-guard.mjs": "blocks asking the operator a platform decision with no kernel consultation",
     "ux-fit-precheck.mjs": "reminds to run a UX-fit review when editing UI surfaces",
     "spec-plan-doc-precheck.mjs": "reminds to attach a spec/plan/doc when writing gated files",
+    "design-grounding-precheck.mjs": "reminds to review specs and current code substrate before UX/workflow edits",
     "tool-economy-precheck.mjs": "reminds about tool-economy budget when adding tool surface",
     "worktree-create.mjs": "seeds a new worktree with MCP config on WorktreeCreate",
     "governance-freshness-check.mjs": "SessionStart: warns if governance guard wiring is stale",

--- a/scripts/dpf-bootstrap-agent-toolchain.sh
+++ b/scripts/dpf-bootstrap-agent-toolchain.sh
@@ -119,6 +119,53 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 # shellcheck source=installer/lib/state.sh
 . "$SCRIPT_DIR/installer/lib/state.sh"
 
+# --- Worktree core seeding ---------------------------------------------------
+#
+# AGENTS.md documents this unified bootstrap as the one command that prepares a
+# linked worktree: MCP config, worktree-scoped COMPOSE_PROJECT_NAME, and
+# .dpf-worktree-readiness.json. The legacy seed script remains the single owner
+# of that file-writing/classification logic; bootstrap invokes it in core-only
+# mode to avoid the old ensure-dpf-skill-pack -> bootstrap recursion.
+
+is_linked_worktree() {
+  git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+  _common="$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+  _main="$(cd "$(dirname "$_common")" && pwd -P)"
+  [ "$_main" != "$REPO_ROOT" ]
+}
+
+seed_worktree_core() {
+  _phase="$1"
+  [ "$DRY_RUN" -eq 1 ] && { info "DRY-RUN: would refresh worktree MCP config, Compose isolation, and readiness marker ($_phase)."; return 0; }
+  [ -f "$SCRIPT_DIR/seed-worktree-mcp.sh" ] || return 0
+  if is_linked_worktree; then
+    if bash "$SCRIPT_DIR/seed-worktree-mcp.sh" "$REPO_ROOT" --core-only >/dev/null; then
+      ok "Worktree core seeded ($_phase): MCP config, Compose isolation, readiness marker."
+    else
+      warn "Worktree core seed failed ($_phase); continuing with toolchain bootstrap."
+    fi
+  fi
+}
+
+seed_worktree_core "pre-toolchain"
+
+# Some contributor surfaces launch this script with pnpm available through a
+# bundled runtime while `node` itself is absent from PATH. pnpm can start, but
+# dependency lifecycle scripts (`node install/check.js`, etc.) then fail. If a
+# known bundled Node runtime exists, expose its bin directory to child processes.
+if ! command -v node >/dev/null 2>&1; then
+  for _node_dir in \
+    "$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin" \
+    "$HOME/.local/share/codex/node/bin" \
+    "$HOME/.codex/node/bin"; do
+    if [ -x "$_node_dir/node" ]; then
+      export PATH="$_node_dir:$PATH"
+      ok "Node runtime added to PATH for bootstrap child processes."
+      break
+    fi
+  done
+fi
+
 # --- Resolve substrate paths -------------------------------------------------
 
 CODEX_CONFIG_PATH="$HOME/.codex/config.toml"
@@ -356,7 +403,12 @@ if ! pnpm "${bridge_args[@]}" > "$PLAN_TMP" 2>&1; then
   if [ -f "$FALLBACK" ]; then
     fallback_args=(--mcp-url "$MCP_ENDPOINT")
     [ "$DRY_RUN" -eq 1 ] && fallback_args+=(--dry-run)
-    exec bash "$FALLBACK" "${fallback_args[@]}"
+    if bash "$FALLBACK" "${fallback_args[@]}"; then
+      seed_worktree_core "post-fallback"
+      exit 0
+    fi
+    fail "Standalone updater failed."
+    exit 1
   fi
   fail "Standalone updater missing at $FALLBACK; cannot proceed."
   exit 1
@@ -710,5 +762,7 @@ if [ "$SHOW_SUBSTRATE" -eq 1 ]; then
   printf '    DPF platform ver  : %s\n' "$EXPECTED_VERSION"
   printf '    State file        : %s\n' "$(dpf_state_path)"
 fi
+
+seed_worktree_core "post-toolchain"
 
 printf '\n'

--- a/scripts/seed-worktree-mcp.sh
+++ b/scripts/seed-worktree-mcp.sh
@@ -21,14 +21,17 @@
 #   ./scripts/seed-worktree-mcp.sh <path>           # seed a specific worktree
 #   ./scripts/seed-worktree-mcp.sh --force          # overwrite existing files
 #   ./scripts/seed-worktree-mcp.sh <path> --force
+#   ./scripts/seed-worktree-mcp.sh <path> --core-only
 
 set -euo pipefail
 
 target=""
 force=0
+core_only=0
 for arg in "$@"; do
     case "$arg" in
         --force) force=1 ;;
+        --core-only) core_only=1 ;;
         *)
             if [ -z "$target" ]; then
                 target="$arg"
@@ -225,14 +228,18 @@ cat > "$target_abs/.dpf-worktree-readiness.json" <<EOF
 EOF
 ok "Recorded $readiness_state readiness in $target_abs/.dpf-worktree-readiness.json ($readiness_reason)"
 
-step "Ensuring DPF skill pack"
-skill_pack_script="$target_abs/scripts/ensure-dpf-skill-pack.sh"
-if [ -f "$skill_pack_script" ]; then
-    if ! bash "$skill_pack_script" "$target_abs"; then
-        warn "DPF skill pack bootstrap failed; MCP config, Compose isolation, and readiness marker were still written."
-    fi
+if [ "$core_only" -eq 1 ]; then
+    skip "Core-only mode requested; skipping DPF skill pack bootstrap."
 else
-    skip "No DPF skill pack installer found at $skill_pack_script"
+    step "Ensuring DPF skill pack"
+    skill_pack_script="$target_abs/scripts/ensure-dpf-skill-pack.sh"
+    if [ -f "$skill_pack_script" ]; then
+        if ! bash "$skill_pack_script" "$target_abs"; then
+            warn "DPF skill pack bootstrap failed; MCP config, Compose isolation, and readiness marker were still written."
+        fi
+    else
+        skip "No DPF skill pack installer found at $skill_pack_script"
+    fi
 fi
 
 printf '\nDone. Restart Claude Code, Codex, or VS Code in the worktree to pick up the dpf connector and skill pack.\n\n'

--- a/tests/release/worktree-readiness-contract.test.mjs
+++ b/tests/release/worktree-readiness-contract.test.mjs
@@ -112,6 +112,22 @@ test("seed-worktree-mcp.sh keeps core worktree setup even when optional skill bo
   }
 });
 
+test("seed-worktree-mcp.sh core-only writes worktree metadata without invoking skill bootstrap", () => {
+  const fixture = createRepoWithWorktree("core-only");
+  try {
+    mkdirSync(join(fixture.worktree, "scripts"), { recursive: true });
+    writeFileSync(join(fixture.worktree, "scripts", "ensure-dpf-skill-pack.sh"), "#!/bin/sh\nexit 42\n");
+
+    run("sh", [seedScript.pathname, fixture.worktree, "--core-only"]);
+
+    assert.match(readFileSync(join(fixture.worktree, ".env"), "utf8"), /^COMPOSE_PROJECT_NAME=dpf-core-only$/m);
+    assert.equal(readReadiness(fixture.worktree).reason, "node_modules_missing");
+    assert.equal(readFileSync(join(fixture.worktree, ".mcp.json"), "utf8"), readFileSync(join(fixture.repo, ".mcp.json"), "utf8"));
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("sync-mcp-worktrees.sh refreshes linked worktrees and stamps readiness markers", () => {
   const fixture = createRepoWithWorktree("sync-topic");
   try {
@@ -145,4 +161,14 @@ test("PowerShell worktree sync/seed scripts retain readiness-marker parity", () 
 
   assert.match(syncPs1, /Copy-WorktreeFile/, "sync script should copy MCP files portably");
   assert.doesNotMatch(syncPs1, /fsutil\s+hardlink/i, "sync script must not regress to D-drive-only hardlinks");
+});
+
+test("unified POSIX bootstrap delegates linked-worktree metadata to seed core", () => {
+  const bootstrap = readRepo("scripts/dpf-bootstrap-agent-toolchain.sh");
+
+  assert.match(bootstrap, /seed-worktree-mcp\.sh/, "bootstrap should invoke the seed script for linked worktree metadata");
+  assert.match(bootstrap, /--core-only/, "bootstrap must avoid recursive skill-pack bootstrap when seeding worktree metadata");
+  assert.match(bootstrap, /pre-toolchain/, "bootstrap should seed Compose isolation before toolchain work");
+  assert.match(bootstrap, /post-toolchain/, "bootstrap should refresh readiness after toolchain work");
+  assert.match(bootstrap, /post-fallback/, "fallback path should refresh readiness too");
 });


### PR DESCRIPTION
## Summary

Fixes `BI-9A8E85F4`: the unified POSIX agent bootstrap now actually creates the linked-worktree metadata that AGENTS.md says it owns.

Changes:
- Adds `--core-only` mode to `scripts/seed-worktree-mcp.sh` so it can write MCP config, `COMPOSE_PROJECT_NAME`, and `.dpf-worktree-readiness.json` without recursively invoking the skill-pack/bootstrap path.
- Updates `scripts/dpf-bootstrap-agent-toolchain.sh` to run that core seeding before toolchain work and refresh it after normal or fallback completion.
- Adds a small PATH hardening step so bundled Node is exposed to dependency lifecycle scripts when `pnpm` exists but `node` is absent from PATH.
- Adds release contract tests and a BI-backed plan.

## Backlog

- `BI-9A8E85F4`

## Verification

- `node --test tests/release/worktree-readiness-contract.test.mjs` — 7/7 passed
- `bash -n scripts/dpf-bootstrap-agent-toolchain.sh scripts/seed-worktree-mcp.sh`
- `git diff --check`
- Functional linked-worktree check: deleted `.env` and `.dpf-worktree-readiness.json`, ran `bash scripts/dpf-bootstrap-agent-toolchain.sh`, verified:
  - `.env` contains `COMPOSE_PROJECT_NAME=dpf-bootstrap-readiness`
  - `.dpf-worktree-readiness.json` exists and reports `compile-ready`
- `pnpm run pregate` — local-CI lease `NPEL-7E21A99432`, gate passed

## Design grounding

- Existing spec/plan search for `BI-9A8E85F4` and bootstrap readiness returned no covering plan.
- Current substrate reviewed: `scripts/dpf-bootstrap-agent-toolchain.sh`, `scripts/seed-worktree-mcp.sh`, `tests/release/worktree-readiness-contract.test.mjs`, `AGENTS.md` worktree/bootstrap contract.
- Decision: keep seed script as the single owner of worktree metadata and delegate to it from bootstrap in `--core-only` mode to avoid recursive bootstrap.
