### PR TITLE
feat(healthcare): add intake review controls

### DIFF
--- a/apps/web/app/api/v1/healthcare/intake/[packetId]/access-grants/[grantId]/revoke/route.ts
+++ b/apps/web/app/api/v1/healthcare/intake/[packetId]/access-grants/[grantId]/revoke/route.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+import { requireCapability, requireEmployeeAuth } from "@/lib/api/auth-middleware";
+import { ApiError, apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { revokeCareIntakeAccessGrant } from "@/lib/healthcare/care-intake-review-repository";
+
+const RevokeBody = z.object({
+  organizationId: z.string().min(1).max(128),
+  reason: z.string().trim().min(1).max(500),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ packetId: string; grantId: string }> },
+) {
+  try {
+    const { capabilities, authContext } = await requireEmployeeAuth(request);
+    requireCapability(capabilities, "operate_customer");
+    if (!authContext.principalId) return apiError("PRINCIPAL_REQUIRED", "Relational principal required", 403).toResponse();
+    const parsed = RevokeBody.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return apiError("INVALID_REQUEST", "Invalid grant revocation", 400).toResponse();
+    const { packetId, grantId } = await params;
+    return apiSuccess(await revokeCareIntakeAccessGrant({
+      ...parsed.data,
+      packetId,
+      grantId,
+      actorPrincipalId: authContext.principalId,
+    }));
+  } catch (error) {
+    if (error instanceof ApiError) return error.toResponse();
+    if (error instanceof Error) {
+      if (error.message === "stale-intake-grant") {
+        return apiError("STALE_INTAKE_GRANT", "The intake grant changed; refresh before revoking", 409).toResponse();
+      }
+      if (error.message.includes("not found")) {
+        return apiError("INTAKE_GRANT_NOT_FOUND", "Active intake grant not found", 404).toResponse();
+      }
+    }
+    return apiError("INTERNAL_ERROR", "An unexpected error occurred", 500).toResponse();
+  }
+}

