### PR TITLE
feat(healthcare): add reviewed intake evidence

### DIFF
--- a/apps/web/app/api/v1/healthcare/intake/[packetId]/consent-attestations/[attestationId]/decision/route.ts
+++ b/apps/web/app/api/v1/healthcare/intake/[packetId]/consent-attestations/[attestationId]/decision/route.ts
@@ -1,0 +1,24 @@
+import { requireCapability, requireEmployeeAuth } from "@/lib/api/auth-middleware";
+import { apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { EvidenceDecisionBody, careIntakeEvidenceError } from "@/lib/healthcare/care-intake-evidence-api";
+import { decideCareConsentAttestation } from "@/lib/healthcare/care-intake-evidence-repository";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ packetId: string; attestationId: string }> },
+) {
+  try {
+    const { capabilities, authContext } = await requireEmployeeAuth(request);
+    requireCapability(capabilities, "operate_customer");
+    if (!authContext.principalId) return apiError("PRINCIPAL_REQUIRED", "Relational principal required", 403).toResponse();
+    const parsed = EvidenceDecisionBody.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return apiError("INVALID_REQUEST", "Invalid consent attestation decision", 400).toResponse();
+    const { packetId, attestationId } = await params;
+    return apiSuccess(await decideCareConsentAttestation({
+      ...parsed.data, packetId, attestationId, actorPrincipalId: authContext.principalId,
+    }));
+  } catch (error) {
+    return careIntakeEvidenceError(error);
+  }
+}

--- a/apps/web/app/api/v1/healthcare/intake/[packetId]/consent-attestations/route.ts
+++ b/apps/web/app/api/v1/healthcare/intake/[packetId]/consent-attestations/route.ts
@@ -1,0 +1,21 @@
+import { requireCapability, requireEmployeeAuth } from "@/lib/api/auth-middleware";
+import { apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { ConsentAttestationBody, careIntakeEvidenceError } from "@/lib/healthcare/care-intake-evidence-api";
+import { stageCareConsentAttestation } from "@/lib/healthcare/care-intake-evidence-repository";
+
+export async function POST(request: Request, { params }: { params: Promise<{ packetId: string }> }) {
+  try {
+    const { capabilities, authContext } = await requireEmployeeAuth(request);
+    requireCapability(capabilities, "operate_customer");
+    if (!authContext.principalId) return apiError("PRINCIPAL_REQUIRED", "Relational principal required", 403).toResponse();
+    const parsed = ConsentAttestationBody.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return apiError("INVALID_REQUEST", "Invalid consent attestation", 400).toResponse();
+    const { packetId } = await params;
+    return apiSuccess(await stageCareConsentAttestation({
+      ...parsed.data, packetId, actorPrincipalId: authContext.principalId,
+    }));
+  } catch (error) {
+    return careIntakeEvidenceError(error);
+  }
+}

--- a/apps/web/app/api/v1/healthcare/intake/[packetId]/coverage-evidence/[evidenceId]/decision/route.ts
+++ b/apps/web/app/api/v1/healthcare/intake/[packetId]/coverage-evidence/[evidenceId]/decision/route.ts
@@ -1,0 +1,24 @@
+import { requireCapability, requireEmployeeAuth } from "@/lib/api/auth-middleware";
+import { apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { EvidenceDecisionBody, careIntakeEvidenceError } from "@/lib/healthcare/care-intake-evidence-api";
+import { decideCareCoverageEvidence } from "@/lib/healthcare/care-intake-evidence-repository";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ packetId: string; evidenceId: string }> },
+) {
+  try {
+    const { capabilities, authContext } = await requireEmployeeAuth(request);
+    requireCapability(capabilities, "operate_customer");
+    if (!authContext.principalId) return apiError("PRINCIPAL_REQUIRED", "Relational principal required", 403).toResponse();
+    const parsed = EvidenceDecisionBody.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return apiError("INVALID_REQUEST", "Invalid coverage evidence decision", 400).toResponse();
+    const { packetId, evidenceId } = await params;
+    return apiSuccess(await decideCareCoverageEvidence({
+      ...parsed.data, packetId, evidenceId, actorPrincipalId: authContext.principalId,
+    }));
+  } catch (error) {
+    return careIntakeEvidenceError(error);
+  }
+}

--- a/apps/web/app/api/v1/healthcare/intake/[packetId]/coverage-evidence/route.ts
+++ b/apps/web/app/api/v1/healthcare/intake/[packetId]/coverage-evidence/route.ts
@@ -1,0 +1,21 @@
+import { requireCapability, requireEmployeeAuth } from "@/lib/api/auth-middleware";
+import { apiError } from "@/lib/api/error";
+import { apiSuccess } from "@/lib/api/response";
+import { CoverageEvidenceBody, careIntakeEvidenceError } from "@/lib/healthcare/care-intake-evidence-api";
+import { stageCareCoverageEvidence } from "@/lib/healthcare/care-intake-evidence-repository";
+
+export async function POST(request: Request, { params }: { params: Promise<{ packetId: string }> }) {
+  try {
+    const { capabilities, authContext } = await requireEmployeeAuth(request);
+    requireCapability(capabilities, "operate_customer");
+    if (!authContext.principalId) return apiError("PRINCIPAL_REQUIRED", "Relational principal required", 403).toResponse();
+    const parsed = CoverageEvidenceBody.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return apiError("INVALID_REQUEST", "Invalid coverage evidence", 400).toResponse();
+    const { packetId } = await params;
+    return apiSuccess(await stageCareCoverageEvidence({
+      ...parsed.data, packetId, actorPrincipalId: authContext.principalId,
+    }));
+  } catch (error) {
+    return careIntakeEvidenceError(error);
+  }
+}

