### PR TITLE
feat(ai-providers): surface real remaining weekly allocation on provider rows (BI-779FA953)

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/page.tsx
@@ -11,7 +11,7 @@ import { TokenSpendPanel } from "@/components/platform/TokenSpendPanel";
 import { ScheduledJobsTable } from "@/components/platform/ScheduledJobsTable";
 import { ServiceSection } from "@/components/platform/ServiceSection";
 import { ServiceRow } from "@/components/platform/ServiceRow";
-import { getAllCliPoolStatuses, type CliPoolState } from "@/lib/routing/cli-pool-status";
+import { getAllCliPoolStatuses, formatWeeklyAllocationHint, type CliPoolState } from "@/lib/routing/cli-pool-status";
 import { CliPoolStatusPanel } from "@/components/platform/CliPoolStatusPanel";
 import { cliAdapterTypeForProvider, deriveRoutingEligibility, type RoutingEligibility } from "@/lib/routing/provider-routing-eligibility";
 import { getRecentBudgetEvents, countRecentRejections } from "@/lib/inference/budget-events-data";
@@ -87,6 +87,7 @@ export default async function ProvidersPage() {
   const cliPoolByAdapter = new Map(cliPoolStatuses.map((s) => [s.adapterType, s] as const));
   const nowMs = now.getTime();
   const eligibilityById: Record<string, RoutingEligibility> = {};
+  const weeklyHintById: Record<string, string | null> = {};
   for (const pw of aiProviders) {
     const p = pw.provider;
     const adapterType = cliAdapterTypeForProvider(p.providerId);
@@ -107,6 +108,8 @@ export default async function ProvidersPage() {
       cliPoolExhausted: pool?.isExhausted ?? false,
       cliPoolResetHint: pool ? poolResetHint(pool) : null,
     });
+    // Real remaining weekly subscription allocation, when a fresh snapshot exists.
+    weeklyHintById[p.providerId] = pool ? formatWeeklyAllocationHint(pool, now) : null;
   }
 
   const lastSync = freshJobs.find((j) => j.jobId === "provider-registry-sync")?.lastRunAt;
@@ -203,6 +206,7 @@ export default async function ProvidersPage() {
                   key={pw.provider.providerId}
                   pw={pw}
                   eligibility={eligibilityById[pw.provider.providerId]!}
+                  weeklyAllocationHint={weeklyHintById[pw.provider.providerId] ?? null}
                   {...(modelSummaries.has(pw.provider.providerId) ? { modelSummary: modelSummaries.get(pw.provider.providerId)! } : {})}
                   {...(resolvesPhasesById.has(pw.provider.providerId) ? { resolvesPhases: resolvesPhasesById.get(pw.provider.providerId)! } : {})}
                 />

--- a/apps/web/components/platform/ServiceRow.test.tsx
+++ b/apps/web/components/platform/ServiceRow.test.tsx
@@ -124,6 +124,46 @@ describe("ServiceRow eligibility surface (BI-1C4AAE1E)", () => {
   });
 });
 
