### PR TITLE
feat(coworker): offer next-step decisions as button presses (BI-3237B5D6)

### DIFF
--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -993,6 +993,12 @@ export function AgentCoworkerPanel({
         {messages.map((msg, i) => {
           const prevAgentId = i > 0 ? messages[i - 1]?.agentId : null;
           const showAgentLabel = msg.role === "assistant" && msg.agentId !== prevAgentId;
+          // Button-decisions are actionable only on the latest turn while idle:
+          // clicking submits the option as the human's reply and continues the
+          // turn. Superseded decisions (a newer message exists) or an in-flight
+          // turn (isBusy) render without buttons — the prose closeout still shows.
+          const isLatest = i === messages.length - 1;
+          const decisionActive = isLatest && !isBusy && msg.role === "assistant";
           return (
             <AgentMessageBubble
               key={msg.id}
@@ -1001,6 +1007,7 @@ export function AgentCoworkerPanel({
               agentName={showAgentLabel && msg.agentId ? (AGENT_NAME_MAP[msg.agentId] ?? msg.agentId) : null}
               onApprove={handleApprove}
               onReject={handleReject}
+              {...(decisionActive ? { onDecision: (value: string) => handleSend(value) } : {})}
               {...(msg.deliveryState ? { deliveryState: msg.deliveryState } : {})}
               {...(msg.deliveryState === "failed" ? { onRetry: () => handleRetry(msg.id) } : {})}
             />

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -278,10 +278,12 @@ function DecisionButtons({
   const buttonStyle = (option: CoworkerDecisionOption) => {
     const negative = option.kind === "reject";
     if (option.recommended) {
+      // Primary — accent-tinted, matching the proposal Approve button's
+      // token-only treatment (no hardcoded hex; theme-safe in light/dark).
       return {
-        background: "var(--dpf-accent)",
-        border: "1px solid var(--dpf-accent)",
-        color: "#fff",
+        background: "color-mix(in srgb, var(--dpf-accent) 22%, transparent)",
+        border: "1px solid color-mix(in srgb, var(--dpf-accent) 45%, transparent)",
+        color: "var(--dpf-accent)",
         fontWeight: 600,
       };
     }

--- a/apps/web/components/agent/AgentMessageBubble.tsx
+++ b/apps/web/components/agent/AgentMessageBubble.tsx
@@ -7,6 +7,11 @@ import type { AgentMessageProvider, AgentMessageRow } from "@/lib/agent-coworker
 import type { ReactNode } from "react";
 import { AgentAttachmentCard } from "./AgentAttachmentCard";
 import { providerModelLabel } from "@/lib/agent/provider-model-label";
+import {
+  parseDecisionFromContent,
+  type CoworkerDecision,
+  type CoworkerDecisionOption,
+} from "@/lib/tak/decision-block";
 
 /**
  * Format the per-turn provider/model attribution badge shown on assistant
@@ -67,6 +72,14 @@ type Props = {
   agentName: string | null;
   onApprove?: (proposalId: string) => void;
   onReject?: (proposalId: string) => void;
+  /**
+   * Present only when this message is the latest turn and the panel is idle:
+   * a clicked decision option is submitted as the human's reply via this
+   * callback, continuing the turn. When absent, decision buttons are not
+   * rendered (a superseded/in-flight decision is conveyed by the prose closeout
+   * already visible above it).
+   */
+  onDecision?: (value: string) => void;
   deliveryState?: "sending" | "sent" | "failed";
   onRetry?: () => void;
 };
@@ -248,12 +261,82 @@ function formatRelativeTime(isoString: string): string {
   return `${days}d ago`;
 }
 
+/**
+ * Renders a coworker decision as clickable buttons (EP-COWORKER-INTERACTIVITY).
+ * The recommended option is the primary button; a "reject" option is tinted as
+ * the negative action. Clicking submits the option's value as the human's reply
+ * — the single-press equivalent of typing it. The free-text input remains the
+ * "Other…" escape hatch, so this never traps the human into the offered set.
+ */
+function DecisionButtons({
+  decision,
+  onDecision,
+}: {
+  decision: CoworkerDecision;
+  onDecision: (value: string) => void;
+}) {
+  const buttonStyle = (option: CoworkerDecisionOption) => {
+    const negative = option.kind === "reject";
+    if (option.recommended) {
+      return {
+        background: "var(--dpf-accent)",
+        border: "1px solid var(--dpf-accent)",
+        color: "#fff",
+        fontWeight: 600,
+      };
+    }
+    if (negative) {
+      return {
+        background: "color-mix(in srgb, var(--dpf-error) 12%, transparent)",
+        border: "1px solid color-mix(in srgb, var(--dpf-error) 34%, transparent)",
+        color: "var(--dpf-error)",
+        fontWeight: 500,
+      };
+    }
+    return {
+      background: "color-mix(in srgb, var(--dpf-surface-2) 90%, transparent)",
+      border: "1px solid var(--dpf-border)",
+      color: "var(--dpf-text)",
+      fontWeight: 500,
+    };
+  };
+
+  return (
+    <div
+      data-testid="agent-decision"
+      style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 6, marginLeft: 4 }}
+    >
+      {decision.options.map((option) => (
+        <button
+          key={option.id}
+          type="button"
+          data-testid="agent-decision-option"
+          data-recommended={option.recommended ? "true" : undefined}
+          onClick={() => onDecision(option.value)}
+          title={decision.prompt ?? undefined}
+          style={{
+            borderRadius: 8,
+            padding: "6px 14px",
+            fontSize: 12,
+            lineHeight: 1.2,
+            cursor: "pointer",
+            ...buttonStyle(option),
+          }}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 export function AgentMessageBubble({
   message,
   showAgentLabel,
   agentName,
   onApprove,
   onReject,
+  onDecision,
   deliveryState,
   onRetry,
 }: Props) {
@@ -475,7 +558,12 @@ export function AgentMessageBubble({
   }
 
   const isAssistantError = !isUser && looksLikeAgentError(message.content);
-  const managedDocumentIds = isUser ? [] : extractManagedDocumentIds(message.content);
+  // Extract any button-decision the coworker attached, and strip its sentinel
+  // from the human-visible content before rendering / doc-id extraction.
+  const { cleanedContent, decision } = !isUser
+    ? parseDecisionFromContent(message.content)
+    : { cleanedContent: message.content, decision: null };
+  const managedDocumentIds = isUser ? [] : extractManagedDocumentIds(cleanedContent);
 
   return (
     <div
@@ -544,8 +632,8 @@ export function AgentMessageBubble({
             )}
             <ReactMarkdown components={MARKDOWN_COMPONENTS}>
               {message.role === "assistant"
-                ? stripSystemPromptPrefix(message.content)
-                : message.content}
+                ? stripSystemPromptPrefix(cleanedContent)
+                : cleanedContent}
             </ReactMarkdown>
             {managedDocumentIds.length > 0 && (
               <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 6 }}>
@@ -607,6 +695,9 @@ export function AgentMessageBubble({
           </div>
         )}
       </div>
+      {!isUser && decision && onDecision && (
+        <DecisionButtons decision={decision} onDecision={onDecision} />
+      )}
       {isUser && deliveryState && deliveryState !== "sent" && (
         <div
           style={{

--- a/apps/web/lib/tak/coworker-interaction-contract.test.ts
+++ b/apps/web/lib/tak/coworker-interaction-contract.test.ts
@@ -29,6 +29,15 @@ describe("coworker interaction contract", () => {
     expect(prompt).toMatch(/Act on your own recommendation/i);
   });
 
+  it("instructs the coworker to offer button decisions via the dpf-decision sentinel", () => {
+    const prompt = withCoworkerInteractionContract("Base prompt");
+    expect(prompt).toContain("BUTTON DECISIONS");
+    expect(prompt).toContain("dpf-decision");
+    // The degenerate proceed-case must map to a single recommended "Go" button.
+    expect(prompt).toContain('"label":"Go"');
+    expect(prompt).toContain('"recommended":true');
+  });
+
   it("formats deterministic closeouts with the required four fields", () => {
     expect(formatCoworkerOperationalCloseout({
       status: "ready for PR",

--- a/apps/web/lib/tak/coworker-interaction-contract.ts
+++ b/apps/web/lib/tak/coworker-interaction-contract.ts
@@ -12,7 +12,18 @@ Do not end with ambiguous handoffs such as "keep working it to ready", "let me k
 Clarify vs proceed — remove cognitive load, don't add it:
 - Prefer proceeding on a clearly-stated, reasonable assumption over asking. Ask at most ONE focused question, and only when a wrong assumption would be costly, hard to reverse, or would make the result misleading. Everyday ambiguity (formatting, obvious defaults, typo interpretation) is yours to resolve — never ask the human to spell things out you can infer.
 - When you proceed on an assumption, say so in one line and give your recommended action for the human to confirm or correct — do not make them specify every detail before you start.
-- Act on your own recommendation. When you have surfaced options and one is clearly best, take it (or tee it up) and name it; don't hand the decision back with a menu when you can make the call yourself.`;
+- Act on your own recommendation. When you have surfaced options and one is clearly best, take it (or tee it up) and name it; don't hand the decision back with a menu when you can make the call yourself.
+
+BUTTON DECISIONS
+When the Next action is owned by the human AND it reduces to a small, discrete choice — including the common "shall I proceed?" case — offer it as buttons the human can press, not prose they must reply to by typing. Do this by appending ONE machine-readable decision block on its own final line, in exactly this form (a single-line HTML comment; the human never sees the raw markup — it renders as buttons):
+<!--dpf-decision:{"prompt":"<the question, omit for a plain proceed>","options":[{"label":"<button text>","recommended":true},{"label":"<other option>"}]}-->
+Rules:
+- Lead with your grounded recommendation: mark exactly one option "recommended":true (it renders as the primary button). This complements — never replaces — the Next action line above.
+- The degenerate "shall I proceed / want me to start?" case becomes a SINGLE button: options:[{"label":"Go","recommended":true}]. Prefer this over ending on a bare question.
+- Keep it to at most a handful of concrete, mutually-exclusive options. Each "label" is the button text; add "value" only when the reply text should differ from the label. Optional "kind" is one of approve, reject, request-changes, answer, dismiss, snooze for styling.
+- Free-text always remains available to the human, so never force a genuinely open-ended question into buttons — omit the block when there is no small discrete option set.
+- Do NOT emit a decision block when a goal, autopilot directive, or prior instruction already authorized you to proceed without asking — in that case just proceed.
+- Emit at most one decision block, always as the final line.`;
 
 export type CoworkerOperationalCloseout = {
   status: string;

--- a/apps/web/lib/tak/decision-block.test.ts
+++ b/apps/web/lib/tak/decision-block.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseDecisionFromContent,
+  normalizeDecision,
+  formatDecisionSentinel,
+  MAX_DECISION_OPTIONS,
+  type CoworkerDecision,
+} from "./decision-block";
+
+describe("parseDecisionFromContent", () => {
+  it("returns no decision for plain content", () => {
+    const { cleanedContent, decision } = parseDecisionFromContent("Just a normal reply.");
+    expect(decision).toBeNull();
+    expect(cleanedContent).toBe("Just a normal reply.");
+  });
+
+  it("extracts a degenerate single Go decision and strips the sentinel", () => {
+    const content =
+      'All set — ready to start.\n<!--dpf-decision:{"options":[{"label":"Go","recommended":true}]}-->';
+    const { cleanedContent, decision } = parseDecisionFromContent(content);
+    expect(cleanedContent).toBe("All set — ready to start.");
+    expect(decision).not.toBeNull();
+    expect(decision!.options).toHaveLength(1);
+    expect(decision!.options[0]).toMatchObject({
+      label: "Go",
+      value: "Go",
+      kind: "answer",
+      recommended: true,
+    });
+    expect(decision!.options[0]!.id).toBeTruthy();
+    expect(decision!.freeTextAllowed).toBe(true);
+  });
+
+  it("extracts a multi-option decision with prompt and preserves order", () => {
+    const content = [
+      "Here is where we stand.",
+      formatDecisionSentinel({
+        prompt: "Where should I start?",
+        freeTextAllowed: true,
+        options: [
+          { id: "render", label: "Fix the render first", value: "Fix the render first", kind: "approve", recommended: true },
+          { id: "cli", label: "Prioritize the CLI saturation", value: "Prioritize the CLI saturation", kind: "answer" },
+        ],
+      }),
+    ].join("\n");
+    const { cleanedContent, decision } = parseDecisionFromContent(content);
+    expect(cleanedContent).toBe("Here is where we stand.");
+    expect(decision!.prompt).toBe("Where should I start?");
+    expect(decision!.options.map((o) => o.label)).toEqual([
+      "Fix the render first",
+      "Prioritize the CLI saturation",
+    ]);
+    expect(decision!.options[0]!.recommended).toBe(true);
+    expect(decision!.options[1]!.recommended).toBeUndefined();
+  });
+
+  it("strips a malformed sentinel and degrades to prose (no raw marker leaks)", () => {
+    const content = 'Proceeding.\n<!--dpf-decision:{not valid json}-->';
+    const { cleanedContent, decision } = parseDecisionFromContent(content);
+    expect(decision).toBeNull();
+    expect(cleanedContent).toBe("Proceeding.");
+    expect(cleanedContent).not.toContain("dpf-decision");
+  });
+
+  it("round-trips via formatDecisionSentinel", () => {
+    const decision: CoworkerDecision = {
+      prompt: "Ship it?",
+      freeTextAllowed: true,
+      options: [
+        { id: "ship-0", label: "Ship", value: "Ship", kind: "approve", recommended: true },
+        { id: "hold-1", label: "Hold", value: "Hold", kind: "reject" },
+      ],
+    };
+    const content = `Done.\n${formatDecisionSentinel(decision)}`;
+    const parsed = parseDecisionFromContent(content).decision;
+    expect(parsed).toEqual(decision);
+  });
+});
+
+describe("normalizeDecision", () => {
+  it("rejects input with no valid options", () => {
+    expect(normalizeDecision({ options: [] })).toBeNull();
+    expect(normalizeDecision({ options: [{ label: "" }] })).toBeNull();
+    expect(normalizeDecision({ options: "nope" })).toBeNull();
+    expect(normalizeDecision(null)).toBeNull();
+    expect(normalizeDecision(42)).toBeNull();
+  });
+
+  it("defaults value to label and kind to answer", () => {
+    const decision = normalizeDecision({ options: [{ label: "Continue" }] })!;
+    expect(decision.options[0]).toMatchObject({ label: "Continue", value: "Continue", kind: "answer" });
+  });
+
+  it("keeps only the first recommended option as primary", () => {
+    const decision = normalizeDecision({
+      options: [
+        { label: "A", recommended: true },
+        { label: "B", recommended: true },
+      ],
+    })!;
+    expect(decision.options[0]!.recommended).toBe(true);
+    expect(decision.options[1]!.recommended).toBeUndefined();
+  });
+
+  it("dedupes options by label (case-insensitive)", () => {
+    const decision = normalizeDecision({
+      options: [{ label: "Go" }, { label: "go" }, { label: "Wait" }],
+    })!;
+    expect(decision.options.map((o) => o.label)).toEqual(["Go", "Wait"]);
+  });
+
+  it("caps options at MAX_DECISION_OPTIONS", () => {
+    const many = Array.from({ length: MAX_DECISION_OPTIONS + 4 }, (_, i) => ({ label: `Opt ${i}` }));
+    const decision = normalizeDecision({ options: many })!;
+    expect(decision.options).toHaveLength(MAX_DECISION_OPTIONS);
+  });
+
+  it("rejects an unknown kind by falling back to answer", () => {
+    const decision = normalizeDecision({ options: [{ label: "X", kind: "detonate" }] })!;
+    expect(decision.options[0]!.kind).toBe("answer");
+  });
+
+  it("honors freeTextAllowed=false", () => {
+    const decision = normalizeDecision({ options: [{ label: "Only this" }], freeTextAllowed: false })!;
+    expect(decision.freeTextAllowed).toBe(false);
+  });
+});

--- a/apps/web/lib/tak/decision-block.ts
+++ b/apps/web/lib/tak/decision-block.ts
@@ -1,0 +1,179 @@
+// Coworker button-decision carrier (EP-COWORKER-INTERACTIVITY, BI-3237B5D6).
+// Spec: docs/superpowers/specs/2026-07-16-coworker-button-decision-interface.md
+//
+// P1 carrier: the coworker emits a machine-readable decision as an HTML-comment
+// sentinel at the very end of its message, e.g.
+//   <!--dpf-decision:{"prompt":"Where should I start?","options":[
+//     {"label":"Fix the render first","recommended":true},
+//     {"label":"Prioritize the CLI saturation"}]}-->
+// This module extracts + validates it and returns the human-visible content with
+// the sentinel stripped. The sentinel rides inside AgentMessage.content (already
+// persisted + refetched), so P1 needs no schema migration. The blessed decision
+// vocabulary is AttentionActionKind (lib/attention/types.ts) — kept in sync via
+// DECISION_OPTION_KINDS below. P2 promotes this to a typed AgentMessage.decision
+// column (tracked follow-up); this parser stays the single validation seam.
+
+/** Decision-option kinds — the SAME vocabulary as AttentionActionKind
+ *  (lib/attention/types.ts). Kept as a runtime list here for validation; keep
+ *  the two in sync. Drives button styling; semantics are advisory in P1. */
+export const DECISION_OPTION_KINDS = [
+  "approve",
+  "reject",
+  "request-changes",
+  "answer",
+  "open-in-context",
+  "dismiss",
+  "snooze",
+] as const;
+
+export type DecisionOptionKind = (typeof DECISION_OPTION_KINDS)[number];
+
+const OPTION_KIND_SET = new Set<string>(DECISION_OPTION_KINDS);
+
+/** Max options rendered as buttons — beyond this, the coworker should be asking
+ *  a genuinely open question, so we cap and let the free-text input carry it. */
+export const MAX_DECISION_OPTIONS = 6;
+
+export type CoworkerDecisionOption = {
+  /** Stable id (slug of label + index); echoed for keys/analytics. */
+  id: string;
+  /** Button text. */
+  label: string;
+  /** What gets submitted as the user's reply when clicked. Defaults to label. */
+  value: string;
+  /** Styling/semantic hint from the shared vocabulary. Defaults to "answer". */
+  kind: DecisionOptionKind;
+  /** At most one option is recommended → rendered as the primary button. */
+  recommended?: boolean;
+};
+
+export type CoworkerDecision = {
+  /** The question, e.g. "Where should I start?". Optional for the degenerate
+   *  proceed-case (a single "Go" button needs no restated prompt). */
+  prompt?: string;
+  options: CoworkerDecisionOption[];
+  /** Whether the free-text input remains an "Other…" escape hatch. Default true
+   *  — buttons are the default, never a cage. */
+  freeTextAllowed: boolean;
+};
+
+// Non-greedy JSON capture between the sentinel markers. `[\s\S]` so it spans
+// newlines even though the coworker is instructed to keep it on one line.
+const DECISION_SENTINEL_RE = /<!--\s*dpf-decision:\s*(\{[\s\S]*?\})\s*-->/;
+
+function slugify(label: string, index: number): string {
+  const base = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return base ? `${base}-${index}` : `option-${index}`;
+}
+
+function normalizeOption(raw: unknown, index: number): CoworkerDecisionOption | null {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+  const rec = raw as Record<string, unknown>;
+
+  const label = typeof rec.label === "string" ? rec.label.replace(/\s+/g, " ").trim() : "";
+  if (!label) return null;
+
+  const value =
+    typeof rec.value === "string" && rec.value.trim() ? rec.value.trim() : label;
+
+  const kind: DecisionOptionKind =
+    typeof rec.kind === "string" && OPTION_KIND_SET.has(rec.kind)
+      ? (rec.kind as DecisionOptionKind)
+      : "answer";
+
+  const option: CoworkerDecisionOption = {
+    id: typeof rec.id === "string" && rec.id.trim() ? rec.id.trim() : slugify(label, index),
+    label,
+    value,
+    kind,
+  };
+  if (rec.recommended === true) option.recommended = true;
+  return option;
+}
+
+/**
+ * Normalize an arbitrary parsed value into a valid CoworkerDecision, or null.
+ * Enforces: ≥1 valid option, ≤MAX_DECISION_OPTIONS, at most one `recommended`
+ * (first wins), deduped labels, freeTextAllowed defaulting to true.
+ */
+export function normalizeDecision(input: unknown): CoworkerDecision | null {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return null;
+  const rec = input as Record<string, unknown>;
+
+  if (!Array.isArray(rec.options)) return null;
+
+  const seenLabels = new Set<string>();
+  const options: CoworkerDecisionOption[] = [];
+  let recommendedTaken = false;
+
+  for (const raw of rec.options) {
+    if (options.length >= MAX_DECISION_OPTIONS) break;
+    const option = normalizeOption(raw, options.length);
+    if (!option) continue;
+    const dedupeKey = option.label.toLowerCase();
+    if (seenLabels.has(dedupeKey)) continue;
+    seenLabels.add(dedupeKey);
+    if (option.recommended) {
+      if (recommendedTaken) {
+        delete option.recommended; // only the first recommended stays primary
+      } else {
+        recommendedTaken = true;
+      }
+    }
+    options.push(option);
+  }
+
+  if (options.length === 0) return null;
+
+  const decision: CoworkerDecision = {
+    options,
+    freeTextAllowed: rec.freeTextAllowed !== false, // default true
+  };
+  const prompt =
+    typeof rec.prompt === "string" ? rec.prompt.replace(/\s+/g, " ").trim() : "";
+  if (prompt) decision.prompt = prompt;
+  return decision;
+}
+
+/**
+ * Extract a decision sentinel from coworker message content.
+ *
+ * Returns the human-visible content with the sentinel stripped, plus the parsed
+ * decision (or null when absent/malformed). Malformed sentinels are still
+ * stripped so no raw `<!--dpf-decision:…-->` ever reaches the transcript. Pure +
+ * side-effect free — safe to call at render time on every message.
+ */
+export function parseDecisionFromContent(content: string): {
+  cleanedContent: string;
+  decision: CoworkerDecision | null;
+} {
+  if (!content || !content.includes("dpf-decision")) {
+    return { cleanedContent: content, decision: null };
+  }
+
+  const match = content.match(DECISION_SENTINEL_RE);
+  if (!match) return { cleanedContent: content, decision: null };
+
+  const cleanedContent = content.replace(DECISION_SENTINEL_RE, "").trim();
+
+  let decision: CoworkerDecision | null = null;
+  try {
+    decision = normalizeDecision(JSON.parse(match[1]!));
+  } catch {
+    decision = null; // malformed JSON → strip sentinel, degrade to prose
+  }
+
+  return { cleanedContent, decision };
+}
+
+/**
+ * Serialize a decision back into the sentinel string. Used by tests and any
+ * future server-side emitter. Kept single-line so the content sanitizer's
+ * blank-line collapse never touches it.
+ */
+export function formatDecisionSentinel(decision: CoworkerDecision): string {
+  return `<!--dpf-decision:${JSON.stringify(decision)}-->`;
+}

--- a/docs/superpowers/plans/2026-07-16-coworker-button-decision-p1.md
+++ b/docs/superpowers/plans/2026-07-16-coworker-button-decision-p1.md
@@ -1,0 +1,33 @@
+# Plan: Coworker Button-Decision Interface — P1
+
+**BI:** BI-3237B5D6 · **Epic:** EP-COWORKER-INTERACTIVITY
+**Spec:** docs/superpowers/specs/2026-07-16-coworker-button-decision-interface.md
+
+## Goal of P1
+
+Kill the "type go" friction: when a coworker's next action is a human decision with a small discrete option set (including the plain "shall I proceed?" case), the human resolves it with a **button press** instead of typing a reply. Ship the smallest end-to-end slice with no schema migration.
+
+## Approach (migration-free carrier)
+
+The coworker appends a single-line HTML-comment **sentinel** at the end of its message:
+`<!--dpf-decision:{"prompt":"…","options":[{"label":"Go","recommended":true}]}-->`
+The sentinel rides inside `AgentMessage.content` (already persisted + refetched), so P1 needs no DB change. It is parsed and **stripped at render**; buttons are derived client-side. Clicking an option submits its value as the human's reply through the existing send pipeline — no new server action. This mirrors the existing managed-doc-chip pattern (`extractManagedDocumentIds`).
+
+## Steps (all complete)
+
+1. **Parser** — `apps/web/lib/tak/decision-block.ts`: `parseDecisionFromContent` (extract + strip + normalize), `normalizeDecision` (≥1 option, ≤6, one recommended, dedupe, kind from the AttentionActionKind vocab, freeTextAllowed default true), `formatDecisionSentinel`. Pure + tested (`decision-block.test.ts`).
+2. **Contract emit** — augment `COWORKER_INTERACTION_CONTRACT_PROMPT` (`coworker-interaction-contract.ts`) with the BUTTON DECISIONS clause: recommended-first, degenerate proceed → single "Go", skip when already authorized to proceed, free-text always available. Injected via `prompt-assembler.ts`. Test updated.
+3. **Render** — `AgentMessageBubble.tsx`: `DecisionButtons` component; parse content, strip sentinel from the markdown + doc-id extraction, render options (recommended = primary, reject = negative). New `onDecision` prop.
+4. **Wire** — `AgentCoworkerPanel.tsx`: pass `onDecision` (→ `handleSend`) only for the latest assistant turn while idle; superseded/in-flight turns render without buttons.
+
+## Verification
+
+- Core parser: 26 assertions against the real esbuild-transpiled source — pass.
+- Syntax/transform: all touched `.ts`/`.tsx` clean via esbuild.
+- Hermetic vitest suites (`decision-block.test.ts`, `coworker-interaction-contract.test.ts`): run in CI.
+- Full typecheck + live portal drive: gated by CI + a rebuilt portal (source-only worktree can't run either locally).
+
+## Follow-ups (tracked, not silent debt)
+
+- **P2:** promote the carrier to a typed `AgentMessage.decision Json?` column (removes content-embedded sentinel + semantic-memory noise); converge `AgentActionProposal` approve/reject onto the decision carrier.
+- **P3:** in-place decision buttons in `AttentionInbox` so a decision is resolvable cross-page ("Needs you" inbox), per the epic's cross-page HITL handoff.

--- a/docs/superpowers/plans/2026-07-16-coworker-button-decision-p1.md
+++ b/docs/superpowers/plans/2026-07-16-coworker-button-decision-p1.md
@@ -27,6 +27,13 @@ The sentinel rides inside `AgentMessage.content` (already persisted + refetched)
 - Hermetic vitest suites (`decision-block.test.ts`, `coworker-interaction-contract.test.ts`): run in CI.
 - Full typecheck + live portal drive: gated by CI + a rebuilt portal (source-only worktree can't run either locally).
 
+## Design grounding
+
+- Existing specs/plans reviewed: `docs/superpowers/specs/2026-07-16-coworker-button-decision-interface.md` (authored this session) and this plan. No existing spec covered agent→human button decisions; `apps/web/lib/tak/question-packet.ts` is the opposite direction (operator→agent).
+- Current code substrate reviewed: `apps/web/lib/tak/coworker-interaction-contract.ts` (the free-text Next-action closeout — the emit seam), `apps/web/components/agent/AgentMessageBubble.tsx` (existing `AgentActionProposal` Approve/Reject — the only live decision UI, binary via `messageId @unique`), `apps/web/lib/attention/types.ts` (`AttentionActionKind` — reused vocabulary), `apps/web/components/build-studio/cards/ChoiceCard.tsx` (unpersisted UI reference).
+- Source of truth: EP-COWORKER-INTERACTIVITY (cross-page HITL handoff). Carrier + rendering follow the existing proposal-button and managed-doc-chip patterns rather than inventing new substrate.
+- Decision: P1 = migration-free content-embedded decision sentinel parsed at render; reuse `AttentionActionKind`; defer the typed `AgentMessage.decision` column, proposal convergence, and cross-page inbox buttons to P2/P3 (BI-450D5833).
+
 ## Follow-ups (tracked, not silent debt)
 
 - **P2:** promote the carrier to a typed `AgentMessage.decision Json?` column (removes content-embedded sentinel + semantic-memory noise); converge `AgentActionProposal` approve/reject onto the decision carrier.

--- a/docs/superpowers/specs/2026-07-16-coworker-button-decision-interface.md
+++ b/docs/superpowers/specs/2026-07-16-coworker-button-decision-interface.md
@@ -1,0 +1,93 @@
+# Spec: Coworker Button-Decision Interface
+
+**Epic:** EP-COWORKER-INTERACTIVITY (PUC envelope flow, grant taxonomy, cross-page HITL handoff)
+**Date:** 2026-07-16
+**Status:** Draft for founder review
+**Author:** AI Coworker (session: ai-coworker-button-interface)
+
+## 1. Problem
+
+When an AI coworker (or Claude in this CLI) needs the human to make a next-step decision, it ends its turn with **free-text prose** — "Want me to start there, or prioritize X first?" — and the human must **type a reply** ("go") to proceed. That reply is pure UX tax: the decision is almost always a small, discrete choice that a **single button press** would resolve faster and with less friction.
+
+The founder's directive: *systematically boil AI→human handoffs down to button-press decisions wherever possible.*
+
+## 2. Current state (verified 2026-07-16)
+
+The platform already forces a next-step handoff and already renders decision buttons in one narrow case — but has no general structured multi-option decision carrier.
+
+| Concern | Today | File |
+| --- | --- | --- |
+| Binary approve/reject of **one** held tool call | Live, fully wired | `AgentActionProposal` (schema.prisma ~4021); `AgentMessageBubble.tsx` ~253-445; `lib/actions/proposals.ts`; created in `lib/actions/agent-coworker.ts` ~1751 |
+| Message content | Scalar `String` markdown; only structured attachment is the optional **1:1** `proposal` | `lib/tak/agent-coworker-types.ts` `AgentMessageRow` |
+| **Decision vocabulary** | Enum already exists: `approve \| reject \| request-changes \| answer \| open-in-context \| dismiss \| snooze` | `lib/attention/types.ts` `AttentionActionKind` |
+| "Needs you" inbox | Renders attention `actions[]` — but only `action.href` as deep-links; in-place buttons "wired in later slices" | `components/attention/AttentionInbox.tsx` |
+| "What's next" signal | Interaction contract mandates free-text **Status / Evidence / Next action / Owner** closeout (prose) | `lib/tak/coworker-interaction-contract.ts` |
+| "Lead with a recommendation, only offer a choice when a genuine option remains" | Prose instruction, no structured carrier | `lib/tak/decision-routing-block.ts` |
+| Multi-option chip UI | Prototype `ChoiceCard` + `Message.choices[]` — **unpersisted, stubbed handlers** | `components/build-studio/cards/ChoiceCard.tsx` |
+
+**Load-bearing constraint:** `AgentActionProposal.messageId String @unique` — one message may carry at most one binary proposal. This is what prevents attaching N discrete options to a turn today.
+
+## 3. Design
+
+A single coherent capability across three layers. Reuse the existing `AttentionActionKind` vocabulary end-to-end; do not invent new action names.
+
+### 3.1 Data / contract layer — a structured Decision carrier
+
+A coworker turn may carry an optional **`decision`**:
+
+```ts
+type CoworkerDecisionOption = {
+  id: string;                 // stable id echoed back on click
+  label: string;              // button text, e.g. "Go", "Fix the render first"
+  kind: AttentionActionKind;  // reuse existing enum
+  recommended?: boolean;      // at most one; rendered as the primary button
+  value?: Json;               // optional structured payload the click resolves to
+};
+
+type CoworkerDecision = {
+  prompt: string;             // the question, e.g. "Where should I start?"
+  options: CoworkerDecisionOption[];  // 1..N; the degenerate "proceed?" case = a single { label: "Go", recommended: true } option
+  freeTextAllowed?: boolean;  // default true — an "Other…" escape hatch preserving today's typed reply
+};
+```
+
+Because `AgentActionProposal` is binary/1-action (`messageId @unique`), a decision with N options needs its **own carrier**. Two implementation options (decision for §5):
+- **(A) New relation** `AgentDecision` (1:1 with `AgentMessage`, holds `options[]` + resolution), mirroring the proposal model. Cleanest audit story; consistent with existing proposal pattern.
+- **(B) JSON column** `AgentMessage.decision Json?`. Lightest migration; weaker query/audit surface.
+
+Resolution is audited the way proposals are: which option, by whom, when. The single-`AgentActionProposal` path is **subsumed** as the special case `options = [approve, reject]` so we converge on one decision concept rather than two (avoids one-concept-two-impls debt).
+
+### 3.2 Prompt / behavior layer — teach the interaction contract to emit decisions
+
+Augment `COWORKER_INTERACTION_CONTRACT_PROMPT` (and mirror in `decision-routing-block`): **when the closeout's Next action is owned by the human AND reduces to a small discrete choice, emit a structured `decision` instead of ending on prose.** Rules:
+- Lead with the recommended option (`recommended: true`) — this preserves the existing "grounded recommendation, not a raw open question" doctrine, now machine-readable.
+- The degenerate "shall I proceed?" case becomes a **single "Go" button**, `recommended: true`. This is the exact friction the founder called out.
+- Keep the `freeTextAllowed` escape hatch so nothing that's genuinely open-ended is forced into buttons.
+- Do **not** emit a decision when a goal/autopilot directive already authorized proceeding without asking (mirrors `feedback_drive_100_percent_means_dont_ask`).
+
+### 3.3 UI layer — render buttons in both surfaces (cross-page HITL)
+
+- **In-conversation:** `AgentMessageBubble` renders `decision.options` as buttons (recommended = primary). Click posts the option `id` to `/api/agent/send` (reusing the proposal approve/reject wiring), which resolves the decision and continues the turn. An "Other…" affordance re-opens the free-text input when `freeTextAllowed`.
+- **Cross-page:** the same decision projects into an `AttentionItem` so it is actionable from the "Needs you" inbox. This requires finishing the already-anticipated `AttentionInbox` work: render `approve/reject/answer/...` kinds as **in-place buttons**, not just href deep-links. That is the "cross-page HITL handoff" EP-COWORKER-INTERACTIVITY already scopes.
+
+## 4. Phasing
+
+- **P1 — Minimal "Go" button + contract instruction.** Add the carrier (option B JSON is fine for P1), teach the interaction contract to emit a single recommended "Go" for the proceed-case, render it in `AgentMessageBubble`. Smallest change that kills the "type go" friction. Live-verify on the portal.
+- **P2 — N-option decisions + recommended-first.** Multi-option choices; converge the existing `AgentActionProposal` approve/reject onto the decision carrier.
+- **P3 — Cross-page inbox parity.** In-place decision buttons in `AttentionInbox` / `NeedsYouBand`; decision projects to an attention item; resolvable from either surface.
+
+## 5. Open decisions for founder / kernel
+
+1. **Carrier:** new `AgentDecision` relation (A, cleaner audit) vs `AgentMessage.decision Json?` (B, lighter). Recommendation: B for P1, migrate to A if audit/query needs grow.
+2. **Scope to start:** full 3-layer capability vs P1-only increment.
+3. **Build path:** promote to Build Studio (standing rule) vs external build.
+
+## 6. Non-goals
+
+- Not removing free-text input — the "Other…" escape hatch stays; buttons are the *default*, not a cage.
+- Not a new epic — this lands under EP-COWORKER-INTERACTIVITY.
+- Not forcing buttons on genuinely open questions or on turns already authorized to proceed autonomously.
+
+## 7. Verification
+
+Functional, not structural: drive the live portal coworker to a proceed-decision, confirm a "Go" button renders and a single click continues the turn (verify via DB decision-resolution row + the coworker's next turn), per the founder's structural≠functional commandment.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -2,7 +2,7 @@ apps/web/app/api/mcp/v1/route.test.ts	1260
 apps/web/app/api/v1/edge/discovery-runs/route.test.ts	982
 apps/web/components/admin/BusinessModelBuilder.tsx	821
 apps/web/components/admin/McpTokenManager.tsx	1373
-apps/web/components/agent/AgentCoworkerPanel.tsx	1260
+apps/web/components/agent/AgentCoworkerPanel.tsx	1267
 apps/web/components/agent/AgentMessageInput.tsx	1034
 apps/web/components/ea/EaCanvas.tsx	1047
 apps/web/components/inventory/TopologyGraph.tsx	1031


### PR DESCRIPTION
## What

Makes a coworker's **next-step decision a button press** instead of prose the human must answer by typing "go". When the next action is owned by the human and reduces to a small discrete choice — including the common "shall I proceed?" case — the coworker offers clickable options, recommended-first. The plain proceed-case becomes a single **Go** button.

Founder goal (2026-07-16): *systematically boil AI→human handoffs down to button-press decisions wherever possible.* This is **P1** — the smallest end-to-end slice, migration-free.

## How (P1 carrier — no schema change)

The coworker appends a single-line HTML-comment sentinel to its message:

```
<!--dpf-decision:{"prompt":"Where should I start?","options":[
  {"label":"Fix the render first","recommended":true},
  {"label":"Prioritize the CLI saturation"}]}-->
```

It rides inside `AgentMessage.content` (already persisted + refetched), is **parsed and stripped at render**, and the options render as buttons. Clicking submits the option's value as the human's reply through the existing send pipeline — no new server action. This mirrors the existing managed-doc-chip pattern. The free-text input stays as the "Other…" escape hatch.

## Changes

- **`apps/web/lib/tak/decision-block.ts`** (new) — pure `parseDecisionFromContent` / `normalizeDecision` / `formatDecisionSentinel`. Reuses the `AttentionActionKind` vocabulary; enforces ≥1 option, ≤6, one recommended, dedupe, `freeTextAllowed` default true. Fully unit-tested.
- **`coworker-interaction-contract.ts`** — new **BUTTON DECISIONS** clause instructs the emit (recommended-first; degenerate proceed → single "Go"; skips when a goal/directive already authorized proceeding). Complements the existing clarify-vs-proceed clause. Injected via `prompt-assembler.ts`.
- **`AgentMessageBubble.tsx`** — `DecisionButtons` component; parses + strips the sentinel from rendered markdown + doc-id extraction (recommended = primary, reject = negative).
- **`AgentCoworkerPanel.tsx`** — wires `onDecision` (→ existing `handleSend`) only on the latest assistant turn while idle; superseded/in-flight turns render without buttons.

## Epic / tracking

Under **EP-COWORKER-INTERACTIVITY** (cross-page HITL handoff) · **BI-3237B5D6**.
P2/P3 hardening tracked as **BI-450D5833**: promote to a typed `AgentMessage.decision` column, converge `AgentActionProposal` approve/reject onto the decision carrier, and render in-place decision buttons in the "Needs you" inbox (`AttentionInbox`).

Spec: `docs/superpowers/specs/2026-07-16-coworker-button-decision-interface.md`
Plan: `docs/superpowers/plans/2026-07-16-coworker-button-decision-p1.md`

## Verification

- Core parser: **26 assertions** run against the real esbuild-transpiled source — all pass (parse/strip/normalize/roundtrip/guards).
- esbuild transform-clean on all touched `.ts`/`.tsx` files (post-merge onto current main).
- Hermetic vitest suites (`decision-block.test.ts`, `coworker-interaction-contract.test.ts`) run in CI.
- Full typecheck + live portal drive: gated by CI + a rebuilt portal (source-only worktree can't run either locally; committed with the repo's documented `DPF_SKIP_TYPECHECK=1` pre-commit override — CI gates the merge).

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-07-16-coworker-button-decision-interface.md` (authored this session after mapping the substrate) and `docs/superpowers/plans/2026-07-16-coworker-button-decision-p1.md`. Confirmed no existing spec covered agent→human button decisions; `question-packet.ts` is the opposite direction (operator→agent).
- Current code substrate reviewed:
  - `apps/web/lib/tak/coworker-interaction-contract.ts` (already mandates the free-text Next-action closeout — the emit seam), `apps/web/components/agent/AgentMessageBubble.tsx` (existing `AgentActionProposal` Approve/Reject buttons — the only live decision UI; binary, `messageId @unique`), `apps/web/lib/attention/types.ts` (`AttentionActionKind` — the blessed decision vocabulary, reused), and the prototype `apps/web/components/build-studio/cards/ChoiceCard.tsx` (unpersisted UI reference).
- Source of truth:
  - EP-COWORKER-INTERACTIVITY (cross-page HITL handoff) owns this ground; carrier + rendering follow the existing proposal-button + managed-doc-chip patterns rather than inventing new substrate.
- Decision:
  - P1 = migration-free content-embedded decision sentinel parsed at render (no schema change); reuse `AttentionActionKind`; the typed `AgentMessage.decision` column + proposal convergence + cross-page inbox buttons are deferred to P2/P3 (BI-450D5833), tracked not silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
