### PR TITLE
refactor(compliance): extract pure compliance helpers into a domain-core module (BI-OPT-FAT-ACTIONS — compliance slice)

### DIFF
--- a/apps/web/lib/actions/compliance.ts
+++ b/apps/web/lib/actions/compliance.ts
@@ -18,14 +18,24 @@ import {
 // @/lib/actions/compliance-helpers directly.
 import {
   generateRegulationId, generateObligationId, generateControlId,
-  generateAssessmentId, generateIncidentId, generateActionId,
-  generateAuditId, generateFindingId, generateEvidenceId, generateSubmissionId,
   validateRegulationInput, validateObligationInput, validateControlInput,
   type RegulationInput, type ObligationInput, type ControlInput,
   type RiskAssessmentInput, type IncidentInput, type CorrectiveActionInput,
   type AuditInput, type FindingInput, type EvidenceInput, type SubmissionInput,
   type OnboardingInput,
 } from "@/lib/compliance-types";
+import {
+  regulationCreateFields, regulationUpdateFields,
+  obligationCreateFields, obligationUpdateFields,
+  controlCreateFields, controlUpdateFields,
+  riskAssessmentCreateFields, riskAssessmentUpdateFields,
+  incidentCreateFields, incidentUpdateFields,
+  correctiveActionCreateFields, correctiveActionUpdateFields,
+  auditCreateFields, auditUpdateFields,
+  auditFindingCreateFields, auditFindingUpdateFields,
+  evidenceCreateFields, submissionCreateFields, submissionUpdateFields,
+  mapRegulationSummaries,
+} from "@/lib/compliance/compliance-core";
 
 // ─── Regulation ─────────────────────────────────────────────────────────────
 
@@ -55,20 +65,10 @@ export async function createRegulation(input: RegulationInput): Promise<Complian
   if (error) return { ok: false, message: error };
 
   const employeeId = await getSessionEmployeeId();
-  const regulationId = generateRegulationId();
 
   const record = await prisma.regulation.create({
     data: {
-      regulationId,
-      name: input.name.trim(),
-      shortName: input.shortName.trim(),
-      jurisdiction: input.jurisdiction.trim(),
-      industry: input.industry ?? null,
-      sourceType: input.sourceType ?? "external",
-      effectiveDate: input.effectiveDate ?? null,
-      reviewDate: input.reviewDate ?? null,
-      sourceUrl: input.sourceUrl ?? null,
-      notes: input.notes ?? null,
+      ...regulationCreateFields(input),
       ...(input.applicability != null && {
         applicability: input.applicability as unknown as Prisma.InputJsonValue,
       }),
@@ -85,15 +85,7 @@ export async function updateRegulation(id: string, input: Partial<RegulationInpu
   const employeeId = await getSessionEmployeeId();
 
   await prisma.regulation.update({ where: { id }, data: {
-    ...(input.name !== undefined && { name: input.name.trim() }),
-    ...(input.shortName !== undefined && { shortName: input.shortName.trim() }),
-    ...(input.jurisdiction !== undefined && { jurisdiction: input.jurisdiction.trim() }),
-    ...(input.industry !== undefined && { industry: input.industry }),
-    ...(input.sourceType !== undefined && { sourceType: input.sourceType }),
-    ...(input.effectiveDate !== undefined && { effectiveDate: input.effectiveDate }),
-    ...(input.reviewDate !== undefined && { reviewDate: input.reviewDate }),
-    ...(input.sourceUrl !== undefined && { sourceUrl: input.sourceUrl }),
-    ...(input.notes !== undefined && { notes: input.notes }),
+    ...regulationUpdateFields(input),
     ...(input.applicability != null && {
       applicability: input.applicability as unknown as Prisma.InputJsonValue,
     }),
@@ -202,20 +194,7 @@ export async function createObligation(input: ObligationInput): Promise<Complian
 
   const employeeId = await getSessionEmployeeId();
   const record = await prisma.obligation.create({
-    data: {
-      obligationId: generateObligationId(),
-      regulationId: input.regulationId,
-      title: input.title.trim(),
-      description: input.description ?? null,
-      reference: input.reference ?? null,
-      category: input.category ?? null,
-      frequency: input.frequency ?? null,
-      applicability: input.applicability ?? null,
-      deliverableType: input.deliverableType ?? null,
-      penaltySummary: input.penaltySummary ?? null,
-      ownerEmployeeId: input.ownerEmployeeId ?? null,
-      reviewDate: input.reviewDate ?? null,
-    },
+    data: obligationCreateFields(input),
   });
 
   await logComplianceAction("obligation", record.id, "created", employeeId, null);
@@ -227,18 +206,7 @@ export async function updateObligation(id: string, input: Partial<ObligationInpu
   await requireManageCompliance();
   const employeeId = await getSessionEmployeeId();
 
-  await prisma.obligation.update({ where: { id }, data: {
-    ...(input.title !== undefined && { title: input.title.trim() }),
-    ...(input.description !== undefined && { description: input.description }),
-    ...(input.reference !== undefined && { reference: input.reference }),
-    ...(input.category !== undefined && { category: input.category }),
-    ...(input.frequency !== undefined && { frequency: input.frequency }),
-    ...(input.applicability !== undefined && { applicability: input.applicability }),
-    ...(input.deliverableType !== undefined && { deliverableType: input.deliverableType }),
-    ...(input.penaltySummary !== undefined && { penaltySummary: input.penaltySummary }),
-    ...(input.ownerEmployeeId !== undefined && { ownerEmployeeId: input.ownerEmployeeId }),
-    ...(input.reviewDate !== undefined && { reviewDate: input.reviewDate }),
-  }});
+  await prisma.obligation.update({ where: { id }, data: obligationUpdateFields(input) });
 
   await logComplianceAction("obligation", id, "updated", employeeId, null);
   revalidatePath("/compliance");
@@ -298,18 +266,7 @@ export async function createControl(input: ControlInput): Promise<ComplianceActi
 
   const employeeId = await getSessionEmployeeId();
   const record = await prisma.control.create({
-    data: {
-      controlId: generateControlId(),
-      title: input.title.trim(),
-      controlType: input.controlType,
-      description: input.description ?? null,
-      implementationStatus: input.implementationStatus ?? "planned",
-      ownerEmployeeId: input.ownerEmployeeId ?? null,
-      reviewFrequency: input.reviewFrequency ?? null,
-      nextReviewDate: input.nextReviewDate ?? null,
-      effectiveness: input.effectiveness ?? null,
-      catalogKey: input.catalogKey ?? null,
-    },
+    data: controlCreateFields(input),
   });
 
   await logComplianceAction("control", record.id, "created", employeeId, null);
@@ -321,17 +278,7 @@ export async function updateControl(id: string, input: Partial<ControlInput>): P
   await requireManageCompliance();
   const employeeId = await getSessionEmployeeId();
 
-  await prisma.control.update({ where: { id }, data: {
-    ...(input.title !== undefined && { title: input.title.trim() }),
-    ...(input.controlType !== undefined && { controlType: input.controlType }),
-    ...(input.description !== undefined && { description: input.description }),
-    ...(input.implementationStatus !== undefined && { implementationStatus: input.implementationStatus }),
-    ...(input.ownerEmployeeId !== undefined && { ownerEmployeeId: input.ownerEmployeeId }),
-    ...(input.reviewFrequency !== undefined && { reviewFrequency: input.reviewFrequency }),
-    ...(input.nextReviewDate !== undefined && { nextReviewDate: input.nextReviewDate }),
-    ...(input.effectiveness !== undefined && { effectiveness: input.effectiveness }),
-    ...(input.catalogKey !== undefined && { catalogKey: input.catalogKey }),
-  }});
+  await prisma.control.update({ where: { id }, data: controlUpdateFields(input) });
 
   await logComplianceAction("control", id, "updated", employeeId, null);
   revalidatePath("/compliance");
@@ -403,19 +350,7 @@ export async function createRiskAssessment(input: RiskAssessmentInput): Promise<
 
   const employeeId = await getSessionEmployeeId();
   const record = await prisma.riskAssessment.create({
-    data: {
-      assessmentId: generateAssessmentId(),
-      title: input.title.trim(),
-      hazard: input.hazard.trim(),
-      likelihood: input.likelihood,
-      severity: input.severity,
-      inherentRisk: input.inherentRisk,
-      scope: input.scope ?? null,
-      residualRisk: input.residualRisk ?? null,
-      assessedByEmployeeId: input.assessedByEmployeeId ?? employeeId,
-      nextReviewDate: input.nextReviewDate ?? null,
-      notes: input.notes ?? null,
-    },
+    data: riskAssessmentCreateFields(input, employeeId),
   });
 
   await logComplianceAction("risk-assessment", record.id, "created", employeeId, null);
@@ -427,18 +362,7 @@ export async function updateRiskAssessment(id: string, input: Partial<RiskAssess
   await requireManageCompliance();
   const employeeId = await getSessionEmployeeId();
 
-  await prisma.riskAssessment.update({ where: { id }, data: {
-    ...(input.title !== undefined && { title: input.title.trim() }),
-    ...(input.hazard !== undefined && { hazard: input.hazard.trim() }),
-    ...(input.likelihood !== undefined && { likelihood: input.likelihood }),
-    ...(input.severity !== undefined && { severity: input.severity }),
-    ...(input.inherentRisk !== undefined && { inherentRisk: input.inherentRisk }),
-    ...(input.scope !== undefined && { scope: input.scope }),
-    ...(input.residualRisk !== undefined && { residualRisk: input.residualRisk }),
-    ...(input.assessedByEmployeeId !== undefined && { assessedByEmployeeId: input.assessedByEmployeeId }),
-    ...(input.nextReviewDate !== undefined && { nextReviewDate: input.nextReviewDate }),
-    ...(input.notes !== undefined && { notes: input.notes }),
-  }});
+  await prisma.riskAssessment.update({ where: { id }, data: riskAssessmentUpdateFields(input) });
 
   await logComplianceAction("risk-assessment", id, "updated", employeeId, null);
   revalidatePath("/compliance");
@@ -508,20 +432,7 @@ export async function createIncident(input: IncidentInput): Promise<ComplianceAc
 
   const employeeId = await getSessionEmployeeId();
   const record = await prisma.complianceIncident.create({
-    data: {
-      incidentId: generateIncidentId(),
-      title: input.title.trim(),
-      description: input.description ?? null,
-      occurredAt: input.occurredAt,
-      detectedAt: input.detectedAt ?? null,
-      severity: input.severity,
-      category: input.category ?? null,
-      regulatoryNotifiable: input.regulatoryNotifiable ?? false,
-      notificationDeadline: input.notificationDeadline ?? null,
-      rootCause: input.rootCause ?? null,
-      riskAssessmentId: input.riskAssessmentId ?? null,
-      reportedByEmployeeId: input.reportedByEmployeeId ?? employeeId,
-    },
+    data: incidentCreateFields(input, employeeId),
   });
 
   // Auto-create calendar deadline for notifiable incidents
@@ -542,17 +453,7 @@ export async function updateIncident(id: string, input: Partial<IncidentInput> &
   await requireManageCompliance();
   const employeeId = await getSessionEmployeeId();
 
-  await prisma.complianceIncident.update({ where: { id }, data: {
-    ...(input.title !== undefined && { title: input.title.trim() }),
-    ...(input.description !== undefined && { description: input.description }),
-    ...(input.severity !== undefined && { severity: input.severity }),
-    ...(input.category !== undefined && { category: input.category }),
-    ...(input.regulatoryNotifiable !== undefined && { regulatoryNotifiable: input.regulatoryNotifiable }),
-    ...(input.notificationDeadline !== undefined && { notificationDeadline: input.notificationDeadline }),
-    ...(input.notifiedAt !== undefined && { notifiedAt: input.notifiedAt }),
-    ...(input.rootCause !== undefined && { rootCause: input.rootCause }),
-    ...(input.riskAssessmentId !== undefined && { riskAssessmentId: input.riskAssessmentId }),
-  }});
+  await prisma.complianceIncident.update({ where: { id }, data: incidentUpdateFields(input) });
 
   await logComplianceAction("incident", id, "updated", employeeId, null);
   revalidatePath("/compliance");
@@ -598,17 +499,7 @@ export async function createCorrectiveAction(input: CorrectiveActionInput): Prom
 
   const employeeId = await getSessionEmployeeId();
   const record = await prisma.correctiveAction.create({
-    data: {
-      actionId: generateActionId(),
-      title: input.title.trim(),
-      description: input.description ?? null,
-      rootCause: input.rootCause ?? null,
-      sourceType: input.sourceType,
-      incidentId: input.incidentId ?? null,
-      auditFindingId: input.auditFindingId ?? null,
-      ownerEmployeeId: input.ownerEmployeeId ?? employeeId,
-      dueDate: input.dueDate ?? null,
-    },
+    data: correctiveActionCreateFields(input, employeeId),
   });
 
   await logComplianceAction("corrective-action", record.id, "created", employeeId, null);
@@ -620,15 +511,7 @@ export async function updateCorrectiveAction(id: string, input: Partial<Correcti
   await requireManageCompliance();
   const employeeId = await getSessionEmployeeId();
 
-  await prisma.correctiveAction.update({ where: { id }, data: {
-    ...(input.title !== undefined && { title: input.title.trim() }),
-    ...(input.description !== undefined && { description: input.description }),
-    ...(input.rootCause !== undefined && { rootCause: input.rootCause }),
-    ...(input.ownerEmployeeId !== undefined && { ownerEmployeeId: input.ownerEmployeeId }),
-    ...(input.dueDate !== undefined && { dueDate: input.dueDate }),
-    ...(input.status !== undefined && { status: input.status }),
-    ...(input.completedAt !== undefined && { completedAt: input.completedAt }),
-  }});
+  await prisma.correctiveAction.update({ where: { id }, data: correctiveActionUpdateFields(input) });
 
   await logComplianceAction("corrective-action", id, "updated", employeeId, null);
   revalidatePath("/compliance");
@@ -691,16 +574,7 @@ export async function createAudit(input: AuditInput): Promise<ComplianceActionRe
 
   const employeeId = await getSessionEmployeeId();
   const record = await prisma.complianceAudit.create({
-    data: {
-      auditId: generateAuditId(),
-      title: input.title.trim(),
-      auditType: input.auditType,
-      scope: input.scope ?? null,
-      auditorName: input.auditorName ?? null,
-      auditorEmployeeId: input.auditorEmployeeId ?? null,
-      scheduledAt: input.scheduledAt ?? null,
-      notes: input.notes ?? null,
-    },
+    data: auditCreateFields(input),
   });
 
   if (input.scheduledAt && employeeId) {
@@ -716,19 +590,7 @@ export async function updateAudit(id: string, input: Partial<AuditInput> & { sta
   await requireManageCompliance();
   const employeeId = await getSessionEmployeeId();
 
-  await prisma.complianceAudit.update({ where: { id }, data: {
-    ...(input.title !== undefined && { title: input.title.trim() }),
-    ...(input.auditType !== undefined && { auditType: input.auditType }),
-    ...(input.scope !== undefined && { scope: input.scope }),
-    ...(input.auditorName !== undefined && { auditorName: input.auditorName }),
-    ...(input.auditorEmployeeId !== undefined && { auditorEmployeeId: input.auditorEmployeeId }),
-    ...(input.scheduledAt !== undefined && { scheduledAt: input.scheduledAt }),
-    ...(input.notes !== undefined && { notes: input.notes }),
-    ...(input.status !== undefined && { status: input.status }),
-    ...(input.conductedAt !== undefined && { conductedAt: input.conductedAt }),
-    ...(input.completedAt !== undefined && { completedAt: input.completedAt }),
-    ...(input.overallRating !== undefined && { overallRating: input.overallRating }),
-  }});
+  await prisma.complianceAudit.update({ where: { id }, data: auditUpdateFields(input) });
 
   await logComplianceAction("audit", id, "updated", employeeId, null);
   revalidatePath("/compliance");
@@ -741,15 +603,7 @@ export async function createAuditFinding(auditId: string, input: FindingInput): 
 
   const employeeId = await getSessionEmployeeId();
   const record = await prisma.auditFinding.create({
-    data: {
-      findingId: generateFindingId(),
-      auditId,
-      title: input.title.trim(),
-      findingType: input.findingType,
-      controlId: input.controlId ?? null,
-      description: input.description ?? null,
-      dueDate: input.dueDate ?? null,
-    },
+    data: auditFindingCreateFields(auditId, input),
   });
 
   await logComplianceAction("finding", record.id, "created", employeeId, null, { notes: `In audit ${auditId}` });
@@ -761,15 +615,7 @@ export async function updateAuditFinding(id: string, input: Partial<FindingInput
   await requireManageCompliance();
   const employeeId = await getSessionEmployeeId();
 
-  await prisma.auditFinding.update({ where: { id }, data: {
-    ...(input.title !== undefined && { title: input.title.trim() }),
-    ...(input.findingType !== undefined && { findingType: input.findingType }),
-    ...(input.controlId !== undefined && { controlId: input.controlId }),
-    ...(input.description !== undefined && { description: input.description }),
-    ...(input.dueDate !== undefined && { dueDate: input.dueDate }),
-    ...(input.status !== undefined && { status: input.status }),
-    ...(input.resolvedAt !== undefined && { resolvedAt: input.resolvedAt }),
-  }});
+  await prisma.auditFinding.update({ where: { id }, data: auditFindingUpdateFields(input) });
 
   await logComplianceAction("finding", id, "updated", employeeId, null);
   revalidatePath("/compliance");
@@ -815,17 +661,7 @@ export async function createEvidence(input: EvidenceInput): Promise<ComplianceAc
 
   const employeeId = await getSessionEmployeeId();
   const record = await prisma.complianceEvidence.create({
-    data: {
-      evidenceId: generateEvidenceId(),
-      title: input.title.trim(),
-      evidenceType: input.evidenceType,
-      description: input.description ?? null,
-      obligationId: input.obligationId ?? null,
-      controlId: input.controlId ?? null,
-      collectedByEmployeeId: input.collectedByEmployeeId ?? employeeId,
-      fileRef: input.fileRef ?? null,
-      retentionUntil: input.retentionUntil ?? null,
-    },
+    data: evidenceCreateFields(input, employeeId),
   });
 
   await logComplianceAction("evidence", record.id, "created", employeeId, null);
@@ -841,17 +677,7 @@ export async function supersedeEvidence(existingId: string, newInput: EvidenceIn
 
   const newRecord = await prisma.$transaction(async (tx) => {
     const created = await tx.complianceEvidence.create({
-      data: {
-        evidenceId: generateEvidenceId(),
-        title: newInput.title.trim(),
-        evidenceType: newInput.evidenceType,
-        description: newInput.description ?? null,
-        obligationId: newInput.obligationId ?? null,
-        controlId: newInput.controlId ?? null,
-        collectedByEmployeeId: newInput.collectedByEmployeeId ?? employeeId,
-        fileRef: newInput.fileRef ?? null,
-        retentionUntil: newInput.retentionUntil ?? null,
-      },
+      data: evidenceCreateFields(newInput, employeeId),
     });
     await tx.complianceEvidence.update({
       where: { id: existingId },
@@ -890,16 +716,7 @@ export async function createSubmission(input: SubmissionInput): Promise<Complian
 
   const employeeId = await getSessionEmployeeId();
   const record = await prisma.regulatorySubmission.create({
-    data: {
-      submissionId: generateSubmissionId(),
-      title: input.title.trim(),
-      recipientBody: input.recipientBody.trim(),
-      submissionType: input.submissionType,
-      regulationId: input.regulationId ?? null,
-      dueDate: input.dueDate ?? null,
-      submittedByEmployeeId: input.submittedByEmployeeId ?? employeeId,
-      notes: input.notes ?? null,
-    },
+    data: submissionCreateFields(input, employeeId),
   });
 
   if (input.dueDate && employeeId) {
@@ -915,20 +732,7 @@ export async function updateSubmission(id: string, input: Partial<SubmissionInpu
   await requireManageCompliance();
   const employeeId = await getSessionEmployeeId();
 
-  await prisma.regulatorySubmission.update({ where: { id }, data: {
-    ...(input.title !== undefined && { title: input.title.trim() }),
-    ...(input.recipientBody !== undefined && { recipientBody: input.recipientBody.trim() }),
-    ...(input.submissionType !== undefined && { submissionType: input.submissionType }),
-    ...(input.regulationId !== undefined && { regulationId: input.regulationId }),
-    ...(input.dueDate !== undefined && { dueDate: input.dueDate }),
-    ...(input.notes !== undefined && { notes: input.notes }),
-    ...(input.status !== undefined && { status: input.status }),
-    ...(input.submittedAt !== undefined && { submittedAt: input.submittedAt }),
-    ...(input.confirmationRef !== undefined && { confirmationRef: input.confirmationRef }),
-    ...(input.responseReceived !== undefined && { responseReceived: input.responseReceived }),
-    ...(input.responseDate !== undefined && { responseDate: input.responseDate }),
-    ...(input.responseSummary !== undefined && { responseSummary: input.responseSummary }),
-  }});
+  await prisma.regulatorySubmission.update({ where: { id }, data: submissionUpdateFields(input) });
 
   await logComplianceAction("submission", id, "updated", employeeId, null);
   revalidatePath("/compliance");
@@ -978,12 +782,7 @@ export async function getComplianceDashboard() {
     overdueActionCount,
     upcomingDeadlines,
     recentActivity,
-    regulationSummaries: regulations.map((r) => ({
-      id: r.id,
-      shortName: r.shortName,
-      jurisdiction: r.jurisdiction,
-      obligationCount: r._count.obligations,
-    })),
+    regulationSummaries: mapRegulationSummaries(regulations),
   };
 }
 

--- a/apps/web/lib/compliance/compliance-core.test.ts
+++ b/apps/web/lib/compliance/compliance-core.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import {
+  regulationCreateFields, regulationUpdateFields,
+  obligationCreateFields, obligationUpdateFields,
+  controlCreateFields, controlUpdateFields,
+  riskAssessmentCreateFields, riskAssessmentUpdateFields,
+  incidentCreateFields, incidentUpdateFields,
+  correctiveActionCreateFields, correctiveActionUpdateFields,
+  auditCreateFields, auditUpdateFields,
+  auditFindingCreateFields, auditFindingUpdateFields,
+  evidenceCreateFields, submissionCreateFields, submissionUpdateFields,
+  mapRegulationSummaries,
+} from "./compliance-core";
+
+describe("regulationCreateFields", () => {
+  it("trims name/shortName/jurisdiction and applies defaults", () => {
+    const out = regulationCreateFields({ name: "  GDPR  ", shortName: " GDPR ", jurisdiction: " EU " });
+    expect(out.name).toBe("GDPR");
+    expect(out.shortName).toBe("GDPR");
+    expect(out.jurisdiction).toBe("EU");
+    expect(out.sourceType).toBe("external"); // default
+    expect(out.industry).toBeNull();
+    expect(out.notes).toBeNull();
+    expect(out.regulationId).toMatch(/^REG-[0-9A-F]{8}$/);
+  });
+
+  it("honors provided optional fields and sourceType override", () => {
+    const eff = new Date("2026-01-01");
+    const out = regulationCreateFields({
+      name: "X", shortName: "X", jurisdiction: "US",
+      industry: "finance", sourceType: "standard", effectiveDate: eff, sourceUrl: "http://x", notes: "n",
+    });
+    expect(out.industry).toBe("finance");
+    expect(out.sourceType).toBe("standard");
+    expect(out.effectiveDate).toBe(eff);
+    expect(out.sourceUrl).toBe("http://x");
+    expect(out.notes).toBe("n");
+  });
+
+  it("never emits an applicability key (JSON cast stays at call site)", () => {
+    const out = regulationCreateFields({ name: "X", shortName: "X", jurisdiction: "US" });
+    expect("applicability" in out).toBe(false);
+  });
+});
+
+describe("regulationUpdateFields", () => {
+  it("includes only provided keys and trims strings", () => {
+    expect(regulationUpdateFields({ name: "  A  " })).toEqual({ name: "A" });
+    expect(regulationUpdateFields({})).toEqual({});
+  });
+
+  it("passes through null values explicitly set", () => {
+    expect(regulationUpdateFields({ industry: null })).toEqual({ industry: null });
+  });
+
+  it("omits applicability (handled at call site)", () => {
+    const out = regulationUpdateFields({ name: "A" });
+    expect("applicability" in out).toBe(false);
+  });
+});
+
+describe("obligationCreateFields", () => {
+  it("maps and defaults, generating an OBL id", () => {
+    const out = obligationCreateFields({ title: "  T  ", regulationId: "reg-1" });
+    expect(out.title).toBe("T");
+    expect(out.regulationId).toBe("reg-1");
+    expect(out.category).toBeNull();
+    expect(out.applicability).toBeNull();
+    expect(out.obligationId).toMatch(/^OBL-[0-9A-F]{8}$/);
+  });
+});
+
+describe("obligationUpdateFields", () => {
+  it("includes only provided keys", () => {
+    expect(obligationUpdateFields({ title: " T " })).toEqual({ title: "T" });
+    expect(obligationUpdateFields({ category: "safety" })).toEqual({ category: "safety" });
+    expect(obligationUpdateFields({})).toEqual({});
+  });
+});
+
+describe("controlCreateFields", () => {
+  it("defaults implementationStatus to planned", () => {
+    const out = controlCreateFields({ title: " C ", controlType: "preventive" });
+    expect(out.title).toBe("C");
+    expect(out.controlType).toBe("preventive");
+    expect(out.implementationStatus).toBe("planned");
+    expect(out.controlId).toMatch(/^CTL-[0-9A-F]{8}$/);
+  });
+  it("honors provided implementationStatus", () => {
+    expect(controlCreateFields({ title: "C", controlType: "detective", implementationStatus: "implemented" }).implementationStatus).toBe("implemented");
+  });
+});
+
+describe("controlUpdateFields", () => {
+  it("includes only provided keys and trims title", () => {
+    expect(controlUpdateFields({ title: " C " })).toEqual({ title: "C" });
+    expect(controlUpdateFields({})).toEqual({});
+  });
+});
+
+describe("riskAssessmentCreateFields", () => {
+  it("falls back to the session employeeId when assessedBy not given", () => {
+    const out = riskAssessmentCreateFields(
+      { title: " R ", hazard: " H ", likelihood: "likely", severity: "major", inherentRisk: "high" },
+      "emp-1",
+    );
+    expect(out.title).toBe("R");
+    expect(out.hazard).toBe("H");
+    expect(out.assessedByEmployeeId).toBe("emp-1");
+    expect(out.assessmentId).toMatch(/^RA-[0-9A-F]{8}$/);
+  });
+  it("prefers an explicit assessedByEmployeeId over the session id", () => {
+    const out = riskAssessmentCreateFields(
+      { title: "R", hazard: "H", likelihood: "rare", severity: "minor", inherentRisk: "low", assessedByEmployeeId: "emp-2" },
+      "emp-1",
+    );
+    expect(out.assessedByEmployeeId).toBe("emp-2");
+  });
+});
+
+describe("riskAssessmentUpdateFields", () => {
+  it("includes only provided keys, trimming title/hazard", () => {
+    expect(riskAssessmentUpdateFields({ title: " R ", hazard: " H " })).toEqual({ title: "R", hazard: "H" });
+    expect(riskAssessmentUpdateFields({})).toEqual({});
+  });
+});
+
+describe("incidentCreateFields", () => {
+  it("maps fields, defaults regulatoryNotifiable false, falls back reportedBy", () => {
+    const occurredAt = new Date("2026-03-01");
+    const out = incidentCreateFields({ title: " I ", occurredAt, severity: "high" }, "emp-9");
+    expect(out.title).toBe("I");
+    expect(out.occurredAt).toBe(occurredAt);
+    expect(out.regulatoryNotifiable).toBe(false);
+    expect(out.reportedByEmployeeId).toBe("emp-9");
+    expect(out.incidentId).toMatch(/^INC-[0-9A-F]{8}$/);
+  });
+});
+
+describe("incidentUpdateFields", () => {
+  it("includes notifiedAt only when provided", () => {
+    const d = new Date();
+    expect(incidentUpdateFields({ notifiedAt: d })).toEqual({ notifiedAt: d });
+    expect(incidentUpdateFields({})).toEqual({});
+    // occurredAt is NOT an updatable field in the original action shape
+    expect("occurredAt" in incidentUpdateFields({ title: "x" })).toBe(false);
+  });
+});
+
+describe("correctiveActionCreateFields", () => {
+  it("falls back owner to session employeeId and generates CA id", () => {
+    const out = correctiveActionCreateFields({ title: " A ", sourceType: "incident" }, "emp-3");
+    expect(out.title).toBe("A");
+    expect(out.sourceType).toBe("incident");
+    expect(out.ownerEmployeeId).toBe("emp-3");
+    expect(out.actionId).toMatch(/^CA-[0-9A-F]{8}$/);
+  });
+});
+
+describe("correctiveActionUpdateFields", () => {
+  it("includes status/completedAt only when provided", () => {
+    expect(correctiveActionUpdateFields({ status: "verified" })).toEqual({ status: "verified" });
+    expect(correctiveActionUpdateFields({})).toEqual({});
+  });
+});
+
+describe("auditCreateFields", () => {
+  it("maps + defaults nulls and generates AUD id", () => {
+    const out = auditCreateFields({ title: " Au ", auditType: "internal" });
+    expect(out.title).toBe("Au");
+    expect(out.auditorEmployeeId).toBeNull();
+    expect(out.auditId).toMatch(/^AUD-[0-9A-F]{8}$/);
+  });
+});
+
+describe("auditUpdateFields", () => {
+  it("includes only provided keys incl. overallRating", () => {
+    expect(auditUpdateFields({ overallRating: "conforming" })).toEqual({ overallRating: "conforming" });
+    expect(auditUpdateFields({})).toEqual({});
+  });
+});
+
+describe("auditFindingCreateFields", () => {
+  it("carries the auditId param and generates FND id", () => {
+    const out = auditFindingCreateFields("aud-1", { title: " F ", findingType: "observation" });
+    expect(out.auditId).toBe("aud-1");
+    expect(out.title).toBe("F");
+    expect(out.findingId).toMatch(/^FND-[0-9A-F]{8}$/);
+  });
+});
+
+describe("auditFindingUpdateFields", () => {
+  it("includes resolvedAt only when provided", () => {
+    const d = new Date();
+    expect(auditFindingUpdateFields({ resolvedAt: d })).toEqual({ resolvedAt: d });
+    expect(auditFindingUpdateFields({})).toEqual({});
+  });
+});
+
+describe("evidenceCreateFields", () => {
+  it("falls back collectedBy to session employeeId and generates EVD id", () => {
+    const out = evidenceCreateFields({ title: " E ", evidenceType: "policy" }, "emp-7");
+    expect(out.title).toBe("E");
+    expect(out.evidenceType).toBe("policy");
+    expect(out.collectedByEmployeeId).toBe("emp-7");
+    expect(out.evidenceId).toMatch(/^EVD-[0-9A-F]{8}$/);
+  });
+  it("prefers explicit collectedByEmployeeId", () => {
+    expect(evidenceCreateFields({ title: "E", evidenceType: "policy", collectedByEmployeeId: "emp-x" }, "emp-7").collectedByEmployeeId).toBe("emp-x");
+  });
+});
+
+describe("submissionCreateFields", () => {
+  it("trims title + recipientBody, falls back submittedBy, generates SUB id", () => {
+    const out = submissionCreateFields({ title: " S ", recipientBody: " Reg Body ", submissionType: "annual-report" }, "emp-5");
+    expect(out.title).toBe("S");
+    expect(out.recipientBody).toBe("Reg Body");
+    expect(out.submittedByEmployeeId).toBe("emp-5");
+    expect(out.submissionId).toMatch(/^SUB-[0-9A-F]{8}$/);
+  });
+});
+
+describe("submissionUpdateFields", () => {
+  it("includes only provided keys, trimming title/recipientBody", () => {
+    expect(submissionUpdateFields({ title: " S ", recipientBody: " R " })).toEqual({ title: "S", recipientBody: "R" });
+    expect(submissionUpdateFields({ responseReceived: true })).toEqual({ responseReceived: true });
+    expect(submissionUpdateFields({})).toEqual({});
+  });
+});
+
+describe("mapRegulationSummaries", () => {
+  it("projects rows into the dashboard summary shape", () => {
+    const out = mapRegulationSummaries([
+      { id: "r1", shortName: "GDPR", jurisdiction: "EU", _count: { obligations: 3 } },
+      { id: "r2", shortName: "HIPAA", jurisdiction: "US", _count: { obligations: 0 } },
+    ]);
+    expect(out).toEqual([
+      { id: "r1", shortName: "GDPR", jurisdiction: "EU", obligationCount: 3 },
+      { id: "r2", shortName: "HIPAA", jurisdiction: "US", obligationCount: 0 },
+    ]);
+  });
+  it("returns an empty array for no rows", () => {
+    expect(mapRegulationSummaries([])).toEqual([]);
+  });
+});

--- a/apps/web/lib/compliance/compliance-core.ts
+++ b/apps/web/lib/compliance/compliance-core.ts
@@ -1,0 +1,365 @@
+// apps/web/lib/compliance/compliance-core.ts
+//
+// Pure (no prisma / auth / Next.js) domain helpers extracted from
+// lib/actions/compliance.ts (BI-OPT-FAT-ACTIONS, Compliance slice). These
+// functions are side-effect-free shape/transform/mapping and projection
+// builders — each maps a validated *Input into the plain field-map that a
+// prisma create/update write expects, and the dashboard projection maps
+// already-fetched rows into their view shape. Behavior-preserving relocation —
+// identical field maps, mirroring the EA slice (ea-core.ts), the CRM slice, the
+// Build slice (build-actions-core.ts / businessBriefJsonPayload), and the
+// platform-dev-config slice.
+//
+// Orchestration (auth() checks, prisma, $transaction, revalidatePath, the
+// calendar/audit-log side effects, the "use server" wrappers) STAYS in
+// lib/actions/compliance.ts and imports these helpers back. The prisma-typed
+// JSON casts (Regulation.applicability -> Prisma.InputJsonValue) stay at the
+// call sites so this module carries no @dpf/db value/type coupling.
+
+import {
+  generateRegulationId, generateObligationId, generateControlId,
+  generateAssessmentId, generateIncidentId, generateActionId,
+  generateAuditId, generateFindingId, generateEvidenceId, generateSubmissionId,
+  type RegulationInput, type ObligationInput, type ControlInput,
+  type RiskAssessmentInput, type IncidentInput, type CorrectiveActionInput,
+  type AuditInput, type FindingInput, type EvidenceInput, type SubmissionInput,
+} from "@/lib/compliance-types";
+
+// ─── Regulation ─────────────────────────────────────────────────────────────
+
+/**
+ * Field map for a Regulation create. The prisma-typed `applicability` JSON
+ * conditional stays at the call site; everything else is a pure trim/normalize.
+ */
+export function regulationCreateFields(input: RegulationInput) {
+  return {
+    regulationId: generateRegulationId(),
+    name: input.name.trim(),
+    shortName: input.shortName.trim(),
+    jurisdiction: input.jurisdiction.trim(),
+    industry: input.industry ?? null,
+    sourceType: input.sourceType ?? "external",
+    effectiveDate: input.effectiveDate ?? null,
+    reviewDate: input.reviewDate ?? null,
+    sourceUrl: input.sourceUrl ?? null,
+    notes: input.notes ?? null,
+  };
+}
+
+/** Conditional-spread field map for a Regulation update (applicability JSON
+ * conditional stays at the call site). */
+export function regulationUpdateFields(input: Partial<RegulationInput>) {
+  return {
+    ...(input.name !== undefined && { name: input.name.trim() }),
+    ...(input.shortName !== undefined && { shortName: input.shortName.trim() }),
+    ...(input.jurisdiction !== undefined && { jurisdiction: input.jurisdiction.trim() }),
+    ...(input.industry !== undefined && { industry: input.industry }),
+    ...(input.sourceType !== undefined && { sourceType: input.sourceType }),
+    ...(input.effectiveDate !== undefined && { effectiveDate: input.effectiveDate }),
+    ...(input.reviewDate !== undefined && { reviewDate: input.reviewDate }),
+    ...(input.sourceUrl !== undefined && { sourceUrl: input.sourceUrl }),
+    ...(input.notes !== undefined && { notes: input.notes }),
+  };
+}
+
+// ─── Obligation ─────────────────────────────────────────────────────────────
+
+export function obligationCreateFields(input: ObligationInput) {
+  return {
+    obligationId: generateObligationId(),
+    regulationId: input.regulationId,
+    title: input.title.trim(),
+    description: input.description ?? null,
+    reference: input.reference ?? null,
+    category: input.category ?? null,
+    frequency: input.frequency ?? null,
+    applicability: input.applicability ?? null,
+    deliverableType: input.deliverableType ?? null,
+    penaltySummary: input.penaltySummary ?? null,
+    ownerEmployeeId: input.ownerEmployeeId ?? null,
+    reviewDate: input.reviewDate ?? null,
+  };
+}
+
+export function obligationUpdateFields(input: Partial<ObligationInput>) {
+  return {
+    ...(input.title !== undefined && { title: input.title.trim() }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.reference !== undefined && { reference: input.reference }),
+    ...(input.category !== undefined && { category: input.category }),
+    ...(input.frequency !== undefined && { frequency: input.frequency }),
+    ...(input.applicability !== undefined && { applicability: input.applicability }),
+    ...(input.deliverableType !== undefined && { deliverableType: input.deliverableType }),
+    ...(input.penaltySummary !== undefined && { penaltySummary: input.penaltySummary }),
+    ...(input.ownerEmployeeId !== undefined && { ownerEmployeeId: input.ownerEmployeeId }),
+    ...(input.reviewDate !== undefined && { reviewDate: input.reviewDate }),
+  };
+}
+
+// ─── Control ──────────────────────────────────────────────────────────────────
+
+export function controlCreateFields(input: ControlInput) {
+  return {
+    controlId: generateControlId(),
+    title: input.title.trim(),
+    controlType: input.controlType,
+    description: input.description ?? null,
+    implementationStatus: input.implementationStatus ?? "planned",
+    ownerEmployeeId: input.ownerEmployeeId ?? null,
+    reviewFrequency: input.reviewFrequency ?? null,
+    nextReviewDate: input.nextReviewDate ?? null,
+    effectiveness: input.effectiveness ?? null,
+    catalogKey: input.catalogKey ?? null,
+  };
+}
+
+export function controlUpdateFields(input: Partial<ControlInput>) {
+  return {
+    ...(input.title !== undefined && { title: input.title.trim() }),
+    ...(input.controlType !== undefined && { controlType: input.controlType }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.implementationStatus !== undefined && { implementationStatus: input.implementationStatus }),
+    ...(input.ownerEmployeeId !== undefined && { ownerEmployeeId: input.ownerEmployeeId }),
+    ...(input.reviewFrequency !== undefined && { reviewFrequency: input.reviewFrequency }),
+    ...(input.nextReviewDate !== undefined && { nextReviewDate: input.nextReviewDate }),
+    ...(input.effectiveness !== undefined && { effectiveness: input.effectiveness }),
+    ...(input.catalogKey !== undefined && { catalogKey: input.catalogKey }),
+  };
+}
+
+// ─── Risk Assessment ──────────────────────────────────────────────────────────
+
+export function riskAssessmentCreateFields(input: RiskAssessmentInput, employeeId: string | null) {
+  return {
+    assessmentId: generateAssessmentId(),
+    title: input.title.trim(),
+    hazard: input.hazard.trim(),
+    likelihood: input.likelihood,
+    severity: input.severity,
+    inherentRisk: input.inherentRisk,
+    scope: input.scope ?? null,
+    residualRisk: input.residualRisk ?? null,
+    assessedByEmployeeId: input.assessedByEmployeeId ?? employeeId,
+    nextReviewDate: input.nextReviewDate ?? null,
+    notes: input.notes ?? null,
+  };
+}
+
+export function riskAssessmentUpdateFields(input: Partial<RiskAssessmentInput>) {
+  return {
+    ...(input.title !== undefined && { title: input.title.trim() }),
+    ...(input.hazard !== undefined && { hazard: input.hazard.trim() }),
+    ...(input.likelihood !== undefined && { likelihood: input.likelihood }),
+    ...(input.severity !== undefined && { severity: input.severity }),
+    ...(input.inherentRisk !== undefined && { inherentRisk: input.inherentRisk }),
+    ...(input.scope !== undefined && { scope: input.scope }),
+    ...(input.residualRisk !== undefined && { residualRisk: input.residualRisk }),
+    ...(input.assessedByEmployeeId !== undefined && { assessedByEmployeeId: input.assessedByEmployeeId }),
+    ...(input.nextReviewDate !== undefined && { nextReviewDate: input.nextReviewDate }),
+    ...(input.notes !== undefined && { notes: input.notes }),
+  };
+}
+
+// ─── Incident ─────────────────────────────────────────────────────────────────
+
+export function incidentCreateFields(input: IncidentInput, employeeId: string | null) {
+  return {
+    incidentId: generateIncidentId(),
+    title: input.title.trim(),
+    description: input.description ?? null,
+    occurredAt: input.occurredAt,
+    detectedAt: input.detectedAt ?? null,
+    severity: input.severity,
+    category: input.category ?? null,
+    regulatoryNotifiable: input.regulatoryNotifiable ?? false,
+    notificationDeadline: input.notificationDeadline ?? null,
+    rootCause: input.rootCause ?? null,
+    riskAssessmentId: input.riskAssessmentId ?? null,
+    reportedByEmployeeId: input.reportedByEmployeeId ?? employeeId,
+  };
+}
+
+export function incidentUpdateFields(input: Partial<IncidentInput> & { notifiedAt?: Date | null }) {
+  return {
+    ...(input.title !== undefined && { title: input.title.trim() }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.severity !== undefined && { severity: input.severity }),
+    ...(input.category !== undefined && { category: input.category }),
+    ...(input.regulatoryNotifiable !== undefined && { regulatoryNotifiable: input.regulatoryNotifiable }),
+    ...(input.notificationDeadline !== undefined && { notificationDeadline: input.notificationDeadline }),
+    ...(input.notifiedAt !== undefined && { notifiedAt: input.notifiedAt }),
+    ...(input.rootCause !== undefined && { rootCause: input.rootCause }),
+    ...(input.riskAssessmentId !== undefined && { riskAssessmentId: input.riskAssessmentId }),
+  };
+}
+
+// ─── Corrective Action ──────────────────────────────────────────────────────
+
+export function correctiveActionCreateFields(input: CorrectiveActionInput, employeeId: string | null) {
+  return {
+    actionId: generateActionId(),
+    title: input.title.trim(),
+    description: input.description ?? null,
+    rootCause: input.rootCause ?? null,
+    sourceType: input.sourceType,
+    incidentId: input.incidentId ?? null,
+    auditFindingId: input.auditFindingId ?? null,
+    ownerEmployeeId: input.ownerEmployeeId ?? employeeId,
+    dueDate: input.dueDate ?? null,
+  };
+}
+
+export function correctiveActionUpdateFields(
+  input: Partial<CorrectiveActionInput> & { status?: string; completedAt?: Date | null },
+) {
+  return {
+    ...(input.title !== undefined && { title: input.title.trim() }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.rootCause !== undefined && { rootCause: input.rootCause }),
+    ...(input.ownerEmployeeId !== undefined && { ownerEmployeeId: input.ownerEmployeeId }),
+    ...(input.dueDate !== undefined && { dueDate: input.dueDate }),
+    ...(input.status !== undefined && { status: input.status }),
+    ...(input.completedAt !== undefined && { completedAt: input.completedAt }),
+  };
+}
+
+// ─── Audit ────────────────────────────────────────────────────────────────────
+
+export function auditCreateFields(input: AuditInput) {
+  return {
+    auditId: generateAuditId(),
+    title: input.title.trim(),
+    auditType: input.auditType,
+    scope: input.scope ?? null,
+    auditorName: input.auditorName ?? null,
+    auditorEmployeeId: input.auditorEmployeeId ?? null,
+    scheduledAt: input.scheduledAt ?? null,
+    notes: input.notes ?? null,
+  };
+}
+
+export function auditUpdateFields(
+  input: Partial<AuditInput> & {
+    status?: string; conductedAt?: Date | null; completedAt?: Date | null; overallRating?: string | null;
+  },
+) {
+  return {
+    ...(input.title !== undefined && { title: input.title.trim() }),
+    ...(input.auditType !== undefined && { auditType: input.auditType }),
+    ...(input.scope !== undefined && { scope: input.scope }),
+    ...(input.auditorName !== undefined && { auditorName: input.auditorName }),
+    ...(input.auditorEmployeeId !== undefined && { auditorEmployeeId: input.auditorEmployeeId }),
+    ...(input.scheduledAt !== undefined && { scheduledAt: input.scheduledAt }),
+    ...(input.notes !== undefined && { notes: input.notes }),
+    ...(input.status !== undefined && { status: input.status }),
+    ...(input.conductedAt !== undefined && { conductedAt: input.conductedAt }),
+    ...(input.completedAt !== undefined && { completedAt: input.completedAt }),
+    ...(input.overallRating !== undefined && { overallRating: input.overallRating }),
+  };
+}
+
+// ─── Audit Finding ────────────────────────────────────────────────────────────
+
+export function auditFindingCreateFields(auditId: string, input: FindingInput) {
+  return {
+    findingId: generateFindingId(),
+    auditId,
+    title: input.title.trim(),
+    findingType: input.findingType,
+    controlId: input.controlId ?? null,
+    description: input.description ?? null,
+    dueDate: input.dueDate ?? null,
+  };
+}
+
+export function auditFindingUpdateFields(
+  input: Partial<FindingInput> & { status?: string; resolvedAt?: Date | null },
+) {
+  return {
+    ...(input.title !== undefined && { title: input.title.trim() }),
+    ...(input.findingType !== undefined && { findingType: input.findingType }),
+    ...(input.controlId !== undefined && { controlId: input.controlId }),
+    ...(input.description !== undefined && { description: input.description }),
+    ...(input.dueDate !== undefined && { dueDate: input.dueDate }),
+    ...(input.status !== undefined && { status: input.status }),
+    ...(input.resolvedAt !== undefined && { resolvedAt: input.resolvedAt }),
+  };
+}
+
+// ─── Evidence ─────────────────────────────────────────────────────────────────
+
+/** Field map for an (immutable) Evidence create — reused by both createEvidence
+ * and the supersedeEvidence transaction, which build the identical row. */
+export function evidenceCreateFields(input: EvidenceInput, employeeId: string | null) {
+  return {
+    evidenceId: generateEvidenceId(),
+    title: input.title.trim(),
+    evidenceType: input.evidenceType,
+    description: input.description ?? null,
+    obligationId: input.obligationId ?? null,
+    controlId: input.controlId ?? null,
+    collectedByEmployeeId: input.collectedByEmployeeId ?? employeeId,
+    fileRef: input.fileRef ?? null,
+    retentionUntil: input.retentionUntil ?? null,
+  };
+}
+
+// ─── Regulatory Submission ────────────────────────────────────────────────────
+
+export function submissionCreateFields(input: SubmissionInput, employeeId: string | null) {
+  return {
+    submissionId: generateSubmissionId(),
+    title: input.title.trim(),
+    recipientBody: input.recipientBody.trim(),
+    submissionType: input.submissionType,
+    regulationId: input.regulationId ?? null,
+    dueDate: input.dueDate ?? null,
+    submittedByEmployeeId: input.submittedByEmployeeId ?? employeeId,
+    notes: input.notes ?? null,
+  };
+}
+
+export function submissionUpdateFields(
+  input: Partial<SubmissionInput> & {
+    status?: string; submittedAt?: Date | null; confirmationRef?: string | null;
+    responseReceived?: boolean; responseDate?: Date | null; responseSummary?: string | null;
+  },
+) {
+  return {
+    ...(input.title !== undefined && { title: input.title.trim() }),
+    ...(input.recipientBody !== undefined && { recipientBody: input.recipientBody.trim() }),
+    ...(input.submissionType !== undefined && { submissionType: input.submissionType }),
+    ...(input.regulationId !== undefined && { regulationId: input.regulationId }),
+    ...(input.dueDate !== undefined && { dueDate: input.dueDate }),
+    ...(input.notes !== undefined && { notes: input.notes }),
+    ...(input.status !== undefined && { status: input.status }),
+    ...(input.submittedAt !== undefined && { submittedAt: input.submittedAt }),
+    ...(input.confirmationRef !== undefined && { confirmationRef: input.confirmationRef }),
+    ...(input.responseReceived !== undefined && { responseReceived: input.responseReceived }),
+    ...(input.responseDate !== undefined && { responseDate: input.responseDate }),
+    ...(input.responseSummary !== undefined && { responseSummary: input.responseSummary }),
+  };
+}
+
+// ─── Dashboard ────────────────────────────────────────────────────────────────
+
+/**
+ * Project active-regulation rows (each carrying an obligation `_count`) into the
+ * dashboard's regulationSummaries view shape. Pure map over already-fetched
+ * rows; the caller owns the prisma query.
+ */
+export function mapRegulationSummaries(
+  regulations: ReadonlyArray<{
+    id: string;
+    shortName: string;
+    jurisdiction: string;
+    _count: { obligations: number };
+  }>,
+) {
+  return regulations.map((r) => ({
+    id: r.id,
+    shortName: r.shortName,
+    jurisdiction: r.jurisdiction,
+    obligationCount: r._count.obligations,
+  }));
+}


### PR DESCRIPTION
## What

Pure **MOVE** of the side-effect-free logic out of `apps/web/lib/actions/compliance.ts` into a new domain-core module `apps/web/lib/compliance/compliance-core.ts`. Behavior is byte-for-byte preserved — this mirrors the merged EA slice (#3118), the Build slice (`build-actions-core.ts` / `businessBriefJsonPayload`), and the platform-dev-config slice (#3129).

The relocated helpers are the pure Prisma **data-payload builders** (each `*Input` → create/update field map: trim/normalize/`?? null` defaults + ID generation) and the dashboard `regulationSummaries` **projection**. Orchestration — `auth()`, `prisma`, `$transaction`, `revalidatePath`, the calendar/audit-log side effects, and the `"use server"` wrappers — stays in the action file and imports the helpers back. The prisma-typed JSON casts (`Regulation.applicability → Prisma.InputJsonValue`) stay at the call sites, so the core module carries **no `@dpf/db` value/type coupling**.

## LOC

| file | before | after |
| --- | --- | --- |
| `apps/web/lib/actions/compliance.ts` | 1067 | **866** |
| `apps/web/lib/compliance/compliance-core.ts` | — | 365 (new, < 800 cap) |

Baseline is 1068; the shrink passes the module-size ratchet.

## Helpers extracted (20)

Create/update field-map builders for: regulation, obligation, control, risk-assessment, incident, corrective-action, audit, audit-finding, submission (create+update pairs), plus `evidenceCreateFields` (create-only; **reused** by both `createEvidence` and the `supersedeEvidence` transaction, which build the identical row), and `mapRegulationSummaries` (dashboard projection).

Left as orchestration on purpose: the `onboardRegulation` and `supersedeRegulation` transaction bodies (loops / `buildNextRegulationVersion`-derived rows with different defaults), and `verifyCorrectiveAction` (inline `new Date()`).

## Behavior preservation

- Existing behavior-pin test `apps/web/lib/actions/compliance.test.ts` (16 tests) is **UNCHANGED** and green — the pin.
- Added `apps/web/lib/compliance/compliance-core.test.ts` — 28 new unit tests asserting each builder's trim/default/employeeId-fallback/conditional-inclusion behavior, ID prefixes, and the projection shape.
- `tsc --noEmit` on `apps/web`: **zero errors in touched files**; the only remaining project errors are the pre-existing stale-junctioned `@dpf/db/healthcare-*` subpath artifacts (unrelated to this change).

## Zero unused imports

After extraction, every imported-back symbol was word-boundary grepped in the action file and confirmed to occur ≥1 time **outside** the import block (create/update builders each appear twice = import + call site; `evidenceCreateFields` three times). The now-unneeded ID generators (`generateAssessmentId`, `generateIncidentId`, `generateActionId`, `generateAuditId`, `generateFindingId`, `generateEvidenceId`, `generateSubmissionId`) were **dropped** from the `@/lib/compliance-types` import (they now live inside the core builders); `generateRegulationId`/`generateObligationId`/`generateControlId` are retained (still used by the onboarding/supersede transactions). `node scripts/check-no-type-reexport-in-use-server.mjs` passes — no type is re-exported through the `"use server"` module.

Generated with Claude Code