### PR TITLE
fix(self-upgrade): bake postgres init+pgvector into a first-party image so the promoter can't brick the DB (BI-4796D52B)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,15 @@ x-dev-workspace-volumes: &dev-workspace-volumes
 
 services:
   postgres:
-    image: pgvector/pgvector:pg16
+    # Built from docker/postgres/Dockerfile (FROM pgvector + baked-in inngest
+    # init script) rather than the stock pgvector image with a host bind mount.
+    # The bind mount made postgres un-startable when the self-upgrade promoter
+    # recreated it under `--project-directory /host-source` (BI-4796D52B); the
+    # baked image has no host-path dependency, and pgvector can never drift out
+    # of the image (BI-A35347E4). Compose auto-tags this `${project}-postgres`.
+    build:
+      context: .
+      dockerfile: docker/postgres/Dockerfile
     restart: unless-stopped
     logging: *default-logging
     environment:
@@ -51,7 +59,6 @@ services:
       POSTGRES_DB: dpf
     volumes:
       - pgdata:/var/lib/postgresql/data
-      - ./scripts/init-inngest-db.sh:/docker-entrypoint-initdb.d/20-create-inngest-db.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-dpf}"]
       interval: 5s

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,0 +1,24 @@
+# DPF Postgres image (BI-4796D52B).
+#
+# FROM pgvector so the vector.so the BET-5 schema depends on is ALWAYS present
+# in the image — it can never drift back to a plain postgres:16-alpine (which
+# breaks pg_dump / vector queries; see BI-A35347E4 / local-ci-pregate-pgvector).
+#
+# The inngest-db init script is BAKED IN rather than host-bind-mounted. The old
+# `./scripts/init-inngest-db.sh:/docker-entrypoint-initdb.d/...` bind mount made
+# the container un-startable whenever compose recreated it under a project
+# directory the Docker daemon can't resolve to a shared host path — most acutely
+# the self-upgrade promoter, which runs compose with `--project-directory
+# /host-source` (a path that exists only inside the promoter container). The
+# bind source then became `/host-source/scripts/init-inngest-db.sh`, Docker
+# refused the mount, postgres stuck in `Created`, and the whole install lost its
+# DB mid-upgrade. Baking the script into an image layer removes that host-path
+# dependency entirely: postgres can be recreated under ANY project directory.
+#
+# The build context is the repo root (see docker-compose.yml `build.context`),
+# streamed to the daemon — so this COPY works even from the promoter, where the
+# source is only readable at /host-source and never a valid host bind path.
+FROM pgvector/pgvector:pg16
+
+# Runs only on first init (empty data dir); idempotent for existing volumes.
+COPY scripts/init-inngest-db.sh /docker-entrypoint-initdb.d/20-create-inngest-db.sh

