### PR TITLE
feat(enrich): CPE 2.3 crosswalk for CatalogIdentity (BI-44B8B1E4, EP-ASSET-INTELLIGENCE)

### DIFF
--- a/docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md
+++ b/docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md
@@ -131,7 +131,7 @@ This is the kernel/org-overlay pattern again: component catalog entries are kern
 
 **Phase B — Open support-lifecycle & vuln feeds:**
 - endoflife.date connector → CatalogLifecycleMilestone (+ optional vendor calendars) — **BI-3A2328D6** — feed logic **landed** in `packages/db/src/endoflife-lifecycle.ts` (`releaseToMilestones`/`selectRelease`/`fetchEolProduct`/`upsertLifecycleForIdentity`, endoflife.date→milestone mapping + idempotent upsert onto CatalogIdentity); the scheduled sweep that iterates CatalogIdentities + the CPE-keyed slug resolution are the follow-up wiring.
-- NVD CPE 2.3 crosswalk + broaden vuln beyond OSS — **BI-44B8B1E4**
+- NVD CPE 2.3 crosswalk + broaden vuln beyond OSS — **BI-44B8B1E4** — crosswalk **landed** in `packages/db/src/cpe-crosswalk.ts` (`buildCpe23` deterministic CPE 2.3 from a CatalogIdentity, `fetchNvdCpeNames` NVD-dictionary resolution, `resolveCatalogIdentityCpe` sets `CatalogIdentity.cpe`); broadening vuln lookups to installed/commercial products via the resolved CPE is the follow-up.
 - OS-package patch coverage + EOL/support posture UI — **BI-9C0424E4**
 - SBOM → CatalogIdentity enrichment bridge (component=public, occurrence=private) — **BI-19FD07F9**
 

--- a/packages/db/src/cpe-crosswalk.test.ts
+++ b/packages/db/src/cpe-crosswalk.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCpe23,
+  cpeToken,
+  fetchNvdCpeNames,
+  resolveCatalogIdentityCpe,
+  type CpeUpsertClient,
+} from "./cpe-crosswalk";
+
+describe("cpeToken", () => {
+  it("lowercases, underscores whitespace, strips other punctuation, and maps empty to *", () => {
+    expect(cpeToken("PostgreSQL Global Development Group")).toBe("postgresql_global_development_group");
+    expect(cpeToken("Node.js")).toBe("node.js");
+    expect(cpeToken("C++")).toBe("c");
+    expect(cpeToken("  ")).toBe("*");
+    expect(cpeToken(null)).toBe("*");
+  });
+});
+
+describe("buildCpe23", () => {
+  it("builds a well-formed cpe:2.3 string with * for unspecified attributes", () => {
+    expect(buildCpe23({ part: "a", manufacturer: "PostgreSQL", product: "PostgreSQL" })).toBe(
+      "cpe:2.3:a:postgresql:postgresql:*:*:*:*:*:*:*:*",
+    );
+  });
+  it("fills version + edition and honors the CPE part", () => {
+    expect(
+      buildCpe23({ part: "o", manufacturer: "Canonical", product: "Ubuntu", productVersion: "22.04", edition: "LTS" }),
+    ).toBe("cpe:2.3:o:canonical:ubuntu:22.04:*:lts:*:*:*:*:*");
+    expect(buildCpe23({ part: "h", manufacturer: "Dell", product: "PowerEdge R750" })).toContain("cpe:2.3:h:dell:poweredge_r750:");
+  });
+  it("defaults an unknown/missing part to 'a'", () => {
+    expect(buildCpe23({ part: "x", manufacturer: "Acme", product: "Thing" })).toContain("cpe:2.3:a:acme:thing:");
+    expect(buildCpe23({ manufacturer: "Acme", product: "Thing" })).toContain("cpe:2.3:a:acme:thing:");
+  });
+});
+
+describe("fetchNvdCpeNames", () => {
+  const okResponse = (products: unknown) =>
+    ({ ok: true, json: async () => ({ products }) }) as unknown as Response;
+
+  it("extracts curated cpeName values from the NVD products payload", async () => {
+    const fetcher = (async () =>
+      okResponse([
+        { cpe: { cpeName: "cpe:2.3:a:postgresql:postgresql:16.2:*:*:*:*:*:*:*" } },
+        { cpe: {} },
+        { other: true },
+      ])) as unknown as typeof fetch;
+    expect(await fetchNvdCpeNames("cpe:2.3:a:postgresql:postgresql:*:*:*:*:*:*:*:*", fetcher)).toEqual([
+      "cpe:2.3:a:postgresql:postgresql:16.2:*:*:*:*:*:*:*",
+    ]);
+  });
+
+  it("returns [] on a non-OK response and on a thrown error", async () => {
+    const notOk = (async () => ({ ok: false }) as unknown as Response) as unknown as typeof fetch;
+    expect(await fetchNvdCpeNames("cpe:2.3:a:x:y:*:*:*:*:*:*:*:*", notOk)).toEqual([]);
+    const throws = (async () => {
+      throw new Error("network");
+    }) as unknown as typeof fetch;
+    expect(await fetchNvdCpeNames("cpe:2.3:a:x:y:*:*:*:*:*:*:*:*", throws)).toEqual([]);
+  });
+});
+
+describe("resolveCatalogIdentityCpe", () => {
+  it("persists the deterministic CPE when no fetcher is supplied", async () => {
+    const updates: Array<{ where: { id: string }; data: { cpe: string } }> = [];
+    const db: CpeUpsertClient = {
+      catalogIdentity: {
+        update: async (args: unknown) => {
+          updates.push(args as { where: { id: string }; data: { cpe: string } });
+          return {};
+        },
+      },
+    };
+    const cpe = await resolveCatalogIdentityCpe(db, { id: "ci_1", manufacturer: "PostgreSQL", product: "PostgreSQL" });
+    expect(cpe).toBe("cpe:2.3:a:postgresql:postgresql:*:*:*:*:*:*:*:*");
+    expect(updates).toEqual([{ where: { id: "ci_1" }, data: { cpe } }]);
+  });
+
+  it("prefers a curated NVD dictionary name when the fetcher resolves one", async () => {
+    const db: CpeUpsertClient = { catalogIdentity: { update: async () => ({}) } };
+    const fetcher = (async () =>
+      ({
+        ok: true,
+        json: async () => ({ products: [{ cpe: { cpeName: "cpe:2.3:a:postgresql:postgresql:16.2:*:*:*:*:*:*:*" } }] }),
+      }) as unknown as Response) as unknown as typeof fetch;
+    const cpe = await resolveCatalogIdentityCpe(
+      db,
+      { id: "ci_1", manufacturer: "PostgreSQL", product: "PostgreSQL" },
+      fetcher,
+    );
+    expect(cpe).toBe("cpe:2.3:a:postgresql:postgresql:16.2:*:*:*:*:*:*:*");
+  });
+});

