### PR TITLE
feat(decision): WorkWarrant deriveWarrant mapping — altitude + blast-radius + context → rigor (BI-8AB0E66D)

### DIFF
--- a/apps/web/lib/decision/work-warrant.test.ts
+++ b/apps/web/lib/decision/work-warrant.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { classifyAltitude } from "./work-warrant-altitude";
+import { deriveWarrant, type BlastRadius } from "./work-warrant";
+
+// All corpus-free: altitude verdict in → warrant out, deterministic.
+
+describe("deriveWarrant — altitude base mapping", () => {
+  it("WSID → autonomous, cheap, collapsed gates, minimal evidence, one-line report", () => {
+    const verdict = classifyAltitude({ effortSize: "small", workType: "feature", singleLeafSurface: true });
+    const w = deriveWarrant({ verdict });
+    expect(w.altitude).toBe("WSID");
+    expect(w.lane).toBe("autonomous-bs");
+    expect(w.budget.modelTier).toBe("economical");
+    expect(w.budget.gateProfile).toBe("collapsed");
+    expect(w.evidenceProfile).toBe("minimal");
+    expect(w.reportingProfile).toBe("one-line");
+  });
+
+  it("WWMD → governed-interactive, strong, full gates, architectural evidence, ledger report", () => {
+    const verdict = classifyAltitude({ effortSize: "xlarge" });
+    const w = deriveWarrant({ verdict });
+    expect(w.altitude).toBe("WWMD");
+    expect(w.lane).toBe("governed-interactive");
+    expect(w.budget.modelTier).toBe("strong");
+    expect(w.budget.gateProfile).toBe("full");
+    expect(w.evidenceProfile).toBe("architectural");
+    expect(w.reportingProfile).toBe("ledger");
+  });
+
+  it("WWWD → governed-interactive, standard, business report", () => {
+    const verdict = classifyAltitude({ effortSize: "medium", customerBusinessSurface: true });
+    const w = deriveWarrant({ verdict });
+    expect(w.altitude).toBe("WWWD");
+    expect(w.reportingProfile).toBe("business");
+    expect(w.budget.gateProfile).toBe("standard");
+  });
+});
+
+describe("deriveWarrant — blast-radius overlay only ESCALATES (monotonic)", () => {
+  const wsid = () => classifyAltitude({ effortSize: "small", workType: "feature", singleLeafSurface: true });
+
+  it("a small WSID change with a large blast radius is pulled off the autonomous lane + confirmed", () => {
+    const blastRadius: BlastRadius = { downstreamCount: 40, touchesCoreContract: true, riskLevel: "high" };
+    const w = deriveWarrant({ verdict: wsid(), blastRadius });
+    expect(w.altitude).toBe("WSID"); // altitude unchanged...
+    expect(w.lane).toBe("governed-interactive"); // ...but lane escalated
+    expect(w.evidenceProfile).toBe("architectural");
+    expect(w.needsOperatorConfirm).toBe(true); // escalation contradicts altitude → confirm
+  });
+
+  it("moderate blast radius bumps evidence to standard but keeps the lane", () => {
+    const blastRadius: BlastRadius = { downstreamCount: 10, touchesCoreContract: false, riskLevel: "medium" };
+    const w = deriveWarrant({ verdict: wsid(), blastRadius });
+    expect(w.lane).toBe("autonomous-bs");
+    expect(w.evidenceProfile).toBe("standard");
+  });
+
+  it("low blast radius leaves a WSID warrant fully hands-off", () => {
+    const blastRadius: BlastRadius = { downstreamCount: 1, touchesCoreContract: false, riskLevel: "low" };
+    const w = deriveWarrant({ verdict: wsid(), blastRadius });
+    expect(w.lane).toBe("autonomous-bs");
+    expect(w.evidenceProfile).toBe("minimal");
+  });
+
+  it("never RELAXES a WWMD warrant even with a tiny blast radius", () => {
+    const verdict = classifyAltitude({ effortSize: "xlarge" });
+    const w = deriveWarrant({ verdict, blastRadius: { downstreamCount: 0, touchesCoreContract: false, riskLevel: "low" } });
+    expect(w.evidenceProfile).toBe("architectural");
+    expect(w.lane).toBe("governed-interactive");
+  });
+});
+
+describe("deriveWarrant — WWWD context overlay (industry/jurisdiction)", () => {
+  it("a jurisdiction obligation raises evidence to compliance and carries context scope", () => {
+    const verdict = classifyAltitude({ effortSize: "medium", archetypeObligation: true });
+    const w = deriveWarrant({
+      verdict,
+      context: { industry: "healthcare", jurisdiction: "US-CA", archetype: "clinical" },
+    });
+    expect(w.evidenceProfile).toBe("compliance");
+    expect(w.contextScope).toEqual({ industry: "healthcare", jurisdiction: "US-CA", archetype: "clinical" });
+  });
+
+  it("no context leaves evidence at the altitude default and scope null", () => {
+    const verdict = classifyAltitude({ effortSize: "small", workType: "feature", singleLeafSurface: true });
+    const w = deriveWarrant({ verdict });
+    expect(w.evidenceProfile).toBe("minimal");
+    expect(w.contextScope).toEqual({ industry: null, jurisdiction: null, archetype: null });
+  });
+});
+
+describe("deriveWarrant — determinism", () => {
+  it("is pure", () => {
+    const verdict = classifyAltitude({ effortSize: "medium", customerBusinessSurface: true });
+    expect(deriveWarrant({ verdict })).toEqual(deriveWarrant({ verdict }));
+  });
+});