--- a/docs/superpowers/specs/2026-07-16-postgres-baked-image-self-upgrade-mount-fix.md
+++ b/docs/superpowers/specs/2026-07-16-postgres-baked-image-self-upgrade-mount-fix.md
@@ -1,0 +1,71 @@
+# Postgres baked image — self-upgrade mount fix (BI-4796D52B)
+
+**Status:** implemented · **Date:** 2026-07-16 · **Owner:** platform
+
+## Problem
+
+On a Docker Desktop install, the self-upgrade **deploy** step took the database
+(and thus the whole install) down and failed the run with
+`worker-error: Can't reach database server at postgres` (observed
+`SUR-AFB0DAB2`, `SUR-600F551A`).
+
+The promoter (`scripts/promote.sh`) runs every compose command with
+`--project-directory /host-source -p dpf` — `/host-source` is the promoter
+container's read-only mount of the install source
+(`PROMOTER_CONTAINER_SOURCE` in `apps/web/lib/self-upgrade/promoter.ts`). The
+deploy steps pass `--no-deps` to leave postgres running, but compose still
+**recreated** `dpf-postgres-1` (config drift is enough; `--no-deps` only stops
+dependency *startup*, not reconciliation of an existing container). Under
+`--project-directory /host-source`, the postgres service's host bind mount
+`./scripts/init-inngest-db.sh` resolved to `/host-source/scripts/init-inngest-db.sh`
+— a path that exists only *inside* the promoter container, not on the Docker
+Desktop host. The daemon refused the mount
+(`mounts denied: … not shared from the host`), postgres stuck in `state=Created`
+(never started), the portal went unhealthy, and the upgrade worker lost its DB.
+
+The portal service is immune because it runs from an image with no host
+`./scripts` bind mount. This is the same path-divergence class as the
+self-upgrade docker-build-context divergence.
+
+Related, separately fixed: the recovery-point pg_dump failing when the image
+lacks pgvector (BI-A35347E4 / PR #3040). That drift is *also* closed here.
+
+## Decision
+
+Kernel consult (`principle_decide`, high confidence, composite 5.61, margin
+1.61, no commandment conflict) selected **bake a first-party postgres image**
+over: a compose `configs:` entry (may still resolve against `/host-source`),
+a published ghcr image (registry dependency for the core DB — hurts self-hosted
+operational independence), and a promoter host-path rewrite (fixes only the
+mount, not pgvector drift, and adds promoter complexity).
+
+## Change
+
+- **`docker/postgres/Dockerfile`** — `FROM pgvector/pgvector:pg16` +
+  `COPY scripts/init-inngest-db.sh /docker-entrypoint-initdb.d/…`. Two wins in
+  one image: (1) no host bind mount → postgres can be recreated under **any**
+  project directory (including `/host-source`); (2) pgvector is always in the
+  image → it can never drift to a plain postgres image. The build context is
+  streamed to the daemon, so the `COPY` works from the promoter even though the
+  source is only readable at `/host-source` and never a valid host bind path.
+- **`docker-compose.yml`** — the `postgres` service now uses
+  `build: { context: ., dockerfile: docker/postgres/Dockerfile }` and drops the
+  `./scripts/init-inngest-db.sh:/docker-entrypoint-initdb.d/…:ro` bind mount.
+  Only the main `postgres` service is affected (`sandbox-postgres` / `dev-postgres`
+  never had the init bind mount). Compose auto-tags it `${project}-postgres`.
+- **`scripts/promote.sh`** — builds `portal postgres` (was `portal`) so the
+  image exists before any recreate; a single COPY over the cached pgvector base.
+- **Guard** — `scripts/check-no-postgres-initdb-host-mount.mjs` (+ self-test)
+  runs in the Repo Guard Loop and fails if any compose service host-bind-mounts
+  into `/docker-entrypoint-initdb.d`, so the bind-mount form can't creep back.
+
+`/docker-entrypoint-initdb.d` scripts only run on first init (empty data
+volume), so baking the script in is a no-op for existing installs — the inngest
+DB already exists — and identical behavior for fresh ones.
+
+## Verification
+
+Disposable-container run of the built image: starts, the baked script
+auto-creates the `inngest` database, `CREATE EXTENSION vector` + an hnsw index
+succeed, and `pg_dump --schema-only` exits 0 (the exact operation that failed at
+recovery-point). Guard self-test 5/5.

--- a/scripts/check-no-postgres-initdb-host-mount.mjs
+++ b/scripts/check-no-postgres-initdb-host-mount.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Ratchet guard — BI-4796D52B.
+//
+// Forbids ANY docker-compose service from host-bind-mounting a file into
+// `/docker-entrypoint-initdb.d`. That pattern (the old
+// `- ./scripts/init-inngest-db.sh:/docker-entrypoint-initdb.d/...:ro`) makes
+// postgres un-startable whenever compose recreates the container under a
+// project directory the Docker daemon can't resolve to a shared host path —
+// most acutely the self-upgrade promoter, which runs compose with
+// `--project-directory /host-source` (a path that exists only inside the
+// promoter container). The recreated container then fails with
+// `mounts denied: path /host-source/scripts/init-inngest-db.sh is not shared`,
+// stays in state=Created, and the whole install loses its DB mid-upgrade.
+//
+// The sanctioned pattern is to BAKE init scripts into the image
+// (docker/postgres/Dockerfile), which has no host-path dependency. This guard
+// keeps the bind-mount form from creeping back.
+//
+// Contract: exit 0 = clean, non-zero = violation (see check-guards.mjs).
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const INITDB_DIR = "/docker-entrypoint-initdb.d";
+
+/**
+ * Return the offending compose volume entries that host-bind-mount into
+ * /docker-entrypoint-initdb.d. Pure + exported so the sibling self-test can
+ * exercise it without a real file.
+ *
+ * @param {string} composeText raw docker-compose.yml contents
+ * @returns {{ line: number, text: string }[]}
+ */
+export function findInitdbHostMounts(composeText) {
+  const violations = [];
+  const lines = composeText.split("\n");
+  lines.forEach((raw, i) => {
+    const line = raw.trim();
+    // Volume list entries look like `- <source>:<target>[:mode]`.
+    if (!line.startsWith("- ")) return;
+    if (!line.includes(INITDB_DIR)) return;
+    const entry = line.slice(2).trim();
+    // Named-volume mounts (`- somevol:/path`) can't carry init scripts and are
+    // not the failure mode; a host bind has a path-like source (starts with
+    // `.`, `/`, `~`, or a `${VAR}` expansion, or otherwise contains a slash).
+    const source = entry.split(":")[0];
+    const isHostPath =
+      /^[./~]/.test(source) || source.includes("/") || source.includes("${");
+    if (isHostPath) violations.push({ line: i + 1, text: line });
+  });
+  return violations;
+}
+
+// --- CLI ---------------------------------------------------------------------
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const composePath = join(repoRoot, "docker-compose.yml");
+  let text;
+  try {
+    text = readFileSync(composePath, "utf8");
+  } catch (err) {
+    console.error(`check-no-postgres-initdb-host-mount: cannot read ${composePath}: ${err.message}`);
+    process.exit(1);
+  }
+  const violations = findInitdbHostMounts(text);
+  if (violations.length > 0) {
+    console.error(
+      "Host bind mount(s) into /docker-entrypoint-initdb.d found in docker-compose.yml.",
+    );
+    console.error(
+      "This breaks postgres recreation under `--project-directory /host-source` (self-upgrade promoter, BI-4796D52B).",
+    );
+    console.error("Bake init scripts into the image (docker/postgres/Dockerfile) instead:");
+    for (const v of violations) console.error(`  docker-compose.yml:${v.line}: ${v.text}`);
+    process.exit(1);
+  }
+  console.log("No /docker-entrypoint-initdb.d host bind mounts in docker-compose.yml.");
+}