--- a/packages/db/src/cpe-crosswalk.ts
+++ b/packages/db/src/cpe-crosswalk.ts
@@ -1,0 +1,103 @@
+// CPE 2.3 crosswalk for the CatalogIdentity spine (BI-44B8B1E4, EP-ASSET-INTELLIGENCE).
+// CPE (Common Platform Enumeration, cpe:2.3) is the open identity key that both the
+// endoflife.date feed (its identifiers[] carry CPE) and NVD CVE lookups join on — the
+// vendor→product→version identity analog. This builds a deterministic CPE from a
+// CatalogIdentity and (optionally) resolves it to a curated NVD-dictionary name.
+//
+// The NVD fetch is injectable so the pure build + the upsert are unit-tested from
+// fixtures, no network. Air-gapped installs point NVD_API_BASE at a mirror; a free
+// NVD_API_KEY raises the rate limit (5→50 req/30s) but is optional.
+
+export type CpeIdentityInput = {
+  part?: string | null; // CPE part: a (application) | o (os) | h (hardware)
+  manufacturer: string;
+  product: string;
+  productVersion?: string | null;
+  edition?: string | null;
+};
+
+const WELL_KNOWN_PARTS = new Set(["a", "o", "h"]);
+const NVD_BASE = process.env.NVD_API_BASE ?? "https://services.nvd.nist.gov";
+const NVD_KEY = process.env.NVD_API_KEY;
+const TIMEOUT_MS = Number(process.env.NVD_TIMEOUT_MS ?? 20000);
+
+/**
+ * Normalize a value to a CPE 2.3 well-formed-name component: lowercase, `_` for
+ * whitespace, punctuation outside `._-` stripped. Empty → `*` (the CPE "any" marker).
+ */
+export function cpeToken(value: string | null | undefined): string {
+  const v = (value ?? "").trim().toLowerCase();
+  if (v === "") return "*";
+  const token = v.replace(/\s+/g, "_").replace(/[^a-z0-9._-]/g, "");
+  return token === "" ? "*" : token;
+}
+
+/**
+ * Build a CPE 2.3 formatted string from a CatalogIdentity. Deterministic — a candidate
+ * join key; `fetchNvdCpeNames` refines it to a curated dictionary name where one exists.
+ * Unspecified attributes are `*`.
+ *   cpe:2.3:part:vendor:product:version:update:edition:lang:sw_edition:target_sw:target_hw:other
+ */
+export function buildCpe23(identity: CpeIdentityInput): string {
+  const part = WELL_KNOWN_PARTS.has(identity.part ?? "") ? identity.part : "a";
+  const vendor = cpeToken(identity.manufacturer);
+  const product = cpeToken(identity.product);
+  const version = identity.productVersion ? cpeToken(identity.productVersion) : "*";
+  const edition = identity.edition ? cpeToken(identity.edition) : "*";
+  return `cpe:2.3:${part}:${vendor}:${product}:${version}:*:${edition}:*:*:*:*:*`;
+}
+
+/**
+ * Query the NVD CPE dictionary for names matching a cpe match string. Returns the
+ * matching `cpeName` values (curated dictionary names), or [] on any non-OK / error.
+ */
+export async function fetchNvdCpeNames(
+  cpeMatchString: string,
+  fetcher: typeof fetch = fetch,
+): Promise<string[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const url = `${NVD_BASE}/rest/json/cpes/2.0?cpeMatchString=${encodeURIComponent(cpeMatchString)}&resultsPerPage=20`;
+    const res = await fetcher(url, {
+      signal: controller.signal,
+      headers: NVD_KEY ? { apiKey: NVD_KEY } : {},
+    });
+    if (!res.ok) return [];
+    const json = (await res.json()) as { products?: Array<{ cpe?: { cpeName?: string } }> };
+    return (json.products ?? [])
+      .map((p) => p.cpe?.cpeName)
+      .filter((name): name is string => typeof name === "string");
+  } catch {
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Minimal prisma surface for the update — keeps this unit-testable with a mock. */
+export type CpeUpsertClient = {
+  catalogIdentity: {
+    update(args: unknown): Promise<unknown>;
+  };
+};
+
+/**
+ * Resolve and persist a CatalogIdentity's `cpe`. Builds the deterministic CPE, then —
+ * when a fetcher is supplied — prefers the first curated NVD dictionary name that
+ * matches. Returns the CPE written.
+ */
+export async function resolveCatalogIdentityCpe(
+  db: CpeUpsertClient,
+  identity: CpeIdentityInput & { id: string },
+  fetcher?: typeof fetch,
+): Promise<string> {
+  const built = buildCpe23(identity);
+  let cpe = built;
+  if (fetcher) {
+    const names = await fetchNvdCpeNames(built, fetcher);
+    if (names.length > 0 && typeof names[0] === "string") cpe = names[0];
+  }
+  await db.catalogIdentity.update({ where: { id: identity.id }, data: { cpe } });
+  return cpe;
+}


### PR DESCRIPTION
## What
Phase B — the open **CPE 2.3** (Common Platform Enumeration) identity key that both the endoflife.date feed (its `identifiers[]` carry CPE) and NVD CVE lookups join on.

- **`buildCpe23()`** — deterministic `cpe:2.3` string from a `CatalogIdentity` (`part:vendor:product:version:edition`, `*` for unspecified). The always-works core.
- **`cpeToken()`** — CPE well-formed-name normalization.
- **`fetchNvdCpeNames()`** — NVD CPE dictionary resolution (`rest/json/cpes/2.0`); injectable fetcher, `NVD_API_BASE`-overridable for mirrors, optional `NVD_API_KEY` for the rate limit.
- **`resolveCatalogIdentityCpe()`** — build the CPE, prefer a curated NVD name when a fetcher resolves one, set `CatalogIdentity.cpe`.

## Scope / deferred
Bounded to the crosswalk + build/resolve (fully unit-tested from fixtures, no network). Follow-up: broaden vuln lookups to installed/commercial products via the resolved CPE, and a sweep over `CatalogIdentity` rows. **No migration** — `CatalogIdentity.cpe` is on main (#3123).

## Backlog
BI-44B8B1E4 · Epic **EP-ASSET-INTELLIGENCE**. Gives every canonical identity a CPE join key (the endoflife.date `identifiers[]` join + NVD CVE for commercial products). Spec §5 updated.

Process-Spine-Decision: composes the open CPE identity standard onto the designed model; spec updated in-PR.
Design-Grounding-Decision: BI-44B8B1E4

🤖 Generated with [Claude Code](https://claude.com/claude-code)