### PR TITLE
feat: add forge-neutral GitHub adapter foundation

### DIFF
--- a/apps/web/lib/actions/platform-dev-config.ts
+++ b/apps/web/lib/actions/platform-dev-config.ts
@@ -629,11 +629,11 @@ export async function configureForkSetup(input: {
     select: { upstreamRemoteUrl: true },
   });
   const upstreamUrl = cfg?.upstreamRemoteUrl ?? DEFAULT_UPSTREAM_URL;
-  const match = upstreamUrl.match(/github\.com[/:]([^/]+)\/([^/.]+)/);
-  if (!match) {
+  const upstream = (await import("@/lib/forge/github-adapter")).parseGitHubRepositoryUrl(upstreamUrl);
+  if (!upstream) {
     return { success: false, error: `Upstream URL is not a recognizable GitHub repo: ${upstreamUrl}` };
   }
-  const [, upstreamOwner, upstreamRepo] = match;
+  const { owner: upstreamOwner, repo: upstreamRepo } = upstream;
 
   const { forkExistsAndIsFork, createForkAndWait } = await import("@/lib/integrate/github-fork");
 

--- a/apps/web/lib/forge/github-adapter.test.ts
+++ b/apps/web/lib/forge/github-adapter.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GitHubForgeAdapter,
+  classifyGitHubFailure,
+  parseGitHubRepositoryUrl,
+} from "./github-adapter";
+
+function response(status: number, body: unknown, headers: Record<string, string> = {}): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) => headers[name] ?? headers[name.toLowerCase()] ?? null,
+    },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe("parseGitHubRepositoryUrl", () => {
+  it("parses GitHub HTTPS, SSH, and ssh:// repository URLs through one helper", () => {
+    expect(parseGitHubRepositoryUrl("https://github.com/acme/portal.git")).toEqual({
+      forge: "github",
+      owner: "acme",
+      repo: "portal",
+    });
+    expect(parseGitHubRepositoryUrl("git@github.com:acme/portal.git")).toEqual({
+      forge: "github",
+      owner: "acme",
+      repo: "portal",
+    });
+    expect(parseGitHubRepositoryUrl("ssh://git@github.com/acme/portal.git")).toEqual({
+      forge: "github",
+      owner: "acme",
+      repo: "portal",
+    });
+  });
+
+  it("rejects non-GitHub and malformed URLs without guessing a forge", () => {
+    expect(parseGitHubRepositoryUrl("https://gitlab.com/acme/portal.git")).toBeNull();
+    expect(parseGitHubRepositoryUrl("not a remote")).toBeNull();
+    expect(parseGitHubRepositoryUrl(null)).toBeNull();
+  });
+});
+
+describe("classifyGitHubFailure", () => {
+  it("classifies TLS, EOF, DNS, and abort failures as retryable connectivity problems", () => {
+    expect(classifyGitHubFailure(new TypeError("Client network socket disconnected before secure TLS connection was established"))).toMatchObject({
+      category: "retryable",
+      retryable: true,
+      freshness: "unavailable",
+    });
+    expect(classifyGitHubFailure(new Error("read ECONNRESET / unexpected EOF"))).toMatchObject({
+      category: "retryable",
+      retryable: true,
+    });
+  });
+
+  it("classifies API statuses without collapsing policy and connectivity failures", () => {
+    expect(classifyGitHubFailure(response(401, { message: "Bad credentials" }))).toMatchObject({
+      category: "unauthorized",
+      retryable: false,
+      status: 401,
+    });
+    expect(classifyGitHubFailure(response(429, { message: "rate limited" }, { "retry-after": "30" }))).toMatchObject({
+      category: "retryable",
+      retryable: true,
+      status: 429,
+      retryAfterSeconds: 30,
+    });
+    expect(classifyGitHubFailure(response(422, { message: "Validation Failed" }))).toMatchObject({
+      category: "policy-rejected",
+      retryable: false,
+      status: 422,
+    });
+  });
+});
+
+describe("GitHubForgeAdapter", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("advertises GitHub as an external adapter, not the bundled local integration core", () => {
+    const adapter = new GitHubForgeAdapter({ token: "ghp_test" });
+
+    expect(adapter.capabilities()).toMatchObject({
+      adapter: "github",
+      integrationAuthority: "external-forge-adapter",
+      supportedEgressClasses: ["own-repo", "public-hive", "release-distribution"],
+    });
+  });
+
+  it("creates an issue through normalized adapter output", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      response(201, { number: 42, html_url: "https://github.com/acme/portal/issues/42" }),
+    );
+    const adapter = new GitHubForgeAdapter({ token: "ghp_test" });
+
+    const result = await adapter.createIssue({
+      repository: { forge: "github", owner: "acme", repo: "portal" },
+      title: "Saved local evidence should publish later",
+      body: "Network-tolerant issue projection.",
+      labels: ["hive:submitted"],
+      egressClass: "public-hive",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      remote: {
+        adapter: "github",
+        id: "42",
+        number: 42,
+        url: "https://github.com/acme/portal/issues/42",
+      },
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/portal/issues",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          title: "Saved local evidence should publish later",
+          body: "Network-tolerant issue projection.",
+          labels: ["hive:submitted"],
+        }),
+      }),
+    );
+  });
+});