--- a/apps/web/lib/decision/work-warrant.ts
+++ b/apps/web/lib/decision/work-warrant.ts
@@ -1,0 +1,181 @@
+// Work Warrant — the control object of the decision-altitude control plane
+// (EP-7B169558 / BI-8AB0E66D). `deriveWarrant` is where the two rigor-ends meet:
+// the DECISION end (altitude, from classifyAltitude at promote-time) and the
+// DIFF end (blast radius, from change-impact.ts / EP-QUALITY-RIGHTSIZING). It
+// maps altitude + blast-radius + org context into the five knobs every
+// downstream consumer reads — lane, budget, evidence depth, reporting format,
+// context scope — so execution stops applying uniform maximal rigor to every job.
+//
+// Pure and dependency-free (over its own types + the AltitudeVerdict) → fully
+// unit-testable with no DB/model/corpus, same as the classifier it consumes.
+
+import type { Altitude, AltitudeBasis, AltitudeConfidence, AltitudeVerdict } from "./work-warrant-altitude";
+
+export type Lane = "autonomous-bs" | "governed-interactive" | "direct-expert";
+export type ModelTier = "economical" | "standard" | "strong";
+export type EffortLevel = "low" | "medium" | "high";
+export type GateProfile = "collapsed" | "standard" | "full";
+export type EvidenceProfile = "minimal" | "standard" | "compliance" | "architectural";
+export type ReportingProfile = "one-line" | "business" | "ledger";
+export type RiskLevel = "low" | "medium" | "high" | "critical";
+
+/** Graded blast-radius signal — derived from the code graph + EA diagrams a-priori
+ *  (promote) and confirmed from the diff a-posteriori (verify). See BI-22250BA2.
+ *  Optional: the warrant is derivable from altitude alone before blast radius is
+ *  known; blast radius, when present, can only ESCALATE rigor, never relax it. */
+export interface BlastRadius {
+  downstreamCount: number;
+  touchesCoreContract: boolean;
+  riskLevel: RiskLevel;
+}
+
+/** Company/industry/location context from the WWWD org stance (BI-EE211BFA). */
+export interface WarrantContext {
+  industry?: string | null;
+  jurisdiction?: string | null;
+  archetype?: string | null;
+}
+
+export interface WorkWarrant {
+  altitude: Altitude;
+  altitudeBasis: AltitudeBasis;
+  confidence: AltitudeConfidence;
+  needsOperatorConfirm: boolean;
+  lane: Lane;
+  budget: {
+    modelTier: ModelTier;
+    effortLevel: EffortLevel;
+    gateProfile: GateProfile;
+    /** Advisory until per-phase metering lands (BI-0A6B8B38); null = unmetered. */
+    tokenCeiling: number | null;
+  };
+  evidenceProfile: EvidenceProfile;
+  reportingProfile: ReportingProfile;
+  contextScope: WarrantContext;
+  /** Human-readable derivation trail for the ledger + reporting. */
+  reasons: string[];
+}
+
+interface AltitudeDefaults {
+  lane: Lane;
+  modelTier: ModelTier;
+  effortLevel: EffortLevel;
+  gateProfile: GateProfile;
+  evidenceProfile: EvidenceProfile;
+  reportingProfile: ReportingProfile;
+}
+
+// Base mapping by altitude. Low altitude = cheap + hands-off; high = strong +
+// governed. The whole point of the plane: a WSID task must NOT pay WWMD rigor.
+const ALTITUDE_DEFAULTS: Record<Altitude, AltitudeDefaults> = {
+  WSID: {
+    lane: "autonomous-bs",
+    modelTier: "economical",
+    effortLevel: "low",
+    gateProfile: "collapsed",
+    evidenceProfile: "minimal",
+    reportingProfile: "one-line",
+  },
+  WWWD: {
+    lane: "governed-interactive",
+    modelTier: "standard",
+    effortLevel: "medium",
+    gateProfile: "standard",
+    evidenceProfile: "standard",
+    reportingProfile: "business",
+  },
+  WWMD: {
+    lane: "governed-interactive",
+    modelTier: "strong",
+    effortLevel: "high",
+    gateProfile: "full",
+    evidenceProfile: "architectural",
+    reportingProfile: "ledger",
+  },
+};
+
+const EVIDENCE_RANK: EvidenceProfile[] = ["minimal", "standard", "compliance", "architectural"];
+const LANE_RANK: Lane[] = ["autonomous-bs", "governed-interactive", "direct-expert"];
+
+function maxEvidence(a: EvidenceProfile, b: EvidenceProfile): EvidenceProfile {
+  return EVIDENCE_RANK.indexOf(a) >= EVIDENCE_RANK.indexOf(b) ? a : b;
+}
+function maxLane(a: Lane, b: Lane): Lane {
+  return LANE_RANK.indexOf(a) >= LANE_RANK.indexOf(b) ? a : b;
+}
+
+/**
+ * Derive a WorkWarrant from the altitude verdict, optional blast radius, and
+ * optional org context. Blast radius and context can only ESCALATE rigor
+ * (monotonic) — a warrant is safe to compute from altitude alone and only
+ * hardens as more signal arrives.
+ */
+export function deriveWarrant(input: {
+  verdict: AltitudeVerdict;
+  blastRadius?: BlastRadius;
+  context?: WarrantContext;
+}): WorkWarrant {
+  const { verdict, blastRadius, context } = input;
+  const base = ALTITUDE_DEFAULTS[verdict.altitude];
+  const reasons: string[] = [`altitude ${verdict.altitude} (${verdict.basis}, ${verdict.confidence})`];
+
+  let lane = base.lane;
+  let evidenceProfile = base.evidenceProfile;
+  let needsOperatorConfirm = verdict.needsOperatorConfirm;
+
+  // ── Blast-radius overlay (risk = what could break). A nominally-small change
+  //    with a large blast radius must NOT run autonomously with minimal evidence. ──
+  if (blastRadius) {
+    const highRisk =
+      blastRadius.touchesCoreContract ||
+      blastRadius.riskLevel === "high" ||
+      blastRadius.riskLevel === "critical" ||
+      blastRadius.downstreamCount >= 25;
+    const moderate = blastRadius.riskLevel === "medium" || blastRadius.downstreamCount >= 8;
+
+    if (highRisk) {
+      lane = maxLane(lane, "governed-interactive");
+      evidenceProfile = maxEvidence(evidenceProfile, "architectural");
+      reasons.push(
+        `blast-radius escalation: ${blastRadius.touchesCoreContract ? "touches a core contract; " : ""}risk ${blastRadius.riskLevel}, ${blastRadius.downstreamCount} downstream`,
+      );
+      // If the altitude was low but blast radius says otherwise, confirm the escalation.
+      if (verdict.altitude === "WSID") needsOperatorConfirm = true;
+    } else if (moderate) {
+      evidenceProfile = maxEvidence(evidenceProfile, "standard");
+      reasons.push(`moderate blast radius (risk ${blastRadius.riskLevel}, ${blastRadius.downstreamCount} downstream)`);
+    }
+  }
+
+  // ── Context overlay: a vertical/jurisdiction obligation raises evidence to
+  //    compliance (unless already architectural). Company/industry/location
+  //    scope rides along for the evidence collector + reporter (BI-EE211BFA). ──
+  if (context && (context.jurisdiction || context.archetype)) {
+    evidenceProfile = maxEvidence(evidenceProfile, "compliance");
+    reasons.push(
+      `context: ${[context.industry, context.jurisdiction, context.archetype].filter(Boolean).join(" / ")} → compliance evidence`,
+    );
+  }
+
+  return {
+    altitude: verdict.altitude,
+    altitudeBasis: verdict.basis,
+    confidence: verdict.confidence,
+    needsOperatorConfirm,
+    lane,
+    budget: {
+      modelTier: base.modelTier,
+      effortLevel: base.effortLevel,
+      gateProfile: base.gateProfile,
+      tokenCeiling: null, // advisory until metering lands (BI-0A6B8B38)
+    },
+    evidenceProfile,
+    reportingProfile: base.reportingProfile,
+    contextScope: {
+      industry: context?.industry ?? null,
+      jurisdiction: context?.jurisdiction ?? null,
+      archetype: context?.archetype ?? null,
+    },
+    reasons,
+  };
+}

