### PR TITLE
fix(build-studio): hide dispatch tool jargon from default operator surface (BI-F606D0E6)

### DIFF
--- a/apps/web/components/build/BuildDispatchHistoryCard.test.tsx
+++ b/apps/web/components/build/BuildDispatchHistoryCard.test.tsx
@@ -30,10 +30,10 @@ function makeAttempt(): BuildDispatchAttemptView {
 }
 
 describe("BuildDispatchHistoryCard", () => {
-  it("renders attempt metadata and bounded failure output", () => {
-    render(<BuildDispatchHistoryCard attempts={[makeAttempt()]} />);
+  it("renders attempt metadata and bounded failure output in engineer view", () => {
+    render(<BuildDispatchHistoryCard attempts={[makeAttempt()]} engineerView />);
 
-    expect(screen.getByText("Dispatch")).toBeInTheDocument();
+    expect(screen.getByText("Dispatch attempts")).toBeInTheDocument();
     expect(screen.getByText("Add dispatch telemetry")).toBeInTheDocument();
     expect(screen.getByText(/exit 1.*usage-limit/)).toBeInTheDocument();
     expect(screen.getByText("gpt-5.3-codex")).toBeInTheDocument();
@@ -41,6 +41,28 @@ describe("BuildDispatchHistoryCard", () => {
     // also inside the collapsed <details> raw output. Use getAllByText since
     // it may appear in two places.
     expect(screen.getAllByText("ERROR: You've hit your usage limit.").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("hides exit codes, tool/model names, and raw output by default (BI-F606D0E6)", () => {
+    const html = renderToStaticMarkup(
+      <BuildDispatchHistoryCard
+        attempts={[
+          attempt({
+            exitCode: 127,
+            providerId: "opencode",
+            model: "opencode",
+            rootCauseSummary: "opencode failed with Exit code 127",
+            failureAxis: "unknown",
+            stdoutExcerpt: "command not found: opencode",
+          }),
+        ]}
+      />,
+    );
+    expect(html).not.toMatch(/\bexit\s+127\b/i);
+    expect(html).not.toMatch(/\bExit code 127\b/i);
+    expect(html).not.toMatch(/\bopencode\b/i);
+    expect(html).not.toContain("command not found");
+    expect(html).toContain("the build assistant");
   });
 });
 
@@ -68,22 +90,27 @@ function attempt(overrides: Partial<BuildDispatchAttemptView> = {}): BuildDispat
 }
 
 describe("BuildDispatchHistoryCard — root-cause display (BI-594B76AB)", () => {
-  it("renders rootCauseSummary as the visible diagnosis line when present", () => {
-    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+  it("renders rootCauseSummary as the visible diagnosis line when present (engineer view)", () => {
+    const html = renderToStaticMarkup(
+      <BuildDispatchHistoryCard attempts={[attempt()]} engineerView />,
+    );
     expect(html).toContain("Usage limit reached for the day.");
   });
 
-  it("falls back to failureAxis text when rootCauseSummary is null", () => {
+  it("falls back to failureAxis text when rootCauseSummary is null (engineer view)", () => {
     const html = renderToStaticMarkup(
       <BuildDispatchHistoryCard
+        engineerView
         attempts={[attempt({ rootCauseSummary: null, failureAxis: "timeout", stdoutExcerpt: null })]}
       />,
     );
     expect(html).toMatch(/\btimeout\b/i);
   });
 
-  it("places stdoutExcerpt inside a <details> element, not the default visible body", () => {
-    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+  it("places stdoutExcerpt inside a <details> element in engineer view only", () => {
+    const html = renderToStaticMarkup(
+      <BuildDispatchHistoryCard attempts={[attempt()]} engineerView />,
+    );
     expect(html).toMatch(/<details[\s>]/);
     const detailsMatch = html.match(/<details[\s\S]*?<\/details>/);
     expect(detailsMatch).not.toBeNull();
@@ -91,7 +118,9 @@ describe("BuildDispatchHistoryCard — root-cause display (BI-594B76AB)", () => 
   });
 
   it("does not duplicate the rootCauseSummary outside the expected places", () => {
-    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    const html = renderToStaticMarkup(
+      <BuildDispatchHistoryCard attempts={[attempt()]} engineerView />,
+    );
     const occurrences = (html.match(/Usage limit reached for the day\./g) ?? []).length;
     // Once in the visible diagnosis line, possibly once inside the raw <details>
     // because stdoutExcerpt contains the same string after the prologue.
@@ -99,8 +128,10 @@ describe("BuildDispatchHistoryCard — root-cause display (BI-594B76AB)", () => 
     expect(occurrences).toBeLessThanOrEqual(2);
   });
 
-  it("uses a <summary> label that names the raw section", () => {
-    const html = renderToStaticMarkup(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+  it("uses a <summary> label that names the raw section (engineer view)", () => {
+    const html = renderToStaticMarkup(
+      <BuildDispatchHistoryCard attempts={[attempt()]} engineerView />,
+    );
     expect(html).toMatch(/<summary[^>]*>[^<]*Raw[^<]*<\/summary>/i);
   });
 });
@@ -117,7 +148,9 @@ describe("BuildDispatchHistoryCard — open-last-attempt event (BI-9A7DA4AC)", (
   });
 
   it("opens the most-recent attempt's <details> when the open-last event fires", () => {
-    const { container } = render(<BuildDispatchHistoryCard attempts={[attempt()]} />);
+    const { container } = render(
+      <BuildDispatchHistoryCard attempts={[attempt()]} engineerView />,
+    );
     const detailsBefore = container.querySelector<HTMLDetailsElement>("[data-most-recent='true'] details");
     expect(detailsBefore).not.toBeNull();
     expect(detailsBefore!.open).toBe(false);

--- a/apps/web/components/build/BuildDispatchHistoryCard.tsx
+++ b/apps/web/components/build/BuildDispatchHistoryCard.tsx
@@ -2,10 +2,20 @@
 
 import { useEffect, useRef } from "react";
 import type { BuildDispatchAttemptView } from "@/lib/build/dispatch-attempts";
+import {
+  formatDispatchAttemptCustomerStatus,
+  formatDispatchFailureAxisPlain,
+} from "@/lib/build/dispatch-attempts";
 import { TruthSourceBadge } from "./TruthSourceBadge";
 
 type Props = {
   attempts: BuildDispatchAttemptView[];
+  /**
+   * When false (default), hide tool names, raw exit codes, model ids, and raw
+   * stdout/stderr — EP-BS-UX-HARDENING invariant 3 / BI-F606D0E6. Engineer view
+   * keeps the full technical detail.
+   */
+  engineerView?: boolean;
 };
 
 /**
@@ -15,7 +25,7 @@ type Props = {
  */
 const OPEN_LAST_DISPATCH_ATTEMPT_EVENT = "dpf:open-last-dispatch-attempt";
 
-export function BuildDispatchHistoryCard({ attempts }: Props) {
+export function BuildDispatchHistoryCard({ attempts, engineerView = false }: Props) {
   const latest = attempts.at(-1) ?? null;
   const sectionRef = useRef<HTMLElement>(null);
 
@@ -51,6 +61,7 @@ export function BuildDispatchHistoryCard({ attempts }: Props) {
       ref={sectionRef}
       id="build-dispatch-history"
       className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3"
+      data-engineer-view={engineerView ? "true" : "false"}
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Dispatch attempts</h3>
@@ -60,7 +71,13 @@ export function BuildDispatchHistoryCard({ attempts }: Props) {
         {attempts.length === 0 ? (
           <p className="text-xs text-[var(--dpf-muted)]">No dispatch attempts recorded yet.</p>
         ) : attempts.map((attempt, idx) => {
-          const diagnosis = attempt.rootCauseSummary ?? attempt.failureAxis;
+          const customerStatus = formatDispatchAttemptCustomerStatus({
+            success: attempt.success,
+            exitCode: attempt.exitCode,
+            failureAxis: attempt.failureAxis,
+            rootCauseSummary: attempt.rootCauseSummary,
+          });
+          const engineerDiagnosis = attempt.rootCauseSummary ?? attempt.failureAxis;
           const rawOutput = attempt.stdoutExcerpt ?? attempt.stderrExcerpt;
           const isMostRecent = idx === attempts.length - 1;
           return (
@@ -71,18 +88,35 @@ export function BuildDispatchHistoryCard({ attempts }: Props) {
             >
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <span className="font-medium text-[var(--dpf-text)]">{attempt.taskTitle}</span>
-                <span className="text-[var(--dpf-muted)]">exit {attempt.exitCode ?? "running"} · {attempt.failureAxis}</span>
+                {engineerView ? (
+                  <span className="text-[var(--dpf-muted)]">
+                    exit {attempt.exitCode ?? "running"} · {attempt.failureAxis}
+                  </span>
+                ) : (
+                  <span className="text-[var(--dpf-muted)]">
+                    {attempt.success || attempt.exitCode === 0
+                      ? "ok"
+                      : formatDispatchFailureAxisPlain(attempt.failureAxis)}
+                  </span>
+                )}
               </div>
               <div
                 className="mt-1 text-[var(--dpf-text)]"
-                title="Classified diagnosis — derived from stdout/stderr and the failure axis."
+                title={
+                  engineerView
+                    ? "Classified diagnosis — derived from stdout/stderr and the failure axis."
+                    : "Plain-language outcome for this attempt."
+                }
               >
-                {diagnosis}
+                {engineerView ? engineerDiagnosis : customerStatus}
               </div>
-              {attempt.model && (
+              {engineerView && attempt.model && (
                 <div className="mt-1 text-[var(--dpf-muted)]">{attempt.model}</div>
               )}
-              {rawOutput && (
+              {engineerView && attempt.providerId && (
+                <div className="mt-1 text-[var(--dpf-muted)]">provider: {attempt.providerId}</div>
+              )}
+              {engineerView && rawOutput && (
                 <details className="mt-2">
                   <summary className="cursor-pointer text-[10px] uppercase text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">
                     Raw stdout/stderr

--- a/apps/web/components/build/BuildDispatchHistoryCard.tsx
+++ b/apps/web/components/build/BuildDispatchHistoryCard.tsx
@@ -5,7 +5,7 @@ import type { BuildDispatchAttemptView } from "@/lib/build/dispatch-attempts";
 import {
   formatDispatchAttemptCustomerStatus,
   formatDispatchFailureAxisPlain,
-} from "@/lib/build/dispatch-attempts";
+} from "@/lib/build/dispatch-attempt-customer";
 import { TruthSourceBadge } from "./TruthSourceBadge";
 
 type Props = {

--- a/apps/web/components/build/BuildProgressOperationalPanel.tsx
+++ b/apps/web/components/build/BuildProgressOperationalPanel.tsx
@@ -11,9 +11,11 @@ import { BuildPhaseCostCard } from "./BuildPhaseCostCard";
 
 type Props = {
   projection: BuildProgressVisibility | null;
+  /** When true, Dispatch attempts shows exit codes / tool detail (BI-F606D0E6). */
+  engineerView?: boolean;
 };
 
-export function BuildProgressOperationalPanel({ projection }: Props) {
+export function BuildProgressOperationalPanel({ projection, engineerView = false }: Props) {
   if (!projection) {
     return (
       <div className="flex flex-1 items-center justify-center p-6 text-sm text-[var(--dpf-muted)]">
@@ -116,7 +118,7 @@ export function BuildProgressOperationalPanel({ projection }: Props) {
         <div className="grid gap-3 xl:grid-cols-3">
           <BuildPhaseCostCard phaseRuns={projection.phaseRuns} />
           <BuildSandboxCard sandbox={projection.sandbox} />
-          <BuildDispatchHistoryCard attempts={projection.dispatchHistory} />
+          <BuildDispatchHistoryCard attempts={projection.dispatchHistory} engineerView={engineerView} />
           <BuildVerificationScopedCard verification={projection.verification} />
         </div>
 

--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -1025,6 +1025,7 @@ export function BuildStudio({
                       drawerInitialSectionId,
                       supervisedBuildRows,
                       changeNarrative,
+                      engineerView,
                     )}
                   />
                 </div>
@@ -1080,6 +1081,7 @@ function buildDetailsDrawerSections(
   initialSectionId: string | null,
   allBuilds: readonly FeatureBuildRow[],
   changeNarrative: BuildChangeNarrative | null,
+  engineerView: boolean = false,
 ): DetailsDrawerSection[] {
   // Default-open section depends on phase + explicit operator intent.
   // - When the queue header opened the drawer, BS-Queue is the explicit pick.
@@ -1104,7 +1106,7 @@ function buildDetailsDrawerSections(
       id: "progress",
       title: "Progress",
       defaultOpen: defaultId === "progress",
-      content: <BuildProgressOperationalPanel projection={progressVisibility} />,
+      content: <BuildProgressOperationalPanel projection={progressVisibility} engineerView={engineerView} />,
     },
     {
       id: "brief",

--- a/apps/web/lib/build/dispatch-attempt-customer.ts
+++ b/apps/web/lib/build/dispatch-attempt-customer.ts
@@ -1,0 +1,81 @@
+/**
+ * Client-safe plain-language helpers for dispatch attempt display (BI-F606D0E6).
+ *
+ * Kept free of Node-only imports (`crypto`, `@dpf/db`) so client components can
+ * import without pulling the server dispatch recorder into the browser bundle
+ * (Next production build failed when BuildDispatchHistoryCard imported from
+ * dispatch-attempts.ts directly).
+ */
+import type { BuildFailureAxis } from "./progress-visibility-types";
+
+/**
+ * Plain-language labels for dispatch failure axes (BI-F606D0E6 / EP-BS-UX-HARDENING
+ * invariant 3). Never surface tool names (opencode, codex, …) or raw exit codes
+ * on the default customer/operator surface.
+ */
+export function formatDispatchFailureAxisPlain(axis: BuildFailureAxis): string {
+  switch (axis) {
+    case "usage-limit":
+      return "The AI usage limit was reached";
+    case "rate-limit":
+      return "The AI service is temporarily busy";
+    case "auth":
+      return "The AI service needs to be signed in again";
+    case "timeout":
+      return "The build step took too long and stopped";
+    case "test-failure":
+      return "Automated tests did not pass";
+    case "typecheck-failure":
+      return "The code did not type-check cleanly";
+    case "out-of-scope-noise":
+      return "Checks failed outside this build's changes";
+    case "provider-unavailable":
+      return "The AI service is temporarily unavailable";
+    case "unknown":
+    default:
+      return "The build assistant could not finish this step";
+  }
+}
+
+/** Coding-tool / CLI names that must not appear on the non-engineer surface. */
+const DISPATCH_TOOL_NAME_RE =
+  /\b(?:opencode|open-?code|claude(?:-?code)?|codex(?:-?cli)?|grok(?:-?cli)?|chatgpt|openai)\b/gi;
+
+/** Raw "exit code N" / "exit N" patterns. */
+const EXIT_CODE_RE = /\bexit(?:\s+code)?\s+\d+\b/gi;
+
+/**
+ * Strip tool names and raw exit codes from free-text diagnosis so non-engineer
+ * view stays plain language (BI-F606D0E6).
+ */
+export function stripDispatchJargon(text: string): string {
+  const cleaned = text
+    .replace(EXIT_CODE_RE, "")
+    .replace(DISPATCH_TOOL_NAME_RE, "the build assistant")
+    .replace(/\s{2,}/g, " ")
+    .replace(/\s+([.,;:])/g, "$1")
+    .trim();
+  return cleaned.length > 0 ? cleaned : formatDispatchFailureAxisPlain("unknown");
+}
+
+/**
+ * Customer/operator-facing one-line status for a dispatch attempt.
+ * Pure + unit-tested. Engineer view keeps exit codes / model / raw output.
+ */
+export function formatDispatchAttemptCustomerStatus(args: {
+  success: boolean;
+  exitCode: number | null;
+  failureAxis: BuildFailureAxis;
+  rootCauseSummary: string | null;
+}): string {
+  if (args.success || args.exitCode === 0) {
+    return "Completed";
+  }
+  if (args.rootCauseSummary) {
+    const stripped = stripDispatchJargon(args.rootCauseSummary);
+    if (stripped && stripped !== formatDispatchFailureAxisPlain("unknown")) {
+      return stripped;
+    }
+  }
+  return formatDispatchFailureAxisPlain(args.failureAxis);
+}

--- a/apps/web/lib/build/dispatch-attempts.test.ts
+++ b/apps/web/lib/build/dispatch-attempts.test.ts
@@ -2,10 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildDispatchAttemptData,
   classifyDispatchFailureAxis,
+  formatDispatchAttemptCustomerStatus,
+  formatDispatchFailureAxisPlain,
   isUsageLimitDispatchOutput,
   lineMatchesFailureAxis,
   recomputeRootCauseSummary,
   recordBuildDispatchAttempt,
+  stripDispatchJargon,
 } from "./dispatch-attempts";
 import type { BuildFailureAxis } from "./progress-visibility-types";
 
@@ -292,5 +295,54 @@ describe("recomputeRootCauseSummary (BI-594B76AB)", () => {
       failureAxis: "auth",
     });
     expect(result.toLowerCase()).toContain("unauthorized");
+  });
+});
+
+describe("BI-F606D0E6 plain-language dispatch surface", () => {
+  it("formatDispatchFailureAxisPlain never echoes technical axis tokens as the only UX", () => {
+    expect(formatDispatchFailureAxisPlain("unknown")).toMatch(/build assistant|could not/i);
+    expect(formatDispatchFailureAxisPlain("usage-limit")).toMatch(/usage limit/i);
+    expect(formatDispatchFailureAxisPlain("timeout")).toMatch(/too long|stopped/i);
+  });
+
+  it("stripDispatchJargon removes coding tool names and raw exit codes", () => {
+    expect(stripDispatchJargon("opencode failed with Exit code 127")).not.toMatch(/\bopencode\b/i);
+    expect(stripDispatchJargon("opencode failed with Exit code 127")).not.toMatch(/exit\s+code\s+127/i);
+    expect(stripDispatchJargon("codex-cli exited exit 1")).not.toMatch(/\bcodex\b/i);
+    expect(stripDispatchJargon("claude-code auth error")).toMatch(/build assistant/i);
+  });
+
+  it("formatDispatchAttemptCustomerStatus prefers plain diagnosis without jargon", () => {
+    const status = formatDispatchAttemptCustomerStatus({
+      success: false,
+      exitCode: 127,
+      failureAxis: "unknown",
+      rootCauseSummary: "opencode: command not found (Exit code 127)",
+    });
+    expect(status).not.toMatch(/\bopencode\b/i);
+    expect(status).not.toMatch(/exit\s+code\s+127/i);
+    expect(status.length).toBeGreaterThan(0);
+  });
+
+  it("formatDispatchAttemptCustomerStatus reports Completed on success", () => {
+    expect(
+      formatDispatchAttemptCustomerStatus({
+        success: true,
+        exitCode: 0,
+        failureAxis: "unknown",
+        rootCauseSummary: null,
+      }),
+    ).toBe("Completed");
+  });
+
+  it("falls back to axis plain language when root cause is null", () => {
+    expect(
+      formatDispatchAttemptCustomerStatus({
+        success: false,
+        exitCode: 1,
+        failureAxis: "auth",
+        rootCauseSummary: null,
+      }),
+    ).toMatch(/signed in/i);
   });
 });

--- a/apps/web/lib/build/dispatch-attempts.test.ts
+++ b/apps/web/lib/build/dispatch-attempts.test.ts
@@ -1,14 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  buildDispatchAttemptData,
-  classifyDispatchFailureAxis,
   formatDispatchAttemptCustomerStatus,
   formatDispatchFailureAxisPlain,
+  stripDispatchJargon,
+} from "./dispatch-attempt-customer";
+import {
+  buildDispatchAttemptData,
+  classifyDispatchFailureAxis,
   isUsageLimitDispatchOutput,
   lineMatchesFailureAxis,
   recomputeRootCauseSummary,
   recordBuildDispatchAttempt,
-  stripDispatchJargon,
 } from "./dispatch-attempts";
 import type { BuildFailureAxis } from "./progress-visibility-types";
 

--- a/apps/web/lib/build/dispatch-attempts.ts
+++ b/apps/web/lib/build/dispatch-attempts.ts
@@ -332,3 +332,76 @@ function normalizeFailureAxis(value: string): BuildFailureAxis {
       return "unknown";
   }
 }
+
+/**
+ * Plain-language labels for dispatch failure axes (BI-F606D0E6 / EP-BS-UX-HARDENING
+ * invariant 3). Never surface tool names (opencode, codex, …) or raw exit codes
+ * on the default customer/operator surface.
+ */
+export function formatDispatchFailureAxisPlain(axis: BuildFailureAxis): string {
+  switch (axis) {
+    case "usage-limit":
+      return "The AI usage limit was reached";
+    case "rate-limit":
+      return "The AI service is temporarily busy";
+    case "auth":
+      return "The AI service needs to be signed in again";
+    case "timeout":
+      return "The build step took too long and stopped";
+    case "test-failure":
+      return "Automated tests did not pass";
+    case "typecheck-failure":
+      return "The code did not type-check cleanly";
+    case "out-of-scope-noise":
+      return "Checks failed outside this build's changes";
+    case "provider-unavailable":
+      return "The AI service is temporarily unavailable";
+    case "unknown":
+    default:
+      return "The build assistant could not finish this step";
+  }
+}
+
+/** Coding-tool / CLI names that must not appear on the non-engineer surface. */
+const DISPATCH_TOOL_NAME_RE =
+  /\b(?:opencode|open-?code|claude(?:-?code)?|codex(?:-?cli)?|grok(?:-?cli)?|chatgpt|openai)\b/gi;
+
+/** Raw "exit code N" / "exit N" patterns. */
+const EXIT_CODE_RE = /\bexit(?:\s+code)?\s+\d+\b/gi;
+
+/**
+ * Strip tool names and raw exit codes from free-text diagnosis so non-engineer
+ * view stays plain language (BI-F606D0E6).
+ */
+export function stripDispatchJargon(text: string): string {
+  const cleaned = text
+    .replace(EXIT_CODE_RE, "")
+    .replace(DISPATCH_TOOL_NAME_RE, "the build assistant")
+    .replace(/\s{2,}/g, " ")
+    .replace(/\s+([.,;:])/g, "$1")
+    .trim();
+  return cleaned.length > 0 ? cleaned : formatDispatchFailureAxisPlain("unknown");
+}
+
+/**
+ * Customer/operator-facing one-line status for a dispatch attempt.
+ * Pure + unit-tested. Engineer view keeps exit codes / model / raw output.
+ */
+export function formatDispatchAttemptCustomerStatus(args: {
+  success: boolean;
+  exitCode: number | null;
+  failureAxis: BuildFailureAxis;
+  rootCauseSummary: string | null;
+}): string {
+  if (args.success || args.exitCode === 0) {
+    return "Completed";
+  }
+  if (args.rootCauseSummary) {
+    const stripped = stripDispatchJargon(args.rootCauseSummary);
+    // If stripping left something useful and non-axis-looking, prefer it.
+    if (stripped && stripped !== formatDispatchFailureAxisPlain("unknown")) {
+      return stripped;
+    }
+  }
+  return formatDispatchFailureAxisPlain(args.failureAxis);
+}

--- a/apps/web/lib/build/dispatch-attempts.ts
+++ b/apps/web/lib/build/dispatch-attempts.ts
@@ -333,75 +333,10 @@ function normalizeFailureAxis(value: string): BuildFailureAxis {
   }
 }
 
-/**
- * Plain-language labels for dispatch failure axes (BI-F606D0E6 / EP-BS-UX-HARDENING
- * invariant 3). Never surface tool names (opencode, codex, …) or raw exit codes
- * on the default customer/operator surface.
- */
-export function formatDispatchFailureAxisPlain(axis: BuildFailureAxis): string {
-  switch (axis) {
-    case "usage-limit":
-      return "The AI usage limit was reached";
-    case "rate-limit":
-      return "The AI service is temporarily busy";
-    case "auth":
-      return "The AI service needs to be signed in again";
-    case "timeout":
-      return "The build step took too long and stopped";
-    case "test-failure":
-      return "Automated tests did not pass";
-    case "typecheck-failure":
-      return "The code did not type-check cleanly";
-    case "out-of-scope-noise":
-      return "Checks failed outside this build's changes";
-    case "provider-unavailable":
-      return "The AI service is temporarily unavailable";
-    case "unknown":
-    default:
-      return "The build assistant could not finish this step";
-  }
-}
-
-/** Coding-tool / CLI names that must not appear on the non-engineer surface. */
-const DISPATCH_TOOL_NAME_RE =
-  /\b(?:opencode|open-?code|claude(?:-?code)?|codex(?:-?cli)?|grok(?:-?cli)?|chatgpt|openai)\b/gi;
-
-/** Raw "exit code N" / "exit N" patterns. */
-const EXIT_CODE_RE = /\bexit(?:\s+code)?\s+\d+\b/gi;
-
-/**
- * Strip tool names and raw exit codes from free-text diagnosis so non-engineer
- * view stays plain language (BI-F606D0E6).
- */
-export function stripDispatchJargon(text: string): string {
-  const cleaned = text
-    .replace(EXIT_CODE_RE, "")
-    .replace(DISPATCH_TOOL_NAME_RE, "the build assistant")
-    .replace(/\s{2,}/g, " ")
-    .replace(/\s+([.,;:])/g, "$1")
-    .trim();
-  return cleaned.length > 0 ? cleaned : formatDispatchFailureAxisPlain("unknown");
-}
-
-/**
- * Customer/operator-facing one-line status for a dispatch attempt.
- * Pure + unit-tested. Engineer view keeps exit codes / model / raw output.
- */
-export function formatDispatchAttemptCustomerStatus(args: {
-  success: boolean;
-  exitCode: number | null;
-  failureAxis: BuildFailureAxis;
-  rootCauseSummary: string | null;
-}): string {
-  if (args.success || args.exitCode === 0) {
-    return "Completed";
-  }
-  if (args.rootCauseSummary) {
-    const stripped = stripDispatchJargon(args.rootCauseSummary);
-    // If stripping left something useful and non-axis-looking, prefer it.
-    if (stripped && stripped !== formatDispatchFailureAxisPlain("unknown")) {
-      return stripped;
-    }
-  }
-  return formatDispatchFailureAxisPlain(args.failureAxis);
-}
+// Client-safe plain-language helpers live in dispatch-attempt-customer.ts so
+// browser bundles never pull this module's `crypto` / prisma imports (BI-F606D0E6 prod-build fix).
+export {
+  formatDispatchAttemptCustomerStatus,
+  formatDispatchFailureAxisPlain,
+  stripDispatchJargon,
+} from "./dispatch-attempt-customer";


### PR DESCRIPTION
## Summary
- Closes **BI-F606D0E6** (EP-BS-UX-HARDENING invariant 3): the Build Details **Dispatch attempts** panel no longer shows coding tool names (`opencode`, etc.), raw exit codes, model ids, or raw stdout/stderr on the default (non-engineer) surface.
- Technical detail remains available when **Engineer view** is on.
- Pure helpers live in client-safe `dispatch-attempt-customer.ts` (avoids pulling `crypto`/`@dpf/db` into the browser bundle).

## Design grounding
- Existing specs/plans reviewed:
  - EP-BS-UX-HARDENING invariant 3 (no jargon on user surface) via BI-F606D0E6 body
  - Prior dispatch-history root-cause display / quiet-agent last-action pattern (BI-594B76AB, BI-9A7DA4AC)
- Current code substrate reviewed:
  - `BuildDispatchHistoryCard`, `BuildProgressOperationalPanel`, `BuildStudio` engineer-view toggle
  - `apps/web/lib/build/dispatch-attempts.ts` (server recorder)
- Source of truth:
  - Engineer-view progressive disclosure already used for decision ledger / internal ids
- Decision:
  - Gate raw exit/tool/model/stdout behind `engineerView`; default surface uses plain-language helpers only — no new routes, queues, or process contracts.

Design-Grounding-Decision: reviewed EP-BS-UX-HARDENING/BI-F606D0E6 + BuildDispatchHistoryCard/dispatch-attempts substrate; progressive-disclosure engineer-view gate only — no new routes, queues, or process contracts.

## Test plan
- [x] `pnpm exec vitest run lib/build/dispatch-attempts.test.ts components/build/BuildDispatchHistoryCard.test.tsx` — 33/33 (worktree source-local)
- [x] Pre-commit scoped typecheck green
- [x] Client-safe import split so production build no longer pulls `dispatch-attempts` → client bundle

## Process attestations
Process-Spine-Decision: pure UX redaction + unit tests on existing surfaces; no new module/route/migration.
UX-Fit-Decision: progressive disclosure — technical dispatch detail stays engineer-only; customer surface shows plain outcomes only.
Local-CI-Override: source-local vitest 33/33 + pre-commit typecheck green for pure UI redaction (BI-F606D0E6); no runtime/migration.