--- a/apps/web/app/api/v1/healthcare/intake/review/route.ts
+++ b/apps/web/app/api/v1/healthcare/intake/review/route.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+import { requireCapability, requireEmployeeAuth } from "@/lib/api/auth-middleware";
+import { ApiError, apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { listCareIntakeReviewQueue } from "@/lib/healthcare/care-intake-review-repository";
+
+const Query = z.object({
+  organizationId: z.string().min(1).max(128),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  status: z.enum(["assigned", "in-progress", "amended"]).array().optional(),
+});
+
+export async function GET(request: Request) {
+  try {
+    const { capabilities, authContext } = await requireEmployeeAuth(request);
+    requireCapability(capabilities, "view_customer");
+    if (!authContext.principalId) return apiError("PRINCIPAL_REQUIRED", "Relational principal required", 403).toResponse();
+    const url = new URL(request.url);
+    const parsed = Query.safeParse({
+      organizationId: url.searchParams.get("organizationId"),
+      limit: url.searchParams.get("limit") ?? undefined,
+      status: url.searchParams.getAll("status").length ? url.searchParams.getAll("status") : undefined,
+    });
+    if (!parsed.success) return apiError("INVALID_REQUEST", "Invalid intake review query", 400).toResponse();
+    return apiSuccess(await listCareIntakeReviewQueue({
+      organizationId: parsed.data.organizationId,
+      actorPrincipalId: authContext.principalId,
+      limit: parsed.data.limit,
+      statuses: parsed.data.status,
+    }));
+  } catch (error) {
+    if (error instanceof ApiError) return error.toResponse();
+    return apiError("INTERNAL_ERROR", "An unexpected error occurred", 500).toResponse();
+  }
+}

--- a/apps/web/lib/api/__tests__/healthcare-intake-review-endpoints.test.ts
+++ b/apps/web/lib/api/__tests__/healthcare-intake-review-endpoints.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../api/auth-middleware.js", () => ({
+  requireEmployeeAuth: vi.fn(),
+  requireCapability: vi.fn(),
+}));
+vi.mock("../../healthcare/care-intake-review-repository.js", () => ({
+  listCareIntakeReviewQueue: vi.fn(),
+  revokeCareIntakeAccessGrant: vi.fn(),
+}));
+
+import { POST as revokeGrant } from "../../../app/api/v1/healthcare/intake/[packetId]/access-grants/[grantId]/revoke/route.js";
+import { GET as reviewQueue } from "../../../app/api/v1/healthcare/intake/review/route.js";
+import { requireCapability, requireEmployeeAuth } from "../../api/auth-middleware.js";
+import { listCareIntakeReviewQueue, revokeCareIntakeAccessGrant } from "../../healthcare/care-intake-review-repository.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireEmployeeAuth).mockResolvedValue({
+    user: { id: "user-reception", type: "admin" } as never,
+    capabilities: ["view_customer", "operate_customer"],
+    authContext: { principalId: "principal-receptionist" } as never,
+  });
+});
+
+describe("healthcare intake receptionist endpoints", () => {
+  it("requires the customer-view capability and passes the authenticated principal", async () => {
+    vi.mocked(listCareIntakeReviewQueue).mockResolvedValue({ items: [] });
+    const response = await reviewQueue(new Request("http://localhost/api/v1/healthcare/intake/review?organizationId=org-a"));
+    expect(response.status).toBe(200);
+    expect(requireCapability).toHaveBeenCalledWith(["view_customer", "operate_customer"], "view_customer");
+    expect(listCareIntakeReviewQueue).toHaveBeenCalledWith(expect.objectContaining({
+      organizationId: "org-a", actorPrincipalId: "principal-receptionist",
+    }));
+  });
+
+  it("requires the customer-operate capability for grant revocation", async () => {
+    vi.mocked(revokeCareIntakeAccessGrant).mockResolvedValue({
+      grantId: "grant-a", status: "revoked", revokedAt: new Date("2026-08-01"),
+    });
+    const response = await revokeGrant(new Request("http://localhost", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ organizationId: "org-a", reason: "patient-requested" }),
+    }), { params: Promise.resolve({ packetId: "intake-a", grantId: "grant-a" }) });
+    expect(response.status).toBe(200);
+    expect(requireCapability).toHaveBeenCalledWith(["view_customer", "operate_customer"], "operate_customer");
+    expect(revokeCareIntakeAccessGrant).toHaveBeenCalledWith(expect.objectContaining({
+      packetId: "intake-a", grantId: "grant-a", actorPrincipalId: "principal-receptionist",
+    }));
+  });
+});

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 557,
+  "routeCount": 559,
   "routes": [
     {
       "routePath": "/",
@@ -2753,6 +2753,25 @@
       "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/access-grants/route.ts"
     },
     {
+      "routePath": "/api/v1/healthcare/intake/[packetId]/access-grants/[grantId]/revoke",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "healthcare",
+        "intake",
+        "[packetId]",
+        "access-grants",
+        "[grantId]",
+        "revoke"
+      ],
+      "dynamicParams": [
+        "packetId",
+        "grantId"
+      ],
+      "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/access-grants/[grantId]/revoke/route.ts"
+    },
+    {
       "routePath": "/api/v1/healthcare/intake/[packetId]/responses/[formId]",
       "kind": "route",
       "segments": [
@@ -2785,6 +2804,19 @@
         "packetId"
       ],
       "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/submit/route.ts"
+    },
+    {
+      "routePath": "/api/v1/healthcare/intake/review",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "healthcare",
+        "intake",
+        "review"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/api/v1/healthcare/intake/review/route.ts"
     },
     {
       "routePath": "/api/v1/integrations/coverage",

--- a/apps/web/lib/healthcare/care-intake-review-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-review-repository.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  listCareIntakeReviewQueue,
+  revokeCareIntakeAccessGrant,
+  type CareIntakeReviewDatabase,
+} from "./care-intake-review-repository";
+
+function database() {
+  const tx = {
+    $executeRaw: vi.fn().mockResolvedValue(1),
+    careIntakePacket: {
+      findMany: vi.fn().mockResolvedValue([{
+        id: "packet-row-a", packetId: "intake-a", patientProfileId: "patient-a",
+        appointmentId: "appointment-a", status: "in-progress", version: 2,
+        sourceMode: "staff-assisted", dueAt: null, completionPercent: 50,
+        requirementSnapshot: [{
+          dynamicFormId: "form-a", dynamicFormVersion: 1, linkId: "visit-reason",
+          dataCategory: "visit-reason", required: true,
+        }],
+        requiredConsentCount: 0, requiresCoverageEvidence: false,
+        responses: [{ answeredLinkIds: ["visit-reason"], sourceMode: "staff-assisted", status: "in-progress", authoredAt: new Date("2026-08-01") }],
+        exceptions: [], consentAttestations: [], coverageEvidence: [],
+        accessGrants: [{ grantId: "grant-a", granteePrincipalId: "principal-patient-a", permittedOperations: ["view"], expiresAt: new Date("2026-08-02"), lastUsedAt: null, revokedAt: null }],
+      }]),
+      findFirst: vi.fn().mockResolvedValue({ id: "packet-row-a", packetId: "intake-a", patientProfileId: "patient-a" }),
+    },
+    careIntakeAccessGrant: {
+      findFirst: vi.fn().mockResolvedValue({ grantId: "grant-a", revokedAt: null }),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    authorizationDecisionLog: { create: vi.fn().mockResolvedValue({}) },
+  };
+  return { tx, db: { $transaction: vi.fn((callback) => callback(tx)) } as unknown as CareIntakeReviewDatabase };
+}
+
+describe("care intake receptionist review repository", () => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));
+
+  it("returns readiness and provenance without response answer payloads", async () => {
+    const { db, tx } = database();
+    const result = await listCareIntakeReviewQueue({
+      organizationId: "org-a", actorPrincipalId: "principal-receptionist", limit: 25,
+    }, db);
+
+    expect(result.items[0]).toEqual(expect.objectContaining({
+      packetId: "intake-a", ready: true, completionPercent: 100,
+      sourceModes: ["staff-assisted"], openExceptions: [],
+    }));
+    expect(JSON.stringify(result)).not.toContain("answers");
+    expect(tx.authorizationDecisionLog.create).toHaveBeenCalledWith({ data: expect.objectContaining({
+      actorRef: "principal-receptionist", actionKey: "healthcare.intake.review",
+      purposeOfUse: "intake-review", decision: "allow",
+    }) });
+  });
+
+  it("revokes only an active grant and records immutable decision evidence", async () => {
+    const { db, tx } = database();
+    const result = await revokeCareIntakeAccessGrant({
+      organizationId: "org-a", packetId: "intake-a", grantId: "grant-a",
+      actorPrincipalId: "principal-receptionist", reason: "patient-requested",
+    }, db);
+
+    expect(result).toEqual({ grantId: "grant-a", status: "revoked", revokedAt: new Date("2026-08-01T14:00:00.000Z") });
+    expect(tx.careIntakeAccessGrant.updateMany).toHaveBeenCalledWith({
+      where: { grantId: "grant-a", packetId: "packet-row-a", organizationId: "org-a", revokedAt: null },
+      data: { revokedAt: new Date("2026-08-01T14:00:00.000Z"), revocationReason: "patient-requested" },
+    });
+    expect(tx.authorizationDecisionLog.create).toHaveBeenCalledWith({ data: expect.objectContaining({
+      actionKey: "healthcare.intake.grant.revoke", objectRef: "care-intake-grant:grant-a",
+    }) });
+  });
+});

