### PR TITLE
fix(self-upgrade): always rebuild the promoter before a swap (BET-5)

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -21,13 +21,13 @@ const mocks = vi.hoisted(() => ({
   getLatestRun: vi.fn(),
   getLatestSucceededRun: vi.fn(),
   runPromoter: vi.fn(),
-  // Skip-before-drain guard: promoter image present by default in every setup.
+  // Retained for back-compat; the precheck no longer calls it (it always rebuilds).
   isPromoterAvailable: vi.fn().mockResolvedValue(true),
-  // Auto-heal: default to "couldn't build" so a test that flips the image to
-  // absent still exercises the skip path unless it opts into a successful build.
+  // The precheck ALWAYS rebuilds the promoter before a swap, so the default is a
+  // successful rebuild; a test opts into failure to exercise the skip path.
   ensurePromoterImage: vi
     .fn()
-    .mockResolvedValue({ ok: false, alreadyPresent: false, built: false, skipReason: "build-failed" }),
+    .mockResolvedValue({ ok: true, alreadyPresent: false, built: true }),
   // Cooldown backoff (this fix): no active cooldown by default.
   getCooldownUntil: vi.fn().mockResolvedValue(null),
   recordCooldown: vi.fn().mockResolvedValue(undefined),
@@ -1116,12 +1116,13 @@ describe("skip-before-drain guards", () => {
     // clearAllMocks resets call history but NOT implementations, so re-assert
     // the gate defaults each test (a prior describe can leave them flipped).
     mocks.isCheckIntervalElapsed.mockReturnValue(true);
+    // The precheck ALWAYS rebuilds the promoter (ensurePromoterImage) before a swap, so the
+    // happy-path default is a successful rebuild; individual tests override to a failure.
     mocks.isPromoterAvailable.mockResolvedValue(true);
     mocks.ensurePromoterImage.mockResolvedValue({
-      ok: false,
+      ok: true,
       alreadyPresent: false,
-      built: false,
-      skipReason: "build-failed",
+      built: true,
     });
     mocks.getCooldownUntil.mockResolvedValue(null);
     mocks.recordCooldown.mockResolvedValue(undefined);
@@ -1137,9 +1138,9 @@ describe("skip-before-drain guards", () => {
     mocks.completeRun.mockResolvedValue({});
   });
 
-  it("skips with promoter-unavailable BEFORE draining when the image is absent AND unbuildable", async () => {
-    mocks.isPromoterAvailable.mockResolvedValue(false);
-    // Auto-heal is attempted first; skip only survives when the build fails.
+  it("skips with promoter-unavailable BEFORE draining when the promoter cannot be built", async () => {
+    // The precheck always rebuilds the promoter; the skip survives only when that build fails
+    // (or a custom/registry image is configured that we cannot synthesise locally).
     mocks.ensurePromoterImage.mockResolvedValue({
       ok: false,
       alreadyPresent: false,
@@ -1179,7 +1180,13 @@ describe("skip-before-drain guards", () => {
   });
 
   it("marks a pre-created queued run skipped when a pre-drain guard stops the attempt", async () => {
-    mocks.isPromoterAvailable.mockResolvedValue(false);
+    // The promoter rebuild fails → the pre-drain promoter-unavailable guard stops the attempt.
+    mocks.ensurePromoterImage.mockResolvedValue({
+      ok: false,
+      alreadyPresent: false,
+      built: false,
+      skipReason: "build-failed",
+    });
 
     const result = await runSelfUpgrade({
       triggeredBy: "manual:ops",
@@ -1199,14 +1206,14 @@ describe("skip-before-drain guards", () => {
     expect(mocks.createRun).not.toHaveBeenCalled();
   });
 
-  it("checks promoter availability against the configured image", async () => {
+  it("rebuilds the promoter against the configured image", async () => {
     await runSelfUpgrade({ triggeredBy: "scheduled", scheduled: true });
-    expect(mocks.isPromoterAvailable).toHaveBeenCalledWith("dpf-promoter");
+    expect(mocks.ensurePromoterImage).toHaveBeenCalledWith("dpf-promoter");
   });
 
-  it("does NOT check the promoter on a dryRun (it never swaps)", async () => {
+  it("does NOT touch the promoter on a dryRun (it never swaps)", async () => {
     await runSelfUpgrade({ triggeredBy: "ops", dryRun: true });
-    expect(mocks.isPromoterAvailable).not.toHaveBeenCalled();
+    expect(mocks.ensurePromoterImage).not.toHaveBeenCalled();
   });
 
   it("skips with up-to-date (no drain) when the built stamp already matches the deployed SHA", async () => {

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -211,13 +211,19 @@ export async function runSelfUpgrade(
   // fails (or a custom/registry image is configured, which the operator pulls).
   // A skip here remains a clean no-op: no cooldown, and the next tick re-checks.
   if (!params.dryRun) {
-    const { isPromoterAvailable, ensurePromoterImage } = await loadPromoterRuntime();
-    let promoterReady = await isPromoterAvailable(config.promoterImage);
-    if (!promoterReady) {
-      const healed = await ensurePromoterImage(config.promoterImage);
-      promoterReady = healed.ok;
-    }
-    if (!promoterReady) {
+    const { ensurePromoterImage } = await loadPromoterRuntime();
+    // ALWAYS rebuild the promoter before a swap, not only when its image is absent.
+    // The promoter bakes promote.sh into its image (Dockerfile.promoter ENTRYPOINT), so a
+    // promoter image built by an EARLIER portal version carries THAT version's promote.sh.
+    // Reusing a stale-but-present image means a promote.sh fix shipped in the portal never
+    // reaches the promoter that runs it — the live symptom: an install whose dpf-promoter
+    // predated BET-5 ran the old promote.sh, so the pgvector-recreate (step 3a) and the
+    // Neo4j/Qdrant decommission (step 7c) silently never executed and the upgrade died at
+    // migrate. ensurePromoterImage() rebuilds JIT-buildable images from the portal's baked
+    // /promoter/ files every time (custom/registry images are still left to the operator's
+    // pull), keeping the promoter's promote.sh in lock-step with the running portal.
+    const ensured = await ensurePromoterImage(config.promoterImage);
+    if (!ensured.ok) {
       const promoterImage = config.promoterImage ?? "dpf-promoter";
       return await skipAttempt(
         "promoter-unavailable",

--- a/docs/superpowers/plans/2026-07-13-bet5-db-compression-plan.md
+++ b/docs/superpowers/plans/2026-07-13-bet5-db-compression-plan.md
@@ -176,3 +176,29 @@ data-preserving (`pgvector/pgvector:pg16` is the same PG16 engine on the same `p
 strict superset image — no dump/restore). Step 3a is fail-closed (abort before swap); the
 sandbox-postgres recreate is fail-loud-not-abort like the rest of 7b. This makes every existing
 install (Mac + Windows) upgrade cleanly with no manual DB step.
+
+### Self-upgrade promoter-staleness (the deeper gap the live test exposed, 2026-07-14)
+
+The first live re-trigger still failed — and revealed a THIRD, more fundamental gap. The promoter
+**bakes `promote.sh` into its image** (`Dockerfile.promoter` ENTRYPOINT), and the self-upgrade
+pre-drain check only (re)built the promoter when its image was **absent** — a stale-but-present
+`dpf-promoter` (built before BET-5) was reused as-is. So the `ensure-pgvector` (3a) and decommission
+(7c) steps in the fixed `promote.sh` **never ran** — the promoter executed its old baked copy, went
+straight to migrate, and died on `CREATE EXTENSION vector`. That first (pre-fix) attempt also left
+the `20260714110000_bet5_pgvector_foundation` migration in a FAILED state, so every later attempt
+then hit **P3009** ("failed migrations… new migrations will not be applied").
+
+Fix (this PR):
+- **Always rebuild the promoter before a swap** (`self-upgrade.ts` precheck now calls
+  `ensurePromoterImage` unconditionally for JIT-buildable images, not only when absent), keeping the
+  promoter's `promote.sh` in lock-step with the running portal. Custom/registry promoter images are
+  still left to the operator's pull.
+- **P3009 self-heal** in `promote.sh` step 3a: once pgvector is guaranteed present, `migrate resolve
+  --rolled-back` the pgvector-foundation migration if a prior pre-fix attempt left it failed — scoped
+  to that one migration (which fails at its first statement, so rolling it back is a data no-op).
+
+**Bootstrap caveat:** a fix to the self-upgrade machinery can't retroactively un-stick an install
+whose portal AND promoter both predate the fix — the orchestrating portal is the old one. Such an
+install (this Mac, and Windows) needs ONE manual bootstrap — rebuild `dpf-promoter` from the target
+source, which then carries the fixed `promote.sh` — after which `ensure-pgvector` + the P3009
+self-heal complete the upgrade automatically. From then on the always-rebuild keeps it self-sustaining.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -47,7 +47,7 @@ apps/web/lib/mcp/packs/contribution-hive-pack.ts	846
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
 apps/web/lib/navigation/portal-navigation-model.ts	937
 apps/web/lib/operate/coworker-regression-detector.ts	935
-apps/web/lib/queue/functions/self-upgrade.test.ts	1328
+apps/web/lib/queue/functions/self-upgrade.test.ts	1335
 apps/web/lib/routing/chat-adapter.test.ts	820
 apps/web/lib/routing/fallback.test.ts	1038
 apps/web/lib/self-upgrade/quiescence.test.ts	865

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -198,6 +198,16 @@ if [[ $_dry_run -eq 0 ]]; then
     done
     [[ $_pg_ready -eq 1 ]] || { printf 'error: postgres did not become ready after the pgvector recreate\n' >&2; exit 1; }
   fi
+  # P3009 recovery (BET-5): an install that attempted this upgrade on a pre-fix promoter (no
+  # pgvector) left the pgvector-foundation migration in a FAILED state, which then blocks ALL
+  # subsequent `migrate deploy` with P3009 — even after pgvector is present. Now that pgvector
+  # is guaranteed available above, clear that ONE failed record so deploy can re-apply it.
+  # Scoped to this single migration, which fails at its first statement (CREATE EXTENSION), so
+  # nothing was applied and rolling it back is a no-op on data. Best-effort (`|| true`): a
+  # clean install has no such record and this is a harmless miss.
+  docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+    "${_f_args[@]}" run --rm -T --no-deps --entrypoint sh portal \
+    -c 'cd /app && pnpm --filter @dpf/db exec prisma migrate resolve --rolled-back 20260714110000_bet5_pgvector_foundation' >/dev/null 2>&1 || true
 fi
 
 # --- Step 3b: migrate ---


### PR DESCRIPTION
## BET-5 self-upgrade completion — always rebuild the promoter

A **live self-upgrade re-trigger** (after #2969 merged) still failed, exposing a deeper gap. The promoter **bakes `promote.sh` into its image** (`Dockerfile.promoter` ENTRYPOINT), and the pre-drain check only (re)built the promoter when its image was **absent** — a stale-but-present `dpf-promoter` (built before BET-5) was reused as-is. So the fixed `promote.sh` (with `ensure-pgvector` step 3a + the Neo4j/Qdrant decommission step 7c) **never ran**: the promoter executed its old baked copy, went straight to migrate, and died on `CREATE EXTENSION vector`. That first pre-fix attempt also left `20260714110000_bet5_pgvector_foundation` in a FAILED state, so subsequent attempts hit **P3009**.

### Fix
- **`self-upgrade.ts` precheck now ALWAYS rebuilds** the promoter before a swap (`ensurePromoterImage` for JIT-buildable images, not only when absent), keeping the promoter's `promote.sh` in lock-step with the running portal. Custom/registry promoter images are still left to the operator's pull.
- **`promote.sh` step 3a self-heals a prior P3009**: once pgvector is guaranteed present, `migrate resolve --rolled-back` the pgvector-foundation migration if a pre-fix attempt left it failed — scoped to that one migration (it fails at its first statement, so rolling it back is a data no-op).

### Bootstrap caveat (documented in the plan)
A fix to the self-upgrade machinery can't retroactively un-stick an install whose **portal AND promoter both predate** the fix — the orchestrating portal is the old one. Such an install (the Mac test box + Windows) needs ONE manual bootstrap: rebuild `dpf-promoter` from the target source (which then carries the fixed `promote.sh`), after which `ensure-pgvector` + the P3009 self-heal complete the upgrade automatically. From then on, always-rebuild keeps it self-sustaining.

### Verification
- Diagnosed against the two live failed runs (P3018 `extension "vector" is not available` → P3009), the stale `dpf-promoter:latest` (2026-07-12, pre-BET-5), and the failed `_prisma_migrations` record.
- `self-upgrade.test.ts` + `promoter.test.ts` + `skip-reason.test.ts`: **109 passed**; bundle-boundary passes; `apps/web` tsc **0 errors**; `bash -n scripts/promote.sh` clean.

Local-CI-Override: apps/web tsc 0 errors + 110 self-upgrade unit tests green + `bash -n` clean, verified at 8GB heap; local prepush gate OOMs cold. CI is authoritative.

Process-Spine-Decision: extend — BET-5 self-upgrade completion; plan updated with the promoter-staleness gap + fix.
Design-Grounding-Decision: extend — BET-5 self-upgrade orchestration hardening (apps/web/lib precheck); no new contract or UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
