### PR TITLE
feat: add receptionist intake workspace

### DIFF
--- a/apps/web/app/(shell)/storefront/intake/intake-queue-view.test.ts
+++ b/apps/web/app/(shell)/storefront/intake/intake-queue-view.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatIntakeBlocker,
+  summarizeIntakeQueue,
+} from "./intake-queue-view";
+
+describe("receptionist intake queue view", () => {
+  it("summarizes ready, attention, and in-progress work", () => {
+    expect(summarizeIntakeQueue([
+      { ready: true, completionPercent: 100, openExceptions: [] },
+      { ready: false, completionPercent: 70, openExceptions: [{ exceptionId: "exception-a" }] },
+      { ready: false, completionPercent: 30, openExceptions: [] },
+    ])).toEqual({ total: 3, ready: 1, needsAttention: 1, inProgress: 1 });
+  });
+
+  it("turns internal readiness codes into front-desk language", () => {
+    expect(formatIntakeBlocker("required-answers-missing")).toBe("Required information missing");
+    expect(formatIntakeBlocker("consent-incomplete")).toBe("Consent incomplete");
+    expect(formatIntakeBlocker("coverage-unverified")).toBe("Coverage not verified");
+    expect(formatIntakeBlocker("exceptions-unresolved")).toBe("Exception needs review");
+    expect(formatIntakeBlocker("future-code")).toBe("Additional review needed");
+  });
+});

