### PR TITLE
fix(discovery): dedupe InventoryRelationship upserts by resolved tuple to stop in-run P2002 (BI-PIR-7d69a445)

### DIFF
--- a/packages/db/src/discovery-sync.test.ts
+++ b/packages/db/src/discovery-sync.test.ts
@@ -309,4 +309,122 @@ describe("persistBootstrapDiscoveryRun", () => {
 
     expect(createdObservedKeys).toEqual(["duplicate:item"]);
   });
+
+  it("upserts one InventoryRelationship per resolved tuple when distinct keys collapse (BI-PIR-7d69a445)", async () => {
+    // Two inventory entities share the SAME entityKey ("host:shared") but arrive
+    // under DIFFERENT discovered keys ("dk:a" / "dk:b"), so entity resolution
+    // maps both discovered keys onto the same persisted entity id. Two
+    // relationships with DISTINCT relationshipKeys ("rel:k1" / "rel:k2") therefore
+    // collapse onto the same (fromEntityId, toEntityId, relationshipType) tuple.
+    // Before the fix the second one took the create path and violated the compound
+    // @@unique (P2002, aborting the whole $transaction). The dedup must upsert the
+    // InventoryRelationship exactly once, while EACH relationship still records its
+    // own DiscoveredRelationship provenance row linked to the shared row.
+    const relationshipUpsertKeys: string[] = [];
+    const discoveredRelationshipCreates: Array<{ relationshipKey: string; connectId: string }> = [];
+
+    const db = {
+      $transaction: async <T>(fn: (tx: any) => Promise<T>): Promise<T> => fn({
+        discoveryRun: { create: async () => ({ id: "run-3" }) },
+        inventoryEntity: {
+          findMany: async () => [],
+          upsert: async ({ where }: { where: { entityKey: string } }) => ({
+            id: `entity:${where.entityKey}`,
+            entityKey: where.entityKey,
+          }),
+          updateMany: async () => ({ count: 0 }),
+        },
+        discoveredItem: {
+          create: async ({ data }: { data: { observedKey: string } }) => ({
+            id: `discovered:${data.observedKey}`,
+          }),
+        },
+        discoveredSoftwareEvidence: { upsert: async () => ({}) },
+        inventoryRelationship: {
+          findMany: async () => [],
+          upsert: async ({ where }: { where: { relationshipKey: string } }) => {
+            relationshipUpsertKeys.push(where.relationshipKey);
+            return { id: `relationship:${where.relationshipKey}`, relationshipKey: where.relationshipKey };
+          },
+          updateMany: async () => ({ count: 0 }),
+        },
+        discoveredRelationship: {
+          create: async ({ data }: { data: { relationshipKey: string; inventoryRelationship: { connect: { id: string } } } }) => {
+            discoveredRelationshipCreates.push({
+              relationshipKey: data.relationshipKey,
+              connectId: data.inventoryRelationship.connect.id,
+            });
+            return {};
+          },
+        },
+        portfolioQualityIssue: { findMany: async () => [], upsert: async () => ({}) },
+      }),
+    };
+
+    const entity = (discoveredKey: string, entityKey: string) => ({
+      entityKey,
+      entityType: "host",
+      name: entityKey,
+      discoveredKey,
+      portfolioSlug: "foundational",
+      taxonomyNodeId: "foundational/compute/servers",
+      attributionStatus: "attributed" as const,
+      attributionMethod: "rule" as const,
+      attributionConfidence: 0.98,
+      providerView: "foundational",
+      properties: {},
+    });
+    const item = (discoveredKey: string) => ({
+      discoveredKey,
+      sourceKind: "dpf_bootstrap",
+      itemType: "host",
+      name: discoveredKey,
+      externalRef: discoveredKey,
+      attributes: {},
+    });
+
+    await persistBootstrapDiscoveryRun(
+      db,
+      {
+        discoveredItems: [item("dk:a"), item("dk:b"), item("dk:c")],
+        inventoryEntities: [
+          entity("dk:a", "host:shared"),
+          entity("dk:b", "host:shared"),
+          entity("dk:c", "runtime:target"),
+        ],
+        inventoryRelationships: [
+          {
+            relationshipKey: "rel:k1",
+            relationshipType: "hosts",
+            fromDiscoveredKey: "dk:a",
+            toDiscoveredKey: "dk:c",
+            properties: {},
+          },
+          {
+            relationshipKey: "rel:k2",
+            relationshipType: "hosts",
+            fromDiscoveredKey: "dk:b",
+            toDiscoveredKey: "dk:c",
+            properties: {},
+          },
+        ],
+        softwareEvidence: [],
+      },
+      { runKey: "run-3", sourceSlug: "dpf_bootstrap" },
+      {
+        projectInventoryEntity: async () => undefined,
+        projectInventoryRelationship: async () => undefined,
+      },
+    );
+
+    // The colliding tuple was upserted exactly once (the second relationship
+    // reused it instead of taking the crashing create path)...
+    expect(relationshipUpsertKeys).toEqual(["rel:k1"]);
+    // ...but BOTH relationships kept their own provenance row, linked to the one
+    // shared InventoryRelationship.
+    expect(discoveredRelationshipCreates).toEqual([
+      { relationshipKey: "rel:k1", connectId: "relationship:rel:k1" },
+      { relationshipKey: "rel:k2", connectId: "relationship:rel:k1" },
+    ]);
+  });
 });

