### PR TITLE
fix(coworker): reliable button-decisions — stronger emit + deterministic prose fallback

### DIFF
--- a/apps/web/lib/tak/coworker-interaction-contract.ts
+++ b/apps/web/lib/tak/coworker-interaction-contract.ts
@@ -15,11 +15,15 @@ Clarify vs proceed — remove cognitive load, don't add it:
 - Act on your own recommendation. When you have surfaced options and one is clearly best, take it (or tee it up) and name it; don't hand the decision back with a menu when you can make the call yourself.
 
 BUTTON DECISIONS
-When the Next action is owned by the human AND it reduces to a small, discrete choice — including the common "shall I proceed?" case — offer it as buttons the human can press, not prose they must reply to by typing. Do this by appending ONE machine-readable decision block on its own final line, in exactly this form (a single-line HTML comment; the human never sees the raw markup — it renders as buttons):
+Whenever your message ends by putting a choice to the human — ANY closeout whose final line is a question offering options, including the common "shall I proceed?" case and any "do X, or Y?" alternative — you MUST append ONE machine-readable decision block so it renders as clickable buttons instead of prose they answer by typing. This is not optional: if you wrote a question with a small set of answers, emit the block. Append it on its own final line, in exactly this form (a single-line HTML comment; the human never sees the raw markup — it renders as buttons):
 <!--dpf-decision:{"prompt":"<the question, omit for a plain proceed>","options":[{"label":"<button text>","recommended":true},{"label":"<other option>"}]}-->
+Examples:
+- "…, or move to the next priority?" → <!--dpf-decision:{"options":[{"label":"Break into work items","recommended":true},{"label":"Move to the next priority"}]}-->
+- "Ready for me to start?" → <!--dpf-decision:{"options":[{"label":"Go","recommended":true}]}-->
 Rules:
 - Lead with your grounded recommendation: mark exactly one option "recommended":true (it renders as the primary button). This complements — never replaces — the Next action line above.
 - The degenerate "shall I proceed / want me to start?" case becomes a SINGLE button: options:[{"label":"Go","recommended":true}]. Prefer this over ending on a bare question.
+- Keep each label short (a few words) even when the underlying option is a long phrase — the button is a summary, not the full sentence.
 - Keep it to at most a handful of concrete, mutually-exclusive options. Each "label" is the button text; add "value" only when the reply text should differ from the label. Optional "kind" is one of approve, reject, request-changes, answer, dismiss, snooze for styling.
 - Free-text always remains available to the human, so never force a genuinely open-ended question into buttons — omit the block when there is no small discrete option set.
 - Do NOT emit a decision block when a goal, autopilot directive, or prior instruction already authorized you to proceed without asking — in that case just proceed.

--- a/apps/web/lib/tak/decision-block.test.ts
+++ b/apps/web/lib/tak/decision-block.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseDecisionFromContent,
   normalizeDecision,
+  deriveDecisionFromProse,
   formatDecisionSentinel,
   MAX_DECISION_OPTIONS,
   type CoworkerDecision,
