### PR TITLE
feat(twin): operational-twin grammar kit — ten React primitives (EP-LIVING-BUSINESS-VIZ P2)

### DIFF
--- a/apps/web/app/(shell)/admin/twin-kit/page.tsx
+++ b/apps/web/app/(shell)/admin/twin-kit/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+
+import { TwinKitShowcase } from "@/components/twin/TwinKitShowcase";
+
+export const metadata: Metadata = {
+  title: "Operational Twin Kit — preview",
+};
+
+// Fixture/reference surface for the Operational Twin grammar kit (P2). Not linked
+// from the admin nav — it is a developer preview of the ten primitives, reachable
+// directly at /admin/twin-kit and gated by the admin layout's view_admin guard.
+// P3 replaces the hand-built prototypes with template compositions of this kit
+// bound to a real TwinProfile + LivingBusinessSnapshot.
+export default function AdminTwinKitPage() {
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Operational Twin Kit</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          Preview of the ten grammar primitives every twin composes from — shown on a
+          physical floor and a non-physical board.
+        </p>
+      </div>
+      <TwinKitShowcase />
+    </div>
+  );
+}

--- a/apps/web/components/twin/ActorMark.tsx
+++ b/apps/web/components/twin/ActorMark.tsx
@@ -1,0 +1,39 @@
+// apps/web/components/twin/ActorMark.tsx
+//
+// Shared rendering of an actor on the twin — a human or an AI coworker — on ONE
+// plane (the operating-twin doctrine, parent spec §3.3). Used by resource units,
+// work items, presence, and the feed so the two are always visually attributed
+// and never segregated into separate lists.
+
+import { Bot, User } from "lucide-react";
+
+import type { TwinActorKind } from "./types";
+
+export interface ActorMarkProps {
+  name: string;
+  kind: TwinActorKind;
+  /** Icon-only (for dense contexts like a resource-unit owner line). */
+  compact?: boolean;
+  className?: string;
+}
+
+export function ActorMark({ name, kind, compact, className = "" }: ActorMarkProps) {
+  const isAi = kind === "ai";
+  const Icon = isAi ? Bot : User;
+  const color = isAi ? "var(--dpf-accent)" : "var(--dpf-muted)";
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-[11px] ${className}`.trim()}
+      title={isAi ? `${name} (AI coworker)` : name}
+    >
+      <Icon aria-hidden size={12} style={{ color }} />
+      {compact ? (
+        <span className="sr-only">{isAi ? `${name}, AI coworker` : name}</span>
+      ) : (
+        <span style={{ color: isAi ? "var(--dpf-accent)" : "var(--dpf-text-secondary)" }}>
+          {name}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/components/twin/AttributedFeed.tsx
+++ b/apps/web/components/twin/AttributedFeed.tsx
@@ -1,0 +1,43 @@
+// apps/web/components/twin/AttributedFeed.tsx
+//
+// Primitive 9/10 — attributed feed: who did what, human or AI, on one shared
+// event plane (seat/dispatch/allocate actions + AI reactions). Every entry is
+// attributed to its actor so the AI coworker reads as a teammate, not an
+// invisible automation. Pure + server-usable.
+
+import { ActorMark } from "./ActorMark";
+import type { FeedEventData } from "./types";
+
+export interface AttributedFeedProps {
+  events: FeedEventData[];
+  emptyLabel?: string;
+  className?: string;
+}
+
+export function AttributedFeed({ events, emptyLabel, className = "" }: AttributedFeedProps) {
+  if (events.length === 0) {
+    return (
+      <p className={`text-[11px] text-[var(--dpf-muted)] ${className}`.trim()}>
+        {emptyLabel ?? "No activity yet"}
+      </p>
+    );
+  }
+  return (
+    <ul className={`flex flex-col gap-1.5 ${className}`.trim()}>
+      {events.map((e) => (
+        <li key={e.key} className="flex items-baseline gap-2 text-[11px]">
+          <ActorMark name={e.actor.name} kind={e.actor.kind} />
+          <span className="text-[var(--dpf-text-secondary)]">
+            {e.action}
+            {e.target ? (
+              <span className="text-[var(--dpf-text)]"> {e.target}</span>
+            ) : null}
+          </span>
+          {e.at ? (
+            <span className="ml-auto shrink-0 tabular-nums text-[var(--dpf-muted)]">{e.at}</span>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/components/twin/CapacityChips.tsx
+++ b/apps/web/components/twin/CapacityChips.tsx
@@ -1,0 +1,57 @@
+// apps/web/components/twin/CapacityChips.tsx
+//
+// Primitive 1/10 — capacity chips: the archetype's real constraints as live
+// counters (tables·seats·6-tops / techs·queue·emergencies / assets·utilization·overdue).
+// Pure + server-usable; the only motion is a motion-safe live dot.
+
+import { intentStyle, type Intent } from "@/components/ui/report-kit";
+
+import type { CapacityChipData } from "./types";
+
+function chipStyle(intent: Intent | undefined) {
+  const style = intentStyle(intent ?? "neutral");
+  return { backgroundColor: style.softBg, color: style.fg, borderColor: style.border };
+}
+
+export function CapacityChip({ label, value, max, intent, live }: Omit<CapacityChipData, "key">) {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium"
+      style={chipStyle(intent)}
+      data-intent={intent ?? "neutral"}
+    >
+      {live ? (
+        <span
+          aria-hidden="true"
+          className="h-1.5 w-1.5 rounded-full bg-current motion-safe:animate-pulse"
+        />
+      ) : null}
+      <span className="uppercase tracking-wide opacity-80">{label}</span>
+      <span className="tabular-nums font-semibold">
+        {value}
+        {typeof max === "number" ? (
+          <span className="opacity-60">
+            {" / "}
+            {max}
+          </span>
+        ) : null}
+      </span>
+    </span>
+  );
+}
+
+export interface CapacityChipsProps {
+  chips: CapacityChipData[];
+  className?: string;
+}
+
+/** The headline constraint row for a twin — the live limits that gate the operation. */
+export function CapacityChips({ chips, className = "" }: CapacityChipsProps) {
+  return (
+    <div className={`flex flex-wrap items-center gap-2 ${className}`.trim()}>
+      {chips.map(({ key, ...chip }) => (
+        <CapacityChip key={key} {...chip} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/twin/CogBanner.tsx
+++ b/apps/web/components/twin/CogBanner.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+// apps/web/components/twin/CogBanner.tsx
+//
+// Primitive 6/10 — the cog: an AI coworker's allocation proposal over live state,
+// following the constraint → proposal → confirm loop (seat-from-dwell-time /
+// nearest-tech-by-travel / best-asset-by-readiness). This is the ONE inherently
+// interactive primitive: HITL is mandatory on every cog action (parent spec §3),
+// so the proposal is never auto-applied — a human taps Confirm.
+//
+// Client because it owns the confirm/dismiss interaction; the surrounding twin
+// stays server-rendered.
+
+import { Bot, Check, X } from "lucide-react";
+
+export interface CogBannerProps {
+  /** The proposed allocation, e.g. "Seat the Nguyen party (4) at Table 12". */
+  proposal: string;
+  /** The live signals the proposal is derived from (dwell-time, travel-time…). */
+  signals: string[];
+  /** Label of the AI coworker making the proposal. */
+  cogLabel?: string;
+  confirmLabel?: string;
+  onConfirm?: () => void;
+  onDismiss?: () => void;
+  /** Confirmed/handled — collapses to an attributed, non-actionable state. */
+  resolved?: boolean;
+}
+
+export function CogBanner({
+  proposal,
+  signals,
+  cogLabel = "AI coworker",
+  confirmLabel = "Confirm",
+  onConfirm,
+  onDismiss,
+  resolved,
+}: CogBannerProps) {
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-lg border p-3"
+      style={{
+        borderColor: "var(--dpf-accent)",
+        backgroundColor: "var(--dpf-accent-soft)",
+      }}
+      data-resolved={resolved ? "true" : undefined}
+    >
+      <div className="flex items-start gap-2">
+        <Bot aria-hidden size={16} style={{ color: "var(--dpf-accent)" }} className="mt-0.5" />
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-accent)]">
+            {cogLabel} suggests
+          </span>
+          <span className="text-sm font-medium text-[var(--dpf-text)]">{proposal}</span>
+        </div>
+      </div>
+
+      {signals.length > 0 ? (
+        <div className="flex flex-wrap gap-1 pl-6">
+          {signals.map((s) => (
+            <span
+              key={s}
+              className="rounded-full border border-[var(--dpf-accent)] px-1.5 py-0.5 text-[10px] text-[var(--dpf-accent)]"
+            >
+              {s}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {resolved ? (
+        <span className="inline-flex items-center gap-1 pl-6 text-[11px] text-[var(--dpf-success)]">
+          <Check aria-hidden size={12} /> Confirmed
+        </span>
+      ) : (
+        <div className="flex items-center gap-2 pl-6">
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium text-[var(--dpf-surface-1)]"
+            style={{ backgroundColor: "var(--dpf-accent)" }}
+          >
+            <Check aria-hidden size={13} />
+            {confirmLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="inline-flex items-center gap-1 rounded-md border border-[var(--dpf-border)] px-2 py-1 text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          >
+            <X aria-hidden size={13} />
+            Dismiss
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/twin/NeedsYouQuests.tsx
+++ b/apps/web/components/twin/NeedsYouQuests.tsx
@@ -1,0 +1,56 @@
+// apps/web/components/twin/NeedsYouQuests.tsx
+//
+// Primitive 10/10 — needs-you quests: the attention queue pinned to twin context
+// (6-top blocked / emergencies unassigned / overdue return). The single
+// "what-needs-you-now" surface — the escalation channel for anything the cog
+// can't resolve without a human judgment (parent spec §3, WWWD gate §7). Pure +
+// server-usable.
+
+import { intentStyle } from "@/components/ui/report-kit";
+
+import type { QuestData } from "./types";
+
+export interface NeedsYouQuestsProps {
+  quests: QuestData[];
+  emptyLabel?: string;
+  className?: string;
+}
+
+export function NeedsYouQuests({ quests, emptyLabel, className = "" }: NeedsYouQuestsProps) {
+  if (quests.length === 0) {
+    return (
+      <p className={`text-[11px] text-[var(--dpf-muted)] ${className}`.trim()}>
+        {emptyLabel ?? "Nothing needs you right now"}
+      </p>
+    );
+  }
+  return (
+    <ul className={`flex flex-col gap-2 ${className}`.trim()}>
+      {quests.map((q) => {
+        const style = intentStyle(q.intent ?? "warning");
+        return (
+          <li
+            key={q.key}
+            className="flex items-start gap-2 rounded-md border bg-[var(--dpf-surface-1)] p-2"
+            style={{ borderLeftColor: style.border, borderLeftWidth: "3px" }}
+          >
+            <div className="flex flex-1 flex-col gap-0.5">
+              <span className="text-xs font-semibold text-[var(--dpf-text)]">{q.title}</span>
+              {q.detail ? (
+                <span className="text-[11px] text-[var(--dpf-muted)]">{q.detail}</span>
+              ) : null}
+            </div>
+            {q.cta ? (
+              <span
+                className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium"
+                style={{ backgroundColor: style.softBg, color: style.fg }}
+              >
+                {q.cta}
+              </span>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/components/twin/PresenceRow.tsx
+++ b/apps/web/components/twin/PresenceRow.tsx
@@ -1,0 +1,31 @@
+// apps/web/components/twin/PresenceRow.tsx
+//
+// Primitive 8/10 — presence row: who inhabits the twin NOW — humans and AI
+// coworkers on one plane, each with what they're attending to. The operating-twin
+// doctrine made visible (parent spec §3.3). Pure + server-usable.
+
+import { ActorMark } from "./ActorMark";
+import type { TwinActor } from "./types";
+
+export interface PresenceRowProps {
+  members: TwinActor[];
+  className?: string;
+}
+
+export function PresenceRow({ members, className = "" }: PresenceRowProps) {
+  return (
+    <div className={`flex flex-wrap gap-2 ${className}`.trim()}>
+      {members.map((m) => (
+        <div
+          key={`${m.kind}:${m.name}`}
+          className="flex items-center gap-2 rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-1"
+        >
+          <ActorMark name={m.name} kind={m.kind} />
+          {m.focus ? (
+            <span className="text-[11px] text-[var(--dpf-muted)]">· {m.focus}</span>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/twin/ResourceUnit.tsx
+++ b/apps/web/components/twin/ResourceUnit.tsx
@@ -1,0 +1,48 @@
+// apps/web/components/twin/ResourceUnit.tsx
+//
+// Primitive 3/10 — resource unit: a countable unit (table+seats / van+tech /
+// chair / room / account) with state + owner. Pure + server-usable.
+
+import { StatusBadge } from "@/components/ui/report-kit";
+
+import { ActorMark } from "./ActorMark";
+import type { ResourceUnitData } from "./types";
+
+export function ResourceUnit({
+  label,
+  state,
+  intent,
+  owner,
+  sublabel,
+}: Omit<ResourceUnitData, "key">) {
+  return (
+    <div className="flex flex-col gap-1 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-semibold text-[var(--dpf-text)]">{label}</span>
+        <StatusBadge intent={intent ?? "neutral"} label={state} variant="soft" size="sm" />
+      </div>
+      {sublabel ? (
+        <span className="text-[11px] text-[var(--dpf-muted)]">{sublabel}</span>
+      ) : null}
+      {owner ? <ActorMark name={owner.name} kind={owner.kind} /> : null}
+    </div>
+  );
+}
+
+export interface ResourceUnitGridProps {
+  units: ResourceUnitData[];
+  className?: string;
+}
+
+/** A responsive grid of units — the interior of a zone. */
+export function ResourceUnitGrid({ units, className = "" }: ResourceUnitGridProps) {
+  return (
+    <div
+      className={`grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 ${className}`.trim()}
+    >
+      {units.map(({ key, ...unit }) => (
+        <ResourceUnit key={key} {...unit} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/twin/TwinKitShowcase.tsx
+++ b/apps/web/components/twin/TwinKitShowcase.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+// apps/web/components/twin/TwinKitShowcase.tsx
+//
+// Developer preview of the Operational Twin grammar kit (P2). Renders the ten
+// primitives twice — once for a PHYSICAL twin (restaurant FLOOR) and once for a
+// NON-PHYSICAL board twin (SaaS TENANTS) — proving one grammar spans both lenses.
+// The cog banner is live (tap Confirm / Dismiss) to demonstrate the HITL loop.
+
+import { useState } from "react";
+
+import {
+  AttributedFeed,
+  CapacityChips,
+  CogBanner,
+  NeedsYouQuests,
+  PresenceRow,
+  ResourceUnitGrid,
+  TwinQueue,
+  TwinZone,
+  UtilityBand,
+  WorkItem,
+  type CapacityChipData,
+  type FeedEventData,
+  type QuestData,
+  type QueueItemData,
+  type ResourceUnitData,
+  type TwinActor,
+  type UtilityMeterData,
+  type WorkItemData,
+} from "@/components/twin";
+
+// ── Shared: the utility band is identical across archetypes (that's the point). ──
+const UTILITY: UtilityMeterData[] = [
+  { key: "bills", label: "Bills due", value: "2 · £1,240", intent: "warning", hint: "Next 7 days" },
+  { key: "tax", label: "VAT return", value: "12 days", intent: "info" },
+  { key: "compliance", label: "Compliance", value: "All clear", intent: "success" },
+  { key: "improve", label: "Improve", value: "3 ideas", intent: "accent" },
+];
+
+// ─────────────────────────── Physical: restaurant FLOOR ──────────────────────────
+const FLOOR_CHIPS: CapacityChipData[] = [
+  { key: "tables", label: "Tables", value: 6, max: 8, intent: "info", live: true },
+  { key: "seats", label: "Seats", value: 22, max: 32, intent: "info" },
+  { key: "6tops", label: "6-tops free", value: 1, intent: "warning" },
+  { key: "wait", label: "Waitlist", value: 3, intent: "danger", live: true },
+];
+const FLOOR_UNITS: ResourceUnitData[] = [
+  { key: "t9", label: "Table 9", state: "Seated", intent: "success", sublabel: "2 · 34 min", owner: { name: "Ana", kind: "human" } },
+  { key: "t10", label: "Table 10", state: "Dessert", intent: "info", sublabel: "4 · 1h05", owner: { name: "Ana", kind: "human" } },
+  { key: "t11", label: "Table 11", state: "Open", intent: "neutral", sublabel: "seats 2" },
+  { key: "t12", label: "Table 12", state: "Bussing", intent: "warning", sublabel: "seats 6", owner: { name: "AI expo", kind: "ai" } },
+];
+const FLOOR_TICKETS: WorkItemData[] = [
+  { key: "k1", label: "Table 10 · mains", owner: { name: "Kitchen", kind: "human" }, progress: 70 },
+  { key: "k2", label: "Online · pickup #4821", owner: { name: "AI host", kind: "ai" }, progress: 40, sublabel: "ready 7:45" },
+  { key: "k3", label: "Table 7 · wine", blockedOnExternal: true, blockedLabel: "Blocked · cellar restock" },
+];
+const FLOOR_QUEUE: QueueItemData[] = [
+  { key: "w1", label: "Nguyen party", meta: "4 guests", waiting: "8 min", suggestion: "Seat at Table 12 (bussing, ~4 min)" },
+  { key: "w2", label: "Walk-in", meta: "2 guests", waiting: "3 min" },
+  { key: "w3", label: "Reservation · Patel", meta: "6 · 8:00pm", waiting: "res" },
+];
+const FLOOR_PRESENCE: TwinActor[] = [
+  { name: "You", kind: "human", focus: "expediting" },
+  { name: "Ana", kind: "human", focus: "sections 9–10" },
+  { name: "AI host", kind: "ai", focus: "waitlist + online" },
+  { name: "AI expo", kind: "ai", focus: "table turns" },
+];
+const FLOOR_FEED: FeedEventData[] = [
+  { key: "f1", actor: { name: "AI host", kind: "ai" }, action: "proposed seating for", target: "Nguyen party", at: "just now" },
+  { key: "f2", actor: { name: "Ana", kind: "human" }, action: "fired mains for", target: "Table 10", at: "2m" },
+  { key: "f3", actor: { name: "AI expo", kind: "ai" }, action: "flagged slow turn on", target: "Table 12", at: "5m" },
+];
+const FLOOR_QUESTS: QuestData[] = [
+  { key: "q1", title: "6-top blocked", detail: "Nguyen party waiting 8 min · only Table 12 fits (bussing)", intent: "danger", cta: "Seat" },
+  { key: "q2", title: "Cellar restock", detail: "Table 7 wine order can't complete", intent: "warning", cta: "Reorder" },
+];
+
+// ─────────────────────────── Non-physical: SaaS TENANTS board ─────────────────────
+const SAAS_CHIPS: CapacityChipData[] = [
+  { key: "accounts", label: "Accounts", value: 128, intent: "info" },
+  { key: "atrisk", label: "At risk", value: 4, intent: "danger", live: true },
+  { key: "renewals", label: "Renewals (30d)", value: 9, intent: "warning" },
+  { key: "seats", label: "Seats used", value: 812, max: 1000, intent: "info" },
+];
+const SAAS_UNITS: ResourceUnitData[] = [
+  { key: "a1", label: "Northwind", state: "Healthy", intent: "success", sublabel: "92 · Enterprise", owner: { name: "Dana (CSM)", kind: "human" } },
+  { key: "a2", label: "Acme Co", state: "At risk", intent: "danger", sublabel: "41 · usage −38%", owner: { name: "AI success", kind: "ai" } },
+  { key: "a3", label: "Globex", state: "Onboarding", intent: "info", sublabel: "day 6 of 14", owner: { name: "Dana (CSM)", kind: "human" } },
+  { key: "a4", label: "Initech", state: "Expansion", intent: "accent", sublabel: "seats +20 pending" },
+];
+const SAAS_WORK: WorkItemData[] = [
+  { key: "s1", label: "Acme · renewal", owner: { name: "AI success", kind: "ai" }, progress: 25, sublabel: "closes in 11 days" },
+  { key: "s2", label: "Globex · onboarding", owner: { name: "Dana (CSM)", kind: "human" }, progress: 45 },
+  { key: "s3", label: "Initech · security review", blockedOnExternal: true, blockedLabel: "Blocked · customer legal" },
+];
+const SAAS_QUEUE: QueueItemData[] = [
+  { key: "r1", label: "Acme Co", meta: "Enterprise · usage −38%", waiting: "at risk", suggestion: "Route to Dana (lowest load, owns segment)" },
+  { key: "r2", label: "Umbrella", meta: "renewal · 6 days", waiting: "6d" },
+  { key: "r3", label: "Soylent", meta: "NPS detractor", waiting: "2d" },
+];
+const SAAS_PRESENCE: TwinActor[] = [
+  { name: "You", kind: "human", focus: "renewals desk" },
+  { name: "Dana", kind: "human", focus: "3 accounts" },
+  { name: "AI success", kind: "ai", focus: "health scores + at-risk" },
+];
+const SAAS_FEED: FeedEventData[] = [
+  { key: "sf1", actor: { name: "AI success", kind: "ai" }, action: "flagged churn risk on", target: "Acme Co", at: "just now" },
+  { key: "sf2", actor: { name: "Dana", kind: "human" }, action: "logged QBR for", target: "Northwind", at: "18m" },
+  { key: "sf3", actor: { name: "AI success", kind: "ai" }, action: "drafted renewal email for", target: "Umbrella", at: "1h" },
+];
+const SAAS_QUESTS: QuestData[] = [
+  { key: "sq1", title: "Acme at risk", detail: "Usage −38% with renewal in 11 days", intent: "danger", cta: "Assign" },
+  { key: "sq2", title: "Initech blocked", detail: "Security review stalled on customer legal", intent: "warning", cta: "Nudge" },
+];
+
+interface TwinExample {
+  chips: CapacityChipData[];
+  zoneLabel: string;
+  units: ResourceUnitData[];
+  workLabel: string;
+  work: WorkItemData[];
+  queueLabel: string;
+  queue: QueueItemData[];
+  cog: { proposal: string; signals: string[]; confirmLabel: string };
+  presence: TwinActor[];
+  feed: FeedEventData[];
+  quests: QuestData[];
+}
+
+const FLOOR: TwinExample = {
+  chips: FLOOR_CHIPS,
+  zoneLabel: "Dining floor",
+  units: FLOOR_UNITS,
+  workLabel: "On the pass",
+  work: FLOOR_TICKETS,
+  queueLabel: "Waitlist",
+  queue: FLOOR_QUEUE,
+  cog: {
+    proposal: "Seat the Nguyen party (4) at Table 12 once bussed (~4 min)",
+    signals: ["dwell-time", "turn-time", "party-fit"],
+    confirmLabel: "Seat party",
+  },
+  presence: FLOOR_PRESENCE,
+  feed: FLOOR_FEED,
+  quests: FLOOR_QUESTS,
+};
+
+const BOARD: TwinExample = {
+  chips: SAAS_CHIPS,
+  zoneLabel: "Accounts · at-risk lane",
+  units: SAAS_UNITS,
+  workLabel: "Engagements in flight",
+  work: SAAS_WORK,
+  queueLabel: "Renewals & risk queue",
+  queue: SAAS_QUEUE,
+  cog: {
+    proposal: "Route Acme Co to Dana — lowest CSM load and owns the Enterprise segment",
+    signals: ["health-score", "CSM-load", "segment-fit"],
+    confirmLabel: "Assign account",
+  },
+  presence: SAAS_PRESENCE,
+  feed: SAAS_FEED,
+  quests: SAAS_QUESTS,
+};
+
+function TwinPanel({ title, kind, example }: { title: string; kind: string; example: TwinExample }) {
+  const [resolved, setResolved] = useState(false);
+  return (
+    <section className="flex flex-col gap-3 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <header className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)]">{title}</h2>
+        <span className="rounded-full bg-[var(--dpf-surface-3)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+          {kind}
+        </span>
+      </header>
+
+      <CapacityChips chips={example.chips} />
+
+      <PresenceRow members={example.presence} />
+
+      <CogBanner
+        proposal={example.cog.proposal}
+        signals={example.cog.signals}
+        confirmLabel={example.cog.confirmLabel}
+        resolved={resolved}
+        onConfirm={() => setResolved(true)}
+        onDismiss={() => setResolved(true)}
+      />
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <TwinZone label={example.zoneLabel} meta={`${example.units.length} units`}>
+          <ResourceUnitGrid units={example.units} className="!grid-cols-2" />
+        </TwinZone>
+
+        <TwinZone label={example.workLabel}>
+          <div className="flex flex-col gap-2">
+            {example.work.map(({ key, ...item }) => (
+              <WorkItem key={key} {...item} />
+            ))}
+          </div>
+        </TwinZone>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <TwinQueue label={example.queueLabel} items={example.queue} />
+        <div className="flex flex-col gap-3">
+          <TwinZone label="Needs you">
+            <NeedsYouQuests quests={example.quests} />
+          </TwinZone>
+          <TwinZone label="Activity">
+            <AttributedFeed events={example.feed} />
+          </TwinZone>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function TwinKitShowcase() {
+  return (
+    <div className="flex flex-col gap-6">
+      <TwinZone label="Utility band — identical across every archetype">
+        <UtilityBand meters={UTILITY} />
+      </TwinZone>
+
+      <TwinPanel title="Restaurant — FLOOR" kind="physical twin" example={FLOOR} />
+      <TwinPanel title="SaaS — TENANTS board" kind="non-physical twin" example={BOARD} />
+    </div>
+  );
+}

--- a/apps/web/components/twin/TwinQueue.tsx
+++ b/apps/web/components/twin/TwinQueue.tsx
@@ -1,0 +1,78 @@
+// apps/web/components/twin/TwinQueue.tsx
+//
+// Primitive 5/10 — queue: ordered demand awaiting allocation (waitlist +
+// reservations / dispatch queue / reservations to fill). The heartbeat of the
+// twin. Each row can carry the cog's inline suggestion for that item; the
+// tap-to-confirm itself lives on the CogBanner (HITL). Pure + server-usable.
+
+import { Bot } from "lucide-react";
+
+import type { QueueItemData } from "./types";
+
+export interface TwinQueueProps {
+  label: string;
+  items: QueueItemData[];
+  /** Shown when the queue is empty — an idle queue is good news, say so. */
+  emptyLabel?: string;
+  className?: string;
+}
+
+export function TwinQueue({ label, items, emptyLabel, className = "" }: TwinQueueProps) {
+  return (
+    <section
+      className={`rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] ${className}`.trim()}
+    >
+      <header className="flex items-center justify-between gap-2 border-b border-[var(--dpf-border)] px-3 py-2">
+        <h4 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
+          {label}
+        </h4>
+        <span className="rounded-full bg-[var(--dpf-surface-3)] px-2 py-0.5 text-[11px] tabular-nums text-[var(--dpf-text-secondary)]">
+          {items.length}
+        </span>
+      </header>
+
+      {items.length === 0 ? (
+        <p className="px-3 py-4 text-center text-[11px] text-[var(--dpf-muted)]">
+          {emptyLabel ?? "Queue clear"}
+        </p>
+      ) : (
+        <ol className="divide-y divide-[var(--dpf-border)]">
+          {items.map((item, i) => (
+            <li key={item.key} className="flex flex-col gap-1 px-3 py-2">
+              <div className="flex items-center justify-between gap-2">
+                <span className="flex items-center gap-2">
+                  <span className="text-[10px] tabular-nums text-[var(--dpf-muted)]">
+                    {i + 1}
+                  </span>
+                  <span className="text-xs font-medium text-[var(--dpf-text)]">
+                    {item.label}
+                  </span>
+                </span>
+                {item.waiting ? (
+                  <span className="text-[10px] tabular-nums text-[var(--dpf-muted)]">
+                    {item.waiting}
+                  </span>
+                ) : null}
+              </div>
+              {item.meta ? (
+                <span className="pl-5 text-[11px] text-[var(--dpf-muted)]">{item.meta}</span>
+              ) : null}
+              {item.suggestion ? (
+                <span
+                  className="ml-5 inline-flex w-fit items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium"
+                  style={{
+                    backgroundColor: "var(--dpf-accent-soft)",
+                    color: "var(--dpf-accent)",
+                  }}
+                >
+                  <Bot aria-hidden size={11} />
+                  {item.suggestion}
+                </span>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/twin/TwinZone.tsx
+++ b/apps/web/components/twin/TwinZone.tsx
@@ -1,0 +1,31 @@
+// apps/web/components/twin/TwinZone.tsx
+//
+// Primitive 2/10 — zone: a named region of the operation (kitchen·dining·entrance /
+// territory zones·yard / ready line·returns·maintenance). A titled container that
+// holds resource units or work items. Pure + server-usable.
+
+import type { ReactNode } from "react";
+
+export interface TwinZoneProps {
+  label: string;
+  /** Optional right-aligned summary ("6 / 8 seated"). */
+  meta?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+export function TwinZone({ label, meta, children, className = "" }: TwinZoneProps) {
+  return (
+    <section
+      className={`rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] ${className}`.trim()}
+    >
+      <header className="flex items-center justify-between gap-2 border-b border-[var(--dpf-border)] px-3 py-2">
+        <h4 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
+          {label}
+        </h4>
+        {meta ? <span className="text-[11px] text-[var(--dpf-muted)]">{meta}</span> : null}
+      </header>
+      <div className="p-3">{children}</div>
+    </section>
+  );
+}

--- a/apps/web/components/twin/UtilityBand.tsx
+++ b/apps/web/components/twin/UtilityBand.tsx
@@ -1,0 +1,41 @@
+// apps/web/components/twin/UtilityBand.tsx
+//
+// Primitive 7/10 — utility band: the supporting activities as meters (bills, tax,
+// compliance, improve) — identical across every archetype. The "pay the bills and
+// taxes" surface the founder asked to keep in view. Pure + server-usable.
+
+import { intentStyle } from "@/components/ui/report-kit";
+
+import type { UtilityMeterData } from "./types";
+
+export interface UtilityBandProps {
+  meters: UtilityMeterData[];
+  className?: string;
+}
+
+export function UtilityBand({ meters, className = "" }: UtilityBandProps) {
+  return (
+    <div
+      className={`flex flex-wrap gap-2 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 ${className}`.trim()}
+    >
+      {meters.map((m) => {
+        const style = intentStyle(m.intent ?? "neutral");
+        return (
+          <div
+            key={m.key}
+            className="flex min-w-[7rem] flex-1 flex-col gap-0.5 rounded-md px-2.5 py-1.5"
+            style={{ backgroundColor: style.softBg }}
+            title={m.hint}
+          >
+            <span className="text-[10px] uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
+              {m.label}
+            </span>
+            <span className="text-sm font-semibold" style={{ color: style.fg }}>
+              {m.value}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/twin/WorkItem.tsx
+++ b/apps/web/components/twin/WorkItem.tsx
@@ -1,0 +1,62 @@
+// apps/web/components/twin/WorkItem.tsx
+//
+// Primitive 4/10 — work item: a unit of demand being processed (ticket / job /
+// agreement / matter), each with owner + progress, and a distinct blocked-on-
+// external state (waiting on a supplier, customer, or court — outside the
+// business's control). Pure + server-usable.
+
+import { intentStyle } from "@/components/ui/report-kit";
+
+import { ActorMark } from "./ActorMark";
+import type { WorkItemData } from "./types";
+
+export function WorkItem({
+  label,
+  owner,
+  progress,
+  blockedOnExternal,
+  blockedLabel,
+  sublabel,
+}: Omit<WorkItemData, "key">) {
+  const accent = blockedOnExternal ? intentStyle("warning") : intentStyle("accent");
+  const pct = typeof progress === "number" ? Math.max(0, Math.min(100, progress)) : null;
+
+  return (
+    <div
+      className="flex flex-col gap-1.5 rounded-md border bg-[var(--dpf-surface-2)] p-2"
+      style={{ borderLeftColor: accent.border, borderLeftWidth: "3px" }}
+      data-blocked={blockedOnExternal ? "true" : undefined}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-xs font-medium text-[var(--dpf-text)]">{label}</span>
+        {owner ? <ActorMark name={owner.name} kind={owner.kind} compact /> : null}
+      </div>
+
+      {sublabel ? (
+        <span className="text-[11px] text-[var(--dpf-muted)]">{sublabel}</span>
+      ) : null}
+
+      {blockedOnExternal ? (
+        <span
+          className="inline-flex w-fit items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium"
+          style={{ backgroundColor: accent.softBg, color: accent.fg }}
+        >
+          {blockedLabel ?? "Blocked · external"}
+        </span>
+      ) : pct !== null ? (
+        <div
+          className="h-1 w-full overflow-hidden rounded-full bg-[var(--dpf-surface-3)]"
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div
+            className="h-full rounded-full"
+            style={{ width: `${pct}%`, backgroundColor: accent.fg }}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/twin/index.ts
+++ b/apps/web/components/twin/index.ts
@@ -1,0 +1,26 @@
+// apps/web/components/twin/index.ts
+//
+// The Operational Twin grammar kit (EP-LIVING-BUSINESS-VIZ P2). Ten presentational
+// primitives every twin composes from, on the `--dpf-*` token + report-kit
+// substrate. A template (P3) binds a `TwinProfile` (@dpf/storefront-templates) +
+// a live snapshot to these props.
+//
+// Spec: docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md §3
+// Plan: docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md P2
+
+export * from "./types";
+export { ActorMark, type ActorMarkProps } from "./ActorMark";
+export { CapacityChip, CapacityChips, type CapacityChipsProps } from "./CapacityChips";
+export { TwinZone, type TwinZoneProps } from "./TwinZone";
+export {
+  ResourceUnit,
+  ResourceUnitGrid,
+  type ResourceUnitGridProps,
+} from "./ResourceUnit";
+export { WorkItem } from "./WorkItem";
+export { TwinQueue, type TwinQueueProps } from "./TwinQueue";
+export { CogBanner, type CogBannerProps } from "./CogBanner";
+export { UtilityBand, type UtilityBandProps } from "./UtilityBand";
+export { PresenceRow, type PresenceRowProps } from "./PresenceRow";
+export { AttributedFeed, type AttributedFeedProps } from "./AttributedFeed";
+export { NeedsYouQuests, type NeedsYouQuestsProps } from "./NeedsYouQuests";

--- a/apps/web/components/twin/twin-kit.test.tsx
+++ b/apps/web/components/twin/twin-kit.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  AttributedFeed,
+  CapacityChips,
+  NeedsYouQuests,
+  PresenceRow,
+  ResourceUnitGrid,
+  TwinQueue,
+  UtilityBand,
+  WorkItem,
+  type CapacityChipData,
+} from "./index";
+
+// The kit's pure primitives must render to static markup (server-usable) and
+// surface their data. The one client primitive (CogBanner) owns interaction and
+// is exercised via the showcase, not here.
+
+describe("twin grammar kit — pure primitives render statically", () => {
+  it("capacity chips show value / max and a live counter", () => {
+    const chips: CapacityChipData[] = [
+      { key: "t", label: "Tables", value: 6, max: 8, intent: "info", live: true },
+    ];
+    const html = renderToStaticMarkup(<CapacityChips chips={chips} />);
+    expect(html).toContain("Tables");
+    expect(html).toContain("6");
+    expect(html).toContain("8");
+    // live dot uses the motion-safe class (reduced-motion respected)
+    expect(html).toContain("motion-safe:animate-pulse");
+  });
+
+  it("resource unit grid renders state and owner", () => {
+    const html = renderToStaticMarkup(
+      <ResourceUnitGrid
+        units={[
+          { key: "t9", label: "Table 9", state: "Seated", intent: "success", owner: { name: "Ana", kind: "human" } },
+        ]}
+      />,
+    );
+    expect(html).toContain("Table 9");
+    expect(html).toContain("Seated");
+    expect(html).toContain("Ana");
+  });
+
+  it("work item renders the blocked-on-external state distinctly", () => {
+    const html = renderToStaticMarkup(
+      <WorkItem label="Table 7 · wine" blockedOnExternal blockedLabel="Blocked · cellar restock" />,
+    );
+    expect(html).toContain("Blocked · cellar restock");
+    expect(html).toContain('data-blocked="true"');
+  });
+
+  it("queue numbers items and shows the cog suggestion inline", () => {
+    const html = renderToStaticMarkup(
+      <TwinQueue
+        label="Waitlist"
+        items={[{ key: "w1", label: "Nguyen party", suggestion: "Seat at Table 12" }]}
+      />,
+    );
+    expect(html).toContain("Waitlist");
+    expect(html).toContain("Nguyen party");
+    expect(html).toContain("Seat at Table 12");
+  });
+
+  it("empty queue states the good news", () => {
+    const html = renderToStaticMarkup(<TwinQueue label="Dispatch" items={[]} />);
+    expect(html).toContain("Queue clear");
+  });
+
+  it("presence and feed attribute humans and AI on one plane", () => {
+    const presence = renderToStaticMarkup(
+      <PresenceRow
+        members={[
+          { name: "You", kind: "human", focus: "expediting" },
+          { name: "AI host", kind: "ai", focus: "waitlist" },
+        ]}
+      />,
+    );
+    expect(presence).toContain("You");
+    expect(presence).toContain("AI host");
+    expect(presence).toContain("expediting");
+
+    const feed = renderToStaticMarkup(
+      <AttributedFeed
+        events={[
+          { key: "f1", actor: { name: "AI host", kind: "ai" }, action: "proposed seating for", target: "Nguyen party", at: "now" },
+        ]}
+      />,
+    );
+    expect(feed).toContain("AI host");
+    expect(feed).toContain("proposed seating for");
+    expect(feed).toContain("Nguyen party");
+  });
+
+  it("utility band renders the identical support meters", () => {
+    const html = renderToStaticMarkup(
+      <UtilityBand
+        meters={[
+          { key: "bills", label: "Bills due", value: "2", intent: "warning" },
+          { key: "tax", label: "VAT return", value: "12 days", intent: "info" },
+        ]}
+      />,
+    );
+    expect(html).toContain("Bills due");
+    expect(html).toContain("VAT return");
+  });
+
+  it("needs-you quests render or state the calm-state fallback", () => {
+    const withQuests = renderToStaticMarkup(
+      <NeedsYouQuests quests={[{ key: "q1", title: "6-top blocked", intent: "danger", cta: "Seat" }]} />,
+    );
+    expect(withQuests).toContain("6-top blocked");
+    expect(withQuests).toContain("Seat");
+
+    const empty = renderToStaticMarkup(<NeedsYouQuests quests={[]} />);
+    expect(empty).toContain("Nothing needs you right now");
+  });
+});

--- a/apps/web/components/twin/types.ts
+++ b/apps/web/components/twin/types.ts
@@ -1,0 +1,101 @@
+// apps/web/components/twin/types.ts
+//
+// Shared prop vocabulary for the Operational Twin grammar kit (EP-LIVING-BUSINESS-VIZ P2).
+// These are the ten primitives every twin — floor, map, yard, or board — composes from,
+// lifted out of the four prototypes onto the `--dpf-*` token + report-kit substrate.
+// Spec: docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md §3.
+//
+// The components are presentational: a template (P3) binds a `TwinProfile`
+// (@dpf/storefront-templates) + a live snapshot to these props. Keeping the kit
+// snapshot-shaped rather than profile-shaped is deliberate — the same primitive
+// renders a restaurant table and a SaaS tenant.
+
+import type { Intent } from "@/components/ui/report-kit";
+
+/** The defining doctrine of the operating twin: humans and AI coworkers inhabit
+ *  the SAME surface. Every actor-bearing primitive carries this so the two are
+ *  rendered on one plane (attributed, not segregated). */
+export type TwinActorKind = "human" | "ai";
+
+export interface TwinActor {
+  name: string;
+  kind: TwinActorKind;
+  /** What this actor is attending to right now (presence "focus"). */
+  focus?: string;
+}
+
+/** A live constraint counter — the archetype's real limits, not vanity metrics. */
+export interface CapacityChipData {
+  key: string;
+  label: string;
+  value: number | string;
+  /** Denominator for "x / max" counters (seats, assets, seats-in-use). */
+  max?: number;
+  intent?: Intent;
+  /** Pulse a live dot (motion-safe) — the counter is changing in real time. */
+  live?: boolean;
+}
+
+/** A countable unit — table, van, chair, room, account, tenant — with state + owner. */
+export interface ResourceUnitData {
+  key: string;
+  label: string;
+  /** Human-readable state ("Seated", "Ready", "In bay", "At risk"). */
+  state: string;
+  intent?: Intent;
+  owner?: TwinActor;
+  /** Secondary line — occupancy, ETA, plan tier. */
+  sublabel?: string;
+}
+
+/** A unit of demand being processed — ticket, job, agreement, matter, renewal. */
+export interface WorkItemData {
+  key: string;
+  label: string;
+  owner?: TwinActor;
+  /** 0–100 progress along the item's lane. */
+  progress?: number;
+  /** Waiting on something outside the business (supplier, customer, court). */
+  blockedOnExternal?: boolean;
+  blockedLabel?: string;
+  sublabel?: string;
+}
+
+/** One item waiting in an ordered demand queue. */
+export interface QueueItemData {
+  key: string;
+  label: string;
+  meta?: string;
+  /** How long it has been waiting ("8 min", "2 days"). */
+  waiting?: string;
+  /** The cog's proposed allocation for THIS item (rendered inline, tap-to-confirm upstream). */
+  suggestion?: string;
+}
+
+/** A supporting-activity meter — bills, tax, compliance, improve. */
+export interface UtilityMeterData {
+  key: string;
+  label: string;
+  value: string;
+  intent?: Intent;
+  hint?: string;
+}
+
+/** One entry on the shared human+AI event plane. */
+export interface FeedEventData {
+  key: string;
+  actor: TwinActor;
+  action: string;
+  target?: string;
+  /** Pre-formatted relative time ("just now", "2m"). Formatting is the caller's job. */
+  at?: string;
+}
+
+/** One attention item pinned to twin context. */
+export interface QuestData {
+  key: string;
+  title: string;
+  detail?: string;
+  intent?: Intent;
+  cta?: string;
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 547,
+  "routeCount": 548,
   "routes": [
     {
       "routePath": "/",
@@ -317,6 +317,16 @@
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/admin/storefront/team/page.tsx",
       "redirectTo": "/storefront/team"
+    },
+    {
+      "routePath": "/admin/twin-kit",
+      "kind": "page",
+      "segments": [
+        "admin",
+        "twin-kit"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/admin/twin-kit/page.tsx"
     },
     {
       "routePath": "/admin/wiki/lint",

--- a/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
+++ b/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
@@ -34,8 +34,28 @@ archetype configuration — including the ones **not enabled**, which the
 setup-wizard redirect otherwise hides — with each row's derived operational-twin
 template. Plan: [2026-07-12-archetype-catalog-admin-view-execution.md](2026-07-12-archetype-catalog-admin-view-execution.md). Composed from report-kit; no render kit yet (that is P2).
 
-## P2 — the grammar kit · NEXT
-The ten primitives as React components on the token/report-kit substrate (`apps/web/components/twin/`), lifted from the four prototypes: capacity chips, zone, resource unit, work item (with blocked-on-external state), queue, cog banner, utility band, presence row, attributed feed, needs-you quests. Each rendered through `--dpf-*` tokens, reduced-motion-safe, dynamic text via a safe helper (no innerHTML). A fixture page per primitive. Requires a recorded `UX-Fit-Decision` (§12) for the metric/status components.
+## P2 — the grammar kit · DONE
+The ten primitives as React components on the token/report-kit substrate
+(`apps/web/components/twin/`), lifted from the four prototypes: capacity chips,
+zone, resource unit, work item (with blocked-on-external state), queue, cog banner,
+utility band, presence row, attributed feed, needs-you quests — plus a shared
+`ActorMark` that renders humans and AI coworkers on one plane (the operating-twin
+doctrine). Each is `--dpf-*` token-driven, reduced-motion-safe (`motion-safe:` live
+dots), and React-safe by construction (no `innerHTML`). Nine are pure/server-usable;
+only `CogBanner` is a client component (it owns the HITL confirm/dismiss). A viewable
+fixture — `/admin/twin-kit` (`TwinKitShowcase`) — renders all ten twice: a physical
+restaurant **FLOOR** and a non-physical SaaS **TENANTS** board, proving one grammar
+spans both lenses. Unit tests (`twin-kit.test.tsx`) assert each pure primitive renders
+to static markup and surfaces its data (incl. the blocked-on-external and attributed
+human/AI states).
+
+Verification: `pnpm --filter web typecheck` clean; `twin-kit.test.tsx` green;
+route manifest regenerated. **UX-Fit-Decision** recorded on the PR (composed from
+report-kit `intentStyle`/`StatusBadge`; progressive disclosure — capacity chips +
+one bottleneck queue + a single needs-you surface, not a chart wall; no raw/numeric
+operator inputs). The fixture is intentionally **not** linked from the admin nav —
+it is a developer preview, reachable directly and gated by the admin `view_admin`
+guard.
 
 ## P3 — first templates live
 FLOOR, TERRITORY, YARD as template compositions bound via `TwinProfile`, replacing the three hand-built prototypes with framework-rendered equivalents wired to `LivingBusinessSnapshot` + `agent-event-bus` (parent spec P1–P2). Registers as a workspace-home contribution per archetype.


### PR DESCRIPTION
## Summary

Delivers **P2 of the Operational Twin Framework**: the ten grammar primitives from the [design spec](docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md) §3 as real React components in `apps/web/components/twin/`, on the `--dpf-*` token + report-kit substrate. This lifts the grammar out of the four hand-built HTML prototypes so **P3 can render live templates from a `TwinProfile`** (the merged P1 derivation, #2875) instead of building each twin by hand. One grammar spans both lenses — physical *space* and non-physical *board*.

## Changes

- **`apps/web/components/twin/`** — the kit:
  - Pure / server-usable: `CapacityChips`, `TwinZone`, `ResourceUnit` (+`ResourceUnitGrid`), `WorkItem` (with the distinct **blocked-on-external** state), `TwinQueue` (inline cog suggestion per item), `UtilityBand`, `PresenceRow`, `AttributedFeed`, `NeedsYouQuests`.
  - `CogBanner` — the **one** client primitive; HITL confirm/dismiss on the AI coworker's allocation proposal (constraint → proposal → confirm), never auto-applied.
  - `ActorMark` — humans and AI coworkers on **one plane** (the operating-twin doctrine), used by units, work items, presence, and the feed.
  - `types.ts` (snapshot-shaped props) + `index.ts` barrel.
- **`apps/web/app/(shell)/admin/twin-kit/page.tsx`** + **`TwinKitShowcase.tsx`** — a viewable fixture at `/admin/twin-kit` rendering all ten primitives twice: a physical restaurant **FLOOR** and a non-physical SaaS **TENANTS** board, with a live cog. Not linked from the admin nav (developer preview); gated by the admin `view_admin` layout guard.
- **`twin-kit.test.tsx`** — asserts each pure primitive renders to static markup and surfaces its data (blocked-on-external, attributed human/AI, empty-queue calm state, motion-safe live dot).
- **`route-manifest.json`** — regenerated (548 routes).
- **Plan** — `docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md` P2 → DONE.

All `--dpf-*` token-driven, reduced-motion-safe (`motion-safe:` live dots), React-safe by construction (no `innerHTML`).

## Test plan

- [x] **Runtime-bound change** (new component kit + `/admin/twin-kit` route)
  - [x] `pnpm --filter web typecheck` — clean
  - [x] `pnpm --filter web exec vitest run components/twin/twin-kit.test.tsx` — 8/8 green
  - [x] `pnpm --filter web check:route-manifest` — up to date (548 routes)
  - [ ] Visual confirmation of `/admin/twin-kit` against the canonical runtime — CI (the worktree is not a full runtime; the page is a client showcase behind the admin guard)

- [x] **Verification-harness limitation acknowledged** — the worktree is source-control isolation, not a full runtime (AGENTS.md §5); the primitives are covered by `twin-kit.test.tsx` in CI Unit Tests.

### Verification evidence

```
$ pnpm --filter web typecheck
✓ Types generated successfully   (tsc --noEmit clean)

