### PR TITLE
feat: surface contribution provenance states

### DIFF
--- a/apps/web/app/(shell)/admin/hive/page.tsx
+++ b/apps/web/app/(shell)/admin/hive/page.tsx
@@ -1,4 +1,5 @@
 import { AdminTabNav } from "@/components/admin/AdminTabNav";
+import { ContributionProvenanceTable } from "@/components/admin/ContributionProvenanceTable";
 import { HiveContributionsPanel } from "@/components/admin/HiveContributionsPanel";
 import { SeedContributionReviewTable } from "@/components/admin/SeedContributionReviewTable";
 import { StatusBadge, type Intent } from "@/components/ui/report-kit";
@@ -45,6 +46,15 @@ export default async function AdminHiveContributionsPage() {
           >
             {view.contributor ?? "not yet generated"}
           </div>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-[var(--dpf-text)] mb-1">Contribution provenance</h2>
+          <p className="text-sm text-[var(--dpf-muted)] mb-3">
+            A plain-language view of what is kept here, privately backed up, or shared with the community. A feature can
+            be active on this system and also sent outward, so these states are shown separately.
+          </p>
+          <ContributionProvenanceTable rows={view.contributionProvenance} />
         </section>
 
         <section>

--- a/apps/web/components/admin/ContributionProvenanceTable.test.tsx
+++ b/apps/web/components/admin/ContributionProvenanceTable.test.tsx
@@ -1,0 +1,59 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ContributionProvenanceTable } from "./ContributionProvenanceTable";
+import type { ContributionProvenanceRow } from "@/lib/actions/hive-contributions";
+
+function row(overrides: Partial<ContributionProvenanceRow>): ContributionProvenanceRow {
+  return {
+    id: "feature-pack:FP-1",
+    source: "feature-pack",
+    title: "Shared dispatch workflow",
+    sourceLabel: "Feature Pack",
+    occurredAt: "2026-07-15T12:00:00.000Z",
+    localAvailability: { status: "saved-locally", label: "Saved locally", detail: "Feature Pack exists on this install." },
+    privacyDisposition: { status: "approved-to-share", label: "Approved to share", detail: "A public community contribution record exists for this Feature Pack." },
+    publication: { status: "sent-community", label: "Sent to community project", detail: "PR #42", url: "https://github.com/example/repo/pull/42" },
+    upstreamAcceptance: { status: "under-review", label: "Under review", detail: "The community project has not accepted it yet." },
+    ...overrides,
+  };
+}
+
+describe("ContributionProvenanceTable", () => {
+  it("renders all four provenance axes in plain language", () => {
+    const html = renderToStaticMarkup(<ContributionProvenanceTable rows={[row({})]} />);
+
+    expect(html).toContain("Shared dispatch workflow");
+    expect(html).toContain("Saved locally");
+    expect(html).toContain("Approved to share");
+    expect(html).toContain("Sent to community project");
+    expect(html).toContain("Under review");
+    expect(html).toContain("Open contribution");
+  });
+
+  it("renders ambiguous legacy contributions as review work, not as confirmed community acceptance", () => {
+    const html = renderToStaticMarkup(<ContributionProvenanceTable rows={[row({
+      id: "feature-pack:FP-AMBIGUOUS",
+      title: "Ambiguous contribution",
+      publication: {
+        status: "needs-attention",
+        label: "Needs attention",
+        detail: "Marked contributed, but no sent-community proof was found.",
+      },
+      upstreamAcceptance: {
+        status: "needs-review",
+        label: "Needs provenance review",
+        detail: "Legacy status cannot prove whether the community accepted it.",
+      },
+    })]} />);
+
+    expect(html).toContain("Needs attention");
+    expect(html).toContain("Needs provenance review");
+    expect(html).not.toContain("Accepted by community");
+  });
+
+  it("renders an honest empty state", () => {
+    const html = renderToStaticMarkup(<ContributionProvenanceTable rows={[]} />);
+    expect(html).toContain("No contribution provenance yet");
+  });
+});

--- a/apps/web/components/admin/ContributionProvenanceTable.test.tsx
+++ b/apps/web/components/admin/ContributionProvenanceTable.test.tsx
@@ -31,6 +31,13 @@ describe("ContributionProvenanceTable", () => {
     expect(html).toContain("Open contribution");
   });
 
