### PR TITLE
feat(workspace): operational twin as the /workspace home hero (EP-LIVING-BUSINESS-VIZ P3)

### DIFF
--- a/apps/web/app/(shell)/workspace/page.tsx
+++ b/apps/web/app/(shell)/workspace/page.tsx
@@ -6,10 +6,12 @@ import { prisma } from "@dpf/db";
 import { PlatformWorkspaceHome } from "@/components/workspace-home/PlatformWorkspaceHome";
 import { VerticalWorkspaceHome } from "@/components/workspace-home/VerticalWorkspaceHome";
 import { OperatorCockpit } from "@/components/workspace-home/OperatorCockpit";
+import { WorkspaceTwinHero } from "@/components/workspace-home/WorkspaceTwinHero";
 import { LocalOnlyProviderNotice } from "@/components/workspace-home/LocalOnlyProviderNotice";
 import { UnconfiguredWorkspaceHomeNotice } from "@/components/workspace-home/UnconfiguredWorkspaceHomeNotice";
 import { loadPlatformWorkspaceHomeData } from "@/lib/workspace-home/platform-loader";
 import { resolveWorkspaceHomeContribution } from "@/lib/workspace-home/registry";
+import { resolveWorkspaceTwinPresentation } from "@/lib/workspace-home/twin-panel-data";
 import { recordWorkspaceHomeResolution } from "@/lib/workspace-home/telemetry";
 import {
   isSimpleNavMode,
@@ -33,6 +35,16 @@ export default async function WorkspacePage() {
     storefrontConfig: platformHomeData.storefrontConfig,
   });
 
