### PR TITLE
feat(work-mgmt): work-item presence primitive (BI-B416B12A)

### DIFF
--- a/apps/web/lib/work-management/work-item-presence-actions.ts
+++ b/apps/web/lib/work-management/work-item-presence-actions.ts
@@ -1,0 +1,51 @@
+"use server";
+
+// BI-B416B12A: heartbeat + read presence for a work item. The client calls
+// heartbeatWorkItemPresence on an interval while the case is open, and
+// getActiveWorkItemPresence to show who else is here. Returns values (never
+// throws to the client). Active-window filtering is the pure filterActivePresence.
+
+import { prisma } from "@dpf/db";
+
+import { auth } from "@/lib/auth";
+import { filterActivePresence, type ActiveViewer } from "./work-item-presence";
+
+export async function heartbeatWorkItemPresence(input: {
+  workItemId: string;
+}): Promise<{ ok: boolean }> {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) return { ok: false };
+
+  const me = await prisma.user.findUnique({ where: { id: userId }, select: { email: true } });
+  const label = me?.email?.split("@")[0] ?? null;
+
+  await prisma.workItemPresence.upsert({
+    where: {
+      workItemId_principalType_principalId: {
+        workItemId: input.workItemId,
+        principalType: "user",
+        principalId: userId,
+      },
+    },
+    create: { workItemId: input.workItemId, principalType: "user", principalId: userId, displayLabel: label },
+    update: { lastSeenAt: new Date(), displayLabel: label },
+  });
+  return { ok: true };
+}
+
+export async function getActiveWorkItemPresence(input: {
+  workItemId: string;
+}): Promise<{ viewers: ActiveViewer[] }> {
+  const session = await auth();
+  const userId = session?.user?.id ?? undefined;
+
+  const rows = await prisma.workItemPresence.findMany({
+    where: { workItemId: input.workItemId },
+    orderBy: { lastSeenAt: "desc" },
+    take: 50,
+  });
+
+  const viewers = filterActivePresence(rows, Date.now(), { excludePrincipalId: userId });
+  return { viewers };
+}

--- a/apps/web/lib/work-management/work-item-presence.test.ts
+++ b/apps/web/lib/work-management/work-item-presence.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { filterActivePresence, PRESENCE_ACTIVE_WINDOW_MS } from "./work-item-presence";
+
+const now = 1_000_000_000_000;
+const at = (msAgo: number) => new Date(now - msAgo);
+
+describe("filterActivePresence (BI-B416B12A)", () => {
+  it("keeps viewers seen within the window and drops stale ones", () => {
+    const active = filterActivePresence(
+      [
+        { principalType: "user", principalId: "u1", displayLabel: "Mark", lastSeenAt: at(1_000) },
+        { principalType: "agent", principalId: "a1", displayLabel: "Ops", lastSeenAt: at(PRESENCE_ACTIVE_WINDOW_MS + 5_000) },
+      ],
+      now,
+    );
+    expect(active.map((v) => v.principalId)).toEqual(["u1"]);
+    expect(active[0]).toMatchObject({ principalType: "user", label: "Mark" });
+  });
+
+  it("excludes the current viewer and dedupes to newest per principal", () => {
+    const active = filterActivePresence(
+      [
+        { principalType: "user", principalId: "u1", displayLabel: "Me", lastSeenAt: at(500) },
+        { principalType: "agent", principalId: "a1", displayLabel: "Ops", lastSeenAt: at(2_000) },
+        { principalType: "agent", principalId: "a1", displayLabel: "Ops", lastSeenAt: at(9_000) },
+      ],
+      now,
+      { excludePrincipalId: "u1" },
+    );
+    expect(active.map((v) => v.principalId)).toEqual(["a1"]);
+  });
+
+  it("falls back to a generic label by principal type", () => {
+    const active = filterActivePresence(
+      [
+        { principalType: "agent", principalId: "a1", displayLabel: null, lastSeenAt: at(100) },
+        { principalType: "user", principalId: "u2", displayLabel: "  ", lastSeenAt: at(100) },
+      ],
+      now,
+    );
+    const labels = Object.fromEntries(active.map((v) => [v.principalId, v.label]));
+    expect(labels).toEqual({ a1: "A coworker", u2: "Someone" });
+  });
+});

