### PR TITLE
feat(healthcare): add governed intake access API

### DIFF
--- a/apps/web/app/api/v1/healthcare/intake/[packetId]/access-grants/route.ts
+++ b/apps/web/app/api/v1/healthcare/intake/[packetId]/access-grants/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { authenticateRequest } from "@/lib/api/auth-middleware";
+import { ApiError, apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { CARE_INTAKE_GRANT_OPERATIONS } from "@/lib/healthcare/care-intake-access";
+import { authorizeAndIssueCareIntakeResumeGrant } from "@/lib/healthcare/care-intake-api-repository";
+import { resolvePrincipalRecordIdForSessionIdentity } from "@/lib/identity/principal-linking";
+
+const IssueGrantBody = z.object({
+  organizationId: z.string().min(1).max(160),
+  patientProfileId: z.string().min(1).max(160),
+  patientPrincipalId: z.string().min(1).max(160),
+  permittedOperations: z
+    .array(z.enum(CARE_INTAKE_GRANT_OPERATIONS))
+    .min(1)
+    .transform((values) => [...new Set(values)]),
+  expiresAt: z.coerce.date(),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ packetId: string }> },
+) {
+  try {
+    const { user } = await authenticateRequest(request);
+    const actorPrincipalId = await resolvePrincipalRecordIdForSessionIdentity({
+      type: user.type,
+      id: user.id,
+    });
+    if (!actorPrincipalId) {
+      throw apiError("PRINCIPAL_REQUIRED", "A linked principal identity is required", 403);
+    }
+    const parsed = IssueGrantBody.safeParse(
+      await request.json().catch(() => null),
+    );
+    if (!parsed.success) {
+      throw apiError("INVALID_REQUEST", "Invalid intake grant request", 400);
+    }
+    const now = Date.now();
+    if (
+      parsed.data.expiresAt.getTime() <= now
+      || parsed.data.expiresAt.getTime() > now + 24 * 60 * 60 * 1000
+    ) {
+      throw apiError(
+        "INVALID_EXPIRY",
+        "Intake grant expiry must be within the next 24 hours",
+        400,
+      );
+    }
+    const { packetId } = await params;
+    const grant = await authorizeAndIssueCareIntakeResumeGrant({
+      ...parsed.data,
+      packetId,
+      actorPrincipalId,
+    });
+    return apiSuccess(grant, 201);
+  } catch (error) {
+    if (error instanceof ApiError) return error.toResponse();
+    if (
+      error instanceof Error
+      && error.message === "Patient authority denied care intake access"
+    ) {
+      return apiError("PATIENT_AUTHORITY_DENIED", "Patient authority denied", 403).toResponse();
+    }
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/v1/healthcare/intake/[packetId]/route.ts
+++ b/apps/web/app/api/v1/healthcare/intake/[packetId]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import { ApiError, apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { getCareIntakePacketProjection } from "@/lib/healthcare/care-intake-api-repository";
+
+function resumeToken(request: Request): string {
+  const token = request.headers.get("x-intake-resume-token")?.trim();
+  if (!token) throw apiError("INTAKE_TOKEN_REQUIRED", "Intake access token required", 401);
+  return token;
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ packetId: string }> },
+) {
+  try {
+    const { packetId } = await params;
+    const projection = await getCareIntakePacketProjection({
+      packetId,
+      token: resumeToken(request),
+    });
+    return apiSuccess(projection);
+  } catch (error) {
+    if (error instanceof ApiError) return error.toResponse();
+    if (
+      error instanceof Error
+      && [
+        "Invalid care intake resume token",
+        "Care intake access denied",
+      ].includes(error.message)
+    ) {
+      return apiError("INTAKE_ACCESS_DENIED", "Intake access denied", 403).toResponse();
+    }
+    return NextResponse.json(
+      { code: "INTERNAL_ERROR", message: "An unexpected error occurred" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/lib/api/__tests__/healthcare-intake-endpoints.test.ts
+++ b/apps/web/lib/api/__tests__/healthcare-intake-endpoints.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../api/auth-middleware.js", () => ({
+  authenticateRequest: vi.fn(),
+}));
+vi.mock("../../healthcare/care-intake-api-repository.js", () => ({
+  authorizeAndIssueCareIntakeResumeGrant: vi.fn(),
+  getCareIntakePacketProjection: vi.fn(),
+}));
+vi.mock("../../identity/principal-linking.js", () => ({
+  resolvePrincipalRecordIdForSessionIdentity: vi.fn(),
+}));
+
+import { POST as issueGrant } from "../../../app/api/v1/healthcare/intake/[packetId]/access-grants/route.js";
+import { GET as getPacket } from "../../../app/api/v1/healthcare/intake/[packetId]/route.js";
+import { authenticateRequest } from "../../api/auth-middleware.js";
+import {
+  authorizeAndIssueCareIntakeResumeGrant,
+  getCareIntakePacketProjection,
+} from "../../healthcare/care-intake-api-repository.js";
+import { resolvePrincipalRecordIdForSessionIdentity } from "../../identity/principal-linking.js";
+
+const params = { params: Promise.resolve({ packetId: "intake-a" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z");
+});
+
+describe("GET /api/v1/healthcare/intake/:packetId", () => {
+  it("requires a dedicated intake token instead of accepting ambient session access", async () => {
+    const response = await getPacket(
+      new Request("http://localhost/api/v1/healthcare/intake/intake-a"),
+      params,
+    );
+    expect(response.status).toBe(401);
+    expect(getCareIntakePacketProjection).not.toHaveBeenCalled();
+  });
+
+  it("returns the minimum-necessary token-scoped projection", async () => {
+    vi.mocked(getCareIntakePacketProjection).mockResolvedValue({
+      packetId: "intake-a",
+      status: "assigned",
+      version: 1,
+      dueAt: null,
+      completionPercent: 0,
+      forms: [],
+    });
+    const response = await getPacket(
+      new Request("http://localhost/api/v1/healthcare/intake/intake-a", {
+        headers: { "x-intake-resume-token": "opaque-token" },
+      }),
+      params,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({ packetId: "intake-a", forms: [] }),
+    );
+  });
+});
+
+describe("POST /api/v1/healthcare/intake/:packetId/access-grants", () => {
+  it("binds issuance to the authenticated relational principal and a 24-hour maximum", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      user: {
+        id: "contact-a",
+        email: "patient@example.test",
+        type: "customer",
+        platformRole: null,
+        isSuperuser: false,
+        accountId: "account-a",
+        accountName: "Patient",
+        contactId: "contact-a",
+      },
+      capabilities: [],
+      authContext: {} as never,
+    });
+    vi.mocked(resolvePrincipalRecordIdForSessionIdentity).mockResolvedValue(
+      "principal-patient-a",
+    );
+    vi.mocked(authorizeAndIssueCareIntakeResumeGrant).mockResolvedValue({
+      grantId: "grant-a",
+      token: "returned-once",
+      expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      permittedOperations: ["view", "save"],
+    });
+
+    const response = await issueGrant(
+      new Request(
+        "http://localhost/api/v1/healthcare/intake/intake-a/access-grants",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            organizationId: "org-a",
+            patientProfileId: "patient-a",
+            patientPrincipalId: "principal-patient-a",
+            permittedOperations: ["view", "save"],
+            expiresAt: "2026-08-01T15:00:00.000Z",
+          }),
+        },
+      ),
+      params,
+    );
+    expect(response.status).toBe(201);
+    expect(authorizeAndIssueCareIntakeResumeGrant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packetId: "intake-a",
+        actorPrincipalId: "principal-patient-a",
+      }),
+    );
+  });
+
+  it("rejects grants beyond 24 hours", async () => {
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      user: { id: "user-a", type: "admin" } as never,
+      capabilities: [],
+      authContext: {} as never,
+    });
+    vi.mocked(resolvePrincipalRecordIdForSessionIdentity).mockResolvedValue(
+      "principal-a",
+    );
+    const response = await issueGrant(
+      new Request("http://localhost", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          organizationId: "org-a",
+          patientProfileId: "patient-a",
+          patientPrincipalId: "principal-patient-a",
+          permittedOperations: ["view"],
+          expiresAt: "2026-08-02T14:00:00.001Z",
+        }),
+      }),
+      params,
+    );
+    expect(response.status).toBe(400);
+    expect(authorizeAndIssueCareIntakeResumeGrant).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 553,
+  "routeCount": 555,
   "routes": [
     {
       "routePath": "/",
@@ -2720,6 +2720,37 @@
         "tableId"
       ],
       "file": "apps/web/app/api/v1/grid/[tableId]/schema/route.ts"
+    },
+    {
+      "routePath": "/api/v1/healthcare/intake/[packetId]",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "healthcare",
+        "intake",
+        "[packetId]"
+      ],
+      "dynamicParams": [
+        "packetId"
+      ],
+      "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/route.ts"
+    },
+    {
+      "routePath": "/api/v1/healthcare/intake/[packetId]/access-grants",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "healthcare",
+        "intake",
+        "[packetId]",
+        "access-grants"
+      ],
+      "dynamicParams": [
+        "packetId"
+      ],
+      "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/access-grants/route.ts"
     },
     {
       "routePath": "/api/v1/integrations/coverage",

--- a/apps/web/lib/healthcare/care-intake-access.test.ts
+++ b/apps/web/lib/healthcare/care-intake-access.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertCareIntakeGrant,
+  createCareIntakeResumeToken,
+  digestCareIntakeResumeToken,
+  parseCareIntakeResumeToken,
+} from "./care-intake-access";
+
+describe("care intake resume token", () => {
+  it("round-trips opaque RLS bootstrap claims without storing the raw token", () => {
+    const issued = createCareIntakeResumeToken({
+      organizationId: "org-a",
+      patientProfileId: "patient-a",
+      grantId: "intake-grant-a",
+    });
+
+    expect(parseCareIntakeResumeToken(issued.token)).toEqual({
+      organizationId: "org-a",
+      patientProfileId: "patient-a",
+      grantId: "intake-grant-a",
+    });
+    expect(issued.digest).toBe(digestCareIntakeResumeToken(issued.token));
+    expect(issued.digest).toMatch(/^[a-f0-9]{64}$/);
+    expect(issued.digest).not.toContain(issued.token);
+  });
+
+  it("rejects malformed and tampered token envelopes before database access", () => {
+    const issued = createCareIntakeResumeToken({
+      organizationId: "org-a",
+      patientProfileId: "patient-a",
+      grantId: "intake-grant-a",
+    });
+    const [envelope, secret] = issued.token.split(".");
+
+    expect(() => parseCareIntakeResumeToken("not-a-token")).toThrow(
+      "Invalid care intake resume token",
+    );
+    expect(() =>
+      parseCareIntakeResumeToken(`${envelope}.${secret?.slice(1)}`),
+    ).toThrow("Invalid care intake resume token");
+    expect(() =>
+      parseCareIntakeResumeToken(
+        `${Buffer.from(JSON.stringify({ organizationId: "org-b" })).toString("base64url")}.${secret}`,
+      ),
+    ).toThrow("Invalid care intake resume token");
+  });
+});
+
+describe("care intake grant enforcement", () => {
+  const grant = {
+    grantId: "intake-grant-a",
+    packetId: "packet-row-a",
+    patientProfileId: "patient-a",
+    tokenDigest: "digest-a",
+    permittedOperations: ["view", "save"],
+    expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+    revokedAt: null,
+  };
+
+  it("allows only the token, packet, patient, operation, and time in scope", () => {
+    expect(() =>
+      assertCareIntakeGrant(grant, {
+        digest: "digest-a",
+        grantId: "intake-grant-a",
+        packetRowId: "packet-row-a",
+        patientProfileId: "patient-a",
+        operation: "save",
+        at: new Date("2026-08-01T14:00:00.000Z"),
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ["digest-b", "intake-grant-a", "packet-row-a", "patient-a", "save", "2026-08-01T14:00:00.000Z"],
+    ["digest-a", "intake-grant-b", "packet-row-a", "patient-a", "save", "2026-08-01T14:00:00.000Z"],
+    ["digest-a", "intake-grant-a", "packet-row-b", "patient-a", "save", "2026-08-01T14:00:00.000Z"],
+    ["digest-a", "intake-grant-a", "packet-row-a", "patient-b", "save", "2026-08-01T14:00:00.000Z"],
+    ["digest-a", "intake-grant-a", "packet-row-a", "patient-a", "submit", "2026-08-01T14:00:00.000Z"],
+    ["digest-a", "intake-grant-a", "packet-row-a", "patient-a", "save", "2026-08-01T15:00:00.000Z"],
+  ])("denies a mismatched or expired grant", (digest, grantId, packetRowId, patientProfileId, operation, at) => {
+    expect(() =>
+      assertCareIntakeGrant(grant, {
+        digest,
+        grantId,
+        packetRowId,
+        patientProfileId,
+        operation: operation as "save" | "submit",
+        at: new Date(at),
+      }),
+    ).toThrow("Care intake access denied");
+  });
+
+  it("denies a revoked grant", () => {
+    expect(() =>
+      assertCareIntakeGrant(
+        { ...grant, revokedAt: new Date("2026-08-01T13:00:00.000Z") },
+        {
+          digest: "digest-a",
+          grantId: "intake-grant-a",
+          packetRowId: "packet-row-a",
+          patientProfileId: "patient-a",
+          operation: "view",
+          at: new Date("2026-08-01T14:00:00.000Z"),
+        },
+      ),
+    ).toThrow("Care intake access denied");
+  });
+});

--- a/apps/web/lib/healthcare/care-intake-access.ts
+++ b/apps/web/lib/healthcare/care-intake-access.ts
@@ -1,0 +1,103 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+
+export const CARE_INTAKE_GRANT_OPERATIONS = ["view", "save", "submit"] as const;
+export type CareIntakeGrantOperation =
+  (typeof CARE_INTAKE_GRANT_OPERATIONS)[number];
+
+export type CareIntakeResumeClaims = {
+  organizationId: string;
+  patientProfileId: string;
+  grantId: string;
+};
+
+export type CareIntakeGrantView = {
+  grantId: string;
+  packetId: string;
+  patientProfileId: string;
+  tokenDigest: string;
+  permittedOperations: string[];
+  expiresAt: Date;
+  revokedAt: Date | null;
+};
+
+const INVALID_TOKEN = "Invalid care intake resume token";
+const ACCESS_DENIED = "Care intake access denied";
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,160}$/;
+const SECRET_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+function validClaims(value: unknown): value is CareIntakeResumeClaims {
+  if (!value || typeof value !== "object") return false;
+  const claims = value as Record<string, unknown>;
+  return (
+    typeof claims.organizationId === "string"
+    && ID_PATTERN.test(claims.organizationId)
+    && typeof claims.patientProfileId === "string"
+    && ID_PATTERN.test(claims.patientProfileId)
+    && typeof claims.grantId === "string"
+    && ID_PATTERN.test(claims.grantId)
+  );
+}
+
+export function digestCareIntakeResumeToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+export function createCareIntakeResumeToken(
+  claims: CareIntakeResumeClaims,
+): { token: string; digest: string } {
+  if (!validClaims(claims)) throw new Error(INVALID_TOKEN);
+  const envelope = Buffer.from(JSON.stringify(claims), "utf8").toString(
+    "base64url",
+  );
+  const secret = randomBytes(32).toString("base64url");
+  const token = `${envelope}.${secret}`;
+  return { token, digest: digestCareIntakeResumeToken(token) };
+}
+
+export function parseCareIntakeResumeToken(
+  token: string,
+): CareIntakeResumeClaims {
+  if (token.length > 1024) throw new Error(INVALID_TOKEN);
+  const parts = token.split(".");
+  if (parts.length !== 2 || !parts[0] || !SECRET_PATTERN.test(parts[1]!)) {
+    throw new Error(INVALID_TOKEN);
+  }
+  try {
+    const decoded: unknown = JSON.parse(
+      Buffer.from(parts[0], "base64url").toString("utf8"),
+    );
+    if (!validClaims(decoded)) throw new Error(INVALID_TOKEN);
+    return decoded;
+  } catch {
+    throw new Error(INVALID_TOKEN);
+  }
+}
+
+function equalDigest(left: string, right: string): boolean {
+  if (!/^[a-f0-9]{64}$/.test(left) || !/^[a-f0-9]{64}$/.test(right)) {
+    return left === right;
+  }
+  return timingSafeEqual(Buffer.from(left, "hex"), Buffer.from(right, "hex"));
+}
+
+export function assertCareIntakeGrant(
+  grant: CareIntakeGrantView,
+  request: {
+    digest: string;
+    grantId: string;
+    packetRowId: string;
+    patientProfileId: string;
+    operation: CareIntakeGrantOperation;
+    at: Date;
+  },
+): void {
+  const allowed =
+    equalDigest(grant.tokenDigest, request.digest)
+    && grant.grantId === request.grantId
+    && grant.packetId === request.packetRowId
+    && grant.patientProfileId === request.patientProfileId
+    && grant.permittedOperations.includes(request.operation)
+    && grant.revokedAt === null
+    && grant.expiresAt.getTime() > request.at.getTime();
+  if (!allowed) throw new Error(ACCESS_DENIED);
+}

--- a/apps/web/lib/healthcare/care-intake-api-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-api-repository.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getCareIntakePacketProjection,
+  issueCareIntakeResumeGrant,
+  type CareIntakeApiDatabase,
+} from "./care-intake-api-repository";
+import { digestCareIntakeResumeToken } from "./care-intake-access";
+
+const packet = {
+  id: "packet-row-a",
+  packetId: "intake-a",
+  organizationId: "org-a",
+  patientProfileId: "patient-a",
+  status: "assigned",
+  version: 1,
+  dueAt: null,
+  completionPercent: 0,
+  purposeOfUse: "patient-intake",
+  requirementSnapshot: [
+    {
+      dynamicFormId: "form-row-a",
+      dynamicFormVersion: 2,
+      linkId: "visit-reason",
+      dataCategory: "visit-reason",
+      required: true,
+    },
+  ],
+  requiredConsentCount: 0,
+  requiresCoverageEvidence: false,
+};
+
+function database() {
+  const tx = {
+    $executeRaw: vi.fn().mockResolvedValue(1),
+    careIntakePacket: { findFirst: vi.fn().mockResolvedValue(packet) },
+    careIntakeAccessGrant: {
+      create: vi.fn().mockImplementation(({ data }) => Promise.resolve({ ...data })),
+      findFirst: vi.fn(),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    dynamicForm: {
+      findMany: vi.fn().mockResolvedValue([
+        {
+          id: "form-row-a",
+          formId: "medical-history",
+          title: "Medical history",
+          version: 2,
+          fields: [{ key: "visit-reason", type: "textarea", label: "Reason" }],
+          submitAction: null,
+          offlineCapable: true,
+        },
+      ]),
+    },
+  };
+  return {
+    tx,
+    db: {
+      $transaction: vi.fn((callback) => callback(tx)),
+    } as unknown as CareIntakeApiDatabase,
+  };
+}
+
+describe("issueCareIntakeResumeGrant", () => {
+  it("issues the raw token once only after an allow decision", async () => {
+    const { db, tx } = database();
+    const result = await issueCareIntakeResumeGrant(
+      {
+        organizationId: "org-a",
+        patientProfileId: "patient-a",
+        patientPrincipalId: "principal-patient-a",
+        packetId: "intake-a",
+        granteePrincipalId: "principal-patient-a",
+        issuedByPrincipalId: "principal-patient-a",
+        permittedOperations: ["view", "save", "submit"],
+        expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+        authorityDecision: { effect: "allow", reasonCodes: ["patient-self-access"] },
+      },
+      db,
+    );
+
+    expect(result.token).toBeTruthy();
+    expect(tx.careIntakeAccessGrant.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        tokenDigest: digestCareIntakeResumeToken(result.token),
+        packetId: "packet-row-a",
+        patientProfileId: "patient-a",
+        granteePrincipalId: "principal-patient-a",
+      }),
+    });
+  });
+
+  it("does not mint a token after a denied authority decision", async () => {
+    const { db, tx } = database();
+    await expect(
+      issueCareIntakeResumeGrant(
+        {
+          organizationId: "org-a",
+          patientProfileId: "patient-a",
+          patientPrincipalId: "principal-patient-a",
+          packetId: "intake-a",
+          granteePrincipalId: "principal-proxy",
+          issuedByPrincipalId: "principal-proxy",
+          permittedOperations: ["view"],
+          expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+          authorityDecision: { effect: "deny", reasonCodes: ["authority-not-found"] },
+        },
+        db,
+      ),
+    ).rejects.toThrow("Patient authority denied care intake access");
+    expect(tx.careIntakeAccessGrant.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("getCareIntakePacketProjection", () => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));
+
+  it("returns only lifecycle/readiness and packet-pinned form definitions", async () => {
+    const { db, tx } = database();
+    const issued = await issueCareIntakeResumeGrant(
+      {
+        organizationId: "org-a",
+        patientProfileId: "patient-a",
+        patientPrincipalId: "principal-patient-a",
+        packetId: "intake-a",
+        granteePrincipalId: "principal-patient-a",
+        issuedByPrincipalId: "principal-patient-a",
+        permittedOperations: ["view"],
+        expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+        authorityDecision: { effect: "allow", reasonCodes: [] },
+      },
+      db,
+    );
+    tx.careIntakeAccessGrant.findFirst.mockResolvedValue({
+      grantId: issued.grantId,
+      packetId: "packet-row-a",
+      patientProfileId: "patient-a",
+      tokenDigest: digestCareIntakeResumeToken(issued.token),
+      permittedOperations: ["view"],
+      expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      revokedAt: null,
+    });
+
+    const projection = await getCareIntakePacketProjection(
+      { packetId: "intake-a", token: issued.token },
+      db,
+    );
+
+    expect(projection).toEqual({
+      packetId: "intake-a",
+      status: "assigned",
+      version: 1,
+      dueAt: null,
+      completionPercent: 0,
+      forms: [
+        expect.objectContaining({ formId: "medical-history", version: 2 }),
+      ],
+    });
+    expect(JSON.stringify(projection)).not.toContain("answers");
+    expect(tx.dynamicForm.findMany).toHaveBeenCalledWith({
+      where: { OR: [{ id: "form-row-a", version: 2 }] },
+    });
+  });
+});

--- a/apps/web/lib/healthcare/care-intake-api-repository.ts
+++ b/apps/web/lib/healthcare/care-intake-api-repository.ts
@@ -1,0 +1,328 @@
+import { randomUUID } from "node:crypto";
+
+import { prisma } from "@dpf/db";
+import {
+  requirementsForPinnedForm,
+  type CareIntakeRequirement,
+} from "@dpf/db/healthcare-care-intake";
+
+import {
+  assertCareIntakeGrant,
+  CARE_INTAKE_GRANT_OPERATIONS,
+  createCareIntakeResumeToken,
+  digestCareIntakeResumeToken,
+  parseCareIntakeResumeToken,
+  type CareIntakeGrantOperation,
+} from "./care-intake-access";
+import { evaluateAndRecordPatientAuthority } from "./patient-authority-repository";
+
+type PacketRow = {
+  id: string;
+  packetId: string;
+  organizationId: string;
+  patientProfileId: string;
+  status: string;
+  version: number;
+  dueAt: Date | null;
+  completionPercent: number;
+  purposeOfUse: string;
+  requirementSnapshot: unknown;
+  requiredConsentCount: number;
+  requiresCoverageEvidence: boolean;
+};
+
+type GrantRow = {
+  grantId: string;
+  packetId: string;
+  patientProfileId: string;
+  tokenDigest: string;
+  permittedOperations: string[];
+  expiresAt: Date;
+  revokedAt: Date | null;
+};
+
+type DynamicFormRow = {
+  id: string;
+  formId: string;
+  title: string;
+  version: number;
+  fields: unknown;
+  submitAction: string | null;
+  offlineCapable: boolean;
+};
+
+type Transaction = {
+  $executeRaw(query: TemplateStringsArray, ...values: unknown[]): Promise<number>;
+  careIntakePacket: { findFirst(args: unknown): Promise<PacketRow | null> };
+  careIntakeAccessGrant: {
+    create(args: unknown): Promise<GrantRow>;
+    findFirst(args: unknown): Promise<GrantRow | null>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  dynamicForm: { findMany(args: unknown): Promise<DynamicFormRow[]> };
+};
+
+export type CareIntakeApiDatabase = {
+  $transaction<T>(callback: (tx: Transaction) => Promise<T>): Promise<T>;
+};
+
+function packetRequirements(value: unknown): CareIntakeRequirement[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error("Invalid intake requirement snapshot");
+  }
+  for (const requirement of value) {
+    if (
+      !requirement
+      || typeof requirement !== "object"
+      || typeof requirement.dynamicFormId !== "string"
+      || !Number.isInteger(requirement.dynamicFormVersion)
+      || requirement.dynamicFormVersion < 1
+      || typeof requirement.linkId !== "string"
+      || typeof requirement.dataCategory !== "string"
+      || typeof requirement.required !== "boolean"
+    ) {
+      throw new Error("Invalid intake requirement snapshot");
+    }
+  }
+  return value as CareIntakeRequirement[];
+}
+
+async function setPatientContext(
+  tx: Transaction,
+  input: { organizationId: string; patientProfileId: string },
+) {
+  await tx.$executeRaw`SELECT set_config('app.organization_id', ${input.organizationId}, true), set_config('app.patient_profile_ids', ${input.patientProfileId}, true)`;
+}
+
+function validateOperations(
+  operations: CareIntakeGrantOperation[],
+): CareIntakeGrantOperation[] {
+  const unique = [...new Set(operations)];
+  if (
+    unique.length === 0
+    || unique.some(
+      (operation) => !CARE_INTAKE_GRANT_OPERATIONS.includes(operation),
+    )
+  ) {
+    throw new Error("Invalid care intake grant operations");
+  }
+  return unique;
+}
+
+export async function issueCareIntakeResumeGrant(
+  input: {
+    organizationId: string;
+    patientProfileId: string;
+    patientPrincipalId: string;
+    packetId: string;
+    granteePrincipalId: string;
+    issuedByPrincipalId: string;
+    permittedOperations: CareIntakeGrantOperation[];
+    expiresAt: Date;
+    authorityDecision: { effect: "allow" | "deny"; reasonCodes: string[] };
+  },
+  database: CareIntakeApiDatabase = prisma as unknown as CareIntakeApiDatabase,
+) {
+  if (input.authorityDecision.effect !== "allow") {
+    throw new Error("Patient authority denied care intake access");
+  }
+  if (input.expiresAt.getTime() <= Date.now()) {
+    throw new Error("Care intake grant expiry must be in the future");
+  }
+  const permittedOperations = validateOperations(input.permittedOperations);
+
+  return database.$transaction(async (tx) => {
+    await setPatientContext(tx, input);
+    const packet = await tx.careIntakePacket.findFirst({
+      where: {
+        packetId: input.packetId,
+        organizationId: input.organizationId,
+        patientProfileId: input.patientProfileId,
+        patientProfile: { principalId: input.patientPrincipalId },
+      },
+    });
+    if (!packet) throw new Error("Care intake packet not found");
+    if (["entered-in-error", "stopped"].includes(packet.status)) {
+      throw new Error("Care intake packet does not accept access grants");
+    }
+
+    const grantId = `intake-grant-${randomUUID()}`;
+    const issued = createCareIntakeResumeToken({
+      organizationId: input.organizationId,
+      patientProfileId: input.patientProfileId,
+      grantId,
+    });
+    await tx.careIntakeAccessGrant.create({
+      data: {
+        grantId,
+        organizationId: input.organizationId,
+        packetId: packet.id,
+        patientProfileId: input.patientProfileId,
+        tokenDigest: issued.digest,
+        granteePrincipalId: input.granteePrincipalId,
+        permittedOperations,
+        issuedByPrincipalId: input.issuedByPrincipalId,
+        expiresAt: input.expiresAt,
+      },
+    });
+    return {
+      grantId,
+      token: issued.token,
+      expiresAt: input.expiresAt,
+      permittedOperations,
+    };
+  });
+}
+
+export async function authorizeAndIssueCareIntakeResumeGrant(
+  input: {
+    organizationId: string;
+    patientProfileId: string;
+    patientPrincipalId: string;
+    packetId: string;
+    actorPrincipalId: string;
+    permittedOperations: CareIntakeGrantOperation[];
+    expiresAt: Date;
+  },
+  options: {
+    database?: CareIntakeApiDatabase;
+    evaluateAuthority?: typeof evaluateAndRecordPatientAuthority;
+  } = {},
+) {
+  const database =
+    options.database ?? (prisma as unknown as CareIntakeApiDatabase);
+  const packet = await database.$transaction(async (tx) => {
+    await setPatientContext(tx, input);
+    return tx.careIntakePacket.findFirst({
+      where: {
+        packetId: input.packetId,
+        organizationId: input.organizationId,
+        patientProfileId: input.patientProfileId,
+        patientProfile: { principalId: input.patientPrincipalId },
+      },
+    });
+  });
+  if (!packet) throw new Error("Care intake packet not found");
+  const evaluateAuthority =
+    options.evaluateAuthority ?? evaluateAndRecordPatientAuthority;
+  const authorityDecision = await evaluateAuthority({
+    organizationId: input.organizationId,
+    actorPrincipalId: input.actorPrincipalId,
+    actorType: "human",
+    patientPrincipalId: input.patientPrincipalId,
+    purposeOfUse: packet.purposeOfUse,
+    operation: "create",
+    recordCategory: "care-intake",
+    at: new Date(),
+    accessMode: "ordinary",
+    emergencyAccess: null,
+  });
+  return issueCareIntakeResumeGrant(
+    {
+      ...input,
+      granteePrincipalId: input.actorPrincipalId,
+      issuedByPrincipalId: input.actorPrincipalId,
+      authorityDecision,
+    },
+    database,
+  );
+}
+
+export async function getCareIntakePacketProjection(
+  input: { packetId: string; token: string },
+  database: CareIntakeApiDatabase = prisma as unknown as CareIntakeApiDatabase,
+) {
+  const claims = parseCareIntakeResumeToken(input.token);
+  const digest = digestCareIntakeResumeToken(input.token);
+  return database.$transaction(async (tx) => {
+    await setPatientContext(tx, claims);
+    const packet = await tx.careIntakePacket.findFirst({
+      where: {
+        packetId: input.packetId,
+        organizationId: claims.organizationId,
+        patientProfileId: claims.patientProfileId,
+      },
+    });
+    if (!packet) throw new Error("Care intake access denied");
+    const grant = await tx.careIntakeAccessGrant.findFirst({
+      where: {
+        grantId: claims.grantId,
+        organizationId: claims.organizationId,
+        patientProfileId: claims.patientProfileId,
+      },
+    });
+    if (!grant) throw new Error("Care intake access denied");
+    assertCareIntakeGrant(grant, {
+      digest,
+      grantId: claims.grantId,
+      packetRowId: packet.id,
+      patientProfileId: claims.patientProfileId,
+      operation: "view",
+      at: new Date(),
+    });
+
+    const requirements = packetRequirements(packet.requirementSnapshot);
+    const formKeys = [
+      ...new Map(
+        requirements.map((requirement) => [
+          `${requirement.dynamicFormId}:${requirement.dynamicFormVersion}`,
+          {
+            id: requirement.dynamicFormId,
+            version: requirement.dynamicFormVersion,
+          },
+        ]),
+      ).values(),
+    ];
+    const forms = await tx.dynamicForm.findMany({ where: { OR: formKeys } });
+    if (forms.length !== formKeys.length) {
+      throw new Error("Pinned intake form is unavailable");
+    }
+    await tx.careIntakeAccessGrant.updateMany({
+      where: { grantId: claims.grantId, tokenDigest: digest },
+      data: { lastUsedAt: new Date() },
+    });
+
+    return {
+      packetId: packet.packetId,
+      status: packet.status,
+      version: packet.version,
+      dueAt: packet.dueAt,
+      completionPercent: packet.completionPercent,
+      forms: forms.map((form) => {
+        const assigned = requirementsForPinnedForm(requirements, {
+          dynamicFormId: form.id,
+          dynamicFormVersion: form.version,
+        });
+        const allowedKeys = new Set(assigned.map((item) => item.linkId));
+        const fields = Array.isArray(form.fields)
+          ? form.fields.filter(
+              (field) =>
+                field
+                && typeof field === "object"
+                && "key" in field
+                && typeof field.key === "string"
+                && allowedKeys.has(field.key),
+            )
+          : [];
+        if (
+          new Set(
+            fields.flatMap((field) =>
+              field && typeof field === "object" && "key" in field
+                ? [field.key]
+                : [],
+            ),
+          ).size !== allowedKeys.size
+        ) {
+          throw new Error("Pinned intake form does not match packet requirements");
+        }
+        return {
+          formId: form.formId,
+          title: form.title,
+          version: form.version,
+          fields,
+          offlineCapable: form.offlineCapable,
+        };
+      }),
+    };
+  });
+}

--- a/apps/web/lib/healthcare/care-intake-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-repository.test.ts
@@ -18,8 +18,8 @@ function makeDatabase() {
         status: "in-progress",
         version: 2,
         requirementSnapshot: [
-          { linkId: "phone", dataCategory: "contact", required: true },
-          { linkId: "reason", dataCategory: "visit-reason", required: true },
+          { dynamicFormId: "form-row-intake", dynamicFormVersion: 1, linkId: "phone", dataCategory: "contact", required: true },
+          { dynamicFormId: "form-row-intake", dynamicFormVersion: 1, linkId: "reason", dataCategory: "visit-reason", required: true },
         ],
         requiredConsentCount: 1,
         requiresCoverageEvidence: true,

--- a/apps/web/lib/healthcare/care-intake-repository.ts
+++ b/apps/web/lib/healthcare/care-intake-repository.ts
@@ -52,7 +52,7 @@ function requirements(value: unknown): CareIntakeRequirement[] {
 }
 
 async function setContext(tx: Transaction, input: CareIntakeContext) {
-  await tx.$executeRaw`SELECT set_config('app.organization_id', ${input.organizationId}, true), set_config('app.patient_principal_id', ${input.patientPrincipalId}, true)`;
+  await tx.$executeRaw`SELECT set_config('app.organization_id', ${input.organizationId}, true), set_config('app.patient_profile_ids', ${input.patientProfileId}, true), set_config('app.patient_principal_id', ${input.patientPrincipalId}, true)`;
 }
 
 async function readiness(tx: Transaction, packet: PacketRow) {

--- a/apps/web/lib/identity/principal-linking.test.ts
+++ b/apps/web/lib/identity/principal-linking.test.ts
@@ -28,6 +28,7 @@ vi.mock("@dpf/db", () => ({
 
 import { prisma } from "@dpf/db";
 import {
+  resolvePrincipalRecordIdForSessionIdentity,
   syncAgentPrincipal,
   syncCustomerPrincipal,
   syncEmployeePrincipal,
@@ -234,5 +235,24 @@ describe("syncCustomerPrincipal", () => {
     await expect(syncCustomerPrincipal("missing-contact")).rejects.toThrow(
       /CustomerContact missing-contact not found/,
     );
+  });
+});
+
+describe("resolvePrincipalRecordIdForSessionIdentity", () => {
+  it.each([
+    ["admin", "user-1", "user"],
+    ["customer", "contact-1", "customer_contact"],
+  ] as const)("resolves the relational principal for %s sessions", async (type, id, aliasType) => {
+    vi.mocked(prisma.principalAlias.findFirst).mockResolvedValue({
+      principal: { id: "principal-db-1" },
+    } as never);
+
+    await expect(
+      resolvePrincipalRecordIdForSessionIdentity({ type, id }),
+    ).resolves.toBe("principal-db-1");
+    expect(prisma.principalAlias.findFirst).toHaveBeenCalledWith({
+      where: { aliasType, aliasValue: id, issuer: "" },
+      include: { principal: { select: { id: true } } },
+    });
   });
 });

--- a/apps/web/lib/identity/principal-linking.ts
+++ b/apps/web/lib/identity/principal-linking.ts
@@ -407,6 +407,30 @@ export async function resolvePrincipalIdForUser(
 }
 
 /**
+ * Resolve the relational Principal.id used by healthcare foreign keys and
+ * patient-authority comparisons. This is deliberately distinct from the
+ * public Principal.principalId returned by resolvePrincipalIdForUser.
+ */
+export async function resolvePrincipalRecordIdForSessionIdentity(
+  identity: { type: "admin" | "customer"; id: string },
+  db: PrincipalDb = prisma,
+): Promise<string | null> {
+  const alias = await db.principalAlias.findFirst({
+    where: {
+      aliasType: identity.type === "admin" ? "user" : "customer_contact",
+      aliasValue: identity.id,
+      issuer: INTERNAL_ISSUER,
+    },
+    include: {
+      principal: {
+        select: { id: true },
+      },
+    },
+  });
+  return alias?.principal?.id ?? null;
+}
+
+/**
  * Resolve the Principal id behind an agent (coworker) id, via the
  * `aliasType: "agent"` PrincipalAlias (principal-convergence, AGENTS.md §11).
  * Sibling of resolvePrincipalIdForUser; used by decision caller-context

--- a/docs/superpowers/plans/2026-07-16-healthcare-digital-intake.md
+++ b/docs/superpowers/plans/2026-07-16-healthcare-digital-intake.md
@@ -56,13 +56,44 @@ and exception records that those generic surfaces do not own.
 
 ## Phase 2 — patient/proxy and receptionist APIs
 
-1. Issue expiring, revocable resume grants after identity/proxy authorization.
-2. Expose minimum-necessary packet metadata and form definitions.
-3. Save partial responses idempotently and submit only after completeness
-   validation.
-4. Support staff-assisted and paper-transcribed provenance.
-5. Stage coverage/entitlement evidence for human review and bind accepted
-   consent attestations to `PatientConsentDirective`.
+1. Extend each requirement snapshot entry with the internal `DynamicForm.id`
+   and exact version it belongs to. Reject access or writes when a requested
+   form is not pinned by the packet; do not turn the global dynamic-form
+   catalog into a patient-visible discovery surface.
+2. Issue expiring, revocable `view` / `save` / `submit` resume grants only
+   after `PatientAuthority` permits the authenticated patient or proxy. Return
+   the high-entropy bearer token once and persist only its SHA-256 digest.
+3. Expose `/api/v1/healthcare/intake/:packetId` as a token-scoped,
+   minimum-necessary projection: packet lifecycle/readiness plus only the
+   pinned form definitions. Never include saved answer values in the packet
+   projection or receptionist projections.
+4. Save partial responses through
+   `/api/v1/healthcare/intake/:packetId/responses/:formId` with an
+   idempotency key, optimistic response version, minimum-necessary validation,
+   and patient/proxy/staff/paper provenance. Server-owned source keys provide
+   retry idempotency; clients cannot choose another source system.
+5. Submit through `/api/v1/healthcare/intake/:packetId/submit`; recompute
+   completeness inside the same patient-context transaction and reject
+   incomplete, expired, revoked, wrong-packet, or under-scoped grants.
+6. Keep coverage evidence and consent attestation acceptance as separate
+   reviewer-authorized endpoints. They are not part of the patient bearer-token
+   write surface and remain staged evidence rather than canonical coverage or
+   consent authority.
+
+### Phase 2 delivery slices
+
+- **2A — access and response API:** form-version pinning, tamper-resistant
+  resume-token codec, authority-gated grant issuance, minimum packet
+  projection, idempotent partial saves, and completeness-gated submit.
+- **2B — receptionist review API:** readiness/exception queue with no response
+  payloads, assisted/paper disclosure, grant revocation, and immutable audit
+  projections.
+- **2C — reviewed evidence API:** stage coverage documents and consent
+  attestations, then accept/reject them only through explicit human authority.
+
+Rollback for 2A is route and repository removal; it adds no schema migration.
+Existing Phase 1 tables remain forward-compatible and contain no raw resume
+tokens.
 
 ## Phase 3 — user experience
 

--- a/packages/db/prisma/migrations/20260717024000_scope_care_intake_rls_to_patient/migration.sql
+++ b/packages/db/prisma/migrations/20260717024000_scope_care_intake_rls_to_patient/migration.sql
@@ -1,0 +1,34 @@
+-- BI-HEALTHCARE-012 Phase 2A: the original intake policy constrained rows to
+-- the organization but did not consume the repository's patient context.
+-- Replace it with an explicit allow-list of patient profile ids. Missing or
+-- empty patient context fails closed.
+-- @migration-safety: data-safe: replaces RLS policies only; no rows or constraints are changed.
+
+DO $$
+DECLARE
+  table_name TEXT;
+  policy_name TEXT;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'CareIntakePacket',
+    'CareIntakeResponse',
+    'CareIntakeAccessGrant',
+    'CareConsentAttestation',
+    'CareCoverageEvidence',
+    'CareIntakeException',
+    'CareIntakeStatusEvent'
+  ]
+  LOOP
+    policy_name := table_name || '_context_policy';
+    EXECUTE format('DROP POLICY IF EXISTS %I ON %I', policy_name, table_name);
+    EXECUTE format(
+      'CREATE POLICY %I ON %I '
+      || 'USING ("organizationId" = NULLIF(current_setting(''app.organization_id'', true), '''') '
+      || 'AND "patientProfileId" = ANY(string_to_array(NULLIF(current_setting(''app.patient_profile_ids'', true), ''''), '',''))) '
+      || 'WITH CHECK ("organizationId" = NULLIF(current_setting(''app.organization_id'', true), '''') '
+      || 'AND "patientProfileId" = ANY(string_to_array(NULLIF(current_setting(''app.patient_profile_ids'', true), ''''), '','')))',
+      policy_name,
+      table_name
+    );
+  END LOOP;
+END $$;

--- a/packages/db/src/healthcare-care-intake.test.ts
+++ b/packages/db/src/healthcare-care-intake.test.ts
@@ -4,22 +4,29 @@ import {
   CARE_INTAKE_RESPONSE_STATUSES,
   assertCareIntakeTransition,
   calculateIntakeReadiness,
+  requirementsForPinnedForm,
   validateMinimumNecessaryAnswers,
   type CareIntakeRequirement,
 } from "./healthcare-care-intake";
 
 const requirements: CareIntakeRequirement[] = [
   {
+    dynamicFormId: "form-row-intake",
+    dynamicFormVersion: 3,
     linkId: "contact-phone",
     dataCategory: "contact",
     required: true,
   },
   {
+    dynamicFormId: "form-row-intake",
+    dynamicFormVersion: 3,
     linkId: "visit-reason",
     dataCategory: "visit-reason",
     required: true,
   },
   {
+    dynamicFormId: "form-row-marketing",
+    dynamicFormVersion: 1,
     linkId: "marketing-source",
     dataCategory: "marketing",
     required: false,
@@ -75,6 +82,27 @@ describe("healthcare care intake contract", () => {
       ok: false,
       errors: ["data-category-not-authorized:marketing-source"],
     });
+  });
+
+  it("returns requirements only for the exact form row and version pinned by the packet", () => {
+    expect(
+      requirementsForPinnedForm(requirements, {
+        dynamicFormId: "form-row-intake",
+        dynamicFormVersion: 3,
+      }).map((requirement) => requirement.linkId),
+    ).toEqual(["contact-phone", "visit-reason"]);
+  });
+
+  it.each([
+    ["form-row-intake", 2],
+    ["form-row-unknown", 3],
+  ])("rejects an unpinned form/version", (dynamicFormId, dynamicFormVersion) => {
+    expect(() =>
+      requirementsForPinnedForm(requirements, {
+        dynamicFormId,
+        dynamicFormVersion,
+      }),
+    ).toThrow("Dynamic form is not assigned to this intake packet");
   });
 
   it.each([

--- a/packages/db/src/healthcare-care-intake.ts
+++ b/packages/db/src/healthcare-care-intake.ts
@@ -44,10 +44,27 @@ export type CareIntakeExceptionType =
   (typeof CARE_INTAKE_EXCEPTION_TYPES)[number];
 
 export type CareIntakeRequirement = {
+  dynamicFormId: string;
+  dynamicFormVersion: number;
   linkId: string;
   dataCategory: string;
   required: boolean;
 };
+
+export function requirementsForPinnedForm(
+  requirements: CareIntakeRequirement[],
+  form: { dynamicFormId: string; dynamicFormVersion: number },
+): CareIntakeRequirement[] {
+  const assigned = requirements.filter(
+    (requirement) =>
+      requirement.dynamicFormId === form.dynamicFormId
+      && requirement.dynamicFormVersion === form.dynamicFormVersion,
+  );
+  if (assigned.length === 0) {
+    throw new Error("Dynamic form is not assigned to this intake packet");
+  }
+  return assigned;
+}
 
 export type CareIntakeAnswerDescriptor = {
   linkId: string;


### PR DESCRIPTION
## Summary
- add authority-gated, expiring patient/proxy intake resume grants that return a high-entropy bearer token once and persist only its digest
- add a token-scoped intake packet endpoint that returns lifecycle/readiness plus only exact packet-pinned `DynamicForm` fields, never saved answers or the global form catalog
- correct the Phase 1 intake RLS policy so every PHI-bearing intake table is constrained by both organization and explicit patient-profile context
- refine the delivery plan into Phase 2A/2B/2C slices; this PR delivers the access/read foundation while BI-HEALTHCARE-012 remains in progress for partial-save, submit, receptionist, and reviewed-evidence APIs

Backlog: BI-HEALTHCARE-012 · Epic: EP-HEALTHCARE-PRACTICE

## Security and authority boundaries
- patient/proxy issuance reuses `PatientAuthority` and records the authorization decision
- authenticated customer and workforce sessions resolve to the relational `Principal.id` used by healthcare foreign keys
- grants are limited to `view` / `save` / `submit`, expire within 24 hours, can be revoked, and are bound to one organization, patient, packet, and operation
- untrusted token claims establish only fail-closed RLS bootstrap context; the stored digest, grant id, packet, patient, expiry, revocation, and operation are all revalidated before data is returned
- only packet-pinned form versions and requirement-pinned fields are projected

## Verification
- [x] focused web tests: 32 passing across access codec, repository, endpoints, patient authority, intake repository, and principal linking
- [x] focused DB tests: 16 passing for intake contracts and Prisma substrate
- [x] web and DB typechecks: clean
- [x] Prisma schema validation: clean
- [x] migration safety guard: clean
- [x] governed merged-code CI against `origin/main` `5b3436928`: full web Vitest suite, DB/web typechecks, and Next production build passed
- [x] migration `20260717024000_scope_care_intake_rls_to_patient` applied cleanly as migration 398 in the shared integration database
- [x] Next build: 131 pages, including both new healthcare intake API routes
- [x] UX verification: not applicable; this is an API/security foundation with route-level functional tests

Merged-code candidate: `cb24ac2e52703d88933c9ef70fd66e19f46efeba`  
Integration commit: `c6de65c6d50dd411acf9bc9dd3fc44b2e1d89b3e`

Overlap sweep: no open PR overlaps the healthcare intake API or RLS surface.
