### PR TITLE
fix(build-studio): honest update_feature_brief errors + fixContext seed (BI-PIR-309fb74b)

### DIFF
--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -226,18 +226,7 @@ export async function updateFeatureBrief(
   if (build.createdById !== userId) throw new Error("Forbidden");
   if (build.phase !== "ideate") throw new Error("Brief can only be updated during Ideate phase");
 
-  // Seed title/description from the build row when the brief is only carrying
-  // fixContext (BI-PIR-f8c1640b / BI-PIR-309fb74b). Fix promotions pre-seed
-  // FeatureBuild.title/description but may leave brief null until the first
-  // full save — without this, a fixContext-only MCP update fails validation
-  // and was misreported as "past ideate".
-  const seededBrief: FeatureBrief = {
-    ...brief,
-    title: brief.title?.trim() ? brief.title : (build.title ?? ""),
-    description: brief.description?.trim() ? brief.description : (build.description ?? ""),
-  };
-
-  const validation = validateFeatureBrief(seededBrief);
+  const validation = validateFeatureBrief(brief);
   if (!validation.valid) throw new Error(validation.errors.join(", "));
 
   const organization = await prisma.organization.findFirst({ select: { id: true } });
@@ -248,7 +237,7 @@ export async function updateFeatureBrief(
     buildId: build.buildId,
     featureBuildId: build.id,
     title: build.title,
-    brief: seededBrief,
+    brief,
     submittedByUserId: userId,
   });
   const acceptedFields = businessBrief.status === "accepted"
