### PR TITLE
feat(coworker): honest failure message + one-click reconnect on AI-provider config gaps

### DIFF
--- a/apps/web/components/agent/AgentMessageBubble.test.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.test.tsx
@@ -3,7 +3,9 @@ import { renderToStaticMarkup } from "react-dom/server";
 import {
   AgentMessageBubble,
   formatProviderBadge,
+  referencesProviderRoutingSurface,
   stripSystemPromptPrefix,
+  PROVIDER_ROUTING_ROUTE,
 } from "./AgentMessageBubble";
 
 describe("formatProviderBadge", () => {
@@ -211,6 +213,67 @@ describe("AgentMessageBubble", () => {
     expect(html).not.toContain('data-testid="agent-message-provider"');
   });
 
+  it("renders a one-click reconnect CTA when an assistant message names Providers & Routing (BI-282C39D5)", () => {
+    // The exact honest-failure string from describeToolRouteFailure (agentic-loop.ts).
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-cta",
+          role: "assistant",
+          content:
+            "No AI model can handle this request right now. This usually means your cloud AI providers are disconnected or their sign-in has expired, and the built-in local model can't fit this assistant's larger requests on its own. Open Platform > AI Operations > Providers & Routing to reconnect a provider — waiting won't clear this on its own.",
+          agentId: "scrum-master",
+          routeContext: "/platform/ai/providers",
+          createdAt: "2026-07-14T12:00:00.000Z",
+        }}
+        showAgentLabel={true}
+        agentName="Scrum Master"
+      />,
+    );
+
+    expect(html).toContain('data-testid="agent-provider-reconnect-cta"');
+    expect(html).toContain(`href="${PROVIDER_ROUTING_ROUTE}"`);
+    expect(html).toContain("Open Providers");
+  });
+
+  it("does NOT render the reconnect CTA for a normal assistant message", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-no-cta",
+          role: "assistant",
+          content: "Here's a summary of today's standup and the three blockers.",
+          agentId: "scrum-master",
+          routeContext: "/ops",
+          createdAt: "2026-07-14T12:00:00.000Z",
+        }}
+        showAgentLabel={true}
+        agentName="Scrum Master"
+      />,
+    );
+
+    expect(html).not.toContain('data-testid="agent-provider-reconnect-cta"');
+  });
+
+  it("does NOT render the reconnect CTA on a user message that happens to name the surface", () => {
+    const html = renderToStaticMarkup(
+      <AgentMessageBubble
+        message={{
+          id: "msg-user-cta",
+          role: "user",
+          content: "where is Providers & Routing?",
+          agentId: null,
+          routeContext: "/ops",
+          createdAt: "2026-07-14T12:00:00.000Z",
+        }}
+        showAgentLabel={false}
+        agentName={null}
+      />,
+    );
+
+    expect(html).not.toContain('data-testid="agent-provider-reconnect-cta"');
+  });
+
   it("renders managed document chips for assistant messages with stable document ids", () => {
     const html = renderToStaticMarkup(
       <AgentMessageBubble
@@ -229,6 +292,19 @@ describe("AgentMessageBubble", () => {
 
     expect(html).toContain("/workspace/documents/DOC-ABC12345");
     expect(html).toContain("DOC-ABC12345");
+  });
+});
+
+describe("referencesProviderRoutingSurface (BI-282C39D5)", () => {
+  it("matches every provider-config remediation phrasing", () => {
+    expect(referencesProviderRoutingSurface("Open Platform > AI > Providers & Routing to activate a tool-capable provider, then try again.")).toBe(true);
+    expect(referencesProviderRoutingSurface("Open Platform › AI Operations › Providers & Routing, connect a cloud provider")).toBe(true);
+    expect(referencesProviderRoutingSurface("… Open Platform > AI Operations > Providers & Routing to reconnect a provider — waiting won't clear this on its own.")).toBe(true);
+  });
+
+  it("does not match normal conversation", () => {
+    expect(referencesProviderRoutingSurface("Here are the three standup blockers.")).toBe(false);
+    expect(referencesProviderRoutingSurface("")).toBe(false);
   });
 });
 

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import ReactMarkdown from "react-markdown";
-import { FileText } from "lucide-react";
+import { FileText, PlugZap } from "lucide-react";
 import type { AgentMessageProvider, AgentMessageRow } from "@/lib/agent-coworker-types";
 import type { ReactNode } from "react";
 import { AgentAttachmentCard } from "./AgentAttachmentCard";
@@ -90,6 +90,22 @@ const HIDDEN_PARAMS = new Set(["buildId", "digitalProductId", "featureBrief"]);
 
 function extractManagedDocumentIds(content: string): string[] {
   return [...new Set(content.match(/\bDOC-[A-Z0-9]{8}\b/g) ?? [])].slice(0, 4);
+}
+
+/** Deep-link target for the AI provider reconnect / activation surface. */
+export const PROVIDER_ROUTING_ROUTE = "/platform/ai/providers";
+
+/**
+ * True when an assistant message steers the operator to reconnect or activate an
+ * AI provider. Every provider-config failure branch (describeToolRouteFailure in
+ * agentic-loop.ts, and the credential-gap messages in agent-coworker.ts) names
+ * the "Providers & Routing" surface. BI-282C39D5: rather than make the user hunt
+ * the menu, render a one-click chip straight to it — hand the fix, don't just
+ * describe it. Benign on the rare false positive: the chip only links to a page
+ * the message already names. Assistant-only; user text is never scanned.
+ */
+export function referencesProviderRoutingSurface(content: string): boolean {
+  return /Providers\s*&\s*Routing/i.test(content);
 }
 
 function formatProposalParams(
@@ -554,6 +570,31 @@ export function AgentMessageBubble({
                     {documentId}
                   </Link>
                 ))}
+              </div>
+            )}
+            {referencesProviderRoutingSurface(message.content) && (
+              <div style={{ marginTop: 8 }}>
+                <Link
+                  href={PROVIDER_ROUTING_ROUTE}
+                  data-testid="agent-provider-reconnect-cta"
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                    border: "1px solid color-mix(in srgb, var(--dpf-accent) 45%, transparent)",
+                    background: "color-mix(in srgb, var(--dpf-accent) 14%, transparent)",
+                    borderRadius: 999,
+                    color: "var(--dpf-accent)",
+                    fontSize: 11,
+                    fontWeight: 600,
+                    lineHeight: 1,
+                    padding: "6px 10px",
+                    textDecoration: "none",
+                  }}
+                >
+                  <PlugZap size={12} aria-hidden="true" />
+                  Open Providers &amp; Routing
+                </Link>
               </div>
             )}
           </div>

