### PR TITLE
feat(twin): /admin/twin-gallery — all 94 persona'd demos through TwinView (A·P2, BI-1C26FCD5)

### DIFF
--- a/apps/web/app/(shell)/admin/twin-gallery/[archetypeId]/page.tsx
+++ b/apps/web/app/(shell)/admin/twin-gallery/[archetypeId]/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { ALL_ARCHETYPES, deriveDemoBusiness, deriveTwinProfile } from "@dpf/storefront-templates";
+
+import { TwinView } from "@/components/twin";
+import { demoBusinessToTwinSnapshot } from "@/lib/twin/demo-business-snapshot";
+
+export const metadata: Metadata = {
+  title: "Demo twin — Archetype Demo Gallery",
+};
+
+// The full persona'd twin for one archetype (EP-ARCHETYPE-DEMO A·P2), rendered
+// through the SAME <TwinView> the live workspace uses — from the generated demo,
+// in memory. Deterministic, so safe to static-render.
+
+export default async function TwinGalleryDetailPage({
+  params,
+}: {
+  params: Promise<{ archetypeId: string }>;
+}) {
+  const { archetypeId } = await params;
+  const archetype = ALL_ARCHETYPES.find((a) => a.archetypeId === archetypeId);
+  if (!archetype) notFound();
+
+  const demo = deriveDemoBusiness(archetype);
+  const profile = deriveTwinProfile(archetype);
+  const snapshot = demoBusinessToTwinSnapshot(demo, profile);
+
+  return (
+    <div>
+      <div className="mb-4">
+        <Link
+          href="/admin/twin-gallery"
+          className="text-xs text-[var(--dpf-muted)] no-underline hover:text-[var(--dpf-text-secondary)]"
+        >
+          &larr; All archetypes
+        </Link>
+        <div className="mt-1 flex items-baseline gap-2">
+          <h1 className="text-xl font-bold text-[var(--dpf-text)]">{demo.companyName}</h1>
+          <span className="text-sm text-[var(--dpf-muted)]">{archetype.name}</span>
+          <span className="rounded bg-[var(--dpf-surface-2)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-text-secondary)]">
+            {profile.template}
+          </span>
+        </div>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">{demo.narrative.primaryGoal}</p>
+      </div>
+
+      <TwinView profile={profile} snapshot={snapshot} />
+    </div>
+  );
+}

