### PR TITLE
fix(quality): make createPlatformIssueReport idempotent on the dedupeKey race (BI-PIR-76bf293c)

### DIFF
--- a/apps/web/lib/quality/platform-issue-reports.test.ts
+++ b/apps/web/lib/quality/platform-issue-reports.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 // Hoisted Prisma mock — must be declared before the import under test
 const prismaMock = vi.hoisted(() => ({
-  platformIssueReport: { create: vi.fn() },
+  platformIssueReport: { create: vi.fn(), findFirst: vi.fn() },
   portfolio: { findUnique: vi.fn() },
   digitalProduct: { findUnique: vi.fn() },
 }));
@@ -17,6 +17,7 @@ import { ISSUE_REPORT_STATUS } from "./issue-report-status";
 
 beforeEach(() => {
   prismaMock.platformIssueReport.create.mockReset();
+  prismaMock.platformIssueReport.findFirst.mockReset();
   prismaMock.portfolio.findUnique.mockReset();
   prismaMock.digitalProduct.findUnique.mockReset();
   prismaMock.platformIssueReport.create.mockResolvedValue({});
@@ -297,6 +298,62 @@ describe("createPlatformIssueReport", () => {
       name: "quality/issue-report.created",
       data: { reportId },
     });
+  });
+
+  // BI-PIR-76bf293c — idempotency race on the dedupeKey partial-unique.
+  const p2002 = (target: unknown) =>
+    Object.assign(new Error("Unique constraint failed"), { code: "P2002", meta: { target } });
+
+  it("returns the surviving open report's id when a concurrent dedupeKey insert races (P2002)", async () => {
+    prismaMock.platformIssueReport.create.mockRejectedValueOnce(
+      p2002("PlatformIssueReport_dedupeKey_open_key"),
+    );
+    prismaMock.platformIssueReport.findFirst.mockResolvedValue({ reportId: "PIR-EXIST" });
+    const result = await createPlatformIssueReport({
+      type: "runtime_error",
+      title: "Recurring signature",
+      source: "automated-detection",
+      dedupeKey: "log-sig:portal:abc1234567",
+    });
+    expect(result.reportId).toBe("PIR-EXIST");
+    expect(prismaMock.platformIssueReport.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          dedupeKey: "log-sig:portal:abc1234567",
+          status: { notIn: ["resolved_locally", "resolved_upstream", "suppressed"] },
+        }),
+      }),
+    );
+    // The surviving report already projected when first filed — no re-projection.
+    expect(inngestMock.send).not.toHaveBeenCalled();
+  });
+
+  it("re-throws a P2002 that is not on the dedupeKey (e.g. reportId collision)", async () => {
+    prismaMock.platformIssueReport.create.mockRejectedValueOnce(p2002("PlatformIssueReport_reportId_key"));
+    await expect(
+      createPlatformIssueReport({
+        type: "runtime_error",
+        title: "x",
+        source: "automated-detection",
+        dedupeKey: "log-sig:portal:abc1234567",
+      }),
+    ).rejects.toMatchObject({ code: "P2002" });
+    expect(prismaMock.platformIssueReport.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("re-throws a dedupeKey P2002 when no surviving report can be found", async () => {
+    prismaMock.platformIssueReport.create.mockRejectedValueOnce(
+      p2002(["dedupeKey"]),
+    );
+    prismaMock.platformIssueReport.findFirst.mockResolvedValue(null);
+    await expect(
+      createPlatformIssueReport({
+        type: "runtime_error",
+        title: "x",
+        source: "automated-detection",
+        dedupeKey: "log-sig:portal:abc1234567",
+      }),
+    ).rejects.toMatchObject({ code: "P2002" });
   });
 
   it("is non-fatal when the projection event fails to send", async () => {

--- a/apps/web/lib/quality/platform-issue-reports.ts
+++ b/apps/web/lib/quality/platform-issue-reports.ts
@@ -163,34 +163,61 @@ export async function createPlatformIssueReport(
   }
 
   const reportId = generateReportId();
+  const dedupeKey = trimTo(input.dedupeKey ?? null, LIMITS.dedupeKey);
 
-  await prisma.platformIssueReport.create({
-    data: {
-      reportId,
-      type: input.type.slice(0, LIMITS.type),
-      severity: (input.severity ?? "medium").slice(0, LIMITS.severity),
-      title: input.title.slice(0, LIMITS.title),
-      description: trimTo(input.description ?? null, LIMITS.description),
-      routeContext: trimTo(input.routeContext ?? null, LIMITS.routeContext),
-      errorStack: trimTo(input.errorStack ?? null, LIMITS.errorStack),
-      errorDigest: trimTo(input.errorDigest ?? null, LIMITS.errorDigest),
-      deployedSha: trimTo(input.deployedSha ?? null, LIMITS.deployedSha),
-      userAgent: trimTo(input.userAgent ?? null, LIMITS.userAgent),
-      triggerKind: trimTo(input.triggerKind ?? null, LIMITS.triggerKind),
-      supportSessionId: trimTo(input.supportSessionId ?? null, LIMITS.supportSessionId),
-      dedupeKey: trimTo(input.dedupeKey ?? null, LIMITS.dedupeKey),
-      selfFixClass: trimTo(input.selfFixClass ?? null, LIMITS.selfFixClass),
-      reportedById: input.reportedById ?? null,
-      threadId: input.threadId ?? null,
-      agentId: input.agentId ?? null,
-      taskRunId: input.taskRunId ?? null,
-      featureBuildId: input.featureBuildId ?? null,
-      source: input.source.slice(0, LIMITS.source),
-      portfolioId,
-      digitalProductId,
-      ...(status !== undefined ? { status } : {}),
-    },
-  });
+  try {
+    await prisma.platformIssueReport.create({
+      data: {
+        reportId,
+        type: input.type.slice(0, LIMITS.type),
+        severity: (input.severity ?? "medium").slice(0, LIMITS.severity),
+        title: input.title.slice(0, LIMITS.title),
+        description: trimTo(input.description ?? null, LIMITS.description),
+        routeContext: trimTo(input.routeContext ?? null, LIMITS.routeContext),
+        errorStack: trimTo(input.errorStack ?? null, LIMITS.errorStack),
+        errorDigest: trimTo(input.errorDigest ?? null, LIMITS.errorDigest),
+        deployedSha: trimTo(input.deployedSha ?? null, LIMITS.deployedSha),
+        userAgent: trimTo(input.userAgent ?? null, LIMITS.userAgent),
+        triggerKind: trimTo(input.triggerKind ?? null, LIMITS.triggerKind),
+        supportSessionId: trimTo(input.supportSessionId ?? null, LIMITS.supportSessionId),
+        dedupeKey,
+        selfFixClass: trimTo(input.selfFixClass ?? null, LIMITS.selfFixClass),
+        reportedById: input.reportedById ?? null,
+        threadId: input.threadId ?? null,
+        agentId: input.agentId ?? null,
+        taskRunId: input.taskRunId ?? null,
+        featureBuildId: input.featureBuildId ?? null,
+        source: input.source.slice(0, LIMITS.source),
+        portfolioId,
+        digitalProductId,
+        ...(status !== undefined ? { status } : {}),
+      },
+    });
+  } catch (err) {
+    // BI-PIR-76bf293c — idempotency race on the dedupeKey partial-unique.
+    // Two automated producers (e.g. the log-signature scanner firing on
+    // overlapping cycles, or the same signature twice within one cycle) can
+    // both create the same dedupeKey while a non-resolved report is open,
+    // violating PlatformIssueReport_dedupeKey_open_key (UNIQUE WHERE status NOT
+    // IN resolved_locally/resolved_upstream/suppressed). Previously that P2002
+    // escaped this shared front door, got logged, and was itself re-scanned.
+    // Treat it as idempotent success: return the surviving open report's id and
+    // skip re-projection (that report already projected when first filed).
+    const code = (err as { code?: string } | null)?.code;
+    const target = JSON.stringify((err as { meta?: { target?: unknown } } | null)?.meta?.target ?? "");
+    if (code === "P2002" && dedupeKey && target.includes("dedupeKey")) {
+      const existing = await prisma.platformIssueReport.findFirst({
+        where: {
+          dedupeKey,
+          status: { notIn: ["resolved_locally", "resolved_upstream", "suppressed"] },
+        },
+        orderBy: { createdAt: "desc" },
+        select: { reportId: true },
+      });
+      if (existing) return { reportId: existing.reportId };
+    }
+    throw err;
+  }
 
   // EP-INTAKE-UNIFY Phase 4 (BI-EDFBE081): project OPEN reports into the backlog
   // immediately via a durable event, instead of waiting up to 15 min for the


### PR DESCRIPTION
## Problem

`createPlatformIssueReport` — the single server-side writer for `PlatformIssueReport` — did a bare `prisma.platformIssueReport.create()`. Two automated producers (the log-signature scanner firing on overlapping cycles, or the same signature twice within one 15-min cycle) can both try to create the same `dedupeKey` while a non-resolved report is open, violating the partial-unique:

```sql
CREATE UNIQUE INDEX "PlatformIssueReport_dedupeKey_open_key"
  ON "PlatformIssueReport"("dedupeKey")
  WHERE "dedupeKey" IS NOT NULL
    AND "status" NOT IN ('resolved_locally','resolved_upstream','suppressed');
```

The resulting `P2002` escaped the shared front door, was logged, and then got re-scanned into *more* PIRs — one of the noise sources cleaned up in backlog triage. Individual callers like `staleness-escalation.ts` already swallow this, but the shared writer (used by the scanner) did not.

## Fix

Guard the `create` in `createPlatformIssueReport`: on a `P2002` whose target is the `dedupeKey` index **and** only when a `dedupeKey` was supplied, look up the surviving non-resolved report and return its `reportId` (idempotent success), skipping re-projection — the open report already emitted its projection event on first file. Any other `P2002` (e.g. a random-`reportId` collision) still re-throws unchanged.

## Verification

- Added 3 regression tests: the race returns the surviving id + no re-projection; a non-dedupeKey `P2002` (reportId collision) re-throws without a lookup; a dedupeKey `P2002` with no surviving report re-throws.
- Functionally verified the P2002/target detection predicate against index-name, array-target, reportId-collision, non-P2002, and no-dedupeKey cases.
- Local scoped typecheck skipped (source-only worktree, no `node_modules`); CI runs the authoritative typecheck + unit tests.

Fixes `BI-PIR-76bf293c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)