### PR TITLE
feat(self-upgrade): human-readable upgrade scope on the Latest Run card

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -92,6 +92,7 @@ const baseStatus = {
     summary: "Pending-update tally unavailable — routine upgrades proceed without batching.",
   },
   latestRun: null,
+  latestRunImpact: null,
   quiescence: {
     level: "normal" as const,
     runId: null,

--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -994,3 +994,76 @@ describe("SelfUpgradeClient – upgrade activity", () => {
     expect(html).toContain("Automatic upgrades paused until");
   });
 });
+
+describe("Latest Run card — human-readable upgrade scope", () => {
+  const digest = {
+    counts: { breaking: 1, feature: 5, fix: 3, performance: 0, other: 0, total: 9 },
+    headline: "Nine changes since your last upgrade, one breaking.",
+  };
+
+  it("leads with the plain-language headline when the run recorded one", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        latestRun={makeRun("succeeded")}
+        latestRunImpact={digest}
+      />,
+    );
+    expect(html).toContain("data-run-impact-headline");
+    expect(html).toContain("Nine changes since your last upgrade, one breaking.");
+  });
+
+  it("renders the scope ribbon with total and category breakdown", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        latestRun={makeRun("succeeded")}
+        latestRunImpact={digest}
+      />,
+    );
+    expect(html).toContain("data-run-impact-counts");
+    expect(html).toContain("9 changes");
+    expect(html).toContain("1 breaking · 5 new · 3 fixes");
+    // Breaking present -> ribbon takes the destructive color.
+    expect(html).toContain("--dpf-destructive");
+  });
+
+  it("shortens the SHA pair and keeps the full value as a hover title", () => {
+    const long = { currentSha: "1".repeat(40), targetSha: "2".repeat(40) };
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient {...baseStatus} latestRun={makeRun("succeeded", long)} />,
+    );
+    expect(html).toContain("data-run-sha-range");
+    // Truncated display (12 chars + ellipsis) is what the operator reads —
+    // never the full 40-char wall as visible body text.
+    expect(html).toContain(`>111111111111…</span>`);
+    // Full SHA is preserved for copy/verify via the title attribute only.
+    expect(html).toContain(`title="${"1".repeat(40)}"`);
+  });
+
+  it("omits the ribbon entirely when the run recorded no summary", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient {...baseStatus} latestRun={makeRun("succeeded")} />,
+    );
+    expect(html).not.toContain("data-run-impact-counts");
+    expect(html).not.toContain("data-run-impact-headline");
+    // The SHA identity line still renders.
+    expect(html).toContain("data-run-sha-range");
+  });
+
+  it("uses muted (non-destructive) ribbon color when nothing is breaking", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        latestRun={makeRun("succeeded")}
+        latestRunImpact={{
+          counts: { breaking: 0, feature: 2, fix: 1, performance: 0, other: 0, total: 3 },
+          headline: null,
+        }}
+      />,
+    );
+    expect(html).toContain("2 new · 1 fix");
+    // No headline block when the digest headline is null.
+    expect(html).not.toContain("data-run-impact-headline");
+  });
+});

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -11,7 +11,8 @@ import {
 } from "@/lib/actions/promotions";
 import { LocalTime } from "@/components/ui/LocalTime";
 import UpgradeImpactPanel from "@/components/ops/UpgradeImpactPanel";
-import type { SummaryResult } from "@/lib/self-upgrade/impact/types";
+import type { SummaryResult, RunImpactDigest } from "@/lib/self-upgrade/impact/types";
+import { formatImpactCounts } from "@/lib/self-upgrade/impact/format";
 import { StatusBadge } from "@/components/ui/report-kit";
 import { describeSkipReason } from "@/lib/self-upgrade/skip-reason";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
@@ -116,6 +117,8 @@ type Props = {
     summary: string;
   } | null;
   latestRun: LatestRun | null;
