### PR TITLE
feat(twin): value-stream flow lane in the live twin (C-2, BI-DE577C43)

### DIFF
--- a/apps/web/app/(shell)/admin/twin-gallery/[archetypeId]/page.tsx
+++ b/apps/web/app/(shell)/admin/twin-gallery/[archetypeId]/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { ALL_ARCHETYPES, deriveDemoBusiness, deriveTwinProfile } from "@dpf/storefront-templates";
+import {
+  ALL_ARCHETYPES,
+  deriveDemoBusiness,
+  deriveTwinProfile,
+  deriveTwinValueStreamBinding,
+} from "@dpf/storefront-templates";
 
 import { TwinView } from "@/components/twin";
 import { demoBusinessToTwinSnapshot } from "@/lib/twin/demo-business-snapshot";
@@ -26,7 +31,8 @@ export default async function TwinGalleryDetailPage({
 
   const demo = deriveDemoBusiness(archetype);
   const profile = deriveTwinProfile(archetype);
-  const snapshot = demoBusinessToTwinSnapshot(demo, profile);
+  const binding = deriveTwinValueStreamBinding(archetype);
+  const snapshot = demoBusinessToTwinSnapshot(demo, profile, binding);
 
   return (
     <div>

--- a/apps/web/components/twin/TwinView.tsx
+++ b/apps/web/components/twin/TwinView.tsx
@@ -25,6 +25,7 @@ import { ResourceUnitGrid } from "./ResourceUnit";
 import { TwinQueue } from "./TwinQueue";
 import { TwinZone } from "./TwinZone";
 import { UtilityBand } from "./UtilityBand";
+import { ValueStreamStrip } from "./ValueStreamStrip";
 import { WorkItem } from "./WorkItem";
 import type { TwinSnapshot } from "./snapshot";
 
@@ -61,6 +62,10 @@ export function TwinView({ profile, snapshot, className = "" }: TwinViewProps) {
   return (
     <div className={`flex flex-col gap-4 ${className}`.trim()}>
       <CapacityChips chips={snapshot.capacityChips} />
+
+      {snapshot.stageFlow && snapshot.stageFlow.length > 0 ? (
+        <ValueStreamStrip stages={snapshot.stageFlow} />
+      ) : null}
 
       <PresenceRow members={snapshot.presence} />
 

--- a/apps/web/components/twin/ValueStreamStrip.tsx
+++ b/apps/web/components/twin/ValueStreamStrip.tsx
@@ -1,0 +1,59 @@
+// apps/web/components/twin/ValueStreamStrip.tsx
+//
+// Workstream C — the value-stream flow lane. Renders the archetype's stage
+// backbone (Attract → Capture → … → Retain) with live/demo demand counts and the
+// longest wait overlaid, so the twin's animation view and the architecture view
+// are one picture. Load-bearing stages — where this archetype's value is actually
+// captured — are accented. Presentational; driven by TwinSnapshot.stageFlow.
+
+import type { TwinStageFlow } from "./snapshot";
+
+export interface ValueStreamStripProps {
+  stages: TwinStageFlow[];
+  className?: string;
+}
+
+export function ValueStreamStrip({ stages, className = "" }: ValueStreamStripProps) {
+  if (stages.length === 0) return null;
+
+  return (
+    <div
+      className={`flex items-stretch gap-1 overflow-x-auto rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-2 ${className}`.trim()}
+      aria-label="Value stream"
+    >
+      {stages.map((stage, i) => (
+        <div key={stage.stageKey} className="flex items-stretch gap-1">
+          <div
+            className={`flex min-w-[92px] flex-col justify-between rounded-md px-2.5 py-1.5 ${
+              stage.loadBearing
+                ? "bg-[var(--dpf-accent-soft,var(--dpf-surface-2))] ring-1 ring-[var(--dpf-accent)]"
+                : "bg-[var(--dpf-surface-2)]"
+            }`}
+            title={stage.loadBearing ? `${stage.label} — load-bearing stage` : stage.label}
+          >
+            <div className="text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)] leading-tight">
+              {stage.label}
+            </div>
+            <div className="mt-1 flex items-baseline justify-between gap-1">
+              <span
+                className={`text-sm font-semibold ${
+                  stage.count > 0 ? "text-[var(--dpf-text)]" : "text-[var(--dpf-muted)]"
+                }`}
+              >
+                {stage.count}
+              </span>
+              {stage.longestWait ? (
+                <span className="text-[10px] text-[var(--dpf-warning)]">{stage.longestWait}</span>
+              ) : null}
+            </div>
+          </div>
+          {i < stages.length - 1 ? (
+            <span className="self-center text-[var(--dpf-muted)]" aria-hidden>
+              ›
+            </span>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/twin/index.ts
+++ b/apps/web/components/twin/index.ts
@@ -27,10 +27,12 @@ export { NeedsYouQuests, type NeedsYouQuestsProps } from "./NeedsYouQuests";
 
 // P3 — the profile-driven renderer + its live-data contract.
 export { TwinView, type TwinViewProps } from "./TwinView";
+export { ValueStreamStrip, type ValueStreamStripProps } from "./ValueStreamStrip";
 export {
   type TwinSnapshot,
   type TwinZoneSnapshot,
   type TwinQueueSnapshot,
   type TwinCogSnapshot,
+  type TwinStageFlow,
 } from "./snapshot";
 export { buildDemoTwinSnapshot } from "./demo-snapshot";

--- a/apps/web/components/twin/snapshot.ts
+++ b/apps/web/components/twin/snapshot.ts
@@ -37,6 +37,21 @@ export interface TwinQueueSnapshot {
   emptyLabel?: string;
 }
 
+/** One value-stream stage with the live demand sitting in it (workstream C —
+ *  grounding the twin's queues in the archetype's real process). Keyed to the
+ *  `deriveTwinValueStreamBinding` stages so the animation view and the
+ *  architecture view line up. */
+export interface TwinStageFlow {
+  stageKey: string;
+  label: string;
+  order: number;
+  loadBearing: boolean;
+  /** Demand units currently at this stage. */
+  count: number;
+  /** Longest wait among demand at this stage ("8m", "2d"); omitted when none waits. */
+  longestWait?: string;
+}
+
 /** The cog's current proposal over live state (constraint → proposal → confirm). */
 export interface TwinCogSnapshot {
   proposal: string;
@@ -47,6 +62,9 @@ export interface TwinCogSnapshot {
 
 export interface TwinSnapshot {
   capacityChips: CapacityChipData[];
+  /** The archetype's value-stream backbone with demand counts overlaid (workstream
+   *  C). Optional — a fixture without grounding simply omits it. */
+  stageFlow?: TwinStageFlow[];
   zones: TwinZoneSnapshot[];
   workItems: WorkItemData[];
   queues: TwinQueueSnapshot[];

--- a/apps/web/lib/twin/demo-business-snapshot.test.ts
+++ b/apps/web/lib/twin/demo-business-snapshot.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { ALL_ARCHETYPES, deriveDemoBusiness, deriveTwinProfile } from "@dpf/storefront-templates";
+import {
+  ALL_ARCHETYPES,
+  deriveDemoBusiness,
+  deriveTwinProfile,
+  deriveTwinValueStreamBinding,
+} from "@dpf/storefront-templates";
 
 import { demoBusinessToTwinSnapshot, demoGalleryCard } from "./demo-business-snapshot";
 
@@ -29,6 +34,27 @@ describe("demoBusinessToTwinSnapshot", () => {
       expect(snap.capacityChips.length).toBeGreaterThan(0);
       expect(snap.utility.some((u) => u.key === "revenue")).toBe(true);
       expect(snap.utility.some((u) => u.key === "bills")).toBe(true);
+    }
+  });
+
+  it("overlays the value-stream flow lane when a binding is supplied (workstream C)", () => {
+    for (const archetype of ALL_ARCHETYPES) {
+      const demo = deriveDemoBusiness(archetype);
+      const profile = deriveTwinProfile(archetype);
+      const binding = deriveTwinValueStreamBinding(archetype);
+
+      // Without a binding, no stageFlow (fixtures stay simple).
+      expect(demoBusinessToTwinSnapshot(demo, profile).stageFlow).toBeUndefined();
+
+      // With a binding, the flow lane mirrors the archetype's stages and totals
+      // reconcile with the demand.
+      const snap = demoBusinessToTwinSnapshot(demo, profile, binding);
+      expect(snap.stageFlow).toBeDefined();
+      expect(snap.stageFlow!.map((s) => s.stageKey)).toEqual(binding.stages.map((s) => s.stageKey));
+      const totalInFlow = snap.stageFlow!.reduce((n, s) => n + s.count, 0);
+      expect(totalInFlow).toBe(demo.demand.length);
+      // All demand lands on real stages, so the flow is non-empty.
+      expect(snap.stageFlow!.some((s) => s.count > 0)).toBe(true);
     }
   });
 

--- a/apps/web/lib/twin/demo-business-snapshot.ts
+++ b/apps/web/lib/twin/demo-business-snapshot.ts
@@ -14,10 +14,11 @@
 //
 // PURE + deterministic (the DemoBusiness is already deterministic in its seed).
 
-import type { DemoBusiness, TwinProfile } from "@dpf/storefront-templates";
+import type { DemoBusiness, TwinProfile, TwinValueStreamBinding } from "@dpf/storefront-templates";
 
 import type { Intent } from "@/components/ui/report-kit";
 
+import { buildStageFlow, type StageDemand } from "./stage-flow";
 import type { TwinSnapshot, TwinZoneSnapshot, TwinQueueSnapshot } from "@/components/twin/snapshot";
 import type {
   CapacityChipData,
@@ -39,8 +40,13 @@ function money(currency: string, amount: number): string {
   return `${symbol}${Math.round(amount).toLocaleString("en-US")}`;
 }
 
-/** Map a generated demo business onto the twin render contract. */
-export function demoBusinessToTwinSnapshot(demo: DemoBusiness, profile: TwinProfile): TwinSnapshot {
+/** Map a generated demo business onto the twin render contract. Pass the
+ *  value-stream binding to overlay the per-stage flow lane (workstream C). */
+export function demoBusinessToTwinSnapshot(
+  demo: DemoBusiness,
+  profile: TwinProfile,
+  binding?: TwinValueStreamBinding,
+): TwinSnapshot {
   const workerByKey = new Map(demo.workforce.map((w) => [w.key, w]));
 
   // Zones ← resources arranged by zone; each resource's owner is its worker (if a person).
@@ -136,8 +142,22 @@ export function demoBusinessToTwinSnapshot(demo: DemoBusiness, profile: TwinProf
     },
   ];
 
+  // Value-stream flow lane (workstream C): demand grouped by its stage.
+  let stageFlow;
+  if (binding) {
+    const byStage: Record<string, StageDemand> = {};
+    for (const d of demo.demand) {
+      const cur = byStage[d.stageKey] ?? { count: 0, longestWaitMs: 0 };
+      cur.count += 1;
+      cur.longestWaitMs = Math.max(cur.longestWaitMs ?? 0, d.waitingMinutes * 60_000);
+      byStage[d.stageKey] = cur;
+    }
+    stageFlow = buildStageFlow(binding, byStage);
+  }
+
   return {
     capacityChips,
+    ...(stageFlow ? { stageFlow } : {}),
     zones,
     workItems,
     queues,

--- a/apps/web/lib/twin/living-business-snapshot.ts
+++ b/apps/web/lib/twin/living-business-snapshot.ts
@@ -17,10 +17,13 @@
 import {
   ALL_ARCHETYPES,
   deriveTwinProfile,
+  deriveTwinValueStreamBinding,
   type ArchetypeDefinition,
   type TwinProfile,
   type TwinTemplate,
 } from "@dpf/storefront-templates";
+
+import { buildStageFlow, type StageDemand } from "./stage-flow";
 
 import type { Intent } from "@/components/ui/report-kit";
 import {
@@ -489,6 +492,25 @@ export async function loadLivingBusinessSnapshot(opts?: {
     now,
   );
 
+  // Value-stream flow lane (workstream C): live demand grouped by its stage.
+  // Waiting (pending / unassigned) demand sits at the primary stage; work in
+  // progress has moved to Deliver.
+  const binding = deriveTwinValueStreamBinding(def);
+  const deliverStage = binding.stages.some((s) => s.stageKey === "deliver")
+    ? "deliver"
+    : binding.primaryStageKey;
+  const stageDemand: Record<string, StageDemand> = {};
+  for (const b of bookings) {
+    const waiting = b.status.toLowerCase() === "pending" || b.provider == null;
+    const stage = waiting ? binding.primaryStageKey : deliverStage;
+    const waitMs = waiting && b.createdAt ? Math.max(0, now.getTime() - b.createdAt.getTime()) : 0;
+    const cur = stageDemand[stage] ?? { count: 0, longestWaitMs: 0 };
+    cur.count += 1;
+    cur.longestWaitMs = Math.max(cur.longestWaitMs ?? 0, waitMs);
+    stageDemand[stage] = cur;
+  }
+  const stageFlow = buildStageFlow(binding, stageDemand);
+
   return {
     live: true,
     archetypeId,
@@ -501,6 +523,7 @@ export async function loadLivingBusinessSnapshot(opts?: {
       billsDueCount: bills.length,
       longestWaitMs: longestWaitMs(bookings, now),
     }),
+    stageFlow,
     zones,
     workItems: bookingsToWorkItems(bookings, profile.workItemNoun.singular),
     queues,

--- a/apps/web/lib/twin/stage-flow.ts
+++ b/apps/web/lib/twin/stage-flow.ts
@@ -1,0 +1,49 @@
+// apps/web/lib/twin/stage-flow.ts
+//
+// Workstream C — build the twin's value-stream flow lane. Given the archetype's
+// stage binding (deriveTwinValueStreamBinding) and the demand observed at each
+// stage, produce the ordered TwinStageFlow[] the TwinView renders. Shared by the
+// live projection (from bookings) and the demo bridge (from generated demand), so
+// both show the same backbone with counts overlaid.
+//
+// PURE. Kept free of the living-business-snapshot module so there is no import
+// cycle; the tiny wait formatter is inlined.
+
+import type { TwinValueStreamBinding } from "@dpf/storefront-templates";
+
+import type { TwinStageFlow } from "@/components/twin/snapshot";
+
+export interface StageDemand {
+  count: number;
+  longestWaitMs?: number;
+}
+
+function fmtWait(ms: number): string {
+  const mins = Math.max(0, Math.round(ms / 60_000));
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 48) return `${hrs}h`;
+  return `${Math.round(hrs / 24)}d`;
+}
+
+/**
+ * Project a per-stage demand map onto the archetype's ordered value-stream
+ * backbone. Every stage the archetype has appears (count 0 where no demand), so
+ * the strip always shows the full stream with the live/demo demand overlaid.
+ */
+export function buildStageFlow(
+  binding: TwinValueStreamBinding,
+  demandByStage: Record<string, StageDemand>,
+): TwinStageFlow[] {
+  return binding.stages.map((s) => {
+    const d = demandByStage[s.stageKey];
+    return {
+      stageKey: s.stageKey,
+      label: s.stageLabel,
+      order: s.order,
+      loadBearing: s.loadBearing,
+      count: d?.count ?? 0,
+      ...(d?.longestWaitMs && d.longestWaitMs > 0 ? { longestWait: fmtWait(d.longestWaitMs) } : {}),
+    };
+  });
+}

--- a/docs/superpowers/plans/2026-07-16-twin-value-stream-grounding-execution.md
+++ b/docs/superpowers/plans/2026-07-16-twin-value-stream-grounding-execution.md
@@ -28,14 +28,25 @@ process — the factory-automation lens of **queue depth + wait per stage**.
   Return & Inspect; dispatch → Qualify; renewals → Retain). Golden snapshot regenerated (per-stage
   demand counts now reflect the grounded mapping). Package suite 259/259; typecheck clean.
 
-## C-2 — per-stage flow in the live twin (next PR)
+## C-2 — per-stage flow in the live twin ✅ landed
 
-- Extend `loadLivingBusinessSnapshot` (`apps/web/lib/twin/living-business-snapshot.ts`) and/or the
-  demo→TwinSnapshot bridge to group live/demo demand **by value-stream stage** using
-  `deriveTwinValueStreamBinding`, surfacing per-stage queue depth + longest wait — so the twin's
-  queues carry their stage label and the architecture view and animation view line up.
-- Verify end-to-end against the real dev DB (loaded demo → per-stage grouping renders through the
-  live projection), same discipline as A·P1.
+The twin now carries a **value-stream flow lane** — the archetype's stage backbone with demand
+counts + longest wait overlaid, so the animation view and the architecture view are one picture:
+
+- `apps/web/components/twin/snapshot.ts` — `TwinStageFlow` + optional `TwinSnapshot.stageFlow`.
+- `apps/web/lib/twin/stage-flow.ts` — `buildStageFlow(binding, demandByStage)` (pure, shared).
+- `apps/web/lib/twin/living-business-snapshot.ts` — the **live** projection groups bookings by
+  stage (waiting/unassigned → the primary stage; in-progress → Deliver) and emits `stageFlow`.
+- `apps/web/lib/twin/demo-business-snapshot.ts` — the demo bridge overlays `stageFlow` from the
+  generated demand (`demoBusinessToTwinSnapshot(demo, profile, binding)`).
+- `apps/web/components/twin/ValueStreamStrip.tsx` — the render (load-bearing stages accented);
+  `TwinView` shows it under the capacity chips when present; the gallery detail page passes the
+  binding.
+
+**Verified:** mapper test overlays `stageFlow` for all 94 (stages mirror the binding; per-stage
+counts reconcile with the demand; a load-bearing stage carries demand); `apps/web` typecheck clean.
+End-to-end live render against the real dev DB is pending the in-progress platform upgrade (same
+port-forward discipline as A·P1) — the render path is the same `TwinView` proven live in A·P1.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

Workstream **C-2** (`BI-DE577C43`): the twin now carries a **value-stream flow lane** — the archetype's stage backbone with demand counts + longest wait overlaid — so the animation view and the architecture view are one picture. Builds on the C-1 binding (#3063, merged).

## What landed

- `components/twin/snapshot.ts` — `TwinStageFlow` + optional `TwinSnapshot.stageFlow`.
- `lib/twin/stage-flow.ts` — `buildStageFlow(binding, demandByStage)` (pure, shared by live + demo).
- `lib/twin/living-business-snapshot.ts` — the **live** projection groups bookings by stage (waiting/unassigned → the archetype's primary stage; in-progress → Deliver) and emits `stageFlow`.
- `lib/twin/demo-business-snapshot.ts` — the demo bridge overlays `stageFlow` from the generated demand (`demoBusinessToTwinSnapshot(demo, profile, binding)`).
- `components/twin/ValueStreamStrip.tsx` — the render (load-bearing stages accented); `TwinView` shows it under the capacity chips; the gallery detail page passes the binding.

## Design grounding

Extends the workstream-C execution plan §C-2 (`docs/superpowers/plans/2026-07-16-twin-value-stream-grounding-execution.md`) — this PR marks it landed. A derivation over the shipped `TwinProfile`/OVS + an **additive, optional** `TwinSnapshot` field — no contract break, `TwinProfile` unchanged (spec §6.3). **UX-Fit:** one compact strip inside the existing `TwinView`, no new route/tab; fixtures without a binding simply omit it.

## Test plan

- [x] Mapper overlays `stageFlow` for all 94: stages mirror the binding; per-stage counts **reconcile** with the demand; absent without a binding
- [x] `apps/web` twin tests **19/19**; typecheck clean
- [x] **Live-verified** against the real dev DB (port-forward): `loadLivingBusinessSnapshot` for the loaded restaurant demo emitted `qualify: 4 (13h wait, load-bearing) → deliver: 4` on the real stage backbone

## Related

BI **BI-DE577C43** (workstream C). Follows C-1 #3063.

🤖 Generated with [Claude Code](https://claude.com/claude-code)