### PR TITLE
feat: record local ci content evidence

### DIFF
--- a/docs/superpowers/plans/2026-07-11-forge-neutral-offline-integration-plan.md
+++ b/docs/superpowers/plans/2026-07-11-forge-neutral-offline-integration-plan.md
@@ -47,11 +47,13 @@ Verification: targeted tests, web typecheck, production build, and before/after 
 
 **BI-76551B2D — Decouple pre-push and local CI from remote branch publication** (`large`)
 
-Status: implementation started. The first slice changes `scripts/gate-worktree.sh`
-so `pnpm run pregate` records local evidence without publishing by default, with
-push-before-lease retained only as an explicit `--push` transition/recovery
-mode. The remaining work in this BI is local candidate/base ref freshness,
-richer content-addressed evidence, and network-disconnect proof.
+Status: implementation in progress. Landed slices make `pnpm run pregate`
+record local evidence without publishing by default, retain push-before-lease
+only as explicit `--push` transition/recovery mode, consume a locally available
+accepted-base ref by default, and record candidate/base/integration/tree SHA
+metadata in gate evidence. The remaining work in this BI is stronger
+toolchain/expiry evidence, pre-push refinements independent of remote names, and
+full network-disconnect proof.
 
 1. Change `scripts/gate-worktree.sh` so local verification defaults to `--no-push`; publication is a separate explicit operation.
 2. Change `scripts/local-ci-runner.sh` and `scripts/lib/local-integration-ci.mjs` to consume a local candidate ref/SHA and a locally available accepted-base ref.

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -145,13 +145,18 @@ recovery/transition cases that intentionally need it.
 
 **The gate command has a checked-in default (BI-157DC9B2):**
 [`scripts/local-ci-runner.sh`](../../scripts/local-ci-runner.sh) runs the
-canonical merged-code plan (`scripts/lib/local-integration-ci.mjs`: fetch
-`origin/main` → merge candidate → sandbox-freshness converge → vitest →
-typecheck → production build) in a dedicated **non-mutating scratch worktree**
-(`~/dpf-worktrees/.local-ci-runner` by default) — never in your topic worktree.
-`DPF_LOCAL_CI_COMMAND` remains an explicit override. The old Phase 1 stub is
-only reachable via `DPF_ALLOW_LOCAL_CI_STUB=1` for contract tests and must
-never be used as release evidence.
+canonical merged-code plan (`scripts/lib/local-integration-ci.mjs`: checkout
+the locally available accepted-base ref, `origin/main` by default → merge
+candidate → sandbox-freshness converge → vitest → typecheck → production build)
+in a dedicated **non-mutating scratch worktree** (`~/dpf-worktrees/.local-ci-runner`
+by default) — never in your topic worktree. It records content-addressed
+metadata to `.git/dpf-local-ci-metadata.json` and into MCP evidence: candidate
+ref/SHA, base ref/SHA, integration commit SHA, synthesized tree SHA, command
+list, and timestamps. `DPF_LOCAL_CI_BASE_REF` can point at another local
+accepted-base ref; `DPF_LOCAL_CI_FETCH_BASE=1` / `--fetch-base` is the explicit
+network-refresh mode. `DPF_LOCAL_CI_COMMAND` remains an explicit override. The
+old Phase 1 stub is only reachable via `DPF_ALLOW_LOCAL_CI_STUB=1` for contract
+tests and must never be used as release evidence.
 
 **The pre-push hook chain is active by default.** The local `pre-push` file is
 gitignored (git-lfs generates it), so the enforced logic ships as the tracked

--- a/scripts/gate-worktree.sh
+++ b/scripts/gate-worktree.sh
@@ -150,6 +150,7 @@ done
 [ -n "$WORKTREE_PATH" ] || WORKTREE_PATH="$("$GIT_BIN" rev-parse --show-toplevel)"
 [ -n "$OWNER_SESSION_ID" ] || OWNER_SESSION_ID="gate-$$"
 STATE_FILE="$("$GIT_BIN" rev-parse --git-path dpf-local-ci-gate.json)"
