### PR TITLE
feat(twin): TwinView — profile-driven twin renderer for every archetype (EP-LIVING-BUSINESS-VIZ P3)

### DIFF
--- a/apps/web/app/(shell)/admin/twin-kit/page.tsx
+++ b/apps/web/app/(shell)/admin/twin-kit/page.tsx
@@ -1,27 +1,71 @@
 import type { Metadata } from "next";
 
-import { TwinKitShowcase } from "@/components/twin/TwinKitShowcase";
+import {
+  ALL_ARCHETYPES,
+  deriveTwinProfile,
+  type ArchetypeDefinition,
+} from "@dpf/storefront-templates";
+
+import { buildDemoTwinSnapshot } from "@/components/twin";
+import { TwinKitShowcase, type TwinExample } from "@/components/twin/TwinKitShowcase";
 
 export const metadata: Metadata = {
   title: "Operational Twin Kit — preview",
 };
 
-// Fixture/reference surface for the Operational Twin grammar kit (P2). Not linked
-// from the admin nav — it is a developer preview of the ten primitives, reachable
-// directly at /admin/twin-kit and gated by the admin layout's view_admin guard.
-// P3 replaces the hand-built prototypes with template compositions of this kit
-// bound to a real TwinProfile + LivingBusinessSnapshot.
+// Fixture/reference surface for the Operational Twin renderer (P3). Not linked
+// from the admin nav — it is a developer preview reachable directly at
+// /admin/twin-kit, gated by the admin layout's view_admin guard. Every panel is
+// rendered by the SAME <TwinView> from a real deriveTwinProfile(archetype) plus a
+// deterministic demo snapshot; only the archetype differs. When the live
+// LivingBusinessSnapshot projection lands (parent spec P4), it drops in behind the
+// same TwinSnapshot shape and these become live.
+
+// A spread across both lenses — physical space and non-physical boards — proving
+// one renderer serves every archetype. Chosen by category; falls back gracefully
+// if a category has no seeded leaf.
+const SHOWCASE_CATEGORIES: Array<{ category: string; kind: string }> = [
+  { category: "food-hospitality", kind: "physical · floor" },
+  { category: "trades-maintenance", kind: "physical · territory" },
+  { category: "asset-rental", kind: "physical · yard" },
+  { category: "software-platform", kind: "board · tenants" },
+  { category: "professional-services", kind: "board · pipeline" },
+  { category: "nonprofit-community", kind: "board · programs" },
+];
+
+function firstInCategory(category: string): ArchetypeDefinition | undefined {
+  return ALL_ARCHETYPES.find((a) => a.category === category);
+}
+
 export default function AdminTwinKitPage() {
+  const examples: TwinExample[] = SHOWCASE_CATEGORIES.flatMap(({ category, kind }) => {
+    const archetype = firstInCategory(category);
+    if (!archetype) return [];
+    const profile = deriveTwinProfile(archetype);
+    return [
+      {
+        id: archetype.archetypeId,
+        label: archetype.name,
+        kind,
+        template: profile.template,
+        profile,
+        snapshot: buildDemoTwinSnapshot(profile),
+      },
+    ];
+  });
+
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Operational Twin Kit</h1>
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Operational Twin</h1>
         <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
-          Preview of the ten grammar primitives every twin composes from — shown on a
-          physical floor and a non-physical board.
+          One renderer, every archetype — each panel below is the same{" "}
+          <code className="text-[var(--dpf-text-secondary)]">TwinView</code> driven by a real{" "}
+          <code className="text-[var(--dpf-text-secondary)]">deriveTwinProfile</code> and demo
+          data. Switch archetype to see the template, vocabulary, and queues change.
         </p>
       </div>
-      <TwinKitShowcase />
+      <TwinKitShowcase examples={examples} />
     </div>
   );
 }

--- a/apps/web/components/twin/TwinKitShowcase.tsx
+++ b/apps/web/components/twin/TwinKitShowcase.tsx
@@ -2,231 +2,90 @@
 
 // apps/web/components/twin/TwinKitShowcase.tsx
 //
-// Developer preview of the Operational Twin grammar kit (P2). Renders the ten
-// primitives twice — once for a PHYSICAL twin (restaurant FLOOR) and once for a
-// NON-PHYSICAL board twin (SaaS TENANTS) — proving one grammar spans both lenses.
-// The cog banner is live (tap Confirm / Dismiss) to demonstrate the HITL loop.
+// Developer preview of the Operational Twin renderer (P3). An archetype switcher
+// over a set of pre-derived examples, each rendered by the SAME <TwinView> from a
+// real TwinProfile + a demo snapshot. Proves one renderer serves both lenses —
+// physical space and non-physical boards.
 
 import { useState } from "react";
 
-import {
-  AttributedFeed,
-  CapacityChips,
-  CogBanner,
-  NeedsYouQuests,
-  PresenceRow,
-  ResourceUnitGrid,
-  TwinQueue,
-  TwinZone,
-  UtilityBand,
-  WorkItem,
-  type CapacityChipData,
-  type FeedEventData,
-  type QuestData,
-  type QueueItemData,
-  type ResourceUnitData,
-  type TwinActor,
-  type UtilityMeterData,
-  type WorkItemData,
-} from "@/components/twin";
+import type { TwinProfile } from "@dpf/storefront-templates";
 
