### PR TITLE
feat(work-capsules): push agent-session progress

### DIFF
--- a/apps/web/app/(shell)/build/work/[capsuleId]/page.tsx
+++ b/apps/web/app/(shell)/build/work/[capsuleId]/page.tsx
@@ -2,10 +2,12 @@ import { notFound } from "next/navigation";
 
 import { PortalContextStrip } from "@/components/portal-context/PortalContextStrip";
 import { WorkCapsuleLaunchPanel } from "@/components/build/work-control/WorkCapsuleLaunchPanel";
-import { AgentSessionFeed } from "@/components/build/AgentSessionFeed";
+import { AgentSessionFeedLive } from "@/components/build/AgentSessionFeedLive";
 import { getCapsuleDetail } from "@/lib/actions/work-capsules";
 import { auth } from "@/lib/auth";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
+import { presentAgentSession } from "@/lib/work-capsules/agent-activity-presenter";
+import { serializeAgentSessionEntry } from "@/lib/work-capsules/activity-stream";
 import { presentLaunchInstructions } from "@/lib/work-capsules/launch-presenter";
 
 export default async function CapsuleDetailPage({
@@ -46,7 +48,10 @@ export default async function CapsuleDetailPage({
         <div className="font-mono text-xs text-[var(--dpf-muted)]">{capsule.capsuleId}</div>
       </header>
       <PortalContextStrip envelope={portalContext} />
-      <AgentSessionFeed activities={capsule.activities} />
+      <AgentSessionFeedLive
+        capsuleId={capsule.capsuleId}
+        initialEntries={presentAgentSession(capsule.activities).map(serializeAgentSessionEntry)}
+      />
       <WorkCapsuleLaunchPanel steps={steps} />
     </section>
   );

--- a/apps/web/app/api/work-capsules/[capsuleId]/activity-stream/route.ts
+++ b/apps/web/app/api/work-capsules/[capsuleId]/activity-stream/route.ts
@@ -1,0 +1,91 @@
+import { prisma } from "@dpf/db";
+
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import { createSseResponse } from "@/lib/sse/sse-stream";
+import {
+  subscribeToWorkCapsuleActivityEvents,
+  type WorkCapsuleActivityEvent,
+} from "@/lib/work-capsules/activity-events";
+import {
+  loadAgentSessionEntryByActivityId,
+  loadInitialAgentSessionEntries,
+  WORK_CAPSULE_ACTIVITY_EVENT,
+} from "@/lib/work-capsules/activity-stream";
+
+export const dynamic = "force-dynamic";
+
+function unauthorized(): Response {
+  return new Response("Unauthorized", { status: 401 });
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ capsuleId: string }> },
+) {
+  const session = await auth();
+  const user = session?.user;
+  if (!user?.id || !can({ platformRole: user.platformRole, isSuperuser: user.isSuperuser }, "view_platform")) {
+    return unauthorized();
+  }
+
+  const { capsuleId } = await params;
+
+  return createSseResponse({
+    signal: request.signal,
+    start(controller) {
+      let workCapsuleId: string | null = null;
+      let active = true;
+      let unsubscribe: (() => void) | null = null;
+
+      void (async () => {
+        const initial = await loadInitialAgentSessionEntries({
+          db: prisma,
+          capsuleId,
+        });
+        if (!active || controller.closed) return;
+        if (!initial) {
+          controller.sendNamed("error", { error: "not_found" });
+          controller.close();
+          return;
+        }
+        workCapsuleId = initial.workCapsuleId;
+        controller.sendNamed(WORK_CAPSULE_ACTIVITY_EVENT, {
+          type: "snapshot",
+          entries: initial.entries,
+        });
+      })().catch(() => {
+        if (!controller.closed) {
+          controller.sendNamed("error", { error: "initial_replay_failed" });
+        }
+      });
+
+      void subscribeToWorkCapsuleActivityEvents(async (event: WorkCapsuleActivityEvent) => {
+        if (!active || controller.closed) return;
+        if (!workCapsuleId || event.workCapsuleId !== workCapsuleId) return;
+        const entry = await loadAgentSessionEntryByActivityId({
+          db: prisma,
+          workCapsuleId,
+          activityId: event.activityId,
+        });
+        if (!entry || !active || controller.closed) return;
+        controller.sendNamed(WORK_CAPSULE_ACTIVITY_EVENT, {
+          type: "activity",
+          entry,
+        });
+      }).then((cleanup) => {
+        if (!active) cleanup();
+        else unsubscribe = cleanup;
+      }).catch(() => {
+        if (!controller.closed) {
+          controller.sendNamed("error", { error: "subscribe_failed" });
+        }
+      });
+
+      return () => {
+        active = false;
+        unsubscribe?.();
+      };
+    },
+  });
+}

--- a/apps/web/components/build/AgentSessionFeedLive.test.tsx
+++ b/apps/web/components/build/AgentSessionFeedLive.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WORK_CAPSULE_ACTIVITY_EVENT } from "@/lib/work-capsules/activity-stream";
+import { AgentSessionFeedLive } from "./AgentSessionFeedLive";
+
+const hookState = vi.hoisted(() => ({
+  named: {} as Record<string, (event: MessageEvent) => void>,
+  urls: [] as string[],
+}));
+
+vi.mock("@/lib/hooks/useResilientEventSource", () => ({
+  useResilientEventSource: (
+    url: string | null,
+    opts: { onNamed?: Record<string, (event: MessageEvent) => void> },
+  ) => {
+    if (url) hookState.urls.push(url);
+    hookState.named = opts.onNamed ?? {};
+    return { status: "open" };
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  hookState.named = {};
+  hookState.urls = [];
+});
+
+describe("AgentSessionFeedLive", () => {
+  it("renders the initial server-provided feed and opens the capsule stream", () => {
+    render(
+      <AgentSessionFeedLive
+        capsuleId="WC-123"
+        initialEntries={[
+          {
+            id: "act-1",
+            tone: "thought",
+            label: "Thinking",
+            summary: "Choosing the approach",
+            actor: "agent",
+            recordedAt: "2026-07-14T04:00:00.000Z",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Choosing the approach")).toBeTruthy();
+    expect(screen.getByText("Live")).toBeTruthy();
+    expect(hookState.urls).toEqual(["/api/work-capsules/WC-123/activity-stream"]);
+  });
+
+  it("appends pushed activity and dedupes repeated events", () => {
+    render(<AgentSessionFeedLive capsuleId="WC-123" initialEntries={[]} />);
+
+    act(() => {
+      hookState.named[WORK_CAPSULE_ACTIVITY_EVENT]?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "activity",
+            entry: {
+              id: "act-2",
+              tone: "action",
+              label: "Did",
+              summary: "Ran the targeted tests",
+              actor: "agent",
+              recordedAt: "2026-07-14T04:01:00.000Z",
+            },
+          }),
+        }),
+      );
+      hookState.named[WORK_CAPSULE_ACTIVITY_EVENT]?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "activity",
+            entry: {
+              id: "act-2",
+              tone: "action",
+              label: "Did",
+              summary: "Ran the targeted tests",
+              actor: "agent",
+              recordedAt: "2026-07-14T04:01:00.000Z",
+            },
+          }),
+        }),
+      );
+    });
+
+    expect(screen.getAllByText("Ran the targeted tests")).toHaveLength(1);
+  });
+});

