### PR TITLE
ci: split mobile-only PRs from heavy CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Detects whether a PR touches anything beyond documentation. A docs-only PR
-  # (every changed file under docs/ or ending .md/.mdx) skips the expensive
-  # build/test/typecheck WORK while the required status checks still report
-  # success — the jobs run but short-circuit after this gate. A workflow-level
-  # `paths:` filter cannot be used: a skipped REQUIRED check stays "pending"
-  # forever under branch protection and blocks the merge. Fails safe to
-  # heavy=true on any non-PR event (push to main, future merge_group) or if the
-  # diff cannot be computed. SHAs are passed via env, never interpolated into
-  # the script body (actions-injection-safe).
+  # Detects whether a PR touches documentation, mobile app code, shared mobile
+  # package code, or the broader web/platform surface. Required checks cannot
+  # disappear under branch protection, so jobs run and short-circuit after this
+  # gate instead of relying on workflow-level `paths:` filters. Fails safe to
+  # heavy=true on non-PR events or if the diff cannot be computed.
+  # SHAs are passed via env, never interpolated into the script body
+  # (actions-injection-safe).
   changes:
     name: Detect change scope
     runs-on: ubuntu-latest
@@ -65,14 +63,7 @@ jobs:
           fi
           echo "Changed files:"
           printf '%s\n' "$changed"
-          # Heavy unless EVERY changed file is documentation (docs/ or *.md|*.mdx).
-          if printf '%s\n' "$changed" | grep -qvE '(^docs/|\.mdx?$)'; then
-            echo "-> non-docs changes present: full CI."
-            echo "heavy=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "-> docs-only change: skipping heavy jobs."
-            echo "heavy=false" >> "$GITHUB_OUTPUT"
-          fi
+          printf '%s\n' "$changed" | node scripts/ci-change-scope.mjs --github-output "$GITHUB_OUTPUT"
 
   typecheck:
     name: Typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ e2e-results/
 e2e/debug/
 e2e/.auth/
 test-results/
+apps/mobile/coverage/
 
 # Local agent / codex caches
 .codex/

--- a/docs/superpowers/plans/2026-07-17-mobile-ci-lane.md
+++ b/docs/superpowers/plans/2026-07-17-mobile-ci-lane.md
@@ -1,0 +1,22 @@
+# Mobile CI Lane
+
+## Backlog Item
+
+BI-MOBAPP-CI — Path-filtered mobile CI lane.
+
+## Scope
+
+Complete the path-aware mobile CI split across the existing GitHub Actions workflows. `.github/workflows/mobile-ci.yml` already runs mobile typecheck and Jest for `apps/mobile/**` plus shared mobile package changes; `.github/workflows/ci.yml` still treated mobile app-only PRs as heavyweight and made them wait on the web shard matrix. This slice makes `ci.yml` short-circuit heavyweight required checks for mobile app-only PRs while keeping full CI for shared packages.
+
+## Plan
+
+1. Extract CI change-scope classification into a small tested Node helper.
+2. Extend `.github/workflows/ci.yml` to classify mobile app-only changes as non-heavy.
+3. Preserve full CI for shared packages that can affect web/platform code.
+4. Verify the existing standalone mobile workflow commands locally.
+
+## Verification
+
+- `node --test scripts/ci-change-scope.test.mjs`
+- `pnpm --filter mobile typecheck`
+- `pnpm --filter mobile test:ci`

