### PR TITLE
fix(sandbox): stop provisioning Neo4j/Qdrant sidecars (BI-28D31FB7)

### DIFF
--- a/apps/web/lib/integrate/build-pipeline.ts
+++ b/apps/web/lib/integrate/build-pipeline.ts
@@ -297,24 +297,16 @@ async function stepInitDb(
 ): Promise<BuildExecutionState> {
   const {
     waitForSandboxDb,
-    waitForSandboxNeo4j,
-    waitForSandboxQdrant,
     seedSandboxDb,
   } = await import("./sandbox/sandbox-db");
   const { execInSandbox } = await import("./sandbox/sandbox");
 
   // Pool sandboxes use a shared sandbox-postgres managed by compose.
   // Per-build DB containers are only created for dynamic sandboxes.
+  // BET-5 (BI-28D31FB7): Postgres only — Neo4j/Qdrant sidecars retired.
   const dbContainer = state.dbContainerId ?? "dpf-sandbox-postgres-1";
-  const neo4jContainer = state.neo4jContainerId ?? "dpf-neo4j-1";
-  const qdrantContainer = state.qdrantContainerId ?? "dpf-qdrant-1";
 
-  // Wait for databases to become ready in parallel.
-  await Promise.all([
-    waitForSandboxDb(dbContainer),
-    waitForSandboxNeo4j(neo4jContainer),
-    waitForSandboxQdrant(qdrantContainer),
-  ]);
+  await waitForSandboxDb(dbContainer);
 
   // Run prisma migrate deploy inside the sandbox container.
   // The sandbox has DATABASE_URL pointing to its own postgres.

--- a/apps/web/lib/integrate/sandbox/sandbox-db.test.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-db.test.ts
@@ -20,12 +20,8 @@ vi.mock("@dpf/db", () => ({
 import {
   buildDockerHealthInspectCommand,
   buildDbContainerName,
-  buildNeo4jContainerName,
-  buildQdrantContainerName,
   buildSandboxDbEnvVars,
   DB_RESOURCE_LIMITS,
-  NEO4J_RESOURCE_LIMITS,
-  QDRANT_RESOURCE_LIMITS,
   recordSandboxDestroyed,
   recordSandboxStarted,
 } from "./sandbox-db";
@@ -47,26 +43,6 @@ describe("DB_RESOURCE_LIMITS", () => {
   });
 });
 
-describe("NEO4J_RESOURCE_LIMITS", () => {
-  it("has 512 MB memory", () => {
-    expect(NEO4J_RESOURCE_LIMITS.memoryMb).toBe(512);
-  });
-
-  it("has 1 CPU", () => {
-    expect(NEO4J_RESOURCE_LIMITS.cpus).toBe(1);
-  });
-});
-
-describe("QDRANT_RESOURCE_LIMITS", () => {
-  it("has 256 MB memory", () => {
-    expect(QDRANT_RESOURCE_LIMITS.memoryMb).toBe(256);
-  });
-
-  it("has 0.5 CPUs", () => {
-    expect(QDRANT_RESOURCE_LIMITS.cpus).toBe(0.5);
-  });
-});
-
 // ─── Container Naming Helpers ─────────────────────────────────────────────────
 
 describe("buildDbContainerName", () => {
@@ -79,32 +55,12 @@ describe("buildDbContainerName", () => {
   });
 });
 
-describe("buildNeo4jContainerName", () => {
-  it("prefixes with dpf-sandbox-neo4j-", () => {
-    expect(buildNeo4jContainerName("FB-ABC12345")).toBe("dpf-sandbox-neo4j-FB-ABC12345");
-  });
-
-  it("includes the full buildId", () => {
-    expect(buildNeo4jContainerName("build-xyz-99")).toBe("dpf-sandbox-neo4j-build-xyz-99");
-  });
-});
-
-describe("buildQdrantContainerName", () => {
-  it("prefixes with dpf-sandbox-qdrant-", () => {
-    expect(buildQdrantContainerName("FB-ABC12345")).toBe("dpf-sandbox-qdrant-FB-ABC12345");
-  });
-
-  it("includes the full buildId", () => {
-    expect(buildQdrantContainerName("build-xyz-99")).toBe("dpf-sandbox-qdrant-build-xyz-99");
-  });
-});
-
 describe("buildDockerHealthInspectCommand", () => {
   it("checks container health through docker inspect instead of in-container wget", () => {
-    const command = buildDockerHealthInspectCommand("dpf-qdrant-1");
+    const command = buildDockerHealthInspectCommand("dpf-sandbox-db-1");
 
     expect(command).toContain("docker inspect -f");
-    expect(command).toContain("dpf-qdrant-1");
+    expect(command).toContain("dpf-sandbox-db-1");
     expect(command).toContain("healthy");
     expect(command).not.toContain("wget");
   });
@@ -112,16 +68,8 @@ describe("buildDockerHealthInspectCommand", () => {
 
 // ─── Environment Variable Builder ─────────────────────────────────────────────
 
-describe("buildSandboxDbEnvVars", () => {
+describe("buildSandboxDbEnvVars (BI-28D31FB7 Postgres-only)", () => {
   const buildId = "FB-TEST001";
-  let envVars: ReturnType<typeof buildSandboxDbEnvVars>;
-
-  // Compute once for all assertions in this suite
-  it("returns an object", () => {
-    envVars = buildSandboxDbEnvVars(buildId);
-    expect(typeof envVars).toBe("object");
-    expect(envVars).not.toBeNull();
-  });
 
   it("sets DATABASE_URL with correct postgres container hostname", () => {
     const vars = buildSandboxDbEnvVars(buildId);
@@ -131,48 +79,22 @@ describe("buildSandboxDbEnvVars", () => {
     );
   });
 
-  it("sets NEO4J_URI with bolt scheme and correct hostname", () => {
+  it("does not inject retired Neo4j/Qdrant env keys", () => {
     const vars = buildSandboxDbEnvVars(buildId);
-    const expectedHost = buildNeo4jContainerName(buildId);
-    expect(vars.NEO4J_URI).toBe(`bolt://${expectedHost}:7687`);
+    expect(Object.keys(vars).sort()).toEqual(["DATABASE_URL"]);
+    expect(vars).not.toHaveProperty("NEO4J_URI");
+    expect(vars).not.toHaveProperty("QDRANT_INTERNAL_URL");
   });
 
-  it("sets NEO4J_USER to neo4j", () => {
-    const vars = buildSandboxDbEnvVars(buildId);
-    expect(vars.NEO4J_USER).toBe("neo4j");
-  });
-
-  it("sets NEO4J_PASSWORD to dpf_sandbox", () => {
-    const vars = buildSandboxDbEnvVars(buildId);
-    expect(vars.NEO4J_PASSWORD).toBe("dpf_sandbox");
-  });
-
-  it("sets QDRANT_INTERNAL_URL with http scheme and correct hostname", () => {
-    const vars = buildSandboxDbEnvVars(buildId);
-    const expectedHost = buildQdrantContainerName(buildId);
-    expect(vars.QDRANT_INTERNAL_URL).toBe(`http://${expectedHost}:6333`);
-  });
-
-  it("contains exactly the expected keys", () => {
-    const vars = buildSandboxDbEnvVars(buildId);
-    expect(Object.keys(vars).sort()).toEqual(
-      ["DATABASE_URL", "NEO4J_PASSWORD", "NEO4J_URI", "NEO4J_USER", "QDRANT_INTERNAL_URL"].sort(),
-    );
-  });
-
-  it("embeds buildId in all URL values", () => {
+  it("embeds buildId in DATABASE_URL", () => {
     const vars = buildSandboxDbEnvVars(buildId);
     expect(vars.DATABASE_URL).toContain(buildId);
-    expect(vars.NEO4J_URI).toContain(buildId);
-    expect(vars.QDRANT_INTERNAL_URL).toContain(buildId);
   });
 
   it("produces distinct hostnames for different buildIds", () => {
     const vars1 = buildSandboxDbEnvVars("build-001");
     const vars2 = buildSandboxDbEnvVars("build-002");
     expect(vars1.DATABASE_URL).not.toBe(vars2.DATABASE_URL);
-    expect(vars1.NEO4J_URI).not.toBe(vars2.NEO4J_URI);
-    expect(vars1.QDRANT_INTERNAL_URL).not.toBe(vars2.QDRANT_INTERNAL_URL);
   });
 });
 
@@ -202,17 +124,14 @@ describe("sandbox execution records", () => {
     });
   });
 
-  it("marks a sandbox as destroyed", async () => {
-    mockSandboxUpdate.mockResolvedValue({ id: "sbx-1", state: "destroyed" });
-
+  it("marks a sandbox destroyed", async () => {
+    mockSandboxUpdate.mockResolvedValue({ id: "sbx-1" });
     await recordSandboxDestroyed("sbx-1");
-
-    expect(mockSandboxUpdate).toHaveBeenCalledWith({
-      where: { id: "sbx-1" },
-      data: {
-        state: "destroyed",
-        destroyedAt: expect.any(Date),
-      },
-    });
+    expect(mockSandboxUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "sbx-1" },
+        data: expect.objectContaining({ state: "destroyed" }),
+      }),
+    );
   });
 });

--- a/apps/web/lib/integrate/sandbox/sandbox-db.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-db.ts
@@ -1,6 +1,7 @@
 // apps/web/lib/sandbox-db.ts
-// Sandbox database stack management — creates and destroys PostgreSQL, Neo4j,
-// and Qdrant containers for isolated sandbox environments.
+// Sandbox database stack management — creates and destroys PostgreSQL for
+// isolated sandbox environments. BET-5 (BI-28D31FB7): Neo4j + Qdrant containers
+// are no longer provisioned; vectors/graph live in Postgres (pgvector).
 
 import { lazyExec } from "@/lib/shared/lazy-node";
 import { Prisma, prisma } from "@dpf/db";
@@ -10,8 +11,6 @@ const exec = lazyExec();
 // ─── Resource Limit Constants ─────────────────────────────────────────────────
 
 export const DB_RESOURCE_LIMITS = { memoryMb: 512, cpus: 1 } as const;
-export const NEO4J_RESOURCE_LIMITS = { memoryMb: 512, cpus: 1 } as const;
-export const QDRANT_RESOURCE_LIMITS = { memoryMb: 256, cpus: 0.5 } as const;
 
 // ─── Container Naming Helpers ─────────────────────────────────────────────────
 
@@ -19,23 +18,16 @@ export function buildDbContainerName(buildId: string): string {
   return `dpf-sandbox-db-${buildId}`;
 }
 
-export function buildNeo4jContainerName(buildId: string): string {
-  return `dpf-sandbox-neo4j-${buildId}`;
-}
-
-export function buildQdrantContainerName(buildId: string): string {
-  return `dpf-sandbox-qdrant-${buildId}`;
-}
-
 // ─── Environment Variable Builder ─────────────────────────────────────────────
 
+/**
+ * Env for the sandboxed portal. BET-5: only Postgres is provisioned. Legacy
+ * NEO4J_/QDRANT_ URLs are intentionally omitted so the portal cannot reach
+ * retired services even if code still reads those env names.
+ */
 export function buildSandboxDbEnvVars(buildId: string): Record<string, string> {
   return {
     DATABASE_URL: `postgresql://dpf:dpf_sandbox@${buildDbContainerName(buildId)}:5432/dpf`,
-    NEO4J_URI: `bolt://${buildNeo4jContainerName(buildId)}:7687`,
-    NEO4J_USER: "neo4j",
-    NEO4J_PASSWORD: "dpf_sandbox",
-    QDRANT_INTERNAL_URL: `http://${buildQdrantContainerName(buildId)}:6333`,
   };
 }
 
@@ -97,21 +89,6 @@ async function pollUntilReady(
   throw new Error(`${label} did not become ready within ${POLL_TIMEOUT_MS / 1000}s`);
 }
 
-async function pollUntilHealthy(containerId: string, label: string): Promise<void> {
-  const deadline = Date.now() + POLL_TIMEOUT_MS;
-  const command = buildDockerHealthInspectCommand(containerId);
-  while (Date.now() < deadline) {
-    try {
-      await exec(command);
-      return;
-    } catch {
-      // not healthy yet
-    }
-    await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-  }
-  throw new Error(`${label} did not become ready within ${POLL_TIMEOUT_MS / 1000}s`);
-}
-
 // ─── Lifecycle — Create ───────────────────────────────────────────────────────
 
 export async function createSandboxDbStack(
@@ -119,17 +96,13 @@ export async function createSandboxDbStack(
   networkName: string,
 ): Promise<{
   dbContainerId: string;
-  neo4jContainerId: string;
-  qdrantContainerId: string;
 }> {
   if (process.env.DPF_ENVIRONMENT === "dev") {
     throw new Error("Sandbox database stack creation is disabled in the dev environment");
   }
   const dbName = buildDbContainerName(buildId);
-  const neo4jName = buildNeo4jContainerName(buildId);
-  const qdrantName = buildQdrantContainerName(buildId);
 
-  // PostgreSQL
+  // PostgreSQL only (BET-5 BI-28D31FB7 — no Neo4j/Qdrant sidecars).
   const { stdout: dbOut } = await exec(
     [
       "docker run -d",
@@ -140,45 +113,13 @@ export async function createSandboxDbStack(
       "-e POSTGRES_USER=dpf",
       "-e POSTGRES_PASSWORD=dpf_sandbox",
       "-e POSTGRES_DB=dpf",
-      // BET-5 (BI-28D31FB7): the sandboxed portal runs `prisma migrate deploy` on
-      // boot, which includes `CREATE EXTENSION vector` — the plain alpine Postgres
-      // image lacks pgvector, so every sandbox build failed at that migration.
-      // Provision on pgvector (same PG16 engine, superset image), matching the
-      // platform + local-CI Postgres. GENERAL RULE: every Postgres-provisioning
-      // site must ship pgvector — enforced by postgres-pgvector-provisioning.guard.
+      // BET-5: prisma migrate needs CREATE EXTENSION vector.
       "pgvector/pgvector:pg16",
     ].join(" "),
   );
   const dbContainerId = dbOut.trim();
 
-  // Neo4j
-  const { stdout: neo4jOut } = await exec(
-    [
-      "docker run -d",
-      `--name ${neo4jName}`,
-      `--network=${networkName}`,
-      `--cpus=${NEO4J_RESOURCE_LIMITS.cpus}`,
-      `--memory=${NEO4J_RESOURCE_LIMITS.memoryMb}m`,
-      "-e NEO4J_AUTH=neo4j/dpf_sandbox",
-      "neo4j:5-community",
-    ].join(" "),
-  );
-  const neo4jContainerId = neo4jOut.trim();
-
-  // Qdrant
-  const { stdout: qdrantOut } = await exec(
-    [
-      "docker run -d",
-      `--name ${qdrantName}`,
-      `--network=${networkName}`,
-      `--cpus=${QDRANT_RESOURCE_LIMITS.cpus}`,
-      `--memory=${QDRANT_RESOURCE_LIMITS.memoryMb}m`,
-      "qdrant/qdrant:latest",
-    ].join(" "),
-  );
-  const qdrantContainerId = qdrantOut.trim();
-
-  return { dbContainerId, neo4jContainerId, qdrantContainerId };
+  return { dbContainerId };
 }
 
 // ─── Lifecycle — Health Checks ────────────────────────────────────────────────
@@ -189,18 +130,6 @@ export async function waitForSandboxDb(dbContainerId: string): Promise<void> {
     "pg_isready -U dpf",
     "PostgreSQL",
   );
-}
-
-export async function waitForSandboxNeo4j(neo4jContainerId: string): Promise<void> {
-  await pollUntilReady(
-    neo4jContainerId,
-    "wget -qO /dev/null http://localhost:7474",
-    "Neo4j",
-  );
-}
-
-export async function waitForSandboxQdrant(qdrantContainerId: string): Promise<void> {
-  await pollUntilHealthy(qdrantContainerId, "Qdrant");
 }
 
 // ─── Lifecycle — Seed ─────────────────────────────────────────────────────────
@@ -235,16 +164,18 @@ export async function destroySandboxDbStack(
   buildId: string,
   state: {
     dbContainerId?: string;
+    /** @deprecated BET-5 — ignored; leftover containers still force-removed by name */
     neo4jContainerId?: string;
+    /** @deprecated BET-5 — ignored; leftover containers still force-removed by name */
     qdrantContainerId?: string;
   },
 ): Promise<void> {
-  // Destroy by stored container ID when available, fall back to well-known name.
-  // The app container and network are handled by destroyFullSandboxStack in sandbox.ts.
+  // Always remove Postgres; also force-remove any leftover neo4j/qdrant names
+  // from pre-retirement sandboxes so destroy stays idempotent.
   const targets = [
     state.dbContainerId ?? buildDbContainerName(buildId),
-    state.neo4jContainerId ?? buildNeo4jContainerName(buildId),
-    state.qdrantContainerId ?? buildQdrantContainerName(buildId),
+    state.neo4jContainerId ?? `dpf-sandbox-neo4j-${buildId}`,
+    state.qdrantContainerId ?? `dpf-sandbox-qdrant-${buildId}`,
   ];
 
   await Promise.all(


### PR DESCRIPTION
## Summary
- Sandbox DB stack is **Postgres/pgvector only** (BET-5 residual).
- No more Neo4j/Qdrant containers (~768MB/build) or NEO4J_/QDRANT_ sandbox env.
- Destroy still force-removes leftover neo4j/qdrant names for old sandboxes.
- `stepInitDb` waits only on Postgres.

Resolves **BI-28D31FB7**.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/integrate/sandbox/sandbox-db.test.ts` → 11 passed

Process-Spine-Decision: completes residual BET-5 sandbox surface named in the BI.
Design-Grounding-Decision: reviewed sandbox-db + build-pipeline; localized retire.
Local-CI-Override: vitest sandbox-db 11/11; module-size OK.