### PR TITLE
fix(self-upgrade): quiet promoter-sweep docker-unavailable log to stop PIR noise (BI-PIR-ae7f19b6)

### DIFF
--- a/apps/web/lib/self-upgrade/promoter-sweep.test.ts
+++ b/apps/web/lib/self-upgrade/promoter-sweep.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { isPromoterContainerStale } from "./promoter-sweep";
+import { describe, it, expect, vi } from "vitest";
+import {
+  isPromoterContainerStale,
+  sweepOrphanedPromoterContainers,
+  type DockerRun,
+} from "./promoter-sweep";
 
 describe("isPromoterContainerStale (orphaned-promoter sweep gate)", () => {
   const now = new Date("2026-07-11T12:20:00Z");
@@ -18,5 +22,63 @@ describe("isPromoterContainerStale (orphaned-promoter sweep gate)", () => {
   it("refuses to declare an unparseable stamp stale (never kill what we can't age)", () => {
     expect(isPromoterContainerStale("", now, maxAge)).toBe(false);
     expect(isPromoterContainerStale("not-a-date", now, maxAge)).toBe(false);
+  });
+});
+
+describe("sweepOrphanedPromoterContainers", () => {
+  const now = () => new Date("2026-07-11T12:20:00Z");
+  const logger = () => ({ log: vi.fn(), error: vi.fn() });
+
+  it("logs docker-unavailable (ENOENT) quietly, NOT at error level (BI-PIR-ae7f19b6)", async () => {
+    const run: DockerRun = async () => {
+      throw Object.assign(new Error("spawn docker ENOENT"), { code: "ENOENT" });
+    };
+    const log = logger();
+    const result = await sweepOrphanedPromoterContainers({ run, now }, log);
+
+    expect(result).toBeNull();
+    // Quiet info log, and crucially NOT logger.error (which the PIR scanner trips on).
+    expect(log.error).not.toHaveBeenCalled();
+    expect(log.log).toHaveBeenCalledWith(
+      expect.stringContaining("docker CLI unavailable (ENOENT)"),
+    );
+  });
+
+  it("still surfaces a genuine docker failure at error level", async () => {
+    const run: DockerRun = async () => {
+      throw Object.assign(new Error("Cannot connect to the Docker daemon"), { code: "1" });
+    };
+    const log = logger();
+    const result = await sweepOrphanedPromoterContainers({ run, now }, log);
+
+    expect(result).toBeNull();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining("[promoter-sweep] failed"),
+      expect.anything(),
+    );
+  });
+
+  it("force-removes only promoters older than maxAge", async () => {
+    const calls: string[][] = [];
+    const run: DockerRun = async (_file, args) => {
+      calls.push(args);
+      if (args[0] === "ps") {
+        return {
+          stdout:
+            "dpf-promoter-stale\t2026-07-11 11:41:26 +0000 UTC\n" + // ~39 min → stale
+            "dpf-promoter-live\t2026-07-11 12:10:00 +0000 UTC\n", // ~10 min → keep
+        };
+      }
+      return { stdout: "" };
+    };
+    const log = logger();
+    const result = await sweepOrphanedPromoterContainers(
+      { run, now, maxAgeMs: 30 * 60 * 1000 },
+      log,
+    );
+
+    expect(result).toEqual({ removed: 1 });
+    const rmCalls = calls.filter((a) => a[0] === "rm");
+    expect(rmCalls).toEqual([["rm", "-f", "dpf-promoter-stale"]]);
   });
 });

--- a/apps/web/lib/self-upgrade/promoter-sweep.ts
+++ b/apps/web/lib/self-upgrade/promoter-sweep.ts
@@ -25,21 +25,32 @@ export function isPromoterContainerStale(
   return now.getTime() - started >= maxAgeMs;
 }
 
+/** Minimal shape of a promisified execFile, so tests can inject a fake docker. */
+export type DockerRun = (
+  file: string,
+  args: string[],
+  options: { timeout: number },
+) => Promise<{ stdout: string }>;
+
+async function defaultDockerRun(): Promise<DockerRun> {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  return promisify(execFile) as unknown as DockerRun;
+}
+
 /**
  * Force-remove any `dpf-promoter-*` container older than `maxAgeMs` — well past
  * both runPromoter's self-timeout and a normal ~7-min swap, so a legitimately
  * in-flight promoter is never touched. Non-fatal; never throws.
  */
 export async function sweepOrphanedPromoterContainers(
-  opts: { maxAgeMs?: number; now?: () => Date } = {},
+  opts: { maxAgeMs?: number; now?: () => Date; run?: DockerRun } = {},
   logger: Pick<Console, "log" | "error"> = console,
 ): Promise<{ removed: number } | null> {
   const maxAgeMs = opts.maxAgeMs ?? 30 * 60 * 1000;
   const now = opts.now?.() ?? new Date();
   try {
-    const { execFile } = await import("node:child_process");
-    const { promisify } = await import("node:util");
-    const run = promisify(execFile);
+    const run = opts.run ?? (await defaultDockerRun());
     const { stdout } = await run(
       "docker",
       ["ps", "--filter", "name=dpf-promoter-", "--format", "{{.Names}}\t{{.CreatedAt}}"],
@@ -62,7 +73,15 @@ export async function sweepOrphanedPromoterContainers(
     }
     return { removed };
   } catch (err) {
-    // `docker ps` unreachable (no daemon in this env) — nothing to sweep.
+    const code = (err as { code?: string } | null)?.code;
+    if (code === "ENOENT") {
+      // The docker CLI isn't on PATH — an entirely expected state on Docker-less
+      // runtimes. Log it quietly (info, no stack) so this benign "skip" doesn't
+      // trip the error-log PIR scanner on every sweep interval (BI-PIR-ae7f19b6).
+      logger.log("[promoter-sweep] docker CLI unavailable (ENOENT); nothing to sweep");
+      return null;
+    }
+    // A real docker/daemon failure (timeout, permission, daemon down) — surface it.
     logger.error("[promoter-sweep] failed (non-fatal):", err);
     return null;
   }


### PR DESCRIPTION
## What

The orphaned-promoter sweep (`apps/web/lib/self-upgrade/promoter-sweep.ts`) already treats docker being unreachable as **non-fatal** — but it logged the `spawn docker ENOENT` via `logger.error` on **every sweep interval** on Docker-less runtimes. That recurring error-level line is benign (the docker CLI simply isn't on PATH), yet the error-log PIR scanner keeps auto-detecting it as a defect (BI-PIR-ae7f19b6).

## Fix

- Distinguish **ENOENT** (docker CLI not installed — expected; log once at info, no stack) from a **genuine** docker/daemon failure (timeout, permission, daemon down — still `logger.error`).
- Make the docker runner **injectable** (`opts.run`) so the sweep's catch paths are unit-testable without a real daemon.

**Container-removal behavior, the `name=dpf-promoter-` filter, and the 30-min age threshold are unchanged** — this only changes the log level on the docker-missing branch. It does **not** touch the swap / promote / deploy / volume path.

## Tests
- ENOENT → quiet `logger.log`, never `logger.error`, returns null.
- Genuine docker failure → still `logger.error`, returns null.
- Age-gated removal: only the >30-min promoter is `rm -f`'d; the live one is left alone.

## Verification
Source-verifiable — pure log-level + testability change in a best-effort janitor, fully covered by the new unit tests. Not in the module-size baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)