### PR TITLE
feat(healthcare): add patient authority foundation

### DIFF
--- a/apps/web/lib/ea/data-model-mirror.test.ts
+++ b/apps/web/lib/ea/data-model-mirror.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import { parsePrismaSchema } from "../integrate/code-graph/extractors/prisma-schema-adapter";
 import {
@@ -150,5 +152,35 @@ describe("planMirror", () => {
     expect(summary.created).toBeGreaterThan(0);
     expect(summary.updated).toBe(0);
     expect(summary.removed).toBe(0);
+  });
+});
+
+describe("healthcare patient authority mirror allocation", () => {
+  it("discovers the canonical patient models and their Principal/Organization relationships", () => {
+    const schema = readFileSync(
+      resolve(process.cwd(), "../../packages/db/prisma/schema.prisma"),
+      "utf8",
+    );
+    const desired = buildDesiredState(parsePrismaSchema(schema));
+    const elementKeys = desired.elements.map((element) => element.sourceKey);
+    const relationshipKeys = desired.relationships.map(
+      (relationship) => relationship.sourceKey,
+    );
+
+    expect(elementKeys).toEqual(
+      expect.arrayContaining([
+        modelSourceKey("PatientProfile"),
+        modelSourceKey("PatientAuthority"),
+        modelSourceKey("PatientConsentDirective"),
+      ]),
+    );
+    expect(relationshipKeys).toEqual(
+      expect.arrayContaining([
+        "prisma:relation:PatientProfile:organization:Organization",
+        "prisma:relation:PatientProfile:principal:Principal",
+        "prisma:relation:PatientAuthority:patientProfile:PatientProfile",
+        "prisma:relation:PatientConsentDirective:patientProfile:PatientProfile",
+      ]),
+    );
   });
 });

--- a/apps/web/lib/healthcare/patient-authority-repository.test.ts
+++ b/apps/web/lib/healthcare/patient-authority-repository.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  evaluateAndRecordPatientAuthority,
+  withPatientDataContext,
+} from "./patient-authority-repository";
+
+const NOW = new Date("2026-07-16T12:00:00.000Z");
+
+function createHarness() {
+  const order: string[] = [];
+  const patientProfile = {
+    id: "patient-profile-a",
+    organizationId: "org-a",
+    principalId: "principal-patient",
+    status: "active",
+    minorStatus: "adult",
+    selfAccessAllowed: true,
+  };
+  const tx = {
+    $executeRaw: vi.fn(async () => {
+      order.push("context");
+      return 1;
+    }),
+    patientProfile: {
+      findFirst: vi.fn<() => Promise<typeof patientProfile | null>>(
+        async () => {
+          order.push("profile");
+          return patientProfile;
+        },
+      ),
+    },
+    patientAuthority: {
+      findMany: vi.fn(async () => {
+        order.push("authority");
+        return [
+          {
+            id: "authority-row-a",
+            authorityId: "authority-a",
+            organizationId: "org-a",
+            patientProfileId: "patient-profile-a",
+            granteePrincipalId: "principal-proxy",
+            relationshipType: "proxy",
+            status: "active",
+            purposesOfUse: ["patient-support"],
+            permittedOperations: ["view"],
+            recordCategories: ["appointments"],
+            effectiveFrom: new Date("2026-01-01T00:00:00.000Z"),
+            expiresAt: null,
+            revokedAt: null,
+            version: 2,
+          },
+        ];
+      }),
+    },
+    patientConsentDirective: {
+      findMany: vi.fn(async () => {
+        order.push("directive");
+        return [];
+      }),
+    },
+    authorizationDecisionLog: {
+      create: vi.fn(async ({ data }) => {
+        order.push("decision");
+        return data;
+      }),
+    },
+  };
+  const db = {
+    $transaction: vi.fn(async (callback) => callback(tx)),
+  };
+
+  return { db, tx, order };
+}
+
+describe("withPatientDataContext", () => {
+  it("establishes transaction-local tenant and patient context before work", async () => {
+    const { db, tx, order } = createHarness();
+    const callback = vi.fn(async () => {
+      order.push("callback");
+      return "ok";
+    });
+
+    await expect(
+      withPatientDataContext(
+        {
+          organizationId: "org-a",
+          patientPrincipalIds: ["principal-patient"],
+        },
+        callback,
+        db,
+      ),
+    ).resolves.toBe("ok");
+
+    expect(db.$transaction).toHaveBeenCalledTimes(1);
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["context", "callback"]);
+  });
+
+  it.each([
+    { organizationId: "", patientPrincipalIds: ["principal-patient"] },
+    { organizationId: "org-a", patientPrincipalIds: [] },
+    { organizationId: "org-a", patientPrincipalIds: ["patient,other"] },
+  ])("fails closed for invalid context %#", async (context) => {
+    const { db, tx } = createHarness();
+
+    await expect(
+      withPatientDataContext(context, vi.fn(), db),
+    ).rejects.toThrow("Invalid patient data context");
+    expect(db.$transaction).not.toHaveBeenCalled();
+    expect(tx.$executeRaw).not.toHaveBeenCalled();
+  });
+});
+
+describe("evaluateAndRecordPatientAuthority", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("queries one tenant/patient and records immutable decision evidence in the same transaction", async () => {
+    const { db, tx, order } = createHarness();
+
+    const result = await evaluateAndRecordPatientAuthority(
+      {
+        organizationId: "org-a",
+        actorPrincipalId: "principal-proxy",
+        actorType: "human",
+        patientPrincipalId: "principal-patient",
+        purposeOfUse: "patient-support",
+        operation: "view",
+        recordCategory: "appointments",
+        at: NOW,
+        accessMode: "ordinary",
+        emergencyAccess: null,
+      },
+      db,
+    );
+
+    expect(result).toMatchObject({
+      effect: "allow",
+      reasonCodes: ["matched-patient-authority"],
+      matchedAuthorityId: "authority-a",
+    });
+    expect(order).toEqual([
+      "context",
+      "profile",
+      "authority",
+      "directive",
+      "decision",
+    ]);
+    expect(tx.patientProfile.findFirst).toHaveBeenCalledWith({
+      where: {
+        organizationId: "org-a",
+        principalId: "principal-patient",
+      },
+    });
+    expect(tx.patientAuthority.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationId: "org-a",
+          patientProfileId: "patient-profile-a",
+          status: "active",
+        }),
+      }),
+    );
+    expect(tx.authorizationDecisionLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        organizationId: "org-a",
+        patientSubjectPrincipalId: "principal-patient",
+        patientAuthorityId: "authority-row-a",
+        purposeOfUse: "patient-support",
+        decision: "allow",
+        policyVersion: "healthcare-patient-authority/v1",
+      }),
+    });
+  });
+
+  it("denies and records a missing patient profile without querying authority rows", async () => {
+    const { db, tx } = createHarness();
+    tx.patientProfile.findFirst.mockResolvedValueOnce(null);
+
+    const result = await evaluateAndRecordPatientAuthority(
+      {
+        organizationId: "org-a",
+        actorPrincipalId: "principal-proxy",
+        actorType: "human",
+        patientPrincipalId: "principal-patient",
+        purposeOfUse: "patient-support",
+        operation: "view",
+        recordCategory: "appointments",
+        at: NOW,
+        accessMode: "ordinary",
+        emergencyAccess: null,
+      },
+      db,
+    );
+
+    expect(result).toMatchObject({
+      effect: "deny",
+      reasonCodes: ["patient-profile-unavailable"],
+    });
+    expect(tx.patientAuthority.findMany).not.toHaveBeenCalled();
+    expect(tx.patientConsentDirective.findMany).not.toHaveBeenCalled();
+    expect(tx.authorizationDecisionLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        decision: "deny",
+        patientAuthorityId: null,
+        patientConsentDirectiveId: null,
+      }),
+    });
+  });
+});

