### PR TITLE
feat(platform): add local source repository health card

### DIFF
--- a/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
+++ b/apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx
@@ -7,6 +7,7 @@ import type { ContributorChangeLane } from "@/lib/contributor-change-lanes/types
 
 import { ChangeLaneSourceSummary } from "./ChangeLaneSourceSummary";
 import { ChangeLaneTable } from "./ChangeLaneTable";
+import { LocalRepositoryHealthCard } from "./LocalRepositoryHealthCard";
 
 const TABS = [
   { id: "all", label: "All work" },
@@ -70,6 +71,8 @@ export function ChangeLanesDashboard({
       </header>
 
       <ChangeLaneSourceSummary freshness={freshness} isAdmin={isAdmin} />
+
+      <LocalRepositoryHealthCard lanes={lanes} freshness={freshness} />
 
       <div
         className="flex flex-wrap gap-1 border-b text-xs"

--- a/apps/web/components/platform/development/change-lanes/LocalRepositoryHealthCard.test.tsx
+++ b/apps/web/components/platform/development/change-lanes/LocalRepositoryHealthCard.test.tsx
@@ -1,0 +1,76 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { LaneReadModelFreshness } from "@/lib/contributor-change-lanes/read-model";
+import type { ContributorChangeLane } from "@/lib/contributor-change-lanes/types";
+
+import { LocalRepositoryHealthCard } from "./LocalRepositoryHealthCard";
+
+const NOW = new Date("2026-07-17T04:00:00.000Z");
+
+function freshness(
+  source: LaneReadModelFreshness["source"],
+  state: LaneReadModelFreshness["state"],
+  count: number,
+  message: string | null = null,
+): LaneReadModelFreshness {
+  return { source, state, count, message, fetchedAt: NOW };
+}
+
+function lane(overrides: Partial<ContributorChangeLane> = {}): ContributorChangeLane {
+  return {
+    id: "lane-1",
+    laneKind: "external-debug",
+    source: "git-branch",
+    status: "stale",
+    owner: null,
+    branch: "codex/example",
+    worktreePath: null,
+    commitSha: "abc1234abc1234abc1234abc1234abc1234abc1234",
+    servedCommitSha: null,
+    pullRequestUrl: null,
+    runtimeTargetId: null,
+    runtimeUrl: null,
+    workCapsuleId: null,
+    backlogItemId: null,
+    expiresAt: null,
+    lastHeartbeatAt: null,
+    latestVerification: { status: "pending", checkedAt: null, summary: null },
+    blockers: ["No open PR and no active WIP record"],
+    nextAction: "Open a PR or file a WIP handoff with TTL",
+    ...overrides,
+  };
+}
+
+describe("LocalRepositoryHealthCard", () => {
+  it("renders a plain-language repository health answer before the technical table", () => {
+    const html = renderToStaticMarkup(
+      <LocalRepositoryHealthCard
+        lanes={[
+          lane(),
+          lane({
+            id: "RT-ROOT-PORTAL",
+            laneKind: "root-portal",
+            source: "runtime-target",
+            blockers: [],
+            branch: "main",
+            servedCommitSha: "22081554f7908d49e0fd1e187bd68faf667aec46",
+          }),
+        ]}
+        freshness={[
+          freshness("git-worktree", "ok", 2),
+          freshness("git-branch", "ok", 4),
+          freshness("github-pr", "not-configured", 0),
+        ]}
+      />,
+    );
+
+    expect(html).toContain("Local source repository");
+    expect(html).toContain("Needs attention");
+    expect(html).toContain("The local source repository needs attention before you rely on it.");
+    expect(html).toContain("GitHub PRs are not connected, but local Git checks are still available.");
+    expect(html).toContain("Review the 1 local Git blocker(s) in the table below.");
+    expect(html).toContain("2208155");
+    expect(html).not.toContain("git fsck");
+  });
+});

--- a/apps/web/components/platform/development/change-lanes/LocalRepositoryHealthCard.tsx
+++ b/apps/web/components/platform/development/change-lanes/LocalRepositoryHealthCard.tsx
@@ -1,0 +1,121 @@
+import { StatusBadge } from "@/components/ui/report-kit";
+import type { LaneReadModelFreshness } from "@/lib/contributor-change-lanes/read-model";
+import {
+  summarizeLocalRepositoryHealth,
+  type LocalRepositoryHealthSummary,
+} from "@/lib/contributor-change-lanes/local-repository-health";
+import type { ContributorChangeLane } from "@/lib/contributor-change-lanes/types";
+
+export function LocalRepositoryHealthCard({
+  lanes,
+  freshness,
+}: {
+  lanes: ContributorChangeLane[];
+  freshness: LaneReadModelFreshness[];
+}) {
+  const summary = summarizeLocalRepositoryHealth({ lanes, freshness });
+
+  return (
+    <section
+      aria-labelledby="local-source-repository-health"
+      className="rounded border p-4"
+      style={{
+        borderColor: "var(--dpf-border)",
+        backgroundColor: "var(--dpf-surface-1)",
+      }}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2
+              id="local-source-repository-health"
+              className="text-sm font-semibold text-[var(--dpf-text)]"
+            >
+              Local source repository
+            </h2>
+            <StatusBadge
+              intent={summary.intent}
+              label={summary.badgeLabel}
+              variant="soft"
+            />
+          </div>
+          <p className="text-sm text-[var(--dpf-text)]">{summary.headline}</p>
+          <p className="max-w-3xl text-xs text-[var(--dpf-muted)]">
+            This checks the local Git branches and worktrees that protect work before it
+            is shared. GitHub PR data is helpful when connected, but the local repository
+            check works on its own.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
+          <MiniStat label="Branches" value={summary.gitBranchCount} />
+          <MiniStat label="Worktrees" value={summary.gitWorktreeCount} />
+          <MiniStat label="Local blockers" value={summary.localBlockerCount} />
+          <MiniStat label="Served commit" value={summary.servedCommitShort ?? "—"} mono />
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <SummaryList title="What DPF sees" items={summary.details} />
+        <SummaryList title="Next action" items={summary.nextActions} />
+      </div>
+    </section>
+  );
+}
+
+function MiniStat({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string | number;
+  mono?: boolean;
+}) {
+  return (
+    <div
+      className="rounded border px-3 py-2"
+      style={{
+        borderColor: "var(--dpf-border)",
+        backgroundColor: "var(--dpf-surface-2)",
+      }}
+    >
+      <div className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+        {label}
+      </div>
+      <div
+        className={[
+          "mt-1 text-sm font-semibold text-[var(--dpf-text)]",
+          mono ? "font-mono" : "",
+        ].join(" ")}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function SummaryList({
+  title,
+  items,
+}: {
+  title: string;
+  items: LocalRepositoryHealthSummary["details"];
+}) {
+  return (
+    <div>
+      <h3 className="text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+        {title}
+      </h3>
+      <ul className="mt-1 space-y-1 text-xs text-[var(--dpf-text)]">
+        {items.map((item) => (
+          <li key={item} className="flex gap-2">
+            <span className="text-[var(--dpf-muted)]" aria-hidden>
+              •
+            </span>
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/lib/contributor-change-lanes/local-repository-health.test.ts
+++ b/apps/web/lib/contributor-change-lanes/local-repository-health.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import type { LaneReadModelFreshness } from "./read-model";
+import { summarizeLocalRepositoryHealth } from "./local-repository-health";
+import type { ContributorChangeLane } from "./types";
+
+const NOW = new Date("2026-07-17T04:00:00.000Z");
+
+function freshness(
+  source: LaneReadModelFreshness["source"],
+  state: LaneReadModelFreshness["state"],
+  count: number,
+  message: string | null = null,
+): LaneReadModelFreshness {
+  return { source, state, count, message, fetchedAt: NOW };
+}
+
+function lane(overrides: Partial<ContributorChangeLane> = {}): ContributorChangeLane {
+  return {
+    id: "lane-1",
+    laneKind: "external-debug",
+    source: "git-branch",
+    status: "claimed",
+    owner: null,
+    branch: "codex/example",
+    worktreePath: null,
+    commitSha: "abc1234abc1234abc1234abc1234abc1234abc1234",
+    servedCommitSha: null,
+    pullRequestUrl: null,
+    runtimeTargetId: null,
+    runtimeUrl: null,
+    workCapsuleId: null,
+    backlogItemId: null,
+    expiresAt: null,
+    lastHeartbeatAt: null,
+    latestVerification: { status: "pending", checkedAt: null, summary: null },
+    blockers: [],
+    nextAction: "Open a PR or file a WIP handoff with TTL",
+    ...overrides,
+  };
+}
+
+describe("summarizeLocalRepositoryHealth", () => {
+  it("reports healthy when Git snapshots are fresh and there are no local blockers", () => {
+    const summary = summarizeLocalRepositoryHealth({
+      lanes: [
+        lane({
+          id: "RT-ROOT-PORTAL",
+          laneKind: "root-portal",
+          source: "runtime-target",
+          branch: "main",
+          servedCommitSha: "22081554f7908d49e0fd1e187bd68faf667aec46",
+        }),
+      ],
+      freshness: [
+        freshness("git-worktree", "ok", 2),
+        freshness("git-branch", "ok", 4),
+        freshness("github-pr", "not-configured", 0),
+      ],
+    });
+
+    expect(summary.state).toBe("healthy");
+    expect(summary.badgeLabel).toBe("Healthy");
+    expect(summary.headline).toContain("local source repository looks protected");
+    expect(summary.servedCommitShort).toBe("2208155");
+    expect(summary.nextActions).toEqual(["No action needed right now."]);
+  });
+
+  it("treats GitHub PR not-configured as optional when local Git inventory is healthy", () => {
+    const summary = summarizeLocalRepositoryHealth({
+      lanes: [],
+      freshness: [
+        freshness("git-worktree", "ok", 1),
+        freshness("git-branch", "ok", 1),
+        freshness("github-pr", "not-configured", 0),
+      ],
+    });
+
+    expect(summary.state).toBe("healthy");
+    expect(summary.details).toContain("GitHub PRs are not connected, but local Git checks are still available.");
+  });
+
+  it("reports syncing while local Git snapshots are warming up", () => {
+    const summary = summarizeLocalRepositoryHealth({
+      lanes: [],
+      freshness: [
+        freshness("git-worktree", "warming-up", 0),
+        freshness("git-branch", "warming-up", 0),
+      ],
+    });
+
+    expect(summary.state).toBe("syncing");
+    expect(summary.badgeLabel).toBe("Syncing");
+    expect(summary.nextActions[0]).toContain("Wait for the local Git inventory sync");
+  });
+
+  it("reports attention when Git inventory is stale or errored", () => {
+    const summary = summarizeLocalRepositoryHealth({
+      lanes: [],
+      freshness: [
+        freshness("git-worktree", "ok", 2),
+        freshness("git-branch", "stale", 4, "Last successful sync 42 min ago"),
+      ],
+    });
+
+    expect(summary.state).toBe("attention");
+    expect(summary.badgeLabel).toBe("Needs attention");
+    expect(summary.details).toContain("Last successful sync 42 min ago");
+    expect(summary.nextActions[0]).toContain("Refresh contributor inventory");
+  });
+
+  it("reports attention for orphan local branches and worktrees", () => {
+    const summary = summarizeLocalRepositoryHealth({
+      lanes: [
+        lane({
+          id: "branch:codex/orphan",
+          source: "git-branch",
+          branch: "codex/orphan",
+          blockers: ["No open PR and no active WIP record"],
+        }),
+        lane({
+          id: "worktree:/tmp/orphan",
+          source: "worktree",
+          worktreePath: "/tmp/orphan",
+          branch: null,
+          blockers: ["Worktree has no active Work Capsule"],
+        }),
+      ],
+      freshness: [
+        freshness("git-worktree", "ok", 2),
+        freshness("git-branch", "ok", 4),
+      ],
+    });
+
+    expect(summary.state).toBe("attention");
+    expect(summary.pendingLocalBranches).toBe(1);
+    expect(summary.orphanWorktrees).toBe(1);
+    expect(summary.nextActions).toContain("Review the 2 local Git blocker(s) in the table below.");
+  });
+});

--- a/apps/web/lib/contributor-change-lanes/local-repository-health.ts
+++ b/apps/web/lib/contributor-change-lanes/local-repository-health.ts
@@ -1,0 +1,180 @@
+import type { LaneReadModelFreshness } from "./read-model";
+import type { ContributorChangeLane } from "./types";
+
+type LocalRepositoryHealthState = "healthy" | "attention" | "syncing" | "unknown";
+type LocalRepositoryHealthIntent = "success" | "warning" | "danger" | "neutral";
+
+const LOCAL_GIT_SOURCES: LaneReadModelFreshness["source"][] = [
+  "git-worktree",
+  "git-branch",
+];
+
+export type LocalRepositoryHealthSummary = {
+  state: LocalRepositoryHealthState;
+  intent: LocalRepositoryHealthIntent;
+  badgeLabel: string;
+  headline: string;
+  details: string[];
+  nextActions: string[];
+  servedCommitShort: string | null;
+  gitWorktreeCount: number;
+  gitBranchCount: number;
+  pendingLocalBranches: number;
+  orphanWorktrees: number;
+  localBlockerCount: number;
+};
+
+export function summarizeLocalRepositoryHealth({
+  lanes,
+  freshness,
+}: {
+  lanes: ContributorChangeLane[];
+  freshness: LaneReadModelFreshness[];
+}): LocalRepositoryHealthSummary {
+  const bySource = new Map(freshness.map((row) => [row.source, row]));
+  const localRows = LOCAL_GIT_SOURCES.map((source) => bySource.get(source)).filter(
+    (row): row is LaneReadModelFreshness => Boolean(row),
+  );
+  const githubRow = bySource.get("github-pr");
+  const gitWorktreeCount = bySource.get("git-worktree")?.count ?? 0;
+  const gitBranchCount = bySource.get("git-branch")?.count ?? 0;
+  const localGitLanes = lanes.filter(
+    (lane) => lane.source === "git-branch" || lane.source === "worktree",
+  );
+  const localBlockerCount = localGitLanes.reduce(
+    (sum, lane) => sum + lane.blockers.length,
+    0,
+  );
+  const pendingLocalBranches = localGitLanes.filter(
+    (lane) => lane.source === "git-branch" && !lane.pullRequestUrl,
+  ).length;
+  const orphanWorktrees = localGitLanes.filter((lane) => lane.source === "worktree").length;
+  const servedCommitShort = shortenSha(resolveRootServedCommit(lanes));
+
+  const details: string[] = [
+    `${gitBranchCount} branch${plural(gitBranchCount)} tracked.`,
+    `${gitWorktreeCount} worktree${plural(gitWorktreeCount)} tracked.`,
+  ];
+  const nextActions: string[] = [];
+
+  if (servedCommitShort) {
+    details.push(`Live portal is serving commit ${servedCommitShort}.`);
+  }
+
+  if (githubRow?.state === "not-configured") {
+    details.push("GitHub PRs are not connected, but local Git checks are still available.");
+  }
+
+  if (localRows.length === 0 || localRows.every((row) => row.state === "warming-up")) {
+    return {
+      state: "syncing",
+      intent: "neutral",
+      badgeLabel: "Syncing",
+      headline: "DPF is still checking the local source repository.",
+      details,
+      nextActions: ["Wait for the local Git inventory sync, then refresh this page."],
+      servedCommitShort,
+      gitWorktreeCount,
+      gitBranchCount,
+      pendingLocalBranches,
+      orphanWorktrees,
+      localBlockerCount,
+    };
+  }
+
+  const freshnessProblems = localRows.filter(
+    (row) => row.state === "stale" || row.state === "error",
+  );
+  for (const row of freshnessProblems) {
+    details.push(row.message ?? `${row.source} inventory is ${row.state}.`);
+  }
+
+  if (freshnessProblems.length > 0) {
+    nextActions.push("Refresh contributor inventory and check whether Git data returns to green.");
+  }
+
+  if (localBlockerCount > 0) {
+    nextActions.push(`Review the ${localBlockerCount} local Git blocker(s) in the table below.`);
+  }
+
+  if (freshnessProblems.length > 0 || localBlockerCount > 0) {
+    return {
+      state: "attention",
+      intent: freshnessProblems.some((row) => row.state === "error") ? "danger" : "warning",
+      badgeLabel: "Needs attention",
+      headline: "The local source repository needs attention before you rely on it.",
+      details,
+      nextActions,
+      servedCommitShort,
+      gitWorktreeCount,
+      gitBranchCount,
+      pendingLocalBranches,
+      orphanWorktrees,
+      localBlockerCount,
+    };
+  }
+
+  if (localRows.some((row) => row.state === "warming-up")) {
+    return {
+      state: "syncing",
+      intent: "neutral",
+      badgeLabel: "Syncing",
+      headline: "DPF has partial local Git data and is still finishing the check.",
+      details,
+      nextActions: ["Wait for the local Git inventory sync, then refresh this page."],
+      servedCommitShort,
+      gitWorktreeCount,
+      gitBranchCount,
+      pendingLocalBranches,
+      orphanWorktrees,
+      localBlockerCount,
+    };
+  }
+
+  if (localRows.every((row) => row.state === "ok")) {
+    return {
+      state: "healthy",
+      intent: "success",
+      badgeLabel: "Healthy",
+      headline: "The local source repository looks protected.",
+      details,
+      nextActions: ["No action needed right now."],
+      servedCommitShort,
+      gitWorktreeCount,
+      gitBranchCount,
+      pendingLocalBranches,
+      orphanWorktrees,
+      localBlockerCount,
+    };
+  }
+
+  return {
+    state: "unknown",
+    intent: "neutral",
+    badgeLabel: "Unknown",
+    headline: "DPF does not have enough local Git evidence yet.",
+    details,
+    nextActions: ["Refresh contributor inventory, then check this card again."],
+    servedCommitShort,
+    gitWorktreeCount,
+    gitBranchCount,
+    pendingLocalBranches,
+    orphanWorktrees,
+    localBlockerCount,
+  };
+}
+
+function resolveRootServedCommit(lanes: ContributorChangeLane[]): string | null {
+  const root =
+    lanes.find((lane) => lane.laneKind === "root-portal") ??
+    lanes.find((lane) => lane.id === "RT-ROOT-PORTAL");
+  return root?.servedCommitSha ?? null;
+}
+
+function shortenSha(sha: string | null): string | null {
+  return sha ? sha.slice(0, 7) : null;
+}
+
+function plural(count: number): string {
+  return count === 1 ? "" : "s";
+}

--- a/docs/superpowers/plans/2026-07-17-local-source-repository-health-card.md
+++ b/docs/superpowers/plans/2026-07-17-local-source-repository-health-card.md
@@ -23,6 +23,26 @@ Give a non-technical operator a plain answer to: “Is my local source home heal
 - Empty/failure behavior: syncing, stale, not-configured, and blocked states get plain next actions.
 - AI boundary: no coworker prompt is started by this card.
 
+## Design grounding
+
+- Existing specs/plans reviewed:
+  - `docs/superpowers/specs/2026-05-26-contributor-change-lanes-design.md`
+  - `docs/superpowers/plans/2026-05-26-contributor-change-lanes.md`
+  - `docs/superpowers/plans/2026-05-26-contributor-inventory-sync.md`
+  - `docs/superpowers/specs/2026-06-18-private-public-change-segregation-design.md`
+- Current code substrate reviewed:
+  - `apps/web/app/(shell)/platform/development/change-lanes/page.tsx`
+  - `apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx`
+  - `apps/web/components/platform/development/change-lanes/ChangeLaneSourceSummary.tsx`
+  - `apps/web/components/platform/development/change-lanes/ChangeLaneTable.tsx`
+  - `apps/web/lib/contributor-change-lanes/read-model.ts`
+  - `apps/web/lib/contributor-change-lanes/lane-projection.ts`
+  - `apps/web/lib/contributor-change-lanes/types.ts`
+- Source of truth:
+  - The card derives from the existing `loadContributorChangeLaneReadModel` freshness rows and projected `ContributorChangeLane` rows; it does not add a second repository-health model.
+- Decision:
+  - Add a page-local summary card above the existing technical table. This keeps the operator-facing answer plain while preserving the table as the evidence drill-down.
+
 ## Phases
 
 1. Add a pure repository-health summarizer.

--- a/docs/superpowers/plans/2026-07-17-local-source-repository-health-card.md
+++ b/docs/superpowers/plans/2026-07-17-local-source-repository-health-card.md
@@ -1,0 +1,39 @@
+# Local Source Repository Health Card Plan
+
+| Field | Value |
+| --- | --- |
+| Backlog item | `BI-CE54B73F` |
+| Epic | `EP-5410E8EA` — Forge-neutral, offline-capable Git integration substrate |
+| Date | 2026-07-17 |
+| Status | Implementation plan for this slice |
+
+## Goal
+
+Give a non-technical operator a plain answer to: “Is my local source home healthy and protected?” The existing Development Activity page already has the raw ingredients: Git branch/worktree inventory, source freshness, runtime served commit, PR links, and blocker rows. This slice adds an operator-facing summary card on `/platform/development/change-lanes` without creating a new route or a second source of truth.
+
+## UX fit review
+
+- Decision: fits-with-guardrails.
+- Owning area: Platform.
+- Route family: `/platform/development/change-lanes`.
+- Primary persona: contributor/platform operator who needs confidence before accepting, keeping, or sharing work.
+- Navigation layer touched: none; this is a page-local summary above the existing table.
+- Reuse/convergence: reuse the contributor-change-lanes read model and report-kit `StatusBadge`; no new dashboard route.
+- Source truth: `loadContributorChangeLaneReadModel` freshness plus projected `ContributorChangeLane` rows.
+- Empty/failure behavior: syncing, stale, not-configured, and blocked states get plain next actions.
+- AI boundary: no coworker prompt is started by this card.
+
+## Phases
+
+1. Add a pure repository-health summarizer.
+   - Touch: `apps/web/lib/contributor-change-lanes/local-repository-health.ts`.
+   - Verify: unit tests cover healthy, syncing, stale/error, and blocker states.
+2. Render the summary card on the existing Development Activity page.
+   - Touch: `apps/web/components/platform/development/change-lanes/LocalRepositoryHealthCard.tsx`, `ChangeLanesDashboard.tsx`.
+   - Verify: component test asserts the card answers “Local source repository” and exposes plain next actions.
+3. Merge hygiene.
+   - Run targeted tests and typecheck. Runtime/browser verification can use the already-live `/platform/development/change-lanes` route after self-upgrade.
+
+## Risk and rollback
+
+Risk is low because this is read-only presentation over an existing read model. Rollback is removing the card import/render and helper; no schema, queue, or Git mechanics change.


### PR DESCRIPTION
## Summary
- Adds a plain-language "Local source repository" health card to `/platform/development/change-lanes` for `BI-CE54B73F` under `EP-5410E8EA`.
- Reuses the contributor change-lanes read model to summarize Git branch/worktree freshness, local blockers, and served commit without adding a new source of truth.
- Adds a small implementation plan and tests for healthy, syncing, stale/error, and blocker states.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/contributor-change-lanes/ components/platform/development/change-lanes/` — 9 files, 60 tests passed
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` — passed
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build` — passed
- [x] `node scripts/check-module-size.mjs` — passed
- [x] `node scripts/check-design-grounding-decision.mjs` — passed

## Local-CI-Override
`pnpm run pregate` merged `codex/local-git-health-card` into the local-CI sandbox and reached full `vitest run`, but failed in unrelated suites because `localStorage` is unavailable in the local-CI harness. The failure shape matches the known harness issue observed earlier in this thread: 52 failures in `AgentFAB`, Build Studio header/drawer/node inspector, `TopologyGraph`, and `UpdatePendingBannerClient`, all rooted in `localStorage.clear/getItem/setItem`; 16,735 tests passed before the harness failure. Branch-specific tests, typecheck, production build, module-size, and design-grounding guards passed.

## UX note
This is a read-only summary over existing Development Activity data. It answers the operator question first, then leaves the existing table as the evidence drill-down.