--- a/apps/web/lib/healthcare/care-intake-review-repository.ts
+++ b/apps/web/lib/healthcare/care-intake-review-repository.ts
@@ -1,0 +1,203 @@
+import { randomUUID } from "node:crypto";
+
+import { prisma } from "@dpf/db";
+import {
+  calculateIntakeReadiness,
+  type CareIntakeRequirement,
+} from "@dpf/db/healthcare-care-intake";
+
+type ReviewPacketRow = {
+  id: string;
+  packetId: string;
+  patientProfileId: string;
+  appointmentId: string | null;
+  status: string;
+  version: number;
+  sourceMode: string;
+  dueAt: Date | null;
+  completionPercent: number;
+  requirementSnapshot: unknown;
+  requiredConsentCount: number;
+  requiresCoverageEvidence: boolean;
+  responses: Array<{ answeredLinkIds: string[]; sourceMode: string; status: string; authoredAt: Date }>;
+  exceptions: Array<{ exceptionId: string; exceptionType: string; status: string; severity: string; summary: string; assignedToPrincipalId: string | null }>;
+  consentAttestations: Array<{ status: string }>;
+  coverageEvidence: Array<{ status: string }>;
+  accessGrants: Array<{
+    grantId: string; granteePrincipalId: string | null; permittedOperations: string[];
+    expiresAt: Date; lastUsedAt: Date | null; revokedAt: Date | null;
+  }>;
+};
+
+type Transaction = {
+  $executeRaw(query: TemplateStringsArray, ...values: unknown[]): Promise<number>;
+  careIntakePacket: {
+    findMany(args: unknown): Promise<ReviewPacketRow[]>;
+    findFirst(args: unknown): Promise<{ id: string; packetId: string; patientProfileId: string } | null>;
+  };
+  careIntakeAccessGrant: {
+    findFirst(args: unknown): Promise<{ grantId: string; revokedAt: Date | null } | null>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  authorizationDecisionLog: { create(args: unknown): Promise<unknown> };
+};
+
+export type CareIntakeReviewDatabase = {
+  $transaction<T>(callback: (tx: Transaction) => Promise<T>): Promise<T>;
+};
+
+function requirements(value: unknown): CareIntakeRequirement[] {
+  if (!Array.isArray(value)) throw new Error("Invalid intake requirement snapshot");
+  return value as CareIntakeRequirement[];
+}
+
+async function setStaffReviewContext(
+  tx: Transaction,
+  input: { organizationId: string; actorPrincipalId: string },
+) {
+  await tx.$executeRaw`SELECT set_config('app.organization_id', ${input.organizationId}, true), set_config('app.care_intake_staff_principal_id', ${input.actorPrincipalId}, true), set_config('app.care_intake_access_purpose', 'intake-review', true)`;
+}
+
+async function recordAccessDecision(
+  tx: Transaction,
+  input: {
+    organizationId: string;
+    actorPrincipalId: string;
+    actionKey: string;
+    objectRef: string;
+    rationale: Record<string, unknown>;
+  },
+) {
+  await tx.authorizationDecisionLog.create({
+    data: {
+      decisionId: `intake-staff-decision-${randomUUID()}`,
+      actorType: "user",
+      actorRef: input.actorPrincipalId,
+      organizationId: input.organizationId,
+      purposeOfUse: "intake-review",
+      policyVersion: "healthcare-intake-staff-review/v1",
+      actionKey: input.actionKey,
+      objectRef: input.objectRef,
+      decision: "allow",
+      rationale: input.rationale,
+      routeContext: "/api/v1/healthcare/intake/review",
+      sensitivityLevel: "restricted",
+    },
+  });
+}
+
+export async function listCareIntakeReviewQueue(
+  input: {
+    organizationId: string;
+    actorPrincipalId: string;
+    limit?: number;
+    statuses?: string[];
+  },
+  database: CareIntakeReviewDatabase = prisma as unknown as CareIntakeReviewDatabase,
+) {
+  const limit = Math.min(Math.max(input.limit ?? 25, 1), 100);
+  return database.$transaction(async (tx) => {
+    await setStaffReviewContext(tx, input);
+    const packets = await tx.careIntakePacket.findMany({
+      where: {
+        organizationId: input.organizationId,
+        status: input.statuses?.length ? { in: input.statuses } : { in: ["assigned", "in-progress", "amended"] },
+      },
+      orderBy: [{ dueAt: "asc" }, { createdAt: "asc" }],
+      take: limit,
+      select: {
+        id: true, packetId: true, patientProfileId: true, appointmentId: true,
+        status: true, version: true, sourceMode: true, dueAt: true,
+        completionPercent: true, requirementSnapshot: true,
+        requiredConsentCount: true, requiresCoverageEvidence: true,
+        responses: {
+          where: { status: { not: "entered-in-error" } },
+          select: { answeredLinkIds: true, sourceMode: true, status: true, authoredAt: true },
+        },
+        exceptions: {
+          where: { status: { in: ["open", "in-progress"] } },
+          select: { exceptionId: true, exceptionType: true, status: true, severity: true, summary: true, assignedToPrincipalId: true },
+        },
+        consentAttestations: { select: { status: true } },
+        coverageEvidence: { select: { status: true } },
+        accessGrants: {
+          select: { grantId: true, granteePrincipalId: true, permittedOperations: true, expiresAt: true, lastUsedAt: true, revokedAt: true },
+        },
+      },
+    });
+    const items = packets.map((packet) => {
+      const readiness = calculateIntakeReadiness({
+        requirements: requirements(packet.requirementSnapshot),
+        answeredLinkIds: [...new Set(packet.responses.flatMap((response) => response.answeredLinkIds))],
+        unresolvedExceptionCount: packet.exceptions.length,
+        requiredConsentCount: packet.requiredConsentCount,
+        acceptedConsentCount: packet.consentAttestations.filter((row) => row.status === "accepted").length,
+        requiredCoverageEvidence: packet.requiresCoverageEvidence,
+        acceptedCoverageEvidenceCount: packet.coverageEvidence.filter((row) => row.status === "accepted").length,
+      });
+      return {
+        packetId: packet.packetId,
+        patientProfileId: packet.patientProfileId,
+        appointmentId: packet.appointmentId,
+        status: packet.status,
+        version: packet.version,
+        dueAt: packet.dueAt,
+        ready: readiness.ready,
+        completionPercent: readiness.completionPercent,
+        blockers: readiness.blockers,
+        missingRequiredLinkIds: readiness.missingRequiredLinkIds,
+        sourceModes: [...new Set([packet.sourceMode, ...packet.responses.map((response) => response.sourceMode)])].sort(),
+        openExceptions: packet.exceptions,
+        accessGrants: packet.accessGrants,
+      };
+    });
+    await recordAccessDecision(tx, {
+      organizationId: input.organizationId,
+      actorPrincipalId: input.actorPrincipalId,
+      actionKey: "healthcare.intake.review",
+      objectRef: `care-intake-review:${input.organizationId}`,
+      rationale: { resultCount: items.length, payloadProjection: "readiness-no-answers" },
+    });
+    return { items };
+  });
+}
+
+export async function revokeCareIntakeAccessGrant(
+  input: {
+    organizationId: string;
+    packetId: string;
+    grantId: string;
+    actorPrincipalId: string;
+    reason: string;
+  },
+  database: CareIntakeReviewDatabase = prisma as unknown as CareIntakeReviewDatabase,
+) {
+  if (!input.reason.trim() || input.reason.length > 500) throw new Error("Invalid revocation reason");
+  return database.$transaction(async (tx) => {
+    await setStaffReviewContext(tx, input);
+    const packet = await tx.careIntakePacket.findFirst({
+      where: { packetId: input.packetId, organizationId: input.organizationId },
+      select: { id: true, packetId: true, patientProfileId: true },
+    });
+    if (!packet) throw new Error("Care intake packet not found");
+    const grant = await tx.careIntakeAccessGrant.findFirst({
+      where: { grantId: input.grantId, packetId: packet.id, organizationId: input.organizationId },
+      select: { grantId: true, revokedAt: true },
+    });
+    if (!grant || grant.revokedAt) throw new Error("Active care intake grant not found");
+    const revokedAt = new Date();
+    const updated = await tx.careIntakeAccessGrant.updateMany({
+      where: { grantId: input.grantId, packetId: packet.id, organizationId: input.organizationId, revokedAt: null },
+      data: { revokedAt, revocationReason: input.reason.trim() },
+    });
+    if (updated.count !== 1) throw new Error("stale-intake-grant");
+    await recordAccessDecision(tx, {
+      organizationId: input.organizationId,
+      actorPrincipalId: input.actorPrincipalId,
+      actionKey: "healthcare.intake.grant.revoke",
+      objectRef: `care-intake-grant:${input.grantId}`,
+      rationale: { packetId: input.packetId, reason: input.reason.trim() },
+    });
+    return { grantId: input.grantId, status: "revoked" as const, revokedAt };
+  });
+}

--- a/docs/superpowers/plans/2026-07-16-healthcare-digital-intake.md
+++ b/docs/superpowers/plans/2026-07-16-healthcare-digital-intake.md
@@ -99,6 +99,17 @@ submit completes current responses and advances the packet with one optimistic,
 append-only status event. An incomplete submit returns blocker codes and never
 advances packet state.
 
+Receptionist access uses the existing intake records rather than a duplicate
+projection store. Employee routes require `view_customer` for review and
+`operate_customer` for revocation, then establish an organization-bound,
+actor-and-purpose-scoped `intake-review` database context. Additive RLS policies
+grant that context `SELECT` only; the sole staff mutation policy permits
+`UPDATE` on access grants for revocation. Repository projections explicitly
+exclude response answers and document/signature payloads, and each allowed
+review or revocation writes canonical `AuthorizationDecisionLog` evidence.
+This implements workforce role-based minimum-necessary access and audit-control
+expectations without weakening the patient bearer-token policies.
+
 Rollback for 2A is route and repository removal; it adds no schema migration.
 Existing Phase 1 tables remain forward-compatible and contain no raw resume
 tokens.

--- a/packages/db/prisma/migrations/20260717032000_allow_staff_intake_review/migration.sql
+++ b/packages/db/prisma/migrations/20260717032000_allow_staff_intake_review/migration.sql
@@ -1,0 +1,49 @@
+-- BI-HEALTHCARE-012 Phase 2B: receptionist review needs organization-wide,
+-- payload-minimized visibility while patient self-service remains subject-only.
+-- Staff context is set only after employee capability authorization and is
+-- bound to an actor principal plus the exact intake-review purpose.
+-- @migration-safety: data-safe: adds RLS policies only; no rows or constraints are changed.
+
+DO $$
+DECLARE
+  table_name TEXT;
+  policy_name TEXT;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'CareIntakePacket',
+    'CareIntakeResponse',
+    'CareIntakeAccessGrant',
+    'CareConsentAttestation',
+    'CareCoverageEvidence',
+    'CareIntakeException',
+    'CareIntakeStatusEvent'
+  ]
+  LOOP
+    policy_name := table_name || '_staff_review_select_policy';
+    EXECUTE format('DROP POLICY IF EXISTS %I ON %I', policy_name, table_name);
+    EXECUTE format(
+      'CREATE POLICY %I ON %I FOR SELECT USING ('
+      || '"organizationId" = NULLIF(current_setting(''app.organization_id'', true), '''') '
+      || 'AND NULLIF(current_setting(''app.care_intake_staff_principal_id'', true), '''') IS NOT NULL '
+      || 'AND current_setting(''app.care_intake_access_purpose'', true) = ''intake-review'')',
+      policy_name,
+      table_name
+    );
+  END LOOP;
+END $$;
+
+DROP POLICY IF EXISTS "CareIntakeAccessGrant_staff_revoke_update_policy"
+  ON "CareIntakeAccessGrant";
+CREATE POLICY "CareIntakeAccessGrant_staff_revoke_update_policy"
+  ON "CareIntakeAccessGrant"
+  FOR UPDATE
+  USING (
+    "organizationId" = NULLIF(current_setting('app.organization_id', true), '')
+    AND NULLIF(current_setting('app.care_intake_staff_principal_id', true), '') IS NOT NULL
+    AND current_setting('app.care_intake_access_purpose', true) = 'intake-review'
+  )
+  WITH CHECK (
+    "organizationId" = NULLIF(current_setting('app.organization_id', true), '')
+    AND NULLIF(current_setting('app.care_intake_staff_principal_id', true), '') IS NOT NULL
+    AND current_setting('app.care_intake_access_purpose', true) = 'intake-review'
+  );

