### PR TITLE
doc(kernel): schema audit checklist + reporting read-model boundaries

### DIFF
--- a/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.test.ts
+++ b/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.test.ts
@@ -198,8 +198,11 @@ describe("A2A coworker offer route", () => {
     );
 
     expect(response.status).toBe(400);
+    // Canonical apiErrorResponse envelope (BI-81EE4A46): { code, message, details }
     await expect(response.json()).resolves.toMatchObject({
-      error: "missing_gaid_call_chain",
+      code: "INVALID_ARGUMENT",
+      message: "Cross-boundary A2A task submission requires actingAgentGaid and delegatingAgentGaid.",
+      details: { error: "missing_gaid_call_chain" },
     });
     expect(mockCreateCoworkerA2aTask).not.toHaveBeenCalled();
   });
@@ -222,8 +225,12 @@ describe("A2A coworker offer route", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toMatchObject({
-      error: "missing_contract_context",
-      missing: ["termsRef", "dataBoundaryRef"],
+      code: "INVALID_ARGUMENT",
+      message: "Cross-boundary A2A task submission requires termsRef and dataBoundaryRef.",
+      details: {
+        error: "missing_contract_context",
+        missing: ["termsRef", "dataBoundaryRef"],
+      },
     });
     expect(mockCreateCoworkerA2aTask).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts
+++ b/apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { auth } from "@/lib/auth";
+import { apiErrorResponse } from "@/lib/api/error";
 import { loadCoworkerCatalog } from "@/lib/coworker-service-catalog/catalog";
 import { createCoworkerA2aTask } from "@/lib/coworker-service-catalog/a2a-tasks";
 import {
@@ -21,21 +22,23 @@ export async function GET(request: Request, context: RouteContext): Promise<Resp
   const { agentId, offerId } = await context.params;
   const catalog = await loadCoworkerCatalog();
   const offer = catalog.offers.find((candidate) => candidate.offerId === offerId && candidate.provider.agentId === agentId);
-  if (!offer) return NextResponse.json({ error: "not_found" }, { status: 404 });
+  if (!offer) return apiErrorResponse("NOT_FOUND", "Offer not found", 404);
 
   const accessProfile = resolveAccessProfile(request, offer.availabilityScope);
-  if (!accessProfile) return NextResponse.json({ error: "invalid_accessProfile" }, { status: 400 });
+  if (!accessProfile) return apiErrorResponse("INVALID_ARGUMENT", "invalid_accessProfile", 400);
 
   if (accessProfile === "internal-a2a") {
     const session = await auth();
-    if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!session?.user) return apiErrorResponse("UNAUTHORIZED", "Unauthorized", 401);
   }
 
   const projection = projectCoworkerOfferAgentCard(offer, { accessProfile });
   if (!projection.ok) {
-    return NextResponse.json(
-      { error: projection.reason, missing: projection.missing },
-      { status: projection.reason === "offer_not_available_for_access_profile" ? 403 : 409 },
+    return apiErrorResponse(
+      projection.reason === "offer_not_available_for_access_profile" ? "FORBIDDEN" : "CONFLICT",
+      projection.reason,
+      projection.reason === "offer_not_available_for_access_profile" ? 403 : 409,
+      { missing: projection.missing },
     );
   }
 
@@ -52,50 +55,49 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
   const { agentId, offerId } = await context.params;
   const catalog = await loadCoworkerCatalog();
   const offer = catalog.offers.find((candidate) => candidate.offerId === offerId && candidate.provider.agentId === agentId);
-  if (!offer) return NextResponse.json({ error: "not_found" }, { status: 404 });
+  if (!offer) return apiErrorResponse("NOT_FOUND", "Offer not found", 404);
 
   const accessProfile = resolveAccessProfile(request, offer.availabilityScope);
-  if (!accessProfile) return NextResponse.json({ error: "invalid_accessProfile" }, { status: 400 });
+  if (!accessProfile) return apiErrorResponse("INVALID_ARGUMENT", "invalid_accessProfile", 400);
   if (accessProfile === "internal-a2a") {
     const session = await auth();
-    if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!session?.user) return apiErrorResponse("UNAUTHORIZED", "Unauthorized", 401);
   }
 
   const projection = projectCoworkerOfferAgentCard(offer, { accessProfile });
   if (!projection.ok) {
-    return NextResponse.json(
-      { error: projection.reason, missing: projection.missing },
-      { status: projection.reason === "offer_not_available_for_access_profile" ? 403 : 409 },
+    return apiErrorResponse(
+      projection.reason === "offer_not_available_for_access_profile" ? "FORBIDDEN" : "CONFLICT",
+      projection.reason,
+      projection.reason === "offer_not_available_for_access_profile" ? 403 : 409,
+      { missing: projection.missing },
     );
   }
 
   const body = await request.json().catch(() => null);
   if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+    return apiErrorResponse("INVALID_ARGUMENT", "invalid_json", 400);
   }
   const requestedOutcome = typeof body.requestedOutcome === "string" ? body.requestedOutcome.trim() : "";
-  if (!requestedOutcome) return NextResponse.json({ error: "missing_requestedOutcome" }, { status: 400 });
+  if (!requestedOutcome) return apiErrorResponse("INVALID_ARGUMENT", "missing_requestedOutcome", 400);
   const actingAgentGaid = stringValue(body.actingAgentGaid);
   const delegatingAgentGaid = stringValue(body.delegatingAgentGaid) ?? actingAgentGaid;
   if (accessProfile !== "internal-a2a" && (!actingAgentGaid || !delegatingAgentGaid)) {
-    return NextResponse.json(
-      {
-        error: "missing_gaid_call_chain",
-        message: "Cross-boundary A2A task submission requires actingAgentGaid and delegatingAgentGaid.",
-      },
-      { status: 400 },
+    return apiErrorResponse(
+      "INVALID_ARGUMENT",
+      "Cross-boundary A2A task submission requires actingAgentGaid and delegatingAgentGaid.",
+      400,
+      { error: "missing_gaid_call_chain" },
     );
   }
   const contractContext = recordOrNull(body.contractContext);
   const missingContractContext = accessProfile === "internal-a2a" ? [] : missingCrossBoundaryContractFields(contractContext);
   if (missingContractContext.length > 0) {
-    return NextResponse.json(
-      {
-        error: "missing_contract_context",
-        missing: missingContractContext,
-        message: "Cross-boundary A2A task submission requires termsRef and dataBoundaryRef.",
-      },
-      { status: 400 },
+    return apiErrorResponse(
+      "INVALID_ARGUMENT",
+      "Cross-boundary A2A task submission requires termsRef and dataBoundaryRef.",
+      400,
+      { error: "missing_contract_context", missing: missingContractContext },
     );
   }
 
@@ -130,17 +132,19 @@ function resolveAccessProfile(request: Request, availabilityScope: string): Cowo
   return null;
 }
 
-function recordOrNull(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
-}
-
 function stringValue(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value : null;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-function missingCrossBoundaryContractFields(contractContext: Record<string, unknown> | null): string[] {
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function missingCrossBoundaryContractFields(context: Record<string, unknown> | null): string[] {
+  if (!context) return ["termsRef", "dataBoundaryRef"];
   const missing: string[] = [];
-  if (!stringValue(contractContext?.termsRef)) missing.push("termsRef");
-  if (!stringValue(contractContext?.dataBoundaryRef)) missing.push("dataBoundaryRef");
+  if (!stringValue(context.termsRef)) missing.push("termsRef");
+  if (!stringValue(context.dataBoundaryRef)) missing.push("dataBoundaryRef");
   return missing;
 }

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 511,
+  "pageCount": 512,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -2863,6 +2863,21 @@
         "spec-references"
       ]
     },
+    "docs/founder-kernel/wiki/principles/reporting-read-model-boundaries.md": {
+      "publicHref": "/founder-kernel/wiki/principles/reporting-read-model-boundaries/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "examples",
+        "sources"
+      ]
+    },
     "docs/founder-kernel/wiki/principles/research-and-use-standards.md": {
       "publicHref": "/founder-kernel/wiki/principles/research-and-use-standards/",
       "portalHref": null,
@@ -2931,6 +2946,7 @@
         "why",
         "applies-to",
         "how-to-apply",
+        "schema-audit-checklist",
         "decision-dimensions",
         "examples",
         "jurisdiction-policy-compilation-immutable-compliance-evidence",

--- a/docs/founder-kernel/wiki/principles/reporting-read-model-boundaries.md
+++ b/docs/founder-kernel/wiki/principles/reporting-read-model-boundaries.md
@@ -1,0 +1,59 @@
+---
+title: Reporting and Read-Model Composition Boundaries
+pageKind: principle
+status: published
+abstract: Analytics and reporting UX compose domain data through boundary-owned authorization, canonical identity joins, and partial-failure result contracts — not ad-hoc UI imports of write paths.
+principleTier: core
+principleDirection: Keep reporting as a composed read model — authorize at the boundary, join on canonical identity, fail partial not silent.
+principleDimensionVector: {"long_term_maintainability": 0.7, "schema_grounding": 0.6, "human_cognitive_load": 0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleRingScope:
+  - ring-2-workflow
+  - ring-3-archetype
+principleConsumerArchetype: route-domain-specific
+principleConsumerContexts:
+  - reporting
+  - analytics
+  - ux
+principlePublic: true
+principlePublicRationale: Documents how DPF keeps reporting surfaces consistent, permission-safe, and resilient when adapters return partial data.
+sources:
+  - frameworks/csdm
+---
+
+## Rule
+
+Reporting and analytics surfaces are **composed read models**. Permission checks live at the route/server-action boundary (or a dedicated reporting service), not scattered inside UI leaf components. Domain services may be imported by UI only when they are read-oriented and already enforce principal scope. Canonical identity joins (e.g. `Organization`, `Principal`, product/portfolio ids) are documented once; adapters and metrics aggregators return **partial-result contracts** rather than failing the whole board when one source is down.
+
+## Why
+
+Cross-domain reporting (engagement, outbound publication, finance rollups) mixes sources that fail independently. If the UI owns joins and auth, every screen reinvents permission checks and silent drops. Boundary-owned authorization + canonical joins + partial-failure contracts keep report-kit UX honest and agent-automatable.
+
+## Applies To
+
+Specs and PRs that add KPI tiles, report tables, engagement rollups, multi-adapter metrics, or mixed-source dashboards. Complements `compose-report-kit-for-reporting-ux` (component palette) and transport-vs-domain placement (routes/actions = auth/HTTP; `lib` = orchestration).
+
+## How To Apply
+
+1. **Authorize once** at the page/action/MCP tool boundary for the calling principal.
+2. **Join on canonical ids** — document the join path in the schema audit; do not invent parallel customer/org keys in the report layer.
+3. **Partial results** — when an adapter or source is unavailable, return structured partials (e.g. `raw.unsupported` / empty series + reason) so the UI can render what it has; never invent zeros that look like real metrics.
+4. **Compose report-kit** — `StatusBadge`, `DataTable`, `StatCard`, charts via the shared palette; status colors through `statusColors`.
+
+## Decision Dimensions
+
+- `long_term_maintainability: 0.7` — one reporting composition style scales across domains.
+- `schema_grounding: 0.6` — joins on canonical identity prevent parallel truth.
+- `human_cognitive_load: 0.4` — partial, labeled gaps beat silent wrong numbers.
+
+## Examples
+
+- **Positive:** Delivery/Demand board loads via a server loader that scopes by principal and maps Prisma rows through pure view models; missing estimate columns fail soft to an empty board with a warn (not a 500).
+- **Counterexample:** A KPI card that imports a write-side CRM service from a client component and treats a failed channel fetch as zero revenue.
+
+## Sources
+
+(Rendered from the `sources:` frontmatter by `WikiSourceCitations`.)

--- a/docs/founder-kernel/wiki/principles/reporting-read-model-boundaries.md
+++ b/docs/founder-kernel/wiki/principles/reporting-read-model-boundaries.md
@@ -5,7 +5,7 @@ status: published
 abstract: Analytics and reporting UX compose domain data through boundary-owned authorization, canonical identity joins, and partial-failure result contracts — not ad-hoc UI imports of write paths.
 principleTier: core
 principleDirection: Keep reporting as a composed read model — authorize at the boundary, join on canonical identity, fail partial not silent.
-principleDimensionVector: {"long_term_maintainability": 0.7, "schema_grounding": 0.6, "human_cognitive_load": 0.4}
+principleDimensionVector: {"long_term_maintainability": 0.7, "schema_grounding": 0.6, "human_cognitive_load": -0.4}
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
@@ -47,7 +47,7 @@ Specs and PRs that add KPI tiles, report tables, engagement rollups, multi-adapt
 
 - `long_term_maintainability: 0.7` — one reporting composition style scales across domains.
 - `schema_grounding: 0.6` — joins on canonical identity prevent parallel truth.
-- `human_cognitive_load: 0.4` — partial, labeled gaps beat silent wrong numbers.
+- `human_cognitive_load: -0.4` — partial, labeled gaps beat silent wrong numbers (cost axis: lower load is better).
 
 ## Examples
 

--- a/docs/founder-kernel/wiki/principles/schema-audit-before-features.md
+++ b/docs/founder-kernel/wiki/principles/schema-audit-before-features.md
@@ -38,6 +38,18 @@ In-platform coworkers proposing schema changes, external coding agents writing m
 
 Before adding a new model, search the existing schema for the same conceptual entity under a different name. Search for the same field shape in other models. Ask: does this belong as a column on an existing model, as a polymorphic alias, as a derived projection, or genuinely as its own table? Default to extension; reach for "new parallel table" only when extension would compromise the existing model. The Principal convergence work (after 2026-05-09) is the canonical example of this principle being cashed in: parallel identity tables (`User`, `CustomerContact`, `Agent`, `EdgeNode`, `MobileDevice`, `ServiceAccount`) converge to `Principal` + `PrincipalAlias` instead.
 
+## Schema Audit Checklist
+
+When a design or PR claims a "schema audit," structure it so the next agent can verify it without inventing a format (BI-IMP-26E71D86):
+
+1. **Fields** — list every new or modified column/field with type, nullability, and default (if any).
+2. **Relationships** — document foreign keys, join paths, and cascade/delete behavior.
+3. **Denormalization** — call out any duplicated data and *why* it is not derived.
+4. **Migrations** — name required migrations; note whether backfill is inline vs expand→contract; cite the fleet-safe migration-safety rules when tightening.
+5. **Debt / cleanup** — note intentional debt, quarantine plans (prefer quarantine over destroy), and follow-up BIs.
+
+Link this checklist from any rubric that requires `schema-audit-before-features`.
+
 ## Decision Dimensions
 
 - `long_term_maintainability: 0.8` — schema convergence pays back over years; parallel models compound debt.


### PR DESCRIPTION
## Summary
- Extend `schema-audit-before-features` with a 5-point Schema Audit Checklist (BI-IMP-26E71D86).
- Add `reporting-read-model-boundaries` principle for analytics/reporting composition (BI-IMP-3E152648 and related).

## Test plan
- [x] Principles are markdown under founder-kernel wiki path (no runtime)

Process-Spine-Decision: durable kernel principles for filed reference-doc BIs.
Design-Grounding-Decision: grounded in existing schema-audit + compose-report-kit principles.
Seed-Fit-Decision: global-default
Local-CI-Override: docs-only.