### PR TITLE
fix: stabilize attach campaign identifiers

### DIFF
--- a/apps/web/lib/marketing/campaigns-attach.test.ts
+++ b/apps/web/lib/marketing/campaigns-attach.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  marketingCampaign: {
+    findUnique: vi.fn(),
+  },
+  marketingCampaignBrief: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  marketingAssetTask: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: prismaMock }));
+
+vi.mock("../marketing", () => ({
+  getMarketingWorkspaceSnapshot: vi.fn(),
+}));
+
+import { attachToCampaign } from "./campaigns";
+
+describe("attachToCampaign", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("explains when the caller passes a briefId as campaignId", async () => {
+    prismaMock.marketingCampaign.findUnique.mockResolvedValue(null);
+    prismaMock.marketingCampaignBrief.findUnique.mockResolvedValue({
+      briefId: "brief-1",
+      campaignId: null,
+    });
+    prismaMock.marketingAssetTask.findUnique.mockResolvedValue(null);
+
+    const result = await attachToCampaign({
+      campaignId: "brief-1",
+      taskId: "task-1",
+    });
+
+    expect(result).toMatchObject({
+      error: "wrong-campaign-id",
+    });
+    expect(result.message).toMatch(/briefId/i);
+    expect(result.message).toMatch(/campaignId/i);
+    expect(prismaMock.marketingAssetTask.update).not.toHaveBeenCalled();
+  });
+
+  it("returns a structured not-found result when the task target is missing", async () => {
+    prismaMock.marketingCampaign.findUnique.mockResolvedValue({ campaignId: "campaign-1" });
+    prismaMock.marketingAssetTask.findUnique.mockResolvedValue(null);
+
+    const result = await attachToCampaign({
+      campaignId: "campaign-1",
+      taskId: "missing-task",
+    });
+
+    expect(result).toMatchObject({
+      error: "task-not-found",
+      message: "Task missing-task does not exist.",
+    });
+    expect(prismaMock.marketingAssetTask.update).not.toHaveBeenCalled();
+  });
+
+  it("attaches valid brief and task targets without partial updates", async () => {
+    prismaMock.marketingCampaign.findUnique.mockResolvedValue({ campaignId: "campaign-1" });
+    prismaMock.marketingCampaignBrief.findUnique.mockResolvedValue({ briefId: "brief-1" });
+    prismaMock.marketingAssetTask.findUnique.mockResolvedValue({ taskId: "task-1" });
+    prismaMock.marketingCampaignBrief.update.mockResolvedValue({ briefId: "brief-1" });
+    prismaMock.marketingAssetTask.update.mockResolvedValue({ taskId: "task-1" });
+
+    const result = await attachToCampaign({
+      campaignId: "campaign-1",
+      briefId: "brief-1",
+      taskId: "task-1",
+    });
+
+    expect(result).toMatchObject({
+      message: "Attached brief brief-1 and task task-1 to campaign campaign-1.",
+    });
+    expect(prismaMock.marketingCampaignBrief.update).toHaveBeenCalledWith({
+      where: { briefId: "brief-1" },
+      data: { campaignId: "campaign-1" },
+    });
+    expect(prismaMock.marketingAssetTask.update).toHaveBeenCalledWith({
+      where: { taskId: "task-1" },
+      data: { campaignId: "campaign-1" },
+    });
+  });
+});

