### PR TITLE
chore(monitoring): finish BET-5 health-UI decommission left by #3050 (BI-2B70C92C)

### DIFF
--- a/apps/web/components/monitoring/ServiceStatusGrid.tsx
+++ b/apps/web/components/monitoring/ServiceStatusGrid.tsx
@@ -14,7 +14,7 @@ type Props = {
   // Optional override — callers can still pass their own service list (the
   // legacy hardcoded shape). When omitted, the grid uses the targets-driven
   // path: one tile per active scrape target, plus the canonical
-  // UNSCRAPED_SERVICES (Neo4j, AI Inference, Voice STT) appended.
+  // UNSCRAPED_SERVICES (AI Inference, Voice STT) appended.
   services?: ServiceDefinition[];
   className?: string;
 };
@@ -98,8 +98,7 @@ function Grid({
 export const DPF_SERVICES: ServiceDefinition[] = [
   { name: "Portal", job: "portal" },
   { name: "PostgreSQL", job: "postgres" },
-  { name: "Neo4j", statusHint: "Not scraped" },
-  { name: "Qdrant", job: "qdrant" },
+  // BET-5 retired Neo4j + Qdrant (Postgres-only) — tiles removed (BI-2B70C92C).
   { name: "AI Inference", statusHint: "Portal metrics" },
   { name: "Sandbox", job: "sandbox" },
   { name: "Inngest", job: "inngest" },

--- a/apps/web/components/monitoring/health-summary.test.ts
+++ b/apps/web/components/monitoring/health-summary.test.ts
@@ -95,20 +95,20 @@ describe("derivePlatformSummary", () => {
     const summary = derivePlatformSummary({
       checked: true,
       online: true,
-      // qdrant absent entirely (not in upTargets) => missing/unknown, not down.
-      upTargets: [up("prometheus"), up("portal"), up("postgres"), up("sandbox")],
+      // sandbox absent entirely (not in upTargets) => missing/unknown, not down.
+      upTargets: [up("prometheus"), up("portal"), up("postgres")],
       alerts: [],
     });
 
     expect(summary.value).toBe("Degraded");
-    expect(summary.detail).toBe("AI memory & search is not reporting");
+    expect(summary.detail).toBe("Build workspace is not reporting");
   });
 });
 
 describe("friendlyJobLabel / humanizeJobList", () => {
   it("maps known jobs to plain-language labels", () => {
     expect(friendlyJobLabel("postgres")).toBe("Database");
-    expect(friendlyJobLabel("qdrant")).toBe("AI memory & search");
+    expect(friendlyJobLabel("inngest")).toBe("Background jobs");
     expect(friendlyJobLabel("sandbox")).toBe("Build workspace");
   });
 

--- a/apps/web/components/monitoring/health-summary.ts
+++ b/apps/web/components/monitoring/health-summary.ts
@@ -110,7 +110,8 @@ type ServiceStatusInput = {
   offline: boolean;
 };
 
-const PLATFORM_REQUIRED_JOBS = ["portal", "postgres", "qdrant", "sandbox"];
+// BET-5: qdrant retired (Postgres-only), so it's no longer a required job.
+const PLATFORM_REQUIRED_JOBS = ["portal", "postgres", "sandbox"];
 const TELEMETRY_JOBS = ["node-exporter", "cadvisor"];
 const TELEMETRY_JOB_SET = new Set(TELEMETRY_JOBS);
 // Host-hardware telemetry exporters, one per substrate (Windows / Linux).
@@ -323,7 +324,6 @@ export const JOB_PRESENTATION: Record<string, JobPresentation> = {
   portal: { name: "Portal" },
   sandbox: { name: "Sandbox" },
   postgres: { name: "PostgreSQL" },
-  qdrant: { name: "Qdrant" },
   inngest: { name: "Inngest" },
   redis: { name: "Redis" },
   adp: { name: "ADP" },
@@ -346,8 +346,6 @@ const PLATFORM_SERVICE_LABEL: Record<string, string> = {
   portal: "Web portal",
   sandbox: "Build workspace",
   postgres: "Database",
-  qdrant: "AI memory & search",
-  neo4j: "Knowledge graph",
   inngest: "Background jobs",
   redis: "Queues & cache",
   adp: "Document processing",
@@ -376,14 +374,11 @@ export function humanizeJobList(jobs: string[]): string {
 }
 
 // Services that have no Prometheus scrape target but the user should still
-// see on the Health tab — either because they exist but ship without a
-// /metrics endpoint (Neo4j Community, whisper-server), or because they're
-// observable through a different channel (AI Inference + Voice STT both
-// flow through portal application metrics on /api/metrics, not their own
-// scrape job). These tiles render as neutral "Not scraped" / "Portal
-// metrics" — the same pattern the older hardcoded grid used for Neo4j.
+// see on the Health tab — because they're observable through a different
+// channel (AI Inference + Voice STT both flow through portal application
+// metrics on /api/metrics, not their own scrape job). These tiles render as
+// neutral "Portal metrics". (Neo4j was removed here by BET-5 — BI-2B70C92C.)
 export const UNSCRAPED_SERVICES: ServiceDefinition[] = [
-  { name: "Neo4j", statusHint: "Not scraped" },
   { name: "AI Inference", statusHint: "Portal metrics" },
   { name: "Voice STT", statusHint: "Portal metrics" },
 ];


### PR DESCRIPTION
## What
Finishes the BET-5 monitoring decommission (`BI-2B70C92C`) — the part **not** already covered by the concurrently-merged **#3050**.

**Collision note:** while this was in flight, #3050 ("retire BET-5 Qdrant/Neo4j scrape jobs and alerts") merged, covering the prometheus configs, `alerts.yml`, `alert-humanize.ts` (it kept the `QdrantDown`/`Neo4jDown` humanizer entries as defensive "retired" stubs — respected here), and the `PlatformHealthStrip` tile. I rebased this PR down to only the **non-overlapping remainder**.

**Regression #3050 introduced:** removing the qdrant scrape job while leaving `qdrant` in `PLATFORM_REQUIRED_JOBS` means `up{job="qdrant"}` now has no series → health-summary reports the required job as *missing* → **"Degraded: AI memory & search is not reporting"** on a healthy install. This PR fixes that.

## Changes (3 files, +12/−18)
- **`health-summary.ts`** — drop `qdrant` from `PLATFORM_REQUIRED_JOBS` (fixes the phantom "degraded"), and remove qdrant/neo4j from `JOB_PRESENTATION`, `PLATFORM_SERVICE_LABEL`, and `UNSCRAPED_SERVICES` (the Neo4j "Not scraped" tile).
- **`ServiceStatusGrid.tsx`** — remove the Neo4j + Qdrant tiles.
- **`health-summary.test.ts`** — the two cases that used qdrant as the example required/labelled service now use sandbox/inngest.

## Out of scope
Backup subsystem + legacy migration drivers (retained for migration).

## Tests
Monitoring suites green (45); `tsc --noEmit` clean (after Prisma regen for the concurrently-merged #3060); local-CI gate passed.

## Design grounding
Design-Grounding-Decision: specs/plans reviewed (source of truth: BET-5 Postgres-only retirement, BI-A1E864A5; reconciled with merged #3050) and code substrate reviewed in `apps/web/components/monitoring`. Trivial no-contract-change decommission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)