### PR TITLE
docs(professions): author 2 data-architect data-modeling corpus pages (BI-62F934C9)

### DIFF
--- a/docs/professions/data-architect/wiki/data-governance-principles.md
+++ b/docs/professions/data-architect/wiki/data-governance-principles.md
@@ -1,0 +1,55 @@
+---
+title: Data Governance Principles
+pageKind: entity
+status: published
+abstract: Data governance is the exercise of authority and control over the management of data assets — deciding who can take what action, on which data, under which circumstances, and by which method. Its principles turn ownership, stewardship, quality, and accountability into enforceable policy rather than good intentions.
+sources:
+  - postgresql/data-definition
+  - gdpr/chap-3
+---
+
+## Definition
+
+**Data governance** is the exercise of authority, control, and shared decision-making over the management of data assets. Where data modelling decides *what* the data is and how it is structured, governance decides *who may do what with it, and who answers for the outcome*. The DAMA-DMBOK (Data Management Body of Knowledge) frames governance as the function that sits at the centre of every other data-management discipline — quality, security, architecture, metadata — because each of those needs an owner, a policy, and an accountability path to be real.
+
+Governance is not a tool or a one-time project; it is a standing operating model. Its output is a small number of durable principles applied consistently, not a large binder of rules nobody reads.
+
+## Core Principles
+
+- **Accountability** — every significant data asset has a named **owner** (accountable for its fitness for purpose and the policies that apply to it) and one or more **stewards** (responsible for day-to-day quality and definitions). "Everyone owns it" means no one does.
+- **Single authoritative definition** — a business term (customer, active account, revenue) has one agreed definition and one system of record. Governance resolves the conflicts *before* two teams build on contradictory meanings.
+- **Fitness for purpose (data quality)** — data is governed against explicit quality dimensions: **accuracy, completeness, consistency, timeliness, validity, and uniqueness**. Quality is measured, not assumed, and the acceptable threshold is a policy decision tied to how the data is used.
+- **Least authority** — access follows need. Read, write, and administrative rights are granted to the narrowest role that requires them, and privileged access is auditable. This is the governance principle that the [[professions/data-architect/least-privilege-db-access]] page operationalises at the database layer.
+- **Privacy and lawful use** — personal data carries obligations that travel with it: a lawful basis for processing, purpose limitation, retention limits, and the data-subject rights (access, rectification, erasure, portability) codified in regulations such as the GDPR. Governance is where those obligations become schema, retention jobs, and access rules rather than legal footnotes.
+- **Transparency and lineage** — where a data element came from, how it was transformed, and who changed it are recorded. Lineage makes both quality incidents and compliance requests answerable.
+
+## Roles
+
+| Role | Accountable / responsible for |
+|------|-------------------------------|
+| **Data owner** | The policies, classification, and acceptable use of a data domain; sign-off on access. |
+| **Data steward** | Definitions, quality rules, and issue resolution for specific data within a domain. |
+| **Data custodian** | The technical environment — storage, backups, access enforcement (often the DBA / platform team). |
+| **Data governance council** | Cross-domain arbitration: resolving conflicting definitions and approving enterprise-wide policy. |
+
+Separating **owner** (business authority) from **custodian** (technical control) is deliberate: the person who decides *who should* have access is not the same as the person who *implements* it, which preserves an audit boundary.
+
+## Enforcement Lives in the Engine, Not the Wiki
+
+A governance principle that exists only in a policy document drifts. The data architect's job is to push each principle down to where the database enforces it automatically:
+
+- **Ownership and access** → PostgreSQL **roles and `GRANT`/`REVOKE`**, so the least-authority principle is enforced on every connection, not trusted to application code.
+- **Valid values and integrity** → **`CHECK`, `NOT NULL`, `UNIQUE`, and foreign-key constraints**, so "completeness" and "validity" quality dimensions are guaranteed at write time.
+- **Classification and retention** → columns, row-level security policies, and scheduled deletion jobs that turn a retention policy into a mechanism.
+
+A governed data element is one where the rule and the enforcement point are the same object.
+
+## Why It Matters
+
+Ungoverned data fails quietly: two dashboards report different revenue, a deleted customer reappears from a copy, a regulator asks who accessed a record and no one can answer. Governance is the discipline that makes data trustworthy enough to make decisions on — and, for the Data Architect coworker, the frame that decides whether a proposed schema or access change is *allowed*, not merely *possible*.
+
+## See Also
+
+- [[professions/data-architect/data-modelling-concepts]]
+- [[professions/data-architect/least-privilege-db-access]]
+- [[professions/data-architect/schema-migration-practices]]