@@ -123,5 +124,71 @@ describe("normalizeDecision", () => {
   it("honors freeTextAllowed=false", () => {
     const decision = normalizeDecision({ options: [{ label: "Only this" }], freeTextAllowed: false })!;
     expect(decision.freeTextAllowed).toBe(false);
+  });
+});
+
+describe("deriveDecisionFromProse (fallback when the model emits no sentinel)", () => {
+  it("recovers a two-way choice from the exact live-miss closeout", () => {
+    // Observed live: Haiku ended on this with no sentinel and no button rendered.
+    const content =
+      "Done. The plan is recorded.\n\n**Next action:** Triage the plan into child items, or promote to Build Studio.\n\nWhat's your call — break this into phase-based work items, or move to the next priority?";
+    const decision = deriveDecisionFromProse(content)!;
+    expect(decision).not.toBeNull();
+    expect(decision.options.map((o) => o.value)).toEqual([
+      "Break this into phase-based work items",
+      "Move to the next priority",
+    ]);
+    expect(decision.options[0]!.recommended).toBe(true);
+    expect(decision.options[1]!.recommended).toBeUndefined();
+    expect(decision.freeTextAllowed).toBe(true);
+  });
+
+  it("does NOT fire on a noun disjunction (no comma before 'or')", () => {
+    // "reliability or incidents" is a list, not a choice — a wrong button here
+    // would be worse than none.
+    const content =
+      "Here is the situation.\n\nWant me to pull the backlog items tagged for reliability or incidents?";
+    expect(deriveDecisionFromProse(content)).toBeNull();
+  });
+
+  it("does NOT fire when the message does not end in a question", () => {
+    expect(deriveDecisionFromProse("I can break this into work items, or move on. Let me know.")).toBeNull();
+  });
+
+  it("does NOT fire on a plain statement", () => {
+    expect(deriveDecisionFromProse("The plan is attached and ready for review.")).toBeNull();
+  });
+
+  it("strips a 'would you like me to' lead-in and keeps clean option clauses", () => {
+    const content =
+      "Would you like me to check the progress on the two active builds, or list the in-flight coordination tasks?";
+    const decision = deriveDecisionFromProse(content)!;
+    expect(decision.options.map((o) => o.value)).toEqual([
+      "Check the progress on the two active builds",
+      "List the in-flight coordination tasks",
+    ]);
+  });
+
+  it("truncates a long label but keeps the full value for the reply", () => {
+    const content =
+      "What next — draft a very detailed multi-phase implementation plan covering every rollout step, or defer it?";
+    const decision = deriveDecisionFromProse(content)!;
+    expect(decision.options[0]!.label.length).toBeLessThanOrEqual(56);
+    expect(decision.options[0]!.value.length).toBeGreaterThan(decision.options[0]!.label.length);
+  });
+
+  it("parseDecisionFromContent uses the prose fallback when no sentinel is present", () => {
+    const content = "Plan done.\n\nWhat's your call — ship it now, or hold for review?";
+    const { cleanedContent, decision } = parseDecisionFromContent(content);
+    expect(cleanedContent).toBe(content); // prose is NOT stripped
+    expect(decision!.options.map((o) => o.value)).toEqual(["Ship it now", "Hold for review"]);
+  });
+
+  it("an explicit sentinel still wins over the prose fallback", () => {
+    const content =
+      'Ready.\n<!--dpf-decision:{"options":[{"label":"Go","recommended":true}]}-->\nProceed with A, or B?';
+    const { decision } = parseDecisionFromContent(content);
+    expect(decision!.options).toHaveLength(1);
+    expect(decision!.options[0]!.label).toBe("Go");
   });
 });

