### PR TITLE
fix(test): de-time-bomb crm lifecycle test — was failing shard 4/4 post-midnight (BI-435905C1)

### DIFF
--- a/apps/web/lib/actions/crm.test.ts
+++ b/apps/web/lib/actions/crm.test.ts
@@ -561,7 +561,13 @@ describe("updateCustomerConfigurationItem", () => {
       ciType: "linux-server",
       supportModel: "lts",
       normalizedVersion: "22.04 LTS",
-      endOfSupportAt: "2026-07-15",
+      // BI-435905C1: keep end-of-support ~60 days out RELATIVE to now, so it
+      // stays inside evaluateTechnologyLifecycle's REVIEW_WINDOW_DAYS (120) band
+      // ("approaching_end") no matter when CI runs. A hardcoded "2026-07-15"
+      // silently flipped to "expired"/"upgrade_due" the moment the clock passed
+      // it (2026-07-15T00:00 UTC), failing this test deterministically post-
+      // midnight — a time-bomb, not a mock-bleed flake.
+      endOfSupportAt: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
       evidenceSource: "Ubuntu LTS release calendar",
       evidenceNotes: "Verified against vendor-supported LTS timeline.",
       reviewCadenceDays: 45,


### PR DESCRIPTION
## Root cause (corrected)
`Unit Tests (web shard 4/4)` began failing deterministically at **2026-07-15T00:00 UTC** on `apps/web/lib/actions/crm.test.ts:571` — *"updates lifecycle evidence and recalculates support posture."*

It is **not** a mock-bleed / teardown flake (my first hypothesis). It's a **time-bomb test**: it hardcoded `endOfSupportAt: "2026-07-15"` and asserted `supportStatus: "approaching_end"` / `lifecycleStatus: "review"`. `evaluateTechnologyLifecycle` (lifecycle-evaluation.ts) classifies `endOfSupportAt <= now` as **expired**, and only a date within `REVIEW_WINDOW_DAYS` (120) in the future as **approaching_end**. The moment the wall clock passed 2026-07-15, the fixed date became the past → `expired`/`upgrade_due` → assertion mismatch.

This is why main's last **pre-midnight** run (22:49 UTC) was green while every post-midnight run — including three unrelated feature PRs (#2970/#2971/#2972) — failed the same assertion. The `[quiescence]`/`[memory-corpus]` log lines were unrelated interleaved shard output, and those tests are correctly fake-timered.

## Fix
Compute `endOfSupportAt` ~60 days out **relative to `now`**, so it stays inside the `approaching_end` band regardless of when CI runs. The assertion uses `expect.objectContaining` and doesn't pin the exact date, so no other change is needed. Verified via a standalone harness: 60 days out → `daysUntil≈59`, not expired, `approaching_end=true`.

## Impact
Unblocks the required `Unit Tests` check for every PR (it was failing platform-wide post-midnight, not just mine). After this lands on main, #2970/#2971/#2972 go green on re-run.

Resolves BI-435905C1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)