### PR TITLE
fix(curator): stop filing idle-but-healthy skills as stale backlog bugs (BI-509FF31E)

### DIFF
--- a/apps/web/lib/skills/curator.test.ts
+++ b/apps/web/lib/skills/curator.test.ts
@@ -99,9 +99,15 @@ function addSkill(partial: Partial<(typeof state.skills)[number]> & { skillId: s
 }
 
 describe("runSkillCurator — happy path", () => {
-  it("classifies, emits one signal per non-active finding, writes one report", async () => {
+  it("classifies all skills but signals only actionable findings — not idle-but-healthy skills (BI-509FF31E)", async () => {
     addSkill({ skillId: "active-skill", skillMdContent: "body" });
-    addSkill({ skillId: "stale-skill", skillMdContent: "body" });
+    // Idle-but-healthy: has a SKILL.md body, just no invocations in 30 days →
+    // classifySkillLifecycle rule 4 → "stale", but NOT a defect (situational
+    // skill). Must be classified stale in the report yet raise NO backlog signal.
+    addSkill({ skillId: "idle-skill", skillMdContent: "body" });
+    // Content-incomplete: empty SKILL.md body but has an assignment → rule 3
+    // "stale" — genuinely actionable → still raises a signal.
+    addSkill({ skillId: "incomplete-skill", skillMdContent: "", assignments: [{ id: "a1" }] });
     state.usageEvents.push({
       skillId: "active-skill",
       phase: "invoked",
@@ -110,11 +116,16 @@ describe("runSkillCurator — happy path", () => {
 
     const report = await runSkillCurator({ invokedByUserId: "usr_owner" });
 
-    // The stale skill produced a finding and a signal.
-    expect(report.findings.find((f) => f.skillId === "stale-skill")?.toState).toBe("stale");
+    // Both stale skills still appear in the curator report (classification is
+    // unchanged — only the backlog-signal disposition differs).
+    expect(report.findings.find((f) => f.skillId === "idle-skill")?.toState).toBe("stale");
+    expect(report.findings.find((f) => f.skillId === "incomplete-skill")?.toState).toBe("stale");
+    // Only the actionable (content-incomplete) finding raises a backlog signal;
+    // the idle-but-healthy skill does not.
     expect(state.signalsTouched).toHaveLength(1);
     expect(state.signalsTouched[0]?.sourceType).toBe("curator-finding");
-    expect(state.signalsTouched[0]?.sourceId).toBe("stale-skill:stale");
+    expect(state.signalsTouched[0]?.sourceId).toBe("incomplete-skill:stale");
+    expect(state.signalsTouched.find((s) => s.sourceId === "idle-skill:stale")).toBeUndefined();
 
     // Exactly one TaskArtifact with the right metadata kind.
     expect(state.artifactsCreated).toHaveLength(1);
@@ -201,10 +212,14 @@ describe("runSkillCurator — no skillMdContent mutation", () => {
 
 describe("runSkillCurator — dedupe", () => {
   it("re-running the curator over the same population produces the same signal sourceIds", async () => {
-    addSkill({ skillId: "stale-skill" });
+    // Use a content-incomplete (actionable) skill so a real signal is emitted —
+    // an idle-but-healthy skill no longer signals (BI-509FF31E), which would
+    // make this a vacuous empty-set comparison.
+    addSkill({ skillId: "incomplete-skill", skillMdContent: "", assignments: [{ id: "a1" }] });
 
     await runSkillCurator({ invokedByUserId: "usr_owner" });
     const firstIds = state.signalsTouched.map((s) => s.sourceId);
+    expect(firstIds).toEqual(["incomplete-skill:stale"]);
 
     state.signalsTouched.length = 0;
     state.skillUpdates.length = 0;

--- a/apps/web/lib/skills/curator.ts
+++ b/apps/web/lib/skills/curator.ts
@@ -125,12 +125,14 @@ export async function runSkillCurator(
       ? currentRaw
       : "active";
     const usage30d = usageMap.get(s.skillId) ?? { invoked: 0, failed: 0 };
+    const hasContent =
+      typeof s.skillMdContent === "string" && s.skillMdContent.trim().length > 0;
     const result = classifySkillLifecycle({
       current,
       usage30d,
       assignmentCount: s.assignments.length,
       lastUsedAt: lastUsedMap.get(s.skillId) ?? null,
-      hasContent: typeof s.skillMdContent === "string" && s.skillMdContent.trim().length > 0,
+      hasContent,
     });
 
     const next = isCuratorImmutable(current) ? current : result.next;
@@ -165,7 +167,18 @@ export async function runSkillCurator(
     // — surfacing them every day would be noise. (sourceType, sourceId)
     // dedupe means re-runs on the same population increment recurrenceCount
     // rather than producing parallel signals.
-    if (next !== "active" && !isCuratorImmutable(next)) {
+    //
+    // BI-509FF31E: a "stale" skill that still HAS content is idle-but-healthy —
+    // classifySkillLifecycle rule 4 (has content + assignments, zero invocations
+    // in 30 days). Most DPF skills are situational (dpf-tdd, review-inbox, …), so
+    // 30-day idleness is the expected steady state, not a defect. Raising a
+    // per-skill backlog signal for it floods the backlog (~76 BI-SIG-* items
+    // filed at once). Such skills stay classified stale in the report
+    // (findings/totals above) but do NOT raise a backlog signal. Content-
+    // incomplete stale (rule 3, !hasContent) and archived remain actionable and
+    // still signal.
+    const idleButHealthyStale = next === "stale" && hasContent;
+    if (next !== "active" && !isCuratorImmutable(next) && !idleButHealthyStale) {
       await createOrTouchImprovementSignal({
         sourceType: "curator-finding",
         sourceId: `${s.skillId}:${next}`,


### PR DESCRIPTION
## Summary
The skill curator emits a `curator-finding` ImprovementSignal for every skill classified non-active, and those signals are ingested as `workType: bug` backlog items. `classifySkillLifecycle` **rule 4** marks any skill with a SKILL.md body but **zero invocations in 30 days** as `stale`. Most DPF skills are situational (`dpf-tdd`, `dpf-architecture-review`, `review-inbox`, …) — 30-day idleness is their expected steady state — so this filed **~76 `BI-SIG-*` "Skill X is stale" items** at once (recurrence ≥3), swamping the backlog. An uninvoked-but-complete skill is not a defect.

## Fix
Suppress the backlog signal for **idle-but-healthy stale** (`next === "stale" && hasContent`). The skill is still classified `stale` in the curator report (findings / totals / `lifecycleState` all unchanged) — it just no longer raises a per-skill backlog bug. **Content-incomplete stale** (rule 3, no SKILL.md body) and **archived** remain actionable and still signal.

Among `stale` classifications, `hasContent === true` uniquely identifies rule 4 (rule 3 stale has `!hasContent`), so the guard is structural, not string-matching.

## Tests
- Happy-path split: an idle-but-healthy skill is classified `stale` but emits **no** signal, while a content-incomplete skill still does.
- Dedupe test re-pointed at a content-incomplete skill so it exercises a real signal.

## Impact
Stops the largest backlog-noise source at the root. The ~76 existing `BI-SIG-*` items were folded into this item (BI-509FF31E) and won't recur once this lands.

## Verification
Confirmed rule 4 is the noise source in `lifecycle.ts`; fix + tests added. Source-only worktree — CI runs the authoritative typecheck + `curator.test.ts`.

Resolves BI-509FF31E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)