--- a/scripts/check-no-postgres-initdb-host-mount.test.mjs
+++ b/scripts/check-no-postgres-initdb-host-mount.test.mjs
@@ -1,0 +1,56 @@
+// Self-test for check-no-postgres-initdb-host-mount.mjs (BI-4796D52B).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { findInitdbHostMounts } from "./check-no-postgres-initdb-host-mount.mjs";
+
+test("flags a ./scripts host bind mount into initdb.d", () => {
+  const compose = `
+  postgres:
+    image: pgvector/pgvector:pg16
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./scripts/init-inngest-db.sh:/docker-entrypoint-initdb.d/20-create-inngest-db.sh:ro
+`;
+  const v = findInitdbHostMounts(compose);
+  assert.equal(v.length, 1);
+  assert.match(v[0].text, /init-inngest-db\.sh/);
+});
+
+test("flags an absolute-path and a ${VAR} bind into initdb.d", () => {
+  const compose = `
+      - /host-source/scripts/init.sh:/docker-entrypoint-initdb.d/10.sh:ro
+      - \${INIT_DIR}/x.sh:/docker-entrypoint-initdb.d/30.sh
+`;
+  assert.equal(findInitdbHostMounts(compose).length, 2);
+});
+
+test("passes when there is no initdb host mount (baked image form)", () => {
+  const compose = `
+  postgres:
+    build:
+      context: .
+      dockerfile: docker/postgres/Dockerfile
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+`;
+  assert.deepEqual(findInitdbHostMounts(compose), []);
+});
+
+test("does not flag an unrelated ./scripts bind (different target)", () => {
+  const compose = `      - ./scripts/other.sh:/somewhere/else.sh:ro`;
+  assert.deepEqual(findInitdbHostMounts(compose), []);
+});
+
+test("the live docker-compose.yml is clean (baked, not bind-mounted)", () => {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const text = readFileSync(join(repoRoot, "docker-compose.yml"), "utf8");
+  assert.deepEqual(
+    findInitdbHostMounts(text),
+    [],
+    "docker-compose.yml must bake init scripts into the image, not host-bind-mount them (BI-4796D52B)",
+  );
+});

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -194,8 +194,14 @@ if [[ $_dry_run -eq 0 ]]; then
   # using Bake, but buildx isn't installed". This matches the working manual
   # `docker compose build` path. (Self-upgrade docker-build failures, 2026-06-06.)
   export COMPOSE_BAKE=false