--- a/apps/web/app/(shell)/storefront/intake/intake-queue-view.ts
+++ b/apps/web/app/(shell)/storefront/intake/intake-queue-view.ts
@@ -1,0 +1,44 @@
+type QueueSummaryInput = {
+  ready: boolean;
+  completionPercent: number;
+  openExceptions: Array<{ exceptionId: string }>;
+};
+
+export function summarizeIntakeQueue(items: QueueSummaryInput[]) {
+  return items.reduce(
+    (summary, item) => {
+      summary.total += 1;
+      if (item.ready) summary.ready += 1;
+      else if (item.openExceptions.length > 0) summary.needsAttention += 1;
+      else summary.inProgress += 1;
+      return summary;
+    },
+    { total: 0, ready: 0, needsAttention: 0, inProgress: 0 },
+  );
+}
+
+const BLOCKER_LABELS: Record<string, string> = {
+  "required-answers-missing": "Required information missing",
+  "consent-incomplete": "Consent incomplete",
+  "coverage-unverified": "Coverage not verified",
+  "exceptions-unresolved": "Exception needs review",
+};
+
+export function formatIntakeBlocker(blocker: string): string {
+  return BLOCKER_LABELS[blocker] ?? "Additional review needed";
+}
+
+export function formatSourceMode(mode: string): string {
+  return mode
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function formatAppointmentTime(value: Date): string {
+  return `${new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+  }).format(value)} UTC`;
+}

--- a/apps/web/app/(shell)/storefront/intake/page.test.tsx
+++ b/apps/web/app/(shell)/storefront/intake/page.test.tsx
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const {
+  mockAuth,
+  mockCan,
+  mockConfigFindFirst,
+  mockListQueue,
+  mockOrganizationFindFirst,
+  mockResolvePrincipal,
+  mockSyncPrincipal,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCan: vi.fn(),
+  mockConfigFindFirst: vi.fn(),
+  mockListQueue: vi.fn(),
+  mockOrganizationFindFirst: vi.fn(),
+  mockResolvePrincipal: vi.fn(),
+  mockSyncPrincipal: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ notFound: vi.fn(() => { throw new Error("not-found"); }) }));
+vi.mock("@/lib/auth", () => ({ auth: mockAuth }));
+vi.mock("@/lib/permissions", () => ({ can: mockCan }));
+vi.mock("@/lib/identity/principal-linking", () => ({
+  resolvePrincipalIdForUser: mockResolvePrincipal,
+  syncUserPrincipal: mockSyncPrincipal,
+}));
+vi.mock("@/lib/healthcare/care-intake-review-repository", () => ({
+  listCareIntakeReviewQueue: mockListQueue,
+}));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    organization: { findFirst: mockOrganizationFindFirst },
+    storefrontConfig: { findFirst: mockConfigFindFirst },
+  },
+}));
+
+describe("CareIntakeQueuePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({
+      user: { id: "user-staff", type: "admin", platformRole: "HR-100", isSuperuser: false },
+    });
+    mockCan.mockReturnValue(true);
+    mockOrganizationFindFirst.mockResolvedValue({ id: "org-a" });
+    mockConfigFindFirst.mockResolvedValue({ archetype: { category: "healthcare-wellness" } });
+    mockResolvePrincipal.mockResolvedValue("principal-staff");
+    mockSyncPrincipal.mockResolvedValue({ principalId: "principal-synced" });
+    mockListQueue.mockResolvedValue({ items: [] });
+  });
+
+  it("renders minimum-necessary readiness and exception details", async () => {
+    mockListQueue.mockResolvedValue({ items: [{
+      packetId: "packet-secret-id",
+      patientReference: "A1B2C3D4E5",
+      appointmentLinked: true,
+      status: "in-progress",
+      version: 2,
+      dueAt: null,
+      ready: false,
+      completionPercent: 70,
+      blockers: ["coverage-unverified", "exceptions-unresolved"],
+      missingRequiredLinkIds: [],
+      sourceModes: ["staff-assisted"],
+      openExceptions: [{
+        exceptionId: "exception-secret-id",
+        exceptionType: "coverage",
+        status: "open",
+        severity: "medium",
+        summary: "Insurance card image needs review",
+        assignedToPrincipalId: null,
+      }],
+      accessGrants: [],
+    }] });
+
+    const { default: CareIntakeQueuePage } = await import("./page");
+    const html = renderToStaticMarkup(await CareIntakeQueuePage());
+
+    expect(html).toContain("Patient intake");
+    expect(html).toContain("Patient A1B2C3D4E5");
+    expect(html).toContain("Linked to a scheduled visit");
+    expect(html).toContain("Coverage not verified");
+    expect(html).toContain("Insurance card image needs review");
+    expect(html).toContain("Clinical answers are not shown");
+    expect(html).not.toContain("packet-secret-id");
+    expect(html).not.toContain("exception-secret-id");
+  });
+
+  it("does not query intake outside healthcare archetypes", async () => {
+    mockConfigFindFirst.mockResolvedValue({ archetype: { category: "professional-services" } });
+
+    const { default: CareIntakeQueuePage } = await import("./page");
+    const html = renderToStaticMarkup(await CareIntakeQueuePage());
+
+    expect(html).toContain("Healthcare intake is not active");
+    expect(mockListQueue).not.toHaveBeenCalled();
+  });
+
+  it("synchronizes the authenticated staff principal when onboarding has not created its alias", async () => {
+    mockResolvePrincipal.mockResolvedValue(null);
+
+    const { default: CareIntakeQueuePage } = await import("./page");
+    const html = renderToStaticMarkup(await CareIntakeQueuePage());
+
+    expect(mockSyncPrincipal).toHaveBeenCalledWith("user-staff");
+    expect(mockListQueue).toHaveBeenCalledWith({
+      organizationId: "org-a",
+      actorPrincipalId: "principal-synced",
+      limit: 50,
+    });
+    expect(html).toContain("No active intake packets");
+  });
+});

