### PR TITLE
feat(twin): demo load path — loadDemoBusiness/unloadDemoBusiness (A·P1, BI-7C95BEF6)

### DIFF
--- a/apps/web/lib/demo/load-demo-business.test.ts
+++ b/apps/web/lib/demo/load-demo-business.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DEMO_REF_PREFIX } from "@dpf/storefront-templates";
+
+// The app-layer collaborators are mocked; we are testing the IO orchestration,
+// not the reset/seed/playbook internals (those have their own coverage).
+vi.mock("@dpf/db", () => ({ prisma: {} }));
+vi.mock("@/lib/storefront/archetype-reset", () => ({
+  resetStorefrontArchetype: vi.fn(async () => ({ storefrontId: "sf-1" })),
+}));
+vi.mock("@/lib/onboarding/setup-completion-seeds", () => ({
+  runSetupCompletionSeeds: vi.fn(async () => undefined),
+}));
+vi.mock("@/lib/tak/marketing-playbooks", () => ({
+  getPlaybook: () => ({ primaryGoal: "goal", keyMetrics: ["m1"] }),
+}));
+vi.mock("@/lib/onboarding/archetype-business-context", () => ({
+  resolveBusinessProfile: () => ({ whoWeServe: "who" }),
+}));
+
+import { loadDemoBusiness, unloadDemoBusiness } from "./load-demo-business";
+import { resetStorefrontArchetype } from "@/lib/storefront/archetype-reset";
+import { runSetupCompletionSeeds } from "@/lib/onboarding/setup-completion-seeds";
+
+/** Minimal in-memory prisma stand-in tracking upserts + deletes. */
+function makeFakeDb(opts: { nonDemoBookings?: number; nonDemoInvoices?: number } = {}) {
+  let seq = 0;
+  const created: Record<string, string[]> = {
+    provider: [],
+    supplier: [],
+    bill: [],
+    booking: [],
+    employee: [],
+  };
+  const model = (bucket: string, refField: string) => ({
+    upsert: vi.fn(async ({ create }: any) => {
+      created[bucket].push(create[refField]);
+      return { id: `${bucket}-${seq++}` };
+    }),
+    deleteMany: vi.fn(async ({ where }: any) => {
+      const prefix = where[refField].startsWith as string;
+      const remaining = created[bucket].filter((r) => !r.startsWith(prefix));
+      const count = created[bucket].length - remaining.length;
+      created[bucket] = remaining;
+      return { count };
+    }),
+    count: vi.fn(async () => 0),
+  });
+  const db: any = {
+    organization: { findFirst: vi.fn(async () => ({ id: "org-1" })) },
+    storefrontItem: { findMany: vi.fn(async () => [{ itemId: "item-a" }, { itemId: "item-b" }]) },
+    invoice: { count: vi.fn(async () => opts.nonDemoInvoices ?? 0) },
+    serviceProvider: model("provider", "providerId"),
+    supplier: model("supplier", "supplierId"),
+    bill: model("bill", "billRef"),
+    employeeProfile: model("employee", "employeeId"),
+    storefrontBooking: {
+      ...model("booking", "bookingRef"),
+      count: vi.fn(async () => opts.nonDemoBookings ?? 0),
+    },
+  };
+  return { db, created };
+}
+
+const ARCHETYPE = "dental-practice";
+
+describe("loadDemoBusiness", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("loads a demo, tagging every row with the demo prefix", async () => {
+    const { db, created } = makeFakeDb();
+    const result = await loadDemoBusiness(ARCHETYPE, { db, now: new Date(0) });
+
+    expect(resetStorefrontArchetype).toHaveBeenCalledWith(
+      expect.objectContaining({ targetArchetypeId: ARCHETYPE, mode: "replace-seeded-content" }),
+    );
+    expect(runSetupCompletionSeeds).toHaveBeenCalledWith("org-1");
+
+    for (const bucket of Object.values(created)) {
+      expect(bucket.length).toBeGreaterThan(0);
+      for (const ref of bucket) expect(ref.startsWith(DEMO_REF_PREFIX)).toBe(true);
+    }
+    expect(result.storefrontId).toBe("sf-1");
+    expect(result.counts.bookings).toBe(created.booking.length);
+    expect(result.seededAt).toEqual(new Date(0));
+  });
+
+  it("refuses to load over real (non-demo) bookings unless forced", async () => {
+    const { db } = makeFakeDb({ nonDemoBookings: 4 });
+    await expect(loadDemoBusiness(ARCHETYPE, { db })).rejects.toThrow(/non-demo data/);
+    expect(resetStorefrontArchetype).not.toHaveBeenCalled();
+  });
+
+  it("loads over non-demo data when force is set", async () => {
+    const { db } = makeFakeDb({ nonDemoInvoices: 2 });
+    await expect(loadDemoBusiness(ARCHETYPE, { db, force: true, now: new Date(0) })).resolves.toBeTruthy();
+    expect(resetStorefrontArchetype).toHaveBeenCalled();
+  });
+
+  it("throws on an unknown archetype", async () => {
+    const { db } = makeFakeDb();
+    await expect(loadDemoBusiness("not-a-real-archetype", { db })).rejects.toThrow(/unknown archetype/);
+  });
+});
+
+describe("unloadDemoBusiness", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("removes only demo rows and reports counts", async () => {
+    const { db } = makeFakeDb();
+    await loadDemoBusiness(ARCHETYPE, { db, now: new Date(0) });
+    const result = await unloadDemoBusiness({ archetypeId: ARCHETYPE, db });
+    expect(result.removed.bookings).toBeGreaterThan(0);
+    expect(result.removed.providers).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/lib/demo/load-demo-business.ts
+++ b/apps/web/lib/demo/load-demo-business.ts
@@ -1,0 +1,307 @@
+import { prisma } from "@dpf/db";
+import {
+  ALL_ARCHETYPES,
+  deriveDemoBusiness,
+  planDemoLoad,
+  demoTeardownSpec,
+  isSafeToLoadDemo,
+  DEMO_REF_PREFIX,
+  type DemoFlavor,
+  type DemoLoadPlan,
+} from "@dpf/storefront-templates";
+
+import { resetStorefrontArchetype } from "@/lib/storefront/archetype-reset";
+import { runSetupCompletionSeeds } from "@/lib/onboarding/setup-completion-seeds";
+import { getPlaybook } from "@/lib/tak/marketing-playbooks";
+import { resolveBusinessProfile } from "@/lib/onboarding/archetype-business-context";
+
+/**
+ * Archetype Demo Factory — the load path (EP-ARCHETYPE-DEMO A·P1).
+ *
+ * `loadDemoBusiness` stands up a realistic, persona'd business for an archetype
+ * on the deployment org by (1) setting the org archetype via the existing reset
+ * path, (2) generating a {@link deriveDemoBusiness} + mapping it with the pure
+ * {@link planDemoLoad}, (3) upserting the plan into the real tables tagged with a
+ * reversible `demo-` ref prefix, and (4) running the setup-completion seeds
+ * (incl. WWWD priming). The result renders through the LIVE
+ * `loadLivingBusinessSnapshot` projection — same code path, not a fixture.
+ *
+ * `unloadDemoBusiness` removes every `demo-` row — a clean, single-org-safe
+ * teardown. A guardrail refuses to load over an org that has real (non-demo)
+ * bookings or invoices (spec §4).
+ *
+ * Thin by design: all mapping/tagging logic lives in the pure, unit-tested
+ * `planDemoLoad`; this module is the IO shell (org resolution, dates, prisma
+ * upserts, seeds). `db` is injectable for tests.
+ */
+
+type Db = typeof prisma;
+
+const MIN = 60_000;
+const DAY = 86_400_000;
+
+export interface LoadDemoBusinessOptions {
+  flavor?: DemoFlavor;
+  /** Load even if the org already has non-demo data (default false — the guardrail). */
+  force?: boolean;
+  db?: Db;
+  /** Injected clock for deterministic tests; defaults to now. */
+  now?: Date;
+}
+
+export interface LoadDemoBusinessResult {
+  archetypeId: string;
+  storefrontId: string;
+  seededAt: Date;
+  counts: {
+    providers: number;
+    bookings: number;
+    bills: number;
+    suppliers: number;
+    employees: number;
+  };
+}
+
+async function nonDemoDataCounts(db: Db): Promise<{ bookings: number; invoices: number }> {
+  const [bookings, invoices] = await Promise.all([
+    db.storefrontBooking.count({ where: { NOT: { bookingRef: { startsWith: DEMO_REF_PREFIX } } } }),
+    db.invoice.count({ where: { NOT: { invoiceRef: { startsWith: DEMO_REF_PREFIX } } } }),
+  ]);
+  return { bookings, invoices };
+}
+
+export async function loadDemoBusiness(
+  archetypeId: string,
+  options: LoadDemoBusinessOptions = {},
+): Promise<LoadDemoBusinessResult> {
+  const db = options.db ?? prisma;
+  const now = options.now ?? new Date();
+
+  const archetype = ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId);
+  if (!archetype) throw new Error(`loadDemoBusiness: unknown archetype "${archetypeId}"`);
+
+  const org = await db.organization.findFirst({ select: { id: true } });
+  if (!org) throw new Error("loadDemoBusiness: no deployment organization found");
+
+  // Guardrail — never clobber a real operating business (spec §4).
+  if (!options.force) {
+    const counts = await nonDemoDataCounts(db);
+    if (!isSafeToLoadDemo(counts)) {
+      throw new Error(
+        `loadDemoBusiness: refusing to load over non-demo data ` +
+          `(${counts.bookings} bookings, ${counts.invoices} invoices). Pass force:true to override.`,
+      );
+    }
+  }
+
+  // 1. Set the org archetype (reseeds sections/items/provider) via the existing path.
+  const reset = await resetStorefrontArchetype({
+    organizationId: org.id,
+    targetArchetypeId: archetypeId,
+    mode: "replace-seeded-content",
+  });
+  const { storefrontId } = reset;
+
+  // Real items to attach demo bookings to.
+  const items = await db.storefrontItem.findMany({
+    where: { storefrontId },
+    select: { itemId: true },
+  });
+  const itemIds = items.map((i) => i.itemId);
+  if (itemIds.length === 0) {
+    throw new Error(`loadDemoBusiness: archetype "${archetypeId}" seeded no storefront items`);
+  }
+
+  // 2. Generate + plan. Enrichment (playbook KPIs, who-we-serve) is wired in here
+  //    because those helpers live in the app; the package core stays pure.
+  const playbook = getPlaybook(archetype.category, archetype.ctaType);
+  const businessProfile = resolveBusinessProfile({
+    archetypeId: archetype.archetypeId,
+    industry: archetype.category,
+  });
+  const demo = deriveDemoBusiness(archetype, {
+    flavor: options.flavor,
+    playbook: { primaryGoal: playbook.primaryGoal, keyMetrics: playbook.keyMetrics },
+    businessProfile: { whoWeServe: businessProfile.whoWeServe },
+  });
+  const plan: DemoLoadPlan = planDemoLoad(demo, { storefrontId, itemIds });
+
+  // 3. Upsert the plan (parents first so FK targets exist; demo-tagged, idempotent).
+  await upsertEmployees(db, plan);
+  const supplierIdByRef = await upsertSuppliers(db, plan);
+  const providerIdByRef = await upsertProviders(db, plan, storefrontId);
+  await upsertBills(db, plan, supplierIdByRef, now);
+  await upsertBookings(db, plan, storefrontId, providerIdByRef, now);
+
+  // 4. Setup-completion seeds (WWWD priming corpus etc.) — fail-open, idempotent.
+  await runSetupCompletionSeeds(org.id);
+
+  return {
+    archetypeId,
+    storefrontId,
+    seededAt: now,
+    counts: {
+      providers: plan.providers.length,
+      bookings: plan.bookings.length,
+      bills: plan.bills.length,
+      suppliers: plan.suppliers.length,
+      employees: plan.employees.length,
+    },
+  };
+}
+
+async function upsertEmployees(db: Db, plan: DemoLoadPlan): Promise<void> {
+  for (const e of plan.employees) {
+    await db.employeeProfile.upsert({
+      where: { employeeId: e.employeeRef },
+      create: {
+        employeeId: e.employeeRef,
+        firstName: e.firstName,
+        lastName: e.lastName,
+        displayName: e.displayName,
+      },
+      update: { firstName: e.firstName, lastName: e.lastName, displayName: e.displayName },
+    });
+  }
+}
+
+async function upsertSuppliers(db: Db, plan: DemoLoadPlan): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  for (const s of plan.suppliers) {
+    const row = await db.supplier.upsert({
+      where: { supplierId: s.supplierId },
+      create: { supplierId: s.supplierId, name: s.name },
+      update: { name: s.name },
+      select: { id: true },
+    });
+    map.set(s.supplierId, row.id);
+  }
+  return map;
+}
+
+async function upsertProviders(
+  db: Db,
+  plan: DemoLoadPlan,
+  storefrontId: string,
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  for (const p of plan.providers) {
+    const row = await db.serviceProvider.upsert({
+      where: { providerId: p.providerId },
+      create: { providerId: p.providerId, storefrontId, name: p.name, isActive: p.isActive },
+      update: { name: p.name, isActive: p.isActive, storefrontId },
+      select: { id: true },
+    });
+    map.set(p.providerId, row.id);
+  }
+  return map;
+}
+
+async function upsertBills(
+  db: Db,
+  plan: DemoLoadPlan,
+  supplierIdByRef: Map<string, string>,
+  now: Date,
+): Promise<void> {
+  for (const b of plan.bills) {
+    const supplierId = supplierIdByRef.get(b.supplierId);
+    if (!supplierId) continue; // planner guarantees a supplier; defensive
+    const issueDate = new Date(now.getTime() - b.issuedDaysAgo * DAY);
+    const dueDate = new Date(now.getTime() + b.dueInDays * DAY);
+    const money = { subtotal: b.subtotal, totalAmount: b.totalAmount, amountDue: b.amountDue };
+    await db.bill.upsert({
+      where: { billRef: b.billRef },
+      create: {
+        billRef: b.billRef,
+        supplierId,
+        issueDate,
+        dueDate,
+        currency: b.currency,
+        status: b.status,
+        ...money,
+      },
+      update: { supplierId, issueDate, dueDate, currency: b.currency, status: b.status, ...money },
+    });
+  }
+}
+
+async function upsertBookings(
+  db: Db,
+  plan: DemoLoadPlan,
+  storefrontId: string,
+  providerIdByRef: Map<string, string>,
+  now: Date,
+): Promise<void> {
+  for (const bk of plan.bookings) {
+    const providerId = bk.providerId ? providerIdByRef.get(bk.providerId) ?? null : null;
+    const scheduledAt = new Date(now.getTime() + bk.scheduledInMinutes * MIN);
+    const createdAt = new Date(now.getTime() - bk.createdMinutesAgo * MIN);
+    await db.storefrontBooking.upsert({
+      where: { bookingRef: bk.bookingRef },
+      create: {
+        bookingRef: bk.bookingRef,
+        storefrontId,
+        itemId: bk.itemId,
+        providerId,
+        customerName: bk.customerName,
+        customerEmail: bk.customerEmail,
+        scheduledAt,
+        durationMinutes: bk.durationMinutes,
+        status: bk.status,
+        createdAt,
+      },
+      update: {
+        providerId,
+        scheduledAt,
+        status: bk.status,
+        customerName: bk.customerName,
+        customerEmail: bk.customerEmail,
+      },
+    });
+  }
+}
+
+export interface UnloadDemoBusinessResult {
+  removed: {
+    bookings: number;
+    providers: number;
+    bills: number;
+    suppliers: number;
+    employees: number;
+  };
+}
+
+/**
+ * Remove every demo row (children before parents so FK constraints hold). Scope
+ * to one archetype's prefix when given, else remove all demo rows.
+ */
+export async function unloadDemoBusiness(
+  options: { archetypeId?: string; db?: Db } = {},
+): Promise<UnloadDemoBusinessResult> {
+  const db = options.db ?? prisma;
+  const spec = demoTeardownSpec(options.archetypeId);
+
+  const bookings = await db.storefrontBooking.deleteMany({
+    where: { bookingRef: { startsWith: spec.bookingRefPrefix } },
+  });
+  const providers = await db.serviceProvider.deleteMany({
+    where: { providerId: { startsWith: spec.providerRefPrefix } },
+  });
+  const bills = await db.bill.deleteMany({ where: { billRef: { startsWith: spec.billRefPrefix } } });
+  const suppliers = await db.supplier.deleteMany({
+    where: { supplierId: { startsWith: spec.supplierRefPrefix } },
+  });
+  const employees = await db.employeeProfile.deleteMany({
+    where: { employeeId: { startsWith: spec.employeeRefPrefix } },
+  });
+
+  return {
+    removed: {
+      bookings: bookings.count,
+      providers: providers.count,
+      bills: bills.count,
+      suppliers: suppliers.count,
+      employees: employees.count,
+    },
+  };
+}

--- a/docs/superpowers/plans/2026-07-15-archetype-demo-factory-execution.md
+++ b/docs/superpowers/plans/2026-07-15-archetype-demo-factory-execution.md
@@ -30,15 +30,23 @@ no `Math.random`/`Date` in the core).
   shows money in-flight *and* revenue accruing. `evaluateDemoDelight` is exported for reuse as the P4
   CI gate. **Verified:** 100 tests green (94 oracle + determinism/flavor/enrichment/grounding/golden);
   full package suite 238/238.