+METADATA_FILE="$("$GIT_BIN" rev-parse --git-path dpf-local-ci-metadata.json)"
 
 # Checked-in default (BI-157DC9B2): when no DPF_LOCAL_CI_COMMAND is supplied and
 # the stub is not explicitly allowed, run the non-mutating merge-workspace
@@ -161,6 +162,7 @@ fi
 if [ "$DRY_RUN" = "1" ]; then
   printf 'gate-worktree dry-run\n'
   printf 'branch=%s\nsha=%s\nworktree=%s\nremote=%s\nmcpUrl=%s\n' "$BRANCH" "$SHA" "$WORKTREE_PATH" "$REMOTE" "$MCP_URL"
+  printf 'metadataFile=%s\n' "$METADATA_FILE"
   if [ "$PUSH_BRANCH" = "1" ]; then
     printf 'pushBeforeLease=true\n'
   else
@@ -237,7 +239,7 @@ printf '%s\n' "local-CI sandbox lease claimed: $lease_id"
 if [ -n "$LOCAL_CI_COMMAND" ]; then
   gate_command_label="$LOCAL_CI_COMMAND"
   printf '%s\n' "running local-CI command: $LOCAL_CI_COMMAND"
-  sh -c "$LOCAL_CI_COMMAND" >"$gate_output_file" 2>&1
+  DPF_LOCAL_CI_METADATA_FILE="$METADATA_FILE" sh -c "$LOCAL_CI_COMMAND" >"$gate_output_file" 2>&1
   gate_status=$?
 else
   gate_command_label="sandbox checkout/build stub"
@@ -286,7 +288,10 @@ gate_passed="$(printf '%s' "$outcome_json" | field gatePassed)"
 gate_summary="$(printf '%s' "$outcome_json" | field summary)"
 
 evidence_args="$(node -e '
+const fs = require("node:fs");
 const outcome = JSON.parse(process.argv[11]);
