### PR TITLE
feat(demand-mgmt): use-it-or-lose-it capacity draining (BI-656F4E4B, EP-DEMAND-MGMT)

### DIFF
--- a/apps/web/lib/capacity/drain-policy.test.ts
+++ b/apps/web/lib/capacity/drain-policy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { evaluateDrain, nextWeeklyReset, type DrainPolicyInput } from "./drain-policy";
+
+function base(overrides: Partial<DrainPolicyInput> = {}): DrainPolicyInput {
+  return {
+    enabled: true,
+    now: new Date("2026-07-12T12:00:00Z"),
+    windowResetAt: new Date("2026-07-12T18:00:00Z"), // 6h out
+    drainWindowHours: 12,
+    poolExhausted: false,
+    activeBuilds: 1,
+    wipCap: 4,
+    maxDispatch: 3,
+    ...overrides,
+  };
+}
+
+describe("nextWeeklyReset", () => {
+  it("returns the next Monday 00:00 UTC after now", () => {
+    // 2026-07-12 is a Sunday. Next Monday 00:00 = 2026-07-13T00:00Z.
+    const r = nextWeeklyReset(new Date("2026-07-12T12:00:00Z"), 1, 0);
+    expect(r.toISOString()).toBe("2026-07-13T00:00:00.000Z");
+  });
+
+  it("jumps a full week when the boundary is exactly now", () => {
+    const now = new Date("2026-07-13T00:00:00Z"); // a Monday 00:00
+    const r = nextWeeklyReset(now, 1, 0);
+    expect(r.toISOString()).toBe("2026-07-20T00:00:00.000Z");
+  });
+
+  it("handles same-day-later-hour today", () => {
+    // Sunday 12:00, reset Sunday (0) 18:00 -> later today.
+    const r = nextWeeklyReset(new Date("2026-07-12T12:00:00Z"), 0, 18);
+    expect(r.toISOString()).toBe("2026-07-12T18:00:00.000Z");
+  });
+});
+
+describe("evaluateDrain", () => {
+  it("drains when near reset, pool healthy, slots free", () => {
+    const d = evaluateDrain(base());
+    expect(d.drain).toBe(true);
+    expect(d.targetDispatch).toBe(3); // min(headroom 3, maxDispatch 3)
+    expect(d.hoursUntilReset).toBe(6);
+  });
+
+  it("caps dispatch at WIP headroom", () => {
+    const d = evaluateDrain(base({ activeBuilds: 3, wipCap: 4, maxDispatch: 3 }));
+    expect(d.drain).toBe(true);
+    expect(d.targetDispatch).toBe(1); // headroom 1 < maxDispatch 3
+  });
+
+  it("does not drain when disabled", () => {
+    expect(evaluateDrain(base({ enabled: false })).drain).toBe(false);
+  });
+
+  it("does not drain into an exhausted pool", () => {
+    const d = evaluateDrain(base({ poolExhausted: true }));
+    expect(d.drain).toBe(false);
+    expect(d.reason).toMatch(/exhausted/);
+  });
+
+  it("does not drain outside the window", () => {
+    const d = evaluateDrain(base({ windowResetAt: new Date("2026-07-14T12:00:00Z") })); // 48h out
+    expect(d.drain).toBe(false);
+    expect(d.reason).toMatch(/not in drain window/);
+  });
+
+  it("does not drain when WIP cap reached", () => {
+    const d = evaluateDrain(base({ activeBuilds: 4, wipCap: 4 }));
+    expect(d.drain).toBe(false);
+    expect(d.reason).toMatch(/WIP cap reached/);
+  });
+});

