### PR TITLE
fix(build-studio): dispatch a decomposed child's plan when its dependencies release (BI-E49DDE47)

### DIFF
--- a/apps/web/lib/build/feature-build-dependencies.test.ts
+++ b/apps/web/lib/build/feature-build-dependencies.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   deriveFeatureBuildDependencyGate,
   deriveReadyDependentsAfterCompletion,
+  recordReadyDependentsAfterCompletion,
 } from "./feature-build-dependencies";
 
 describe("deriveFeatureBuildDependencyGate", () => {
@@ -152,7 +153,120 @@ describe("deriveReadyDependentsAfterCompletion", () => {
         buildId: "FB-USAGE",
         title: "Record usage",
         phase: "plan",
+        createdById: null,
       },
     ]);
+  });
+});
+
+describe("recordReadyDependentsAfterCompletion — dispatches the released child's plan (BI-E49DDE47)", () => {
+  function mockDb(completed: unknown) {
+    return {
+      featureBuild: { findUnique: async (_args: unknown) => completed as never },
+      buildActivity: { create: async (_args: unknown) => ({}) as never },
+    };
+  }
+
+  it("dispatches plan for a dependent whose upstream is now complete, keyed by its owner", async () => {
+    const dispatched: Array<{ buildId: string; userId: string }> = [];
+    const ready = await recordReadyDependentsAfterCompletion({
+      buildId: "FB-UP",
+      db: mockDb({
+        id: "row-up",
+        buildId: "FB-UP",
+        title: "Upstream",
+        parentEpicId: "epic-1",
+        phase: "complete",
+        dependenciesIn: [
+          {
+            dependent: {
+              id: "row-dep",
+              buildId: "FB-DEP",
+              title: "Downstream child",
+              parentEpicId: "epic-1",
+              phase: "plan",
+              createdById: "user-42",
+              dependenciesOut: [
+                { dependsOn: { id: "row-up", buildId: "FB-UP", title: "Upstream", phase: "complete" } },
+              ],
+            },
+          },
+        ],
+      }),
+      dispatchPlanForChild: async (p) => {
+        dispatched.push(p);
+      },
+    });
+
+    expect(ready.map((r) => r.buildId)).toEqual(["FB-DEP"]);
+    expect(dispatched).toEqual([{ buildId: "FB-DEP", userId: "user-42" }]); // ← the fix: it dispatches, not just logs
+  });
+
+  it("does NOT dispatch a dependent still waiting on an incomplete sibling", async () => {
+    const dispatched: string[] = [];
+    await recordReadyDependentsAfterCompletion({
+      buildId: "FB-UP",
+      db: mockDb({
+        id: "row-up",
+        buildId: "FB-UP",
+        title: "Upstream",
+        parentEpicId: "epic-1",
+        phase: "complete",
+        dependenciesIn: [
+          {
+            dependent: {
+              id: "row-dep",
+              buildId: "FB-DEP",
+              title: "Still blocked",
+              parentEpicId: "epic-1",
+              phase: "plan",
+              createdById: "user-42",
+              dependenciesOut: [
+                { dependsOn: { id: "row-up", buildId: "FB-UP", title: "Upstream", phase: "complete" } },
+                { dependsOn: { id: "row-other", buildId: "FB-OTHER", title: "Other", phase: "build" } },
+              ],
+            },
+          },
+        ],
+      }),
+      dispatchPlanForChild: async (p) => {
+        dispatched.push(p.buildId);
+      },
+    });
+    expect(dispatched).toEqual([]);
+  });
+
+  it("skips dispatch (does not throw) when the ready dependent has no owner", async () => {
+    const dispatched: string[] = [];
+    const ready = await recordReadyDependentsAfterCompletion({
+      buildId: "FB-UP",
+      db: mockDb({
+        id: "row-up",
+        buildId: "FB-UP",
+        title: "Upstream",
+        parentEpicId: "epic-1",
+        phase: "complete",
+        dependenciesIn: [
+          {
+            dependent: {
+              id: "row-dep",
+              buildId: "FB-DEP",
+              title: "Ownerless child",
+              parentEpicId: "epic-1",
+              phase: "plan",
+              createdById: null,
+              dependenciesOut: [
+                { dependsOn: { id: "row-up", buildId: "FB-UP", title: "Upstream", phase: "complete" } },
+              ],
+            },
+          },
+        ],
+      }),
+      dispatchPlanForChild: async (p) => {
+        dispatched.push(p.buildId);
+      },
+    });
+    expect(ready.map((r) => r.buildId)).toEqual(["FB-DEP"]);
+    expect(dispatched).toEqual([]);
   });
 });

