### PR TITLE
feat(delivery-flow): shadow-measure auto-claim autonomy on funded bets (EP-DELIVERY-FLOW BI-A6648529 auto-claim, shadow_first)

### DIFF
--- a/apps/web/lib/demand/funding-risk.test.ts
+++ b/apps/web/lib/demand/funding-risk.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { fundedItemRiskClass, fundingRiskTier, riskTierToRiskClass } from "./funding-risk";
+
+describe("fundingRiskTier", () => {
+  it("rates transform bets and xlarge work highest", () => {
+    expect(fundingRiskTier("transform", "small")).toBe("high");
+    expect(fundingRiskTier("grow", "xlarge")).toBe("high");
+  });
+
+  it("rates large work medium", () => {
+    expect(fundingRiskTier("grow", "large")).toBe("medium");
+    expect(fundingRiskTier(null, "large")).toBe("medium");
+  });
+
+  it("rates everything else low", () => {
+    expect(fundingRiskTier("run", "small")).toBe("low");
+    expect(fundingRiskTier(null, null)).toBe("low");
+  });
+});
+
+describe("riskTierToRiskClass", () => {
+  it("maps the tier onto the governed risk class (high = the kernel floor)", () => {
+    expect(riskTierToRiskClass("high")).toBe("outbound-or-floor");
+    expect(riskTierToRiskClass("medium")).toBe("internal-irreversible");
+    expect(riskTierToRiskClass("low")).toBe("internal-reversible");
+  });
+});
+
+describe("fundedItemRiskClass", () => {
+  it("composes tier + class so a transform bet lands at the floor and a small run is reversible", () => {
+    expect(fundedItemRiskClass("transform", "medium")).toBe("outbound-or-floor");
+    expect(fundedItemRiskClass("grow", "large")).toBe("internal-irreversible");
+    expect(fundedItemRiskClass("run", "small")).toBe("internal-reversible");
+  });
+});

--- a/apps/web/lib/demand/funding-risk.ts
+++ b/apps/web/lib/demand/funding-risk.ts
@@ -1,0 +1,44 @@
+// Funding-risk classification for demand bets (EP-DELIVERY-FLOW).
+//
+// The demand funding gate rates a bet's risk tier (low|medium|high); the AI-led
+// volunteering autonomy resolver maps that tier onto the governed work-management
+// RiskClass so a coworker's auto-claim authority is CAPPED by how risky the bet
+// is. Kept pure (no prisma) so both the demand-scoring pack (the funding gate)
+// and the volunteering resolver share one source of truth for the thresholds.
+
+import type { RiskClass } from "@/lib/autonomy/trust-graduation";
+
+export type FundingRiskTier = "low" | "medium" | "high";
+
+/**
+ * Bet risk tier from its investment bucket + effort: transform bets and xlarge
+ * work rank highest, large is medium, everything else low.
+ */
+export function fundingRiskTier(investmentBucket: string | null, effortSize: string | null): FundingRiskTier {
+  if (investmentBucket === "transform" || effortSize === "xlarge") return "high";
+  if (effortSize === "large") return "medium";
+  return "low";
+}
+
+/**
+ * Map a funding risk tier onto the governed RiskClass that ceilings a coworker's
+ * autonomy. A funded build pickup is an internal action, so low/medium map to the
+ * reversible/irreversible internal classes (ceiling autopilot — a fully trusted
+ * coworker may auto-claim); a high-risk (transform / xlarge) bet maps to the
+ * kernel floor (ceiling propose — even a trusted coworker must ask first).
+ */
+export function riskTierToRiskClass(tier: FundingRiskTier): RiskClass {
+  switch (tier) {
+    case "high":
+      return "outbound-or-floor";
+    case "medium":
+      return "internal-irreversible";
+    case "low":
+      return "internal-reversible";
+  }
+}
+
+/** The governed RiskClass for a funded item directly from its facets. */
+export function fundedItemRiskClass(investmentBucket: string | null, effortSize: string | null): RiskClass {
+  return riskTierToRiskClass(fundingRiskTier(investmentBucket, effortSize));
+}

--- a/apps/web/lib/demand/volunteering.server.ts
+++ b/apps/web/lib/demand/volunteering.server.ts
@@ -11,7 +11,19 @@
 // own.
 
 import { prisma } from "@dpf/db";
