### PR TITLE
fix(db): repair booking overlap applied-state drift

### DIFF
--- a/docs/superpowers/plans/2026-07-14-bi-0cc492a8-booking-overlap-applied-repair.md
+++ b/docs/superpowers/plans/2026-07-14-bi-0cc492a8-booking-overlap-applied-repair.md
@@ -1,0 +1,46 @@
+# BI-0CC492A8 — booking-overlap applied-state repair plan
+
+Backlog item: `BI-0CC492A8`  
+Epic: `EP-056D2A5E` — Resource contention & concurrency safety  
+Date: 2026-07-14
+
+## Current evidence
+
+- The original hazard described in the BI was partially remediated by PR #2568 (`00040ea02`): `packages/db/prisma/migrations/20260702150000_booking_overlap_exclusion/migration.sql` now includes `overlapQuarantinedAt` columns, quarantine loops, and quarantine-aware EXCLUDE predicates.
+- The canonical local install has already applied migration `20260702150000_booking_overlap_exclusion` with checksum `bb142273c65ba88bc96d89975df5e4919e48870b6cc1e58298e3184bdaae4e44`, and live DB introspection shows the old state:
+  - no `overlapQuarantinedAt` columns on `StorefrontBooking` / `RentalAgreement`;
+  - both EXCLUDE constraints exist, but their predicates do not exclude quarantined rows.
+- `schema.prisma` now declares `overlapQuarantinedAt` on both models, so already-applied-old installs can remain schema-drifted even though source is safe for not-yet-applied installs.
+
+## Scope
+
+Add a forward-only repair migration for installs that already applied the old migration content before PR #2568 landed. The migration must also be safe on installs that apply the already-corrected original migration first.
+
+## Phases
+
+1. **Migration**
+   - Add a new timestamped Prisma migration after the current latest migration.
+   - `ADD COLUMN IF NOT EXISTS` for both quarantine columns.
+   - Run the same idempotent quarantine loops before constraints are recreated, so any overlaps present in a drifted/manual state are parked rather than destroyed.
+   - Drop and recreate `StorefrontBooking_no_overlap` and `RentalAgreement_no_overlap` with quarantine-aware predicates.
+   - Keep the migration forward-only and data-preserving.
+
+2. **Verification harness**
+   - Extend `packages/db/test/booking-overlap-migration.verify.sql` or add a focused repair harness proving:
+     - old-applied state (constraints exist, quarantine columns absent) is repaired;
+     - clean/fixed state is idempotent;
+     - overlapping active rows are quarantined before constraints are recreated;
+     - a fresh overlapping insert still fails with SQLSTATE `23P01`.
+
+3. **Local source checks**
+   - Run the repair harness against throwaway Postgres if available.
+   - Run migration safety guard / relevant DB tests.
+   - Run `git diff --check`.
+
+4. **Canonical verification**
+   - Run the shared local-CI gate before push/merge.
+   - Capture evidence on `BI-0CC492A8`.
+
+## Rollback
+
+This is a schema migration, so rollback is forward-only: ship a subsequent migration if an issue is found. The intended change is additive plus constraint replacement; no booking/agreement rows are deleted or status-mutated.