-// ── Shared: the utility band is identical across archetypes (that's the point). ──
-const UTILITY: UtilityMeterData[] = [
-  { key: "bills", label: "Bills due", value: "2 · £1,240", intent: "warning", hint: "Next 7 days" },
-  { key: "tax", label: "VAT return", value: "12 days", intent: "info" },
-  { key: "compliance", label: "Compliance", value: "All clear", intent: "success" },
-  { key: "improve", label: "Improve", value: "3 ideas", intent: "accent" },
-];
+import { TwinView } from "./TwinView";
+import type { TwinSnapshot } from "./snapshot";
 
-// ─────────────────────────── Physical: restaurant FLOOR ──────────────────────────
-const FLOOR_CHIPS: CapacityChipData[] = [
-  { key: "tables", label: "Tables", value: 6, max: 8, intent: "info", live: true },
-  { key: "seats", label: "Seats", value: 22, max: 32, intent: "info" },
-  { key: "6tops", label: "6-tops free", value: 1, intent: "warning" },
-  { key: "wait", label: "Waitlist", value: 3, intent: "danger", live: true },
-];
-const FLOOR_UNITS: ResourceUnitData[] = [
-  { key: "t9", label: "Table 9", state: "Seated", intent: "success", sublabel: "2 · 34 min", owner: { name: "Ana", kind: "human" } },
-  { key: "t10", label: "Table 10", state: "Dessert", intent: "info", sublabel: "4 · 1h05", owner: { name: "Ana", kind: "human" } },
-  { key: "t11", label: "Table 11", state: "Open", intent: "neutral", sublabel: "seats 2" },
-  { key: "t12", label: "Table 12", state: "Bussing", intent: "warning", sublabel: "seats 6", owner: { name: "AI expo", kind: "ai" } },
-];
-const FLOOR_TICKETS: WorkItemData[] = [
-  { key: "k1", label: "Table 10 · mains", owner: { name: "Kitchen", kind: "human" }, progress: 70 },
-  { key: "k2", label: "Online · pickup #4821", owner: { name: "AI host", kind: "ai" }, progress: 40, sublabel: "ready 7:45" },
-  { key: "k3", label: "Table 7 · wine", blockedOnExternal: true, blockedLabel: "Blocked · cellar restock" },
-];
-const FLOOR_QUEUE: QueueItemData[] = [
-  { key: "w1", label: "Nguyen party", meta: "4 guests", waiting: "8 min", suggestion: "Seat at Table 12 (bussing, ~4 min)" },
-  { key: "w2", label: "Walk-in", meta: "2 guests", waiting: "3 min" },
-  { key: "w3", label: "Reservation · Patel", meta: "6 · 8:00pm", waiting: "res" },
-];
-const FLOOR_PRESENCE: TwinActor[] = [
-  { name: "You", kind: "human", focus: "expediting" },
-  { name: "Ana", kind: "human", focus: "sections 9–10" },
-  { name: "AI host", kind: "ai", focus: "waitlist + online" },
-  { name: "AI expo", kind: "ai", focus: "table turns" },
-];
-const FLOOR_FEED: FeedEventData[] = [
-  { key: "f1", actor: { name: "AI host", kind: "ai" }, action: "proposed seating for", target: "Nguyen party", at: "just now" },
-  { key: "f2", actor: { name: "Ana", kind: "human" }, action: "fired mains for", target: "Table 10", at: "2m" },
-  { key: "f3", actor: { name: "AI expo", kind: "ai" }, action: "flagged slow turn on", target: "Table 12", at: "5m" },
-];
-const FLOOR_QUESTS: QuestData[] = [
-  { key: "q1", title: "6-top blocked", detail: "Nguyen party waiting 8 min · only Table 12 fits (bussing)", intent: "danger", cta: "Seat" },
-  { key: "q2", title: "Cellar restock", detail: "Table 7 wine order can't complete", intent: "warning", cta: "Reorder" },
-];
-
-// ─────────────────────────── Non-physical: SaaS TENANTS board ─────────────────────
-const SAAS_CHIPS: CapacityChipData[] = [
-  { key: "accounts", label: "Accounts", value: 128, intent: "info" },
-  { key: "atrisk", label: "At risk", value: 4, intent: "danger", live: true },
-  { key: "renewals", label: "Renewals (30d)", value: 9, intent: "warning" },
-  { key: "seats", label: "Seats used", value: 812, max: 1000, intent: "info" },
-];
-const SAAS_UNITS: ResourceUnitData[] = [
-  { key: "a1", label: "Northwind", state: "Healthy", intent: "success", sublabel: "92 · Enterprise", owner: { name: "Dana (CSM)", kind: "human" } },
-  { key: "a2", label: "Acme Co", state: "At risk", intent: "danger", sublabel: "41 · usage −38%", owner: { name: "AI success", kind: "ai" } },
-  { key: "a3", label: "Globex", state: "Onboarding", intent: "info", sublabel: "day 6 of 14", owner: { name: "Dana (CSM)", kind: "human" } },
-  { key: "a4", label: "Initech", state: "Expansion", intent: "accent", sublabel: "seats +20 pending" },
-];
-const SAAS_WORK: WorkItemData[] = [
-  { key: "s1", label: "Acme · renewal", owner: { name: "AI success", kind: "ai" }, progress: 25, sublabel: "closes in 11 days" },
-  { key: "s2", label: "Globex · onboarding", owner: { name: "Dana (CSM)", kind: "human" }, progress: 45 },
-  { key: "s3", label: "Initech · security review", blockedOnExternal: true, blockedLabel: "Blocked · customer legal" },
-];
-const SAAS_QUEUE: QueueItemData[] = [
-  { key: "r1", label: "Acme Co", meta: "Enterprise · usage −38%", waiting: "at risk", suggestion: "Route to Dana (lowest load, owns segment)" },
-  { key: "r2", label: "Umbrella", meta: "renewal · 6 days", waiting: "6d" },
-  { key: "r3", label: "Soylent", meta: "NPS detractor", waiting: "2d" },
-];
-const SAAS_PRESENCE: TwinActor[] = [
-  { name: "You", kind: "human", focus: "renewals desk" },
-  { name: "Dana", kind: "human", focus: "3 accounts" },
-  { name: "AI success", kind: "ai", focus: "health scores + at-risk" },
-];
-const SAAS_FEED: FeedEventData[] = [
-  { key: "sf1", actor: { name: "AI success", kind: "ai" }, action: "flagged churn risk on", target: "Acme Co", at: "just now" },
-  { key: "sf2", actor: { name: "Dana", kind: "human" }, action: "logged QBR for", target: "Northwind", at: "18m" },
-  { key: "sf3", actor: { name: "AI success", kind: "ai" }, action: "drafted renewal email for", target: "Umbrella", at: "1h" },
-];
-const SAAS_QUESTS: QuestData[] = [
-  { key: "sq1", title: "Acme at risk", detail: "Usage −38% with renewal in 11 days", intent: "danger", cta: "Assign" },
-  { key: "sq2", title: "Initech blocked", detail: "Security review stalled on customer legal", intent: "warning", cta: "Nudge" },
-];
-
-interface TwinExample {
-  chips: CapacityChipData[];
-  zoneLabel: string;
-  units: ResourceUnitData[];
-  workLabel: string;
-  work: WorkItemData[];
-  queueLabel: string;
-  queue: QueueItemData[];
-  cog: { proposal: string; signals: string[]; confirmLabel: string };
-  presence: TwinActor[];
-  feed: FeedEventData[];
-  quests: QuestData[];
+export interface TwinExample {
+  id: string;
+  label: string;
+  kind: string;
+  template: string;
+  profile: TwinProfile;
+  snapshot: TwinSnapshot;
 }
 
-const FLOOR: TwinExample = {
-  chips: FLOOR_CHIPS,
-  zoneLabel: "Dining floor",
-  units: FLOOR_UNITS,
-  workLabel: "On the pass",
-  work: FLOOR_TICKETS,
-  queueLabel: "Waitlist",
-  queue: FLOOR_QUEUE,
-  cog: {
-    proposal: "Seat the Nguyen party (4) at Table 12 once bussed (~4 min)",
-    signals: ["dwell-time", "turn-time", "party-fit"],
-    confirmLabel: "Seat party",
-  },
-  presence: FLOOR_PRESENCE,
-  feed: FLOOR_FEED,
-  quests: FLOOR_QUESTS,
-};
-
-const BOARD: TwinExample = {
-  chips: SAAS_CHIPS,
-  zoneLabel: "Accounts · at-risk lane",
-  units: SAAS_UNITS,
-  workLabel: "Engagements in flight",
-  work: SAAS_WORK,
-  queueLabel: "Renewals & risk queue",
-  queue: SAAS_QUEUE,
-  cog: {
-    proposal: "Route Acme Co to Dana — lowest CSM load and owns the Enterprise segment",
-    signals: ["health-score", "CSM-load", "segment-fit"],
-    confirmLabel: "Assign account",
-  },
-  presence: SAAS_PRESENCE,
-  feed: SAAS_FEED,
-  quests: SAAS_QUESTS,
-};
-
-function TwinPanel({ title, kind, example }: { title: string; kind: string; example: TwinExample }) {
-  const [resolved, setResolved] = useState(false);
-  return (
-    <section className="flex flex-col gap-3 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
-      <header className="flex items-center justify-between gap-2">
-        <h2 className="text-sm font-semibold text-[var(--dpf-text)]">{title}</h2>
-        <span className="rounded-full bg-[var(--dpf-surface-3)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
-          {kind}
-        </span>
-      </header>
-
-      <CapacityChips chips={example.chips} />
-
-      <PresenceRow members={example.presence} />
-
-      <CogBanner
-        proposal={example.cog.proposal}
-        signals={example.cog.signals}
-        confirmLabel={example.cog.confirmLabel}
-        resolved={resolved}
-        onConfirm={() => setResolved(true)}
-        onDismiss={() => setResolved(true)}
-      />
-
-      <div className="grid gap-3 lg:grid-cols-2">
-        <TwinZone label={example.zoneLabel} meta={`${example.units.length} units`}>
-          <ResourceUnitGrid units={example.units} className="!grid-cols-2" />
-        </TwinZone>
-
-        <TwinZone label={example.workLabel}>
-          <div className="flex flex-col gap-2">
-            {example.work.map(({ key, ...item }) => (
-              <WorkItem key={key} {...item} />
-            ))}
-          </div>
-        </TwinZone>
-      </div>
-
-      <div className="grid gap-3 lg:grid-cols-2">
-        <TwinQueue label={example.queueLabel} items={example.queue} />
-        <div className="flex flex-col gap-3">
-          <TwinZone label="Needs you">
-            <NeedsYouQuests quests={example.quests} />
-          </TwinZone>
-          <TwinZone label="Activity">
-            <AttributedFeed events={example.feed} />
-          </TwinZone>
-        </div>
-      </div>
-    </section>
-  );
+export interface TwinKitShowcaseProps {
+  examples: TwinExample[];
 }
 
-export function TwinKitShowcase() {
-  return (
-    <div className="flex flex-col gap-6">
-      <TwinZone label="Utility band — identical across every archetype">
-        <UtilityBand meters={UTILITY} />
-      </TwinZone>
+export function TwinKitShowcase({ examples }: TwinKitShowcaseProps) {
+  const [activeId, setActiveId] = useState(examples[0]?.id ?? "");
+  const active = examples.find((e) => e.id === activeId) ?? examples[0];
 
-      <TwinPanel title="Restaurant — FLOOR" kind="physical twin" example={FLOOR} />
-      <TwinPanel title="SaaS — TENANTS board" kind="non-physical twin" example={BOARD} />
+  if (!active) {
+    return (
+      <p className="text-sm text-[var(--dpf-muted)]">No archetypes available to preview.</p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div
+        role="tablist"
+        aria-label="Archetype"
+        className="flex flex-wrap gap-1.5 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-1.5"
+      >
+        {examples.map((e) => {
+          const on = e.id === active.id;
+          return (
+            <button
+              key={e.id}
+              type="button"
+              role="tab"
+              aria-selected={on}
+              onClick={() => setActiveId(e.id)}
+              className="flex flex-col items-start rounded-md px-2.5 py-1.5 text-left transition-colors"
+              style={
+                on
+                  ? { backgroundColor: "var(--dpf-accent-soft)", color: "var(--dpf-accent)" }
+                  : { color: "var(--dpf-muted)" }
+              }
+            >
+              <span className="text-xs font-medium">{e.label}</span>
+              <span className="text-[10px] uppercase tracking-wide opacity-80">{e.kind}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <section className="flex flex-col gap-3 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+        <header className="flex items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold text-[var(--dpf-text)]">{active.label}</h2>
+          <span className="rounded-full bg-[var(--dpf-surface-3)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">
+            {active.template}
+            {active.profile.variant ? ` · ${active.profile.variant}` : ""}
+          </span>
+        </header>
+
+        {/* key forces a fresh cog state per archetype switch */}
+        <TwinView key={active.id} profile={active.profile} snapshot={active.snapshot} />
+      </section>
+
+      <p className="text-[11px] text-[var(--dpf-muted)]">
+        Values are deterministic demo data (
+        <code className="text-[var(--dpf-text-secondary)]">buildDemoTwinSnapshot</code>). The live{" "}
+        <code className="text-[var(--dpf-text-secondary)]">LivingBusinessSnapshot</code> projection
+        drops in behind the same shape.
+      </p>
     </div>
   );
 }

--- a/apps/web/components/twin/TwinView.tsx
+++ b/apps/web/components/twin/TwinView.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+// apps/web/components/twin/TwinView.tsx
+//
+// The profile-driven twin renderer (EP-LIVING-BUSINESS-VIZ P3). Given a
+// `TwinProfile` (which template + nouns/zones/queues/cog) and a `TwinSnapshot`
+// (the live values), it composes the grammar kit into the right layout — one
+// component for every archetype, physical or board. This is the piece that
+// replaces the four hand-built HTML prototypes with framework rendering.
+//
+// Client because it hosts the interactive cog (HITL confirm). The zones/queues/
+// feed are all kit primitives; only the vocabulary and which-template come from
+// the profile.
+
+import { useMemo, useState } from "react";
+
+import type { TwinProfile } from "@dpf/storefront-templates";
+
+import { AttributedFeed } from "./AttributedFeed";
+import { CapacityChips } from "./CapacityChips";
+import { CogBanner } from "./CogBanner";
+import { NeedsYouQuests } from "./NeedsYouQuests";
+import { PresenceRow } from "./PresenceRow";
+import { ResourceUnitGrid } from "./ResourceUnit";
+import { TwinQueue } from "./TwinQueue";
+import { TwinZone } from "./TwinZone";
+import { UtilityBand } from "./UtilityBand";
+import { WorkItem } from "./WorkItem";
+import type { TwinSnapshot } from "./snapshot";
+
+export interface TwinViewProps {
+  profile: TwinProfile;
+  snapshot: TwinSnapshot;
+  className?: string;
+}
+
+function titleCase(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+export function TwinView({ profile, snapshot, className = "" }: TwinViewProps) {
+  const [cogResolved, setCogResolved] = useState(false);
+
+  // Zone label lookup comes from the profile; the snapshot supplies the units.
+  const zoneLabel = useMemo(() => {
+    const map = new Map(profile.zones.map((z) => [z.key, z.label]));
+    return (key: string) => map.get(key) ?? titleCase(key);
+  }, [profile.zones]);
+
+  const queueLabel = useMemo(() => {
+    const map = new Map(profile.queues.map((q) => [q.key, q.label]));
+    return (key: string) => map.get(key) ?? titleCase(key);
+  }, [profile.queues]);
+
+  // Physical twins render space (a grid of zones); board twins render a portfolio
+  // (a single wide board). Both share the same primitives — only emphasis differs.
+  const zoneWrapClass = profile.physical
+    ? "grid gap-3 sm:grid-cols-2"
+    : "grid gap-3";
+
+  return (
+    <div className={`flex flex-col gap-4 ${className}`.trim()}>
+      <CapacityChips chips={snapshot.capacityChips} />
+
+      <PresenceRow members={snapshot.presence} />
+
+      {snapshot.cog ? (
+        <CogBanner
+          proposal={snapshot.cog.proposal}
+          signals={snapshot.cog.signals ?? profile.cog.signals}
+          confirmLabel={snapshot.cog.confirmLabel}
+          resolved={cogResolved}
+          onConfirm={() => setCogResolved(true)}
+          onDismiss={() => setCogResolved(true)}
+        />
+      ) : null}
+
+      <div className="grid gap-4 lg:grid-cols-[1.6fr_1fr]">
+        {/* Left: the operation itself — zones of resource units + work in flight. */}
+        <div className="flex flex-col gap-3">
+          <div className={zoneWrapClass}>
+            {snapshot.zones.map((zone) => (
+              <TwinZone
+                key={zone.key}
+                label={zoneLabel(zone.key)}
+                meta={zone.meta ?? `${zone.units.length} ${profile.resourceNoun.plural}`}
+              >
+                <ResourceUnitGrid units={zone.units} className="!grid-cols-2" />
+              </TwinZone>
+            ))}
+          </div>
+
+          {snapshot.workItems.length > 0 ? (
+            <TwinZone label={titleCase(profile.workItemNoun.plural)}>
+              <div className="flex flex-col gap-2">
+                {snapshot.workItems.map(({ key, ...item }) => (
+                  <WorkItem key={key} {...item} />
+                ))}
+              </div>
+            </TwinZone>
+          ) : null}
+        </div>
+
+        {/* Right: the heartbeat — queues, what-needs-you, and the shared feed. */}
+        <div className="flex flex-col gap-3">
+          {snapshot.queues.map((queue) => (
+            <TwinQueue
+              key={queue.key}
+              label={queueLabel(queue.key)}
+              items={queue.items}
+              emptyLabel={queue.emptyLabel}
+            />
+          ))}
+
+          <TwinZone label="Needs you">
+            <NeedsYouQuests quests={snapshot.quests} />
+          </TwinZone>
+
+          <TwinZone label="Activity">
+            <AttributedFeed events={snapshot.feed} />
+          </TwinZone>
+        </div>
+      </div>
+
+      <UtilityBand meters={snapshot.utility} />
+    </div>
+  );
+}

--- a/apps/web/components/twin/demo-snapshot.ts
+++ b/apps/web/components/twin/demo-snapshot.ts
@@ -1,0 +1,147 @@
+// apps/web/components/twin/demo-snapshot.ts
+//
+// Deterministic demo data for a `TwinView` (EP-LIVING-BUSINESS-VIZ P3). Fills a
+// `TwinSnapshot` from any `TwinProfile` so the twin is demonstrable BEFORE the
+// live `LivingBusinessSnapshot` projection exists (parent spec P4). This is
+// FIXTURE data — plausible, profile-shaped, and fully deterministic (no
+// Math.random/Date, so tests and SSR are stable). It is not, and must not become,
+// a data source: the real projection replaces it wholesale behind the same shape.
+
+import type { TwinProfile } from "@dpf/storefront-templates";
+
+import type { Intent } from "@/components/ui/report-kit";
+
+import type { TwinSnapshot, TwinZoneSnapshot } from "./snapshot";
+import type { CapacityChipData, ResourceUnitData } from "./types";
+
+const STATE_CYCLE: Array<{ state: string; intent: Intent }> = [
+  { state: "Active", intent: "success" },
+  { state: "In progress", intent: "info" },
+  { state: "Open", intent: "neutral" },
+  { state: "Needs attention", intent: "warning" },
+];
+
+function titleCase(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+/** A small, stable pseudo-value from a string — keeps the fixture deterministic. */
+function seed(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i += 1) h = (h * 31 + s.charCodeAt(i)) % 997;
+  return h;
+}
+
+function unitsForZone(profile: TwinProfile, zoneKey: string, count: number): ResourceUnitData[] {
+  const noun = titleCase(profile.resourceNoun.singular);
+  const base = seed(`${profile.template}:${zoneKey}`);
+  return Array.from({ length: count }, (_, i) => {
+    const s = STATE_CYCLE[(base + i) % STATE_CYCLE.length];
+    const owned = (base + i) % 3 === 0;
+    return {
+      key: `${zoneKey}-${i}`,
+      label: `${noun} ${base % 20 + i + 1}`,
+      state: s.state,
+      intent: s.intent,
+      owner: owned
+        ? { name: i % 2 === 0 ? "AI coworker" : "Team", kind: i % 2 === 0 ? "ai" : "human" }
+        : undefined,
+    } satisfies ResourceUnitData;
+  });
+}
+
+/**
+ * Build a deterministic demo snapshot for a profile. `buildDemoTwinSnapshot` is
+ * the fixture equivalent of the future projection: same shape, invented values.
+ */
+export function buildDemoTwinSnapshot(profile: TwinProfile): TwinSnapshot {
+  const resPlural = profile.resourceNoun.plural;
+  const workSingular = profile.workItemNoun.singular;
+
+  const capacityChips: CapacityChipData[] = profile.capacityChips.map((label, i) => {
+    const v = (seed(label) % 12) + i;
+    const intents: Intent[] = ["info", "success", "warning", "danger"];
+    return {
+      key: `cap-${i}`,
+      label,
+      value: v,
+      intent: intents[i % intents.length],
+      live: i === 0,
+    } satisfies CapacityChipData;
+  });
+
+  const zones: TwinZoneSnapshot[] = profile.zones.map((z) => {
+    const count = 3 + (seed(z.key) % 3);
+    return { key: z.key, units: unitsForZone(profile, z.key, count) } satisfies TwinZoneSnapshot;
+  });
+
+  const queues = profile.queues.map((qs, qi) => {
+    const n = 2 + (seed(qs.key) % 3);
+    return {
+      key: qs.key,
+      items: Array.from({ length: n }, (_, i) => ({
+        key: `${qs.key}-${i}`,
+        label: `${titleCase(workSingular)} #${seed(qs.key) + i}`,
+        meta: i === 0 ? "highest priority" : undefined,
+        waiting: `${(i + 1) * 4}m`,
+        suggestion:
+          qi === 0 && i === 0
+            ? `Route to best ${profile.resourceNoun.singular} (${profile.cog.signals[0]})`
+            : undefined,
+      })),
+    };
+  });
+
+  const workItems = [
+    {
+      key: "w0",
+      label: `${titleCase(workSingular)} · in flight`,
+      owner: { name: "AI coworker", kind: "ai" as const },
+      progress: 55,
+    },
+    {
+      key: "w1",
+      label: `${titleCase(workSingular)} · with the team`,
+      owner: { name: "Team", kind: "human" as const },
+      progress: 30,
+    },
+    {
+      key: "w2",
+      label: `${titleCase(workSingular)} · waiting on a third party`,
+      blockedOnExternal: true,
+      blockedLabel: "Blocked · external",
+    },
+  ];
+
+  const firstChip = profile.capacityChips[0] ?? resPlural;
+  const cog = {
+    proposal: `Allocate the next ${workSingular} to the best ${profile.resourceNoun.singular} by ${profile.cog.signals[0]}`,
+    confirmLabel: `Assign ${workSingular}`,
+    signals: profile.cog.signals.slice(0, 3),
+  };
+
+  const presence = [
+    { name: "You", kind: "human" as const, focus: "on the floor" },
+    { name: "Team", kind: "human" as const, focus: resPlural },
+    { name: "AI coworker", kind: "ai" as const, focus: `watching ${firstChip}` },
+  ];
+
+  const feed = [
+    { key: "f0", actor: { name: "AI coworker", kind: "ai" as const }, action: `proposed a ${workSingular} allocation`, at: "just now" },
+    { key: "f1", actor: { name: "You", kind: "human" as const }, action: `confirmed a ${workSingular}`, at: "3m" },
+    { key: "f2", actor: { name: "AI coworker", kind: "ai" as const }, action: `flagged a ${profile.resourceNoun.singular} needing attention`, at: "9m" },
+  ];
+
+  const quests = [
+    { key: "q0", title: `A ${workSingular} needs you`, detail: `Blocked on a third party — one tap to nudge`, intent: "warning" as Intent, cta: "Nudge" },
+  ];
+
+  const utility = [
+    { key: "bills", label: "Bills due", value: "2 · £1,240", intent: "warning" as Intent, hint: "Next 7 days" },
+    { key: "tax", label: "Tax filing", value: "12 days", intent: "info" as Intent },
+    { key: "compliance", label: "Compliance", value: "All clear", intent: "success" as Intent },
+    { key: "improve", label: "Improve", value: "3 ideas", intent: "accent" as Intent },
+  ];
+
+  return { capacityChips, zones, workItems, queues, cog, presence, feed, quests, utility };
+}

--- a/apps/web/components/twin/index.ts
+++ b/apps/web/components/twin/index.ts
@@ -24,3 +24,13 @@ export { UtilityBand, type UtilityBandProps } from "./UtilityBand";
 export { PresenceRow, type PresenceRowProps } from "./PresenceRow";
 export { AttributedFeed, type AttributedFeedProps } from "./AttributedFeed";
 export { NeedsYouQuests, type NeedsYouQuestsProps } from "./NeedsYouQuests";
+
+// P3 — the profile-driven renderer + its live-data contract.
+export { TwinView, type TwinViewProps } from "./TwinView";
+export {
+  type TwinSnapshot,
+  type TwinZoneSnapshot,
+  type TwinQueueSnapshot,
+  type TwinCogSnapshot,
+} from "./snapshot";
+export { buildDemoTwinSnapshot } from "./demo-snapshot";

--- a/apps/web/components/twin/snapshot.ts
+++ b/apps/web/components/twin/snapshot.ts
@@ -1,0 +1,58 @@
+// apps/web/components/twin/snapshot.ts
+//
+// The render contract for a live operational twin (EP-LIVING-BUSINESS-VIZ P3).
+// A `TwinProfile` (@dpf/storefront-templates, merged P1) says WHICH template and
+// WHAT the nouns/zones/queues/cog are; a `TwinSnapshot` supplies the live VALUES
+// that fill them at a moment in time. `TwinView` composes the grammar kit from
+// the two.
+//
+// A future projection (`LivingBusinessSnapshot`, parent spec P4) will produce this
+// shape from real substrate — agent_registry/Agent + agent-event-bus, the finance
+// spine, scheduling — keyed by the profile. Until then `buildDemoTwinSnapshot`
+// (demo-snapshot.ts) fills it deterministically for the fixture.
+
+import type {
+  CapacityChipData,
+  FeedEventData,
+  QuestData,
+  QueueItemData,
+  ResourceUnitData,
+  TwinActor,
+  UtilityMeterData,
+  WorkItemData,
+} from "./types";
+
+/** Live units for one of the profile's zones (keyed to `TwinProfile.zones[].key`). */
+export interface TwinZoneSnapshot {
+  key: string;
+  units: ResourceUnitData[];
+  /** Right-aligned zone summary ("6 / 8 seated"). */
+  meta?: string;
+}
+
+/** Live demand for one of the profile's queues (keyed to `TwinProfile.queues[].key`). */
+export interface TwinQueueSnapshot {
+  key: string;
+  items: QueueItemData[];
+  emptyLabel?: string;
+}
+
+/** The cog's current proposal over live state (constraint → proposal → confirm). */
+export interface TwinCogSnapshot {
+  proposal: string;
+  confirmLabel?: string;
+  /** Overrides the profile's default cog signals for this specific proposal. */
+  signals?: string[];
+}
+
+export interface TwinSnapshot {
+  capacityChips: CapacityChipData[];
+  zones: TwinZoneSnapshot[];
+  workItems: WorkItemData[];
+  queues: TwinQueueSnapshot[];
+  cog?: TwinCogSnapshot;
+  presence: TwinActor[];
+  feed: FeedEventData[];
+  quests: QuestData[];
+  utility: UtilityMeterData[];
+}

--- a/apps/web/components/twin/twin-view.test.tsx
+++ b/apps/web/components/twin/twin-view.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ALL_ARCHETYPES, deriveTwinProfile } from "@dpf/storefront-templates";
+
+import { buildDemoTwinSnapshot } from "./demo-snapshot";
+import { TwinView } from "./TwinView";
+
+const byCategory = (category: string) => ALL_ARCHETYPES.find((a) => a.category === category)!;
+
+describe("buildDemoTwinSnapshot — totality + determinism", () => {
+  it("produces a renderable snapshot for EVERY seeded archetype", () => {
+    for (const a of ALL_ARCHETYPES) {
+      const profile = deriveTwinProfile(a);
+      const snap = buildDemoTwinSnapshot(profile);
+      expect(snap.capacityChips.length, `${a.archetypeId} chips`).toBeGreaterThan(0);
+      expect(snap.zones.length, `${a.archetypeId} zones`).toBe(profile.zones.length);
+      expect(snap.queues.length, `${a.archetypeId} queues`).toBe(profile.queues.length);
+      // every zone binds to a real profile zone key
+      const zoneKeys = new Set(profile.zones.map((z) => z.key));
+      for (const zs of snap.zones) expect(zoneKeys.has(zs.key), `${a.archetypeId} zone ${zs.key}`).toBe(true);
+      expect(snap.utility.length).toBeGreaterThan(0);
+      expect(snap.presence.some((p) => p.kind === "ai"), `${a.archetypeId} has an AI coworker`).toBe(true);
+    }
+  });
+
+  it("is deterministic (same profile → identical snapshot)", () => {
+    const profile = deriveTwinProfile(byCategory("food-hospitality"));
+    expect(buildDemoTwinSnapshot(profile)).toEqual(buildDemoTwinSnapshot(profile));
+  });
+});
+
+describe("TwinView — one renderer, both lenses", () => {
+  it("renders a physical FLOOR twin with its profile vocabulary and queues", () => {
+    const profile = deriveTwinProfile(byCategory("food-hospitality"));
+    expect(profile.template).toBe("FLOOR");
+    const html = renderToStaticMarkup(
+      <TwinView profile={profile} snapshot={buildDemoTwinSnapshot(profile)} />,
+    );
+    // zone label from the profile grammar
+    expect(html).toContain("Dining room");
+    // queue label from the profile grammar
+    expect(html).toContain("Waitlist");
+    // the shared utility band
+    expect(html).toContain("Bills due");
+    // the cog proposal references the profile's resource noun
+    expect(html).toContain(profile.resourceNoun.singular);
+  });
+
+  it("renders a non-physical TENANTS board from the same component", () => {
+    const profile = deriveTwinProfile(byCategory("software-platform"));
+    expect(profile.template).toBe("TENANTS");
+    expect(profile.physical).toBe(false);
+    const html = renderToStaticMarkup(
+      <TwinView profile={profile} snapshot={buildDemoTwinSnapshot(profile)} />,
+    );
+    expect(html).toContain("Account health board");
+    expect(html).toContain("Renewals at risk");
+    // still shows the needs-you + activity surfaces
+    expect(html).toContain("Needs you");
+    expect(html).toContain("Activity");
+  });
+});

--- a/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
+++ b/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
@@ -57,8 +57,31 @@ operator inputs). The fixture is intentionally **not** linked from the admin nav
 it is a developer preview, reachable directly and gated by the admin `view_admin`
 guard.
 
-## P3 — first templates live
-FLOOR, TERRITORY, YARD as template compositions bound via `TwinProfile`, replacing the three hand-built prototypes with framework-rendered equivalents wired to `LivingBusinessSnapshot` + `agent-event-bus` (parent spec P1–P2). Registers as a workspace-home contribution per archetype.
+## P3 — the profile-driven renderer · DONE (first increment)
+`TwinView` (`apps/web/components/twin/TwinView.tsx`) renders **any** archetype's
+twin by composing the P2 kit from a `TwinProfile` (merged P1) + a `TwinSnapshot` —
+one component for every template, physical or board. The profile supplies the
+template, vocabulary (`resourceNoun`/`workItemNoun`), zone/queue labels, and cog
+signals; the snapshot supplies the live values. `TwinSnapshot` (`snapshot.ts`) is
+the render contract the future `LivingBusinessSnapshot` projection (P4) fills; until
+then `buildDemoTwinSnapshot` (`demo-snapshot.ts`) fills it deterministically. The
+`/admin/twin-kit` fixture now renders six archetypes through the *same* `TwinView`
+— restaurant FLOOR, trades TERRITORY, rental YARD, SaaS TENANTS, prof-svcs PIPELINE,
+nonprofit PROGRAMS — via an archetype switcher, proving one renderer serves both
+lenses.
+
+Tests (`twin-view.test.tsx`): demo-snapshot **totality** over all seeded archetypes
+(every profile → a renderable snapshot whose zones bind to real profile keys and
+whose presence includes an AI coworker), determinism, and `TwinView` rendering a
+physical FLOOR and a non-physical TENANTS board from the one component with the
+correct profile vocabulary. Verification: typecheck clean; `vitest components/twin/`
+12/12 green; route manifest current.
+
+**Next P3 increment (not in this PR):** bind the snapshot to real substrate —
+`LivingBusinessSnapshot` over `deriveOperationalValueStream`, `agent_registry`/`Agent`
++ `agent-event-bus`, the finance spine — and register `TwinView` as a workspace-home
+contribution per archetype (workspace-home registry). The demo snapshot is explicitly
+a placeholder that the projection replaces wholesale behind the same shape.
 
 ## P4 — remaining templates by install demand
 BOOK, BAYS, ROOMS, STORE, VENUE, COUNTER + the TENANTS/PIPELINE/PROGRAMS boards, each a template + bindings (not a bespoke build). Certification: a golden-journey per template exercising queue → cog → confirm. PHI-class ROOMS (healthcare) gets the presence/feed redaction mode (role, not patient identity) keyed off `privacyClass` (open question §9.2).


### PR DESCRIPTION
## Summary

Delivers the **first P3 increment** of the Operational Twin Framework: **one renderer** that turns any archetype's `TwinProfile` (merged P1, #2875) into a live operational twin by composing the P2 grammar kit (merged, #2982). This is the piece that replaces the four hand-built HTML prototypes with framework rendering — a physical restaurant floor and a non-physical SaaS board come out of the *same* component, differing only by profile.

## Changes

- **`TwinView.tsx`** (client) — composes the kit from `{ profile, snapshot }`. The **profile** supplies the template, vocabulary (`resourceNoun`/`workItemNoun`), zone/queue labels, and cog signals; the **snapshot** supplies the live values. Physical templates render *space* (a grid of zones); board templates render a *portfolio* — same primitives, different emphasis, keyed off `profile.physical`. Hosts the HITL cog.
- **`snapshot.ts`** — `TwinSnapshot`, the render contract the future `LivingBusinessSnapshot` projection (parent spec P4) fills behind the same shape.
- **`demo-snapshot.ts`** — `buildDemoTwinSnapshot(profile)`: deterministic fixture data (no `Math.random`/`Date`) so the twin is demonstrable before the live projection exists. Explicitly a placeholder, not a data source.
- **`/admin/twin-kit`** now renders **six** archetypes through the same `TwinView` via an archetype switcher — restaurant FLOOR, trades TERRITORY, rental YARD, SaaS TENANTS, prof-svcs PIPELINE, nonprofit PROGRAMS — proving one renderer serves both lenses. Still an unlinked developer preview behind the admin `view_admin` guard.
- **`twin-view.test.tsx`** — demo-snapshot **totality** over all seeded archetypes (every profile → a renderable snapshot bound to real zone keys, with an AI coworker in presence), determinism, and `TwinView` rendering a physical FLOOR and non-physical TENANTS board from the one component with correct profile vocabulary.
- **Plan** updated: P3 → DONE (first increment), with the next increment named.

## Test plan

- [x] **Runtime-bound change** (new renderer + rewired `/admin/twin-kit`)
  - [x] `pnpm --filter web typecheck` — clean
  - [x] `pnpm --filter web exec vitest run components/twin/` — 12/12 green (kit + view)
  - [x] `pnpm --filter web check:route-manifest` — up to date (route pre-existed from P2)
  - [ ] Visual confirmation of `/admin/twin-kit` archetype switcher against the canonical runtime — CI (worktree is not a full runtime)

- [x] **Verification-harness limitation acknowledged** — worktree is source-control isolation, not a full runtime (AGENTS.md §5); the renderer + snapshot are covered by `twin-view.test.tsx` in CI Unit Tests. (Note: a stale generated Prisma client surfaced an unrelated `workItemPresence` typecheck error in the worktree; `prisma generate` resolved it — not a product defect.)

### Verification evidence

```
$ pnpm --filter web exec vitest run components/twin/
 Test Files  2 passed (2)
      Tests  12 passed (12)

$ pnpm --filter web typecheck
✓ Types generated successfully   (tsc --noEmit clean)
```

## Related issues / Epic

- **EP-LIVING-BUSINESS-VIZ** P3 (first increment). Builds on P1 `deriveTwinProfile` (#2875) and P2 grammar kit (#2982), both merged. Design: [operational-twin-framework](docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md) §3.

## Overlap sweep

Extends the `apps/web/components/twin/` kit and its existing fixture route; no new route, no in-flight overlap. Reuses `deriveTwinProfile` + the P2 kit rather than a parallel renderer.

## Notes for the reviewer

- **Design-Grounding-Decision:** source of truth is the operational-twin design spec §3 grammar + `packages/storefront-templates/src/twin-profile.ts` (`TwinProfile`); this extends the documented P3 plan item, adding a new render contract (`TwinSnapshot`) with no change to the derivation.
- **Process-Spine-Decision:** plan updated in this PR (P3 → DONE, next increment named).
- **UX-Fit-Decision:** composed from the P2 kit + report-kit (no bespoke metric/status components); progressive disclosure — capacity chips + one bottleneck queue + a single needs-you surface per twin, not a chart wall; zero raw/numeric operator inputs; reduced-motion-safe. The fixture is an unlinked developer preview; live workspace-home placement will carry its own UX-fit decision.
- **Still demo data** — the next P3 increment binds `TwinSnapshot` to real substrate (`LivingBusinessSnapshot` over `deriveOperationalValueStream`, `agent_registry`/`Agent` + `agent-event-bus`, the finance spine) and registers `TwinView` as a workspace-home contribution. Open `/admin/twin-kit` and switch archetypes to see the template + vocabulary change and tap the cog's Confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ko4H8pkFGNvgnbz5j3wVF8)_