--- a/apps/web/lib/healthcare/patient-authority-repository.ts
+++ b/apps/web/lib/healthcare/patient-authority-repository.ts
@@ -1,0 +1,313 @@
+import { randomUUID } from "node:crypto";
+
+import { prisma, type Prisma } from "@dpf/db";
+import {
+  evaluatePatientAuthority,
+  type EmergencyPatientAccess,
+  type PatientAuthorityDecision,
+  type PatientAuthorityEvaluationInput,
+  type PatientAuthorityStatus,
+  type PatientConsentDirectiveView,
+  type PatientOperation,
+  type PatientProfileStatus,
+  type PatientRelationshipType,
+} from "@dpf/db/healthcare-patient-authority";
+
+export const PATIENT_AUTHORITY_POLICY_VERSION =
+  "healthcare-patient-authority/v1";
+
+type PatientProfileRow = {
+  id: string;
+  organizationId: string;
+  principalId: string;
+  status: string;
+  minorStatus: string;
+  selfAccessAllowed: boolean;
+};
+
+type PatientAuthorityRow = {
+  id: string;
+  authorityId: string;
+  organizationId: string;
+  patientProfileId: string;
+  granteePrincipalId: string;
+  relationshipType: string;
+  status: string;
+  purposesOfUse: string[];
+  permittedOperations: string[];
+  recordCategories: string[];
+  effectiveFrom: Date;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+  version: number;
+};
+
+type PatientConsentDirectiveRow = {
+  id: string;
+  directiveId: string;
+  organizationId: string;
+  patientProfileId: string;
+  directiveType: string;
+  status: string;
+  decision: string;
+  purposesOfUse: string[];
+  operations: string[];
+  recordCategories: string[];
+  effectiveFrom: Date;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+  emergencyOverrideAllowed: boolean;
+  version: number;
+};
+
+type PatientDataTransaction = {
+  $executeRaw(
+    query: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<number>;
+  patientProfile: {
+    findFirst(args: unknown): Promise<PatientProfileRow | null>;
+  };
+  patientAuthority: {
+    findMany(args: unknown): Promise<PatientAuthorityRow[]>;
+  };
+  patientConsentDirective: {
+    findMany(args: unknown): Promise<PatientConsentDirectiveRow[]>;
+  };
+  authorizationDecisionLog: {
+    create(args: unknown): Promise<unknown>;
+  };
+};
+
+export type PatientDataDatabase = {
+  $transaction<T>(
+    callback: (transaction: PatientDataTransaction) => Promise<T>,
+  ): Promise<T>;
+};
+
+export type PatientDataContext = {
+  organizationId: string;
+  patientPrincipalIds: string[];
+};
+
+export type EvaluatePatientAuthorityRequest = {
+  organizationId: string;
+  actorPrincipalId: string;
+  actorType: "human" | "agent" | "service";
+  patientPrincipalId: string;
+  purposeOfUse: string;
+  operation: PatientOperation;
+  recordCategory: string;
+  at: Date;
+  accessMode: "ordinary" | "staff-override" | "emergency";
+  emergencyAccess: EmergencyPatientAccess | null;
+};
+
+function validContextValue(value: string): boolean {
+  return value.trim().length > 0 && !value.includes(",");
+}
+
+function assertPatientDataContext(context: PatientDataContext): void {
+  if (
+    !validContextValue(context.organizationId)
+    || context.patientPrincipalIds.length === 0
+    || context.patientPrincipalIds.some(
+      (principalId) => !validContextValue(principalId),
+    )
+  ) {
+    throw new Error("Invalid patient data context");
+  }
+}
+
+export async function withPatientDataContext<T>(
+  context: PatientDataContext,
+  callback: (transaction: PatientDataTransaction) => Promise<T>,
+  database: PatientDataDatabase = prisma as unknown as PatientDataDatabase,
+): Promise<T> {
+  assertPatientDataContext(context);
+
+  return database.$transaction(async (transaction) => {
+    await transaction.$executeRaw`
+      SELECT
+        set_config('app.organization_id', ${context.organizationId}, true),
+        set_config(
+          'app.patient_principal_ids',
+          ${context.patientPrincipalIds.join(",")},
+          true
+        )
+    `;
+    return callback(transaction);
+  });
+}
+
+function unavailableDecision(): PatientAuthorityDecision {
+  return {
+    effect: "deny",
+    reasonCodes: ["patient-profile-unavailable"],
+    matchedAuthorityId: null,
+    matchedDirectiveIds: [],
+    emergencyAccessId: null,
+    obligations: ["staff-assisted-recovery"],
+  };
+}
+
+function toDirectiveView(
+  directive: PatientConsentDirectiveRow,
+): PatientConsentDirectiveView {
+  return {
+    directiveId: directive.directiveId,
+    organizationId: directive.organizationId,
+    patientProfileId: directive.patientProfileId,
+    directiveType: directive.directiveType as PatientConsentDirectiveView["directiveType"],
+    status: directive.status as PatientConsentDirectiveView["status"],
+    decision: directive.decision as PatientConsentDirectiveView["decision"],
+    purposesOfUse: directive.purposesOfUse,
+    operations: directive.operations as PatientOperation[],
+    recordCategories: directive.recordCategories,
+    effectiveFrom: directive.effectiveFrom,
+    expiresAt: directive.expiresAt,
+    revokedAt: directive.revokedAt,
+    emergencyOverrideAllowed: directive.emergencyOverrideAllowed,
+  };
+}
+
+async function writeDecisionEvidence(
+  transaction: PatientDataTransaction,
+  request: EvaluatePatientAuthorityRequest,
+  decision: PatientAuthorityDecision,
+  authorities: PatientAuthorityRow[],
+  directives: PatientConsentDirectiveRow[],
+): Promise<void> {
+  const authorityRow =
+    authorities.find(
+      (authority) => authority.authorityId === decision.matchedAuthorityId,
+    ) ?? null;
+  const directiveRows = directives.filter((directive) =>
+    decision.matchedDirectiveIds.includes(directive.directiveId)
+  );
+
+  await transaction.authorizationDecisionLog.create({
+    data: {
+      decisionId: `patient-decision-${randomUUID()}`,
+      actorType: request.actorType,
+      actorRef: request.actorPrincipalId,
+      organizationId: request.organizationId,
+      patientSubjectPrincipalId: request.patientPrincipalId,
+      patientAuthorityId: authorityRow?.id ?? null,
+      patientConsentDirectiveId: directiveRows[0]?.id ?? null,
+      purposeOfUse: request.purposeOfUse,
+      policyVersion: PATIENT_AUTHORITY_POLICY_VERSION,
+      actionKey: `healthcare.patient.${request.operation}`,
+      objectRef:
+        `patient:${request.patientPrincipalId}:${request.recordCategory}`,
+      decision: decision.effect,
+      rationale: {
+        reasonCodes: decision.reasonCodes,
+        matchedAuthorityId: decision.matchedAuthorityId,
+        matchedDirectiveIds: decision.matchedDirectiveIds,
+        authorityVersions: authorities.map((authority) => ({
+          authorityId: authority.authorityId,
+          version: authority.version,
+        })),
+        directiveVersions: directives.map((directive) => ({
+          directiveId: directive.directiveId,
+          version: directive.version,
+        })),
+        emergencyAccessId: decision.emergencyAccessId,
+        obligations: decision.obligations,
+        recordCategory: request.recordCategory,
+        accessMode: request.accessMode,
+      } satisfies Prisma.InputJsonValue,
+    },
+  });
+}
+
+export async function evaluateAndRecordPatientAuthority(
+  request: EvaluatePatientAuthorityRequest,
+  database: PatientDataDatabase = prisma as unknown as PatientDataDatabase,
+): Promise<PatientAuthorityDecision> {
+  return withPatientDataContext(
+    {
+      organizationId: request.organizationId,
+      patientPrincipalIds: [request.patientPrincipalId],
+    },
+    async (transaction) => {
+      const patient = await transaction.patientProfile.findFirst({
+        where: {
+          organizationId: request.organizationId,
+          principalId: request.patientPrincipalId,
+        },
+      });
+
+      if (patient === null) {
+        const decision = unavailableDecision();
+        await writeDecisionEvidence(transaction, request, decision, [], []);
+        return decision;
+      }
+
+      const effectiveWindow = {
+        status: "active",
+        effectiveFrom: { lte: request.at },
+        revokedAt: null,
+        OR: [{ expiresAt: null }, { expiresAt: { gt: request.at } }],
+      };
+      const [authorities, directives] = await Promise.all([
+        transaction.patientAuthority.findMany({
+          where: {
+            organizationId: request.organizationId,
+            patientProfileId: patient.id,
+            ...effectiveWindow,
+          },
+          orderBy: [{ effectiveFrom: "desc" }, { version: "desc" }],
+        }),
+        transaction.patientConsentDirective.findMany({
+          where: {
+            organizationId: request.organizationId,
+            patientProfileId: patient.id,
+            ...effectiveWindow,
+          },
+          orderBy: [{ effectiveFrom: "desc" }, { version: "desc" }],
+        }),
+      ]);
+
+      const evaluation: PatientAuthorityEvaluationInput = {
+        ...request,
+        patient: {
+          patientProfileId: patient.id,
+          organizationId: patient.organizationId,
+          principalId: patient.principalId,
+          status: patient.status as PatientProfileStatus,
+          isMinor: patient.minorStatus === "minor",
+          selfAccessAllowed: patient.selfAccessAllowed,
+        },
+        authorities: authorities.map((authority) => ({
+          authorityId: authority.authorityId,
+          organizationId: authority.organizationId,
+          patientProfileId: authority.patientProfileId,
+          granteePrincipalId: authority.granteePrincipalId,
+          relationshipType:
+            authority.relationshipType as PatientRelationshipType,
+          status: authority.status as PatientAuthorityStatus,
+          purposesOfUse: authority.purposesOfUse,
+          permittedOperations:
+            authority.permittedOperations as PatientOperation[],
+          recordCategories: authority.recordCategories,
+          effectiveFrom: authority.effectiveFrom,
+          expiresAt: authority.expiresAt,
+          revokedAt: authority.revokedAt,
+        })),
+        directives: directives.map(toDirectiveView),
+      };
+      const decision = evaluatePatientAuthority(evaluation);
+      await writeDecisionEvidence(
+        transaction,
+        request,
+        decision,
+        authorities,
+        directives,
+      );
+      return decision;
+    },
+    database,
+  );
+}

--- a/docs/superpowers/plans/2026-07-16-healthcare-patient-authority.md
+++ b/docs/superpowers/plans/2026-07-16-healthcare-patient-authority.md
@@ -1,0 +1,138 @@
+# Healthcare patient authority implementation plan
+
+**Backlog item:** BI-HEALTHCARE-004
+
+**Epic:** EP-HEALTHCARE-PRACTICE
+**Design inputs:** `2026-07-15-healthcare-canonical-data-authority-design.md` and `2026-07-15-healthcare-privacy-security-safety-threat-model.md`
+
+## Objective
+
+Add the first executable healthcare identity boundary without creating a second person master:
+
+- `Principal` and `PrincipalAlias` remain universal identity authority.
+- An organization-scoped `PatientProfile` records the patient role and non-demographic care preferences.
+- Effective-dated patient-to-human authority records express guardian, caregiver, household, emergency-contact, responsible-party, and proxy relationships.
+- Versioned consent and privacy-restriction directives constrain purposes, operations, and record categories.
+- Existing `AuthorizationDecisionLog` records which patient authority and consent records were evaluated.
+- A pure, deny-by-default decision contract makes cross-tenant, wrong-subject, expired/revoked proxy, identity-review, merge, minor, staff-override, and emergency-access behavior testable before routes exist.
+
+## Substrate verification
+
+| Concern | Existing authority | Decision |
+|---|---|---|
+| Universal identity | `Principal`, `PrincipalAlias`, MDM merge/unmerge services | Extend; never duplicate demographics |
+| Organization | `Organization` | Parent scope for patient roles and authority |
+| Generic resource/agent authority | `AuthorityBinding` | Reuse for AI/resource grants; do not overload it as the patient legal relationship record |
+| Authorization evidence | `AuthorizationDecisionLog` | Extend with patient subject, purpose, authority, and consent references |
+| Compliance audit | `ComplianceAuditLog` | Reuse for administrative entity changes; no healthcare-only audit log |
+| Voice consent | `VoiceConsentRecord` | Remains voice-specific and is not reused as general healthcare consent |
+
+No existing `PatientProfile`, guardian/proxy authority, or general patient consent/restriction substrate exists on `origin/main`.
+
+## Phase 1 — Domain contract and red tests
+
+Files:
+
+- `packages/db/src/healthcare-patient-authority.ts`
+- `packages/db/src/healthcare-patient-authority.test.ts`
+- `packages/db/src/healthcare-patient-authority-model.test.ts`
+- `packages/db/src/index.ts`
+- `packages/db/package.json`
+
+Deliver:
+
+- Closed string vocabularies for patient lifecycle, relationship type, authority status, directive type/status/decision, operations, and decision reason codes.
+- A deterministic `evaluatePatientAuthority` function with no database or UI dependency.
+- Explicit emergency-access contract: human-only, declared reason, patient-specific, unexpired, minimum requested operation; it is never inferred from staff role.
+
+Verification:
+
+- Observe the new tests fail before implementation.
+- Targeted Vitest passes after implementation.
+- Tests cover every BI-004 negative case and prove self-access is not treated as proxy authority.
+
+## Phase 2 — Fleet-safe schema expansion
+
+Files:
+
+- `packages/db/prisma/schema.prisma`
+- `packages/db/prisma/migrations/20260716220000_add_healthcare_patient_authority/migration.sql`
+- generated Prisma client
+
+Deliver:
+
+- `PatientProfile` as an organization-scoped 1:1 role extension of `Principal`.
+- `PatientAuthority` for typed, evidenced, effective-dated human relationships.
+- `PatientConsentDirective` for versioned permits/restrictions.
+- Optional healthcare context references on `AuthorizationDecisionLog`.
+- Composite organization-consistent foreign keys from authority/directive rows to `PatientProfile`.
+- Retention-safe `RESTRICT`/`SET NULL` deletion behavior; no cascade from `Principal` or `Organization` into retained patient authority.
+- RLS policies that fail closed when organization context is absent.
+
+Migration safety:
+
+- This is an expand-only migration creating empty tables and nullable columns on an existing audit table.
+- No existing row is tightened or backfilled.
+- All new constrained data enters through the new contract.
+
+Verification:
+
+- `prisma validate` and client generation pass.
+- Model-delegate tests pass.
+- Migration safety guard accepts the in-file data-safety attestation.
+- Apply the migration against a disposable/canonical governed Postgres target, not by mutating the root install ad hoc.
+
+## Phase 3 — Repository boundary and evidence writer
+
+Files:
+
+- `apps/web/lib/healthcare/patient-authority-repository.ts`
+- `apps/web/lib/healthcare/patient-authority-repository.test.ts`
+
+Deliver:
+
+- A transaction-scoped helper that sets validated organization and patient context with `set_config(..., true)`.
+- Read helpers return only active, effective authority and directive records for one organization and patient.
+- Decision logging writes `AuthorizationDecisionLog` with organization, patient subject, purpose, matched authority/directive, policy/version rationale, and allow/deny result.
+- No route directly queries the new Prisma delegates.
+
+Verification:
+
+- Mocked repository tests assert one transaction, local context establishment before reads, tenant/patient predicates on every query, and immutable decision-log creation.
+- Negative tests prove absent context and cross-tenant inputs fail before queries.
+
+## Phase 4 — EA allocation and durable documentation
+
+Files:
+
+- `packages/db/src/data-model-mirror-config.ts` only if the generic mirror requires explicit registration.
+- The canonical healthcare design, if implementation details materially clarify it.
+
+Deliver:
+
+- Confirm the generic Prisma-to-EA mirror discovers all new models and relations.
+- Record repository/RLS/decision-contract allocation and verification cases.
+
+Verification:
+
+- Existing data-model mirror tests pass.
+- Architecture review confirms Principal convergence, single-source-of-truth, tenant consistency, retention, and audit reuse.
+
+## Risks and rollback
+
+- **Risk: parallel identity.** Mitigation: no name, birth date, email, phone, or address fields exist on `PatientProfile`; those stay on canonical identity/contact sources.
+- **Risk: proxy overreach.** Mitigation: operation, purpose, record-category, effective-period, status, organization, and subject are all mandatory decision inputs.
+- **Risk: deleting retained authority evidence.** Mitigation: `RESTRICT` relationships and revocation/supersession instead of deletion.
+- **Risk: RLS connection leakage.** Mitigation: transaction-local `set_config` only, fail-closed policies, and connection-reuse verification before runtime launch.
+- **Risk: jurisdiction-specific minor rules becoming hardcoded.** Mitigation: this slice denies when authority is insufficient; jurisdiction evaluation supplies the effective authority/directive inputs later.
+- **Rollback:** application code can stop using the new repository without affecting existing flows. The expand-only tables remain inert. A later cleanup migration may remove unused substrate only after confirming no patient rows or decision-log references exist.
+
+## Definition of done
+
+1. No duplicate patient/person demographics authority exists.
+2. Every patient role is unique per organization and Principal.
+3. Every proxy decision is scoped to organization, patient, purpose, operation, category, and time.
+4. Minor, duplicate/identity-review, cross-tenant, revoked/expired proxy, merged profile, staff override, and emergency-access tests pass.
+5. Staff-assisted and self-service recovery are represented as explicit decision outcomes/obligations, not silent override.
+6. Authorization evidence names who acted, the patient subject, purpose, authority/directive versions consulted, and the result.
+7. Prisma, migration, domain, repository, and EA checks pass with evidence recorded against BI-HEALTHCARE-004.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -45,6 +45,7 @@
     "./workforce-seed": "./src/workforce-seed.ts",
     "./agent-identity": "./src/agent-identity.ts",
     "./agent-model-defaults": "./src/agent-model-defaults.ts",
+    "./healthcare-patient-authority": "./src/healthcare-patient-authority.ts",
     "./seed-skills": "./src/seed-skills.ts",
     "./patch": "./src/patch/index.ts"
   },

