### PR TITLE
fix(ci): retighten route-error baseline after #3144 full migration (BI-81EE4A46)

### DIFF
--- a/scripts/route-error-baseline.txt
+++ b/scripts/route-error-baseline.txt
@@ -1,4 +1,3 @@
-apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts	12
 apps/web/app/api/a2a/tasks/[taskId]/route.ts	1
 apps/web/app/api/admin/bs-dispatch-test/route.ts	2
 apps/web/app/api/admin/model-capability-changes/route.ts	2


### PR DESCRIPTION
## What

The a2a coworker offer route's raw `NextResponse.json({ error … })` returns were flagged as growing **10 → 12** in [#3137](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3137). While this fix was in flight, [#3144](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3144) landed and **fully migrated the whole route file** onto the canonical `apiErrorResponse()` envelope (count **12 → 0**) — but it did **not** run the ratchet's `--update`, so `scripts/route-error-baseline.txt` still carried the stale line:

```
apps/web/app/api/a2a/coworkers/[agentId]/offers/[offerId]/route.ts	12
```

`check-no-raw-route-error.mjs` only fails on *growth* (`0 ≤ 12`), so the guard stayed green — but a loose baseline of 12 against a file that now has **0** raw errors would silently permit up to 12 raw errors to regrow there without CI noticing.

## Change

Drop the stale line — the file is fully migrated so it is no longer listed. One-line deletion, pure ratchet retighten, **no code or test change** (the original scoped 10→12 fix drafted here is superseded; #3144 paid down the code debt more completely).

## Verify

```
node scripts/check-no-raw-route-error.mjs
# ✓ No new raw route errors (baseline: 82 files, 282 pending …)  — was 83 files / 294
```

## Follow-up (not in this PR)

Root cause is the same each time: `check-no-raw-route-error` is a **non-required** check, so main can merge with a stale/loose baseline (a migration PR forgetting `--update`, or a debt PR growing the count). Consider promoting it to a required check. That's a branch-protection change (CLASSIC protection) and an operator call, not an in-repo edit — flagging rather than doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)