+describe("ServiceRow weekly allocation hint (BI-779FA953)", () => {
+  it("renders the real remaining weekly allocation when a hint is provided", () => {
+    const html = renderToStaticMarkup(
+      <ServiceRow
+        pw={pw(provider({ providerId: "anthropic", name: "Anthropic", authMethod: "oauth" }))}
+        eligibility={routable}
+        weeklyAllocationHint="63% weekly left · resets ~2d 4h"
+      />,
+    );
+    expect(html).toContain("63% weekly left · resets ~2d 4h");
+    // Informational only — it never replaces the routing answer.
+    expect(html).toContain("Routable");
+  });
+
+  it("shows the weekly hint even when the pool is rate-limited (independent of the 429 gate)", () => {
+    const rateLimited: RoutingEligibility = {
+      state: "rate_limited",
+      eligible: false,
+      label: "Rate-limited",
+      reason: "Temporarily rate-limited at the provider. Recovers in ~5min.",
+    };
+    const html = renderToStaticMarkup(
+      <ServiceRow
+        pw={pw(provider({ providerId: "anthropic", name: "Anthropic", authMethod: "oauth" }))}
+        eligibility={rateLimited}
+        weeklyAllocationHint="12% weekly left · resets ~18h"
+      />,
+    );
+    expect(html).toContain("12% weekly left · resets ~18h");
+    expect(html).toContain("Rate-limited");
+  });
+
+  it("renders nothing extra when no hint is provided", () => {
+    const html = renderToStaticMarkup(
+      <ServiceRow pw={pw(provider())} eligibility={routable} />,
+    );
+    expect(html).not.toContain("weekly left");
+  });
+});
+
 describe("ServiceRow calibrated routing scores (BI-1B46967D)", () => {
   it("renders the calibrated ModelProfile rollup scores, not a placeholder 50", () => {
     const html = renderToStaticMarkup(

--- a/apps/web/components/platform/ServiceRow.tsx
+++ b/apps/web/components/platform/ServiceRow.tsx
@@ -131,9 +131,16 @@ type Props = {
    * so the operator can see, on the providers list, which one to turn on.
    */
   resolvesPhases?: string[];
+  /**
+   * BI-779FA953: operator-facing weekly subscription allocation hint for a CLI-
+   * backed provider — "63% weekly left · resets ~2d 4h" — from the real quota
+   * snapshot. Informational (not a routing state); shown regardless of the 429
+   * gate so the operator can see remaining allocation. Null when no fresh reading.
+   */
+  weeklyAllocationHint?: string | null;
 };
 
-export function ServiceRow({ pw, modelSummary, eligibility, resolvesPhases }: Props) {
+export function ServiceRow({ pw, modelSummary, eligibility, resolvesPhases, weeklyAllocationHint }: Props) {
   const { provider, credential } = pw;
   const [expanded, setExpanded] = useState(false);
   const [hovered, setHovered] = useState(false);
@@ -207,6 +214,23 @@ export function ServiceRow({ pw, modelSummary, eligibility, resolvesPhases }: Pr
         >
           {provider.name}
         </span>
+
+        {/* BI-779FA953: real remaining weekly subscription allocation, when a
+            fresh quota snapshot is available. Informational — never gates routing. */}
+        {weeklyAllocationHint && (
+          <span
+            title={`Remaining pre-paid weekly LLM allocation for this subscription pool: ${weeklyAllocationHint}.`}
+            style={{
+              flexShrink: 0,
+              fontSize: 9,
+              fontVariantNumeric: "tabular-nums",
+              color: "var(--dpf-text-muted)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {weeklyAllocationHint}
+          </span>
+        )}
 
         {/* Routing eligibility — the single "can routing use this now?" answer */}
         <span title={eligibilityTitle} style={{ flexShrink: 0, display: "inline-flex" }}>

--- a/apps/web/lib/routing/cli-pool-status.test.ts
+++ b/apps/web/lib/routing/cli-pool-status.test.ts
@@ -38,6 +38,7 @@ import {
   recordCliRateLimit,
   recordCliWeeklyQuota,
   captureAnthropicWeeklyQuota,
+  formatWeeklyAllocationHint,
   getCliPoolStatus,
   getAllCliPoolStatuses,
   clearCliRateLimit,
@@ -300,5 +301,43 @@ describe("captureAnthropicWeeklyQuota", () => {
     await captureAnthropicWeeklyQuota("anthropic", new Headers({ "x-ratelimit-remaining-tokens": "5000" }));
     expect(prisma.cliPoolStatus.upsert).not.toHaveBeenCalled();
     expect(await getCliPoolStatus("claude-cli")).toBeNull();
+  });
+});
+
+describe("formatWeeklyAllocationHint", () => {
+  const NOW = new Date("2026-07-16T12:00:00Z");
+
+  it("returns null when there is no weekly reading", () => {
+    expect(formatWeeklyAllocationHint({ weeklyUtilization: null, weeklyResetAt: null, weeklyObservedAt: null }, NOW)).toBeNull();
+  });
+
+  it("formats remaining % with a day+hour reset hint", () => {
+    const hint = formatWeeklyAllocationHint(
+      { weeklyUtilization: 0.37, weeklyResetAt: new Date("2026-07-18T16:00:00Z"), weeklyObservedAt: NOW },
+      NOW,
+    );
+    expect(hint).toBe("63% weekly left · resets ~2d 4h");
+  });
+
+  it("uses hour granularity under a day", () => {
+    const hint = formatWeeklyAllocationHint(
+      { weeklyUtilization: 0.1, weeklyResetAt: new Date("2026-07-16T17:00:00Z"), weeklyObservedAt: NOW },
+      NOW,
+    );
+    expect(hint).toBe("90% weekly left · resets ~5h");
+  });
+
+  it("omits the reset hint when no reset is known", () => {
+    expect(
+      formatWeeklyAllocationHint({ weeklyUtilization: 0.5, weeklyResetAt: null, weeklyObservedAt: NOW }, NOW),
+    ).toBe("50% weekly left");
+  });
+
+  it("returns null for a stale reading (older than the display window)", () => {
+    const hint = formatWeeklyAllocationHint(
+      { weeklyUtilization: 0.2, weeklyResetAt: new Date("2026-07-18T12:00:00Z"), weeklyObservedAt: new Date("2026-07-15T00:00:00Z") },
+      NOW,
+    );
+    expect(hint).toBeNull();
   });
 });

--- a/apps/web/lib/routing/cli-pool-status.ts
+++ b/apps/web/lib/routing/cli-pool-status.ts
@@ -314,6 +314,44 @@ export async function clearCliRateLimit(adapterType: CliAdapterType): Promise<vo
 }
 
 /**
+ * Human-readable relative time until a future instant: "any moment", "~5min",
+ * "~3h", "~2d 4h". Returns null for a null date.
+ */
+function humanizeUntil(target: Date | null, now: Date): string | null {
+  if (!target) return null;
+  const secs = Math.round((target.getTime() - now.getTime()) / 1000);
+  if (secs <= 0) return "any moment";
+  if (secs < 3_600) return `~${Math.max(1, Math.round(secs / 60))}min`;
+  if (secs < 86_400) return `~${Math.round(secs / 3_600)}h`;
+  const days = Math.floor(secs / 86_400);
+  const hours = Math.round((secs % 86_400) / 3_600);
+  return hours > 0 ? `~${days}d ${hours}h` : `~${days}d`;
+}
+
+/**
+ * Operator-facing weekly-allocation hint for a CLI pool — "63% weekly left ·
+ * resets ~2d 4h" — from the real quota snapshot. The same number every
+ * subscription client renders, surfaced on the provider row so the operator can
+ * SEE remaining allocation (tell-don't-act), not just infer it from a 429.
+ *
+ * Returns null when there is no snapshot, or when the reading is older than
+ * `maxAgeMs` (default 24h) — a display can tolerate a staler value than the drain
+ * policy, but a wildly stale number should not masquerade as current.
+ */
+export function formatWeeklyAllocationHint(
+  state: Pick<CliPoolState, "weeklyUtilization" | "weeklyResetAt" | "weeklyObservedAt">,
+  now: Date = new Date(),
+  maxAgeMs = 24 * 60 * 60 * 1000,
+): string | null {
+  if (state.weeklyUtilization == null || state.weeklyObservedAt == null) return null;
+  const age = now.getTime() - state.weeklyObservedAt.getTime();
+  if (age < 0 || age > maxAgeMs) return null;
+  const remainingPct = Math.round(Math.min(1, Math.max(0, 1 - state.weeklyUtilization)) * 100);
+  const resetHint = humanizeUntil(state.weeklyResetAt, now);
+  return resetHint ? `${remainingPct}% weekly left · resets ${resetHint}` : `${remainingPct}% weekly left`;
+}
+
+/**
  * Topology-free LIVE capture: extract the weekly-quota signal from a successful
  * Anthropic HTTP response's `anthropic-ratelimit-unified-7d-*` headers and persist
  * it against the claude-cli subscription pool. A real subscription/OAuth response


### PR DESCRIPTION
## What

Completes the **operator-visible** half of the real weekly-quota signal (spine merged in #3065). CLI-backed provider rows on the AI providers page now show the real remaining pre-paid weekly subscription allocation — e.g. **"63% weekly left · resets ~2d 4h"** — from the quota snapshot captured on the Anthropic success path.

This directly closes the loop on the original observation that every subscription client renders a weekly limit: now DPF's operator sees it too, instead of inferring it from a 429.

## Design

- `formatWeeklyAllocationHint(pool)` (pure, `cli-pool-status.ts`) — remaining % + humanized reset hint; returns null with no snapshot or a >24h-stale reading (a display tolerates staler data than the drain policy, but not a wildly stale number).
- `ServiceRow` gains an optional `weeklyAllocationHint` prop → a small muted row badge. **Informational only** — it never gates routing (distinct from the `cliPoolExhausted` rate-limited state) and renders regardless of the 429 gate.
- `providers/page.tsx` computes the per-provider hint from the CLI pool and passes it.

`deriveRoutingEligibility` (the routing contract) is deliberately **untouched** — weekly allocation doesn't affect routability.

## Tests

`formatWeeklyAllocationHint` (5 cases: format, day/hour granularity, no-reset, staleness, null) + `ServiceRow` render (3: shows hint, shows even when rate-limited, absent when no hint). `tsc --noEmit` clean; module-size clean.

## Design grounding

Source of truth: the AI providers readiness page + `ServiceRow`'s existing informational-hint pattern (`cliPoolResetHint`). This mirrors that pattern for a new informational element — no routing-contract change, no new spec. Extends `docs/superpowers/plans/2026-07-16-capacity-weekly-quota-signal.md`.

## Deferred (BI-779FA953)

The two CLI-native collectors (container OAuth creds → `/api/oauth/usage`; `codex app-server`) stay deferred — topology-dependent. This ships the topology-free display half, fed by the existing capture path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)