### PR TITLE
feat(delivery-flow): estimate provenance facets on BacklogItem (EP-DELIVERY-FLOW BI-E731A6C1)

### DIFF
--- a/apps/web/lib/demand/board.test.ts
+++ b/apps/web/lib/demand/board.test.ts
@@ -21,6 +21,10 @@ function item(partial: Partial<DemandItemView> & { itemId: string }): DemandItem
     jobSize: null,
     impact: null,
     investmentBucket: null,
+    estimateAiJobSize: null,
+    estimateHumanJobSize: null,
+    estimateSource: null,
+    estimateAgreed: null,
     ...partial,
   };
 }

--- a/apps/web/lib/demand/board.ts
+++ b/apps/web/lib/demand/board.ts
@@ -21,6 +21,13 @@ export type DemandItemView = {
   jobSize: number | null;
   impact: number | null;
   investmentBucket: string | null;
+  // Estimate provenance (EP-DELIVERY-FLOW): the attributed AI/human effort
+  // numbers, whose estimate is effective, and whether they still diverge — so the
+  // Delivery Flow can show the estimate chip and the ⇄ reconcile affordance.
+  estimateAiJobSize: number | null;
+  estimateHumanJobSize: number | null;
+  estimateSource: string | null;
+  estimateAgreed: boolean | null;
 };
 
 export type FunnelColumn = {

--- a/apps/web/lib/demand/demand-data.ts
+++ b/apps/web/lib/demand/demand-data.ts
@@ -22,6 +22,10 @@ export const getDemandItems = cache(async (): Promise<DemandItemView[]> => {
       jobSize: true,
       impact: true,
       investmentBucket: true,
+      estimateAiJobSize: true,
+      estimateHumanJobSize: true,
+      estimateSource: true,
+      estimateAgreed: true,
       epic: { select: { epicId: true } },
     },
   });
@@ -38,5 +42,9 @@ export const getDemandItems = cache(async (): Promise<DemandItemView[]> => {
     jobSize: r.jobSize,
     impact: r.impact,
     investmentBucket: r.investmentBucket,
+    estimateAiJobSize: r.estimateAiJobSize,
+    estimateHumanJobSize: r.estimateHumanJobSize,
+    estimateSource: r.estimateSource,
+    estimateAgreed: r.estimateAgreed,
   }));
 });

--- a/apps/web/lib/demand/estimate-provenance.test.ts
+++ b/apps/web/lib/demand/estimate-provenance.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveEstimateProvenance } from "./estimate-provenance";
+
+describe("resolveEstimateProvenance", () => {
+  it("is unestimated when neither side has a number", () => {
+    expect(resolveEstimateProvenance({})).toEqual({
+      effectiveJobSize: null,
+      source: null,
+      diverged: false,
+      agreed: false,
+    });
+    // null/NaN/Infinity are treated as absent.
+    expect(resolveEstimateProvenance({ aiJobSize: null, humanJobSize: undefined })).toMatchObject({
+      effectiveJobSize: null,
+      source: null,
+    });
+    expect(resolveEstimateProvenance({ aiJobSize: NaN, humanJobSize: Infinity })).toMatchObject({
+      effectiveJobSize: null,
+      source: null,
+    });
+  });
+
+  it("uses the AI number when only the AI has estimated (first-pass, forward)", () => {
+    expect(resolveEstimateProvenance({ aiJobSize: 8 })).toEqual({
+      effectiveJobSize: 8,
+      source: "ai",
+      diverged: false,
+      agreed: false,
+    });
+  });
+
+  it("uses the human number when only the human has estimated", () => {
+    expect(resolveEstimateProvenance({ humanJobSize: 3 })).toEqual({
+      effectiveJobSize: 3,
+      source: "human",
+      diverged: false,
+      agreed: false,
+    });
+  });
+
+  it("surfaces divergence when AI and human disagree and are not reconciled", () => {
+    // ⇄ 8 ↔ 3 · reconcile — the human number leads (humans decide), score provisional.
+    expect(resolveEstimateProvenance({ aiJobSize: 8, humanJobSize: 3 })).toEqual({
+      effectiveJobSize: 3,
+      source: "human",
+      diverged: true,
+      agreed: false,
+    });
+  });
+
+  it("auto-agrees when both sides land on the identical number (no explicit flag needed)", () => {
+    expect(resolveEstimateProvenance({ aiJobSize: 5, humanJobSize: 5 })).toEqual({
+      effectiveJobSize: 5,
+      source: "agreed",
+      diverged: false,
+      agreed: true,
+    });
+  });
+
+  it("treats an explicit agreement as reconciled and clears divergence", () => {
+    // Human confirmed the estimate — even if the raw numbers differ, agreement wins.
+    expect(resolveEstimateProvenance({ aiJobSize: 8, humanJobSize: 8, agreed: true })).toEqual({
+      effectiveJobSize: 8,
+      source: "agreed",
+      diverged: false,
+      agreed: true,
+    });
+    // A human confirming the AI's number (adopted into humanJobSize) reads as agreed.
+    expect(resolveEstimateProvenance({ aiJobSize: 8, agreed: true, humanJobSize: 8 })).toMatchObject({
+      source: "agreed",
+      diverged: false,
+    });
+  });
+
+  it("never reports divergence when only one side has estimated", () => {
+    expect(resolveEstimateProvenance({ aiJobSize: 8, agreed: false }).diverged).toBe(false);
+    expect(resolveEstimateProvenance({ humanJobSize: 3 }).diverged).toBe(false);
+  });
+});

