### PR TITLE
refactor(finance): extract remaining pure tax-remittance helpers into the domain-core module (BI-OPT-FAT-ACTIONS — tax-remittance remainder)

### DIFF
--- a/apps/web/lib/actions/tax-remittance.ts
+++ b/apps/web/lib/actions/tax-remittance.ts
@@ -10,11 +10,18 @@ import {
   addDays,
   addMonths,
   appendNote,
+  buildBillLiabilityDrafts,
+  buildCoworkerGuide,
+  buildFilingPacketNotes,
+  buildInvoiceLiabilityDrafts,
+  buildManagedTaxIssues,
+  computeNextCronRun,
   credentialPublicId,
   decimalValue,
   issueKey,
   issuePublicId,
   nullableString,
+  periodMonthsForFrequency,
   periodPublicId,
   registrationPublicId,
   remittanceRunPublicId,
@@ -22,7 +29,8 @@ import {
   stableTaxEntityId,
   taxExecutionTaskId,
   taxMonitorTaskId,
-  taxableBaseFromLine,
+  type LiabilityDraft,
+  type TaxRegistrationRecord,
 } from "@/lib/finance/tax-remittance-core";
 import {
   addTaxFilingArtifactSchema,
@@ -44,45 +52,6 @@ import {
 } from "@/lib/finance/tax-remittance-validation";
 
 type TaxProfileRecord = Awaited<ReturnType<typeof getOrCreateTaxProfile>>;
-type TaxRegistrationRecord = {
-  id: string;
-  registrationId: string;
-  taxType: string;
-  registrationNumber: string | null;
-  registrationStatus: string;
-  filingFrequency: string;
-  filingBasis: string | null;
-  remitterRole: string;
-  effectiveFrom: Date;
-  effectiveTo: Date | null;
-  firstPeriodStart: Date | null;
-  portalAccountNotes: string | null;
-  verifiedFromSourceUrl: string | null;
-  lastVerifiedAt: Date | null;
-  confidence: string;
-  jurisdictionReferenceId: string;
-  organizationTaxProfileId: string;
-  createdAt: Date;
-  updatedAt: Date;
-  jurisdictionReference: {
-    id: string;
-    jurisdictionRefId: string;
-    authorityName: string;
-    countryCode: string;
-    stateProvinceCode: string | null;
-    authorityType: string;
-    taxTypes: string[];
-  };
-};
-
-type ManagedTaxIssueDraft = {
-  issueType: string;
-  severity: string;
-  title: string;
-  details: string;
-  registrationId?: string | null;
-  periodId?: string | null;
-};
 
 async function requireManageFinance() {
   const session = await auth();
@@ -144,139 +113,6 @@ async function createTaxNotification(userId: string, title: string, body: string
       read: false,
     },
   });
-}
-
-type LiabilityDraft = {
-  snapshotId?: string;
-  entryId: string;
-  sourceType: string;
-  sourceId: string;
-  sourceLineItemId?: string | null;
-  direction: "output" | "input" | "adjustment";
-  taxType: string;
-  taxCode?: string | null;
-  taxableAmount: number;
-  taxRate?: number | null;
-  taxAmount: number;
-  currency: string;
-  occurredAt: Date;
-  evidence?: Record<string, unknown>;
-  notes?: string | null;
-};
-
-function buildInvoiceLiabilityDrafts(
-  registration: TaxRegistrationRecord,
-  invoices: Array<{
-    id: string;
-    invoiceRef?: string | null;
-    type?: string | null;
-    currency?: string | null;
-    issueDate: Date;
-    lineItems: Array<{
-      id: string;
-      description?: string | null;
-      lineTotal: unknown;
-      taxRate: unknown;
-      taxAmount: unknown;
-    }>;
-  }>,
-): LiabilityDraft[] {
-  const drafts: LiabilityDraft[] = [];
-
-  for (const invoice of invoices) {
-    for (const lineItem of invoice.lineItems) {
-      const rawTaxAmount = roundCurrency(decimalValue(lineItem.taxAmount));
-      if (!rawTaxAmount) continue;
-
-      const isCredit = invoice.type === "credit_note";
-      const signedTaxAmount = isCredit ? -Math.abs(rawTaxAmount) : rawTaxAmount;
-      const taxRate = roundCurrency(decimalValue(lineItem.taxRate));
-
-      drafts.push({
-        snapshotId: stableTaxEntityId(
-          "TAX-SNAP",
-          registration.id,
-          invoice.id,
-          lineItem.id,
-          invoice.issueDate,
-          invoice.type ?? "standard",
-        ),
-        entryId: stableTaxEntityId(
-          "TAX-LIAB",
-          registration.id,
-          invoice.id,
-          lineItem.id,
-          invoice.issueDate,
-          invoice.type ?? "standard",
-        ),
-        sourceType: isCredit ? "credit_note" : "invoice_tax",
-        sourceId: invoice.id,
-        sourceLineItemId: lineItem.id,
-        direction: "output",
-        taxType: registration.taxType,
-        taxCode: isCredit ? "credit_note" : "standard",
-        taxableAmount: taxableBaseFromLine(lineItem.lineTotal, Math.abs(rawTaxAmount)),
-        taxRate,
-        taxAmount: signedTaxAmount,
-        currency: invoice.currency ?? "GBP",
-        occurredAt: invoice.issueDate,
-        evidence: {
-          invoiceRef: invoice.invoiceRef ?? null,
-          description: lineItem.description ?? null,
-        },
-      });
-    }
-  }
-
-  return drafts;
-}
-
-function buildBillLiabilityDrafts(
-  registration: TaxRegistrationRecord,
-  bills: Array<{
-    id: string;
-    billRef?: string | null;
-    currency?: string | null;
-    issueDate: Date;
-    lineItems: Array<{
-      id: string;
-      description?: string | null;
-      lineTotal: unknown;
-      taxRate: unknown;
-      taxAmount: unknown;
-    }>;
-  }>,
-): LiabilityDraft[] {
-  const drafts: LiabilityDraft[] = [];
-
-  for (const bill of bills) {
-    for (const lineItem of bill.lineItems) {
-      const taxAmount = roundCurrency(decimalValue(lineItem.taxAmount));
-      if (!taxAmount) continue;
-
-      drafts.push({
-        snapshotId: stableTaxEntityId("TAX-SNAP", registration.id, bill.id, lineItem.id, bill.issueDate, "bill"),
-        entryId: stableTaxEntityId("TAX-LIAB", registration.id, bill.id, lineItem.id, bill.issueDate, "bill"),
-        sourceType: "bill_tax",
-        sourceId: bill.id,
-        sourceLineItemId: lineItem.id,
-        direction: "input",
-        taxType: registration.taxType,
-        taxCode: "standard",
-        taxableAmount: taxableBaseFromLine(lineItem.lineTotal, taxAmount),
-        taxRate: roundCurrency(decimalValue(lineItem.taxRate)),
-        taxAmount,
-        currency: bill.currency ?? "GBP",
-        occurredAt: bill.issueDate,
-        evidence: {
-          billRef: bill.billRef ?? null,
-          description: lineItem.description ?? null,
-        },
-      });
-    }
-  }
-
-  return drafts;
 }
 
 async function upsertOperationalTaxIssue(input: {
@@ -435,173 +271,6 @@ async function persistLiabilityDrafts(
   }
 }
 
-function computeNextCronRun(cronExpr: string, from: Date) {
-  const parts = cronExpr.trim().split(/\s+/);
-  if (parts.length !== 5) return addDays(from, 1);
-
-  const [minPart, hourPart, , , dowPart] = parts;
-  const minute = minPart === "*" ? 0 : parseInt(minPart!, 10);
-  const hour = hourPart === "*" ? from.getHours() : parseInt(hourPart!, 10);
-
-  const next = new Date(from);
-  next.setSeconds(0, 0);
-  next.setMinutes(minute);
-  next.setHours(hour);
-
-  if (next <= from) {
-    next.setDate(next.getDate() + 1);
-  }
-
-  if (dowPart && dowPart !== "*") {
-    const targetDays = dowPart.split(",").map((value) => parseInt(value, 10));
-    let safety = 0;
-    while (!targetDays.includes(next.getDay()) && safety < 8) {
-      next.setDate(next.getDate() + 1);
-      safety += 1;
-    }
-  }
-
-  return next;
-}
-
-function periodMonthsForFrequency(filingFrequency: string) {
-  switch (filingFrequency) {
-    case "monthly":
-      return 1;
-    case "bi_monthly":
-      return 2;
-    case "quarterly":
-      return 3;
-    case "half_yearly":
-      return 6;
-    case "annual":
-      return 12;
-    default:
-      return null;
-  }
-}
-
-function buildFilingPacketNotes(period: {
-  periodStart: Date;
-  periodEnd: Date;
-  salesTaxAmount: unknown;
-  inputTaxAmount: unknown;
-  netTaxAmount: unknown;
-  registration: {
-    taxType: string;
-    registrationNumber: string | null;
-    jurisdictionReference: {
-      authorityName: string;
-    };
-  };
-}) {
-  const salesTaxAmount = roundCurrency(decimalValue(period.salesTaxAmount));
-  const inputTaxAmount = roundCurrency(decimalValue(period.inputTaxAmount));
-  const netTaxAmount = roundCurrency(decimalValue(period.netTaxAmount));
-
-  return [
-    `${period.registration.jurisdictionReference.authorityName} ${period.registration.taxType} filing packet`,
-    `Period: ${period.periodStart.toISOString().slice(0, 10)} to ${period.periodEnd.toISOString().slice(0, 10)}`,
-    `Registration: ${period.registration.registrationNumber ?? "pending"}`,
-    `Sales tax captured: ${salesTaxAmount.toFixed(2)}`,
-    `Input tax captured: ${inputTaxAmount.toFixed(2)}`,
-    `Net tax due: ${netTaxAmount.toFixed(2)}`,
-  ].join("\n");
-}
-
-function buildManagedTaxIssues(
-  profile: TaxProfileRecord,
-  registrations: TaxRegistrationRecord[],
-): ManagedTaxIssueDraft[] {
-  const issues: ManagedTaxIssueDraft[] = [];
-
-  if (profile.setupMode === "unknown") {
-    issues.push({
-      issueType: "tax_setup_mode_unknown",
-      severity: "medium",
-      title: "Tax setup mode still needs classification",
-      details:
-        "Confirm whether the business is already filing indirect taxes, partially configured, or setting up for the first time.",
-    });
-  }
-
-  if (!nullableString(profile.homeCountryCode)) {
-    issues.push({
-      issueType: "tax_home_jurisdiction_missing",
-      severity: "high",
-      title: "Home jurisdiction is missing",
-      details:
-        "Capture the primary country so the finance coworker can suggest the first authorities and remittance obligations.",
-    });
-  }
-
-  if (!nullableString(profile.footprintSummary)) {
-    issues.push({
-      issueType: "tax_footprint_missing",
-      severity: "high",
-      title: "Operating footprint is not documented",
-      details:
-        "Record where the business is registered, operates, and delivers taxable services before tax setup is treated as ready.",
-    });
-  }
-
-  if (profile.handoffMode !== "dpf_readiness_only" && !nullableString(profile.externalSystem)) {
-    issues.push({
-      issueType: "tax_external_handoff_missing",
-      severity: "high",
-      title: "External filing handoff is not configured",
-      details:
-        "Record the accountant, filing partner, or external tax system that owns final filing and payment before treating this remittance workflow as operational.",
-    });
-  }
-
-  if (profile.filingOwner === "dpf_coworker" && profile.handoffMode !== "dpf_readiness_only") {
-    issues.push({
-      issueType: "tax_dpf_filing_not_available",
-      severity: "medium",
-      title: "Direct DPF filing remains future-scope automation",
-      details:
-        "DPF can prepare registrations, periods, workpapers, and evidence today, but final statutory submission and payment still need an external handoff boundary.",
-    });
-  }
-
-  if (registrations.length === 0) {
-    issues.push({
-      issueType: "tax_registration_research_needed",
-      severity: "high",
-      title: "Tax authority research is still needed",
-      details:
-        profile.setupMode === "existing"
-          ? "List the authorities the business already files with and verify each official filing portal."
-          : "Research likely authorities from the business footprint and add the first registrations to move setup forward.",
-    });
-  }
-
-  for (const registration of registrations) {
-    if (registration.registrationStatus === "active" && !nullableString(registration.registrationNumber)) {
-      issues.push({
-        issueType: "tax_registration_number_missing",
-        severity: "medium",
-        title: "Registration number is missing",
-        details: `Add the registration number for ${registration.jurisdictionReference.authorityName} or record why the authority is still pending.`,
-        registrationId: registration.id,
-      });
-    }
-
-    if (!registration.lastVerifiedAt) {
-      issues.push({
-        issueType: "tax_registration_live_verification_needed",
-        severity: "high",
-        title: "Live verification is still required",
-        details: `Verify ${registration.jurisdictionReference.authorityName} against the official portal and record the source URL before relying on this registration.`,
-        registrationId: registration.id,
-      });
-    }
-  }
-
-  return issues;
-}
-
 async function reconcileTaxIssues(
   profile: TaxProfileRecord,
   registrations: TaxRegistrationRecord[],
@@ -681,82 +350,6 @@ async function reconcileTaxIssues(
     }
     return left.severity.localeCompare(right.severity);
   });
