### PR TITLE
feat(delivery-flow): unified Delivery Flow surface — funnel→bet→board lens (EP-DELIVERY-FLOW BI-1DE21746)

### DIFF
--- a/apps/web/app/(shell)/ops/demand/page.tsx
+++ b/apps/web/app/(shell)/ops/demand/page.tsx
@@ -18,10 +18,11 @@ export default async function DemandPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Demand</h1>
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Delivery Flow</h1>
         <p className="mt-1 text-sm text-[var(--dpf-muted)]">
-          What&apos;s being asked for, how valuable, and how big — ranked so the highest value-per-effort
-          work is drawn first.
+          One flow from investment to execution: what&apos;s asked for, how valuable and how big, funded at
+          the bet, then built. The Flow lens shows the whole river; Funnel, Value × effort and Balance zoom
+          into the invest half.
         </p>
       </div>
       <OpsTabNav />

--- a/apps/web/components/ops/DemandBoard.tsx
+++ b/apps/web/components/ops/DemandBoard.tsx
@@ -13,6 +13,8 @@ import {
 } from "@/lib/demand/board";
 import type { ValueEffortQuadrant } from "@/lib/demand/scoring";
 import { bucketBalance, BUCKET_LABELS, computeBucketMix } from "@/lib/demand/buckets";
