### PR TITLE
feat(onboarding): capture source system context

### DIFF
--- a/apps/web/app/(shell)/storefront/settings/business/page.tsx
+++ b/apps/web/app/(shell)/storefront/settings/business/page.tsx
@@ -33,6 +33,7 @@ export default async function StorefrontBusinessSettingsPage() {
     description: businessContext?.description ?? suggestions?.description ?? "",
     mission: businessContext?.mission ?? "",
     targetMarket: businessContext?.targetMarket ?? "",
+    sourceSystem: businessContext?.sourceSystem ?? "",
     companySize: businessContext?.companySize ?? null,
     geographicScope: businessContext?.geographicScope ?? suggestions?.geographicScope ?? null,
     revenueModel: businessContext?.revenueModel ?? "",

--- a/apps/web/app/api/business-context/setup/route.test.ts
+++ b/apps/web/app/api/business-context/setup/route.test.ts
@@ -53,4 +53,19 @@ describe("POST /api/business-context/setup", () => {
     expect(call?.create.description).toBe("Hello");
     expect(call?.create.targetMarket).toBe("Locals");
   });
+
+  it("persists the source system when captured during setup", async () => {
+    await POST(makeReq({ description: "Hello", sourceSystem: "QuickBooks and spreadsheets" }));
+    const call = mockBusinessContext.upsert.mock.calls[0]?.[0];
+
+    expect(call?.create.sourceSystem).toBe("QuickBooks and spreadsheets");
+    expect(call?.update.sourceSystem).toBe("QuickBooks and spreadsheets");
+  });
+
+  it("does not overwrite source system when omitted from a partial update", async () => {
+    await POST(makeReq({ description: "Hello" }));
+    const call = mockBusinessContext.upsert.mock.calls[0]?.[0];
+
+    expect(call?.update).not.toHaveProperty("sourceSystem");
+  });
 });

