### PR TITLE
fix(security): stop Anthropic OAuth token leaking into BuildActivity (BI-1291B677)

### DIFF
--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -554,7 +554,14 @@ export async function getAvailableTools(
 function redactFunctionalFailureText(text: string): string {
   return text
     .replace(/\bdpfmcp_[A-Za-z0-9_-]+/g, "[redacted-token]")
-    .replace(/\bBearer\s+[A-Za-z0-9._-]+/g, "[redacted-token]");
+    .replace(/\bBearer\s+[A-Za-z0-9._-]+/g, "[redacted-token]")
+    // BI-1291B677: Anthropic OAuth tokens (sk-ant-oat01-*) and API keys
+    // (sk-ant-api03-*) in raw form.
+    .replace(/\bsk-ant-[A-Za-z0-9_-]{8,}/g, "[redacted-token]")
+    // BI-1291B677: a secret staged into the sandbox as `echo '<base64>' | base64 -d`
+    // (the CLI dispatch token / mcp-config write). Redact the base64 payload so a
+    // surfaced docker command can't be reversed back to the secret.
+    .replace(/echo '[A-Za-z0-9+\/=]{20,}'(\s*\|\s*base64\s+-d)/g, "echo '[redacted-token]'$1");
 }
 
 // BI-F4A30FCB (Dale dogfood 2026-05-24): see ideate-build-resolution.ts for

--- a/apps/web/lib/mcp/packs/build-evidence-pack.test.ts
+++ b/apps/web/lib/mcp/packs/build-evidence-pack.test.ts
@@ -158,7 +158,9 @@ describe("build-evidence pack — handler behavior (delegation preserved)", () =
         suite: "smoke",
         route: "/build",
         expected: "loads",
-        actual: "500 Bearer abc.def.ghi",
+        actual:
+          "500 Bearer abc.def.ghi; token sk-ant-oat01-DEADbeef01234567890ABCDEF; " +
+          "cmd: docker exec dpf-sandbox-1 sh -c \"echo 'c2stYW50LW9hdDAxLURFQURiZWVmMDEyMzQ1Njc4OTA' | base64 -d > /tmp/cli-token.txt\"",
         userRole: "operator",
         routeContext: "/build",
         reproCommand: "pnpm test",
@@ -172,6 +174,10 @@ describe("build-evidence pack — handler behavior (delegation preserved)", () =
     const createArg = db.backlogItemCreate.mock.calls[0][0];
     expect(createArg.data.body).toContain("[redacted-token]");
     expect(createArg.data.body).not.toContain("Bearer abc.def.ghi");
+    // BI-1291B677: Anthropic OAuth token — neither the raw sk-ant form nor the
+    // base64-staged `echo '<b64>' | base64 -d` command may survive redaction.
+    expect(createArg.data.body).not.toContain("sk-ant-oat01-DEADbeef01234567890ABCDEF");
+    expect(createArg.data.body).not.toContain("c2stYW50LW9hdDAxLURFQURiZWVmMDEyMzQ1Njc4OTA");
   });
 
   it("record_functional_failure_evidence increments an existing deduped item", async () => {

--- a/apps/web/lib/mcp/packs/build-evidence-pack.ts
+++ b/apps/web/lib/mcp/packs/build-evidence-pack.ts
@@ -18,11 +18,18 @@ import { prisma } from "@dpf/db";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
 
-/** Strip bearer tokens / MCP tokens out of operator-supplied failure text. */
+/** Strip bearer tokens / MCP tokens / Anthropic keys out of operator-supplied failure text. */
 function redactFunctionalFailureText(text: string): string {
   return text
     .replace(/\bdpfmcp_[A-Za-z0-9_-]+/g, "[redacted-token]")
-    .replace(/\bBearer\s+[A-Za-z0-9._-]+/g, "[redacted-token]");
+    .replace(/\bBearer\s+[A-Za-z0-9._-]+/g, "[redacted-token]")
+    // BI-1291B677: Anthropic OAuth tokens (sk-ant-oat01-*) and API keys
+    // (sk-ant-api03-*) in raw form.
+    .replace(/\bsk-ant-[A-Za-z0-9_-]{8,}/g, "[redacted-token]")
+    // BI-1291B677: a secret staged into the sandbox as `echo '<base64>' | base64 -d`
+    // (the CLI dispatch token / mcp-config write). Redact the base64 payload so a
+    // surfaced docker command can't be reversed back to the secret.
+    .replace(/echo '[A-Za-z0-9+\/=]{20,}'(\s*\|\s*base64\s+-d)/g, "echo '[redacted-token]'$1");
 }
 
 const definitions: ToolDefinition[] = [

--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -492,10 +492,19 @@ export const cliAdapter: ExecutionAdapterHandler = {
       let bareFlag = "";
       if (auth.mode === "oauth") {
         const tokenB64 = Buffer.from(auth.token).toString("base64");
-        await execAsync(
-          `docker exec ${SANDBOX_CONTAINER} sh -c "echo '${tokenB64}' | base64 -d > ${tokenFile} && chmod 644 ${tokenFile}"`,
-          { timeout: 5_000 },
-        );
+        try {
+          await execAsync(
+            `docker exec ${SANDBOX_CONTAINER} sh -c "echo '${tokenB64}' | base64 -d > ${tokenFile} && chmod 644 ${tokenFile}"`,
+            { timeout: 5_000 },
+          );
+        } catch {
+          // BI-1291B677: this command embeds the base64-encoded OAuth token, and a
+          // rejected exec Error carries the full command (.cmd / .message) — which
+          // would otherwise propagate the token into the dispatch error and the
+          // BuildActivity / ideate_dispatch summary. Swallow the original and
+          // re-throw a token-free error so the secret never reaches a log surface.
+          throw new Error("Failed to stage the CLI OAuth token into the sandbox.");
+        }
         authExportLine = `export CLAUDE_CODE_OAUTH_TOKEN=$(cat ${tokenFile})`;
       } else {
         authExportLine = `export ANTHROPIC_API_KEY=${auth.apiKey}`;

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -41,7 +41,7 @@ apps/web/lib/integrate/build-orchestrator.ts	1779
 apps/web/lib/integrate/sandbox/build-branch.ts	854
 apps/web/lib/marketing.ts	1367
 apps/web/lib/mcp-tools-backlog.test.ts	912
-apps/web/lib/mcp-tools.ts	1940
+apps/web/lib/mcp-tools.ts	1947
 apps/web/lib/mcp/packs/backlog-pack.ts	1328
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	846
 apps/web/lib/mcp/packs/sandbox-pack.ts	920


### PR DESCRIPTION
## Summary
The CLI dispatch path staged the Anthropic OAuth token by base64-echoing it into a `docker exec … sh -c "echo '<b64>' | base64 -d > …"` command (`apps/web/lib/routing/cli-adapter.ts`). That `execAsync` sits inside the adapter's `try` block, so a docker failure propagated the **full command — whose base64 payload decodes to `sk-ant-oat01-*`** — into the dispatch error and the BuildActivity / `ideate_dispatch` summary. The only scrubber (`redactFunctionalFailureText`) covered `dpfmcp_*` / `Bearer *` but **not** `sk-ant-*` or base64-staged secrets.

## Fix — two layers
1. **Source (`cli-adapter.ts`)** — wrap the token-staging `execAsync` in try/catch and re-throw a **token-free** error, so the secret-bearing command can never reach a log surface at its origin. Behavior-preserving: the token still stages into the sandbox exactly as before.
2. **Defense-in-depth (`redactFunctionalFailureText`, both copies)** — also strip raw `sk-ant-*` tokens and the `echo '<base64>' | base64 -d` staging pattern. This covers the mcp-config JWT and any other command-surface echo on the failure-text/evidence write paths.

## Verification
- Node harness confirms all three secret forms redact (raw `sk-ant-`, base64 blob, existing Bearer).
- Regression test extends the evidence-pack redaction case with the raw sk-ant token **and** the base64-staged command.
- Source-only worktree — CI runs the authoritative typecheck + `build-evidence-pack.test.ts`.

## Design grounding
Security hardening, no behavior/contract change. Follow-up (separate item): rework `writeSandboxFile` to pipe secrets via **stdin** so they never enter argv at all — the root-cause structural fix.

## ⚠️ Operator action
**Rotate the Anthropic OAuth token** if it may already have been captured in stored BuildActivity summaries prior to this fix.

Resolves BI-1291B677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)