### PR TITLE
fix(db): reindex corrupt BacklogItem_itemId_key btree so MCP resolvers stop missing rows (BI-EB0E6727)

### DIFF
--- a/packages/db/prisma/migrations/20260715220000_reindex_backlog_itemid_unique/migration.sql
+++ b/packages/db/prisma/migrations/20260715220000_reindex_backlog_itemid_unique/migration.sql
@@ -1,0 +1,25 @@
+-- Rebuild the unique btree backing BacklogItem.itemId.
+--
+-- BI-EB0E6727: the "BacklogItem_itemId_key" btree became corrupt (an unclean
+-- shutdown / torn write). Equality lookups (WHERE "itemId" = $1) — which the
+-- backlog MCP resolvers issue via Prisma findUnique for get / update /
+-- update-status / retire / link / size — MISS ~45 rows that a sequential scan
+-- still returns, so those governance paths return not_found for ids that
+-- list_backlog_items happily lists.
+--
+-- Verified against the live index for a known-present itemId:
+--     WHERE "itemId" = $1            -> 0 rows  (index scan, corrupt)
+--     WHERE "itemId" LIKE $1         -> 0 rows  (index scan, corrupt)
+--     WHERE "itemId" IN ($1)         -> 0 rows  (index scan, corrupt)
+--     WHERE upper("itemId")=upper($1)-> 1 row   (sequential scan, correct)
+-- That divergence between index and heap is the classic signature of a corrupt
+-- btree; a code-level findFirst fallback cannot fix it because equality still
+-- routes through the same broken index.
+--
+-- REINDEX rebuilds the index in place from the heap. It restores correct
+-- equality lookups WITHOUT changing the schema (the index definition is
+-- unchanged, so Prisma sees no drift) and WITHOUT touching row data. On a
+-- healthy index it is a harmless no-op, so this migration is safe to apply in
+-- every environment. Non-CONCURRENT REINDEX is transaction-safe, which the
+-- Prisma migration runner requires.
+REINDEX INDEX "BacklogItem_itemId_key";


### PR DESCRIPTION
## What & why

The unique btree backing `BacklogItem.itemId` is **corrupt** (unclean shutdown / torn write). Equality lookups miss ~45 rows that a sequential scan still returns, so every backlog MCP path that resolves by `itemId` via Prisma `findUnique` — `get_backlog_item`, `update_backlog_item`, `update_backlog_item_status`, `retire_backlog_item`, `link_backlog_item_to_epic`, `size_backlog_item` — returns **not_found** for ids that `list_backlog_items` happily lists. This is the keystone tracking blocker behind **BI-EB0E6727**.

## Verified against the live index

For a known-present itemId:

| Predicate | Rows | Path |
|---|---|---|
| `WHERE "itemId" = $1` | **0** | index scan (corrupt) |
| `WHERE "itemId" LIKE $1` | **0** | index scan (corrupt) |
| `WHERE "itemId" IN ($1)` | **0** | index scan (corrupt) |
| `WHERE upper("itemId") = upper($1)` | **1** | sequential scan (correct) |

The divergence between index and heap is the classic corrupt-btree signature. Notably a code-level `findFirst({ where: { itemId } })` fallback would **not** help — equality still routes through the same broken index (only a function/seq-scan finds the rows).

## The fix

A maintenance migration that `REINDEX INDEX "BacklogItem_itemId_key"`:
- Rebuilds the btree in place from the heap → restores correct equality lookups.
- **No schema change** (index definition unchanged → no Prisma drift), **no row-data change**.
- **Harmless no-op** on a healthy index → safe to apply in every environment.
- Non-`CONCURRENT` REINDEX is transaction-safe, which the Prisma migration runner requires.

Shipping it as a governed migration (rather than a manual prod `REINDEX`) makes the fix durable across installs and applies it through the normal deploy (`prisma migrate deploy`), so the operator retains control over exactly when it lands on prod.

## Verification / notes

- Index name + definition confirmed via `pg_indexes`; corruption signature confirmed via the probe above.
- Pre-commit migration safety guard passed (no unattested tightening).
- This does not auto-apply on the running portal (self-upgrade skips migrations); it applies on the next `prisma migrate deploy`. Until then, the `/ops` grid (which resolves by the working cuid PK) remains the closure path for the affected items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)