### PR TITLE
fix(build): startBacklogBuild re-promotes a terminal/abandoned build instead of wedging (BI-08AE51DC)

### DIFF
--- a/apps/web/lib/actions/backlog-build.test.ts
+++ b/apps/web/lib/actions/backlog-build.test.ts
@@ -5,6 +5,7 @@ const { mockAuth, mockPrisma, mockPromote } = vi.hoisted(() => ({
   mockPrisma: {
     backlogItem: {
       findUnique: vi.fn(),
+      update: vi.fn(),
     },
     platformDevConfig: {
       findUnique: vi.fn(),
@@ -92,5 +93,57 @@ describe("startBacklogBuild", () => {
 
     expect(mockPrisma.$transaction).not.toHaveBeenCalled();
     expect(mockPromote).not.toHaveBeenCalled();
+    // A live build must never have its link cleared.
+    expect(mockPrisma.backlogItem.update).not.toHaveBeenCalled();
+  });
+
+  // BI-08AE51DC: a terminal (complete/failed/abandoned) activeBuild previously
+  // wedged the item — Start-build routed to the corpse forever. It must instead
+  // detach the stale 1:1 link and create a fresh draft.
+  it("re-promotes a fresh draft when the active build is terminal/abandoned", async () => {
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({
+      itemId: "BI-123",
+      activeBuild: { buildId: "FB-ABANDONED", phase: "abandoned" },
+    });
+    mockPrisma.backlogItem.update.mockResolvedValue({});
+    mockPromote.mockResolvedValue({
+      kind: "success",
+      build: { id: "row-2", buildId: "FB-NEW" },
+      backlogItemId: "BI-123",
+    });
+
+    await expect(startBacklogBuild("BI-123")).resolves.toEqual({
+      status: "created",
+      buildId: "FB-NEW",
+      href: "/build?buildId=FB-NEW",
+    });
+
+    // The stale terminal link is cleared inside the promote transaction, before
+    // promote (which refuses when activeBuildId is set) runs.
+    expect(mockPrisma.backlogItem.update).toHaveBeenCalledWith({
+      where: { itemId: "BI-123" },
+      data: { activeBuildId: null },
+    });
+    expect(mockPromote).toHaveBeenCalled();
+  });
+
+  it("treats a completed build as re-promotable too", async () => {
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({
+      itemId: "BI-123",
+      activeBuild: { buildId: "FB-DONE", phase: "complete" },
+    });
+    mockPrisma.backlogItem.update.mockResolvedValue({});
+    mockPromote.mockResolvedValue({
+      kind: "success",
+      build: { id: "row-3", buildId: "FB-FRESH" },
+      backlogItemId: "BI-123",
+    });
+
+    const res = await startBacklogBuild("BI-123");
+    expect(res.status).toBe("created");
+    expect(mockPrisma.backlogItem.update).toHaveBeenCalledWith({
+      where: { itemId: "BI-123" },
+      data: { activeBuildId: null },
+    });
   });
 });

--- a/apps/web/lib/actions/backlog-build.ts
+++ b/apps/web/lib/actions/backlog-build.ts
@@ -5,6 +5,12 @@ import { promoteBacklogItemToBuildDraft } from "@/lib/governed-backlog-tee-up";
 import { prisma } from "@dpf/db";
 import { revalidatePath } from "next/cache";
 
+// A build in one of these phases is no longer live, so it must not block a
+// re-start of the backlog item (BI-08AE51DC). Mirrors the same set used by
+// coworker-tool-filter.ts; kept local to avoid coupling to wip-cap's variant,
+// which intentionally omits "abandoned".
+const TERMINAL_BUILD_PHASES = new Set<string>(["complete", "failed", "abandoned"]);
+
 export type StartBacklogBuildResult =
   | {
     status: "created" | "existing";
@@ -40,22 +46,41 @@ export async function startBacklogBuild(itemId: string): Promise<StartBacklogBui
     return { status: "blocked", error: `Backlog item ${semanticItemId} was not found.` };
   }
 
-  if (existing.activeBuild?.buildId) {
-    const href = buildHref(existing.activeBuild.buildId);
+  // BI-08AE51DC: only a LIVE build blocks re-start. A terminal build
+  // (complete/failed/abandoned — e.g. the un-audited bulk-abandon incident that
+  // set phase='abandoned' with no reason) previously left the item permanently
+  // wedged: Start-build routed to the corpse and nothing detached it. Route to
+  // the build only when it is still live; a terminal activeBuild falls through
+  // to a fresh draft.
+  const activeBuild = existing.activeBuild;
+  if (activeBuild?.buildId && !TERMINAL_BUILD_PHASES.has(activeBuild.phase)) {
+    const href = buildHref(activeBuild.buildId);
     return {
       status: "existing",
-      buildId: existing.activeBuild.buildId,
+      buildId: activeBuild.buildId,
       href,
     };
   }
+  // Past this point any activeBuild is terminal; capture its id so we can clear
+  // the stale 1:1 link (activeBuildId is @unique and promoteBacklogItemToBuildDraft
+  // refuses when it is set) inside the promote transaction below.
+  const staleTerminalBuildId = activeBuild?.buildId ?? null;
 
   const config = await prisma.platformDevConfig.findUnique({
     where: { id: "singleton" },
     select: { governedBacklogEnabled: true },
   });
 
-  const result = await prisma.$transaction((tx) =>
-    promoteBacklogItemToBuildDraft({
+  const result = await prisma.$transaction(async (tx) => {
+    if (staleTerminalBuildId) {
+      // Detach the corpse so promote can create a fresh draft. Atomic with the
+      // promote below; promote re-reads the item inside this same tx.
+      await tx.backlogItem.update({
+        where: { itemId: semanticItemId },
+        data: { activeBuildId: null },
+      });
+    }
+    return promoteBacklogItemToBuildDraft({
       tx,
       itemId: semanticItemId,
       userId,
@@ -64,8 +89,8 @@ export async function startBacklogBuild(itemId: string): Promise<StartBacklogBui
         tool: "backlog_row_start_build",
         summary: `Build Studio draft created from backlog row ${semanticItemId}.`,
       },
-    }),
-  );
+    });
+  });
 
   if (result.kind !== "success") {
     return { status: "blocked", error: result.message || result.error };


### PR DESCRIPTION
## Summary
`startBacklogBuild` returned `status:"existing"` for **any** `activeBuild` without checking its phase, so a backlog item whose active build was **abandoned** (e.g. the un-audited bulk-abandon incident that set `phase='abandoned'` with no reason) was permanently wedged — Start-build routed to the corpse and nothing detached it. The 1:1 `activeBuildId` is `@unique` and `promoteBacklogItemToBuildDraft` refuses when it's set, so falling through alone wasn't enough.

## Fix
Only a **live** build blocks re-start. A **terminal** build (`complete`/`failed`/`abandoned`) is re-promotable: its stale `activeBuildId` link is cleared **inside the promote transaction** (atomic — promote re-reads the item in the same tx) and a fresh draft is created.

This resolves the item's **secondary defect**. The **governance half** — every abandon going through one audited path (actor + reason + BuildActivity) plus an invariant flagging direct-SQL abandons — is re-filed as a focused follow-up; the June rogue-writer forensics aren't reproducible now.

## Tests
- Terminal (`abandoned`) and completed activeBuilds clear the link and create a fresh draft.
- A live build (`plan`) still routes to it and never clears the link.

## Verification
Confirmed on `origin/main`: `promoteBacklogItemToBuildDraft` re-reads the item inside the tx and refuses when `activeBuildId` is set; `activeBuildId` is `@unique`. Source-only worktree — CI runs typecheck + `backlog-build.test.ts`.

Resolves the startBacklogBuild deadlock in BI-08AE51DC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)