### PR TITLE
fix(self-upgrade): classify database-unreachable (P1001) migrate failures (BI-D8C0D045)

### DIFF
--- a/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
@@ -100,6 +100,14 @@ const P3009_BLOCKED_LOG = `Error: P3009
 migrate found failed migrations in the target database, new migrations will not be applied. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
 The \`20260714110000_bet5_pgvector_foundation\` migration started at 2026-07-14 11:02:03 UTC failed`;
 
+// Verbatim shape from BI-D8C0D045 (run SUR-C8BC533B, 2026-07-15): postgres was
+// unreachable during the upgrade (stranded in `Created` by the pre-#2978
+// ensure-pgvector bug), so the boot backfill's Prisma write hit P1001.
+const DB_UNREACHABLE_LOG = `[bet5-backfill] starting projection backfill
+Invalid \`prisma.selfUpgradeRun.update()\` invocation:
+Error querying the database: Can't reach database server at \`postgres\`:\`5432\`
+Please make sure your database server is running at \`postgres\`:\`5432\`.`;
+
 describe("classifyBuildFailure", () => {
   it("classifies the real @opentelemetry host-vs-Docker hoist divergence", () => {
     const c = classifyBuildFailure({ log: HOIST_LOG, hostBuildPassed: true });
@@ -221,6 +229,22 @@ describe("classifyBuildFailure", () => {
     expect(c.class).toBe("unknown");
   });
 
+  it("classifies a Prisma P1001 database-unreachable failure as environment", () => {
+    const c = classifyBuildFailure({ log: DB_UNREACHABLE_LOG });
+    expect(c.class).toBe("database-unreachable");
+    expect(c.isMainDefectVsEnvironment).toBe("environment");
+    expect(c.summary).toContain("Can't reach database server");
+    expect(c.playbookLink).toMatch(/bet5-windows-self-upgrade/);
+    expect(c.failingTrace).toContain("Can't reach database server");
+  });
+
+  it("discriminates P1001 (database-unreachable) from a bare ECONNREFUSED (unknown)", () => {
+    // The specific Prisma phrasing is classified; the ambiguous bare errno is not
+    // (UNKNOWN_LOG is `connect ECONNREFUSED 127.0.0.1:5432` with no P1001 text).
+    expect(classifyBuildFailure({ log: DB_UNREACHABLE_LOG }).class).toBe("database-unreachable");
+    expect(classifyBuildFailure({ log: UNKNOWN_LOG }).class).toBe("unknown");
+  });
+
   it("keeps a non-pnpm ECONNREFUSED (e.g. prisma → postgres) unclassified", () => {
     const c = classifyBuildFailure({ log: UNKNOWN_LOG });
     expect(c.class).toBe("unknown");
@@ -234,7 +258,7 @@ describe("classifyBuildFailure", () => {
   });
 
   it("is total — every input yields a populated summary and playbook", () => {
-    for (const log of [HOIST_LOG, NFT_LOG, BUNDLE_BOUNDARY_LOG, DOCKER_CONTEXT_MISS_LOG, PGVECTOR_MISSING_LOG, P3009_BLOCKED_LOG, UNKNOWN_LOG, ""]) {
+    for (const log of [HOIST_LOG, NFT_LOG, BUNDLE_BOUNDARY_LOG, DOCKER_CONTEXT_MISS_LOG, PGVECTOR_MISSING_LOG, P3009_BLOCKED_LOG, DB_UNREACHABLE_LOG, UNKNOWN_LOG, ""]) {
       const c = classifyBuildFailure({ log });
       expect(c.summary.length).toBeGreaterThan(0);
       expect(c.playbookLink.length).toBeGreaterThan(0);

--- a/apps/web/lib/self-upgrade/build-failure-classifier.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.ts
@@ -62,6 +62,13 @@ export type BuildFailureClass =
   // --rolled-back). Environment state from an earlier aborted attempt — often the
   // pgvector failure above — not a main defect (promoter step-3a self-heals it).
   | "p3009-failed-migration"
+  // The migrate/boot step cannot reach Postgres (Prisma P1001 "Can't reach
+  // database server") — the DB is down or unreachable (e.g. postgres stranded in
+  // `Created`, crashed, still starting). Environment/infra, not a main defect:
+  // confirm dpf-postgres-1 is Up; recreate it from the host compose if stuck
+  // (the pgdata volume is intact). Matched on the specific Prisma phrasing, NOT a
+  // bare ECONNREFUSED (which is ambiguous and stays unclassified).
+  | "database-unreachable"
   | "unknown";
 
 export type BuildFailureClassification = {
@@ -130,6 +137,10 @@ const PGVECTOR_MISSING = /extension\s+"?vector"?\s+is not available|could not op
 // Anchored on the P3009 code / its exact phrasing — NOT a bare "migrate failed",
 // which is a different (unknown) failure that must not be mislabeled.
 const P3009_FAILED_MIGRATION = /\bP3009\b|migrate found failed migrations in the target database|following migrations? have failed/i;
+// Prisma P1001: the DB server is unreachable. Anchored on the P1001 code / its
+// exact "Can't reach database server" phrasing — deliberately NOT a bare
+// ECONNREFUSED, which appears in many unrelated failures and stays unclassified.
+const DATABASE_UNREACHABLE = /\bP1001\b|can'?t reach database server|cannot reach database server/i;
 
 /** Up to ~6 lines around the first matching line, capped, for the agent. */
 function traceAround(log: string, re: RegExp): string {
@@ -258,8 +269,21 @@ export function classifyBuildFailure(
   }
 
   // Migrate-step failures (checked after the build-output classes — a migrate
-  // failure means the build already succeeded). pgvector first: when a retry
-  // shows P3009 it is the downstream symptom of this root cause.
+  // failure means the build already succeeded). Connectivity first: if the DB is
+  // unreachable, migrate never ran, so no pgvector/P3009 signal can be present.
+  if (DATABASE_UNREACHABLE.test(log)) {
+    return {
+      class: "database-unreachable",
+      summary:
+        "The migrate/boot step cannot reach Postgres (Prisma P1001 — \"Can't reach database server\"). The database is down or unreachable, not a main defect: confirm dpf-postgres-1 is Up and healthy; if it is stranded in `Created` (the pre-#2978 ensure-pgvector symptom) recreate it from the host compose — the named pgdata volume is intact — then re-trigger. Do NOT hand-rebuild the portal.",
+      playbookLink: BET5_PLAYBOOK,
+      failingTrace: traceAround(log, DATABASE_UNREACHABLE),
+      isMainDefectVsEnvironment: "environment",
+    };
+  }
+
+  // pgvector first among the reachable-DB migrate failures: when a retry shows
+  // P3009 it is the downstream symptom of this root cause.
   if (PGVECTOR_MISSING.test(log)) {
     return {
       class: "pgvector-extension-missing",


### PR DESCRIPTION
## What

Run `SUR-C8BC533B` (2026-07-15) filed an **`unknown`** build-gate failure (BI-D8C0D045) whose real signature was **Prisma P1001** — `Invalid prisma.selfUpgradeRun.update()` → *"Can't reach database server at postgres"*. That's the **postgres-unreachable** failure mode (the DB stranded in `Created` by the pre-#2978 ensure-pgvector bug, or otherwise down) — distinct from the `pgvector-missing`/`P3009` classes added in #3002. It fell through to `unknown` → *reproduce from zero*, when the actionable diagnosis is "the DB is down; recreate postgres from the host compose."

## Change (third BET-5-era class; follows #3002)

- New class **`database-unreachable`** (`environment`), checked **before** the pgvector/P3009 migrate classes — if the DB is unreachable, migrate never ran, so no pgvector/P3009 signal can be present. Points at the runbook's postgres-recreate recovery.
- Anchored on Prisma's **P1001 / "Can't reach database server"** — deliberately **not** a bare `ECONNREFUSED` (ambiguous, stays `unknown`); a discriminator test guards that.
- 2 new unit tests from the verbatim `SUR-C8BC533B` shape.

## Validation
- **20/20** classifier unit tests green; `apps/web` tsc **0 errors** at 8GB (local prepush tsc OOMs cold — CI Typecheck authoritative).

With #3002, the classifier now names all three self-upgrade migrate failure modes our fleet actually hit tonight: pgvector-missing, P3009, and postgres-unreachable.

BI: BI-D8C0D045

🤖 Generated with [Claude Code](https://claude.com/claude-code)