--- a/apps/web/lib/api/__tests__/healthcare-intake-evidence-endpoints.test.ts
+++ b/apps/web/lib/api/__tests__/healthcare-intake-evidence-endpoints.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../api/auth-middleware.js", () => ({
+  requireEmployeeAuth: vi.fn(),
+  requireCapability: vi.fn(),
+}));
+vi.mock("../../healthcare/care-intake-evidence-repository.js", () => ({
+  stageCareCoverageEvidence: vi.fn(),
+  decideCareCoverageEvidence: vi.fn(),
+  stageCareConsentAttestation: vi.fn(),
+  decideCareConsentAttestation: vi.fn(),
+}));
+
+import { POST as stageCoverage } from "../../../app/api/v1/healthcare/intake/[packetId]/coverage-evidence/route.js";
+import { POST as decideCoverage } from "../../../app/api/v1/healthcare/intake/[packetId]/coverage-evidence/[evidenceId]/decision/route.js";
+import { POST as stageConsent } from "../../../app/api/v1/healthcare/intake/[packetId]/consent-attestations/route.js";
+import { POST as decideConsent } from "../../../app/api/v1/healthcare/intake/[packetId]/consent-attestations/[attestationId]/decision/route.js";
+import { requireCapability, requireEmployeeAuth } from "../../api/auth-middleware.js";
+import {
+  decideCareConsentAttestation,
+  decideCareCoverageEvidence,
+  stageCareConsentAttestation,
+  stageCareCoverageEvidence,
+} from "../../healthcare/care-intake-evidence-repository.js";
+
+const digestA = "a".repeat(64);
+const digestB = "b".repeat(64);
+
+function post(body: unknown) {
+  return new Request("http://localhost", {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireEmployeeAuth).mockResolvedValue({
+    user: { id: "user-reception", type: "admin" } as never,
+    capabilities: ["operate_customer"],
+    authContext: { principalId: "principal-receptionist" } as never,
+  });
+});
+
+describe("healthcare intake reviewed evidence endpoints", () => {
+  it("requires customer-operation authority to stage coverage evidence", async () => {
+    vi.mocked(stageCareCoverageEvidence).mockResolvedValue({
+      evidenceId: "coverage-a", status: "pending-review", canonicalCoverageCreated: false,
+    });
+    const response = await stageCoverage(post({
+      organizationId: "org-a", idempotencyKey: "upload-a", fundingType: "commercial",
+      evidenceRef: "object://coverage/a", evidenceDigest: digestA,
+    }), { params: Promise.resolve({ packetId: "intake-a" }) });
+    expect(response.status).toBe(200);
+    expect(requireCapability).toHaveBeenCalledWith(["operate_customer"], "operate_customer");
+    expect(stageCareCoverageEvidence).toHaveBeenCalledWith(expect.objectContaining({
+      packetId: "intake-a", actorPrincipalId: "principal-receptionist", evidenceDigest: digestA,
+    }));
+  });
+
+  it("requires an explicit coverage accept/reject decision", async () => {
+    vi.mocked(decideCareCoverageEvidence).mockResolvedValue({
+      evidenceId: "coverage-a", status: "accepted", canonicalCoverageCreated: false,
+    });
+    const response = await decideCoverage(post({ organizationId: "org-a", decision: "accepted" }), {
+      params: Promise.resolve({ packetId: "intake-a", evidenceId: "coverage-a" }),
+    });
+    expect(response.status).toBe(200);
+    expect(decideCareCoverageEvidence).toHaveBeenCalledWith(expect.objectContaining({
+      evidenceId: "coverage-a", decision: "accepted", actorPrincipalId: "principal-receptionist",
+    }));
+  });
+
+  it("stages consent evidence without changing the consent directive", async () => {
+    vi.mocked(stageCareConsentAttestation).mockResolvedValue({
+      attestationId: "attestation-a", status: "pending-review", consentDirectiveChanged: false,
+    });
+    const response = await stageConsent(post({
+      organizationId: "org-a", idempotencyKey: "signature-a", patientConsentDirectiveId: "directive-a",
+      documentRef: "object://consent/a", documentDigest: digestA, documentVersion: "v3",
+      signatureEvidenceRef: "object://signature/a", signatureDigest: digestB,
+      signatureMethod: "drawn", signerPrincipalId: "principal-patient", attestedAt: "2026-08-01T13:55:00Z",
+    }), { params: Promise.resolve({ packetId: "intake-a" }) });
+    expect(response.status).toBe(200);
+    expect(stageCareConsentAttestation).toHaveBeenCalledWith(expect.objectContaining({
+      packetId: "intake-a", patientConsentDirectiveId: "directive-a",
+      attestedAt: new Date("2026-08-01T13:55:00Z"),
+    }));
+  });
+
+  it("requires a reason for a rejected consent attestation", async () => {
+    vi.mocked(decideCareConsentAttestation).mockResolvedValue({
+      attestationId: "attestation-a", status: "rejected", consentDirectiveChanged: false,
+    });
+    const response = await decideConsent(post({
+      organizationId: "org-a", decision: "rejected", reason: "signature-does-not-match",
+    }), { params: Promise.resolve({ packetId: "intake-a", attestationId: "attestation-a" }) });
+    expect(response.status).toBe(200);
+    expect(decideCareConsentAttestation).toHaveBeenCalledWith(expect.objectContaining({
+      attestationId: "attestation-a", decision: "rejected", reason: "signature-does-not-match",
+    }));
+  });
+});

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 559,
+  "routeCount": 563,
   "routes": [
     {
       "routePath": "/",
@@ -2770,6 +2770,76 @@
         "grantId"
       ],
       "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/access-grants/[grantId]/revoke/route.ts"
+    },
+    {
+      "routePath": "/api/v1/healthcare/intake/[packetId]/consent-attestations",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "healthcare",
+        "intake",
+        "[packetId]",
+        "consent-attestations"
+      ],
+      "dynamicParams": [
+        "packetId"
+      ],
+      "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/consent-attestations/route.ts"
+    },
+    {
+      "routePath": "/api/v1/healthcare/intake/[packetId]/consent-attestations/[attestationId]/decision",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "healthcare",
+        "intake",
+        "[packetId]",
+        "consent-attestations",
+        "[attestationId]",
+        "decision"
+      ],
+      "dynamicParams": [
+        "packetId",
+        "attestationId"
+      ],
+      "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/consent-attestations/[attestationId]/decision/route.ts"
+    },
+    {
+      "routePath": "/api/v1/healthcare/intake/[packetId]/coverage-evidence",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "healthcare",
+        "intake",
+        "[packetId]",
+        "coverage-evidence"
+      ],
+      "dynamicParams": [
+        "packetId"
+      ],
+      "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/coverage-evidence/route.ts"
+    },
+    {
+      "routePath": "/api/v1/healthcare/intake/[packetId]/coverage-evidence/[evidenceId]/decision",
+      "kind": "route",
+      "segments": [
+        "api",
+        "v1",
+        "healthcare",
+        "intake",
+        "[packetId]",
+        "coverage-evidence",
+        "[evidenceId]",
+        "decision"
+      ],
+      "dynamicParams": [
+        "packetId",
+        "evidenceId"
+      ],
+      "file": "apps/web/app/api/v1/healthcare/intake/[packetId]/coverage-evidence/[evidenceId]/decision/route.ts"
     },
     {
       "routePath": "/api/v1/healthcare/intake/[packetId]/responses/[formId]",

--- a/apps/web/lib/healthcare/care-intake-evidence-api.ts
+++ b/apps/web/lib/healthcare/care-intake-evidence-api.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+import { ApiError, apiError } from "@/lib/api/error";
+
+const Digest = z.string().regex(/^[a-f0-9]{64}$/i);
+const Reference = z.string().trim().min(1).max(1000);
+
+export const CoverageEvidenceBody = z.object({
+  organizationId: z.string().min(1).max(128),
+  idempotencyKey: z.string().trim().min(1).max(128),
+  fundingType: z.enum(["commercial", "public-entitlement", "private", "supplemental", "self-pay", "other"]),
+  payerOrProgramName: z.string().trim().min(1).max(200).optional(),
+  memberIdentifierLast4: z.string().regex(/^[a-z0-9]{1,4}$/i).optional(),
+  responsiblePartyPrincipalId: z.string().min(1).max(128).optional(),
+  evidenceRef: Reference,
+  evidenceDigest: Digest,
+  effectiveFrom: z.coerce.date().optional(),
+  effectiveUntil: z.coerce.date().optional(),
+  sourceSystem: z.string().trim().min(1).max(128).optional(),
+  sourceId: z.string().trim().min(1).max(256).optional(),
+  sourceVersion: z.string().trim().min(1).max(128).optional(),
+}).refine(
+  (value) => !value.effectiveFrom || !value.effectiveUntil || value.effectiveUntil >= value.effectiveFrom,
+  { message: "Invalid coverage effective window" },
+);
+
+export const ConsentAttestationBody = z.object({
+  organizationId: z.string().min(1).max(128),
+  idempotencyKey: z.string().trim().min(1).max(128),
+  patientConsentDirectiveId: z.string().min(1).max(128),
+  responseId: z.string().min(1).max(128).optional(),
+  documentRef: Reference,
+  documentDigest: Digest,
+  documentVersion: z.string().trim().min(1).max(100),
+  signatureEvidenceRef: Reference,
+  signatureDigest: Digest,
+  signatureMethod: z.string().trim().min(1).max(100),
+  signerPrincipalId: z.string().min(1).max(128),
+  witnessPrincipalId: z.string().min(1).max(128).optional(),
+  attestedAt: z.coerce.date(),
+});
+
+export const EvidenceDecisionBody = z.object({
+  organizationId: z.string().min(1).max(128),
+  decision: z.enum(["accepted", "rejected"]),
+  reason: z.string().trim().min(1).max(500).optional(),
+}).superRefine((value, ctx) => {
+  if (value.decision === "rejected" && !value.reason) {
+    ctx.addIssue({ code: "custom", path: ["reason"], message: "Rejection reason required" });
+  }
+  if (value.decision === "accepted" && value.reason) {
+    ctx.addIssue({ code: "custom", path: ["reason"], message: "Acceptance cannot include a rejection reason" });
+  }
+});
+
+export function careIntakeEvidenceError(error: unknown): Response {
+  if (error instanceof ApiError) return error.toResponse();
+  if (error instanceof Error) {
+    if (error.message.includes("not found")) {
+      return apiError("INTAKE_EVIDENCE_NOT_FOUND", "Intake evidence or authority record not found", 404).toResponse();
+    }
+    if (["evidence-idempotency-conflict", "evidence-already-reviewed", "stale-evidence-review"].includes(error.message)) {
+      return apiError("INTAKE_EVIDENCE_CONFLICT", "The evidence record changed or conflicts with this request", 409).toResponse();
+    }
+    if (/^(Invalid|Rejection|Acceptance|Signer)/.test(error.message)) {
+      return apiError("INVALID_REQUEST", "Invalid intake evidence request", 400).toResponse();
+    }
+  }
+  return apiError("INTERNAL_ERROR", "An unexpected error occurred", 500).toResponse();
+}

--- a/apps/web/lib/healthcare/care-intake-evidence-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-evidence-repository.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  decideCareConsentAttestation,
+  decideCareCoverageEvidence,
+  stageCareConsentAttestation,
+  stageCareCoverageEvidence,
+  type CareIntakeEvidenceDatabase,
+} from "./care-intake-evidence-repository";
+
+function database() {
+  const tx = {
+    $executeRaw: vi.fn().mockResolvedValue(1),
+    careIntakePacket: {
+      findFirst: vi.fn().mockResolvedValue({
+        id: "packet-row-a", packetId: "intake-a", patientProfileId: "patient-a",
+      }),
+    },
+    patientConsentDirective: {
+      findFirst: vi.fn().mockResolvedValue({ id: "directive-row-a", directiveId: "directive-a" }),
+    },
+    careIntakeResponse: {
+      findFirst: vi.fn().mockResolvedValue({ id: "response-row-a" }),
+    },
+    careCoverageEvidence: {
+      upsert: vi.fn().mockImplementation(({ create }) => Promise.resolve({ ...create })),
+      findFirst: vi.fn().mockResolvedValue({
+        id: "coverage-row-a", evidenceId: "coverage-a", status: "pending-review",
+      }),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    careConsentAttestation: {
+      upsert: vi.fn().mockImplementation(({ create }) => Promise.resolve({ ...create })),
+      findFirst: vi.fn().mockResolvedValue({
+        id: "attestation-row-a", attestationId: "attestation-a", status: "pending-review",
+      }),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    authorizationDecisionLog: { create: vi.fn().mockResolvedValue({}) },
+  };
+  return {
+    tx,
+    db: { $transaction: vi.fn((callback) => callback(tx)) } as unknown as CareIntakeEvidenceDatabase,
+  };
+}
+
+const digestA = "a".repeat(64);
+const digestB = "b".repeat(64);
+
+describe("care intake reviewed evidence repository", () => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime("2026-08-01T14:00:00.000Z"));
+
+  it("stages coverage as pending evidence without making it canonical coverage", async () => {
+    const { db, tx } = database();
+    const result = await stageCareCoverageEvidence({
+      organizationId: "org-a", packetId: "intake-a", actorPrincipalId: "principal-receptionist",
+      idempotencyKey: "upload-a", fundingType: "commercial", payerOrProgramName: "Example Payer",
+      memberIdentifierLast4: "9X2A", evidenceRef: "object://coverage/a", evidenceDigest: digestA,
+    }, db);
+
+    expect(result).toEqual(expect.objectContaining({ status: "pending-review", canonicalCoverageCreated: false }));
+    expect(JSON.stringify(result)).not.toContain("object://coverage/a");
+    expect(tx.careCoverageEvidence.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      create: expect.objectContaining({
+        organizationId: "org-a", packetId: "packet-row-a", patientProfileId: "patient-a",
+        status: "pending-review", evidenceRef: "object://coverage/a", evidenceDigest: digestA,
+      }),
+    }));
+    expect(tx.authorizationDecisionLog.create).toHaveBeenCalledWith({ data: expect.objectContaining({
+      actionKey: "healthcare.intake.coverage-evidence.stage", decision: "allow",
+    }) });
+  });
+
+  it("stages consent evidence against an existing patient directive", async () => {
+    const { db, tx } = database();
+    const result = await stageCareConsentAttestation({
+      organizationId: "org-a", packetId: "intake-a", actorPrincipalId: "principal-receptionist",
+      idempotencyKey: "signature-a", patientConsentDirectiveId: "directive-a",
+      responseId: "response-row-a", documentRef: "object://consent/a", documentDigest: digestA,
+      documentVersion: "v3", signatureEvidenceRef: "object://signature/a", signatureDigest: digestB,
+      signatureMethod: "drawn", signerPrincipalId: "principal-patient", attestedAt: new Date("2026-08-01T13:55:00Z"),
+    }, db);
+
+    expect(result).toEqual(expect.objectContaining({ status: "pending-review", consentDirectiveChanged: false }));
+    expect(tx.patientConsentDirective.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ directiveId: "directive-a", patientProfileId: "patient-a" }),
+    }));
+    expect(tx.careConsentAttestation.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      create: expect.objectContaining({
+        patientConsentDirectiveId: "directive-row-a", responseId: "response-row-a",
+        signatureEvidenceRef: "object://signature/a", signatureDigest: digestB,
+      }),
+    }));
+  });
+
+  it("accepts pending coverage only through an explicit reviewer decision", async () => {
+    const { db, tx } = database();
+    const result = await decideCareCoverageEvidence({
+      organizationId: "org-a", packetId: "intake-a", evidenceId: "coverage-a",
+      actorPrincipalId: "principal-reviewer", decision: "accepted",
+    }, db);
+
+    expect(result).toEqual({ evidenceId: "coverage-a", status: "accepted", canonicalCoverageCreated: false });
+    expect(tx.careCoverageEvidence.updateMany).toHaveBeenCalledWith({
+      where: { id: "coverage-row-a", status: "pending-review" },
+      data: {
+        status: "accepted", verifiedAt: new Date("2026-08-01T14:00:00.000Z"),
+        verifiedByPrincipalId: "principal-reviewer", rejectionReason: null,
+      },
+    });
+  });
+
+  it("rejects pending consent with a reason and does not alter consent authority", async () => {
+    const { db, tx } = database();
+    const result = await decideCareConsentAttestation({
+      organizationId: "org-a", packetId: "intake-a", attestationId: "attestation-a",
+      actorPrincipalId: "principal-reviewer", decision: "rejected", reason: "signature-does-not-match",
+    }, db);
+
+    expect(result).toEqual({ attestationId: "attestation-a", status: "rejected", consentDirectiveChanged: false });
+    expect(tx.careConsentAttestation.updateMany).toHaveBeenCalledWith({
+      where: { id: "attestation-row-a", status: "pending-review" },
+      data: {
+        status: "rejected", acceptedAt: null, acceptedByPrincipalId: null,
+        rejectionReason: "signature-does-not-match",
+      },
+    });
+  });
+});

