### PR TITLE
fix(scheduler): idempotent claim before running a scheduled agent task — no double dispatch (BI-D1CD3A11)

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler-proactivity.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler-proactivity.test.ts
@@ -11,9 +11,11 @@ const mocks = vi.hoisted(() => ({
       findMany: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
     scheduledJob: {
       update: vi.fn(),
+      updateMany: vi.fn(),
       upsert: vi.fn(),
     },
     agentThread: {
@@ -103,6 +105,10 @@ const FIXED_NOW = new Date(2026, 6, 12, 9, 0, 0, 0);
 
 beforeEach(() => {
   vi.resetAllMocks();
+  // BI-D1CD3A11: the idempotent claim runs before execution; default to a WON
+  // claim so these plan-behavior tests exercise the work.
+  mocks.prisma.scheduledAgentTask.updateMany.mockResolvedValue({ count: 1 });
+  mocks.prisma.scheduledJob.updateMany.mockResolvedValue({ count: 1 });
   vi.useFakeTimers({ toFake: ["Date"] });
   vi.setSystemTime(FIXED_NOW);
 });

--- a/apps/web/lib/actions/agent-task-scheduler.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.test.ts
@@ -8,9 +8,11 @@ const mocks = vi.hoisted(() => ({
       findMany: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
     scheduledJob: {
       update: vi.fn(),
+      updateMany: vi.fn(),
       upsert: vi.fn(),
     },
     agentThread: {
@@ -95,6 +97,11 @@ import {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  // BI-D1CD3A11: the idempotent claim (updateMany) runs before execution;
+  // default to a WON claim so existing tests exercise the work. Per-test
+  // overrides simulate losing the claim.
+  mocks.prisma.scheduledAgentTask.updateMany.mockResolvedValue({ count: 1 });
+  mocks.prisma.scheduledJob.updateMany.mockResolvedValue({ count: 1 });
 });
 
 describe("extractDiscoveryTriageSummary", () => {
@@ -489,6 +496,37 @@ describe("executeScheduledAgentTask — coworker self-task model + required-tool
     await executeScheduledAgentTask("self-marketing-specialist-user-1");
 
     expect(mocks.governedExecuteTool).not.toHaveBeenCalled();
+  });
+});
+
+describe("executeScheduledAgentTask idempotent claim (BI-D1CD3A11)", () => {
+  it("advances nextRunAt via a guarded claim BEFORE running the work", async () => {
+    arrangeScheduledTask();
+    mocks.runAgenticLoop.mockResolvedValue({ content: "Done.", executedTools: [] });
+
+    await executeScheduledAgentTask("discovery-taxonomy-gap-triage-daily");
+
+    // The claim updateMany fired, guarded on the task still being due…
+    const claim = mocks.prisma.scheduledAgentTask.updateMany.mock.calls[0]?.[0];
+    expect(claim?.where).toMatchObject({ taskId: "discovery-taxonomy-gap-triage-daily", isActive: true });
+    expect(claim?.where?.nextRunAt?.lte).toBeInstanceOf(Date);
+    expect(claim?.data?.nextRunAt).toBeInstanceOf(Date);
+    // …and it happened BEFORE the agentic loop ran.
+    expect(mocks.prisma.scheduledAgentTask.updateMany.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.runAgenticLoop.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does NOT run the work when the claim is lost (a concurrent dispatch already claimed it)", async () => {
+    arrangeScheduledTask();
+    // The other dispatcher won the race → our guarded update matches 0 rows.
+    mocks.prisma.scheduledAgentTask.updateMany.mockResolvedValue({ count: 0 });
+
+    await executeScheduledAgentTask("discovery-taxonomy-gap-triage-daily");
+
+    // No double execution: the agentic loop and TaskRun creation never happen.
+    expect(mocks.runAgenticLoop).not.toHaveBeenCalled();
+    expect(mocks.prisma.taskRun.create).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/actions/agent-task-scheduler.ts
+++ b/apps/web/lib/actions/agent-task-scheduler.ts
@@ -107,6 +107,38 @@ export async function executeScheduledAgentTask(taskId: string): Promise<void> {
   });
   if (!task || !task.isActive) return;
 
+  // BI-D1CD3A11: idempotent claim BEFORE execution. The 5-min dispatch poll
+  // selects every task whose nextRunAt is due; an agent run routinely exceeds
+  // 5 minutes, so without advancing nextRunAt first the NEXT poll re-selects the
+  // still-running task and dispatches it a SECOND time (duplicate autonomous
+  // runs, doubled spend, racing writes). Atomically move nextRunAt forward here,
+  // guarded on it still being due — exactly ONE caller wins the claim; a
+  // concurrent poll (or an Inngest step retry) that loses gets count 0 and
+  // returns without re-running. The per-branch post-run updates below refine
+  // lastRunAt/lastStatus (and re-stamp the same nextRunAt) once work completes.
+  {
+    const claimNow = new Date();
+    // Mirror the terminal scheduling the post-run branches apply: a one-shot
+    // ("Once") task deactivates instead of re-arming (BI-D72CC945); a recurring
+    // task advances to its next cron time.
+    const oneShot = isOneShotCron(task.schedule);
+    const claimedNextRunAt = oneShot ? null : computeNextCronRun(task.schedule, claimNow);
+    const claim = await prisma.scheduledAgentTask.updateMany({
+      where: { taskId, isActive: true, nextRunAt: { lte: claimNow } },
+      data: oneShot ? { nextRunAt: null, isActive: false } : { nextRunAt: claimedNextRunAt },
+    });
+    if (claim.count === 0) {
+      // Already claimed by another dispatch of this due tick, or no longer due.
+      return;
+    }
+    await prisma.scheduledJob
+      .updateMany({
+        where: { jobId: taskId },
+        data: oneShot ? { nextRunAt: null } : { nextRunAt: claimedNextRunAt },
+      })
+      .catch(() => {});
+  }
+
   // EP-DATA-ARCH Phase 6: the data-model mirror is deterministic — run it
   // directly instead of through the LLM agentic loop.
   if (task.taskId === DATA_MODEL_MIRROR_TASK_ID) {

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -17,7 +17,7 @@ apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1341
 apps/web/lib/actions/agent-coworker-external.test.ts	867
 apps/web/lib/actions/agent-coworker.ts	2761
-apps/web/lib/actions/agent-task-scheduler.test.ts	1083
+apps/web/lib/actions/agent-task-scheduler.test.ts	1121
 apps/web/lib/actions/ai-providers.ts	915
 apps/web/lib/actions/build-governed.test.ts	1134
 apps/web/lib/actions/build.ts	1805


### PR DESCRIPTION
## Idempotent claim before a scheduled agent task runs (BI-D1CD3A11)

`executeScheduledAgentTask` advanced `nextRunAt` only **after** the work finished. The 5-min dispatch poll selects every task with `nextRunAt <= now`, and an autonomous agent run routinely exceeds 5 minutes — so the next poll re-selected the still-running task and dispatched it a **second** time (duplicate runs, doubled spend, racing writes).

### Fix
An **atomic claim** at the top of `executeScheduledAgentTask`: advance `nextRunAt` (recurring) or deactivate (one-shot, mirroring the post-run branches) via a **guarded `updateMany`** that matches only while the task is still due. Exactly one caller wins; a concurrent poll or Inngest step-retry that loses gets `count 0` and returns **without** re-running. `find-due` filters `isActive + nextRunAt<=now`, so the claim removes the task from the due set immediately. Per-branch post-run updates still refine `lastRunAt`/`lastStatus`.

### Verification
Worktree typecheck green; scheduler + proactivity suites **30/30** (new claim-before-execute + lost-claim-skips-work regressions); local-CI pregate green.

Design-Grounding-Decision: existing specs/plans reviewed (none govern this internal scheduler) and current code substrate reviewed (apps/web/lib/actions/agent-task-scheduler.ts, apps/web/lib/queue/functions/agent-task-dispatch.ts); extends the existing scheduled-task execution flow, no new contract.
Process-Spine-Decision: a claim-before-execute guard on an existing scheduler function with regression tests; no new capability/route/contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)