### PR TITLE
feat(work-mgmt): work-item comment thread UI + @mention server action (EP-WORK-CONVERGENCE, BI-B416B12A)

### DIFF
--- a/apps/web/components/workspace/WorkCaseDetailView.test.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.test.tsx
@@ -1,5 +1,12 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+vi.mock("@/lib/actions/work-item-comments", () => ({
+  postWorkItemCommentAction: vi.fn(),
+}));
 
 import { WorkCaseDetailView } from "./WorkCaseDetailView";
 import type { WorkspaceWorkCaseDetailView } from "@/lib/work-management/workspace-case-loader";
@@ -39,6 +46,28 @@ const detail: WorkspaceWorkCaseDetailView = {
     { kind: "source", id: "BK-1", sourceType: "booking" },
     { kind: "work-item", id: "WI-1", status: "awaiting-input" },
   ],
+  commentThread: {
+    workItemId: "row-1",
+    itemPublicId: "WI-1",
+    canComment: true,
+    participants: ["You", "AI coworker"],
+    messages: [
+      {
+        messageId: "WIM-1",
+        senderLabel: "AI coworker",
+        body: "Need a human confirmation before booking.",
+        createdAt: "2026-06-28T10:10:00.000Z",
+        mine: false,
+      },
+      {
+        messageId: "WIM-2",
+        senderLabel: "You",
+        body: "On it — calling the customer now.",
+        createdAt: "2026-06-28T10:20:00.000Z",
+        mine: true,
+      },
+    ],
+  },
 };
 
 describe("WorkCaseDetailView", () => {
@@ -55,6 +84,20 @@ describe("WorkCaseDetailView", () => {
 
     expect(html).toContain('href="/workspace/my-queue"');
     expect(html).not.toContain("/ops");
+  });
+
+  it("renders the discussion thread with messages and a compose control", () => {
+    const html = renderToStaticMarkup(<WorkCaseDetailView detail={detail} />);
+
+    expect(html).toContain("Discussion");
+    expect(html).toContain("Need a human confirmation before booking.");
+    expect(html).toContain("On it — calling the customer now.");
+    expect(html).toContain("In this thread:");
+    expect(html).toContain("Post comment");
+    expect(html).toContain("Use @name to notify a teammate.");
+    // Discussion sits after the evidence timeline, before source refs.
+    expect(html.indexOf("Evidence timeline")).toBeLessThan(html.indexOf("Discussion"));
+    expect(html.indexOf("Discussion")).toBeLessThan(html.indexOf("Source refs"));
   });
 
   it("uses DPF theme tokens", () => {

--- a/apps/web/components/workspace/WorkCaseDetailView.tsx
+++ b/apps/web/components/workspace/WorkCaseDetailView.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, Clock, FileText, ShieldCheck } from "lucide-react";
 
 import { LocalTime } from "@/components/ui/LocalTime";
+import { WorkItemCommentThread } from "@/components/workspace/WorkItemCommentThread";
 import { StatusBadge } from "@/components/ui/report-kit";
 import type { Intent } from "@/components/ui/report-kit/statusColors";
 import type { WorkspaceWorkCaseDetailView } from "@/lib/work-management/workspace-case-loader";
@@ -104,6 +105,8 @@ export function WorkCaseDetailView({ detail }: Props) {
           </div>
         )}
       </section>
+
+      <WorkItemCommentThread thread={detail.commentThread} />
 
       <section aria-labelledby="work-case-source-title" className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
         <div className="flex items-center gap-2">

--- a/apps/web/components/workspace/WorkItemCommentThread.tsx
+++ b/apps/web/components/workspace/WorkItemCommentThread.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+// BI-B416B12A (EP-WORK-CONVERGENCE): the Discussion surface for a Work Case.
+// Reads the projected commentThread view model and posts new comments through
+// the postWorkItemCommentAction "use server" wrapper (which returns domain
+// failures as values — we render its error text rather than throwing).
+
+import { MessageSquare } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+import { postWorkItemCommentAction } from "@/lib/actions/work-item-comments";
+import type { WorkItemCommentThread } from "@/lib/work-management/workspace-case-loader";
+
+type Props = {
+  thread: WorkItemCommentThread;
+};
+
+const ERROR_COPY: Record<string, string> = {
+  unauthorized: "Sign in to post a comment.",
+  empty: "Write a comment before posting.",
+  not_found: "This work item is no longer available.",
+  failed: "Could not post your comment. Try again.",
+};
+
+function errorCopy(error: string): string {
+  return ERROR_COPY[error] ?? "Could not post your comment. Try again.";
+}
+
+export function WorkItemCommentThread({ thread }: Props) {
+  const router = useRouter();
+  const [body, setBody] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = body.trim();
+  const disabled = !thread.canComment || !thread.workItemId || trimmed.length === 0 || pending;
+
+  async function handlePost() {
+    if (!thread.workItemId || trimmed.length === 0) return;
+    setPending(true);
+    setError(null);
+    try {
+      const result = await postWorkItemCommentAction({ workItemId: thread.workItemId, body: trimmed });
+      if (result.ok) {
+        setBody("");
+        router.refresh();
+      } else {
+        setError(errorCopy(result.error));
+      }
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby="work-case-discussion-title"
+      className="overflow-hidden rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+    >
+      <div className="flex items-center gap-2 border-b border-[var(--dpf-border)] px-4 py-3">
+        <MessageSquare className="size-4 text-[var(--dpf-accent)]" aria-hidden="true" />
+        <h2 id="work-case-discussion-title" className="text-sm font-semibold text-[var(--dpf-text)]">
+          Discussion
+        </h2>
+      </div>
+
+      {thread.participants.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-2 border-b border-[var(--dpf-border)] px-4 py-2 text-xs text-[var(--dpf-muted)]">
+          <span className="font-medium">In this thread:</span>
+          {thread.participants.map((participant) => (
+            <span
+              key={participant}
+              className="inline-flex items-center gap-1 rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-0.5 text-[var(--dpf-text)]"
+            >
+              <span className="size-1.5 rounded-full bg-[var(--dpf-success)]" aria-hidden="true" />
+              {participant}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {thread.messages.length > 0 ? (
+        <ol className="divide-y divide-[var(--dpf-border)]">
+          {thread.messages.map((message) => (
+            <li key={message.messageId} className="px-4 py-3">
+              <div className="flex items-baseline justify-between gap-2">
+                <p className="text-sm font-semibold text-[var(--dpf-text)]">{message.senderLabel}</p>
+                {message.createdAt ? (
+                  <span className="text-xs text-[var(--dpf-muted)]">
+                    <LocalTime value={message.createdAt} mode="datetime" />
+                  </span>
+                ) : null}
+              </div>
+              <p className="mt-1 whitespace-pre-wrap text-sm leading-6 text-[var(--dpf-text)]">{message.body}</p>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <div className="px-4 py-6 text-sm text-[var(--dpf-muted)]">
+          No comments yet. Start the discussion below.
+        </div>
+      )}
+
+      <div className="space-y-2 border-t border-[var(--dpf-border)] px-4 py-3">
+        <label htmlFor="work-case-comment-body" className="sr-only">
+          Add a comment
+        </label>
+        <textarea
+          id="work-case-comment-body"
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          rows={3}
+          disabled={!thread.canComment || !thread.workItemId || pending}
+          placeholder="Add a comment…"
+          className="w-full resize-y rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)]"
+        />
+        {error ? <p className="text-xs text-[var(--dpf-error)]">{error}</p> : null}
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs text-[var(--dpf-muted)]">Use @name to notify a teammate.</p>
+          <button
+            type="button"
+            onClick={handlePost}
+            disabled={disabled}
+            className="inline-flex items-center rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-accent)] px-3 py-1.5 text-sm font-medium text-[var(--dpf-on-accent,white)] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {pending ? "Posting…" : "Post comment"}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/lib/actions/work-item-comments.test.ts
+++ b/apps/web/lib/actions/work-item-comments.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    workItem: { findUnique: vi.fn() },
+    agent: { findMany: vi.fn() },
+    workItemMessage: { findMany: vi.fn(), create: vi.fn() },
+    user: { findMany: vi.fn() },
+    notification: { create: vi.fn() },
+  },
+}));
+
+import { auth } from "@/lib/auth";
+import { prisma } from "@dpf/db";
+
+import { postWorkItemCommentAction } from "./work-item-comments";
+
+const mockAuth = auth as unknown as ReturnType<typeof vi.fn>;
+const db = prisma as unknown as {
+  workItem: { findUnique: ReturnType<typeof vi.fn> };
+  agent: { findMany: ReturnType<typeof vi.fn> };
+  workItemMessage: { findMany: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> };
+  user: { findMany: ReturnType<typeof vi.fn> };
+  notification: { create: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.mockResolvedValue({ user: { id: "user-1" } });
+  db.workItem.findUnique.mockResolvedValue({
+    id: "row-1",
+    itemId: "WI-1",
+    title: "Confirm condenser appointment",
+    assignedToUserId: "user-2",
+  });
+  db.agent.findMany.mockResolvedValue([]);
+  db.workItemMessage.findMany.mockResolvedValue([]);
+  db.user.findMany.mockResolvedValue([
+    { id: "user-1", email: "alice@example.com" },
+    { id: "user-2", email: "bob@example.com" },
+  ]);
+  db.workItemMessage.create.mockResolvedValue({ messageId: "WIM-99" });
+  db.notification.create.mockResolvedValue({});
+});
+
+describe("postWorkItemCommentAction", () => {
+  it("returns unauthorized when there is no session user", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const result = await postWorkItemCommentAction({ workItemId: "row-1", body: "hi" });
+
+    expect(result).toEqual({ ok: false, error: "unauthorized" });
+    expect(db.workItem.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns empty when the trimmed body is blank", async () => {
+    const result = await postWorkItemCommentAction({ workItemId: "row-1", body: "   " });
+
+    expect(result).toEqual({ ok: false, error: "empty" });
+  });
+
+  it("returns not_found when the work item is missing", async () => {
+    db.workItem.findUnique.mockResolvedValue(null);
+
+    const result = await postWorkItemCommentAction({ workItemId: "missing", body: "hello" });
+
+    expect(result).toEqual({ ok: false, error: "not_found" });
+  });
+
+  it("posts the comment and fans a notification out to a mentioned teammate", async () => {
+    const result = await postWorkItemCommentAction({ workItemId: "row-1", body: "hey @bob please look" });
+
+    expect(result).toEqual({ ok: true, messageId: "WIM-99", notified: 1 });
+    expect(db.workItemMessage.create).toHaveBeenCalledTimes(1);
+    const createArg = db.workItemMessage.create.mock.calls[0][0].data;
+    expect(createArg).toMatchObject({ workItemId: "row-1", senderType: "user", senderUserId: "user-1", body: "hey @bob please look" });
+    expect(db.notification.create).toHaveBeenCalledTimes(1);
+    expect(db.notification.create.mock.calls[0][0].data.userId).toBe("user-2");
+  });
+
+  it("does not notify the author for self-mentions and returns zero notified", async () => {
+    const result = await postWorkItemCommentAction({ workItemId: "row-1", body: "note to self @alice" });
+
+    expect(result).toEqual({ ok: true, messageId: "WIM-99", notified: 0 });
+    expect(db.notification.create).not.toHaveBeenCalled();
+  });
+
+  it("returns failed instead of throwing when a DB call rejects", async () => {
+    db.workItemMessage.create.mockRejectedValue(new Error("db down"));
+
+    const result = await postWorkItemCommentAction({ workItemId: "row-1", body: "hello" });
+
+    expect(result).toEqual({ ok: false, error: "failed" });
+  });
+});

--- a/apps/web/lib/actions/work-item-comments.ts
+++ b/apps/web/lib/actions/work-item-comments.ts
@@ -1,0 +1,83 @@
+"use server";
+
+// BI-B416B12A (EP-WORK-CONVERGENCE): the "use server" wrapper that assembles the
+// real @mention roster from the DB and calls the pure comment write path
+// (postWorkItemComment). Domain failures are RETURNED as values, never thrown —
+// Next.js strips thrown errors in production, so a thrown error would surface to
+// the client as a generic opaque message with no actionable text.
+
+import { prisma } from "@dpf/db";
+
+import { auth } from "@/lib/auth";
+import { buildMentionRoster } from "@/lib/work-management/mention-roster";
+import { postWorkItemComment } from "@/lib/work-management/post-work-item-comment";
+
+export type PostWorkItemCommentResult =
+  | { ok: true; messageId: string; notified: number }
+  | { ok: false; error: string };
+
+export async function postWorkItemCommentAction(input: {
+  workItemId: string;
+  body: string;
+}): Promise<PostWorkItemCommentResult> {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) return { ok: false, error: "unauthorized" };
+
+  const trimmed = input.body.trim();
+  if (!trimmed) return { ok: false, error: "empty" };
+
+  try {
+    const item = await prisma.workItem.findUnique({
+      where: { id: input.workItemId },
+      select: { id: true, itemId: true, title: true, assignedToUserId: true },
+    });
+    if (!item) return { ok: false, error: "not_found" };
+
+    // Coworkers: every agent is addressable via @handle.
+    const agents = await prisma.agent.findMany({
+      select: { agentId: true, name: true, slugId: true },
+    });
+    const coworkers = agents.map((agent) => ({
+      agentId: agent.agentId,
+      name: agent.name,
+      displayName: agent.slugId,
+    }));
+
+    // Humans: bound to this item's principals (assignee, commenter, prior
+    // senders) — the User table has no @handle field, so we resolve a small,
+    // relevant set rather than every user in the org.
+    const priorSenders = await prisma.workItemMessage.findMany({
+      where: { workItemId: item.id },
+      select: { senderUserId: true },
+    });
+    const userIds = new Set<string>([userId]);
+    if (item.assignedToUserId) userIds.add(item.assignedToUserId);
+    for (const sender of priorSenders) {
+      if (sender.senderUserId) userIds.add(sender.senderUserId);
+    }
+    const userRows = await prisma.user.findMany({
+      where: { id: { in: [...userIds] } },
+      select: { id: true, email: true },
+    });
+    const users = userRows.map((user) => ({ id: user.id, email: user.email, name: null }));
+
+    const roster = buildMentionRoster({ coworkers, users });
+
+    const commenterEmail = userRows.find((user) => user.id === userId)?.email ?? "";
+    const label = commenterEmail.split("@")[0] || "someone";
+
+    const result = await postWorkItemComment({
+      db: prisma,
+      workItemId: item.id,
+      workItemTitle: item.title,
+      body: trimmed,
+      sender: { type: "user", id: userId, label },
+      roster,
+    });
+
+    return { ok: true, messageId: result.messageId, notified: result.notifiedUserIds.length };
+  } catch {
+    return { ok: false, error: "failed" };
+  }
+}

--- a/apps/web/lib/work-management/workspace-case-loader.test.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.test.ts
@@ -105,4 +105,26 @@ describe("workspace Work Case loader", () => {
     ]);
     expect(detail?.sourceRefs.map((ref) => ref.kind)).toContain("work-item");
   });
+
+  it("projects the comment thread view model from work-item messages", async () => {
+    const detail = await loadWorkspaceWorkCaseDetail({
+      prismaClient: prismaFor([baseItem]),
+      caseKey: "booking%3ABK-1",
+      userId: "user-1",
+    });
+
+    expect(detail?.commentThread.workItemId).toBe("row-1");
+    expect(detail?.commentThread.itemPublicId).toBe("WI-1");
+    expect(detail?.commentThread.canComment).toBe(true);
+    expect(detail?.commentThread.messages).toEqual([
+      {
+        messageId: "WIM-1",
+        senderLabel: "AI coworker",
+        body: "Need a human confirmation before booking.",
+        createdAt: "2026-06-28T10:10:00.000Z",
+        mine: false,
+      },
+    ]);
+    expect(detail?.commentThread.participants).toEqual(["AI coworker"]);
+  });
 });

--- a/apps/web/lib/work-management/workspace-case-loader.ts
+++ b/apps/web/lib/work-management/workspace-case-loader.ts
@@ -55,6 +55,7 @@ type WorkspaceWorkItemRecord = {
 type WorkspaceWorkItemMessageRecord = {
   messageId: string;
   senderType: string;
+  senderUserId?: string | null;
   messageType: string;
   body: string;
   createdAt: Date | string;
@@ -103,10 +104,35 @@ export type WorkspaceWorkCaseLensView = {
   cases: WorkspaceWorkCaseListItem[];
 };
 
+export type WorkItemCommentThreadMessage = {
+  messageId: string;
+  senderLabel: string;
+  body: string;
+  createdAt: string;
+  mine: boolean;
+};
+
+export type WorkItemCommentThread = {
+  workItemId: string | null;
+  itemPublicId: string | null;
+  canComment: boolean;
+  participants: string[];
+  messages: WorkItemCommentThreadMessage[];
+};
+
+export const EMPTY_COMMENT_THREAD: WorkItemCommentThread = {
+  workItemId: null,
+  itemPublicId: null,
+  canComment: false,
+  participants: [],
+  messages: [],
+};
+
 export type WorkspaceWorkCaseDetailView = {
   summary: WorkspaceWorkCaseListItem;
   evidenceTimeline: WorkCaseTimelineEvent[];
   sourceRefs: WorkCaseSourceRef[];
+  commentThread: WorkItemCommentThread;
 };
 
 function iso(value: Date | string | null | undefined): string | null {
@@ -332,9 +358,31 @@ export async function loadWorkspaceWorkCaseDetail({
     evidence,
   });
 
+  const threadMessages: WorkItemCommentThreadMessage[] = messages.map((message) => {
+    const mine = message.senderUserId != null && message.senderUserId === userId;
+    const senderLabel = message.senderType === "user"
+      ? (message.senderUserId === userId ? "You" : "Teammate")
+      : "AI coworker";
+    return {
+      messageId: message.messageId,
+      senderLabel,
+      body: message.body,
+      createdAt: iso(message.createdAt) ?? "",
+      mine,
+    };
+  });
+  const participants = [...new Set(threadMessages.map((message) => message.senderLabel))];
+
   return {
     summary: toListItem(item, userId, now),
     evidenceTimeline: detail.timeline,
     sourceRefs: detail.summary.sourceRefs,
+    commentThread: {
+      workItemId: item.id,
+      itemPublicId: item.itemId,
+      canComment: true,
+      participants,
+      messages: threadMessages,
+    },
   };
 }


### PR DESCRIPTION
## What
Completes the deferred **BI-B416B12A** "wife-test" surface on top of the merged write-path core (#2950). #2950 shipped the pure `postWorkItemComment` fan-out + `buildMentionRoster` but **no server-action entry point and no UI** — this adds both, reusing #2950's core verbatim (no duplication).

## Changes
- **Server action** `postWorkItemCommentAction` (`"use server"`): auth → load WorkItem → assemble roster (all agents + bounded user set: assignee + prior senders + commenter) via `buildMentionRoster` → call the pure `postWorkItemComment({ db: prisma, … })`. Domain errors **returned as values** (thrown = stripped in prod).
- **UI** `WorkItemCommentThread.tsx`: participants presence strip + message list + compose box wired to the action (`router.refresh()` on success); rendered after the Evidence timeline in `WorkCaseDetailView`.
- **Loader**: `workspace-case-loader` projects `commentThread` (messages + participants + itemId) from the already-loaded `WorkItemMessage`s onto `WorkspaceWorkCaseDetailView`.

## Verification
- 14 tests green: action (auth/empty/not_found/happy-path fan-out/self-mention-skip/db-error), detail view (Discussion renders), loader (commentThread projection).
- `apps/web` tsc clean post-typegen; module-size OK.
- **Live-validated** the write-path against the live DB earlier this session: a comment with `@lauragbodman` created the `WorkItemMessage` and a real unread `Notification` for that user via the merged fan-out; loader→thread render validated on the `:3001` Contributor preview.

**Local-CI-Override:** verified off fresh `origin/main` (14 tests, tsc 0 errors post-typegen, module-size OK). Local-CI `next build` OOMs (env limit); GitHub Production Build authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)