-- ⏳ **Next** — `apps/web/lib/demo/load-demo-business.ts` — `loadDemoBusiness(archetypeId, { flavor? })` /
-  `unloadDemoBusiness()`: upsert the generated `DemoBusiness` into the real tables, set the org
-  archetype via the existing reset path (`resetStorefrontArchetype`), run `runSetupCompletionSeeds`.
-  Provenance/teardown: most target models (`StorefrontBooking`, `ServiceProvider`, `Bill`,
-  `TaxObligationPeriod`, `Obligation`) have **no** `source` column, so demo rows are tagged with a
-  stable `demo-` prefix on their `@unique` refs (`bookingRef`/`providerId`/`billRef`/…) for a
-  `deleteMany({ startsWith: "demo-" })` teardown (resolves spec §9.1). Guardrail: never load over
-  non-demo data. Verified against the **live** `loadLivingBusinessSnapshot` (same code path, not a
-  fixture).
+- ✅ **Landed (pure planner)** — `packages/storefront-templates/src/demo-business-load.ts` —
+  `planDemoLoad(demo, { storefrontId, itemIds })` maps a `DemoBusiness` onto the exact rows the live
+  loader reads (`ServiceProvider`, `StorefrontBooking`, `Bill`/`Supplier`, `EmployeeProfile`),
+  DB-free and deterministic, so the risky part — field mapping, reversible `demo-` tagging, the
+  load-over-real-data guardrail (`isSafeToLoadDemo`) — is unit-tested without a database. Provenance:
+  most target models have **no** `source` column, so every demo row carries a stable `demo-` prefix
+  on its `@unique` ref; `demoTeardownSpec` drives a `deleteMany({ startsWith })` teardown (resolves
+  spec §9.1). **Verified:** planner suite green over all 94 (refs/FK-safety/status-mapping/teardown/
+  guardrail); package suite stays green.
+- ✅ **Landed (thin executor)** — `apps/web/lib/demo/load-demo-business.ts` — `loadDemoBusiness` /
+  `unloadDemoBusiness`: resolve the org, run the guardrail, set the archetype via
+  `resetStorefrontArchetype`, execute `planDemoLoad` as prisma upserts (parents first; FK ids
+  resolved for `Bill.supplierId`→`Supplier.id`, `Booking.providerId`→`ServiceProvider.id`), and run
+  `runSetupCompletionSeeds`. `db` is injectable; covered by a fake-db unit test (guardrail refusal,
+  demo-prefix tagging, reversible teardown) run in CI. Schema wiring verified against the live DB
+  (`information_schema` column + FK checks). **Remaining tier:** end-to-end render through the live
+  `loadLivingBusinessSnapshot` on a running install — exercised by P2's gallery / a deployed build.
 
 ## P2 — the gallery (founder review surface)
 

