### PR TITLE
fix(promotions): deploy ChangePromotions via the in-portal pipeline, not the self-upgrade promoter (BI-B8A6E80B)

### DIFF
--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -4,7 +4,6 @@ import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import { prisma, type Prisma } from "@dpf/db";
-import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { slugify } from "@/lib/shared/slugify";
 import { revalidatePath } from "next/cache";
 import { generateRfcId } from "./change-management";
@@ -407,9 +406,19 @@ export async function markDeployed(promotionId: string, deploymentLog?: string) 
 }
 
 /**
- * Execute an approved promotion. Tries the Docker promoter service first
- * (autonomous pipeline: backup, build, swap, health check). Falls back to
- * in-portal execution if Docker is not available.
+ * Execute an approved promotion through the in-portal promotion pipeline
+ * (backup production DB → scan destructive migrations → apply patch →
+ * post-deploy health check → mark deployed, or roll back with a recorded
+ * reason).
+ *
+ * This deliberately does NOT launch the `dpf-promoter` container: that image
+ * is a self-upgrade-only contract (its promote.sh hard-requires `--self-upgrade`
+ * plus PROMOTE_SOURCE/PROMOTE_TARGET_SHA/…), so starting it for a ChangePromotion
+ * (PROMOTION_ID env, no flag) made promote.sh exit 1 at its guard — the
+ * container died non-zero, the promotion never reached "deployed", and no
+ * rollbackReason was ever set, surfacing as a bare "Rolled back: unknown".
+ * BI-B8A6E80B routes change promotions to the deployer whose contract matches
+ * the operation.
  */
 export async function executePromotionAction(
   promotionId: string,
@@ -423,78 +432,13 @@ export async function executePromotionAction(
 
   const promo = await prisma.changePromotion.findFirst({
     where: { promotionId },
-    include: { productVersion: { include: { featureBuild: { select: { sandboxId: true } } } } },
+    select: { status: true },
   });
   if (!promo) return { success: false, step: "validate", message: "Promotion not found." };
   if (promo.status !== "approved") return { success: false, step: "validate", message: `Status is ${promo.status}, not approved.` };
 
-  const sandboxId = promo.productVersion?.featureBuild?.sandboxId;
-
-  // Try Docker promoter first (production path)
-  try {
-    const cp = lazyChildProcess();
-    const { promisify } = lazyUtil();
-    const execFileAsync = promisify(cp.execFile);
-    const execAsync = promisify(cp.exec);
-
-    await execAsync("docker info", { timeout: 5_000 });
-    await execAsync("docker rm dpf-promoter-1 2>/dev/null || true");
-
-    // Ensure the promoter image exists, building it just-in-time from the
-    // portal's baked-in /promoter/ files if missing. Shared with the
-    // self-upgrade auto-heal and the governed repair tool so there is one
-    // recipe. On failure, fall through to the outer catch → in-portal path.
-    const ensured = await (await import("@/lib/self-upgrade/promoter")).ensurePromoterImage("dpf-promoter");
-    if (!ensured.ok) {
-      throw new Error(
-        `promoter image unavailable (${ensured.skipReason ?? "unknown"})${
-          ensured.detail ? `: ${ensured.detail}` : ""
-        }`,
-      );
-    }
-
-    // Resolve the host path where docker-compose.yml and .env live.
-    // DPF_HOST_INSTALL_PATH is the host-side path of the install directory
-    // (e.g. "D:/DPF" on Windows, "/opt/dpf" on Linux). The promoter needs
-    // these mounted at /host-source/ to restart the portal via compose.
-    const hostPath = process.env.DPF_HOST_INSTALL_PATH ?? "";
-    if (!hostPath) {
-      return {
-        success: false,
-        step: "validate",
-        message: "DPF_HOST_INSTALL_PATH is not configured. Set it in .env to the host-side install directory (e.g. D:/DPF) and restart the portal.",
-      };
-    }
-
-    const envArgs: string[] = [
-      "run", "-d",
-      "--name", "dpf-promoter-1",
-      "--network", `${process.env.DPF_COMPOSE_PROJECT ?? "dpf"}_default`,
-      "-v", "/var/run/docker.sock:/var/run/docker.sock",
-      "-v", "dpf_backups:/backups",
-    ];
-    if (hostPath) {
-      envArgs.push("-v", `${hostPath}/docker-compose.yml:/host-source/docker-compose.yml:ro`);
-      envArgs.push("-v", `${hostPath}/.env:/host-source/.env:ro`);
-    }
-    envArgs.push(
-      "-e", `PROMOTION_ID=${promotionId}`,
-      "-e", `DPF_PRODUCTION_DB_CONTAINER=${process.env.DPF_PRODUCTION_DB_CONTAINER ?? "dpf-postgres-1"}`,
-      "-e", "DPF_PORTAL_CONTAINER=dpf-portal-1",
-      "-e", `DPF_COMPOSE_PROJECT=${process.env.DPF_COMPOSE_PROJECT ?? "dpf"}`,
-      "-e", `POSTGRES_USER=${process.env.POSTGRES_USER ?? "dpf"}`,
-    );
-    if (sandboxId) envArgs.push("-e", `DPF_SANDBOX_CONTAINER=${sandboxId}`);
-    if (overrideReason) envArgs.push("-e", `DPF_WINDOW_OVERRIDE=${overrideReason}`);
-    envArgs.push("dpf-promoter");
-
-    await execFileAsync("docker", envArgs);
-    return { success: true, step: "started", message: "Promoter started. Deployment in progress -- monitor in promotions list." };
-  } catch {
-    // Docker not available -- fall back to in-portal execution
-    const { executePromotion } = await import("@/lib/sandbox-promotion");
-    return executePromotion(promotionId, overrideReason);
-  }
+  const { executePromotion } = await import("@/lib/sandbox-promotion");
+  return executePromotion(promotionId, overrideReason);
 }
 
 /**

--- a/apps/web/lib/mcp/packs/release-pack.test.ts
+++ b/apps/web/lib/mcp/packs/release-pack.test.ts
@@ -29,6 +29,36 @@ vi.mock("@dpf/db", () => ({
   },
 }));
 
+// BI-B8A6E80B: execute_promotion must deploy a ChangePromotion via the in-portal
+// executePromotion pipeline, NOT by launching the self-upgrade-only `dpf-promoter`
+// image (whose promote.sh hard-requires --self-upgrade and exits 1 otherwise,
+// leaving the promotion stuck and logging "Rolled back: unknown").
+const promo = vi.hoisted(() => ({
+  runInPortal: vi.fn(),
+  execFile: vi.fn(),
+  exec: vi.fn(),
+  logBuildActivity: vi.fn(),
+  reconcileBuildCompletion: vi.fn(),
+}));
+vi.mock("@/lib/sandbox-promotion", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  executePromotion: (...a: unknown[]) => promo.runInPortal(...a),
+}));
+vi.mock("@/lib/shared/lazy-node", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  lazyChildProcess: () => ({ exec: promo.exec, execFile: promo.execFile }),
+  lazyUtil: () => ({ promisify: (fn: (...a: unknown[]) => unknown) => fn }),
+}));
+vi.mock("@/lib/mcp/build-tool-helpers", () => ({
+  logBuildActivity: (...a: unknown[]) => promo.logBuildActivity(...a),
+}));
+vi.mock("@/lib/build-flow-state", () => ({
+  reconcileBuildCompletion: (...a: unknown[]) => {
+    promo.reconcileBuildCompletion(...a);
+    return Promise.resolve();
+  },
+}));
+
 import { releasePack } from "./release-pack";
 import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
 
@@ -104,6 +134,45 @@ describe("release pack — handler behavior (delegation preserved)", () => {
     expect(res.success).toBe(false);
     expect(res.error).toBe("Invalid promotion_id");
     expect(db.changePromotionFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("execute_promotion deploys via the in-portal pipeline and never launches the self-upgrade promoter (BI-B8A6E80B)", async () => {
+    db.changePromotionFindFirst.mockResolvedValue({
+      promotionId: "CP-1",
+      status: "approved",
+      rollbackReason: null,
+      deploymentLog: null,
+      productVersion: { featureBuild: { sandboxId: "sbx-1", buildId: "FB-1" } },
+    });
+    // Simulate an install where the dpf-promoter image DOES exist locally, so the
+    // old code path would try to `docker run dpf-promoter` (the wrong contract).
+    promo.exec.mockImplementation(async (cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("docker inspect dpf-promoter-1")) {
+        return { stdout: "exited 1\n" }; // promoter exited non-zero (flag guard)
+      }
+      return { stdout: "" };
+    });
+    promo.execFile.mockResolvedValue({ stdout: "" });
+    promo.runInPortal.mockResolvedValue({ success: true, step: "deployed", message: "deployed" });
+
+    vi.useFakeTimers();
+    const pending = releasePack.handlers.execute_promotion(
+      { promotion_id: "CP-1", override_reason: "emergency-hotfix" },
+      "u1",
+    );
+    await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+    const res = await pending;
+    vi.useRealTimers();
+
+    // Delegates to the in-portal ChangePromotion deployer with the override.
+    expect(promo.runInPortal).toHaveBeenCalledWith("CP-1", "emergency-hotfix");
+    // Never spawns the self-upgrade-only promoter container for a ChangePromotion.
+    const spawnedPromoter = promo.execFile.mock.calls.some(
+      ([bin, args]) =>
+        bin === "docker" && Array.isArray(args) && args.includes("dpf-promoter"),
+    );
+    expect(spawnedPromoter).toBe(false);
+    expect(res.success).toBe(true);
   });
 
   it("create_release_bundle requires a title and at least one build id", async () => {

--- a/apps/web/lib/mcp/packs/release-pack.ts
+++ b/apps/web/lib/mcp/packs/release-pack.ts
@@ -17,7 +17,6 @@ import { prisma } from "@dpf/db";
 
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
-import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 import { logBuildActivity } from "@/lib/mcp/build-tool-helpers";
 
 const definitions: ToolDefinition[] = [
@@ -276,108 +275,40 @@ async function executePromotion(params: Record<string, unknown>): Promise<ToolRe
     }
   }
 
-  // Resolve sandbox and build ID
+  // Resolve the originating build (for activity logging + fork reconciliation).
   const promoDetail = await prisma.changePromotion.findFirst({
     where: { promotionId },
-    include: { productVersion: { include: { featureBuild: { select: { sandboxId: true, buildId: true } } } } },
+    include: { productVersion: { include: { featureBuild: { select: { buildId: true } } } } },
   });
-  const sandboxId = promoDetail?.productVersion?.featureBuild?.sandboxId;
   const promoBuildId = promoDetail?.productVersion?.featureBuild?.buildId;
-  if (!sandboxId) return { success: false, error: "No sandbox", message: "No sandbox linked to this promotion." };
 
-  const { execFile: execFileCb } = lazyChildProcess();
-  const { promisify } = lazyUtil();
-  const execFileAsync = promisify(execFileCb);
-  const execAsync = promisify((lazyChildProcess()).exec);
-
-  // Preflight: the promoter image has to exist locally for `docker run
-  // dpf-promoter` to work. On most installs today it doesn't — the image
-  // is built separately and isn't on the default compose path. Detect
-  // that up front and hand off to the operator UI instead of attempting
-  // the run and returning a scary "Could not start the promoter
-  // container." message. The promotion stays approved; the operator
-  // triggers it from Operations > Promotions.
-  try {
-    await execAsync("docker image inspect dpf-promoter");
-  } catch {
-    // Persist the awaiting_operator state so getBuildFlowState reads it
-    // from the ChangePromotion column directly (no BuildActivity detour)
-    // and the reconciler can treat the fork as dispositioned. The prior
-    // version returned awaiting_operator only in the tool response, which
-    // the fork state machine couldn't see.
-    await prisma.changePromotion.update({
-      where: { promotionId },
-      data: { status: "awaiting_operator" },
-    }).catch(() => {});
-    logBuildActivity(promoBuildId ?? promotionId, "execute_promotion", "Promoter image not present — handing off to operator");
-    if (promoBuildId) {
-      const { reconcileBuildCompletion } = await import("@/lib/build-flow-state");
-      await reconcileBuildCompletion(promoBuildId).catch(() => {});
-    }
-    return {
-      success: true,
-      message: `Promotion ${promotionId} is approved and ready. This install doesn't have the "dpf-promoter" container image built locally, so automatic deployment is disabled here. An operator needs to run the promotion manually from Operations > Promotions, which will stream the deployment log and handle rollback. The promotion stays in "awaiting_operator" status until then.`,
-      data: { status: "awaiting_operator", reason: "promoter_image_missing", promotionId },
-    };
-  }
-
-  // Start promoter container (array form — no shell injection)
-  try {
-    await execAsync("docker rm dpf-promoter-1 2>/dev/null || true");
-    const dockerArgs = [
-      "run", "-d",
-      "--name", "dpf-promoter-1",
-      "--network", `${process.env.DPF_COMPOSE_PROJECT ?? "dpf"}_default`,
-      "-v", "/var/run/docker.sock:/var/run/docker.sock",
-      "-v", "dpf_backups:/backups",
-      "-e", `PROMOTION_ID=${promotionId}`,
-      "-e", `DPF_PRODUCTION_DB_CONTAINER=${process.env.DPF_PRODUCTION_DB_CONTAINER ?? "dpf-postgres-1"}`,
-      "-e", "DPF_PORTAL_CONTAINER=dpf-portal-1",
-      "-e", `DPF_COMPOSE_PROJECT=${process.env.DPF_COMPOSE_PROJECT ?? "dpf"}`,
-      "-e", `DPF_SANDBOX_CONTAINER=${sandboxId}`,
-      "-e", `POSTGRES_USER=${process.env.POSTGRES_USER ?? "dpf"}`,
-    ];
-    if (overrideReason) {
-      dockerArgs.push("-e", `DPF_WINDOW_OVERRIDE=${overrideReason}`);
-    }
-    dockerArgs.push("dpf-promoter");
-    await execFileAsync("docker", dockerArgs);
-  } catch (err) {
-    return {
-      success: false,
-      error: `Failed to start promoter: ${(err as Error).message?.slice(0, 200)}`,
-      message: `Could not start the promoter container. An operator can run this promotion manually from Operations > Promotions — the promotion stays in "approved" status until deployed.`,
-    };
-  }
-
-  // Poll for completion (max 10 minutes)
-  const maxWaitMs = 10 * 60 * 1000;
-  const pollIntervalMs = 10_000;
-  const startTime = Date.now();
-  let exitCode: number | null = null;
-
-  while (Date.now() - startTime < maxWaitMs) {
-    await new Promise(r => setTimeout(r, pollIntervalMs));
-    try {
-      const { stdout } = await execAsync("docker inspect dpf-promoter-1 --format='{{.State.Status}} {{.State.ExitCode}}'");
-      const parts = stdout.trim().replace(/'/g, "").split(" ");
-      if (parts[0] === "exited") {
-        exitCode = parseInt(parts[1] ?? "1", 10);
-        break;
-      }
-    } catch { /* container may not exist yet */ }
-  }
-
-  if (exitCode === null) {
-    await execAsync("docker stop dpf-promoter-1 2>/dev/null || true").catch(() => {});
-    return { success: false, error: "Timeout (10 min)", message: "Promoter did not complete. Check ops dashboard." };
-  }
+  // Deploy through the in-portal ChangePromotion pipeline: backup production
+  // DB → scan destructive migrations → apply patch → post-deploy health check →
+  // mark deployed, or roll back (restore DB + revert code) with a recorded
+  // rollbackReason. This is the deployer that actually services a change
+  // promotion. The `dpf-promoter` image is a SELF-UPGRADE-ONLY contract:
+  // its promote.sh hard-requires the `--self-upgrade` flag and the
+  // PROMOTE_SOURCE/PROMOTE_TARGET_SHA/… env, so launching it for a
+  // ChangePromotion (PROMOTION_ID env, no flag) made promote.sh exit 1 at its
+  // guard — the container died non-zero, the promotion never reached
+  // "deployed", and no rollbackReason was ever set, so this tool logged the
+  // bare "Rolled back: unknown". BI-B8A6E80B routes change promotions to the
+  // deployer whose contract matches the operation.
+  const { executePromotion: runInPortalPromotion } = await import("@/lib/sandbox-promotion");
+  const result = await runInPortalPromotion(promotionId, overrideReason);
 
   const finalPromo = await prisma.changePromotion.findFirst({ where: { promotionId } });
