### PR TITLE
feat(twin): ground the twin in the value stream — deriveTwinValueStreamBinding (C-1, BI-DE577C43)

### DIFF
--- a/docs/superpowers/plans/2026-07-16-twin-value-stream-grounding-execution.md
+++ b/docs/superpowers/plans/2026-07-16-twin-value-stream-grounding-execution.md
@@ -1,0 +1,44 @@
+# Ground the Twin in the Value Stream — execution plan (workstream C)
+
+**Program:** [Living Business Excellence](../specs/2026-07-15-living-business-excellence-program-design.md) §2 (row C)
+**Parent:** [Operational Twin Framework](../specs/2026-07-12-operational-twin-framework-design.md)
+**Epic / BI:** `EP-LIVING-BUSINESS-EXCELLENCE` · `BI-DE577C43`
+**Started:** 2026-07-16
+
+## Why
+
+The operational twin (`deriveTwinProfile`) renders *space* — zones + demand queues.
+The operational value stream (`deriveOperationalValueStream`, OVSM) renders *flow* — the
+six-stage backbone (Attract → Capture → Qualify → Deliver → Settle → Retain, plus cross-cuts).
+They were two disjoint sibling derivations, so the animation view and the architecture view were
+two unrelated pictures of the same business. Workstream C binds them: each twin queue and zone maps
+to the value-stream stage its work actually sits in, so the twin's tiles map to the archetype's real
+process — the factory-automation lens of **queue depth + wait per stage**.
+
+## C-1 — the binding derivation (this PR)
+
+- `packages/storefront-templates/src/twin-value-stream.ts` — `deriveTwinValueStreamBinding(archetype)`
+  → `TwinValueStreamBinding`: `queueToStage` / `zoneToStage` maps (clamped to the stages the
+  archetype actually has), the ordered `stages[]` (each OVS stage with its bound twin queues/zones),
+  and `primaryStageKey`. Pure, total, deterministic — the seventh member of the derive family.
+- Refactor: `deriveDemoBusiness` now takes its per-item `stageKey` from
+  `binding.queueToStage` (single source of truth; the private `stageForQueue` duplication is gone).
+- **Verified:** binding unit tests over all 94 (every queue/zone resolves to a real stage of the
+  archetype; stages ordered; queues/zones partitioned consistently; deterministic; rental gets
+  Return & Inspect; dispatch → Qualify; renewals → Retain). Golden snapshot regenerated (per-stage
+  demand counts now reflect the grounded mapping). Package suite 259/259; typecheck clean.
+
+## C-2 — per-stage flow in the live twin (next PR)
+
+- Extend `loadLivingBusinessSnapshot` (`apps/web/lib/twin/living-business-snapshot.ts`) and/or the
+  demo→TwinSnapshot bridge to group live/demo demand **by value-stream stage** using
+  `deriveTwinValueStreamBinding`, surfacing per-stage queue depth + longest wait — so the twin's
+  queues carry their stage label and the architecture view and animation view line up.
+- Verify end-to-end against the real dev DB (loaded demo → per-stage grouping renders through the
+  live projection), same discipline as A·P1.
+
+## Non-goals
+
+- Not a `TwinProfile` schema change (spec §6.3): the binding is a *derivation over* the existing
+  profile + OVS, not a new authored field — leaves both stable and keeps the ADR-4 override story
+  intact.