--- a/packages/storefront-templates/src/demo-business-load.test.ts
+++ b/packages/storefront-templates/src/demo-business-load.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { ALL_ARCHETYPES } from "./archetypes/index";
+import { deriveDemoBusiness } from "./demo-business";
+import {
+  planDemoLoad,
+  demoTeardownSpec,
+  isSafeToLoadDemo,
+  DEMO_REF_PREFIX,
+} from "./demo-business-load";
+
+const ITEM_IDS = ["item-a", "item-b", "item-c"];
+
+describe("planDemoLoad", () => {
+  it("maps every archetype onto a reversible, demo-tagged plan", () => {
+    for (const archetype of ALL_ARCHETYPES) {
+      const demo = deriveDemoBusiness(archetype);
+      const plan = planDemoLoad(demo, { storefrontId: "sf-1", itemIds: ITEM_IDS });
+
+      // Every business ref carries the demo prefix (reversible teardown).
+      for (const p of plan.providers) expect(p.providerId.startsWith(DEMO_REF_PREFIX)).toBe(true);
+      for (const s of plan.suppliers) expect(s.supplierId.startsWith(DEMO_REF_PREFIX)).toBe(true);
+      for (const b of plan.bills) expect(b.billRef.startsWith(DEMO_REF_PREFIX)).toBe(true);
+      for (const bk of plan.bookings) expect(bk.bookingRef.startsWith(DEMO_REF_PREFIX)).toBe(true);
+      for (const e of plan.employees) expect(e.employeeRef.startsWith(DEMO_REF_PREFIX)).toBe(true);
+
+      // Bookings attach to a provided item and, when assigned, to a demo provider.
+      const providerRefs = new Set(plan.providers.map((p) => p.providerId));
+      for (const bk of plan.bookings) {
+        expect(ITEM_IDS).toContain(bk.itemId);
+        if (bk.providerId) expect(providerRefs.has(bk.providerId)).toBe(true);
+        expect(bk.customerEmail).toContain("@");
+      }
+
+      // Bills reference a supplier the plan also creates (FK-safe).
+      const supplierRefs = new Set(plan.suppliers.map((s) => s.supplierId));
+      for (const b of plan.bills) expect(supplierRefs.has(b.supplierId)).toBe(true);
+
+      // One booking per demand item; one employee per human worker.
+      expect(plan.bookings).toHaveLength(demo.demand.length);
+      expect(plan.employees).toHaveLength(demo.workforce.filter((w) => w.kind === "human").length);
+      expect(plan.providers).toHaveLength(demo.resources.length);
+    }
+  });
+
+  it("maps queue state → booking status and preserves wait-time", () => {
+    const archetype = ALL_ARCHETYPES.find((a) => a.archetypeId === "dental-practice") ?? ALL_ARCHETYPES[0];
+    const demo = deriveDemoBusiness(archetype);
+    const plan = planDemoLoad(demo, { storefrontId: "sf-1", itemIds: ITEM_IDS });
+
+    demo.demand.forEach((item, i) => {
+      const bk = plan.bookings[i];
+      expect(bk.createdMinutesAgo).toBe(item.waitingMinutes);
+      if (item.queueKey) expect(bk.status).toBe("pending");
+      else if (item.stageKey === "settle") expect(bk.status).toBe("completed");
+      else expect(bk.status).toBe("confirmed");
+    });
+
+    // A pending booking's wait-time is the queue age; it is scheduled in the future.
+    const pending = plan.bookings.filter((b) => b.status === "pending");
+    expect(pending.length).toBeGreaterThan(0);
+    for (const b of pending) {
+      expect(b.createdMinutesAgo).toBeGreaterThanOrEqual(1);
+      expect(b.scheduledInMinutes).toBeGreaterThan(0);
+    }
+  });
+
+  it("carries the currency and reuses one supplier ref across bills", () => {
+    const demo = deriveDemoBusiness(ALL_ARCHETYPES[0], { flavor: { currency: "USD" } });
+    const plan = planDemoLoad(demo, { storefrontId: "sf-1", itemIds: ITEM_IDS });
+    expect(plan.currency).toBe("USD");
+    for (const b of plan.bills) expect(b.currency).toBe("USD");
+    // Deduped: never more suppliers than bills.
+    expect(plan.suppliers.length).toBeLessThanOrEqual(plan.bills.length);
+  });
+
+  it("throws rather than write orphaned bookings when no items exist", () => {
+    const demo = deriveDemoBusiness(ALL_ARCHETYPES[0]);
+    expect(() => planDemoLoad(demo, { storefrontId: "sf-1", itemIds: [] })).toThrow();
+  });
+});
+
+describe("demoTeardownSpec", () => {
+  it("scopes teardown prefixes per archetype and globally", () => {
+    const scoped = demoTeardownSpec("dental-practice");
+    expect(scoped.bookingRefPrefix).toBe("demo-dental-practice-bk-");
+    expect(scoped.providerRefPrefix).toBe("demo-dental-practice-prov-");
+    const global = demoTeardownSpec();
+    expect(global.bookingRefPrefix).toBe(DEMO_REF_PREFIX);
+  });
+
+  it("teardown prefixes actually match the refs a plan produces", () => {
+    const demo = deriveDemoBusiness(ALL_ARCHETYPES[0], { seed: "dental-practice" });
+    const plan = planDemoLoad(demo, { storefrontId: "sf-1", itemIds: ITEM_IDS });
+    const spec = demoTeardownSpec(demo.archetypeId);
+    for (const bk of plan.bookings) expect(bk.bookingRef.startsWith(spec.bookingRefPrefix)).toBe(true);
+    for (const p of plan.providers) expect(p.providerId.startsWith(spec.providerRefPrefix)).toBe(true);
+    for (const b of plan.bills) expect(b.billRef.startsWith(spec.billRefPrefix)).toBe(true);
+    for (const s of plan.suppliers) expect(s.supplierId.startsWith(spec.supplierRefPrefix)).toBe(true);
+    for (const e of plan.employees) expect(e.employeeRef.startsWith(spec.employeeRefPrefix)).toBe(true);
+  });
+});
+
+describe("isSafeToLoadDemo", () => {
+  it("refuses to load over a real operating business", () => {
+    expect(isSafeToLoadDemo({ bookings: 0, invoices: 0 })).toBe(true);
+    expect(isSafeToLoadDemo({ bookings: 3, invoices: 0 })).toBe(false);
+    expect(isSafeToLoadDemo({ bookings: 0, invoices: 2 })).toBe(false);
+  });
+});

