### PR TITLE
fix(dev-portal): stop crash-looping when leased worktree is removed (BI-0DF1F354)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,15 @@ WORKDIR /app
 FROM base AS dev
 WORKDIR /workspace
 RUN apk add --no-cache git postgresql16-client
-# BI-0DF1F354: preflight stops cleanly when the bind-mounted worktree is gone
-# (exit 0) so Docker does not thrash pnpm/next forever.
-CMD ["sh", "-c", "node scripts/lib/dev-portal-workspace-preflight.mjs && pnpm install && pnpm --filter @dpf/db exec prisma generate && pnpm --filter web dev"]
+# BI-0DF1F354: bake preflight + entrypoint into the IMAGE. The primary failure
+# mode is a deleted/empty bind mount — the worktree copy of this script is not
+# available then, so it must not live only under /workspace.
+COPY scripts/lib/dev-portal-workspace-preflight.mjs /usr/local/bin/dev-portal-workspace-preflight.mjs
+COPY scripts/lib/dev-portal-entrypoint.sh /usr/local/bin/dev-portal-entrypoint.sh
+RUN chmod +x /usr/local/bin/dev-portal-entrypoint.sh
+# Entrypoint: preflight fails non-zero on missing workspace → exit 0 without pnpm
+# (see planDevPortalBoot). Healthy workspace → pnpm install + next dev.
+CMD ["/usr/local/bin/dev-portal-entrypoint.sh"]
 
 # ─── Stage 2: deps ────────────────────────────────────────────────────────────
 FROM base AS deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ WORKDIR /app
 FROM base AS dev
 WORKDIR /workspace
 RUN apk add --no-cache git postgresql16-client
-CMD ["sh", "-c", "pnpm install && pnpm --filter @dpf/db exec prisma generate && pnpm --filter web dev"]
+# BI-0DF1F354: preflight stops cleanly when the bind-mounted worktree is gone
+# (exit 0) so Docker does not thrash pnpm/next forever.
+CMD ["sh", "-c", "node scripts/lib/dev-portal-workspace-preflight.mjs && pnpm install && pnpm --filter @dpf/db exec prisma generate && pnpm --filter web dev"]
 
 # ─── Stage 2: deps ────────────────────────────────────────────────────────────
 FROM base AS deps

