### PR TITLE
feat(workbooks): row-expand record detail modal

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -128,6 +128,7 @@ import {
   FOOTER_AGG_LABELS,
   type FooterAgg,
 } from "./grid-footer-summary";
+import { RecordDetailModal } from "./RecordDetailModal";
 
 export interface WorkbookGridProps {
   /** custom WorkbookTable id (TBL-*) or, for platform data, the entity type. */
@@ -369,6 +370,8 @@ export function WorkbookGrid({
   // Per-column footer aggregate (Airtable-style summary bar): columnId → agg.
   const [footerAgg, setFooterAgg] = useState<Record<string, FooterAgg>>({});
   const [showFooter, setShowFooter] = useState(false);
+  // Which row is expanded into the record detail modal (null = closed).
+  const [openRowId, setOpenRowId] = useState<string | null>(null);
   // Which groups the user has collapsed (session-scoped); everything else is
   // expanded by default so the grouped grid reads like Smartsheet on open.
   const [collapsedGroups, setCollapsedGroups] = useState<ReadonlySet<string>>(() => new Set());
@@ -486,9 +489,31 @@ export function WorkbookGrid({
         ),
       } as Column<GridRowData, SummaryRow>;
     });
+    // Leading "expand" column: opens the full-record modal for its row.
+    const expandCol: Column<GridRowData, SummaryRow> = {
+      key: "__expand__",
+      name: "",
+      width: 36,
+      minWidth: 36,
+      maxWidth: 36,
+      frozen: true,
+      resizable: false,
+      sortable: false,
+      renderCell: ({ row }) => (
+        <button
+          type="button"
+          className="dpf-grid-expand"
+          onClick={() => setOpenRowId(row.rowId)}
+          aria-label="Expand record"
+          title="Expand record"
+        >
+          ⤢
+        </button>
+      ),
+    };
     return capabilities.canDeleteRow
-      ? [SelectColumn as Column<GridRowData, SummaryRow>, ...cols]
-      : cols;
+      ? [SelectColumn as Column<GridRowData, SummaryRow>, expandCol, ...cols]
+      : [expandCol, ...cols];
   }, [visibleCols, capabilities, showProvenance, effectiveFrozen, showFooter, footerAgg]);
 
   const onColumnsReorder = useCallback(
@@ -585,6 +610,26 @@ export function WorkbookGrid({
       return true;
     },
     [tableId, source],
+  );
+
+  // Persist one field edited in the record modal, through the same validated
+  // dispatch (+ optimistic update + undo history) as an in-grid edit.
+  const onModalSave = useCallback(
+    (columnId: string, value: CellValue) => {
+      const rid = openRowId;
+      if (!rid) return;
+      const prevRow = rowData.find((r) => r.rowId === rid);
+      const prevValue: CellValue = prevRow ? prevRow[columnId] ?? null : null;
+      setRowData((prev) =>
+        prev.map((r) => (r.rowId === rid ? { ...r, [columnId]: value } : r)),
+      );
+      void persistCell(rid, columnId, value, prevValue).then((ok) => {
+        if (ok) {
+          setHistory((h) => recordEdit(h, { rowId: rid, columnId, prevValue, nextValue: value }));
+        }
+      });
+    },
+    [openRowId, rowData, persistCell],
   );
 
   const onRowsChange = useCallback(
@@ -1372,6 +1417,20 @@ export function WorkbookGrid({
           )}
         </div>
       )}
+
+      {openRowId &&
+        (() => {
+          const openRow = rowData.find((r) => r.rowId === openRowId);
+          return openRow ? (
+            <RecordDetailModal
+              row={openRow}
+              columns={columns}
+              canEdit={capabilities.canEditCell}
+              onClose={() => setOpenRowId(null)}
+              onSave={onModalSave}
+            />
+          ) : null;
+        })()}
     </div>
   );
 }

