### PR TITLE
feat(discovery): CatalogIdentity + support-lifecycle spine (BI-74579817, EP-ASSET-INTELLIGENCE)

### DIFF
--- a/docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md
+++ b/docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md
@@ -1,0 +1,188 @@
+# Software & Asset Intelligence — Discovery Enrichment, Normalization Catalog & Support-Lifecycle Feeds
+
+**Date:** 2026-07-16
+**Status:** Draft (backlog + spec only — no code this cycle, per CEO decision 2026-07-16)
+**Epic:** EP-ASSET-INTELLIGENCE
+**Supersedes / consolidates:** `2026-04-18-lifecycle-evidence-specialist-design.md` and the enrichment intent in `2026-04-30-discovery-portfolio-gap-closure-design.md` (both Draft, never implemented)
+**Grounded in:** live `packages/db/prisma/schema.prisma` verification (2026-07-16) + external reference research (Technopedia/Flexera, ServiceNow SAM/HAM, open feeds)
+
+---
+
+## 1. Why this exists
+
+Discovery finds an asset; **enrichment investigates it and fills in the detail** — normalized vendor, product, version/edition, support lifecycle (release / end-of-support / end-of-life), vulnerabilities, and a human-readable description. This is the same "normalize discovered data against a reference catalog + lifecycle feed" pattern that **BDNA/Technopedia (Flexera)** and **ServiceNow SAM/HAM Content Service** are built on.
+
+DPF **designed** this (the two superseded specs above) but **never built it.** Verified absent from the live schema/code on 2026-07-16:
+
+- No canonical models: `CatalogIdentity`, `CatalogLifecycleMilestone`, `FingerprintRule`, `IdentityResolutionLog`.
+- No enrichment fields on `InventoryEntity` / `DigitalProduct` (`catalogIdentityId`, `updatePosture`, `latestKnownVersion`, `supportLifecycleSource/Confidence`, `identityStatus/Confidence`, `enrichmentStatus`, `lastEnrichedAt`). `supportStatus` is a bare string defaulting to `"unknown"` (spec snapshot: 120/120 items `unknown_support`, 114 missing manufacturer/version).
+- No enrichment engine: no `apps/web/lib/queue/functions/enrich-digital-product.ts`, no `enrich_digital_product` / `request_re_enrichment` MCP tools.
+- `DiscoveredSoftwareEvidence.softwareIdentityId` (`schema.prisma:3638`) is a **dangling FK** to a table dropped in migration `20260320222431`.
+- The **estate-specialist** agent (`AGT-WS-INVENTORY`) that is supposed to own enrichment exists only as a prompt (`prompts/route-persona/estate-specialist.prompt.md`) — the tools it references don't exist.
+
+**What does exist:** discovery/inventory (`InventoryEntity`, cross-platform collectors), a **read-only** patch-posture wedge (`/ops/patches`, `apps/web/lib/patch/*`) fed by **OSV + CISA KEV** (language ecosystems only, findings-only), the `AssuranceFinding` ledger, and the gated `RemoteAction` execution primitive.
+
+So DPF has a **vulnerability feed but no software normalization catalog, no EOL/EOS lifecycle feed, no SAM/license, no reclamation, and no hardware lifecycle/financials** — precisely the BDNA/Flexera/ServiceNow-SAM/HAM gaps.
+
+The vestigial `data-enrichment` / `document-parser` / `advanced-code-analysis` `ModelProvider` service rows in `packages/db/data/providers-registry.json` are leftovers of the superseded EP-MCP-SURFACE-001 design; they gesture at this capability but have no engine behind them. They are retired by this epic (BI-3EE51676).
+
+---
+
+## 2. Positioning — compose open feeds, don't clone Flexera
+
+The reference products' moat is **proprietary catalog data** at a scale DPF will not license: Technopedia claims 5M+ products / 4,500+ daily updates ([Flexera Technopedia](https://www.flexera.com/products/technopedia)); ServiceNow's SAM content service tracks ~680,000 lifecycle entries across 2,558 publishers / 21,000 products, synced weekly ([ServiceNow: Software Product Lifecycles](https://www.servicenow.com/community/sam-blog/navigating-software-product-lifecycles-a-key-to-effective/ba-p/3030314)).
+
+DPF's deliberate choice (echoing the patch-management spec's "compose standards + build governance") is to **assemble open feeds behind a CPE-keyed normalization spine, and build the governance/evidence/agent layer natively.** The research confirms the open feeds fully cover four of the pillars and leave exactly two proprietary "build-or-curate" moats:
+
+| Pillar | Open-feed coverage | Verdict |
+|--------|--------------------|---------|
+| Software/vuln **identity** | **CPE 2.3** (NVD dictionary ~1.77M names) + SWID tags + Wikidata backfill | Coverable |
+| **Support lifecycle** (release/EOL/EOS/EOES) | **endoflife.date v1** (MIT, ~461 products) + manual overlay for long-tail | Coverable (mainstream), overlay for tail |
+| **Vulnerability** intel | **NVD CVE** (installed/commercial via CPE) + **OSV** (OSS ecosystems) + **CISA KEV** (exploited priority) | Coverable |
+| Firmware/HW **model hints** | **LVFS/fwupd** + endoflife.date hardware + Wikidata | Partial backfill |
+| **License entitlement / rights** (SAM) | *No open substitute* — Flexera 900k-app PURL library, SN Publisher Packs | **Build-or-curate** |
+| **Reclamation / HAM financials / SaaS** | *No open catalog* | **Native build** |
+
+---
+
+## 3. Capability pillars & target (from reference research)
+
+Canonical checklist a native platform must match to credibly claim "asset + software management with support-lifecycle feeds":
+
+(a) discovery/inventory · (b) software normalization catalog/identity · (c) support-lifecycle data (release/EOL/EOS) · (d) vulnerability intel · (e) patch/remediation · (f) license entitlement & compliance (SAM) · (g) reclamation/usage metering · (h) hardware lifecycle & financials (HAM) · (i) SaaS management · (j) CMDB/CSDM model.
+
+DPF today: (a) built, (d) partial (OSS-only), (e) read-only wedge, (j) strong CSDM-aligned ontology. **Missing: (b), (c), (f), (g), (h), (i).**
+
+---
+
+## 4. Design
+
+### 4.1 The normalization spine — `CatalogIdentity`
+
+The canonical, deterministic **manufacturer → product → version → edition (→ patch level)** identity — the open analog of the Technopedia hierarchy ([Flexera: power of normalization](https://www.flexera.com/blog/it-visibility/the-power-of-normalization-a-key-to-unlocking-it-efficiency/)). Machine key: **CPE 2.3** (`cpe:2.3:<part>:<vendor>:<product>:<version>:<update>:<edition>:…`, part ∈ {a,o,h}) ([NVD CPE Dictionary](https://nvd.nist.gov/products/cpe)). Raw vendor strings (`DiscoveredSoftwareEvidence.rawVendor`) **never** leak directly onto the canonical identity — only the fingerprint/normalize pipeline sets `CatalogIdentity.manufacturer`, via rules (2026-04-18 §7.2 mapping note).
+
+Companion models (2026-04-18 §7.2):
+- **`CatalogLifecycleMilestone`** — child of `CatalogIdentity`; one row per named milestone (`mainstream_end`, `extended_support_end`, `eol`, `eosl`, `security_updates_end`), each with `date`, `source`, `confidence`. Lifecycle is structured, not a flat string.
+- **`FingerprintRule`** — deterministic raw-evidence → `CatalogIdentity` matcher; `status` (`shadow|active|rejected`), `origin` (`seeded|human|auto_promoted`).
+- **`IdentityResolutionLog`** — resolution lineage/audit; `resolutionType` (`rule|ai_resolved|human_confirmed|human_corrected`), confidence, evidence packet. Human-confirmed rows are never overwritten by a rule (2026-04-18 §6.3.1).
+
+### 4.2 The enrichment pipeline (the engine that was never built)
+
+A **decoupled, continuous** stage (not one-shot), triggered on promotion + weekly cadence + manual request. Stages (2026-04-18 §6.3): **Scan → Fingerprint → Normalize → Infer → Proceduralize → Detect-drift → Human-fallback.** Deterministic rules first; a **cheap-model** fallback (via `apps/web/lib/ai-inference.ts`, **no vendor pinning**) resolves the ambiguous tail; repeated AI successes are promoted to **shadow** `FingerprintRule`s and auto-applied only at confidence ≥ 0.97. Owned by the estate-specialist agent, exposed via `enrich_digital_product` + `request_re_enrichment` MCP tools. **Cost guardrail required**: batching + budget cap for per-entity inference at 10k+ estate scale (gap-closure §11 Q2 open question).
+
+Writes results onto `InventoryEntity` / `DigitalProduct` (§4.3), with lineage in `IdentityResolutionLog`.
+
+### 4.3 Existing-model updates
+
+`InventoryEntity` gains: `catalogIdentityId` (FK), `identityStatus`/`identityConfidence`, `updatePosture` (`unknown|current|behind|ahead`) + source + confidence, `latestKnownVersion`, `supportLifecycleSource`/`supportLifecycleConfidence`. `DigitalProduct` gains: `enrichmentStatus` (`pending|enriched|partial|failed`), `lastEnrichedAt`. The dangling `softwareIdentityId` is resolved **in the same migration that lands `CatalogIdentity`** (rename→`legacySoftwareIdentityId` + join, or drop-with-evidence) — post-state invariant: no discovery/inventory field points at a non-existent table (2026-04-18 §7.4).
+
+### 4.4 Open feeds (Phase B)
+
+- **endoflife.date v1** → `CatalogLifecycleMilestone`. `GET /api/v1/products/{name}/` returns `releases[]` with `releaseDate`, `isEol/eolFrom`, `isEoas/eoasFrom` (active support), `isEoes/eoesFrom` (extended support). Each product's `identifiers[]` carries **CPE**, the join back to `CatalogIdentity`. MIT-licensed, community-maintained (no SLA), ~461 products → maintain a manual overlay table for commercial long-tail. ([endoflife.date API](https://endoflife.date/docs/api))
+- **NVD CPE + CVE** → CPE crosswalk on `CatalogIdentity`; unlocks CVEs for **installed/commercial** products (today's OSV coverage is OSS-only). NVD API `services.nvd.nist.gov/rest/json/cpes/2.0`; free API key → 50 req/30s. ([NVD Product APIs](https://nvd.nist.gov/developers/products))
+- **OSV** (OSS ecosystems) + **CISA KEV** (exploited-in-wild priority overlay) — already integrated; retained.
+- **LVFS/fwupd**, **Wikidata**, endoflife.date hardware — model/EOL backfill hints for HAM (Phase D).
+
+### 4.5 UI surfaces
+
+Support-lifecycle signal (`supportStatus`, `updatePosture`, `latestKnownVersion`, `supportEndsAt`) rendered on `/ops/patches` tiles and on the estate + `DigitalProduct` detail pages. EOL/patch findings write into the existing `AssuranceFinding` ledger (`findingKind`: `unsupported-component` = EOL, `missing-patch`) — **no parallel finding table** (respect the EP-ASSURANCE-LEDGER one-substrate rule).
+
+### 4.6 Coworker & skills — extend, don't add a role
+
+No new AI coworker role is required. The **Digital Product Estate Specialist** (`AGT-WS-INVENTORY`, `estate-specialist` / `inventory-specialist` prompts) already owns the daily Discovery Taxonomy Gap Triage, support posture, and dependency mapping — enrichment is a direct extension of its existing remit. What it needs added:
+
+- **Tool grants** on `packages/db/data/agent_registry.json`: `enrich_digital_product`, `request_re_enrichment`, and `contribute_to_hive` (today it has only `portfolio_read`, `registry_read/write`, `backlog_read/write`, `agent_control_read`).
+- **New coworker skills** (2026-04-18 §9.3): `improve-fingerprint-rule` (propose/refine a `FingerprintRule` from a resolution-log entry) and `show-identity-resolution` (show the full `IdentityResolutionLog` lineage for an item). These are named coworker skills, not a new persona.
+- **Reuse the existing sharing agent/loop:** the hive-scout agent + `contribute_to_hive` + `run_hive_scout_ingest` + the built device-fingerprint contribution path (`packages/db/src/device-fingerprint-contribution.ts` — `buildFingerprintContribution`/`decideInboundActivation`) already carry the outbound/inbound "hive-mind" loop. Enrichment plugs into it rather than inventing a second one.
+
+### 4.7 Cross-customer sharing — public vs proprietary (reuse the egress boundary)
+
+The mechanism the CEO is asking about **already exists** and must be reused, not re-invented: the **public-egress boundary** (`2026-06-19-hive-contribution-architecture-and-egress-model.md`, epic EP-1A78BAE1) built on the same kernel/org-overlay pattern DPF uses for knowledge (`WikiPage` kernel vs org overlay; `principlePublic`; `contributionStatus local→contributed`).
+
+Applied to enrichment:
+
+- **Public / commodity technology** — Windows, PostgreSQL, a Dell PowerEdge model, a common OSS library. Its `FingerprintRule`, CPE mapping, and `CatalogLifecycleMilestone` rows are **generic, redacted, and broadly reusable** → eligible to contribute to the shared hive catalog so every opt-in install recognizes it deterministically instead of re-resolving it. **Hardware fingerprint contribution is already built** (`device-fingerprint-contribution.ts`) — consistent with the CEO's point that hardware is nearly all commodity and safely shareable.
+- **Proprietary / local-only technology** — a company's bespoke internal app. Classified `proprietary`/`local-only`, **fail-closed `private` by default**, **never egresses**, and requires human approval even to mark shareable (fingerprint spec §10 routes "the identity is proprietary or local-only" and any raw evidence with private strings/hostnames/customer names straight to human review, and blocks contribution when `redactionStatus = blocked_sensitive`). Software has materially more proprietary cases than hardware — exactly the CEO's distinction.
+- **The determinant is identity classification, not the tool.** Egress applies only at *public-hive* boundary; a customer's own repo/install (`dpf/install`) is the unfiltered proprietary home. Redaction (§12 of the fingerprint spec) strips private literals before any contribution candidate is drafted; the daily coworker triage proposes `auto-accept` / `human-review` / `local-only` / `reject` / `gather-more-evidence` per observation.
+
+Net: public-tech catalog + lifecycle knowledge flows to the commons (opt-in); proprietary tech stays sovereign. Zero new infra — git + Postgres + in-process, mirroring the knowledge-segregation substrate.
+
+### 4.8 SBOMs as an enrichment source (many products in one package)
+
+An SBOM enumerates the many software components inside one package — a rich enrichment input. The substrate exists: `cyclonedx-generator.ts` → `BomDocument` → `BomComponent` (`name`, `version`, `packageUrl`/PURL, `supplierName`, `licenseExpression`, `componentType`) → `BomComponentOccurrence` (`schema.prisma:4990+`), under EP-ASSURANCE-LEDGER; a `sbom` portfolio projector is designed in `2026-06-21-portfolio-coverage-multisource-projection-design.md` but the components are **not yet normalized into the identity/lifecycle spine**.
+
+Bridge: each `BomComponent` PURL/CPE → resolve to a `CatalogIdentity` → attach `CatalogLifecycleMilestone` (EOL/EOS) + CVEs (via the CPE crosswalk). One SBOM ingest thus enriches dozens/hundreds of identities at once.
+
+**Sharing split maps cleanly onto §4.7:**
+- **`BomComponent`** (the generic component identity — usually public OSS: a log4j version, an openssl version) → **public/shareable** catalog knowledge.
+- **`BomComponentOccurrence`** (the fact that *this proprietary product v3* contains *those specific components/versions*) → **proprietary composition** (IP + attack-surface); stays **private** (org-overlay), never contributed even when each component's generic entry is public.
+
+This is the kernel/org-overlay pattern again: component catalog entries are kernel; the product↔component graph is org overlay.
+
+---
+
+## 5. Phasing (maps 1:1 to backlog)
+
+**Phase A — Enrichment core** (the "make it work"):
+- Canonical models + dangling-FK fix — **BI-74579817**
+- Enrichment fields on InventoryEntity/DigitalProduct — **BI-70469721**
+- enrich-digital-product pipeline + estate-specialist tools + cost guardrail — **BI-27EE2AF7**
+- FingerprintRule catalog + legacy warm-start — **BI-0528AD01**
+
+**Phase B — Open support-lifecycle & vuln feeds:**
+- endoflife.date connector → CatalogLifecycleMilestone (+ optional vendor calendars) — **BI-3A2328D6**
+- NVD CPE 2.3 crosswalk + broaden vuln beyond OSS — **BI-44B8B1E4**
+- OS-package patch coverage + EOL/support posture UI — **BI-9C0424E4**
+- SBOM → CatalogIdentity enrichment bridge (component=public, occurrence=private) — **BI-19FD07F9**
+
+**Enablement (coworker + sharing):**
+- Estate-specialist enrichment skills + hive-contribution grants + public/proprietary egress classification — **BI-1D25BC3C**
+
+**Phase C — SAM (roadmap):**
+- License entitlement & compliance (ELP, contracts, true-up) — **BI-E454034B**
+- Reclamation & usage metering — **BI-55756F66**
+- SaaS management — **BI-30151E25**
+
+**Phase D — HAM (roadmap):**
+- Hardware lifecycle & financials — **BI-3D1DBFBE**
+
+**Cross-cutting:**
+- Retire placeholder ModelProvider rows once real enrichment lands — **BI-3EE51676** (supersedes BI-D9EA2D9C)
+
+---
+
+## 6. Non-goals / explicit deferrals
+
+- **Cloning a proprietary catalog** (Technopedia's 5M products, ServiceNow's publisher rules). We compose open feeds + hand-curate publisher rules for the top vendors only.
+- **A complete package-vulnerability database inside DPF** (supply-chain spec non-goal); we consume OSV/NVD/KEV.
+- **Auto-mutating remediation/reclamation** — any uninstall/patch apply goes through the gated `RemoteAction` path with approval, never automatically.
+- **A new finding table** — reuse `AssuranceFinding`.
+- Phases C/D are **roadmap**; sequencing is steered before build. This cycle is **backlog + spec only**.
+
+---
+
+## 7. Data-model stewardship notes
+
+- `CatalogIdentity` holds the current normalized result; `IdentityResolutionLog` + `FingerprintRule` hold evidence + rule lifecycle — do not collapse (2026-04-18 §7.1, mirrors the fingerprint-pipeline stewardship rule).
+- All four new models + the InventoryEntity/DigitalProduct column additions land under **data-architecture stewardship review** (this is a data-model change, a founder-gated concern).
+- The dangling-FK fix is a hard prerequisite invariant, not optional cleanup.
+
+---
+
+## 8. Testing strategy (when built)
+
+- Golden path: discover → fingerprint-match → normalize to `CatalogIdentity` → endoflife.date populates `CatalogLifecycleMilestone` → `InventoryEntity.supportStatus`/`updatePosture` set → `/ops/patches` shows EOL/behind posture → `AssuranceFinding` written for out-of-support items.
+- Auto-promote path (2026-04-18 §11): repeated identical AI resolutions create a `status='shadow'` rule that writes only `IdentityResolutionLog` (never `catalogIdentityId`) during the shadow window; a contradicting human correction demotes it to `rejected`.
+- Feed resilience: endoflife.date slug↔CPE mapping, NVD rate-limit backoff, long-tail overlay fallback.
+
+---
+
+## Appendix — open feed reference (cited)
+
+- **endoflife.date** — MIT, ~461 products, v1 API (`/api/v1/products/`, `/api/v1/products/{name}/`, `identifiers[]` = CPE). [home](https://endoflife.date/) · [API](https://endoflife.date/docs/api) · [repo](https://github.com/endoflife-date/endoflife.date)
+- **NVD CPE / CVE** — CPE 2.3 (13-field), ~1.77M names; 5/30s anon, 50/30s keyed. [CPE](https://nvd.nist.gov/products/cpe) · [Product APIs](https://nvd.nist.gov/developers/products) · [Vuln APIs](https://nvd.nist.gov/developers/vulnerabilities)
+- **OSV.dev** — OpenSSF OSV schema, 24+ ecosystems. [FAQ](https://google.github.io/osv.dev/faq/) · [schema](https://ossf.github.io/osv-schema/)
+- **CISA KEV** — JSON/CSV, no auth. [catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) · [feed](https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json)
+- **SWID (ISO/IEC 19770-2)** / **CycloneDX** / **SPDX** — identity vs composition standards. [overview](https://www.aikido.dev/blog/understanding-sbom-standards-a-look-at-cyclonedx-spdx-and-swid)
+- **LVFS/fwupd** — firmware model/version. [fwupd](https://fwupd.org/) · [LVFS](https://lvfs.readthedocs.io/en/latest/intro.html)
+- Reference products: [Flexera Technopedia](https://www.flexera.com/products/technopedia) · [FlexNet Manager](https://www.flexera.com/products/flexnet-manager) · [ServiceNow SAM Content](https://www.servicenow.com/docs/bundle/vancouver-it-asset-management/page/product/software-asset-management2/concept/calculated-lifecycles.html) · [ServiceNow HAM](https://www.servicenow.com/products/hardware-asset-management.html)

--- a/packages/db/prisma/migrations/20260717010000_add_catalog_identity_lifecycle/migration.sql
+++ b/packages/db/prisma/migrations/20260717010000_add_catalog_identity_lifecycle/migration.sql
@@ -1,0 +1,135 @@
+-- EP-ASSET-INTELLIGENCE / BI-74579817: canonical identity + support-lifecycle spine
+-- for discovery enrichment. Additive only — new tables land empty; new columns are
+-- nullable (or have a default) so existing rows are unaffected.
+-- @migration-safety: data-safe: all new tables are empty on creation; every added
+-- column is nullable or carries a default, so no existing row is invalidated and no
+-- constraint can fail on current data. The pre-existing dangling
+-- DiscoveredSoftwareEvidence.softwareIdentityId column is intentionally left untouched.
+
+-- CreateTable
+CREATE TABLE "CatalogIdentity" (
+    "id" TEXT NOT NULL,
+    "identityKey" TEXT NOT NULL,
+    "part" TEXT NOT NULL DEFAULT 'a',
+    "manufacturer" TEXT NOT NULL,
+    "product" TEXT NOT NULL,
+    "productVersion" TEXT,
+    "edition" TEXT,
+    "patchLevel" TEXT,
+    "cpe" TEXT,
+    "category" TEXT,
+    "source" TEXT NOT NULL DEFAULT 'manual',
+    "confidence" DOUBLE PRECISION,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "CatalogIdentity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CatalogLifecycleMilestone" (
+    "id" TEXT NOT NULL,
+    "catalogIdentityId" TEXT NOT NULL,
+    "milestone" TEXT NOT NULL,
+    "date" TIMESTAMP(3),
+    "source" TEXT NOT NULL,
+    "confidence" DOUBLE PRECISION,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "CatalogLifecycleMilestone_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "IdentityResolutionLog" (
+    "id" TEXT NOT NULL,
+    "inventoryEntityId" TEXT,
+    "catalogIdentityId" TEXT,
+    "fingerprintRuleId" TEXT,
+    "resolutionType" TEXT NOT NULL,
+    "confidence" DOUBLE PRECISION,
+    "evidence" JSONB,
+    "discoveryRunId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "IdentityResolutionLog_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "DiscoveredSoftwareEvidence" ADD COLUMN     "catalogIdentityId" TEXT;
+
+-- AlterTable
+ALTER TABLE "DigitalProduct" ADD COLUMN     "enrichmentStatus" TEXT DEFAULT 'pending',
+ADD COLUMN     "lastEnrichedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "DiscoveryFingerprintRule" ADD COLUMN     "catalogIdentityId" TEXT;
+
+-- AlterTable
+ALTER TABLE "InventoryEntity" ADD COLUMN     "catalogIdentityId" TEXT,
+ADD COLUMN     "identityConfidence" DOUBLE PRECISION,
+ADD COLUMN     "identityStatus" TEXT,
+ADD COLUMN     "latestKnownVersion" TEXT,
+ADD COLUMN     "supportLifecycleConfidence" DOUBLE PRECISION,
+ADD COLUMN     "supportLifecycleSource" TEXT,
+ADD COLUMN     "updatePosture" TEXT NOT NULL DEFAULT 'unknown',
+ADD COLUMN     "updatePostureConfidence" DOUBLE PRECISION,
+ADD COLUMN     "updatePostureSource" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CatalogIdentity_identityKey_key" ON "CatalogIdentity"("identityKey");
+
+-- CreateIndex
+CREATE INDEX "CatalogIdentity_manufacturer_product_idx" ON "CatalogIdentity"("manufacturer", "product");
+
+-- CreateIndex
+CREATE INDEX "CatalogIdentity_cpe_idx" ON "CatalogIdentity"("cpe");
+
+-- CreateIndex
+CREATE INDEX "CatalogIdentity_part_idx" ON "CatalogIdentity"("part");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CatalogLifecycleMilestone_identity_milestone_source_key" ON "CatalogLifecycleMilestone"("catalogIdentityId", "milestone", "source");
+
+-- CreateIndex
+CREATE INDEX "CatalogLifecycleMilestone_catalogIdentityId_idx" ON "CatalogLifecycleMilestone"("catalogIdentityId");
+
+-- CreateIndex
+CREATE INDEX "CatalogLifecycleMilestone_milestone_idx" ON "CatalogLifecycleMilestone"("milestone");
+
+-- CreateIndex
+CREATE INDEX "IdentityResolutionLog_inventoryEntityId_idx" ON "IdentityResolutionLog"("inventoryEntityId");
+
+-- CreateIndex
+CREATE INDEX "IdentityResolutionLog_catalogIdentityId_idx" ON "IdentityResolutionLog"("catalogIdentityId");
+
+-- CreateIndex
+CREATE INDEX "IdentityResolutionLog_resolutionType_idx" ON "IdentityResolutionLog"("resolutionType");
+
+-- CreateIndex
+CREATE INDEX "DiscoveredSoftwareEvidence_catalogIdentityId_idx" ON "DiscoveredSoftwareEvidence"("catalogIdentityId");
+
+-- CreateIndex
+CREATE INDEX "DiscoveryFingerprintRule_catalogIdentityId_idx" ON "DiscoveryFingerprintRule"("catalogIdentityId");
+
+-- CreateIndex
+CREATE INDEX "InventoryEntity_catalogIdentityId_idx" ON "InventoryEntity"("catalogIdentityId");
+
+-- AddForeignKey
+ALTER TABLE "CatalogLifecycleMilestone" ADD CONSTRAINT "CatalogLifecycleMilestone_catalogIdentityId_fkey" FOREIGN KEY ("catalogIdentityId") REFERENCES "CatalogIdentity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "IdentityResolutionLog" ADD CONSTRAINT "IdentityResolutionLog_inventoryEntityId_fkey" FOREIGN KEY ("inventoryEntityId") REFERENCES "InventoryEntity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "IdentityResolutionLog" ADD CONSTRAINT "IdentityResolutionLog_catalogIdentityId_fkey" FOREIGN KEY ("catalogIdentityId") REFERENCES "CatalogIdentity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "IdentityResolutionLog" ADD CONSTRAINT "IdentityResolutionLog_fingerprintRuleId_fkey" FOREIGN KEY ("fingerprintRuleId") REFERENCES "DiscoveryFingerprintRule"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DiscoveredSoftwareEvidence" ADD CONSTRAINT "DiscoveredSoftwareEvidence_catalogIdentityId_fkey" FOREIGN KEY ("catalogIdentityId") REFERENCES "CatalogIdentity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DiscoveryFingerprintRule" ADD CONSTRAINT "DiscoveryFingerprintRule_catalogIdentityId_fkey" FOREIGN KEY ("catalogIdentityId") REFERENCES "CatalogIdentity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InventoryEntity" ADD CONSTRAINT "InventoryEntity_catalogIdentityId_fkey" FOREIGN KEY ("catalogIdentityId") REFERENCES "CatalogIdentity"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -707,6 +707,9 @@ model DigitalProduct {
   observationConfig             Json?
   coverageStatus                String?
   sourceKind                    String?
+  // Enrichment status roll-up (BI-70469721) — written by the enrich-digital-product pipeline.
+  enrichmentStatus              String?                        @default("pending") // pending | enriched | partial | failed
+  lastEnrichedAt                DateTime?
   backlogItems                  BacklogItem[]
   manifests                     CodebaseManifest[]
   assuranceFindings             AssuranceFinding[]
@@ -4349,13 +4352,101 @@ model DiscoveredSoftwareEvidence {
   rawMetadata             Json?
   normalizationStatus     String          @default("pending")
   normalizationConfidence Float?
+  // `softwareIdentityId` is a pre-existing DANGLING FK — its target `SoftwareIdentity` was dropped
+  // in migration 20260320222431. Left untouched here (additive change); its resolution
+  // (rename→legacy + warm-start join, OR drop-with-evidence) needs live row counts and is an
+  // explicit sandbox sub-task of BI-74579817. Spec §7.4.
   softwareIdentityId      String?
+  // New canonical linkage into the CatalogIdentity spine (additive).
+  catalogIdentityId       String?
   firstSeenAt             DateTime        @default(now())
   lastSeenAt              DateTime        @default(now())
   inventoryEntity         InventoryEntity @relation(fields: [inventoryEntityId], references: [id], onDelete: Cascade)
+  catalogIdentity         CatalogIdentity? @relation(fields: [catalogIdentityId], references: [id], onDelete: SetNull)
 
   @@index([inventoryEntityId])
   @@index([normalizationStatus])
+  @@index([catalogIdentityId])
+}
+
+/// Canonical normalized software/hardware identity — the manufacturer→product→version→edition
+/// spine (Technopedia-style), keyed by CPE 2.3 where resolved. Raw vendor strings never write
+/// here directly; only the fingerprint/normalize pipeline sets these fields, via rules.
+/// EP-ASSET-INTELLIGENCE / BI-74579817.
+/// Spec: docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md §4.1
+model CatalogIdentity {
+  id                  String                       @id @default(cuid())
+  // Stable canonical key (e.g. the cpe:2.3 string, or manufacturer:product:version:edition).
+  identityKey         String                       @unique
+  part                String                       @default("a") // CPE part: a (application) | o (os) | h (hardware)
+  manufacturer        String
+  product             String
+  productVersion      String?
+  edition             String?
+  patchLevel          String?
+  cpe                 String? // cpe:2.3 formatted string when resolved
+  category            String?
+  source              String                       @default("manual") // seeded | rule | ai_resolved | human_confirmed | feed
+  confidence          Float?
+  createdAt           DateTime                     @default(now())
+  updatedAt           DateTime                     @updatedAt
+  lifecycleMilestones CatalogLifecycleMilestone[]
+  // Convergence (BI-74579817): reuse the existing DiscoveryFingerprintRule subsystem rather than
+  // add a parallel rule model — it already maps evidence→identity (via inline resolvedIdentity
+  // JSON). This FK lets a rule resolve to a canonical CatalogIdentity. See spec §4.1 + the
+  // stewardship note in the BI. STEWARD DECISION: converge vs. keep device/software rules separate.
+  fingerprintRules    DiscoveryFingerprintRule[]
+  resolutionLogs      IdentityResolutionLog[]
+  inventoryEntities   InventoryEntity[]
+  softwareEvidence    DiscoveredSoftwareEvidence[]
+
+  @@index([manufacturer, product])
+  @@index([cpe])
+  @@index([part])
+}
+
+/// Structured support-lifecycle milestone for a CatalogIdentity — one row per named milestone,
+/// each carrying its own source + confidence. Populated from open feeds (endoflife.date) plus a
+/// manual overlay for long-tail commercial software. BI-74579817 (model) / BI-3A2328D6 (feed).
+model CatalogLifecycleMilestone {
+  id                String          @id @default(cuid())
+  catalogIdentityId String
+  // mainstream_end | extended_support_end | eol | eosl | security_updates_end | release
+  milestone         String
+  date              DateTime?
+  source            String // endoflife.date | nvd | vendor_calendar | manual
+  confidence        Float?
+  notes             String?
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @updatedAt
+  catalogIdentity   CatalogIdentity @relation(fields: [catalogIdentityId], references: [id], onDelete: Cascade)
+
+  @@unique([catalogIdentityId, milestone, source], map: "CatalogLifecycleMilestone_identity_milestone_source_key")
+  @@index([catalogIdentityId])
+  @@index([milestone])
+}
+
+/// Audit lineage of every identity resolution — which rule / AI / human resolved an entity to a
+/// CatalogIdentity, with confidence + evidence. Human-confirmed rows are never overwritten by a
+/// rule (§6.3.1). BI-74579817.
+model IdentityResolutionLog {
+  id                String           @id @default(cuid())
+  inventoryEntityId String?
+  catalogIdentityId String?
+  fingerprintRuleId String?
+  // rule | ai_resolved | human_confirmed | human_corrected | shadow
+  resolutionType    String
+  confidence        Float?
+  evidence          Json?
+  discoveryRunId    String?
+  createdAt         DateTime         @default(now())
+  inventoryEntity   InventoryEntity?          @relation(fields: [inventoryEntityId], references: [id], onDelete: SetNull)
+  catalogIdentity   CatalogIdentity?          @relation(fields: [catalogIdentityId], references: [id], onDelete: SetNull)
+  fingerprintRule   DiscoveryFingerprintRule? @relation(fields: [fingerprintRuleId], references: [id], onDelete: SetNull)
+
+  @@index([inventoryEntityId])
+  @@index([catalogIdentityId])
+  @@index([resolutionType])
 }
 
 model DiscoveryFingerprintObservation {
@@ -4436,15 +4527,21 @@ model DiscoveryFingerprintRule {
   sourceObservationIds     String[] @default([])
   createdAt                DateTime @default(now())
   updatedAt                DateTime @updatedAt
+  // Convergence FK (BI-74579817): resolve a fingerprint to the canonical CatalogIdentity spine,
+  // superseding the inline `resolvedIdentity` JSON over time. Nullable during migration.
+  catalogIdentityId        String?
 
   catalogVersion       DiscoveryFingerprintCatalogVersion? @relation(fields: [catalogVersionId], references: [id], onDelete: SetNull)
   taxonomyNode         TaxonomyNode?                       @relation(fields: [taxonomyNodeId], references: [id], onDelete: SetNull)
   approvedObservations DiscoveryFingerprintObservation[]   @relation("ApprovedFingerprintRule")
+  catalogIdentity      CatalogIdentity?                    @relation(fields: [catalogIdentityId], references: [id], onDelete: SetNull)
+  resolutionLogs       IdentityResolutionLog[]
 
   @@index([status])
   @@index([scope])
   @@index([taxonomyNodeId])
   @@index([catalogVersionId])
+  @@index([catalogIdentityId])
 }
 
 model DiscoveryFingerprintCatalogVersion {
@@ -4508,7 +4605,20 @@ model InventoryEntity {
   attributionConfidence       Float?
   attributionEvidence         Json?
   candidateTaxonomy           Json?
+  // Enrichment result fields (BI-70469721). Populated by the enrich-digital-product pipeline
+  // (BI-27EE2AF7). Spec 2026-07-16-software-asset-intelligence-enrichment-design §4.3.
+  catalogIdentityId           String?
+  identityStatus              String? // unresolved | rule_resolved | ai_resolved | human_confirmed
+  identityConfidence          Float?
+  updatePosture               String                            @default("unknown") // unknown | current | behind | ahead
+  updatePostureSource         String?
+  updatePostureConfidence     Float?
+  latestKnownVersion          String?
+  supportLifecycleSource      String?
+  supportLifecycleConfidence  Float?
   discoveredItems             DiscoveredItem[]
+  catalogIdentity             CatalogIdentity?                  @relation(fields: [catalogIdentityId], references: [id])
+  identityResolutionLogs      IdentityResolutionLog[]
   digitalProduct              DigitalProduct?                   @relation(fields: [digitalProductId], references: [id])
   lastConfirmedRun            DiscoveryRun?                     @relation("InventoryEntityConfirmedRun", fields: [lastConfirmedRunId], references: [id])
   portfolio                   Portfolio?                        @relation(fields: [portfolioId], references: [id])
@@ -4534,6 +4644,7 @@ model InventoryEntity {
   @@index([portfolioId])
   @@index([taxonomyNodeId])
   @@index([digitalProductId])
+  @@index([catalogIdentityId])
   @@index([scopeKey])
   @@index([customerAccountId])
   @@index([customerSiteId])


### PR DESCRIPTION
## What

Phase A dependency-root schema for **EP-ASSET-INTELLIGENCE** — the canonical software/asset **identity + support-lifecycle spine** that powers discovery *enrichment* (the never-built engine behind the vestigial `data-enrichment` provider). Spec: `docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md`.

### New models
- **`CatalogIdentity`** — normalized manufacturer→product→version→edition, CPE-keyed (Technopedia-analog, open-feed strategy).
- **`CatalogLifecycleMilestone`** — structured EOL/EOS/EOES/release milestones (the `endoflife.date` feed target), each with source + confidence.
- **`IdentityResolutionLog`** — resolution lineage/audit; human-confirmed rows are never overwritten by a rule.

### Convergence (not duplication)
The existing **`DiscoveryFingerprintRule`** already maps evidence→identity via an inline `resolvedIdentity` JSON, so this **extends it** with a `catalogIdentityId` FK rather than adding a parallel rule model — the data-architecture-stewardship decision flagged inline in the schema (converge vs. keep device/software rules separate).

### Additive fields (all nullable or defaulted — existing rows unaffected)
- `InventoryEntity`: `catalogIdentityId`, `identityStatus`/`identityConfidence`, `updatePosture`(+source/conf), `latestKnownVersion`, `supportLifecycleSource`/`Confidence`.
- `DigitalProduct`: `enrichmentStatus`, `lastEnrichedAt`.
- `DiscoveredSoftwareEvidence`: `catalogIdentityId`.

The pre-existing **dangling `softwareIdentityId`** column is intentionally left untouched — its rename-vs-drop needs live non-null row counts (follow-up sub-task, spec §7.4).

## Migration
`20260717010000_add_catalog_identity_lifecycle` — `@migration-safety: data-safe` (new tables land empty; every added column is nullable or defaulted, so no constraint can fail on existing data).

## Verification
- `prisma validate` **passes** (schema syntax + all relations, incl. the DiscoveryFingerprintRule convergence).
- The migration mirrors this repo's exact Prisma-emitted SQL conventions.
- Shadow-DB **drift-check**, `prisma migrate deploy`, typecheck, and unit tests run in **CI** — this worktree is source-only (no schema-engine/DB), same path as #3105.

## Backlog
- Item: **BI-74579817** (in-progress) · Epic: **EP-ASSET-INTELLIGENCE**
- Next in the chain (separate PRs): enrichment fields consumers → FingerprintRule catalog + `endoflife.date` connector + NVD/CPE crosswalk → the `enrich-digital-product` pipeline.

Design-Grounding-Decision: BI-74579817

🤖 Generated with [Claude Code](https://claude.com/claude-code)