### PR TITLE
feat(twin): live workspace twin — real data, queue wait-times & cog optimizer (EP-LIVING-BUSINESS-VIZ P3 · 2c)

### DIFF
--- a/apps/web/app/(shell)/workspace/page.tsx
+++ b/apps/web/app/(shell)/workspace/page.tsx
@@ -11,7 +11,7 @@ import { LocalOnlyProviderNotice } from "@/components/workspace-home/LocalOnlyPr
 import { UnconfiguredWorkspaceHomeNotice } from "@/components/workspace-home/UnconfiguredWorkspaceHomeNotice";
 import { loadPlatformWorkspaceHomeData } from "@/lib/workspace-home/platform-loader";
 import { resolveWorkspaceHomeContribution } from "@/lib/workspace-home/registry";
-import { resolveWorkspaceTwinPresentation } from "@/lib/workspace-home/twin-panel-data";
+import { loadWorkspaceTwinPresentation } from "@/lib/workspace-home/twin-panel-data";
 import { recordWorkspaceHomeResolution } from "@/lib/workspace-home/telemetry";
 import {
   isSimpleNavMode,
@@ -38,9 +38,11 @@ export default async function WorkspacePage() {
   // The operational twin becomes the main workspace view (EP-LIVING-BUSINESS-VIZ
   // P3). It derives for every archetype with a definition, independent of whether
   // a workspace-home registry contribution is seeded; a resolution miss falls back
-  // to the existing home. Snapshot is DEMO behind the twin-panel-data seam.
+  // to the existing home. Now wired to the LIVE `LivingBusinessSnapshot` projection
+  // (increment 2a) — real business data where the org has it, deterministic demo
+  // otherwise.
   const archetypeRef = platformHomeData.storefrontConfig?.archetype ?? null;
-  const twinPresentation = resolveWorkspaceTwinPresentation(
+  const twinPresentation = await loadWorkspaceTwinPresentation(
     archetypeRef?.archetypeId ?? null,
     archetypeRef?.name ?? null,
   );

--- a/apps/web/lib/twin/living-business-snapshot.test.ts
+++ b/apps/web/lib/twin/living-business-snapshot.test.ts
@@ -9,6 +9,7 @@ import {
   liveCapacityChips,
   loadLivingBusinessSnapshot,
   longestWaitMs,
+  proposeCogAllocation,
   resourceUnits,
   rosterToPresence,
   statusIntent,
@@ -132,6 +133,43 @@ describe("living-business-snapshot — pure helpers", () => {
     expect(longestWaitMs(bookings, NOW)).toBe(86_400_000);
     const chips = liveCapacityChips({ teamTotal: 3, aiCount: 1, openDemand: 2, billsDueCount: 0, longestWaitMs: 86_400_000 });
     expect(chips[0]).toMatchObject({ key: "wait", value: "24h" });
+  });
+
+  it("proposeCogAllocation names the longest-waiting item and least-loaded provider", () => {
+    const bookings = [
+      { id: "old", scheduledAt: null, createdAt: new Date("2026-07-14T09:00:00Z"), status: "pending", provider: null },
+      { id: "new", scheduledAt: null, createdAt: new Date("2026-07-15T08:00:00Z"), status: "pending", provider: null },
+      // Dr Lee already carries an in-flight booking → higher load than Dr Fox.
+      { id: "busy", scheduledAt: null, createdAt: null, status: "confirmed", provider: { name: "Dr Lee" } },
+    ];
+    const providers = [
+      { id: "p1", name: "Dr Lee", isActive: true },
+      { id: "p2", name: "Dr Fox", isActive: true },
+    ];
+    const cog = proposeCogAllocation(bookings, providers, [], "appointment", "provider", ["skill", "availability"], NOW);
+    expect(cog).toBeTruthy();
+    expect(cog!.proposal).toContain("Dr Fox"); // lowest load wins
+    expect(cog!.proposal).toContain("appointment");
+    expect(cog!.confirmLabel).toBe("Assign appointment");
+    expect(cog!.signals).toEqual(["skill", "availability"]);
+  });
+
+  it("proposeCogAllocation falls back to an active AI coworker when no providers exist", () => {
+    const bookings = [{ id: "x", scheduledAt: null, createdAt: new Date("2026-07-14T09:00:00Z"), status: "pending", provider: null }];
+    const cog = proposeCogAllocation(
+      bookings,
+      [],
+      [member({ id: "AGT-1", displayName: "Aria", kind: "agent", status: "active" })],
+      "case",
+      "reviewer",
+      ["workload"],
+      NOW,
+    );
+    expect(cog!.proposal).toContain("Aria");
+  });
+
+  it("proposeCogAllocation stays silent when there is nothing to allocate", () => {
+    expect(proposeCogAllocation([], [], [], "job", "tech", ["skill"], NOW)).toBeUndefined();
   });
 
   it("liveCapacityChips are all real counts", () => {

--- a/apps/web/lib/twin/living-business-snapshot.test.ts
+++ b/apps/web/lib/twin/living-business-snapshot.test.ts
@@ -5,8 +5,10 @@ import {
   bookingsToWorkItems,
   buildQuests,
   financeToUtility,
+  humanizeWait,
   liveCapacityChips,
   loadLivingBusinessSnapshot,
+  longestWaitMs,
   resourceUnits,
   rosterToPresence,
   statusIntent,
@@ -91,17 +93,45 @@ describe("living-business-snapshot — pure helpers", () => {
 
   it("bookings map to queue (pending/unassigned) and work items (in flight)", () => {
     const bookings = [
-      { id: "b1", scheduledAt: new Date("2026-07-18T09:00:00Z"), status: "pending", provider: null },
-      { id: "b2", scheduledAt: new Date("2026-07-16T09:00:00Z"), status: "confirmed", provider: { name: "Dr Lee" } },
+      {
+        id: "b1",
+        scheduledAt: new Date("2026-07-18T09:00:00Z"),
+        createdAt: new Date("2026-07-15T06:00:00Z"), // 3h before NOW
+        status: "pending",
+        provider: null,
+      },
+      {
+        id: "b2",
+        scheduledAt: new Date("2026-07-16T09:00:00Z"),
+        createdAt: new Date("2026-07-14T09:00:00Z"),
+        status: "confirmed",
+        provider: { name: "Dr Lee" },
+      },
     ];
     const queue = bookingsToQueueItems(bookings, NOW);
     expect(queue).toHaveLength(1);
     expect(queue[0]).toMatchObject({ key: "b1", label: "Unassigned" });
+    // real wait time, measured from createdAt (3h before NOW)
+    expect(queue[0].waiting).toBe("3h");
 
     const work = bookingsToWorkItems(bookings, "appointment");
     expect(work).toHaveLength(1);
     expect(work[0]).toMatchObject({ owner: { name: "Dr Lee", kind: "human" } });
     expect(work[0].label).toContain("Appointment");
+  });
+
+  it("humanizeWait + longestWaitMs surface the queue's flow metric", () => {
+    expect(humanizeWait(8 * 60_000)).toBe("8m");
+    expect(humanizeWait(3 * 3_600_000)).toBe("3h");
+    expect(humanizeWait(2 * 86_400_000)).toBe("2d");
+    const bookings = [
+      { id: "a", scheduledAt: null, createdAt: new Date("2026-07-14T09:00:00Z"), status: "pending", provider: null },
+      { id: "b", scheduledAt: null, createdAt: new Date("2026-07-15T06:00:00Z"), status: "pending", provider: null },
+    ];
+    // longest wait = the older item (1 day before NOW)
+    expect(longestWaitMs(bookings, NOW)).toBe(86_400_000);
+    const chips = liveCapacityChips({ teamTotal: 3, aiCount: 1, openDemand: 2, billsDueCount: 0, longestWaitMs: 86_400_000 });
+    expect(chips[0]).toMatchObject({ key: "wait", value: "24h" });
   });
 
   it("liveCapacityChips are all real counts", () => {
@@ -171,7 +201,15 @@ describe("loadLivingBusinessSnapshot — loader", () => {
       taxObligationPeriod: { findMany: async () => [{ dueDate: new Date("2026-07-20T00:00:00Z"), status: "open", filedAt: null }] },
       obligation: { findMany: async () => [] },
       storefrontBooking: {
-        findMany: async () => [{ id: "bk1", scheduledAt: new Date("2026-07-15T18:00:00Z"), status: "pending", provider: null }],
+        findMany: async () => [
+          {
+            id: "bk1",
+            scheduledAt: new Date("2026-07-15T18:00:00Z"),
+            createdAt: new Date("2026-07-15T07:00:00Z"),
+            status: "pending",
+            provider: null,
+          },
+        ],
       },
       serviceProvider: { findMany: async () => [] },
     } as unknown as LivingBusinessClient;

--- a/apps/web/lib/twin/living-business-snapshot.ts
+++ b/apps/web/lib/twin/living-business-snapshot.ts
@@ -35,6 +35,7 @@ import type {
   QueueItemData,
   ResourceUnitData,
   TwinActor,
+  TwinCogSnapshot,
   TwinQueueSnapshot,
   TwinSnapshot,
   TwinZoneSnapshot,
@@ -326,6 +327,53 @@ export function liveCapacityChips(input: {
   return chips;
 }
 
+/**
+ * The cog's live allocation proposal — the real `constraint → proposal → confirm`
+ * loop the founder asked for ("a suggested table seating cog"). Takes the
+ * longest-waiting unassigned demand and proposes the least-loaded active resource
+ * (fewest in-flight items), naming the actual item + resource. Returns `undefined`
+ * when there is nothing to allocate — the cog only speaks when it has a real move.
+ */
+export function proposeCogAllocation(
+  bookings: BookingRow[],
+  providers: ProviderRow[],
+  members: WorkforceMember[],
+  workNoun: string,
+  resourceNoun: string,
+  signals: string[],
+  now: Date,
+): TwinCogSnapshot | undefined {
+  const next = bookings
+    .filter((b) => b.status.toLowerCase() === "pending" || b.provider == null)
+    .sort((a, b) => (a.createdAt?.getTime() ?? Infinity) - (b.createdAt?.getTime() ?? Infinity))[0];
+  if (!next) return undefined;
+
+  // In-flight load per named resource, from the bookings already assigned.
+  const load = new Map<string, number>();
+  for (const b of bookings) {
+    if (b.provider?.name) load.set(b.provider.name, (load.get(b.provider.name) ?? 0) + 1);
+  }
+
+  let resource: string | undefined;
+  if (providers.length > 0) {
+    resource = [...providers].sort(
+      (a, b) => (load.get(a.name) ?? 0) - (load.get(b.name) ?? 0),
+    )[0]?.name;
+  } else {
+    const active = members.filter((m) => m.status.toLowerCase() === "active");
+    resource = (active.find((m) => m.kind === "agent") ?? active[0])?.displayName;
+  }
+
+  const waited = next.createdAt ? humanizeWait(now.getTime() - next.createdAt.getTime()) : null;
+  return {
+    proposal: resource
+      ? `Assign the ${waited ? `${waited}-waiting ` : "next "}${workNoun} to ${resource} (lowest load)`
+      : `Route the longest-waiting ${workNoun} to an available ${resourceNoun}`,
+    confirmLabel: `Assign ${workNoun}`,
+    signals: signals.slice(0, 3),
+  };
+}
+
 /** A bounded attributed feed from the demand rows we already read. The persisted
  *  human+AI event log (parent spec §4 live-delta plane) is a later increment; for
  *  now the feed reflects real booking activity, attributed to its provider. */
@@ -431,14 +479,15 @@ export async function loadLivingBusinessSnapshot(opts?: {
     emptyLabel: i === 0 ? "No demand waiting" : "Clear",
   }));
 
-  const cog =
-    queueItems.length > 0
-      ? {
-          proposal: `Route the next ${profile.workItemNoun.singular} to the best ${profile.resourceNoun.singular} by ${profile.cog.signals[0]}`,
-          confirmLabel: `Assign ${profile.workItemNoun.singular}`,
-          signals: profile.cog.signals.slice(0, 3),
-        }
-      : undefined;
+  const cog = proposeCogAllocation(
+    bookings,
+    providers,
+    members,
+    profile.workItemNoun.singular,
+    profile.resourceNoun.singular,
+    profile.cog.signals,
+    now,
+  );
 
   return {
     live: true,

--- a/apps/web/lib/twin/living-business-snapshot.ts
+++ b/apps/web/lib/twin/living-business-snapshot.ts
@@ -73,6 +73,7 @@ interface ObligationRow {
 interface BookingRow {
   id: string;
   scheduledAt: Date | null;
+  createdAt: Date | null;
   status: string;
   provider: { name: string } | null;
 }
@@ -101,6 +102,14 @@ function titleCase(s: string): string {
 }
 function daysBetween(from: Date, to: Date): number {
   return Math.ceil((to.getTime() - from.getTime()) / 86_400_000);
+}
+/** Humanize an elapsed duration for a queue-wait chip ("8m", "3h", "2d"). */
+export function humanizeWait(ms: number): string {
+  const mins = Math.max(0, Math.round(ms / 60_000));
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 48) return `${hrs}h`;
+  return `${Math.round(hrs / 24)}d`;
 }
 const CURRENCY_SYMBOL: Record<string, string> = { GBP: "£", USD: "$", EUR: "€" };
 function currencySymbol(code: string | null): string {
@@ -163,17 +172,30 @@ export function resourceUnits(
     }));
 }
 
-/** Pending, unstarted demand → queue items (the primary queue's live contents). */
+/** Pending, unstarted demand → queue items with a REAL wait time (age in the
+ *  queue, measured from when the booking was created — the flow metric the founder
+ *  asked for: "if we know the queue and wait times"). Ordered longest-waiting first. */
 export function bookingsToQueueItems(bookings: BookingRow[], now: Date, limit = 6): QueueItemData[] {
   return bookings
     .filter((b) => b.status.toLowerCase() === "pending" || b.provider == null)
+    .sort((a, b) => (a.createdAt?.getTime() ?? Infinity) - (b.createdAt?.getTime() ?? Infinity))
     .slice(0, limit)
     .map((b) => ({
       key: b.id,
       label: b.provider?.name ? `With ${b.provider.name}` : "Unassigned",
-      meta: b.scheduledAt ? undefined : "awaiting schedule",
-      waiting: b.scheduledAt ? `${Math.max(0, daysBetween(now, b.scheduledAt))}d` : undefined,
+      meta: b.scheduledAt ? `booked for ${b.scheduledAt.toISOString().slice(5, 10)}` : "awaiting schedule",
+      waiting: b.createdAt ? humanizeWait(now.getTime() - b.createdAt.getTime()) : undefined,
     }));
+}
+
+/** The longest a pending item has waited — the queue's headline flow metric. */
+export function longestWaitMs(bookings: BookingRow[], now: Date): number {
+  const pending = bookings.filter((b) => b.status.toLowerCase() === "pending" || b.provider == null);
+  let max = 0;
+  for (const b of pending) {
+    if (b.createdAt) max = Math.max(max, now.getTime() - b.createdAt.getTime());
+  }
+  return max;
 }
 
 /** In-flight demand → work items, attributed to the assigned provider (human). */
@@ -276,19 +298,32 @@ export function buildQuests(input: {
   return quests;
 }
 
-/** Live, archetype-agnostic capacity counters — each is a true number. */
+/** Live, archetype-agnostic capacity counters — each is a true number. When any
+ *  demand is waiting, the longest wait leads as the headline flow metric. */
 export function liveCapacityChips(input: {
   teamTotal: number;
   aiCount: number;
   openDemand: number;
   billsDueCount: number;
+  longestWaitMs?: number;
 }): CapacityChipData[] {
-  return [
+  const chips: CapacityChipData[] = [];
+  if (input.longestWaitMs && input.longestWaitMs > 0) {
+    chips.push({
+      key: "wait",
+      label: "Longest wait",
+      value: humanizeWait(input.longestWaitMs),
+      intent: input.longestWaitMs > 86_400_000 ? "danger" : "warning",
+      live: true,
+    });
+  }
+  chips.push(
     { key: "team", label: "Workforce", value: input.teamTotal, intent: "info", live: true },
     { key: "ai", label: "AI coworkers", value: input.aiCount, intent: "accent" },
     { key: "demand", label: "Open demand", value: input.openDemand, intent: input.openDemand > 0 ? "warning" : "success", live: true },
     { key: "bills", label: "Bills due", value: input.billsDueCount, intent: input.billsDueCount > 0 ? "warning" : "success" },
-  ];
+  );
+  return chips;
 }
 
 /** A bounded attributed feed from the demand rows we already read. The persisted
@@ -358,7 +393,13 @@ export async function loadLivingBusinessSnapshot(opts?: {
         where: { status: { notIn: ["completed", "cancelled"] } },
         orderBy: { scheduledAt: "asc" },
         take: 24,
-        select: { id: true, scheduledAt: true, status: true, provider: { select: { name: true } } },
+        select: {
+          id: true,
+          scheduledAt: true,
+          createdAt: true,
+          status: true,
+          provider: { select: { name: true } },
+        },
       })
       .catch(() => []) as Promise<BookingRow[]>,
     db.serviceProvider
@@ -409,6 +450,7 @@ export async function loadLivingBusinessSnapshot(opts?: {
       aiCount: roster.summary.agents,
       openDemand: bookings.length,
       billsDueCount: bills.length,
+      longestWaitMs: longestWaitMs(bookings, now),
     }),
     zones,
     workItems: bookingsToWorkItems(bookings, profile.workItemNoun.singular),

--- a/apps/web/lib/workspace-home/twin-panel-data.test.ts
+++ b/apps/web/lib/workspace-home/twin-panel-data.test.ts
@@ -2,9 +2,48 @@ import { describe, it, expect } from "vitest";
 
 import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
 
-import { resolveWorkspaceTwinPresentation } from "./twin-panel-data";
+import {
+  loadWorkspaceTwinPresentation,
+  resolveWorkspaceTwinPresentation,
+} from "./twin-panel-data";
 
 const SAMPLE = ALL_ARCHETYPES[0];
+const NOW = new Date("2026-07-15T09:00:00Z");
+
+// A fake client for the live projection path. `configured` toggles whether an org
+// (with the given archetype) resolves — driving live vs demo fallback.
+function fakeDb(configured: { archetypeId: string; name: string } | null) {
+  return {
+    employeeProfile: {
+      findMany: async () => [
+        { id: "E-1", displayName: "Sam", status: "active", position: { title: "Server" }, department: { name: "Floor" } },
+      ],
+    },
+    agent: {
+      findMany: async () => [
+        {
+          agentId: "AGT-HOST",
+          name: "AI host",
+          status: "active",
+          valueStream: "operate",
+          humanSupervisorId: null,
+          portfolioId: null,
+          hitlTierDefault: "tier2",
+          lifecycleStage: "active",
+          executionConfig: null,
+          _count: { toolGrants: 0, skills: 0 },
+          coworkerNeeds: [],
+        },
+      ],
+    },
+    storefrontConfig: { findFirst: async () => (configured ? { archetype: configured } : null) },
+    bill: { findMany: async () => [{ amountDue: 500, dueDate: NOW, status: "open", currency: "GBP" }] },
+    taxObligationPeriod: { findMany: async () => [] },
+    obligation: { findMany: async () => [] },
+    storefrontBooking: { findMany: async () => [] },
+    serviceProvider: { findMany: async () => [] },
+  } as never;
+}
 
 describe("resolveWorkspaceTwinPresentation", () => {
   it("resolves a profile + snapshot for a real archetype slug", () => {
@@ -55,5 +94,38 @@ describe("resolveWorkspaceTwinPresentation", () => {
       const result = resolveWorkspaceTwinPresentation(arch.archetypeId);
       expect(result, arch.archetypeId).not.toBeNull();
     }
+  });
+});
+
+describe("loadWorkspaceTwinPresentation — live overlay", () => {
+  it("uses the live projection (demo: false) when the org is configured", async () => {
+    const result = await loadWorkspaceTwinPresentation(SAMPLE.archetypeId, null, {
+      db: fakeDb({ archetypeId: SAMPLE.archetypeId, name: "Acme Co" }),
+      now: NOW,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.demo).toBe(false);
+    // live presence carries the real workforce (a human + an AI coworker)
+    expect(result!.snapshot.presence.some((p) => p.kind === "ai")).toBe(true);
+    // real finance flows through
+    expect(result!.snapshot.utility.find((m) => m.key === "bills")!.value).toContain("£500");
+    // home-mount condensing still applies to the live snapshot
+    expect(result!.snapshot.cog).toBeUndefined();
+    expect(result!.snapshot.quests).toEqual([]);
+  });
+
+  it("falls back to the demo (demo: true) when no org is configured", async () => {
+    const result = await loadWorkspaceTwinPresentation(SAMPLE.archetypeId, null, {
+      db: fakeDb(null),
+      now: NOW,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.demo).toBe(true);
+    expect(result!.snapshot.cog).toBeUndefined();
+  });
+
+  it("returns null for an unresolvable slug regardless of live data", async () => {
+    expect(await loadWorkspaceTwinPresentation(null)).toBeNull();
+    expect(await loadWorkspaceTwinPresentation("not-a-real-archetype-slug")).toBeNull();
   });
 });

--- a/apps/web/lib/workspace-home/twin-panel-data.ts
+++ b/apps/web/lib/workspace-home/twin-panel-data.ts
@@ -2,9 +2,14 @@
 //
 // The workspace-home twin seam (EP-LIVING-BUSINESS-VIZ P3, increment 2). Resolves
 // the org's archetype into a rendered operational twin for the /workspace hero:
-// slug -> ALL_ARCHETYPES -> deriveTwinProfile -> snapshot. Pure, total (returns
-// null rather than throwing when no definition resolves), and DB-free — the page
-// already loads StorefrontConfig.archetype and hands the slug + name in.
+// slug -> ALL_ARCHETYPES -> deriveTwinProfile -> snapshot.
+//
+// Two resolvers share one presentation shape:
+//   - resolveWorkspaceTwinPresentation — pure, total, DB-free; deterministic DEMO
+//     snapshot (used by tests and as the always-available fallback).
+//   - loadWorkspaceTwinPresentation — async; overlays the real
+//     `LivingBusinessSnapshot` projection when an org is configured, else falls
+//     back to the demo. This is the wired demo -> real path.
 //
 // Plan: docs/superpowers/plans/2026-07-15-twin-workspace-home-placement-execution.md
 // Renderer (sibling-owned, not edited here): apps/web/components/twin/TwinView.tsx
@@ -16,6 +21,7 @@ import {
 } from "@dpf/storefront-templates";
 
 import { buildDemoTwinSnapshot, type TwinSnapshot } from "@/components/twin";
+import { loadLivingBusinessSnapshot } from "@/lib/twin/living-business-snapshot";
 
 export interface WorkspaceTwinPresentation {
   archetypeId: string;
@@ -79,4 +85,32 @@ export function resolveWorkspaceTwinPresentation(
     snapshot: condenseForWorkspaceHome(snapshot),
     demo,
   };
+}
+
+/**
+ * The LIVE workspace-home twin (EP-LIVING-BUSINESS-VIZ P3, increment 2 — wired).
+ * Overlays the real `LivingBusinessSnapshot` projection onto the resolved
+ * presentation: when an org is configured and its archetype matches, the panel
+ * renders live business data (`demo: false`); otherwise it falls back to the
+ * deterministic demo above. Never throws — a projection failure degrades to demo,
+ * so the home always renders. The home-mount condensing (drop the twin's rival
+ * `cog`/`quests` so `OperatorCockpit` stays the single attention surface) applies
+ * to the live snapshot too.
+ */
+export async function loadWorkspaceTwinPresentation(
+  archetypeId: string | null | undefined,
+  archetypeName?: string | null,
+  opts?: Parameters<typeof loadLivingBusinessSnapshot>[0],
+): Promise<WorkspaceTwinPresentation | null> {
+  const base = resolveWorkspaceTwinPresentation(archetypeId, archetypeName);
+  if (!base) return null;
+  try {
+    const live = await loadLivingBusinessSnapshot(opts);
+    if (live && live.archetypeId === base.archetypeId) {
+      return { ...base, snapshot: condenseForWorkspaceHome(live), demo: false };
+    }
+  } catch {
+    // Projection failed (no DB in this context, transient error) — keep the demo.
+  }
+  return base;
 }

--- a/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
+++ b/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
@@ -101,15 +101,32 @@ ahead of the demo archetypes. Pure mapping helpers are unit-tested
 (`living-business-snapshot.test.ts`, 11 assertions incl. a fake-client loader run);
 what has no substrate yet is left empty with its calm-state label, not faked.
 
-**Still to come:** a persisted human+AI event log for a richer live feed, per-stage
-flow metrics (queue depth / WIP / wait) over `deriveOperationalValueStream`, and a
-live cog optimizer — each lands behind this same `TwinSnapshot` shape.
+### P3 increment 2b — workspace-home placement · DONE (merged, sibling PR)
+`TwinView` is the main `/workspace` view — a dedicated hero (`WorkspaceTwinHero`,
+parent viz spec §9 option c) that folds `OperatorCockpit` in as its HUD so exactly
+one attention surface renders, with the platform launcher demoted below. The
+`twin-panel-data` seam (`resolveWorkspaceTwinPresentation`) resolves the org's
+archetype → profile → snapshot and condenses for the home mount (strips the twin's
+rival `cog`/`quests`).
 
-### P3 increment 2b — workspace-home placement · IN A SIBLING PR
-Register `TwinView` as a per-archetype workspace-home contribution and render it on
-the real `/workspace` home (relative to `OperatorCockpit`; the placement is the open
-question in the parent viz design spec §9). Built in parallel on its own branch,
-rendering via this projection behind the shared `TwinSnapshot` seam.
+### P3 increment 2c — wire the home to LIVE data + real flow metrics · DONE
+The home seam now renders the **real** projection. `loadWorkspaceTwinPresentation`
+(async) overlays `loadLivingBusinessSnapshot` onto the resolved presentation:
+`demo: false` with live business data when the org is configured, deterministic demo
+otherwise, never throwing (a projection failure degrades to demo). The workspace page
+awaits it. Added **real queue wait-time** flow metrics — the founder's original ask
+("if we know the queue and wait times"): `bookingsToQueueItems` orders longest-waiting
+first and shows each item's true age (from `createdAt`), and a **Longest wait**
+capacity chip leads the board when demand is waiting (`humanizeWait`/`longestWaitMs`).
+Tests: live-overlay + demo-fallback (`twin-panel-data.test.ts`) and the wait-metric
+helpers (`living-business-snapshot.test.ts`); 33 twin assertions green.
+
+**Still deferred (each behind the same `TwinSnapshot` shape, no contract change):**
+a *persisted* human+AI event log for a richer live feed (needs a new table +
+write-path instrumentation — a migration-class change, out of scope here; the feed
+stays derived-from-bookings until then); per-value-stream-stage WIP over
+`deriveOperationalValueStream`; and a live cog *optimizer* (the home strips the cog —
+this benefits the admin/non-home mounts).
 
 ## P4 — remaining templates by install demand
 BOOK, BAYS, ROOMS, STORE, VENUE, COUNTER + the TENANTS/PIPELINE/PROGRAMS boards, each a template + bindings (not a bespoke build). Certification: a golden-journey per template exercising queue → cog → confirm. PHI-class ROOMS (healthcare) gets the presence/feed redaction mode (role, not patient identity) keyed off `privacyClass` (open question §9.2).

--- a/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
+++ b/docs/superpowers/plans/2026-07-12-operational-twin-framework-execution.md
@@ -118,15 +118,23 @@ awaits it. Added **real queue wait-time** flow metrics — the founder's origina
 ("if we know the queue and wait times"): `bookingsToQueueItems` orders longest-waiting
 first and shows each item's true age (from `createdAt`), and a **Longest wait**
 capacity chip leads the board when demand is waiting (`humanizeWait`/`longestWaitMs`).
-Tests: live-overlay + demo-fallback (`twin-panel-data.test.ts`) and the wait-metric
-helpers (`living-business-snapshot.test.ts`); 33 twin assertions green.
+A **live cog optimizer** (`proposeCogAllocation`) realizes the founder's
+`constraint → proposal → confirm` cog ("a suggested table seating cog"): it takes the
+longest-waiting unassigned demand and proposes the least-loaded active resource
+(fewest in-flight items), naming the actual item + resource, and stays silent when
+there is nothing to allocate. It shows on the admin/twin-kit live tab and any
+non-home mount (the workspace home condenses the cog out, keeping `OperatorCockpit`
+the single attention surface).
+
+Tests: live-overlay + demo-fallback (`twin-panel-data.test.ts`); wait-metric + cog
+helpers (`living-business-snapshot.test.ts`); 37 twin assertions green.
 
 **Still deferred (each behind the same `TwinSnapshot` shape, no contract change):**
 a *persisted* human+AI event log for a richer live feed (needs a new table +
 write-path instrumentation — a migration-class change, out of scope here; the feed
-stays derived-from-bookings until then); per-value-stream-stage WIP over
-`deriveOperationalValueStream`; and a live cog *optimizer* (the home strips the cog —
-this benefits the admin/non-home mounts).
+stays derived-from-bookings until then), and per-value-stream-stage WIP over
+`deriveOperationalValueStream` (the value-stream *lens*, a distinct render surface
+from the twin's spatial "now" lens).
 
 ## P4 — remaining templates by install demand
 BOOK, BAYS, ROOMS, STORE, VENUE, COUNTER + the TENANTS/PIPELINE/PROGRAMS boards, each a template + bindings (not a bespoke build). Certification: a golden-journey per template exercising queue → cog → confirm. PHI-class ROOMS (healthcare) gets the presence/feed redaction mode (role, not patient identity) keyed off `privacyClass` (open question §9.2).


### PR DESCRIPTION
## Summary

Completes the twin-as-live-main-view. The `/workspace` hero (placed by increment **2b**, merged) now renders the **real** `LivingBusinessSnapshot` projection (increment **2a**, merged) instead of demo data; the live board shows genuine **queue wait-times**; and the cog is now a **real allocation optimizer**, not a shell. This makes the operational twin the actual main workspace view, driven by real business data — the goal of the whole epic.

## Changes

- **`twin-panel-data.ts`** — new async `loadWorkspaceTwinPresentation` overlays `loadLivingBusinessSnapshot` onto the resolved presentation: `demo: false` with live data when the org is configured, deterministic demo otherwise, and **never throws** (a projection failure degrades to demo). The pure `resolveWorkspaceTwinPresentation` stays as fallback + test path. Home-mount condensing (strip the twin's `cog`/`quests` so `OperatorCockpit` stays the single attention surface) applies to the live snapshot too.
- **`workspace/page.tsx`** — awaits the live resolver.
- **`living-business-snapshot.ts`**:
  - **Real queue wait-times** (the founder's ask: *"if we know the queue and wait times"*) — `bookingsToQueueItems` orders longest-waiting first and shows each item's true age from `createdAt` (`humanizeWait`); a **Longest wait** capacity chip leads the board when demand waits (`longestWaitMs`).
  - **Live cog optimizer** (*"a suggested table seating cog"*) — `proposeCogAllocation` takes the longest-waiting unassigned demand and proposes the least-loaded active resource (fewest in-flight items), naming the actual item + resource; silent when there's nothing to allocate. Prefers ranked service providers, falls back to an active AI coworker.
- **Tests** — live-overlay + demo-fallback; wait-metric + cog helpers. 37 twin assertions green.
- **Plan** — P3 increments 2b/2c → DONE; cog optimizer delivered; remaining work deferred with rationale.

## Test plan

- [x] **Runtime-bound change** (live data source on `/workspace` + projection enrichment)
  - [x] `pnpm --filter web typecheck` — clean
  - [x] `pnpm --filter web exec vitest run lib/twin/ lib/workspace-home/twin-panel-data.test.ts components/twin/ app/(shell)/workspace/page.test.tsx components/workspace-home/` — green
  - [x] `pnpm --filter web check:route-manifest` — up to date (548)
  - [ ] Visual confirmation of `/workspace` live twin with a seeded org — CI (worktree has no seeded DB)

- [x] **Verification-harness limitation acknowledged** — worktree is source-control isolation, not a full runtime (AGENTS.md §5); the overlay, fallback, wait-metrics and cog are covered by fake-client + pure-helper tests in CI Unit Tests.

### Verification evidence

```
$ pnpm --filter web exec vitest run lib/twin/ lib/workspace-home/twin-panel-data.test.ts
 Test Files  2 passed (2)
      Tests  24 passed (24)

$ pnpm --filter web typecheck
✓ Types generated successfully   (tsc --noEmit clean)
```

## Related issues / Epic

- **EP-LIVING-BUSINESS-VIZ** P3 increment 2c. Builds on 2a (`loadLivingBusinessSnapshot`, #2992) and 2b (`WorkspaceTwinHero`, merged sibling), plus P1 (#2875), P2 (#2982), P3 `TwinView` (#2987) — all merged.

## Overlap sweep

Touches the twin projection (`lib/twin/`) and the workspace-home seam (`lib/workspace-home/twin-panel-data.ts` + the page) — the intended integration point between 2a and 2b. No other in-flight work on these files.

## Notes for the reviewer

- **Design-Grounding-Decision:** parent viz design spec §4 (`LivingBusinessSnapshot`) + §9 placement (option c, implemented by the sibling plan `2026-07-15-twin-workspace-home-placement-execution.md`); demo→real seam wiring + enrichment of existing `TwinSnapshot` fields (`queues`/`capacityChips`/`cog`) — no render-contract change.
- **Process-Spine-Decision:** plan updated in this PR.
- **UX-Fit-Decision:** no new UI primitives or surfaces — reuses the merged `WorkspaceTwinHero` + `TwinView` (incl. its HITL `CogBanner`); the change is a data source (demo → live) plus real flow-metrics. The home keeps exactly one attention surface (`OperatorCockpit`); the twin's `cog`/`quests` stay condensed out there. Zero raw/numeric operator inputs.
- **Deferred, honestly:** a *persisted* human+AI event log (migration-class — feed stays derived-from-bookings until then), and per-value-stream-stage WIP (the value-stream *lens*, a distinct render surface). Both land behind the same `TwinSnapshot` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)