### PR TITLE
feat(decision): converge WorkWarrant onto the one rigor engine (bridge)

### DIFF
--- a/apps/web/lib/decision/warrant-rightsizing-bridge.test.ts
+++ b/apps/web/lib/decision/warrant-rightsizing-bridge.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  warrantToRightsizingOpts,
+  resolveWarrantedPolicy,
+  warrantToModelTier,
+} from "./warrant-rightsizing-bridge";
+import { getProcessPolicy } from "@/lib/explore/build-process-matrix";
+import type { WorkWarrant, GateProfile, ModelTier } from "./work-warrant";
+
+// Minimal warrant fixture — only the fields the bridge reads matter; the rest are
+// filled with defensible defaults so the type is satisfied.
+function warrant(overrides: { gateProfile?: GateProfile; modelTier?: ModelTier }): WorkWarrant {
+  return {
+    altitude: "WSID",
+    altitudeBasis: "structural",
+    confidence: "high",
+    needsOperatorConfirm: false,
+    lane: "autonomous-bs",
+    budget: {
+      modelTier: overrides.modelTier ?? "standard",
+      effortLevel: "medium",
+      gateProfile: overrides.gateProfile ?? "standard",
+      tokenCeiling: null,
+    },
+    evidenceProfile: "standard",
+    reportingProfile: "one-line",
+    contextScope: {},
+    reasons: [],
+  };
+}
+
+describe("warrantToRightsizingOpts", () => {
+  it("collapsed → inert opts (qualityFirst off, low sensitivity) — base cell unchanged", () => {
+    expect(warrantToRightsizingOpts(warrant({ gateProfile: "collapsed" }))).toEqual({
+      qualityFirst: false,
+      sensitivity: "low",
+    });
+  });
+
+  it("standard → qualityFirst + elevated", () => {
+    expect(warrantToRightsizingOpts(warrant({ gateProfile: "standard" }))).toEqual({
+      qualityFirst: true,
+      sensitivity: "elevated",
+    });
+  });
+
+  it("full → qualityFirst + high (deepest policy for the type)", () => {
+    expect(warrantToRightsizingOpts(warrant({ gateProfile: "full" }))).toEqual({
+      qualityFirst: true,
+      sensitivity: "high",
+    });
+  });
+});
+
+describe("resolveWarrantedPolicy — the warrant drives the ONE existing engine", () => {
+  it("collapsed warrant returns the byte-identical base cell (no escalation)", () => {
+    const base = getProcessPolicy("feature", "small");
+    const warranted = resolveWarrantedPolicy("feature", "small", warrant({ gateProfile: "collapsed" }));
+    expect(warranted).toBe(base); // getProcessPolicy returns the same object when opts are inert
+  });
+
+  it("a full-gate (WWMD/high-blast) warrant escalates a SMALL build to thorough review", () => {
+    const warranted = resolveWarrantedPolicy("feature", "small", warrant({ gateProfile: "full" }));
+    expect(warranted.reviewIntensity).toBe("thorough");
+  });
+
+  it("rigor is monotonic in gate profile: full ≥ standard ≥ collapsed", () => {
+    const rank = { minimal: 0, standard: 1, thorough: 2 } as const;
+    const collapsed = resolveWarrantedPolicy("feature", "small", warrant({ gateProfile: "collapsed" }));
+    const standard = resolveWarrantedPolicy("feature", "small", warrant({ gateProfile: "standard" }));
+    const full = resolveWarrantedPolicy("feature", "small", warrant({ gateProfile: "full" }));
+    expect(rank[standard.reviewIntensity]).toBeGreaterThanOrEqual(rank[collapsed.reviewIntensity]);
+    expect(rank[full.reviewIntensity]).toBeGreaterThanOrEqual(rank[standard.reviewIntensity]);
+  });
+});
+
+describe("warrantToModelTier — reconcile 3-tier budget with 2-tier engine", () => {
+  it("economical → local", () => {
+    expect(warrantToModelTier(warrant({ modelTier: "economical" }))).toBe("local");
+  });
+  it("standard → robust", () => {
+    expect(warrantToModelTier(warrant({ modelTier: "standard" }))).toBe("robust");
+  });
+  it("strong → robust", () => {
+    expect(warrantToModelTier(warrant({ modelTier: "strong" }))).toBe("robust");
+  });
+});