--- a/apps/web/app/api/business-context/setup/route.ts
+++ b/apps/web/app/api/business-context/setup/route.ts
@@ -15,6 +15,7 @@ export async function POST(req: NextRequest) {
     description,
     mission,
     targetMarket,
+    sourceSystem,
     companySize,
     geographicScope,
     revenueModel,
@@ -32,6 +33,7 @@ export async function POST(req: NextRequest) {
     description?: string;
     mission?: string;
     targetMarket?: string;
+    sourceSystem?: string;
     companySize?: string;
     geographicScope?: string;
     revenueModel?: string;
@@ -131,6 +133,7 @@ export async function POST(req: NextRequest) {
       description: description ?? null,
       mission: mission ?? null,
       targetMarket: targetMarket ?? null,
+      sourceSystem: sourceSystem ?? null,
       companySize: companySize ?? null,
       geographicScope: geographicScope ?? null,
       revenueModel: revenueModel ?? null,
@@ -143,6 +146,7 @@ export async function POST(req: NextRequest) {
       ...(description !== undefined && { description }),
       ...(mission !== undefined && { mission }),
       ...(targetMarket !== undefined && { targetMarket }),
+      ...(sourceSystem !== undefined && { sourceSystem }),
       ...(companySize !== undefined && { companySize }),
       ...(geographicScope !== undefined && { geographicScope }),
       ...(revenueModel !== undefined && { revenueModel }),

--- a/apps/web/components/admin/BusinessContextForm.test.tsx
+++ b/apps/web/components/admin/BusinessContextForm.test.tsx
@@ -1,0 +1,51 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { BusinessContextForm } from "./BusinessContextForm";
+
+vi.mock("@/components/admin/BusinessDocumentUpload", () => ({
+  BusinessDocumentUpload: () => <div data-testid="business-document-upload" />,
+}));
+
+vi.mock("@/components/admin/RosterImport", () => ({
+  RosterImport: () => <div data-testid="roster-import" />,
+}));
+
+vi.mock("@/components/admin/MarketContextFields", () => ({
+  MarketContextFields: () => <div data-testid="market-context-fields" />,
+}));
+
+const baseInitial = {
+  description: "",
+  mission: "",
+  targetMarket: "",
+  sourceSystem: "Legacy spreadsheets",
+  companySize: null,
+  geographicScope: null,
+  revenueModel: "",
+  contactEmail: "",
+  contactPhone: "",
+  operatesIn: [],
+  sellsTo: [],
+  employsIn: [],
+  dataResidency: [],
+  handlesCardPayments: false,
+  listingStatus: null,
+  riskPosture: null,
+  address: {},
+};
+
+describe("BusinessContextForm", () => {
+  it("renders the optional switching-from source system question", () => {
+    const html = renderToStaticMarkup(
+      <BusinessContextForm
+        initial={baseInitial}
+        archetypeSummary={null}
+      />,
+    );
+
+    expect(html).toContain("What system or process are you switching from?");
+    expect(html).toContain("Legacy spreadsheets");
+    expect(html).toContain("sourceSystem");
+  });
+});

--- a/apps/web/components/admin/BusinessContextForm.tsx
+++ b/apps/web/components/admin/BusinessContextForm.tsx
@@ -81,6 +81,7 @@ type BusinessContextData = {
   description: string;
   mission: string;
   targetMarket: string;
+  sourceSystem: string;
   companySize: string | null;
   geographicScope: string | null;
   revenueModel: string;
@@ -404,6 +405,22 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
           />
           <div style={hintStyle}>
             Your stakeholders — the people who interact with your business. These aren't always "customers."
+          </div>
+        </label>
+
+        {/* Source system / migration context */}
+        <label style={labelStyle}>
+          <div style={fieldLabelStyle}>What system or process are you switching from? {optionalHint}</div>
+          <input
+            type="text"
+            name="sourceSystem"
+            value={data.sourceSystem}
+            onChange={(e) => update("sourceSystem", e.target.value)}
+            placeholder="e.g. QuickBooks, spreadsheets, paper forms, another platform"
+            style={inputStyle}
+          />
+          <div style={hintStyle}>
+            Helps your AI coworker plan imports, migration steps, and where old records may still live.
           </div>
         </label>
 

--- a/docs/superpowers/plans/2026-07-17-onboarding-source-system.md
+++ b/docs/superpowers/plans/2026-07-17-onboarding-source-system.md
@@ -1,0 +1,83 @@
+# Onboarding Source System Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture "what are you switching from?" during onboarding as `BusinessContext.sourceSystem`.
+
+**Architecture:** Store the answer on the existing `BusinessContext` record because it is first-party organization context gathered in the same setup flow as description, target market, and operating facts. The existing business-context setup API remains the single write path, and the existing `BusinessContextForm` renders one optional text field without adding a new onboarding model.
+
+**Tech Stack:** Next.js 16, React, Vitest, Prisma 7, PostgreSQL.
+
+---
+
+## Chunk 1: Source-System Capture
+
+### Task 1: Add tests for the new field
+
+**Files:**
+- Modify: `apps/web/app/api/business-context/setup/route.test.ts`
+- Add: `apps/web/components/admin/BusinessContextForm.test.tsx`
+- Add: `packages/db/src/business-context-source-system-schema.test.ts`
+
+- [ ] **Step 1: Write failing API tests**
+
+Assert that POST `/api/business-context/setup` includes `sourceSystem` in both `create` and `update` when the payload provides it, and omits it when absent.
+
+- [ ] **Step 2: Write failing form render test**
+
+Render `BusinessContextForm` with `sourceSystem: ""`; assert the UI includes the optional "What system or process are you switching from?" prompt and a controlled input initialized from the field.
+
+- [ ] **Step 3: Write failing schema/migration test**
+
+Read `packages/db/prisma/schema.prisma` and the migration directory; assert `BusinessContext` declares `sourceSystem String?` and a migration adds the column.
+
+### Task 2: Implement persistence and UI
+
+**Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/20260717033000_add_business_context_source_system/migration.sql`
+- Modify: `apps/web/app/api/business-context/setup/route.ts`
+- Modify: `apps/web/app/(shell)/storefront/settings/business/page.tsx`
+- Modify: `apps/web/components/admin/BusinessContextForm.tsx`
+
+- [ ] **Step 1: Add nullable schema column**
+
+Add `sourceSystem String?` to `BusinessContext` near the other business-model context fields.
+
+- [ ] **Step 2: Add migration**
+
+Add SQL:
+
+```sql
+ALTER TABLE "BusinessContext" ADD COLUMN "sourceSystem" TEXT;
+```
+
+- [ ] **Step 3: Wire API payload**
+
+Accept optional `sourceSystem?: string`, write it on create, and write it on update only when present.
+
+- [ ] **Step 4: Wire page initial state**
+
+Initialize `sourceSystem` from `businessContext?.sourceSystem ?? ""`.
+
+- [ ] **Step 5: Render optional prompt**
+
+Add a text input after "Who do you serve?" with concise helper copy explaining it helps import and migration decisions.
+
+### Task 3: Verify and ship
+
+- [ ] Run targeted tests:
+
+```powershell
+pnpm --filter web exec vitest run apps/web/app/api/business-context/setup/route.test.ts apps/web/components/admin/BusinessContextForm.test.tsx
+pnpm --filter @dpf/db exec vitest run packages/db/src/business-context-source-system-schema.test.ts
+```
+
+- [ ] Run source checks:
+
+```powershell
+pnpm --filter web typecheck
+git diff --check
+```
+
+- [ ] Commit with DCO sign-off, push, open a ready PR, record evidence, and mark `BI-9EFD3C3D` done after the branch is published.

--- a/packages/db/prisma/migrations/20260717033000_add_business_context_source_system/migration.sql
+++ b/packages/db/prisma/migrations/20260717033000_add_business_context_source_system/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "BusinessContext" ADD COLUMN "sourceSystem" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3774,6 +3774,7 @@ model BusinessContext {
   companyStage    String?
   companySize     String?
   geographicScope String?
+  sourceSystem    String?
   // US state/province code driving statutory defaults (records-request response
   // deadlines, retention schedules) for public-sector archetypes. Org-level
   // configuration on seeded obligations — not 50 seed variants (civic spec $10).

--- a/packages/db/src/business-context-source-system-schema.test.ts
+++ b/packages/db/src/business-context-source-system-schema.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(__dirname, "..", "..", "..");
+
+describe("BusinessContext source system schema", () => {
+  it("declares and migrates the optional sourceSystem field", () => {
+    const schema = readFileSync(join(repoRoot, "packages/db/prisma/schema.prisma"), "utf8");
+    expect(schema).toMatch(/model BusinessContext \{[\s\S]*sourceSystem\s+String\?/);
+
+    const migrationPath = join(
+      repoRoot,
+      "packages/db/prisma/migrations/20260717033000_add_business_context_source_system/migration.sql",
+    );
+    expect(existsSync(migrationPath)).toBe(true);
+    expect(readFileSync(migrationPath, "utf8")).toContain('ADD COLUMN "sourceSystem" TEXT');
+  });
+});


### PR DESCRIPTION
## Summary
- add nullable `BusinessContext.sourceSystem` with a migration
- persist the onboarding "switching from" answer through `/api/business-context/setup`
- render the optional source-system prompt in the existing business-context form
- add a compact implementation plan for BI-9EFD3C3D

## Verification
- `pnpm --filter web exec vitest run app/api/business-context/setup/route.test.ts components/admin/BusinessContextForm.test.tsx`
- `pnpm --filter @dpf/db exec vitest run src/business-context-source-system-schema.test.ts`
- `pnpm --filter @dpf/db exec prisma validate`
- `pnpm --filter @dpf/db exec prisma generate`
- `pnpm docs:links`
- `pnpm docs:index:check`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck`

Backlog: BI-9EFD3C3D