### PR TITLE
feat(build-studio): refuse core-platform promote without force (BI-4A30D8AC)

### DIFF
--- a/apps/web/lib/explore/architecture-altitude.test.ts
+++ b/apps/web/lib/explore/architecture-altitude.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyArchitectureAltitude,
+  isCorePlatformAltitude,
+} from "./architecture-altitude";
+
+describe("classifyArchitectureAltitude (BI-4A30D8AC)", () => {
+  it("treats ordinary product features as functional", () => {
+    const v = classifyArchitectureAltitude({
+      title: "Add invoice CSV export",
+      body: "Operator can download last month's invoices.",
+      workType: "feature",
+    });
+    expect(v.altitude).toBe("functional");
+    expect(v.reason).toBeNull();
+    expect(v.signals).toEqual([]);
+    expect(
+      isCorePlatformAltitude({
+        title: "Add invoice CSV export",
+        body: "Operator can download last month's invoices.",
+        workType: "feature",
+      }),
+    ).toBe(false);
+  });
+
+  it("elevates workType=refactor as core-platform", () => {
+    const v = classifyArchitectureAltitude({
+      title: "Tidy helpers",
+      body: "No schema changes.",
+      workType: "refactor",
+    });
+    expect(v.altitude).toBe("core-platform");
+    expect(v.signals).toContain("workType=refactor");
+    expect(v.reason).toMatch(/direct expert build/i);
+    expect(v.reason).toMatch(/force=true/i);
+  });
+
+  it("elevates schema.prisma / migration language", () => {
+    const v = classifyArchitectureAltitude({
+      title: "Add unique constraint on WikiPage",
+      body: "Update schema.prisma and ship a prisma migrate.",
+      workType: "feature",
+    });
+    expect(v.altitude).toBe("core-platform");
+    expect(v.signals.some((s) => s.includes("schema") || s.includes("migration"))).toBe(true);
+  });
+
+  it("elevates datastore / BET refactors", () => {
+    const v = classifyArchitectureAltitude({
+      title: "BET-5 · Hybridize Neo4j + Qdrant onto Postgres",
+      body: "Retire Neo4j and Qdrant; use pgvector.",
+      workType: "refactor",
+    });
+    expect(v.altitude).toBe("core-platform");
+    expect(v.signals).toEqual(expect.arrayContaining(["workType=refactor", "bet-refactor"]));
+  });
+
+  it("does not flag customer CRM work as core-platform", () => {
+    const v = classifyArchitectureAltitude({
+      title: "Add prospect Emma3D to CRM",
+      body: "Create account and contact for Ian Pruden.",
+      workType: "feature",
+    });
+    expect(v.altitude).toBe("functional");
+  });
+});

