### PR TITLE
fix(demand): fail-soft /ops/demand when estimate columns missing (BI-PIR-1d2d84a3)

### DIFF
--- a/apps/web/lib/demand/demand-data.test.ts
+++ b/apps/web/lib/demand/demand-data.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { mapDemandRows } from "./demand-data";
+
+describe("mapDemandRows", () => {
+  it("maps epic + estimate provenance fields for the demand board", () => {
+    const views = mapDemandRows([
+      {
+        itemId: "BI-1",
+        title: "Thing",
+        status: "open",
+        workType: "feature",
+        demandStage: "screened",
+        demandScore: 1.5,
+        demandScoreFramework: "rice",
+        effortSize: "small",
+        jobSize: null,
+        impact: null,
+        investmentBucket: null,
+        estimateAiJobSize: 2,
+        estimateHumanJobSize: 3,
+        estimateSource: "ai",
+        estimateAgreed: false,
+        claimStatus: null,
+        claimedByAgentId: null,
+        epic: { epicId: "EP-1" },
+      },
+    ]);
+    expect(views).toHaveLength(1);
+    expect(views[0]).toMatchObject({
+      itemId: "BI-1",
+      epicId: "EP-1",
+      estimateAiJobSize: 2,
+      estimateAgreed: false,
+    });
+  });
+});

--- a/apps/web/lib/demand/demand-data.ts
+++ b/apps/web/lib/demand/demand-data.ts
@@ -5,32 +5,31 @@
 import { cache } from "react";
 import { prisma } from "@dpf/db";
 import type { DemandItemView } from "./board";
+import { isPrismaMissingColumnError } from "./prisma-missing-column";
 
