### PR TITLE
fix(workbooks): reach the per-group subtotal aggregate while grouped (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -1151,7 +1151,9 @@ export function WorkbookGrid({
           topGroupIds={topGroupIds}
           setCollapsedGroups={setCollapsedGroups}
           setExtraExpanded={setExtraExpanded}
+          visibleCols={visibleCols}
           footerAgg={footerAgg}
+          setFooterAgg={setFooterAgg}
         />
       )}
 

--- a/apps/web/components/workbooks/GridPanels.tsx
+++ b/apps/web/components/workbooks/GridPanels.tsx
@@ -31,7 +31,12 @@ import {
   operatorNeedsValue,
 } from "./grid-conditional-format";
 import { ROW_HEIGHTS, type RowHeight } from "./grid-view-options";
-import type { FooterAgg } from "./grid-footer-summary";
+import {
+  availableAggs,
+  toFooterAgg,
+  FOOTER_AGG_LABELS,
+  type FooterAgg,
+} from "./grid-footer-summary";
 
 const PANEL = "flex flex-col gap-2 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2";
 const CTRL = "rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-sm text-[var(--dpf-text)]";
@@ -411,7 +416,10 @@ export interface GridGroupPanelProps {
   topGroupIds: readonly string[];
   setCollapsedGroups: Dispatch<SetStateAction<ReadonlySet<unknown>>>;
   setExtraExpanded: Dispatch<SetStateAction<ReadonlySet<unknown>>>;
+  /** Visible columns (in order) — used for the per-column subtotal pickers. */
+  visibleCols: ColumnDefinition[];
   footerAgg: Record<string, FooterAgg>;
+  setFooterAgg: Dispatch<SetStateAction<Record<string, FooterAgg>>>;
 }
 
 export function GridGroupPanel({
@@ -423,7 +431,9 @@ export function GridGroupPanel({
   topGroupIds,
   setCollapsedGroups,
   setExtraExpanded,
+  visibleCols,
   footerAgg,
+  setFooterAgg,
 }: GridGroupPanelProps): ReactNode {
   const available = columns.filter((c) => !effectiveGroupBy.includes(c.columnId));
   return (
@@ -496,11 +506,34 @@ export function GridGroupPanel({
             {effectiveGroupBy.length > 1 ? `${effectiveGroupBy.length} levels · ` : ""}
             {topGroupIds.length} group{topGroupIds.length === 1 ? "" : "s"}
           </span>
-          {!Object.values(footerAgg).some((a) => a && a !== "none") && (
-            <span className="text-xs italic text-[var(--dpf-muted)]">
-              Tip: pick an aggregate in the Summary bar (Columns) to show subtotals per group.
-            </span>
-          )}
+          {/* Per-column subtotal pickers — shown here (not just the footer bar,
+              which TreeDataGrid hides while grouped) so a subtotal aggregate is
+              always reachable while grouping. Drives the same footerAgg state. */}
+          <div className="flex w-full flex-wrap items-center gap-x-3 gap-y-1 border-t border-[var(--dpf-border)] pt-2">
+            <span className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">Subtotals</span>
+            {visibleCols.map((c) => (
+              <label
+                key={c.columnId}
+                className="inline-flex items-center gap-1 text-sm text-[var(--dpf-text)]"
+              >
+                <span className="text-[var(--dpf-muted)]">{c.name}</span>
+                <select
+                  value={footerAgg[c.columnId] ?? "none"}
+                  onChange={(e) =>
+                    setFooterAgg((prev) => ({ ...prev, [c.columnId]: toFooterAgg(e.target.value) }))
+                  }
+                  aria-label={`Subtotal for ${c.name}`}
+                  className={CTRL}
+                >
+                  {availableAggs(c.fieldType).map((a) => (
+                    <option key={a} value={a}>
+                      {FOOTER_AGG_LABELS[a]}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ))}
+          </div>
         </>
       )}
     </div>

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -206,8 +206,11 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   selection that drives the footer bar, so one summary function reads as both per-group subtotal and
   grand total — Excel/Smartsheet behavior — with no new config, state, or persistence. Group-by columns
   are left untouched so `TreeDataGrid` keeps rendering their toggle + value + child count. Reuses the
-  pure, unit-tested `computeFooter` (`grid-footer-summary.ts`); a Group-panel tip points the user to the
-  Summary bar to pick aggregates. This closes the grouping-parity follow-up noted in Slice 22.
+  pure, unit-tested `computeFooter` (`grid-footer-summary.ts`). This closes the grouping-parity
+  follow-up noted in Slice 22. **UX fix (2026-07):** the per-column subtotal aggregate is now picked
+  from a "Subtotals" row **inside the Group panel** (not only the footer bar, which `TreeDataGrid`
+  hides while grouped) — so the aggregate is always reachable while grouping, and the earlier
+  "use the Summary bar" tip is no longer a dead end. Both surfaces drive the same `footerAgg` state.
 - **Slice 18 — table ergonomics: hide fields + frozen columns + row height — SHIPPED.** A "Columns"
   toolbar panel (progressive disclosure) with per-field show/hide checkboxes, a "Freeze first N
   columns" selector (pins the leftmost visible columns on horizontal scroll via react-data-grid

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -12,7 +12,7 @@ apps/web/components/platform/AiOperationsMap.tsx	2881
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
 apps/web/components/storefront/SlotBookingFlow.tsx	919
-apps/web/components/workbooks/Grid.tsx	1273
+apps/web/components/workbooks/Grid.tsx	1275
 apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1341
 apps/web/lib/actions/agent-coworker-external.test.ts	867


### PR DESCRIPTION
## Problem (found during live verification of #3096)

Per-group subtotals are driven by the per-column footer aggregate (`footerAgg`), but that was only settable via the **footer summary bar** — which `TreeDataGrid` **hides while grouping is active** (`bottomSummaryRows = showFooter && !grouping`). So a user who grouped first, then followed the tip *"pick an aggregate in the Summary bar (Columns)"*, found no picker there. A dead end.

## Fix

The **Group panel** now renders a **"Subtotals"** row with a per-column aggregate picker (Count/Filled/Empty/Unique for any field; Sum/Average/Min/Max for numbers), shown whenever grouping is active. It writes the **same `footerAgg` state**, so one selection drives both the grouped subtotal *and* (when ungrouped) the footer grand total. Removed the now-misleading tip.

Pure UI change over existing state — no contract change, no new pure logic. `Grid.tsx` +2 (two props); `GridPanels.tsx` 610→643 (under the size guard). Unit tests green (125/125). CI runs the authoritative typecheck.

## Design grounding

Extends the phase-2 plan (Slice 23) over the `apps/web/` grid substrate; reuses `footerAgg` + the existing `grid-footer-summary` helpers (`availableAggs`/`toFooterAgg`/`FOOTER_AGG_LABELS`).

Design-Grounding-Decision: extends docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md (Slice 23); no contract change — reuses footerAgg + footer-summary helpers.
UX-Fit-Decision: progressive disclosure — Subtotals pickers appear only while grouping, inside the already-open Group panel; plain per-column dropdowns default "—", same control users know from the footer bar; no tokens/endpoints. Lower cognitive load than a dead-end tip.
Process-Spine-Decision: touched the phase-2 plan (Slice 23 UX-fix note); no new module or spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)