### PR TITLE
fix(monitoring): retire BET-5 Qdrant/Neo4j scrape jobs and alerts (BI-31FDC859, BI-49C4EA5D)

### DIFF
--- a/apps/web/components/monitoring/alert-humanize.test.ts
+++ b/apps/web/components/monitoring/alert-humanize.test.ts
@@ -55,6 +55,13 @@ describe("humanizeHealthAlert", () => {
     expect(h.title).toBe("new-service is offline");
     expect(h.explanation).toContain("won't work until it's back");
   });
+
+  it("does not claim a live knowledge-graph outage for retired Neo4jDown (BI-49C4EA5D)", () => {
+    const h = humanizeHealthAlert(alert({ alertname: "Neo4jDown", severity: "critical" }));
+    expect(h.title).toMatch(/retired|Stale/i);
+    expect(h.explanation).toMatch(/Postgres/i);
+    expect(h.title).not.toBe("The knowledge graph is down");
+  });
 });
 
 describe("friendlyServiceName", () => {

--- a/apps/web/components/monitoring/alert-humanize.ts
+++ b/apps/web/components/monitoring/alert-humanize.ts
@@ -40,10 +40,12 @@ const SERVICE_DOWN_IMPACT: Record<string, string> = {
   portal: "The web portal is not responding — most of the platform is unavailable.",
   sandbox: "Builds and AI coworker development work can't run until it's back.",
   postgres: "The platform database is unreachable — most features will fail.",
-  qdrant: "AI memory and semantic search lookups will fail.",
+  // BET-5 retired Qdrant/Neo4j services — keep keys only so a stale scrape/label
+  // never invents a "knowledge graph down" consequence after decommission.
+  qdrant: "Legacy vector-DB label (retired) — memory lives in Postgres/pgvector.",
   inngest: "Background jobs and scheduled coworker work are paused.",
   redis: "Work queues and caching are unavailable.",
-  neo4j: "The knowledge graph is unavailable.",
+  neo4j: "Legacy graph-DB label (retired) — graph mirror lives in Postgres.",
   adp: "Document processing is unavailable.",
   "dev-portal": "The contributor preview (a contributor-only surface) is down.",
   prometheus: "Health monitoring itself is down — alert data may be stale.",
@@ -106,13 +108,18 @@ const ALERT_TRANSLATIONS: Record<string, AlertTranslation> = {
     title: () => "The database is nearly out of connections",
     explanation: () => "If connections run out, pages and coworkers will start failing.",
   },
+  // QdrantDown / Neo4jDown retired with BET-5 (BI-31FDC859 / BI-49C4EA5D) —
+  // rules removed from alerts.yml; if a stale alert still arrives, do not
+  // restate a phantom "knowledge graph" failure as current platform state.
   QdrantDown: {
-    title: () => "AI memory search is down",
-    explanation: () => SERVICE_DOWN_IMPACT.qdrant,
+    title: () => "Stale memory-search alert (Qdrant was retired)",
+    explanation: () =>
+      "Qdrant is no longer part of the install — memory and vectors live in Postgres. This alert should clear after monitoring reloads.",
   },
   Neo4jDown: {
-    title: () => "The knowledge graph is down",
-    explanation: () => SERVICE_DOWN_IMPACT.neo4j,
+    title: () => "Stale graph alert (Neo4j was retired)",
+    explanation: () =>
+      "Neo4j is no longer part of the install — the graph mirror lives in Postgres. This alert should clear after monitoring reloads.",
   },
   ModelRunnerDown: {
     title: () => "Local AI is unavailable",

--- a/apps/web/components/monitoring/prometheus-config.test.ts
+++ b/apps/web/components/monitoring/prometheus-config.test.ts
@@ -18,6 +18,24 @@ describe("Prometheus substrate configs", () => {
     expect(config).not.toContain('targets: ["node-exporter:9100"]');
   });
 
+  it("does not scrape retired BET-5 services qdrant/neo4j (BI-31FDC859)", () => {
+    for (const name of [
+      "prometheus.yml",
+      "prometheus.dev.yml",
+      "prometheus.linux.yml",
+      "prometheus.macos.yml",
+    ]) {
+      const config = readPrometheusConfig(name);
+      // Active scrape jobs only — commented historical neo4j blocks may remain.
+      expect(config, name).not.toMatch(/^\s*-\s*job_name:\s*"qdrant"/m);
+      expect(config, name).not.toContain('targets: ["qdrant:6333"]');
+      expect(config, name).not.toMatch(/^\s*-\s*job_name:\s*"neo4j"/m);
+    }
+    const alerts = readPrometheusConfig("alerts.yml");
+    expect(alerts).not.toMatch(/^\s*-\s*alert:\s*QdrantDown/m);
+    expect(alerts).not.toMatch(/^\s*-\s*alert:\s*Neo4jDown/m);
+  });
+
   it("keeps Linux exporter scrape targets in the Linux config", () => {
     const config = readPrometheusConfig("prometheus.linux.yml");
 

--- a/apps/web/components/portfolio/PlatformHealthStrip.tsx
+++ b/apps/web/components/portfolio/PlatformHealthStrip.tsx
@@ -30,10 +30,10 @@ const INITIAL: HealthState = {
   criticalAlerts: 0,
 };
 
+// BET-5: Qdrant/Neo4j retired — memory/graph are Postgres (BI-31FDC859).
 const SERVICE_JOBS = [
   { name: "Portal", job: "portal" },
   { name: "PostgreSQL", job: "postgres" },
-  { name: "Qdrant", job: "qdrant" },
   { name: "AI Inference", job: "model-runner" },
 ];
 

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -98,28 +98,6 @@ groups:
         annotations:
           summary: "PostgreSQL is unreachable"
 
-      - alert: QdrantDown
-        expr: up{job="qdrant"} == 0
-        for: 1m
-        labels:
-          severity: critical
-        annotations:
-          summary: "Qdrant vector DB is unreachable -- AI Coworker memory offline"
-
-      # neo4j exposes no Prometheus metrics, so it cannot be a scrape target;
-      # the portal probes its HTTP API and exports dpf_dependency_up{service}. [BI-963DBB05]
-      - alert: Neo4jDown
-        expr: dpf_dependency_up{service="neo4j"} == 0
-        for: 1m
-        labels:
-          severity: critical
-        annotations:
-          summary: "Neo4j graph DB is unreachable -- code graph + architecture views offline"
-
-      # model-runner + stt have no /metrics; the portal probes them into
-      # dpf_dependency_up{service}. Gate on "was up in the last 6h" so these never
-      # false-fire on installs that don't run a local model runner / STT (e.g. a
-      # cloud install) -- only alert when a previously-working service drops. [BI-963DBB05]
       - alert: ModelRunnerDown
         expr: dpf_dependency_up{service="model-runner"} == 0 and max_over_time(dpf_dependency_up{service="model-runner"}[6h]) == 1
         for: 5m

--- a/monitoring/prometheus/prometheus.dev.yml
+++ b/monitoring/prometheus/prometheus.dev.yml
@@ -26,12 +26,6 @@ scrape_configs:
     static_configs:
       - targets: ["postgres-exporter:9187"]
 
-  - job_name: "qdrant"
-    scrape_interval: 30s
-    static_configs:
-      - targets: ["qdrant:6333"]
-    metrics_path: /metrics
-
   # ─── Application (live) ─────────────────────────────────────
   - job_name: "portal"
     static_configs:

--- a/monitoring/prometheus/prometheus.linux.yml
+++ b/monitoring/prometheus/prometheus.linux.yml
@@ -31,12 +31,6 @@ scrape_configs:
   #     - targets: ["neo4j:2004"]
   #   metrics_path: /metrics
 
-  - job_name: "qdrant"
-    scrape_interval: 30s
-    static_configs:
-      - targets: ["qdrant:6333"]
-    metrics_path: /metrics
-
   # ─── Application ────────────────────────────────────────────
   - job_name: "portal"
     static_configs:

--- a/monitoring/prometheus/prometheus.macos.yml
+++ b/monitoring/prometheus/prometheus.macos.yml
@@ -39,12 +39,6 @@ scrape_configs:
   #     - targets: ["neo4j:2004"]
   #   metrics_path: /metrics
 
-  - job_name: "qdrant"
-    scrape_interval: 30s
-    static_configs:
-      - targets: ["qdrant:6333"]
-    metrics_path: /metrics
-
   # ─── Application ────────────────────────────────────────────
   - job_name: "portal"
     static_configs:

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -24,12 +24,6 @@ scrape_configs:
   #     - targets: ["neo4j:2004"]
   #   metrics_path: /metrics
 
-  - job_name: "qdrant"
-    scrape_interval: 30s
-    static_configs:
-      - targets: ["qdrant:6333"]
-    metrics_path: /metrics
-
   # ─── Application ────────────────────────────────────────────
   - job_name: "portal"
     static_configs:


### PR DESCRIPTION
## Summary
- Remove `qdrant` scrape jobs from all Prometheus configs.
- Remove `QdrantDown` / `Neo4jDown` alert rules.
- Platform health strip no longer shows Qdrant.
- Stale alerts humanize as **retired** (Postgres owns memory/graph).

Resolves **BI-31FDC859**, **BI-49C4EA5D**, and monitoring half of **BI-2B70C92C**.

## Test plan
- [x] `vitest` prometheus-config + alert-humanize → 18 passed

Process-Spine-Decision: operational cleanup of retired services; config tests gate the scrape/alert surface.

Design-Grounding-Decision: reviewed BET-5 retirement + CoworkerHealthStatus postgres memory signal; localized monitoring config + humanize.

Local-CI-Override: vitest prometheus-config + alert-humanize 18/18; full CI on push.