### PR TITLE
fix(web): ignore code-frame lines in log signatures

### DIFF
--- a/apps/web/lib/observability/log-signature.test.ts
+++ b/apps/web/lib/observability/log-signature.test.ts
@@ -35,6 +35,15 @@ describe("isErrorLine", () => {
     expect(isErrorLine("final error sending batch, no retries left")).toBe(false);
   });
 
+  it("rejects compiler code-frame source lines with error-like import paths", () => {
+    expect(
+      isErrorLine('2 | import { getErrorMessage } from "@/lib/shared/get-error-message";'),
+    ).toBe(false);
+    expect(
+      isErrorLine('\x1b[90m329 |\x1b[0m       console.error("[tool-trace] wwmd.voice.dispatch.failed")'),
+    ).toBe(false);
+  });
+
   it("rejects empty/clean lines", () => {
     expect(isErrorLine("")).toBe(false);
     expect(isErrorLine("request completed in 12ms")).toBe(false);

--- a/apps/web/lib/observability/log-signature.ts
+++ b/apps/web/lib/observability/log-signature.ts
@@ -60,15 +60,19 @@ const OUTBOUND_REQUEST_NOISE = /\[responses-adapter\]\s+REQUEST|Error Report PIR
 // class minted ~6 duplicate BI-PIR-* during the 2026-07-15 self-upgrade window.
 const DB_LIFECYCLE_NOISE =
   /database system is (starting up|shutting down)|terminating connection due to administrator command|error scraping (target|dsn)/i;
+const ANSI_COLOR = /\x1b\[[0-9;]*m/g;
+const CODE_FRAME_LINE = /^\s*\d+\s*\|/;
 
 /** True when a line is a genuine error worth clustering (not info/debug/self-noise). */
 export function isErrorLine(line: string): boolean {
   if (!line) return false;
-  if (SELF_NOISE.test(line)) return false;
-  if (INFO_DEBUG.test(line)) return false;
-  if (OUTBOUND_REQUEST_NOISE.test(line)) return false;
-  if (DB_LIFECYCLE_NOISE.test(line)) return false;
-  return ERROR_TOKEN.test(line);
+  const plain = line.replace(ANSI_COLOR, "");
+  if (CODE_FRAME_LINE.test(plain)) return false;
+  if (SELF_NOISE.test(plain)) return false;
+  if (INFO_DEBUG.test(plain)) return false;
+  if (OUTBOUND_REQUEST_NOISE.test(plain)) return false;
+  if (DB_LIFECYCLE_NOISE.test(plain)) return false;
+  return ERROR_TOKEN.test(plain);
 }
 
 /** Collapse a log line to a stable template by masking variable tokens. */


### PR DESCRIPTION
## Summary

Fixes `BI-PIR-fd328b5e` by preventing the log-signature classifier from treating compiler source-code frame lines as genuine error signatures. The scanner now strips ANSI coloring before classification and ignores `N | ...` code-frame rows, so paths like `@/lib/shared/get-error-message` do not create false operational bugs.

## Root Cause

The existing whole-word `error` matcher correctly ignored `getErrorMessage`, but it still matched hyphen-delimited import paths such as `get-error-message` in compiler code-frame output. That allowed a source snippet line to become a `PlatformIssueReport` and then a backlog item.

## Validation

- `pnpm --filter web exec vitest run lib/observability/log-signature.test.ts` - 13 tests passed
- `pnpm --filter web exec vitest run lib/queue/functions/log-signature-scanner.test.ts` - 5 tests passed
- `pnpm --filter web build` - passed; emitted existing Turbopack warnings, no errors
- Commit hook: staged Gitleaks scan passed; scoped typecheck passed

Process-Spine-Decision: no durable spec/doc update needed; this is a narrow observability classifier bugfix with regression coverage and no architecture or user-facing contract change.
