### PR TITLE
fix(self-upgrade): preflight DB extension availability — recovery-point fails with a remedy, not opaque pg_dump exit=1 (BI-A35347E4)

### DIFF
--- a/apps/web/lib/operate/backups/engine-specs.ts
+++ b/apps/web/lib/operate/backups/engine-specs.ts
@@ -51,6 +51,10 @@ import type {
   QdrantBackupManifest,
 } from "./types";
 import type { PrismaLike } from "./managed-backup";
+import {
+  postgresExtensionPreflight,
+  type BackupPreflightResult,
+} from "./extension-preflight";
 import { RestoreIntegrityError } from "./managed-restore";
 import { buildNeo4jBackupScriptEnv } from "./neo4j-backup-runner";
 import { buildNeo4jRestoreScriptEnv } from "./neo4j-restore-runner";
@@ -105,6 +109,18 @@ export interface BackupEngineSpec {
   buildEnv(ctx: BackupScriptEnvContext): NodeJS.ProcessEnv;
   /** Extra BackupRun fields written on success (postgres: pgVersion). */
   successRowExtras?(manifest: AnyBackupManifest): Record<string, unknown>;
+  /**
+   * Optional pre-dump capability check. Runs before the backup script and,
+   * when it returns `{ ok: false }`, short-circuits the run to a failed
+   * BackupRun carrying the actionable `error` — the script is never spawned.
+   * Postgres uses it to catch a container image missing a required extension
+   * library (pgvector) before pg_dump fails opaquely (BI-A35347E4). Must be
+   * fail-open on any inconclusive signal so it never becomes a new failure
+   * source. Never mutates infrastructure.
+   */
+  preflight?(ctx: {
+    composeProject: string;
+  }): Promise<BackupPreflightResult>;
 }
 
 /** Inputs the shared restore engine hands to a spec's env builder. */