--- a/packages/storefront-templates/src/demo-business-load.ts
+++ b/packages/storefront-templates/src/demo-business-load.ts
@@ -1,0 +1,252 @@
+import type {
+  DemoBusiness,
+  DemoBill,
+  DemoDemandItem,
+} from "./demo-business";
+
+/**
+ * Archetype Demo Factory — the **pure load plan** (EP-ARCHETYPE-DEMO A·P1).
+ *
+ * `planDemoLoad` maps a generated {@link DemoBusiness} onto the exact rows the
+ * live `loadLivingBusinessSnapshot` projection reads (ServiceProvider,
+ * StorefrontBooking, Bill/Supplier, EmployeeProfile) — deterministically and
+ * DB-free, so the risky part (field mapping, reversible `demo-` tagging, the
+ * load-over-real-data guardrail) is unit-testable without a database. The thin
+ * `apps/web/lib/demo/load-demo-business.ts` executor resolves the storefront/item
+ * ids, stamps absolute dates, and runs the prisma upserts from this plan.
+ *
+ * Provenance/teardown (spec §4, §9.1): most target models have **no** `source`
+ * column, so every demo row carries a stable {@link DEMO_REF_PREFIX} on its
+ * `@unique` business ref. Teardown is a `deleteMany({ ref: { startsWith:
+ * DEMO_REF_PREFIX } })` — fully reversible, single-org-safe.
+ *
+ * PURE + DB-free + deterministic (no `Math.random`/`Date`): the plan speaks in
+ * *relative* offsets (minutes/days); the executor turns them into timestamps.
+ */
+
+export const DEMO_REF_PREFIX = "demo-";
+
+export interface DemoProviderUpsert {
+  /** `demo-<archetypeId>-<resourceKey>` — the ServiceProvider.providerId. */
+  providerId: string;
+  name: string;
+  isActive: boolean;
+  /** The demo employee this provider is (when the resource is a person). */
+  employeeRef?: string;
+}
+
+export interface DemoSupplierUpsert {
+  supplierId: string;
+  name: string;
+}
+
+export interface DemoBillUpsert {
+  billRef: string;
+  supplierId: string;
+  subtotal: number;
+  totalAmount: number;
+  amountDue: number;
+  currency: string;
+  status: string;
+  /** Days ago the bill was issued (executor: issueDate = now − issuedDaysAgo). */
+  issuedDaysAgo: number;
+  /** Days ahead the bill is due (executor: dueDate = now + dueInDays). */
+  dueInDays: number;
+}
+
+export interface DemoBookingUpsert {
+  bookingRef: string;
+  itemId: string;
+  providerId?: string;
+  customerName: string;
+  customerEmail: string;
+  /** Minutes from now the booking is scheduled (negative = past). */
+  scheduledInMinutes: number;
+  /** Minutes ago the booking was created — drives the twin's queue wait-time. */
+  createdMinutesAgo: number;
+  durationMinutes: number;
+  status: "pending" | "confirmed" | "completed";
+}
+
+export interface DemoEmployeeUpsert {
+  employeeRef: string;
+  firstName: string;
+  lastName: string;
+  displayName: string;
+  role: string;
+}
+
+export interface DemoLoadPlan {
+  archetypeId: string;
+  currency: string;
+  providers: DemoProviderUpsert[];
+  suppliers: DemoSupplierUpsert[];
+  bills: DemoBillUpsert[];
+  bookings: DemoBookingUpsert[];
+  employees: DemoEmployeeUpsert[];
+}
+
+export interface PlanDemoLoadInput {
+  /** The deployment org's storefront id (resolved by the executor). */
+  storefrontId: string;
+  /** Real StorefrontItem ids to attach demo bookings to (bookings round-robin over them). */
+  itemIds: string[];
+  /** Default booking length when the archetype has none. */
+  defaultDurationMinutes?: number;
+}
+
+function ref(archetypeId: string, kind: string, key: string): string {
+  return `${DEMO_REF_PREFIX}${archetypeId}-${kind}-${key}`;
+}
+
+function splitName(name: string): { firstName: string; lastName: string } {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return { firstName: parts[0], lastName: "" };
+  return { firstName: parts[0], lastName: parts.slice(1).join(" ") };
+}
+
+function bookingStatusFor(item: DemoDemandItem): DemoBookingUpsert["status"] {
+  if (item.queueKey) return "pending"; // waiting in a queue
+  if (item.stageKey === "settle") return "completed"; // recently settled
+  return "confirmed"; // in-flight / being delivered
+}
+
+function scheduledMinutesFor(item: DemoDemandItem, index: number): number {
+  const status = bookingStatusFor(item);
+  if (status === "completed") return -(60 + index * 30); // in the recent past
+  if (status === "pending") return 30 + index * 15; // upcoming
+  return 5 + index * 5; // in-flight, imminent
+}
+
+/**
+ * Map a demo business onto its load plan. Pure and total. `input.itemIds` must
+ * be non-empty (bookings need a real item to attach to); throws otherwise so the
+ * executor fails loudly rather than writing orphaned rows.
+ */
+export function planDemoLoad(demo: DemoBusiness, input: PlanDemoLoadInput): DemoLoadPlan {
+  if (input.itemIds.length === 0) {
+    throw new Error(`planDemoLoad: no StorefrontItem ids for ${demo.archetypeId}`);
+  }
+  const { archetypeId } = demo;
+  const duration = input.defaultDurationMinutes ?? 30;
+
+  // Employees — the human workforce (AI coworkers rely on existing seeded Agents).
+  const employees: DemoEmployeeUpsert[] = demo.workforce
+    .filter((w) => w.kind === "human")
+    .map((w) => {
+      const { firstName, lastName } = splitName(w.name);
+      return {
+        employeeRef: ref(archetypeId, "emp", w.key),
+        firstName,
+        lastName,
+        displayName: w.name,
+        role: w.role,
+      };
+    });
+  const employeeRefByWorker = new Map(
+    demo.workforce.filter((w) => w.kind === "human").map((w) => [w.key, ref(archetypeId, "emp", w.key)]),
+  );
+
+  // Providers — the countable resources the twin arranges in zones.
+  const providers: DemoProviderUpsert[] = demo.resources.map((r) => ({
+    providerId: ref(archetypeId, "prov", r.key),
+    name: r.label,
+    isActive: true,
+    ...(r.workerKey && employeeRefByWorker.has(r.workerKey)
+      ? { employeeRef: employeeRefByWorker.get(r.workerKey) }
+      : {}),
+  }));
+  const providerRefByResource = new Map(demo.resources.map((r) => [r.key, ref(archetypeId, "prov", r.key)]));
+
+  // Suppliers — deduped from the bills.
+  const supplierRefByName = new Map<string, string>();
+  const suppliers: DemoSupplierUpsert[] = [];
+  for (const bill of demo.finance.bills) {
+    if (!supplierRefByName.has(bill.supplierName)) {
+      const supplierId = ref(
+        archetypeId,
+        "sup",
+        bill.supplierName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, ""),
+      );
+      supplierRefByName.set(bill.supplierName, supplierId);
+      suppliers.push({ supplierId, name: bill.supplierName });
+    }
+  }
+
+  const bills: DemoBillUpsert[] = demo.finance.bills.map((bill: DemoBill) => ({
+    billRef: ref(archetypeId, "bill", bill.key),
+    supplierId: supplierRefByName.get(bill.supplierName)!,
+    subtotal: bill.amountDue,
+    totalAmount: bill.amountDue,
+    amountDue: bill.amountDue,
+    currency: demo.currency,
+    status: bill.status === "overdue" ? "approved" : bill.status,
+    issuedDaysAgo: 7,
+    dueInDays: bill.dueInDays,
+  }));
+
+  // Customer lookup for booking contact fields.
+  const customerByKey = new Map(demo.customers.map((c) => [c.key, c]));
+
+  // Demand → bookings (the twin's demand + queue spine).
+  const bookings: DemoBookingUpsert[] = demo.demand.map((item, i) => {
+    const customer = customerByKey.get(item.customerKey) ?? demo.customers[0];
+    const providerId = item.assignedResourceKey
+      ? providerRefByResource.get(item.assignedResourceKey)
+      : undefined;
+    return {
+      bookingRef: ref(archetypeId, "bk", String(i)),
+      itemId: input.itemIds[i % input.itemIds.length],
+      ...(providerId ? { providerId } : {}),
+      customerName: customer.name,
+      customerEmail: customer.email,
+      scheduledInMinutes: scheduledMinutesFor(item, i),
+      createdMinutesAgo: item.waitingMinutes,
+      durationMinutes: duration,
+      status: bookingStatusFor(item),
+    };
+  });
+
+  return {
+    archetypeId,
+    currency: demo.currency,
+    providers,
+    suppliers,
+    bills,
+    bookings,
+    employees,
+  };
+}
+
+/**
+ * The `@unique`-ref prefixes the teardown deletes by, per model. The executor
+ * runs `deleteMany` in this order (children before parents) so FK constraints
+ * hold: bookings → providers, bills → suppliers, providers → employees.
+ */
+export interface DemoTeardownSpec {
+  bookingRefPrefix: string;
+  providerRefPrefix: string;
+  billRefPrefix: string;
+  supplierRefPrefix: string;
+  employeeRefPrefix: string;
+}
+
+export function demoTeardownSpec(archetypeId?: string): DemoTeardownSpec {
+  const base = archetypeId ? `${DEMO_REF_PREFIX}${archetypeId}-` : DEMO_REF_PREFIX;
+  return {
+    bookingRefPrefix: archetypeId ? `${base}bk-` : DEMO_REF_PREFIX,
+    providerRefPrefix: archetypeId ? `${base}prov-` : DEMO_REF_PREFIX,
+    billRefPrefix: archetypeId ? `${base}bill-` : DEMO_REF_PREFIX,
+    supplierRefPrefix: archetypeId ? `${base}sup-` : DEMO_REF_PREFIX,
+    employeeRefPrefix: archetypeId ? `${base}emp-` : DEMO_REF_PREFIX,
+  };
+}
+
+/**
+ * The load-over-real-data guardrail (spec §4). Given counts of rows whose refs
+ * do NOT carry the demo prefix, decide whether loading a demo is safe. Real
+ * bookings or invoices mean a real operating business — refuse.
+ */
+export function isSafeToLoadDemo(nonDemoCounts: { bookings: number; invoices: number }): boolean {
+  return nonDemoCounts.bookings === 0 && nonDemoCounts.invoices === 0;
+}

