### PR TITLE
feat(enrich): SBOM → CatalogIdentity bridge (BI-19FD07F9, EP-ASSET-INTELLIGENCE)

### DIFF
--- a/docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md
+++ b/docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md
@@ -133,7 +133,7 @@ This is the kernel/org-overlay pattern again: component catalog entries are kern
 - endoflife.date connector → CatalogLifecycleMilestone (+ optional vendor calendars) — **BI-3A2328D6** — feed logic **landed** in `packages/db/src/endoflife-lifecycle.ts` (`releaseToMilestones`/`selectRelease`/`fetchEolProduct`/`upsertLifecycleForIdentity`, endoflife.date→milestone mapping + idempotent upsert onto CatalogIdentity); the scheduled sweep that iterates CatalogIdentities + the CPE-keyed slug resolution are the follow-up wiring.
 - NVD CPE 2.3 crosswalk + broaden vuln beyond OSS — **BI-44B8B1E4**
 - OS-package patch coverage + EOL/support posture UI — **BI-9C0424E4**
-- SBOM → CatalogIdentity enrichment bridge (component=public, occurrence=private) — **BI-19FD07F9**
+- SBOM → CatalogIdentity enrichment bridge (component=public, occurrence=private) — **BI-19FD07F9** — bridge **landed** in `packages/db/src/sbom-catalog-bridge.ts` (`parsePurl` + `bomComponentToCatalogIdentity` + `upsertIdentitiesForComponents`: BomComponent PURL → canonical CatalogIdentity, `source='sbom'`; the private `BomComponentOccurrence` graph is untouched). Linking `BomComponent.catalogIdentityId` (needs a migration) is the follow-up.
 
 **Enablement (coworker + sharing):**
 - Estate-specialist enrichment skills + hive-contribution grants + public/proprietary egress classification — **BI-1D25BC3C**

--- a/packages/db/src/sbom-catalog-bridge.test.ts
+++ b/packages/db/src/sbom-catalog-bridge.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  bomComponentToCatalogIdentity,
+  parsePurl,
+  upsertIdentitiesForComponents,
+  upsertIdentityForComponent,
+  type SbomBridgeClient,
+} from "./sbom-catalog-bridge";
+
+describe("parsePurl", () => {
+  it("parses type / name / version", () => {
+    expect(parsePurl("pkg:npm/lodash@4.17.21")).toEqual({ type: "npm", namespace: null, name: "lodash", version: "4.17.21" });
+  });
+  it("does not mistake an npm scope for a version", () => {
+    expect(parsePurl("pkg:npm/@babel/core@7.0.0")).toEqual({ type: "npm", namespace: "@babel", name: "core", version: "7.0.0" });
+    expect(parsePurl("pkg:npm/@babel/core")).toEqual({ type: "npm", namespace: "@babel", name: "core", version: null });
+  });
+  it("parses a maven namespace and strips qualifiers", () => {
+    expect(parsePurl("pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1?type=jar")).toEqual({
+      type: "maven",
+      namespace: "org.apache.logging.log4j",
+      name: "log4j-core",
+      version: "2.14.1",
+    });
+  });
+  it("returns null for non-PURL input", () => {
+    expect(parsePurl("lodash@4")).toBeNull();
+    expect(parsePurl(null)).toBeNull();
+  });
+});
+
+describe("bomComponentToCatalogIdentity", () => {
+  it("derives from the PURL (namespace→manufacturer, name→product, version)", () => {
+    expect(bomComponentToCatalogIdentity({ name: "core", packageUrl: "pkg:npm/@babel/core@7.0.0" })).toEqual({
+      identityKey: "a:babel:core:7-0-0", // slug() strips the leading @ from the namespace
+      part: "a",
+      manufacturer: "@babel",
+      product: "core",
+      productVersion: "7.0.0",
+    });
+  });
+  it("falls back to supplierName / component name when there is no PURL", () => {
+    expect(bomComponentToCatalogIdentity({ name: "log4j-core", version: "2.14.1", supplierName: "Apache" })).toEqual({
+      identityKey: "a:apache:log4j-core:2-14-1",
+      part: "a",
+      manufacturer: "Apache",
+      product: "log4j-core",
+      productVersion: "2.14.1",
+    });
+  });
+  it("returns null when there is no resolvable product name", () => {
+    expect(bomComponentToCatalogIdentity({ name: "" })).toBeNull();
+  });
+});
+
+describe("upsertIdentityForComponent", () => {
+  it("upserts a source='sbom' CatalogIdentity keyed on identityKey", async () => {
+    const upserts: Array<{ where: { identityKey: string }; create: { source: string; product: string } }> = [];
+    const db: SbomBridgeClient = {
+      catalogIdentity: {
+        upsert: async (args: unknown) => {
+          upserts.push(args as { where: { identityKey: string }; create: { source: string; product: string } });
+          return { id: "ci_1" };
+        },
+      },
+    };
+    const key = await upsertIdentityForComponent(db, { name: "lodash", packageUrl: "pkg:npm/lodash@4.17.21" });
+    expect(key).toBe("a:npm:lodash:4-17-21");
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]!.where.identityKey).toBe("a:npm:lodash:4-17-21");
+    expect(upserts[0]!.create.source).toBe("sbom");
+    expect(upserts[0]!.create.product).toBe("lodash");
+  });
+
+  it("counts only resolvable components in a batch", async () => {
+    let calls = 0;
+    const db: SbomBridgeClient = {
+      catalogIdentity: { upsert: async () => ((calls += 1), { id: `ci_${calls}` }) },
+    };
+    const written = await upsertIdentitiesForComponents(db, [
+      { name: "lodash", packageUrl: "pkg:npm/lodash@4.17.21" },
+      { name: "" }, // unresolvable → skipped
+      { name: "requests", packageUrl: "pkg:pypi/requests@2.28.0" },
+    ]);
+    expect(written).toBe(2);
+    expect(calls).toBe(2);
+  });
+});

