### PR TITLE
fix(self-upgrade): ensure-pgvector recreate no longer strands postgres (BET-5)

### DIFF
--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -298,4 +298,68 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       rmSync(root, { recursive: true, force: true });
     }
   }, PROMOTE_TEST_TIMEOUT_MS);
+
+  // BET-5 (BI-A1E864A5): ensure-pgvector must detect pgvector image-agnostically
+  // via pg_available_extensions. A container already on the pgvector image answers
+  // the probe with "1", so the recreate is SKIPPED — no churn, no risk. (The
+  // original bug probed a hard-coded control-file path that the Debian pgvector
+  // image doesn't use, so the skip never fired and it recreated on every upgrade.)
+  it("SKIPS the pgvector recreate when the image already provides vector (pg_available_extensions=1)", () => {
+    const { root, source, backup, head } = makeScratch();
+    try {
+      const bin = join(root, "vecbin");
+      mkdirSync(bin, { recursive: true });
+      const dockerLog = join(root, "docker.log");
+      // A docker shim whose `psql ... pg_available_extensions` probe reports vector
+      // present ("1"); everything else behaves like the default fake.
+      writeFileSync(
+        join(bin, "docker"),
+        '#!/bin/sh\n[ -n "$DOCKER_LOG" ] && printf "%s\\n" "$*" >> "$DOCKER_LOG"\ncase "$*" in\n  *pg_available_extensions*) printf "1" ;;\n  *"/app/.dpf-source-content-hash"*) printf "deadbeefhash" ;;\nesac\nexit 0\n',
+      );
+      writeFileSync(
+        join(bin, "curl"),
+        '#!/bin/sh\nfor a in "$@"; do url="$a"; done\ncase "$url" in\n  */sha) printf "%s" "$DPF_VERSION" ;;\n  *) printf "ok" ;;\nesac\nexit 0\n',
+      );
+      chmodSync(join(bin, "docker"), 0o755);
+      chmodSync(join(bin, "curl"), 0o755);
+
+      const r = runPromote({ source, backup, targetSha: head, fakeBin: bin, dockerLog });
+
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain(`step=done target=${head}`);
+      // The recreate marker never prints and no postgres/sandbox-postgres recreate runs.
+      expect(r.stdout).not.toContain("ensure-pgvector-recreate");
+      const log = readFileSync(dockerLog, "utf8");
+      expect(log).not.toContain("force-recreate postgres");
+      expect(log).not.toContain("force-recreate sandbox-postgres");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, PROMOTE_TEST_TIMEOUT_MS);
+
+  // BET-5 (BI-A1E864A5): when a recreate IS needed, it must be host-bind-safe. The
+  // promoter runs compose with --project-directory=/host-source, so the postgres
+  // service's relative ./scripts/init-inngest-db.sh bind would resolve to an
+  // unshareable /host-source path and strand the container. The fix recreates via an
+  // extra override compose file (pins the pgvector image, resets volumes to the named
+  // data volume only) — so the recreate line carries a SECOND `-f`, not the bare
+  // base-only `up --force-recreate postgres` that dragged the host bind.
+  it("recreates postgres onto pgvector host-bind-safe (via an override compose file)", () => {
+    const { root, source, backup, fakeBin, head } = makeScratch();
+    try {
+      const dockerLog = join(root, "docker.log");
+      const r = runPromote({ source, backup, targetSha: head, fakeBin, dockerLog });
+
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("step=ensure-pgvector-recreate");
+      const log = readFileSync(dockerLog, "utf8");
+      const pgLine = log.split("\n").find((l) => l.includes("force-recreate postgres"));
+      expect(pgLine).toBeDefined();
+      // Base compose contributes one `-f`; the host-bind-safe override adds a second.
+      // A regression to the bare `up --force-recreate postgres` would carry only one.
+      expect((pgLine!.match(/ -f /g) ?? []).length).toBeGreaterThanOrEqual(2);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, PROMOTE_TEST_TIMEOUT_MS);
 });

--- a/docs/superpowers/plans/2026-07-13-bet5-db-compression-plan.md
+++ b/docs/superpowers/plans/2026-07-13-bet5-db-compression-plan.md
@@ -202,3 +202,51 @@ whose portal AND promoter both predate the fix — the orchestrating portal is t
 install (this Mac, and Windows) needs ONE manual bootstrap — rebuild `dpf-promoter` from the target
 source, which then carries the fixed `promote.sh` — after which `ensure-pgvector` + the P3009
 self-heal complete the upgrade automatically. From then on the always-rebuild keeps it self-sustaining.
+
+## Fix 3 — ensure-pgvector is fleet-fatal (recreate strands postgres) — 2026-07-14
+
+The live re-trigger on the Mac box (with the always-rebuild promoter from Fix 2) got past
+`docker-build`, entered `ensure-pgvector`, recreated `dpf-postgres-1` onto the pgvector image — and
+**left it dead in `Created` state**, taking the whole DB offline and aborting the run before migrate.
+Root cause = **two bugs in `promote.sh` step 3a `ensure-pgvector`** (both fleet-fatal — they would
+brick postgres on the FIRST BET-5 upgrade of every existing install, and a non-technical operator
+cannot recover a `Created` postgres at fleet scale):
+
+1. **Wrong `vector.control` path.** The idempotency check tested
+   `/usr/local/share/postgresql/extension/vector.control`, but the Debian-based
+   `pgvector/pgvector:pg16` image keeps it at `/usr/share/postgresql/16/extension/vector.control`.
+   So the "already pgvector, skip" branch NEVER fired → it `--force-recreate`d postgres on every run.
+2. **The recreate stranded postgres.** It ran `docker compose --project-directory "$PROMOTE_SOURCE"
+   up -d --force-recreate postgres` from INSIDE the promoter, where `PROMOTE_SOURCE`=`/host-source`
+   (the promoter's in-container mount). The postgres service's RELATIVE host bind
+   `./scripts/init-inngest-db.sh` therefore resolved to `/host-source/scripts/...` — a path the HOST
+   docker daemon can't share → `mounts denied` → container stuck in `Created`. (The portal recreate
+   escapes this because its only host bind uses the ABSOLUTE `${DPF_HOST_INSTALL_PATH:-.}` env, not a
+   relative `./`.) Same bug in step 7b's `sandbox-postgres` recreate.
+
+Fix (this PR):
+- **Image-agnostic vector detection** — new `_pg_provides_vector()` helper queries
+  `pg_available_extensions` (reflects the on-disk control file wherever it lives) instead of a
+  hard-coded path. Used by both step 3a and step 7b.
+- **Host-bind-safe recreate** — new `_recreate_pg_onto_pgvector()` helper recreates the service with
+  an extra compose override (`!override`) that pins the pgvector image and resets volumes to ONLY the
+  named data volume (`pgdata` / `sandbox_pgdata`), dropping the init-script host bind. The init script
+  only runs on an empty data dir (never on an upgrade), so this is behaviourally a no-op AND fully
+  data-preserving (the named volume is untouched).
+- **Regression tests** (`promote-script-functional.test.ts`, run against the REAL script): (a) SKIPS
+  the recreate when `pg_available_extensions` reports vector present; (b) when a recreate IS needed,
+  the postgres recreate line carries a SECOND `-f` (the override) — a regression to the bare
+  `up --force-recreate postgres` that dragged the host bind would carry only one.
+
+**Live recovery of the Mac box** (data never at risk — the named `dpf_pgdata` volume was intact): the
+stranded container already had the right image (pgvector) + volume, so `docker rm dpf-postgres-1` then
+`docker compose -p dpf -f <host compose files> -f <override pinning pgvector image> up -d --no-deps
+--no-build postgres` from the REAL host path brought it back Up (healthy) with all data. Portal kept
+serving on the old sha throughout (fail-closed held). P3009 left in place so the fixed promoter's
+self-heal is exercised on the next re-trigger.
+
+**Fleet-readiness decision (kernel-routed, 2026-07-14):** this fix unblocks the Mac + Windows boxes
+but BET-5 is NOT declared fleet-ready on it alone — the machinery-first Wave-1/Wave-2 re-sequencing
+remains a tracked follow-up (a self-upgrade must never ship a step the currently-deployed machinery
+can't execute). principle_decide ledger: fix-verify-hold-fleet 8.90 / fold-resequence 8.73 /
+minimal-now 7.86 (confidence low; operator confirmed fix-verify-hold-fleet).

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -73,6 +73,48 @@ emit_step() {
   fi
 }
 
+# BET-5 (BI-A1E864A5): does this Postgres container's IMAGE provide the pgvector
+# extension? Image-agnostic — query pg_available_extensions (which reflects the
+# on-disk control file wherever it lives) instead of probing a hard-coded path.
+# The Debian-based pgvector/pgvector image keeps vector.control at
+# /usr/share/postgresql/16/extension, NOT /usr/local/share/postgresql/extension
+# (a source build's path), so a path probe wrongly reports "absent" on the very
+# image we recreate onto — making the idempotent skip never fire and recreating
+# Postgres on every upgrade. `psql -U` connects over the local socket (trust), so
+# no password is needed. Returns 0 (yes) / non-zero (no).
+_pg_provides_vector() {
+  local _c="$1" _out
+  _out="$(docker exec "$_c" psql -U "${POSTGRES_USER:-dpf}" -d "${POSTGRES_DB:-dpf}" -tAc \
+    "select 1 from pg_available_extensions where name = 'vector' limit 1" 2>/dev/null | tr -d '[:space:]')"
+  [[ "$_out" == "1" ]]
+}
+
+# BET-5 (BI-A1E864A5): recreate a Postgres service onto the pgvector image WITHOUT
+# dragging any host bind mount. The promoter runs compose with
+# --project-directory="$PROMOTE_SOURCE" (its in-container /host-source mount), so a
+# service's RELATIVE host bind — the main postgres mounts ./scripts/init-inngest-db.sh
+# — resolves to /host-source/scripts/..., a path the HOST docker daemon cannot share,
+# stranding the container in `Created` (DB offline, migrate never runs). The init
+# script only runs on an EMPTY data dir (never on an upgrade), so recreate with a
+# compose override that pins the pgvector image and replaces the service volumes with
+# only its named data volume. Data-preserving: the named volume is never touched.
+# Args: <service> <named-data-volume>.
+_recreate_pg_onto_pgvector() {
+  local _svc="$1" _datavol="$2" _ov _rc=0
+  _ov="$(mktemp)" || return 1
+  cat > "$_ov" <<YAML
+services:
+  ${_svc}:
+    image: pgvector/pgvector:pg16
+    volumes: !override
+      - ${_datavol}:/var/lib/postgresql/data
+YAML
+  docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
+    "${_f_args[@]}" -f "$_ov" up -d --no-deps --force-recreate "$_svc" || _rc=1
+  rm -f "$_ov"
+  return "$_rc"
+}
+
 # --- Step 1: prepare ---
 # Ensure backup parent directory exists and source is present.
 emit_step prepare
@@ -174,19 +216,19 @@ fi
 # `migrate deploy` fails with "extension \"vector\" is not available" and the upgrade aborts
 # before the swap. Recreate postgres onto the compose-pinned pgvector image BEFORE migrate.
 #
-# IDEMPOTENT: skips when the running container already provides vector.control (a fresh install
-# built from the new compose, or an install already upgraded). DATA-PRESERVING: pgvector/pgvector
-# is the same PG16 engine as postgres:16 on the same pgdata volume (a strict superset image), so
-# the recreate keeps all data — no dump/restore. FAIL-CLOSED like migrate: if the recreate or the
-# readiness wait fails, abort before the swap so the old portal keeps serving the old code.
+# IDEMPOTENT: skips when the running container's image already provides pgvector (a fresh install
+# built from the new compose, or an install already upgraded), detected image-agnostically via
+# pg_available_extensions. DATA-PRESERVING: pgvector/pgvector is the same PG16 engine as postgres:16
+# on the same pgdata volume (a strict superset image), so the recreate keeps all data — no
+# dump/restore. FAIL-CLOSED like migrate: if the recreate or the readiness wait fails, abort before
+# the swap so the old portal keeps serving the old code.
 emit_step ensure-pgvector
 if [[ $_dry_run -eq 0 ]]; then
   _pg_container="${DPF_PRODUCTION_DB_CONTAINER:-${_project}-postgres-1}"
-  _has_vector="$(docker exec "$_pg_container" sh -lc 'test -f /usr/local/share/postgresql/extension/vector.control && echo yes || echo no' 2>/dev/null || echo no)"
+  if _pg_provides_vector "$_pg_container"; then _has_vector=yes; else _has_vector=no; fi
   if [[ "$_has_vector" != "yes" ]]; then
     printf 'step=ensure-pgvector-recreate target=%s\n' "$PROMOTE_TARGET_SHA"
-    docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
-      "${_f_args[@]}" up -d --no-deps --force-recreate postgres || {
+    _recreate_pg_onto_pgvector postgres pgdata || {
         printf 'error: could not recreate postgres onto the pgvector image — the BET-5 vector migration cannot apply\n' >&2
         exit 1
       }
@@ -368,15 +410,14 @@ if [[ $_dry_run -eq 0 ]]; then
   _sandbox_ok=1
   # BET-5 (BI-A1E864A5): the sandbox runs the same schema, so its Postgres also needs pgvector
   # for `CREATE EXTENSION vector`. Recreate sandbox-postgres onto the pgvector image first — same
-  # idempotent (skip if vector.control present), data-preserving contract as step 3a. Fail-LOUD-
-  # not-ABORT like the rest of 7b: a sandbox-postgres it cannot upgrade degrades Build Studio, it
-  # never reverts the already-promoted portal.
+  # image-agnostic idempotency check (pg_available_extensions) and host-bind-safe recreate as
+  # step 3a. Fail-LOUD-not-ABORT like the rest of 7b: a sandbox-postgres it cannot upgrade degrades
+  # Build Studio, it never reverts the already-promoted portal.
   _sbx_pg="${_project}-sandbox-postgres-1"
   if docker inspect "$_sbx_pg" >/dev/null 2>&1; then
-    _sbx_has_vector="$(docker exec "$_sbx_pg" sh -lc 'test -f /usr/local/share/postgresql/extension/vector.control && echo yes || echo no' 2>/dev/null || echo no)"
+    if _pg_provides_vector "$_sbx_pg"; then _sbx_has_vector=yes; else _sbx_has_vector=no; fi
     if [[ "$_sbx_has_vector" != "yes" ]]; then
-      docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
-        "${_f_args[@]}" up -d --no-deps --force-recreate sandbox-postgres || _sandbox_ok=0
+      _recreate_pg_onto_pgvector sandbox-postgres sandbox_pgdata || _sandbox_ok=0
     fi
   fi
   if [[ $_sandbox_ok -eq 1 ]]; then


### PR DESCRIPTION
## What

The **live BET-5 upgrade verification** on a real install stranded `dpf-postgres-1` in `Created` state and took the DB offline. Root cause = **two fleet-fatal bugs in `promote.sh` step 3a `ensure-pgvector`** — either one would brick postgres on the *first* BET-5 upgrade of *every existing install*, and a non-technical operator cannot recover a `Created` postgres at fleet scale.

1. **Wrong control-file path.** The idempotency check probed `/usr/local/share/postgresql/extension/vector.control`, but the Debian-based `pgvector/pgvector:pg16` image keeps it at `/usr/share/postgresql/16/extension/vector.control`. The "already pgvector → skip" branch never fired, so it `--force-recreate`d postgres on **every** upgrade.
2. **The recreate stranded postgres.** It ran `docker compose --project-directory "$PROMOTE_SOURCE" up -d --force-recreate postgres` from *inside the promoter*, where `PROMOTE_SOURCE`=`/host-source`. The postgres service's **relative** bind `./scripts/init-inngest-db.sh` therefore resolved to `/host-source/scripts/...` — a path the **host** docker daemon can't share → `mounts denied` → container stuck in `Created`, DB offline, migrate never runs. (The portal recreate escapes this because its host bind uses the **absolute** `${DPF_HOST_INSTALL_PATH:-.}` env, not a relative `./`.) Same bug in step 7b `sandbox-postgres`.

## Fix

- **`_pg_provides_vector()`** — detect pgvector **image-agnostically** via `pg_available_extensions` (reflects the on-disk control file wherever it lives) instead of a hard-coded path. Used by step 3a and step 7b.
- **`_recreate_pg_onto_pgvector()`** — recreate the service with an extra compose override (`!override`) that pins the pgvector image and resets volumes to **only the named data volume** (`pgdata` / `sandbox_pgdata`), dropping the init-script host bind. The init script only runs on an empty data dir (never on an upgrade), so this is behaviourally a no-op **and** data-preserving (the named volume is untouched).
- Applied to both main `postgres` (3a) and `sandbox-postgres` (7b).

## Tests

Two regression tests in `promote-script-functional.test.ts` (run against the **real** script):
- **SKIPS** the recreate when `pg_available_extensions` reports vector present (guards bug #1).
- When a recreate **is** needed, the postgres recreate line carries a **second `-f`** (the override) — a regression to the bare `up --force-recreate postgres` that dragged the host bind would carry only one (guards bug #2).

All four self-upgrade suites green (128 → 130 with the new cases); `apps/web` `tsc` 0 errors; `bash -n scripts/promote.sh` clean.

## Fail-safe & fleet posture

Fail-closed is unchanged: a failed recreate aborts before the swap and the old portal keeps serving. Per the **kernel-routed** fleet decision (`principle_decide`: fix-verify-hold-fleet **8.90** / fold-resequence 8.73 / minimal-now 7.86; confidence low; operator confirmed *fix-verify-hold-fleet*), this unblocks the Mac + Windows boxes but **BET-5 is not declared fleet-ready** on this fix alone — the machinery-first Wave-1/Wave-2 re-sequencing remains a tracked follow-up.

Full arc: #2967 retire → #2969 postgres→pgvector recreate → #2974 always-rebuild promoter → **this** (recreate host-bind-safe).

Local-CI-Override: apps/web tsc 0 errors + promote-script/self-upgrade suites (130) green at 8GB heap + `bash -n` clean; local prepush typecheck OOMs cold (Abort trap: 6). CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)