--- a/apps/web/lib/build/feature-build-dependencies.ts
+++ b/apps/web/lib/build/feature-build-dependencies.ts
@@ -13,6 +13,10 @@ export type FeatureBuildDependencyGateBuild = {
   title: string;
   parentEpicId: string | null;
   phase: DependencyBuildPhase;
+  /** Owner — used to dispatch the dependent's plan when it becomes ready.
+   *  Optional because only the completion-select path (which drives dispatch)
+   *  populates it; the plain gate-check path does not need it. */
+  createdById?: string | null;
   dependenciesOut: ReadonlyArray<{
     dependsOn: FeatureBuildDependencyBuild;
   }>;
@@ -32,6 +36,7 @@ export type ReadyDependentBuild = {
   buildId: string;
   title: string;
   phase: DependencyBuildPhase;
+  createdById: string | null;
 };
 
 export const FEATURE_BUILD_DEPENDENCY_READY_TOOL = "dependency:ready";
@@ -71,6 +76,7 @@ export const FEATURE_BUILD_DEPENDENCY_COMPLETION_SELECT = {
           title: true,
           parentEpicId: true,
           phase: true,
+          createdById: true,
           dependenciesOut: {
             select: {
               dependsOn: {
@@ -197,12 +203,16 @@ export function deriveReadyDependentsAfterCompletion(args: {
       buildId: dependent.buildId,
       title: dependent.title,
       phase: dependent.phase,
+      createdById: dependent.createdById ?? null,
     }));
 }
 
 export async function recordReadyDependentsAfterCompletion(args: {
   db: FeatureBuildDependencyDb;
   buildId: string;
+  /** Injectable for tests; defaults to the real plan dispatcher (dynamic import
+   *  to avoid a static cycle with plan-on-approval). Mirrors approve-decomposition. */
+  dispatchPlanForChild?: (params: { buildId: string; userId: string }) => Promise<unknown>;
 }): Promise<ReadyDependentBuild[]> {
   const completedBuild = await args.db.featureBuild.findUnique({
     where: { buildId: args.buildId },
@@ -225,6 +235,38 @@ export async function recordReadyDependentsAfterCompletion(args: {
         },
       }).catch(() => {}),
     ),
+  );
+
+  // BI-E49DDE47 (dependency-release half): approve-decomposition dispatches the
+  // UNBLOCKED heads, but dependency-chained siblings were only logged
+  // "ready to plan" here and never dispatched — so they stranded in `plan` after
+  // their upstream completed. Now that all upstream dependencies are complete,
+  // dispatch plan generation so the chain actually advances. Fire-and-forget
+  // (mirrors the ideate→plan handoff); a null owner or dispatch failure is logged,
+  // never blocks the completing build.
+  const dispatchPlanForChild =
+    args.dispatchPlanForChild ??
+    (async (params: { buildId: string; userId: string }) => {
+      const { dispatchPlanForApprovedBuild } = await import("@/lib/integrate/plan-on-approval");
+      return dispatchPlanForApprovedBuild(params);
+    });
+  await Promise.all(
+    readyDependents.map(async (dependent) => {
+      if (!dependent.createdById) {
+        console.warn(
+          `[feature-build-dependencies] ready dependent ${dependent.buildId} has no owner — cannot dispatch plan`,
+        );
+        return;
+      }
+      try {
+        await dispatchPlanForChild({ buildId: dependent.buildId, userId: dependent.createdById });
+      } catch (err) {
+        console.warn(
+          `[feature-build-dependencies] plan dispatch for ready dependent ${dependent.buildId} failed:`,
+          (err as Error)?.message,
+        );
+      }
+    }),
   );
 
   return readyDependents;


### PR DESCRIPTION
Completes **BI-E49DDE47**. `approve-decomposition` already dispatches the **unblocked head** children (empty `dependsOn`), but **dependency-chained siblings** were only *logged* `"ready to plan"` in `recordReadyDependentsAfterCompletion` and **never dispatched** — so a decomposed epic's chain stranded after the head completed. Every non-head child sat in `plan` forever (observed live on EP-91F0168C's children this session — the exact reason those builds wouldn't advance).

## Fix
When a completing build releases dependents whose full upstream set is now complete, **dispatch each one's plan generation** (`dispatchPlanForApprovedBuild`), keyed by the child's own `createdById`:
- Carries `createdById` through the completion select + the `ReadyDependentBuild` shape.
- Dispatcher is **injectable** (tests) and resolved via dynamic import to avoid a static cycle — mirrors the `approve-decomposition` head path.
- **Fire-and-forget**: a null owner or dispatch failure is logged, never blocks the completing build.

## Verification
`vitest run lib/build/feature-build-dependencies.test.ts` — **7 pass**, incl. 3 new: dispatches-on-release, does-not-dispatch-while-still-blocked, skips-ownerless-without-throwing.

Together with the head-dispatch already on main, a decomposed epic now flows end to end — the throughput path for large backlog items actually ushers its children through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)