### PR TITLE
fix(release): re-pin hwdsl2 whisper server digest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -820,7 +820,7 @@ services:
   # No profile gate — voice ships working on `docker compose up`.
   dpf-stt:
     # Pinned to the multi-arch index digest for hwdsl2/whisper-server:latest
-    # resolved on 2026-07-11 (the prior 44d7690a… digest was deleted from the
+    # resolved on 2026-07-17 (the prior 3ee18f84… digest was deleted from the
     # registry — Release Image Manifest Guard caught it again). The registry
     # owner re-pushes :latest periodically and prunes the previous index, so
     # this digest must be re-resolved every time the guard fails. Bump
@@ -830,7 +830,7 @@ services:
     # the sidecar won't start, set DPF_STT_IMAGE in .env to a reachable ref
     # (e.g. hwdsl2/whisper-server:latest) then `docker compose up -d dpf-stt`,
     # and open a PR re-resolving the digest here (this is that PR's pattern).
-    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:3ee18f84149389e886829e31ea4bec40b1919682d8fff7f2f0d447a278f196a6}
+    image: ${DPF_STT_IMAGE:-hwdsl2/whisper-server@sha256:120e4b7835898715d97b16e54e991e5226535fdfad506863a3b9cd4dd6d6377f}
     restart: unless-stopped
     logging: *default-logging
     environment:

--- a/tests/release/installer-release-contract.test.mjs
+++ b/tests/release/installer-release-contract.test.mjs
@@ -3,9 +3,9 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const RETIRED_STT_DIGEST =
-  "hwdsl2/whisper-server@sha256:44d7690a05787f76d001a097513e578c51624def64e9dbc4a61132d739851e6b";
-const CURRENT_STT_DIGEST =
   "hwdsl2/whisper-server@sha256:3ee18f84149389e886829e31ea4bec40b1919682d8fff7f2f0d447a278f196a6";
+const CURRENT_STT_DIGEST =
+  "hwdsl2/whisper-server@sha256:120e4b7835898715d97b16e54e991e5226535fdfad506863a3b9cd4dd6d6377f";
 const MANIFEST_GUARD =
   "node scripts/release/verify-compose-image-manifests.mjs --mode release --platform linux --only digest-pinned";
 


### PR DESCRIPTION
## Summary
- Re-pins `hwdsl2/whisper-server:latest` to the current Docker Hub index digest after Release Image Manifest Guard reported the previous digest missing.
- Updates `tests/release/installer-release-contract.test.mjs` retired/current digest constants via `scripts/release/re-resolve-stt-digest.mjs --apply`.

## Test plan
- [x] `node --test scripts/release/re-resolve-stt-digest.test.mjs tests/release/installer-release-contract.test.mjs` — 20 passed
- [x] `node scripts/release/re-resolve-stt-digest.mjs --check` — in sync with Docker Hub API
- [ ] GitHub `Release Image Manifest Guard` — authoritative `docker manifest inspect` verification from fresh runner

## Local-CI-Override

This is a two-file registry digest re-pin generated by the checked-in STT re-resolver. I did not run the full local pregate because the current local-CI full Vitest harness is known-red in unrelated `localStorage` suites. Local targeted release tests passed, and the GitHub release manifest guard is the authoritative validation for the failing check this PR fixes.
