### PR TITLE
feat: prove local ci offline publication replay

### DIFF
--- a/docs/superpowers/plans/2026-07-11-forge-neutral-offline-integration-plan.md
+++ b/docs/superpowers/plans/2026-07-11-forge-neutral-offline-integration-plan.md
@@ -47,17 +47,21 @@ Verification: targeted tests, web typecheck, production build, and before/after 
 
 **BI-76551B2D — Decouple pre-push and local CI from remote branch publication** (`large`)
 
-Status: implementation in progress. Landed slices make `pnpm run pregate`
+Status: implemented through the local-CI/pre-push substrate. Landed slices make `pnpm run pregate`
 record local evidence without publishing by default, retain push-before-lease
 only as explicit `--push` transition/recovery mode, consume a locally available
 accepted-base ref by default, record candidate/base/integration/tree SHA
 metadata in gate evidence, and remove the pre-push docs-only bypass's hard
 dependency on `origin/main` by allowing a configured local accepted-base ref.
-This slice adds toolchain fingerprint and gate-evidence expiry metadata so
-local passes are auditable but not timeless; the follow-up slice enforces that
-expiry in the pre-push gate, so later publication is allowed only while the
-record is still fresh. The remaining work in this BI is full
-network-disconnect proof.
+Follow-up slices added toolchain fingerprint and gate-evidence expiry metadata
+so local passes are auditable but not timeless, enforce that expiry in the
+pre-push gate, and record an explicit resilience envelope
+(`publicationMode`, `acceptedBaseMode`, `networkTolerance`) so later publication
+is allowed only while the same SHA-bound, offline-capable record is still fresh.
+The network-disconnect proof is captured in
+`tests/release/local-ci-gate-contract.test.mjs`: the test denies network Git
+verbs during local gate evidence capture, then proves `.githooks/pre-push-gate`
+accepts the same unexpired record when network Git verbs are still denied.
 
 1. Change `scripts/gate-worktree.sh` so local verification defaults to `--no-push`; publication is a separate explicit operation.
 2. Change `scripts/local-ci-runner.sh` and `scripts/lib/local-integration-ci.mjs` to consume a local candidate ref/SHA and a locally available accepted-base ref.
@@ -65,7 +69,10 @@ network-disconnect proof.
 4. Make stale/missing base explicit. If a recent remote base cannot be fetched, report the accepted local base age; do not fabricate freshness.
 5. Update `.githooks/pre-push-gate` so docs-only bypasses compare against a configured local base ref instead of a hard-coded remote name.
 
