### PR TITLE
refactor(ea): extract pure EA helpers into a domain-core module (BI-OPT-FAT-ACTIONS — EA slice)

### DIFF
--- a/apps/web/lib/actions/ea.ts
+++ b/apps/web/lib/actions/ea.ts
@@ -18,22 +18,19 @@ import {
   deleteEaElement as neo4jDeleteEaElement,
   deleteEaRelationship as neo4jDeleteEaRelationship,
 } from "@dpf/db/graph-sync";
-
-const REFERENCE_COVERAGE_STATUSES = [
-  "implemented",
-  "partial",
-  "planned",
-  "not_started",
-  "out_of_mvp",
-] as const;
-
-const REFERENCE_PROPOSAL_STATUSES = [
-  "proposed",
-  "reviewed",
-  "approved",
-  "rejected",
-  "promoted",
-] as const;
+import {
+  assertCoverageStatus,
+  assertProposalStatus,
+  type ReferenceCoverageStatus,
+  type ReferenceProposalStatus,
+} from "@/lib/ea/ea-validation";
+import {
+  deriveStructuredWarnings,
+  insertStructuredChild,
+  resequenceStructuredChildren,
+  sortStructuredMutationRecords,
+  type StructuredMutationRecord,
+} from "@/lib/ea/ea-core";
 
 // ─── Auth helper ──────────────────────────────────────────────────────────────
 
@@ -47,21 +44,6 @@ async function requireManageEaModel(): Promise<{ userId: string | null }> {
     throw new Error("Unauthorized");
   }
   return { userId: user.id ?? null };
-}
-
-type ReferenceCoverageStatus = (typeof REFERENCE_COVERAGE_STATUSES)[number];
-type ReferenceProposalStatus = (typeof REFERENCE_PROPOSAL_STATUSES)[number];
-
-function assertCoverageStatus(value: string): asserts value is ReferenceCoverageStatus {
-  if (!REFERENCE_COVERAGE_STATUSES.includes(value as ReferenceCoverageStatus)) {
-    throw new Error("Invalid coverage status");
-  }
-}
-
-function assertProposalStatus(value: string): asserts value is ReferenceProposalStatus {
-  if (!REFERENCE_PROPOSAL_STATUSES.includes(value as ReferenceProposalStatus)) {
-    throw new Error("Invalid proposal status");
-  }
 }
 
 // ─── Element actions ──────────────────────────────────────────────────────────