-export const getDemandItems = cache(async (): Promise<DemandItemView[]> => {
-  const rows = await prisma.backlogItem.findMany({
-    where: { status: { notIn: ["done", "deferred"] } },
-    orderBy: [{ demandScore: "desc" }, { createdAt: "asc" }],
-    select: {
-      itemId: true,
-      title: true,
-      status: true,
-      workType: true,
-      demandStage: true,
-      demandScore: true,
-      demandScoreFramework: true,
-      effortSize: true,
-      jobSize: true,
-      impact: true,
-      investmentBucket: true,
-      estimateAiJobSize: true,
-      estimateHumanJobSize: true,
-      estimateSource: true,
-      estimateAgreed: true,
-      claimStatus: true,
-      claimedByAgentId: true,
-      epic: { select: { epicId: true } },
-    },
-  });
+type DemandRow = {
+  itemId: string;
+  title: string;
+  status: string;
+  workType: string | null;
+  demandStage: string | null;
+  demandScore: number | null;
+  demandScoreFramework: string | null;
+  effortSize: string | null;
+  jobSize: string | null;
+  impact: string | null;
+  investmentBucket: string | null;
+  estimateAiJobSize: number | null;
+  estimateHumanJobSize: number | null;
+  estimateSource: string | null;
+  estimateAgreed: boolean | null;
+  claimStatus: string | null;
+  claimedByAgentId: string | null;
+  epic: { epicId: string } | null;
+};
+
+/** Pure map from Prisma rows → board view models (unit-tested). */
+export function mapDemandRows(rows: DemandRow[]): DemandItemView[] {
   return rows.map((r) => ({
     itemId: r.itemId,
     title: r.title,
@@ -51,4 +50,45 @@ export const getDemandItems = cache(async (): Promise<DemandItemView[]> => {
     claimStatus: r.claimStatus,
     claimedByAgentId: r.claimedByAgentId,
   }));
+}
+
+export const getDemandItems = cache(async (): Promise<DemandItemView[]> => {
+  try {
+    const rows = await prisma.backlogItem.findMany({
+      where: { status: { notIn: ["done", "deferred"] } },
+      orderBy: [{ demandScore: "desc" }, { createdAt: "asc" }],
+      select: {
+        itemId: true,
+        title: true,
+        status: true,
+        workType: true,
+        demandStage: true,
+        demandScore: true,
+        demandScoreFramework: true,
+        effortSize: true,
+        jobSize: true,
+        impact: true,
+        investmentBucket: true,
+        estimateAiJobSize: true,
+        estimateHumanJobSize: true,
+        estimateSource: true,
+        estimateAgreed: true,
+        claimStatus: true,
+        claimedByAgentId: true,
+        epic: { select: { epicId: true } },
+      },
+    });
+    return mapDemandRows(rows);
+  } catch (err) {
+    // Install lagging the estimate-provenance migration must not 500 the board
+    // (BI-PIR-1d2d84a3). Empty list + log is the fail-soft path until migrate.
+    if (isPrismaMissingColumnError(err)) {
+      console.warn(
+        "[getDemandItems] BacklogItem schema behind migrations (missing estimate columns) — returning empty demand board. Advance via self-upgrade/migrate.",
+        err,
+      );
+      return [];
+    }
+    throw err;
+  }
 });

--- a/apps/web/lib/demand/demand-data.ts
+++ b/apps/web/lib/demand/demand-data.ts
@@ -16,8 +16,8 @@ type DemandRow = {
   demandScore: number | null;
   demandScoreFramework: string | null;
   effortSize: string | null;
-  jobSize: string | null;
-  impact: string | null;
+  jobSize: number | null;
+  impact: number | null;
   investmentBucket: string | null;
   estimateAiJobSize: number | null;
   estimateHumanJobSize: number | null;

--- a/apps/web/lib/demand/prisma-missing-column.test.ts
+++ b/apps/web/lib/demand/prisma-missing-column.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isPrismaMissingColumnError } from "./prisma-missing-column";
+
+describe("isPrismaMissingColumnError (BI-PIR-1d2d84a3)", () => {
+  it("matches Prisma missing-column messages from live /ops/demand crash", () => {
+    const msg =
+      "The column `BacklogItem.estimateAiJobSize` does not exist in the current database.";
+    expect(isPrismaMissingColumnError(new Error(msg))).toBe(true);
+    expect(isPrismaMissingColumnError(msg)).toBe(true);
+  });
+
+  it("rejects unrelated errors", () => {
+    expect(isPrismaMissingColumnError(new Error("Connection refused"))).toBe(false);
+    expect(isPrismaMissingColumnError(null)).toBe(false);
+  });
+});

--- a/apps/web/lib/demand/prisma-missing-column.ts
+++ b/apps/web/lib/demand/prisma-missing-column.ts
@@ -1,0 +1,13 @@
+/**
+ * Detect Prisma "column does not exist" errors so loaders can degrade
+ * instead of crashing the RSC page when the install is behind migrations
+ * (BI-PIR-1d2d84a3 — /ops/demand after estimate provenance columns ship).
+ */
+export function isPrismaMissingColumnError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return (
+    /does not exist in the current database/i.test(msg) ||
+    /column [`"]?[\w.]+[`"]? does not exist/i.test(msg) ||
+    /The column `.+` does not exist/i.test(msg)
+  );
+}


### PR DESCRIPTION
## Summary
- `isPrismaMissingColumnError` detects lagging schema.
- `getDemandItems` returns `[]` (with warn) instead of 500 when `estimateAiJobSize` etc. missing.
- `mapDemandRows` pure map unit-tested.
- `DemandRow.jobSize` / `impact` typed `number | null` to match Prisma + `DemandItemView` (CI Typecheck fix).

Resolves **BI-PIR-1d2d84a3** (and related contributor-preview crash BI-53D7E70C class).

## Test plan
- [x] vitest prisma-missing-column + demand-data → 3 passed (worktree)
- [x] `pnpm --filter web typecheck` green after jobSize/impact number|null align (worktree, NODE_OPTIONS=8g)

Process-Spine-Decision: pure guard + unit tests for shipped loader.
Design-Grounding-Decision: reviewed demand-data.ts + crash digest; fail-soft until migrate.
Seed-Fit-Decision: global-default
Local-CI-Override: vitest demand 3/3 + web typecheck green on worktree; CI Typecheck/Production Build is the merge gate.