### PR TITLE
fix(build-studio): auto-dispatch plan for unblocked decomp children (BI-E49DDE47)

### DIFF
--- a/apps/web/lib/build/approve-decomposition.test.ts
+++ b/apps/web/lib/build/approve-decomposition.test.ts
@@ -10,7 +10,10 @@ import type {
   ApproveDecompositionDb,
   TxShape,
 } from "./approve-decomposition";
-import { approveDecomposition } from "./approve-decomposition";
+import {
+  approveDecomposition,
+  selectUnblockedChildBuildIds,
+} from "./approve-decomposition";
 import type { DecompositionCandidate } from "./decomposition-candidates";
 
 // --- Fake DB harness -------------------------------------------------------
@@ -460,5 +463,98 @@ describe("approveDecomposition — happy path (Dale scenario)", () => {
     expect(writes.activities[0]!.tool).toBe("approveDecomposition");
     const childBuildIds = writes.activities.slice(1).map((a) => a.buildId);
     expect(childBuildIds).toEqual(["FB-CHILD1", "FB-CHILD2", "FB-CHILD3"]);
+  });
+
+  it("returns unblocked head-of-chain children and plan-dispatches only those (BI-E49DDE47)", async () => {
+    const { db } = makeFakeDb(makeBuild());
+    const dispatchPlanForChild = vi.fn(async () => ({ kind: "dispatched-success" }));
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+      dispatchPlanForChild,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    // Dale fixture: child 1 has dependsOn=[], 2 depends on 1, 3 on 1+2
+    expect(result.unblockedChildBuildIds).toEqual(["FB-CHILD1"]);
+    // fire-and-forget — flush microtasks
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dispatchPlanForChild).toHaveBeenCalledTimes(1);
+    expect(dispatchPlanForChild).toHaveBeenCalledWith({
+      buildId: "FB-CHILD1",
+      userId: "user-1",
+    });
+  });
+
+  it("plan-dispatches every child when the partition has no dependency edges", async () => {
+    const { db } = makeFakeDb(makeBuild());
+    const dispatchPlanForChild = vi.fn(async () => ({ kind: "dispatched-success" }));
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: {
+        ...makeCandidate(),
+        childScopes: [
+          {
+            childOrder: 1,
+            title: "Solo-A",
+            summary: "",
+            acceptanceCriteriaIndices: [0, 1],
+            dependsOn: [],
+          },
+          {
+            childOrder: 2,
+            title: "Solo-B",
+            summary: "",
+            acceptanceCriteriaIndices: [2, 3, 4],
+            dependsOn: [],
+          },
+        ],
+      },
+      userId: "user-9",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+      dispatchPlanForChild,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.unblockedChildBuildIds).toEqual(["FB-CHILD1", "FB-CHILD2"]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dispatchPlanForChild).toHaveBeenCalledTimes(2);
+    expect(dispatchPlanForChild).toHaveBeenCalledWith({
+      buildId: "FB-CHILD1",
+      userId: "user-9",
+    });
+    expect(dispatchPlanForChild).toHaveBeenCalledWith({
+      buildId: "FB-CHILD2",
+      userId: "user-9",
+    });
+  });
+});
+
+describe("selectUnblockedChildBuildIds", () => {
+  it("keeps only scopes with empty dependsOn that resolve in the order map", () => {
+    const map = new Map<number, string>([
+      [1, "FB-A"],
+      [2, "FB-B"],
+      [3, "FB-C"],
+    ]);
+    expect(
+      selectUnblockedChildBuildIds(
+        [
+          { childOrder: 1, dependsOn: [] },
+          { childOrder: 2, dependsOn: [1] },
+          { childOrder: 3, dependsOn: [] },
+          { childOrder: 99, dependsOn: [] }, // missing from map
+        ],
+        map,
+      ),
+    ).toEqual(["FB-A", "FB-C"]);
   });
 });

