### PR TITLE
feat(healthcare): add intake response workflow

### DIFF
--- a/apps/web/app/api/v1/healthcare/intake/[packetId]/responses/[formId]/route.ts
+++ b/apps/web/app/api/v1/healthcare/intake/[packetId]/responses/[formId]/route.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+import { apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { saveCareIntakePartialResponse } from "@/lib/healthcare/care-intake-api-repository";
+
+const SaveBody = z.object({
+  idempotencyKey: z.string().regex(/^[A-Za-z0-9._:-]{8,160}$/),
+  expectedVersion: z.number().int().positive().nullable(),
+  sourceMode: z.enum([
+    "patient-mobile", "patient-web", "proxy-mobile", "proxy-web",
+    "kiosk", "staff-assisted", "paper-transcribed",
+  ]),
+  answers: z.record(z.string(), z.unknown()),
+  dataCategories: z.record(z.string(), z.string().min(1)),
+});
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ packetId: string; formId: string }> },
+) {
+  const token = request.headers.get("x-intake-resume-token")?.trim();
+  if (!token) return apiError("INTAKE_TOKEN_REQUIRED", "Intake access token required", 401).toResponse();
+  const parsed = SaveBody.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return apiError("INVALID_REQUEST", "Invalid intake response", 400).toResponse();
+  try {
+    const { packetId, formId } = await params;
+    return apiSuccess(await saveCareIntakePartialResponse({
+      ...parsed.data,
+      packetId,
+      formId,
+      token,
+    }));
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      return apiError("INTERNAL_ERROR", "An unexpected error occurred", 500).toResponse();
+    }
+    if (error.message === "stale-intake-response-version" || error.message === "stale-intake-packet-version") {
+      return apiError("STALE_INTAKE_VERSION", "The intake response changed; refresh before saving", 409).toResponse();
+    }
+    if (error.message.startsWith("data-category-not-authorized:")) {
+      return apiError("MINIMUM_NECESSARY_VIOLATION", "The response contains data outside this intake assignment", 422).toResponse();
+    }
+    if (
+      error.message.includes("access denied")
+      || error.message.includes("resume token")
+      || error.message.includes("not assigned")
+    ) {
+      return apiError("INTAKE_ACCESS_DENIED", "Intake access denied", 403).toResponse();
+    }
+    return apiError("INTERNAL_ERROR", "An unexpected error occurred", 500).toResponse();
+  }
+}

--- a/apps/web/app/api/v1/healthcare/intake/[packetId]/submit/route.ts
+++ b/apps/web/app/api/v1/healthcare/intake/[packetId]/submit/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { submitCareIntakePacket } from "@/lib/healthcare/care-intake-api-repository";
+
+const SubmitBody = z.object({
+  expectedVersion: z.number().int().positive(),
+  sourceMode: z.enum([
+    "patient-mobile", "patient-web", "proxy-mobile", "proxy-web",
+    "kiosk", "staff-assisted", "paper-transcribed",
+  ]),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ packetId: string }> },
+) {
+  const token = request.headers.get("x-intake-resume-token")?.trim();
+  if (!token) return apiError("INTAKE_TOKEN_REQUIRED", "Intake access token required", 401).toResponse();
+  const parsed = SubmitBody.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return apiError("INVALID_REQUEST", "Invalid intake submission", 400).toResponse();
+  try {
+    const { packetId } = await params;
+    const result = await submitCareIntakePacket({ ...parsed.data, packetId, token });
+    if (!result.ok) {
+      return NextResponse.json(result, { status: 422 });
+    }
+    return apiSuccess(result);
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === "stale-intake-packet-version") {
+        return apiError("STALE_INTAKE_VERSION", "The intake packet changed; refresh before submitting", 409).toResponse();
+      }
+      if (error.message.includes("access denied") || error.message.includes("resume token")) {
+        return apiError("INTAKE_ACCESS_DENIED", "Intake access denied", 403).toResponse();
+      }
+    }
+    return NextResponse.json({ code: "INTERNAL_ERROR", message: "An unexpected error occurred" }, { status: 500 });
+  }
+}

