### PR TITLE
fix(agentic-loop): recover when model denies a delivered tool (BI-PIR-6de01e8d)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -7,6 +7,7 @@ import {
   buildRepeatedQuestionNudge,
   buildRepeatedToolStopMessage,
   detectToolRefusedDespiteAvailability,
+  buildToolRefusedDespiteAvailableNudge,
   phaseRequiresToolCall,
   detectUnsavedEvidence,
   enrichToolDescriptions,
@@ -1856,6 +1857,19 @@ describe("detectToolRefusedDespiteAvailability (clause 2.6)", () => {
     );
     expect(out).not.toBeNull();
     expect(out).toContain("unspecified");
+  });
+});
+
+describe("buildToolRefusedDespiteAvailableNudge (BI-PIR-6de01e8d)", () => {
+  it("names the refused tool and orders a tool call", () => {
+    const nudge = buildToolRefusedDespiteAvailableNudge({
+      refusedToolName: "run_hive_scout_ingest",
+      deliveredToolNames: ["run_hive_scout_ingest", "other"],
+    });
+    expect(nudge).toContain("run_hive_scout_ingest");
+    expect(nudge).toMatch(/IS available/i);
+    expect(nudge).toMatch(/Call it now/i);
+    expect(nudge).not.toMatch(/not available/i);
   });
 });
 

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -7,7 +7,6 @@ import {
   buildRepeatedQuestionNudge,
   buildRepeatedToolStopMessage,
   detectToolRefusedDespiteAvailability,
-  buildToolRefusedDespiteAvailableNudge,
   phaseRequiresToolCall,
   detectUnsavedEvidence,
   enrichToolDescriptions,
@@ -1857,19 +1856,6 @@ describe("detectToolRefusedDespiteAvailability (clause 2.6)", () => {
     );
     expect(out).not.toBeNull();
     expect(out).toContain("unspecified");
-  });
-});
-
-describe("buildToolRefusedDespiteAvailableNudge (BI-PIR-6de01e8d)", () => {
-  it("names the refused tool and orders a tool call", () => {
-    const nudge = buildToolRefusedDespiteAvailableNudge({
-      refusedToolName: "run_hive_scout_ingest",
-      deliveredToolNames: ["run_hive_scout_ingest", "other"],
-    });
-    expect(nudge).toContain("run_hive_scout_ingest");
-    expect(nudge).toMatch(/IS available/i);
-    expect(nudge).toMatch(/Call it now/i);
-    expect(nudge).not.toMatch(/not available/i);
   });
 });
 

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -762,6 +762,24 @@ export function detectToolRefusedDespiteAvailability(
 }
 
 /**
+ * Corrective nudge text when the model claims a delivered tool is unavailable
+ * (BI-PIR-6de01e8d). Pure + unit-tested; used by the agentic-loop recovery path.
+ */
+export function buildToolRefusedDespiteAvailableNudge(args: {
+  refusedToolName: string;
+  deliveredToolNames: string[];
+}): string {
+  const toolHint =
+    args.refusedToolName.startsWith("(unspecified")
+      ? args.deliveredToolNames.slice(0, 12).join(", ")
+      : args.refusedToolName;
+  return (
+    `CORRECTION: that tool IS available in this session (delivered tool list includes: ${toolHint}). ` +
+    `Do not claim it is unavailable, missing, or ungranted. Call it now via a tool call and continue the task.`
+  );
+}
+
+/**
  * Clause 2.2: phase advance is illegal without saved evidence; therefore
  * a turn in a build phase that produces zero tool calls is a contract
  * violation. Returns true when the phase requires a tool call before close.
@@ -1789,6 +1807,24 @@ export async function runAgenticLoop(params: {
           `tool-refused-despite-availability: ${refusedToolName}`,
           `Agent ${agentId} on route ${routeContext} asserted that ${refusedToolName} is unavailable in iteration ${iteration}, but the tool was in the delivered tool list. Response excerpt: ${trimmed.slice(0, 500)}`,
         );
+        // BI-PIR-6de01e8d: do not only file a PIR — recover in-loop when the
+        // model closed with zero tool calls. The tool is in `tools`; tell the
+        // model explicitly and continue so delivery is not abandoned.
+        if (executedTools.length === 0 && !result.toolsStripped) {
+          continuationNudges++;
+          messages = [
+            ...messages,
+            { role: "assistant" as const, content: result.content },
+            {
+              role: "user" as const,
+              content: buildToolRefusedDespiteAvailableNudge({
+                refusedToolName,
+                deliveredToolNames: tools.map((t) => t.name),
+              }),
+            },
+          ];
+          continue;
+        }
       }
 
       // 2.6b: zero-tool-call on phase-required turn

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -37,6 +37,12 @@ import { estimateContextTokens, classifyContextPressure, deriveCompactionCaps } 
 import { clampToolResultForModel, resolveToolResultCharCap } from "./tool-result-budget";
 import { assessToolSurface, computeToolSelectionAccuracy, contextEconomyTurnMetricFields } from "./context-economy-metrics";
 import { summarizeDroppedMessages } from "./compaction-digest";
+import {
+  detectToolRefusedDespiteAvailability,
+  appendToolRefusedRecoveryMessages,
+} from "./tool-refused-recovery";
+// Re-export for importers (certification-oracles, tests) that pull from agentic-loop.
+export { detectToolRefusedDespiteAvailability } from "./tool-refused-recovery";
 
 // Safety ceiling — NOT a behavioral limit. The loop terminates when the model
 // responds with text only (no tool calls), matching the Anthropic API pattern
@@ -738,46 +744,6 @@ export function shouldNudge(params: {
 // ─── Build-specialist Operator Contract — clause 2.6 platform-side guards ────
 // Spec: docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md §2.6
 // Hallucinating LLMs cannot be trusted to self-report; the platform detects.
-
-/**
- * Clause 2.6 platform path: detect when the agent's text asserts a tool
- * is unavailable AND that tool name appears in its delivered tool list.
- * Returns the offending tool name (or `(unspecified — generic refusal)`
- * for blanket "currently empty / pending" claims), or null.
- */
-export function detectToolRefusedDespiteAvailability(
-  responseText: string,
-  deliveredTools: Array<{ name: string }>,
-): string | null {
-  if (!responseText) return null;
-  const refusalPattern = /(?:not (?:available|enabled|granted|callable|in (?:my )?tool list|exposed)|isn['’]t (?:available|enabled|granted|callable|in (?:my )?tool list|exposed)|is missing|currently `?\[\]`?|pending (?:follow-on |grant)|don['’]t have (?:access|the ability))(?:\s+(?:in|for|to|yet|now|here))?/i;
-  if (!refusalPattern.test(responseText)) return null;
-  for (const tool of deliveredTools) {
-    if (responseText.includes(tool.name)) return tool.name;
-  }
-  if (/currently `?\[\]`?|pending (?:follow-on |grant)/i.test(responseText)) {
-    return "(unspecified — generic refusal)";
-  }
-  return null;
-}
-
-/**
- * Corrective nudge text when the model claims a delivered tool is unavailable
- * (BI-PIR-6de01e8d). Pure + unit-tested; used by the agentic-loop recovery path.
- */
-export function buildToolRefusedDespiteAvailableNudge(args: {
-  refusedToolName: string;
-  deliveredToolNames: string[];
-}): string {
-  const toolHint =
-    args.refusedToolName.startsWith("(unspecified")
-      ? args.deliveredToolNames.slice(0, 12).join(", ")
-      : args.refusedToolName;
-  return (
-    `CORRECTION: that tool IS available in this session (delivered tool list includes: ${toolHint}). ` +
-    `Do not claim it is unavailable, missing, or ungranted. Call it now via a tool call and continue the task.`
-  );
-}
 
 /**
  * Clause 2.2: phase advance is illegal without saved evidence; therefore
@@ -1807,24 +1773,12 @@ export async function runAgenticLoop(params: {
           `tool-refused-despite-availability: ${refusedToolName}`,
           `Agent ${agentId} on route ${routeContext} asserted that ${refusedToolName} is unavailable in iteration ${iteration}, but the tool was in the delivered tool list. Response excerpt: ${trimmed.slice(0, 500)}`,
         );
-        // BI-PIR-6de01e8d: do not only file a PIR — recover in-loop when the
-        // model closed with zero tool calls. The tool is in `tools`; tell the
-        // model explicitly and continue so delivery is not abandoned.
-        if (executedTools.length === 0 && !result.toolsStripped) {
-          continuationNudges++;
-          messages = [
-            ...messages,
-            { role: "assistant" as const, content: result.content },
-            {
-              role: "user" as const,
-              content: buildToolRefusedDespiteAvailableNudge({
-                refusedToolName,
-                deliveredToolNames: tools.map((t) => t.name),
-              }),
-            },
-          ];
-          continue;
-        }
+        // BI-PIR-6de01e8d: recover in-loop when model closed with no tools.
+        const recovered = appendToolRefusedRecoveryMessages({
+          messages, assistantContent: result.content, refusedToolName, deliveredTools: tools,
+          executedToolCount: executedTools.length, toolsStripped: Boolean(result.toolsStripped),
+        });
+        if (recovered) { continuationNudges++; messages = recovered; continue; }
       }
 
       // 2.6b: zero-tool-call on phase-required turn

--- a/apps/web/lib/tak/tool-refused-recovery.test.ts
+++ b/apps/web/lib/tak/tool-refused-recovery.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectToolRefusedDespiteAvailability,
+  buildToolRefusedDespiteAvailableNudge,
+  appendToolRefusedRecoveryMessages,
+} from "./tool-refused-recovery";
+
+describe("detectToolRefusedDespiteAvailability (clause 2.6)", () => {
+  const tools = [{ name: "start_ideate_research" }, { name: "saveBuildEvidence" }];
+
+  it("returns the tool name when response asserts unavailability of a delivered tool", () => {
+    const out = detectToolRefusedDespiteAvailability(
+      "Blocker: start_ideate_research is not available in the current runtime.",
+      tools,
+    );
+    expect(out).toBe("start_ideate_research");
+  });
+
+  it("returns null when response does not assert unavailability", () => {
+    const out = detectToolRefusedDespiteAvailability("I'll call start_ideate_research now.", tools);
+    expect(out).toBeNull();
+  });
+
+  it("returns null when the named tool is not in the delivered list", () => {
+    const out = detectToolRefusedDespiteAvailability(
+      "I cannot call do_something_else because it's not available.",
+      tools,
+    );
+    expect(out).toBeNull();
+  });
+
+  it("matches alternate phrasings", () => {
+    expect(
+      detectToolRefusedDespiteAvailability("saveBuildEvidence isn't enabled yet — pending grants.", tools),
+    ).toBe("saveBuildEvidence");
+  });
+
+  it("returns the unspecified sentinel for generic 'currently []' refusals", () => {
+    const out = detectToolRefusedDespiteAvailability(
+      "The tool grants are currently `[]` for this persona.",
+      tools,
+    );
+    expect(out).not.toBeNull();
+    expect(out).toContain("unspecified");
+  });
+});
+
+describe("buildToolRefusedDespiteAvailableNudge (BI-PIR-6de01e8d)", () => {
+  it("names the refused tool and orders a tool call", () => {
+    const nudge = buildToolRefusedDespiteAvailableNudge({
+      refusedToolName: "run_hive_scout_ingest",
+      deliveredToolNames: ["run_hive_scout_ingest", "other"],
+    });
+    expect(nudge).toContain("run_hive_scout_ingest");
+    expect(nudge).toMatch(/IS available/i);
+    expect(nudge).toMatch(/Call it now/i);
+    expect(nudge).not.toMatch(/not available/i);
+  });
+
+  it("lists delivered tools for unspecified refusal", () => {
+    const nudge = buildToolRefusedDespiteAvailableNudge({
+      refusedToolName: "(unspecified — generic refusal)",
+      deliveredToolNames: ["alpha", "beta"],
+    });
+    expect(nudge).toContain("alpha");
+    expect(nudge).toContain("beta");
+  });
+});
+
+describe("appendToolRefusedRecoveryMessages (BI-PIR-6de01e8d)", () => {
+  const tools = [{ name: "run_hive_scout_ingest" }];
+
+  it("appends assistant + correction when no tools ran", () => {
+    const next = appendToolRefusedRecoveryMessages({
+      messages: [{ role: "user", content: "scout" }],
+      assistantContent: "tool not available",
+      refusedToolName: "run_hive_scout_ingest",
+      deliveredTools: tools,
+      executedToolCount: 0,
+      toolsStripped: false,
+    });
+    expect(next).not.toBeNull();
+    expect(next).toHaveLength(3);
+    expect(next![1].role).toBe("assistant");
+    expect(next![2].role).toBe("user");
+    expect(String(next![2].content)).toMatch(/IS available/i);
+  });
+
+  it("returns null when tools already executed or stripped", () => {
+    expect(
+      appendToolRefusedRecoveryMessages({
+        messages: [],
+        assistantContent: "x",
+        refusedToolName: "run_hive_scout_ingest",
+        deliveredTools: tools,
+        executedToolCount: 1,
+        toolsStripped: false,
+      }),
+    ).toBeNull();
+    expect(
+      appendToolRefusedRecoveryMessages({
+        messages: [],
+        assistantContent: "x",
+        refusedToolName: "run_hive_scout_ingest",
+        deliveredTools: tools,
+        executedToolCount: 0,
+        toolsStripped: true,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/tak/tool-refused-recovery.ts
+++ b/apps/web/lib/tak/tool-refused-recovery.ts
@@ -1,0 +1,72 @@
+// Pure helpers for BI-PIR-6de01e8d — detect + recover when the model claims a
+// delivered tool is unavailable. Kept out of agentic-loop.ts so the baselined
+// module does not grow (module-size ratchet).
+
+import type { ChatMessage } from "@/lib/ai-inference";
+
+/**
+ * Clause 2.6 platform path: detect when the agent's text asserts a tool
+ * is unavailable AND that tool name appears in its delivered tool list.
+ * Returns the offending tool name (or `(unspecified — generic refusal)`
+ * for blanket "currently empty / pending" claims), or null.
+ */
+export function detectToolRefusedDespiteAvailability(
+  responseText: string,
+  deliveredTools: Array<{ name: string }>,
+): string | null {
+  if (!responseText) return null;
+  const refusalPattern = /(?:not (?:available|enabled|granted|callable|in (?:my )?tool list|exposed)|isn['’]t (?:available|enabled|granted|callable|in (?:my )?tool list|exposed)|is missing|currently `?\[\]`?|pending (?:follow-on |grant)|don['’]t have (?:access|the ability))(?:\s+(?:in|for|to|yet|now|here))?/i;
+  if (!refusalPattern.test(responseText)) return null;
+  for (const tool of deliveredTools) {
+    if (responseText.includes(tool.name)) return tool.name;
+  }
+  if (/currently `?\[\]`?|pending (?:follow-on |grant)/i.test(responseText)) {
+    return "(unspecified — generic refusal)";
+  }
+  return null;
+}
+
+/**
+ * Corrective nudge text when the model claims a delivered tool is unavailable
+ * (BI-PIR-6de01e8d). Pure + unit-tested; used by the agentic-loop recovery path.
+ */
+export function buildToolRefusedDespiteAvailableNudge(args: {
+  refusedToolName: string;
+  deliveredToolNames: string[];
+}): string {
+  const toolHint =
+    args.refusedToolName.startsWith("(unspecified")
+      ? args.deliveredToolNames.slice(0, 12).join(", ")
+      : args.refusedToolName;
+  return (
+    `CORRECTION: that tool IS available in this session (delivered tool list includes: ${toolHint}). ` +
+    `Do not claim it is unavailable, missing, or ungranted. Call it now via a tool call and continue the task.`
+  );
+}
+
+/**
+ * When the model closed with zero tool calls after a false unavailability claim,
+ * append the assistant text + a corrective user nudge so the loop can continue.
+ * Returns null when recovery should not run (tools already executed, or stripped).
+ */
+export function appendToolRefusedRecoveryMessages(args: {
+  messages: ChatMessage[];
+  assistantContent: string;
+  refusedToolName: string;
+  deliveredTools: Array<{ name: string }>;
+  executedToolCount: number;
+  toolsStripped: boolean;
+}): ChatMessage[] | null {
+  if (args.executedToolCount > 0 || args.toolsStripped) return null;
+  return [
+    ...args.messages,
+    { role: "assistant" as const, content: args.assistantContent },
+    {
+      role: "user" as const,
+      content: buildToolRefusedDespiteAvailableNudge({
+        refusedToolName: args.refusedToolName,
+        deliveredToolNames: args.deliveredTools.map((t) => t.name),
+      }),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Detect when a coworker asserts a delivered tool is unavailable (`tool-refused-despite-availability`).
- Instead of only filing a PIR, recover in-loop with a corrective nudge that names the delivered tool and orders a tool call.
- Pure helpers live in `tool-refused-recovery.ts` so `agentic-loop.ts` stays under the module-size ratchet.

Closes / resolves **BI-PIR-6de01e8d**.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/tak/tool-refused-recovery.test.ts lib/tak/agentic-loop.test.ts` → 105 passed (worktree)
- [x] `node scripts/check-module-size.mjs` → OK (agentic-loop under baseline)

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md §2.6
- Current code substrate reviewed:
  - apps/web/lib/tak/agentic-loop.ts (clause 2.6a + continuation nudges)
  - apps/web/lib/tak/tool-refused-recovery.ts (extracted pure helpers)
- Source of truth:
  - Clause 2.6 already files PIR; recovery continues the loop when zero tools ran
- Decision:
  - Recover in-loop; keep helpers out of baselined agentic-loop.ts

Process-Spine-Decision: pure helper extraction + unit tests for existing clause-2.6 recovery path; no new product surface requiring a durable-spec delta.

Design-Grounding-Decision: reviewed docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md and code substrate apps/web/lib/tak/agentic-loop.ts; localized recovery nudge, no new routing surface.

Local-CI-Override: module-size OK + vitest 105/105 on tool-refused-recovery + agentic-loop; full CI re-run on push.