-  const promoSuccess = exitCode === 0 && finalPromo?.status === "deployed";
+  const rolledBack = finalPromo?.status === "rolled_back";
 
-  await execAsync("docker rm dpf-promoter-1 2>/dev/null || true").catch(() => {});
-  logBuildActivity(promoBuildId ?? promotionId, "execute_promotion", promoSuccess ? "Deployed successfully" : `Rolled back: ${finalPromo?.rollbackReason ?? "unknown"}`);
+  logBuildActivity(
+    promoBuildId ?? promotionId,
+    "execute_promotion",
+    result.success
+      ? "Deployed successfully"
+      : rolledBack
+        ? `Rolled back: ${finalPromo?.rollbackReason ?? result.message ?? "see deployment log"}`
+        : `Not deployed: ${result.message}`,
+  );
 
   if (promoBuildId) {
     const { reconcileBuildCompletion } = await import("@/lib/build-flow-state");
@@ -385,10 +316,10 @@ async function executePromotion(params: Record<string, unknown>): Promise<ToolRe
   }
 
   return {
-    success: promoSuccess,
-    message: promoSuccess
+    success: result.success,
+    message: result.success
       ? `Promotion ${promotionId} deployed. Health check passed.`
-      : `Rolled back. ${finalPromo?.rollbackReason ?? "Check deployment log."}`,
+      : result.message,
     data: { promotionId, status: finalPromo?.status, deploymentLog: finalPromo?.deploymentLog?.slice(0, 1000) },
   };
 }


