### PR TITLE
fix(routing): honest local-fallback banner — active provider ineligible, not "unavailable" (BI-9DFAFB4A)

### DIFF
--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -725,8 +725,9 @@ export async function routeAndCall(
     (m) => m.providerTier === "user_configured" && (m.status === "active" || m.status === "degraded"),
   );
   const fellToLocal = selectedTier === "bundled" && hasUserConfiguredActive && !result.downgraded;
+  // fellToLocal requires an ACTIVE paid provider (no outage) — it was merely ineligible for this request (usually context-window/capability), not unavailable (BI-9DFAFB4A).
   const localFallbackBanner = fellToLocal
-    ? `This turn ran on the bundled local model because configured paid providers were unavailable. Tool calls and complex reasoning may be unreliable on local — retry in a moment, or check provider status in Admin > AI.`
+    ? `This turn ran on the bundled local model. Your configured provider is active but wasn't eligible for this request — usually because the request exceeded its context window, or needed a capability it doesn't offer. Local output can be less reliable for tool use and complex reasoning; try a shorter request, or review provider settings in Admin > AI.`
     : null;
 
   // 6. Persist TokenUsage row for the cost ledger (Phase J).


### PR DESCRIPTION
## What
When a coworker turn falls to the bundled local model, the banner asserted *"configured paid providers were unavailable"* and pointed the operator at provider status. That's misdirection: `fellToLocal` is only set when `hasUserConfiguredActive` is true — the paid provider is **active/degraded** (credentials fine, no outage).

Reading the pipeline: the Stage-5b tier sort already ranks `user_configured` ahead of `bundled`, so local only wins when **every** paid endpoint was excluded by a hard routing constraint *for this specific request* — most often the request exceeded the provider's context window, or needed a capability it doesn't offer. The null-context exemption in the `pipeline-v2` filter then keeps local as a **last-resort** so the request degrades instead of failing outright.

So the defect is the **message**, not the routing. This reword names the real cause (per-request eligibility) and the real levers (shorten the request, review provider config). No routing-behavior change — deliberately, since excluding the null-context local would turn a graceful degrade into a hard failure.

## Scope note
The original BI hypothesized a context-filter asymmetry bug; investigation refined that to "intentional safety net + misleading banner" (BI body updated). A genuinely stale cloud `maxContextTokens` would be a catalog/reconciliation data issue, separate from this.

## Tests
No test pinned the banner string. `routed-inference.activity-overrides`, `local-degradation-caveat`, `inference-failure` suites green; full `tsc --noEmit` clean; local-CI gate passed.

## Design grounding
Design-Grounding-Decision: no-contract-change bug fix in apps/web/; corrects a misleading observability string in the inference routing layer. No spec/plan change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)