--- a/packages/db/prisma/migrations/20260716220000_add_healthcare_patient_authority/migration.sql
+++ b/packages/db/prisma/migrations/20260716220000_add_healthcare_patient_authority/migration.sql
@@ -1,0 +1,356 @@
+-- BI-HEALTHCARE-004: canonical patient role, human proxy authority, and consent.
+-- @migration-safety: data-safe: all required columns and tightening constraints
+-- apply only to newly created empty tables; existing AuthorizationDecisionLog
+-- changes are nullable and therefore valid for every existing row.
+
+-- Extend the existing authorization evidence stream rather than creating a
+-- healthcare-only audit log.
+ALTER TABLE "AuthorizationDecisionLog"
+  ADD COLUMN "organizationId" TEXT,
+  ADD COLUMN "patientSubjectPrincipalId" TEXT,
+  ADD COLUMN "patientAuthorityId" TEXT,
+  ADD COLUMN "patientConsentDirectiveId" TEXT,
+  ADD COLUMN "purposeOfUse" TEXT,
+  ADD COLUMN "policyVersion" TEXT;
+
+CREATE TABLE "PatientProfile" (
+  "id" TEXT NOT NULL,
+  "patientId" TEXT NOT NULL,
+  "organizationId" TEXT NOT NULL,
+  "principalId" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'active',
+  "minorStatus" TEXT NOT NULL DEFAULT 'unknown',
+  "minorStatusAsOf" TIMESTAMP(3),
+  "selfAccessAllowed" BOOLEAN NOT NULL DEFAULT false,
+  "preferredLanguage" TEXT,
+  "accessibilityNeeds" JSONB,
+  "communicationPreferences" JSONB,
+  "sourceSystem" TEXT,
+  "sourceId" TEXT,
+  "sourceVersion" TEXT,
+  "recordedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "recordedByPrincipalId" TEXT,
+  "verifiedAt" TIMESTAMP(3),
+  "verifiedByPrincipalId" TEXT,
+  "sensitivityLabels" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "retentionClass" TEXT,
+  "legalHold" BOOLEAN NOT NULL DEFAULT false,
+  "mergedIntoPatientProfileId" TEXT,
+  "enteredInErrorAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "PatientProfile_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "PatientProfile_status_check" CHECK (
+    "status" IN ('active', 'inactive', 'identity-review', 'merged', 'entered-in-error')
+  ),
+  CONSTRAINT "PatientProfile_minorStatus_check" CHECK (
+    "minorStatus" IN ('unknown', 'minor', 'adult')
+  ),
+  CONSTRAINT "PatientProfile_merge_state_check" CHECK (
+    ("status" = 'merged' AND "mergedIntoPatientProfileId" IS NOT NULL)
+    OR ("status" <> 'merged')
+  ),
+  CONSTRAINT "PatientProfile_entered_error_state_check" CHECK (
+    ("status" = 'entered-in-error' AND "enteredInErrorAt" IS NOT NULL)
+    OR ("status" <> 'entered-in-error')
+  ),
+  CONSTRAINT "PatientProfile_no_self_merge_check" CHECK (
+    "mergedIntoPatientProfileId" IS NULL OR "mergedIntoPatientProfileId" <> "id"
+  )
+);
+
+CREATE TABLE "PatientAuthority" (
+  "id" TEXT NOT NULL,
+  "authorityId" TEXT NOT NULL,
+  "organizationId" TEXT NOT NULL,
+  "patientProfileId" TEXT NOT NULL,
+  "granteePrincipalId" TEXT NOT NULL,
+  "relationshipType" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'proposed',
+  "legalBasis" TEXT,
+  "purposesOfUse" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "permittedOperations" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "recordCategories" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "locationRefs" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "scopeJson" JSONB,
+  "evidenceRef" TEXT,
+  "effectiveFrom" TIMESTAMP(3) NOT NULL,
+  "expiresAt" TIMESTAMP(3),
+  "revokedAt" TIMESTAMP(3),
+  "revokedByPrincipalId" TEXT,
+  "revocationReason" TEXT,
+  "assertedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "assertedByPrincipalId" TEXT NOT NULL,
+  "verifiedAt" TIMESTAMP(3),
+  "verifiedByPrincipalId" TEXT,
+  "version" INTEGER NOT NULL DEFAULT 1,
+  "supersedesAuthorityId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "PatientAuthority_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "PatientAuthority_relationshipType_check" CHECK (
+    "relationshipType" IN (
+      'guardian', 'caregiver', 'household-member', 'emergency-contact',
+      'responsible-party', 'proxy'
+    )
+  ),
+  CONSTRAINT "PatientAuthority_status_check" CHECK (
+    "status" IN ('proposed', 'active', 'expired', 'revoked', 'entered-in-error')
+  ),
+  CONSTRAINT "PatientAuthority_version_check" CHECK ("version" > 0),
+  CONSTRAINT "PatientAuthority_effective_window_check" CHECK (
+    "expiresAt" IS NULL OR "expiresAt" > "effectiveFrom"
+  ),
+  CONSTRAINT "PatientAuthority_revoked_state_check" CHECK (
+    ("status" = 'revoked' AND "revokedAt" IS NOT NULL)
+    OR ("status" <> 'revoked')
+  ),
+  CONSTRAINT "PatientAuthority_no_self_supersede_check" CHECK (
+    "supersedesAuthorityId" IS NULL OR "supersedesAuthorityId" <> "id"
+  )
+);
+
+CREATE TABLE "PatientConsentDirective" (
+  "id" TEXT NOT NULL,
+  "directiveId" TEXT NOT NULL,
+  "organizationId" TEXT NOT NULL,
+  "patientProfileId" TEXT NOT NULL,
+  "directiveType" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'proposed',
+  "decision" TEXT NOT NULL,
+  "purposesOfUse" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "operations" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "recordCategories" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "legalBasis" TEXT,
+  "evidenceRef" TEXT,
+  "scopeJson" JSONB,
+  "effectiveFrom" TIMESTAMP(3) NOT NULL,
+  "expiresAt" TIMESTAMP(3),
+  "emergencyOverrideAllowed" BOOLEAN NOT NULL DEFAULT false,
+  "revokedAt" TIMESTAMP(3),
+  "revokedByPrincipalId" TEXT,
+  "revocationReason" TEXT,
+  "assertedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "assertedByPrincipalId" TEXT NOT NULL,
+  "verifiedAt" TIMESTAMP(3),
+  "verifiedByPrincipalId" TEXT,
+  "version" INTEGER NOT NULL DEFAULT 1,
+  "supersedesDirectiveId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "PatientConsentDirective_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "PatientConsentDirective_type_check" CHECK (
+    "directiveType" IN ('consent', 'privacy-restriction')
+  ),
+  CONSTRAINT "PatientConsentDirective_status_check" CHECK (
+    "status" IN ('proposed', 'active', 'expired', 'revoked', 'entered-in-error')
+  ),
+  CONSTRAINT "PatientConsentDirective_decision_check" CHECK (
+    "decision" IN ('permit', 'deny')
+  ),
+  CONSTRAINT "PatientConsentDirective_version_check" CHECK ("version" > 0),
+  CONSTRAINT "PatientConsentDirective_effective_window_check" CHECK (
+    "expiresAt" IS NULL OR "expiresAt" > "effectiveFrom"
+  ),
+  CONSTRAINT "PatientConsentDirective_revoked_state_check" CHECK (
+    ("status" = 'revoked' AND "revokedAt" IS NOT NULL)
+    OR ("status" <> 'revoked')
+  ),
+  CONSTRAINT "PatientConsentDirective_no_self_supersede_check" CHECK (
+    "supersedesDirectiveId" IS NULL OR "supersedesDirectiveId" <> "id"
+  )
+);
+
+CREATE UNIQUE INDEX "PatientProfile_patientId_key"
+  ON "PatientProfile"("patientId");
+CREATE UNIQUE INDEX "PatientProfile_organizationId_principalId_key"
+  ON "PatientProfile"("organizationId", "principalId");
+CREATE UNIQUE INDEX "PatientProfile_id_organizationId_key"
+  ON "PatientProfile"("id", "organizationId");
+CREATE UNIQUE INDEX "PatientProfile_organizationId_sourceSystem_sourceId_key"
+  ON "PatientProfile"("organizationId", "sourceSystem", "sourceId");
+CREATE INDEX "PatientProfile_organizationId_status_idx"
+  ON "PatientProfile"("organizationId", "status");
+CREATE INDEX "PatientProfile_principalId_idx"
+  ON "PatientProfile"("principalId");
+CREATE INDEX "PatientProfile_mergedIntoPatientProfileId_idx"
+  ON "PatientProfile"("mergedIntoPatientProfileId");
+
+CREATE UNIQUE INDEX "PatientAuthority_authorityId_key"
+  ON "PatientAuthority"("authorityId");
+CREATE UNIQUE INDEX "PatientAuthority_id_organizationId_patientProfileId_key"
+  ON "PatientAuthority"("id", "organizationId", "patientProfileId");
+CREATE INDEX "PatientAuthority_organizationId_patientProfileId_status_idx"
+  ON "PatientAuthority"("organizationId", "patientProfileId", "status");
+CREATE INDEX "PatientAuthority_granteePrincipalId_status_idx"
+  ON "PatientAuthority"("granteePrincipalId", "status");
+CREATE INDEX "PatientAuthority_expiresAt_idx"
+  ON "PatientAuthority"("expiresAt");
+CREATE INDEX "PatientAuthority_supersedesAuthorityId_idx"
+  ON "PatientAuthority"("supersedesAuthorityId");
+
+CREATE UNIQUE INDEX "PatientConsentDirective_directiveId_key"
+  ON "PatientConsentDirective"("directiveId");
+CREATE UNIQUE INDEX "PatientConsentDirective_id_organizationId_patientProfileId_key"
+  ON "PatientConsentDirective"("id", "organizationId", "patientProfileId");
+CREATE INDEX "PatientConsentDirective_organizationId_patientProfileId_sta_idx"
+  ON "PatientConsentDirective"("organizationId", "patientProfileId", "status");
+CREATE INDEX "PatientConsentDirective_expiresAt_idx"
+  ON "PatientConsentDirective"("expiresAt");
+CREATE INDEX "PatientConsentDirective_supersedesDirectiveId_idx"
+  ON "PatientConsentDirective"("supersedesDirectiveId");
+
+CREATE INDEX "AuthorizationDecisionLog_organizationId_patientSubjectPrinc_idx"
+  ON "AuthorizationDecisionLog"(
+    "organizationId", "patientSubjectPrincipalId", "createdAt"
+  );
+CREATE INDEX "AuthorizationDecisionLog_patientAuthorityId_idx"
+  ON "AuthorizationDecisionLog"("patientAuthorityId");
+CREATE INDEX "AuthorizationDecisionLog_patientConsentDirectiveId_idx"
+  ON "AuthorizationDecisionLog"("patientConsentDirectiveId");
+
+ALTER TABLE "PatientProfile"
+  ADD CONSTRAINT "PatientProfile_organizationId_fkey"
+  FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientProfile_principalId_fkey"
+  FOREIGN KEY ("principalId") REFERENCES "Principal"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientProfile_recordedByPrincipalId_fkey"
+  FOREIGN KEY ("recordedByPrincipalId") REFERENCES "Principal"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientProfile_verifiedByPrincipalId_fkey"
+  FOREIGN KEY ("verifiedByPrincipalId") REFERENCES "Principal"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientProfile_mergedIntoPatientProfileId_organizationId_fkey"
+  FOREIGN KEY ("mergedIntoPatientProfileId", "organizationId")
+  REFERENCES "PatientProfile"("id", "organizationId")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "PatientAuthority"
+  ADD CONSTRAINT "PatientAuthority_patientProfileId_organizationId_fkey"
+  FOREIGN KEY ("patientProfileId", "organizationId")
+  REFERENCES "PatientProfile"("id", "organizationId")
+  ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientAuthority_granteePrincipalId_fkey"
+  FOREIGN KEY ("granteePrincipalId") REFERENCES "Principal"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientAuthority_assertedByPrincipalId_fkey"
+  FOREIGN KEY ("assertedByPrincipalId") REFERENCES "Principal"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientAuthority_verifiedByPrincipalId_fkey"
+  FOREIGN KEY ("verifiedByPrincipalId") REFERENCES "Principal"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientAuthority_revokedByPrincipalId_fkey"
+  FOREIGN KEY ("revokedByPrincipalId") REFERENCES "Principal"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientAuthority_supersedesAuthorityId_organizationId_pati_fkey"
+  FOREIGN KEY ("supersedesAuthorityId", "organizationId", "patientProfileId")
+  REFERENCES "PatientAuthority"("id", "organizationId", "patientProfileId")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "PatientConsentDirective"
+  ADD CONSTRAINT "PatientConsentDirective_patientProfileId_organizationId_fkey"
+  FOREIGN KEY ("patientProfileId", "organizationId")
+  REFERENCES "PatientProfile"("id", "organizationId")
+  ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientConsentDirective_assertedByPrincipalId_fkey"
+  FOREIGN KEY ("assertedByPrincipalId") REFERENCES "Principal"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientConsentDirective_verifiedByPrincipalId_fkey"
+  FOREIGN KEY ("verifiedByPrincipalId") REFERENCES "Principal"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientConsentDirective_revokedByPrincipalId_fkey"
+  FOREIGN KEY ("revokedByPrincipalId") REFERENCES "Principal"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "PatientConsentDirective_supersedesDirectiveId_organization_fkey"
+  FOREIGN KEY ("supersedesDirectiveId", "organizationId", "patientProfileId")
+  REFERENCES "PatientConsentDirective"("id", "organizationId", "patientProfileId")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "AuthorizationDecisionLog"
+  ADD CONSTRAINT "AuthorizationDecisionLog_organizationId_fkey"
+  FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "AuthorizationDecisionLog_patientSubjectPrincipalId_fkey"
+  FOREIGN KEY ("patientSubjectPrincipalId") REFERENCES "Principal"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "AuthorizationDecisionLog_patientAuthorityId_fkey"
+  FOREIGN KEY ("patientAuthorityId") REFERENCES "PatientAuthority"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "AuthorizationDecisionLog_patientConsentDirectiveId_fkey"
+  FOREIGN KEY ("patientConsentDirectiveId") REFERENCES "PatientConsentDirective"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Patient-bearing tables fail closed unless both tenant and patient context are
+-- set on the current transaction. Staff and patient repositories must set these
+-- with set_config(..., true) before accessing the tables.
+ALTER TABLE "PatientProfile" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "PatientProfile" FORCE ROW LEVEL SECURITY;
+CREATE POLICY "PatientProfile_context_policy" ON "PatientProfile"
+  USING (
+    "organizationId" = NULLIF(current_setting('app.organization_id', true), '')
+    AND "principalId" = ANY(
+      string_to_array(
+        NULLIF(current_setting('app.patient_principal_ids', true), ''),
+        ','
+      )
+    )
+  )
+  WITH CHECK (
+    "organizationId" = NULLIF(current_setting('app.organization_id', true), '')
+    AND "principalId" = ANY(
+      string_to_array(
+        NULLIF(current_setting('app.patient_principal_ids', true), ''),
+        ','
+      )
+    )
+  );
+
+ALTER TABLE "PatientAuthority" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "PatientAuthority" FORCE ROW LEVEL SECURITY;
+CREATE POLICY "PatientAuthority_context_policy" ON "PatientAuthority"
+  USING (
+    "organizationId" = NULLIF(current_setting('app.organization_id', true), '')
+    AND EXISTS (
+      SELECT 1
+      FROM "PatientProfile" profile
+      WHERE profile."id" = "PatientAuthority"."patientProfileId"
+        AND profile."organizationId" = "PatientAuthority"."organizationId"
+    )
+  )
+  WITH CHECK (
+    "organizationId" = NULLIF(current_setting('app.organization_id', true), '')
+    AND EXISTS (
+      SELECT 1
+      FROM "PatientProfile" profile
+      WHERE profile."id" = "PatientAuthority"."patientProfileId"
+        AND profile."organizationId" = "PatientAuthority"."organizationId"
+    )
+  );
+
+ALTER TABLE "PatientConsentDirective" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "PatientConsentDirective" FORCE ROW LEVEL SECURITY;
+CREATE POLICY "PatientConsentDirective_context_policy"
+  ON "PatientConsentDirective"
+  USING (
+    "organizationId" = NULLIF(current_setting('app.organization_id', true), '')
+    AND EXISTS (
+      SELECT 1
+      FROM "PatientProfile" profile
+      WHERE profile."id" = "PatientConsentDirective"."patientProfileId"
+        AND profile."organizationId" = "PatientConsentDirective"."organizationId"
+    )
+  )
+  WITH CHECK (
+    "organizationId" = NULLIF(current_setting('app.organization_id', true), '')
+    AND EXISTS (
+      SELECT 1
+      FROM "PatientProfile" profile
+      WHERE profile."id" = "PatientConsentDirective"."patientProfileId"
+        AND profile."organizationId" = "PatientConsentDirective"."organizationId"
+    )
+  );

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -60,7 +60,7 @@ model User {
   improvementReviews            ImprovementProposal[]         @relation("ImprovementReviews")
   improvementSubmissions        ImprovementProposal[]         @relation("ImprovementSubmissions")
   notifications                 Notification[]
-  notificationSubscriptions     NotificationSubscription[] @relation("NotificationSubscriptionUser")
+  notificationSubscriptions     NotificationSubscription[]    @relation("NotificationSubscriptionUser")
   requestedPasswordResetTokens  PasswordResetToken[]          @relation("PasswordResetRequestedBy")
   passwordResetTokens           PasswordResetToken[]          @relation("PasswordResetForUser")
   issueReports                  PlatformIssueReport[]
@@ -134,7 +134,7 @@ model CustomerContact {
   // MDM write-time dedup (EP-4A12A7CB WG-1): standardizeName of the display
   // name (firstName+lastName, falling back to legacy name). Fuzzy-alert only —
   // email stays the unique identity key.
-  nameNormalized   String  @default("")
+  nameNormalized   String               @default("")
   phone            String?
   jobTitle         String?
   linkedinUrl      String?
@@ -337,6 +337,17 @@ model Principal {
   ownedDecisionPerspectiveProfiles    DecisionPerspectiveProfile[]        @relation("DecisionPerspectiveProfileOwner")
   promotedDecisionPerspectiveVersions DecisionPerspectiveProfileVersion[] @relation("DecisionPerspectiveProfileVersionPromoter")
   decisionEscalationsResolved         EscalationCapture[]                 @relation("DecisionEscalationResolverPrincipal")
+  patientProfiles                     PatientProfile[]                    @relation("PatientProfileIdentity")
+  patientProfilesRecorded             PatientProfile[]                    @relation("PatientProfileRecorder")
+  patientProfilesVerified             PatientProfile[]                    @relation("PatientProfileVerifier")
+  patientAuthoritiesGranted           PatientAuthority[]                  @relation("PatientAuthorityGrantee")
+  patientAuthoritiesAsserted          PatientAuthority[]                  @relation("PatientAuthorityAsserter")
+  patientAuthoritiesVerified          PatientAuthority[]                  @relation("PatientAuthorityVerifier")
+  patientAuthoritiesRevoked           PatientAuthority[]                  @relation("PatientAuthorityRevoker")
+  patientConsentDirectivesAsserted    PatientConsentDirective[]           @relation("PatientConsentDirectiveAsserter")
+  patientConsentDirectivesVerified    PatientConsentDirective[]           @relation("PatientConsentDirectiveVerifier")
+  patientConsentDirectivesRevoked     PatientConsentDirective[]           @relation("PatientConsentDirectiveRevoker")
+  patientAuthorizationDecisions       AuthorizationDecisionLog[]          @relation("PatientAuthorizationSubject")
   createdAt                           DateTime                            @default(now())
   updatedAt                           DateTime                            @updatedAt
 
@@ -1420,11 +1431,11 @@ model BacklogItemActivity {
 }
 
 model WorkCapsule {
-  id                      String                @id @default(cuid())
-  capsuleId               String                @unique
+  id                      String                   @id @default(cuid())
+  capsuleId               String                   @unique
   title                   String
-  objective               String                @db.Text
-  status                  String                @default("draft")
+  objective               String                   @db.Text
+  status                  String                   @default("draft")
   source                  String
   executorKind            String?
   executorRef             String?
@@ -1438,9 +1449,9 @@ model WorkCapsule {
   portfolioRole           String?
   servedPersona           String?
   activityKind            String?
-  outcomeAnchor           Json                  @default("{}")
-  servesPortfolioRoles    Json                  @default("[]")
-  dependsOnPortfolioRoles Json                  @default("[]")
+  outcomeAnchor           Json                     @default("{}")
+  servesPortfolioRoles    Json                     @default("[]")
+  dependsOnPortfolioRoles Json                     @default("[]")
   repositoryFullName      String?
   baseBranch              String?
   baseSha                 String?
@@ -1451,14 +1462,14 @@ model WorkCapsule {
   pullRequestNumber       Int?
   sandboxProviderId       String?
   sandboxId               String?
-  scopeClaims             Json                  @default("[]")
-  workspaceState          Json                  @default("{}")
-  verificationState       Json                  @default("{}")
-  providerRequirements    Json                  @default("[]")
-  promotionPolicy         Json                  @default("{}")
-  contributionMode        String                @default("private")
+  scopeClaims             Json                     @default("[]")
+  workspaceState          Json                     @default("{}")
+  verificationState       Json                     @default("{}")
+  providerRequirements    Json                     @default("[]")
+  promotionPolicy         Json                     @default("{}")
+  contributionMode        String                   @default("private")
   branchTaxonomy          String?
-  idempotencyKey          String?               @unique
+  idempotencyKey          String?                  @unique
   leaseHolderPrincipalId  String?
   leaseExpiresAt          DateTime?
   createdByPrincipalId    String?
@@ -1466,8 +1477,8 @@ model WorkCapsule {
   // commissioned the work, distinct from the creator/executor. Nullable; the
   // stable human-quotable key already exists as capsuleId (WC-*).
   requestedByPrincipalId  String?
-  createdAt               DateTime              @default(now())
-  updatedAt               DateTime              @updatedAt
+  createdAt               DateTime                 @default(now())
+  updatedAt               DateTime                 @updatedAt
   lastSyncedAt            DateTime?
   archivedAt              DateTime?
   activities              WorkCapsuleActivity[]
@@ -2369,8 +2380,8 @@ model Agent {
   skills               AgentSkillAssignment[]
   toolGrants           AgentToolGrant[]
   toolGrantRevocations AgentToolGrantRevocation[]
-  memoryNotes          CoworkerMemoryNote[]      @relation("CoworkerMemoryNoteAgent")
-  taskGoals            CoworkerTaskGoal[]        @relation("CoworkerTaskGoalAgent")
+  memoryNotes          CoworkerMemoryNote[]        @relation("CoworkerMemoryNoteAgent")
+  taskGoals            CoworkerTaskGoal[]          @relation("CoworkerTaskGoalAgent")
   coworkerServices     CoworkerService[]
   coworkerEngagements  CoworkerEngagement[]
   coworkerAssessments  CoworkerSelfAssessment[]    @relation("CoworkerSelfAssessmentAgent")
@@ -2737,31 +2748,181 @@ model AgentPromptContext {
 }
 
 model AuthorizationDecisionLog {
-  id                  String            @id @default(cuid())
-  decisionId          String            @unique
-  actorType           String
-  actorRef            String
-  humanContextRef     String?
-  agentContextRef     String?
-  delegationGrantId   String?
-  authorityBindingId  String?
-  actionKey           String
-  objectRef           String?
-  decision            String
-  rationale           Json
-  createdAt           DateTime          @default(now())
-  endpointUsed        String?
-  mode                String?
-  routeContext        String?
-  sensitivityLevel    String?
-  sensitivityOverride Boolean?
-  authorityBinding    AuthorityBinding? @relation(fields: [authorityBindingId], references: [id])
-  delegationGrant     DelegationGrant?  @relation(fields: [delegationGrantId], references: [id])
+  id                        String                   @id @default(cuid())
+  decisionId                String                   @unique
+  actorType                 String
+  actorRef                  String
+  humanContextRef           String?
+  agentContextRef           String?
+  delegationGrantId         String?
+  authorityBindingId        String?
+  organizationId            String?
+  patientSubjectPrincipalId String?
+  patientAuthorityId        String?
+  patientConsentDirectiveId String?
+  purposeOfUse              String?
+  policyVersion             String?
+  actionKey                 String
+  objectRef                 String?
+  decision                  String
+  rationale                 Json
+  createdAt                 DateTime                 @default(now())
+  endpointUsed              String?
+  mode                      String?
+  routeContext              String?
+  sensitivityLevel          String?
+  sensitivityOverride       Boolean?
+  authorityBinding          AuthorityBinding?        @relation(fields: [authorityBindingId], references: [id])
+  delegationGrant           DelegationGrant?         @relation(fields: [delegationGrantId], references: [id])
+  organization              Organization?            @relation(fields: [organizationId], references: [id], onDelete: SetNull)
+  patientSubjectPrincipal   Principal?               @relation("PatientAuthorizationSubject", fields: [patientSubjectPrincipalId], references: [id], onDelete: SetNull)
+  patientAuthority          PatientAuthority?        @relation(fields: [patientAuthorityId], references: [id], onDelete: SetNull)
+  patientConsentDirective   PatientConsentDirective? @relation(fields: [patientConsentDirectiveId], references: [id], onDelete: SetNull)
 
   @@index([decision])
   @@index([createdAt])
   @@index([actorRef])
   @@index([authorityBindingId])
+  @@index([organizationId, patientSubjectPrincipalId, createdAt])
+  @@index([patientAuthorityId])
+  @@index([patientConsentDirectiveId])
+}
+
+/// Healthcare patient role attached to canonical Principal identity.
+/// Demographics remain in their owning clinical/identity resource; this model
+/// contains only role, communication, retention, and identity-review state.
+model PatientProfile {
+  id                         String                    @id @default(cuid())
+  patientId                  String                    @unique
+  organizationId             String
+  principalId                String
+  status                     String                    @default("active")
+  minorStatus                String                    @default("unknown")
+  minorStatusAsOf            DateTime?
+  selfAccessAllowed          Boolean                   @default(false)
+  preferredLanguage          String?
+  accessibilityNeeds         Json?
+  communicationPreferences   Json?
+  sourceSystem               String?
+  sourceId                   String?
+  sourceVersion              String?
+  recordedAt                 DateTime                  @default(now())
+  recordedByPrincipalId      String?
+  verifiedAt                 DateTime?
+  verifiedByPrincipalId      String?
+  sensitivityLabels          String[]                  @default([])
+  retentionClass             String?
+  legalHold                  Boolean                   @default(false)
+  mergedIntoPatientProfileId String?
+  enteredInErrorAt           DateTime?
+  createdAt                  DateTime                  @default(now())
+  updatedAt                  DateTime                  @updatedAt
+  organization               Organization              @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+  principal                  Principal                 @relation("PatientProfileIdentity", fields: [principalId], references: [id], onDelete: Restrict)
+  recordedByPrincipal        Principal?                @relation("PatientProfileRecorder", fields: [recordedByPrincipalId], references: [id], onDelete: SetNull)
+  verifiedByPrincipal        Principal?                @relation("PatientProfileVerifier", fields: [verifiedByPrincipalId], references: [id], onDelete: SetNull)
+  mergedIntoPatientProfile   PatientProfile?           @relation("PatientProfileMerge", fields: [mergedIntoPatientProfileId, organizationId], references: [id, organizationId], onDelete: Restrict)
+  mergedPatientProfiles      PatientProfile[]          @relation("PatientProfileMerge")
+  authorities                PatientAuthority[]
+  consentDirectives          PatientConsentDirective[]
+
+  @@unique([organizationId, principalId])
+  @@unique([id, organizationId])
+  @@unique([organizationId, sourceSystem, sourceId])
+  @@index([organizationId, status])
+  @@index([principalId])
+  @@index([mergedIntoPatientProfileId])
+}
+
+/// Effective-dated human relationship authority for a patient. This does not
+/// replace AuthorityBinding, which remains the canonical AI/resource grant.
+model PatientAuthority {
+  id                      String                     @id @default(cuid())
+  authorityId             String                     @unique
+  organizationId          String
+  patientProfileId        String
+  granteePrincipalId      String
+  relationshipType        String
+  status                  String                     @default("proposed")
+  legalBasis              String?
+  purposesOfUse           String[]                   @default([])
+  permittedOperations     String[]                   @default([])
+  recordCategories        String[]                   @default([])
+  locationRefs            String[]                   @default([])
+  scopeJson               Json?
+  evidenceRef             String?
+  effectiveFrom           DateTime
+  expiresAt               DateTime?
+  revokedAt               DateTime?
+  revokedByPrincipalId    String?
+  revocationReason        String?
+  assertedAt              DateTime                   @default(now())
+  assertedByPrincipalId   String
+  verifiedAt              DateTime?
+  verifiedByPrincipalId   String?
+  version                 Int                        @default(1)
+  supersedesAuthorityId   String?
+  createdAt               DateTime                   @default(now())
+  updatedAt               DateTime                   @updatedAt
+  patientProfile          PatientProfile             @relation(fields: [patientProfileId, organizationId], references: [id, organizationId], onDelete: Restrict)
+  granteePrincipal        Principal                  @relation("PatientAuthorityGrantee", fields: [granteePrincipalId], references: [id], onDelete: Restrict)
+  assertedByPrincipal     Principal                  @relation("PatientAuthorityAsserter", fields: [assertedByPrincipalId], references: [id], onDelete: Restrict)
+  verifiedByPrincipal     Principal?                 @relation("PatientAuthorityVerifier", fields: [verifiedByPrincipalId], references: [id], onDelete: SetNull)
+  revokedByPrincipal      Principal?                 @relation("PatientAuthorityRevoker", fields: [revokedByPrincipalId], references: [id], onDelete: SetNull)
+  supersedesAuthority     PatientAuthority?          @relation("PatientAuthorityVersion", fields: [supersedesAuthorityId, organizationId, patientProfileId], references: [id, organizationId, patientProfileId], onDelete: Restrict)
+  supersededByAuthorities PatientAuthority[]         @relation("PatientAuthorityVersion")
+  authorizationDecisions  AuthorizationDecisionLog[]
+
+  @@unique([id, organizationId, patientProfileId])
+  @@index([organizationId, patientProfileId, status])
+  @@index([granteePrincipalId, status])
+  @@index([expiresAt])
+  @@index([supersedesAuthorityId])
+}
+
+/// Versioned patient consent or privacy restriction. A deny directive is
+/// evaluated before ordinary proxy access and may explicitly forbid emergency
+/// override.
+model PatientConsentDirective {
+  id                       String                     @id @default(cuid())
+  directiveId              String                     @unique
+  organizationId           String
+  patientProfileId         String
+  directiveType            String
+  status                   String                     @default("proposed")
+  decision                 String
+  purposesOfUse            String[]                   @default([])
+  operations               String[]                   @default([])
+  recordCategories         String[]                   @default([])
+  legalBasis               String?
+  evidenceRef              String?
+  scopeJson                Json?
+  effectiveFrom            DateTime
+  expiresAt                DateTime?
+  emergencyOverrideAllowed Boolean                    @default(false)
+  revokedAt                DateTime?
+  revokedByPrincipalId     String?
+  revocationReason         String?
+  assertedAt               DateTime                   @default(now())
+  assertedByPrincipalId    String
+  verifiedAt               DateTime?
+  verifiedByPrincipalId    String?
+  version                  Int                        @default(1)
+  supersedesDirectiveId    String?
+  createdAt                DateTime                   @default(now())
+  updatedAt                DateTime                   @updatedAt
+  patientProfile           PatientProfile             @relation(fields: [patientProfileId, organizationId], references: [id, organizationId], onDelete: Restrict)
+  assertedByPrincipal      Principal                  @relation("PatientConsentDirectiveAsserter", fields: [assertedByPrincipalId], references: [id], onDelete: Restrict)
+  verifiedByPrincipal      Principal?                 @relation("PatientConsentDirectiveVerifier", fields: [verifiedByPrincipalId], references: [id], onDelete: SetNull)
+  revokedByPrincipal       Principal?                 @relation("PatientConsentDirectiveRevoker", fields: [revokedByPrincipalId], references: [id], onDelete: SetNull)
+  supersedesDirective      PatientConsentDirective?   @relation("PatientConsentDirectiveVersion", fields: [supersedesDirectiveId, organizationId, patientProfileId], references: [id, organizationId, patientProfileId], onDelete: Restrict)
+  supersededByDirectives   PatientConsentDirective[]  @relation("PatientConsentDirectiveVersion")
+  authorizationDecisions   AuthorizationDecisionLog[]
+
+  @@unique([id, organizationId, patientProfileId])
+  @@index([organizationId, patientProfileId, status])
+  @@index([expiresAt])
+  @@index([supersedesDirectiveId])
 }
 
 model CustomerAccount {
@@ -3303,7 +3464,7 @@ model Quote {
   notes         String?
   // Public accept-link token (mirrors Invoice.payToken): possession authorizes
   // the customer to view and accept this quote at /s/quote/[token].
-  acceptToken String?   @unique
+  acceptToken   String?   @unique
   sentAt        DateTime?
   acceptedAt    DateTime?
   rejectedAt    DateTime?
@@ -3358,8 +3519,8 @@ model SalesOrder {
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
 
-  quote   Quote           @relation(fields: [quoteId], references: [id])
-  account CustomerAccount @relation(fields: [accountId], references: [id])
+  quote        Quote           @relation(fields: [quoteId], references: [id])
+  account      CustomerAccount @relation(fields: [accountId], references: [id])
   subscription Subscription?
 
   @@index([accountId])
@@ -3391,9 +3552,9 @@ model Subscription {
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 
-  account    CustomerAccount @relation(fields: [accountId], references: [id])
-  salesOrder SalesOrder?     @relation(fields: [salesOrderId], references: [id])
-  edgeNodes  EdgeNode[]
+  account         CustomerAccount    @relation(fields: [accountId], references: [id])
+  salesOrder      SalesOrder?        @relation(fields: [salesOrderId], references: [id])
+  edgeNodes       EdgeNode[]
   renewalSchedule RecurringSchedule?
 
   @@index([accountId])
@@ -3485,6 +3646,8 @@ model Organization {
   mediaAssets                   MediaAsset[]
   ledgerAccounts                LedgerAccount[]
   journalEntries                JournalEntry[]
+  patientProfiles               PatientProfile[]
+  patientAuthorizationDecisions AuthorizationDecisionLog[]
 }
 
 // EP-PARTNER-CHANNEL Phase 1b. Generic per-organization opt-in overlay on top of
@@ -7366,42 +7529,42 @@ model CalendarSync {
 }
 
 model Regulation {
-  id               String                 @id @default(cuid())
-  regulationId     String                 @unique
-  name             String
-  shortName        String
-  jurisdiction     String
-  industry         String?
+  id                String                 @id @default(cuid())
+  regulationId      String                 @unique
+  name              String
+  shortName         String
+  jurisdiction      String
+  industry          String?
   // Data-driven applicability spec (RegulationApplicability in
   // regulation-applicability.ts): { basis[], jurisdictions[], archetypes?,
   // listingStatuses? }. When set, the generic evaluator (regulationApplies)
   // classifies this regulation for an install with no per-regulation code —
   // adding a governance requirement is a data operation, not a code change.
   // Null → fall back to the legacy jurisdiction/industry string matcher.
-  applicability    Json?
-  sourceType       String                 @default("external")
-  effectiveDate    DateTime?
-  reviewDate       DateTime?
-  sourceUrl        String?
-  notes            String?
-  agentId          String?
-  status           String                 @default("active")
-  createdAt        DateTime               @default(now())
-  updatedAt        DateTime               @updatedAt
-  changeDetected   Boolean                @default(false)
-  lastKnownVersion String?
-  sourceCheckDate  DateTime?
+  applicability     Json?
+  sourceType        String                 @default("external")
+  effectiveDate     DateTime?
+  reviewDate        DateTime?
+  sourceUrl         String?
+  notes             String?
+  agentId           String?
+  status            String                 @default("active")
+  createdAt         DateTime               @default(now())
+  updatedAt         DateTime               @updatedAt
+  changeDetected    Boolean                @default(false)
+  lastKnownVersion  String?
+  sourceCheckDate   DateTime?
   // Phase 4 — version lineage. `version` increments per governed iteration;
   // `previousVersionId` links a new version to the one it supersedes, so
   // "iterate an existing regulation" is an immutable new version, not a silent
   // in-place mutation. The prior version is retired (status="superseded").
-  version           Int                   @default(1)
+  version           Int                    @default(1)
   previousVersionId String?
-  previousVersion   Regulation?           @relation("RegulationVersions", fields: [previousVersionId], references: [id])
-  nextVersions      Regulation[]          @relation("RegulationVersions")
-  obligations      Obligation[]
-  alerts           RegulatoryAlert[]
-  submissions      RegulatorySubmission[]
+  previousVersion   Regulation?            @relation("RegulationVersions", fields: [previousVersionId], references: [id])
+  nextVersions      Regulation[]           @relation("RegulationVersions")
+  obligations       Obligation[]
+  alerts            RegulatoryAlert[]
+  submissions       RegulatorySubmission[]
 
   @@index([status])
   @@index([jurisdiction])
@@ -7501,10 +7664,10 @@ model ControlObligationLink {
 // commits via the existing create/link actions. `payload` holds the kind-specific
 // proposal; `kind` selects how approval commits it.
 model ComplianceProposal {
-  id                   String    @id @default(cuid())
-  proposalId           String    @unique
+  id                   String   @id @default(cuid())
+  proposalId           String   @unique
   kind                 String // "control-mapping" | "regulation" | "obligation"
-  status               String    @default("pending") // pending | approved | rejected
+  status               String   @default("pending") // pending | approved | rejected
   payload              Json
   rationale            String?
   proposedByAgentId    String?
@@ -7512,8 +7675,8 @@ model ComplianceProposal {
   reviewedByEmployeeId String?
   reviewNotes          String?
   committedEntityId    String?
-  createdAt            DateTime  @default(now())
-  updatedAt            DateTime  @updatedAt
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
 
   @@index([status])
   @@index([kind])
@@ -8663,26 +8826,26 @@ model StorefrontItem {
 }
 
 model StorefrontBooking {
-  id                 String              @id @default(cuid())
-  bookingRef         String              @unique
-  storefrontId       String
-  itemId             String
-  customerContactId  String?
-  customerEmail      String
-  customerName       String
-  customerPhone      String?
-  scheduledAt        DateTime
-  durationMinutes    Int
-  notes              String?
-  status             String              @default("pending")
-  providerId         String?
-  assignmentMode     String?
-  recurrenceRule     String?
-  recurrenceEndDate  DateTime?
-  parentBookingId    String?
-  fromReschedule     String?
-  cancellationReason String?
-  cancelledAt        DateTime?
+  id                   String              @id @default(cuid())
+  bookingRef           String              @unique
+  storefrontId         String
+  itemId               String
+  customerContactId    String?
+  customerEmail        String
+  customerName         String
+  customerPhone        String?
+  scheduledAt          DateTime
+  durationMinutes      Int
+  notes                String?
+  status               String              @default("pending")
+  providerId           String?
+  assignmentMode       String?
+  recurrenceRule       String?
+  recurrenceEndDate    DateTime?
+  parentBookingId      String?
+  fromReschedule       String?
+  cancellationReason   String?
+  cancelledAt          DateTime?
   // EP-056D2A5E / BI-CC4659CB. Set by the booking-overlap-exclusion migration
   // when a PRE-EXISTING overlap is found: the later row of the pair is parked
   // here (not cancelled, not deleted) so the EXCLUDE constraint can land without
@@ -8690,13 +8853,13 @@ model StorefrontBooking {
   // Excluded from the constraint predicate; non-null rows are the operator review
   // queue. New bookings never set this.
   overlapQuarantinedAt DateTime?
-  idempotencyKey     String?             @unique
-  createdAt          DateTime            @default(now())
-  updatedAt          DateTime            @updatedAt
-  storefront         StorefrontConfig    @relation(fields: [storefrontId], references: [id])
-  provider           ServiceProvider?    @relation(fields: [providerId], references: [id])
-  parentBooking      StorefrontBooking?  @relation("BookingRecurrence", fields: [parentBookingId], references: [id])
-  childBookings      StorefrontBooking[] @relation("BookingRecurrence")
+  idempotencyKey       String?             @unique
+  createdAt            DateTime            @default(now())
+  updatedAt            DateTime            @updatedAt
+  storefront           StorefrontConfig    @relation(fields: [storefrontId], references: [id])
+  provider             ServiceProvider?    @relation(fields: [providerId], references: [id])
+  parentBooking        StorefrontBooking?  @relation("BookingRecurrence", fields: [parentBookingId], references: [id])
+  childBookings        StorefrontBooking[] @relation("BookingRecurrence")
 
   @@index([storefrontId, status])
   @@index([customerEmail])
@@ -8830,36 +8993,36 @@ model RentableUnit {
 }
 
 model RentalAgreement {
-  id                  String    @id @default(cuid())
-  agreementRef        String    @unique
-  storefrontId        String
-  storefrontItemId    String
-  rentableUnitId      String? // null for quantity-pool classes
-  customerContactId   String?
-  customerEmail       String
-  customerName        String
-  customerPhone       String?
-  periodStart         DateTime
-  periodEnd           DateTime
-  pricingModel        String    @default("per-day") // per-day|per-week|usage-based|fixed
-  rateAmount          Decimal?
-  depositAmount       Decimal?
-  currency            String    @default("GBP")
-  status              String    @default("reserved") // reserved|verified|active|returned|closed|cancelled
-  verificationStatus  String    @default("not-required") // not-required|pending|verified|failed
-  checkoutConditionId String?   @unique
-  returnConditionId   String?   @unique
-  cancellationReason  String?
-  cancelledAt         DateTime?
+  id                   String    @id @default(cuid())
+  agreementRef         String    @unique
+  storefrontId         String
+  storefrontItemId     String
+  rentableUnitId       String? // null for quantity-pool classes
+  customerContactId    String?
+  customerEmail        String
+  customerName         String
+  customerPhone        String?
+  periodStart          DateTime
+  periodEnd            DateTime
+  pricingModel         String    @default("per-day") // per-day|per-week|usage-based|fixed
+  rateAmount           Decimal?
+  depositAmount        Decimal?
+  currency             String    @default("GBP")
+  status               String    @default("reserved") // reserved|verified|active|returned|closed|cancelled
+  verificationStatus   String    @default("not-required") // not-required|pending|verified|failed
+  checkoutConditionId  String?   @unique
+  returnConditionId    String?   @unique
+  cancellationReason   String?
+  cancelledAt          DateTime?
   // EP-056D2A5E / BI-CC4659CB. See StorefrontBooking.overlapQuarantinedAt — the
   // later row of a pre-existing overlapping pair is parked here (not cancelled,
   // not deleted) so the EXCLUDE constraint can land without destroying customer
   // data. Excluded from the constraint predicate; non-null rows are the operator
   // review queue.
   overlapQuarantinedAt DateTime?
-  idempotencyKey      String?   @unique
-  createdAt           DateTime  @default(now())
-  updatedAt           DateTime  @updatedAt
+  idempotencyKey       String?   @unique
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
 
   storefront        StorefrontConfig        @relation(fields: [storefrontId], references: [id], onDelete: Cascade)
   item              StorefrontItem          @relation(fields: [storefrontItemId], references: [id], onDelete: Cascade)
@@ -9670,11 +9833,11 @@ model RecurringSchedule {
   updatedAt       DateTime  @updatedAt
 
   // The support contract this schedule renews, if it was minted from one.
-  subscriptionId String? @unique
-  account   CustomerAccount     @relation(fields: [accountId], references: [id])
-  createdBy User?               @relation("RecurringScheduleCreations", fields: [createdById], references: [id])
-  subscription Subscription?    @relation(fields: [subscriptionId], references: [id], onDelete: SetNull)
-  lineItems RecurringLineItem[]
+  subscriptionId String?             @unique
+  account        CustomerAccount     @relation(fields: [accountId], references: [id])
+  createdBy      User?               @relation("RecurringScheduleCreations", fields: [createdById], references: [id])
+  subscription   Subscription?       @relation(fields: [subscriptionId], references: [id], onDelete: SetNull)
+  lineItems      RecurringLineItem[]
 
   @@index([accountId])
   @@index([status])
@@ -10603,41 +10766,41 @@ model WorkQueue {
 }
 
 model WorkItem {
-  id                String            @id @default(cuid())
-  itemId            String            @unique @default(cuid())
+  id                String             @id @default(cuid())
+  itemId            String             @unique @default(cuid())
   sourceType        String
   sourceId          String?
   title             String
-  description       String            @db.Text
-  urgency           String            @default("routine")
-  effortClass       String            @default("medium")
+  description       String             @db.Text
+  urgency           String             @default("routine")
+  effortClass       String             @default("medium")
   workerConstraint  Json
   teamId            String?
-  team              ValueStreamTeam?  @relation(fields: [teamId], references: [id])
+  team              ValueStreamTeam?   @relation(fields: [teamId], references: [id])
   queueId           String
-  queue             WorkQueue         @relation(fields: [queueId], references: [id])
-  status            String            @default("queued")
+  queue             WorkQueue          @relation(fields: [queueId], references: [id])
+  status            String             @default("queued")
   assignedToType    String?
   assignedToUserId  String?
-  assignedToUser    User?             @relation("WorkItemAssignee", fields: [assignedToUserId], references: [id])
+  assignedToUser    User?              @relation("WorkItemAssignee", fields: [assignedToUserId], references: [id])
   assignedToAgentId String?
-  assignedToAgent   Agent?            @relation("WorkItemAgent", fields: [assignedToAgentId], references: [id])
+  assignedToAgent   Agent?             @relation("WorkItemAgent", fields: [assignedToAgentId], references: [id])
   assignedThreadId  String?
   claimedAt         DateTime?
   dueAt             DateTime?
   calendarEventId   String?
-  calendarEvent     CalendarEvent?    @relation(fields: [calendarEventId], references: [id])
+  calendarEvent     CalendarEvent?     @relation(fields: [calendarEventId], references: [id])
   evidence          Json?
   parentItemId      String?
-  parentItem        WorkItem?         @relation("WorkItemHierarchy", fields: [parentItemId], references: [id])
-  childItems        WorkItem[]        @relation("WorkItemHierarchy")
+  parentItem        WorkItem?          @relation("WorkItemHierarchy", fields: [parentItemId], references: [id])
+  childItems        WorkItem[]         @relation("WorkItemHierarchy")
   a2aTaskId         String?
   messages          WorkItemMessage[]
   presence          WorkItemPresence[]
   routingDecision   Json?
   completedAt       DateTime?
-  createdAt         DateTime          @default(now())
-  updatedAt         DateTime          @updatedAt
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
 
   @@index([queueId, status])
   @@index([assignedToUserId, status])
@@ -12651,20 +12814,20 @@ model JournalEntry {
 }
 
 model JournalLine {
-  id             String   @id @default(cuid())
-  journalEntryId String
-  accountId      String
+  id                String   @id @default(cuid())
+  journalEntryId    String
+  accountId         String
   // Exactly one of debit/credit is non-zero per line; both stored as non-negative
   // Decimal. The posting service enforces sum(debit) == sum(credit) per entry.
-  debit          Decimal  @default(0)
-  credit         Decimal  @default(0)
-  currency       String   @default("GBP")
-  description    String?
+  debit             Decimal  @default(0)
+  credit            Decimal  @default(0)
+  currency          String   @default("GBP")
+  description       String?
   // Optional analytical dimensions (ACDOCA-style rich line): who the posting relates to.
   customerAccountId String?
   contactId         String?
-  sortOrder      Int      @default(0)
-  createdAt      DateTime @default(now())
+  sortOrder         Int      @default(0)
+  createdAt         DateTime @default(now())
 
   journalEntry JournalEntry  @relation(fields: [journalEntryId], references: [id], onDelete: Cascade)
   account      LedgerAccount @relation(fields: [accountId], references: [id])

--- a/packages/db/src/healthcare-patient-authority-model.test.ts
+++ b/packages/db/src/healthcare-patient-authority-model.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { Prisma } from "../generated/client/client";
+import { prisma } from "./client";
+
+describe("healthcare patient authority Prisma substrate", () => {
+  it("exposes patient role, authority, and consent directive models", () => {
+    expect(Prisma.ModelName.PatientProfile).toBe("PatientProfile");
+    expect(Prisma.ModelName.PatientAuthority).toBe("PatientAuthority");
+    expect(Prisma.ModelName.PatientConsentDirective).toBe(
+      "PatientConsentDirective",
+    );
+    expect(prisma.patientProfile).toBeDefined();
+    expect(prisma.patientAuthority).toBeDefined();
+    expect(prisma.patientConsentDirective).toBeDefined();
+  });
+
+  it("extends authorization decisions with explicit patient context", () => {
+    const where: Prisma.AuthorizationDecisionLogWhereInput = {
+      organizationId: "org-a",
+      patientSubjectPrincipalId: "principal-patient",
+      patientAuthorityId: "authority-row-id",
+      patientConsentDirectiveId: "directive-row-id",
+      purposeOfUse: "patient-support",
+    };
+
+    expect(where).toMatchObject({
+      organizationId: "org-a",
+      patientSubjectPrincipalId: "principal-patient",
+      patientAuthorityId: "authority-row-id",
+      patientConsentDirectiveId: "directive-row-id",
+      purposeOfUse: "patient-support",
+    });
+  });
+});

--- a/packages/db/src/healthcare-patient-authority.test.ts
+++ b/packages/db/src/healthcare-patient-authority.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CONSENT_DIRECTIVE_DECISIONS,
+  CONSENT_DIRECTIVE_STATUSES,
+  CONSENT_DIRECTIVE_TYPES,
+  PATIENT_AUTHORITY_STATUSES,
+  PATIENT_OPERATIONS,
+  PATIENT_PROFILE_STATUSES,
+  PATIENT_RELATIONSHIP_TYPES,
+  evaluatePatientAuthority,
+  resolvePatientAccessRecovery,
+  type PatientAuthorityEvaluationInput,
+} from "./healthcare-patient-authority";
+
+const NOW = new Date("2026-07-16T12:00:00.000Z");
+
+function baseInput(
+  overrides: Partial<PatientAuthorityEvaluationInput> = {},
+): PatientAuthorityEvaluationInput {
+  return {
+    organizationId: "org-a",
+    actorPrincipalId: "principal-proxy",
+    actorType: "human",
+    patient: {
+      patientProfileId: "patient-profile-a",
+      organizationId: "org-a",
+      principalId: "principal-patient",
+      status: "active",
+      isMinor: false,
+      selfAccessAllowed: true,
+    },
+    patientPrincipalId: "principal-patient",
+    purposeOfUse: "patient-support",
+    operation: "view",
+    recordCategory: "appointments",
+    at: NOW,
+    authorities: [
+      {
+        authorityId: "authority-a",
+        organizationId: "org-a",
+        patientProfileId: "patient-profile-a",
+        granteePrincipalId: "principal-proxy",
+        relationshipType: "proxy",
+        status: "active",
+        purposesOfUse: ["patient-support"],
+        permittedOperations: ["view", "schedule"],
+        recordCategories: ["appointments"],
+        effectiveFrom: new Date("2026-01-01T00:00:00.000Z"),
+        expiresAt: new Date("2026-12-31T23:59:59.000Z"),
+        revokedAt: null,
+      },
+    ],
+    directives: [],
+    accessMode: "ordinary",
+    emergencyAccess: null,
+    ...overrides,
+  };
+}
+
+describe("healthcare patient authority vocabularies", () => {
+  it("keeps fixed values closed and hyphenated", () => {
+    expect(PATIENT_PROFILE_STATUSES).toEqual([
+      "active",
+      "inactive",
+      "identity-review",
+      "merged",
+      "entered-in-error",
+    ]);
+    expect(PATIENT_RELATIONSHIP_TYPES).toContain("responsible-party");
+    expect(PATIENT_AUTHORITY_STATUSES).toEqual([
+      "proposed",
+      "active",
+      "expired",
+      "revoked",
+      "entered-in-error",
+    ]);
+    expect(CONSENT_DIRECTIVE_TYPES).toEqual(["consent", "privacy-restriction"]);
+    expect(CONSENT_DIRECTIVE_STATUSES).toEqual(PATIENT_AUTHORITY_STATUSES);
+    expect(CONSENT_DIRECTIVE_DECISIONS).toEqual(["permit", "deny"]);
+    expect(PATIENT_OPERATIONS).toContain("release");
+  });
+});
+
+describe("evaluatePatientAuthority", () => {
+  it("allows an effective proxy only for its explicit patient, purpose, operation, category, and tenant", () => {
+    expect(evaluatePatientAuthority(baseInput())).toMatchObject({
+      effect: "allow",
+      reasonCodes: ["matched-patient-authority"],
+      matchedAuthorityId: "authority-a",
+    });
+  });
+
+  it("denies a cross-tenant request before considering authority", () => {
+    const result = evaluatePatientAuthority(
+      baseInput({ organizationId: "org-b" }),
+    );
+    expect(result).toMatchObject({
+      effect: "deny",
+      reasonCodes: ["cross-tenant"],
+      matchedAuthorityId: null,
+    });
+  });
+
+  it("denies the wrong patient subject", () => {
+    const result = evaluatePatientAuthority(
+      baseInput({ patientPrincipalId: "principal-other-patient" }),
+    );
+    expect(result.effect).toBe("deny");
+    expect(result.reasonCodes).toContain("wrong-patient-subject");
+  });
+
+  it.each([
+    ["identity-review", "identity-review-required"],
+    ["merged", "patient-profile-merged"],
+    ["entered-in-error", "patient-profile-unavailable"],
+    ["inactive", "patient-profile-unavailable"],
+  ] as const)("denies patient status %s", (status, reason) => {
+    const input = baseInput({
+      patient: { ...baseInput().patient, status },
+    });
+    expect(evaluatePatientAuthority(input)).toMatchObject({
+      effect: "deny",
+      reasonCodes: [reason],
+    });
+  });
+
+  it.each([
+    {
+      title: "expired",
+      authority: { expiresAt: new Date("2026-07-15T00:00:00.000Z") },
+      reason: "authority-expired",
+    },
+    {
+      title: "revoked",
+      authority: { status: "revoked" as const, revokedAt: NOW },
+      reason: "authority-revoked",
+    },
+    {
+      title: "wrong purpose",
+      input: { purposeOfUse: "treatment" },
+      reason: "purpose-not-authorized",
+    },
+    {
+      title: "wrong operation",
+      input: { operation: "release" as const },
+      reason: "operation-not-authorized",
+    },
+    {
+      title: "wrong record category",
+      input: { recordCategory: "sensitive-result" },
+      reason: "record-category-not-authorized",
+    },
+  ])("denies $title proxy authority", ({ authority, input, reason }) => {
+    const original = baseInput();
+    const result = evaluatePatientAuthority(
+      baseInput({
+        ...input,
+        authorities: [
+          {
+            ...original.authorities[0]!,
+            ...authority,
+          },
+        ],
+      }),
+    );
+    expect(result.effect).toBe("deny");
+    expect(result.reasonCodes).toContain(reason);
+  });
+
+  it("lets an adult patient access their own subject without inventing a proxy relationship", () => {
+    const result = evaluatePatientAuthority(
+      baseInput({
+        actorPrincipalId: "principal-patient",
+        authorities: [],
+      }),
+    );
+    expect(result).toMatchObject({
+      effect: "allow",
+      reasonCodes: ["patient-self-access"],
+      matchedAuthorityId: null,
+    });
+  });
+
+  it("denies minor self-access until the jurisdiction profile permits it", () => {
+    const input = baseInput({
+      actorPrincipalId: "principal-patient",
+      authorities: [],
+      patient: {
+        ...baseInput().patient,
+        isMinor: true,
+        selfAccessAllowed: false,
+      },
+    });
+    expect(evaluatePatientAuthority(input)).toMatchObject({
+      effect: "deny",
+      reasonCodes: ["minor-jurisdiction-review-required"],
+    });
+  });
+
+  it("applies an active privacy restriction before ordinary proxy access", () => {
+    const input = baseInput({
+      directives: [
+        {
+          directiveId: "restriction-a",
+          organizationId: "org-a",
+          patientProfileId: "patient-profile-a",
+          directiveType: "privacy-restriction",
+          status: "active",
+          decision: "deny",
+          purposesOfUse: ["patient-support"],
+          operations: ["view"],
+          recordCategories: ["appointments"],
+          effectiveFrom: new Date("2026-01-01T00:00:00.000Z"),
+          expiresAt: null,
+          revokedAt: null,
+          emergencyOverrideAllowed: false,
+        },
+      ],
+    });
+    expect(evaluatePatientAuthority(input)).toMatchObject({
+      effect: "deny",
+      reasonCodes: ["active-privacy-restriction"],
+      matchedDirectiveIds: ["restriction-a"],
+    });
+  });
+
+  it("never treats a generic staff override as patient authority", () => {
+    const result = evaluatePatientAuthority(
+      baseInput({ accessMode: "staff-override", authorities: [] }),
+    );
+    expect(result).toMatchObject({
+      effect: "deny",
+      reasonCodes: ["staff-override-not-authorized"],
+      obligations: ["staff-assisted-recovery"],
+    });
+  });
+
+  it.each(["agent", "service"] as const)(
+    "does not let a %s principal inherit human proxy authority",
+    (actorType) => {
+      const result = evaluatePatientAuthority(
+        baseInput({ actorType }),
+      );
+      expect(result).toMatchObject({
+        effect: "deny",
+        reasonCodes: ["patient-authority-human-only"],
+      });
+    },
+  );
+
+  it("allows patient-specific, human-only, declared and unexpired emergency access", () => {
+    const result = evaluatePatientAuthority(
+      baseInput({
+        actorPrincipalId: "principal-clinician",
+        authorities: [],
+        accessMode: "emergency",
+        purposeOfUse: "emergency-treatment",
+        recordCategory: "allergies",
+        emergencyAccess: {
+          emergencyAccessId: "emergency-a",
+          organizationId: "org-a",
+          patientProfileId: "patient-profile-a",
+          actorPrincipalId: "principal-clinician",
+          actorType: "human",
+          declaredReason: "Patient is unconscious and allergy status is required.",
+          permittedOperations: ["view"],
+          expiresAt: new Date("2026-07-16T12:15:00.000Z"),
+        },
+      }),
+    );
+    expect(result).toMatchObject({
+      effect: "allow",
+      reasonCodes: ["emergency-access"],
+      obligations: ["minimum-necessary", "notify-privacy", "retrospective-review"],
+    });
+  });
+
+  it.each(["agent", "service"] as const)(
+    "denies emergency access to %s actors",
+    (actorType) => {
+      const result = evaluatePatientAuthority(
+        baseInput({
+          actorPrincipalId: "non-human-actor",
+          actorType,
+          authorities: [],
+          accessMode: "emergency",
+          emergencyAccess: {
+            emergencyAccessId: "emergency-a",
+            organizationId: "org-a",
+            patientProfileId: "patient-profile-a",
+            actorPrincipalId: "non-human-actor",
+            actorType,
+            declaredReason: "urgent",
+            permittedOperations: ["view"],
+            expiresAt: new Date("2026-07-16T12:15:00.000Z"),
+          },
+        }),
+      );
+      expect(result.effect).toBe("deny");
+      expect(result.reasonCodes).toContain("emergency-human-only");
+    },
+  );
+
+  it("does not let emergency access delete or export patient data", () => {
+    const input = baseInput({
+      actorPrincipalId: "principal-clinician",
+      authorities: [],
+      accessMode: "emergency",
+      operation: "delete",
+      emergencyAccess: {
+        emergencyAccessId: "emergency-a",
+        organizationId: "org-a",
+        patientProfileId: "patient-profile-a",
+        actorPrincipalId: "principal-clinician",
+        actorType: "human",
+        declaredReason: "Patient safety requires immediate clinical access.",
+        permittedOperations: ["delete"],
+        expiresAt: new Date("2026-07-16T12:15:00.000Z"),
+      },
+    });
+    expect(evaluatePatientAuthority(input)).toMatchObject({
+      effect: "deny",
+      reasonCodes: ["emergency-operation-prohibited"],
+    });
+  });
+});
+
+describe("resolvePatientAccessRecovery", () => {
+  it("defines staff-assisted and self-service paths without overriding authority", () => {
+    expect(resolvePatientAccessRecovery(["identity-review-required"])).toEqual({
+      selfServiceActions: [],
+      staffAssistedActions: ["verify-identity", "resolve-duplicate"],
+    });
+    expect(resolvePatientAccessRecovery(["authority-revoked"])).toEqual({
+      selfServiceActions: ["request-new-authority"],
+      staffAssistedActions: ["review-authority-evidence"],
+    });
+  });
+});

--- a/packages/db/src/healthcare-patient-authority.ts
+++ b/packages/db/src/healthcare-patient-authority.ts
@@ -1,0 +1,454 @@
+export const PATIENT_PROFILE_STATUSES = [
+  "active",
+  "inactive",
+  "identity-review",
+  "merged",
+  "entered-in-error",
+] as const;
+export type PatientProfileStatus = (typeof PATIENT_PROFILE_STATUSES)[number];
+
+export const PATIENT_RELATIONSHIP_TYPES = [
+  "guardian",
+  "caregiver",
+  "household-member",
+  "emergency-contact",
+  "responsible-party",
+  "proxy",
+] as const;
+export type PatientRelationshipType =
+  (typeof PATIENT_RELATIONSHIP_TYPES)[number];
+
+export const PATIENT_AUTHORITY_STATUSES = [
+  "proposed",
+  "active",
+  "expired",
+  "revoked",
+  "entered-in-error",
+] as const;
+export type PatientAuthorityStatus =
+  (typeof PATIENT_AUTHORITY_STATUSES)[number];
+
+export const CONSENT_DIRECTIVE_TYPES = [
+  "consent",
+  "privacy-restriction",
+] as const;
+export type ConsentDirectiveType =
+  (typeof CONSENT_DIRECTIVE_TYPES)[number];
+
+export const CONSENT_DIRECTIVE_STATUSES = PATIENT_AUTHORITY_STATUSES;
+export type ConsentDirectiveStatus = PatientAuthorityStatus;
+
+export const CONSENT_DIRECTIVE_DECISIONS = ["permit", "deny"] as const;
+export type ConsentDirectiveDecision =
+  (typeof CONSENT_DIRECTIVE_DECISIONS)[number];
+
+export const PATIENT_OPERATIONS = [
+  "view",
+  "create",
+  "amend",
+  "release",
+  "export",
+  "delete",
+  "schedule",
+  "communicate",
+  "pay",
+] as const;
+export type PatientOperation = (typeof PATIENT_OPERATIONS)[number];
+
+export const PATIENT_AUTHORITY_REASON_CODES = [
+  "matched-patient-authority",
+  "patient-self-access",
+  "emergency-access",
+  "cross-tenant",
+  "wrong-patient-subject",
+  "identity-review-required",
+  "patient-profile-merged",
+  "patient-profile-unavailable",
+  "minor-jurisdiction-review-required",
+  "authority-not-found",
+  "authority-not-active",
+  "authority-not-effective",
+  "authority-expired",
+  "authority-revoked",
+  "purpose-not-authorized",
+  "operation-not-authorized",
+  "record-category-not-authorized",
+  "active-privacy-restriction",
+  "patient-authority-human-only",
+  "staff-override-not-authorized",
+  "emergency-context-mismatch",
+  "emergency-human-only",
+  "emergency-reason-required",
+  "emergency-expired",
+  "emergency-operation-not-authorized",
+  "emergency-operation-prohibited",
+] as const;
+export type PatientAuthorityReasonCode =
+  (typeof PATIENT_AUTHORITY_REASON_CODES)[number];
+
+export type PatientProfileAuthorityView = {
+  patientProfileId: string;
+  organizationId: string;
+  principalId: string;
+  status: PatientProfileStatus;
+  isMinor: boolean;
+  selfAccessAllowed: boolean;
+};
+
+export type PatientAuthorityView = {
+  authorityId: string;
+  organizationId: string;
+  patientProfileId: string;
+  granteePrincipalId: string;
+  relationshipType: PatientRelationshipType;
+  status: PatientAuthorityStatus;
+  purposesOfUse: string[];
+  permittedOperations: PatientOperation[];
+  recordCategories: string[];
+  effectiveFrom: Date;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+};
+
+export type PatientConsentDirectiveView = {
+  directiveId: string;
+  organizationId: string;
+  patientProfileId: string;
+  directiveType: ConsentDirectiveType;
+  status: ConsentDirectiveStatus;
+  decision: ConsentDirectiveDecision;
+  purposesOfUse: string[];
+  operations: PatientOperation[];
+  recordCategories: string[];
+  effectiveFrom: Date;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+  emergencyOverrideAllowed: boolean;
+};
+
+export type EmergencyPatientAccess = {
+  emergencyAccessId: string;
+  organizationId: string;
+  patientProfileId: string;
+  actorPrincipalId: string;
+  actorType: "human" | "agent" | "service";
+  declaredReason: string;
+  permittedOperations: PatientOperation[];
+  expiresAt: Date;
+};
+
+export type PatientAuthorityEvaluationInput = {
+  organizationId: string;
+  actorPrincipalId: string;
+  actorType: "human" | "agent" | "service";
+  patient: PatientProfileAuthorityView;
+  patientPrincipalId: string;
+  purposeOfUse: string;
+  operation: PatientOperation;
+  recordCategory: string;
+  at: Date;
+  authorities: PatientAuthorityView[];
+  directives: PatientConsentDirectiveView[];
+  accessMode: "ordinary" | "staff-override" | "emergency";
+  emergencyAccess: EmergencyPatientAccess | null;
+};
+
+export type PatientAuthorityDecision = {
+  effect: "allow" | "deny";
+  reasonCodes: PatientAuthorityReasonCode[];
+  matchedAuthorityId: string | null;
+  matchedDirectiveIds: string[];
+  emergencyAccessId: string | null;
+  obligations: string[];
+};
+
+function deny(
+  reasonCodes: PatientAuthorityReasonCode[],
+  options: Partial<
+    Pick<
+      PatientAuthorityDecision,
+      | "matchedAuthorityId"
+      | "matchedDirectiveIds"
+      | "emergencyAccessId"
+      | "obligations"
+    >
+  > = {},
+): PatientAuthorityDecision {
+  return {
+    effect: "deny",
+    reasonCodes,
+    matchedAuthorityId: options.matchedAuthorityId ?? null,
+    matchedDirectiveIds: options.matchedDirectiveIds ?? [],
+    emergencyAccessId: options.emergencyAccessId ?? null,
+    obligations: options.obligations ?? [],
+  };
+}
+
+function isEffective(
+  effectiveFrom: Date,
+  expiresAt: Date | null,
+  at: Date,
+): boolean {
+  return effectiveFrom.getTime() <= at.getTime()
+    && (expiresAt === null || expiresAt.getTime() > at.getTime());
+}
+
+function scopeIncludes(values: readonly string[], requested: string): boolean {
+  return values.includes("*") || values.includes(requested);
+}
+
+function matchingDirective(
+  directive: PatientConsentDirectiveView,
+  input: PatientAuthorityEvaluationInput,
+): boolean {
+  return directive.organizationId === input.organizationId
+    && directive.patientProfileId === input.patient.patientProfileId
+    && directive.status === "active"
+    && directive.revokedAt === null
+    && isEffective(directive.effectiveFrom, directive.expiresAt, input.at)
+    && scopeIncludes(directive.purposesOfUse, input.purposeOfUse)
+    && scopeIncludes(directive.operations, input.operation)
+    && scopeIncludes(directive.recordCategories, input.recordCategory);
+}
+
+function evaluateEmergencyAccess(
+  input: PatientAuthorityEvaluationInput,
+): PatientAuthorityDecision {
+  const emergency = input.emergencyAccess;
+  if (
+    emergency === null
+    || emergency.organizationId !== input.organizationId
+    || emergency.patientProfileId !== input.patient.patientProfileId
+    || emergency.actorPrincipalId !== input.actorPrincipalId
+  ) {
+    return deny(["emergency-context-mismatch"]);
+  }
+  if (input.actorType !== "human" || emergency.actorType !== "human") {
+    return deny(["emergency-human-only"], {
+      emergencyAccessId: emergency.emergencyAccessId,
+    });
+  }
+  if (emergency.declaredReason.trim().length < 8) {
+    return deny(["emergency-reason-required"], {
+      emergencyAccessId: emergency.emergencyAccessId,
+    });
+  }
+  if (emergency.expiresAt.getTime() <= input.at.getTime()) {
+    return deny(["emergency-expired"], {
+      emergencyAccessId: emergency.emergencyAccessId,
+    });
+  }
+  if (input.operation === "delete" || input.operation === "export") {
+    return deny(["emergency-operation-prohibited"], {
+      emergencyAccessId: emergency.emergencyAccessId,
+    });
+  }
+  if (!scopeIncludes(emergency.permittedOperations, input.operation)) {
+    return deny(["emergency-operation-not-authorized"], {
+      emergencyAccessId: emergency.emergencyAccessId,
+    });
+  }
+
+  const blockingRestrictions = input.directives.filter(
+    (directive) =>
+      matchingDirective(directive, input)
+      && directive.decision === "deny"
+      && !directive.emergencyOverrideAllowed,
+  );
+  if (blockingRestrictions.length > 0) {
+    return deny(["active-privacy-restriction"], {
+      emergencyAccessId: emergency.emergencyAccessId,
+      matchedDirectiveIds: blockingRestrictions.map(
+        (directive) => directive.directiveId,
+      ),
+    });
+  }
+
+  return {
+    effect: "allow",
+    reasonCodes: ["emergency-access"],
+    matchedAuthorityId: null,
+    matchedDirectiveIds: [],
+    emergencyAccessId: emergency.emergencyAccessId,
+    obligations: [
+      "minimum-necessary",
+      "notify-privacy",
+      "retrospective-review",
+    ],
+  };
+}
+
+function explainAuthorityMismatch(
+  authority: PatientAuthorityView,
+  input: PatientAuthorityEvaluationInput,
+): PatientAuthorityReasonCode {
+  if (authority.revokedAt !== null || authority.status === "revoked") {
+    return "authority-revoked";
+  }
+  if (
+    authority.status === "expired"
+    || (
+      authority.expiresAt !== null
+      && authority.expiresAt.getTime() <= input.at.getTime()
+    )
+  ) {
+    return "authority-expired";
+  }
+  if (authority.status !== "active") return "authority-not-active";
+  if (authority.effectiveFrom.getTime() > input.at.getTime()) {
+    return "authority-not-effective";
+  }
+  if (!scopeIncludes(authority.purposesOfUse, input.purposeOfUse)) {
+    return "purpose-not-authorized";
+  }
+  if (!scopeIncludes(authority.permittedOperations, input.operation)) {
+    return "operation-not-authorized";
+  }
+  if (!scopeIncludes(authority.recordCategories, input.recordCategory)) {
+    return "record-category-not-authorized";
+  }
+  return "authority-not-found";
+}
+
+export function evaluatePatientAuthority(
+  input: PatientAuthorityEvaluationInput,
+): PatientAuthorityDecision {
+  if (
+    input.organizationId !== input.patient.organizationId
+    || input.authorities.some(
+      (authority) =>
+        authority.patientProfileId === input.patient.patientProfileId
+        && authority.organizationId !== input.organizationId,
+    )
+  ) {
+    return deny(["cross-tenant"]);
+  }
+  if (input.patientPrincipalId !== input.patient.principalId) {
+    return deny(["wrong-patient-subject"]);
+  }
+  if (input.patient.status === "identity-review") {
+    return deny(["identity-review-required"], {
+      obligations: ["staff-assisted-recovery"],
+    });
+  }
+  if (input.patient.status === "merged") {
+    return deny(["patient-profile-merged"], {
+      obligations: ["resolve-surviving-patient"],
+    });
+  }
+  if (input.patient.status !== "active") {
+    return deny(["patient-profile-unavailable"]);
+  }
+  if (input.accessMode === "staff-override") {
+    return deny(["staff-override-not-authorized"], {
+      obligations: ["staff-assisted-recovery"],
+    });
+  }
+  if (input.accessMode === "emergency") {
+    return evaluateEmergencyAccess(input);
+  }
+  if (input.actorType !== "human") {
+    return deny(["patient-authority-human-only"], {
+      obligations: ["evaluate-authority-binding"],
+    });
+  }
+
+  const restrictions = input.directives.filter(
+    (directive) =>
+      matchingDirective(directive, input)
+      && directive.decision === "deny",
+  );
+  if (restrictions.length > 0) {
+    return deny(["active-privacy-restriction"], {
+      matchedDirectiveIds: restrictions.map(
+        (directive) => directive.directiveId,
+      ),
+    });
+  }
+
+  if (input.actorPrincipalId === input.patient.principalId) {
+    if (input.patient.isMinor && !input.patient.selfAccessAllowed) {
+      return deny(["minor-jurisdiction-review-required"], {
+        obligations: ["staff-assisted-recovery"],
+      });
+    }
+    return {
+      effect: "allow",
+      reasonCodes: ["patient-self-access"],
+      matchedAuthorityId: null,
+      matchedDirectiveIds: [],
+      emergencyAccessId: null,
+      obligations: ["record-access-decision"],
+    };
+  }
+
+  const actorAuthorities = input.authorities.filter(
+    (authority) =>
+      authority.organizationId === input.organizationId
+      && authority.patientProfileId === input.patient.patientProfileId
+      && authority.granteePrincipalId === input.actorPrincipalId,
+  );
+  const matchedAuthority = actorAuthorities.find(
+    (authority) =>
+      authority.status === "active"
+      && authority.revokedAt === null
+      && isEffective(authority.effectiveFrom, authority.expiresAt, input.at)
+      && scopeIncludes(authority.purposesOfUse, input.purposeOfUse)
+      && scopeIncludes(authority.permittedOperations, input.operation)
+      && scopeIncludes(authority.recordCategories, input.recordCategory),
+  );
+  if (matchedAuthority) {
+    return {
+      effect: "allow",
+      reasonCodes: ["matched-patient-authority"],
+      matchedAuthorityId: matchedAuthority.authorityId,
+      matchedDirectiveIds: [],
+      emergencyAccessId: null,
+      obligations: ["record-access-decision"],
+    };
+  }
+
+  return deny([
+    actorAuthorities.length === 0
+      ? "authority-not-found"
+      : explainAuthorityMismatch(actorAuthorities[0]!, input),
+  ]);
+}
+
+export type PatientAccessRecovery = {
+  selfServiceActions: string[];
+  staffAssistedActions: string[];
+};
+
+export function resolvePatientAccessRecovery(
+  reasonCodes: PatientAuthorityReasonCode[],
+): PatientAccessRecovery {
+  if (reasonCodes.includes("identity-review-required")) {
+    return {
+      selfServiceActions: [],
+      staffAssistedActions: ["verify-identity", "resolve-duplicate"],
+    };
+  }
+  if (
+    reasonCodes.includes("authority-revoked")
+    || reasonCodes.includes("authority-expired")
+  ) {
+    return {
+      selfServiceActions: ["request-new-authority"],
+      staffAssistedActions: ["review-authority-evidence"],
+    };
+  }
+  if (
+    reasonCodes.includes("authority-not-found")
+    || reasonCodes.includes("minor-jurisdiction-review-required")
+  ) {
+    return {
+      selfServiceActions: ["request-authority-review"],
+      staffAssistedActions: ["verify-identity", "review-authority-evidence"],
+    };
+  }
+  return {
+    selfServiceActions: [],
+    staffAssistedActions: ["contact-practice"],
+  };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,6 +5,7 @@ export { prisma } from "./client";
 export { Prisma } from "../generated/client/client";
 export type { PrismaClient } from "../generated/client/client";
 export { WriteGateRequirement } from "../generated/client/client";
+export * from "./healthcare-patient-authority";
 
 // Qdrant vector database
 export {


### PR DESCRIPTION
## Summary

- Add organization-scoped patient role records on canonical `Principal` identity; no duplicate demographic master.
- Add effective-dated human guardian/proxy authority and versioned consent/privacy restrictions with tenant- and patient-safe foreign keys, fail-closed RLS, retention-safe deletion, and human-only enforcement.
- Extend `AuthorizationDecisionLog` with patient context and provide one transaction-scoped repository that evaluates and records every allow/deny decision.
- Add deterministic recovery and emergency-access rules plus EA mirror allocation.

Linked: BI-HEALTHCARE-004 · EP-HEALTHCARE-PRACTICE

## Verification

- [x] Red-green domain and model tests: 26 passing
- [x] Repository and EA allocation tests: 16 passing
- [x] DB and web typechecks: clean
- [x] Migration safety guard and Prisma schema validation: pass
- [x] Governed merged-code sandbox: all 392 migrations applied; healthcare migration applied cleanly
- [x] Full web suite: 1,906 files passed, 16,429 tests passed
- [x] Merged production build: pass
- [x] UX verification: not applicable; this PR is data/policy/repository substrate with no route or UI change

## Architecture notes

- `AuthorityBinding` remains the AI/resource grant authority; non-human actors cannot inherit a patient human proxy relationship.
- `ComplianceAuditLog` and `AuthorizationDecisionLog` remain the shared evidence authorities; no healthcare-only audit island was introduced.
- Merge and supersession links are composite-constrained to one organization and patient.

## Delivery checks

- One concern, one signed commit.
- Open-PR and recent-main overlap sweep found no competing healthcare patient-authority implementation.
- Local-CI evidence record: `cmro1ylkq008601tbvhkokq52`.
