### PR TITLE
fix(crm): de-flake lifecycle test date boundary

### DIFF
--- a/apps/web/lib/actions/crm.test.ts
+++ b/apps/web/lib/actions/crm.test.ts
@@ -561,7 +561,13 @@ describe("updateCustomerConfigurationItem", () => {
       ciType: "linux-server",
       supportModel: "lts",
       normalizedVersion: "22.04 LTS",
-      endOfSupportAt: "2026-07-15",
+      // Relative to now (~60 days out, inside the 120-day REVIEW_WINDOW_DAYS) so the computed
+      // "approaching_end" posture is stable across the calendar-day boundary. A hardcoded date
+      // ("2026-07-15") flipped to the "expired" branch once "today" reached it — a date-boundary
+      // flake that failed every run on/after that date.
+      endOfSupportAt: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10),
       evidenceSource: "Ubuntu LTS release calendar",
       evidenceNotes: "Verified against vendor-supported LTS timeline.",
       reviewCadenceDays: 45,


### PR DESCRIPTION
## Date-boundary flake blocking the merge queue

`lib/actions/crm.test.ts` hardcoded `endOfSupportAt: "2026-07-15"` and asserted an `approaching_end` support posture that `customer-estate/lifecycle-evaluation.ts` computes **relative to now**. Once the calendar reached that date, `endOfSupportAt <= now` flipped the result to the `expired` branch (line 123 vs 147), so the test failed **every run on/after 2026-07-15** — a deterministic date-boundary flake that blocked the entire merge queue platform-wide today.

### Fix (test-only)
Use a date ~60 days in the future (inside the 120-day `REVIEW_WINDOW_DAYS`) computed relative to `Date.now()`, so the posture is stable across any calendar day.

### Verification
- `lib/actions/crm.test.ts`: **13/13 pass** (was 1 failed / 12).
- Confirmed the failure reproduces on clean `origin/main` and is unrelated to any feature change.

Local-CI-Override: test-only one-line change; crm.test.ts 13/13 green locally; CI authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)