--- a/scripts/ci-change-scope.mjs
+++ b/scripts/ci-change-scope.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { appendFileSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const DOC_PATTERN = /(^docs\/|\.mdx?$)/;
+const MOBILE_APP_PATTERN = /^apps\/mobile\//;
+const MOBILE_SHARED_PATTERNS = [
+  /^packages\/api-client\//,
+  /^packages\/types\//,
+  /^packages\/validators\//,
+];
+
+export function classifyChangedFiles(files) {
+  const changedFiles = files.map((file) => file.trim()).filter(Boolean);
+
+  if (changedFiles.length === 0) {
+    return { heavy: true, mobile: true, docsOnly: false, mobileOnly: false };
+  }
+
+  const docsOnly = changedFiles.every((file) => DOC_PATTERN.test(file));
+  if (docsOnly) {
+    return { heavy: false, mobile: false, docsOnly: true, mobileOnly: false };
+  }
+
+  const mobileOnly = changedFiles.every((file) => DOC_PATTERN.test(file) || MOBILE_APP_PATTERN.test(file));
+  const mobile = changedFiles.some(
+    (file) => MOBILE_APP_PATTERN.test(file) || MOBILE_SHARED_PATTERNS.some((pattern) => pattern.test(file)),
+  );
+
+  return {
+    heavy: !mobileOnly,
+    mobile,
+    docsOnly: false,
+    mobileOnly,
+  };
+}
+
+function parseArgs(args) {
+  const outputPathIndex = args.indexOf("--github-output");
+  return {
+    githubOutputPath: outputPathIndex >= 0 ? args[outputPathIndex + 1] : undefined,
+  };
+}
+
+function readStdin() {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function writeGitHubOutput(path, result) {
+  if (!path) {
+    return;
+  }
+
+  appendFileSync(path, `heavy=${result.heavy}\n`);
+  appendFileSync(path, `mobile=${result.mobile}\n`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const { githubOutputPath } = parseArgs(process.argv.slice(2));
+  const files = readStdin().split(/\r?\n/);
+  const result = classifyChangedFiles(files);
+  const scope = result.docsOnly ? "docs-only" : result.mobileOnly ? "mobile-only" : "full";
+
+  console.log(`-> ${scope} change: heavy=${result.heavy}, mobile=${result.mobile}`);
+  writeGitHubOutput(githubOutputPath, result);
+}

--- a/scripts/ci-change-scope.test.mjs
+++ b/scripts/ci-change-scope.test.mjs
@@ -1,0 +1,59 @@
+// Run: node --test scripts/ci-change-scope.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyChangedFiles } from "./ci-change-scope.mjs";
+
+test("docs-only changes skip heavy and mobile CI", () => {
+  assert.deepEqual(classifyChangedFiles(["docs/user-guide/mobile.md", "README.md"]), {
+    heavy: false,
+    mobile: false,
+    docsOnly: true,
+    mobileOnly: false,
+  });
+});
+
+test("mobile app-only changes skip heavy CI and run mobile CI", () => {
+  assert.deepEqual(classifyChangedFiles(["apps/mobile/src/session.ts", "apps/mobile/__tests__/session.test.ts"]), {
+    heavy: false,
+    mobile: true,
+    docsOnly: false,
+    mobileOnly: true,
+  });
+});
+
+test("mobile app changes may include documentation without becoming heavy", () => {
+  assert.deepEqual(classifyChangedFiles(["apps/mobile/app/index.tsx", "docs/user-guide/mobile-app.md"]), {
+    heavy: false,
+    mobile: true,
+    docsOnly: false,
+    mobileOnly: true,
+  });
+});
+
+test("shared package changes run full CI and the mobile lane", () => {
+  assert.deepEqual(classifyChangedFiles(["packages/types/src/mobile-manifest.ts"]), {
+    heavy: true,
+    mobile: true,
+    docsOnly: false,
+    mobileOnly: false,
+  });
+});
+
+test("web changes run full CI without the mobile lane", () => {
+  assert.deepEqual(classifyChangedFiles(["apps/web/components/admin/Panel.tsx"]), {
+    heavy: true,
+    mobile: false,
+    docsOnly: false,
+    mobileOnly: false,
+  });
+});
+
+test("empty diff fails safe to full and mobile CI", () => {
+  assert.deepEqual(classifyChangedFiles([]), {
+    heavy: true,
+    mobile: true,
+    docsOnly: false,
+    mobileOnly: false,
+  });
+});


### PR DESCRIPTION
## Summary
- Extract CI change-scope classification into `scripts/ci-change-scope.mjs` with node tests.
- Treat `apps/mobile/**`-only PRs as non-heavy in `.github/workflows/ci.yml`, so required web/db checks short-circuit while the existing standalone Mobile CI workflow runs mobile typecheck and Jest.
- Keep shared mobile package changes on full CI and add `apps/mobile/coverage/` to ignored test artifacts.

## Backlog
- BI-MOBAPP-CI

## Verification
- `node --test scripts/ci-change-scope.test.mjs`
- `pnpm --filter mobile typecheck`
- `pnpm --filter mobile test:ci`
- `git diff --check`
- `BASE_SHA=origin/main node scripts/check-spec-plan-doc.mjs`
- `BASE_SHA=origin/main node scripts/check-design-grounding-decision.mjs`
- `BASE_SHA=origin/main node scripts/check-ux-fit-decision.mjs`
- `BASE_SHA=origin/main node scripts/check-docs-impact.mjs`

UX-Fit-Decision: no user-facing UI surfaces changed; CI workflow latency behavior only.
Docs-Impact-Decision: no documented app route or user-guide behavior changed; implementation plan added under docs/superpowers/plans.
Design-Grounding: reviewed existing `.github/workflows/ci.yml` heavy/docs-only gate and `.github/workflows/mobile-ci.yml` standalone mobile lane before changing scope classification.