### PR TITLE
feat(occupation): Phase 1 substrate — OccupationProfile + resolver (EP-EMPLOYEE-OCCUPATION / BI-442E2B42)

### DIFF
--- a/apps/web/lib/workforce/occupation.test.ts
+++ b/apps/web/lib/workforce/occupation.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getOccupationByKey,
+  resolveOccupationForEmployee,
+  resolveOccupationForUser,
+  invalidateOccupationCache,
+  OCCUPATION_INTERACTIONS,
+  type OccupationDbClient,
+} from "./occupation";
+
+// A hygienist-shaped OccupationProfile row as Prisma would return it (JSON columns
+// are plain objects/arrays).
+const HYGIENIST_ROW = {
+  occupationKey: "dental-hygienist",
+  label: "Dental Hygienist",
+  summary: "Runs patient hygiene visits.",
+  archetypeCategories: ["healthcare-wellness"],
+  archetypeIds: [],
+  baseAccessProfile: "workforce-member",
+  wsidProfessionFamily: null,
+  featureSurface: {
+    tileAllowlist: ["today-schedule", "needs-you"],
+    navEmphasis: ["/workspace"],
+    workspaceHomeOccupationId: null,
+  },
+  coworkerRoster: [
+    { agentSlug: "customer-advisor", interaction: "summon", governanceProfileRef: null },
+    // An invalid interaction must be dropped by the parser, not crash resolution.
+    { agentSlug: "storefront-advisor", interaction: "bogus", governanceProfileRef: null },
+  ],
+  onboardingCurriculumId: "occ-intro-dental-hygienist",
+  moverCurriculumId: null,
+};
+
+function makeDb(overrides: {
+  profile?: unknown;
+  employeeById?: { position: { occupationKey: string | null } | null } | null;
+  employeeByUser?: { position: { occupationKey: string | null } | null } | null;
+}) {
+  const occupationProfile = {
+    findFirst: vi.fn().mockResolvedValue(overrides.profile ?? null),
+  };
+  const employeeProfile = {
+    findUnique: vi.fn().mockResolvedValue(overrides.employeeById ?? null),
+    findFirst: vi.fn().mockResolvedValue(overrides.employeeByUser ?? null),
+  };
+  return { db: { occupationProfile, employeeProfile } as unknown as OccupationDbClient, occupationProfile, employeeProfile };
+}
+
+beforeEach(() => {
+  invalidateOccupationCache();
+});
+
+describe("getOccupationByKey", () => {
+  it("resolves and parses a profile row", async () => {
+    const { db } = makeDb({ profile: HYGIENIST_ROW });
+    const occ = await getOccupationByKey("dental-hygienist", db);
+    expect(occ).not.toBeNull();
+    expect(occ!.label).toBe("Dental Hygienist");
+    expect(occ!.featureSurface.tileAllowlist).toContain("needs-you");
+    // The bogus interaction is filtered out; only the valid grant survives.
+    expect(occ!.coworkerRoster).toHaveLength(1);
+    expect(occ!.coworkerRoster[0].agentSlug).toBe("customer-advisor");
+    expect(OCCUPATION_INTERACTIONS).toContain(occ!.coworkerRoster[0].interaction);
+  });
+
+  it("returns null for an unknown key", async () => {
+    const { db } = makeDb({ profile: null });
+    expect(await getOccupationByKey("ghost", db)).toBeNull();
+  });
+
+  it("memoizes by key and re-queries after invalidation", async () => {
+    const { db, occupationProfile } = makeDb({ profile: HYGIENIST_ROW });
+    await getOccupationByKey("dental-hygienist", db);
+    await getOccupationByKey("dental-hygienist", db);
+    expect(occupationProfile.findFirst).toHaveBeenCalledTimes(1); // second call hit the memo
+    invalidateOccupationCache("dental-hygienist");
+    await getOccupationByKey("dental-hygienist", db);
+    expect(occupationProfile.findFirst).toHaveBeenCalledTimes(2); // seam forces a re-read
+  });
+
+  it("caches a miss so unknown keys don't re-query", async () => {
+    const { db, occupationProfile } = makeDb({ profile: null });
+    await getOccupationByKey("ghost", db);
+    await getOccupationByKey("ghost", db);
+    expect(occupationProfile.findFirst).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveOccupationForEmployee", () => {
+  it("walks position -> occupationKey -> profile", async () => {
+    const { db } = makeDb({
+      profile: HYGIENIST_ROW,
+      employeeById: { position: { occupationKey: "dental-hygienist" } },
+    });
+    const occ = await resolveOccupationForEmployee("emp-1", db);
+    expect(occ!.occupationKey).toBe("dental-hygienist");
+  });
+
+  it("returns null when the employee has no position", async () => {
+    const { db } = makeDb({ employeeById: { position: null } });
+    expect(await resolveOccupationForEmployee("emp-1", db)).toBeNull();
+  });
+
+  it("returns null when the position has no occupationKey", async () => {
+    const { db } = makeDb({ employeeById: { position: { occupationKey: null } } });
+    expect(await resolveOccupationForEmployee("emp-1", db)).toBeNull();
+  });
+
+  it("returns null when the employee does not exist", async () => {
+    const { db } = makeDb({ employeeById: null });
+    expect(await resolveOccupationForEmployee("nope", db)).toBeNull();
+  });
+
+  it("returns null when the referenced occupation is unknown (honest fallback)", async () => {
+    const { db } = makeDb({
+      profile: null,
+      employeeById: { position: { occupationKey: "retired-occupation" } },
+    });
+    expect(await resolveOccupationForEmployee("emp-1", db)).toBeNull();
+  });
+});
+
+describe("resolveOccupationForUser", () => {
+  it("resolves via the linked employee profile", async () => {
+    const { db } = makeDb({
+      profile: HYGIENIST_ROW,
+      employeeByUser: { position: { occupationKey: "dental-hygienist" } },
+    });
+    const occ = await resolveOccupationForUser("user-1", db);
+    expect(occ!.label).toBe("Dental Hygienist");
+  });
+
+  it("returns null when the user has no employee profile", async () => {
+    const { db } = makeDb({ employeeByUser: null });
+    expect(await resolveOccupationForUser("user-1", db)).toBeNull();
+  });
+});

--- a/apps/web/lib/workforce/occupation.ts
+++ b/apps/web/lib/workforce/occupation.ts
@@ -1,0 +1,199 @@
+import { prisma } from "@dpf/db";
+
+/**
+ * EP-EMPLOYEE-OCCUPATION Phase 1 (BI-442E2B42) — the occupation resolver.
+ *
+ * Resolves a customer's in-trench employee to their OCCUPATION (dental hygienist,
+ * field service technician) so downstream surfaces can focus the workspace, scope
+ * the coworker roster, and drive the job-aware onboarding intro. Occupation is a
+ * FOCUS + curation layer; it never widens the platform-management RBAC floor.
+ *
+ * Resolution walks: EmployeeProfile.positionId -> Position.occupationKey ->
+ * OccupationProfile. An unmapped position resolves to `null` (honest fallback to
+ * the archetype/platform home — never a broken surface).
+ *
+ * Caching: the employee->occupation walk is deliberately UNCACHED (reads live
+ * Position each call) so a mover event — a changed Position.occupationKey — is
+ * picked up immediately (spec §5.2). Only the immutable OccupationProfile config
+ * is memoized by key; `invalidateOccupationCache` is the seam the Phase-5 mover
+ * event and any seed re-run call to drop that memo.
+ *
+ * Spec: docs/superpowers/specs/2026-07-16-employee-occupation-onboarding-and-role-tailored-workspace-design.md §5.1/§5.2
+ */
+
+export const OCCUPATION_INTERACTIONS = ["summon", "assigned-only", "read-only"] as const;
+export type OccupationInteraction = (typeof OCCUPATION_INTERACTIONS)[number];
+
+export type OccupationCoworkerGrant = {
+  agentSlug: string;
+  interaction: OccupationInteraction;
+  governanceProfileRef: string | null;
+};
+
+export type OccupationFeatureSurface = {
+  tileAllowlist: string[];
+  navEmphasis: string[];
+  workspaceHomeOccupationId: string | null;
+};
+
+export type ResolvedOccupation = {
+  occupationKey: string;
+  label: string;
+  summary: string;
+  archetypeCategories: string[];
+  archetypeIds: string[];
+  baseAccessProfile: string;
+  wsidProfessionFamily: string | null;
+  featureSurface: OccupationFeatureSurface;
+  coworkerRoster: OccupationCoworkerGrant[];
+  onboardingCurriculumId: string;
+  moverCurriculumId: string | null;
+};
+
+type PositionKeyRow = { position: { occupationKey: string | null } | null } | null;
+
+/**
+ * The minimal Prisma surface the resolver needs. Kept structural (not the full
+ * generated `PrismaClient`) so tests can inject a small fake and the module does
+ * not couple to generated types — the DI pattern that avoids `vi.mock` bleed.
+ */
+export interface OccupationDbClient {
+  occupationProfile: {
+    findFirst(args: { where: { occupationKey: string; isActive: boolean } }): Promise<unknown>;
+  };
+  employeeProfile: {
+    findUnique(args: { where: { id: string }; select: { position: { select: { occupationKey: true } } } }): Promise<PositionKeyRow>;
+    findFirst(args: { where: { userId: string }; select: { position: { select: { occupationKey: true } } } }): Promise<PositionKeyRow>;
+  };
+}
+
+const defaultDb = prisma as unknown as OccupationDbClient;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+function parseFeatureSurface(value: unknown): OccupationFeatureSurface {
+  const rec = asRecord(value);
+  const workspaceHomeOccupationId = rec.workspaceHomeOccupationId;
+  return {
+    tileAllowlist: asStringArray(rec.tileAllowlist),
+    navEmphasis: asStringArray(rec.navEmphasis),
+    workspaceHomeOccupationId:
+      typeof workspaceHomeOccupationId === "string" ? workspaceHomeOccupationId : null,
+  };
+}
+
+function parseCoworkerRoster(value: unknown): OccupationCoworkerGrant[] {
+  if (!Array.isArray(value)) return [];
+  const grants: OccupationCoworkerGrant[] = [];
+  for (const entry of value) {
+    const rec = asRecord(entry);
+    const agentSlug = rec.agentSlug;
+    const interaction = rec.interaction;
+    if (typeof agentSlug !== "string") continue;
+    if (
+      typeof interaction !== "string" ||
+      !OCCUPATION_INTERACTIONS.includes(interaction as OccupationInteraction)
+    ) {
+      continue;
+    }
+    grants.push({
+      agentSlug,
+      interaction: interaction as OccupationInteraction,
+      governanceProfileRef:
+        typeof rec.governanceProfileRef === "string" ? rec.governanceProfileRef : null,
+    });
+  }
+  return grants;
+}
+
+function toResolvedOccupation(value: unknown): ResolvedOccupation {
+  const row = asRecord(value);
+  return {
+    occupationKey: String(row.occupationKey ?? ""),
+    label: String(row.label ?? ""),
+    summary: String(row.summary ?? ""),
+    archetypeCategories: asStringArray(row.archetypeCategories),
+    archetypeIds: asStringArray(row.archetypeIds),
+    baseAccessProfile: String(row.baseAccessProfile ?? ""),
+    wsidProfessionFamily: typeof row.wsidProfessionFamily === "string" ? row.wsidProfessionFamily : null,
+    featureSurface: parseFeatureSurface(row.featureSurface),
+    coworkerRoster: parseCoworkerRoster(row.coworkerRoster),
+    onboardingCurriculumId: String(row.onboardingCurriculumId ?? ""),
+    moverCurriculumId: typeof row.moverCurriculumId === "string" ? row.moverCurriculumId : null,
+  };
+}
+
+// Memoizes the immutable OccupationProfile config keyed by occupationKey. `null`
+// is cached as an explicit MISS marker so unknown keys don't re-query every call.
+const OCCUPATION_MISS = Symbol("occupation-miss");
+const profileCache = new Map<string, ResolvedOccupation | typeof OCCUPATION_MISS>();
+
+/**
+ * The invalidation seam (spec §5.2). Called by the Phase-5 mover event and by any
+ * occupation re-seed so a changed OccupationProfile config is re-read. Pass a key
+ * to drop one entry, or omit to clear all.
+ */
+export function invalidateOccupationCache(occupationKey?: string): void {
+  if (occupationKey) profileCache.delete(occupationKey);
+  else profileCache.clear();
+}
+
+/** Loads an active OccupationProfile by key (memoized). Returns null when unknown/inactive. */
+export async function getOccupationByKey(
+  occupationKey: string,
+  db: OccupationDbClient = defaultDb,
+): Promise<ResolvedOccupation | null> {
+  const cached = profileCache.get(occupationKey);
+  if (cached !== undefined) return cached === OCCUPATION_MISS ? null : cached;
+
+  const row = await db.occupationProfile.findFirst({
+    where: { occupationKey, isActive: true },
+  });
+  const resolved = row ? toResolvedOccupation(row) : null;
+  profileCache.set(occupationKey, resolved ?? OCCUPATION_MISS);
+  return resolved;
+}
+
+/**
+ * Resolves an employee's occupation via their position. Returns null when the
+ * employee has no position, the position has no occupationKey, or the referenced
+ * occupation is unknown/inactive — every case an honest fallback, not an error.
+ */
+export async function resolveOccupationForEmployee(
+  employeeProfileId: string,
+  db: OccupationDbClient = defaultDb,
+): Promise<ResolvedOccupation | null> {
+  const employee = await db.employeeProfile.findUnique({
+    where: { id: employeeProfileId },
+    select: { position: { select: { occupationKey: true } } },
+  });
+  const occupationKey = employee?.position?.occupationKey;
+  if (!occupationKey) return null;
+  return getOccupationByKey(occupationKey, db);
+}
+
+/**
+ * Convenience for surfaces that hold a userId (workspace resolver, coworker panel):
+ * finds the linked EmployeeProfile, then resolves its occupation. Null when the
+ * user has no employee profile or no mapped occupation.
+ */
+export async function resolveOccupationForUser(
+  userId: string,
+  db: OccupationDbClient = defaultDb,
+): Promise<ResolvedOccupation | null> {
+  const employee = await db.employeeProfile.findFirst({
+    where: { userId },
+    select: { position: { select: { occupationKey: true } } },
+  });
+  const occupationKey = employee?.position?.occupationKey;
+  if (!occupationKey) return null;
+  return getOccupationByKey(occupationKey, db);
+}

--- a/docs/superpowers/plans/2026-07-16-employee-occupation-onboarding-and-role-tailored-workspace.md
+++ b/docs/superpowers/plans/2026-07-16-employee-occupation-onboarding-and-role-tailored-workspace.md
@@ -52,6 +52,7 @@ This plan sequences the spec into independently reviewable slices. Each phase na
 - Resolver [`apps/web/lib/workforce/occupation.ts`](../../../apps/web/lib/workforce/occupation.ts): `resolveOccupationForEmployee` / `resolveOccupationForUser` / `getOccupationByKey`, DI-testable, with the `invalidateOccupationCache` seam P5's mover event consumes (employee→occupation walk stays uncached so a mover change is seen immediately).
 - Tests: `seed-occupations.test.ts` (referential integrity + fail-closed) and `occupation.test.ts` (resolver fallbacks, JSON parsing, memo + invalidation).
 - **Stewardship note:** `OnboardingTask.kind` from spec §6 maps onto the **existing** `OnboardingTask.checklistType` field — no new column. The `platform-intro` / `occupation-mover` values are introduced when P4/P5 create those rows; `baseAccessProfile` is a slug pending the P0.1 RBAC decision (seeded `workforce-member`); `wsidProfessionFamily` and roster `governanceProfileRef` are bound in P3.
+- **Seed-fit applicability decision:** `archetype-scoped`. The seeded occupations are canonical fleet defaults scoped by archetype category (healthcare-wellness, trades-maintenance), symmetric with the storefront archetype seeds — not global-default, not install-local. (Recorded here durably in addition to the `Seed-Fit-Decision:` PR trailer the CI gate reads.)
 
 ---
 

--- a/docs/superpowers/plans/2026-07-16-employee-occupation-onboarding-and-role-tailored-workspace.md
+++ b/docs/superpowers/plans/2026-07-16-employee-occupation-onboarding-and-role-tailored-workspace.md
@@ -46,6 +46,13 @@ This plan sequences the spec into independently reviewable slices. Each phase na
 
 **Exit:** an employee can be resolved to an occupation (or an honest null) server-side.
 
+**Implementation status (landed 2026-07-17):** Phase 1 substrate implemented.
+- `OccupationProfile` model + nullable `Position.occupationKey` (slug reference, not an FK — mirrors `StorefrontConfig.archetypeId`) — [`packages/db/prisma/schema.prisma`](../../../packages/db/prisma/schema.prisma); migration `20260717000000_add_occupation_dimension` (data-safe, hand-authored — worktree is source-only so `prisma migrate dev` runs in the sandbox).
+- Registry data [`packages/db/data/occupation_registry.json`](../../../packages/db/data/occupation_registry.json) (dental-hygienist, front-desk-coordinator, field-service-technician, field-dispatcher) + fail-closed seed [`packages/db/src/seed-occupations.ts`](../../../packages/db/src/seed-occupations.ts) wired into `seed.ts` after `storefrontArchetypes`. Seed validates every occupation against the live archetype-category catalog and the seeded coworker slugs (`COWORKER_AGENT_SEEDS`); `interaction` is the closed `summon|assigned-only|read-only` enum.
+- Resolver [`apps/web/lib/workforce/occupation.ts`](../../../apps/web/lib/workforce/occupation.ts): `resolveOccupationForEmployee` / `resolveOccupationForUser` / `getOccupationByKey`, DI-testable, with the `invalidateOccupationCache` seam P5's mover event consumes (employee→occupation walk stays uncached so a mover change is seen immediately).
+- Tests: `seed-occupations.test.ts` (referential integrity + fail-closed) and `occupation.test.ts` (resolver fallbacks, JSON parsing, memo + invalidation).
+- **Stewardship note:** `OnboardingTask.kind` from spec §6 maps onto the **existing** `OnboardingTask.checklistType` field — no new column. The `platform-intro` / `occupation-mover` values are introduced when P4/P5 create those rows; `baseAccessProfile` is a slug pending the P0.1 RBAC decision (seeded `workforce-member`); `wsidProfessionFamily` and roster `governanceProfileRef` are bound in P3.
+
 ---
 
 ## Phase 2 — Role-tailored workspace (extend the dormant vertical-home resolver)

--- a/packages/db/data/occupation_registry.json
+++ b/packages/db/data/occupation_registry.json
@@ -1,0 +1,89 @@
+{
+  "version": "1.0.0",
+  "generated_at": "2026-07-17",
+  "note": "EP-EMPLOYEE-OCCUPATION Phase 1. Reusable occupation templates scoped by storefront archetype category. agentSlug values MUST exist in COWORKER_AGENT_SEEDS (packages/db/src/workforce-seed.ts). archetypeCategories MUST exist in the storefront archetype catalog. baseAccessProfile is a slug for the RBAC floor finalized by the P0.1 decision (spec §5.6). wsidProfessionFamily and coworkerRoster[].governanceProfileRef are bound in Phase 3. tileAllowlist/navEmphasis are reconciled against ALL_TILES in Phase 2. interaction is the closed enum summon|assigned-only|read-only.",
+  "occupations": [
+    {
+      "occupationKey": "dental-hygienist",
+      "label": "Dental Hygienist",
+      "summary": "Runs patient hygiene visits: prepares the chair, records charting notes, and keeps recall/follow-up communication moving.",
+      "archetypeCategories": ["healthcare-wellness"],
+      "archetypeIds": [],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": null,
+      "featureSurface": {
+        "tileAllowlist": ["today-schedule", "needs-you", "calendar"],
+        "navEmphasis": ["/workspace", "/workspace/calendar", "/workspace/inbox"],
+        "workspaceHomeOccupationId": null
+      },
+      "coworkerRoster": [
+        { "agentSlug": "customer-advisor", "interaction": "summon", "governanceProfileRef": null },
+        { "agentSlug": "storefront-advisor", "interaction": "summon", "governanceProfileRef": null },
+        { "agentSlug": "compliance-officer", "interaction": "read-only", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-dental-hygienist",
+      "moverCurriculumId": null
+    },
+    {
+      "occupationKey": "front-desk-coordinator",
+      "label": "Front-Desk Coordinator",
+      "summary": "Owns the front office: booking and confirming appointments, greeting patients, and handling inbound calls and messages.",
+      "archetypeCategories": ["healthcare-wellness"],
+      "archetypeIds": [],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": null,
+      "featureSurface": {
+        "tileAllowlist": ["today-schedule", "needs-you", "calendar", "customer-callbacks"],
+        "navEmphasis": ["/workspace", "/workspace/calendar", "/workspace/inbox"],
+        "workspaceHomeOccupationId": null
+      },
+      "coworkerRoster": [
+        { "agentSlug": "customer-advisor", "interaction": "summon", "governanceProfileRef": null },
+        { "agentSlug": "storefront-advisor", "interaction": "summon", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-front-desk-coordinator",
+      "moverCurriculumId": null
+    },
+    {
+      "occupationKey": "field-service-technician",
+      "label": "Field Service Technician",
+      "summary": "Works assigned jobs in the field: checks the day's service calls, updates job status, and keeps customers posted on ETA.",
+      "archetypeCategories": ["trades-maintenance"],
+      "archetypeIds": [],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": null,
+      "featureSurface": {
+        "tileAllowlist": ["today-schedule", "needs-you", "customer-callbacks"],
+        "navEmphasis": ["/workspace", "/workspace/my-queue", "/workspace/inbox"],
+        "workspaceHomeOccupationId": null
+      },
+      "coworkerRoster": [
+        { "agentSlug": "dispatcher", "interaction": "summon", "governanceProfileRef": null },
+        { "agentSlug": "customer-advisor", "interaction": "read-only", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-field-service-technician",
+      "moverCurriculumId": null
+    },
+    {
+      "occupationKey": "field-dispatcher",
+      "label": "Field Dispatcher",
+      "summary": "Runs the dispatch board: assigns technicians to jobs, schedules service calls, and coordinates running-late customer notifications.",
+      "archetypeCategories": ["trades-maintenance"],
+      "archetypeIds": [],
+      "baseAccessProfile": "workforce-member",
+      "wsidProfessionFamily": null,
+      "featureSurface": {
+        "tileAllowlist": ["today-schedule", "needs-you", "unassigned-work", "technician-load", "customer-callbacks"],
+        "navEmphasis": ["/workspace", "/workspace/calendar", "/workspace/inbox"],
+        "workspaceHomeOccupationId": null
+      },
+      "coworkerRoster": [
+        { "agentSlug": "dispatcher", "interaction": "summon", "governanceProfileRef": null },
+        { "agentSlug": "customer-advisor", "interaction": "summon", "governanceProfileRef": null },
+        { "agentSlug": "ops-coordinator", "interaction": "read-only", "governanceProfileRef": null }
+      ],
+      "onboardingCurriculumId": "occ-intro-field-dispatcher",
+      "moverCurriculumId": null
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260717000000_add_occupation_dimension/migration.sql
+++ b/packages/db/prisma/migrations/20260717000000_add_occupation_dimension/migration.sql
@@ -1,0 +1,48 @@
+-- EP-EMPLOYEE-OCCUPATION Phase 1 (BI-442E2B42): the occupation dimension.
+-- Adds the OccupationProfile registry table + a nullable Position.occupationKey
+-- slug reference. Occupation is config/template (not an identity Principal) that
+-- FOCUSES the workspace surface and ADDS a governed coworker roster; it never
+-- widens the platform-management RBAC floor. Spec §5.1/§5.2.
+--
+-- @migration-safety: data-safe. Position.occupationKey is added nullable with no
+-- default (metadata-only change, no table rewrite, no existing row can violate
+-- it); an unmapped position resolves to the archetype/platform fallback. The new
+-- OccupationProfile table is created empty and populated by the seed
+-- (packages/db/src/seed-occupations.ts from packages/db/data/occupation_registry.json).
+-- No constraints are tightened over existing data; occupationKey is a slug
+-- reference validated in app code, deliberately NOT a foreign key (mirrors the
+-- StorefrontConfig.archetypeId semantic-slug pattern).
+
+-- CreateTable
+CREATE TABLE "OccupationProfile" (
+    "id" TEXT NOT NULL,
+    "occupationKey" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "archetypeCategories" TEXT[],
+    "archetypeIds" TEXT[],
+    "baseAccessProfile" TEXT NOT NULL,
+    "wsidProfessionFamily" TEXT,
+    "featureSurface" JSONB NOT NULL,
+    "coworkerRoster" JSONB NOT NULL,
+    "onboardingCurriculumId" TEXT NOT NULL,
+    "moverCurriculumId" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "isBuiltIn" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OccupationProfile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OccupationProfile_occupationKey_key" ON "OccupationProfile"("occupationKey");
+
+-- CreateIndex
+CREATE INDEX "OccupationProfile_isActive_idx" ON "OccupationProfile"("isActive");
+
+-- AlterTable
+ALTER TABLE "Position" ADD COLUMN "occupationKey" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Position_occupationKey_idx" ON "Position"("occupationKey");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -505,12 +505,54 @@ model Position {
   title      String
   jobFamily  String?
   jobLevel   String?
+  // Occupation dimension (EP-EMPLOYEE-OCCUPATION): a slug reference into the
+  // OccupationProfile registry (validated in app code, not an FK — mirrors the
+  // StorefrontConfig.archetypeId semantic-slug pattern). Nullable: an unmapped
+  // position resolves to the archetype/platform fallback, an honest degrade.
+  occupationKey String?
   status     String            @default("active")
   createdAt  DateTime          @default(now())
   updatedAt  DateTime          @updatedAt
   employees  EmployeeProfile[]
 
   @@index([status])
+  @@index([occupationKey])
+}
+
+// Reusable, archetype-scoped template describing a customer's in-trench JOB
+// (dental hygienist, field service technician) — the "occupation" dimension.
+// Config/template, NOT an identity Principal (AGENTS.md §11 principal-convergence
+// not triggered); seeded from packages/db/data/occupation_registry.json, mirrored
+// here like StorefrontArchetype. Occupation FOCUSES the workspace surface and ADDS
+// a governed coworker roster; it never widens the platform-management RBAC floor.
+// Spec: docs/superpowers/specs/2026-07-16-employee-occupation-onboarding-and-role-tailored-workspace-design.md §5.1
+model OccupationProfile {
+  id                     String   @id @default(cuid())
+  occupationKey          String   @unique
+  label                  String
+  summary                String
+  // Industries/business-types this occupation appears in (validated against the
+  // storefront archetype catalog at seed time).
+  archetypeCategories    String[]
+  archetypeIds           String[]
+  // The RBAC/capability floor this occupation sits on (see spec §5.6). Stored as a
+  // slug; the concrete platform-role binding is finalized by the P0.1 base-access
+  // decision. Occupation never widens beyond this floor.
+  baseAccessProfile      String
+  // Link to the WSID professional corpus (EP-WSID); bound in Phase 3.
+  wsidProfessionFamily   String?
+  // { tileAllowlist: string[], navEmphasis: string[], workspaceHomeOccupationId?: string }
+  featureSurface         Json
+  // OccupationCoworkerGrant[]: { agentSlug, interaction: summon|assigned-only|read-only, governanceProfileRef? }
+  coworkerRoster         Json
+  onboardingCurriculumId String
+  moverCurriculumId      String?
+  isActive               Boolean  @default(true)
+  isBuiltIn              Boolean  @default(true)
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+
+  @@index([isActive])
 }
 
 model EmploymentType {

--- a/packages/db/src/seed-occupations.test.ts
+++ b/packages/db/src/seed-occupations.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  OCCUPATION_SEED_DATA,
+  OCCUPATION_INTERACTIONS,
+  validateOccupationRegistry,
+  knownArchetypeCategories,
+  knownArchetypeIds,
+  knownCoworkerSlugs,
+  type OccupationSeed,
+} from "./seed-occupations";
+
+const refs = {
+  categories: knownArchetypeCategories(),
+  archetypeIds: knownArchetypeIds(),
+  coworkerSlugs: knownCoworkerSlugs(),
+};
+
+function clone(seed: OccupationSeed): OccupationSeed {
+  return JSON.parse(JSON.stringify(seed)) as OccupationSeed;
+}
+
+describe("occupation registry (shipped seed)", () => {
+  it("loads the Phase-0 occupations", () => {
+    expect(OCCUPATION_SEED_DATA.length).toBeGreaterThanOrEqual(4);
+    const keys = OCCUPATION_SEED_DATA.map((o) => o.occupationKey);
+    expect(keys).toContain("dental-hygienist");
+    expect(keys).toContain("field-service-technician");
+  });
+
+  it("passes referential-integrity validation against the live catalogs", () => {
+    expect(() => validateOccupationRegistry(OCCUPATION_SEED_DATA, refs)).not.toThrow();
+  });
+
+  it("references only real archetype categories and real coworker slugs", () => {
+    for (const occ of OCCUPATION_SEED_DATA) {
+      for (const cat of occ.archetypeCategories) {
+        expect(refs.categories.has(cat)).toBe(true);
+      }
+      for (const grant of occ.coworkerRoster) {
+        expect(refs.coworkerSlugs.has(grant.agentSlug)).toBe(true);
+        expect(OCCUPATION_INTERACTIONS).toContain(grant.interaction);
+      }
+    }
+  });
+
+  it("has unique occupation keys", () => {
+    const keys = OCCUPATION_SEED_DATA.map((o) => o.occupationKey);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe("validateOccupationRegistry (fails closed)", () => {
+  const base = clone(OCCUPATION_SEED_DATA[0]);
+
+  it("rejects an unknown archetype category", () => {
+    const bad = clone(base);
+    bad.archetypeCategories = ["not-a-real-category"];
+    expect(() => validateOccupationRegistry([bad], refs)).toThrow(/unknown archetype category/);
+  });
+
+  it("rejects an unknown coworker slug", () => {
+    const bad = clone(base);
+    bad.coworkerRoster = [{ agentSlug: "ghost-coworker", interaction: "summon" }];
+    expect(() => validateOccupationRegistry([bad], refs)).toThrow(/unknown coworker slug/);
+  });
+
+  it("rejects an invalid interaction value", () => {
+    const bad = clone(base);
+    bad.coworkerRoster = [
+      { agentSlug: base.coworkerRoster[0].agentSlug, interaction: "control" as never },
+    ];
+    expect(() => validateOccupationRegistry([bad], refs)).toThrow(/invalid interaction/);
+  });
+
+  it("rejects a duplicate occupation key", () => {
+    expect(() => validateOccupationRegistry([clone(base), clone(base)], refs)).toThrow(
+      /duplicate occupationKey/,
+    );
+  });
+
+  it("rejects an empty tile allowlist", () => {
+    const bad = clone(base);
+    bad.featureSurface.tileAllowlist = [];
+    expect(() => validateOccupationRegistry([bad], refs)).toThrow(/tileAllowlist/);
+  });
+
+  it("rejects an empty coworker roster", () => {
+    const bad = clone(base);
+    bad.coworkerRoster = [];
+    expect(() => validateOccupationRegistry([bad], refs)).toThrow(/coworkerRoster/);
+  });
+
+  it("rejects a non-kebab occupationKey", () => {
+    const bad = clone(base);
+    bad.occupationKey = "Not_Valid Key";
+    expect(() => validateOccupationRegistry([bad], refs)).toThrow(/kebab-case/);
+  });
+});

--- a/packages/db/src/seed-occupations.ts
+++ b/packages/db/src/seed-occupations.ts
@@ -1,0 +1,197 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Prisma, PrismaClient } from "../generated/client/client";
+import { ARCHETYPE_SEED_DATA } from "@dpf/storefront-templates/seed";
+import { COWORKER_AGENT_SEEDS } from "./workforce-seed.js";
+
+// EP-EMPLOYEE-OCCUPATION Phase 1 (BI-442E2B42). Seeds the OccupationProfile
+// registry from packages/db/data/occupation_registry.json — the "occupation"
+// dimension (a customer's in-trench JOB), config/template, not an identity
+// Principal. Mirrors seed-storefront-archetypes.ts.
+// Spec: docs/superpowers/specs/2026-07-16-employee-occupation-onboarding-and-role-tailored-workspace-design.md §5.1
+
+const DATA_DIR = join(__dirname, "..", "data");
+
+/** Closed enum for how an occupation may reach a rostered coworker (AGENTS.md §3). */
+export const OCCUPATION_INTERACTIONS = ["summon", "assigned-only", "read-only"] as const;
+export type OccupationInteraction = (typeof OCCUPATION_INTERACTIONS)[number];
+
+export type OccupationCoworkerGrant = {
+  agentSlug: string;
+  interaction: OccupationInteraction;
+  governanceProfileRef?: string | null;
+};
+
+export type OccupationFeatureSurface = {
+  tileAllowlist: string[];
+  navEmphasis: string[];
+  workspaceHomeOccupationId?: string | null;
+};
+
+export type OccupationSeed = {
+  occupationKey: string;
+  label: string;
+  summary: string;
+  archetypeCategories: string[];
+  archetypeIds: string[];
+  baseAccessProfile: string;
+  wsidProfessionFamily?: string | null;
+  featureSurface: OccupationFeatureSurface;
+  coworkerRoster: OccupationCoworkerGrant[];
+  onboardingCurriculumId: string;
+  moverCurriculumId?: string | null;
+};
+
+type OccupationRegistryFile = {
+  version: string;
+  occupations: OccupationSeed[];
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const json = (v: unknown): Prisma.InputJsonValue =>
+  JSON.parse(JSON.stringify(v)) as Prisma.InputJsonValue;
+
+function readJson<T>(filename: string): T {
+  return JSON.parse(readFileSync(join(DATA_DIR, filename), "utf-8")) as T;
+}
+
+/** The set of archetype categories present in the storefront catalog. */
+export function knownArchetypeCategories(): ReadonlySet<string> {
+  return new Set(ARCHETYPE_SEED_DATA.map((a) => a.category));
+}
+
+/** The set of archetype ids present in the storefront catalog. */
+export function knownArchetypeIds(): ReadonlySet<string> {
+  return new Set(ARCHETYPE_SEED_DATA.map((a) => a.archetypeId));
+}
+
+/** The set of seeded coworker slugs an occupation may roster. */
+export function knownCoworkerSlugs(): ReadonlySet<string> {
+  return new Set(COWORKER_AGENT_SEEDS.map((c) => c.slugId));
+}
+
+export type OccupationValidationRefs = {
+  categories: ReadonlySet<string>;
+  archetypeIds: ReadonlySet<string>;
+  coworkerSlugs: ReadonlySet<string>;
+};
+
+/**
+ * Referential-integrity validation (spec §7). Throws on the first violation so a
+ * bad seed fails closed rather than writing a dangling occupation. Exported so the
+ * seed test asserts the shipped registry is clean without a live DB.
+ */
+export function validateOccupationRegistry(
+  occupations: readonly OccupationSeed[],
+  refs: OccupationValidationRefs,
+): void {
+  const seenKeys = new Set<string>();
+  for (const occ of occupations) {
+    const where = `occupation "${occ.occupationKey}"`;
+
+    if (!occ.occupationKey || !/^[a-z0-9-]+$/.test(occ.occupationKey)) {
+      throw new Error(`${where}: occupationKey must be a non-empty kebab-case slug.`);
+    }
+    if (seenKeys.has(occ.occupationKey)) {
+      throw new Error(`${where}: duplicate occupationKey.`);
+    }
+    seenKeys.add(occ.occupationKey);
+
+    for (const field of ["label", "summary", "baseAccessProfile", "onboardingCurriculumId"] as const) {
+      if (typeof occ[field] !== "string" || occ[field].trim().length === 0) {
+        throw new Error(`${where}: ${field} must be a non-empty string.`);
+      }
+    }
+
+    if (!Array.isArray(occ.archetypeCategories) || occ.archetypeCategories.length === 0) {
+      throw new Error(`${where}: archetypeCategories must be a non-empty array.`);
+    }
+    for (const cat of occ.archetypeCategories) {
+      if (!refs.categories.has(cat)) {
+        throw new Error(`${where}: unknown archetype category "${cat}".`);
+      }
+    }
+    for (const id of occ.archetypeIds ?? []) {
+      if (!refs.archetypeIds.has(id)) {
+        throw new Error(`${where}: unknown archetypeId "${id}".`);
+      }
+    }
+
+    if (!occ.featureSurface || !Array.isArray(occ.featureSurface.tileAllowlist) || occ.featureSurface.tileAllowlist.length === 0) {
+      throw new Error(`${where}: featureSurface.tileAllowlist must be a non-empty array.`);
+    }
+    if (!Array.isArray(occ.featureSurface.navEmphasis)) {
+      throw new Error(`${where}: featureSurface.navEmphasis must be an array.`);
+    }
+
+    if (!Array.isArray(occ.coworkerRoster) || occ.coworkerRoster.length === 0) {
+      throw new Error(`${where}: coworkerRoster must be a non-empty array.`);
+    }
+    const seenAgents = new Set<string>();
+    for (const grant of occ.coworkerRoster) {
+      if (!refs.coworkerSlugs.has(grant.agentSlug)) {
+        throw new Error(`${where}: rosters unknown coworker slug "${grant.agentSlug}".`);
+      }
+      if (seenAgents.has(grant.agentSlug)) {
+        throw new Error(`${where}: duplicate coworker "${grant.agentSlug}" in roster.`);
+      }
+      seenAgents.add(grant.agentSlug);
+      if (!OCCUPATION_INTERACTIONS.includes(grant.interaction)) {
+        throw new Error(`${where}: coworker "${grant.agentSlug}" has invalid interaction "${grant.interaction}".`);
+      }
+    }
+  }
+}
+
+/** Loads and validates the shipped occupation registry. */
+export function loadOccupationRegistry(): OccupationSeed[] {
+  const registry = readJson<OccupationRegistryFile>("occupation_registry.json");
+  validateOccupationRegistry(registry.occupations, {
+    categories: knownArchetypeCategories(),
+    archetypeIds: knownArchetypeIds(),
+    coworkerSlugs: knownCoworkerSlugs(),
+  });
+  return registry.occupations;
+}
+
+export const OCCUPATION_SEED_DATA: readonly OccupationSeed[] = loadOccupationRegistry();
+
+export async function seedOccupations(prisma: PrismaClient): Promise<void> {
+  console.log(`[seed] upserting ${OCCUPATION_SEED_DATA.length} occupation profiles…`);
+
+  for (const occ of OCCUPATION_SEED_DATA) {
+    await prisma.occupationProfile.upsert({
+      where: { occupationKey: occ.occupationKey },
+      create: {
+        occupationKey: occ.occupationKey,
+        label: occ.label,
+        summary: occ.summary,
+        archetypeCategories: occ.archetypeCategories,
+        archetypeIds: occ.archetypeIds ?? [],
+        baseAccessProfile: occ.baseAccessProfile,
+        wsidProfessionFamily: occ.wsidProfessionFamily ?? null,
+        featureSurface: json(occ.featureSurface),
+        coworkerRoster: json(occ.coworkerRoster),
+        onboardingCurriculumId: occ.onboardingCurriculumId,
+        moverCurriculumId: occ.moverCurriculumId ?? null,
+        isActive: true,
+      },
+      update: {
+        // isActive intentionally excluded: re-seeding must not reactivate an
+        // occupation an operator has soft-deleted (mirrors seed-storefront-archetypes).
+        label: occ.label,
+        summary: occ.summary,
+        archetypeCategories: occ.archetypeCategories,
+        archetypeIds: occ.archetypeIds ?? [],
+        baseAccessProfile: occ.baseAccessProfile,
+        wsidProfessionFamily: occ.wsidProfessionFamily ?? null,
+        featureSurface: json(occ.featureSurface),
+        coworkerRoster: json(occ.coworkerRoster),
+        onboardingCurriculumId: occ.onboardingCurriculumId,
+        moverCurriculumId: occ.moverCurriculumId ?? null,
+      },
+    });
+  }
+
+  console.log(`[seed] occupation profiles done`);
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -39,6 +39,7 @@ import {
   seedWorkforceReferenceData,
 } from "./workforce-seed.js";
 import { seedStorefrontArchetypes } from "./seed-storefront-archetypes.js";
+import { seedOccupations } from "./seed-occupations.js";
 import { seedPublicSectorCompliance } from "./seed-public-sector-compliance.js";
 import { seedCooperativeCompliance } from "./seed-cooperative-compliance.js";
 import { seedLawEnforcementCompliance } from "./seed-law-enforcement-compliance.js";
@@ -2421,6 +2422,9 @@ async function main(): Promise<void> {
   await step("clientIdentity", () => seedClientIdentity());
   await step("hiveContributionCredential", () => seedHiveContributionCredential());
   await step("storefrontArchetypes", () => seedStorefrontArchetypes(prisma));
+  // EP-EMPLOYEE-OCCUPATION: occupation registry depends on the storefront archetype
+  // catalog (categories) + the coworker roster, so it seeds after both.
+  await step("occupations", () => seedOccupations(prisma));
   await step("publicSectorCompliance", () => seedPublicSectorCompliance(prisma));
   await step("cooperativeCompliance", () => seedCooperativeCompliance(prisma));
   await step("lawEnforcementCompliance", () => seedLawEnforcementCompliance(prisma));


### PR DESCRIPTION
First **implementation** slice of `EP-EMPLOYEE-OCCUPATION` (design + plan landed in #3114/#3121). Delivers the Phase-1 substrate that every later phase depends on: the **occupation dimension** bridging a customer's in-trench employees (dental hygienist, field service technician) to a role-tailored workspace, a coworker roster, and job-aware onboarding.

**Occupation FOCUSES the surface and ADDS a governed coworker roster; it never widens the platform-management RBAC floor.**

## What's in this slice
- **Schema:** `OccupationProfile` model (config/template, **not** a `Principal`) + nullable `Position.occupationKey` (a slug reference, not an FK — mirrors `StorefrontConfig.archetypeId`). Data-safe migration `20260717000000_add_occupation_dimension` (nullable column + new table; hand-authored because the worktree is source-only).
- **Seed:** [`occupation_registry.json`](../blob/feat/occupation-dimension-substrate/packages/db/data/occupation_registry.json) — 4 Phase-0 occupations across two archetype categories (clinic: dental-hygienist, front-desk-coordinator; trades: field-service-technician, field-dispatcher) — with a **fail-closed** `seed-occupations.ts` wired into `seed.ts`. The seed validates every occupation against the **live archetype-category catalog** and the **seeded coworker slugs** (`COWORKER_AGENT_SEEDS`); `interaction` is the closed `summon|assigned-only|read-only` enum (AGENTS.md §3).
- **Resolver:** `apps/web/lib/workforce/occupation.ts` — `resolveOccupationForEmployee` / `resolveOccupationForUser` / `getOccupationByKey`, DI-testable, with the `invalidateOccupationCache` **seam the Phase-5 mover event consumes**. The employee→occupation walk is uncached so a `Position.occupationKey` change is seen immediately (spec §5.2); only the immutable profile config is memoized.
- **Tests:** referential-integrity + fail-closed seed validation; resolver fallbacks (no position / no key / unknown occupation all → honest `null`), JSON parsing, memoization + invalidation.

## Stewardship
- `OnboardingTask.kind` (spec §6) maps onto the **existing** `OnboardingTask.checklistType` field — **no new column**. `platform-intro`/`occupation-mover` values arrive when P4/P5 create rows.
- `baseAccessProfile` is seeded as the `workforce-member` slug **pending the P0.1 RBAC decision** (spec §5.6 recommends `HR-600`); `wsidProfessionFamily` + roster `governanceProfileRef` bind in Phase 3.

## Verification
Worktree is source-only (no `node_modules`), so the four gates run in **CI/sandbox**, not locally: Typecheck, Unit Tests, Prod Build, migration apply. Local typecheck was unrunnable (harness limitation, AGENTS.md §5) — `DPF_SKIP_TYPECHECK` override documented in the commit; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Seed-Fit-Decision: archetype-scoped — the seeded occupations are scoped by archetype category (healthcare-wellness, trades-maintenance), symmetric with the storefront archetype seeds; they are fleet defaults per archetype, not global or install-local.