--- a/apps/web/components/build/AgentSessionFeedLive.tsx
+++ b/apps/web/components/build/AgentSessionFeedLive.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { useResilientEventSource } from "@/lib/hooks/useResilientEventSource";
+import {
+  WORK_CAPSULE_ACTIVITY_EVENT,
+  type WorkCapsuleActivityStreamEntry,
+} from "@/lib/work-capsules/activity-stream";
+import type { AgentSessionTone } from "@/lib/work-capsules/agent-activity-presenter";
+
+const TONE_DOT: Record<AgentSessionTone, string> = {
+  thought: "var(--dpf-muted)",
+  action: "var(--dpf-accent)",
+  question: "var(--dpf-warning)",
+  response: "var(--dpf-accent)",
+  error: "var(--dpf-danger)",
+  lifecycle: "var(--dpf-border)",
+};
+
+const ACTOR_LABEL = { agent: "AI coworker", human: "You", system: "System" } as const;
+
+function mergeEntries(
+  current: WorkCapsuleActivityStreamEntry[],
+  incoming: WorkCapsuleActivityStreamEntry[],
+): WorkCapsuleActivityStreamEntry[] {
+  const byId = new Map<string, WorkCapsuleActivityStreamEntry>();
+  for (const entry of [...incoming, ...current]) {
+    byId.set(entry.id, entry);
+  }
+  return Array.from(byId.values()).sort((a, b) => b.recordedAt.localeCompare(a.recordedAt));
+}
+
+function parseStreamPayload(raw: string):
+  | { type: "snapshot"; entries: WorkCapsuleActivityStreamEntry[] }
+  | { type: "activity"; entry: WorkCapsuleActivityStreamEntry }
+  | null {
+  try {
+    const parsed = JSON.parse(raw) as {
+      type?: unknown;
+      entries?: unknown;
+      entry?: unknown;
+    };
+    if (parsed.type === "snapshot" && Array.isArray(parsed.entries)) {
+      return { type: "snapshot", entries: parsed.entries as WorkCapsuleActivityStreamEntry[] };
+    }
+    if (parsed.type === "activity" && parsed.entry && typeof parsed.entry === "object") {
+      return { type: "activity", entry: parsed.entry as WorkCapsuleActivityStreamEntry };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function AgentSessionFeedLive({
+  capsuleId,
+  initialEntries,
+}: {
+  capsuleId: string;
+  initialEntries: WorkCapsuleActivityStreamEntry[];
+}) {
+  const [entries, setEntries] = useState(initialEntries);
+  const streamUrl = useMemo(
+    () => `/api/work-capsules/${encodeURIComponent(capsuleId)}/activity-stream`,
+    [capsuleId],
+  );
+
+  useResilientEventSource(streamUrl, {
+    onMessage: () => {},
+    onNamed: {
+      [WORK_CAPSULE_ACTIVITY_EVENT]: (event) => {
+        const payload = parseStreamPayload(event.data);
+        if (!payload) return;
+        if (payload.type === "snapshot") {
+          setEntries((current) => mergeEntries(current, payload.entries));
+        } else {
+          setEntries((current) => mergeEntries(current, [payload.entry]));
+        }
+      },
+    },
+  });
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)]">Activity</h2>
+        <span className="text-[11px] text-[var(--dpf-muted)]">Live</span>
+      </div>
+      {entries.length === 0 ? (
+        <p className="m-0 text-xs text-[var(--dpf-muted)]">
+          No activity yet — updates from whoever is working this item will appear here.
+        </p>
+      ) : (
+        <ol className="m-0 list-none space-y-2 p-0">
+          {entries.map((entry) => (
+            <li key={entry.id} className="flex gap-2.5">
+              <span
+                aria-hidden="true"
+                className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: TONE_DOT[entry.tone] }}
+              />
+              <div className="min-w-0">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-xs font-semibold text-[var(--dpf-text)]">{entry.label}</span>
+                  <span className="text-[11px] text-[var(--dpf-muted)]">{ACTOR_LABEL[entry.actor]}</span>
+                </div>
+                <p className="m-0 text-sm text-[var(--dpf-text)]">{entry.summary}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 546,
+  "routeCount": 547,
   "routes": [
     {
       "routePath": "/",
@@ -3140,6 +3140,20 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/api/voice/train/route.ts"
+    },
+    {
+      "routePath": "/api/work-capsules/[capsuleId]/activity-stream",
+      "kind": "route",
+      "segments": [
+        "api",
+        "work-capsules",
+        "[capsuleId]",
+        "activity-stream"
+      ],
+      "dynamicParams": [
+        "capsuleId"
+      ],
+      "file": "apps/web/app/api/work-capsules/[capsuleId]/activity-stream/route.ts"
     },
     {
       "routePath": "/auth/callback",

--- a/apps/web/lib/work-capsules/activity-events.test.ts
+++ b/apps/web/lib/work-capsules/activity-events.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  WORK_CAPSULE_ACTIVITY_CHANNEL,
+  parseWorkCapsuleActivityEvent,
+  publishWorkCapsuleActivityEvent,
+  serializeWorkCapsuleActivityEvent,
+  subscribeToWorkCapsuleActivityEvents,
+} from "./activity-events";
+
+describe("WorkCapsule activity push events", () => {
+  it("serializes and parses a valid activity event", () => {
+    const event = { workCapsuleId: "cm-work-1", activityId: "act-1" };
+    expect(parseWorkCapsuleActivityEvent(serializeWorkCapsuleActivityEvent(event))).toEqual(event);
+  });
+
+  it("rejects malformed notification payloads", () => {
+    expect(parseWorkCapsuleActivityEvent("")).toBeNull();
+    expect(parseWorkCapsuleActivityEvent("not-json")).toBeNull();
+    expect(parseWorkCapsuleActivityEvent(JSON.stringify({ workCapsuleId: "", activityId: "act" }))).toBeNull();
+    expect(parseWorkCapsuleActivityEvent(JSON.stringify({ workCapsuleId: "wc" }))).toBeNull();
+  });
+
+  it("publishes through pg_notify with the canonical channel", async () => {
+    const pool = { query: vi.fn().mockResolvedValue({}) };
+
+    await expect(
+      publishWorkCapsuleActivityEvent({ workCapsuleId: "cm-work-1", activityId: "act-1" }, pool),
+    ).resolves.toBe(true);
+
+    expect(pool.query).toHaveBeenCalledWith("SELECT pg_notify($1, $2)", [
+      WORK_CAPSULE_ACTIVITY_CHANNEL,
+      JSON.stringify({ workCapsuleId: "cm-work-1", activityId: "act-1" }),
+    ]);
+  });
+
+  it("fails open when publish transport is unavailable", async () => {
+    await expect(
+      publishWorkCapsuleActivityEvent({ workCapsuleId: "cm-work-1", activityId: "act-1" }, null),
+    ).resolves.toBe(false);
+
+    await expect(
+      publishWorkCapsuleActivityEvent(
+        { workCapsuleId: "cm-work-1", activityId: "act-1" },
+        { query: vi.fn().mockRejectedValue(new Error("db unavailable")) },
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("subscribes to matching notifications and ignores unrelated payloads", async () => {
+    const notificationHandlers: Array<(message: { channel?: string; payload?: string }) => void> = [];
+    const client = {
+      query: vi.fn().mockResolvedValue({}),
+      on: vi.fn((event: "notification", handler: (message: { channel?: string; payload?: string }) => void) => {
+        if (event === "notification") notificationHandlers.push(handler);
+      }),
+      off: vi.fn(),
+      release: vi.fn(),
+    };
+    const pool = { connect: vi.fn().mockResolvedValue(client) };
+    const onEvent = vi.fn();
+
+    const unsubscribe = await subscribeToWorkCapsuleActivityEvents(onEvent, pool);
+
+    expect(client.query).toHaveBeenCalledWith(`LISTEN ${WORK_CAPSULE_ACTIVITY_CHANNEL}`);
+    const emit = notificationHandlers[0]!;
+    expect(emit).toBeTypeOf("function");
+    emit({ channel: "something_else", payload: JSON.stringify({ workCapsuleId: "x", activityId: "a" }) });
+    emit({ channel: WORK_CAPSULE_ACTIVITY_CHANNEL, payload: "bad-json" });
+    emit({
+      channel: WORK_CAPSULE_ACTIVITY_CHANNEL,
+      payload: JSON.stringify({ workCapsuleId: "cm-work-1", activityId: "act-1" }),
+    });
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith({ workCapsuleId: "cm-work-1", activityId: "act-1" });
+
+    unsubscribe();
+    expect(client.off).toHaveBeenCalledWith("notification", expect.any(Function));
+    expect(client.query).toHaveBeenCalledWith(`UNLISTEN ${WORK_CAPSULE_ACTIVITY_CHANNEL}`);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/work-capsules/activity-events.ts
+++ b/apps/web/lib/work-capsules/activity-events.ts
@@ -88,6 +88,11 @@ export async function publishWorkCapsuleActivityEvent(
   }
 }
 
+export function publishRecordedWorkCapsuleActivity(workCapsuleId: string, activityId?: string | null): void {
+  if (!activityId) return;
+  void publishWorkCapsuleActivityEvent({ workCapsuleId, activityId });
+}
+
 export async function subscribeToWorkCapsuleActivityEvents(
   onEvent: (event: WorkCapsuleActivityEvent) => void,
   pool: ListenPool | null = getListenPool(),

--- a/apps/web/lib/work-capsules/activity-events.ts
+++ b/apps/web/lib/work-capsules/activity-events.ts
@@ -1,0 +1,120 @@
+import { Pool } from "pg";
+
+export const WORK_CAPSULE_ACTIVITY_CHANNEL = "dpf_work_capsule_activity";
+
+export type WorkCapsuleActivityEvent = {
+  workCapsuleId: string;
+  activityId: string;
+};
+
+type Queryable = {
+  query(sql: string, values?: unknown[]): Promise<unknown>;
+};
+
+type ListenerClient = Queryable & {
+  on(event: "notification", listener: (message: { channel?: string; payload?: string }) => void): void;
+  off?(event: "notification", listener: (message: { channel?: string; payload?: string }) => void): void;
+  removeListener?(event: "notification", listener: (message: { channel?: string; payload?: string }) => void): void;
+  release(): void;
+};
+
+type ListenPool = {
+  connect(): Promise<ListenerClient>;
+};
+
+let publishPool: Pool | null = null;
+let listenPool: Pool | null = null;
+
+function databaseUrl(): string | null {
+  // Unit tests inject fake pools. Never let pure tests open real Postgres
+  // sockets just because .env provided DATABASE_URL.
+  if (process.env.NODE_ENV === "test" || process.env.VITEST) return null;
+  const url = process.env.DATABASE_URL?.trim();
+  return url ? url : null;
+}
+
+function getPublishPool(): Pool | null {
+  const connectionString = databaseUrl();
+  if (!connectionString) return null;
+  publishPool ??= new Pool({ connectionString });
+  return publishPool;
+}
+
+function getListenPool(): Pool | null {
+  const connectionString = databaseUrl();
+  if (!connectionString) return null;
+  listenPool ??= new Pool({ connectionString });
+  return listenPool;
+}
+
+export function serializeWorkCapsuleActivityEvent(event: WorkCapsuleActivityEvent): string {
+  return JSON.stringify(event);
+}
+
+export function parseWorkCapsuleActivityEvent(payload: unknown): WorkCapsuleActivityEvent | null {
+  if (typeof payload !== "string" || payload.length === 0) return null;
+  try {
+    const parsed = JSON.parse(payload) as Record<string, unknown>;
+    const workCapsuleId = parsed.workCapsuleId;
+    const activityId = parsed.activityId;
+    if (typeof workCapsuleId !== "string" || workCapsuleId.length === 0) return null;
+    if (typeof activityId !== "string" || activityId.length === 0) return null;
+    return { workCapsuleId, activityId };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Publish a best-effort wake-up after a WorkCapsuleActivity write.
+ *
+ * The activity table remains the source of truth; this notification only tells
+ * subscribed browser streams to fetch the committed row. Failure is fail-open so
+ * progress persistence never depends on the push transport.
+ */
+export async function publishWorkCapsuleActivityEvent(
+  event: WorkCapsuleActivityEvent,
+  pool: Queryable | null = getPublishPool(),
+): Promise<boolean> {
+  if (!pool) return false;
+  try {
+    await pool.query("SELECT pg_notify($1, $2)", [
+      WORK_CAPSULE_ACTIVITY_CHANNEL,
+      serializeWorkCapsuleActivityEvent(event),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function subscribeToWorkCapsuleActivityEvents(
+  onEvent: (event: WorkCapsuleActivityEvent) => void,
+  pool: ListenPool | null = getListenPool(),
+): Promise<() => void> {
+  if (!pool) return () => {};
+
+  const client = await pool.connect();
+  let released = false;
+  const listener = (message: { channel?: string; payload?: string }) => {
+    if (message.channel !== WORK_CAPSULE_ACTIVITY_CHANNEL) return;
+    const event = parseWorkCapsuleActivityEvent(message.payload);
+    if (event) onEvent(event);
+  };
+
+  client.on("notification", listener);
+  await client.query(`LISTEN ${WORK_CAPSULE_ACTIVITY_CHANNEL}`);
+
+  return () => {
+    if (released) return;
+    released = true;
+    try {
+      client.off?.("notification", listener);
+      client.removeListener?.("notification", listener);
+    } catch {
+      /* cleanup is best effort */
+    }
+    void client.query(`UNLISTEN ${WORK_CAPSULE_ACTIVITY_CHANNEL}`).catch(() => {});
+    client.release();
+  };
+}

--- a/apps/web/lib/work-capsules/activity-stream.test.ts
+++ b/apps/web/lib/work-capsules/activity-stream.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  loadAgentSessionEntryByActivityId,
+  loadInitialAgentSessionEntries,
+  serializeAgentSessionEntry,
+} from "./activity-stream";
+
+const at = new Date("2026-07-14T04:00:00.000Z");
+
+describe("WorkCapsule activity stream projection", () => {
+  it("serializes agent-session entries with JSON-safe recordedAt", () => {
+    expect(
+      serializeAgentSessionEntry({
+        id: "act-1",
+        tone: "action",
+        label: "Did",
+        summary: "Updated the parser",
+        actor: "agent",
+        recordedAt: at,
+      }),
+    ).toEqual({
+      id: "act-1",
+      tone: "action",
+      label: "Did",
+      summary: "Updated the parser",
+      actor: "agent",
+      recordedAt: "2026-07-14T04:00:00.000Z",
+    });
+  });
+
+  it("loads a replay snapshot scoped to the public capsule id", async () => {
+    const db = {
+      workCapsule: {
+        findUnique: vi.fn().mockResolvedValue({ id: "cm-work-1" }),
+      },
+      workCapsuleActivity: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "act-1",
+            kind: "thought",
+            summary: "Choosing the approach",
+            recordedAt: at,
+            recordedByAgentId: "AGT-1",
+          },
+        ]),
+        findFirst: vi.fn(),
+      },
+    };
+
+    const result = await loadInitialAgentSessionEntries({
+      db,
+      capsuleId: "WC-123",
+      limit: 10,
+    });
+
+    expect(db.workCapsule.findUnique).toHaveBeenCalledWith({
+      where: { capsuleId: "WC-123" },
+      select: { id: true },
+    });
+    expect(db.workCapsuleActivity.findMany).toHaveBeenCalledWith({
+      where: { workCapsuleId: "cm-work-1" },
+      orderBy: { recordedAt: "desc" },
+      take: 10,
+    });
+    expect(result).toEqual({
+      workCapsuleId: "cm-work-1",
+      entries: [
+        expect.objectContaining({
+          id: "act-1",
+          label: "Thinking",
+          actor: "agent",
+          recordedAt: "2026-07-14T04:00:00.000Z",
+        }),
+      ],
+    });
+  });
+
+  it("returns null when the capsule does not exist", async () => {
+    const db = {
+      workCapsule: { findUnique: vi.fn().mockResolvedValue(null) },
+      workCapsuleActivity: { findMany: vi.fn(), findFirst: vi.fn() },
+    };
+    await expect(loadInitialAgentSessionEntries({ db, capsuleId: "missing" })).resolves.toBeNull();
+    expect(db.workCapsuleActivity.findMany).not.toHaveBeenCalled();
+  });
+
+  it("loads one pushed activity only when it belongs to the subscribed capsule", async () => {
+    const db = {
+      workCapsule: { findUnique: vi.fn() },
+      workCapsuleActivity: {
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue({
+          id: "act-2",
+          kind: "action",
+          summary: "Ran the test",
+          recordedAt: at,
+          recordedByAgentId: "AGT-1",
+        }),
+      },
+    };
+
+    const entry = await loadAgentSessionEntryByActivityId({
+      db,
+      workCapsuleId: "cm-work-1",
+      activityId: "act-2",
+    });
+
+    expect(db.workCapsuleActivity.findFirst).toHaveBeenCalledWith({
+      where: { id: "act-2", workCapsuleId: "cm-work-1" },
+    });
+    expect(entry).toMatchObject({ id: "act-2", label: "Did", summary: "Ran the test" });
+  });
+});

--- a/apps/web/lib/work-capsules/activity-stream.ts
+++ b/apps/web/lib/work-capsules/activity-stream.ts
@@ -1,0 +1,68 @@
+import { presentAgentSession, type AgentSessionEntry } from "./agent-activity-presenter";
+
+export const WORK_CAPSULE_ACTIVITY_EVENT = "capsule-activity";
+
+export type WorkCapsuleActivityStreamEntry = Omit<AgentSessionEntry, "recordedAt"> & {
+  recordedAt: string;
+};
+
+type ActivityRow = {
+  id: string;
+  kind: string;
+  summary: string;
+  recordedAt: Date;
+  recordedByAgentId?: string | null;
+  recordedById?: string | null;
+};
+
+type ActivityStreamDb = {
+  workCapsule: {
+    findUnique(args: unknown): Promise<{ id: string } | null>;
+  };
+  workCapsuleActivity: {
+    findMany(args: unknown): Promise<ActivityRow[]>;
+    findFirst(args: unknown): Promise<ActivityRow | null>;
+  };
+};
+
+export function serializeAgentSessionEntry(entry: AgentSessionEntry): WorkCapsuleActivityStreamEntry {
+  return {
+    ...entry,
+    recordedAt: entry.recordedAt.toISOString(),
+  };
+}
+
+export async function loadInitialAgentSessionEntries(args: {
+  db: ActivityStreamDb;
+  capsuleId: string;
+  limit?: number;
+}): Promise<{ workCapsuleId: string; entries: WorkCapsuleActivityStreamEntry[] } | null> {
+  const capsule = await args.db.workCapsule.findUnique({
+    where: { capsuleId: args.capsuleId },
+    select: { id: true },
+  });
+  if (!capsule) return null;
+
+  const rows = await args.db.workCapsuleActivity.findMany({
+    where: { workCapsuleId: capsule.id },
+    orderBy: { recordedAt: "desc" },
+    take: args.limit ?? 25,
+  });
+
+  return {
+    workCapsuleId: capsule.id,
+    entries: presentAgentSession(rows).map(serializeAgentSessionEntry),
+  };
+}
+
+export async function loadAgentSessionEntryByActivityId(args: {
+  db: ActivityStreamDb;
+  workCapsuleId: string;
+  activityId: string;
+}): Promise<WorkCapsuleActivityStreamEntry | null> {
+  const row = await args.db.workCapsuleActivity.findFirst({
+    where: { id: args.activityId, workCapsuleId: args.workCapsuleId },
+  });
+  if (!row) return null;
+  return serializeAgentSessionEntry(presentAgentSession([row])[0]!);
+}

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-
 import {
   LEASE_TTL_MS,
   STATUS_OVERRIDE_TTL_MS,
@@ -26,8 +25,7 @@ import {
   type WorkCapsuleStatus,
 } from "@/lib/work-capsules";
 import { revalidatePortalContext } from "@/lib/portal-context/invalidation";
-import { publishWorkCapsuleActivityEvent } from "@/lib/work-capsules/activity-events";
-
+import { publishRecordedWorkCapsuleActivity } from "@/lib/work-capsules/activity-events";
 export type WorkCapsuleActor = {
   userId: string;
   agentId: string | null;
@@ -154,12 +152,7 @@ async function recordActivity(
       recordedByAgentId: input.actor.agentId,
     },
   });
-  if (typeof activity?.id === "string" && activity.id.length > 0) {
-    void publishWorkCapsuleActivityEvent({
-      workCapsuleId: input.workCapsuleId,
-      activityId: activity.id,
-    }).catch(() => {});
-  }
+  publishRecordedWorkCapsuleActivity(input.workCapsuleId, activity?.id);
   revalidatePortalContext();
   return activity;
 }

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -26,6 +26,7 @@ import {
   type WorkCapsuleStatus,
 } from "@/lib/work-capsules";
 import { revalidatePortalContext } from "@/lib/portal-context/invalidation";
+import { publishWorkCapsuleActivityEvent } from "@/lib/work-capsules/activity-events";
 
 export type WorkCapsuleActor = {
   userId: string;
@@ -153,6 +154,12 @@ async function recordActivity(
       recordedByAgentId: input.actor.agentId,
     },
   });
+  if (typeof activity?.id === "string" && activity.id.length > 0) {
+    void publishWorkCapsuleActivityEvent({
+      workCapsuleId: input.workCapsuleId,
+      activityId: activity.id,
+    }).catch(() => {});
+  }
   revalidatePortalContext();
   return activity;
 }

--- a/docs/superpowers/plans/2026-07-14-bi-83e63277-agent-progress-push.md
+++ b/docs/superpowers/plans/2026-07-14-bi-83e63277-agent-progress-push.md
@@ -1,0 +1,137 @@
+# BI-83E63277 — Push-based reactive agent progress
+
+**Backlog item:** BI-83E63277 — Push-based reactive agent-progress — replace polling with real-time push in the agent-session feed  
+**Status:** Implementation plan  
+**Worktree:** `/Users/markbodman/dpf-worktrees/agent-progress-push`  
+**Branch:** `codex/agent-progress-push`
+
+## Goal
+
+Make the Work Capsule agent-session feed update in real time when an AI coworker or external executor records progress, without requiring page refresh or client polling.
+
+The intended user experience is the “reactive subscription” behavior called out in the BI: a non-technical operator watching a capsule should see “what the coworker is doing now” appear as it happens.
+
+## Current substrate verified
+
+- `apps/web/app/(shell)/build/work/[capsuleId]/page.tsx` server-renders `AgentSessionFeed` from `getCapsuleDetail(capsuleId)`.
+- `apps/web/components/build/AgentSessionFeed.tsx` is currently a static server/client-neutral renderer over `capsule.activities`.
+- `apps/web/lib/work-capsules/work-capsule-store.ts` has the canonical write path, `recordAgentActivity()`, which calls the internal `recordActivity()` helper.
+- `packages/db/prisma/schema.prisma` has `WorkCapsuleActivity` indexed by `(workCapsuleId, recordedAt desc)`, which is enough for replay/catch-up without a new datastore.
+- `apps/web/lib/sse/sse-stream.ts` provides the shared heartbeating SSE response builder.
+- `apps/web/lib/hooks/useResilientEventSource.ts` provides the browser-side EventSource wrapper with heartbeat watchdog/reconnect behavior.
+- `apps/web/package.json` already depends on `pg`, so Postgres `LISTEN/NOTIFY` is available without adding a new service.
+
+## Design
+
+Use Postgres `NOTIFY` as the cross-process wake-up bus and SSE as the browser transport.
+
+The database remains the source of truth. The push channel is only an invalidation/event-delivery path:
+
+1. `recordActivity()` persists the `WorkCapsuleActivity`.
+2. After the write succeeds, the server publishes a small notification containing `capsuleId` and `activityId`.
+3. A capsule-scoped SSE route subscribes to notifications, fetches the committed activity row, presents it with the existing `presentAgentSession()` projection, and sends it to the browser.
+4. The browser appends unseen entries to the feed in place.
+5. On connect/reconnect, the stream replays recent rows after the caller’s last known timestamp/id so missed events are recovered.
+
+No new datastore, queue, or browser polling loop.
+
+## Phases
+
+### Phase 1 — WorkCapsule activity event bus
+
+Files:
+
+- `apps/web/lib/work-capsules/activity-events.ts` (new)
+- `apps/web/lib/work-capsules/work-capsule-store.ts`
+- focused tests near `apps/web/lib/work-capsules/`
+
+Deliverable:
+
+- Add a small helper for:
+  - building a safe Postgres channel name;
+  - publishing a committed capsule activity notification;
+  - subscribing/unsubscribing to notifications with `pg`;
+  - parsing notification payloads defensively.
+- Call the publisher after `workCapsuleActivity.create()` succeeds.
+- Fail open if notification publish fails; activity persistence must remain authoritative.
+
+Verification:
+
+- Unit tests prove channel/payload parsing, publish fail-open behavior, and that `recordAgentActivity()` still returns a persisted activity even if notification fails.
+
+### Phase 2 — Capsule-scoped SSE route
+
+Files:
+
+- `apps/web/app/api/work-capsules/[capsuleId]/activity-stream/route.ts` (new)
+- `apps/web/lib/work-capsules/activity-stream.ts` (new helper if needed)
+
+Deliverable:
+
+- Add an authenticated SSE endpoint for one capsule.
+- Use `createSseResponse()` for heartbeats, cleanup, and reconnect safety.
+- On connection, replay the latest agent-session activities from `WorkCapsuleActivity`.
+- On notification, fetch the committed row and send a named event such as `capsule-activity`.
+- Return only presented feed entries, not raw DB plumbing.
+
+Verification:
+
+- Route/unit tests prove:
+  - unauthorized requests fail;
+  - initial replay sends current activities;
+  - a matching notification emits a new activity event;
+  - non-matching capsule notifications are ignored;
+  - cleanup unsubscribes on stream close.
+
+### Phase 3 — Reactive feed client
+
+Files:
+
+- `apps/web/components/build/AgentSessionFeed.tsx`
+- possibly `apps/web/components/build/AgentSessionFeedLive.tsx` (new client wrapper)
+- `apps/web/app/(shell)/build/work/[capsuleId]/page.tsx`
+
+Deliverable:
+
+- Keep the server-rendered initial feed for first paint and non-JS fallback.
+- Add a client wrapper that opens the capsule SSE stream with `useResilientEventSource()`.
+- Append new, deduped entries in chronological display order.
+- Surface a small connection state only when useful; do not make transport status the hero of the page.
+
+Verification:
+
+- Component tests prove initial rows render, pushed rows append, duplicate events are ignored, and the empty state changes when the first pushed event arrives.
+
+### Phase 4 — Documentation and evidence
+
+Files:
+
+- This plan.
+- Potentially `docs/user-guide/build-studio/index.md` or Work Capsule docs if the route behavior needs an operator-facing note.
+
+Deliverable:
+
+- Record execution evidence on BI-83E63277.
+- Link tests and any manual/live verification.
+
+Verification:
+
+- Targeted tests for the event bus, route, and feed.
+- Source-local typecheck/build as appropriate; runtime-bound live verification should use canonical install or local-CI sandbox before PR merge.
+
+## UX fit
+
+The user-facing behavior should be calm and plain:
+
+- The Activity section remains the same mental model.
+- New coworker lines appear automatically.
+- The page should not ask the operator to refresh.
+- Connection/reconnect status is secondary; the content is the point.
+
+## Risks and rollback
+
+- **Cross-process delivery risk:** In-memory events would miss worker/process boundaries, so this plan uses Postgres `LISTEN/NOTIFY`.
+- **Lost event risk:** Notifications are not durable, so replay on connect/reconnect reads the canonical activity table.
+- **Connection-slot risk:** All SSE uses the existing heartbeating `createSseResponse()` and `useResilientEventSource()` pair.
+- **Blast radius:** Limited to Work Capsule activity feed and `recordActivity()` notification side effect. If push misbehaves, the persisted activity feed still works on page reload.
+- **Rollback:** Remove the SSE client/route and notification helper call; no schema rollback required.


### PR DESCRIPTION
## Summary
- add a BI-grounded implementation plan for BI-83E63277
- publish WorkCapsule activity wake-up events through Postgres NOTIFY/LISTEN after timeline writes
- add a heartbeating capsule-scoped SSE stream and live Activity feed client so agent-session progress appears without refresh/polling

## Design grounding

- Existing specs/plans reviewed:
  - docs/superpowers/plans/2026-07-14-bi-83e63277-agent-progress-push.md
  - docs/testing/pre-pr-gate.md
  - docs/testing/pr-health.md
- Current code substrate reviewed:
  - apps/web/app/(shell)/build/work/[capsuleId]/page.tsx
  - apps/web/components/build/Activity.tsx
  - apps/web/lib/work-capsules/agent-activity-presenter.ts
  - apps/web/lib/sse.ts
  - apps/web/lib/hooks/useResilientEventSource.ts
  - apps/web/lib/work-capsules/work-capsule-store.ts
- Source of truth:
  - WorkCapsuleActivity remains the persisted source of truth; Postgres NOTIFY/LISTEN is only a wake-up transport and SSE replays/fetches committed rows by capsule.
- Decision:
  - Keep the build/work page IA unchanged and replace only the agent-session activity feed transport, using the existing SSE substrate and no new datastore.

## Verification
- pnpm --filter web exec vitest run lib/work-capsules/activity-events.test.ts lib/work-capsules/activity-stream.test.ts components/build/AgentSessionFeedLive.test.tsx lib/work-capsules/agent-activity-presenter.test.ts lib/work-capsules/work-capsule-store.test.ts
- NODE_OPTIONS="--max-old-space-size=8192" pnpm --filter web typecheck
- NODE_OPTIONS="--max-old-space-size=8192" pnpm --filter web build
- pnpm run pregate (local-CI merged candidate onto origin/main; gate passed)

Backlog: BI-83E63277
