### PR TITLE
fix(build): count ideate/plan builds as in-flight so fleet/queue counters aren't 0 while active (BI-5939B62F)

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -1558,7 +1558,14 @@ function FleetRailZone({
   const [showCompleted, setShowCompleted] = useState(false);
   const [showAllFocus, setShowAllFocus] = useState(false);
 
-  const counts = deriveFleetCounts(focusEntries.map((e) => e.queueState));
+  // BI-5939B62F: a build can be BOTH needs-attention and running (e.g. a plan
+  // build with a failed review — its phase now derives to "running"). Such a
+  // build belongs in the "Needs you" bucket only; deriving working/waiting over
+  // the non-attention entries keeps it from being double-counted as "Working"
+  // (blockedCount below already applies the same !needsAttention guard).
+  const counts = deriveFleetCounts(
+    focusEntries.filter((e) => !e.needsAttention).map((e) => e.queueState),
+  );
   const parkedItemCount = parkedEntries.length + parkedEpicRollups.length;
   const needsYouCount =
     focusEntries.filter((entry) => entry.needsAttention).length

--- a/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
+++ b/apps/web/components/build/BuildStudioDetailsDrawer.test.tsx
@@ -289,7 +289,14 @@ describe("BuildStudio DetailsDrawer integration", () => {
       <BuildStudio
         builds={[
           makeBuild({ buildId: "FB-RUNRUNRUN", phase: "build" }),
-          makeBuild({ buildId: "FB-IDLEEEEEE", phase: "ideate" }),
+          // BI-5939B62F: ideate/plan now derive to "running", so use a still-idle
+          // phase (ship with acceptance recorded → idle, not needs-you) to keep
+          // the running → idle sort covered.
+          makeBuild({
+            buildId: "FB-IDLEEEEEE",
+            phase: "ship",
+            acceptanceMet: true as unknown as FeatureBuildRow["acceptanceMet"],
+          }),
         ]}
         portfolios={[]}
         governedBacklogEnabled

--- a/apps/web/components/build/fleet-derivation.test.ts
+++ b/apps/web/components/build/fleet-derivation.test.ts
@@ -67,9 +67,12 @@ function makeBuild(overrides: Partial<FeatureBuildRow> = {}): FeatureBuildRow {
 }
 
 describe("deriveQueueState", () => {
-  it("returns idle for ideate / plan / ship / complete phases", () => {
-    expect(deriveQueueState(makeBuild({ phase: "ideate" }))).toEqual({ kind: "idle" });
-    expect(deriveQueueState(makeBuild({ phase: "plan" }))).toEqual({ kind: "idle" });
+  it("counts ideate / plan as running in-flight, ship / complete as idle (BI-5939B62F)", () => {
+    // ideate/plan are active in-flight phases — they must not read as idle, or
+    // the fleet/queue counters show 0 while builds are genuinely in progress.
+    expect(deriveQueueState(makeBuild({ phase: "ideate" }))).toEqual({ kind: "running", stepLabel: "Ideating" });
+    expect(deriveQueueState(makeBuild({ phase: "plan" }))).toEqual({ kind: "running", stepLabel: "Planning" });
+    // ship/complete are terminal-ish → still idle.
     expect(deriveQueueState(makeBuild({ phase: "ship" }))).toEqual({ kind: "idle" });
     expect(deriveQueueState(makeBuild({ phase: "complete" }))).toEqual({ kind: "idle" });
   });
@@ -235,6 +238,24 @@ describe("isOperatorFocusEntry", () => {
         null,
       ),
     ).toBe(false);
+  });
+
+  it("keeps quiet ideate/plan OUT of focus even though they now derive to running (BI-5939B62F)", () => {
+    // deriveQueueState(ideate/plan) is now "running" so the fleet counters count
+    // them, but a non-selected, non-attention ideate/plan build stays out of the
+    // operator focus queue.
+    for (const phase of ["ideate", "plan"] as const) {
+      expect(
+        isOperatorFocusEntry(
+          {
+            build: makeBuild({ buildId: `FB-${phase}`, phase }),
+            queueState: { kind: "running", stepLabel: phase === "ideate" ? "Ideating" : "Planning" },
+            needsAttention: false,
+          },
+          null,
+        ),
+      ).toBe(false);
+    }
   });
 
   it("keeps the selected build visible even when it is otherwise parked", () => {

--- a/apps/web/components/build/fleet-derivation.ts
+++ b/apps/web/components/build/fleet-derivation.ts
@@ -52,7 +52,20 @@ export function deriveQueueState(build: FeatureBuildRow): BuildQueueState {
     return { kind: "running", stepLabel: "Verification & review" };
   }
 
-  // All other phases (ideate, plan, ship, complete) are idle from a runtime
+  // BI-5939B62F: ideate and plan are IN-FLIGHT phases — a coworker is actively
+  // working the brief / plan (or it's sitting at the gate awaiting approval), so
+  // the build is part of the live fleet. Mapping them to "idle" made the
+  // fleet/queue counters read 0 while builds were genuinely in progress. Count
+  // them as running so the fleet summary reflects reality; the phase mini-rail
+  // still conveys which stage.
+  if (build.phase === "ideate") {
+    return { kind: "running", stepLabel: "Ideating" };
+  }
+  if (build.phase === "plan") {
+    return { kind: "running", stepLabel: "Planning" };
+  }
+
+  // Remaining phases (ship, complete) are terminal-ish and idle from a runtime
   // queue perspective. The mini-rail conveys progress; the badge stays off.
   return { kind: "idle" };
 }
@@ -146,6 +159,12 @@ export function isOperatorFocusEntry(
 ): boolean {
   if (activeBuildId && entry.build.buildId === activeBuildId) return true;
   if (entry.needsAttention) return true;
+  // BI-5939B62F: ideate/plan now derive to "running" so they COUNT in the fleet
+  // summary, but quiet ideation/planning probes still stay OUT of the operator
+  // focus queue (AI-custody) unless selected or needing attention — the pre-fix
+  // behavior this list intentionally preserves. Keying focus on phase here
+  // decouples "counted as in-flight" from "operator-actionable".
+  if (entry.build.phase === "ideate" || entry.build.phase === "plan") return false;
   return entry.queueState.kind !== "idle";
 }
 


### PR DESCRIPTION
## What

The Build Studio fleet/queue counters read **0** while builds were genuinely in progress in the `ideate` / `plan` phases. `deriveQueueState` mapped those phases to `idle`, so `deriveFleetCounts` (which tallies running/queued/blocked) skipped them.

## Fix

- `deriveQueueState`: `ideate → running("Ideating")`, `plan → running("Planning")`. `ship`/`complete` stay `idle` (terminal-ish).
- Decouple *counted as in-flight* from *operator-actionable*: `isOperatorFocusEntry` now keeps quiet `ideate`/`plan` builds **out** of the operator focus queue by phase (unless selected or needing attention), preserving the AI-custody behavior that previously fell out of the idle mapping. The fleet header counts them; the operator focus list still parks them.
- Operator-focus header: derive working/waiting counts over the **non-needs-attention** focus entries, so a build that is *both* needs-you and running (e.g. a `plan` build with a failed review — now phase-derived to running) is counted once, under "Needs you" — matching the existing `!needsAttention` guard on the blocked count. (This is the double-count the full integration suite caught.)

## Tests

- `fleet-derivation.test.ts`: ideate/plan now derive to running; still-out-of-focus regression.
- `BuildStudioHeaderLayout.test.tsx`: `Needs you: 1 · Working: 2 · Parked: 5` (no double-count).
- `BuildStudioDetailsDrawer.test.tsx`: BS-Queue running→idle sort preserved via a still-idle `ship` fixture.
- Local pregate green: `gate passed`, full suite 15990 passed.

## Design grounding

Design-Grounding-Decision: existing specs/plans reviewed (none govern this internal fleet-derivation helper); current code substrate reviewed (`apps/web/components/build/fleet-derivation.ts`, `apps/web/components/build/BuildStudio.tsx`). Trivial phase-mapping correction to an existing pure helper plus its consumer count; no new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)