### PR TITLE
refactor(build): extract pure Build-action helpers into a domain-core module (BI-OPT-FAT-ACTIONS — Build slice)

### DIFF
--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -28,7 +28,7 @@ import {
   recordReadyDependentsAfterCompletion,
 } from "@/lib/build/feature-build-dependencies";
 import { evaluateBuildStudioPlanAdvancementGate } from "@/lib/decision-perspective/build-studio-gate";
-import type { ResumeBuildImplementationOutcome, ResumeImplementationMode } from "@/lib/build/progress-visibility-types";
+import type { ResumeBuildImplementationOutcome } from "@/lib/build/progress-visibility-types";
 import {
   type BusinessBriefEvidenceKind,
   type BusinessBuildBriefSource,
@@ -44,23 +44,18 @@ import {
 } from "@/lib/work-capsules/build-studio-attachment";
 import type { UnifiedWipDb } from "@/lib/build/unified-wip-query";
 import { revalidatePortalContextForBuild } from "@/lib/portal-context/invalidation";
+import {
+  businessBriefJsonPayload,
+  readPersistedSourceCurrency,
+  derivePhaseHandoffContext,
+  deriveResumeImplementationMode,
+  formatResumeImplementationOutcomeMessage,
+} from "@/lib/build/build-actions-core";
 
 // ─── Auth Guard ──────────────────────────────────────────────────────────────
 
 async function requireBuildAccess(): Promise<string> {
   return (await requireCapability("view_platform")).userId;
-}
-
-function businessBriefJsonPayload(
-  businessBrief: ReturnType<typeof legacyFeatureBuildBriefToBusinessBuildBriefInput>,
-) {
-  return {
-    affectedPeople: businessBrief.affectedPeople as unknown as Prisma.InputJsonValue,
-    sourceEvidence: businessBrief.sourceEvidence as unknown as Prisma.InputJsonValue,
-    technicalInterpretation: businessBrief.technicalInterpretation as unknown as Prisma.InputJsonValue,
-    riskProfile: businessBrief.riskProfile as unknown as Prisma.InputJsonValue,
-    hiveReadiness: businessBrief.hiveReadiness as unknown as Prisma.InputJsonValue,
-  };
 }
 
 // ─── Create Feature Build ────────────────────────────────────────────────────
@@ -626,42 +621,11 @@ export async function advanceBuildPhase(
 
   // Write PhaseHandoff document — structured context for the next phase's agent
   try {
-    const PHASE_AGENT: Record<string, string> = {
-      ideate: "build-specialist",
-      plan: "ea-architect",
-      build: "build-specialist",
-      review: "ops-coordinator",
-      ship: "platform-engineer",
-    };
-    const fromAgent = PHASE_AGENT[currentPhase] ?? "build-specialist";
-    const toAgent = PHASE_AGENT[targetPhase] ?? "build-specialist";
-
-    // Build evidence digest — one-line summary per populated field
-    const evidenceFields: string[] = [];
-    const evidenceDigest: Record<string, string> = {};
-    if (build.designDoc) { evidenceFields.push("designDoc"); evidenceDigest.designDoc = "Design document saved"; }
-    if (build.designReview) {
-      evidenceFields.push("designReview");
-      const review = build.designReview as Record<string, unknown>;
-      evidenceDigest.designReview = `${review.decision ?? "reviewed"} — ${String(review.summary ?? "").slice(0, 100)}`;
-    }
-    if (build.buildPlan) { evidenceFields.push("buildPlan"); evidenceDigest.buildPlan = "Implementation plan saved"; }
-    if (build.planReview) {
-      evidenceFields.push("planReview");
-      const review = build.planReview as Record<string, unknown>;
-      evidenceDigest.planReview = `${review.decision ?? "reviewed"} — ${String(review.summary ?? "").slice(0, 100)}`;
-    }
-    if (build.verificationOut) {
-      evidenceFields.push("verificationOut");
-      const v = build.verificationOut as Record<string, unknown>;
-      evidenceDigest.verificationOut = `typecheck: ${v.typecheckPassed ? "pass" : "fail"}`;
-    }
-    if (build.acceptanceMet) {
-      evidenceFields.push("acceptanceMet");
-      evidenceDigest.acceptanceMet = Array.isArray(build.acceptanceMet)
-        ? `${(build.acceptanceMet as Array<{ met?: boolean }>).filter(c => c.met).length}/${(build.acceptanceMet as unknown[]).length} criteria met`
-        : "Evaluated";
-    }
+    const { fromAgent, toAgent, evidenceFields, evidenceDigest } = derivePhaseHandoffContext({
+      currentPhase,
+      targetPhase,
+      build,
+    });
 
     await prisma.phaseHandoff.create({
       data: {
@@ -834,17 +798,6 @@ export async function autoExecuteBuild(buildId: string): Promise<void> {
         : `Build pipeline failed at step: ${result.failedAt ?? result.step}`,
     },
   }).catch(() => {});
-}
-
-function readPersistedSourceCurrency(value: unknown): unknown {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  const sourceCurrency = (value as { sourceCurrency?: unknown }).sourceCurrency;
-  if (!sourceCurrency || typeof sourceCurrency !== "object" || Array.isArray(sourceCurrency)) {
-    return null;
-  }
-  return sourceCurrency;
 }
 
 /**
@@ -1211,40 +1164,6 @@ export async function resumeBuildImplementation(buildId: string): Promise<Resume
     dispatchQueued: true,
     message: formatResumeImplementationOutcomeMessage(resumeMode, resetTasks),
   };
-}
-
-function deriveResumeImplementationMode(args: {
-  phase: BuildPhase;
-  taskCount: number;
-  resetTasks: number;
-  verificationFailed: boolean;
-}): ResumeImplementationMode {
-  if (args.resetTasks > 0) {
-    return "reset-blocked";
-  }
-  if (args.taskCount === 0) {
-    return "replan-and-dispatch";
-  }
-  if (args.phase === "review" && args.verificationFailed) {
-    return "rerun-verification";
-  }
-  return "already-running";
-}
-
-function formatResumeImplementationOutcomeMessage(
-  mode: ResumeImplementationMode,
-  resetTasks: number,
-): string {
-  if (mode === "reset-blocked") {
-    return `Reset ${resetTasks} task${resetTasks === 1 ? "" : "s"} to BLOCKED; queued implementation resume.`;
-  }
-  if (mode === "replan-and-dispatch") {
-    return "No persisted task rows were reset; queued implementation dispatch from the current plan.";
-  }
-  if (mode === "rerun-verification") {
-    return "Cleared verification output; queued verification recovery through the existing implementation resume path.";
-  }
-  return "Resume request recorded; implementation already has observable work in progress.";
 }
 
 // autoA11yAudit was removed on 2026-04-20 when the Inngest-based

--- a/apps/web/lib/build/build-actions-core.test.ts
+++ b/apps/web/lib/build/build-actions-core.test.ts
@@ -1,0 +1,187 @@
+// apps/web/lib/build/build-actions-core.test.ts
+//
+// Unit tests for the pure Build-action helpers extracted from
+// lib/actions/build.ts (BI-OPT-FAT-ACTIONS, Build slice). These functions are
+// now side-effect-free (no prisma / auth / Next.js), so they are exercised
+// directly here. Mirrors ea-core.test.ts.
+import { describe, it, expect } from "vitest";
+import {
+  businessBriefJsonPayload,
+  readPersistedSourceCurrency,
+  derivePhaseHandoffContext,
+  deriveResumeImplementationMode,
+  formatResumeImplementationOutcomeMessage,
+} from "./build-actions-core";
+
+describe("businessBriefJsonPayload", () => {
+  it("projects exactly the five JSON-column fields, passing values through", () => {
+    const businessBrief = {
+      affectedPeople: [{ role: "operator" }],
+      sourceEvidence: { kind: "conversation" },
+      technicalInterpretation: { summary: "x" },
+      riskProfile: { level: "low" },
+      hiveReadiness: { ready: true },
+      // extra fields that must NOT appear in the payload
+      status: "accepted",
+      businessOutcome: "faster",
+    } as unknown as Parameters<typeof businessBriefJsonPayload>[0];
+
+    const payload = businessBriefJsonPayload(businessBrief);
+
+    expect(Object.keys(payload).sort()).toEqual([
+      "affectedPeople",
+      "hiveReadiness",
+      "riskProfile",
+      "sourceEvidence",
+      "technicalInterpretation",
+    ]);
+    expect(payload.affectedPeople).toEqual([{ role: "operator" }]);
+    expect(payload.hiveReadiness).toEqual({ ready: true });
+  });
+});
+
+describe("readPersistedSourceCurrency", () => {
+  it("returns the sourceCurrency sub-object when present", () => {
+    const sc = { headSha: "abc", baseSha: "def" };
+    expect(readPersistedSourceCurrency({ step: "build", sourceCurrency: sc })).toBe(sc);
+  });
+
+  it("returns null for non-objects, arrays, and missing/invalid sourceCurrency", () => {
+    expect(readPersistedSourceCurrency(null)).toBeNull();
+    expect(readPersistedSourceCurrency(undefined)).toBeNull();
+    expect(readPersistedSourceCurrency("x")).toBeNull();
+    expect(readPersistedSourceCurrency([1, 2])).toBeNull();
+    expect(readPersistedSourceCurrency({ step: "build" })).toBeNull();
+    expect(readPersistedSourceCurrency({ sourceCurrency: null })).toBeNull();
+    expect(readPersistedSourceCurrency({ sourceCurrency: "nope" })).toBeNull();
+    expect(readPersistedSourceCurrency({ sourceCurrency: [1] })).toBeNull();
+  });
+});
+
+describe("derivePhaseHandoffContext", () => {
+  const emptyBuild = {
+    designDoc: null,
+    designReview: null,
+    buildPlan: null,
+    planReview: null,
+    verificationOut: null,
+    acceptanceMet: null,
+  };
+
+  it("maps known phases to their handoff agents and falls back for unknown", () => {
+    const a = derivePhaseHandoffContext({ currentPhase: "plan", targetPhase: "build", build: emptyBuild });
+    expect(a.fromAgent).toBe("ea-architect");
+    expect(a.toAgent).toBe("build-specialist");
+
+    const b = derivePhaseHandoffContext({ currentPhase: "review", targetPhase: "ship", build: emptyBuild });
+    expect(b.fromAgent).toBe("ops-coordinator");
+    expect(b.toAgent).toBe("platform-engineer");
+
+    const c = derivePhaseHandoffContext({ currentPhase: "mystery", targetPhase: "void", build: emptyBuild });
+    expect(c.fromAgent).toBe("build-specialist");
+    expect(c.toAgent).toBe("build-specialist");
+  });
+
+  it("emits no evidence for an empty build", () => {
+    const { evidenceFields, evidenceDigest } = derivePhaseHandoffContext({
+      currentPhase: "ideate",
+      targetPhase: "plan",
+      build: emptyBuild,
+    });
+    expect(evidenceFields).toEqual([]);
+    expect(evidenceDigest).toEqual({});
+  });
+
+  it("builds an ordered evidence digest with per-field one-line summaries", () => {
+    const { evidenceFields, evidenceDigest } = derivePhaseHandoffContext({
+      currentPhase: "build",
+      targetPhase: "review",
+      build: {
+        designDoc: { any: true },
+        designReview: { decision: "approve", summary: "looks good" },
+        buildPlan: { any: true },
+        planReview: { decision: "approve", summary: "solid" },
+        verificationOut: { typecheckPassed: true },
+        acceptanceMet: [{ met: true }, { met: false }, { met: true }],
+      },
+    });
+
+    expect(evidenceFields).toEqual([
+      "designDoc",
+      "designReview",
+      "buildPlan",
+      "planReview",
+      "verificationOut",
+      "acceptanceMet",
+    ]);
+    expect(evidenceDigest.designDoc).toBe("Design document saved");
+    expect(evidenceDigest.designReview).toBe("approve — looks good");
+    expect(evidenceDigest.planReview).toBe("approve — solid");
+    expect(evidenceDigest.verificationOut).toBe("typecheck: pass");
+    expect(evidenceDigest.acceptanceMet).toBe("2/3 criteria met");
+  });
+
+  it("falls back to 'reviewed' / fail markers and non-array acceptance", () => {
+    const { evidenceDigest } = derivePhaseHandoffContext({
+      currentPhase: "build",
+      targetPhase: "review",
+      build: {
+        designDoc: null,
+        designReview: {},
+        buildPlan: null,
+        planReview: null,
+        verificationOut: { typecheckPassed: false },
+        acceptanceMet: { met: true },
+      },
+    });
+    expect(evidenceDigest.designReview).toBe("reviewed — ");
+    expect(evidenceDigest.verificationOut).toBe("typecheck: fail");
+    expect(evidenceDigest.acceptanceMet).toBe("Evaluated");
+  });
+});
+
+describe("deriveResumeImplementationMode", () => {
+  it("prioritizes reset-blocked when tasks were reset", () => {
+    expect(
+      deriveResumeImplementationMode({ phase: "build", taskCount: 3, resetTasks: 1, verificationFailed: false }),
+    ).toBe("reset-blocked");
+  });
+
+  it("returns replan-and-dispatch when there are no persisted tasks", () => {
+    expect(
+      deriveResumeImplementationMode({ phase: "build", taskCount: 0, resetTasks: 0, verificationFailed: false }),
+    ).toBe("replan-and-dispatch");
+  });
+
+  it("returns rerun-verification only in review with failed verification", () => {
+    expect(
+      deriveResumeImplementationMode({ phase: "review", taskCount: 2, resetTasks: 0, verificationFailed: true }),
+    ).toBe("rerun-verification");
+    expect(
+      deriveResumeImplementationMode({ phase: "build", taskCount: 2, resetTasks: 0, verificationFailed: true }),
+    ).toBe("already-running");
+  });
+
+  it("returns already-running otherwise", () => {
+    expect(
+      deriveResumeImplementationMode({ phase: "review", taskCount: 2, resetTasks: 0, verificationFailed: false }),
+    ).toBe("already-running");
+  });
+});
+
+describe("formatResumeImplementationOutcomeMessage", () => {
+  it("pluralizes the reset-blocked task count", () => {
+    expect(formatResumeImplementationOutcomeMessage("reset-blocked", 1)).toBe(
+      "Reset 1 task to BLOCKED; queued implementation resume.",
+    );
+    expect(formatResumeImplementationOutcomeMessage("reset-blocked", 3)).toBe(
+      "Reset 3 tasks to BLOCKED; queued implementation resume.",
+    );
+  });
+
+  it("returns the fixed message per mode", () => {
+    expect(formatResumeImplementationOutcomeMessage("replan-and-dispatch", 0)).toMatch(/queued implementation dispatch/);
+    expect(formatResumeImplementationOutcomeMessage("rerun-verification", 0)).toMatch(/verification recovery/);
+    expect(formatResumeImplementationOutcomeMessage("already-running", 0)).toMatch(/already has observable work/);
+  });
+});

--- a/apps/web/lib/build/build-actions-core.ts
+++ b/apps/web/lib/build/build-actions-core.ts
@@ -1,0 +1,156 @@
+// apps/web/lib/build/build-actions-core.ts
+//
+// Pure (no prisma / auth / Next.js / Inngest) domain helpers extracted from
+// lib/actions/build.ts (BI-OPT-FAT-ACTIONS, Build slice). These functions are
+// side-effect-free — input validation-free shape/transform/mapping, derivation,
+// and formatting — so the deterministic Build-action logic lives in the build
+// domain layer and is unit-testable on its own. Behavior-preserving relocation
+// — identical bodies, mirroring the EA slice (ea-core.ts) and CRM slice.
+//
+// Orchestration (auth() checks, prisma, $transaction, revalidatePath, Inngest
+// sends, the "use server" wrappers) STAYS in lib/actions/build.ts and imports
+// these helpers back.
+
+import type { Prisma } from "@dpf/db";
+import type { BuildPhase } from "@/lib/feature-build-types";
+import type { ResumeImplementationMode } from "@/lib/build/progress-visibility-types";
+import type { legacyFeatureBuildBriefToBusinessBuildBriefInput } from "@/lib/build/business-build-brief";
+
+/**
+ * Map the derived business-build-brief object into the JSON-column payload the
+ * BusinessBuildBrief create/update writes expect. Pure cast/shape — the caller
+ * owns the prisma write.
+ */
+export function businessBriefJsonPayload(
+  businessBrief: ReturnType<typeof legacyFeatureBuildBriefToBusinessBuildBriefInput>,
+) {
+  return {
+    affectedPeople: businessBrief.affectedPeople as unknown as Prisma.InputJsonValue,
+    sourceEvidence: businessBrief.sourceEvidence as unknown as Prisma.InputJsonValue,
+    technicalInterpretation: businessBrief.technicalInterpretation as unknown as Prisma.InputJsonValue,
+    riskProfile: businessBrief.riskProfile as unknown as Prisma.InputJsonValue,
+    hiveReadiness: businessBrief.hiveReadiness as unknown as Prisma.InputJsonValue,
+  };
+}
+
+/**
+ * Extract a persisted `sourceCurrency` sub-object from an opaque
+ * `buildExecState` value, returning null unless it is a plain object carrying a
+ * plain-object `sourceCurrency`. Pure guard/projection over unknown JSON.
+ */
+export function readPersistedSourceCurrency(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const sourceCurrency = (value as { sourceCurrency?: unknown }).sourceCurrency;
+  if (!sourceCurrency || typeof sourceCurrency !== "object" || Array.isArray(sourceCurrency)) {
+    return null;
+  }
+  return sourceCurrency;
+}
+
+/**
+ * Derive the PhaseHandoff context — the from/to agent ids and the evidence
+ * digest (one-line summary per populated build artifact field) — for a phase
+ * transition. Pure derivation over the build's artifact fields; the caller owns
+ * the prisma.phaseHandoff.create write and supplies the gateResult/summary.
+ */
+export function derivePhaseHandoffContext(input: {
+  currentPhase: string;
+  targetPhase: string;
+  build: {
+    designDoc: unknown;
+    designReview: unknown;
+    buildPlan: unknown;
+    planReview: unknown;
+    verificationOut: unknown;
+    acceptanceMet: unknown;
+  };
+}): {
+  fromAgent: string;
+  toAgent: string;
+  evidenceFields: string[];
+  evidenceDigest: Record<string, string>;
+} {
+  const { currentPhase, targetPhase, build } = input;
+  const PHASE_AGENT: Record<string, string> = {
+    ideate: "build-specialist",
+    plan: "ea-architect",
+    build: "build-specialist",
+    review: "ops-coordinator",
+    ship: "platform-engineer",
+  };
+  const fromAgent = PHASE_AGENT[currentPhase] ?? "build-specialist";
+  const toAgent = PHASE_AGENT[targetPhase] ?? "build-specialist";
+
+  // Build evidence digest — one-line summary per populated field
+  const evidenceFields: string[] = [];
+  const evidenceDigest: Record<string, string> = {};
+  if (build.designDoc) { evidenceFields.push("designDoc"); evidenceDigest.designDoc = "Design document saved"; }
+  if (build.designReview) {
+    evidenceFields.push("designReview");
+    const review = build.designReview as Record<string, unknown>;
+    evidenceDigest.designReview = `${review.decision ?? "reviewed"} — ${String(review.summary ?? "").slice(0, 100)}`;
+  }
+  if (build.buildPlan) { evidenceFields.push("buildPlan"); evidenceDigest.buildPlan = "Implementation plan saved"; }
+  if (build.planReview) {
+    evidenceFields.push("planReview");
+    const review = build.planReview as Record<string, unknown>;
+    evidenceDigest.planReview = `${review.decision ?? "reviewed"} — ${String(review.summary ?? "").slice(0, 100)}`;
+  }
+  if (build.verificationOut) {
+    evidenceFields.push("verificationOut");
+    const v = build.verificationOut as Record<string, unknown>;
+    evidenceDigest.verificationOut = `typecheck: ${v.typecheckPassed ? "pass" : "fail"}`;
+  }
+  if (build.acceptanceMet) {
+    evidenceFields.push("acceptanceMet");
+    evidenceDigest.acceptanceMet = Array.isArray(build.acceptanceMet)
+      ? `${(build.acceptanceMet as Array<{ met?: boolean }>).filter(c => c.met).length}/${(build.acceptanceMet as unknown[]).length} criteria met`
+      : "Evaluated";
+  }
+
+  return { fromAgent, toAgent, evidenceFields, evidenceDigest };
+}
+
+/**
+ * Classify the resume-implementation outcome mode from the recovery inputs.
+ * Pure decision ladder — no DB, no side effects.
+ */
+export function deriveResumeImplementationMode(args: {
+  phase: BuildPhase;
+  taskCount: number;
+  resetTasks: number;
+  verificationFailed: boolean;
+}): ResumeImplementationMode {
+  if (args.resetTasks > 0) {
+    return "reset-blocked";
+  }
+  if (args.taskCount === 0) {
+    return "replan-and-dispatch";
+  }
+  if (args.phase === "review" && args.verificationFailed) {
+    return "rerun-verification";
+  }
+  return "already-running";
+}
+
+/**
+ * Format the operator-facing message for a resume-implementation outcome. Pure
+ * string formatting over the derived mode.
+ */
+export function formatResumeImplementationOutcomeMessage(
+  mode: ResumeImplementationMode,
+  resetTasks: number,
+): string {
+  if (mode === "reset-blocked") {
+    return `Reset ${resetTasks} task${resetTasks === 1 ? "" : "s"} to BLOCKED; queued implementation resume.`;
+  }
+  if (mode === "replan-and-dispatch") {
+    return "No persisted task rows were reset; queued implementation dispatch from the current plan.";
+  }
+  if (mode === "rerun-verification") {
+    return "Cleared verification output; queued verification recovery through the existing implementation resume path.";
+  }
+  return "Resume request recorded; implementation already has observable work in progress.";
+}


### PR DESCRIPTION
## What

Build slice of **BI-OPT-FAT-ACTIONS**. Moves the pure, side-effect-free logic out of the largest fat action file, `apps/web/lib/actions/build.ts`, into a new domain-core module — a **pure MOVE, behavior byte-for-byte preserved**, mirroring the merged **EA slice #3118** (`lib/ea/ea-core.ts`) and **CRM slice #3125** (`lib/crm/crm-core.ts`).

`build.ts` LOC: **1,807 → 1,726** (below its 1,808 module-size baseline — the shrink passes the ratchet, no baseline edit).

New module `apps/web/lib/build/build-actions-core.ts` (156 LOC, < 800 ceiling) exports five pure helpers, extracted verbatim:

| Helper | Was in build.ts | Nature |
| --- | --- | --- |
| `businessBriefJsonPayload` | `updateFeatureBrief` | JSON-column projection/mapping |
| `readPersistedSourceCurrency` | `autoExecuteBuild` (updateState) | `buildExecState` sourceCurrency guard |
| `derivePhaseHandoffContext` | `advanceBuildPhase` (inline block) | from/to agent map + evidence-digest derivation |
| `deriveResumeImplementationMode` | `resumeBuildImplementation` | resume-mode decision ladder |
| `formatResumeImplementationOutcomeMessage` | `resumeBuildImplementation` | operator-message formatting |

All orchestration (auth via `requireBuildAccess`, prisma, `$transaction`, `revalidatePath`/`revalidatePortalContextForBuild`, Inngest sends, the `"use server"` wrappers) **stays in build.ts**, which imports the helpers back.

## Behavior preservation

- Identical bodies, unchanged call sites, no server-action contract or signature change.
- The existing **`build-governed.test.ts` behavior pin passes UNCHANGED** (no edits) — the regression guard, exactly as `ea.test.ts`/`crm.test.ts` stayed untouched in their slices.
- **13 new focused unit test cases** in `build-actions-core.test.ts` exercise the now-pure helpers directly (40+ assertions). Combined run: **34 tests, all green** (13 core + 21 governed).

## Dead-import sweep (the #3125 lesson)

After extraction I grepped `build.ts` for **every** imported-back symbol and confirmed each appears at a call site **outside** the import statement. The five helpers are each still called in build.ts. The only casualty was the `ResumeImplementationMode` **type** import — its sole users (`deriveResumeImplementationMode` / `formatResumeImplementationOutcomeMessage`) moved into the core module, so I removed it from the `progress-visibility-types` import. **build.ts ships with zero unused imports** (verified by word-boundary grep post-edit).

## Verification (source-only worktree)

- Junctioned `node_modules` + Prisma client from a populated sibling; `cd apps/web && tsc --noEmit` (heap-raised) run to completion.
- **Zero tsc errors in `build.ts` or `build-actions-core.ts`.** The only 5 diagnostics were in untouched files (`lib/healthcare/*`, `lib/operate/issue-report-triage-runner.ts`, `lib/quality/platform-issue-reports.ts`) — stale-junctioned-Prisma artifacts (older generated client missing `@dpf/db/healthcare-*` subpaths / `stagedUntilPromoted` / `occurrenceCount`), not touched by and unrelated to this diff. The pre-commit hook then regenerated the client, confirming the staleness.
- Module-size ratchet: **PASS** (no new oversized file, no baselined file grew).

## Pure-vs-orchestration calls

Every extracted helper is standalone-pure (no `await`, no prisma/auth). Deliberately **left in build.ts** as orchestration: `businessBuildBriefEditToPersistence` usage sites (they wrap prisma writes), `callReviewerLLM` (external inference), and every `findUnique`/status-guard-on-a-DB-record (the borderline-trap precedent from EA's `getDefaultRelTypeIdForView` / CRM's DB-record status guards). `derivePhaseHandoffContext` was the one inline-block extraction — its prisma.phaseHandoff.create write and the `gateResult`/`summary` inputs stay inline; only the pure agent-map + digest derivation moved.

Design-Grounding-Decision: BI-OPT-FAT-ACTIONS

Generated with Claude Code