### PR TITLE
fix(agentic-loop): hard-flag fabricated CRM account-created claims (BI-PIR-c4d9de00)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -80,7 +80,7 @@ const COMPLETION_CLAIM_PATTERN =
 // makes one of THESE claims without a backing tool call we append an honest
 // "not saved yet" note so the user is not misled. See buildUnsavedAdviceNote.
 export const HARD_COMPLETION_CLAIM_PATTERN =
-  /\bI(?:'ve| have| just)?\s*(?:have\s+)?(?:saved|created|published|posted|sent|scheduled|recorded|queued|logged|added|drafted and saved|placed)\b|\b(?:saved|published|posted|sent|scheduled|queued|added|recorded)\s+(?:it|that|your|the)\b|\b(?:is|are|has been|have been)\s+(?:now\s+)?(?:live|saved|published|sent|scheduled|posted|queued|recorded)\b|in\s+(?:your\s+)?approval\s+queue/i;
+  /\bI(?:'ve| have| just)?\s*(?:have\s+)?(?:saved|created|published|posted|sent|scheduled|recorded|queued|logged|added|drafted and saved|placed)\b|\b(?:saved|published|posted|sent|scheduled|queued|added|recorded)\s+(?:it|that|your|the)\b|\b(?:is|are|has been|have been)\s+(?:now\s+)?(?:live|saved|published|sent|scheduled|posted|queued|recorded)\b|in\s+(?:your\s+)?approval\s+queue|\b(?:prospect\s+)?account\s+created\b|\bACCT-[A-Z0-9]{4,}\b/i;
 
 /**
  * Build a plain-language, non-technical explanation when an agent turn fails

--- a/apps/web/lib/tak/hard-completion-claim.test.ts
+++ b/apps/web/lib/tak/hard-completion-claim.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { HARD_COMPLETION_CLAIM_PATTERN } from "./agentic-loop";
+
+describe("HARD_COMPLETION_CLAIM_PATTERN CRM create claims (BI-PIR-c4d9de00)", () => {
+  it("matches passive prospect/account created claims and ACCT ids", () => {
+    expect(
+      HARD_COMPLETION_CLAIM_PATTERN.test(
+        "Prospect account created for Emma3D (ACCT-17EC9F57).",
+      ),
+    ).toBe(true);
+    expect(HARD_COMPLETION_CLAIM_PATTERN.test("Account created for Acme Corp.")).toBe(true);
+    expect(HARD_COMPLETION_CLAIM_PATTERN.test("Reference ACCT-ABCD12")).toBe(true);
+  });
+
+  it("still ignores future-intent create wording", () => {
+    expect(HARD_COMPLETION_CLAIM_PATTERN.test("I'll create the campaign brief next.")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Extend `HARD_COMPLETION_CLAIM_PATTERN` to catch passive CRM create claims (`account created`, `prospect account created`) and fabricated `ACCT-*` identifiers.
- Conversational coworker routes already append an unsaved-work note for hard claims; those fabrications were only matching the soft completion pattern and could still mislead.

Resolves **BI-PIR-c4d9de00**.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/tak/hard-completion-claim.test.ts` → 2 passed (worktree)
- [x] `node scripts/check-module-size.mjs` → OK

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md (fabrication / save-before-final patterns; clause 2.x)
- Current code substrate reviewed:
  - apps/web/lib/tak/agentic-loop.ts (`HARD_COMPLETION_CLAIM_PATTERN`, `detectFabrication`, `buildUnsavedAdviceNote`)
- Source of truth:
  - HARD_COMPLETION_CLAIM_PATTERN drives the conversational unsaved-work note when no tool ran
- Decision:
  - Extend the hard-claim pattern only; no new routing or UX surface

Process-Spine-Decision: one-line pattern + unit case for existing fabrication guard; no new product surface requiring a durable-spec delta.

Design-Grounding-Decision: reviewed docs/superpowers/specs/2026-04-30-build-specialist-operator-contract.md and code substrate apps/web/lib/tak/agentic-loop.ts; localized pattern widen for CRM create fabrications; no contract or routing change.

Local-CI-Override: module-size OK + vitest hard-completion-claim 2/2; full CI re-run on push.