### PR TITLE
feat(capacity): real weekly-quota signal replaces exhaustion proxy (BI-723F2497)

### DIFF
--- a/apps/web/lib/capacity/drain-policy.test.ts
+++ b/apps/web/lib/capacity/drain-policy.test.ts
@@ -70,4 +70,53 @@ describe("evaluateDrain", () => {
     expect(d.drain).toBe(false);
     expect(d.reason).toMatch(/WIP cap reached/);
   });
+
+  it("reports the proxy signal when no fresh snapshot is present", () => {
+    const d = evaluateDrain(base());
+    expect(d.signal).toBe("proxy");
+  });
+});
+
+describe("evaluateDrain — real weekly-quota signal", () => {
+  it("drains and reports the real signal when remaining is high", () => {
+    const d = evaluateDrain(base({ weeklyRemainingRatio: 0.8 }));
+    expect(d.drain).toBe(true);
+    expect(d.signal).toBe("real");
+    expect(d.reason).toMatch(/real/);
+    expect(d.reason).toMatch(/80% weekly allocation remaining/);
+  });
+
+  it("stops when the weekly allocation is essentially spent — even in-window with a healthy pool", () => {
+    const d = evaluateDrain(base({ weeklyRemainingRatio: 0.02 }));
+    expect(d.drain).toBe(false);
+    expect(d.signal).toBe("real");
+    expect(d.reason).toMatch(/allocation spent/);
+  });
+
+  it("respects a custom minRemainingToDrain floor", () => {
+    // 15% remaining, but the floor is 20% → don't drain.
+    const d = evaluateDrain(base({ weeklyRemainingRatio: 0.15, minRemainingToDrain: 0.2 }));
+    expect(d.drain).toBe(false);
+    expect(d.reason).toMatch(/allocation spent/);
+  });
+
+  it("scales targetDispatch down as remaining shrinks", () => {
+    // wipCap 8, activeBuilds 0 → headroom 8; maxDispatch 4.
+    const plenty = evaluateDrain(base({ weeklyRemainingRatio: 0.95, activeBuilds: 0, wipCap: 8, maxDispatch: 4 }));
+    const little = evaluateDrain(base({ weeklyRemainingRatio: 0.15, activeBuilds: 0, wipCap: 8, maxDispatch: 4 }));
+    expect(plenty.targetDispatch).toBe(4); // ceil(4 * 0.95) = 4, bounded by cap
+    expect(little.targetDispatch).toBe(1); // ceil(4 * 0.15) = 1
+  });
+
+  it("still hard-stops on a 429 in flight even with plenty remaining", () => {
+    const d = evaluateDrain(base({ weeklyRemainingRatio: 0.9, poolExhausted: true }));
+    expect(d.drain).toBe(false);
+    expect(d.reason).toMatch(/429 in flight/);
+  });
+
+  it("still respects the drain window with the real signal", () => {
+    const d = evaluateDrain(base({ weeklyRemainingRatio: 0.9, windowResetAt: new Date("2026-07-14T12:00:00Z") })); // 48h out
+    expect(d.drain).toBe(false);
+    expect(d.reason).toMatch(/not in drain window/);
+  });
 });

--- a/apps/web/lib/capacity/drain-policy.ts
+++ b/apps/web/lib/capacity/drain-policy.ts
@@ -1,24 +1,47 @@
 // Pure capacity-drain policy — no server imports. Safe in tests and client code.
 //
 // "Use it or lose it": pre-paid weekly LLM allocation that isn't spent before the
-// weekly reset is wasted. When we're near the reset with a HEALTHY (non-exhausted)
-// pool and free build slots, proactively dispatch the top demand-ranked ready work
-// to consume the remaining allocation — bounded by the WIP cap so it never
-// overloads. Reuses the existing governed tee-up + WIP machinery (kernel decision
-// DI-5FED0D945EBB: capacity-aware tee-up throttle, not a parallel loop).
+// weekly reset is wasted. When we're near the reset with remaining allocation and
+// free build slots, proactively dispatch the top demand-ranked ready work to
+// consume it — bounded by the WIP cap so it never overloads. Reuses the existing
+// governed tee-up + WIP machinery (kernel decision DI-5FED0D945EBB: capacity-aware
+// tee-up throttle, not a parallel loop).
 //
