### PR TITLE
fix(ci): preserve typecheck heap on Windows

### DIFF
--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -164,6 +164,12 @@ mode. `DPF_LOCAL_CI_COMMAND` remains an explicit override. The
 old Phase 1 stub is only reachable via `DPF_ALLOW_LOCAL_CI_STUB=1` for contract
 tests and must never be used as release evidence.
 
+The command plan carries required process environment as `env NAME=value ...`
+prefixes, and the Node runner interprets those prefixes directly instead of
+depending on a host `env` executable. This keeps the 8 GiB `NODE_OPTIONS`
+headroom on both POSIX and Windows typecheck paths; the production build may
+still use the host-specific strategy selected by the plan.
+
 The network-disconnect proof is encoded in
 `tests/release/local-ci-gate-contract.test.mjs`: the contract denies network
 Git verbs during `gate-worktree.sh`, records local-only evidence with

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -27,6 +27,44 @@ export function dockerBuildTag(candidateBranch) {
 // it). Verified 2026-07-05: default heap SIGABRT; 8 GiB completes cleanly.
 export const HOST_BUILD_NODE_OPTIONS = "NODE_OPTIONS=--max-old-space-size=8192";
 
+export function resolveCommandInvocation(command, baseEnv = process.env) {
+  if (command[0] !== "env") {
+    return { command: command[0], args: command.slice(1), env: baseEnv };
+  }
+
+  const env = { ...baseEnv };
+  let commandIndex = 1;
+  while (commandIndex < command.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(command[commandIndex])) {
+    const assignment = command[commandIndex];
+    const separator = assignment.indexOf("=");
+    env[assignment.slice(0, separator)] = assignment.slice(separator + 1);
+    commandIndex += 1;
+  }
+  if (commandIndex < command.length && command[commandIndex].includes("=")) {
+    throw new Error(`invalid environment assignment in local-CI command: ${command[commandIndex]}`);
+  }
+  if (commandIndex >= command.length) {
+    throw new Error("environment-prefixed local-CI command is missing an executable");
+  }
+  return {
+    command: command[commandIndex],
+    args: command.slice(commandIndex + 1),
+    env,
+  };
+}
+
+export function resolveGitRevision(ref, { spawnSyncImpl = spawnSync, cwd } = {}) {
+  const result = spawnSyncImpl("git", ["rev-parse", "--verify", ref], {
+    cwd,
+    encoding: "utf8",
+    shell: false,
+  });
+  if (result.status !== 0) {
+    throw new Error(`failed to resolve ${ref}: ${result.stderr || result.stdout}`);
+  }
+  return result.stdout.trim();
+}
+
 function stableJson(value) {
   if (value === undefined) return "null";
   if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
@@ -79,7 +117,7 @@ export function collectToolchainFingerprint({ buildStrategy, cwd = process.cwd()
     platform: process.platform,
     arch: process.arch,
     lockfileSha256: fileSha256(`${cwd}/pnpm-lock.yaml`),
-    nodeOptions: buildStrategy === "host-next" ? HOST_BUILD_NODE_OPTIONS : "",
+    nodeOptions: HOST_BUILD_NODE_OPTIONS,
   });
 }
 
@@ -119,11 +157,9 @@ export function createLocalIntegrationPlan(input) {
     // typecheck needs the same heap headroom as the host-next build: with the
     // node 24 default heap, `tsc --noEmit` over apps/web SIGABRTs (exit 134)
     // exactly like the build worker did (BI-B5011ACE) — observed live on the
-    // first BI-157DC9B2 gate run, 2026-07-06. Windows keeps the plain form
-    // (`env` is POSIX; win32 routes the build through docker anyway).
-    buildStrategy === "docker-build"
-      ? ["pnpm", "--filter", "web", "typecheck"]
-      : ["env", HOST_BUILD_NODE_OPTIONS, "pnpm", "--filter", "web", "typecheck"],
+    // first BI-157DC9B2 gate run, 2026-07-06. The runner interprets the `env`
+    // prefix itself, so this heap contract is identical on every host.
+    ["env", HOST_BUILD_NODE_OPTIONS, "pnpm", "--filter", "web", "typecheck"],
     productionBuildCommand,
   ];
   return {

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -3,7 +3,12 @@
 // CI test job).
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { createLocalIntegrationPlan, createToolchainFingerprint } from "./local-integration-ci.mjs";
+import {
+  createLocalIntegrationPlan,
+  createToolchainFingerprint,
+  resolveGitRevision,
+  resolveCommandInvocation,
+} from "./local-integration-ci.mjs";
 
 describe("createLocalIntegrationPlan", () => {
   it("creates a stable toolchain fingerprint for local-CI evidence (BI-76551B2D)", () => {
@@ -136,6 +141,57 @@ describe("createLocalIntegrationPlan", () => {
     assert.ok(!plan.commands.map((command) => command.join(" ")).join("\n").includes(
       "exec next build",
     ));
+    assert.ok(plan.commands.map((command) => command.join(" ")).includes(
+      "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck",
+    ));
+  });
+
+  it("resolves environment-prefixed commands without relying on a host env binary", () => {
+    const invocation = resolveCommandInvocation(
+      ["env", "NODE_OPTIONS=--max-old-space-size=8192", "pnpm", "--filter", "web", "typecheck"],
+      { PATH: "test-path", NODE_OPTIONS: "--trace-warnings" },
+    );
+
+    assert.equal(invocation.command, "pnpm");
+    assert.deepEqual(invocation.args, ["--filter", "web", "typecheck"]);
+    assert.deepEqual(invocation.env, {
+      PATH: "test-path",
+      NODE_OPTIONS: "--max-old-space-size=8192",
+    });
+  });
+
+  it("preserves plain commands and their base environment", () => {
+    const baseEnv = { PATH: "test-path" };
+    assert.deepEqual(resolveCommandInvocation(["pnpm", "test"], baseEnv), {
+      command: "pnpm",
+      args: ["test"],
+      env: baseEnv,
+    });
+  });
+
+  it("supports multiple, empty, and embedded-equals environment values", () => {
+    assert.deepEqual(resolveCommandInvocation([
+      "env",
+      "EMPTY=",
+      "TOKEN=left=right",
+      "pnpm",
+      "test",
+    ], { PATH: "test-path" }), {
+      command: "pnpm",
+      args: ["test"],
+      env: { PATH: "test-path", EMPTY: "", TOKEN: "left=right" },
+    });
+  });
+
+  it("rejects missing executables and malformed environment assignments", () => {
+    assert.throws(
+      () => resolveCommandInvocation(["env", "NODE_OPTIONS=--trace-warnings"]),
+      /missing an executable/,
+    );
+    assert.throws(
+      () => resolveCommandInvocation(["env", "1BAD=value", "pnpm", "test"]),
+      /invalid environment assignment/,
+    );
   });
 });
 
@@ -164,5 +220,28 @@ describe("createLocalIntegrationPlan migrate-deploy opt-in (BI-157DC9B2)", () =>
       hostPlatform: "linux",
     });
     assert.ok(!plan.commands.map((command) => command.join(" ")).some((c) => c.includes("migrate deploy")));
+  });
+});
+
+describe("resolveGitRevision", () => {
+  it("passes revision expressions directly to Git without a Windows shell", () => {
+    const calls = [];
+    const revision = resolveGitRevision("HEAD^{tree}", {
+      spawnSyncImpl(command, args, options) {
+        calls.push({ command, args, options });
+        return { status: 0, stdout: "tree-sha\n", stderr: "" };
+      },
+    });
+
+    assert.equal(revision, "tree-sha");
+    assert.equal(calls[0].command, "git");
+    assert.deepEqual(calls[0].args, ["rev-parse", "--verify", "HEAD^{tree}"]);
+    assert.equal(calls[0].options.shell, false);
+  });
+
+  it("reports the rejected revision when Git fails", () => {
+    assert.throws(() => resolveGitRevision("missing", {
+      spawnSyncImpl: () => ({ status: 128, stdout: "", stderr: "fatal: bad revision\n" }),
+    }), /failed to resolve missing: fatal: bad revision/);
   });
 });

