### PR TITLE
fix(build-studio): auto-commit in-flight task output so builds ship without manual intervention (BI-53C14D19)

### DIFF
--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -668,14 +668,35 @@ async function stepComplete(
   if (!state.containerId) return state;
 
   const { prisma } = await import("@dpf/db");
-  const { extractDiff, listSandboxCommitsAheadOfBase } = await import("./sandbox/sandbox");
-  const { getClientIdentity, resolveBuildWorkdir } = await import("./sandbox/build-branch");
+  const { extractDiff, execInSandbox, listSandboxCommitsAheadOfBase } = await import(
+    "./sandbox/sandbox"
+  );
+  const { getClientIdentity, resolveBuildWorkdir, buildSandboxCommitInFlightWorkCommand } =
+    await import("./sandbox/build-branch");
 
   const identity = await getClientIdentity();
   const baseRef = identity.clientBranch;
   // Extract the diff from the build's working dir: its own worktree when
   // isolation is on, else /workspace (default — byte-identical). BI-98B723C0 2c.
   const buildWorkdir = resolveBuildWorkdir(buildId);
+
+  // BI-53C14D19: the per-task coding agents WRITE files into the working tree
+  // but do not COMMIT them, so listSandboxCommitsAheadOfBase() below would
+  // capture 0 commits and the build would strand at deploy/ship with "no
+  // releasable source changes" (working tree dirty) — the generated code sat
+  // uncommitted and was lost on the next branch scrub. Commit any in-flight
+  // task output onto the build branch here, before capture. Best-effort and
+  // build/-branch-scoped (the helper no-ops off a build/ branch and excludes
+  // generated artifacts), so a no-op or failure never blocks completion.
+  await execInSandbox(
+    state.containerId,
+    buildSandboxCommitInFlightWorkCommand(buildWorkdir),
+  ).catch((err: unknown) => {
+    console.warn(
+      "[build-pipeline] pre-capture in-flight commit failed (best-effort):",
+      (err as Error)?.message,
+    );
+  });
 
   const [fullDiff, commitHashes] = await Promise.all([
     extractDiff(state.containerId, { baseRef, workspace: buildWorkdir }),


### PR DESCRIPTION
## The bug — builds strand with correct-but-uncommitted code

Observed repeatedly this session while ushering the backlog through the funnel (FB-041879CD, FB-A0D3D23C, and others): the build phase runs its coding tasks, which **write generated files into the sandbox working tree but never commit them**. Then `stepComplete()` captures the build's commits via `listSandboxCommitsAheadOfBase()` — which returns **0 commits** because the tree is dirty/uncommitted — so:

- `gitCommitHashes = []`, and
- deploy / "Continue to Release" rejects the build: **"No releasable source changes are present in the sandbox"** (working tree dirty).

Every build required a **manual `git commit`** in the sandbox to ship, and the uncommitted code was **lost** when the shared `/workspace` tree was scrubbed for the next build.

## Fix

In `stepComplete()`, before capturing the diff + commit list, commit any uncommitted in-flight task output onto the build branch — reusing the existing [`buildSandboxCommitInFlightWorkCommand`](apps/web/lib/integrate/sandbox/build-branch.ts) via [`execInSandbox`](apps/web/lib/integrate/sandbox/sandbox.ts). The helper is:
- **build/-branch-scoped** (no-ops off a `build/` branch),
- **excludes generated artifacts** (its pathspecs), and
- **best-effort** (`|| true` + a caught/logged failure) — a no-op or error never blocks completion.

`listSandboxCommitsAheadOfBase()` then sees the real commit and deploy/ship find releasable changes.

## Impact

Removes the manual-commit step from every build — the single biggest friction in ushering items through the funnel. Pairs with **BI-8C6AA60E** (review-resume must not re-init a branch that has committed work) for a fully robust ship path.

## Verification

Reuses two battle-tested helpers with matching signatures; `state.containerId` is null-narrowed by the guard above the change. CI Typecheck/Build is authoritative here (the change execs in the sandbox, so it's validated end-to-end by a real build post-deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)