### PR TITLE
feat(workbooks): drag-to-reorder columns + in-grid row grouping (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -16,6 +16,7 @@ import {
 } from "react";
 import {
   DataGrid,
+  TreeDataGrid,
   SelectColumn,
   renderTextEditor,
   type Column,
@@ -88,6 +89,12 @@ import {
   parseViewState,
   type SortState,
 } from "./grid-view-state";
+import {
+  reorderColumnIds,
+  applyColumnOrder,
+  groupRowsByColumn,
+  groupKeys,
+} from "./grid-reorder-group";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -120,6 +127,8 @@ function buildColumn(
     name: label,
     resizable: true,
     sortable: true,
+    // Drag the header to reorder columns (onColumnsReorder on the grid).
+    draggable: true,
     width: col.width,
     minWidth: 80,
     // Progressive disclosure (Dale review): provenance is hidden until the user
@@ -270,6 +279,13 @@ export function WorkbookGrid({
   const [summaryChart, setSummaryChart] = useState(false);
   const [columnFilters, setColumnFilters] = useState<ColumnFilters>({});
   const activeFilterCount = Object.values(columnFilters).filter((v) => v.trim()).length;
+  // Drag-to-reorder column order (column ids) + in-grid collapsible grouping.
+  const [columnOrder, setColumnOrder] = useState<string[]>([]);
+  const [groupBy, setGroupBy] = useState<string[]>([]);
+  const [showGroup, setShowGroup] = useState(false);
+  // Which groups the user has collapsed (session-scoped); everything else is
+  // expanded by default so the grouped grid reads like Smartsheet on open.
+  const [collapsedGroups, setCollapsedGroups] = useState<ReadonlySet<string>>(() => new Set());
   // Multi-step undo/redo of cell edits (distinct from the audit history). Each
   // entry's inverse replays through the same validated dispatch as a normal edit.
   const [history, setHistory] = useState<GridHistory>(EMPTY_HISTORY);
@@ -287,6 +303,8 @@ export function WorkbookGrid({
         if (parsed.sort) setSortColumns(parsed.sort);
         if (parsed.cfRules) setCfRules(parsed.cfRules);
         if (parsed.showProvenance !== undefined) setShowProvenance(parsed.showProvenance);
+        if (parsed.columnOrder) setColumnOrder(parsed.columnOrder);
+        if (parsed.groupBy) setGroupBy(parsed.groupBy);
       }
     } catch {
       // ignore unreadable storage
@@ -303,17 +321,48 @@ export function WorkbookGrid({
       }));
       localStorage.setItem(
         viewStorageKey(tableId),
-        serializeViewState({ filterQuery, columnFilters, sort, cfRules, showProvenance }),
+        serializeViewState({
+          filterQuery,
+          columnFilters,
+          sort,
+          cfRules,
+          showProvenance,
+          columnOrder,
+          groupBy,
+        }),
       );
     } catch {
       // ignore quota / unavailable storage
     }
-  }, [tableId, filterQuery, columnFilters, sortColumns, cfRules, showProvenance]);
+  }, [tableId, filterQuery, columnFilters, sortColumns, cfRules, showProvenance, columnOrder, groupBy]);
+
+  // Columns in the user's saved drag order; new columns append, stale ids drop.
+  const orderedColumns = useMemo(
+    () => applyColumnOrder(columns, columnOrder),
+    [columns, columnOrder],
+  );
 
   const gridColumns = useMemo<Column<GridRowData>[]>(() => {
-    const cols = columns.map((c) => buildColumn(c, capabilities.canEditCell, showProvenance));
+    const cols = orderedColumns.map((c) => buildColumn(c, capabilities.canEditCell, showProvenance));
     return capabilities.canDeleteRow ? [SelectColumn, ...cols] : cols;
-  }, [columns, capabilities, showProvenance]);
+  }, [orderedColumns, capabilities, showProvenance]);
+
+  const onColumnsReorder = useCallback(
+    (sourceKey: string, targetKey: string) => {
+      setColumnOrder((prev) =>
+        reorderColumnIds(prev.length ? prev : columns.map((c) => c.columnId), sourceKey, targetKey),
+      );
+    },
+    [columns],
+  );
+
+  // In-grid grouping (v1: single column). Drop stale ids so a deleted grouping
+  // column can't wedge the grid into an empty TreeDataGrid.
+  const effectiveGroupBy = useMemo(
+    () => groupBy.filter((id) => columns.some((c) => c.columnId === id)),
+    [groupBy, columns],
+  );
+  const groupColumnId = effectiveGroupBy[0];
 
   const sortedRows = useMemo<GridRowData[]>(() => {
     const filtered = applyColumnFilters(
@@ -331,6 +380,32 @@ export function WorkbookGrid({
     });
     return sorted;
   }, [rowData, columns, filterQuery, columnFilters, sortColumns]);
+
+  // Grouping is grid-only; gallery renders flat cards regardless.
+  const grouping = Boolean(groupColumnId) && !gallery && columns.length > 0;
+
+  const rowGrouper = useCallback(
+    (rows: readonly GridRowData[], columnKey: string) => groupRowsByColumn(rows, columnKey),
+    [],
+  );
+
+  // Every group starts expanded; the user's collapses are remembered and applied
+  // as a subtraction so new groups (from edits/filtering) still open by default.
+  const allGroupIds = useMemo(
+    () => (groupColumnId ? groupKeys(sortedRows, groupColumnId) : []),
+    [sortedRows, groupColumnId],
+  );
+  const expandedGroupIds = useMemo(
+    () => new Set<unknown>(allGroupIds.filter((id) => !collapsedGroups.has(id))),
+    [allGroupIds, collapsedGroups],
+  );
+  const onExpandedGroupIdsChange = useCallback(
+    (ids: Set<unknown>) => {
+      const expanded = new Set(Array.from(ids, String));
+      setCollapsedGroups(new Set(allGroupIds.filter((id) => !expanded.has(id))));
+    },
+    [allGroupIds],
+  );
 
   const persistCell = useCallback(
     async (
@@ -566,6 +641,16 @@ export function WorkbookGrid({
           title="Group rows and summarize"
         >
           {showSummary ? "Hide summary" : "Summary"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setShowGroup((v) => !v)}
+          aria-pressed={showGroup}
+          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          title="Collapse rows into groups by a column"
+        >
+          {showGroup ? "Hide grouping" : "Group"}
+          {groupColumnId ? ` (1)` : ""}
         </button>
         <button
           type="button"
@@ -864,6 +949,49 @@ export function WorkbookGrid({
         );
       })()}
 
+      {showGroup && columns.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+          <span className="text-sm text-[var(--dpf-muted)]">Group by</span>
+          <select
+            value={groupColumnId ?? ""}
+            onChange={(e) => {
+              setGroupBy(e.target.value ? [e.target.value] : []);
+              setCollapsedGroups(new Set());
+            }}
+            aria-label="Group by column"
+            className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]"
+          >
+            <option value="">none</option>
+            {columns.map((c) => (
+              <option key={c.columnId} value={c.columnId}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          {grouping && (
+            <>
+              <button
+                type="button"
+                onClick={() => setCollapsedGroups(new Set())}
+                className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+              >
+                Expand all
+              </button>
+              <button
+                type="button"
+                onClick={() => setCollapsedGroups(new Set(allGroupIds))}
+                className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+              >
+                Collapse all
+              </button>
+              <span className="text-xs text-[var(--dpf-muted)]">
+                {allGroupIds.length} group{allGroupIds.length === 1 ? "" : "s"}
+              </span>
+            </>
+          )}
+        </div>
+      )}
+
       {columns.length === 0 ? (
         <div className="rounded-md border border-dashed border-[var(--dpf-border)] p-8 text-center text-[var(--dpf-muted)]">
           This table has no columns yet. Add a column to start entering data.
@@ -900,22 +1028,47 @@ export function WorkbookGrid({
         </div>
       ) : (
         <div className="min-h-0 flex-1">
-          <DataGrid
-            className="dpf-workbook-grid"
-            columns={gridColumns}
-            rows={sortedRows}
-            rowKeyGetter={(row) => row.rowId}
-            onRowsChange={onRowsChange}
-            sortColumns={sortColumns}
-            onSortColumnsChange={setSortColumns}
-            selectedRows={selectedRows}
-            onSelectedRowsChange={setSelectedRows}
-            rowClass={(row) => {
-              const color = rowColor(row, cfRules);
-              return color ? rowColorClass(color) : undefined;
-            }}
-            defaultColumnOptions={{ resizable: true, sortable: true }}
-          />
+          {grouping ? (
+            <TreeDataGrid
+              className="dpf-workbook-grid"
+              columns={gridColumns}
+              rows={sortedRows}
+              rowKeyGetter={(row) => row.rowId}
+              onRowsChange={onRowsChange}
+              sortColumns={sortColumns}
+              onSortColumnsChange={setSortColumns}
+              selectedRows={selectedRows}
+              onSelectedRowsChange={setSelectedRows}
+              onColumnsReorder={onColumnsReorder}
+              groupBy={effectiveGroupBy}
+              rowGrouper={rowGrouper}
+              expandedGroupIds={expandedGroupIds}
+              onExpandedGroupIdsChange={onExpandedGroupIdsChange}
+              rowClass={(row) => {
+                const color = rowColor(row, cfRules);
+                return color ? rowColorClass(color) : undefined;
+              }}
+              defaultColumnOptions={{ resizable: true, sortable: true }}
+            />
+          ) : (
+            <DataGrid
+              className="dpf-workbook-grid"
+              columns={gridColumns}
+              rows={sortedRows}
+              rowKeyGetter={(row) => row.rowId}
+              onRowsChange={onRowsChange}
+              sortColumns={sortColumns}
+              onSortColumnsChange={setSortColumns}
+              selectedRows={selectedRows}
+              onSelectedRowsChange={setSelectedRows}
+              onColumnsReorder={onColumnsReorder}
+              rowClass={(row) => {
+                const color = rowColor(row, cfRules);
+                return color ? rowColorClass(color) : undefined;
+              }}
+              defaultColumnOptions={{ resizable: true, sortable: true }}
+            />
+          )}
         </div>
       )}
     </div>

--- a/apps/web/components/workbooks/grid-reorder-group.test.ts
+++ b/apps/web/components/workbooks/grid-reorder-group.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  reorderColumnIds,
+  applyColumnOrder,
+  groupRowsByColumn,
+  groupKeys,
+  EMPTY_GROUP_LABEL,
+} from "./grid-reorder-group";
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+
+const col = (columnId: string, position: number): ColumnDefinition => ({
+  columnId,
+  name: columnId.toUpperCase(),
+  fieldType: "text",
+  position,
+  required: false,
+  editable: true,
+});
+
+describe("reorderColumnIds", () => {
+  const order = ["a", "b", "c", "d"];
+
+  it("moves a column to the right (into the target's slot)", () => {
+    expect(reorderColumnIds(order, "a", "c")).toEqual(["b", "c", "a", "d"]);
+  });
+
+  it("moves a column to the left (into the target's slot)", () => {
+    expect(reorderColumnIds(order, "d", "b")).toEqual(["a", "d", "b", "c"]);
+  });
+
+  it("is a no-op when source equals target", () => {
+    expect(reorderColumnIds(order, "b", "b")).toEqual(order);
+  });
+
+  it("returns the order unchanged for an unknown key", () => {
+    expect(reorderColumnIds(order, "z", "b")).toEqual(order);
+    expect(reorderColumnIds(order, "a", "z")).toEqual(order);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = ["a", "b", "c"];
+    reorderColumnIds(input, "a", "c");
+    expect(input).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("applyColumnOrder", () => {
+  const columns = [col("a", 0), col("b", 1), col("c", 2)];
+
+  it("reorders columns by the saved id list", () => {
+    expect(applyColumnOrder(columns, ["c", "a", "b"]).map((c) => c.columnId)).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+  });
+
+  it("returns columns untouched for an empty order", () => {
+    expect(applyColumnOrder(columns, [])).toBe(columns);
+  });
+
+  it("appends columns missing from the saved order (newly added)", () => {
+    // order predates column "c" being added
+    expect(applyColumnOrder(columns, ["b", "a"]).map((c) => c.columnId)).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+  });
+
+  it("skips ids that no longer map to a column (deleted)", () => {
+    expect(applyColumnOrder(columns, ["c", "gone", "a", "b"]).map((c) => c.columnId)).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+  });
+
+  it("never duplicates a column when the order repeats an id", () => {
+    expect(applyColumnOrder(columns, ["a", "a", "b", "c"]).map((c) => c.columnId)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+});
+
+describe("groupRowsByColumn", () => {
+  const rows: GridRowData[] = [
+    { rowId: "1", status: "open" },
+    { rowId: "2", status: "done" },
+    { rowId: "3", status: "open" },
+    { rowId: "4", status: "" },
+    { rowId: "5", status: null },
+  ];
+
+  it("buckets rows by the column's displayed value", () => {
+    const grouped = groupRowsByColumn(rows, "status");
+    expect(grouped["open"]!.map((r) => r.rowId)).toEqual(["1", "3"]);
+    expect(grouped["done"]!.map((r) => r.rowId)).toEqual(["2"]);
+  });
+
+  it("collapses empty and null values into a single (empty) bucket", () => {
+    const grouped = groupRowsByColumn(rows, "status");
+    expect(grouped[EMPTY_GROUP_LABEL]!.map((r) => r.rowId)).toEqual(["4", "5"]);
+  });
+
+  it("preserves row order within a bucket (so an active sort survives)", () => {
+    const grouped = groupRowsByColumn(rows, "status");
+    expect(grouped["open"]!.map((r) => r.rowId)).toEqual(["1", "3"]);
+  });
+
+  it("exposes the group keys in first-seen order", () => {
+    expect(groupKeys(rows, "status")).toEqual(["open", "done", EMPTY_GROUP_LABEL]);
+  });
+});

--- a/apps/web/components/workbooks/grid-reorder-group.ts
+++ b/apps/web/components/workbooks/grid-reorder-group.ts
@@ -1,0 +1,84 @@
+// Universal Grid & Workbooks — column reordering + in-grid row grouping
+// (EP-GRID-WORKBOOKS Phase 3, toward Smartsheet parity).
+//
+// Two spreadsheet affordances the grid was missing: drag a column header to a
+// new position, and collapse rows into groups by a column's value. Both are
+// first-class react-data-grid features (onColumnsReorder / TreeDataGrid); the
+// logic that decides the new order and buckets the rows lives here, pure and
+// unit-testable — the Grid owns the react-data-grid wiring and persistence.
+
+import type { ColumnDefinition } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+import { cellSearchText } from "./grid-filter";
+
+/** Label used for a group whose group-by cell is empty. */
+export const EMPTY_GROUP_LABEL = "(empty)";
+
+/**
+ * Return a new column-id order with `sourceKey` moved into `targetKey`'s slot —
+ * react-data-grid's drop semantics (the dragged column takes the drop target's
+ * position, the rest shift to make room). Mirrors the library's own reference
+ * handler so behavior matches user expectation. An unknown key or a no-op move
+ * returns a copy of the input unchanged, so a column is never dropped or
+ * duplicated.
+ */
+export function reorderColumnIds(
+  order: readonly string[],
+  sourceKey: string,
+  targetKey: string,
+): string[] {
+  const from = order.indexOf(sourceKey);
+  const to = order.indexOf(targetKey);
+  const next = order.slice();
+  if (from === -1 || to === -1 || from === to) return next;
+  next.splice(to, 0, next.splice(from, 1)[0]!);
+  return next;
+}
+
+/**
+ * Order `columns` by a saved list of column ids. Ids that no longer exist are
+ * skipped; columns missing from the saved order (e.g. a column added after the
+ * order was saved) are appended in their original relative order. An empty order
+ * returns the input untouched. Never drops or duplicates a live column.
+ */
+export function applyColumnOrder(
+  columns: ColumnDefinition[],
+  order: readonly string[],
+): ColumnDefinition[] {
+  if (order.length === 0) return columns;
+  const byId = new Map(columns.map((c) => [c.columnId, c]));
+  const seen = new Set<string>();
+  const out: ColumnDefinition[] = [];
+  for (const id of order) {
+    const col = byId.get(id);
+    if (col && !seen.has(id)) {
+      out.push(col);
+      seen.add(id);
+    }
+  }
+  for (const col of columns) if (!seen.has(col.columnId)) out.push(col);
+  return out;
+}
+
+/**
+ * Bucket rows by a column's displayed value — the `rowGrouper` a `TreeDataGrid`
+ * calls for each grouping level. Empty/blank values collapse into a single
+ * `(empty)` bucket. Insertion order within a bucket is preserved (so an active
+ * sort still orders rows inside each group).
+ */
+export function groupRowsByColumn(
+  rows: readonly GridRowData[],
+  columnId: string,
+): Record<string, readonly GridRowData[]> {
+  const out: Record<string, GridRowData[]> = {};
+  for (const row of rows) {
+    const key = cellSearchText(row[columnId] ?? null) || EMPTY_GROUP_LABEL;
+    (out[key] ??= []).push(row);
+  }
+  return out;
+}
+
+/** The set of group keys (in first-seen order) for the default expand-all state. */
+export function groupKeys(rows: readonly GridRowData[], columnId: string): string[] {
+  return Object.keys(groupRowsByColumn(rows, columnId));
+}

--- a/apps/web/components/workbooks/grid-view-state.test.ts
+++ b/apps/web/components/workbooks/grid-view-state.test.ts
@@ -12,6 +12,8 @@ const sample: GridViewState = {
   sort: [{ columnKey: "name", direction: "ASC" }],
   cfRules: [{ id: "r1", columnId: "status", operator: "eq", value: "overdue", color: "red" }],
   showProvenance: true,
+  columnOrder: ["name", "status", "amount"],
+  groupBy: ["status"],
 };
 
 describe("viewStorageKey", () => {
@@ -64,5 +66,19 @@ describe("parseViewState — defensive", () => {
       JSON.stringify({ sort: [{ columnKey: "a", direction: "ASC" }, { columnKey: "b", direction: "sideways" }, {}] }),
     );
     expect(parsed!.sort).toEqual([{ columnKey: "a", direction: "ASC" }]);
+  });
+
+  it("keeps only string ids in columnOrder and groupBy", () => {
+    const parsed = parseViewState(
+      JSON.stringify({ columnOrder: ["a", 2, "b", null], groupBy: ["status", 7] }),
+    );
+    expect(parsed!.columnOrder).toEqual(["a", "b"]);
+    expect(parsed!.groupBy).toEqual(["status"]);
+  });
+
+  it("ignores columnOrder / groupBy that are not arrays", () => {
+    const parsed = parseViewState(JSON.stringify({ columnOrder: "a,b", groupBy: {} }));
+    expect(parsed!.columnOrder).toBeUndefined();
+    expect(parsed!.groupBy).toBeUndefined();
   });
 });

--- a/apps/web/components/workbooks/grid-view-state.ts
+++ b/apps/web/components/workbooks/grid-view-state.ts
@@ -20,6 +20,10 @@ export interface GridViewState {
   sort: SortState[];
   cfRules: ConditionalRule[];
   showProvenance: boolean;
+  /** User-chosen column order (column ids); empty = natural order. */
+  columnOrder: string[];
+  /** Column ids the grid is grouped by (in-grid collapsible groups). */
+  groupBy: string[];
 }
 
 export function viewStorageKey(tableId: string): string {
@@ -43,6 +47,12 @@ function parseSort(raw: unknown): SortState[] {
     }
   }
   return out;
+}
+
+/** Keep only the string entries of a would-be `string[]` (ids). */
+function parseStringArray(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((v): v is string => typeof v === "string");
 }
 
 function parseColumnFilters(raw: unknown): Record<string, string> {
@@ -95,5 +105,7 @@ export function parseViewState(raw: string | null | undefined): Partial<GridView
   if (Array.isArray(data.sort)) out.sort = parseSort(data.sort);
   if (Array.isArray(data.cfRules)) out.cfRules = parseCfRules(data.cfRules);
   if (typeof data.showProvenance === "boolean") out.showProvenance = data.showProvenance;
+  if (Array.isArray(data.columnOrder)) out.columnOrder = parseStringArray(data.columnOrder);
+  if (Array.isArray(data.groupBy)) out.groupBy = parseStringArray(data.groupBy);
   return out;
 }

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -176,8 +176,25 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
 - **Slice 15 — gallery (card) view — SHIPPED.** A Grid/Gallery toggle on the WorkbookGrid renders
   rows as cards (one card per row, each column as a label/value pair), honoring the active filters,
   sort, and conditional-format colour (a left-border accent). No new dependency, like the kanban board.
-- **Remaining (not built):** named/shareable views; calendar view (fullcalendar — needs a date
-  column); full pivots + richer charts; metrics/semantic layer; operationalization lifecycle.
+- **Slice 16 — drag-to-reorder columns — SHIPPED (BI-FFBDE996).** Every WorkbookGrid header is
+  `draggable`; dropping one onto another fires react-data-grid's `onColumnsReorder`, which updates a
+  saved `columnOrder` (column ids) applied through the pure, unit-tested `applyColumnOrder`
+  (`grid-reorder-group.ts`): new columns append, deleted ids drop — a column is never lost or
+  duplicated. `columnOrder` persists in the per-tableId view state (localStorage, no migration), so
+  it works for every custom + platform grid.
+- **Slice 17 — in-grid collapsible row grouping — SHIPPED (BI-198281FC).** A "Group" toolbar panel
+  (progressive disclosure, parallel to Summary) with a single "Group by [column]" select renders the
+  grid via react-data-grid's `TreeDataGrid` (`groupBy` + `rowGrouper` + `expandedGroupIds`). Distinct
+  from the Summary panel: Summary *aggregates* a group-by into a separate table/chart; this collapses
+  the *rows themselves* into groups (the Smartsheet affordance). Groups start expanded; user collapses
+  are remembered as a subtraction (`collapsedGroups`) so new groups from edits/filtering still open by
+  default. Grid-only (gallery stays flat); the group-by column persists in the view state. Bucketing
+  is the pure, unit-tested `groupRowsByColumn`. **Multi-level grouping** is a documented follow-up —
+  `groupBy` is already an array end-to-end and `TreeDataGrid` supports nesting; only the panel UI
+  (add/remove ordered group levels) and expand-id handling for nested ids remain.
+- **Remaining (not built):** multi-level (nested) grouping UI; named/shareable views; calendar view
+  (fullcalendar — needs a date column); full pivots + richer charts; metrics/semantic layer;
+  operationalization lifecycle.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -12,7 +12,7 @@ apps/web/components/platform/AiOperationsMap.tsx	2849
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
 apps/web/components/storefront/SlotBookingFlow.tsx	919
-apps/web/components/workbooks/Grid.tsx	924
+apps/web/components/workbooks/Grid.tsx	1077
 apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1341
 apps/web/lib/actions/agent-coworker-external.test.ts	867


### PR DESCRIPTION
## What & why

Two Smartsheet-parity gaps the operator hit on the **Operations backlog grid** (Grid view): columns couldn't be reordered, and rows couldn't be collapsed into groups by a column. Both are first-class `react-data-grid` features that were simply never wired into `WorkbookGrid`. Closes the remaining "spreadsheet-on-data" gaps under **EP-GRID-WORKBOOKS**.

Backlog: **BI-FFBDE996** (column reorder), **BI-198281FC** (in-grid grouping).

## Changes

- **Drag-to-reorder columns** — every grid header is `draggable`; dropping one onto another fires `onColumnsReorder`, updating a saved `columnOrder` applied through the pure `applyColumnOrder` (new columns append, deleted ids drop — a column is never lost or duplicated).
- **In-grid collapsible row grouping** — a "Group" toolbar panel (progressive disclosure, parallel to Summary) with a single "Group by [column]" select renders the grid via `TreeDataGrid` (`groupBy` + `rowGrouper` + `expandedGroupIds`). This is distinct from the existing **Summary** panel, which only *aggregates* a group-by into a side table/chart — this collapses the **rows themselves** into groups (the Smartsheet affordance). Groups start expanded; user collapses are remembered as a subtraction so new groups (from edits/filtering) still open by default. Grid-only; gallery stays flat.
- **Persistence** — both `columnOrder` and `groupBy` are saved in the per-`tableId` grid view state (localStorage, no migration), so they work for every custom + platform grid, alongside the existing filter/sort/format/provenance state.
- **New pure, unit-tested helpers** — `grid-reorder-group.ts` (`reorderColumnIds`, `applyColumnOrder`, `groupRowsByColumn`); `grid-view-state.ts` parse/serialize extended with defensive string-array parsing.

Multi-level (nested) grouping is a documented follow-up — `groupBy` is already an array end-to-end and `TreeDataGrid` supports nesting; only the panel UI (ordered group levels) and nested expand-id handling remain.

## Testing

- `grid-reorder-group.test.ts` + extended `grid-view-state.test.ts` — **22 unit tests pass locally** (via the root toolchain; source-only worktree).
- Local scoped typecheck is **not runnable in this worktree** — it has no `react-data-grid` / `@dpf/db` install, so tsc can't resolve those modules (untouched files like `cell-editors.tsx` fail identically). **CI's required Typecheck + Production Build + Unit Tests are the authoritative gate** for the react-data-grid integration layer; the exact API used (`onColumnsReorder`, `TreeDataGrid` `groupBy`/`rowGrouper`/`expandedGroupIds`, `Column.draggable`) was verified against the published `react-data-grid@7.0.0-beta.59` type declarations.

## UX-Fit-Decision

Chose a **progressive-disclosure "Group" toolbar toggle + panel** with a single "Group by [column]" dropdown (default *none*) plus Expand-all/Collapse-all, mirroring the existing Filters/Format/Summary panels. Lowest `human_cognitive_load` per AGENTS.md §12/§17: hidden until opened, one plain choice, no typing, groups and counts auto-derived. Rejected an always-visible multi-level chip row (higher standing load) and a per-column header menu (lower discoverability, inconsistent with the toolbar-panel pattern). `principle_decide` (DI-C138960E2AAB) ran but the cognitive-load dimensions aren't in the closed registry, so it fell back to commandment-only scoring (low-confidence artifact, not a UX signal); the §12/§17 progressive-disclosure rule was applied directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design grounding

- **Existing specs/plans reviewed:**
  - `docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md` — EP-GRID-WORKBOOKS phased build order, "Phase 3 — Spreadsheet-on-data UX (toward Smartsheet parity)" and "Remaining toward full Smartsheet + Supabase parity". Column reorder and in-grid grouping were the unbuilt parity gaps (now added as slices 16–17 in that plan).
  - Its parent spec `2026-06-07-workbooks-hybrid-systems-of-record-reporting-lifecycle-design.md`.
- **Current code substrate reviewed:**
  - `apps/web/components/workbooks/Grid.tsx` — existing `DataGrid` wrapper with Summary / Filters / Format / Gallery toolbar panels, the sort+filter pipeline, and per-`tableId` view-state persistence.
  - `grid-view-state.ts` (persisted view), `grid-summary.ts` / `grid-filter.ts` (`cellSearchText` reused for grouping keys; existing group-by *aggregation* is separate from the new row grouping).
  - Verified via live `EP-GRID-WORKBOOKS` backlog query that no column-reorder or in-grid-grouping code or backlog item existed before this change.
- **Source of truth:** `react-data-grid@7.0.0-beta.59` (already the grid engine) — `onColumnsReorder` and `TreeDataGrid` are its first-class features. Persistence reuses the existing localStorage per-`tableId` `GridViewState` (no new store, no migration).
- **Decision:** Wire the library's native reorder + `TreeDataGrid` grouping behind the **existing** toolbar-panel + view-state patterns rather than inventing new UX or a new persistence surface. Row grouping (collapse the rows) is intentionally distinct from the existing Summary panel (aggregate into a side table). Backlog: BI-FFBDE996, BI-198281FC. Cognitive-load rationale in the UX-Fit-Decision above.
