### PR TITLE
fix(ops): expose repo root to live readiness preflight

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,6 +179,11 @@ services:
       DEPLOYED_SHA: ${DEPLOYED_SHA:-${DPF_VERSION:-}}
       DPF_ENVIRONMENT: production
       DPF_HOST_INSTALL_PATH: ${DPF_HOST_INSTALL_PATH:-}
+      # Portal-side live-readiness checks run inside the container, where
+      # process.cwd() is /app and not the host Git clone. Point git ancestry
+      # helpers at the mounted host source so verify_live_install_readiness can
+      # decide CAN-TEST vs MUST-ADVANCE without depending on github.com.
+      DPF_REPO_ROOT: /host-dpf
       # Forwarded so scripts/backup-neo4j.sh + scripts/restore-neo4j.sh can
       # translate the portal's /backups view to the host path that the
       # docker-in-docker dump container needs as its bind mount source.

--- a/docs/superpowers/plans/2026-07-17-live-readiness-repo-root.md
+++ b/docs/superpowers/plans/2026-07-17-live-readiness-repo-root.md
@@ -1,0 +1,33 @@
+# Live-readiness repo-root wiring
+
+Date: 2026-07-17
+Backlog: BI-1D55A2AD
+Epic: EP-5410E8EA — Forge-neutral, offline-capable Git integration substrate
+
+## Goal
+
+Make the portal-side `verify_live_install_readiness` path compute Git ancestry on a normal local install without assuming the container working directory is a Git repository.
+
+## Grounding
+
+- `apps/web/lib/verify/preflight-service.ts` already delegates verdicts to `computePreflightVerdict`.
+- `apps/web/lib/verify/git-ancestry.ts` already supports `DPF_REPO_ROOT`, `DPF_GIT_WORK_TREE`, `GIT_DIR`, and then `process.cwd()` as candidate roots.
+- `docker-compose.yml` already mounts the host install path at `/host-dpf` for the `portal` service.
+- The missing contract is the environment variable that tells the portal to use that mount as the Git repo root.
+
+## Plan
+
+1. Add a failing compose-runtime regression test proving the `portal` service exports `DPF_REPO_ROOT: /host-dpf`.
+2. Set `DPF_REPO_ROOT: /host-dpf` in the installed `portal` runtime environment, adjacent to `DPF_HOST_INSTALL_PATH`.
+3. Run the compose-runtime test and the live-readiness unit tests.
+4. After merge and governed self-upgrade, verify `verify_live_install_readiness(featureSha)` returns `CAN-TEST` or `MUST-ADVANCE` instead of `BLOCKED` for a normal Git-stamped local install.
+
+## Verification
+
+- `node --test scripts/lib/compose-runtime-env.test.mjs`
+- `pnpm --filter web exec vitest run lib/verify/git-ancestry.test.ts lib/verify/preflight-service.test.ts lib/verify/preflight.test.ts`
+- Post-upgrade MCP check: `verify_live_install_readiness` against the #3168 merge SHA.
+
+## Rollback
+
+Remove the `DPF_REPO_ROOT` environment variable from `docker-compose.yml`; the portal will fall back to the previous behavior and return the existing operator-readable `BLOCKED` result when it cannot find a Git repo.

--- a/scripts/lib/compose-runtime-env.test.mjs
+++ b/scripts/lib/compose-runtime-env.test.mjs
@@ -31,6 +31,14 @@ test("example compose env documents background job override flags", () => {
   assert.match(envExample, /DPF_OPTIONAL_STARTUP_TASKS_ENABLED=/);
 });
 
+test("portal runtime exposes the host source mount as the git repo root for live-readiness ancestry checks", () => {
+  assert.match(
+    compose,
+    /portal:[\s\S]*- \${DPF_HOST_INSTALL_PATH:-\.}:\/host-dpf[\s\S]*environment:[\s\S]*DPF_REPO_ROOT:\s*\/host-dpf/,
+    "portal must set DPF_REPO_ROOT=/host-dpf so verify_live_install_readiness can compute ancestry without assuming process.cwd() is a git repo",
+  );
+});
+
 test("postgres exporter starts with an explicit config file in compose and installer output", () => {
   assert.equal(existsSync(postgresExporterConfigUrl), true);
   assert.match(readFileSync(postgresExporterConfigUrl, "utf8"), /^auth_modules:\s*\{\}\s*$/m);


### PR DESCRIPTION
## Summary
- Fixes BI-1D55A2AD by setting `DPF_REPO_ROOT=/host-dpf` for the installed portal runtime, using the existing host source mount as the Git ancestry root.
- Adds a compose-runtime regression test so `verify_live_install_readiness` does not quietly fall back to `process.cwd()` inside the container.
- Adds the BI implementation plan stub under `docs/superpowers/plans/`.

## Test plan
- [x] `node --test scripts/lib/compose-runtime-env.test.mjs` — 4 passed
- [x] `pnpm --filter web exec vitest run lib/verify/git-ancestry.test.ts lib/verify/preflight-service.test.ts lib/verify/preflight.test.ts` — 30 passed
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` — passed
- [x] `node scripts/check-design-grounding-decision.mjs && node scripts/check-module-size.mjs` — passed
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build` — passed (existing Edge-runtime warnings only)

## Local-CI-Override

`pnpm run pregate` merged `codex/live-readiness-repo-root` into the local-CI candidate, converged sandbox freshness, generated Prisma, and applied migrations cleanly. It then failed in the known unrelated full-Vitest localStorage harness suites (`AgentFAB`, `BuildStudioDetailsDrawer`, `BuildStudioHeaderLayout`, `BuildStudioNodeInspector`, `TopologyGraph`, `UpdatePendingBannerClient`): 52 failures, 16,739 tests passed. This branch only changes `docker-compose.yml`, `scripts/lib/compose-runtime-env.test.mjs`, and a plan doc; the targeted compose/preflight tests, typecheck, production build, module-size, and design-grounding guards passed.

## UX / runtime note
- No operator-facing UI changes in this PR. After this lands and the local install advances, `verify_live_install_readiness(featureSha)` should return `CAN-TEST` or `MUST-ADVANCE` instead of `BLOCKED` on a normal Git-stamped local install.