--- a/apps/web/lib/explore/architecture-altitude.ts
+++ b/apps/web/lib/explore/architecture-altitude.ts
@@ -1,0 +1,71 @@
+// Architecture-altitude classifier for Build Studio suitability (BI-4A30D8AC).
+// Kernel: docs/founder-kernel/wiki/principles/build-studio-suitability-boundary.md
+// Pure — unit-tested; used by promote_to_build_studio and triage advisors.
+
+export type ArchitectureAltitude = "functional" | "core-platform";
+
+export type ArchitectureAltitudeVerdict = {
+  altitude: ArchitectureAltitude;
+  /** Operator-facing reason when altitude is core-platform; null for functional. */
+  reason: string | null;
+  /** Matched signal labels for audit (empty when functional). */
+  signals: string[];
+};
+
+const CORE_PLATFORM_WORK_TYPES = new Set(["refactor"]);
+
+/** Title/body tokens that signal substrate / core-platform altitude. */
+const CORE_PLATFORM_PATTERNS: Array<{ id: string; re: RegExp }> = [
+  { id: "schema-prisma", re: /\bschema\.prisma\b|prisma\s+schema\b/i },
+  { id: "data-layer-migration", re: /\b(data[- ]layer|schema)\s+migration\b|\bmigrate\s+dev\b|\bprisma\s+migrate\b/i },
+  { id: "datastore", re: /\b(neo4j|qdrant|pgvector|postgres(?:ql)?\s+only|datastore\s+swap|retire\s+(?:neo4j|qdrant))\b/i },
+  { id: "cross-cutting-substrate", re: /\b(cross[- ]cutting\s+substrate|core[- ]platform|substrate\s+work|platform[- ]spine)\b/i },
+  { id: "authz-spine", re: /\b(authorization|authz)\s+spine\b|\beffectivepermission\b|\bprincipal\s+convergence\b/i },
+  { id: "mcp-tool-pack-migration", re: /\bmcp\s+tool[- ]pack\s+migration\b|\b234[- ]case\s+switch\b/i },
+  { id: "bet-refactor", re: /\bBET-\d+\b/i },
+  { id: "workunit-spine", re: /\bworkunit\s+spine\b|\bone\s+spine\s*\+\s*typed\s+role\b/i },
+];
+
+/**
+ * Classify whether a backlog item is customer-functional (Build Studio OK)
+ * or architecturally-heavy core-platform work (direct expert build).
+ *
+ * Signals are OR'd; any match elevates to core-platform. workType=refactor
+ * alone is enough (BET-style platform refactors).
+ */
+export function classifyArchitectureAltitude(input: {
+  title?: string | null;
+  body?: string | null;
+  workType?: string | null;
+}): ArchitectureAltitudeVerdict {
+  const signals: string[] = [];
+  const workType = (input.workType ?? "").trim().toLowerCase();
+  if (CORE_PLATFORM_WORK_TYPES.has(workType)) {
+    signals.push(`workType=${workType}`);
+  }
+  const text = `${input.title ?? ""}\n${input.body ?? ""}`;
+  for (const { id, re } of CORE_PLATFORM_PATTERNS) {
+    if (re.test(text)) signals.push(id);
+  }
+  if (signals.length === 0) {
+    return { altitude: "functional", reason: null, signals: [] };
+  }
+  return {
+    altitude: "core-platform",
+    reason:
+      "Architecture altitude is core-platform — Build Studio is for end-customer functional builds. " +
+      "Route this to a direct expert build (single serialized author), not promote_to_build_studio. " +
+      `Signals: ${signals.join(", ")}. ` +
+      "See docs/founder-kernel/wiki/principles/build-studio-suitability-boundary.md. " +
+      "Pass force=true only for an explicit override after human confirmation.",
+    signals,
+  };
+}
+
+export function isCorePlatformAltitude(input: {
+  title?: string | null;
+  body?: string | null;
+  workType?: string | null;
+}): boolean {
+  return classifyArchitectureAltitude(input).altitude === "core-platform";
+}

