### PR TITLE
feat(twin): customer-outcome surface — revenue in + work delivered (D-2, BI-08C23C85)

### DIFF
--- a/apps/web/components/twin/OutcomesStrip.tsx
+++ b/apps/web/components/twin/OutcomesStrip.tsx
@@ -1,0 +1,51 @@
+// apps/web/components/twin/OutcomesStrip.tsx
+//
+// Workstream D — the customer-outcome surface. Renders the realized outcomes the
+// business is producing (revenue in, work delivered) as a prominent strip, so the
+// twin shows not just activity but that real value is being delivered.
+// Presentational; driven by TwinSnapshot.outcomes.
+
+import type { Intent } from "@/components/ui/report-kit";
+
+import type { TwinOutcome } from "./snapshot";
+
+const INTENT_COLOR: Record<Intent, string> = {
+  success: "var(--dpf-success)",
+  info: "var(--dpf-info, var(--dpf-text))",
+  warning: "var(--dpf-warning)",
+  danger: "var(--dpf-danger)",
+  neutral: "var(--dpf-text)",
+  accent: "var(--dpf-accent)",
+};
+
+export interface OutcomesStripProps {
+  outcomes: TwinOutcome[];
+  className?: string;
+}
+
+export function OutcomesStrip({ outcomes, className = "" }: OutcomesStripProps) {
+  if (outcomes.length === 0) return null;
+
+  return (
+    <div
+      className={`flex flex-wrap items-stretch gap-2 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface)] p-3 ${className}`.trim()}
+      aria-label="Customer outcomes"
+    >
+      <div className="mr-1 flex items-center text-[10px] font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+        Delivered
+      </div>
+      {outcomes.map((o) => (
+        <div key={o.key} className="flex min-w-[110px] flex-col rounded-md bg-[var(--dpf-surface-2)] px-3 py-1.5">
+          <span className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">{o.label}</span>
+          <span
+            className="text-base font-semibold leading-tight"
+            style={{ color: o.intent ? INTENT_COLOR[o.intent] : "var(--dpf-text)" }}
+          >
+            {o.value}
+          </span>
+          {o.hint ? <span className="text-[10px] text-[var(--dpf-muted)]">{o.hint}</span> : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/twin/TwinView.tsx
+++ b/apps/web/components/twin/TwinView.tsx
@@ -24,6 +24,7 @@ import { PresenceRow } from "./PresenceRow";
 import { ResourceUnitGrid } from "./ResourceUnit";
 import { TwinQueue } from "./TwinQueue";
 import { TwinZone } from "./TwinZone";
+import { OutcomesStrip } from "./OutcomesStrip";
 import { UtilityBand } from "./UtilityBand";
 import { ValueStreamStrip } from "./ValueStreamStrip";
 import { WorkItem } from "./WorkItem";
@@ -65,6 +66,10 @@ export function TwinView({ profile, snapshot, className = "" }: TwinViewProps) {
 
       {snapshot.stageFlow && snapshot.stageFlow.length > 0 ? (
         <ValueStreamStrip stages={snapshot.stageFlow} />
+      ) : null}
+
+      {snapshot.outcomes && snapshot.outcomes.length > 0 ? (
+        <OutcomesStrip outcomes={snapshot.outcomes} />
       ) : null}
 
       <PresenceRow members={snapshot.presence} />

--- a/apps/web/components/twin/index.ts
+++ b/apps/web/components/twin/index.ts
@@ -28,11 +28,13 @@ export { NeedsYouQuests, type NeedsYouQuestsProps } from "./NeedsYouQuests";
 // P3 — the profile-driven renderer + its live-data contract.
 export { TwinView, type TwinViewProps } from "./TwinView";
 export { ValueStreamStrip, type ValueStreamStripProps } from "./ValueStreamStrip";
+export { OutcomesStrip, type OutcomesStripProps } from "./OutcomesStrip";
 export {
   type TwinSnapshot,
   type TwinZoneSnapshot,
   type TwinQueueSnapshot,
   type TwinCogSnapshot,
   type TwinStageFlow,
+  type TwinOutcome,
 } from "./snapshot";
 export { buildDemoTwinSnapshot } from "./demo-snapshot";

--- a/apps/web/components/twin/snapshot.ts
+++ b/apps/web/components/twin/snapshot.ts
@@ -11,6 +11,8 @@
 // spine, scheduling — keyed by the profile. Until then `buildDemoTwinSnapshot`
 // (demo-snapshot.ts) fills it deterministically for the fixture.
 
+import type { Intent } from "@/components/ui/report-kit";
+
 import type {
   CapacityChipData,
   FeedEventData,
@@ -52,6 +54,16 @@ export interface TwinStageFlow {
   longestWait?: string;
 }
 
+/** A realized customer outcome — revenue in, work delivered (workstream D). The
+ *  proof that the machine is producing, not just busy. */
+export interface TwinOutcome {
+  key: string;
+  label: string;
+  value: string;
+  intent?: Intent;
+  hint?: string;
+}
+
 /** The cog's current proposal over live state (constraint → proposal → confirm). */
 export interface TwinCogSnapshot {
   proposal: string;
@@ -65,6 +77,9 @@ export interface TwinSnapshot {
   /** The archetype's value-stream backbone with demand counts overlaid (workstream
    *  C). Optional — a fixture without grounding simply omits it. */
   stageFlow?: TwinStageFlow[];
+  /** Realized customer outcomes — revenue in, work delivered (workstream D).
+   *  Optional; omitted when there is no outcome data. */
+  outcomes?: TwinOutcome[];
   zones: TwinZoneSnapshot[];
   workItems: WorkItemData[];
   queues: TwinQueueSnapshot[];

--- a/apps/web/lib/twin/demo-business-snapshot.test.ts
+++ b/apps/web/lib/twin/demo-business-snapshot.test.ts
@@ -34,6 +34,11 @@ describe("demoBusinessToTwinSnapshot", () => {
       expect(snap.capacityChips.length).toBeGreaterThan(0);
       expect(snap.utility.some((u) => u.key === "revenue")).toBe(true);
       expect(snap.utility.some((u) => u.key === "bills")).toBe(true);
+
+      // Customer outcomes (workstream D): revenue in + work delivered.
+      expect(snap.outcomes).toBeDefined();
+      expect(snap.outcomes!.some((o) => o.key === "revenue")).toBe(true);
+      expect(snap.outcomes!.some((o) => o.key === "delivered")).toBe(true);
     }
   });
 

--- a/apps/web/lib/twin/demo-business-snapshot.ts
+++ b/apps/web/lib/twin/demo-business-snapshot.ts
@@ -19,7 +19,12 @@ import type { DemoBusiness, TwinProfile, TwinValueStreamBinding } from "@dpf/sto
 import type { Intent } from "@/components/ui/report-kit";
 
 import { buildStageFlow, type StageDemand } from "./stage-flow";
-import type { TwinSnapshot, TwinZoneSnapshot, TwinQueueSnapshot } from "@/components/twin/snapshot";
+import type {
+  TwinSnapshot,
+  TwinZoneSnapshot,
+  TwinQueueSnapshot,
+  TwinOutcome,
+} from "@/components/twin/snapshot";
 import type {
   CapacityChipData,
   QueueItemData,
@@ -142,6 +147,25 @@ export function demoBusinessToTwinSnapshot(
     },
   ];
 
+  // Customer outcomes (workstream D): revenue realized + work delivered.
+  const paidInvoices = demo.finance.invoices.filter((v) => v.paid);
+  const outcomes: TwinOutcome[] = [
+    {
+      key: "revenue",
+      label: "Revenue in",
+      value: money(demo.currency, paidRevenue),
+      intent: "success",
+      hint: "Paid invoices",
+    },
+    {
+      key: "delivered",
+      label: "Delivered",
+      value: `${paidInvoices.length} job${paidInvoices.length === 1 ? "" : "s"}`,
+      intent: "info",
+      hint: "Settled & paid",
+    },
+  ];
+
   // Value-stream flow lane (workstream C): demand grouped by its stage.
   let stageFlow;
   if (binding) {
@@ -158,6 +182,7 @@ export function demoBusinessToTwinSnapshot(
   return {
     capacityChips,
     ...(stageFlow ? { stageFlow } : {}),
+    outcomes,
     zones,
     workItems,
     queues,

--- a/apps/web/lib/twin/living-business-snapshot.test.ts
+++ b/apps/web/lib/twin/living-business-snapshot.test.ts
@@ -196,6 +196,7 @@ describe("loadLivingBusinessSnapshot — loader", () => {
       bill: { findMany: async () => [] },
       taxObligationPeriod: { findMany: async () => [] },
       obligation: { findMany: async () => [] },
+      invoice: { findMany: async () => [] },
       storefrontBooking: { findMany: async () => [] },
       serviceProvider: { findMany: async () => [] },
     } as unknown as LivingBusinessClient;
@@ -238,6 +239,7 @@ describe("loadLivingBusinessSnapshot — loader", () => {
       bill: { findMany: async () => [{ amountDue: 500, dueDate: NOW, status: "open", currency: "GBP" }] },
       taxObligationPeriod: { findMany: async () => [{ dueDate: new Date("2026-07-20T00:00:00Z"), status: "open", filedAt: null }] },
       obligation: { findMany: async () => [] },
+      invoice: { findMany: async () => [] },
       storefrontBooking: {
         findMany: async () => [
           {

--- a/apps/web/lib/twin/living-business-snapshot.ts
+++ b/apps/web/lib/twin/living-business-snapshot.ts
@@ -39,6 +39,7 @@ import type {
   ResourceUnitData,
   TwinActor,
   TwinCogSnapshot,
+  TwinOutcome,
   TwinQueueSnapshot,
   TwinSnapshot,
   TwinZoneSnapshot,
@@ -51,6 +52,8 @@ type FindMany = (args: unknown) => Promise<unknown>;
 export type LivingBusinessClient = WorkforceRosterClient & {
   storefrontConfig: { findFirst: (args: unknown) => Promise<unknown> };
   bill: { findMany: FindMany };
+  /** Optional — outcomes (paid-invoice revenue) degrade to empty if absent. */
+  invoice?: { findMany: FindMany };
   taxObligationPeriod: { findMany: FindMany };
   obligation: { findMany: FindMany };
   storefrontBooking: { findMany: FindMany };
@@ -85,6 +88,10 @@ interface ProviderRow {
   id: string;
   name: string;
   isActive: boolean;
+}
+interface InvoiceRow {
+  totalAmount: Money;
+  currency: string | null;
 }
 
 export interface LiveTwinSnapshot extends TwinSnapshot {
@@ -420,7 +427,8 @@ export async function loadLivingBusinessSnapshot(opts?: {
 
   const profile: TwinProfile = deriveTwinProfile(def);
 
-  const [roster, bills, taxPeriods, obligations, bookings, providers] = await Promise.all([
+  const in90 = new Date(now.getTime() - 90 * 86_400_000);
+  const [roster, bills, taxPeriods, obligations, bookings, providers, paidInvoices] = await Promise.all([
     loadWorkforceRoster({ db }).catch(() => ({ members: [], summary: { total: 0, humans: 0, agents: 0, agentsWithUnmetNeeds: 0 } })),
     db.bill
       .findMany({
@@ -456,6 +464,14 @@ export async function loadLivingBusinessSnapshot(opts?: {
     db.serviceProvider
       .findMany({ where: { isActive: true }, take: 12, select: { id: true, name: true, isActive: true } })
       .catch(() => []) as Promise<ProviderRow[]>,
+    (db.invoice?.findMany
+      ? db.invoice
+          .findMany({
+            where: { paidAt: { not: null, gte: in90 } },
+            select: { totalAmount: true, currency: true },
+          })
+          .catch(() => [])
+      : Promise.resolve([])) as Promise<InvoiceRow[]>,
   ]);
 
   const members = roster.members;
@@ -511,6 +527,27 @@ export async function loadLivingBusinessSnapshot(opts?: {
   }
   const stageFlow = buildStageFlow(binding, stageDemand);
 
+  // Customer outcomes (workstream D): revenue realized in the last 90 days + the
+  // count of settled+paid work — the proof the business is producing.
+  const paidRevenue = paidInvoices.reduce((sum, inv) => sum + toNum(inv.totalAmount), 0);
+  const revenueCurrency = paidInvoices.find((i) => i.currency)?.currency ?? currency;
+  const outcomes: TwinOutcome[] = [
+    {
+      key: "revenue",
+      label: "Revenue in",
+      value: `${currencySymbol(revenueCurrency)}${Math.round(paidRevenue).toLocaleString("en-GB")}`,
+      intent: "success",
+      hint: "Paid · 90 days",
+    },
+    {
+      key: "delivered",
+      label: "Delivered",
+      value: `${paidInvoices.length} job${paidInvoices.length === 1 ? "" : "s"}`,
+      intent: "info",
+      hint: "Settled & paid",
+    },
+  ];
+
   return {
     live: true,
     archetypeId,
@@ -524,6 +561,7 @@ export async function loadLivingBusinessSnapshot(opts?: {
       longestWaitMs: longestWaitMs(bookings, now),
     }),
     stageFlow,
+    outcomes,
     zones,
     workItems: bookingsToWorkItems(bookings, profile.workItemNoun.singular),
     queues,

--- a/docs/superpowers/plans/2026-07-16-wwwd-outcomes-execution.md
+++ b/docs/superpowers/plans/2026-07-16-wwwd-outcomes-execution.md
@@ -1,0 +1,47 @@
+# WWWD Outcomes Loop — execution plan (workstream D)
+
+**Program:** [Living Business Excellence](../specs/2026-07-15-living-business-excellence-program-design.md) §2 (row D)
+**Epic:** `EP-LIVING-BUSINESS-EXCELLENCE` · BIs `BI-36815303` (D-1, cog gate) · `BI-08C23C85` (D-2, outcome surface)
+**Started:** 2026-07-16
+
+## Why
+
+The twin renders activity, but not *outcomes* — the proof the machine is producing. Workstream D
+makes real customer outcomes visible and (D-1) routes the consequential decisions the twin surfaces
+through the org's own WWWD stance.
+
+## D-2 — the customer-outcome surface ✅ landed (`BI-08C23C85`)
+
+The twin now carries an **outcomes strip** — revenue realized + work delivered — so the founder sees
+value being produced, not just demand moving:
+
+- `apps/web/components/twin/snapshot.ts` — `TwinOutcome` + optional `TwinSnapshot.outcomes`.
+- `apps/web/lib/twin/living-business-snapshot.ts` — the **live** projection reads paid invoices
+  (`Invoice.paidAt` within 90 days) → **Revenue in** + **Delivered** (count of settled+paid work).
+- `apps/web/lib/twin/demo-business-snapshot.ts` — the demo bridge emits the same from the generated
+  finance (paid invoices).
+- `apps/web/components/twin/OutcomesStrip.tsx` — the render; `TwinView` shows it under the
+  value-stream lane.
+
+**Verified:** mapper test asserts `outcomes` (revenue + delivered) for all 94; loader structural
+client extended with `invoice`; `apps/web` twin tests 19/19; typecheck clean. Live render pending a
+port-forward pass (same discipline as C-2).
+
+## D-1 — cog/quests through the WWWD gate (design note, `BI-36815303`)
+
+`evaluateOrgBusinessDecisionGate` (`apps/web/lib/decision-perspective/org-business-gate.ts`) is a
+**business-decision** gate — `{ question, options, domainClass, riskTier }` → `{ allowed, evaluation,
+operatorMessage }` — and it **records a `DecisionInteraction` per call**. So it must NOT run on every
+twin render (perf + semantics): the twin's routine allocation cog ("seat the next party") is not a
+stance-gated business decision.
+
+**Correct binding (follow-on):** gate the *action* when the operator confirms a cog proposal or acts
+on a quest that IS a consequential business decision (e.g. "approve £X of bills", "authorise this
+spend") — an action-time server action wrapping the gate, surfacing `operatorMessage` + the verdict.
+This is interactive and needs the running auth'd app to verify end-to-end, so it is scoped as a
+distinct follow-on rather than folded into the render path.
+
+## Non-goals
+
+- Not a new analytics warehouse (program spec §5): D surfaces the finance/work substrate the twin
+  already touches (`Invoice`, `StorefrontBooking`), not a new store.


### PR DESCRIPTION
## Summary

Workstream **D-2** (`BI-08C23C85`): the twin now shows **realized customer outcomes** — revenue in + work delivered — so the founder sees value being produced, not just demand moving. This is the "real customer outcomes being delivered, made visible" goal of the program's workstream D.

## What landed

- `components/twin/snapshot.ts` — `TwinOutcome` + optional `TwinSnapshot.outcomes`.
- `lib/twin/living-business-snapshot.ts` — the **live** projection reads paid invoices (`Invoice.paidAt` within 90 days) → **Revenue in** + **Delivered** (count of settled+paid work); the structural client gains `invoice`.
- `lib/twin/demo-business-snapshot.ts` — the demo bridge emits the same from generated finance (paid invoices).
- `components/twin/OutcomesStrip.tsx` — the render; `TwinView` shows it under the value-stream lane.

## D-1 reframing (see the plan)

`evaluateOrgBusinessDecisionGate` is a **business-decision** gate that records a `DecisionInteraction` per call — wrong to run on every twin render. D-1 (routing the cog/quests through the WWWD gate) is therefore scoped as an **action-time interactive follow-on** (`BI-36815303`): gate the *action* when the operator confirms a consequential decision. Documented in `docs/superpowers/plans/2026-07-16-wwwd-outcomes-execution.md`.

## Design grounding

Extends the program spec §2 row D (outcome surface). Additive **optional** `TwinSnapshot` field + one strip in the existing `TwinView` — no contract break, no new route/tab. Surfaces the existing finance substrate; **no new analytics store** (program §5 non-goal).

## Test plan

- [x] Mapper asserts `outcomes` (revenue + delivered) for all 94
- [x] Loader structural client extended with `invoice`; loader test fakes updated
- [x] `apps/web` twin tests **19/19**; typecheck clean

## Related

BI **BI-08C23C85** (D-2). Follows the twin-grounding PRs (C). Plan: `docs/superpowers/plans/2026-07-16-wwwd-outcomes-execution.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)