### PR TITLE
fix(coworkers): cap 32k local tool surface

### DIFF
--- a/apps/web/lib/actions/coworker-tool-budget.test.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.test.ts
@@ -13,8 +13,8 @@ import {
 } from "./coworker-tool-budget";
 
 describe("deriveCoworkerToolCap", () => {
-  it("keeps the full 48 ceiling at a 32k window (capable-model line)", () => {
-    expect(deriveCoworkerToolCap(32_768)).toBe(MAX_COWORKER_ATTACHED_TOOLS);
+  it("caps an exact 32k local window at the 15-tool accuracy cliff", () => {
+    expect(deriveCoworkerToolCap(32_768)).toBe(15);
   });
 
   it("caps a cliff-prone 24,576 window at the 15-tool accuracy cliff (BI-2B2F59EB)", () => {
@@ -44,8 +44,8 @@ describe("deriveCoworkerToolCap", () => {
   it("applies the accuracy-cliff ceiling only below the capable-model line", () => {
     // Just below 32k: cliff-prone → bounded at 15 despite window-fit allowing more.
     expect(deriveCoworkerToolCap(31_999)).toBe(15);
-    // At/above 32k: capable → full window-fit ceiling.
-    expect(deriveCoworkerToolCap(32_768)).toBe(MAX_COWORKER_ATTACHED_TOOLS);
+    // Just above 32k: capable → full window-fit ceiling.
+    expect(deriveCoworkerToolCap(32_769)).toBe(MAX_COWORKER_ATTACHED_TOOLS);
   });
 
   it("is monotonic — a larger window never yields fewer tools", () => {

--- a/apps/web/lib/actions/coworker-tool-budget.ts
+++ b/apps/web/lib/actions/coworker-tool-budget.ts
@@ -78,16 +78,17 @@ export const ACCURACY_CLIFF_PRONE_MAX_CONTEXT = 32_768;
  * load_tools round-trips, never a failure. `null`/unknown (no small-context
  * local model) → the full 48.
  *
- *   32_768 → 48 (capable; ceiling)   24_576 → 15 (accuracy cliff)   16_000 → 12 (floor)   null → 48
+ *   32_768 → 15 (accuracy cliff)   32_769 → 48 (capable; ceiling)   16_000 → 12 (floor)   null → 48
  */
 export function deriveCoworkerToolCap(servedContextTokens: number | null | undefined): number {
   if (!servedContextTokens || servedContextTokens <= 0) return MAX_COWORKER_ATTACHED_TOOLS;
   const toolBudgetTokens = servedContextTokens - COWORKER_NON_TOOL_RESERVE_TOKENS;
   const fitted = Math.floor(toolBudgetTokens / TOOL_SCHEMA_TOKEN_ESTIMATE);
   // A cliff-prone small local model also caps at the selection cliff, not just
-  // the window fit. Larger/capable windows keep the full window-fit ceiling.
+  // the window fit. 32k local contexts still sit on the selection-accuracy
+  // cliff; larger/capable windows keep the full window-fit ceiling.
   const ceiling =
-    servedContextTokens < ACCURACY_CLIFF_PRONE_MAX_CONTEXT
+    servedContextTokens <= ACCURACY_CLIFF_PRONE_MAX_CONTEXT
       ? Math.min(MAX_COWORKER_ATTACHED_TOOLS, LOCAL_TOOL_SELECTION_CLIFF)
       : MAX_COWORKER_ATTACHED_TOOLS;
   return Math.max(MIN_COWORKER_ATTACHED_TOOLS, Math.min(ceiling, fitted));

--- a/docs/superpowers/plans/2026-07-14-bi-cap-a11bb8bb-coworker-tool-surface-scope.md
+++ b/docs/superpowers/plans/2026-07-14-bi-cap-a11bb8bb-coworker-tool-surface-scope.md
@@ -1,0 +1,30 @@
+# BI-CAP-A11BB8BB — coworker tool-surface scope
+
+Backlog item: BI-CAP-A11BB8BB
+
+## Goal
+
+Reduce the in-portal coworker tool surface before local model tool selection degrades, without revoking coworker authority. The affected intake is the inventory specialist capability need: the coworker should keep broad authorized access, but the model should receive a smaller per-turn attached tool set and load deferred tools on demand.
+
+## Current substrate
+
+- `apps/web/lib/actions/agent-coworker.ts` resolves the authorized platform/page tool set, applies mode/build-phase filtering, and then calls `selectCoworkerToolBudget`.
+- `apps/web/lib/actions/coworker-tool-budget.ts` already separates authority from attachment: attached tools go to the model, deferred tools remain authorized and are retrievable through `load_tools`.
+- `apps/web/lib/tak/context-economy-metrics.ts` defines `LOCAL_TOOL_SELECTION_CLIFF = 15` as the raw-count cliff where small local model tool selection becomes unreliable.
+- The gap is in `deriveCoworkerToolCap`: exactly `32_768` served-context local models are currently treated as capable enough for the full 48-tool ceiling, even though the local selection cliff is a count/selection-quality constraint, not just a context-fit constraint.
+
+## Plan
+
+1. Add a failing unit test showing a 32,768-token local served context is capped at the local selection cliff, not at the full 48-tool ceiling.
+2. Update `deriveCoworkerToolCap` so local served contexts at or below the 32k line use the `LOCAL_TOOL_SELECTION_CLIFF` ceiling, while larger/unknown contexts preserve the existing full ceiling.
+3. Run the source-local budget tests, then the targeted coworker action tests that exercise the filtering/budget path.
+4. If the shared fix also covers the near-duplicate marketing-specialist item (`BI-CAP-CBDB9A24`), record evidence there too; otherwise leave it open for the marketing-specific surface.
+
+## Verification
+
+- `pnpm --filter web exec vitest run lib/actions/coworker-tool-budget.test.ts`
+- `pnpm --filter web exec vitest run lib/actions/coworker-tool-budget.test.ts lib/actions/agent-coworker-tool-filter.test.ts`
+
+## Rollback
+
+Revert the `deriveCoworkerToolCap` threshold change and its tests. Since this changes attachment only, rollback does not affect coworker grants or persisted authority.


### PR DESCRIPTION
## Summary
- Treat an exact 32,768-token local served context as selection-cliff-prone, capping attached non-essential coworker tools at the 15-tool local selection cliff.
- Preserve coworker authority and the existing load_tools deferred-tool path; this only narrows per-turn attachment.
- Add a BI-linked implementation plan for BI-CAP-A11BB8BB.

## Backlog
- BI-CAP-A11BB8BB

## Verification
- PATH=... pnpm --filter web exec vitest run lib/actions/coworker-tool-budget.test.ts lib/actions/agent-coworker-tool-filter.test.ts — 2 files, 28 tests passed
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck — passed
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build — passed with existing unrelated Edge-runtime warnings
- pnpm run pregate — local-CI gate passed for codex/coworker-tool-surface-scope@6d0512554447bbc9cc4dcca3c20b542a25906bf8
