### PR TITLE
feat(discovery): seed CatalogIdentity from the fingerprint catalog (BI-0528AD01, EP-ASSET-INTELLIGENCE)

### DIFF
--- a/packages/db/src/discovery-fingerprint-catalog-loader.test.ts
+++ b/packages/db/src/discovery-fingerprint-catalog-loader.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultCatalogPath,
+  deriveCatalogIdentity,
+  loadFingerprintCatalogIntoDb,
+  type FingerprintCatalogLoaderClient,
+} from "./discovery-fingerprint-catalog-loader";
+
+describe("deriveCatalogIdentity", () => {
+  it("maps a software resolvedIdentity to an application (part 'a') identity with a slugged key", () => {
+    expect(
+      deriveCatalogIdentity({ kind: "software", name: "Prometheus Node Exporter", vendor: "Prometheus" }),
+    ).toEqual({
+      identityKey: "a:prometheus:prometheus-node-exporter",
+      part: "a",
+      manufacturer: "Prometheus",
+      product: "Prometheus Node Exporter",
+    });
+  });
+
+  it("maps hardware → part 'h' and os → part 'o'", () => {
+    expect(deriveCatalogIdentity({ kind: "hardware", name: "PowerEdge R750", vendor: "Dell" })?.part).toBe("h");
+    expect(deriveCatalogIdentity({ kind: "os", name: "Ubuntu", vendor: "Canonical" })?.part).toBe("o");
+  });
+
+  it("returns null unless both product and manufacturer are present", () => {
+    expect(deriveCatalogIdentity({ kind: "software", name: "OnlyName" })).toBeNull();
+    expect(deriveCatalogIdentity({ vendor: "OnlyVendor" })).toBeNull();
+    expect(deriveCatalogIdentity(null)).toBeNull();
+    expect(deriveCatalogIdentity("not-an-object")).toBeNull();
+  });
+});
+
+describe("loadFingerprintCatalogIntoDb — CatalogIdentity bridge (BI-0528AD01)", () => {
+  it("upserts a canonical CatalogIdentity per resolvable rule and links catalogIdentityId", async () => {
+    const identityUpserts: Array<{ where: { identityKey: string }; create: { source: string } }> = [];
+    const ruleUpserts: Array<{ create: { catalogIdentityId: string | null } }> = [];
+    let seq = 0;
+
+    const db: FingerprintCatalogLoaderClient = {
+      taxonomyNode: { findMany: async () => [] },
+      discoveryFingerprintCatalogVersion: { upsert: async () => ({ id: "catalog-version-1" }) },
+      discoveryFingerprintRule: {
+        upsert: async (args: unknown) => {
+          ruleUpserts.push(args as { create: { catalogIdentityId: string | null } });
+          return {};
+        },
+      },
+      catalogIdentity: {
+        upsert: async (args: unknown) => {
+          identityUpserts.push(args as { where: { identityKey: string }; create: { source: string } });
+          return { id: `catalog-identity-${(seq += 1)}` };
+        },
+      },
+    };
+
+    const result = await loadFingerprintCatalogIntoDb(db, defaultCatalogPath(__dirname));
+
+    expect(result.loaded).toBeGreaterThan(0);
+    expect(result.catalogIdentitiesLinked).toBeGreaterThan(0);
+
+    // Every identity upsert is keyed on the CPE-part-prefixed identityKey and seeded.
+    for (const upsert of identityUpserts) {
+      expect(upsert.where.identityKey).toMatch(/^[aoh]:/);
+      expect(upsert.create.source).toBe("seeded");
+    }
+
+    // Exactly the rules that resolved to an identity carry a non-null catalogIdentityId.
+    const linkedRules = ruleUpserts.filter((r) => r.create.catalogIdentityId != null);
+    expect(linkedRules.length).toBe(result.catalogIdentitiesLinked);
+  });
+});