--- a/packages/db/src/healthcare-care-intake-staff-rls.test.ts
+++ b/packages/db/src/healthcare-care-intake-staff-rls.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  resolve(process.cwd(), "prisma/migrations/20260717032000_allow_staff_intake_review/migration.sql"),
+  "utf8",
+);
+
+describe("healthcare intake staff review RLS", () => {
+  it("adds purpose-and-actor-bound select policies without replacing patient policies", () => {
+    expect(migration).toContain("FOR SELECT USING");
+    expect(migration).toContain("app.care_intake_staff_principal_id");
+    expect(migration).toContain("app.care_intake_access_purpose");
+    expect(migration).toContain("intake-review");
+    expect(migration).not.toContain("_context_policy';\n    EXECUTE format('DROP POLICY");
+  });
+
+  it("limits staff mutation policy to access-grant revocation updates", () => {
+    expect(migration).toContain('CareIntakeAccessGrant_staff_revoke_update_policy');
+    expect(migration.match(/FOR UPDATE/g)).toHaveLength(1);
+    expect(migration).not.toContain("FOR INSERT");
+    expect(migration).not.toContain("FOR DELETE");
+  });
+});


### PR DESCRIPTION
## Summary

- add a minimum-necessary receptionist intake queue that exposes readiness, blockers, source modes, exceptions, and grant metadata without response answers
- add authority-gated access-grant revocation with canonical AuthorizationDecisionLog evidence
- add purpose-scoped staff RLS for intake review while preserving patient bearer-token policies
- document the Phase 2B authority boundary and reuse decision

## Standards and architecture

The routes require existing employee capabilities (`view_customer` for review and `operate_customer` for revocation), establish an organization/actor/purpose-bound database context, and audit allowed decisions. This follows HHS minimum-necessary and role-based workforce access guidance: https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/minimum-necessary-requirement/index.html

The architecture decision DI-5B3E8CB282FD selected purpose-scoped RLS over a duplicate projection store or separate database role.

## Verification

- governed local-integration gate passed on `ee60cc0d5fa1ba800da97138bdf588005f2a4e38`
- full web suite passed (16,700+ tests)
- Prisma migrate deploy passed with 399 migrations
- web/database typecheck passed
- production build passed with 559 routes
- module-size, migration-safety, route-manifest, and DCO guards passed locally

## Backlog

Advances BI-HEALTHCARE-012 Phase 2B. The backlog item remains in progress for reviewed evidence (2C) and patient/receptionist UX (Phase 3).