### PR TITLE
fix(build): D33 design-review banner uses operator vocabulary, not tool name (BI-62442F75)

### DIFF
--- a/apps/web/lib/explore/feature-build-types.test.ts
+++ b/apps/web/lib/explore/feature-build-types.test.ts
@@ -601,7 +601,9 @@ describe("describeDesignReviewFailure (BI-CE49D82E)", () => {
   it("returns base reason when no iteration metadata is attached", () => {
     const reason = describeDesignReviewFailure(review());
     expect(reason).toContain("Design review failed");
-    expect(reason).toContain("re-run reviewDesignDoc");
+    // BI-62442F75: operator vocabulary — must NOT leak the raw camelCase tool name.
+    expect(reason).toContain("re-run the design review");
+    expect(reason).not.toContain("reviewDesignDoc");
     expect(reason).not.toContain("Round");
   });
 

--- a/apps/web/lib/explore/feature-build-types.ts
+++ b/apps/web/lib/explore/feature-build-types.ts
@@ -696,7 +696,10 @@ export function describePlanReviewFailure(planReview: ReviewResult): string {
  *  the design path (BI-CE49D82E). Same convergence/oscillation language so the
  *  operator's mental model is consistent across phase gates. */
 export function describeDesignReviewFailure(designReview: ReviewResult): string {
-  const base = "Design review failed. Revise the design document and re-run reviewDesignDoc before advancing.";
+  // BI-62442F75: operator vocabulary, not the raw camelCase tool name. Mirrors
+  // the plan sibling's "re-run plan review" so the D33 banner never leaks
+  // "reviewDesignDoc" into human-facing copy.
+  const base = "Design review failed. Revise the design document and re-run the design review before advancing.";
   const iter = designReview.iteration;
   if (!iter) return base;
   const round = `Round ${iter.round}`;

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -33,7 +33,7 @@ apps/web/lib/actions/tax-remittance.ts	1788
 apps/web/lib/ai-operations-map/load-map-data.test.ts	943
 apps/web/lib/deliberation/orchestrator.ts	808
 apps/web/lib/explore/build-process-matrix.ts	811
-apps/web/lib/explore/feature-build-types.ts	1106
+apps/web/lib/explore/feature-build-types.ts	1109
 apps/web/lib/finance/ai-provider-finance.ts	1309
 apps/web/lib/inference/ai-provider-internals.ts	1228
 apps/web/lib/integrate/build-agent-prompts.ts	1054


### PR DESCRIPTION
## Summary
`describeDesignReviewFailure` — the operator-facing reason string rendered in the Build Studio **D33 status banner** — hardcoded the raw camelCase tool name: *"…re-run **reviewDesignDoc** before advancing."* Its plan-review sibling `describePlanReviewFailure` already uses plain English (*"re-run plan review"*). This aligns the design path to the same operator vocabulary so the banner never leaks an internal tool name.

The agent-facing tool-result guidance in `mcp-tools.ts` still names the tools — the agent needs them to act. **Only the human banner copy changes.**

## Changes
- `feature-build-types.ts` — banner base string → *"…re-run the design review before advancing."*
- Regression test asserts the banner contains `re-run the design review` and never the raw `reviewDesignDoc`.

## Design grounding
Trivial user-facing copy fix, no contract change. Source of truth is the sibling `describePlanReviewFailure`'s operator vocabulary.

## Verification
Confirmed the leaked string was present on `origin/main`; the plan sibling was already clean. Source-only worktree — CI runs the authoritative typecheck + `feature-build-types.test.ts`.

Resolves BI-62442F75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)