### PR TITLE
fix(sandbox): stream writeSandboxFile content via stdin, not argv, to stop secret leak (BI-AFEF038A)

### DIFF
--- a/apps/web/lib/integrate/sandbox/agent-cli-runtime.test.ts
+++ b/apps/web/lib/integrate/sandbox/agent-cli-runtime.test.ts
@@ -1,0 +1,256 @@
+// apps/web/lib/integrate/sandbox/agent-cli-runtime.test.ts
+//
+// Security coverage for BI-AFEF038A: writeSandboxFile must stream file content
+// (potentially a secret — OAuth token, mcp-config JWT, codex auth.json) through
+// the child's stdin, NEVER embedded in the `docker exec` command. If the content
+// were in argv it would show up in `ps` / /proc, container exec logs, and any
+// rejected-exec error string — which is exactly the leak this BI closes.
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+
+// ── Spawn mock infrastructure (mirrors codex-cli-adapter.test.ts) ─────────────
+
+interface MockProcess extends EventEmitter {
+  stdin: {
+    write: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+  };
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+  /** All bytes handed to stdin.write, concatenated. */
+  stdinData: string;
+}
+
+function makeMockProcess(): MockProcess {
+  const proc = new EventEmitter() as MockProcess;
+  proc.stdinData = "";
+  proc.stdin = {
+    write: vi.fn((data: unknown, cb?: (err?: Error | null) => void) => {
+      proc.stdinData += String(data);
+      cb?.();
+      return true;
+    }),
+    end: vi.fn(),
+    on: vi.fn(),
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  return proc;
+}
+
+const mockSpawn = vi.fn();
+
+vi.mock("@/lib/shared/lazy-node", () => ({
+  lazyChildProcess: () => ({
+    spawn: (...args: unknown[]) => mockSpawn(...args),
+  }),
+  lazyUtil: () => ({ promisify: (fn: Function) => fn }),
+}));
+
+import { writeSandboxFile, dockerExecWriteStdin } from "./agent-cli-runtime";
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("writeSandboxFile (BI-AFEF038A — content via stdin, not argv)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const SECRET = "sk-ant-oat01-SUPER-SECRET-TOKEN-abc123";
+
+  it("uses `docker exec -i` and never puts the content (raw or base64) in argv", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const p = writeSandboxFile({
+      containerId: "dpf-sandbox-1",
+      path: "/tmp/claude-oauth-token.txt",
+      content: SECRET,
+      mode: "644",
+    });
+    proc.emit("close", 0);
+    await p;
+
+    const [cmd, args] = mockSpawn.mock.calls[0] as [string, string[]];
+    expect(cmd).toBe("docker");
+    // -i is required so the host stdin is wired to the container stdin.
+    expect(args).toContain("-i");
+
+    const argvJoined = args.join(" ");
+    // The raw secret must not be in argv.
+    expect(argvJoined).not.toContain(SECRET);
+    // Neither may its base64 encoding — that decodes straight back to the secret,
+    // which is the precise leak vector BI-AFEF038A closes.
+    const b64 = Buffer.from(SECRET).toString("base64");
+    expect(argvJoined).not.toContain(b64);
+    // No `echo '<payload>'` staging anywhere in the command.
+    expect(argvJoined).not.toMatch(/echo '/);
+  });
+
+  it("streams the base64 payload through stdin (the ONLY channel the secret uses)", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const p = writeSandboxFile({
+      containerId: "dpf-sandbox-1",
+      path: "/tmp/claude-oauth-token.txt",
+      content: SECRET,
+      mode: "644",
+    });
+    proc.emit("close", 0);
+    await p;
+
+    expect(proc.stdin.write).toHaveBeenCalledTimes(1);
+    expect(proc.stdin.end).toHaveBeenCalled();
+    // What went to stdin decodes back to exactly the original content bytes.
+    expect(Buffer.from(proc.stdinData, "base64").toString("utf-8")).toBe(SECRET);
+    // The container reconstructs the file by decoding stdin, not an argv payload.
+    const innerCmd = (mockSpawn.mock.calls[0] as [string, string[]])[1].join(" ");
+    expect(innerCmd).toContain("base64 -d");
+  });
+
+  it("single-quotes the target path and applies chmod (no path/shell breakout)", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const p = writeSandboxFile({
+      containerId: "dpf-sandbox-1",
+      path: "/tmp/cli-run.sh",
+      content: "#!/bin/sh\necho hi",
+      mode: "755",
+    });
+    proc.emit("close", 0);
+    await p;
+
+    const inner = (mockSpawn.mock.calls[0] as [string, string[]])[1].at(-1) as string;
+    expect(inner).toBe("base64 -d > '/tmp/cli-run.sh' && chmod 755 '/tmp/cli-run.sh'");
+  });
+
+  it("adds --user node and chown when requested (node-user + root-written config)", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const p = writeSandboxFile({
+      containerId: "dpf-sandbox-1",
+      path: "/tmp/cli-mcp.json",
+      content: "{}",
+      chownNodeUser: true,
+      mode: "644",
+    });
+    proc.emit("close", 0);
+    await p;
+
+    const args = (mockSpawn.mock.calls[0] as [string, string[]])[1];
+    const inner = args.at(-1) as string;
+    expect(inner).toContain("chown node:node '/tmp/cli-mcp.json'");
+    expect(inner).toContain("chmod 644 '/tmp/cli-mcp.json'");
+  });
+
+  it("prefixes mkdir -p when mkdirParents is given, and omits chmod when mode omitted", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const p = writeSandboxFile({
+      containerId: "dpf-sandbox-1",
+      path: "/root/.codex/auth.json",
+      content: "{}",
+      mkdirParents: "/root/.codex",
+    });
+    proc.emit("close", 0);
+    await p;
+
+    const inner = (mockSpawn.mock.calls[0] as [string, string[]])[1].at(-1) as string;
+    expect(inner).toBe("mkdir -p '/root/.codex' && base64 -d > '/root/.codex/auth.json'");
+    expect(inner).not.toContain("chmod");
+  });
+
+  it("rejects secret-free when docker exits non-zero (no payload in the error)", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const p = writeSandboxFile({
+      containerId: "dpf-sandbox-1",
+      path: "/tmp/x.txt",
+      content: SECRET,
+      mode: "644",
+    });
+    proc.stderr.emit("data", Buffer.from("sh: cannot create /tmp/x.txt: permission denied"));
+    proc.emit("close", 1);
+
+    await expect(p).rejects.toThrow(/Sandbox file write failed/);
+    await p.catch((err: Error) => {
+      expect(err.message).not.toContain(SECRET);
+      expect(err.message).not.toContain(Buffer.from(SECRET).toString("base64"));
+    });
+  });
+
+  it("kills the process and rejects after the write timeout", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const p = writeSandboxFile({
+      containerId: "dpf-sandbox-1",
+      path: "/tmp/slow.txt",
+      content: SECRET,
+      mode: "644",
+      timeoutMs: 5_000,
+    });
+
+    vi.advanceTimersByTime(6_000);
+
+    await expect(p).rejects.toThrow(/timed out/);
+    expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+});
+
+describe("dockerExecWriteStdin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rejects on spawn-level error (docker not found)", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const p = dockerExecWriteStdin({
+      containerId: "dpf-sandbox-1",
+      innerCommand: "base64 -d > '/tmp/x'",
+      input: "aGk=",
+    });
+    proc.emit("error", new Error("spawn ENOENT"));
+
+    await expect(p).rejects.toThrow("spawn ENOENT");
+  });
+
+  it("does not double-settle when both timeout and close fire", async () => {
+    const proc = makeMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    const p = dockerExecWriteStdin({
+      containerId: "dpf-sandbox-1",
+      innerCommand: "base64 -d > '/tmp/x'",
+      input: "aGk=",
+      timeoutMs: 5_000,
+    });
+
+    vi.advanceTimersByTime(6_000);
+    // A late close must be swallowed by the settled flag.
+    proc.emit("close", 0);
+
+    await expect(p).rejects.toThrow(/timed out/);
+  });
+});