+  # Build portal AND postgres. postgres is now a first-party built image
+  # (docker/postgres/Dockerfile — pgvector + baked init script, BI-4796D52B);
+  # building it here guarantees the image exists before any recreate, and the
+  # build context is streamed to the daemon so it works from /host-source where
+  # a host bind mount could not. The build is a single COPY over the cached
+  # pgvector base — negligible cost.
   docker compose ${_env_args[@]+"${_env_args[@]}"} --project-directory "$PROMOTE_SOURCE" -p "$_project" \
-    "${_f_args[@]}" build portal
+    "${_f_args[@]}" build portal postgres
   # Capture the source content hash baked into the FRESHLY BUILT image. It is
   # computed from the actual bundled source bytes (Dockerfile) independent of
   # the DPF_VERSION label, so the content-verify step can prove the recreated


### PR DESCRIPTION
## Problem

On Docker Desktop, the self-upgrade **deploy** step takes the DB (and the whole
install) down with `worker-error: Can't reach database server at postgres`
(observed repeatedly: SUR-E51351C2, SUR-AFB0DAB2, SUR-600F551A).

The promoter (`scripts/promote.sh`) runs compose with `--project-directory
/host-source` (its container-internal RO mount of the source). Compose recreates
`dpf-postgres-1` despite `--no-deps` (config drift is enough — `--no-deps` only
stops dependency *startup*, not reconciliation of an existing container), and the
postgres host bind mount `./scripts/init-inngest-db.sh` resolves to
`/host-source/scripts/init-inngest-db.sh` — a path the Docker daemon can't share.
`mounts denied` → postgres stuck in `Created` → DB down → the upgrade worker
loses its own database. The portal is immune (image, no host bind mount).

## Fix (BI-4796D52B)

Kernel-selected (`principle_decide`, high confidence, margin 1.61): **bake a
first-party postgres image** — `docker/postgres/Dockerfile` (`FROM
pgvector/pgvector:pg16` + `COPY scripts/init-inngest-db.sh` into
`/docker-entrypoint-initdb.d`) and drop the host bind mount. Two wins in one:

- **No host-path dependency** → postgres can be recreated under any project
  directory (including `/host-source`). The build context is streamed to the
  daemon, so the `COPY` works from the promoter where a bind mount cannot.
- **pgvector can't drift out of the image** → also closes the recovery-point
  pg_dump failure class (BI-A35347E4 / #3040).

Changes:
- `docker-compose.yml`: `postgres` now `build:`s the Dockerfile, no initdb bind
  mount (only the main service had it; sandbox/dev never did).
- `scripts/promote.sh`: builds `portal postgres` so the image exists before any
  recreate (a single COPY over the cached pgvector base).
- `scripts/check-no-postgres-initdb-host-mount.mjs` (+ self-test): Repo Guard
  Loop guard that fails if any compose service host-bind-mounts into
  `/docker-entrypoint-initdb.d`, so the bind form can't return.

`/docker-entrypoint-initdb.d` scripts run only on an empty volume, so baking the
script in is a no-op for existing installs and identical for fresh ones.

## Verification

Disposable container from the built image: starts, the baked script auto-creates
the `inngest` DB, `CREATE EXTENSION vector` + an hnsw index succeed, and
`pg_dump --schema-only` exits 0 (the exact op that failed at recovery-point).
Guard self-test 5/5; guard clean on the live compose; Compose Image Pins still
green; compose config parses.

## Local-CI-Override attestation

Infra-only change (Dockerfile / compose / promote.sh / guard / doc — no app TS).
Local pregate could not run: the portal was in self-upgrade quiescence and
refused the local-CI lease. The `next build` divergence is environmental
(non-canonical tree, no `DATABASE_URL`). The authoritative **Production Build**
and **Repo Guard Loop** required checks gate the merge via GitHub CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