--- a/docs/professions/data-architect/wiki/schema-migration-practices.md
+++ b/docs/professions/data-architect/wiki/schema-migration-practices.md
@@ -1,0 +1,50 @@
+---
+title: Schema Migration Practices
+pageKind: entity
+status: published
+abstract: A schema migration is a versioned, ordered change to a database's structure applied as code. Safe migrations are backward-compatible, reversible where possible, and decoupled from the deploy so that old and new application versions can run against the same database during a rollout.
+sources:
+  - postgresql/data-definition
+---
+
+## Definition
+
+A **schema migration** is a change to the structure of a database — adding a table or column, altering a type, adding a constraint or index — captured as an ordered, versioned unit of code and applied deterministically to every environment. Migrations are how a data model *evolves* after it is in production, where the schema can no longer simply be recreated because it holds live data that must be preserved. In PostgreSQL the mechanism is `ALTER TABLE` (and `CREATE`/`DROP`) run inside a migration transaction; the discipline is in *how* those statements are sequenced and released.
+
+## Migrations Are Code
+
+- **Versioned and ordered** — each migration has a monotonic identifier; the tool applies pending migrations in order and records which have run. The schema state is a pure function of the migration history, so every environment converges to the same structure.
+- **Forward-only history, additive by default** — a migration that has been applied to a shared environment is never edited in place; a correction is a new migration. History is append-only for the same reason a ledger is.
+- **Reviewed like any change** — a migration is a diff that a reviewer reads, because a bad `ALTER` can lock a table or drop data. Migrations belong in the same PR as the code that depends on them.
+
+## The Expand / Contract Pattern
+
+The central practice for **zero-downtime** migration is to never make a single breaking change. Instead, split every incompatible change into backward-compatible steps so that the old and new application versions can both run against the database during the rollout window:
+
+1. **Expand** — add the new structure without removing the old. Add the new nullable column / new table / new index; deploy it *before* the code that needs it.
+2. **Migrate + dual-write** — backfill existing rows and have the application write to both old and new shapes while both code versions are live.
+3. **Contract** — once every running instance uses only the new shape, drop the old column/table in a later migration.
+
+Renaming a column, for example, is never a single `RENAME`: it is *add new column → backfill → write both → switch reads → drop old column*, spread across releases. The migration is decoupled from the deploy precisely so that a rollback of the application code does not require a rollback of the schema.
+
+## Safety Practices on PostgreSQL
+
+- **Prefer non-blocking operations.** Adding a column with no volatile default is fast; adding a `NOT NULL` or a new `CHECK`/foreign-key constraint validates every existing row and can take a long lock. Add the constraint as `NOT VALID` first, then `VALIDATE CONSTRAINT` in a separate step to avoid holding a heavy lock.
+- **Build indexes concurrently.** `CREATE INDEX CONCURRENTLY` avoids locking writes on a large table (at the cost of running outside a transaction).
+- **Keep the lock window short.** `ALTER TABLE` takes an `ACCESS EXCLUSIVE` lock; set a `lock_timeout` so a migration fails fast rather than queueing behind — and blocking — production traffic.
+- **Backfill in batches.** Update large tables in bounded chunks rather than one transaction that bloats WAL and holds locks.
+- **Test on production-like data.** A migration that is instant on an empty test database can lock a table for minutes on a table with a hundred million rows; measure against representative volume.
+
+## Reversibility
+
+Every migration should have a defined **down** path, or an explicit note that it is irreversible (a `DROP COLUMN` destroys data — its true reverse is *restore from backup*, not a `down` script). Additive expand-phase migrations are trivially reversible; destructive contract-phase migrations are the ones that must be gated behind confirmation that nothing still depends on the old shape.
+
+## Why It Matters
+
+Schema migration is where data modelling meets operational risk. A well-run migration practice lets a data model change continuously without outages, data loss, or a frozen release train; a careless one turns a one-line `ALTER` into a production incident. For the Data Architect coworker, proposing a migration means proposing the *sequence* — expand, backfill, contract — and the lock-safety plan, not just the final schema.
+
+## See Also
+
+- [[professions/data-architect/data-modelling-concepts]]
+- [[professions/data-architect/normalisation-and-denormalisation]]
+- [[professions/data-architect/data-governance-principles]]


### PR DESCRIPTION
## What

Authors the two missing WSID corpus pages for the `data-architect` profession family, closing the data-modeling half of its `coverageChecklist`.

- `docs/professions/data-architect/wiki/data-governance-principles.md`
- `docs/professions/data-architect/wiki/schema-migration-practices.md`

## Why these two

`docs/professions/registry.json` gives `data-architect` a **6-item** `coverageChecklist`:
`data-modelling-concepts`, `normalisation-and-denormalisation`, `sql-standards`, `data-security-sql-injection`, `data-governance-principles`, `schema-migration-practices`.

`data-modelling-concepts` and `normalisation-and-denormalisation` are **already published** on `main`; the SQL cluster covers the standards/security items. The only checklist topics with **no matching page** were **`data-governance-principles`** and **`schema-migration-practices`** — the two authored here.

## Content (research-grounded, not filler)

- **Data governance** — DAMA-DMBOK governance framing; owner/steward/custodian roles; the six data-quality dimensions; least-authority; GDPR data-subject rights (Chapter 3); and how each principle is pushed into the engine (roles/`GRANT`, constraints, RLS).
- **Schema migration** — migrations as versioned code; the **expand/contract** zero-downtime pattern; PostgreSQL lock-safety (`NOT VALID` + `VALIDATE`, `CREATE INDEX CONCURRENTLY`, `lock_timeout`, batched backfills); reversibility.

Both cite registered **open** sources from the seed's source registry (`postgresql/data-definition`, `gdpr/chap-3`); DAMA-DMBOK and ISO SQL remain checklist-only per the conduit rule. Frontmatter shape copied exactly from the existing pages in the dir.

## Seed pickup

`packages/db/src/seed-profession-corpus.ts` discovers pages via `walkMarkdownFiles(<family>/wiki)` (a glob), so the new files are **auto-included** — no enumeration change. Coverage is a page-count over checklist size (`apps/web/lib/coworker-record/roster.ts`); all six checklist slugs now have a matching published page. No live seed was run.

## Acceptance

- [x] Two new WSID corpus pages with valid frontmatter
- [x] Every checklist item now has a matching published page (slug-level coverage 100%)
- [x] Seed globs the dir — new pages picked up with no code change
- [x] Docs-only

Generated with Claude Code.