-import { shouldOfferToCoworker } from "./volunteering";
+import { resolveVolunteeringAutonomy, shouldOfferToCoworker, type VolunteeringDecision } from "./volunteering";
+import { fundedItemRiskClass } from "./funding-risk";
+import { AUTONOMY_LEVELS, type AutonomyLevel } from "@/lib/autonomy/trust-graduation";
+
+/** The activityType under which a coworker's funded-bet-pickup trust is measured. */
+const PICKUP_ACTIVITY_TYPE = "demand_bet_pickup";
+
+/** Coerce a stored string to an AutonomyLevel, defaulting to the floor (shadow). */
+function asAutonomyLevel(value: string | null | undefined): AutonomyLevel {
+  return value && (AUTONOMY_LEVELS as readonly string[]).includes(value)
+    ? (value as AutonomyLevel)
+    : "shadow";
+}
 
 export type FundedItemOfferResult = {
   offered: boolean;
@@ -50,4 +62,88 @@ export async function offerFundedItemToCoworker(item: {
     }),
   ]);
   return { offered: true, agentId };
+}
+
+export type VolunteeringAutonomyShadowResult = {
+  recorded: boolean;
+  /** What auto-claim WOULD have decided given the coworker's resolved autonomy. */
+  wouldHave: VolunteeringDecision | null;
+  decisionMode: string | null;
+  effectiveTrustLevel: string | null;
+};
+
+/**
+ * Shadow-measure what an autonomous auto-claim WOULD do for this funded bet, and
+ * record it — without acting on it. Kernel decision (shadow_first, high conf,
+ * composite 9.10): the TrustState tables measure trust but do not yet authorize
+ * runtime autonomy, so this resolves the coworker's auto-claim authority
+ * (TrustState.currentLevel → risk/regulatory ceiling → decisionMode) and writes a
+ * DecisionShadowLedger row comparing the WOULD-BE decision against what actually
+ * happened (the ask-first offer). This builds the graduation evidence that a
+ * later, operator-gated step would need before real auto-claim is enabled — the
+ * measure-before-authorize path. Non-authoritative: never claims or advances
+ * status. Best-effort (callers treat as non-fatal).
+ */
+export async function recordVolunteeringAutonomyShadow(item: {
+  id: string;
+  itemId: string;
+  agentId: string | null;
+  investmentBucket: string | null;
+  effortSize: string | null;
+  claimStatus: string | null;
+}): Promise<VolunteeringAutonomyShadowResult> {
+  const empty: VolunteeringAutonomyShadowResult = {
+    recorded: false,
+    wouldHave: null,
+    decisionMode: null,
+    effectiveTrustLevel: null,
+  };
+  if (!item.agentId) return empty;
+
+  const riskClass = fundedItemRiskClass(item.investmentBucket, item.effortSize);
+  const trust = await prisma.trustState.findUnique({
+    where: {
+      agentId_activityType_riskClass: {
+        agentId: item.agentId,
+        activityType: PICKUP_ACTIVITY_TYPE,
+        riskClass,
+      },
+    },
+    select: { currentLevel: true, regulatoryCeiling: true },
+  });
+  const autonomy = resolveVolunteeringAutonomy({
+    trustLevel: asAutonomyLevel(trust?.currentLevel),
+    risk: riskClass,
+    regulatoryCeiling: trust?.regulatoryCeiling ? asAutonomyLevel(trust.regulatoryCeiling) : null,
+  });
+
+  // The act stays ask-first (shadow-first): record the WOULD-BE decision against
+  // what actually happens so the two can be reconciled into graduation evidence.
+  const actual: VolunteeringDecision = shouldOfferToCoworker(item) ? "ask_first" : "observe";
+  const ledgerId = `demand-pickup:${item.itemId}:${Date.now()}`;
+  await prisma.decisionShadowLedger.create({
+    data: {
+      ledgerId,
+      agentId: item.agentId,
+      activityType: PICKUP_ACTIVITY_TYPE,
+      riskClass,
+      autonomyLevel: autonomy.effectiveTrustLevel,
+      proposedDecision: { volunteering: autonomy.decision, decisionMode: autonomy.decisionMode },
+      actualDecision: { volunteering: actual, offered: actual === "ask_first" },
+      agreement: autonomy.decision === actual,
+      sourceKind: "demand-bet-pickup",
+      metadata: {
+        itemId: item.itemId,
+        risk: riskClass,
+        effectiveTrustLevel: autonomy.effectiveTrustLevel,
+        runtimeConsumer: "delivery-flow-volunteering",
+      },
+    },
+  });
+  return {
+    recorded: true,
+    wouldHave: autonomy.decision,
+    decisionMode: autonomy.decisionMode,
+    effectiveTrustLevel: autonomy.effectiveTrustLevel,
+  };
 }

