### PR TITLE
fix(seed): tolerate Agent_slugId_key P2002 in coworker seed (BI-3073F13B)

### DIFF
--- a/packages/db/src/coworker-agent-upsert.test.ts
+++ b/packages/db/src/coworker-agent-upsert.test.ts
@@ -1,0 +1,130 @@
+// packages/db/src/coworker-agent-upsert.test.ts
+//
+// Regression test for BI-3073F13B: the coworker-agent seed upsert keys on
+// agentId but writes the @unique slugId in its create branch, so a new agentId
+// re-using an existing slugId throws P2002 and (outside a transaction) aborts
+// the whole coworker seed. upsertCoworkerAgentTolerant must:
+//   (a) pass through a normal upsert unchanged,
+//   (b) on a slugId P2002, re-resolve the canonical row by slugId and update it,
+//   (c) NOT swallow non-P2002 errors,
+//   (d) re-throw a P2002 that resolves to no slug owner (a different constraint).
+
+import { describe, it, expect } from "vitest";
+import { upsertCoworkerAgentTolerant } from "./coworker-agent-upsert";
+import type { PrismaClient, Prisma } from "../generated/client/client";
+
+type UpsertFn = (args: Prisma.AgentUpsertArgs) => Promise<{ id: string; agentId: string }>;
+type FindFirstFn = (args: {
+  where: { slugId: string };
+  select: { id: true; agentId: true };
+}) => Promise<{ id: string; agentId: string } | null>;
+type UpdateFn = (args: {
+  where: { id: string };
+  data: unknown;
+}) => Promise<{ id: string; agentId: string }>;
+
+function buildClient(opts: {
+  upsert: UpsertFn;
+  findFirst?: FindFirstFn;
+  update?: UpdateFn;
+}): PrismaClient {
+  return {
+    agent: {
+      upsert: opts.upsert,
+      findFirst: opts.findFirst ?? (async () => null),
+      update: opts.update ?? (async () => ({ id: "unused", agentId: "unused" })),
+    },
+  } as unknown as PrismaClient;
+}
+
+const p2002 = () =>
+  Object.assign(new Error("Unique constraint failed"), {
+    code: "P2002",
+    meta: { target: ["slugId"] },
+  });
+
+const args = (agentId: string, slugId: string): Prisma.AgentUpsertArgs =>
+  ({
+    where: { agentId },
+    create: { agentId, slugId, kind: "specialist" },
+    update: { slugId, name: `${agentId}-name` },
+  }) as unknown as Prisma.AgentUpsertArgs;
+
+describe("upsertCoworkerAgentTolerant", () => {
+  it("passes a normal upsert through unchanged (outcome=upserted)", async () => {
+    let upsertCalls = 0;
+    const client = buildClient({
+      upsert: async () => {
+        upsertCalls++;
+        return { id: "agent-1", agentId: "AGT-NEW" };
+      },
+    });
+
+    const result = await upsertCoworkerAgentTolerant(client, "coo", args("AGT-NEW", "coo"));
+
+    expect(result).toEqual({ id: "agent-1", agentId: "AGT-NEW", outcome: "upserted" });
+    expect(upsertCalls).toBe(1);
+  });
+
+  it("re-resolves by slugId and updates the canonical row on a slugId P2002 (BI-3073F13B)", async () => {
+    // AGT-NEW re-uses slugId "coo" already held by AGT-OLD (id agent-old).
+    let findFirstArgs: Parameters<FindFirstFn>[0] | null = null;
+    let updateArgs: Parameters<UpdateFn>[0] | null = null;
+    const client = buildClient({
+      upsert: async () => {
+        throw p2002();
+      },
+      findFirst: async (a) => {
+        findFirstArgs = a;
+        return { id: "agent-old", agentId: "AGT-OLD" };
+      },
+      update: async (a) => {
+        updateArgs = a;
+        return { id: "agent-old", agentId: "AGT-OLD" };
+      },
+    });
+
+    const result = await upsertCoworkerAgentTolerant(client, "coo", args("AGT-NEW", "coo"));
+
+    expect(result).toEqual({
+      id: "agent-old",
+      agentId: "AGT-OLD",
+      outcome: "reresolved_slug_collision",
+    });
+    // Resolved the winner by the colliding slug, and applied the new coworker's
+    // update fields to that canonical row (no duplicate, no crash).
+    expect(findFirstArgs!.where).toEqual({ slugId: "coo" });
+    expect(updateArgs!.where).toEqual({ id: "agent-old" });
+    expect(updateArgs!.data).toMatchObject({ slugId: "coo", name: "AGT-NEW-name" });
+  });
+
+  it("re-throws non-P2002 errors so genuine failures surface", async () => {
+    const client = buildClient({
+      upsert: async () => {
+        throw Object.assign(new Error("connection lost"), { code: "P1001" });
+      },
+    });
+
+    await expect(
+      upsertCoworkerAgentTolerant(client, "coo", args("AGT-NEW", "coo")),
+    ).rejects.toThrow(/connection lost/);
+  });
+
+  it("re-throws a P2002 that resolves to no slug owner (a different unique)", async () => {
+    let findFirstCalls = 0;
+    const client = buildClient({
+      upsert: async () => {
+        throw p2002();
+      },
+      findFirst: async () => {
+        findFirstCalls++;
+        return null; // no agent holds this slug -> not the slug collision -> surface it
+      },
+    });
+
+    await expect(
+      upsertCoworkerAgentTolerant(client, "ghost", args("AGT-NEW", "ghost")),
+    ).rejects.toMatchObject({ code: "P2002" });
+    expect(findFirstCalls).toBe(1);
+  });
+});