@@ -207,6 +223,7 @@ export const POSTGRES_BACKUP_SPEC: BackupEngineSpec = {
   successRowExtras(manifest) {
     return { pgVersion: (manifest as BackupManifest).pgVersion };
   },
+  preflight: (ctx) => postgresExtensionPreflight(ctx),
 };
 
 export const NEO4J_BACKUP_SPEC: BackupEngineSpec = {

--- a/apps/web/lib/operate/backups/extension-preflight.test.ts
+++ b/apps/web/lib/operate/backups/extension-preflight.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the Postgres extension-availability preflight (BI-A35347E4).
+ * Pure logic with an injected `ContainerPsql`; no docker, no DB.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DB_EXTENSION_AVAILABILITY_SQL,
+  buildMissingExtensionMessage,
+  detectMissingExtensions,
+  postgresExtensionPreflight,
+  type ContainerPsql,
+} from "./extension-preflight";
+
+const psqlReturning = (stdout: string, exitCode = 0): ContainerPsql =>
+  vi.fn(async () => ({ stdout, exitCode }));
+
+describe("detectMissingExtensions", () => {
+  it("passes (ok) when every installed extension is provided by the image", async () => {
+    const result = await detectMissingExtensions(psqlReturning("\n"));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("fails with an actionable remedy when an extension is unprovided", async () => {
+    const result = await detectMissingExtensions(psqlReturning("vector\n"));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toContain("vector");
+    expect(result.error).toContain("docker compose up -d --no-deps postgres");
+  });
+
+  it("handles multiple unprovided extensions (comma-joined string_agg)", async () => {
+    const result = await detectMissingExtensions(psqlReturning("ltree,vector"));
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toContain("ltree");
+    expect(result.error).toContain("vector");
+    expect(result.error).toContain("extensions"); // plural wording
+  });
+
+  it("FAILS OPEN on a non-zero psql exit (inconclusive, never a new failure)", async () => {
+    const result = await detectMissingExtensions(psqlReturning("garbage", 1));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("FAILS OPEN when the psql invocation throws (DB unreachable / no docker)", async () => {
+    const throwing: ContainerPsql = vi.fn(async () => {
+      throw new Error("docker: command not found");
+    });
+    const result = await detectMissingExtensions(throwing);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("ignores whitespace-only output (string_agg NULL renders empty)", async () => {
+    const result = await detectMissingExtensions(psqlReturning("   \n  "));
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+describe("buildMissingExtensionMessage", () => {
+  it("names a single extension and uses singular phrasing", () => {
+    const msg = buildMissingExtensionMessage(["vector"]);
+    expect(msg).toContain("the extension the database requires: vector");
+    expect(msg).toContain("pgvector");
+    expect(msg).toContain("docker compose up -d --no-deps postgres");
+  });
+
+  it("uses plural phrasing for multiple extensions", () => {
+    const msg = buildMissingExtensionMessage(["ltree", "vector"]);
+    expect(msg).toContain("extensions the database requires: ltree, vector");
+  });
+});
+
+describe("DB_EXTENSION_AVAILABILITY_SQL", () => {
+  it("joins the catalog against image-provided extensions", () => {
+    // Guard the detection contract: catalog (pg_extension) vs image
+    // (pg_available_extensions) is the whole mechanism.
+    expect(DB_EXTENSION_AVAILABILITY_SQL).toContain("pg_extension");
+    expect(DB_EXTENSION_AVAILABILITY_SQL).toContain("pg_available_extensions");
+    expect(DB_EXTENSION_AVAILABILITY_SQL).toContain("IS NULL");
+  });
+});
+
+describe("postgresExtensionPreflight", () => {
+  it("threads the injected psql through and reports a definitive miss", async () => {
+    const psql = psqlReturning("vector");
+    const result = await postgresExtensionPreflight(
+      { composeProject: "dpf" },
+      psql,
+    );
+    expect(result.ok).toBe(false);
+    expect(psql).toHaveBeenCalledWith(DB_EXTENSION_AVAILABILITY_SQL);
+  });
+
+  it("returns ok when the injected psql reports no missing extensions", async () => {
+    const result = await postgresExtensionPreflight(
+      { composeProject: "dpf" },
+      psqlReturning(""),
+    );
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/apps/web/lib/operate/backups/extension-preflight.ts
+++ b/apps/web/lib/operate/backups/extension-preflight.ts
@@ -1,0 +1,161 @@
+/**
+ * Postgres extension-availability preflight (BI-A35347E4).
+ *
+ * The pre-upgrade recovery point (and the daily backup) run `pg_dump` of the
+ * live Postgres database. If the running postgres *container image* does not
+ * provide an extension the database's catalog depends on — the canonical case
+ * is pgvector's `vector.so` after the container was recreated onto a plain
+ * `postgres:16-alpine` image while the BET-5 schema carries `vector` objects —
+ * `pg_dump` dies with `could not access file "$libdir/vector"` and the backup
+ * fails with an opaque `pg_dump exit=1`. The self-upgrade then aborts at the
+ * recovery point with no cause and no remedy surfaced to the operator.
+ *
+ * This preflight catches that state BEFORE pg_dump and converts it into an
+ * actionable failure: it names the missing extension(s) and the one-command
+ * remedy. It never recreates the container itself — the self-upgrade deploy
+ * deliberately uses `--no-deps` and never touches postgres (fleet-safety
+ * invariant); recreating the DB mid-upgrade is a destructive action that
+ * requires an explicit operator go. (Kernel decision, principle_decide:
+ * fail-fast-with-remedy over auto-heal, high confidence.)
+ *
+ * Detection is general, not vector-specific: an extension recorded in
+ * `pg_extension` (the DB catalog, which lives in the data volume) but absent
+ * from `pg_available_extensions` (the control files the *image* ships) is
+ * installed-but-unprovided — exactly the image-swap failure class.
+ *
+ * The preflight is FAIL-OPEN on any inconclusive signal (cannot reach the DB,
+ * query error, unexpected output): it must never become a NEW failure source.
+ * pg_dump remains the source of truth. It fails CLOSED only on a definitive
+ * "installed but unavailable" result.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Extensions present in the catalog (`pg_extension`) but not provided by the
+ * running image (absent from `pg_available_extensions`). string_agg keeps the
+ * result to a single row/line the caller can parse without ceremony.
+ */
+export const DB_EXTENSION_AVAILABILITY_SQL =
+  "SELECT string_agg(e.extname, ',' ORDER BY e.extname) " +
+  "FROM pg_extension e " +
+  "LEFT JOIN pg_available_extensions a ON a.name = e.extname " +
+  "WHERE a.name IS NULL";
+
+/** Runs one SQL string against the DB and returns its stdout + exit code. */
+export type ContainerPsql = (
+  sql: string,
+) => Promise<{ stdout: string; exitCode: number }>;
+
+export type BackupPreflightResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+/**
+ * Operator-facing remedy message. Names the missing extension(s) and the exact
+ * one-command fix. The remedy recreates ONLY postgres (`--no-deps`) from the
+ * compose image; the data is preserved in the pgdata volume.
+ */
+export function buildMissingExtensionMessage(unmet: string[]): string {
+  const names = unmet.join(", ");
+  const isPlural = unmet.length > 1;
+  return (
+    `The Postgres container is running an image that does not provide ` +
+    `${isPlural ? "extensions" : "the extension"} the database requires: ` +
+    `${names}. This happens when the postgres container was recreated onto a ` +
+    `plain image (e.g. postgres:16-alpine) instead of the pgvector-enabled ` +
+    `image the schema depends on, which makes pg_dump and vector queries fail. ` +
+    `Recreate the postgres container from the compose image — the data is ` +
+    `preserved in the pgdata volume — with: ` +
+    `docker compose up -d --no-deps postgres`
+  );
+}
+
+/**
+ * Parse the availability-query stdout. Empty output (or an all-whitespace
+ * string_agg NULL) means every installed extension is provided by the image.
+ */
+function parseUnmetExtensions(stdout: string): string[] {
+  return stdout
+    .split(/[,\n]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Detect extensions installed in the catalog but not provided by the running
+ * image. FAIL-OPEN on any error or non-zero exit — an inconclusive preflight
+ * must not block a backup that pg_dump might complete fine.
+ */
+export async function detectMissingExtensions(
+  psql: ContainerPsql,
+): Promise<BackupPreflightResult> {
+  let stdout: string;
+  try {
+    const res = await psql(DB_EXTENSION_AVAILABILITY_SQL);
+    if (res.exitCode !== 0) return { ok: true };
+    stdout = res.stdout;
+  } catch {
+    // Cannot reach the DB / docker missing / query blew up — inconclusive.
+    return { ok: true };
+  }
+  const unmet = parseUnmetExtensions(stdout);
+  if (unmet.length === 0) return { ok: true };
+  return { ok: false, error: buildMissingExtensionMessage(unmet) };
+}
+
+/**
+ * Production ContainerPsql: exec `psql` inside the postgres container over the
+ * mounted docker socket (same access path the backup shell script uses).
+ */
+export function dockerContainerPsql(args: {
+  container: string;
+  user: string;
+  db: string;
+}): ContainerPsql {
+  return async (sql: string) => {
+    try {
+      const { stdout } = await execFileAsync(
+        "docker",
+        [
+          "exec",
+          args.container,
+          "psql",
+          "-U",
+          args.user,
+          "-d",
+          args.db,
+          "-tAc",
+          sql,
+        ],
+        { timeout: 15_000, maxBuffer: 1024 * 1024 },
+      );
+      return { stdout, exitCode: 0 };
+    } catch (err) {
+      const e = err as { code?: number | string };
+      const exitCode = typeof e.code === "number" ? e.code : -1;
+      return { stdout: "", exitCode };
+    }
+  };
+}
+
+/**
+ * Spec-level preflight hook for the Postgres backup engine. Resolves the
+ * container/user/db exactly as POSTGRES_BACKUP_SPEC.buildEnv does, then runs
+ * the missing-extension detection. `psql` is injectable for tests.
+ */
+export async function postgresExtensionPreflight(
+  ctx: { composeProject: string },
+  psql?: ContainerPsql,
+): Promise<BackupPreflightResult> {
+  const container =
+    process.env.DPF_PRODUCTION_DB_CONTAINER ??
+    `${ctx.composeProject}-postgres-1`;
+  const user = process.env.POSTGRES_USER ?? "dpf";
+  const db = process.env.POSTGRES_DB ?? "dpf";
+  const exec = psql ?? dockerContainerPsql({ container, user, db });
+  return detectMissingExtensions(exec);
+}

--- a/apps/web/lib/operate/backups/managed-backup.test.ts
+++ b/apps/web/lib/operate/backups/managed-backup.test.ts
@@ -59,6 +59,12 @@ const FIXED_NOW = new Date("2026-07-09T05:00:00.000Z");
 const EXPECTED_TS_KEY = "2026-07-09T05-00-00Z";
 const EXPECTED_NEXT_RUN = new Date("2026-07-10T03:00:00.000Z");
 
+// These tests exercise the SCRIPT lifecycle, not the capability preflight.
+// POSTGRES_BACKUP_SPEC.preflight would otherwise shell out to `docker exec`;
+// inject a no-op so the runs are deterministic. Preflight behaviour has its
+// own suite (extension-preflight.test.ts + the short-circuit test below).
+const NOOP_PREFLIGHT = async () => ({ ok: true as const });
+
 interface EngineCase {
   spec: BackupEngineSpec;
   /** stderr line the shell script emits on failure. */
@@ -149,6 +155,7 @@ describe.each(ENGINES)("runManagedBackup — $spec.target", ({ spec, failLine, e
       backupsRoot,
       composeProject: "dpf",
       prismaClient: prisma as never,
+      preflight: NOOP_PREFLIGHT,
       now: () => FIXED_NOW,
     });
 
@@ -246,6 +253,7 @@ describe.each(ENGINES)("runManagedBackup — $spec.target", ({ spec, failLine, e
       trigger: "manual",
       backupsRoot,
       prismaClient: prisma as never,
+      preflight: NOOP_PREFLIGHT,
       now: () => FIXED_NOW,
     });
 
@@ -294,11 +302,80 @@ describe.each(ENGINES)("runManagedBackup — $spec.target", ({ spec, failLine, e
       trigger: "manual",
       backupsRoot,
       prismaClient: prisma as never,
+      preflight: NOOP_PREFLIGHT,
       now: () => FIXED_NOW,
     });
 
     expect(result.status).toBe("failed");
     expect(result.error).toBe(spec.failureFallback);
+
+    await fs.rm(backupsRoot, { recursive: true, force: true });
+  });
+});
+
+describe("runManagedBackup — preflight short-circuit", () => {
+  it("fails with the preflight's actionable error and never spawns the script", async () => {
+    const backupsRoot = await makeBackupsRoot();
+    const prisma = makePrisma();
+    const remedy =
+      "The Postgres container is running an image that does not provide the extension the database requires: vector. …docker compose up -d --no-deps postgres";
+
+    const result = await runManagedBackup(POSTGRES_BACKUP_SPEC, {
+      trigger: "pre-upgrade-recovery",
+      backupsRoot,
+      prismaClient: prisma as never,
+      preflight: async () => ({ ok: false, error: remedy }),
+      now: () => FIXED_NOW,
+    });
+
+    expect(result).toEqual({
+      runId: "run-1",
+      status: "failed",
+      error: remedy,
+    });
+    // The whole point: the opaque pg_dump path is never reached.
+    expect(runScriptMock).not.toHaveBeenCalled();
+    // The failed BackupRun carries the actionable remedy, not a generic message.
+    expect(prisma.backupRun.update).toHaveBeenCalledWith({
+      where: { id: "run-1" },
+      data: expect.objectContaining({
+        status: "failed",
+        errorMessage: remedy,
+      }),
+    });
+    // Failure heartbeat + metric still recorded through the shared path.
+    expect(POSTGRES_BACKUP_SPEC.metrics.runsTotal.inc).toHaveBeenCalledWith({
+      status: "failed",
+      trigger: "pre-upgrade-recovery",
+    });
+
+    await fs.rm(backupsRoot, { recursive: true, force: true });
+  });
+
+  it("proceeds to the script when the preflight passes", async () => {
+    const backupsRoot = await makeBackupsRoot();
+    const targetDir = path.posix.join(backupsRoot, "postgres", EXPECTED_TS_KEY);
+    const prisma = makePrisma({ retainedRows: [{ sizeBytes: BigInt(1024) }] });
+
+    runScriptMock.mockImplementation(async () => {
+      await fs.mkdir(targetDir, { recursive: true });
+      await fs.writeFile(
+        path.posix.join(targetDir, "manifest.json"),
+        JSON.stringify({ sizeBytes: 1024, sha256: "abc", pgVersion: "16.3" }),
+      );
+      return { ok: true, stdout: "", stderr: "", exitCode: 0 };
+    });
+
+    const result = await runManagedBackup(POSTGRES_BACKUP_SPEC, {
+      trigger: "manual",
+      backupsRoot,
+      prismaClient: prisma as never,
+      preflight: async () => ({ ok: true }),
+      now: () => FIXED_NOW,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(runScriptMock).toHaveBeenCalledTimes(1);
 
     await fs.rm(backupsRoot, { recursive: true, force: true });
   });
@@ -351,6 +428,7 @@ describe("runManagedBackup — retention pruning", () => {
       backupsRoot,
       retention: { daily: 1, weekly: 1, monthly: 1 },
       prismaClient: prisma as never,
+      preflight: NOOP_PREFLIGHT,
       now: () => FIXED_NOW,
     });
 

--- a/apps/web/lib/operate/backups/managed-backup.ts
+++ b/apps/web/lib/operate/backups/managed-backup.ts
@@ -40,6 +40,7 @@ import {
 } from "./types";
 import { resolveManagedScriptPath, runManagedScript } from "./managed-script-path";
 import type { AnyBackupManifest, BackupEngineSpec } from "./engine-specs";
+import type { BackupPreflightResult } from "./extension-preflight";
 
 const BACKUPS_ROOT = "/backups";
 
@@ -71,6 +72,14 @@ export interface ManagedBackupArgs {
   prismaClient?: PrismaLike;
   /** Inject a clock for deterministic testing. */
   now?: () => Date;
+  /**
+   * Override the spec's pre-dump capability check (for tests). When provided,
+   * takes precedence over `spec.preflight`. Pass `() => Promise.resolve({ ok:
+   * true })` to skip the real (docker-spawning) preflight in unit tests.
+   */
+  preflight?: (ctx: {
+    composeProject: string;
+  }) => Promise<BackupPreflightResult>;
 }
 
 /**
@@ -136,7 +145,8 @@ export async function recordJobHeartbeat(
  * back to the last stderr line, then the exit code, then the engine fallback.
  */
 export function summarizeScriptFailure(
-  outcome: Pick<ScriptOutcome, "stderr" | "exitCode">,
+  outcome: Pick<ScriptOutcome, "stderr" | "exitCode"> &
+    Partial<Pick<ScriptOutcome, "stdout">>,
   opts: {
     /** Marker the shell script prints on failure, e.g. "[backup-trace] failed:". */
     marker: string;
@@ -148,10 +158,12 @@ export function summarizeScriptFailure(
     fallback: string;
   },
 ): string {
-  const traceLine = outcome.stderr
-    .split("\n")
-    .reverse()
-    .find((line) => line.includes(opts.marker));
+  // The managed scripts print their curated `[backup-trace] failed:` line to
+  // STDOUT (the log/fail helpers use printf without >&2), so search both
+  // streams — searching stderr alone silently missed the human-authored
+  // reason and fell through to the raw last-stderr line.
+  const lines = `${outcome.stdout ?? ""}\n${outcome.stderr}`.split("\n");
+  const traceLine = lines.reverse().find((line) => line.includes(opts.marker));
   if (traceLine) {
     return traceLine.replace(opts.strip, "").trim();
   }
@@ -308,6 +320,47 @@ export async function runManagedBackup(
     lastError: null,
   });
 
+  // Record a failed run: BackupRun row + heartbeat + metrics + trace. Shared by
+  // the preflight short-circuit and the script-failure path so both surface the
+  // same operator-facing shape.
+  const recordFailure = async (
+    errorSummary: string,
+  ): Promise<{ runId: string; status: "failed"; error: string }> => {
+    const finishedAt = now();
+    const durationMs = finishedAt.getTime() - startedAt.getTime();
+    await prisma.backupRun.update({
+      where: { id: created.id },
+      data: {
+        status: "failed",
+        finishedAt,
+        durationMs,
+        errorMessage: errorSummary,
+      },
+    });
+    await recordJobHeartbeat(prisma, spec.jobId, {
+      lastRunAt: startedAt,
+      lastStatus: "failed",
+      lastError: errorSummary,
+      nextRunAt: nextDailyRunAt(finishedAt),
+    });
+    spec.metrics.runsTotal.inc({ status: "failed", trigger });
+    spec.metrics.durationSeconds.observe({ trigger }, durationMs / 1000);
+    trace(`run failed id=${created.id} reason=${errorSummary}`);
+    return { runId: created.id, status: "failed", error: errorSummary };
+  };
+
+  // Pre-dump capability check. Catches a DB container whose image lacks a
+  // required extension library (e.g. pgvector) BEFORE pg_dump fails opaquely,
+  // and fails with an actionable remedy instead. Fail-open by contract, so it
+  // never blocks a run pg_dump could complete (BI-A35347E4).
+  const preflight = args.preflight ?? spec.preflight;
+  if (preflight) {
+    const verdict = await preflight({ composeProject });
+    if (!verdict.ok) {
+      return recordFailure(verdict.error);
+    }
+  }
+
   // Ensure the parent /backups/<subdir> directory exists. The target itself
   // is created by the shell script.
   await fs.mkdir(path.posix.join(backupsRoot, spec.subdir), { recursive: true });
@@ -367,26 +420,5 @@ export async function runManagedBackup(
     exitLabel: "runner",
     fallback: spec.failureFallback,
   });
-  await prisma.backupRun.update({
-    where: { id: created.id },
-    data: {
-      status: "failed",
-      finishedAt,
-      durationMs,
-      errorMessage: errorSummary,
-    },
-  });
-
-  await recordJobHeartbeat(prisma, spec.jobId, {
-    lastRunAt: startedAt,
-    lastStatus: "failed",
-    lastError: errorSummary,
-    nextRunAt: nextDailyRunAt(finishedAt),
-  });
-
-  spec.metrics.runsTotal.inc({ status: "failed", trigger });
-  spec.metrics.durationSeconds.observe({ trigger }, durationMs / 1000);
-
-  trace(`run failed id=${created.id} reason=${errorSummary}`);
-  return { runId: created.id, status: "failed", error: errorSummary };
+  return recordFailure(errorSummary);
 }

--- a/apps/web/lib/operate/backups/managed-restore.ts
+++ b/apps/web/lib/operate/backups/managed-restore.ts
@@ -149,7 +149,11 @@ export async function runManagedRestore(
       parts.map((p) => JSON.stringify(p)).join(" "),
     );
   };
-  const summarize = (outcome: { stderr: string; exitCode: number }) =>
+  const summarize = (outcome: {
+    stdout?: string;
+    stderr: string;
+    exitCode: number;
+  }) =>
     summarizeScriptFailure(outcome, {
       marker: spec.failureMarker,
       strip: spec.failureStrip,

--- a/docs/superpowers/specs/2026-07-09-managed-backup-restore-substrate-design.md
+++ b/docs/superpowers/specs/2026-07-09-managed-backup-restore-substrate-design.md
@@ -103,3 +103,33 @@ that layer waits for the Claude-Inside-Out workflow primitive
 substrate instead of a backup-only mini-framework. The specs introduced here
 are the intended input to that primitive: a fourth engine should be a spec
 entry + one workflow registration, nothing more.
+
+## Pre-dump extension preflight (BI-A35347E4)
+
+`runManagedBackup` runs an optional `spec.preflight` capability check before it
+spawns the backup script. `POSTGRES_BACKUP_SPEC.preflight`
+(`extension-preflight.ts`) catches a Postgres container whose **image** does
+not provide an extension the **database catalog** depends on — the canonical
+case being pgvector's `vector.so` after the container was recreated onto a
+plain `postgres:16-alpine` image while the BET-5 schema carries `vector`
+objects. Without the preflight, `pg_dump` dies with
+`could not access file "$libdir/vector"` and the self-upgrade recovery point
+aborts with an opaque `pg_dump exit=1` and no remedy.
+
+Detection is general, not vector-specific: an extension in `pg_extension`
+(catalog, lives in the data volume) but absent from `pg_available_extensions`
+(control files the image ships) is installed-but-unprovided. On a definitive
+miss the preflight fails the run with an actionable message naming the
+extension(s) and the one-command remedy —
+`docker compose up -d --no-deps postgres` (data preserved in the pgdata
+volume). It is **fail-open** on any inconclusive signal (DB unreachable, query
+error) so it never becomes a new failure source, and it **never recreates the
+container** — the self-upgrade deploy deliberately uses `--no-deps` and never
+touches postgres (fleet-safety invariant); recreating the DB mid-upgrade is a
+destructive action requiring explicit operator go. (Kernel decision via
+`principle_decide`: fail-fast-with-remedy over auto-heal, high confidence.)
+
+Companion fix: `summarizeScriptFailure` now scans **stdout and stderr** for the
+curated `[backup-trace] failed:` line (the managed scripts print it to stdout),
+so the residual pg_dump failure path also surfaces the human-authored reason
+instead of the raw last-stderr line.


### PR DESCRIPTION
## Problem

A live self-upgrade failed at the **pre-upgrade recovery point** with an opaque
`recovery-point-failed: postgres <id>: [backup-trace] pg_dump exit=1 — tail of log:`
(empty tail). Root cause: the running postgres container image lacked the
pgvector `vector.so` the BET-5 schema depends on (`dpf-postgres-1` was
`postgres:16-alpine`, DB catalog has `vector` 0.8.5), so `pg_dump` died on
`could not access file "$libdir/vector"`. Every retry hit the same wall, and the
operator got no cause and no remedy.

This is operational/fleet, not upgrade logic: `promote.sh`/`redeploy-portal.sh`
deliberately use `--no-deps` and never recreate postgres, so a container on a
non-pgvector image persists across upgrades; the merged pgvector compose (#2967)
does not heal a running container. The self-upgrade cannot repair the DB image
its own backup depends on.

## Fix (BI-A35347E4)

Kernel decision (`principle_decide`, high confidence, margin 3.84):
**fail-fast-with-remedy**, not auto-recreate (auto-recreate would violate the
`--no-deps` fleet-safety invariant + destructive-actions-require-explicit-go).

- **`extension-preflight.ts`** — before pg_dump, detect extensions present in
  `pg_extension` but absent from `pg_available_extensions` (installed but not
  provided by the image). On a definitive miss, short-circuit the run to a
  failed `BackupRun` carrying an actionable message that names the extension(s)
  and the one-command remedy `docker compose up -d --no-deps postgres` (data
  preserved in the pgdata volume). **Fail-open** on any inconclusive signal so
  it never becomes a new failure source; **never** recreates the container.
- Wired as an optional `spec.preflight` hook on the shared `runManagedBackup`
  engine, set only for `POSTGRES_BACKUP_SPEC`. Benefits the daily backup and the
  recovery point (shared runner).
- **`summarizeScriptFailure`** now scans stdout as well as stderr for the
  curated `[backup-trace] failed:` line (the managed scripts print it to stdout,
  but only stderr was searched) — the residual pg_dump path now surfaces the
  human-authored reason too. Threaded through the restore path for consistency.

## Tests

- New `extension-preflight.test.ts` — detection, plural/singular messaging,
  fail-open on non-zero exit / thrown exec / whitespace, SQL contract guard.
- New `runManagedBackup — preflight short-circuit` cases — asserts the script is
  never spawned and the actionable remedy lands on the failed `BackupRun`;
  existing managed-backup tests inject a no-op preflight to stay deterministic.
- Doc: pre-dump extension preflight section added to the managed-backup/restore
  substrate design.

## Local-CI-Override attestation

Local pregate ran to completion: **16,200 tests pass** (incl. the new suites) and
**`pnpm --filter web typecheck` passes clean**. `next build` reported
`✓ Compiled successfully` and generated all 131 static pages, then exited 1 from
the **known non-canonical local-tree divergence** (no `DATABASE_URL`; 133
pre-existing edge-runtime `node:*` warnings across the codebase, none in the
changed files; the sibling `managed-script-path.ts` already statically imports
`node:child_process` and builds on `main`). The authoritative **Prod Build**
required check gates the merge in the canonical Docker context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
