### PR TITLE
fix(twin): demo load path fail-open on setup seeds (A·P1, live-verified)

### DIFF
--- a/apps/web/lib/demo/load-demo-business.ts
+++ b/apps/web/lib/demo/load-demo-business.ts
@@ -53,6 +53,8 @@ export interface LoadDemoBusinessResult {
   archetypeId: string;
   storefrontId: string;
   seededAt: Date;
+  /** False when the (non-fatal) setup-completion priming seeds failed. */
+  primed: boolean;
   counts: {
     providers: number;
     bookings: number;
@@ -133,13 +135,22 @@ export async function loadDemoBusiness(
   await upsertBills(db, plan, supplierIdByRef, now);
   await upsertBookings(db, plan, storefrontId, providerIdByRef, now);
 
-  // 4. Setup-completion seeds (WWWD priming corpus etc.) — fail-open, idempotent.
-  await runSetupCompletionSeeds(org.id);
+  // 4. Setup-completion seeds (WWWD priming corpus etc.) — best-effort. The demo's
+  //    operational-twin data (steps 1–3) is the deliverable; priming is enrichment,
+  //    so a seed failure (e.g. embedding service down) must not abort the load.
+  let primed = true;
+  try {
+    await runSetupCompletionSeeds(org.id);
+  } catch (err) {
+    primed = false;
+    console.warn(`loadDemoBusiness: setup-completion seeds failed (non-fatal): ${String(err)}`);
+  }
 
   return {
     archetypeId,
     storefrontId,
     seededAt: now,
+    primed,
     counts: {
       providers: plan.providers.length,
       bookings: plan.bookings.length,


### PR DESCRIPTION
## Summary

Follow-up to the A·P1 load path (#3026): make `loadDemoBusiness` **fail-open on the setup-completion priming seeds**. The demo's operational-twin data (providers/bookings/bills/employees) is the deliverable; the priming seeds (WWWD corpus, embeddings) are enrichment, so a priming failure — e.g. the embedding service being unreachable — must not abort a load whose twin data already committed. Surfaces a `primed` flag on the result.

## How it was found — live end-to-end verification ✅

I ran the load path **against the real dev DB** (`dpf-postgres-1`, reached via a reversible socat port-forward on the docker network — this is the non-prod portal, not a business-in-use install):

```
loadDemoBusiness("restaurant") →
  loaded:   { providers: 9, bookings: 11, bills: 3, suppliers: 3, employees: 3 }
  rendered: loadLivingBusinessSnapshot() → live:true, template:FLOOR,
            8 zone units, 4 queued tickets (with waits),
            cog "Assign the 14m-waiting ticket to …",
            chips [Longest wait=14m, Workforce=95, AI coworkers=89]
  unloaded: { bookings: 11, providers: 9, bills: 3, suppliers: 3, employees: 3 }  ← reversible, exact
```

So a generated demo **renders through the live projection (same code path, not a fixture)** and tears down cleanly — the A·P1 "Verification" line, proven end-to-end. The only failure in that run was the priming seed step throwing in the raw runner context; fail-open is the correct product behavior and is what this PR lands.

## Test plan

- [x] Executor fake-db unit test still green (5/5); `apps/web` typecheck clean (pre-commit hook)
- [x] Live: load → render → unload against the real DB (above)

## Related

Epic **EP-ARCHETYPE-DEMO** · BI **BI-7C95BEF6** (A·P1). Follows #3023 (generator) + #3026 (load path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)