--- a/apps/web/lib/api/__tests__/healthcare-intake-endpoints.test.ts
+++ b/apps/web/lib/api/__tests__/healthcare-intake-endpoints.test.ts
@@ -6,6 +6,8 @@ vi.mock("../../api/auth-middleware.js", () => ({
 vi.mock("../../healthcare/care-intake-api-repository.js", () => ({
   authorizeAndIssueCareIntakeResumeGrant: vi.fn(),
   getCareIntakePacketProjection: vi.fn(),
+  saveCareIntakePartialResponse: vi.fn(),
+  submitCareIntakePacket: vi.fn(),
 }));
 vi.mock("../../identity/principal-linking.js", () => ({
   resolvePrincipalRecordIdForSessionIdentity: vi.fn(),
@@ -13,10 +15,14 @@ vi.mock("../../identity/principal-linking.js", () => ({
 
 import { POST as issueGrant } from "../../../app/api/v1/healthcare/intake/[packetId]/access-grants/route.js";
 import { GET as getPacket } from "../../../app/api/v1/healthcare/intake/[packetId]/route.js";
+import { PUT as saveResponse } from "../../../app/api/v1/healthcare/intake/[packetId]/responses/[formId]/route.js";
+import { POST as submitPacket } from "../../../app/api/v1/healthcare/intake/[packetId]/submit/route.js";
 import { authenticateRequest } from "../../api/auth-middleware.js";
 import {
   authorizeAndIssueCareIntakeResumeGrant,
   getCareIntakePacketProjection,
+  saveCareIntakePartialResponse,
+  submitCareIntakePacket,
 } from "../../healthcare/care-intake-api-repository.js";
 import { resolvePrincipalRecordIdForSessionIdentity } from "../../identity/principal-linking.js";
 
@@ -25,6 +31,46 @@ const params = { params: Promise.resolve({ packetId: "intake-a" }) };
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z");
+});
+
+describe("PUT /api/v1/healthcare/intake/:packetId/responses/:formId", () => {
+  it("passes an idempotent partial save to the token-scoped repository", async () => {
+    vi.mocked(saveCareIntakePartialResponse).mockResolvedValue({
+      responseId: "intake-response-a", status: "in-progress", version: 1,
+      answeredLinkIds: ["visit-reason"],
+    });
+    const response = await saveResponse(new Request("http://localhost", {
+      method: "PUT",
+      headers: { "content-type": "application/json", "x-intake-resume-token": "opaque-token" },
+      body: JSON.stringify({
+        idempotencyKey: "device-a-save-1", expectedVersion: null, sourceMode: "patient-web",
+        answers: { "visit-reason": "Routine" }, dataCategories: { "visit-reason": "visit-reason" },
+      }),
+    }), { params: Promise.resolve({ packetId: "intake-a", formId: "medical-history" }) });
+    expect(response.status).toBe(200);
+    expect(saveCareIntakePartialResponse).toHaveBeenCalledWith(expect.objectContaining({
+      packetId: "intake-a", formId: "medical-history", token: "opaque-token",
+    }));
+  });
+});
+
+describe("POST /api/v1/healthcare/intake/:packetId/submit", () => {
+  it("returns completeness blockers without advancing an incomplete packet", async () => {
+    vi.mocked(submitCareIntakePacket).mockResolvedValue({
+      ok: false, blockers: ["required-answers-missing"],
+      missingRequiredLinkIds: ["visit-reason"], completionPercent: 50,
+    });
+    const response = await submitPacket(new Request("http://localhost", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-intake-resume-token": "opaque-token" },
+      body: JSON.stringify({ expectedVersion: 2, sourceMode: "patient-web" }),
+    }), params);
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual(expect.objectContaining({
+      blockers: ["required-answers-missing"], missingRequiredLinkIds: ["visit-reason"],
+    }));
+  });
 });
 
 describe("GET /api/v1/healthcare/intake/:packetId", () => {

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 555,
+  "routeCount": 557,
   "routes": [
     {
       "routePath": "/",
@@ -2751,6 +2751,40 @@
         "packetId"
       ],
       "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/access-grants/route.ts"
+    },
+    {
+      "routePath": "/api/v1/healthcare/intake/[packetId]/responses/[formId]",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "healthcare",
+        "intake",
+        "[packetId]",
+        "responses",
+        "[formId]"
+      ],
+      "dynamicParams": [
+        "packetId",
+        "formId"
+      ],
+      "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/responses/[formId]/route.ts"
+    },
+    {
+      "routePath": "/api/v1/healthcare/intake/[packetId]/submit",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "healthcare",
+        "intake",
+        "[packetId]",
+        "submit"
+      ],
+      "dynamicParams": [
+        "packetId"
+      ],
+      "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/submit/route.ts"
     },
     {
       "routePath": "/api/v1/integrations/coverage",

--- a/apps/web/lib/healthcare/care-intake-api-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-api-repository.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getCareIntakePacketProjection,
   issueCareIntakeResumeGrant,
+  saveCareIntakePartialResponse,
+  submitCareIntakePacket,
   type CareIntakeApiDatabase,
 } from "./care-intake-api-repository";
 import { digestCareIntakeResumeToken } from "./care-intake-access";
@@ -17,6 +19,7 @@ const packet = {
   dueAt: null,
   completionPercent: 0,
   purposeOfUse: "patient-intake",
+  allowedDataCategories: ["visit-reason"],
   requirementSnapshot: [
     {
       dynamicFormId: "form-row-a",
@@ -33,7 +36,10 @@ const packet = {
 function database() {
   const tx = {
     $executeRaw: vi.fn().mockResolvedValue(1),
-    careIntakePacket: { findFirst: vi.fn().mockResolvedValue(packet) },
+    careIntakePacket: {
+      findFirst: vi.fn().mockResolvedValue(packet),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
     careIntakeAccessGrant: {
       create: vi.fn().mockImplementation(({ data }) => Promise.resolve({ ...data })),
       findFirst: vi.fn(),
@@ -51,7 +57,28 @@ function database() {
           offlineCapable: true,
         },
       ]),
+      findFirst: vi.fn().mockResolvedValue({
+        id: "form-row-a",
+        formId: "medical-history",
+        title: "Medical history",
+        version: 2,
+        fields: [{ key: "visit-reason", type: "textarea", label: "Reason" }],
+        submitAction: null,
+        offlineCapable: true,
+      }),
     },
+    careIntakeResponse: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      findMany: vi.fn().mockResolvedValue([]),
+      create: vi.fn().mockImplementation(({ data }) =>
+        Promise.resolve({ ...data, id: "response-row-a", version: 1 }),
+      ),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    careIntakeException: { count: vi.fn().mockResolvedValue(0) },
+    careConsentAttestation: { count: vi.fn().mockResolvedValue(0) },
+    careCoverageEvidence: { count: vi.fn().mockResolvedValue(0) },
+    careIntakeStatusEvent: { create: vi.fn().mockResolvedValue({}) },
   };
   return {
     tx,
@@ -109,6 +136,216 @@ describe("issueCareIntakeResumeGrant", () => {
       ),
     ).rejects.toThrow("Patient authority denied care intake access");
     expect(tx.careIntakeAccessGrant.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("submitCareIntakePacket", () => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));
+
+  async function submitFixture() {
+    const { db, tx } = database();
+    const issued = await issueCareIntakeResumeGrant({
+      organizationId: "org-a", patientProfileId: "patient-a", patientPrincipalId: "principal-patient-a",
+      packetId: "intake-a", granteePrincipalId: "principal-patient-a", issuedByPrincipalId: "principal-patient-a",
+      permittedOperations: ["submit"], expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      authorityDecision: { effect: "allow", reasonCodes: [] },
+    }, db);
+    tx.careIntakePacket.findFirst.mockResolvedValue({ ...packet, status: "in-progress", version: 2 });
+    tx.careIntakeAccessGrant.findFirst.mockResolvedValue({
+      grantId: issued.grantId, packetId: "packet-row-a", patientProfileId: "patient-a",
+      granteePrincipalId: "principal-patient-a", tokenDigest: digestCareIntakeResumeToken(issued.token),
+      permittedOperations: ["submit"], expiresAt: new Date("2026-08-01T15:00:00.000Z"), revokedAt: null,
+    });
+    return { db, tx, token: issued.token };
+  }
+
+  it("rejects incomplete intake without advancing packet state", async () => {
+    const { db, tx, token } = await submitFixture();
+
+    const result = await submitCareIntakePacket({
+      packetId: "intake-a", token, expectedVersion: 2, sourceMode: "patient-web",
+    }, db);
+
+    expect(result).toEqual({
+      ok: false,
+      blockers: ["required-answers-missing"],
+      missingRequiredLinkIds: ["visit-reason"],
+      completionPercent: 50,
+    });
+    expect(tx.careIntakePacket.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("completes a ready packet and records its optimistic lifecycle event", async () => {
+    const { db, tx, token } = await submitFixture();
+    tx.careIntakeResponse.findMany.mockResolvedValue([{ answeredLinkIds: ["visit-reason"] }]);
+
+    const result = await submitCareIntakePacket({
+      packetId: "intake-a", token, expectedVersion: 2, sourceMode: "patient-web",
+    }, db);
+
+    expect(result).toEqual({
+      ok: true, packetId: "intake-a", status: "completed", version: 3, completionPercent: 100,
+    });
+    expect(tx.careIntakePacket.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "packet-row-a", organizationId: "org-a", status: "in-progress", version: 2,
+      },
+      data: expect.objectContaining({
+        status: "completed", version: 3, completionPercent: 100,
+        completedAt: new Date("2026-08-01T14:00:00.000Z"),
+      }),
+    });
+    expect(tx.careIntakeResponse.updateMany).toHaveBeenCalledWith({
+      where: { packetId: "packet-row-a", organizationId: "org-a", status: "in-progress" },
+      data: { status: "completed", completedAt: new Date("2026-08-01T14:00:00.000Z") },
+    });
+    expect(tx.careIntakeStatusEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        packetVersion: 3, fromStatus: "in-progress", toStatus: "completed",
+        reason: "patient-submitted", actorPrincipalId: "principal-patient-a",
+      }),
+    });
+  });
+});
+
+describe("saveCareIntakePartialResponse", () => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));
+
+  it("saves a minimum-necessary partial response without echoing answers", async () => {
+    const { db, tx } = database();
+    const issued = await issueCareIntakeResumeGrant(
+      {
+        organizationId: "org-a",
+        patientProfileId: "patient-a",
+        patientPrincipalId: "principal-patient-a",
+        packetId: "intake-a",
+        granteePrincipalId: "principal-patient-a",
+        issuedByPrincipalId: "principal-patient-a",
+        permittedOperations: ["save"],
+        expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+        authorityDecision: { effect: "allow", reasonCodes: [] },
+      },
+      db,
+    );
+    tx.careIntakeAccessGrant.findFirst.mockResolvedValue({
+      grantId: issued.grantId,
+      packetId: "packet-row-a",
+      patientProfileId: "patient-a",
+      granteePrincipalId: "principal-patient-a",
+      tokenDigest: digestCareIntakeResumeToken(issued.token),
+      permittedOperations: ["save"],
+      expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      revokedAt: null,
+    });
+
+    const result = await saveCareIntakePartialResponse(
+      {
+        packetId: "intake-a",
+        formId: "medical-history",
+        token: issued.token,
+        idempotencyKey: "device-a-save-1",
+        expectedVersion: null,
+        sourceMode: "patient-web",
+        answers: { "visit-reason": "Routine check" },
+        dataCategories: { "visit-reason": "visit-reason" },
+      },
+      db,
+    );
+
+    expect(result).toEqual({
+      responseId: expect.stringMatching(/^intake-response-/),
+      status: "in-progress",
+      version: 1,
+      answeredLinkIds: ["visit-reason"],
+    });
+    expect(JSON.stringify(result)).not.toContain("Routine check");
+    expect(tx.careIntakeResponse.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        sourceSystem: "care-intake-api",
+        sourceId: "packet-row-a:form-row-a",
+        sourceVersion: "device-a-save-1",
+        recordedByPrincipalId: "principal-patient-a",
+      }),
+    });
+    expect(tx.careIntakePacket.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "packet-row-a",
+        organizationId: "org-a",
+        status: "assigned",
+        version: 1,
+      },
+      data: expect.objectContaining({
+        status: "in-progress",
+        version: 2,
+        startedAt: new Date("2026-08-01T14:00:00.000Z"),
+      }),
+    });
+    expect(tx.careIntakeStatusEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        packetVersion: 2,
+        fromStatus: "assigned",
+        toStatus: "in-progress",
+        reason: "first-response-saved",
+        actorPrincipalId: "principal-patient-a",
+      }),
+    });
+  });
+
+  it("returns an idempotent result without rewriting the response", async () => {
+    const { db, tx } = database();
+    const issued = await issueCareIntakeResumeGrant({
+      organizationId: "org-a", patientProfileId: "patient-a", patientPrincipalId: "principal-patient-a",
+      packetId: "intake-a", granteePrincipalId: "principal-patient-a", issuedByPrincipalId: "principal-patient-a",
+      permittedOperations: ["save"], expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+      authorityDecision: { effect: "allow", reasonCodes: [] },
+    }, db);
+    tx.careIntakeAccessGrant.findFirst.mockResolvedValue({
+      grantId: issued.grantId, packetId: "packet-row-a", patientProfileId: "patient-a",
+      granteePrincipalId: "principal-patient-a", tokenDigest: digestCareIntakeResumeToken(issued.token),
+      permittedOperations: ["save"], expiresAt: new Date("2026-08-01T15:00:00.000Z"), revokedAt: null,
+    });
+    tx.careIntakeResponse.findFirst.mockResolvedValue({
+      id: "response-row-a", responseId: "intake-response-a", version: 3,
+      sourceVersion: "device-a-save-3", answeredLinkIds: ["visit-reason"],
+    });
+    tx.careIntakePacket.findFirst.mockResolvedValue({ ...packet, status: "in-progress", version: 2 });
+
+    const result = await saveCareIntakePartialResponse({
+      packetId: "intake-a", formId: "medical-history", token: issued.token,
+      idempotencyKey: "device-a-save-3", expectedVersion: 2, sourceMode: "patient-web",
+      answers: { "visit-reason": "Routine" }, dataCategories: { "visit-reason": "visit-reason" },
+    }, db);
+
+    expect(result).toEqual({
+      responseId: "intake-response-a", status: "in-progress", version: 3,
+      answeredLinkIds: ["visit-reason"],
+    });
+    expect(tx.careIntakeResponse.updateMany).not.toHaveBeenCalled();
+    expect(tx.careIntakePacket.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects answer categories outside the packet scope", async () => {
+    const { db, tx } = database();
+    const issued = await issueCareIntakeResumeGrant(
+      {
+        organizationId: "org-a", patientProfileId: "patient-a", patientPrincipalId: "principal-patient-a",
+        packetId: "intake-a", granteePrincipalId: "principal-patient-a", issuedByPrincipalId: "principal-patient-a",
+        permittedOperations: ["save"], expiresAt: new Date("2026-08-01T15:00:00.000Z"),
+        authorityDecision: { effect: "allow", reasonCodes: [] },
+      }, db,
+    );
+    tx.careIntakeAccessGrant.findFirst.mockResolvedValue({
+      grantId: issued.grantId, packetId: "packet-row-a", patientProfileId: "patient-a",
+      granteePrincipalId: "principal-patient-a", tokenDigest: digestCareIntakeResumeToken(issued.token),
+      permittedOperations: ["save"], expiresAt: new Date("2026-08-01T15:00:00.000Z"), revokedAt: null,
+    });
+    await expect(saveCareIntakePartialResponse({
+      packetId: "intake-a", formId: "medical-history", token: issued.token,
+      idempotencyKey: "device-a-save-2", expectedVersion: null, sourceMode: "patient-web",
+      answers: { "visit-reason": "Routine", extra: "secret" },
+      dataCategories: { "visit-reason": "visit-reason", extra: "clinical-note" },
+    }, db)).rejects.toThrow("data-category-not-authorized:extra");
+    expect(tx.careIntakeResponse.create).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/healthcare/care-intake-api-repository.ts
+++ b/apps/web/lib/healthcare/care-intake-api-repository.ts
@@ -1,9 +1,12 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { prisma } from "@dpf/db";
 import {
+  calculateIntakeReadiness,
   requirementsForPinnedForm,
+  validateMinimumNecessaryAnswers,
   type CareIntakeRequirement,
+  type CareIntakeSourceMode,
 } from "@dpf/db/healthcare-care-intake";
 
 import {
@@ -29,6 +32,7 @@ type PacketRow = {
   requirementSnapshot: unknown;
   requiredConsentCount: number;
   requiresCoverageEvidence: boolean;
+  allowedDataCategories: string[];
 };
 
 type GrantRow = {
@@ -39,6 +43,7 @@ type GrantRow = {
   permittedOperations: string[];
   expiresAt: Date;
   revokedAt: Date | null;
+  granteePrincipalId: string | null;
 };
 
 type DynamicFormRow = {
@@ -53,13 +58,39 @@ type DynamicFormRow = {
 
 type Transaction = {
   $executeRaw(query: TemplateStringsArray, ...values: unknown[]): Promise<number>;
-  careIntakePacket: { findFirst(args: unknown): Promise<PacketRow | null> };
+  careIntakePacket: {
+    findFirst(args: unknown): Promise<PacketRow | null>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
   careIntakeAccessGrant: {
     create(args: unknown): Promise<GrantRow>;
     findFirst(args: unknown): Promise<GrantRow | null>;
     updateMany(args: unknown): Promise<{ count: number }>;
   };
-  dynamicForm: { findMany(args: unknown): Promise<DynamicFormRow[]> };
+  dynamicForm: {
+    findMany(args: unknown): Promise<DynamicFormRow[]>;
+    findFirst(args: unknown): Promise<DynamicFormRow | null>;
+  };
+  careIntakeResponse: {
+    findFirst(args: unknown): Promise<{
+      id: string;
+      responseId: string;
+      version: number;
+      sourceVersion: string | null;
+      answeredLinkIds: string[];
+    } | null>;
+    findMany(args: unknown): Promise<Array<{ answeredLinkIds: string[] }>>;
+    create(args: unknown): Promise<{
+      responseId: string;
+      version: number;
+      answeredLinkIds: string[];
+    }>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  careIntakeException: { count(args: unknown): Promise<number> };
+  careConsentAttestation: { count(args: unknown): Promise<number> };
+  careCoverageEvidence: { count(args: unknown): Promise<number> };
+  careIntakeStatusEvent: { create(args: unknown): Promise<unknown> };
 };
 
 export type CareIntakeApiDatabase = {
@@ -107,6 +138,43 @@ function validateOperations(
     throw new Error("Invalid care intake grant operations");
   }
   return unique;
+}
+
+async function markPacketInProgressAfterFirstSave(
+  tx: Transaction,
+  packet: PacketRow,
+  input: { sourceMode: CareIntakeSourceMode; actorPrincipalId: string },
+) {
+  if (packet.status !== "assigned") return;
+  const version = packet.version + 1;
+  const updated = await tx.careIntakePacket.updateMany({
+    where: {
+      id: packet.id,
+      organizationId: packet.organizationId,
+      status: "assigned",
+      version: packet.version,
+    },
+    data: {
+      status: "in-progress",
+      version,
+      startedAt: new Date(),
+    },
+  });
+  if (updated.count !== 1) throw new Error("stale-intake-packet-version");
+  await tx.careIntakeStatusEvent.create({
+    data: {
+      eventId: `intake-event-${randomUUID()}`,
+      organizationId: packet.organizationId,
+      packetId: packet.id,
+      patientProfileId: packet.patientProfileId,
+      packetVersion: version,
+      fromStatus: "assigned",
+      toStatus: "in-progress",
+      reason: "first-response-saved",
+      sourceMode: input.sourceMode,
+      actorPrincipalId: input.actorPrincipalId,
+    },
+  });
 }
 
 export async function issueCareIntakeResumeGrant(
@@ -323,6 +391,303 @@ export async function getCareIntakePacketProjection(
           offlineCapable: form.offlineCapable,
         };
       }),
+    };
+  });
+}
+
+export async function saveCareIntakePartialResponse(
+  input: {
+    packetId: string;
+    formId: string;
+    token: string;
+    idempotencyKey: string;
+    expectedVersion: number | null;
+    sourceMode: CareIntakeSourceMode;
+    answers: Record<string, unknown>;
+    dataCategories: Record<string, string>;
+  },
+  database: CareIntakeApiDatabase = prisma as unknown as CareIntakeApiDatabase,
+) {
+  if (!/^[A-Za-z0-9._:-]{8,160}$/.test(input.idempotencyKey)) {
+    throw new Error("Invalid intake idempotency key");
+  }
+  const claims = parseCareIntakeResumeToken(input.token);
+  const digest = digestCareIntakeResumeToken(input.token);
+  return database.$transaction(async (tx) => {
+    await setPatientContext(tx, claims);
+    const packet = await tx.careIntakePacket.findFirst({
+      where: {
+        packetId: input.packetId,
+        organizationId: claims.organizationId,
+        patientProfileId: claims.patientProfileId,
+      },
+    });
+    if (!packet || !["assigned", "in-progress", "amended"].includes(packet.status)) {
+      throw new Error("Care intake access denied");
+    }
+    const grant = await tx.careIntakeAccessGrant.findFirst({
+      where: {
+        grantId: claims.grantId,
+        organizationId: claims.organizationId,
+        patientProfileId: claims.patientProfileId,
+      },
+    });
+    if (!grant || !grant.granteePrincipalId) throw new Error("Care intake access denied");
+    assertCareIntakeGrant(grant, {
+      digest,
+      grantId: claims.grantId,
+      packetRowId: packet.id,
+      patientProfileId: claims.patientProfileId,
+      operation: "save",
+      at: new Date(),
+    });
+    const form = await tx.dynamicForm.findFirst({ where: { formId: input.formId } });
+    if (!form) throw new Error("Dynamic form is not assigned to this intake packet");
+    const assigned = requirementsForPinnedForm(
+      packetRequirements(packet.requirementSnapshot),
+      { dynamicFormId: form.id, dynamicFormVersion: form.version },
+    );
+    const answerDescriptors = Object.keys(input.answers).map((linkId) => ({
+      linkId,
+      dataCategory: input.dataCategories[linkId] ?? "",
+    }));
+    const minimumNecessary = validateMinimumNecessaryAnswers({
+      requirements: assigned,
+      allowedDataCategories: packet.allowedDataCategories,
+      answers: answerDescriptors,
+    });
+    if (!minimumNecessary.ok) throw new Error(minimumNecessary.errors.join(","));
+
+    const existing = await tx.careIntakeResponse.findFirst({
+      where: {
+        organizationId: claims.organizationId,
+        packetId: packet.id,
+        dynamicFormId: form.id,
+        status: { not: "entered-in-error" },
+      },
+      orderBy: { version: "desc" },
+    });
+    if (existing?.sourceVersion === input.idempotencyKey) {
+      await markPacketInProgressAfterFirstSave(tx, packet, {
+        sourceMode: input.sourceMode,
+        actorPrincipalId: grant.granteePrincipalId,
+      });
+      await tx.careIntakeAccessGrant.updateMany({
+        where: { grantId: claims.grantId, tokenDigest: digest },
+        data: { lastUsedAt: new Date() },
+      });
+      return {
+        responseId: existing.responseId,
+        status: "in-progress" as const,
+        version: existing.version,
+        answeredLinkIds: existing.answeredLinkIds,
+      };
+    }
+    const answeredLinkIds = Object.keys(input.answers).sort();
+    const formSnapshot = { formId: form.formId, title: form.title, version: form.version, fields: form.fields };
+    const formDigest = createHash("sha256")
+      .update(JSON.stringify(formSnapshot))
+      .digest("hex");
+
+    if (existing) {
+      if (input.expectedVersion !== existing.version) {
+        throw new Error("stale-intake-response-version");
+      }
+      const version = existing.version + 1;
+      const updated = await tx.careIntakeResponse.updateMany({
+        where: { id: existing.id, version: existing.version },
+        data: {
+          version,
+          answers: input.answers,
+          answeredLinkIds,
+          dataCategories: [...new Set(answerDescriptors.map((item) => item.dataCategory))],
+          sourceMode: input.sourceMode,
+          sourcePrincipalId: grant.granteePrincipalId,
+          recordedByPrincipalId: grant.granteePrincipalId,
+          sourceVersion: input.idempotencyKey,
+          authoredAt: new Date(),
+        },
+      });
+      if (updated.count !== 1) throw new Error("stale-intake-response-version");
+      await markPacketInProgressAfterFirstSave(tx, packet, {
+        sourceMode: input.sourceMode,
+        actorPrincipalId: grant.granteePrincipalId,
+      });
+      await tx.careIntakeAccessGrant.updateMany({
+        where: { grantId: claims.grantId, tokenDigest: digest },
+        data: { lastUsedAt: new Date() },
+      });
+      return { responseId: existing.responseId, status: "in-progress" as const, version, answeredLinkIds };
+    }
+    if (input.expectedVersion !== null) throw new Error("stale-intake-response-version");
+    const response = await tx.careIntakeResponse.create({
+      data: {
+        responseId: `intake-response-${randomUUID()}`,
+        organizationId: claims.organizationId,
+        packetId: packet.id,
+        patientProfileId: claims.patientProfileId,
+        dynamicFormId: form.id,
+        dynamicFormVersion: form.version,
+        formSnapshot,
+        formDigest,
+        answers: input.answers,
+        answeredLinkIds,
+        dataCategories: [...new Set(answerDescriptors.map((item) => item.dataCategory))],
+        sourceMode: input.sourceMode,
+        sourcePrincipalId: grant.granteePrincipalId,
+        recordedByPrincipalId: grant.granteePrincipalId,
+        sourceSystem: "care-intake-api",
+        sourceId: `${packet.id}:${form.id}`,
+        sourceVersion: input.idempotencyKey,
+      },
+    });
+    await markPacketInProgressAfterFirstSave(tx, packet, {
+      sourceMode: input.sourceMode,
+      actorPrincipalId: grant.granteePrincipalId,
+    });
+    await tx.careIntakeAccessGrant.updateMany({
+      where: { grantId: claims.grantId, tokenDigest: digest },
+      data: { lastUsedAt: new Date() },
+    });
+    return {
+      responseId: response.responseId,
+      status: "in-progress" as const,
+      version: response.version,
+      answeredLinkIds: response.answeredLinkIds,
+    };
+  });
+}
+
+export async function submitCareIntakePacket(
+  input: {
+    packetId: string;
+    token: string;
+    expectedVersion: number;
+    sourceMode: CareIntakeSourceMode;
+  },
+  database: CareIntakeApiDatabase = prisma as unknown as CareIntakeApiDatabase,
+) {
+  if (!Number.isInteger(input.expectedVersion) || input.expectedVersion < 1) {
+    throw new Error("Invalid intake packet version");
+  }
+  const claims = parseCareIntakeResumeToken(input.token);
+  const digest = digestCareIntakeResumeToken(input.token);
+  return database.$transaction(async (tx) => {
+    await setPatientContext(tx, claims);
+    const packet = await tx.careIntakePacket.findFirst({
+      where: {
+        packetId: input.packetId,
+        organizationId: claims.organizationId,
+        patientProfileId: claims.patientProfileId,
+      },
+    });
+    if (!packet || packet.status !== "in-progress") {
+      throw new Error("Care intake access denied");
+    }
+    const grant = await tx.careIntakeAccessGrant.findFirst({
+      where: {
+        grantId: claims.grantId,
+        organizationId: claims.organizationId,
+        patientProfileId: claims.patientProfileId,
+      },
+    });
+    if (!grant || !grant.granteePrincipalId) throw new Error("Care intake access denied");
+    assertCareIntakeGrant(grant, {
+      digest,
+      grantId: claims.grantId,
+      packetRowId: packet.id,
+      patientProfileId: claims.patientProfileId,
+      operation: "submit",
+      at: new Date(),
+    });
+
+    const [responses, unresolvedExceptionCount, acceptedConsentCount, acceptedCoverageEvidenceCount] =
+      await Promise.all([
+        tx.careIntakeResponse.findMany({
+          where: {
+            packetId: packet.id,
+            organizationId: claims.organizationId,
+            status: { not: "entered-in-error" },
+          },
+          select: { answeredLinkIds: true },
+        }),
+        tx.careIntakeException.count({
+          where: {
+            packetId: packet.id,
+            organizationId: claims.organizationId,
+            status: { in: ["open", "in-progress"] },
+          },
+        }),
+        tx.careConsentAttestation.count({
+          where: { packetId: packet.id, organizationId: claims.organizationId, status: "accepted" },
+        }),
+        tx.careCoverageEvidence.count({
+          where: { packetId: packet.id, organizationId: claims.organizationId, status: "accepted" },
+        }),
+      ]);
+    const readiness = calculateIntakeReadiness({
+      requirements: packetRequirements(packet.requirementSnapshot),
+      answeredLinkIds: [...new Set(responses.flatMap((row) => row.answeredLinkIds))],
+      unresolvedExceptionCount,
+      requiredConsentCount: packet.requiredConsentCount,
+      acceptedConsentCount,
+      requiredCoverageEvidence: packet.requiresCoverageEvidence,
+      acceptedCoverageEvidenceCount,
+    });
+    await tx.careIntakeAccessGrant.updateMany({
+      where: { grantId: claims.grantId, tokenDigest: digest },
+      data: { lastUsedAt: new Date() },
+    });
+    if (!readiness.ready) {
+      return {
+        ok: false as const,
+        blockers: readiness.blockers,
+        missingRequiredLinkIds: readiness.missingRequiredLinkIds,
+        completionPercent: readiness.completionPercent,
+      };
+    }
+
+    const completedAt = new Date();
+    const version = packet.version + 1;
+    const updated = await tx.careIntakePacket.updateMany({
+      where: {
+        id: packet.id,
+        organizationId: claims.organizationId,
+        status: "in-progress",
+        version: input.expectedVersion,
+      },
+      data: {
+        status: "completed",
+        version,
+        completionPercent: readiness.completionPercent,
+        completedAt,
+      },
+    });
+    if (updated.count !== 1) throw new Error("stale-intake-packet-version");
+    await tx.careIntakeResponse.updateMany({
+      where: { packetId: packet.id, organizationId: claims.organizationId, status: "in-progress" },
+      data: { status: "completed", completedAt },
+    });
+    await tx.careIntakeStatusEvent.create({
+      data: {
+        eventId: `intake-event-${randomUUID()}`,
+        organizationId: claims.organizationId,
+        packetId: packet.id,
+        patientProfileId: claims.patientProfileId,
+        packetVersion: version,
+        fromStatus: "in-progress",
+        toStatus: "completed",
+        reason: "patient-submitted",
+        sourceMode: input.sourceMode,
+        actorPrincipalId: grant.granteePrincipalId,
+      },
+    });
+    return {
+      ok: true as const,
+      packetId: packet.packetId,
+      status: "completed" as const,
+      version,
+      completionPercent: readiness.completionPercent,
     };
   });
 }

--- a/docs/superpowers/plans/2026-07-16-healthcare-digital-intake.md
+++ b/docs/superpowers/plans/2026-07-16-healthcare-digital-intake.md
@@ -91,6 +91,14 @@ and exception records that those generic surfaces do not own.
 - **2C — reviewed evidence API:** stage coverage documents and consent
   attestations, then accept/reject them only through explicit human authority.
 
+Phase 2A is delivered as two reviewable checkpoints: the access/read checkpoint
+owns grant issuance, patient-context RLS correction, and the minimum packet
+projection; the response checkpoint owns retry-safe partial saves, the atomic
+`assigned` to `in-progress` transition, and completeness-gated submit. A ready
+submit completes current responses and advances the packet with one optimistic,
+append-only status event. An incomplete submit returns blocker codes and never
+advances packet state.
+
 Rollback for 2A is route and repository removal; it adds no schema migration.
 Existing Phase 1 tables remain forward-compatible and contain no raw resume
 tokens.


### PR DESCRIPTION
## Summary

- add token-scoped, minimum-necessary partial response saves with idempotency and optimistic response versions
- atomically advance the packet from assigned to in-progress on first save with append-only status evidence
- add completeness-gated submit that completes current responses and the packet only when required answers, consent, coverage, and exceptions are ready
- never echo stored answers from save or submit responses

## Verification

- focused healthcare endpoint and repository tests: 14 passed
- web typecheck passed
- module-size and route-manifest checks passed
- governed local-integration-ci merge gate passed against main: 16,740 tests, Prisma migration deploy, typecheck, and production build of 131 pages

## Delivery context

BI-HEALTHCARE-012 remains in progress after this checkpoint. Receptionist review and reviewed evidence APIs are separate follow-on work.