### PR TITLE
feat(capacity): opt-in fail-closed claude-cli weekly-quota collector (BI-779FA953)

### DIFF
--- a/apps/web/lib/queue/functions/capacity-drain.ts
+++ b/apps/web/lib/queue/functions/capacity-drain.ts
@@ -24,6 +24,13 @@ export const capacityDrainScheduled = inngest.createFunction(
       const { dispatchApprovedIdeateBuilds } = await import("@/lib/integrate/ideate-on-approval");
       const { resolveScheduledOwnerUserId } = await import("../scheduled-owner");
 
+      // Refresh the REAL weekly-quota snapshot before evaluating, so the drain
+      // policy burns on live remaining allocation rather than the proxy. Opt-in
+      // + fail-closed: a no-op unless the operator has declared the creds path
+      // and enabled collection (BI-779FA953). Never throws into the drain.
+      const { collectClaudeCliWeeklyQuota } = await import("@/lib/routing/weekly-quota-collector");
+      const collect = await collectClaudeCliWeeklyQuota().catch(() => ({ collected: false, reason: "collector threw" }));
+
       const userId = await resolveScheduledOwnerUserId();
       const result = await evaluateAndDrainCapacity({ prisma, userId });
       // Fire Ideate for anything the drain just promoted (same completion the
@@ -31,7 +38,7 @@ export const capacityDrainScheduled = inngest.createFunction(
       const ideateDispatch = result.drained
         ? await dispatchApprovedIdeateBuilds({ userId })
         : null;
-      return { ...result, ideateDispatch };
+      return { ...result, ideateDispatch, weeklyCollect: collect };
     });
   },
 );

