### PR TITLE
feat(discovery): surface the path to enable Data Enrichment + role-visibility notes (BI-1F35055C)

### DIFF
--- a/apps/web/components/inventory/DataEnrichmentHelpNote.test.tsx
+++ b/apps/web/components/inventory/DataEnrichmentHelpNote.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { DataEnrichmentHelpNote } from "./DataEnrichmentHelpNote";
+
+describe("DataEnrichmentHelpNote", () => {
+  const html = renderToStaticMarkup(<DataEnrichmentHelpNote />);
+
+  it("surfaces the question users asked on Discovery Operations", () => {
+    expect(html).toContain("Where do I enable Data Enrichment?");
+  });
+
+  it("points to the real enablement surface (Tools & Services)", () => {
+    expect(html).toContain('href="/platform/tools/services"');
+    expect(html).toContain("Tools &amp; Services");
+  });
+
+  it("states the role-based visibility: only the Admin role can enable it", () => {
+    expect(html).toContain("Admin role (HR-000)");
+    expect(html).toMatch(/Other roles \(HR-100.HR-500\) do not see the enable controls/);
+  });
+
+  it("gives non-admins the admin-handoff step", () => {
+    expect(html).toContain("Not an admin?");
+    expect(html).toContain("Ask your");
+    expect(html).toContain("platform admin (HR-000 / CDIO)");
+  });
+});

--- a/apps/web/components/inventory/DataEnrichmentHelpNote.tsx
+++ b/apps/web/components/inventory/DataEnrichmentHelpNote.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+
+/**
+ * Discoverability affordance for BI-1F35055C.
+ *
+ * On Discovery Operations, users asked where to enable "Data Enrichment" but no
+ * verifiable in-product path was surfaced. Data Enrichment is not a Discovery
+ * setting — it is an external data service enabled with the other MCP / provider
+ * services under Platform → Tools & Services.
+ *
+ * The facts below are grounded in code, not invented:
+ *   - Enabling a service / provider connection requires the
+ *     `manage_provider_connections` capability (see apps/web/lib/govern/permissions.ts
+ *     and the `requireManageProviders` guard in apps/web/lib/actions/mcp-services.ts).
+ *   - That capability is granted only to role HR-000 (Admin / CDIO) and superusers;
+ *     roles HR-100–HR-500 do not hold it and never see the enable controls.
+ *
+ * Pure presentational component (no DB / auth / client state) so it renders in a
+ * plain node environment and is trivially unit-testable. Uses a native <details>
+ * disclosure so the note stays collapsed and non-intrusive with no client JS.
+ */
+export function DataEnrichmentHelpNote() {
+  return (
+    <details className="rounded-2xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
+      <summary className="cursor-pointer list-none text-sm font-medium text-[var(--dpf-text)] marker:content-['']">
+        <span className="text-[var(--dpf-accent)]">Where do I enable Data Enrichment?</span>
+      </summary>
+      <div className="mt-3 space-y-3 text-sm leading-6 text-[var(--dpf-text)]">
+        <p>
+          Data Enrichment is an external data service, not a Discovery setting. A platform
+          admin enables it alongside the other MCP and provider services under{" "}
+          <Link href="/platform/tools/services" className="text-[var(--dpf-accent)]">
+            Platform → Tools &amp; Services
+          </Link>
+          . New services can be found first in the{" "}
+          <Link href="/platform/tools/catalog" className="text-[var(--dpf-accent)]">
+            Tool Marketplace
+          </Link>
+          .
+        </p>
+        <p className="text-[var(--dpf-muted)]">
+          <span className="font-semibold text-[var(--dpf-text)]">Who can enable it:</span>{" "}
+          only the Admin role (HR-000) and superusers can enable services or provider
+          connections. Other roles (HR-100–HR-500) do not see the enable controls.
+        </p>
+        <p className="text-[var(--dpf-muted)]">
+          <span className="font-semibold text-[var(--dpf-text)]">Not an admin?</span> Ask your
+          platform admin (HR-000 / CDIO) to enable Data Enrichment for you.
+        </p>
+      </div>
+    </details>
+  );
+}

