### PR TITLE
fix(inference): unify chat + local build engine onto ONE local-GPU admission lane (BI-98572A51)

### DIFF
--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -40,6 +40,7 @@ import { recordBuildDispatchAttempt } from "@/lib/build/dispatch-attempts";
 import { sanitizeForLog } from "@/lib/security/safe-log";
 import { resolveBuildWorkdir } from "./sandbox/build-branch";
 import { classifyProviderCapacity } from "@/lib/routing/provider-capacity";
+import { withLocalInferenceLock } from "@/lib/queue/resource-lane";
 import { recordProviderCapacityStatus } from "@/lib/routing/provider-capacity/store";
 
 const DEFAULT_SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
@@ -566,19 +567,29 @@ export async function dispatchOpencodeTask(params: {
     // STDOUT (its `--format json` event stream) rather than stderr — wire that
     // through onStdoutChunk; the stderr buffer is captured by the loop and
     // attached to any rejection for the catch block below.
-    const { stdout, durationMs: elapsed } = await runSandboxAgentCli({
-      containerId,
-      runnerScript,
-      timeoutMs,
-      asNodeUser: true,
-      onStdoutChunk: (chunk) => {
-        // --format json streams events; surface tool/file actions as progress.
-        for (const line of chunk.split("\n")) {
-          const msg = summarizeOpencodeEvent(line);
-          if (msg) params.onProgress?.(msg);
-        }
-      },
-    });
+    //
+    // BI-98572A51: opencode runs the model on the ONE local GPU. Acquire the SAME
+    // single-slot admission lane the coworker chat path uses (withLocalInferenceLock),
+    // held for the whole CLI run, so a chat local call and a build specialist (or
+    // two concurrent builds) never collide on the GPU. The portal owns admission
+    // in both cases — it awaits this docker-exec — so one in-process lane serializes
+    // them. The orchestrator's per-build MAX_CONCURRENT_TASKS=1 only serialized
+    // within a single build; this closes the chat↔build and build↔build gap.
+    const { stdout, durationMs: elapsed } = await withLocalInferenceLock(() =>
+      runSandboxAgentCli({
+        containerId,
+        runnerScript,
+        timeoutMs,
+        asNodeUser: true,
+        onStdoutChunk: (chunk) => {
+          // --format json streams events; surface tool/file actions as progress.
+          for (const line of chunk.split("\n")) {
+            const msg = summarizeOpencodeEvent(line);
+            if (msg) params.onProgress?.(msg);
+          }
+        },
+      }),
+    );
 
     const content = extractOpencodeResult(stdout);
 

--- a/apps/web/lib/queue/resource-lane.test.ts
+++ b/apps/web/lib/queue/resource-lane.test.ts
@@ -4,6 +4,8 @@ import {
   LaneBusyError,
   getResourceLane,
   localInferenceMaxQueueDepth,
+  withLocalInferenceLock,
+  LOCAL_INFERENCE_LANE_KEY,
 } from "./resource-lane";
 import type { QueueTransitionInput } from "./queue-telemetry";
 
@@ -159,5 +161,38 @@ describe("localInferenceMaxQueueDepth", () => {
     process.env[KEY] = "abc";
     expect(localInferenceMaxQueueDepth()).toBeNull();
     delete process.env[KEY];
+  });
+});
+
+describe("withLocalInferenceLock — the ONE local-GPU admission gate (BI-98572A51)", () => {
+  it("serializes concurrent local-inference callers strictly one at a time", async () => {
+    // Simulates chat and a build specialist both wanting the single GPU: only
+    // one runs at a time, the other waits — never double-subscribed.
+    let active = 0;
+    let maxActive = 0;
+    const gate = deferred<void>();
+    const run = () =>
+      withLocalInferenceLock(async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await gate.promise;
+        active--;
+        return "ok";
+      });
+    const a = run(); // "chat"
+    const b = run(); // "build specialist"
+    // Both scheduled, but only one may be inside the lane.
+    await Promise.resolve();
+    expect(maxActive).toBe(1);
+    gate.resolve();
+    await expect(a).resolves.toBe("ok");
+    await expect(b).resolves.toBe("ok");
+    expect(maxActive).toBe(1);
+  });
+
+  it("acquires the canonical LOCAL_INFERENCE_LANE_KEY singleton (chat + build share it)", () => {
+    // getResourceLane is one-lane-per-key, so every caller of withLocalInferenceLock —
+    // chat-adapter and opencode-dispatch alike — operates the same instance.
+    expect(getResourceLane(LOCAL_INFERENCE_LANE_KEY)).toBe(getResourceLane(LOCAL_INFERENCE_LANE_KEY));
   });
 });

--- a/apps/web/lib/queue/resource-lane.ts
+++ b/apps/web/lib/queue/resource-lane.ts
@@ -175,3 +175,29 @@ export function localInferenceMaxQueueDepth(): number | null {
   const n = Number(raw);
   return Number.isInteger(n) && n > 0 ? n : null;
 }