--- a/apps/web/lib/forge/github-adapter.ts
+++ b/apps/web/lib/forge/github-adapter.ts
@@ -1,0 +1,267 @@
+import { assertSafeOutboundUrl } from "@/lib/security/safe-fetch";
+import type {
+  CreateIssueInput,
+  ForgeCapabilities,
+  ForgeFailure,
+  ForgeRepository,
+  RemoteIssueResult,
+} from "./types";
+
+export type {
+  CreateIssueInput,
+  EgressClass,
+  ForgeCapabilities,
+  ForgeFailure,
+  ForgeRepository,
+  RemoteIssue,
+  RemoteIssueResult,
+} from "./types";
+
+const GITHUB_API_HOST = "api.github.com";
+const GITHUB_REPO_HOST = "github.com";
+
+const RETRYABLE_NETWORK_PATTERNS = [
+  "abort",
+  "certificate",
+  "connection reset",
+  "dns",
+  "connection refused",
+  "econnreset",
+  "econnrefused",
+  "eof",
+  "etimedout",
+  "network",
+  "socket",
+  "tls",
+  "timeout",
+];
+
+function trimGitSuffix(value: string): string {
+  return value.endsWith(".git") ? value.slice(0, -4) : value;
+}
+
+function repoFromParts(owner: string | undefined, repo: string | undefined): ForgeRepository | null {
+  if (!owner || !repo) return null;
+  const cleanRepo = trimGitSuffix(repo);
+  if (!cleanRepo || owner.includes("/") || cleanRepo.includes("/")) return null;
+  return { forge: "github", owner, repo: cleanRepo };
+}
+
+export function parseGitHubRepositoryUrl(url: string | null | undefined): ForgeRepository | null {
+  if (!url) return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  const scpLike = trimmed.match(/^git@github\.com:([^/]+)\/([^/?#]+?)(?:\.git)?(?:[?#].*)?$/i);
+  if (scpLike) return repoFromParts(scpLike[1], scpLike[2]);
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.hostname.toLowerCase() !== GITHUB_REPO_HOST) return null;
+    const [owner, repo] = parsed.pathname.replace(/^\/+/, "").split("/");
+    return repoFromParts(owner, repo);
+  } catch {
+    return null;
+  }
+}
+
+function messageFromFailure(input: unknown): string {
+  if (input instanceof Error) return input.message;
+  if (typeof input === "string") return input;
+  return "GitHub operation failed";
+}
+
+function isResponseLike(input: unknown): input is Pick<Response, "status" | "headers"> {
+  return (
+    !!input &&
+    typeof input === "object" &&
+    "status" in input &&
+    typeof input.status === "number"
+  );
+}
+
+function retryAfterSeconds(response: Partial<Pick<Response, "headers">>): number | undefined {
+  if (!response.headers || typeof response.headers.get !== "function") return undefined;
+  const value = response.headers.get("retry-after");
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function bodyMessage(body: unknown, fallback: string): string {
+  if (body && typeof body === "object" && "message" in body && typeof body.message === "string") {
+    return body.message;
+  }
+  return fallback;
+}
+
+export function classifyGitHubFailure(input: unknown, body?: unknown): ForgeFailure {
+  if (isResponseLike(input)) {
+    const message = bodyMessage(body, `GitHub returned status ${input.status}`);
+    if (input.status === 401 || input.status === 403) {
+      return {
+        ok: false,
+        adapter: "github",
+        category: "unauthorized",
+        retryable: false,
+        freshness: "unavailable",
+        status: input.status,
+        message,
+      };
+    }
+    if (input.status === 404) {
+      return {
+        ok: false,
+        adapter: "github",
+        category: "not-found",
+        retryable: false,
+        freshness: "unavailable",
+        status: input.status,
+        message,
+      };
+    }
+    if (input.status === 409) {
+      return {
+        ok: false,
+        adapter: "github",
+        category: "conflict",
+        retryable: false,
+        freshness: "conflicted",
+        status: input.status,
+        message,
+      };
+    }
+    if (input.status === 422) {
+      return {
+        ok: false,
+        adapter: "github",
+        category: "policy-rejected",
+        retryable: false,
+        freshness: "current",
+        status: input.status,
+        message,
+      };
+    }
+    if (input.status === 429 || input.status >= 500) {
+      return {
+        ok: false,
+        adapter: "github",
+        category: "retryable",
+        retryable: true,
+        freshness: "unavailable",
+        status: input.status,
+        retryAfterSeconds: retryAfterSeconds(input),
+        message,
+      };
+    }
+    return {
+      ok: false,
+      adapter: "github",
+      category: "invalid-response",
+      retryable: false,
+      freshness: "unavailable",
+      status: input.status,
+      message,
+    };
+  }
+
+  const message = messageFromFailure(input);
+  const lower = message.toLowerCase();
+  const retryable = RETRYABLE_NETWORK_PATTERNS.some((pattern) => lower.includes(pattern));
+  return {
+    ok: false,
+    adapter: "github",
+    category: retryable ? "retryable" : "invalid-response",
+    retryable,
+    freshness: "unavailable",
+    message,
+  };
+}
+
+function githubHeaders(token: string): Record<string, string> {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+interface GitHubIssueResponse {
+  number?: number;
+  html_url?: string;
+  message?: string;
+}
+
+export class GitHubForgeAdapter {
+  constructor(private readonly config: { token: string }) {}
+
+  capabilities(): ForgeCapabilities {
+    return {
+      adapter: "github",
+      integrationAuthority: "external-forge-adapter",
+      supportedEgressClasses: ["own-repo", "public-hive", "release-distribution"],
+      supports: {
+        branches: true,
+        changeRequests: true,
+        checks: true,
+        issues: true,
+        releases: true,
+      },
+    };
+  }
+
+  async createIssue(input: CreateIssueInput): Promise<RemoteIssueResult> {
+    const pathOwner = encodeURIComponent(input.repository.owner);
+    const pathRepo = encodeURIComponent(input.repository.repo);
+    const url = `https://${GITHUB_API_HOST}/repos/${pathOwner}/${pathRepo}/issues`;
+    assertSafeOutboundUrl(url, { allowedHosts: [GITHUB_API_HOST] });
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: {
+          ...githubHeaders(this.config.token),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title: input.title,
+          body: input.body,
+          labels: input.labels,
+        }),
+      });
+    } catch (err) {
+      return classifyGitHubFailure(err);
+    }
+
+    let data: GitHubIssueResponse;
+    try {
+      data = (await response.json()) as GitHubIssueResponse;
+    } catch {
+      return classifyGitHubFailure(response, { message: "GitHub returned an unparseable issue response" });
+    }
+
+    if (!response.ok) return classifyGitHubFailure(response, data);
+    if (typeof data.number !== "number" || typeof data.html_url !== "string") {
+      return {
+        ok: false,
+        adapter: "github",
+        category: "invalid-response",
+        retryable: false,
+        freshness: "unavailable",
+        status: response.status,
+        message: "GitHub response missing number/html_url",
+      };
+    }
+
+    return {
+      ok: true,
+      remote: {
+        adapter: "github",
+        id: String(data.number),
+        number: data.number,
+        url: data.html_url,
+      },
+    };
+  }
+}