--- a/packages/storefront-templates/src/__snapshots__/demo-business.test.ts.snap
+++ b/packages/storefront-templates/src/__snapshots__/demo-business.test.ts.snap
@@ -10,8 +10,7 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 8,
     "demand": {
       "byStage": {
-        "capture": 6,
-        "deliver": 5,
+        "deliver": 11,
         "settle": 4,
       },
       "inFlight": 9,
@@ -41,8 +40,7 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 8,
     "demand": {
       "byStage": {
-        "capture": 8,
-        "deliver": 5,
+        "deliver": 13,
         "settle": 2,
       },
       "inFlight": 7,
@@ -72,8 +70,7 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 7,
     "demand": {
       "byStage": {
-        "capture": 5,
-        "deliver": 4,
+        "deliver": 9,
         "settle": 3,
       },
       "inFlight": 7,
@@ -103,8 +100,7 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 8,
     "demand": {
       "byStage": {
-        "capture": 5,
-        "deliver": 6,
+        "deliver": 11,
         "settle": 4,
       },
       "inFlight": 10,
@@ -134,8 +130,7 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 7,
     "demand": {
       "byStage": {
-        "capture": 6,
-        "deliver": 4,
+        "deliver": 10,
         "settle": 2,
       },
       "inFlight": 6,
@@ -1033,9 +1028,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 10,
     "demand": {
       "byStage": {
-        "capture": 2,
         "deliver": 6,
-        "retain": 6,
+        "retain": 8,
         "settle": 4,
       },
       "inFlight": 10,
@@ -1530,9 +1524,9 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 8,
     "demand": {
       "byStage": {
-        "capture": 5,
         "deliver": 6,
         "settle": 4,
+        "trust-compliance": 5,
       },
       "inFlight": 10,
       "primaryQueue": "pickups",
@@ -1592,8 +1586,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 9,
     "demand": {
       "byStage": {
-        "capture": 6,
         "deliver": 6,
+        "retain": 6,
         "settle": 2,
       },
       "inFlight": 8,
@@ -1623,8 +1617,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 6,
     "demand": {
       "byStage": {
-        "capture": 5,
         "deliver": 4,
+        "retain": 5,
         "settle": 3,
       },
       "inFlight": 7,
@@ -1654,8 +1648,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 7,
     "demand": {
       "byStage": {
-        "capture": 5,
         "deliver": 5,
+        "retain": 5,
         "settle": 4,
       },
       "inFlight": 9,
@@ -1685,9 +1679,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 6,
     "demand": {
       "byStage": {
-        "capture": 2,
         "deliver": 6,
-        "retain": 5,
+        "retain": 7,
         "settle": 2,
       },
       "inFlight": 8,
@@ -1717,9 +1710,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 10,
     "demand": {
       "byStage": {
-        "capture": 2,
         "deliver": 5,
-        "retain": 5,
+        "retain": 7,
         "settle": 2,
       },
       "inFlight": 7,
@@ -1749,9 +1741,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 8,
     "demand": {
       "byStage": {
-        "capture": 3,
         "deliver": 4,
-        "retain": 7,
+        "retain": 10,
         "settle": 2,
       },
       "inFlight": 6,
@@ -1781,9 +1772,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 9,
     "demand": {
       "byStage": {
-        "capture": 3,
         "deliver": 3,
-        "retain": 7,
+        "retain": 10,
         "settle": 4,
       },
       "inFlight": 7,
@@ -1813,9 +1803,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 7,
     "demand": {
       "byStage": {
-        "capture": 2,
         "deliver": 5,
-        "retain": 8,
+        "retain": 10,
         "settle": 2,
       },
       "inFlight": 7,
@@ -2031,10 +2020,10 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 10,
     "demand": {
       "byStage": {
-        "capture": 2,
         "deliver": 3,
         "retain": 5,
         "settle": 2,
+        "trust-compliance": 2,
       },
       "inFlight": 5,
       "primaryQueue": "renewals",
@@ -2063,10 +2052,10 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 10,
     "demand": {
       "byStage": {
-        "capture": 4,
         "deliver": 4,
         "retain": 6,
         "settle": 4,
+        "trust-compliance": 4,
       },
       "inFlight": 8,
       "primaryQueue": "renewals",
@@ -2095,10 +2084,10 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 9,
     "demand": {
       "byStage": {
-        "capture": 2,
         "deliver": 5,
         "retain": 5,
         "settle": 2,
+        "trust-compliance": 2,
       },
       "inFlight": 7,
       "primaryQueue": "renewals",
@@ -2840,9 +2829,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 8,
     "demand": {
       "byStage": {
-        "capture": 2,
+        "capture": 5,
         "deliver": 5,
-        "qualify": 3,
         "settle": 4,
       },
       "inFlight": 9,
@@ -2872,9 +2860,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 6,
     "demand": {
       "byStage": {
-        "capture": 3,
+        "capture": 7,
         "deliver": 6,
-        "qualify": 4,
         "settle": 4,
       },
       "inFlight": 10,
@@ -2904,9 +2891,8 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     "customers": 6,
     "demand": {
       "byStage": {
-        "capture": 2,
+        "capture": 4,
         "deliver": 3,
-        "qualify": 2,
         "settle": 3,
       },
       "inFlight": 6,

--- a/packages/storefront-templates/src/demo-business.ts
+++ b/packages/storefront-templates/src/demo-business.ts
@@ -4,6 +4,7 @@ import {
   type OperationalValueStreamStageKey,
 } from "./operational-value-stream";
 import { deriveTwinProfile, type TwinProfile, type TwinTemplate } from "./twin-profile";
+import { deriveTwinValueStreamBinding } from "./twin-value-stream";
 import { resolveDemoFlavor } from "./demo-flavor";
 
 /**
@@ -245,17 +246,6 @@ function humanizeCog(kind: string): string {
   return kind.split("-").map(titleCase).join(" ");
 }
 
-/** Map a twin queue to the value-stream stage its work sits in (Epic C grounding). */
-function stageForQueue(queueKey: string, loadBearing: OperationalValueStreamStageKey[]): OperationalValueStreamStageKey {
-  const k = queueKey.toLowerCase();
-  if (/(renew|atrisk|at-risk|laps|retain|grant)/.test(k)) return "retain";
-  if (/(dispatch|schedul|promised|deadline|hold)/.test(k)) return "qualify";
-  if (/(review|inspect|wip)/.test(k)) return "deliver";
-  if (/(restock|pick|tickets|ctas)/.test(k)) return "capture";
-  // intake / waitlist / requests / reservations / walkins / checkins → capture,
-  // unless the archetype's load-bearing stage is qualify (booking/rental).
-  return loadBearing.includes("qualify") ? "qualify" : "capture";
-}
 
 /** A plausible per-ticket value from the archetype's own item prices, else a
  *  category-shaped default. */
@@ -302,6 +292,9 @@ export function deriveDemoBusiness(
   const flavor = options.flavor ?? resolveDemoFlavor(archetype.archetypeId, archetype.category);
   const profile = deriveTwinProfile(archetype);
   const ovs = deriveOperationalValueStream(archetype);
+  // Grounding (workstream C): the single source of truth for which value-stream
+  // stage each twin queue's demand sits in.
+  const binding = deriveTwinValueStreamBinding(archetype);
 
   const currency = flavor?.currency ?? "GBP";
   const timezone = flavor?.timezone ?? "Europe/London";
@@ -378,7 +371,7 @@ export function deriveDemoBusiness(
       demand.push({
         key: `dm-${demandIndex}`,
         label: `${titleCase(workNoun)} #${1000 + demandIndex}`,
-        stageKey: stageForQueue(queue.key, ovs.loadBearingStageKeys),
+        stageKey: binding.queueToStage[queue.key],
         queueKey: queue.key,
         waitingMinutes: baseWait + i * intIn(4, 12, seed, `q-step-${queue.key}-${i}`),
         customerKey: nextCustomer(`q-cust-${queue.key}-${i}`),

--- a/packages/storefront-templates/src/index.ts
+++ b/packages/storefront-templates/src/index.ts
@@ -9,6 +9,7 @@ export * from "./archetypes/index";
 export * from "./media-profile";
 export * from "./operational-value-stream";
 export * from "./twin-profile";
+export * from "./twin-value-stream";
 export * from "./demo-business";
 export * from "./demo-business-load";
 export * from "./demo-flavor";

--- a/packages/storefront-templates/src/twin-value-stream.test.ts
+++ b/packages/storefront-templates/src/twin-value-stream.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { ALL_ARCHETYPES } from "./archetypes/index";
+import { deriveTwinProfile } from "./twin-profile";
+import { deriveOperationalValueStream } from "./operational-value-stream";
+import { deriveTwinValueStreamBinding } from "./twin-value-stream";
+
+describe("deriveTwinValueStreamBinding", () => {
+  it("binds every twin queue and zone to a stage the archetype actually has", () => {
+    for (const archetype of ALL_ARCHETYPES) {
+      const binding = deriveTwinValueStreamBinding(archetype);
+      const profile = deriveTwinProfile(archetype);
+      const ovs = deriveOperationalValueStream(archetype);
+      const stageKeys = new Set(ovs.stages.map((s) => s.key));
+
+      // Every queue + zone resolves, and only to a real stage of THIS archetype.
+      for (const q of profile.queues) {
+        expect(binding.queueToStage[q.key]).toBeDefined();
+        expect(stageKeys.has(binding.queueToStage[q.key])).toBe(true);
+      }
+      for (const z of profile.zones) {
+        expect(binding.zoneToStage[z.key]).toBeDefined();
+        expect(stageKeys.has(binding.zoneToStage[z.key])).toBe(true);
+      }
+      expect(stageKeys.has(binding.primaryStageKey)).toBe(true);
+    }
+  });
+
+  it("stages are ordered and partition the queues/zones consistently", () => {
+    for (const archetype of ALL_ARCHETYPES) {
+      const binding = deriveTwinValueStreamBinding(archetype);
+      const profile = deriveTwinProfile(archetype);
+
+      // Ordered by the OVS order.
+      const orders = binding.stages.map((s) => s.order);
+      expect(orders).toEqual([...orders].sort((a, b) => a - b));
+
+      // The per-stage queueKeys are a partition of the profile's queues.
+      const boundQueues = binding.stages.flatMap((s) => s.queueKeys).sort();
+      expect(boundQueues).toEqual(profile.queues.map((q) => q.key).sort());
+      const boundZones = binding.stages.flatMap((s) => s.zoneKeys).sort();
+      expect(boundZones).toEqual(profile.zones.map((z) => z.key).sort());
+
+      // Each stage's queueKeys agree with queueToStage.
+      for (const s of binding.stages) {
+        for (const qk of s.queueKeys) expect(binding.queueToStage[qk]).toBe(s.stageKey);
+      }
+    }
+  });
+
+  it("is deterministic", () => {
+    for (const archetype of ALL_ARCHETYPES) {
+      expect(deriveTwinValueStreamBinding(archetype)).toEqual(deriveTwinValueStreamBinding(archetype));
+    }
+  });
+
+  it("maps retain-style queues to Retain and dispatch/booking demand to its captured stage", () => {
+    // A SaaS/board archetype has renewals / at-risk queues → retain.
+    const saas = ALL_ARCHETYPES.find((a) => a.category === "software-platform");
+    if (saas) {
+      const b = deriveTwinValueStreamBinding(saas);
+      const p = deriveTwinProfile(saas);
+      const renewal = p.queues.find((q) => /renew|risk|cta/i.test(q.key));
+      if (renewal) expect(["retain"]).toContain(b.queueToStage[renewal.key]);
+    }
+
+    // A field-service archetype's dispatch queue → qualify.
+    const trades = ALL_ARCHETYPES.find((a) => a.category === "trades-maintenance");
+    if (trades) {
+      const b = deriveTwinValueStreamBinding(trades);
+      const p = deriveTwinProfile(trades);
+      const dispatch = p.queues.find((q) => /dispatch/i.test(q.key));
+      if (dispatch) expect(b.queueToStage[dispatch.key]).toBe("qualify");
+    }
+  });
+
+  it("gives rental archetypes a Return & Inspect binding", () => {
+    const rental = ALL_ARCHETYPES.find((a) => a.category === "asset-rental");
+    if (!rental) return;
+    const b = deriveTwinValueStreamBinding(rental);
+    expect(b.stages.some((s) => s.stageKey === "return-inspect")).toBe(true);
+  });
+});

--- a/packages/storefront-templates/src/twin-value-stream.ts
+++ b/packages/storefront-templates/src/twin-value-stream.ts
@@ -1,0 +1,155 @@
+import type { ArchetypeDefinition } from "./types";
+import { deriveTwinProfile, type TwinProfile, type TwinTemplate } from "./twin-profile";
+import {
+  deriveOperationalValueStream,
+  type OperationalValueStream,
+  type OperationalValueStreamStageKey,
+} from "./operational-value-stream";
+
+/**
+ * Twin ⇄ Value-Stream grounding (EP-LIVING-BUSINESS-EXCELLENCE, workstream C).
+ *
+ * The operational twin (`deriveTwinProfile`) renders *space* — zones and demand
+ * queues; the operational value stream (`deriveOperationalValueStream`) renders
+ * *flow* — the six-stage backbone (Attract → Capture → Qualify → Deliver → Settle
+ * → Retain, plus cross-cuts). Until now they were two disjoint sibling
+ * derivations, so the animation view and the architecture view were unrelated
+ * pictures of the same business.
+ *
+ * `deriveTwinValueStreamBinding` closes that gap: it binds each twin queue and
+ * zone to the value-stream stage its work actually sits in, so the twin's tiles
+ * map to the archetype's real process — the factory-automation lens of "queue
+ * depth + wait per stage". One pure derivation, consumed by the demo generator
+ * (per-stage demand), the live projection (per-stage flow), and the architecture
+ * view (the same stage labels).
+ *
+ * Design: docs/superpowers/specs/2026-07-15-living-business-excellence-program-design.md §2 (row C)
+ * Parent: docs/superpowers/specs/2026-07-12-operational-twin-framework-design.md
+ *
+ * PURE + DB-free + deterministic. The seventh member of the derive family.
+ */
+
+export interface TwinStageBinding {
+  stageKey: OperationalValueStreamStageKey;
+  stageLabel: string;
+  order: number;
+  loadBearing: boolean;
+  /** Twin queue keys whose demand sits at this stage. */
+  queueKeys: string[];
+  /** Twin zone keys where this stage's work physically happens. */
+  zoneKeys: string[];
+}
+
+export interface TwinValueStreamBinding {
+  archetypeId: string;
+  archetypeName: string;
+  template: TwinTemplate;
+  /** The archetype's OVS stages in order, each with the twin queues/zones bound to it. */
+  stages: TwinStageBinding[];
+  /** Every twin queue key → its value-stream stage. */
+  queueToStage: Record<string, OperationalValueStreamStageKey>;
+  /** Every twin zone key → its value-stream stage. */
+  zoneToStage: Record<string, OperationalValueStreamStageKey>;
+  /** The single stage that carries the archetype's primary demand (its load-bearing lens). */
+  primaryStageKey: OperationalValueStreamStageKey;
+}
+
+// ── Keyword → stage rules ──────────────────────────────────────────────────────
+// Ordered, first-match-wins; clamped to the stages the archetype actually has.
+
+interface Rule {
+  test: RegExp;
+  stage: OperationalValueStreamStageKey;
+}
+
+const QUEUE_RULES: Rule[] = [
+  { test: /(renew|at-?risk|laps|retain|grant|shift|moves)/, stage: "retain" },
+  { test: /(inspect|compliance|obligation)/, stage: "trust-compliance" },
+  { test: /(dispatch|schedul|promised|deadline|approv)/, stage: "qualify" },
+  { test: /(review|wip|in-?progress|bay)/, stage: "deliver" },
+  { test: /(return)/, stage: "return-inspect" },
+  // The demand-capture family (intake/waitlist/requests/reservations/walkins/
+  // checkins/holds/tickets/pickups/restock/ctas/online) is handled by the
+  // primary-stage fallback so it tracks where THIS archetype captures value.
+];
+
+const ZONE_RULES: Rule[] = [
+  { test: /(entrance|waitlist|intake|queue|online|back)/, stage: "capture" },
+  { test: /(grid|book|calendar|day)/, stage: "qualify" },
+  { test: /(return)/, stage: "return-inspect" },
+  { test: /(maintenance)/, stage: "operate-improve" },
+  { test: /(inspection)/, stage: "trust-compliance" },
+  { test: /(ready|pickup|out)/, stage: "settle" },
+  { test: /(kitchen|floor|bays?|map|runofshow|pipeline|programs|board|room|base|moves)/, stage: "deliver" },
+];
+
+function clamp(
+  stage: OperationalValueStreamStageKey,
+  available: ReadonlySet<OperationalValueStreamStageKey>,
+  fallback: OperationalValueStreamStageKey,
+): OperationalValueStreamStageKey {
+  return available.has(stage) ? stage : fallback;
+}
+
+function primaryStage(ovs: OperationalValueStream): OperationalValueStreamStageKey {
+  // The first load-bearing stage is where the archetype's value is captured or
+  // committed; it is the home of the primary demand queue.
+  return ovs.loadBearingStageKeys[0] ?? "capture";
+}
+
+function matchRule(
+  key: string,
+  rules: Rule[],
+  available: ReadonlySet<OperationalValueStreamStageKey>,
+  fallback: OperationalValueStreamStageKey,
+): OperationalValueStreamStageKey {
+  const k = key.toLowerCase();
+  for (const rule of rules) {
+    if (rule.test.test(k)) return clamp(rule.stage, available, fallback);
+  }
+  return fallback;
+}
+
+/**
+ * Bind an archetype's twin queues and zones to its value-stream stages. Pure and
+ * total: every queue and zone resolves to a stage the archetype actually has.
+ */
+export function deriveTwinValueStreamBinding(archetype: ArchetypeDefinition): TwinValueStreamBinding {
+  const profile: TwinProfile = deriveTwinProfile(archetype);
+  const ovs = deriveOperationalValueStream(archetype);
+  const available = new Set<OperationalValueStreamStageKey>(ovs.stages.map((s) => s.key));
+  const primary = clamp(primaryStage(ovs), available, "capture");
+
+  const queueToStage: Record<string, OperationalValueStreamStageKey> = {};
+  for (const queue of profile.queues) {
+    // Capture-family queues track the primary stage; the rest match by keyword.
+    queueToStage[queue.key] = matchRule(queue.key, QUEUE_RULES, available, primary);
+  }
+
+  const zoneToStage: Record<string, OperationalValueStreamStageKey> = {};
+  for (const zone of profile.zones) {
+    zoneToStage[zone.key] = matchRule(zone.key, ZONE_RULES, available, primary);
+  }
+
+  const stages: TwinStageBinding[] = ovs.stages
+    .slice()
+    .sort((a, b) => a.order - b.order)
+    .map((s) => ({
+      stageKey: s.key,
+      stageLabel: s.label,
+      order: s.order,
+      loadBearing: s.loadBearing,
+      queueKeys: profile.queues.filter((q) => queueToStage[q.key] === s.key).map((q) => q.key),
+      zoneKeys: profile.zones.filter((z) => zoneToStage[z.key] === s.key).map((z) => z.key),
+    }));
+
+  return {
+    archetypeId: archetype.archetypeId,
+    archetypeName: archetype.name,
+    template: profile.template,
+    stages,
+    queueToStage,
+    zoneToStage,
+    primaryStageKey: primary,
+  };
+}


### PR DESCRIPTION
## Summary

Workstream **C** (`EP-LIVING-BUSINESS-EXCELLENCE` / `BI-DE577C43`): bind the operational twin's zones/queues to the operational **value-stream stages**, so the twin's tiles map to the archetype's real process — the factory-automation lens of *queue depth + wait per stage* — instead of the animation-view and the architecture-view being two unrelated pictures.

This is **C-1**: the pure binding derivation + generator refactor. **C-2** (per-stage flow in the live loader / `TwinView`, live-verified) follows.

## What landed

- **`packages/storefront-templates/src/twin-value-stream.ts`** — `deriveTwinValueStreamBinding(archetype)` → `TwinValueStreamBinding`:
  - `queueToStage` / `zoneToStage` — every twin queue/zone → its OVS stage, **clamped** to the stages the archetype actually has;
  - ordered `stages[]` — each OVS stage with the twin queues/zones bound to it;
  - `primaryStageKey` — where the archetype's primary demand sits.

  Pure, total, deterministic — the 7th member of the derive family. **Not** a `TwinProfile` schema change (spec §6.3): a derivation *over* profile + OVS, so both stay stable and the ADR-4 override story is intact.
- **Refactor:** `deriveDemoBusiness` now takes each demand item's `stageKey` from `binding.queueToStage` (single source of truth; the private `stageForQueue` duplication is removed).

## Test plan

- [x] Binding over all 94: every queue **and** zone resolves to a real stage *of that archetype*; `primaryStageKey` valid
- [x] `stages[]` ordered by OVS order; per-stage `queueKeys`/`zoneKeys` **partition** the profile's queues/zones and agree with `queueToStage`
- [x] Deterministic; rental → **Return & Inspect** present; dispatch → **Qualify**; renewals → **Retain**
- [x] Golden snapshot regenerated (per-stage demand counts now reflect the grounded mapping)
- [x] `@dpf/storefront-templates` **259/259**; typecheck clean

## Related

Epic **EP-LIVING-BUSINESS-EXCELLENCE** · BI **BI-DE577C43** (workstream C). Program §2 row C; plan `docs/superpowers/plans/2026-07-16-twin-value-stream-grounding-execution.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)