### PR TITLE
fix(self-upgrade): classify P3018/23505 migration unique-violation + correct P3009 resolve guidance (BI-46030F7E)

### DIFF
--- a/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
@@ -100,6 +100,20 @@ const P3009_BLOCKED_LOG = `Error: P3009
 migrate found failed migrations in the target database, new migrations will not be applied. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
 The \`20260714110000_bet5_pgvector_foundation\` migration started at 2026-07-14 11:02:03 UTC failed`;
 
+// Verbatim shape from SUR-859DB221 (2026-07-16): the staging-gate migration's
+// bulk backfill UPDATE over PlatformIssueReport collided with the log-signature
+// scanner still writing the same hot table, tripping the partial unique index.
+// P3018 + 23505 + a dedupeKey duplicate — NO "vector" text, so it must NOT be
+// swept up as pgvector, and it precedes the P3009 the identical retry hits.
+const MIGRATION_UNIQUE_VIOLATION_LOG = `Applying migration \`20260716130000_add_pir_reach_staging_gate\`
+Error: P3018
+A migration failed to apply. New migrations cannot be applied before the error is recovered from.
+Migration name: 20260716130000_add_pir_reach_staging_gate
+Database error code: 23505
+Database error:
+ERROR: duplicate key value violates unique constraint "PlatformIssueReport_dedupeKey_open_key"
+DETAIL: Key ("dedupeKey")=(log-sig:sandbox:3c148b45c3) already exists.`;
+
 // Verbatim shape from BI-D8C0D045 (run SUR-C8BC533B, 2026-07-15): postgres was
 // unreachable during the upgrade (stranded in `Created` by the pre-#2978
 // ensure-pgvector bug), so the boot backfill's Prisma write hit P1001.
@@ -209,12 +223,31 @@ describe("classifyBuildFailure", () => {
     expect(c.failingTrace).toContain("vector");
   });
 
