### PR TITLE
fix(portfolio): stop recording terminal structural promotion skips as open quality issues

### DIFF
--- a/packages/db/prisma/migrations/20260717030000_resolve_terminal_structural_promotion_issues/migration.sql
+++ b/packages/db/prisma/migrations/20260717030000_resolve_terminal_structural_promotion_issues/migration.sql
@@ -1,0 +1,27 @@
+-- BI-62846516 — Resolve historical terminal-structural promotion skips that were
+-- mistakenly recorded as OPEN portfolio quality issues.
+--
+-- `name_not_promotable` (evidence source `name-gate`) and `type_not_promotable`
+-- (evidence source `structural-type-gate`) are CORRECT "this entity is
+-- infrastructure / a runtime instance, not a digital product" classifications —
+-- the platform's own Docker self-scan (containers, hosts, subnets, NICs,
+-- gateways). They are not actionable gaps and can never be resolved, so they
+-- accumulated as permanent-open noise (378 rows on the Foundational catalog) that
+-- buried the handful of genuinely-fixable issues.
+--
+-- Going forward the promotion runner no longer writes these (see
+-- packages/db/src/discovery-promotion.ts + isTerminalStructuralSkip in
+-- discovery-promotion-policy.ts). This one-shot backfill clears the rows already
+-- persisted under the old behaviour. It is non-destructive: it only flips
+-- status open -> resolved (rows remain for audit). Gated on evidence source so a
+-- genuinely-actionable type_not_promotable (legacy-list / non-auto node policy)
+-- is left open.
+UPDATE "PortfolioQualityIssue"
+SET "status" = 'resolved',
+    "resolvedAt" = NOW()
+WHERE "status" = 'open'
+  AND (
+    ("issueType" = 'name_not_promotable' AND "details" ->> 'source' = 'name-gate')
+    OR
+    ("issueType" = 'type_not_promotable' AND "details" ->> 'source' = 'structural-type-gate')
+  );

--- a/packages/db/src/discovery-promotion-policy.test.ts
+++ b/packages/db/src/discovery-promotion-policy.test.ts
@@ -5,6 +5,8 @@ import {
   isNonProductEntityType,
   classifyEstateProvenance,
   resolvePromotionDecision,
+  isTerminalStructuralSkip,
+  TERMINAL_STRUCTURAL_SKIP_SOURCES,
 } from "./discovery-promotion-policy";
 
 describe("resolvePromotionDecision", () => {
@@ -232,6 +234,66 @@ describe("resolvePromotionDecision — estate provenance", () => {
     const d = resolvePromotionDecision({ ...realDevice, name: "dpf-redis-1", provenance: "real_estate" }, node, portfolio);
     expect(d.decision).toBe("skip");
     expect(d.reason).toBe("name_not_promotable");
+  });
+});
+
+describe("isTerminalStructuralSkip (BI-62846516)", () => {
+  const node = { id: "tn_1", nodeId: "foundational/compute/servers", governance: null };
+  const portfolio = { id: "p_1", slug: "foundational" };
+  const base = {
+    entityType: "application",
+    name: "Real Product",
+    attributionStatus: "attributed" as const,
+    attributionConfidence: 0.95,
+    digitalProductId: null,
+    taxonomyNodeId: "tn_1",
+  };
+
+  it("TERMINAL_STRUCTURAL_SKIP_SOURCES is exactly the two structural gates", () => {
+    expect([...TERMINAL_STRUCTURAL_SKIP_SOURCES].sort()).toEqual([
+      "name-gate",
+      "structural-type-gate",
+    ]);
+  });
+
+  it("classifies a name-gate skip (dpf-redis-1) as terminal", () => {
+    const d = resolvePromotionDecision({ ...base, name: "dpf-redis-1" }, node, portfolio);
+    expect(d.reason).toBe("name_not_promotable");
+    expect(isTerminalStructuralSkip(d)).toBe(true);
+  });
+
+  it("classifies a structural-type-gate skip (host) as terminal", () => {
+    const d = resolvePromotionDecision(
+      { ...base, entityType: "host", name: "LAN Host 172.18.0.5" },
+      node,
+      portfolio,
+    );
+    expect(d.reason).toBe("type_not_promotable");
+    expect(d.evidence.source).toBe("structural-type-gate");
+    expect(isTerminalStructuralSkip(d)).toBe(true);
+  });
+
+  it("does NOT classify actionable gaps (no_taxonomy / low_confidence / no_portfolio_root) as terminal", () => {
+    expect(isTerminalStructuralSkip(resolvePromotionDecision({ ...base, taxonomyNodeId: null }, null, portfolio))).toBe(false);
+    expect(isTerminalStructuralSkip(resolvePromotionDecision({ ...base, attributionConfidence: 0.5 }, node, portfolio))).toBe(false);
+    expect(isTerminalStructuralSkip(resolvePromotionDecision(base, node, null))).toBe(false);
+  });
+
+  it("does NOT classify an actionable legacy-list type_not_promotable as terminal", () => {
+    // A non-infra type with no governance policy is an actionable gap (add a
+    // promotion policy), not a terminal structural rejection — its source is
+    // "legacy-list", not "structural-type-gate".
+    const d = resolvePromotionDecision({ ...base, entityType: "custom_widget" }, node, portfolio);
+    expect(d.reason).toBe("type_not_promotable");
+    expect(d.evidence.source).toBe("legacy-list");
+    expect(isTerminalStructuralSkip(d)).toBe(false);
+  });
+
+  it("does NOT classify a promote decision as terminal", () => {
+    const autoNode = { ...node, governance: { promotion: { mode: "auto" } } };
+    const d = resolvePromotionDecision(base, autoNode, portfolio);
+    expect(d.decision).toBe("promote");
+    expect(isTerminalStructuralSkip(d)).toBe(false);
   });
 });
 