--- a/apps/web/app/(shell)/admin/twin-gallery/page.tsx
+++ b/apps/web/app/(shell)/admin/twin-gallery/page.tsx
@@ -1,0 +1,129 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { ALL_ARCHETYPES, deriveDemoBusiness, deriveTwinProfile } from "@dpf/storefront-templates";
+
+import { demoGalleryCard, type DemoGalleryCard } from "@/lib/twin/demo-business-snapshot";
+
+export const metadata: Metadata = {
+  title: "Archetype Demo Gallery — all 94 twins",
+};
+
+// Archetype Demo Factory review surface (EP-ARCHETYPE-DEMO A·P2). Renders a
+// generated, persona'd demo business for EVERY archetype through the SAME
+// derive-with-override generator + twin grammar — in memory, no database — so a
+// reviewer scans the whole catalog in minutes, spots the weak ones, and clicks
+// through to the full twin. Deterministic, so it is safe to statically render.
+// Admin dev surface, reachable directly at /admin/twin-gallery (view_admin gated).
+
+function categoryLabel(category: string): string {
+  return category
+    .split("-")
+    .map((w) => (w.length === 0 ? w : w[0].toUpperCase() + w.slice(1)))
+    .join(" ");
+}
+
+interface CategoryGroup {
+  category: string;
+  label: string;
+  cards: DemoGalleryCard[];
+}
+
+function buildGroups(): CategoryGroup[] {
+  const byCategory = new Map<string, DemoGalleryCard[]>();
+  for (const archetype of ALL_ARCHETYPES) {
+    const demo = deriveDemoBusiness(archetype);
+    const profile = deriveTwinProfile(archetype);
+    const card = demoGalleryCard(demo, profile);
+    const list = byCategory.get(archetype.category) ?? [];
+    list.push(card);
+    byCategory.set(archetype.category, list);
+  }
+  return Array.from(byCategory.entries())
+    .map(([category, cards]) => ({ category, label: categoryLabel(category), cards }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function GalleryCard({ card }: { card: DemoGalleryCard }) {
+  const waitIntent = card.longestWaitMinutes > 60 ? "var(--dpf-warning)" : "var(--dpf-muted)";
+  return (
+    <Link
+      href={`/admin/twin-gallery/${card.archetypeId}`}
+      className="group flex flex-col gap-2 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-4 no-underline transition hover:border-[var(--dpf-accent)]"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate font-semibold text-[var(--dpf-text)]">{card.companyName}</div>
+          <div className="truncate text-xs text-[var(--dpf-muted)]">{card.archetypeName}</div>
+        </div>
+        <span className="shrink-0 rounded bg-[var(--dpf-surface-2)] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-text-secondary)]">
+          {card.template}
+        </span>
+      </div>
+
+      <dl className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+        <div className="flex justify-between">
+          <dt className="text-[var(--dpf-muted)]">Zones</dt>
+          <dd className="text-[var(--dpf-text-secondary)]">{card.staffedZones.replace(" zones staffed", "")}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-[var(--dpf-muted)]">Queue</dt>
+          <dd className="text-[var(--dpf-text-secondary)]">{card.queuedDemand}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-[var(--dpf-muted)]">Team</dt>
+          <dd className="text-[var(--dpf-text-secondary)]">
+            {card.workforce} · {card.aiCoworkers} AI
+          </dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-[var(--dpf-muted)]">Wait</dt>
+          <dd style={{ color: waitIntent }}>{card.longestWaitMinutes}m</dd>
+        </div>
+        <div className="col-span-2 flex justify-between">
+          <dt className="text-[var(--dpf-muted)]">Revenue in</dt>
+          <dd className="font-medium text-[var(--dpf-success)]">{card.revenueIn}</dd>
+        </div>
+      </dl>
+
+      <p className="line-clamp-2 border-t border-[var(--dpf-border)] pt-2 text-[11px] italic text-[var(--dpf-muted)]">
+        {card.cogProposal}
+      </p>
+    </Link>
+  );
+}
+
+export default function AdminTwinGalleryPage() {
+  const groups = buildGroups();
+  const total = groups.reduce((n, g) => n + g.cards.length, 0);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Archetype Demo Gallery</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          A realistic, persona&rsquo;d demo business for every one of the{" "}
+          <span className="font-medium text-[var(--dpf-text-secondary)]">{total}</span> archetypes —
+          derived from a single generator, no per-archetype build. Scan the catalogue, then click a
+          card for the full living twin.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-8">
+        {groups.map((group) => (
+          <section key={group.category}>
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[var(--dpf-text-secondary)]">
+              {group.label}{" "}
+              <span className="text-[var(--dpf-muted)]">({group.cards.length})</span>
+            </h2>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {group.cards.map((card) => (
+                <GalleryCard key={card.archetypeId} card={card} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 550,
+  "routeCount": 552,
   "routes": [
     {
       "routePath": "/",
@@ -317,6 +317,29 @@
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/admin/storefront/team/page.tsx",
       "redirectTo": "/storefront/team"
+    },
+    {
+      "routePath": "/admin/twin-gallery",
+      "kind": "page",
+      "segments": [
+        "admin",
+        "twin-gallery"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/admin/twin-gallery/page.tsx"
+    },
+    {
+      "routePath": "/admin/twin-gallery/[archetypeId]",
+      "kind": "page",
+      "segments": [
+        "admin",
+        "twin-gallery",
+        "[archetypeId]"
+      ],
+      "dynamicParams": [
+        "archetypeId"
+      ],
+      "file": "apps/web/app/(shell)/admin/twin-gallery/[archetypeId]/page.tsx"
     },
     {
       "routePath": "/admin/twin-kit",

--- a/apps/web/lib/twin/demo-business-snapshot.test.ts
+++ b/apps/web/lib/twin/demo-business-snapshot.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { ALL_ARCHETYPES, deriveDemoBusiness, deriveTwinProfile } from "@dpf/storefront-templates";
+
+import { demoBusinessToTwinSnapshot, demoGalleryCard } from "./demo-business-snapshot";
+
+describe("demoBusinessToTwinSnapshot", () => {
+  it("renders a non-degenerate TwinSnapshot for every archetype", () => {
+    for (const archetype of ALL_ARCHETYPES) {
+      const demo = deriveDemoBusiness(archetype);
+      const profile = deriveTwinProfile(archetype);
+      const snap = demoBusinessToTwinSnapshot(demo, profile);
+
+      // Zones keyed to the profile, every zone has units (mirrors the delight oracle).
+      expect(snap.zones.map((z) => z.key)).toEqual(profile.zones.map((z) => z.key));
+      expect(snap.zones.every((z) => z.units.length > 0)).toBe(true);
+
+      // Queues keyed to the profile; the primary queue has demand with wait strings.
+      expect(snap.queues.map((q) => q.key)).toEqual(profile.queues.map((q) => q.key));
+      const primary = snap.queues[0];
+      expect(primary.items.length).toBeGreaterThan(0);
+      expect(primary.items.every((i) => /^\d+m$/.test(i.waiting ?? ""))).toBe(true);
+      // The cog's move is surfaced inline on the first queued item.
+      expect(primary.items[0].suggestion).toBe(demo.cogProposal);
+
+      // Cog, presence (humans + AI), capacity chips, and finance utility all present.
+      expect(snap.cog?.proposal).toBe(demo.cogProposal);
+      expect(snap.presence.some((p) => p.kind === "human")).toBe(true);
+      expect(snap.presence.some((p) => p.kind === "ai")).toBe(true);
+      expect(snap.capacityChips.length).toBeGreaterThan(0);
+      expect(snap.utility.some((u) => u.key === "revenue")).toBe(true);
+      expect(snap.utility.some((u) => u.key === "bills")).toBe(true);
+    }
+  });
+
+  it("owns resource units by their worker when the resource is a person", () => {
+    // A booking archetype (BOOK) has person-resources (providers).
+    const dentist = ALL_ARCHETYPES.find((a) => a.archetypeId === "dental-practice")!;
+    const demo = deriveDemoBusiness(dentist);
+    const profile = deriveTwinProfile(dentist);
+    const snap = demoBusinessToTwinSnapshot(demo, profile);
+    const owned = snap.zones.flatMap((z) => z.units).filter((u) => u.owner);
+    expect(owned.length).toBeGreaterThan(0);
+    expect(owned.every((u) => typeof u.owner!.name === "string")).toBe(true);
+  });
+});
+
+describe("demoGalleryCard", () => {
+  it("summarizes each archetype for the scannable grid", () => {
+    for (const archetype of ALL_ARCHETYPES) {
+      const demo = deriveDemoBusiness(archetype);
+      const profile = deriveTwinProfile(archetype);
+      const card = demoGalleryCard(demo, profile);
+      expect(card.archetypeId).toBe(archetype.archetypeId);
+      expect(card.companyName.length).toBeGreaterThan(0);
+      expect(card.template).toBe(profile.template);
+      expect(card.aiCoworkers).toBeGreaterThanOrEqual(1);
+      expect(card.workforce).toBeGreaterThan(card.aiCoworkers);
+      expect(card.staffedZones).toMatch(/^\d+ \/ \d+ zones staffed$/);
+      expect(card.cogProposal.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/web/lib/twin/demo-business-snapshot.ts
+++ b/apps/web/lib/twin/demo-business-snapshot.ts
@@ -34,10 +34,6 @@ const RESOURCE_STATES: Array<{ state: string; intent: Intent }> = [
   { state: "Needs attention", intent: "warning" },
 ];
 
-function titleCase(s: string): string {
-  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
-}
-
 function money(currency: string, amount: number): string {
   const symbol = currency === "GBP" ? "£" : currency === "USD" ? "$" : currency === "EUR" ? "€" : "";
   return `${symbol}${Math.round(amount).toLocaleString("en-US")}`;

--- a/apps/web/lib/twin/demo-business-snapshot.ts
+++ b/apps/web/lib/twin/demo-business-snapshot.ts
@@ -1,0 +1,213 @@
+// apps/web/lib/twin/demo-business-snapshot.ts
+//
+// Archetype Demo Factory — the persona'd render bridge (EP-ARCHETYPE-DEMO A·P2).
+//
+// `demoBusinessToTwinSnapshot` maps a generated `DemoBusiness`
+// (@dpf/storefront-templates, A·P1) onto the `TwinSnapshot` render contract, so
+// the SAME `TwinView` renders a real persona'd demo — in memory, no database.
+// It is the third sibling of the snapshot family:
+//   • live    : DB rows      → TwinSnapshot   (loadLivingBusinessSnapshot)
+//   • fixture : TwinProfile  → TwinSnapshot   (buildDemoTwinSnapshot)
+//   • demo    : DemoBusiness → TwinSnapshot   (this)
+// The gallery (A·P2) renders all 94 through it; the load path (A·P1) proves the
+// live path renders the same shape from the same generator.
+//
+// PURE + deterministic (the DemoBusiness is already deterministic in its seed).
+
+import type { DemoBusiness, TwinProfile } from "@dpf/storefront-templates";
+
+import type { Intent } from "@/components/ui/report-kit";
+
+import type { TwinSnapshot, TwinZoneSnapshot, TwinQueueSnapshot } from "@/components/twin/snapshot";
+import type {
+  CapacityChipData,
+  QueueItemData,
+  ResourceUnitData,
+  UtilityMeterData,
+  WorkItemData,
+} from "@/components/twin/types";
+
+const RESOURCE_STATES: Array<{ state: string; intent: Intent }> = [
+  { state: "Active", intent: "success" },
+  { state: "In progress", intent: "info" },
+  { state: "Open", intent: "neutral" },
+  { state: "Needs attention", intent: "warning" },
+];
+
+function titleCase(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+function money(currency: string, amount: number): string {
+  const symbol = currency === "GBP" ? "£" : currency === "USD" ? "$" : currency === "EUR" ? "€" : "";
+  return `${symbol}${Math.round(amount).toLocaleString("en-US")}`;
+}
+
+/** Map a generated demo business onto the twin render contract. */
+export function demoBusinessToTwinSnapshot(demo: DemoBusiness, profile: TwinProfile): TwinSnapshot {
+  const workerByKey = new Map(demo.workforce.map((w) => [w.key, w]));
+
+  // Zones ← resources arranged by zone; each resource's owner is its worker (if a person).
+  const zones: TwinZoneSnapshot[] = profile.zones.map((zone) => {
+    const inZone = demo.resources.filter((r) => r.zoneKey === zone.key);
+    const units: ResourceUnitData[] = inZone.map((r, i) => {
+      const st = RESOURCE_STATES[i % RESOURCE_STATES.length];
+      const worker = r.workerKey ? workerByKey.get(r.workerKey) : undefined;
+      return {
+        key: r.key,
+        label: r.label,
+        state: st.state,
+        intent: st.intent,
+        ...(worker ? { owner: { name: worker.name, kind: worker.kind } } : {}),
+      };
+    });
+    return { key: zone.key, units, meta: `${units.length} ${profile.resourceNoun.plural}` };
+  });
+
+  // Queues ← demand still waiting in each queue; the primary queue leads with the cog suggestion.
+  const queues: TwinQueueSnapshot[] = profile.queues.map((qs, qi) => {
+    const waiting = demo.demand.filter((d) => d.queueKey === qs.key);
+    const items: QueueItemData[] = waiting.map((d, i) => ({
+      key: d.key,
+      label: d.label,
+      meta: i === 0 ? "next up" : undefined,
+      waiting: `${d.waitingMinutes}m`,
+      suggestion: qi === 0 && i === 0 ? demo.cogProposal : undefined,
+    }));
+    return { key: qs.key, items, emptyLabel: "No demand waiting" };
+  });
+
+  // Work items ← in-flight (assigned, not queued) demand.
+  const inFlight = demo.demand.filter((d) => !d.queueKey && d.assignedResourceKey);
+  const workItems: WorkItemData[] = inFlight.slice(0, 4).map((d, i) => ({
+    key: d.key,
+    label: d.label,
+    owner: i === 0 ? { name: demo.workforce[0]?.name ?? "Team", kind: "human" } : undefined,
+    progress: 30 + ((i * 20) % 60),
+  }));
+
+  const paidRevenue = demo.finance.invoices.filter((v) => v.paid).reduce((s, v) => s + v.amount, 0);
+  const billsDue = demo.finance.bills.reduce((s, b) => s + b.amountDue, 0);
+  const longestWait = demo.demand.reduce((m, d) => Math.max(m, d.waitingMinutes), 0);
+
+  const capacityChips: CapacityChipData[] = [
+    { key: "team", label: "Workforce", value: demo.workforce.length, intent: "info", live: true },
+    {
+      key: "ai",
+      label: "AI coworkers",
+      value: demo.workforce.filter((w) => w.kind === "ai").length,
+      intent: "accent",
+    },
+    { key: "demand", label: "Open demand", value: demo.demand.length, intent: "success" },
+    {
+      key: "wait",
+      label: "Longest wait",
+      value: `${longestWait}m`,
+      intent: longestWait > 60 ? "warning" : "neutral",
+    },
+  ];
+
+  const utility: UtilityMeterData[] = [
+    {
+      key: "revenue",
+      label: "Revenue in",
+      value: money(demo.currency, paidRevenue),
+      intent: "success",
+      hint: "Paid invoices",
+    },
+    {
+      key: "bills",
+      label: "Bills due",
+      value: `${demo.finance.bills.length} · ${money(demo.currency, billsDue)}`,
+      intent: "warning",
+      hint: "Upcoming",
+    },
+    ...(demo.finance.taxPeriod
+      ? [
+          {
+            key: "tax",
+            label: "Tax filing",
+            value: `${demo.finance.taxPeriod.dueInDays} days`,
+            intent: "info" as Intent,
+          },
+        ]
+      : []),
+    {
+      key: "compliance",
+      label: "Compliance",
+      value: demo.finance.obligations.length === 0 ? "All clear" : `${demo.finance.obligations.length} open`,
+      intent: demo.finance.obligations.length === 0 ? ("success" as Intent) : ("warning" as Intent),
+    },
+  ];
+
+  return {
+    capacityChips,
+    zones,
+    workItems,
+    queues,
+    cog: {
+      proposal: demo.cogProposal,
+      confirmLabel: `Assign ${profile.workItemNoun.singular}`,
+      signals: profile.cog.signals.slice(0, 3),
+    },
+    presence: demo.workforce
+      .slice(0, 6)
+      .map((w) => ({ name: w.name, kind: w.kind, focus: w.role })),
+    feed: demo.demand.slice(0, 3).map((d, i) => ({
+      key: `feed-${i}`,
+      actor:
+        i % 2 === 0
+          ? { name: demo.workforce.find((w) => w.kind === "ai")?.name ?? "AI coworker", kind: "ai" as const }
+          : { name: demo.workforce[0]?.name ?? "You", kind: "human" as const },
+      action: i % 2 === 0 ? `proposed an allocation for ${d.label}` : `confirmed ${d.label}`,
+      at: i === 0 ? "just now" : `${i * 4}m`,
+    })),
+    quests:
+      demo.finance.bills.length > 0
+        ? [
+            {
+              key: "bills",
+              title: `${demo.finance.bills.length} bills need review`,
+              detail: `${money(demo.currency, billsDue)} due soon`,
+              intent: "warning" as Intent,
+              cta: "Review",
+            },
+          ]
+        : [],
+    utility,
+  };
+}
+
+/** A compact, scannable card summary for the gallery grid (A·P2). */
+export interface DemoGalleryCard {
+  archetypeId: string;
+  archetypeName: string;
+  companyName: string;
+  template: string;
+  staffedZones: string; // "3 / 3 zones staffed"
+  queuedDemand: number;
+  longestWaitMinutes: number;
+  workforce: number;
+  aiCoworkers: number;
+  revenueIn: string;
+  cogProposal: string;
+}
+
+export function demoGalleryCard(demo: DemoBusiness, profile: TwinProfile): DemoGalleryCard {
+  const staffedZoneKeys = new Set(demo.resources.map((r) => r.zoneKey));
+  const queued = demo.demand.filter((d) => d.queueKey);
+  const paidRevenue = demo.finance.invoices.filter((v) => v.paid).reduce((s, v) => s + v.amount, 0);
+  return {
+    archetypeId: demo.archetypeId,
+    archetypeName: demo.archetypeName,
+    companyName: demo.companyName,
+    template: demo.template,
+    staffedZones: `${staffedZoneKeys.size} / ${profile.zones.length} zones staffed`,
+    queuedDemand: queued.length,
+    longestWaitMinutes: demo.demand.reduce((m, d) => Math.max(m, d.waitingMinutes), 0),
+    workforce: demo.workforce.length,
+    aiCoworkers: demo.workforce.filter((w) => w.kind === "ai").length,
+    revenueIn: money(demo.currency, paidRevenue),
+    cogProposal: demo.cogProposal,
+  };
+}

--- a/docs/superpowers/plans/2026-07-15-archetype-demo-factory-execution.md
+++ b/docs/superpowers/plans/2026-07-15-archetype-demo-factory-execution.md
@@ -50,9 +50,23 @@ no `Math.random`/`Date` in the core).
 
 ## P2 — the gallery (founder review surface)
 
-`/admin/twin-gallery` (or extend `/admin/twin-kit`): iterate `ALL_ARCHETYPES`, render each twin
-from its generated demo through `TwinView`, grouped by category, click-through to `/workspace`.
-Carries a recorded `UX-Fit-Decision` (new admin surface).
+✅ **Landed** (BI-1C26FCD5). Three pieces:
+
+- `apps/web/lib/twin/demo-business-snapshot.ts` — `demoBusinessToTwinSnapshot(demo, profile)`, the
+  **persona'd render bridge**: the third sibling of the snapshot family (live = DB→TwinSnapshot,
+  fixture = TwinProfile→TwinSnapshot, **demo = DemoBusiness→TwinSnapshot**), so the same `TwinView`
+  renders a real generated demo in memory, no DB. Plus `demoGalleryCard` (the scannable summary).
+- `app/(shell)/admin/twin-gallery/page.tsx` — a **scannable grid** of all 94 persona'd demos grouped
+  by category (company name, template, staffed zones, queued demand + longest wait, workforce/AI,
+  revenue-in, the cog's proposed move), click-through per card.
+- `app/(shell)/admin/twin-gallery/[archetypeId]/page.tsx` — the **full persona'd twin** rendered
+  through `TwinView` from `demoBusinessToTwinSnapshot`.
+
+Deterministic ⇒ safe to static-render; no per-archetype build. **Verified:** mapper + gallery-card
+unit tests over all 94 (zones/queues keyed to the profile, primary queue carries the cog move,
+presence has humans + AI, finance utility present); `apps/web` typecheck clean. `UX-Fit-Decision`:
+new admin dev surface, view_admin-gated, reachable at `/admin/twin-gallery` (not added to primary
+nav — a reviewer/developer surface, like `/admin/twin-kit`).
 
 ## P3 — the flavor registry (shared with the Excellence Corpus, `BI-44EF78DE`)
 


### PR DESCRIPTION
## Summary

Workstream **A·P2** (`EP-ARCHETYPE-DEMO` / `BI-1C26FCD5`): the **founder review surface**. Renders a generated, persona'd demo business for **every one of the 94 archetypes** — in memory, no database — so a reviewer scans the whole catalogue in minutes, spots the weak ones, and clicks through to the full living twin. Built on the A·P1 generator.

## What landed

- **`apps/web/lib/twin/demo-business-snapshot.ts`** — `demoBusinessToTwinSnapshot(demo, profile)`, the **persona'd render bridge** and third sibling of the snapshot family:
  - live: DB rows → `TwinSnapshot` (`loadLivingBusinessSnapshot`)
  - fixture: `TwinProfile` → `TwinSnapshot` (`buildDemoTwinSnapshot`)
  - **demo: `DemoBusiness` → `TwinSnapshot` (this)**

  so the SAME `TwinView` renders a real generated demo. Plus `demoGalleryCard`, the scannable summary.
- **`app/(shell)/admin/twin-gallery/page.tsx`** — a scannable grid of all 94 grouped by category (company, template, staffed zones, queued demand + longest wait, workforce/AI, revenue-in, the cog's proposed move), click-through per card.
- **`app/(shell)/admin/twin-gallery/[archetypeId]/page.tsx`** — the full persona'd twin via `TwinView`.

## Design grounding

Extends the demo-factory design spec **§5.1**, which explicitly specifies `/admin/twin-gallery` as the review-at-scale harness. Reuses the shipped `TwinView` renderer + the A·P1 generator — **no new contract**. Source of truth: `docs/superpowers/specs/2026-07-15-archetype-demo-factory-design.md`.

**UX-Fit:** new admin dev/review surface, `view_admin`-gated, reachable at `/admin/twin-gallery`; **not** added to primary nav (a reviewer surface, like `/admin/twin-kit`). No new top-level tab, no customer-facing change.

## Test plan

- [x] `demoBusinessToTwinSnapshot` over all 94: zones/queues keyed to the profile, every zone has units, primary queue carries the cog's move inline, presence has humans + AI, finance utility (revenue + bills) present
- [x] `demoGalleryCard` over all 94: company/template/staffed-zones/AI-coworkers sane
- [x] `apps/web` typecheck clean (after `prisma generate` for the current schema)
- [x] The `snapshot → TwinView` render path itself was proven **live** in A·P1 (the restaurant twin rendered through `loadLivingBusinessSnapshot`)

Deterministic ⇒ safe to static-render; no per-archetype build.

## Related

Epic **EP-ARCHETYPE-DEMO** · BI **BI-1C26FCD5** (A·P2) · program **EP-LIVING-BUSINESS-EXCELLENCE**. Follows the A·P1 generator (#3023) + load path (#3026) + fail-open (#3033).

🤖 Generated with [Claude Code](https://claude.com/claude-code)