### PR TITLE
fix(local-ci): provision the pregate Postgres on pgvector, not alpine (BI-032B49EB)

### DIFF
--- a/scripts/local-ci-runner.sh
+++ b/scripts/local-ci-runner.sh
@@ -136,10 +136,21 @@ resolve_database_url() {
     return
   fi
   if command -v docker >/dev/null 2>&1; then
+    # BET-5 (BI-032B49EB): the provisioned Postgres MUST ship pgvector — migrations run
+    # `CREATE EXTENSION vector`, which plain postgres:16-alpine lacks (every branch pregate
+    # then fails at that migration). A pre-BET-5 sandbox container is on the alpine image, so
+    # recreate it onto pgvector. Image-based check (no readiness race); the sandbox DB is
+    # ephemeral (no volume) so recreating loses nothing — migrations re-run each pregate.
+    if docker inspect dpf-local-ci-postgres >/dev/null 2>&1; then
+      case "$(docker inspect dpf-local-ci-postgres --format '{{.Config.Image}}' 2>/dev/null || true)" in
+        *pgvector*) : ;;
+        *) docker rm -f dpf-local-ci-postgres >/dev/null 2>&1 || true ;;
+      esac
+    fi
     if ! docker inspect dpf-local-ci-postgres >/dev/null 2>&1; then
       docker run -d --name dpf-local-ci-postgres -p 54329:5432 \
         -e POSTGRES_USER=dpf -e POSTGRES_PASSWORD=dpf_dev -e POSTGRES_DB=dpf \
-        postgres:16-alpine >/dev/null 2>&1 || return 0
+        pgvector/pgvector:pg16 >/dev/null 2>&1 || return 0
     else
       docker start dpf-local-ci-postgres >/dev/null 2>&1 || true
     fi


### PR DESCRIPTION
## What

The local-CI runner's self-provisioned sandbox Postgres (`scripts/local-ci-runner.sh`) used `postgres:16-alpine`, which does not ship pgvector. Since BET-5, every branch's pregate applies a migration that runs `CREATE EXTENSION vector` — so pregate failed at that migration on any box relying on the self-provisioned container (no `:5433` dev plane, no explicit `DATABASE_URL`).

## Fix

- Provision the sandbox container on **`pgvector/pgvector:pg16`**.
- **Recreate** a pre-existing sandbox container that is *not* on a pgvector image (image-based check — no readiness race). The sandbox DB is ephemeral (no volume mount), so recreating loses nothing; migrations re-run each pregate anyway.

The `:5433` dev data plane and all compose files already ship pgvector; this closes the last gap (the runner's `docker run` fallback).

Scripts-only; `bash -n` clean.

BI: BI-032B49EB

🤖 Generated with [Claude Code](https://claude.com/claude-code)