### PR TITLE
feat(assurance): add no-seventh-finding-table guard (BI-REFACTOR-CC46703A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,26 @@ jobs:
       - name: Run guard
         run: node scripts/check-module-size.mjs
 
+  finding-substrate-guard:
+    name: Finding Substrate Guard
+    runs-on: ubuntu-latest
+    # BI-REFACTOR-CC46703A — the "no-seventh-finding-table guard". The Assurance
+    # Ledger spec (§3.3) froze the finding substrate after AssuranceFinding became
+    # the seventh finding-shaped model. Until the founder Phase-2 unify decision
+    # lands, this ratchet fails CI if an eighth finding-shaped model (name ending
+    # in Finding/Issue/Report, outside the curated allowlist) is added without a
+    # decision. Guard owner: founder (markbodman), dated 2026-07-16.
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+      - name: Drift-guard — guard self-test mirrors the frozen substrate
+        run: node --test scripts/check-finding-substrate.test.mjs
+      - name: Run guard
+        run: node scripts/check-finding-substrate.mjs
+
   docs-staleness-detector:
     name: Docs Staleness Detector
     runs-on: ubuntu-latest

--- a/docs/superpowers/specs/2026-05-21-supply-chain-and-desired-state-assurance-design.md
+++ b/docs/superpowers/specs/2026-05-21-supply-chain-and-desired-state-assurance-design.md
@@ -168,6 +168,18 @@ the Phase 2 critical path.
 This reconciliation is not optional and must not be papered over. The §2.3 #5 principle should
 read "one finding substrate" as a stated direction; the schema does not yet honor it.
 
+**Dated owner + no-seventh-finding-table guard (2026-07-16).** Phase 1 landed `AssuranceFinding`
+as the seventh finding-shaped model, so the §3.3 fallback now applies: the finding substrate is
+frozen behind an explicit **dated owner — founder (markbodman), 2026-07-16** — pending the Phase-2
+unify vs. keep decision (BI-REFACTOR-CC46703A). The decision-free half of that fallback is now
+enforced in CI by `scripts/check-finding-substrate.mjs` (the "Finding Substrate Guard" job): it
+freezes the seven known finding-shaped models — `PortfolioQualityIssue`, `AuditFinding`,
+`WikiLintFinding`, `EaConformanceIssue`, `LicenseReadinessIssue`, `PlatformIssueReport`,
+`AssuranceFinding` — and fails CI if an eighth (any new model whose name ends in
+`Finding`/`Issue`/`Report`, outside the curated allowlist) is added without a recorded decision.
+The guard does NOT make the unify decision; it prevents further drift while that founder-reserved
+call is open.
+
 ---
 
 ## 4. Goals

--- a/scripts/check-finding-substrate.mjs
+++ b/scripts/check-finding-substrate.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * BI-REFACTOR-CC46703A — CI ratchet: the "no-seventh-finding-table guard".
+ *
+ * The architect-reviewed Assurance Ledger spec
+ * (docs/superpowers/specs/2026-05-21-supply-chain-and-desired-state-assurance-design.md
+ * §3.3) identified six existing finding-shaped models with overlapping
+ * lifecycle semantics, then Phase 1 landed a seventh (`AssuranceFinding`).
+ * The spec's exit criterion (§3.3, §9) requires that before ANY further
+ * finding-shaped model is introduced, Phase 2 must EITHER unify
+ * `AssuranceFinding` with `AuditFinding` (extract a shared `Finding` base)
+ * OR carry an explicit dated owner and a no-seventh-finding-table guard.
+ *
+ * The unify decision is a founder-reserved architecture call and is NOT made
+ * here. This script is the GUARD half of that fallback: it freezes the known
+ * set of finding-shaped models and fails CI when a NEW one is added without an
+ * explicit decision. It mirrors DPF's existing ratchet pattern
+ * (scripts/check-module-size.mjs + baseline, scripts/check-no-local-isrecord.mjs).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Guard owner / dated-deferral (spec §3.3 fallback):
+ *   Owner:  founder (markbodman)
+ *   Dated:  2026-07-16
+ *   State:  Phase-2 finding-substrate unify decision PENDING. Until it lands,
+ *           this guard is the sanctioned "no-seventh-finding-table" backstop
+ *           per BI-REFACTOR-CC46703A. It prevents an EIGHTH finding table from
+ *           silently landing while the unify vs. keep decision is open.
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * How it works: parse packages/db/prisma/schema.prisma for `model <Name> {`
+ * declarations, flag any model whose name matches the finding-shape suffix
+ * (`Finding` | `Issue` | `Report`) that is NOT in the explicit ALLOWLIST.
+ * The allowlist is curated (not a pure heuristic) so unrelated suffix
+ * collisions don't false-positive — those live in SUFFIX_COLLISION_EXCLUSIONS.
+ *
+ * Run: node scripts/check-finding-substrate.mjs
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = join(SCRIPTS_DIR, "..");
+export const SCHEMA_PATH = "packages/db/prisma/schema.prisma";
+
+// The frozen set of finding-shaped models — the six named in spec §3.3 plus
+// the seventh (AssuranceFinding) that Phase 1 landed. One comment per entry
+// naming what each carries. A NEW model whose name ends in Finding/Issue/Report
+// that is NOT here fails the guard: either unify it into AuditFinding, or, if a
+// new table is genuinely justified, add it here AND record the decision per
+// BI-REFACTOR-CC46703A / Assurance Ledger spec §3.3.
+export const ALLOWLIST = new Set([
+  "PortfolioQualityIssue", // Portfolio quality reports (severity/status/ownership/affected object)
+  "AuditFinding", // Compliance audit findings (status/severity/evidence link/control linkage)
+  "WikiLintFinding", // Wiki/documentation lint findings (status/severity/normalized run output)
+  "EaConformanceIssue", // Enterprise-architecture conformance issues (severity/owner/lifecycle)
+  "LicenseReadinessIssue", // Licensing-readiness issues (severity/status/evidence)
+  "PlatformIssueReport", // Cross-platform issue intake (status/owner/severity)
+  "AssuranceFinding", // Supply-chain + fleet assurance findings — Phase 1, the seventh (spec §5)
+]);
+
+// Models whose name ENDS in a finding suffix but which are NOT part of the
+// finding substrate the spec §3.3 governs. These are genuine naming collisions
+// and are intentionally excluded so the guard stays precise. Grep-verified
+// against schema.prisma; add here (with a reason) only for a real collision.
+export const SUFFIX_COLLISION_EXCLUSIONS = new Set([
+  // Tax-obligation issue tied to OrganizationTaxProfile / TaxRegistration —
+  // a tax-domain compliance record, not a discovery/audit/assurance finding.
+  "TaxIssue",
+]);
+
+// A finding-shape suffix: the naming convention every finding-shaped model in
+// the schema follows.
+export const FINDING_SUFFIX_RE = /(?:Finding|Issue|Report)$/;
+
+/** Every `model <Name> {` declaration name in a Prisma schema string. */
+export function extractModelNames(schema) {
+  const names = [];
+  const re = /^\s*model\s+([A-Za-z_]\w*)\s*\{/gm;
+  let m;
+  while ((m = re.exec(schema)) !== null) names.push(m[1]);
+  return names;
+}
+
+/**
+ * Names in `schema` that look finding-shaped (suffix match) but are neither in
+ * the ALLOWLIST nor the SUFFIX_COLLISION_EXCLUSIONS — i.e. a new finding-shaped
+ * table that slipped in without a decision. Pure function of the schema string.
+ */
+export function findFindingShapedViolations(schema) {
+  return extractModelNames(schema).filter(
+    (name) =>
+      FINDING_SUFFIX_RE.test(name) &&
+      !ALLOWLIST.has(name) &&
+      !SUFFIX_COLLISION_EXCLUSIONS.has(name),
+  );
+}
+
+/** ALLOWLIST entries no longer present in the schema (unified/removed → prune). */
+export function findStaleAllowlist(schema) {
+  const present = new Set(extractModelNames(schema));
+  return [...ALLOWLIST].filter((name) => !present.has(name));
+}
+
+/** SUFFIX_COLLISION_EXCLUSIONS entries no longer present in the schema. */
+export function findStaleExclusions(schema) {
+  const present = new Set(extractModelNames(schema));
+  return [...SUFFIX_COLLISION_EXCLUSIONS].filter((name) => !present.has(name));
+}
+
+export function readSchema(root = REPO_ROOT) {
+  return readFileSync(join(root, SCHEMA_PATH), "utf8");
+}
+
+function main() {
+  const schema = readSchema();
+  const violations = findFindingShapedViolations(schema);
+  const staleAllow = findStaleAllowlist(schema);
+  const staleExcl = findStaleExclusions(schema);
+
+  if (violations.length > 0) {
+    console.error("");
+    console.error(
+      "ERROR: BI-REFACTOR-CC46703A — a NEW finding-shaped model was added.",
+    );
+    console.error("");
+    console.error("New finding-shaped table(s):");
+    for (const v of violations) console.error(`  model ${v}`);
+    console.error("");
+    console.error("The finding substrate is frozen pending the Phase-2 unify");
+    console.error("decision. Do ONE of:");
+    console.error(
+      "  1. Unify this data into an existing finding model (AuditFinding), OR",
+    );
+    console.error(
+      "  2. If a new table is genuinely justified, add the model to ALLOWLIST",
+    );
+    console.error(
+      "     in scripts/check-finding-substrate.mjs AND record the decision per",
+    );
+    console.error(
+      "     BI-REFACTOR-CC46703A / the Assurance Ledger spec §3.3 (docs/superpowers/",
+    );
+    console.error(
+      "     specs/2026-05-21-supply-chain-and-desired-state-assurance-design.md).",
+    );
+    console.error("");
+    process.exit(1);
+  }
+
+  const stale = [...staleAllow, ...staleExcl];
+  if (stale.length > 0) {
+    console.error("");
+    console.error(
+      "ERROR: BI-REFACTOR-CC46703A — the finding-substrate allowlist is stale.",
+    );
+    console.error(
+      "These models are listed but no longer exist in schema.prisma",
+    );
+    console.error(
+      "(unified or removed — the good outcome). Remove them from ALLOWLIST /",
+    );
+    console.error(
+      "SUFFIX_COLLISION_EXCLUSIONS in scripts/check-finding-substrate.mjs:",
+    );
+    for (const s of stale) console.error(`  ${s}`);
+    console.error("");
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ Finding substrate frozen — ${ALLOWLIST.size} known finding-shaped models, ` +
+      `${SUFFIX_COLLISION_EXCLUSIONS.size} suffix-collision exclusion(s), no eighth table.`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-finding-substrate.test.mjs
+++ b/scripts/check-finding-substrate.test.mjs
@@ -1,0 +1,81 @@
+/**
+ * BI-REFACTOR-CC46703A — tests for the no-seventh-finding-table guard.
+ * Run: node --test scripts/check-finding-substrate.test.mjs
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ALLOWLIST,
+  SUFFIX_COLLISION_EXCLUSIONS,
+  extractModelNames,
+  findFindingShapedViolations,
+  findStaleAllowlist,
+  findStaleExclusions,
+  readSchema,
+} from "./check-finding-substrate.mjs";
+
+test("extractModelNames finds every model declaration", () => {
+  const schema = "model Foo {\n}\n\nmodel BarFinding {\n  id String\n}\n";
+  assert.deepEqual(extractModelNames(schema), ["Foo", "BarFinding"]);
+});
+
+test("the live schema passes — no finding-shaped model outside the allowlist", () => {
+  assert.deepEqual(findFindingShapedViolations(readSchema()), []);
+});
+
+test("the allowlist is not stale — every entry still exists in schema.prisma", () => {
+  assert.deepEqual(findStaleAllowlist(readSchema()), []);
+});
+
+test("the suffix-collision exclusions are not stale", () => {
+  assert.deepEqual(findStaleExclusions(readSchema()), []);
+});
+
+test("a NEW finding-shaped model not in the allowlist FAILS", () => {
+  const schema = "model FooFinding {\n  id String\n}\n";
+  assert.deepEqual(findFindingShapedViolations(schema), ["FooFinding"]);
+});
+
+test("Issue and Report suffixes are also caught", () => {
+  assert.deepEqual(
+    findFindingShapedViolations("model DriftIssue {\n}\nmodel ScanReport {\n}\n"),
+    ["DriftIssue", "ScanReport"],
+  );
+});
+
+test("a model already in the allowlist PASSES", () => {
+  assert.deepEqual(findFindingShapedViolations("model AuditFinding {\n}\n"), []);
+});
+
+test("a suffix-collision exclusion (TaxIssue) PASSES", () => {
+  assert.deepEqual(findFindingShapedViolations("model TaxIssue {\n}\n"), []);
+});
+
+test("models NOT matching the finding suffix are ignored", () => {
+  assert.deepEqual(
+    findFindingShapedViolations("model User {\n}\nmodel BomComponent {\n}\n"),
+    [],
+  );
+});
+
+test("the seven known finding-shaped models are all allowlisted", () => {
+  for (const name of [
+    "PortfolioQualityIssue",
+    "AuditFinding",
+    "WikiLintFinding",
+    "EaConformanceIssue",
+    "LicenseReadinessIssue",
+    "PlatformIssueReport",
+    "AssuranceFinding",
+  ]) {
+    assert.ok(ALLOWLIST.has(name), `${name} should be allowlisted`);
+  }
+  assert.equal(ALLOWLIST.size, 7);
+});
+
+test("allowlist and exclusions do not overlap", () => {
+  for (const name of SUFFIX_COLLISION_EXCLUSIONS) {
+    assert.ok(!ALLOWLIST.has(name), `${name} must not be in both sets`);
+  }
+});


### PR DESCRIPTION
## What

Implements the **decision-free, non-destructive half** of BI-REFACTOR-CC46703A: the "no-seventh-finding-table guard" that the Assurance Ledger spec (§3.3) requires as the fallback when `AssuranceFinding` is not unified with `AuditFinding`.

The unify (extract a shared `Finding` base) is a **founder-reserved architecture decision** and is explicitly NOT made here. This PR only builds the guard that freezes the current finding substrate so an eighth finding-shaped model can't silently land while that decision is open.

## Substrate verified (origin/main)

Six finding-shaped models named by spec §3.3 **plus** the seventh that Phase 1 landed, all present in `packages/db/prisma/schema.prisma`:

- `PortfolioQualityIssue`, `AuditFinding`, `WikiLintFinding`, `EaConformanceIssue`, `LicenseReadinessIssue`, `PlatformIssueReport` (the six)
- `AssuranceFinding` — the **seventh**, already landed

Suffix-collision exclusion (matches `Issue` suffix but is NOT a finding): `TaxIssue` — a tax-obligation record tied to `OrganizationTaxProfile`, not a discovery/audit/assurance finding.

## What's in the box

- `scripts/check-finding-substrate.mjs` — parses `model <Name> {` decls, flags any name ending in `Finding`/`Issue`/`Report` outside the curated allowlist. Green on current main (0 violations). Mirrors `check-module-size.mjs` / `check-no-local-isrecord.mjs`.
- `scripts/check-finding-substrate.test.mjs` — 11 self-tests: live schema passes, allowlist not stale, synthetic `FooFinding` fails, `Issue`/`Report` suffixes caught, allowlisted model passes, `TaxIssue` exclusion passes, non-finding models ignored.
- `.github/workflows/ci.yml` — dedicated **Finding Substrate Guard** job (self-test + guard), mirroring `module-size-guard`.
- Spec §3.3 — records the **dated owner (founder/markbodman, 2026-07-16)** and points at the guard as the sanctioned fallback pending the Phase-2 unify decision.

## Verified locally

- `node scripts/check-finding-substrate.mjs` → exit 0
- `node --test scripts/check-finding-substrate.test.mjs` → 11/11 pass

This guard prevents debt without making the unify decision, so it is safe to auto-merge.

Design-Grounding-Decision: BI-REFACTOR-CC46703A
Process-Spine-Decision: This is the spec-sanctioned no-seventh-finding-table guard fallback for BI-REFACTOR-CC46703A / Assurance Ledger spec §3.3; it touches the spec doc to record the dated guard owner and is decision-free (the founder-reserved unify decision is not made here).

Generated with Claude Code