--- a/apps/web/lib/marketing/campaigns.ts
+++ b/apps/web/lib/marketing/campaigns.ts
@@ -158,33 +158,78 @@ export async function attachToCampaign(input: {
   briefId?: string;
   taskId?: string;
 }): Promise<{ message: string } | { error: string; message: string }> {
-  if (!input.briefId && !input.taskId) {
+  const campaignId = input.campaignId.trim();
+  const briefId = input.briefId?.trim() || undefined;
+  const taskId = input.taskId?.trim() || undefined;
+
+  if (!briefId && !taskId) {
     return { error: "no-target", message: "Provide a briefId or taskId to attach to the campaign." };
   }
   const campaign = await prisma.marketingCampaign.findUnique({
-    where: { campaignId: input.campaignId },
+    where: { campaignId },
     select: { campaignId: true },
   });
   if (!campaign) {
-    return { error: "not-found", message: `Campaign ${input.campaignId} does not exist.` };
+    const [briefWithThatId, taskWithThatId] = await Promise.all([
+      prisma.marketingCampaignBrief.findUnique({
+        where: { briefId: campaignId },
+        select: { briefId: true },
+      }),
+      prisma.marketingAssetTask.findUnique({
+        where: { taskId: campaignId },
+        select: { taskId: true },
+      }),
+    ]);
+    if (briefWithThatId) {
+      return {
+        error: "wrong-campaign-id",
+        message: `The value passed as campaignId looks like a briefId (${campaignId}). Use the MarketingCampaign.campaignId returned by create_marketing_campaign or get_campaign_plan, and pass ${campaignId} as briefId if that is the brief to attach.`,
+      };
+    }
+    if (taskWithThatId) {
+      return {
+        error: "wrong-campaign-id",
+        message: `The value passed as campaignId looks like a taskId (${campaignId}). Use the MarketingCampaign.campaignId returned by create_marketing_campaign or get_campaign_plan, and pass ${campaignId} as taskId if that is the task to attach.`,
+      };
+    }
+    return { error: "not-found", message: `Campaign ${campaignId} does not exist.` };
+  }
+
+  if (briefId) {
+    const brief = await prisma.marketingCampaignBrief.findUnique({
+      where: { briefId },
+      select: { briefId: true },
+    });
+    if (!brief) {
+      return { error: "brief-not-found", message: `Brief ${briefId} does not exist.` };
+    }
+  }
+  if (taskId) {
+    const task = await prisma.marketingAssetTask.findUnique({
+      where: { taskId },
+      select: { taskId: true },
+    });
+    if (!task) {
+      return { error: "task-not-found", message: `Task ${taskId} does not exist.` };
+    }
   }
 
   const attached: string[] = [];
-  if (input.briefId) {
+  if (briefId) {
     await prisma.marketingCampaignBrief.update({
-      where: { briefId: input.briefId },
-      data: { campaignId: input.campaignId },
+      where: { briefId },
+      data: { campaignId },
     });
-    attached.push(`brief ${input.briefId}`);
+    attached.push(`brief ${briefId}`);
   }
-  if (input.taskId) {
+  if (taskId) {
     await prisma.marketingAssetTask.update({
-      where: { taskId: input.taskId },
-      data: { campaignId: input.campaignId },
+      where: { taskId },
+      data: { campaignId },
     });
-    attached.push(`task ${input.taskId}`);
+    attached.push(`task ${taskId}`);
   }
-  return { message: `Attached ${attached.join(" and ")} to campaign ${input.campaignId}.` };
+  return { message: `Attached ${attached.join(" and ")} to campaign ${campaignId}.` };
 }
 
 export async function getCampaignPlan(

--- a/apps/web/lib/mcp/packs/marketing-pack.ts
+++ b/apps/web/lib/mcp/packs/marketing-pack.ts
@@ -90,7 +90,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "attach_to_campaign",
     description:
-      "Attach an existing campaign brief and/or asset task to a campaign so it rolls up under one plan (replacing fuzzy title matching with a real link). Provide campaignId plus a briefId and/or taskId.",
+      "Attach an existing campaign brief and/or asset task to a campaign so it rolls up under one plan (replacing fuzzy title matching with a real link). campaignId must be a MarketingCampaign.campaignId returned by create_marketing_campaign or get_campaign_plan; do not pass a briefId or taskId as campaignId. Provide campaignId plus a briefId and/or taskId.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary
- Fixes BI-CAP-F9D6DF02 by making attach_to_campaign return specific guidance when a caller passes a briefId or taskId as campaignId.
- Validates brief/task targets before updating, so missing targets return structured errors instead of misleading success or Prisma update failures.
- Tightens the model-facing tool description so agents use MarketingCampaign.campaignId from create_marketing_campaign/get_campaign_plan.

## Test plan
- [x] Red regression first: `pnpm --filter web exec vitest run lib/marketing/campaigns-attach.test.ts` failed on the old generic/misleading behavior.
- [x] Targeted tests: `pnpm --filter web exec vitest run lib/marketing/campaigns-attach.test.ts lib/marketing/campaigns.test.ts` — 2 files, 15 tests passed.
- [x] Typecheck: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` — passed.
- [x] Local-CI pregate: merged into origin/main, migrations deploy, full web Vitest, and production build — gate passed.

Overlap sweep: `gh pr list --state open --limit 50` returned no open PRs; recent path log showed no overlapping changes.

Process-Spine-Decision: Regression-only tool hardening against an existing marketing campaign contract; no new spec or plan because no architecture, route, data model, or user workflow contract changed.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-06-26-marketing-coworker-campaign-parity.md` — campaign tools are the Marketing coworker contract, including create/update/attach/read campaign plan.
- Current code substrate reviewed:
  - `apps/web/lib/marketing/campaigns.ts` — `attachToCampaign` handler and campaign/brief/task persistence behavior.
  - `apps/web/lib/mcp/packs/marketing-pack.ts` — model-facing `attach_to_campaign` tool definition and identifier guidance.
  - Live `ToolExecution` rows for `attach_to_campaign` — repeated failures showed a brief/task identifier being reused as `campaignId` before a later successful attach used the real campaign id.
- Source of truth:
  - `MarketingCampaign.campaignId` is the parent plan identifier; `MarketingCampaignBrief.briefId` and `MarketingAssetTask.taskId` are attach targets.
- Decision:
  - Keep the existing campaign data model and tool contract; harden the handler with structured ID-confusion errors and target validation, plus regression coverage.


Local-CI-Override: empty design-grounding attestation commit c005044e5; source tree is identical to local-CI-passed c36bf1e87, so no code/test/build substrate changed after the passing sandbox gate.
