### PR TITLE
fix(seed): tolerate P2002 on concurrent region seed + coworker establish (BI-PIR-3c6ed25d, BI-PIR-f5f32d54)

### DIFF
--- a/apps/web/lib/coworker-lifecycle/establish-coworker.test.ts
+++ b/apps/web/lib/coworker-lifecycle/establish-coworker.test.ts
@@ -77,6 +77,30 @@ describe("establishCoworker (EP-COWORKER-LIFECYCLE Phase 3 factory door)", () =>
     if (!result.ok) expect(result.code).toBe("already_exists");
   });
 
+  it("collapses a P2002 slugId race onto already_exists (TOCTOU loser)", async () => {
+    // findFirst sees nothing (both concurrent callers passed the guard), then
+    // create trips Agent_slugId_key. The loser must resolve to already_exists,
+    // not a raw unique-constraint crash.
+    asMock(prisma.agent.findFirst).mockResolvedValue(null);
+    asMock(prisma.agent.create).mockRejectedValue(
+      Object.assign(new Error("Unique constraint failed"), {
+        code: "P2002",
+        meta: { target: ["slugId"] },
+      }),
+    );
+    const result = await establishCoworker(VALID_INPUT, "usr-1");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("already_exists");
+  });
+
+  it("re-throws non-P2002 create failures so genuine bugs surface", async () => {
+    asMock(prisma.agent.findFirst).mockResolvedValue(null);
+    asMock(prisma.agent.create).mockRejectedValue(
+      Object.assign(new Error("connection lost"), { code: "P1001" }),
+    );
+    await expect(establishCoworker(VALID_INPUT, "usr-1")).rejects.toThrow(/connection lost/);
+  });
+
   it("rejects malformed agentIds and missing fields", async () => {
     expect((await establishCoworker({ ...VALID_INPUT, agentId: "Bad_ID!" }, "u")).ok).toBe(false);
     expect((await establishCoworker({ ...VALID_INPUT, name: " " }, "u")).ok).toBe(false);

--- a/apps/web/lib/coworker-lifecycle/establish-coworker.ts
+++ b/apps/web/lib/coworker-lifecycle/establish-coworker.ts
@@ -100,22 +100,40 @@ export async function establishCoworker(
     };
   }
 
-  const agent = await prisma.agent.create({
-    data: {
-      agentId,
-      slugId: agentId,
-      name: input.name.trim(),
-      displayName: input.name.trim(),
-      kind: "specialist",
-      tier: 2,
-      type: "coworker",
-      description: input.description.trim(),
-      valueStream: input.valueStream ?? null,
-      sensitivity: input.sensitivity ?? "internal",
-      status: "active",
-      lifecycleStage: "draft",
-    },
-  });
+  let agent: { id: string };
+  try {
+    agent = await prisma.agent.create({
+      data: {
+        agentId,
+        slugId: agentId,
+        name: input.name.trim(),
+        displayName: input.name.trim(),
+        kind: "specialist",
+        tier: 2,
+        type: "coworker",
+        description: input.description.trim(),
+        valueStream: input.valueStream ?? null,
+        sensitivity: input.sensitivity ?? "internal",
+        status: "active",
+        lifecycleStage: "draft",
+      },
+    });
+  } catch (err: unknown) {
+    // The findFirst guard above is a TOCTOU check: two concurrent
+    // establishCoworker calls for the same id both pass it, then both create,
+    // and the loser trips the Agent_agentId / Agent_slugId_key unique index
+    // (Prisma P2002). Collapse that race onto the same already_exists result
+    // the guard returns, rather than surfacing a raw constraint crash.
+    const code = (err as { code?: string } | null)?.code;
+    if (code === "P2002") {
+      return {
+        ok: false,
+        code: "already_exists",
+        message: `${agentId} already exists (lost a concurrent creation race).`,
+      };
+    }
+    throw err;
+  }
 
   // Tombstone-honoring grant writes (BI-4FA040D5 pattern from bootstrap-first-run).
   const revoked = await prisma.agentToolGrantRevocation.findMany({

--- a/packages/db/src/seed-geographic-data.test.ts
+++ b/packages/db/src/seed-geographic-data.test.ts
@@ -10,7 +10,7 @@
 // and must NOT swallow non-P2002 errors.
 
 import { describe, it, expect } from "vitest";
-import { seedCityOnce } from "./seed-geographic-data";
+import { seedCityOnce, seedRegionOnce } from "./seed-geographic-data";
 import type { PrismaClient } from "../generated/client/client";
 
 type CityFindFirst = (args: {
@@ -126,6 +126,113 @@ describe("seedCityOnce", () => {
 
     await expect(seedCityOnce(prisma, "region-1", cityRecord("Toronto"))).rejects.toThrow(
       /unrelated failure/,
+    );
+  });
+});
+
+type RegionFindFirst = (args: {
+  where: {
+    countryId: string;
+    name: string | { equals: string; mode: "insensitive" };
+  };
+  select: { id: true };
+}) => Promise<{ id: string } | null>;
+
+type RegionCreate = (args: {
+  data: { name: string; code: string | null; countryId: string };
+}) => Promise<{ id: string }>;
+
+function buildRegionStub(opts: {
+  findFirst: RegionFindFirst;
+  create: RegionCreate;
+}): PrismaClient {
+  return {
+    region: { findFirst: opts.findFirst, create: opts.create },
+  } as unknown as PrismaClient;
+}
+
+const regionRecord = (name: string) => ({ name, code: "CA", countryCode: "US" });
+
+describe("seedRegionOnce", () => {
+  it("creates the region and returns its id when findFirst misses and create succeeds", async () => {
+    let captured: Parameters<RegionCreate>[0] | null = null;
+    const prisma = buildRegionStub({
+      findFirst: async () => null,
+      create: async (args) => {
+        captured = args;
+        return { id: "region-new" };
+      },
+    });
+
+    const result = await seedRegionOnce(prisma, "country-1", regionRecord("California"));
+
+    expect(result).toEqual({ outcome: "created", id: "region-new" });
+    expect(captured!.data).toMatchObject({ name: "California", code: "CA", countryId: "country-1" });
+  });
+
+  it("reports 'existing' with the found id and does not call create", async () => {
+    let createCalls = 0;
+    const prisma = buildRegionStub({
+      findFirst: async () => ({ id: "region-existing" }),
+      create: async () => {
+        createCalls++;
+        return { id: "region-x" };
+      },
+    });
+
+    const result = await seedRegionOnce(prisma, "country-1", regionRecord("Ontario"));
+
+    expect(result).toEqual({ outcome: "existing", id: "region-existing" });
+    expect(createCalls).toBe(0);
+  });
+
+  it("swallows P2002 as 'skipped_duplicate' and re-resolves the winning row's id", async () => {
+    // findFirst is case-sensitive (misses "québec"); the case-insensitive
+    // unique index rejects the create; the P2002 branch re-queries insensitively.
+    let findCalls = 0;
+    const prisma = buildRegionStub({
+      findFirst: async (args) => {
+        findCalls++;
+        // First (case-sensitive) lookup misses; second (insensitive) hits.
+        return typeof args.where.name === "object" ? { id: "region-dup" } : null;
+      },
+      create: async () => {
+        throw Object.assign(new Error("Unique constraint failed"), {
+          code: "P2002",
+          meta: { target: ["countryId", "name"] },
+        });
+      },
+    });
+
+    const result = await seedRegionOnce(prisma, "country-1", regionRecord("Québec"));
+
+    expect(result).toEqual({ outcome: "skipped_duplicate", id: "region-dup" });
+    expect(findCalls).toBe(2);
+  });
+
+  it("returns a null id (not a crash) if the duplicate row cannot be re-resolved", async () => {
+    const prisma = buildRegionStub({
+      findFirst: async () => null,
+      create: async () => {
+        throw Object.assign(new Error("Unique constraint failed"), { code: "P2002" });
+      },
+    });
+
+    const result = await seedRegionOnce(prisma, "country-1", regionRecord("Ghost"));
+
+    expect(result).toEqual({ outcome: "skipped_duplicate", id: null });
+  });
+
+  it("re-throws non-P2002 errors so genuine failures surface", async () => {
+    const prisma = buildRegionStub({
+      findFirst: async () => null,
+      create: async () => {
+        throw Object.assign(new Error("connection lost"), { code: "P1001" });
+      },
+    });
+
+    await expect(seedRegionOnce(prisma, "country-1", regionRecord("Boston"))).rejects.toThrow(
+      /connection lost/,
     );
   });
 });

--- a/packages/db/src/seed-geographic-data.ts
+++ b/packages/db/src/seed-geographic-data.ts
@@ -4,7 +4,9 @@
 // Reads from static JSON data files in packages/db/data/.
 //
 // Idempotent: safe to run multiple times. Uses upsert for countries (unique iso2),
-// and findFirst + create for regions/cities (no unique constraint on composite keys).
+// and findFirst + P2002-tolerant create for regions/cities — both carry a
+// case-insensitive unique index that a case-sensitive findFirst can disagree
+// with (see seedRegionOnce / seedCityOnce).
 
 import { readFileSync } from "fs";
 import { join } from "path";
@@ -85,6 +87,63 @@ async function seedCountries(prisma: PrismaClient): Promise<Map<string, string>>
   return iso2ToDbId;
 }
 
+/**
+ * Outcome of attempting to seed a single region, plus the row's db id (so the
+ * caller can build the region-key map even when our findFirst missed the row).
+ */
+export type SeedRegionOutcome = "created" | "existing" | "skipped_duplicate";
+
+/**
+ * Idempotently seed one region, tolerating both findFirst-doesn't-see-it
+ * (cold path, normal create) and P2002 (the row exists but our lookup index
+ * disagreed with the unique constraint).
+ *
+ * The Region model carries a case-insensitive unique index
+ *   Region_countryId_name_ci ON (LOWER("name"), "countryId")
+ * while the findFirst below matches "name" case-sensitively. Source data with
+ * near-duplicate casing/accents — or a concurrent cold-install seeder racing on
+ * the same row — passes the case-sensitive lookup but collides on the index, so
+ * the bare create throws P2002 and (previously) aborted the whole seed run.
+ * This mirrors seedCityOnce, which hardened the identical failure for cities
+ * (BI-E4E21A7F). On a swallowed duplicate we re-resolve the row case-
+ * insensitively so the region-key map still gets a usable id.
+ */
+export async function seedRegionOnce(
+  prisma: PrismaClient,
+  countryDbId: string,
+  region: RegionRecord,
+): Promise<{ outcome: SeedRegionOutcome; id: string | null }> {
+  const found = await prisma.region.findFirst({
+    where: { countryId: countryDbId, name: region.name },
+    select: { id: true },
+  });
+
+  if (found) return { outcome: "existing", id: found.id };
+
+  try {
+    const record = await prisma.region.create({
+      data: {
+        name: region.name,
+        code: region.code || null,
+        countryId: countryDbId,
+      },
+    });
+    return { outcome: "created", id: record.id };
+  } catch (err: unknown) {
+    // Prisma P2002 = unique constraint violation. Anything else re-throws.
+    const code = (err as { code?: string } | null)?.code;
+    if (code !== "P2002") throw err;
+    // The case-insensitive unique index rejected a case/accent variant our
+    // case-sensitive findFirst missed (or a concurrent seeder won the race).
+    // Re-resolve the winning row so the region key still maps to a real id.
+    const dup = await prisma.region.findFirst({
+      where: { countryId: countryDbId, name: { equals: region.name, mode: "insensitive" } },
+      select: { id: true },
+    });
+    return { outcome: "skipped_duplicate", id: dup?.id ?? null };
+  }
+}
+
 async function seedRegions(
   prisma: PrismaClient,
   countryIdMap: Map<string, string>,
@@ -96,34 +155,23 @@ async function seedRegions(
 
   let created = 0;
   let existing = 0;
+  let skippedDuplicate = 0;
 
   for (const r of regions) {
     const countryDbId = countryIdMap.get(r.countryCode);
     if (!countryDbId) continue;
 
-    const found = await prisma.region.findFirst({
-      where: { countryId: countryDbId, name: r.name },
-      select: { id: true },
-    });
-
-    if (found) {
-      regionKeyToDbId.set(`${r.countryCode}::${r.code}`, found.id);
-      existing++;
-    } else {
-      const record = await prisma.region.create({
-        data: {
-          name: r.name,
-          code: r.code || null,
-          countryId: countryDbId,
-        },
-      });
-      regionKeyToDbId.set(`${r.countryCode}::${r.code}`, record.id);
-      created++;
-    }
+    const { outcome, id } = await seedRegionOnce(prisma, countryDbId, r);
+    if (id) regionKeyToDbId.set(`${r.countryCode}::${r.code}`, id);
+    if (outcome === "created") created++;
+    else if (outcome === "existing") existing++;
+    else skippedDuplicate++;
   }
 
-  const regionCount = created + existing;
-  log(`  Regions: ${created} created, ${existing} already existed. Total: ${regionCount}`);
+  const regionCount = created + existing + skippedDuplicate;
+  log(
+    `  Regions: ${created} created, ${existing} already existed, ${skippedDuplicate} skipped (duplicate index). Total: ${regionCount}`,
+  );
   return { regionKeyToDbId, regionCount };
 }
 


### PR DESCRIPTION
## What

Two `findFirst`-then-`create` sites crash with Prisma **P2002** unique-constraint violations when a case/accent variant — or a concurrent cold-install writer — races the guard. Both are the same TOCTOU class already hardened elsewhere (`seedCityOnce`/BI-E4E21A7F, `agentToolGrant.createMany`/BI-25A1ADF7). Auto-detected as BI-PIR-3c6ed25d (Region) and BI-PIR-f5f32d54 (Agent slugId).

## Fixes

**1. Region seed — `packages/db/src/seed-geographic-data.ts`**
- Extract a testable `seedRegionOnce` mirroring the existing `seedCityOnce`.
- The `Region_countryId_name_ci` index `(LOWER(name), countryId)` can reject a row the case-sensitive `findFirst` missed. On P2002 we swallow the duplicate and **re-resolve the winning row case-insensitively** so the region-key map still gets a real id. Previously the bare `create` threw and aborted the entire seed run (the same failure mode that BI-E4E21A7F fixed for cities).

**2. Coworker factory door — `apps/web/lib/coworker-lifecycle/establish-coworker.ts`**
- The `findFirst` OR-guard is a TOCTOU check; two concurrent `establishCoworker` calls for the same id both pass it and both `create`, and the loser trips `Agent_agentId` / `Agent_slugId_key`. Collapse that race onto the same `already_exists` result the guard already returns, instead of a raw constraint crash.

Both paths **re-throw non-P2002 errors** so genuine failures still surface.

## Tests
- `seed-geographic-data.test.ts`: `seedRegionOnce` — create/existing/P2002-skip-with-id-reresolve/null-fallback/non-P2002-rethrow.
- `establish-coworker.test.ts`: P2002 slugId race → `already_exists`; non-P2002 create failure re-throws.

## Verification
Source-verifiable — pure logic hardening of two create sites, covered by unit tests. No runtime repro required. Neither file is in the module-size baseline (no ratchet impact).

## Seed-fit
This change adds **no** new seeded content — it only makes the existing global geographic reference seed (countries/regions/cities) idempotent under a case-insensitive-index / concurrent-writer race. The seeded data and its scope are unchanged: universal reference data every install needs.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)