--- a/apps/web/lib/tak/decision-block.ts
+++ b/apps/web/lib/tak/decision-block.ts
@@ -150,23 +150,26 @@ export function parseDecisionFromContent(content: string): {
   cleanedContent: string;
   decision: CoworkerDecision | null;
 } {
-  if (!content || !content.includes("dpf-decision")) {
-    return { cleanedContent: content, decision: null };
+  if (!content) return { cleanedContent: content, decision: null };
+
+  // 1. Prefer an explicit sentinel when present.
+  if (content.includes("dpf-decision")) {
+    const match = content.match(DECISION_SENTINEL_RE);
+    if (match) {
+      const cleanedContent = content.replace(DECISION_SENTINEL_RE, "").trim();
+      let decision: CoworkerDecision | null = null;
+      try {
+        decision = normalizeDecision(JSON.parse(match[1]!));
+      } catch {
+        decision = null; // malformed JSON → strip sentinel, then try prose below
+      }
+      // A malformed sentinel is still stripped; fall back to prose on the cleaned text.
+      return { cleanedContent, decision: decision ?? deriveDecisionFromProse(cleanedContent) };
+    }
   }
 
-  const match = content.match(DECISION_SENTINEL_RE);
-  if (!match) return { cleanedContent: content, decision: null };
-
-  const cleanedContent = content.replace(DECISION_SENTINEL_RE, "").trim();
-
-  let decision: CoworkerDecision | null = null;
-  try {
-    decision = normalizeDecision(JSON.parse(match[1]!));
-  } catch {
-    decision = null; // malformed JSON → strip sentinel, degrade to prose
-  }
-
-  return { cleanedContent, decision };
+  // 2. No sentinel — recover buttons from a clear prose choice (content unchanged).
+  return { cleanedContent: content, decision: deriveDecisionFromProse(content) };
 }
 
 /**
@@ -176,4 +179,93 @@ export function parseDecisionFromContent(content: string): {
  */
 export function formatDecisionSentinel(decision: CoworkerDecision): string {
   return `<!--dpf-decision:${JSON.stringify(decision)}-->`;
+}
+
+// --- Prose fallback ---------------------------------------------------------
+// The coworker is *instructed* to emit a sentinel, but a smaller model does not
+// always comply — it sometimes ends on a plain "…A, or B?" question with no
+// sentinel (observed live: Haiku 4.5 skipped it on a follow-up turn). This
+// deterministic fallback recovers buttons for the highest-confidence case: a
+// final question that ENUMERATES alternatives with a "comma-or" (", or ").
+//
+// The comma-or guard is deliberate. It fires on a real choice
+// ("break this into work items, or move to the next priority?") but NOT on a
+// noun disjunction ("tagged for reliability or incidents?", which has no comma)
+// — a wrong button is worse than no button, so we only act on the strong signal.
+
+// Lead-in phrases that precede the actual options in a choice question.
+const PROSE_LEADIN_RE =
+  /^(?:what(?:'s| is) your call|what would you like(?: me to do)?|which would you prefer|would you like me to|do you want me to|want me to|should i|shall i|shall we|should we|do you want to|do you want)\b[\s,:—–-]*/i;
+
+const PROSE_OPTION_PREFIX_RE = /^(?:perhaps|maybe|instead|else|or|either)\s+/i;
+
+const PROSE_LABEL_MAX = 56;
+
+/** Isolate the final sentence when the trimmed content ends with a question. */
+function finalQuestion(content: string): string | null {
+  const trimmed = content.trim();
+  if (!/\?\s*$/.test(trimmed)) return null;
+  const body = trimmed.replace(/\?+\s*$/, "");
+  // Start of the last sentence = after the last sentence terminator / newline.
+  let start = 0;
+  for (const m of body.matchAll(/[.!?\n]+\s+/g)) {
+    start = m.index! + m[0].length;
+  }
+  return body.slice(start).trim() || null;
+}
+
+/**
+ * Derive a decision from a coworker's plain-prose closeout when no sentinel was
+ * emitted. Conservative by construction — returns null unless the final question
+ * clearly enumerates 2–3 alternatives via a comma-or, each a clean clause.
+ */
+export function deriveDecisionFromProse(content: string): CoworkerDecision | null {
+  if (!content || !/,\s+or\s+/i.test(content)) return null;
+
+  const question = finalQuestion(content);
+  // Require the comma-or to live inside the FINAL question, not earlier prose.
+  if (!question || !/,\s+or\s+/i.test(question)) return null;
+
+  // Drop a leading lead-in clause: an explicit verb phrase, or a short prefix
+  // terminated by an em/en dash or colon (e.g. "What's your call — ").
+  let body = question.replace(PROSE_LEADIN_RE, "");
+  body = body.replace(/^[^—–:]{0,44}[—–:]\s*/, (m) => (/,\s+or\s+/i.test(m) ? m : ""));
+  body = body.replace(PROSE_LEADIN_RE, "").trim();
+
+  const rawParts = body.split(/,\s+or\s+/i);
+  if (rawParts.length < 2 || rawParts.length > 3) return null;
+
+  const options: CoworkerDecisionOption[] = [];
+  rawParts.forEach((part, index) => {
+    const clause = part
+      .replace(PROSE_OPTION_PREFIX_RE, "")
+      .replace(/\s+/g, " ")
+      .replace(/[.,;:\s]+$/, "")
+      .trim();
+    // Guardrails: each option must be a clean, sentence-free clause with letters.
+    if (clause.length < 4 || clause.length > 90) return;
+    if (!/[a-z]/i.test(clause)) return;
+    if (/[.!?]/.test(clause)) return; // a period/bang means we split across sentences
+    const value = clause.charAt(0).toUpperCase() + clause.slice(1);
+    const label =
+      value.length > PROSE_LABEL_MAX ? `${value.slice(0, PROSE_LABEL_MAX - 1).trimEnd()}…` : value;
+    const option: CoworkerDecisionOption = {
+      id: slugify(clause, index),
+      label,
+      value,
+      kind: "answer",
+    };
+    if (index === 0) option.recommended = true;
+    options.push(option);
+  });
+
+  // All parts must have survived the guards, and labels must be distinct.
+  if (options.length !== rawParts.length) return null;
+  const labels = new Set(options.map((o) => o.label.toLowerCase()));
+  if (labels.size !== options.length) return null;
+
+  const decision: CoworkerDecision = { options, freeTextAllowed: true };
+  const prompt = question.replace(/\s+/g, " ").trim();
+  if (prompt) decision.prompt = prompt;
+  return decision;
 }

--- a/docs/superpowers/plans/2026-07-16-coworker-button-decision-p1.md
+++ b/docs/superpowers/plans/2026-07-16-coworker-button-decision-p1.md
@@ -34,6 +34,13 @@ The sentinel rides inside `AgentMessage.content` (already persisted + refetched)
 - Source of truth: EP-COWORKER-INTERACTIVITY (cross-page HITL handoff). Carrier + rendering follow the existing proposal-button and managed-doc-chip patterns rather than inventing new substrate.
 - Decision: P1 = migration-free content-embedded decision sentinel parsed at render; reuse `AttentionActionKind`; defer the typed `AgentMessage.decision` column, proposal convergence, and cross-page inbox buttons to P2/P3 (BI-450D5833).
 
+## P1.5 — emit reliability (2026-07-16)
+
+Live drive surfaced the expected weakness: the sentinel emit is model-dependent. Haiku 4.5 emitted it on one turn and skipped it on a follow-up whose closeout was still a clear choice ("…break this into phase-based work items, or move to the next priority?"). DB confirmed `strpos(content,'dpf-decision')=0` — no sentinel, not a parser miss. Two-pronged fix:
+
+1. **Stronger instruction** (`coworker-interaction-contract.ts`): the BUTTON DECISIONS clause is now a MUST with worked examples, and a "keep labels short" rule.
+2. **Deterministic prose fallback** (`decision-block.ts` `deriveDecisionFromProse`, wired into `parseDecisionFromContent`): when no sentinel is present but the final question enumerates alternatives with a **comma-or** (", or "), derive the buttons. The comma-or guard is the safety: it fires on a real choice but NOT on a noun disjunction ("reliability or incidents?", no comma) — a wrong button is worse than none. Content is never mutated; guards require 2–3 clean, sentence-free, letter-bearing clauses with distinct labels, else it returns null. Long labels truncate; the full clause is still submitted as the reply.
+
 ## Follow-ups (tracked, not silent debt)
 
 - **P2:** promote the carrier to a typed `AgentMessage.decision Json?` column (removes content-embedded sentinel + semantic-memory noise); converge `AgentActionProposal` approve/reject onto the decision carrier.


### PR DESCRIPTION
## What

Follow-up to PR #3109. Live drive showed the button-decision **emit is model-dependent**: Haiku 4.5 emitted the sentinel on one turn and skipped it on a follow-up whose closeout was still a clear choice — *"…break this into phase-based work items, or move to the next priority?"* — so no buttons rendered. DB confirmed `strpos(content,'dpf-decision')=0` (no sentinel stored), i.e. an instruction-adherence gap, not a parser miss.

## Fix (two-pronged)

1. **Stronger instruction** — the BUTTON DECISIONS clause in `coworker-interaction-contract.ts` is now a MUST with worked examples and a keep-labels-short rule, so the model emits far more consistently.
2. **Deterministic prose fallback** — `deriveDecisionFromProse` (wired into `parseDecisionFromContent`) recovers buttons when no sentinel is present but the final question enumerates alternatives with a **comma-or** (`, or `). The comma-or guard is the safety: it fires on a real choice ("…work items, **or** move on?") but **not** on a noun disjunction ("reliability or incidents?", no comma) — a wrong button is worse than none. Content is never mutated; guards require 2–3 clean, sentence-free, letter-bearing clauses with distinct labels or it returns null. Long labels truncate; the full clause is still submitted as the reply.

## Verification

- 10 assertions against the real esbuild-transpiled source — all pass, including the false-positive guard (noun-list does not fire) and "explicit sentinel still wins".
- New vitest cases cover the exact live-miss closeout plus negatives (noun-list, non-question, plain statement).
- esbuild transform-clean; module-size + style-drift guards green locally.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-07-16-coworker-button-decision-interface.md`, `docs/superpowers/plans/2026-07-16-coworker-button-decision-p1.md` (P1.5 section added here).
- Current code substrate reviewed: `apps/web/lib/tak/decision-block.ts` (the P1 parser — extended, not replaced), `apps/web/lib/tak/coworker-interaction-contract.ts` (emit seam). No new module; the fallback lives behind the same `parseDecisionFromContent` seam the renderer already calls.
- Source of truth: EP-COWORKER-INTERACTIVITY / BI-3237B5D6.
- Decision: keep the P1 content-embedded carrier; add a conservative deterministic fallback rather than a second LLM pass (deferred to the P2 typed-column work, BI-450D5833).

Continues **BI-3237B5D6** / EP-COWORKER-INTERACTIVITY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)