### PR TITLE
fix(local-ci): add heap headroom to Windows typecheck

### DIFF
--- a/docs/superpowers/plans/2026-07-17-windows-typecheck-heap.md
+++ b/docs/superpowers/plans/2026-07-17-windows-typecheck-heap.md
@@ -1,0 +1,16 @@
+# Windows Local-CI Typecheck Heap
+
+## Backlog
+
+- `BI-LOCAL-CI-WINDOWS-TYPECHECK-HEAP` - Windows local-CI typecheck omits required Node heap headroom and exits 134.
+
+## Problem
+
+The local-CI plan already gives the host Next build an 8 GiB V8 heap via `NODE_OPTIONS=--max-old-space-size=8192`, but the Windows `docker-build` strategy still planned a plain `pnpm --filter web typecheck`. On Windows hosts, that leaves `tsc --noEmit` at the Node default heap and can terminate with exit 134 before the product gate produces useful evidence.
+
+## Plan
+
+1. Add a contract test that Windows local-CI plans the web typecheck through a heap-aware wrapper instead of the plain `pnpm --filter web typecheck` command.
+2. Add a small Node wrapper that appends requested options to `NODE_OPTIONS` and then delegates to the existing command.
+3. Keep the canonical typecheck entrypoint unchanged so package scripts and CI parity stay in one place.
+4. Verify the plan contract and wrapper behavior with `node --test`.

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -25,7 +25,8 @@ export function dockerBuildTag(candidateBranch) {
 // product build, so it poisons gate evidence exactly like sandbox staleness
 // did (and the freshness gate correctly stays green, so nothing else catches
 // it). Verified 2026-07-05: default heap SIGABRT; 8 GiB completes cleanly.
-export const HOST_BUILD_NODE_OPTIONS = "NODE_OPTIONS=--max-old-space-size=8192";
+export const BUILD_NODE_MAX_OLD_SPACE_SIZE = "--max-old-space-size=8192";
+export const HOST_BUILD_NODE_OPTIONS = `NODE_OPTIONS=${BUILD_NODE_MAX_OLD_SPACE_SIZE}`;
 
 function stableJson(value) {
   if (value === undefined) return "null";
@@ -117,12 +118,11 @@ export function createLocalIntegrationPlan(input) {
       : []),
     ["pnpm", "--filter", "web", "exec", "vitest", "run"],
     // typecheck needs the same heap headroom as the host-next build: with the
-    // node 24 default heap, `tsc --noEmit` over apps/web SIGABRTs (exit 134)
-    // exactly like the build worker did (BI-B5011ACE) — observed live on the
-    // first BI-157DC9B2 gate run, 2026-07-06. Windows keeps the plain form
-    // (`env` is POSIX; win32 routes the build through docker anyway).
+    // node 24 default heap, `tsc --noEmit` over apps/web SIGABRTs (exit 134).
+    // Windows uses a tiny Node wrapper instead of POSIX `env` so the existing
+    // `pnpm --filter web typecheck` script still runs with NODE_OPTIONS set.
     buildStrategy === "docker-build"
-      ? ["pnpm", "--filter", "web", "typecheck"]
+      ? ["node", "scripts/run-with-node-options.mjs", BUILD_NODE_MAX_OLD_SPACE_SIZE, "--", "pnpm", "--filter", "web", "typecheck"]
       : ["env", HOST_BUILD_NODE_OPTIONS, "pnpm", "--filter", "web", "typecheck"],
     productionBuildCommand,
   ];

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -137,6 +137,22 @@ describe("createLocalIntegrationPlan", () => {
       "exec next build",
     ));
   });
+
+  it("gives Windows web typecheck the same V8 heap headroom as host-next", () => {
+    const plan = createLocalIntegrationPlan({
+      candidateBranch: "fix/windows-typecheck-heap",
+      mode: "single-branch",
+      siblingBranches: [],
+      hostPlatform: "win32",
+    });
+
+    assert.ok(plan.commands.map((command) => command.join(" ")).includes(
+      "node scripts/run-with-node-options.mjs --max-old-space-size=8192 -- pnpm --filter web typecheck",
+    ));
+    assert.ok(!plan.commands.map((command) => command.join(" ")).includes(
+      "pnpm --filter web typecheck",
+    ));
+  });
 });
 
 describe("createLocalIntegrationPlan migrate-deploy opt-in (BI-157DC9B2)", () => {

--- a/scripts/run-with-node-options.mjs
+++ b/scripts/run-with-node-options.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+const separatorIndex = process.argv.indexOf("--");
+if (separatorIndex < 0 || separatorIndex === process.argv.length - 1) {
+  console.error("Usage: node scripts/run-with-node-options.mjs <node-options...> -- <command> [args...]");
+  process.exit(2);
+}
+
+const nodeOptions = process.argv.slice(2, separatorIndex).join(" ");
+const [command, ...args] = process.argv.slice(separatorIndex + 1);
+const existing = process.env.NODE_OPTIONS?.trim();
+const env = {
+  ...process.env,
+  NODE_OPTIONS: [existing, nodeOptions].filter(Boolean).join(" "),
+};
+
+const result = spawnSync(command, args, {
+  env,
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+
+process.exit(result.status ?? 1);

--- a/scripts/run-with-node-options.test.mjs
+++ b/scripts/run-with-node-options.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { describe, it } from "node:test";
+
+describe("run-with-node-options", () => {
+  it("preserves existing NODE_OPTIONS while adding the requested options", () => {
+    const result = spawnSync(process.execPath, [
+      "scripts/run-with-node-options.mjs",
+      "--max-old-space-size=8192",
+      "--",
+      "node",
+      "scripts/test-fixtures/assert-node-options.mjs",
+    ], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NODE_OPTIONS: "--trace-warnings",
+      },
+    });
+
+    assert.equal(result.status, 0, `${result.stderr}${result.stdout}`);
+  });
+});

--- a/scripts/test-fixtures/assert-node-options.mjs
+++ b/scripts/test-fixtures/assert-node-options.mjs
@@ -1,0 +1,7 @@
+const options = process.env.NODE_OPTIONS || "";
+const expected = [
+  "--trace-warnings",
+  "--max-old-space-size=8192",
+];
+
+process.exit(expected.every((option) => options.includes(option)) ? 0 : 1);


### PR DESCRIPTION
## Summary
- Route Windows local-CI web typecheck through a Node wrapper that injects `NODE_OPTIONS=--max-old-space-size=8192`.
- Keep the canonical `pnpm --filter web typecheck` entrypoint unchanged while preserving any existing `NODE_OPTIONS`.
- Add a plan note and focused Node tests for the local-CI plan and wrapper behavior.

## Verification
- `node --test scripts/lib/local-integration-ci.test.mjs scripts/run-with-node-options.test.mjs`
- `git diff --check origin/main...HEAD`
- `BASE_SHA=origin/main node scripts/check-spec-plan-doc.mjs`
- `BASE_SHA=origin/main node scripts/check-design-grounding-decision.mjs`