### PR TITLE
fix: add postgres exporter config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -755,8 +755,11 @@ services:
     image: prometheuscommunity/postgres-exporter:v0.19.1
     restart: unless-stopped
     logging: *default-logging
+    command: ["--config.file=/postgres_exporter.yml"]
     ports:
       - "9187:9187"
+    volumes:
+      - ./monitoring/postgres-exporter/postgres_exporter.yml:/postgres_exporter.yml:ro
     environment:
       DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-dpf}:${POSTGRES_PASSWORD:-dpf_dev}@postgres:5432/dpf?sslmode=disable"
     depends_on:

--- a/docs/superpowers/plans/2026-07-17-postgres-exporter-config.md
+++ b/docs/superpowers/plans/2026-07-17-postgres-exporter-config.md
@@ -1,0 +1,25 @@
+# Postgres Exporter Config Warning Plan
+
+## Goal
+
+Stop the benign `postgres_exporter.yml` missing-config warning at startup without changing the exporter from its existing single-target `DATA_SOURCE_NAME` mode.
+
+## Current state
+
+- `docker-compose.yml` starts `prometheuscommunity/postgres-exporter:v0.19.1` with `DATA_SOURCE_NAME` only.
+- `install-dpf.ps1` generates a compose file with the same missing config surface for fresh installs.
+- The warning is not platform-specific: it comes from the exporter default config lookup, not from a Windows/macOS/Linux bind mount quirk.
+
+## Implementation
+
+1. Add a minimal `monitoring/postgres-exporter/postgres_exporter.yml` with an empty `auth_modules` map.
+2. Mount that config into the postgres-exporter service and pass `--config.file=/postgres_exporter.yml` explicitly.
+3. Update the Windows installer's generated compose and monitoring file creation so fresh installs converge to the same runtime shape.
+4. Lock the source invariant with a targeted compose/runtime test.
+
+## Verification
+
+- Run the targeted compose/runtime test.
+- Render `docker compose config`.
+- Start the exporter image with the mounted config and confirm the missing-config warning is gone.
+- Run `pnpm --filter web build`.

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -1214,8 +1214,11 @@ services:
   postgres-exporter:
     image: prometheuscommunity/postgres-exporter:latest
     restart: unless-stopped
+    command: ["--config.file=/postgres_exporter.yml"]
     ports:
       - "9187:9187"
+    volumes:
+      - ./monitoring/postgres-exporter/postgres_exporter.yml:/postgres_exporter.yml:ro
     environment:
       DATA_SOURCE_NAME: postgresql://`${POSTGRES_USER:-dpf}:`${POSTGRES_PASSWORD}@postgres:5432/dpf?sslmode=disable
     depends_on:
@@ -1238,9 +1241,14 @@ volumes:
             # Write monitoring configuration files (Prometheus + Grafana)
             $monDir = "$DPF_DIR\monitoring"
             New-Item -ItemType Directory -Path "$monDir\prometheus" -Force | Out-Null
+            New-Item -ItemType Directory -Path "$monDir\postgres-exporter" -Force | Out-Null
             New-Item -ItemType Directory -Path "$monDir\grafana\provisioning\datasources" -Force | Out-Null
             New-Item -ItemType Directory -Path "$monDir\grafana\provisioning\dashboards" -Force | Out-Null
             New-Item -ItemType Directory -Path "$monDir\grafana\dashboards" -Force | Out-Null
+
+            @"
+auth_modules: {}
+"@ | Set-Content "$monDir\postgres-exporter\postgres_exporter.yml" -Encoding UTF8
 
             # Prometheus config
             @"

--- a/monitoring/postgres-exporter/postgres_exporter.yml
+++ b/monitoring/postgres-exporter/postgres_exporter.yml
@@ -1,0 +1,1 @@
+auth_modules: {}

--- a/scripts/lib/compose-runtime-env.test.mjs
+++ b/scripts/lib/compose-runtime-env.test.mjs
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const compose = readFileSync(new URL("../../docker-compose.yml", import.meta.url), "utf8");
 const envExample = readFileSync(new URL("../../.env.docker.example", import.meta.url), "utf8");
+const installer = readFileSync(new URL("../../install-dpf.ps1", import.meta.url), "utf8");
+const postgresExporterConfigUrl = new URL(
+  "../../monitoring/postgres-exporter/postgres_exporter.yml",
+  import.meta.url,
+);
 
 test("installed compose runtime enables background job registration by default", () => {
   assert.match(
@@ -24,4 +29,22 @@ test("example compose env documents background job override flags", () => {
   assert.match(envExample, /DPF_INNGEST_SELF_SYNC_ON_BOOT_ENABLED=/);
   assert.match(envExample, /DPF_SCHEDULED_INNGEST_FUNCTIONS_ENABLED=/);
   assert.match(envExample, /DPF_OPTIONAL_STARTUP_TASKS_ENABLED=/);
+});
+
+test("postgres exporter starts with an explicit config file in compose and installer output", () => {
+  assert.equal(existsSync(postgresExporterConfigUrl), true);
+  assert.match(readFileSync(postgresExporterConfigUrl, "utf8"), /^auth_modules:\s*\{\}\s*$/m);
+
+  assert.match(compose, /postgres-exporter:[\s\S]*command:\s*\["--config\.file=\/postgres_exporter\.yml"\]/);
+  assert.match(
+    compose,
+    /postgres-exporter:[\s\S]*\.\/monitoring\/postgres-exporter\/postgres_exporter\.yml:\/postgres_exporter\.yml:ro/,
+  );
+
+  assert.match(installer, /postgres-exporter:[\s\S]*command:\s*\["--config\.file=\/postgres_exporter\.yml"\]/);
+  assert.match(
+    installer,
+    /postgres-exporter:[\s\S]*\.\/monitoring\/postgres-exporter\/postgres_exporter\.yml:\/postgres_exporter\.yml:ro/,
+  );
+  assert.match(installer, /postgres-exporter\\postgres_exporter\.yml/);
 });


### PR DESCRIPTION
## Summary
- add a minimal postgres-exporter config file with `auth_modules: {}`
- mount it into the base compose postgres-exporter service and pass `--config.file=/postgres_exporter.yml`
- update the Windows installer-generated compose and monitoring file creation so fresh installs converge
- add a runtime compose invariant test covering the config, mount, and installer output

## Verification
- `node --test scripts/lib/compose-runtime-env.test.mjs`
- `$env:CREDENTIAL_ENCRYPTION_KEY="compose-render-test-key"; $env:AUTH_SECRET="compose-render-test-secret"; docker compose -f docker-compose.yml config --quiet`
- disposable `prometheuscommunity/postgres-exporter:v0.19.1` container with mounted `/postgres_exporter.yml`; logs showed exporter listening and no missing-config warning
- `pnpm --filter web build` (passed; existing Turbopack tracing warnings remain)