### PR TITLE
fix(ux): accessible platform-health name + drop identity jargon in doc byline

### DIFF
--- a/apps/web/app/(shell)/workspace/documents/[documentId]/page.tsx
+++ b/apps/web/app/(shell)/workspace/documents/[documentId]/page.tsx
@@ -57,7 +57,7 @@ export default async function DocumentDetailPage({ params }: Props) {
           </div>
           <h1 className="mt-2 text-2xl font-semibold text-[var(--dpf-text)]">{document.title}</h1>
           <p className="mt-2 max-w-3xl text-sm text-[var(--dpf-muted)]">
-            Updated <LocalTime value={document.updatedAt} /> by {document.createdByName ?? document.ownerName ?? "unknown principal"}.
+            Updated <LocalTime value={document.updatedAt} /> by {document.createdByName ?? document.ownerName ?? "unknown"}.
           </p>
         </div>
         <div className="flex flex-wrap gap-2">

--- a/apps/web/components/monitoring/PlatformHealthIndicator.tsx
+++ b/apps/web/components/monitoring/PlatformHealthIndicator.tsx
@@ -37,6 +37,7 @@ export function PlatformHealthIndicator() {
         onClick={() => setOpen(!open)}
         className="flex items-center gap-1.5 px-2 py-1 rounded hover:bg-[var(--dpf-surface-2)] transition-colors"
         title={label}
+        aria-label={`Platform health: ${label}`}
       >
         <span
           className={`h-2 w-2 rounded-full ${health === "critical" ? "animate-pulse" : ""}`}


### PR DESCRIPTION
Two small, low-risk UX fixes surfaced by a workspace UX audit, verified against current `origin/main`.

## Changes
- **`monitoring/PlatformHealthIndicator`** — add `aria-label` so the global-header health indicator has a text equivalent in every state. Previously the healthy state rendered only a green dot (`aria-hidden`) with the label available solely via the hover `title` — color-only, and no accessible name for screen-reader/keyboard users. Fixes **WCAG 2.1 SC 1.4.1 (Use of Color)** / accessible-name.
- **`workspace/documents/[documentId]`** — drop identity-architecture jargon from the byline fallback: `"unknown principal"` → `"unknown"`.

## Scope notes
- A third audit finding (hardcoded status colors in `workspace/my-queue`) was **dropped**: that page differs from the audited copy on current `main` and no longer carries the issue.
- No new capability, contract, schema, or route; additive/label-only.

## Verification
- Structural: 2-line diff; `aria-label` is additive and doesn't touch the tested z-index logic; the byline change is copy-only.
- Local web typecheck was env-blocked in the source-only worktree (per-package `.bin` shims unresolved); **CI gates typecheck/build/tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)