### PR TITLE
feat(decision): corpus-free work-warrant altitude classifier (EP-7B169558)

### DIFF
--- a/apps/web/lib/decision/work-warrant-altitude.test.ts
+++ b/apps/web/lib/decision/work-warrant-altitude.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { classifyAltitude, type AltitudeSignals } from "./work-warrant-altitude";
+
+// Every test runs with ZERO corpus — the whole point of the structure-first
+// classifier is that it is fully decisive from day-one structural signals.
+
+describe("classifyAltitude — WWMD-hard (architectural, must be right on day one)", () => {
+  it("classifies decompose-required design as WWMD, high, no confirm", () => {
+    const v = classifyAltitude({ designSize: "decompose-required", effortSize: "large" });
+    expect(v.altitude).toBe("WWMD");
+    expect(v.confidence).toBe("high");
+    expect(v.basis).toBe("structural");
+    expect(v.needsOperatorConfirm).toBe(false);
+  });
+
+  it("classifies xlarge effort as WWMD", () => {
+    expect(classifyAltitude({ effortSize: "xlarge", workType: "feature" }).altitude).toBe("WWMD");
+  });
+
+  it("classifies a schema/migration touch as WWMD even at small effort", () => {
+    const v = classifyAltitude({ effortSize: "small", workType: "feature", touchesSchema: true, singleLeafSurface: true });
+    expect(v.altitude).toBe("WWMD");
+    expect(v.reasons.join(" ")).toContain("schema");
+  });
+
+  it("classifies routing / core-contract touches as WWMD", () => {
+    expect(classifyAltitude({ effortSize: "medium", touchesRouting: true }).altitude).toBe("WWMD");
+    expect(classifyAltitude({ effortSize: "medium", touchesCoreContract: true }).altitude).toBe("WWMD");
+  });
+
+  it("treats a large refactor as architectural WWMD", () => {
+    expect(classifyAltitude({ workType: "refactor", effortSize: "large" }).altitude).toBe("WWMD");
+  });
+});
+
+describe("classifyAltitude — WSID-hard (task, cheap if slightly wrong)", () => {
+  it("classifies a small single-surface feature as WSID, high, no confirm", () => {
+    // The FB-041879CD (engine badge) shape: small, functional, one leaf surface.
+    const v = classifyAltitude({
+      effortSize: "small",
+      workType: "feature",
+      singleLeafSurface: true,
+      touchesSchema: false,
+      touchesRouting: false,
+      touchesCoreContract: false,
+    });
+    expect(v.altitude).toBe("WSID");
+    expect(v.confidence).toBe("high");
+    expect(v.needsOperatorConfirm).toBe(false);
+  });
+
+  it("does NOT drop to WSID when a small item touches a core contract", () => {
+    const v = classifyAltitude({ effortSize: "small", workType: "feature", singleLeafSurface: true, touchesCoreContract: true });
+    expect(v.altitude).toBe("WWMD");
+  });
+
+  it("does NOT WSID a small item that lacks single-leaf confinement (ambiguous → confirm)", () => {
+    const v = classifyAltitude({ effortSize: "small", workType: "feature", singleLeafSurface: false });
+    expect(v.altitude).not.toBe("WSID");
+    expect(v.needsOperatorConfirm).toBe(true);
+  });
+});
+
+describe("classifyAltitude — WWWD (business/vertical, corpus thin → confirm + seed)", () => {
+  it("classifies a vertical/jurisdiction obligation as WWWD, medium, confirm", () => {
+    const v = classifyAltitude({ effortSize: "medium", workType: "feature", archetypeObligation: true });
+    expect(v.altitude).toBe("WWWD");
+    expect(v.confidence).toBe("medium");
+    expect(v.needsOperatorConfirm).toBe(true); // the confirmation seeds the WWWD corpus
+  });
+
+  it("classifies a customer/business capability surface as WWWD", () => {
+    expect(classifyAltitude({ effortSize: "small", workType: "feature", customerBusinessSurface: true }).altitude).toBe("WWWD");
+  });
+});
+
+describe("classifyAltitude — ambiguous defaults to the safer higher altitude + confirm", () => {
+  it("leans WWMD for large/medium ambiguous work", () => {
+    const v = classifyAltitude({ effortSize: "large", workType: "chore" });
+    expect(v.altitude).toBe("WWMD");
+    expect(v.confidence).toBe("low");
+    expect(v.needsOperatorConfirm).toBe(true);
+  });
+
+  it("sits at WWWD (never silent WSID) for small/unknown ambiguous work", () => {
+    const v = classifyAltitude({ workType: "chore" });
+    expect(v.altitude).toBe("WWWD");
+    expect(v.needsOperatorConfirm).toBe(true);
+  });
+
+  it("is fully decisive with an empty signal set (no corpus, no fields) — never throws, always confirms", () => {
+    const v = classifyAltitude({});
+    expect(["WSID", "WWWD", "WWMD"]).toContain(v.altitude);
+    expect(v.basis).toBe("structural");
+    expect(v.needsOperatorConfirm).toBe(true);
+  });
+});
+
+describe("classifyAltitude — determinism (same signals → same verdict, corpus-free)", () => {
+  it("is a pure function", () => {
+    const s: AltitudeSignals = { effortSize: "small", workType: "bug", singleLeafSurface: true };
+    expect(classifyAltitude(s)).toEqual(classifyAltitude(s));
+  });
+});

