### PR TITLE
feat(ops): detect Inngest executor starvation

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -112,6 +112,14 @@ const baseStatus = {
     status: "healthy" as const,
     detail: null,
     checkedAt: "2026-05-24T00:00:00.000Z",
+    watchdog: {
+      status: "healthy" as const,
+      detail: null,
+      lastInvocationAt: "2026-05-24T00:00:00.000Z",
+      lastGatewayHitAt: "2026-05-24T00:00:00.000Z",
+      lastRecoveryAttemptAt: null,
+      lastRecoverySummary: null,
+    },
   },
   platformVersion: {
     version: "1.0.0",

--- a/apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
@@ -18,6 +18,7 @@ import { AskCoworkerButton } from "@/components/agent/AskCoworkerButton";
 import { AiReadinessHeaderLink } from "@/components/platform/AiReadinessHeaderLink";
 import { QueueHealthSection } from "@/components/queue/QueueHealthSection";
 import { readQueueSnapshots } from "@/lib/queue/queue-snapshot-service";
+import { getJobEngineHealth } from "@/lib/queue/job-engine-health";
 import { PhaseRemediationActions } from "@/components/platform/PhaseRemediationActions";
 import Link from "next/link";
 
@@ -115,7 +116,10 @@ export default async function RuntimeHealthPage() {
 
   // Fetch here (in the async page body) and pass to the synchronous section so
   // the page renders in a single synchronous pass — no suspending child.
-  const queueSnapshots = await readQueueSnapshots({ limit: 24 });
+  const [queueSnapshots, jobEngineHealth] = await Promise.all([
+    readQueueSnapshots({ limit: 24 }),
+    getJobEngineHealth(),
+  ]);
 
   return (
     <div>
@@ -137,6 +141,78 @@ export default async function RuntimeHealthPage() {
       <div style={{ marginBottom: 20 }}>
         <QueueHealthSection snapshots={queueSnapshots} />
       </div>
+
+      <section
+        style={{
+          border: "1px solid var(--dpf-border)",
+          borderRadius: 8,
+          padding: 14,
+          marginBottom: 20,
+          background: "var(--dpf-surface-1)",
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+          <div>
+            <h2 style={{ fontSize: 13, fontWeight: 700, color: "var(--dpf-text)", margin: 0 }}>
+              Background job engine
+            </h2>
+            <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 4, maxWidth: 740 }}>
+              Watches Inngest registration and executor traffic from the portal process,
+              so starvation is visible even when Inngest cron itself is not firing.
+            </p>
+          </div>
+          <Chip
+            bg={
+              jobEngineHealth.status === "healthy"
+                ? "var(--dpf-state-success)"
+                : jobEngineHealth.status === "degraded"
+                  ? "var(--dpf-state-error)"
+                  : "var(--dpf-surface-2)"
+            }
+            fg={
+              jobEngineHealth.status === "healthy"
+                ? "var(--dpf-success)"
+                : jobEngineHealth.status === "degraded"
+                  ? "var(--dpf-error)"
+                  : "var(--dpf-muted)"
+            }
+          >
+            {jobEngineHealth.status.toUpperCase()}
+          </Chip>
+        </div>
+        {jobEngineHealth.detail && (
+          <p style={{ fontSize: 12, color: "var(--dpf-text)", marginTop: 8, marginBottom: 0 }}>
+            {jobEngineHealth.detail}
+          </p>
+        )}
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 10, fontSize: 11, color: "var(--dpf-muted)" }}>
+          <span>
+            Last registration:{" "}
+            {jobEngineHealth.checkedAt ? <LocalTime value={jobEngineHealth.checkedAt} /> : "not recorded"}
+          </span>
+          <span>
+            Last executor POST:{" "}
+            {jobEngineHealth.watchdog.lastInvocationAt ? (
+              <LocalTime value={jobEngineHealth.watchdog.lastInvocationAt} />
+            ) : (
+              "not observed"
+            )}
+          </span>
+          <span>
+            Watchdog: {jobEngineHealth.watchdog.status}
+          </span>
+          {jobEngineHealth.watchdog.lastRecoveryAttemptAt && (
+            <span>
+              Last safe reap: <LocalTime value={jobEngineHealth.watchdog.lastRecoveryAttemptAt} />
+            </span>
+          )}
+        </div>
+        {jobEngineHealth.watchdog.lastRecoverySummary && (
+          <p style={{ fontSize: 11, color: "var(--dpf-muted)", marginTop: 8, marginBottom: 0 }}>
+            Recovery summary: {jobEngineHealth.watchdog.lastRecoverySummary}
+          </p>
+        )}
+      </section>
 
       {loadError && (
         <div

--- a/apps/web/app/api/inngest/route.ts
+++ b/apps/web/app/api/inngest/route.ts
@@ -2,7 +2,28 @@ import { serve } from "inngest/next";
 import { inngest } from "@/lib/queue/inngest-client";
 import { getInngestFunctionsForRuntime } from "@/lib/queue/functions";
 
-export const { GET, POST, PUT } = serve({
+const served = serve({
   client: inngest,
   functions: getInngestFunctionsForRuntime(),
 });
+
+function recordGatewayHit(method: "GET" | "POST" | "PUT") {
+  void import("@/lib/queue/job-engine-health")
+    .then(({ recordInngestGatewayHit }) => recordInngestGatewayHit(method))
+    .catch(() => {});
+}
+
+export async function GET(...args: Parameters<typeof served.GET>) {
+  recordGatewayHit("GET");
+  return served.GET(...args);
+}
+
+export async function POST(...args: Parameters<typeof served.POST>) {
+  recordGatewayHit("POST");
+  return served.POST(...args);
+}
+
+export async function PUT(...args: Parameters<typeof served.PUT>) {
+  recordGatewayHit("PUT");
+  return served.PUT(...args);
+}

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1087,15 +1087,13 @@ export async function register() {
     // Periodic re-sync (in-process, cron-independent): re-register every 5 min so
     // the job engine self-heals WITHOUT a portal reboot if the boot sync failed
     // or Inngest later restarts and forgets its registration (the 2026-06-14
-    // outage needed a reboot to re-register). Also keeps the ops.jobEngine health
-    // record fresh — it then reflects the CURRENT state, not just boot. The PUT is
-    // idempotent ("modified:false" when the catalog is unchanged).
+    // outage needed a reboot to re-register). Also keeps ops.jobEngine fresh.
     if (process.env.INNGEST_BASE_URL && isInngestSelfSyncOnBootEnabled()) {
       const appUrl = process.env.APP_URL ?? "http://localhost:3000";
       setInterval(
         () => {
           void (async () => {
-            const { recordInngestRegistration } = await import(
+            const { recordInngestRegistration, runInngestExecutorWatchdog } = await import(
               "@/lib/queue/job-engine-health"
             );
             try {
@@ -1110,6 +1108,7 @@ export async function register() {
                 `Inngest re-sync failed: ${getErrorMessage(err)}`,
               );
             }
+            void runInngestExecutorWatchdog().then((r) => r.status === "degraded" && console.warn(`[inngest-watchdog] ${r.detail ?? "executor degraded"}`));
           })();
         },
         5 * 60 * 1000,

--- a/apps/web/lib/queue/job-engine-health.test.ts
+++ b/apps/web/lib/queue/job-engine-health.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const upsertMock = vi.fn();
 const findUniqueMock = vi.fn();
+const executeScheduledInngestRetentionSweepMock = vi.fn();
 
 vi.mock("@dpf/db", () => ({
   prisma: {
@@ -12,16 +13,31 @@ vi.mock("@dpf/db", () => ({
   },
 }));
 
+vi.mock("@/lib/operate/inngest-retention/run", () => ({
+  executeScheduledInngestRetentionSweep: (...a: unknown[]) =>
+    executeScheduledInngestRetentionSweepMock(...a),
+}));
+
 import {
   INNGEST_REGISTRATION_CONFIG_KEY,
+  INNGEST_WATCHDOG_CONFIG_KEY,
+  classifyInngestWatchdogHealth,
   classifyJobEngineHealth,
   getJobEngineHealth,
+  recordInngestGatewayHit,
   recordInngestRegistration,
+  runInngestExecutorWatchdog,
 } from "./job-engine-health";
 
 beforeEach(() => {
   upsertMock.mockReset().mockResolvedValue({});
   findUniqueMock.mockReset();
+  executeScheduledInngestRetentionSweepMock.mockReset().mockResolvedValue({
+    skipped: false,
+    orphansReaped: 2,
+    historyTrimmed: 3,
+    errorCount: 0,
+  });
 });
 
 describe("classifyJobEngineHealth", () => {
@@ -30,13 +46,49 @@ describe("classifyJobEngineHealth", () => {
   });
   it("is healthy when the last registration succeeded", () => {
     expect(
-      classifyJobEngineHealth({ ok: true, at: "2026-06-15T00:00:00.000Z", error: null }),
+      classifyJobEngineHealth(
+        { ok: true, at: "2026-06-15T00:00:00.000Z", error: null },
+        null,
+        new Date("2026-06-15T00:01:00.000Z"),
+      ),
     ).toMatchObject({ status: "healthy", checkedAt: "2026-06-15T00:00:00.000Z" });
   });
   it("is degraded with the error when the last registration failed", () => {
     expect(
       classifyJobEngineHealth({ ok: false, at: "2026-06-15T00:00:00.000Z", error: "HTTP 500" }),
     ).toMatchObject({ status: "degraded", detail: "HTTP 500" });
+  });
+  it("is degraded when registration is healthy but executor POSTs are stale", () => {
+    expect(
+      classifyJobEngineHealth(
+        { ok: true, at: "2026-06-15T00:00:00.000Z", error: null },
+        {
+          lastGatewayHitAt: "2026-06-15T00:20:00.000Z",
+          lastInvocationAt: "2026-06-15T00:00:00.000Z",
+          lastRegistrationRefreshAt: "2026-06-15T00:20:00.000Z",
+          lastProbeAt: null,
+          lastRecoveryAttemptAt: null,
+          lastRecoverySummary: null,
+          lastRecoveryError: null,
+        },
+        new Date("2026-06-15T00:20:00.000Z"),
+      ),
+    ).toMatchObject({
+      status: "degraded",
+      watchdog: { status: "degraded" },
+    });
+  });
+});
+
+describe("classifyInngestWatchdogHealth", () => {
+  it("does not alarm before a healthy registration baseline exists", () => {
+    expect(
+      classifyInngestWatchdogHealth({
+        registration: null,
+        watchdog: null,
+        now: new Date("2026-06-15T00:20:00.000Z"),
+      }),
+    ).toMatchObject({ status: "unknown" });
   });
 });
 
@@ -66,6 +118,24 @@ describe("recordInngestRegistration", () => {
   });
 });
 
+describe("recordInngestGatewayHit", () => {
+  it("records POST as the last executor invocation", async () => {
+    findUniqueMock.mockResolvedValueOnce(null);
+    await recordInngestGatewayHit("POST", new Date("2026-06-15T00:01:00.000Z"));
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { key: INNGEST_WATCHDOG_CONFIG_KEY },
+        update: expect.objectContaining({
+          value: expect.objectContaining({
+            lastGatewayHitAt: "2026-06-15T00:01:00.000Z",
+            lastInvocationAt: "2026-06-15T00:01:00.000Z",
+          }),
+        }),
+      }),
+    );
+  });
+});
+
 describe("getJobEngineHealth", () => {
   it("reads and classifies the persisted state", async () => {
     findUniqueMock.mockResolvedValueOnce({
@@ -81,5 +151,71 @@ describe("getJobEngineHealth", () => {
     expect(await getJobEngineHealth()).toMatchObject({ status: "unknown" });
     findUniqueMock.mockRejectedValueOnce(new Error("db down"));
     expect(await getJobEngineHealth()).toMatchObject({ status: "unknown" });
+  });
+});
+
+describe("runInngestExecutorWatchdog", () => {
+  it("runs the non-destructive retention sweep when executor traffic is stale", async () => {
+    findUniqueMock
+      .mockResolvedValueOnce({
+        value: { ok: true, at: "2026-06-15T00:00:00.000Z", error: null },
+      })
+      .mockResolvedValueOnce({
+        value: {
+          lastGatewayHitAt: "2026-06-15T00:00:00.000Z",
+          lastInvocationAt: "2026-06-15T00:00:00.000Z",
+          lastRegistrationRefreshAt: "2026-06-15T00:00:00.000Z",
+          lastProbeAt: null,
+          lastRecoveryAttemptAt: null,
+          lastRecoverySummary: null,
+          lastRecoveryError: null,
+        },
+      });
+
+    const result = await runInngestExecutorWatchdog({
+      now: new Date("2026-06-15T00:20:00.000Z"),
+      starvationThresholdMs: 15 * 60 * 1000,
+    });
+
+    expect(result.status).toBe("degraded");
+    expect(executeScheduledInngestRetentionSweepMock).toHaveBeenCalledWith({
+      dryRun: false,
+      now: new Date("2026-06-15T00:20:00.000Z"),
+    });
+    expect(upsertMock.mock.calls.at(-1)?.[0].update.value).toMatchObject({
+      lastRecoveryAttemptAt: "2026-06-15T00:20:00.000Z",
+      lastRecoverySummary: "retention sweep ran, orphansReaped=2, historyTrimmed=3, errors=0",
+    });
+  });
+
+  it("honors the recovery cooldown", async () => {
+    findUniqueMock
+      .mockResolvedValueOnce({
+        value: { ok: true, at: "2026-06-15T00:00:00.000Z", error: null },
+      })
+      .mockResolvedValueOnce({
+        value: {
+          lastGatewayHitAt: "2026-06-15T00:00:00.000Z",
+          lastInvocationAt: "2026-06-15T00:00:00.000Z",
+          lastRegistrationRefreshAt: "2026-06-15T00:00:00.000Z",
+          lastProbeAt: null,
+          lastRecoveryAttemptAt: "2026-06-15T00:10:00.000Z",
+          lastRecoverySummary: "recent",
+          lastRecoveryError: null,
+        },
+      });
+
+    const result = await runInngestExecutorWatchdog({
+      now: new Date("2026-06-15T00:20:00.000Z"),
+      starvationThresholdMs: 15 * 60 * 1000,
+      recoveryCooldownMs: 30 * 60 * 1000,
+    });
+
+    expect(result.status).toBe("degraded");
+    expect(executeScheduledInngestRetentionSweepMock).not.toHaveBeenCalled();
+    expect(upsertMock.mock.calls.at(-1)?.[0].update.value).toMatchObject({
+      lastProbeAt: "2026-06-15T00:20:00.000Z",
+      lastRecoveryAttemptAt: "2026-06-15T00:10:00.000Z",
+    });
   });
 });

--- a/apps/web/lib/queue/job-engine-health.ts
+++ b/apps/web/lib/queue/job-engine-health.ts
@@ -12,6 +12,10 @@ import { prisma } from "@dpf/db";
  * surface it immediately.
  */
 export const INNGEST_REGISTRATION_CONFIG_KEY = "ops.jobEngine.inngestRegistration";
+export const INNGEST_WATCHDOG_CONFIG_KEY = "ops.jobEngine.inngestWatchdog";
+
+const DEFAULT_STARVATION_THRESHOLD_MS = 15 * 60 * 1000;
+const DEFAULT_RECOVERY_COOLDOWN_MS = 30 * 60 * 1000;
 
 export type InngestRegistrationState = {
   ok: boolean;
@@ -19,10 +23,30 @@ export type InngestRegistrationState = {
   error: string | null;
 };
 
+export type InngestGatewayMethod = "GET" | "POST" | "PUT";
+
+export type InngestWatchdogState = {
+  lastGatewayHitAt: string | null;
+  lastInvocationAt: string | null;
+  lastRegistrationRefreshAt: string | null;
+  lastProbeAt: string | null;
+  lastRecoveryAttemptAt: string | null;
+  lastRecoverySummary: string | null;
+  lastRecoveryError: string | null;
+};
+
 export type JobEngineHealth = {
   status: "healthy" | "degraded" | "unknown";
   detail: string | null;
   checkedAt: string | null;
+  watchdog: {
+    status: "healthy" | "degraded" | "unknown";
+    detail: string | null;
+    lastInvocationAt: string | null;
+    lastGatewayHitAt: string | null;
+    lastRecoveryAttemptAt: string | null;
+    lastRecoverySummary: string | null;
+  };
 };
 
 /**
@@ -50,16 +74,273 @@ export async function recordInngestRegistration(
   }
 }
 
+function emptyWatchdogState(): InngestWatchdogState {
+  return {
+    lastGatewayHitAt: null,
+    lastInvocationAt: null,
+    lastRegistrationRefreshAt: null,
+    lastProbeAt: null,
+    lastRecoveryAttemptAt: null,
+    lastRecoverySummary: null,
+    lastRecoveryError: null,
+  };
+}
+
+function coerceWatchdogState(value: unknown): InngestWatchdogState {
+  if (!value || typeof value !== "object") return emptyWatchdogState();
+  const raw = value as Partial<Record<keyof InngestWatchdogState, unknown>>;
+  return {
+    lastGatewayHitAt: typeof raw.lastGatewayHitAt === "string" ? raw.lastGatewayHitAt : null,
+    lastInvocationAt: typeof raw.lastInvocationAt === "string" ? raw.lastInvocationAt : null,
+    lastRegistrationRefreshAt:
+      typeof raw.lastRegistrationRefreshAt === "string" ? raw.lastRegistrationRefreshAt : null,
+    lastProbeAt: typeof raw.lastProbeAt === "string" ? raw.lastProbeAt : null,
+    lastRecoveryAttemptAt:
+      typeof raw.lastRecoveryAttemptAt === "string" ? raw.lastRecoveryAttemptAt : null,
+    lastRecoverySummary:
+      typeof raw.lastRecoverySummary === "string" ? raw.lastRecoverySummary : null,
+    lastRecoveryError:
+      typeof raw.lastRecoveryError === "string" ? raw.lastRecoveryError : null,
+  };
+}
+
+async function readInngestRegistrationState(): Promise<InngestRegistrationState | null> {
+  if (typeof prisma.platformConfig?.findUnique !== "function") return null;
+  const row = await prisma.platformConfig.findUnique({
+    where: { key: INNGEST_REGISTRATION_CONFIG_KEY },
+  });
+  return (row?.value as InngestRegistrationState | null) ?? null;
+}
+
+async function readInngestWatchdogState(): Promise<InngestWatchdogState> {
+  if (typeof prisma.platformConfig?.findUnique !== "function") return emptyWatchdogState();
+  const row = await prisma.platformConfig.findUnique({
+    where: { key: INNGEST_WATCHDOG_CONFIG_KEY },
+  });
+  return coerceWatchdogState(row?.value);
+}
+
+async function writeInngestWatchdogState(state: InngestWatchdogState): Promise<void> {
+  if (typeof prisma.platformConfig?.upsert !== "function") return;
+  await prisma.platformConfig.upsert({
+    where: { key: INNGEST_WATCHDOG_CONFIG_KEY },
+    create: { key: INNGEST_WATCHDOG_CONFIG_KEY, value: state as unknown as object },
+    update: { value: state as unknown as object },
+  });
+}
+
+/**
+ * Record traffic through /api/inngest. POST is the important executor signal:
+ * when the self-hosted Inngest server invokes a function, it calls this route.
+ * If time passes after healthy registration but POSTs stop arriving, the
+ * executor is probably wedged. Best-effort; never throw into the route.
+ */
+export async function recordInngestGatewayHit(
+  method: InngestGatewayMethod,
+  now: Date = new Date(),
+): Promise<void> {
+  try {
+    const prior = await readInngestWatchdogState();
+    const at = now.toISOString();
+    await writeInngestWatchdogState({
+      ...prior,
+      lastGatewayHitAt: at,
+      lastInvocationAt: method === "POST" ? at : prior.lastInvocationAt,
+      lastRegistrationRefreshAt:
+        method === "PUT" ? at : prior.lastRegistrationRefreshAt,
+    });
+  } catch {
+    // Non-fatal — health recording must not break job dispatch.
+  }
+}
+
+export function classifyInngestWatchdogHealth(args: {
+  registration: InngestRegistrationState | null;
+  watchdog: InngestWatchdogState | null;
+  now: Date;
+  starvationThresholdMs?: number;
+}): JobEngineHealth["watchdog"] {
+  const thresholdMs = args.starvationThresholdMs ?? DEFAULT_STARVATION_THRESHOLD_MS;
+  const watchdog = args.watchdog ? coerceWatchdogState(args.watchdog) : emptyWatchdogState();
+
+  if (!args.registration || typeof args.registration.ok !== "boolean") {
+    return {
+      status: "unknown",
+      detail: "Waiting for the first Inngest registration attempt before judging executor traffic.",
+      lastInvocationAt: watchdog.lastInvocationAt,
+      lastGatewayHitAt: watchdog.lastGatewayHitAt,
+      lastRecoveryAttemptAt: watchdog.lastRecoveryAttemptAt,
+      lastRecoverySummary: watchdog.lastRecoverySummary,
+    };
+  }
+
+  if (!args.registration.ok) {
+    return {
+      status: "unknown",
+      detail: "Registration is already degraded; executor-starvation detection waits for a healthy registration baseline.",
+      lastInvocationAt: watchdog.lastInvocationAt,
+      lastGatewayHitAt: watchdog.lastGatewayHitAt,
+      lastRecoveryAttemptAt: watchdog.lastRecoveryAttemptAt,
+      lastRecoverySummary: watchdog.lastRecoverySummary,
+    };
+  }
+
+  const baseline = watchdog.lastInvocationAt ?? args.registration.at;
+  const baselineMs = Date.parse(baseline);
+  if (!Number.isFinite(baselineMs)) {
+    return {
+      status: "unknown",
+      detail: "The last Inngest registration timestamp is not parseable.",
+      lastInvocationAt: watchdog.lastInvocationAt,
+      lastGatewayHitAt: watchdog.lastGatewayHitAt,
+      lastRecoveryAttemptAt: watchdog.lastRecoveryAttemptAt,
+      lastRecoverySummary: watchdog.lastRecoverySummary,
+    };
+  }
+
+  const ageMs = args.now.getTime() - baselineMs;
+  if (ageMs > thresholdMs) {
+    const minutes = Math.floor(ageMs / 60_000);
+    return {
+      status: "degraded",
+      detail:
+        `No /api/inngest POST execution has been observed for ${minutes} minute(s) after healthy registration. ` +
+        "The executor may be starved or wedged; the portal watchdog can run the non-destructive Inngest orphan-retention sweep.",
+      lastInvocationAt: watchdog.lastInvocationAt,
+      lastGatewayHitAt: watchdog.lastGatewayHitAt,
+      lastRecoveryAttemptAt: watchdog.lastRecoveryAttemptAt,
+      lastRecoverySummary: watchdog.lastRecoverySummary,
+    };
+  }
+
+  return {
+    status: "healthy",
+    detail: null,
+    lastInvocationAt: watchdog.lastInvocationAt,
+    lastGatewayHitAt: watchdog.lastGatewayHitAt,
+    lastRecoveryAttemptAt: watchdog.lastRecoveryAttemptAt,
+    lastRecoverySummary: watchdog.lastRecoverySummary,
+  };
+}
+
+function summarizeRetentionResult(report: {
+  skipped?: boolean;
+  skipReason?: string;
+  orphansReaped?: number;
+  historyTrimmed?: number;
+  errorCount?: number;
+}): string {
+  if (report.skipped) return `retention sweep skipped: ${report.skipReason ?? "unknown"}`;
+  return [
+    `retention sweep ran`,
+    `orphansReaped=${report.orphansReaped ?? 0}`,
+    `historyTrimmed=${report.historyTrimmed ?? 0}`,
+    `errors=${report.errorCount ?? 0}`,
+  ].join(", ");
+}
+
+function shouldAttemptRecovery(args: {
+  health: JobEngineHealth["watchdog"];
+  watchdog: InngestWatchdogState;
+  now: Date;
+  recoveryCooldownMs: number;
+}): boolean {
+  if (args.health.status !== "degraded") return false;
+  if (!args.watchdog.lastRecoveryAttemptAt) return true;
+  const last = Date.parse(args.watchdog.lastRecoveryAttemptAt);
+  return !Number.isFinite(last) || args.now.getTime() - last > args.recoveryCooldownMs;
+}
+
+/**
+ * Portal-side watchdog for Inngest executor starvation. This intentionally does
+ * not run as an Inngest cron: if Inngest is wedged, an Inngest cron cannot be
+ * trusted to diagnose or recover it. Recovery is non-destructive: it invokes the
+ * existing retention/orphan reaper directly and never flushes Redis or restarts
+ * containers.
+ */
+export async function runInngestExecutorWatchdog(opts: {
+  now?: Date;
+  starvationThresholdMs?: number;
+  recoveryCooldownMs?: number;
+} = {}): Promise<JobEngineHealth["watchdog"]> {
+  const now = opts.now ?? new Date();
+  const recoveryCooldownMs = opts.recoveryCooldownMs ?? DEFAULT_RECOVERY_COOLDOWN_MS;
+  try {
+    const [registration, watchdog] = await Promise.all([
+      readInngestRegistrationState(),
+      readInngestWatchdogState(),
+    ]);
+    const probed = { ...watchdog, lastProbeAt: now.toISOString() };
+    const health = classifyInngestWatchdogHealth({
+      registration,
+      watchdog: probed,
+      now,
+      starvationThresholdMs: opts.starvationThresholdMs,
+    });
+
+    if (!shouldAttemptRecovery({ health, watchdog: probed, now, recoveryCooldownMs })) {
+      await writeInngestWatchdogState(probed);
+      return health;
+    }
+
+    const attemptAt = now.toISOString();
+    try {
+      const { executeScheduledInngestRetentionSweep } = await import(
+        "@/lib/operate/inngest-retention/run"
+      );
+      const report = await executeScheduledInngestRetentionSweep({ dryRun: false, now });
+      const summary = summarizeRetentionResult(report);
+      await writeInngestWatchdogState({
+        ...probed,
+        lastRecoveryAttemptAt: attemptAt,
+        lastRecoverySummary: summary,
+        lastRecoveryError: null,
+      });
+      return { ...health, lastRecoveryAttemptAt: attemptAt, lastRecoverySummary: summary };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : "watchdog recovery failed";
+      await writeInngestWatchdogState({
+        ...probed,
+        lastRecoveryAttemptAt: attemptAt,
+        lastRecoverySummary: null,
+        lastRecoveryError: error,
+      });
+      return { ...health, lastRecoveryAttemptAt: attemptAt, lastRecoverySummary: error };
+    }
+  } catch {
+    return {
+      status: "unknown",
+      detail: "Could not read Inngest watchdog state.",
+      lastInvocationAt: null,
+      lastGatewayHitAt: null,
+      lastRecoveryAttemptAt: null,
+      lastRecoverySummary: null,
+    };
+  }
+}
+
 /** Pure classifier — unit-tested without a DB. */
 export function classifyJobEngineHealth(
   state: InngestRegistrationState | null,
+  watchdogState: InngestWatchdogState | null = null,
+  now: Date = new Date(),
 ): JobEngineHealth {
+  const watchdog = classifyInngestWatchdogHealth({
+    registration: state,
+    watchdog: watchdogState,
+    now,
+  });
   // No record yet (fresh install, or before the first boot sync): don't alarm.
   if (!state || typeof state.ok !== "boolean") {
-    return { status: "unknown", detail: null, checkedAt: null };
+    return { status: "unknown", detail: null, checkedAt: null, watchdog };
   }
   if (state.ok) {
-    return { status: "healthy", detail: null, checkedAt: state.at ?? null };
+    return {
+      status: watchdog.status === "degraded" ? "degraded" : "healthy",
+      detail: watchdog.status === "degraded" ? watchdog.detail : null,
+      checkedAt: state.at ?? null,
+      watchdog,
+    };
   }
   return {
     status: "degraded",
@@ -67,22 +348,34 @@ export function classifyJobEngineHealth(
       state.error ??
       "The portal could not register its jobs with Inngest — background jobs will not run.",
     checkedAt: state.at ?? null,
+    watchdog,
   };
 }
 
 export async function getJobEngineHealth(): Promise<JobEngineHealth> {
   // Defensive: a partially-seeded test/dev DB may lack the model.
   if (typeof prisma.platformConfig?.findUnique !== "function") {
-    return { status: "unknown", detail: null, checkedAt: null };
+    return classifyJobEngineHealth(null);
   }
   try {
-    const row = await prisma.platformConfig.findUnique({
-      where: { key: INNGEST_REGISTRATION_CONFIG_KEY },
-    });
-    return classifyJobEngineHealth(
-      (row?.value as InngestRegistrationState | null) ?? null,
-    );
+    const [registration, watchdog] = await Promise.all([
+      readInngestRegistrationState(),
+      readInngestWatchdogState(),
+    ]);
+    return classifyJobEngineHealth(registration, watchdog);
   } catch {
-    return { status: "unknown", detail: null, checkedAt: null };
+    return {
+      status: "unknown",
+      detail: null,
+      checkedAt: null,
+      watchdog: {
+        status: "unknown",
+        detail: "Could not read Inngest watchdog state.",
+        lastInvocationAt: null,
+        lastGatewayHitAt: null,
+        lastRecoveryAttemptAt: null,
+        lastRecoverySummary: null,
+      },
+    };
   }
 }

--- a/docs/superpowers/plans/2026-07-14-bi-fe558c5c-inngest-starvation-watchdog.md
+++ b/docs/superpowers/plans/2026-07-14-bi-fe558c5c-inngest-starvation-watchdog.md
@@ -1,0 +1,55 @@
+# BI-FE558C5C — Inngest executor-starvation watchdog
+
+Backlog item: `BI-FE558C5C`  
+Epic: `EP-B9DD37C7` — Coworker chat: runtime truthfulness, transparency & controls
+
+## Current substrate
+
+- `/api/inngest` is served by `apps/web/app/api/inngest/route.ts`.
+- Portal boot already self-registers the function catalog from `apps/web/instrumentation.ts` and stores registration health in `apps/web/lib/queue/job-engine-health.ts`.
+- Slice 1 exists as `apps/web/lib/queue/functions/inngest-retention-sweep.ts` and `apps/web/lib/operate/inngest-retention/run.ts`: it bounds Inngest history and reaps Redis-TTL orphan rows.
+- `/platform/ai/runtime-health` already renders queue/runtime signals and is the right operator surface for this failure mode.
+
+## Plan
+
+1. Track executor traffic outside Inngest cron.
+   - Wrap `/api/inngest` route handlers and record gateway hits, especially `POST` invocation hits, in `PlatformConfig`.
+   - Keep this best-effort so health recording cannot break job dispatch.
+
+2. Add a portal-side watchdog.
+   - Evaluate from `instrumentation.ts` on a normal `setInterval`, not an Inngest cron.
+   - Declare starvation when registration is healthy but no `/api/inngest` `POST` invocation has arrived within the threshold.
+   - Keep fresh installs quiet until the first healthy registration is older than the threshold.
+
+3. Recover only through the safe slice-1 mechanism.
+   - On starvation, invoke `executeScheduledInngestRetentionSweep({ dryRun: false })` directly from the portal process.
+   - Enforce a cooldown so the watchdog cannot hammer the Inngest database.
+   - Do not add Redis `FLUSHALL`, container restart, or any destructive drain; those remain operator/capability-gated future work.
+
+4. Surface the signal.
+   - Extend `JobEngineHealth` with watchdog fields.
+   - Add an operator-visible “Background job engine” panel to `/platform/ai/runtime-health`.
+
+## Verification
+
+- Unit-test the classifier, gateway recording, and watchdog recovery cooldown in `apps/web/lib/queue/job-engine-health.test.ts`.
+- Run the targeted Vitest suite.
+- Run source-local typecheck for `web`.
+- Use PR CI as production-build evidence before merge.
+
+## UX fit review
+
+- Decision: fits-with-guardrails.
+- Owning area: Platform.
+- Route family: `/platform/ai/runtime-health`.
+- Primary persona: founder/platform operator checking whether autonomous background work is alive.
+- Navigation layer touched: no new navigation; one read-only status panel on the existing runtime-health page.
+- Reuse/convergence: uses the page's existing token-based status-chip pattern; no new dashboard or component family.
+- Source truth: `PlatformConfig` keys `ops.jobEngine.inngestRegistration` and `ops.jobEngine.inngestWatchdog`.
+- Empty/failure behavior: fresh installs stay `unknown` until registration exists; degraded state names the missing executor POST and the safe recovery summary.
+- AI boundary: no prompt-sending action added.
+- Guardrail: the panel must not expose destructive drain/restart controls; the only automatic recovery is the existing non-destructive Inngest retention/orphan sweep.
+
+## Rollback
+
+Revert the route wrapper + `job-engine-health` additions. The existing boot registration health and scheduled retention sweep remain independently functional.


### PR DESCRIPTION
## Summary
- Implements BI-FE558C5C as a portal-side Inngest executor-starvation watchdog, outside Inngest cron.
- Records `/api/inngest` gateway traffic, classifies stale executor POSTs after healthy registration, and runs the existing non-destructive retention/orphan sweep with a cooldown.
- Surfaces background job-engine health on `/platform/ai/runtime-health` and captures the BI plan + UX fit guardrails.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/queue/job-engine-health.test.ts app/(shell)/ops/self-upgrade/page.test.tsx` — 20 passing
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` — clean
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build` — pass; existing Edge-runtime warnings only
- [x] `pnpm run pregate` — pass; local-CI merge gate on `codex/inngest-starvation-watchdog @ 1754c1ee09ddcfcdb3530bfa12500678baec9aa3`

## Notes
- No destructive recovery is introduced: no Redis flush, no container restart. The automatic path is limited to the existing retention/orphan sweep from BI-0AB96FE7.
- UX fit review is captured in `docs/superpowers/plans/2026-07-14-bi-fe558c5c-inngest-starvation-watchdog.md`.

BI-FE558C5C

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/plans/2026-07-14-bi-fe558c5c-inngest-starvation-watchdog.md
  - BI-FE558C5C acceptance context: external portal-side watchdog, alert/non-destructive recovery first, runtime-health visibility
- Current code substrate reviewed:
  - apps/web/app/api/inngest/route.ts
  - apps/web/instrumentation.ts
  - apps/web/lib/queue/job-engine-health.ts
  - apps/web/lib/queue/functions/inngest-retention-sweep.ts
  - apps/web/lib/operate/inngest-retention/run.ts
  - apps/web/app/(shell)/platform/ai/runtime-health/page.tsx
- Source of truth:
  - PlatformConfig keys ops.jobEngine.inngestRegistration and ops.jobEngine.inngestWatchdog
  - Existing Inngest retention/orphan sweep for safe recovery
- Decision:
  - Extend the existing runtime-health page with a read-only job-engine panel; do not create a new route, do not expose destructive Redis/container actions, and keep detection outside Inngest cron by running from the portal process.
