### PR TITLE
fix: triage issue-backed discovery entities

### DIFF
--- a/apps/web/lib/actions/agent-task-scheduler-summary.test.ts
+++ b/apps/web/lib/actions/agent-task-scheduler-summary.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { extractDiscoveryTriageSummary } from "./agent-task-scheduler-summary";
+
+describe("extractDiscoveryTriageSummary wrapped tool results", () => {
+  it("reads triage metrics from MCP tool-result payloads wrapped under data", () => {
+    const summary = extractDiscoveryTriageSummary([
+      {
+        name: "run_discovery_triage",
+        args: { trigger: "cadence" },
+        result: {
+          success: true,
+          message: "Discovery triage processed 3 entities with 0 auto-attributed.",
+          data: {
+            success: true,
+            message: "Discovery triage processed 3 entities with 0 auto-attributed.",
+            data: {
+              trigger: "cadence",
+              processedAt: "2026-07-15T08:01:13.034Z",
+              runIdempotencyKey: "2026-07-15:inventory-specialist:cadence",
+              metrics: {
+                processed: 3,
+                decisionsCreated: 3,
+                autoAttributed: 0,
+                humanReview: 2,
+                taxonomyGap: 0,
+                needsMoreEvidence: 1,
+                dismissed: 0,
+                escalationQueueDepth: 2,
+                repeatUnresolved: 3,
+                autoApplyRate: 0,
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(summary?.compactStatus).toContain("processed=3");
+    expect(summary?.compactStatus).toContain("escalations=2");
+    expect(summary?.payload?.metrics).toMatchObject({ decisionsCreated: 3 });
+  });
+});

--- a/apps/web/lib/actions/agent-task-scheduler-summary.ts
+++ b/apps/web/lib/actions/agent-task-scheduler-summary.ts
@@ -77,6 +77,12 @@ function asBoolean(value: unknown): boolean | null {
   return typeof value === "boolean" ? value : null;
 }
 
+function unwrapToolData(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  if (isRecord(value.metrics)) return value;
+  return isRecord(value.data) ? value.data : value;
+}
+
 function asPositiveNumberRecord(value: unknown): Record<string, number> | null {
   if (!isRecord(value)) return null;
   const entries = Object.entries(value)
@@ -101,18 +107,19 @@ export function extractDiscoveryTriageSummary(
 ): ScheduledTaskSummary | null {
   const triageTool = [...executedTools]
     .reverse()
-    .find((entry) => entry.name === "run_discovery_triage" && entry.result.success && isRecord(entry.result.data));
+    .find((entry) => entry.name === "run_discovery_triage" && entry.result.success && Boolean(unwrapToolData(entry.result.data)));
 
-  if (!triageTool || !isRecord(triageTool.result.data)) {
+  const triageData = unwrapToolData(triageTool?.result.data);
+  if (!triageData) {
     return null;
   }
 
-  const trigger = triageTool.result.data.trigger === "volume" ? "volume" : "cadence";
-  const processedAt = asString(triageTool.result.data.processedAt) ?? new Date().toISOString();
-  const runIdempotencyKey = asString(triageTool.result.data.runIdempotencyKey);
-  const skipped = asBoolean(triageTool.result.data.skipped) ?? false;
-  const skipReason = asString(triageTool.result.data.skipReason);
-  const metrics = isRecord(triageTool.result.data.metrics) ? triageTool.result.data.metrics : {};
+  const trigger = triageData.trigger === "volume" ? "volume" : "cadence";
+  const processedAt = asString(triageData.processedAt) ?? new Date().toISOString();
+  const runIdempotencyKey = asString(triageData.runIdempotencyKey);
+  const skipped = asBoolean(triageData.skipped) ?? false;
+  const skipReason = asString(triageData.skipReason);
+  const metrics = isRecord(triageData.metrics) ? triageData.metrics : {};
 
   const payload: DiscoveryTriageSummaryPayload = {
     trigger,

--- a/apps/web/lib/discovery-triage-runner.test.ts
+++ b/apps/web/lib/discovery-triage-runner.test.ts
@@ -190,6 +190,42 @@ describe("runDiscoveryTriagePass", () => {
     expect(result.metrics.repeatUnresolved).toBe(1);
   });
 
+  it("triages entities referenced by open quality issues even when their attribution status is not already queued", async () => {
+    const db = createRunnerDb();
+    db.inventoryEntity.findMany.mockResolvedValue([
+      makeAmbiguousEntity("issue-backed-entity", {
+        attributionStatus: "attributed",
+        attributionConfidence: 0.97,
+      }),
+    ]);
+    db.portfolioQualityIssue.findMany.mockResolvedValue([
+      {
+        id: "issue-backed-1",
+        issueType: "name_not_promotable",
+        inventoryEntityId: "issue-backed-entity",
+        summary: "Name cannot be promoted without triage.",
+      },
+    ]);
+
+    const result = await runDiscoveryTriagePass(db);
+
+    expect(db.inventoryEntity.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        OR: expect.arrayContaining([
+          { id: { in: ["issue-backed-entity"] } },
+        ]),
+      }),
+    }));
+    expect(db.discoveryTriageDecision.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        inventoryEntityId: "issue-backed-entity",
+        qualityIssueId: "issue-backed-1",
+      }),
+    });
+    expect(result.metrics.processed).toBe(1);
+    expect(result.metrics.repeatUnresolved).toBe(1);
+  });
+
   it("uses bounded review for ambiguous packets and records schema drops without blocking deterministic decisions", async () => {
     const db = createRunnerDb();
     db.inventoryEntity.findMany.mockResolvedValue([

--- a/apps/web/lib/discovery-triage-runner.ts
+++ b/apps/web/lib/discovery-triage-runner.ts
@@ -287,24 +287,28 @@ export async function runDiscoveryTriagePass(
   const thresholds = options.thresholds ?? DEFAULT_DISCOVERY_TRIAGE_THRESHOLDS;
   const processedAt = (options.now ?? new Date()).toISOString();
 
-  const [entities, issues] = await Promise.all([
-    db.inventoryEntity.findMany({
-      where: {
-        OR: [
-          { attributionStatus: "needs_review" },
-          { attributionConfidence: { lt: thresholds.coworkerAutoApply } },
-        ],
-      },
-      orderBy: [{ lastSeenAt: "desc" }],
-    }),
-    db.portfolioQualityIssue.findMany({
-      where: {
-        status: "open",
-        inventoryEntityId: { not: null },
-      },
-      orderBy: [{ lastDetectedAt: "desc" }],
-    }),
-  ]);
+  const issues = await db.portfolioQualityIssue.findMany({
+    where: {
+      status: "open",
+      inventoryEntityId: { not: null },
+    },
+    orderBy: [{ lastDetectedAt: "desc" }],
+  });
+  const issueEntityIds = Array.from(new Set(
+    issues
+      .map((issue) => issue.inventoryEntityId)
+      .filter((id): id is string => typeof id === "string" && id.length > 0),
+  ));
+  const entities = await db.inventoryEntity.findMany({
+    where: {
+      OR: [
+        { attributionStatus: "needs_review" },
+        { attributionConfidence: { lt: thresholds.coworkerAutoApply } },
+        ...(issueEntityIds.length > 0 ? [{ id: { in: issueEntityIds } }] : []),
+      ],
+    },
+    orderBy: [{ lastSeenAt: "desc" }],
+  });
 
   const taxonomyNodeIdByCandidate = await loadTaxonomyNodeLookup(db, entities);
   const issueByEntityId = new Map(


### PR DESCRIPTION
## Summary
- include inventory entities referenced by open PortfolioQualityIssue rows in discovery triage candidate selection
- unwrap nested MCP tool-result payloads in scheduled discovery-triage summaries so processed/decision counts are not reported as zero
- add regression tests for issue-backed triage selection and wrapped summary extraction

## Evidence
- Live-state diagnosis on 2026-07-15: scheduled task `discovery-taxonomy-gap-triage-daily` was active and completed at 08:00 UTC, but `run_discovery_triage` only processed 3 entities while 250 open quality issues referenced 208 distinct inventory entities; total matching open quality issues were 675.
- Live candidate-count check after patch predicate: old_candidate_count=3, issue_backed_entity_count=208, new_candidate_count=208.
- Focused tests: `pnpm --filter web exec vitest run lib/discovery-triage-runner.test.ts lib/actions/agent-task-scheduler-summary.test.ts lib/actions/agent-task-scheduler.test.ts` — 37 passed.
- Module-size guard: `node scripts/check-module-size.mjs` — passed.
- Typecheck: `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec tsc --noEmit --pretty false` — passed.
- Local-CI pregate: lease `NPEL-A7ADA5D99F` passed for `4b945f95142a57e2f3917675e48031c05a31858a` (migrations, full web Vitest, production build).

## Notes
- Work item: BI-3552C6EA.
- Build Studio promotion tool was not exposed in this Codex session, so this was implemented externally with MCP backlog evidence.
- Worktree bootstrap reported `FAILED_SMOKE` on the kernel-principle smoke, while core worktree seeding and compile-ready checks completed.

Process-Spine-Decision: Existing BI plus regression tests cover the durable process artifact for this bounded scheduler/runner bug; no new spec/plan is needed.