### PR TITLE
refactor(workbooks): extract Format/Group/Columns panels from Grid.tsx (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -88,15 +88,16 @@ import {
 import { rowsToCsv } from "./grid-csv";
 import {
   type ConditionalRule,
-  CF_OPERATORS,
-  CF_OPERATOR_LABELS,
-  CF_COLORS,
   rowColor,
   rowColorClass,
-  blankRule,
-  operatorNeedsValue,
 } from "./grid-conditional-format";
-import { GridFilterPanel, GridSummaryPanel } from "./GridPanels";
+import {
+  GridFilterPanel,
+  GridSummaryPanel,
+  GridFormatPanel,
+  GridGroupPanel,
+  GridColumnsPanel,
+} from "./GridPanels";
 import {
   viewStorageKey,
   serializeViewState,
@@ -115,7 +116,6 @@ import {
   visibleColumns as computeVisibleColumns,
   clampFrozenCount,
   rowHeightPx,
-  ROW_HEIGHTS,
   type RowHeight,
 } from "./grid-view-options";
 import {
@@ -946,82 +946,7 @@ export function WorkbookGrid({
       )}
 
       {showFormat && columns.length > 0 && (
-        <div className="flex flex-col gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
-          {cfRules.map((rule) => {
-            const update = (patch: Partial<ConditionalRule>) =>
-              setCfRules((rs) => rs.map((r) => (r.id === rule.id ? { ...r, ...patch } : r)));
-            const ctrlClass =
-              "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
-            return (
-              <div key={rule.id} className="flex flex-wrap items-center gap-2">
-                <span className="text-sm text-[var(--dpf-muted)]">Highlight when</span>
-                <select
-                  value={rule.columnId}
-                  onChange={(e) => update({ columnId: e.target.value })}
-                  aria-label="Column"
-                  className={ctrlClass}
-                >
-                  {columns.map((c) => (
-                    <option key={c.columnId} value={c.columnId}>
-                      {c.name}
-                    </option>
-                  ))}
-                </select>
-                <select
-                  value={rule.operator}
-                  onChange={(e) => update({ operator: e.target.value as ConditionalRule["operator"] })}
-                  aria-label="Operator"
-                  className={ctrlClass}
-                >
-                  {CF_OPERATORS.map((op) => (
-                    <option key={op} value={op}>
-                      {CF_OPERATOR_LABELS[op]}
-                    </option>
-                  ))}
-                </select>
-                {operatorNeedsValue(rule.operator) && (
-                  <input
-                    value={rule.value}
-                    onChange={(e) => update({ value: e.target.value })}
-                    placeholder="value"
-                    aria-label="Value"
-                    className={ctrlClass}
-                  />
-                )}
-                <select
-                  value={rule.color}
-                  onChange={(e) => update({ color: e.target.value as ConditionalRule["color"] })}
-                  aria-label="Color"
-                  className={ctrlClass}
-                >
-                  {CF_COLORS.map((c) => (
-                    <option key={c} value={c}>
-                      {c}
-                    </option>
-                  ))}
-                </select>
-                <span className={`dpf-cf-swatch ${rowColorClass(rule.color)}`} aria-hidden="true" />
-                <button
-                  type="button"
-                  onClick={() => setCfRules((rs) => rs.filter((r) => r.id !== rule.id))}
-                  className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-                  aria-label="Remove rule"
-                >
-                  ✕
-                </button>
-              </div>
-            );
-          })}
-          <button
-            type="button"
-            onClick={() =>
-              setCfRules((rs) => [...rs, blankRule(`cf-${(cfIdRef.current += 1)}`, columns)])
-            }
-            className="w-fit rounded-md border border-[var(--dpf-border)] px-3 py-1 text-sm text-[var(--dpf-text)]"
-          >
-            + Add formatting rule
-          </button>
-        </div>
+        <GridFormatPanel columns={columns} cfRules={cfRules} setCfRules={setCfRules} cfIdRef={cfIdRef} />
       )}
 
       {showSummary && columns.length > 0 && (
@@ -1038,161 +963,32 @@ export function WorkbookGrid({
       )}
 
       {showGroup && columns.length > 0 && (
-        <div className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
-          <span className="text-sm text-[var(--dpf-muted)]">Group by</span>
-          {/* Ordered group-by levels: each chip is one level (outer → inner). */}
-          {effectiveGroupBy.map((id, level) => {
-            const col = columns.find((c) => c.columnId === id);
-            if (!col) return null;
-            return (
-              <span
-                key={id}
-                className="inline-flex items-center gap-1 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]"
-              >
-                <span className="text-xs text-[var(--dpf-muted)]">{level + 1}</span>
-                {col.name}
-                <button
-                  type="button"
-                  aria-label={`Remove grouping by ${col.name}`}
-                  onClick={() => {
-                    setGroupBy(effectiveGroupBy.filter((g) => g !== id));
-                    resetGroupExpansion();
-                  }}
-                  className="ml-0.5 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-                >
-                  ×
-                </button>
-              </span>
-            );
-          })}
-          {(() => {
-            const available = columns.filter((c) => !effectiveGroupBy.includes(c.columnId));
-            if (available.length === 0) return null;
-            return (
-              <select
-                value=""
-                onChange={(e) => {
-                  if (!e.target.value) return;
-                  setGroupBy([...effectiveGroupBy, e.target.value]);
-                  resetGroupExpansion();
-                }}
-                aria-label={effectiveGroupBy.length ? "Add group-by level" : "Group by column"}
-                className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]"
-              >
-                <option value="">{effectiveGroupBy.length ? "add level…" : "none"}</option>
-                {available.map((c) => (
-                  <option key={c.columnId} value={c.columnId}>
-                    {c.name}
-                  </option>
-                ))}
-              </select>
-            );
-          })()}
-          {grouping && (
-            <>
-              <button
-                type="button"
-                onClick={resetGroupExpansion}
-                className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-              >
-                Expand all
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setCollapsedGroups(new Set(topGroupIds));
-                  setExtraExpanded(new Set());
-                }}
-                className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-              >
-                Collapse all
-              </button>
-              <span className="text-xs text-[var(--dpf-muted)]">
-                {effectiveGroupBy.length > 1 ? `${effectiveGroupBy.length} levels · ` : ""}
-                {topGroupIds.length} group{topGroupIds.length === 1 ? "" : "s"}
-              </span>
-              {!Object.values(footerAgg).some((a) => a && a !== "none") && (
-                <span className="text-xs italic text-[var(--dpf-muted)]">
-                  Tip: pick an aggregate in the Summary bar (Columns) to show subtotals per group.
-                </span>
-              )}
-            </>
-          )}
-        </div>
+        <GridGroupPanel
+          columns={columns}
+          effectiveGroupBy={effectiveGroupBy}
+          setGroupBy={setGroupBy}
+          resetGroupExpansion={resetGroupExpansion}
+          grouping={grouping}
+          topGroupIds={topGroupIds}
+          setCollapsedGroups={setCollapsedGroups}
+          setExtraExpanded={setExtraExpanded}
+          footerAgg={footerAgg}
+        />
       )}
 
       {showColumns && columns.length > 0 && (
-        <div className="flex flex-col gap-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
-          <div className="flex flex-wrap items-center gap-3">
-            <span className="text-sm text-[var(--dpf-muted)]">Row height</span>
-            <div className="inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
-              {(Object.keys(ROW_HEIGHTS) as RowHeight[]).map((h) => (
-                <button
-                  key={h}
-                  type="button"
-                  onClick={() => setRowHeight(h)}
-                  className={
-                    rowHeight === h
-                      ? "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium capitalize text-[var(--dpf-text)]"
-                      : "px-2 py-1 capitalize text-[var(--dpf-muted)]"
-                  }
-                >
-                  {h}
-                </button>
-              ))}
-            </div>
-            <span className="text-sm text-[var(--dpf-muted)]">Freeze first</span>
-            <select
-              value={effectiveFrozen}
-              onChange={(e) => setFrozenCount(Number(e.target.value))}
-              aria-label="Freeze first N columns"
-              className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]"
-            >
-              {Array.from({ length: Math.max(1, visibleCols.length) }, (_, i) => i).map((n) => (
-                <option key={n} value={n}>
-                  {n === 0 ? "no columns" : `${n} column${n === 1 ? "" : "s"}`}
-                </option>
-              ))}
-            </select>
-            <label className="inline-flex items-center gap-1 text-sm text-[var(--dpf-text)]">
-              <input
-                type="checkbox"
-                checked={showFooter}
-                onChange={() => setShowFooter((v) => !v)}
-              />
-              Summary bar
-            </label>
-          </div>
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span className="text-sm text-[var(--dpf-muted)]">Fields</span>
-            {orderedColumns.map((col) => {
-              const hidden = hiddenColumns.includes(col.columnId);
-              return (
-                <label key={col.columnId} className="inline-flex items-center gap-1 text-sm text-[var(--dpf-text)]">
-                  <input
-                    type="checkbox"
-                    checked={!hidden}
-                    onChange={() =>
-                      setHiddenColumns((prev) =>
-                        hidden ? prev.filter((id) => id !== col.columnId) : [...prev, col.columnId],
-                      )
-                    }
-                  />
-                  {col.name}
-                </label>
-              );
-            })}
-            {hiddenColumns.length > 0 && (
-              <button
-                type="button"
-                onClick={() => setHiddenColumns([])}
-                className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
-              >
-                Show all
-              </button>
-            )}
-          </div>
-        </div>
+        <GridColumnsPanel
+          orderedColumns={orderedColumns}
+          visibleColsCount={visibleCols.length}
+          rowHeight={rowHeight}
+          setRowHeight={setRowHeight}
+          effectiveFrozen={effectiveFrozen}
+          setFrozenCount={setFrozenCount}
+          showFooter={showFooter}
+          setShowFooter={setShowFooter}
+          hiddenColumns={hiddenColumns}
+          setHiddenColumns={setHiddenColumns}
+        />
       )}
 
       {columns.length === 0 ? (

--- a/apps/web/components/workbooks/GridPanels.tsx
+++ b/apps/web/components/workbooks/GridPanels.tsx
@@ -21,6 +21,17 @@ import {
   type FilterOp,
 } from "./grid-filter-builder";
 import { numericColumns, summarize, summaryChartBars } from "./grid-summary";
+import {
+  type ConditionalRule,
+  CF_OPERATORS,
+  CF_OPERATOR_LABELS,
+  CF_COLORS,
+  rowColorClass,
+  blankRule,
+  operatorNeedsValue,
+} from "./grid-conditional-format";
+import { ROW_HEIGHTS, type RowHeight } from "./grid-view-options";
+import type { FooterAgg } from "./grid-footer-summary";
 
 const PANEL = "flex flex-col gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2";
 const CTRL = "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
@@ -292,6 +303,307 @@ export function GridSummaryPanel({
           </table>
         </div>
       )}
+    </div>
+  );
+}
+
+// --- Conditional-formatting (Format) panel ---------------------------------
+
+export interface GridFormatPanelProps {
+  columns: ColumnDefinition[];
+  cfRules: ConditionalRule[];
+  setCfRules: Dispatch<SetStateAction<ConditionalRule[]>>;
+  /** Monotonic counter for stable new-rule ids (owned by the Grid). */
+  cfIdRef: MutableRefObject<number>;
+}
+
+export function GridFormatPanel({
+  columns,
+  cfRules,
+  setCfRules,
+  cfIdRef,
+}: GridFormatPanelProps): ReactNode {
+  return (
+    <div className={PANEL}>
+      {cfRules.map((rule) => {
+        const update = (patch: Partial<ConditionalRule>) =>
+          setCfRules((rs) => rs.map((r) => (r.id === rule.id ? { ...r, ...patch } : r)));
+        return (
+          <div key={rule.id} className="flex flex-wrap items-center gap-2">
+            <span className="text-sm text-[var(--dpf-muted)]">Highlight when</span>
+            <select
+              value={rule.columnId}
+              onChange={(e) => update({ columnId: e.target.value })}
+              aria-label="Column"
+              className={CTRL}
+            >
+              {columns.map((c) => (
+                <option key={c.columnId} value={c.columnId}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+            <select
+              value={rule.operator}
+              onChange={(e) => update({ operator: e.target.value as ConditionalRule["operator"] })}
+              aria-label="Operator"
+              className={CTRL}
+            >
+              {CF_OPERATORS.map((op) => (
+                <option key={op} value={op}>
+                  {CF_OPERATOR_LABELS[op]}
+                </option>
+              ))}
+            </select>
+            {operatorNeedsValue(rule.operator) && (
+              <input
+                value={rule.value}
+                onChange={(e) => update({ value: e.target.value })}
+                placeholder="value"
+                aria-label="Value"
+                className={CTRL}
+              />
+            )}
+            <select
+              value={rule.color}
+              onChange={(e) => update({ color: e.target.value as ConditionalRule["color"] })}
+              aria-label="Color"
+              className={CTRL}
+            >
+              {CF_COLORS.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            <span className={`dpf-cf-swatch ${rowColorClass(rule.color)}`} aria-hidden="true" />
+            <button
+              type="button"
+              onClick={() => setCfRules((rs) => rs.filter((r) => r.id !== rule.id))}
+              className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+              aria-label="Remove rule"
+            >
+              ✕
+            </button>
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        onClick={() => setCfRules((rs) => [...rs, blankRule(`cf-${(cfIdRef.current += 1)}`, columns)])}
+        className="w-fit rounded-md border border-[var(--dpf-border)] px-3 py-1 text-sm text-[var(--dpf-text)]"
+      >
+        + Add formatting rule
+      </button>
+    </div>
+  );
+}
+
+// --- In-grid grouping (Group) panel ----------------------------------------
+
+export interface GridGroupPanelProps {
+  columns: ColumnDefinition[];
+  effectiveGroupBy: string[];
+  setGroupBy: Dispatch<SetStateAction<string[]>>;
+  /** Reset collapse/expand intents (owned by the Grid). */
+  resetGroupExpansion: () => void;
+  grouping: boolean;
+  topGroupIds: readonly string[];
+  setCollapsedGroups: Dispatch<SetStateAction<ReadonlySet<unknown>>>;
+  setExtraExpanded: Dispatch<SetStateAction<ReadonlySet<unknown>>>;
+  footerAgg: Record<string, FooterAgg>;
+}
+
+export function GridGroupPanel({
+  columns,
+  effectiveGroupBy,
+  setGroupBy,
+  resetGroupExpansion,
+  grouping,
+  topGroupIds,
+  setCollapsedGroups,
+  setExtraExpanded,
+  footerAgg,
+}: GridGroupPanelProps): ReactNode {
+  const available = columns.filter((c) => !effectiveGroupBy.includes(c.columnId));
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+      <span className="text-sm text-[var(--dpf-muted)]">Group by</span>
+      {/* Ordered group-by levels: each chip is one level (outer → inner). */}
+      {effectiveGroupBy.map((id, level) => {
+        const col = columns.find((c) => c.columnId === id);
+        if (!col) return null;
+        return (
+          <span
+            key={id}
+            className="inline-flex items-center gap-1 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]"
+          >
+            <span className="text-xs text-[var(--dpf-muted)]">{level + 1}</span>
+            {col.name}
+            <button
+              type="button"
+              aria-label={`Remove grouping by ${col.name}`}
+              onClick={() => {
+                setGroupBy(effectiveGroupBy.filter((g) => g !== id));
+                resetGroupExpansion();
+              }}
+              className="ml-0.5 text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+            >
+              ×
+            </button>
+          </span>
+        );
+      })}
+      {available.length > 0 && (
+        <select
+          value=""
+          onChange={(e) => {
+            if (!e.target.value) return;
+            setGroupBy([...effectiveGroupBy, e.target.value]);
+            resetGroupExpansion();
+          }}
+          aria-label={effectiveGroupBy.length ? "Add group-by level" : "Group by column"}
+          className={CTRL}
+        >
+          <option value="">{effectiveGroupBy.length ? "add level…" : "none"}</option>
+          {available.map((c) => (
+            <option key={c.columnId} value={c.columnId}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      )}
+      {grouping && (
+        <>
+          <button
+            type="button"
+            onClick={resetGroupExpansion}
+            className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          >
+            Expand all
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setCollapsedGroups(new Set(topGroupIds));
+              setExtraExpanded(new Set());
+            }}
+            className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          >
+            Collapse all
+          </button>
+          <span className="text-xs text-[var(--dpf-muted)]">
+            {effectiveGroupBy.length > 1 ? `${effectiveGroupBy.length} levels · ` : ""}
+            {topGroupIds.length} group{topGroupIds.length === 1 ? "" : "s"}
+          </span>
+          {!Object.values(footerAgg).some((a) => a && a !== "none") && (
+            <span className="text-xs italic text-[var(--dpf-muted)]">
+              Tip: pick an aggregate in the Summary bar (Columns) to show subtotals per group.
+            </span>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// --- Row height / freeze / hide-fields (Columns) panel ----------------------
+
+export interface GridColumnsPanelProps {
+  orderedColumns: ColumnDefinition[];
+  visibleColsCount: number;
+  rowHeight: RowHeight;
+  setRowHeight: Dispatch<SetStateAction<RowHeight>>;
+  effectiveFrozen: number;
+  setFrozenCount: Dispatch<SetStateAction<number>>;
+  showFooter: boolean;
+  setShowFooter: Dispatch<SetStateAction<boolean>>;
+  hiddenColumns: string[];
+  setHiddenColumns: Dispatch<SetStateAction<string[]>>;
+}
+
+export function GridColumnsPanel({
+  orderedColumns,
+  visibleColsCount,
+  rowHeight,
+  setRowHeight,
+  effectiveFrozen,
+  setFrozenCount,
+  showFooter,
+  setShowFooter,
+  hiddenColumns,
+  setHiddenColumns,
+}: GridColumnsPanelProps): ReactNode {
+  return (
+    <div className="flex flex-col gap-3 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-sm text-[var(--dpf-muted)]">Row height</span>
+        <div className="inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
+          {(Object.keys(ROW_HEIGHTS) as RowHeight[]).map((h) => (
+            <button
+              key={h}
+              type="button"
+              onClick={() => setRowHeight(h)}
+              className={
+                rowHeight === h
+                  ? "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium capitalize text-[var(--dpf-text)]"
+                  : "px-2 py-1 capitalize text-[var(--dpf-muted)]"
+              }
+            >
+              {h}
+            </button>
+          ))}
+        </div>
+        <span className="text-sm text-[var(--dpf-muted)]">Freeze first</span>
+        <select
+          value={effectiveFrozen}
+          onChange={(e) => setFrozenCount(Number(e.target.value))}
+          aria-label="Freeze first N columns"
+          className={CTRL}
+        >
+          {Array.from({ length: Math.max(1, visibleColsCount) }, (_, i) => i).map((n) => (
+            <option key={n} value={n}>
+              {n === 0 ? "no columns" : `${n} column${n === 1 ? "" : "s"}`}
+            </option>
+          ))}
+        </select>
+        <label className="inline-flex items-center gap-1 text-sm text-[var(--dpf-text)]">
+          <input type="checkbox" checked={showFooter} onChange={() => setShowFooter((v) => !v)} />
+          Summary bar
+        </label>
+      </div>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <span className="text-sm text-[var(--dpf-muted)]">Fields</span>
+        {orderedColumns.map((col) => {
+          const hidden = hiddenColumns.includes(col.columnId);
+          return (
+            <label
+              key={col.columnId}
+              className="inline-flex items-center gap-1 text-sm text-[var(--dpf-text)]"
+            >
+              <input
+                type="checkbox"
+                checked={!hidden}
+                onChange={() =>
+                  setHiddenColumns((prev) =>
+                    hidden ? prev.filter((id) => id !== col.columnId) : [...prev, col.columnId],
+                  )
+                }
+              />
+              {col.name}
+            </label>
+          );
+        })}
+        {hiddenColumns.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setHiddenColumns([])}
+            className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+          >
+            Show all
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -239,8 +239,12 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
 - **Remaining (not built):** named/shareable server-side views; calendar view (fullcalendar — needs a
   date column); manual row reordering; full pivots + richer charts; metrics/semantic layer;
   operationalization lifecycle.
-  **Debt:** `Grid.tsx` is over the 1000-LOC hard cap — decompose the toolbar/panels into
-  subcomponents (in progress: Filter + Summary panels extracted to `GridPanels.tsx`).
+  **Debt (decomposition — largely paid down):** all five toolbar panels — Filter, Summary, Format,
+  Group, Columns — now live as typed, presentational components in `GridPanels.tsx` (pure UI over
+  props the Grid owns). This dropped `Grid.tsx` from 1298 → 1094 LOC. Remaining `Grid.tsx` bulk is the
+  data / react-data-grid wiring (column builder, cell persistence, view-state, CSV, keyboard) — a
+  further pass could extract the toolbar button row and the `buildColumn` factory, but the panels were
+  the growth driver as each parity feature added one.
 
 ## Remaining toward full Smartsheet + Supabase parity (tracked, not built)
 

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -12,7 +12,7 @@ apps/web/components/platform/AiOperationsMap.tsx	2881
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
 apps/web/components/storefront/SlotBookingFlow.tsx	919
-apps/web/components/workbooks/Grid.tsx	1298
+apps/web/components/workbooks/Grid.tsx	1094
 apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1341
 apps/web/lib/actions/agent-coworker-external.test.ts	867


### PR DESCRIPTION
## What

Continues the WorkbookGrid decomposition begun in #3045 (Filter + Summary panels). The three remaining inline toolbar panels now live as typed, presentational components in `GridPanels.tsx`:

- **GridFormatPanel** — conditional-formatting rules
- **GridGroupPanel** — in-grid (multi-level) grouping
- **GridColumnsPanel** — row height / freeze / hide-fields / summary-bar toggle

## Pure refactor

The JSX is moved **verbatim** — the Format panel's local `ctrlClass` was byte-identical to GridPanels' shared `CTRL` constant, so markup, aria labels, classNames, and behavior are unchanged. No contract change; no new or altered controls.

## Impact

- `Grid.tsx`: **1298 → 1094 LOC** (−204). The five toolbar panels were the growth driver — each parity feature added one — so extracting them keeps the Grid focused on data / react-data-grid wiring and lets the next panel land as its own file (its own PR).
- `GridPanels.tsx`: 298 → 610 (still under the 800 size-guard threshold, unbaselined).
- Removed now-unused conditional-format + `ROW_HEIGHTS` imports from Grid.tsx.

## Verification

Unit tests green (113/113 across 14 workbooks test files). CI runs the authoritative typecheck (source-only worktree can't run tsc locally). Behavior-preserving by construction (identical JSX). I'll smoke-test the panels live once this deploys.

Design-Grounding-Decision: no-contract-change refactor of the apps/web/ grid substrate; continues the decomposition tracked in docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md (Debt note).
UX-Fit-Decision: no-op — identical UI, zero new/changed controls; same JSX relocated into GridPanels.tsx.
Process-Spine-Decision: touched the phase-2 plan (Debt note); no new module or spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)