-Verification: disconnect network; prove the full local gate runs and records evidence. Reconnect; prove the same candidate can publish without rerunning unless policy/freshness requires it.
+Verification: `node --test tests/release/local-ci-gate-contract.test.mjs`
+includes the network-denied proof that the local gate records offline-capable
+evidence and that the pre-push publication check can reuse the same candidate
+record without rerunning while policy/freshness still allow it.
 
 ## Phase 3 — Local admission and serialized integration
 

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -152,12 +152,24 @@ in a dedicated **non-mutating scratch worktree** (`~/dpf-worktrees/.local-ci-run
 by default) — never in your topic worktree. It records content-addressed
 metadata to `.git/dpf-local-ci-metadata.json` and into MCP evidence: candidate
 ref/SHA, base ref/SHA, integration commit SHA, synthesized tree SHA, command
-list, timestamps, toolchain fingerprint, and gate-evidence expiry.
+list, timestamps, whether the accepted base came from a local ref or explicit
+`--fetch-base`, toolchain fingerprint, and gate-evidence expiry. The evidence
+also carries a `resilience` envelope: `publicationMode` (`deferred` by default
+or explicit `push-before-lease`), `acceptedBaseMode` (`local-ref` or
+`fetch-base`), and `networkTolerance` (`offline-capable` only when publication
+is deferred and the accepted base was local).
 `DPF_LOCAL_CI_BASE_REF` can point at another local accepted-base ref;
 `DPF_LOCAL_CI_FETCH_BASE=1` / `--fetch-base` is the explicit network-refresh
 mode. `DPF_LOCAL_CI_COMMAND` remains an explicit override. The
 old Phase 1 stub is only reachable via `DPF_ALLOW_LOCAL_CI_STUB=1` for contract
 tests and must never be used as release evidence.
+
+The network-disconnect proof is encoded in
+`tests/release/local-ci-gate-contract.test.mjs`: the contract denies network
+Git verbs during `gate-worktree.sh`, records local-only evidence with
+`networkTolerance=offline-capable`, then runs `.githooks/pre-push-gate` through
+the same no-network Git wrapper and proves the same unexpired SHA-bound record
+is sufficient for later publication.
 
 **The pre-push hook chain is active by default.** The local `pre-push` file is
 gitignored (git-lfs generates it), so the enforced logic ships as the tracked

--- a/scripts/gate-worktree.sh
+++ b/scripts/gate-worktree.sh
@@ -107,9 +107,11 @@ write_state() {
   evidence_id="$3"
   status="$4"
   expires_at_value="$5"
+  resilience_json="${6:-null}"
   mkdir -p "$(dirname "$STATE_FILE")"
   node -e '
 const fs = require("node:fs");
+const resilience = JSON.parse(process.argv[9]);
 const out = process.argv[1];
 const payload = {
   branch: process.argv[2],
@@ -121,8 +123,9 @@ const payload = {
   expiresAt: process.argv[8],
   recordedAt: new Date().toISOString()
 };
+if (resilience) payload.resilience = resilience;
 fs.writeFileSync(out, JSON.stringify(payload, null, 2) + "\n");
-' "$STATE_FILE" "$BRANCH" "$SHA" "$gate_passed" "$lease_id" "$evidence_id" "$status" "$expires_at_value"
+' "$STATE_FILE" "$BRANCH" "$SHA" "$gate_passed" "$lease_id" "$evidence_id" "$status" "$expires_at_value" "$resilience_json"
 }
 
 while [ "$#" -gt 0 ]; do
@@ -289,9 +292,23 @@ status="$(printf '%s' "$outcome_json" | field status)"
 gate_passed="$(printf '%s' "$outcome_json" | field gatePassed)"
 gate_summary="$(printf '%s' "$outcome_json" | field summary)"
 
+resilience_json="$(node -e '
+const fs = require("node:fs");
+const pushBeforeLease = process.argv[1] === "1";
+let contentMetadata = null;
+try { contentMetadata = JSON.parse(fs.readFileSync(process.argv[2], "utf8")); } catch {}
+const fetchBase = contentMetadata && contentMetadata.fetchBase === true;
+process.stdout.write(JSON.stringify({
+  publicationMode: pushBeforeLease ? "push-before-lease" : "deferred",
+  acceptedBaseMode: fetchBase ? "fetch-base" : "local-ref",
+  networkTolerance: (!pushBeforeLease && !fetchBase) ? "offline-capable" : "network-required"
+}));
+' "$PUSH_BRANCH" "$METADATA_FILE")"
+
 evidence_args="$(node -e '
 const fs = require("node:fs");
 const outcome = JSON.parse(process.argv[11]);
+const resilience = JSON.parse(process.argv[16]);
 let contentMetadata = null;
 try { contentMetadata = JSON.parse(fs.readFileSync(process.argv[14], "utf8")); } catch {}
 const evidence = {
@@ -304,6 +321,7 @@ const evidence = {
   sha: process.argv[5],
   expiresAt: process.argv[15],
   pushBeforeLease: process.argv[13] === "1",
+  resilience,
   content: contentMetadata,
   gatePassed: outcome.gatePassed,
   freshness: outcome.freshness,
@@ -323,7 +341,7 @@ process.stdout.write(JSON.stringify({
   summary: outcome.summary,
   evidence
 }));
-' "$status" "$gate_passed" "$lease_id" "$BRANCH" "$SHA" "$URL" "$gate_command_label" "$gate_output" "$OWNER_PROVIDER" "$OWNER_SESSION_ID" "$outcome_json" "$gate_status" "$PUSH_BRANCH" "$METADATA_FILE" "$expires_at")"
+' "$status" "$gate_passed" "$lease_id" "$BRANCH" "$SHA" "$URL" "$gate_command_label" "$gate_output" "$OWNER_PROVIDER" "$OWNER_SESSION_ID" "$outcome_json" "$gate_status" "$PUSH_BRANCH" "$METADATA_FILE" "$expires_at" "$resilience_json")"
 evidence_response="$(mcp_call record_local_integration_result "$evidence_args" | extract_tool_result)"
 evidence_success="$(printf '%s' "$evidence_response" | field success)"
 if [ "$evidence_success" != "true" ] && [ "$status" = "blocked_sandbox_drift" ]; then
@@ -347,7 +365,7 @@ fi
 if [ "$evidence_success" = "true" ]; then
   evidence_id="$(printf '%s' "$evidence_response" | field entityId)"
 else
-  write_state false "$lease_id" "" "failed" "$expires_at"
+  write_state false "$lease_id" "" "failed" "$expires_at" "$resilience_json"
   mcp_call release_nonprod_environment_lease "{\"leaseId\":$(json_escape "$lease_id")}" >/dev/null || true
   die "failed to record local integration evidence: $evidence_response"
 fi
@@ -356,7 +374,7 @@ release_response="$(mcp_call release_nonprod_environment_lease "{\"leaseId\":$(j
 release_success="$(printf '%s' "$release_response" | field success)"
 [ "$release_success" = "true" ] || die "failed to release local-CI lease: $release_response"
 
-write_state "$gate_passed" "$lease_id" "$evidence_id" "$status" "$expires_at"
+write_state "$gate_passed" "$lease_id" "$evidence_id" "$status" "$expires_at" "$resilience_json"
 
 if [ "$gate_passed" = "true" ]; then
   printf '%s\n' "gate passed"

--- a/scripts/local-integration-ci.mjs
+++ b/scripts/local-integration-ci.mjs
@@ -15,6 +15,7 @@ const baseSha = valueAfter("--base-sha");
 const metadataOut = valueAfter("--metadata-out");
 const mode = valueAfter("--mode") || "single-branch";
 const buildStrategy = valueAfter("--build-strategy");
+const fetchBase = process.argv.includes("--fetch-base");
 const siblingBranches = process.argv
   .filter((arg) => arg.startsWith("--sibling="))
   .map((arg) => arg.slice("--sibling=".length));
@@ -30,7 +31,7 @@ const plan = createLocalIntegrationPlan({
   mode,
   siblingBranches,
   buildStrategy: buildStrategy || undefined,
-  fetchBase: process.argv.includes("--fetch-base"),
+  fetchBase,
   includeMigrateDeploy: process.argv.includes("--migrate-deploy"),
 });
 const startedAt = new Date().toISOString();
@@ -60,6 +61,7 @@ if (metadataOut) {
     candidateRef: candidateBranch,
     candidateSha: candidateSha || revParse(candidateBranch),
     baseRef,
+    fetchBase,
     baseSha: baseSha || revParse(baseRef),
     integrationBranch: plan.integrationBranch,
     integrationCommitSha: revParse("HEAD"),

--- a/tests/release/local-ci-gate-contract.test.mjs
+++ b/tests/release/local-ci-gate-contract.test.mjs
@@ -406,6 +406,7 @@ writeFileSync(process.env.DPF_LOCAL_CI_METADATA_FILE, JSON.stringify({
   candidateRef: "feat/local-ci-sandbox",
   candidateSha: "candidate-sha",
   baseRef: "origin/main",
+  fetchBase: false,
   baseSha: "base-sha",
   integrationCommitSha: "integration-sha",
   synthesizedTreeSha: "tree-sha",
@@ -443,15 +444,151 @@ writeFileSync(process.env.DPF_LOCAL_CI_METADATA_FILE, JSON.stringify({
     candidateRef: "feat/local-ci-sandbox",
     candidateSha: "candidate-sha",
     baseRef: "origin/main",
+    fetchBase: false,
     baseSha: "base-sha",
     integrationCommitSha: "integration-sha",
     synthesizedTreeSha: "tree-sha",
     toolchainFingerprint: "toolchain-sha",
     toolchain: { nodeVersion: "v24.0.0" },
   });
+  assert.deepEqual(evidenceCall.params.arguments.evidence.resilience, {
+    publicationMode: "deferred",
+    acceptedBaseMode: "local-ref",
+    networkTolerance: "offline-capable",
+  });
   assert.match(evidenceCall.params.arguments.evidence.expiresAt, /^\d{4}-\d{2}-\d{2}T/);
   const state = JSON.parse(readFileSync(join(temp, "dpf-local-ci-gate.json"), "utf8"));
   assert.equal(state.expiresAt, evidenceCall.params.arguments.evidence.expiresAt);
+  assert.deepEqual(state.resilience, evidenceCall.params.arguments.evidence.resilience);
+});
+
+test("gate-worktree.sh records local-only evidence that pre-push can later publish without network git operations (BI-76551B2D)", () => {
+  const { dir, g } = makeTempRepo();
+  writeFileSync(join(dir, "code.ts"), "export const x = 2;\n");
+  g(["commit", "-aqm", "runtime change"]);
+  const sha = g(["rev-parse", "HEAD"]);
+
+  const temp = mkdtempSync(join(tmpdir(), "dpf-local-ci-offline-"));
+  const callsFile = join(temp, "calls.ndjson");
+  const gateGitStub = join(temp, "gate-git");
+  const curlStub = join(temp, "curl");
+  const writerScript = join(temp, "write-metadata.mjs");
+
+  writeFileSync(gateGitStub, `#!/bin/sh
+case "$1" in
+  fetch|push|pull|clone|ls-remote)
+    echo "network git operation forbidden during offline proof: $*" >&2
+    exit 42
+    ;;
+esac
+if [ "$1" = "remote" ] && [ "$2" = "update" ]; then
+  echo "network git operation forbidden during offline proof: $*" >&2
+  exit 42
+fi
+if [ "$1" = "rev-parse" ] && [ "$2" = "--git-path" ]; then
+  echo "${dir}/.git/$3"
+  exit 0
+fi
+echo "unexpected gate git call: $*" >&2
+exit 1
+`);
+  writeFileSync(curlStub, `#!/bin/sh
+data=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --data) data="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s\\n' "$data" >> "${callsFile}"
+tool="$(node -e 'const fs=require("node:fs"); const p=JSON.parse(fs.readFileSync(0,"utf8")); console.log(p.params.name)' <<EOF
+$data
+EOF
+)"
+case "$tool" in
+  claim_nonprod_environment_lease)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-OFFLINE\\"}"}]}}'
+    ;;
+  record_local_integration_result)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"EXT-OFFLINE\\"}"}]}}'
+    ;;
+  release_nonprod_environment_lease)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":true,\\"entityId\\":\\"NPEL-OFFLINE\\"}"}]}}'
+    ;;
+  *)
+    printf '%s\\n' '{"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"{\\"success\\":false,\\"error\\":\\"unexpected_tool\\"}"}]}}'
+    ;;
+esac
+`);
+  writeFileSync(writerScript, `
+import { writeFileSync } from "node:fs";
+writeFileSync(process.env.DPF_LOCAL_CI_METADATA_FILE, JSON.stringify({
+  schemaVersion: 1,
+  bi: "BI-76551B2D",
+  candidateRef: "feat/topic",
+  candidateSha: "${sha}",
+  baseRef: "refs/dpf/integration/main",
+  fetchBase: false,
+  baseSha: "base-sha",
+  integrationCommitSha: "integration-sha",
+  synthesizedTreeSha: "tree-sha",
+  toolchainFingerprint: "toolchain-sha"
+}) + "\\n");
+`);
+  chmodSync(gateGitStub, 0o755);
+  chmodSync(curlStub, 0o755);
+
+  const gateResult = runGate([
+    "--branch",
+    "feat/topic",
+    "--sha",
+    sha,
+    "--worktree",
+    dir,
+    "--no-push",
+  ], {
+    env: {
+      ...process.env,
+      DPF_MCP_BEARER_TOKEN: "dpfmcp_test",
+      DPF_LOCAL_CI_COMMAND: `"${process.execPath}" "${writerScript}"`,
+      DPF_GATE_GIT_BIN: gateGitStub,
+      DPF_GATE_CURL_BIN: curlStub,
+    },
+  });
+  assert.equal(gateResult.status, 0, `${gateResult.stdout}\n${gateResult.stderr}`);
+
+  const calls = readFileSync(callsFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+  const evidenceCall = calls.find((call) => call.params.name === "record_local_integration_result");
+  assert.ok(evidenceCall, "expected evidence to be recorded");
+  assert.deepEqual(evidenceCall.params.arguments.evidence.resilience, {
+    publicationMode: "deferred",
+    acceptedBaseMode: "local-ref",
+    networkTolerance: "offline-capable",
+  });
+
+  const realGit = spawnSync("sh", ["-c", "command -v git"], { encoding: "utf8" }).stdout.trim();
+  const pathStubDir = mkdtempSync(join(tmpdir(), "dpf-no-network-git-"));
+  writeFileSync(join(pathStubDir, "git"), `#!/bin/sh
+case "$1" in
+  fetch|push|pull|clone|ls-remote)
+    echo "network git operation forbidden during publication replay proof: $*" >&2
+    exit 42
+    ;;
+esac
+if [ "$1" = "remote" ] && [ "$2" = "update" ]; then
+  echo "network git operation forbidden during publication replay proof: $*" >&2
+  exit 42
+fi
+exec "${realGit}" "$@"
+`);
+  chmodSync(join(pathStubDir, "git"), 0o755);
+
+  const publishReplay = runGateHook(dir, {
+    input: refsLine(g),
+    env: cleanHookEnv({ PATH: `${pathStubDir}:${process.env.PATH}` }),
+  });
+  assert.equal(publishReplay.status, 0, `${publishReplay.stdout}\n${publishReplay.stderr}`);
+  assert.match(publishReplay.stdout, /local-CI gate passed/);
 });
 
 // ── pre-push hook chain + pre-push-gate contract (BI-C74F4DE9) ───────────────


### PR DESCRIPTION
## Summary
- Adds explicit local-CI resilience metadata (`publicationMode`, `acceptedBaseMode`, `networkTolerance`) to recorded MCP evidence and `.git/dpf-local-ci-gate.json`.
- Persists `fetchBase` in local integration metadata so offline/local-ref runs can be distinguished from explicit network-refresh runs.
- Adds the BI-76551B2D network-disconnect proof: deny network Git verbs during gate evidence capture, then prove pre-push can reuse the same fresh record without rerunning.

## Test plan
- [x] `node --test tests/release/local-ci-gate-contract.test.mjs` — 25/25 passing.
- [x] `pnpm run pregate` — passed; evidence `cmrk4yryg04s301np4ojip0rb`, lease `NPEL-968AD6D30A`, expires `2026-07-14T05:11:16.535Z`.
- [x] Local-CI full runner in pregate: vitest, typecheck, production build completed in the non-mutating `.local-ci-runner` workspace.

## Evidence
- Candidate SHA: `d831dd80abdc31cb13ad2c2a21193b5c37c003ba`
- Base SHA: `398f65c30530c8a2c6719e84957402c6f6a01aa6`
- Integration commit SHA: `de51f10ce77ead257cd7dbc7dcb52c0945f35a9f`
- Synthesized tree SHA: `e6d5d8eb0cd4c3861c4cf6530b18dd6398796d2f`
- Toolchain fingerprint: `de7556d652c459f9d690c27255eaaac537432f600cb756ab9dac13b731c395ba`
- Resilience: `publicationMode=deferred`, `acceptedBaseMode=local-ref`, `networkTolerance=offline-capable`

Overlap sweep: only open PR was #2941 (`codex/inngest-starvation-watchdog`), unrelated.

Local-CI-Evidence: cmrk4yryg04s301np4ojip0rb
