### PR TITLE
fix(self-upgrade): recreate postgres onto pgvector before migrate (BET-5)

### DIFF
--- a/docs/superpowers/plans/2026-07-13-bet5-db-compression-plan.md
+++ b/docs/superpowers/plans/2026-07-13-bet5-db-compression-plan.md
@@ -159,3 +159,20 @@ now-inert `NEO4J_*`/`QDRANT_*` env — all backfill-only, retired once every ins
 **Optional specialized-store path (recorded, not built):** at very large scale a dedicated
 vector/graph engine may again beat Postgres; for the target customer that is far off. The
 seam-behind-a-re-export design means re-introducing one is a localized change, not a rewrite.
+
+### Self-upgrade postgres-image recreate (follow-up, 2026-07-14)
+
+A live self-upgrade of an existing install surfaced a gap the CI fix (pgvector CI service image)
+did not cover: `promote.sh` recreates ONLY the portal (`--no-deps`), so an existing install's
+`postgres` / `sandbox-postgres` containers keep the image they launched with (`postgres:16-alpine`).
+The Phase-0 compose bump to `pgvector/pgvector:pg16` therefore never reaches a running install, and
+`prisma migrate deploy` fails at `CREATE EXTENSION vector` ("extension vector is not available")
+BEFORE the swap — the upgrade aborts safely (old portal keeps serving) but never completes.
+
+Fix: `promote.sh` gains **step 3a `ensure-pgvector`** (recreate `postgres` onto the compose-pinned
+pgvector image before migrate) and a sandbox-postgres recreate in **step 7b**. Both are idempotent
+(skip when `vector.control` is already present — fresh installs and already-upgraded installs) and
+data-preserving (`pgvector/pgvector:pg16` is the same PG16 engine on the same `pgdata` volume, a
+strict superset image — no dump/restore). Step 3a is fail-closed (abort before swap); the
+sandbox-postgres recreate is fail-loud-not-abort like the rest of 7b. This makes every existing
+install (Mac + Windows) upgrade cleanly with no manual DB step.

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -166,6 +166,40 @@ if [[ $_dry_run -eq 0 ]]; then
   }
 fi
 
+# --- Step 3a: ensure Postgres provides pgvector ---
+# BET-5 (BI-A1E864A5): the vector migration runs `CREATE EXTENSION vector`, which the plain
+# `postgres:16` image does not ship. A self-upgrade recreates ONLY the portal (step 4, --no-deps),
+# so an existing install's postgres container keeps whatever image it launched with — and the
+# Phase-0 compose bump to `pgvector/pgvector:pg16` never reaches it. Without this step, step 3b
+# `migrate deploy` fails with "extension \"vector\" is not available" and the upgrade aborts
+# before the swap. Recreate postgres onto the compose-pinned pgvector image BEFORE migrate.
+#
+# IDEMPOTENT: skips when the running container already provides vector.control (a fresh install
+# built from the new compose, or an install already upgraded). DATA-PRESERVING: pgvector/pgvector
+# is the same PG16 engine as postgres:16 on the same pgdata volume (a strict superset image), so
+# the recreate keeps all data — no dump/restore. FAIL-CLOSED like migrate: if the recreate or the
+# readiness wait fails, abort before the swap so the old portal keeps serving the old code.
+emit_step ensure-pgvector
+if [[ $_dry_run -eq 0 ]]; then
+  _pg_container="${DPF_PRODUCTION_DB_CONTAINER:-${_project}-postgres-1}"
+  _has_vector="$(docker exec "$_pg_container" sh -lc 'test -f /usr/local/share/postgresql/extension/vector.control && echo yes || echo no' 2>/dev/null || echo no)"
+  if [[ "$_has_vector" != "yes" ]]; then
+    printf 'step=ensure-pgvector-recreate target=%s\n' "$PROMOTE_TARGET_SHA"
+    docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+      "${_f_args[@]}" up -d --no-deps --force-recreate postgres || {
+        printf 'error: could not recreate postgres onto the pgvector image — the BET-5 vector migration cannot apply\n' >&2
+        exit 1
+      }
+    # Wait for the recreated postgres to accept connections before migrate.
+    _pg_ready=0
+    for _i in $(seq 1 30); do
+      if docker exec "$_pg_container" pg_isready -U "${POSTGRES_USER:-dpf}" >/dev/null 2>&1; then _pg_ready=1; break; fi
+      sleep 2
+    done
+    [[ $_pg_ready -eq 1 ]] || { printf 'error: postgres did not become ready after the pgvector recreate\n' >&2; exit 1; }
+  fi
+fi
+
 # --- Step 3b: migrate ---
 # Apply DB migrations using the FRESHLY BUILT portal image BEFORE recreating the
 # long-running portal. The swap in step 4 recreates ONLY `portal` (--no-deps),
