### PR TITLE
feat(work-mgmt): work-item comments with @mention→notification (EP-WORK-CONVERGENCE, BI-B416B12A)

### DIFF
--- a/apps/web/components/attention/AttentionInbox.tsx
+++ b/apps/web/components/attention/AttentionInbox.tsx
@@ -29,6 +29,7 @@ const SOURCE_LABEL: Record<AttentionSource, string> = {
   "research-proposal": "Research",
   "ai-readiness-blocker": "AI readiness",
   "platform-health": "Platform health",
+  "work-item-mention": "Mention",
 };
 
 export function AttentionInbox({

--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -1,5 +1,15 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// The detail view now embeds the client comment thread (BI-B416B12A), which
+// pulls in useRouter and the postWorkItemComment server action. Stub both so this
+// server-render test stays a pure markup assertion.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: () => {} }),
+}));
+vi.mock("@/lib/actions/work-item-comments", () => ({
+  postWorkItemComment: async () => ({ ok: true, messageId: "stub", notified: 0 }),
+}));
 
 import { WorkCaseDetailView } from "./WorkCaseDetailView";
 import type { WorkspaceWorkCaseDetailView } from "@/lib/work-management/workspace-case-loader";
@@ -39,6 +49,21 @@ const detail: WorkspaceWorkCaseDetailView = {
     { kind: "source", id: "BK-1", sourceType: "booking" },
     { kind: "work-item", id: "WI-1", status: "awaiting-input" },
   ],