@@ -651,125 +633,6 @@ export async function addElementToView(input: {
     if (prismaErr.code === "P2002") return { error: "ElementAlreadyOnView" };
     throw err;
   }
-}
-
-type StructuredMutationRecord = {
-  id: string;
-  elementId: string;
-  parentViewElementId: string | null;
-  orderIndex: number | null;
-};
-
-type StructuredConformanceWarning = {
-  issueType: "missing_required_children" | "detached_child" | "duplicate_order_index";
-  severity: "warn" | "error";
-  message: string;
-  viewElementIds: string[];
-  details?: Record<string, unknown>;
-};
-
-function sortStructuredMutationRecords(records: StructuredMutationRecord[]): StructuredMutationRecord[] {
-  return [...records].sort((left, right) => {
-    const leftOrder = left.orderIndex ?? Number.MAX_SAFE_INTEGER;
-    const rightOrder = right.orderIndex ?? Number.MAX_SAFE_INTEGER;
-    if (leftOrder !== rightOrder) return leftOrder - rightOrder;
-    return left.id.localeCompare(right.id);
-  });
-}
-
-function resequenceStructuredChildren(
-  records: StructuredMutationRecord[],
-  parentViewElementId: string,
-): StructuredMutationRecord[] {
-  return sortStructuredMutationRecords(records).map((record, index) => ({
-    ...record,
-    parentViewElementId,
-    orderIndex: index,
-  }));
-}
-
-function insertStructuredChild(
-  records: StructuredMutationRecord[],
-  movingRecord: StructuredMutationRecord,
-  parentViewElementId: string,
-  targetOrderIndex: number | null,
-): StructuredMutationRecord[] {
-  const ordered = sortStructuredMutationRecords(records.filter((record) => record.id !== movingRecord.id));
-  const insertionIndex = targetOrderIndex == null
-    ? ordered.length
-    : Math.max(0, Math.min(targetOrderIndex, ordered.length));
-
-  ordered.splice(insertionIndex, 0, {
-    ...movingRecord,
-    parentViewElementId,
-  });
-
-  return ordered.map((record, index) => ({
-    ...record,
-    parentViewElementId,
-    orderIndex: index,
-  }));
-}
-
-function deriveStructuredWarnings(input: {
-  parentViewElementId: string;
-  minChildren: number;
-  children: StructuredMutationRecord[];
-}): StructuredConformanceWarning[] {
-  const warnings: StructuredConformanceWarning[] = [];
-  const attachedChildren = input.children.filter(
-    (child) => child.parentViewElementId === input.parentViewElementId,
-  );
-  const detachedChildren = input.children.filter(
-    (child) => child.parentViewElementId !== input.parentViewElementId,
-  );
-
-  if (attachedChildren.length < input.minChildren) {
-    warnings.push({
-      issueType: "missing_required_children",
-      severity: "warn",
-      message: `Expected at least ${input.minChildren} structured child elements`,
-      viewElementIds: [input.parentViewElementId],
-      details: {
-        minChildren: input.minChildren,
-        attachedChildCount: attachedChildren.length,
-      },
-    });
-  }
-
-  for (const child of detachedChildren) {
-    warnings.push({
-      issueType: "detached_child",
-      severity: "warn",
-      message: "Structured child is detached from its expected parent",
-      viewElementIds: [child.id],
-      details: {
-        expectedParentViewElementId: input.parentViewElementId,
-        actualParentViewElementId: child.parentViewElementId,
-      },
-    });
-  }
-
-  const siblingsByOrderIndex = new Map<number, string[]>();
-  for (const child of attachedChildren) {
-    if (child.orderIndex == null) continue;
-    const siblings = siblingsByOrderIndex.get(child.orderIndex) ?? [];
-    siblings.push(child.id);
-    siblingsByOrderIndex.set(child.orderIndex, siblings);
-  }
-
-  for (const [orderIndex, siblings] of siblingsByOrderIndex) {
-    if (siblings.length < 2) continue;
-    warnings.push({
-      issueType: "duplicate_order_index",
-      severity: "warn",
-      message: `Multiple structured children share order index ${orderIndex}`,
-      viewElementIds: siblings,
-      details: { orderIndex },
-    });
-  }
-
-  return warnings;
 }
 
 export async function moveStructuredViewElement(input: {

--- a/apps/web/lib/ea/ea-core.test.ts
+++ b/apps/web/lib/ea/ea-core.test.ts
@@ -1,0 +1,156 @@
+// apps/web/lib/ea/ea-core.test.ts
+//
+// Unit tests for the pure structured-view mutation helpers extracted from
+// lib/actions/ea.ts (BI-OPT-FAT-ACTIONS, EA slice). These functions are now
+// side-effect-free (no prisma / auth), so they are exercised directly here.
+import { describe, it, expect } from "vitest";
+import {
+  sortStructuredMutationRecords,
+  resequenceStructuredChildren,
+  insertStructuredChild,
+  deriveStructuredWarnings,
+  type StructuredMutationRecord,
+} from "./ea-core";
+
+function rec(
+  id: string,
+  parentViewElementId: string | null,
+  orderIndex: number | null,
+): StructuredMutationRecord {
+  return { id, elementId: `${id}-el`, parentViewElementId, orderIndex };
+}
+
+describe("sortStructuredMutationRecords", () => {
+  it("orders by ascending orderIndex", () => {
+    const sorted = sortStructuredMutationRecords([
+      rec("b", "p", 2),
+      rec("a", "p", 0),
+      rec("c", "p", 1),
+    ]);
+    expect(sorted.map((r) => r.id)).toEqual(["a", "c", "b"]);
+  });
+
+  it("treats null orderIndex as last and breaks ties by id", () => {
+    const sorted = sortStructuredMutationRecords([
+      rec("z", "p", null),
+      rec("m", "p", null),
+      rec("a", "p", 0),
+    ]);
+    expect(sorted.map((r) => r.id)).toEqual(["a", "m", "z"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [rec("b", "p", 1), rec("a", "p", 0)];
+    const snapshot = input.map((r) => r.id);
+    sortStructuredMutationRecords(input);
+    expect(input.map((r) => r.id)).toEqual(snapshot);
+  });
+});
+
+describe("resequenceStructuredChildren", () => {
+  it("reassigns contiguous 0..n order indices and forces the parent", () => {
+    const out = resequenceStructuredChildren(
+      [rec("b", "old", 5), rec("a", "old", 2), rec("c", "old", null)],
+      "new-parent",
+    );
+    expect(out.map((r) => [r.id, r.orderIndex, r.parentViewElementId])).toEqual([
+      ["a", 0, "new-parent"],
+      ["b", 1, "new-parent"],
+      ["c", 2, "new-parent"],
+    ]);
+  });
+});
+
+describe("insertStructuredChild", () => {
+  it("inserts the moving record at the target index and resequences", () => {
+    const out = insertStructuredChild(
+      [rec("a", "p", 0), rec("b", "p", 1), rec("c", "p", 2)],
+      rec("x", "other", null),
+      "p",
+      1,
+    );
+    expect(out.map((r) => r.id)).toEqual(["a", "x", "b", "c"]);
+    expect(out.map((r) => r.orderIndex)).toEqual([0, 1, 2, 3]);
+    expect(out.every((r) => r.parentViewElementId === "p")).toBe(true);
+  });
+
+  it("appends when targetOrderIndex is null", () => {
+    const out = insertStructuredChild(
+      [rec("a", "p", 0), rec("b", "p", 1)],
+      rec("x", "other", null),
+      "p",
+      null,
+    );
+    expect(out.map((r) => r.id)).toEqual(["a", "b", "x"]);
+  });
+
+  it("clamps an out-of-range target index to the end", () => {
+    const out = insertStructuredChild(
+      [rec("a", "p", 0), rec("b", "p", 1)],
+      rec("x", "other", null),
+      "p",
+      99,
+    );
+    expect(out.map((r) => r.id)).toEqual(["a", "b", "x"]);
+  });
+
+  it("drops any prior copy of the moving record before inserting", () => {
+    const out = insertStructuredChild(
+      [rec("a", "p", 0), rec("x", "p", 1), rec("b", "p", 2)],
+      rec("x", "p", 1),
+      "p",
+      0,
+    );
+    expect(out.filter((r) => r.id === "x")).toHaveLength(1);
+    expect(out.map((r) => r.id)).toEqual(["x", "a", "b"]);
+  });
+});
+
+describe("deriveStructuredWarnings", () => {
+  it("flags missing_required_children when attached children are below the minimum", () => {
+    const warnings = deriveStructuredWarnings({
+      parentViewElementId: "stream",
+      minChildren: 2,
+      children: [rec("s1", "stream", 0)],
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.issueType).toBe("missing_required_children");
+    expect(warnings[0]!.viewElementIds).toEqual(["stream"]);
+  });
+
+  it("flags a detached_child pointing at a different parent", () => {
+    const warnings = deriveStructuredWarnings({
+      parentViewElementId: "stream",
+      minChildren: 1,
+      children: [rec("s1", "stream", 0), rec("s2", "other", 0)],
+    });
+    const detached = warnings.find((w) => w.issueType === "detached_child");
+    expect(detached).toBeDefined();
+    expect(detached!.viewElementIds).toEqual(["s2"]);
+    expect(detached!.details).toMatchObject({
+      expectedParentViewElementId: "stream",
+      actualParentViewElementId: "other",
+    });
+  });
+
+  it("flags duplicate_order_index when attached siblings share an index", () => {
+    const warnings = deriveStructuredWarnings({
+      parentViewElementId: "stream",
+      minChildren: 1,
+      children: [rec("s1", "stream", 0), rec("s2", "stream", 0)],
+    });
+    const dup = warnings.find((w) => w.issueType === "duplicate_order_index");
+    expect(dup).toBeDefined();
+    expect(dup!.viewElementIds.sort()).toEqual(["s1", "s2"]);
+    expect(dup!.details).toMatchObject({ orderIndex: 0 });
+  });
+
+  it("returns no warnings for a well-formed parent/children set", () => {
+    const warnings = deriveStructuredWarnings({
+      parentViewElementId: "stream",
+      minChildren: 1,
+      children: [rec("s1", "stream", 0), rec("s2", "stream", 1)],
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/apps/web/lib/ea/ea-core.ts
+++ b/apps/web/lib/ea/ea-core.ts
@@ -1,0 +1,127 @@
+// apps/web/lib/ea/ea-core.ts
+//
+// Pure (no prisma / auth / Next.js) domain helpers for EA structured-view
+// mutations: ordering, resequencing, insertion, and conformance-warning
+// derivation for parent/child structured elements (e.g. value-stream stages).
+// Extracted verbatim from lib/actions/ea.ts (BI-OPT-FAT-ACTIONS, EA slice) so
+// the deterministic domain logic lives in the EA domain layer and is
+// unit-testable on its own. Behavior-preserving relocation — identical bodies.
+
+export type StructuredMutationRecord = {
+  id: string;
+  elementId: string;
+  parentViewElementId: string | null;
+  orderIndex: number | null;
+};
+
+export type StructuredConformanceWarning = {
+  issueType: "missing_required_children" | "detached_child" | "duplicate_order_index";
+  severity: "warn" | "error";
+  message: string;
+  viewElementIds: string[];
+  details?: Record<string, unknown>;
+};
+
+export function sortStructuredMutationRecords(records: StructuredMutationRecord[]): StructuredMutationRecord[] {
+  return [...records].sort((left, right) => {
+    const leftOrder = left.orderIndex ?? Number.MAX_SAFE_INTEGER;
+    const rightOrder = right.orderIndex ?? Number.MAX_SAFE_INTEGER;
+    if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function resequenceStructuredChildren(
+  records: StructuredMutationRecord[],
+  parentViewElementId: string,
+): StructuredMutationRecord[] {
+  return sortStructuredMutationRecords(records).map((record, index) => ({
+    ...record,
+    parentViewElementId,
+    orderIndex: index,
+  }));
+}
+
+export function insertStructuredChild(
+  records: StructuredMutationRecord[],
+  movingRecord: StructuredMutationRecord,
+  parentViewElementId: string,
+  targetOrderIndex: number | null,
+): StructuredMutationRecord[] {
+  const ordered = sortStructuredMutationRecords(records.filter((record) => record.id !== movingRecord.id));
+  const insertionIndex = targetOrderIndex == null
+    ? ordered.length
+    : Math.max(0, Math.min(targetOrderIndex, ordered.length));
+
+  ordered.splice(insertionIndex, 0, {
+    ...movingRecord,
+    parentViewElementId,
+  });
+
+  return ordered.map((record, index) => ({
+    ...record,
+    parentViewElementId,
+    orderIndex: index,
+  }));
+}
+
+export function deriveStructuredWarnings(input: {
+  parentViewElementId: string;
+  minChildren: number;
+  children: StructuredMutationRecord[];
+}): StructuredConformanceWarning[] {
+  const warnings: StructuredConformanceWarning[] = [];
+  const attachedChildren = input.children.filter(
+    (child) => child.parentViewElementId === input.parentViewElementId,
+  );
+  const detachedChildren = input.children.filter(
+    (child) => child.parentViewElementId !== input.parentViewElementId,
+  );
+
+  if (attachedChildren.length < input.minChildren) {
+    warnings.push({
+      issueType: "missing_required_children",
+      severity: "warn",
+      message: `Expected at least ${input.minChildren} structured child elements`,
+      viewElementIds: [input.parentViewElementId],
+      details: {
+        minChildren: input.minChildren,
+        attachedChildCount: attachedChildren.length,
+      },
+    });
+  }
+
+  for (const child of detachedChildren) {
+    warnings.push({
+      issueType: "detached_child",
+      severity: "warn",
+      message: "Structured child is detached from its expected parent",
+      viewElementIds: [child.id],
+      details: {
+        expectedParentViewElementId: input.parentViewElementId,
+        actualParentViewElementId: child.parentViewElementId,
+      },
+    });
+  }
+
+  const siblingsByOrderIndex = new Map<number, string[]>();
+  for (const child of attachedChildren) {
+    if (child.orderIndex == null) continue;
+    const siblings = siblingsByOrderIndex.get(child.orderIndex) ?? [];
+    siblings.push(child.id);
+    siblingsByOrderIndex.set(child.orderIndex, siblings);
+  }
+
+  for (const [orderIndex, siblings] of siblingsByOrderIndex) {
+    if (siblings.length < 2) continue;
+    warnings.push({
+      issueType: "duplicate_order_index",
+      severity: "warn",
+      message: `Multiple structured children share order index ${orderIndex}`,
+      viewElementIds: siblings,
+      details: { orderIndex },
+    });
+  }
+
+  return warnings;
+}

--- a/apps/web/lib/ea/ea-validation.test.ts
+++ b/apps/web/lib/ea/ea-validation.test.ts
@@ -1,0 +1,35 @@
+// apps/web/lib/ea/ea-validation.test.ts
+//
+// Unit tests for the pure reference-status assertion helpers extracted from
+// lib/actions/ea.ts (BI-OPT-FAT-ACTIONS, EA slice).
+import { describe, it, expect } from "vitest";
+import {
+  assertCoverageStatus,
+  assertProposalStatus,
+  REFERENCE_COVERAGE_STATUSES,
+  REFERENCE_PROPOSAL_STATUSES,
+} from "./ea-validation";
+
+describe("assertCoverageStatus", () => {
+  it("accepts every supported coverage status", () => {
+    for (const status of REFERENCE_COVERAGE_STATUSES) {
+      expect(() => assertCoverageStatus(status)).not.toThrow();
+    }
+  });
+
+  it("throws 'Invalid coverage status' for an unsupported value", () => {
+    expect(() => assertCoverageStatus("unknown")).toThrow("Invalid coverage status");
+  });
+});
+
+describe("assertProposalStatus", () => {
+  it("accepts every supported proposal status", () => {
+    for (const status of REFERENCE_PROPOSAL_STATUSES) {
+      expect(() => assertProposalStatus(status)).not.toThrow();
+    }
+  });
+
+  it("throws 'Invalid proposal status' for an unsupported value", () => {
+    expect(() => assertProposalStatus("bogus")).toThrow("Invalid proposal status");
+  });
+});

--- a/apps/web/lib/ea/ea-validation.ts
+++ b/apps/web/lib/ea/ea-validation.ts
@@ -1,0 +1,38 @@
+// apps/web/lib/ea/ea-validation.ts
+//
+// Pure (no prisma / auth / Next.js) validation constants and assertion helpers
+// for EA reference-model coverage/proposal statuses. Extracted verbatim from
+// lib/actions/ea.ts (BI-OPT-FAT-ACTIONS, EA slice) so the enum guards live in
+// the EA domain layer and are unit-testable on their own. Behavior-preserving
+// relocation — identical bodies and error messages.
+
+export const REFERENCE_COVERAGE_STATUSES = [
+  "implemented",
+  "partial",
+  "planned",
+  "not_started",
+  "out_of_mvp",
+] as const;
+
+export const REFERENCE_PROPOSAL_STATUSES = [
+  "proposed",
+  "reviewed",
+  "approved",
+  "rejected",
+  "promoted",
+] as const;
+
+export type ReferenceCoverageStatus = (typeof REFERENCE_COVERAGE_STATUSES)[number];
+export type ReferenceProposalStatus = (typeof REFERENCE_PROPOSAL_STATUSES)[number];
+
+export function assertCoverageStatus(value: string): asserts value is ReferenceCoverageStatus {
+  if (!REFERENCE_COVERAGE_STATUSES.includes(value as ReferenceCoverageStatus)) {
+    throw new Error("Invalid coverage status");
+  }
+}
+
+export function assertProposalStatus(value: string): asserts value is ReferenceProposalStatus {
+  if (!REFERENCE_PROPOSAL_STATUSES.includes(value as ReferenceProposalStatus)) {
+    throw new Error("Invalid proposal status");
+  }
+}


### PR DESCRIPTION
## What

Pure **MOVE** refactor: extract the side-effect-free logic out of the fat `apps/web/lib/actions/ea.ts` action file into two new EA domain modules, mirroring the already-merged Slice-A tax-remittance extraction (`af179f845` → `lib/finance/tax-remittance-core.ts` + `tax-remittance-validation.ts`). This is the **EA slice** of `BI-OPT-FAT-ACTIONS` under `EP-PLATFORM-OPTIMIZATION` ("reduce the bodies behind the consolidated boundaries").

## Extracted helpers

**`apps/web/lib/ea/ea-core.ts`** — pure structured-view mutation logic:
- `sortStructuredMutationRecords`
- `resequenceStructuredChildren`
- `insertStructuredChild`
- `deriveStructuredWarnings`
- types `StructuredMutationRecord`, `StructuredConformanceWarning`

**`apps/web/lib/ea/ea-validation.ts`** — pure reference-status guards:
- constants `REFERENCE_COVERAGE_STATUSES`, `REFERENCE_PROPOSAL_STATUSES`
- types `ReferenceCoverageStatus`, `ReferenceProposalStatus`
- assertions `assertCoverageStatus`, `assertProposalStatus`

The thin orchestration — `auth()` checks, all prisma reads/writes, the `$transaction` blocks, `revalidatePath`, the fire-and-forget Neo4j sync, and the `"use server"` action wrappers — stays in `ea.ts`, which now imports the extracted helpers back.

## Behavior preservation

**Byte-for-byte preserved.** Identical function bodies (verbatim relocation), identical error messages, unchanged call sites, and no change to any server-action external contract. Callers of the `ea.ts` server actions are unaffected.

- `apps/web/lib/actions/ea.ts`: **1,055 → 917 LOC** (module-size ratchet shrinks; baseline was 1055).
- Existing `apps/web/lib/actions/ea.test.ts` is the **behavior pin** — it passes **unchanged** (25 tests, zero edits; the actions delegate to the moved helpers).
- New direct unit tests for the now-pure helpers: `ea-core.test.ts` (12 tests) + `ea-validation.test.ts` (4 tests) = 16 new tests. Full run: **41 passed** across the 3 files.

Typecheck: my new files (`ea-core.ts`, `ea-validation.ts`) produce zero errors. Local full `tsc` in this source-only worktree runs against a junctioned sibling's stale Prisma client, so it surfaces pre-existing environmental errors (e.g. `@dpf/db/graph-sync`, `EaRelationshipWhereUniqueInput`); a differential run confirmed the identical errors appear on the untouched original `ea.ts` — none are introduced by this refactor. CI's fresh-client Typecheck gate is the authority.

## Review note

Large action-file refactor — **not** enabling auto-merge; behavior is preserved but live verification of the EA flows (canvas mutations, lifecycle advance, reference-model assessment/proposal) is deferred to founder post-merge.

Design-Grounding-Decision: BI-OPT-FAT-ACTIONS

Generated with Claude Code
