### PR TITLE
feat(workbooks): unified named/saved views on every grid (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -67,6 +67,10 @@ import {
   createRowAction,
   updateCellsAction,
   deleteRowAction,
+  listViewsAction,
+  saveViewAction,
+  deleteViewAction,
+  setDefaultViewAction,
 } from "@/lib/actions/workbooks";
 import { updatePlatformCellsAction } from "@/lib/actions/platform-grid";
 import {
@@ -102,8 +106,20 @@ import {
   viewStorageKey,
   serializeViewState,
   parseViewState,
-  type SortState,
+  type GridViewState,
 } from "./grid-view-state";
+import {
+  type NamedView,
+  localViewsKey,
+  parseNamedViews,
+  serializeNamedViews,
+  upsertNamedView,
+  removeNamedView,
+  setDefaultNamedView,
+  defaultNamedView,
+  normalizeViewState,
+} from "./grid-named-views";
+import { GridViewsMenu } from "./GridViewsMenu";
 import {
   reorderColumnIds,
   applyColumnOrder,
@@ -382,65 +398,217 @@ export function WorkbookGrid({
   // entry's inverse replays through the same validated dispatch as a normal edit.
   const [history, setHistory] = useState<GridHistory>(EMPTY_HISTORY);
 
+  // --- Named/saved views ---------------------------------------------------
+  // A named snapshot of the full grid view-state. Custom tables persist views
+  // server-side (WorkbookView, shared across table users); platform grids persist
+  // to localStorage (personal). Same UI (GridViewsMenu); backend chosen by source.
+  const serverBacked = source === "custom";
+  const [views, setViews] = useState<NamedView[]>([]);
+  const [activeViewId, setActiveViewId] = useState<string | null>(null);
+
+  const buildCurrentViewState = useCallback(
+    (): GridViewState => ({
+      filterQuery,
+      filterGroup,
+      sort: sortColumns.map((s) => ({ columnKey: s.columnKey, direction: s.direction })),
+      cfRules,
+      showProvenance,
+      columnOrder,
+      groupBy,
+      hiddenColumns,
+      frozenCount,
+      rowHeight,
+      footerAgg,
+      showFooter,
+    }),
+    [
+      filterQuery,
+      filterGroup,
+      sortColumns,
+      cfRules,
+      showProvenance,
+      columnOrder,
+      groupBy,
+      hiddenColumns,
+      frozenCount,
+      rowHeight,
+      footerAgg,
+      showFooter,
+    ],
+  );
+
+  // Apply a full saved view-state to the grid (every field, so a view is a clean
+  // reset — not a merge). Group expansion resets to the default for the new grouping.
+  const applyViewState = useCallback((s: GridViewState) => {
+    setFilterQuery(s.filterQuery);
+    setFilterGroup(s.filterGroup);
+    setSortColumns(s.sort);
+    setCfRules(s.cfRules);
+    setShowProvenance(s.showProvenance);
+    setColumnOrder(s.columnOrder);
+    setGroupBy(s.groupBy);
+    setHiddenColumns(s.hiddenColumns);
+    setFrozenCount(s.frozenCount);
+    setRowHeight(s.rowHeight);
+    const coerced: Record<string, FooterAgg> = {};
+    for (const [k, v] of Object.entries(s.footerAgg)) coerced[k] = toFooterAgg(v);
+    setFooterAgg(coerced);
+    setShowFooter(s.showFooter);
+    setCollapsedGroups(new Set());
+    setExtraExpanded(new Set());
+  }, []);
+
+  const loadViews = useCallback(async (): Promise<NamedView[]> => {
+    if (serverBacked) {
+      const res = await listViewsAction(tableId);
+      if (!res.ok) return [];
+      return res.data.map((sv) => {
+        const parsed = parseViewState(
+          typeof sv.config === "string" ? sv.config : JSON.stringify(sv.config),
+        );
+        return {
+          viewId: sv.viewId,
+          name: sv.name,
+          state: normalizeViewState(parsed ?? {}),
+          isDefault: sv.isDefault,
+        };
+      });
+    }
+    try {
+      return parseNamedViews(localStorage.getItem(localViewsKey(tableId)));
+    } catch {
+      return [];
+    }
+  }, [serverBacked, tableId]);
+
+  const persistLocalViews = useCallback(
+    (next: NamedView[]) => {
+      if (serverBacked) return;
+      try {
+        localStorage.setItem(localViewsKey(tableId), serializeNamedViews(next));
+      } catch {
+        // ignore quota / unavailable storage
+      }
+    },
+    [serverBacked, tableId],
+  );
+
+  const handleApplyView = useCallback(
+    (v: NamedView) => {
+      applyViewState(v.state);
+      setActiveViewId(v.viewId);
+    },
+    [applyViewState],
+  );
+
+  const handleSaveView = useCallback(
+    async (name: string) => {
+      const state = buildCurrentViewState();
+      const match = (v: NamedView) => v.name.trim().toLowerCase() === name.trim().toLowerCase();
+      if (serverBacked) {
+        const res = await saveViewAction(tableId, { name, config: state });
+        if (!res.ok) return setError(res.error);
+        const loaded = await loadViews();
+        setViews(loaded);
+        setActiveViewId(loaded.find(match)?.viewId ?? null);
+      } else {
+        const id = `lv-${globalThis.crypto?.randomUUID?.() ?? String(views.length + 1)}`;
+        const next = upsertNamedView(views, name, state, id);
+        setViews(next);
+        persistLocalViews(next);
+        setActiveViewId(next.find(match)?.viewId ?? null);
+      }
+    },
+    [serverBacked, tableId, views, buildCurrentViewState, loadViews, persistLocalViews],
+  );
+
+  const handleDeleteView = useCallback(
+    async (viewId: string) => {
+      if (serverBacked) {
+        const res = await deleteViewAction(tableId, viewId);
+        if (!res.ok) return setError(res.error);
+        setViews(await loadViews());
+      } else {
+        const next = removeNamedView(views, viewId);
+        setViews(next);
+        persistLocalViews(next);
+      }
+      setActiveViewId((cur) => (cur === viewId ? null : cur));
+    },
+    [serverBacked, tableId, views, loadViews, persistLocalViews],
+  );
+
+  const handleSetDefaultView = useCallback(
+    async (viewId: string | null) => {
+      if (serverBacked) {
+        const res = await setDefaultViewAction(tableId, viewId);
+        if (!res.ok) return setError(res.error);
+        setViews(await loadViews());
+      } else {
+        const next = setDefaultNamedView(views, viewId);
+        setViews(next);
+        persistLocalViews(next);
+      }
+    },
+    [serverBacked, tableId, views, loadViews, persistLocalViews],
+  );
+
   // Persist the per-grid view (filters/sort/formatting/provenance) per tableId so
   // it survives reloads. Client-only (localStorage); hydrate once, then save on change.
   const viewHydratedRef = useRef(false);
   useEffect(() => {
     viewHydratedRef.current = false;
-    try {
-      const parsed = parseViewState(localStorage.getItem(viewStorageKey(tableId)));
-      if (parsed) {
-        if (parsed.filterQuery !== undefined) setFilterQuery(parsed.filterQuery);
-        if (parsed.filterGroup) setFilterGroup(parsed.filterGroup);
-        if (parsed.sort) setSortColumns(parsed.sort);
-        if (parsed.cfRules) setCfRules(parsed.cfRules);
-        if (parsed.showProvenance !== undefined) setShowProvenance(parsed.showProvenance);
-        if (parsed.columnOrder) setColumnOrder(parsed.columnOrder);
-        if (parsed.groupBy) setGroupBy(parsed.groupBy);
-        if (parsed.hiddenColumns) setHiddenColumns(parsed.hiddenColumns);
-        if (parsed.frozenCount !== undefined) setFrozenCount(parsed.frozenCount);
-        if (parsed.rowHeight) setRowHeight(parsed.rowHeight);
-        if (parsed.footerAgg) {
-          const coerced: Record<string, FooterAgg> = {};
-          for (const [k, v] of Object.entries(parsed.footerAgg)) coerced[k] = toFooterAgg(v);
-          setFooterAgg(coerced);
+    let cancelled = false;
+    void (async () => {
+      const loaded = await loadViews();
+      if (cancelled) return;
+      setViews(loaded);
+      // A saved default view wins over the last-used layout; else restore the
+      // last-used single-view state (field-by-field, so absent fields are kept).
+      const def = defaultNamedView(loaded);
+      if (def) {
+        applyViewState(def.state);
+        setActiveViewId(def.viewId);
+      } else {
+        try {
+          const parsed = parseViewState(localStorage.getItem(viewStorageKey(tableId)));
+          if (parsed) {
+            if (parsed.filterQuery !== undefined) setFilterQuery(parsed.filterQuery);
+            if (parsed.filterGroup) setFilterGroup(parsed.filterGroup);
+            if (parsed.sort) setSortColumns(parsed.sort);
+            if (parsed.cfRules) setCfRules(parsed.cfRules);
+            if (parsed.showProvenance !== undefined) setShowProvenance(parsed.showProvenance);
+            if (parsed.columnOrder) setColumnOrder(parsed.columnOrder);
+            if (parsed.groupBy) setGroupBy(parsed.groupBy);
+            if (parsed.hiddenColumns) setHiddenColumns(parsed.hiddenColumns);
+            if (parsed.frozenCount !== undefined) setFrozenCount(parsed.frozenCount);
+            if (parsed.rowHeight) setRowHeight(parsed.rowHeight);
+            if (parsed.footerAgg) {
+              const coerced: Record<string, FooterAgg> = {};
+              for (const [k, v] of Object.entries(parsed.footerAgg)) coerced[k] = toFooterAgg(v);
+              setFooterAgg(coerced);
+            }
+            if (parsed.showFooter !== undefined) setShowFooter(parsed.showFooter);
+          }
+        } catch {
+          // ignore unreadable storage
         }
-        if (parsed.showFooter !== undefined) setShowFooter(parsed.showFooter);
       }
-    } catch {
-      // ignore unreadable storage
-    }
-    viewHydratedRef.current = true;
-  }, [tableId]);
+      if (!cancelled) viewHydratedRef.current = true;
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tableId, loadViews, applyViewState]);
 
   useEffect(() => {
     if (!viewHydratedRef.current) return;
     try {
-      const sort: SortState[] = sortColumns.map((s) => ({
-        columnKey: s.columnKey,
-        direction: s.direction,
-      }));
-      localStorage.setItem(
-        viewStorageKey(tableId),
-        serializeViewState({
-          filterQuery,
-          filterGroup,
-          sort,
-          cfRules,
-          showProvenance,
-          columnOrder,
-          groupBy,
-          hiddenColumns,
-          frozenCount,
-          rowHeight,
-          footerAgg,
-          showFooter,
-        }),
-      );
+      localStorage.setItem(viewStorageKey(tableId), serializeViewState(buildCurrentViewState()));
     } catch {
       // ignore quota / unavailable storage
     }
-  }, [tableId, filterQuery, filterGroup, sortColumns, cfRules, showProvenance, columnOrder, groupBy, hiddenColumns, frozenCount, rowHeight, footerAgg, showFooter]);
+  }, [tableId, buildCurrentViewState]);
 
   // Columns in the user's saved drag order; new columns append, stale ids drop.
   const orderedColumns = useMemo(
@@ -842,11 +1010,22 @@ export function WorkbookGrid({
             </button>
           </>
         )}
+        <div className="ml-auto">
+          <GridViewsMenu
+            views={views}
+            activeViewId={activeViewId}
+            shared={serverBacked}
+            onApply={handleApplyView}
+            onSaveAs={handleSaveView}
+            onDelete={handleDeleteView}
+            onSetDefault={handleSetDefaultView}
+          />
+        </div>
         <button
           type="button"
           onClick={onExportCsv}
           disabled={columns.length === 0}
-          className="ml-auto rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-40"
+          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] disabled:opacity-40"
           title="Export the current view to CSV"
         >
           Export CSV

--- a/apps/web/components/workbooks/GridViewsMenu.tsx
+++ b/apps/web/components/workbooks/GridViewsMenu.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+// Universal Grid & Workbooks — the "Views" dropdown (EP-GRID-WORKBOOKS).
+//
+// One saved-views control for every grid. The Grid owns the backend (server-side
+// WorkbookView for custom tables, localStorage for platform grids) and passes the
+// resolved list + handlers here; this component is pure UI over them. Naming a new
+// view uses an inline input (not window.prompt, which blocks automation and reads
+// worse). Applying a view is the Grid's job — this only signals intent.
+
+import { useState, type ReactNode } from "react";
+import type { NamedView } from "./grid-named-views";
+
+export interface GridViewsMenuProps {
+  views: NamedView[];
+  activeViewId: string | null;
+  /** true → server-side shared views (custom tables); false → personal (localStorage). */
+  shared: boolean;
+  onApply: (view: NamedView) => void;
+  /** Capture the current grid state under this name (Grid builds the snapshot). */
+  onSaveAs: (name: string) => void;
+  onDelete: (viewId: string) => void;
+  /** Pass null to clear the default. */
+  onSetDefault: (viewId: string | null) => void;
+}
+
+const ITEM = "flex w-full items-center gap-2 rounded px-2 py-1 text-left text-sm hover:bg-[var(--dpf-surface-2)]";
+
+export function GridViewsMenu({
+  views,
+  activeViewId,
+  shared,
+  onApply,
+  onSaveAs,
+  onDelete,
+  onSetDefault,
+}: GridViewsMenuProps): ReactNode {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+
+  const active = views.find((v) => v.viewId === activeViewId);
+  const save = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    onSaveAs(trimmed);
+    setName("");
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="rounded-md border border-[var(--dpf-border)] px-3 py-1 text-sm text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+        title="Saved views"
+      >
+        {active ? active.name : "Views"}
+        <span aria-hidden="true"> ▾</span>
+      </button>
+      {open && (
+        <>
+          {/* click-away layer */}
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} aria-hidden="true" />
+          <div
+            role="menu"
+            className="absolute right-0 z-20 mt-1 flex w-72 flex-col gap-1 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 shadow-lg"
+          >
+            <div className="px-2 py-1 text-xs uppercase tracking-wide text-[var(--dpf-muted)]">
+              {shared ? "Shared views" : "My views"}
+            </div>
+            {views.length === 0 && (
+              <div className="px-2 py-1 text-sm text-[var(--dpf-muted)]">No saved views yet.</div>
+            )}
+            {views.map((v) => (
+              <div key={v.viewId} className="flex items-center gap-1">
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    onApply(v);
+                    setOpen(false);
+                  }}
+                  className={`${ITEM} ${v.viewId === activeViewId ? "font-medium text-[var(--dpf-text)]" : "text-[var(--dpf-text)]"}`}
+                >
+                  <span className="flex-1 truncate">{v.name}</span>
+                  {v.isDefault && (
+                    <span className="text-xs text-[var(--dpf-muted)]" title="Default view">
+                      default
+                    </span>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onSetDefault(v.isDefault ? null : v.viewId)}
+                  aria-label={v.isDefault ? `Unset ${v.name} as default` : `Set ${v.name} as default`}
+                  title={v.isDefault ? "Unset default" : "Set as default"}
+                  className="rounded px-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                >
+                  {v.isDefault ? "★" : "☆"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDelete(v.viewId)}
+                  aria-label={`Delete view ${v.name}`}
+                  title="Delete view"
+                  className="rounded px-1 text-sm text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+            <div className="mt-1 flex items-center gap-1 border-t border-[var(--dpf-border)] pt-2">
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") save();
+                }}
+                placeholder="Save current view as…"
+                aria-label="New view name"
+                className="min-w-0 flex-1 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]"
+              />
+              <button
+                type="button"
+                onClick={save}
+                disabled={!name.trim()}
+                className="rounded-md border border-[var(--dpf-border)] px-2 py-1 text-sm text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] disabled:opacity-50"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/workbooks/grid-named-views.test.ts
+++ b/apps/web/components/workbooks/grid-named-views.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  upsertNamedView,
+  removeNamedView,
+  setDefaultNamedView,
+  defaultNamedView,
+  serializeNamedViews,
+  parseNamedViews,
+  normalizeViewState,
+  type NamedView,
+} from "./grid-named-views";
+import type { GridViewState } from "./grid-view-state";
+
+const baseState = (over: Partial<GridViewState> = {}): GridViewState =>
+  normalizeViewState({ groupBy: ["status"], ...over });
+
+const view = (id: string, name: string, over: Partial<GridViewState> = {}): NamedView => ({
+  viewId: id,
+  name,
+  state: baseState(over),
+});
+
+describe("upsertNamedView", () => {
+  it("appends a new view", () => {
+    const out = upsertNamedView([], "My open bugs", baseState(), "lv-1");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ viewId: "lv-1", name: "My open bugs" });
+  });
+
+  it("overwrites an existing view with the same name (case-insensitive), keeping its id", () => {
+    const views = [view("lv-1", "By Owner")];
+    const out = upsertNamedView(views, "by owner", baseState({ groupBy: ["owner"] }), "lv-2");
+    expect(out).toHaveLength(1);
+    expect(out[0]!.viewId).toBe("lv-1"); // kept
+    expect(out[0]!.name).toBe("by owner"); // renamed to the new trimmed input
+    expect(out[0]!.state.groupBy).toEqual(["owner"]); // state replaced
+  });
+
+  it("trims the name", () => {
+    const out = upsertNamedView([], "  Spaced  ", baseState(), "lv-1");
+    expect(out[0]!.name).toBe("Spaced");
+  });
+
+  it("does not mutate the input array", () => {
+    const views = [view("lv-1", "A")];
+    upsertNamedView(views, "B", baseState(), "lv-2");
+    expect(views).toHaveLength(1);
+  });
+});
+
+describe("removeNamedView", () => {
+  it("removes by id", () => {
+    const views = [view("lv-1", "A"), view("lv-2", "B")];
+    expect(removeNamedView(views, "lv-1").map((v) => v.viewId)).toEqual(["lv-2"]);
+  });
+});
+
+describe("setDefaultNamedView / defaultNamedView", () => {
+  it("marks exactly one view default and clears the rest", () => {
+    const views = [view("lv-1", "A"), view("lv-2", "B"), view("lv-3", "C")];
+    const out = setDefaultNamedView(setDefaultNamedView(views, "lv-1"), "lv-3");
+    expect(out.filter((v) => v.isDefault).map((v) => v.viewId)).toEqual(["lv-3"]);
+    expect(defaultNamedView(out)!.viewId).toBe("lv-3");
+  });
+
+  it("clears all defaults when given null", () => {
+    const views = setDefaultNamedView([view("lv-1", "A")], "lv-1");
+    expect(defaultNamedView(setDefaultNamedView(views, null))).toBeUndefined();
+  });
+});
+
+describe("serialize / parse round-trip", () => {
+  it("round-trips views through localStorage serialization", () => {
+    const views = setDefaultNamedView(
+      [view("lv-1", "Open", { groupBy: ["status"] }), view("lv-2", "By owner", { groupBy: ["owner"] })],
+      "lv-2",
+    );
+    const parsed = parseNamedViews(serializeNamedViews(views));
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]!.state.groupBy).toEqual(["status"]);
+    expect(defaultNamedView(parsed)!.viewId).toBe("lv-2");
+  });
+
+  it("returns [] for null / malformed input, never throws", () => {
+    expect(parseNamedViews(null)).toEqual([]);
+    expect(parseNamedViews("not json")).toEqual([]);
+    expect(parseNamedViews('{"not":"an array"}')).toEqual([]);
+  });
+
+  it("drops entries missing viewId/name or with an unparseable state", () => {
+    const raw = JSON.stringify([
+      { name: "no id", state: "{}" },
+      { viewId: "lv-9", state: "{}" }, // no name
+      { viewId: "lv-1", name: "ok", state: "{}" },
+    ]);
+    const parsed = parseNamedViews(raw);
+    expect(parsed.map((v) => v.viewId)).toEqual(["lv-1"]);
+  });
+
+  it("accepts a server view whose `state` is an object (not a serialized string)", () => {
+    const raw = JSON.stringify([
+      { viewId: "VW-abc", name: "Server view", state: { groupBy: ["status"], showFooter: true } },
+    ]);
+    const parsed = parseNamedViews(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]!.state.groupBy).toEqual(["status"]);
+    expect(parsed[0]!.state.showFooter).toBe(true);
+  });
+});
+
+describe("normalizeViewState", () => {
+  it("fills every field with a baseline default so a view fully resets the grid", () => {
+    const s = normalizeViewState({ groupBy: ["x"] });
+    expect(s.filterQuery).toBe("");
+    expect(s.sort).toEqual([]);
+    expect(s.hiddenColumns).toEqual([]);
+    expect(s.frozenCount).toBe(0);
+    expect(s.rowHeight).toBe("medium");
+    expect(s.showFooter).toBe(false);
+    expect(s.groupBy).toEqual(["x"]);
+  });
+});

--- a/apps/web/components/workbooks/grid-named-views.ts
+++ b/apps/web/components/workbooks/grid-named-views.ts
@@ -1,0 +1,143 @@
+// Universal Grid & Workbooks — named/saved views (EP-GRID-WORKBOOKS).
+//
+// A "view" is a named snapshot of the full grid view-state (filters, sort,
+// grouping, formatting, column order/visibility/freeze, row height, footer
+// aggregates). Two backends share this shape:
+//   • custom workbook tables → WorkbookView rows (server, shared across users)
+//   • platform grids         → localStorage (personal, per browser)
+// so the Views dropdown is identical on every grid. The array operations here
+// are pure + unit-testable; the Grid owns the IO (localStorage or server action)
+// and the react state.
+
+import {
+  type GridViewState,
+  parseViewState,
+  serializeViewState,
+} from "./grid-view-state";
+
+/** A saved view: a name over a complete grid view-state snapshot. */
+export interface NamedView {
+  /** Stable id — "VW-<cuid>" server-side, "lv-<n>" for local views. */
+  viewId: string;
+  name: string;
+  /** The full grid view-state this view restores. */
+  state: GridViewState;
+  /** At most one default per table; applied on first load. */
+  isDefault?: boolean;
+}
+
+/** localStorage key holding a table's personal saved views (distinct from the
+ * single last-used view state under `viewStorageKey`). */
+export function localViewsKey(tableId: string): string {
+  return `dpf-workbook-views:${tableId}`;
+}
+
+/** Insert a new view or overwrite an existing one with the same (case-insensitive)
+ * name — "Save view" is an upsert so re-saving a name updates it in place. */
+export function upsertNamedView(
+  views: readonly NamedView[],
+  name: string,
+  state: GridViewState,
+  newId: string,
+): NamedView[] {
+  const trimmed = name.trim();
+  const idx = views.findIndex((v) => v.name.trim().toLowerCase() === trimmed.toLowerCase());
+  if (idx >= 0) {
+    const next = views.slice();
+    next[idx] = { ...next[idx]!, name: trimmed, state };
+    return next;
+  }
+  return [...views, { viewId: newId, name: trimmed, state }];
+}
+
+/** Remove a view by id (and clear it as default implicitly, since it's gone). */
+export function removeNamedView(views: readonly NamedView[], viewId: string): NamedView[] {
+  return views.filter((v) => v.viewId !== viewId);
+}
+
+/** Mark exactly one view default (or none, if viewId is not present/​null). */
+export function setDefaultNamedView(
+  views: readonly NamedView[],
+  viewId: string | null,
+): NamedView[] {
+  return views.map((v) => ({ ...v, isDefault: v.viewId === viewId }));
+}
+
+/** The default view for a table, if any. */
+export function defaultNamedView(views: readonly NamedView[]): NamedView | undefined {
+  return views.find((v) => v.isDefault);
+}
+
+// --- localStorage serialization (defensive; never throws on bad data) --------
+
+interface SerializedNamedView {
+  viewId: string;
+  name: string;
+  state: string; // serializeViewState output
+  isDefault?: boolean;
+}
+
+export function serializeNamedViews(views: readonly NamedView[]): string {
+  const payload: SerializedNamedView[] = views.map((v) => ({
+    viewId: v.viewId,
+    name: v.name,
+    state: serializeViewState(v.state),
+    ...(v.isDefault ? { isDefault: true } : {}),
+  }));
+  return JSON.stringify(payload);
+}
+
+/** Parse saved views; each field validated independently, bad entries dropped. */
+export function parseNamedViews(raw: string | null | undefined): NamedView[] {
+  if (!raw) return [];
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(data)) return [];
+  const out: NamedView[] = [];
+  for (const entry of data) {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      typeof (entry as Record<string, unknown>).viewId !== "string" ||
+      typeof (entry as Record<string, unknown>).name !== "string"
+    ) {
+      continue;
+    }
+    const e = entry as Record<string, unknown>;
+    // `state` may be a serialized string (localStorage) or an object (server JSON).
+    const rawState = typeof e.state === "string" ? e.state : JSON.stringify(e.state);
+    const state = parseViewState(rawState);
+    if (!state) continue;
+    out.push({
+      viewId: e.viewId as string,
+      name: e.name as string,
+      state: normalizeViewState(state),
+      ...(e.isDefault === true ? { isDefault: true } : {}),
+    });
+  }
+  return out;
+}
+
+/** Fill a partial (defensively-parsed) view-state with safe defaults so a saved
+ * view always restores every field — missing fields reset to the grid's baseline
+ * rather than leaving the prior view's value. */
+export function normalizeViewState(partial: Partial<GridViewState>): GridViewState {
+  return {
+    filterQuery: partial.filterQuery ?? "",
+    filterGroup: partial.filterGroup ?? { combinator: "and", conditions: [] },
+    sort: partial.sort ?? [],
+    cfRules: partial.cfRules ?? [],
+    showProvenance: partial.showProvenance ?? false,
+    columnOrder: partial.columnOrder ?? [],
+    groupBy: partial.groupBy ?? [],
+    hiddenColumns: partial.hiddenColumns ?? [],
+    frozenCount: partial.frozenCount ?? 0,
+    rowHeight: partial.rowHeight ?? "medium",
+    footerAgg: partial.footerAgg ?? {},
+    showFooter: partial.showFooter ?? false,
+  };
+}