--- a/apps/web/lib/routing/cli-pool-status.ts
+++ b/apps/web/lib/routing/cli-pool-status.ts
@@ -398,9 +398,12 @@ export async function captureAnthropicWeeklyQuota(
  * confirmed. Left unimplemented so nothing hard-codes an unverified path.
  */
 export async function collectCliWeeklyQuota(_adapterType: CliAdapterType): Promise<void> {
-  // Intentionally unimplemented — see the doc comment above. A follow-up wires
-  // the provider-native read + parse + recordCliWeeklyQuota once topology is
-  // confirmed. Until then, the topology-free direct-SDK capture path feeds the
-  // signal, and the policy falls back to the proxy when no fresh snapshot exists.
+  // UPDATE (BI-779FA953): the claude-cli oauth/usage read is now implemented as
+  // an opt-in, fail-closed collector in weekly-quota-collector.ts
+  // (collectClaudeCliWeeklyQuota) — off by default, driven by operator-declared
+  // config. The codex-cli read (a `codex app-server` subprocess spawn) remains
+  // unimplemented here pending topology confirmation, so nothing hard-codes an
+  // unverified subprocess path. The topology-free direct-SDK capture still feeds
+  // the signal, and the policy falls back to the proxy without a fresh snapshot.
   return;
 }

--- a/apps/web/lib/routing/weekly-quota-collector.test.ts
+++ b/apps/web/lib/routing/weekly-quota-collector.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Spy the recorder without touching prisma.
+vi.mock("./cli-pool-status", () => ({
+  recordCliWeeklyQuota: vi.fn(async () => {}),
+}));
+
+import { collectClaudeCliWeeklyQuota, extractAccessToken } from "./weekly-quota-collector";
+import { recordCliWeeklyQuota } from "./cli-pool-status";
+
+const OK_CREDS = JSON.stringify({ claudeAiOauth: { accessToken: "sk-oauth-abc" } });
+const OK_USAGE = { seven_day: { utilization: 0.62, resets_at: "2026-07-18T05:00:00Z" } };
+
+function okFetch(body: unknown): typeof fetch {
+  return vi.fn(async () => new Response(JSON.stringify(body), { status: 200 })) as unknown as typeof fetch;
+}
+
+const ENABLED = { DPF_WEEKLY_QUOTA_COLLECT_ENABLED: "true", DPF_CLAUDE_OAUTH_CREDS_PATH: "/creds.json" } as unknown as NodeJS.ProcessEnv;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("extractAccessToken", () => {
+  it("reads nested claudeAiOauth.accessToken", () => {
+    expect(extractAccessToken(OK_CREDS)).toBe("sk-oauth-abc");
+  });
+  it("reads a flat accessToken / token", () => {
+    expect(extractAccessToken(JSON.stringify({ accessToken: "x" }))).toBe("x");
+    expect(extractAccessToken(JSON.stringify({ token: "y" }))).toBe("y");
+  });
+  it("returns null for junk or missing token", () => {
+    expect(extractAccessToken("not json")).toBeNull();
+    expect(extractAccessToken(JSON.stringify({ other: 1 }))).toBeNull();
+  });
+});
+
+describe("collectClaudeCliWeeklyQuota — opt-in gating", () => {
+  it("is a no-op when the enable flag is unset (default)", async () => {
+    const r = await collectClaudeCliWeeklyQuota({ env: {} as NodeJS.ProcessEnv });
+    expect(r.collected).toBe(false);
+    expect(r.reason).toMatch(/disabled/);
+    expect(recordCliWeeklyQuota).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when enabled but no creds path is configured", async () => {
+    const r = await collectClaudeCliWeeklyQuota({ env: { DPF_WEEKLY_QUOTA_COLLECT_ENABLED: "true" } as unknown as NodeJS.ProcessEnv });
+    expect(r.collected).toBe(false);
+    expect(r.reason).toMatch(/no creds path/);
+    expect(recordCliWeeklyQuota).not.toHaveBeenCalled();
+  });
+});
+
+describe("collectClaudeCliWeeklyQuota — happy path + fail-closed", () => {
+  it("records the parsed weekly snapshot when enabled + creds + valid response", async () => {
+    const fetchImpl = okFetch(OK_USAGE);
+    const r = await collectClaudeCliWeeklyQuota({
+      env: ENABLED,
+      readCreds: async () => OK_CREDS,
+      fetchImpl,
+      now: new Date("2026-07-16T12:00:00Z"),
+    });
+    expect(r.collected).toBe(true);
+    expect(recordCliWeeklyQuota).toHaveBeenCalledOnce();
+    const [adapter, , snap] = vi.mocked(recordCliWeeklyQuota).mock.calls[0]!;
+    expect(adapter).toBe("claude-cli");
+    expect(snap.utilization).toBeCloseTo(0.62);
+    expect(snap.source).toBe("anthropic-oauth-usage");
+  });
+
+  it("sends the required OAuth beta + claude-code User-Agent headers", async () => {
+    const fetchImpl = okFetch(OK_USAGE);
+    await collectClaudeCliWeeklyQuota({ env: ENABLED, readCreds: async () => OK_CREDS, fetchImpl });
+    const call = vi.mocked(fetchImpl).mock.calls[0]!;
+    const headers = (call[1] as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer sk-oauth-abc");
+    expect(headers["anthropic-beta"]).toBe("oauth-2025-04-20");
+    expect(headers["User-Agent"]).toMatch(/^claude-code\//);
+  });
+
+  it("fails closed on an HTTP error (records nothing)", async () => {
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 429 })) as unknown as typeof fetch;
+    const r = await collectClaudeCliWeeklyQuota({ env: ENABLED, readCreds: async () => OK_CREDS, fetchImpl });
+    expect(r.collected).toBe(false);
+    expect(r.reason).toMatch(/HTTP 429/);
+    expect(recordCliWeeklyQuota).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the creds file can't be read", async () => {
+    const r = await collectClaudeCliWeeklyQuota({
+      env: ENABLED,
+      readCreds: async () => { throw new Error("ENOENT"); },
+      fetchImpl: okFetch(OK_USAGE),
+    });
+    expect(r.collected).toBe(false);
+    expect(r.reason).toMatch(/error:/);
+    expect(recordCliWeeklyQuota).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the response carries no weekly window", async () => {
+    const r = await collectClaudeCliWeeklyQuota({
+      env: ENABLED,
+      readCreds: async () => OK_CREDS,
+      fetchImpl: okFetch({ five_hour: { utilization: 0.1 } }),
+    });
+    expect(r.collected).toBe(false);
+    expect(r.reason).toMatch(/no weekly window/);
+    expect(recordCliWeeklyQuota).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/routing/weekly-quota-collector.ts
+++ b/apps/web/lib/routing/weekly-quota-collector.ts
@@ -1,0 +1,104 @@
+// Opt-in, fail-closed collector for the claude-cli weekly subscription quota.
+//
+// This is the live half of the BI-779FA953 seam for the ONE provider whose read
+// is a plain gated HTTP call (codex-cli, which needs a subprocess spawn, stays a
+// documented seam). It is deliberately OFF by default and driven entirely by
+// operator-declared config, which is how we honour "Never Assume — Verify"
+// without a human in the loop: the code does nothing until an operator names the
+// credentials path and flips the enable flag — i.e. the operator declares the
+// runtime topology this build could not verify autonomously.
+//
+//   DPF_WEEKLY_QUOTA_COLLECT_ENABLED = "true"   — master switch (default: off)
+//   DPF_CLAUDE_OAUTH_CREDS_PATH       = <path>   — where the CLI OAuth token lives
+//   DPF_CLAUDE_CODE_UA                = <ua>      — optional User-Agent override
+//
+// Every failure path returns { collected: false } and records NOTHING — a failed
+// or stale read must never masquerade as "plenty of quota" to the drain policy.
+
+import { readFile } from "node:fs/promises";
+import { parseOAuthUsageJson } from "./weekly-quota";
+import { recordCliWeeklyQuota } from "./cli-pool-status";
+
+const OAUTH_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+
+export type WeeklyQuotaCollectResult = {
+  collected: boolean;
+  reason: string;
+  /** The provider signal source when a snapshot was recorded. */
+  source?: string;
+};
+
+/** Injectable dependencies so the collector is testable without real fs / network. */
+export interface WeeklyQuotaCollectDeps {
+  readCreds?: (path: string) => Promise<string>;
+  fetchImpl?: typeof fetch;
+  now?: Date;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Extract the OAuth access token from a Claude Code credentials file. Lenient
+ * about shape (the CLI has used `{ claudeAiOauth: { accessToken } }` and flat
+ * `{ accessToken }`); returns null when no token field is present.
+ */
+export function extractAccessToken(raw: string): string | null {
+  try {
+    const j = JSON.parse(raw) as Record<string, unknown>;
+    const nested = (j.claudeAiOauth as Record<string, unknown> | undefined) ?? undefined;
+    const candidates = [nested?.accessToken, nested?.access_token, j.accessToken, j.access_token, j.token];
+    for (const c of candidates) {
+      if (typeof c === "string" && c.length > 0) return c;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the claude-cli weekly subscription quota from /api/oauth/usage and record
+ * it against the claude-cli pool. Opt-in + fail-closed (see module header).
+ */
+export async function collectClaudeCliWeeklyQuota(
+  deps: WeeklyQuotaCollectDeps = {},
+): Promise<WeeklyQuotaCollectResult> {
+  const env = deps.env ?? process.env;
+
+  if (env.DPF_WEEKLY_QUOTA_COLLECT_ENABLED !== "true") {
+    return { collected: false, reason: "collection disabled (DPF_WEEKLY_QUOTA_COLLECT_ENABLED != true)" };
+  }
+  const credsPath = env.DPF_CLAUDE_OAUTH_CREDS_PATH;
+  if (!credsPath) {
+    return { collected: false, reason: "no creds path (DPF_CLAUDE_OAUTH_CREDS_PATH unset)" };
+  }
+
+  try {
+    const readCreds = deps.readCreds ?? ((p: string) => readFile(p, "utf8"));
+    const raw = await readCreds(credsPath);
+    const token = extractAccessToken(raw);
+    if (!token) return { collected: false, reason: "no access token in creds file" };
+
+    const fetchImpl = deps.fetchImpl ?? fetch;
+    const res = await fetchImpl(OAUTH_USAGE_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "anthropic-beta": "oauth-2025-04-20",
+        // REQUIRED — without a claude-code User-Agent the endpoint drops the
+        // caller into an aggressively rate-limited bucket and 429s.
+        "User-Agent": env.DPF_CLAUDE_CODE_UA ?? "claude-code/1.0.0",
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return { collected: false, reason: `oauth/usage HTTP ${res.status}` };
+
+    const body = await res.json().catch(() => null);
+    const snapshot = parseOAuthUsageJson(body, deps.now ?? new Date());
+    if (!snapshot) return { collected: false, reason: "no weekly window in oauth/usage response" };
+
+    await recordCliWeeklyQuota("claude-cli", "anthropic-sub", snapshot);
+    return { collected: true, reason: "recorded weekly quota", source: snapshot.source };
+  } catch (err) {
+    // Fail closed — never record a partial/failed read.
+    return { collected: false, reason: `error: ${err instanceof Error ? err.message : String(err)}` };
+  }
+}

--- a/docs/superpowers/plans/2026-07-16-capacity-weekly-quota-signal.md
+++ b/docs/superpowers/plans/2026-07-16-capacity-weekly-quota-signal.md
@@ -62,11 +62,31 @@ Pure spine + corrected policy + one topology-free live path + one documented sea
 
 `collectCliWeeklyQuota(adapterType)` in `cli-pool-status.ts` is a documented stub for
 the two CLI-native collectors (read container OAuth creds → `/api/oauth/usage`;
-spawn `codex app-server` → `account/rateLimits/read`). Left unwired because live
-collection depends on per-install container/credential topology that could not be
-verified in this autonomous build. Both endpoints are undocumented and their auth
-headers have changed before, so the collector must treat a failed/parse-less read as
-"no signal," never "plenty of quota."
+spawn `codex app-server` → `account/rateLimits/read`). Live collection depends on
+per-install container/credential topology that could not be verified in this
+autonomous build. Both endpoints are undocumented and their auth headers have
+changed before, so the collector must treat a failed/parse-less read as "no signal,"
+never "plenty of quota."
+
+### Update (PR #3072 / follow-up) — operator UI + claude-cli collector
+
+- **Operator visibility (PR #3072, BI-779FA953):** `formatWeeklyAllocationHint(pool)`
+  + a `ServiceRow` `weeklyAllocationHint` prop render the real remaining allocation
+  on CLI-backed provider rows ("63% weekly left · resets ~2d 4h"). Informational —
+  never gates routing.
+- **claude-cli collector (this follow-up):** `weekly-quota-collector.ts` →
+  `collectClaudeCliWeeklyQuota()` implements the claude-cli oauth/usage read as an
+  **opt-in, fail-closed** collector — OFF by default, driven entirely by
+  operator-declared config:
+  - `DPF_WEEKLY_QUOTA_COLLECT_ENABLED=true` (master switch),
+  - `DPF_CLAUDE_OAUTH_CREDS_PATH=<path>` (where the CLI OAuth token lives),
+  - `DPF_CLAUDE_CODE_UA` (optional User-Agent override; the endpoint REQUIRES a
+    `claude-code/*` UA or it 429s).
+  Wired into the hourly capacity-drain job before `evaluateAndDrainCapacity`, so a
+  fresh snapshot precedes the policy read — a strict no-op until the operator opts
+  in. This honours *Never Assume — Verify* by making the operator **declare** the
+  topology rather than the build assuming it. The **codex-cli** read (subprocess
+  spawn) stays a documented stub pending confirmation.
 
 ## Tests
 


### PR DESCRIPTION
## What

Implements the **claude-cli half** of the weekly-quota collector seam (spine merged in #3065, operator UI in #3072) as an **OFF-by-default, operator-declared, fail-closed** reader. This turns the seam into tested-but-dormant code so the remaining follow-up is *"flip a flag + confirm the path,"* not a from-scratch build.

## Why this is safe to ship autonomously

The earlier kernel decision deferred the collectors because live collection depends on per-install container/credential topology I can't verify autonomously. This design **respects that** rather than working around it: the collector is a strict **no-op** unless the operator sets both env knobs — i.e. the operator *declares* the topology (which honours *Never Assume — Verify*), and nothing runs against an unverified path by default.

```
DPF_WEEKLY_QUOTA_COLLECT_ENABLED=true   # master switch (default: off)
DPF_CLAUDE_OAUTH_CREDS_PATH=<path>      # where the CLI OAuth token lives
DPF_CLAUDE_CODE_UA=<ua>                 # optional UA override
```

## Design

- `weekly-quota-collector.ts` → `collectClaudeCliWeeklyQuota()`: reads the CLI OAuth token from the operator-declared path, GETs `/api/oauth/usage` with the required `anthropic-beta: oauth-2025-04-20` + `User-Agent: claude-code/*` headers (the UA is required or the endpoint 429s), parses via the existing `parseOAuthUsageJson`, records against the claude-cli pool. **Every failure path records NOTHING** — a failed/stale read must never read as "plenty of quota." Deps (`readCreds`/`fetchImpl`/`env`/`now`) injectable for tests.
- `capacity-drain.ts`: refresh the snapshot before `evaluateAndDrainCapacity` (no-op unless enabled; never throws into the drain).
- `cli-pool-status.ts`: seam comment now points at the collector; the **codex-cli** read (a `codex app-server` subprocess spawn) stays a documented stub pending topology confirmation.

## Tests

10 cases: gating (disabled / no-path), happy path, required headers, fail-closed on HTTP error / unreadable creds / no-weekly-window. `tsc --noEmit` + module-size clean; queue drift-guard green (no cron change).

## Remaining

The **codex-cli** collector (subprocess spawn) is the last deferred piece — riskier to run blind, so it stays a stub. Plan updated: `docs/superpowers/plans/2026-07-16-capacity-weekly-quota-signal.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)