-  it("classifies a P3009 blocked-migration state as environment, pointing at resolve --rolled-back", () => {
+  it("classifies a P3009 blocked-migration state as environment, pointing at BOTH resolve directions", () => {
     const c = classifyBuildFailure({ log: P3009_BLOCKED_LOG });
     expect(c.class).toBe("p3009-failed-migration");
     expect(c.isMainDefectVsEnvironment).toBe("environment");
+    // Guidance must offer both directions so a schema-already-applied failure
+    // (data-collision) is not mis-recovered with --rolled-back (SUR-859DB221).
     expect(c.summary).toContain("resolve --rolled-back");
+    expect(c.summary).toContain("resolve --applied");
     expect(c.playbookLink).toMatch(/bet5-windows-self-upgrade/);
+  });
+
+  it("classifies a P3018 unique-constraint migration failure as its own class with --applied guidance (SUR-859DB221)", () => {
+    const c = classifyBuildFailure({ log: MIGRATION_UNIQUE_VIOLATION_LOG });
+    expect(c.class).toBe("migration-unique-violation");
+    expect(c.isMainDefectVsEnvironment).toBe("environment");
+    // Names the offending constraint and steers to the correct resolve direction.
+    expect(c.summary).toContain("PlatformIssueReport_dedupeKey_open_key");
+    expect(c.summary).toContain("resolve --applied");
+    expect(c.failingTrace).toContain("duplicate key value violates unique constraint");
+  });
+
+  it("does NOT sweep the pgvector P3018 (0A000, no 23505) into the unique-violation class", () => {
+    // Both are P3018 apply failures; only the 23505 one is the unique-violation class.
+    expect(classifyBuildFailure({ log: PGVECTOR_MISSING_LOG }).class).toBe("pgvector-extension-missing");
+    expect(classifyBuildFailure({ log: MIGRATION_UNIQUE_VIOLATION_LOG }).class).toBe("migration-unique-violation");
   });
 
   it("prefers the pgvector root cause over P3009 when a log carries both", () => {

--- a/apps/web/lib/self-upgrade/build-failure-classifier.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.ts
@@ -57,10 +57,20 @@ export type BuildFailureClass =
   // migrate (data-preserving). Environment/image gap, not a main defect
   // (SUR-* 2026-07-14; fixed by PR #2969/#2978).
   | "pgvector-extension-missing"
+  // A migration FAILED TO APPLY (P3018) because a statement hit a unique-
+  // constraint violation (Postgres 23505 "duplicate key value"). The canonical
+  // case (SUR-859DB221/SUR-69A54F89, 2026-07-16): a data migration's bulk UPDATE
+  // over PlatformIssueReport re-validated the partial unique index
+  // `PlatformIssueReport_dedupeKey_open_key` and collided with the log-signature
+  // scanner concurrently writing the same hot table. The failed record then
+  // wedges ALL future upgrades (P3009) until resolved — and the resolve direction
+  // depends on whether the schema half applied. Distinct from the pgvector P3018
+  // (0A000 "extension vector") above, which is its own class.
+  | "migration-unique-violation"
   // A prior failed migration left Prisma's P3009 state, which blocks ALL later
   // migrations until the failed record is resolved (migrate resolve
-  // --rolled-back). Environment state from an earlier aborted attempt — often the
-  // pgvector failure above — not a main defect (promoter step-3a self-heals it).
+  // --rolled-back OR --applied — see summary). Environment state from an earlier
+  // aborted attempt — often the pgvector or unique-violation failure above.
   | "p3009-failed-migration"
   // The migrate/boot step cannot reach Postgres (Prisma P1001 "Can't reach
   // database server") — the DB is down or unreachable (e.g. postgres stranded in
@@ -133,6 +143,14 @@ const BET5_PLAYBOOK = "docs/runbooks/bet5-windows-self-upgrade.md";
 // not open extension control file ".../vector.control"`. Deliberately anchored on
 // the word "vector" so a generic missing-extension error stays unclassified.
 const PGVECTOR_MISSING = /extension\s+"?vector"?\s+is not available|could not open extension control file[^\n]*vector|vector\.control/i;
+// A migration that FAILED TO APPLY (P3018) on a UNIQUE-constraint violation
+// (Postgres 23505). Requires BOTH the apply-failure marker AND the duplicate-key
+// signal so a P3018 with a DIFFERENT underlying error (e.g. pgvector's 0A000,
+// handled above) is never swept in here. The constraint name is pulled out for a
+// specific diagnosis.
+const MIGRATION_APPLY_FAILED = /\bP3018\b|A migration failed to apply/i;
+const UNIQUE_VIOLATION = /duplicate key value violates unique constraint|Database error code:\s*23505|\bSqlState\(E?23505\)/i;
+const UNIQUE_CONSTRAINT_NAME = /violates unique constraint "([^"]+)"/i;
 // Prisma's P3009: a prior migration is recorded failed and blocks all later ones.
 // Anchored on the P3009 code / its exact phrasing — NOT a bare "migrate failed",
 // which is a different (unknown) failure that must not be mislabeled.
@@ -295,11 +313,28 @@ export function classifyBuildFailure(
     };
   }
 
+  // A migration that FAILED TO APPLY on a unique-constraint violation. Checked
+  // before P3009 because this is the FIRST-failure signature (P3018 + 23505); the
+  // P3009 block below is the downstream symptom the identical retry then hits.
+  if (MIGRATION_APPLY_FAILED.test(log) && UNIQUE_VIOLATION.test(log)) {
+    const constraint = log.match(UNIQUE_CONSTRAINT_NAME)?.[1] ?? null;
+    const constraintNote = constraint ? ` (unique index \`${constraint}\`)` : "";
+    return {
+      class: "migration-unique-violation",
+      summary:
+        `A migration failed to apply (P3018) on a duplicate-key / unique-constraint violation${constraintNote}. ` +
+        "The canonical cause is a data migration's bulk UPDATE/insert re-validating a partial unique index on a HOT table while the app is still writing it (SUR-859DB221, 2026-07-16: the log-signature scanner concurrently minting PlatformIssueReport rows during the staging-gate migration's backfill). RECOVERY depends on whether the schema half-applied: if the migration's columns/index are already present in the DB, run `prisma migrate resolve --applied <name>` (NOT --rolled-back, which would re-run the ADD COLUMN and fail 'already exists'); if the schema did not apply, de-duplicate the offending rows for that key, then `--rolled-back` + re-trigger. A failed record left here wedges ALL future upgrades via P3009. Deeper fix: keep a bulk data-migration off a table under active concurrent writes to a partial unique index.",
+      playbookLink: BET5_PLAYBOOK,
+      failingTrace: traceAround(log, UNIQUE_VIOLATION),
+      isMainDefectVsEnvironment: "environment",
+    };
+  }
+
   if (P3009_FAILED_MIGRATION.test(log)) {
     return {
       class: "p3009-failed-migration",
       summary:
-        "A prior failed migration left Prisma's P3009 state, which blocks ALL later migrations. Resolve the failed migration (`prisma migrate resolve --rolled-back <name>`) once its precondition is fixed — the promoter's step-3a self-heals the BET-5 pgvector migration automatically. Environment state from an earlier aborted attempt, not a main defect.",
+        "A prior failed migration left Prisma's P3009 state, which blocks ALL later migrations. Resolve the failed migration once its precondition is fixed, choosing the direction by what actually landed: `prisma migrate resolve --rolled-back <name>` when the migration did NOT apply its schema (e.g. the BET-5 pgvector case, which the promoter's step-3a self-heals), or `prisma migrate resolve --applied <name>` when the migration's schema changes are ALREADY present (a partial-apply, e.g. a data-collision failure — otherwise a re-run re-executes the DDL and fails 'already exists'). Environment state from an earlier aborted attempt, not a main defect.",
       playbookLink: BET5_PLAYBOOK,
       failingTrace: traceAround(log, P3009_FAILED_MIGRATION),
       isMainDefectVsEnvironment: "environment",


### PR DESCRIPTION
## Why

Incident 2026-07-16 (SUR-859DB221 / SUR-69A54F89): the self-upgrade repeatedly failed at the migrate step with **no legible diagnosis**, and recovery required manual `_prisma_migrations` surgery.

The staging-gate migration `20260716130000_add_pir_reach_staging_gate` failed with **P3018 + Postgres 23505** — a duplicate key on the partial unique index `PlatformIssueReport_dedupeKey_open_key`. Its bulk backfill `UPDATE` re-validated that index on a **hot table** while the log-signature scanner was still writing `PlatformIssueReport`. The failed record then wedged **all** future upgrades via P3009, and every retry re-failed identically.

`build-failure-classifier.ts` — whose entire purpose is *"hand the agent an actionable diagnosis, not a raw log"* — had two gaps that made this incident opaque:

1. **No class for a P3018 + 23505 apply failure** → it fell through to `unknown`.
2. The `p3009-failed-migration` guidance advised only `migrate resolve --rolled-back` (the pgvector case). For a migration whose schema **already applied** (ours), `--rolled-back` re-runs the DDL and fails *"already exists"* — the correct recovery is `--applied`.

## What

- **New `migration-unique-violation` class**: matches `P3018` + (`23505` | `duplicate key value violates unique constraint` | `SqlState(E23505)`), extracts the offending **constraint name**, and steers to the correct resolve direction (`--applied` when the schema is already present; de-dup + `--rolled-back` otherwise). Checked **before** P3009 (the first-failure signature). The pgvector P3018 (`0A000`, no `23505`) stays its own class.
- **Broadened P3009 guidance** to offer both resolve directions with the rule for choosing, so a schema-already-applied failure isn't mis-recovered.
- **Tests**: verbatim SUR-859DB221 fixture; asserts the new class, the named constraint, `--applied` guidance, and that the pgvector P3018 is *not* swept in.

Pure-function change to a well-tested classifier — no runtime/DDL behavior changes.

## Verification

- Unit tests added (deterministic pure-function classification).
- Local typecheck/unit pre-gate env-blocked (source-only worktree, no `node_modules`); **CI Typecheck / Unit / Prod Build gate the merge.**

## Follow-ups (deeper prevention, tracked in BI-46030F7E — out of scope here)

- Migrate-step **auto-heal**: on a schema-already-applied stuck migration, resolve `--applied` and retry (extend the promoter's step-3a self-heal beyond pgvector) so this self-recovers.
- **Migration-authoring guard**: don't run a bulk data-migration over a table under active concurrent writes to a partial unique index.
- De-dup the churning duplicate `log-sig:*` PIRs at the source (the scanner loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)