+  it("resolves provenance statuses through the shared report-kit intent registry", () => {
+    const html = renderToStaticMarkup(<ContributionProvenanceTable rows={[row({})]} />);
+
+    expect(html).toContain('data-intent="neutral"');
+    expect(html).toContain('data-intent="accent"');
+  });
+
   it("renders ambiguous legacy contributions as review work, not as confirmed community acceptance", () => {
     const html = renderToStaticMarkup(<ContributionProvenanceTable rows={[row({
       id: "feature-pack:FP-AMBIGUOUS",

--- a/apps/web/components/admin/ContributionProvenanceTable.tsx
+++ b/apps/web/components/admin/ContributionProvenanceTable.tsx
@@ -6,34 +6,14 @@ import {
   EmptyState,
   StatusBadge,
   type Column,
-  type Intent,
 } from "@/components/ui/report-kit";
-
-const AXIS_INTENTS: Record<string, Intent> = {
-  "accepted": "success",
-  "approved-to-share": "accent",
-  "blocked-policy": "warning",
-  "blocked-private-path": "warning",
-  "kept-here": "neutral",
-  "needs-attention": "warning",
-  "needs-review": "warning",
-  "not-queued": "neutral",
-  "not-sent": "neutral",
-  "private-backup": "accent",
-  "private-parts-removed": "success",
-  "rejected": "warning",
-  "saved-locally": "neutral",
-  "sent-community": "accent",
-  "under-review": "accent",
-  "waiting-online": "warning",
-  "withdrawn": "neutral",
-};
 
 function AxisBadge({ axis }: { axis: ContributionProvenanceAxis }) {
   return (
     <div className="min-w-36">
       <StatusBadge
-        intent={AXIS_INTENTS[axis.status] ?? "neutral"}
+        domain="contributionProvenance"
+        status={axis.status}
         label={axis.label}
         uppercase={false}
         variant="soft"

--- a/apps/web/components/admin/ContributionProvenanceTable.tsx
+++ b/apps/web/components/admin/ContributionProvenanceTable.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import type { ContributionProvenanceAxis, ContributionProvenanceRow } from "@/lib/actions/hive-contributions";
+import {
+  DataTable,
+  EmptyState,
+  StatusBadge,
+  type Column,
+  type Intent,
+} from "@/components/ui/report-kit";
+
+const AXIS_INTENTS: Record<string, Intent> = {
+  "accepted": "success",
+  "approved-to-share": "accent",
+  "blocked-policy": "warning",
+  "blocked-private-path": "warning",
+  "kept-here": "neutral",
+  "needs-attention": "warning",
+  "needs-review": "warning",
+  "not-queued": "neutral",
+  "not-sent": "neutral",
+  "private-backup": "accent",
+  "private-parts-removed": "success",
+  "rejected": "warning",
+  "saved-locally": "neutral",
+  "sent-community": "accent",
+  "under-review": "accent",
+  "waiting-online": "warning",
+  "withdrawn": "neutral",
+};
+
+function AxisBadge({ axis }: { axis: ContributionProvenanceAxis }) {
+  return (
+    <div className="min-w-36">
+      <StatusBadge
+        intent={AXIS_INTENTS[axis.status] ?? "neutral"}
+        label={axis.label}
+        uppercase={false}
+        variant="soft"
+      />
+      <p className="mt-1 text-xs text-[var(--dpf-muted)]">{axis.detail}</p>
+      {axis.url ? (
+        <a
+          href={axis.url}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-1 inline-block text-xs text-[var(--dpf-accent)] hover:underline"
+        >
+          Open contribution
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+const columns: Column<ContributionProvenanceRow>[] = [
+  {
+    key: "item",
+    header: "Item",
+    cell: (row) => (
+      <div className="min-w-48">
+        <p className="font-medium text-[var(--dpf-text)]">{row.title}</p>
+        <p className="text-[10px] text-[var(--dpf-muted)]">{row.sourceLabel}</p>
+      </div>
+    ),
+    sortAccessor: (row) => row.title,
+  },
+  {
+    key: "kept-here",
+    header: "Kept here",
+    cell: (row) => <AxisBadge axis={row.localAvailability} />,
+    sortAccessor: (row) => row.localAvailability.label,
+  },
+  {
+    key: "privacy",
+    header: "Privacy",
+    cell: (row) => <AxisBadge axis={row.privacyDisposition} />,
+    sortAccessor: (row) => row.privacyDisposition.label,
+  },
+  {
+    key: "sent-outside",
+    header: "Sent outside",
+    cell: (row) => <AxisBadge axis={row.publication} />,
+    sortAccessor: (row) => row.publication.label,
+  },
+  {
+    key: "community-status",
+    header: "Community status",
+    cell: (row) => <AxisBadge axis={row.upstreamAcceptance} />,
+    sortAccessor: (row) => row.upstreamAcceptance.label,
+  },
+];
+
+export function ContributionProvenanceTable({ rows }: { rows: ContributionProvenanceRow[] }) {
+  return (
+    <div className="overflow-x-auto rounded border border-[var(--dpf-border)]">
+      <DataTable
+        columns={columns}
+        rows={rows}
+        getRowKey={(row) => row.id}
+        initialSort={{ key: "sent-outside", dir: "asc" }}
+        pageSize={20}
+        empty={(
+          <EmptyState
+            title="No contribution provenance yet"
+            description="Features and learnings will appear here once they are kept locally, privately backed up, or shared with the community."
+            size="sm"
+            bordered={false}
+          />
+        )}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/ui/report-kit/statusColors.ts
+++ b/apps/web/components/ui/report-kit/statusColors.ts
@@ -449,6 +449,29 @@ export const STATUS_INTENT: Record<string, Record<string, Intent>> = {
     "install-local-only": "neutral",
     "reject-as-seed": "danger",
   },
+  // Admin > Hive contribution provenance. These statuses answer plain-language
+  // operator questions across four axes: kept here, privacy disposition, sent
+  // outside, and community acceptance. Keep them in the shared registry so the
+  // provenance report does not carry a private status color map.
+  contributionProvenance: {
+    accepted: "success",
+    "approved-to-share": "accent",
+    "blocked-policy": "warning",
+    "blocked-private-path": "warning",
+    "kept-here": "neutral",
+    "needs-attention": "warning",
+    "needs-review": "warning",
+    "not-queued": "neutral",
+    "not-sent": "neutral",
+    "private-backup": "accent",
+    "private-parts-removed": "success",
+    rejected: "warning",
+    "saved-locally": "neutral",
+    "sent-community": "accent",
+    "under-review": "accent",
+    "waiting-online": "warning",
+    withdrawn: "neutral",
+  },
 };
 
 /**

--- a/apps/web/lib/actions/hive-contributions.test.ts
+++ b/apps/web/lib/actions/hive-contributions.test.ts
@@ -4,10 +4,12 @@ const {
   platformDevConfigFindUnique,
   hiveContributionLedgerFindMany,
   featurePackFindMany,
+  improvementProposalFindMany,
 } = vi.hoisted(() => ({
   platformDevConfigFindUnique: vi.fn(),
   hiveContributionLedgerFindMany: vi.fn(),
   featurePackFindMany: vi.fn(),
+  improvementProposalFindMany: vi.fn(),
 }));
 
 vi.mock("@dpf/db", () => ({
@@ -15,6 +17,7 @@ vi.mock("@dpf/db", () => ({
     platformDevConfig: { findUnique: platformDevConfigFindUnique, upsert: vi.fn() },
     hiveContributionLedger: { findMany: hiveContributionLedgerFindMany },
     featurePack: { findMany: featurePackFindMany },
+    improvementProposal: { findMany: improvementProposalFindMany },
   },
   resolveHiveContributionStatuses: vi.fn(() => []),
 }));
@@ -32,6 +35,7 @@ describe("getHiveContributionsView seed reviews", () => {
     vi.clearAllMocks();
     platformDevConfigFindUnique.mockResolvedValue(null);
     hiveContributionLedgerFindMany.mockResolvedValue([]);
+    improvementProposalFindMany.mockResolvedValue([]);
   });
 
   it("maps reviewed seed-fit evidence from FeaturePack.reviewReport", async () => {
@@ -96,6 +100,103 @@ describe("getHiveContributionsView seed reviews", () => {
       mergeEligible: false,
       changedSeedPaths: ["prompts/reviewer/code-review.prompt.md"],
       rationale: "Seed-fit evidence is unavailable; review is required.",
+    });
+  });
+});
+
+describe("getHiveContributionsView contribution provenance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    platformDevConfigFindUnique.mockResolvedValue(null);
+    hiveContributionLedgerFindMany.mockResolvedValue([]);
+    improvementProposalFindMany.mockResolvedValue([]);
+  });
+
+  it("does not treat FeaturePack.status=local as proof that nothing was shared", async () => {
+    featurePackFindMany.mockResolvedValue([{
+      packId: "FP-SHARED",
+      title: "Shared dispatch workflow",
+      status: "local",
+      prUrl: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/42",
+      prNumber: 42,
+      mergeReadiness: null,
+      reviewedAt: null,
+      createdAt: new Date("2026-07-15T12:00:00.000Z"),
+      manifest: {},
+      reviewReport: null,
+    }]);
+
+    const view = await getHiveContributionsView();
+
+    expect(view.contributionProvenance).toEqual([
+      expect.objectContaining({
+        id: "feature-pack:FP-SHARED",
+        title: "Shared dispatch workflow",
+        localAvailability: expect.objectContaining({ label: "Saved locally" }),
+        privacyDisposition: expect.objectContaining({ label: "Approved to share" }),
+        publication: expect.objectContaining({
+          label: "Sent to community project",
+          detail: "PR #42",
+          url: "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/42",
+        }),
+        upstreamAcceptance: expect.objectContaining({ label: "Under review" }),
+      }),
+    ]);
+  });
+
+  it("flags contributed FeaturePacks without PR or outbox evidence for provenance review", async () => {
+    featurePackFindMany.mockResolvedValue([{
+      packId: "FP-AMBIGUOUS",
+      title: "Ambiguous contribution",
+      status: "contributed",
+      prUrl: null,
+      prNumber: null,
+      mergeReadiness: null,
+      reviewedAt: null,
+      createdAt: new Date("2026-07-15T12:00:00.000Z"),
+      manifest: {},
+      reviewReport: null,
+    }]);
+
+    const view = await getHiveContributionsView();
+
+    expect(view.contributionProvenance[0]).toMatchObject({
+      id: "feature-pack:FP-AMBIGUOUS",
+      publication: {
+        status: "needs-attention",
+        label: "Needs attention",
+        detail: "Marked contributed, but no sent-community proof was found.",
+      },
+      upstreamAcceptance: {
+        status: "needs-review",
+        label: "Needs provenance review",
+        detail: "Legacy status cannot prove whether the community accepted it.",
+      },
+    });
+  });
+
+  it("shows local-only FeaturePacks as kept here and not queued", async () => {
+    featurePackFindMany.mockResolvedValue([{
+      packId: "FP-LOCAL",
+      title: "Private workflow",
+      status: "local",
+      prUrl: null,
+      prNumber: null,
+      mergeReadiness: null,
+      reviewedAt: null,
+      createdAt: new Date("2026-07-15T12:00:00.000Z"),
+      manifest: {},
+      reviewReport: null,
+    }]);
+
+    const view = await getHiveContributionsView();
+
+    expect(view.contributionProvenance[0]).toMatchObject({
+      id: "feature-pack:FP-LOCAL",
+      localAvailability: { status: "saved-locally", label: "Saved locally", detail: "Feature Pack exists on this install." },
+      privacyDisposition: { status: "kept-here", label: "Kept on this system", detail: "No public contribution evidence was found." },
+      publication: { status: "not-queued", label: "Not queued", detail: "Nothing has been sent outside this install." },
+      upstreamAcceptance: { status: "not-sent", label: "Not sent", detail: "No community review exists." },
     });
   });
 });

--- a/apps/web/lib/actions/hive-contributions.ts
+++ b/apps/web/lib/actions/hive-contributions.ts
@@ -43,6 +43,26 @@ export type HiveContributionsView = {
     createdAt: string;
   }>;
   seedReviews: SeedContributionReviewRow[];
+  contributionProvenance: ContributionProvenanceRow[];
+};
+
+export type ContributionProvenanceAxis = {
+  status: string;
+  label: string;
+  detail: string;
+  url?: string;
+};
+
+export type ContributionProvenanceRow = {
+  id: string;
+  source: "feature-pack" | "improvement-proposal" | "hive-ledger";
+  title: string;
+  sourceLabel: string;
+  occurredAt: string;
+  localAvailability: ContributionProvenanceAxis;
+  privacyDisposition: ContributionProvenanceAxis;
+  publication: ContributionProvenanceAxis;
+  upstreamAcceptance: ContributionProvenanceAxis;
 };
 
 export type SeedContributionReviewRow = {
@@ -68,6 +88,20 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function stringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return null;
+}
+
+function firstNumber(...values: unknown[]): number | null {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return null;
 }
 
 const seedFitDecisions = new Set<string>(SEED_CONTRIBUTION_FIT_DECISIONS);
@@ -133,6 +167,204 @@ function toSeedReview(row: {
   };
 }
 
+function sentToCommunityAxis(prUrl: string, prNumber: number | null): ContributionProvenanceAxis {
+  return {
+    status: "sent-community",
+    label: "Sent to community project",
+    detail: prNumber ? `PR #${prNumber}` : "Public contribution PR recorded.",
+    url: prUrl,
+  };
+}
+
+function upstreamAxisFromLedgerStatus(status: string): ContributionProvenanceAxis {
+  switch (status) {
+    case "accepted":
+      return { status: "accepted", label: "Accepted by community", detail: "The community ledger marks this contribution accepted." };
+    case "rejected":
+      return { status: "rejected", label: "Rejected", detail: "The community ledger marks this contribution rejected." };
+    case "withdrawn":
+      return { status: "withdrawn", label: "Withdrawn", detail: "The contribution was withdrawn." };
+    case "curating":
+    case "submitted":
+      return { status: "under-review", label: "Under review", detail: "The community project has not accepted it yet." };
+    default:
+      return { status: "needs-review", label: "Needs provenance review", detail: `Ledger status is ${status}.` };
+  }
+}
+
+function upstreamAxisFromFeaturePackReview(mergeReadiness: string | null | undefined): ContributionProvenanceAxis {
+  if (mergeReadiness === "needs-work" || mergeReadiness === "blocked") {
+    return {
+      status: "needs-changes",
+      label: "Needs changes",
+      detail: "Contribution review found work that must be addressed before acceptance.",
+    };
+  }
+
+  return {
+    status: "under-review",
+    label: "Under review",
+    detail: "The community project has not accepted it yet.",
+  };
+}
+
+function featurePackProvenance(row: {
+  packId: string;
+  title: string;
+  status?: string | null;
+  prUrl?: string | null;
+  prNumber?: number | null;
+  mergeReadiness?: string | null;
+  reviewedAt?: Date | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+  manifest: unknown;
+}): ContributionProvenanceRow {
+  const manifest = asRecord(row.manifest);
+  const prUrl = firstString(row.prUrl, manifest?.prUrl);
+  const prNumber = firstNumber(row.prNumber, manifest?.prNumber);
+  const rawStatus = row.status ?? "local";
+  const occurredAt = (row.updatedAt ?? row.reviewedAt ?? row.createdAt ?? new Date(0)).toISOString();
+
+  const localAvailability: ContributionProvenanceAxis = {
+    status: "saved-locally",
+    label: "Saved locally",
+    detail: "Feature Pack exists on this install.",
+  };
+
+  if (prUrl) {
+    return {
+      id: `feature-pack:${row.packId}`,
+      source: "feature-pack",
+      title: row.title,
+      sourceLabel: "Feature Pack",
+      occurredAt,
+      localAvailability,
+      privacyDisposition: {
+        status: "approved-to-share",
+        label: "Approved to share",
+        detail: "A public community contribution record exists for this Feature Pack.",
+      },
+      publication: sentToCommunityAxis(prUrl, prNumber),
+      upstreamAcceptance: upstreamAxisFromFeaturePackReview(row.mergeReadiness),
+    };
+  }
+
+  if (rawStatus === "contributed") {
+    return {
+      id: `feature-pack:${row.packId}`,
+      source: "feature-pack",
+      title: row.title,
+      sourceLabel: "Feature Pack",
+      occurredAt,
+      localAvailability,
+      privacyDisposition: {
+        status: "approved-to-share",
+        label: "Approved to share",
+        detail: "Legacy Feature Pack status says contributed.",
+      },
+      publication: {
+        status: "needs-attention",
+        label: "Needs attention",
+        detail: "Marked contributed, but no sent-community proof was found.",
+      },
+      upstreamAcceptance: {
+        status: "needs-review",
+        label: "Needs provenance review",
+        detail: "Legacy status cannot prove whether the community accepted it.",
+      },
+    };
+  }
+
+  return {
+    id: `feature-pack:${row.packId}`,
+    source: "feature-pack",
+    title: row.title,
+    sourceLabel: "Feature Pack",
+    occurredAt,
+    localAvailability,
+    privacyDisposition: {
+      status: "kept-here",
+      label: "Kept on this system",
+      detail: "No public contribution evidence was found.",
+    },
+    publication: {
+      status: "not-queued",
+      label: "Not queued",
+      detail: "Nothing has been sent outside this install.",
+    },
+    upstreamAcceptance: {
+      status: "not-sent",
+      label: "Not sent",
+      detail: "No community review exists.",
+    },
+  };
+}
+
+function improvementProposalProvenance(row: {
+  proposalId: string;
+  title: string;
+  contributionStatus: string;
+  createdAt: Date;
+  updatedAt: Date;
+}): ContributionProvenanceRow {
+  const shared = row.contributionStatus === "contributed";
+  return {
+    id: `improvement-proposal:${row.proposalId}`,
+    source: "improvement-proposal",
+    title: row.title,
+    sourceLabel: "Improvement proposal",
+    occurredAt: row.updatedAt.toISOString(),
+    localAvailability: {
+      status: "saved-locally",
+      label: "Saved locally",
+      detail: "Improvement proposal exists on this install.",
+    },
+    privacyDisposition: shared
+      ? { status: "approved-to-share", label: "Approved to share", detail: "Proposal status says it was contributed." }
+      : { status: "kept-here", label: "Kept on this system", detail: "Proposal has not been contributed." },
+    publication: shared
+      ? { status: "sent-community", label: "Sent to community project", detail: "Contribution status says it was sent; no PR URL is attached." }
+      : { status: "not-queued", label: "Not queued", detail: "Nothing has been sent outside this install." },
+    upstreamAcceptance: shared
+      ? { status: "needs-review", label: "Needs provenance review", detail: "Legacy status does not prove community acceptance." }
+      : { status: "not-sent", label: "Not sent", detail: "No community review exists." },
+  };
+}
+
+function ledgerProvenance(row: {
+  id: string;
+  contributionType: string;
+  summary: string;
+  status: string;
+  redactionStatus: string | null;
+  createdAt: Date;
+}): ContributionProvenanceRow {
+  return {
+    id: `hive-ledger:${row.id}`,
+    source: "hive-ledger",
+    title: row.summary,
+    sourceLabel: row.contributionType,
+    occurredAt: row.createdAt.toISOString(),
+    localAvailability: {
+      status: "saved-locally",
+      label: "Saved locally",
+      detail: "Ledger record is stored on this install.",
+    },
+    privacyDisposition: {
+      status: row.redactionStatus === "blocked" ? "blocked-private-path" : "private-parts-removed",
+      label: row.redactionStatus === "blocked" ? "Blocked by policy" : "Private parts removed",
+      detail: row.redactionStatus ?? "Ledger contribution passed through the redaction boundary.",
+    },
+    publication: {
+      status: "sent-community",
+      label: "Sent to community project",
+      detail: "Hive ledger contains a public contribution record.",
+    },
+    upstreamAcceptance: upstreamAxisFromLedgerStatus(row.status),
+  };
+}
+
 export async function getHiveContributionsView(): Promise<HiveContributionsView> {
   const row = await prisma.platformDevConfig.findUnique({
     where: { id: "singleton" },
@@ -146,24 +378,37 @@ export async function getHiveContributionsView(): Promise<HiveContributionsView>
 
   const contributor = await getDisplayPseudonym().catch(() => null);
 
-  const [ledgerRows, featurePacks] = await Promise.all([
+  const [ledgerRows, featurePacks, improvementProposals] = await Promise.all([
     prisma.hiveContributionLedger.findMany({
       orderBy: { createdAt: "desc" },
       take: 50,
     }),
     prisma.featurePack.findMany({
-      where: { reviewedAt: { not: null } },
-      orderBy: { reviewedAt: "desc" },
+      orderBy: { updatedAt: "desc" },
       take: 50,
       select: {
         packId: true,
         title: true,
+        status: true,
         prUrl: true,
         prNumber: true,
         mergeReadiness: true,
         reviewedAt: true,
+        createdAt: true,
+        updatedAt: true,
         manifest: true,
         reviewReport: true,
+      },
+    }),
+    prisma.improvementProposal.findMany({
+      orderBy: { updatedAt: "desc" },
+      take: 50,
+      select: {
+        proposalId: true,
+        title: true,
+        contributionStatus: true,
+        createdAt: true,
+        updatedAt: true,
       },
     }),
   ]);
@@ -179,21 +424,30 @@ export async function getHiveContributionsView(): Promise<HiveContributionsView>
     createdAt: Date;
   };
 
+  const ledger = (ledgerRows as LedgerRow[]).map((r: LedgerRow) => ({
+    id: r.id,
+    contributionType: r.contributionType,
+    contributor: r.contributor,
+    ruleKey: r.ruleKey,
+    summary: r.summary,
+    status: r.status,
+    redactionStatus: r.redactionStatus,
+    createdAt: r.createdAt.toISOString(),
+  }));
+
+  const contributionProvenance = [
+    ...(featurePacks as Parameters<typeof featurePackProvenance>[0][]).map(featurePackProvenance),
+    ...(improvementProposals as Parameters<typeof improvementProposalProvenance>[0][]).map(improvementProposalProvenance),
+    ...(ledgerRows as LedgerRow[]).map(ledgerProvenance),
+  ].sort((a, b) => b.occurredAt.localeCompare(a.occurredAt));
+
   return {
     config,
     statuses: resolveHiveContributionStatuses(config),
     contributor,
-    ledger: (ledgerRows as LedgerRow[]).map((r: LedgerRow) => ({
-      id: r.id,
-      contributionType: r.contributionType,
-      contributor: r.contributor,
-      ruleKey: r.ruleKey,
-      summary: r.summary,
-      status: r.status,
-      redactionStatus: r.redactionStatus,
-      createdAt: r.createdAt.toISOString(),
-    })),
+    ledger,
     seedReviews: featurePacks.map(toSeedReview).filter((row): row is SeedContributionReviewRow => row !== null),
+    contributionProvenance,
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds a four-axis contribution provenance read model over `FeaturePack`, `ImprovementProposal`, and `HiveContributionLedger`.
- Adds an Admin > Hive “Contribution provenance” report that separately shows kept-here, privacy/disposition, sent-outside, and community-status states.
- Pins the confusing cases in tests: `FeaturePack.status=local` with a PR URL is still shown as sent to the community, while `status=contributed` without PR/outbox proof is flagged for provenance review.

## Related design
- Follows the reviewed forge-neutral contribution provenance design/spec update in #3012.

## Test plan
- [x] Red first: `pnpm --filter web exec vitest run lib/actions/hive-contributions.test.ts` failed on missing `contributionProvenance` read model.
- [x] `pnpm --filter web exec vitest run lib/actions/hive-contributions.test.ts components/admin/ContributionProvenanceTable.test.tsx` — 8 passed.
- [x] `NODE_OPTIONS="--max-old-space-size=8192" pnpm --filter web typecheck` — passed. Default heap hit Node OOM before type errors.
- [x] `NODE_OPTIONS="--max-old-space-size=8192" pnpm --filter web build` — passed; emitted existing Edge Runtime warnings from unrelated Node API imports.
- [x] `node scripts/check-spec-plan-doc.mjs --base origin/main --head HEAD`
- [x] `node scripts/check-ux-fit-decision.mjs`
- [x] `node scripts/check-design-grounding-decision.mjs`
- [x] `pnpm run pregate` — passed; local-CI merged candidate into `origin/main`, ran migrations, full web Vitest, TypeScript, and production build.

## UX fit
- Decision: fits-with-guardrails.
- Owning area: Platform / Admin Hive.
- Route family: existing `/admin/hive`; no new route or global navigation.
- Reuse: report-kit `DataTable`, `StatusBadge`, and `EmptyState`.
- Source truth: Hive contribution read model over existing contribution records.
- Empty/failure behavior: empty state for no provenance; ambiguous legacy contribution rows show “Needs attention” / “Needs provenance review.”

## Design grounding
- Existing specs/plans reviewed: `docs/superpowers/specs/2026-07-11-forge-neutral-offline-integration-design.md`, `docs/superpowers/plans/2026-07-11-forge-neutral-offline-integration-plan.md`.
- Current code substrate reviewed: `apps/web/lib/actions/hive-contributions.ts`, `apps/web/app/(shell)/admin/hive/page.tsx`, `apps/web/components/admin/SeedContributionReviewTable.tsx`.
- Source of truth: existing Hive contribution records; no new DB substrate.

Process-Spine-Decision: implementation follows the durable spec/plan update in PR #3012; separate docs PR carries the artifact while this PR keeps the code slice focused.
UX-Fit-Decision: fits-with-guardrails; Admin Hive report-kit table, no new route/control, plain-language axes for non-technical operators.

🤖 Generated with Codex
