### PR TITLE
feat(build): distinct "Coworker" count on the operator fleet header (BI-5939B62F)

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -27,6 +27,7 @@ import { BuildAssuranceGateCard } from "./BuildAssuranceGateCard";
 import { BuildListItem } from "./BuildListItem";
 import { EpicRollupListItem } from "./EpicRollupListItem";
 import {
+  deriveCoworkerActivityCount,
   deriveFleetCounts,
   deriveNeedsAttention,
   deriveQueueState,
@@ -1577,11 +1578,16 @@ function FleetRailZone({
     rollup.status === "in-progress"
     && rollup.children.some((child) => child.phase === "build" || child.phase === "review"),
   ).length;
+  // Coworker-custody work (ideate/plan) is off the operator focus rail by design,
+  // so it never shows in "Working". Surface it as a distinct "Coworker" count so
+  // the header reflects that the coworker is active, not that nothing is happening.
+  const coworkerCount = deriveCoworkerActivityCount(buildRows);
   const focusHeaderLabel = formatOperatorFocusHeader({
     needsYouCount,
     workingCount: counts.runningCount + workingEpicCount,
     blockedCount,
     queuedCount: counts.queuedCount,
+    coworkerCount,
     parkedCount: parkedItemCount,
   });
   const totalFocusItemCount = focusEpicRollups.length + focusEntries.length;

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -515,7 +515,7 @@ describe("BuildStudio active-build header layout", () => {
       />,
     );
 
-    expect(html).toContain("Needs you: 1 · Working: 2 · Parked: 5");
+    expect(html).toContain("Needs you: 1 · Working: 2 · Coworker: 6 · Parked: 5");
     expect(html).not.toContain("WIP slots");
     expect(html).toContain("Review customer entry gate");
     expect(html).toContain("Ship provider readiness check");

--- a/apps/web/components/build/fleet-derivation.test.ts
+++ b/apps/web/components/build/fleet-derivation.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  deriveCoworkerActivityCount,
   deriveFleetCounts,
   deriveNeedsAttention,
   deriveQueueState,
@@ -335,5 +336,34 @@ describe("formatOperatorFocusHeader", () => {
         parkedCount: 8,
       }),
     ).toBe("Needs you: 1 · Working: 2 · Parked: 8");
+  });
+
+  it("omits the Coworker segment when no coworker-custody work is active", () => {
+    expect(
+      formatOperatorFocusHeader({ needsYouCount: 0, workingCount: 0, parkedCount: 3, coworkerCount: 0 }),
+    ).toBe("Needs you: 0 · Working: 0 · Parked: 3");
+  });
+
+  it("shows a distinct Coworker segment (between Working and Parked) when > 0", () => {
+    expect(
+      formatOperatorFocusHeader({ needsYouCount: 0, workingCount: 0, parkedCount: 1, coworkerCount: 2 }),
+    ).toBe("Needs you: 0 · Working: 0 · Coworker: 2 · Parked: 1");
+  });
+});
+
+describe("deriveCoworkerActivityCount", () => {
+  it("counts only ideate/plan builds (the coworker's off-rail custody), not build/review/idle", () => {
+    const builds = [
+      { phase: "ideate" as const },
+      { phase: "plan" as const },
+      { phase: "plan" as const },
+      { phase: "build" as const },
+      { phase: "review" as const },
+      { phase: "ship" as const },
+      { phase: "complete" as const },
+      { phase: "failed" as const },
+    ];
+    expect(deriveCoworkerActivityCount(builds)).toBe(3);
+    expect(deriveCoworkerActivityCount([])).toBe(0);
   });
 });

--- a/apps/web/components/build/fleet-derivation.ts
+++ b/apps/web/components/build/fleet-derivation.ts
@@ -141,6 +141,19 @@ export function deriveFleetCounts(states: readonly BuildQueueState[]): {
   return { runningCount: running, queuedCount: queued, blockedCount: blocked };
 }
 
+/**
+ * How many builds the AI coworker is actively carrying in its own custody —
+ * ideate/plan phases that stay OFF the operator focus rail (isOperatorFocusEntry)
+ * but are genuinely in progress. Surfaced as a distinct "Coworker" header count so
+ * the operator sees activity is happening without those probes cluttering the rail
+ * or being conflated with operator-actionable "Working" builds (BI-5939B62F).
+ */
+export function deriveCoworkerActivityCount(
+  builds: ReadonlyArray<Pick<FeatureBuildRow, "phase">>,
+): number {
+  return builds.filter((b) => b.phase === "ideate" || b.phase === "plan").length;
+}
+
 export type OperatorFocusEntry = {
   build: Pick<FeatureBuildRow, "buildId" | "phase">;
   queueState: BuildQueueState;
@@ -174,12 +187,16 @@ export function formatOperatorFocusHeader({
   parkedCount,
   blockedCount = 0,
   queuedCount = 0,
+  coworkerCount = 0,
 }: {
   needsYouCount: number;
   workingCount: number;
   parkedCount: number;
   blockedCount?: number;
   queuedCount?: number;
+  /** Builds the coworker is actively working off-rail (ideate/plan). Shown only
+   *  when > 0 so it never adds noise on a quiet fleet. */
+  coworkerCount?: number;
 }): string {
   const parts = [
     `Needs you: ${needsYouCount}`,
@@ -190,6 +207,9 @@ export function formatOperatorFocusHeader({
   }
   if (queuedCount > 0) {
     parts.push(`Waiting: ${queuedCount}`);
+  }
+  if (coworkerCount > 0) {
+    parts.push(`Coworker: ${coworkerCount}`);
   }
   parts.push(`Parked: ${parkedCount}`);
   return parts.join(" · ");


### PR DESCRIPTION
## Design grounding
- **Existing specs/plans reviewed:** searched `docs/superpowers/plans` + `docs/superpowers/specs` — no dedicated fleet-derivation spec exists; grounded instead in PR #2963 (the counter fix that made ideate/plan derive to `running`) and the design comments in `fleet-derivation.ts`.
- **Current code substrate reviewed:** `apps/web/components/build/fleet-derivation.ts` (`deriveQueueState` / `isOperatorFocusEntry` — the deliberate off-rail exclusion) + `BuildStudio.tsx` `FleetRailZone`.
- **Decision:** *extend* additively — no change to the focus-rail exclusion contract.

## What
#2963 already fixed the fleet/queue **counters** reading 0. But the operator **focus header** still deliberately excludes ideate/plan (`isOperatorFocusEntry` keeps quiet coworker-custody probes off the rail), so it reads **"Working: 0"** while the coworker is actively ideating/planning.

This adds a **distinct, additive** signal:
- `deriveCoworkerActivityCount(builds)` — count of ideate/plan builds (off-rail coworker custody).
- `formatOperatorFocusHeader` gains an optional `coworkerCount` → a **"Coworker: N"** segment shown **only when > 0**, between Working and Parked. `FleetRailZone` computes and passes it.

Result: **"Working: 0 · Coworker: 2 · Parked: N"** — activity is visible without cluttering the focus rail. Legacy `FleetRail` component is test-only, left unchanged.

## Validation
- **27/27** fleet-derivation + **26/26** header-layout tests; `apps/web` tsc **0 errors** at 8GB.

Design-Grounding-Decision: extend — reviewed docs/superpowers (no fleet-derivation spec) + apps/web/components/build/fleet-derivation.ts + #2963; additive header count, focus-rail exclusion contract unchanged.

BI: BI-5939B62F