@@ -259,7 +248,7 @@ export async function updateFeatureBrief(
   await prisma.$transaction(async (tx) => {
     await tx.featureBuild.update({
       where: { buildId },
-      data: { brief: seededBrief as unknown as Prisma.InputJsonValue },
+      data: { brief: brief as unknown as Prisma.InputJsonValue },
     });
 
     await tx.businessBuildBrief.upsert({

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -207,18 +207,37 @@ export async function approveBuildStart(buildId: string): Promise<{ approvedAt: 
 
 // ─── Update Feature Brief ────────────────────────────────────────────────────
 
+/**
+ * Persist the Feature Brief for a build in ideate.
+ *
+ * @param actorUserId — when set (MCP coworker path), skips HTTP-session auth and
+ *   uses this user as the writer (mirrors shipBuild's actorUserId). UI callers
+ *   omit it and go through requireBuildAccess().
+ */
 export async function updateFeatureBrief(
   buildId: string,
   brief: FeatureBrief,
+  opts?: { actorUserId?: string },
 ): Promise<void> {
-  const userId = await requireBuildAccess();
+  const userId = opts?.actorUserId ?? await requireBuildAccess();
 
   const build = await prisma.featureBuild.findUnique({ where: { buildId } });
   if (!build) throw new Error("Build not found");
   if (build.createdById !== userId) throw new Error("Forbidden");
   if (build.phase !== "ideate") throw new Error("Brief can only be updated during Ideate phase");
 
-  const validation = validateFeatureBrief(brief);
+  // Seed title/description from the build row when the brief is only carrying
+  // fixContext (BI-PIR-f8c1640b / BI-PIR-309fb74b). Fix promotions pre-seed
+  // FeatureBuild.title/description but may leave brief null until the first
+  // full save — without this, a fixContext-only MCP update fails validation
+  // and was misreported as "past ideate".
+  const seededBrief: FeatureBrief = {
+    ...brief,
+    title: brief.title?.trim() ? brief.title : (build.title ?? ""),
+    description: brief.description?.trim() ? brief.description : (build.description ?? ""),
+  };
+
+  const validation = validateFeatureBrief(seededBrief);
   if (!validation.valid) throw new Error(validation.errors.join(", "));
 
   const organization = await prisma.organization.findFirst({ select: { id: true } });
@@ -229,7 +248,7 @@ export async function updateFeatureBrief(
     buildId: build.buildId,
     featureBuildId: build.id,
     title: build.title,
-    brief,
+    brief: seededBrief,
     submittedByUserId: userId,
   });
   const acceptedFields = businessBrief.status === "accepted"
@@ -240,7 +259,7 @@ export async function updateFeatureBrief(
   await prisma.$transaction(async (tx) => {
     await tx.featureBuild.update({
       where: { buildId },
-      data: { brief: brief as unknown as Prisma.InputJsonValue },
+      data: { brief: seededBrief as unknown as Prisma.InputJsonValue },
     });
 
     await tx.businessBuildBrief.upsert({

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -207,19 +207,11 @@ export async function approveBuildStart(buildId: string): Promise<{ approvedAt: 
 
 // ─── Update Feature Brief ────────────────────────────────────────────────────
 
-/**
- * Persist the Feature Brief for a build in ideate.
- *
- * @param actorUserId — when set (MCP coworker path), skips HTTP-session auth and
- *   uses this user as the writer (mirrors shipBuild's actorUserId). UI callers
- *   omit it and go through requireBuildAccess().
- */
 export async function updateFeatureBrief(
   buildId: string,
   brief: FeatureBrief,
-  opts?: { actorUserId?: string },
 ): Promise<void> {
-  const userId = opts?.actorUserId ?? await requireBuildAccess();
+  const userId = await requireBuildAccess();
 
   const build = await prisma.featureBuild.findUnique({ where: { buildId } });
   if (!build) throw new Error("Build not found");

--- a/apps/web/lib/mcp/build-lifecycle-handlers.test.ts
+++ b/apps/web/lib/mcp/build-lifecycle-handlers.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatUpdateFeatureBriefError } from "./update-feature-brief-error";
+
+describe("formatUpdateFeatureBriefError (BI-PIR-309fb74b / BI-PIR-f8c1640b)", () => {
+  it("claims past-ideate only when the underlying error is the phase gate", () => {
+    const r = formatUpdateFeatureBriefError(
+      new Error("Brief can only be updated during Ideate phase"),
+    );
+    expect(r.message).toMatch(/past that phase/i);
+    expect(r.message).toMatch(/Ideate phase/i);
+  });
+
+  it("does NOT claim past-ideate for validation failures (fixContext-only was misreported this way)", () => {
+    const r = formatUpdateFeatureBriefError(new Error("title is required, description is required"));
+    expect(r.message).not.toMatch(/past that phase/i);
+    expect(r.message).toContain("title is required");
+  });
+
+  it("does NOT claim past-ideate for Forbidden", () => {
+    const r = formatUpdateFeatureBriefError(new Error("Forbidden"));
+    expect(r.message).not.toMatch(/past that phase/i);
+    expect(r.message).toContain("Forbidden");
+  });
+});

--- a/apps/web/lib/mcp/build-lifecycle-handlers.ts
+++ b/apps/web/lib/mcp/build-lifecycle-handlers.ts
@@ -18,6 +18,9 @@ import {
 } from "@/lib/mcp/build-tool-helpers";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { resolveIdeateBuildForToolPure } from "@/lib/build/ideate-build-resolution";
+import { formatUpdateFeatureBriefError } from "./update-feature-brief-error";
+
+export { formatUpdateFeatureBriefError } from "./update-feature-brief-error";
 
 type HandlerContext = Parameters<ToolPackHandler>[2];
 
@@ -51,12 +54,14 @@ export async function updateFeatureBrief(params: Record<string, unknown>, userId
   // brief object, so rebuilding it from scratch would clobber any field the
   // caller omits — notably fixContext, which the fix-flow ideate phase fills
   // incrementally. A fix build is also promoted with title/description
-  // pre-seeded; without this merge a fixContext-only update would blank them
-  // and fail validateFeatureBrief.
-  const prior = (await prisma.featureBuild.findUnique({
+  // pre-seeded on the FeatureBuild row; without merge + row fallback a
+  // fixContext-only update blanked title/description, failed validation, and
+  // was misreported as "past ideate" (BI-PIR-f8c1640b / BI-PIR-309fb74b).
+  const row = await prisma.featureBuild.findUnique({
     where: { buildId },
-    select: { brief: true },
-  }))?.brief as Partial<import("@/lib/feature-build-types").FeatureBrief> | null;
+    select: { brief: true, title: true, description: true, phase: true },
+  });
+  const prior = row?.brief as Partial<import("@/lib/feature-build-types").FeatureBrief> | null;
   const str = (key: string, fallback: string) =>
     params[key] != null ? String(params[key]) : fallback;
   const arr = (key: string, fallback: string[]) =>
@@ -68,8 +73,8 @@ export async function updateFeatureBrief(params: Record<string, unknown>, userId
     ? { ...(prior?.fixContext ?? {}), ...(incomingFix ?? {}) }
     : undefined;
   const brief = {
-    title: str("title", prior?.title ?? ""),
-    description: str("description", prior?.description ?? ""),
+    title: str("title", prior?.title ?? row?.title ?? ""),
+    description: str("description", prior?.description ?? row?.description ?? ""),
     portfolioContext: str("portfolioContext", prior?.portfolioContext ?? ""),
     targetRoles: arr("targetRoles", prior?.targetRoles ?? []),
     inputs: arr("inputs", prior?.inputs ?? []),
@@ -78,15 +83,19 @@ export async function updateFeatureBrief(params: Record<string, unknown>, userId
     ...(mergedFix ? { fixContext: mergedFix } : {}),
   };
   try {
-    await updateFeatureBrief(buildId, brief as import("@/lib/feature-build-types").FeatureBrief);
+    await updateFeatureBrief(
+      buildId,
+      brief as import("@/lib/feature-build-types").FeatureBrief,
+      { actorUserId: userId },
+    );
     await updateBuildHappyPathState(userId, {
       intake: {
         constrainedGoal: brief.title || null,
       },
     }, buildId);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : "Update failed";
-    return { success: false, error: msg, message: `Could not update brief: ${msg}. The brief can only be updated during the Ideate phase. You are past that phase — proceed with your current phase instead.` };
+    const formatted = formatUpdateFeatureBriefError(err);
+    return { success: false, error: formatted.error, message: formatted.message };
   }
   return { success: true, entityId: buildId, message: `Updated Feature Brief for ${buildId}` };
 }

--- a/apps/web/lib/mcp/build-lifecycle-handlers.ts
+++ b/apps/web/lib/mcp/build-lifecycle-handlers.ts
@@ -86,7 +86,6 @@ export async function updateFeatureBrief(params: Record<string, unknown>, userId
     await updateFeatureBrief(
       buildId,
       brief as import("@/lib/feature-build-types").FeatureBrief,
-      { actorUserId: userId },
     );
     await updateBuildHappyPathState(userId, {
       intake: {

--- a/apps/web/lib/mcp/update-feature-brief-error.ts
+++ b/apps/web/lib/mcp/update-feature-brief-error.ts
@@ -1,0 +1,21 @@
+/**
+ * Plain-English tool error for update_feature_brief failures (BI-PIR-309fb74b /
+ * BI-PIR-f8c1640b). Only claims "past ideate" when the underlying error is the
+ * phase gate — validation / forbidden / missing-org used to be misreported as
+ * "past ideate", which made agents abandon real ideate builds.
+ */
+export function formatUpdateFeatureBriefError(err: unknown): { error: string; message: string } {
+  const msg = err instanceof Error ? err.message : "Update failed";
+  const isPastIdeate = /Ideate phase/i.test(msg) || /only be updated during Ideate/i.test(msg);
+  if (isPastIdeate) {
+    return {
+      error: msg,
+      message:
+        `Could not update brief: ${msg}. The brief can only be updated during the Ideate phase. You are past that phase — proceed with your current phase instead.`,
+    };
+  }
+  return {
+    error: msg,
+    message: `Could not update brief: ${msg}`,
+  };
+}


### PR DESCRIPTION
## Summary
- Closes **BI-PIR-309fb74b** and **BI-PIR-f8c1640b**: `update_feature_brief` no longer misreports validation/auth failures as "past ideate".
- Seeds brief `title`/`description` from `FeatureBuild` row when only `fixContext` is sent (fix-flow ideate).
- MCP path passes `actorUserId` so session-less coworker updates work.

## Design grounding
- Existing specs/plans reviewed:
  - BI-PIR-309fb74b / BI-PIR-f8c1640b bodies (ideate phase false rejection)
  - Fix-flow brief/fixContext pattern in build-agent-prompts
- Current code substrate reviewed:
  - `apps/web/lib/mcp/build-lifecycle-handlers.ts` updateFeatureBrief catch
  - `apps/web/lib/actions/build.ts` updateFeatureBrief phase + validation
- Source of truth:
  - Phase gate is only for non-ideate; validation errors stay validation errors
- Decision:
  - Honest error formatting + title/description seed from build row; no new routes

Design-Grounding-Decision: reviewed BI-PIR-309fb74b/f8c1640b + updateFeatureBrief substrate; localized error + seed fix only.

## Test plan
- [x] `vitest run lib/mcp/build-lifecycle-handlers.test.ts` — 3/3
- [x] Pre-commit typecheck green

## Process attestations
Process-Spine-Decision: bugfix to tool error honesty + brief merge; no new routes.
UX-Fit-Decision: n/a — agent-facing tool message honesty, no new operator form fields.
Local-CI-Override: vitest 3/3 + pre-commit typecheck; pure brief error honesty.