### PR TITLE
feat(wwwd): Excellence Corpus — seed "what great looks like" priming (B, BI-44EF78DE)

### DIFF
--- a/apps/web/lib/onboarding/excellence-corpus.test.ts
+++ b/apps/web/lib/onboarding/excellence-corpus.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+
+import { deriveExcellenceCorpus, excellenceCorpusToMarkdown } from "./excellence-corpus";
+
+describe("deriveExcellenceCorpus", () => {
+  it("uses the authored flavor note for a flagship archetype", () => {
+    const c = deriveExcellenceCorpus({ archetypeId: "dental-practice", industry: "healthcare-wellness" });
+    expect(c.whatGreatLooksLike.length).toBeGreaterThan(0);
+    expect(c.whatGreatLooksLike).not.toMatch(/A well-run one keeps demand/); // not the generic fallback
+    expect(c.northStarKpis.length).toBeGreaterThan(0);
+    expect(c.goodOperatorMoves.length).toBeGreaterThan(0);
+    expect(c.primaryGoal.length).toBeGreaterThan(0);
+  });
+
+  it("returns category good-operator moves for the category", () => {
+    const c = deriveExcellenceCorpus({ archetypeId: "some-clinic", industry: "healthcare-wellness" });
+    expect(c.goodOperatorMoves.some((m) => /same-day|rebook/i.test(m))).toBe(true);
+  });
+
+  it("falls back to generic content when nothing is known", () => {
+    const c = deriveExcellenceCorpus({ archetypeId: null, industry: null });
+    expect(c.whatGreatLooksLike).toMatch(/well-run/);
+    expect(c.goodOperatorMoves.length).toBeGreaterThan(0);
+  });
+
+  it("is deterministic", () => {
+    const a = deriveExcellenceCorpus({ archetypeId: "restaurant", industry: "food-hospitality" });
+    const b = deriveExcellenceCorpus({ archetypeId: "restaurant", industry: "food-hospitality" });
+    expect(a).toEqual(b);
+  });
+});
+
+describe("excellenceCorpusToMarkdown", () => {
+  it("renders a well-formed WWWD priming page", () => {
+    const md = excellenceCorpusToMarkdown(
+      deriveExcellenceCorpus({ archetypeId: "restaurant", industry: "food-hospitality" }),
+      "Demo Bistro",
+    );
+    expect(md).toContain("# What great looks like");
+    expect(md).toContain("## North-star metrics");
+    expect(md).toContain("## What a good operator does");
+    expect(md).toContain("Demo Bistro");
+  });
+});

