### PR TITLE
fix(eval): claim the GPU eval slot before running — stop the lease-error retry storm re-burning the local GPU (BI-C8164664)

### DIFF
--- a/apps/web/lib/queue/functions/eval-background.test.ts
+++ b/apps/web/lib/queue/functions/eval-background.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prisma: {
+    scheduledJob: {
+      updateMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@dpf/db", () => ({ prisma: mocks.prisma }));
+// The Inngest client pulls in the whole queue graph at import; stub it.
+vi.mock("../inngest-client", () => ({ inngest: { createFunction: () => ({}) } }));
+vi.mock("../quiescence-gates", () => ({ gateAtEntry: vi.fn() }));
+
+import { claimEvalSlot } from "./eval-background";
+
+const NOW = new Date("2026-07-14T12:00:00.000Z");
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("claimEvalSlot (BI-C8164664)", () => {
+  it("wins the claim when the last eval attempt is older than the cooldown (or none)", async () => {
+    mocks.prisma.scheduledJob.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(claimEvalSlot("local/qwen", NOW)).resolves.toBe(true);
+
+    const where = mocks.prisma.scheduledJob.updateMany.mock.calls[0]?.[0]?.where;
+    expect(where?.jobId).toBe("eval-local/qwen");
+    // Recency guard: claim only when lastRunAt is stale or unset.
+    expect(where?.OR).toEqual([
+      { lastRunAt: { lt: expect.any(Date) } },
+      { lastRunAt: null },
+    ]);
+    expect(mocks.prisma.scheduledJob.create).not.toHaveBeenCalled();
+  });
+
+  it("LOSES the claim (skips GPU work) for a storm re-invocation within the cooldown", async () => {
+    // updateMany matched 0 rows (a fresh lastRunAt exists) and the row is present.
+    mocks.prisma.scheduledJob.updateMany.mockResolvedValue({ count: 0 });
+    mocks.prisma.scheduledJob.findUnique.mockResolvedValue({ jobId: "eval-local/qwen" });
+
+    await expect(claimEvalSlot("local/qwen", NOW)).resolves.toBe(false);
+    expect(mocks.prisma.scheduledJob.create).not.toHaveBeenCalled();
+  });
+
+  it("creates and claims the slot on the first-ever eval for a model", async () => {
+    mocks.prisma.scheduledJob.updateMany.mockResolvedValue({ count: 0 });
+    mocks.prisma.scheduledJob.findUnique.mockResolvedValue(null);
+    mocks.prisma.scheduledJob.create.mockResolvedValue({});
+
+    await expect(claimEvalSlot("local/new-model", NOW)).resolves.toBe(true);
+    expect(mocks.prisma.scheduledJob.create).toHaveBeenCalledOnce();
+    expect(mocks.prisma.scheduledJob.create.mock.calls[0]?.[0]?.data).toMatchObject({
+      jobId: "eval-local/new-model",
+      lastStatus: "running",
+      lastRunAt: NOW,
+    });
+  });
+});

--- a/apps/web/lib/queue/functions/eval-background.ts
+++ b/apps/web/lib/queue/functions/eval-background.ts
@@ -9,6 +9,49 @@
 import { inngest } from "../inngest-client";
 import { gateAtEntry } from "../quiescence-gates";
 
+// BI-C8164664: how long a "running" eval slot blocks a duplicate GPU eval for
+// the same model. runDimensionEval already skips when the model was EVALUATED
+// (lastEvalAt) within its own cooldown — but lastEvalAt is stamped only on a
+// SUCCESSFUL run, so an Inngest lease error that re-invokes the function BEFORE
+// completion never trips that guard and the GPU eval runs again and again (the
+// observed "burns the local GPU" storm). This slot claim is stamped BEFORE the
+// GPU work on the eval-background ScheduledJob (not lastEvalAt — that keeps its
+// "last successful eval" meaning for the routing/calibration signal), so a
+// storm re-invocation sees a recent "running" slot and skips. Override with
+// DPF_EVAL_SLOT_COOLDOWN_MS; must comfortably exceed one eval's duration.
+const EVAL_SLOT_COOLDOWN_MS = (() => {
+  const raw = Number(process.env.DPF_EVAL_SLOT_COOLDOWN_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 20 * 60_000;
+})();
+
+/** Atomically claim the GPU eval slot for a model before running it. Recency-
+ *  based: the claim wins only when the last eval attempt for this model is older
+ *  than the cooldown (or there is none). A retry/lease-storm re-invocation
+ *  within the window loses (count 0) and the caller skips the GPU work. Keyed on
+ *  the eval-<modelId> ScheduledJob's lastRunAt — NOT ModelProfile.lastEvalAt,
+ *  which must keep meaning "last SUCCESSFUL eval" for the calibration signal.
+ *  The stamp self-heals: it ages out after the cooldown, so a genuinely-next
+ *  eval proceeds. Exported for testing. */
+export async function claimEvalSlot(modelId: string, now: Date = new Date()): Promise<boolean> {
+  const { prisma } = await import("@dpf/db");
+  const jobId = `eval-${modelId}`;
+  const cutoff = new Date(now.getTime() - EVAL_SLOT_COOLDOWN_MS);
+  const claimed = await prisma.scheduledJob.updateMany({
+    where: { jobId, OR: [{ lastRunAt: { lt: cutoff } }, { lastRunAt: null }] },
+    data: { lastRunAt: now },
+  });
+  if (claimed.count > 0) return true;
+  // No row yet (first-ever eval for this model) → create and claim it.
+  const existing = await prisma.scheduledJob.findUnique({ where: { jobId }, select: { jobId: true } });
+  if (existing) return false; // row exists with a fresh lastRunAt → claim lost.
+  await prisma.scheduledJob
+    .create({
+      data: { jobId, name: `Eval: ${modelId}`, schedule: "manual", lastStatus: "running", lastRunAt: now, nextRunAt: null },
+    })
+    .catch(() => {});
+  return true;
+}
+
 /**
  * Background dimension eval for a single model.
  * Triggered by the "Run Eval" button on ModelCard / RoutingProfilePanel.
@@ -25,6 +68,20 @@ export const evalBackground = inngest.createFunction(
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
 
     const { endpointId, modelId, userId, force } = event.data;
+
+    // BI-C8164664: claim the GPU eval slot BEFORE the work. A retry/lease-storm
+    // re-invocation within the cooldown loses the claim and skips, so the GPU is
+    // not re-burned. Operator-forced runs bypass the slot (they also bypass the
+    // recency cooldown inside runDimensionEval).
+    if (force !== true) {
+      const claimed = await step.run("claim-eval-slot", async () => {
+        const { claimEvalSlot } = await import("./eval-background");
+        return claimEvalSlot(modelId);
+      });
+      if (!claimed) {
+        return { skipped: true, reason: "eval-slot-busy" };
+      }
+    }
 
     const result = await step.run("run-dimension-eval", async () => {
       const { runDimensionEval } = await import("@/lib/routing/eval-runner");


### PR DESCRIPTION
## Stop the lease-error retry storm re-burning the local GPU (BI-C8164664)

`runDimensionEval` already skips when a model was **evaluated** within a recency cooldown — but that guard keys on `ModelProfile.lastEvalAt`, which is stamped only after a **successful** eval. An Inngest lease error that re-invokes `evalBackground` **before** completion never trips it, so the GPU dimension eval runs again and again (the observed 'burns the local GPU' storm).

`lastEvalAt` can't be stamped early — it also feeds the *is this model calibrated* routing signal (`provider-routing-rollup.ts`), and a migration for a separate attempt field is the highest-risk change type.

### Fix (migration-free)
A recency-based **slot claim** on the `eval-<modelId>` `ScheduledJob`, stamped **before** the GPU work: a storm re-invocation within the cooldown loses the claim (`updateMany` count 0) and skips. Self-heals (the stamp ages out after the cooldown) and operator-forced runs bypass it — matching the existing `runDimensionEval` cooldown's intent.

### Verification
Worktree typecheck green; new `eval-background` claim tests **3/3** (win / lose-on-storm / first-ever-create); local-CI pregate green.

Design-Grounding-Decision: existing specs/plans reviewed (none govern this internal eval runner) and current code substrate reviewed (apps/web/lib/queue/functions/eval-background.ts, apps/web/lib/routing/eval-runner.ts, apps/web/lib/inference/provider-routing-rollup.ts); extends the existing eval-cooldown mitigation, no new contract or schema.
Process-Spine-Decision: a recency claim-before-execute guard on an existing Inngest function with tests; migration-free, no new capability/route/contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)