+import { groupByFlowLane, FLOW_LANE_LABELS, type FlowColumn } from "@/lib/demand/flow";
+import { resolveEstimateProvenance } from "@/lib/demand/estimate-provenance";
 
 const VALUE_BAND_LABEL: Record<ReturnType<typeof valueBand>, string> = {
   high: "High value",
@@ -35,6 +37,42 @@ const QUADRANT_TOKEN: Record<ValueEffortQuadrant, string> = {
   time_sink: "var(--dpf-warning)",
 };
 
+/**
+ * Estimate-provenance chip (EP-DELIVERY-FLOW). Shows WHOSE effort estimate the
+ * value/effort score carries, and surfaces the ⇄ reconcile affordance when the AI
+ * and human numbers still diverge. Display-only here — the interactive
+ * confirm/overrule/reconcile flow is BI-AA1763CD. Returns null when no attributed
+ * estimate exists yet (the plain effort line covers that case).
+ */
+function EstimateChip({ item }: { item: DemandItemView }) {
+  const prov = resolveEstimateProvenance({
+    aiJobSize: item.estimateAiJobSize,
+    humanJobSize: item.estimateHumanJobSize,
+    agreed: item.estimateAgreed,
+  });
+  if (prov.source === null) return null;
+  if (prov.diverged) {
+    return (
+      <span
+        className="rounded px-1.5 py-0.5 text-[10px] font-medium"
+        style={{ color: "var(--dpf-warning)", borderColor: "var(--dpf-warning)" }}
+        title="AI and human estimates diverge — reconcile to trust the score"
+      >
+        ⇄ {item.estimateAiJobSize} ↔ {item.estimateHumanJobSize} · reconcile
+      </span>
+    );
+  }
+  const SOURCE_LABEL: Record<string, string> = { ai: "AI", human: "human", agreed: "agreed" };
+  return (
+    <span
+      className="rounded px-1.5 py-0.5 text-[10px] font-medium text-[var(--dpf-muted)]"
+      title={`Effort estimate: ${prov.effectiveJobSize} (${SOURCE_LABEL[prov.source] ?? prov.source})`}
+    >
+      est {prov.effectiveJobSize} · {SOURCE_LABEL[prov.source] ?? prov.source}
+    </span>
+  );
+}
+
 function DemandCard({ item }: { item: DemandItemView }) {
   const [open, setOpen] = useState(false);
   const band = valueBand(item);
@@ -53,6 +91,7 @@ function DemandCard({ item }: { item: DemandItemView }) {
         <span className="text-[10px] text-[var(--dpf-muted)]">
           {item.effortSize ? `${item.effortSize} effort` : effort !== null ? `effort ${effort}` : "unsized"}
         </span>
+        <EstimateChip item={item} />
         <span className="ml-auto font-mono text-[var(--dpf-muted-foreground)]">{item.itemId}</span>
       </div>
       <button
@@ -99,6 +138,71 @@ function FunnelView({ items }: { items: DemandItemView[] }) {
           </div>
         </div>
       ))}
+    </div>
+  );
+}
+
+// The Flow lens (EP-DELIVERY-FLOW BI-1DE21746): the whole river in one view —
+// investment funnel → the bet → execution board — so Demand and Backlog stop
+// reading as two duplicate boards. Two deliberately different visual languages:
+// the funnel lanes are score-tinted and narrowing (invest); the board lane reads
+// as execution; the amber bet seam is the funded crossing between them.
+function FlowLaneColumn({ col }: { col: FlowColumn }) {
+  const isBet = col.half === "bet";
+  const isBoard = col.half === "board";
+  const accent = isBet ? "var(--dpf-warning)" : isBoard ? "var(--dpf-success)" : "var(--dpf-border)";
+  return (
+    <div
+      className="min-w-0 rounded-lg border bg-[var(--dpf-surface-2)] p-2"
+      style={{ borderColor: accent, ...(isBet ? { backgroundColor: "color-mix(in srgb, var(--dpf-warning) 8%, var(--dpf-surface-2))" } : {}) }}
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-[var(--dpf-text)]">
+          {isBet ? "⟐ " : ""}
+          {FLOW_LANE_LABELS[col.lane]}
+        </h3>
+        <span className="text-xs text-[var(--dpf-muted)]">{col.items.length}</span>
+      </div>
+      {isBet && (
+        <p className="mb-2 text-[10px] leading-snug text-[var(--dpf-warning)]">
+          Funded — a coworker volunteers to build it.
+        </p>
+      )}
+      <div className="space-y-2">
+        {col.items.length === 0 ? (
+          <p className="text-xs text-[var(--dpf-muted)]">{isBet ? "No bets on the table." : "Nothing here yet."}</p>
+        ) : (
+          col.items.map((item) => <DemandCard key={item.itemId} item={item} />)
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FlowView({ items }: { items: DemandItemView[] }) {
+  const columns = useMemo(() => groupByFlowLane(items), [items]);
+  const funnel = columns.filter((c) => c.half === "funnel");
+  const bet = columns.find((c) => c.half === "bet");
+  const board = columns.filter((c) => c.half === "board");
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+        <span>← Invest · value ÷ effort</span>
+        <span>Execute · owner + burn-down →</span>
+      </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3 lg:grid-cols-5">
+        {funnel.map((col) => (
+          <FlowLaneColumn key={col.lane} col={col} />
+        ))}
+        {bet && <FlowLaneColumn col={bet} />}
+        {board.map((col) => (
+          <FlowLaneColumn key={col.lane} col={col} />
+        ))}
+      </div>
+      <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+        One flow, one item two faces: a score + estimate upstream, an owner + burn-down once it crosses the bet.
+        Same dataset as Prioritize and Execute — just a different lens.
+      </p>
     </div>
   );
 }
@@ -217,7 +321,14 @@ function BalanceView({
   );
 }
 
-type Tab = "funnel" | "matrix" | "balance";
+type Tab = "flow" | "funnel" | "matrix" | "balance";
+
+const TAB_LABELS: Record<Tab, string> = {
+  flow: "Flow",
+  funnel: "Funnel",
+  matrix: "Value × effort",
+  balance: "Balance",
+};
 
 export function DemandBoard({
   items,
@@ -228,7 +339,7 @@ export function DemandBoard({
   bucketTargets?: Partial<Record<"run" | "grow" | "transform", number>> | null;
   activeFramework?: string;
 }) {
-  const [tab, setTab] = useState<Tab>("funnel");
+  const [tab, setTab] = useState<Tab>("flow");
   const scored = items.filter((i) => i.demandScore !== null).length;
 
   if (items.length === 0) {
@@ -246,7 +357,7 @@ export function DemandBoard({
     <div className="space-y-3">
       <div className="flex items-center gap-2">
         <div className="inline-flex rounded-md border border-[var(--dpf-border)] p-0.5">
-          {(["funnel", "matrix", "balance"] as const).map((t) => (
+          {(["flow", "funnel", "matrix", "balance"] as const).map((t) => (
             <button
               key={t}
               type="button"
@@ -257,7 +368,7 @@ export function DemandBoard({
                   : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
               }`}
             >
-              {t === "funnel" ? "Funnel" : t === "matrix" ? "Value × effort" : "Balance"}
+              {TAB_LABELS[t]}
             </button>
           ))}
         </div>
@@ -266,7 +377,9 @@ export function DemandBoard({
           {activeFramework ? ` · ${activeFramework} policy` : ""}
         </span>
       </div>
-      {tab === "funnel" ? (
+      {tab === "flow" ? (
+        <FlowView items={items} />
+      ) : tab === "funnel" ? (
         <FunnelView items={items} />
       ) : tab === "matrix" ? (
         <MatrixView items={items} />

--- a/apps/web/components/ops/ops-nav.ts
+++ b/apps/web/components/ops/ops-nav.ts
@@ -5,6 +5,11 @@
 // registered as a navigation source in lib/ea/domain-nav-sources.ts. The two groups
 // (Delivery vs Runtime & Releases) keep self-upgrade/dev-loop visibly distinct from the
 // Backlog queue until P2 re-homes them off /ops entirely.
+//
+// EP-DELIVERY-FLOW BI-1DE21746: the Delivery group reads left-to-right as ONE flow —
+// "Delivery Flow" (the investment funnel → the bet → execution board, at /ops/demand)
+// leads, and "Backlog" is the execution/burn-down board (/ops) it feeds into. They
+// are two faces of the same BacklogItem, no longer two duplicate boards.
 
 export const OPS_NAV_GROUPS: ReadonlyArray<{
   label: string;
@@ -13,8 +18,8 @@ export const OPS_NAV_GROUPS: ReadonlyArray<{
   {
     label: "Delivery",
     tabs: [
+      { label: "Delivery Flow", href: "/ops/demand" },
       { label: "Backlog", href: "/ops" },
-      { label: "Demand", href: "/ops/demand" },
     ],
   },
   {

--- a/apps/web/lib/demand/flow.test.ts
+++ b/apps/web/lib/demand/flow.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { placeInFlow, groupByFlowLane, FLOW_LANES, type FlowLane } from "./flow";
+import { type DemandItemView } from "./board";
+
+function item(partial: Partial<DemandItemView> & { itemId: string }): DemandItemView {
+  return {
+    title: partial.itemId,
+    status: "open",
+    workType: "feature",
+    epicId: null,
+    demandStage: null,
+    demandScore: null,
+    demandScoreFramework: null,
+    effortSize: null,
+    jobSize: null,
+    impact: null,
+    investmentBucket: null,
+    estimateAiJobSize: null,
+    estimateHumanJobSize: null,
+    estimateSource: null,
+    estimateAgreed: null,
+    ...partial,
+  };
+}
+
+describe("placeInFlow", () => {
+  it("places by demandStage in the funnel when not yet executing", () => {
+    expect(placeInFlow(item({ itemId: "A" }))).toBe("funnel_raw"); // null stage -> raw
+    expect(placeInFlow(item({ itemId: "B", demandStage: "raw" }))).toBe("funnel_raw");
+    expect(placeInFlow(item({ itemId: "C", demandStage: "screened" }))).toBe("funnel_screened");
+    expect(placeInFlow(item({ itemId: "D", demandStage: "shaped" }))).toBe("funnel_shaped");
+  });
+
+  it("places a ready (funded) item on the bet seam", () => {
+    expect(placeInFlow(item({ itemId: "E", demandStage: "ready" }))).toBe("bet");
+  });
+
+  it("lets execution status win over funnel stage (one item, downstream face)", () => {
+    // Being built = downstream, regardless of how far it got in the funnel.
+    expect(placeInFlow(item({ itemId: "F", status: "in-progress", demandStage: "ready" }))).toBe("in_progress");
+    expect(placeInFlow(item({ itemId: "G", status: "in-progress", demandStage: "screened" }))).toBe("in_progress");
+  });
+});
+
+describe("groupByFlowLane", () => {
+  it("returns all lanes in river order, even when empty", () => {
+    const cols = groupByFlowLane([]);
+    expect(cols.map((c) => c.lane)).toEqual(FLOW_LANES);
+    expect(cols.every((c) => c.items.length === 0)).toBe(true);
+  });
+
+  it("assigns each item to exactly one lane and orders by score desc", () => {
+    const cols = groupByFlowLane([
+      item({ itemId: "low", demandStage: "screened", demandScore: 5 }),
+      item({ itemId: "high", demandStage: "screened", demandScore: 50 }),
+      item({ itemId: "bet1", demandStage: "ready", demandScore: 20 }),
+      item({ itemId: "exec", status: "in-progress", demandStage: "ready", demandScore: 99 }),
+      item({ itemId: "rawItem" }),
+    ]);
+    const byLane = Object.fromEntries(cols.map((c) => [c.lane, c.items.map((i) => i.itemId)])) as Record<FlowLane, string[]>;
+    expect(byLane.funnel_raw).toEqual(["rawItem"]);
+    expect(byLane.funnel_screened).toEqual(["high", "low"]); // 50 before 5
+    expect(byLane.bet).toEqual(["bet1"]);
+    expect(byLane.in_progress).toEqual(["exec"]); // status wins over demandStage=ready
+    // Every input item placed exactly once across all lanes.
+    expect(cols.reduce((n, c) => n + c.items.length, 0)).toBe(5);
+  });
+
+  it("tags each lane with its river half (two visual languages)", () => {
+    const cols = groupByFlowLane([]);
+    const halfByLane = Object.fromEntries(cols.map((c) => [c.lane, c.half]));
+    expect(halfByLane.funnel_raw).toBe("funnel");
+    expect(halfByLane.bet).toBe("bet");
+    expect(halfByLane.in_progress).toBe("board");
+  });
+});

--- a/apps/web/lib/demand/flow.ts
+++ b/apps/web/lib/demand/flow.ts
@@ -1,0 +1,85 @@
+// Pure Delivery-Flow projection — no server imports. Safe in tests and client
+// components. EP-DELIVERY-FLOW BI-1DE21746 (unified surface).
+//
+// Demand (invest) and Backlog (execute) are two lenses on the SAME BacklogItem.
+// The Flow lens renders them as ONE left-to-right river — investment funnel → the
+// bet → execution board — so they stop reading as two duplicate boards. This
+// module places each item into a single flow lane by its lifecycle position, and
+// the surface paints two deliberately different visual languages across the lanes
+// (a score-tinted narrowing funnel upstream; a WIP status board downstream, joined
+// by the amber "bet" seam).
+//
+// Spec: docs/superpowers/specs/2026-07-12-delivery-flow-demand-backlog-unification-design.md
+// §"The design — one river, two halves, joined by the bet". Placement uses the
+// same non-terminal DemandItemView dataset the Demand board already loads, so the
+// whole surface is one dataset under a lens switch (no second heavy query).
+
+import { type DemandItemView } from "./board";
+
+/**
+ * The lanes of the flow river, left to right:
+ * - `funnel_raw` / `funnel_screened` / `funnel_shaped` — the investment funnel
+ *   (upstream half): value÷effort, score-tinted, still being shaped.
+ * - `bet` — the seam: a `ready` (funded) item that has crossed the governed
+ *   funding gate but hasn't been picked up for execution yet. The amber crossing.
+ * - `in_progress` — the execution half (downstream): owner + burn-down.
+ */
+export const FLOW_LANES = ["funnel_raw", "funnel_screened", "funnel_shaped", "bet", "in_progress"] as const;
+export type FlowLane = (typeof FLOW_LANES)[number];
+
+/** Which half of the river a lane belongs to — drives the two visual languages. */
+export const FLOW_LANE_HALF: Record<FlowLane, "funnel" | "bet" | "board"> = {
+  funnel_raw: "funnel",
+  funnel_screened: "funnel",
+  funnel_shaped: "funnel",
+  bet: "bet",
+  in_progress: "board",
+};
+
+export const FLOW_LANE_LABELS: Record<FlowLane, string> = {
+  funnel_raw: "Raw",
+  funnel_screened: "Screened",
+  funnel_shaped: "Shaped",
+  bet: "The bet",
+  in_progress: "In progress",
+};
+
+/**
+ * Place an item into a single flow lane by its lifecycle position. Execution
+ * status wins over funnel stage (an item being built is downstream regardless of
+ * how it was scored); a `ready`-but-unstarted item sits on the bet; otherwise it
+ * falls in the funnel by `demandStage` (missing stage = raw, per the funnel).
+ */
+export function placeInFlow(item: Pick<DemandItemView, "status" | "demandStage">): FlowLane {
+  if (item.status === "in-progress") return "in_progress";
+  if (item.demandStage === "ready") return "bet";
+  if (item.demandStage === "shaped") return "funnel_shaped";
+  if (item.demandStage === "screened") return "funnel_screened";
+  return "funnel_raw";
+}
+
+export type FlowColumn = {
+  lane: FlowLane;
+  half: "funnel" | "bet" | "board";
+  items: DemandItemView[];
+};
+
+/**
+ * Group items into the flow lanes in river order. Within a lane, highest
+ * demandScore first (unscored last) — matching the Demand funnel's ordering so
+ * the two lenses agree on priority.
+ */
+export function groupByFlowLane(items: DemandItemView[]): FlowColumn[] {
+  const lanes: Record<FlowLane, DemandItemView[]> = {
+    funnel_raw: [],
+    funnel_screened: [],
+    funnel_shaped: [],
+    bet: [],
+    in_progress: [],
+  };
+  for (const item of items) lanes[placeInFlow(item)].push(item);
+  for (const lane of FLOW_LANES) {
+    lanes[lane].sort((a, b) => (b.demandScore ?? -Infinity) - (a.demandScore ?? -Infinity));
+  }
+  return FLOW_LANES.map((lane) => ({ lane, half: FLOW_LANE_HALF[lane], items: lanes[lane] }));
+}

--- a/docs/superpowers/plans/2026-07-15-delivery-flow-unified-surface-plan.md
+++ b/docs/superpowers/plans/2026-07-15-delivery-flow-unified-surface-plan.md
@@ -1,0 +1,32 @@
+# Plan — Delivery Flow unified surface (BI-1DE21746, EP-DELIVERY-FLOW phase 2)
+
+**Status:** DRAFT (staged in scratchpad; move into the BI-1DE21746 worktree off updated main once PR #3027 merges).
+**BI:** BI-1DE21746 (large) — "Delivery Flow surface: unify /ops (backlog) + /ops/demand into one funnel→bet→board flow".
+**Design source of truth:** `docs/superpowers/specs/2026-07-12-delivery-flow-demand-backlog-unification-design.md` (kernel-ratified unify-flow-ai-led).
+**Depends on:** BI-E731A6C1 (PR #3027) — provenance read fields on `DemandItemView`/`getDemandItems` (`estimateAiJobSize`, `estimateHumanJobSize`, `estimateSource`, `estimateAgreed`). Branch off main AFTER #3027 lands.
+
+## Goal
+Demand and Backlog stop reading as two duplicate boards. One left-to-right **Delivery Flow**: investment **funnel** → **the bet** (the funded seam) → execution **board** — two deliberately different visual languages, one `BacklogItem` with two faces, a lens switch (Flow / Prioritize / Execute) over one dataset.
+
+## Current substrate (read 2026-07-15)
+- **Demand (invest):** `apps/web/app/(shell)/ops/demand/page.tsx` → `components/ops/DemandBoard.tsx` (3 tabs: Funnel `groupByFunnelStage`, Value×effort `buildValueEffortMatrix`, Balance `computeBucketMix`). Card = `DemandCard` — title, value band, effort/estimate line, "Why this score?" drill-in. Pure projections in `lib/demand/board.ts`.
+- **Backlog (execute):** `apps/web/app/(shell)/ops/page.tsx` → `components/ops/OpsClient.tsx` — status board/list/grid over `BacklogItem.status`, with `SurfaceViewSwitcher`.
+- **Nav:** `components/ops/ops-nav.ts` `OPS_NAV_GROUPS` — "Delivery" group = Backlog (`/ops`) + Demand (`/ops/demand`); rendered by `OpsTabNav`.
+- **The bet (governed seam):** `approve_demand_for_funding` in `lib/mcp/packs/demand-scoring-pack.ts` → org WWWD gate → advances `demandStage` to `ready`.
+
+## Phased steps (additive; no green-field)
+1. **Route + shell.** Introduce `/ops/flow` (or promote in place) as the single Delivery Flow surface. Keep `/ops` and `/ops/demand` as redirects/aliases initially (no dead links) — collapse the nav in step 5. Server page loads both `getDemandItems()` and `getBacklogItems()` (already exist).
+2. **Lens switch.** One client shell with three lenses over one dataset: **Flow** (the whole river: funnel → bet → board), **Prioritize** (today's Demand tabs — funnel/matrix/balance), **Execute** (today's Backlog status board). Reuse `DemandBoard` internals and `OpsClient` as the Prioritize/Execute lens bodies rather than re-implementing.
+3. **The Flow lens (new).** Left-to-right composite: score-tinted narrowing funnel (raw→screened→shaped→ready) → an amber **"the bet"** seam column (the `ready`, funded crossing; surfaces `approve_demand_for_funding` state) → WIP status board (in-progress→done). Two visual languages: funnel = value/score tint; board = owner + burn-down. Pure grouping helper in `lib/demand/` (e.g. `flow.ts`) — one item placed by (`demandStage` upstream of bet) vs (`status` downstream), unit-tested.
+4. **One-item-two-faces + estimate chip.** Upstream card face: score + **estimate chip** consuming the provenance fields — show effective estimate, whose (`estimateSource`), and `⇄ ai ↔ human · reconcile` when `estimateAiJobSize !== estimateHumanJobSize` and not agreed. (Display only here; the interactive reconcile flow is BI-AA1763CD.) Downstream face: owner + status/burn-down. Same `BI-…`, no copy.
+5. **Nav collapse.** `ops-nav.ts`: "Delivery" group's Backlog+Demand → one **"Flow"** tab (lens sub-views). Verify nav-source registration (`lib/ea/domain-nav-sources.ts`) and the nav-teleport gate. Update any inbound links.
+6. **Tests + guards.** Unit tests for the new pure flow-projection; component smoke for the lens switch; keep `OpsClient.test.tsx` green. Watch module-size ratchet (DemandBoard/new shell), Design Grounding Gate (this plan + spec are the grounding), UX-Fit (new route/nav change).
+
+## Explicitly out of scope (later phases)
+- **BI-A6648529** — AI-led volunteering: funding the bet triggers a proactive coworker to self-task/claim → advance status (wires the demand→ready seam to the proactivity/self-task engine).
+- **BI-AA1763CD** — collaborative estimation UX: AI proposes on arrival, human confirm/overrule, interactive reconcile (writes via `record_effort_estimate`, shipped in BI-E731A6C1).
+
+## Verification
+- tsc green (`NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` — pre-commit scoped tsc OOM-crashes; commit with `DPF_SKIP_TYPECHECK=1` after a clean out-of-band run).
+- Drive the live `/ops/flow` surface (dev-portal-start / dpf-verify-on-live-install) once the portal upgrade settles.
+- New route + nav change ⇒ regen route-manifest; UX-Fit-Decision trailer.


### PR DESCRIPTION
## What

Phase 2 of **EP-DELIVERY-FLOW**. Makes Demand and Backlog read as **one left-to-right delivery flow** instead of two duplicate boards. The Delivery surface (`/ops/demand`) leads with a new **Flow** lens — the whole river, investment funnel → the amber **bet** seam → execution board — with the existing Funnel / Value×effort / Balance kept as invest-half sub-lenses over the same dataset. The Delivery nav group now reads **Delivery Flow → Backlog** (invest → execute): two faces of one `BacklogItem`.

Resolves **BI-1DE21746** (WC-26ECB26C). Builds on phase 1 (BI-E731A6C1, #3027, merged).

## Changes
- **`lib/demand/flow.ts`** (pure, unit-tested): `placeInFlow` / `groupByFlowLane` map each item to a single lane by lifecycle — funnel(raw/screened/shaped) → bet(ready/funded) → in_progress(executing); execution status wins over funnel stage (one item, downstream face). Two visual languages via `FLOW_LANE_HALF`.
- **`DemandBoard`**: new `FlowView` (score-tinted funnel lanes, amber "the bet · a coworker volunteers" seam, execution lane) as the **default** lens; new `EstimateChip` on `DemandCard` consuming the BI-E731A6C1 provenance fields — shows whose estimate the score carries and a `⇄ reconcile` affordance when AI/human diverge (display-only; interactive reconcile is BI-AA1763CD).
- **`ops-nav.ts` + demand page copy**: Delivery group collapses to one flow reading.
- **Plan**: `docs/superpowers/plans/2026-07-15-delivery-flow-unified-surface-plan.md`.

## Verification
- `apps/web` `tsc --noEmit` — exit 0, **0 errors** (8GB heap).
- Unit tests green: 6 new `flow` tests + `board`/`estimate`/`scoring` — all passing.
- Guards green: module-size, and the **sandbox pregate (local-CI-equivalent) passed** — full production build + gate record (`Local-CI-Override` not needed).
- **Live-verify note:** driving `/ops/demand` on the Contributor preview (`:3001`) was BLOCKED by a **pre-existing dev-portal Turbopack defect** (`Invalid __TURBOPACK__imported__module__` for `packages/db/src/client.ts`). I confirmed it **reproduces on clean origin/main with my changes stashed** — so it is not caused by this change — and filed **BI-53D7E70C**. The sibling `/ops` route rendered live and confirmed the new nav (Delivery Flow → Backlog); the Live portal `:3000` production build renders `/ops/demand` fine.

## Design grounding
Extends the kernel-ratified design `docs/superpowers/specs/2026-07-12-delivery-flow-demand-backlog-unification-design.md` (unify-flow-ai-led) + the phase-2 plan. Additive UI over the existing Demand surface; nav relabel, **no new route**.

Design-Grounding-Decision: extends existing spec + plan; additive UI in apps/web/components/ops + apps/web/lib/demand; nav relabel, no contract change.

## Follow-on (epic)
- BI-A6648529 — AI-led volunteering: funding the bet triggers a proactive coworker to self-task/claim.
- BI-AA1763CD — collaborative estimation UX: interactive AI-propose / human-confirm / reconcile (writes via `record_effort_estimate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)