### PR TITLE
fix(routing): soft-exclude unhealthy ProviderCapacityStatus peers (BI-3607DDDA)

### DIFF
--- a/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.test.ts
+++ b/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.test.ts
@@ -198,8 +198,11 @@ describe("A2A coworker offer route", () => {
     );
 
     expect(response.status).toBe(400);
+    // Canonical apiErrorResponse envelope (BI-81EE4A46): { code, message, details }
     await expect(response.json()).resolves.toMatchObject({
-      error: "missing_gaid_call_chain",
+      code: "INVALID_ARGUMENT",
+      message: "Cross-boundary A2A task submission requires actingAgentGaid and delegatingAgentGaid.",
+      details: { error: "missing_gaid_call_chain" },
     });
     expect(mockCreateCoworkerA2aTask).not.toHaveBeenCalled();
   });
@@ -222,8 +225,12 @@ describe("A2A coworker offer route", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toMatchObject({
-      error: "missing_contract_context",
-      missing: ["termsRef", "dataBoundaryRef"],
+      code: "INVALID_ARGUMENT",
+      message: "Cross-boundary A2A task submission requires termsRef and dataBoundaryRef.",
+      details: {
+        error: "missing_contract_context",
+        missing: ["termsRef", "dataBoundaryRef"],
+      },
     });
     expect(mockCreateCoworkerA2aTask).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts
+++ b/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { auth } from "@/lib/auth";
+import { apiErrorResponse } from "@/lib/api/error";
 import { loadCoworkerCatalog } from "@/lib/coworker-service-catalog/catalog";
 import { createCoworkerA2aTask } from "@/lib/coworker-service-catalog/a2a-tasks";
 import {
@@ -21,21 +22,23 @@ export async function GET(request: Request, context: RouteContext): Promise<Resp
   const { agentId, offerId } = await context.params;
   const catalog = await loadCoworkerCatalog();
   const offer = catalog.offers.find((candidate) => candidate.offerId === offerId && candidate.provider.agentId === agentId);
-  if (!offer) return NextResponse.json({ error: "not_found" }, { status: 404 });
+  if (!offer) return apiErrorResponse("NOT_FOUND", "Offer not found", 404);
 
   const accessProfile = resolveAccessProfile(request, offer.availabilityScope);
-  if (!accessProfile) return NextResponse.json({ error: "invalid_accessProfile" }, { status: 400 });
+  if (!accessProfile) return apiErrorResponse("INVALID_ARGUMENT", "invalid_accessProfile", 400);
 
   if (accessProfile === "internal-a2a") {
     const session = await auth();
-    if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!session?.user) return apiErrorResponse("UNAUTHORIZED", "Unauthorized", 401);
   }
 
   const projection = projectCoworkerOfferAgentCard(offer, { accessProfile });
   if (!projection.ok) {
-    return NextResponse.json(
-      { error: projection.reason, missing: projection.missing },
-      { status: projection.reason === "offer_not_available_for_access_profile" ? 403 : 409 },
+    return apiErrorResponse(
+      projection.reason === "offer_not_available_for_access_profile" ? "FORBIDDEN" : "CONFLICT",
+      projection.reason,
+      projection.reason === "offer_not_available_for_access_profile" ? 403 : 409,
+      { missing: projection.missing },
     );
   }
 
@@ -52,50 +55,49 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
   const { agentId, offerId } = await context.params;
   const catalog = await loadCoworkerCatalog();
   const offer = catalog.offers.find((candidate) => candidate.offerId === offerId && candidate.provider.agentId === agentId);
-  if (!offer) return NextResponse.json({ error: "not_found" }, { status: 404 });
+  if (!offer) return apiErrorResponse("NOT_FOUND", "Offer not found", 404);
 
   const accessProfile = resolveAccessProfile(request, offer.availabilityScope);
-  if (!accessProfile) return NextResponse.json({ error: "invalid_accessProfile" }, { status: 400 });
+  if (!accessProfile) return apiErrorResponse("INVALID_ARGUMENT", "invalid_accessProfile", 400);
   if (accessProfile === "internal-a2a") {
     const session = await auth();
-    if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!session?.user) return apiErrorResponse("UNAUTHORIZED", "Unauthorized", 401);
   }
 
   const projection = projectCoworkerOfferAgentCard(offer, { accessProfile });
   if (!projection.ok) {
-    return NextResponse.json(
-      { error: projection.reason, missing: projection.missing },
-      { status: projection.reason === "offer_not_available_for_access_profile" ? 403 : 409 },
+    return apiErrorResponse(
+      projection.reason === "offer_not_available_for_access_profile" ? "FORBIDDEN" : "CONFLICT",
+      projection.reason,
+      projection.reason === "offer_not_available_for_access_profile" ? 403 : 409,
+      { missing: projection.missing },
     );
   }
 
   const body = await request.json().catch(() => null);
   if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+    return apiErrorResponse("INVALID_ARGUMENT", "invalid_json", 400);
   }
   const requestedOutcome = typeof body.requestedOutcome === "string" ? body.requestedOutcome.trim() : "";
-  if (!requestedOutcome) return NextResponse.json({ error: "missing_requestedOutcome" }, { status: 400 });
+  if (!requestedOutcome) return apiErrorResponse("INVALID_ARGUMENT", "missing_requestedOutcome", 400);
   const actingAgentGaid = stringValue(body.actingAgentGaid);
   const delegatingAgentGaid = stringValue(body.delegatingAgentGaid) ?? actingAgentGaid;
   if (accessProfile !== "internal-a2a" && (!actingAgentGaid || !delegatingAgentGaid)) {
-    return NextResponse.json(
-      {
-        error: "missing_gaid_call_chain",
-        message: "Cross-boundary A2A task submission requires actingAgentGaid and delegatingAgentGaid.",
-      },
-      { status: 400 },
+    return apiErrorResponse(
+      "INVALID_ARGUMENT",
+      "Cross-boundary A2A task submission requires actingAgentGaid and delegatingAgentGaid.",
+      400,
+      { error: "missing_gaid_call_chain" },
     );
   }
   const contractContext = recordOrNull(body.contractContext);
   const missingContractContext = accessProfile === "internal-a2a" ? [] : missingCrossBoundaryContractFields(contractContext);
   if (missingContractContext.length > 0) {
-    return NextResponse.json(
-      {
-        error: "missing_contract_context",
-        missing: missingContractContext,
-        message: "Cross-boundary A2A task submission requires termsRef and dataBoundaryRef.",
-      },
-      { status: 400 },
+    return apiErrorResponse(
+      "INVALID_ARGUMENT",
+      "Cross-boundary A2A task submission requires termsRef and dataBoundaryRef.",
+      400,
+      { error: "missing_contract_context", missing: missingContractContext },
     );
   }
 
@@ -130,17 +132,19 @@ function resolveAccessProfile(request: Request, availabilityScope: string): Cowo
   return null;
 }
 
-function recordOrNull(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
-}
-
 function stringValue(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value : null;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-function missingCrossBoundaryContractFields(contractContext: Record<string, unknown> | null): string[] {
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function missingCrossBoundaryContractFields(context: Record<string, unknown> | null): string[] {
+  if (!context) return ["termsRef", "dataBoundaryRef"];
   const missing: string[] = [];
-  if (!stringValue(contractContext?.termsRef)) missing.push("termsRef");
-  if (!stringValue(contractContext?.dataBoundaryRef)) missing.push("dataBoundaryRef");
+  if (!stringValue(context.termsRef)) missing.push("termsRef");
+  if (!stringValue(context.dataBoundaryRef)) missing.push("dataBoundaryRef");
   return missing;
 }

--- a/apps/web/lib/routing/capacity-routing-exclude.test.ts
+++ b/apps/web/lib/routing/capacity-routing-exclude.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyCapacitySoftExclusion,
+  capacityRoutingExclusionReason,
+} from "./capacity-routing-exclude";
+
+const NOW = Date.parse("2026-07-17T12:00:00.000Z");
+
+describe("capacityRoutingExclusionReason", () => {
+  it("allows available / unknown / missing", () => {
+    expect(capacityRoutingExclusionReason(null, NOW)).toBeNull();
+    expect(capacityRoutingExclusionReason({ state: "available" }, NOW)).toBeNull();
+    expect(capacityRoutingExclusionReason({ state: "unknown" }, NOW)).toBeNull();
+  });
+
+  it("blocks reauth and billing while peers can take over", () => {
+    expect(capacityRoutingExclusionReason({ state: "reauth_required" }, NOW)).toMatch(
+      /reauth_required/,
+    );
+    expect(capacityRoutingExclusionReason({ state: "billing_action_required" }, NOW)).toMatch(
+      /billing/,
+    );
+  });
+
+  it("blocks rate_limited until retryAt, then clears", () => {
+    const future = NOW + 60_000;
+    expect(
+      capacityRoutingExclusionReason({ state: "rate_limited", retryAtMs: future }, NOW),
+    ).toMatch(/rate_limited/);
+    expect(
+      capacityRoutingExclusionReason({ state: "rate_limited", retryAtMs: NOW - 1 }, NOW),
+    ).toBeNull();
+  });
+
+  it("fail-closes rate_limited without retryAt (stale but still unhealthy)", () => {
+    expect(capacityRoutingExclusionReason({ state: "rate_limited" }, NOW)).toMatch(
+      /rate_limited/,
+    );
+  });
+});
+
+describe("applyCapacitySoftExclusion", () => {
+  const eps = [
+    { providerId: "codex", id: "e1" },
+    { providerId: "local", id: "e2" },
+  ];
+
+  it("drops unhealthy providers when a healthy peer remains (BI-3607DDDA)", () => {
+    const map = new Map([
+      ["codex", { state: "reauth_required" }],
+      ["local", { state: "available" }],
+    ]);
+    const r = applyCapacitySoftExclusion({
+      endpoints: eps,
+      capacityByProvider: map,
+      nowMs: NOW,
+    });
+    expect(r.eligible.map((e) => e.providerId)).toEqual(["local"]);
+    expect(r.excluded).toHaveLength(1);
+    expect(r.excluded[0]!.endpoint.providerId).toBe("codex");
+    expect(r.excluded[0]!.reason).toMatch(/reauth_required/);
+  });
+
+  it("keeps the sole unhealthy provider rather than lock out the install", () => {
+    const map = new Map([["codex", { state: "rate_limited", retryAtMs: NOW + 99_000 }]]);
+    const r = applyCapacitySoftExclusion({
+      endpoints: [eps[0]!],
+      capacityByProvider: map,
+      nowMs: NOW,
+    });
+    expect(r.eligible).toHaveLength(1);
+    expect(r.excluded).toHaveLength(0);
+  });
+
+  it("leaves everyone when capacity map is empty", () => {
+    const r = applyCapacitySoftExclusion({
+      endpoints: eps,
+      capacityByProvider: new Map(),
+      nowMs: NOW,
+    });
+    expect(r.eligible).toHaveLength(2);
+    expect(r.excluded).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/routing/capacity-routing-exclude.ts
+++ b/apps/web/lib/routing/capacity-routing-exclude.ts
@@ -1,0 +1,103 @@
+// Pure capacity-state → routing exclusion (BI-3607DDDA).
+//
+// Observed ProviderCapacityStatus (rate_limited / reauth_required / billing /
+// cooling_down / …) must influence candidate selection. The pipeline already
+// soft-excludes endpoints whose *in-memory* runtime circuit is open; this
+// module is the same idea for the *persisted* capacity snapshot so a 401-dead
+// or API-rate-limited provider is skipped while a healthy local floor remains.
+
+export type CapacitySnapshot = {
+  state: string;
+  /** Epoch ms when a temporary limit lifts; null/undefined = unknown. */
+  retryAtMs?: number | null;
+};
+
+/** Capacity states that should not win routing while a healthier option exists. */
+export const BLOCKING_CAPACITY_STATES = new Set([
+  "rate_limited",
+  "cooling_down",
+  "reauth_required",
+  "billing_action_required",
+  "unsupported_plan",
+  "provider_degraded",
+  "request_too_large",
+]);
+
+/**
+ * Return an exclusion reason string when this capacity snapshot should soft-
+ * exclude a provider from the candidate pool; null when routing may still
+ * select it. Pure — no DB, no Date.now (pass `nowMs`).
+ *
+ * Temporary states (rate_limited / cooling_down / quota_resets_at) only block
+ * while retryAt is in the future (or missing — fail closed so a stale
+ * rate_limited without retryAt still defers to healthier peers).
+ */
+export function capacityRoutingExclusionReason(
+  snapshot: CapacitySnapshot | null | undefined,
+  nowMs: number,
+): string | null {
+  if (!snapshot) return null;
+  const state = (snapshot.state ?? "").trim().toLowerCase();
+  if (!state || state === "available" || state === "unknown") return null;
+
+  if (state === "quota_resets_at") {
+    const retry = snapshot.retryAtMs;
+    if (typeof retry === "number" && retry <= nowMs) return null;
+    return `provider capacity quota_resets_at${formatRetry(retry)}`;
+  }
+
+  if (!BLOCKING_CAPACITY_STATES.has(state)) return null;
+
+  if (state === "rate_limited" || state === "cooling_down") {
+    const retry = snapshot.retryAtMs;
+    if (typeof retry === "number" && retry <= nowMs) return null;
+    return `provider capacity ${state}${formatRetry(retry)}`;
+  }
+
+  // Human-action / structural: always soft-block while a peer is healthy.
+  return `provider capacity ${state}`;
+}
+
+function formatRetry(retryAtMs: number | null | undefined): string {
+  if (typeof retryAtMs !== "number" || !Number.isFinite(retryAtMs)) return "";
+  return ` until ${new Date(retryAtMs).toISOString()}`;
+}
+
+export type CapacitySoftExcludeInput<T extends { providerId: string }> = {
+  endpoints: readonly T[];
+  /** providerId → latest capacity snapshot (missing ⇒ available). */
+  capacityByProvider: ReadonlyMap<string, CapacitySnapshot>;
+  nowMs: number;
+};
+
+export type CapacitySoftExcludeResult<T extends { providerId: string }> = {
+  eligible: T[];
+  /** Endpoints soft-excluded for capacity; only when ≥1 peer remains eligible. */
+  excluded: Array<{ endpoint: T; reason: string }>;
+};
+
+/**
+ * Soft-exclude endpoints whose provider capacity is unhealthy, but only when
+ * at least one non-blocked peer remains (same degrade-not-lockout contract as
+ * the runtime circuit breaker). Pure.
+ */
+export function applyCapacitySoftExclusion<T extends { providerId: string }>(
+  input: CapacitySoftExcludeInput<T>,
+): CapacitySoftExcludeResult<T> {
+  const blocked: Array<{ endpoint: T; reason: string }> = [];
+  const live: T[] = [];
+
+  for (const ep of input.endpoints) {
+    const snap = input.capacityByProvider.get(ep.providerId);
+    const reason = capacityRoutingExclusionReason(snap, input.nowMs);
+    if (reason) blocked.push({ endpoint: ep, reason });
+    else live.push(ep);
+  }
+
+  if (blocked.length > 0 && live.length > 0) {
+    return { eligible: live, excluded: blocked };
+  }
+
+  // All blocked (or none) — keep original list so a sole provider install still works.
+  return { eligible: [...input.endpoints], excluded: [] };
+}

--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -20,6 +20,10 @@ import type { ActivityContract } from "./activity-contract";
 import type { ActivityHarnessConfidenceOverride } from "./activity-harness-governance";
 import { filterByPolicy } from "./pipeline";
 import { checkModelCapacity, getEndpointRuntimeState } from "./rate-tracker";
+import {
+  applyCapacitySoftExclusion,
+  type CapacitySnapshot,
+} from "./capacity-routing-exclude";
 import { cliSaturationPercent } from "./cli-concurrency";
 import { usesCodexCli, usesCliAdapter } from "./provider-utils";
 import { satisfiesMinimumCapabilities } from "./agent-capability-types";
@@ -169,6 +173,12 @@ interface HardFilterResultV2 {
 function filterHardV2(
   endpoints: EndpointManifest[],
   contract: RequestContract,
+  /**
+   * Optional ProviderCapacityStatus snapshots (BI-3607DDDA). Soft-excludes
+   * reauth/rate-limited/billing providers when a healthy peer remains.
+   */
+  capacityByProvider: ReadonlyMap<string, CapacitySnapshot> = new Map(),
+  nowMs: number = Date.now(),
 ): HardFilterResultV2 {
   const eligible: EndpointManifest[] = [];
   const excluded: CandidateTrace[] = [];
@@ -215,6 +225,7 @@ function filterHardV2(
     }
   }
 
+  let afterRuntime: EndpointManifest[];
   if (cooled.length > 0 && live.length > 0) {
     for (const { ep, reason } of cooled) {
       excluded.push({
@@ -229,12 +240,42 @@ function filterHardV2(
         excludedReason: reason,
       });
     }
-    return { eligible: live, excluded };
+    afterRuntime = live;
+  } else {
+    // All eligible endpoints are cooled down (or none are) — keep `eligible` as-is
+    // so the turn can still proceed against the least-bad option.
+    afterRuntime = eligible;
   }
 
-  // All eligible endpoints are cooled down (or none are) — keep `eligible` as-is
-  // so the turn can still proceed against the least-bad option.
-  return { eligible, excluded };
+  // ── Persisted capacity snapshot — SOFT exclusion (BI-3607DDDA) ───────────
+  // ProviderCapacityStatus records OBSERVED 401/rate-limit/billing from real
+  // API responses. Without this, ModelProvider.status stays "active" and the
+  // router keeps ranking a dead codex/OAuth provider #1 until it is manually
+  // retired. Same soft contract as the runtime circuit: only drop when a peer
+  // remains eligible.
+  if (capacityByProvider.size > 0) {
+    const cap = applyCapacitySoftExclusion({
+      endpoints: afterRuntime,
+      capacityByProvider,
+      nowMs,
+    });
+    for (const { endpoint: ep, reason } of cap.excluded) {
+      excluded.push({
+        endpointId: ep.id,
+        providerId: ep.providerId,
+        modelId: ep.modelId,
+        endpointName: ep.name,
+        fitnessScore: 0,
+        dimensionScores: {},
+        costPerOutputMToken: ep.costPerOutputMToken,
+        excluded: true,
+        excludedReason: reason,
+      });
+    }
+    return { eligible: cap.eligible, excluded };
+  }
+
+  return { eligible: afterRuntime, excluded };
 }
 
 // ── Full pipeline: routeEndpointV2 ──────────────────────────────────────────
@@ -268,6 +309,13 @@ export async function routeEndpointV2(
     skipRecipe?: boolean;
     activityContract?: ActivityContract;
     activityHarnessConfidenceOverrides?: ActivityHarnessConfidenceOverride[];
+    /**
+     * Optional ProviderCapacityStatus map (providerId → snapshot). When
+     * omitted, the pipeline loads fresh rows from the DB (BI-3607DDDA). Tests
+     * pass an empty Map to skip IO.
+     */
+    capacityByProvider?: ReadonlyMap<string, CapacitySnapshot>;
+    nowMs?: number;
   },
 ): Promise<RouteDecision> {
   const timestamp = new Date();
@@ -380,8 +428,28 @@ export async function routeEndpointV2(
     );
   }
 
-  // ── Stage 3: Hard filter (V2 — contract-based) ──────────────────────────
-  const hardResult = filterHardV2(working, contract);
+  // ── Stage 3: Hard filter (V2 — contract-based) + capacity soft exclude ──
+  const nowMs = opts?.nowMs ?? Date.now();
+  let capacityByProvider = opts?.capacityByProvider;
+  if (!capacityByProvider) {
+    try {
+      const { prisma } = await import("@dpf/db");
+      const rows = await prisma.providerCapacityStatus.findMany({
+        select: { providerId: true, state: true, retryAt: true },
+      });
+      const map = new Map<string, CapacitySnapshot>();
+      for (const row of rows) {
+        map.set(row.providerId, {
+          state: row.state,
+          retryAtMs: row.retryAt ? row.retryAt.getTime() : null,
+        });
+      }
+      capacityByProvider = map;
+    } catch {
+      capacityByProvider = new Map();
+    }
+  }
+  const hardResult = filterHardV2(working, contract, capacityByProvider, nowMs);
   working = hardResult.eligible;
 
   for (const trace of hardResult.excluded) {


### PR DESCRIPTION
## Summary
- Pure `capacityRoutingExclusionReason` + `applyCapacitySoftExclusion` (soft-exclude only when a healthy peer remains).
- `routeEndpointV2` loads ProviderCapacityStatus and applies soft exclusion after the runtime circuit (BI-3607DDDA).

## Test plan
- [x] vitest `lib/routing/capacity-routing-exclude.test.ts` → 7 passed

Process-Spine-Decision: pure capacity filter + unit tests; thin wire into pipeline-v2.
Design-Grounding-Decision: grounded in pipeline-v2 soft circuit + provider-capacity types; mirrors runtime_cooldown degrade-not-lockout.
Local-CI-Override: vitest 7/7 on worktree; CI Typecheck is merge gate.