--- a/apps/web/lib/work-management/work-item-presence.ts
+++ b/apps/web/lib/work-management/work-item-presence.ts
@@ -1,0 +1,48 @@
+// BI-B416B12A (EP-WORK-CONVERGENCE): presence on a work item — who is currently
+// viewing/working it. Clients heartbeat `lastSeenAt`; "who's active now" is a
+// pure time-window filter over the rows. Kept DB-free and unit-testable; the
+// server action persists heartbeats and reads rows, then calls this.
+
+export const PRESENCE_ACTIVE_WINDOW_MS = 45_000;
+
+export interface PresenceRow {
+  principalType: string;
+  principalId: string;
+  displayLabel?: string | null;
+  lastSeenAt: Date;
+}
+
+export interface ActiveViewer {
+  principalType: string;
+  principalId: string;
+  label: string;
+}
+
+/**
+ * Return the viewers seen within the active window, newest-first, one per
+ * principal. `excludePrincipalId` drops the current viewer (you don't show
+ * yourself as "also here"). Pure.
+ */
+export function filterActivePresence(
+  rows: PresenceRow[],
+  nowMs: number,
+  options?: { windowMs?: number; excludePrincipalId?: string },
+): ActiveViewer[] {
+  const windowMs = options?.windowMs ?? PRESENCE_ACTIVE_WINDOW_MS;
+  const seen = new Set<string>();
+  return rows
+    .filter((row) => nowMs - row.lastSeenAt.getTime() <= windowMs)
+    .filter((row) => row.principalId !== options?.excludePrincipalId)
+    .sort((a, b) => b.lastSeenAt.getTime() - a.lastSeenAt.getTime())
+    .filter((row) => {
+      const key = `${row.principalType}:${row.principalId}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .map((row) => ({
+      principalType: row.principalType,
+      principalId: row.principalId,
+      label: row.displayLabel?.trim() || (row.principalType === "agent" ? "A coworker" : "Someone"),
+    }));
+}

--- a/docs/superpowers/plans/2026-07-14-bi-b416b12a-presence.md
+++ b/docs/superpowers/plans/2026-07-14-bi-b416b12a-presence.md
@@ -1,0 +1,17 @@
+# Implementation Plan — BI-B416B12A: work-item presence
+
+**BI:** BI-B416B12A (EP-WORK-CONVERGENCE) · **Date:** 2026-07-14 · **Status:** presence substrate + read implemented; live subscription UI deferred.
+
+## Design grounding
+Source of truth: convergence memo §6.6 (collaboration primitives: threaded comments + @mention + presence). Substrate check: no WorkItemPresence primitive existed. This adds the last collaboration primitive.
+
+## This slice
+- schema: `WorkItemPresence` (workItemId FK, principalType, principalId, displayLabel, lastSeenAt; unique per (item, principal); indexed by (workItemId, lastSeenAt)). Additive data-safe migration.
+- `apps/web/lib/work-management/work-item-presence.ts` — pure `filterActivePresence(rows, nowMs)`: who's active within the 45s window, deduped, self-excluded, generic-label fallback.
+- `apps/web/lib/work-management/work-item-presence-actions.ts` — `"use server"` heartbeat (upsert lastSeenAt) + read (findMany → filter). Returns values, never throws.
+
+## Verification
+- Unit tests on the pure filter (window, exclude-self, dedupe, label fallback). Typecheck, migration-safety, module-size.
+
+## Deferred (portal-dependent)
+The live presence indicator UI (heartbeat interval + poll on the case surface) and the live spouse-test — need the running portal to build against and observe.

--- a/packages/db/prisma/migrations/20260714170000_add_work_item_presence/migration.sql
+++ b/packages/db/prisma/migrations/20260714170000_add_work_item_presence/migration.sql
@@ -1,0 +1,19 @@
+-- @migration-safety: data-safe: new table WorkItemPresence + its index/unique/FK only. No changes to existing tables, no drops, no data backfill.
+-- BI-B416B12A: work-item presence.
+
+-- CreateTable
+CREATE TABLE "WorkItemPresence" (
+    "id" TEXT NOT NULL,
+    "workItemId" TEXT NOT NULL,
+    "principalType" TEXT NOT NULL,
+    "principalId" TEXT NOT NULL,
+    "displayLabel" TEXT,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "WorkItemPresence_pkey" PRIMARY KEY ("id")
+);
+-- CreateIndex
+CREATE INDEX "WorkItemPresence_workItemId_lastSeenAt_idx" ON "WorkItemPresence"("workItemId", "lastSeenAt");
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkItemPresence_workItemId_principalType_principalId_key" ON "WorkItemPresence"("workItemId", "principalType", "principalId");
+-- AddForeignKey
+ALTER TABLE "WorkItemPresence" ADD CONSTRAINT "WorkItemPresence_workItemId_fkey" FOREIGN KEY ("workItemId") REFERENCES "WorkItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -10578,6 +10578,7 @@ model WorkItem {
   childItems        WorkItem[]        @relation("WorkItemHierarchy")
   a2aTaskId         String?
   messages          WorkItemMessage[]
+  presence          WorkItemPresence[]
   routingDecision   Json?
   completedAt       DateTime?
   createdAt         DateTime          @default(now())
@@ -10613,6 +10614,23 @@ model WorkItemMessage {
 
   @@index([workItemId, createdAt])
   @@index([senderUserId])
+}
+
+// BI-B416B12A (EP-WORK-CONVERGENCE): lightweight presence on a work item — who
+// (human or coworker) is currently viewing/working it. Heartbeated on lastSeenAt;
+// "active" is a time-window read (see filterActivePresence). One row per
+// (workItem, principal); the client heartbeats, the read filters by recency.
+model WorkItemPresence {
+  id            String   @id @default(cuid())
+  workItemId    String
+  workItem      WorkItem @relation(fields: [workItemId], references: [id], onDelete: Cascade)
+  principalType String
+  principalId   String
+  displayLabel  String?
+  lastSeenAt    DateTime @default(now())
+
+  @@unique([workItemId, principalType, principalId])
+  @@index([workItemId, lastSeenAt])
 }
 
 model WorkSchedule {


### PR DESCRIPTION
## What
Adds the last collaboration primitive from the convergence memo (§6.6): **presence** — who (human or coworker) is currently viewing/working a work item.

- schema: `WorkItemPresence` (additive, data-safe migration).
- `work-item-presence.ts` — pure `filterActivePresence` (45s window, dedupe, self-exclude, label fallback).
- `work-item-presence-actions.ts` — `"use server"` heartbeat (upsert lastSeenAt) + read.

## Verification
- Pure-filter unit tests; typecheck clean; migration-safety + module-size ok.
- **Deferred (portal):** the live presence-indicator UI (heartbeat interval + poll) and the spouse-test.


**Local-CI-Override:** verified locally; local-CI next build OOM (env); GitHub CI authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Design-Grounding-Decision: design-sensitive files apps/web/lib/work-management/work-item-presence.ts and apps/web/lib/work-management/work-item-presence-actions.ts add the presence primitive; source of truth = convergence memo §6.6 (collaboration primitives). Substrate verified: no WorkItemPresence existed.