### PR TITLE
fix(ops): suppress zero-result discovery notes from PIR backlog (BI-PIR-76694be9)

### DIFF
--- a/apps/web/lib/operate/issue-report-triage.test.ts
+++ b/apps/web/lib/operate/issue-report-triage.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { buildIssueBacklogItem, triageIssueReports, llmTriageReport, checkForSpike, _resetCache } from "./issue-report-triage";
+import {
+  buildIssueBacklogItem,
+  triageIssueReports,
+  llmTriageReport,
+  checkForSpike,
+  shouldSuppressIssueReportAsBacklog,
+  _resetCache,
+} from "./issue-report-triage";
 
 // General-path fixture. NOTE: source is "manual" (not "crash_boundary") because
 // crash_boundary reports take the dedicated honest-triage gate (BI-B4F401B3)
@@ -17,6 +24,27 @@ const report = {
 };
 
 beforeEach(() => _resetCache());
+
+describe("shouldSuppressIssueReportAsBacklog (BI-PIR-76694be9)", () => {
+  it("suppresses zero-result discovery cadence status notes", () => {
+    expect(
+      shouldSuppressIssueReportAsBacklog({
+        title: "Filter out zero-result daily discovery triage notifications from backlog",
+        description:
+          "The cadence triage run found no taxonomy gaps. All metrics at zero: processed 0, decisions 0. The digital product estate is clean for this cycle.",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress a real defect report", () => {
+    expect(
+      shouldSuppressIssueReportAsBacklog({
+        title: "Page crash on /ops",
+        description: "ReferenceError: ActionResult is not defined",
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("buildIssueBacklogItem", () => {
   it("creates item with BI-PIR prefix, workType=bug, source=automated-detection", () => {
@@ -87,6 +115,34 @@ describe("triageIssueReports", () => {
     expect(result.created).toBe(0);
     expect(created).toHaveLength(0);
     expect(incrementedTitles).toEqual(["Page crash on /platform/ai/providers/ollama"]);
+  });
+
+  it("acknowledges zero-result discovery notes without creating a BI (BI-PIR-76694be9)", async () => {
+    const zeroResult = {
+      ...report,
+      id: "zr1",
+      reportId: "PIR-WTWQA",
+      title: "Filter out zero-result daily discovery triage notifications from backlog",
+      description:
+        "The 2026-06-26 cadence triage run found no taxonomy gaps. All metrics at zero: processed 0, decisions 0. The digital product estate is clean for this cycle.",
+      severity: "low",
+    };
+    const created: unknown[] = [];
+    const acknowledged: string[] = [];
+    const result = await triageIssueReports(
+      triageDeps({
+        getOpenReports: async () => [zeroResult],
+        createBacklogItem: async (data: unknown) => {
+          created.push(data);
+        },
+        acknowledgeReport: async (id: string) => {
+          acknowledged.push(id);
+        },
+      }),
+    );
+    expect(result.created).toBe(0);
+    expect(created).toHaveLength(0);
+    expect(acknowledged).toEqual(["zr1"]);
   });
 
   it("prevents intra-batch duplicates", async () => {

--- a/apps/web/lib/operate/issue-report-triage.ts
+++ b/apps/web/lib/operate/issue-report-triage.ts
@@ -69,6 +69,36 @@ function buildCrashBoundaryItem(report: IssueReport, base: BacklogItemData): Bac
 
 // ─── Pure Functions ─────────────────────────────────────────────────────────
 
+/**
+ * True when a PlatformIssueReport is a zero-result / clean-estate status note
+ * that must not become a backlog item (BI-PIR-76694be9). Daily discovery
+ * triage that finds nothing still used to file "informational" PIRs that
+ * cluttered the open backlog with non-defects.
+ */
+export function shouldSuppressIssueReportAsBacklog(report: {
+  title: string;
+  description?: string | null;
+}): boolean {
+  const text = `${report.title}\n${report.description ?? ""}`.toLowerCase();
+  if (
+    /filter out zero-result|zero-result daily discovery|found no taxonomy gaps|no taxonomy gaps/.test(
+      text,
+    )
+  ) {
+    return true;
+  }
+  if (
+    /all metrics at zero/.test(text)
+    || (/processed\s*0/.test(text) && /decisions\s*0/.test(text))
+  ) {
+    return true;
+  }
+  if (/digital product estate is clean/.test(text) && /this cycle/.test(text)) {
+    return true;
+  }
+  return false;
+}
+
 export function buildIssueBacklogItem(
   report: IssueReport,
   digitalProductId: string | null,
@@ -228,6 +258,13 @@ export async function triageIssueReports(deps: {
     // build-stall-escalation reports filed before the front-door guard existed.
     if (isResponderStream(classifyIssueReportStream(report))) {
       if (deps.holdForResponder) await deps.holdForResponder(report.id);
+      continue;
+    }
+
+    // BI-PIR-76694be9: acknowledge clean-estate / zero-result discovery notes
+    // without filing a bug BI (no defect to fix).
+    if (shouldSuppressIssueReportAsBacklog(report)) {
+      await deps.acknowledgeReport(report.id);
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Suppress zero-result discovery triage notes from PIR backlog intake via `shouldSuppressIssueReportAsBacklog` in issue-report-triage.

Resolves **BI-PIR-76694be9**.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/operate/issue-report-triage.test.ts` → 30 passed (worktree)

Process-Spine-Decision: pure triage-suppress helper + unit tests for existing intake path; no new product surface requiring a durable-spec delta.

Design-Grounding: reuses issue-report-triage suppress path; no new design surface.

Local-CI-Override: vitest issue-report-triage 30/30 after rebase; full CI re-run on push.