### PR TITLE
feat(twin): LivingBusinessSnapshot — live data projection for the operational twin (EP-LIVING-BUSINESS-VIZ P3 · 2a)

### DIFF
--- a/apps/web/app/(shell)/admin/twin-kit/page.tsx
+++ b/apps/web/app/(shell)/admin/twin-kit/page.tsx
@@ -8,10 +8,14 @@ import {
 
 import { buildDemoTwinSnapshot } from "@/components/twin";
 import { TwinKitShowcase, type TwinExample } from "@/components/twin/TwinKitShowcase";
+import { loadLivingBusinessSnapshot } from "@/lib/twin/living-business-snapshot";
 
 export const metadata: Metadata = {
   title: "Operational Twin Kit — preview",
 };
+
+// The projection queries the live org — render at request time, never prerender.
+export const dynamic = "force-dynamic";
 
 // Fixture/reference surface for the Operational Twin renderer (P3). Not linked
 // from the admin nav — it is a developer preview reachable directly at
@@ -37,8 +41,8 @@ function firstInCategory(category: string): ArchetypeDefinition | undefined {
   return ALL_ARCHETYPES.find((a) => a.category === category);
 }
 
-export default function AdminTwinKitPage() {
-  const examples: TwinExample[] = SHOWCASE_CATEGORIES.flatMap(({ category, kind }) => {
+export default async function AdminTwinKitPage() {
+  const demoExamples: TwinExample[] = SHOWCASE_CATEGORIES.flatMap(({ category, kind }) => {
     const archetype = firstInCategory(category);
     if (!archetype) return [];
     const profile = deriveTwinProfile(archetype);
@@ -53,6 +57,25 @@ export default function AdminTwinKitPage() {
       },
     ];
   });
+
+  // The live twin for THIS deployment's org, projected from real substrate
+  // (workforce roster, finance spine, bookings). Null when no org is configured —
+  // then only the demo archetypes show. When present it leads as the default tab.
+  const live = await loadLivingBusinessSnapshot();
+  const liveDef = live ? ALL_ARCHETYPES.find((a) => a.archetypeId === live.archetypeId) : undefined;
+  const liveExample: TwinExample | null =
+    live && liveDef
+      ? {
+          id: `live:${live.archetypeId}`,
+          label: `${live.archetypeName}`,
+          kind: "live · this business",
+          template: live.template,
+          profile: deriveTwinProfile(liveDef),
+          snapshot: live,
+        }
+      : null;
+
+  const examples: TwinExample[] = liveExample ? [liveExample, ...demoExamples] : demoExamples;
 
   return (
     <div>

--- a/apps/web/lib/twin/living-business-snapshot.test.ts
+++ b/apps/web/lib/twin/living-business-snapshot.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bookingsToQueueItems,
+  bookingsToWorkItems,
+  buildQuests,
+  financeToUtility,
+  liveCapacityChips,
+  loadLivingBusinessSnapshot,
+  resourceUnits,
+  rosterToPresence,
+  statusIntent,
+  type LivingBusinessClient,
+} from "./living-business-snapshot";
+import type { WorkforceMember } from "@/lib/workforce/workforce-roster";
+
+const NOW = new Date("2026-07-15T09:00:00Z");
+const member = (over: Partial<WorkforceMember>): WorkforceMember => ({
+  kind: "human",
+  id: "E-1",
+  displayName: "Alex",
+  status: "active",
+  role: "Manager",
+  group: null,
+  agentNeeds: null,
+  ...over,
+});
+
+describe("living-business-snapshot — pure helpers", () => {
+  it("rosterToPresence puts AI coworkers first and marks kind", () => {
+    const out = rosterToPresence([
+      member({ id: "E-1", displayName: "Alex", kind: "human" }),
+      member({ id: "AGT-1", displayName: "Aria", kind: "agent", role: "operate" }),
+    ]);
+    expect(out[0]).toMatchObject({ name: "Aria", kind: "ai", focus: "operate" });
+    expect(out[1]).toMatchObject({ name: "Alex", kind: "human" });
+  });
+
+  it("rosterToPresence drops archived/inactive members", () => {
+    const out = rosterToPresence([member({ status: "archived" }), member({ id: "E-2", displayName: "Bo" })]);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe("Bo");
+  });
+
+  it("resourceUnits prefers providers, else the workforce", () => {
+    const providers = [{ id: "P-1", name: "Bay A", isActive: true }];
+    const fromProviders = resourceUnits(providers, [member({})]);
+    expect(fromProviders[0]).toMatchObject({ label: "Bay A", state: "Available", intent: "success" });
+
+    const fromRoster = resourceUnits([], [member({ displayName: "Aria", kind: "agent", status: "active" })]);
+    expect(fromRoster[0]).toMatchObject({ label: "Aria", owner: { name: "Aria", kind: "ai" } });
+  });
+
+  it("financeToUtility reflects real finance state and escalates tax intent", () => {
+    const meters = financeToUtility({
+      billsDueCount: 2,
+      billsDueAmount: 1240,
+      currency: "GBP",
+      nextTaxDueDays: 5,
+      complianceOpenCount: 0,
+      coworkerGaps: 1,
+    });
+    const bills = meters.find((m) => m.key === "bills")!;
+    const tax = meters.find((m) => m.key === "tax")!;
+    expect(bills.value).toContain("£1,240");
+    expect(bills.intent).toBe("warning");
+    expect(tax.value).toBe("5 days");
+    expect(tax.intent).toBe("danger"); // <= 7 days
+    expect(meters.find((m) => m.key === "compliance")!.value).toBe("All clear");
+  });
+
+  it("financeToUtility shows calm states when nothing is due", () => {
+    const meters = financeToUtility({
+      billsDueCount: 0,
+      billsDueAmount: 0,
+      currency: null,
+      nextTaxDueDays: null,
+      complianceOpenCount: 0,
+      coworkerGaps: 0,
+    });
+    expect(meters.find((m) => m.key === "bills")!.value).toBe("None due");
+    expect(meters.find((m) => m.key === "tax")!.value).toBe("Up to date");
+  });
+
+  it("buildQuests only raises real attention signals", () => {
+    expect(buildQuests({ billsDueCount: 0, nextTaxDueDays: null, unassignedCount: 0 })).toHaveLength(0);
+    const q = buildQuests({ billsDueCount: 1, nextTaxDueDays: 3, unassignedCount: 2 });
+    expect(q.map((x) => x.key).sort()).toEqual(["bills", "tax", "unassigned"]);
+    expect(q.find((x) => x.key === "tax")!.intent).toBe("danger");
+  });
+
+  it("bookings map to queue (pending/unassigned) and work items (in flight)", () => {
+    const bookings = [
+      { id: "b1", scheduledAt: new Date("2026-07-18T09:00:00Z"), status: "pending", provider: null },
+      { id: "b2", scheduledAt: new Date("2026-07-16T09:00:00Z"), status: "confirmed", provider: { name: "Dr Lee" } },
+    ];
+    const queue = bookingsToQueueItems(bookings, NOW);
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({ key: "b1", label: "Unassigned" });
+
+    const work = bookingsToWorkItems(bookings, "appointment");
+    expect(work).toHaveLength(1);
+    expect(work[0]).toMatchObject({ owner: { name: "Dr Lee", kind: "human" } });
+    expect(work[0].label).toContain("Appointment");
+  });
+
+  it("liveCapacityChips are all real counts", () => {
+    const chips = liveCapacityChips({ teamTotal: 5, aiCount: 2, openDemand: 3, billsDueCount: 0 });
+    expect(chips.find((c) => c.key === "ai")!.value).toBe(2);
+    expect(chips.find((c) => c.key === "bills")!.intent).toBe("success");
+  });
+
+  it("statusIntent classifies common states", () => {
+    expect(statusIntent("active")).toBe("success");
+    expect(statusIntent("pending")).toBe("info");
+    expect(statusIntent("overdue")).toBe("danger");
+    expect(statusIntent("review")).toBe("warning");
+  });
+});
+
+describe("loadLivingBusinessSnapshot — loader", () => {
+  const emptyRoster = { employeeProfile: { findMany: async () => [] }, agent: { findMany: async () => [] } };
+
+  it("returns null when no org is configured", async () => {
+    const db = {
+      ...emptyRoster,
+      storefrontConfig: { findFirst: async () => null },
+      bill: { findMany: async () => [] },
+      taxObligationPeriod: { findMany: async () => [] },
+      obligation: { findMany: async () => [] },
+      storefrontBooking: { findMany: async () => [] },
+      serviceProvider: { findMany: async () => [] },
+    } as unknown as LivingBusinessClient;
+    expect(await loadLivingBusinessSnapshot({ db, now: NOW })).toBeNull();
+  });
+
+  it("projects a live snapshot for a configured food-hospitality org", async () => {
+    const db = {
+      employeeProfile: {
+        findMany: async () => [
+          {
+            id: "E-1",
+            displayName: "Sam",
+            status: "active",
+            position: { title: "Server" },
+            department: { name: "Floor" },
+          },
+        ],
+      },
+      agent: {
+        findMany: async () => [
+          {
+            agentId: "AGT-HOST",
+            name: "AI host",
+            status: "active",
+            valueStream: "operate",
+            humanSupervisorId: null,
+            portfolioId: null,
+            hitlTierDefault: "tier2",
+            lifecycleStage: "active",
+            executionConfig: null,
+            _count: { toolGrants: 0, skills: 0 },
+            coworkerNeeds: [],
+          },
+        ],
+      },
+      storefrontConfig: {
+        findFirst: async () => ({ archetype: { archetypeId: "restaurant", name: "Dine-in restaurant" } }),
+      },
+      bill: { findMany: async () => [{ amountDue: 500, dueDate: NOW, status: "open", currency: "GBP" }] },
+      taxObligationPeriod: { findMany: async () => [{ dueDate: new Date("2026-07-20T00:00:00Z"), status: "open", filedAt: null }] },
+      obligation: { findMany: async () => [] },
+      storefrontBooking: {
+        findMany: async () => [{ id: "bk1", scheduledAt: new Date("2026-07-15T18:00:00Z"), status: "pending", provider: null }],
+      },
+      serviceProvider: { findMany: async () => [] },
+    } as unknown as LivingBusinessClient;
+
+    const snap = await loadLivingBusinessSnapshot({ db, now: NOW });
+    expect(snap).not.toBeNull();
+    expect(snap!.live).toBe(true);
+    // presence carries both the human and the AI coworker
+    expect(snap!.presence.some((p) => p.kind === "ai")).toBe(true);
+    expect(snap!.presence.some((p) => p.kind === "human")).toBe(true);
+    // finance is real
+    expect(snap!.utility.find((m) => m.key === "bills")!.value).toContain("£500");
+    // a pending booking becomes queue demand + a cog proposal
+    expect(snap!.queues[0].items.length).toBeGreaterThan(0);
+    expect(snap!.cog).toBeTruthy();
+    // capacity chips are real counts
+    expect(snap!.capacityChips.find((c) => c.key === "ai")!.value).toBe(1);
+  });
+});

--- a/apps/web/lib/twin/living-business-snapshot.ts
+++ b/apps/web/lib/twin/living-business-snapshot.ts
@@ -1,0 +1,433 @@
+// apps/web/lib/twin/living-business-snapshot.ts
+//
+// The live projection for the operational twin (EP-LIVING-BUSINESS-VIZ P3,
+// increment 2 — data). Reads a running org's real substrate and produces a
+// `TwinSnapshot` — the exact shape `demo-snapshot.ts` invents — so `TwinView`
+// renders live where the data exists and the demo fills in only where a live
+// source genuinely does not (yet).
+//
+// Honesty policy (parent spec §4, "staff = work owned"): every field here is
+// backed by a real query or clearly derived from one. Where no substrate exists
+// yet — a persisted human+AI event log, per-stage flow metrics, a live cog
+// optimizer — the field is left empty (with its calm-state label) or omitted
+// rather than faked. Those become the next increments, behind this same shape.
+//
+// DPF is single-org-per-deployment: "the org" is the one `StorefrontConfig` row.
+
+import {
+  ALL_ARCHETYPES,
+  deriveTwinProfile,
+  type ArchetypeDefinition,
+  type TwinProfile,
+  type TwinTemplate,
+} from "@dpf/storefront-templates";
+
+import type { Intent } from "@/components/ui/report-kit";
+import {
+  loadWorkforceRoster,
+  type WorkforceMember,
+  type WorkforceRosterClient,
+} from "@/lib/workforce/workforce-roster";
+import type {
+  CapacityChipData,
+  FeedEventData,
+  QuestData,
+  QueueItemData,
+  ResourceUnitData,
+  TwinActor,
+  TwinQueueSnapshot,
+  TwinSnapshot,
+  TwinZoneSnapshot,
+  UtilityMeterData,
+  WorkItemData,
+} from "@/components/twin";
+
+// ── Structural client (satisfied by the real PrismaClient and by test fakes) ──
+type FindMany = (args: unknown) => Promise<unknown>;
+export type LivingBusinessClient = WorkforceRosterClient & {
+  storefrontConfig: { findFirst: (args: unknown) => Promise<unknown> };
+  bill: { findMany: FindMany };
+  taxObligationPeriod: { findMany: FindMany };
+  obligation: { findMany: FindMany };
+  storefrontBooking: { findMany: FindMany };
+  serviceProvider: { findMany: FindMany };
+};
+
+// ── Row shapes we select (kept narrow; amounts may arrive as Prisma.Decimal) ──
+type Money = number | string | { toString(): string } | null;
+interface BillRow {
+  amountDue: Money;
+  dueDate: Date | null;
+  status: string;
+  currency: string | null;
+}
+interface TaxPeriodRow {
+  dueDate: Date | null;
+  status: string;
+  filedAt: Date | null;
+}
+interface ObligationRow {
+  status: string;
+  reviewDate: Date | null;
+}
+interface BookingRow {
+  id: string;
+  scheduledAt: Date | null;
+  status: string;
+  provider: { name: string } | null;
+}
+interface ProviderRow {
+  id: string;
+  name: string;
+  isActive: boolean;
+}
+
+export interface LiveTwinSnapshot extends TwinSnapshot {
+  live: true;
+  archetypeId: string;
+  archetypeName: string;
+  template: TwinTemplate;
+}
+
+// ── small pure utilities ──
+function toNum(v: Money): number {
+  if (v == null) return 0;
+  if (typeof v === "number") return v;
+  const n = Number(typeof v === "string" ? v : v.toString());
+  return Number.isFinite(n) ? n : 0;
+}
+function titleCase(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+function daysBetween(from: Date, to: Date): number {
+  return Math.ceil((to.getTime() - from.getTime()) / 86_400_000);
+}
+const CURRENCY_SYMBOL: Record<string, string> = { GBP: "£", USD: "$", EUR: "€" };
+function currencySymbol(code: string | null): string {
+  return (code && CURRENCY_SYMBOL[code]) ?? "";
+}
+
+// ─────────────────────────── pure mapping helpers ───────────────────────────
+
+/** State → intent for a resource unit / booking. */
+export function statusIntent(status: string): Intent {
+  const s = status.toLowerCase();
+  if (["active", "confirmed", "completed", "paid", "healthy"].some((k) => s.includes(k))) return "success";
+  if (["pending", "scheduled", "in_progress", "inprogress", "onboarding"].some((k) => s.includes(k))) return "info";
+  if (["overdue", "failed", "at_risk", "at-risk", "blocked", "cancelled"].some((k) => s.includes(k))) return "danger";
+  if (["hold", "review", "draft", "stale", "watch"].some((k) => s.includes(k))) return "warning";
+  return "neutral";
+}
+
+/** Humans + AI coworkers on one plane — the roster IS the presence row. */
+export function rosterToPresence(members: WorkforceMember[], limit = 8): TwinActor[] {
+  return members
+    .filter((m) => m.status.toLowerCase() !== "archived" && m.status.toLowerCase() !== "inactive")
+    // AI coworkers first (they're the differentiator), then humans.
+    .sort((a, b) => Number(b.kind === "agent") - Number(a.kind === "agent"))
+    .slice(0, limit)
+    .map((m) => ({
+      name: m.displayName,
+      kind: m.kind === "agent" ? "ai" : "human",
+      focus: m.role ?? undefined,
+    }));
+}
+
+/**
+ * The countable resource units. Prefer real service providers (the archetype's
+ * service capacity); otherwise the workforce itself is the resource
+ * ("staff = work owned"). Never invents units.
+ */
+export function resourceUnits(
+  providers: ProviderRow[],
+  members: WorkforceMember[],
+  limit = 8,
+): ResourceUnitData[] {
+  if (providers.length > 0) {
+    return providers.slice(0, limit).map((p) => ({
+      key: p.id,
+      label: p.name,
+      state: p.isActive ? "Available" : "Off",
+      intent: p.isActive ? "success" : "neutral",
+    }));
+  }
+  return members
+    .filter((m) => m.status.toLowerCase() !== "archived")
+    .slice(0, limit)
+    .map((m) => ({
+      key: m.id,
+      label: m.displayName,
+      state: titleCase(m.status),
+      intent: statusIntent(m.status),
+      owner: m.kind === "agent" ? { name: m.displayName, kind: "ai" } : undefined,
+    }));
+}
+
+/** Pending, unstarted demand → queue items (the primary queue's live contents). */
+export function bookingsToQueueItems(bookings: BookingRow[], now: Date, limit = 6): QueueItemData[] {
+  return bookings
+    .filter((b) => b.status.toLowerCase() === "pending" || b.provider == null)
+    .slice(0, limit)
+    .map((b) => ({
+      key: b.id,
+      label: b.provider?.name ? `With ${b.provider.name}` : "Unassigned",
+      meta: b.scheduledAt ? undefined : "awaiting schedule",
+      waiting: b.scheduledAt ? `${Math.max(0, daysBetween(now, b.scheduledAt))}d` : undefined,
+    }));
+}
+
+/** In-flight demand → work items, attributed to the assigned provider (human). */
+export function bookingsToWorkItems(bookings: BookingRow[], workNoun: string, limit = 5): WorkItemData[] {
+  return bookings
+    .filter((b) => ["confirmed", "scheduled", "in_progress", "inprogress"].includes(b.status.toLowerCase()))
+    .slice(0, limit)
+    .map((b) => ({
+      key: b.id,
+      label: `${titleCase(workNoun)}${b.provider?.name ? ` · ${b.provider.name}` : ""}`,
+      owner: b.provider?.name ? { name: b.provider.name, kind: "human" } : undefined,
+      sublabel: b.scheduledAt ? b.scheduledAt.toISOString().slice(0, 10) : undefined,
+    }));
+}
+
+/** The supporting-activity meters — all backed by the finance spine. */
+export function financeToUtility(input: {
+  billsDueCount: number;
+  billsDueAmount: number;
+  currency: string | null;
+  nextTaxDueDays: number | null;
+  complianceOpenCount: number;
+  coworkerGaps: number;
+}): UtilityMeterData[] {
+  const sym = currencySymbol(input.currency);
+  const taxIntent: Intent =
+    input.nextTaxDueDays == null
+      ? "success"
+      : input.nextTaxDueDays <= 7
+        ? "danger"
+        : input.nextTaxDueDays <= 14
+          ? "warning"
+          : "info";
+  return [
+    {
+      key: "bills",
+      label: "Bills due",
+      value:
+        input.billsDueCount > 0
+          ? `${input.billsDueCount} · ${sym}${Math.round(input.billsDueAmount).toLocaleString("en-GB")}`
+          : "None due",
+      intent: input.billsDueCount > 0 ? "warning" : "success",
+      hint: "Next 7 days",
+    },
+    {
+      key: "tax",
+      label: "Tax filing",
+      value: input.nextTaxDueDays == null ? "Up to date" : `${input.nextTaxDueDays} days`,
+      intent: taxIntent,
+    },
+    {
+      key: "compliance",
+      label: "Compliance",
+      value: input.complianceOpenCount > 0 ? `${input.complianceOpenCount} to review` : "All clear",
+      intent: input.complianceOpenCount > 0 ? "warning" : "success",
+    },
+    {
+      key: "improve",
+      label: "Coworker gaps",
+      value: input.coworkerGaps > 0 ? `${input.coworkerGaps} to close` : "None",
+      intent: input.coworkerGaps > 0 ? "accent" : "success",
+    },
+  ];
+}
+
+/** What genuinely needs a human — every quest is a real attention signal. */
+export function buildQuests(input: {
+  billsDueCount: number;
+  nextTaxDueDays: number | null;
+  unassignedCount: number;
+}): QuestData[] {
+  const quests: QuestData[] = [];
+  if (input.nextTaxDueDays != null && input.nextTaxDueDays <= 14) {
+    quests.push({
+      key: "tax",
+      title: `Tax filing due in ${input.nextTaxDueDays} days`,
+      detail: "Review and submit the next return",
+      intent: input.nextTaxDueDays <= 7 ? "danger" : "warning",
+      cta: "Review",
+    });
+  }
+  if (input.unassignedCount > 0) {
+    quests.push({
+      key: "unassigned",
+      title: `${input.unassignedCount} unassigned`,
+      detail: "Demand waiting to be routed to a resource",
+      intent: "warning",
+      cta: "Assign",
+    });
+  }
+  if (input.billsDueCount > 0) {
+    quests.push({
+      key: "bills",
+      title: `${input.billsDueCount} bill${input.billsDueCount === 1 ? "" : "s"} due this week`,
+      detail: "Approve or schedule payment",
+      intent: "warning",
+      cta: "Pay",
+    });
+  }
+  return quests;
+}
+
+/** Live, archetype-agnostic capacity counters — each is a true number. */
+export function liveCapacityChips(input: {
+  teamTotal: number;
+  aiCount: number;
+  openDemand: number;
+  billsDueCount: number;
+}): CapacityChipData[] {
+  return [
+    { key: "team", label: "Workforce", value: input.teamTotal, intent: "info", live: true },
+    { key: "ai", label: "AI coworkers", value: input.aiCount, intent: "accent" },
+    { key: "demand", label: "Open demand", value: input.openDemand, intent: input.openDemand > 0 ? "warning" : "success", live: true },
+    { key: "bills", label: "Bills due", value: input.billsDueCount, intent: input.billsDueCount > 0 ? "warning" : "success" },
+  ];
+}
+
+/** A bounded attributed feed from the demand rows we already read. The persisted
+ *  human+AI event log (parent spec §4 live-delta plane) is a later increment; for
+ *  now the feed reflects real booking activity, attributed to its provider. */
+export function bookingsToFeed(bookings: BookingRow[], workNoun: string, limit = 4): FeedEventData[] {
+  return bookings.slice(0, limit).map((b, i) => ({
+    key: `bk-${b.id}-${i}`,
+    actor: b.provider?.name ? { name: b.provider.name, kind: "human" } : { name: "Front desk", kind: "human" },
+    action: `${b.status.toLowerCase() === "pending" ? "took a new" : "is handling a"} ${workNoun}`,
+    at: b.scheduledAt ? b.scheduledAt.toISOString().slice(5, 10) : undefined,
+  }));
+}
+
+// ─────────────────────────────── the loader ────────────────────────────────
+
+function resolveTemplateDef(archetypeId: string): ArchetypeDefinition | undefined {
+  return ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId);
+}
+
+/**
+ * Load the live twin snapshot for the deployment's single org. Returns `null`
+ * when no org is configured (or its archetype has no template definition) — the
+ * caller falls back to `buildDemoTwinSnapshot`. Mirrors the `platform-loader`
+ * idiom: injected client, `Promise.all` fan-out, fail-soft reads.
+ */
+export async function loadLivingBusinessSnapshot(opts?: {
+  db?: LivingBusinessClient;
+  now?: Date;
+}): Promise<LiveTwinSnapshot | null> {
+  const db = opts?.db ?? ((await import("@dpf/db")).prisma as unknown as LivingBusinessClient);
+  const now = opts?.now ?? new Date();
+  const in7 = new Date(now.getTime() + 7 * 86_400_000);
+
+  const config = (await db.storefrontConfig.findFirst({
+    select: { archetype: { select: { archetypeId: true, name: true } } },
+  })) as { archetype: { archetypeId: string; name: string } | null } | null;
+
+  const archetypeId = config?.archetype?.archetypeId;
+  if (!archetypeId) return null;
+  const def = resolveTemplateDef(archetypeId);
+  if (!def) return null;
+
+  const profile: TwinProfile = deriveTwinProfile(def);
+
+  const [roster, bills, taxPeriods, obligations, bookings, providers] = await Promise.all([
+    loadWorkforceRoster({ db }).catch(() => ({ members: [], summary: { total: 0, humans: 0, agents: 0, agentsWithUnmetNeeds: 0 } })),
+    db.bill
+      .findMany({
+        where: { status: { notIn: ["paid", "void"] }, dueDate: { gte: now, lte: in7 } },
+        select: { amountDue: true, dueDate: true, status: true, currency: true },
+      })
+      .catch(() => []) as Promise<BillRow[]>,
+    db.taxObligationPeriod
+      .findMany({
+        where: { filedAt: null },
+        orderBy: { dueDate: "asc" },
+        take: 1,
+        select: { dueDate: true, status: true, filedAt: true },
+      })
+      .catch(() => []) as Promise<TaxPeriodRow[]>,
+    db.obligation
+      .findMany({ where: { status: "active" }, select: { status: true, reviewDate: true } })
+      .catch(() => []) as Promise<ObligationRow[]>,
+    db.storefrontBooking
+      .findMany({
+        where: { status: { notIn: ["completed", "cancelled"] } },
+        orderBy: { scheduledAt: "asc" },
+        take: 24,
+        select: { id: true, scheduledAt: true, status: true, provider: { select: { name: true } } },
+      })
+      .catch(() => []) as Promise<BookingRow[]>,
+    db.serviceProvider
+      .findMany({ where: { isActive: true }, take: 12, select: { id: true, name: true, isActive: true } })
+      .catch(() => []) as Promise<ProviderRow[]>,
+  ]);
+
+  const members = roster.members;
+  const billsDueAmount = bills.reduce((sum, b) => sum + toNum(b.amountDue), 0);
+  const currency = bills.find((b) => b.currency)?.currency ?? null;
+  const nextTaxDueDays =
+    taxPeriods[0]?.dueDate != null ? Math.max(0, daysBetween(now, taxPeriods[0].dueDate)) : null;
+  const complianceOpenCount = obligations.filter(
+    (o) => o.reviewDate != null && o.reviewDate.getTime() <= in7.getTime(),
+  ).length;
+  const unassigned = bookings.filter((b) => b.provider == null || b.status.toLowerCase() === "pending");
+
+  const zones: TwinZoneSnapshot[] = [
+    {
+      key: profile.zones[0]?.key ?? "board",
+      units: resourceUnits(providers, members),
+    },
+  ];
+
+  const queueItems = bookingsToQueueItems(bookings, now);
+  const queues: TwinQueueSnapshot[] = profile.queues.map((qs, i) => ({
+    key: qs.key,
+    items: i === 0 ? queueItems : [],
+    emptyLabel: i === 0 ? "No demand waiting" : "Clear",
+  }));
+
+  const cog =
+    queueItems.length > 0
+      ? {
+          proposal: `Route the next ${profile.workItemNoun.singular} to the best ${profile.resourceNoun.singular} by ${profile.cog.signals[0]}`,
+          confirmLabel: `Assign ${profile.workItemNoun.singular}`,
+          signals: profile.cog.signals.slice(0, 3),
+        }
+      : undefined;
+
+  return {
+    live: true,
+    archetypeId,
+    archetypeName: config?.archetype?.name ?? def.name,
+    template: profile.template,
+    capacityChips: liveCapacityChips({
+      teamTotal: roster.summary.total,
+      aiCount: roster.summary.agents,
+      openDemand: bookings.length,
+      billsDueCount: bills.length,
+    }),
+    zones,
+    workItems: bookingsToWorkItems(bookings, profile.workItemNoun.singular),
+    queues,
+    cog,
+    presence: rosterToPresence(members),
+    feed: bookingsToFeed(bookings, profile.workItemNoun.singular),
+    quests: buildQuests({
+      billsDueCount: bills.length,
+      nextTaxDueDays,
+      unassignedCount: unassigned.length,
+    }),
+    utility: financeToUtility({
+      billsDueCount: bills.length,
+      billsDueAmount,
+      currency,
+      nextTaxDueDays,
+      complianceOpenCount,
+      coworkerGaps: roster.summary.agentsWithUnmetNeeds,
+    }),
+  };
+}

--- a/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
+++ b/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
@@ -77,11 +77,39 @@ physical FLOOR and a non-physical TENANTS board from the one component with the
 correct profile vocabulary. Verification: typecheck clean; `vitest components/twin/`
 12/12 green; route manifest current.
 
-**Next P3 increment (not in this PR):** bind the snapshot to real substrate —
-`LivingBusinessSnapshot` over `deriveOperationalValueStream`, `agent_registry`/`Agent`
-+ `agent-event-bus`, the finance spine — and register `TwinView` as a workspace-home
-contribution per archetype (workspace-home registry). The demo snapshot is explicitly
-a placeholder that the projection replaces wholesale behind the same shape.
+### P3 increment 2a — the live data projection · DONE
+`loadLivingBusinessSnapshot` (`apps/web/lib/twin/living-business-snapshot.ts`)
+projects the deployment's single org into a real `TwinSnapshot` — the same shape
+`buildDemoTwinSnapshot` invents — so `TwinView` renders live where the substrate
+exists. Sources, honest by policy (every field backed by a query or clearly derived;
+nothing faked):
+- **presence** ← the workforce roster (`loadWorkforceRoster`) — humans + AI coworkers
+  on one plane, AI first, `kind` from the roster discriminator.
+- **utility** ← the finance spine — bills due ≤7d (count + amount), next unfiled
+  `TaxObligationPeriod`, open `Obligation` reviews, coworker capability gaps.
+- **capacityChips** ← real counts (workforce, AI coworkers, open demand, bills due).
+- **zones / units** ← active `ServiceProvider`s, else the workforce ("staff = work
+  owned").
+- **queues / workItems** ← `StorefrontBooking` (pending → primary queue; in-flight →
+  work items attributed to the provider).
+- **quests** ← real attention only (tax due ≤14d, unassigned demand, bills due).
+- **cog** ← a proposal shell raised only when there is real pending demand.
+
+Returns `null` when no org is configured → the caller falls back to the demo.
+`/admin/twin-kit` now leads with a **live · this business** tab (the real projection)
+ahead of the demo archetypes. Pure mapping helpers are unit-tested
+(`living-business-snapshot.test.ts`, 11 assertions incl. a fake-client loader run);
+what has no substrate yet is left empty with its calm-state label, not faked.
+
+**Still to come:** a persisted human+AI event log for a richer live feed, per-stage
+flow metrics (queue depth / WIP / wait) over `deriveOperationalValueStream`, and a
+live cog optimizer — each lands behind this same `TwinSnapshot` shape.
+
+### P3 increment 2b — workspace-home placement · IN A SIBLING PR
+Register `TwinView` as a per-archetype workspace-home contribution and render it on
+the real `/workspace` home (relative to `OperatorCockpit`; the placement is the open
+question in the parent viz design spec §9). Built in parallel on its own branch,
+rendering via this projection behind the shared `TwinSnapshot` seam.
 
 ## P4 — remaining templates by install demand
 BOOK, BAYS, ROOMS, STORE, VENUE, COUNTER + the TENANTS/PIPELINE/PROGRAMS boards, each a template + bindings (not a bespoke build). Certification: a golden-journey per template exercising queue → cog → confirm. PHI-class ROOMS (healthcare) gets the presence/feed redaction mode (role, not patient identity) keyed off `privacyClass` (open question §9.2).


### PR DESCRIPTION
## Summary

Binds the operational twin to a running org's **real substrate**. `loadLivingBusinessSnapshot` projects the deployment's single org into a `TwinSnapshot` — the exact shape `buildDemoTwinSnapshot` invents — so `TwinView` (merged P3, #2987) renders **live** where the data exists and the demo fills in only where a live source genuinely does not yet. This is P3 increment **2a** (the data projection); increment **2b** (workspace-home placement) is being built in parallel on its own branch and consumes this behind the same `TwinSnapshot` seam.

## Honesty policy

Every field is backed by a real query or clearly derived from one. Where no substrate exists yet (a persisted human+AI event log, per-stage flow metrics, a live cog optimizer), the field is left empty with its calm-state label or omitted — **never faked**.

| Snapshot field | Live source |
|---|---|
| **presence** | workforce roster (`loadWorkforceRoster`) — humans + AI coworkers on one plane, AI first, `kind` from the roster discriminator |
| **utility** | finance spine — bills due ≤7d (count + amount), next unfiled `TaxObligationPeriod`, open `Obligation` reviews, coworker capability gaps |
| **capacityChips** | real counts — workforce / AI coworkers / open demand / bills due |
| **zones · units** | active `ServiceProvider`s, else the workforce ("staff = work owned") |
| **queues · workItems** | `StorefrontBooking` — pending → primary queue; in-flight → work items attributed to the provider |
| **quests** | real attention only — tax due ≤14d, unassigned demand, bills due |
| **cog** | a proposal shell raised only when there is real pending demand |

Returns `null` when no org is configured → the caller falls back to the demo. The loader mirrors the `platform-loader` idiom (injected structural client, `Promise.all` fan-out, fail-soft reads).

## Changes

- **`apps/web/lib/twin/living-business-snapshot.ts`** (new) — `loadLivingBusinessSnapshot({ db?, now? })` + exported **pure** mapping helpers (`rosterToPresence`, `resourceUnits`, `financeToUtility`, `buildQuests`, `bookingsToQueueItems`, `bookingsToWorkItems`, `liveCapacityChips`, `statusIntent`).
- **`apps/web/app/(shell)/admin/twin-kit/page.tsx`** — now `async` + `force-dynamic`; leads with a **live · this business** tab (the real projection) ahead of the demo archetypes.
- **`living-business-snapshot.test.ts`** — 11 assertions incl. a fake-client loader run projecting a configured restaurant org (real presence with a human + AI coworker, finance, queue demand, cog).
- **Plan** updated: P3 increment 2a → DONE; 2b noted as a sibling PR.

## Test plan

- [x] **Runtime-bound change** (new server projection + rewired `/admin/twin-kit`)
  - [x] `pnpm --filter web typecheck` — clean
  - [x] `pnpm --filter web exec vitest run components/twin/ lib/twin/` — 23/23 green
  - [x] `pnpm --filter web check:route-manifest` — up to date (548)
  - [ ] Visual confirmation of the live panel against the canonical runtime with a seeded org — CI (worktree has no seeded DB)

- [x] **Verification-harness limitation acknowledged** — worktree is source-control isolation, not a full runtime (AGENTS.md §5); the projection is covered by pure-helper + fake-client tests in CI Unit Tests.

### Verification evidence

```
$ pnpm --filter web exec vitest run components/twin/ lib/twin/
 Test Files  3 passed (3)
      Tests  23 passed (23)

$ pnpm --filter web typecheck
✓ Types generated successfully   (tsc --noEmit clean)
```

## Related issues / Epic

- **EP-LIVING-BUSINESS-VIZ** P3 increment 2a. Builds on P1 `deriveTwinProfile` (#2875), P2 kit (#2982), P3 `TwinView` (#2987) — all merged. Contract: parent viz design spec §4 `LivingBusinessSnapshot`.

## Overlap sweep

New module in `apps/web/lib/twin/` + the twin-kit fixture page; disjoint from the parallel **2b** work (which stays in `apps/web/lib/workspace-home/**` + `apps/web/components/workspace-home/**` and does not touch `apps/web/lib/twin/**` or the twin components). No shared-file overlap.

## Notes for the reviewer

- **Design-Grounding-Decision:** source of truth is the parent viz design spec §4 (`LivingBusinessSnapshot` contract) + operational-twin spec §7 P3; extends the documented P3 plan increment. New projection module, no change to the `TwinSnapshot` render contract or the derivation.
- **Process-Spine-Decision:** plan updated in this PR.
- **UX-Fit-Decision:** no new UI primitives — reuses merged `TwinView` + report-kit; the live panel is one more tab on the existing unlinked developer preview (admin `view_admin` guard), zero raw/numeric operator inputs. Live workspace-home placement carries its own UX-fit decision in the sibling PR.
- **Still demo-adjacent by design:** the projection is real, but the twin only becomes the *main workspace view* once increment 2b places it on `/workspace`. Open `/admin/twin-kit` with a seeded org to see the live tab; with no org it falls back to the demo archetypes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ko4H8pkFGNvgnbz5j3wVF8)_