### PR TITLE
fix(self-upgrade): local-changes ledger uses content diff, not a sha range (BI-75C4A412)

### DIFF
--- a/apps/web/lib/self-upgrade/local-changes-ledger.test.ts
+++ b/apps/web/lib/self-upgrade/local-changes-ledger.test.ts
@@ -39,8 +39,15 @@ describe("collectLocalChanges", () => {
     expect(res.available).toBe(true);
     expect(res.changes).toHaveLength(1);
     expect(res.changes[0].subject).toBe("feat: keep this private");
-    // log invoked with the upstream..installBranch range
-    expect(run).toHaveBeenLastCalledWith(expect.arrayContaining(["origin/main..dpf/install", `--format=${LEDGER_LOG_FORMAT}`]));
+    // BI-75C4A412: content diff, not sha range — three-dot symmetric range with
+    // --cherry-pick --right-only drops commits already upstreamed under a
+    // different (squash-rebased) sha.
+    const logArgs = run.mock.calls.at(-1)?.[0] as string[];
+    expect(logArgs).toContain("origin/main...dpf/install");
+    expect(logArgs).not.toContain("origin/main..dpf/install");
+    expect(logArgs).toContain("--cherry-pick");
+    expect(logArgs).toContain("--right-only");
+    expect(logArgs).toContain(`--format=${LEDGER_LOG_FORMAT}`);
   });
 
   it("returns unavailable (not an error) when the log command fails", async () => {

--- a/apps/web/lib/self-upgrade/local-changes-ledger.ts
+++ b/apps/web/lib/self-upgrade/local-changes-ledger.ts
@@ -1,11 +1,19 @@
 /**
  * Local-changes ledger — Private/Public Change Segregation (EP-1A78BAE1).
  *
- * Lists the commits on the durable install branch (`dpf/install`) that are NOT
- * in upstream — i.e. the changes the operator has kept on their own system and
- * not shared with the community. Shared changes flow upstream (and return via
- * the self-upgrade merge), so by construction the local-only commits ARE the
- * private delta. This answers, in plain language, "what have we kept private?"
+ * Lists the commits on the durable install branch (`dpf/install`) whose CONTENT
+ * is NOT upstream — i.e. the changes the operator has kept on their own system
+ * and not shared with the community. This answers, in plain language, "what have
+ * we kept private?"
+ *
+ * BI-75C4A412: a plain two-dot commit range (`upstream..installBranch`) over-
+ * reports. Shared changes flow upstream and return via the self-upgrade merge,
+ * but upstream squash-rebases them, so the returned commit has a DIFFERENT sha —
+ * the operator's original commit is still not reachable from upstream and a
+ * commit-range would keep counting it as "private". We instead compare by
+ * CONTENT: `--cherry-pick --right-only` over a three-dot (`...`) symmetric range
+ * drops any install-branch commit that is patch-equivalent to one already
+ * upstream, leaving only the genuinely-private delta.
  *
  * Pure parsing/collection here (unit-tested over a GitRunner); the server
  * resolver `getLocalChangesLedger` wires the live install path + config.
@@ -67,9 +75,13 @@ export async function collectLocalChanges(run: GitRunner, opts: CollectOptions):
     };
   }
 
-  const range = `${remote}/${branch}..${installBranch}`;
+  // Three-dot symmetric range + --cherry-pick --right-only = install-branch
+  // commits whose patch is NOT already upstream (content diff, not sha range).
+  // See BI-75C4A412 note above.
+  const range = `${remote}/${branch}...${installBranch}`;
   const res = await run([
-    "-C", hostSourcePath, "log", "--no-merges", `--max-count=${max}`, `--format=${LEDGER_LOG_FORMAT}`, range,
+    "-C", hostSourcePath, "log", "--no-merges", "--cherry-pick", "--right-only",
+    `--max-count=${max}`, `--format=${LEDGER_LOG_FORMAT}`, range,
   ]);
   if (res.code !== 0) {
     return {


### PR DESCRIPTION
## Problem

The local-changes ledger (Private/Public Change Segregation) lists the commits an operator has kept private — not shared upstream. It used a **two-dot commit range** `${remote}/${branch}..${installBranch}` in `git log`.

But shared changes flow upstream and **return via the self-upgrade merge under a rewritten SHA** (upstream squash-rebases contributions — origin/main is confirmed squash-rebased). The operator's original commit is therefore never reachable from upstream, so the two-dot range keeps counting *already-shared* changes as "private" — **over-reporting the private delta**.

## Fix

Compare by **content**, not SHA: `--cherry-pick --right-only` over a three-dot symmetric range (`${remote}/${branch}...${installBranch}`). `--cherry-pick` drops any install-branch commit that is patch-equivalent to one already upstream; `--right-only` keeps only the install-branch side. What remains is the genuinely-private delta.

## Verification

Functionally verified in a throwaway repo (make a change on the install branch, re-apply it upstream under a different SHA, plus one genuinely-private commit):
- **two-dot (old):** reports both the shared change and the private one ❌
- **three-dot `--cherry-pick --right-only` (new):** reports only the private one ✅

Unit test updated to assert the three-dot range + `--cherry-pick`/`--right-only` flags. Local scoped typecheck skipped (source-only worktree, no `node_modules`); CI runs the authoritative typecheck + tests.

Fixes `BI-75C4A412`. (Supersedes an earlier unmerged branch fix `e6513b2c4`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)