--- a/packages/storefront-templates/src/index.ts
+++ b/packages/storefront-templates/src/index.ts
@@ -10,4 +10,5 @@ export * from "./media-profile";
 export * from "./operational-value-stream";
 export * from "./twin-profile";
 export * from "./demo-business";
+export * from "./demo-business-load";
 export * from "./sections/schemas";


### PR DESCRIPTION
## Summary

Completes **A·P1** (`EP-ARCHETYPE-DEMO` / `BI-7C95BEF6`): the reversible **load path** that stands up a generated demo business on the deployment org so it renders through the **live** `loadLivingBusinessSnapshot` projection — same code path, not a fixture. Builds on the generator merged in #3023.

Built directly (Claude Code, not Build Studio) under the relaxed policy; tracked on `BI-7C95BEF6` (capsule `WC-C8177ACA`).

## Design: pure planner + thin executor

The mapping is where the risk is (field names, FK ids, reversible tagging, the guardrail), so it's a **pure, DB-free, fully unit-tested planner**; the app module is a thin IO shell.

- **`packages/storefront-templates/src/demo-business-load.ts`** — `planDemoLoad(demo, { storefrontId, itemIds })` maps a `DemoBusiness` onto the exact rows the live loader reads (`ServiceProvider`, `StorefrontBooking`, `Bill`/`Supplier`, `EmployeeProfile`). Deterministic (no `Date`/`Math.random`; relative offsets the executor stamps into timestamps). `isSafeToLoadDemo` = the load-over-real-data guardrail; `demoTeardownSpec` = the teardown prefixes.
- **`apps/web/lib/demo/load-demo-business.ts`** — `loadDemoBusiness` / `unloadDemoBusiness`: resolve the org, run the guardrail, set the archetype via `resetStorefrontArchetype`, execute the plan as prisma upserts (parents first; `Bill.supplierId`→`Supplier.id` and `Booking.providerId`→`ServiceProvider.id` resolved post-upsert), run `runSetupCompletionSeeds`. `db` injectable.