--- a/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
+++ b/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
@@ -75,6 +75,27 @@ never trust corpus it doesn't have.
 4. **BI-EE211BFA** — WWWD org stance parameterizes evidence/reporting/decomposition
    AC-groups by industry + jurisdiction (extends the compliance-archetype pattern).
 
+## Update — `deriveWarrant` mapping core landed (Phase 2 partial)
+
+`apps/web/lib/decision/work-warrant.ts`: the pure `deriveWarrant(verdict, blastRadius?, context?)`
+→ `WorkWarrant` mapping — where the decision-end (altitude) and diff-end (blast radius)
+meet. Design decisions baked in:
+
+- **Altitude base map:** WSID → autonomous-bs / economical / collapsed gates / minimal
+  evidence / one-line; WWWD → governed-interactive / standard / business; WWMD →
+  governed-interactive / strong / full gates / architectural / ledger.
+- **Blast radius only ESCALATES (monotonic).** A warrant is safe to compute from
+  altitude alone; blast radius (a-priori from code-graph+EA, a-posteriori from the diff
+  — BI-22250BA2) can raise lane/evidence but never relax them. A small WSID change with
+  a large blast radius is pulled off the autonomous lane + flagged for confirm; a tiny
+  blast radius never softens a WWMD warrant. This is the "risk = what could break"
+  override, and it reconciles with EP-QUALITY-RIGHTSIZING (diff-end sensitivity).
+- **Context overlay:** a WWWD industry/jurisdiction obligation raises evidence to
+  `compliance` and carries `contextScope` for the evidence collector + reporter
+  (BI-EE211BFA).
+- `budget.tokenCeiling` is `null` (advisory) until metering lands (BI-0A6B8B38); the
+  `effortLevel`/`gateProfile`/`modelTier` knobs deliver the immediate token win.
+
 ## Reuse (migration, not green-field)
 
 Right-sizing matrix (`build-process-matrix.ts`), decision tables