--- a/apps/web/lib/forge/types.ts
+++ b/apps/web/lib/forge/types.ts
@@ -1,0 +1,72 @@
+export type ForgeAdapterId = "github";
+
+export type EgressClass =
+  | "local-integration"
+  | "own-repo"
+  | "public-hive"
+  | "release-distribution";
+
+export type IntegrationAuthority =
+  | "bundled-local-git-core"
+  | "external-forge-adapter";
+
+export type FreshnessState =
+  | "current"
+  | "cached"
+  | "unavailable"
+  | "conflicted";
+
+export type ForgeFailureCategory =
+  | "retryable"
+  | "unauthorized"
+  | "policy-rejected"
+  | "conflict"
+  | "not-found"
+  | "invalid-response";
+
+export interface ForgeRepository {
+  forge: ForgeAdapterId;
+  owner: string;
+  repo: string;
+}
+
+export interface ForgeCapabilities {
+  adapter: ForgeAdapterId;
+  integrationAuthority: IntegrationAuthority;
+  supportedEgressClasses: EgressClass[];
+  supports: {
+    branches: boolean;
+    changeRequests: boolean;
+    checks: boolean;
+    issues: boolean;
+    releases: boolean;
+  };
+}
+
+export interface ForgeFailure {
+  ok: false;
+  adapter: ForgeAdapterId;
+  category: ForgeFailureCategory;
+  retryable: boolean;
+  freshness: FreshnessState;
+  message: string;
+  status?: number;
+  retryAfterSeconds?: number;
+}
+
+export interface RemoteIssue {
+  adapter: ForgeAdapterId;
+  id: string;
+  number: number;
+  url: string;
+}
+
+export type RemoteIssueResult = { ok: true; remote: RemoteIssue } | ForgeFailure;
+
+export interface CreateIssueInput {
+  repository: ForgeRepository;
+  title: string;
+  body: string;
+  labels: string[];
+  egressClass: EgressClass;
+}