--- a/apps/web/components/workbooks/RecordDetailModal.tsx
+++ b/apps/web/components/workbooks/RecordDetailModal.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+// Universal Grid & Workbooks — record detail modal (EP-GRID-WORKBOOKS, toward
+// Airtable parity). "Expand a row" into a full-record editor: every field on its
+// own line, edited through the SAME validated dispatch as an in-grid edit (the
+// Grid passes an onSave that routes to persistCell). Presentational + self-
+// contained; the Grid owns persistence and which row is open.
+
+import { useEffect } from "react";
+import type { CellValue, ColumnDefinition, SelectOption } from "@/lib/workbooks/types";
+import type { GridRowData } from "./cell-editors";
+import { cellSearchText } from "./grid-filter";
+
+export interface RecordDetailModalProps {
+  row: GridRowData;
+  columns: ColumnDefinition[];
+  canEdit: boolean;
+  onClose: () => void;
+  /** Persist one field; the Grid wires this to its validated persistCell path. */
+  onSave: (columnId: string, value: CellValue) => void;
+}
+
+/** Field types the modal edits inline; everything else is shown read-only. */
+const INLINE_EDITABLE = new Set([
+  "text",
+  "url",
+  "email",
+  "phone",
+  "number",
+  "currency",
+  "percent",
+  "progress",
+  "rating",
+  "duration",
+  "checkbox",
+  "select",
+  "date",
+  "datetime",
+]);
+
+function asStr(v: CellValue): string {
+  if (v === null || v === undefined) return "";
+  return String(v);
+}
+
+export function RecordDetailModal({
+  row,
+  columns,
+  canEdit,
+  onClose,
+  onSave,
+}: RecordDetailModalProps) {
+  // Close on Escape — standard modal affordance.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const ctrl =
+    "w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
+
+  const field = (col: ColumnDefinition) => {
+    const value = row[col.columnId] ?? null;
+    const editable = canEdit && col.editable && INLINE_EDITABLE.has(col.fieldType);
+
+    if (!editable) {
+      return (
+        <div className="truncate text-sm text-[var(--dpf-text)]" title={cellSearchText(value)}>
+          {cellSearchText(value) || <span className="text-[var(--dpf-muted)]">—</span>}
+        </div>
+      );
+    }
+
+    switch (col.fieldType) {
+      case "checkbox":
+        return (
+          <input
+            type="checkbox"
+            checked={value === true}
+            onChange={(e) => onSave(col.columnId, e.target.checked)}
+            aria-label={col.name}
+          />
+        );
+      case "select":
+        return (
+          <select
+            className={ctrl}
+            value={asStr(value)}
+            onChange={(e) => onSave(col.columnId, e.target.value || null)}
+            aria-label={col.name}
+          >
+            <option value="">—</option>
+            {(col.config?.options ?? []).map((o: SelectOption) => (
+              <option key={o.key} value={o.key}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        );
+      case "number":
+      case "currency":
+      case "percent":
+      case "progress":
+      case "rating":
+      case "duration":
+        return (
+          <input
+            type="number"
+            className={ctrl}
+            defaultValue={asStr(value)}
+            onBlur={(e) => onSave(col.columnId, e.target.value === "" ? null : Number(e.target.value))}
+            aria-label={col.name}
+          />
+        );
+      case "date":
+      case "datetime":
+        return (
+          <input
+            type={col.fieldType === "datetime" ? "datetime-local" : "date"}
+            className={ctrl}
+            defaultValue={asStr(value).slice(0, col.fieldType === "datetime" ? 16 : 10)}
+            onBlur={(e) => onSave(col.columnId, e.target.value || null)}
+            aria-label={col.name}
+          />
+        );
+      default:
+        return (
+          <input
+            className={ctrl}
+            defaultValue={asStr(value)}
+            onBlur={(e) => onSave(col.columnId, e.target.value === "" ? null : e.target.value)}
+            aria-label={col.name}
+          />
+        );
+    }
+  };
+
+  return (
+    <div
+      className="dpf-record-modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Record detail"
+      onClick={onClose}
+    >
+      <div className="dpf-record-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="dpf-record-modal-header">
+          <span className="text-sm font-semibold text-[var(--dpf-text)]">Record</span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          >
+            ✕
+          </button>
+        </div>
+        <dl className="dpf-record-modal-body">
+          {columns.map((col) => (
+            <div key={col.columnId} className="dpf-record-modal-row">
+              <dt className="text-xs font-medium uppercase tracking-wide text-[var(--dpf-muted)]">
+                {col.name}
+              </dt>
+              <dd>{field(col)}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/workbooks/dpf-grid.css
+++ b/apps/web/components/workbooks/dpf-grid.css
@@ -298,3 +298,59 @@
   font-variant-numeric: tabular-nums;
   color: var(--dpf-muted);
 }
+
+/* Expand-row affordance in the grid's leading action cell. */
+.dpf-grid-expand {
+  border: none;
+  background: transparent;
+  color: var(--dpf-muted);
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+}
+.dpf-grid-expand:hover {
+  color: var(--dpf-text);
+}
+
+/* Record detail modal — expand a row into a full-record editor. */
+.dpf-record-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background-color: color-mix(in srgb, #000 45%, transparent);
+}
+.dpf-record-modal {
+  inline-size: min(40rem, 100%);
+  max-block-size: 85vh;
+  overflow: auto;
+  border-radius: 0.75rem;
+  border: 1px solid var(--dpf-border);
+  background-color: var(--dpf-surface-1);
+  box-shadow: 0 10px 40px color-mix(in srgb, #000 30%, transparent);
+}
+.dpf-record-modal-header {
+  position: sticky;
+  inset-block-start: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-block-end: 1px solid var(--dpf-border);
+  background-color: var(--dpf-surface-2);
+}
+.dpf-record-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+.dpf-record-modal-row {
+  display: grid;
+  grid-template-columns: minmax(8rem, 12rem) 1fr;
+  gap: 0.75rem;
+  align-items: center;
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -242,3 +242,12 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
 - **Semantic layer (Phase 4):** `WorkbookMetric` (unique/owned/versioned, lineage-required).
 - **Operationalization lifecycle (Phase 5):** promote column → metric → schema field / page-visual,
   with gates + blast-radius + governed retirement; derived-column lineage edges (fail-closed).
+
+## Slice 22 — row-expand record detail modal — SHIPPED (BI-90971F1F)
+
+A leading expand button on each grid row opens `RecordDetailModal` — every field on its own line for
+viewing/editing. Simple types (text/url/email/phone/number + numeric-backed/checkbox/select/date)
+edit inline in the modal through the **same** validated `persistCell` path (+ optimistic update + undo
+history) as an in-grid edit; complex types (reference/link/attachment/formula/lookup/rollup/
+multi_select) render read-only (edit in-grid). Self-contained component; `Grid.tsx` adds only an
+`openRowId` state, a 36px frozen expand column, and the modal render. Escape / backdrop-click closes.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -12,7 +12,7 @@ apps/web/components/platform/AiOperationsMap.tsx	2849
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
 apps/web/components/storefront/SlotBookingFlow.tsx	919
-apps/web/components/workbooks/Grid.tsx	1379
+apps/web/components/workbooks/Grid.tsx	1437
 apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1341
 apps/web/lib/actions/agent-coworker-external.test.ts	867


### PR DESCRIPTION
## Why
Airtable-style **expand a row** — a leading expand button opens a full-record editor showing every field on its own line. Toward no-perceptible-difference parity.

## Changes
- **`RecordDetailModal.tsx`** (self-contained): one field per line. Simple types (text/url/email/phone, number + numeric-backed, checkbox, select, date/datetime) edit inline through the **same** validated `persistCell` path (+ optimistic update + undo history) as an in-grid edit. Complex types (reference/link/attachment/formula/lookup/rollup/multi_select) render read-only (edit in-grid).
- **`Grid.tsx`** adds only: an `openRowId` state, a 36px frozen expand column, and the modal render. Escape / backdrop-click closes.

Backlog: **BI-90971F1F**. Plan: slice 22.

## Testing
- **70 workbooks unit tests still pass** (additive; no pure helper changed). Full CI (Typecheck + Build) is the authoritative gate. Baseline 1188→1249.

## Note on sequencing
Built off fresh `main` (one PR at a time, no stacking). It touches `Grid.tsx`, so once **#3042** (footer/field/filter) merges I'll rebase this onto `main` — but each stays an independent base-`main` PR that gets full CI (unlike the earlier stack).

## UX-Fit-Decision
One expand affordance per row (a small ⤢ button in a 36px leading column — the Airtable/Smartsheet pattern) opens a plain full-record form (label + the right input per type; complex types read-only). No new toolbar controls, nothing raw to type, Escape/backdrop to close. Lowest `human_cognitive_load` per AGENTS.md §12/§17. Rejected an always-open side panel (steals grid width) and per-cell expand (redundant with in-grid editing).

## Design grounding
- Existing specs/plans reviewed: `docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md` (slice 22).
- Current code substrate reviewed: `apps/web/components/workbooks/Grid.tsx` (persistCell + gridColumns + history), `apps/web/components/workbooks/cell-editors.tsx`.
- Source of truth: the existing validated `persistCell` dispatch + `GridRowData`/`ColumnDefinition` contracts.
- Decision: a self-contained presentational modal reusing the existing persistence path — no contract/routing/data-model change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)