--- a/apps/web/lib/onboarding/excellence-corpus.ts
+++ b/apps/web/lib/onboarding/excellence-corpus.ts
@@ -1,0 +1,143 @@
+// apps/web/lib/onboarding/excellence-corpus.ts
+//
+// Excellence Corpus (EP-LIVING-BUSINESS-EXCELLENCE, workstream B) — the
+// per-archetype "what great looks like": the one-line feel (from the demo-flavor
+// notes), the north-star KPIs a well-run one watches (from the marketing
+// playbook), and the moves a good operator makes. This is the PRIMING content
+// that seeds a new org's WWWD corpus at unconfirmed B/0.6, so the twin's cog is
+// primed with excellence instead of starting from a blank slate.
+//
+// Derived, not authored per-org: composes the shipped per-archetype signal
+// (DemoFlavor notes, getPlaybook KPIs) with a thin authored per-category moves
+// floor — the same derive-with-override discipline as the rest of the program.
+//
+// PURE + deterministic (no Date/Math.random).
+
+import { resolveDemoFlavor, type ArchetypeCategory } from "@dpf/storefront-templates";
+
+import { getPlaybook } from "@/lib/tak/marketing-playbooks";
+
+export interface ExcellenceCorpus {
+  archetypeId: string | null;
+  /** One line: what a great one *feels* like. */
+  whatGreatLooksLike: string;
+  /** The north-star KPIs a well-run one watches (from the playbook). */
+  northStarKpis: string[];
+  /** The concrete moves a good operator makes. */
+  goodOperatorMoves: string[];
+  /** The primary goal the business is organised around. */
+  primaryGoal: string;
+}
+
+/** Per-category "good operator moves" — the concrete habits of a well-run one.
+ *  Merged/​fallen-back like the demo-flavor notes floor. */
+const CATEGORY_OPERATOR_MOVES: Partial<Record<ArchetypeCategory, string[]>> = {
+  "healthcare-wellness": [
+    "Keep a same-day slot open for urgent cases",
+    "Rebook the next visit before the patient leaves",
+    "Confirm appointments the day before to cut no-shows",
+  ],
+  "beauty-personal-care": [
+    "Rebook clients at the chair, not by chasing later",
+    "Fill cancellations from a standby list, never leave a gap",
+    "Track colour/repeat clients and prompt their next visit",
+  ],
+  "food-hospitality": [
+    "Turn tables without rushing — seat from the waitlist as they clear",
+    "Keep the pass moving; expedite before it backs up",
+    "Protect the covers-per-shift number without cutting quality",
+  ],
+  "trades-maintenance": [
+    "Route the nearest available tech to urgent jobs first",
+    "Stock the van for the day's job mix so nothing needs a return trip",
+    "Quote and schedule while you're on site, not after",
+  ],
+  "professional-services": [
+    "Bill work-in-progress promptly — nothing sits unbilled",
+    "Watch utilisation weekly and rebalance before deadlines slip",
+    "Turn one engagement into the next before it closes",
+  ],
+  "retail-goods": [
+    "Reorder to demand — stock the sellers, clear the dead stock",
+    "Pick and hand off online orders fast",
+    "Keep the shelf-to-sale path short at the till",
+  ],
+  "pet-services": [
+    "Fit urgent cases in the same day",
+    "Send owners home with a clear plan, not just a bill",
+    "Keep boarding/daycare capacity visible so you never oversell",
+  ],
+  "real-estate-construction": [
+    "Hit the promised handover date; manage the critical path daily",
+    "Close snags fast so the client signs off clean",
+    "Keep the client informed at every stage, unprompted",
+  ],
+  "fitness-recreation": [
+    "Fill classes from the waitlist; never run an empty slot",
+    "Nudge members whose streak is slipping before they lapse",
+    "Flex the timetable to where demand actually is",
+  ],
+  "nonprofit-community": [
+    "Show donors the impact of their gift, specifically",
+    "Keep volunteer shifts filled and thanked",
+    "Track each programme against its goal, not just activity",
+  ],
+};
+
+const GENERIC_MOVES: string[] = [
+  "Act on waiting demand before it ages",
+  "Keep resources busy without overloading any one of them",
+  "Turn each completed job into the next booking",
+];
+
+/**
+ * Derive the per-archetype excellence corpus. Total and deterministic; always
+ * returns usable priming content, richer for archetypes with authored flavor.
+ */
+export function deriveExcellenceCorpus(input: {
+  archetypeId?: string | null;
+  industry?: string | null;
+  ctaType?: string | null;
+}): ExcellenceCorpus {
+  const category = (input.industry ?? undefined) as ArchetypeCategory | undefined;
+  const flavor = input.archetypeId ? resolveDemoFlavor(input.archetypeId, category) : category ? resolveDemoFlavor("", category) : undefined;
+  const playbook = getPlaybook(input.industry ?? null, input.ctaType ?? null);
+
+  const whatGreatLooksLike =
+    flavor?.notes?.trim() ||
+    "A well-run one keeps demand moving, resources busy without strain, and every job delivered and paid.";
+
+  const moves = (category && CATEGORY_OPERATOR_MOVES[category]) || GENERIC_MOVES;
+
+  return {
+    archetypeId: input.archetypeId ?? null,
+    whatGreatLooksLike,
+    northStarKpis: playbook.keyMetrics.slice(0, 4),
+    goodOperatorMoves: moves,
+    primaryGoal: playbook.primaryGoal,
+  };
+}
+
+/** Render the corpus as a WWWD wiki-page body (markdown) — the priming material
+ *  seeded into the org's stance corpus. */
+export function excellenceCorpusToMarkdown(corpus: ExcellenceCorpus, orgLabel = "this business"): string {
+  const kpis = corpus.northStarKpis.length
+    ? corpus.northStarKpis.map((k) => `- ${k}`).join("\n")
+    : "- (set your north-star metrics)";
+  const moves = corpus.goodOperatorMoves.map((m) => `- ${m}`).join("\n");
+  return [
+    "# What great looks like",
+    "",
+    corpus.whatGreatLooksLike,
+    "",
+    `A well-run ${orgLabel} is organised around: ${corpus.primaryGoal}.`,
+    "",
+    "## North-star metrics",
+    kpis,
+    "",
+    "## What a good operator does",
+    moves,
+    "",
+    "This is a starting picture of excellence for this kind of business, derived from how the best ones operate. Confirm or refine it as the organization's own judgment is captured.",
+  ].join("\n");
+}

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.test.ts
@@ -147,9 +147,10 @@ describe("seedOrgWwwdCorpus", () => {
     expect(fake.versions).toHaveLength(1);
     expect(fake.versions[0]).toMatchObject({ versionId: result.versionId, versionNumber: 1 });
 
-    // Twelve materials across all four decision classes (BI-70ADC71F)
-    expect(result.materialCount).toBe(12);
-    expect(fake.materials).toHaveLength(12);
+    // Thirteen materials across all four decision classes (BI-70ADC71F + the
+    // workstream-B excellence page in plan-readiness).
+    expect(result.materialCount).toBe(13);
+    expect(fake.materials).toHaveLength(13);
     for (const m of fake.materials) {
       expect(m.profileVersionId).toBe(result.versionId);
       expect(m.reviewStatus).toBe("approved");
@@ -163,14 +164,14 @@ describe("seedOrgWwwdCorpus", () => {
       return acc;
     }, {});
     expect(byClass).toEqual({
-      "plan-readiness": 4,
+      "plan-readiness": 5,
       "risk-assessment": 3,
       "professional-practice": 3,
       "architecture-tradeoff": 2,
     });
 
-    // Nine published, org-scoped, non-kernel wiki pages (4 identity + 5 vectors)
-    expect(fake.wikiPages).toHaveLength(9);
+    // Ten published, org-scoped, non-kernel wiki pages (4 identity + 1 excellence + 5 vectors)
+    expect(fake.wikiPages).toHaveLength(10);
     for (const p of fake.wikiPages) {
       expect(p.status).toBe("published");
       expect(p.organizationId).toBe(ORG);
@@ -180,6 +181,7 @@ describe("seedOrgWwwdCorpus", () => {
       "org-how-we-decide",
       "org-mission",
       "org-supply-chain",
+      "org-what-great-looks-like",
       "org-who-we-serve",
       "stances/customer-goodwill",
       "stances/growth-vs-stability",
@@ -195,9 +197,9 @@ describe("seedOrgWwwdCorpus", () => {
     expect(mission!.pageKind).toBe("principle");
 
     // Every published page was embedded into Qdrant
-    expect(embed).toHaveBeenCalledTimes(9);
+    expect(embed).toHaveBeenCalledTimes(10);
     expect(result.embedded).toBe(true);
-    expect(result.wikiPageIds).toHaveLength(9);
+    expect(result.wikiPageIds).toHaveLength(10);
   });
 
   it("is idempotent — re-running produces no duplicate profile/version/material/page rows", async () => {
@@ -218,11 +220,11 @@ describe("seedOrgWwwdCorpus", () => {
     // Fallback + org profile, each upserted once (no duplicates on re-run).
     expect(fake.profiles).toHaveLength(2);
     expect(fake.versions).toHaveLength(1);
-    expect(fake.materials).toHaveLength(12);
-    expect(fake.wikiPages).toHaveLength(9);
+    expect(fake.materials).toHaveLength(13);
+    expect(fake.wikiPages).toHaveLength(10);
     // Body unchanged on the 2nd run → no extra revision, no re-embed
-    expect(fake.revisions).toHaveLength(9);
-    expect(embed).toHaveBeenCalledTimes(9);
+    expect(fake.revisions).toHaveLength(10);
+    expect(embed).toHaveBeenCalledTimes(10);
   });
 
   it("still seeds a non-empty corpus when no mission was captured (archetype fallback)", async () => {
@@ -234,7 +236,7 @@ describe("seedOrgWwwdCorpus", () => {
 
     const result = await seedOrgWwwdCorpus({ organizationId: ORG, db: fake.db, embed });
 
-    expect(result.materialCount).toBe(12);
+    expect(result.materialCount).toBe(13);
     const mission = fake.wikiPages.find((p) => p.slug === "org-mission");
     expect(mission).toBeDefined();
     expect(mission!.body.trim().length).toBeGreaterThan(20);
@@ -253,8 +255,8 @@ describe("seedOrgWwwdCorpus", () => {
 
     expect(result.embedded).toBe(false);
     // DB rows still created despite embedding failure
-    expect(fake.wikiPages).toHaveLength(9);
-    expect(fake.materials).toHaveLength(12);
+    expect(fake.wikiPages).toHaveLength(10);
+    expect(fake.materials).toHaveLength(13);
   });
 
   it("seeds an archetype-aware org-supply-chain stance page + material", async () => {

--- a/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
+++ b/apps/web/lib/onboarding/seed-org-wwwd-corpus.ts
@@ -37,6 +37,7 @@ import { upsertWikiPage, appendRevision } from "@dpf/db/wiki-store";
 import { storeWikiPage, type StoreWikiPageInput } from "@/lib/wiki/embeddings";
 import { DECISION_DOMAIN_CLASSES, type DecisionDomainClass } from "@/lib/decision-perspective/types";
 import { suggestMission } from "./mission-suggestion";
+import { deriveExcellenceCorpus, excellenceCorpusToMarkdown } from "./excellence-corpus";
 import {
   resolveBusinessProfile,
   resolveStanceVectors,
@@ -148,6 +149,14 @@ function buildPages(
   orgName: string | null,
 ): SeedPage[] {
   const profile = resolveBusinessProfile({ archetypeId, industry: industry ?? bc?.industry ?? null });
+  // Excellence Corpus (workstream B): "what great looks like" for this archetype,
+  // seeded as unconfirmed priming so the AI cog starts from a picture of a well-run
+  // one rather than a blank slate.
+  const excellence = deriveExcellenceCorpus({
+    archetypeId,
+    industry: industry ?? bc?.industry ?? null,
+    ctaType: null,
+  });
 
   const mission =
     (bc?.mission ?? "").trim() ||
@@ -235,6 +244,16 @@ function buildPages(
         `This is ${orgLabel}'s starting supplier and supply-chain stance, derived from how this kind of business typically runs. Refine it as actual suppliers, vendors, and purchasing rhythms are captured.`,
       ].join("\n"),
       abstract: profile.supplyChain,
+    },
+    {
+      // Excellence Corpus (workstream B): the "what great looks like" primer, so
+      // the AI cog starts from a picture of a well-run one, not a blank slate.
+      slug: "org-what-great-looks-like",
+      title: "What great looks like",
+      pageKind: "principle",
+      bundles: ["plan-readiness"],
+      body: excellenceCorpusToMarkdown(excellence, orgLabel),
+      abstract: excellence.whatGreatLooksLike,
     },
   ];
 

--- a/docs/superpowers/plans/2026-07-16-excellence-corpus-execution.md
+++ b/docs/superpowers/plans/2026-07-16-excellence-corpus-execution.md
@@ -1,0 +1,39 @@
+# Excellence Corpus — execution plan (workstream B)
+
+**Program:** [Living Business Excellence](../specs/2026-07-15-living-business-excellence-program-design.md) §2 (row B)
+**Epic / BI:** `EP-LIVING-BUSINESS-EXCELLENCE` · `BI-44EF78DE`
+**Started:** 2026-07-16
+
+## Why
+
+A new business starts closer to a blank slate than it should. The program's thesis is *priming, not
+blank slate*: seed each archetype with a picture of **what great looks like** so the AI cog starts
+from excellence. The demo-flavor `notes` authored in A·P3 are the seed; workstream B turns them into
+per-archetype priming material in the org's WWWD corpus.
+
+## What landed
+
+- `apps/web/lib/onboarding/excellence-corpus.ts` — `deriveExcellenceCorpus({ archetypeId, industry,
+  ctaType })` → `{ whatGreatLooksLike, northStarKpis, goodOperatorMoves, primaryGoal }`. Composes the
+  shipped per-archetype signal — the demo-flavor `notes` (A·P3, the "what great feels like" line),
+  `getPlaybook` KPIs (north-star metrics) — with a thin authored per-category **good-operator moves**
+  floor. Derive-with-override; pure and deterministic. `excellenceCorpusToMarkdown` renders it as a
+  WWWD wiki-page body.
+- `apps/web/lib/onboarding/seed-org-wwwd-corpus.ts` — seeds an **`org-what-great-looks-like`** page
+  (pageKind `principle`, `plan-readiness` bundle) alongside the existing identity + stance pages, at
+  the same **unconfirmed B/0.6** confidence. It clears nothing on its own (effective 0.45 < every
+  band) — the owner confirms/refines it, upgrading to A/0.9, exactly like the stance vectors.
+
+This is the convergence the program names: the same curated material (the flavor `notes`) now feeds
+**both** demo fidelity (workstream A) and WWWD priming (this).
+
+**Verified:** `deriveExcellenceCorpus` + markdown unit tests; the seed corpus now lands **10 pages /
+13 materials** (was 9/12) at B/0.6, asserted in `seed-org-wwwd-corpus.test.ts`; idempotent re-run
+unchanged; typecheck clean.
+
+## Non-goals / follow-ons
+
+- Not auto-confirmed: seeded at B/0.6 so it primes but does not act until the owner confirms
+  (matches the stance-onboarding contract).
+- Per-archetype good-operator moves start at the category floor; fan out to flagship-specific moves
+  as fidelity is raised (same incremental path as the flavor registry).


### PR DESCRIPTION
## Summary

Workstream **B** (`BI-44EF78DE`): prime a new org's WWWD corpus with a per-archetype picture of **what great looks like**, so the AI cog starts from a well-run one rather than a blank slate — the "priming, not blank slate" leg of the program.

## What landed

- **`apps/web/lib/onboarding/excellence-corpus.ts`** — `deriveExcellenceCorpus({ archetypeId, industry, ctaType })` → `{ whatGreatLooksLike, northStarKpis, goodOperatorMoves, primaryGoal }`. Composes the **shipped** per-archetype signal — the A·P3 demo-flavor `notes` ("what great feels like"), `getPlaybook` KPIs (north-star metrics) — with a thin authored **per-category good-operator-moves** floor. Pure, deterministic, derive-with-override. `excellenceCorpusToMarkdown` renders the WWWD page body.
- **`apps/web/lib/onboarding/seed-org-wwwd-corpus.ts`** — seeds an **`org-what-great-looks-like`** page (`plan-readiness` bundle) at unconfirmed **B/0.6**, alongside the identity + stance pages. It clears nothing on its own (effective 0.45 < every band) — the owner confirms/refines it to A/0.9, exactly like the stance vectors.

This is the **convergence** the program names: the same curated material (the flavor `notes`) now feeds *both* demo fidelity (workstream A) and WWWD priming (this).

## Design grounding

Extends the program spec §2 row B + the stance-onboarding seeding contract (`seedOrgWwwdCorpus`). Reuses the shipped flavor registry (A·P3) + `getPlaybook`; no new contract, no auto-confirmed stance (B/0.6 primes, owner confirms). Plan: `docs/superpowers/plans/2026-07-16-excellence-corpus-execution.md`.

## Test plan

- [x] `deriveExcellenceCorpus` + markdown unit tests (flagship uses the authored note; category moves; generic fallback; deterministic; well-formed page)
- [x] The corpus now lands **10 pages / 13 materials** (was 9/12) at B/0.6 — asserted in `seed-org-wwwd-corpus.test.ts`; idempotent re-run unchanged
- [x] Onboarding suite **104/104**; typecheck clean

## Related

BI **BI-44EF78DE** (workstream B) — converges with the A·P3 flavor registry (`BI-7308C27E`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Seed-Fit-Decision: archetype-scoped