--- a/apps/web/lib/capacity/drain-policy.ts
+++ b/apps/web/lib/capacity/drain-policy.ts
@@ -1,0 +1,102 @@
+// Pure capacity-drain policy — no server imports. Safe in tests and client code.
+//
+// "Use it or lose it": pre-paid weekly LLM allocation that isn't spent before the
+// weekly reset is wasted. When we're near the reset with a HEALTHY (non-exhausted)
+// pool and free build slots, proactively dispatch the top demand-ranked ready work
+// to consume the remaining allocation — bounded by the WIP cap so it never
+// overloads. Reuses the existing governed tee-up + WIP machinery (kernel decision
+// DI-5FED0D945EBB: capacity-aware tee-up throttle, not a parallel loop).
+//
+// The honest signal: the provider doesn't expose remaining weekly quota, so we use
+// a proxy — if the pool has NOT been rate-limited (CliPoolStatus not exhausted) and
+// we're inside the drain window before the reset, there is likely unspent
+// allocation worth draining. If the pool IS exhausted, the allocation is already
+// fully used (or we're throttled) and we must not push more.
+
+const MS_PER_HOUR = 3_600_000;
+const HOURS_PER_WEEK = 168;
+
+/**
+ * The next weekly reset boundary strictly after `now`, for a plan that resets on
+ * `resetDow` (0=Sun … 6=Sat) at `resetHourUtc` (0–23) in UTC.
+ */
+export function nextWeeklyReset(now: Date, resetDow: number, resetHourUtc: number): Date {
+  const dow = ((resetDow % 7) + 7) % 7;
+  const hour = Math.min(23, Math.max(0, Math.floor(resetHourUtc)));
+  const candidate = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), hour, 0, 0, 0),
+  );
+  // Advance to the target day-of-week.
+  const dayDelta = (dow - candidate.getUTCDay() + 7) % 7;
+  candidate.setUTCDate(candidate.getUTCDate() + dayDelta);
+  // If that lands at or before now, jump a full week.
+  if (candidate.getTime() <= now.getTime()) {
+    candidate.setUTCDate(candidate.getUTCDate() + 7);
+  }
+  return candidate;
+}
+
+export type DrainPolicyInput = {
+  enabled: boolean;
+  now: Date;
+  /** Next weekly allocation reset (see nextWeeklyReset). */
+  windowResetAt: Date;
+  /** Start draining once within this many hours of the reset. */
+  drainWindowHours: number;
+  /** CLI subscription pool currently rate-limited (allocation spent / throttled)? */
+  poolExhausted: boolean;
+  /** Non-terminal Build Studio builds in flight. */
+  activeBuilds: number;
+  /** The WIP cap on concurrent builds. */
+  wipCap: number;
+  /** Max builds to dispatch in a single drain evaluation. */
+  maxDispatch: number;
+};
+
+export type DrainDecision = {
+  drain: boolean;
+  /** How many top-ranked ready items to dispatch now (0 when not draining). */
+  targetDispatch: number;
+  hoursUntilReset: number;
+  reason: string;
+};
+
+/**
+ * Decide whether — and how much — to drain now. Pure and side-effect-free; the
+ * caller (a scheduled evaluator) supplies live state and acts on the result.
+ */
+export function evaluateDrain(input: DrainPolicyInput): DrainDecision {
+  const hoursUntilReset = Math.max(0, (input.windowResetAt.getTime() - input.now.getTime()) / MS_PER_HOUR);
+  const base = { drain: false as const, targetDispatch: 0, hoursUntilReset };
+
+  if (!input.enabled) return { ...base, reason: "capacity draining disabled" };
+
+  // A rate-limited pool means the weekly allocation is already being fully used
+  // (or we're throttled). Pushing more would only pile up doomed dispatches.
+  if (input.poolExhausted) {
+    return { ...base, reason: "pool exhausted — allocation already spent or rate-limited" };
+  }
+
+  // Only drain the tail of the window; the normal cadence covers the rest.
+  const window = Math.min(HOURS_PER_WEEK, Math.max(0, input.drainWindowHours));
+  if (hoursUntilReset > window) {
+    return { ...base, reason: `not in drain window (${hoursUntilReset.toFixed(1)}h > ${window}h until reset)` };
+  }
+
+  const headroom = input.wipCap - input.activeBuilds;
+  if (headroom <= 0) {
+    return { ...base, reason: `WIP cap reached (${input.activeBuilds}/${input.wipCap}) — no free slots` };
+  }
+
+  const targetDispatch = Math.max(0, Math.min(headroom, Math.floor(input.maxDispatch)));
+  if (targetDispatch === 0) {
+    return { ...base, reason: "maxDispatch is 0" };
+  }
+
+  return {
+    drain: true,
+    targetDispatch,
+    hoursUntilReset,
+    reason: `draining: ${hoursUntilReset.toFixed(1)}h to reset, pool healthy, ${headroom} of ${input.wipCap} build slots free`,
+  };
+}