$ pnpm --filter web exec vitest run components/twin/twin-kit.test.tsx
 Test Files  1 passed (1)
      Tests  8 passed (8)

$ pnpm --filter web check:route-manifest
[route-manifest] up to date (548 routes)
```

## Related issues / Epic

- **EP-LIVING-BUSINESS-VIZ** P2. Builds on P1 `deriveTwinProfile` (#2875, merged) and the catalog view (#2889, merged). Design: [operational-twin-framework](docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md) §3 grammar.

## Overlap sweep

New component directory + one unlinked fixture route; no in-flight overlap. Composes existing report-kit (`intentStyle`/`StatusBadge`) and lucide-react rather than introducing a parallel primitive or icon set.

## Notes for the reviewer

- **UX-Fit-Decision:** composed from report-kit `intentStyle`/`StatusBadge` (no bespoke metric/status components); progressive disclosure — capacity chips + one bottleneck queue + a single needs-you surface, not a chart wall; zero raw/numeric operator inputs; reduced-motion-safe. The fixture is an unlinked developer preview, not a new product nav surface.
- **Design-Grounding-Decision:** source of truth is the operational-twin design spec §3 grammar + `packages/storefront-templates/src/twin-profile.ts` (`TwinProfile`); this extends the documented P2 plan item, adding presentational source with no contract change to the derivation.
- **Presentational only** — no data binding yet. P3 wires the kit to `TwinProfile` + `LivingBusinessSnapshot` on the workspace home. Try `/admin/twin-kit` to see the FLOOR and TENANTS twins and tap the cog's Confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ko4H8pkFGNvgnbz5j3wVF8)_