### PR TITLE
feat(discovery): populate CatalogIdentity on fingerprint-resolved entities (BI-27EE2AF7, EP-ASSET-INTELLIGENCE)

### DIFF
--- a/packages/db/src/discovery-fingerprint-adapter.test.ts
+++ b/packages/db/src/discovery-fingerprint-adapter.test.ts
@@ -47,6 +47,13 @@ describe("matchInventoryEntity", () => {
     expect(result!.combinedConfidence).toBeCloseTo(1.75);
   });
 
+  it("carries the rule's catalogIdentityId through the match (BI-27EE2AF7)", () => {
+    const linked: AdapterRule = { ...baseRule, catalogIdentityId: "ci_postgres" };
+    expect(matchInventoryEntity(obsPostgres, { rules: [linked] })!.catalogIdentityId).toBe("ci_postgres");
+    // A rule not yet linked to the identity spine yields a null catalogIdentityId.
+    expect(matchInventoryEntity(obsPostgres, { rules: [baseRule] })!.catalogIdentityId).toBeNull();
+  });
+
   it("returns the highest-combined-confidence match when multiple match", () => {
     const lowConfRule: AdapterRule = {
       ...baseRule,

--- a/packages/db/src/discovery-fingerprint-adapter.ts
+++ b/packages/db/src/discovery-fingerprint-adapter.ts
@@ -32,6 +32,12 @@ export interface AdapterRule {
   identityConfidence: number;
   taxonomyConfidence: number;
   resolvedIdentity: ResolvedIdentity;
+  /**
+   * Canonical CatalogIdentity this rule resolves to (BI-27EE2AF7 — the enrich
+   * pipeline). Populated by the seed loader (BI-0528AD01); null for rules not
+   * yet linked to the identity spine.
+   */
+  catalogIdentityId?: string | null;
 }
 
 export interface AdapterMatch {
@@ -49,6 +55,8 @@ export interface AdapterMatch {
   combinedConfidence: number;
   /** The matched rule's resolved identity ({kind,name,vendor,model,deviceClass}). */
   resolvedIdentity: ResolvedIdentity;
+  /** Canonical CatalogIdentity the matched rule resolves to, or null (BI-27EE2AF7). */
+  catalogIdentityId: string | null;
 }
 
 /**
@@ -109,5 +117,6 @@ export function matchInventoryEntity(
     taxonomyConfidence: rule.taxonomyConfidence,
     combinedConfidence,
     resolvedIdentity: rule.resolvedIdentity,
+    catalogIdentityId: rule.catalogIdentityId ?? null,
   };
 }

--- a/packages/db/src/discovery-normalize.ts
+++ b/packages/db/src/discovery-normalize.ts
@@ -46,6 +46,10 @@ export type NormalizedInventoryEntity = {
   candidateTaxonomy?: RankedTaxonomyCandidate[];
   providerView: string;
   confidence?: number;
+  // Enrichment linkage (BI-27EE2AF7) — the canonical identity a rule resolved to.
+  catalogIdentityId?: string | null;
+  identityStatus?: string | null;
+  identityConfidence?: number | null;
   properties: Record<string, unknown>;
 };
 
@@ -162,7 +166,11 @@ function fingerprintAttribution(
       identityConfidence: match.identityConfidence,
       taxonomyConfidence: match.taxonomyConfidence,
       resolvedIdentity: match.resolvedIdentity,
+      catalogIdentityId: match.catalogIdentityId,
     },
+    catalogIdentityId: match.catalogIdentityId,
+    identityStatus: match.catalogIdentityId ? "rule_resolved" : null,
+    identityConfidence: match.identityConfidence,
   };
 }
 
@@ -174,6 +182,11 @@ type DerivedAttribution = {
   taxonomyNodeId: string | null;
   candidateTaxonomy: RankedTaxonomyCandidate[];
   evidence: Record<string, unknown>;
+  // Enrichment linkage to the canonical identity spine (BI-27EE2AF7). Set only
+  // on a deterministic fingerprint-rule match that resolves to a CatalogIdentity.
+  catalogIdentityId?: string | null;
+  identityStatus?: string | null;
+  identityConfidence?: number | null;
 };
 
 function mapEntityType(itemType: string): string {
@@ -287,6 +300,9 @@ function normalizeItem(
     attributionConfidence: attributed.confidence,
     attributionEvidence: attributed.evidence,
     candidateTaxonomy: attributed.candidateTaxonomy,
+    catalogIdentityId: attributed.catalogIdentityId ?? null,
+    identityStatus: attributed.identityStatus ?? null,
+    identityConfidence: attributed.identityConfidence ?? null,
     providerView: attributed.portfolioSlug ?? "foundational",
     properties: {
       ...(item.attributes ?? {}),

--- a/packages/db/src/discovery-runner.ts
+++ b/packages/db/src/discovery-runner.ts
@@ -148,6 +148,7 @@ export async function executeBootstrapDiscovery(
                 identityConfidence: true;
                 taxonomyConfidence: true;
                 resolvedIdentity: true;
+                catalogIdentityId: true;
                 taxonomyNode: { select: { nodeId: true } };
               };
             }): Promise<Array<{
@@ -159,6 +160,7 @@ export async function executeBootstrapDiscovery(
               identityConfidence: number;
               taxonomyConfidence: number;
               resolvedIdentity: unknown;
+              catalogIdentityId: string | null;
               taxonomyNode: { nodeId: string } | null;
             }>>;
           };
@@ -173,6 +175,7 @@ export async function executeBootstrapDiscovery(
             identityConfidence: true,
             taxonomyConfidence: true,
             resolvedIdentity: true,
+            catalogIdentityId: true,
             taxonomyNode: { select: { nodeId: true } },
           },
         })).map((rule): AdapterRule => ({
@@ -185,6 +188,7 @@ export async function executeBootstrapDiscovery(
           identityConfidence: rule.identityConfidence,
           taxonomyConfidence: rule.taxonomyConfidence,
           resolvedIdentity: (rule.resolvedIdentity ?? {}) as ResolvedIdentity,
+          catalogIdentityId: rule.catalogIdentityId ?? null,
         }))
       : undefined);
 

--- a/packages/db/src/discovery-sync.ts
+++ b/packages/db/src/discovery-sync.ts
@@ -367,6 +367,12 @@ export async function persistBootstrapDiscoveryRun(
           attributionConfidence: entity.attributionConfidence ?? null,
           attributionEvidence: entity.attributionEvidence ?? null,
           candidateTaxonomy: entity.candidateTaxonomy ?? undefined,
+          // Enrichment linkage to the canonical identity spine (BI-27EE2AF7).
+          catalogIdentity: entity.catalogIdentityId
+            ? { connect: { id: entity.catalogIdentityId } }
+            : undefined,
+          identityStatus: entity.identityStatus ?? null,
+          identityConfidence: entity.identityConfidence ?? null,
           providerView: entity.providerView,
           confidence: entity.confidence ?? null,
           portfolio: entity.portfolioSlug
@@ -404,6 +410,15 @@ export async function persistBootstrapDiscoveryRun(
           attributionConfidence: entity.attributionConfidence ?? null,
           attributionEvidence: entity.attributionEvidence ?? null,
           candidateTaxonomy: entity.candidateTaxonomy ?? undefined,
+          // Enrichment linkage (BI-27EE2AF7) — only written on a fresh rule match
+          // that resolved a CatalogIdentity; never clobber an existing link with null.
+          ...(entity.catalogIdentityId
+            ? {
+                catalogIdentity: { connect: { id: entity.catalogIdentityId } },
+                identityStatus: entity.identityStatus ?? null,
+                identityConfidence: entity.identityConfidence ?? null,
+              }
+            : {}),
           providerView: entity.providerView,
           confidence: entity.confidence ?? null,
           portfolio: entity.portfolioSlug

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -66,5 +66,5 @@ apps/web/lib/work-capsules/work-capsule-store.ts	1041
 apps/web/lib/workbooks/platform-tables.ts	938
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace/command-center.ts	1118
-packages/db/src/discovery-sync.ts	822
+packages/db/src/discovery-sync.ts	837
 packages/db/src/wiki-store.test.ts	824


### PR DESCRIPTION
## What
Cascade step 3 — the **enrich pipeline's deterministic path**. When the existing discovery matcher resolves an `InventoryEntity` to a fingerprint rule, this carries that rule's linked **`CatalogIdentity`** (seeded in #3142) through the match and persists it, so discovered assets link to the canonical identity spine (#3123) instead of stopping at taxonomy placement.

## Flow (all additive)
- **`discovery-fingerprint-adapter`** — `AdapterRule` + `AdapterMatch` carry `catalogIdentityId`; `matchInventoryEntity` projects it.
- **`discovery-runner`** — selects + maps `catalogIdentityId` when loading active rules.
- **`discovery-normalize`** — on a rule match, sets the entity's `catalogIdentityId`, `identityStatus='rule_resolved'`, `identityConfidence`.
- **`discovery-sync`** — writes them on `InventoryEntity` create (unconditional) and update (**guarded** — a later non-matching run never clobbers an existing link with null).
- Module-size baseline: `discovery-sync.ts` 822→837 (ratchet).

## Scope / deferred
Bounded to the deterministic rule → identity linkage. Deferred to follow-ups: `IdentityResolutionLog` audit write, the AI-assisted fallback for the ambiguous tail, and the per-entity inference cost guardrail. **No migration** (schema on main via #3123).

## Verification
Adapter unit test asserts `catalogIdentityId` flows through the match; the discovery-sync tests use `toMatchObject` so the additive fields don't break them; typecheck + tests run in CI.

## Backlog
BI-27EE2AF7 · Epic **EP-ASSET-INTELLIGENCE**. Depends on #3123 (schema) + #3142 (seeded rules), both merged. Next: the support-lifecycle feeds (endoflife.date BI-3A2328D6, NVD/CPE BI-44B8B1E4) now have identities to enrich.

Process-Spine-Decision: extends the existing discovery matcher onto the designed identity spine; no new capability surface.
Design-Grounding-Decision: BI-27EE2AF7

🤖 Generated with [Claude Code](https://claude.com/claude-code)