--- a/apps/web/lib/capacity/evaluate-drain.ts
+++ b/apps/web/lib/capacity/evaluate-drain.ts
@@ -1,0 +1,96 @@
+// Capacity-drain evaluator (server) — reads live state, applies the pure
+// drain-policy, and (when draining) dispatches top demand-ranked ready work via
+// the existing governed tee-up. EP-DEMAND-MGMT capacity automation; kernel
+// decision DI-5FED0D945EBB (capacity-aware tee-up throttle).
+
+import type { PrismaClient } from "@dpf/db";
+import { evaluateDrain, nextWeeklyReset, type DrainDecision } from "./drain-policy";
+
+export type CapacityDrainResult = {
+  drained: boolean;
+  decision: DrainDecision;
+  windowResetAt: string;
+  poolExhausted: boolean;
+  activeBuilds: number;
+  wipCap: number;
+  /** Builds actually created this run (0 when not draining). */
+  dispatched: number;
+};
+
+/**
+ * Evaluate whether to drain remaining weekly allocation and, if so, dispatch
+ * top-ranked ready work. Safe to call on a schedule — no-op unless enabled AND
+ * in the drain window AND the pool is healthy AND slots are free.
+ */
+export async function evaluateAndDrainCapacity(input: {
+  prisma: PrismaClient;
+  userId: string;
+  now?: Date;
+  /** When true, evaluate and report but do NOT dispatch — for a status check. */
+  dryRun?: boolean;
+}): Promise<CapacityDrainResult> {
+  const { prisma, userId } = input;
+  const now = input.now ?? new Date();
+
+  const config = await prisma.platformDevConfig.findUnique({
+    where: { id: "singleton" },
+    select: {
+      capacityDrainEnabled: true,
+      capacityResetDow: true,
+      capacityResetHourUtc: true,
+      capacityDrainWindowHours: true,
+      capacityDrainMaxDispatch: true,
+    },
+  });
+
+  const { BUILD_WIP_CAP, TERMINAL_BUILD_PHASES } = await import("@/lib/build/wip-cap");
+  const { getAllCliPoolStatuses } = await import("@/lib/routing/cli-pool-status");
+
+  // A pool is "exhausted" if any CLI adapter is currently rate-limited — the
+  // allocation is already fully in use (or we're throttled), so we must not push.
+  const pools = await getAllCliPoolStatuses();
+  const poolExhausted = pools.some((p) => p.isExhausted);
+
+  const activeBuilds = await prisma.featureBuild.count({
+    where: { phase: { notIn: [...TERMINAL_BUILD_PHASES] }, abandonedAt: null, parentEpicId: null },
+  });
+
+  const resetDow = config?.capacityResetDow ?? 1;
+  const resetHourUtc = config?.capacityResetHourUtc ?? 0;
+  const windowResetAt = nextWeeklyReset(now, resetDow, resetHourUtc);
+
+  const decision = evaluateDrain({
+    enabled: config?.capacityDrainEnabled === true,
+    now,
+    windowResetAt,
+    drainWindowHours: config?.capacityDrainWindowHours ?? 12,
+    poolExhausted,
+    activeBuilds,
+    wipCap: BUILD_WIP_CAP,
+    maxDispatch: config?.capacityDrainMaxDispatch ?? 3,
+  });
+
+  const shared = {
+    decision,
+    windowResetAt: windowResetAt.toISOString(),
+    poolExhausted,
+    activeBuilds,
+    wipCap: BUILD_WIP_CAP,
+  };
+
+  if (!decision.drain || input.dryRun === true) {
+    return { ...shared, drained: false, dispatched: 0 };
+  }
+
+  const { runGovernedBacklogTeeUp } = await import("@/lib/governed-backlog-tee-up");
+  const teeUp = await runGovernedBacklogTeeUp({
+    prisma,
+    userId,
+    trigger: "capacity-drain",
+    limit: decision.targetDispatch,
+    // Let the drain fill idle slots up to the WIP cap, past the normal daily cap.
+    capOverride: decision.targetDispatch,
+  });
+
+  return { ...shared, drained: true, dispatched: teeUp.createdCount };
+}

