### PR TITLE
fix(self-upgrade): stream the page + bound git so it can't hang under load (BI-4A400DE4)

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/loading.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/loading.tsx
@@ -1,0 +1,46 @@
+import { OpsTabNav } from "@/components/ops/OpsTabNav";
+
+/**
+ * Instant Suspense fallback for the Self-Upgrade route (BI-4A400DE4).
+ *
+ * page.tsx blocks on a fan-out of ~5 loaders (status + ~10 DB queries, run
+ * history, dev config, the git-backed local-changes ledger, the impact summary)
+ * before it can return any markup — making it by far the heaviest /ops render
+ * (~25-30x the sibling tabs). When the host is saturated by the portal's agent
+ * subprocesses that render degrades to tens of seconds, and with no streaming
+ * boundary the operator saw a blank page that "won't come up". This file is that
+ * boundary: Next renders it immediately so the shell, heading, and tab nav paint
+ * at once and the data streams in underneath. The page is responsive under load
+ * instead of hanging.
+ */
+
+function SkeletonBlock({ className = "" }: { className?: string }) {
+  return (
+    <div
+      className={`animate-pulse rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] ${className}`}
+      aria-hidden
+    />
+  );
+}
+
+export default function SelfUpgradeLoading() {
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Self-Upgrade</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
+          Automated portal self-upgrade status and controls.
+        </p>
+      </div>
+
+      <OpsTabNav />
+
+      <div className="mt-6 space-y-4" aria-busy="true" aria-label="Loading self-upgrade status">
+        <SkeletonBlock className="h-20" />
+        <SkeletonBlock className="h-32" />
+        <SkeletonBlock className="h-24" />
+        <SkeletonBlock className="h-40" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/self-upgrade/local-changes-ledger.test.ts
+++ b/apps/web/lib/self-upgrade/local-changes-ledger.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import { parseNumstat, collectLocalChanges } from "./local-changes-ledger";
+import {
+  parseNumstat,
+  collectLocalChanges,
+  getLocalChangesLedger,
+} from "./local-changes-ledger";
+import type { LocalChangesResult } from "./local-changes-ledger";
 import type { GitResult } from "./prepare-source";
 
 const ok = (stdout: string): GitResult => ({ stdout, stderr: "", code: 0 });
@@ -97,6 +102,42 @@ describe("collectLocalChanges", () => {
       remote: "origin",
       branch: "main",
       installBranch: "dpf/install",
+    });
+    expect(res.available).toBe(false);
+  });
+});
+
+describe("getLocalChangesLedger render deadline (BI-4A400DE4)", () => {
+  const collected: LocalChangesResult = {
+    available: true,
+    changes: [{ path: "apps/web/lib/private.ts", added: 3, deleted: 1 }],
+  };
+
+  it("returns the collected result when git resolves before the deadline", async () => {
+    const res = await getLocalChangesLedger({
+      collect: async () => collected,
+      deadlineMs: 50,
+    });
+    expect(res).toEqual(collected);
+  });
+
+  it("degrades to 'unavailable' (never hangs) when collection exceeds the deadline", async () => {
+    const res = await getLocalChangesLedger({
+      // Simulates a hung/slow git that never resolves within the render window.
+      collect: () => new Promise<LocalChangesResult>(() => {}),
+      deadlineMs: 10,
+    });
+    expect(res.available).toBe(false);
+    expect(res.changes).toEqual([]);
+    expect(res.note).toMatch(/unavailable/i);
+  });
+
+  it("degrades to 'unavailable' when collection throws", async () => {
+    const res = await getLocalChangesLedger({
+      collect: async () => {
+        throw new Error("boom");
+      },
+      deadlineMs: 50,
     });
     expect(res.available).toBe(false);
   });

--- a/apps/web/lib/self-upgrade/local-changes-ledger.ts
+++ b/apps/web/lib/self-upgrade/local-changes-ledger.ts
@@ -106,20 +106,61 @@ export async function collectLocalChanges(run: GitRunner, opts: CollectOptions):
   return { available: true, changes: parseNumstat(res.stdout).slice(0, max) };
 }
 
-/** Server resolver: read the live install's config + run git. */
-export async function getLocalChangesLedger(): Promise<LocalChangesResult> {
+/**
+ * Render-path deadline for the (git-backed) ledger. This runs inside the
+ * self-upgrade page's server render; the hard defaultGitRunner cap (120s) only
+ * guards against a truly-hung git, which is too long to make an operator wait
+ * for a below-the-fold panel. Bound it tightly so the page content streams
+ * promptly and the ledger degrades to its "unavailable" note under contention.
+ * BI-4A400DE4.
+ */
+const LEDGER_RENDER_DEADLINE_MS = 5_000;
+
+const LEDGER_UNAVAILABLE: LocalChangesResult = {
+  available: false,
+  note: "The local-changes list is unavailable right now.",
+  changes: [],
+};
+
+export interface LedgerDeps {
+  /** Override the git-backed collection (defaults to the live config + runner). */
+  collect?: () => Promise<LocalChangesResult>;
+  /** Override the render deadline (ms) — tests use a tiny value. */
+  deadlineMs?: number;
+}
+
+async function defaultCollect(): Promise<LocalChangesResult> {
+  const { getSelfUpgradeConfig } = await import("./config");
+  const { defaultGitRunner } = await import("./prepare-source");
+  const config = await getSelfUpgradeConfig();
+  const hostSourcePath = config.hostSourceMountPath ?? process.env.HOST_SOURCE_PATH ?? "/workspace";
+  return collectLocalChanges(defaultGitRunner, {
+    hostSourcePath,
+    remote: config.repositoryRemote ?? "origin",
+    branch: config.repositoryBranch ?? "main",
+    installBranch: config.installBranch,
+  });
+}
+
+/**
+ * Server resolver: read the live install's config + run git, bounded by a render
+ * deadline so a slow/hung git can never hold up the self-upgrade page render.
+ * Times out (or errors) to the "unavailable" note. BI-4A400DE4.
+ */
+export async function getLocalChangesLedger(deps: LedgerDeps = {}): Promise<LocalChangesResult> {
+  const collect = deps.collect ?? defaultCollect;
+  const deadlineMs = deps.deadlineMs ?? LEDGER_RENDER_DEADLINE_MS;
   try {
-    const { getSelfUpgradeConfig } = await import("./config");
-    const { defaultGitRunner } = await import("./prepare-source");
-    const config = await getSelfUpgradeConfig();
-    const hostSourcePath = config.hostSourceMountPath ?? process.env.HOST_SOURCE_PATH ?? "/workspace";
-    return await collectLocalChanges(defaultGitRunner, {
-      hostSourcePath,
-      remote: config.repositoryRemote ?? "origin",
-      branch: config.repositoryBranch ?? "main",
-      installBranch: config.installBranch,
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<LocalChangesResult>((resolve) => {
+      timer = setTimeout(() => resolve(LEDGER_UNAVAILABLE), deadlineMs);
     });
+    try {
+      return await Promise.race([collect(), deadline]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   } catch {
-    return { available: false, note: "The local-changes list is unavailable right now.", changes: [] };
+    return LEDGER_UNAVAILABLE;
   }
 }

--- a/apps/web/lib/self-upgrade/prepare-source.ts
+++ b/apps/web/lib/self-upgrade/prepare-source.ts
@@ -439,9 +439,23 @@ async function prepareUpgradeSourceInWorkspace(
 }
 
 /**
+ * Hard ceiling on any single git invocation. The real failure mode this guards
+ * is an INDEFINITE hang — a credential prompt, an `index.lock` wait, or process-
+ * spawn contention on Windows/WSL2 when the host is saturated by the portal's
+ * agent subprocesses. Those never return on their own, so without a timeout a
+ * single `git log` on the git-backed self-upgrade render (local-changes ledger)
+ * can wedge the whole page. 120s is far above any legitimate mechanical prep op
+ * (branch move / merge / checkout are sub-second here) yet still converts an
+ * infinite hang into a bounded non-zero result the caller already handles.
+ * BI-4A400DE4.
+ */
+const GIT_RUNNER_TIMEOUT_MS = 120_000;
+
+/**
  * Real git runner over execFile. Never throws on non-zero exit — git's exit
  * code and captured stderr are returned so callers can branch on them (a merge
- * conflict is exit 1, not an exception).
+ * conflict is exit 1, not an exception). A timed-out git is killed and returned
+ * as a non-zero result (never a hang) — see GIT_RUNNER_TIMEOUT_MS.
  */
 export async function defaultGitRunner(args: string[]): Promise<GitResult> {
   const { execFile } = await import("node:child_process");
@@ -457,13 +471,21 @@ export async function defaultGitRunner(args: string[]): Promise<GitResult> {
   return new Promise<GitResult>((resolve) => {
     execFile("git", safeArgs, {
       maxBuffer: 10 * 1024 * 1024,
+      timeout: GIT_RUNNER_TIMEOUT_MS,
+      killSignal: "SIGKILL",
       env: { ...process.env, GIT_LFS_SKIP_SMUDGE: "1" },
     }, (err, stdout, stderr) => {
       const out = stdout?.toString() ?? "";
       const errOut = stderr?.toString() ?? "";
       if (err) {
+        // execFile flags a timeout kill via err.killed + err.signal; surface it
+        // as a distinct, non-zero result so callers degrade rather than hang.
+        const killed = (err as { killed?: boolean }).killed === true;
         const code = typeof (err as { code?: unknown }).code === "number" ? (err as { code: number }).code : 1;
-        resolve({ stdout: out, stderr: errOut || errMsg(err), code });
+        const stderrOut = killed
+          ? errOut || `git timed out after ${GIT_RUNNER_TIMEOUT_MS}ms and was terminated`
+          : errOut || errMsg(err);
+        resolve({ stdout: out, stderr: stderrOut, code: killed ? 124 : code });
       } else {
         resolve({ stdout: out, stderr: errOut, code: 0 });
       }


### PR DESCRIPTION
## Problem

Reported: *"the portal is unresponsive when clicking on the self-upgrade page. Other pages work but that one will not come up."*

Reproduced against the live portal with coordinate-independent methods:

- **RSC render time (host CPU idle):** `/ops/patches` = **18ms**; `/ops/self-upgrade` = **453–543ms** (~25–30× heavier).
- **During the portal's Claude-CLI agent-subprocess flood** (4 concurrent, 12–63s each, from backlog triage + coworker reasoning): the same self-upgrade render degrades to **>9–45s and effectively hangs**, while lighter `/ops` pages stay responsive.
- **Root:** [`ops/self-upgrade/page.tsx`] blocks on a `Promise.all` of ~5 loaders (`getSelfUpgradeStatus` → ~10 DB queries + operating-hours + quiescence + job-engine health; run history; dev config; the **git-backed** local-changes ledger; the impact summary) before returning **any** bytes. There is **no Suspense/`loading.tsx` anywhere in `apps/web/app`**, so a slow render is a blank page that "won't come up".

## Fix

1. **`ops/self-upgrade/loading.tsx`** — an instant Suspense fallback (shell + heading + `OpsTabNav` + skeleton). Next renders it immediately so the route paints at once and the heavy data streams in underneath. The page is responsive under load instead of hanging.
2. **`defaultGitRunner` timeout** — a 120s `execFile` timeout (SIGKILL). The real failure mode is an *indefinite* hang (index.lock wait, credential prompt, Windows/WSL2 process-spawn contention); 120s is far above any legitimate mechanical prep op yet converts an infinite hang into a bounded non-zero result the callers already handle.
3. **Ledger render deadline** — the render-path local-changes ledger is bounded by a 5s deadline that degrades to its "unavailable" note, with an injectable seam + unit tests.

## Verification

- Unit tests added for the ledger deadline (resolves-before / times-out / throws).
- Local typecheck/unit pre-gate is env-blocked (source-only worktree, no `node_modules`); **CI Typecheck / Unit / Prod Build gate the merge.**

## Follow-ups (tracked in BI-4A400DE4, out of scope here)

- React **#418** hydration text mismatch on this page (recovers on reload; `Date.now()` in render at `SelfUpgradeClient.tsx`).
- Coworker side-panel `getOrCreateThreadSnapshot` retry loop.
- `proxy.ts` per-request same-origin subrequest to `/api/internal/quiescence-state` (503 amplification under prefetch bursts).
- The Claude-CLI subprocess flood (the acute amplifier degrading the whole portal) — operational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)