### PR TITLE
feat(onboarding): HVAC contractor archetype detection keywords (BI-85A1E175)

### DIFF
--- a/apps/web/lib/__tests__/public-web-tools.test.ts
+++ b/apps/web/lib/__tests__/public-web-tools.test.ts
@@ -9,4 +9,19 @@ describe("detectArchetype", () => {
   it("detects electrician from electrical keywords", () => {
     expect(detectArchetype("Licensed electrician for wiring and circuit installation")?.id).toBe("electrician");
   });
+
+  // BI-85A1E175: Trades/HVAC archetype.
+  it("detects HVAC contractor from heating/cooling keywords", () => {
+    const m = detectArchetype(
+      "HVAC contractor — air conditioning, furnace and heat pump installation, plus ventilation and climate control",
+    );
+    expect(m?.id).toBe("hvac-contractor");
+    expect(m?.confidence).toBeDefined();
+  });
+
+  it("does not misroute AC-specific text to plumber", () => {
+    // "air conditioning" / "heat pump" belong to HVAC, not plumbing — the plumber
+    // block owns boiler/water-heater, so these must not collide.
+    expect(detectArchetype("air conditioning and heat pump servicing")?.id).not.toBe("plumber");
+  });
 });

--- a/apps/web/lib/public-web-tools.ts
+++ b/apps/web/lib/public-web-tools.ts
@@ -543,6 +543,10 @@ const ARCHETYPE_CATALOG: Array<{ id: string; name: string; keywords: string[]; c
   { id: "nonprofit", name: "Non-Profit / Charity", keywords: ["charity", "nonprofit", "non-profit", "donation", "fundraising", "volunteer", "community interest"] },
   { id: "plumber", name: "Plumber", keywords: ["plumber", "plumbing", "pipe", "drain", "leak repair", "water heater", "boiler", "toilet", "bathroom fitting"], category: "trades-maintenance" },
   { id: "electrician", name: "Electrician", keywords: ["electrician", "electrical", "wiring", "fuse box", "circuit", "ev charging", "rewire", "lighting installation"], category: "trades-maintenance" },
+  // BI-85A1E175: HVAC contractor. Keywords are HVAC-specific and deliberately
+  // avoid "boiler"/"water heater" (owned by plumber above) so scoring stays
+  // distinct. Slug matches the mobile trades-maintenance/hvac-contractor archetype.
+  { id: "hvac-contractor", name: "HVAC Contractor", keywords: ["hvac", "heating and cooling", "air conditioning", "aircon", "furnace", "heat pump", "ac repair", "ac installation", "ventilation", "climate control"], category: "trades-maintenance" },
 ];
 
 type ArchetypeMatch = { id: string; name: string; score: number };


### PR DESCRIPTION
## Summary
The onboarding website-scrape archetype classifier (`detectArchetype` / `ARCHETYPE_CATALOG` in `public-web-tools.ts`) had `plumber` and `electrician` under `trades-maintenance` but **no HVAC entry** — so heating/cooling businesses went undetected. Adds an `hvac-contractor` archetype (slug aligned to the mobile `trades-maintenance/hvac-contractor`) with HVAC-specific keywords (air conditioning, furnace, heat pump, ventilation, climate control, …), deliberately avoiding `boiler`/`water heater` (owned by `plumber`) so keyword scoring stays distinct.

## Tests
HVAC copy resolves to `hvac-contractor` with a confidence; AC/heat-pump text does not misroute to `plumber`.

## Verification
`detectArchetype` is a pure keyword-scoring function; the added keywords are HVAC-specific with no collisions on the test strings. Source-only — CI runs `public-web-tools.test.ts`.

Resolves BI-85A1E175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)