--- a/apps/web/lib/integrate/contribution-egress.ts
+++ b/apps/web/lib/integrate/contribution-egress.ts
@@ -13,6 +13,8 @@
  * tool that produced it.
  */
 
+import { parseGitHubRepositoryUrl } from "@/lib/forge/github-adapter";
+
 /** The canonical public DPF upstream — the public hive of last resort. */
 export const CANONICAL_UPSTREAM_OWNER = "OpenDigitalProductFactory";
 export const CANONICAL_UPSTREAM_REPO = "opendigitalproductfactory";
@@ -26,9 +28,8 @@ export interface RepoCoords {
 
 /** Parse owner/repo from a GitHub HTTPS or SSH remote URL. */
 export function parseRepoCoords(url: string | null | undefined): RepoCoords | null {
-  if (!url) return null;
-  const m = url.match(/github\.com[/:]([^/]+)\/([^/.]+)/);
-  return m ? { owner: m[1], repo: m[2] } : null;
+  const parsed = parseGitHubRepositoryUrl(url);
+  return parsed ? { owner: parsed.owner, repo: parsed.repo } : null;
 }
 
 function eq(a: string, b: string): boolean {

--- a/apps/web/lib/integrate/contribution-pipeline.ts
+++ b/apps/web/lib/integrate/contribution-pipeline.ts
@@ -16,6 +16,7 @@ import { redactHostnames } from "@/lib/integrate/identity-privacy";
 import type { ChangeImpactReport } from "@/lib/change-impact";
 import type { SecurityScanResult } from "@/lib/security-scan";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { parseGitHubRepositoryUrl } from "@/lib/forge/github-adapter";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -179,15 +180,8 @@ function generateCommitMessage(input: {
  *   git@github.com:owner/repo.git
  */
 function parseGitHubRepo(remoteUrl: string): { owner: string; repo: string } | null {
-  // HTTPS: https://github.com/owner/repo.git
-  const httpsMatch = remoteUrl.match(/github\.com\/([^/]+)\/([^/.]+)/);
-  if (httpsMatch) return { owner: httpsMatch[1], repo: httpsMatch[2] };
-
-  // SSH: git@github.com:owner/repo.git
-  const sshMatch = remoteUrl.match(/github\.com:([^/]+)\/([^/.]+)/);
-  if (sshMatch) return { owner: sshMatch[1], repo: sshMatch[2] };
-
-  return null;
+  const parsed = parseGitHubRepositoryUrl(remoteUrl);
+  return parsed ? { owner: parsed.owner, repo: parsed.repo } : null;
 }
 
 // PR creation is now handled by github-api-commit.ts (createBranchAndPR)

--- a/apps/web/lib/integrate/issue-bridge.ts
+++ b/apps/web/lib/integrate/issue-bridge.ts
@@ -14,6 +14,7 @@
  */
 
 import { prisma } from "@dpf/db";
+import { GitHubForgeAdapter, parseGitHubRepositoryUrl } from "@/lib/forge/github-adapter";
 import { getPlatformIdentity, redactHostnames } from "./identity-privacy";
 import { resolveHiveToken } from "./identity-privacy";
 
@@ -131,15 +132,8 @@ export async function loadSource(
 // ─── Repo coordinate parsing ────────────────────────────────────────────────
 
 export function parseGitHubRepo(remoteUrl: string): RepoCoordinates | null {
-  const httpsMatch = remoteUrl.match(/github\.com\/([^/]+)\/([^/.]+)/);
-  if (httpsMatch?.[1] && httpsMatch?.[2]) {
-    return { owner: httpsMatch[1], repo: httpsMatch[2] };
-  }
-  const sshMatch = remoteUrl.match(/github\.com:([^/]+)\/([^/.]+)/);
-  if (sshMatch?.[1] && sshMatch?.[2]) {
-    return { owner: sshMatch[1], repo: sshMatch[2] };
-  }
-  return null;
+  const parsed = parseGitHubRepositoryUrl(remoteUrl);
+  return parsed ? { owner: parsed.owner, repo: parsed.repo } : null;
 }
 
 // ─── Issue payload building ─────────────────────────────────────────────────
@@ -269,12 +263,6 @@ async function recordEscalation(
 
 // ─── GitHub API ─────────────────────────────────────────────────────────────
 
-interface CreateIssueResponse {
-  number?: number;
-  html_url?: string;
-  message?: string;
-}
-
 async function postIssue(args: {
   coordinates: RepoCoordinates;
   token: string;
@@ -282,43 +270,28 @@ async function postIssue(args: {
   labels: string[];
 }): Promise<{ number: number; url: string } | { error: string }> {
   const { coordinates, token, payload, labels } = args;
-  const apiUrl = `https://api.github.com/repos/${coordinates.owner}/${coordinates.repo}/issues`;
+  const adapter = new GitHubForgeAdapter({ token });
+  const result = await adapter.createIssue({
+    repository: { forge: "github", owner: coordinates.owner, repo: coordinates.repo },
+    title: payload.title,
+    body: payload.body,
+    labels,
+    egressClass: "public-hive",
+  });
 
-  let response: Response;
-  try {
-    response = await fetch(apiUrl, {
-      method: "POST",
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        title: payload.title,
-        body: payload.body,
-        labels,
-      }),
-    });
-  } catch (err) {
-    return { error: `Network error: ${(err as Error).message}` };
+  if (!result.ok) {
+    if (result.category === "retryable" && result.status == null) {
+      return { error: `Network error: ${result.message}` };
+    }
+    if (result.category === "invalid-response" && result.message.includes("unparseable")) {
+      return { error: `GitHub returned ${result.status ?? "unknown"} with unparseable body` };
+    }
+    if (result.category === "invalid-response") {
+      return { error: result.message };
+    }
+    return { error: `GitHub API error: ${result.message}` };
   }
-
-  let data: CreateIssueResponse;
-  try {
-    data = (await response.json()) as CreateIssueResponse;
-  } catch {
-    return { error: `GitHub returned ${response.status} with unparseable body` };
-  }
-
-  if (!response.ok) {
-    const msg = data?.message ?? `status ${response.status}`;
-    return { error: `GitHub API error: ${msg}` };
-  }
-  if (typeof data.number !== "number" || typeof data.html_url !== "string") {
-    return { error: "GitHub response missing number/html_url" };
-  }
-  return { number: data.number, url: data.html_url };
+  return { number: result.remote.number, url: result.remote.url };
 }
 
 // ─── Main entry point ──────────────────────────────────────────────────────

--- a/docs/superpowers/plans/2026-07-11-forge-neutral-offline-integration-plan.md
+++ b/docs/superpowers/plans/2026-07-11-forge-neutral-offline-integration-plan.md
@@ -1,10 +1,11 @@
 # Forge-Neutral, Offline-Capable Git Integration Plan
 
 **Date:** 2026-07-11
-**Status:** Proposed — do not implement until operator ratifies the design direction
+**Status:** Ratified — Phase 1 implementation in progress
 **Epic:** EP-5410E8EA
 **Spec:** `docs/superpowers/specs/2026-07-11-forge-neutral-offline-integration-design.md`
 **Kernel ledger:** DI-C6483F614871
+**Boundary ledger:** DI-14811CE8E7ED
 
 ## Delivery rules
 
@@ -26,7 +27,9 @@ Owner: operator + Enterprise Architect.
 3. Decide signed bundle/release provenance authority.
 4. Update the spec decision log; if options remain architecturally distinct, route each through `principle_decide`.
 
-Exit: no unresolved boundary changes the authority model.
+Status: partially ratified. `DI-14811CE8E7ED` selects the bundled bare local Git/ref-store core plus external forge adapters. Full Forgejo/Gitea remains optional deployment-profile scope, not default bundled architecture. Local-admission target and signed bundle/release provenance authority remain later-phase decisions before Phase 3/6 cutover work.
+
+Exit: no unresolved boundary changes the authority model for the phase being implemented.
 
 ## Phase 1 — Forge contracts and GitHub parity
 

--- a/docs/superpowers/specs/2026-07-11-forge-neutral-offline-integration-design.md
+++ b/docs/superpowers/specs/2026-07-11-forge-neutral-offline-integration-design.md
@@ -1,9 +1,10 @@
 # Forge-Neutral, Offline-Capable Git Integration Design
 
 **Date:** 2026-07-11
-**Status:** Proposed — operator reaction required before implementation
+**Status:** Ratified — Phase 1 implementation in progress
 **Epic:** EP-5410E8EA
 **Kernel decision:** `DI-C6483F614871` — `forge_abstraction_local_first`, composite 11.302, margin 1.785, high confidence, no commandment conflict, structured coverage strong
+**Boundary decision:** `DI-14811CE8E7ED` — bundle a bare local Git/ref-store core; keep full forges as external adapters
 **Decision population:** `external_coding_agent`
 **Related prior art:** `2026-06-18-local-git-and-private-public-segregation-analysis.md`, `2026-06-18-private-public-change-segregation-design.md`, `2026-06-19-hive-contribution-architecture-and-egress-model.md`
 
@@ -12,6 +13,8 @@
 DPF should make a **forge-neutral local integration record and serialized integration ref** the canonical, offline-capable integration point. GitHub remains the first public forge adapter and the public hive/release distribution surface. A self-hosted Forgejo/Gitea adapter is optional. Remote publication is asynchronous and reconciled; it is not evidence that the change was locally integrated correctly.
 
 This is not authorization to change the live remote. The first implementation phases preserve GitHub behavior behind contracts, then remove unnecessary network dependencies from local verification. Remote cutover, mirroring, or installation of a forge requires a later operator decision and its own migration evidence.
+
+Ratification update (2026-07-14): the operator selected in-session implementation for Phase 1. `DI-14811CE8E7ED` resolves the bundled-vs-external boundary: DPF bundles an invisible bare local Git/ref-store core as the source-byte substrate, while GitHub, GitLab, Forgejo, and Gitea remain external forge adapters. Portal/Postgres remains authoritative for review, approval, evidence, Hive/contribution classification, and merge-admission policy.
 
 The key distinction is:
 


### PR DESCRIPTION
## Summary
- Adds the first forge-neutral contract surface for `BI-FC29F7AB`: shared forge types, explicit egress classes, normalized GitHub failure categories, and a `GitHubForgeAdapter` issue projection method.
- Migrates duplicated GitHub repository parsing in contribution egress, issue escalation, contribution PR setup, and fork setup onto the shared parser while preserving current GitHub behavior.
- Updates the forge-neutral design/plan status with the ratified `DI-14811CE8E7ED` boundary: bundled bare local Git/ref-store core, full forges as external adapters.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/forge/github-adapter.test.ts lib/integrate/contribution-egress.test.ts lib/integrate/issue-bridge.test.ts lib/actions/configure-fork-setup.test.ts lib/integrate/contribution-pipeline.test.ts` — 44 passing
- [x] `NODE_OPTIONS="--max-old-space-size=8192" pnpm --filter web typecheck` — passed
- [x] `pnpm run pregate` — passed local merged-code gate on `39702a13170f82ef147ef91bb5d31e232abf0a2a`; lease `NPEL-FD64BE2843`; evidence `cmrk0hhdd015201nppi8wxgim`

## Notes
- No live remote configuration or push mechanics were changed in this PR.
- The current pregate still performs push-before-lease; that remains the Phase 2 target under `BI-76551B2D`.
