### PR TITLE
Fix WWMD voice dispatch enrichment failures

### DIFF
--- a/apps/web/lib/voice-synthesis/synthesis-job.test.ts
+++ b/apps/web/lib/voice-synthesis/synthesis-job.test.ts
@@ -40,6 +40,7 @@ vi.mock("./audio-storage", () => ({
 }))
 
 import { runVoiceSynthesisJob } from "./synthesis-job"
+import { applyPersonaStyle } from "./persona-style"
 
 describe("runVoiceSynthesisJob", () => {
   beforeEach(() => vi.clearAllMocks())
@@ -103,5 +104,29 @@ describe("runVoiceSynthesisJob", () => {
     })
 
     await expect(runVoiceSynthesisJob("DI-abc")).resolves.toBeUndefined()
+  })
+
+  it("does not throw if persona styling fails - voice remains non-blocking enrichment", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    vi.mocked(applyPersonaStyle).mockRejectedValueOnce(new Error("style model unavailable"))
+    mockPrisma.decisionInteraction.findUnique.mockResolvedValue({
+      interactionId: "DI-abc",
+      rationale: "Plan is ready.",
+      outcomeType: "recommend",
+      confidenceAfter: 0.7,
+      profile: {
+        voiceEnabled: true,
+        personaConfig: { systemPrompt: "Speak warmly." },
+        voiceProfile: { id: "vp-1", providerVoiceId: "v1", provider: "cartesia", language: "en", status: "ready" },
+      },
+    })
+
+    await expect(runVoiceSynthesisJob("DI-abc")).resolves.toBeUndefined()
+    expect(mockPrisma.decisionInteractionVoiceOutput.create).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[tool-trace] voice.synthesis.style.failed",
+      expect.objectContaining({ interactionId: "DI-abc" }),
+    )
+    errorSpy.mockRestore()
   })
 })

--- a/apps/web/lib/voice-synthesis/synthesis-job.ts
+++ b/apps/web/lib/voice-synthesis/synthesis-job.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@dpf/db"
 import { buildNarrationText } from "./narration-builder"
 import { applyPersonaStyle } from "./persona-style"
-import { synthesizeSpeech, VoiceSynthesisError, defaultProvider } from "./voice-service"
+import { synthesizeSpeech, defaultProvider } from "./voice-service"
 import { writeAudioBlob } from "./audio-storage"
 import type { NarrationOutcomeType } from "./types"
 
@@ -33,21 +33,23 @@ export async function runVoiceSynthesisJob(interactionId: string): Promise<void>
     return
   }
 
-  const personaSystemPrompt = (profile.personaConfig as { systemPrompt?: string } | null)?.systemPrompt
-
-  const rawNarrationText = buildNarrationText({
-    outcomeType: interaction.outcomeType as NarrationOutcomeType,
-    confidenceScore: interaction.confidenceAfter ?? 0,
-    rationale: interaction.rationale ?? "",
-    personaSystemPrompt,
-  })
-
-  const narrationText = await applyPersonaStyle({
-    narrationText: rawNarrationText,
-    personaSystemPrompt,
-  })
-
+  let stage: "style" | "synthesis" | "storage" = "style"
   try {
+    const personaSystemPrompt = (profile.personaConfig as { systemPrompt?: string } | null)?.systemPrompt
+
+    const rawNarrationText = buildNarrationText({
+      outcomeType: interaction.outcomeType as NarrationOutcomeType,
+      confidenceScore: interaction.confidenceAfter ?? 0,
+      rationale: interaction.rationale ?? "",
+      personaSystemPrompt,
+    })
+
+    const narrationText = await applyPersonaStyle({
+      narrationText: rawNarrationText,
+      personaSystemPrompt,
+    })
+
+    stage = "synthesis"
     // Honor the deployment-configured provider (TTS_PROVIDER env), not the
     // value stored on the profile at registration time — same reasoning as
     // /api/voice/synthesize. defaultProvider() falls back to "chatterbox".
@@ -57,6 +59,7 @@ export async function runVoiceSynthesisJob(interactionId: string): Promise<void>
       language: vp.language,
     })
 
+    stage = "storage"
     const { storageKey } = await writeAudioBlob({
       interactionId,
       audioBuffer: synthesis.audioBuffer,
@@ -81,8 +84,7 @@ export async function runVoiceSynthesisJob(interactionId: string): Promise<void>
 
     console.info(`${TRACE}.completed`, { interactionId, durationMs, provider: synthesis.provider })
   } catch (err) {
-    const tag = err instanceof VoiceSynthesisError ? "synthesis.failed" : "storage.failed"
-    console.error(`${TRACE}.${tag}`, { interactionId, error: String(err) })
+    console.error(`${TRACE}.${stage}.failed`, { interactionId, error: String(err) })
     // Do NOT rethrow — voice is non-blocking enrichment
   }
 }


### PR DESCRIPTION
## Summary
- Keep WWMD voice synthesis enrichment non-blocking when persona styling fails.
- Move narration styling into the synthesis job's guarded flow and log stage-specific failure tags.
- Add regression coverage for persona styling failures so they no longer bubble to `wwmd.voice.dispatch.failed`.

## Verification
- `pnpm --filter web exec vitest run lib/voice-synthesis/synthesis-job.test.ts lib/voice-synthesis/integration.test.ts`
- `git diff --check`
- `pnpm --filter web build` (passes; existing Turbopack Edge-runtime warnings remain)

Backlog: BI-PIR-f2923d84