### PR TITLE
fix(ops): run contributor inventory from repo root

### DIFF
--- a/apps/web/lib/queue/functions/contributor-inventory-sync.test.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.test.ts
@@ -63,7 +63,11 @@ vi.mock("@dpf/db", () => ({
   CONTRIBUTOR_INVENTORY_SCHEDULE: "every-10-minutes",
 }));
 
-import { runContributorInventorySync, type SyncSourceReaders } from "./contributor-inventory-sync";
+import {
+  resolveContributorInventoryGitCwd,
+  runContributorInventorySync,
+  type SyncSourceReaders,
+} from "./contributor-inventory-sync";
 
 const FIXED_NOW = new Date("2026-05-26T20:00:00.000Z");
 
@@ -313,6 +317,26 @@ describe("runContributorInventorySync", () => {
       lastError: null,
       nextRunAt: new Date(FIXED_NOW.getTime() + 10 * 60_000),
     });
+  });
+});
+
+describe("resolveContributorInventoryGitCwd", () => {
+  it("prefers DPF_REPO_ROOT so portal inventory commands run against the mounted host clone", () => {
+    expect(
+      resolveContributorInventoryGitCwd({
+        env: { DPF_REPO_ROOT: "/host-dpf" },
+        cwd: "/app",
+      }),
+    ).toBe("/host-dpf");
+  });
+
+  it("falls back to process cwd when DPF_REPO_ROOT is not configured", () => {
+    expect(
+      resolveContributorInventoryGitCwd({
+        env: {},
+        cwd: "/app",
+      }),
+    ).toBe("/app");
   });
 });
 

--- a/apps/web/lib/queue/functions/contributor-inventory-sync.ts
+++ b/apps/web/lib/queue/functions/contributor-inventory-sync.ts
@@ -70,6 +70,17 @@ export type SyncSourceReaders = {
   githubPr: () => Promise<SyncSourceResult>;
 };
 
+export function resolveContributorInventoryGitCwd({
+  env = process.env,
+  cwd = process.cwd(),
+}: {
+  env?: Record<string, string | undefined>;
+  cwd?: string;
+} = {}): string {
+  const repoRoot = env.DPF_REPO_ROOT?.trim();
+  return repoRoot || cwd;
+}
+
 export type RunSyncOptions = {
   triggeredBy?: "cron" | "mcp" | "ui" | string;
   reapStuckRuns?: boolean;
@@ -528,7 +539,7 @@ async function createDefaultReaders(): Promise<SyncSourceReaders> {
     parseGitBranchList,
   } = await import("@/lib/contributor-change-lanes/git-inventory");
 
-  const cwd = process.cwd();
+  const cwd = resolveContributorInventoryGitCwd();
   const TIMEOUT_MS = 8_000;
   const MAX_BUFFER = 4 * 1024 * 1024;
 

--- a/docs/superpowers/plans/2026-07-17-local-source-repository-health-card.md
+++ b/docs/superpowers/plans/2026-07-17-local-source-repository-health-card.md
@@ -53,6 +53,11 @@ Give a non-technical operator a plain answer to: “Is my local source home heal
    - Verify: component test asserts the card answers “Local source repository” and exposes plain next actions.
 3. Merge hygiene.
    - Run targeted tests and typecheck. Runtime/browser verification can use the already-live `/platform/development/change-lanes` route after self-upgrade.
+4. Live-install inventory cwd hardening.
+   - Observation from self-upgrade verification: the card rendered on the live image, but the contributor inventory cron still ran Git from the portal process cwd (`/app`) instead of the mounted host clone (`/host-dpf`), so local Git snapshot sources reported `fatal: not a git repository`.
+   - Touch: `apps/web/lib/queue/functions/contributor-inventory-sync.ts`.
+   - Contract: default Git inventory readers must prefer `DPF_REPO_ROOT` when present and fall back to `process.cwd()` only for source-local/dev execution.
+   - Verify: regression test covers the `DPF_REPO_ROOT=/host-dpf`, `cwd=/app` case before relying on live inventory health.
 
 ## Risk and rollback
 


### PR DESCRIPTION
## Summary
- make contributor inventory Git readers prefer `DPF_REPO_ROOT` so the portal container reads the mounted host clone (`/host-dpf`) instead of `/app`
- add regression coverage for `DPF_REPO_ROOT=/host-dpf`, `cwd=/app`
- document the live-install finding in the local source repository health card plan

## Verification
- `pnpm --filter web exec vitest run lib/queue/functions/contributor-inventory-sync.test.ts lib/contributor-change-lanes/local-repository-health.test.ts components/platform/development/change-lanes/LocalRepositoryHealthCard.test.tsx`
- `NODE_OPTIONS='--max-old-space-size=8192' pnpm --filter web typecheck`

Local-CI-Override: full `pnpm run pregate` merged the branch and applied migrations, but failed in unrelated UI suites that require `localStorage` in the full Vitest harness (`AgentFAB`, `BuildStudio*`, `TopologyGraph`, `UpdatePendingBannerClient`). The affected contributor-inventory tests and web typecheck pass.