--- a/apps/web/lib/build/approve-decomposition.ts
+++ b/apps/web/lib/build/approve-decomposition.ts
@@ -63,6 +63,15 @@ export type ApproveDecompositionInput = {
   db?: ApproveDecompositionDb;
   /** Test seam: override id generators so tests can assert deterministic ids. */
   idGen?: { epicId: () => string; childBuildId: () => string };
+  /**
+   * Test seam / override: plan dispatch for children that have no unsatisfied
+   * sibling deps (BI-E49DDE47). Default fire-and-forgets
+   * `dispatchPlanForApprovedBuild` so the head-of-chain does not strand in plan.
+   */
+  dispatchPlanForChild?: (params: {
+    buildId: string;
+    userId: string;
+  }) => Promise<unknown>;
 };
 
 export type ApproveDecompositionResult =
@@ -70,12 +79,31 @@ export type ApproveDecompositionResult =
       ok: true;
       epicId: string;
       childBuildIds: string[];
+      /** Children with empty dependsOn — plan_dispatch was (or will be) fired. */
+      unblockedChildBuildIds: string[];
     }
   | {
       ok: false;
       error: string;
       code: ApproveDecompositionErrorCode;
     };
+
+/**
+ * Pure: among newly-created children, which have no sibling dependency edges
+ * and can start plan generation immediately after approve_decomposition.
+ */
+export function selectUnblockedChildBuildIds(
+  childScopes: ReadonlyArray<{ childOrder: number; dependsOn: readonly number[] }>,
+  orderToBuildId: ReadonlyMap<number, string>,
+): string[] {
+  const ids: string[] = [];
+  for (const scope of childScopes) {
+    if (scope.dependsOn.length > 0) continue;
+    const id = orderToBuildId.get(scope.childOrder);
+    if (typeof id === "string" && id.length > 0) ids.push(id);
+  }
+  return ids;
+}
 
 export type ApproveDecompositionErrorCode =
   | "build-not-found"
@@ -400,15 +428,42 @@ export async function approveDecomposition(
       });
     }
 
+    const unblockedChildBuildIds = selectUnblockedChildBuildIds(
+      args.candidate.childScopes,
+      orderToRealBuildId,
+    );
+
     return {
       epicId: createdEpic.epicId,
       childBuildIds: Array.from(orderToRealBuildId.values()),
+      unblockedChildBuildIds,
     };
   });
+
+  // BI-E49DDE47: children land in plan with designDoc copied, but nothing
+  // previously fired plan_dispatch — they sat "gone quiet" forever. Kick
+  // unblocked heads (empty dependsOn) the same way ideate→plan approval does.
+  // Dependency-chained siblings still wait on completion + dependency:ready.
+  if (txResult.unblockedChildBuildIds.length > 0) {
+    const dispatch =
+      args.dispatchPlanForChild ??
+      (async (params: { buildId: string; userId: string }) => {
+        const { dispatchPlanForApprovedBuild } = await import(
+          "@/lib/integrate/plan-on-approval"
+        );
+        return dispatchPlanForApprovedBuild(params);
+      });
+    for (const childBuildId of txResult.unblockedChildBuildIds) {
+      void dispatch({ buildId: childBuildId, userId: args.userId }).catch(() => {
+        // never block approve on plan-dispatch failure; activity log lives inside dispatcher
+      });
+    }
+  }
 
   return {
     ok: true,
     epicId: txResult.epicId,
     childBuildIds: txResult.childBuildIds,
+    unblockedChildBuildIds: txResult.unblockedChildBuildIds,
   };
 }


### PR DESCRIPTION
## Summary
- After `approve_decomposition` creates child builds in `plan`, fire `dispatchPlanForApprovedBuild` for **unblocked** children (empty `dependsOn`).
- Pure helper `selectUnblockedChildBuildIds` unit-tested; injectable dispatch seam for tests.
- Dependency-chained siblings still wait on upstream completion (`dependency:ready`); this unblocks the head-of-chain that was stranding forever.

Resolves **BI-E49DDE47**.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/build/approve-decomposition.test.ts` → 19 passed (worktree)

Process-Spine-Decision: pure helper + unit tests against shipped approveDecomposition; no new route.
Design-Grounding-Decision: grounded in approve-decomposition.ts + plan-on-approval.ts + feature-build-dependencies ready dependents; matches ideate→plan auto-dispatch pattern.
Local-CI-Override: approve-decomposition 19/19 on worktree; CI Typecheck/Unit Tests are merge gates.