### PR TITLE
feat(observability): flag detector contradictions

### DIFF
--- a/apps/web/app/api/platform/metrics/alerts/route.ts
+++ b/apps/web/app/api/platform/metrics/alerts/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { fetchAlertSources } from "@/lib/observability/alert-sources";
+import { screenAlertsForSelfDistrust } from "@/lib/observability/alert-self-distrust";
 
 export const dynamic = "force-dynamic";
 
@@ -20,7 +21,8 @@ const NO_CACHE_HEADERS = {
 // frontend's offline handling.
 
 export async function GET() {
-  const { alerts, reached } = await fetchAlertSources();
+  const { alerts: rawAlerts, reached } = await fetchAlertSources();
+  const alerts = await screenAlertsForSelfDistrust(rawAlerts);
 
   if (!reached.prometheus && !reached["loki-ruler"]) {
     return NextResponse.json(

--- a/apps/web/components/monitoring/alert-humanize.test.ts
+++ b/apps/web/components/monitoring/alert-humanize.test.ts
@@ -29,6 +29,19 @@ describe("humanizeHealthAlert", () => {
     expect(h.explanation).toContain("speech service");
   });
 
+  it("translates detector self-distrust into a monitoring-quality issue", () => {
+    const h = humanizeHealthAlert(
+      alert({
+        alertname: "DetectorSelfDistrust",
+        contradicted_alert: "VoiceServiceDown",
+        service: "VoiceServiceDown",
+        severity: "warning",
+      }),
+    );
+    expect(h.title).toBe("Monitoring may be wrong about voice narration");
+    expect(h.explanation).toContain("monitoring problem");
+  });
+
   it("falls back to a de-camel-cased title + summary for unknown alerts", () => {
     const h = humanizeHealthAlert(
       alert({ alertname: "SomeNewRule" }, { summary: "Something is odd" }),

--- a/apps/web/components/monitoring/alert-humanize.ts
+++ b/apps/web/components/monitoring/alert-humanize.ts
@@ -127,6 +127,16 @@ const ALERT_TRANSLATIONS: Record<string, AlertTranslation> = {
     explanation: () =>
       "Voice narration is turned on, but its speech service isn't running — narration and voice previews won't play.",
   },
+  DetectorSelfDistrust: {
+    title: (_s, labels) =>
+      labels.contradicted_alert === "VoiceServiceDown"
+        ? "Monitoring may be wrong about voice narration"
+        : "A health monitor may be reporting the wrong thing",
+    explanation: (_s, labels) =>
+      labels.contradicted_alert === "VoiceServiceDown"
+        ? "The monitor says voice narration is down, but narration is not currently enabled. Treat this as a monitoring problem, not a feature outage."
+        : "A health rule is firing even though live platform state contradicts it. Check the monitor before treating the feature as broken.",
+  },
   ServiceFlapping: {
     title: (s) => `${s ?? "A platform service"} is unstable`,
     explanation: () => "It keeps switching between up and down, so it can't be relied on right now.",

--- a/apps/web/lib/observability/alert-self-distrust.test.ts
+++ b/apps/web/lib/observability/alert-self-distrust.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { screenAlertsForSelfDistrust } from "./alert-self-distrust";
+import type { PlatformAlert } from "./alert-sources";
+
+function alert(name: string): PlatformAlert {
+  return {
+    labels: { alertname: name, severity: "warning" },
+    annotations: { summary: name },
+    state: "firing",
+    sourceSystem: "prometheus",
+    activeAt: "2026-07-14T02:00:00Z",
+  };
+}
+
+describe("screenAlertsForSelfDistrust", () => {
+  it("keeps VoiceServiceDown when live feature state says narration is enabled", async () => {
+    const screened = await screenAlertsForSelfDistrust([alert("VoiceServiceDown")], {
+      isVoiceNarrationEnabled: async () => true,
+    });
+
+    expect(screened[0].labels.alertname).toBe("VoiceServiceDown");
+    expect(screened[0].labels.detector_self_distrust).toBeUndefined();
+  });
+
+  it("converts VoiceServiceDown into a detector contradiction when narration is disabled", async () => {
+    const screened = await screenAlertsForSelfDistrust([alert("VoiceServiceDown")], {
+      isVoiceNarrationEnabled: async () => false,
+    });
+
+    expect(screened[0].labels.alertname).toBe("DetectorSelfDistrust");
+    expect(screened[0].labels.service).toBe("VoiceServiceDown");
+    expect(screened[0].labels.contradicted_alert).toBe("VoiceServiceDown");
+    expect(screened[0].labels.detector_self_distrust).toBe("true");
+    expect(screened[0].annotations.description).toMatch(/no ready voice profile/i);
+  });
+
+  it("keeps the original alert if the live-state checker is unavailable", async () => {
+    const checker = vi.fn(async () => {
+      throw new Error("db unavailable");
+    });
+
+    const screened = await screenAlertsForSelfDistrust([alert("VoiceServiceDown")], {
+      isVoiceNarrationEnabled: checker,
+    });
+
+    expect(screened[0].labels.alertname).toBe("VoiceServiceDown");
+    expect(screened[0].labels.detector_self_distrust).toBeUndefined();
+  });
+
+  it("does not run the voice checker for unrelated alerts", async () => {
+    const checker = vi.fn(async () => false);
+
+    const screened = await screenAlertsForSelfDistrust([alert("PostgresDown")], {
+      isVoiceNarrationEnabled: checker,
+    });
+
+    expect(screened[0].labels.alertname).toBe("PostgresDown");
+    expect(checker).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/observability/alert-self-distrust.ts
+++ b/apps/web/lib/observability/alert-self-distrust.ts
@@ -1,0 +1,67 @@
+import { type PlatformAlert } from "@/lib/observability/alert-sources";
+import { isVoiceNarrationEnabled } from "@/lib/voice-synthesis/service-status";
+
+const DETECTOR_SELF_DISTRUST_ALERT = "DetectorSelfDistrust";
+
+export interface AlertSelfDistrustDeps {
+  isVoiceNarrationEnabled?: () => Promise<boolean>;
+}
+
+function detectorContradictionAlert(alert: PlatformAlert, reason: string): PlatformAlert {
+  const contradictedAlert = alert.labels.alertname ?? "unknown";
+  const sourceLabel = alert.labels.service || alert.labels.instance || alert.labels.job || contradictedAlert;
+  return {
+    ...alert,
+    labels: {
+      ...alert.labels,
+      alertname: DETECTOR_SELF_DISTRUST_ALERT,
+      severity: alert.labels.severity ?? "warning",
+      service: sourceLabel,
+      contradicted_alert: contradictedAlert,
+      detector_self_distrust: "true",
+    },
+    annotations: {
+      ...alert.annotations,
+      summary: `Monitoring contradiction: ${contradictedAlert}`,
+      description: reason,
+    },
+  };
+}
+
+async function screenOneAlert(
+  alert: PlatformAlert,
+  deps: Required<AlertSelfDistrustDeps>,
+): Promise<PlatformAlert> {
+  if (alert.labels.alertname !== "VoiceServiceDown") return alert;
+
+  try {
+    const narrationEnabled = await deps.isVoiceNarrationEnabled();
+    if (narrationEnabled) return alert;
+  } catch {
+    // If the checker cannot read feature state, keep the original alert. A
+    // self-distrust finding is only useful when grounded in contradictory live
+    // evidence, not when the validator itself is blind.
+    return alert;
+  }
+
+  return detectorContradictionAlert(
+    alert,
+    "Prometheus reported VoiceServiceDown, but the platform currently has no ready voice profile with narration enabled. Treat the monitor/gauge path as suspect instead of reporting a true TTS outage.",
+  );
+}
+
+/**
+ * Convert firing alerts that contradict live platform feature state into
+ * detector-contradiction alerts. This keeps the monitor failure visible while
+ * preventing a broken detector from masquerading as the feature's real state.
+ */
+export async function screenAlertsForSelfDistrust(
+  alerts: PlatformAlert[],
+  deps: AlertSelfDistrustDeps = {},
+): Promise<PlatformAlert[]> {
+  const resolvedDeps: Required<AlertSelfDistrustDeps> = {
+    isVoiceNarrationEnabled: deps.isVoiceNarrationEnabled ?? isVoiceNarrationEnabled,
+  };
+
+  return await Promise.all(alerts.map((alert) => screenOneAlert(alert, resolvedDeps)));
+}

--- a/apps/web/lib/queue/functions/alert-delivery-bridge.test.ts
+++ b/apps/web/lib/queue/functions/alert-delivery-bridge.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   upsert: vi.fn(),
   resolve: vi.fn(),
   findMany: vi.fn(),
+  isVoiceNarrationEnabled: vi.fn(),
 }));
 
 vi.mock("@/lib/observability/alert-sources", () => ({
@@ -13,6 +14,9 @@ vi.mock("@/lib/observability/alert-sources", () => ({
 vi.mock("@/lib/observability/health-alert-issue", () => ({
   upsertHealthAlertIssue: mocks.upsert,
   resolveHealthAlertIssue: mocks.resolve,
+}));
+vi.mock("@/lib/voice-synthesis/service-status", () => ({
+  isVoiceNarrationEnabled: mocks.isVoiceNarrationEnabled,
 }));
 vi.mock("@dpf/db", () => ({
   prisma: { portfolioQualityIssue: { findMany: mocks.findMany } },
@@ -40,6 +44,7 @@ const BOTH_UP = { prometheus: true, "loki-ruler": true };
 describe("runAlertDeliveryScan", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.isVoiceNarrationEnabled.mockResolvedValue(true);
     // Default: upsert returns the deterministic key for the alert it received.
     mocks.upsert.mockImplementation(async (_db: unknown, a: { labels: Record<string, string> }) =>
       keyOf(a.labels.alertname, a.labels.service),
@@ -62,6 +67,31 @@ describe("runAlertDeliveryScan", () => {
     expect(res.firing).toBe(1);
     expect(mocks.upsert).toHaveBeenCalledTimes(1);
     expect(mocks.upsert.mock.calls[0][1].labels.alertname).toBe("PostgresDown");
+  });
+
+  it("flags a VoiceServiceDown alert as detector self-distrust when narration is disabled", async () => {
+    mocks.isVoiceNarrationEnabled.mockResolvedValue(false);
+    mocks.fetchAlertSources.mockResolvedValue({
+      alerts: [alert("VoiceServiceDown", "prometheus", "firing")],
+      reached: BOTH_UP,
+    });
+    mocks.findMany.mockResolvedValue([
+      { issueKey: keyOf("VoiceServiceDown"), details: { source: "prometheus" } },
+    ]);
+
+    const res = await runAlertDeliveryScan();
+
+    expect(res.delivered).toBe(1);
+    expect(mocks.upsert).toHaveBeenCalledTimes(1);
+    expect(mocks.upsert.mock.calls[0][1].labels).toMatchObject({
+      alertname: "DetectorSelfDistrust",
+      service: "VoiceServiceDown",
+      contradicted_alert: "VoiceServiceDown",
+      detector_self_distrust: "true",
+    });
+    // The original VoiceServiceDown key is no longer considered firing, so a
+    // stale phantom issue from the same source is allowed to resolve.
+    expect(mocks.resolve).toHaveBeenCalledWith(expect.anything(), keyOf("VoiceServiceDown"));
   });
 
   it("resolves an open issue whose alert cleared, from a source it reached", async () => {

--- a/apps/web/lib/queue/functions/alert-delivery-bridge.ts
+++ b/apps/web/lib/queue/functions/alert-delivery-bridge.ts
@@ -25,6 +25,7 @@ import {
   fetchAlertSources,
   type AlertSourceSystem,
 } from "@/lib/observability/alert-sources";
+import { screenAlertsForSelfDistrust } from "@/lib/observability/alert-self-distrust";
 import {
   upsertHealthAlertIssue,
   resolveHealthAlertIssue,
@@ -61,7 +62,8 @@ const ZERO = (reached: Record<AlertSourceSystem, boolean>): AlertDeliveryResult 
 export async function runAlertDeliveryScan(): Promise<AlertDeliveryResult> {
   const { prisma } = await import("@dpf/db");
 
-  const { alerts, reached } = await fetchAlertSources();
+  const { alerts: rawAlerts, reached } = await fetchAlertSources();
+  const alerts = await screenAlertsForSelfDistrust(rawAlerts);
 
   // Both evaluators down — do nothing. Critically, do NOT resolve anything: an
   // empty firing set here means "we couldn't see", not "everything cleared".

--- a/docs/superpowers/plans/2026-07-14-bi-4fb6a765-detector-self-distrust.md
+++ b/docs/superpowers/plans/2026-07-14-bi-4fb6a765-detector-self-distrust.md
@@ -1,0 +1,33 @@
+# BI-4FB6A765 — Detector self-distrust for alert/feature contradictions
+
+Backlog item: `BI-4FB6A765`
+
+## Problem
+
+`VoiceServiceDown` is only truthful when voice narration is enabled and the TTS sidecar is down. The Prometheus rule encodes that (`dpf_voice_tts_enabled == 1 and dpf_voice_tts_up == 0`), but the alert delivery path currently trusts evaluator output blindly. If gauge export, scrape staleness, or evaluator state contradicts the platform's live feature state, the portal can persist and show a phantom outage as if it were true.
+
+## Plan
+
+1. Add a shared alert self-distrust screen in the observability layer.
+   - Input: normalized `PlatformAlert` records from Prometheus/Loki.
+   - First rule: for `VoiceServiceDown`, query live voice narration state via `isVoiceNarrationEnabled`.
+   - If the alert says voice is down while live state says narration is disabled, transform it into a detector-contradiction alert instead of a service-down alert.
+
+2. Apply the screen to both user-facing and durable alert paths.
+   - `/api/platform/metrics/alerts` should stop showing a contradicted alert as a true voice outage.
+   - `alert-delivery-bridge` should persist the detector contradiction as the actionable issue and allow stale `VoiceServiceDown` issues to resolve.
+
+3. Verify with focused tests.
+   - Unit-test the self-distrust screen for enabled, disabled, and checker-error cases.
+   - Extend alert-delivery tests so a contradicted `VoiceServiceDown` becomes a `DetectorSelfDistrust` issue and does not keep the original `VoiceServiceDown` key firing.
+
+## Verification
+
+- `pnpm --filter web exec vitest run lib/observability/alert-self-distrust.test.ts lib/queue/functions/alert-delivery-bridge.test.ts components/monitoring/alert-humanize.test.ts`
+- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck`
+- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build`
+- Local-CI merge gate before push/PR.
+
+## Rollback
+
+Remove the self-distrust screen and restore direct consumption of `fetchAlertSources()` in the metrics route and bridge. No migration or data-shape change is required.


### PR DESCRIPTION
## Summary
- Implements BI-4FB6A765 detector self-distrust for `VoiceServiceDown` contradictions.
- Screens Prometheus/Loki alerts against live voice narration state before the metrics API and durable alert-delivery bridge trust them.
- Adds plain-language UX copy so contradicted alerts read as monitoring-quality issues, plus a durable implementation plan.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/observability/alert-self-distrust.test.ts lib/queue/functions/alert-delivery-bridge.test.ts components/monitoring/alert-humanize.test.ts` — 20 passing
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build` — passed; existing Edge-runtime warnings only
- [x] `pnpm run pregate` — local-CI sandbox gate passed for `codex/detector-self-distrust@4f3d29d07f385cba42ba3918308450c454639c43`

Backlog: BI-4FB6A765
