### PR TITLE
feat(antigravity): first-class external coding surface — Phase 0 (EP-ANTIGRAVITY-001)

### DIFF
--- a/apps/web/lib/auth/mcp-setup-snippets.test.ts
+++ b/apps/web/lib/auth/mcp-setup-snippets.test.ts
@@ -45,6 +45,17 @@ describe("buildSetupSnippets", () => {
     expect(grok).not.toContain(TOKEN);
   });
 
+  it("antigravity produces a JSON mcpServers.dpf block (http, env-backed auth) and never embeds the secret", () => {
+    const { antigravity } = buildSetupSnippets(TOKEN, BASE);
+    const parsed = JSON.parse(antigravity) as {
+      mcpServers?: { dpf?: { type?: string; url?: string; headers?: { Authorization?: string } } };
+    };
+    expect(parsed.mcpServers?.dpf?.type).toBe("http");
+    expect(parsed.mcpServers?.dpf?.url).toBe(LOCAL_MCP_URL);
+    expect(parsed.mcpServers?.dpf?.headers?.Authorization).toBe("Bearer ${DPF_MCP_BEARER_TOKEN}");
+    expect(antigravity).not.toContain(TOKEN);
+  });
+
   it("env and runtime refresh snippets carry the full plaintext token", () => {
     const t = "dpfmcp_UNIQUETOKEN";
     const { envPowerShell, runtimeRefreshPowerShell } = buildSetupSnippets(t, BASE);

--- a/apps/web/lib/auth/mcp-setup-snippets.ts
+++ b/apps/web/lib/auth/mcp-setup-snippets.ts
@@ -3,7 +3,7 @@
 // Used by apps/web/lib/actions/mcp-tokens.ts (server action) and
 // apps/web/scripts/issue-mcp-token.ts (CLI).
 
-export type McpSnippetFormat = "claude-code" | "codex" | "grok" | "vscode" | "raw";
+export type McpSnippetFormat = "claude-code" | "codex" | "grok" | "antigravity" | "vscode" | "raw";
 
 export const MCP_BEARER_TOKEN_ENV_VAR = "DPF_MCP_BEARER_TOKEN";
 
@@ -11,6 +11,7 @@ export type McpSetupSnippets = {
   claudeCode: string;
   codex: string;
   grok: string;
+  antigravity: string;
   vscode: string;
   syncCommand: string;
   envPowerShell: string;
@@ -81,6 +82,15 @@ export function buildSetupSnippets(plaintext: string, baseUrl: string): McpSetup
     `url = "${url}"`,
     `bearer_token_env_var = "${MCP_BEARER_TOKEN_ENV_VAR}"`,
   ].join("\n");
+  // Antigravity (Google): VS Code / Windsurf-derived agentic IDE. Its MCP config
+  // is a JSON block keyed by `mcpServers` (same shape as Claude Code's .mcp.json),
+  // consumed by both the IDE and the `agy` CLI. EP-ANTIGRAVITY-001 evidence gate
+  // (BI-47A81FEB): confirm the exact config path against a live install before
+  // this is automated in the bootstrap — the common 2026 locations are:
+  //   macOS/Linux: ~/.antigravity/mcp_config.json  (or the in-IDE MCP settings)
+  //   Windows:     %USERPROFILE%\.antigravity\mcp_config.json
+  // The JSON content itself is identical across platforms.
+  const antigravity = JSON.stringify({ mcpServers: { dpf: httpEntry } }, null, 2);
   // VS Code: .vscode/mcp.json uses servers (not mcpServers)
   const vscode = JSON.stringify({ servers: { dpf: vscodeHttpEntry } }, null, 2);
   const syncCommand = ".\\scripts\\seed-worktree-mcp.ps1";
@@ -95,6 +105,7 @@ export function buildSetupSnippets(plaintext: string, baseUrl: string): McpSetup
     claudeCode,
     codex,
     grok,
+    antigravity,
     vscode,
     syncCommand,
     envPowerShell,

--- a/apps/web/lib/build/unified-wip.ts
+++ b/apps/web/lib/build/unified-wip.ts
@@ -28,7 +28,7 @@ export type WipPool = "bs-sandbox" | "shared-lease" | "host-worktree" | "none";
 
 /** A single unit of active work, surface-tagged via its capsule executorKind. */
 export interface ActiveWipItem {
-  /** WorkCapsule executorKind: build-studio | claude/codex/grok-desktop | dpf-native | human | git-webhook. */
+  /** WorkCapsule executorKind: build-studio | claude/codex/grok/antigravity-desktop | dpf-native | human | git-webhook. */
   readonly executorKind: string;
   /** True when this work currently holds a shared singleton lease (e.g. the :3001 nonprod lease). */
   readonly holdsSharedLease?: boolean;

--- a/apps/web/lib/work-capsules.test.ts
+++ b/apps/web/lib/work-capsules.test.ts
@@ -60,6 +60,7 @@ describe("work capsule enums", () => {
     expect(WORK_CAPSULE_SOURCES).toContain("external-adoption");
     expect(WORK_CAPSULE_EXECUTOR_KINDS).toContain("codex-desktop");
     expect(WORK_CAPSULE_EXECUTOR_KINDS).toContain("grok-desktop");
+    expect(WORK_CAPSULE_EXECUTOR_KINDS).toContain("antigravity-desktop");
     expect(WORK_CAPSULE_ACTIVITY_KINDS).toContain("evidence-recorded");
   });
 });

--- a/apps/web/lib/work-capsules.ts
+++ b/apps/web/lib/work-capsules.ts
@@ -72,6 +72,7 @@ export const WORK_CAPSULE_EXECUTOR_KINDS = [
   "codex-desktop",
   "claude-desktop",
   "grok-desktop",
+  "antigravity-desktop",
   "human",
   "git-webhook",
   "dpf-native",

--- a/apps/web/lib/work-capsules/external-session-capture.ts
+++ b/apps/web/lib/work-capsules/external-session-capture.ts
@@ -24,6 +24,7 @@ export function providerToExecutorKind(provider: string): WorkCapsuleExecutorKin
   if (normalized.includes("claude")) return "claude-desktop";
   if (normalized.includes("codex")) return "codex-desktop";
   if (normalized.includes("grok")) return "grok-desktop";
+  if (normalized.includes("antigravity")) return "antigravity-desktop";
   return "human";
 }
 

--- a/apps/web/lib/work-capsules/work-capsule-store.ts
+++ b/apps/web/lib/work-capsules/work-capsule-store.ts
@@ -120,6 +120,7 @@ function isExternalLeaseExecutor(executorKind: WorkCapsuleExecutorKind | null | 
     executorKind === "codex-desktop" ||
     executorKind === "claude-desktop" ||
     executorKind === "grok-desktop" ||
+    executorKind === "antigravity-desktop" ||
     executorKind === "human"
   );
 }

