### PR TITLE
fix(pattern-observer): don't assert tool-surface overload from an execution-derived surface (BI-98D17D0B)

### DIFF
--- a/apps/web/lib/tak/pattern-observer/classifiers.test.ts
+++ b/apps/web/lib/tak/pattern-observer/classifiers.test.ts
@@ -195,6 +195,37 @@ describe("pattern observer classifiers", () => {
         severity: "important",
       });
     });
+
+    // BI-98D17D0B: an execution-derived surface (periodic-review fallback) omits
+    // the attached-but-uncalled read baseline, so it is not a valid basis for an
+    // overload assertion — the classifier must suppress every zone when the
+    // surface does not reflect the attached set.
+    it("suppresses overload/caution when the surface does not reflect the attached set", () => {
+      const degraded: ToolSelectionAccuracy = { total: 10, succeeded: 6, accuracy: 0.6, perTool: {} };
+      // Even a would-be degraded-selection proxy overload is suppressed…
+      expect(classifyToolSurfaceOverload(proxyOverload, degraded, false)).toBeNull();
+      // …and a would-be window-known overload is suppressed…
+      const knownOverload: ToolSurfaceAssessment = {
+        toolCount: 40, estDefinitionTokens: 9000, exceedsLocalCliff: true, windowShare: 0.4, zone: "overload",
+      };
+      expect(classifyToolSurfaceOverload(knownOverload, null, false)).toBeNull();
+      // …and a caution surface is suppressed too.
+      expect(
+        classifyToolSurfaceOverload(
+          { toolCount: 12, estDefinitionTokens: 2200, exceedsLocalCliff: false, windowShare: 0.16, zone: "caution" },
+          null,
+          false,
+        ),
+      ).toBeNull();
+    });
+
+    it("still fires for a real attached surface (surfaceReflectsAttached defaults true)", () => {
+      const degraded: ToolSelectionAccuracy = { total: 10, succeeded: 6, accuracy: 0.6, perTool: {} };
+      expect(classifyToolSurfaceOverload(proxyOverload, degraded, true)).toMatchObject({
+        kind: "tool",
+        severity: "important",
+      });
+    });
   });
 
   describe("classifyRepeatedSuccess", () => {

--- a/apps/web/lib/tak/pattern-observer/classifiers.ts
+++ b/apps/web/lib/tak/pattern-observer/classifiers.ts
@@ -98,8 +98,25 @@ function selectionIsDegraded(selection?: ToolSelectionAccuracy | null): boolean 
 export function classifyToolSurfaceOverload(
   assessment: ToolSurfaceAssessment,
   selection?: ToolSelectionAccuracy | null,
+  /**
+   * True when `assessment` was computed from the surface the runtime actually
+   * ATTACHED (baseline + grants). False when it was reconstructed from executed
+   * tools (the periodic-review fallback), which structurally omits every
+   * attached-but-uncalled tool — including the ~68-tool read baseline — and so
+   * is not a valid basis for an overload assertion (BI-98D17D0B). Defaults true
+   * for callers that always pass a real attached surface.
+   */
+  surfaceReflectsAttached: boolean = true,
 ): CoworkerCapabilityNeedInput | null {
   const windowKnown = assessment.windowShare !== null;
+
+  // An execution-derived surface omits the attached-but-uncalled baseline, so
+  // its toolCount/definition-token estimate understates the real surface. Never
+  // assert overload (or caution) from it — the count is measured against the
+  // wrong denominator. Evidence-before-diagnosis: assess overload only from the
+  // attached surface (BI-98D17D0B). The window-share path needs a live window
+  // too, which the executions fallback never carries.
+  if (!surfaceReflectsAttached) return null;
 
   // Two overload regimes, only one of which is self-evidently real:
   //  • window KNOWN and definitions crowd it (zone === "overload") — mechanistic

--- a/apps/web/lib/tak/pattern-observer/observer.test.ts
+++ b/apps/web/lib/tak/pattern-observer/observer.test.ts
@@ -228,6 +228,33 @@ describe("observeCoworkerPatterns", () => {
     });
   });
 
+  it("does NOT assert tool-surface overload from an execution-derived surface (BI-98D17D0B)", async () => {
+    // Periodic-review path: no toolSurface passed, so the observer reconstructs
+    // it from executed tools. Even 18 distinct calls with degraded selection —
+    // which would trip the count-proxy overload — must NOT fire, because the
+    // execution-derived surface omits the ~68-tool attached read baseline and is
+    // not a valid basis for an overload assertion.
+    const execs = Array.from({ length: 18 }, (_, i) =>
+      toolExecution({ toolName: `called_tool_${i}`, success: i % 3 !== 0 }),
+    );
+    const deps = makeDeps({ toolExecutions: execs });
+
+    await observeCoworkerPatterns(
+      { agentId: "agent-build", routeContext: "/build" /* no toolSurface, no window */ },
+      deps,
+    );
+
+    const submit = vi.mocked(deps.submitCoworkerSelfAssessment);
+    if (submit.mock.calls.length > 0) {
+      const needs = submit.mock.calls[0]?.[0]?.needs ?? [];
+      expect(
+        needs.some((n) => n.evidenceJson?.classifier === "tool-surface-overload"),
+      ).toBe(false);
+    }
+    // (No overload candidate ⇒ possibly no assessment submitted at all — both are
+    // acceptable; the invariant is simply that no tool-surface-overload need fires.)
+  });
+
   it("submits a code or convention need for a repeated successful manual workflow", async () => {
     const deps = makeDeps({
       taskRuns: [

--- a/apps/web/lib/tak/pattern-observer/observer.ts
+++ b/apps/web/lib/tak/pattern-observer/observer.ts
@@ -510,6 +510,14 @@ export async function observeCoworkerPatterns(
     loadTaskRuns(input, window, resolved),
   ]);
 
+  // BI-98D17D0B: an explicitly-provided surface reflects the tools the runtime
+  // actually ATTACHED (baseline + grants). The executions fallback reconstructs
+  // the surface from tools that were CALLED — it structurally omits every
+  // attached-but-uncalled tool, including the ~68-tool read baseline the runtime
+  // always attaches. Overload is a property of the ATTACHED surface, so the
+  // classifier must know which it is looking at and never assert overload from
+  // the incomplete execution-derived view.
+  const surfaceReflectsAttached = input.toolSurface != null;
   const toolSurface = input.toolSurface ?? toolSurfaceFromExecutions(toolExecutions);
   const toolSurfaceAssessment = resolved.assessToolSurface({
     tools: toolSurface,
@@ -522,8 +530,13 @@ export async function observeCoworkerPatterns(
   const grantCandidates = classifyGrantDenials(toolExecutions);
   // Pass observed tool-selection accuracy so a count-proxy overload (window
   // unknown, surface past the local cliff) is only asserted when selection is
-  // actually degrading — not on the raw count alone (BI-3346DC28).
-  const toolSurfaceNeed = classifyToolSurfaceOverload(toolSurfaceAssessment, toolSelectionAccuracy);
+  // actually degrading — not on the raw count alone (BI-3346DC28) — and pass
+  // whether the surface reflects the true attached set (BI-98D17D0B).
+  const toolSurfaceNeed = classifyToolSurfaceOverload(
+    toolSurfaceAssessment,
+    toolSelectionAccuracy,
+    surfaceReflectsAttached,
+  );
   const toolSurfaceCandidates: CandidateNeed[] = toolSurfaceNeed
     ? [{ classifier: "tool-surface-overload", need: toolSurfaceNeed }]
     : [];


### PR DESCRIPTION
## Don't assert tool-surface overload from an execution-derived surface (BI-98D17D0B)

The BI has two facets. **Facet 1** ("classifier fires unconditionally: cliff 15 < read-baseline ~68") was fixed by [#2683](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2683) (BI-3346DC28) ~1 hour after this BI was filed — the classifier now gates the count-proxy overload on demonstrably-degraded selection and prefers the real window-share when known. **Facet 2** ("assessed surface omits the baseline the runtime includes") remained and is what this PR fixes.

### The bug (facet 2)
The periodic-review path (`periodic-review.ts:202`) calls `observeCoworkerPatterns` with **no `toolSurface`**, so the observer reconstructs the surface from **executed** tools (`toolSurfaceFromExecutions`). That structurally omits every attached-but-uncalled tool — including the ~68-tool `COWORKER_READ_BASELINE` the runtime always attaches — so an overload assessment computed from it measures the count against the wrong denominator. Asserting overload from an incomplete surface is exactly the evidence-free diagnosis the classifier is meant to avoid.

### Fix
- The observer threads `surfaceReflectsAttached` (true only when the caller passes the real attached surface — e.g. the autonomous path's `toolsForProvider`) into `classifyToolSurfaceOverload`.
- When the surface is **execution-derived**, the classifier **suppresses** the overload/caution need entirely — assess overload only from the true attached surface.
- The autonomous path is unaffected (it already passes the real attached surface). Regression tests added at both the classifier and observer level.

### Out of scope (noted on the BI)
Threading the active model's context window into the autonomous observer (to light up the `knownOverload` window-crowding signal, currently dead there because the window is omitted), and optionally reconstructing the true attached surface for periodic review so it *can* validly detect overload.

### Verification
Worktree typecheck green; pattern-observer + context-economy suites **33/33**; local-CI pregate green.

## Design grounding
- **Searched substrate:** traced the classifier pipeline — `apps/web/lib/tak/pattern-observer/observer.ts` (surface derivation), `classifiers.ts` (`classifyToolSurfaceOverload`), `context-economy-metrics.ts` (`assessToolSurface`), and the two callers (`autonomous-work-run.ts`, `periodic-review.ts`).
- **Source of truth:** the pattern-observer classifier + BI-3346DC28's prior evidence-gating fix (#2683). No spec governs this internal observability classifier.
- **Decision:** extend the existing classifier's evidence-gating; no new contract or routing change.

Design-Grounding-Decision: existing specs/plans reviewed (none govern this internal observability classifier; searched docs/superpowers) and current code substrate reviewed (apps/web/lib/tak/pattern-observer/observer.ts, classifiers.ts, context-economy-metrics.ts) plus BI-3346DC28's prior fix (#2683); extends the existing classifier's evidence-gating, no new contract or routing change.
<!-- grounding evidence refreshed -->