--- a/scripts/local-integration-ci.mjs
+++ b/scripts/local-integration-ci.mjs
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
-import { collectToolchainFingerprint, createLocalIntegrationPlan } from "./lib/local-integration-ci.mjs";
+import {
+  collectToolchainFingerprint,
+  createLocalIntegrationPlan,
+  resolveCommandInvocation,
+  resolveGitRevision,
+} from "./lib/local-integration-ci.mjs";
 
 function valueAfter(flag) {
   const index = process.argv.indexOf(flag);
@@ -37,35 +42,27 @@ const plan = createLocalIntegrationPlan({
 const startedAt = new Date().toISOString();
 for (const command of plan.commands) {
   console.log(`[local-integration-ci] ${command.join(" ")}`);
-  const result = spawnSync(command[0], command.slice(1), {
+  const invocation = resolveCommandInvocation(command);
+  const result = spawnSync(invocation.command, invocation.args, {
     stdio: "inherit",
     shell: process.platform === "win32",
+    env: invocation.env,
   });
   if (result.status !== 0) process.exit(result.status ?? 1);
 }
 if (metadataOut) {
-  const revParse = (ref) => {
-    const result = spawnSync("git", ["rev-parse", "--verify", ref], {
-      encoding: "utf8",
-      shell: process.platform === "win32",
-    });
-    if (result.status !== 0) {
-      throw new Error(`failed to resolve ${ref}: ${result.stderr || result.stdout}`);
-    }
-    return result.stdout.trim();
-  };
   const payload = {
     schemaVersion: 1,
     bi: "BI-76551B2D",
     mode,
     candidateRef: candidateBranch,
-    candidateSha: candidateSha || revParse(candidateBranch),
+    candidateSha: candidateSha || resolveGitRevision(candidateBranch),
     baseRef,
     fetchBase,
-    baseSha: baseSha || revParse(baseRef),
+    baseSha: baseSha || resolveGitRevision(baseRef),
     integrationBranch: plan.integrationBranch,
-    integrationCommitSha: revParse("HEAD"),
-    synthesizedTreeSha: revParse("HEAD^{tree}"),
+    integrationCommitSha: resolveGitRevision("HEAD"),
+    synthesizedTreeSha: resolveGitRevision("HEAD^{tree}"),
     buildStrategy: plan.buildStrategy,
     ...collectToolchainFingerprint({ buildStrategy: plan.buildStrategy }),
     commands: plan.commands.map((command) => command.join(" ")),


### PR DESCRIPTION
## Summary
- preserve the 8 GiB Node heap contract for local-CI typecheck on Windows and POSIX hosts
- interpret command environment prefixes in Node instead of depending on a host `env` executable
- resolve Git evidence revisions without a shell so `HEAD^{tree}` remains intact on Windows
- document the cross-platform command contract

## Root cause
The Windows `docker-build` plan deliberately emitted plain `pnpm typecheck`, even though the same TypeScript graph already required 8 GiB on POSIX. After that was corrected, metadata generation exposed a second boundary bug: `shell: true` consumed the caret in `HEAD^{tree}` before Git received it.

## Verification
- `node --test scripts/lib/local-integration-ci.test.mjs` — 15/15 passed
- independent spec review — approved
- independent quality review — ready to merge
- governed `local-integration-ci` gate for `ad7b0df1e8742dda52dbb14279a376e67949a8b9` — passed
- canonical gate included Prisma generation/migrations, full web Vitest corpus, Windows typecheck with heap headroom, production Docker build, metadata write, evidence recording, and lease release