### PR TITLE
feat(workbooks): pivot table in the Summary panel (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/components/workbooks/Grid.tsx
+++ b/apps/web/components/workbooks/Grid.tsx
@@ -121,6 +121,7 @@ import {
   normalizeViewState,
 } from "./grid-named-views";
 import { GridViewsMenu } from "./GridViewsMenu";
+import { type PivotAgg, type SummaryMode } from "./grid-pivot";
 import {
   reorderColumnIds,
   applyColumnOrder,
@@ -371,7 +372,10 @@ export function WorkbookGrid({
   const [showSummary, setShowSummary] = useState(false);
   const [summaryGroupBy, setSummaryGroupBy] = useState("");
   const [summaryValue, setSummaryValue] = useState("");
-  const [summaryChart, setSummaryChart] = useState(false);
+  const [summaryMode, setSummaryMode] = useState<SummaryMode>("table");
+  // Pivot (2-D summary): the "across" column + the aggregate applied to cells.
+  const [summaryPivotCol, setSummaryPivotCol] = useState("");
+  const [summaryAgg, setSummaryAgg] = useState<PivotAgg>("count");
   const [filterGroup, setFilterGroup] = useState<FilterGroup>(EMPTY_FILTER_GROUP);
   const activeFilterCount = activeConditionCount(filterGroup);
   // Drag-to-reorder column order (column ids) + in-grid collapsible grouping.
@@ -1207,8 +1211,12 @@ export function WorkbookGrid({
           setSummaryGroupBy={setSummaryGroupBy}
           summaryValue={summaryValue}
           setSummaryValue={setSummaryValue}
-          summaryChart={summaryChart}
-          setSummaryChart={setSummaryChart}
+          summaryMode={summaryMode}
+          setSummaryMode={setSummaryMode}
+          summaryPivotCol={summaryPivotCol}
+          setSummaryPivotCol={setSummaryPivotCol}
+          summaryAgg={summaryAgg}
+          setSummaryAgg={setSummaryAgg}
         />
       )}
 

--- a/apps/web/components/workbooks/GridPanels.tsx
+++ b/apps/web/components/workbooks/GridPanels.tsx
@@ -22,6 +22,13 @@ import {
 } from "./grid-filter-builder";
 import { numericColumns, summarize, summaryChartBars } from "./grid-summary";
 import {
+  pivot,
+  pivotAggNeedsValue,
+  PIVOT_AGG_LABELS,
+  type PivotAgg,
+  type SummaryMode,
+} from "./grid-pivot";
+import {
   type ConditionalRule,
   CF_OPERATORS,
   CF_OPERATOR_LABELS,
@@ -182,9 +189,18 @@ export interface GridSummaryPanelProps {
   setSummaryGroupBy: Dispatch<SetStateAction<string>>;
   summaryValue: string;
   setSummaryValue: Dispatch<SetStateAction<string>>;
-  summaryChart: boolean;
-  setSummaryChart: Dispatch<SetStateAction<boolean>>;
+  summaryMode: SummaryMode;
+  setSummaryMode: Dispatch<SetStateAction<SummaryMode>>;
+  /** Pivot "across" column + the aggregate applied to each cell. */
+  summaryPivotCol: string;
+  setSummaryPivotCol: Dispatch<SetStateAction<string>>;
+  summaryAgg: PivotAgg;
+  setSummaryAgg: Dispatch<SetStateAction<PivotAgg>>;
 }
+
+const MODES: SummaryMode[] = ["table", "chart", "pivot"];
+const MODE_LABELS: Record<SummaryMode, string> = { table: "Table", chart: "Chart", pivot: "Pivot" };
+const PIVOT_AGGS: PivotAgg[] = ["count", "sum", "avg", "min", "max"];
 
 export function GridSummaryPanel({
   columns,
@@ -193,22 +209,33 @@ export function GridSummaryPanel({
   setSummaryGroupBy,
   summaryValue,
   setSummaryValue,
-  summaryChart,
-  setSummaryChart,
+  summaryMode,
+  setSummaryMode,
+  summaryPivotCol,
+  setSummaryPivotCol,
+  summaryAgg,
+  setSummaryAgg,
 }: GridSummaryPanelProps): ReactNode {
   const groupBy = summaryGroupBy || columns[0]!.columnId;
   const valueCol = summaryValue || undefined;
   const numCols = numericColumns(columns);
   const summary = summarize(sortedRows, groupBy, valueCol);
+  // Pivot "across" axis defaults to the first column that isn't the row axis.
+  const pivotCol =
+    summaryPivotCol || columns.find((c) => c.columnId !== groupBy)?.columnId || columns[0]!.columnId;
+  const showValuePicker = summaryMode !== "pivot" || pivotAggNeedsValue(summaryAgg);
+  const p = summaryMode === "pivot" ? pivot(sortedRows, groupBy, pivotCol, valueCol, summaryAgg) : null;
 
   return (
     <div className={PANEL}>
       <div className="flex flex-wrap items-center gap-2">
-        <span className="text-sm text-[var(--dpf-muted)]">Group by</span>
+        <span className="text-sm text-[var(--dpf-muted)]">
+          {summaryMode === "pivot" ? "Rows" : "Group by"}
+        </span>
         <select
           value={groupBy}
           onChange={(e) => setSummaryGroupBy(e.target.value)}
-          aria-label="Group by column"
+          aria-label={summaryMode === "pivot" ? "Pivot row column" : "Group by column"}
           className={CTRL}
         >
           {columns.map((c) => (
@@ -217,46 +244,115 @@ export function GridSummaryPanel({
             </option>
           ))}
         </select>
-        <span className="text-sm text-[var(--dpf-muted)]">summarize</span>
-        <select
-          value={summaryValue}
-          onChange={(e) => setSummaryValue(e.target.value)}
-          aria-label="Value column"
-          className={CTRL}
-        >
-          <option value="">count only</option>
-          {numCols.map((c) => (
-            <option key={c.columnId} value={c.columnId}>
-              {c.name}
-            </option>
-          ))}
-        </select>
+        {summaryMode === "pivot" && (
+          <>
+            <span className="text-sm text-[var(--dpf-muted)]">Columns</span>
+            <select
+              value={pivotCol}
+              onChange={(e) => setSummaryPivotCol(e.target.value)}
+              aria-label="Pivot column"
+              className={CTRL}
+            >
+              {columns.map((c) => (
+                <option key={c.columnId} value={c.columnId}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+            <select
+              value={summaryAgg}
+              onChange={(e) => setSummaryAgg(e.target.value as PivotAgg)}
+              aria-label="Pivot aggregate"
+              className={CTRL}
+            >
+              {PIVOT_AGGS.map((a) => (
+                <option key={a} value={a}>
+                  {PIVOT_AGG_LABELS[a]}
+                </option>
+              ))}
+            </select>
+          </>
+        )}
+        {showValuePicker && (
+          <>
+            <span className="text-sm text-[var(--dpf-muted)]">
+              {summaryMode === "pivot" ? "of" : "summarize"}
+            </span>
+            <select
+              value={summaryValue}
+              onChange={(e) => setSummaryValue(e.target.value)}
+              aria-label="Value column"
+              className={CTRL}
+            >
+              <option value="">{summaryMode === "pivot" ? "—" : "count only"}</option>
+              {numCols.map((c) => (
+                <option key={c.columnId} value={c.columnId}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </>
+        )}
         <div className="ml-auto inline-flex overflow-hidden rounded-md border border-[var(--dpf-border)] text-sm">
-          <button
-            type="button"
-            onClick={() => setSummaryChart(false)}
-            className={
-              summaryChart
-                ? "px-2 py-1 text-[var(--dpf-muted)]"
-                : "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
-            }
-          >
-            Table
-          </button>
-          <button
-            type="button"
-            onClick={() => setSummaryChart(true)}
-            className={
-              summaryChart
-                ? "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
-                : "px-2 py-1 text-[var(--dpf-muted)]"
-            }
-          >
-            Chart
-          </button>
+          {MODES.map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setSummaryMode(m)}
+              className={
+                summaryMode === m
+                  ? "bg-[var(--dpf-surface-1)] px-2 py-1 font-medium text-[var(--dpf-text)]"
+                  : "px-2 py-1 text-[var(--dpf-muted)]"
+              }
+            >
+              {MODE_LABELS[m]}
+            </button>
+          ))}
         </div>
       </div>
-      {summaryChart ? (
+      {summaryMode === "pivot" && p ? (
+        <div className="overflow-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-[var(--dpf-muted)]">
+                <th className="px-2 py-1" />
+                {p.colKeys.map((ck) => (
+                  <th key={ck} className="px-2 py-1 text-right tabular-nums">
+                    {ck}
+                  </th>
+                ))}
+                <th className="px-2 py-1 text-right font-semibold">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {p.rowKeys.map((rk) => (
+                <tr key={rk} className="border-t border-[var(--dpf-border)]">
+                  <th className="px-2 py-1 text-left font-normal text-[var(--dpf-muted)]">{rk}</th>
+                  {p.colKeys.map((ck) => (
+                    <td key={ck} className="px-2 py-1 text-right tabular-nums text-[var(--dpf-text)]">
+                      {p.cells[rk]![ck]}
+                    </td>
+                  ))}
+                  <td className="px-2 py-1 text-right font-semibold tabular-nums text-[var(--dpf-text)]">
+                    {p.rowTotals[rk]}
+                  </td>
+                </tr>
+              ))}
+              <tr className="border-t border-[var(--dpf-border)] font-semibold">
+                <th className="px-2 py-1 text-left">Total</th>
+                {p.colKeys.map((ck) => (
+                  <td key={ck} className="px-2 py-1 text-right tabular-nums text-[var(--dpf-text)]">
+                    {p.colTotals[ck]}
+                  </td>
+                ))}
+                <td className="px-2 py-1 text-right tabular-nums text-[var(--dpf-text)]">
+                  {p.grandTotal}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      ) : summaryMode === "chart" ? (
         <div className="flex flex-col gap-1">
           {summaryChartBars(summary, Boolean(valueCol)).map((bar) => (
             <div key={bar.group} className="flex items-center gap-2 text-sm">

--- a/apps/web/components/workbooks/grid-pivot.test.ts
+++ b/apps/web/components/workbooks/grid-pivot.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { pivot, pivotAggNeedsValue, PIVOT_AGG_LABELS } from "./grid-pivot";
+import type { GridRowData } from "./cell-editors";
+
+// status × type, with an `amount` value column.
+const rows: GridRowData[] = [
+  { rowId: "1", status: "open", type: "bug", amount: 10 },
+  { rowId: "2", status: "open", type: "bug", amount: 20 },
+  { rowId: "3", status: "open", type: "feature", amount: 5 },
+  { rowId: "4", status: "done", type: "bug", amount: 100 },
+  { rowId: "5", status: "done", type: "feature", amount: 0 },
+  { rowId: "6", status: "", type: "bug", amount: 7 }, // blank status → (empty)
+];
+
+describe("pivot — count", () => {
+  const p = pivot(rows, "status", "type", undefined, "count");
+
+  it("lists row keys with (empty) last, columns sorted", () => {
+    expect(p.rowKeys).toEqual(["done", "open", "(empty)"]);
+    expect(p.colKeys).toEqual(["bug", "feature"]);
+  });
+
+  it("counts rows per intersection", () => {
+    expect(p.cells["open"]!["bug"]).toBe(2);
+    expect(p.cells["open"]!["feature"]).toBe(1);
+    expect(p.cells["done"]!["bug"]).toBe(1);
+    expect(p.cells["(empty)"]!["feature"]).toBe(0); // no such row
+  });
+
+  it("computes row / column / grand totals", () => {
+    expect(p.rowTotals["open"]).toBe(3);
+    expect(p.colTotals["bug"]).toBe(4); // rows 1,2,4,6
+    expect(p.grandTotal).toBe(6);
+  });
+});
+
+describe("pivot — sum of a value column", () => {
+  const p = pivot(rows, "status", "type", "amount", "sum");
+
+  it("sums the value per intersection", () => {
+    expect(p.cells["open"]!["bug"]).toBe(30); // 10 + 20
+    expect(p.cells["done"]!["bug"]).toBe(100);
+  });
+
+  it("row/col/grand totals sum the raw values", () => {
+    expect(p.rowTotals["open"]).toBe(35); // 10+20+5
+    expect(p.colTotals["bug"]).toBe(137); // 10+20+100+7
+    expect(p.grandTotal).toBe(142);
+  });
+});
+
+describe("pivot — avg/min/max aggregate raw values, not cell aggregates", () => {
+  it("avg total is the mean of the row's raw values (not a mean of cell means)", () => {
+    const p = pivot(rows, "status", "type", "amount", "avg");
+    // open row: values 10, 20, 5 → mean 11.67 (NOT (avg(bug)=15 + avg(feature)=5)/2 = 10)
+    expect(p.rowTotals["open"]).toBe(11.67);
+    expect(p.cells["open"]!["bug"]).toBe(15); // (10+20)/2
+  });
+
+  it("min/max over raw values", () => {
+    const pMin = pivot(rows, "status", "type", "amount", "min");
+    expect(pMin.rowTotals["open"]).toBe(5);
+    const pMax = pivot(rows, "status", "type", "amount", "max");
+    expect(pMax.colTotals["bug"]).toBe(100);
+  });
+});
+
+describe("pivot — edge cases", () => {
+  it("returns empty axes for no rows", () => {
+    const p = pivot([], "status", "type", "amount", "sum");
+    expect(p.rowKeys).toEqual([]);
+    expect(p.colKeys).toEqual([]);
+    expect(p.grandTotal).toBe(0);
+  });
+
+  it("non-numeric values are ignored by numeric aggregates (0 when none)", () => {
+    const textRows: GridRowData[] = [{ rowId: "1", a: "x", b: "y", v: "not a number" }];
+    const p = pivot(textRows, "a", "b", "v", "sum");
+    expect(p.cells["x"]!["y"]).toBe(0);
+  });
+});
+
+describe("pivotAggNeedsValue / labels", () => {
+  it("count needs no value column; the rest do", () => {
+    expect(pivotAggNeedsValue("count")).toBe(false);
+    expect(pivotAggNeedsValue("sum")).toBe(true);
+    expect(pivotAggNeedsValue("avg")).toBe(true);
+  });
+
+  it("labels every aggregate", () => {
+    expect(PIVOT_AGG_LABELS.sum).toBe("Sum");
+    expect(PIVOT_AGG_LABELS.count).toBe("Count");
+  });
+});

--- a/apps/web/components/workbooks/grid-pivot.ts
+++ b/apps/web/components/workbooks/grid-pivot.ts
@@ -1,0 +1,158 @@
+// Universal Grid & Workbooks — pivot table (EP-GRID-WORKBOOKS Phase 4).
+//
+// The 2-D generalization of the group-by summary (`grid-summary.ts`): cross a
+// "rows" column against a "columns" column and aggregate a value (or count) into
+// a matrix, with row / column / grand totals. Pure + unit-testable; operates over
+// the rows already loaded in the grid. Totals aggregate the raw values (not the
+// cell aggregates), so an `avg`/`min`/`max` total is correct rather than an
+// average-of-averages.
+
+import type { GridRowData } from "./cell-editors";
+import { cellSearchText } from "./grid-filter";
+import { toSummaryNumber } from "./grid-summary";
+
+export type PivotAgg = "count" | "sum" | "avg" | "min" | "max";
+
+/** How the Summary panel renders the grouped rows. */
+export type SummaryMode = "table" | "chart" | "pivot";
+
+export const PIVOT_AGG_LABELS: Record<PivotAgg, string> = {
+  count: "Count",
+  sum: "Sum",
+  avg: "Average",
+  min: "Min",
+  max: "Max",
+};
+
+/** `count` works for any value column; the rest need a numeric value column. */
+export function pivotAggNeedsValue(agg: PivotAgg): boolean {
+  return agg !== "count";
+}
+
+const EMPTY_KEY = "(empty)";
+
+/** Running accumulator for one bucket (cell / row / col / grand). */
+interface Acc {
+  count: number; // rows in the bucket
+  sum: number;
+  min: number;
+  max: number;
+  n: number; // numeric values seen (for avg/min/max validity)
+}
+
+function newAcc(): Acc {
+  return { count: 0, sum: 0, min: Infinity, max: -Infinity, n: 0 };
+}
+
+function add(acc: Acc, value: number | null): void {
+  acc.count += 1;
+  if (value !== null) {
+    acc.sum += value;
+    acc.n += 1;
+    if (value < acc.min) acc.min = value;
+    if (value > acc.max) acc.max = value;
+  }
+}
+
+function round2(x: number): number {
+  return Math.round(x * 100) / 100;
+}
+
+/** Reduce an accumulator to the chosen aggregate (0 when no numeric values). */
+function reduce(acc: Acc, agg: PivotAgg): number {
+  switch (agg) {
+    case "count":
+      return acc.count;
+    case "sum":
+      return round2(acc.sum);
+    case "avg":
+      return acc.n ? round2(acc.sum / acc.n) : 0;
+    case "min":
+      return acc.n ? round2(acc.min) : 0;
+    case "max":
+      return acc.n ? round2(acc.max) : 0;
+    default:
+      return 0;
+  }
+}
+
+/** Sort keys alphabetically, with the "(empty)" bucket always last. */
+function sortKeys(keys: Iterable<string>): string[] {
+  return [...keys].sort((a, b) => {
+    if (a === EMPTY_KEY) return 1;
+    if (b === EMPTY_KEY) return -1;
+    return a.localeCompare(b);
+  });
+}
+
+export interface PivotTable {
+  rowKeys: string[];
+  colKeys: string[];
+  /** cells[rowKey][colKey] — the aggregate for that intersection (0 if empty). */
+  cells: Record<string, Record<string, number>>;
+  rowTotals: Record<string, number>;
+  colTotals: Record<string, number>;
+  grandTotal: number;
+  agg: PivotAgg;
+}
+
+/**
+ * Cross `rowColumnId` (down) against `colColumnId` (across) and aggregate
+ * `valueColumnId` per intersection with `agg`. When `agg` is `count` (or no value
+ * column), each row contributes 1. Blank group values collapse into `(empty)`.
+ */
+export function pivot(
+  rows: readonly GridRowData[],
+  rowColumnId: string,
+  colColumnId: string,
+  valueColumnId: string | undefined,
+  agg: PivotAgg,
+): PivotTable {
+  const cellAcc = new Map<string, Map<string, Acc>>();
+  const rowAcc = new Map<string, Acc>();
+  const colAcc = new Map<string, Acc>();
+  const grand = newAcc();
+  const useValue = pivotAggNeedsValue(agg) && Boolean(valueColumnId);
+
+  for (const row of rows) {
+    const rk = cellSearchText(row[rowColumnId] ?? null) || EMPTY_KEY;
+    const ck = cellSearchText(row[colColumnId] ?? null) || EMPTY_KEY;
+    const v = useValue ? toSummaryNumber(row[valueColumnId!] ?? null) : null;
+
+    let byCol = cellAcc.get(rk);
+    if (!byCol) cellAcc.set(rk, (byCol = new Map()));
+    let acc = byCol.get(ck);
+    if (!acc) byCol.set(ck, (acc = newAcc()));
+    add(acc, v);
+
+    let ra = rowAcc.get(rk);
+    if (!ra) rowAcc.set(rk, (ra = newAcc()));
+    add(ra, v);
+
+    let ca = colAcc.get(ck);
+    if (!ca) colAcc.set(ck, (ca = newAcc()));
+    add(ca, v);
+
+    add(grand, v);
+  }
+
+  const rowKeys = sortKeys(rowAcc.keys());
+  const colKeys = sortKeys(colAcc.keys());
+
+  const cells: Record<string, Record<string, number>> = {};
+  for (const rk of rowKeys) {
+    cells[rk] = {};
+    const byCol = cellAcc.get(rk);
+    for (const ck of colKeys) {
+      const acc = byCol?.get(ck);
+      cells[rk][ck] = acc ? reduce(acc, agg) : 0;
+    }
+  }
+
+  const rowTotals: Record<string, number> = {};
+  for (const rk of rowKeys) rowTotals[rk] = reduce(rowAcc.get(rk)!, agg);
+  const colTotals: Record<string, number> = {};
+  for (const ck of colKeys) colTotals[ck] = reduce(colAcc.get(ck)!, agg);
+
+  return { rowKeys, colKeys, cells, rowTotals, colTotals, grandTotal: reduce(grand, agg), agg };
+}

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -258,10 +258,17 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   `orderBy asc`, so no migration). The handle is shown only when a manual order is actually in effect —
   custom source, editable, **no active sort and no grouping** (a sort/group defines the order and
   overrides the manual one). Platform grids (large, DB-ordered) are intentionally out of scope.
+- **Slice 26 — pivot table — SHIPPED.** The Summary panel's Table/Chart toggle becomes Table/Chart/**Pivot**.
+  Pivot mode crosses a **Rows** column against a **Columns** column and aggregates a value (or count) into
+  a matrix with row / column / grand totals — the 2-D generalization of the group-by summary. Pure,
+  unit-tested `pivot()` in `grid-pivot.ts`: incremental `{count,sum,min,max,n}` accumulators per cell /
+  row / col / grand, so an `avg`/`min`/`max` **total is over the raw values, not an average-of-averages**.
+  Aggregates: count / sum / average / min / max (numeric aggregates need a value column). Over the loaded
+  rows (SQL push-down is later work). Reuses `toSummaryNumber`/`cellSearchText`; no contract change.
 - **Remaining (not built):** manual row reordering for *platform* grids (would need a per-user client
   order; low value on 1000s of rows); platform-grid *shareable* views (needs a `WorkbookView.tableId`
   schema change — platform tables have no `WorkbookTable` row); calendar view (fullcalendar — needs a date
-  column); full pivots + richer charts; metrics/semantic layer; operationalization lifecycle.
+  column); richer charts (grouped/stacked/line); metrics/semantic layer; operationalization lifecycle.
   **Debt (decomposition — largely paid down):** all five toolbar panels — Filter, Summary, Format,
   Group, Columns — now live as typed, presentational components in `GridPanels.tsx` (pure UI over
   props the Grid owns). This dropped `Grid.tsx` from 1298 → 1094 LOC. Remaining `Grid.tsx` bulk is the

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -12,7 +12,7 @@ apps/web/components/platform/AiOperationsMap.tsx	2881
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
 apps/web/components/storefront/SlotBookingFlow.tsx	919
-apps/web/components/workbooks/Grid.tsx	1346
+apps/web/components/workbooks/Grid.tsx	1354
 apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1341
 apps/web/lib/actions/agent-coworker-external.test.ts	867

--- a/scripts/reporting-composition-baseline.json
+++ b/scripts/reporting-composition-baseline.json
@@ -71,6 +71,6 @@
   "apps/web/components/product/ProductSupplyChainPanel.tsx": 1,
   "apps/web/components/storefront/sections/LoanCalculatorSection.tsx": 1,
   "apps/web/components/wiki/WikiPageViewer.tsx": 1,
-  "apps/web/components/workbooks/GridPanels.tsx": 1,
+  "apps/web/components/workbooks/GridPanels.tsx": 2,
   "apps/web/components/workspace/PlatformReadinessMatrix.tsx": 1
 }


### PR DESCRIPTION
## What

The Summary panel's **Table / Chart** toggle becomes **Table / Chart / Pivot**. Pivot mode crosses a **Rows** column against a **Columns** column and aggregates a value (or count) into a matrix with **row / column / grand totals** — the 2-D generalization of the group-by summary, and the last big reporting-parity gap.

Aggregates: **count / sum / average / min / max** (numeric ones need a value column; count needs none). Blank group values → "(empty)" (sorted last). Over the loaded rows.

## Correctness

Pure, unit-tested `pivot()` in `grid-pivot.ts` uses incremental `{count, sum, min, max, n}` accumulators per cell / row / col / grand — so an **avg/min/max total aggregates the raw values**, not the cell aggregates. A test pins the mean-of-means bug it avoids: open row `[10, 20, 5]` → avg **11.67**, not `(15+5)/2 = 10`. 11 new tests; **140/140 workbooks green**.

## Notes

- Summary state moved from a `summaryChart` boolean to a `summaryMode` enum + pivot column/aggregate — all **ephemeral** (not persisted), so no view-state change.
- `GridPanels.tsx` 643→739 (under the size guard); `Grid.tsx` 1346→1354. Bumped the reporting-composition ratchet for the new pivot `<table>`. CI runs the authoritative typecheck.

## Design grounding

Extends the phase-2 plan (Slice 26, the Phase-4 "full pivots" remaining item) and `grid-summary.ts`; pure client compute over loaded rows, no contract change.

Design-Grounding-Decision: extends docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md (Slice 26) + grid-summary.ts over apps/web/; no contract change.
UX-Fit-Decision: progressive disclosure — Rows/Columns/aggregate pickers show only in Pivot mode; the value picker hides when the aggregate is Count; plain column dropdowns + plain aggregate labels, no tokens/endpoints; one extra segment on a toggle users already know.
Process-Spine-Decision: new module grid-pivot.ts grounded by the touched phase-2 plan (Slice 26); no new spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)