--- a/packages/db/src/discovery-sync.ts
+++ b/packages/db/src/discovery-sync.ts
@@ -173,6 +173,23 @@ function dedupeDiscoveredItems(
   return [...byKey.values()];
 }
 
+/**
+ * Stable key for an InventoryRelationship's persisted-identity tuple
+ * (fromEntityId, toEntityId, relationshipType) — the columns of the compound
+ * `@@unique([fromEntityId, toEntityId, relationshipType])`. Used to dedupe
+ * relationships within a single persistence run so two distinct relationshipKeys
+ * that resolve to the same persisted tuple upsert the row once (BI-PIR-7d69a445).
+ * The `|` separator cannot appear in cuid ids (alphanumeric) or relationship-type
+ * slugs, so the composed key is unambiguous.
+ */
+export function relationshipTupleKey(
+  fromEntityId: string,
+  toEntityId: string,
+  relationshipType: string,
+): string {
+  return `${fromEntityId}|${toEntityId}|${relationshipType}`;
+}
+
 export function summarizeDiscoveryPersistence(
   summary: Partial<DiscoveryPersistenceSummary>,
 ): DiscoveryPersistenceSummary {
@@ -465,6 +482,12 @@ export async function persistBootstrapDiscoveryRun(
 
     let createdRelationships = 0;
     let updatedRelationships = 0;
+    // BI-PIR-7d69a445: within a single run, maps each resolved relationship tuple
+    // (fromEntityId, toEntityId, relationshipType) to the InventoryRelationship id
+    // already upserted for it, so a second relationship that collapses onto the
+    // same tuple under a DIFFERENT relationshipKey reuses that row instead of
+    // taking the create path and violating the compound @@unique.
+    const persistedRelationshipIdByTuple = new Map<string, string>();
 
     for (const relationship of normalized.inventoryRelationships) {
       const fromEntityId = relationship.fromDiscoveredKey
@@ -484,47 +507,76 @@ export async function persistBootstrapDiscoveryRun(
         continue;
       }
 
-      const existed = existingRelationshipKeys.has(relationship.relationshipKey);
-      const persistedRelationship = await tx.inventoryRelationship.upsert({
-        where: { relationshipKey: relationship.relationshipKey },
-        create: {
-          relationshipKey: relationship.relationshipKey,
-          relationshipType: relationship.relationshipType,
-          status: "active",
-          confidence: relationship.confidence ?? null,
-          properties: relationship.properties,
-          scopeKey: runScope.scopeKey,
-          customerAccount: runScope.customerAccountId
-            ? { connect: { id: runScope.customerAccountId } }
-            : undefined,
-          customerSite: runScope.customerSiteId
-            ? { connect: { id: runScope.customerSiteId } }
-            : undefined,
-          firstSeenAt: now,
-          lastSeenAt: now,
-          lastConfirmedRun: { connect: { id: run.id } },
-          fromEntity: { connect: { id: fromEntityId } },
-          toEntity: { connect: { id: toEntityId } },
-        },
-        update: {
-          relationshipType: relationship.relationshipType,
-          status: "active",
-          confidence: relationship.confidence ?? null,
-          properties: relationship.properties,
-          scopeKey: runScope.scopeKey,
-          customerAccount: runScope.customerAccountId
-            ? { connect: { id: runScope.customerAccountId } }
-            : { disconnect: true },
-          customerSite: runScope.customerSiteId
-            ? { connect: { id: runScope.customerSiteId } }
-            : { disconnect: true },
-          lastSeenAt: now,
-          lastConfirmedRun: { connect: { id: run.id } },
-          fromEntity: { connect: { id: fromEntityId } },
-          toEntity: { connect: { id: toEntityId } },
-        },
-        select: { id: true, relationshipKey: true },
-      });
+      // BI-PIR-7d69a445: entity dedup can map two distinct discovered refs onto
+      // one persisted entity id, so two relationships with DISTINCT
+      // relationshipKeys can resolve to the SAME (fromEntityId, toEntityId,
+      // relationshipType) tuple. The upsert's conflict target is relationshipKey,
+      // so the second one misses, takes the create path, and violates the compound
+      // @@unique — a P2002 that (inside this $transaction) aborts the entire
+      // persistence run. Reuse the row already upserted for this tuple in the
+      // current run rather than re-entering the create path. The
+      // DiscoveredRelationship below is still written for every relationship, so
+      // each source key keeps its own provenance row linked to the shared
+      // InventoryRelationship. (Cross-run collisions, where the tuple was
+      // persisted by a PRIOR run under a different relationshipKey, still need a
+      // canonical-key decision — tracked on BI-PIR-7d69a445.)
+      const tupleKey = relationshipTupleKey(
+        fromEntityId,
+        toEntityId,
+        relationship.relationshipType,
+      );
+      let persistedRelationshipId = persistedRelationshipIdByTuple.get(tupleKey);
+      if (!persistedRelationshipId) {
+        const existed = existingRelationshipKeys.has(relationship.relationshipKey);
+        const persistedRelationship = await tx.inventoryRelationship.upsert({
+          where: { relationshipKey: relationship.relationshipKey },
+          create: {
+            relationshipKey: relationship.relationshipKey,
+            relationshipType: relationship.relationshipType,
+            status: "active",
+            confidence: relationship.confidence ?? null,
+            properties: relationship.properties,
+            scopeKey: runScope.scopeKey,
+            customerAccount: runScope.customerAccountId
+              ? { connect: { id: runScope.customerAccountId } }
+              : undefined,
+            customerSite: runScope.customerSiteId
+              ? { connect: { id: runScope.customerSiteId } }
+              : undefined,
+            firstSeenAt: now,
+            lastSeenAt: now,
+            lastConfirmedRun: { connect: { id: run.id } },
+            fromEntity: { connect: { id: fromEntityId } },
+            toEntity: { connect: { id: toEntityId } },
+          },
+          update: {
+            relationshipType: relationship.relationshipType,
+            status: "active",
+            confidence: relationship.confidence ?? null,
+            properties: relationship.properties,
+            scopeKey: runScope.scopeKey,
+            customerAccount: runScope.customerAccountId
+              ? { connect: { id: runScope.customerAccountId } }
+              : { disconnect: true },
+            customerSite: runScope.customerSiteId
+              ? { connect: { id: runScope.customerSiteId } }
+              : { disconnect: true },
+            lastSeenAt: now,
+            lastConfirmedRun: { connect: { id: run.id } },
+            fromEntity: { connect: { id: fromEntityId } },
+            toEntity: { connect: { id: toEntityId } },
+          },
+          select: { id: true, relationshipKey: true },
+        });
+        persistedRelationshipId = persistedRelationship.id;
+        persistedRelationshipIdByTuple.set(tupleKey, persistedRelationshipId);
+
+        if (existed) {
+          updatedRelationships += 1;
+        } else {
+          createdRelationships += 1;
+        }
+      }
 
       await tx.discoveredRelationship.create({
         data: {
@@ -535,15 +587,9 @@ export async function persistBootstrapDiscoveryRun(
           toDiscoveredItem: { connect: { id: toDiscoveredItemId } },
           confidence: relationship.confidence ?? null,
           rawData: relationship.properties,
-          inventoryRelationship: { connect: { id: persistedRelationship.id } },
+          inventoryRelationship: { connect: { id: persistedRelationshipId } },
         },
       });
-
-      if (existed) {
-        updatedRelationships += 1;
-      } else {
-        createdRelationships += 1;
-      }
     }
 
     const currentRelationshipKeys = new Set(


### PR DESCRIPTION
## What & why

`persistBootstrapDiscoveryRun` upserts each `InventoryRelationship` keyed on `relationshipKey`. But entity dedup can map two **distinct** discovered refs onto **one** persisted entity id — so two relationships carrying different `relationshipKey`s resolve to the **same** `(fromEntityId, toEntityId, relationshipType)` tuple. The second misses on `relationshipKey`, takes the create path, and violates the compound `@@unique([fromEntityId, toEntityId, relationshipType])` → **P2002**, which (inside the persistence `$transaction`) aborts the entire discovery-sync run.

Diagnosed and tracked as **BI-PIR-7d69a445**; the diagnosis notes this fires *deterministically within a single run*.

## The fix (part 1 of the diagnosis — the safe, no-schema-decision part)

Dedupe by the **resolved tuple** within the run:
- New exported `relationshipTupleKey(fromEntityId, toEntityId, relationshipType)` — keyed on the columns of the compound unique.
- A per-run `Map<tupleKey, persistedId>`: the first relationship for a tuple upserts the `InventoryRelationship`; later colliding keys **reuse** its id instead of re-entering the create path.
- Every relationship still writes its own `DiscoveredRelationship` provenance row, linked to the shared `InventoryRelationship` — no provenance is lost, no row is folded.

This is a **prevention**, not a catch-P2002 (which the diagnosis correctly notes can't compose inside an interactive `$transaction` without savepoints).

## Scope / what's deliberately left

This fixes the **deterministic in-run** collision. **Cross-run** collisions — where the tuple was persisted by a *prior* run under a different `relationshipKey` — change identity semantics (stale-sweep and `DiscoveredRelationship` linkage are keyed on `relationshipKey`) and need a **canonical-unique-key decision**. That remains tracked on **BI-PIR-7d69a445** and is intentionally not decided here.

## Verification

- New regression test in `discovery-sync.test.ts` — two entities sharing an `entityKey` under different discovered keys, two relationships with distinct `relationshipKey`s collapsing to one tuple. Asserts **exactly one** `inventoryRelationship.upsert` and **two** `discoveredRelationship.create`s both linked to the shared row. **discovery-sync suite 4/4 pass.**
- `@dpf/db` typecheck clean.
- Pushed with the documented pre-push override (local pregate env-blocked: shared shallow-clone object store fails `local-integration-ci` `HEAD^{tree}`; `apps/web` typecheck OOMs at default heap — both runner-env, not this change). CI runs the authoritative full-clone check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)