--- a/apps/web/lib/integrate/sandbox/agent-cli-runtime.ts
+++ b/apps/web/lib/integrate/sandbox/agent-cli-runtime.ts
@@ -154,11 +154,97 @@ export function sandboxExec(): (cmd: string, opts?: { timeout?: number }) => Pro
 }
 
 /**
+ * Stream `input` to the stdin of a `docker exec -i` running `innerCommand`
+ * inside the sandbox. The payload NEVER enters argv, so a rejected exec, a `ps`
+ * / /proc listing, or a container exec log cannot echo it back — the fix for
+ * BI-AFEF038A (follow-up to the BI-1291B677 OAuth-token leak) and the same
+ * `docker exec -i … base64 -d > file` shape already proven in
+ * codex-cli-adapter.ts (BI-2685C1E5). `innerCommand` MUST be secret-free; the
+ * real content flows only over stdin.
+ *
+ * Rejects (secret-free) on spawn error, non-zero exit, or timeout — the error
+ * carries stderr/exit code but never `input`.
+ */
+export function dockerExecWriteStdin(params: {
+  containerId: string;
+  /** Secret-free `sh -c` payload; reads the real content from stdin. */
+  innerCommand: string;
+  /** Bytes streamed to the child's stdin — the ONLY channel the content uses. */
+  input: string;
+  asNodeUser?: boolean;
+  timeoutMs?: number;
+}): Promise<{ stdout: string; stderr: string }> {
+  const { containerId, innerCommand, input, asNodeUser } = params;
+  const timeoutMs = params.timeoutMs ?? 5_000;
+  const spawn = lazyChildProcess().spawn;
+  const args = [
+    "exec",
+    "-i",
+    ...(asNodeUser ? ["--user", "node"] : []),
+    containerId,
+    "sh",
+    "-c",
+    innerCommand,
+  ];
+  return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    const proc = spawn("docker", args, { stdio: ["pipe", "pipe", "pipe"] });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      proc.kill("SIGTERM");
+      settle(() => reject(new Error(`Sandbox file write timed out after ${timeoutMs / 1000}s`)));
+    }, timeoutMs);
+
+    proc.stdout?.on("data", (d: Buffer) => { stdout += d.toString(); });
+    proc.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
+
+    // stdin may EPIPE if the container command exits before draining; the close
+    // handler owns the real outcome, so a stream-level error is not fatal here.
+    proc.stdin?.on("error", () => {});
+    proc.stdin?.write(input, (writeErr?: Error | null) => {
+      if (writeErr) settle(() => reject(new Error(`Sandbox file write stdin error: ${writeErr.message}`)));
+    });
+    proc.stdin?.end();
+
+    proc.on("close", (code: number | null) => {
+      settle(() => {
+        if (code === 0) {
+          resolve({ stdout, stderr });
+        } else {
+          // NB: never attach `input` — the rejection must stay secret-free.
+          reject(Object.assign(new Error(`Sandbox file write failed (exit ${code ?? "?"}): ${stderr.slice(0, 200)}`), { code }));
+        }
+      });
+    });
+
+    proc.on("error", (err: Error) => {
+      settle(() => reject(err));
+    });
+  });
+}
+
+/**
  * Write `content` to `path` inside the sandbox via a base64 round-trip (avoids
  * all shell-escaping issues), chmod it, and optionally run as the `node` user.
  * This is the temp-file / runner-script write every surface repeats; perms and
  * the exec user stay caller-controlled because they are a real per-surface
  * choice (644 readable prompt vs 600 secret; root vs node).
+ *
+ * SECURITY (BI-AFEF038A): the base64 payload is streamed via the child's stdin,
+ * NOT embedded in the `docker exec` command. When `content` is a secret (OAuth
+ * token, JWT, codex auth.json) it therefore never appears in argv, a process
+ * listing, or an exec log, and a rejected write cannot echo it into an error.
+ * The target `path` (and any `mkdirParents`) are single-quoted so a path can
+ * never break out of the `sh -c` command either.
  */
 export async function writeSandboxFile(params: {
   containerId: string;
@@ -170,18 +256,26 @@ export async function writeSandboxFile(params: {
    *  this. */
   mode?: string;
   asNodeUser?: boolean;
+  /** `chown node:node <path>` after writing (root-written file the node-user CLI
+   *  must read, e.g. the per-call mcp-config). */
+  chownNodeUser?: boolean;
   timeoutMs?: number;
   mkdirParents?: string;   // optional `mkdir -p <dir> &&` prefix target
 }): Promise<void> {
-  const { containerId, path, content, mode, asNodeUser, mkdirParents } = params;
-  const userFlag = asNodeUser ? "--user node " : "";
+  const { containerId, path, content, mode, asNodeUser, chownNodeUser, mkdirParents } = params;
   const b64 = Buffer.from(content).toString("base64");
-  const mkdir = mkdirParents ? `mkdir -p ${mkdirParents} && ` : "";
-  const chmod = mode ? ` && chmod ${mode} ${path}` : "";
-  await sandboxExec()(
-    `docker exec ${userFlag}${containerId} sh -c "${mkdir}echo '${b64}' | base64 -d > ${path}${chmod}"`,
-    { timeout: params.timeoutMs ?? 5_000 },
-  );
+  const mkdir = mkdirParents ? `mkdir -p '${mkdirParents}' && ` : "";
+  const chown = chownNodeUser ? ` && chown node:node '${path}'` : "";
+  const chmod = mode ? ` && chmod ${mode} '${path}'` : "";
+  // Content flows over stdin (see dockerExecWriteStdin); the command string is
+  // secret-free. `base64 -d` reads the payload from stdin when given no file arg.
+  await dockerExecWriteStdin({
+    containerId,
+    innerCommand: `${mkdir}base64 -d > '${path}'${chown}${chmod}`,
+    input: b64,
+    asNodeUser,
+    timeoutMs: params.timeoutMs ?? 5_000,
+  });
 }
 
 /** Ensure /workspace is writable by the node user (uid 1000) and git is

--- a/apps/web/lib/routing/cli-adapter.test.ts
+++ b/apps/web/lib/routing/cli-adapter.test.ts
@@ -66,6 +66,15 @@ vi.mock("@/lib/shared/lazy-node", () => ({
   }),
 }));
 
+// Sandbox file writer — the adapter delegates every temp-file / secret write to
+// writeSandboxFile, which streams content via stdin (BI-AFEF038A). Mock it so we
+// can assert on the (path, content, mode) it was handed WITHOUT the content ever
+// touching a command string.
+const mockWriteSandboxFile = vi.fn((..._args: unknown[]): Promise<void> => Promise.resolve());
+vi.mock("@/lib/integrate/sandbox/agent-cli-runtime", () => ({
+  writeSandboxFile: (...args: unknown[]) => mockWriteSandboxFile(...args),
+}));
+
 import {
   cliAdapter,
   CLAUDE_CODE_NATIVE_TOOLS_FLAG_VALUE,
@@ -73,6 +82,14 @@ import {
   parseCliJsonOutput,
   parseCliStreamOutput,
 } from "./cli-adapter";
+
+// The (path, content, mode, chownNodeUser) each writeSandboxFile call received.
+type SandboxWriteParams = { path: string; content: string; mode?: string; chownNodeUser?: boolean };
+function sandboxWriteFor(pathSubstring: string): SandboxWriteParams | undefined {
+  return mockWriteSandboxFile.mock.calls
+    .map((c) => c[0] as unknown as SandboxWriteParams)
+    .find((p) => p.path.includes(pathSubstring));
+}
 import { InferenceError } from "@/lib/ai-inference";
 import type { AdapterRequest } from "./adapter-types";
 import type { RoutedExecutionPlan } from "./recipe-types";
@@ -132,6 +149,7 @@ describe("cliAdapter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExecAsync.mockResolvedValue({ stdout: "", stderr: "" });
+    mockWriteSandboxFile.mockResolvedValue(undefined);
   });
 
   it("has type 'claude-cli'", () => {
@@ -276,11 +294,11 @@ describe("cliAdapter", () => {
 
     await cliAdapter.execute(makeRequest({ tools }));
 
-    // The system prompt file should include tool descriptions
-    // Verify via the exec calls that wrote to temp files
-    const execCalls = mockExecAsync.mock.calls.map(c => c[0] as string);
-    const systemFileWrite = execCalls.find(c => c.includes("cli-system-"));
-    expect(systemFileWrite).toBeDefined();
+    // The system prompt file should include tool descriptions. Verify via the
+    // captured writeSandboxFile content (streamed to the sandbox via stdin).
+    const systemWrite = sandboxWriteFor("cli-system-");
+    expect(systemWrite).toBeDefined();
+    expect(systemWrite!.content).toContain("create_backlog_item");
   });
 
   it("handles CLI process error with auth failure classification", async () => {
@@ -367,16 +385,11 @@ describe("cliAdapter", () => {
 
     await cliAdapter.execute(makeRequest());
 
-    // Find the runner-script write — it has cli-run-... in the filename and
-    // base64-encodes the script body. We decode and assert.
-    const execCalls = mockExecAsync.mock.calls.map((c) => c[0] as string);
-    const runnerWrite = execCalls.find((c) => c.includes("cli-run-"));
+    // Find the runner-script write — path has cli-run-…; the script body is the
+    // `content` streamed to the sandbox via stdin (never in a command string).
+    const runnerWrite = sandboxWriteFor("cli-run-");
     expect(runnerWrite).toBeDefined();
-
-    // Extract the base64 payload between the single quotes after `echo '`.
-    const m = runnerWrite!.match(/echo '([A-Za-z0-9+/=]+)'/);
-    expect(m).not.toBeNull();
-    const decodedScript = Buffer.from(m![1]!, "base64").toString("utf-8");
+    const decodedScript = runnerWrite!.content;
 
     expect(decodedScript).toContain("--disallowedTools");
     expect(decodedScript).toContain(CLAUDE_CODE_NATIVE_TOOLS_FLAG_VALUE);
@@ -457,13 +470,15 @@ describe("cliAdapter", () => {
       expect(mintArgs.scopes).toContain("backlog_read");
       expect(mintArgs.scopes).toContain("backlog_write");
 
-      // mcp-config file write
-      const execCalls = mockExecAsync.mock.calls.map((c) => c[0] as string);
-      const mcpWrite = execCalls.find((c) => c.includes("cli-mcp-"));
+      // mcp-config file write — chown to the node user + chmod 644 so the Claude
+      // CLI process can read the config. These are now params to writeSandboxFile
+      // (the JWT-bearing content flows via stdin, never the command surface).
+      const mcpWrite = sandboxWriteFor("cli-mcp-");
       expect(mcpWrite).toBeDefined();
-      // chown to node user + chmod 644 so the Claude CLI process can read the config
-      expect(mcpWrite).toContain("chown node:node");
-      expect(mcpWrite).toContain("chmod 644");
+      expect(mcpWrite!.chownNodeUser).toBe(true);
+      expect(mcpWrite!.mode).toBe("644");
+      // The short-lived JWT is carried in the config content, not in argv.
+      expect(mcpWrite!.content).toContain("eyJ.test.jwt");
     });
 
     it("includes --mcp-config + --strict-mcp-config in the runner script", async () => {
@@ -473,10 +488,7 @@ describe("cliAdapter", () => {
 
       await cliAdapter.execute(makeMcpRequest());
 
-      const execCalls = mockExecAsync.mock.calls.map((c) => c[0] as string);
-      const runnerWrite = execCalls.find((c) => c.includes("cli-run-"));
-      const m = runnerWrite!.match(/echo '([A-Za-z0-9+/=]+)'/);
-      const decoded = Buffer.from(m![1]!, "base64").toString("utf-8");
+      const decoded = sandboxWriteFor("cli-run-")!.content;
 
       expect(decoded).toContain("--mcp-config");
       expect(decoded).toContain("--strict-mcp-config");
@@ -492,10 +504,7 @@ describe("cliAdapter", () => {
 
       await cliAdapter.execute(makeMcpRequest());
 
-      const execCalls = mockExecAsync.mock.calls.map((c) => c[0] as string);
-      const systemWrite = execCalls.find((c) => c.includes("cli-system-"));
-      const m = systemWrite!.match(/echo '([A-Za-z0-9+/=]+)'/);
-      const sys = Buffer.from(m![1]!, "base64").toString("utf-8");
+      const sys = sandboxWriteFor("cli-system-")!.content;
 
       // Tool descriptions and the structured-JSON wire-format contract must
       // be absent — the CLI advertises tools via MCP discovery.
@@ -510,14 +519,11 @@ describe("cliAdapter", () => {
 
       await cliAdapter.execute(makeMcpRequest());
 
-      const execCalls = mockExecAsync.mock.calls.map((c) => c[0] as string);
-      const runnerWrite = execCalls.find((c) => c.includes("cli-run-"));
-      const decoded = Buffer.from(runnerWrite!.match(/echo '([A-Za-z0-9+/=]+)'/)![1]!, "base64").toString("utf-8");
+      const decoded = sandboxWriteFor("cli-run-")!.content;
       expect(decoded).not.toContain("--mcp-config");
       expect(decoded).toContain("--disallowedTools"); // legacy path still suppresses native tools
 
-      const systemWrite = execCalls.find((c) => c.includes("cli-system-"));
-      const sys = Buffer.from(systemWrite!.match(/echo '([A-Za-z0-9+/=]+)'/)![1]!, "base64").toString("utf-8");
+      const sys = sandboxWriteFor("cli-system-")!.content;
       // Legacy text-tool injection is back when the mint fails
       expect(sys).toContain("To invoke a tool");
     });
@@ -539,11 +545,9 @@ describe("cliAdapter", () => {
       );
 
       expect(mockCreateMcpSessionToken).not.toHaveBeenCalled();
-      const execCalls = mockExecAsync.mock.calls.map((c) => c[0] as string);
-      const runnerWrite = execCalls.find((c) => c.includes("cli-run-"));
+      const runnerWrite = sandboxWriteFor("cli-run-");
       expect(runnerWrite).toBeDefined();
-      const decoded = Buffer.from(runnerWrite!.match(/echo '([A-Za-z0-9+/=]+)'/)![1]!, "base64").toString("utf-8");
-      expect(decoded).not.toContain("--mcp-config");
+      expect(runnerWrite!.content).not.toContain("--mcp-config");
     });
 
     it("derives capability=read when no tools require write grants", async () => {

--- a/apps/web/lib/routing/cli-adapter.ts
+++ b/apps/web/lib/routing/cli-adapter.ts
@@ -21,6 +21,7 @@ import { InferenceError } from "@/lib/ai-inference";
 import { getDecryptedCredential, getProviderBearerToken } from "@/lib/inference/ai-provider-internals";
 import { registerExecutionAdapter } from "./execution-adapter-registry";
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
+import { writeSandboxFile } from "@/lib/integrate/sandbox/agent-cli-runtime";
 import { extractToolCalls as extractToolCallsFromText } from "./extract-tool-calls";
 import { createMcpSessionToken } from "@/lib/mcp/session-token";
 import { getToolGrantMapping } from "@/lib/tak/agent-grants";
@@ -446,19 +447,14 @@ export const cliAdapter: ExecutionAdapterHandler = {
     const spawnCb = cp.spawn;
 
     try {
-      // Write prompt and system prompt to sandbox
-      const promptB64 = Buffer.from(prompt).toString("base64");
-      const systemB64 = Buffer.from(fullSystemPrompt).toString("base64");
-
+      // Write prompt and system prompt to sandbox. Content is streamed via the
+      // child's stdin (writeSandboxFile → dockerExecWriteStdin), NOT embedded in
+      // the docker exec command — so secrets staged this way (the OAuth token /
+      // mcp-config JWT below) never enter argv, a `ps` listing, or an exec log
+      // (BI-AFEF038A).
       const writes: Promise<unknown>[] = [
-        execAsync(
-          `docker exec ${SANDBOX_CONTAINER} sh -c "echo '${promptB64}' | base64 -d > ${promptFile} && chmod 644 ${promptFile}"`,
-          { timeout: 5_000 },
-        ),
-        execAsync(
-          `docker exec ${SANDBOX_CONTAINER} sh -c "echo '${systemB64}' | base64 -d > ${systemFile} && chmod 644 ${systemFile}"`,
-          { timeout: 5_000 },
-        ),
+        writeSandboxFile({ containerId: SANDBOX_CONTAINER, path: promptFile, content: prompt, mode: "644", timeoutMs: 5_000 }),
+        writeSandboxFile({ containerId: SANDBOX_CONTAINER, path: systemFile, content: fullSystemPrompt, mode: "644", timeoutMs: 5_000 }),
       ];
 
       if (mcpJwt) {
@@ -476,12 +472,15 @@ export const cliAdapter: ExecutionAdapterHandler = {
             },
           },
         };
-        const mcpB64 = Buffer.from(JSON.stringify(mcpConfig)).toString("base64");
         writes.push(
-          execAsync(
-            `docker exec ${SANDBOX_CONTAINER} sh -c "echo '${mcpB64}' | base64 -d > ${mcpConfigFile} && chown node:node ${mcpConfigFile} && chmod 644 ${mcpConfigFile}"`,
-            { timeout: 5_000 },
-          ),
+          writeSandboxFile({
+            containerId: SANDBOX_CONTAINER,
+            path: mcpConfigFile,
+            content: JSON.stringify(mcpConfig),
+            chownNodeUser: true,
+            mode: "644",
+            timeoutMs: 5_000,
+          }),
         );
       }
 
@@ -491,18 +490,14 @@ export const cliAdapter: ExecutionAdapterHandler = {
       let authExportLine: string;
       let bareFlag = "";
       if (auth.mode === "oauth") {
-        const tokenB64 = Buffer.from(auth.token).toString("base64");
         try {
-          await execAsync(
-            `docker exec ${SANDBOX_CONTAINER} sh -c "echo '${tokenB64}' | base64 -d > ${tokenFile} && chmod 644 ${tokenFile}"`,
-            { timeout: 5_000 },
-          );
+          await writeSandboxFile({ containerId: SANDBOX_CONTAINER, path: tokenFile, content: auth.token, mode: "644", timeoutMs: 5_000 });
         } catch {
-          // BI-1291B677: this command embeds the base64-encoded OAuth token, and a
-          // rejected exec Error carries the full command (.cmd / .message) — which
-          // would otherwise propagate the token into the dispatch error and the
-          // BuildActivity / ideate_dispatch summary. Swallow the original and
-          // re-throw a token-free error so the secret never reaches a log surface.
+          // BI-1291B677 / BI-AFEF038A: the token now streams via stdin so it no
+          // longer enters the command surface, but keep this belt-and-suspenders
+          // catch so any failure surfaces a token-free error rather than a raw
+          // exec rejection that could carry stderr detail into the dispatch
+          // error and the BuildActivity / ideate_dispatch summary.
           throw new Error("Failed to stage the CLI OAuth token into the sandbox.");
         }
         authExportLine = `export CLAUDE_CODE_OAUTH_TOKEN=$(cat ${tokenFile})`;
@@ -543,11 +538,7 @@ export const cliAdapter: ExecutionAdapterHandler = {
         `wait "$CLIPID"`,
       ].join("\n");
 
-      const scriptB64 = Buffer.from(script).toString("base64");
-      await execAsync(
-        `docker exec ${SANDBOX_CONTAINER} sh -c "echo '${scriptB64}' | base64 -d > ${runnerScript} && chmod 755 ${runnerScript}"`,
-        { timeout: 5_000 },
-      );
+      await writeSandboxFile({ containerId: SANDBOX_CONTAINER, path: runnerScript, content: script, mode: "755", timeoutMs: 5_000 });
 
       // 6. Spawn the CLI process
       console.log(


### PR DESCRIPTION
## What & why (BI-AFEF038A)

Follow-up to **BI-1291B677** (OAuth token leaked into BuildActivity via the CLI dispatch command surface). That fix was a source-level try/catch + redaction; this closes the underlying mechanism.

`writeSandboxFile` base64-encoded the file content and embedded it **directly in the `docker exec` command**:

```
docker exec <c> sh -c "echo '<base64>' | base64 -d > <path> && chmod <mode> <path>"
```

Because the payload lives in **argv**, any secret staged this way (the CLI OAuth token, the mcp-config JWT, codex `auth.json`) is visible in `ps` / `/proc`, container exec logs, and a rejected exec `Error` whose `.cmd`/`.message` carries the base64 — which decodes straight back to the secret.

## The fix

Stream the base64 payload via the child's **stdin** instead of argv, using `docker exec -i <c> sh -c "base64 -d > <path>"` — the exact shape already proven in `codex-cli-adapter.ts` (BI-2685C1E5).

**Before**
```ts
await sandboxExec()(
  `docker exec ${userFlag}${containerId} sh -c "${mkdir}echo '${b64}' | base64 -d > ${path}${chmod}"`,
);
```
**After**
```ts
await dockerExecWriteStdin({
  containerId,
  innerCommand: `${mkdir}base64 -d > '${path}'${chown}${chmod}`, // secret-free
  input: b64,                                                     // → child stdin
  asNodeUser,
});
```

- New shared `dockerExecWriteStdin` helper (spawn + stdin write + timeout/close loop). Its rejection carries `stderr` + exit code but **never** the input.
- The target `path` (and `mkdir`/`chown`/`chmod` operands) are now **single-quoted**, so a path can't break out of `sh -c` either.
- `cli-adapter.ts`'s five inline `echo '<b64>' | base64 -d` writes (prompt / system / **mcp-config JWT** / **OAuth token** / runner script) now route through `writeSandboxFile` (added an opt-in `chownNodeUser`). The per-caller try/catch + redaction become belt-and-suspenders rather than the primary control.

## Tests

- **New** `agent-cli-runtime.test.ts` proves content flows via stdin: asserts the raw secret **and its base64** are absent from argv (`expect(args.join(" ")).not.toContain(secret)` / `.not.toContain(b64)`), that stdin decodes back to the exact bytes, path single-quoting, `chown`/`mkdir`/`chmod` assembly, and secret-free rejection on non-zero exit / timeout.
- `cli-adapter.test.ts` write-inspection tests updated to read the mocked `writeSandboxFile` `(path, content, mode, chownNodeUser)` instead of decoding argv base64.

Verified locally: touched vitest files **34/34 pass**; `tsc --noEmit` on `@dpf/web` **clean** (8GB heap; the pre-commit hook OOMs at its default 4GB, so this commit used the hook-sanctioned `DPF_SKIP_TYPECHECK=1` — CI gates typecheck).

## Risk / edge cases

- **Large files / binary content**: stdin is unbounded (also dodges `ARG_MAX`/E2BIG); base64 round-trip preserves exact bytes — `base64 -d` ignores whitespace so the missing trailing newline vs the old `echo` is inert.
- **Path escaping**: paths are now single-quoted (were unquoted). All callers pass fixed `/tmp/...` / `/root/.codex/...` paths with no single quotes, so behavior is unchanged for real inputs while removing the breakout surface.
- **Out of scope**: other `echo '<b64>' | base64 -d` writers (`tool-script.ts`, `sandbox.ts`, `coding-agent.ts`, `sandbox-pack.ts`) are separate callers not named in this BI; the existing redaction in `mcp-tools.ts` / `build-evidence-pack.ts` still covers them.

Security change — please review; auto-merge intentionally **not** enabled.

Generated with Claude Code