### PR TITLE
fix(coworker): runtime-limit message stays domain-agnostic (BI-0C19AFDD)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.test.ts
+++ b/apps/web/lib/tak/agentic-loop.test.ts
@@ -6,6 +6,7 @@ import {
   detectFabrication,
   buildRepeatedQuestionNudge,
   buildRepeatedToolStopMessage,
+  buildRuntimeLimitToolLoopMessage,
   detectToolRefusedDespiteAvailability,
   phaseRequiresToolCall,
   detectUnsavedEvidence,
@@ -245,6 +246,35 @@ describe("buildRepeatedToolStopMessage", () => {
     expect(msg).not.toMatch(/\d times with the same arguments/);
     expect(msg).toMatch(/build's details panel|build details/i);
     expect(msg.toLowerCase()).toContain("got stuck");
+  });
+});
+
+describe("buildRuntimeLimitToolLoopMessage (BI-0C19AFDD)", () => {
+  const anyTools = [
+    { name: "search_knowledge", result: { ok: true } as never },
+    { name: "query_ontology_graph", result: { ok: true } as never },
+  ];
+
+  it("stays domain-agnostic — never confabulates a finance domain", () => {
+    const msg = buildRuntimeLimitToolLoopMessage(anyTools);
+    // The prior copy hard-coded a "finance reports"/"finance-summary tool"
+    // suggestion that surfaced for every non-finance coworker (Dale's
+    // truck-parts build was told to "use the finance reports directly").
+    expect(msg.toLowerCase()).not.toContain("finance");
+    expect(msg).not.toMatch(/finance-summary tool/i);
+  });
+
+  it("gives a generic, honest next step and summarizes the tools it used", () => {
+    const msg = buildRuntimeLimitToolLoopMessage(anyTools);
+    expect(msg).toContain("search_knowledge");
+    expect(msg.toLowerCase()).toContain("runtime limit");
+    expect(msg).toMatch(/narrower question|smaller step/i);
+  });
+
+  it("falls back to a generic phrase when no tools were executed", () => {
+    const msg = buildRuntimeLimitToolLoopMessage([]);
+    expect(msg).toContain("the available tools");
+    expect(msg.toLowerCase()).not.toContain("finance");
   });
 });
 

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -597,12 +597,17 @@ function summarizeExecutedToolNames(executedTools: ExecutedTool[]): string {
     .join(", ");
 }
 
-function buildRuntimeLimitToolLoopMessage(executedTools: ExecutedTool[]): string {
+// BI-0C19AFDD: this message must stay domain-agnostic. The prior copy hard-coded
+// a "finance reports"/"finance-summary tool" suggestion, which confabulated an
+// unrelated domain for every non-finance coworker (e.g. Dale's truck-parts build
+// was told to "use the finance reports directly"). Keep the guidance generic,
+// mirroring the honest max-iter sibling below.
+export function buildRuntimeLimitToolLoopMessage(executedTools: ExecutedTool[]): string {
   const toolSummary = summarizeExecutedToolNames(executedTools) || "the available tools";
   return [
     `I used ${toolSummary}, but the coworker hit the runtime limit before it produced a final answer.`,
     "I stopped before returning another raw tool request.",
-    "The route and tool attempts were recorded; try a narrower question or use the finance reports directly for the current totals while we add a more direct finance-summary tool.",
+    "The route and tool attempts were recorded; try a narrower question, or break the request into a smaller step.",
   ].join(" ");
 }
 

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -56,8 +56,8 @@ apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	903
 apps/web/lib/tak/agent-grants.ts	816
 apps/web/lib/tak/agent-routing.ts	965
-apps/web/lib/tak/agentic-loop.test.ts	2210
-apps/web/lib/tak/agentic-loop.ts	2588
+apps/web/lib/tak/agentic-loop.test.ts	2240
+apps/web/lib/tak/agentic-loop.ts	2593
 apps/web/lib/tak/route-context-map.ts	1226
 apps/web/lib/tak/route-context.ts	1239
 apps/web/lib/work-capsules/mcp-handlers.ts	884


### PR DESCRIPTION
## Summary
`buildRuntimeLimitToolLoopMessage` (apps/web/lib/tak/agentic-loop.ts) hard-coded a **"finance reports" / "finance-summary tool"** suggestion. Any coworker that hit the runtime limit was told to *"use the finance reports directly for the current totals"* regardless of its actual domain — the **D37** symptom, where Dale's truck-parts build got a finance hint.

This aligns the runtime-limit path to the honest, domain-agnostic copy already used by its sibling `buildMaxIterationsExhaustedMessage` (G2, 2026-05-23): summarize the tools used, state the runtime limit was hit, and suggest a narrower question / smaller step — no confabulated domain.

## Changes
- Domain-agnostic message copy; export the function for testability; provenance comment naming BI-0C19AFDD.
- Regression tests: never mentions "finance", summarizes executed tools, generic fallback when no tools ran.

## Design grounding
Trivial user-facing copy fix, no contract change. Source of truth is the honest-copy pattern in `buildMaxIterationsExhaustedMessage`; this change extends that pattern to the runtime-limit tool-loop path.

## Verification
Verified the buggy string was present on `origin/main` before editing; fix + tests added. Source-only worktree (no node_modules) — CI runs the authoritative typecheck + `agentic-loop.test.ts`.

Resolves BI-0C19AFDD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)