--- a/apps/web/lib/mcp/packs/build-ops-pack.test.ts
+++ b/apps/web/lib/mcp/packs/build-ops-pack.test.ts
@@ -9,6 +9,7 @@ const db = vi.hoisted(() => ({
   digitalProductUpdate: vi.fn(),
   modelProfileFindFirst: vi.fn(),
   agentActionProposalUpdateMany: vi.fn(),
+  backlogItemFindFirst: vi.fn(),
   transaction: vi.fn(),
 }));
 vi.mock("@dpf/db", () => ({
@@ -25,6 +26,7 @@ vi.mock("@dpf/db", () => ({
     },
     modelProfile: { findFirst: (...a: unknown[]) => db.modelProfileFindFirst(...a) },
     agentActionProposal: { updateMany: (...a: unknown[]) => db.agentActionProposalUpdateMany(...a) },
+    backlogItem: { findFirst: (...a: unknown[]) => db.backlogItemFindFirst(...a) },
     $transaction: (...a: unknown[]) => db.transaction(...a),
   },
 }));
@@ -230,6 +232,11 @@ describe("build-ops pack — handler behavior (delegation preserved)", () => {
 
   it("promote_to_build_studio promotes a triaged item through the transaction", async () => {
     db.platformDevConfigFindUnique.mockResolvedValue({ governedBacklogEnabled: false });
+    db.backlogItemFindFirst.mockResolvedValue({
+      title: "Add invoice CSV export",
+      body: "Customer feature",
+      workType: "feature",
+    });
     db.featureBuildCount.mockResolvedValue(0);
     db.transaction.mockImplementation(async (cb: (tx: unknown) => unknown) => cb({}));
     teeUp.promoteBacklogItemToBuildDraft.mockResolvedValue({
@@ -243,8 +250,49 @@ describe("build-ops pack — handler behavior (delegation preserved)", () => {
     expect(teeUp.promoteBacklogItemToBuildDraft).toHaveBeenCalled();
   });
 
+  it("promote_to_build_studio refuses core-platform altitude without force (BI-4A30D8AC)", async () => {
+    db.platformDevConfigFindUnique.mockResolvedValue({ governedBacklogEnabled: false });
+    db.backlogItemFindFirst.mockResolvedValue({
+      title: "BET-5 · Hybridize Neo4j + Qdrant onto Postgres",
+      body: "Retire Neo4j; use pgvector.",
+      workType: "refactor",
+    });
+    const res = await buildOpsPack.handlers.promote_to_build_studio({ itemId: "BI-BET5" }, "u1");
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("unsuitable_for_build_studio");
+    expect(String(res.message)).toMatch(/direct expert build/i);
+    expect(teeUp.promoteBacklogItemToBuildDraft).not.toHaveBeenCalled();
+  });
+
+  it("promote_to_build_studio allows core-platform when force=true", async () => {
+    db.platformDevConfigFindUnique.mockResolvedValue({ governedBacklogEnabled: false });
+    db.backlogItemFindFirst.mockResolvedValue({
+      title: "BET-5 · Hybridize Neo4j + Qdrant onto Postgres",
+      body: "Retire Neo4j; use pgvector.",
+      workType: "refactor",
+    });
+    db.featureBuildCount.mockResolvedValue(0);
+    db.transaction.mockImplementation(async (cb: (tx: unknown) => unknown) => cb({}));
+    teeUp.promoteBacklogItemToBuildDraft.mockResolvedValue({
+      kind: "ok",
+      build: { buildId: "FB-FORCE" },
+      autoApprovedDispatchEligible: false,
+    });
+    const res = await buildOpsPack.handlers.promote_to_build_studio(
+      { itemId: "BI-BET5", force: true },
+      "u1",
+    );
+    expect(res.success).toBe(true);
+    expect(res.entityId).toBe("FB-FORCE");
+  });
+
   it("promote_to_build_studio refuses when the WIP cap is reached", async () => {
     db.platformDevConfigFindUnique.mockResolvedValue({ governedBacklogEnabled: false });
+    db.backlogItemFindFirst.mockResolvedValue({
+      title: "Add invoice CSV export",
+      body: "Customer feature",
+      workType: "feature",
+    });
     db.featureBuildCount.mockResolvedValue(99);
     wipCap.wipCapReached.mockReturnValue(true);
     const res = await buildOpsPack.handlers.promote_to_build_studio({ itemId: "BI-1" }, "u1");

--- a/apps/web/lib/mcp/packs/build-ops-pack.ts
+++ b/apps/web/lib/mcp/packs/build-ops-pack.ts
@@ -34,11 +34,17 @@ import type { ToolPack, ToolPackHandler } from "../tool-pack";
 const definitions: ToolDefinition[] = [
   {
     name: "promote_to_build_studio",
-    description: "Promote a triaged backlog item (status=open, triageOutcome=build) to a FeatureBuild in Build Studio. Runs the Definition of Ready capacity check under an advisory-lock transaction. Authority-gated via the build_promote grant category.",
+    description:
+      "Promote a triaged backlog item (status=open, triageOutcome=build) to a FeatureBuild in Build Studio. Runs the Definition of Ready capacity check under an advisory-lock transaction. Refuses core-platform / architecturally-heavy items (schema, datastore, cross-cutting substrate, BET refactors) unless force=true — those route to a direct expert build. Authority-gated via the build_promote grant category.",
     inputSchema: {
       type: "object",
       properties: {
         itemId: { type: "string", description: "The item ID to promote" },
+        force: {
+          type: "boolean",
+          description:
+            "Override the Build Studio suitability boundary for a core-platform item after explicit human confirmation (default false).",
+        },
       },
       required: ["itemId"],
     },
@@ -137,11 +143,41 @@ const definitions: ToolDefinition[] = [
 
 async function promoteToBuildStudioHandler(params: Record<string, unknown>, userId: string): Promise<ToolResult> {
   const itemId = String(params["itemId"] ?? "");
+  const force = params["force"] === true;
   const governedConfig = await prisma.platformDevConfig.findUnique({
     where: { id: "singleton" },
     select: { governedBacklogEnabled: true },
   });
   const governedBacklogEnabled = governedConfig?.governedBacklogEnabled === true;
+
+  // Build Studio suitability boundary (BI-4A30D8AC): refuse core-platform /
+  // architecturally-heavy items unless force=true after human confirmation.
+  {
+    const item = await prisma.backlogItem.findFirst({
+      where: { itemId },
+      select: { title: true, body: true, workType: true },
+    });
+    if (item) {
+      const { classifyArchitectureAltitude } = await import("@/lib/explore/architecture-altitude");
+      const verdict = classifyArchitectureAltitude({
+        title: item.title,
+        body: item.body,
+        workType: item.workType,
+      });
+      if (verdict.altitude === "core-platform" && !force) {
+        return {
+          success: false,
+          error: "unsuitable_for_build_studio",
+          message: verdict.reason ?? "Unsuitable for Build Studio",
+          data: {
+            architectureAltitude: verdict.altitude,
+            signals: verdict.signals,
+            route: "direct-expert-build",
+          },
+        };
+      }
+    }
+  }
 
   // WIP cap (shared with the createFeatureBuild start path): refuse to
   // promote another build into Build Studio while too many are unfinished.


### PR DESCRIPTION
## Summary
- Add pure `classifyArchitectureAltitude` (title/body/workType signals for schema, datastore, BET, refactor, cross-cutting substrate).
- Gate `promote_to_build_studio` with `error=unsuitable_for_build_studio` unless `force=true` after human confirmation.
- Surfaces route=`direct-expert-build` and matched signals for operators.

Resolves **BI-4A30D8AC**.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/explore/architecture-altitude.test.ts lib/mcp/packs/build-ops-pack.test.ts` → 23 passed (worktree)
- [x] `node scripts/check-module-size.mjs` → OK

## Design grounding

- Existing specs/plans reviewed:
  - docs/founder-kernel/wiki/principles/build-studio-suitability-boundary.md
  - docs/superpowers/specs/2026-05-30-build-studio-right-sizing-design.md (type×size matrix remains; altitude is an additional axis)
- Current code substrate reviewed:
  - apps/web/lib/mcp/packs/build-ops-pack.ts (`promote_to_build_studio`)
  - apps/web/lib/explore/build-process-matrix.ts
- Source of truth:
  - Kernel principle: BS for functional builds; core-platform → direct expert build
- Decision:
  - Enforce at promote time with force override; pure classifier unit-tested

Process-Spine-Decision: implements existing kernel principle build-studio-suitability-boundary; no separate durable-spec required beyond principle pointer.

Design-Grounding-Decision: reviewed docs/founder-kernel/wiki/principles/build-studio-suitability-boundary.md and code substrate apps/web/lib/mcp/packs/build-ops-pack.ts; localized promote gate + pure classifier, no new UX surface.

Local-CI-Override: vitest 23/23 architecture-altitude + build-ops-pack; module-size OK; full CI re-run on push.