--- a/apps/web/lib/demand/estimate-provenance.ts
+++ b/apps/web/lib/demand/estimate-provenance.ts
@@ -1,0 +1,93 @@
+// Pure estimate-provenance engine — no server imports. Safe in tests and client
+// components. EP-DELIVERY-FLOW BI-E731A6C1 (write-model).
+//
+// The effort estimate (jobSize) is the value/effort score's DENOMINATOR — today
+// invisible and single-source. Collaborative estimation makes it a visible,
+// attributed, collaborative act: an AI coworker proposes a first-pass estimate
+// the moment an item lands, a human can confirm or overrule it, and when the two
+// disagree the divergence surfaces so a person can reconcile. This module is the
+// pure resolver that turns the persisted provenance facets (the AI's number, the
+// human's number, an agreement flag) into the derived truth the surface needs:
+// which number is EFFECTIVE (feeds demandScore), WHOSE it is, and whether AI and
+// human still diverge and need reconciling.
+//
+// Persisted facets live on BacklogItem (schema.prisma): estimateAiJobSize /
+// estimateHumanJobSize / estimateAgreed etc. jobSize stays the effective
+// denominator scoring reads; the write door mirrors `effectiveJobSize` into it.
+//
+// Spec: docs/superpowers/specs/2026-07-12-delivery-flow-demand-backlog-unification-design.md
+// §"Collaborative estimation (the ÷ effort)".
+
+/**
+ * Provenance of the EFFECTIVE effort estimate feeding demandScore.
+ * - `ai`     — only an AI coworker has estimated (its first-pass proposal stands).
+ * - `human`  — a human set or overruled the estimate (humans lead and decide).
+ * - `agreed` — human and AI are reconciled (a human confirmed, or both landed on
+ *              the same number); the score behind the item is trustworthy.
+ */
+export const ESTIMATE_SOURCE_VALUES = ["ai", "human", "agreed"] as const;
+export type EstimateSource = (typeof ESTIMATE_SOURCE_VALUES)[number];
+
+/** The persisted provenance facets the resolver reads (all nullable). */
+export type EstimateProvenanceInputs = {
+  /** The AI coworker's proposed effort points. */
+  aiJobSize?: number | null;
+  /** The human's proposed (or confirmed) effort points. */
+  humanJobSize?: number | null;
+  /** Explicit agreement flag: a human confirmed the estimate. */
+  agreed?: boolean | null;
+};
+
+export type EstimateProvenance = {
+  /**
+   * The effective effort denominator that feeds demandScore, or null when
+   * neither side has estimated (callers fall back to jobSize/effortSize).
+   */
+  effectiveJobSize: number | null;
+  /** Whose judgment the effective estimate carries; null when unestimated. */
+  source: EstimateSource | null;
+  /**
+   * Both sides estimated, the numbers differ, and they are not yet reconciled —
+   * the card shows `⇄ ai ↔ human · reconcile` and the score is provisional.
+   */
+  diverged: boolean;
+  /** Human and AI are reconciled (explicit confirm, or identical numbers). */
+  agreed: boolean;
+};
+
+function num(v: number | null | undefined): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Resolve the derived estimate provenance from the persisted facets. Pure and
+ * idempotent.
+ *
+ * Rules (operator stance: AI proposes forward, humans lead and decide):
+ * - A human number OVERRULES an AI number — when both exist the human's is
+ *   effective. When only one side estimated, that side's number is effective.
+ * - `agreed` is true when a human explicitly confirmed OR both numbers are
+ *   identical. Agreement clears divergence (the score is trustworthy).
+ * - `diverged` is true only when BOTH sides estimated, the numbers differ, and
+ *   they are not agreed — that is the state that needs a human to reconcile.
+ */
+export function resolveEstimateProvenance(inputs: EstimateProvenanceInputs): EstimateProvenance {
+  const ai = num(inputs.aiJobSize);
+  const human = num(inputs.humanJobSize);
+  const bothPresent = ai !== null && human !== null;
+  const identical = bothPresent && ai === human;
+  const agreed = inputs.agreed === true || identical;
+
+  // Human overrules AI; otherwise whichever single side estimated.
+  const effectiveJobSize = human !== null ? human : ai;
+
+  let source: EstimateSource | null;
+  if (effectiveJobSize === null) source = null;
+  else if (agreed) source = "agreed";
+  else if (human !== null) source = "human";
+  else source = "ai";
+
+  const diverged = bothPresent && ai !== human && !agreed;
+
+  return { effectiveJobSize, source, diverged, agreed };
+}