+
+// The single local GPU (Docker Model Runner / Ollama) serves ONE request at a
+// time. BI-98572A51: chat inference and the local (opencode) build engine each
+// hit that one GPU, and both admission points run in the PORTAL process (chat
+// makes the HTTP call; the build orchestrator spawns AND awaits the sandbox CLI
+// for its whole run). They must share ONE admission gate or they collide/OOM —
+// so the canonical `withLocalInferenceLock` lives HERE, beside the lane key, and
+// BOTH callers import it. Defining it here (not in chat-adapter) makes the lane
+// singleton's telemetry deps independent of which caller loads first.
+const localInferenceLane = getResourceLane(LOCAL_INFERENCE_LANE_KEY, {
+  record: (input: QueueTransitionInput) => {
+    // Only emit on the hot inference path when an operator has opted into
+    // managing the lane — avoids per-inference DB writes in the default config.
+    if (localInferenceMaxQueueDepth() == null) return;
+    void import("./queue-telemetry").then(({ recordQueueTransition }) => {
+      void recordQueueTransition(input);
+    });
+  },
+});
+
+/** Run `fn` under the single-slot local-GPU admission lane. The one gate every
+ *  local-inference caller (chat + build) must acquire so the single GPU is
+ *  never double-subscribed (BI-98572A51). */
+export function withLocalInferenceLock<T>(fn: () => Promise<T>): Promise<T> {
+  return localInferenceLane.run(fn, { maxQueueDepth: localInferenceMaxQueueDepth() });
+}

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -26,12 +26,10 @@ import {
 import { isAnthropic } from "./provider-utils";
 import { registerExecutionAdapter } from "./execution-adapter-registry";
 import { extractToolCalls as extractTextualToolUse } from "./extract-tool-calls";
-import {
-  getResourceLane,
-  LOCAL_INFERENCE_LANE_KEY,
-  localInferenceMaxQueueDepth,
-} from "@/lib/queue/resource-lane";
-import type { QueueTransitionInput } from "@/lib/queue/queue-telemetry";
+// BI-98572A51: the single-GPU admission lane is canonical in resource-lane.ts so
+// chat AND the local build engine share ONE gate. Re-exported below for callers
+// (and tests) that import it from here.
+import { withLocalInferenceLock } from "@/lib/queue/resource-lane";
 import { buildAnthropicSystem } from "./anthropic-cache";
 
 // ─── Inference HTTP timeouts ──────────────────────────────────────────────────
@@ -65,20 +63,10 @@ function resolveInferenceTimeoutMs(providerId: string): number {
 // pile up and time out while waiting), and flow telemetry so lane wait/process
 // time is measurable. Both are gated on that env: UNSET ⇒ unbounded serialize with
 // no telemetry writes, byte-for-byte the prior behavior.
-const localInferenceLane = getResourceLane(LOCAL_INFERENCE_LANE_KEY, {
-  record: (input: QueueTransitionInput) => {
-    // Only emit on the hot inference path when an operator has opted into managing
-    // the lane — avoids per-inference DB writes in the default configuration.
-    if (localInferenceMaxQueueDepth() == null) return;
-    void import("@/lib/queue/queue-telemetry").then(({ recordQueueTransition }) => {
-      void recordQueueTransition(input);
-    });
-  },
-});
-
-export function withLocalInferenceLock<T>(fn: () => Promise<T>): Promise<T> {
-  return localInferenceLane.run(fn, { maxQueueDepth: localInferenceMaxQueueDepth() });
-}
+// Canonical home is resource-lane.ts (shared with the local build engine,
+// BI-98572A51); re-exported so existing importers/tests of this module are
+// unaffected.
+export { withLocalInferenceLock };
 
 // ─── Gemini part types ───────────────────────────────────────────────────────
 

--- a/docs/superpowers/plans/2026-07-14-unify-local-gpu-admission.md
+++ b/docs/superpowers/plans/2026-07-14-unify-local-gpu-admission.md
@@ -1,0 +1,25 @@
+# Plan — Unify the two local-GPU serializers behind one admission gate (BI-98572A51)
+
+**Kernel decision (2026-07-14, external_coding_agent, high confidence 10.91):** `unified-inprocess-lane` — route the local build engine through the *same* in-process `ResourceLane` chat uses, over a cross-process DB lease or a bounded fast-fail-to-cloud variant.
+
+## Problem
+The single local GPU (DMR/Ollama) serves one request at a time, but two independent gates guard it:
+- **Chat:** `withLocalInferenceLock` (the `compute:local-inference` `ResourceLane`, concurrency-1) in the portal — applied at `chat-adapter.ts` for `providerId === "local"`.
+- **Build (opencode local engine):** serialized *only* by the orchestrator's per-build `MAX_CONCURRENT_TASKS = 1` loop (`build-orchestrator.ts`, BI-0F291741).
+
+They don't share a gate, so chat + a build specialist (or two concurrent builds) each admit a local-GPU request → collision/OOM/timeout. The code already documents the gap (`build-orchestrator.ts:1267`).
+
+## Why in-process suffices (process-boundary analysis)
+Although opencode inference *executes* in the `dpf-sandbox-1` container, **admission is controlled by the portal in both paths**: chat makes the HTTP call; the orchestrator spawns *and awaits* the `docker exec` for the CLI's whole run. DPF deploys a single portal container, so one in-process serial-1 lane held around both the chat call and the awaited docker-exec serializes all local-GPU admission (chat + build + concurrent builds). A cross-process DB lease is only required for a multi-portal deployment — deferred (noted below).
+
+## Changes
+1. `queue/resource-lane.ts` — make it the **canonical home** of `withLocalInferenceLock` (beside `LOCAL_INFERENCE_LANE_KEY`), so the lane singleton's telemetry deps are independent of which caller loads first.
+2. `routing/chat-adapter.ts` — import + re-export `withLocalInferenceLock` from resource-lane (removes the duplicate local definition; existing importers/tests unaffected).
+3. `integrate/opencode-dispatch.ts` — wrap the awaited `runSandboxAgentCli(...)` (the held-open local CLI run) in `withLocalInferenceLock`, so every local build inference acquires the same lane as chat.
+4. Tests — `resource-lane.test.ts` asserts `withLocalInferenceLock` serializes concurrent callers strictly one-at-a-time and returns the one keyed singleton (chat + build share it); existing `chat-adapter.test.ts` lane test continues to pass via the re-export.
+
+## Deferred (noted, not this BI)
+A cross-process admission lease (pg_advisory_lock on the endpoint, or `nonProductionEnvironmentLease` keyed `local-gpu:<endpoint>`) for a future multi-portal/replica deployment; and, if chat blocking behind a 30-min local build proves painful, the bounded-queue fast-fail-to-cloud variant (set `DPF_LOCAL_INFERENCE_MAX_QUEUE_DEPTH` — the lane already supports `LaneBusyError`, which the fallback chain can route to cloud).
+
+## Verification
+Worktree typecheck green; `resource-lane` + `chat-adapter` lane suites green (14/14 + 2/2). Local-CI pregate for the merged gate.


### PR DESCRIPTION
## Unify chat + local build engine onto ONE local-GPU admission lane (BI-98572A51)

The single local GPU (DMR/Ollama) serves one request at a time, but two independent gates guarded it: chat used the in-process `withLocalInferenceLock` `ResourceLane` (concurrency-1); the local (opencode) **build** engine was serialized *only* by the orchestrator's per-build `MAX_CONCURRENT_TASKS = 1` loop (BI-0F291741). They didn't compose — so chat + a build specialist, **or two concurrent builds**, each admitted a local-GPU request and collided (OOM/timeout). The gap was already documented in `build-orchestrator.ts:1267`.

### Why an in-process lane is the right fix (kernel-decided)
Admission is **portal-controlled in both paths** — chat makes the HTTP call; the orchestrator spawns *and awaits* the sandbox `docker exec` for the CLI's whole run — and DPF deploys a single portal container. So one in-process serial-1 lane serializes all local-GPU admission. Kernel (2026-07-14, high confidence 10.91) chose `unified-inprocess-lane` over a cross-process DB lease.

### Changes
- `queue/resource-lane.ts` becomes the **canonical home** of `withLocalInferenceLock` (beside `LOCAL_INFERENCE_LANE_KEY`), so the lane singleton's telemetry deps don't depend on caller load order.
- `routing/chat-adapter.ts` imports + re-exports it (removes the duplicate definition; existing importers/tests unaffected).
- `integrate/opencode-dispatch.ts` wraps the awaited `runSandboxAgentCli(...)` — the held-open local CLI run — in the same lane.
- `resource-lane.test.ts` asserts strict one-at-a-time serialization and one shared keyed singleton (chat + build).

### Deferred (plan §Deferred)
A cross-process admission lease for a future multi-portal deployment; and, if chat blocking behind a long local build proves painful, the bounded-queue fast-fail-to-cloud variant (the lane already supports `LaneBusyError`).

### Verification
Worktree typecheck green; `resource-lane` **14/14** + `chat-adapter` lane test **2/2**; local-CI pregate green. Plan: `docs/superpowers/plans/2026-07-14-unify-local-gpu-admission.md`.

## Design grounding
Traced the two gates — `chat-adapter.ts` (`withLocalInferenceLock`), `build-orchestrator.ts` (`MAX_CONCURRENT_TASKS`), `opencode-dispatch.ts` (the awaited sandbox CLI), `queue/resource-lane.ts` (the shared primitive). Source of truth: the `compute:local-inference` `ResourceLane`. Decision: extend it to both callers; no new contract.

Design-Grounding-Decision: existing specs/plans reviewed (docs/superpowers/plans/2026-07-14-unify-local-gpu-admission.md written) and current code substrate reviewed (apps/web/lib/queue/resource-lane.ts, apps/web/lib/routing/chat-adapter.ts, apps/web/lib/integrate/opencode-dispatch.ts, apps/web/lib/integrate/build-orchestrator.ts); extends the existing ResourceLane primitive, no new contract.
Process-Spine-Decision: plan docs/superpowers/plans/2026-07-14-unify-local-gpu-admission.md added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