--- a/apps/web/lib/decision/warrant-rightsizing-bridge.ts
+++ b/apps/web/lib/decision/warrant-rightsizing-bridge.ts
@@ -1,0 +1,72 @@
+// apps/web/lib/decision/warrant-rightsizing-bridge.ts
+//
+// Convergence bridge: WorkWarrant (decision-altitude control plane, EP-7B169558)
+// → the EXISTING right-sizing engine (getProcessPolicy / getModelTier /
+// deriveDeliverableSensitivity, EP-QUALITY-RIGHTSIZING).
+//
+// WHY THIS EXISTS: build-process-matrix already escalates gate/review rigor
+// MONOTONICALLY via RightsizingOpts {qualityFirst, sensitivity} and picks a
+// BuildModelTier. The warrant's budget.gateProfile / budget.modelTier are the
+// SAME decisions viewed through altitude + blast-radius. Rather than run two
+// parallel rigor engines (drift + double gate logic), the warrant becomes the
+// single front door and this bridge lets it DRIVE the one existing engine —
+// checkPhaseGate stays the sole gate authority; the warrant just supplies opts.
+//
+// Monotonic by construction: a collapsed (WSID) warrant maps to inert opts →
+// getProcessPolicy returns the byte-identical base cell; higher gate profiles can
+// only RAISE rigor, never relax below the matrix baseline.
+
+import type { WorkWarrant } from "./work-warrant";
+import {
+  getProcessPolicy,
+  type RightsizingOpts,
+  type LifecyclePolicy,
+  type BuildProcessType,
+  type BuildProcessSize,
+  type BuildModelTier,
+  type DeliverableSensitivity,
+} from "@/lib/explore/build-process-matrix";
+
+/**
+ * Map the warrant's gate profile to the existing RightsizingOpts.
+ *   collapsed → inert (qualityFirst off, low sensitivity) ⇒ base cell, unchanged
+ *   standard  → qualityFirst + elevated sensitivity
+ *   full      → qualityFirst + high sensitivity ⇒ deepest policy for the type
+ */
+export function warrantToRightsizingOpts(warrant: WorkWarrant): RightsizingOpts {
+  const sensitivity: DeliverableSensitivity =
+    warrant.budget.gateProfile === "full"
+      ? "high"
+      : warrant.budget.gateProfile === "standard"
+        ? "elevated"
+        : "low";
+  return {
+    qualityFirst: warrant.budget.gateProfile !== "collapsed",
+    sensitivity,
+  };
+}
+
+/**
+ * Resolve the ONE lifecycle policy a build should run, driven by its warrant.
+ * Thin over getProcessPolicy so checkPhaseGate remains the single gate authority
+ * and the (type, size) base matrix is unchanged — the warrant only supplies the
+ * escalation opts derived from altitude + blast-radius.
+ */
+export function resolveWarrantedPolicy(
+  processType: BuildProcessType | string | null | undefined,
+  processSize: BuildProcessSize | string | null | undefined,
+  warrant: WorkWarrant,
+): LifecyclePolicy {
+  return getProcessPolicy(processType, processSize, warrantToRightsizingOpts(warrant));
+}
+
+/**
+ * Reconcile the warrant's 3-tier model budget with the engine's 2-tier
+ * BuildModelTier (local | robust). `economical` → on-box local model; both
+ * `standard` and `strong` → the robust configured engine. Keeps a single
+ * model-tier vocabulary at the dispatch boundary (build-studio-config resolves
+ * the concrete provider for the tier).
+ */
+export function warrantToModelTier(warrant: WorkWarrant): BuildModelTier {
+  return warrant.budget.modelTier === "economical" ? "local" : "robust";
+}