--- a/apps/web/lib/decision/work-warrant-altitude.ts
+++ b/apps/web/lib/decision/work-warrant-altitude.ts
@@ -1,0 +1,154 @@
+// Work-warrant altitude classifier (EP-7B169558 / BI-8AB0E66D).
+//
+// Classifies a unit of work into a DECISION ALTITUDE — WSID (task/job),
+// WWWD (business/org, industry-vertical), or WWMD (architectural/platform) —
+// which the WorkWarrant then uses to meter execution (lane, token/model budget,
+// evidence depth, reporting format, context scope).
+//
+// COLD-START (the load-bearing property, kernel-ratified structure-first,
+// composite 0.874, "Architecture Over Shortcuts" top contributor):
+// this function classifies from DETERMINISTIC, DAY-ONE STRUCTURAL signals only —
+// it needs NO established WWWD/WSID corpus to run. The corpus is a later OVERLAY
+// (applied by the caller, flipping `basis` to "corpus") and an operator override
+// (`basis` "operator"); every verdict + its outcome is meant to SEED that corpus
+// so it sharpens from operation. The asymmetry that makes this safe:
+//   - WWMD (expensive to mis-classify) is covered here by hard structural rules,
+//     because its corpus (principle dimensions, AGENTS.md, golden decisions) is
+//     already established — so the must-be-right end is right on a fresh install.
+//   - WSID (cheap to mis-classify) rides structural defaults.
+//   - Only the thin WWWD middle defers to operator-confirm — and each
+//     confirmation is a corpus seed, not a blocker.
+//
+// This module is intentionally pure and dependency-free so it is fully
+// unit-testable WITHOUT any corpus, DB, or model — which is exactly why it is
+// the right first artifact for the control plane.
+
+export type Altitude = "WSID" | "WWWD" | "WWMD";
+
+/** Provenance of the classification — lets an auditor see the classifier shift
+ *  from structural → corpus-driven as the org matures, and never trust corpus it
+ *  does not have. */
+export type AltitudeBasis = "structural" | "corpus" | "operator";
+
+export type AltitudeConfidence = "high" | "medium" | "low";
+
+export type EffortSize = "small" | "medium" | "large" | "xlarge";
+
+/** Deterministic structural signals, all present at promote/triage on day one. */
+export interface AltitudeSignals {
+  /** BacklogItem.effortSize. */
+  effortSize?: EffortSize | null;
+  /** BacklogItem.workType (feature | bug | chore | doc | tool | skill | refactor). */
+  workType?: string | null;
+  /** Design-size assessment outcome, when a design doc has been sized. */
+  designSize?: "ok" | "decompose-recommended" | "decompose-required" | null;
+  /** Touches Prisma schema / migrations. */
+  touchesSchema?: boolean;
+  /** Touches routing / core dispatch / inference-routing. */
+  touchesRouting?: boolean;
+  /** Touches a cross-cutting platform contract (auth, governance, kernel, MCP surface). */
+  touchesCoreContract?: boolean;
+  /** An archetype/jurisdiction obligation gate matched (a vertical/location duty). */
+  archetypeObligation?: boolean;
+  /** A customer/business capability surface (not a platform-internal surface). */
+  customerBusinessSurface?: boolean;
+  /** Confined to a single leaf surface (one component/util), no cross-cutting reach. */
+  singleLeafSurface?: boolean;
+}
+
+export interface AltitudeVerdict {
+  altitude: Altitude;
+  basis: AltitudeBasis;
+  confidence: AltitudeConfidence;
+  /** True when the classification should be confirmed by the operator before the
+   *  warrant hardens — always true for the corpus-thin WWWD middle and for
+   *  low-confidence ambiguous cases. The confirmation seeds the corpus. */
+  needsOperatorConfirm: boolean;
+  /** Human-readable structural reasons, for the ledger + reporting. */
+  reasons: string[];
+}
+
+const TASK_WORKTYPES = new Set(["feature", "bug", "doc", "chore"]);
+
+/** workType values that are architectural by nature regardless of size. */
+const ARCHITECTURAL_WORKTYPES = new Set(["refactor", "tool", "skill"]);
+
+/**
+ * Classify work altitude from structural signals alone. Deterministic and
+ * corpus-free: same signals in → same verdict out. Rules are ordered; the first
+ * decisive rule wins, then softer rules and the ambiguous fallback apply.
+ */
+export function classifyAltitude(s: AltitudeSignals): AltitudeVerdict {
+  const reasons: string[] = [];
+
+  // ── Rule 1: WWMD-hard (architectural). Must be right on day one; covered here
+  //    because these are unambiguous structural markers of platform-altitude work. ──
+  const wwmdMarkers: string[] = [];
+  if (s.designSize === "decompose-required") wwmdMarkers.push("design sized decompose-required");
+  if (s.effortSize === "xlarge") wwmdMarkers.push("effort xlarge");
+  if (s.touchesSchema) wwmdMarkers.push("touches schema/migrations");
+  if (s.touchesRouting) wwmdMarkers.push("touches routing/core dispatch");
+  if (s.touchesCoreContract) wwmdMarkers.push("touches a cross-cutting platform contract");
+  if (s.workType && ARCHITECTURAL_WORKTYPES.has(s.workType) && (s.effortSize === "large" || s.effortSize === "xlarge")) {
+    wwmdMarkers.push(`architectural workType '${s.workType}' at ${s.effortSize} effort`);
+  }
+  if (wwmdMarkers.length > 0) {
+    return {
+      altitude: "WWMD",
+      basis: "structural",
+      confidence: "high",
+      needsOperatorConfirm: false,
+      reasons: wwmdMarkers,
+    };
+  }
+
+  // ── Rule 2: WSID-hard (task/job). Cheap if slightly wrong; structural defaults. ──
+  const isTaskType = s.workType != null && TASK_WORKTYPES.has(s.workType);
+  const noCrossCutting = !s.touchesSchema && !s.touchesRouting && !s.touchesCoreContract;
+  if (
+    s.effortSize === "small" &&
+    isTaskType &&
+    noCrossCutting &&
+    s.singleLeafSurface === true &&
+    !s.archetypeObligation &&
+    !s.customerBusinessSurface
+  ) {
+    return {
+      altitude: "WSID",
+      basis: "structural",
+      confidence: "high",
+      needsOperatorConfirm: false,
+      reasons: [`small ${s.workType} confined to a single leaf surface, no cross-cutting reach`],
+    };
+  }
+
+  // ── Rule 3: WWWD (business/vertical). Corpus is thin initially → medium
+  //    confidence + operator-confirm; each confirmation seeds the WWWD corpus. ──
+  if (s.archetypeObligation || s.customerBusinessSurface) {
+    if (s.archetypeObligation) reasons.push("carries a vertical/jurisdiction obligation");
+    if (s.customerBusinessSurface) reasons.push("customer/business capability surface");
+    return {
+      altitude: "WWWD",
+      basis: "structural",
+      confidence: "medium",
+      needsOperatorConfirm: true,
+      reasons,
+    };
+  }
+
+  // ── Rule 4: Ambiguous — weak/conflicting signals. Default to the SAFER higher
+  //    altitude (never silently WSID a thing we are unsure about) + confirm. ──
+  //    Large/medium ambiguous work leans WWMD (governed-interactive is the safe
+  //    lane for bigger unknowns); small/unknown ambiguous work sits at WWWD so it
+  //    still gets a human confirm and seeds the corpus rather than auto-running. ──
+  const leansLarge = s.effortSize === "large" || s.effortSize === "medium";
+  return {
+    altitude: leansLarge ? "WWMD" : "WWWD",
+    basis: "structural",
+    confidence: "low",
+    needsOperatorConfirm: true,
+    reasons: [
+      `ambiguous structural signals${s.effortSize ? ` at ${s.effortSize} effort` : ""} — defaulting to the safer higher altitude pending operator confirmation`,
+    ],
+  };
+}

