### PR TITLE
fix(observability): mask URLs, model names, and entity ids in log-signature templates (BI-51F6A428 slice)

### DIFF
--- a/apps/web/lib/observability/log-signature.test.ts
+++ b/apps/web/lib/observability/log-signature.test.ts
@@ -73,6 +73,40 @@ describe("toTemplate", () => {
   it("masks uuids", () => {
     expect(toTemplate("session 4f9c1a2b-1111-2222-3333-444455556666 dropped")).toContain("<uuid>");
   });
+
+  it("masks URLs so requests to different endpoints collapse (BI-51F6A428)", () => {
+    const a = toTemplate("Error: POST https://api.openai.com/v1/responses failed");
+    const b = toTemplate("Error: POST https://api.anthropic.com/v1/messages failed");
+    expect(a).toBe(b);
+    expect(a).toContain("<url>");
+    expect(a).not.toContain("openai.com");
+  });
+
+  it("masks AI model names so per-model variants collapse (BI-51F6A428)", () => {
+    const a = toTemplate("inference failed for model gpt-5.4 rate limited");
+    const b = toTemplate("inference failed for model claude-opus-4-8 rate limited");
+    const c = toTemplate("inference failed for model qwen3-coder rate limited");
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(a).toContain("<model>");
+    // version suffixes must not survive as their own <n> fragments
+    expect(a).not.toMatch(/gpt|<n>/);
+  });
+
+  it("does NOT mask a bare English word that merely starts like a hyphenated model family", () => {
+    // 'claude'/'grok'/'gpt' only fold when followed by a version, so prose stays intact.
+    expect(toTemplate("the claude assistant returned an error")).toContain("claude");
+    expect(toTemplate("the claude assistant returned an error")).not.toContain("<model>");
+  });
+
+  it("masks embedded platform entity ids so per-id variants collapse (BI-51F6A428)", () => {
+    const a = toTemplate("failed to project PIR-Y8EA8 into the backlog");
+    const b = toTemplate("failed to project PIR-A1B2C into the backlog");
+    expect(a).toBe(b);
+    expect(a).toContain("<id>");
+    // BI-PIR-* compound ids fold to a single <id>, not <id>-<id>.
+    expect(toTemplate("BI-PIR-3c6ed25d unique violation")).toBe("<id> unique violation");
+  });
 });
 
 describe("signatureId / dedupeKeyFor", () => {

--- a/apps/web/lib/observability/log-signature.ts
+++ b/apps/web/lib/observability/log-signature.ts
@@ -62,6 +62,22 @@ export function isErrorLine(line: string): boolean {
 /** Collapse a log line to a stable template by masking variable tokens. */
 export function toTemplate(line: string): string {
   return line
+    // URLs first — before the path/number masks would chew their slashes and
+    // digits. Two errors that differ only by endpoint/query collapse to one.
+    .replace(/https?:\/\/\S+/gi, "<url>")
+    // Platform entity ids (PIR-…, BI-…, BI-PIR-…, FB-…, SUR-…, EP-…, WC-…,
+    // AGT-…). An error line that embeds a fresh report/build/run id would
+    // otherwise mint a distinct signature per occurrence.
+    .replace(/\b(?:BI|PIR|FB|SUR|EP|WC|AGT)-[A-Za-z0-9-]+/g, "<id>")
+    // AI model / engine names — masked before the number pass so version
+    // suffixes (gpt-5.4, claude-opus-4-8, grok-4.3) don't fragment first. The
+    // hyphen-bearing families (gpt-/o1-/o3-/claude-/grok-) require a version so
+    // bare English words aren't touched; local families (qwen/gemma/llama/
+    // mistral/deepseek/codex) appear bare as model ids and are safe to fold.
+    .replace(
+      /\b(?:gpt-[\w.]+|o[13]-[\w.]+|claude-[\w.-]+|grok-[\w.]+|qwen[\w.-]*|gemma[\w.-]*|llama[\w.-]*|mistral[\w.-]*|deepseek[\w.-]*|codex[\w.-]*)\b/gi,
+      "<model>",
+    )
     .replace(/\d{4}-\d{2}-\d{2}[T ][\d:.]+Z?/g, "<ts>") // ISO timestamps
     .replace(/\b[0-9a-fA-F]{8}-[0-9a-fA-F-]{20,}\b/g, "<uuid>") // uuids
     .replace(/\b0x[0-9a-fA-F]+\b/g, "<hex>") // hex addresses


### PR DESCRIPTION
## What

`toTemplate()` (apps/web/lib/observability/log-signature.ts) collapses near-identical error log lines to a stable signature by masking variable tokens — but it left **three high-variance token classes unmasked**, so lines differing only by endpoint, model, or embedded id minted a **distinct signature (→ distinct `BI-PIR-*`) each**. This is a direct source of the auto-detected backlog noise.

## Fix (pure-function, in `toTemplate`)

- **URLs** (`https?://…`) → `<url>` — masked first, before the path/number passes chew their slashes and digits.
- **AI model / engine names** → `<model>` — masked before the number pass so version suffixes (`gpt-5.4`, `claude-opus-4-8`, `grok-4.3`) don't fragment into `<n>`. Hyphen-bearing families (`gpt-`/`o1-`/`o3-`/`claude-`/`grok-`) require a version suffix so bare English words (e.g. "claude") are **left intact**; local families (`qwen`/`gemma`/`llama`/`mistral`/`deepseek`/`codex`) fold bare.
- **Platform entity ids** (`PIR-…`, `BI-…`, `BI-PIR-…`, `FB-…`, `SUR-…`, `EP-…`, `WC-…`, `AGT-…`) → `<id>` — so an error echoing a fresh report/build/run id collapses to one signature.

## Scope
This is the **`toTemplate` normalization slice** of BI-51F6A428. The staging/reach gate + per-window creation cap remain (they need occurrence-accrual substrate + projection-timing changes across the live intake pipeline — recorded on the item as a build note). This slice is independently valuable and carries none of that risk.

## Verification
`log-signature.ts` is explicitly pure and dependency-free ("exhaustively unit-testable without Loki, Prisma, or Inngest"). New unit tests cover each of the three masks (URLs/models/ids collapse to one template), the **no-false-positive** case (bare "claude" stays unmasked), and `BI-PIR-*` compound-id folding to a single `<id>`. Existing `toTemplate`/`clusterBySignature` tests are unaffected (traced: my masks don't touch their inputs). Not in the module-size baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)