### PR TITLE
fix(agentic-loop): downgrade recovered tool-refusals to a resolved trend record, not an open PIR (BI-09C2480B)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -40,6 +40,7 @@ import { summarizeDroppedMessages } from "./compaction-digest";
 import {
   detectToolRefusedDespiteAvailability,
   appendToolRefusedRecoveryMessages,
+  classifyToolRefusedIssue,
 } from "./tool-refused-recovery";
 // Re-export for importers (certification-oracles, tests) that pull from agentic-loop.
 export { detectToolRefusedDespiteAvailability } from "./tool-refused-recovery";
@@ -1768,14 +1769,15 @@ export async function runAgenticLoop(params: {
         category: "tool-refused-despite-availability" | "zero-tool-call" | "unsaved-evidence",
         title: string,
         description: string,
-        severity: "high" | "medium" = "high",
+        severity: "high" | "medium" | "low" = "high",
+        status: string = "open",
       ): void => {
         prisma.platformIssueReport.create({
           data: {
             reportId: `coworker-process-${Date.now()}-${threadId.slice(0, 8)}-${category}`,
             type: "runtime_error",
             severity,
-            status: "open",
+            status,
             title: `[coworker-process] ${title}`,
             description,
             routeContext,
@@ -1791,17 +1793,34 @@ export async function runAgenticLoop(params: {
       // 2.6a: tool-refused-despite-availability
       const refusedToolName = runContractGuards ? detectToolRefusedDespiteAvailability(trimmed, tools) : null;
       if (refusedToolName) {
-        console.warn(`[agentic-loop] contract-violation tool-refused-despite-availability: ${refusedToolName}`);
-        writeContractIssue(
-          "tool-refused-despite-availability",
-          `tool-refused-despite-availability: ${refusedToolName}`,
-          `Agent ${agentId} on route ${routeContext} asserted that ${refusedToolName} is unavailable in iteration ${iteration}, but the tool was in the delivered tool list. Response excerpt: ${trimmed.slice(0, 500)}`,
-        );
-        // BI-PIR-6de01e8d: recover in-loop when model closed with no tools.
+        // BI-PIR-6de01e8d: recover in-loop when the model closed with no tools.
         const recovered = appendToolRefusedRecoveryMessages({
           messages, assistantContent: result.content, refusedToolName, deliveredTools: tools,
           executedToolCount: executedTools.length, toolsStripped: Boolean(result.toolsStripped),
         });
+        // BI-09C2480B: a refusal the loop self-corrects is a low-severity,
+        // resolved_locally trend record — not one of the ~24 duplicate OPEN
+        // BI-PIR-* items the triage cron would project. An unrecovered refusal
+        // stays a high-severity OPEN contract issue.
+        const { severity: refusedSeverity, status: refusedStatus } =
+          classifyToolRefusedIssue({ recovered: Boolean(recovered) });
+        console.warn(
+          `[agentic-loop] contract-violation tool-refused-despite-availability: ${refusedToolName}` +
+            (recovered ? " (recovered in-loop)" : ""),
+        );
+        writeContractIssue(
+          "tool-refused-despite-availability",
+          recovered
+            ? `tool-refused-despite-availability (recovered): ${refusedToolName}`
+            : `tool-refused-despite-availability: ${refusedToolName}`,
+          `Agent ${agentId} on route ${routeContext} asserted that ${refusedToolName} is unavailable in iteration ${iteration}, but the tool was in the delivered tool list.` +
+            (recovered
+              ? " The loop issued a corrective nudge and continued; recorded for trend analysis, not operator action."
+              : "") +
+            ` Response excerpt: ${trimmed.slice(0, 500)}`,
+          refusedSeverity,
+          refusedStatus,
+        );
         if (recovered) { continuationNudges++; messages = recovered; continue; }
       }
 

--- a/apps/web/lib/tak/tool-refused-recovery.test.ts
+++ b/apps/web/lib/tak/tool-refused-recovery.test.ts
@@ -3,7 +3,9 @@ import {
   detectToolRefusedDespiteAvailability,
   buildToolRefusedDespiteAvailableNudge,
   appendToolRefusedRecoveryMessages,
+  classifyToolRefusedIssue,
 } from "./tool-refused-recovery";
+import { ISSUE_REPORT_STATUS } from "@/lib/quality/issue-report-status";
 
 describe("detectToolRefusedDespiteAvailability (clause 2.6)", () => {
   const tools = [{ name: "start_ideate_research" }, { name: "saveBuildEvidence" }];
@@ -107,5 +109,25 @@ describe("appendToolRefusedRecoveryMessages (BI-PIR-6de01e8d)", () => {
         toolsStripped: true,
       }),
     ).toBeNull();
+  });
+});
+
+describe("classifyToolRefusedIssue (BI-09C2480B)", () => {
+  it("downgrades a recovered self-refusal to a low-severity, non-open trend record", () => {
+    const c = classifyToolRefusedIssue({ recovered: true });
+    expect(c.severity).toBe("low");
+    // The issue-report-triage cron only projects OPEN reports into BI-PIR
+    // backlog items, so a refusal the loop self-corrected must never be OPEN —
+    // that is the ~24-duplicate-PIR noise this BI removes.
+    expect(c.status).not.toBe(ISSUE_REPORT_STATUS.OPEN);
+    // A terminal/resolved status both the triage runner and the dedupe-key
+    // path skip, so the record survives for trend analysis without escalating.
+    expect(c.status).toBe(ISSUE_REPORT_STATUS.RESOLVED_LOCALLY);
+  });
+
+  it("keeps an unrecovered self-refusal as a high-severity open contract issue", () => {
+    const c = classifyToolRefusedIssue({ recovered: false });
+    expect(c.severity).toBe("high");
+    expect(c.status).toBe(ISSUE_REPORT_STATUS.OPEN);
   });
 });

--- a/apps/web/lib/tak/tool-refused-recovery.ts
+++ b/apps/web/lib/tak/tool-refused-recovery.ts
@@ -3,6 +3,7 @@
 // module does not grow (module-size ratchet).
 
 import type { ChatMessage } from "@/lib/ai-inference";
+import { ISSUE_REPORT_STATUS, type IssueReportStatus } from "@/lib/quality/issue-report-status";
 
 /**
  * Clause 2.6 platform path: detect when the agent's text asserts a tool
@@ -69,4 +70,30 @@ export function appendToolRefusedRecoveryMessages(args: {
       }),
     },
   ];
+}
+
+/**
+ * Severity + status for the PlatformIssueReport a tool-refused-despite-
+ * availability detection files (BI-09C2480B).
+ *
+ * The root-cause cluster already shipped (skip local fallback above the tool
+ * threshold, cap the local tool surface, and issue an in-loop corrective
+ * nudge). What remained was noise: the detector filed a high-severity OPEN
+ * report on EVERY self-refusal, so a refusal the loop immediately self-corrected
+ * still became one of the ~24 duplicate BI-PIR-* backlog items — the
+ * issue-report-triage cron only projects OPEN reports into the backlog.
+ *
+ * When recovery ran, downgrade to a low-severity `resolved_locally` record: a
+ * terminal status the triage runner and the dedupe-key path both skip, so it
+ * survives for trend analysis without escalating to an operator-facing BI. An
+ * unrecovered refusal (tools already executed, or tools stripped) still stands
+ * as a high-severity OPEN contract issue.
+ */
+export function classifyToolRefusedIssue(args: { recovered: boolean }): {
+  severity: "high" | "low";
+  status: IssueReportStatus;
+} {
+  return args.recovered
+    ? { severity: "low", status: ISSUE_REPORT_STATUS.RESOLVED_LOCALLY }
+    : { severity: "high", status: ISSUE_REPORT_STATUS.OPEN };
 }

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -57,7 +57,7 @@ apps/web/lib/tak/agent-grants.test.ts	903
 apps/web/lib/tak/agent-grants.ts	816
 apps/web/lib/tak/agent-routing.ts	965
 apps/web/lib/tak/agentic-loop.test.ts	2240
-apps/web/lib/tak/agentic-loop.ts	2593
+apps/web/lib/tak/agentic-loop.ts	2612
 apps/web/lib/tak/route-context-map.ts	1226
 apps/web/lib/tak/route-context.ts	1239
 apps/web/lib/work-capsules/mcp-handlers.ts	884


### PR DESCRIPTION
## What

`detectToolRefusedDespiteAvailability` filed a **high-severity OPEN** `PlatformIssueReport` on *every* self-refusal — including ones the loop immediately recovers from via the shipped in-loop corrective nudge. Because the issue-report-triage cron projects only **OPEN** reports into the backlog, each recovered refusal still became one of the ~24 duplicate `BI-PIR-*` items. A refusal the loop self-corrects on the next turn is not an operator-actionable contract violation.

This classifies the report by recovery outcome:
- **recovered** → severity `low`, status `resolved_locally` — a terminal status the triage runner and the dedupe-key path both skip, so it survives for trend analysis without ever reaching the OPEN → BI-PIR projection.
- **not recovered** (tools already executed, or tools stripped) → severity `high`, status `open` — unchanged, still operator-actionable.

## Why this is the residual (root cause already shipped)

The root-cause cluster is already on `main`: tool-heavy turns skip the weak local fallback (`LOCAL_FALLBACK_MAX_TOOLS`, #2945), the local tool surface is capped, the tool-surface-overload classifier was fixed (#2954), and the in-loop recovery nudge was added (#2935). What remained was pure PIR noise from recovered refusals — this closes it.

## How

- New pure helper `classifyToolRefusedIssue` in `tool-refused-recovery.ts` (kept out of the baselined `agentic-loop.ts`).
- `writeContractIssue` gains an optional `status` param (default `open`) and accepts `low` severity; the tool-refused branch computes recovery first, then files once with the classified severity/status.

Folds the ~24 duplicate `BI-PIR-*` tool-refused reports into this primary.

## Test-first

`tool-refused-recovery.test.ts` asserts a recovered refusal is `low` severity and **not** `ISSUE_REPORT_STATUS.OPEN` (specifically `RESOLVED_LOCALLY`), and an unrecovered one stays `high`/`open`. Written failing, then made green.

## Kernel decision

Routed through `principle_decide` (dpf-decision-via-kernel): recommended **`downgrade-recovered-note`** (confidence high, composite 7.645, margin 1.332; top contributors *"every defect needs reproduction steps"*, *"never fabricate"*) over suppressing the record entirely, tightening the detector regex, or closing as fixed-by-cluster. The kernel **flipped the pre-call default** (suppress-entirely): the evidence-density principle keeps the trend trace, it just stops it escalating.

## Verification
- Local merged-CI pregate: **gate passed** (full `next build` + workspace tests) — lease `NPEL-586286BD17`.
- Typecheck `tsc --noEmit` exit 0; module-size ratchet re-baselined (+19 LOC on `agentic-loop.ts`); `tool-description-hygiene` green.

## Design grounding
Trivial-contract severity/status fix — no new UX/route/tool. Source of truth: the existing `PlatformIssueReport` status vocabulary (`apps/web/lib/quality/issue-report-status.ts`) and the OPEN-only projection in `apps/web/lib/operate/issue-report-triage-runner.ts`.

Design-Grounding-Decision: trivial no-contract-change edit in `apps/web/lib/tak/agentic-loop.ts` + `apps/web/lib/tak/tool-refused-recovery.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Design grounding (evidence for the record):**
- Existing specs/plans reviewed: `docs/superpowers/specs/2026-05-24-capacity-aware-feedback-escalation-design.md` (§6.2 = the PlatformIssueReport status vocabulary this fix reuses) and `docs/superpowers/specs/2026-03-16-platform-feedback-loop-design.md`.
- Current code substrate reviewed: `apps/web/lib/tak/agentic-loop.ts`, `apps/web/lib/tak/tool-refused-recovery.ts`, `apps/web/lib/quality/issue-report-status.ts`, `apps/web/lib/operate/issue-report-triage-runner.ts`.
- Source of truth: `ISSUE_REPORT_STATUS` + the OPEN-only triage projection. Trivial no-contract-change edit.