--- a/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
+++ b/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
@@ -1,0 +1,86 @@
+# Work Warrant — decision-altitude control plane
+
+**Epic:** EP-7B169558 · **Anchor BI:** BI-8AB0E66D
+**Backlogged siblings:** BI-0A6B8B38 (per-phase token/cost metering), BI-EE211BFA (WWWD org-stance → evidence/reporting/AC-groups)
+
+## Problem
+
+The decision-governance ladder (WSID task · WWWD business · WWMD architectural) and
+the shared execution substrate (the one sandbox) are **disconnected**: a decision's
+altitude and its company/industry/location context don't flow down to change how
+execution spends tokens, gathers evidence, or reports. So Build Studio applies
+**uniform maximal rigor and unmetered spend to every job** — a 4-file badge and an
+xlarge cross-channel report both run the same ideate→plan→(2 reviews)→build machinery,
+and both record `cost=null`. Observed 2026-07-16: `BuildPhaseRun` token/cost were
+0/null across all builds; completed builds ran identical phase sets regardless of size.
+
+## Design: the Work Warrant
+
+A `WorkWarrant`, computed once at promote/triage and read by every downstream consumer:
+
+```
+WorkWarrant {
+  altitude:         WSID | WWWD | WWMD
+  altitudeBasis:    structural | corpus | operator   // provenance
+  confidence:       high | medium | low
+  lane:             autonomous-bs | governed-interactive | direct-expert
+  budget:           { tokenCeiling, modelTier, effortLevel, gateProfile }
+  evidenceProfile:  minimal | standard | compliance | architectural
+  reportingProfile: one-line | business | ledger
+  contextScope:     { industry, jurisdiction, archetype }
+}
+```
+
+Consumers: funnel admission/prioritization, lane router (governed-interactive runs on
+the **same** sandbox — no proliferation), effort binder (activates the dormant
+EP-27FD96BC knobs from `budget`), evidence collector (`evidenceProfile`), reporter
+(`reportingProfile`).
+
+## Cold-start: structure-first (kernel-ratified)
+
+The hard constraint (operator): altitude must classify when the WWWD/WSID corpus is
+**not yet established** on a fresh install. Routed through `principle_decide`
+(WWMD-altitude platform decision):
+
+- **Recommendation: `structure-first`** — composite **0.874**, margin **0.78**,
+  confidence **high**; top positive contributor **Architecture Over Shortcuts**
+  (read `corpus-required` / `operator-labeled` as shortcuts that defer the design and
+  incur rework); governing profile: organization; no commandment conflict.
+
+The classifier (`apps/web/lib/decision/work-warrant-altitude.ts`, this PR) is a pure,
+corpus-free function over day-one structural signals. It works because of the ladder's
+asymmetry:
+
+- **WWMD** (expensive to mis-classify) — hard structural rules (decompose-required,
+  xlarge, schema/routing/core-contract touch). Its corpus is *already* established
+  (principle dimensions, AGENTS.md, golden decisions), so the must-be-right end is
+  right on day one.
+- **WSID** (cheap if wrong) — structural defaults (small + single-leaf + no cross-cutting).
+- **WWWD** (thin corpus) — defers to `needsOperatorConfirm`; each confirmation **seeds**
+  the corpus, so it sharpens from operation rather than blocking on it.
+- **Ambiguous** — never silently WSID; defaults to the safer higher altitude + confirm.
+
+`altitudeBasis` records provenance (structural → corpus → operator), so an auditor can
+watch the classifier shift from structural to corpus-driven as the org matures and
+never trust corpus it doesn't have.
+
+## Phasing
+
+1. **This PR** — corpus-free `classifyAltitude` core + unit tests (no DB/model/corpus).
+   The de-risking artifact: proves the cold-start classification is decisive with zero corpus.
+2. **BI-8AB0E66D cont.** — the `WorkWarrant` object + wiring into promote/triage;
+   consumers read it (lane, budget→effort knobs, gate profile).
+3. **BI-0A6B8B38** — populate `BuildPhaseRun` token/cost so `budget.tokenCeiling` is
+   enforceable (until then it is advisory).
+4. **BI-EE211BFA** — WWWD org stance parameterizes evidence/reporting/decomposition
+   AC-groups by industry + jurisdiction (extends the compliance-archetype pattern).
+
+## Reuse (migration, not green-field)
+
+Right-sizing matrix (`build-process-matrix.ts`), decision tables
+(`DecisionShadowLedger`/`DecisionPerspectiveProfile`), dormant effort-warrant knobs
+(EP-27FD96BC), archetype scoping (compliance). The warrant is the control object that
+ties them to a single altitude signal.
+
+Process-Spine-Decision: altitude-classifier approach ratified via principle_decide
+(structure-first, composite 0.874, high confidence) — see above.


