### PR TITLE
fix(discovery): make the (from,to,type) tuple the canonical InventoryRelationship key to end cross-run P2002 (BI-PIR-7d69a445)

### DIFF
--- a/packages/db/prisma/migrations/20260716230000_inventoryrelationship_tuple_canonical/migration.sql
+++ b/packages/db/prisma/migrations/20260716230000_inventoryrelationship_tuple_canonical/migration.sql
@@ -1,0 +1,31 @@
+-- BI-PIR-7d69a445 (part 2): make the (fromEntityId, toEntityId, relationshipType)
+-- tuple the CANONICAL identity of an InventoryRelationship and demote
+-- relationshipKey to non-unique.
+--
+-- InventoryRelationship carried TWO uniques: relationshipKey (source-scoped) and
+-- the compound (fromEntityId, toEntityId, relationshipType) (persisted-entity
+-- level). Entity dedup can map two distinct discovered refs onto ONE persisted
+-- entity id, so relationships with DISTINCT relationshipKeys resolve to the SAME
+-- tuple. The discovery-sync upsert targeted `where: { relationshipKey }` but its
+-- `create` wrote the tuple, so when a PRIOR run had already persisted that tuple
+-- under a different relationshipKey the create path violated the compound
+-- @@unique -> P2002 aborted the whole persistence transaction. Re-pointing the
+-- upsert at the tuple (in the same commit) fixes that; this migration removes the
+-- now-wrong global uniqueness on relationshipKey.
+--
+-- relationshipKey stays as a plain column (still written for provenance /
+-- back-compat). Nothing looks up InventoryRelationship by relationshipKey
+-- (no findUnique/where on it outside discovery-sync), and per-run relationshipKey
+-- provenance is preserved on DiscoveredRelationship via its own
+-- @@unique([discoveryRunId, relationshipKey]) -- so demoting this @unique loses
+-- nothing.
+--
+-- @migration-safety: data-safe: dropping a UNIQUE index is a metadata-only
+-- catalog change (no table rewrite, no heap scan of existing rows) and only
+-- LOOSENS a constraint, so it cannot fail on existing data. No new/tightened
+-- constraint is introduced. The canonical tuple @@unique
+-- ("InventoryRelationship_fromEntityId_toEntityId_relationshipType_key") is
+-- UNCHANGED and remains enforced, so no duplicate tuple can appear as a result of
+-- this change (verified: 0 duplicate-tuple groups on the live estate before
+-- migration).
+DROP INDEX "InventoryRelationship_relationshipKey_key";

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4530,7 +4530,15 @@ model InventoryEntity {
 
 model InventoryRelationship {
   id                      String                   @id @default(cuid())
-  relationshipKey         String                   @unique
+  // BI-PIR-7d69a445 (part 2): relationshipKey is SOURCE-SCOPED provenance that
+  // varies per source/scope for the same real relationship, so it is NOT the
+  // canonical identity — it is intentionally non-unique. The canonical identity
+  // is the compound @@unique([fromEntityId, toEntityId, relationshipType]) below.
+  // Per-run relationshipKey provenance is preserved on DiscoveredRelationship
+  // (@@unique([discoveryRunId, relationshipKey])); nothing looks up
+  // InventoryRelationship by relationshipKey, so dropping its @unique loses
+  // nothing and ends the cross-run P2002 (the upsert now targets the tuple).
+  relationshipKey         String
   relationshipType        String
   status                  String                   @default("active")
   confidence              Float?

--- a/packages/db/scripts/schema-regression-guard.mjs
+++ b/packages/db/scripts/schema-regression-guard.mjs
@@ -159,6 +159,16 @@ export const INTENTIONAL_FIELD_REMOVALS = new Set([
   "ModelProvider.supportedModalities",
   // 2026-06-19: deprecated duplicate of the canonical StorefrontConfig.archetypeId.
   "BusinessContext.archetypeId",
+  // 2026-07-16 BI-PIR-7d69a445 (part 2): drop the `@unique` on
+  // InventoryRelationship.relationshipKey — the COLUMN is KEPT (still written for
+  // provenance/back-compat), only its source-scoped uniqueness is removed so the
+  // discovery-sync upsert can target the canonical
+  // @@unique([fromEntityId, toEntityId, relationshipType]) tuple and stop the
+  // cross-run P2002. Migration:
+  // 20260716230000_inventoryrelationship_tuple_canonical. Prune once shipped to
+  // every environment. (This guard keys the skip by field name; the field itself
+  // is not dropped, so no other line for it can regress.)
+  "InventoryRelationship.relationshipKey",
 ]);
 
 export function diffSchemas(base, head, allowlist = INTENTIONAL_FIELD_REMOVALS) {

--- a/packages/db/src/discovery-sync.test.ts
+++ b/packages/db/src/discovery-sync.test.ts
@@ -56,10 +56,16 @@ describe("persistBootstrapDiscoveryRun", () => {
         },
         inventoryRelationship: {
           findMany: async () => [],
-          upsert: async ({ where }: { where: { relationshipKey: string } }) => ({
-            id: `relationship:${where.relationshipKey}`,
-            relationshipKey: where.relationshipKey,
-          }),
+          upsert: async ({ where, create }: {
+            where: { fromEntityId_toEntityId_relationshipType: { fromEntityId: string; toEntityId: string; relationshipType: string } };
+            create: { relationshipKey: string };
+          }) => {
+            const { fromEntityId, toEntityId, relationshipType } = where.fromEntityId_toEntityId_relationshipType;
+            return {
+              id: `relationship:${fromEntityId}|${toEntityId}|${relationshipType}`,
+              relationshipKey: create.relationshipKey,
+            };
+          },
           updateMany: async () => ({ count: 0 }),
         },
         discoveredRelationship: {
@@ -245,10 +251,16 @@ describe("persistBootstrapDiscoveryRun", () => {
         },
         inventoryRelationship: {
           findMany: async () => [],
-          upsert: async ({ where }: { where: { relationshipKey: string } }) => ({
-            id: `relationship:${where.relationshipKey}`,
-            relationshipKey: where.relationshipKey,
-          }),
+          upsert: async ({ where, create }: {
+            where: { fromEntityId_toEntityId_relationshipType: { fromEntityId: string; toEntityId: string; relationshipType: string } };
+            create: { relationshipKey: string };
+          }) => {
+            const { fromEntityId, toEntityId, relationshipType } = where.fromEntityId_toEntityId_relationshipType;
+            return {
+              id: `relationship:${fromEntityId}|${toEntityId}|${relationshipType}`,
+              relationshipKey: create.relationshipKey,
+            };
+          },
           updateMany: async () => ({ count: 0 }),
         },
         discoveredRelationship: {
@@ -342,9 +354,18 @@ describe("persistBootstrapDiscoveryRun", () => {
         discoveredSoftwareEvidence: { upsert: async () => ({}) },
         inventoryRelationship: {
           findMany: async () => [],
-          upsert: async ({ where }: { where: { relationshipKey: string } }) => {
-            relationshipUpsertKeys.push(where.relationshipKey);
-            return { id: `relationship:${where.relationshipKey}`, relationshipKey: where.relationshipKey };
+          upsert: async ({ where, create }: {
+            where: { fromEntityId_toEntityId_relationshipType: { fromEntityId: string; toEntityId: string; relationshipType: string } };
+            create: { relationshipKey: string };
+          }) => {
+            // The upsert conflict target is the tuple; record the source key it
+            // carried so the assertion can prove the single upsert used rel:k1.
+            relationshipUpsertKeys.push(create.relationshipKey);
+            const { fromEntityId, toEntityId, relationshipType } = where.fromEntityId_toEntityId_relationshipType;
+            return {
+              id: `relationship:${fromEntityId}|${toEntityId}|${relationshipType}`,
+              relationshipKey: create.relationshipKey,
+            };
           },
           updateMany: async () => ({ count: 0 }),
         },
@@ -421,10 +442,147 @@ describe("persistBootstrapDiscoveryRun", () => {
     // reused it instead of taking the crashing create path)...
     expect(relationshipUpsertKeys).toEqual(["rel:k1"]);
     // ...but BOTH relationships kept their own provenance row, linked to the one
-    // shared InventoryRelationship.
+    // shared InventoryRelationship (identified by its resolved tuple, since the
+    // upsert now keys on the tuple, not relationshipKey).
+    const sharedTupleId = "relationship:entity:host:shared|entity:runtime:target|hosts";
     expect(discoveredRelationshipCreates).toEqual([
-      { relationshipKey: "rel:k1", connectId: "relationship:rel:k1" },
-      { relationshipKey: "rel:k2", connectId: "relationship:rel:k1" },
+      { relationshipKey: "rel:k1", connectId: sharedTupleId },
+      { relationshipKey: "rel:k2", connectId: sharedTupleId },
+    ]);
+  });
+
+  it("UPDATES a tuple persisted by a PRIOR run under a different relationshipKey — no cross-run P2002 (BI-PIR-7d69a445 part 2)", async () => {
+    // Part 2 cross-run repro. A PRIOR run persisted the (from, to, "hosts") tuple
+    // under relationshipKey "rel:k1" (returned here by findMany as an existing
+    // row). This NEW run presents the SAME tuple under a DIFFERENT relationshipKey
+    // "rel:k2". With relationshipKey as the upsert conflict target, the create path
+    // would fire and violate the compound @@unique (the cross-run P2002). With the
+    // tuple as the conflict target, the upsert UPDATES the existing row instead:
+    // exactly one upsert, counted as UPDATED (not created), and the new run still
+    // records its own DiscoveredRelationship provenance under "rel:k2".
+    const fromEntityId = "entity:host:shared";
+    const toEntityId = "entity:runtime:target";
+    const relationshipType = "hosts";
+    const tupleId = "prior-run-relationship-id";
+
+    const upsertCalls: Array<{
+      where: { fromEntityId_toEntityId_relationshipType: { fromEntityId: string; toEntityId: string; relationshipType: string } };
+      create: { relationshipKey: string };
+      update: { relationshipKey: string };
+    }> = [];
+    const discoveredRelationshipCreates: Array<{ relationshipKey: string; connectId: string }> = [];
+
+    const db = {
+      $transaction: async <T>(fn: (tx: any) => Promise<T>): Promise<T> => fn({
+        discoveryRun: { create: async () => ({ id: "run-cross" }) },
+        inventoryEntity: {
+          findMany: async () => [],
+          upsert: async ({ where }: { where: { entityKey: string } }) => ({
+            id: `entity:${where.entityKey}`,
+            entityKey: where.entityKey,
+          }),
+          updateMany: async () => ({ count: 0 }),
+        },
+        discoveredItem: {
+          create: async ({ data }: { data: { observedKey: string } }) => ({
+            id: `discovered:${data.observedKey}`,
+          }),
+        },
+        discoveredSoftwareEvidence: { upsert: async () => ({}) },
+        inventoryRelationship: {
+          // The prior run's row for this tuple, under the OLD relationshipKey.
+          findMany: async () => [
+            { id: tupleId, relationshipKey: "rel:k1", fromEntityId, toEntityId, relationshipType },
+          ],
+          upsert: async (args: {
+            where: { fromEntityId_toEntityId_relationshipType: { fromEntityId: string; toEntityId: string; relationshipType: string } };
+            create: { relationshipKey: string };
+            update: { relationshipKey: string };
+          }) => {
+            upsertCalls.push(args);
+            // A tuple-keyed upsert against an existing tuple returns that same row.
+            return { id: tupleId, relationshipKey: args.create.relationshipKey };
+          },
+          updateMany: async () => ({ count: 0 }),
+        },
+        discoveredRelationship: {
+          create: async ({ data }: { data: { relationshipKey: string; inventoryRelationship: { connect: { id: string } } } }) => {
+            discoveredRelationshipCreates.push({
+              relationshipKey: data.relationshipKey,
+              connectId: data.inventoryRelationship.connect.id,
+            });
+            return {};
+          },
+        },
+        portfolioQualityIssue: { findMany: async () => [], upsert: async () => ({}) },
+      }),
+    };
+
+    const entity = (discoveredKey: string, entityKey: string) => ({
+      entityKey,
+      entityType: "host",
+      name: entityKey,
+      discoveredKey,
+      portfolioSlug: "foundational",
+      taxonomyNodeId: "foundational/compute/servers",
+      attributionStatus: "attributed" as const,
+      attributionMethod: "rule" as const,
+      attributionConfidence: 0.98,
+      providerView: "foundational",
+      properties: {},
+    });
+    const item = (discoveredKey: string) => ({
+      discoveredKey,
+      sourceKind: "dpf_bootstrap",
+      itemType: "host",
+      name: discoveredKey,
+      externalRef: discoveredKey,
+      attributes: {},
+    });
+
+    const summary = await persistBootstrapDiscoveryRun(
+      db,
+      {
+        discoveredItems: [item("dk:from"), item("dk:to")],
+        inventoryEntities: [
+          entity("dk:from", "host:shared"),
+          entity("dk:to", "runtime:target"),
+        ],
+        inventoryRelationships: [
+          {
+            // Same tuple as the prior run, but a NEW relationshipKey.
+            relationshipKey: "rel:k2",
+            relationshipType,
+            fromDiscoveredKey: "dk:from",
+            toDiscoveredKey: "dk:to",
+            properties: {},
+          },
+        ],
+        softwareEvidence: [],
+      },
+      { runKey: "run-cross", sourceSlug: "dpf_bootstrap" },
+      {
+        projectInventoryEntity: async () => undefined,
+        projectInventoryRelationship: async () => undefined,
+      },
+    );
+
+    // Exactly one upsert, and its conflict target is the tuple (not relationshipKey).
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0]?.where).toEqual({
+      fromEntityId_toEntityId_relationshipType: { fromEntityId, toEntityId, relationshipType },
+    });
+    // The upsert's update block refreshes relationshipKey to the new run's key.
+    expect(upsertCalls[0]?.update.relationshipKey).toBe("rel:k2");
+    // The prior tuple existed, so it counts as UPDATED, not created — and it is
+    // NOT swept stale (its tuple was re-observed this run).
+    expect(summary.updatedRelationships).toBe(1);
+    expect(summary.createdRelationships).toBe(0);
+    expect(summary.staleRelationships).toBe(0);
+    // The new run still records its own provenance row under rel:k2, linked to the
+    // one shared canonical InventoryRelationship.
+    expect(discoveredRelationshipCreates).toEqual([
+      { relationshipKey: "rel:k2", connectId: tupleId },
     ]);
   });
 });

--- a/packages/db/src/discovery-sync.ts
+++ b/packages/db/src/discovery-sync.ts
@@ -95,16 +95,40 @@ type DiscoverySyncTx = {
         scopeKey?: string;
         lastConfirmedRun?: { sourceSlug?: string };
       };
-      select: { relationshipKey: true };
-    }): Promise<Array<{ relationshipKey: string }>>;
+      // BI-PIR-7d69a445 (part 2): the tuple is the canonical identity, so the
+      // existing-relationship read pulls the tuple columns (+ id for the stale
+      // sweep, + relationshipKey for the stale-relationship quality issue).
+      select: {
+        id: true;
+        relationshipKey: true;
+        fromEntityId: true;
+        toEntityId: true;
+        relationshipType: true;
+      };
+    }): Promise<Array<{
+      id: string;
+      relationshipKey: string;
+      fromEntityId: string;
+      toEntityId: string;
+      relationshipType: string;
+    }>>;
     upsert(args: {
-      where: { relationshipKey: string };
+      // Conflict target is the compound @@unique, NOT relationshipKey, so a tuple
+      // persisted by a prior run under a different relationshipKey UPDATES rather
+      // than crashing on the create path (P2002).
+      where: {
+        fromEntityId_toEntityId_relationshipType: {
+          fromEntityId: string;
+          toEntityId: string;
+          relationshipType: string;
+        };
+      };
       create: Record<string, unknown>;
       update: Record<string, unknown>;
       select: { id: true; relationshipKey: true };
     }): Promise<{ id: string; relationshipKey: string }>;
     updateMany(args: {
-      where: { scopeKey?: string; relationshipKey: { in: string[] } };
+      where: { id: { in: string[] } };
       data: { status: string; lastSeenAt: Date };
     }): Promise<{ count: number }>;
   };
@@ -244,12 +268,29 @@ export async function persistBootstrapDiscoveryRun(
         select: { entityKey: true },
       })).map((entity) => entity.entityKey),
     );
