### PR TITLE
feat(inference): origin-aware admission patience + capacity-inconclusive cert requeue (BI-44E401B5)

### DIFF
--- a/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.test.ts
@@ -122,6 +122,28 @@ describe("coworker certification runner (EP-COWORKER-LIFECYCLE Phase 2)", () => 
     );
   });
 
+  it("an inference admission timeout yields an INCONCLUSIVE run (to requeue), not a coworker failure", async () => {
+    const { deps, created } = makeDeps();
+    // Inference was at capacity: the admission wait exhausted its (patient) budget.
+    // Tagged with the admission-timeout code the runner recognizes.
+    const capacityErr = Object.assign(
+      new Error("inference admission timeout on local engine after 1800000ms (origin=autonomous)"),
+      { code: "INFERENCE_ADMISSION_TIMEOUT" },
+    );
+    (deps.runLoop as ReturnType<typeof vi.fn>).mockRejectedValue(capacityErr);
+
+    const sweep = await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });
+
+    // Not a failure — capacity backpressure is inconclusive and gets requeued.
+    expect(sweep.results[0].status).toBe("inconclusive");
+    expect(sweep.inconclusive).toBe(1);
+    expect(sweep.failed).toBe(0);
+    expect((created.runs[0] as Record<string, unknown>).status).toBe("inconclusive");
+    // every journey flagged capacity-inconclusive, and NO failure findings filed
+    expect(sweep.results[0].journeys.every((j) => j.capacityInconclusive)).toBe(true);
+    expect((created.findings as Array<unknown>).length).toBe(0);
+  });
+
   it("a recovered oracle is absent-cleaned via updateMany scoped to the agent", async () => {
     const { deps, updateManyCalls } = makeDeps();
     await runCoworkerCertificationSweep({ agentIds: ["coo"], deps });

--- a/apps/web/lib/coworker-lifecycle/certification-runner.ts
+++ b/apps/web/lib/coworker-lifecycle/certification-runner.ts
@@ -35,6 +35,7 @@ import {
 
 import { COWORKER_CERT_ADAPTER_KEY } from "./certification-status";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { isAdmissionTimeout } from "@/lib/inference/inference-admission";
 
 export { COWORKER_CERT_ADAPTER_KEY };
 export const COWORKER_CERT_ADAPTER_VERSION = "1.0.0";
@@ -43,6 +44,10 @@ export type JourneyResult = {
   journeyId: string;
   mode: GoldenJourney["mode"];
   passed: boolean;
+  /** The journey could not be assessed because inference was at capacity and the
+   *  admission wait was exhausted — capacity backpressure, NOT a substantive
+   *  failure of the coworker. Such a run is requeued, never scored as a failure. */
+  capacityInconclusive: boolean;
   verdicts: OracleVerdict[];
   executedToolNames: string[];
   downgraded: boolean;
@@ -51,7 +56,9 @@ export type JourneyResult = {
 
 export type CoworkerCertificationResult = {
   agentId: string;
-  status: "passed" | "failed";
+  // "inconclusive" = at least one journey hit capacity backpressure and there was
+  // no genuine failure; the run is requeued rather than passing or failing.
+  status: "passed" | "failed" | "inconclusive";
   runId: string;
   journeys: JourneyResult[];
 };
@@ -62,6 +69,8 @@ export type CertificationSweepResult = {
   results: CoworkerCertificationResult[];
   passed: number;
   failed: number;
+  /** Runs left unresolved by inference capacity (not failures) — to be requeued. */
+  inconclusive: number;
 };
 
 /** First route bound to the agent in ROUTE_AGENT_MAP; workspace as fallback. */
@@ -188,12 +197,29 @@ async function executeJourney(
       journeyId: journey.journeyId,
       mode: journey.mode,
       passed: journeyPassed(verdicts),
+      capacityInconclusive: false,
       verdicts,
       executedToolNames: [...new Set(loop.executedTools.map((t) => t.name))],
       downgraded: loop.downgraded,
       durationMs: deps.now().getTime() - startedAt,
     };
   } catch (error) {
+    // Capacity backpressure, not a coworker failure: the engine was at its
+    // ceiling and the (patient, autonomous) admission wait was exhausted. Mark
+    // the journey inconclusive with NO failure verdicts, so the run is requeued
+    // and the coworker is never wrongly failed for a busy box.
+    if (isAdmissionTimeout(error)) {
+      return {
+        journeyId: journey.journeyId,
+        mode: journey.mode,
+        passed: false,
+        capacityInconclusive: true,
+        verdicts: [],
+        executedToolNames: [],
+        downgraded: false,
+        durationMs: deps.now().getTime() - startedAt,
+      };
+    }
     const message = getErrorMessage(error);
     const verdicts = evaluateJourneyOracles({
       content: "",
@@ -206,6 +232,7 @@ async function executeJourney(
       journeyId: journey.journeyId,
       mode: journey.mode,
       passed: false,
+      capacityInconclusive: false,
       verdicts,
       executedToolNames: [],
       downgraded: false,
@@ -224,7 +251,17 @@ async function persistCoworkerRun(
   deps: CertificationDeps,
 ): Promise<CoworkerCertificationResult> {
   const at = deps.now();
-  const status: "passed" | "failed" = journeys.every((j) => j.passed) ? "passed" : "failed";
+  // A GENUINE failure (a journey that ran and failed an oracle) trumps capacity
+  // backpressure — a broken coworker must not hide behind a busy box. Only a run
+  // with no genuine failures but some capacity-inconclusive journeys is
+  // "inconclusive" (requeued); an all-passed run is "passed".
+  const genuineFailure = journeys.some((j) => !j.passed && !j.capacityInconclusive);
+  const anyInconclusive = journeys.some((j) => j.capacityInconclusive);
+  const status: "passed" | "failed" | "inconclusive" = genuineFailure
+    ? "failed"
+    : anyInconclusive
+      ? "inconclusive"
+      : "passed";
   const runId = `assurance_coworker_cert_${agentId}_${at.toISOString().replace(/[^a-zA-Z0-9]/g, "_")}`;
 
   await deps.db.assuranceRun.create({
@@ -242,6 +279,7 @@ async function persistCoworkerRun(
         journeys: journeys.map((j) => ({
           journeyId: j.journeyId,
           passed: j.passed,
+          capacityInconclusive: j.capacityInconclusive,
           executedToolNames: j.executedToolNames,
           downgraded: j.downgraded,
           durationMs: j.durationMs,
@@ -328,7 +366,7 @@ export async function runCoworkerCertificationSweep(options?: {
 
   const userContext = await resolveCertificationUserContext(deps.db);
   if (!userContext) {
-    return { startedAt, completedAt: deps.now(), results: [], passed: 0, failed: 0 };
+    return { startedAt, completedAt: deps.now(), results: [], passed: 0, failed: 0, inconclusive: 0 };
   }
 
   const results: CoworkerCertificationResult[] = [];
@@ -346,6 +384,7 @@ export async function runCoworkerCertificationSweep(options?: {
     results,
     passed: results.filter((r) => r.status === "passed").length,
     failed: results.filter((r) => r.status === "failed").length,
+    inconclusive: results.filter((r) => r.status === "inconclusive").length,
   };
 }
 

--- a/apps/web/lib/inference/inference-admission.test.ts
+++ b/apps/web/lib/inference/inference-admission.test.ts
@@ -5,6 +5,7 @@ import {
   currentInferenceOrigin,
   engineKeyForProvider,
   getInferenceAdmissionSnapshot,
+  isAdmissionTimeout,
   resolveEngineLimit,
   withInferenceOrigin,
 } from "./inference-admission";
@@ -13,6 +14,7 @@ const ENV_KEYS = [
   "DPF_INFERENCE_MAX_CONCURRENCY_LOCAL",
   "DPF_INFERENCE_MAX_CONCURRENCY_REMOTE",
   "DPF_INFERENCE_ADMISSION_TIMEOUT_MS",
+  "DPF_INFERENCE_ADMISSION_TIMEOUT_MS_AUTONOMOUS",
 ] as const;
 
 const savedEnv: Record<string, string | undefined> = {};
@@ -151,15 +153,46 @@ describe("acquireInferenceSlot", () => {
     expect(getInferenceAdmissionSnapshot().local.active).toBe(0);
   });
 
-  it("times out a waiter that never gets a slot", async () => {
+  it("times out an interactive waiter via the interactive budget, tagged isAdmissionTimeout", async () => {
     process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL = "1";
     process.env.DPF_INFERENCE_ADMISSION_TIMEOUT_MS = "20";
+    const r1 = await acquireInferenceSlot("local", "interactive");
+    let caught: unknown;
+    await acquireInferenceSlot("local", "interactive").catch((e) => (caught = e));
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/admission timeout/);
+    // the capacity-timeout is tagged so callers (e.g. cert) can requeue not fail
+    expect(isAdmissionTimeout(caught)).toBe(true);
+    expect(getInferenceAdmissionSnapshot().local.interactiveWaiting).toBe(0);
+    r1();
+  });
+
+  it("times out an autonomous waiter via its OWN (autonomous) budget", async () => {
+    process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL = "1";
+    process.env.DPF_INFERENCE_ADMISSION_TIMEOUT_MS_AUTONOMOUS = "20";
     const r1 = await acquireInferenceSlot("local", "autonomous");
     await expect(acquireInferenceSlot("local", "autonomous")).rejects.toThrow(
       /admission timeout/,
     );
-    // the timed-out waiter is removed from the queue
     expect(getInferenceAdmissionSnapshot().local.autonomousWaiting).toBe(0);
     r1();
+  });
+
+  it("autonomous is PATIENT: it ignores the tight interactive budget and waits for a slot", async () => {
+    process.env.DPF_INFERENCE_MAX_CONCURRENCY_LOCAL = "1";
+    // A tiny INTERACTIVE budget must NOT time out autonomous work; autonomous has
+    // its own generous budget, so the waiter holds and is served when a slot frees.
+    process.env.DPF_INFERENCE_ADMISSION_TIMEOUT_MS = "20";
+    process.env.DPF_INFERENCE_ADMISSION_TIMEOUT_MS_AUTONOMOUS = "5000";
+    const r1 = await acquireInferenceSlot("local", "autonomous");
+    const waiting = acquireInferenceSlot("local", "autonomous");
+    await tick();
+    // still queued well past the 20ms interactive budget — not turned away
+    await new Promise((r) => setTimeout(r, 60));
+    expect(getInferenceAdmissionSnapshot().local.autonomousWaiting).toBe(1);
+    r1(); // free the slot — the patient waiter is now served
+    const r2 = await waiting;
+    expect(getInferenceAdmissionSnapshot().local.autonomousWaiting).toBe(0);
+    r2();
   });
 });

--- a/apps/web/lib/inference/inference-admission.ts
+++ b/apps/web/lib/inference/inference-admission.ts
@@ -71,15 +71,43 @@ export function resolveEngineLimit(engineKey: EngineKey): number {
   return engineKey === "local" ? 1 : 8;
 }
 
-/** Max time a caller will wait for a slot before giving up. A safety net against
- *  a leaked release, not a routine path — with interactive priority and the
- *  serial autonomous dispatcher, sustained saturation is not expected on a
- *  single-operator install. */
-function resolveAcquireTimeoutMs(): number {
-  const raw = process.env.DPF_INFERENCE_ADMISSION_TIMEOUT_MS;
+/** Error code stamped on an admission-timeout rejection so a caller can treat a
+ *  capacity backpressure timeout distinctly from a substantive failure — e.g. a
+ *  coworker-certification journey should REQUEUE on this, not fail the coworker. */
+export const ADMISSION_TIMEOUT_CODE = "INFERENCE_ADMISSION_TIMEOUT" as const;
+type AdmissionTimeoutError = Error & { code?: string };
+
+/** True when `err` is an inference admission timeout (the engine was at capacity
+ *  and the wait exceeded the origin's budget) — capacity backpressure, NOT a
+ *  substantive failure of the work itself. */
+export function isAdmissionTimeout(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err as AdmissionTimeoutError).code === ADMISSION_TIMEOUT_CODE
+  );
+}
+
+/** Max time a caller will wait for a slot before giving up — ORIGIN-AWARE.
+ *
+ *  `interactive` keeps a tight budget: a human is waiting, so failing fast beats
+ *  hanging. `autonomous` (certification / background / long-running deliverable
+ *  work) is patient: no human is blocked, so it waits through capacity contention
+ *  and runs when a slot frees — the priority queue is the booking system, so we
+ *  maximize utilization rather than turn autonomous work away. Both stay bounded
+ *  as a safety net against a leaked release; the autonomous ceiling is a backstop
+ *  (callers such as cert REQUEUE on it, they do not fail). Tune per install via
+ *  DPF_INFERENCE_ADMISSION_TIMEOUT_MS (interactive) and
+ *  DPF_INFERENCE_ADMISSION_TIMEOUT_MS_AUTONOMOUS (autonomous). */
+function resolveAcquireTimeoutMs(origin: InferenceOrigin): number {
+  const raw =
+    origin === "autonomous"
+      ? process.env.DPF_INFERENCE_ADMISSION_TIMEOUT_MS_AUTONOMOUS
+      : process.env.DPF_INFERENCE_ADMISSION_TIMEOUT_MS;
   const parsed = raw != null && raw.trim() !== "" ? Number(raw) : NaN;
   if (Number.isFinite(parsed) && parsed > 0) return Math.trunc(parsed);
-  return 120_000;
+  // Interactive: fail fast (human waiting). Autonomous: patient (30 min) — long
+  // enough to wait out real contention, bounded enough to catch a stuck slot.
+  return origin === "autonomous" ? 1_800_000 : 120_000;
 }
 
 interface Waiter {
@@ -148,16 +176,17 @@ export async function acquireInferenceSlot(
       timer: null,
       enqueuedAt: startedWaiting,
     };
+    const timeoutMs = resolveAcquireTimeoutMs(origin);
     waiter.timer = setTimeout(() => {
       removeWaiter(s, waiter);
-      reject(
-        new Error(
-          `inference admission timeout on ${engineKey} engine after ` +
-            `${resolveAcquireTimeoutMs()}ms (origin=${origin}` +
-            `${opts?.providerId ? `, provider=${opts.providerId}` : ""})`,
-        ),
+      const err: AdmissionTimeoutError = new Error(
+        `inference admission timeout on ${engineKey} engine after ` +
+          `${timeoutMs}ms (origin=${origin}` +
+          `${opts?.providerId ? `, provider=${opts.providerId}` : ""})`,
       );
-    }, resolveAcquireTimeoutMs());
+      err.code = ADMISSION_TIMEOUT_CODE;
+      reject(err);
+    }, timeoutMs);
     (origin === "interactive" ? s.interactiveQ : s.autonomousQ).push(waiter);
   });
 

--- a/apps/web/lib/queue/functions/coworker-certification.ts
+++ b/apps/web/lib/queue/functions/coworker-certification.ts
@@ -10,20 +10,48 @@
 //
 // Mirrors patch-assessment-sweep.ts: pure exported sweep + thin Inngest
 // wrappers (cron + run-now event) behind the quiescence gate.
+//
+// Capacity backpressure (BI-44E401B5): a journey that cannot be assessed because
+// inference was at its concurrency ceiling is NOT a coworker failure. The sweep
+// marks it "inconclusive"; the wrapper then sleeps and re-runs only the still-
+// inconclusive coworkers, so they are certified when a slot frees rather than
+// wrongly failed on a busy box — the queue is the booking system, we do not turn
+// autonomous work away. Bounded so a persistently-saturated box eventually stops
+// (those coworkers stay un-promoted, never failed).
 
 import { cron } from "inngest";
 import { inngest } from "../inngest-client";
 import { gateAtEntry } from "../quiescence-gates";
 
-export async function runCoworkerCertificationJob() {
+/** Max capacity-backpressure requeue attempts, and the sleep between them. With
+ *  the origin-aware admission budget (autonomous waits ~30m per call) this covers
+ *  a long saturation window before giving up for the night. */
+const MAX_CAPACITY_REQUEUES = 6;
+const CAPACITY_REQUEUE_BACKOFF = "10m";
+
+export type CoworkerCertificationJobResult = {
+  passed: number;
+  failed: number;
+  inconclusive: number;
+  agents: Array<{ agentId: string; status: "passed" | "failed" | "inconclusive" }>;
+  inconclusiveAgentIds: string[];
+};
+
+export async function runCoworkerCertificationJob(
+  agentIds?: string[],
+): Promise<CoworkerCertificationJobResult> {
   const { runCoworkerCertificationSweep } = await import(
     "@/lib/coworker-lifecycle/certification-runner"
   );
-  const sweep = await runCoworkerCertificationSweep();
+  const sweep = await runCoworkerCertificationSweep(agentIds ? { agentIds } : undefined);
   return {
     passed: sweep.passed,
     failed: sweep.failed,
+    inconclusive: sweep.inconclusive,
     agents: sweep.results.map((r) => ({ agentId: r.agentId, status: r.status })),
+    inconclusiveAgentIds: sweep.results
+      .filter((r) => r.status === "inconclusive")
+      .map((r) => r.agentId),
   };
 }
 
@@ -38,7 +66,22 @@ export const coworkerCertificationNightly = inngest.createFunction(
   async ({ step }) => {
     const gate = await gateAtEntry(step);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
-    return await step.run("coworker-certification", runCoworkerCertificationJob);
+    // Full roster, then requeue only capacity-inconclusive coworkers (below).
+    let agentIds: string[] | undefined = undefined;
+    let last = await step.run("coworker-certification", () =>
+      runCoworkerCertificationJob(agentIds),
+    );
+    for (let attempt = 1; attempt <= MAX_CAPACITY_REQUEUES; attempt++) {
+      if (last.inconclusiveAgentIds.length === 0) break;
+      // Sleep durably (the function suspends — it does not hold an inference
+      // slot) and re-run only the coworkers left inconclusive by capacity.
+      await step.sleep(`capacity-backoff-${attempt}`, CAPACITY_REQUEUE_BACKOFF);
+      agentIds = last.inconclusiveAgentIds;
+      last = await step.run(`coworker-certification-requeue-${attempt}`, () =>
+        runCoworkerCertificationJob(agentIds),
+      );
+    }
+    return last;
   },
 );
 
@@ -49,9 +92,24 @@ export const coworkerCertificationRunNow = inngest.createFunction(
     concurrency: [{ limit: 1 }],
     triggers: [{ event: "ops/coworker-certification.requested" }],
   },
-  async ({ step }) => {
+  async ({ step, event }) => {
     const gate = await gateAtEntry(step);
     if (!gate.proceed) return { skipped: true, reason: gate.reason };
-    return await step.run("coworker-certification", runCoworkerCertificationJob);
+    const requested = (event?.data as { agentIds?: unknown } | undefined)?.agentIds;
+    let agentIds: string[] | undefined = Array.isArray(requested)
+      ? requested.filter((a): a is string => typeof a === "string")
+      : undefined;
+    let last = await step.run("coworker-certification", () =>
+      runCoworkerCertificationJob(agentIds),
+    );
+    for (let attempt = 1; attempt <= MAX_CAPACITY_REQUEUES; attempt++) {
+      if (last.inconclusiveAgentIds.length === 0) break;
+      await step.sleep(`capacity-backoff-${attempt}`, CAPACITY_REQUEUE_BACKOFF);
+      agentIds = last.inconclusiveAgentIds;
+      last = await step.run(`coworker-certification-requeue-${attempt}`, () =>
+        runCoworkerCertificationJob(agentIds),
+      );
+    }
+    return last;
   },
 );

--- a/docs/superpowers/plans/2026-07-15-capacity-aware-certification-plan.md
+++ b/docs/superpowers/plans/2026-07-15-capacity-aware-certification-plan.md
@@ -1,0 +1,55 @@
+# Capacity-aware coworker certification — don't fail coworkers on a busy box (BI-44E401B5)
+
+**Status:** implemented (this PR). **BI:** BI-44E401B5.
+**Kernel decision (WWMD):** `principle_decide` recommended **origin-aware-patience** —
+composite **1.50**, margin **0.70**, confidence **high**; top contributor *Architecture Over
+Shortcuts* (+0.40). It rejected the symptom-only patch and the crude global-timeout bump. The
+`capacity_utilization` + `cost_efficiency` dimensions are first-class in the registry, so the founder
+principle ("capacity-limited work should be queued and served like a business managing utilization —
+maximize spend-to-utilization, decrease waste") scores directly.
+
+## Problem
+
+A coworker must pass a nightly golden-journey certification sweep to be promoted. The cert runner is
+**binary** (`passed | failed`). `acquireInferenceSlot()` already **queues** waiters over the engine
+ceiling (`interactiveQ` then `autonomousQ`), but the admission **timeout was a single 120s budget for
+both origins**. On a busy install (`local = 1`) a cert (autonomous) inference call waits in
+`autonomousQ`, blows 120s, throws — and the runner scores the journey (hence the coworker) as
+**failed**. Good coworkers are wrongly denied promotion because the box was busy, not because they're
+bad. That is "turning the customer away" instead of "booking the next slot."
+
+## Design (origin-aware patience + requeue-not-fail)
+
+### Part 1 — origin-aware admission patience (`inference-admission.ts`)
+- `resolveAcquireTimeoutMs(origin)` is now per-origin. `interactive` keeps the tight **120s** (a human
+  is waiting; fail fast beats hang). `autonomous` (cert / background / deliverable work) is **patient**:
+  default **30 min**, so it waits through contention and runs when a slot frees. Both stay bounded as a
+  leaked-release safety net. Tunable: `DPF_INFERENCE_ADMISSION_TIMEOUT_MS` (interactive) /
+  `DPF_INFERENCE_ADMISSION_TIMEOUT_MS_AUTONOMOUS` (autonomous).
+- The admission-timeout rejection is tagged `code = ADMISSION_TIMEOUT_CODE`; `isAdmissionTimeout(err)`
+  lets any caller treat capacity backpressure distinctly from a substantive failure. **Reusable** — this
+  benefits *all* autonomous work, not just cert.
+
+### Part 2 — requeue, don't fail (`certification-runner.ts` + `queue/functions/coworker-certification.ts`)
+- `executeJourney` catches `isAdmissionTimeout` → returns `capacityInconclusive: true` with **no failure
+  verdicts** (so no findings are filed).
+- `persistCoworkerRun` outcome is now `passed | failed | inconclusive` with a **safety rule: a genuine
+  failure trumps capacity backpressure** — a journey that *ran and failed an oracle* still fails the run,
+  so a broken coworker can't hide behind a busy box. Only "no genuine failures + some capacity-inconclusive"
+  → `inconclusive`.
+- The Inngest wrapper **requeues** just the still-inconclusive coworkers: it `step.sleep`s (durably — the
+  function suspends, holding no slot) and re-runs them, bounded by `MAX_CAPACITY_REQUEUES` (6) ×
+  `CAPACITY_REQUEUE_BACKOFF` (10m). Persistently saturated → those coworkers stay un-promoted, **never
+  failed**.
+
+## Verification
+- `inference-admission.test.ts`: origin-aware timeouts (interactive vs autonomous env), `isAdmissionTimeout`
+  tag, and an **autonomous-patience** test (a tiny interactive budget does not turn autonomous work away).
+- `certification-runner.test.ts`: an admission timeout yields an **inconclusive** run (requeue) with no
+  findings, not a coworker failure.
+- 23/23 green; `apps/web` tsc 0 errors at 8GB.
+
+## Deferred (BI-44E401B5 part 2)
+"Cap the tool surface during cert so local model selection doesn't degrade" is a distinct
+reasoning-economy concern (the runner already restricts to read-only tools). Tracked as a follow-up so
+this PR stays a focused capacity-policy change.


### PR DESCRIPTION
Coworkers were being **wrongly failed at certification because the box was busy**, not because they were bad. Fixes BI-44E401B5 via the kernel-recommended approach (origin-aware patience), not a symptom patch.

**Kernel (`principle_decide`):** `origin-aware-patience` — composite **1.50**, margin **0.70**, confidence **high**; top contributor *Architecture Over Shortcuts*. `capacity_utilization` + `cost_efficiency` are first-class dimensions, so the "queue-and-serve like a business managing utilization" principle scores directly.

## The bug
`acquireInferenceSlot()` already queues waiters over the engine ceiling (`interactiveQ`/`autonomousQ`), but the admission **timeout was a single 120s budget for both origins**. On a busy install (`local = 1`) a cert (autonomous) call blows 120s → throws → the **binary** cert runner scores the coworker as *failed*. That's turning the customer away instead of booking the next slot.

## The fix
**Part 1 — origin-aware patience** (`inference-admission.ts`): `interactive` keeps the tight 120s (a human waits); `autonomous` is patient (30m default, env-tunable) so cert/background/deliverable work runs when a slot frees. Rejection tagged `isAdmissionTimeout()`. *Reusable across all autonomous work.*

**Part 2 — requeue, don't fail** (`certification-runner.ts` + Inngest wrapper): admission timeout → journey `capacityInconclusive` (no failure verdicts); run outcome becomes `passed|failed|**inconclusive**` with a **safety rule — a genuine failure trumps capacity backpressure** (a broken coworker can't hide behind a busy box). The wrapper requeues only the still-inconclusive coworkers via durable `step.sleep` backoff (bounded 6×10m); a saturated box leaves them un-promoted, never failed.

**Deferred** (BI part 2): cap tool surface during cert (reasoning-economy) — runner already restricts to read-only tools; tracked separately.

## Validation
- **23/23** admission + cert-runner tests (incl. autonomous-patience + inconclusive-requeue); `apps/web` tsc **0 errors** at 8GB.
- Plan: `docs/superpowers/plans/2026-07-15-capacity-aware-certification-plan.md`

⚠️ **Held for your review — not auto-merged.** `inference-admission.ts` gates *all* platform inference; wanted your eyes on the capacity-policy change before it enqueues.

BI: BI-44E401B5

🤖 Generated with [Claude Code](https://claude.com/claude-code)