### PR TITLE
fix(discovery): compact run_discovery_triage payload so the triage agent can read its own metrics (BI-PIR-edaa1d12)

### DIFF
--- a/apps/web/lib/mcp/packs/discovery-inventory-pack.test.ts
+++ b/apps/web/lib/mcp/packs/discovery-inventory-pack.test.ts
@@ -25,7 +25,7 @@ const db = vi.hoisted(() => ({
 }));
 vi.mock("@dpf/db", () => db);
 
-import { discoveryInventoryPack } from "./discovery-inventory-pack";
+import { discoveryInventoryPack, compactDiscoveryTriageData } from "./discovery-inventory-pack";
 import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
 
 const EXPECTED_TOOLS = [
@@ -133,6 +133,56 @@ describe("discovery-inventory pack — handler behavior (delegation preserved)",
     expect(arg.actorId).toBe("agent-discovery-triage");
   });
 
+  it("run_discovery_triage returns a compact summary inline and omits the full decisions[] by default", async () => {
+    const decisions = Array.from({ length: 30 }, (_, i) => ({
+      inventoryEntityId: `entity-${i}`,
+      outcome: i % 2 === 0 ? "human-review" : "auto-attributed",
+      requiresHumanReview: i % 2 === 0,
+    }));
+    triageRunner.runDiscoveryTriageDaily.mockResolvedValue({
+      trigger: "cadence",
+      processedAt: "2026-07-16T00:00:00.000Z",
+      runIdempotencyKey: "run-1",
+      skipped: false,
+      metrics: { processed: 30, autoAttributed: 15, humanReview: 15, escalationQueueDepth: 15 },
+      decisions,
+    });
+    const res = await discoveryInventoryPack.handlers.run_discovery_triage({}, "u1");
+    expect(res.success).toBe(true);
+    expect(res.message).toContain("processed 30 entities with 15 auto-attributed");
+    expect(res.message).toContain("15 awaiting human review");
+    const data = res.data as Record<string, unknown>;
+    // The heavy array is NOT inlined by default…
+    expect(data.decisions).toBeUndefined();
+    // …but the metrics, the count, the top follow-up, and a capped sample are.
+    expect(data.metrics).toEqual({ processed: 30, autoAttributed: 15, humanReview: 15, escalationQueueDepth: 15 });
+    expect(data.decisionCount).toBe(30);
+    expect((data.decisionSampleIds as unknown[]).length).toBe(10);
+    expect(data.topFollowUp).toEqual({
+      inventoryEntityId: "entity-0",
+      outcome: "human-review",
+      pendingHumanReview: 15,
+    });
+  });
+
+  it("run_discovery_triage inlines the full decisions[] only when includeDecisions is opted in", async () => {
+    const decisions = [
+      { inventoryEntityId: "e0", outcome: "auto-attributed", requiresHumanReview: false },
+      { inventoryEntityId: "e1", outcome: "taxonomy-gap", requiresHumanReview: true },
+    ];
+    triageRunner.runDiscoveryTriageDaily.mockResolvedValue({
+      trigger: "volume",
+      processedAt: "2026-07-16T00:00:00.000Z",
+      skipped: false,
+      metrics: { processed: 2, autoAttributed: 1, humanReview: 1, escalationQueueDepth: 1 },
+      decisions,
+    });
+    const res = await discoveryInventoryPack.handlers.run_discovery_triage({ includeDecisions: true }, "u1");
+    const data = res.data as Record<string, unknown>;
+    expect(data.decisions).toEqual(decisions);
+    expect(data.decisionCount).toBe(2);
+  });
+
   it("run_hive_scout_ingest forwards actor + taskRun context and summarizes the run", async () => {
     hiveScout.runHiveScoutIngest.mockResolvedValue({
       catalogEntries: 10, gaps: 2, reviewed: 1, created: 1, duplicates: 0, deferred: 0,
@@ -228,5 +278,40 @@ describe("discovery-inventory pack — handler behavior (delegation preserved)",
     expect(noName.error).toBe("missing_name");
     const noUrl = await discoveryInventoryPack.handlers.configure_gateway_scan({ name: "x" }, "u1");
     expect(noUrl.error).toBe("missing_endpoint_url");
+  });
+});
+
+describe("compactDiscoveryTriageData", () => {
+  it("handles a skipped run with no decisions — zero count, null follow-up, empty sample", () => {
+    const data = compactDiscoveryTriageData(
+      {
+        trigger: "cadence",
+        processedAt: "2026-07-16T00:00:00.000Z",
+        skipped: true,
+        skipReason: "too soon",
+        metrics: { processed: 0, autoAttributed: 0, humanReview: 0 },
+        decisions: [],
+      } as never,
+      false,
+    );
+    expect(data.skipped).toBe(true);
+    expect(data.skipReason).toBe("too soon");
+    expect(data.decisionCount).toBe(0);
+    expect(data.topFollowUp).toBeNull();
+    expect(data.decisionSampleIds).toEqual([]);
+    expect(data.decisions).toBeUndefined();
+  });
+
+  it("samples the first decisions when none require human review (no actionable follow-up)", () => {
+    const decisions = [
+      { inventoryEntityId: "e0", outcome: "auto-attributed", requiresHumanReview: false },
+      { inventoryEntityId: "e1", outcome: "dismissed", requiresHumanReview: false },
+    ];
+    const data = compactDiscoveryTriageData(
+      { trigger: "volume", processedAt: "t", metrics: { humanReview: 0 }, decisions } as never,
+      false,
+    );
+    expect(data.topFollowUp).toBeNull();
+    expect((data.decisionSampleIds as unknown[]).length).toBe(2);
   });
 });

--- a/apps/web/lib/mcp/packs/discovery-inventory-pack.ts
+++ b/apps/web/lib/mcp/packs/discovery-inventory-pack.ts
@@ -14,7 +14,56 @@
 
 import { DISCOVERY_TRIAGE_AGENT_ID } from "@dpf/db";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { DiscoveryTriageRunResult } from "@/lib/discovery-triage-runner";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
+
+const DISCOVERY_TRIAGE_SAMPLE_LIMIT = 10;
+
+/**
+ * Compact the discovery-triage run result for inline tool output (BI-PIR-edaa1d12).
+ *
+ * run_discovery_triage persists every decision server-side, but the scheduled
+ * triage agent has no file-reading tool, so returning the full decisions[] array
+ * inline (~50k chars on a full run) overflows the runtime token budget and the
+ * daily metrics become unreadable — the summary can confirm executed-vs-skipped
+ * but not report a single count. By default we return a metrics-only summary
+ * (every count, the single top follow-up, and a capped sample of the entities
+ * still needing human review) and only inline the full decisions[] array when
+ * the caller explicitly opts in.
+ */
+export function compactDiscoveryTriageData(
+  result: DiscoveryTriageRunResult,
+  includeDecisions: boolean,
+): Record<string, unknown> {
+  const decisions = Array.isArray(result.decisions) ? result.decisions : [];
+  const actionable = decisions.filter((d) => d.requiresHumanReview);
+  const sample = (actionable.length > 0 ? actionable : decisions)
+    .slice(0, DISCOVERY_TRIAGE_SAMPLE_LIMIT)
+    .map((d) => ({ inventoryEntityId: d.inventoryEntityId, outcome: d.outcome }));
+  const topFollowUp = actionable[0]
+    ? {
+        inventoryEntityId: actionable[0].inventoryEntityId,
+        outcome: actionable[0].outcome,
+        pendingHumanReview: result.metrics?.humanReview ?? actionable.length,
+      }
+    : null;
+
+  const data: Record<string, unknown> = {
+    trigger: result.trigger,
+    processedAt: result.processedAt,
+    runIdempotencyKey: result.runIdempotencyKey,
+    skipped: result.skipped ?? false,
+    skipReason: result.skipReason ?? null,
+    metrics: result.metrics,
+    decisionCount: decisions.length,
+    topFollowUp,
+    decisionSampleIds: sample,
+  };
+  if (includeDecisions) {
+    data.decisions = decisions;
+  }
+  return data;
+}
 
 const definitions: ToolDefinition[] = [
   {
@@ -35,6 +84,12 @@ const definitions: ToolDefinition[] = [
       type: "object",
       properties: {
         trigger: { type: "string", enum: ["cadence", "volume"], default: "cadence" },
+        includeDecisions: {
+          type: "boolean",
+          default: false,
+          description:
+            "Include the full per-entity decisions[] array inline. Off by default — the response returns a compact metrics summary plus a sample of the entities needing review, because the full array can exceed the runtime token limit.",
+        },
       },
       required: [],
     },
@@ -139,18 +194,21 @@ async function runDiscoveryTriageHandler(
 ): Promise<ToolResult> {
   const { runDiscoveryTriageDaily } = await import("@/lib/discovery-triage-runner");
   const trigger = params["trigger"] === "volume" ? "volume" : "cadence";
+  const includeDecisions = params["includeDecisions"] === true;
   const result = await runDiscoveryTriageDaily(undefined, {
     trigger,
     actorType: "agent",
     actorId: context?.agentId ?? DISCOVERY_TRIAGE_AGENT_ID,
     enableAutonomousReview: true,
   });
+  const escalation = result.metrics?.escalationQueueDepth ?? 0;
   return {
     success: true,
     message: result.skipped
       ? result.skipReason ?? "Discovery triage skipped."
-      : `Discovery triage processed ${result.metrics.processed} entities with ${result.metrics.autoAttributed} auto-attributed.`,
-    data: result as unknown as Record<string, unknown>,
+      : `Discovery triage processed ${result.metrics.processed} entities with ${result.metrics.autoAttributed} auto-attributed` +
+        (escalation > 0 ? `; ${escalation} awaiting human review.` : "."),
+    data: compactDiscoveryTriageData(result, includeDecisions),
   };
 }
 


### PR DESCRIPTION
## Problem (BI-PIR-edaa1d12)

The scheduled Discovery Taxonomy Gap Triage runs `run_discovery_triage` successfully and persists its decisions/auto-attributions server-side, but the tool returned the **full result inline (~52,681 chars** of `decisions[]`), exceeding the runtime token limit. The oversized payload gets written to a tool-results file, and the triage agent's runtime has no file-reading tool (Read/Bash unavailable, including for spawned subagents), so the daily metrics (processed, decisionsCreated, autoAttributed, humanReview, taxonomyGap, needsMoreEvidence, escalationQueueDepth, repeatUnresolved) could not be read back. The daily summary could confirm executed-vs-skipped but **not report a single metric count or the top follow-up**.

## Fix

`run_discovery_triage` now returns a **compact metrics-only summary inline by default** and gates the heavy array behind an opt-in parameter:

- Inline always: `metrics` (all counts), `decisionCount`, `topFollowUp` (the single highest-priority entity still needing human review + pending count), `decisionSampleIds` (capped sample of up to 10 actionable entity ids), plus `trigger`/`processedAt`/`runIdempotencyKey`/`skipped`/`skipReason`.
- Full `decisions[]` array inlined **only** when the caller passes `includeDecisions: true`.
- The run message now also surfaces the escalation depth (`; N awaiting human review.`).

The gating logic is a pure, exported helper (`compactDiscoveryTriageData`). The backing `runDiscoveryTriageDaily` result and its server-side persistence are unchanged — this is purely the tool's inline-output shape.

## Design grounding

**Source of truth:** BI-PIR-edaa1d12, which specifies exactly this fix ("return a compact metrics-only summary inline … and put the full decisions[] array behind an opt-in/paged parameter"). Substrate inspected: `apps/web/lib/mcp/packs/discovery-inventory-pack.ts` (handler returned the full `result` inline) and the `DiscoveryTriageRunResult` shape in `apps/web/lib/discovery-triage-runner.ts`. Bounded tool-output-shape change, no new contract.

## Tests

`apps/web/lib/mcp/packs/discovery-inventory-pack.test.ts` — 20/20 pass:
- default response omits the full `decisions[]` and inlines metrics + count + `topFollowUp` + capped sample
- `includeDecisions: true` inlines the full array
- pure-helper coverage for the skipped/no-decisions path and the no-actionable-follow-up path

Touched files typecheck clean (`tsc --noEmit`; the full-worktree run shows only pre-existing junction Prisma-drift, absent in CI).

Generated with Claude Code