--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -497,6 +497,33 @@ describe("runAgenticLoop", () => {
     expect(result.modelId).toBe("unknown");
   });
 
+  it("tells the operator to reconnect a provider (not 'wait 30s') when every endpoint is eliminated", async () => {
+    // The real incident: the cloud provider's OAuth sign-in expired AND the bundled
+    // local model's 24k window is too small for a heavy coworker's ~21k-token prompt
+    // (recorded RouteDecisionLog: "Context window too small: 24576 < 32000"). Routing
+    // eliminates every candidate and throws a plain "No eligible endpoints for task
+    // type '…'" with NO toolUse token — which used to fall through to the misleading
+    // "temporarily unavailable, try again in 30 seconds". Waiting never clears a
+    // config gap.
+    const mockRoute = vi.mocked(routeAndCall);
+    mockRoute.mockRejectedValueOnce(new Error(
+      "No eligible endpoints for task 'data-extraction': No eligible endpoints for task type 'data-extraction' with sensitivity 'internal'. 1 endpoint(s) excluded. (1 endpoint(s) excluded)",
+    ));
+
+    const result = await runAgenticLoop({
+      ...baseParams,
+      routeContext: "/platform/ai/providers",
+      agentId: "scrum-master",
+    });
+
+    expect(result.content).toContain("No AI model can handle this request right now");
+    expect(result.content).toContain("Providers & Routing");
+    expect(result.content).toContain("waiting won't clear this");
+    expect(result.content).not.toContain("try again in about 30 seconds");
+    expect(result.providerId).toBe("unknown");
+    expect(result.modelId).toBe("unknown");
+  });
+
   it("explains a transient paid outage + local tool cap instead of blaming config", async () => {
     const mockRoute = vi.mocked(routeAndCall);
     mockRoute.mockRejectedValueOnce(new Error(

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -172,6 +172,25 @@ export function describeToolRouteFailure(
     );
   }
 
+  // Config/capacity gap: routing eliminated EVERY candidate (e.g. the cloud
+  // provider's sign-in expired AND the bundled local model's context window is
+  // too small for this coworker's larger requests). This reaches here as a plain
+  // "No eligible endpoints for task type '…'" with no `toolUse` token, so the
+  // branch above misses it and — before this fix — it fell through to the generic
+  // "temporarily unavailable, try again in 30 seconds" below. That is a LIE for a
+  // config gap: nothing changes on retry. Tell the operator the truth and the one
+  // lever that actually clears it. Check AFTER the tool-capability branch so its
+  // more specific wording still wins for the capability-floor case.
+  if (/No eligible endpoints/i.test(msg)) {
+    return (
+      "No AI model can handle this request right now. This usually means your cloud " +
+      "AI providers are disconnected or their sign-in has expired, and the built-in " +
+      "local model can't fit this assistant's larger requests on its own. Open " +
+      "Platform > AI Operations > Providers & Routing to reconnect a provider — " +
+      "waiting won't clear this on its own."
+    );
+  }
+
   // Endpoints exist but all transiently failed (rate-limit / overload / network).
   if (/All endpoints failed/i.test(msg)) {
     return (

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -56,8 +56,8 @@ apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	903
 apps/web/lib/tak/agent-grants.ts	816
 apps/web/lib/tak/agent-routing.ts	965
-apps/web/lib/tak/agentic-loop.test.ts	2183
-apps/web/lib/tak/agentic-loop.ts	2569
+apps/web/lib/tak/agentic-loop.test.ts	2210
+apps/web/lib/tak/agentic-loop.ts	2588
 apps/web/lib/tak/route-context-map.ts	1226
 apps/web/lib/tak/route-context.ts	1239
 apps/web/lib/work-capsules/mcp-handlers.ts	884


### PR DESCRIPTION
## What
Make a coworker turn that fails on an AI-provider config gap **recoverable in one click**, instead of a dead-end status.

1. **Honest message** — when routing eliminates every endpoint (e.g. cloud sign-in expired **and** the local model's 24k window is too small for a heavy coworker's ~21k-token prompt), `describeToolRouteFailure` no longer falls through to the misleading "temporarily unavailable, try again in 30 seconds." It states plainly that a provider needs reconnecting and that waiting won't clear it.
2. **One-click reconnect CTA** (BI-282C39D5) — the coworker bubble now renders an "Open Providers & Routing" chip whenever an assistant message names that surface, deep-linking straight to `/platform/ai/providers`. Proactivity hands the fix rather than describing it.

## Why (evidence)
Reproduced live. `resolve_model_selection` flagged `anthropic-sub` (Claude OAuth) as expired; `RouteDecisionLog` recorded the local exclusion verbatim: `"Context window too small: 24576 < 32000"` (`minContextTokens = estimatedInputTokens × 1.5`, so ~21k input). With cloud expired there was zero eligible endpoint → the generic transient lie.

## Design notes
- **The link lives at the UI layer, not the message string.** `describeToolRouteFailure` output is consumed by non-markdown surfaces (build-pipeline, autonomous-run, coding-agent) where a markdown link would leak as literal text. The CTA is instead derived from the persisted message content in `AgentMessageBubble.tsx` — mirroring the existing DOC-id `<Link>` chip pattern, so it survives reload with no schema change.
- Assistant-only; benign on the rare false positive (links to a page the message already names). Transient rate-limit branches deliberately do **not** get the chip — nothing is misconfigured there.

## Testing
- `agentic-loop.test.ts` — new case asserts the config-gap string routes to the honest message, not "try again in about 30 seconds."
- `AgentMessageBubble.test.tsx` — asserts the CTA renders (with `href="/platform/ai/providers"`) for the real failure string, and does **not** render for normal or user messages. `referencesProviderRoutingSurface` unit-tested against every provider-config branch phrasing.
- Local vitest/tsc can't run in this source-only worktree (no `node_modules`) — CI gates the real suite. Detection + branch logic verified functionally against the real strings.

## Scope / follow-up
- **Phase 2 (proactive, this BI's remainder):** raise an Attention Surface item the moment a credential expires — via `provider-health` / `credential-health-check` — so the platform flags it *before* a coworker turn dies. Tracked in **BI-282C39D5**.
- **Context-window remediation** (raise local served context / right-size coworker tool surface): **BI-712A0893**.
- Operator action (not code): reconnect Claude OAuth in Platform › AI Operations › Providers & Routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
