### PR TITLE
feat(build): surface work warrant in Build Studio

### DIFF
--- a/apps/web/components/build/BuildStudio.tsx
+++ b/apps/web/components/build/BuildStudio.tsx
@@ -41,6 +41,7 @@ import { BuildDecisionLedgerBand } from "./BuildDecisionLedgerBand";
 import { BuildChangeSummaryBand } from "./BuildChangeSummaryBand";
 import { BuildSolutionSummaryBand } from "./BuildSolutionSummaryBand";
 import { BuildCustomerStatusBand } from "./BuildCustomerStatusBand";
+import { BuildWorkWarrantBand } from "./BuildWorkWarrantBand";
 import type { BuildStudioCustomerStatus } from "@/lib/build/customer-status-projection";
 import { BuildOperatorHeaderDetails, BuildWorkRequestStrip, formatOperatorPhaseLabel } from "./BuildOperatorContext";
 import { resolveBuildStudioBranchBadge } from "./build-studio-branch-badge";
@@ -265,6 +266,7 @@ export function BuildStudio({
     buildTitle: activeBuild?.title ?? null,
     workspaceBranch: projectBranch,
   });
+  const activeWorkWarrant = (activeBuild?.plan as Record<string, unknown> | null | undefined)?.workWarrant;
   const activeLifecycleLabel = activeBuild
     ? deriveLifecycleLabel({
       backlogItem: activeBuild.originator
@@ -874,6 +876,11 @@ export function BuildStudio({
                     setDrawerOpen(true);
                   }}
                 />
+                {activeWorkWarrant !== null && activeWorkWarrant !== undefined && (
+                  <div className="border-b border-[var(--dpf-border)] px-4 py-3">
+                    <BuildWorkWarrantBand warrant={activeWorkWarrant} />
+                  </div>
+                )}
                 {activeBuild && activeBuild.phase === "ship" && (
                   <div className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
                     <ReleaseDecisionPanel

--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -874,6 +874,52 @@ describe("BuildStudio header — hide internal IDs by default (BI-63EAD801)", ()
     expect(details.textContent).toContain("BI-5B839D74");
     expect(details.textContent).toContain("dpf/aabbccdd/");
   });
+
+  it("surfaces the active build WorkWarrant in plain language", () => {
+    const html = renderToStaticMarkup(
+      <BuildStudio
+        builds={[
+          makeBuild({
+            plan: {
+              workWarrant: {
+                altitude: "WWMD",
+                altitudeBasis: "structural",
+                confidence: "high",
+                needsOperatorConfirm: false,
+                lane: "governed-interactive",
+                budget: {
+                  modelTier: "strong",
+                  effortLevel: "high",
+                  gateProfile: "full",
+                  tokenCeiling: null,
+                },
+                evidenceProfile: "architectural",
+                reportingProfile: "ledger",
+                contextScope: {
+                  industry: null,
+                  jurisdiction: null,
+                  archetype: null,
+                },
+                reasons: ["touches a cross-cutting platform contract"],
+              },
+            },
+          }),
+        ]}
+        epicRollups={[]}
+        portfolios={[]}
+        governedBacklogEnabled
+        portalContext={makePortalContextEnvelope()}
+        projectBranch="main"
+        submissionBranchShortId="aabbccdd"
+      />,
+    );
+
+    expect(html).toContain('data-testid="build-work-warrant-band"');
+    expect(html).toContain("Architecture-level work");
+    expect(html).toContain("governed review");
+    expect(html).toContain("strong model");
+    expect(html).toContain("ledger evidence");
+  });
 });
 
 function makePortalContextEnvelope(): PortalContextEnvelope {

--- a/apps/web/components/build/BuildWorkWarrantBand.test.tsx
+++ b/apps/web/components/build/BuildWorkWarrantBand.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { BuildWorkWarrantBand } from "./BuildWorkWarrantBand";
+import type { WorkWarrant } from "@/lib/decision/work-warrant";
+
+const baseWarrant: WorkWarrant = {
+  altitude: "WWMD",
+  altitudeBasis: "structural",
+  confidence: "high",
+  needsOperatorConfirm: false,
+  lane: "governed-interactive",
+  budget: {
+    modelTier: "strong",
+    effortLevel: "high",
+    gateProfile: "full",
+    tokenCeiling: null,
+  },
+  evidenceProfile: "architectural",
+  reportingProfile: "ledger",
+  contextScope: {
+    industry: null,
+    jurisdiction: null,
+    archetype: null,
+  },
+  reasons: ["touches a cross-cutting platform contract"],
+};
+
+describe("BuildWorkWarrantBand", () => {
+  it("renders a plain-language architectural warrant summary", () => {
+    const html = renderToStaticMarkup(<BuildWorkWarrantBand warrant={baseWarrant} />);
+
+    expect(html).toContain("Work warrant");
+    expect(html).toContain("Architecture-level work");
+    expect(html).toContain("governed review");
+    expect(html).toContain("strong model");
+    expect(html).toContain("ledger evidence");
+    expect(html).toContain("touches a cross-cutting platform contract");
+  });
+
+  it("renders nothing when no warrant has been recorded", () => {
+    const html = renderToStaticMarkup(<BuildWorkWarrantBand warrant={null} />);
+
+    expect(html).toBe("");
+  });
+});

--- a/apps/web/components/build/BuildWorkWarrantBand.tsx
+++ b/apps/web/components/build/BuildWorkWarrantBand.tsx
@@ -1,0 +1,97 @@
+import { StatusBadge, type Intent } from "@/components/ui/report-kit";
+import type { WorkWarrant } from "@/lib/decision/work-warrant";
+
+type WarrantAltitude = WorkWarrant["altitude"];
+type WarrantLane = WorkWarrant["lane"];
+type WarrantEvidence = WorkWarrant["evidenceProfile"];
+type WarrantReporting = WorkWarrant["reportingProfile"];
+
+const ALTITUDE_COPY: Record<WarrantAltitude, { label: string; summary: string; intent: Intent }> = {
+  WSID: {
+    label: "Craft-level work",
+    summary: "lightweight execution",
+    intent: "neutral",
+  },
+  WWWD: {
+    label: "Business-level work",
+    summary: "operator-confirmed business review",
+    intent: "accent",
+  },
+  WWMD: {
+    label: "Architecture-level work",
+    summary: "governed review",
+    intent: "warning",
+  },
+};
+
+const LANE_COPY: Record<WarrantLane, string> = {
+  "autonomous-bs": "autonomous Build Studio lane",
+  "governed-interactive": "governed review",
+  "direct-expert": "direct expert review",
+};
+
+const EVIDENCE_COPY: Record<WarrantEvidence, string> = {
+  minimal: "minimal evidence",
+  standard: "standard evidence",
+  compliance: "compliance evidence",
+  architectural: "ledger evidence",
+};
+
+const REPORTING_COPY: Record<WarrantReporting, string> = {
+  "one-line": "one-line update",
+  business: "business summary",
+  ledger: "ledger report",
+};
+
+function firstReason(warrant: WorkWarrant): string | null {
+  return warrant.reasons.find((reason) => !reason.startsWith("altitude ")) ?? warrant.reasons[0] ?? null;
+}
+
+function isWorkWarrant(value: unknown): value is WorkWarrant {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<WorkWarrant>;
+  return (
+    (candidate.altitude === "WSID" || candidate.altitude === "WWWD" || candidate.altitude === "WWMD") &&
+    (candidate.lane === "autonomous-bs" || candidate.lane === "governed-interactive" || candidate.lane === "direct-expert") &&
+    !!candidate.budget &&
+    typeof candidate.budget === "object" &&
+    typeof candidate.budget.modelTier === "string" &&
+    typeof candidate.evidenceProfile === "string" &&
+    typeof candidate.reportingProfile === "string" &&
+    Array.isArray(candidate.reasons)
+  );
+}
+
+export function BuildWorkWarrantBand({ warrant }: { warrant: unknown }) {
+  if (!isWorkWarrant(warrant)) return null;
+
+  const altitude = ALTITUDE_COPY[warrant.altitude];
+  const model = `${warrant.budget.modelTier} model`;
+  const evidence = EVIDENCE_COPY[warrant.evidenceProfile];
+  const reporting = REPORTING_COPY[warrant.reportingProfile];
+  const lane = LANE_COPY[warrant.lane];
+  const reason = firstReason(warrant);
+
+  return (
+    <section
+      data-testid="build-work-warrant-band"
+      className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3 shadow-dpf-xs"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <h3 className="m-0 text-sm font-semibold text-[var(--dpf-text)]">Work warrant</h3>
+        <StatusBadge intent={altitude.intent} label={altitude.label} variant="soft" uppercase={false} />
+        {warrant.needsOperatorConfirm && (
+          <StatusBadge intent="warning" label="Needs confirmation" variant="soft" uppercase={false} />
+        )}
+      </div>
+      <p className="m-0 mt-2 max-w-4xl text-xs leading-relaxed text-[var(--dpf-text-secondary)]">
+        {altitude.summary}: {lane}, {model}, {evidence}, {reporting}.
+      </p>
+      {reason && (
+        <p className="m-0 mt-1 max-w-4xl text-xs leading-relaxed text-[var(--dpf-muted)]">
+          Why: {reason}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
+++ b/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
@@ -130,6 +130,34 @@ heuristic with code-graph blast-radius." They should be consolidated: the code-g
 blast-radius feeds `sensitivity` (verify) and the warrant's blast-radius (promote) through
 one core, not two.
 
+## Operator visibility slice (feat/work-warrant-visibility)
+
+UX fit: fits-with-guardrails.
+
+- Owning area: Platform > Build Studio.
+- Route family: `/build`.
+- Primary persona: founder/operator or contributor who needs to understand how much rigor a build will use without reading JSON or enum names.
+- Navigation layer: no navigation change; existing active-build pane only.
+- Reuse/convergence: compose report-kit `StatusBadge` and existing Build Studio status-band styling; no new route, dashboard, tab, or one-off badge palette.
+- Source truth: `FeatureBuild.plan.workWarrant`.
+- Empty/failure behavior: older builds without `plan.workWarrant` render no band, avoiding false certainty.
+- AI boundary: informational only; no prompt-send or coworker action.
+
+Implementation:
+
+- Add a plain-language WorkWarrant band to the active-build pane:
+  - “Architecture-level work — governed review, strong model, ledger evidence”
+  - “Business-level work — operator-confirmed business review”
+  - “Craft-level work — lightweight execution”
+- Carry the warrant’s first concrete reason into the band as “Why: …” so the operator can see what caused the rigor level.
+
+Evidence before merge:
+
+```bash
+pnpm --filter web exec vitest run components/build/BuildWorkWarrantBand.test.tsx components/build/BuildStudioHeaderLayout.test.tsx
+pnpm --filter web typecheck
+```
+
 ## Promote wiring (feat/warrant-promote-wiring) — the plane takes effect
 
 Before this, `deliverableSensitivity` was never set on promoted builds, so


### PR DESCRIPTION
## Summary
- Adds a Build Studio work-warrant band for active builds that carry `plan.workWarrant`, translating WSID/WWWD/WWMD into plain-language operator labels.
- Shows the selected lane, model tier, evidence posture, reporting profile, and the first useful reason without exposing enum-heavy implementation detail.
- Updates the WorkWarrant plan with the operator-visibility slice and UX fit decision.

Linked BI: BI-8AB0E66D

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md` — WorkWarrant plan, Phase 3 operator visibility intent.
  - DPF UX fit rules via `dpf-ux-fit-review`: keep this inside existing Build Studio active-build context; do not add a new route, tab, dashboard, or action surface.
- Current code substrate reviewed:
  - `apps/web/components/build/BuildStudio.tsx` — active build panel composition and existing work request strip placement.
  - `apps/web/components/build/BuildStudioHeaderLayout.test.tsx` — static Build Studio render contract.
  - `apps/web/components/report-kit/StatusBadge.tsx` — existing status badge styling and tokenized UI vocabulary.
  - `apps/web/lib/build/work-warrant.ts` — source WorkWarrant shape and values.
- Source of truth:
  - `FeatureBuild.plan.workWarrant`; the band renders only when that warrant exists and remains informational only.
- Decision:
  - Surface the warrant as a compact informational band below the existing active-build request strip, using plain-language labels and existing report-kit styling.

## Test plan
- [x] `pnpm --filter web exec vitest run components/build/BuildWorkWarrantBand.test.tsx components/build/BuildStudioHeaderLayout.test.tsx`
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck`
- [x] `node scripts/check-doc-reference-integrity.mjs`
- [x] `git diff --check`
- [x] `pnpm run pregate` on rebased SHA `046f49c937177f3aca9c43a53f982405eae1d19e` — full local-CI gate passed: migrations no-op, full web vitest, typecheck, and production `next build`.
- [x] UX fit review: fits-with-guardrails; reused existing Build Studio active-build surface and report-kit badge styling; no new route/nav/tab.

## Operator notes
- Overlap sweep: open PRs reviewed; no overlapping WorkWarrant/Build Studio visibility PR found.
- This is intentionally informational only: it makes the existing WorkWarrant decision legible to operators and does not add new actions or prompt sends.

Local-CI-Override: Full governed local-CI passed on feature head 046f49c937177f3aca9c43a53f982405eae1d19e. The current signed merge only refreshes against already-green main; design-grounding, UX-fit, and diff checks pass locally, with fresh merged-code verification delegated to PR CI.