### PR TITLE
refactor(coworker): extract pure agent-coworker helpers into a domain-core module (BI-OPT-FAT-ACTIONS — agent-coworker slice)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -40,7 +40,7 @@ import { getCoworkerProactivityPreference } from "@/lib/actions/proactivity";
 import { resolveReadingLevelForRoute } from "@/lib/readability/policy";
 import type { QuestionPacket } from "@/lib/tak/question-packet";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
-import type { PortalContextEnvelope, PortalObjectAnchor } from "@/lib/portal-context";
+import type { PortalContextEnvelope } from "@/lib/portal-context";
 import { formatCoworkerOperationalCloseout } from "@/lib/tak/coworker-interaction-contract";
 import {
   extractInvokedSkillId,
@@ -91,6 +91,15 @@ import {
 import { filterToolsForCoworkerRuntime, buildAdvisePromptSuffix } from "./coworker-tool-filter";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { requireUser } from "./shared/guards";
+import {
+  formatPortalContextPromptSection,
+  isSubstantiveCoworkerOutput,
+  normalizePortalContextPathname,
+  normalizePortalContextRoute,
+  isPortalContextSupportedPath,
+  resolveBuildIdFromRouteContext,
+  resolveCapsuleIdFromPathname,
+} from "@/lib/coworker/agent-coworker-core";
 export { filterToolsForCoworkerRuntime };
 
 
@@ -122,15 +131,6 @@ async function buildPortalContextPromptSection(input: {
     console.warn("[portal-context] Failed to resolve coworker prompt context", error);
     return null;
   }
-}
-
-function formatPortalContextPromptSection(promptDigest: string, anchors: PortalObjectAnchor[]): string | null {
-  const digest = promptDigest.trim();
-  const anchorLine = anchors.length
-    ? `Anchors: ${anchors.map((anchor) => `${anchor.kind}:${anchor.id}`).join(", ")}`
-    : null;
-  const lines = ["--- PORTAL CONTEXT ---", digest, anchorLine].filter((line): line is string => Boolean(line));
-  return lines.length > 1 ? lines.join("\n") : null;
 }
 
 async function persistCoworkerResponseArtifact(input: {
@@ -220,47 +220,6 @@ async function persistCoworkerResponseArtifact(input: {
   } catch (error) {
     console.warn("[portal-context] Failed to persist coworker response artifact", error);
   }
-}
-
-function isSubstantiveCoworkerOutput(content: string): boolean {
-  const trimmed = content.trim();
-  if (trimmed.length < 40) return false;
-  return !/^(?:ok|yes|no|thanks|thank you|sure|got it|hello|hi|hey)$/i.test(trimmed);
-}
-
-function normalizePortalContextPathname(routeContext: string): string {
-  return routeContext.split("#")[0]?.split("?")[0] || routeContext;
-}
-
-function normalizePortalContextRoute(pathname: string): string {
-  if (pathname === "/build" || pathname.startsWith("/build/")) {
-    return pathname.startsWith("/build/work") ? "/build/work" : "/build";
-  }
-  return pathname;
-}
-
-function isPortalContextSupportedPath(pathname: string): boolean {
-  // /build and /build/work were the original surfaces. D29 (2026-05-23)
-  // extends to /platform/ai/* so the coworker on the providers/configuration
-  // pages gets the build-studio capability snapshot in its prompt and can
-  // give concrete "connect this provider" advice instead of generic
-  // "wait and try again" hedging.
-  return (
-    pathname === "/build" ||
-    pathname.startsWith("/build/work") ||
-    pathname === "/platform/ai" ||
-    pathname.startsWith("/platform/ai/")
-  );
-}
-
-function resolveBuildIdFromRouteContext(routeContext: string): string | null {
-  const hash = routeContext.match(/^\/build#([^?#/]+)$/);
-  return hash?.[1] ? decodeURIComponent(hash[1]) : null;
-}
-
-function resolveCapsuleIdFromPathname(pathname: string): string | null {
-  const match = pathname.match(/^\/build\/work\/([^/]+)$/);
-  return match?.[1] ? decodeURIComponent(match[1]) : null;
 }
 
 /**

--- a/apps/web/lib/coworker/agent-coworker-core.test.ts
+++ b/apps/web/lib/coworker/agent-coworker-core.test.ts
@@ -1,0 +1,130 @@
+// apps/web/lib/coworker/agent-coworker-core.test.ts
+//
+// Unit tests for the pure agent-coworker domain helpers extracted from
+// lib/actions/agent-coworker.ts (BI-OPT-FAT-ACTIONS, agent-coworker slice).
+// These functions are side-effect-free (no prisma / auth / Next.js), so they
+// are exercised directly here.
+import { describe, it, expect } from "vitest";
+import type { PortalObjectAnchor } from "@/lib/portal-context";
+import {
+  formatPortalContextPromptSection,
+  isSubstantiveCoworkerOutput,
+  normalizePortalContextPathname,
+  normalizePortalContextRoute,
+  isPortalContextSupportedPath,
+  resolveBuildIdFromRouteContext,
+  resolveCapsuleIdFromPathname,
+} from "./agent-coworker-core";
+
+function anchor(kind: string, id: string): PortalObjectAnchor {
+  return { kind, id } as PortalObjectAnchor;
+}
+
+describe("formatPortalContextPromptSection", () => {
+  it("emits a header + digest and an anchor line when anchors are present", () => {
+    const section = formatPortalContextPromptSection("A digest.", [
+      anchor("build", "FB-1"),
+      anchor("capsule", "WC-2"),
+    ]);
+    expect(section).toBe(
+      "--- PORTAL CONTEXT ---\nA digest.\nAnchors: build:FB-1, capsule:WC-2",
+    );
+  });
+
+  it("omits the anchor line when there are no anchors but still renders the digest", () => {
+    const section = formatPortalContextPromptSection("  Only a digest  ", []);
+    expect(section).toBe("--- PORTAL CONTEXT ---\nOnly a digest");
+  });
+
+  it("returns null when the digest is empty and there are no anchors (only the header survives)", () => {
+    expect(formatPortalContextPromptSection("   ", [])).toBeNull();
+  });
+});
+
+describe("isSubstantiveCoworkerOutput", () => {
+  it("rejects content shorter than 40 chars", () => {
+    expect(isSubstantiveCoworkerOutput("too short")).toBe(false);
+  });
+
+  it("rejects trivial social acknowledgements", () => {
+    expect(isSubstantiveCoworkerOutput("Thanks")).toBe(false);
+    expect(isSubstantiveCoworkerOutput("GOT IT")).toBe(false);
+  });
+
+  it("accepts a substantive, sufficiently long response", () => {
+    expect(
+      isSubstantiveCoworkerOutput(
+        "Here is a real answer that is well beyond the length floor and carries content.",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("normalizePortalContextPathname", () => {
+  it("strips hash and query fragments", () => {
+    expect(normalizePortalContextPathname("/build#FB-1?x=1")).toBe("/build");
+    expect(normalizePortalContextPathname("/platform/ai?tab=providers")).toBe("/platform/ai");
+  });
+
+  it("returns the route unchanged when there is no fragment", () => {
+    expect(normalizePortalContextPathname("/build/work/WC-1")).toBe("/build/work/WC-1");
+  });
+});
+
+describe("normalizePortalContextRoute", () => {
+  it("collapses build-work paths to /build/work", () => {
+    expect(normalizePortalContextRoute("/build/work/WC-1")).toBe("/build/work");
+  });
+
+  it("collapses other build paths to /build", () => {
+    expect(normalizePortalContextRoute("/build")).toBe("/build");
+    expect(normalizePortalContextRoute("/build/anything")).toBe("/build");
+  });
+
+  it("passes non-build paths through unchanged", () => {
+    expect(normalizePortalContextRoute("/platform/ai")).toBe("/platform/ai");
+  });
+});
+
+describe("isPortalContextSupportedPath", () => {
+  it("accepts build and build-work surfaces", () => {
+    expect(isPortalContextSupportedPath("/build")).toBe(true);
+    expect(isPortalContextSupportedPath("/build/work/WC-1")).toBe(true);
+  });
+
+  it("accepts the /platform/ai family (D29)", () => {
+    expect(isPortalContextSupportedPath("/platform/ai")).toBe(true);
+    expect(isPortalContextSupportedPath("/platform/ai/providers")).toBe(true);
+  });
+
+  it("rejects unrelated surfaces", () => {
+    expect(isPortalContextSupportedPath("/workspace")).toBe(false);
+    expect(isPortalContextSupportedPath("/crm")).toBe(false);
+  });
+});
+
+describe("resolveBuildIdFromRouteContext", () => {
+  it("extracts and decodes a build id from a /build#<id> hash route", () => {
+    expect(resolveBuildIdFromRouteContext("/build#FB-1")).toBe("FB-1");
+    expect(resolveBuildIdFromRouteContext("/build#FB%2D2")).toBe("FB-2");
+  });
+
+  it("returns null when the shape does not match", () => {
+    expect(resolveBuildIdFromRouteContext("/build")).toBeNull();
+    expect(resolveBuildIdFromRouteContext("/build/work/WC-1")).toBeNull();
+    expect(resolveBuildIdFromRouteContext("/build#a/b")).toBeNull();
+  });
+});
+
+describe("resolveCapsuleIdFromPathname", () => {
+  it("extracts and decodes a capsule id from a /build/work/<id> path", () => {
+    expect(resolveCapsuleIdFromPathname("/build/work/WC-1")).toBe("WC-1");
+    expect(resolveCapsuleIdFromPathname("/build/work/WC%2D2")).toBe("WC-2");
+  });
+
+  it("returns null when the shape does not match", () => {
+    expect(resolveCapsuleIdFromPathname("/build/work")).toBeNull();
+    expect(resolveCapsuleIdFromPathname("/build/work/WC-1/extra")).toBeNull();
+    expect(resolveCapsuleIdFromPathname("/build")).toBeNull();
+  });
+});

--- a/apps/web/lib/coworker/agent-coworker-core.ts
+++ b/apps/web/lib/coworker/agent-coworker-core.ts
@@ -1,0 +1,62 @@
+// apps/web/lib/coworker/agent-coworker-core.ts
+//
+// Pure (no prisma / auth / Next.js) domain helpers for the agent-coworker
+// server actions: portal-context path normalization, route/build/capsule id
+// derivation from a route context, portal-context prompt-section formatting,
+// and the substantive-output guard used before persisting a response artifact.
+// Extracted verbatim from lib/actions/agent-coworker.ts (BI-OPT-FAT-ACTIONS,
+// agent-coworker slice) so the deterministic domain logic lives in the coworker
+// domain layer and is unit-testable on its own. Behavior-preserving relocation
+// — identical bodies.
+
+import type { PortalObjectAnchor } from "@/lib/portal-context";
+
+export function formatPortalContextPromptSection(promptDigest: string, anchors: PortalObjectAnchor[]): string | null {
+  const digest = promptDigest.trim();
+  const anchorLine = anchors.length
+    ? `Anchors: ${anchors.map((anchor) => `${anchor.kind}:${anchor.id}`).join(", ")}`
+    : null;
+  const lines = ["--- PORTAL CONTEXT ---", digest, anchorLine].filter((line): line is string => Boolean(line));
+  return lines.length > 1 ? lines.join("\n") : null;
+}
+
+export function isSubstantiveCoworkerOutput(content: string): boolean {
+  const trimmed = content.trim();
+  if (trimmed.length < 40) return false;
+  return !/^(?:ok|yes|no|thanks|thank you|sure|got it|hello|hi|hey)$/i.test(trimmed);
+}
+
+export function normalizePortalContextPathname(routeContext: string): string {
+  return routeContext.split("#")[0]?.split("?")[0] || routeContext;
+}
+
+export function normalizePortalContextRoute(pathname: string): string {
+  if (pathname === "/build" || pathname.startsWith("/build/")) {
+    return pathname.startsWith("/build/work") ? "/build/work" : "/build";
+  }
+  return pathname;
+}
+
+export function isPortalContextSupportedPath(pathname: string): boolean {
+  // /build and /build/work were the original surfaces. D29 (2026-05-23)
+  // extends to /platform/ai/* so the coworker on the providers/configuration
+  // pages gets the build-studio capability snapshot in its prompt and can
+  // give concrete "connect this provider" advice instead of generic
+  // "wait and try again" hedging.
+  return (
+    pathname === "/build" ||
+    pathname.startsWith("/build/work") ||
+    pathname === "/platform/ai" ||
+    pathname.startsWith("/platform/ai/")
+  );
+}
+
+export function resolveBuildIdFromRouteContext(routeContext: string): string | null {
+  const hash = routeContext.match(/^\/build#([^?#/]+)$/);
+  return hash?.[1] ? decodeURIComponent(hash[1]) : null;
+}
+
+export function resolveCapsuleIdFromPathname(pathname: string): string | null {
+  const match = pathname.match(/^\/build\/work\/([^/]+)$/);
+  return match?.[1] ? decodeURIComponent(match[1]) : null;
+}


### PR DESCRIPTION
## Summary

Pure **MOVE** — behavior byte-for-byte preserved. Mirrors the merged **EA slice #3118** and the **CRM #3125** + **Build #3126** slices of BI-OPT-FAT-ACTIONS. Pushes side-effect-free logic out of the largest fat action file, `apps/web/lib/actions/agent-coworker.ts`, into a new focused domain module `apps/web/lib/coworker/agent-coworker-core.ts`, and imports it back.

**No logic changes, no signature changes, no server-action contract changes.** Helper bodies relocated verbatim; call sites unchanged. All orchestration (`"use server"`, `auth()`/`requireUser`, prisma, `$transaction`, `revalidatePath`, Inngest, dynamic imports) stays in `agent-coworker.ts`.

`agent-coworker.ts`: **2778 → 2736 LOC** (shrinks below its 2778 module-size baseline — passes the ratchet). New core module: **62 LOC** (< 800 soft ceiling).

## Extracted (bodies verbatim → `agent-coworker-core.ts`)
- `formatPortalContextPromptSection`
- `isSubstantiveCoworkerOutput`
- `normalizePortalContextPathname`
- `normalizePortalContextRoute`
- `isPortalContextSupportedPath`
- `resolveBuildIdFromRouteContext`
- `resolveCapsuleIdFromPathname`

These 7 are genuinely standalone-pure (only string/regex ops + one `PortalObjectAnchor` type). Everything async/DB stays put — including the **borderline** `summariseIdeateOutcome`, which *looks* summary-shaped but `await`s a `FeatureBuild` lookup, so it is orchestration and was deliberately left in `agent-coworker.ts` (same call as EA's `getDefaultRelTypeIdForView` / CRM's DB-status guards).

## Unused-import guard (the trap that blocked CRM #3125)
- Removed the now-**dead** `PortalObjectAnchor` type import — its only user (`formatPortalContextPromptSection`) moved to core. `PortalContextEnvelope` stays (still used 3×).
- Verified **every** imported-back symbol has ≥1 caller remaining outside the import line (word-boundary grep: each shows exactly 2 occurrences = import + 1 live caller in `buildPortalContextPromptSection` / `persistCoworkerResponseArtifact`, both of which stay).
- Ran a deterministic whole-file unused-import scan: my diff introduces **zero** unused imports. (The scan surfaces 3 imports — `ToolDefinition`, `getTaskType`, `ensurePerformanceProfile` — that are **pre-existing on origin/main**, identical import lines outside my diff; not introduced here.)

## Verification
- **Existing behavior tests stayed GREEN and UNCHANGED** (not edited): `agent-coworker.test.ts`, `agent-coworker-server.test.ts`, `agent-coworker-external.test.ts`, `agent-coworker-tool-filter.test.ts` — **4 files, 25 tests pass**. This is the behavior pin, exactly as EA/CRM/Build `.test.ts` stayed untouched.
- **New** `agent-coworker-core.test.ts` — 18 focused unit cases for the extracted helpers, all pass.
- `tsc --noEmit` on `apps/web`: **zero errors in the touched files**. The only 3 errors are pre-existing, unrelated `@dpf/db/healthcare-*` submodule-resolution errors (stale generated Prisma client in the source-only worktree, predating current main's `feat(healthcare)` commits) — not touched by this PR.

Design-Grounding-Decision: BI-OPT-FAT-ACTIONS
Process-Spine-Decision: Pure behavior-preserving relocation of side-effect-free helpers into the coworker domain layer; no new capability, contract, or data-model surface — identical bodies, same call sites, existing behavior tests unchanged and green. No spec/plan/doc touch warranted (mirrors merged EA slice #3118).

Generated with Claude Code