### PR TITLE
feat(delivery-flow): collaborative estimation UX — AI proposes, human confirm/overrule, reconcile (EP-DELIVERY-FLOW BI-AA1763CD)

### DIFF
--- a/apps/web/components/ops/DemandBoard.estimate.test.tsx
+++ b/apps/web/components/ops/DemandBoard.estimate.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import "@/components/build-studio/test-setup";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EstimateControls } from "./DemandBoard";
+import type { DemandItemView } from "@/lib/demand/board";
+
+// Opt this file into React's act() environment so state updates from the
+// useTransition flush cleanly (silences the "not configured to support act" warning).
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Mock the governed server action — the test verifies the control→action wiring
+// and the state→control branching, not the server round-trip (covered by the
+// record_effort_estimate pack + estimate-provenance unit tests).
+const recordEstimate = vi.fn(async (_input: unknown) => ({ ok: true as const, message: "ok", data: {} }));
+vi.mock("@/lib/actions/demand-estimate", () => ({
+  recordEstimate: (input: unknown) => recordEstimate(input),
+}));
+
+/** Click and flush the useTransition async so the mocked action settles. */
+async function click(name: RegExp) {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name }));
+  });
+}
+
+function item(partial: Partial<DemandItemView> & { itemId: string }): DemandItemView {
+  return {
+    title: partial.itemId,
+    status: "open",
+    workType: "feature",
+    epicId: null,
+    demandStage: "screened",
+    demandScore: 5,
+    demandScoreFramework: "rice",
+    effortSize: "medium",
+    jobSize: 3,
+    impact: 2,
+    investmentBucket: "grow",
+    estimateAiJobSize: null,
+    estimateHumanJobSize: null,
+    estimateSource: null,
+    estimateAgreed: null,
+    claimStatus: null,
+    claimedByAgentId: null,
+    ...partial,
+  };
+}
+
+describe("EstimateControls", () => {
+  beforeEach(() => recordEstimate.mockClear());
+
+  it("with no estimate yet, offers an AI first-pass and a manual set", () => {
+    render(<EstimateControls item={item({ itemId: "A" })} />);
+    expect(screen.getByRole("button", { name: /✨ AI estimate/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /✎ estimate/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Confirm/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the AI first-pass when the item has no effort size to project from", () => {
+    render(<EstimateControls item={item({ itemId: "A", effortSize: null })} />);
+    expect(screen.queryByRole("button", { name: /AI estimate/i })).not.toBeInTheDocument();
+  });
+
+  it("requests an AI first-pass with by=ai when 'AI estimate' is clicked", async () => {
+    render(<EstimateControls item={item({ itemId: "A" })} />);
+    await click(/✨ AI estimate/i);
+    expect(recordEstimate).toHaveBeenCalledWith({ itemId: "A", by: "ai" });
+  });
+
+  it("on an AI-proposed estimate, offers Confirm (adopt) and Overrule", async () => {
+    render(<EstimateControls item={item({ itemId: "B", estimateAiJobSize: 8, estimateSource: "ai" })} />);
+    expect(screen.getByText(/est 8 · AI \(proposed\)/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Overrule/i })).toBeInTheDocument();
+    await click(/Confirm/i);
+    expect(recordEstimate).toHaveBeenCalledWith({ itemId: "B", by: "human", agree: true });
+  });
+
+  it("on divergence, offers Use-AI and Keep-mine reconcile actions", async () => {
+    render(
+      <EstimateControls
+        item={item({ itemId: "C", estimateAiJobSize: 8, estimateHumanJobSize: 3, estimateAgreed: false })}
+      />,
+    );
+    expect(screen.getByText(/AI 8 ↔ you 3/)).toBeInTheDocument();
+    await click(/Use AI 8/i);
+    expect(recordEstimate).toHaveBeenCalledWith({ itemId: "C", by: "human", agree: true });
+    await click(/Keep 3/i);
+    expect(recordEstimate).toHaveBeenCalledWith({ itemId: "C", by: "human", jobSize: 3, agree: true });
+  });
+
+  it("overrule opens an input and submits the typed human estimate", async () => {
+    render(<EstimateControls item={item({ itemId: "D", estimateAiJobSize: 8, estimateSource: "ai" })} />);
+    await click(/Overrule/i);
+    fireEvent.change(screen.getByLabelText(/Effort points/i), { target: { value: "5" } });
+    await click(/^Set$/i);
+    expect(recordEstimate).toHaveBeenCalledWith({ itemId: "D", by: "human", jobSize: 5, agree: undefined });
+  });
+});

--- a/apps/web/components/ops/DemandBoard.tsx
+++ b/apps/web/components/ops/DemandBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useTransition } from "react";
 import {
   buildValueEffortMatrix,
   groupByFunnelStage,
@@ -15,6 +15,7 @@ import type { ValueEffortQuadrant } from "@/lib/demand/scoring";
 import { bucketBalance, BUCKET_LABELS, computeBucketMix } from "@/lib/demand/buckets";
 import { groupByFlowLane, FLOW_LANE_LABELS, type FlowColumn } from "@/lib/demand/flow";
 import { resolveEstimateProvenance } from "@/lib/demand/estimate-provenance";
+import { recordEstimate } from "@/lib/actions/demand-estimate";
 
 const VALUE_BAND_LABEL: Record<ReturnType<typeof valueBand>, string> = {
   high: "High value",
@@ -37,38 +38,179 @@ const QUADRANT_TOKEN: Record<ValueEffortQuadrant, string> = {
   time_sink: "var(--dpf-warning)",
 };
 
+const ESTIMATE_SOURCE_LABEL: Record<string, string> = { ai: "AI", human: "human", agreed: "agreed" };
+
+/** Tiny inline text button used across the estimate controls. */
+function MiniButton({
+  onClick,
+  disabled,
+  title,
+  children,
+  tone = "accent",
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  title?: string;
+  children: React.ReactNode;
+  tone?: "accent" | "muted" | "success";
+}) {
+  const color =
+    tone === "success" ? "var(--dpf-success)" : tone === "muted" ? "var(--dpf-muted)" : "var(--dpf-accent)";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      className="rounded border px-1.5 py-0.5 text-[10px] font-medium disabled:opacity-40"
+      style={{ color, borderColor: color }}
+    >
+      {children}
+    </button>
+  );
+}
+
 /**
- * Estimate-provenance chip (EP-DELIVERY-FLOW). Shows WHOSE effort estimate the
- * value/effort score carries, and surfaces the ⇄ reconcile affordance when the AI
- * and human numbers still diverge. Display-only here — the interactive
- * confirm/overrule/reconcile flow is BI-AA1763CD. Returns null when no attributed
- * estimate exists yet (the plain effort line covers that case).
+ * Interactive collaborative-estimation controls (EP-DELIVERY-FLOW BI-AA1763CD).
+ * The effort estimate is the value/effort score's denominator; here it becomes a
+ * visible, attributed, collaborative act:
+ * - **AI proposes forward** — "AI estimate" records a first-pass (derived from the
+ *   intake effortSize) attributed to the coworker.
+ * - **Human confirm/overrule** — confirm adopts the AI number; overrule sets a
+ *   different one (the human number leads).
+ * - **Reconcile divergence** — when AI and human differ, "Use AI" / "Keep mine"
+ *   settle it; the score is provisional (⇄) until then.
+ * Writes through the governed recordEstimate action, which recomputes demandScore.
  */
-function EstimateChip({ item }: { item: DemandItemView }) {
+export function EstimateControls({ item }: { item: DemandItemView }) {
   const prov = resolveEstimateProvenance({
     aiJobSize: item.estimateAiJobSize,
     humanJobSize: item.estimateHumanJobSize,
     agreed: item.estimateAgreed,
   });
-  if (prov.source === null) return null;
-  if (prov.diverged) {
-    return (
+  const [pending, startTransition] = useTransition();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const run = (input: Parameters<typeof recordEstimate>[0]) =>
+    startTransition(async () => {
+      setError(null);
+      const res = await recordEstimate(input);
+      if (!res.ok) setError(res.error);
+      else {
+        setEditing(false);
+        setDraft("");
+      }
+    });
+
+  const submitHuman = (agree?: boolean) => {
+    const n = Number(draft);
+    if (!Number.isFinite(n) || n <= 0) {
+      setError("Enter effort points greater than 0.");
+      return;
+    }
+    run({ itemId: item.itemId, by: "human", jobSize: n, agree });
+  };
+
+  const editor = (
+    <span className="inline-flex items-center gap-1">
+      <input
+        type="number"
+        min={0}
+        step="any"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        placeholder="pts"
+        aria-label="Effort points"
+        className="w-12 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-1 py-0.5 text-[10px] text-[var(--dpf-text)]"
+      />
+      <MiniButton onClick={() => submitHuman()} disabled={pending} title="Set your estimate">
+        Set
+      </MiniButton>
+      <MiniButton
+        onClick={() => {
+          setEditing(false);
+          setError(null);
+        }}
+        disabled={pending}
+        tone="muted"
+        title="Cancel"
+      >
+        ✕
+      </MiniButton>
+    </span>
+  );
+
+  // Chip describing the resolved state.
+  const chip =
+    prov.source === null ? null : prov.diverged ? (
       <span
         className="rounded px-1.5 py-0.5 text-[10px] font-medium"
         style={{ color: "var(--dpf-warning)", borderColor: "var(--dpf-warning)" }}
         title="AI and human estimates diverge — reconcile to trust the score"
       >
-        ⇄ {item.estimateAiJobSize} ↔ {item.estimateHumanJobSize} · reconcile
+        ⇄ AI {item.estimateAiJobSize} ↔ you {item.estimateHumanJobSize}
+      </span>
+    ) : (
+      <span
+        className="rounded px-1.5 py-0.5 text-[10px] font-medium text-[var(--dpf-muted)]"
+        title={`Effort estimate: ${prov.effectiveJobSize} (${ESTIMATE_SOURCE_LABEL[prov.source] ?? prov.source})`}
+      >
+        est {prov.effectiveJobSize} · {ESTIMATE_SOURCE_LABEL[prov.source] ?? prov.source}
+        {prov.source === "ai" ? " (proposed)" : ""}
       </span>
     );
-  }
-  const SOURCE_LABEL: Record<string, string> = { ai: "AI", human: "human", agreed: "agreed" };
+
   return (
-    <span
-      className="rounded px-1.5 py-0.5 text-[10px] font-medium text-[var(--dpf-muted)]"
-      title={`Effort estimate: ${prov.effectiveJobSize} (${SOURCE_LABEL[prov.source] ?? prov.source})`}
-    >
-      est {prov.effectiveJobSize} · {SOURCE_LABEL[prov.source] ?? prov.source}
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {chip}
+      {editing ? (
+        editor
+      ) : prov.diverged ? (
+        <>
+          <MiniButton onClick={() => run({ itemId: item.itemId, by: "human", agree: true })} disabled={pending} tone="success" title="Adopt the AI estimate">
+            Use AI {item.estimateAiJobSize}
+          </MiniButton>
+          <MiniButton
+            onClick={() => run({ itemId: item.itemId, by: "human", jobSize: item.estimateHumanJobSize ?? 0, agree: true })}
+            disabled={pending}
+            title="Keep your estimate as the agreed one"
+          >
+            Keep {item.estimateHumanJobSize}
+          </MiniButton>
+        </>
+      ) : prov.source === "ai" ? (
+        <>
+          <MiniButton onClick={() => run({ itemId: item.itemId, by: "human", agree: true })} disabled={pending} tone="success" title="Confirm the AI estimate">
+            Confirm
+          </MiniButton>
+          <MiniButton onClick={() => setEditing(true)} disabled={pending} title="Set a different estimate">
+            Overrule
+          </MiniButton>
+        </>
+      ) : prov.source === null ? (
+        <>
+          {item.effortSize && (
+            <MiniButton onClick={() => run({ itemId: item.itemId, by: "ai" })} disabled={pending} tone="muted" title="Propose a first-pass estimate from the effort size">
+              ✨ AI estimate
+            </MiniButton>
+          )}
+          <MiniButton onClick={() => setEditing(true)} disabled={pending} title="Set the effort estimate">
+            ✎ estimate
+          </MiniButton>
+        </>
+      ) : (
+        <MiniButton onClick={() => setEditing(true)} disabled={pending} tone="muted" title="Revise the estimate">
+          ✎
+        </MiniButton>
+      )}
+      {pending && <span className="text-[10px] text-[var(--dpf-muted)]">…</span>}
+      {error && (
+        <span className="text-[10px] text-[var(--dpf-warning)]" title={error}>
+          {error.length > 40 ? `${error.slice(0, 40)}…` : error}
+        </span>
+      )}
     </span>
   );
 }
@@ -91,7 +233,7 @@ function DemandCard({ item }: { item: DemandItemView }) {
         <span className="text-[10px] text-[var(--dpf-muted)]">
           {item.effortSize ? `${item.effortSize} effort` : effort !== null ? `effort ${effort}` : "unsized"}
         </span>
-        <EstimateChip item={item} />
+        <EstimateControls item={item} />
         {item.claimStatus === "offered" && item.claimedByAgentId && (
           <span
             className="rounded px-1.5 py-0.5 text-[10px] font-medium"

--- a/apps/web/lib/actions/demand-estimate.ts
+++ b/apps/web/lib/actions/demand-estimate.ts
@@ -1,0 +1,87 @@
+"use server";
+
+// Collaborative-estimation write action (EP-DELIVERY-FLOW BI-AA1763CD). The
+// Delivery Flow board (a client component) calls this to record an attributed
+// effort estimate — an AI coworker's first-pass proposal, or a human's
+// confirm/overrule/reconcile — through the governed `record_effort_estimate`
+// MCP door. The tool resolves provenance, mirrors the effective estimate into
+// jobSize, and recomputes demandScore, so the agreed estimate feeds the score.
+//
+// Domain failures are RETURNED as values (never thrown): a thrown error is
+// stripped to a generic message in a prod "use server" bundle, so the card
+// could not tell the user why. Only the auth guard throws (framework contract).
+
+import { prisma } from "@dpf/db";
+import { revalidatePath } from "next/cache";
+import { requireCapability } from "@/lib/actions/shared/guards";
+import { executeTool } from "@/lib/mcp-tools";
+import { firstPassJobSize } from "@/lib/demand/estimate-provenance";
+
+// Not exported (a "use server" module may only export async functions); the
+// client infers this via Awaited<ReturnType<typeof recordEstimate>>.
+type EstimateActionResult =
+  | { ok: true; message: string; data: Record<string, unknown> }
+  | { ok: false; error: string };
+
+export type EstimateBy = "ai" | "human";
+
+/**
+ * Record an attributed effort estimate for a demand item.
+ *
+ * - `by:"ai"` with no `jobSize` derives the AI first-pass from the item's
+ *   t-shirt effortSize (server-authoritative), so "propose on arrival" needs no
+ *   client-side heuristic.
+ * - `by:"human"` sets/overrules with an explicit `jobSize`, or `agree:true`
+ *   confirms/adopts the current AI estimate (reconcile).
+ */
+export async function recordEstimate(input: {
+  itemId: string;
+  by: EstimateBy;
+  jobSize?: number;
+  agentId?: string;
+  agree?: boolean;
+}): Promise<EstimateActionResult> {
+  const { userId } = await requireCapability("manage_backlog");
+
+  const itemId = typeof input.itemId === "string" ? input.itemId.trim() : "";
+  if (!itemId) return { ok: false, error: "No item to estimate." };
+  if (input.by !== "ai" && input.by !== "human") {
+    return { ok: false, error: "Estimate source must be AI or human." };
+  }
+
+  const args: Record<string, unknown> = { itemId, by: input.by };
+  const explicitJobSize =
+    typeof input.jobSize === "number" && Number.isFinite(input.jobSize) && input.jobSize > 0
+      ? input.jobSize
+      : null;
+  if (explicitJobSize !== null) args["jobSize"] = explicitJobSize;
+  if (input.agree === true) args["agree"] = true;
+
+  if (input.by === "ai") {
+    // Derive the first-pass from the intake effort signal when no number given.
+    if (explicitJobSize === null) {
+      const item = await prisma.backlogItem.findUnique({
+        where: { itemId },
+        select: { effortSize: true },
+      });
+      if (!item) return { ok: false, error: `Item ${itemId} not found.` };
+      const derived = firstPassJobSize(item.effortSize);
+      if (derived === null) {
+        return { ok: false, error: "No effort size to base a first-pass AI estimate on — size the item first." };
+      }
+      args["jobSize"] = derived;
+    }
+    args["agentId"] = input.agentId ?? "first-pass";
+  }
+
+  const res = await executeTool("record_effort_estimate", args, userId, { routeContext: "/ops/demand" });
+  if (!res.success) {
+    return { ok: false, error: res.message ?? "Could not record the estimate." };
+  }
+  revalidatePath("/ops/demand");
+  return {
+    ok: true,
+    message: res.message ?? "Estimate recorded.",
+    data: (res.data as Record<string, unknown>) ?? {},
+  };
+}

--- a/apps/web/lib/demand/estimate-provenance.test.ts
+++ b/apps/web/lib/demand/estimate-provenance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveEstimateProvenance } from "./estimate-provenance";
+import { firstPassJobSize, resolveEstimateProvenance } from "./estimate-provenance";
 
 describe("resolveEstimateProvenance", () => {
   it("is unestimated when neither side has a number", () => {
@@ -76,5 +76,21 @@ describe("resolveEstimateProvenance", () => {
   it("never reports divergence when only one side has estimated", () => {
     expect(resolveEstimateProvenance({ aiJobSize: 8, agreed: false }).diverged).toBe(false);
     expect(resolveEstimateProvenance({ humanJobSize: 3 }).diverged).toBe(false);
+  });
+});
+
+describe("firstPassJobSize", () => {
+  it("projects the t-shirt effort size to the shared job-size points", () => {
+    expect(firstPassJobSize("small")).toBe(1);
+    expect(firstPassJobSize("medium")).toBe(3);
+    expect(firstPassJobSize("large")).toBe(8);
+    expect(firstPassJobSize("xlarge")).toBe(20);
+  });
+
+  it("returns null when there is no effort size to project from", () => {
+    expect(firstPassJobSize(null)).toBeNull();
+    expect(firstPassJobSize(undefined)).toBeNull();
+    expect(firstPassJobSize("")).toBeNull();
+    expect(firstPassJobSize("enormous")).toBeNull();
   });
 });

--- a/apps/web/lib/demand/estimate-provenance.ts
+++ b/apps/web/lib/demand/estimate-provenance.ts
@@ -18,6 +18,8 @@
 // Spec: docs/superpowers/specs/2026-07-12-delivery-flow-demand-backlog-unification-design.md
 // §"Collaborative estimation (the ÷ effort)".
 
+import { EFFORT_SIZE_TO_JOB_SIZE } from "./scoring";
+
 /**
  * Provenance of the EFFECTIVE effort estimate feeding demandScore.
  * - `ai`     — only an AI coworker has estimated (its first-pass proposal stands).
@@ -57,6 +59,18 @@ export type EstimateProvenance = {
 
 function num(v: number | null | undefined): number | null {
   return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * The AI coworker's first-pass effort estimate — derived from the t-shirt
+ * `effortSize` signal already captured at intake — so a coworker can propose an
+ * estimate forward the moment an item lands, before any human has weighed in.
+ * Returns null when the item has no effortSize to project from (nothing to
+ * propose; a human sets the first number). EP-DELIVERY-FLOW BI-AA1763CD.
+ */
+export function firstPassJobSize(effortSize: string | null | undefined): number | null {
+  if (effortSize && effortSize in EFFORT_SIZE_TO_JOB_SIZE) return EFFORT_SIZE_TO_JOB_SIZE[effortSize];
+  return null;
 }
 
 /**

--- a/docs/superpowers/specs/2026-07-12-delivery-flow-demand-backlog-unification-design.md
+++ b/docs/superpowers/specs/2026-07-12-delivery-flow-demand-backlog-unification-design.md
@@ -40,7 +40,7 @@ Same `BacklogItem`; `demandStage`/`status`/scoring inputs/`demandScore`/`investm
 1. **BI-E731A6C1** — estimate **provenance + agreement** facets on `BacklogItem` (human/AI/agreed/divergent), additive nullable, feeds `demandScore`. *(write-model first — **built**, see below)*
 2. **BI-1DE21746** — the **Delivery Flow surface**: funnel→bet→board, two visual languages, one-item-two-faces, nav collapse to one Flow with lens sub-views.
 3. **BI-A6648529** — **AI-led volunteering**: funding the bet triggers a proactive coworker to self-task/claim → advance status; governed per proactivity.
-4. **BI-AA1763CD** — **collaborative estimation UX**: AI proposes on arrival, human confirm/overrule, reconcile divergence.
+4. **BI-AA1763CD** — **collaborative estimation UX**: AI proposes on arrival, human confirm/overrule, reconcile divergence. *(**built**, see below)*
 
 Mockup (private): the Delivery Flow board with the funnel, the amber "bet · a coworker volunteers" gate, estimate chips (AI/human/agreed/diverge), and the AI-led-execution callout.
 
@@ -51,6 +51,14 @@ The estimate is the score's `jobSize` denominator; `jobSize` stays the effective
 - **Pure resolver** `apps/web/lib/demand/estimate-provenance.ts` — `resolveEstimateProvenance({aiJobSize, humanJobSize, agreed})` returns `{effectiveJobSize, source, diverged, agreed}`. Rules: a human number overrules an AI number (humans lead and decide); `agreed` when a human confirms or both numbers are identical; `diverged` only when both sides estimated, the numbers differ, and they are not agreed (the `⇄ reconcile` state). Unit-tested.
 - **Governed write door** `record_effort_estimate` (demand-scoring pack, `backlog_write`): `{itemId, by: "ai"|"human", jobSize?, agentId?, agree?}`. Records the attributed estimate, resolves provenance, mirrors the effective estimate into `jobSize`, and recomputes `demandScore` under the active framework — so the agreed estimate feeds the score. `by=human, agree=true` confirms/adopts the current AI estimate.
 - **Read exposure:** `DemandItemView` + `getDemandItems` now carry `estimateAiJobSize` / `estimateHumanJobSize` / `estimateSource` / `estimateAgreed` for the surface (BI-1DE21746) and estimation UX (BI-AA1763CD) to render the estimate chip and reconcile affordance.
+
+## Collaborative estimation UX as built (BI-AA1763CD)
+Makes the phase-1 write-model interactive on the Delivery Flow card (`DemandBoard.tsx` → `EstimateControls`), writing through a governed action.
+
+- **Server action** `apps/web/lib/actions/demand-estimate.ts` `recordEstimate({itemId, by, jobSize?, agentId?, agree?})` — `manage_backlog`-gated, dispatches the `record_effort_estimate` MCP door, `revalidatePath("/ops/demand")`. Domain failures are returned as values (a thrown error is stripped in a prod "use server" bundle). `by:"ai"` with no `jobSize` derives the first-pass server-side from the item's `effortSize`.
+- **AI proposes forward** — `firstPassJobSize(effortSize)` (pure, in `estimate-provenance.ts`) projects the intake t-shirt size to points; the "✨ AI estimate" control records it attributed to the coworker (`first-pass`), so a proposal exists the moment an item lands.
+- **Human confirm/overrule** — an AI-proposed estimate shows `est N · AI (proposed)` with **Confirm** (adopts the AI number, `agreed`) and **Overrule** (inline input → the human number leads).
+- **Reconcile divergence** — when AI and human differ the card shows `⇄ AI n ↔ you m` with **Use AI n** / **Keep m**; the score is provisional until reconciled. Progressive disclosure: the number input only appears on demand, the default is a compact chip + at most two contextual buttons, effort is the domain's own points unit (no raw token/endpoint entry).
 
 ## Success criterion
 Demand and Backlog no longer read as two duplicate boards — they read as **one continuous investment-funnel → execution-board flow**, where funding a bet visibly pulls a coworker forward to build it, and every estimate shows whose judgment it carries.


### PR DESCRIPTION
## What

**Phase 4 (final) of EP-DELIVERY-FLOW.** Makes the phase-1 estimate write-model **interactive** on the Delivery Flow card. The effort estimate — the value/effort score's denominator — becomes a visible, attributed, collaborative act: every score shows whose judgment it carries, and AI↔human divergence surfaces for a human to reconcile.

Resolves **BI-AA1763CD**. Completes the epic (phases 1–3 already merged: #3027 write-model, the unified surface, #3031 AI-led volunteering).

## Changes
- **Server action** `apps/web/lib/actions/demand-estimate.ts` — `recordEstimate({itemId, by, jobSize?, agentId?, agree?})`, `manage_backlog`-gated, dispatches the governed `record_effort_estimate` MCP door, `revalidatePath("/ops/demand")`. Domain failures returned as values (thrown errors are stripped in prod `"use server"` bundles). `by:"ai"` with no `jobSize` derives the first-pass server-side from `effortSize`.
- **`firstPassJobSize(effortSize)`** (pure, in `estimate-provenance.ts`) — projects the intake t-shirt size to points, so a coworker can propose an estimate forward the moment an item lands.
- **`EstimateControls`** (`DemandBoard.tsx`) — progressive-disclosure controls: a compact chip + ≤2 contextual buttons. `✨ AI estimate` proposes; an AI-proposed estimate shows **Confirm** (adopt) / **Overrule** (inline input, human leads); divergence shows `⇄ AI n ↔ you m` with **Use AI** / **Keep mine** reconcile.

## Verification
- `tsc --noEmit` — exit 0, **0 errors** (8GB heap).
- **15** estimate tests (pure `firstPassJobSize` + a **jsdom render test** asserting state→control branching and click→action args for every state) + **173** demand/ops tests green; module-size OK.
- **Live click-through on `:3001` was unreachable**: the Contributor preview requires an authenticated session I cannot create (entering credentials / creating accounts is disallowed), and the route is also gated by the pre-existing turbopack-dev defect **BI-53D7E70C** (`:3000` Live renders `/ops/demand` fine). The jsdom render test covers the interaction wiring the browser would have exercised — the state machine, the buttons each state shows, and the exact action arguments each click sends.

## Design grounding
Extends the kernel-ratified spec `docs/superpowers/specs/2026-07-12-delivery-flow-demand-backlog-unification-design.md` §"Collaborative estimation". No new contract — a governed action over the existing `record_effort_estimate` door + client controls.

Design-Grounding-Decision: extends existing spec; governed action + client controls in apps/web/components/ops; no contract change.

UX-Fit-Decision: spec-prescribed interaction with progressive disclosure — default is a chip + ≤2 buttons, the number input appears only on demand, effort uses the platform's existing points unit (no raw token/endpoint entry, AGENTS.md §12/§17). Low human_cognitive_load; no new tab/dashboard.

## Local-CI-Override
Local pregate `next build` OOMs on this machine (documented cold-tsc/V8 issue); verified-clean out-of-band as above. GitHub CI (Typecheck + Production Build + Unit Tests) is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)