### PR TITLE
fix: surface design auto-intake failures

### DIFF
--- a/apps/web/lib/integrate/auto-intake-activity.test.ts
+++ b/apps/web/lib/integrate/auto-intake-activity.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { prisma } from "@dpf/db";
+import { recordAutoIntakeFailure } from "@/lib/mcp/build-tool-helpers";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    buildActivity: {
+      create: vi.fn(async () => ({})),
+    },
+  },
+}));
+
+describe("recordAutoIntakeFailure", () => {
+  it("surfaces auto-intake failures as BuildActivity rows instead of console-only warnings", () => {
+    const warn = vi.fn();
+
+    recordAutoIntakeFailure(
+      "FB-REVIEW",
+      "epic",
+      new Error("requireCapability(view_platform) has no request session"),
+      { warn },
+    );
+
+    expect(prisma.buildActivity.create).toHaveBeenCalledWith({
+      data: {
+        buildId: "FB-REVIEW",
+        tool: "auto-intake:epic:failed",
+        summary: expect.stringContaining(
+          "Auto-intake epic failed: requireCapability(view_platform) has no request session",
+        ),
+      },
+    });
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -10,7 +10,7 @@ import * as crypto from "crypto";
 import { lazyFs, lazyFsPromises, lazyPath, lazyChildProcess, lazyUtil, getCwd } from "@/lib/shared/lazy-node";
 import { slugify } from "@/lib/shared/slugify";
 import {
-  logBuildActivity,
+  logBuildActivity, recordAutoIntakeFailure,
   extractBuildIdHint,
   resolveActiveBuildId,
   updateBuildHappyPathState,
@@ -1327,7 +1327,7 @@ export async function executeTool(
               happyPathState = { ...happyPathState, intake: { ...happyPathState.intake, epicId: createdEpic.epicId } };
               logBuildActivity(buildId, "auto-intake:epic", `Auto-created epic ${createdEpic.epicId} (${epicTitle})`);
             } catch (err) {
-              console.warn("[reviewDesignDoc] auto-create epic failed:", err);
+              recordAutoIntakeFailure(buildId, "epic", err);
             }
           }
 
@@ -1371,7 +1371,7 @@ export async function executeTool(
               happyPathState = { ...happyPathState, intake: { ...happyPathState.intake, backlogItemId: itemId } };
               logBuildActivity(buildId, "auto-intake:backlog", `Auto-created backlog item ${itemId} (${title})`);
             } catch (err) {
-              console.warn("[reviewDesignDoc] auto-create backlog item failed:", err);
+              recordAutoIntakeFailure(buildId, "backlog", err);
             }
           }
 
@@ -1399,7 +1399,7 @@ export async function executeTool(
               };
               logBuildActivity(buildId, "auto-intake:constrained-goal", `Auto-set constrainedGoal from build title`);
             } catch (err) {
-              console.warn("[reviewDesignDoc] auto-set constrainedGoal failed:", err);
+              recordAutoIntakeFailure(buildId, "constrained-goal", err);
             }
           }
 
@@ -1421,7 +1421,7 @@ export async function executeTool(
               };
               logBuildActivity(buildId, "auto-intake:taxonomy-anchor", `Auto-set taxonomyNodeId=${anchor}`);
             } catch (err) {
-              console.warn("[reviewDesignDoc] auto-set taxonomyNodeId failed:", err);
+              recordAutoIntakeFailure(buildId, "taxonomy-anchor", err);
             }
           }
 

--- a/apps/web/lib/mcp/build-tool-helpers.ts
+++ b/apps/web/lib/mcp/build-tool-helpers.ts
@@ -13,6 +13,24 @@ export function logBuildActivity(buildId: string, tool: string, summary: string)
   prisma.buildActivity.create({ data: { buildId, tool, summary } }).catch(() => {});
 }
 
+export type AutoIntakeStep = "epic" | "backlog" | "constrained-goal" | "taxonomy-anchor";
+
+function summarizeAutoIntakeError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message.trim();
+  if (typeof error === "string" && error.trim()) return error.trim();
+  return "Unknown error";
+}
+
+export function recordAutoIntakeFailure(
+  buildId: string,
+  step: AutoIntakeStep,
+  error: unknown,
+  logger: Pick<Console, "warn"> = console,
+): void {
+  logBuildActivity(buildId, `auto-intake:${step}:failed`, `Auto-intake ${step} failed: ${summarizeAutoIntakeError(error)}`);
+  logger.warn(`[reviewDesignDoc] auto-intake ${step} failed:`, error);
+}
+
 /**
  * Phases that exclude a FeatureBuild from "active" auto-resolution.
  * `abandoned` is included because abandoned builds from prior runs would


### PR DESCRIPTION
## Summary
- Fixes BI-00B7DDE2 follow-up visibility gap: `reviewDesignDoc` auto-intake failures now write BuildActivity rows instead of disappearing into `console.warn`.
- Keeps the already-shipped request-scope-independent epic path intact and puts the failure recorder in the existing Build Studio tool-helper module so `mcp-tools.ts` does not grow past the module-size ratchet.
- Covers all four auto-intake anchors: epic, backlog item, constrained goal, and taxonomy anchor.

## Test plan
- [x] Red first: `pnpm --filter web exec vitest run lib/integrate/auto-intake-activity.test.ts` failed before helper existed.
- [x] Targeted green: `pnpm --filter web exec vitest run lib/integrate/auto-intake-activity.test.ts lib/integrate/auto-intake-epic.test.ts` — 2 files, 5 tests passed.
- [x] Broader green: `pnpm --filter web exec vitest run lib/mcp-tools.test.ts lib/integrate/auto-intake-activity.test.ts lib/integrate/auto-intake-epic.test.ts` — 3 files, 40 tests passed.
- [x] Module-size guard: `node scripts/check-module-size.mjs` passed.
- [x] Direct typecheck: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec tsc --noEmit --pretty false` passed.
- [x] Pre-commit: gitleaks secret scan passed; scoped typecheck passed.
- [x] Local merged-code pregate: `pnpm run pregate` passed lease `NPEL-4A58143336`, including migrations, full web Vitest, and production build, for commit `73dfe8eb3c2883b2e3f0978ba0aa1b509fe49711`.

## Notes
- The package wrapper `pnpm --filter web typecheck` generated route types successfully but SIGTERM'd `tsc` in this worktree shell; direct `tsc --noEmit`, pre-commit scoped typecheck, and local-CI production build TypeScript all passed.
- Process-Spine-Decision is in the commit trailer: no new spec/plan because this is regression-only visibility hardening for an existing Build Studio auto-intake contract.