--- a/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
+++ b/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
@@ -105,3 +105,27 @@ ties them to a single altitude signal.
 
 Process-Spine-Decision: altitude-classifier approach ratified via principle_decide
 (structure-first, composite 0.874, high confidence) — see above.
+
+## Convergence with EP-QUALITY-RIGHTSIZING (bridge, feat/warrant-rightsizing-bridge)
+
+Grounding review found the warrant must NOT run a parallel rigor engine: the existing
+`build-process-matrix.ts` already escalates gate/review rigor monotonically via
+`getProcessPolicy(type, size, RightsizingOpts{qualityFirst, sensitivity})`, already
+derives a blast-radius `sensitivity` (`deriveDeliverableSensitivity`), and already picks
+a `BuildModelTier` (`getModelTier`). The warrant's `budget.gateProfile`/`budget.modelTier`
+are the SAME decisions viewed through altitude + blast-radius.
+
+Decision: the warrant is the single **front door**; `warrant-rightsizing-bridge.ts` maps
+it onto the one existing engine so `checkPhaseGate` stays the sole gate authority:
+- `warrantToRightsizingOpts(warrant)` → `{qualityFirst, sensitivity}` (collapsed→inert base
+  cell; standard→elevated; full→high). Monotonic — can only raise rigor above the matrix
+  baseline, never relax below it.
+- `resolveWarrantedPolicy(type, size, warrant)` → the one `LifecyclePolicy` a build runs.
+- `warrantToModelTier(warrant)` → reconciles the 3-tier budget (economical|standard|strong)
+  with the engine's 2-tier `BuildModelTier` (local|robust).
+
+Consequence: **BI-22250BA2 (blast-radius signal provider) IS the already-planned
+BI-CFEB2B22 (P3)** — the `deriveDeliverableSensitivity` header names it: "replaces the
+heuristic with code-graph blast-radius." They should be consolidated: the code-graph + EA
+blast-radius feeds `sensitivity` (verify) and the warrant's blast-radius (promote) through
+one core, not two.


### PR DESCRIPTION
Third piece of the decision-altitude control plane (EP-7B169558), after the classifier (#3091) and `deriveWarrant` (#3092).

## What
Grounding review found the warrant was drifting into a **parallel rigor engine**. `build-process-matrix.ts` already:
- escalates gate/review rigor monotonically via `getProcessPolicy(type, size, RightsizingOpts{qualityFirst, sensitivity})`
- derives a blast-radius `sensitivity` (`deriveDeliverableSensitivity`)
- picks a `BuildModelTier` (`getModelTier`)

The warrant's `budget.gateProfile`/`modelTier` are the **same decisions** viewed through altitude + blast-radius. This PR makes the warrant the single front door that *drives* the one existing engine instead of duplicating it — `checkPhaseGate` stays the sole gate authority.

- `warrantToRightsizingOpts` — collapsed→inert (base cell unchanged), standard→elevated, full→high. Monotonic.
- `resolveWarrantedPolicy` — the one `LifecyclePolicy` a build runs.
- `warrantToModelTier` — reconciles the 3-tier budget (economical|standard|strong) with the 2-tier `BuildModelTier` (local|robust).

## Convergence note (in the plan doc)
**BI-22250BA2 (blast-radius signal provider) IS the already-planned BI-CFEB2B22 (P3)** — `deriveDeliverableSensitivity`'s own header says "replaces the heuristic with code-graph blast-radius." Consolidate: one blast-radius core feeds both `sensitivity` (verify) and the warrant's blast-radius (promote).

## Verification
`tsc --noEmit` clean; `vitest` 9 passed (incl. "a full-gate warrant escalates a SMALL build to thorough review" and monotonicity full ≥ standard ≥ collapsed).

Pure + tested; no migration, no runtime wiring yet — the next PR swaps promote/gate call sites to `resolveWarrantedPolicy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)