-}
-
-function buildCoworkerGuide(
-  profile: TaxProfileRecord,
-  registrations: TaxRegistrationRecord[],
-  openIssues: Array<{
-    id: string;
-    issueType: string;
-    title: string;
-    severity: string;
-    registrationId: string | null;
-  }>,
-) {
-  const verificationQueue = registrations
-    .filter((registration) => !registration.lastVerifiedAt)
-    .map((registration) => ({
-      registrationId: registration.id,
-      authorityName: registration.jurisdictionReference.authorityName,
-      jurisdictionRefId: registration.jurisdictionReference.jurisdictionRefId,
-      registrationNumber: registration.registrationNumber,
-    }));
-
-  if (profile.setupMode === "existing") {
-    return {
-      summary:
-        "This business appears to be already configured, so the finance coworker should normalize existing registrations before suggesting new authorities.",
-      nextQuestions: [
-        "Which authorities do you already file with today?",
-        "Do you already have registration numbers and portal access for each authority?",
-        "Which filings are handled internally versus by an accountant or tax system?",
-      ],
-      recommendedActions: [
-        "Add each known authority registration.",
-        "Mark the official filing portal live-verified for every active registration.",
-        "Resolve setup gaps before treating remittance as active automation.",
-      ],
-      verificationQueue,
-      openIssueCount: openIssues.length,
-    };
-  }
-
-  if (profile.setupMode === "new_business") {
-    return {
-      summary:
-        "This looks like a first-time setup, so the finance coworker should start from footprint and registration research rather than assuming filing history exists.",
-      nextQuestions: [
-        "Where is the business legally registered and where are services delivered?",
-        "Are there any jurisdictions the owner already knows they must register in?",
-        "Should DPF prepare handoff for an accountant or keep setup directly in the platform?",
-      ],
-      recommendedActions: [
-        "Confirm the home jurisdiction and service footprint.",
-        "Research likely authorities from the seeded jurisdiction registry.",
-        "Record the first verified registrations before scheduling remittance periods.",
-      ],
-      verificationQueue,
-      openIssueCount: openIssues.length,
-    };
-  }
-
-  return {
-    summary:
-      "The finance coworker still needs to classify whether this business is already configured or starting from scratch before tax setup should progress.",
-    nextQuestions: [
-      "Are you already filing sales tax, VAT, or GST anywhere today?",
-      "If yes, which authorities do you file with and how often?",
-      "If no, where is the business registered, operating, and delivering taxable services?",
-    ],
-    recommendedActions: [
-      "Classify the setup mode first.",
-      "Capture the home jurisdiction and footprint.",
-      "Add the first known or likely authority registrations.",
-    ],
-    verificationQueue,
-    openIssueCount: openIssues.length,
-  };
 }
 
 async function loadTaxWorkspaceState(profile: TaxProfileRecord, ownerUserId: string) {

--- a/apps/web/lib/finance/tax-remittance-core.test.ts
+++ b/apps/web/lib/finance/tax-remittance-core.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBillLiabilityDrafts,
+  buildCoworkerGuide,
+  buildFilingPacketNotes,
+  buildInvoiceLiabilityDrafts,
+  buildManagedTaxIssues,
+  computeNextCronRun,
+  periodMonthsForFrequency,
+  type TaxRegistrationRecord,
+} from "./tax-remittance-core";
+
+function makeRegistration(overrides: Partial<TaxRegistrationRecord> = {}): TaxRegistrationRecord {
+  return {
+    id: "reg-1",
+    registrationId: "TAX-REG-AAAAAAAA",
+    taxType: "vat",
+    registrationNumber: "GB123",
+    registrationStatus: "active",
+    filingFrequency: "quarterly",
+    filingBasis: "accrual",
+    remitterRole: "principal",
+    effectiveFrom: new Date("2026-01-01T00:00:00Z"),
+    effectiveTo: null,
+    firstPeriodStart: new Date("2026-01-01T00:00:00Z"),
+    portalAccountNotes: null,
+    verifiedFromSourceUrl: null,
+    lastVerifiedAt: new Date("2026-02-01T00:00:00Z"),
+    confidence: "medium",
+    jurisdictionReferenceId: "jur-1",
+    organizationTaxProfileId: "profile-1",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    jurisdictionReference: {
+      id: "jur-1",
+      jurisdictionRefId: "JUR-REF-1",
+      authorityName: "HMRC",
+      countryCode: "GB",
+      stateProvinceCode: null,
+      authorityType: "national",
+      taxTypes: ["vat"],
+    },
+    ...overrides,
+  };
+}
+
+const baseProfile = {
+  setupMode: "existing",
+  homeCountryCode: "GB",
+  footprintSummary: "UK only",
+  handoffMode: "external",
+  externalSystem: "AcmeAccountants",
+  filingOwner: "external_accountant",
+};
+
+describe("periodMonthsForFrequency", () => {
+  it("maps known filing frequencies to month spans", () => {
+    expect(periodMonthsForFrequency("monthly")).toBe(1);
+    expect(periodMonthsForFrequency("bi_monthly")).toBe(2);
+    expect(periodMonthsForFrequency("quarterly")).toBe(3);
+    expect(periodMonthsForFrequency("half_yearly")).toBe(6);
+    expect(periodMonthsForFrequency("annual")).toBe(12);
+  });
+
+  it("returns null for an unknown frequency", () => {
+    expect(periodMonthsForFrequency("weekly")).toBeNull();
+  });
+});
+
+describe("computeNextCronRun", () => {
+  it("returns +1 day when the expression is not a 5-field cron", () => {
+    const from = new Date("2026-03-10T09:15:00Z");
+    const next = computeNextCronRun("bad expr", from);
+    expect(next.getTime()).toBe(new Date("2026-03-11T09:15:00Z").getTime());
+  });
+
+  it("advances to the next day when the target time has already passed today", () => {
+    const from = new Date("2026-03-10T12:00:00");
+    const next = computeNextCronRun("0 8 * * *", from);
+    expect(next.getHours()).toBe(8);
+    expect(next.getMinutes()).toBe(0);
+    expect(next.getDate()).toBe(11);
+  });
+
+  it("honors a target day-of-week list", () => {
+    // 2026-03-10 is a Tuesday; ask for Friday (5).
+    const from = new Date("2026-03-10T06:00:00");
+    const next = computeNextCronRun("30 9 * * 5", from);
+    expect(next.getDay()).toBe(5);
+    expect(next.getHours()).toBe(9);
+    expect(next.getMinutes()).toBe(30);
+  });
+});
+
+describe("buildInvoiceLiabilityDrafts", () => {
+  it("skips zero-tax lines and produces stable output drafts", () => {
+    const registration = makeRegistration();
+    const drafts = buildInvoiceLiabilityDrafts(registration, [
+      {
+        id: "inv-1",
+        invoiceRef: "INV-1",
+        type: "standard",
+        currency: "GBP",
+        issueDate: new Date("2026-01-15T00:00:00Z"),
+        lineItems: [
+          { id: "li-1", description: "Consulting", lineTotal: 120, taxRate: 20, taxAmount: 20 },
+          { id: "li-2", description: "Zero rated", lineTotal: 50, taxRate: 0, taxAmount: 0 },
+        ],
+      },
+    ]);
+
+    expect(drafts).toHaveLength(1);
+    const draft = drafts[0]!;
+    expect(draft.direction).toBe("output");
+    expect(draft.taxAmount).toBe(20);
+    expect(draft.taxableAmount).toBe(100);
+    expect(draft.taxCode).toBe("standard");
+    expect(draft.sourceType).toBe("invoice_tax");
+    // deterministic id keyed on registration + invoice + line + date + type
+    const again = buildInvoiceLiabilityDrafts(registration, [
+      {
+        id: "inv-1",
+        invoiceRef: "INV-1",
+        type: "standard",
+        currency: "GBP",
+        issueDate: new Date("2026-01-15T00:00:00Z"),
+        lineItems: [{ id: "li-1", description: "Consulting", lineTotal: 120, taxRate: 20, taxAmount: 20 }],
+      },
+    ]);
+    expect(again[0]!.entryId).toBe(draft.entryId);
+    expect(again[0]!.snapshotId).toBe(draft.snapshotId);
+  });
+
+  it("negates tax and tags credit notes", () => {
+    const drafts = buildInvoiceLiabilityDrafts(makeRegistration(), [
+      {
+        id: "cn-1",
+        invoiceRef: "CN-1",
+        type: "credit_note",
+        currency: "GBP",
+        issueDate: new Date("2026-01-20T00:00:00Z"),
+        lineItems: [{ id: "li-9", description: "Refund", lineTotal: 60, taxRate: 20, taxAmount: 10 }],
+      },
+    ]);
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]!.taxAmount).toBe(-10);
+    expect(drafts[0]!.taxCode).toBe("credit_note");
+    expect(drafts[0]!.sourceType).toBe("credit_note");
+    // taxable base uses the absolute tax amount
+    expect(drafts[0]!.taxableAmount).toBe(50);
+  });
+});
+
+describe("buildBillLiabilityDrafts", () => {
+  it("produces input-direction drafts and defaults currency to GBP", () => {
+    const drafts = buildBillLiabilityDrafts(makeRegistration(), [
+      {
+        id: "bill-1",
+        billRef: "BILL-1",
+        currency: null,
+        issueDate: new Date("2026-01-10T00:00:00Z"),
+        lineItems: [
+          { id: "bl-1", description: "Supplies", lineTotal: 240, taxRate: 20, taxAmount: 40 },
+          { id: "bl-2", description: "No tax", lineTotal: 10, taxRate: 0, taxAmount: 0 },
+        ],
+      },
+    ]);
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0]!.direction).toBe("input");
+    expect(drafts[0]!.currency).toBe("GBP");
+    expect(drafts[0]!.taxableAmount).toBe(200);
+    expect(drafts[0]!.taxAmount).toBe(40);
+  });
+});
+
+describe("buildFilingPacketNotes", () => {
+  it("renders a formatted multi-line workpaper summary", () => {
+    const notes = buildFilingPacketNotes({
+      periodStart: new Date("2026-01-01T00:00:00Z"),
+      periodEnd: new Date("2026-03-31T00:00:00Z"),
+      salesTaxAmount: 1000,
+      inputTaxAmount: 250,
+      netTaxAmount: 750,
+      registration: {
+        taxType: "vat",
+        registrationNumber: "GB123",
+        jurisdictionReference: { authorityName: "HMRC" },
+      },
+    });
+    expect(notes).toContain("HMRC vat filing packet");
+    expect(notes).toContain("Period: 2026-01-01 to 2026-03-31");
+    expect(notes).toContain("Registration: GB123");
+    expect(notes).toContain("Sales tax captured: 1000.00");
+    expect(notes).toContain("Net tax due: 750.00");
+  });
+
+  it("falls back to 'pending' when no registration number", () => {
+    const notes = buildFilingPacketNotes({
+      periodStart: new Date("2026-01-01T00:00:00Z"),
+      periodEnd: new Date("2026-03-31T00:00:00Z"),
+      salesTaxAmount: 0,
+      inputTaxAmount: 0,
+      netTaxAmount: 0,
+      registration: {
+        taxType: "gst",
+        registrationNumber: null,
+        jurisdictionReference: { authorityName: "ATO" },
+      },
+    });
+    expect(notes).toContain("Registration: pending");
+  });
+});
+
+describe("buildManagedTaxIssues", () => {
+  it("returns no managed issues for a fully-configured profile with a verified registration", () => {
+    const issues = buildManagedTaxIssues(baseProfile, [makeRegistration()]);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("flags unknown setup mode, missing home jurisdiction and footprint", () => {
+    const issues = buildManagedTaxIssues(
+      {
+        setupMode: "unknown",
+        homeCountryCode: null,
+        footprintSummary: "   ",
+        handoffMode: "external",
+        externalSystem: "Acme",
+        filingOwner: "external_accountant",
+      },
+      [makeRegistration()],
+    );
+    const types = issues.map((i) => i.issueType);
+    expect(types).toContain("tax_setup_mode_unknown");
+    expect(types).toContain("tax_home_jurisdiction_missing");
+    expect(types).toContain("tax_footprint_missing");
+  });
+
+  it("flags research needed when there are no registrations", () => {
+    const issues = buildManagedTaxIssues(baseProfile, []);
+    expect(issues.map((i) => i.issueType)).toContain("tax_registration_research_needed");
+  });
+
+  it("flags a missing registration number and unverified registrations", () => {
+    const issues = buildManagedTaxIssues(baseProfile, [
+      makeRegistration({ registrationNumber: null, lastVerifiedAt: null }),
+    ]);
+    const types = issues.map((i) => i.issueType);
+    expect(types).toContain("tax_registration_number_missing");
+    expect(types).toContain("tax_registration_live_verification_needed");
+    expect(issues.every((i) => i.registrationId === "reg-1")).toBe(true);
+  });
+
+  it("flags DPF-filing and external-handoff gaps together", () => {
+    const issues = buildManagedTaxIssues(
+      {
+        setupMode: "existing",
+        homeCountryCode: "GB",
+        footprintSummary: "UK",
+        handoffMode: "dpf_coworker",
+        externalSystem: null,
+        filingOwner: "dpf_coworker",
+      },
+      [makeRegistration()],
+    );
+    const types = issues.map((i) => i.issueType);
+    expect(types).toContain("tax_external_handoff_missing");
+    expect(types).toContain("tax_dpf_filing_not_available");
+  });
+});
+
+describe("buildCoworkerGuide", () => {
+  it("returns the existing-business guide and a verification queue for unverified registrations", () => {
+    const guide = buildCoworkerGuide(
+      baseProfile,
+      [makeRegistration({ id: "reg-9", lastVerifiedAt: null })],
+      [{ id: "iss-1", issueType: "x", title: "t", severity: "high", registrationId: "reg-9" }],
+    );
+    expect(guide.summary).toContain("already configured");
+    expect(guide.verificationQueue).toHaveLength(1);
+    expect(guide.verificationQueue[0]!.registrationId).toBe("reg-9");
+    expect(guide.openIssueCount).toBe(1);
+  });
+
+  it("returns the new-business guide", () => {
+    const guide = buildCoworkerGuide({ ...baseProfile, setupMode: "new_business" }, [], []);
+    expect(guide.summary).toContain("first-time setup");
+    expect(guide.verificationQueue).toHaveLength(0);
+  });
+
+  it("returns the unclassified guide when the setup mode is unknown", () => {
+    const guide = buildCoworkerGuide({ ...baseProfile, setupMode: "unknown" }, [], []);
+    expect(guide.summary).toContain("classify");
+  });
+});

--- a/apps/web/lib/finance/tax-remittance-core.ts
+++ b/apps/web/lib/finance/tax-remittance-core.ts
@@ -113,3 +113,439 @@ export function addMonths(date: Date, months: number) {
 export function taxableBaseFromLine(lineTotal: unknown, taxAmount: number) {
   return roundCurrency(Math.max(decimalValue(lineTotal) - taxAmount, 0));
 }
+
+// ---------------------------------------------------------------------------
+// BI-OPT-FAT-ACTIONS (tax-remittance remainder): additional pure domain logic
+// relocated verbatim from lib/actions/tax-remittance.ts — structural record
+// shapes, liability-draft builders, period/date math, filing-packet notes, and
+// the managed-issue / coworker-guide projections. No prisma / auth / Next.js.
+// Behavior byte-for-byte preserved; orchestration stays in the action file.
+// ---------------------------------------------------------------------------
+
+// Structural profile shape carrying only the fields the managed-issue and
+// coworker-guide projections read. The action passes its full
+// OrganizationTaxProfile record (a structural supertype) unchanged.
+type TaxProfileRecord = {
+  setupMode: string;
+  homeCountryCode: string | null;
+  footprintSummary: string | null;
+  handoffMode: string;
+  externalSystem: string | null;
+  filingOwner: string;
+};
+
+export type TaxRegistrationRecord = {
+  id: string;
+  registrationId: string;
+  taxType: string;
+  registrationNumber: string | null;
+  registrationStatus: string;
+  filingFrequency: string;
+  filingBasis: string | null;
+  remitterRole: string;
+  effectiveFrom: Date;
+  effectiveTo: Date | null;
+  firstPeriodStart: Date | null;
+  portalAccountNotes: string | null;
+  verifiedFromSourceUrl: string | null;
+  lastVerifiedAt: Date | null;
+  confidence: string;
+  jurisdictionReferenceId: string;
+  organizationTaxProfileId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  jurisdictionReference: {
+    id: string;
+    jurisdictionRefId: string;
+    authorityName: string;
+    countryCode: string;
+    stateProvinceCode: string | null;
+    authorityType: string;
+    taxTypes: string[];
+  };
+};
+
+export type ManagedTaxIssueDraft = {
+  issueType: string;
+  severity: string;
+  title: string;
+  details: string;
+  registrationId?: string | null;
+  periodId?: string | null;
+};
+
+export type LiabilityDraft = {
+  snapshotId?: string;
+  entryId: string;
+  sourceType: string;
+  sourceId: string;
+  sourceLineItemId?: string | null;
+  direction: "output" | "input" | "adjustment";
+  taxType: string;
+  taxCode?: string | null;
+  taxableAmount: number;
+  taxRate?: number | null;
+  taxAmount: number;
+  currency: string;
+  occurredAt: Date;
+  evidence?: Record<string, unknown>;
+  notes?: string | null;
+};
+
+export function buildInvoiceLiabilityDrafts(
+  registration: TaxRegistrationRecord,
+  invoices: Array<{
+    id: string;
+    invoiceRef?: string | null;
+    type?: string | null;
+    currency?: string | null;
+    issueDate: Date;
+    lineItems: Array<{
+      id: string;
+      description?: string | null;
+      lineTotal: unknown;
+      taxRate: unknown;
+      taxAmount: unknown;
+    }>;
+  }>,
+): LiabilityDraft[] {
+  const drafts: LiabilityDraft[] = [];
+
+  for (const invoice of invoices) {
+    for (const lineItem of invoice.lineItems) {
+      const rawTaxAmount = roundCurrency(decimalValue(lineItem.taxAmount));
+      if (!rawTaxAmount) continue;
+
+      const isCredit = invoice.type === "credit_note";
+      const signedTaxAmount = isCredit ? -Math.abs(rawTaxAmount) : rawTaxAmount;
+      const taxRate = roundCurrency(decimalValue(lineItem.taxRate));
+
+      drafts.push({
+        snapshotId: stableTaxEntityId(
+          "TAX-SNAP",
+          registration.id,
+          invoice.id,
+          lineItem.id,
+          invoice.issueDate,
+          invoice.type ?? "standard",
+        ),
+        entryId: stableTaxEntityId(
+          "TAX-LIAB",
+          registration.id,
+          invoice.id,
+          lineItem.id,
+          invoice.issueDate,
+          invoice.type ?? "standard",
+        ),
+        sourceType: isCredit ? "credit_note" : "invoice_tax",
+        sourceId: invoice.id,
+        sourceLineItemId: lineItem.id,
+        direction: "output",
+        taxType: registration.taxType,
+        taxCode: isCredit ? "credit_note" : "standard",
+        taxableAmount: taxableBaseFromLine(lineItem.lineTotal, Math.abs(rawTaxAmount)),
+        taxRate,
+        taxAmount: signedTaxAmount,
+        currency: invoice.currency ?? "GBP",
+        occurredAt: invoice.issueDate,
+        evidence: {
+          invoiceRef: invoice.invoiceRef ?? null,
+          description: lineItem.description ?? null,
+        },
+      });
+    }
+  }
+
+  return drafts;
+}
+
+export function buildBillLiabilityDrafts(
+  registration: TaxRegistrationRecord,
+  bills: Array<{
+    id: string;
+    billRef?: string | null;
+    currency?: string | null;
+    issueDate: Date;
+    lineItems: Array<{
+      id: string;
+      description?: string | null;
+      lineTotal: unknown;
+      taxRate: unknown;
+      taxAmount: unknown;
+    }>;
+  }>,
+): LiabilityDraft[] {
+  const drafts: LiabilityDraft[] = [];
+
+  for (const bill of bills) {
+    for (const lineItem of bill.lineItems) {
+      const taxAmount = roundCurrency(decimalValue(lineItem.taxAmount));
+      if (!taxAmount) continue;
+
+      drafts.push({
+        snapshotId: stableTaxEntityId("TAX-SNAP", registration.id, bill.id, lineItem.id, bill.issueDate, "bill"),
+        entryId: stableTaxEntityId("TAX-LIAB", registration.id, bill.id, lineItem.id, bill.issueDate, "bill"),
+        sourceType: "bill_tax",
+        sourceId: bill.id,
+        sourceLineItemId: lineItem.id,
+        direction: "input",
+        taxType: registration.taxType,
+        taxCode: "standard",
+        taxableAmount: taxableBaseFromLine(lineItem.lineTotal, taxAmount),
+        taxRate: roundCurrency(decimalValue(lineItem.taxRate)),
+        taxAmount,
+        currency: bill.currency ?? "GBP",
+        occurredAt: bill.issueDate,
+        evidence: {
+          billRef: bill.billRef ?? null,
+          description: lineItem.description ?? null,
+        },
+      });
+    }
+  }
+
+  return drafts;
+}
+
+export function computeNextCronRun(cronExpr: string, from: Date) {
+  const parts = cronExpr.trim().split(/\s+/);
+  if (parts.length !== 5) return addDays(from, 1);
+
+  const [minPart, hourPart, , , dowPart] = parts;
+  const minute = minPart === "*" ? 0 : parseInt(minPart!, 10);
+  const hour = hourPart === "*" ? from.getHours() : parseInt(hourPart!, 10);
+
+  const next = new Date(from);
+  next.setSeconds(0, 0);
+  next.setMinutes(minute);
+  next.setHours(hour);
+
+  if (next <= from) {
+    next.setDate(next.getDate() + 1);
+  }
+
+  if (dowPart && dowPart !== "*") {
+    const targetDays = dowPart.split(",").map((value) => parseInt(value, 10));
+    let safety = 0;
+    while (!targetDays.includes(next.getDay()) && safety < 8) {
+      next.setDate(next.getDate() + 1);
+      safety += 1;
+    }
+  }
+
+  return next;
+}
+
+export function periodMonthsForFrequency(filingFrequency: string) {
+  switch (filingFrequency) {
+    case "monthly":
+      return 1;
+    case "bi_monthly":
+      return 2;
+    case "quarterly":
+      return 3;
+    case "half_yearly":
+      return 6;
+    case "annual":
+      return 12;
+    default:
+      return null;
+  }
+}
+
+export function buildFilingPacketNotes(period: {
+  periodStart: Date;
+  periodEnd: Date;
+  salesTaxAmount: unknown;
+  inputTaxAmount: unknown;
+  netTaxAmount: unknown;
+  registration: {
+    taxType: string;
+    registrationNumber: string | null;
+    jurisdictionReference: {
+      authorityName: string;
+    };
+  };
+}) {
+  const salesTaxAmount = roundCurrency(decimalValue(period.salesTaxAmount));
+  const inputTaxAmount = roundCurrency(decimalValue(period.inputTaxAmount));
+  const netTaxAmount = roundCurrency(decimalValue(period.netTaxAmount));
+
+  return [
+    `${period.registration.jurisdictionReference.authorityName} ${period.registration.taxType} filing packet`,
+    `Period: ${period.periodStart.toISOString().slice(0, 10)} to ${period.periodEnd.toISOString().slice(0, 10)}`,
+    `Registration: ${period.registration.registrationNumber ?? "pending"}`,
+    `Sales tax captured: ${salesTaxAmount.toFixed(2)}`,
+    `Input tax captured: ${inputTaxAmount.toFixed(2)}`,
+    `Net tax due: ${netTaxAmount.toFixed(2)}`,
+  ].join("\n");
+}
+
+export function buildManagedTaxIssues(
+  profile: TaxProfileRecord,
+  registrations: TaxRegistrationRecord[],
+): ManagedTaxIssueDraft[] {
+  const issues: ManagedTaxIssueDraft[] = [];
+
+  if (profile.setupMode === "unknown") {
+    issues.push({
+      issueType: "tax_setup_mode_unknown",
+      severity: "medium",
+      title: "Tax setup mode still needs classification",
+      details:
+        "Confirm whether the business is already filing indirect taxes, partially configured, or setting up for the first time.",
+    });
+  }
+
+  if (!nullableString(profile.homeCountryCode)) {
+    issues.push({
+      issueType: "tax_home_jurisdiction_missing",
+      severity: "high",
+      title: "Home jurisdiction is missing",
+      details:
+        "Capture the primary country so the finance coworker can suggest the first authorities and remittance obligations.",
+    });
+  }
+
+  if (!nullableString(profile.footprintSummary)) {
+    issues.push({
+      issueType: "tax_footprint_missing",
+      severity: "high",
+      title: "Operating footprint is not documented",
+      details:
+        "Record where the business is registered, operates, and delivers taxable services before tax setup is treated as ready.",
+    });
+  }
+
+  if (profile.handoffMode !== "dpf_readiness_only" && !nullableString(profile.externalSystem)) {
+    issues.push({
+      issueType: "tax_external_handoff_missing",
+      severity: "high",
+      title: "External filing handoff is not configured",
+      details:
+        "Record the accountant, filing partner, or external tax system that owns final filing and payment before treating this remittance workflow as operational.",
+    });
+  }
+
+  if (profile.filingOwner === "dpf_coworker" && profile.handoffMode !== "dpf_readiness_only") {
+    issues.push({
+      issueType: "tax_dpf_filing_not_available",
+      severity: "medium",
+      title: "Direct DPF filing remains future-scope automation",
+      details:
+        "DPF can prepare registrations, periods, workpapers, and evidence today, but final statutory submission and payment still need an external handoff boundary.",
+    });
+  }
+
+  if (registrations.length === 0) {
+    issues.push({
+      issueType: "tax_registration_research_needed",
+      severity: "high",
+      title: "Tax authority research is still needed",
+      details:
+        profile.setupMode === "existing"
+          ? "List the authorities the business already files with and verify each official filing portal."
+          : "Research likely authorities from the business footprint and add the first registrations to move setup forward.",
+    });
+  }
+
+  for (const registration of registrations) {
+    if (registration.registrationStatus === "active" && !nullableString(registration.registrationNumber)) {
+      issues.push({
+        issueType: "tax_registration_number_missing",
+        severity: "medium",
+        title: "Registration number is missing",
+        details: `Add the registration number for ${registration.jurisdictionReference.authorityName} or record why the authority is still pending.`,
+        registrationId: registration.id,
+      });
+    }
+
+    if (!registration.lastVerifiedAt) {
+      issues.push({
+        issueType: "tax_registration_live_verification_needed",
+        severity: "high",
+        title: "Live verification is still required",
+        details: `Verify ${registration.jurisdictionReference.authorityName} against the official portal and record the source URL before relying on this registration.`,
+        registrationId: registration.id,
+      });
+    }
+  }
+
+  return issues;
+}
+
+export function buildCoworkerGuide(
+  profile: TaxProfileRecord,
+  registrations: TaxRegistrationRecord[],
+  openIssues: Array<{
+    id: string;
+    issueType: string;
+    title: string;
+    severity: string;
+    registrationId: string | null;
+  }>,
+) {
+  const verificationQueue = registrations
+    .filter((registration) => !registration.lastVerifiedAt)
+    .map((registration) => ({
+      registrationId: registration.id,
+      authorityName: registration.jurisdictionReference.authorityName,
+      jurisdictionRefId: registration.jurisdictionReference.jurisdictionRefId,
+      registrationNumber: registration.registrationNumber,
+    }));
+
+  if (profile.setupMode === "existing") {
+    return {
+      summary:
+        "This business appears to be already configured, so the finance coworker should normalize existing registrations before suggesting new authorities.",
+      nextQuestions: [
+        "Which authorities do you already file with today?",
+        "Do you already have registration numbers and portal access for each authority?",
+        "Which filings are handled internally versus by an accountant or tax system?",
+      ],
+      recommendedActions: [
+        "Add each known authority registration.",
+        "Mark the official filing portal live-verified for every active registration.",
+        "Resolve setup gaps before treating remittance as active automation.",
+      ],
+      verificationQueue,
+      openIssueCount: openIssues.length,
+    };
+  }
+
+  if (profile.setupMode === "new_business") {
+    return {
+      summary:
+        "This looks like a first-time setup, so the finance coworker should start from footprint and registration research rather than assuming filing history exists.",
+      nextQuestions: [
+        "Where is the business legally registered and where are services delivered?",
+        "Are there any jurisdictions the owner already knows they must register in?",
+        "Should DPF prepare handoff for an accountant or keep setup directly in the platform?",
+      ],
+      recommendedActions: [
+        "Confirm the home jurisdiction and service footprint.",
+        "Research likely authorities from the seeded jurisdiction registry.",
+        "Record the first verified registrations before scheduling remittance periods.",
+      ],
+      verificationQueue,
+      openIssueCount: openIssues.length,
+    };
+  }
+
+  return {
+    summary:
+      "The finance coworker still needs to classify whether this business is already configured or starting from scratch before tax setup should progress.",
+    nextQuestions: [
+      "Are you already filing sales tax, VAT, or GST anywhere today?",
+      "If yes, which authorities do you file with and how often?",
+      "If no, where is the business registered, operating, and delivering taxable services?",
+    ],
+    recommendedActions: [
+      "Classify the setup mode first.",
+      "Capture the home jurisdiction and footprint.",
+      "Add the first known or likely authority registrations.",
+    ],
+    verificationQueue,
+    openIssueCount: openIssues.length,
+  };
+}

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -29,7 +29,7 @@ apps/web/lib/actions/platform-dev-config.ts	1331
 apps/web/lib/actions/promotions.self-upgrade.test.ts	1022
 apps/web/lib/actions/promotions.ts	948
 apps/web/lib/actions/tax-remittance.test.ts	1080
-apps/web/lib/actions/tax-remittance.ts	1788
+apps/web/lib/actions/tax-remittance.ts	1381
 apps/web/lib/ai-operations-map/load-map-data.test.ts	943
 apps/web/lib/deliberation/orchestrator.ts	808
 apps/web/lib/explore/build-process-matrix.ts	811


### PR DESCRIPTION
## Pure MOVE — behavior preserved (completes the tax-remittance extraction begun in Slice-A)

Relocates the **remaining** side-effect-free logic out of `apps/web/lib/actions/tax-remittance.ts` into the existing domain-core module `apps/web/lib/finance/tax-remittance-core.ts` (created in Slice-A). No logic, signature, or contract changes — bodies moved verbatim. Mirrors the EA (#3118), CRM (#3125), Build (#3126), agent-coworker (#3128), and platform-dev-config (#3129) slices.

### Relocated verbatim into `tax-remittance-core.ts`
- **Structural record shapes:** `TaxRegistrationRecord`, `LiabilityDraft`, `ManagedTaxIssueDraft` (all inline structural types, not prisma-derived).
- **Liability-draft builders:** `buildInvoiceLiabilityDrafts`, `buildBillLiabilityDrafts`.
- **Period/date math:** `computeNextCronRun`, `periodMonthsForFrequency`.
- **Projections:** `buildFilingPacketNotes`, `buildManagedTaxIssues`, `buildCoworkerGuide`.

The managed-issue / coworker-guide projections read a structural profile shape; the action passes its full `OrganizationTaxProfile` record (a structural supertype) unchanged.

### Stays in the action file (orchestration)
`auth`, `prisma`, `revalidatePath`, notification writes, the `"use server"` wrappers, and the DB-touching helpers `reconcileTaxIssues` / `loadTaxWorkspaceState` / `persistLiabilityDrafts` / `upsert`/`resolveOperationalTaxIssue`. They import the pure helpers back.

### LOC
- `apps/web/lib/actions/tax-remittance.ts`: **1788 → 1381** (ratcheted down in `scripts/module-size-baseline.txt`).
- `apps/web/lib/finance/tax-remittance-core.ts`: 116 → **551** (< 800; single module, no second file needed).

### Verification
- **Existing behavior-pin test `tax-remittance.test.ts` (19 tests) passes GREEN and UNCHANGED.**
- New focused unit tests in `tax-remittance-core.test.ts` (18 assertions across all 7 extracted helpers) pass.
- **Zero unused imports:** word-boundary grep of the action file confirms every imported-back symbol (`buildInvoiceLiabilityDrafts`, `buildBillLiabilityDrafts`, `computeNextCronRun`, `periodMonthsForFrequency`, `buildFilingPacketNotes`, `buildManagedTaxIssues`, `buildCoworkerGuide`, `type LiabilityDraft`, `type TaxRegistrationRecord`) has ≥1 use outside the import. `taxableBaseFromLine` was used only by the two moved builders, so it was removed from the action import (it stays exported from core).
- **`check-no-type-reexport-in-use-server` passes** — moved types are imported directly from core; no `export type` re-export leaks from the `"use server"` module.
- Module-size ratchet + type-reexport guards both pass.
- Scoped `tsc --noEmit` on the changed files: core module and core test are **clean**; the residual errors reported in the action file (`User.platformRole`/`isSuperuser`, `user.id: string | undefined`, Prisma `Notification`/`ScheduledAgentTask` create-input types) are **identical pre-existing artifacts** confirmed via a differential run against the untouched `HEAD` original — they are stale-junctioned next-auth `User` augmentation + Prisma-client types in this source-only worktree, not regressions from this change.

### Pure-vs-orchestration calls left deliberately
Every remaining helper in the action file `await`s prisma or reads auth/session state, so nothing else was safe to move without touching the DB/auth boundary — per the smaller-safe-extraction rule.

Generated with Claude Code