--- a/packages/db/src/discovery-fingerprint-catalog-loader.ts
+++ b/packages/db/src/discovery-fingerprint-catalog-loader.ts
@@ -54,6 +54,9 @@ export type FingerprintCatalogLoaderClient = {
   discoveryFingerprintRule: {
     upsert(args: unknown): Promise<unknown>;
   };
+  catalogIdentity: {
+    upsert(args: unknown): Promise<{ id: string }>;
+  };
 };
 
 export type FingerprintCatalogLoadResult = {
@@ -61,6 +64,8 @@ export type FingerprintCatalogLoadResult = {
   version: string;
   loaded: number;
   unresolvedTaxonomy: string[];
+  /** How many rules were linked to a canonical CatalogIdentity (BI-0528AD01). */
+  catalogIdentitiesLinked: number;
 };
 
 async function readJson<T>(filePath: string): Promise<T> {
@@ -70,6 +75,29 @@ async function readJson<T>(filePath: string): Promise<T> {
 /** Only string fixture refs are persisted on the rule row; inline fixtures are validation-only. */
 function stringFixtureRefs(refs: unknown[] | undefined): string[] {
   return (refs ?? []).filter((ref): ref is string => typeof ref === "string");
+}
+
+/**
+ * Derive a canonical CatalogIdentity from a rule's inline `resolvedIdentity`
+ * (BI-0528AD01 — the bridge to the identity spine landed by #3123). A rule's
+ * `resolvedIdentity` is `{ kind, name, vendor }`; the CatalogIdentity is the
+ * normalized manufacturer→product row a fingerprint resolves to. Returns null
+ * when the identity lacks a product+manufacturer (rule then loads identity-only,
+ * catalogIdentityId stays null — same tolerance as an unresolved taxonomy).
+ */
+export function deriveCatalogIdentity(
+  resolvedIdentity: unknown,
+): { identityKey: string; part: string; manufacturer: string; product: string } | null {
+  if (!resolvedIdentity || typeof resolvedIdentity !== "object") return null;
+  const ri = resolvedIdentity as { kind?: unknown; name?: unknown; vendor?: unknown };
+  const product = typeof ri.name === "string" ? ri.name.trim() : "";
+  const manufacturer = typeof ri.vendor === "string" ? ri.vendor.trim() : "";
+  if (!product || !manufacturer) return null;
+  // CPE 2.3 part: hardware → h, OS → o, everything else → a (application).
+  const part = ri.kind === "hardware" ? "h" : ri.kind === "os" ? "o" : "a";
+  const slug = (s: string) =>
+    s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+  return { identityKey: `${part}:${slug(manufacturer)}:${slug(product)}`, part, manufacturer, product };
 }
 
 /**
@@ -105,6 +133,7 @@ export async function loadFingerprintCatalogIntoDb(
 
   const unresolvedTaxonomy: string[] = [];
   let loaded = 0;
+  let catalogIdentitiesLinked = 0;
 
   for (const ruleRef of manifest.rules ?? []) {
     const content = await readJson<CatalogRule | CatalogRule[]>(path.join(catalogDir, ruleRef));
@@ -122,6 +151,29 @@ export async function loadFingerprintCatalogIntoDb(
         }
       }
 
+      // Bridge to the canonical identity spine (BI-0528AD01): upsert the
+      // CatalogIdentity this rule resolves to and link it. Idempotent on
+      // identityKey; null when the rule has no product+manufacturer.
+      let catalogIdentityId: string | null = null;
+      const identity = deriveCatalogIdentity(rule.resolvedIdentity);
+      if (identity) {
+        const row = await db.catalogIdentity.upsert({
+          where: { identityKey: identity.identityKey },
+          update: { part: identity.part, manufacturer: identity.manufacturer, product: identity.product, source: "seeded" },
+          create: {
+            identityKey: identity.identityKey,
+            part: identity.part,
+            manufacturer: identity.manufacturer,
+            product: identity.product,
+            source: "seeded",
+            confidence: rule.identityConfidence ?? null,
+          },
+          select: { id: true },
+        });
+        catalogIdentityId = row.id;
+        catalogIdentitiesLinked += 1;
+      }
+
       const data = {
         catalogVersionId: catalogVersion.id,
         status: rule.status ?? "active",
@@ -130,6 +182,7 @@ export async function loadFingerprintCatalogIntoDb(
         matchExpression: rule.matchExpression as FingerprintMatchExpression,
         requiredEvidenceFamilies: rule.requiredEvidenceFamilies ?? [],
         resolvedIdentity: (rule.resolvedIdentity ?? {}) as object,
+        catalogIdentityId,
         taxonomyNodeId: taxonomyCuid,
         identityConfidence: rule.identityConfidence ?? 0,
         taxonomyConfidence: rule.taxonomyConfidence ?? 0,
@@ -150,5 +203,6 @@ export async function loadFingerprintCatalogIntoDb(
     version: manifest.version,
     loaded,
     unresolvedTaxonomy,
+    catalogIdentitiesLinked,
   };
 }

--- a/packages/db/src/estate-fingerprint-seed.test.ts
+++ b/packages/db/src/estate-fingerprint-seed.test.ts
@@ -157,6 +157,9 @@ describe("loadFingerprintCatalogIntoDb", () => {
           return {};
         },
       },
+      catalogIdentity: {
+        upsert: async () => ({ id: "catalog_identity_1" }),
+      },
     };
 
     const result = await loadFingerprintCatalogIntoDb(client, defaultCatalogPath(__dirname));

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -477,7 +477,10 @@ async function seedDiscoveryFingerprints(): Promise<void> {
         result.unresolvedTaxonomy.join(", "),
     );
   }
-  console.log(`Seeded ${result.loaded} discovery fingerprint rules (catalog ${result.catalogKey}@${result.version})`);
+  console.log(
+    `Seeded ${result.loaded} discovery fingerprint rules (catalog ${result.catalogKey}@${result.version}), ` +
+      `${result.catalogIdentitiesLinked} linked to canonical CatalogIdentity rows`,
+  );
 }
 
 async function seedDigitalProducts(): Promise<void> {


### PR DESCRIPTION
## What
Cascade step 2 after the foundation (#3123). Bridges the existing repo-owned fingerprint catalog to the canonical **CatalogIdentity** spine.

The loader (`discovery-fingerprint-catalog-loader.ts`) already seeds `DiscoveryFingerprintRule` rows from `packages/db/data/discovery_fingerprints/`, but each rule only carried an inline `resolvedIdentity` JSON. Now, for every rule whose `resolvedIdentity` has a product + manufacturer, the loader **upserts a canonical `CatalogIdentity`** (manufacturer→product, CPE `part` from `kind`) and links `DiscoveryFingerprintRule.catalogIdentityId` — so classification resolves to the shared spine, not a per-rule blob.

- New exported pure helper `deriveCatalogIdentity()` (kind→CPE part `a`/`o`/`h`, slugged `identityKey`).
- Loader upserts + links (idempotent on `identityKey`); result gains `catalogIdentitiesLinked`; seed log surfaces it.
- Unit tests: `deriveCatalogIdentity` cases + a mock-client load over the **real** catalog asserting identities upsert (`source=seeded`, part-prefixed key) and exactly the resolvable rules link a `catalogIdentityId`.

## No migration
`CatalogIdentity` + `DiscoveryFingerprintRule.catalogIdentityId` are already on `main` (#3123). Additive — rules without a vendor stay unlinked.

## Verification
Unit tests + typecheck run in CI (source-only worktree, no local toolchain — same path as #3123/#3105).

## Backlog
BI-0528AD01 (rescoped for the #3123 convergence: reuse `DiscoveryFingerprintRule`, not a new model) · Epic **EP-ASSET-INTELLIGENCE**. Next: BI-27EE2AF7 (enrich pipeline) consumes these seeded identities + rules.

Process-Spine-Decision: seed/loader extension onto the already-designed identity spine; no new capability surface.
Design-Grounding-Decision: BI-0528AD01

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Seed-Fit-Decision: global-default