--- a/apps/web/lib/demand/volunteering.test.ts
+++ b/apps/web/lib/demand/volunteering.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { decideVolunteering, shouldOfferToCoworker } from "./volunteering";
+import { decideVolunteering, resolveVolunteeringAutonomy, shouldOfferToCoworker } from "./volunteering";
 
 describe("decideVolunteering", () => {
   it("auto-claims only when the autonomy envelope grants autonomous-action", () => {
@@ -14,6 +14,44 @@ describe("decideVolunteering", () => {
 
   it("observes (no claim, no ask) when shadow-only", () => {
     expect(decideVolunteering("shadow-only")).toBe("observe");
+  });
+});
+
+describe("resolveVolunteeringAutonomy", () => {
+  it("auto-claims when a fully-trusted coworker takes a low-risk (reversible) bet", () => {
+    const r = resolveVolunteeringAutonomy({ trustLevel: "autopilot", risk: "internal-reversible" });
+    expect(r.effectiveTrustLevel).toBe("autopilot");
+    expect(r.decisionMode).toBe("autonomous-action");
+    expect(r.decision).toBe("auto_claim");
+  });
+
+  it("caps even a fully-trusted coworker to ask-first on a high-risk (floor) bet", () => {
+    // outbound-or-floor ceiling is `propose` — autopilot is capped down to it.
+    const r = resolveVolunteeringAutonomy({ trustLevel: "autopilot", risk: "outbound-or-floor" });
+    expect(r.effectiveTrustLevel).toBe("propose");
+    expect(r.decision).toBe("ask_first");
+  });
+
+  it("observes when no trust is established (shadow), regardless of risk", () => {
+    expect(resolveVolunteeringAutonomy({ trustLevel: "shadow", risk: "internal-reversible" }).decision).toBe(
+      "observe",
+    );
+  });
+
+  it("asks first for a supervised coworker on a reversible bet", () => {
+    expect(resolveVolunteeringAutonomy({ trustLevel: "supervised", risk: "internal-reversible" }).decision).toBe(
+      "ask_first",
+    );
+  });
+
+  it("lets a regulatory ceiling cap autonomy below the risk ceiling", () => {
+    const r = resolveVolunteeringAutonomy({
+      trustLevel: "autopilot",
+      risk: "internal-reversible", // risk ceiling autopilot…
+      regulatoryCeiling: "propose", // …but regulation caps to propose.
+    });
+    expect(r.effectiveTrustLevel).toBe("propose");
+    expect(r.decision).toBe("ask_first");
   });
 });
 

--- a/apps/web/lib/demand/volunteering.ts
+++ b/apps/web/lib/demand/volunteering.ts
@@ -23,7 +23,16 @@
 // §"AI-led execution (the synced bet)". Plan:
 // docs/superpowers/plans/2026-07-15-ai-led-volunteering-plan.md.
 
-import type { WorkCaseAutonomyDecisionMode } from "@/lib/work-management/autonomy-envelope";
+import {
+  autonomyLevelToDecisionMode,
+  type WorkCaseAutonomyDecisionMode,
+} from "@/lib/work-management/autonomy-envelope";
+import {
+  DEFAULT_RISK_CEILINGS,
+  minLevel,
+  type AutonomyLevel,
+  type RiskClass,
+} from "@/lib/autonomy/trust-graduation";
 
 /**
  * What a coworker does with a freshly-funded item, given its resolved autonomy
@@ -54,6 +63,40 @@ export function decideVolunteering(decisionMode: WorkCaseAutonomyDecisionMode): 
     case "supervised-action":
       return "ask_first";
   }
+}
+
+/** A coworker's resolved auto-claim authority for a funded bet. */
+export type VolunteeringAutonomy = {
+  /** The coworker's trust level after the risk + regulatory ceilings apply. */
+  effectiveTrustLevel: AutonomyLevel;
+  /** The work-case decision mode that effective level projects to. */
+  decisionMode: WorkCaseAutonomyDecisionMode;
+  /** What the coworker may do with the bet under that mode. */
+  decision: VolunteeringDecision;
+};
+
+/**
+ * Resolve how a coworker may volunteer for a funded bet from its governed
+ * autonomy inputs. Pure — mirrors the work-management autonomy envelope's cap
+ * math (risk ceiling, then any regulatory ceiling, then the coworker's own trust
+ * level, taking the minimum) without the WorkCase source/action coupling, so the
+ * demand seam can resolve a decision from just (trustLevel, risk, regulatory).
+ *
+ * The ceiling is what makes this safe: a fully-trusted (`autopilot`) coworker is
+ * still capped to `propose` on a high-risk (`outbound-or-floor`) bet, so it must
+ * ask first; a coworker with no established trust (`shadow`) only observes.
+ */
+export function resolveVolunteeringAutonomy(input: {
+  trustLevel: AutonomyLevel;
+  risk: RiskClass;
+  regulatoryCeiling?: AutonomyLevel | null;
+  ceilings?: Record<RiskClass, AutonomyLevel>;
+}): VolunteeringAutonomy {
+  const riskCeiling = (input.ceilings ?? DEFAULT_RISK_CEILINGS)[input.risk];
+  const ceiling = input.regulatoryCeiling ? minLevel(riskCeiling, input.regulatoryCeiling) : riskCeiling;
+  const effectiveTrustLevel = minLevel(input.trustLevel, ceiling);
+  const decisionMode = autonomyLevelToDecisionMode(effectiveTrustLevel);
+  return { effectiveTrustLevel, decisionMode, decision: decideVolunteering(decisionMode) };
 }
 
 /**

--- a/apps/web/lib/mcp/packs/demand-scoring-pack.ts
+++ b/apps/web/lib/mcp/packs/demand-scoring-pack.ts
@@ -12,6 +12,7 @@ import { DEMAND_SCORE_FRAMEWORKS, DEMAND_STAGE_VALUES, INVESTMENT_BUCKET_VALUES 
 import type { DemandScoreFramework } from "@/lib/explore/backlog";
 import type { DemandScoreInputs, DemandScoreResult } from "@/lib/demand/scoring";
 import { resolveEstimateProvenance } from "@/lib/demand/estimate-provenance";
+import { fundingRiskTier } from "@/lib/demand/funding-risk";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack } from "../tool-pack";
 
@@ -567,13 +568,6 @@ async function sweepDuplicateDemandHandler(params: Record<string, unknown>): Pro
   };
 }
 
-/** Investment risk tier from bucket + effort: transform bets and xlarge work rank higher. */
-function fundingRiskTier(investmentBucket: string | null, effortSize: string | null): "low" | "medium" | "high" {
-  if (investmentBucket === "transform" || effortSize === "xlarge") return "high";
-  if (effortSize === "large") return "medium";
-  return "low";
-}
-
 async function approveDemandForFundingHandler(
   params: Record<string, unknown>,
   userId: string,
@@ -625,6 +619,16 @@ async function approveDemandForFundingHandler(
     try {
       const { offerFundedItemToCoworker } = await import("@/lib/demand/volunteering.server");
       volunteered = await offerFundedItemToCoworker(item);
+    } catch {
+      // non-fatal
+    }
+    // Shadow-measure what an autonomous auto-claim WOULD do (kernel: shadow_first)
+    // — resolves the coworker's autonomy envelope and records it against the
+    // ask-first act, building graduation evidence without acting on it. Its own
+    // try so the measurement records even if the offer above failed.
+    try {
+      const { recordVolunteeringAutonomyShadow } = await import("@/lib/demand/volunteering.server");
+      await recordVolunteeringAutonomyShadow(item);
     } catch {
       // non-fatal
     }

--- a/apps/web/lib/work-management/autonomy-envelope.ts
+++ b/apps/web/lib/work-management/autonomy-envelope.ts
@@ -45,20 +45,34 @@ export interface WorkCaseAutonomyEnvelopeResolution {
   reason: string;
 }
 
+/**
+ * Map a coworker's (already risk-capped) autonomy level to the work-case
+ * decision mode. Exported so consumers that need only this projection — e.g. the
+ * AI-led volunteering resolver — reuse the canonical mapping instead of
+ * re-deriving it. `autonomous-action` is the sole mode that permits acting
+ * without a human turn.
+ */
+export function autonomyLevelToDecisionMode(level: AutonomyLevel): WorkCaseAutonomyDecisionMode {
+  switch (level) {
+    case "shadow":
+      return "shadow-only";
+    case "propose":
+      return "propose-for-approval";
+    case "supervised":
+      return "supervised-action";
+    case "autopilot":
+      return "autonomous-action";
+  }
+}
+
 function toWorkCaseAutonomy(level: AutonomyLevel): {
   autonomyMode: WorkCaseAutonomyMode;
   decisionMode: WorkCaseAutonomyDecisionMode;
 } {
-  switch (level) {
-    case "shadow":
-      return { autonomyMode: "observed", decisionMode: "shadow-only" };
-    case "propose":
-      return { autonomyMode: "supervised", decisionMode: "propose-for-approval" };
-    case "supervised":
-      return { autonomyMode: "supervised", decisionMode: "supervised-action" };
-    case "autopilot":
-      return { autonomyMode: "autonomous", decisionMode: "autonomous-action" };
-  }
+  const decisionMode = autonomyLevelToDecisionMode(level);
+  const autonomyMode: WorkCaseAutonomyMode =
+    level === "shadow" ? "observed" : level === "autopilot" ? "autonomous" : "supervised";
+  return { autonomyMode, decisionMode };
 }
 
 function requiresCoworkerEnvelope(

--- a/docs/superpowers/plans/2026-07-15-ai-led-volunteering-plan.md
+++ b/docs/superpowers/plans/2026-07-15-ai-led-volunteering-plan.md
@@ -49,3 +49,19 @@ These **do not trivially map** (`constrained`/`autonomous` vs `propose`/`supervi
 - ⚠ Idempotency: re-funding or re-running approve must not double-claim. Guard on existing `claimStatus`.
 - ⚠ Proactivity level semantics: confirm exact level names + which "ask first". 
 - Verify-on-live for the Ready/bet render is blocked on BI-53D7E70C (dev-portal /ops/demand turbopack defect) — same caveat as phase 2.
+
+## ✅ Source-of-truth RESOLVED + shadow-first increment shipped (2026-07-15, focused session)
+The "which enum is authoritative" blocker is resolved, and a kernel decision set the shape.
+
+**Source-of-truth found.** The coworker execution-trust dial is `TrustState.currentLevel` (schema `TrustState`, unique on `[agentId, activityType, riskClass]`, values = the trust-graduation `AutonomyLevel` shadow|propose|supervised|autopilot, with `regulatoryCeiling`). It is *operator-confirmed* via `recommendTrustChange` and is the enum `resolveWorkCaseAutonomyEnvelope` consumes — so the `GovernanceProfile.autonomyLevel` (supervised|constrained|autonomous) enum is NOT the envelope authority; `TrustState.currentLevel` is. **But** the schema draws a load-bearing line: *"these tables measure trust only; they do not authorize runtime autonomy changes,"* and `resolveWorkCaseAutonomyEnvelope` has **zero production callers** — auto-claim would be its first adopter.
+
+**Kernel decision (`principle_decide`, in_platform_coworker, composite 9.10, margin 1.33, HIGH conf, no commandment conflict): `shadow_first`.** Beat `wire_now` (4.35 — crosses the "measure only" boundary as first-adopter; lost on Least-Privilege 0.35, HITL 0.36, Architecture-Over-Shortcuts, Never-auto-execute) and `capture_gap` (7.78). So: build the resolution + **shadow-record what auto-claim WOULD do**, keep the act ask-first, gate real auto-claim behind accumulated evidence + an explicit operator enable flag.
+
+**Shipped this increment (additive, no behaviour change to what actually happens):**
+- Pure `apps/web/lib/demand/funding-risk.ts` — `fundingRiskTier` (lifted out of the demand-scoring pack, now shared) + `riskTierToRiskClass`/`fundedItemRiskClass` mapping the tier onto the governed `RiskClass` (high→`outbound-or-floor` floor; medium→`internal-irreversible`; low→`internal-reversible`). Tested.
+- Exported `autonomyLevelToDecisionMode` from `autonomy-envelope.ts` (refactor, no duplication) so the demand seam reuses the canonical level→decisionMode mapping.
+- Pure `resolveVolunteeringAutonomy({trustLevel, risk, regulatoryCeiling})` in `volunteering.ts` — mirrors the envelope's cap math (risk ceiling → regulatory ceiling → trust, min) without the WorkCase source/action coupling; returns `{effectiveTrustLevel, decisionMode, decision}`. Tested (autopilot+low→auto_claim; autopilot+floor→ask_first; shadow→observe; regulatory ceiling caps).
+- `recordVolunteeringAutonomyShadow(item)` in `volunteering.server.ts` — reads `TrustState` for `(agentId, "demand_bet_pickup", riskClass)`, resolves autonomy, writes a `DecisionShadowLedger` row (proposed = would-be decision, actual = ask-first, agreement flag). Non-authoritative, best-effort.
+- Wired into `approveDemandForFundingHandler`'s funded transition (its own non-fatal try, alongside the shipped `offerFundedItemToCoworker`).
+
+**Remaining for real auto-claim (a future, evidence-gated step):** a graduation step that, once `DecisionShadowLedger` evidence + an explicit operator enable flag exist, flips `decision==="auto_claim"` from shadow-recorded to actually claiming + dispatching the run. The measurement now runs on every funded bet; nothing acts autonomously yet.


### PR DESCRIPTION
## What

The **deferred auto-claim half** of AI-led volunteering, built in the shape the kernel chose. When a bet is funded, the platform now **shadow-measures what an autonomous auto-claim *would* do** for its coworker — while the actual act stays the shipped ask-first offer. This builds the graduation evidence a future, operator-gated step needs before real auto-claim is enabled.

## Why this shape (kernel decision)

The coworker execution-trust source-of-truth is `TrustState.currentLevel` (operator-confirmed, per `agent×activity×risk`) feeding the blessed-but-**unadopted** `resolveWorkCaseAutonomyEnvelope`. But the schema draws a line — *"these tables measure trust only; they do not authorize runtime autonomy changes"* — and the envelope has **zero production callers**, so auto-claim would be its first adopter.

`principle_decide` (in_platform_coworker) chose **`shadow_first`** — composite **9.10**, margin **1.33**, high confidence, no commandment conflict — over `wire_now` (4.35; lost on Least-Privilege 0.35, HITL 0.36, Architecture-Over-Shortcuts, Never-auto-execute) and `capture_gap` (7.78). Measure before authorizing; don't cross the "measure only" boundary as first-adopter.

## Changes (all additive — no change to what actually happens)
- **`funding-risk.ts`** (new, pure): `fundingRiskTier` (lifted out of the demand pack — now one shared source of truth) + `riskTierToRiskClass`/`fundedItemRiskClass`. A high-risk (transform/xlarge) bet maps to the kernel floor `outbound-or-floor`, so a trusted coworker still can't auto-claim it.
- **`autonomy-envelope.ts`**: export `autonomyLevelToDecisionMode` (refactor, no duplication) so the demand seam reuses the canonical mapping.
- **`volunteering.ts`**: pure `resolveVolunteeringAutonomy({trustLevel, risk, regulatoryCeiling})` — mirrors the envelope's cap math (risk → regulatory → trust, min) → `{effectiveTrustLevel, decisionMode, decision}`.
- **`volunteering.server.ts`**: `recordVolunteeringAutonomyShadow` — reads `TrustState`, resolves autonomy, writes a `DecisionShadowLedger` row (proposed = would-be decision vs actual = ask-first, agreement flag). Non-authoritative, best-effort.
- Wired into `approveDemandForFundingHandler`'s funded transition (its own non-fatal try, beside the shipped offer).

## Verification
- `tsc --noEmit` — exit 0, **0 errors** (8GB heap).
- **16** volunteering + funding-risk tests (incl. autopilot+low-risk→auto_claim, autopilot+floor→ask_first, shadow→observe, regulatory-ceiling cap) + **110** demand/registry tests green; module-size OK.
- No live-verify needed — server-side measurement, no UI surface.

## Remaining (future, evidence-gated)
A graduation step that, once `DecisionShadowLedger` evidence + an explicit operator enable flag exist, flips `decision==="auto_claim"` from shadow-recorded to actually claiming + dispatching the run. Nothing acts autonomously yet.

## Design grounding
Design-Grounding-Decision: extends `docs/superpowers/plans/2026-07-15-ai-led-volunteering-plan.md` (its source-of-truth blocker is now resolved) and adopts the existing autonomy-envelope / trust-graduation substrate; no new contract — additive shadow measurement over the existing funded-transition seam.

## Local-CI-Override
Local pregate `next build` OOMs on this machine (documented); verified-clean out-of-band as above. GitHub CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)