--- a/packages/db/prisma/migrations/20260714100000_repair_booking_overlap_applied_state/migration.sql
+++ b/packages/db/prisma/migrations/20260714100000_repair_booking_overlap_applied_state/migration.sql
@@ -1,0 +1,102 @@
+-- BI-0CC492A8 — repair installs that applied the pre-quarantine version of
+-- 20260702150000_booking_overlap_exclusion before PR #2568 made that migration
+-- fleet-safe in source.
+--
+-- Some installs can have _prisma_migrations recording the old checksum while
+-- schema.prisma and current source now expect `overlapQuarantinedAt` columns and
+-- quarantine-aware EXCLUDE predicates. This forward migration reconciles both
+-- populations:
+--   1. installs that already applied the old migration (constraints exist,
+--      quarantine columns absent);
+--   2. installs that apply the corrected original migration first (columns and
+--      corrected constraints already exist).
+--
+-- Data safety: quarantine active pre-existing overlaps before (re)adding the
+-- constraints. No booking/agreement rows are deleted, cancelled, provider-nulled,
+-- or unit-nulled.
+
+BEGIN;
+
+ALTER TABLE "StorefrontBooking" ADD COLUMN IF NOT EXISTS "overlapQuarantinedAt" TIMESTAMP(3);
+ALTER TABLE "RentalAgreement"  ADD COLUMN IF NOT EXISTS "overlapQuarantinedAt" TIMESTAMP(3);
+
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- StorefrontBooking remediation. Each pass quarantines the later-created row of
+-- one remaining active overlap pair. The earliest row in an overlap component
+-- survives; later rows become an operator-review queue.
+DO $$
+DECLARE v_rows int;
+BEGIN
+  LOOP
+    WITH pair AS (
+      SELECT a.id AS later_id
+      FROM "StorefrontBooking" a
+      JOIN "StorefrontBooking" b
+        ON a."providerId" = b."providerId"
+       AND a.id <> b.id
+       AND a."status" <> 'cancelled' AND b."status" <> 'cancelled'
+       AND a."providerId" IS NOT NULL AND a."durationMinutes" > 0 AND b."durationMinutes" > 0
+       AND a."overlapQuarantinedAt" IS NULL AND b."overlapQuarantinedAt" IS NULL
+       AND tsrange(a."scheduledAt", a."scheduledAt" + make_interval(mins => a."durationMinutes")) &&
+           tsrange(b."scheduledAt", b."scheduledAt" + make_interval(mins => b."durationMinutes"))
+       AND (a."createdAt", a.id) > (b."createdAt", b.id)
+      LIMIT 1
+    )
+    UPDATE "StorefrontBooking" s
+       SET "overlapQuarantinedAt" = now()
+      FROM pair WHERE s.id = pair.later_id;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    EXIT WHEN v_rows = 0;
+  END LOOP;
+END $$;
+
+-- RentalAgreement remediation, matching the original fleet-safe strategy.
+DO $$
+DECLARE v_rows int;
+BEGIN
+  LOOP
+    WITH pair AS (
+      SELECT a.id AS later_id
+      FROM "RentalAgreement" a
+      JOIN "RentalAgreement" b
+        ON a."rentableUnitId" = b."rentableUnitId"
+       AND a.id <> b.id
+       AND a."rentableUnitId" IS NOT NULL
+       AND a."status" NOT IN ('cancelled', 'closed', 'returned')
+       AND b."status" NOT IN ('cancelled', 'closed', 'returned')
+       AND a."overlapQuarantinedAt" IS NULL AND b."overlapQuarantinedAt" IS NULL
+       AND tsrange(a."periodStart", a."periodEnd") && tsrange(b."periodStart", b."periodEnd")
+       AND (a."createdAt", a.id) > (b."createdAt", b.id)
+      LIMIT 1
+    )
+    UPDATE "RentalAgreement" s
+       SET "overlapQuarantinedAt" = now()
+      FROM pair WHERE s.id = pair.later_id;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    EXIT WHEN v_rows = 0;
+  END LOOP;
+END $$;
+
+ALTER TABLE "StorefrontBooking" DROP CONSTRAINT IF EXISTS "StorefrontBooking_no_overlap";
+ALTER TABLE "RentalAgreement" DROP CONSTRAINT IF EXISTS "RentalAgreement_no_overlap";
+
+ALTER TABLE "StorefrontBooking"
+  ADD CONSTRAINT "StorefrontBooking_no_overlap"
+  EXCLUDE USING gist (
+    "providerId" WITH =,
+    tsrange("scheduledAt", "scheduledAt" + make_interval(mins => "durationMinutes")) WITH &&
+  )
+  WHERE ("status" <> 'cancelled' AND "providerId" IS NOT NULL AND "durationMinutes" > 0
+         AND "overlapQuarantinedAt" IS NULL);
+
+ALTER TABLE "RentalAgreement"
+  ADD CONSTRAINT "RentalAgreement_no_overlap"
+  EXCLUDE USING gist (
+    "rentableUnitId" WITH =,
+    tsrange("periodStart", "periodEnd") WITH &&
+  )
+  WHERE ("rentableUnitId" IS NOT NULL AND "status" NOT IN ('cancelled', 'closed', 'returned')
+         AND "overlapQuarantinedAt" IS NULL);
+
+COMMIT;