--- a/apps/web/scripts/issue-mcp-token.ts
+++ b/apps/web/scripts/issue-mcp-token.ts
@@ -117,8 +117,15 @@ function parseArgs(argv: readonly string[]): Args {
       }
       case "--format": {
         const v = next();
-        if (v !== "claude-code" && v !== "codex" && v !== "grok" && v !== "vscode" && v !== "raw") {
-          fatal(`--format must be claude-code | codex | grok | vscode | raw; got: ${v}`);
+        if (
+          v !== "claude-code" &&
+          v !== "codex" &&
+          v !== "grok" &&
+          v !== "antigravity" &&
+          v !== "vscode" &&
+          v !== "raw"
+        ) {
+          fatal(`--format must be claude-code | codex | grok | antigravity | vscode | raw; got: ${v}`);
         }
         format = v;
         break;
@@ -157,7 +164,7 @@ function printHelp(): void {
       "                         template (sandbox_execute, iac_execute, build_promote,",
       "                         ...); admin -> admin template; read -> coding-agent reads.",
       `  --expires-days N|never Token TTL in days, or "never" (default: ${DEFAULT_EXPIRES_DAYS})`,
-      "  --format <fmt>         claude-code | codex | grok | vscode | raw (default: claude-code)",
+      "  --format <fmt>         claude-code | codex | grok | antigravity | vscode | raw (default: claude-code)",
       "  --base-url <url>       Portal base URL",
       "                         (default: $AUTH_URL / $APP_URL / http://localhost:3000)",
       "  --help, -h             Show this help",
@@ -166,6 +173,7 @@ function printHelp(): void {
       "  claude-code  .mcp.json snippet   (mcpServers.dpf, http transport)",
       "  codex        ~/.codex/config.toml snippet using bearer_token_env_var",
       "  grok         ~/.grok/config.toml snippet (same TOML shape as codex; also works for project .grok/config.toml)",
+      "  antigravity  ~/.antigravity/mcp_config.json snippet (mcpServers.dpf, http transport; confirm path per EP-ANTIGRAVITY-001 evidence gate)",
       "  vscode       .vscode/mcp.json snippet (servers.dpf)",
       "  raw          Plaintext token only",
       "",
@@ -247,7 +255,9 @@ async function main(): Promise<void> {
           ? snippets.codex
           : args.format === "grok"
             ? snippets.grok
-            : snippets.claudeCode;
+            : args.format === "antigravity"
+              ? snippets.antigravity
+              : snippets.claudeCode;
     console.log(snippet);
   }
 

--- a/docs/superpowers/specs/2026-07-17-antigravity-first-class-support-design.md
+++ b/docs/superpowers/specs/2026-07-17-antigravity-first-class-support-design.md
@@ -1,0 +1,110 @@
+# EP-ANTIGRAVITY-001: First-Class Google Antigravity Support (External Coding Surface)
+
+| Field | Value |
+| ----- | ----- |
+| Status | Draft — author draft for review |
+| Date | 2026-07-17 |
+| Epic | `EP-ANTIGRAVITY-001` (filed via governed MCP; in-progress) |
+| Kernel decision | `DI-F8A78E41B01D` — `principle_decide` recommended **evidence-gated thin-slice** (composite 11.24, margin 4.72, high confidence, no commandment conflict) over full-parity-now (6.51) and defer/keep-ad-hoc (2.85). |
+| Precedent | [EP-GROK-001 first-class Grok support](2026-05-31-grok-first-class-support-design.md) — the established playbook for onboarding a new external coding surface. Antigravity mirrors it. |
+| Dry-run evidence | Operator manually ran Antigravity against **BI-F4156099**; it delivered **PR #3155** (`36f40c903`, `feat(decision-perspective): unify gate execution logic under evaluatePerspectiveGate`) — a 506/499-line gate-unification refactor **with test coverage**, merged clean to main. Code quality: properly typed, fail-closed error handling, reused existing helpers (`getErrorMessage`), matched house JSDoc conventions. This is a genuine "good enough" signal, not a toy. |
+| Scope (Phase 0) | Antigravity as a **fifth external host-worktree coding surface**, peer to Claude Code / Codex / Grok: a governed `antigravity-desktop` WorkCapsule executor kind, `antigravity` MCP token-snippet + skill-pack packaging, and one **proven** governed `agy --headless` build recording capsule evidence. |
+| Out of scope (behind the evidence gate) | Antigravity as a **Build Studio in-sandbox dispatch engine** (the `claude\|codex\|grok\|opencode\|agentic` axis) — the larger ~19-seam bet, deferred to `BI-D2E3F2FD`. Antigravity-specific inference-provider entry, custom Gemini fine-tunes as platform models, in-portal Antigravity coworker personality. |
+
+---
+
+## Architect Verdict
+
+The platform has **two parallel axes** for coding agents, and conflating them is the primary scoping risk:
+
+1. **External host-worktree executor axis** — Claude Code / Codex / Grok run in a host git worktree and record evidence back through MCP as `*-desktop` executor kinds. This is where `agy --headless` naturally belongs.
+2. **Build Studio in-sandbox dispatch engine axis** — the CLI engine that runs a build inside the shared BS sandbox (`claude | codex | grok | opencode | agentic`). This is where **opencode** lives (the operator's roster "codex, claude, grok, and opencode" mixes the two axes: opencode is an *engine*, not a host CLI).
+
+Antigravity is fundamentally axis-1: Google's agentic IDE ships a headless CLI (`agy --headless --approve <policy>`, the successor to the retired Gemini CLI) with **native MCP-server support** and is **model-agnostic** (Gemini 3.x Pro/Flash, Claude Sonnet/Opus, GPT-OSS 120B). It connects to the DPF MCP the same way the incumbents do. The BS-engine role (axis-2) is a second, larger bet — deliberately deferred.
+
+The trust decision is **already precedented**: Claude/Codex/Grok already route code + backlog context to Anthropic/OpenAI/xAI. Antigravity → Google is the same *class* of trust boundary the platform has already accepted three times. What is new is Antigravity's **hook/packaging plane**: Grok reads Claude-format hooks natively and Codex aliases `CLAUDE_PLUGIN_ROOT`, but Antigravity is VS Code / Windsurf-derived with its own AI-Rules / MCP-config model, so governance-hook enforcement (`lease-guard`, `worktree-create`, `decision-routing`) may **not** transfer for free. That single unknown is what the evidence gate exists to resolve.
+
+**Recommendation:** parity-first on the external-executor axis (cheap, precedented), gated by one proven end-to-end `agy` build, then reassess axis-2.
+
+---
+
+## Tool-Evaluation Verdict (CoSAI lens)
+
+**Verdict:** CONDITIONAL · **Risk:** low-medium · **Confidence:** 0.8
+
+Antigravity is not a bundled dependency imported into our tree — it is an external coding-agent *product* that operates *on* our tree and connects *to* our MCP. The risk surface is therefore the same shape as the already-approved Claude/Codex/Grok external surfaces, evaluated here per the 12-category checklist:
+
+| # | Category | Finding | Severity |
+|---|----------|---------|----------|
+| 1 | Authentication | MCP connects via `DPF_MCP_BEARER_TOKEN` env var (same governed token flow as incumbents); Antigravity's own auth is Google account. No hardcoded creds. | none |
+| 2 | Access Control | Scoped MCP token; least-privilege via existing tool grants. Host-worktree isolation. | none |
+| 3 | Input Validation | Reuses the existing MCP JSON-RPC transport + arg coercion; no new input surface. | none |
+| 4 | Data/Control Boundary | Agent has worktree write + MCP tool access — identical to incumbents. Prompt-injection posture unchanged. | low |
+| 5 | Data Protection | Code + backlog context flows to Google models. Google states code is **used to provide the service, not to train models**; enterprise runs in-cloud-boundary. Same *class* as Anthropic/OpenAI/xAI already accepted. Verify against org data-handling stance (WWWD) before enabling on customer-identifying repos — see [[oss-repo-identity-leak-guard]]. | medium |
+| 6 | Integrity Controls | All output lands via DCO-signed PR through CI gates (§4 all-changes-land-via-pr). Provenance-agnostic gates apply. | none |
+| 7 | Session/Transport | HTTP MCP transport, `127.0.0.1` local; TLS for remote installs. | none |
+| 8 | Network Isolation | Host worktree + isolated `COMPOSE_PROJECT_NAME`; sandbox `--approve` policy recommended for `agy`. | low |
+| 9 | Trust Boundary | LLM judgment gated by the same evidence lifecycle + HITL phase boundaries as every surface. | low |
+| 10 | Resource Management | `agy --headless` runs under the operator's account/quota; no shared-runtime contention on axis-1 (own worktree, not BS sandbox). | none |
+| 11 | Operational Security | Capsule attribution (`antigravity-desktop`) + evidence records make its work auditable in the unified tracking view. | none |
+| 12 | Supply Chain | We do **not** import Antigravity code; it's an external tool. Maintainer = Google (active, well-resourced). No dependency-tree exposure. | none |
+
+**Early-termination check:** no hardcoded creds, no unpatched critical CVE, license compatible (we bundle nothing), tool actively maintained. **Proceed.**
+
+**Conditions (why CONDITIONAL, not APPROVE):** (a) resolve the hook/packaging-plane unknown via the evidence gate before automating bootstrap; (b) confirm the data-handling posture against the org WWWD stance before enabling on customer-identifying repos; (c) sandbox the `agy --approve` policy.
+
+---
+
+## Current-State Seam Map (verified against `origin/main`)
+
+> The MCP layer was refactored on main (`mcp-tools.ts` split into `mcp/packs/*` + `mcp-handlers/*`); the seam map below reflects **actual main**, not the pre-refactor layout.
+
+### Axis 1 — External executor (Phase 0, this epic)
+- `apps/web/lib/work-capsules.ts:70` — `WORK_CAPSULE_EXECUTOR_KINDS` (source of truth). The `create_work_capsule` / `adopt_worktree` MCP `executorKind` enum derives from it via `executors: [...WORK_CAPSULE_EXECUTOR_KINDS]` in `apps/web/lib/work-capsules/mcp-handlers.ts:62`, and `work-capsules-enum-parity.test.ts` enforces the mirror — so **one const edit propagates to the MCP enum and the parity test for free**.
+- `apps/web/lib/work-capsules/work-capsule-store.ts:118` — `isExternalLeaseExecutor` (add the new kind so host-worktree Antigravity gets an external lease).
+- `apps/web/lib/work-capsules/external-session-capture.ts:22` — `providerToExecutorKind` (add an `antigravity` branch).
+- `record_external_development_evidence.provider` is **free-text** — Antigravity evidence "just works"; only the executor kind is a closed enum.
+- **Finding:** the nonprod `NonprodOwnerProvider` enum (`environment-lease.ts:5`, `local-integration.ts:6`) is `build-studio | claude | codex | coworker` — **grok is not in it either**. External host-worktree CLIs do not flow through that enum (they run in their own worktree, not the shared nonprod env), so Antigravity does **not** need adding there. This corrected an early over-scoping assumption.
+
+### Axis 2 — Build Studio in-sandbox engine (DEFERRED, `BI-D2E3F2FD`)
+Only after a green evidence gate. ~19 seams incl. a **new runner file** `apps/web/lib/integrate/sandbox/agents/antigravity-agent-runner.ts` + `BuildAgentId` union (`agent-runner-types.ts:9`) + runner map (`agents/index.ts`); `packages/db/data/build-engines.json` install recipe + `providers-registry.json` `cliEngine` entry; the field-per-engine dispatch config (`build-studio-config.ts:13`, widens ~8 files); `phase-model-resolution.ts` `buildEngineLabel`; `build-orchestrator.ts` dispatch + preflight (note: preflight already omits `opencode` — avoid replicating that gap); UI radios (`BuildStudioConfigForm.tsx`, `build-studio/page.tsx`). This is the larger, riskier bet — kept gated.
+
+---
+
+## Phase 0 — Delivered in this PR (external-executor scaffolding)
+
+1. `antigravity-desktop` executor kind + all consumers (`isExternalLeaseExecutor`, `providerToExecutorKind`, enum-parity test, `work-capsules.test.ts` assertion).
+2. `antigravity` MCP token-snippet format (`mcp-setup-snippets.ts` + `issue-mcp-token.ts --format antigravity`) — emits a JSON `mcpServers.dpf` block (http, env-backed auth), with the exact config path flagged for evidence-gate confirmation.
+3. Skill-pack packaging: `.antigravity-plugin/plugin.json` + `antigravity.mcp.json`, mirroring `.grok-plugin/`. Hook consumption flagged pending.
+4. Snippet unit test for the antigravity shape (no embedded secret).
+
+**Not yet automated (gated):** `update_agent_toolchain.py` / `dpf-bootstrap` detection + wiring for a host Antigravity CLI. Deferred until the evidence gate confirms the exact MCP-config path and whether Claude-format hooks fire on the Antigravity surface (`BI-ECAE3494`, `BI-47A81FEB`).
+
+---
+
+## The Evidence Gate (`BI-47A81FEB`) — kernel-mandated (Human-in-the-Loop at Phase Boundaries)
+
+After this PR lands, the operator runs Antigravity (`agy --headless --approve <policy>`, inside a sandboxed worktree) on **one** real backlog item, wired to the DPF MCP via `--format antigravity`. **Green** requires:
+- (a) Antigravity connects to the DPF MCP and calls `claim_backlog_item_for_work` + `create_work_capsule` / `adopt_worktree`;
+- (b) it records external evidence attributed to `antigravity-desktop`;
+- (c) it ships a DCO-signed PR that passes CI;
+- (d) we capture the hook/packaging-plane reality — does governance-hook enforcement fire? which config path/format? which `--approve` policy is safe?
+
+**Only a green gate opens Axis 2** (`BI-D2E3F2FD`). A red/partial gate → file findings and stop; do not force the BS-engine axis.
+
+---
+
+## Backlog (filed under EP-ANTIGRAVITY-001)
+
+| BI | Title | Axis / Phase |
+|----|-------|--------------|
+| `BI-D49C4746` | `antigravity-desktop` executor kind + consumers | Axis 1 · Phase 0 |
+| `BI-FA5F49C6` | MCP provider enums (revised: no change needed — see seam finding) | Axis 1 · Phase 0 |
+| `BI-EF0489B8` | `antigravity` token-snippet + confirm config shape | Axis 1 · Phase 0 |
+| `BI-ECAE3494` | `.antigravity-plugin` packaging + bootstrap wiring + onboarding doc | Axis 1 · Phase 0/1 |
+| `BI-47A81FEB` | **EVIDENCE GATE** — prove one governed `agy --headless` build | Gate |
+| `BI-D2E3F2FD` | Antigravity as BS in-sandbox dispatch engine | Axis 2 · **deferred** |
+
+---
+
+**Author note:** Parity-first on the cheap precedented axis, one proof before the expensive axis. Kernel principles invoked: `never-adopt-an-unvetted-external-tool`, `least-privilege-deny-by-default`, `never-assume-verify`, `human-in-the-loop-at-phase-boundaries`, `architecture-over-shortcuts`, `all-changes-land-via-pr`.

--- a/packages/dpf-skill-pack/.antigravity-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.antigravity-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "dpf-platform",
+  "description": "DPF-native agent skills for Google Antigravity contributors. Single-source-of-truth contract: superset SKILL.md frontmatter feeds external Antigravity users (agy CLI + IDE) and in-portal coworkers alike. Hook consumption on the Antigravity surface is pending functional confirmation (EP-ANTIGRAVITY-001 evidence gate BI-47A81FEB) — until confirmed, comply with the lease/worktree contract by construction. See README.md.",
+  "version": "0.2.2",
+  "author": {
+    "name": "Digital Product Factory",
+    "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"
+  },
+  "homepage": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/packages/dpf-skill-pack",
+  "repository": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/tree/main/packages/dpf-skill-pack",
+  "license": "Apache-2.0",
+  "skills": "./skills/",
+  "mcpConfig": "./antigravity.mcp.json",
+  "hooks": "./hooks/hooks.json",
+  "keywords": [
+    "dpf",
+    "digital-product-factory",
+    "agent-skills",
+    "build-studio",
+    "kernel-principles",
+    "backlog",
+    "worktree",
+    "dco",
+    "antigravity",
+    "google",
+    "gemini"
+  ]
+}

--- a/packages/dpf-skill-pack/antigravity.mcp.json
+++ b/packages/dpf-skill-pack/antigravity.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "dpf": {
+      "type": "http",
+      "url": "${DPF_MCP_URL:-http://127.0.0.1:3000/api/mcp/v1}",
+      "headers": {
+        "Authorization": "Bearer ${DPF_MCP_BEARER_TOKEN:-}"
+      }
+    }
+  }
+}

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -43,7 +43,7 @@ apps/web/lib/marketing.ts	1367
 apps/web/lib/mcp-tools-backlog.test.ts	920
 apps/web/lib/mcp-tools.ts	1957
 apps/web/lib/mcp/packs/backlog-pack.ts	1328
-apps/web/lib/mcp/packs/contribution-hive-pack.ts	861
+apps/web/lib/mcp/packs/contribution-hive-pack.ts	858
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
 apps/web/lib/navigation/portal-navigation-model.ts	937
 apps/web/lib/operate/coworker-regression-detector.ts	935
@@ -62,7 +62,7 @@ apps/web/lib/tak/route-context-map.ts	1226
 apps/web/lib/tak/route-context.ts	1239
 apps/web/lib/work-capsules/mcp-handlers.ts	884
 apps/web/lib/work-capsules/work-capsule-store.test.ts	1103
-apps/web/lib/work-capsules/work-capsule-store.ts	1041
+apps/web/lib/work-capsules/work-capsule-store.ts	1042
 apps/web/lib/workbooks/platform-tables.ts	938
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace/command-center.ts	1118


### PR DESCRIPTION
## What & why

Onboards **Google Antigravity** as a fifth external host-worktree coding surface, peer to Claude Code / Codex / Grok. Kicked off after the operator's manual dry run (Antigravity delivered PR #3155 `36f40c903`, a clean gate-unification refactor with tests, merged to main).

**Kernel decision `DI-F8A78E41B01D`** (`principle_decide`) selected an **evidence-gated thin slice** (composite 11.24 vs full-parity-now 6.51 vs defer 2.85; high confidence, no commandment conflict): do the cheap, precedented **external-executor axis** now, prove ONE governed `agy --headless` build end-to-end, then reassess the larger Build Studio in-sandbox engine axis.

### The two-axis distinction
- **External host-worktree executor axis** (this PR) — where `agy --headless` belongs, peer to Claude/Codex/Grok.
- **Build Studio in-sandbox engine axis** — where `opencode` lives (`claude|codex|grok|opencode|agentic`). ~19 seams incl. a new runner file. **Deferred** to `BI-D2E3F2FD` behind the evidence gate.

## Changes (external-executor axis, mirrors EP-GROK-001)
- `antigravity-desktop` executor kind + consumers (`isExternalLeaseExecutor`, `providerToExecutorKind`). The `create_work_capsule`/`adopt_worktree` MCP enum and the enum-parity test derive from the const, so the kind propagates for free.
- `antigravity` MCP token-snippet (`issue-mcp-token.ts --format antigravity`) — JSON `mcpServers.dpf` block (http, env-backed auth). Exact Antigravity MCP-config path flagged for the evidence gate.
- Skill-pack packaging `.antigravity-plugin/plugin.json` + `antigravity.mcp.json`, mirroring `.grok-plugin`.
- Snippet unit test + `work-capsules` assertions.

**Seam finding (verified vs real `main`, post mcp-tools refactor):** the nonprod `NonprodOwnerProvider` enum is `build-studio|claude|codex|coworker` — grok is not in it either, so external CLIs don't flow through it and Antigravity needs no change there.

## Not in this PR (gated)
- Bootstrap auto-wiring (`update_agent_toolchain.py` / `dpf-bootstrap`) — `BI-ECAE3494`.
- **Evidence gate `BI-47A81FEB`** (kernel-mandated, Human-in-the-Loop): operator runs one governed `agy --headless` build against a real BI, wired via `--format antigravity`, recording capsule evidence as `antigravity-desktop`, shipping a DCO PR through CI. This resolves the sole open unknown — Antigravity's hook/packaging plane (Windsurf-derived; Claude-format hook enforcement is unverified). Only a green gate opens the BS-engine axis.

## Verification
- Full `apps/web` `tsc --noEmit` exit 0 (8GB heap).
- Affected suites green: `mcp-setup-snippets` + `work-capsules` + `work-capsules-enum-parity` — 46 tests.
- gitleaks clean.

Spec: `docs/superpowers/specs/2026-07-17-antigravity-first-class-support-design.md`
Epic: `EP-ANTIGRAVITY-001`

## Local-CI-Override attestation
The pre-push sandbox pregate could not claim the local-integration-ci lease — the portal is **quiescing for platform upgrade `QR-2026-07-17-rq1v0846`** (drain state, new actions refused). Verified locally in its place: full `tsc --noEmit` exit 0, the three directly-affected vitest suites green (46 tests), gitleaks clean. Change is additive/mechanical and mirrors the landed EP-GROK-001 pattern. Remote CI gates the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)