--- a/packages/db/src/discovery-promotion-policy.ts
+++ b/packages/db/src/discovery-promotion-policy.ts
@@ -153,6 +153,47 @@ export type PromotionDecision =
   | { decision: "promote"; classifyAs?: string; reason?: undefined; evidence: PromotionEvidence }
   | { decision: "skip"; classifyAs?: undefined; reason: PromotionSkipReason; evidence: PromotionEvidence };
 
+// ── Terminal structural skips vs. actionable gaps ────────────────────────────
+//
+// A skip decision can mean one of two very different things:
+//
+//   1. A TERMINAL STRUCTURAL classification — "this entity is infrastructure /
+//      a runtime instance, and is CORRECTLY not a digital product." The name-gate
+//      ("dpf-redis-1", raw IPs) and the structural-type-gate (host/container/
+//      subnet/NIC/gateway) produce these. Nothing an operator does will ever make
+//      a Docker container a product; the decision is final and correct.
+//
+//   2. An ACTIONABLE GAP — "this entity could be promoted, but something is
+//      missing/wrong": no_taxonomy (attribute it), low_confidence_promotion
+//      (re-run attribution), no_portfolio_root (seed the portfolio), or a
+//      type_not_promotable from the legacy-list / non-auto node policy (add a
+//      governance.promotion policy).
+//
+// Only class (2) belongs in the operator-facing PortfolioQualityIssue queue.
+// Recording class (1) there was the original design mistake (BI-62846516): the
+// dev install accumulated 378 permanent-open name/type_not_promotable rows for
+// its own Docker self-scan, drowning the handful of real, fixable issues. These
+// are keyed by the decision's `evidence.source`, which is the precise
+// discriminator — `type_not_promotable` alone is ambiguous (it also covers the
+// actionable legacy-list / node-policy cases), but its SOURCE is not.
+export const TERMINAL_STRUCTURAL_SKIP_SOURCES: ReadonlySet<string> = new Set([
+  "name-gate",
+  "structural-type-gate",
+]);
+
+/**
+ * True when a decision is a TERMINAL STRUCTURAL skip — a correct "this is
+ * infrastructure, not a product" classification that must NOT be surfaced as an
+ * open portfolio quality issue (it can never be resolved). Distinguished from
+ * actionable gaps by `evidence.source`, not by the skip `reason` (which is
+ * ambiguous for `type_not_promotable`). Returns false for promote decisions.
+ */
+export function isTerminalStructuralSkip(decision: PromotionDecision): boolean {
+  if (decision.decision !== "skip") return false;
+  const source = decision.evidence.source;
+  return typeof source === "string" && TERMINAL_STRUCTURAL_SKIP_SOURCES.has(source);
+}
+
 /**
  * Loose input shapes — callers may pass richer Prisma rows; only these
  * fields are read.

--- a/packages/db/src/discovery-promotion.test.ts
+++ b/packages/db/src/discovery-promotion.test.ts
@@ -127,7 +127,11 @@ describe("promoteInventoryEntities", () => {
 
   // --- Task 2.1 new behaviors ---
 
-  it("skips network_client (no governance.promotion) with type_not_promotable + writes quality issue", async () => {
+  it("skips network_client (structural-type-gate) WITHOUT writing a quality issue — terminal, not actionable (BI-62846516)", async () => {
+    // network_client is infrastructure: the structural-type-gate correctly skips
+    // it. That is a terminal classification, not an actionable gap, so it must
+    // NOT open a PortfolioQualityIssue (these accumulated as permanent-open noise
+    // burying the real queue). Still counted as skipped from promotion.
     mockPrisma.inventoryEntity.findMany.mockResolvedValue([{
       id: "ent_nc",
       entityKey: "network_client:1",
@@ -151,19 +155,17 @@ describe("promoteInventoryEntities", () => {
     expect(result.promoted).toBe(0);
     expect(result.skipped).toBe(1);
     expect(mockPrisma.digitalProduct.upsert).not.toHaveBeenCalled();
-    expect(mockPrisma.portfolioQualityIssue.upsert).toHaveBeenCalledTimes(1);
-    const upsertArgs = mockPrisma.portfolioQualityIssue.upsert.mock.calls[0][0];
-    expect(upsertArgs.where.issueKey).toContain("type_not_promotable");
-    expect(upsertArgs.create.issueType).toBe("type_not_promotable");
+    expect(mockPrisma.portfolioQualityIssue.upsert).not.toHaveBeenCalled();
   });
 
-  it("skips an infra entityType (network_client) even with auto governance.promotion + classifyAs", async () => {
+  it("skips an infra entityType (network_client) with auto policy WITHOUT writing a quality issue", async () => {
     // Estate-accuracy structural-type-gate: a network_client is infrastructure,
     // never a product — even when its taxonomy node
     // ("foundational/network_management/network_connectivity") is mode:auto with
     // classifyAs:"infrastructure_endpoint" and the name clears the runtime-
     // artifact name-gate. This is the live leak that promoted "Access Point" /
-    // "eth0 (172.18.0.11)" rows into the product portfolio.
+    // "eth0 (172.18.0.11)" rows into the product portfolio. The skip is terminal
+    // (source structural-type-gate) so it opens no quality issue (BI-62846516).
     mockPrisma.inventoryEntity.findMany.mockResolvedValue([{
       id: "ent_nc2",
       entityKey: "network_client:2",
@@ -187,8 +189,36 @@ describe("promoteInventoryEntities", () => {
     expect(result.promoted).toBe(0);
     expect(result.skipped).toBe(1);
     expect(mockPrisma.digitalProduct.upsert).not.toHaveBeenCalled();
-    const issueArgs = mockPrisma.portfolioQualityIssue.upsert.mock.calls[0][0];
-    expect(issueArgs.create.issueType).toBe("type_not_promotable");
+    expect(mockPrisma.portfolioQualityIssue.upsert).not.toHaveBeenCalled();
+  });
+
+  it("skips a runtime-named entity (name-gate) WITHOUT writing a quality issue — terminal (BI-62846516)", async () => {
+    // "dpf-redis-1" is structurally a container. The name-gate skip is terminal;
+    // no PortfolioQualityIssue is opened even though gates 1-3 passed.
+    mockPrisma.inventoryEntity.findMany.mockResolvedValue([{
+      id: "ent_rt",
+      entityKey: "container:dpf-redis-1",
+      entityType: "database",
+      name: "dpf-redis-1",
+      attributionStatus: "attributed",
+      attributionConfidence: 0.98,
+      taxonomyNodeId: "tn_db",
+      digitalProductId: null,
+      properties: {},
+    }]);
+    mockPrisma.taxonomyNode.findUnique.mockResolvedValue({
+      id: "tn_db",
+      nodeId: "foundational/data_and_storage_management/database",
+      governance: { promotion: { mode: "auto" } },
+    });
+    mockPrisma.portfolio.findUnique.mockResolvedValue({ id: "port_1" });
+
+    const result = await promoteInventoryEntities(mockPrisma as never);
+
+    expect(result.promoted).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(mockPrisma.digitalProduct.upsert).not.toHaveBeenCalled();
+    expect(mockPrisma.portfolioQualityIssue.upsert).not.toHaveBeenCalled();
   });
 
   it("skips low-confidence entity with low_confidence_promotion + writes quality issue", async () => {

--- a/packages/db/src/discovery-promotion.ts
+++ b/packages/db/src/discovery-promotion.ts
@@ -14,6 +14,7 @@
 import {
   resolvePromotionDecision,
   classifyEstateProvenance,
+  isTerminalStructuralSkip,
   type PromotionTaxonomyNodeInput,
 } from "./discovery-promotion-policy";
 import {
@@ -188,17 +189,28 @@ export async function promoteInventoryEntities(db: PromotionDb): Promise<Promoti
       );
 
       if (decision.decision === "skip") {
-        await openOrUpdateQualityIssue({
-          db,
-          issueType: decision.reason,
-          scope: {
-            inventoryEntityId: entity.id,
-            taxonomyNodeId: taxonomyNode?.id,
-            portfolioId: portfolio?.id,
-          },
-          summary: skipSummaryFor(decision.reason, entity.entityKey, entity.entityType),
-          details: decision.evidence,
-        });
+        // Terminal structural skips (name-gate / structural-type-gate) are
+        // CORRECT "this is infrastructure, not a product" classifications — not
+        // actionable gaps. Recording them as open PortfolioQualityIssue rows was
+        // the original design mistake (BI-62846516): they can never be resolved,
+        // so the platform's own Docker self-scan accumulated 378 permanent-open
+        // rows that buried the real, fixable issues. Skip the write; still count
+        // the entity as skipped from promotion. Actionable skips (no_taxonomy,
+        // low_confidence_promotion, no_portfolio_root, legacy-list/node-policy
+        // type_not_promotable) still open a quality issue below.
+        if (!isTerminalStructuralSkip(decision)) {
+          await openOrUpdateQualityIssue({
+            db,
+            issueType: decision.reason,
+            scope: {
+              inventoryEntityId: entity.id,
+              taxonomyNodeId: taxonomyNode?.id,
+              portfolioId: portfolio?.id,
+            },
+            summary: skipSummaryFor(decision.reason, entity.entityKey, entity.entityType),
+            details: decision.evidence,
+          });
+        }
         summary.skipped++;
         continue;
       }


### PR DESCRIPTION
## Problem
The Foundational product catalog surfaced **OPEN ISSUES 378** (323 `name_not_promotable` + 55 `type_not_promotable`). The operator flagged it as concerning / possibly a design problem.

## Root cause (evidence-backed against the live dev DB)
Every one of the 378 is a **correct** "this entity is infrastructure, not a digital product" classification of the platform's own Docker/self-scan:

| entityType | count |
|---|---|
| container | 185 |
| host | 129 |
| network_interface | 28 |
| subnet | 16 |
| monitoring_service | 16 |
| gateway | 3 |
| docker_host | 1 |

All 378 come from exactly two **terminal structural gates**: `name-gate` (323) + `structural-type-gate` (55).

This is a **design flaw, not a policy bug**: the discovery→portfolio promotion runner funneled these terminal structural rejections into the same `PortfolioQualityIssue` queue used for *actionable* gaps. They can never resolve (a Docker container is permanently not a product), so they accumulated as permanent-open noise burying the handful of real, fixable issues. On the Foundational catalog they were **100%** of the open-issues count.

## Fix
1. `isTerminalStructuralSkip()` + `TERMINAL_STRUCTURAL_SKIP_SOURCES` (`name-gate`, `structural-type-gate`) in `discovery-promotion-policy.ts`. Keyed on `evidence.source` — the precise discriminator, since `type_not_promotable` alone is ambiguous (it also covers actionable legacy-list / non-auto node-policy cases) but its *source* is not.
2. `promoteInventoryEntities` no longer opens a quality issue for terminal structural skips (still counts them as skipped). Actionable skips (`no_taxonomy`, `low_confidence_promotion`, `no_portfolio_root`, legacy-list / node-policy `type_not_promotable`) still open issues.
3. Data migration resolves the 378 rows already persisted under the old behaviour — non-destructive (`open` → `resolved`), gated on evidence source so genuinely-actionable rows are left open.

## Verification
- Policy classification exercised against the real source: **16/16**.
- Real `promoteInventoryEntities` driven with a mock db: writes **0** issues for terminal skips (host + `dpf-redis-1`), **1** for the actionable legacy-list case, promotes the real product.
- Migration `WHERE` previewed on the live DB: resolves **exactly 378**, zero collateral. Foundational panel goes 378 → 0.
- Local typecheck skipped (source-only worktree, no `node_modules`); CI Typecheck / Unit / Prod Build / DCO gate the merge.

## Out of scope (flagged for follow-up)
The full `PortfolioQualityIssue` table has ~2,247 open rows dominated by `stale_relationship` (1,370, null-portfolio) + `stale_entity` / `catalog_match_ambiguous` / `lifecycle_unverified`. These don't surface on the portfolio panel but warrant a separate staleness-churn review.

BI-62846516

🤖 Generated with [Claude Code](https://claude.com/claude-code)