### PR TITLE
feat(coworker): surface advise-mode recommendations as selectable approval cards (BI-867263F4)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -88,7 +88,7 @@ import {
 
 // ─── Auth helper ────────────────────────────────────────────────────────────
 
-import { filterToolsForCoworkerRuntime, adviseHeldBackTools } from "./coworker-tool-filter";
+import { filterToolsForCoworkerRuntime, buildAdvisePromptSuffix } from "./coworker-tool-filter";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { requireUser } from "./shared/guards";
 export { filterToolsForCoworkerRuntime };
@@ -1309,8 +1309,15 @@ export async function sendMessage(input: {
     }
   }
 
+  // BI-867263F4: in Advise mode, keep the side-effecting tools and let the loop
+  // capture each call as an AgentActionProposal, so the coworker's recommended
+  // actions surface as selectable Approve/Reject cards instead of prose that
+  // asks the employee to flip a global toggle. Off in Act mode (tools run) and
+  // during a build phase (phase gating owns the surface).
+  const surfaceAsProposals = input.coworkerMode === "advise" && !activeBuildPhase;
   const availableTools = filterToolsForCoworkerRuntime(mergedTools, {
     coworkerMode: input.coworkerMode,
+    surfaceAsProposals,
     activeBuildPhase,
   });
 
@@ -1547,29 +1554,14 @@ export async function sendMessage(input: {
     }
   }
 
-  // Advise mode holds back the coworker's side-effecting tools. Tell it exactly
-  // which authority is being held back — this is NOT a missing permission — so it
-  // proposes switching to Act mode and names the specific capability per the
-  // limitation-response contract, instead of misdiagnosing a mode muzzle as a
-  // missing grant or deflecting the employee to an administrator. Mirrors the
-  // external-access block below. Covers both prompt paths (they converge here).
-  if (input.coworkerMode === "advise") {
-    const heldBack = adviseHeldBackTools(mergedTools);
-    if (heldBack.length > 0) {
-      const ADVISE_HELD_BACK_CAP = 10;
-      const shown = heldBack.slice(0, ADVISE_HELD_BACK_CAP);
-      const toolList = shown.map((t) => `- ${t.name}: ${t.description}`).join("\n");
-      const moreLine = heldBack.length > shown.length ? `- (+${heldBack.length - shown.length} more)` : "";
-      populatedPrompt += [
-        "",
-        "",
-        "ADVISE MODE — AUTHORITY HELD BACK (NOT A MISSING PERMISSION).",
-        "You already hold permission for the actions below; they are disabled ONLY because you are in Advise mode. Do not tell the employee you lack access to these, and do not send them to an administrator. When the request needs one, follow the limitation-response contract: say you can do it and ask to switch to Act mode.",
-        toolList,
-        moreLine,
-      ].filter(Boolean).join("\n");
-    }
-  }
+  // Advise-mode prompt suffix: either "your recommendations become approval
+  // cards" (surfaceAsProposals, BI-867263F4) or the legacy held-back muzzle note
+  // (build-phase advise). Extracted to coworker-tool-filter for testability.
+  populatedPrompt += buildAdvisePromptSuffix({
+    coworkerMode: input.coworkerMode,
+    surfaceAsProposals,
+    mergedTools,
+  });
 
   // When external access is enabled, tell the agent about its web tools
   if (input.externalAccessEnabled) {
@@ -1927,6 +1919,10 @@ export async function sendMessage(input: {
         // conversational reply ("yes do the truck list first") does not
         // false-positive into a PlatformIssueReport.
         interactionMode: "chat",
+        // BI-867263F4: Advise mode surfaces recommended actions as proposals —
+        // the loop diverts each side-effecting non-artifact call to an
+        // AgentActionProposal card instead of executing it.
+        proposeSideEffects: surfaceAsProposals,
         ...(Object.keys(modelReqs).length > 0 ? { modelRequirements: modelReqs } : {}),
         onProgress: (event) => agentEventBus.emit(input.threadId, event),
       }),

--- a/apps/web/lib/actions/coworker-tool-filter.test.ts
+++ b/apps/web/lib/actions/coworker-tool-filter.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { ToolDefinition } from "@/lib/mcp-tools";
 
-import { adviseHeldBackTools, filterToolsForCoworkerRuntime } from "./coworker-tool-filter";
+import { adviseHeldBackTools, buildAdvisePromptSuffix, filterToolsForCoworkerRuntime } from "./coworker-tool-filter";
 
 const tool = (over: Partial<ToolDefinition> & { name: string }): ToolDefinition =>
   ({
@@ -51,6 +51,26 @@ describe("filterToolsForCoworkerRuntime — advise rule", () => {
     const kept = filterToolsForCoworkerRuntime(MERGED, { coworkerMode: "act", activeBuildPhase: null }).map((t) => t.name);
     expect(kept).toEqual(["list_backlog_items", "create_backlog_item", "manage_coworker_tool_grant", "save_marketing_review"]);
   });
+
+  it("KEEPS side-effect tools in advise mode when surfaceAsProposals is on (BI-867263F4)", () => {
+    // Advise now proposes: the tools stay so the loop can capture each call as an
+    // approval card, instead of stripping them and describing in prose.
+    const kept = filterToolsForCoworkerRuntime(MERGED, {
+      coworkerMode: "advise",
+      surfaceAsProposals: true,
+      activeBuildPhase: null,
+    }).map((t) => t.name);
+    expect(kept).toEqual(["list_backlog_items", "create_backlog_item", "manage_coworker_tool_grant", "save_marketing_review"]);
+  });
+
+  it("still strips in advise mode when surfaceAsProposals is off (default unchanged)", () => {
+    const kept = filterToolsForCoworkerRuntime(MERGED, {
+      coworkerMode: "advise",
+      surfaceAsProposals: false,
+      activeBuildPhase: null,
+    }).map((t) => t.name);
+    expect(kept).toEqual(["list_backlog_items", "save_marketing_review"]);
+  });
 });
 
 describe("adviseHeldBackTools", () => {
@@ -74,5 +94,29 @@ describe("adviseHeldBackTools", () => {
 
   it("returns empty when the coworker holds no side-effecting authority", () => {
     expect(adviseHeldBackTools([READ, ARTIFACT])).toEqual([]);
+  });
+});
+
+describe("buildAdvisePromptSuffix (BI-867263F4)", () => {
+  it("tells the coworker its recommendations become approval cards when surfacing proposals", () => {
+    const suffix = buildAdvisePromptSuffix({ coworkerMode: "advise", surfaceAsProposals: true, mergedTools: MERGED });
+    expect(suffix).toContain("YOUR RECOMMENDATIONS BECOME APPROVAL CARDS");
+    expect(suffix).toContain("do NOT just describe them in prose");
+    // It must NOT use the old muzzle framing that held the tools back.
+    expect(suffix).not.toContain("AUTHORITY HELD BACK");
+  });
+
+  it("falls back to the held-back muzzle note in advise mode without surfacing", () => {
+    const suffix = buildAdvisePromptSuffix({ coworkerMode: "advise", surfaceAsProposals: false, mergedTools: MERGED });
+    expect(suffix).toContain("AUTHORITY HELD BACK");
+    expect(suffix).toContain("create_backlog_item");
+  });
+
+  it("returns empty for act mode", () => {
+    expect(buildAdvisePromptSuffix({ coworkerMode: "act", mergedTools: MERGED })).toBe("");
+  });
+
+  it("returns empty when advise mode holds no side-effecting authority (nothing to muzzle)", () => {
+    expect(buildAdvisePromptSuffix({ coworkerMode: "advise", surfaceAsProposals: false, mergedTools: [READ, ARTIFACT] })).toBe("");
   });
 });

--- a/apps/web/lib/actions/coworker-tool-filter.ts
+++ b/apps/web/lib/actions/coworker-tool-filter.ts
@@ -44,11 +44,24 @@ const TERMINAL_BUILD_TOOLS = new Set<string>([
  */
 export function filterToolsForCoworkerRuntime(
   tools: ToolDefinition[],
-  input: { coworkerMode?: "advise" | "act"; activeBuildPhase: string | null },
+  input: {
+    coworkerMode?: "advise" | "act";
+    activeBuildPhase: string | null;
+    /**
+     * BI-867263F4: when true, advise mode KEEPS its side-effecting tools instead
+     * of stripping them — the agentic loop captures each call as an
+     * AgentActionProposal (propose-interception) so the coworker's recommended
+     * actions render as selectable Approve/Reject cards rather than prose. The
+     * default (false) preserves the original strip-in-advise behavior for every
+     * other caller.
+     */
+    surfaceAsProposals?: boolean;
+  },
 ): ToolDefinition[] {
   return tools.filter((tool) => {
     if (
       input.coworkerMode === "advise" &&
+      !input.surfaceAsProposals &&
       tool.sideEffect &&
       !tool.coworkerArtifact &&
       !tool.adviseCoordination
@@ -85,4 +98,45 @@ export function adviseHeldBackTools(mergedTools: ToolDefinition[]): ToolDefiniti
   return mergedTools.filter(
     (tool) => tool.sideEffect && !tool.coworkerArtifact && !tool.adviseCoordination,
   );
+}
+
+/**
+ * The advise-mode prompt suffix appended to a coworker's system prompt.
+ *
+ * BI-867263F4: when `surfaceAsProposals` is on, Advise mode PROPOSES — it tells
+ * the coworker to call the relevant tools (each is captured as an approval card)
+ * rather than describe them in prose or ask to switch to Act mode. When it is
+ * off (e.g. an advise turn inside a build phase), the legacy held-back note
+ * fires: name the exact authority being muzzled so the coworker asks to switch
+ * to Act mode instead of misdiagnosing a mode muzzle as a missing permission.
+ * Returns "" when nothing applies. Pass the FULL merged (authorized) tool set.
+ */
+export function buildAdvisePromptSuffix(input: {
+  coworkerMode?: "advise" | "act";
+  surfaceAsProposals?: boolean;
+  mergedTools: ToolDefinition[];
+}): string {
+  if (input.coworkerMode !== "advise") return "";
+  if (input.surfaceAsProposals) {
+    return [
+      "",
+      "",
+      "ADVISE MODE — YOUR RECOMMENDATIONS BECOME APPROVAL CARDS.",
+      "When the request calls for a side-effecting action, DO call the relevant tool. In Advise mode the platform does not execute it — it captures the call as a proposal card the employee can approve with one click. So surface your recommended actions by calling the tools (each becomes a card); do NOT just describe them in prose, and do NOT ask the employee to switch to Act mode. Read-only tools run normally.",
+    ].join("\n");
+  }
+  const heldBack = adviseHeldBackTools(input.mergedTools);
+  if (heldBack.length === 0) return "";
+  const ADVISE_HELD_BACK_CAP = 10;
+  const shown = heldBack.slice(0, ADVISE_HELD_BACK_CAP);
+  const toolList = shown.map((t) => `- ${t.name}: ${t.description}`).join("\n");
+  const moreLine = heldBack.length > shown.length ? `- (+${heldBack.length - shown.length} more)` : "";
+  return [
+    "",
+    "",
+    "ADVISE MODE — AUTHORITY HELD BACK (NOT A MISSING PERMISSION).",
+    "You already hold permission for the actions below; they are disabled ONLY because you are in Advise mode. Do not tell the employee you lack access to these, and do not send them to an administrator. When the request needs one, follow the limitation-response contract: say you can do it and ask to switch to Act mode.",
+    toolList,
+    moreLine,
+  ].filter(Boolean).join("\n");
 }

--- a/apps/web/lib/tak/agent-coworker-data.test.ts
+++ b/apps/web/lib/tak/agent-coworker-data.test.ts
@@ -1,5 +1,37 @@
 import { describe, expect, it } from "vitest";
-import { selectVisibleTelemetry } from "./agent-coworker-data";
+import { selectVisibleTelemetry, serializeMessage } from "./agent-coworker-data";
+
+const assistantMsg = {
+  id: "m1",
+  role: "assistant",
+  content: "Proposed `add customer contact` for your approval.",
+  agentId: "customer-advisor",
+  routeContext: "/customer",
+  createdAt: new Date("2026-07-12T00:00:00Z"),
+};
+
+describe("serializeMessage — proposal join (BI-867263F4)", () => {
+  it("attaches a joined proposal so its Approve/Reject card renders (incl. on reload)", () => {
+    const row = serializeMessage(assistantMsg, {
+      proposalId: "prop-1",
+      actionType: "add_customer_contact",
+      parameters: { name: "Dan Warfield" },
+      status: "proposed",
+      resultEntityId: null,
+      resultError: null,
+    });
+    expect(row.proposal).toEqual({
+      proposalId: "prop-1",
+      actionType: "add_customer_contact",
+      parameters: { name: "Dan Warfield" },
+      status: "proposed",
+    });
+  });
+
+  it("leaves proposal undefined when the message has none", () => {
+    expect(serializeMessage(assistantMsg, null).proposal).toBeUndefined();
+  });
+});
 
 const baseRow = {
   providerId: "anthropic",

--- a/apps/web/lib/tak/agent-coworker-data.ts
+++ b/apps/web/lib/tak/agent-coworker-data.ts
@@ -192,12 +192,27 @@ export const getRecentMessages = cache(
         attachments: {
           select: { id: true, fileName: true, mimeType: true, sizeBytes: true, parsedContent: true },
         },
+        // BI-867263F4: join the proposal so its Approve/Reject card survives a
+        // reload AND so proposals minted by propose-interception (a coworker in
+        // advise mode recommending N actions) render as selectable cards — the
+        // history loader previously always passed `undefined`, so any proposal
+        // card vanished on reload and interception proposals never surfaced.
+        proposal: {
+          select: {
+            proposalId: true,
+            actionType: true,
+            parameters: true,
+            status: true,
+            resultEntityId: true,
+            resultError: true,
+          },
+        },
       },
     });
     const providerInfo = await loadProviderInfo(messages);
     return messages
       .reverse()
-      .map((m) => serializeMessage(m, undefined, providerInfo.get(m.id)));
+      .map((m) => serializeMessage(m, m.proposal, providerInfo.get(m.id)));
   },
 );
 

--- a/docs/superpowers/specs/2026-07-12-act-mode-surfacing-design.md
+++ b/docs/superpowers/specs/2026-07-12-act-mode-surfacing-design.md
@@ -1,0 +1,34 @@
+# Act-mode surfacing — coworker recommendations as selectable action cards (BI-867263F4)
+
+- **BI:** BI-867263F4 (P4, large) · **Epic:** EP-B9DD37C7 (coworker chat: runtime truthfulness, transparency & controls)
+- **Depends on:** BI-80532D5C propose-interception (the loop's accumulate-and-continue diversion mechanism) merging first.
+- **Kernel decisions (2026-07-12, external_coding_agent, high confidence):** approach = `advise-emits-proposals-via-interception` (11.53); presentation = `reuse-existing-approve-reject-card` (6.66, `human_cognitive_load`).
+
+## 1. Problem
+
+When a coworker recommends actions in chat ("I recommend: 1) add Dan Warfield as primary contact, 2) update the quote"), the text renders as an inert markdown list. Advise mode **strips** side-effecting tools before the model sees them and injects a prompt telling the model to *describe* what it would do and ask the user to flip a global Act toggle (`coworker-tool-filter.ts:45-67`, `agent-coworker.ts:1552-1567`). Nothing is clickable; the advise→act handoff is entirely conversational and the user must switch a global mode and re-ask. The `AgentActionProposal` + Approve/Reject card (`AgentMessageBubble.tsx:267-459`, `proposals.ts:20-114`) is the platform's real "click to execute" primitive, but it only fires when a tool is authored `executionMode:"proposal"` **and** the model calls it — and advise mode has already stripped the interesting tools.
+
+## 2. Why this is now cheap: propose-interception already did the hard part
+
+BI-80532D5C added, in the agentic loop, a **divert-and-continue** mechanism: under a propose posture a side-effecting non-artifact tool call is captured as an `AgentActionProposal` (via `interceptToolCallAsProposal`) and the loop **continues**, accumulating multiple proposals in one turn. The existing `approveProposal` executes `actionType` as a tool name. So the only remaining gap for BI-867263F4 is to route the **interactive advise turn** through that same mechanism and surface the accumulated proposals as cards.
+
+## 3. Design
+
+1. **Advise mode stops stripping; it proposes.** In `coworker-tool-filter.ts`, advise mode keeps side-effecting non-artifact tools in the surface (so the model can *call* them) rather than removing them. The interactive chat turn sets the interactive equivalent of `proposeSideEffects = true` (a new `agent-coworker.ts` send-path flag mirroring the scheduler's), so each such call is diverted to an `AgentActionProposal` instead of executing.
+2. **Accumulate, don't return-on-first.** Reuse BI-80532D5C's continue-after-divert so a single turn surfaces **N** proposals (one per recommended action), not just the first.
+3. **Render with the existing card.** Each accumulated proposal renders with the **existing** Approve/Reject proposal card (kernel UX-fit choice — no new visual language). Today the turn carries a single `proposal`; extend `AgentMessageRow` to carry `proposals[]` (or emit one assistant message per proposal) and stack the existing card per action.
+4. **Execution + audit unchanged.** Approve → `approveProposal` → `executeTool` → status `executed`/`failed` + `authorizationDecisionLog` (all existing).
+
+The advise-mode system-prompt guidance shifts from "ask the user to switch to Act mode" to "propose the concrete actions" — the model's recommendations become real, capability-checked, parameterized proposals rather than prose.
+
+## 4. Research & Benchmarking
+
+Reuses the platform's own proven proposal primitive rather than inventing one — the substrate map (this BI's scoping) confirms `AgentActionProposal` + `approveProposal` is the single load-bearing "click to execute" mechanism, already governance-audited. Rejected: (B) a new `recommendedActions[]` field + bespoke renderer + client-side "materialize on click" — larger new surface for no governance gain; (C) client-side prose parsing — brittle NL→tool mapping, no parameter fidelity, no capability pre-check, fights the proposal-as-DB-row model. External assistant UIs (the benchmark set in the coworker-UX consolidation spec) converge on "the model proposes a concrete, parameterized action the human one-click approves" over free-text-then-mode-switch — this adopts that pattern on the existing primitive.
+
+## 5. Open dependency & sequencing
+
+Implement only **after** BI-80532D5C merges (this design builds on `interceptToolCallAsProposal` and the continue-after-divert loop change). The interactive-path flag and the multi-proposal turn shape are the net-new surface; the card, execution, and audit are all reuse.
+
+## 6. UX-Fit
+
+Presentation reuses the existing Approve/Reject card (kernel `reuse-existing-approve-reject-card`, high confidence) — no new control a layman must learn; progressive disclosure via the same human-labeled param table already shipped. `UX-Fit-Decision:` trailer will cite this on the implementing PR.


### PR DESCRIPTION
## Surface advise-mode recommendations as selectable approval cards (BI-867263F4)

Closes the advise→act loop. **Before:** advise mode *stripped* side-effecting tools and the coworker described what it would do in prose, asking the employee to flip a global Act toggle — nothing was clickable. **Now:** advise mode keeps those tools and routes the turn through propose-interception (BI-80532D5C), so each side-effecting non-artifact tool the coworker calls is captured as an `AgentActionProposal` card the employee approves with one click; multiple recommended actions accumulate as N cards in a single turn.

**Kernel decisions** (2026-07-12, external_coding_agent, high confidence): approach = `advise-emits-proposals-via-interception` (11.53); presentation = `reuse-existing-approve-reject-card` (6.66, `human_cognitive_load`).

### Changes
- `filterToolsForCoworkerRuntime` gains `surfaceAsProposals`: advise mode **keeps** its side-effecting tools instead of stripping them. Default off → every other caller unchanged.
- `agent-coworker` send path sets `surfaceAsProposals = advise && !buildPhase`, passes `proposeSideEffects` to the loop, and (via the extracted `buildAdvisePromptSuffix` helper) swaps the "switch to Act mode" muzzle prompt for a "call the tools; they become approval cards" prompt.
- `getRecentMessages` now **joins `AgentActionProposal` by messageId** — this both fixes a latent bug (proposal cards silently vanished on reload, since the loader always passed `undefined`) and is what surfaces the interception-minted cards.
- Reuses the existing Approve/Reject card + `approveProposal` execution + authorization audit — no new visual language (kernel UX-fit choice).

### Verification
Depends on BI-80532D5C (merged, #2880). Worktree typecheck green; filter + message-data + interception suites **27/27**; local-CI pregate green (rebased onto main). Live UX verification on the running portal below.

Spec: `docs/superpowers/specs/2026-07-12-act-mode-surfacing-design.md`

UX-Fit-Decision: reuse-existing-approve-reject-card — principle_decide 2026-07-12, external_coding_agent, high confidence (6.66), human_cognitive_load; reuses the shipped Approve/Reject proposal card so a layman learns no new control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design grounding

- **Searched substrate:** the BI scoping pass mapped the full recommendation-rendering + proposal pipeline (AgentMessageBubble prose vs proposal branch, runAgenticLoop proposal emission, `approveProposal`/`executeTool`, `getRecentMessages`, `coworker-tool-filter`). Confirmed no existing "recommended actions" structured output.
- **Source of truth:** the `AgentActionProposal` row + `approveProposal` execution + the existing Approve/Reject card in `AgentMessageBubble` — the one governance-audited "click to execute" primitive. This change routes proposals to it; it invents no parallel surface.
- **Decision:** created a new spec (`docs/superpowers/specs/2026-07-12-act-mode-surfacing-design.md`) capturing the kernel approach + UX-fit decisions and the dependency on BI-80532D5C; extends the propose-interception substrate rather than adding a new contract.

Design-Grounding-Decision: extend existing AgentActionProposal/approveProposal substrate; new spec 2026-07-12-act-mode-surfacing-design.md records the kernel-decided approach (advise-emits-proposals-via-interception) and reuse-existing-card UX-fit.