--- a/packages/db/src/coworker-agent-upsert.ts
+++ b/packages/db/src/coworker-agent-upsert.ts
@@ -1,0 +1,76 @@
+// packages/db/src/coworker-agent-upsert.ts
+//
+// BI-3073F13B: seedCoworkerAgents upserts each coworker Agent keyed on
+// `agentId`, but the create branch writes `slugId`, which carries its own
+// `@unique` (Agent_slugId_key). When a NEW agentId re-uses a slugId already held
+// by a DIFFERENT agentId (a rename / re-registration), the upsert misses on
+// agentId, takes the create path, and the slugId unique throws P2002 — which,
+// because seedCoworkerAgents runs OUTSIDE a transaction, propagates and aborts
+// the rest of the boot seed. This is the exact failure class already hardened
+// for the geographic seeds (seedRegionOnce / seedCityOnce, BI-E4E21A7F: an
+// unguarded seed P2002 crashed mid-run and downstream seeds never executed).
+//
+// Recovery: on the slugId collision, re-resolve the canonical row BY slugId and
+// apply the coworker's update fields to it. The established slug identity is
+// canonical — most surfaces FK Agent by slug (CoworkerService.providerAgentId,
+// hive scout task, agent-model-defaults), and the AI Workforce roster already
+// collapses dual-seed twins via dropDualSeedAliasAgents (BI-74FD6420). So one
+// slugId keeps exactly one row, the coworker's latest data is applied, and the
+// seed never crashes. Anything that is NOT a resolvable slug collision is
+// re-thrown, so genuine bugs still surface.
+
+import type { PrismaClient, Prisma } from "../generated/client/client";
+
+export type CoworkerAgentUpsertOutcome = "upserted" | "reresolved_slug_collision";
+
+export interface CoworkerAgentUpsertResult {
+  id: string;
+  agentId: string;
+  outcome: CoworkerAgentUpsertOutcome;
+}
+
+/** True when err is a Prisma P2002 unique-constraint violation. */
+function isP2002(err: unknown): boolean {
+  return (err as { code?: string } | null)?.code === "P2002";
+}
+
+/**
+ * Idempotently upsert one coworker Agent, tolerating the Agent_slugId_key
+ * collision that arises when a new agentId re-uses an existing slugId. See the
+ * file header (BI-3073F13B). Mirrors seedRegionOnce/seedCityOnce: try the write,
+ * and on P2002 re-resolve the winning row rather than aborting the whole seed.
+ * Never throws on a resolvable slugId collision; re-throws everything else.
+ */
+export async function upsertCoworkerAgentTolerant(
+  client: PrismaClient,
+  slugId: string,
+  args: Prisma.AgentUpsertArgs,
+): Promise<CoworkerAgentUpsertResult> {
+  try {
+    const agent = await client.agent.upsert(args);
+    return { id: agent.id, agentId: agent.agentId, outcome: "upserted" };
+  } catch (err: unknown) {
+    // Prisma P2002 = unique-constraint violation. Anything else re-throws.
+    if (!isP2002(err)) throw err;
+    // The create branch collided on the slugId unique (a different agentId
+    // already holds this slug). Re-resolve the canonical slug row and apply this
+    // coworker's fields to it, so the seed stays complete without a duplicate
+    // slug and without crashing the boot.
+    const existing = await client.agent.findFirst({
+      where: { slugId },
+      select: { id: true, agentId: true },
+    });
+    // A P2002 that does not resolve to a slug owner is a different constraint —
+    // surface it rather than swallowing a genuine bug.
+    if (!existing) throw err;
+    const updated = await client.agent.update({
+      where: { id: existing.id },
+      data: args.update,
+    });
+    return {
+      id: updated.id,
+      agentId: updated.agentId,
+      outcome: "reresolved_slug_collision",
+    };
+  }
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -6,6 +6,7 @@ import { prisma } from "./client.js";
 import { Prisma } from "../generated/client/client";
 import { parseRoleId, parseAgentTier, parseAgentType, parseAgentPortfolioSlug } from "./seed-helpers.js";
 import { resolveAgentIdentity } from "./agent-identity.js";
+import { upsertCoworkerAgentTolerant } from "./coworker-agent-upsert.js";
 import { loadFingerprintCatalogIntoDb, defaultCatalogPath } from "./discovery-fingerprint-catalog-loader.js";
 import { seedEaArchimate4 } from "./seed-ea-archimate4.js";
 import { seedEaBpmn20 } from "./seed-ea-bpmn20.js";
@@ -1044,7 +1045,12 @@ async function seedCoworkerAgents(): Promise<void> {
     // (BI-74FD6420) until a full FK migration lands.
     const { agentId, slugId, ...rest } = cw;
     const identity = resolveAgentIdentity({ agentId, name: rest.name, slugId, displayName: rest.name });
-    const agent = await prisma.agent.upsert({
+    // BI-3073F13B: this upsert keys on agentId but its create branch writes the
+    // @unique slugId, so a new agentId re-using an existing slugId throws P2002
+    // and (outside a transaction) aborts the whole coworker seed. Tolerate it:
+    // on a slugId collision, re-resolve the canonical slug row and apply this
+    // coworker's fields to it instead of crashing.
+    const agent = await upsertCoworkerAgentTolerant(prisma, slugId, {
       where: { agentId },
       create: { agentId, slugId, displayName: identity.displayName, kind: identity.kind, ...rest, lifecycleStage: "production" },
       update: {
@@ -1061,6 +1067,11 @@ async function seedCoworkerAgents(): Promise<void> {
         lifecycleStage: "production",
       },
     });
+    if (agent.outcome === "reresolved_slug_collision") {
+      console.warn(
+        `[seed-coworker] slugId "${slugId}" already held by another agent; applied ${agentId}'s fields to the canonical slug row instead of crashing (BI-3073F13B).`,
+      );
+    }
 
     const grants = HARDCODED_COWORKER_GRANTS[agentId];
     if (grants) {


### PR DESCRIPTION
## What & why

`seedCoworkerAgents` upserts each coworker Agent keyed on `agentId`, but its **create** branch writes the `@unique` `slugId`. When a new `agentId` re-uses a `slugId` already held by a different `agentId` (a rename / re-registration), the upsert misses on `agentId`, takes the create path, and the `slugId` unique throws **P2002** — which, because the loop runs **outside a transaction**, aborts the entire coworker seed and everything downstream in the boot seed.

This is the exact failure class already hardened for the geographic seeds (`seedRegionOnce` / `seedCityOnce`, BI-E4E21A7F). It surfaced as a large pile of deferred `BI-PIR` (`Agent_slugId_key` violation) reports that had **no tracked open item** — filed as **BI-3073F13B** during a triage of the deferred PIR backlog.

## The fix

Extract an idempotent, P2002-tolerant helper `upsertCoworkerAgentTolerant` (`packages/db/src/coworker-agent-upsert.ts`). On a `slugId` collision it re-resolves the canonical row **by slugId** and applies the coworker's fields to it — the established slug identity is canonical (what `CoworkerService.providerAgentId` / hive scout / `agent-model-defaults` FK, and the AI Workforce roster already collapses dual-seed twins via `dropDualSeedAliasAgents`, BI-74FD6420). One `slugId` keeps one row, the coworker's data is applied, and the seed never crashes. Non-P2002 errors and a P2002 with no resolvable slug owner still surface.

## Verification

- New unit test `coworker-agent-upsert.test.ts` — mocks the P2002 throw (no real DB), covering: normal upsert, collision re-resolve, non-P2002 re-throw, unresolved-slug re-throw. **4/4 pass.**
- Full local suite: **16,236 tests pass** (incl. this test); `@dpf/db` typecheck clean; `apps/web` typecheck clean; integration image builds.
- Pushed with the documented pre-push override because the local pregate is **environment-blocked** (root is a shallow clone → `local-integration-ci` fails on `HEAD^{tree}`; `apps/web` typecheck OOMs at the default heap). Both are runner-env issues, not this change. CI runs the authoritative full-clone check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)