### PR TITLE
fix(setup): idempotent agentToolGrant seeding — race-safe createMany (BI-25A1ADF7)

### DIFF
--- a/apps/web/lib/inference/bootstrap-first-run.test.ts
+++ b/apps/web/lib/inference/bootstrap-first-run.test.ts
@@ -14,6 +14,7 @@ vi.mock("@dpf/db", () => ({
     },
     agentToolGrant: {
       upsert: vi.fn(),
+      createMany: vi.fn(),
     },
     agentToolGrantRevocation: {
       findMany: vi.fn().mockResolvedValue([]),
@@ -96,6 +97,39 @@ describe("bootstrap-first-run", () => {
         }),
       );
       expect(syncAgentPrincipal).toHaveBeenCalledWith("onboarding-coo");
+    });
+
+    // BI-25A1ADF7: the tool grants must be seeded via a single race-safe
+    // createMany({ skipDuplicates }) — not a per-grant upsert loop that races
+    // the (agentId, grantKey) composite unique on concurrent cold-install runs.
+    it("seeds tool grants via a single idempotent createMany with skipDuplicates", async () => {
+      (prisma.agent.upsert as any).mockResolvedValue({ id: "cuid-coo", agentId: "onboarding-coo" });
+      (prisma.agentModelConfig.upsert as any).mockResolvedValue({ agentId: "onboarding-coo" });
+      await seedOnboardingAgent();
+      expect(prisma.agentToolGrant.upsert).not.toHaveBeenCalled();
+      expect(prisma.agentToolGrant.createMany).toHaveBeenCalledTimes(1);
+      const arg = (prisma.agentToolGrant.createMany as any).mock.calls[0][0];
+      expect(arg.skipDuplicates).toBe(true);
+      expect(arg.data).toEqual(
+        expect.arrayContaining([
+          { agentId: "cuid-coo", grantKey: "registry_write" },
+          { agentId: "cuid-coo", grantKey: "email_config" },
+        ]),
+      );
+      // Every row is scoped to the resolved agent PK (not the semantic agentId).
+      for (const row of arg.data) expect(row.agentId).toBe("cuid-coo");
+    });
+
+    it("omits revoked grants (BI-4FA040D5 tombstones) from the createMany insert", async () => {
+      (prisma.agent.upsert as any).mockResolvedValue({ id: "cuid-coo", agentId: "onboarding-coo" });
+      (prisma.agentModelConfig.upsert as any).mockResolvedValue({ agentId: "onboarding-coo" });
+      (prisma.agentToolGrantRevocation.findMany as any).mockResolvedValueOnce([
+        { grantKey: "web_search" },
+      ]);
+      await seedOnboardingAgent();
+      const arg = (prisma.agentToolGrant.createMany as any).mock.calls[0][0];
+      expect(arg.data.map((r: { grantKey: string }) => r.grantKey)).not.toContain("web_search");
+      expect(arg.data.map((r: { grantKey: string }) => r.grantKey)).toContain("file_read");
     });
   });
 });

--- a/apps/web/lib/inference/bootstrap-first-run.ts
+++ b/apps/web/lib/inference/bootstrap-first-run.ts
@@ -65,14 +65,19 @@ export async function seedOnboardingAgent(): Promise<void> {
     select: { grantKey: true },
   });
   const revokedKeys = new Set(revoked.map((r) => r.grantKey));
-  for (const grantKey of grants) {
-    if (revokedKeys.has(grantKey)) continue;
-    await prisma.agentToolGrant.upsert({
-      where: { agentId_grantKey: { agentId: agent.id, grantKey } },
-      update: {},
-      create: { agentId: agent.id, grantKey },
-    });
-  }
+  // BI-25A1ADF7: two concurrent cold-install setup-init passes raced this
+  // per-grant loop on the agentToolGrant (agentId, grantKey) composite unique —
+  // each upsert does read-then-write, so both could miss the row and one insert
+  // lost the race with P2002. A single createMany with skipDuplicates is an
+  // atomic insert that DB-side no-ops on existing rows (ON CONFLICT DO NOTHING),
+  // so it is idempotent AND race-safe. The upsert's update was a no-op ({}), so
+  // there is no lost mutation. Revocation tombstones (BI-4FA040D5) still honored.
+  await prisma.agentToolGrant.createMany({
+    data: grants
+      .filter((grantKey) => !revokedKeys.has(grantKey))
+      .map((grantKey) => ({ agentId: agent.id, grantKey })),
+    skipDuplicates: true,
+  });
 
   // EP-AI-WORKFORCE-001: Provider selection via capability requirements (not pinning).
   // Uses capability-based routing: router picks best available provider meeting floor.


### PR DESCRIPTION
## Summary
`seedOnboardingAgent` (apps/web/lib/inference/bootstrap-first-run.ts) seeded the onboarding-COO's tool grants with a **per-grant `prisma.agentToolGrant.upsert` loop**. Two concurrent cold-install setup-init passes — reproduced on two consecutive cold installs — raced the `(agentId, grantKey)` composite unique: each upsert does read-then-write, both could miss the row, and one insert lost with **P2002**.

## Fix
Replace the loop with a single `prisma.agentToolGrant.createMany({ skipDuplicates: true })` — an atomic insert that DB-side no-ops on existing rows (`ON CONFLICT DO NOTHING`), so it's idempotent **and** race-safe. The upsert's `update` was a no-op (`{}`), so no mutation is lost. Revocation tombstones (BI-4FA040D5) are still filtered out before the insert.

Same idempotency pattern already used for the PlatformIssueReport dedupe race (BI-PIR-76bf293c, #2964).

## Tests
- Grants are seeded via exactly one `createMany({skipDuplicates:true})` and never via `upsert`; every row scoped to the resolved agent PK.
- Revoked grants (BI-4FA040D5 tombstones) are omitted from the insert.

## Design grounding
Existing specs/plans reviewed — none pin the seed mechanism; grounded in the current code substrate `apps/web/lib/inference/bootstrap-first-run.ts`. Bug-fix only, no contract/routing change.

## Verification
Confirmed the racy upsert loop was present on `origin/main` before editing (verification sweep). Fix + tests added. Source-only worktree — CI runs the authoritative typecheck + `bootstrap-first-run.test.ts`.

Resolves BI-25A1ADF7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)