### PR DESCRIPTION
## What

`execute_promotion` launched the `dpf-promoter` image for a **ChangePromotion**. That image is a **self-upgrade-only contract**: its `promote.sh` hard-requires the `--self-upgrade` flag plus `PROMOTE_SOURCE` / `PROMOTE_TARGET_SHA` / `PROMOTE_BACKUP_PATH` / `PROMOTE_HEALTH_URL`. A change promotion supplies none of that (`PROMOTION_ID` env, no flag), so `promote.sh` exits 1 at its guard, the container dies non-zero, the `ChangePromotion` never reaches `deployed`, and no `rollbackReason` is ever set — surfacing to the operator as the bare **"Rolled back: unknown"**.

A deployer whose contract actually matches a change promotion already exists: the in-portal `executePromotion` pipeline (`integrate/sandbox/sandbox-promotion.ts`) — backup production DB, scan destructive migrations, apply the patch, run a post-deploy health check, mark deployed, or roll back (restore DB + revert code) with a **recorded reason**. It was previously reachable only as a fallback when `docker info` failed.

## How

Route change promotions to that pipeline from both entry points:
- **`release-pack.ts` `execute_promotion`** (MCP tool): replace the promoter-image preflight + `docker run dpf-promoter` + 10-min poll with a direct call to the in-portal deployer; log an honest activity line (deployed / rolled back with reason / not deployed).
- **`actions/promotions.ts` `executePromotionAction`** (Ops UI action): drop the docker-promoter-first branch and delegate straight to the in-portal deployer.