--- a/apps/web/components/inventory/DiscoveryOperationsPage.tsx
+++ b/apps/web/components/inventory/DiscoveryOperationsPage.tsx
@@ -11,6 +11,7 @@ import {
   summarizeDiscoveryHealth,
 } from "@/lib/discovery-data";
 import { getFullGraphData } from "@/lib/actions/graph";
+import { DataEnrichmentHelpNote } from "@/components/inventory/DataEnrichmentHelpNote";
 import { DiscoveryRunSummary } from "@/components/inventory/DiscoveryRunSummary";
 import { InventoryExceptionQueue } from "@/components/inventory/InventoryExceptionQueue";
 import { PortfolioQualityIssuesPanel } from "@/components/inventory/PortfolioQualityIssuesPanel";
@@ -113,6 +114,8 @@ export async function DiscoveryOperationsPage({
             Treat discovery as evidence. Use it to understand purpose, ownership, and dependencies across the product estate.
           </p>
         </div>
+
+        <DataEnrichmentHelpNote />
       </div>
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">


### PR DESCRIPTION
## What & why

On Discovery Operations (`/platform/tools/discovery`) users asked where to enable **Data Enrichment**, but no verifiable in-product path was surfaced (BI-1F35055C). This adds a small, collapsed `<details>` help affordance to the Discovery Operations header that answers the question accurately, with role-based visibility and an admin-handoff step.

Pure discoverability/help affordance. **No permission or enablement logic is changed.**

## The actual path (grounded in code, not invented)

- **Where it is enabled:** Data Enrichment is an external data service (`providerId: "data-enrichment"`, `category: "mcp-subscribed"` in `packages/db/data/providers-registry.json`), **not** a Discovery setting. Data/MCP services are enabled by an admin under **Platform → Tools & Services** (`/platform/tools/services`) and discovered via the **Tool Marketplace** (`/platform/tools/catalog`). The AI Providers page deliberately filters out `endpointType === "service"` rows, so it is not enabled there.
- **Who can enable it:** enabling a service/provider connection requires the `manage_provider_connections` capability — see `apps/web/lib/govern/permissions.ts` (`manage_provider_connections: { roles: ["HR-000"] }`) and the `requireManageProviders` guard in `apps/web/lib/actions/mcp-services.ts`. Only the **Admin role (HR-000)** and superusers hold it. Roles HR-100–HR-500 do not see the enable controls.
- **Admin handoff:** non-admins are told to ask their platform admin (HR-000 / CDIO).

## Design grounding

Trivial, no-contract-change help affordance. Grounded by inspecting the code substrate: `providers-registry.json`, `apps/web/lib/govern/permissions.ts`, `apps/web/lib/actions/mcp-services.ts`, and `apps/web/app/(shell)/platform/ai/providers/page.tsx`. Source of truth for the role gate is `lib/govern/permissions.ts`. No spec/plan created or changed.

Design-Grounding-Decision: BI-1F35055C — surface (not alter) the existing, code-defined Data Enrichment enablement path and its `manage_provider_connections` (HR-000-only) gate on the Discovery Operations page.

## Note on the BI example (role inversion)

The BI text gives the example "*HR-000 cannot access toggles*". Per the code and `docs/user-guide/getting-started/roles-and-access.md` (`Admin (HR-000) | Full platform access`), **HR-000 is the Admin role that _can_ enable services** — it is the non-admin roles (HR-100–HR-500) that cannot. The affordance follows the code, not the BI's inverted example.

## Test

`apps/web/components/inventory/DataEnrichmentHelpNote.test.tsx` — colocated `renderToStaticMarkup` unit test (mirrors existing `ServiceRow.test.tsx` / discovery `page.test.tsx` style) asserting the help question renders, the real enablement link (`/platform/tools/services`), the role-visibility note (only Admin HR-000 can; HR-100–HR-500 cannot), and the admin-handoff step.

## Local verification

Local vitest/tsc are env-blocked in this source-only worktree (empty `.bin` shims; the pnpm store's `vite` package is unresolved). Verified by careful manual review; `DPF_SKIP_TYPECHECK=1` and the sanctioned pre-push override were used. **CI gates** typecheck/build/unit.

Generated with Claude Code