--- a/apps/web/lib/mcp/packs/demand-scoring-pack.ts
+++ b/apps/web/lib/mcp/packs/demand-scoring-pack.ts
@@ -9,6 +9,9 @@
 
 import { prisma } from "@dpf/db";
 import { DEMAND_SCORE_FRAMEWORKS, DEMAND_STAGE_VALUES, INVESTMENT_BUCKET_VALUES } from "@/lib/explore/backlog";
+import type { DemandScoreFramework } from "@/lib/explore/backlog";
+import type { DemandScoreInputs, DemandScoreResult } from "@/lib/demand/scoring";
+import { resolveEstimateProvenance } from "@/lib/demand/estimate-provenance";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack } from "../tool-pack";
 
@@ -33,6 +36,24 @@ const definitions: ToolDefinition[] = [
         investmentBucket: { type: "string", enum: [...INVESTMENT_BUCKET_VALUES], description: "Optional investment bucket (run|grow|transform). Auto-derived from workType when omitted (bug/chore/refactor=run, feature=grow)." },
       },
       required: ["itemId"],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
+    name: "record_effort_estimate",
+    description:
+      "Record an attributed effort estimate — the value/effort score's denominator (jobSize) — for a backlog item and (re)compute its demandScore. by=ai captures an AI coworker's first-pass proposal; by=human sets or overrules it, and agree=true confirms the current AI estimate (marking the score reconciled). When the AI and human numbers differ the item surfaces as diverged for a human to reconcile; the human number leads when both exist, and the resolved estimate feeds demandScore. EP-DELIVERY-FLOW collaborative estimation.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        itemId: { type: "string", description: "The item to estimate." },
+        by: { type: "string", enum: ["ai", "human"], description: "Whose estimate this is: an AI coworker's proposal (ai) or a human's (human)." },
+        jobSize: { type: "number", description: "Effort points (the RICE/WSJF denominator). Required for an AI estimate; for a human, required unless agree=true adopts the current AI estimate." },
+        agentId: { type: "string", description: "For by=ai: the coworker/agent id that proposed the estimate (attribution)." },
+        agree: { type: "boolean", description: "For by=human: confirm the current AI estimate — marks the score reconciled/trustworthy and adopts the AI number when jobSize is omitted." },
+      },
+      required: ["itemId", "by"],
     },
     requiredCapability: "manage_backlog",
     sideEffect: true,
@@ -126,15 +147,31 @@ const definitions: ToolDefinition[] = [
   },
 ];
 
-async function scoreDemandItemHandler(params: Record<string, unknown>): Promise<ToolResult> {
-  const itemId = String(params["itemId"] ?? "");
-  const item = await prisma.backlogItem.findUnique({ where: { itemId } });
-  if (!item) {
-    return { success: false, error: "not_found", message: `Item ${itemId} not found` };
-  }
+/** The BacklogItem fields the score/funnel derivation reads. */
+type ScorableItem = {
+  demandStage: string | null;
+  investmentBucket: string | null;
+  workType: string | null;
+};
+
+/**
+ * Shared: resolve the active framework, compute the demandScore under it, and
+ * derive the funnel-stage + investment-bucket advance — returning the prisma
+ * `data` patch that both score_demand_item and record_effort_estimate persist.
+ * The scoring INPUTS in `inputs` (reach…jobSize) are written back; occurrenceCount
+ * and effortSize are read-only fallbacks and are not part of the patch.
+ */
+async function buildScorePatch(
+  item: ScorableItem,
+  inputs: DemandScoreInputs,
+  opts: { framework?: unknown; demandStage?: unknown; investmentBucket?: unknown } = {},
+): Promise<{
+  patch: Record<string, unknown>;
+  result: DemandScoreResult;
+  framework: DemandScoreFramework;
+  nextStage: string;
+}> {
   const { computeDemandScore } = await import("@/lib/demand/scoring");
-  const numOrKeep = (key: string, current: number | null): number | null =>
-    typeof params[key] === "number" ? (params[key] as number) : current;
   // Framework: explicit param wins; otherwise the operator-owned demand policy
   // (PlatformDevConfig), falling back to the built-in default.
   const { resolveDemandPolicy } = await import("@/lib/demand/policy");
@@ -143,12 +180,55 @@ async function scoreDemandItemHandler(params: Record<string, unknown>): Promise<
     select: { demandFramework: true, demandBucketTargets: true },
   });
   const policyFramework = resolveDemandPolicy(policyConfig).framework;
