### PR TITLE
fix(build-studio): honest empty-diff status instead of generic quiet (BI-9C66860E)

### DIFF
--- a/apps/web/components/build/build-studio-custodian.test.ts
+++ b/apps/web/components/build/build-studio-custodian.test.ts
@@ -8,7 +8,11 @@ import {
   deriveBuildStudioWorkflowAction,
   type BuildStudioWorkflowAction,
 } from "./build-studio-workflow-actions";
-import { deriveBuildStudioCustodianPrompt } from "./build-studio-custodian";
+import {
+  deriveBuildStudioCustodianPrompt,
+  hasNoReleasableDiff,
+  isEmptyDiffHonestOutcome,
+} from "./build-studio-custodian";
 
 function makeBuild(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
   return {
@@ -358,5 +362,93 @@ describe("deriveBuildStudioCustodianPrompt — terminal abandoned (BI-A2F3FA9D)"
 
     expect(action.kind).toBe("escalated-to-human");
     expect(prompt).toBeNull();
+  });
+});
+
+// BI-9C66860E — empty-diff honest status (EP-BS-UX-HARDENING invariant 5)
+describe("empty-diff honest status (BI-9C66860E)", () => {
+  it("hasNoReleasableDiff is true for null/whitespace patch+summary", () => {
+    expect(hasNoReleasableDiff({ diffPatch: null, diffSummary: null })).toBe(true);
+    expect(hasNoReleasableDiff({ diffPatch: "  ", diffSummary: "" })).toBe(true);
+    expect(hasNoReleasableDiff({ diffPatch: "diff --git a/x b/x\n+", diffSummary: null })).toBe(false);
+  });
+
+  it("isEmptyDiffHonestOutcome is false mid-coding without quiet/terminal step", () => {
+    const build = makeBuild({
+      phase: "build",
+      diffPatch: null,
+      diffSummary: null,
+      buildExecState: { step: "deps_installed", retryCount: 0, startedAt: "2026-06-29T12:12:00.000Z" },
+    });
+    expect(
+      isEmptyDiffHonestOutcome({
+        build,
+        progressVisibility: progress({
+          quietAgent: { quiet: false, minutesQuiet: 1, lastObservableSignalAt: "2026-06-29T12:19:00.000Z" },
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("surfaces a specific no-changes card instead of generic quiet when empty-diff + quiet", () => {
+    const build = makeBuild({
+      phase: "build",
+      diffPatch: null,
+      diffSummary: null,
+      uxVerificationStatus: null,
+      buildExecState: { step: "complete", retryCount: 0, startedAt: "2026-06-29T12:00:00.000Z" },
+    });
+    const action: BuildStudioWorkflowAction = {
+      kind: "retry-build",
+      title: "Retry",
+      message: "Retry the build.",
+      primaryLabel: "Retry build",
+      targetPhase: null,
+      disabledReason: null,
+      coworkerLabel: "Retry with coworker",
+      coworkerPrompt: "Retry the build.",
+    };
+    const prompt = deriveBuildStudioCustodianPrompt({
+      build,
+      action,
+      progressVisibility: progress({
+        quietAgent: { quiet: true, minutesQuiet: 17, lastObservableSignalAt: "2026-06-29T12:00:00.000Z" },
+      }),
+    });
+
+    expect(prompt).not.toBeNull();
+    expect(prompt?.title).toBe("This build finished without changes to deploy.");
+    expect(prompt?.statusLabel).toBe("No changes to deploy");
+    expect(prompt?.title).not.toBe("This build has gone quiet.");
+    expect(prompt?.whyNow).toMatch(/no source changes|nothing to release/i);
+    expect(prompt?.recommendedAction).toMatch(/Retry|refine/i);
+    expect(prompt?.details.join(" ")).toMatch(/no releasable/i);
+    expect(prompt?.primaryAction).toBe("workflow");
+  });
+
+  it("surfaces empty-diff honest card on ship phase (deploy refused, no releasable diff)", () => {
+    const build = makeBuild({
+      phase: "ship",
+      diffPatch: "",
+      diffSummary: null,
+      uxVerificationStatus: "complete",
+    });
+    const action: BuildStudioWorkflowAction = {
+      kind: "advance-phase",
+      title: "Release",
+      message: "Ship.",
+      primaryLabel: "Deploy",
+      targetPhase: "complete",
+      disabledReason: null,
+      coworkerLabel: "Ship with coworker",
+      coworkerPrompt: "Ship the build.",
+    };
+    const prompt = deriveBuildStudioCustodianPrompt({
+      build,
+      action,
+      progressVisibility: progress(),
+    });
+    expect(prompt?.statusLabel).toBe("No changes to deploy");
+    expect(prompt?.title).toContain("without changes to deploy");
   });
 });

--- a/apps/web/components/build/build-studio-custodian.ts
+++ b/apps/web/components/build/build-studio-custodian.ts
@@ -92,8 +92,15 @@ function resolveCustodianStatusSignal(input: {
   isQuietReview: boolean;
   isQuietBuild: boolean;
   isQuietEarlyPhase: boolean;
+  emptyDiff: boolean;
 }): NonNullable<ProactivityResolverInput["statusSignal"]> {
-  if (input.uxReviewGap || input.blockedByEvidence || input.technicalRecovery || input.failedInference) {
+  if (
+    input.uxReviewGap
+    || input.blockedByEvidence
+    || input.technicalRecovery
+    || input.failedInference
+    || input.emptyDiff
+  ) {
     return "blocked";
   }
   if (input.isQuietReview || input.isQuietBuild || input.isQuietEarlyPhase) {
@@ -102,22 +109,86 @@ function resolveCustodianStatusSignal(input: {
   return "normal";
 }
 
+/**
+ * True when the build has no deployable source changes (BI-9C66860E).
+ * Pure — null/whitespace-only patch and summary both count as empty.
+ */
+export function hasNoReleasableDiff(
+  build: Pick<FeatureBuildRow, "diffPatch" | "diffSummary">,
+): boolean {
+  const patch = build.diffPatch?.trim() ?? "";
+  const summary = build.diffSummary?.trim() ?? "";
+  return patch.length === 0 && summary.length === 0;
+}
+
+/**
+ * True when the system should surface the empty-diff honest card instead of a
+ * generic "gone quiet" state (EP-BS-UX-HARDENING invariant 5 / BI-9C66860E).
+ * Mid-coding builds with no patch yet are excluded unless they are quiet or
+ * already in review/ship after coding finished.
+ */
+export function isEmptyDiffHonestOutcome(args: {
+  build: FeatureBuildRow;
+  progressVisibility?: BuildProgressVisibility | null;
+}): boolean {
+  const { build, progressVisibility } = args;
+  if (!hasNoReleasableDiff(build)) return false;
+  if (build.phase === "ideate" || build.phase === "plan" || build.phase === "complete" || build.phase === "abandoned") {
+    return false;
+  }
+  // Ship with nothing to deploy is the classic deploy_feature refuse path.
+  if (build.phase === "ship") {
+    return true;
+  }
+  const quiet = progressVisibility?.quietAgent.quiet === true;
+  // Review: only when quiet (would otherwise show generic quiet) or UX already
+  // passed (coding finished, deploy path next) — not while UX/evidence is the
+  // active blocker (those cards take precedence).
+  if (build.phase === "review") {
+    // "complete" is the successful UX verification terminal (see FeatureBuildRow).
+    const uxPassed = build.uxVerificationStatus === "complete";
+    return quiet || uxPassed;
+  }
+  // build phase: only after coding has gone quiet or the exec step is terminalish
+  if (build.phase === "build") {
+    const step = (build.buildExecState as { step?: string } | null)?.step ?? null;
+    const terminalish =
+      step === "complete"
+      || step === "failed"
+      || step === "ship_blocked"
+      || step === "deploy_failed";
+    return quiet || terminalish;
+  }
+  return false;
+}
+
 export function deriveBuildStudioCustodianPrompt({
   build,
   action,
   progressVisibility,
 }: CustodianPromptInput): BuildStudioCustodianPrompt | null {
-  // Terminal phases the custodian must never nudge on. "abandoned" (BI-A2F3FA9D)
-  // is an escalate-to-human handoff: WIP is freed and the originating BI parked
-  // as "deferred", so there is nothing to keep moving here — a nudge would be
-  // noise. "failed" is intentionally NOT excluded: it retains a live retry-build
-  // recovery path the custodian's technicalRecovery branch surfaces on purpose.
-  if (build.phase === "complete" || build.phase === "ship" || build.phase === "abandoned") {
+  const emptyDiff = isEmptyDiffHonestOutcome({ build, progressVisibility });
+
+  // Terminal phases the custodian must never nudge on — except empty-diff ship
+  // (BI-9C66860E), a definitive terminal outcome that must not look healthy.
+  // "abandoned" (BI-A2F3FA9D) is an escalate-to-human handoff: WIP is freed and
+  // the originating BI parked as "deferred", so there is nothing to keep moving
+  // here — a nudge would be noise. "failed" is intentionally NOT excluded: it
+  // retains a live retry-build recovery path the custodian's technicalRecovery
+  // branch surfaces on purpose.
+  if (
+    (build.phase === "complete" || build.phase === "ship" || build.phase === "abandoned")
+    && !emptyDiff
+  ) {
     return null;
   }
 
   const guidance = deriveBuildStudioOperatorGuidance(action, build);
-  if (guidance.status.kind === "working" && progressVisibility?.quietAgent.quiet !== true) {
+  if (
+    !emptyDiff
+    && guidance.status.kind === "working"
+    && progressVisibility?.quietAgent.quiet !== true
+  ) {
     return null;
   }
 
@@ -146,7 +217,8 @@ export function deriveBuildStudioCustodianPrompt({
   const uxReviewGap = isUxReviewGap(build, action, progressVisibility);
 
   if (
-    !uxReviewGap
+    !emptyDiff
+    && !uxReviewGap
     && !blockedByEvidence
     && !technicalRecovery
     && !failedInference
@@ -170,9 +242,12 @@ export function deriveBuildStudioCustodianPrompt({
       isQuietReview,
       isQuietBuild,
       isQuietEarlyPhase,
+      emptyDiff,
     }),
   });
 
+  // UX evidence gap stays ahead of empty-diff: a failed/missing UX check is a
+  // more specific next action than "no releasable diff" when both could apply.
   if (uxReviewGap) {
     return {
       dismissKey,
@@ -221,6 +296,33 @@ export function deriveBuildStudioCustodianPrompt({
         action.message,
         "This is a failed AI call, not a missing input from you. Retrying re-runs the same request.",
       ].filter(Boolean),
+      proactivityPlan,
+    };
+  }
+
+  // Empty-diff (BI-9C66860E) is more specific than generic technical recovery
+  // when the retry/reset path is only available because coding produced no
+  // releasable bytes — lead with the honest outcome, still keep workflow CTA.
+  if (emptyDiff && (action.kind === "retry-build" || action.kind === "reset-build" || action.kind === "resume-implementation")) {
+    return {
+      dismissKey: `${dismissKey}:empty-diff`,
+      title: "This build finished without changes to deploy.",
+      whyNow:
+        "The AI completed its pass but did not produce any source changes — there is nothing to release from this run.",
+      recommendedAction:
+        "Retry the build from the current brief, or refine the description so the next pass has a clearer target.",
+      primaryLabel: action.primaryLabel ?? "Retry build",
+      primaryAction: "workflow",
+      coworkerPrompt: appendCustodianInstruction(
+        action,
+        "Act as the Build Studio custodian. This build has no releasable diff. Explain that in plain English, offer Retry build or refine the brief, and do not claim work is still moving.",
+      ),
+      statusLabel: "No changes to deploy",
+      intent: "warning",
+      details: [
+        "Deploy correctly refused because there was no releasable source diff.",
+        "This is not an indefinite quiet state — the outcome is known: zero deployable changes from this run.",
+      ],
       proactivityPlan,
     };
   }
@@ -321,6 +423,33 @@ export function deriveBuildStudioCustodianPrompt({
       details: [
         action.disabledReason ?? "Required evidence is missing.",
         "The human should see the conclusion and one next action, not raw workflow internals.",
+      ],
+      proactivityPlan,
+    };
+  }
+
+  // BI-9C66860E — definitive empty-diff outcome beats generic quiet copy
+  // (EP-BS-UX-HARDENING invariant 5: honest status). Retry/reset/resume kinds
+  // are handled earlier (with workflow CTA); remaining actions use coworker.
+  if (emptyDiff) {
+    return {
+      dismissKey: `${dismissKey}:empty-diff`,
+      title: "This build finished without changes to deploy.",
+      whyNow:
+        "The AI completed its pass but did not produce any source changes — there is nothing to release from this run.",
+      recommendedAction:
+        "Retry the build from the current brief, or refine the description so the next pass has a clearer target.",
+      primaryLabel: "Retry build",
+      primaryAction: "coworker",
+      coworkerPrompt: appendCustodianInstruction(
+        action,
+        "Act as the Build Studio custodian. This build has no releasable diff. Explain that in plain English, offer Retry build or refine the brief, and do not claim work is still moving.",
+      ),
+      statusLabel: "No changes to deploy",
+      intent: "warning",
+      details: [
+        "Deploy correctly refused because there was no releasable source diff.",
+        "This is not an indefinite quiet state — the outcome is known: zero deployable changes from this run.",
       ],
       proactivityPlan,
     };


### PR DESCRIPTION
## Summary
- Closes **BI-9C66860E** (EP-BS-UX-HARDENING invariant 5): when a build has no releasable source diff after coding (or ship with empty patch), the custodian shows a specific **No changes to deploy** card with Retry / refine — not the indefinite "This build has gone quiet" copy.
- Pure helpers: `hasNoReleasableDiff`, `isEmptyDiffHonestOutcome`.
- More specific paths (UX gap, evidence, generic technical recovery for non-empty-diff) still take precedence where appropriate.

## Test plan
- [x] `pnpm exec vitest run components/build/build-studio-custodian.test.ts` — 14/14 (worktree source-local)
- [x] Pre-commit scoped typecheck green

## Process attestations
Process-Spine-Decision: pure UX status classification + unit tests; no new module/route/migration.
UX-Fit-Decision: honest terminal outcome over vague quiet; one clear Retry next step.
Local-CI-Override: source-local vitest 14/14 + pre-commit typecheck green for custodian empty-diff card (BI-9C66860E); no runtime/migration.