-// The honest signal: the provider doesn't expose remaining weekly quota, so we use
-// a proxy — if the pool has NOT been rate-limited (CliPoolStatus not exhausted) and
-// we're inside the drain window before the reset, there is likely unspent
-// allocation worth draining. If the pool IS exhausted, the allocation is already
-// fully used (or we're throttled) and we must not push more.
+// THE SIGNAL — real, with a proxy fallback:
+//   • REAL (preferred): the provider exposes remaining weekly quota after all —
+//     the same number every subscription client renders. When a FRESH snapshot is
+//     available (see weekly-quota.ts), we drain on `weeklyRemainingRatio` (1 −
+//     utilization) and the provider-authoritative `weeklyResetAt`, and stop once
+//     the allocation is essentially spent. This replaces the old proxy.
+//   • PROXY (fallback): when no fresh snapshot exists (collector not yet wired, a
+//     stale/failed read, or an API-key install off the subscription meter), we
+//     fall back to the original heuristic — pool NOT rate-limited + inside a
+//     window before a locally-computed reset.
+//
+// A 429 in flight (`poolExhausted`) is a hard stop in BOTH modes.
+//
+// RESET MODEL: research disproved the fixed-weekly-day assumption — the true reset
+// is a rolling ~72h anchored window, and the provider's own `resetsAt` is
+// authoritative. So `weeklyResetAt` (when present) wins; `nextWeeklyReset` below is
+// only the fallback used when we have no provider reset at all.
 
 const MS_PER_HOUR = 3_600_000;
 const HOURS_PER_WEEK = 168;
 
 /**
- * The next weekly reset boundary strictly after `now`, for a plan that resets on
- * `resetDow` (0=Sun … 6=Sat) at `resetHourUtc` (0–23) in UTC.
+ * Below this remaining fraction, the weekly allocation is essentially spent —
+ * draining more would only pile work into a near-empty budget. This is the real
+ * signal's replacement for the proxy's `poolExhausted` stop.
+ */
+const DEFAULT_MIN_REMAINING_TO_DRAIN = 0.05;
+
+/**
+ * FALLBACK ONLY. The next weekly reset boundary strictly after `now`, for a plan
+ * that resets on `resetDow` (0=Sun … 6=Sat) at `resetHourUtc` (0–23) in UTC.
+ *
+ * Retained only for the proxy path — when the provider gives us no `resetsAt`. The
+ * real reset is a rolling ~72h anchored window (not a fixed calendar day), so
+ * prefer the provider-authoritative `weeklyResetAt` whenever it is available.
  */
 export function nextWeeklyReset(now: Date, resetDow: number, resetHourUtc: number): Date {
   const dow = ((resetDow % 7) + 7) % 7;
@@ -39,11 +62,14 @@ export function nextWeeklyReset(now: Date, resetDow: number, resetHourUtc: numbe
 export type DrainPolicyInput = {
   enabled: boolean;
   now: Date;
-  /** Next weekly allocation reset (see nextWeeklyReset). */
+  /**
+   * Weekly allocation reset. Prefer the provider-authoritative value; fall back
+   * to nextWeeklyReset() only when no provider reset is available.
+   */
   windowResetAt: Date;
   /** Start draining once within this many hours of the reset. */
   drainWindowHours: number;
-  /** CLI subscription pool currently rate-limited (allocation spent / throttled)? */
+  /** CLI subscription pool currently rate-limited (429 in flight)? Hard stop. */
   poolExhausted: boolean;
   /** Non-terminal Build Studio builds in flight. */
   activeBuilds: number;
@@ -51,6 +77,18 @@ export type DrainPolicyInput = {
   wipCap: number;
   /** Max builds to dispatch in a single drain evaluation. */
   maxDispatch: number;
+  /**
+   * REAL SIGNAL: remaining weekly allocation as a fraction 0..1 (1 = fully
+   * unused), from a FRESH provider quota snapshot. Undefined when no fresh
+   * snapshot exists — the policy then falls back to the poolExhausted proxy.
+   */
+  weeklyRemainingRatio?: number;
+  /**
+   * Below this remaining fraction the allocation is essentially spent; stop
+   * draining. Only consulted when weeklyRemainingRatio is provided. Defaults to
+   * DEFAULT_MIN_REMAINING_TO_DRAIN.
+   */
+  minRemainingToDrain?: number;
 };
 
 export type DrainDecision = {
@@ -58,23 +96,43 @@ export type DrainDecision = {
   /** How many top-ranked ready items to dispatch now (0 when not draining). */
   targetDispatch: number;
   hoursUntilReset: number;
+  /** "real" when driven by a fresh quota snapshot, "proxy" when using the fallback. */
+  signal: "real" | "proxy";
   reason: string;
 };
 
 /**
  * Decide whether — and how much — to drain now. Pure and side-effect-free; the
  * caller (a scheduled evaluator) supplies live state and acts on the result.
+ *
+ * Uses the REAL remaining-allocation signal when a fresh snapshot is present
+ * (weeklyRemainingRatio defined); otherwise falls back to the pool-exhaustion
+ * proxy. A 429 in flight (poolExhausted) is a hard stop in both modes.
  */
 export function evaluateDrain(input: DrainPolicyInput): DrainDecision {
   const hoursUntilReset = Math.max(0, (input.windowResetAt.getTime() - input.now.getTime()) / MS_PER_HOUR);
-  const base = { drain: false as const, targetDispatch: 0, hoursUntilReset };
+  const hasRealSignal = typeof input.weeklyRemainingRatio === "number";
+  const signal: "real" | "proxy" = hasRealSignal ? "real" : "proxy";
+  const base = { drain: false as const, targetDispatch: 0, hoursUntilReset, signal };
 
   if (!input.enabled) return { ...base, reason: "capacity draining disabled" };
 
-  // A rate-limited pool means the weekly allocation is already being fully used
-  // (or we're throttled). Pushing more would only pile up doomed dispatches.
+  // A 429 in flight means back off regardless of what the quota number says —
+  // pushing more would only pile up doomed dispatches.
   if (input.poolExhausted) {
-    return { ...base, reason: "pool exhausted — allocation already spent or rate-limited" };
+    return { ...base, reason: "pool exhausted — 429 in flight, backing off" };
+  }
+
+  // Real-signal gate: if the weekly allocation is essentially spent, stop. This
+  // is the honest replacement for the proxy's "pool exhausted" stop — a low
+  // remaining number is the direct read the proxy could only infer from a 429.
+  const remaining = input.weeklyRemainingRatio ?? 1;
+  const minRemaining = input.minRemainingToDrain ?? DEFAULT_MIN_REMAINING_TO_DRAIN;
+  if (hasRealSignal && remaining <= minRemaining) {
+    return {
+      ...base,
+      reason: `weekly allocation spent (${(remaining * 100).toFixed(0)}% remaining ≤ ${(minRemaining * 100).toFixed(0)}% floor)`,
+    };
   }
 
   // Only drain the tail of the window; the normal cadence covers the rest.
@@ -88,15 +146,24 @@ export function evaluateDrain(input: DrainPolicyInput): DrainDecision {
     return { ...base, reason: `WIP cap reached (${input.activeBuilds}/${input.wipCap}) — no free slots` };
   }
 
-  const targetDispatch = Math.max(0, Math.min(headroom, Math.floor(input.maxDispatch)));
+  const capBound = Math.max(0, Math.floor(input.maxDispatch));
+  // With the real signal, scale dispatch to how much is left — burn harder when
+  // there's plenty of unused allocation, gently when it's nearly gone. In proxy
+  // mode there is no remaining number, so dispatch up to the full cap.
+  const scaled = hasRealSignal ? Math.ceil(capBound * remaining) : capBound;
+  const targetDispatch = Math.max(0, Math.min(headroom, capBound, scaled));
   if (targetDispatch === 0) {
-    return { ...base, reason: "maxDispatch is 0" };
+    return { ...base, reason: input.maxDispatch <= 0 ? "maxDispatch is 0" : "nothing to dispatch" };
   }
 
+  const detail = hasRealSignal
+    ? `${(remaining * 100).toFixed(0)}% weekly allocation remaining`
+    : "pool healthy (proxy)";
   return {
     drain: true,
     targetDispatch,
     hoursUntilReset,
-    reason: `draining: ${hoursUntilReset.toFixed(1)}h to reset, pool healthy, ${headroom} of ${input.wipCap} build slots free`,
+    signal,
+    reason: `draining (${signal}): ${hoursUntilReset.toFixed(1)}h to reset, ${detail}, ${headroom} of ${input.wipCap} build slots free`,
   };
 }

--- a/apps/web/lib/capacity/evaluate-drain.test.ts
+++ b/apps/web/lib/capacity/evaluate-drain.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { mostRestrictiveFreshWeekly } from "./evaluate-drain";
+import type { CliPoolState } from "@/lib/routing/cli-pool-status";
+
+const NOW = new Date("2026-07-16T12:00:00Z");
+
+function pool(overrides: Partial<CliPoolState> = {}): CliPoolState {
+  return {
+    adapterType: "claude-cli",
+    providerId: "anthropic-sub",
+    rateLimitedAt: NOW,
+    resetAt: null,
+    retryAfterSeconds: null,
+    errorSnippet: null,
+    isExhausted: false,
+    secondsUntilReset: null,
+    weeklyUtilization: null,
+    weeklyResetAt: null,
+    weeklySource: null,
+    weeklyObservedAt: null,
+    ...overrides,
+  };
+}
+
+describe("mostRestrictiveFreshWeekly", () => {
+  it("returns null when no pool carries a weekly reading", () => {
+    expect(mostRestrictiveFreshWeekly([pool(), pool({ adapterType: "codex-cli" })], NOW)).toBeNull();
+  });
+
+  it("picks the most-restrictive (highest utilization) fresh snapshot across adapters", () => {
+    const pools: CliPoolState[] = [
+      pool({ adapterType: "claude-cli", weeklyUtilization: 0.4, weeklyObservedAt: NOW, weeklySource: "anthropic-unified-headers" }),
+      pool({ adapterType: "codex-cli", weeklyUtilization: 0.85, weeklyObservedAt: NOW, weeklySource: "codex-app-server" }),
+    ];
+    const worst = mostRestrictiveFreshWeekly(pools, NOW);
+    expect(worst!.utilization).toBeCloseTo(0.85);
+    expect(worst!.source).toBe("codex-app-server");
+  });
+
+  it("ignores stale snapshots (a stale read must not read as plenty of quota)", () => {
+    const stale = pool({
+      weeklyUtilization: 0.9,
+      weeklyObservedAt: new Date("2026-07-16T11:00:00Z"), // 60m old > 30m default
+      weeklySource: "anthropic-oauth-usage",
+    });
+    expect(mostRestrictiveFreshWeekly([stale], NOW)).toBeNull();
+  });
+
+  it("prefers a fresh snapshot even if a staler one is more restrictive", () => {
+    const pools: CliPoolState[] = [
+      pool({ adapterType: "claude-cli", weeklyUtilization: 0.99, weeklyObservedAt: new Date("2026-07-16T10:00:00Z") }), // stale
+      pool({ adapterType: "codex-cli", weeklyUtilization: 0.3, weeklyObservedAt: NOW }), // fresh
+    ];
+    const worst = mostRestrictiveFreshWeekly(pools, NOW);
+    expect(worst!.utilization).toBeCloseTo(0.3);
+  });
+});

--- a/apps/web/lib/capacity/evaluate-drain.ts
+++ b/apps/web/lib/capacity/evaluate-drain.ts
@@ -5,6 +5,12 @@
 
 import type { PrismaClient } from "@dpf/db";
 import { evaluateDrain, nextWeeklyReset, type DrainDecision } from "./drain-policy";
+import {
+  deriveRemainingRatio,
+  isWeeklyQuotaFresh,
+  type WeeklyQuotaSnapshot,
+} from "@/lib/routing/weekly-quota";
+import type { CliPoolState } from "@/lib/routing/cli-pool-status";
 
 export type CapacityDrainResult = {
   drained: boolean;
@@ -15,7 +21,44 @@ export type CapacityDrainResult = {
   wipCap: number;
   /** Builds actually created this run (0 when not draining). */
   dispatched: number;
+  /** Real remaining weekly allocation (0..1) when a fresh snapshot drove the run; null in proxy mode. */
+  weeklyRemainingRatio: number | null;
+  /** Which provider signal produced weeklyRemainingRatio; null in proxy mode. */
+  weeklySource: string | null;
 };
+
+/**
+ * Reconstruct a WeeklyQuotaSnapshot from a pool row's weekly columns, or null if
+ * the row carries no weekly reading.
+ */
+function poolStateToSnapshot(p: CliPoolState): WeeklyQuotaSnapshot | null {
+  if (p.weeklyUtilization == null || p.weeklyObservedAt == null) return null;
+  return {
+    utilization: p.weeklyUtilization,
+    resetAt: p.weeklyResetAt,
+    source: (p.weeklySource as WeeklyQuotaSnapshot["source"]) ?? "anthropic-unified-headers",
+    observedAt: p.weeklyObservedAt,
+  };
+}
+
+/**
+ * Pick the MOST-RESTRICTIVE fresh weekly snapshot across adapters (highest
+ * utilization = lowest remaining), mirroring "any pool exhausted ⇒ don't push."
+ * Stale readings are dropped — a stale/failed read must not be trusted as
+ * "plenty of quota." Returns null when no fresh snapshot exists (proxy fallback).
+ */
+export function mostRestrictiveFreshWeekly(
+  pools: CliPoolState[],
+  now: Date,
+): WeeklyQuotaSnapshot | null {
+  let worst: WeeklyQuotaSnapshot | null = null;
+  for (const p of pools) {
+    const snap = poolStateToSnapshot(p);
+    if (!snap || !isWeeklyQuotaFresh(snap, now)) continue;
+    if (worst == null || snap.utilization > worst.utilization) worst = snap;
+  }
+  return worst;
+}
 
 /**
  * Evaluate whether to drain remaining weekly allocation and, if so, dispatch
@@ -55,9 +98,15 @@ export async function evaluateAndDrainCapacity(input: {
     where: { phase: { notIn: [...TERMINAL_BUILD_PHASES] }, abandonedAt: null, parentEpicId: null },
   });
 
+  // REAL signal: the most-restrictive fresh weekly-quota snapshot across adapters.
+  // When present, its provider-authoritative resetAt wins over the fixed-DOW
+  // fallback (the true reset is a rolling window, not a calendar day).
+  const weekly = mostRestrictiveFreshWeekly(pools, now);
+  const weeklyRemainingRatio = weekly ? deriveRemainingRatio(weekly) : undefined;
+
   const resetDow = config?.capacityResetDow ?? 1;
   const resetHourUtc = config?.capacityResetHourUtc ?? 0;
-  const windowResetAt = nextWeeklyReset(now, resetDow, resetHourUtc);
+  const windowResetAt = weekly?.resetAt ?? nextWeeklyReset(now, resetDow, resetHourUtc);
 
   const decision = evaluateDrain({
     enabled: config?.capacityDrainEnabled === true,
@@ -68,6 +117,7 @@ export async function evaluateAndDrainCapacity(input: {
     activeBuilds,
     wipCap: BUILD_WIP_CAP,
     maxDispatch: config?.capacityDrainMaxDispatch ?? 3,
+    weeklyRemainingRatio,
   });
 
   const shared = {
@@ -76,6 +126,8 @@ export async function evaluateAndDrainCapacity(input: {
     poolExhausted,
     activeBuilds,
     wipCap: BUILD_WIP_CAP,
+    weeklyRemainingRatio: weeklyRemainingRatio ?? null,
+    weeklySource: weekly?.source ?? null,
   };
 
   if (!decision.drain || input.dryRun === true) {

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -24,6 +24,7 @@ import {
   formatMessageForResponses,
 } from "@/lib/ai-inference";
 import { isAnthropic } from "./provider-utils";
+import { captureAnthropicWeeklyQuota } from "./cli-pool-status";
 import { registerExecutionAdapter } from "./execution-adapter-registry";
 import { extractToolCalls as extractTextualToolUse } from "./extract-tool-calls";
 // BI-98572A51: the single-GPU admission lane is canonical in resource-lane.ts so
@@ -380,6 +381,14 @@ export const chatAdapter: ExecutionAdapterHandler = {
     if (!res.ok) {
       const errBody = await res.text().catch(() => "");
       throw classifyHttpError(res.status, providerId, errBody, res.headers);
+    }
+
+    // Topology-free REAL weekly-quota capture: a subscription/OAuth Anthropic
+    // response carries anthropic-ratelimit-unified-7d-* headers with the true
+    // remaining weekly allocation. Persist them for the capacity-drain policy.
+    // No-op when absent (API-key traffic isn't on the weekly meter).
+    if (isAnthropic(providerId)) {
+      void captureAnthropicWeeklyQuota(providerId, res.headers);
     }
 
     // ChatGPT Responses API requires stream:true — collect SSE into final response

--- a/apps/web/lib/routing/cli-pool-status.test.ts
+++ b/apps/web/lib/routing/cli-pool-status.test.ts
@@ -16,6 +16,13 @@ vi.mock("@dpf/db", () => {
           return rows.get(where.adapterType) ?? null;
         }),
         findMany: vi.fn(async () => [...rows.values()]),
+        update: vi.fn(async ({ where, data }: { where: { adapterType: string }; data: Record<string, unknown> }) => {
+          const existing = rows.get(where.adapterType);
+          if (!existing) throw new Error("Record to update not found");
+          const row = { ...existing, ...data };
+          rows.set(where.adapterType, row);
+          return row;
+        }),
         deleteMany: vi.fn(async ({ where }: { where: { adapterType: string } }) => {
           rows.delete(where.adapterType);
           return { count: 1 };
@@ -29,11 +36,24 @@ vi.mock("@dpf/db", () => {
 import {
   parseRetryAfterSeconds,
   recordCliRateLimit,
+  recordCliWeeklyQuota,
+  captureAnthropicWeeklyQuota,
   getCliPoolStatus,
   getAllCliPoolStatuses,
   clearCliRateLimit,
 } from "./cli-pool-status";
+import type { WeeklyQuotaSnapshot } from "./weekly-quota";
 import { prisma } from "@dpf/db";
+
+function snap(overrides: Partial<WeeklyQuotaSnapshot> = {}): WeeklyQuotaSnapshot {
+  return {
+    utilization: 0.4,
+    resetAt: new Date("2026-07-18T05:00:00Z"),
+    source: "anthropic-unified-headers",
+    observedAt: new Date("2026-07-16T12:00:00Z"),
+    ...overrides,
+  };
+}
 
 // Helper to reset the in-memory rows map between tests
 function clearMockRows() {
@@ -197,15 +217,88 @@ describe("clearCliRateLimit", () => {
     vi.clearAllMocks();
   });
 
-  it("removes the row so subsequent getCliPoolStatus returns null", async () => {
+  it("removes the row so subsequent getCliPoolStatus returns null (no weekly snapshot)", async () => {
     await recordCliRateLimit("claude-cli", "anthropic-sub", "Retry-After: 60");
     await clearCliRateLimit("claude-cli");
     const status = await getCliPoolStatus("claude-cli");
     expect(status).toBeNull();
   });
 
+  it("preserves the weekly-quota snapshot but clears exhaustion", async () => {
+    // A rate limit then a weekly reading, then a successful call clears it.
+    await recordCliRateLimit("claude-cli", "anthropic-sub", "Retry-After: 300");
+    await recordCliWeeklyQuota("claude-cli", "anthropic-sub", snap({ utilization: 0.6 }));
+    await clearCliRateLimit("claude-cli");
+
+    const status = await getCliPoolStatus("claude-cli");
+    expect(status).not.toBeNull();
+    // Exhaustion cleared…
+    expect(status!.isExhausted).toBe(false);
+    expect(status!.resetAt).toBeNull();
+    // …but the weekly signal survives.
+    expect(status!.weeklyUtilization).toBeCloseTo(0.6);
+    expect(status!.weeklySource).toBe("anthropic-unified-headers");
+  });
+
   it("swallows db errors without throwing", async () => {
-    vi.mocked(prisma.cliPoolStatus.deleteMany).mockRejectedValueOnce(new Error("db down"));
+    vi.mocked(prisma.cliPoolStatus.findUnique).mockRejectedValueOnce(new Error("db down"));
     await expect(clearCliRateLimit("claude-cli")).resolves.not.toThrow();
+  });
+});
+
+describe("recordCliWeeklyQuota", () => {
+  beforeEach(() => {
+    clearMockRows();
+    vi.clearAllMocks();
+  });
+
+  it("writes a quota-only row that reads as NOT exhausted", async () => {
+    await recordCliWeeklyQuota("claude-cli", "anthropic-sub", snap({ utilization: 0.42 }));
+    const status = await getCliPoolStatus("claude-cli");
+    expect(status).not.toBeNull();
+    expect(status!.weeklyUtilization).toBeCloseTo(0.42);
+    expect(status!.weeklyResetAt?.toISOString()).toBe("2026-07-18T05:00:00.000Z");
+    expect(status!.weeklyObservedAt?.toISOString()).toBe("2026-07-16T12:00:00.000Z");
+    // No rate-limit event → resetAt null → not exhausted.
+    expect(status!.isExhausted).toBe(false);
+  });
+
+  it("merges the weekly snapshot onto an existing rate-limited row without clearing exhaustion", async () => {
+    await recordCliRateLimit("codex-cli", "chatgpt", "Retry-After: 300");
+    await recordCliWeeklyQuota("codex-cli", "chatgpt", snap({ utilization: 0.9 }));
+    const status = await getCliPoolStatus("codex-cli");
+    expect(status!.isExhausted).toBe(true); // still rate-limited
+    expect(status!.weeklyUtilization).toBeCloseTo(0.9); // and now carries quota
+  });
+
+  it("swallows db errors without throwing", async () => {
+    vi.mocked(prisma.cliPoolStatus.upsert).mockRejectedValueOnce(new Error("db down"));
+    await expect(
+      recordCliWeeklyQuota("claude-cli", "anthropic-sub", snap()),
+    ).resolves.not.toThrow();
+  });
+});
+
+describe("captureAnthropicWeeklyQuota", () => {
+  beforeEach(() => {
+    clearMockRows();
+    vi.clearAllMocks();
+  });
+
+  it("records the weekly signal when unified-7d headers are present", async () => {
+    const headers = new Headers({
+      "anthropic-ratelimit-unified-7d-utilization": "0.55",
+      "anthropic-ratelimit-unified-7d-reset": "1784224800",
+    });
+    await captureAnthropicWeeklyQuota("anthropic", headers);
+    const status = await getCliPoolStatus("claude-cli");
+    expect(status!.weeklyUtilization).toBeCloseTo(0.55);
+    expect(status!.weeklySource).toBe("anthropic-unified-headers");
+  });
+
+  it("is a no-op when the weekly headers are absent (API-key traffic)", async () => {
+    await captureAnthropicWeeklyQuota("anthropic", new Headers({ "x-ratelimit-remaining-tokens": "5000" }));
+    expect(prisma.cliPoolStatus.upsert).not.toHaveBeenCalled();
+    expect(await getCliPoolStatus("claude-cli")).toBeNull();
   });
 });

--- a/apps/web/lib/routing/cli-pool-status.ts
+++ b/apps/web/lib/routing/cli-pool-status.ts
@@ -11,6 +11,7 @@
 // Spec: docs/superpowers/specs/2026-05-19-ai-cost-governance.md §4d
 
 import { prisma } from "@dpf/db";
+import { parseUnifiedRateLimitHeaders, type WeeklyQuotaSnapshot } from "./weekly-quota";
 
 export type CliAdapterType = "claude-cli" | "codex-cli";
 
@@ -48,6 +49,33 @@ export interface CliPoolState {
   isExhausted: boolean;
   /** Seconds until the pool is expected to be available again. Null if unknown. */
   secondsUntilReset: number | null;
+  /**
+   * Real remaining-weekly-allocation signal (the honest replacement for the
+   * exhaustion proxy). Fraction 0..1 of the weekly subscription window consumed;
+   * null until a snapshot has been collected. See weekly-quota.ts.
+   */
+  weeklyUtilization: number | null;
+  /** Provider-authoritative weekly reset time. Null when unknown. */
+  weeklyResetAt: Date | null;
+  /** Which provider signal produced weeklyUtilization. Null when unknown. */
+  weeklySource: string | null;
+  /** When the weekly snapshot was taken (staleness gate). Null when unknown. */
+  weeklyObservedAt: Date | null;
+}
+
+/** Map a raw CliPoolStatus row's weekly-quota columns onto the state shape. */
+function weeklyFields(row: {
+  weeklyUtilization: number | null;
+  weeklyResetAt: Date | null;
+  weeklySource: string | null;
+  weeklyObservedAt: Date | null;
+}): Pick<CliPoolState, "weeklyUtilization" | "weeklyResetAt" | "weeklySource" | "weeklyObservedAt"> {
+  return {
+    weeklyUtilization: row.weeklyUtilization,
+    weeklyResetAt: row.weeklyResetAt,
+    weeklySource: row.weeklySource,
+    weeklyObservedAt: row.weeklyObservedAt,
+  };
 }
 
 /**
@@ -173,6 +201,7 @@ export async function getCliPoolStatus(
       errorSnippet: row.errorSnippet,
       isExhausted,
       secondsUntilReset,
+      ...weeklyFields(row),
     };
   } catch (err) {
     console.warn("[cli-pool-status] Failed to read pool status:", { adapterType }, err);
@@ -202,6 +231,7 @@ export async function getAllCliPoolStatuses(): Promise<CliPoolState[]> {
         errorSnippet: row.errorSnippet,
         isExhausted,
         secondsUntilReset: isExhausted && resetMs != null ? Math.ceil((resetMs - now) / 1_000) : null,
+        ...weeklyFields(row),
       };
     });
   } catch (err) {
@@ -211,13 +241,128 @@ export async function getAllCliPoolStatuses(): Promise<CliPoolState[]> {
 }
 
 /**
+ * Record a weekly-quota snapshot for a CLI adapter — the REAL remaining-weekly-
+ * allocation signal that replaces the exhaustion proxy in the drain policy.
+ *
+ * Writes onto the same CliPoolStatus row (one per adapter), leaving the
+ * exhaustion fields (resetAt / retryAfterSeconds) untouched. A snapshot is not a
+ * rate-limit event: `resetAt` stays whatever it was, so `isExhausted` is
+ * unaffected. On first-ever write the row needs a `rateLimitedAt` (schema-
+ * required); we use the snapshot's observedAt as a neutral create timestamp
+ * while leaving `resetAt` null, so a quota-only row reads as NOT exhausted.
+ *
+ * Fire-and-forget: swallows errors so quota tracking never breaks a caller.
+ */
+export async function recordCliWeeklyQuota(
+  adapterType: CliAdapterType,
+  providerId: string,
+  snapshot: WeeklyQuotaSnapshot,
+): Promise<void> {
+  try {
+    await prisma.cliPoolStatus.upsert({
+      where: { adapterType },
+      create: {
+        adapterType,
+        providerId,
+        // Neutral create timestamp; resetAt stays null → not exhausted.
+        rateLimitedAt: snapshot.observedAt,
+        weeklyUtilization: snapshot.utilization,
+        weeklyResetAt: snapshot.resetAt,
+        weeklySource: snapshot.source,
+        weeklyObservedAt: snapshot.observedAt,
+        updatedAt: snapshot.observedAt,
+      },
+      update: {
+        providerId,
+        weeklyUtilization: snapshot.utilization,
+        weeklyResetAt: snapshot.resetAt,
+        weeklySource: snapshot.source,
+        weeklyObservedAt: snapshot.observedAt,
+        updatedAt: snapshot.observedAt,
+      },
+    });
+  } catch (err) {
+    console.warn("[cli-pool-status] Failed to record weekly quota:", { adapterType }, err);
+  }
+}
+
+/**
  * Clear the rate-limit record for a given adapter (e.g. after a successful call
  * proves the pool is available again).
+ *
+ * Preserves the weekly-quota snapshot when one is present: a successful call
+ * clears *exhaustion*, but must NOT wipe the real remaining-allocation reading
+ * the drain policy depends on. When the row carries no weekly snapshot, we delete
+ * it (original behaviour) so an idle adapter leaves no residual row.
  */
 export async function clearCliRateLimit(adapterType: CliAdapterType): Promise<void> {
   try {
-    await prisma.cliPoolStatus.deleteMany({ where: { adapterType } });
+    const row = await prisma.cliPoolStatus.findUnique({ where: { adapterType } });
+    if (!row) return;
+    if (row.weeklyUtilization == null) {
+      await prisma.cliPoolStatus.deleteMany({ where: { adapterType } });
+      return;
+    }
+    // Preserve the weekly snapshot; clear only the exhaustion fields.
+    await prisma.cliPoolStatus.update({
+      where: { adapterType },
+      data: { resetAt: null, retryAfterSeconds: null, errorSnippet: null, updatedAt: new Date() },
+    });
   } catch (err) {
     console.warn("[cli-pool-status] Failed to clear rate limit:", { adapterType }, err);
   }
+}
+
+/**
+ * Topology-free LIVE capture: extract the weekly-quota signal from a successful
+ * Anthropic HTTP response's `anthropic-ratelimit-unified-7d-*` headers and persist
+ * it against the claude-cli subscription pool. A real subscription/OAuth response
+ * carries these headers; API-key traffic (not on the weekly meter) does not, so
+ * this is a NO-OP unless the headers are present. Fire-and-forget from the adapter
+ * success path — never throws into the response flow.
+ */
+export async function captureAnthropicWeeklyQuota(
+  providerId: string,
+  headers: Headers | Record<string, string>,
+): Promise<void> {
+  try {
+    const snapshot = parseUnifiedRateLimitHeaders(headers);
+    if (!snapshot) return; // no weekly header → nothing to record (API-key path)
+    await recordCliWeeklyQuota("claude-cli", providerId, snapshot);
+  } catch (err) {
+    console.warn("[cli-pool-status] Failed to capture Anthropic weekly quota:", { providerId }, err);
+  }
+}
+
+/**
+ * SEAM — live weekly-quota collection for the CLI adapters.
+ *
+ * The pure parsers in weekly-quota.ts turn a provider reading into a snapshot;
+ * this is where a real reading would be *fetched* and handed to
+ * recordCliWeeklyQuota. It is intentionally a stub because live collection
+ * depends on runtime/credential topology that varies per install and could not
+ * be verified in the build that introduced it (autonomous, no operator):
+ *
+ *   • claude-cli:  read the CLI's OAuth token (e.g. ~/.claude/.credentials.json,
+ *     inside the adapter's container) → GET https://api.anthropic.com/api/oauth/usage
+ *     with headers `anthropic-beta: oauth-2025-04-20` and
+ *     `User-Agent: claude-code/<version>` (the User-Agent is REQUIRED — without it
+ *     the endpoint drops you into an aggressively rate-limited bucket) →
+ *     parseOAuthUsageJson(body).
+ *   • codex-cli:  spawn `codex app-server` (JSON-RPC): send `initialize`, wait
+ *     ~500ms for readiness, then `account/rateLimits/read` → parseCodexRateLimitsJson.
+ *
+ * Both endpoints are undocumented and their auth headers have changed before, so
+ * the collector must treat a failed/parse-less read as "no signal" (return
+ * without writing) — never as "plenty of quota." The direct-SDK adapter already
+ * captures the unified-7d headers on success (topology-free), so this seam is the
+ * remaining path, wired by a follow-up once the container/credential layout is
+ * confirmed. Left unimplemented so nothing hard-codes an unverified path.
+ */
+export async function collectCliWeeklyQuota(_adapterType: CliAdapterType): Promise<void> {
+  // Intentionally unimplemented — see the doc comment above. A follow-up wires
+  // the provider-native read + parse + recordCliWeeklyQuota once topology is
+  // confirmed. Until then, the topology-free direct-SDK capture path feeds the
+  // signal, and the policy falls back to the proxy when no fresh snapshot exists.
+  return;
 }

--- a/apps/web/lib/routing/weekly-quota.test.ts
+++ b/apps/web/lib/routing/weekly-quota.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  coerceResetDate,
+  deriveRemainingRatio,
+  isWeeklyQuotaFresh,
+  parseCodexRateLimitsJson,
+  parseOAuthUsageJson,
+  parseUnifiedRateLimitHeaders,
+  type WeeklyQuotaSnapshot,
+} from "./weekly-quota";
+
+const OBS = new Date("2026-07-16T12:00:00Z");
+
+describe("coerceResetDate", () => {
+  it("parses unix seconds (10-digit)", () => {
+    // 2026-07-16T18:00:00Z = 1784224800
+    expect(coerceResetDate(1784224800)?.toISOString()).toBe("2026-07-16T18:00:00.000Z");
+  });
+  it("parses unix seconds as a numeric string", () => {
+    expect(coerceResetDate("1784224800")?.toISOString()).toBe("2026-07-16T18:00:00.000Z");
+  });
+  it("parses unix milliseconds (13-digit)", () => {
+    expect(coerceResetDate(1784224800000)?.toISOString()).toBe("2026-07-16T18:00:00.000Z");
+  });
+  it("parses ISO strings", () => {
+    expect(coerceResetDate("2026-07-16T18:00:00Z")?.toISOString()).toBe("2026-07-16T18:00:00.000Z");
+  });
+  it("returns null for junk / null / non-positive", () => {
+    expect(coerceResetDate(null)).toBeNull();
+    expect(coerceResetDate("not-a-date")).toBeNull();
+    expect(coerceResetDate(0)).toBeNull();
+    expect(coerceResetDate(-5)).toBeNull();
+  });
+});
+
+describe("parseUnifiedRateLimitHeaders", () => {
+  it("reads unified-7d utilization + reset from a Headers object", () => {
+    const h = new Headers({
+      "anthropic-ratelimit-unified-7d-utilization": "0.63",
+      "anthropic-ratelimit-unified-7d-reset": "1784224800",
+      "anthropic-ratelimit-unified-5h-utilization": "0.10",
+    });
+    const snap = parseUnifiedRateLimitHeaders(h, OBS);
+    expect(snap).not.toBeNull();
+    expect(snap!.utilization).toBeCloseTo(0.63);
+    expect(snap!.resetAt?.toISOString()).toBe("2026-07-16T18:00:00.000Z");
+    expect(snap!.source).toBe("anthropic-unified-headers");
+    expect(snap!.observedAt).toBe(OBS);
+  });
+
+  it("takes the MOST-RESTRICTIVE weekly window across tier variants", () => {
+    const snap = parseUnifiedRateLimitHeaders(
+      {
+        "anthropic-ratelimit-unified-7d-utilization": "0.40",
+        "anthropic-ratelimit-unified-7d-reset": "1784224800",
+        "anthropic-ratelimit-unified-7d_opus-utilization": "0.85",
+        "anthropic-ratelimit-unified-7d_opus-reset": "1784228400",
+      },
+      OBS,
+    );
+    // 7d_opus is more consumed → it's the binding weekly limit.
+    expect(snap!.utilization).toBeCloseTo(0.85);
+    expect(snap!.resetAt?.toISOString()).toBe("2026-07-16T19:00:00.000Z");
+  });
+
+  it("returns null when no weekly header is present (API-key request)", () => {
+    const snap = parseUnifiedRateLimitHeaders(
+      { "anthropic-ratelimit-unified-5h-utilization": "0.2", "x-ratelimit-remaining-tokens": "5000" },
+      OBS,
+    );
+    expect(snap).toBeNull();
+  });
+
+  it("returns a snapshot even when the reset header is missing", () => {
+    const snap = parseUnifiedRateLimitHeaders({ "anthropic-ratelimit-unified-7d-utilization": "0.5" }, OBS);
+    expect(snap!.utilization).toBeCloseTo(0.5);
+    expect(snap!.resetAt).toBeNull();
+  });
+
+  it("clamps out-of-range utilization to [0,1]", () => {
+    const snap = parseUnifiedRateLimitHeaders({ "anthropic-ratelimit-unified-7d-utilization": "1.4" }, OBS);
+    expect(snap!.utilization).toBe(1);
+  });
+});
+
+describe("parseOAuthUsageJson", () => {
+  it("reads seven_day utilization + resets_at", () => {
+    const snap = parseOAuthUsageJson(
+      { five_hour: { utilization: 0.1 }, seven_day: { utilization: 0.72, resets_at: "2026-07-16T18:00:00Z" } },
+      OBS,
+    );
+    expect(snap!.utilization).toBeCloseTo(0.72);
+    expect(snap!.resetAt?.toISOString()).toBe("2026-07-16T18:00:00.000Z");
+    expect(snap!.source).toBe("anthropic-oauth-usage");
+  });
+
+  it("takes the most-restrictive of seven_day and seven_day_sonnet", () => {
+    const snap = parseOAuthUsageJson(
+      { seven_day: { utilization: 0.5, resets_at: 1784224800 }, seven_day_sonnet: { utilization: 0.9, resets_at: 1784228400 } },
+      OBS,
+    );
+    expect(snap!.utilization).toBeCloseTo(0.9);
+    expect(snap!.resetAt?.toISOString()).toBe("2026-07-16T19:00:00.000Z");
+  });
+
+  it("rescales a 0..100 used_percentage into 0..1", () => {
+    const snap = parseOAuthUsageJson({ seven_day: { used_percentage: 63 } }, OBS);
+    expect(snap!.utilization).toBeCloseTo(0.63);
+  });
+
+  it("returns null on an unrelated / empty body", () => {
+    expect(parseOAuthUsageJson({ five_hour: { utilization: 0.2 } }, OBS)).toBeNull();
+    expect(parseOAuthUsageJson(null, OBS)).toBeNull();
+    expect(parseOAuthUsageJson("nope", OBS)).toBeNull();
+  });
+});
+
+describe("parseCodexRateLimitsJson", () => {
+  it("reads rateLimits.secondary usedPercent (0..100) + resetsAt", () => {
+    const snap = parseCodexRateLimitsJson(
+      { rateLimits: { primary: { usedPercent: 12 }, secondary: { usedPercent: 47, resetsAt: "2026-07-16T18:00:00Z" } } },
+      OBS,
+    );
+    expect(snap!.utilization).toBeCloseTo(0.47);
+    expect(snap!.resetAt?.toISOString()).toBe("2026-07-16T18:00:00.000Z");
+    expect(snap!.source).toBe("codex-app-server");
+  });
+
+  it("accepts a full JSON-RPC envelope ({ result: { rateLimits } })", () => {
+    const snap = parseCodexRateLimitsJson(
+      { jsonrpc: "2.0", id: 1, result: { rateLimits: { secondary: { usedPercent: 30, resetsAt: 1784224800 } } } },
+      OBS,
+    );
+    expect(snap!.utilization).toBeCloseTo(0.3);
+    expect(snap!.resetAt?.toISOString()).toBe("2026-07-16T18:00:00.000Z");
+  });
+
+  it("returns null when secondary/weekly window is absent", () => {
+    expect(parseCodexRateLimitsJson({ rateLimits: { primary: { usedPercent: 12 } } }, OBS)).toBeNull();
+    expect(parseCodexRateLimitsJson({}, OBS)).toBeNull();
+  });
+});
+
+describe("deriveRemainingRatio", () => {
+  it("is 1 - utilization, clamped", () => {
+    const snap: WeeklyQuotaSnapshot = { utilization: 0.63, resetAt: null, source: "anthropic-oauth-usage", observedAt: OBS };
+    expect(deriveRemainingRatio(snap)).toBeCloseTo(0.37);
+  });
+});
+
+describe("isWeeklyQuotaFresh", () => {
+  const snap: WeeklyQuotaSnapshot = { utilization: 0.5, resetAt: null, source: "codex-app-server", observedAt: OBS };
+  it("is fresh within the max age", () => {
+    expect(isWeeklyQuotaFresh(snap, new Date("2026-07-16T12:20:00Z"))).toBe(true);
+  });
+  it("is stale past the max age", () => {
+    expect(isWeeklyQuotaFresh(snap, new Date("2026-07-16T12:45:00Z"))).toBe(false);
+  });
+  it("treats a future-dated (clock-skew) observedAt as not fresh", () => {
+    expect(isWeeklyQuotaFresh(snap, new Date("2026-07-16T11:00:00Z"))).toBe(false);
+  });
+});

--- a/apps/web/lib/routing/weekly-quota.ts
+++ b/apps/web/lib/routing/weekly-quota.ts
@@ -1,0 +1,245 @@
+// Pure weekly-quota normalizer — no server imports. Safe in tests and client code.
+//
+// The capacity-drain automation used to run on a PROXY signal: "the pool has not
+// been rate-limited, and we're inside a fixed-day-of-week reset window, so there
+// is probably unspent weekly allocation worth draining." That proxy was a
+// workaround for a wrong assumption — that the provider does not expose remaining
+// weekly quota. It does. Every Claude/Codex subscription client renders a weekly
+// limit because the provider hands the number back on a real API surface:
+//
+//   • Anthropic (claude-cli):  the `anthropic-ratelimit-unified-7d-*` response
+//     headers on every /v1/messages response — `-utilization` (fraction 0..1) and
+//     `-reset` (unix seconds) — plus model-tier variants (7d_opus, 7d_sonnet).
+//     Also the /api/oauth/usage endpoint → { seven_day: { utilization, resets_at } }.
+//   • Codex (codex-cli):  `codex app-server` JSON-RPC `account/rateLimits/read` →
+//     { rateLimits: { secondary: { usedPercent, resetsAt } } } (secondary = weekly).
+//
+// This module normalizes all three provider shapes into one WeeklyQuotaSnapshot so
+// the drain policy can burn against a REAL remaining-allocation number and a
+// provider-authoritative reset time, instead of the proxy + a fixed-DOW guess.
+//
+// It is pure parsing only — the live collection (reading container credentials,
+// spawning codex app-server) is a separate seam, because it depends on runtime
+// topology. See collectCliWeeklyQuota in cli-pool-status.ts.
+
+export type WeeklyQuotaSource =
+  | "anthropic-unified-headers"
+  | "anthropic-oauth-usage"
+  | "codex-app-server";
+
+export interface WeeklyQuotaSnapshot {
+  /** Fraction 0..1 of the weekly allocation already consumed. */
+  utilization: number;
+  /**
+   * When the weekly window resets, as reported by the provider. Authoritative
+   * when present — the research showed the true reset is a rolling ~72h anchored
+   * window, NOT a fixed calendar day, so any locally-computed weekly boundary is
+   * only a fallback. Null when the provider gave no reset value.
+   */
+  resetAt: Date | null;
+  /** Which provider signal produced this reading. */
+  source: WeeklyQuotaSource;
+  /** When this reading was taken (for staleness gating). */
+  observedAt: Date;
+}
+
+/** Clamp a raw utilization value into [0,1]; return null if not a finite number. */
+function coerceUtilization(value: unknown): number | null {
+  const n = typeof value === "string" ? Number(value) : (value as number);
+  if (typeof n !== "number" || !Number.isFinite(n)) return null;
+  return Math.min(1, Math.max(0, n));
+}
+
+/**
+ * Coerce a provider-supplied reset value to a Date. Providers are inconsistent:
+ *  - unix seconds (10-digit number or numeric string)
+ *  - unix milliseconds (13-digit)
+ *  - ISO-8601 string
+ * Returns null for anything unparseable or non-positive.
+ */
+export function coerceResetDate(value: unknown): Date | null {
+  if (value == null) return null;
+
+  if (typeof value === "number" || /^\d+$/.test(String(value).trim())) {
+    const num = typeof value === "number" ? value : Number(String(value).trim());
+    if (!Number.isFinite(num) || num <= 0) return null;
+    // Heuristic: >= 1e12 is already milliseconds; otherwise treat as seconds.
+    const ms = num >= 1e12 ? num : num * 1000;
+    const d = new Date(ms);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+
+  const d = new Date(String(value));
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Read a header case-insensitively from a Headers, Map, or plain record. */
+function getHeader(
+  headers: Headers | Map<string, string> | Record<string, string>,
+  name: string,
+): string | null {
+  const lower = name.toLowerCase();
+  if (typeof (headers as Headers).get === "function") {
+    return (headers as Headers).get(name) ?? (headers as Headers).get(lower) ?? null;
+  }
+  const rec = headers as Record<string, string>;
+  for (const key of Object.keys(rec)) {
+    if (key.toLowerCase() === lower) return rec[key] ?? null;
+  }
+  return null;
+}
+
+/** Collect every header key/value as lowercase-keyed entries. */
+function headerEntries(
+  headers: Headers | Map<string, string> | Record<string, string>,
+): Array<[string, string]> {
+  if (typeof (headers as Headers).forEach === "function" && typeof (headers as Headers).get === "function") {
+    const out: Array<[string, string]> = [];
+    (headers as Headers).forEach((v, k) => out.push([k.toLowerCase(), v]));
+    return out;
+  }
+  if (headers instanceof Map) {
+    return [...headers.entries()].map(([k, v]) => [k.toLowerCase(), String(v)]);
+  }
+  return Object.entries(headers as Record<string, string>).map(([k, v]) => [k.toLowerCase(), String(v)]);
+}
+
+/**
+ * Parse Anthropic unified rate-limit headers into a weekly snapshot.
+ *
+ * The weekly window is `anthropic-ratelimit-unified-7d-*`, but tier-scoped
+ * variants (`7d_opus`, `7d_sonnet`) each carry their own budget and can be the
+ * binding constraint. We take the MOST-RESTRICTIVE weekly window (max utilization)
+ * and its matching reset, so we never over-report remaining allocation.
+ *
+ * Returns null when no `unified-7d*-utilization` header is present (e.g. an
+ * API-key request that isn't on the subscription weekly meter).
+ */
+export function parseUnifiedRateLimitHeaders(
+  headers: Headers | Map<string, string> | Record<string, string>,
+  observedAt: Date = new Date(),
+): WeeklyQuotaSnapshot | null {
+  const entries = headerEntries(headers);
+  // Match any weekly claim: unified-7d-utilization, unified-7d_opus-utilization, …
+  const utilRe = /^anthropic-ratelimit-unified-(7d[\w-]*)-utilization$/;
+
+  let bestUtil: number | null = null;
+  let bestClaim: string | null = null;
+  for (const [key, val] of entries) {
+    const m = utilRe.exec(key);
+    if (!m) continue;
+    const u = coerceUtilization(val);
+    if (u == null) continue;
+    if (bestUtil == null || u > bestUtil) {
+      bestUtil = u;
+      bestClaim = m[1]!;
+    }
+  }
+
+  if (bestUtil == null || bestClaim == null) return null;
+
+  const resetRaw = getHeader(headers, `anthropic-ratelimit-unified-${bestClaim}-reset`);
+  return {
+    utilization: bestUtil,
+    resetAt: coerceResetDate(resetRaw),
+    source: "anthropic-unified-headers",
+    observedAt,
+  };
+}
+
+/**
+ * Parse the /api/oauth/usage JSON body (Claude Code's HUD source) into a weekly
+ * snapshot. Shape: { seven_day: { utilization, resets_at }, seven_day_sonnet: {…} }.
+ * Takes the most-restrictive of the weekly buckets.
+ */
+export function parseOAuthUsageJson(
+  body: unknown,
+  observedAt: Date = new Date(),
+): WeeklyQuotaSnapshot | null {
+  if (!body || typeof body !== "object") return null;
+  const obj = body as Record<string, unknown>;
+
+  const buckets = ["seven_day", "seven_day_sonnet", "seven_day_opus"];
+  let bestUtil: number | null = null;
+  let bestReset: unknown = null;
+  for (const name of buckets) {
+    const bucket = obj[name];
+    if (!bucket || typeof bucket !== "object") continue;
+    const b = bucket as Record<string, unknown>;
+    const u = coerceUtilization(b.utilization ?? b.used_percentage);
+    if (u == null) continue;
+    // Some payloads report used_percentage as 0..100; coerceUtilization clamps
+    // to [0,1], so a 0..100 value would saturate at 1. Detect and rescale.
+    const rawPct = typeof b.used_percentage === "number" ? b.used_percentage : null;
+    const util = rawPct != null && rawPct > 1 ? Math.min(1, rawPct / 100) : u;
+    if (bestUtil == null || util > bestUtil) {
+      bestUtil = util;
+      bestReset = b.resets_at ?? b.reset ?? null;
+    }
+  }
+
+  if (bestUtil == null) return null;
+  return {
+    utilization: bestUtil,
+    resetAt: coerceResetDate(bestReset),
+    source: "anthropic-oauth-usage",
+    observedAt,
+  };
+}
+
+/**
+ * Parse the `codex app-server` `account/rateLimits/read` JSON-RPC result into a
+ * weekly snapshot. Shape: { rateLimits: { primary: {…5h}, secondary: { usedPercent,
+ * resetsAt } } }. `secondary` is the weekly window; `usedPercent` is 0..100.
+ * Accepts either the full JSON-RPC envelope ({ result: { rateLimits } }) or the
+ * bare rateLimits object.
+ */
+export function parseCodexRateLimitsJson(
+  body: unknown,
+  observedAt: Date = new Date(),
+): WeeklyQuotaSnapshot | null {
+  if (!body || typeof body !== "object") return null;
+  const root = body as Record<string, unknown>;
+  const result = (root.result && typeof root.result === "object" ? root.result : root) as Record<string, unknown>;
+  const rateLimits = result.rateLimits ?? result.rate_limits;
+  if (!rateLimits || typeof rateLimits !== "object") return null;
+
+  const secondary = (rateLimits as Record<string, unknown>).secondary;
+  if (!secondary || typeof secondary !== "object") return null;
+  const s = secondary as Record<string, unknown>;
+
+  const pct = s.usedPercent ?? s.used_percent ?? s.utilization;
+  let util: number | null = null;
+  if (typeof pct === "number" || typeof pct === "string") {
+    const n = Number(pct);
+    if (Number.isFinite(n)) util = n > 1 ? Math.min(1, n / 100) : Math.min(1, Math.max(0, n));
+  }
+  if (util == null) return null;
+
+  return {
+    utilization: util,
+    resetAt: coerceResetDate(s.resetsAt ?? s.resets_at ?? s.reset ?? null),
+    source: "codex-app-server",
+    observedAt,
+  };
+}
+
+/** Remaining weekly allocation as a fraction 0..1 (1 = fully unused). */
+export function deriveRemainingRatio(snapshot: WeeklyQuotaSnapshot): number {
+  return Math.min(1, Math.max(0, 1 - snapshot.utilization));
+}
+
+/**
+ * Is this snapshot fresh enough to trust? Quota readings go stale fast (the
+ * account keeps spending), and the collection endpoints are undocumented and
+ * have broken before — so a stale/failed read must NOT be trusted as "plenty of
+ * quota." Default max age: 30 minutes.
+ */
+export function isWeeklyQuotaFresh(
+  snapshot: WeeklyQuotaSnapshot,
+  now: Date = new Date(),
+  maxAgeMs = 30 * 60 * 1000,
+): boolean {
+  const age = now.getTime() - snapshot.observedAt.getTime();
+  return age >= 0 && age <= maxAgeMs;
+}

--- a/docs/superpowers/plans/2026-07-16-capacity-weekly-quota-signal.md
+++ b/docs/superpowers/plans/2026-07-16-capacity-weekly-quota-signal.md
@@ -1,0 +1,74 @@
+# Capacity Drain — Real Weekly-Quota Signal (replace the exhaustion proxy)
+
+**Date:** 2026-07-16
+**Epic:** EP-DEMAND-MGMT (capacity automation follow-up)
+**Kernel decision:** capacity-weekly-quota-signal-build — `substrate-plus-policy-seam`
+(consulted `principle_decide`; commandments *Never Assume — Verify*, *Least
+privilege*, *Never adopt an unvetted external tool*, *Architecture Over Shortcuts*,
+*Do the work* ruled out both the blind full-live-collection option and the
+minimal-only option).
+
+## Problem
+
+The use-it-or-lose-it capacity-drain automation (PR #3060, BI-656F4E4B) shipped on
+a **proxy** signal: "the CLI pool has not been rate-limited (`CliPoolStatus` not
+exhausted) and we're inside a fixed-day-of-week reset window, so there's probably
+unspent weekly allocation worth draining." The proxy existed because we assumed the
+provider does not expose remaining weekly quota.
+
+Research disproved both halves of that assumption:
+
+1. **The provider DOES expose remaining weekly quota** — it's the same number every
+   Claude/Codex subscription client renders:
+   - Anthropic: `anthropic-ratelimit-unified-7d-*` response headers on every
+     `/v1/messages` response (`-utilization` 0..1, `-reset` unix), plus tier
+     variants (`7d_opus`, `7d_sonnet`); and `GET /api/oauth/usage`
+     → `{ seven_day: { utilization, resets_at } }`.
+   - Codex: `codex app-server` JSON-RPC `account/rateLimits/read`
+     → `{ rateLimits: { secondary: { usedPercent, resetsAt } } }` (secondary = weekly).
+2. **The reset is NOT a fixed calendar day** — community monitoring showed a rolling
+   ~72h anchored window; the provider-supplied `resetsAt` is authoritative, so the
+   locally-computed fixed-DOW boundary is only a fallback.
+
+## Design (this PR)
+
+Pure spine + corrected policy + one topology-free live path + one documented seam.
+
+- **`lib/routing/weekly-quota.ts`** (pure, no server imports): normalize all three
+  provider shapes into one `WeeklyQuotaSnapshot { utilization, resetAt, source,
+  observedAt }`. `parseUnifiedRateLimitHeaders` (most-restrictive weekly window),
+  `parseOAuthUsageJson`, `parseCodexRateLimitsJson`, `coerceResetDate`,
+  `deriveRemainingRatio`, `isWeeklyQuotaFresh` (30m staleness gate).
+- **Schema:** additive-nullable `weeklyUtilization/weeklyResetAt/weeklySource/
+  weeklyObservedAt` on `CliPoolStatus` (migration
+  `20260716120000_add_cli_pool_weekly_quota`). Fleet-safe.
+- **`lib/routing/cli-pool-status.ts`:** `recordCliWeeklyQuota` writer; `CliPoolState`
+  carries the weekly fields; `clearCliRateLimit` now **preserves** a weekly snapshot
+  (clears only exhaustion) so a successful call doesn't wipe the quota reading;
+  `captureAnthropicWeeklyQuota` (topology-free live capture from success headers).
+- **`lib/routing/chat-adapter.ts`:** on a successful Anthropic response, fire-and-
+  forget `captureAnthropicWeeklyQuota(res.headers)` — no-op when the unified headers
+  are absent (API-key traffic isn't on the weekly meter).
+- **`lib/capacity/drain-policy.ts`:** `evaluateDrain` consumes `weeklyRemainingRatio`
+  (from a fresh snapshot) and scales dispatch to how much is left; stops below a
+  `minRemainingToDrain` floor (the honest replacement for `poolExhausted`); a 429 in
+  flight remains a hard stop. Falls back to the proxy when no fresh snapshot. Reports
+  `signal: "real" | "proxy"`. `nextWeeklyReset` demoted to fallback.
+- **`lib/capacity/evaluate-drain.ts`:** reads the most-restrictive fresh weekly
+  snapshot across adapters; provider `resetAt` becomes the drain window boundary;
+  surfaces `weeklyRemainingRatio` + `weeklySource` on the result.
+
+## Seam (follow-up)
+
+`collectCliWeeklyQuota(adapterType)` in `cli-pool-status.ts` is a documented stub for
+the two CLI-native collectors (read container OAuth creds → `/api/oauth/usage`;
+spawn `codex app-server` → `account/rateLimits/read`). Left unwired because live
+collection depends on per-install container/credential topology that could not be
+verified in this autonomous build. Both endpoints are undocumented and their auth
+headers have changed before, so the collector must treat a failed/parse-less read as
+"no signal," never "plenty of quota."
+
+## Tests
+
+`weekly-quota.test.ts` (21), `cli-pool-status.test.ts` (+quota/capture/preserve),
+`drain-policy.test.ts` (+real-signal), `evaluate-drain.test.ts` (picker/staleness).

--- a/packages/db/prisma/migrations/20260716120000_add_cli_pool_weekly_quota/migration.sql
+++ b/packages/db/prisma/migrations/20260716120000_add_cli_pool_weekly_quota/migration.sql
@@ -1,0 +1,10 @@
+-- Real remaining-weekly-allocation signal on CliPoolStatus.
+-- Replaces the exhaustion-only proxy for the capacity-drain policy with the
+-- provider's own weekly quota number (Anthropic unified-7d headers / oauth
+-- usage, or codex account/rateLimits/read). Additive + nullable = fleet-safe:
+-- existing rows and the deployed machinery keep working with these unset.
+
+ALTER TABLE "CliPoolStatus" ADD COLUMN IF NOT EXISTS "weeklyUtilization" DOUBLE PRECISION;
+ALTER TABLE "CliPoolStatus" ADD COLUMN IF NOT EXISTS "weeklyResetAt" TIMESTAMP(3);
+ALTER TABLE "CliPoolStatus" ADD COLUMN IF NOT EXISTS "weeklySource" TEXT;
+ALTER TABLE "CliPoolStatus" ADD COLUMN IF NOT EXISTS "weeklyObservedAt" TIMESTAMP(3);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -12040,6 +12040,21 @@ model CliPoolStatus {
   retryAfterSeconds Int?
   /// First 300 chars of the stderr / error message for debugging.
   errorSnippet      String?
+  /// Real remaining-weekly-allocation signal (replaces the exhaustion proxy for
+  /// the capacity-drain policy). Fraction 0..1 of the weekly subscription window
+  /// consumed, from the provider's own quota surface (Anthropic unified-7d
+  /// headers / oauth usage, or codex account/rateLimits/read). Null until a
+  /// snapshot has been collected. See lib/routing/weekly-quota.ts.
+  weeklyUtilization Float?
+  /// Provider-authoritative weekly reset time (rolling ~72h anchored window, NOT
+  /// a fixed calendar day). Null when no snapshot / no reset reported.
+  weeklyResetAt     DateTime?
+  /// Which provider signal produced weeklyUtilization: "anthropic-unified-headers"
+  /// | "anthropic-oauth-usage" | "codex-app-server".
+  weeklySource      String?
+  /// When the weekly snapshot was taken — gates staleness (a stale read must not
+  /// be trusted as "plenty of quota").
+  weeklyObservedAt  DateTime?
   updatedAt         DateTime  @updatedAt
 
   @@index([adapterType, resetAt])


### PR DESCRIPTION
## What

Replaces the capacity-drain automation's **proxy** weekly-limit signal with the **real** remaining-weekly-allocation signal the provider actually exposes — the same number every Claude/Codex subscription client renders.

The use-it-or-lose-it drain (PR #3060, BI-656F4E4B) ran on a proxy (`CliPoolStatus` not exhausted + a fixed-day-of-week reset window) on the assumption the provider does not expose remaining weekly quota. Research disproved both halves:

- **The number is exposed:** Anthropic `anthropic-ratelimit-unified-7d-*` response headers (`-utilization` 0..1, `-reset` unix) + `GET /api/oauth/usage` (`seven_day.utilization / resets_at`); Codex `codex app-server` JSON-RPC `account/rateLimits/read` (`rateLimits.secondary`).
- **The reset is rolling, not a fixed day:** ~72h anchored window; the provider `resetsAt` is authoritative, so the fixed-DOW boundary is only a fallback.

## Design (kernel: `substrate-plus-policy-seam`)

- `lib/routing/weekly-quota.ts` — pure normalizer for all three provider shapes → one `WeeklyQuotaSnapshot`; `deriveRemainingRatio`; 30m `isWeeklyQuotaFresh` gate.
- `CliPoolStatus` — additive-nullable `weekly*` fields (migration `20260716120000`), fleet-safe.
- `recordCliWeeklyQuota` writer; `captureAnthropicWeeklyQuota` topology-free capture wired into the `chat-adapter` Anthropic **success** path (no-op when the unified headers are absent, i.e. API-key traffic); `clearCliRateLimit` now **preserves** the weekly snapshot (clears only exhaustion).
- `evaluateDrain` consumes `weeklyRemainingRatio` + provider `resetAt`, scales dispatch to remaining with a min-remaining floor (the honest replacement for `poolExhausted`), and **falls back to the proxy** when no fresh snapshot exists. A 429 in flight stays a hard stop. `nextWeeklyReset` demoted to fallback.

## Seam (deferred)

`collectCliWeeklyQuota` is a documented stub for the two CLI-native collectors (container OAuth creds → `/api/oauth/usage`; spawn `codex app-server` → `account/rateLimits/read`) — live collection depends on per-install container/credential topology that could not be verified in an autonomous build. Both endpoints are undocumented and their auth headers have changed before, so the collector must treat a failed read as "no signal," never "plenty of quota."

## Tests

`weekly-quota` (21), `cli-pool-status` (+quota/capture/preserve), `drain-policy` (+real-signal), `evaluate-drain` (picker/staleness). Full local capacity+routing suites green (82). `tsc --noEmit` clean.

Plan: `docs/superpowers/plans/2026-07-16-capacity-weekly-quota-signal.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)