### PR TITLE
fix(ci): retighten route-error baseline for signed a2a delegation (#3137)

### DIFF
--- a/scripts/route-error-baseline.txt
+++ b/scripts/route-error-baseline.txt
@@ -1,4 +1,4 @@
-apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts	10
+apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts	12
 apps/web/app/api/a2a/tasks/[taskId]/route.ts	1
 apps/web/app/api/admin/bs-dispatch-test/route.ts	2
 apps/web/app/api/admin/model-capability-changes/route.ts	2


### PR DESCRIPTION
## Problem

`scripts/check-no-raw-route-error.mjs` (guard **BI-81EE4A46**, run by the `Repo Guard Loop` CI job) is failing on `origin/main` HEAD.

[#3137](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3137) ("sign a2a delegation receipts", `d8c0f5c77`) added two new error responses to `apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts` — `missing_gaid_call_chain` and `missing_contract_context` — growing its raw `NextResponse.json({ error })` count from **10 → 12** and tripping the ratchet. Because `Repo Guard Loop` is not one of the 5 branch-protection required checks (Typecheck / Production Build / DCO / Unit Tests / Module Size Guard), #3137 merged with it red, and it now shows red on every PR.

## Fix

The two new responses are **legitimately raw**, so the sanctioned path is to retighten the baseline (`--update`), not migrate:

- The entire `/api/a2a` surface returns the A2A protocol envelope `{ error: "snake_case", missing?, message? }`. No a2a route uses `apiErrorResponse`.
- Both the route tests (`route.test.ts` asserts `{ error: "missing_gaid_call_chain" }` and `{ error: "missing_contract_context", missing: [...] }`) and external A2A clients depend on that `{ error }` shape.
- Migrating to the internal `{ code, message }` envelope would fragment this route's error contract (2 of 12 differ) or force an out-of-scope rewrite of the whole A2A surface that changes its external wire contract and breaks tests.

Only one baseline line changes: `10 → 12` for this route.

## Verification

`node scripts/check-guards.mjs` → exits **0** ("17 guards passed").

🤖 Generated with [Claude Code](https://claude.com/claude-code)