### PR TITLE
fix: complete coworker decisions wiki alias

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/decisions/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/decisions/page.tsx
@@ -2,7 +2,7 @@
 // split by governance tier (WWMD / WWWD / WSID). Answers "is the decision
 // gate actually being used, and what did it decide?" — per-tier usage stats
 // up top, the decision timeline below, drill-in per row.
-// Server component; queries Prisma directly (same pattern as /wiki).
+// Server component; queries Prisma directly (same pattern as the decision-governance hub).
 
 import Link from "next/link";
 import { prisma } from "@dpf/db";

--- a/apps/web/app/(shell)/coworker-decisions/perspectives/[profileId]/voice/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/perspectives/[profileId]/voice/page.tsx
@@ -1,5 +1,5 @@
 // Voice profile admin page — wiki context.
-// Route: /wiki/perspectives/[profileId]/voice
+// Route: /coworker-decisions/perspectives/[profileId]/voice
 //
 // Surfaces consent capture, reference audio upload, and enable/disable
 // toggle for WWMD/WWTD decision perspective personas.
@@ -51,7 +51,7 @@ export default async function VoiceProfileAdminPage({ params }: { params: Params
     <div className="mx-auto max-w-2xl px-4 py-8">
       {/* Breadcrumb */}
       <nav className="mb-6 flex items-center gap-2 text-sm text-muted-foreground">
-        <Link href="/coworker-decisions" className="hover:text-foreground">Wiki</Link>
+        <Link href="/coworker-decisions" className="hover:text-foreground">Coworker Decisions</Link>
         <span>/</span>
         <Link href="/coworker-decisions/perspectives" className="hover:text-foreground">Perspectives</Link>
         <span>/</span>

--- a/apps/web/app/(shell)/coworker-decisions/perspectives/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/perspectives/page.tsx
@@ -1,5 +1,5 @@
 // EP-WIKI-001 Phase 6a: Decision Perspective Profiles index.
-// Route: /wiki/perspectives
+// Route: /coworker-decisions/perspectives
 //
 // Lists all active decision perspective profiles with links to each
 // profile's voice configuration page. Entry point for voice admin.

--- a/apps/web/app/(shell)/coworker-decisions/review/actions.ts
+++ b/apps/web/app/(shell)/coworker-decisions/review/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-// Answer-once action behind the /wiki/review ask-when-silent loop (BI-3AAB96E9).
+// Answer-once action behind the /coworker-decisions/review ask-when-silent loop (BI-3AAB96E9).
 //
 // When evaluate_org_business_decision defers because the org has no recorded
 // stance, the gap surfaces here. Answering it once routes the confirmed answer

--- a/apps/web/app/(shell)/wiki/[...slug]/page.test.ts
+++ b/apps/web/app/(shell)/wiki/[...slug]/page.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+import WikiAliasSlugRedirect from "./page";
+
+const redirectMock = vi.hoisted(() => vi.fn((target: string) => {
+  throw new Error(`redirect:${target}`);
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+describe("WikiAliasSlugRedirect", () => {
+  it("redirects legacy wiki child paths to the renamed coworker decisions path", async () => {
+    await expect(
+      WikiAliasSlugRedirect({ params: Promise.resolve({ slug: ["stance"] }) }),
+    ).rejects.toThrow("redirect:/coworker-decisions/stance");
+    expect(redirectMock).toHaveBeenCalledWith("/coworker-decisions/stance");
+  });
+
+  it("preserves nested wiki child paths", async () => {
+    await expect(
+      WikiAliasSlugRedirect({ params: Promise.resolve({ slug: ["perspectives", "P-1", "voice"] }) }),
+    ).rejects.toThrow("redirect:/coworker-decisions/perspectives/P-1/voice");
+    expect(redirectMock).toHaveBeenCalledWith("/coworker-decisions/perspectives/P-1/voice");
+  });
+});

--- a/apps/web/app/(shell)/wiki/[...slug]/page.tsx
+++ b/apps/web/app/(shell)/wiki/[...slug]/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from "next/navigation";
+
+type Params = Promise<{ slug: string[] }>;
+
+export default async function WikiAliasSlugRedirect({ params }: { params: Params }) {
+  const { slug } = await params;
+  redirect(`/coworker-decisions/${slug.map(encodeURIComponent).join("/")}`);
+}

--- a/apps/web/app/(shell)/wiki/page.test.ts
+++ b/apps/web/app/(shell)/wiki/page.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+
+import WikiAliasRedirect from "./page";
+
+const redirectMock = vi.hoisted(() => vi.fn((target: string) => {
+  throw new Error(`redirect:${target}`);
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+describe("WikiAliasRedirect", () => {
+  it("redirects the legacy wiki root to the coworker decisions surface", () => {
+    expect(() => WikiAliasRedirect()).toThrow("redirect:/coworker-decisions");
+    expect(redirectMock).toHaveBeenCalledWith("/coworker-decisions");
+  });
+});

--- a/apps/web/app/(shell)/wiki/page.tsx
+++ b/apps/web/app/(shell)/wiki/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function WikiAliasRedirect() {
+  redirect("/coworker-decisions");
+}

--- a/apps/web/components/onboarding/HowYouDecideCards.tsx
+++ b/apps/web/components/onboarding/HowYouDecideCards.tsx
@@ -5,8 +5,9 @@
 // scenario cards, every one pre-answered from the archetype, one-click
 // "Confirm all" fast path (<60s), per-card inline adjust as the only second
 // level. No platform vocabulary — no classes, weights, or grades. Mounted in
-// two places: the "how-you-decide" setup step routes to /wiki/stance, and the
-// same cards stay there afterwards for later adjustment.
+// two places: the "how-you-decide" setup step routes to
+// /coworker-decisions/stance, and the same cards stay there afterwards for
+// later adjustment.
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";

--- a/apps/web/components/wiki/DecisionAuditTable.tsx
+++ b/apps/web/components/wiki/DecisionAuditTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-// Decision-ledger table for /wiki/decisions. Server page fetches the rows;
+// Decision-ledger table for /coworker-decisions/decisions. Server page fetches the rows;
 // this client child composes the report-kit DataTable per its server-page →
 // client-table contract.
 

--- a/apps/web/components/wiki/WikiPageEditor.tsx
+++ b/apps/web/components/wiki/WikiPageEditor.tsx
@@ -40,7 +40,7 @@ const MODE_TITLES: Record<WikiPageEditorProps["mode"], string> = {
 };
 
 const MODE_HELPERS: Record<WikiPageEditorProps["mode"], string> = {
-  create: "Creates a new org-scoped overlay page. It will appear on /wiki?status=all until you flip status to Published.",
+  create: "Creates a new org-scoped overlay page. It will appear on /coworker-decisions?status=all until you flip status to Published.",
   update: "Saves a new revision on this overlay page. The viewer route revalidates on save.",
   override:
     "Creates an org override for this kernel page. The override masks the kernel content for your org only; kernel content is untouched.",

--- a/apps/web/lib/actions/setup-constants.test.ts
+++ b/apps/web/lib/actions/setup-constants.test.ts
@@ -6,4 +6,8 @@ describe("STEP_ROUTES", () => {
     expect(STEP_ROUTES["business-context"]).toBe("/storefront/settings/business");
     expect(STEP_ROUTES["operating-hours"]).toBe("/storefront/settings/operations");
   });
+
+  it("points the decision-style setup step at the renamed coworker decisions surface", () => {
+    expect(STEP_ROUTES["how-you-decide"]).toBe("/coworker-decisions/stance");
+  });
 });

--- a/apps/web/lib/actions/setup-constants.ts
+++ b/apps/web/lib/actions/setup-constants.ts
@@ -8,7 +8,7 @@ export const SETUP_STEPS = [
   "ai-providers",        // /platform/ai/providers — configure AI providers
   "branding",            // /admin/branding — logo, colors, tagline
   "business-context",    // /storefront/settings/business — tell us about your business
-  "how-you-decide",      // /wiki/stance — confirm the archetype-prefilled stance cards (BI-D6DC2432)
+  "how-you-decide",      // /coworker-decisions/stance — confirm the archetype-prefilled stance cards (BI-D6DC2432)
   "operating-hours",     // /storefront/settings/operations — business hours
   "storefront",          // /storefront — customer-facing portal setup
   "platform-development",// /admin/platform-development — contribution mode
@@ -21,7 +21,7 @@ export const STEP_ROUTES: Record<string, string> = {
   "ai-providers": "/platform/ai/providers",
   "branding": "/admin/branding",
   "business-context": "/storefront/settings/business",
-  "how-you-decide": "/wiki/stance",
+  "how-you-decide": "/coworker-decisions/stance",
   "operating-hours": "/storefront/settings/operations",
   "storefront": "/storefront",
   "platform-development": "/admin/platform-development",

--- a/apps/web/lib/actions/stance-confirm.ts
+++ b/apps/web/lib/actions/stance-confirm.ts
@@ -159,8 +159,8 @@ export async function confirmStanceVectors(input: {
       if (promoted.ok) upgradedIdentityPages += 1;
     }
 
-    revalidatePath("/wiki/stance");
-    revalidatePath("/wiki");
+    revalidatePath("/coworker-decisions/stance");
+    revalidatePath("/coworker-decisions");
     return { ok: true, confirmedVectors: v.vectors.length, upgradedIdentityPages };
   } catch (err) {
     return { ok: false, error: (err as Error).message || "Could not confirm the stances." };

--- a/apps/web/lib/actions/wiki-edit.ts
+++ b/apps/web/lib/actions/wiki-edit.ts
@@ -256,7 +256,7 @@ export async function saveWikiOverlayEdit(
       title: input.title.trim(),
       body: input.body,
       changeKind: "manual",
-      changeSummary: input.changeSummary ?? "Manual edit via /wiki/<slug>/edit",
+      changeSummary: input.changeSummary ?? "Manual edit via /coworker-decisions/<slug>/edit",
       createdById: user.id,
     });
 

--- a/apps/web/lib/actions/wiki-publish.ts
+++ b/apps/web/lib/actions/wiki-publish.ts
@@ -13,7 +13,7 @@
 //     session's organization are publishable.
 //
 // Every flip appends a `WikiPageRevision` with `changeKind = "manual"` and
-// `changeSummary = "Publish via /wiki?status=all batch"` so the revision log
+// `changeSummary = "Publish via /coworker-decisions?status=all batch"` so the revision log
 // records who approved each page.
 
 import { prisma } from "@dpf/db";

--- a/apps/web/lib/attention/sources/sources.test.ts
+++ b/apps/web/lib/attention/sources/sources.test.ts
@@ -78,7 +78,7 @@ describe("aiDecisionToAttentionItem", () => {
       isAgentInternalKernelConsult({
         buildId: null,
         taskRunId: null,
-        routeContext: "/wiki/decisions",
+        routeContext: "/coworker-decisions/decisions",
         domainClass: "plan-readiness",
       }),
     ).toBe(false);

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 548,
+  "routeCount": 550,
   "routes": [
     {
       "routePath": "/",
@@ -6322,6 +6322,28 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/welcome/page.tsx"
+    },
+    {
+      "routePath": "/wiki",
+      "kind": "page",
+      "segments": [
+        "wiki"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/wiki/page.tsx",
+      "redirectTo": "/coworker-decisions"
+    },
+    {
+      "routePath": "/wiki/[...slug]",
+      "kind": "page",
+      "segments": [
+        "wiki",
+        "[...slug]"
+      ],
+      "dynamicParams": [
+        "slug"
+      ],
+      "file": "apps/web/app/(shell)/wiki/[...slug]/page.tsx"
     },
     {
       "routePath": "/workbooks",

--- a/apps/web/lib/mcp/packs/founder-review-pack.ts
+++ b/apps/web/lib/mcp/packs/founder-review-pack.ts
@@ -1,6 +1,6 @@
 // Founder / decision-review reads (BI-3786CF82, EP-0AF96937 review-and-adjust loop).
 //
-// The /wiki Decision Governance hub shows counts of "open reviews" — unresolved
+// The /coworker-decisions Decision Governance hub shows counts of "open reviews" — unresolved
 // DecisionInteraction rows (outcomeType defer/escalate) awaiting a human — but no
 // coworker-callable tool surfaced them, so a coworker asked "what should we do
 // about these open reviews?" had nothing to read and told the user to paste the
@@ -34,7 +34,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "list_open_decision_reviews",
     description:
-      "List the OPEN DECISION REVIEWS shown on the /wiki Decision Governance hub — decisions your AI workforce deferred or escalated to a human and that are still unresolved. Returns each review's question, discipline (WWMD platform / WWWD business / WSID craft), why it is unresolved, the gap detail, a suggested next action, and a decision-canvas link. Use this to answer 'what should we do about these open reviews?' by reading and recommending on the actual queue instead of asking the user to paste the screen. Read-only: resolving a review is a human action taken in the owning workflow after reviewing the Decision Canvas evidence; this tool lets you understand and recommend.",
+      "List the OPEN DECISION REVIEWS shown on the /coworker-decisions Decision Governance hub — decisions your AI workforce deferred or escalated to a human and that are still unresolved. Returns each review's question, discipline (WWMD platform / WWWD business / WSID craft), why it is unresolved, the gap detail, a suggested next action, and a decision-canvas link. Use this to answer 'what should we do about these open reviews?' by reading and recommending on the actual queue instead of asking the user to paste the screen. Read-only: resolving a review is a human action taken in the owning workflow after reviewing the Decision Canvas evidence; this tool lets you understand and recommend.",
     inputSchema: {
       type: "object",
       properties: {
@@ -82,7 +82,7 @@ async function listOpenDecisionReviews(
     ? Math.min(Math.max(Math.trunc(rawLimit), 1), 50)
     : 20;
 
-  // Scope by discipline, mirroring the /wiki hub counts. WWWD reads off the org's
+  // Scope by discipline, mirroring the /coworker-decisions hub counts. WWWD reads off the org's
   // OWN profile (seeded at onboarding) plus the platform fallback id.
   let profileFilter: string | { startsWith: string } | { in: string[] } | undefined;
   if (discipline === "wwmd") {

--- a/apps/web/lib/mcp/packs/org-decision-pack.ts
+++ b/apps/web/lib/mcp/packs/org-decision-pack.ts
@@ -150,7 +150,7 @@ async function evaluateOrgBusinessDecision(
 // every other source uses (enrichOrgCorpus) — qa provenance, first-party
 // trust, draft-by-default per BI-1378. This closes the elicitation half of the
 // review loop: evaluate_org_business_decision surfaces where the org is silent
-// (gap findings on /wiki/review), and this tool captures the operator's answer
+// (gap findings on /coworker-decisions/review), and this tool captures the operator's answer
 // once so the silence doesn't repeat.
 async function recordOrgBusinessAnswer(
   params: Record<string, unknown>,

--- a/apps/web/lib/mcp/packs/principle-decide-pack.ts
+++ b/apps/web/lib/mcp/packs/principle-decide-pack.ts
@@ -457,7 +457,7 @@ async function principleDecide(
 
   // Persist the consult to the DecisionInteraction ledger so the decision
   // governance hub can audit that the gate is in use (per-tier log at
-  // /wiki/decisions). Fail-open: a ledger outage never blocks the
+  // /coworker-decisions/decisions). Fail-open: a ledger outage never blocks the
   // decision, but the outcome is named in the response either way.
   // This is audit observability, not a business mutation — the tool's
   // read-only annotation stays as-is (ToolExecution already logs calls;

--- a/apps/web/lib/mcp/packs/wiki-pack.ts
+++ b/apps/web/lib/mcp/packs/wiki-pack.ts
@@ -77,7 +77,7 @@ const definitions: ToolDefinition[] = [
   {
     name: "wiki_ingest",
     description:
-      "Ingest a raw source (markdown file on disk) into the wiki: upsert the RawSource row, run the three-pass LLM extraction (abstract, claim, stance/heuristic), and optionally commit the proposal as draft overlay pages under the requesting org. Kernel pages stay PR-only (spec §4). Use when the user wants to import an article into the kernel knowledge surface, or to preview what the LLM would extract from a source without writing anything. Two modes: 'propose' returns the structured proposal for review without DB writes; 'commit' runs the full pipeline and lands drafts on /wiki?status=all.",
+      "Ingest a raw source (markdown file on disk) into the wiki: upsert the RawSource row, run the three-pass LLM extraction (abstract, claim, stance/heuristic), and optionally commit the proposal as draft overlay pages under the requesting org. Kernel pages stay PR-only (spec §4). Use when the user wants to import an article into the kernel knowledge surface, or to preview what the LLM would extract from a source without writing anything. Two modes: 'propose' returns the structured proposal for review without DB writes; 'commit' runs the full pipeline and lands drafts on /coworker-decisions?status=all.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
@@ -62,7 +62,7 @@ export const STANCE_VECTOR_BUNDLES: Record<StanceVectorKey, DecisionDomainClass[
   "spend-authority": ["risk-assessment", "architecture-tradeoff"],
 };
 
-/** Org-overlay slug for a stance vector page (matches the /wiki/stance prefix). */
+/** Org-overlay slug for a stance vector page (shown under /coworker-decisions/stance). */
 export function stanceVectorSlug(key: StanceVectorKey): string {
   return `stances/${key}`;
 }

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -229,7 +229,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   // draft WikiPage/WikiPageRevision rows under the org's overlay.
   record_org_business_answer: ["registry_write"],
 
-  // Open decision reviews — the /wiki governance hub's queue of deferred/escalated
+  // Open decision reviews — the /coworker-decisions governance hub's queue of deferred/escalated
   // decisions awaiting a human. Read-only tool on the `registry_read` baseline: any
   // coworker may read and recommend on the queue; resolving stays a human action
   // in the owning workflow after reviewing Decision Canvas evidence.

--- a/apps/web/lib/wiki/capture-org-answer.ts
+++ b/apps/web/lib/wiki/capture-org-answer.ts
@@ -2,7 +2,7 @@
 //
 // One path shared by the two surfaces that elicit first-party business
 // knowledge: the `record_org_business_answer` MCP tool (a coworker captures an
-// answer mid-conversation) and the /wiki/review answer-once affordance (the
+// answer mid-conversation) and the /coworker-decisions/review answer-once affordance (the
 // operator answers a gap the gate deferred on). Both route the confirmed answer
 // through enrichOrgCorpus with qa provenance + first-party trust, landing
 // draft-by-default per BI-1378 — so nothing becomes authoritative without human

--- a/apps/web/lib/wiki/decision-review-findings.ts
+++ b/apps/web/lib/wiki/decision-review-findings.ts
@@ -33,7 +33,7 @@ export type ReviewFinding = {
   actionHref: string;
   /**
    * When set, the finding is answerable inline: the operator answers the
-   * representative question once on /wiki/review and it flows through the qa
+   * representative question once on /coworker-decisions/review and it flows through the qa
    * enricher (the record_org_business_answer path) into the org's WWWD corpus
    * as draft — closing the ask-when-silent loop instead of dead-ending at the
    * manual stance editor. Only org-business gaps (the org's own profile) are

--- a/docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md
@@ -128,8 +128,8 @@ authoring but no decision loop.
 
 ### 4.1 Rename / reframe the top-level surface
 
-- **Route:** keep `/wiki` working (redirect / alias) but introduce the surface under a
-  business-legible name. Working title **"Decision Governance"** (nav label candidates, to be
+- **Route:** keep `/wiki` working as a redirect alias, with the canonical surface under
+  `/coworker-decisions`. Working title **"Decision Governance"** (nav label candidates, to be
   confirmed with the operator: *"How Your AI Decides"*, *"Decision Center"*). The nav entry
   ([portal-navigation-model.ts:845](../../../apps/web/lib/navigation/portal-navigation-model.ts))
   changes from *"Founder kernel and per-org overlay — stances, heuristics, decisions"* to a
@@ -225,15 +225,16 @@ any phase.
   "Wiki" → "Decision governance", raw material retained as a drill-in. (PR #2575)
 - **Phase 2 — Decision Review & Adjust workspace.** ✅ (conflict + gap, PR #2575) → completion:
   `staleness` findings (stale-but-cited material) + the read-only decision **matrix** view
-  (`/wiki/matrix`). Drift (golden-decision flips) remains the one open sub-slice.
-- **Phase 3 — WWWD business-stance editor.** ✅ `/wiki/stance` — a plain-language draft authoring
+  (`/coworker-decisions/matrix`). Drift (golden-decision flips) remains the one open sub-slice.
+- **Phase 3 — WWWD business-stance editor.** ✅ `/coworker-decisions/stance` — a plain-language draft authoring
   form that writes an org-overlay `stance` page (the WWWD corpus the decision-routing block grounds
   business calls in). Closes the confirmed "no adjust UI" gap. Draft by default.
-- **Phase 4 — WSID per-role craft view + org override.** ✅ `/wiki/craft` + `/wiki/craft/[key]` —
+- **Phase 4 — WSID per-role craft view + org override.** ✅ `/coworker-decisions/craft` + `/coworker-decisions/craft/[key]` —
   per-profession view with a draft org-overlay `heuristic` override form. Does **not** depend on the
   WSID pilot-three corpus completion — it authors org overrides on top of whatever baseline exists.
-- **Phase 5 — Rename + nav + redirects + docs.** ◻ Nav label + on-page framing flipped in Phase 1;
-  the full route rename / `/wiki` alias awaits the operator's name choice (§8 Q1).
+- **Phase 5 — Rename + nav + redirects + docs.** ✅ Canonical route family renamed to
+  `/coworker-decisions`; `/wiki` remains as a thin redirect alias for legacy bookmarks and generated
+  links; active setup/tool copy now points at the canonical route.
 
 Dependency note (corrected during build): the WWWD/WSID **authoring** surfaces write org-overlay
 material and are useful immediately — the org's WWWD answers are grounded in its own org-overlay


### PR DESCRIPTION
## Summary
- point the setup "How You Decide" step and stance revalidation at the canonical `/coworker-decisions` surface
- add thin `/wiki` redirect aliases for legacy root and child paths
- update active app/tool copy and the decision-governance spec status so new agents see `/coworker-decisions` as canonical

## UX fit review — coworker decisions wiki alias

- Decision: fits-with-guardrails
- Owning area: Knowledge / AI decision governance
- Route family: canonical `/coworker-decisions`; legacy `/wiki` redirects only
- Primary persona: founder/operator trying to understand and adjust how coworkers decide
- Navigation layer touched: route alias and setup deep link; no new global nav item
- Reuse/convergence: reuses existing coworker-decisions pages/components; new `/wiki` files are redirect shims only
- Source truth: existing `WikiPage` corpus and decision-governance routes; no new model or data source
- Empty/failure behavior: legacy bookmarks and generated links land on the canonical route instead of 404
- AI boundary: no prompt-send behavior added; MCP/tool copy now points coworkers to the same canonical surface
- Required plan/spec edits: decision-governance surface spec now records Phase 5 as complete and names `/coworker-decisions` canonical
- Evidence before merge: focused route/setup tests, typecheck, module-size, and pregate listed below

UX-Fit-Decision: fits-with-guardrails; canonicalize `/coworker-decisions`, keep `/wiki` as thin redirect alias for cognitive continuity and bookmark safety.

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md`
  - `AGENTS.md` route/governance/process-spine expectations
- Current code substrate reviewed:
  - `apps/web/app/(shell)/coworker-decisions/**`
  - `apps/web/lib/actions/setup-constants.ts`
  - `apps/web/lib/actions/stance-confirm.ts`
  - active MCP/tool copy in `apps/web/lib/mcp/packs/*`
  - stale route sweep with `rg -n '/wiki|coworker-decisions' apps/web docs/superpowers/specs/2026-07-04-decision-governance-surface-redesign-design.md`
- Source of truth:
  - canonical route family is `/coworker-decisions`; `/wiki` is compatibility-only redirect alias
- Decision:
  - complete the Phase 5 rename by updating active links/revalidation/copy and adding redirect shims, without introducing a second navigable home.

Design-Grounding-Decision: reviewed decision-governance spec and current route/action/MCP substrate; localized route-alias completion, no new data contract.

Seed-Fit-Decision: global-default

## Verification
- red first: setup constants test failed with `/wiki/stance` before the route fix
- `pnpm --filter web exec vitest run lib/actions/setup-constants.test.ts 'app/(shell)/wiki/page.test.ts' 'app/(shell)/wiki/[...slug]/page.test.ts' lib/attention/sources/sources.test.ts lib/actions/wiki-edit.test.ts lib/actions/wiki-publish.test.ts lib/mcp/packs/founder-review-pack.test.ts lib/mcp/packs/wiki-pack.test.ts lib/mcp/packs/org-decision-pack.test.ts` — 9 files, 66 tests passed
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` — passed
- `pnpm check:module-size` — passed
- route manifest check — passed (`routeCount=550`)
- `pnpm run pregate` with local-CI lease `NPEL-329922F827` — passed

Backlog: BI-765B9F39