--- a/apps/web/app/(shell)/storefront/intake/page.tsx
+++ b/apps/web/app/(shell)/storefront/intake/page.tsx
@@ -1,0 +1,169 @@
+import { notFound } from "next/navigation";
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { can } from "@/lib/permissions";
+import {
+  resolvePrincipalIdForUser,
+  syncUserPrincipal,
+} from "@/lib/identity/principal-linking";
+import { listCareIntakeReviewQueue } from "@/lib/healthcare/care-intake-review-repository";
+import {
+  EmptyState,
+  Notice,
+  StatCard,
+  StatusBadge,
+} from "@/components/ui/report-kit";
+
+import {
+  formatAppointmentTime,
+  formatIntakeBlocker,
+  formatSourceMode,
+  summarizeIntakeQueue,
+} from "./intake-queue-view";
+
+export const dynamic = "force-dynamic";
+
+function severityIntent(severity: string): "danger" | "warning" | "info" | "neutral" {
+  if (severity === "critical" || severity === "high") return "danger";
+  if (severity === "medium") return "warning";
+  if (severity === "low") return "info";
+  return "neutral";
+}
+
+export default async function CareIntakeQueuePage() {
+  const session = await auth();
+  if (
+    !session?.user
+    || session.user.type !== "admin"
+    || !can(
+      { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
+      "view_customer",
+    )
+  ) {
+    notFound();
+  }
+
+  const [organization, config] = await Promise.all([
+    prisma.organization.findFirst({ select: { id: true } }),
+    prisma.storefrontConfig.findFirst({
+      select: { archetype: { select: { category: true } } },
+    }),
+  ]);
+
+  if (config?.archetype?.category !== "healthcare-wellness") {
+    return (
+      <Notice title="Healthcare intake is not active">
+        This workspace is available when the storefront uses a healthcare or dental practice archetype.
+      </Notice>
+    );
+  }
+
+  if (!organization) {
+    return (
+      <Notice variant="error" title="Staff identity is not ready">
+        The intake queue could not establish an organization-bound staff identity. Ask an administrator to finish workforce identity setup.
+      </Notice>
+    );
+  }
+
+  const actorPrincipalId = await resolvePrincipalIdForUser(session.user.id)
+    ?? (await syncUserPrincipal(session.user.id).catch(() => null))?.principalId
+    ?? null;
+
+  if (!actorPrincipalId) {
+    return (
+      <Notice variant="error" title="Staff identity is not ready">
+        The intake queue could not establish an organization-bound staff identity. Ask an administrator to finish workforce identity setup.
+      </Notice>
+    );
+  }
+
+  const { items } = await listCareIntakeReviewQueue({
+    organizationId: organization.id,
+    actorPrincipalId,
+    limit: 50,
+  });
+  const summary = summarizeIntakeQueue(items);
+
+  return (
+    <main className="space-y-5" aria-labelledby="intake-heading">
+      <header>
+        <h2 id="intake-heading" className="text-base font-bold text-[var(--dpf-text)]">
+          Patient intake
+        </h2>
+        <p className="mt-1 max-w-3xl text-xs text-[var(--dpf-muted)]">
+          Check visit readiness and resolve front-desk exceptions. Clinical answers are not shown in this workspace.
+        </p>
+      </header>
+
+      <section aria-label="Intake summary" className="grid gap-3 sm:grid-cols-3">
+        <StatCard label="Needs attention" value={summary.needsAttention} intent={summary.needsAttention ? "warning" : "neutral"} hint="Open exceptions" />
+        <StatCard label="In progress" value={summary.inProgress} intent="info" hint="Waiting on intake steps" />
+        <StatCard label="Ready" value={summary.ready} intent="success" hint="No readiness blockers" />
+      </section>
+
+      {items.length === 0 ? (
+        <EmptyState
+          title="No active intake packets"
+          description="Assigned, in-progress, and amended patient intake will appear here."
+          icon="✓"
+        />
+      ) : (
+        <section aria-label="Active patient intake" className="space-y-3">
+          {items.map((item) => (
+            <article
+              key={item.packetId}
+              className="rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="font-semibold text-[var(--dpf-text)]">
+                    Patient {item.patientReference}
+                  </h3>
+                  <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                    {item.appointmentLinked ? "Linked to a scheduled visit" : "No visit linked"}
+                  </p>
+                </div>
+                <StatusBadge
+                  intent={item.ready ? "success" : item.openExceptions.length ? "warning" : "info"}
+                  label={item.ready ? "Ready" : item.openExceptions.length ? "Needs attention" : "In progress"}
+                />
+              </div>
+
+              <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-[var(--dpf-muted)]">
+                <span>{item.completionPercent}% complete</span>
+                <span>{item.sourceModes.map(formatSourceMode).join(", ")}</span>
+                {item.dueAt ? <span>Due {formatAppointmentTime(item.dueAt)}</span> : null}
+              </div>
+
+              {item.blockers.length > 0 ? (
+                <ul className="mt-3 flex flex-wrap gap-2" aria-label="Readiness blockers">
+                  {item.blockers.map((blocker) => (
+                    <li key={blocker}>
+                      <StatusBadge intent="warning" label={formatIntakeBlocker(blocker)} uppercase={false} />
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+
+              {item.openExceptions.length > 0 ? (
+                <div className="mt-3 space-y-2 border-t border-[var(--dpf-border)] pt-3">
+                  <h4 className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                    Open exceptions
+                  </h4>
+                  {item.openExceptions.map((exception) => (
+                    <div key={exception.exceptionId} className="flex flex-wrap items-center gap-2 text-sm text-[var(--dpf-text)]">
+                      <StatusBadge intent={severityIntent(exception.severity)} label={exception.severity} />
+                      <span>{exception.summary}</span>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </article>
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/(shell)/storefront/layout.tsx
+++ b/apps/web/app/(shell)/storefront/layout.tsx
@@ -39,6 +39,8 @@ export default async function StorefrontAdminLayout({ children }: { children: Re
   // Dispatch board is the field-service surface — only trades-maintenance
   // storefronts assign confirmed bookings to a crew.
   const showDispatch = config?.archetype?.category === "trades-maintenance";
+  // Intake is a front-desk care workflow, not a generic storefront concept.
+  const showIntake = config?.archetype?.category === "healthcare-wellness";
 
   return (
     <div>
@@ -50,6 +52,7 @@ export default async function StorefrontAdminLayout({ children }: { children: Re
         showAnimals={showAnimals}
         showUnits={showUnits}
         showDispatch={showDispatch}
+        showIntake={showIntake}
       />
       {children}
     </div>

--- a/apps/web/components/storefront-admin/StorefrontAdminTabNav.test.tsx
+++ b/apps/web/components/storefront-admin/StorefrontAdminTabNav.test.tsx
@@ -53,4 +53,18 @@ describe("StorefrontAdminTabNav", () => {
     expect(html).toContain(">Requests<");
     expect(html).toContain(">Settings<");
   });
+
+  it("shows Intake only when the healthcare workspace enables it", () => {
+    pathname = "/storefront/intake";
+    const healthcareHtml = renderToStaticMarkup(
+      <StorefrontAdminTabNav vocabulary={vocabulary} showIntake />,
+    );
+    const generalHtml = renderToStaticMarkup(
+      <StorefrontAdminTabNav vocabulary={vocabulary} />,
+    );
+
+    expect(healthcareHtml).toContain('href="/storefront/intake"');
+    expect(healthcareHtml).toContain(">Intake<");
+    expect(generalHtml).not.toContain('href="/storefront/intake"');
+  });
 });

--- a/apps/web/components/storefront-admin/StorefrontAdminTabNav.tsx
+++ b/apps/web/components/storefront-admin/StorefrontAdminTabNav.tsx
@@ -11,6 +11,8 @@ type Props = {
   showUnits?: boolean;
   /** Show the Dispatch tab — only for field-service (trades-maintenance) storefronts. */
   showDispatch?: boolean;
+  /** Show the Intake tab — only for healthcare and dental practice storefronts. */
+  showIntake?: boolean;
 };
 
 // Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper owns
@@ -22,6 +24,7 @@ export function StorefrontAdminTabNav({
   showAnimals = false,
   showUnits = false,
   showDispatch = false,
+  showIntake = false,
 }: Props) {
   const path = usePathname();
 
@@ -33,6 +36,7 @@ export function StorefrontAdminTabNav({
     ...(showAnimals ? [{ label: "Animals", href: "/storefront/animals" }] : []),
     { label: vocabulary.teamLabel, href: "/storefront/team" },
     ...(showDispatch ? [{ label: "Dispatch", href: "/storefront/dispatch" }] : []),
+    ...(showIntake ? [{ label: "Intake", href: "/storefront/intake" }] : []),
     { label: vocabulary.inboxLabel, href: "/storefront/inbox" },
     { label: "Settings", href: "/storefront/settings" },
   ];

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 567,
+  "routeCount": 568,
   "routes": [
     {
       "routePath": "/",
@@ -6477,6 +6477,16 @@
       ],
       "dynamicParams": [],
       "file": "apps/web/app/(shell)/storefront/inbox/page.tsx"
+    },
+    {
+      "routePath": "/storefront/intake",
+      "kind": "page",
+      "segments": [
+        "storefront",
+        "intake"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/storefront/intake/page.tsx"
     },
     {
       "routePath": "/storefront/items",

--- a/apps/web/lib/healthcare/care-intake-review-repository.test.ts
+++ b/apps/web/lib/healthcare/care-intake-review-repository.test.ts
@@ -21,7 +21,7 @@ function database() {
         requiredConsentCount: 0, requiresCoverageEvidence: false,
         responses: [{ answeredLinkIds: ["visit-reason"], sourceMode: "staff-assisted", status: "in-progress", authoredAt: new Date("2026-08-01") }],
         exceptions: [], consentAttestations: [], coverageEvidence: [],
-        accessGrants: [{ grantId: "grant-a", granteePrincipalId: "principal-patient-a", permittedOperations: ["view"], expiresAt: new Date("2026-08-02"), lastUsedAt: null, revokedAt: null }],
+        accessGrants: [{ grantId: "grant-a", permittedOperations: ["view"], expiresAt: new Date("2026-08-02"), lastUsedAt: null, revokedAt: null }],
       }]),
       findFirst: vi.fn().mockResolvedValue({ id: "packet-row-a", packetId: "intake-a", patientProfileId: "patient-a" }),
     },
@@ -46,8 +46,13 @@ describe("care intake receptionist review repository", () => {
     expect(result.items[0]).toEqual(expect.objectContaining({
       packetId: "intake-a", ready: true, completionPercent: 100,
       sourceModes: ["staff-assisted"], openExceptions: [],
+      patientReference: expect.stringMatching(/^[A-F0-9]{10}$/),
+      appointmentLinked: true,
     }));
     expect(JSON.stringify(result)).not.toContain("answers");
+    expect(result.items[0]).not.toHaveProperty("patientProfileId");
+    expect(result.items[0]).not.toHaveProperty("appointmentId");
+    expect(JSON.stringify(result)).not.toContain("patient-a");
     expect(tx.authorizationDecisionLog.create).toHaveBeenCalledWith({ data: expect.objectContaining({
       actorRef: "principal-receptionist", actionKey: "healthcare.intake.review",
       purposeOfUse: "intake-review", decision: "allow",

--- a/apps/web/lib/healthcare/care-intake-review-repository.ts
+++ b/apps/web/lib/healthcare/care-intake-review-repository.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { prisma } from "@dpf/db";
 import {
   calculateIntakeReadiness,
@@ -27,7 +29,7 @@ type ReviewPacketRow = {
   consentAttestations: Array<{ status: string }>;
   coverageEvidence: Array<{ status: string }>;
   accessGrants: Array<{
-    grantId: string; granteePrincipalId: string | null; permittedOperations: string[];
+    grantId: string; permittedOperations: string[];
     expiresAt: Date; lastUsedAt: Date | null; revokedAt: Date | null;
   }>;
 };
@@ -52,6 +54,14 @@ export type CareIntakeReviewDatabase = {
 function requirements(value: unknown): CareIntakeRequirement[] {
   if (!Array.isArray(value)) throw new Error("Invalid intake requirement snapshot");
   return value as CareIntakeRequirement[];
+}
+
+function patientReference(organizationId: string, patientProfileId: string): string {
+  return createHash("sha256")
+    .update(`${organizationId}:${patientProfileId}`)
+    .digest("hex")
+    .slice(0, 10)
+    .toUpperCase();
 }
 
 export async function listCareIntakeReviewQueue(
@@ -89,7 +99,7 @@ export async function listCareIntakeReviewQueue(
         consentAttestations: { select: { status: true } },
         coverageEvidence: { select: { status: true } },
         accessGrants: {
-          select: { grantId: true, granteePrincipalId: true, permittedOperations: true, expiresAt: true, lastUsedAt: true, revokedAt: true },
+          select: { grantId: true, permittedOperations: true, expiresAt: true, lastUsedAt: true, revokedAt: true },
         },
       },
     });
@@ -105,8 +115,8 @@ export async function listCareIntakeReviewQueue(
       });
       return {
         packetId: packet.packetId,
-        patientProfileId: packet.patientProfileId,
-        appointmentId: packet.appointmentId,
+        patientReference: patientReference(input.organizationId, packet.patientProfileId),
+        appointmentLinked: Boolean(packet.appointmentId),
         status: packet.status,
         version: packet.version,
         dueAt: packet.dueAt,

--- a/docs/superpowers/plans/2026-07-16-healthcare-digital-intake.md
+++ b/docs/superpowers/plans/2026-07-16-healthcare-digital-intake.md
@@ -149,6 +149,25 @@ status, notice, and empty states; use `PatientProfile`, `PatientAuthority`, and
 show staff-assisted recovery for unlinked identity and permission failures;
 and do not start AI work from any care card.
 
+**UX fit review — receptionist intake:** `fits-with-guardrails`. The owning
+area is internal Storefront management, where a small practice already manages
+its team, inbox, and other daily operations. `/storefront/intake` is a
+healthcare-only section tab rather than a new global destination. Its first
+viewport is a front-desk queue ordered by the repository's due-date contract,
+with counts for needs-attention, in-progress, and ready work. Cards use an
+organization-scoped pseudonymous patient reference and disclose whether a
+visit is linked, then show readiness blockers, exception summaries, and
+assisted/paper provenance, but do not render questionnaire
+answers, document/signature payloads, or raw patient/appointment identifiers.
+The route requires employee `view_customer` authority and an organization-bound
+Principal before the restricted review repository establishes its audited
+`intake-review` purpose context. AI actions are deliberately absent: this is a
+human review and coordination surface, not clinical decision support.
+Resolving that reference to a patient display identity and visit details
+requires a separate, column-limited staff summary authority; the intake-review
+RLS policy intentionally does not widen `PatientProfile` or `CareAppointment`
+access for this UI slice.
+
 1. **3A — patient identity and task discovery:** resolve the signed-in customer
    contact through canonical `Principal` identity, establish patient RLS
    context, show minimum-necessary active intake tasks in `/portal/health`, and

--- a/docs/user-guide/storefront/index.md
+++ b/docs/user-guide/storefront/index.md
@@ -17,6 +17,7 @@ The storefront is also the most visible expression of the selected market archet
 - **Items** — The products or services listed for sale or booking. Each item has a price, description, and availability settings.
 - **Domain Routing** — The storefront serves your organization's public experience under its configured path or domain with its selected branding.
 - **Inbox** — Messages and enquiries submitted by visitors through the storefront. Managed by staff from inside the platform.
+- **Healthcare intake** — Medical and dental archetypes add an internal **Intake** workspace for receptionists and care-practice staff. It summarizes visit readiness, missing steps, and open exceptions without displaying clinical answers. Patient references are pseudonymous in this workspace; detailed clinical records remain on their governed care surfaces.
 
 ## What You Can Do
 
@@ -25,6 +26,7 @@ The storefront is also the most visible expression of the selected market archet
 - Add, edit, or remove items available for purchase or booking
 - Manage the booking calendar — set availability, block dates, assign service providers
 - Review and respond to enquiries arriving in the storefront inbox
+- For medical and dental practices, review active patient-intake readiness from **Portal → Intake** and identify packets that need attention before a visit
 
 ## Related
 


### PR DESCRIPTION
## Summary
- add a healthcare-only `/storefront/intake` workspace for receptionists and care-practice staff
- surface visit-readiness counts, pseudonymous patient references, source modes, blockers, and open exception summaries without clinical answers
- add the Intake section tab only for healthcare and dental storefronts
- lazily synchronize the canonical staff Principal for newly onboarded owners while retaining fail-closed behavior
- preserve patient and appointment RLS boundaries; document the follow-on column-limited staff identity/appointment summary authority

## Backlog
- `BI-HEALTHCARE-012` under `EP-HEALTHCARE-PRACTICE`
- this PR delivers the receptionist readiness slice; the BI remains in progress for broader consent, coverage, and staff-assisted workflows

## Privacy and authority boundary
- reuses the purpose-scoped `CareIntakePacket` staff review repository
- returns an organization-scoped SHA-256-derived patient reference rather than raw patient, appointment, or grantee identifiers
- does not widen `PatientProfile` or `CareAppointment` RLS
- does not expose clinical responses, documents, signatures, or AI actions

## UX Fit
- section-level front-desk workspace inside the existing Storefront operations spine
- visible only for the `healthcare-wellness` archetype category
- first viewport prioritizes needs-attention, in-progress, and ready counts plus an honest empty state
- live dental-practice verification confirmed the Intake tab, minimum-necessary copy, three summary cards, and zero browser errors

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/plans/2026-07-16-healthcare-digital-intake.md`
  - healthcare privacy, canonical data model, intake authority, and archetype activation work already linked by that plan
- Current code substrate reviewed:
  - Storefront shell layout and `StorefrontAdminTabNav`
  - `CareIntakePacket` and the existing purpose-scoped `listCareIntakeReviewQueue` repository
  - report-kit `StatCard`, `StatusBadge`, `Notice`, and `EmptyState` primitives
  - canonical Principal linking through `resolvePrincipalIdForUser` and `syncUserPrincipal`
- Source of truth:
  - `StorefrontConfig.archetypeId` and its category govern route/navigation activation
  - `CareIntakePacket` remains the intake authority; patient and appointment RLS remain unchanged
  - `docs/user-guide/storefront/index.md` documents the staff-facing workflow
- Decision:
  - extend the existing Storefront operations spine with one healthcare-only section workspace and a minimum-necessary staff projection; do not create a parallel staff portal, widen patient-context RLS, or add AI/clinical-answer authority

## Verification
- focused Vitest: 3 files / 7 tests passed
- `pnpm --filter web typecheck` passed
- exact-head merged-code gate passed for implementation commit `0f6b07dcd7352a90ce9f7d6e3289213e1c0be4b6` against `origin/main@5834e7548`
  - 402 migrations applied / no pending migrations
  - full web suite: 1,950 files; 16,861 tests
  - DB and web typechecks passed
  - production Next.js build passed and included `/storefront/intake`
- isolated production-image browser verification passed for merged tree `14d652553ae26a2eff66d0020a2b57eb42c2a134`
- Storefront user guide updated for the healthcare intake workflow; Docs Impact and Docs Link Integrity pass locally
