### PR TITLE
fix(ops): count badges honor hideDone so "Unassigned" shows actionable work, not the noise pile (BI-7CB3C1CD)

### DIFF
--- a/apps/web/components/ops/OpsClient.tsx
+++ b/apps/web/components/ops/OpsClient.tsx
@@ -7,7 +7,7 @@ import { BacklogItemRow } from "./BacklogItemRow";
 import { EpicCard, type EpicSort } from "./EpicCard";
 import { EpicPanel } from "./EpicPanel";
 import { OperatorTriageBand } from "./OperatorTriageBand";
-import { isTerminalBacklogItemStatus } from "./backlogVisibility";
+import { visibleUnderHideDone } from "./backlogVisibility";
 import { FilterBar, type FacetDef } from "@/components/ui/report-kit";
 import { backlogItemOrigin, BACKLOG_ORIGIN_FILTERS } from "@/lib/ops/backlog-origin";
 import type {
@@ -143,6 +143,10 @@ export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfo
   const unassigned = items.filter(
     (i) => i.epicId === null && matchesOrigin(i) && !portfolioFilter,
   );
+  // Count badges must reflect the same hideDone filter the list applies, so the
+  // headline "Unassigned" number is actionable work — not the raw pile inflated
+  // by hidden deferred/done items (BI-7CB3C1CD).
+  const visibleUnassigned = visibleUnderHideDone(unassigned, hideDone);
   const types = ["portfolio", "product"] as const;
   const byType = new Map(types.map((t) => [t, unassigned.filter((i) => i.type === t)]));
 
@@ -294,12 +298,12 @@ export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfo
       <div>
         <h2 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-widest mb-4">
           Unassigned
-          <span className="ml-2 normal-case font-normal">{unassigned.length}</span>
+          <span className="ml-2 normal-case font-normal">{visibleUnassigned.length}</span>
         </h2>
 
         {types.map((t) => {
           const typeItems = byType.get(t) ?? [];
-          const filteredItems = hideDone ? typeItems.filter((i) => !isTerminalBacklogItemStatus(i.status)) : typeItems;
+          const filteredItems = visibleUnderHideDone(typeItems, hideDone);
           const hiddenItemCount = typeItems.length - filteredItems.length;
           const label = TYPE_LABELS[t] ?? t;
 
@@ -308,7 +312,7 @@ export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfo
               <div className="flex items-center justify-between mb-3">
                 <h3 className="text-xs font-semibold text-[var(--dpf-muted)] uppercase tracking-widest">
                   {label}
-                  <span className="ml-2 normal-case font-normal">{typeItems.length}</span>
+                  <span className="ml-2 normal-case font-normal">{filteredItems.length}</span>
                 </h3>
                 <button
                   onClick={() => openCreate(t)}

--- a/apps/web/components/ops/backlogVisibility.test.ts
+++ b/apps/web/components/ops/backlogVisibility.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { isTerminalBacklogItemStatus, visibleUnderHideDone } from "./backlogVisibility";
+
+describe("isTerminalBacklogItemStatus", () => {
+  it("treats done and deferred as terminal, everything else as active", () => {
+    expect(isTerminalBacklogItemStatus("done")).toBe(true);
+    expect(isTerminalBacklogItemStatus("deferred")).toBe(true);
+    expect(isTerminalBacklogItemStatus("open")).toBe(false);
+    expect(isTerminalBacklogItemStatus("in-progress")).toBe(false);
+    expect(isTerminalBacklogItemStatus("triaging")).toBe(false);
+  });
+});
+
+describe("visibleUnderHideDone (BI-7CB3C1CD)", () => {
+  const items = [
+    { status: "open" },
+    { status: "in-progress" },
+    { status: "triaging" },
+    { status: "deferred" },
+    { status: "deferred" },
+    { status: "done" },
+  ];
+
+  it("drops terminal (done + deferred) items when hideDone is on", () => {
+    // The regression: the count badge must match what the list shows. With the
+    // default hideDone=true, three deferred/done rows are hidden, so the badge
+    // should count 3 actionable items — not the raw 6.
+    const visible = visibleUnderHideDone(items, true);
+    expect(visible).toHaveLength(3);
+    expect(visible.map((i) => i.status)).toEqual(["open", "in-progress", "triaging"]);
+  });
+
+  it("returns every item unchanged when hideDone is off", () => {
+    expect(visibleUnderHideDone(items, false)).toHaveLength(6);
+  });
+
+  it("returns a stable empty array when all items are terminal", () => {
+    expect(visibleUnderHideDone([{ status: "done" }, { status: "deferred" }], true)).toEqual([]);
+  });
+});

--- a/apps/web/components/ops/backlogVisibility.ts
+++ b/apps/web/components/ops/backlogVisibility.ts
@@ -1,3 +1,18 @@
 export function isTerminalBacklogItemStatus(status: string): boolean {
   return status === "done" || status === "deferred";
 }
+
+/**
+ * The subset of items shown under the "hide done" toggle. When hideDone is on
+ * (the default), terminal items (done + deferred) are removed so both the list
+ * AND its count badges reflect only actionable, unassigned work. Routing counts
+ * through the same helper as the list keeps the badge honest — otherwise a badge
+ * counts rows the list itself hides (BI-7CB3C1CD: "Unassigned 1692" over a
+ * ~239-row list, inflated by the deferred-PIR noise pile).
+ */
+export function visibleUnderHideDone<T extends { status: string }>(
+  items: T[],
+  hideDone: boolean,
+): T[] {
+  return hideDone ? items.filter((item) => !isTerminalBacklogItemStatus(item.status)) : items;
+}


### PR DESCRIPTION
## What & why

The `/ops` **"Unassigned"** tile that reads **1692** is inflated. The count badges counted *every* no-epic backlog item regardless of status, while the list below already hides terminal ones — so the operator sees "Unassigned 1692" above a **~239-row** list.

Root cause:
- `getBacklogItems` (`apps/web/lib/explore/backlog-data.ts`) loads **all** statuses — no `where` clause (~2923 rows).
- `isTerminalBacklogItemStatus` treats **both `done` and `deferred`** as terminal, and `hideDone` defaults to **true**, so the list filters them out (`OpsClient.tsx:302`).
- But the badges used the **unfiltered** set — `unassigned.length` (headline) and `typeItems.length` (per-type). The ~1291 deferred-PIR rows (the log-signature-scanner noise pile) are hidden from the list yet still counted in the badge.

## The fix

Extract a pure `visibleUnderHideDone(items, hideDone)` helper (`backlogVisibility.ts`), DRYing the inline list filter, and route **both** the headline and per-type count badges through it. The badges now match what the list actually shows — the headline becomes the *actionable* unassigned count.

- New unit test (`backlogVisibility.test.ts`, 4 cases) — pure helper, no RTL needed.
- `apps/web` `tsc --noEmit` clean (8 GB heap).

## Scope

Display-correctness only. It does **not** remove the underlying ~1291 deferred/discarded rows — that pile is verified log-signature-scanner noise (root cause already filtered on `main`), and clearing it is a separate operator-authorized cleanup. This PR stops that noise from masquerading as actionable backlog in the headline number.

## Design grounding

Trivial no-contract-change edit. Source of truth is the existing `OpsClient` `hideDone` design (`isTerminalBacklogItemStatus` + `hideDone=true` default already hide done/deferred from the list); this only makes the count badges consistent with that established behavior. No spec/plan change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)