--- a/apps/web/lib/healthcare/care-intake-evidence-repository.ts
+++ b/apps/web/lib/healthcare/care-intake-evidence-repository.ts
@@ -1,0 +1,332 @@
+import { createHash } from "node:crypto";
+
+import { prisma } from "@dpf/db";
+
+import {
+  recordCareIntakeStaffDecision,
+  setCareIntakeStaffContext,
+} from "./care-intake-staff-context";
+
+const FUNDING_TYPES = new Set([
+  "commercial", "public-entitlement", "private", "supplemental", "self-pay", "other",
+]);
+const SHA256 = /^[a-f0-9]{64}$/i;
+
+type PacketRow = { id: string; packetId: string; patientProfileId: string };
+type CoverageRow = {
+  id?: string; evidenceId: string; organizationId?: string; packetId?: string;
+  patientProfileId?: string; status: string; evidenceRef?: string; evidenceDigest?: string;
+};
+type AttestationRow = {
+  id?: string; attestationId: string; organizationId?: string; packetId?: string;
+  patientProfileId?: string; status: string; documentRef?: string; documentDigest?: string;
+  signatureEvidenceRef?: string; signatureDigest?: string;
+};
+
+type Transaction = {
+  $executeRaw(query: TemplateStringsArray, ...values: unknown[]): Promise<number>;
+  careIntakePacket: { findFirst(args: unknown): Promise<PacketRow | null> };
+  patientConsentDirective: { findFirst(args: unknown): Promise<{ id: string; directiveId: string } | null> };
+  careIntakeResponse: { findFirst(args: unknown): Promise<{ id: string } | null> };
+  careCoverageEvidence: {
+    upsert(args: unknown): Promise<CoverageRow>;
+    findFirst(args: unknown): Promise<CoverageRow | null>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  careConsentAttestation: {
+    upsert(args: unknown): Promise<AttestationRow>;
+    findFirst(args: unknown): Promise<AttestationRow | null>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+  authorizationDecisionLog: { create(args: unknown): Promise<unknown> };
+};
+
+export type CareIntakeEvidenceDatabase = {
+  $transaction<T>(callback: (tx: Transaction) => Promise<T>): Promise<T>;
+};
+
+type BaseInput = {
+  organizationId: string;
+  packetId: string;
+  actorPrincipalId: string;
+};
+
+function stableEvidenceId(prefix: string, input: BaseInput & { idempotencyKey: string }) {
+  if (!input.idempotencyKey.trim() || input.idempotencyKey.length > 128) {
+    throw new Error("Invalid evidence idempotency key");
+  }
+  const digest = createHash("sha256")
+    .update(`${input.organizationId}\0${input.packetId}\0${input.idempotencyKey}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `${prefix}-${digest}`;
+}
+
+function assertDigest(value: string, label: string) {
+  if (!SHA256.test(value)) throw new Error(`Invalid ${label} digest`);
+}
+
+function assertReference(value: string, label: string) {
+  if (!value.trim() || value.length > 1000) throw new Error(`Invalid ${label} reference`);
+}
+
+function assertOptionalText(value: string | null | undefined, label: string, max = 500) {
+  if (value != null && (!value.trim() || value.length > max)) throw new Error(`Invalid ${label}`);
+}
+
+async function packetForStaff(tx: Transaction, input: BaseInput) {
+  await setCareIntakeStaffContext(tx, input);
+  const packet = await tx.careIntakePacket.findFirst({
+    where: { packetId: input.packetId, organizationId: input.organizationId },
+    select: { id: true, packetId: true, patientProfileId: true },
+  });
+  if (!packet) throw new Error("Care intake packet not found");
+  await setCareIntakeStaffContext(tx, { ...input, patientProfileId: packet.patientProfileId });
+  return packet;
+}
+
+export type StageCoverageEvidenceInput = BaseInput & {
+  idempotencyKey: string;
+  fundingType: string;
+  payerOrProgramName?: string | null;
+  memberIdentifierLast4?: string | null;
+  responsiblePartyPrincipalId?: string | null;
+  evidenceRef: string;
+  evidenceDigest: string;
+  effectiveFrom?: Date | null;
+  effectiveUntil?: Date | null;
+  sourceSystem?: string | null;
+  sourceId?: string | null;
+  sourceVersion?: string | null;
+};
+
+export async function stageCareCoverageEvidence(
+  input: StageCoverageEvidenceInput,
+  database: CareIntakeEvidenceDatabase = prisma as unknown as CareIntakeEvidenceDatabase,
+) {
+  if (!FUNDING_TYPES.has(input.fundingType)) throw new Error("Invalid funding type");
+  assertReference(input.evidenceRef, "coverage evidence");
+  assertDigest(input.evidenceDigest, "coverage evidence");
+  assertOptionalText(input.payerOrProgramName, "payer or program name", 200);
+  if (input.memberIdentifierLast4 && !/^[a-z0-9]{1,4}$/i.test(input.memberIdentifierLast4)) {
+    throw new Error("Invalid member identifier suffix");
+  }
+  if (input.effectiveFrom && input.effectiveUntil && input.effectiveUntil < input.effectiveFrom) {
+    throw new Error("Invalid coverage effective window");
+  }
+  const evidenceId = stableEvidenceId("coverage-evidence", input);
+  return database.$transaction(async (tx) => {
+    const packet = await packetForStaff(tx, input);
+    const create = {
+      evidenceId,
+      organizationId: input.organizationId,
+      packetId: packet.id,
+      patientProfileId: packet.patientProfileId,
+      status: "pending-review",
+      fundingType: input.fundingType,
+      payerOrProgramName: input.payerOrProgramName?.trim() || null,
+      memberIdentifierLast4: input.memberIdentifierLast4?.toUpperCase() || null,
+      responsiblePartyPrincipalId: input.responsiblePartyPrincipalId || null,
+      evidenceRef: input.evidenceRef.trim(),
+      evidenceDigest: input.evidenceDigest.toLowerCase(),
+      effectiveFrom: input.effectiveFrom || null,
+      effectiveUntil: input.effectiveUntil || null,
+      sourceSystem: input.sourceSystem?.trim() || null,
+      sourceId: input.sourceId?.trim() || null,
+      sourceVersion: input.sourceVersion?.trim() || null,
+    };
+    const row = await tx.careCoverageEvidence.upsert({
+      where: { evidenceId }, update: {}, create,
+    });
+    if (
+      row.evidenceRef !== create.evidenceRef
+      || row.evidenceDigest !== create.evidenceDigest
+      || (row.packetId && row.packetId !== create.packetId)
+    ) {
+      throw new Error("evidence-idempotency-conflict");
+    }
+    await recordCareIntakeStaffDecision(tx, {
+      organizationId: input.organizationId,
+      actorPrincipalId: input.actorPrincipalId,
+      actionKey: "healthcare.intake.coverage-evidence.stage",
+      objectRef: `care-coverage-evidence:${evidenceId}`,
+      routeContext: "/api/v1/healthcare/intake/:packetId/coverage-evidence",
+      rationale: { packetId: input.packetId, fundingType: input.fundingType, status: row.status },
+    });
+    return { evidenceId, status: row.status, canonicalCoverageCreated: false as const };
+  });
+}
+
+export type StageConsentAttestationInput = BaseInput & {
+  idempotencyKey: string;
+  patientConsentDirectiveId: string;
+  responseId?: string | null;
+  documentRef: string;
+  documentDigest: string;
+  documentVersion: string;
+  signatureEvidenceRef: string;
+  signatureDigest: string;
+  signatureMethod: string;
+  signerPrincipalId: string;
+  witnessPrincipalId?: string | null;
+  attestedAt: Date;
+};
+
+export async function stageCareConsentAttestation(
+  input: StageConsentAttestationInput,
+  database: CareIntakeEvidenceDatabase = prisma as unknown as CareIntakeEvidenceDatabase,
+) {
+  assertReference(input.documentRef, "consent document");
+  assertReference(input.signatureEvidenceRef, "signature evidence");
+  assertDigest(input.documentDigest, "consent document");
+  assertDigest(input.signatureDigest, "signature evidence");
+  assertOptionalText(input.documentVersion, "document version", 100);
+  assertOptionalText(input.signatureMethod, "signature method", 100);
+  if (!input.signerPrincipalId) throw new Error("Signer principal required");
+  if (Number.isNaN(input.attestedAt.getTime())) throw new Error("Invalid attestation time");
+  const attestationId = stableEvidenceId("consent-attestation", input);
+  return database.$transaction(async (tx) => {
+    const packet = await packetForStaff(tx, input);
+    const directive = await tx.patientConsentDirective.findFirst({
+      where: {
+        directiveId: input.patientConsentDirectiveId,
+        organizationId: input.organizationId,
+        patientProfileId: packet.patientProfileId,
+      },
+      select: { id: true, directiveId: true },
+    });
+    if (!directive) throw new Error("Patient consent directive not found");
+    let responseId: string | null = null;
+    if (input.responseId) {
+      const response = await tx.careIntakeResponse.findFirst({
+        where: {
+          responseId: input.responseId,
+          packetId: packet.id,
+          organizationId: input.organizationId,
+          patientProfileId: packet.patientProfileId,
+        },
+        select: { id: true },
+      });
+      if (!response) throw new Error("Care intake response not found");
+      responseId = response.id;
+    }
+    const create = {
+      attestationId,
+      organizationId: input.organizationId,
+      packetId: packet.id,
+      patientProfileId: packet.patientProfileId,
+      responseId,
+      patientConsentDirectiveId: directive.id,
+      status: "pending-review",
+      documentRef: input.documentRef.trim(),
+      documentDigest: input.documentDigest.toLowerCase(),
+      documentVersion: input.documentVersion.trim(),
+      signatureEvidenceRef: input.signatureEvidenceRef.trim(),
+      signatureDigest: input.signatureDigest.toLowerCase(),
+      signatureMethod: input.signatureMethod.trim(),
+      signerPrincipalId: input.signerPrincipalId,
+      witnessPrincipalId: input.witnessPrincipalId || null,
+      attestedAt: input.attestedAt,
+    };
+    const row = await tx.careConsentAttestation.upsert({
+      where: { attestationId }, update: {}, create,
+    });
+    if (
+      row.documentRef !== create.documentRef
+      || row.documentDigest !== create.documentDigest
+      || row.signatureEvidenceRef !== create.signatureEvidenceRef
+      || row.signatureDigest !== create.signatureDigest
+      || (row.packetId && row.packetId !== create.packetId)
+    ) {
+      throw new Error("evidence-idempotency-conflict");
+    }
+    await recordCareIntakeStaffDecision(tx, {
+      organizationId: input.organizationId,
+      actorPrincipalId: input.actorPrincipalId,
+      actionKey: "healthcare.intake.consent-attestation.stage",
+      objectRef: `care-consent-attestation:${attestationId}`,
+      routeContext: "/api/v1/healthcare/intake/:packetId/consent-attestations",
+      rationale: { packetId: input.packetId, directiveId: input.patientConsentDirectiveId, status: row.status },
+    });
+    return { attestationId, status: row.status, consentDirectiveChanged: false as const };
+  });
+}
+
+type EvidenceDecisionInput = BaseInput & {
+  decision: "accepted" | "rejected";
+  reason?: string | null;
+};
+
+function rejectionReason(input: EvidenceDecisionInput) {
+  if (input.decision === "accepted") {
+    if (input.reason) throw new Error("Acceptance must not include a rejection reason");
+    return null;
+  }
+  const reason = input.reason?.trim();
+  if (!reason || reason.length > 500) throw new Error("Rejection reason required");
+  return reason;
+}
+
+export async function decideCareCoverageEvidence(
+  input: EvidenceDecisionInput & { evidenceId: string },
+  database: CareIntakeEvidenceDatabase = prisma as unknown as CareIntakeEvidenceDatabase,
+) {
+  const reason = rejectionReason(input);
+  return database.$transaction(async (tx) => {
+    const packet = await packetForStaff(tx, input);
+    const evidence = await tx.careCoverageEvidence.findFirst({
+      where: { evidenceId: input.evidenceId, packetId: packet.id, organizationId: input.organizationId },
+      select: { id: true, evidenceId: true, status: true },
+    });
+    if (!evidence) throw new Error("Coverage evidence not found");
+    if (evidence.status !== "pending-review") throw new Error("evidence-already-reviewed");
+    const data = input.decision === "accepted"
+      ? { status: "accepted", verifiedAt: new Date(), verifiedByPrincipalId: input.actorPrincipalId, rejectionReason: null }
+      : { status: "rejected", verifiedAt: null, verifiedByPrincipalId: null, rejectionReason: reason };
+    const updated = await tx.careCoverageEvidence.updateMany({
+      where: { id: evidence.id, status: "pending-review" }, data,
+    });
+    if (updated.count !== 1) throw new Error("stale-evidence-review");
+    await recordCareIntakeStaffDecision(tx, {
+      organizationId: input.organizationId,
+      actorPrincipalId: input.actorPrincipalId,
+      actionKey: `healthcare.intake.coverage-evidence.${input.decision}`,
+      objectRef: `care-coverage-evidence:${input.evidenceId}`,
+      routeContext: "/api/v1/healthcare/intake/:packetId/coverage-evidence/:evidenceId/decision",
+      rationale: { packetId: input.packetId, decision: input.decision, reason },
+    });
+    return { evidenceId: input.evidenceId, status: input.decision, canonicalCoverageCreated: false as const };
+  });
+}
+
+export async function decideCareConsentAttestation(
+  input: EvidenceDecisionInput & { attestationId: string },
+  database: CareIntakeEvidenceDatabase = prisma as unknown as CareIntakeEvidenceDatabase,
+) {
+  const reason = rejectionReason(input);
+  return database.$transaction(async (tx) => {
+    const packet = await packetForStaff(tx, input);
+    const attestation = await tx.careConsentAttestation.findFirst({
+      where: { attestationId: input.attestationId, packetId: packet.id, organizationId: input.organizationId },
+      select: { id: true, attestationId: true, status: true },
+    });
+    if (!attestation) throw new Error("Consent attestation not found");
+    if (attestation.status !== "pending-review") throw new Error("evidence-already-reviewed");
+    const data = input.decision === "accepted"
+      ? { status: "accepted", acceptedAt: new Date(), acceptedByPrincipalId: input.actorPrincipalId, rejectionReason: null }
+      : { status: "rejected", acceptedAt: null, acceptedByPrincipalId: null, rejectionReason: reason };
+    const updated = await tx.careConsentAttestation.updateMany({
+      where: { id: attestation.id, status: "pending-review" }, data,
+    });
+    if (updated.count !== 1) throw new Error("stale-evidence-review");
+    await recordCareIntakeStaffDecision(tx, {
+      organizationId: input.organizationId,
+      actorPrincipalId: input.actorPrincipalId,
+      actionKey: `healthcare.intake.consent-attestation.${input.decision}`,
+      objectRef: `care-consent-attestation:${input.attestationId}`,
+      routeContext: "/api/v1/healthcare/intake/:packetId/consent-attestations/:attestationId/decision",
+      rationale: { packetId: input.packetId, decision: input.decision, reason },
+    });
+    return { attestationId: input.attestationId, status: input.decision, consentDirectiveChanged: false as const };
+  });
+}

--- a/apps/web/lib/healthcare/care-intake-review-repository.ts
+++ b/apps/web/lib/healthcare/care-intake-review-repository.ts
@@ -1,10 +1,13 @@
-import { randomUUID } from "node:crypto";
-
 import { prisma } from "@dpf/db";
 import {
   calculateIntakeReadiness,
   type CareIntakeRequirement,
 } from "@dpf/db/healthcare-care-intake";
+
+import {
+  recordCareIntakeStaffDecision,
+  setCareIntakeStaffContext,
+} from "./care-intake-staff-context";
 
 type ReviewPacketRow = {
   id: string;
@@ -51,41 +54,6 @@ function requirements(value: unknown): CareIntakeRequirement[] {
   return value as CareIntakeRequirement[];
 }
 
-async function setStaffReviewContext(
-  tx: Transaction,
-  input: { organizationId: string; actorPrincipalId: string },
-) {
-  await tx.$executeRaw`SELECT set_config('app.organization_id', ${input.organizationId}, true), set_config('app.care_intake_staff_principal_id', ${input.actorPrincipalId}, true), set_config('app.care_intake_access_purpose', 'intake-review', true)`;
-}
-
-async function recordAccessDecision(
-  tx: Transaction,
-  input: {
-    organizationId: string;
-    actorPrincipalId: string;
-    actionKey: string;
-    objectRef: string;
-    rationale: Record<string, unknown>;
-  },
-) {
-  await tx.authorizationDecisionLog.create({
-    data: {
-      decisionId: `intake-staff-decision-${randomUUID()}`,
-      actorType: "user",
-      actorRef: input.actorPrincipalId,
-      organizationId: input.organizationId,
-      purposeOfUse: "intake-review",
-      policyVersion: "healthcare-intake-staff-review/v1",
-      actionKey: input.actionKey,
-      objectRef: input.objectRef,
-      decision: "allow",
-      rationale: input.rationale,
-      routeContext: "/api/v1/healthcare/intake/review",
-      sensitivityLevel: "restricted",
-    },
-  });
-}
-
 export async function listCareIntakeReviewQueue(
   input: {
     organizationId: string;
@@ -97,7 +65,7 @@ export async function listCareIntakeReviewQueue(
 ) {
   const limit = Math.min(Math.max(input.limit ?? 25, 1), 100);
   return database.$transaction(async (tx) => {
-    await setStaffReviewContext(tx, input);
+    await setCareIntakeStaffContext(tx, input);
     const packets = await tx.careIntakePacket.findMany({
       where: {
         organizationId: input.organizationId,
@@ -151,11 +119,12 @@ export async function listCareIntakeReviewQueue(
         accessGrants: packet.accessGrants,
       };
     });
-    await recordAccessDecision(tx, {
+    await recordCareIntakeStaffDecision(tx, {
       organizationId: input.organizationId,
       actorPrincipalId: input.actorPrincipalId,
       actionKey: "healthcare.intake.review",
       objectRef: `care-intake-review:${input.organizationId}`,
+      routeContext: "/api/v1/healthcare/intake/review",
       rationale: { resultCount: items.length, payloadProjection: "readiness-no-answers" },
     });
     return { items };
@@ -174,7 +143,7 @@ export async function revokeCareIntakeAccessGrant(
 ) {
   if (!input.reason.trim() || input.reason.length > 500) throw new Error("Invalid revocation reason");
   return database.$transaction(async (tx) => {
-    await setStaffReviewContext(tx, input);
+    await setCareIntakeStaffContext(tx, input);
     const packet = await tx.careIntakePacket.findFirst({
       where: { packetId: input.packetId, organizationId: input.organizationId },
       select: { id: true, packetId: true, patientProfileId: true },
@@ -191,11 +160,12 @@ export async function revokeCareIntakeAccessGrant(
       data: { revokedAt, revocationReason: input.reason.trim() },
     });
     if (updated.count !== 1) throw new Error("stale-intake-grant");
-    await recordAccessDecision(tx, {
+    await recordCareIntakeStaffDecision(tx, {
       organizationId: input.organizationId,
       actorPrincipalId: input.actorPrincipalId,
       actionKey: "healthcare.intake.grant.revoke",
       objectRef: `care-intake-grant:${input.grantId}`,
+      routeContext: "/api/v1/healthcare/intake/:packetId/access-grants/:grantId/revoke",
       rationale: { packetId: input.packetId, reason: input.reason.trim() },
     });
     return { grantId: input.grantId, status: "revoked" as const, revokedAt };

--- a/apps/web/lib/healthcare/care-intake-staff-context.ts
+++ b/apps/web/lib/healthcare/care-intake-staff-context.ts
@@ -1,0 +1,45 @@
+import { randomUUID } from "node:crypto";
+
+export type CareIntakeStaffContextTransaction = {
+  $executeRaw(query: TemplateStringsArray, ...values: unknown[]): Promise<number>;
+  authorizationDecisionLog: { create(args: unknown): Promise<unknown> };
+};
+
+export async function setCareIntakeStaffContext(
+  tx: CareIntakeStaffContextTransaction,
+  input: { organizationId: string; actorPrincipalId: string; patientProfileId?: string },
+) {
+  await tx.$executeRaw`SELECT set_config('app.organization_id', ${input.organizationId}, true), set_config('app.care_intake_staff_principal_id', ${input.actorPrincipalId}, true), set_config('app.care_intake_access_purpose', 'intake-review', true)`;
+  if (input.patientProfileId) {
+    await tx.$executeRaw`SELECT set_config('app.patient_profile_ids', ${input.patientProfileId}, true)`;
+  }
+}
+
+export async function recordCareIntakeStaffDecision(
+  tx: CareIntakeStaffContextTransaction,
+  input: {
+    organizationId: string;
+    actorPrincipalId: string;
+    actionKey: string;
+    objectRef: string;
+    routeContext: string;
+    rationale: Record<string, unknown>;
+  },
+) {
+  await tx.authorizationDecisionLog.create({
+    data: {
+      decisionId: `intake-staff-decision-${randomUUID()}`,
+      actorType: "user",
+      actorRef: input.actorPrincipalId,
+      organizationId: input.organizationId,
+      purposeOfUse: "intake-review",
+      policyVersion: "healthcare-intake-staff-review/v1",
+      actionKey: input.actionKey,
+      objectRef: input.objectRef,
+      decision: "allow",
+      rationale: input.rationale,
+      routeContext: input.routeContext,
+      sensitivityLevel: "restricted",
+    },
+  });
+}

--- a/docs/superpowers/plans/2026-07-16-healthcare-digital-intake.md
+++ b/docs/superpowers/plans/2026-07-16-healthcare-digital-intake.md
@@ -110,6 +110,22 @@ review or revocation writes canonical `AuthorizationDecisionLog` evidence.
 This implements workforce role-based minimum-necessary access and audit-control
 expectations without weakening the patient bearer-token policies.
 
+Reviewed evidence remains deliberately subordinate to its canonical domains.
+Employee routes require `operate_customer` to stage or decide evidence, bind
+every transaction to the organization, authenticated principal, exact packet
+patient, and `intake-review` purpose, and write an `AuthorizationDecisionLog`
+for staging and each accept/reject decision. Idempotency keys derive stable
+server evidence IDs; retries must match the original object references and
+SHA-256 digests or fail as conflicts. Responses disclose evidence IDs and
+review status, never governed object references or signature payloads.
+Acceptance marks intake evidence ready for downstream BI-HEALTHCARE-030 or the
+existing `PatientConsentDirective`; it does not create canonical coverage or
+change the consent directive itself. Decision DI-49F59890F88A selected
+database payload-immutability triggers over repository-only convention or a
+new fully append-only decision schema (high confidence, margin 1.006). The
+triggers retain both evidence types, freeze identity/linkage/provenance/digest
+fields, and leave only the modeled human review fields mutable.
+
 Rollback for 2A is route and repository removal; it adds no schema migration.
 Existing Phase 1 tables remain forward-compatible and contain no raw resume
 tokens.

--- a/packages/db/prisma/migrations/20260717035500_enforce_care_intake_evidence_immutability/migration.sql
+++ b/packages/db/prisma/migrations/20260717035500_enforce_care_intake_evidence_immutability/migration.sql
@@ -1,0 +1,83 @@
+-- BI-HEALTHCARE-012 Phase 2C: evidence references, digests, provenance, and
+-- patient/packet linkage are immutable after staging. Human reviewers may
+-- change only the review status and its reviewer/timestamp/reason fields.
+-- @migration-safety: data-safe: adds trigger functions and triggers only; no existing rows or constraints are changed.
+
+CREATE OR REPLACE FUNCTION prevent_care_consent_attestation_payload_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD."attestationId" IS DISTINCT FROM NEW."attestationId"
+    OR OLD."organizationId" IS DISTINCT FROM NEW."organizationId"
+    OR OLD."packetId" IS DISTINCT FROM NEW."packetId"
+    OR OLD."patientProfileId" IS DISTINCT FROM NEW."patientProfileId"
+    OR OLD."responseId" IS DISTINCT FROM NEW."responseId"
+    OR OLD."patientConsentDirectiveId" IS DISTINCT FROM NEW."patientConsentDirectiveId"
+    OR OLD."documentRef" IS DISTINCT FROM NEW."documentRef"
+    OR OLD."documentDigest" IS DISTINCT FROM NEW."documentDigest"
+    OR OLD."documentVersion" IS DISTINCT FROM NEW."documentVersion"
+    OR OLD."signatureEvidenceRef" IS DISTINCT FROM NEW."signatureEvidenceRef"
+    OR OLD."signatureDigest" IS DISTINCT FROM NEW."signatureDigest"
+    OR OLD."signatureMethod" IS DISTINCT FROM NEW."signatureMethod"
+    OR OLD."signerPrincipalId" IS DISTINCT FROM NEW."signerPrincipalId"
+    OR OLD."witnessPrincipalId" IS DISTINCT FROM NEW."witnessPrincipalId"
+    OR OLD."attestedAt" IS DISTINCT FROM NEW."attestedAt"
+    OR OLD."createdAt" IS DISTINCT FROM NEW."createdAt"
+  THEN
+    RAISE EXCEPTION 'CareConsentAttestation evidence payload is immutable';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION prevent_care_coverage_evidence_payload_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD."evidenceId" IS DISTINCT FROM NEW."evidenceId"
+    OR OLD."organizationId" IS DISTINCT FROM NEW."organizationId"
+    OR OLD."packetId" IS DISTINCT FROM NEW."packetId"
+    OR OLD."patientProfileId" IS DISTINCT FROM NEW."patientProfileId"
+    OR OLD."fundingType" IS DISTINCT FROM NEW."fundingType"
+    OR OLD."payerOrProgramName" IS DISTINCT FROM NEW."payerOrProgramName"
+    OR OLD."memberIdentifierLast4" IS DISTINCT FROM NEW."memberIdentifierLast4"
+    OR OLD."responsiblePartyPrincipalId" IS DISTINCT FROM NEW."responsiblePartyPrincipalId"
+    OR OLD."evidenceRef" IS DISTINCT FROM NEW."evidenceRef"
+    OR OLD."evidenceDigest" IS DISTINCT FROM NEW."evidenceDigest"
+    OR OLD."effectiveFrom" IS DISTINCT FROM NEW."effectiveFrom"
+    OR OLD."effectiveUntil" IS DISTINCT FROM NEW."effectiveUntil"
+    OR OLD."sourceSystem" IS DISTINCT FROM NEW."sourceSystem"
+    OR OLD."sourceId" IS DISTINCT FROM NEW."sourceId"
+    OR OLD."sourceVersion" IS DISTINCT FROM NEW."sourceVersion"
+    OR OLD."createdAt" IS DISTINCT FROM NEW."createdAt"
+  THEN
+    RAISE EXCEPTION 'CareCoverageEvidence evidence payload is immutable';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION prevent_care_intake_evidence_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION '% evidence is append-retained and cannot be deleted', TG_TABLE_NAME;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "CareConsentAttestation_payload_immutable" ON "CareConsentAttestation";
+CREATE TRIGGER "CareConsentAttestation_payload_immutable"
+  BEFORE UPDATE ON "CareConsentAttestation"
+  FOR EACH ROW EXECUTE FUNCTION prevent_care_consent_attestation_payload_mutation();
+
+DROP TRIGGER IF EXISTS "CareConsentAttestation_no_delete" ON "CareConsentAttestation";
+CREATE TRIGGER "CareConsentAttestation_no_delete"
+  BEFORE DELETE ON "CareConsentAttestation"
+  FOR EACH ROW EXECUTE FUNCTION prevent_care_intake_evidence_delete();
+
+DROP TRIGGER IF EXISTS "CareCoverageEvidence_payload_immutable" ON "CareCoverageEvidence";
+CREATE TRIGGER "CareCoverageEvidence_payload_immutable"
+  BEFORE UPDATE ON "CareCoverageEvidence"
+  FOR EACH ROW EXECUTE FUNCTION prevent_care_coverage_evidence_payload_mutation();
+
+DROP TRIGGER IF EXISTS "CareCoverageEvidence_no_delete" ON "CareCoverageEvidence";
+CREATE TRIGGER "CareCoverageEvidence_no_delete"
+  BEFORE DELETE ON "CareCoverageEvidence"
+  FOR EACH ROW EXECUTE FUNCTION prevent_care_intake_evidence_delete();

--- a/packages/db/src/healthcare-care-intake-evidence-immutability.test.ts
+++ b/packages/db/src/healthcare-care-intake-evidence-immutability.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const sql = readFileSync(resolve(
+  process.cwd(),
+  "prisma/migrations/20260717035500_enforce_care_intake_evidence_immutability/migration.sql",
+), "utf8");
+
+describe("care intake reviewed evidence immutability migration", () => {
+  it("freezes consent and coverage payload fields while leaving review fields mutable", () => {
+    expect(sql).toContain("prevent_care_consent_attestation_payload_mutation");
+    expect(sql).toContain("prevent_care_coverage_evidence_payload_mutation");
+    expect(sql).toContain('OLD."signatureDigest" IS DISTINCT FROM NEW."signatureDigest"');
+    expect(sql).toContain('OLD."evidenceDigest" IS DISTINCT FROM NEW."evidenceDigest"');
+    expect(sql).not.toContain('OLD."status" IS DISTINCT FROM NEW."status"');
+    expect(sql).not.toContain('OLD."acceptedAt" IS DISTINCT FROM NEW."acceptedAt"');
+    expect(sql).not.toContain('OLD."verifiedAt" IS DISTINCT FROM NEW."verifiedAt"');
+  });
+
+  it("prevents deletion of both retained evidence types", () => {
+    expect(sql).toContain('"CareConsentAttestation_no_delete"');
+    expect(sql).toContain('"CareCoverageEvidence_no_delete"');
+    expect(sql.match(/prevent_care_intake_evidence_delete/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary

- add employee-authorized staging endpoints for coverage documents and consent attestations
- add explicit human accept/reject endpoints with canonical AuthorizationDecisionLog evidence
- derive retry-stable evidence IDs and reject idempotency collisions when object references or SHA-256 digests differ
- enforce retained, immutable evidence payloads in PostgreSQL while keeping modeled review fields mutable
- preserve authority boundaries: accepted evidence creates neither canonical Coverage nor a consent-directive change

## Architecture

Decision DI-49F59890F88A selected database payload-immutability triggers over repository-only convention or a new fully append-only schema (high confidence, composite 10.224, margin 1.006). Shared staff context/audit logic now has one reusable module for review and evidence workflows.

Employee routes require `operate_customer`, bind organization + principal + exact packet patient + `intake-review` purpose, and return identifiers/status only—never governed object references or signature payloads.

## Verification

- governed exact-SHA local-integration gate passed on `fe31f966b067474be581348cc8419448485b8fe8`
- complete web suite passed
- web and database typecheck passed
- Prisma migrate deploy passed with 401 migrations, including evidence immutability/retention triggers
- production build passed with 563 routes
- focused endpoint/repository/migration tests: 14 passed
- route-manifest, module-size, migration-safety, secret-scan, and DCO guards passed

## Backlog

Advances BI-HEALTHCARE-012 Phase 2C. The backlog item remains in progress for patient/receptionist UX and functional browser verification in Phase 3.