### PR TITLE
feat(observability): reach-threshold + staging gate before a log signature becomes a BI (BI-51F6A428)

### DIFF
--- a/apps/web/lib/operate/issue-report-triage-runner.ts
+++ b/apps/web/lib/operate/issue-report-triage-runner.ts
@@ -9,6 +9,12 @@
 import { prisma } from "@dpf/db";
 
 import { ISSUE_REPORT_STATUS } from "@/lib/quality/issue-report-status";
+import { classifyIssueReportStream } from "@/lib/quality/issue-report-stream";
+import {
+  shouldPromoteIssueReport,
+  shouldExpireStagedReport,
+  MAX_NEW_PROMOTIONS_PER_WINDOW,
+} from "@/lib/quality/issue-report-promotion";
 
 import { triageIssueReports } from "./issue-report-triage";
 import { escalatePriorityForOccurrences } from "./process-observer-triage";
@@ -61,6 +67,10 @@ export async function runIssueReportTriage(opts: { reportId?: string } = {}) {
           source: true,
           errorDigest: true,
           selfFixClass: true,
+          // BI-51F6A428: accrual fields the reach gate evaluates.
+          occurrenceCount: true,
+          firstSeenAt: true,
+          lastSeenAt: true,
         },
       }),
 
@@ -101,9 +111,53 @@ export async function runIssueReportTriage(opts: { reportId?: string } = {}) {
     acknowledgeReport: async (id) => {
       await prisma.platformIssueReport.update({
         where: { id },
-        data: { status: ISSUE_REPORT_STATUS.TRIAGED_LOCAL },
+        // BI-51F6A428: clear the staging flag on promotion — the report has left
+        // the OPEN pool and been minted, so it is no longer held.
+        data: { status: ISSUE_REPORT_STATUS.TRIAGED_LOCAL, stagedUntilPromoted: false },
       });
     },
+
+    // ── Reach-threshold + staging gate wiring (BI-51F6A428) ─────────────────
+    // The gate applies ONLY to the reach-gated "noise-digest" stream (the
+    // automated log-signature treadmill). Every other stream — human/manual
+    // reports, crash-boundary, runtime faults — returns true here and projects
+    // immediately, exactly as before. shouldPromoteIssueReport itself always
+    // returns true for high/critical, so a loud signal is never held.
+    shouldPromote: (report) =>
+      classifyIssueReportStream(report) !== "noise-digest" ||
+      shouldPromoteIssueReport({
+        occurrenceCount: report.occurrenceCount ?? 1,
+        firstSeenAt: report.firstSeenAt ?? null,
+        lastSeenAt: report.lastSeenAt ?? null,
+        severity: report.severity,
+        now: new Date(),
+      }),
+
+    shouldExpire: (report) =>
+      shouldExpireStagedReport({
+        firstSeenAt: report.firstSeenAt ?? null,
+        lastSeenAt: report.lastSeenAt ?? null,
+        now: new Date(),
+      }),
+
+    stageReport: async (id) => {
+      await prisma.platformIssueReport.update({
+        where: { id },
+        data: { stagedUntilPromoted: true },
+      });
+    },
+
+    // Aging-out: a genuinely-stopped one-off is closed WITHOUT a BI. suppressed
+    // is the "closed, never became work" terminal status (also excluded from the
+    // scanner's open-dedupe check, so a true recurrence later can re-file).
+    expireStagedReport: async (id) => {
+      await prisma.platformIssueReport.update({
+        where: { id },
+        data: { status: ISSUE_REPORT_STATUS.SUPPRESSED, stagedUntilPromoted: false },
+      });
+    },
+
+    maxNewPromotions: MAX_NEW_PROMOTIONS_PER_WINDOW,
 
     // BI-0ACD9AB2 §5.2: a self-fix escalation is held for the responder, never
     // generic-projected. Move any legacy OPEN self-fix row into the support-flow

--- a/apps/web/lib/operate/issue-report-triage.test.ts
+++ b/apps/web/lib/operate/issue-report-triage.test.ts
@@ -380,6 +380,118 @@ describe("triageIssueReports — crash_boundary gate (BI-B4F401B3)", () => {
   });
 });
 
