### PR TITLE
fix(git): never shallow-fetch a full shared clone (BI-1ADD56FC)

### DIFF
--- a/scripts/check-design-grounding-decision.mjs
+++ b/scripts/check-design-grounding-decision.mjs
@@ -9,6 +9,7 @@
 
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { fetchOriginMainSharedSafe } from "./lib/git-fetch-shared-safe.mjs";
 
 export const DESIGN_GROUNDING_RE = /(?:^|\n)\s*(?:#{1,6}\s*)?Design[ -]Grounding(?:-Decision)?:/i;
 export const DESIGN_GROUNDING_HEADING_RE = /(?:^|\n)\s*#{1,6}\s+Design grounding\b/i;
@@ -108,7 +109,8 @@ function readEvidenceFromChangedDocs(files) {
 
 function main() {
   const base = assertSafeRef(process.env.BASE_SHA || "origin/main", "BASE_SHA");
-  git("fetch", "--no-tags", "--depth=1", "origin", "main");
+  // BI-1ADD56FC: never write .git/shallow into a full shared clone.
+  fetchOriginMainSharedSafe((args) => git(...args));
 
   const changedFiles = git("diff", "--name-only", `${base}...HEAD`)
     .split("\n")

--- a/scripts/check-spec-plan-doc.mjs
+++ b/scripts/check-spec-plan-doc.mjs
@@ -36,6 +36,7 @@
 // interactive nudge is scripts/hooks/spec-plan-doc-precheck.mjs.
 
 import { execFileSync } from "node:child_process";
+import { fetchOriginMainSharedSafe } from "./lib/git-fetch-shared-safe.mjs";
 
 const ATTESTATION_RE = /Process-Spine-Decision:/i;
 
@@ -96,7 +97,8 @@ function git(...args) {
 }
 
 const base = assertSafeRef(process.env.BASE_SHA || "origin/main", "BASE_SHA");
-git("fetch", "--no-tags", "--depth=1", "origin", "main");
+// BI-1ADD56FC: never write .git/shallow into a full shared clone (breaks worktrees).
+fetchOriginMainSharedSafe((args) => git(...args));
 
 const changed = git("diff", "--name-only", `${base}...HEAD`)
   .split("\n")

--- a/scripts/check-ux-fit-decision.mjs
+++ b/scripts/check-ux-fit-decision.mjs
@@ -23,6 +23,7 @@
 // verify a persisted DecisionInteraction record (BI-65DEE968 §5).
 
 import { execFileSync } from "node:child_process";
+import { fetchOriginMainSharedSafe } from "./lib/git-fetch-shared-safe.mjs";
 
 const ATTESTATION_RE = /UX-Fit-Decision:/i;
 
@@ -71,8 +72,9 @@ function git(...args) {
 }
 
 const base = assertSafeRef(process.env.BASE_SHA || "origin/main", "BASE_SHA");
-// Ensure the base ref is present (CI checks out a shallow tree).
-git("fetch", "--no-tags", "--depth=1", "origin", "main");
+// BI-1ADD56FC: never write .git/shallow into a full shared clone (breaks worktrees).
+// Depth is only used when the repo is already shallow (typical GITHUB_ACTIONS checkout).
+fetchOriginMainSharedSafe((args) => git(...args));
 
 const changed = git("diff", "--name-only", `${base}...HEAD`, "--", "apps/web/**/*.tsx")
   .split("\n")

--- a/scripts/lib/git-fetch-shared-safe.mjs
+++ b/scripts/lib/git-fetch-shared-safe.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * BI-1ADD56FC — never depth-limit a fetch into a shared Git object store.
+ *
+ * A `git fetch --depth=1` (or --shallow-since) against a full clone writes
+ * `.git/shallow`, disconnects linked worktrees from merge-base history, and
+ * produces "refusing to merge unrelated histories" across every worktree that
+ * shares the object store. CI gate scripts used to do this casually while
+ * agents also ran those scripts from shared worktrees.
+ *
+ * Rules:
+ *  1. Prefer a normal `git fetch --no-tags origin main` (no depth).
+ *  2. Only allow depth when the caller opts in AND the repo is already shallow
+ *     (typical GITHUB_ACTIONS checkout) — never convert a full repo to shallow.
+ *  3. `assertRepoNotShallow` fails loud for shared root / multi-worktree clones.
+ */
+
+import { execFileSync } from "node:child_process";
+
+/**
+ * @param {(args: string[]) => string} git  — exec wrapper returning stdout
+ * @returns {boolean}
+ */
+export function isShallowRepository(git) {
+  try {
+    return git(["rev-parse", "--is-shallow-repository"]).trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetch origin/main without writing .git/shallow into a full clone.
+ *
+ * @param {(args: string[]) => string} git
+ * @param {{ allowDepthIfAlreadyShallow?: boolean }} [opts]
+ */
+export function fetchOriginMainSharedSafe(git, opts = {}) {
+  const allowDepthIfAlreadyShallow = opts.allowDepthIfAlreadyShallow !== false;
+  const shallow = isShallowRepository(git);
+  if (shallow && allowDepthIfAlreadyShallow) {
+    // Already shallow (typical CI): deepen/refresh with depth is fine — cannot
+    // make it worse. Prefer fetching the needed tip without converting others.
+    git(["fetch", "--no-tags", "--depth=1", "origin", "main"]);
+    return { mode: "depth-on-already-shallow" };
+  }
+  // Full clone / linked worktree: NEVER pass --depth.
+  git(["fetch", "--no-tags", "origin", "main"]);
+  return { mode: "full-fetch" };
+}
+
+/**
+ * Fail if this object store is shallow — used by verify-preflight / local
+ * invariants so a poisoned root clone fails loud.
+ *
+ * @param {(args: string[]) => string} git
+ * @param {{ label?: string }} [opts]
+ */
+export function assertRepoNotShallow(git, opts = {}) {
+  const label = opts.label ?? "repository";
+  if (isShallowRepository(git)) {
+    const err = new Error(
+      `[BI-1ADD56FC] ${label} is a shallow Git repository (.git/shallow present). ` +
+        "A depth-limited fetch poisoned the shared object store and breaks merge-base " +
+        "for linked worktrees. Repair with: git fetch --unshallow origin  (or " +
+        "git fetch --unshallow origin main). Do not run `git fetch --depth=…` against " +
+        "the shared root clone or any linked worktree.",
+    );
+    err.code = "REPO_IS_SHALLOW";
+    throw err;
+  }
+}
+
+/** Default git runner for CLI use. */
+export function defaultGit(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+}
+
+// CLI: node scripts/lib/git-fetch-shared-safe.mjs assert|fetch
+const entry = typeof process.argv[1] === "string" ? process.argv[1].replace(/\\/g, "/") : "";
+const isMain =
+  entry.endsWith("/git-fetch-shared-safe.mjs") || entry.endsWith("git-fetch-shared-safe.mjs");
+if (isMain) {
+  const cmd = process.argv[2] || "assert";
+  try {
+    if (cmd === "assert") {
+      assertRepoNotShallow(defaultGit);
+      process.stdout.write("[git-fetch-shared-safe] ok — repository is not shallow\n");
+      process.exit(0);
+    }
+    if (cmd === "fetch") {
+      const r = fetchOriginMainSharedSafe(defaultGit);
+      process.stdout.write(`[git-fetch-shared-safe] fetch origin main mode=${r.mode}\n`);
+      process.exit(0);
+    }
+    process.stderr.write(`usage: git-fetch-shared-safe.mjs assert|fetch\n`);
+    process.exit(2);
+  } catch (e) {
+    process.stderr.write(`${e instanceof Error ? e.message : String(e)}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/lib/git-fetch-shared-safe.test.mjs
+++ b/scripts/lib/git-fetch-shared-safe.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * BI-1ADD56FC — unit tests for shared-safe git fetch helpers.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  assertRepoNotShallow,
+  fetchOriginMainSharedSafe,
+  isShallowRepository,
+} from "./git-fetch-shared-safe.mjs";
+
+describe("isShallowRepository", () => {
+  it("is true when rev-parse reports true", () => {
+    const git = (args) => {
+      if (args.join(" ") === "rev-parse --is-shallow-repository") return "true\n";
+      throw new Error(`unexpected ${args}`);
+    };
+    assert.equal(isShallowRepository(git), true);
+  });
+
+  it("is false when rev-parse reports false", () => {
+    const git = () => "false\n";
+    assert.equal(isShallowRepository(git), false);
+  });
+});
+
+describe("fetchOriginMainSharedSafe (BI-1ADD56FC)", () => {
+  it("never passes --depth when the repo is full", () => {
+    /** @type {string[][]} */
+    const calls = [];
+    const git = (args) => {
+      calls.push(args);
+      if (args[0] === "rev-parse") return "false\n";
+      return "";
+    };
+    const r = fetchOriginMainSharedSafe(git);
+    assert.equal(r.mode, "full-fetch");
+    const fetchCall = calls.find((c) => c[0] === "fetch");
+    assert.ok(fetchCall, "expected a fetch call");
+    assert.equal(fetchCall.includes("--depth=1"), false);
+    assert.equal(fetchCall.includes("--depth"), false);
+    assert.deepEqual(fetchCall, ["fetch", "--no-tags", "origin", "main"]);
+  });
+
+  it("allows depth only when already shallow", () => {
+    /** @type {string[][]} */
+    const calls = [];
+    const git = (args) => {
+      calls.push(args);
+      if (args[0] === "rev-parse") return "true\n";
+      return "";
+    };
+    const r = fetchOriginMainSharedSafe(git);
+    assert.equal(r.mode, "depth-on-already-shallow");
+    const fetchCall = calls.find((c) => c[0] === "fetch");
+    assert.ok(fetchCall?.includes("--depth=1"));
+  });
+});
+
+describe("assertRepoNotShallow", () => {
+  it("throws REPO_IS_SHALLOW with repair guidance when shallow", () => {
+    const git = () => "true\n";
+    assert.throws(
+      () => assertRepoNotShallow(git, { label: "root clone" }),
+      (err) => {
+        assert.equal(err.code, "REPO_IS_SHALLOW");
+        assert.match(err.message, /BI-1ADD56FC/);
+        assert.match(err.message, /unshallow/i);
+        return true;
+      },
+    );
+  });
+
+  it("passes on a full repository", () => {
+    const git = () => "false\n";
+    assert.doesNotThrow(() => assertRepoNotShallow(git));
+  });
+});


### PR DESCRIPTION
## Summary
- Closes **BI-1ADD56FC**: process-spine CI gates no longer run `git fetch --depth=1` against a **full** shared object store (which writes `.git/shallow` and breaks merge-base for every linked worktree).
- New helper `scripts/lib/git-fetch-shared-safe.mjs`:
  - full repo → `git fetch --no-tags origin main` (no depth)
  - already-shallow CI checkout → depth still allowed
  - `assert` CLI fails loud with unshallow repair guidance
- Wired into `check-spec-plan-doc.mjs`, `check-ux-fit-decision.mjs`, `check-design-grounding-decision.mjs`.

## Design grounding
- Existing specs/plans reviewed:
  - BI-1ADD56FC body (shared clone shallow poison / worktree merge-base)
  - Process-spine gate design (docs/superpowers/specs/2026-05-30-development-process-spine-design.md)
- Current code substrate reviewed:
  - `scripts/check-spec-plan-doc.mjs`, `scripts/check-ux-fit-decision.mjs`, `scripts/check-design-grounding-decision.mjs` depth fetches
  - git promotion sandbox uses isolated clones with depth (OK — not shared store)
- Source of truth:
  - Shared object store must stay full; depth only on already-shallow CI checkouts or isolated clones
- Decision:
  - Shared-safe fetch helper + gate rewiring; no product UX/route change

Design-Grounding-Decision: reviewed BI-1ADD56FC + process-spine gate scripts; tooling invariant only — no UX/workflow contract change.

## Test plan
- [x] `node --test scripts/lib/git-fetch-shared-safe.test.mjs` — 6/6
- [x] Live assert after unshallow on this host

## Process attestations
Process-Spine-Decision: tooling invariant + tests for shared-clone safety; no product surface.
Local-CI-Override: node:test 6/6 shared-safe fetch; pure scripts no product runtime.