### PR TITLE
fix(self-upgrade): BET-5 boot backfill must exit so the portal can serve

### DIFF
--- a/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
+++ b/apps/web/lib/self-upgrade/portal-migrate-boot.test.ts
@@ -133,6 +133,30 @@ describe.skipIf(!BASH_OK)("portal-migrate-boot.sh (BI-5322D025)", () => {
     }
   }, TIMEOUT_MS);
 
+  it("DEGRADES OPEN — still starts the server when the BET-5 datastore backfill fails", () => {
+    // BI-A1E864A5: the Neo4j/Qdrant→Postgres backfill is best-effort and idempotent (the
+    // separately-gated teardown enforces data safety), so it must never block boot. Observed
+    // live: a backfill that hung after its work left the portal wedged before `exec server`,
+    // never serving. The script force-exits when done and the boot line is timeout-guarded;
+    // this proves a NON-zero backfill result still degrades open to the server start.
+    const root = mkdtempSync(join(tmpdir(), "dpf-pmb-"));
+    try {
+      const appDir = join(root, "app");
+      mkdirSync(appDir, { recursive: true });
+      const r = run({
+        appDir,
+        fakeBin: makeFakeBin(root),
+        pnpmExit: 0,
+        pnpmFailMatch: "scripts/bet5-decommission-backfill.ts",
+      });
+      expect(r.status).toBe(0); // boot still succeeds
+      expect(r.stderr).toContain("BET-5 datastore backfill reported an error");
+      expect(r.stdout).toContain("BOOT_MARKER"); // server WAS started despite the failure
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, TIMEOUT_MS);
+
   it("FAILS CLOSED — does not start the server when migrations cannot apply", () => {
     const root = mkdtempSync(join(tmpdir(), "dpf-pmb-"));
     try {

--- a/docs/superpowers/plans/2026-07-13-bet5-db-compression-plan.md
+++ b/docs/superpowers/plans/2026-07-13-bet5-db-compression-plan.md
@@ -250,3 +250,38 @@ but BET-5 is NOT declared fleet-ready on it alone — the machinery-first Wave-1
 remains a tracked follow-up (a self-upgrade must never ship a step the currently-deployed machinery
 can't execute). principle_decide ledger: fix-verify-hold-fleet 8.90 / fold-resequence 8.73 /
 minimal-now 7.86 (confidence low; operator confirmed fix-verify-hold-fleet).
+
+## Fix 4 — boot backfill never exits → blocks the portal from serving — 2026-07-14
+
+With Fix 3 in place, the live re-trigger (SUR-FIXVER01) ran the FULL chain correctly for the first
+time: `ensure-pgvector` SKIPPED the recreate (postgres stayed up, image-agnostic detection worked),
+the P3009 self-heal cleared the failed migration, both BET-5 migrations applied
+(`bet5_pgvector_foundation` + `bet5_graph_mirror`), `vector` 0.8.5 installed, and the boot backfill
+copied all data into Postgres (87 Qdrant vectors, 207 Neo4j nodes, 626 edges). But the **portal then
+never came up**: it wedged at `[bet5-backfill] done.` with the Next server never bound → `unhealthy`.
+
+Root cause: `scripts/bet5-decommission-backfill.ts` opens a Neo4j driver + Qdrant client whose pooled
+sockets / keep-alive timers keep the Node event loop alive, and its `.finally()` only
+`prisma.$disconnect()`s — neither legacy client is closed and there's no `process.exit`. So after
+`main()` resolves (work done), the process **hangs**. `scripts/portal-migrate-boot.sh` runs the
+backfill SYNCHRONOUSLY (`if ! ...; then WARN; fi`) before `exec "$@"`, so a non-exiting backfill
+blocks the server start forever. This was latent until now — every prior attempt died at migrate
+(before the swap), so the boot backfill had never run to completion on a real install. It would hang
+the FIRST successful BET-5 boot on **every** install (a silent wedge, worse than a fail-closed abort).
+
+Fix (this PR, `fix/bet5-boot-backfill-exit`):
+- `bet5-decommission-backfill.ts`: after the awaited work + `prisma.$disconnect()`, **`process.exit(0)`**
+  so the lingering driver/client handles can't keep the process alive. All copies are awaited, so
+  exiting loses nothing.
+- `portal-migrate-boot.sh`: wrap the backfill in **`timeout 300`** (with a `command -v timeout`
+  fallback for minimal images) as a belt-and-suspenders backstop — a future hang gets killed and boot
+  proceeds (the backfill is best-effort + idempotent; the separately-gated teardown enforces safety).
+- Regression test: `portal-migrate-boot.test.ts` — a non-zero backfill result **degrades open** to the
+  server start (never fail-closed on the backfill).
+
+**Live recovery of the Mac box:** killed the wedged backfill process → boot proceeded to `exec node
+server.js` → portal came up healthy on the new sha just as the promoter's health step was still
+waiting → the run completed `succeeded`, then trailing steps recreated sandbox-postgres onto pgvector
+and **decommissioned Neo4j + Qdrant** (containers AND volumes now gone). BET-5 is fully verified
+end-to-end on the Mac box: Postgres-only, `vector` 0.8.5, graph mirror = 207 nodes / 626 edges,
+vector_embedding = 87.

--- a/packages/db/scripts/bet5-decommission-backfill.ts
+++ b/packages/db/scripts/bet5-decommission-backfill.ts
@@ -44,4 +44,14 @@ main()
     // is what enforces safety. Log and exit 0 so portal boot is never blocked.
     console.warn("[bet5-backfill] unexpected error (non-fatal):", err);
   })
-  .finally(() => prisma.$disconnect());
+  .finally(async () => {
+    await prisma.$disconnect().catch(() => {});
+    // Force a clean exit. The Neo4j driver and Qdrant client this script opens keep
+    // pooled sockets / keep-alive timers on the event loop, and neither exposes a close
+    // handle here — so after `main()` resolves the process would otherwise hang with the
+    // work already done. portal-migrate-boot.sh runs THIS SCRIPT SYNCHRONOUSLY before
+    // `exec node server.js`, so a non-exiting backfill blocks the portal from EVER serving
+    // (BI-A1E864A5 — observed live: boot wedged at "[bet5-backfill] done." with the server
+    // never bound). All copies are awaited above, so exiting here loses nothing.
+    process.exit(0);
+  });

--- a/scripts/portal-migrate-boot.sh
+++ b/scripts/portal-migrate-boot.sh
@@ -64,8 +64,18 @@ fi
 # only stages the data — the actual container/volume removal is the separately-gated
 # scripts/decommission-neo4j-qdrant.{sh,ps1}, which refuses to delete anything until the
 # mirror is confirmed populated.
-if ! pnpm --filter @dpf/db exec tsx scripts/bet5-decommission-backfill.ts; then
-  echo "[portal-boot] WARN: BET-5 datastore backfill reported an error — legacy stores left intact (see error above)" >&2
+# Guard the boot on a wall-clock timeout: the backfill is best-effort and idempotent, so it
+# must NEVER be able to block the server from starting. The script force-exits when done
+# (see bet5-decommission-backfill.ts), but `timeout` is the belt-and-suspenders backstop —
+# a future hang (a wedged Neo4j/Qdrant read, a driver that won't drain) gets killed and boot
+# proceeds. `timeout` may be absent on a minimal image; fall back to a plain run if so.
+if command -v timeout >/dev/null 2>&1; then
+  _bet5_backfill() { timeout 300 pnpm --filter @dpf/db exec tsx scripts/bet5-decommission-backfill.ts; }
+else
+  _bet5_backfill() { pnpm --filter @dpf/db exec tsx scripts/bet5-decommission-backfill.ts; }
+fi
+if ! _bet5_backfill; then
+  echo "[portal-boot] WARN: BET-5 datastore backfill reported an error or timed out — legacy stores left intact (see error above)" >&2
 fi
 
 echo "[portal-boot] provider catalog reconciled (or degraded); starting server"


### PR DESCRIPTION
## What

The **live end-to-end BET-5 verification** (after #2978 fixed the `ensure-pgvector` recreate) ran the full self-upgrade chain correctly for the first time — migrations applied, `vector` 0.8.5 installed, the boot backfill copied all data into Postgres (87 Qdrant vectors, 207 Neo4j nodes, 626 edges) — **but the portal then never came up**: it wedged at `[bet5-backfill] done.` with the Next server never bound (`unhealthy`).

**Root cause:** `bet5-decommission-backfill.ts` opens a Neo4j driver + Qdrant client whose pooled sockets / keep-alive timers keep the Node event loop alive, and its `.finally()` only `prisma.$disconnect()`s — neither legacy client is closed and there's no `process.exit`. So after `main()` resolves (work done), the process **hangs**. `portal-migrate-boot.sh` runs the backfill **synchronously** (`if ! ...; then WARN; fi`) *before* `exec "$@"`, so a non-exiting backfill blocks the server start forever.

This was **latent** until now: every prior upgrade attempt died at migrate (before the swap), so the boot backfill had never run to completion on a real install. It would hang the **first successful BET-5 boot on every install** — a silent wedge, worse than a fail-closed abort.

## Fix

- **`bet5-decommission-backfill.ts`** — `process.exit(0)` after the awaited work + `prisma.$disconnect()`, so lingering driver/client handles can't keep the process alive. All copies are awaited, so exiting loses nothing.
- **`portal-migrate-boot.sh`** — wrap the backfill in `timeout 300` (with a `command -v timeout` fallback for minimal images) as a belt-and-suspenders backstop: a future hang gets killed and boot proceeds (the backfill is best-effort + idempotent; the separately-gated teardown enforces data safety).
- **`portal-migrate-boot.test.ts`** — regression: a non-zero backfill result **degrades open** to the server start (never fail-closed on the backfill).

## Verified

- `portal-migrate-boot.test.ts`: **7 passed** (incl. the new degrade-open case); `packages/db` `tsc` **0 errors**; `bash -n scripts/portal-migrate-boot.sh` clean.
- **Live**: after unblocking the wedged backfill, the run completed `succeeded`, sandbox-postgres recreated onto pgvector, and Neo4j + Qdrant (containers **and** volumes) were decommissioned. The Mac install now runs **Postgres-only** — `vector` 0.8.5, graph mirror 207 nodes / 626 edges, vector_embedding 87.

Follow-on to the BET-5 self-upgrade arc: #2967 retire → #2969 postgres→pgvector recreate → #2974 always-rebuild promoter → #2978 recreate host-bind-safe → **this** (boot backfill exits).

Local-CI-Override: packages/db tsc 0 errors + portal-migrate-boot 7/7 green at 8GB heap + `bash -n` clean; local prepush typecheck OOMs cold (Abort trap: 6). CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)