+describe("triageIssueReports — reach-threshold + staging gate (BI-51F6A428)", () => {
+  // A reach-gated "noise-digest" signal (log-signature scanner output).
+  const logSig = {
+    id: "ls1",
+    reportId: "PIR-LS001",
+    type: "log_signature",
+    severity: "low",
+    title: "New error signature in portal: transient blip",
+    description: "Occurrences (last 20m): 1",
+    routeContext: "/platform",
+    errorStack: null,
+    source: "log-signature-scanner",
+    occurrenceCount: 1,
+    firstSeenAt: new Date("2026-07-16T11:00:00.000Z"),
+    lastSeenAt: new Date("2026-07-16T11:00:00.000Z"),
+  };
+
+  it("holds a below-bar reach-gated report staged — no BI, no acknowledge", async () => {
+    const created: unknown[] = [];
+    const acknowledged: string[] = [];
+    const stagedIds: string[] = [];
+
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [logSig],
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+      acknowledgeReport: async (id: string) => { acknowledged.push(id); },
+      shouldPromote: () => false,
+      stageReport: async (id: string) => { stagedIds.push(id); },
+    }));
+
+    expect(result.created).toBe(0);
+    expect(result.staged).toBe(1);
+    expect(created).toHaveLength(0);
+    expect(acknowledged).toEqual([]);
+    expect(stagedIds).toEqual(["ls1"]);
+  });
+
+  it("ages out a staged report that stopped recurring — expire, never a BI", async () => {
+    const created: unknown[] = [];
+    const expiredIds: string[] = [];
+    const stagedIds: string[] = [];
+
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [logSig],
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+      shouldPromote: () => false,
+      shouldExpire: () => true,
+      expireStagedReport: async (id: string) => { expiredIds.push(id); },
+      stageReport: async (id: string) => { stagedIds.push(id); },
+    }));
+
+    expect(result.created).toBe(0);
+    expect(result.expired).toBe(1);
+    expect(expiredIds).toEqual(["ls1"]);
+    expect(stagedIds).toEqual([]); // expired, not re-staged
+    expect(created).toHaveLength(0);
+  });
+
+  it("promotes a reach-gated report once it clears the bar (shouldPromote true)", async () => {
+    const created: unknown[] = [];
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [logSig],
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+      shouldPromote: () => true,
+    }));
+    expect(result.created).toBe(1);
+    expect(created).toHaveLength(1);
+  });
+
+  it("caps NEW reach-gated promotions per window — extra low signals defer to staging", async () => {
+    const created: unknown[] = [];
+    const stagedIds: string[] = [];
+    // `report` (source manual → runtime-fault) promotes and consumes the cap of 1;
+    // the reach-gated low log signal is then deferred (staged) this window.
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [report, logSig],
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+      shouldPromote: () => true,
+      stageReport: async (id: string) => { stagedIds.push(id); },
+      maxNewPromotions: 1,
+    }));
+    expect(result.created).toBe(1);
+    expect(result.staged).toBe(1);
+    expect(stagedIds).toEqual(["ls1"]);
+  });
+
+  it("high-severity reach-gated signals bypass the per-window cap (never held)", async () => {
+    const created: unknown[] = [];
+    const stagedIds: string[] = [];
+    const highLogSig = { ...logSig, id: "ls2", reportId: "PIR-LS002", severity: "high" };
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [report, highLogSig],
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+      shouldPromote: () => true,
+      stageReport: async (id: string) => { stagedIds.push(id); },
+      maxNewPromotions: 1,
+    }));
+    expect(result.created).toBe(2); // high bypasses the cap
+    expect(stagedIds).toEqual([]);
+  });
+
+  it("without gate deps, behaviour is unchanged — reports always project", async () => {
+    const created: unknown[] = [];
+    const result = await triageIssueReports(triageDeps({
+      getOpenReports: async () => [logSig],
+      createBacklogItem: async (d: unknown) => { created.push(d); },
+    }));
+    expect(result.created).toBe(1); // no shouldPromote → today's always-project path
+    expect(created).toHaveLength(1);
+  });
+});
+
 describe("llmTriageReport", () => {
   it("parses valid LLM JSON response", async () => {
     const mockLlm = vi.fn().mockResolvedValue({

--- a/apps/web/lib/operate/issue-report-triage.ts
+++ b/apps/web/lib/operate/issue-report-triage.ts
@@ -36,6 +36,13 @@ interface IssueReport {
   // BI-0ACD9AB2: self-fix-feasibility class. When set, the report is a self-fix
   // escalation the responder attends — the projection guard skips + holds it.
   selfFixClass?: string | null;
+  // BI-51F6A428: reach-threshold + staging accrual. occurrenceCount is how many
+  // scan cycles this signal has been seen; firstSeenAt/lastSeenAt anchor the
+  // promotion math the reach gate evaluates. Optional so pure-function callers
+  // that predate the gate still type-check.
+  occurrenceCount?: number | null;
+  firstSeenAt?: Date | null;
+  lastSeenAt?: Date | null;
 }
 
 // BI-B4F401B3: reports filed by the production crash boundary carry only a
@@ -235,9 +242,26 @@ export async function triageIssueReports(deps: {
    *  reassessment, taxonomy routing, and root cause analysis. Uses the
    *  cheapest available model via routeAndCall(budgetClass:"minimize_cost"). */
   callLlm?: (messages: Array<{ role: string; content: string }>, systemPrompt: string) => Promise<{ content: string }>;
-}): Promise<{ created: number; llmEnhanced: number }> {
+  // ── Reach-threshold + staging gate (BI-51F6A428) ──────────────────────────
+  /** True when this report may be projected now. When provided and it returns
+   *  false, the report is NOT minted into a BI: it is held staged to accrue, or
+   *  aged out if it stopped recurring. Optional so pre-gate tests keep today's
+   *  always-project behaviour; the runner wires all four together. */
+  shouldPromote?: (report: IssueReport) => boolean;
+  /** True when a below-bar staged report has stopped recurring and should be
+   *  expired (closed, no BI). Only consulted when shouldPromote returned false. */
+  shouldExpire?: (report: IssueReport) => boolean;
+  /** Flag a below-bar report as held-in-staging (keeps it OPEN, accruing). */
+  stageReport?: (id: string) => Promise<void>;
+  /** Close a genuinely-stopped staged report WITHOUT ever creating a BI. */
+  expireStagedReport?: (id: string) => Promise<void>;
+  /** Per-scan-window cap on NEW reach-gated promotions (flood guard). Once this
+   *  many new signals have been minted this run, further reach-gated low/medium
+   *  reports are deferred (staged) to the next window. High/critical bypass it. */
+  maxNewPromotions?: number;
+}): Promise<{ created: number; llmEnhanced: number; staged: number; expired: number }> {
   const reports = await deps.getOpenReports();
-  if (reports.length === 0) return { created: 0, llmEnhanced: 0 };
+  if (reports.length === 0) return { created: 0, llmEnhanced: 0, staged: 0, expired: 0 };
 
   const existingTitles = await deps.getExistingTitles();
   const dpfProductId = deps.resolveProductId
@@ -248,6 +272,8 @@ export async function triageIssueReports(deps: {
     : await getDpfTaxonomyNodeId();
   let created = 0;
   let llmEnhanced = 0;
+  let staged = 0;
+  let expired = 0;
 
   for (const report of reports) {
     // Projection guard (BI-0ACD9AB2 §5.2): a self-fix escalation is attended by
@@ -265,6 +291,41 @@ export async function triageIssueReports(deps: {
     // without filing a bug BI (no defect to fix).
     if (shouldSuppressIssueReportAsBacklog(report)) {
       await deps.acknowledgeReport(report.id);
+      continue;
+    }
+
+    // ── Reach-threshold + staging gate (BI-51F6A428) ─────────────────────
+    // Stops the PIR treadmill: a single transient log signature no longer mints
+    // a BI on first sight. shouldPromote is the pure reach+recency decision (see
+    // lib/quality/issue-report-promotion.ts); the runner wires it to apply only
+    // to the reach-gated "noise-digest" stream — human/crash/runtime reports
+    // always return true here. When it returns false, the report is held staged
+    // to accrue, or (if it stopped recurring) aged out with no BI.
+    if (deps.shouldPromote && !deps.shouldPromote(report)) {
+      if (deps.shouldExpire?.(report) && deps.expireStagedReport) {
+        await deps.expireStagedReport(report.id);
+        expired++;
+      } else if (deps.stageReport) {
+        await deps.stageReport(report.id);
+        staged++;
+      }
+      continue;
+    }
+
+    // Per-scan-window cap (BI-51F6A428): once maxNewPromotions new signals have
+    // been minted this run, defer further reach-gated low/medium promotions to
+    // the next window so a runaway source can't flood the backlog in one cycle.
+    // High/critical bypass the cap (a serious signal is never held).
+    if (
+      deps.maxNewPromotions != null &&
+      created >= deps.maxNewPromotions &&
+      classifyIssueReportStream(report) === "noise-digest" &&
+      !isHighSeverity(report.severity)
+    ) {
+      if (deps.stageReport) {
+        await deps.stageReport(report.id);
+        staged++;
+      }
       continue;
     }
 
@@ -330,7 +391,14 @@ export async function triageIssueReports(deps: {
     created++;
   }
 
-  return { created, llmEnhanced };
+  return { created, llmEnhanced, staged, expired };
+}
+
+/** True for the severities the reach gate never holds (they promote on first
+ *  occurrence). Mirrors ALWAYS_PROMOTE_SEVERITIES in issue-report-promotion.ts. */
+function isHighSeverity(severity: string | null | undefined): boolean {
+  const s = (severity ?? "").toLowerCase();
+  return s === "high" || s === "critical";
 }
 
 // ─── Spike Detection ────────────────────────────────────────────────────────

--- a/apps/web/lib/quality/issue-report-promotion.test.ts
+++ b/apps/web/lib/quality/issue-report-promotion.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldPromoteIssueReport,
+  shouldExpireStagedReport,
+  REACH_OCCURRENCE_THRESHOLD,
+  SCAN_WINDOW_MS,
+  RECENCY_MS,
+  STAGING_STALE_MS,
+} from "./issue-report-promotion";
+
+// A fixed evaluation instant so every case is deterministic.
+const NOW = new Date("2026-07-16T12:00:00.000Z");
+const minutesAgo = (m: number) => new Date(NOW.getTime() - m * 60 * 1000);
+
+describe("shouldPromoteIssueReport (BI-51F6A428)", () => {
+  describe("high/critical always promote on first occurrence", () => {
+    for (const severity of ["high", "critical", "HIGH", "Critical"]) {
+      it(`promotes ${severity} at occurrenceCount=1 with no accrual history`, () => {
+        expect(
+          shouldPromoteIssueReport({
+            occurrenceCount: 1,
+            firstSeenAt: NOW,
+            lastSeenAt: NOW,
+            severity,
+            now: NOW,
+          }),
+        ).toBe(true);
+      });
+    }
+
+    it("promotes critical even when the reach/span/recency bars would all fail", () => {
+      expect(
+        shouldPromoteIssueReport({
+          occurrenceCount: 1,
+          firstSeenAt: minutesAgo(1),
+          lastSeenAt: minutesAgo(1),
+          severity: "critical",
+          now: NOW,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("low/medium below the reach bar are held (staged)", () => {
+    it("holds a low first occurrence (occurrenceCount=1)", () => {
+      expect(
+        shouldPromoteIssueReport({
+          occurrenceCount: 1,
+          firstSeenAt: NOW,
+          lastSeenAt: NOW,
+          severity: "low",
+          now: NOW,
+        }),
+      ).toBe(false);
+    });
+
+    it("holds a medium signal seen twice (still below the reach threshold of 3)", () => {
+      expect(
+        shouldPromoteIssueReport({
+          occurrenceCount: REACH_OCCURRENCE_THRESHOLD - 1,
+          firstSeenAt: minutesAgo(40),
+          lastSeenAt: minutesAgo(2),
+          severity: "medium",
+          now: NOW,
+        }),
+      ).toBe(false);
+    });
+
+    it("holds when reach is met but the first→last span is a single-window burst", () => {
+      // occurrenceCount high, but every sighting arrived within one scan window.
+      expect(
+        shouldPromoteIssueReport({
+          occurrenceCount: 10,
+          firstSeenAt: minutesAgo(5),
+          lastSeenAt: minutesAgo(4),
+          severity: "low",
+          now: NOW,
+        }),
+      ).toBe(false);
+    });
+
+    it("holds (fails closed) when accrual timestamps are missing", () => {
+      expect(
+        shouldPromoteIssueReport({
+          occurrenceCount: 5,
+          firstSeenAt: null,
+          lastSeenAt: null,
+          severity: "medium",
+          now: NOW,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("low/medium above the reach + recency bar promote", () => {
+    it("promotes a low signal seen >=3 times across >=2 windows and still recurring", () => {
+      expect(
+        shouldPromoteIssueReport({
+          occurrenceCount: REACH_OCCURRENCE_THRESHOLD,
+          firstSeenAt: minutesAgo(40), // > MIN_SPAN_MS (15m) before last
+          lastSeenAt: minutesAgo(2), // within RECENCY_MS
+          severity: "low",
+          now: NOW,
+        }),
+      ).toBe(true);
+    });
+
+    it("promotes exactly at the span boundary (span === MIN_SPAN_MS)", () => {
+      const last = minutesAgo(2);
+      const first = new Date(last.getTime() - SCAN_WINDOW_MS);
+      expect(
+        shouldPromoteIssueReport({
+          occurrenceCount: REACH_OCCURRENCE_THRESHOLD,
+          firstSeenAt: first,
+          lastSeenAt: last,
+          severity: "medium",
+          now: NOW,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("recency expiry — reached the bar then stopped recurring", () => {
+    it("does NOT promote a low signal whose last sighting is older than the recency window", () => {
+      const last = new Date(NOW.getTime() - RECENCY_MS - 60 * 1000); // just past recency
+      expect(
+        shouldPromoteIssueReport({
+          occurrenceCount: 8,
+          firstSeenAt: new Date(last.getTime() - 3 * SCAN_WINDOW_MS),
+          lastSeenAt: last,
+          severity: "low",
+          now: NOW,
+        }),
+      ).toBe(false);
+    });
+  });
+});
+
+describe("shouldExpireStagedReport (BI-51F6A428 aging-out)", () => {
+  it("expires a staged report not seen within the stale window", () => {
+    expect(
+      shouldExpireStagedReport({
+        firstSeenAt: new Date(NOW.getTime() - 3 * STAGING_STALE_MS),
+        lastSeenAt: new Date(NOW.getTime() - STAGING_STALE_MS - 60 * 1000),
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it("does NOT expire a staged report still recurring within the stale window", () => {
+    expect(
+      shouldExpireStagedReport({
+        firstSeenAt: minutesAgo(90),
+        lastSeenAt: minutesAgo(5),
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to firstSeenAt when lastSeenAt is missing", () => {
+    expect(
+      shouldExpireStagedReport({
+        firstSeenAt: new Date(NOW.getTime() - STAGING_STALE_MS - 60 * 1000),
+        lastSeenAt: null,
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it("does NOT expire (fail-safe) when no sighting timestamps exist at all", () => {
+    expect(
+      shouldExpireStagedReport({ firstSeenAt: null, lastSeenAt: null, now: NOW }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/lib/quality/issue-report-promotion.ts
+++ b/apps/web/lib/quality/issue-report-promotion.ts
@@ -1,0 +1,112 @@
+// ─── Issue-Report Promotion Gate ────────────────────────────────────────────
+// BI-51F6A428 — reach-threshold + staging lane before a log signature becomes a
+// backlog item.
+//
+// The PIR treadmill: the log-signature scanner files ONE PlatformIssueReport per
+// novel error signature, and (pre-this-change) that first occurrence immediately
+// minted a BI-PIR-* backlog item. A single transient blip — a one-cycle Loki
+// hiccup, a benign restart line that slipped the filters — therefore became a
+// permanent backlog item that a human had to triage and close. This module is
+// the safety contract that stops that: a low/medium automated signal must reach
+// a recurrence bar (seen enough times, across enough scan windows, and still
+// recurring) before it is allowed to project. High/critical signals are never
+// held — they project on first occurrence.
+//
+// Pure + dependency-free so every branch is exhaustively unit-testable without
+// Prisma/Inngest, and so the same decision is used identically by the front-door
+// writer (createPlatformIssueReport) and the triage projection path.
+
+/** The scanner cadence (log-signature-scanner runs every 15 minutes). A staged
+ *  signal must recur across at least this much wall-clock — i.e. two distinct
+ *  scan windows — before it can promote. */
+export const SCAN_WINDOW_MS = 15 * 60 * 1000;
+
+/** Reach bar: a low/medium signal must be seen in at least this many scan
+ *  cycles (occurrenceCount accrues +1 per cycle the signature recurs). */
+export const REACH_OCCURRENCE_THRESHOLD = 3;
+
+/** Minimum wall-clock span between the first and last sighting. Guards against a
+ *  single-window burst inflating occurrenceCount past the reach bar without the
+ *  signal actually persisting across windows. */
+export const MIN_SPAN_MS = SCAN_WINDOW_MS;
+
+/** Recency bar: only promote a signal still actively recurring — its last
+ *  sighting must be within this window. A signal that crossed the reach bar and
+ *  then went quiet is aged out, not promoted. */
+export const RECENCY_MS = 60 * 60 * 1000;
+
+/** Aging-out: a staged signal not seen within this window has stopped. It is
+ *  expired (no BI) rather than held staged forever. */
+export const STAGING_STALE_MS = 60 * 60 * 1000;
+
+/** Per-scan-window cap on NEW signals promoted, so a runaway producer cannot
+ *  flood the backlog in a single cycle. High/critical bypass the cap. */
+export const MAX_NEW_PROMOTIONS_PER_WINDOW = 25;
+
+/** Severities that always promote on first occurrence — never held (safety). */
+const ALWAYS_PROMOTE_SEVERITIES = new Set(["high", "critical"]);
+
+export interface PromotionDecisionInput {
+  /** How many scan cycles this signal has been seen (>= 1). */
+  occurrenceCount: number;
+  /** First sighting of this signal, or null when accrual data is missing. */
+  firstSeenAt: Date | null;
+  /** Most recent sighting of this signal, or null when accrual data is missing. */
+  lastSeenAt: Date | null;
+  /** The report's severity (case-insensitive; low | medium | high | critical). */
+  severity: string;
+  /** The evaluation instant (injected for deterministic tests). */
+  now: Date;
+}
+
+/**
+ * Decide whether a reach-gated issue report may be projected into a backlog item.
+ *
+ * Policy (CONSERVATIVE — this is the safety contract):
+ *  - high/critical severity → ALWAYS promote (return true) on first occurrence.
+ *  - low/medium severity → require the reach + recency bar:
+ *      • occurrenceCount >= REACH_OCCURRENCE_THRESHOLD, AND
+ *      • the first→last span >= MIN_SPAN_MS (spans >= 2 distinct scan windows), AND
+ *      • lastSeenAt within RECENCY_MS of now (still actively recurring).
+ *    Below the bar → false: the caller holds the report staged so it accrues.
+ *
+ * Missing accrual timestamps (firstSeenAt/lastSeenAt null) fail closed for
+ * low/medium — the report is held, never minted on incomplete data.
+ */
+export function shouldPromoteIssueReport(input: PromotionDecisionInput): boolean {
+  const severity = (input.severity ?? "").toLowerCase();
+
+  // Safety: a serious signal is never held.
+  if (ALWAYS_PROMOTE_SEVERITIES.has(severity)) return true;
+
+  // Reach: enough scan cycles.
+  if (input.occurrenceCount < REACH_OCCURRENCE_THRESHOLD) return false;
+
+  const first = input.firstSeenAt?.getTime();
+  const last = input.lastSeenAt?.getTime();
+  if (first == null || last == null) return false;
+
+  // Span: persisted across >= 2 distinct scan windows (not a single-window burst).
+  if (last - first < MIN_SPAN_MS) return false;
+
+  // Recency: still recurring.
+  if (input.now.getTime() - last > RECENCY_MS) return false;
+
+  return true;
+}
+
+/**
+ * Decide whether a staged report has stopped recurring and should be aged out
+ * (expired with no BI). True when its most recent sighting is older than
+ * STAGING_STALE_MS. A report with no sighting timestamps at all is NOT expired
+ * (fail-safe: never silently drop a report we cannot reason about).
+ */
+export function shouldExpireStagedReport(input: {
+  firstSeenAt: Date | null;
+  lastSeenAt: Date | null;
+  now: Date;
+}): boolean {
+  const last = input.lastSeenAt?.getTime() ?? input.firstSeenAt?.getTime();
+  if (last == null) return false;
+  return input.now.getTime() - last > STAGING_STALE_MS;
+}

--- a/apps/web/lib/quality/platform-issue-reports.test.ts
+++ b/apps/web/lib/quality/platform-issue-reports.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 // Hoisted Prisma mock — must be declared before the import under test
 const prismaMock = vi.hoisted(() => ({
-  platformIssueReport: { create: vi.fn(), findFirst: vi.fn() },
+  platformIssueReport: { create: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
   portfolio: { findUnique: vi.fn() },
   digitalProduct: { findUnique: vi.fn() },
 }));
@@ -18,9 +18,11 @@ import { ISSUE_REPORT_STATUS } from "./issue-report-status";
 beforeEach(() => {
   prismaMock.platformIssueReport.create.mockReset();
   prismaMock.platformIssueReport.findFirst.mockReset();
+  prismaMock.platformIssueReport.update.mockReset();
   prismaMock.portfolio.findUnique.mockReset();
   prismaMock.digitalProduct.findUnique.mockReset();
   prismaMock.platformIssueReport.create.mockResolvedValue({});
+  prismaMock.platformIssueReport.update.mockResolvedValue({});
   prismaMock.digitalProduct.findUnique.mockResolvedValue({ id: "dp-portal" });
   inngestMock.send.mockReset();
   inngestMock.send.mockResolvedValue(undefined);
@@ -308,7 +310,7 @@ describe("createPlatformIssueReport", () => {
     prismaMock.platformIssueReport.create.mockRejectedValueOnce(
       p2002("PlatformIssueReport_dedupeKey_open_key"),
     );
-    prismaMock.platformIssueReport.findFirst.mockResolvedValue({ reportId: "PIR-EXIST" });
+    prismaMock.platformIssueReport.findFirst.mockResolvedValue({ id: "row-1", reportId: "PIR-EXIST" });
     const result = await createPlatformIssueReport({
       type: "runtime_error",
       title: "Recurring signature",
@@ -325,6 +327,31 @@ describe("createPlatformIssueReport", () => {
       }),
     );
     // The surviving report already projected when first filed — no re-projection.
+    expect(inngestMock.send).not.toHaveBeenCalled();
+  });
+
+  // BI-51F6A428: the dedupeKey race is a re-occurrence — accrue onto the survivor.
+  it("accrues occurrenceCount + lastSeenAt onto the surviving report on a dedupeKey race", async () => {
+    const NOW = new Date("2026-07-16T12:00:00.000Z");
+    prismaMock.platformIssueReport.create.mockRejectedValueOnce(
+      p2002("PlatformIssueReport_dedupeKey_open_key"),
+    );
+    prismaMock.platformIssueReport.findFirst.mockResolvedValue({ id: "row-1", reportId: "PIR-EXIST" });
+    const result = await createPlatformIssueReport(
+      {
+        type: "log_signature",
+        title: "Recurring signature",
+        source: "log-signature-scanner",
+        severity: "low",
+        dedupeKey: "log-sig:portal:abc1234567",
+      },
+      { now: () => NOW },
+    );
+    expect(result.reportId).toBe("PIR-EXIST");
+    expect(prismaMock.platformIssueReport.update).toHaveBeenCalledWith({
+      where: { id: "row-1" },
+      data: { occurrenceCount: { increment: 1 }, lastSeenAt: NOW },
+    });
     expect(inngestMock.send).not.toHaveBeenCalled();
   });
 
@@ -364,5 +391,73 @@ describe("createPlatformIssueReport", () => {
       source: "crash_boundary",
     });
     expect(result.reportId).toMatch(/^PIR-/);
+  });
+
+  // BI-51F6A428: reach-threshold + staging gate at the front door.
+  describe("reach-threshold + staging gate (BI-51F6A428)", () => {
+    const NOW = new Date("2026-07-16T12:00:00.000Z");
+
+    it("births a low-severity log signature staged and does NOT emit (reach-gated)", async () => {
+      const { reportId } = await createPlatformIssueReport(
+        {
+          type: "log_signature",
+          source: "log-signature-scanner",
+          severity: "low",
+          title: "New error signature in portal: something",
+          dedupeKey: "log-sig:portal:abc1234567",
+        },
+        { now: () => NOW },
+      );
+      const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+      expect(args?.data.stagedUntilPromoted).toBe(true);
+      expect(args?.data.firstSeenAt).toEqual(NOW);
+      expect(args?.data.lastSeenAt).toEqual(NOW);
+      expect(args?.data.status).toBeUndefined(); // still OPEN (schema default)
+      // Held in staging — no immediate projection.
+      expect(inngestMock.send).not.toHaveBeenCalled();
+      expect(reportId).toMatch(/^PIR-/);
+    });
+
+    it("projects a HIGH-severity log signature immediately (loud incident bypasses the bar)", async () => {
+      const { reportId } = await createPlatformIssueReport(
+        {
+          type: "log_signature",
+          source: "log-signature-scanner",
+          severity: "high",
+          title: "New error signature in portal: loud",
+          dedupeKey: "log-sig:portal:def",
+        },
+        { now: () => NOW },
+      );
+      const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+      expect(args?.data.stagedUntilPromoted).toBe(false);
+      expect(inngestMock.send).toHaveBeenCalledWith({
+        name: "quality/issue-report.created",
+        data: { reportId },
+      });
+    });
+
+    it("does NOT stage a human/manual report — it projects on first occurrence", async () => {
+      const { reportId } = await createPlatformIssueReport(
+        { type: "user_report", source: "manual", severity: "low", title: "Human report" },
+        { now: () => NOW },
+      );
+      const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+      expect(args?.data.stagedUntilPromoted).toBe(false);
+      expect(inngestMock.send).toHaveBeenCalledWith({
+        name: "quality/issue-report.created",
+        data: { reportId },
+      });
+    });
+
+    it("seeds firstSeenAt/lastSeenAt on every created report", async () => {
+      await createPlatformIssueReport(
+        { type: "user_report", source: "manual", title: "Test" },
+        { now: () => NOW },
+      );
+      const args = prismaMock.platformIssueReport.create.mock.calls[0]?.[0];
+      expect(args?.data.firstSeenAt).toEqual(NOW);
+      expect(args?.data.lastSeenAt).toEqual(NOW);
+    });
   });
 });

--- a/apps/web/lib/quality/platform-issue-reports.ts
+++ b/apps/web/lib/quality/platform-issue-reports.ts
@@ -2,6 +2,7 @@ import { prisma } from "@dpf/db";
 import { inngest } from "@/lib/queue/inngest-client";
 import { ISSUE_REPORT_STATUS, type IssueReportStatus } from "./issue-report-status";
 import { classifyIssueReportStream, isResponderStream } from "./issue-report-stream";
+import { shouldPromoteIssueReport } from "./issue-report-promotion";
 
 // Field length limits — matched to existing writers and Prisma schema column widths.
 const LIMITS = {
@@ -44,6 +45,25 @@ function resolvePortfolioSlug(routeContext: string | null | undefined): string |
 
 function generateReportId(): string {
   return "PIR-" + Math.random().toString(36).substring(2, 7).toUpperCase();
+}
+
+/**
+ * Record a re-occurrence of an already-open issue report: bump occurrenceCount
+ * and refresh lastSeenAt (BI-51F6A428). This is what lets a reach-gated report
+ * accrue toward its promotion bar across scan windows instead of being minted
+ * into a BI on first sight — and it lets a staged report's aging-out sweep see
+ * that it is still recurring. Called by (a) the log-signature scanner when a
+ * signature recurs while its report is still open, and (b) the P2002 dedupeKey
+ * idempotency race in createPlatformIssueReport.
+ */
+export async function accrueIssueReportOccurrence(
+  reportRowId: string,
+  now: () => Date = () => new Date(),
+): Promise<void> {
+  await prisma.platformIssueReport.update({
+    where: { id: reportRowId },
+    data: { occurrenceCount: { increment: 1 }, lastSeenAt: now() },
+  });
 }
 
 const VALID_STATUSES = new Set<string>(Object.values(ISSUE_REPORT_STATUS));
@@ -117,10 +137,24 @@ export interface CreatePlatformIssueReportInput {
  */
 export async function createPlatformIssueReport(
   input: CreatePlatformIssueReportInput,
+  opts?: { now?: () => Date },
 ): Promise<{ reportId: string }> {
   if (input.status !== undefined && !VALID_STATUSES.has(input.status)) {
     throw new Error(`createPlatformIssueReport: unknown status "${input.status}"`);
   }
+
+  const now = opts?.now ?? (() => new Date());
+  const nowDate = now();
+
+  // Classify the report's handling stream once — reused for the escalation
+  // projection guard (below) and the reach-threshold staging gate (BI-51F6A428).
+  const stream = classifyIssueReportStream({
+    type: input.type,
+    source: input.source,
+    severity: input.severity,
+    selfFixClass: input.selfFixClass,
+    errorDigest: input.errorDigest,
+  });
 
   // Projection guard (BI-0ACD9AB2 §5.2 — trusted escalation routing): a self-fix
   // escalation (type="build-stall-escalation" / selfFixClass set) is attended by
@@ -132,17 +166,7 @@ export async function createPlatformIssueReport(
   // report" partial-unique. Every writer is guarded at this one front door.
   const status: IssueReportStatus | undefined =
     input.status ??
-    (isResponderStream(
-      classifyIssueReportStream({
-        type: input.type,
-        source: input.source,
-        severity: input.severity,
-        selfFixClass: input.selfFixClass,
-        errorDigest: input.errorDigest,
-      }),
-    )
-      ? ISSUE_REPORT_STATUS.AWAITING_ESCALATION_ACK
-      : undefined);
+    (isResponderStream(stream) ? ISSUE_REPORT_STATUS.AWAITING_ESCALATION_ACK : undefined);
 
   const digitalProductId =
     input.digitalProductId ??
@@ -164,6 +188,28 @@ export async function createPlatformIssueReport(
 
   const reportId = generateReportId();
   const dedupeKey = trimTo(input.dedupeKey ?? null, LIMITS.dedupeKey);
+
+  // Reach-threshold + staging gate (BI-51F6A428). The "noise-digest" stream is
+  // the automated log-signature treadmill: a single transient signature must not
+  // mint a BI on first sight. An OPEN reach-gated signal is born staged (held,
+  // not projected) UNLESS it already clears the promotion bar — high/critical
+  // clear it on first occurrence (shouldPromoteIssueReport). Non-gated reports
+  // (human/manual, crash-boundary, runtime faults) are never held: they project
+  // immediately as before. Support-flow reports (status != open) never project.
+  const effectiveStatus = status ?? ISSUE_REPORT_STATUS.OPEN;
+  const reachGated = stream === "noise-digest";
+  const promoteOnCreate =
+    effectiveStatus === ISSUE_REPORT_STATUS.OPEN &&
+    (!reachGated ||
+      shouldPromoteIssueReport({
+        occurrenceCount: 1,
+        firstSeenAt: nowDate,
+        lastSeenAt: nowDate,
+        severity: input.severity ?? "medium",
+        now: nowDate,
+      }));
+  const stagedUntilPromoted =
+    effectiveStatus === ISSUE_REPORT_STATUS.OPEN && reachGated && !promoteOnCreate;
 
   try {
     await prisma.platformIssueReport.create({
@@ -190,6 +236,11 @@ export async function createPlatformIssueReport(
         source: input.source.slice(0, LIMITS.source),
         portfolioId,
         digitalProductId,
+        // BI-51F6A428: seed accrual/staging fields. occurrenceCount defaults to
+        // 1 via the schema; firstSeenAt/lastSeenAt anchor the promotion math.
+        firstSeenAt: nowDate,
+        lastSeenAt: nowDate,
+        stagedUntilPromoted,
         ...(status !== undefined ? { status } : {}),
       },
     });
@@ -201,8 +252,12 @@ export async function createPlatformIssueReport(
     // violating PlatformIssueReport_dedupeKey_open_key (UNIQUE WHERE status NOT
     // IN resolved_locally/resolved_upstream/suppressed). Previously that P2002
     // escaped this shared front door, got logged, and was itself re-scanned.
-    // Treat it as idempotent success: return the surviving open report's id and
-    // skip re-projection (that report already projected when first filed).
+    // Treat it as idempotent success: accrue the re-occurrence onto the surviving
+    // open report and return its id. BI-51F6A428: the re-occurrence bumps
+    // occurrenceCount + lastSeenAt (instead of being silently swallowed) so a
+    // staged signal accrues toward its promotion bar; the triage cron promotes it
+    // once it crosses the bar. No re-projection here — a report already above the
+    // bar projected when first filed, and a staged one is promoted by the cron.
     const code = (err as { code?: string } | null)?.code;
     const target = JSON.stringify((err as { meta?: { target?: unknown } } | null)?.meta?.target ?? "");
     if (code === "P2002" && dedupeKey && target.includes("dedupeKey")) {
@@ -212,9 +267,12 @@ export async function createPlatformIssueReport(
           status: { notIn: ["resolved_locally", "resolved_upstream", "suppressed"] },
         },
         orderBy: { createdAt: "desc" },
-        select: { reportId: true },
+        select: { id: true, reportId: true },
       });
-      if (existing) return { reportId: existing.reportId };
+      if (existing) {
+        await accrueIssueReportOccurrence(existing.id, now);
+        return { reportId: existing.reportId };
+      }
     }
     throw err;
   }
@@ -224,8 +282,12 @@ export async function createPlatformIssueReport(
   // triage cron. Support-flow reports (status !== open) are owned by the support
   // pipeline and skipped. Best-effort — the cron remains the safety net, so a
   // send failure never loses the projection.
-  const effectiveStatus = status ?? ISSUE_REPORT_STATUS.OPEN;
-  if (effectiveStatus === ISSUE_REPORT_STATUS.OPEN) {
+  //
+  // BI-51F6A428: a reach-gated signal born staged (promoteOnCreate=false) does
+  // NOT fire the immediate event — it stays OPEN + stagedUntilPromoted so it can
+  // accrue. The 15-min triage cron re-evaluates staged reports and projects them
+  // once they cross the bar (or ages out the ones that stopped recurring).
+  if (promoteOnCreate) {
     try {
       await inngest.send({ name: "quality/issue-report.created", data: { reportId } });
     } catch (err) {

--- a/apps/web/lib/queue/functions/issue-report-triage.ts
+++ b/apps/web/lib/queue/functions/issue-report-triage.ts
@@ -66,8 +66,8 @@ export const issueReportTriage = inngest.createFunction(
 
     console.log(
       `[issue-report-triage] Created ${result.created} backlog items ` +
-      `(${result.llmEnhanced} LLM-enhanced), spike=${spiked}, ` +
-      `escalations resolved=${hygiene.resolved}/${hygiene.scanned}`,
+      `(${result.llmEnhanced} LLM-enhanced), staged=${result.staged} expired=${result.expired}, ` +
+      `spike=${spiked}, escalations resolved=${hygiene.resolved}/${hygiene.scanned}`,
     );
 
     await step.run("record-job-run", async () => {

--- a/apps/web/lib/queue/functions/log-signature-scanner.test.ts
+++ b/apps/web/lib/queue/functions/log-signature-scanner.test.ts
@@ -4,6 +4,7 @@ import type { RawLogLine } from "@/lib/observability/log-signature";
 const mocks = vi.hoisted(() => ({
   findFirst: vi.fn(),
   createPIR: vi.fn(),
+  accruePIR: vi.fn(),
   queryLoki: vi.fn(),
 }));
 
@@ -15,6 +16,7 @@ vi.mock("@dpf/db", () => ({
 
 vi.mock("@/lib/quality/platform-issue-reports", () => ({
   createPlatformIssueReport: mocks.createPIR,
+  accrueIssueReportOccurrence: mocks.accruePIR,
 }));
 
 vi.mock("@/lib/observability/loki-query", () => ({
@@ -53,7 +55,7 @@ describe("runLogSignatureScan", () => {
     }
   });
 
-  it("does NOT re-file a signature that already has an unresolved report", async () => {
+  it("does NOT re-file a signature that already has an unresolved report — accrues instead", async () => {
     mocks.queryLoki.mockResolvedValue(errLines("portal", "db timeout", 3));
     mocks.findFirst.mockResolvedValue({ id: "existing" }); // already filed + open
 
@@ -62,6 +64,9 @@ describe("runLogSignatureScan", () => {
     expect(res.reportsCreated).toBe(0);
     expect(res.skippedExisting).toBe(1);
     expect(mocks.createPIR).not.toHaveBeenCalled();
+    // BI-51F6A428: a recurrence accrues onto the open report so a staged signal
+    // advances toward its promotion bar instead of being silently swallowed.
+    expect(mocks.accruePIR).toHaveBeenCalledWith("existing");
   });
 
   it("treats a P2002 race as skipped, not a crash", async () => {

--- a/apps/web/lib/queue/functions/log-signature-scanner.ts
+++ b/apps/web/lib/queue/functions/log-signature-scanner.ts
@@ -50,7 +50,9 @@ export async function runLogSignatureScan(opts?: {
   lookbackMinutes?: number;
 }): Promise<LogScanResult> {
   const { prisma } = await import("@dpf/db");
-  const { createPlatformIssueReport } = await import("@/lib/quality/platform-issue-reports");
+  const { createPlatformIssueReport, accrueIssueReportOccurrence } = await import(
+    "@/lib/quality/platform-issue-reports"
+  );
   const lookbackMinutes = opts?.lookbackMinutes ?? LOOKBACK_MIN;
 
   let lines;
@@ -70,12 +72,18 @@ export async function runLogSignatureScan(opts?: {
   for (const b of buckets) {
     const dedupeKey = dedupeKeyFor(b.service, b.signatureId);
 
-    // Skip if an unresolved report for this signature already exists.
+    // An unresolved report for this signature already exists: this is a
+    // re-occurrence, not a novel signature. BI-51F6A428 — accrue it (bump
+    // occurrenceCount + refresh lastSeenAt) instead of plain-skipping, so a
+    // staged (below-reach-bar) signal advances toward promotion and the
+    // aging-out sweep can tell it is still recurring. The triage cron promotes
+    // it once it crosses the bar.
     const existing = await prisma.platformIssueReport.findFirst({
       where: { dedupeKey, status: { notIn: RESOLVED_STATUSES } },
       select: { id: true },
     });
     if (existing) {
+      await accrueIssueReportOccurrence(existing.id);
       skippedExisting++;
       continue;
     }

--- a/docs/superpowers/specs/2026-07-16-pir-reach-threshold-staging-gate-design.md
+++ b/docs/superpowers/specs/2026-07-16-pir-reach-threshold-staging-gate-design.md
@@ -1,0 +1,101 @@
+# PlatformIssueReport — Reach-Threshold + Staging Gate Before a Signature Becomes a BI
+
+| Field | Value |
+| ----- | ----- |
+| Status | Implemented |
+| Date | 2026-07-16 |
+| Epic | `EP-FULL-OBS` / `EP-INTAKE-UNIFY` (intake hygiene) |
+| Backlog item | BI-51F6A428 |
+| Builds on | [PIR Immediate Projection (2026-06-06)](2026-06-06-pir-immediate-projection-design.md); the log-signature scanner ([`log-signature-scanner.ts`](../../../apps/web/lib/queue/functions/log-signature-scanner.ts)) + `toTemplate` normalization ([`log-signature.ts`](../../../apps/web/lib/observability/log-signature.ts)); the stream classifier ([`issue-report-stream.ts`](../../../apps/web/lib/quality/issue-report-stream.ts)) `noise-digest` stream. |
+| New substrate | [`apps/web/lib/quality/issue-report-promotion.ts`](../../../apps/web/lib/quality/issue-report-promotion.ts) (pure decision); migration `20260716120000_add_pir_reach_staging_gate`. |
+| Related substrate | [`platform-issue-reports.ts`](../../../apps/web/lib/quality/platform-issue-reports.ts); [`issue-report-triage.ts`](../../../apps/web/lib/operate/issue-report-triage.ts); [`issue-report-triage-runner.ts`](../../../apps/web/lib/operate/issue-report-triage-runner.ts); [`issue-report-triage.ts` (cron)](../../../apps/web/lib/queue/functions/issue-report-triage.ts). |
+
+---
+
+## 1. Problem — the PIR treadmill
+
+Since immediate projection (2026-06-06), an OPEN `PlatformIssueReport` mints a `BI-PIR-*`
+backlog item within seconds of creation. Combined with the log-signature scanner filing ONE
+report per novel error signature on its **first** occurrence, a single transient log line — a
+one-cycle Loki hiccup, a benign restart FATAL that slipped the filters — became a permanent
+backlog item a human had to triage and close. `toTemplate` normalization (already shipped)
+collapses near-identical lines to one signature, but a genuinely one-off signature still minted
+a BI on sight. There was **no reach gate**: first occurrence == backlog item.
+
+Additionally, the dedupeKey P2002 idempotency path treated a re-occurrence as idempotent
+success and returned the existing reportId **without incrementing any occurrence counter**, so a
+report never accrued evidence of recurrence.
+
+## 2. Design
+
+### 2.1 Accrual (schema)
+Four additive columns on `PlatformIssueReport` (migration `20260716120000`, all backfilled,
+data-safe): `occurrenceCount Int @default(1)`, `firstSeenAt DateTime?`, `lastSeenAt DateTime?`,
+`stagedUntilPromoted Boolean @default(false)`. `stagedUntilPromoted` is a **flag, not a status** —
+a staged report stays `status=open`, so the existing cron OPEN-pool query keeps re-evaluating it.
+
+### 2.2 Accrual on re-occurrence
+`accrueIssueReportOccurrence(id, now)` bumps `occurrenceCount` and refreshes `lastSeenAt`. It is
+called from (a) the scanner's skip-existing branch — the **primary** re-occurrence signal in
+steady state — and (b) the front-door P2002 dedupeKey race. Without (a) a staged signal would
+never accrue (the scanner skips existing open reports), so this is load-bearing for the safety
+contract, not just the race backstop.
+
+### 2.3 Pure promotion decision — `shouldPromoteIssueReport`
+[`issue-report-promotion.ts`](../../../apps/web/lib/quality/issue-report-promotion.ts), fully
+unit-tested. Policy (**conservative — this is the safety contract**):
+- **high / critical severity → ALWAYS promote on first occurrence.** Never held.
+- **low / medium → require the reach + recency bar**: `occurrenceCount >= 3` **AND** first→last
+  span `>= 15 min` (≥ 2 distinct scan windows, guarding against a single-window burst) **AND**
+  `lastSeenAt` within 60 min of now (still actively recurring). Missing accrual timestamps fail
+  closed (held).
+
+Which reports are **subject** to the bar is caller policy: only the reach-gated `noise-digest`
+stream (the log-signature / warmup treadmill). Human/manual reports, crash-boundary, and runtime
+faults are never held — they project on first occurrence exactly as before.
+
+### 2.4 Gate the immediate projection (front door)
+`createPlatformIssueReport` computes the stream once. A reach-gated OPEN report below the bar is
+born `stagedUntilPromoted=true` and does **not** fire `quality/issue-report.created`; it accrues.
+A reach-gated high/critical report (a loud incident, via `severityForCount`) clears the bar and
+projects immediately. Non-gated reports are unchanged.
+
+### 2.5 Promote / stage / age-out in triage
+`triageIssueReports` gains optional deps (`shouldPromote`, `shouldExpire`, `stageReport`,
+`expireStagedReport`, `maxNewPromotions`); when unset, behaviour is byte-identical to today
+(always project). The runner wires them so the 15-min safety-net cron:
+- **promotes** a staged report once it crosses the bar (clears the flag, mints the BI),
+- **holds** a still-accruing below-bar report staged,
+- **ages out** a genuinely-stopped one-off (`lastSeenAt` older than 60 min) by closing it to
+  `suppressed` **without ever creating a BI** — the only path by which a staged report is dropped.
+
+### 2.6 Per-scan-window cap
+`MAX_NEW_PROMOTIONS_PER_WINDOW = 25` bounds NEW reach-gated low/medium promotions per triage run
+so a runaway source cannot flood the backlog in one cycle; deferred signals stay staged for the
+next window. High/critical bypass the cap.
+
+## 3. Safety contract
+
+A staged report is **never silently dropped** except by the explicit aging-out of a
+genuinely-stopped one-off (`shouldExpireStagedReport`). Anything still recurring keeps accruing
+(scanner bumps `lastSeenAt`) and eventually crosses the bar → promotes. High/critical always
+project on first occurrence. The change is additive and gated behind optional deps + the
+`noise-digest` stream, so every non-scanner intake path is untouched.
+
+## 4. Verification gates
+
+| Layer | What |
+| ----- | ---- |
+| Unit | `issue-report-promotion.test.ts` (all branches: high always, low below-bar, low above-bar, single-window burst, recency expiry, aging-out); `platform-issue-reports.test.ts` (staged-on-create, high-projects, manual-unaffected, firstSeenAt/lastSeenAt seeded, P2002 accrual); `issue-report-triage.test.ts` (stage / expire / promote / cap / high-bypass / no-deps-unchanged); `log-signature-scanner.test.ts` (accrue-on-skip). |
+| Typecheck | `pnpm --filter web exec tsc --noEmit` (clean). |
+| Functional (residual — needs live scan cycles) | Over ≥ 3 scanner cycles: a genuine recurring low signal accrues and promotes; a one-off is aged out with no BI; a high signal projects on first cycle. Requires the running platform + Loki. |
+
+## 5. Residual / risk
+
+- **Live scan-cycle behaviour** is not exercised by unit tests (no Loki/Inngest in-unit). The
+  accrual→promotion→aging-out lifecycle needs verification across real 15-min scanner + triage
+  cycles on a running install.
+- **OPEN-pool `take: 100`**: staged reports share the cron's 100-row batch with promotable ones
+  (ordered `createdAt asc`, so oldest/most-likely-stale first). A very large staged backlog
+  (> 100 concurrently) could delay processing of the newest reports by a cycle. Acceptable for
+  expected volumes; revisit with a dedicated staged-expiry sweep if staged rows pile up.

--- a/packages/db/prisma/migrations/20260716130000_add_pir_reach_staging_gate/migration.sql
+++ b/packages/db/prisma/migrations/20260716130000_add_pir_reach_staging_gate/migration.sql
@@ -1,0 +1,28 @@
+-- BI-51F6A428 (reach-threshold + staging gate before a log signature becomes a
+-- backlog item): accrual + staging columns on PlatformIssueReport. A reach-gated
+-- automated signal (the log-signature "noise-digest" stream) is held
+-- `stagedUntilPromoted` and accrues occurrenceCount/lastSeenAt across scan
+-- windows instead of minting a BI-PIR-* on first sight. The triage path projects
+-- it only once it crosses the reach+recency bar, and ages out genuinely-stopped
+-- one-offs (status→suppressed) with no BI. High/critical signals bypass the gate
+-- and project on first occurrence. Resolver:
+-- apps/web/lib/quality/issue-report-promotion.ts.
+--
+-- @migration-safety: data-safe: occurrenceCount and stagedUntilPromoted are NOT
+-- NULL but carry table-level DEFAULTs, so Postgres backfills every existing row
+-- without a rewrite and no pre-existing row can violate the columns.
+-- firstSeenAt/lastSeenAt are nullable and backfilled from createdAt below. No
+-- new constraints, uniques, or indexes are tightened over existing data.
+ALTER TABLE "PlatformIssueReport"
+    ADD COLUMN "occurrenceCount" INTEGER NOT NULL DEFAULT 1,
+    ADD COLUMN "firstSeenAt" TIMESTAMP(3),
+    ADD COLUMN "lastSeenAt" TIMESTAMP(3),
+    ADD COLUMN "stagedUntilPromoted" BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill sighting timestamps for existing rows: treat their creation as the
+-- first and last sighting so the promotion math has a basis if a legacy row is
+-- ever re-evaluated. Existing rows are already projected/triaged and are not
+-- staged, so none can be re-minted by this change.
+UPDATE "PlatformIssueReport"
+    SET "firstSeenAt" = "createdAt", "lastSeenAt" = "createdAt"
+    WHERE "firstSeenAt" IS NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -5271,6 +5271,18 @@ model PlatformIssueReport {
   // that produced them so reflection can avoid route/time-window heuristics.
   threadId            String?
   taskRunId           String?
+  // BI-51F6A428 (reach-threshold + staging gate): accrual + staging fields that
+  // stop the PIR treadmill. A reach-gated automated signal (the log-signature
+  // "noise-digest" stream) is born `stagedUntilPromoted=true` instead of minting
+  // a BI on first sight; each re-occurrence bumps occurrenceCount + lastSeenAt,
+  // and it is projected into the backlog only once it crosses the reach+recency
+  // bar (apps/web/lib/quality/issue-report-promotion.ts). A staged signal that
+  // stops recurring is aged out (status→suppressed) with no BI. High/critical
+  // signals bypass the gate and project on first occurrence.
+  occurrenceCount     Int           @default(1)
+  firstSeenAt         DateTime?
+  lastSeenAt          DateTime?
+  stagedUntilPromoted Boolean       @default(false)
   // BI-0ACD9AB2 §5.3/§14 dial-up: the autonomous responder sweep pre-computes a
   // WWMD recommendation (status / recommended action / reason) here so the /ops
   // attention lens shows it without an operator click. Advisory only — the human


### PR DESCRIPTION
## Summary

Stops the **PIR treadmill**: a single transient log signature no longer mints a `BI-PIR-*` backlog item on first sight. A reach-gated automated signal (the log-signature `noise-digest` stream) is now held in a **staging lane** and must cross a reach + recency bar before it projects into the backlog. A genuinely-stopped one-off is aged out with no BI. **High/critical signals always project on first occurrence** — the safety contract.

Implements **BI-51F6A428**.

## What changed

- **Schema accrual** — additive columns on `PlatformIssueReport`: `occurrenceCount` / `firstSeenAt` / `lastSeenAt` / `stagedUntilPromoted`, with a hand-authored, backfilled, `@migration-safety: data-safe` migration (`20260716130000_add_pir_reach_staging_gate`). `stagedUntilPromoted` is a flag, not a status, so staged reports stay in the cron's OPEN pool for re-evaluation.
- **Accrual on re-occurrence** — `accrueIssueReportOccurrence(id, now)` bumps `occurrenceCount` + `lastSeenAt`, called from the scanner's skip-existing branch (the steady-state recurrence signal) **and** the front-door P2002 dedupeKey race. Previously a re-occurrence was silently swallowed.
- **Pure decision module** — `apps/web/lib/quality/issue-report-promotion.ts` (`shouldPromoteIssueReport` / `shouldExpireStagedReport`), exhaustively unit-tested.
- **Front-door gate** — `createPlatformIssueReport` births a below-bar reach-gated report `stagedUntilPromoted=true` and does **not** fire the immediate projection event.
- **Triage promote/stage/age-out** — the 15-min safety-net cron re-evaluates staged reports: promotes those that cross the bar (clears the flag), holds those still accruing, and ages out stopped one-offs to `suppressed` without a BI.
- **Per-scan-window cap** — bounds NEW reach-gated promotions to 25/run so a runaway source can't flood; high/critical bypass.

## Gating policy / thresholds

| Severity | Policy |
| --- | --- |
| high / critical | **Always promote on first occurrence** (never held) |
| low / medium (reach-gated `noise-digest` only) | Promote only when `occurrenceCount >= 3` **AND** first→last span `>= 15 min` (≥ 2 scan windows) **AND** `lastSeenAt` within `60 min` (still recurring); else stage |

- Aging-out: staged report not seen within `60 min` → closed to `suppressed`, no BI.
- Per-window promotion cap: `25`.
- Missing accrual timestamps fail **closed** (held). Human/manual, crash-boundary, and runtime-fault streams are never gated — they project as before.

## Safety

Staged reports are **never silently dropped** except by explicit aging-out of genuinely-stopped one-offs; anything still recurring keeps accruing and eventually promotes. The gate is additive behind optional deps + the `noise-digest` stream, so every non-scanner intake path is byte-identical to today.

## Tests

- `pnpm --filter web exec vitest run` on the touched files: **88 pass**. Full `lib/quality` + `lib/operate` + `lib/queue` suites: **794 pass, 3 pre-existing skips**.
- `tsc --noEmit`: **clean** (8GB heap; pre-commit hook OOMs at default 4GB, `DPF_SKIP_TYPECHECK` used per hook guidance — CI gates typecheck).
- Migration safety guard + timestamp-collision guard: **pass**.

## Residual / risk (needs live verification)

- **Live scan-cycle lifecycle** (accrual → promote → age-out across real 15-min Loki/Inngest scanner + triage cycles) is not exercisable in unit tests — needs a running install. This is a live-intake-pipeline change, so **not** enabling auto-merge; please review.
- OPEN-pool `take: 100`: a very large staged backlog could delay newest-report processing by a cycle. Acceptable for expected volumes; revisit with a dedicated staged-expiry sweep if staged rows pile up.

Spec: `docs/superpowers/specs/2026-07-16-pir-reach-threshold-staging-gate-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)