### PR TITLE
fix(observability): stop log-signature scanner from filing its own outbound-request logs as errors (BI-PIR-5cc5bb56)

### DIFF
--- a/apps/web/lib/observability/log-signature.test.ts
+++ b/apps/web/lib/observability/log-signature.test.ts
@@ -39,6 +39,25 @@ describe("isErrorLine", () => {
     expect(isErrorLine("")).toBe(false);
     expect(isErrorLine("request completed in 12ms")).toBe(false);
   });
+
+  it("rejects the responses-adapter self-referential outbound-request noise", () => {
+    // The adapter logs its own outbound AI request; when the portal files a PIR
+    // through the AI the body echoes a prior report, so "Error" trips ERROR_TOKEN
+    // and the scanner would file a fresh PIR for its own request (self-loop).
+    expect(
+      isErrorLine(
+        '[responses-adapter] REQUEST to https://chatgpt.com/backend-api/codex/responses | model=gpt-5.4 | tools=0 [none] | stream=true | input=[{"role":"user","content":"Error Report PIR-Y8EA8: New error signature..."}]',
+      ),
+    ).toBe(false);
+    // Plain outbound request line (no echoed report) is likewise not an error.
+    expect(
+      isErrorLine("[responses-adapter] REQUEST to https://chatgpt.com/backend-api/codex/responses | model=gpt-5.4 | stream=true"),
+    ).toBe(false);
+    // Benign OpenAI Responses API SSE start event.
+    expect(isErrorLine('data: {"type":"response.created","response":{"id":"resp_123"}}')).toBe(false);
+    // A genuine error that merely mentions the adapter must still cluster.
+    expect(isErrorLine("[responses-adapter] Error: upstream returned 500 for codex/responses")).toBe(true);
+  });
 });
 
 describe("toTemplate", () => {

--- a/apps/web/lib/observability/log-signature.ts
+++ b/apps/web/lib/observability/log-signature.ts
@@ -37,12 +37,25 @@ const SELF_NOISE = /has timestamp too old|final error sending batch|loki\.write/
 const INFO_DEBUG = /level=(info|debug)\b|"level":\s*"(info|debug)"/i;
 // A whole-word error token, NOT a substring of ErrorCode / ErrorMessage.
 const ERROR_TOKEN = /\b(error|fatal|panic|exception|traceback)\b/i;
+// The responses-adapter logs its OWN outbound AI requests (and streamed SSE
+// events) via console.log with no level= marker, so INFO_DEBUG can't catch
+// them. Two of these are benign but trip ERROR_TOKEN:
+//   1. `[responses-adapter] REQUEST to ...` outbound-request lines — never an
+//      application error, they are the request being sent.
+//   2. When the portal files a PlatformIssueReport THROUGH the AI, that outbound
+//      request body echoes the prior report ("Error Report PIR-..."), so
+//      ERROR_TOKEN matches "Error" and the scanner files a fresh PIR for its own
+//      request — a self-referential loop that generated thousands of duplicate
+//      signatures. `response.created` is the benign OpenAI Responses API SSE
+//      start event, likewise not an error.
+const OUTBOUND_REQUEST_NOISE = /\[responses-adapter\]\s+REQUEST|Error Report PIR-|\bresponse\.created\b/i;
 
 /** True when a line is a genuine error worth clustering (not info/debug/self-noise). */
 export function isErrorLine(line: string): boolean {
   if (!line) return false;
   if (SELF_NOISE.test(line)) return false;
   if (INFO_DEBUG.test(line)) return false;
+  if (OUTBOUND_REQUEST_NOISE.test(line)) return false;
   return ERROR_TOKEN.test(line);
 }
 


### PR DESCRIPTION
## Problem

The `log-signature-scanner` (EP-FULL-OBS Tier 2) treated the portal's own `[responses-adapter] REQUEST` outbound-AI-request log lines as brand-new error signatures. Because those lines are emitted via `console.log` with no `level=` marker, `INFO_DEBUG` couldn't filter them, and `ERROR_TOKEN` matched the word **"Error"** — most damagingly when the portal files a `PlatformIssueReport` **through** the AI and the outbound request body echoes the prior report (`"Error Report PIR-…"`).

The result was a **self-referential loop**: the scanner filed a fresh PIR for its own outbound request, which then appeared in logs, which got scanned again. This generated **thousands of duplicate occurrences and hundreds of near-identical `BI-PIR-*` backlog items** (the canonical signature had ~2,900 merged occurrences).

## Fix

Add an `OUTBOUND_REQUEST_NOISE` exclusion in `isErrorLine()` (`apps/web/lib/observability/log-signature.ts`) for:
- `[responses-adapter] REQUEST` outbound-request lines,
- `Error Report PIR-` echoed report bodies,
- `response.created` benign OpenAI Responses API SSE start events.

Genuine adapter errors (e.g. `[responses-adapter] Error: upstream returned 500`) still cluster normally.

## Verification

- Added a regression test (`log-signature.test.ts`) covering all four cases (3 noise variants excluded + 1 genuine error still clustered).
- Functionally exercised the exact `isErrorLine` logic against the sample lines — all pass, no regression on existing cases.
- Local scoped typecheck was skipped (source-only worktree has no `node_modules`); CI runs the authoritative typecheck + unit tests.

Fixes `BI-PIR-5cc5bb56`. This is the root cause of the large auto-detected PIR noise wave cleaned up in the backlog triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)