### PR TITLE
fix(self-upgrade): promote.sh reclaims leaked tagged verification images (BI-9B7FC928)

### DIFF
--- a/apps/web/lib/self-upgrade/promote-script-functional.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-functional.test.ts
@@ -154,6 +154,12 @@ describe.skipIf(!BASH_OK || !GIT_OK)("promote.sh — real-script functional run"
       expect(dockerCalls).not.toContain("image prune -a");
       // Volumes are operator state — cleanup must never touch them.
       expect(dockerCalls).not.toContain("volume");
+      // BI-9B7FC928: also reclaims the TAGGED ephemeral verify/compare/build-test
+      // images that dangling-prune misses (the ~3.7 GB/upgrade leak). It queries
+      // by exact ephemeral naming so the running dpf-portal image is never hit.
+      expect(dockerCalls).toContain("images --filter reference=dpf-*-build-test");
+      expect(dockerCalls).toContain("images --filter reference=dpf-*-build-compare");
+      expect(dockerCalls).toContain("images --filter reference=dpf-*:verify");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -483,6 +483,19 @@ emit_step cleanup
 if [[ $_dry_run -eq 0 ]]; then
   docker image prune -f >/dev/null 2>&1 || true
   docker builder prune -f --keep-storage "${PROMOTE_BUILD_CACHE_KEEP:-10GB}" >/dev/null 2>&1 || true
+  # BI-9B7FC928: `image prune` above only removes DANGLING images. The TAGGED
+  # throwaway images left by Build Studio's content-verify / main-compare /
+  # local-integration flows (dpf-*-build-test:*, dpf-*-build-compare:*,
+  # dpf-*:verify) survive it and leaked ~3.7 GB per successful upgrade until the
+  # disk filled. Reclaim them by exact ephemeral naming: the running
+  # dpf-portal / dpf-promoter images NEVER carry a -build-test / -build-compare
+  # suffix or a :verify tag, so removing these cannot touch the already-deployed
+  # portal (and this runs only after every verify passed). Best-effort — never
+  # fails the upgrade. Volumes are still never touched.
+  for _ref in 'dpf-*-build-test' 'dpf-*-build-compare' 'dpf-*:verify'; do
+    _imgs="$(docker images --filter "reference=${_ref}" -q 2>/dev/null | sort -u)"
+    [[ -n "${_imgs}" ]] && docker rmi -f ${_imgs} >/dev/null 2>&1 || true
+  done
 fi
 
 # Terminal success marker — emitted only after every verify AND the cleanup sweep, so


### PR DESCRIPTION
## Summary
Each successful self-upgrade leaked ~3.7 GB: Build Studio's content-verify / main-compare / local-integration flows tag throwaway images (`dpf-*-build-test:*`, `dpf-*-build-compare:*`, `dpf-*:verify`), and promote.sh's Step-8 cleanup only ran `docker image prune -f` (**dangling only**) + a bounded builder-cache prune — so the tagged transients survived and piled up until the disk filled and broke the next upgrade's `docker compose build`.

## Fix
Step 8 now also removes those tagged ephemerals by exact naming.

**Safety:** runs only after every verify passed **and the portal is already up**; the naming patterns are used *only* by throwaway test images — the running `dpf-portal` / `dpf-promoter` images never carry a `-build-test`/`-build-compare` suffix or a `:verify` tag — so an `rmi` here **cannot** affect the deployed portal. Best-effort (`|| true`), no `image prune -a`, **volumes still never touched**. Portable (no `xargs -r`): query per pattern, `rmi` only when non-empty.

## Tests
The real-script functional run (`promote-script-functional.test.ts`) asserts the cleanup step queries each ephemeral reference pattern. Verified locally that the loop emits exactly those `docker images --filter reference=…` calls and safely no-ops on empty.

Resolves BI-9B7FC928.

🤖 Generated with [Claude Code](https://claude.com/claude-code)