--- a/packages/db/test/booking-overlap-applied-repair.verify.sql
+++ b/packages/db/test/booking-overlap-applied-repair.verify.sql
@@ -1,0 +1,239 @@
+-- Verification harness for BI-0CC492A8 repair migration.
+--
+-- Run against a THROWAWAY Postgres database:
+--   psql -v ON_ERROR_STOP=1 -f packages/db/test/booking-overlap-applied-repair.verify.sql
+--
+-- Proves:
+--   1. an old-applied StorefrontBooking state (constraint exists, quarantine
+--      column absent) is repaired to the quarantine-aware schema;
+--   2. active overlaps are quarantined, not deleted/cancelled;
+--   3. the repaired EXCLUDE constraint rejects future active overlaps;
+--   4. the repair is idempotent on an already-repaired schema;
+--   5. RentalAgreement receives the same quarantine-aware repair.
+
+\echo 'BI-0CC492A8 repair harness: setup old-applied state'
+
+DROP TABLE IF EXISTS "StorefrontBooking";
+DROP TABLE IF EXISTS "RentalAgreement";
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+CREATE TABLE "StorefrontBooking" (
+  id text PRIMARY KEY,
+  "providerId" text,
+  "scheduledAt" timestamp(3) NOT NULL,
+  "durationMinutes" int NOT NULL,
+  status text NOT NULL DEFAULT 'pending',
+  "createdAt" timestamp(3) NOT NULL DEFAULT now()
+);
+
+CREATE TABLE "RentalAgreement" (
+  id text PRIMARY KEY,
+  "rentableUnitId" text,
+  "periodStart" timestamp(3) NOT NULL,
+  "periodEnd" timestamp(3) NOT NULL,
+  status text NOT NULL DEFAULT 'draft',
+  "createdAt" timestamp(3) NOT NULL DEFAULT now()
+);
+
+-- Match the old-applied migration state: constraints exist but no quarantine columns.
+ALTER TABLE "StorefrontBooking"
+  ADD CONSTRAINT "StorefrontBooking_no_overlap"
+  EXCLUDE USING gist (
+    "providerId" WITH =,
+    tsrange("scheduledAt", "scheduledAt" + make_interval(mins => "durationMinutes")) WITH &&
+  )
+  WHERE ("status" <> 'cancelled' AND "providerId" IS NOT NULL AND "durationMinutes" > 0);
+
+ALTER TABLE "RentalAgreement"
+  ADD CONSTRAINT "RentalAgreement_no_overlap"
+  EXCLUDE USING gist (
+    "rentableUnitId" WITH =,
+    tsrange("periodStart", "periodEnd") WITH &&
+  )
+  WHERE ("rentableUnitId" IS NOT NULL AND "status" NOT IN ('cancelled', 'closed', 'returned'));
+
+INSERT INTO "StorefrontBooking"(id,"providerId","scheduledAt","durationMinutes",status,"createdAt") VALUES
+ ('old-b1','P1','2026-08-01 09:00',60,'confirmed','2026-07-01 10:00'),
+ ('old-b2','P1','2026-08-01 10:00',60,'confirmed','2026-07-01 11:00');
+
+INSERT INTO "RentalAgreement"(id,"rentableUnitId","periodStart","periodEnd",status,"createdAt") VALUES
+ ('old-r1','U1','2026-08-01 09:00','2026-08-01 10:00','active','2026-07-01 10:00'),
+ ('old-r2','U1','2026-08-01 10:00','2026-08-01 11:00','active','2026-07-01 11:00');
+
+\echo 'BI-0CC492A8 repair harness: apply repair once'
+\i packages/db/prisma/migrations/20260714100000_repair_booking_overlap_applied_state/migration.sql
+
+-- EXPECT: both quarantine columns now exist.
+SELECT COUNT(*) AS quarantine_column_count
+FROM information_schema.columns
+WHERE table_name IN ('StorefrontBooking', 'RentalAgreement')
+  AND column_name = 'overlapQuarantinedAt';
+
+DO $$
+DECLARE v_count int;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+  FROM information_schema.columns
+  WHERE table_name IN ('StorefrontBooking', 'RentalAgreement')
+    AND column_name = 'overlapQuarantinedAt';
+  IF v_count <> 2 THEN
+    RAISE EXCEPTION 'expected 2 quarantine columns, got %', v_count;
+  END IF;
+END $$;
+
+-- The old non-overlapping rows should remain active/unquarantined.
+SELECT id, CASE WHEN "overlapQuarantinedAt" IS NULL THEN 'ACTIVE' ELSE 'QUARANTINED' END AS state
+FROM "StorefrontBooking" ORDER BY id;
+
+DO $$
+DECLARE v_count int;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+  FROM "StorefrontBooking"
+  WHERE id LIKE 'old-b%' AND "overlapQuarantinedAt" IS NOT NULL;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'expected old non-overlapping bookings to remain active, got % quarantined', v_count;
+  END IF;
+END $$;
+
+-- Create a drift/manual state by temporarily dropping the repaired constraint,
+-- inserting overlaps, and re-running the repair. This proves the quarantine loop.
+ALTER TABLE "StorefrontBooking" DROP CONSTRAINT "StorefrontBooking_no_overlap";
+INSERT INTO "StorefrontBooking"(id,"providerId","scheduledAt","durationMinutes",status,"createdAt") VALUES
+ ('drift-b1','P2','2026-08-02 09:00',60,'confirmed','2026-07-02 10:00'),
+ ('drift-b2','P2','2026-08-02 09:30',60,'confirmed','2026-07-02 11:00'),
+ ('drift-b3','P2','2026-08-02 09:45',60,'confirmed','2026-07-02 12:00');
+
+ALTER TABLE "RentalAgreement" DROP CONSTRAINT "RentalAgreement_no_overlap";
+INSERT INTO "RentalAgreement"(id,"rentableUnitId","periodStart","periodEnd",status,"createdAt") VALUES
+ ('drift-r1','U2','2026-08-02 09:00','2026-08-02 10:00','active','2026-07-02 10:00'),
+ ('drift-r2','U2','2026-08-02 09:30','2026-08-02 10:30','active','2026-07-02 11:00');
+
+\echo 'BI-0CC492A8 repair harness: apply repair twice'
+\i packages/db/prisma/migrations/20260714100000_repair_booking_overlap_applied_state/migration.sql
+\i packages/db/prisma/migrations/20260714100000_repair_booking_overlap_applied_state/migration.sql
+
+-- EXPECT: drift-b1 ACTIVE; drift-b2/drift-b3 QUARANTINED.
+SELECT id, CASE WHEN "overlapQuarantinedAt" IS NULL THEN 'ACTIVE' ELSE 'QUARANTINED' END AS state
+FROM "StorefrontBooking" WHERE id LIKE 'drift-b%' ORDER BY id;
+
+DO $$
+DECLARE v_bad int;
+BEGIN
+  SELECT COUNT(*) INTO v_bad
+  FROM "StorefrontBooking"
+  WHERE (id = 'drift-b1' AND "overlapQuarantinedAt" IS NOT NULL)
+     OR (id IN ('drift-b2', 'drift-b3') AND "overlapQuarantinedAt" IS NULL);
+  IF v_bad <> 0 THEN
+    RAISE EXCEPTION 'unexpected StorefrontBooking quarantine state count=%', v_bad;
+  END IF;
+END $$;
+
+-- EXPECT: drift-r1 ACTIVE; drift-r2 QUARANTINED.
+SELECT id, CASE WHEN "overlapQuarantinedAt" IS NULL THEN 'ACTIVE' ELSE 'QUARANTINED' END AS state
+FROM "RentalAgreement" WHERE id LIKE 'drift-r%' ORDER BY id;
+
+DO $$
+DECLARE v_bad int;
+BEGIN
+  SELECT COUNT(*) INTO v_bad
+  FROM "RentalAgreement"
+  WHERE (id = 'drift-r1' AND "overlapQuarantinedAt" IS NOT NULL)
+     OR (id = 'drift-r2' AND "overlapQuarantinedAt" IS NULL);
+  IF v_bad <> 0 THEN
+    RAISE EXCEPTION 'unexpected RentalAgreement quarantine state count=%', v_bad;
+  END IF;
+END $$;
+
+-- EXPECT: 0 active StorefrontBooking overlaps.
+SELECT COUNT(*) AS remaining_active_booking_overlaps
+FROM "StorefrontBooking" a
+JOIN "StorefrontBooking" b
+  ON a."providerId" = b."providerId"
+ AND a.id < b.id
+ AND a."status" <> 'cancelled' AND b."status" <> 'cancelled'
+ AND a."providerId" IS NOT NULL
+ AND a."durationMinutes" > 0 AND b."durationMinutes" > 0
+ AND a."overlapQuarantinedAt" IS NULL AND b."overlapQuarantinedAt" IS NULL
+ AND tsrange(a."scheduledAt", a."scheduledAt" + make_interval(mins => a."durationMinutes")) &&
+     tsrange(b."scheduledAt", b."scheduledAt" + make_interval(mins => b."durationMinutes"));
+
+DO $$
+DECLARE v_count int;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+  FROM "StorefrontBooking" a
+  JOIN "StorefrontBooking" b
+    ON a."providerId" = b."providerId"
+   AND a.id < b.id
+   AND a."status" <> 'cancelled' AND b."status" <> 'cancelled'
+   AND a."providerId" IS NOT NULL
+   AND a."durationMinutes" > 0 AND b."durationMinutes" > 0
+   AND a."overlapQuarantinedAt" IS NULL AND b."overlapQuarantinedAt" IS NULL
+   AND tsrange(a."scheduledAt", a."scheduledAt" + make_interval(mins => a."durationMinutes")) &&
+       tsrange(b."scheduledAt", b."scheduledAt" + make_interval(mins => b."durationMinutes"));
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'expected 0 remaining active booking overlaps, got %', v_count;
+  END IF;
+END $$;
+
+-- EXPECT: 0 active RentalAgreement overlaps.
+SELECT COUNT(*) AS remaining_active_rental_overlaps
+FROM "RentalAgreement" a
+JOIN "RentalAgreement" b
+  ON a."rentableUnitId" = b."rentableUnitId"
+ AND a.id < b.id
+ AND a."rentableUnitId" IS NOT NULL
+ AND a."status" NOT IN ('cancelled', 'closed', 'returned')
+ AND b."status" NOT IN ('cancelled', 'closed', 'returned')
+ AND a."overlapQuarantinedAt" IS NULL AND b."overlapQuarantinedAt" IS NULL
+ AND tsrange(a."periodStart", a."periodEnd") && tsrange(b."periodStart", b."periodEnd");
+
+DO $$
+DECLARE v_count int;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+  FROM "RentalAgreement" a
+  JOIN "RentalAgreement" b
+    ON a."rentableUnitId" = b."rentableUnitId"
+   AND a.id < b.id
+   AND a."rentableUnitId" IS NOT NULL
+   AND a."status" NOT IN ('cancelled', 'closed', 'returned')
+   AND b."status" NOT IN ('cancelled', 'closed', 'returned')
+   AND a."overlapQuarantinedAt" IS NULL AND b."overlapQuarantinedAt" IS NULL
+   AND tsrange(a."periodStart", a."periodEnd") && tsrange(b."periodStart", b."periodEnd");
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'expected 0 remaining active rental overlaps, got %', v_count;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  INSERT INTO "StorefrontBooking"(id,"providerId","scheduledAt","durationMinutes",status,"createdAt")
+  VALUES ('future-bad','P2','2026-08-02 09:05',30,'confirmed',now());
+  RAISE EXCEPTION 'expected future overlapping booking insert to fail';
+EXCEPTION
+  WHEN exclusion_violation THEN
+    -- expected SQLSTATE 23P01
+    NULL;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'StorefrontBooking_no_overlap'
+      AND pg_get_constraintdef(oid) LIKE '%overlapQuarantinedAt%'
+  ) THEN
+    RAISE EXCEPTION 'StorefrontBooking constraint is not quarantine-aware';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'RentalAgreement_no_overlap'
+      AND pg_get_constraintdef(oid) LIKE '%overlapQuarantinedAt%'
+  ) THEN
+    RAISE EXCEPTION 'RentalAgreement constraint is not quarantine-aware';
+  END IF;
+END $$;
+
+\echo 'BI-0CC492A8 repair harness complete'


### PR DESCRIPTION
## Summary

- Adds a forward-only repair migration for installs that already applied the pre-quarantine booking-overlap migration before PR #2568 corrected the source migration.
- Adds missing quarantine columns when absent, remediates active overlaps by quarantining later rows, and replaces the old EXCLUDE predicates with quarantine-aware predicates.
- Adds an asserted SQL harness for old-applied state, drift overlap remediation, idempotency, and future-overlap rejection.
- Adds the implementation plan for BI-0CC492A8.

## Backlog

BI-0CC492A8

## Verification

- SQL harness against throwaway Postgres DB: passed
- pnpm --filter @dpf/db exec vitest run scripts/migration-safety-guard.test.ts: passed
- node packages/db/scripts/migration-safety-guard.mjs origin/main: passed
- node packages/db/scripts/migration-timestamp-collision-guard.mjs origin/main: passed
- git diff --check: passed
- Local-CI gate: passed (lease NPEL-4AC078A70E, evidence cmrk11ebr01xa01npyoolqnav)

## Notes

The source migration was already corrected by PR #2568 for not-yet-applied installs. This PR covers the remaining applied-old state observed on the canonical local install: migration recorded as applied with old checksum, constraints present, but quarantine columns absent.