## Provenance / reversibility (resolves spec §9.1)

Most target models (`StorefrontBooking`, `ServiceProvider`, `Bill`, …) have **no** `source` column, so every demo row carries a stable **`demo-` prefix** on its `@unique` ref (`bookingRef`/`providerId`/`billRef`/`supplierId`/`employeeId`). `unloadDemoBusiness` is `deleteMany({ startsWith: "demo-…" })`, children before parents — a clean, single-org-safe teardown. A guardrail refuses to load over an org that has **real (non-demo) bookings or invoices**.

## Test plan

- [x] `planDemoLoad` over all 94 — every ref demo-tagged; bookings attach to real items; bills→suppliers FK-safe; one booking per demand item / one employee per human
- [x] queue-state → booking status (`pending`/`confirmed`/`completed`) with **wait-time preserved** (`createdMinutesAgo` = queue age, so the live loader derives the right wait)
- [x] teardown prefixes actually match the refs a plan produces; `isSafeToLoadDemo` guardrail
- [x] Executor fake-db unit test: guardrail refusal, `force` override, demo-prefix tagging, unknown-archetype, reversible teardown
- [x] **`@dpf/storefront-templates` suite 245/245; `apps/web` typecheck clean; executor test 5/5**
- [x] Schema + FK wiring confirmed against the live DB (`information_schema`)

**Remaining tier:** end-to-end render on a running install. `loadDemoBusiness` calls `resetStorefrontArchetype` (destructive reseed), so it must run against a **non-prod DB / deployed build**, not the shared dev DB. P2's `/admin/twin-gallery` renders demos **in-memory** (no DB write) and is the near-term review surface.

## Related

- Epic **EP-ARCHETYPE-DEMO** · BI **BI-7C95BEF6** (A·P1) · program **EP-LIVING-BUSINESS-EXCELLENCE**
- Follows #3023 (generator). Spec §4/§9.1; plan P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)