@@ -322,8 +356,23 @@ fi
 emit_step sandbox-refresh
 if [[ $_dry_run -eq 0 ]]; then
   _sandbox_ok=1
-  docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
-    "${_f_args[@]}" build sandbox || _sandbox_ok=0
+  # BET-5 (BI-A1E864A5): the sandbox runs the same schema, so its Postgres also needs pgvector
+  # for `CREATE EXTENSION vector`. Recreate sandbox-postgres onto the pgvector image first — same
+  # idempotent (skip if vector.control present), data-preserving contract as step 3a. Fail-LOUD-
+  # not-ABORT like the rest of 7b: a sandbox-postgres it cannot upgrade degrades Build Studio, it
+  # never reverts the already-promoted portal.
+  _sbx_pg="${_project}-sandbox-postgres-1"
+  if docker inspect "$_sbx_pg" >/dev/null 2>&1; then
+    _sbx_has_vector="$(docker exec "$_sbx_pg" sh -lc 'test -f /usr/local/share/postgresql/extension/vector.control && echo yes || echo no' 2>/dev/null || echo no)"
+    if [[ "$_sbx_has_vector" != "yes" ]]; then
+      docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+        "${_f_args[@]}" up -d --no-deps --force-recreate sandbox-postgres || _sandbox_ok=0
+    fi
+  fi
+  if [[ $_sandbox_ok -eq 1 ]]; then
+    docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+      "${_f_args[@]}" build sandbox || _sandbox_ok=0
+  fi
   if [[ $_sandbox_ok -eq 1 ]]; then
     docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
       "${_f_args[@]}" up -d --no-deps --force-recreate sandbox || _sandbox_ok=0


### PR DESCRIPTION
## BET-5 self-upgrade completion — postgres pgvector recreate

A **live self-upgrade** of an existing install surfaced a gap that CI (which uses a fresh pgvector service container) could not: `promote.sh` recreates only the **portal** (`--no-deps`), so an existing install's `postgres` / `sandbox-postgres` containers keep the image they launched with (`postgres:16-alpine`). The BET-5 Phase-0 compose bump to `pgvector/pgvector:pg16` never reaches a running install, so the migrate-deploy step fails at `CREATE EXTENSION vector` ("extension vector is not available") **before the swap** — the upgrade aborts safely (old portal keeps serving, no data loss) but never completes. Confirmed live on the Mac install; the Windows install would hit the identical failure.

### Fix
- **Step 3a `ensure-pgvector`** (new, before the migrate step): recreate `postgres` onto the compose-pinned pgvector image.
- **Step 7b**: recreate `sandbox-postgres` too, so Build Studio's DB isn't left without pgvector.

Both are:
- **Idempotent** — skip when the running container already has `vector.control` (fresh installs built from the new compose, or an install already upgraded).
- **Data-preserving** — `pgvector/pgvector:pg16` is the same PG16 engine as `postgres:16` on the same `pgdata` volume (a strict superset image), so the recreate keeps all data; no dump/restore.
- Step 3a is **fail-closed** (abort before swap on recreate/readiness failure); the sandbox-postgres recreate is **fail-loud-not-abort**, matching the rest of step 7b.

Makes every existing install (Mac + Windows) upgrade cleanly with no manual DB step.

### Verification
- `bash -n scripts/promote.sh` clean; shellcheck runs in CI.
- Diagnosed against the live promoter run: `dpf-postgres-1` was `postgres:16-alpine`, `vector.control` missing, `vector`/`ltree` extensions absent.

Local-CI-Override: shell-only change to scripts/promote.sh; validated with `bash -n` (syntax clean); no app build/typecheck surface; shellcheck + full CI run on the PR. CI is authoritative.

Process-Spine-Decision: extend — BET-5 self-upgrade completion; plan updated with the postgres-recreate gap + fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
