### PR TITLE
fix(build-studio): resolve active build when one sandbox-hot phase exists (BI-PIR-9a75015d)

### DIFF
--- a/apps/web/lib/mcp/build-tool-helpers.test.ts
+++ b/apps/web/lib/mcp/build-tool-helpers.test.ts
@@ -5,6 +5,7 @@ const db = vi.hoisted(() => ({
     featureBuild: {
       findUnique: vi.fn(),
       findFirst: vi.fn(),
+      findMany: vi.fn(),
       count: vi.fn(),
       update: vi.fn(),
     },
@@ -31,6 +32,12 @@ describe("build-tool-helpers", () => {
     expect(extractBuildIdHint({ buildId: "nope" })).toBeNull();
     expect(extractBuildIdHint({ buildId: 42 })).toBeNull();
     expect(extractBuildIdHint({})).toBeNull();
+  });
+
+  it("extractBuildIdHint also reads featureBuildId and FB tokens in routeContext (BI-PIR-9a75015d)", () => {
+    expect(extractBuildIdHint({ featureBuildId: "FB-ALT1" })).toBe("FB-ALT1");
+    expect(extractBuildIdHint({ routeContext: "/build/FB-041879CD" })).toBe("FB-041879CD");
+    expect(extractBuildIdHint({ path: "working on FB-DEADBEEF now" })).toBe("FB-DEADBEEF");
   });
 
   it("TERMINAL_BUILD_PHASES excludes terminal builds from active resolution", () => {
@@ -63,10 +70,25 @@ describe("build-tool-helpers", () => {
 
   // BI-F82915D7: refuse to guess when the fallback is ambiguous rather than
   // silently returning the most-recent build (cross-build contamination).
-  it("resolveActiveBuildId refuses (returns null) when the user has >1 non-terminal build and no hint", async () => {
+  it("resolveActiveBuildId refuses (returns null) when many non-terminal builds share sandbox-hot phases", async () => {
     db.prisma.featureBuild.findFirst.mockResolvedValue({ buildId: "FB-A" });
     db.prisma.featureBuild.count.mockResolvedValue(2);
+    db.prisma.featureBuild.findMany.mockResolvedValue([
+      { buildId: "FB-A", phase: "build" },
+      { buildId: "FB-B", phase: "review" },
+    ]);
     expect(await resolveActiveBuildId("u1")).toBeNull();
+  });
+
+  it("resolveActiveBuildId picks the sole sandbox-hot build among drafts (BI-PIR-9a75015d)", async () => {
+    db.prisma.featureBuild.findFirst.mockResolvedValue({ buildId: "FB-STALE" });
+    db.prisma.featureBuild.count.mockResolvedValue(3);
+    db.prisma.featureBuild.findMany.mockResolvedValue([
+      { buildId: "FB-STALE", phase: "ideate" },
+      { buildId: "FB-041879CD", phase: "review" },
+      { buildId: "FB-OTHER", phase: "plan" },
+    ]);
+    expect(await resolveActiveBuildId("u1")).toBe("FB-041879CD");
   });
 
   // Back-compat: a mock without `count` (the common single-build pack test) must

--- a/apps/web/lib/mcp/build-tool-helpers.ts
+++ b/apps/web/lib/mcp/build-tool-helpers.ts
@@ -38,17 +38,41 @@ export function recordAutoIntakeFailure(
  */
 export const TERMINAL_BUILD_PHASES = ["complete", "failed", "abandoned"] as const;
 
+const FB_ID_RE = /\b(FB-[A-Za-z0-9]+)\b/;
+
+function asFbId(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (/^FB-[A-Za-z0-9]+$/.test(trimmed)) return trimmed;
+  const m = trimmed.match(FB_ID_RE);
+  return m ? m[1]! : null;
+}
+
 /**
  * Pull a well-formed `buildId` hint out of a tool's params bag.
- * Returns null when the hint is missing, non-string, or doesn't have the
- * `FB-` prefix that all real FeatureBuild IDs carry.
+ * Accepts `buildId` / `featureBuildId`, and FB-* tokens embedded in
+ * routeContext/strings (BI-PIR-9a75015d — agents often omit explicit buildId
+ * after start_build while still carrying FB-* in route context).
  */
 export function extractBuildIdHint(params: Record<string, unknown>): string | null {
-  const v = params["buildId"];
-  if (typeof v !== "string") return null;
-  const trimmed = v.trim();
-  return trimmed.startsWith("FB-") ? trimmed : null;
+  for (const key of ["buildId", "featureBuildId", "build_id"]) {
+    const v = params[key];
+    if (typeof v === "string") {
+      const id = asFbId(v);
+      if (id) return id;
+    }
+  }
+  for (const key of ["routeContext", "route", "path", "url", "message", "summary"]) {
+    const v = params[key];
+    if (typeof v === "string") {
+      const id = asFbId(v);
+      if (id) return id;
+    }
+  }
+  return null;
 }
+
+/** Phases where sandbox tools are expected to work — prefer these when disambiguating. */
+export const SANDBOX_HOT_PHASES = ["build", "review", "ship"] as const;
 
 /**
  * Resolve the active FeatureBuild for the current user.
@@ -101,13 +125,43 @@ export async function resolveActiveBuildId(
     }
   ).count;
   const nonTerminalCount = countFn ? await countFn({ where }) : 1;
-  if (nonTerminalCount > 1) {
+  if (nonTerminalCount <= 1) return build.buildId;
+
+  // BI-PIR-9a75015d: when multiple non-terminal builds exist, still resolve if
+  // exactly one is in a sandbox-hot phase (build/review/ship). That is the
+  // build after start_build, not a stale ideate draft. If zero or many are hot,
+  // keep refusing (BI-F82915D7 cross-build contamination guard).
+  const findManyFn = (
+    prisma.featureBuild as unknown as {
+      findMany?: (args: {
+        where: typeof where;
+        orderBy: { updatedAt: "desc" };
+        select: { buildId: true; phase: true };
+        take: number;
+      }) => Promise<Array<{ buildId: string; phase: string }>>;
+    }
+  ).findMany;
+  if (!findManyFn) {
     console.warn(
       `[resolveActiveBuildId] ambiguous: user has multiple non-terminal builds and no buildId hint — refusing to guess. Pass an explicit FB-id.`,
     );
     return null;
   }
-  return build.buildId;
+  const candidates = await findManyFn({
+    where,
+    orderBy: { updatedAt: "desc" },
+    select: { buildId: true, phase: true },
+    take: 25,
+  });
+  const hot = candidates.filter((c) =>
+    (SANDBOX_HOT_PHASES as readonly string[]).includes(c.phase),
+  );
+  if (hot.length === 1) return hot[0]!.buildId;
+  console.warn(
+    `[resolveActiveBuildId] ambiguous: user has ${nonTerminalCount} non-terminal builds` +
+      ` (${hot.length} in sandbox-hot phases) and no buildId hint — refusing to guess. Pass an explicit FB-id.`,
+  );
+  return null;
 }
 
 export async function updateBuildHappyPathState(


### PR DESCRIPTION
## Summary
- `extractBuildIdHint` accepts `featureBuildId` and FB-* in `routeContext`/`path`.
- When multiple non-terminal builds exist, resolve if **exactly one** is in build/review/ship (sandbox-hot); otherwise still refuse (BI-F82915D7).

Resolves **BI-PIR-9a75015d**.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/mcp/build-tool-helpers.test.ts` → 9 passed

Process-Spine-Decision: pure helper + unit tests for existing resolve path.
Design-Grounding-Decision: reviewed apps/web/lib/mcp/build-tool-helpers.ts (BI-F82915D7) and sandbox-pack; localized disambiguation.
Local-CI-Override: vitest build-tool-helpers 9/9.