+  commentThread: {
+    workItemId: "row-1",
+    itemPublicId: "WI-1",
+    messages: [
+      {
+        messageId: "WIM-1",
+        senderLabel: "Teammate",
+        body: "Need a human confirmation before booking.",
+        createdAt: "2026-06-28T10:10:00.000Z",
+        mine: false,
+      },
+    ],
+    participants: ["Teammate"],
+    canComment: true,
+  },
 };
 
 describe("WorkCaseDetailView", () => {

--- a/apps/web/components/workspace/WorkCaseDetailView.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Clock, FileText, ShieldCheck } from "lucide-react";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { StatusBadge } from "@/components/ui/report-kit";
 import type { Intent } from "@/components/ui/report-kit/statusColors";
+import { WorkItemCommentThread } from "@/components/workspace/WorkItemCommentThread";
 import type { WorkspaceWorkCaseDetailView } from "@/lib/work-management/workspace-case-loader";
 
 type Props = {
@@ -104,6 +105,8 @@ export function WorkCaseDetailView({ detail }: Props) {
           </div>
         )}
       </section>
+
+      <WorkItemCommentThread thread={detail.commentThread} />
 
       <section aria-labelledby="work-case-source-title" className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
         <div className="flex items-center gap-2">

--- a/apps/web/components/workspace/WorkItemCommentThread.tsx
+++ b/apps/web/components/workspace/WorkItemCommentThread.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+// BI-B416B12A (EP-WORK-CONVERGENCE): the work-item comment thread + compose box.
+// Renders the projected thread (WorkCaseCommentThread) and posts new comments via
+// the postWorkItemComment server action, which fans out @mention notifications.
+
+import { MessageSquare, Users } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import { postWorkItemComment } from "@/lib/actions/work-item-comments";
+import type { WorkCaseCommentThread } from "@/lib/work-management/case-types";
+
+type Props = {
+  thread: WorkCaseCommentThread;
+};
+
+export function WorkItemCommentThread({ thread }: Props) {
+  const router = useRouter();
+  const [body, setBody] = useState("");
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = body.trim();
+  const disabled = isPending || !trimmed || !thread.canComment || !thread.workItemId;
+
+  async function handlePost() {
+    if (!thread.workItemId || !trimmed) return;
+    setIsPending(true);
+    setError(null);
+    try {
+      const result = await postWorkItemComment({ workItemId: thread.workItemId, body: trimmed });
+      if (result.ok) {
+        setBody("");
+        router.refresh();
+      } else {
+        setError(result.error);
+      }
+    } catch {
+      setError("failed");
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby="work-case-discussion-title"
+      className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+    >
+      <div className="flex items-center gap-2 border-b border-[var(--dpf-border)] px-4 py-3">
+        <MessageSquare className="size-4 text-[var(--dpf-accent)]" aria-hidden="true" />
+        <h2 id="work-case-discussion-title" className="text-sm font-semibold text-[var(--dpf-text)]">
+          Discussion
+        </h2>
+      </div>
+
+      {thread.participants.length > 0 ? (
+        <div className="flex items-center gap-2 border-b border-[var(--dpf-border)] px-4 py-2 text-xs text-[var(--dpf-muted)]">
+          <Users className="size-3.5" aria-hidden="true" />
+          <span>In this thread:</span>
+          <span className="flex flex-wrap gap-1.5">
+            {thread.participants.map((participant) => (
+              <span
+                key={participant}
+                className="inline-flex items-center gap-1 rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-0.5 font-medium text-[var(--dpf-text)]"
+              >
+                <span className="size-1.5 rounded-full bg-[var(--dpf-success)]" aria-hidden="true" />
+                {participant}
+              </span>
+            ))}
+          </span>
+        </div>
+      ) : null}
+
+      {thread.messages.length > 0 ? (
+        <ol className="divide-y divide-[var(--dpf-border)]">
+          {thread.messages.map((message) => (
+            <li key={message.messageId} className="px-4 py-3">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-medium text-[var(--dpf-text)]">{message.senderLabel}</span>
+                <span className="text-xs text-[var(--dpf-muted)]">
+                  <LocalTime value={message.createdAt} mode="datetime" />
+                </span>
+              </div>
+              <p className="mt-1 whitespace-pre-wrap text-sm leading-6 text-[var(--dpf-text)]">{message.body}</p>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <div className="px-4 py-6 text-sm text-[var(--dpf-muted)]">
+          No comments yet. Start the discussion below.
+        </div>
+      )}
+
+      <div className="border-t border-[var(--dpf-border)] p-4">
+        <label htmlFor="work-case-comment-body" className="sr-only">
+          Add a comment
+        </label>
+        <textarea
+          id="work-case-comment-body"
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          rows={3}
+          disabled={isPending || !thread.canComment || !thread.workItemId}
+          placeholder="Add a comment…"
+          className="w-full resize-y rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
+        />
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+          <p className="text-xs text-[var(--dpf-muted)]">Use @name to notify a teammate.</p>
+          <div className="flex items-center gap-3">
+            {error ? (
+              <span role="alert" className="text-xs font-medium text-[var(--dpf-danger)]">
+                {error}
+              </span>
+            ) : null}
+            <button
+              type="button"
+              onClick={handlePost}
+              disabled={disabled}
+              className="inline-flex items-center rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-semibold text-[var(--dpf-on-accent)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isPending ? "Posting…" : "Post comment"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/lib/actions/work-item-comments.ts
+++ b/apps/web/lib/actions/work-item-comments.ts
@@ -1,0 +1,105 @@
+"use server";
+// BI-B416B12A (EP-WORK-CONVERGENCE): post a comment on a work item and fan out
+// @mention → attention notifications. The pure core lives in
+// lib/work-management/mentions.ts (parse/resolve) and mention-notify.ts (roster +
+// recipient selection); this server action is the DB/auth wiring.
+//
+// Domain errors are RETURNED as values (never thrown): Next.js strips thrown
+// error messages in production, so a thrown "not_found" would surface to the
+// client as a generic opaque error. The result union carries the reason instead.
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { resolveMentions } from "@/lib/work-management/mentions";
+import {
+  buildMentionRoster,
+  mentionNotifyRecipients,
+} from "@/lib/work-management/mention-notify";
+import { notifyAttentionLive } from "@/lib/attention/notify-live";
+
+export type PostWorkItemCommentResult =
+  | { ok: true; messageId: string; notified: number }
+  | { ok: false; error: string };
+
+export async function postWorkItemComment(input: {
+  workItemId: string;
+  body: string;
+}): Promise<PostWorkItemCommentResult> {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const body = (input.body ?? "").trim();
+  if (!body) return { ok: false, error: "empty" };
+
+  try {
+    const item = await prisma.workItem.findUnique({
+      where: { id: input.workItemId },
+      select: { id: true, itemId: true, title: true, assignedToUserId: true },
+    });
+    if (!item) return { ok: false, error: "not_found" };
+
+    // Bounded roster: the assignee, the commenter, and everyone who has already
+    // posted on this item. Keeps the @mention lookup scoped to plausible
+    // participants instead of loading every user in the system.
+    const priorSenders = await prisma.workItemMessage.findMany({
+      where: { workItemId: item.id, senderUserId: { not: null } },
+      select: { senderUserId: true },
+    });
+    const userIds = Array.from(
+      new Set(
+        [item.assignedToUserId, userId, ...priorSenders.map((m) => m.senderUserId)].filter(
+          (id): id is string => Boolean(id),
+        ),
+      ),
+    );
+
+    const [users, agents] = await Promise.all([
+      prisma.user.findMany({
+        where: { id: { in: userIds } },
+        select: { id: true, email: true },
+      }),
+      prisma.agent.findMany({
+        select: { id: true, agentId: true, slugId: true, name: true },
+      }),
+    ]);
+
+    const roster = buildMentionRoster(
+      users.map((u) => ({ id: u.id, email: u.email ?? "" })),
+      agents.map((a) => ({ id: a.id, agentId: a.agentId, slugId: a.slugId, name: a.name })),
+    );
+    const targets = resolveMentions(body, roster);
+
+    const created = await prisma.workItemMessage.create({
+      data: {
+        workItemId: item.id,
+        senderType: "user",
+        senderUserId: userId,
+        messageType: "comment",
+        body,
+        channel: "in-app",
+        structuredPayload: {
+          mentions: targets.map((t) => ({ handle: t.handle, type: t.type, id: t.id })),
+        },
+      },
+      select: { messageId: true },
+    });
+
+    const recipients = mentionNotifyRecipients(targets, { excludeUserId: userId });
+    for (const recipient of recipients) {
+      await notifyAttentionLive({
+        source: "work-item-mention",
+        itemKey: `${item.itemId}:${created.messageId}`,
+        userId: recipient,
+        title: `You were mentioned on ${item.title}`,
+        body: body.slice(0, 140),
+        deepLink: `/workspace/cases/${item.itemId}`,
+      });
+    }
+
+    return { ok: true, messageId: created.messageId, notified: recipients.length };
+  } catch {
+    // Unexpected failure (DB, etc.) — return a value, never rethrow.
+    return { ok: false, error: "failed" };
+  }
+}

--- a/apps/web/lib/attention/outside-in.ts
+++ b/apps/web/lib/attention/outside-in.ts
@@ -72,6 +72,7 @@ const SOURCE_PORTFOLIO: Record<AttentionSource, AttentionPortfolio> = {
   "paused-ai": "for-employees", // a coworker paused, needs input/credential
   "scheduled-task": "for-employees", // a coworker cadence errored
   "agent-proposal": "for-employees", // a coworker wants approval to act
+  "work-item-mention": "for-employees", // a teammate @mentioned you on a work item
   // Build / delivery pipeline (deeper inside).
   escalation: "manufacturing-and-delivery", // Build Studio could not self-repair
   "research-proposal": "manufacturing-and-delivery", // internal capability R&D

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -21,7 +21,8 @@ export type AttentionSource =
   | "compliance-submission" // RegulatorySubmission draft (carries a dueDate)
   | "research-proposal" // ResearchProposal pending
   | "ai-readiness-blocker" // AI Readiness blocked domain requiring operator action
-  | "platform-health"; // PortfolioQualityIssue issueType=health_alert, status=open (BI-2F778C13)
+  | "platform-health" // PortfolioQualityIssue issueType=health_alert, status=open (BI-2F778C13)
+  | "work-item-mention"; // WorkItemMessage @mention (BI-B416B12A)
 
 /** Risk vocabulary aligned with the paused-work plan (a2aMetadata.riskClass). */
 export type AttentionRiskClass = "read" | "bounded-write" | "high-risk" | "unknown";

--- a/apps/web/lib/work-management/case-types.ts
+++ b/apps/web/lib/work-management/case-types.ts
@@ -123,3 +123,22 @@ export interface WorkCaseDetail {
   evidence: readonly unknown[];
   timeline: WorkCaseTimelineEvent[];
 }
+
+// BI-B416B12A (EP-WORK-CONVERGENCE): work-item comment thread projection. A single
+// comment (WorkItemMessage of messageType "comment") flattened for the workspace
+// detail view, with authorship resolved to a viewer-relative label.
+export interface WorkCaseComment {
+  messageId: string;
+  senderLabel: string;
+  body: string;
+  createdAt: string;
+  mine: boolean;
+}
+
+export interface WorkCaseCommentThread {
+  workItemId: string | null;
+  itemPublicId: string | null;
+  messages: WorkCaseComment[];
+  participants: string[];
+  canComment: boolean;
+}

--- a/apps/web/lib/work-management/mention-notify.test.ts
+++ b/apps/web/lib/work-management/mention-notify.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+
+import { buildMentionRoster, mentionNotifyRecipients } from "./mention-notify";
+import { resolveMentions } from "./mentions";
+
+describe("buildMentionRoster", () => {
+  it("keys users by their email local-part, lowercased", () => {
+    const roster = buildMentionRoster([{ id: "u1", email: "Ada.Lovelace@example.com" }], []);
+    expect(roster["ada.lovelace"]).toEqual({ type: "user", id: "u1" });
+  });
+
+  it("keys agents by agentId, slugId, and a normalized display name", () => {
+    const roster = buildMentionRoster(
+      [],
+      [{ id: "a1", agentId: "AgentOne", slugId: "sales-bot", name: "Ada Lovelace (AI)" }],
+    );
+    expect(roster["agentone"]).toEqual({ type: "agent", id: "a1" });
+    expect(roster["sales-bot"]).toEqual({ type: "agent", id: "a1" });
+    expect(roster["ada-lovelace-ai"]).toEqual({ type: "agent", id: "a1" });
+  });
+
+  it("omits the slugId key when the agent has none", () => {
+    const roster = buildMentionRoster(
+      [],
+      [{ id: "a1", agentId: "solo", slugId: null, name: "Solo Agent" }],
+    );
+    expect(roster["solo"]).toEqual({ type: "agent", id: "a1" });
+    expect(roster["solo-agent"]).toEqual({ type: "agent", id: "a1" });
+  });
+
+  it("skips empty / whitespace handles", () => {
+    const roster = buildMentionRoster(
+      [{ id: "u1", email: "@nolocalpart.com" }],
+      [{ id: "a1", agentId: "  ", slugId: "", name: "***" }],
+    );
+    expect(roster).toEqual({});
+  });
+
+  it("does not let a later key overwrite an earlier non-empty one", () => {
+    const roster = buildMentionRoster(
+      [{ id: "u1", email: "ada@example.com" }],
+      // agentId collides with the user's "ada" handle — user (added first) wins.
+      [{ id: "a1", agentId: "ada", slugId: null, name: "Ada" }],
+    );
+    expect(roster["ada"]).toEqual({ type: "user", id: "u1" });
+  });
+});
+
+describe("mentionNotifyRecipients", () => {
+  it("keeps only user targets, deduped, in first-seen order", () => {
+    const recipients = mentionNotifyRecipients([
+      { handle: "ada", type: "user", id: "u1" },
+      { handle: "bot", type: "agent", id: "a1" },
+      { handle: "grace", type: "user", id: "u2" },
+      { handle: "ada2", type: "user", id: "u1" },
+    ]);
+    expect(recipients).toEqual(["u1", "u2"]);
+  });
+
+  it("excludes the commenter", () => {
+    const recipients = mentionNotifyRecipients(
+      [
+        { handle: "ada", type: "user", id: "u1" },
+        { handle: "grace", type: "user", id: "u2" },
+      ],
+      { excludeUserId: "u1" },
+    );
+    expect(recipients).toEqual(["u2"]);
+  });
+
+  it("drops agent targets entirely", () => {
+    const recipients = mentionNotifyRecipients([{ handle: "bot", type: "agent", id: "a1" }]);
+    expect(recipients).toEqual([]);
+  });
+});
+
+describe("body → roster → recipients (end to end)", () => {
+  it("notifies mentioned teammates, excluding the author, ignoring agents and typos", () => {
+    const roster = buildMentionRoster(
+      [
+        { id: "u1", email: "ada@example.com" },
+        { id: "u2", email: "grace@example.com" },
+      ],
+      [{ id: "a1", agentId: "sales-bot", slugId: null, name: "Sales Bot" }],
+    );
+    const body = "Thanks @grace and @sales-bot — cc @ada. @nobody please ignore.";
+    const targets = resolveMentions(body, roster);
+    const recipients = mentionNotifyRecipients(targets, { excludeUserId: "u1" });
+    expect(recipients).toEqual(["u2"]);
+  });
+});

--- a/apps/web/lib/work-management/mention-notify.ts
+++ b/apps/web/lib/work-management/mention-notify.ts
@@ -1,0 +1,79 @@
+// BI-B416B12A (EP-WORK-CONVERGENCE): pure roster-building + recipient-selection
+// for work-item comment @mentions. The @handle parsing/resolution core lives in
+// mentions.ts; this module is the (still DB-free) glue that turns real principals
+// (Users, Agents) into a MentionRoster and turns resolved targets into the set of
+// user ids to notify. Keeping it pure keeps the notification policy unit-testable
+// and independent of Prisma/React.
+
+import type { MentionRoster, MentionTarget } from "./mentions";
+
+/**
+ * Normalize a display name into a mention handle: lowercase, every run of
+ * non-alphanumerics collapses to a single "-", and leading/trailing "-" are
+ * trimmed. e.g. "Ada Lovelace (AI)" → "ada-lovelace-ai".
+ */
+function normalizeNameHandle(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Build a handle→principal roster from real Users and Agents.
+ *
+ * - Each user contributes one key: the email local-part (before "@"), lowercased.
+ * - Each agent contributes up to three keys: its agentId, its slugId (if any), and
+ *   a normalized form of its display name — all lowercased.
+ *
+ * Keys are added in that order; an earlier non-empty key is never overwritten by a
+ * later one (first writer wins). Empty/whitespace handles are skipped. Pure.
+ */
+export function buildMentionRoster(
+  users: { id: string; email: string }[],
+  agents: { id: string; agentId: string; slugId: string | null; name: string }[],
+): MentionRoster {
+  const roster: MentionRoster = {};
+  const put = (rawKey: string, value: { type: "user" | "agent"; id: string }): void => {
+    const key = rawKey.trim().toLowerCase();
+    if (!key) return;
+    if (roster[key]) return; // first writer wins — do not overwrite an earlier non-empty key
+    roster[key] = value;
+  };
+
+  for (const user of users) {
+    const local = (user.email ?? "").split("@")[0] ?? "";
+    put(local, { type: "user", id: user.id });
+  }
+
+  for (const agent of agents) {
+    put(agent.agentId ?? "", { type: "agent", id: agent.id });
+    if (agent.slugId) put(agent.slugId, { type: "agent", id: agent.id });
+    put(normalizeNameHandle(agent.name ?? ""), { type: "agent", id: agent.id });
+  }
+
+  return roster;
+}
+
+/**
+ * Distinct ids of the mention targets that are users, in first-seen order,
+ * excluding `opts.excludeUserId` (the commenter — you don't notify yourself) and
+ * dropping agent targets (an @agent mention doesn't produce a user notification).
+ * Pure.
+ */
+export function mentionNotifyRecipients(
+  targets: MentionTarget[],
+  opts?: { excludeUserId?: string },
+): string[] {
+  const exclude = opts?.excludeUserId;
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const target of targets) {
+    if (target.type !== "user") continue;
+    if (exclude && target.id === exclude) continue;
+    if (seen.has(target.id)) continue;
+    seen.add(target.id);
+    out.push(target.id);
+  }
+  return out;
+}

--- a/apps/web/lib/work-management/workspace-case-loader.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.ts
@@ -1,5 +1,7 @@
 import type {
   WorkCaseA2aStatus,
+  WorkCaseComment,
+  WorkCaseCommentThread,
   WorkCaseSourceRef,
   WorkCaseState,
   WorkCaseTimelineEvent,
@@ -55,6 +57,7 @@ type WorkspaceWorkItemRecord = {
 type WorkspaceWorkItemMessageRecord = {
   messageId: string;
   senderType: string;
+  senderUserId?: string | null;
   messageType: string;
   body: string;
   createdAt: Date | string;
@@ -107,7 +110,35 @@ export type WorkspaceWorkCaseDetailView = {
   summary: WorkspaceWorkCaseListItem;
   evidenceTimeline: WorkCaseTimelineEvent[];
   sourceRefs: WorkCaseSourceRef[];
+  commentThread: WorkCaseCommentThread;
 };
+
+function buildCommentThread(
+  item: { id: string; itemId: string },
+  messages: WorkspaceWorkItemMessageRecord[],
+  userId: string,
+): WorkCaseCommentThread {
+  const comments: WorkCaseComment[] = messages.map((message) => {
+    const mine = message.senderType === "user" && message.senderUserId === userId;
+    const senderLabel =
+      message.senderType === "user" ? (mine ? "You" : "Teammate") : "AI coworker";
+    return {
+      messageId: message.messageId,
+      senderLabel,
+      body: message.body,
+      createdAt: iso(message.createdAt) ?? "",
+      mine,
+    };
+  });
+  const participants = Array.from(new Set(comments.map((comment) => comment.senderLabel)));
+  return {
+    workItemId: item.id,
+    itemPublicId: item.itemId,
+    messages: comments,
+    participants,
+    canComment: true,
+  };
+}
 
 function iso(value: Date | string | null | undefined): string | null {
   if (!value) return null;
@@ -336,5 +367,6 @@ export async function loadWorkspaceWorkCaseDetail({
     summary: toListItem(item, userId, now),
     evidenceTimeline: detail.timeline,
     sourceRefs: detail.summary.sourceRefs,
+    commentThread: buildCommentThread(item, messages, userId),
   };
 }


### PR DESCRIPTION
## What
The deferred **BI-B416B12A** render — the last "wife-test" surface of EP-WORK-CONVERGENCE. A **Discussion** thread on the work-case detail surface where a human or coworker posts durable `WorkItemMessage` comments, and `@mentions` fan out to `Notification` rows through the existing attention spine.

## Changes
- **Pure core** (`lib/work-management/mention-notify.ts`): `buildMentionRoster` (email local-part + agent handles, first-writer-wins) + `mentionNotifyRecipients` (user targets, dedup, exclude self) — DB-free, unit-tested. Reuses the merged parse/resolve core (`mentions.ts`, #2858).
- **Server action** (`lib/actions/work-item-comments.ts`): `postWorkItemComment` creates the `WorkItemMessage`, resolves mentions against a **bounded roster** (assignee + prior senders + all agents), and notifies each mentioned user via `notifyAttentionLive` (source `work-item-mention`). Domain errors are **returned as values** (thrown = stripped in prod).
- **UI** (`components/workspace/WorkItemCommentThread.tsx`): message list + participants presence strip + compose box; rendered after the Evidence timeline in `WorkCaseDetailView`. `commentThread` threaded through the workspace case loader.
- `AttentionSource` gains `"work-item-mention"` (+ exhaustive `SOURCE_LABEL` / `SOURCE_PORTFOLIO` entries).

## Scope notes
- **Presence** is a static participants strip; live cross-actor presence is deferred (needs realtime infra) — flagged in the kernel scope as a split candidate.
- Roster is bounded to plausible participants (assignee, prior senders, all agents) rather than every user — @mentioning a brand-new user is out of scope for v1.

## Verification
- 22 tests green: `mention-notify` (roster + recipients + end-to-end body→roster→recipients), `mentions`, `workspace-case-loader`, `WorkCaseDetailView`.
- `apps/web` tsc clean post-typegen; module-size OK.

**Local-CI-Override:** verified off fresh `origin/main` (22 tests, tsc 0 errors post-typegen, module-size OK). Local-CI `next build` OOMs (env limit); GitHub Production Build authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)