### PR TITLE
fix(coworker-health): stop phantom "Memory offline" + duplicate KG alert wording (BI-31FDC859, BI-49C4EA5D)

### DIFF
--- a/apps/web/components/monitoring/AiCoworkerHealthPanel.tsx
+++ b/apps/web/components/monitoring/AiCoworkerHealthPanel.tsx
@@ -6,7 +6,10 @@ import { TONE_COLOR } from "./health-summary";
 
 export function AiCoworkerHealthPanel() {
   const { data: inferenceUp, offline } = useMetricQuery('up{job="model-runner"}');
-  const { data: qdrantUp } = useMetricQuery('up{job="qdrant"}');
+  // BET-5 retired Qdrant: coworker memory is pgvector inside Postgres, so the
+  // memory store is reachable iff Postgres is up (BI-31FDC859). Semantic-memory
+  // health is refined below by dpf_semantic_memory_errors_total.
+  const { data: memoryStoreUp } = useMetricQuery('up{job="postgres"}');
   const { data: memErrors } = useMetricQuery(
     "rate(dpf_semantic_memory_errors_total[5m])",
   );
@@ -27,7 +30,7 @@ export function AiCoworkerHealthPanel() {
 
   const modelRunnerScraped = (inferenceUp?.length ?? 0) > 0;
   const inferenceAvailable = !modelRunnerScraped || parseFloat(inferenceUp?.[0]?.value?.[1] ?? "0") === 1;
-  const memoryAvailable = parseFloat(qdrantUp?.[0]?.value?.[1] ?? "0") === 1;
+  const memoryAvailable = parseFloat(memoryStoreUp?.[0]?.value?.[1] ?? "0") === 1;
   const hasMemErrors = parseFloat(memErrors?.[0]?.value?.[1] ?? "0") > 0;
   const p95Value = parseFloat(inferenceP95?.[0]?.value?.[1] ?? "0");
 

--- a/apps/web/components/monitoring/CoworkerHealthStatus.tsx
+++ b/apps/web/components/monitoring/CoworkerHealthStatus.tsx
@@ -69,7 +69,10 @@ export function CoworkerHealthStatus() {
       );
 
       const modelRunnerUp = results.find((r) => r.job === "model-runner")?.up ?? true;
-      const memoryUp = results.find((r) => r.job === "qdrant")?.up ?? true;
+      // BET-5 retired Qdrant: coworker memory is now pgvector inside Postgres.
+      // The old up{job="qdrant"} target is decommissioned and permanently reads
+      // 0, which produced a phantom "Memory offline" banner (BI-31FDC859).
+      const memoryUp = results.find((r) => r.job === "postgres")?.up ?? true;
 
       setHealth(
         deriveCoworkerHealthState({

--- a/apps/web/lib/agent/opening-briefing.test.ts
+++ b/apps/web/lib/agent/opening-briefing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { composeOpeningBriefing, surfacePrefixFromRouteContext } from "./opening-briefing";
+import { composeOpeningBriefing, detailRestatesTitle, surfacePrefixFromRouteContext } from "./opening-briefing";
 import type { AttentionItem } from "@/lib/attention/types";
 
 function makeItem(overrides: Partial<AttentionItem> = {}): AttentionItem {
@@ -23,6 +23,30 @@ function makeItem(overrides: Partial<AttentionItem> = {}): AttentionItem {
     ...overrides,
   };
 }
+
+describe("detailRestatesTitle", () => {
+  it("treats a detail that only restates the headline as redundant", () => {
+    // The exact BI-49C4EA5D case: title vs a synonymous detail.
+    expect(detailRestatesTitle("The knowledge graph is down", "The knowledge graph is unavailable.")).toBe(true);
+    expect(detailRestatesTitle("AI memory search is down", "AI memory search is offline")).toBe(true);
+  });
+
+  it("keeps a detail that names a real downstream consequence", () => {
+    expect(
+      detailRestatesTitle(
+        "The platform database is down",
+        "The platform database is unreachable — most features will fail.",
+      ),
+    ).toBe(false);
+    expect(detailRestatesTitle("Voice input is unavailable", "Dictation won't work until it's back.")).toBe(false);
+  });
+
+  it("treats empty or whitespace context as redundant (nothing to add)", () => {
+    expect(detailRestatesTitle("Anything", "")).toBe(true);
+    expect(detailRestatesTitle("Anything", "   ")).toBe(true);
+    expect(detailRestatesTitle("Anything", null)).toBe(true);
+  });
+});
 
 describe("surfacePrefixFromRouteContext", () => {
   it("keeps the first two segments and drops build fragments", () => {
@@ -102,6 +126,42 @@ describe("composeOpeningBriefing", () => {
     expect(briefing?.content).toContain("Launch email awaits your approval");
     expect(briefing?.content).toContain("1 more item is waiting for your review");
     expect(briefing?.content).toContain("[open your Needs-you inbox](/workspace/inbox)");
+  });
+
+  it("omits a redundant detail so the headline doesn't restate itself (BI-49C4EA5D)", () => {
+    const briefing = composeOpeningBriefing({
+      routeContext: "/workspace",
+      proactivityLevel: "balanced",
+      items: [
+        makeItem({
+          id: "platform-health:neo4j",
+          source: "platform-health",
+          title: "The knowledge graph is down",
+          context: "The knowledge graph is unavailable.",
+          deepLink: "/platform/health",
+        }),
+      ],
+    });
+    expect(briefing?.content).toContain("[The knowledge graph is down](/platform/health)");
+    // The em-dash-joined restatement must NOT appear.
+    expect(briefing?.content).not.toContain("— The knowledge graph is unavailable");
+  });
+
+  it("keeps a detail that adds a real consequence", () => {
+    const briefing = composeOpeningBriefing({
+      routeContext: "/workspace",
+      proactivityLevel: "balanced",
+      items: [
+        makeItem({
+          id: "platform-health:postgres",
+          source: "platform-health",
+          title: "The platform database is down",
+          context: "The platform database is unreachable — most features will fail.",
+          deepLink: "/platform/health",
+        }),
+      ],
+    });
+    expect(briefing?.content).toContain("— The platform database is unreachable — most features will fail.");
   });
 
   it("falls back to the triage-top item when nothing is surface-local", () => {

--- a/apps/web/lib/agent/opening-briefing.ts
+++ b/apps/web/lib/agent/opening-briefing.ts
@@ -42,6 +42,42 @@ export function surfacePrefixFromRouteContext(routeContext: string): string {
   return `/${segments.slice(0, 2).join("/")}`;
 }
 
+// Status synonyms and articles carry no information distinguishing a headline
+// from its detail, so they're ignored when deciding whether the detail merely
+// restates the headline.
+const STATUS_STOPWORDS = new Set([
+  "the", "a", "an", "is", "are", "was", "were", "be", "been",
+  "down", "offline", "unavailable", "unreachable", "not", "responding", "no",
+]);
+
+function contentTokens(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((w) => w && !STATUS_STOPWORDS.has(w)),
+  );
+}
+
+/**
+ * True when `context` adds no content words beyond `title` — i.e. it merely
+ * restates the headline ("The knowledge graph is down" / "The knowledge graph
+ * is unavailable"). Such a detail is dropped so the briefing doesn't render
+ * "X is down — X is unavailable" (BI-49C4EA5D). A detail that names a real
+ * consequence ("…— most features will fail") keeps content words and is kept.
+ */
+export function detailRestatesTitle(title: string, context: string | null | undefined): boolean {
+  if (!context || !context.trim()) return true;
+  const contextTokens = contentTokens(context);
+  if (contextTokens.size === 0) return true;
+  const titleTokens = contentTokens(title);
+  for (const word of contextTokens) {
+    if (!titleTokens.has(word)) return false;
+  }
+  return true;
+}
+
 /**
  * Compose the opening briefing, gated by the employee's Proactivity choice for
  * this coworker: quiet = stay silent (that's what quiet means), balanced =
@@ -75,8 +111,11 @@ export function composeOpeningBriefing(input: {
   const headline = surfaceLocal[0] ?? input.items[0];
   const remaining = input.items.length - 1;
 
+  const headlineLink = `[${headline.title}](${headline.deepLink})`;
   const lines = [
-    `**Most pressing:** [${headline.title}](${headline.deepLink}) — ${headline.context}`,
+    detailRestatesTitle(headline.title, headline.context)
+      ? `**Most pressing:** ${headlineLink}`
+      : `**Most pressing:** ${headlineLink} — ${headline.context}`,
   ];
   if (remaining > 0) {
     lines.push(


### PR DESCRIPTION
## What
Two coworker-facing health surfaces still read **BET-5-decommissioned** signals, so a healthy Postgres-only install alarmed the operator (from a live coworker screenshot). Confirmed against `origin/main` + the running containers (`docker ps` shows no qdrant/neo4j; `up{job="qdrant"}=0` while postgres/portal/sandbox=1).

- **Phantom "Memory offline" (BI-31FDC859):** `CoworkerHealthStatus` and `AiCoworkerHealthPanel` derived memory health from `up{job="qdrant"}`. That scrape target is retired and permanently reads 0 → a permanent *"Memory offline - responses won't recall prior context"* banner. Coworker memory is now pgvector inside Postgres, so the signal is repointed at Postgres (`AiCoworkerHealthPanel` keeps its `dpf_semantic_memory_errors_total` gate).
- **Duplicate KG wording (BI-49C4EA5D):** the opening briefing joined an attention item's `title` and `context` with an em dash unconditionally, so the `Neo4jDown` humanization rendered *"The knowledge graph is down — The knowledge graph is unavailable."* Added a general `detailRestatesTitle()` guard that drops a detail which only restates the headline, while keeping details that name a real consequence.

## Scope
Deliberately tight — only the coworker-facing symptoms. The broader retirement (qdrant scrape job, `PLATFORM_REQUIRED_JOBS`, platform-health tiles, `Neo4jDown`/`QdrantDown` alert rules) is tracked in **BI-2B70C92C**.

## Tests
- New `detailRestatesTitle` unit tests (redundant restatement vs real consequence vs empty).
- New composition test proving the "X is down — X is unavailable" restatement collapses and a real-consequence detail is kept.
- `opening-briefing`, `CoworkerHealthStatus`, `prometheus-config` suites green; full `tsc --noEmit` clean; local-CI gate passed.

## Design grounding
No-contract-change bug fix in `apps/web/`. Source of truth: the BET-5 retirement (Postgres-only). Corrects health signals pointing at decommissioned stores; no spec/plan change.

Design-Grounding-Decision: trivial no-contract-change edit; apps/web/ health-surface signals corrected against the BET-5 (Postgres-only) source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)