--- a/packages/db/src/sbom-catalog-bridge.ts
+++ b/packages/db/src/sbom-catalog-bridge.ts
@@ -1,0 +1,116 @@
+// SBOM → CatalogIdentity bridge (BI-19FD07F9, EP-ASSET-INTELLIGENCE). An SBOM
+// enumerates the many software components inside one package; this normalizes each
+// BomComponent (via its Package URL / PURL) into a canonical CatalogIdentity, so one
+// SBOM ingest enriches dozens of identities the lifecycle/CVE feeds can then decorate.
+//
+// Sharing split (spec §4.7/§4.8): the BomComponent — a generic component identity,
+// usually public OSS — becomes shareable catalog knowledge; the BomComponentOccurrence
+// (which proprietary product contains it) is composition IP and is NOT touched here.
+
+export type BomComponentInput = {
+  name: string;
+  version?: string | null;
+  packageUrl?: string | null;
+  supplierName?: string | null;
+  ecosystem?: string | null;
+};
+
+export type ParsedPurl = {
+  type: string;
+  namespace: string | null;
+  name: string;
+  version: string | null;
+};
+
+/**
+ * Parse a Package URL (`pkg:type/namespace/name@version?qualifiers#subpath`). The
+ * version `@` is taken after the last path segment, so npm scopes (`@babel`) are not
+ * mistaken for a version. Returns null for anything that is not a `pkg:` URL.
+ */
+export function parsePurl(purl: string | null | undefined): ParsedPurl | null {
+  if (!purl || !purl.startsWith("pkg:")) return null;
+  const clean = purl.slice(4).split(/[?#]/)[0] ?? "";
+  const lastSlash = clean.lastIndexOf("/");
+  if (lastSlash < 0) return null;
+  const head = clean.slice(0, lastSlash);
+  const tail = clean.slice(lastSlash + 1);
+  const atIdx = tail.indexOf("@");
+  const name = atIdx >= 0 ? tail.slice(0, atIdx) : tail;
+  const version = atIdx >= 0 ? tail.slice(atIdx + 1) : null;
+  const headParts = head.split("/");
+  const type = headParts[0] ?? "";
+  const namespace = headParts.slice(1).join("/") || null;
+  if (type === "" || name === "") return null;
+  return { type, namespace, name, version: version || null };
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+}
+
+export type DerivedComponentIdentity = {
+  identityKey: string;
+  part: string;
+  manufacturer: string;
+  product: string;
+  productVersion: string | null;
+};
+
+/**
+ * Derive a canonical CatalogIdentity from a BomComponent. Prefers the PURL
+ * (namespace→manufacturer, name→product, version); falls back to supplierName /
+ * ecosystem / component name. SBOM components are version-specific, so the version is
+ * part of the identityKey. Returns null when there is no resolvable product name.
+ */
+export function bomComponentToCatalogIdentity(component: BomComponentInput): DerivedComponentIdentity | null {
+  const purl = parsePurl(component.packageUrl);
+  const product = (purl?.name ?? component.name ?? "").trim();
+  if (product === "") return null;
+  const manufacturer =
+    (purl?.namespace ?? component.supplierName ?? purl?.type ?? component.ecosystem ?? "unknown").trim() || "unknown";
+  const version = (purl?.version ?? component.version ?? null) || null;
+  const identityKey = `a:${slug(manufacturer)}:${slug(product)}${version ? `:${slug(version)}` : ""}`;
+  return { identityKey, part: "a", manufacturer, product, productVersion: version };
+}
+
+/** Minimal prisma surface for the upsert — keeps this unit-testable with a mock. */
+export type SbomBridgeClient = {
+  catalogIdentity: {
+    upsert(args: unknown): Promise<{ id: string }>;
+  };
+};
+
+/** Upsert a canonical CatalogIdentity for one BomComponent. Returns its identityKey, or null. */
+export async function upsertIdentityForComponent(
+  db: SbomBridgeClient,
+  component: BomComponentInput,
+): Promise<string | null> {
+  const identity = bomComponentToCatalogIdentity(component);
+  if (identity === null) return null;
+  const fields = {
+    part: identity.part,
+    manufacturer: identity.manufacturer,
+    product: identity.product,
+    productVersion: identity.productVersion,
+    source: "sbom",
+  };
+  await db.catalogIdentity.upsert({
+    where: { identityKey: identity.identityKey },
+    update: fields,
+    create: { identityKey: identity.identityKey, ...fields },
+    select: { id: true },
+  });
+  return identity.identityKey;
+}
+
+/** Bridge a set of BomComponents into the catalog; returns how many identities were upserted. */
+export async function upsertIdentitiesForComponents(
+  db: SbomBridgeClient,
+  components: BomComponentInput[],
+): Promise<number> {
+  let upserted = 0;
+  for (const component of components) {
+    if ((await upsertIdentityForComponent(db, component)) !== null) upserted += 1;
+  }
+  return upserted;
+}


### PR DESCRIPTION
## What
Phase B — normalizes each `BomComponent` (via its **PURL**) into a canonical `CatalogIdentity`, so one SBOM ingest enriches dozens of identities the lifecycle/CVE feeds decorate.

- **`parsePurl()`** — `pkg:type/namespace/name@version`, robust to npm scopes (`@babel` ≠ version) + qualifiers/subpaths.
- **`bomComponentToCatalogIdentity()`** — PURL (namespace→manufacturer, name→product, version) with supplierName/ecosystem/name fallback; version-specific `identityKey`; null when unresolvable.
- **`upsertIdentitiesForComponents()`** — upsert `source='sbom'` `CatalogIdentity` rows.

## Sharing split (spec §4.7/§4.8)
The `BomComponent` (generic, usually public OSS) becomes shareable catalog knowledge; the `BomComponentOccurrence` graph — which proprietary product contains it (composition IP) — is **not touched**.

## Scope
Fully unit-tested from fixtures. Linking `BomComponent.catalogIdentityId` (needs a migration) is the follow-up. **No migration** — `CatalogIdentity` on main (#3123). Spec §5 updated.

## Backlog
BI-19FD07F9 · Epic **EP-ASSET-INTELLIGENCE**.

Process-Spine-Decision: normalizes existing SBOM components onto the designed spine; spec updated in-PR.
Design-Grounding-Decision: BI-19FD07F9

🤖 Generated with [Claude Code](https://claude.com/claude-code)