+  /** Human-readable scope of what the latest run carried (null when unrecorded). */
+  latestRunImpact?: RunImpactDigest | null;
   quiescence?: QuiescenceActivity | null;
   admission?: AdmissionSnapshot | null;
   cooldownUntil?: string | null;
@@ -304,6 +307,7 @@ export default function SelfUpgradeClient({
   isFresh,
   releaseBatch,
   latestRun,
+  latestRunImpact,
   quiescence,
   admission,
   cooldownUntil,
@@ -1129,11 +1133,48 @@ export default function SelfUpgradeClient({
             </div>
           )}
 
+          {/* Scope of the upgrade in human terms. The raw 40-char SHA pair told
+              an operator nothing about how big or risky a run is; lead with the
+              plain-language headline + counts ribbon (breaking/new/fix) drawn
+              from the impact summary this run recorded, and keep the shortened
+              SHAs as the precise-but-secondary identity line. */}
+          {latestRunImpact?.headline && (
+            <div className="text-sm text-[var(--dpf-text)]" data-run-impact-headline>
+              {latestRunImpact.headline}
+            </div>
+          )}
+
+          {latestRunImpact && (
+            <div className="text-xs" data-run-impact-counts>
+              <span className="text-[var(--dpf-text)]">
+                {latestRunImpact.counts.total} change
+                {latestRunImpact.counts.total === 1 ? "" : "s"}
+              </span>
+              <span className="text-[var(--dpf-muted)]"> · </span>
+              {/* Breaking changes are the risk signal an operator most needs to
+                  see, so color the ribbon destructive when any are present. */}
+              <span
+                className={
+                  latestRunImpact.counts.breaking > 0
+                    ? "text-[var(--dpf-destructive)]"
+                    : "text-[var(--dpf-muted)]"
+                }
+              >
+                {formatImpactCounts(latestRunImpact.counts)}
+              </span>
+            </div>
+          )}
+
           {latestRun.currentSha && latestRun.targetSha && (
-            <div className="text-xs text-[var(--dpf-muted)]">
-              <span className="font-mono">{latestRun.currentSha}</span>
+            <div className="text-xs text-[var(--dpf-muted)]" data-run-sha-range>
+              <span className="text-[var(--dpf-muted)]">Change: </span>
+              <span className="font-mono" title={latestRun.currentSha}>
+                {shortSha(latestRun.currentSha)}
+              </span>
               {" → "}
-              <span className="font-mono">{latestRun.targetSha}</span>
+              <span className="font-mono" title={latestRun.targetSha}>
+                {shortSha(latestRun.targetSha)}
+              </span>
             </div>
           )}
 
@@ -1329,9 +1370,13 @@ export default function SelfUpgradeClient({
                   <td className="px-3 py-2 text-[var(--dpf-muted)]">
                     {run.currentSha && run.targetSha ? (
                       <>
-                        <span className="font-mono">{run.currentSha}</span>
+                        <span className="font-mono" title={run.currentSha}>
+                          {shortSha(run.currentSha)}
+                        </span>
                         {" → "}
-                        <span className="font-mono">{run.targetSha}</span>
+                        <span className="font-mono" title={run.targetSha}>
+                          {shortSha(run.targetSha)}
+                        </span>
                       </>
                     ) : null}
                   </td>

--- a/apps/web/components/ops/UpgradeImpactPanel.tsx
+++ b/apps/web/components/ops/UpgradeImpactPanel.tsx
@@ -15,6 +15,7 @@
 
 import { useState, useTransition } from "react";
 import type { SummaryResult, ImpactItem } from "@/lib/self-upgrade/impact/types";
+import { formatImpactCounts } from "@/lib/self-upgrade/impact/format";
 import { CollapsibleList } from "@/components/ui/report-kit";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 
@@ -38,24 +39,6 @@ const CATEGORY_BADGE: Record<ImpactItem["category"], string> = {
   other:
     "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] border-[var(--dpf-border)]",
 };
-
-function countsLine(counts: {
-  breaking: number;
-  feature: number;
-  fix: number;
-  performance: number;
-  other: number;
-  total: number;
-}): string {
-  const parts: string[] = [];
-  if (counts.breaking > 0) parts.push(`${counts.breaking} breaking`);
-  if (counts.feature > 0) parts.push(`${counts.feature} new`);
-  if (counts.performance > 0) parts.push(`${counts.performance} perf`);
-  if (counts.fix > 0) parts.push(`${counts.fix} fix${counts.fix === 1 ? "" : "es"}`);
-  if (counts.other > 0) parts.push(`${counts.other} other`);
-  if (parts.length === 0) return `${counts.total} change${counts.total === 1 ? "" : "s"}`;
-  return parts.join(" · ");
-}
 
 function ItemRow({
   item,
@@ -234,7 +217,7 @@ export default function UpgradeImpactPanel({
           )}
 
           <div className="text-xs text-[var(--dpf-muted)]" data-counts-line>
-            {countsLine(result.summary.counts)}
+            {formatImpactCounts(result.summary.counts)}
           </div>
 
           {result.summary.phrased?.touchesCustomizationsCallout && (

--- a/apps/web/lib/actions/promotions.self-upgrade.test.ts
+++ b/apps/web/lib/actions/promotions.self-upgrade.test.ts
@@ -53,6 +53,7 @@ vi.mock("@/lib/self-upgrade/run-store", () => ({
 
 vi.mock("@/lib/self-upgrade/impact", () => ({
   getCurrentImpactSummaryId: vi.fn().mockResolvedValue(null),
+  loadRunImpactDigest: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/lib/self-upgrade/window", () => ({

--- a/apps/web/lib/actions/promotions.ts
+++ b/apps/web/lib/actions/promotions.ts
@@ -14,7 +14,7 @@ import { resolveTargetSha, isShaFresh } from "@/lib/self-upgrade/version";
 import { getDeployedSha } from "@/lib/self-upgrade/completion";
 import { getJobEngineHealth } from "@/lib/queue/job-engine-health";
 import { createRun, failRun, getLatestRun, getLatestSucceededRun } from "@/lib/self-upgrade/run-store";
-import { getCurrentImpactSummaryId } from "@/lib/self-upgrade/impact";
+import { getCurrentImpactSummaryId, loadRunImpactDigest } from "@/lib/self-upgrade/impact";
 import {
   isStoreOpen,
   isUpgradeWindowOpen,
@@ -605,6 +605,12 @@ export async function getSelfUpgradeStatus() {
     getActiveSelfUpgradeBlackout(),
   ]);
 
+  // Human-readable "what did this run carry?" for the Latest Run card, loaded by
+  // the run's OWN impactSummaryId (the summary the operator reviewed at launch).
+  // Null when the run recorded no summary (e.g. a scheduled run, or one launched
+  // before a summary was generated) — the card then shows the SHA pair alone.
+  const latestRunImpact = await loadRunImpactDigest(latestRun?.impactSummaryId ?? null);
+
   // Upgrade timing follows the storefront's open/closed state (single source of
   // truth: operating hours). inMaintenanceWindow = "upgrades may run now" = store
   // closed (or inside an explicit override / auto-overnight window). storeOpen
@@ -726,6 +732,7 @@ export async function getSelfUpgradeStatus() {
       summary: releaseBatch.summary,
     },
     latestRun,
+    latestRunImpact,
     quiescence,
     // §4.5 admission observability — derived from the lane config + the
     // quiescence blockers already captured above (no extra query).

--- a/apps/web/lib/self-upgrade/impact/format.test.ts
+++ b/apps/web/lib/self-upgrade/impact/format.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { formatImpactCounts, formatChangeTotal } from "./format";
+import type { ImpactCategoryCounts } from "./types";
+
+function counts(overrides: Partial<ImpactCategoryCounts> = {}): ImpactCategoryCounts {
+  return { breaking: 0, feature: 0, fix: 0, performance: 0, other: 0, total: 0, ...overrides };
+}
+
+describe("formatImpactCounts", () => {
+  it("joins non-zero categories in severity order", () => {
+    expect(
+      formatImpactCounts(
+        counts({ breaking: 1, feature: 5, performance: 2, fix: 3, other: 1, total: 12 }),
+      ),
+    ).toBe("1 breaking · 5 new · 2 perf · 3 fixes · 1 other");
+  });
+
+  it("singularizes a lone fix", () => {
+    expect(formatImpactCounts(counts({ fix: 1, total: 1 }))).toBe("1 fix");
+  });
+
+  it("omits zero categories", () => {
+    expect(formatImpactCounts(counts({ feature: 2, total: 2 }))).toBe("2 new");
+  });
+
+  it("falls back to a bare change total when no category is set", () => {
+    expect(formatImpactCounts(counts({ total: 4 }))).toBe("4 changes");
+    expect(formatImpactCounts(counts({ total: 1 }))).toBe("1 change");
+  });
+});
+
+describe("formatChangeTotal", () => {
+  it("pluralizes the total", () => {
+    expect(formatChangeTotal(counts({ total: 0 }))).toBe("0 changes");
+    expect(formatChangeTotal(counts({ total: 1 }))).toBe("1 change");
+    expect(formatChangeTotal(counts({ total: 9 }))).toBe("9 changes");
+  });
+});

--- a/apps/web/lib/self-upgrade/impact/format.ts
+++ b/apps/web/lib/self-upgrade/impact/format.ts
@@ -1,0 +1,35 @@
+// apps/web/lib/self-upgrade/impact/format.ts
+//
+// Presentation helpers for the upgrade impact summary, shared by the
+// "What's in this update?" panel (UpgradeImpactPanel) and the Latest Run card
+// (SelfUpgradeClient). Kept framework-agnostic (plain string in, plain string
+// out) so both a client component and a server action can call it.
+
+import type { ImpactCategoryCounts } from "./types";
+
+/**
+ * Human-readable one-line scope ribbon for a set of impact counts, e.g.
+ * "1 breaking · 5 new · 2 perf · 3 fixes". Falls back to a bare change count
+ * ("12 changes") when no category has a non-zero tally. This is the plain-words
+ * answer to "how big is this upgrade?" that a raw SHA pair never gave.
+ */
+export function formatImpactCounts(counts: ImpactCategoryCounts): string {
+  const parts: string[] = [];
+  if (counts.breaking > 0) parts.push(`${counts.breaking} breaking`);
+  if (counts.feature > 0) parts.push(`${counts.feature} new`);
+  if (counts.performance > 0) parts.push(`${counts.performance} perf`);
+  if (counts.fix > 0) parts.push(`${counts.fix} fix${counts.fix === 1 ? "" : "es"}`);
+  if (counts.other > 0) parts.push(`${counts.other} other`);
+  if (parts.length === 0) {
+    return `${counts.total} change${counts.total === 1 ? "" : "s"}`;
+  }
+  return parts.join(" · ");
+}
+
+/**
+ * "12 changes" prefix for the ribbon — the total commit/change count carried by
+ * the upgrade, which directly answers "how many things moved?".
+ */
+export function formatChangeTotal(counts: ImpactCategoryCounts): string {
+  return `${counts.total} change${counts.total === 1 ? "" : "s"}`;
+}

--- a/apps/web/lib/self-upgrade/impact/index.test.ts
+++ b/apps/web/lib/self-upgrade/impact/index.test.ts
@@ -9,21 +9,28 @@ vi.mock("@/lib/self-upgrade/completion", () => ({
 
 // Mock the durable store so the orchestrator tests stay DB-free; store.ts has
 // its own test for the prisma interaction.
-const { persistSummaryMock, getPersistedSummaryMock, getPersistedSummaryRowMock } =
-  vi.hoisted(() => ({
-    persistSummaryMock: vi.fn(),
-    getPersistedSummaryMock: vi.fn(),
-    getPersistedSummaryRowMock: vi.fn(),
-  }));
+const {
+  persistSummaryMock,
+  getPersistedSummaryMock,
+  getPersistedSummaryByIdMock,
+  getPersistedSummaryRowMock,
+} = vi.hoisted(() => ({
+  persistSummaryMock: vi.fn(),
+  getPersistedSummaryMock: vi.fn(),
+  getPersistedSummaryByIdMock: vi.fn(),
+  getPersistedSummaryRowMock: vi.fn(),
+}));
 vi.mock("./store", () => ({
   persistSummary: (...a: unknown[]) => persistSummaryMock(...a),
   getPersistedSummary: (...a: unknown[]) => getPersistedSummaryMock(...a),
+  getPersistedSummaryById: (...a: unknown[]) => getPersistedSummaryByIdMock(...a),
   getPersistedSummaryRow: (...a: unknown[]) => getPersistedSummaryRowMock(...a),
 }));
 
 import {
   summarizeUpgradeImpact,
   loadPersistedImpactSummary,
+  loadRunImpactDigest,
   getCurrentImpactSummaryId,
 } from "./index";
 import { _resetCacheForTest } from "./cache";
@@ -35,6 +42,7 @@ beforeEach(() => {
   // Defaults: nothing persisted, writes succeed. Individual tests override.
   persistSummaryMock.mockResolvedValue("UIS-1");
   getPersistedSummaryMock.mockResolvedValue(null);
+  getPersistedSummaryByIdMock.mockResolvedValue(null);
   getPersistedSummaryRowMock.mockResolvedValue(null);
 });
 
@@ -316,6 +324,53 @@ describe("loadPersistedImpactSummary", () => {
       loadCurrentLineageSha: async () => "a".repeat(40),
     });
     expect(out).toBeNull();
+  });
+});
+
+describe("loadRunImpactDigest", () => {
+  it("returns counts + headline from the run's own summary id", async () => {
+    getPersistedSummaryByIdMock.mockResolvedValue(
+      storedSummary({
+        counts: { breaking: 1, feature: 5, fix: 3, performance: 0, other: 0, total: 9 },
+        phrased: {
+          headline: "Nine changes, one breaking.",
+          itemPhrasings: [],
+          touchesCustomizationsCallout: "",
+        },
+      }),
+    );
+    const out = await loadRunImpactDigest("UIS-42");
+    expect(getPersistedSummaryByIdMock).toHaveBeenCalledWith("UIS-42");
+    expect(out).toEqual({
+      counts: { breaking: 1, feature: 5, fix: 3, performance: 0, other: 0, total: 9 },
+      headline: "Nine changes, one breaking.",
+    });
+  });
+
+  it("returns a null headline when phrasing was skipped", async () => {
+    getPersistedSummaryByIdMock.mockResolvedValue(storedSummary({ phrased: null }));
+    const out = await loadRunImpactDigest("UIS-1");
+    expect(out?.headline).toBeNull();
+    expect(out?.counts.total).toBe(1);
+  });
+
+  it("returns a null headline when the phrased headline is blank", async () => {
+    getPersistedSummaryByIdMock.mockResolvedValue(
+      storedSummary({
+        phrased: { headline: "   ", itemPhrasings: [], touchesCustomizationsCallout: "" },
+      }),
+    );
+    expect((await loadRunImpactDigest("UIS-1"))?.headline).toBeNull();
+  });
+
+  it("returns null for a run that recorded no summary (null id)", async () => {
+    expect(await loadRunImpactDigest(null)).toBeNull();
+    expect(getPersistedSummaryByIdMock).not.toHaveBeenCalled();
+  });
+
+  it("degrades to null when the store read throws", async () => {
+    getPersistedSummaryByIdMock.mockRejectedValue(new Error("db down"));
+    expect(await loadRunImpactDigest("UIS-1")).toBeNull();
   });
 });
 

--- a/apps/web/lib/self-upgrade/impact/index.ts
+++ b/apps/web/lib/self-upgrade/impact/index.ts
@@ -15,7 +15,12 @@ import { getDeployedSha } from "@/lib/self-upgrade/completion";
 import { getSelfUpgradeConfig } from "@/lib/self-upgrade/config";
 import { resolveTargetSha } from "@/lib/self-upgrade/version";
 import { cacheKey, getCached, setCached } from "./cache";
-import { getPersistedSummary, getPersistedSummaryRow, persistSummary } from "./store";
+import {
+  getPersistedSummary,
+  getPersistedSummaryById,
+  getPersistedSummaryRow,
+  persistSummary,
+} from "./store";
 import { collectChangeSet } from "./change-set";
 import { collectInstallSignals } from "./install-signals";
 import { parseCommits } from "./conventional";
@@ -26,6 +31,7 @@ import { phraseSummary } from "./phrase";
 import {
   DEFAULT_TOP_N,
   type InstallSignals,
+  type RunImpactDigest,
   type SummaryResult,
   type UpgradeImpactSummary,
 } from "./types";
@@ -236,6 +242,23 @@ export async function loadPersistedImpactSummary(
   );
   if (!summary) return null;
   return { ok: true, summary: { ...summary, fromCache: true } };
+}
+
+/**
+ * Compact impact digest for the Latest Run card — the human-readable "what did
+ * this run carry?" the raw SHA pair never gave. Loaded by the run's OWN
+ * `impactSummaryId` (the summary the operator reviewed at launch), not by a
+ * (lineage, target) re-derivation, so it stays correct for a completed run even
+ * after the upstream target has advanced past that run's endpoints.
+ */
+export async function loadRunImpactDigest(
+  impactSummaryId: string | null | undefined,
+): Promise<RunImpactDigest | null> {
+  if (!impactSummaryId) return null;
+  const summary = await getPersistedSummaryById(impactSummaryId).catch(() => null);
+  if (!summary) return null;
+  const headline = summary.phrased?.headline?.trim();
+  return { counts: summary.counts, headline: headline ? headline : null };
 }
 
 /**

--- a/apps/web/lib/self-upgrade/impact/store.ts
+++ b/apps/web/lib/self-upgrade/impact/store.ts
@@ -30,6 +30,22 @@ export async function getPersistedSummary(
 }
 
 /**
+ * Read the persisted summary by its row id, or null. A SelfUpgradeRun records
+ * the summary it carried via `impactSummaryId`, so the run card can show
+ * exactly the changes THIS run applied — no (lineage, target) re-derivation,
+ * which would drift once the upstream target advances past the run's endpoints.
+ */
+export async function getPersistedSummaryById(
+  id: string,
+): Promise<UpgradeImpactSummary | null> {
+  const row = await prisma.upgradeImpactSummary.findUnique({
+    where: { id },
+    select: { summary: true },
+  });
+  return (row?.summary as UpgradeImpactSummary | undefined) ?? null;
+}
+
+/**
  * Read the persisted row id + summary for a pair — used to attach a
  * SelfUpgradeRun to the summary the operator reviewed. Null when none exists.
  */

--- a/apps/web/lib/self-upgrade/impact/types.ts
+++ b/apps/web/lib/self-upgrade/impact/types.ts
@@ -77,6 +77,18 @@ export type ImpactCategoryCounts = {
 };
 
 /**
+ * Compact impact digest for the Latest Run card — the human-readable "what did
+ * this run carry?" the raw SHA pair never gave. Assembled server-side from the
+ * run's own persisted summary; kept minimal so it serializes cleanly into the
+ * client component. See `loadRunImpactDigest` in ./index.
+ */
+export type RunImpactDigest = {
+  counts: ImpactCategoryCounts;
+  /** LLM one-line headline, or null when phrasing was skipped/empty. */
+  headline: string | null;
+};
+
+/**
  * Signals about THIS install used to score relevance of each upstream commit.
  *
  * These are intentionally narrow and observable from live DB state — no

--- a/docs/superpowers/decisions/2026-07-15-self-upgrade-run-card-human-readable-scope.md
+++ b/docs/superpowers/decisions/2026-07-15-self-upgrade-run-card-human-readable-scope.md
@@ -1,0 +1,63 @@
+# Self-Upgrade Latest Run card — human-readable upgrade scope
+
+**Date:** 2026-07-15
+**Surface:** `/ops/self-upgrade` → Latest Run card (`apps/web/components/ops/SelfUpgradeClient.tsx`)
+**Kernel decision:** DI-59CB13916826 (interactionId), profile `mark-dpf-platform`
+
+## Problem
+
+The Latest Run card rendered the upgrade as two raw 40-char git SHAs
+(`currentSha → targetSha`) with no human framing. An operator could not tell how
+big or how risky a run was — the identifiers meant nothing on sight. There was
+"no version" because a self-upgrade run is addressed commit-to-commit and the
+target commit is usually not a tagged release, so the SHA pair was the only thing
+the card reached for.
+
+Meanwhile the substrate to answer "how big?" already existed but was not on the
+card:
+
+- **Release version** — `platformVersion.version` (git-describe SemVer) already
+  flows into the same status payload and renders as the *current* platform
+  version at the top of the page. It describes where the install *is*, not what
+  a run moves between.
+- **Impact summary** — `UpgradeImpactSummary` (the "What's in this update?"
+  panel) already computes an LLM headline and a counts ribbon
+  (breaking / new / perf / fix + total). A `SelfUpgradeRun` even records the
+  exact summary it carried via `impactSummaryId`.
+
+## Decision
+
+Surface the scope **on the run card itself**, in human terms:
+
+1. Shorten the SHA pair (12 chars + ellipsis, full value on hover `title`),
+   framed `Change: <from> → <to>` — precise identity, secondary.
+2. Lead with the run's plain-language **headline** when recorded.
+3. Show a **scope ribbon** — `N changes · 1 breaking · 5 new · 3 fixes` — drawn
+   from the run's own impact summary, colored destructive when any change is
+   breaking (the risk signal an operator most needs).
+
+The digest is loaded by the run's own `impactSummaryId`
+(`loadRunImpactDigest` → `getPersistedSummaryById`), **not** by a
+(lineage, target) re-derivation — so a completed run keeps showing the changes
+*it* applied even after the upstream target advances past its endpoints.
+
+A tag-pair version string (e.g. `5.5.2 → 5.6.0`) was **not** adopted: tags for
+arbitrary run SHAs are not reliably resolvable at runtime in a deployed image,
+and fabricating one would violate Never-Fabricate. The commit count + category
+breakdown is the honest, grounded "how big?" answer.
+
+## Kernel consultation
+
+`principle_decide` (DI-59CB13916826) scored a minimal option (short SHAs +
+version/commit-count only) against the full option (also surface the counts
+ribbon). Result: **full** (composite 2.806 vs 2.430, margin 0.376, strong
+structured coverage, no commandment conflict). The evidence-density axis pulled
+the decision toward putting the scope ribbon on the card rather than leaving the
+run identified by SHAs alone.
+
+## Scope of change (no contract change)
+
+- Extended the impact module (shared `formatImpactCounts`, `loadRunImpactDigest`,
+  `getPersistedSummaryById`, `RunImpactDigest` type). Reused by the existing
+  panel and the run card.
+- Display-only. No schema change, no new route, no new operator control.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -6,8 +6,8 @@ apps/web/components/agent/AgentCoworkerPanel.tsx	1260
 apps/web/components/agent/AgentMessageInput.tsx	1034
 apps/web/components/ea/EaCanvas.tsx	1047
 apps/web/components/inventory/TopologyGraph.tsx	1031
-apps/web/components/ops/SelfUpgradeClient.test.tsx	997
-apps/web/components/ops/SelfUpgradeClient.tsx	1377
+apps/web/components/ops/SelfUpgradeClient.test.tsx	1070
+apps/web/components/ops/SelfUpgradeClient.tsx	1422
 apps/web/components/platform/AiOperationsMap.tsx	2849
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
@@ -26,8 +26,8 @@ apps/web/lib/actions/crm.ts	1423
 apps/web/lib/actions/ea.ts	1055
 apps/web/lib/actions/mcp-tokens.test.ts	1254
 apps/web/lib/actions/platform-dev-config.ts	1331
-apps/web/lib/actions/promotions.self-upgrade.test.ts	1021
-apps/web/lib/actions/promotions.ts	997
+apps/web/lib/actions/promotions.self-upgrade.test.ts	1022
+apps/web/lib/actions/promotions.ts	948
 apps/web/lib/actions/tax-remittance.test.ts	1080
 apps/web/lib/actions/tax-remittance.ts	1788
 apps/web/lib/ai-operations-map/load-map-data.test.ts	943


### PR DESCRIPTION
## Why

The Self-Upgrade **Latest Run** card showed an upgrade as two raw 40-char git SHAs (`15909971…d86 → 32a92036…dbb4`) with no human framing. An operator had no way to tell how big or how risky a run was. There was effectively "no version" because a self-upgrade run is addressed *commit-to-commit* and a target commit is usually not a tagged release — the SHA pair was the only thing the card reached for.

The substrate to answer *"how big?"* already existed but wasn't on the card:
- **Impact summary** (`UpgradeImpactSummary`) — the "What's in this update?" panel already computes an LLM headline + a counts ribbon (breaking/new/fix + total), and each `SelfUpgradeRun` records the exact summary it carried via `impactSummaryId`.

## What changed

The Latest Run card now describes scope in human terms (all display-only):

1. **Short SHAs**, framed `Change: <from> → <to>`, with the full 40-char value preserved on hover (`title`). Run History SHAs shortened to match.
2. **Plain-language headline** when the run recorded one.
3. **Scope ribbon** — `N changes · 1 breaking · 5 new · 3 fixes` — from the run's *own* impact summary, colored destructive when anything is breaking (the risk signal an operator most needs).

The digest loads by the run's `impactSummaryId` (`loadRunImpactDigest` → `getPersistedSummaryById`), **not** by a `(lineage, target)` re-derivation — so a completed run keeps showing the changes *it* applied even after the upstream target advances past its endpoints. `countsLine` was extracted to a shared `formatImpactCounts` reused by both the panel and the card.

### Not done, deliberately
No tag-pair version string (e.g. `5.5.2 → 5.6.0`): tags for arbitrary run SHAs are not reliably resolvable at runtime in a deployed image, and fabricating one would violate **Never-Fabricate**. Commit count + category breakdown is the honest, grounded answer.

## Governance
- **Kernel decision `DI-59CB13916826`** — scored minimal vs full scope; recommended **full** (composite 2.806 vs 2.430, margin 0.376, strong coverage, no commandment conflict) on the evidence-density axis.
- **Backlog:** BI-57E57347
- **Decision doc:** `docs/superpowers/decisions/2026-07-15-self-upgrade-run-card-human-readable-scope.md`

## Verification
- `apps/web` typecheck: **0 errors** (`tsc --noEmit`, 8 GB).
- Touched vitest suites green (impact `format` / `index` / store, `UpgradeImpactPanel`, `SelfUpgradeClient`, self-upgrade `page`): 126 tests.
- New tests assert the rendered DOM (`renderToStaticMarkup`): headline, ribbon text + destructive color, SHA truncation with full-value `title`, and the no-summary/no-breaking fallbacks.
- Live-portal UX verification was blocked at authoring time (the install was quiescing for an in-flight self-upgrade); the component render tests exercise the real render path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