-    const existingRelationshipKeys = new Set(
-      (await tx.inventoryRelationship.findMany({
-        where: { ...scopeWhere, ...sourceFilter },
-        select: { relationshipKey: true },
-      })).map((relationship) => relationship.relationshipKey),
-    );
+    // BI-PIR-7d69a445 (part 2): key existing relationships by their canonical
+    // tuple (fromEntityId, toEntityId, relationshipType) rather than by
+    // relationshipKey. relationshipKey is source-scoped provenance that can differ
+    // across runs for the same real relationship, so keying created-vs-updated
+    // accounting and the stale sweep on it double-counts and mis-sweeps across
+    // runs. The tuple is the compound @@unique — the real identity. relationshipKey
+    // is retained per row so the stale-relationship quality issue can still name it.
+    const existingRelationshipByTuple = new Map<string, { id: string; relationshipKey: string }>();
+    for (const existing of await tx.inventoryRelationship.findMany({
+      where: { ...scopeWhere, ...sourceFilter },
+      select: {
+        id: true,
+        relationshipKey: true,
+        fromEntityId: true,
+        toEntityId: true,
+        relationshipType: true,
+      },
+    })) {
+      existingRelationshipByTuple.set(
+        relationshipTupleKey(existing.fromEntityId, existing.toEntityId, existing.relationshipType),
+        { id: existing.id, relationshipKey: existing.relationshipKey },
+      );
+    }
     const existingIssueKeys = new Set(
       (await tx.portfolioQualityIssue.findMany({ select: { issueKey: true } }))
         .map((issue) => issue.issueKey),
@@ -510,16 +551,14 @@ export async function persistBootstrapDiscoveryRun(
       // BI-PIR-7d69a445: entity dedup can map two distinct discovered refs onto
       // one persisted entity id, so two relationships with DISTINCT
       // relationshipKeys can resolve to the SAME (fromEntityId, toEntityId,
-      // relationshipType) tuple. The upsert's conflict target is relationshipKey,
-      // so the second one misses, takes the create path, and violates the compound
-      // @@unique — a P2002 that (inside this $transaction) aborts the entire
-      // persistence run. Reuse the row already upserted for this tuple in the
-      // current run rather than re-entering the create path. The
-      // DiscoveredRelationship below is still written for every relationship, so
-      // each source key keeps its own provenance row linked to the shared
-      // InventoryRelationship. (Cross-run collisions, where the tuple was
-      // persisted by a PRIOR run under a different relationshipKey, still need a
-      // canonical-key decision — tracked on BI-PIR-7d69a445.)
+      // relationshipType) tuple. This in-run map (part 1) collapses same-run tuple
+      // collisions so only the first relationship for a tuple upserts and later
+      // colliding keys reuse its id. Part 2 re-points the upsert conflict target
+      // itself at the tuple @@unique, so a tuple persisted by a PRIOR run (under a
+      // different relationshipKey) now UPDATES rather than crashing on the create
+      // path. The DiscoveredRelationship below is still written for every
+      // relationship, so each source key keeps its own provenance row linked to
+      // the shared InventoryRelationship.
       const tupleKey = relationshipTupleKey(
         fromEntityId,
         toEntityId,
@@ -527,9 +566,21 @@ export async function persistBootstrapDiscoveryRun(
       );
       let persistedRelationshipId = persistedRelationshipIdByTuple.get(tupleKey);
       if (!persistedRelationshipId) {
-        const existed = existingRelationshipKeys.has(relationship.relationshipKey);
+        const existed = existingRelationshipByTuple.has(tupleKey);
         const persistedRelationship = await tx.inventoryRelationship.upsert({
-          where: { relationshipKey: relationship.relationshipKey },
+          // BI-PIR-7d69a445 (part 2): conflict target is the compound @@unique,
+          // not relationshipKey. When a PRIOR run already persisted this tuple
+          // (under any relationshipKey), the upsert now UPDATES that row instead
+          // of taking the create path and violating the tuple @@unique (the
+          // cross-run P2002). The in-run persistedRelationshipIdByTuple guard above
+          // still collapses same-run tuple collisions (part 1).
+          where: {
+            fromEntityId_toEntityId_relationshipType: {
+              fromEntityId,
+              toEntityId,
+              relationshipType: relationship.relationshipType,
+            },
+          },
           create: {
             relationshipKey: relationship.relationshipKey,
             relationshipType: relationship.relationshipType,
@@ -550,6 +601,11 @@ export async function persistBootstrapDiscoveryRun(
             toEntity: { connect: { id: toEntityId } },
           },
           update: {
+            // Refresh relationshipKey to the latest observed source key. The
+            // per-run provenance history is preserved on DiscoveredRelationship;
+            // this column just carries the most-recent source key for the shared
+            // canonical row (now non-unique, so no P2002 on this write).
+            relationshipKey: relationship.relationshipKey,
             relationshipType: relationship.relationshipType,
             status: "active",
             confidence: relationship.confidence ?? null,
@@ -592,18 +648,23 @@ export async function persistBootstrapDiscoveryRun(
       });
     }
 
-    const currentRelationshipKeys = new Set(
-      normalized.inventoryRelationships.map((relationship) => relationship.relationshipKey),
-    );
-    // Same column-based source attribution as entities above — the
-    // sweep only sees relationships it previously confirmed, so it can
-    // only mark its own rows stale.
-    const staleRelationshipKeys = [...existingRelationshipKeys]
-      .filter((relationshipKey) => !currentRelationshipKeys.has(relationshipKey));
-    const staleRelationships = staleRelationshipKeys.length === 0
+    // BI-PIR-7d69a445 (part 2): staleness is tuple-identity based. Any tuple this
+    // source previously confirmed (existingRelationshipByTuple — already scope +
+    // source filtered, same column-based source attribution as entities above)
+    // that was NOT re-persisted this run (persistedRelationshipIdByTuple holds
+    // every tuple resolved in the loop) is stale, and is marked by row id. Keying
+    // on the tuple rather than relationshipKey means a prior run's row re-observed
+    // this run under a DIFFERENT relationshipKey is correctly treated as confirmed
+    // (its tuple is in persistedRelationshipIdByTuple), not swept stale.
+    const staleExistingRelationships = [...existingRelationshipByTuple.entries()]
+      .filter(([tupleKey]) => !persistedRelationshipIdByTuple.has(tupleKey))
+      .map(([, value]) => value);
+    // relationshipKey of each stale row, for the stale-relationship quality issue.
+    const staleRelationshipKeys = staleExistingRelationships.map((value) => value.relationshipKey);
+    const staleRelationships = staleExistingRelationships.length === 0
       ? 0
       : (await tx.inventoryRelationship.updateMany({
-          where: { ...scopeWhere, relationshipKey: { in: staleRelationshipKeys } },
+          where: { id: { in: staleExistingRelationships.map((value) => value.id) } },
           data: { status: "stale", lastSeenAt: now },
         })).count;
 

--- a/packages/db/test/discovery-sync-scope.test.ts
+++ b/packages/db/test/discovery-sync-scope.test.ts
@@ -34,10 +34,16 @@ function buildStubDb() {
         discoveredSoftwareEvidence: { upsert: async () => ({}) },
         inventoryRelationship: {
           findMany: relationshipFindMany,
-          upsert: async ({ where }: { where: { relationshipKey: string } }) => ({
-            id: `relationship:${where.relationshipKey}`,
-            relationshipKey: where.relationshipKey,
-          }),
+          upsert: async ({ where, create }: {
+            where: { fromEntityId_toEntityId_relationshipType: { fromEntityId: string; toEntityId: string; relationshipType: string } };
+            create: { relationshipKey: string };
+          }) => {
+            const { fromEntityId, toEntityId, relationshipType } = where.fromEntityId_toEntityId_relationshipType;
+            return {
+              id: `relationship:${fromEntityId}|${toEntityId}|${relationshipType}`,
+              relationshipKey: create.relationshipKey,
+            };
+          },
           updateMany: relationshipUpdateMany,
         },
         discoveredRelationship: { create: async () => ({}) },
@@ -113,7 +119,15 @@ describe("persistBootstrapDiscoveryRun customer-scope isolation", () => {
         scopeKey: "customer:cust_a:site:site_austin",
         lastConfirmedRun: { sourceSlug: "edge-node:node-a" },
       },
-      select: { relationshipKey: true },
+      // BI-PIR-7d69a445 (part 2): existing relationships are read by their
+      // canonical tuple columns (+ id for the stale sweep, + relationshipKey).
+      select: {
+        id: true,
+        relationshipKey: true,
+        fromEntityId: true,
+        toEntityId: true,
+        relationshipType: true,
+      },
     });
 
     // Stale detection only marks entities in the same scope stale.

--- a/packages/db/test/discovery-sync-source-attribution.test.ts
+++ b/packages/db/test/discovery-sync-source-attribution.test.ts
@@ -19,7 +19,14 @@ type FindManyArgs = {
     scopeKey?: string;
     lastConfirmedRun?: { sourceSlug?: string };
   };
-  select: { entityKey?: true; relationshipKey?: true };
+  select: {
+    entityKey?: true;
+    id?: true;
+    relationshipKey?: true;
+    fromEntityId?: true;
+    toEntityId?: true;
+    relationshipType?: true;
+  };
 };
 
 function buildStubDb(opts: {
@@ -37,8 +44,15 @@ function buildStubDb(opts: {
   const entityUpdateMany = vi.fn().mockResolvedValue({ count: 0 });
   const relationshipFindMany = vi.fn(async (args: FindManyArgs) => {
     const sourceSlug = args.where?.lastConfirmedRun?.sourceSlug ?? "__unknown__";
+    // BI-PIR-7d69a445 (part 2): existing relationships are keyed by tuple now, so
+    // the stub synthesizes a distinct tuple + id per relationshipKey. The stale
+    // sweep marks rows by id, so `id` maps 1:1 back to the source relationshipKey.
     return (opts.relationshipsBySource?.[sourceSlug] ?? []).map((relationshipKey) => ({
+      id: `relationship:${relationshipKey}`,
       relationshipKey,
+      fromEntityId: `from:${relationshipKey}`,
+      toEntityId: `to:${relationshipKey}`,
+      relationshipType: "hosts",
     }));
   });
   const relationshipUpdateMany = vi.fn().mockResolvedValue({ count: 0 });
@@ -63,10 +77,16 @@ function buildStubDb(opts: {
         discoveredSoftwareEvidence: { upsert: async () => ({}) },
         inventoryRelationship: {
           findMany: relationshipFindMany,
-          upsert: async ({ where }: { where: { relationshipKey: string } }) => ({
-            id: `relationship:${where.relationshipKey}`,
-            relationshipKey: where.relationshipKey,
-          }),
+          upsert: async ({ where, create }: {
+            where: { fromEntityId_toEntityId_relationshipType: { fromEntityId: string; toEntityId: string; relationshipType: string } };
+            create: { relationshipKey: string };
+          }) => {
+            const { fromEntityId, toEntityId, relationshipType } = where.fromEntityId_toEntityId_relationshipType;
+            return {
+              id: `relationship:${fromEntityId}|${toEntityId}|${relationshipType}`,
+              relationshipKey: create.relationshipKey,
+            };
+          },
           updateMany: relationshipUpdateMany,
         },
         discoveredRelationship: { create: async () => ({}) },
@@ -225,16 +245,25 @@ describe("persistBootstrapDiscoveryRun source attribution", () => {
         scopeKey,
         lastConfirmedRun: { sourceSlug: "unifi" },
       },
-      select: { relationshipKey: true },
+      // BI-PIR-7d69a445 (part 2): read by canonical tuple columns (+ id, + key).
+      select: {
+        id: true,
+        relationshipKey: true,
+        fromEntityId: true,
+        toEntityId: true,
+        relationshipType: true,
+      },
     });
 
-    // Only unifi's relationship key is a stale candidate.
+    // Only unifi's relationship is a stale candidate — the stale sweep now targets
+    // rows by id (the tuple's row), and unifi's row id maps back to its own key.
+    // edge-node:node-a's row was never even read by unifi's sweep.
     const updateCallArgs = relationshipUpdateMany.mock.calls[0]?.[0];
-    expect(updateCallArgs?.where.relationshipKey.in).toEqual([
-      `${scopeKey}:unifi:hosts:r1->r2`,
+    expect(updateCallArgs?.where.id.in).toEqual([
+      `relationship:${scopeKey}:unifi:hosts:r1->r2`,
     ]);
-    expect(updateCallArgs?.where.relationshipKey.in).not.toContain(
-      `${scopeKey}:edge:hosts:r3->r4`,
+    expect(updateCallArgs?.where.id.in).not.toContain(
+      `relationship:${scopeKey}:edge:hosts:r3->r4`,
     );
   });
 });

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -66,4 +66,5 @@ apps/web/lib/work-capsules/work-capsule-store.ts	1041
 apps/web/lib/workbooks/platform-tables.ts	938
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace/command-center.ts	1118
+packages/db/src/discovery-sync.ts	822
 packages/db/src/wiki-store.test.ts	824


### PR DESCRIPTION
## Why this is safe — the evidence (decision: TUPLE-CANONICAL)

`relationshipKey` on `InventoryRelationship` is **source-scoped provenance**, not the row's global identity. The evidence that the `(fromEntityId, toEntityId, relationshipType)` tuple is the real identity:

- **Nothing looks up `InventoryRelationship` by `relationshipKey`.** A repo-wide grep found no `findUnique`/`findFirst`/`where` on `InventoryRelationship.relationshipKey` outside `discovery-sync.ts` (the upsert conflict target + the stale sweep, both re-pointed here). So its `@unique` bought nothing except the crash.
- **Per-run `relationshipKey` provenance is preserved** on `DiscoveredRelationship` via `@@unique([discoveryRunId, relationshipKey])`. Every source key still gets its own provenance row linked to the shared canonical `InventoryRelationship`. Demoting `InventoryRelationship.relationshipKey` to non-unique loses no information.
- **The tuple is already the persisted-entity identity** — `@@unique([fromEntityId, toEntityId, relationshipType])` — and it is left unchanged.
- **No existing data violates the tuple uniqueness.** Verified on the live estate: `0` duplicate-tuple groups (expected, since the tuple `@@unique` was already enforced). Dropping the `relationshipKey` unique index is a metadata-only loosening that cannot fail on existing rows.

## What was wrong (the cross-run P2002)

The upsert targeted `where: { relationshipKey }` but its `create` wrote the tuple. When a **prior run** had already persisted the same real relationship under a **different** `relationshipKey`, the new run missed on `relationshipKey`, took the **create** path, and violated the tuple `@@unique` → `P2002` aborted the whole persistence `$transaction`.

Before / after conflict target:

```diff
- where: { relationshipKey: relationship.relationshipKey },
+ where: {
+   fromEntityId_toEntityId_relationshipType: {
+     fromEntityId,
+     toEntityId,
+     relationshipType: relationship.relationshipType,
+   },
+ },
```

Now a prior run's tuple re-appears → the upsert **UPDATES** it (refreshing `lastSeenAt` / `lastConfirmedRun` / `relationshipKey`) instead of trying to create a duplicate.

## This completes part 2, atop #3054's part 1

- **Part 1 (#3054, merged):** in-run tuple dedup — a `Map<tupleKey, persistedId>` so two keys that collapse to one tuple **within a run** upsert once. Kept intact.
- **Part 2 (this PR):** the cross-run/concurrent case — the tuple was persisted by a **prior** run under a different `relationshipKey`. Re-points the upsert conflict target at the tuple `@@unique`, drops the now-wrong global uniqueness on `relationshipKey`, and re-keys the created-vs-updated accounting and the stale sweep off the tuple (`existingRelationshipByTuple`; stale rows marked by `id`).

## Changes

- **Migration** `20260716230000_inventoryrelationship_tuple_canonical`: `DROP INDEX "InventoryRelationship_relationshipKey_key"`. `@migration-safety: data-safe` — metadata-only, loosening a constraint, cannot fail on existing data; the canonical tuple `@@unique` is unchanged.
- **Schema**: `relationshipKey String @unique` → `relationshipKey String`. The steward-reviewed removal is recorded in `schema-regression-guard.mjs` `INTENTIONAL_FIELD_REMOVALS` (the column is kept; only its uniqueness is dropped).
- **`discovery-sync.ts`**: tuple-targeted upsert; tuple-keyed created/updated accounting; tuple-keyed stale sweep (marks stale rows by `id`); `update` block refreshes `relationshipKey` to the latest observed key.
- **Tests**: new part-2 cross-run regression test (below); part-1 in-run dedup test and the scope/source-attribution suites adjusted to the tuple conflict target and id-based sweep. All 10 discovery-sync tests pass locally.

## Regression test assertion

A tuple persisted by a **prior** run under `relationshipKey` **K1**, re-presented on a **new** run under a **different** `relationshipKey` **K2**, is **UPDATED** — exactly one upsert whose `where` is the tuple compound unique, counted as `updatedRelationships: 1` / `createdRelationships: 0`, **not swept stale**, and no `P2002` — while `DiscoveredRelationship` still records the new run's own **K2** provenance linked to the one shared canonical row.

## Verification

- `vitest run` on `discovery-sync.test.ts` + `discovery-sync-scope.test.ts` + `discovery-sync-source-attribution.test.ts` → **10 passed**.
- `prisma generate` against the modified schema confirms the compound-unique input `fromEntityId_toEntityId_relationshipType`; `tsc --noEmit` on the change is clean (the only tsc output is pre-existing `@dpf/storefront-templates` workspace-link noise, unrelated to this change).

Design-Grounding-Decision: BI-PIR-7d69a445

Generated with Claude Code


Seed-Fit-Decision: global-default