--- a/apps/web/lib/governed-backlog-tee-up.ts
+++ b/apps/web/lib/governed-backlog-tee-up.ts
@@ -100,7 +100,7 @@ export function parseFixContextFromBody(body: string | null | undefined): Parsed
   return out;
 }
 
-export type GovernedBacklogTeeUpTrigger = "daily" | "manual";
+export type GovernedBacklogTeeUpTrigger = "daily" | "manual" | "capacity-drain";
 
 export type GovernedBacklogTeeUpCandidate = {
   id: string;
@@ -491,8 +491,18 @@ export async function promoteBacklogItemToBuildDraft(
   };
 }
 
-function resolveRequestedLimit(config: GovernedBacklogConfig, requestedLimit?: number): number {
-  const configuredCap = config?.backlogTeeUpDailyCap ?? DEFAULT_DAILY_CAP;
+function resolveRequestedLimit(
+  config: GovernedBacklogConfig,
+  requestedLimit?: number,
+  capOverride?: number,
+): number {
+  // capOverride replaces the daily cap as the ceiling for this run — used by the
+  // capacity-drain path to fill idle build slots up to the WIP cap near the
+  // weekly-allocation reset, rather than being held to the normal daily cadence.
+  const configuredCap =
+    typeof capOverride === "number" && capOverride >= 0
+      ? Math.floor(capOverride)
+      : config?.backlogTeeUpDailyCap ?? DEFAULT_DAILY_CAP;
   if (requestedLimit == null || Number.isNaN(requestedLimit)) {
     return configuredCap;
   }
@@ -506,6 +516,8 @@ export async function runGovernedBacklogTeeUp(input: {
   userId: string;
   trigger: GovernedBacklogTeeUpTrigger;
   limit?: number;
+  /** Overrides the daily cap as the per-run ceiling (capacity-drain path). */
+  capOverride?: number;
 }): Promise<{
   trigger: GovernedBacklogTeeUpTrigger;
   requestedLimit: number;
@@ -514,7 +526,7 @@ export async function runGovernedBacklogTeeUp(input: {
   skippedCount: number;
   builds: Array<{ backlogItemId: string; buildId: string }>;
 }> {
-  const { prisma, userId, trigger, limit } = input;
+  const { prisma, userId, trigger, limit, capOverride } = input;
   const config = await prisma.platformDevConfig.findUnique({
     where: { id: "singleton" },
     select: {
@@ -523,7 +535,7 @@ export async function runGovernedBacklogTeeUp(input: {
     },
   });
 
-  const requestedLimit = resolveRequestedLimit(config, limit);
+  const requestedLimit = resolveRequestedLimit(config, limit, capOverride);
   if (config?.governedBacklogEnabled !== true || requestedLimit <= 0) {
     return {
       trigger,

--- a/apps/web/lib/mcp/packs/demand-scoring-pack.ts
+++ b/apps/web/lib/mcp/packs/demand-scoring-pack.ts
@@ -115,6 +115,20 @@ const definitions: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "run_capacity_drain",
+    description:
+      "Evaluate the use-it-or-lose-it capacity policy: near the weekly pre-paid LLM allocation reset, with a healthy pool and free build slots, dispatch the top demand-ranked ready work so allocation isn't wasted. dryRun=true (default) reports the decision without dispatching; dryRun=false actually dispatches (bounded by the WIP cap). Off unless capacityDrainEnabled.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        dryRun: { type: "boolean", description: "true (default) = report the decision only; false = actually dispatch up to the WIP headroom." },
+      },
+      required: [],
+    },
+    requiredCapability: "manage_backlog",
+    sideEffect: true,
+  },
+  {
     name: "sweep_duplicate_demand",
     description:
       "Scan the open backlog for likely-duplicate pairs (by title/body similarity) so recurring demand can be merged and reach concentrated. Read-only — returns ranked pairs across the whole open set; use merge_backlog_items to act on them. A safe on-demand alternative to auto-deduping at intake.",
@@ -634,6 +648,18 @@ async function approveDemandForFundingHandler(
   };
 }
 
+async function runCapacityDrainHandler(params: Record<string, unknown>, userId: string): Promise<ToolResult> {
+  const dryRun = params["dryRun"] !== false; // default true (report only)
+  const { evaluateAndDrainCapacity } = await import("@/lib/capacity/evaluate-drain");
+  const r = await evaluateAndDrainCapacity({ prisma, userId, dryRun });
+  const suffix = r.drained
+    ? ` — dispatched ${r.dispatched} build(s)`
+    : dryRun && r.decision.drain
+      ? " (would dispatch; dry run)"
+      : "";
+  return { success: true, message: `${r.decision.reason}${suffix}`, data: r };
+}
+
 export const demandScoringPack: ToolPack = {
   packId: "demand-scoring",
   definitions,
@@ -645,6 +671,7 @@ export const demandScoringPack: ToolPack = {
     merge_backlog_items: (params) => mergeBacklogItemsHandler(params),
     sweep_duplicate_demand: (params) => sweepDuplicateDemandHandler(params),
     approve_demand_for_funding: (params, userId, ctx) => approveDemandForFundingHandler(params, userId, ctx),
+    run_capacity_drain: (params, userId) => runCapacityDrainHandler(params, userId),
   },
   grants: {
     score_demand_item: ["backlog_write"],
@@ -654,5 +681,6 @@ export const demandScoringPack: ToolPack = {
     merge_backlog_items: ["backlog_write"],
     sweep_duplicate_demand: ["backlog_read"],
     approve_demand_for_funding: ["backlog_write"],
+    run_capacity_drain: ["backlog_write"],
   },
 };

--- a/apps/web/lib/mcp/tool-registry.test.ts
+++ b/apps/web/lib/mcp/tool-registry.test.ts
@@ -280,7 +280,7 @@ describe("coworker memory pack", () => {
 
 describe("demand-scoring tool pack", () => {
   it("bundles the score_demand_item door with a handler", () => {
-    expect(demandScoringPack.definitions.map((t) => t.name)).toEqual(["score_demand_item", "record_effort_estimate", "set_demand_policy", "find_duplicate_candidates", "merge_backlog_items", "sweep_duplicate_demand", "approve_demand_for_funding"]);
+    expect(demandScoringPack.definitions.map((t) => t.name)).toEqual(["score_demand_item", "record_effort_estimate", "set_demand_policy", "find_duplicate_candidates", "merge_backlog_items", "run_capacity_drain", "sweep_duplicate_demand", "approve_demand_for_funding"]);
     for (const def of demandScoringPack.definitions) {
       expect(demandScoringPack.handlers[def.name], def.name).toBeTypeOf("function");
     }

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -318,6 +318,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: null,
   },
   {
+    jobId: "capacity-drain",
+    inngestId: "build/capacity-drain-scheduled",
+    name: "Capacity drain (use-it-or-lose-it)",
+    purpose:
+      "Near the weekly LLM-allocation reset, with a healthy pool and free build slots, dispatch top demand-ranked ready work so allocation is not wasted. Opt-in (capacityDrainEnabled).",
+    cron: "17 * * * *",
+    cadence: "Hourly at :17",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: null,
+  },
+  {
     jobId: "assurance-remediation-tee-up",
     inngestId: "assurance/remediation-tee-up-scheduled",
     name: "Assurance remediation tee-up",

--- a/apps/web/lib/queue/functions/capacity-drain.ts
+++ b/apps/web/lib/queue/functions/capacity-drain.ts
@@ -1,0 +1,37 @@
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+// Use-it-or-lose-it capacity drain — evaluates hourly. Near the weekly
+// allocation reset, with a healthy pool and free build slots, it dispatches the
+// top demand-ranked ready work so pre-paid LLM capacity is not wasted. No-op
+// unless capacityDrainEnabled (opt-in). Kernel decision DI-5FED0D945EBB.
+export const capacityDrainScheduled = inngest.createFunction(
+  {
+    id: "build/capacity-drain-scheduled",
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    // Off-minute hourly (avoids the top-of-hour fleet stampede).
+    triggers: [cron("17 * * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("evaluate-capacity-drain", async () => {
+      const { prisma } = await import("@dpf/db");
+      const { evaluateAndDrainCapacity } = await import("@/lib/capacity/evaluate-drain");
+      const { dispatchApprovedIdeateBuilds } = await import("@/lib/integrate/ideate-on-approval");
+      const { resolveScheduledOwnerUserId } = await import("../scheduled-owner");
+
+      const userId = await resolveScheduledOwnerUserId();
+      const result = await evaluateAndDrainCapacity({ prisma, userId });
+      // Fire Ideate for anything the drain just promoted (same completion the
+      // daily tee-up does), so drained builds don't strand in `ideate`.
+      const ideateDispatch = result.drained
+        ? await dispatchApprovedIdeateBuilds({ userId })
+        : null;
+      return { ...result, ideateDispatch };
+    });
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -26,6 +26,7 @@ import {
   governedBacklogTeeUpRequested,
   governedBacklogTeeUpScheduled,
 } from "./governed-backlog-tee-up";
+import { capacityDrainScheduled } from "./capacity-drain";
 import { assuranceRemediationTeeUpScheduled } from "./assurance-remediation-teeup";
 import { assuranceMergeGateScheduled } from "./assurance-merge-gate-teeup";
 import { tokenExpiryMonitor } from "./token-expiry-monitor";
@@ -86,6 +87,7 @@ export const scheduledFunctions = [
   agentTaskDispatch,
   taskrunWatchdog,
   governedBacklogTeeUpScheduled,
+  capacityDrainScheduled, // use-it-or-lose-it: drain idle weekly allocation into top demand near reset
   assuranceRemediationTeeUpScheduled, // BI-7C121CCF: off-hours, budget-capped assurance remediation lane
   assuranceMergeGateScheduled, // BI-204EE70B P2.2: WWMD merge gate (dark — escalate-only until actuation enabled)
   tokenExpiryMonitor,

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -142,6 +142,7 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   find_duplicate_candidates: ["backlog_read"],
   merge_backlog_items: ["backlog_write"],
   sweep_duplicate_demand: ["backlog_read"],
+  run_capacity_drain: ["backlog_write"],
   approve_demand_for_funding: ["backlog_write"],
   query_backlog: ["backlog_read"],
   report_quality_issue: ["backlog_write"],

--- a/docs/superpowers/plans/2026-07-12-capacity-drain-automation.md
+++ b/docs/superpowers/plans/2026-07-12-capacity-drain-automation.md
@@ -1,0 +1,36 @@
+# Use-it-or-lose-it Capacity Draining — Plan
+
+| Field | Value |
+|-------|-------|
+| **Epic** | EP-DEMAND-MGMT |
+| **BI** | BI-656F4E4B |
+| **Date** | 2026-07-12 |
+| **Scope decision** | `principle_decide` ledger **DI-5FED0D945EBB** — capacity-aware tee-up throttle (reuse the demand-ordered governed tee-up + WIP cap), beat a parallel dispatch loop and a manual-only command. |
+| **Depends on** | The live demand ranking (the open backlog is now `demandScore`-scored), and the demand-ranked `governedBacklogTeeUp`. |
+
+## Design grounding
+
+- **Source of truth:** the demand-management spec [`docs/superpowers/specs/2026-07-10-demand-management-design.md`](../specs/2026-07-10-demand-management-design.md) §7 (value-ranked promote sweep) and the `governed-backlog-tee-up.ts` substrate + `cli-pool-status.ts` (EP-COST-001 §4d).
+- **Decision:** *extend* both — no new spec. This adds a capacity-drain evaluator that reuses the existing tee-up dispatch + WIP cap and the existing `CliPoolStatus` pool-health signal. No parallel dispatch loop (kernel-rejected).
+
+## Why
+
+Pre-paid weekly LLM allocation that isn't spent before the weekly reset is wasted. DPF already dispatches the highest-`demandScore` ready work to Build Studio via `governedBacklogTeeUp` (bounded by `backlogTeeUpDailyCap` + the WIP cap), but only once a day — so between runs, build slots sit idle and allocation goes unused near the reset. The honest signal available: the provider doesn't expose remaining weekly quota, but `CliPoolStatus` tells us when the pool is **exhausted** (rate-limited). Proxy: pool NOT exhausted + inside the drain window before reset ⇒ likely unspent allocation worth draining.
+
+## What shipped (this PR)
+
+1. **Pure policy** — `apps/web/lib/capacity/drain-policy.ts`: `nextWeeklyReset(now, dow, hourUtc)` + `evaluateDrain(input) → {drain, targetDispatch, reason, hoursUntilReset}`. Drains only when: enabled, pool healthy, within the drain window, and WIP headroom > 0; `targetDispatch = min(headroom, maxDispatch)`. Unit-tested (9).
+2. **Config** — additive `PlatformDevConfig` columns (`capacityDrainEnabled` default **false** = opt-in, `capacityResetDow`/`capacityResetHourUtc`, `capacityDrainWindowHours`, `capacityDrainMaxDispatch`). Migration `20260712120000` — all defaulted, fleet-safe.
+3. **Evaluator** — `evaluate-drain.ts`: reads config + `getAllCliPoolStatuses()` (any adapter exhausted ⇒ don't push) + active-build count vs `BUILD_WIP_CAP`, runs the policy, and (unless `dryRun`) calls `runGovernedBacklogTeeUp({ trigger: "capacity-drain", capOverride })` to fill idle slots up to the WIP cap.
+4. **Schedule** — `queue/functions/capacity-drain.ts`: hourly inngest fn (cron `17 * * * *`), quiescence-gated, registered in the functions index; fires Ideate on anything it promotes.
+5. **Operator control** — `run_capacity_drain` MCP tool (dryRun default true = report the decision; false = dispatch). In the demand pack; grant `backlog_write`.
+6. **Tee-up extension** — `runGovernedBacklogTeeUp` gains `capOverride` so the drain can exceed the normal daily cap up to the WIP headroom (the WIP cap stays the hard safety bound).
+
+## Safety
+
+- **Opt-in** (`capacityDrainEnabled` default false). **WIP cap is the hard ceiling** — the drain only fills free slots, never exceeds concurrent-build safety. **Never pushes into an exhausted pool.** Quiescence-gated (skips during upgrades). Only dispatches `triageOutcome=build`, DoR-ready items — the same governed set the daily tee-up uses, now `demandScore`-ordered so the *highest-value* work fills the idle capacity.
+
+## Deferred (follow-ups)
+
+- Real remaining-quota telemetry (the provider doesn't expose it; the proxy is pool-health + window). If a provider later exposes remaining weekly quota, feed it into the policy as a truer "unused" signal.
+- An admin surface for the capacity config + a live "next reset / would-drain" readout (the `run_capacity_drain` dryRun tool covers this for now).

--- a/packages/db/prisma/migrations/20260712120000_add_capacity_drain_config/migration.sql
+++ b/packages/db/prisma/migrations/20260712120000_add_capacity_drain_config/migration.sql
@@ -1,0 +1,9 @@
+-- Use-it-or-lose-it capacity draining config on the platform-dev singleton.
+-- @migration-safety: data-safe: all columns are additive with defaults; no
+-- existing row can violate any constraint.
+ALTER TABLE "PlatformDevConfig"
+    ADD COLUMN "capacityDrainEnabled" BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN "capacityResetDow" INTEGER NOT NULL DEFAULT 1,
+    ADD COLUMN "capacityResetHourUtc" INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN "capacityDrainWindowHours" INTEGER NOT NULL DEFAULT 12,
+    ADD COLUMN "capacityDrainMaxDispatch" INTEGER NOT NULL DEFAULT 3;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -6467,6 +6467,20 @@ model PlatformDevConfig {
   // (rice, 70/20/10). §11.
   demandFramework           String?
   demandBucketTargets       Json?
+  // Use-it-or-lose-it capacity draining (EP-DEMAND-MGMT / capacity automation).
+  // When enabled, near the weekly pre-paid LLM allocation reset with a healthy
+  // (non-exhausted) pool and free build slots, the scheduled evaluator dispatches
+  // top demand-ranked ready work up to the WIP cap so allocation is not wasted.
+  // All nullable/defaulted → off by default (opt-in). See lib/capacity/drain-policy.ts.
+  capacityDrainEnabled      Boolean   @default(false)
+  /// Weekly reset day-of-week in UTC (0=Sun … 6=Sat). Default Monday.
+  capacityResetDow          Int       @default(1)
+  /// Weekly reset hour in UTC (0–23).
+  capacityResetHourUtc      Int       @default(0)
+  /// Start draining once within this many hours of the reset.
+  capacityDrainWindowHours  Int       @default(12)
+  /// Max builds to dispatch per drain evaluation (still bounded by the WIP cap).
+  capacityDrainMaxDispatch  Int       @default(3)
   // Hive Contributions consent (spec §6.1). Device-fingerprint contribution is
   // opt-in, DEFAULTED ON because outbound fingerprints are PII-free
   // (redactFingerprintEvidence, fail-closed). The master pause halts ALL

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -54,7 +54,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	865
 apps/web/lib/self-upgrade/quiescence.ts	1469
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	903
-apps/web/lib/tak/agent-grants.ts	817
+apps/web/lib/tak/agent-grants.ts	818
 apps/web/lib/tak/agent-routing.ts	965
 apps/web/lib/tak/agentic-loop.test.ts	2240
 apps/web/lib/tak/agentic-loop.ts	2612


### PR DESCRIPTION
## What

Use-it-or-lose-it LLM capacity draining (BI-656F4E4B, EP-DEMAND-MGMT). Near the weekly pre-paid allocation reset, with a healthy pool and free build slots, dispatch the **top demand-ranked** ready work so allocation isn't wasted. Builds directly on the now-live demand ranking (the open backlog is `demandScore`-scored).

Kernel decision **DI-5FED0D945EBB** — capacity-aware tee-up throttle (reuse the demand-ordered `governedBacklogTeeUp` + WIP cap), over a parallel loop or manual-only command.

## Changes

- **`lib/capacity/drain-policy.ts`** (pure, 9 tests) — `nextWeeklyReset` + `evaluateDrain`. Drains only when enabled, pool healthy, within the drain window, WIP headroom > 0; `targetDispatch = min(headroom, maxDispatch)`.
- **`lib/capacity/evaluate-drain.ts`** — reads config + `CliPoolStatus` (any adapter exhausted ⇒ don't push) + active-build count, applies the policy, dispatches via `runGovernedBacklogTeeUp({ trigger: "capacity-drain", capOverride })`. `dryRun` supported.
- **`queue/functions/capacity-drain.ts`** — hourly quiescence-gated inngest evaluator, registered in the functions index.
- **`run_capacity_drain`** MCP tool (dryRun default true = report; false = dispatch) in the demand pack.
- **`PlatformDevConfig` capacity config** (opt-in, default **off**); migration `20260712120000` (all defaulted → fleet-safe).
- **`runGovernedBacklogTeeUp` gains `capOverride`** so the drain fills idle slots past the daily cap up to the WIP cap (the hard safety bound).

## Safety

Opt-in; **WIP cap is the hard ceiling**; never pushes an exhausted pool; quiescence-gated; only governed DoR-ready items, `demandScore`-ordered so the *highest-value* work fills idle capacity.

## Design-Grounding-Decision

Extends the demand-management spec (`docs/superpowers/specs/2026-07-10-demand-management-design.md` §7) + the `governed-backlog-tee-up` and `cli-pool-status` substrate; no new spec. Plan: `docs/superpowers/plans/2026-07-12-capacity-drain-automation.md` (touches `apps/web/`).

## Verification

249 tests green locally (capacity 9 + registry/grants/tee-up/demand); module-size clean; migration validated on a throwaway Postgres. **Local-CI-Override:** local gate runner env-flaky + GitHub connectivity degraded this session; GitHub CI runs the authoritative required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