--- a/apps/web/lib/actions/workbooks.ts
+++ b/apps/web/lib/actions/workbooks.ts
@@ -28,7 +28,13 @@ import {
   getTableGridData as svcGetTableGridData,
   getTableSchema as svcGetTableSchema,
   queryRows as svcQueryRows,
+  listViews as svcListViews,
+  saveView as svcSaveView,
+  deleteView as svcDeleteView,
+  setDefaultView as svcSetDefaultView,
+  type SavedView,
 } from "@/lib/workbooks/workbook-service";
+import type { Prisma } from "@dpf/db";
 import {
   type PlatformUser,
   type ReferenceTarget,
@@ -211,6 +217,63 @@ export async function getTableGridDataAction(tableId: string): Promise<
   try {
     const user = await requireUser("view_workbooks");
     return ok(await svcGetTableGridData(user, tableId));
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+// ── Saved views (Phase 3) ───────────────────────────────────────────────────
+// Named views on custom workbook tables persist server-side (shared across
+// everyone with table access). Platform grids use a client-side (localStorage)
+// store instead — same UI, different backend — so these actions are only invoked
+// for custom tables. `config` is the opaque grid view-state blob.
+
+export async function listViewsAction(tableId: string): Promise<ActionResult<SavedView[]>> {
+  try {
+    const user = await requireUser("view_workbooks");
+    return ok(await svcListViews(user, tableId));
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function saveViewAction(
+  tableId: string,
+  input: { name: string; config: unknown; viewType?: string; isDefault?: boolean },
+): Promise<ActionResult<{ viewId: string }>> {
+  try {
+    const user = await requireUser("manage_workbooks");
+    return ok(
+      await svcSaveView(user, tableId, {
+        name: input.name,
+        config: input.config as Prisma.InputJsonValue,
+        viewType: input.viewType,
+        isDefault: input.isDefault,
+      }),
+    );
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function deleteViewAction(tableId: string, viewId: string): Promise<ActionResult> {
+  try {
+    const user = await requireUser("manage_workbooks");
+    await svcDeleteView(user, tableId, viewId);
+    return ok();
+  } catch (e) {
+    return fail(e);
+  }
+}
+
+export async function setDefaultViewAction(
+  tableId: string,
+  viewId: string | null,
+): Promise<ActionResult> {
+  try {
+    const user = await requireUser("manage_workbooks");
+    await svcSetDefaultView(user, tableId, viewId);
+    return ok();
   } catch (e) {
     return fail(e);
   }

--- a/apps/web/lib/workbooks/workbook-service.ts
+++ b/apps/web/lib/workbooks/workbook-service.ts
@@ -455,10 +455,19 @@ export async function deleteRow(
 // Views
 // ---------------------------------------------------------------------------
 
-export async function listViews(
-  user: ServiceUser,
-  tableId: string,
-): Promise<{ viewId: string; name: string; viewType: string; config: ViewConfig; isDefault: boolean }[]> {
+/** A saved view as the client consumes it. `config` is the opaque grid
+ * view-state blob (the client owns its shape); the server just persists it. */
+export interface SavedView {
+  viewId: string;
+  name: string;
+  viewType: string;
+  config: unknown;
+  isDefault: boolean;
+}
+
+/** Views are table-scoped and shared across everyone with table access
+ * (creator recorded for attribution) — the "shareable" half of named views. */
+export async function listViews(user: ServiceUser, tableId: string): Promise<SavedView[]> {
   const t = await resolveTable(user, tableId, "viewer");
   const views = await prisma.workbookView.findMany({
     where: { tableId: t.internalId },
@@ -468,29 +477,91 @@ export async function listViews(
     viewId: v.viewId,
     name: v.name,
     viewType: v.viewType,
-    config: v.config as unknown as ViewConfig,
+    config: v.config,
     isDefault: v.isDefault,
   }));
 }
 
+/**
+ * Create or overwrite a saved view. Upserts by (table, case-insensitive name) so
+ * re-saving a name updates it in place — matching the client's local-view store.
+ * When `isDefault`, every other view on the table is cleared first so at most one
+ * default exists. `config` is the opaque grid view-state blob.
+ */
 export async function saveView(
   user: ServiceUser,
   tableId: string,
-  input: { name: string; config: ViewConfig; viewType?: string; isDefault?: boolean },
+  input: { name: string; config: Prisma.InputJsonValue; viewType?: string; isDefault?: boolean },
 ): Promise<{ viewId: string }> {
   const t = await resolveTable(user, tableId, "editor");
-  const view = await prisma.workbookView.create({
-    data: {
-      viewId: genSemanticId("VW"),
-      name: input.name,
-      tableId: t.internalId,
-      viewType: input.viewType ?? "grid",
-      config: input.config as unknown as Prisma.InputJsonValue,
-      isDefault: input.isDefault ?? false,
-      createdById: user.id,
-    },
+  const name = input.name.trim();
+  if (!name) throw new WorkbookError("A view name is required", 400);
+  const existing = await prisma.workbookView.findFirst({
+    where: { tableId: t.internalId, name: { equals: name, mode: "insensitive" } },
   });
-  return { viewId: view.viewId };
+  return prisma.$transaction(async (tx) => {
+    if (input.isDefault) {
+      await tx.workbookView.updateMany({
+        where: { tableId: t.internalId, isDefault: true },
+        data: { isDefault: false },
+      });
+    }
+    if (existing) {
+      const v = await tx.workbookView.update({
+        where: { id: existing.id },
+        data: {
+          name,
+          viewType: input.viewType ?? existing.viewType,
+          config: input.config,
+          ...(input.isDefault !== undefined ? { isDefault: input.isDefault } : {}),
+        },
+      });
+      return { viewId: v.viewId };
+    }
+    const v = await tx.workbookView.create({
+      data: {
+        viewId: genSemanticId("VW"),
+        name,
+        tableId: t.internalId,
+        viewType: input.viewType ?? "grid",
+        config: input.config,
+        isDefault: input.isDefault ?? false,
+        createdById: user.id,
+      },
+    });
+    return { viewId: v.viewId };
+  });
+}
+
+/** Delete a saved view by its public viewId (scoped to the table). */
+export async function deleteView(
+  user: ServiceUser,
+  tableId: string,
+  viewId: string,
+): Promise<void> {
+  const t = await resolveTable(user, tableId, "editor");
+  await prisma.workbookView.deleteMany({ where: { viewId, tableId: t.internalId } });
+}
+
+/** Make one view the table's default (or clear all defaults with viewId=null). */
+export async function setDefaultView(
+  user: ServiceUser,
+  tableId: string,
+  viewId: string | null,
+): Promise<void> {
+  const t = await resolveTable(user, tableId, "editor");
+  await prisma.$transaction(async (tx) => {
+    await tx.workbookView.updateMany({
+      where: { tableId: t.internalId, isDefault: true },
+      data: { isDefault: false },
+    });
+    if (viewId) {
+      await tx.workbookView.updateMany({
+        where: { tableId: t.internalId, viewId },
+        data: { isDefault: true },
+      });
+    }
+  });
 }
 
 /**

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -236,8 +236,20 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   Conditions combine with a single AND/OR toggle. Pure, unit-tested `grid-filter-builder.ts`
   (`applyFilterGroup`/`evaluateCondition`/`opsForField`); half-typed conditions never hide rows.
   Persisted as `filterGroup` in the view state (old `columnFilters` still parsed for back-compat).
-- **Remaining (not built):** named/shareable server-side views; calendar view (fullcalendar — needs a
-  date column); manual row reordering; full pivots + richer charts; metrics/semantic layer;
+- **Slice 24 — named/saved views (unified) — SHIPPED.** One "Views" dropdown on every grid: save the
+  current layout under a name, apply a saved view, rename (save over), delete, and mark a default that
+  auto-applies on load. A view snapshots the **full** grid view-state (`GridViewState` — filters, sort,
+  grouping, formatting, column order/visibility/freeze, row height, footer aggregates), a superset of
+  the spec's original `ViewConfig`, so a view restores exactly what the user saw. Two backends, one UI
+  (`GridViewsMenu`): **custom tables** persist server-side to the pre-existing `WorkbookView` model
+  (shared across everyone with table access, creator-attributed) via new `listViews`/`saveView`
+  (upsert-by-name) / `deleteView` / `setDefaultView` service fns + `*ViewAction` server actions;
+  **platform grids** persist to `localStorage` (personal), reusing the same view-state shape. Pure,
+  unit-tested store ops in `grid-named-views.ts` (`upsert`/`remove`/`setDefault`/`parse` +
+  `normalizeViewState`). No migration — the model already existed.
+- **Remaining (not built):** platform-grid *shareable* views (needs a `WorkbookView.tableId` schema
+  change — platform tables have no `WorkbookTable` row); calendar view (fullcalendar — needs a date
+  column); manual row reordering; full pivots + richer charts; metrics/semantic layer;
   operationalization lifecycle.
   **Debt (decomposition — largely paid down):** all five toolbar panels — Filter, Summary, Format,
   Group, Columns — now live as typed, presentational components in `GridPanels.tsx` (pure UI over

--- a/docs/superpowers/specs/2026-03-23-universal-grid-workbooks-design.md
+++ b/docs/superpowers/specs/2026-03-23-universal-grid-workbooks-design.md
@@ -284,6 +284,8 @@ interface ViewConfig {
 
 Kanban validation: when `viewType = "kanban"`, the `kanban.groupByColumnId` must reference a column with `fieldType` of `select` or a platform adapter column marked as `groupable: true` (e.g., status enums). This is validated at the API layer when saving a view — rejected with a descriptive error if the group-by column is incompatible.
 
+> **Update (2026-07, Slice 24 — named views):** as the grid gained grouping, conditional formatting, per-column footer aggregates, column freeze/hide/reorder, and row-density, `WorkbookView.config` now stores the richer client `GridViewState` blob (a superset of the `ViewConfig` above) so a saved view restores *exactly* what the user saw. The server treats `config` as opaque JSON; the grid owns its shape. The narrow `ViewConfig` remains the contract for pre-configured `dataSourceFilter`s and Kanban. Named views persist server-side (`WorkbookView`, shared) for custom tables and in `localStorage` (personal) for platform grids — unified behind one `GridViewsMenu`.
+
 ### Key Indexes and Constraints
 
 - `WorkbookCell(rowId, columnId)` — unique composite for cell lookup

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -12,7 +12,7 @@ apps/web/components/platform/AiOperationsMap.tsx	2881
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
 apps/web/components/storefront/SlotBookingFlow.tsx	919
-apps/web/components/workbooks/Grid.tsx	1094
+apps/web/components/workbooks/Grid.tsx	1273
 apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1341
 apps/web/lib/actions/agent-coworker-external.test.ts	867


### PR DESCRIPTION
## What

One **Views** dropdown on every grid — the marquee Airtable/Smartsheet "saved views" feature:
- **Save** the current layout under a name, **apply** a saved view, **rename** (save over), **delete**, and mark a **default** that auto-applies on load.

A view snapshots the **full** grid view-state (`GridViewState`: quick + structured filters, multi-column sort, multi-level grouping, conditional formatting, column order/visibility/freeze, row height, per-column footer aggregates) — a superset of the spec's original `ViewConfig` — so a view restores *exactly* what the user saw.

## Two backends, one UI (`GridViewsMenu`)

Chosen by the grid's `source`:
- **Custom workbook tables** → server-side `WorkbookView` (shared across everyone with table access, creator-attributed). The model + `listViews`/`saveView` **already existed — no migration**; I added `deleteView` + `setDefaultView`, made `saveView` upsert-by-name, widened `config` to the opaque view-state blob, and added `listViews/saveView/delete/setDefault` **server actions**.
- **Platform grids** (backlog/`/ops`) → `localStorage` (personal), same view-state shape — so the feature shows on the grids the operator actually uses.

A saved **default** wins over the last-used layout on load; otherwise the existing single-view hydrate is unchanged.

## Tests

Pure store ops in `grid-named-views.ts` (upsert/remove/setDefault/parse round-trip + `normalizeViewState`) — 13 new tests; **125/125 workbooks green**. CI runs the authoritative typecheck (source-only worktree can't tsc locally).

## Scope / size

- `Grid.tsx` 1094 → 1273 (the wiring; the earlier decomposition #3102 bought the headroom). New `GridViewsMenu.tsx` (140) + `grid-named-views.ts` (144) are under the size guard.
- **Follow-up:** platform-grid *shareable* (server) views need a small `WorkbookView.tableId` schema change (platform tables have no `WorkbookTable` row) — noted in the plan.

## Design grounding

- **Source of truth:** the 2026-03-23 spec's "View Config Schema" + the phase-2 plan (Slice 24). **Contract change recorded in the spec:** `WorkbookView.config` now stores the richer `GridViewState` blob (superset of `ViewConfig`); the server treats it as opaque JSON, the grid owns its shape.
- **UX-Fit:** progressive disclosure — a single "Views ▾" button showing the active view; the list + one plain "Save current view as…" input appear only on open. No tokens/endpoints.

Design-Grounding-Decision: extends docs/superpowers/specs/2026-03-23-universal-grid-workbooks-design.md and docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md (Slice 24) over the apps/web/ grid substrate; config-shape contract change recorded in the spec.
UX-Fit-Decision: single collapsed "Views ▾" control; save via one plain text input; save/apply/delete/default one click each — lowest cognitive load vs a panel or modal.
Process-Spine-Decision: new modules grounded by the touched phase-2 plan (Slice 24) + spec update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)