### PR TITLE
fix(dpf-skill-pack): self-heal duplicate Codex TOML tables, not just prevent them

### DIFF
--- a/packages/dpf-skill-pack/.claude-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dpf-platform",
   "description": "DPF-native agent skills for both Claude Code contributors (plugin namespace dpf-platform:*) and in-portal coworkers (seeded as SkillDefinition rows by the extended seed-skills.ts loader). Single-source-of-truth contract: superset SKILL.md frontmatter feeds both surfaces from one file per skill. See README.md.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "Digital Product Factory",
     "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"

--- a/packages/dpf-skill-pack/.codex-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dpf-platform",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "DPF-native agent skills for contributor sessions and in-portal coworkers.",
   "author": {
     "name": "Digital Product Factory",

--- a/packages/dpf-skill-pack/.grok-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dpf-platform",
   "description": "DPF-native agent skills for Grok contributors. Single-source-of-truth contract: superset SKILL.md frontmatter feeds both external Grok users and in-portal coworkers. See README.md.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "Digital Product Factory",
     "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -209,28 +209,52 @@ def canonical_toml_table_header(line: str) -> str | None:
     return ".".join(parts)
 
 
+def _is_table_boundary(line: str) -> bool:
+    stripped = line.strip()
+    return canonical_toml_table_header(stripped) is not None or (
+        stripped.startswith("[[") and stripped.endswith("]]")
+    )
+
+
 def upsert_toml_table(text: str, header: str, body_lines: list[str]) -> str:
     lines = text.splitlines()
-    start = None
     target_header = canonical_toml_table_header(header)
-    for index, line in enumerate(lines):
-        if target_header is not None and canonical_toml_table_header(line) == target_header:
-            start = index
-            break
-    block = [lines[start].strip() if start is not None else header, *body_lines]
-    if start is None:
+
+    # Collect the [start, end) span of EVERY table whose canonical key matches.
+    # Canonical matching (added in #2657) already stops us appending a fresh
+    # duplicate, but a config a pre-#2657 updater already corrupted still carries
+    # a stray second copy. Collapsing all matches into one block heals that in
+    # place -- a duplicate table is a TOML redefinition error, so leaving it
+    # forces the operator to hand-delete the block on every run.
+    ranges: list[tuple[int, int]] = []
+    index = 0
+    while index < len(lines):
+        if target_header is not None and canonical_toml_table_header(lines[index]) == target_header:
+            end = index + 1
+            while end < len(lines) and not _is_table_boundary(lines[end]):
+                end += 1
+            ranges.append((index, end))
+            index = end
+        else:
+            index += 1
+
+    if not ranges:
         prefix = "\n" if text.strip() else ""
-        return text.rstrip() + prefix + "\n".join(block) + "\n"
-    end = start + 1
-    while end < len(lines):
-        stripped = lines[end].strip()
-        if canonical_toml_table_header(stripped) is not None or (
-            stripped.startswith("[[") and stripped.endswith("]]")
-        ):
-            break
-        end += 1
-    next_lines = lines[:start] + block + lines[end:]
-    return "\n".join(next_lines).rstrip() + "\n"
+        return text.rstrip() + prefix + "\n".join([header, *body_lines]) + "\n"
+
+    # Preserve the first occurrence's existing header spelling so we never
+    # gratuitously reformat a table whose quoting another writer owns.
+    first_start = ranges[0][0]
+    block = [lines[first_start].strip(), *body_lines]
+    removal = {ln for start, end in ranges for ln in range(start, end)}
+    rebuilt: list[str] = []
+    for i, line in enumerate(lines):
+        if i == first_start:
+            rebuilt.extend(block)
+        if i in removal:
+            continue
+        rebuilt.append(line)
+    return "\n".join(rebuilt).rstrip() + "\n"
 
 
 def ensure_codex_config(home: Path, mcp_url: str, dry_run: bool) -> bool:

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -220,6 +220,47 @@ class UpdateAgentToolchainTest(unittest.TestCase):
                 self.assertTrue(data["plugins"]["dpf-platform"]["enabled"])
             self.assertEqual(raw.count("dpf-platform"), 1)
 
+    def test_heals_config_already_corrupted_with_duplicate_table(self) -> None:
+        """A config a pre-#2657 updater left with a stray appended
+        `[mcp_servers.dpf]` (a TOML redefinition error) is healed back to a single
+        table on the next run, rather than forcing the operator to hand-delete the
+        duplicate every time. Unrelated tables are left intact."""
+        skill_pack = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            config = home / ".codex" / "config.toml"
+            config.parent.mkdir(parents=True)
+            config.write_text(
+                'model = "gpt-5.5"\n\n'
+                "[mcp_servers.dpf]\n"
+                'url = "http://127.0.0.1:3000/api/mcp/v1"\n'
+                'bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"\n'
+                "enabled = true\n\n"
+                "[mcp_servers.node_repl]\n"
+                'command = "node"\n\n'
+                # The stray duplicate a pre-fix fallback run appended at the end.
+                "[mcp_servers.dpf]\n"
+                'url = "http://127.0.0.1:3000/api/mcp/v1"\n'
+                'bearer_token_env_var = "DPF_MCP_BEARER_TOKEN"\n'
+                "enabled = true\n",
+                encoding="utf-8",
+            )
+
+            with patch.dict(os.environ, {"DPF_AGENT_TOOLCHAIN_HOME": tmp}, clear=False):
+                updater.main([
+                    "--skill-pack-path",
+                    str(skill_pack),
+                    "--skip-claude-cli-install",
+                    "--skip-grok-cli-install",
+                ])
+
+            raw = config.read_text()
+            self.assertEqual(raw.count("[mcp_servers.dpf]"), 1)
+            if tomllib is not None:
+                data = tomllib.loads(raw)  # raises if a duplicate table survives
+                self.assertEqual(data["mcp_servers"]["node_repl"]["command"], "node")
+                self.assertEqual(data["model"], "gpt-5.5")
+
     @unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
     def test_repairs_missing_managed_plugin_without_token_or_portal(self) -> None:
         skill_pack = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Problem

Codex `~/.codex/config.toml` "keeps having a second `[mcp_servers.dpf]` / dpf-platform entry appended at the bottom" that the operator has to hand-delete to recover. Reproduced live on a contributor machine mid-investigation.

## Root cause chain

1. Self-update runs `scripts/dpf-bootstrap-agent-toolchain.sh`, which first tries the **safe** TS path (`compute-plan.ts` → `planCodexConfig` → `smol-toml` round-trip — dedups by key, can't duplicate).
2. When that `pnpm … tsx` step fails, the bootstrap **execs the standalone Python fallback** `update_agent_toolchain.py`. That's the "sometimes."
3. Pre-#2657 the Python `upsert_toml_table` matched tables by **exact string**, so when `smol-toml` had written a table bare (`[plugins.dpf-platform]`) and Python searched the quoted form, it missed and **appended a duplicate at the bottom** — which is invalid TOML (same-key redefinition), so the next clean `planCodexConfig` run refuses to write and the corruption sticks.

## Two gaps this PR closes (beyond #2657)

[#2657](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2657) made matching canonical (quote-insensitive) so the updater no longer **appends** a new duplicate. But:

**Gap 1 — no self-heal.** A config already corrupted by pre-#2657 code kept its stray duplicate: `upsert_toml_table` rewrote the *first* match in place and left the *second*. That's why the duplicate keeps coming back — the updater never removes it. **Fix:** collapse every table with the same canonical key into one block at the first occurrence (preserving that occurrence's spelling). Idempotent; unrelated tables stay byte-intact.

**Gap 2 — the fix couldn't propagate.** Plugin caches are **version-keyed** (`~/.codex/plugins/cache/<name>/<version>/`). #2657 shipped its code fix **without a version bump**, so on the repro machine the Codex plugin stayed frozen on buggy `0.2.0` code (only Claude advanced to `0.2.1` via a later unrelated bump) — and kept re-appending the duplicate on every Codex session. **Fix:** bump `0.2.1 → 0.2.2` across the codex/claude/grok manifests so the self-heal actually lands on installs instead of stranding behind the version key.

## Test

`test_heals_config_already_corrupted_with_duplicate_table`: seeds a config with a stray appended `[mcp_servers.dpf]` and asserts it heals to one table with neighbours (`node_repl`, `model`) intact. Runs in the existing `agent-toolchain-bootstrap-smoke` CI job. Full local suite: 22 passed (3 tomllib-gated tests skip on Python 3.9).

## Note for deployed machines

An install already on the buggy cached `0.2.0` needs a plugin refresh to a version ≥ this one before the recurrence stops; a same-version code swap won't propagate through the version-keyed cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)