### PR TITLE
fix(ideate): bounded reformat-retry for local-model design-doc parsing (BI-0463ED78)

### DIFF
--- a/apps/web/lib/integrate/ideate-dispatch.test.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.test.ts
@@ -1,5 +1,49 @@
-import { describe, it, expect } from "vitest";
-import { buildResearchPrompt, deriveSearchTerms } from "./ideate-dispatch";
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildResearchPrompt,
+  deriveSearchTerms,
+  runLocalIdeateWithRetry,
+  LOCAL_IDEATE_MAX_ATTEMPTS,
+} from "./ideate-dispatch";
+
+describe("runLocalIdeateWithRetry", () => {
+  const VALID = '```json\n{"title":"X","summary":"ok"}\n```';
+  const MALFORMED = "Sure! Here is the design: it should do stuff (no JSON at all)";
+
+  it("parses on the first attempt without a reformat call", async () => {
+    const call = vi.fn(async () => VALID);
+    const { designDoc, attempts } = await runLocalIdeateWithRetry(call, "base prompt");
+    expect(designDoc).toEqual({ title: "X", summary: "ok" });
+    expect(attempts).toBe(1);
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers when a malformed first turn is reformatted into valid JSON", async () => {
+    const call = vi
+      .fn()
+      .mockResolvedValueOnce(MALFORMED)
+      .mockResolvedValueOnce(VALID);
+    const onAttempt = vi.fn();
+    const { designDoc, attempts } = await runLocalIdeateWithRetry(call, "base prompt", 2, onAttempt);
+    expect(designDoc).toEqual({ title: "X", summary: "ok" });
+    expect(attempts).toBe(2);
+    expect(call).toHaveBeenCalledTimes(2);
+    // The reformat turn feeds the model its own prior output + a strict instruction.
+    const secondCallMessages = call.mock.calls[1]![0] as Array<{ role: string; content: string }>;
+    expect(secondCallMessages).toHaveLength(3);
+    expect(secondCallMessages[1]).toEqual({ role: "assistant", content: MALFORMED });
+    expect(secondCallMessages[2]!.content).toContain("valid JSON object");
+    expect(onAttempt).toHaveBeenCalledWith(2);
+  });
+
+  it("gives up after the attempt cap and returns no design doc", async () => {
+    const call = vi.fn(async () => MALFORMED);
+    const { designDoc, attempts } = await runLocalIdeateWithRetry(call, "base prompt", LOCAL_IDEATE_MAX_ATTEMPTS);
+    expect(designDoc).toBeNull();
+    expect(attempts).toBe(LOCAL_IDEATE_MAX_ATTEMPTS);
+    expect(call).toHaveBeenCalledTimes(LOCAL_IDEATE_MAX_ATTEMPTS);
+  });
+});
 
 describe("deriveSearchTerms", () => {
   it("splits camelCase and drops boilerplate stopwords", () => {

--- a/apps/web/lib/integrate/ideate-dispatch.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.ts
@@ -18,7 +18,16 @@ import {
   sandboxExec,
   writeSandboxFile,
 } from "./sandbox/agent-cli-runtime";
+import type { ChatMessage } from "@/lib/inference/ai-inference";
 const IDEATE_TIMEOUT_MS = 600_000; // 10 minutes — complex features need time for codebase research
+
+// Local models often wrap the design JSON in prose or emit malformed JSON that
+// survives repairJson. Rather than hard-fail on the first unparseable turn
+// (BI-0463ED78), we give the model a bounded chance to reformat its own output
+// into strict JSON before surfacing an error to the operator.
+export const LOCAL_IDEATE_MAX_ATTEMPTS = 2;
+const REFORMAT_INSTRUCTION =
+  "Your previous response could not be parsed. Reply with ONLY the design document as a single valid JSON object — no prose, no explanation, and no markdown code fences. Make sure every string is properly quoted and escaped, and remove any trailing commas.";
 
 export type IdeateResult = {
   designDoc: Record<string, unknown> | null;
@@ -325,6 +334,42 @@ function parseDesignDoc(output: string): Record<string, unknown> | null {
 }
 
 /**
+ * Run the local (routeAndCall) ideate inference with a bounded reformat-retry.
+ * On the first attempt the model gets the research prompt; if the output can't
+ * be parsed into a design doc, subsequent attempts feed the model its own
+ * output back with a strict "JSON only" instruction. This turns a single
+ * malformed local inference from a hard failure into a recoverable one
+ * (BI-0463ED78) without any provider fallback or new inference path.
+ *
+ * `call` is injected (rather than importing routeAndCall directly) so the retry
+ * loop is unit-testable without the routing stack.
+ */
+export async function runLocalIdeateWithRetry(
+  call: (messages: ChatMessage[]) => Promise<string>,
+  basePrompt: string,
+  maxAttempts: number = LOCAL_IDEATE_MAX_ATTEMPTS,
+  onAttempt?: (attempt: number) => void,
+): Promise<{ designDoc: Record<string, unknown> | null; rawOutput: string; attempts: number }> {
+  let rawOutput = "";
+  let designDoc: Record<string, unknown> | null = null;
+  let attempt = 0;
+  for (attempt = 1; attempt <= maxAttempts && !designDoc; attempt++) {
+    onAttempt?.(attempt);
+    const messages: ChatMessage[] =
+      attempt === 1
+        ? [{ role: "user", content: basePrompt }]
+        : [
+            { role: "user", content: basePrompt },
+            { role: "assistant", content: rawOutput || "(empty response)" },
+            { role: "user", content: REFORMAT_INSTRUCTION },
+          ];
+    rawOutput = (await call(messages)).trim();
+    designDoc = parseDesignDoc(rawOutput);
+  }
+  return { designDoc, rawOutput, attempts: attempt - 1 };
+}
+
+/**
  * Dispatch ideate research to the selected external CLI (Claude / Codex / Grok) inside the sandbox.
  */
 /** Derive a few distinctive search terms from the feature title + description,
@@ -431,16 +476,24 @@ export async function dispatchIdeateResearch(params: {
         deriveSearchTerms(params.featureTitle, params.featureDescription),
         params.onProgress,
       );
-      const prompt = buildResearchPrompt(params) + codeGraphContext;
+      const basePrompt = buildResearchPrompt(params) + codeGraphContext;
       const { routeAndCall } = await import("@/lib/inference/routed-inference");
-      const response = await routeAndCall(
-        [{ role: "user" as const, content: prompt }],
-        "You are a senior software architect producing a structured design document. Respond with the design document content only — no preamble.",
-        "internal",
-        { budgetClass: "quality_first", ...(params.modelTier ? { modelTier: params.modelTier } : {}) },
+      const systemPrompt =
+        "You are a senior software architect producing a structured design document. Respond with the design document content only — no preamble.";
+      const { designDoc, rawOutput } = await runLocalIdeateWithRetry(
+        async (messages) => {
+          const response = await routeAndCall(messages, systemPrompt, "internal", {
+            budgetClass: "quality_first",
+            ...(params.modelTier ? { modelTier: params.modelTier } : {}),
+          });
+          return response.content ?? "";
+        },
+        basePrompt,
+        LOCAL_IDEATE_MAX_ATTEMPTS,
+        (attempt) => {
+          if (attempt > 1) params.onProgress?.("Reformatting the design into valid JSON…");
+        },
       );
-      const rawOutput = (response.content ?? "").trim();
-      const designDoc = parseDesignDoc(rawOutput);
       return {
         designDoc,
         rawOutput,


### PR DESCRIPTION
## What
The local (`routeAndCall`) ideate path made **exactly one** inference and, if the output didn't parse into a design doc, immediately surfaced a hard ISSUE — *"Local-model ideate output could not be parsed into a design document"* — ending the whole ideate flow. Local models frequently wrap the JSON in prose or emit malformed JSON that survives `repairJson`, so one bad turn had no recovery, while the frontier CLI paths already had envelope/tee-file recovery the local path lacked.

## Fix
`runLocalIdeateWithRetry()`: on a parse miss, feed the model its own output back with a strict "JSON only" instruction and retry, up to `LOCAL_IDEATE_MAX_ATTEMPTS` (2) total, before surfacing the same error. No provider fallback and no new inference path — a bounded self-correction on the existing `routeAndCall`. Progress is surfaced via the existing `onProgress` ("Reformatting the design into valid JSON…").

The loop takes an **injected `call` fn** so it's unit-testable without the routing stack.

## Tests
- Parses on first attempt (no reformat call).
- Recovers when a malformed first turn is reformatted into valid JSON (asserts the reformat turn feeds back the prior output + strict instruction).
- Gives up after the attempt cap and returns no design doc.
- Full `ideate-dispatch` suite green (12); `tsc --noEmit` clean; local-CI gate passed.

## Design grounding
Design-Grounding-Decision: no-contract-change reliability fix in apps/web/; hardens the existing local ideate dispatch. No spec/plan change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)