-  const f = typeof params["framework"] === "string" ? String(params["framework"]) : policyFramework;
+  const f = typeof opts.framework === "string" ? String(opts.framework) : policyFramework;
   const framework = (DEMAND_SCORE_FRAMEWORKS as readonly string[]).includes(f)
-    ? (f as (typeof DEMAND_SCORE_FRAMEWORKS)[number])
+    ? (f as DemandScoreFramework)
     : policyFramework;
+  const result = computeDemandScore(inputs, framework);
+  // Advance the funnel: a scored item is at least `screened`. Respect an
+  // explicit stage override and never regress a manually-advanced stage.
+  const stageOrder = DEMAND_STAGE_VALUES as readonly string[];
+  const explicitStage = stageOrder.includes(String(opts.demandStage))
+    ? (opts.demandStage as (typeof DEMAND_STAGE_VALUES)[number])
+    : null;
+  const derivedStage = result.score !== null ? "screened" : item.demandStage ?? "raw";
+  const currentIdx = item.demandStage ? stageOrder.indexOf(item.demandStage) : -1;
+  const derivedIdx = stageOrder.indexOf(derivedStage);
+  const nextStage = explicitStage ?? (derivedIdx > currentIdx ? derivedStage : item.demandStage ?? derivedStage);
+  // Investment bucket: explicit override, else keep what's set, else derive from
+  // work-type (bug/chore/refactor=run, feature=grow, else unclassified).
+  const { deriveBucket } = await import("@/lib/demand/buckets");
+  const explicitBucket = (INVESTMENT_BUCKET_VALUES as readonly string[]).includes(String(opts.investmentBucket))
+    ? (opts.investmentBucket as (typeof INVESTMENT_BUCKET_VALUES)[number])
+    : null;
+  const nextBucket = explicitBucket ?? item.investmentBucket ?? deriveBucket(item.workType);
+  const patch: Record<string, unknown> = {
+    reach: inputs.reach ?? null,
+    impact: inputs.impact ?? null,
+    confidence: inputs.confidence ?? null,
+    businessValue: inputs.businessValue ?? null,
+    timeCriticality: inputs.timeCriticality ?? null,
+    riskOpportunity: inputs.riskOpportunity ?? null,
+    jobSize: inputs.jobSize ?? null,
+    demandScore: result.score,
+    demandScoreFramework: framework,
+    demandScoreComputedAt: new Date(),
+    demandStage: nextStage,
+    investmentBucket: nextBucket,
+  };
+  return { patch, result, framework, nextStage };
+}
+
+async function scoreDemandItemHandler(params: Record<string, unknown>): Promise<ToolResult> {
+  const itemId = String(params["itemId"] ?? "");
+  const item = await prisma.backlogItem.findUnique({ where: { itemId } });
+  if (!item) {
+    return { success: false, error: "not_found", message: `Item ${itemId} not found` };
+  }
+  const numOrKeep = (key: string, current: number | null): number | null =>
+    typeof params[key] === "number" ? (params[key] as number) : current;
   // Merge supplied inputs over what's already stored (partial updates).
-  const inputs = {
+  const inputs: DemandScoreInputs = {
     reach: numOrKeep("reach", item.reach),
     impact: numOrKeep("impact", item.impact),
     confidence: numOrKeep("confidence", item.confidence),
@@ -159,41 +239,12 @@ async function scoreDemandItemHandler(params: Record<string, unknown>): Promise<
     occurrenceCount: item.occurrenceCount,
     effortSize: item.effortSize,
   };
-  const result = computeDemandScore(inputs, framework);
-  // Advance the funnel: a scored item is at least `screened`. Respect an
-  // explicit stage override and never regress a manually-advanced stage.
-  const stageOrder = DEMAND_STAGE_VALUES as readonly string[];
-  const explicitStage = stageOrder.includes(String(params["demandStage"]))
-    ? (params["demandStage"] as (typeof DEMAND_STAGE_VALUES)[number])
-    : null;
-  const derivedStage = result.score !== null ? "screened" : item.demandStage ?? "raw";
-  const currentIdx = item.demandStage ? stageOrder.indexOf(item.demandStage) : -1;
-  const derivedIdx = stageOrder.indexOf(derivedStage);
-  const nextStage = explicitStage ?? (derivedIdx > currentIdx ? derivedStage : item.demandStage ?? derivedStage);
-  // Investment bucket: explicit override, else keep what's set, else derive from
-  // work-type (bug/chore/refactor=run, feature=grow, else unclassified).
-  const { deriveBucket } = await import("@/lib/demand/buckets");
-  const explicitBucket = (INVESTMENT_BUCKET_VALUES as readonly string[]).includes(String(params["investmentBucket"]))
-    ? (params["investmentBucket"] as (typeof INVESTMENT_BUCKET_VALUES)[number])
-    : null;
-  const nextBucket = explicitBucket ?? item.investmentBucket ?? deriveBucket(item.workType);
-  await prisma.backlogItem.update({
-    where: { itemId },
-    data: {
-      reach: inputs.reach,
-      impact: inputs.impact,
-      confidence: inputs.confidence,
-      businessValue: inputs.businessValue,
-      timeCriticality: inputs.timeCriticality,
-      riskOpportunity: inputs.riskOpportunity,
-      jobSize: inputs.jobSize,
-      demandScore: result.score,
-      demandScoreFramework: framework,
-      demandScoreComputedAt: new Date(),
-      demandStage: nextStage,
-      investmentBucket: nextBucket,
-    },
+  const { patch, result, framework, nextStage } = await buildScorePatch(item, inputs, {
+    framework: params["framework"],
+    demandStage: params["demandStage"],
+    investmentBucket: params["investmentBucket"],
   });
+  await prisma.backlogItem.update({ where: { itemId }, data: patch });
   return {
     success: true,
     entityId: itemId,
@@ -207,6 +258,124 @@ async function scoreDemandItemHandler(params: Record<string, unknown>): Promise<
       demandStage: nextStage,
       contributions: result.contributions,
       missing: result.missing,
+    },
+  };
+}
+
+async function recordEffortEstimateHandler(
+  params: Record<string, unknown>,
+  userId: string,
+): Promise<ToolResult> {
+  const itemId = String(params["itemId"] ?? "");
+  const by = String(params["by"] ?? "");
+  if (by !== "ai" && by !== "human") {
+    return { success: false, error: "invalid_input", message: '`by` must be "ai" or "human".' };
+  }
+  const item = await prisma.backlogItem.findUnique({ where: { itemId } });
+  if (!item) {
+    return { success: false, error: "not_found", message: `Item ${itemId} not found` };
+  }
+
+  const agree = params["agree"] === true;
+  const explicitJobSize =
+    typeof params["jobSize"] === "number" && Number.isFinite(params["jobSize"]) && (params["jobSize"] as number) > 0
+      ? (params["jobSize"] as number)
+      : null;
+
+  // Start from the item's current provenance, then apply this attributed edit.
+  let estimateAiJobSize = item.estimateAiJobSize;
+  let estimateAiById = item.estimateAiById;
+  let estimateAiAt = item.estimateAiAt;
+  let estimateHumanJobSize = item.estimateHumanJobSize;
+  let estimateHumanById = item.estimateHumanById;
+  let estimateHumanAt = item.estimateHumanAt;
+  let agreedFlag: boolean | null = item.estimateAgreed;
+  const now = new Date();
+
+  if (by === "ai") {
+    if (explicitJobSize === null) {
+      return { success: false, error: "invalid_input", message: "An AI estimate requires a positive numeric jobSize." };
+    }
+    estimateAiJobSize = explicitJobSize;
+    estimateAiById = typeof params["agentId"] === "string" ? (params["agentId"] as string) : item.estimateAiById;
+    estimateAiAt = now;
+    // A fresh AI proposal re-opens (or closes) reconcile against any human number.
+    if (estimateHumanJobSize !== null) agreedFlag = estimateHumanJobSize === explicitJobSize;
+  } else {
+    // human: adopt the AI number on agree, else set/overrule with an explicit one.
+    const humanVal = explicitJobSize ?? (agree ? item.estimateAiJobSize : null);
+    if (humanVal === null) {
+      return {
+        success: false,
+        error: "invalid_input",
+        message: "A human estimate requires a positive numeric jobSize (or agree=true to adopt the current AI estimate).",
+      };
+    }
+    estimateHumanJobSize = humanVal;
+    estimateHumanById = userId || item.estimateHumanById;
+    estimateHumanAt = now;
+    // Reconciled when the human confirms, or their number matches the AI's.
+    agreedFlag = agree || (estimateAiJobSize !== null && estimateAiJobSize === humanVal);
+  }
+
+  const provenance = resolveEstimateProvenance({
+    aiJobSize: estimateAiJobSize,
+    humanJobSize: estimateHumanJobSize,
+    agreed: agreedFlag,
+  });
+
+  // Recompute the score with the resolved effective estimate mirrored into jobSize.
+  const inputs: DemandScoreInputs = {
+    reach: item.reach,
+    impact: item.impact,
+    confidence: item.confidence,
+    businessValue: item.businessValue,
+    timeCriticality: item.timeCriticality,
+    riskOpportunity: item.riskOpportunity,
+    jobSize: provenance.effectiveJobSize,
+    occurrenceCount: item.occurrenceCount,
+    effortSize: item.effortSize,
+  };
+  const { patch, result, framework, nextStage } = await buildScorePatch(item, inputs);
+
+  await prisma.backlogItem.update({
+    where: { itemId },
+    data: {
+      ...patch,
+      estimateAiJobSize,
+      estimateAiById,
+      estimateAiAt,
+      estimateHumanJobSize,
+      estimateHumanById,
+      estimateHumanAt,
+      estimateSource: provenance.source,
+      estimateAgreed: provenance.agreed,
+    },
+  });
+
+  const divergeNote = provenance.diverged
+    ? ` ⇄ AI ${estimateAiJobSize} ↔ human ${estimateHumanJobSize} — reconcile.`
+    : "";
+  const scoreNote =
+    result.score !== null
+      ? ` ${framework} score ${result.score} (stage ${nextStage}).`
+      : ` ${framework} not computable — missing ${result.missing.join(", ")}.`;
+  return {
+    success: true,
+    entityId: itemId,
+    message:
+      `Recorded ${by} effort estimate for ${itemId}: effective ${provenance.effectiveJobSize} (${provenance.source}).` +
+      scoreNote +
+      divergeNote,
+    data: {
+      effectiveJobSize: provenance.effectiveJobSize,
+      estimateSource: provenance.source,
+      agreed: provenance.agreed,
+      diverged: provenance.diverged,
+      estimateAiJobSize,
+      estimateHumanJobSize,
+      demandScore: result.score,
+      demandStage: nextStage,
     },
   };
 }
@@ -456,6 +625,7 @@ export const demandScoringPack: ToolPack = {
   definitions,
   handlers: {
     score_demand_item: (params) => scoreDemandItemHandler(params),
+    record_effort_estimate: (params, userId) => recordEffortEstimateHandler(params, userId),
     set_demand_policy: (params) => setDemandPolicyHandler(params),
     find_duplicate_candidates: (params) => findDuplicateCandidatesHandler(params),
     merge_backlog_items: (params) => mergeBacklogItemsHandler(params),
@@ -464,6 +634,7 @@ export const demandScoringPack: ToolPack = {
   },
   grants: {
     score_demand_item: ["backlog_write"],
+    record_effort_estimate: ["backlog_write"],
     set_demand_policy: ["backlog_write"],
     find_duplicate_candidates: ["backlog_read"],
     merge_backlog_items: ["backlog_write"],

--- a/apps/web/lib/mcp/tool-registry.test.ts
+++ b/apps/web/lib/mcp/tool-registry.test.ts
@@ -280,7 +280,7 @@ describe("coworker memory pack", () => {
 
 describe("demand-scoring tool pack", () => {
   it("bundles the score_demand_item door with a handler", () => {
-    expect(demandScoringPack.definitions.map((t) => t.name)).toEqual(["score_demand_item", "set_demand_policy", "find_duplicate_candidates", "merge_backlog_items", "sweep_duplicate_demand", "approve_demand_for_funding"]);
+    expect(demandScoringPack.definitions.map((t) => t.name)).toEqual(["score_demand_item", "record_effort_estimate", "set_demand_policy", "find_duplicate_candidates", "merge_backlog_items", "sweep_duplicate_demand", "approve_demand_for_funding"]);
     for (const def of demandScoringPack.definitions) {
       expect(demandScoringPack.handlers[def.name], def.name).toBeTypeOf("function");
     }

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -137,6 +137,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   create_backlog_item: ["backlog_write"],
   update_backlog_item: ["backlog_write"],
   score_demand_item: ["backlog_write"],
+  record_effort_estimate: ["backlog_write"],
   set_demand_policy: ["backlog_write"],
   find_duplicate_candidates: ["backlog_read"],
   merge_backlog_items: ["backlog_write"],

--- a/docs/superpowers/specs/2026-07-12-delivery-flow-demand-backlog-unification-design.md
+++ b/docs/superpowers/specs/2026-07-12-delivery-flow-demand-backlog-unification-design.md
@@ -37,12 +37,20 @@ Not "assign to a coworker" — **coworkers volunteer**. Crossing the bet trigger
 Same `BacklogItem`; `demandStage`/`status`/scoring inputs/`demandScore`/`investmentBucket` already exist. Surfaces: `apps/web/app/(shell)/ops/page.tsx` (OpsClient), `apps/web/app/(shell)/ops/demand/page.tsx` (DemandBoard), nav `apps/web/components/ops/ops-nav.ts`. Volunteering wires the demand→ready seam to the proactivity/self-task engine.
 
 ## Phased build (EP-DELIVERY-FLOW)
-1. **BI-E731A6C1** — estimate **provenance + agreement** facets on `BacklogItem` (human/AI/agreed/divergent), additive nullable, feeds `demandScore`. *(write-model first)*
+1. **BI-E731A6C1** — estimate **provenance + agreement** facets on `BacklogItem` (human/AI/agreed/divergent), additive nullable, feeds `demandScore`. *(write-model first — **built**, see below)*
 2. **BI-1DE21746** — the **Delivery Flow surface**: funnel→bet→board, two visual languages, one-item-two-faces, nav collapse to one Flow with lens sub-views.
 3. **BI-A6648529** — **AI-led volunteering**: funding the bet triggers a proactive coworker to self-task/claim → advance status; governed per proactivity.
 4. **BI-AA1763CD** — **collaborative estimation UX**: AI proposes on arrival, human confirm/overrule, reconcile divergence.
 
 Mockup (private): the Delivery Flow board with the funnel, the amber "bet · a coworker volunteers" gate, estimate chips (AI/human/agreed/diverge), and the AI-led-execution callout.
+
+## Write-model as built (BI-E731A6C1)
+The estimate is the score's `jobSize` denominator; `jobSize` stays the effective value scoring reads, and the provenance facets attribute *how it was arrived at*.
+
+- **Schema (`BacklogItem`, additive-nullable, migration `20260715210000_add_estimate_provenance`):** `estimateAiJobSize` / `estimateAiById` / `estimateAiAt` (the AI coworker's first-pass proposal + attribution), `estimateHumanJobSize` / `estimateHumanById` / `estimateHumanAt` (the human's set/overrule), `estimateSource` (`ai`|`human`|`agreed` — provenance of the effective estimate), `estimateAgreed` (reconciled flag). No index, no backfill, no destructive change.
+- **Pure resolver** `apps/web/lib/demand/estimate-provenance.ts` — `resolveEstimateProvenance({aiJobSize, humanJobSize, agreed})` returns `{effectiveJobSize, source, diverged, agreed}`. Rules: a human number overrules an AI number (humans lead and decide); `agreed` when a human confirms or both numbers are identical; `diverged` only when both sides estimated, the numbers differ, and they are not agreed (the `⇄ reconcile` state). Unit-tested.
+- **Governed write door** `record_effort_estimate` (demand-scoring pack, `backlog_write`): `{itemId, by: "ai"|"human", jobSize?, agentId?, agree?}`. Records the attributed estimate, resolves provenance, mirrors the effective estimate into `jobSize`, and recomputes `demandScore` under the active framework — so the agreed estimate feeds the score. `by=human, agree=true` confirms/adopts the current AI estimate.
+- **Read exposure:** `DemandItemView` + `getDemandItems` now carry `estimateAiJobSize` / `estimateHumanJobSize` / `estimateSource` / `estimateAgreed` for the surface (BI-1DE21746) and estimation UX (BI-AA1763CD) to render the estimate chip and reconcile affordance.
 
 ## Success criterion
 Demand and Backlog no longer read as two duplicate boards — they read as **one continuous investment-funnel → execution-board flow**, where funding a bet visibly pulls a coworker forward to build it, and every estimate shows whose judgment it carries.

--- a/packages/db/prisma/migrations/20260715210000_add_estimate_provenance/migration.sql
+++ b/packages/db/prisma/migrations/20260715210000_add_estimate_provenance/migration.sql
@@ -1,0 +1,18 @@
+-- EP-DELIVERY-FLOW BI-E731A6C1 (write-model): estimate-provenance facets on
+-- BacklogItem. The effort estimate (jobSize) is the value/effort score's
+-- denominator; these columns attribute WHOSE number it is (an AI coworker's
+-- first-pass proposal, a human's confirm/overrule), carry an agreement flag, and
+-- let the Delivery Flow surface AI<->human divergence. jobSize stays the
+-- effective denominator scoring reads. Resolver:
+-- apps/web/lib/demand/estimate-provenance.ts.
+-- @migration-safety: data-safe: every column is a nullable addition; no drops,
+-- no NOT NULL on existing rows, no backfill, no new constraints.
+ALTER TABLE "BacklogItem"
+    ADD COLUMN "estimateAiJobSize" DOUBLE PRECISION,
+    ADD COLUMN "estimateAiById" TEXT,
+    ADD COLUMN "estimateAiAt" TIMESTAMP(3),
+    ADD COLUMN "estimateHumanJobSize" DOUBLE PRECISION,
+    ADD COLUMN "estimateHumanById" TEXT,
+    ADD COLUMN "estimateHumanAt" TIMESTAMP(3),
+    ADD COLUMN "estimateSource" TEXT,
+    ADD COLUMN "estimateAgreed" BOOLEAN;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1341,6 +1341,25 @@ model BacklogItem {
   // strategic-balance dimension so demand is prioritized against a target
   // allocation, not a flat list. Default derived from workType. §8.
   investmentBucket        String?
+  // Estimate provenance (EP-DELIVERY-FLOW BI-E731A6C1). The effort estimate
+  // (jobSize) is the value/effort score's DENOMINATOR; these facets attribute
+  // WHOSE number it is — an AI coworker's first-pass proposal and a human's
+  // confirm/overrule — so the Delivery Flow can show AI<->human divergence, a
+  // reconcile affordance, and mark the score trustworthy once agreed. jobSize
+  // stays the effective denominator scoring reads; the write door
+  // (record_effort_estimate) mirrors the resolved effective estimate into it.
+  // All additive-nullable — null = no attributed estimate yet; the
+  // jobSize/effortSize fallbacks feed scoring unchanged. Resolver:
+  // apps/web/lib/demand/estimate-provenance.ts. Spec: 2026-07-12-delivery-flow
+  // -demand-backlog-unification-design.md §"Collaborative estimation".
+  estimateAiJobSize       Float?
+  estimateAiById          String?
+  estimateAiAt            DateTime?
+  estimateHumanJobSize    Float?
+  estimateHumanById       String?
+  estimateHumanAt         DateTime?
+  estimateSource          String?
+  estimateAgreed          Boolean?
   activeBuildId           String?                       @unique
   activeEpicId            String?                       @unique
   duplicateOfId           String?

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -54,7 +54,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	865
 apps/web/lib/self-upgrade/quiescence.ts	1469
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	903
-apps/web/lib/tak/agent-grants.ts	816
+apps/web/lib/tak/agent-grants.ts	817
 apps/web/lib/tak/agent-routing.ts	965
 apps/web/lib/tak/agentic-loop.test.ts	2240
 apps/web/lib/tak/agentic-loop.ts	2612


### PR DESCRIPTION
## What

Phase 1 (write-model-first) of **EP-DELIVERY-FLOW**. Makes the effort estimate — the value/effort score's `jobSize` denominator, today invisible and single-source — a **visible, attributed, collaborative** act. Additive-nullable facets on `BacklogItem` record *whose number it is*: an AI coworker's first-pass proposal and a human's confirm/overrule, so the Delivery Flow surface can show AI↔human divergence, a reconcile affordance, and mark the score trustworthy once agreed.

Resolves **BI-E731A6C1** (WC-979617BF).

## Changes
- **Schema + migration** (`20260715210000_add_estimate_provenance`, additive-nullable, no backfill/drops): `estimateAiJobSize`/`estimateAiById`/`estimateAiAt`, `estimateHumanJobSize`/`estimateHumanById`/`estimateHumanAt`, `estimateSource` (`ai`|`human`|`agreed`), `estimateAgreed`. `jobSize` stays the effective denominator scoring reads.
- **Pure resolver** `apps/web/lib/demand/estimate-provenance.ts` — `resolveEstimateProvenance()` → `{effectiveJobSize, source, diverged, agreed}`. Human overrules AI (humans lead and decide); identical or confirmed numbers = agreed; `diverged` only when both sides differ and are unreconciled. Unit-tested (8 cases).
- **Governed write door** `record_effort_estimate` (demand-scoring pack, `backlog_write`): records an attributed estimate, mirrors the effective value into `jobSize`, recomputes `demandScore` under the active framework so the agreed estimate feeds the score. `by=human, agree=true` confirms/adopts the current AI estimate. Shared score-patch helper factored out of `score_demand_item` (behaviour-preserving).
- **Read exposure** on `DemandItemView` / `getDemandItems` for the surface (BI-1DE21746) and estimation-UX (BI-AA1763CD) BIs.
- **Spec** updated with the as-built write-model.

## Verification
- `apps/web` `tsc --noEmit` — exit 0, **0 errors** (8GB heap).
- Unit tests green: `estimate-provenance` (8), `board`, `scoring`, `tool-registry` — **62 passed**.
- Guards green: module-size ratchet, mcp-tool-pack ratchet, schema-regression, migration-safety.

## Design grounding
Extends the kernel-ratified design `docs/superpowers/specs/2026-07-12-delivery-flow-demand-backlog-unification-design.md` (unify-flow-ai-led, composite 7.28). No new contract — additive facets on the existing `BacklogItem` write-model.

Design-Grounding-Decision: extends existing spec; additive facets in apps/web/lib/demand + apps/web/lib/mcp/packs/demand-scoring-pack.ts; no contract change.

## Local-CI-Override
The sandbox pregate could not claim the local-integration-ci lease: the portal was **quiescing for a platform upgrade** (`portal_quiescing`/draining, refuses new actions). Change verified-clean out-of-band as above; GitHub CI is the authoritative gate on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)