--- a/apps/web/components/monitoring/ContainerResourceTable.tsx
+++ b/apps/web/components/monitoring/ContainerResourceTable.tsx
@@ -87,11 +87,16 @@ export function ContainerResourceTable() {
           </thead>
           <tbody>
             {rows.map((row) => {
-              const hasRestarts = row.restarts !== null && row.restarts > 0;
+              const restartCount = row.restarts !== null ? Math.round(row.restarts) : null;
+              // BI-0DF1F354: elevate crash-loop-scale restart counts so dev-portal
+              // thrash (observed 262) is visible on Platform Health, not a soft "!".
+              const crashLoopish = restartCount !== null && restartCount >= 10;
+              const hasRestarts = restartCount !== null && restartCount > 0;
               return (
                 <tr
                   key={row.name}
                   className="border-t border-[var(--dpf-border)]"
+                  data-crash-loop={crashLoopish ? "true" : undefined}
                 >
                   <td className="px-3 py-1.5 text-[var(--dpf-text)] font-mono">
                     {row.name.replace(/^dpf-/, "")}
@@ -111,11 +116,20 @@ export function ContainerResourceTable() {
                   </td>
                   <td
                     className={`px-3 py-1.5 text-right ${
-                      hasRestarts ? "text-[var(--dpf-warning)] font-semibold" : "text-[var(--dpf-text)]"
+                      crashLoopish
+                        ? "text-[var(--dpf-danger)] font-semibold"
+                        : hasRestarts
+                          ? "text-[var(--dpf-warning)] font-semibold"
+                          : "text-[var(--dpf-text)]"
                     }`}
+                    title={
+                      crashLoopish
+                        ? "High restart count — likely crash-loop (e.g. missing worktree for dev-portal)"
+                        : undefined
+                    }
                   >
-                    {row.restarts !== null ? Math.round(row.restarts) : "--"}
-                    {hasRestarts ? " !" : ""}
+                    {restartCount !== null ? restartCount : "--"}
+                    {crashLoopish ? " CRASH-LOOP?" : hasRestarts ? " !" : ""}
                   </td>
                 </tr>
               );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -583,7 +583,10 @@ services:
     build:
       context: .
       target: dev
-    restart: unless-stopped
+    # BI-0DF1F354: never infinite-restart when the leased worktree vanishes.
+    # Cap crash restarts; missing-workspace preflight exits 0 so it does not
+    # thrash even under unless-stopped semantics.
+    restart: "on-failure:5"
     logging: *default-logging
     profiles: ["dev"]
     ports:
@@ -597,6 +600,8 @@ services:
       QDRANT_INTERNAL_URL: http://dev-qdrant:6333
       LLM_BASE_URL: ${LLM_BASE_URL:-http://model-runner.docker.internal/v1}
       DPF_ENVIRONMENT: dev
+      # Preflight reads cwd (/workspace); override only for tests.
+      DPF_DEV_PORTAL_WORKSPACE_ROOT: /workspace
       AUTH_SECRET: dev_secret_change_me
       AUTH_TRUST_HOST: "true"
       CREDENTIAL_ENCRYPTION_KEY: dev_only_key_not_for_production_0000

--- a/scripts/lib/dev-portal-entrypoint.sh
+++ b/scripts/lib/dev-portal-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# BI-0DF1F354 — image-baked entrypoint for the Dockerfile `dev` stage.
+# Preflight is COPYed to /usr/local/bin so it still runs when the bind-mounted
+# worktree is deleted/empty (the failure mode that previously crash-looped).
+set -eu
+
+PREFLIGHT="${DEV_PORTAL_PREFLIGHT_BIN:-/usr/local/bin/dev-portal-workspace-preflight.mjs}"
+
+if ! node "$PREFLIGHT"; then
+  # Preflight printed diagnosis and exited non-zero. Exit 0 so Docker
+  # restart:on-failure does not thrash (planDevPortalBoot stop-clean).
+  exit 0
+fi
+
+exec sh -c 'pnpm install && pnpm --filter @dpf/db exec prisma generate && pnpm --filter web dev'

--- a/scripts/lib/dev-portal-workspace-preflight.mjs
+++ b/scripts/lib/dev-portal-workspace-preflight.mjs
@@ -3,19 +3,17 @@
  * BI-0DF1F354 — Contributor preview (dev-portal) must not crash-loop forever
  * when its bind-mounted worktree is removed.
  *
- * Docker `restart: unless-stopped` restarts the container on every non-zero
- * (and even some zero) failure path until an operator intervenes. When
- * DPF_DEV_WORKTREE points at a deleted worktree, the /workspace mount is empty
- * or missing package.json and `pnpm install` / `next dev` thrash forever
- * (observed: 262 restarts) with no Platform Health signal that the *cause* is
- * a missing worktree.
- *
- * This preflight runs before pnpm/next in the Dockerfile `dev` stage CMD.
- * If the workspace root is not a DPF monorepo, it prints a clear diagnosis and
- * exits 0 so Docker does not treat the stop as a crash worth restarting.
- *
- * Pure helpers are exported for unit tests (Node test runner / vitest via
- * dynamic import).
+ * Contract (enforced by unit tests + entrypoint):
+ *  1. Assess workspace at DPF_DEV_PORTAL_WORKSPACE_ROOT (default /workspace).
+ *  2. On FAIL: print diagnosis, exit **non-zero** from this process so the
+ *     entrypoint can branch (must NOT use `preflight && pnpm` with exit 0 on
+ *     fail — that would continue into pnpm).
+ *  3. Entrypoint on FAIL: exit **0** without running pnpm/next so Docker
+ *     `on-failure` does not thrash (observed live: 262 restarts).
+ *  4. This script is **baked into the image** at
+ *     `/usr/local/bin/dev-portal-workspace-preflight.mjs` because the primary
+ *     failure mode is a deleted/empty bind mount — the worktree copy of this
+ *     file is not available when the mount is gone.
  */
 
 import { existsSync, readFileSync, statSync } from "node:fs";
@@ -23,7 +21,16 @@ import { join } from "node:path";
 
 /**
  * @typedef {{ ok: true } | { ok: false; reason: string; detail: string }} PreflightResult
+ * @typedef {{
+ *   action: "start" | "stop-clean",
+ *   runInstallAndDev: boolean,
+ *   processExitCode: number,
+ *   preflightCliExitCode: number,
+ * }} DevPortalBootPlan
  */
+
+/** CLI exit when workspace is unusable — non-zero so entrypoint can gate pnpm. */
+export const PREFLIGHT_FAIL_EXIT = 1;
 
 /**
  * True when `root` looks like a usable DPF workspace mount for dev-portal.
@@ -76,8 +83,6 @@ export function assessDevPortalWorkspace(root, io = {}) {
   try {
     const raw = read(packageJsonPath, "utf8");
     const pkg = JSON.parse(raw);
-    // Prefer a monorepo marker (pnpm-workspace style name) but accept any
-    // package.json with a name so local forks still pass.
     if (!pkg || typeof pkg !== "object") {
       return {
         ok: false,
@@ -107,13 +112,50 @@ export function assessDevPortalWorkspace(root, io = {}) {
 }
 
 /**
- * Exit code for Docker: 0 = intentional stop (do not thrash restarts),
- * 1 = unexpected CLI misuse. Missing workspace uses exit 0 by design.
+ * Pure boot plan used by the image entrypoint (and integration tests).
+ * Missing workspace: never run pnpm; container exits 0 (no restart thrash).
+ * Healthy workspace: run install+dev; preflight CLI exits 0.
+ * @param {PreflightResult} result
+ * @returns {DevPortalBootPlan}
+ */
+export function planDevPortalBoot(result) {
+  if (result.ok) {
+    return {
+      action: "start",
+      runInstallAndDev: true,
+      processExitCode: 0,
+      preflightCliExitCode: 0,
+    };
+  }
+  return {
+    action: "stop-clean",
+    runInstallAndDev: false,
+    processExitCode: 0,
+    preflightCliExitCode: PREFLIGHT_FAIL_EXIT,
+  };
+}
+
+/**
+ * Exit code for the **preflight CLI process alone** (not the container).
+ * Fail → non-zero so entrypoint can skip pnpm. Success → 0.
  * @param {PreflightResult} result
  * @returns {number}
  */
 export function preflightExitCode(result) {
-  return result.ok ? 0 : 0;
+  return planDevPortalBoot(result).preflightCliExitCode;
+}
+
+/**
+ * Simulate the baked entrypoint shell contract without Docker.
+ * @param {PreflightResult} result
+ * @returns {{ ranPnpm: boolean; finalExit: number; action: string }}
+ */
+export function simulateDevPortalEntrypoint(result) {
+  const plan = planDevPortalBoot(result);
+  if (!plan.runInstallAndDev) {
+    return { ranPnpm: false, finalExit: plan.processExitCode, action: plan.action };
+  }
+  return { ranPnpm: true, finalExit: plan.processExitCode, action: plan.action };
 }
 
 /**
@@ -139,7 +181,7 @@ function main() {
     process.exit(0);
   }
   process.stderr.write(`${formatPreflightFailure(result)}\n`);
-  // Exit 0 so Docker restart policies do not treat this as a crash (BI-0DF1F354).
+  // Non-zero so entrypoint does not run pnpm (BI-0DF1F354). Entrypoint maps this to container exit 0.
   process.exit(preflightExitCode(result));
 }
 

--- a/scripts/lib/dev-portal-workspace-preflight.mjs
+++ b/scripts/lib/dev-portal-workspace-preflight.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * BI-0DF1F354 — Contributor preview (dev-portal) must not crash-loop forever
+ * when its bind-mounted worktree is removed.
+ *
+ * Docker `restart: unless-stopped` restarts the container on every non-zero
+ * (and even some zero) failure path until an operator intervenes. When
+ * DPF_DEV_WORKTREE points at a deleted worktree, the /workspace mount is empty
+ * or missing package.json and `pnpm install` / `next dev` thrash forever
+ * (observed: 262 restarts) with no Platform Health signal that the *cause* is
+ * a missing worktree.
+ *
+ * This preflight runs before pnpm/next in the Dockerfile `dev` stage CMD.
+ * If the workspace root is not a DPF monorepo, it prints a clear diagnosis and
+ * exits 0 so Docker does not treat the stop as a crash worth restarting.
+ *
+ * Pure helpers are exported for unit tests (Node test runner / vitest via
+ * dynamic import).
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * @typedef {{ ok: true } | { ok: false; reason: string; detail: string }} PreflightResult
+ */
+
+/**
+ * True when `root` looks like a usable DPF workspace mount for dev-portal.
+ * @param {string} root
+ * @param {{ existsSync?: typeof existsSync; readFileSync?: typeof readFileSync; statSync?: typeof statSync }} [io]
+ * @returns {PreflightResult}
+ */
+export function assessDevPortalWorkspace(root, io = {}) {
+  const exists = io.existsSync ?? existsSync;
+  const read = io.readFileSync ?? readFileSync;
+  const stat = io.statSync ?? statSync;
+
+  if (!root || typeof root !== "string" || root.trim().length === 0) {
+    return {
+      ok: false,
+      reason: "missing-root",
+      detail: "Workspace root path is empty. Set DPF_DEV_WORKTREE to an absolute worktree path.",
+    };
+  }
+
+  let isDir = false;
+  try {
+    isDir = stat(root).isDirectory();
+  } catch {
+    return {
+      ok: false,
+      reason: "root-missing",
+      detail: `Workspace root does not exist: ${root}. The leased worktree was probably removed — release the :3001 lease and claim a live worktree.`,
+    };
+  }
+  if (!isDir) {
+    return {
+      ok: false,
+      reason: "root-not-directory",
+      detail: `Workspace root is not a directory: ${root}`,
+    };
+  }
+
+  const packageJsonPath = join(root, "package.json");
+  if (!exists(packageJsonPath)) {
+    return {
+      ok: false,
+      reason: "package-json-missing",
+      detail:
+        `No package.json under ${root}. The bind mount is empty or the worktree was deleted. ` +
+        "Stop crash-looping: release the dev-portal lease, re-claim with a live worktree, then compose up again.",
+    };
+  }
+
+  try {
+    const raw = read(packageJsonPath, "utf8");
+    const pkg = JSON.parse(raw);
+    // Prefer a monorepo marker (pnpm-workspace style name) but accept any
+    // package.json with a name so local forks still pass.
+    if (!pkg || typeof pkg !== "object") {
+      return {
+        ok: false,
+        reason: "package-json-invalid",
+        detail: `package.json under ${root} is not a JSON object.`,
+      };
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "package-json-unreadable",
+      detail: `Could not read package.json under ${root}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const webPkg = join(root, "apps", "web", "package.json");
+  if (!exists(webPkg)) {
+    return {
+      ok: false,
+      reason: "web-package-missing",
+      detail:
+        `apps/web/package.json missing under ${root}. This is not a DPF monorepo mount — refusing to start dev-portal so it does not crash-loop.`,
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Exit code for Docker: 0 = intentional stop (do not thrash restarts),
+ * 1 = unexpected CLI misuse. Missing workspace uses exit 0 by design.
+ * @param {PreflightResult} result
+ * @returns {number}
+ */
+export function preflightExitCode(result) {
+  return result.ok ? 0 : 0;
+}
+
+/**
+ * Human-facing banner when the preflight fails.
+ * @param {PreflightResult} result
+ * @returns {string}
+ */
+export function formatPreflightFailure(result) {
+  if (result.ok) return "";
+  return [
+    "[dev-portal-preflight] STOPPING — refusing to crash-loop on a missing/invalid worktree (BI-0DF1F354).",
+    `[dev-portal-preflight] reason=${result.reason}`,
+    `[dev-portal-preflight] ${result.detail}`,
+    "[dev-portal-preflight] Next: scripts/dev-portal-lease.sh release (if held), then claim a live worktree and restart dev-portal.",
+  ].join("\n");
+}
+
+function main() {
+  const root = process.env.DPF_DEV_PORTAL_WORKSPACE_ROOT || process.cwd();
+  const result = assessDevPortalWorkspace(root);
+  if (result.ok) {
+    process.stdout.write(`[dev-portal-preflight] ok workspace=${root}\n`);
+    process.exit(0);
+  }
+  process.stderr.write(`${formatPreflightFailure(result)}\n`);
+  // Exit 0 so Docker restart policies do not treat this as a crash (BI-0DF1F354).
+  process.exit(preflightExitCode(result));
+}
+
+const entry = typeof process.argv[1] === "string" ? process.argv[1].replace(/\\/g, "/") : "";
+const isMain =
+  entry.endsWith("/dev-portal-workspace-preflight.mjs")
+  || entry.endsWith("dev-portal-workspace-preflight.mjs");
+
+if (isMain) {
+  main();
+}

--- a/scripts/lib/dev-portal-workspace-preflight.test.mjs
+++ b/scripts/lib/dev-portal-workspace-preflight.test.mjs
@@ -4,7 +4,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, mkdirSync, chmodSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";

--- a/scripts/lib/dev-portal-workspace-preflight.test.mjs
+++ b/scripts/lib/dev-portal-workspace-preflight.test.mjs
@@ -1,57 +1,47 @@
 /**
- * BI-0DF1F354 — unit tests for the pure preflight (node:test, no vitest).
+ * BI-0DF1F354 — unit + integration-style contract tests for preflight + boot plan.
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, chmodSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 import {
   assessDevPortalWorkspace,
   formatPreflightFailure,
+  planDevPortalBoot,
   preflightExitCode,
+  PREFLIGHT_FAIL_EXIT,
+  simulateDevPortalEntrypoint,
 } from "./dev-portal-workspace-preflight.mjs";
 
-function ioFromMap(map) {
-  return {
-    existsSync: (p) => map.has(p),
-    statSync: (p) => {
-      if (!map.has(p) && ![...map.keys()].some((k) => k.startsWith(p + "/") || k === p)) {
-        // allow root dir if any child exists under it
-        const hasChild = [...map.keys()].some((k) => k.startsWith(String(p).replace(/\/$/, "") + "/"));
-        if (!hasChild && !map.has(p)) {
-          const err = new Error("ENOENT");
-          /** @type {NodeJS.ErrnoException} */
-          (err).code = "ENOENT";
-          throw err;
-        }
-      }
-      return {
-        isDirectory: () => {
-          if (map.get(p)?.type === "file") return false;
-          return true;
-        },
-      };
-    },
-    readFileSync: (p) => {
-      const entry = map.get(p);
-      if (!entry || entry.type !== "file") {
-        const err = new Error("ENOENT");
-        /** @type {NodeJS.ErrnoException} */
-        (err).code = "ENOENT";
-        throw err;
-      }
-      return entry.body;
-    },
-  };
-}
+const here = dirname(fileURLToPath(import.meta.url));
+const preflightPath = join(here, "dev-portal-workspace-preflight.mjs");
+const entrypointPath = join(here, "dev-portal-entrypoint.sh");
 
 describe("assessDevPortalWorkspace (BI-0DF1F354)", () => {
   it("fails when root is empty", () => {
-    const r = assessDevPortalWorkspace("", ioFromMap(new Map()));
+    const r = assessDevPortalWorkspace("", {
+      existsSync: () => false,
+      statSync: () => {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      },
+      readFileSync: () => "",
+    });
     assert.equal(r.ok, false);
     if (!r.ok) assert.equal(r.reason, "missing-root");
   });
 
   it("fails when root path does not exist (worktree removed)", () => {
-    const r = assessDevPortalWorkspace("/gone/worktree", ioFromMap(new Map()));
+    const r = assessDevPortalWorkspace("/gone/worktree", {
+      existsSync: () => false,
+      statSync: () => {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      },
+      readFileSync: () => "",
+    });
     assert.equal(r.ok, false);
     if (!r.ok) {
       assert.equal(r.reason, "root-missing");
@@ -60,10 +50,6 @@ describe("assessDevPortalWorkspace (BI-0DF1F354)", () => {
   });
 
   it("fails when package.json is missing (empty bind mount)", () => {
-    const map = new Map([
-      ["/workspace", { type: "dir" }],
-    ]);
-    // force root exists as dir
     const io = {
       existsSync: (p) => p === "/workspace",
       statSync: (p) => {
@@ -82,7 +68,7 @@ describe("assessDevPortalWorkspace (BI-0DF1F354)", () => {
   it("fails when apps/web/package.json is missing", () => {
     const root = "/workspace";
     const map = new Map([
-      [`${root}/package.json`, { type: "file", body: JSON.stringify({ name: "dpf" }) }],
+      [`${root}/package.json`, JSON.stringify({ name: "dpf" })],
     ]);
     const io = {
       existsSync: (p) => map.has(p),
@@ -90,7 +76,7 @@ describe("assessDevPortalWorkspace (BI-0DF1F354)", () => {
         if (p === root) return { isDirectory: () => true };
         throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       },
-      readFileSync: (p) => map.get(p).body,
+      readFileSync: (p) => map.get(p),
     };
     const r = assessDevPortalWorkspace(root, io);
     assert.equal(r.ok, false);
@@ -100,8 +86,8 @@ describe("assessDevPortalWorkspace (BI-0DF1F354)", () => {
   it("passes for a full DPF monorepo layout", () => {
     const root = "/workspace";
     const map = new Map([
-      [`${root}/package.json`, { type: "file", body: JSON.stringify({ name: "dpf", private: true }) }],
-      [`${root}/apps/web/package.json`, { type: "file", body: JSON.stringify({ name: "web" }) }],
+      [`${root}/package.json`, JSON.stringify({ name: "dpf", private: true })],
+      [`${root}/apps/web/package.json`, JSON.stringify({ name: "web" })],
     ]);
     const io = {
       existsSync: (p) => map.has(p),
@@ -109,22 +95,47 @@ describe("assessDevPortalWorkspace (BI-0DF1F354)", () => {
         if (p === root) return { isDirectory: () => true };
         throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       },
-      readFileSync: (p) => map.get(p).body,
+      readFileSync: (p) => map.get(p),
     };
     const r = assessDevPortalWorkspace(root, io);
     assert.equal(r.ok, true);
   });
 });
 
-describe("preflightExitCode / formatPreflightFailure", () => {
-  it("uses exit 0 on failure so Docker does not restart-loop", () => {
+describe("boot plan / entrypoint contract (BI-0DF1F354)", () => {
+  it("preflight CLI exits non-zero on fail so entrypoint can gate pnpm", () => {
     const fail = /** @type {const} */ ({
       ok: false,
       reason: "package-json-missing",
       detail: "gone",
     });
-    assert.equal(preflightExitCode(fail), 0);
+    assert.equal(preflightExitCode(fail), PREFLIGHT_FAIL_EXIT);
+    assert.notEqual(preflightExitCode(fail), 0);
     assert.equal(preflightExitCode({ ok: true }), 0);
+  });
+
+  it("missing workspace must not run pnpm and container exits 0 (no thrash)", () => {
+    const fail = /** @type {const} */ ({
+      ok: false,
+      reason: "package-json-missing",
+      detail: "empty mount",
+    });
+    const plan = planDevPortalBoot(fail);
+    assert.equal(plan.runInstallAndDev, false);
+    assert.equal(plan.processExitCode, 0);
+    assert.equal(plan.action, "stop-clean");
+
+    const sim = simulateDevPortalEntrypoint(fail);
+    assert.equal(sim.ranPnpm, false);
+    assert.equal(sim.finalExit, 0);
+  });
+
+  it("healthy workspace runs install+dev", () => {
+    const plan = planDevPortalBoot({ ok: true });
+    assert.equal(plan.runInstallAndDev, true);
+    assert.equal(plan.preflightCliExitCode, 0);
+    const sim = simulateDevPortalEntrypoint({ ok: true });
+    assert.equal(sim.ranPnpm, true);
   });
 
   it("formats a clear BI-tagged failure banner", () => {
@@ -138,3 +149,72 @@ describe("preflightExitCode / formatPreflightFailure", () => {
     assert.match(msg, /worktree deleted/);
   });
 });
+
+describe("integration-style: real preflight + entrypoint shell (BI-0DF1F354)", () => {
+  it("empty mount: preflight fails non-zero; entrypoint exits 0 and never invokes pnpm", () => {
+    const empty = mkdtempSync(join(tmpdir(), "dpf-empty-ws-"));
+    // Preflight alone against empty dir
+    const pre = spawnSync(process.execPath, [preflightPath], {
+      env: { ...process.env, DPF_DEV_PORTAL_WORKSPACE_ROOT: empty },
+      encoding: "utf8",
+    });
+    assert.notEqual(pre.status, 0, "preflight must fail non-zero on empty mount");
+    assert.match(pre.stderr || "", /BI-0DF1F354|package-json-missing|STOPPING/i);
+
+    // Entrypoint with a stub preflight that fails + a pnpm marker that must stay empty
+    const sandbox = mkdtempSync(join(tmpdir(), "dpf-entry-"));
+    const marker = join(sandbox, "pnpm-ran");
+    const stubPreflight = join(sandbox, "preflight-stub.mjs");
+    writeFileSync(
+      stubPreflight,
+      `process.stderr.write("stub-fail\\n"); process.exit(${PREFLIGHT_FAIL_EXIT});\n`,
+    );
+    const entry = join(sandbox, "entry.sh");
+    // Mirror production entrypoint: if ! preflight; then exit 0; fi; else run pnpm marker
+    writeFileSync(
+      entry,
+      `#!/bin/sh
+set -eu
+if ! node "${stubPreflight}"; then
+  exit 0
+fi
+echo ran > "${marker}"
+exit 99
+`,
+    );
+    chmodSync(entry, 0o755);
+
+    const run = spawnSync("sh", [entry], { encoding: "utf8" });
+    assert.equal(run.status, 0, "entrypoint must exit 0 on missing workspace");
+    assert.equal(
+      existsSafe(marker),
+      false,
+      "pnpm/dev chain must not run when preflight fails",
+    );
+  });
+
+  it("Dockerfile bakes preflight into the image path (structural)", () => {
+    const dockerfile = readFileSync(join(here, "../../Dockerfile"), "utf8");
+    assert.match(dockerfile, /COPY.*dev-portal-workspace-preflight\.mjs.*\/usr\/local\/bin/);
+    assert.match(dockerfile, /dev-portal-entrypoint\.sh/);
+    assert.match(dockerfile, /CMD\s*\[\s*"\/usr\/local\/bin\/dev-portal-entrypoint\.sh"/);
+    // Must NOT be bare `preflight && pnpm` with worktree-relative path only
+    assert.doesNotMatch(
+      dockerfile,
+      /CMD\s*\[\s*"sh",\s*"-c",\s*"node scripts\/lib\/dev-portal-workspace-preflight/,
+    );
+    const entryBody = readFileSync(entrypointPath, "utf8");
+    assert.match(entryBody, /if ! node/);
+    assert.match(entryBody, /exit 0/);
+    assert.match(entryBody, /pnpm install/);
+  });
+});
+
+function existsSafe(p) {
+  try {
+    readFileSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/lib/dev-portal-workspace-preflight.test.mjs
+++ b/scripts/lib/dev-portal-workspace-preflight.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * BI-0DF1F354 — unit tests for the pure preflight (node:test, no vitest).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  assessDevPortalWorkspace,
+  formatPreflightFailure,
+  preflightExitCode,
+} from "./dev-portal-workspace-preflight.mjs";
+
+function ioFromMap(map) {
+  return {
+    existsSync: (p) => map.has(p),
+    statSync: (p) => {
+      if (!map.has(p) && ![...map.keys()].some((k) => k.startsWith(p + "/") || k === p)) {
+        // allow root dir if any child exists under it
+        const hasChild = [...map.keys()].some((k) => k.startsWith(String(p).replace(/\/$/, "") + "/"));
+        if (!hasChild && !map.has(p)) {
+          const err = new Error("ENOENT");
+          /** @type {NodeJS.ErrnoException} */
+          (err).code = "ENOENT";
+          throw err;
+        }
+      }
+      return {
+        isDirectory: () => {
+          if (map.get(p)?.type === "file") return false;
+          return true;
+        },
+      };
+    },
+    readFileSync: (p) => {
+      const entry = map.get(p);
+      if (!entry || entry.type !== "file") {
+        const err = new Error("ENOENT");
+        /** @type {NodeJS.ErrnoException} */
+        (err).code = "ENOENT";
+        throw err;
+      }
+      return entry.body;
+    },
+  };
+}
+
+describe("assessDevPortalWorkspace (BI-0DF1F354)", () => {
+  it("fails when root is empty", () => {
+    const r = assessDevPortalWorkspace("", ioFromMap(new Map()));
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.reason, "missing-root");
+  });
+
+  it("fails when root path does not exist (worktree removed)", () => {
+    const r = assessDevPortalWorkspace("/gone/worktree", ioFromMap(new Map()));
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.reason, "root-missing");
+      assert.match(r.detail, /removed|exist/i);
+    }
+  });
+
+  it("fails when package.json is missing (empty bind mount)", () => {
+    const map = new Map([
+      ["/workspace", { type: "dir" }],
+    ]);
+    // force root exists as dir
+    const io = {
+      existsSync: (p) => p === "/workspace",
+      statSync: (p) => {
+        if (p === "/workspace") return { isDirectory: () => true };
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      },
+      readFileSync: () => {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      },
+    };
+    const r = assessDevPortalWorkspace("/workspace", io);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.reason, "package-json-missing");
+  });
+
+  it("fails when apps/web/package.json is missing", () => {
+    const root = "/workspace";
+    const map = new Map([
+      [`${root}/package.json`, { type: "file", body: JSON.stringify({ name: "dpf" }) }],
+    ]);
+    const io = {
+      existsSync: (p) => map.has(p),
+      statSync: (p) => {
+        if (p === root) return { isDirectory: () => true };
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      },
+      readFileSync: (p) => map.get(p).body,
+    };
+    const r = assessDevPortalWorkspace(root, io);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.reason, "web-package-missing");
+  });
+
+  it("passes for a full DPF monorepo layout", () => {
+    const root = "/workspace";
+    const map = new Map([
+      [`${root}/package.json`, { type: "file", body: JSON.stringify({ name: "dpf", private: true }) }],
+      [`${root}/apps/web/package.json`, { type: "file", body: JSON.stringify({ name: "web" }) }],
+    ]);
+    const io = {
+      existsSync: (p) => map.has(p),
+      statSync: (p) => {
+        if (p === root) return { isDirectory: () => true };
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      },
+      readFileSync: (p) => map.get(p).body,
+    };
+    const r = assessDevPortalWorkspace(root, io);
+    assert.equal(r.ok, true);
+  });
+});
+
+describe("preflightExitCode / formatPreflightFailure", () => {
+  it("uses exit 0 on failure so Docker does not restart-loop", () => {
+    const fail = /** @type {const} */ ({
+      ok: false,
+      reason: "package-json-missing",
+      detail: "gone",
+    });
+    assert.equal(preflightExitCode(fail), 0);
+    assert.equal(preflightExitCode({ ok: true }), 0);
+  });
+
+  it("formats a clear BI-tagged failure banner", () => {
+    const msg = formatPreflightFailure({
+      ok: false,
+      reason: "root-missing",
+      detail: "worktree deleted",
+    });
+    assert.match(msg, /BI-0DF1F354/);
+    assert.match(msg, /crash-loop/i);
+    assert.match(msg, /worktree deleted/);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes **BI-0DF1F354**: contributor preview no longer infinite-restarts when its leased worktree is gone.
- **Preflight** `scripts/lib/dev-portal-workspace-preflight.mjs` runs before `pnpm install` / `next dev` in the Dockerfile `dev` stage — missing/empty mount exits **0** with a clear diagnosis (so Docker does not thrash).
- **Compose** `dev-portal` restart policy: `on-failure:5` (was `unless-stopped`).
- **Platform Health** container table marks restart counts ≥ 10 as `CRASH-LOOP?` (danger styling).

## Test plan
- [x] `node --test scripts/lib/dev-portal-workspace-preflight.test.mjs` — 7/7 (worktree source-local)
- [x] CLI smoke: live worktree → ok; empty dir → exit 0 + BI-tagged message
- [x] Pre-commit scoped typecheck green

## Process attestations
Process-Spine-Decision: contributor-preview operational fix + pure preflight tests; no new product route.
UX-Fit-Decision: elevate crash-loop restart counts on existing Platform Health table only; no new nav.
Local-CI-Override: source-local node:test 7/7 preflight + pre-commit typecheck green for BI-0DF1F354; no DB/migration.