+  // The operational twin becomes the main workspace view (EP-LIVING-BUSINESS-VIZ
+  // P3). It derives for every archetype with a definition, independent of whether
+  // a workspace-home registry contribution is seeded; a resolution miss falls back
+  // to the existing home. Snapshot is DEMO behind the twin-panel-data seam.
+  const archetypeRef = platformHomeData.storefrontConfig?.archetype ?? null;
+  const twinPresentation = resolveWorkspaceTwinPresentation(
+    archetypeRef?.archetypeId ?? null,
+    archetypeRef?.name ?? null,
+  );
+
   const hasCloudProvider =
     (await prisma.modelProvider.count({
       where: { status: "active", NOT: { providerId: "local" } },
@@ -46,28 +58,55 @@ export default async function WorkspacePage() {
     // Swallow — counter recording must not affect the response.
   });
 
+  // The operator cockpit — the ONE consolidated "what needs you now" surface,
+  // organized OUTSIDE-IN from the customer inward, with a single attention count
+  // and honest customer-impact ranking (BI-8C3EB52C, BI-2651043B, BI-D35DE119).
+  // Supersedes the old "Needs you" band; it always states its state, so no other
+  // panel can contradict its count. On the twin hero it folds in as the HUD rail so
+  // there is still exactly ONE attention surface.
+  const cockpit = <OperatorCockpit userId={session.user.id} />;
+
   return (
     <div data-nav-mode={navMode}>
       {workspaceHomeResolution.mode === "unconfigured" && <UnconfiguredWorkspaceHomeNotice />}
       {workspaceHomeResolution.mode !== "unconfigured" && !hasCloudProvider && (
         <LocalOnlyProviderNotice />
       )}
-      {/* The operator cockpit — the ONE consolidated "what needs you now" surface,
-          organized OUTSIDE-IN from the customer inward, with a single attention count
-          and honest customer-impact ranking (BI-8C3EB52C, BI-2651043B, BI-D35DE119).
-          Supersedes the old "Needs you" band; it always states its state, so no other
-          panel can contradict its count. */}
-      <OperatorCockpit userId={session.user.id} />
-      {workspaceHomeResolution.mode === "vertical" ? (
-        <VerticalWorkspaceHome
-          contribution={workspaceHomeResolution.contribution}
-          data={platformHomeData}
+      {twinPresentation ? (
+        // Operator-confirmed placement (parent spec §9 option c): the operational
+        // twin is the main workspace view, a dedicated hero with the cockpit folded
+        // in as its HUD and the platform launcher demoted below.
+        <WorkspaceTwinHero
+          cockpit={cockpit}
+          presentation={twinPresentation}
+          contribution={
+            workspaceHomeResolution.mode === "vertical"
+              ? workspaceHomeResolution.contribution
+              : null
+          }
+          platformBody={
+            <PlatformWorkspaceHome
+              data={platformHomeData}
+              heading="All workspace areas"
+              density="simple"
+            />
+          }
         />
       ) : (
-        <PlatformWorkspaceHome
-          data={platformHomeData}
-          density={simpleHome ? "simple" : "full"}
-        />
+        <>
+          {cockpit}
+          {workspaceHomeResolution.mode === "vertical" ? (
+            <VerticalWorkspaceHome
+              contribution={workspaceHomeResolution.contribution}
+              data={platformHomeData}
+            />
+          ) : (
+            <PlatformWorkspaceHome
+              data={platformHomeData}
+              density={simpleHome ? "simple" : "full"}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/apps/web/components/workspace-home/WorkspaceTwinHero.test.tsx
+++ b/apps/web/components/workspace-home/WorkspaceTwinHero.test.tsx
@@ -1,0 +1,47 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+
+import { WorkspaceTwinHero } from "./WorkspaceTwinHero";
+import { resolveWorkspaceTwinPresentation } from "@/lib/workspace-home/twin-panel-data";
+
+const presentation = resolveWorkspaceTwinPresentation(ALL_ARCHETYPES[0].archetypeId)!;
+
+function render() {
+  return renderToStaticMarkup(
+    <WorkspaceTwinHero
+      cockpit={<div data-testid="cockpit-slot">What needs you now</div>}
+      presentation={presentation}
+      contribution={null}
+      platformBody={<div data-testid="platform-slot">All workspace areas</div>}
+    />,
+  );
+}
+
+describe("WorkspaceTwinHero", () => {
+  it("renders the twin as the hero body with the cockpit folded in as the HUD", () => {
+    const html = render();
+    // Identity: archetype name in the hero header.
+    expect(html).toContain(presentation.archetypeName);
+    expect(html).toContain("Living business");
+    // The single attention surface (cockpit) is present as the HUD.
+    expect(html).toContain("cockpit-slot");
+    // The operational twin body renders (a capacity chip label from the profile).
+    expect(html).toContain(presentation.snapshot.capacityChips[0].label);
+    // Platform launcher demoted below.
+    expect(html).toContain("platform-slot");
+  });
+
+  it("shows the honest demo badge while the live projection is pending", () => {
+    expect(render()).toContain("Demo data — live business projection pending");
+  });
+
+  it("keeps exactly one attention surface — the twin's own cog + needs-you are suppressed", () => {
+    const html = render();
+    // No HITL cog confirm banner (suppressed on the home mount).
+    expect(html).not.toContain("Assign ");
+    // The twin's needs-you renders its empty state, not a rival quest list.
+    expect(html).toContain("Nothing needs you right now");
+  });
+});

--- a/apps/web/components/workspace-home/WorkspaceTwinHero.tsx
+++ b/apps/web/components/workspace-home/WorkspaceTwinHero.tsx
@@ -1,0 +1,79 @@
+// apps/web/components/workspace-home/WorkspaceTwinHero.tsx
+//
+// The dedicated /workspace twin hero (EP-LIVING-BUSINESS-VIZ P3, increment 2).
+// The operator confirmed a dedicated hero (parent spec §9 option c) over the
+// spec's leaning (option a); the hard guardrail survives the choice: exactly ONE
+// attention surface on the home. So the hero folds the `OperatorCockpit` in as its
+// HUD rail (the single "what needs you now" surface, passed in) above the
+// operational-twin body, with the platform tiles/launcher demoted below — reachable
+// navigation, not a rival dashboard stacked beside the twin.
+//
+// Plan: docs/superpowers/plans/2026-07-15-twin-workspace-home-placement-execution.md
+
+import type { ReactNode } from "react";
+import { Activity } from "lucide-react";
+
+import { WorkspaceTwinPanel } from "./WorkspaceTwinPanel";
+import type { WorkspaceTwinPresentation } from "@/lib/workspace-home/twin-panel-data";
+import type { WorkspaceHomeContribution } from "@/lib/workspace-home/types";
+
+export interface WorkspaceTwinHeroProps {
+  /** The single "what needs you now" attention surface, folded in as the HUD. */
+  cockpit: ReactNode;
+  presentation: WorkspaceTwinPresentation;
+  /** Archetype workspace contribution (when one is registered) — supplies the
+   *  operating question for the HUD identity line. Optional; the twin renders for
+   *  every archetype whether or not a workspace-home contribution exists. */
+  contribution: WorkspaceHomeContribution | null;
+  /** Platform tiles / area launcher, demoted below the hero (navigation, not a
+   *  rival dashboard). */
+  platformBody: ReactNode;
+}
+
+export function WorkspaceTwinHero({
+  cockpit,
+  presentation,
+  contribution,
+  platformBody,
+}: WorkspaceTwinHeroProps) {
+  const operatingQuestion = contribution?.primaryOperatingQuestion ?? null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section
+        aria-labelledby="workspace-twin-hero-title"
+        className="overflow-hidden rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+      >
+        {/* HUD rail — identity + the single attention surface. */}
+        <header className="border-b border-[var(--dpf-border)] px-4 pb-3 pt-4">
+          <div className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-[var(--dpf-muted)]">
+            <Activity size={15} aria-hidden="true" />
+            Living business
+          </div>
+          <h1
+            id="workspace-twin-hero-title"
+            className="text-xl font-bold text-[var(--dpf-text)]"
+          >
+            {presentation.archetypeName}
+          </h1>
+          {operatingQuestion ? (
+            <p className="mt-1 max-w-3xl text-sm text-[var(--dpf-muted)]">
+              The worker arrives asking: {operatingQuestion}
+            </p>
+          ) : null}
+        </header>
+
+        {/* The one "what needs you now" surface, folded in as the hero HUD. */}
+        <div className="px-4 pt-4">{cockpit}</div>
+
+        {/* The operational twin — the main workspace view. */}
+        <div className="px-4 pb-4">
+          <WorkspaceTwinPanel presentation={presentation} />
+        </div>
+      </section>
+
+      {/* Demoted: platform areas / navigation, below the hero. */}
+      <section aria-label="All workspace areas">{platformBody}</section>
+    </div>
+  );
+}

--- a/apps/web/components/workspace-home/WorkspaceTwinPanel.tsx
+++ b/apps/web/components/workspace-home/WorkspaceTwinPanel.tsx
@@ -1,0 +1,36 @@
+// apps/web/components/workspace-home/WorkspaceTwinPanel.tsx
+//
+// The operational twin as it renders on the /workspace hero (EP-LIVING-BUSINESS-VIZ
+// P3, increment 2). A thin wrapper over the sibling-owned `TwinView`: it adds the
+// honest "demo data" badge and nothing else. `TwinView` is a client component; this
+// server component renders it with serializable props.
+//
+// Plan: docs/superpowers/plans/2026-07-15-twin-workspace-home-placement-execution.md
+
+import { TwinView } from "@/components/twin";
+import type { WorkspaceTwinPresentation } from "@/lib/workspace-home/twin-panel-data";
+
+export interface WorkspaceTwinPanelProps {
+  presentation: WorkspaceTwinPresentation;
+  className?: string;
+}
+
+export function WorkspaceTwinPanel({ presentation, className = "" }: WorkspaceTwinPanelProps) {
+  return (
+    <div className={`flex flex-col gap-3 ${className}`.trim()}>
+      {presentation.demo ? (
+        <p
+          className="inline-flex w-fit items-center gap-1.5 rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--dpf-muted)]"
+          data-testid="twin-demo-badge"
+        >
+          <span
+            aria-hidden="true"
+            className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--dpf-muted)]"
+          />
+          Demo data — live business projection pending
+        </p>
+      ) : null}
+      <TwinView profile={presentation.profile} snapshot={presentation.snapshot} />
+    </div>
+  );
+}

--- a/apps/web/lib/workspace-home/twin-panel-data.test.ts
+++ b/apps/web/lib/workspace-home/twin-panel-data.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+
+import { resolveWorkspaceTwinPresentation } from "./twin-panel-data";
+
+const SAMPLE = ALL_ARCHETYPES[0];
+
+describe("resolveWorkspaceTwinPresentation", () => {
+  it("resolves a profile + snapshot for a real archetype slug", () => {
+    const result = resolveWorkspaceTwinPresentation(SAMPLE.archetypeId);
+    expect(result).not.toBeNull();
+    expect(result?.archetypeId).toBe(SAMPLE.archetypeId);
+    expect(result?.archetypeName).toBe(SAMPLE.name);
+    expect(result?.profile.template).toBeTruthy();
+    expect(result?.snapshot.capacityChips.length).toBeGreaterThan(0);
+    expect(result?.demo).toBe(true);
+  });
+
+  it("condenses for the home mount — no rival attention surface (cockpit owns it)", () => {
+    // The workspace home renders OperatorCockpit as the single attention surface
+    // (BI-8C3EB52C); the twin's own cog + needs-you quests must be suppressed.
+    const result = resolveWorkspaceTwinPresentation(SAMPLE.archetypeId);
+    expect(result?.snapshot.cog).toBeUndefined();
+    expect(result?.snapshot.quests).toEqual([]);
+    // The operational body still renders.
+    expect(result?.snapshot.zones.length).toBeGreaterThan(0);
+    expect(result?.snapshot.queues.length).toBeGreaterThan(0);
+  });
+
+  it("prefers the supplied display name but falls back to the definition name", () => {
+    expect(resolveWorkspaceTwinPresentation(SAMPLE.archetypeId, "Acme Co")?.archetypeName).toBe(
+      "Acme Co",
+    );
+    expect(resolveWorkspaceTwinPresentation(SAMPLE.archetypeId, "  ")?.archetypeName).toBe(
+      SAMPLE.name,
+    );
+  });
+
+  it("returns null for an unconfigured or unknown archetype (never throws)", () => {
+    expect(resolveWorkspaceTwinPresentation(null)).toBeNull();
+    expect(resolveWorkspaceTwinPresentation(undefined)).toBeNull();
+    expect(resolveWorkspaceTwinPresentation("")).toBeNull();
+    expect(resolveWorkspaceTwinPresentation("not-a-real-archetype-slug")).toBeNull();
+  });
+
+  it("is deterministic — same slug yields the same snapshot", () => {
+    const a = resolveWorkspaceTwinPresentation(SAMPLE.archetypeId);
+    const b = resolveWorkspaceTwinPresentation(SAMPLE.archetypeId);
+    expect(a?.snapshot).toEqual(b?.snapshot);
+  });
+
+  it("derives for every archetype without throwing", () => {
+    for (const arch of ALL_ARCHETYPES) {
+      const result = resolveWorkspaceTwinPresentation(arch.archetypeId);
+      expect(result, arch.archetypeId).not.toBeNull();
+    }
+  });
+});

--- a/apps/web/lib/workspace-home/twin-panel-data.ts
+++ b/apps/web/lib/workspace-home/twin-panel-data.ts
@@ -1,0 +1,82 @@
+// apps/web/lib/workspace-home/twin-panel-data.ts
+//
+// The workspace-home twin seam (EP-LIVING-BUSINESS-VIZ P3, increment 2). Resolves
+// the org's archetype into a rendered operational twin for the /workspace hero:
+// slug -> ALL_ARCHETYPES -> deriveTwinProfile -> snapshot. Pure, total (returns
+// null rather than throwing when no definition resolves), and DB-free — the page
+// already loads StorefrontConfig.archetype and hands the slug + name in.
+//
+// Plan: docs/superpowers/plans/2026-07-15-twin-workspace-home-placement-execution.md
+// Renderer (sibling-owned, not edited here): apps/web/components/twin/TwinView.tsx
+
+import {
+  ALL_ARCHETYPES,
+  deriveTwinProfile,
+  type TwinProfile,
+} from "@dpf/storefront-templates";
+
+import { buildDemoTwinSnapshot, type TwinSnapshot } from "@/components/twin";
+
+export interface WorkspaceTwinPresentation {
+  archetypeId: string;
+  archetypeName: string;
+  profile: TwinProfile;
+  snapshot: TwinSnapshot;
+  /**
+   * True while the snapshot is deterministic demo fixture data — the live
+   * `LivingBusinessSnapshot` projection (parent spec P4) has not been wired.
+   * Drives the "Demo data" badge so a zeros-free demo board is never mistaken
+   * for live state.
+   */
+  demo: boolean;
+}
+
+// ─── THE DEMO → REAL SEAM ─────────────────────────────────────────────────────
+// The single place a workspace-home twin snapshot is produced. Today it returns
+// deterministic demo fixture data. When the sibling `LivingBusinessSnapshot`
+// projection lands it fills the SAME `TwinSnapshot` shape, so swapping this one
+// function body (and flipping `demo` to false) is the entire change — nothing
+// else on this surface moves.
+function produceWorkspaceTwinSnapshot(profile: TwinProfile): {
+  snapshot: TwinSnapshot;
+  demo: boolean;
+} {
+  return { snapshot: buildDemoTwinSnapshot(profile), demo: true };
+}
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The workspace home is NOT the twin's own attention surface: `OperatorCockpit`
+ * is the single "what needs you now" surface here (BI-8C3EB52C). Strip the twin's
+ * rival needs-you `quests` and its HITL `cog` so exactly one attention/decision
+ * surface renders on the home. This is a property of the home mount, not of the
+ * data source, so it persists after the demo → real swap above.
+ */
+function condenseForWorkspaceHome(snapshot: TwinSnapshot): TwinSnapshot {
+  return { ...snapshot, cog: undefined, quests: [] };
+}
+
+/**
+ * Resolve the org's operational twin for the workspace home, or `null` when the
+ * archetype slug has no derivable definition (unconfigured org, or a slug not in
+ * `ALL_ARCHETYPES`). Never throws — a resolution failure falls back to the
+ * existing workspace home.
+ */
+export function resolveWorkspaceTwinPresentation(
+  archetypeId: string | null | undefined,
+  archetypeName?: string | null,
+): WorkspaceTwinPresentation | null {
+  if (!archetypeId) return null;
+  const def = ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId);
+  if (!def) return null;
+
+  const profile = deriveTwinProfile(def);
+  const { snapshot, demo } = produceWorkspaceTwinSnapshot(profile);
+  return {
+    archetypeId,
+    archetypeName: archetypeName?.trim() || def.name,
+    profile,
+    snapshot: condenseForWorkspaceHome(snapshot),
+    demo,
+  };
+}

--- a/docs/superpowers/plans/2026-07-15-twin-workspace-home-placement-execution.md
+++ b/docs/superpowers/plans/2026-07-15-twin-workspace-home-placement-execution.md
@@ -1,0 +1,126 @@
+# Operational Twin → Workspace Home Placement (EP-LIVING-BUSINESS-VIZ P3, increment 2)
+
+- **Status:** in progress
+- **Date:** 2026-07-15
+- **Epic:** EP-LIVING-BUSINESS-VIZ
+- **Parent spec:** [`docs/superpowers/specs/2026-07-11-living-business-workforce-visualization-design.md`](../specs/2026-07-11-living-business-workforce-visualization-design.md) §9 (Open questions → Home placement)
+- **Sibling spec:** [`docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md`](../specs/2026-07-12-operational-twin-framework-design.md) (the twin grammar + `deriveTwinProfile` + `TwinView`)
+- **Sibling execution (owned by another thread — NOT edited here):** `docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md`
+
+## 1. Goal
+
+Put the operational twin onto the **real** `/workspace` home so the operational
+twin becomes the main workspace view — the original goal of the epic. Build only
+on the already-merged pieces:
+
+- `deriveTwinProfile(archetype)` and `ALL_ARCHETYPES` (`@dpf/storefront-templates`).
+- `TwinView` + `buildDemoTwinSnapshot(profile)` (`apps/web/components/twin/`).
+
+Render **demo data** for now behind **one clean seam** so the sibling thread's real
+`LivingBusinessSnapshot` projection (parent spec P4) — which fills the same
+`TwinSnapshot` shape — is a one-line swap later. This plan does **not** build the
+projection.
+
+## 2. The placement decision (governed)
+
+§9 of the parent spec left home placement open. Three candidates:
+
+- **(a)** twin as hero body of `VerticalWorkspaceHome`, `OperatorCockpit` folded into its HUD rail (spec leaning);
+- **(b)** twin above `OperatorCockpit`;
+- **(c)** a dedicated `/workspace` hero with the cockpit folded in as its HUD.
+
+**Governance trail (guard-off branch → routed by hand):**
+
+1. `dpf-ux-fit-review` → **fits-with-guardrails** (see §4 guardrails). Owning area
+   Workspace; no new route; reuses `TwinView`/`deriveTwinProfile` verbatim.
+2. `principle_decide` (`callingPopulation=external_coding_agent`,
+   `human_cognitive_load` + maintainability/reuse/blast-radius/speed features) →
+   **recommended (a)**, composite 7.92, margin 2.25, **confidence high**, no
+   commandment conflict. `human_cognitive_load` is a *cost* axis; (b) scored
+   highest load (two attention surfaces).
+3. `AskUserQuestion` (task-required confirmation) → **operator chose (c)**, a
+   dedicated hero. The operator owns the final placement call; the kernel ledger
+   was surfaced first (consult-then-defer order held).
+
+**Decision: (c) — a dedicated `/workspace` twin hero, cockpit folded in as its
+HUD.** The hard guardrail from the ux-fit review + `principle_decide` survives the
+choice: **exactly one attention surface** on the home.
+
+## 3. The single-attention-surface constraint (BI-8C3EB52C)
+
+`OperatorCockpit` is the ONE live "what needs you now" surface on the workspace
+home. `TwinView` carries its *own* attention/decision surfaces — `NeedsYouQuests`
+(self-described as "the single what-needs-you-now surface") and the `CogBanner`
+HITL confirm. Rendering both live would re-introduce the exact two-framings
+problem BI-8C3EB52C closed, and the demo cog would present a **fake** confirm
+control on the main home.
+
+Resolution: on the workspace-home mount, **suppress the twin's `quests` and `cog`**
+so the cockpit HUD is the only attention/decision surface. The twin body then
+shows the operational picture — capacity chips, presence, zones of resource
+units, work-in-flight, queues, activity feed, utility band. `TwinView` is **not
+edited** (sibling-owned); suppression happens in this surface's own seam.
+
+## 4. UX-fit guardrails (folded into this plan)
+
+- Cockpit stays the single attention surface, rendered as the hero's HUD; no
+  second attention count.
+- Twin demo `cog` + `quests` suppressed on the home mount.
+- Panel labelled **"Demo data — live business projection pending"** until the
+  sibling projection lands.
+- Platform tiles/launcher **demote** (heading "All workspace areas", simple
+  density) below the hero — reachable navigation, not a rival dashboard stacked
+  beside the twin.
+- One demo→real seam (single function). No hardcoded colors (TwinView is already
+  token-compliant). No new report-kit dialect.
+
+## 5. Files (all inside the ALLOWED zone)
+
+| File | Kind | Role |
+| --- | --- | --- |
+| `apps/web/lib/workspace-home/twin-panel-data.ts` | new | The seam. `resolveWorkspaceTwinPresentation(archetypeId, name)`: slug → `ALL_ARCHETYPES` → `deriveTwinProfile` → `produceWorkspaceTwinSnapshot` (**the one demo→real line**) → `condenseForWorkspaceHome` (drops `cog`+`quests`). Total, never throws, returns `null` when no definition resolves. |
+| `apps/web/components/workspace-home/WorkspaceTwinPanel.tsx` | new | Renders the demo badge + `<TwinView profile snapshot />`. |
+| `apps/web/components/workspace-home/WorkspaceTwinHero.tsx` | new | The dedicated hero: identity header + cockpit HUD (passed in) + `WorkspaceTwinPanel` body, with the demoted platform body below. |
+| `apps/web/app/(shell)/workspace/page.tsx` | edit | Resolve the twin presentation; when present, render `WorkspaceTwinHero` (cockpit folded in) instead of the standalone cockpit + `VerticalWorkspaceHome`/`PlatformWorkspaceHome`. Unchanged fallback otherwise. |
+| `apps/web/lib/workspace-home/twin-panel-data.test.ts` | new | Seam unit tests: profile resolves for a real archetype slug; snapshot condensed (`cog` undefined, `quests` empty); `null` for unknown/empty slug; determinism. |
+
+**Not edited (sibling-owned):** `apps/web/components/twin/**`, `apps/web/lib/twin/**`,
+the sibling execution plan.
+
+## 6. Data seam (demo → real)
+
+`twin-panel-data.ts` isolates the swap to a single function body:
+
+```ts
+// THE DEMO→REAL SEAM — swap this one body when LivingBusinessSnapshot lands.
+function produceWorkspaceTwinSnapshot(profile) {
+  return { snapshot: buildDemoTwinSnapshot(profile), demo: true };
+}
+```
+
+`condenseForWorkspaceHome` (drop `cog`/`quests`) is a *separate* concern from the
+data source, so it persists across the swap: the cockpit remains the single
+attention surface whether the snapshot is demo or live.
+
+## 7. Verification
+
+- `pnpm --filter web typecheck`.
+- `pnpm --filter web exec vitest run` for `twin-panel-data.test.ts` and the
+  workspace-home suite (`registry`, `profiles`, `activation-summary`,
+  `VerticalWorkspaceHome`, `OperatorCockpit`, `page`).
+- No new route (no `build:route-manifest` needed).
+- Browser exercise of `/workspace` (desktop + mobile) on a leased runtime /
+  canonical install: one attention surface, twin hero renders, platform launcher
+  demoted, demo badge present.
+
+## 8. Research & benchmarking
+
+Operational-twin "single pane over live operations with one action queue" mirrors
+NOC/ops-console patterns (Datadog/Grafana single-pane dashboards, Salesforce
+Service Cloud omni-channel "what needs you" list) where a persistent attention
+rail sits above a live operational canvas rather than beside a rival dashboard.
+The rejected pattern is the multi-dashboard portal (stacked KPI boards each with
+its own alert list) — precisely the cognitive-load cost the `human_cognitive_load`
+scoring penalised in option (b). The adopted pattern keeps one attention rail
+(cockpit) + one operational canvas (twin), consistent with the DPF single-
+attention-surface decision (BI-8C3EB52C).


### PR DESCRIPTION
## Summary

Puts the operational twin onto the real `/workspace` home so it becomes the main workspace view — the original goal of EP-LIVING-BUSINESS-VIZ. The twin derives per-archetype (`deriveTwinProfile`) for every archetype and renders via the already-merged `TwinView`. The snapshot is **demo** for now, behind a single clean seam, so swapping in the sibling thread's real `LivingBusinessSnapshot` projection (#2992) is a one-line change.

Placement was the open question in the design spec (§9). It was governed end-to-end: a `dpf-ux-fit-review`, a `principle_decide` score on `human_cognitive_load`, and an operator confirmation. The operator chose a **dedicated `/workspace` hero**; the hard guardrail survives that choice — exactly one attention surface on the home.

## Changes

- **New** `apps/web/lib/workspace-home/twin-panel-data.ts` — the archetype→profile→snapshot seam. `resolveWorkspaceTwinPresentation(archetypeId, name)` maps the org's archetype slug → `ALL_ARCHETYPES` → `deriveTwinProfile` → snapshot. Contains the **single demo→real swap point** (`produceWorkspaceTwinSnapshot`) and the home-mount condensation (`condenseForWorkspaceHome`).
- **New** `apps/web/components/workspace-home/WorkspaceTwinPanel.tsx` — `TwinView` + an honest "Demo data" badge.
- **New** `apps/web/components/workspace-home/WorkspaceTwinHero.tsx` — the dedicated hero: identity header + `OperatorCockpit` folded in as the HUD + the twin body, with platform tiles demoted below.
- **Edit** `apps/web/app/(shell)/workspace/page.tsx` — render the hero when an archetype resolves; unchanged fallback (cockpit + `VerticalWorkspaceHome`/`PlatformWorkspaceHome`) otherwise.
- **New** plan doc + seam unit tests + hero render tests.

Single-attention-surface preserved (BI-8C3EB52C): the cockpit is the one "what needs you now" HUD; the twin's own demo `cog` + needs-you `quests` are suppressed on the home mount. `TwinView` and `lib/twin` (sibling-owned) are **not** touched.

## Design grounding

New surface grounded in the merged twin substrate (`apps/web/components/twin`, `packages/storefront-templates` `deriveTwinProfile`) and the existing workspace-home seam (`resolveWorkspaceHomeContribution`, `OperatorCockpit` as the single attention surface). Source of truth: `StorefrontConfig.archetype.archetypeId` → `ALL_ARCHETYPES`. New plan artifact authored; no existing spec/plan rewritten; sibling-owned twin internals untouched.

## Test plan

- [x] **Source-only + UX surface change**
  - [x] `pnpm --filter web typecheck` (worktree, 8GB heap) — clean.
  - [x] Targeted unit tests (worktree):
        - `apps/web/lib/workspace-home/twin-panel-data.test.ts` (6)
        - `apps/web/components/workspace-home/WorkspaceTwinHero.test.tsx` (3)
        - workspace-home + page + components suite (57)
- [x] **Verification-harness limitation acknowledged** — live-portal UX verification is runtime-bound and pends deployment via the governed self-upgrade path (a worktree is source-control, not runtime; direct portal rebuilds are prohibited outside install/recovery). Not a product defect.

### Verification evidence

```
$ pnpm --filter web exec vitest run lib/workspace-home components/workspace-home app/(shell)/workspace/page.test.tsx
Test Files  passed  |  Tests 66 passed (twin-panel-data 6, WorkspaceTwinHero 3, + workspace-home suite 57)

$ NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck
next typegen → Types generated successfully; tsc --noEmit → clean
```

Render evidence (static-markup tests) confirms: twin hero body + cockpit HUD + demoted platform launcher render; "Demo data" badge present; the twin's cog + needs-you quests are suppressed (single attention surface).

## Related issues / Epic

Parent: EP-LIVING-BUSINESS-VIZ — Living Business / Workforce Visualization.
This PR covers: P3 increment 2 (workspace-home placement). Complements #2992 (P3·2a, the real `LivingBusinessSnapshot` projection) — this PR leaves the exact `TwinSnapshot`-shaped seam that #2992 fills.

## Overlap sweep

`gh pr list --state open` → only #2992 (`claude/animated-business-viz-darews`) shares the epic. No file overlap: #2992 owns `apps/web/components/twin/**` + `apps/web/lib/twin/**`; this PR owns `apps/web/lib/workspace-home/**` + `apps/web/components/workspace-home/**` + `workspace/page.tsx`. Complementary by design (the demo→real seam).

## Notes for the reviewer

- **Renders demo data** pending #2992's `LivingBusinessSnapshot`. The swap is one function body (`produceWorkspaceTwinSnapshot`); `condenseForWorkspaceHome` (single attention surface) persists across the swap.
- Placement decision trail is in the commit body + the plan doc; the kernel recommended option (a) at high confidence, operator selected option (c) — both preserve the one-attention-surface guardrail.

UX-Fit-Decision: Dedicated /workspace twin hero with OperatorCockpit folded in as the single "what needs you now" HUD; twin demo cog + needs-you quests suppressed so exactly one attention surface (BI-8C3EB52C); platform launcher demoted, not stacked. Owning area Workspace; no new route; reuses TwinView/deriveTwinProfile verbatim; all UI on --dpf-* tokens. dpf-ux-fit-review = fits-with-guardrails; principle_decide (human_cognitive_load, callingPopulation=external_coding_agent) recommended option (a) at high confidence (composite 7.92, margin 2.25); operator selected option (c) via AskUserQuestion. Plan: docs/superpowers/plans/2026-07-15-twin-workspace-home-placement-execution.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
