### PR TITLE
feat(coworker): sign A2A delegation receipts

### DIFF
--- a/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.test.ts
+++ b/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GET, POST } from "./route";
 
@@ -15,6 +15,10 @@ vi.mock("@/lib/coworker-service-catalog/catalog", () => ({
 vi.mock("@/lib/coworker-service-catalog/a2a-tasks", () => ({
   createCoworkerA2aTask: mockCreateCoworkerA2aTask,
 }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 function catalogOffer(overrides: Record<string, unknown> = {}) {
   const provider = {
@@ -137,7 +141,13 @@ describe("A2A coworker offer route", () => {
       serviceId: "svc-sales",
       messages: [],
       artifacts: [],
-      metadata: { actingAgentGaid: "gaid:public:buyer", delegatingAgentGaid: "gaid:public:buyer", delegatedAgentId: "sales-coworker", approvalContext: {} },
+      metadata: {
+        actingAgentGaid: "gaid:public:buyer",
+        delegatingAgentGaid: "gaid:public:buyer",
+        delegatedAgentId: "sales-coworker",
+        approvalContext: {},
+        delegationReceipt: { receiptKind: "coworker-delegation", receiptId: "CDR-1234" },
+      },
     });
 
     const response = await POST(
@@ -161,8 +171,60 @@ describe("A2A coworker offer route", () => {
         requestedOutcome: "Qualify this buyer.",
         contextId: "ctx-1",
         actingAgentGaid: "gaid:public:buyer",
+        delegatingAgentGaid: "gaid:public:buyer",
+        delegatedAgentGaid: "gaid:public:sales",
+        accessProfile: "external-a2a",
+        authorityBoundary: "proposal-only",
+        riskTier: "medium",
+        requiredGrants: ["registry_read"],
       }),
     );
     await expect(response.json()).resolves.toMatchObject({ id: "CE-A2A", status: { state: "submitted" } });
+  });
+
+  it("rejects external A2A task submission without an acting GAID", async () => {
+    mockAuth.mockResolvedValue(null);
+    mockLoadCoworkerCatalog.mockResolvedValue({ services: [], offers: [catalogOffer()] });
+
+    const response = await POST(
+      new Request("http://test/api/a2a/coworkers/sales-coworker/offers/offer-sales", {
+        method: "POST",
+        body: JSON.stringify({
+          requestedOutcome: "Qualify this buyer.",
+          contractContext: { termsRef: "terms://sales", dataBoundaryRef: "boundary://sales" },
+        }),
+      }),
+      { params: Promise.resolve({ agentId: "sales-coworker", offerId: "offer-sales" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "missing_gaid_call_chain",
+    });
+    expect(mockCreateCoworkerA2aTask).not.toHaveBeenCalled();
+  });
+
+  it("rejects external A2A task submission without terms and data-boundary context", async () => {
+    mockAuth.mockResolvedValue(null);
+    mockLoadCoworkerCatalog.mockResolvedValue({ services: [], offers: [catalogOffer()] });
+
+    const response = await POST(
+      new Request("http://test/api/a2a/coworkers/sales-coworker/offers/offer-sales", {
+        method: "POST",
+        body: JSON.stringify({
+          requestedOutcome: "Qualify this buyer.",
+          actingAgentGaid: "gaid:public:buyer",
+          delegatingAgentGaid: "gaid:public:buyer",
+        }),
+      }),
+      { params: Promise.resolve({ agentId: "sales-coworker", offerId: "offer-sales" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "missing_contract_context",
+      missing: ["termsRef", "dataBoundaryRef"],
+    });
+    expect(mockCreateCoworkerA2aTask).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts
+++ b/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts
@@ -75,16 +75,46 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
   }
   const requestedOutcome = typeof body.requestedOutcome === "string" ? body.requestedOutcome.trim() : "";
   if (!requestedOutcome) return NextResponse.json({ error: "missing_requestedOutcome" }, { status: 400 });
+  const actingAgentGaid = stringValue(body.actingAgentGaid);
+  const delegatingAgentGaid = stringValue(body.delegatingAgentGaid) ?? actingAgentGaid;
+  if (accessProfile !== "internal-a2a" && (!actingAgentGaid || !delegatingAgentGaid)) {
+    return NextResponse.json(
+      {
+        error: "missing_gaid_call_chain",
+        message: "Cross-boundary A2A task submission requires actingAgentGaid and delegatingAgentGaid.",
+      },
+      { status: 400 },
+    );
+  }
+  const contractContext = recordOrNull(body.contractContext);
+  const missingContractContext = accessProfile === "internal-a2a" ? [] : missingCrossBoundaryContractFields(contractContext);
+  if (missingContractContext.length > 0) {
+    return NextResponse.json(
+      {
+        error: "missing_contract_context",
+        missing: missingContractContext,
+        message: "Cross-boundary A2A task submission requires termsRef and dataBoundaryRef.",
+      },
+      { status: 400 },
+    );
+  }
 
   const task = await createCoworkerA2aTask({
     offerId,
+    serviceId: projection.card.serviceId,
     requestedOutcome,
     inputPayload: body.inputPayload ?? {},
     fundingContext: body.fundingContext ?? {},
-    contractContext: recordOrNull(body.contractContext),
+    contractContext,
     contextId: stringValue(body.contextId) ?? undefined,
-    actingAgentGaid: stringValue(body.actingAgentGaid),
-    delegatingAgentGaid: stringValue(body.delegatingAgentGaid) ?? stringValue(body.actingAgentGaid),
+    accessProfile,
+    actingAgentGaid,
+    delegatingAgentGaid,
+    delegatedAgentId: projection.card.agentId,
+    delegatedAgentGaid: projection.card.identity.gaid,
+    authorityBoundary: projection.card.authorityBoundary,
+    riskTier: projection.card.riskTier,
+    requiredGrants: projection.card.security.requiredGrants,
   });
 
   return NextResponse.json(task, { status: 202 });
@@ -106,4 +136,11 @@ function recordOrNull(value: unknown): Record<string, unknown> | null {
 
 function stringValue(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function missingCrossBoundaryContractFields(contractContext: Record<string, unknown> | null): string[] {
+  const missing: string[] = [];
+  if (!stringValue(contractContext?.termsRef)) missing.push("termsRef");
+  if (!stringValue(contractContext?.dataBoundaryRef)) missing.push("dataBoundaryRef");
+  return missing;
 }

--- a/apps/web/lib/coworker-service-catalog/a2a-tasks.test.ts
+++ b/apps/web/lib/coworker-service-catalog/a2a-tasks.test.ts
@@ -77,6 +77,12 @@ describe("Coworker A2A task lifecycle", () => {
         requestedOutcome: "Qualify this customer inquiry.",
         inputPayload: { inquiry: "Need enterprise quote" },
         contractContext: { termsRef: "terms://sales", dataBoundaryRef: "boundary://sales" },
+        accessProfile: "external-a2a",
+        delegatedAgentId: "sales-coworker",
+        delegatedAgentGaid: "gaid:public:sales",
+        authorityBoundary: "proposal-only",
+        riskTier: "medium",
+        requiredGrants: ["registry_read"],
         contextId: "ctx-1",
         actingAgentGaid: "gaid:public:customer-agent",
         delegatingAgentGaid: "gaid:public:customer-agent",
@@ -96,6 +102,19 @@ describe("Coworker A2A task lifecycle", () => {
         requestedOutcome: "Qualify this customer inquiry.",
         metadata: expect.objectContaining({
           a2a: expect.objectContaining({ contextId: "ctx-1" }),
+          callChain: expect.objectContaining({
+            actingAgentGaid: "gaid:public:customer-agent",
+            delegatingAgentGaid: "gaid:public:customer-agent",
+            delegatedAgentGaid: "gaid:public:sales",
+            delegatedAgentId: "sales-coworker",
+          }),
+          delegationReceipt: expect.objectContaining({
+            receiptKind: "coworker-delegation",
+            actingAgentGaid: "gaid:public:customer-agent",
+            delegatingAgentGaid: "gaid:public:customer-agent",
+            delegatedAgentId: "sales-coworker",
+            delegatedAgentGaid: "gaid:public:sales",
+          }),
           routingRationale: expect.objectContaining({
             selectedOfferReason: "Sales qualification offer is externally exposed for customer inquiry triage.",
             alternativesConsidered: ["marketing-intake-coworker"],
@@ -104,6 +123,9 @@ describe("Coworker A2A task lifecycle", () => {
             stage: "repeatable",
             aggregateOfferKey: "aggregate-customer-intake",
           }),
+        }),
+        auditRefs: expect.objectContaining({
+          delegationReceiptId: expect.stringMatching(/^CDR-/),
         }),
       }),
     );
@@ -115,6 +137,27 @@ describe("Coworker A2A task lifecycle", () => {
       metadata: { delegatedAgentId: "sales-coworker" },
       status: { state: "submitted" },
     });
+    expect(task.metadata.delegationReceipt).toMatchObject({
+      receiptKind: "coworker-delegation",
+      delegatedAgentGaid: "gaid:public:sales",
+    });
+  });
+
+  it("rejects cross-boundary A2A tasks without an acting and delegating GAID chain", async () => {
+    await expect(
+      createCoworkerA2aTask(
+        {
+          offerId: "offer-sales",
+          requestedOutcome: "Qualify this customer inquiry.",
+          contractContext: { termsRef: "terms://sales", dataBoundaryRef: "boundary://sales" },
+          accessProfile: "external-a2a",
+          delegatedAgentGaid: "gaid:public:sales",
+          authorityBoundary: "proposal-only",
+          riskTier: "medium",
+        },
+        { createEngagement: vi.fn() },
+      ),
+    ).rejects.toThrow("Cross-boundary A2A tasks require actingAgentGaid and delegatingAgentGaid.");
   });
 
   it("reads an existing engagement task by id", async () => {
@@ -128,6 +171,40 @@ describe("Coworker A2A task lifecycle", () => {
       id: "CE-A2A",
       contextId: "ctx-1",
       status: { state: "submitted" },
+    });
+  });
+
+  it("returns the persisted delegation receipt in task readback metadata", () => {
+    const task = mapCoworkerEngagementToA2aTask({
+      engagementId: "CE-1",
+      offerId: "offer-1",
+      serviceId: "svc-1",
+      providerAgentId: "sales-coworker",
+      requestedOutcome: "Prepare packet.",
+      status: "requested",
+      inputPayload: {},
+      approvalContext: { required: false, reasons: [] },
+      metadata: {
+        a2a: {
+          contextId: "ctx-1",
+          actingAgentGaid: "gaid:public:buyer",
+          delegatingAgentGaid: "gaid:public:buyer",
+        },
+        delegationReceipt: {
+          receiptKind: "coworker-delegation",
+          receiptId: "CDR-1234",
+          delegatedAgentGaid: "gaid:public:sales",
+        },
+      },
+      createdAt: new Date("2026-06-30T00:00:00.000Z"),
+      updatedAt: new Date("2026-06-30T00:01:00.000Z"),
+      completedAt: null,
+    });
+
+    expect(task.metadata.delegationReceipt).toMatchObject({
+      receiptKind: "coworker-delegation",
+      receiptId: "CDR-1234",
+      delegatedAgentGaid: "gaid:public:sales",
     });
   });
 });

--- a/apps/web/lib/coworker-service-catalog/a2a-tasks.ts
+++ b/apps/web/lib/coworker-service-catalog/a2a-tasks.ts
@@ -4,6 +4,11 @@ import {
   createCoworkerEngagement,
   type CreateCoworkerEngagementInput,
 } from "./engagements";
+import {
+  createCoworkerDelegationReceipt,
+  type CoworkerDelegationReceipt,
+  type CoworkerDelegationReceiptAccessProfile,
+} from "./delegation-receipt";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -42,6 +47,7 @@ export type CoworkerA2aTask = {
     delegatingAgentGaid: string | null;
     delegatedAgentId: string;
     approvalContext: unknown;
+    delegationReceipt?: CoworkerDelegationReceipt;
   };
 };
 
@@ -51,9 +57,16 @@ export type CoworkerA2aTaskInput = {
   inputPayload?: unknown;
   fundingContext?: unknown;
   contractContext?: CreateCoworkerEngagementInput["contractContext"];
+  accessProfile?: CoworkerDelegationReceiptAccessProfile;
+  serviceId?: string | null;
   contextId?: string;
   actingAgentGaid?: string | null;
   delegatingAgentGaid?: string | null;
+  delegatedAgentId?: string | null;
+  delegatedAgentGaid?: string | null;
+  authorityBoundary?: string | null;
+  riskTier?: string | null;
+  requiredGrants?: string[];
   routingRationale?: {
     selectedOfferReason?: string;
     alternativesConsidered?: string[];
@@ -89,12 +102,47 @@ export async function createCoworkerA2aTask(
 ): Promise<CoworkerA2aTask> {
   const contextId = input.contextId ?? buildA2aContextId();
   const createEngagement = deps.createEngagement ?? createCoworkerEngagement;
+  const accessProfile = input.accessProfile ?? "internal-a2a";
+  const crossBoundary = accessProfile === "external-a2a" || accessProfile === "partner-a2a";
+  const actingAgentGaid = input.actingAgentGaid ?? null;
+  const delegatingAgentGaid = input.delegatingAgentGaid ?? null;
+  if (crossBoundary && (!actingAgentGaid || !delegatingAgentGaid)) {
+    throw new Error("Cross-boundary A2A tasks require actingAgentGaid and delegatingAgentGaid.");
+  }
+  if (crossBoundary && (!input.delegatedAgentId || !input.delegatedAgentGaid)) {
+    throw new Error("Cross-boundary A2A tasks require delegatedAgentId and delegatedAgentGaid.");
+  }
+
+  const delegationReceipt = actingAgentGaid && delegatingAgentGaid && input.delegatedAgentId && input.delegatedAgentGaid
+    ? createCoworkerDelegationReceipt({
+        protocol: "a2a",
+        accessProfile,
+        offerId: input.offerId,
+        serviceId: input.serviceId ?? "pending-service",
+        actingAgentGaid,
+        delegatingAgentGaid,
+        delegatedAgentId: input.delegatedAgentId,
+        delegatedAgentGaid: input.delegatedAgentGaid,
+        requestedOutcome: input.requestedOutcome,
+        authorityBoundary: input.authorityBoundary ?? "unknown",
+        riskTier: input.riskTier ?? "unknown",
+        requiredGrants: input.requiredGrants ?? [],
+        contractContext: input.contractContext ?? null,
+      })
+    : null;
   const metadata = {
     a2a: {
       contextId,
-      actingAgentGaid: input.actingAgentGaid ?? null,
-      delegatingAgentGaid: input.delegatingAgentGaid ?? null,
+      actingAgentGaid,
+      delegatingAgentGaid,
     },
+    callChain: {
+      actingAgentGaid,
+      delegatingAgentGaid,
+      delegatedAgentId: input.delegatedAgentId ?? null,
+      delegatedAgentGaid: input.delegatedAgentGaid ?? null,
+    },
+    ...(delegationReceipt ? { delegationReceipt } : {}),
     routingRationale: {
       selectedOfferReason: input.routingRationale?.selectedOfferReason ?? "A2A caller selected this coworker offer.",
       alternativesConsidered: input.routingRationale?.alternativesConsidered ?? [],
@@ -111,6 +159,12 @@ export async function createCoworkerA2aTask(
     fundingContext: input.fundingContext ?? {},
     contractContext: input.contractContext ?? null,
     metadata,
+    auditRefs: delegationReceipt
+      ? {
+          delegationReceiptId: delegationReceipt.receiptId,
+          delegationReceiptKind: delegationReceipt.receiptKind,
+        }
+      : {},
   });
 
   return mapCoworkerEngagementToA2aTask({
@@ -179,8 +233,16 @@ export function mapCoworkerEngagementToA2aTask(engagement: EngagementRow): Cowor
       delegatingAgentGaid: stringValue(a2a.delegatingAgentGaid),
       delegatedAgentId: engagement.providerAgentId,
       approvalContext: engagement.approvalContext,
+      delegationReceipt: parseDelegationReceipt(metadata.delegationReceipt),
     },
   };
+}
+
+function parseDelegationReceipt(value: unknown): CoworkerDelegationReceipt | undefined {
+  const receipt = record(value);
+  return receipt.receiptKind === "coworker-delegation"
+    ? (receipt as unknown as CoworkerDelegationReceipt)
+    : undefined;
 }
 
 function mapEngagementStatus(status: string): A2aTaskState {

--- a/apps/web/lib/coworker-service-catalog/delegation-receipt.test.ts
+++ b/apps/web/lib/coworker-service-catalog/delegation-receipt.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createCoworkerDelegationReceipt,
+  verifyCoworkerDelegationReceipt,
+} from "./delegation-receipt";
+
+describe("coworker delegation receipts", () => {
+  it("signs the acting, delegating, and delegated agent chain", () => {
+    const receipt = createCoworkerDelegationReceipt(
+      {
+        protocol: "a2a",
+        accessProfile: "external-a2a",
+        offerId: "offer-sales",
+        serviceId: "svc-sales",
+        actingAgentGaid: "gaid:public:buyer",
+        delegatingAgentGaid: "gaid:public:buyer",
+        delegatedAgentId: "sales-coworker",
+        delegatedAgentGaid: "gaid:public:sales",
+        requestedOutcome: "Qualify this buyer.",
+        authorityBoundary: "proposal-only",
+        riskTier: "medium",
+        requiredGrants: ["registry_read"],
+        contractContext: {
+          termsRef: "terms://sales",
+          dataBoundaryRef: "boundary://sales",
+        },
+      },
+      {
+        issuedAt: new Date("2026-07-16T12:00:00.000Z"),
+        secret: "test-secret",
+        keyId: "test-key",
+      },
+    );
+
+    expect(receipt).toMatchObject({
+      receiptKind: "coworker-delegation",
+      protocol: "a2a",
+      accessProfile: "external-a2a",
+      actingAgentGaid: "gaid:public:buyer",
+      delegatingAgentGaid: "gaid:public:buyer",
+      delegatedAgentId: "sales-coworker",
+      delegatedAgentGaid: "gaid:public:sales",
+      signature: {
+        alg: "HMAC-SHA256",
+        keyId: "test-key",
+      },
+    });
+    expect(receipt.receiptId).toMatch(/^CDR-[A-F0-9]{16}$/);
+    expect(receipt.signature.value).toMatch(/^[a-f0-9]{64}$/);
+    expect(verifyCoworkerDelegationReceipt(receipt, { secret: "test-secret" })).toEqual({ ok: true });
+  });
+
+  it("detects a changed delegated agent after signing", () => {
+    const receipt = createCoworkerDelegationReceipt(
+      {
+        protocol: "a2a",
+        accessProfile: "external-a2a",
+        offerId: "offer-sales",
+        serviceId: "svc-sales",
+        actingAgentGaid: "gaid:public:buyer",
+        delegatingAgentGaid: "gaid:public:buyer",
+        delegatedAgentId: "sales-coworker",
+        delegatedAgentGaid: "gaid:public:sales",
+        requestedOutcome: "Qualify this buyer.",
+        authorityBoundary: "proposal-only",
+        riskTier: "medium",
+        requiredGrants: ["registry_read"],
+        contractContext: {
+          termsRef: "terms://sales",
+          dataBoundaryRef: "boundary://sales",
+        },
+      },
+      {
+        issuedAt: new Date("2026-07-16T12:00:00.000Z"),
+        secret: "test-secret",
+        keyId: "test-key",
+      },
+    );
+
+    const tampered = { ...receipt, delegatedAgentId: "other-coworker" };
+
+    expect(verifyCoworkerDelegationReceipt(tampered, { secret: "test-secret" })).toEqual({
+      ok: false,
+      reason: "signature_mismatch",
+    });
+  });
+});

--- a/apps/web/lib/coworker-service-catalog/delegation-receipt.ts
+++ b/apps/web/lib/coworker-service-catalog/delegation-receipt.ts
@@ -1,0 +1,146 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+
+export type CoworkerDelegationReceiptAccessProfile = "internal-a2a" | "partner-a2a" | "external-a2a";
+
+export type CoworkerDelegationReceiptInput = {
+  protocol: "a2a" | "mcp";
+  accessProfile: CoworkerDelegationReceiptAccessProfile;
+  offerId: string;
+  serviceId: string;
+  actingAgentGaid: string;
+  delegatingAgentGaid: string;
+  delegatedAgentId: string;
+  delegatedAgentGaid: string;
+  requestedOutcome: string;
+  authorityBoundary: string;
+  riskTier: string;
+  requiredGrants?: string[];
+  contractContext?: {
+    termsRef?: string | null;
+    dataBoundaryRef?: string | null;
+    [key: string]: unknown;
+  } | null;
+};
+
+export type CoworkerDelegationReceipt = CoworkerDelegationReceiptInput & {
+  receiptKind: "coworker-delegation";
+  receiptId: string;
+  issuedAt: string;
+  requestedOutcomeDigest: string;
+  contractRefs: {
+    termsRef: string | null;
+    dataBoundaryRef: string | null;
+  };
+  signature: {
+    alg: "HMAC-SHA256";
+    keyId: string;
+    value: string;
+  };
+};
+
+export type CoworkerDelegationReceiptVerification =
+  | { ok: true }
+  | { ok: false; reason: "unsupported_algorithm" | "signature_mismatch" };
+
+export function createCoworkerDelegationReceipt(
+  input: CoworkerDelegationReceiptInput,
+  options: { issuedAt?: Date; secret?: string; keyId?: string } = {},
+): CoworkerDelegationReceipt {
+  const issuedAt = (options.issuedAt ?? new Date()).toISOString();
+  const unsigned = unsignedReceipt(input, issuedAt);
+  const signature = signUnsignedReceipt(unsigned, options);
+  return {
+    ...unsigned,
+    receiptId: `CDR-${createHash("sha256").update(signature.value).digest("hex").slice(0, 16).toUpperCase()}`,
+    signature,
+  };
+}
+
+export function verifyCoworkerDelegationReceipt(
+  receipt: CoworkerDelegationReceipt,
+  options: { secret?: string } = {},
+): CoworkerDelegationReceiptVerification {
+  if (receipt.signature.alg !== "HMAC-SHA256") return { ok: false, reason: "unsupported_algorithm" };
+  const expected = signUnsignedReceipt(stripSignature(receipt), {
+    secret: options.secret,
+    keyId: receipt.signature.keyId,
+  });
+  const actual = Buffer.from(receipt.signature.value, "hex");
+  const expectedValue = Buffer.from(expected.value, "hex");
+  if (actual.length !== expectedValue.length || !timingSafeEqual(actual, expectedValue)) {
+    return { ok: false, reason: "signature_mismatch" };
+  }
+  return { ok: true };
+}
+
+function unsignedReceipt(
+  input: CoworkerDelegationReceiptInput,
+  issuedAt: string,
+): Omit<CoworkerDelegationReceipt, "receiptId" | "signature"> {
+  return {
+    receiptKind: "coworker-delegation",
+    protocol: input.protocol,
+    accessProfile: input.accessProfile,
+    offerId: input.offerId,
+    serviceId: input.serviceId,
+    actingAgentGaid: input.actingAgentGaid,
+    delegatingAgentGaid: input.delegatingAgentGaid,
+    delegatedAgentId: input.delegatedAgentId,
+    delegatedAgentGaid: input.delegatedAgentGaid,
+    requestedOutcome: input.requestedOutcome,
+    requestedOutcomeDigest: digest(input.requestedOutcome),
+    authorityBoundary: input.authorityBoundary,
+    riskTier: input.riskTier,
+    requiredGrants: [...(input.requiredGrants ?? [])].sort(),
+    contractContext: input.contractContext ?? null,
+    contractRefs: {
+      termsRef: stringValue(input.contractContext?.termsRef),
+      dataBoundaryRef: stringValue(input.contractContext?.dataBoundaryRef),
+    },
+    issuedAt,
+  };
+}
+
+function stripSignature(receipt: CoworkerDelegationReceipt): Omit<CoworkerDelegationReceipt, "receiptId" | "signature"> {
+  const { receiptId: _receiptId, signature: _signature, ...unsigned } = receipt;
+  return unsigned;
+}
+
+function signUnsignedReceipt(
+  unsigned: Omit<CoworkerDelegationReceipt, "receiptId" | "signature">,
+  options: { secret?: string; keyId?: string },
+): CoworkerDelegationReceipt["signature"] {
+  return {
+    alg: "HMAC-SHA256",
+    keyId: options.keyId ?? process.env.DPF_DELEGATION_RECEIPT_KEY_ID ?? "local-install",
+    value: createHmac("sha256", options.secret ?? receiptSecret())
+      .update(stableJson(unsigned))
+      .digest("hex"),
+  };
+}
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function receiptSecret(): string {
+  return process.env.DPF_DELEGATION_RECEIPT_SECRET
+    ?? process.env.AUTH_SECRET
+    ?? process.env.NEXTAUTH_SECRET
+    ?? "dpf-local-delegation-receipt";
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/apps/web/lib/coworker-service-catalog/engagements.test.ts
+++ b/apps/web/lib/coworker-service-catalog/engagements.test.ts
@@ -174,4 +174,32 @@ describe("createCoworkerEngagement", () => {
       ),
     ).rejects.toThrow("External coworker offers require contractContext.termsRef and contractContext.dataBoundaryRef.");
   });
+
+  it("persists audit references supplied by an A2A delegation receipt", async () => {
+    const fakeDb = db();
+
+    await createCoworkerEngagement(
+      {
+        offerId: "offer-1",
+        requestedByAgentId: "coordinator-agent",
+        requestedOutcome: "Prepare review packet.",
+        auditRefs: {
+          delegationReceiptId: "CDR-1234",
+          delegationReceiptKind: "coworker-delegation",
+        },
+      },
+      { db: fakeDb },
+    );
+
+    expect(fakeDb.coworkerEngagement.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          auditRefs: {
+            delegationReceiptId: "CDR-1234",
+            delegationReceiptKind: "coworker-delegation",
+          },
+        }),
+      }),
+    );
+  });
 });

--- a/apps/web/lib/coworker-service-catalog/engagements.ts
+++ b/apps/web/lib/coworker-service-catalog/engagements.ts
@@ -47,6 +47,7 @@ export type CreateCoworkerEngagementInput = {
     dataBoundaryRef?: string | null;
     [key: string]: unknown;
   } | null;
+  auditRefs?: unknown;
   metadata?: unknown;
 };
 
@@ -95,7 +96,7 @@ export async function createCoworkerEngagement(
       fundingContext: input.fundingContext ?? {},
       contractContext: input.contractContext ?? {},
       approvalContext,
-      auditRefs: {},
+      auditRefs: input.auditRefs ?? {},
       metadata: input.metadata ?? {},
       workCapsuleId: null,
     },

--- a/docs/superpowers/plans/2026-06-30-coworker-service-offer-catalog.md
+++ b/docs/superpowers/plans/2026-06-30-coworker-service-offer-catalog.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Add a small catalog layer over the existing coworker substrate: provider capabilities (`CoworkerService`), consumable packages (`CoworkerOffer`), and actual demand (`CoworkerEngagement`). Keep projection, MCP handlers, and UI as thin layers over shared service functions.
 
-**Surface doctrine:** This first slice ships human portal discovery, bounded MCP discovery/request tools, Build Studio requirements-packet injection, and selected-offer Agent Card projection. A live external A2A task endpoint, GAID authority verification service, catalog broker ranking, and aggregate/process-refinement offers remain follow-on slices so the first PR does not overload every agent with a universal catalog payload.
+**Surface doctrine:** This slice ships human portal discovery, bounded MCP discovery/request tools, Build Studio requirements-packet injection, selected-offer Agent Card projection, A2A task endpoints, GAID authority verification, and signed delegation receipts. Catalog broker ranking and aggregate/process-refinement offers remain follow-on slices so the implementation does not overload every agent with a universal catalog payload.
 
 **Tech Stack:** Next.js 16 app router, Prisma 7, pnpm workspaces, Vitest, React Testing Library, DPF MCP tool surface.
 
@@ -103,7 +103,7 @@
 - [ ] **Step 4: Exercise `/platform/ai/catalog` on the running portal and capture evidence.**
 - [ ] **Step 5: Record any blocked gate honestly; do not treat unrun gates as passed.**
 
-## Follow-On Chunk: A2A, GAID, and Catalog Broker
+## Chunk 7: A2A, GAID, and Catalog Broker
 
 ### Task 8: Add access-profile projection
 
@@ -111,19 +111,20 @@
 - Modify/create catalog projection modules under `apps/web/lib/coworker-service-catalog/`
 - Add tests near catalog projection tests.
 
-- [ ] **Step 1: Define projection profiles for human portal, MCP summary, MCP detail, internal A2A, partner A2A, and external/public discovery.**
-- [ ] **Step 2: Ensure internal-only specialists such as Legal Operations Counsel do not leak into partner/external projections unless a specific offer is marked for that availability scope.**
-- [ ] **Step 3: Add tests that list responses stay summary-sized and detail is retrieved by offer id.**
+- [x] **Step 1: Define projection profiles for human portal, MCP summary, MCP detail, internal A2A, partner A2A, and external/public discovery.**
+- [x] **Step 2: Ensure internal-only specialists such as Legal Operations Counsel do not leak into partner/external projections unless a specific offer is marked for that availability scope.**
+- [x] **Step 3: Add tests that list responses stay summary-sized and detail is retrieved by offer id.**
 
 ### Task 9: Add A2A/GAID resolution
 
 **Files:**
 - Modify/create A2A/GAID adapter modules after the existing GAID architecture profile is wired into runtime identity.
 
-- [ ] **Step 1: Resolve selected offers to internal/private Agent Card metadata for trusted A2A callers.**
-- [ ] **Step 2: Resolve partner/external offers to GAID/AIDoc references and authenticated/public Agent Card variants.**
-- [ ] **Step 3: Preserve acting, delegating, and delegated identity in engagement/audit receipts.**
-- [ ] **Step 4: Reject cross-organization access when GAID, terms, data boundary, revocation, or authority metadata is missing.**
+- [x] **Step 1: Resolve selected offers to internal/private Agent Card metadata for trusted A2A callers.**
+- [x] **Step 2: Resolve partner/external offers to GAID/AIDoc references and authenticated/public Agent Card variants.**
+- [x] **Step 3: Preserve acting, delegating, and delegated identity in engagement/audit receipts.**
+- [x] **Step 4: Reject cross-organization access when GAID, terms, data boundary, revocation, or authority metadata is missing.**
+- [x] **Step 5: Sign A2A coworker delegation receipts with a stable HMAC-SHA256 envelope and expose the persisted receipt in task readback.**
 
 ### Task 10: Add aggregate offers and process refinement
 

--- a/docs/superpowers/specs/2026-06-30-coworker-service-offer-catalog-design.md
+++ b/docs/superpowers/specs/2026-06-30-coworker-service-offer-catalog-design.md
@@ -184,7 +184,7 @@ Different callers need different catalog projections:
 - Cross-organization A2A/API: sales, marketing, procurement, supplier-facing, and customer-facing coworkers require partner/external availability, GAID-federated or GAID-public identity, provider organization, authenticated card variants where needed, explicit terms, data boundary, audit, and revocation posture.
 - Back-office specialist boundaries: legal, finance, security, and HR specialists can be invoked by internal coordinators, but their offers should stay narrow, approval-aware, and hidden from external discovery unless an explicitly reviewed partner-facing offer exists.
 
-The first implementation slice delivers the human portal, MCP request surface, Build Studio requirements broker, a bounded Agent Card projection for selected coworker offers, GAID authority verification for cross-boundary Agent Cards, A2A-style task endpoints backed by `CoworkerEngagement`, and executable engagement-refinement analysis. Agent Cards are exposed at `/api/a2a/coworkers/[agentId]/offers/[offerId]`; external callers can submit a task with `POST` to that offer endpoint and read lifecycle state at `/api/a2a/tasks/[taskId]`. MCP callers can run `analyze_coworker_engagement_refinement` to find repeated engagement patterns and aggregate offer/playbook candidates without loading full raw history.
+The first implementation slice delivers the human portal, MCP request surface, Build Studio requirements broker, a bounded Agent Card projection for selected coworker offers, GAID authority verification for cross-boundary Agent Cards, A2A-style task endpoints backed by `CoworkerEngagement`, signed delegation receipts for A2A call chains, and executable engagement-refinement analysis. Agent Cards are exposed at `/api/a2a/coworkers/[agentId]/offers/[offerId]`; external callers can submit a task with `POST` to that offer endpoint and read lifecycle state at `/api/a2a/tasks/[taskId]`. Cross-boundary task submission requires acting and delegating GAIDs plus terms and data-boundary references before an engagement is created. MCP callers can run `analyze_coworker_engagement_refinement` to find repeated engagement patterns and aggregate offer/playbook candidates without loading full raw history.
 
 ## Build Studio Requirements Surface
 
@@ -300,6 +300,8 @@ Future A2A/GAID tools should not expand this first MCP list into a huge universa
 - Internal specialist offers, especially legal, default to trusted internal humans and trusted non-human principals only.
 - External/partner offers must be explicitly marked for that availability scope and must not inherit visibility from the provider coworker as a whole.
 - Cross-organization calls must preserve acting, delegating, and delegated agent identities, including GAID where applicable, so receipts can reconstruct the chain of custody.
+- A2A coworker task creation writes a `coworker-delegation` receipt into `CoworkerEngagement.metadata.delegationReceipt` and a receipt pointer into `CoworkerEngagement.auditRefs`. The receipt signs the selected offer, service, access profile, acting/delegating/delegated identities, requested outcome digest, authority boundary, risk tier, required grants, and contract/data-boundary references with HMAC-SHA256.
+- Cross-boundary A2A task creation rejects missing caller GAID chain, missing provider GAID authority, missing terms, or missing data-boundary references before engagement creation. These are 4xx protocol errors, not late service exceptions.
 - Public or partner-facing Agent Cards must not disclose internal-only skills, prompts, tools, pricing details, or privileged data-boundary metadata unless a reviewed external offer requires that disclosure.
 
 ## Refactoring Allocation
@@ -320,6 +322,7 @@ Reserve roughly 20 percent of the implementation effort for targeted refactoring
 - Legal Operations Counsel offers appear when the legal coworker identity is present.
 - UI route supports browse/filter/detail/request initiation.
 - MCP tools support coworker discovery and engagement request.
+- A2A task endpoints support selected-offer Agent Card resolution, governed task submission, signed delegation receipt persistence, receipt readback, and clean rejection for missing GAID/contract/data-boundary context.
 - Tests cover model boundaries, catalog projection, offer packaging, engagement creation, permissions/grants, and Legal Operations Counsel visibility.
 - UX verification is run on a governed running portal or shared local-integration lease.
 - Targeted tests and `pnpm --filter web build` are run before completion, with any pre-existing blocker clearly reported.


### PR DESCRIPTION
## Summary
- add signed `coworker-delegation` receipts for A2A coworker task creation
- persist acting/delegating/delegated GAID call-chain metadata and receipt refs on `CoworkerEngagement`
- reject cross-boundary A2A task submission when caller GAIDs, terms, or data-boundary refs are missing
- update the coworker catalog spec/plan to reflect the implemented A2A/GAID receipt posture

## Verification
- `pnpm --filter web exec vitest run lib/coworker-service-catalog app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.test.ts app/api/a2a/tasks/[taskId]/route.test.ts` — 11 files, 38 tests passed
- `$env:NODE_OPTIONS='--max-old-space-size=8192'; pnpm --filter web typecheck` — passed
- `$env:NODE_OPTIONS='--max-old-space-size=8192'; pnpm --filter web build` — passed; existing Edge-runtime warnings remain in unrelated modules such as `private-paths`, voice synthesis, backups, db discovery/schema-source, sandbox promotion, and deliberation seed imports

## Standards Notes
- A2A remains the selected peer discovery/tasking surface through selected-offer Agent Cards.
- MCP remains the bounded tool authorization surface for catalog discovery/request tools.
- GAID call-chain evidence is now preserved in a signed receipt envelope for cross-boundary A2A tasking.