### PR DESCRIPTION
First artifact of the **decision-altitude control plane** (EP-7B169558) — the keystone that lets the WWMD/WWWD/WSID decision ladder *meter execution* (lane, token/model budget, evidence depth, reporting format, company/industry/location context) instead of Build Studio applying uniform maximal rigor and unmetered spend to every job.

## What this PR lands
A pure, deterministic `classifyAltitude()` (`apps/web/lib/decision/work-warrant-altitude.ts`) that sorts work into **WSID** (task) · **WWWD** (business) · **WWMD** (architectural) from **day-one structural signals** — `effortSize`, `workType`, design-size, schema/routing/core-contract touch, archetype obligation. No DB, no model, **no corpus**.

## The cold-start problem it solves (kernel-ratified)
The hard constraint: altitude must classify when the WWWD/WSID corpus **isn't established yet** on a fresh install. Routed through `principle_decide` (a WWMD-altitude platform decision):

> **Recommendation `structure-first` — composite 0.874, margin 0.78, confidence high**, top contributor *Architecture Over Shortcuts*, governing profile *organization*, no commandment conflict.

It works because of the ladder's asymmetry:
- **WWMD** (expensive to mis-classify) → hard structural rules; its corpus (principle dimensions, AGENTS.md, golden decisions) is *already* established, so the must-be-right end is right on day one.
- **WSID** (cheap if wrong) → structural defaults.
- **WWWD** (thin corpus) → `needsOperatorConfirm`; each confirmation **seeds** the corpus, so it sharpens from operation rather than blocking on it.
- **Ambiguous** → never silent-WSID; defaults to the safer higher altitude + confirm.

`altitudeBasis` (`structural | corpus | operator`) records provenance so the classifier can be audited as it shifts from structural → corpus-driven, and never trusts corpus it doesn't have.

## Verification
Pure + dependency-free → **14 corpus-free unit tests** (WWMD-hard, WSID-hard, WWWD-confirm, ambiguous-safer-default, empty-signal decisiveness, determinism). All green.

## Scope / follow-ons
This is the de-risking core only. The `WorkWarrant` object + promote-time wiring is BI-8AB0E66D; token metering (makes `budget.tokenCeiling` enforceable) is BI-0A6B8B38; WWWD-context → evidence/reporting/AC-groups is BI-EE211BFA. Plan: `docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)