### PR TITLE
feat(healthcare): activate medical and dental practices

### DIFF
--- a/apps/web/lib/onboarding/archetype-business-context.test.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.test.ts
@@ -29,8 +29,23 @@ describe("resolveBusinessProfile", () => {
     // Override specialises missionTheme + businessModel...
     expect(dental.missionTheme).not.toBe(industry.missionTheme);
     expect(dental.missionTheme.toLowerCase()).toContain("smile");
-    // ...but inherits the non-overridden fields from the industry profile.
-    expect(dental.whoWeServe).toBe(industry.whoWeServe);
+    // ...and now specializes the patient/care-team stance while continuing to
+    // inherit fields the leaf does not override.
+    expect(dental.whoWeServe).not.toBe(industry.whoWeServe);
+    expect(dental.whoWeServe).toMatch(/dentist|hygienist/i);
+    expect(dental.supplyChain).toBe(industry.supplyChain);
+  });
+
+  it("specializes medical-practice onboarding around ambulatory care", () => {
+    const medical = resolveBusinessProfile({
+      archetypeId: "medical-practice",
+      industry: "healthcare-wellness",
+    });
+
+    expect(medical.missionTheme).toMatch(/patient|care/i);
+    expect(medical.businessModel).toMatch(/appointment|encounter/i);
+    expect(medical.whoWeServe).toMatch(/patient|family/i);
+    expect(medical.howWeDecide).toMatch(/clinical|safety/i);
   });
 
   it("ignores an unknown archetypeId and uses the industry profile", () => {

--- a/apps/web/lib/onboarding/archetype-business-context.ts
+++ b/apps/web/lib/onboarding/archetype-business-context.ts
@@ -309,11 +309,25 @@ const INDUSTRY_PROFILES: Record<string, ArchetypeBusinessProfile> = {
 // fields you want to specialise; the rest inherit from the industry profile.
 
 const ARCHETYPE_PROFILES: Record<string, Partial<ArchetypeBusinessProfile>> = {
+  "medical-practice": {
+    missionTheme:
+      "provide safe, attentive medical care that helps every patient live healthier",
+    businessModel:
+      "Appointment- and encounter-based ambulatory care, with continuity across preventive, routine, and follow-up visits and a mix of patient, payer, or public funding.",
+    whoWeServe:
+      "We serve patients and families who rely on accessible, coordinated care over time. Each encounter belongs to a continuing care relationship, not an isolated transaction.",
+    howWeDecide:
+      "Clinical safety, patient consent, and professional standards come first. We coordinate across doctors, nurses, and front-desk staff, protect private health information, and escalate consequential or uncertain decisions to the responsible clinician.",
+  },
   "dental-practice": {
     missionTheme:
       "keep our patients' smiles healthy with gentle, expert dental care they trust",
     businessModel:
       "Recurring check-ups plus planned treatment; long-term patient relationships and gentle, anxiety-aware care drive retention and referrals.",
+    whoWeServe:
+      "We serve patients and families across routine prevention, hygiene, treatment, and urgent dental needs, coordinating dentists, hygienists, assistants, and the front desk around a continuing oral-health relationship.",
+    howWeDecide:
+      "Patient safety, informed consent, clinical quality, and anxiety-aware care come first. We protect private health information and keep treatment decisions with the responsible licensed dental professional.",
   },
   restaurant: {
     missionTheme:

--- a/apps/web/lib/storefront/archetype-vocabulary.ts
+++ b/apps/web/lib/storefront/archetype-vocabulary.ts
@@ -196,6 +196,7 @@ const CATEGORY_SUGGESTIONS: Record<string, string[]> = {
   // Healthcare
   "veterinary-clinic": ["Consultations", "Vaccinations", "Surgery", "Dental"],
   "dental-practice": ["Check-ups", "Treatments", "Cosmetic"],
+  "medical-practice": ["New Patients", "Routine Care", "Preventive Care", "Follow-up", "Telehealth"],
   "physiotherapy": ["Assessment", "Treatment", "Rehabilitation"],
   "counselling-therapy": ["Individual", "Couples", "Group"],
   "optician": ["Eye Tests", "Glasses", "Contact Lenses"],

--- a/apps/web/lib/workspace-home/profiles.test.ts
+++ b/apps/web/lib/workspace-home/profiles.test.ts
@@ -71,4 +71,23 @@ describe("default workspace home profiles", () => {
       "client decisions awaiting executive input",
     );
   });
+
+  it("uses an exact care-practice home for medical and dental offices", () => {
+    for (const archetypeId of ["medical-practice", "dental-practice"]) {
+      const resolution = resolveWorkspaceHomeContribution({
+        storefrontConfig: {
+          archetype: {
+            archetypeId,
+            category: "healthcare-wellness",
+            name: archetypeId === "medical-practice" ? "Medical Practice" : "Dental Practice",
+          },
+        },
+      });
+
+      expect(resolution.match).toBe("exact");
+      expect(resolution.contribution?.id).toBe("home-care-practice");
+      expect(resolution.contribution?.topConcerns).toContain("patients waiting or not yet checked in");
+      expect(resolution.contribution?.topConcerns).toContain("clinical handoffs awaiting acknowledgement");
+    }
+  });
 });

--- a/apps/web/lib/workspace-home/profiles.ts
+++ b/apps/web/lib/workspace-home/profiles.ts
@@ -71,6 +71,31 @@ const configurationItem = {
 
 export const DEFAULT_WORKSPACE_HOME_CONTRIBUTIONS: WorkspaceHomeContribution[] = [
   profile({
+    id: "home-care-practice",
+    label: "Care practice command home",
+    description:
+      "Patient arrival, care-team schedule, communication, and clinical handoff attention for small medical and dental practices.",
+    primaryOperatingQuestion: "which patient, appointment, or care-team handoff needs attention now?",
+    topConcerns: [
+      "patients waiting or not yet checked in",
+      "unconfirmed or changed appointments",
+      "clinical handoffs awaiting acknowledgement",
+      "patient communication failures",
+      "rooms, practitioners, or hygienists not ready",
+    ],
+    semanticArchetypeIds: ["medical-practice", "dental-practice"],
+    archetypeCategories: [],
+    primitives: ["appointment-schedule", "case-board", "communication-exceptions", "handoff-queue"],
+    requiredCanonicalData: ["customer-account", "work-item", "calendar-event"],
+    requiredSignals: ["scheduled-work", "urgent-exception", "communication-failed", "coworker-handoff"],
+    components: [
+      { key: "today-schedule", slotId: "today-now", primitiveKey: "appointment-schedule", title: "Patient appointments and care-team schedule", dataRefs: [calendarEvent, scheduledWork] },
+      { key: "patient-queue", slotId: "exceptions-needs-review", primitiveKey: "case-board", title: "Patients waiting or needing front-desk review", dataRefs: [customerAccount, workItem, urgentException] },
+      { key: "notification-status", slotId: "exceptions-needs-review", primitiveKey: "communication-exceptions", title: "Appointment and patient communication exceptions", dataRefs: [failedCommunication] },
+      { key: "coworker-handoffs", slotId: "coworker-handoffs", primitiveKey: "handoff-queue", title: "Clinical and front-desk handoffs", dataRefs: [coworkerHandoff] },
+    ],
+  }),
+  profile({
     id: "home-trades-maintenance",
     label: "Field service command home",
     description:

--- a/docs/superpowers/plans/2026-07-16-healthcare-archetype-activation.md
+++ b/docs/superpowers/plans/2026-07-16-healthcare-archetype-activation.md
@@ -1,0 +1,110 @@
+# Medical and Dental Archetype Activation Plan
+
+> **Backlog item:** `BI-HEALTHCARE-002`
+>
+> **Epic:** `EP-HEALTHCARE-PRACTICE`
+>
+> **Parent design:** `docs/superpowers/specs/2026-07-15-healthcare-dental-practice-archetypes-design.md`
+
+## Outcome
+
+Activate small ambulatory medical and dental practices through the existing
+`healthcare-wellness` archetype substrate. Both leaves must describe a
+patient-and-payer, encounter-based, episode-of-care operating model; keep
+patient-facing records in strict customer scope; use healthcare-specific role
+vocabulary and onboarding context; and resolve to a care-practice workspace
+home without introducing a second healthcare registry.
+
+## Delivery
+
+1. Add failing registry tests for the `medical-practice` leaf and the shared
+   medical/dental activation contract.
+2. Preserve the existing activation-profile schema, but make its already-typed
+   capability override scope, transaction-context, isolation, and surface fields
+   survive runtime normalization.
+3. Add one shared care-practice activation profile and apply it to
+   `medical-practice` and `dental-practice`.
+4. Give the two leaves patient/practitioner/front-desk vocabulary, appropriate
+   service templates, safe intake fields, and appointment scheduling defaults.
+5. Add exact medical/dental workspace-home resolution and specific onboarding
+   context while retaining the category profile for other wellness businesses.
+6. Run affected registry, onboarding, vocabulary, workspace, and risk-posture
+   tests; run web typecheck and the governed shared-sandbox production gate.
+
+## Safety constraints
+
+- Public booking forms collect logistics and broad visit reasons only. They do
+  not solicit diagnosis narratives, test results, insurance identifiers, or
+  other clinical record content.
+- `estateSeparation` is `strict`, patient projection is separate, and all
+  patient-account/billing capability overrides use `strict-customer-scope`.
+- Appointment and episode-of-care context are explicit; billing remains
+  prepared/manual rather than autonomously prescribed.
+- The existing conservative `healthcare-wellness` risk default remains the
+  trust posture source of truth.
+
+## Verification
+
+- Registry tests prove both leaves, axes, isolation, capability contexts, and
+  vocabulary.
+- Workspace tests prove exact care-practice selection.
+- Onboarding tests prove medical and dental specialization.
+- Risk tests continue to prove conservative healthcare defaults.
+- Web typecheck and production build pass.
+
+## UX fit review - care-practice activation
+
+- **Decision:** fits-with-guardrails
+- **Owning area:** Workspace for staff attention; Storefront for business
+  configuration; the external patient experience remains under `/portal`.
+- **Route family:** existing `/workspace`, `/storefront`, and `/portal` families.
+  This slice adds no route, navigation item, tab, dashboard, or component family.
+- **Primary persona:** receptionist/scheduler who needs today's patients,
+  appointment exceptions, and care-team handoffs without learning platform
+  terminology.
+- **Navigation layer touched:** none. Exact archetype resolution changes the
+  content selected by the existing workspace-home registry.
+- **Reuse/convergence:** reuses the workspace-home profile, booking form,
+  archetype vocabulary, and onboarding profile contracts.
+- **Source truth:** `StorefrontConfig.archetypeId` selects the leaf;
+  `StorefrontArchetype` activation/vocabulary seed data selects the profile;
+  current workspace cards remain bound to customer-account, work-item,
+  calendar-event, and signal read models.
+- **Empty/failure behavior:** the existing workspace-home resolver retains its
+  unconfigured mode and `needs-data` empty-state contract. This slice does not
+  render synthetic clinical values when care-specific data is unavailable.
+- **AI boundary:** profile selection and cards send no prompt. The front-desk
+  coworker label is vocabulary only; future actions remain subject to the
+  platform's preview and confirmation boundary.
+- **Required guardrails:** do not expose diagnosis/test-result free text in the
+  public booking form; do not claim clinical encounter widgets until their
+  canonical read models land; do not add a healthcare dashboard alongside
+  `/workspace`.
+- **Evidence before merge:** registry and resolver tests, both leaf profiles in
+  the setup surface, desktop/narrow workspace verification, and an honest
+  missing-data state.
+
+## Architecture review (advisory)
+
+The slice is aligned with the parent capability-overlay decision and DPF's
+single-source-of-truth rules.
+
+- The existing `healthcare-wellness` category, activation-profile axes,
+  capability registry, workspace resolver, risk posture, vocabulary, and
+  onboarding registries are extended rather than duplicated.
+- Runtime normalization now preserves the optional capability override fields
+  already declared by `CapabilityOverride`; no new configuration schema or
+  enum is introduced.
+- `patient-and-payer`, `encounter-based`, and `episode-of-care` remain canonical
+  axes. Patient engagement projection and billing are explicitly
+  `strict-customer-scope` for appointment and episode-of-care contexts.
+- `multi-channel` is used instead of `onsite-plus-portal`: the latter is the
+  canonical signal for a mobile worker travelling to a customer site and would
+  incorrectly activate field dispatch for an office-based clinic.
+- `PatientProfile` remains the canonical clinical identity extension from
+  `BI-HEALTHCARE-004`; this slice uses the existing customer-account capability
+  only as the engagement/projection seam and does not create a competing
+  patient record model.
+- No architecture decision requires escalation. Later encounter, results,
+  payer, credentialing, and jurisdiction models remain in their filed backlog
+  slices rather than being improvised in this activation PR.

--- a/packages/storefront-templates/src/__snapshots__/demo-business.test.ts.snap
+++ b/packages/storefront-templates/src/__snapshots__/demo-business.test.ts.snap
@@ -63,6 +63,36 @@ exports[`deriveDemoBusiness > matches the golden digest across all archetypes 1`
     },
   },
   {
+    "archetypeId": "medical-practice",
+    "cogProposal": "Allocate the next appointment to the best provider by availability",
+    "companyName": "Ashford Medical Practice",
+    "currency": "GBP",
+    "customers": 10,
+    "demand": {
+      "byStage": {
+        "deliver": 11,
+        "settle": 2,
+      },
+      "inFlight": 6,
+      "primaryQueue": "requests",
+      "queued": 7,
+      "total": 13,
+    },
+    "finance": {
+      "bills": 2,
+      "hasTaxPeriod": true,
+      "invoices": 2,
+      "obligations": 2,
+      "paidInvoices": 1,
+    },
+    "resources": 2,
+    "template": "BOOK",
+    "workforce": {
+      "ai": 1,
+      "humans": 3,
+    },
+  },
+  {
     "archetypeId": "physiotherapy",
     "cogProposal": "Allocate the next appointment to the best provider by availability",
     "companyName": "Ashford Physiotherapy",

--- a/packages/storefront-templates/src/activation-profile.ts
+++ b/packages/storefront-templates/src/activation-profile.ts
@@ -24,12 +24,15 @@ import type {
   OperatingModelAxes,
   OperatingModelDelivery,
   OperatingModelForm,
+  OwnershipScope,
   PartnerProgramProfile,
   PlatformEcosystem,
   PortfolioDecomposition,
   PortfolioScope,
   PrimaryConsumer,
   ProvisioningModel,
+  TransactionContext,
+  CapabilityIsolation,
 } from "./types";
 
 type UnknownRecord = Record<string, unknown>;
@@ -115,6 +118,28 @@ const APPLICABILITY_VALUES = new Set<CapabilityApplicability>([
   "optional",
   "hidden",
   "not-applicable",
+]);
+const OWNERSHIP_SCOPE_VALUES = new Set<OwnershipScope>([
+  "organization",
+  "customer-account",
+  "customer-site",
+  "configuration-item",
+  "edge-node",
+  "partner-account",
+]);
+const TRANSACTION_CONTEXT_VALUES = new Set<TransactionContext>([
+  "service-agreement",
+  "engagement",
+  "appointment",
+  "order",
+  "billing-period",
+  "episode-of-care",
+]);
+const ISOLATION_VALUES = new Set<CapabilityIsolation>([
+  "organization-scope",
+  "strict-customer-scope",
+  "shared",
+  "strict-partner-scope",
 ]);
 
 /**
@@ -240,9 +265,44 @@ function readCapabilityOverrides(raw: unknown): CapabilityOverride[] | null {
       return null;
     }
 
+    const ownershipScopes = item.ownershipScopes;
+    const transactionContexts = item.transactionContexts;
+    const isolation = item.isolation;
+    const surfaces = item.surfaces;
+    if (
+      (ownershipScopes !== undefined &&
+        (!Array.isArray(ownershipScopes) ||
+          ownershipScopes.some(
+            (scope) => typeof scope !== "string" || !OWNERSHIP_SCOPE_VALUES.has(scope as OwnershipScope),
+          ))) ||
+      (transactionContexts !== undefined &&
+        (!Array.isArray(transactionContexts) ||
+          transactionContexts.some(
+            (context) =>
+              typeof context !== "string" ||
+              !TRANSACTION_CONTEXT_VALUES.has(context as TransactionContext),
+          ))) ||
+      (isolation !== undefined &&
+        (typeof isolation !== "string" ||
+          !ISOLATION_VALUES.has(isolation as CapabilityIsolation))) ||
+      (surfaces !== undefined && !isStringArray(surfaces))
+    ) {
+      return null;
+    }
+
     overrides.push({
       capabilityKey: item.capabilityKey,
       applicability: item.applicability as CapabilityApplicability,
+      ...(ownershipScopes !== undefined
+        ? { ownershipScopes: ownershipScopes as OwnershipScope[] }
+        : {}),
+      ...(transactionContexts !== undefined
+        ? { transactionContexts: transactionContexts as TransactionContext[] }
+        : {}),
+      ...(isolation !== undefined
+        ? { isolation: isolation as CapabilityIsolation }
+        : {}),
+      ...(surfaces !== undefined ? { surfaces } : {}),
       reason: item.reason,
     });
   }

--- a/packages/storefront-templates/src/archetypes/archetypes.test.ts
+++ b/packages/storefront-templates/src/archetypes/archetypes.test.ts
@@ -128,6 +128,55 @@ describe("archetype catalog", () => {
     expect(getCapabilityApplicability(normalized, "customer-estate")).toBe("not-applicable");
   });
 
+  it("activates medical and dental practices as strictly isolated care practices (BI-HEALTHCARE-002)", () => {
+    const carePractices = ["medical-practice", "dental-practice"].map((id) =>
+      ALL_ARCHETYPES.find((archetype) => archetype.archetypeId === id),
+    );
+
+    for (const practice of carePractices) {
+      expect(practice, "both care-practice leaves should be registered").toBeDefined();
+      expect(practice?.category).toBe("healthcare-wellness");
+      expect(practice?.ctaType).toBe("booking");
+      expect(practice?.schedulingDefaults).toBeDefined();
+      expect(practice?.activationProfile?.axes).toMatchObject({
+        form: "services",
+        delivery: "hybrid",
+        primaryConsumer: "patient-and-payer",
+        consumptionChannel: "multi-channel",
+        commercialModel: "encounter-based",
+        provisioning: "episode-of-care",
+        platform: "no",
+      });
+      expect(practice?.activationProfile?.customerGraph).toBe("separate-customer-projection");
+      expect(practice?.activationProfile?.estateSeparation).toBe("strict");
+      expect(practice?.vocabulary).toMatchObject({
+        stakeholderLabel: "Patients",
+        inboxLabel: "Patient Appointments",
+      });
+      expect(practice?.vocabulary?.teamLabel).toMatch(/Team$/);
+      expect(practice?.vocabulary?.agentName).toMatch(/Front Desk Coordinator$/);
+
+      const normalized = readActivationProfile(practice?.activationProfile);
+      const patientAccounts = normalized?.capabilityActivations.find(
+        (activation) => activation.capabilityKey === "customer-accounts",
+      );
+      expect(patientAccounts).toMatchObject({
+        applicability: "required",
+        ownershipScopes: ["customer-account"],
+        transactionContexts: ["appointment", "episode-of-care"],
+        isolation: "strict-customer-scope",
+      });
+      const billing = normalized?.capabilityActivations.find(
+        (activation) => activation.capabilityKey === "billing-readiness",
+      );
+      expect(billing).toMatchObject({
+        applicability: "required",
+        transactionContexts: ["appointment", "episode-of-care"],
+        isolation: "strict-customer-scope",
+      });
+    }
+  });
+
   it("includes a software-platform archetype for DPF-style product sellers", () => {
     const softwarePlatform = ALL_ARCHETYPES.find((a) => a.archetypeId === "software-platform");
     expect(softwarePlatform).toBeDefined();

--- a/packages/storefront-templates/src/archetypes/healthcare-wellness.ts
+++ b/packages/storefront-templates/src/archetypes/healthcare-wellness.ts
@@ -17,6 +17,77 @@ const BOOKING_CONTACT_FIELDS = [
   { name: "notes", label: "Additional notes", type: "textarea" as const, required: false },
 ];
 
+const CARE_BOOKING_CONTACT_FIELDS = [
+  { name: "name", label: "Patient name", type: "text" as const, required: true },
+  { name: "email", label: "Email", type: "email" as const, required: true },
+  { name: "phone", label: "Phone", type: "tel" as const, required: true },
+];
+
+const CARE_PRACTICE_ACTIVATION: ArchetypeDefinition["activationProfile"] = {
+  profileType: "standard",
+  modules: ["service-operations", "billing-readiness", "lifecycle-signals", "integrations"],
+  billingReadinessMode: "prepared-not-prescribed",
+  customerGraph: "separate-customer-projection",
+  estateSeparation: "strict",
+  axes: {
+    form: "services",
+    delivery: "hybrid",
+    primaryConsumer: "patient-and-payer",
+    consumptionChannel: "multi-channel",
+    commercialModel: "encounter-based",
+    provisioning: "episode-of-care",
+    platform: "no",
+  },
+  portfolios: {
+    foundational: { scope: "standard" },
+    manufactureAndDeliver: {
+      scope: "primary",
+      it4itStages: ["request-to-fulfill", "detect-to-correct"],
+    },
+    forEmployees: { scope: "standard" },
+    productsAndServicesSold: { scope: "primary" },
+  },
+  capabilityOverrides: [
+    {
+      capabilityKey: "customer-accounts",
+      applicability: "required",
+      ownershipScopes: ["customer-account"],
+      transactionContexts: ["appointment", "episode-of-care"],
+      isolation: "strict-customer-scope",
+      surfaces: ["patients", "patient-portal", "appointments"],
+      reason: "Patient identity and care relationships require a strictly patient-scoped projection.",
+    },
+    {
+      capabilityKey: "billing-readiness",
+      applicability: "required",
+      ownershipScopes: ["customer-account"],
+      transactionContexts: ["appointment", "episode-of-care"],
+      isolation: "strict-customer-scope",
+      surfaces: ["finance", "patient-accounts", "payer-work"],
+      reason: "Patient, payer, and public-funding responsibility must remain linked to the care context.",
+    },
+    {
+      capabilityKey: "appointment-checkout",
+      applicability: "optional",
+      ownershipScopes: ["customer-account"],
+      transactionContexts: ["appointment"],
+      isolation: "strict-customer-scope",
+      surfaces: ["appointments", "patient-accounts"],
+      reason: "Patient collection may occur at an appointment but is not universal across funding models.",
+    },
+    {
+      capabilityKey: "point-of-sale",
+      applicability: "optional",
+      ownershipScopes: ["customer-account"],
+      transactionContexts: ["appointment"],
+      isolation: "strict-customer-scope",
+      surfaces: ["payments", "patient-accounts"],
+      reason: "Private or cost-share collection is optional and must remain patient scoped.",
+    },
+  ],
+  seededServiceCategories: ["patient-access", "care-delivery", "patient-accounts", "practice-operations"],
+};
+
 // Mobile / in-home healthcare sends a clinician to the patient rather than the
 // patient to a clinic. form=services + delivery=physical + onsite-plus-portal
 // (with episode-of-care provisioning) is what the forthcoming Field Dispatch
@@ -114,10 +185,62 @@ export const healthcareWellnessArchetypes: ArchetypeDefinition[] = [
       { type: "contact", title: "Find Us", sortOrder: 5 },
     ],
     formSchema: [
-      ...BOOKING_CONTACT_FIELDS,
+      ...CARE_BOOKING_CONTACT_FIELDS,
       { name: "patientType", label: "Patient type", type: "select" as const, required: true, options: ["New patient", "Existing patient"] },
+      { name: "visitReason", label: "Visit type", type: "select" as const, required: true, options: ["Routine check-up", "Hygiene visit", "Treatment follow-up", "Dental concern", "Emergency"] },
     ],
     schedulingDefaults: HEALTHCARE_SCHEDULING,
+    activationProfile: CARE_PRACTICE_ACTIVATION,
+    fieldDispatch: {
+      enabled: false,
+    },
+    vocabulary: {
+      portalLabel: "Dental Patient Portal",
+      stakeholderLabel: "Patients",
+      teamLabel: "Dental Team",
+      inboxLabel: "Patient Appointments",
+      agentName: "Dental Front Desk Coordinator",
+    },
+  },
+  {
+    archetypeId: "medical-practice",
+    name: "Medical Practice",
+    category: "healthcare-wellness",
+    ctaType: "booking",
+    tags: ["medical", "healthcare", "clinic", "doctor", "nurse", "appointment"],
+    itemTemplates: [
+      { name: "New Patient Visit", description: "Initial appointment to establish care", priceType: "quote", bookingDurationMinutes: 45 },
+      { name: "Routine Office Visit", description: "Scheduled visit with the care team", priceType: "quote", bookingDurationMinutes: 30 },
+      { name: "Preventive Care Visit", description: "Age-appropriate preventive care appointment", priceType: "quote", bookingDurationMinutes: 45 },
+      { name: "Follow-up Visit", description: "Follow-up on an existing care plan", priceType: "quote", bookingDurationMinutes: 20 },
+      { name: "Nurse Visit", description: "Short appointment with a member of the nursing team", priceType: "quote", bookingDurationMinutes: 20 },
+      { name: "Telehealth Visit", description: "Remote appointment where clinically appropriate", priceType: "quote", bookingDurationMinutes: 30 },
+    ],
+    sectionTemplates: [
+      { type: "hero", title: "Hero", sortOrder: 0 },
+      { type: "items", title: "Appointments & Services", sortOrder: 1 },
+      { type: "about", title: "About the Practice", sortOrder: 2 },
+      { type: "team", title: "Our Care Team", sortOrder: 3 },
+      { type: "contact", title: "Contact & Location", sortOrder: 4 },
+    ],
+    formSchema: [
+      ...CARE_BOOKING_CONTACT_FIELDS,
+      { name: "patientType", label: "Patient type", type: "select" as const, required: true, options: ["New patient", "Existing patient"] },
+      { name: "visitType", label: "Visit type", type: "select" as const, required: true, options: ["Routine visit", "Preventive care", "Follow-up", "Nurse visit", "Telehealth", "Other"] },
+      { name: "preferredPractitioner", label: "Preferred care team member (optional)", type: "text" as const, required: false },
+    ],
+    schedulingDefaults: HEALTHCARE_SCHEDULING,
+    activationProfile: CARE_PRACTICE_ACTIVATION,
+    fieldDispatch: {
+      enabled: false,
+    },
+    vocabulary: {
+      portalLabel: "Medical Patient Portal",
+      stakeholderLabel: "Patients",
+      teamLabel: "Medical Care Team",
+      inboxLabel: "Patient Appointments",
+      agentName: "Medical Front Desk Coordinator",
+    },
   },
   {
     archetypeId: "physiotherapy",


### PR DESCRIPTION
## Summary

- add the `medical-practice` leaf and deepen `dental-practice` under the existing `healthcare-wellness` category
- activate patient-and-payer, encounter-based, episode-of-care profiles with strict patient projection and appointment/care contexts
- add safe booking intake, medical/dental vocabulary, exact receptionist workspace profile, and specialized onboarding context
- preserve typed capability override scope/context/isolation fields during runtime normalization

## Safety and architecture

- no public diagnosis/test-result free text
- no new dashboard, route, healthcare registry, or parallel patient model
- conservative healthcare trust posture remains canonical
- clinic activity uses `multi-channel`; it is explicitly excluded from mobile field dispatch

## Verification

- `@dpf/storefront-templates`: 261 tests passed
- focused web profiles/onboarding/risk: 75 tests passed
- exact-SHA merged sandbox: 1,906 files / 16,447 tests passed; 4 files and 16 tests skipped; 18 todo
- exact-SHA merged sandbox: web typecheck passed
- exact-SHA merged sandbox: Next.js 16.2.10 production build passed; 131 static pages generated
- all 392 migrations current; no migration added

The checked-in gate wrapper received SIGTERM twice at different phases. The same exact merged SHA was then run directly under an explicit governed `local-integration-ci` lease; test and build evidence were recorded on `BI-HEALTHCARE-002`.

Local-CI-Override: exact-SHA governed sandbox tests, typecheck, and production build passed; wrapper-only SIGTERM documented in BI evidence

Backlog: `BI-HEALTHCARE-002`

Seed-Fit-Decision: archetype-scoped