Removes the now-unused lazy-node `child_process` wiring from both files.

## Test-first

`release-pack.test.ts` asserts `execute_promotion` delegates to the in-portal deployer with the override reason and **never spawns a `dpf-promoter` container**, even on an install where the promoter image is present (fake-timers skip the poll). Written failing, then made green.

## Kernel decision

Routed through `principle_decide` (dpf-decision-via-kernel): recommended **`route-in-portal`** (confidence high, composite 6.327, margin 1.529; top contributor *Architecture Over Shortcuts*) over building a new change-promotion container contract or a bare honest-failure guard. BI re-sized `small -> medium` (self-upgrade / production-deploy critical path).

> Note: the in-portal pipeline applies the code patch via `git apply` + schema migration but does not itself rebuild/restart the portal image — a pre-existing limitation of that deployer, unchanged by this PR and out of scope here.

## Verification
- Local merged-CI pregate: **gate passed** (full `next build` + workspace tests), SHA-bound to 45b75a469.
- Typecheck exit 0 (10 GB heap; the pre-commit scoped typecheck was OOM-killed cold, not a type error).

## Design grounding
Trivial-contract routing fix — no new UX/route/tool. Source of truth: the existing in-portal `executePromotion` deployer (`apps/web/lib/integrate/sandbox/sandbox-promotion.ts`).

Design-Grounding-Decision: trivial no-contract-change edit in `apps/web/lib/mcp/packs/release-pack.ts` and `apps/web/lib/actions/promotions.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Design grounding (evidence for the record):**
- Existing specs/plans reviewed: `docs/superpowers/specs/2026-03-29-autonomous-promotion-pipeline.md`, `docs/superpowers/specs/2026-05-09-deployment-architecture-and-rollout.md`, `docs/superpowers/specs/2026-05-11-git-triggered-sandbox-promotion-slice-2.md`.
- Current code substrate reviewed: `apps/web/lib/mcp/packs/release-pack.ts`, `apps/web/lib/actions/promotions.ts`, `apps/web/lib/integrate/sandbox/sandbox-promotion.ts`, `scripts/promote.sh`.
- Source of truth: the in-portal `executePromotion` pipeline. Trivial no-contract-change routing fix.