### PR DESCRIPTION
Stacked on #3091 (the classifier). Lands `deriveWarrant` — the control object where the **decision-end** (altitude) and **diff-end** (blast radius) meet, mapping into the five knobs execution reads: `lane`, `budget` (modelTier/effortLevel/gateProfile/tokenCeiling), `evidenceProfile`, `reportingProfile`, `contextScope`.

**Design decisions (baked in + tested):**
- **Altitude base map:** WSID → autonomous / economical / collapsed gates / minimal evidence / one-line · WWWD → governed-interactive / standard / business · WWMD → governed-interactive / strong / full gates / architectural / ledger. *A WSID task no longer pays WWMD rigor — the whole point.*
- **Blast radius is monotonic — only ESCALATES.** Safe to compute from altitude alone; blast radius (a-priori code-graph/EA, a-posteriori diff — BI-22250BA2) can raise lane/evidence, never relax. A small WSID change with a large blast radius is pulled off the autonomous lane + confirmed; a tiny blast radius never softens a WWMD warrant. Reconciles with EP-QUALITY-RIGHTSIZING (diff-end sensitivity).
- **Context overlay:** a WWWD industry/jurisdiction obligation → `compliance` evidence + carries `contextScope` (BI-EE211BFA).
- `budget.tokenCeiling` advisory until metering (BI-0A6B8B38); the effort/gate/tier knobs give the immediate token win.

**Verification:** pure + dependency-free → **10 corpus-free unit tests** (base map, monotonic escalation, WWMD-never-relaxed, context overlay, determinism). Green.

Plan updated: `docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)