### PR TITLE
fix(observability): filter benign Postgres controlled-restart lifecycle noise from log signatures

### DIFF
--- a/apps/web/lib/observability/log-signature.test.ts
+++ b/apps/web/lib/observability/log-signature.test.ts
@@ -58,6 +58,34 @@ describe("isErrorLine", () => {
     // A genuine error that merely mentions the adapter must still cluster.
     expect(isErrorLine("[responses-adapter] Error: upstream returned 500 for codex/responses")).toBe(true);
   });
+
+  it("rejects benign Postgres controlled-restart lifecycle noise (BI-PIR self-upgrade churn)", () => {
+    // These are normal restart choreography during a self-upgrade recycle, not
+    // application defects — they minted ~6 duplicate BI-PIR-* on 2026-07-15.
+    expect(
+      isErrorLine("2026-07-15 05:24:11.000 UTC [1] FATAL: terminating connection due to administrator command"),
+    ).toBe(false);
+    expect(isErrorLine("FATAL: the database system is starting up")).toBe(false);
+    expect(isErrorLine("FATAL: the database system is shutting down")).toBe(false);
+    // postgres-exporter sidecar losing its scrape while the DB bounces.
+    expect(
+      isErrorLine('level=error msg="Error scraping target" err="dial tcp: connect: connection refused"'),
+    ).toBe(false);
+  });
+
+  it("STILL clusters a genuine app-side DB outage (lifecycle filter must not hide real failures)", () => {
+    // The safety invariant: a real outage surfaces app-side via Prisma, and that
+    // path is NOT filtered — so filtering the Postgres-side lifecycle FATALs
+    // above never suppresses the actionable signal.
+    expect(
+      isErrorLine("[db] Error: PrismaClientInitializationError: Can't reach database server at postgres:5432"),
+    ).toBe(true);
+    expect(isErrorLine("Error: connect ECONNREFUSED 127.0.0.1:5432 (database unreachable)")).toBe(true);
+    // A genuine catalog-scout scraping error must NOT be swallowed — the DB
+    // filter is scoped to metrics-exporter phrasing ("scraping target/dsn"),
+    // not the word "scraping" alone.
+    expect(isErrorLine("[external-catalog-scout] Error scraping catalog vendor-x: timeout")).toBe(true);
+  });
 });
 
 describe("toTemplate", () => {

--- a/apps/web/lib/observability/log-signature.ts
+++ b/apps/web/lib/observability/log-signature.ts
@@ -49,6 +49,17 @@ const ERROR_TOKEN = /\b(error|fatal|panic|exception|traceback)\b/i;
 //      signatures. `response.created` is the benign OpenAI Responses API SSE
 //      start event, likewise not an error.
 const OUTBOUND_REQUEST_NOISE = /\[responses-adapter\]\s+REQUEST|Error Report PIR-|\bresponse\.created\b/i;
+// Postgres-side lifecycle FATALs emitted during a *controlled* restart (a
+// self-upgrade recycle or deploy): the database announcing it is starting up /
+// shutting down, terminating open connections on an operator SIGTERM, or the
+// postgres-exporter sidecar briefly failing to scrape while the DB bounces.
+// These are normal restart choreography, not application defects — and nothing
+// actionable is hidden by filtering them, because a *genuine* DB outage ALSO
+// surfaces app-side (Prisma DatabaseNotReachable / init errors), and those are
+// NOT filtered here, so the real signal still clusters. Empirically this exact
+// class minted ~6 duplicate BI-PIR-* during the 2026-07-15 self-upgrade window.
+const DB_LIFECYCLE_NOISE =
+  /database system is (starting up|shutting down)|terminating connection due to administrator command|error scraping (target|dsn)/i;
 
 /** True when a line is a genuine error worth clustering (not info/debug/self-noise). */
 export function isErrorLine(line: string): boolean {
@@ -56,6 +67,7 @@ export function isErrorLine(line: string): boolean {
   if (SELF_NOISE.test(line)) return false;
   if (INFO_DEBUG.test(line)) return false;
   if (OUTBOUND_REQUEST_NOISE.test(line)) return false;
+  if (DB_LIFECYCLE_NOISE.test(line)) return false;
   return ERROR_TOKEN.test(line);
 }
 


### PR DESCRIPTION
## What

`isErrorLine()` (apps/web/lib/observability/log-signature.ts) already hard-filters known-always-benign log classes (Loki/Alloy self-noise, the responses-adapter self-loop). This adds the **Postgres controlled-restart lifecycle** class:

- `database system is starting up` / `shutting down` (Postgres readiness/shutdown FATALs)
- `terminating connection due to administrator command` (open connections dropped on an operator SIGTERM)
- `error scraping target|dsn` (postgres-exporter sidecar failing to scrape while the DB bounces)

These are normal self-upgrade/deploy **recycle choreography**, not application defects. Empirically this exact class minted **~6 duplicate `BI-PIR-*`** during the 2026-07-15 self-upgrade window (all triaged-and-discarded as benign).

## Safety invariant (tested)

Nothing actionable is hidden: a **genuine** DB outage also surfaces **app-side** via Prisma (`DatabaseNotReachable` / `PrismaClientInitializationError` / `ECONNREFUSED`), and that path is **not** filtered — so the real, actionable signal still clusters. A test asserts those app-side lines still return `true`.

The exporter pattern is deliberately scoped to metrics phrasing (`scraping target/dsn`) rather than the bare word "scraping", so a legitimate **catalog-scout** error (`[external-catalog-scout] Error scraping catalog…`) is **not** swallowed — also covered by a test.

## Scope / verification
Pure function (`isErrorLine`), no schema or pipeline change. New tests cover each filtered lifecycle line, the real-outage-still-clusters invariant, and the scout over-filter guard. Companion to the `toTemplate` normalization slice (#2996) under BI-51F6A428 / EP-FULL-OBS — both cut auto-detected backlog noise at the source. Not in the module-size baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)