+let contentMetadata = null;
+try { contentMetadata = JSON.parse(fs.readFileSync(process.argv[14], "utf8")); } catch {}
 const evidence = {
   bi: "BI-166C59F3",
   resilienceBi: "BI-76551B2D",
@@ -296,6 +301,7 @@ const evidence = {
   branch: process.argv[4],
   sha: process.argv[5],
   pushBeforeLease: process.argv[13] === "1",
+  content: contentMetadata,
   gatePassed: outcome.gatePassed,
   freshness: outcome.freshness,
   commands: [process.argv[7]],
@@ -314,7 +320,7 @@ process.stdout.write(JSON.stringify({
   summary: outcome.summary,
   evidence
 }));
-' "$status" "$gate_passed" "$lease_id" "$BRANCH" "$SHA" "$URL" "$gate_command_label" "$gate_output" "$OWNER_PROVIDER" "$OWNER_SESSION_ID" "$outcome_json" "$gate_status" "$PUSH_BRANCH")"
+' "$status" "$gate_passed" "$lease_id" "$BRANCH" "$SHA" "$URL" "$gate_command_label" "$gate_output" "$OWNER_PROVIDER" "$OWNER_SESSION_ID" "$outcome_json" "$gate_status" "$PUSH_BRANCH" "$METADATA_FILE")"
 evidence_response="$(mcp_call record_local_integration_result "$evidence_args" | extract_tool_result)"
 evidence_success="$(printf '%s' "$evidence_response" | field success)"
 if [ "$evidence_success" != "true" ] && [ "$status" = "blocked_sandbox_drift" ]; then

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -25,6 +25,7 @@ export const HOST_BUILD_NODE_OPTIONS = "NODE_OPTIONS=--max-old-space-size=8192";
 
 export function createLocalIntegrationPlan(input) {
   const branch = integrationBranchName(input.candidateBranch);
+  const baseRef = input.baseRef ?? "origin/main";
   const buildStrategy = input.buildStrategy ?? defaultBuildStrategy(input.hostPlatform);
   const productionBuildCommand = buildStrategy === "docker-build"
     ? ["docker", "build", "--target", "build", "-t", dockerBuildTag(input.candidateBranch), "."]
@@ -32,8 +33,8 @@ export function createLocalIntegrationPlan(input) {
     // POSIX-only by construction (Windows defaults to docker-build above).
     : ["env", HOST_BUILD_NODE_OPTIONS, "pnpm", "--filter", "web", "exec", "next", "build"];
   const commands = [
-    ["git", "fetch", "origin", "main"],
-    ["git", "checkout", "-B", branch, "origin/main"],
+    ...(input.fetchBase ? [["git", "fetch", "origin", "main"]] : []),
+    ["git", "checkout", "-B", branch, baseRef],
     ["git", "merge", "--no-ff", "--no-edit", input.candidateBranch],
     ...input.siblingBranches.map((sibling) => ["git", "merge", "--no-ff", "--no-edit", sibling]),
     // Step-zero sandbox freshness gate (BI-ECDF9520): after the merge changes
@@ -68,6 +69,7 @@ export function createLocalIntegrationPlan(input) {
   return {
     mode: input.mode,
     integrationBranch: branch,
+    baseRef,
     buildStrategy,
     commands,
   };

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -15,7 +15,6 @@ describe("createLocalIntegrationPlan", () => {
     });
 
     assert.deepEqual(plan.commands.map((command) => command.join(" ")), [
-      "git fetch origin main",
       "git checkout -B local-integration/doc-build-studio-decision-skill-packs origin/main",
       "git merge --no-ff --no-edit doc/build-studio-decision-skill-packs",
       "node scripts/sandbox-freshness-preflight.mjs --converge --branch local-integration/doc-build-studio-decision-skill-packs",
@@ -24,6 +23,37 @@ describe("createLocalIntegrationPlan", () => {
       "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck",
       "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec next build",
     ]);
+  });
+
+  it("uses a locally available accepted-base ref without fetching by default (BI-76551B2D)", () => {
+    const plan = createLocalIntegrationPlan({
+      candidateBranch: "feat/local-ci-content-evidence",
+      mode: "single-branch",
+      siblingBranches: [],
+      baseRef: "refs/dpf/integration/main",
+      hostPlatform: "linux",
+    });
+
+    assert.deepEqual(plan.commands.slice(0, 2).map((command) => command.join(" ")), [
+      "git checkout -B local-integration/feat-local-ci-content-evidence refs/dpf/integration/main",
+      "git merge --no-ff --no-edit feat/local-ci-content-evidence",
+    ]);
+    assert.ok(!plan.commands.map((command) => command.join(" ")).some((command) => command.startsWith("git fetch ")));
+    assert.equal(plan.baseRef, "refs/dpf/integration/main");
+  });
+
+  it("can still opt into fetching the accepted base before local integration", () => {
+    const plan = createLocalIntegrationPlan({
+      candidateBranch: "feat/local-ci-content-evidence",
+      mode: "single-branch",
+      siblingBranches: [],
+      baseRef: "origin/main",
+      fetchBase: true,
+      hostPlatform: "linux",
+    });
+
+    assert.equal(plan.commands[0].join(" "), "git fetch origin main");
+    assert.equal(plan.commands[1].join(" "), "git checkout -B local-integration/feat-local-ci-content-evidence origin/main");
   });
 
   it("runs the sandbox freshness preflight after every merge and before any gate", () => {

--- a/scripts/local-ci-runner.sh
+++ b/scripts/local-ci-runner.sh
@@ -9,20 +9,22 @@
 # ~/dpf-worktrees/.local-ci-runner), never in the topic worktree and never in
 # the root clone's working tree. Inside the scratch workspace it runs the
 # canonical plan from scripts/lib/local-integration-ci.mjs:
-#   fetch origin/main → checkout -B local-integration/<slug> → merge candidate
-#   → sandbox-freshness converge (pnpm install if drifted) → vitest → typecheck
-#   → production build.
+#   resolve the locally available accepted-base ref → checkout -B
+#   local-integration/<slug> → merge candidate → sandbox-freshness converge
+#   (pnpm install if drifted) → vitest → typecheck → production build.
 #
 # This is a merge workspace, not a second DPF runtime: no portal, no compose
 # stack, no dev server (worktree-is-source-control-not-runtime). Runtime/UX
 # verification stays on the canonical install or the leased :3010 sandbox.
 #
 # Usage:
-#   scripts/local-ci-runner.sh [--candidate BRANCH] [--workspace PATH] [--dry-run]
+#   scripts/local-ci-runner.sh [--candidate BRANCH] [--base-ref REF] [--fetch-base] [--workspace PATH] [--dry-run]
 
 set -eu
 
 CANDIDATE=""
+BASE_REF="${DPF_LOCAL_CI_BASE_REF:-origin/main}"
+FETCH_BASE="${DPF_LOCAL_CI_FETCH_BASE:-0}"
 WORKSPACE="${DPF_LOCAL_CI_WORKSPACE:-}"
 DRY_RUN=0
 
@@ -32,11 +34,15 @@ Usage: scripts/local-ci-runner.sh [options]
 
 Options:
   --candidate BRANCH   Branch to gate (default: current branch)
+  --base-ref REF       Locally available accepted-base ref (default: origin/main)
+  --fetch-base         Fetch origin/main before checkout (explicit network mode)
   --workspace PATH     Scratch merge workspace (default: <root>-worktrees/.local-ci-runner)
   --dry-run            Print the resolved workspace + plan; run nothing
   --help               Show this help
 
 Environment:
+  DPF_LOCAL_CI_BASE_REF    Overrides the accepted-base ref (default: origin/main).
+  DPF_LOCAL_CI_FETCH_BASE  Set to 1 to fetch origin/main before integration.
   DPF_LOCAL_CI_WORKSPACE   Overrides the scratch workspace location.
 EOF
 }
@@ -49,6 +55,8 @@ die() {
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --candidate) CANDIDATE="${2:-}"; shift 2 ;;
+    --base-ref) BASE_REF="${2:-}"; shift 2 ;;
+    --fetch-base) FETCH_BASE=1; shift ;;
     --workspace) WORKSPACE="${2:-}"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     --help|-h) usage; exit 0 ;;
@@ -59,6 +67,7 @@ done
 [ -n "$CANDIDATE" ] || CANDIDATE="$(git rev-parse --abbrev-ref HEAD)"
 [ "$CANDIDATE" != "HEAD" ] || die "cannot gate a detached HEAD — pass --candidate BRANCH"
 [ "$CANDIDATE" != "main" ] || die "gate topic branches, not main"
+[ -n "$BASE_REF" ] || die "--base-ref cannot be empty"
 
 # Resolve the TRUE root clone (first worktree entry is always the main
 # worktree), regardless of whether we run from the root or a linked worktree.
@@ -70,16 +79,35 @@ if [ -z "$WORKSPACE" ]; then
   WORKSPACE="$(dirname "$root")/$(basename "$root")-worktrees/.local-ci-runner"
 fi
 
+candidate_sha="$(git -C "$repo_top" rev-parse --verify "$CANDIDATE" 2>/dev/null || true)"
+base_sha="$(git -C "$repo_top" rev-parse --verify "$BASE_REF" 2>/dev/null || true)"
+base_commit_date=""
+[ -n "$base_sha" ] && base_commit_date="$(git -C "$repo_top" show -s --format=%cI "$base_sha" 2>/dev/null || true)"
+metadata_file="${DPF_LOCAL_CI_METADATA_FILE:-$(git -C "$repo_top" rev-parse --git-path dpf-local-ci-metadata.json)}"
+
 if [ "$DRY_RUN" = "1" ]; then
   printf 'local-ci-runner dry-run\n'
-  printf 'candidate=%s\nroot=%s\nworkspace=%s\n' "$CANDIDATE" "$root" "$WORKSPACE"
-  printf 'plan=node scripts/local-integration-ci.mjs --candidate %s (in workspace)\n' "$CANDIDATE"
+  printf 'candidate=%s\ncandidateSha=%s\nbaseRef=%s\nbaseSha=%s\nbaseCommitDate=%s\nfetchBase=%s\nroot=%s\nworkspace=%s\nmetadataFile=%s\n' "$CANDIDATE" "${candidate_sha:-unresolved}" "$BASE_REF" "${base_sha:-unresolved}" "$base_commit_date" "$FETCH_BASE" "$root" "$WORKSPACE" "$metadata_file"
+  printf 'plan=node scripts/local-integration-ci.mjs --candidate %s --base-ref %s --candidate-sha %s --base-sha %s --metadata-out %s%s (in workspace)\n' "$CANDIDATE" "$BASE_REF" "$candidate_sha" "$base_sha" "$metadata_file" "$([ "$FETCH_BASE" = "1" ] && printf ' --fetch-base' || true)"
   exit 0
 fi
 
+[ -n "$candidate_sha" ] || die "candidate ref not found locally: $CANDIDATE"
+[ -n "$base_sha" ] || die "accepted base ref not found locally: $BASE_REF (fetch or set DPF_LOCAL_CI_BASE_REF to a local ref)"
+
+printf 'local-ci-runner: candidate %s @ %s\n' "$CANDIDATE" "$candidate_sha"
+printf 'local-ci-runner: accepted base %s @ %s' "$BASE_REF" "$base_sha"
+if [ -n "$base_commit_date" ]; then
+  printf ' (commit date %s)' "$base_commit_date"
+fi
+printf '\n'
+if [ "$FETCH_BASE" != "1" ]; then
+  printf 'local-ci-runner: using locally available base ref without fetch (BI-76551B2D)\n'
+fi
+
 # Ensure the scratch worktree exists. Linked worktrees share refs with the
-# root clone, so the candidate branch and origin/main are visible without any
-# cross-clone fetch plumbing.
+# root clone, so the candidate branch and accepted-base ref are visible without
+# any cross-clone fetch plumbing.
 if [ ! -e "$WORKSPACE/.git" ]; then
   mkdir -p "$(dirname "$WORKSPACE")"
   git -C "$root" worktree add --detach "$WORKSPACE" >/dev/null 2>&1 \
@@ -139,8 +167,12 @@ fi
 
 # Run the CALLER's copy of the plan entrypoint (the version under review) with
 # the scratch workspace as cwd — a stale scratch checkout must never supply the
-# plan itself. The plan's own first steps fetch origin/main and re-checkout the
-# integration branch, so every command after that runs against merged bytes.
+# plan itself. The plan's own first steps checkout the accepted local base and
+# merge the candidate branch, so every command after that runs against merged
+# bytes.
 cd "$WORKSPACE"
 # shellcheck disable=SC2086 — MIGRATE_FLAG is a single optional token
-exec node "$repo_top/scripts/local-integration-ci.mjs" --candidate "$CANDIDATE" $MIGRATE_FLAG
+FETCH_FLAG=""
+[ "$FETCH_BASE" = "1" ] && FETCH_FLAG="--fetch-base"
+# shellcheck disable=SC2086 — MIGRATE_FLAG and FETCH_FLAG are single optional tokens
+exec node "$repo_top/scripts/local-integration-ci.mjs" --candidate "$CANDIDATE" --base-ref "$BASE_REF" --candidate-sha "$candidate_sha" --base-sha "$base_sha" --metadata-out "$metadata_file" $FETCH_FLAG $MIGRATE_FLAG

--- a/scripts/local-integration-ci.mjs
+++ b/scripts/local-integration-ci.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
 import { createLocalIntegrationPlan } from "./lib/local-integration-ci.mjs";
 
 function valueAfter(flag) {
@@ -8,6 +9,10 @@ function valueAfter(flag) {
 }
 
 const candidateBranch = valueAfter("--candidate");
+const baseRef = valueAfter("--base-ref") || "origin/main";
+const candidateSha = valueAfter("--candidate-sha");
+const baseSha = valueAfter("--base-sha");
+const metadataOut = valueAfter("--metadata-out");
 const mode = valueAfter("--mode") || "single-branch";
 const buildStrategy = valueAfter("--build-strategy");
 const siblingBranches = process.argv
@@ -15,17 +20,20 @@ const siblingBranches = process.argv
   .map((arg) => arg.slice("--sibling=".length));
 
 if (!candidateBranch) {
-  console.error("Usage: node scripts/local-integration-ci.mjs --candidate BRANCH [--mode single-branch|sibling-set|post-merge-main] [--sibling=BRANCH] [--migrate-deploy]");
+  console.error("Usage: node scripts/local-integration-ci.mjs --candidate BRANCH [--base-ref REF] [--candidate-sha SHA] [--base-sha SHA] [--metadata-out PATH] [--fetch-base] [--mode single-branch|sibling-set|post-merge-main] [--sibling=BRANCH] [--migrate-deploy]");
   process.exit(2);
 }
 
 const plan = createLocalIntegrationPlan({
   candidateBranch,
+  baseRef,
   mode,
   siblingBranches,
   buildStrategy: buildStrategy || undefined,
+  fetchBase: process.argv.includes("--fetch-base"),
   includeMigrateDeploy: process.argv.includes("--migrate-deploy"),
 });
+const startedAt = new Date().toISOString();
 for (const command of plan.commands) {
   console.log(`[local-integration-ci] ${command.join(" ")}`);
   const result = spawnSync(command[0], command.slice(1), {
@@ -33,4 +41,34 @@ for (const command of plan.commands) {
     shell: process.platform === "win32",
   });
   if (result.status !== 0) process.exit(result.status ?? 1);
+}
+if (metadataOut) {
+  const revParse = (ref) => {
+    const result = spawnSync("git", ["rev-parse", "--verify", ref], {
+      encoding: "utf8",
+      shell: process.platform === "win32",
+    });
+    if (result.status !== 0) {
+      throw new Error(`failed to resolve ${ref}: ${result.stderr || result.stdout}`);
+    }
+    return result.stdout.trim();
+  };
+  const payload = {
+    schemaVersion: 1,
+    bi: "BI-76551B2D",
+    mode,
+    candidateRef: candidateBranch,
+    candidateSha: candidateSha || revParse(candidateBranch),
+    baseRef,
+    baseSha: baseSha || revParse(baseRef),
+    integrationBranch: plan.integrationBranch,
+    integrationCommitSha: revParse("HEAD"),
+    synthesizedTreeSha: revParse("HEAD^{tree}"),
+    buildStrategy: plan.buildStrategy,
+    commands: plan.commands.map((command) => command.join(" ")),
+    startedAt,
+    completedAt: new Date().toISOString(),
+  };
+  writeFileSync(metadataOut, `${JSON.stringify(payload, null, 2)}\n`);
+  console.log(`[local-integration-ci] metadata ${metadataOut}`);
 }

--- a/tests/release/local-ci-gate-contract.test.mjs
+++ b/tests/release/local-ci-gate-contract.test.mjs
@@ -355,6 +355,98 @@ esac
   ]);
 });
 
+test("gate-worktree.sh includes content-addressed local integration metadata in evidence (BI-76551B2D)", () => {
+  const temp = mkdtempSync(join(tmpdir(), "dpf-local-ci-gate-"));
+  const callsFile = join(temp, "calls.ndjson");
+  const gitStub = join(temp, "git");
+  const curlStub = join(temp, "curl");
+  const writerScript = join(temp, "write-metadata.mjs");
+
+  writeFileSync(gitStub, `#!/bin/sh
+if [ "$1" = "rev-parse" ] && [ "$2" = "--git-path" ]; then
+  echo "${temp}/$3"
+  exit 0
+fi
+echo "unexpected git call: $*" >&2
+exit 1
+`);
+  writeFileSync(curlStub, `#!/bin/sh
+data=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --data) data="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s\\n' "$data" >> "${callsFile}"
+tool="$(node -e 'const fs=require("node:fs"); const p=JSON.parse(fs.readFileSync(0,"utf8")); console.log(p.params.name)' <<EOF
+$data
+EOF
+)"
+case "$tool" in
+  claim_nonprod_environment_lease)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-TEST\\"}"}]}}'
+    ;;
+  record_local_integration_result)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"EXT-TEST\\"}"}]}}'
+    ;;
+  release_nonprod_environment_lease)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-TEST\\"}"}]}}'
+    ;;
+  *)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":false,\\"error\\":\\"unexpected_tool\\"}"}]}}'
+    ;;
+esac
+`);
+  writeFileSync(writerScript, `
+import { writeFileSync } from "node:fs";
+writeFileSync(process.env.DPF_LOCAL_CI_METADATA_FILE, JSON.stringify({
+  schemaVersion: 1,
+  bi: "BI-76551B2D",
+  candidateRef: "feat/local-ci-sandbox",
+  candidateSha: "candidate-sha",
+  baseRef: "origin/main",
+  baseSha: "base-sha",
+  integrationCommitSha: "integration-sha",
+  synthesizedTreeSha: "tree-sha"
+}) + "\\n");
+`);
+  chmodSync(gitStub, 0o755);
+  chmodSync(curlStub, 0o755);
+
+  const result = runGate([
+    "--branch",
+    "feat/local-ci-sandbox",
+    "--sha",
+    "candidate-sha",
+    "--worktree",
+    temp,
+  ], {
+    env: {
+      ...process.env,
+      DPF_MCP_BEARER_TOKEN: "dpfmcp_test",
+      DPF_LOCAL_CI_COMMAND: `"${process.execPath}" "${writerScript}"`,
+      DPF_GATE_GIT_BIN: gitStub,
+      DPF_GATE_CURL_BIN: curlStub,
+    },
+  });
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  const calls = readFileSync(callsFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+  const evidenceCall = calls.find((call) => call.params.name === "record_local_integration_result");
+  assert.ok(evidenceCall, "expected evidence to be recorded");
+  assert.deepEqual(evidenceCall.params.arguments.evidence.content, {
+    schemaVersion: 1,
+    bi: "BI-76551B2D",
+    candidateRef: "feat/local-ci-sandbox",
+    candidateSha: "candidate-sha",
+    baseRef: "origin/main",
+    baseSha: "base-sha",
+    integrationCommitSha: "integration-sha",
+    synthesizedTreeSha: "tree-sha",
+  });
+});
+
 // ── pre-push hook chain + pre-push-gate contract (BI-C74F4DE9) ───────────────
 
 // The tracked hook body — the local `pre-push` shim is gitignored (git-lfs


### PR DESCRIPTION
## Summary

- make local-CI consume a locally available accepted-base ref by default, without fetching
- add explicit `--fetch-base` / `DPF_LOCAL_CI_FETCH_BASE=1` network-refresh mode
- resolve candidate/base SHAs before the merge workspace run
- emit `.git/dpf-local-ci-metadata.json` with candidate/base/integration/tree SHAs, commands, timestamps, and build strategy
- include that content-addressed metadata in `record_local_integration_result` evidence
- update the pre-PR gate docs and forge-neutral plan status

## DPF evidence

- Backlog item: BI-76551B2D
- Work Capsule: WC-1D430275
- External evidence: cmrk299y102al01np6qtsw34u
- Local-CI evidence: cmrk28iam029y01npn12ye30y
- Local-CI lease: NPEL-461285F33D
- Candidate SHA: 871c13e75449fc0aa6bd0660247caf79adca15ca
- Base SHA: 772d9f815c3f24d77f7173612d544bd731bed71f
- Synthesized tree SHA: f642656c8bfdfb9f6c6269a528865f3e0a27a762

## Verification

- `node --test scripts/lib/local-integration-ci.test.mjs tests/release/local-ci-gate-contract.test.mjs` — passed (28 tests)
- `sh scripts/local-ci-runner.sh --dry-run --candidate feat/local-ci-content-evidence` — passed; resolved local candidate/base refs and metadata path
- `pnpm run pregate` — passed after rebase; used local accepted base without fetch, ran merge workspace, migrations, web Vitest, web typecheck, and production build

## Remaining BI-76551B2D work

- stronger toolchain/expiry evidence
- pre-push gate refinements independent of remote names
- full network-disconnect proof
