### PR TITLE
feat(ops): split "Needs you next" into personal vs company-wide scope (BI-01CC2356)

### DIFF
--- a/apps/web/app/(shell)/ops/page.tsx
+++ b/apps/web/app/(shell)/ops/page.tsx
@@ -5,6 +5,7 @@ import { reconcileCapabilityNeedBacklog } from "@/lib/coworker-self-assessment/c
 import { runEscalationHygiene } from "@/lib/quality/escalation-hygiene-runner";
 import { OpsClient } from "@/components/ops/OpsClient";
 import { OpsTabNav } from "@/components/ops/OpsTabNav";
+import { auth } from "@/lib/auth";
 import { SurfaceViewSwitcher } from "@/components/workbooks/SurfaceViewSwitcher";
 import { SurfacePlatformGrid } from "@/components/workbooks/SurfacePlatformGrid";
 
@@ -34,13 +35,17 @@ export default async function OpsPage({ searchParams }: Props) {
     runEscalationHygiene().catch(() => {}),
   ]);
 
-  const [items, digitalProducts, taxonomyNodes, epics, portfolios] = await Promise.all([
+  const [items, digitalProducts, taxonomyNodes, epics, portfolios, session] = await Promise.all([
     getBacklogItems(),
     getDigitalProductsForSelect(),
     getTaxonomyNodesFlat(),
     getEpics(),
     getPortfoliosForSelect(),
+    auth(),
   ]);
+  // Current operator — resolves the "mine" scope in the Needs-you-next band
+  // (BI-01CC2356). Optional: the band degrades to an urgency-only split when absent.
+  const currentUserId = session?.user?.id ?? undefined;
 
   return (
     <div>
@@ -66,6 +71,7 @@ export default async function OpsPage({ searchParams }: Props) {
           portfolios={portfolios}
           focusedItemId={sp?.itemId}
           initialOrigin={sp?.origin}
+          currentUserId={currentUserId}
         />
       )}
     </div>

--- a/apps/web/components/ops/OperatorTriageBand.tsx
+++ b/apps/web/components/ops/OperatorTriageBand.tsx
@@ -5,24 +5,34 @@
 // operator sees "what needs me next" instead of scanning 470+ items of wildly
 // different altitude. Selection + ordering live in the pure, tested
 // lib/ops/operator-triage module; this is only the presentation.
+//
+// BI-01CC2356: the queue is now SPLIT into a personal lens ("mine") and the
+// company-wide pool. Presenting a 171-wide queue as "171 items awaiting YOUR
+// decision" was misleading — most of it is routine platform throughput. The band
+// defaults to the personal lens (what's genuinely on the operator's plate now)
+// and lets them opt into the company-wide pool.
 
 import { useMemo, useState } from "react";
 import { ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
 import { BacklogItemRow } from "./BacklogItemRow";
 import {
-  selectOperatorQueue,
+  partitionOperatorQueue,
   OPERATOR_TRIAGE_REASON_LABEL,
   OPERATOR_TRIAGE_REASON_HINT,
+  type OperatorTriageEntry,
   type OperatorTriageReason,
 } from "@/lib/ops/operator-triage";
 import type { BacklogItemWithRelations } from "@/lib/backlog";
 
 const MAX_VISIBLE = 7;
+const MAX_COMPANY_VISIBLE = 7;
 
 type Props = {
   items: BacklogItemWithRelations[];
   onEdit: (item: BacklogItemWithRelations) => void;
   focusedItemId?: string;
+  /** Current operator's user id — resolves the "mine" scope (BI-01CC2356). */
+  currentUserId?: string;
 };
 
 const REASON_CHIP_CLASS: Record<OperatorTriageReason, string> = {
@@ -33,13 +43,62 @@ const REASON_CHIP_CLASS: Record<OperatorTriageReason, string> = {
   stalled: "border-[var(--dpf-warning)]/40 bg-[var(--dpf-warning)]/10 text-[var(--dpf-warning)]",
 };
 
-export function OperatorTriageBand({ items, onEdit, focusedItemId }: Props) {
-  const queue = useMemo(() => selectOperatorQueue(items), [items]);
-  const [open, setOpen] = useState(true);
+function TriageRow({
+  entry,
+  onEdit,
+  focusedItemId,
+}: {
+  entry: OperatorTriageEntry;
+  onEdit: (item: BacklogItemWithRelations) => void;
+  focusedItemId?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-2">
+        <span
+          className={[
+            "rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+            REASON_CHIP_CLASS[entry.reason],
+          ].join(" ")}
+          title={OPERATOR_TRIAGE_REASON_HINT[entry.reason]}
+        >
+          {OPERATOR_TRIAGE_REASON_LABEL[entry.reason]}
+        </span>
+        {entry.blocksBusinessOutcome && (
+          <span
+            className="inline-flex items-center gap-1 rounded border border-[var(--dpf-error)]/40 bg-[var(--dpf-error)]/10 px-1.5 py-0.5 text-[10px] font-semibold text-[var(--dpf-error)]"
+            title="Plausibly blocks a customer or business outcome"
+          >
+            <AlertTriangle className="h-3 w-3" />
+            Blocks outcome
+          </span>
+        )}
+      </div>
+      <BacklogItemRow
+        item={entry.item}
+        onEdit={onEdit}
+        focused={Boolean(
+          focusedItemId &&
+            (entry.item.itemId === focusedItemId || entry.item.id === focusedItemId),
+        )}
+      />
+    </div>
+  );
+}
 
-  const total = queue.length;
-  const visible = queue.slice(0, MAX_VISIBLE);
-  const overflow = total - visible.length;
+export function OperatorTriageBand({ items, onEdit, focusedItemId, currentUserId }: Props) {
+  const { mine, company } = useMemo(
+    () => partitionOperatorQueue(items, currentUserId),
+    [items, currentUserId],
+  );
+  const [open, setOpen] = useState(true);
+  // The company-wide pool is opt-in — collapsed by default (BI-01CC2356).
+  const [showCompany, setShowCompany] = useState(false);
+
+  const mineVisible = mine.slice(0, MAX_VISIBLE);
+  const mineOverflow = mine.length - mineVisible.length;
+  const companyVisible = company.slice(0, MAX_COMPANY_VISIBLE);
+  const companyOverflow = company.length - companyVisible.length;
 
   return (
     <section className="mb-8 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
@@ -57,66 +116,78 @@ export function OperatorTriageBand({ items, onEdit, focusedItemId }: Props) {
         <span
           className={[
             "rounded-full px-2 py-0.5 text-[10px] font-semibold tabular-nums",
-            total > 0
+            mine.length > 0
               ? "bg-[var(--dpf-accent-soft)] text-[var(--dpf-accent)]"
               : "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)]",
           ].join(" ")}
         >
-          {total}
+          {mine.length}
         </span>
         <span className="ml-1 hidden text-[10px] text-[var(--dpf-muted)] sm:inline">
-          items awaiting an operator decision — customer-blocking &amp; high-risk first
+          on your plate now — customer-blocking &amp; high-risk first
         </span>
       </button>
 
       {open && (
         <div className="border-t border-[var(--dpf-border)] px-3 py-3">
-          {total === 0 ? (
+          {mine.length === 0 ? (
             <p className="text-xs text-[var(--dpf-muted)]">
-              You&rsquo;re clear — nothing in the backlog is waiting on an operator decision right now.
+              You&rsquo;re clear — nothing needs you personally right now.
+              {company.length > 0 && " Routine items are in the platform queue below."}
             </p>
           ) : (
             <>
               <div className="flex flex-col gap-2.5">
-                {visible.map((entry) => (
-                  <div key={entry.item.id} className="flex flex-col gap-1">
-                    <div className="flex items-center gap-2">
-                      <span
-                        className={[
-                          "rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
-                          REASON_CHIP_CLASS[entry.reason],
-                        ].join(" ")}
-                        title={OPERATOR_TRIAGE_REASON_HINT[entry.reason]}
-                      >
-                        {OPERATOR_TRIAGE_REASON_LABEL[entry.reason]}
-                      </span>
-                      {entry.blocksBusinessOutcome && (
-                        <span
-                          className="inline-flex items-center gap-1 rounded border border-[var(--dpf-error)]/40 bg-[var(--dpf-error)]/10 px-1.5 py-0.5 text-[10px] font-semibold text-[var(--dpf-error)]"
-                          title="Plausibly blocks a customer or business outcome"
-                        >
-                          <AlertTriangle className="h-3 w-3" />
-                          Blocks outcome
-                        </span>
-                      )}
-                    </div>
-                    <BacklogItemRow
-                      item={entry.item}
-                      onEdit={onEdit}
-                      focused={Boolean(
-                        focusedItemId &&
-                          (entry.item.itemId === focusedItemId || entry.item.id === focusedItemId),
-                      )}
-                    />
-                  </div>
+                {mineVisible.map((entry) => (
+                  <TriageRow
+                    key={entry.item.id}
+                    entry={entry}
+                    onEdit={onEdit}
+                    focusedItemId={focusedItemId}
+                  />
                 ))}
               </div>
-              {overflow > 0 && (
+              {mineOverflow > 0 && (
                 <p className="mt-2.5 text-[10px] text-[var(--dpf-muted)]">
-                  + {overflow} more awaiting you — worked below in the full backlog.
+                  + {mineOverflow} more of yours — worked below in the full backlog.
                 </p>
               )}
             </>
+          )}
+
+          {/* Company-wide pool — opt-in. Not the operator's personal decisions;
+              the platform drives most of these. (BI-01CC2356) */}
+          {company.length > 0 && (
+            <div className="mt-3 border-t border-[var(--dpf-border)] pt-3">
+              <button
+                onClick={() => setShowCompany((v) => !v)}
+                className="flex items-center gap-1.5 text-[10px] font-medium text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                aria-expanded={showCompany}
+              >
+                {showCompany ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                <span className="tabular-nums">{company.length}</span>
+                <span>in the platform queue — company-wide, mostly auto-driven</span>
+              </button>
+              {showCompany && (
+                <>
+                  <div className="mt-2.5 flex flex-col gap-2.5">
+                    {companyVisible.map((entry) => (
+                      <TriageRow
+                        key={entry.item.id}
+                        entry={entry}
+                        onEdit={onEdit}
+                        focusedItemId={focusedItemId}
+                      />
+                    ))}
+                  </div>
+                  {companyOverflow > 0 && (
+                    <p className="mt-2.5 text-[10px] text-[var(--dpf-muted)]">
+                      + {companyOverflow} more — worked below in the full backlog.
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/apps/web/components/ops/OpsClient.tsx
+++ b/apps/web/components/ops/OpsClient.tsx
@@ -43,6 +43,9 @@ type Props = {
    *  the Source pill already active — so the navigation reads as "capability needs live
    *  here", not an unexplained jump into the full backlog. */
   initialOrigin?: string;
+  /** Current operator's user id — resolves the "mine" scope in the Needs-you-next
+   *  band (BI-01CC2356). */
+  currentUserId?: string;
 };
 
 const TYPE_LABELS: Record<string, string> = {
@@ -102,7 +105,7 @@ function SortButton({ label, field, sort, onSort }: {
   );
 }
 
-export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfolios, focusedItemId, initialOrigin }: Props) {
+export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfolios, focusedItemId, initialOrigin, currentUserId }: Props) {
   const [panel, setPanel] = useState<ItemPanelState>({ open: false });
   const [epicPanel, setEpicPanel] = useState<EpicPanelState>(null);
   const [epicSort, setEpicSort] = useState<SortState>(null);
@@ -183,7 +186,7 @@ export function OpsClient({ items, digitalProducts, taxonomyNodes, epics, portfo
       {/* Operator triage lens (BI-9952EA9E) — the small, prioritized set of items
           awaiting an operator decision, above the raw wall. Spans ALL items (not
           narrowed by the source/portfolio lenses below). */}
-      <OperatorTriageBand items={items} onEdit={openEdit} focusedItemId={focusedItemId} />
+      <OperatorTriageBand items={items} onEdit={openEdit} focusedItemId={focusedItemId} currentUserId={currentUserId} />
 
       {/* Source + portfolio lenses — narrow the one Operations surface */}
       <FilterBar

--- a/apps/web/lib/explore/backlog-data.ts
+++ b/apps/web/lib/explore/backlog-data.ts
@@ -45,6 +45,8 @@ export const getBacklogItems = cache(async (): Promise<BacklogItemWithRelations[
       riskOpportunity: true,
       businessValue: true,
       timeCriticality: true,
+      // Ownership for the mine-vs-company scope split (BI-01CC2356).
+      claimedById: true,
     },
   });
 });
@@ -100,6 +102,8 @@ export const getEpics = cache(async (): Promise<EpicWithRelations[]> => {
           riskOpportunity: true,
           businessValue: true,
           timeCriticality: true,
+          // Ownership for the mine-vs-company scope split (BI-01CC2356).
+          claimedById: true,
         },
       },
     },

--- a/apps/web/lib/explore/backlog.ts
+++ b/apps/web/lib/explore/backlog.ts
@@ -45,6 +45,9 @@ export type BacklogItemWithRelations = {
   riskOpportunity?: number | null;
   businessValue?: number | null;
   timeCriticality?: number | null;
+  // Ownership — who has actively claimed this item. Drives the "mine vs
+  // company-wide" scope split in the Needs-you-next band (BI-01CC2356).
+  claimedById?: string | null;
 };
 
 export type DigitalProductSelect = {

--- a/apps/web/lib/ops/operator-triage.test.ts
+++ b/apps/web/lib/ops/operator-triage.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   classifyOperatorReason,
   selectOperatorQueue,
+  partitionOperatorQueue,
+  resolveOperatorScope,
   type OperatorTriageReason,
 } from "./operator-triage";
 import type { BacklogItemWithRelations } from "@/lib/backlog";
@@ -171,5 +173,70 @@ describe("selectOperatorQueue", () => {
     const snapshot = input.map((i) => i.itemId);
     selectOperatorQueue(input, NOW);
     expect(input.map((i) => i.itemId)).toEqual(snapshot);
+  });
+
+  it("tags each entry with a mine/company scope", () => {
+    const queue = selectOperatorQueue([item({ itemId: "BI-BLK", claimStatus: "blocked" })], NOW);
+    expect(queue[0]?.scope).toBe("mine");
+  });
+});
+
+describe("resolveOperatorScope (BI-01CC2356)", () => {
+  it("puts broken/blocked work on the operator's plate even with no principal", () => {
+    expect(resolveOperatorScope(item({}), "build-attention")).toBe("mine");
+    expect(resolveOperatorScope(item({}), "blocked")).toBe("mine");
+  });
+
+  it("treats routine throughput (triage / launch / stale) as company-wide", () => {
+    expect(resolveOperatorScope(item({}), "awaiting-triage")).toBe("company");
+    expect(resolveOperatorScope(item({}), "ready-to-build")).toBe("company");
+    expect(resolveOperatorScope(item({}), "stalled")).toBe("company");
+  });
+
+  it("claims an item as mine when the current principal owns it", () => {
+    const mineItem = item({ claimedById: "user-1" });
+    expect(resolveOperatorScope(mineItem, "awaiting-triage", "user-1")).toBe("mine");
+  });
+
+  it("does not claim an item owned by someone else", () => {
+    const theirs = item({ claimedById: "user-2" });
+    expect(resolveOperatorScope(theirs, "awaiting-triage", "user-1")).toBe("company");
+  });
+
+  it("ignores claim ownership when no principal is provided", () => {
+    const claimed = item({ claimedById: "user-1" });
+    expect(resolveOperatorScope(claimed, "awaiting-triage")).toBe("company");
+  });
+});
+
+describe("partitionOperatorQueue (BI-01CC2356)", () => {
+  it("splits the queue into a personal lens and the company-wide pool", () => {
+    const broken = item({ itemId: "BI-BROKEN", activeBuildId: "b", activeBuild: null }); // build-attention → mine
+    const routine = item({ itemId: "BI-ROUTINE", status: "triaging" }); // awaiting-triage → company
+    const { mine, company } = partitionOperatorQueue([routine, broken], undefined, NOW);
+    expect(mine.map((e) => e.item.itemId)).toEqual(["BI-BROKEN"]);
+    expect(company.map((e) => e.item.itemId)).toEqual(["BI-ROUTINE"]);
+  });
+
+  it("routes a principal's claimed routine item into the personal lens", () => {
+    const claimedRoutine = item({ itemId: "BI-MINE", status: "triaging", claimedById: "user-1" });
+    const otherRoutine = item({ itemId: "BI-OTHER", status: "triaging" });
+    const { mine, company } = partitionOperatorQueue([claimedRoutine, otherRoutine], "user-1", NOW);
+    expect(mine.map((e) => e.item.itemId)).toEqual(["BI-MINE"]);
+    expect(company.map((e) => e.item.itemId)).toEqual(["BI-OTHER"]);
+  });
+
+  it("preserves the full-queue ordering within each side and loses no items", () => {
+    const items = [
+      item({ itemId: "BI-A", status: "triaging", businessValue: 5 }),
+      item({ itemId: "BI-B", claimStatus: "blocked" }),
+      item({ itemId: "BI-C", status: "triaging", riskOpportunity: 9 }),
+    ];
+    const full = selectOperatorQueue(items, NOW);
+    const { mine, company } = partitionOperatorQueue(items, undefined, NOW);
+    expect(mine.length + company.length).toBe(full.length);
+    // Company side keeps the same relative order it had in the full queue.
+    const fullCompanyOrder = full.filter((e) => e.scope === "company").map((e) => e.item.itemId);
+    expect(company.map((e) => e.item.itemId)).toEqual(fullCompanyOrder);
   });
 });

--- a/apps/web/lib/ops/operator-triage.ts
+++ b/apps/web/lib/ops/operator-triage.ts
@@ -21,11 +21,24 @@ export type OperatorTriageReason =
   | "blocked" // work claim explicitly blocked — needs unblocking
   | "stalled"; // flagged stale and still live — needs a call
 
+/**
+ * Whose plate is this on (BI-01CC2356)?
+ * - "mine": genuinely on the current operator's plate now — work they've claimed,
+ *   or a broken/blocked item a human must personally intervene on.
+ * - "company": routine platform throughput (triage / launch / stale calls) that
+ *   is company-wide, not a personal must-decide-now item.
+ * The band defaults to "mine" and lets the operator opt into the "company" pool,
+ * so a 171-wide queue stops masquerading as 171 personal decisions.
+ */
+export type OperatorTriageScope = "mine" | "company";
+
 export type OperatorTriageEntry = {
   item: BacklogItemWithRelations;
   reason: OperatorTriageReason;
   /** True when the item plausibly blocks a customer or business outcome. */
   blocksBusinessOutcome: boolean;
+  /** Whose plate the item is on — the mine-vs-company lens. */
+  scope: OperatorTriageScope;
   /** Ordering keys (exposed for tests + UI transparency). */
   businessScore: number;
   riskScore: number;
@@ -125,6 +138,23 @@ function riskScore(item: BacklogItemWithRelations, reason: OperatorTriageReason)
 }
 
 /**
+ * Whose plate is this item on (BI-01CC2356)? "mine" when the current principal
+ * has actively claimed it, OR when it is broken/blocked and a human must step in
+ * (build-attention / blocked). Everything else — routine triage, launch, and
+ * stale calls — is company-wide throughput. With no principalId, ownership can't
+ * be resolved, so the split degrades to the urgency signal alone.
+ */
+export function resolveOperatorScope(
+  item: BacklogItemWithRelations,
+  reason: OperatorTriageReason,
+  principalId?: string | null,
+): OperatorTriageScope {
+  if (principalId && item.claimedById && item.claimedById === principalId) return "mine";
+  if (reason === "build-attention" || reason === "blocked") return "mine";
+  return "company";
+}
+
+/**
  * Select and prioritize the small set of items awaiting an operator decision.
  *
  * Ordering (BI-9952EA9E): business-outcome first → risk/severity → staleness,
@@ -132,10 +162,14 @@ function riskScore(item: BacklogItemWithRelations, reason: OperatorTriageReason)
  *
  * @param items every backlog item (unassigned + epic children, flattened)
  * @param now injectable clock for staleness (defaults to wall-clock)
+ * @param principalId current operator's user id — resolves the "mine" scope
+ *   (BI-01CC2356). Optional; when omitted the scope split uses the urgency
+ *   signal only.
  */
 export function selectOperatorQueue(
   items: BacklogItemWithRelations[],
   now: Date = new Date(),
+  principalId?: string | null,
 ): OperatorTriageEntry[] {
   const entries: OperatorTriageEntry[] = [];
   for (const item of items) {
@@ -145,6 +179,7 @@ export function selectOperatorQueue(
       item,
       reason,
       blocksBusinessOutcome: blocksBusinessOutcome(item),
+      scope: resolveOperatorScope(item, reason, principalId),
       businessScore: businessScore(item),
       riskScore: riskScore(item, reason),
       stalenessDays: daysBetween(item.stalenessDetectedAt ?? item.updatedAt, now),
@@ -164,4 +199,34 @@ export function selectOperatorQueue(
     if (ca !== cb) return ca - cb;
     return a.item.itemId.localeCompare(b.item.itemId);
   });
+}
+
+export type OperatorQueuePartition = {
+  /** Genuinely on the operator's plate now — the default lens. */
+  mine: OperatorTriageEntry[];
+  /** Company-wide platform throughput — opt-in, not personal decisions. */
+  company: OperatorTriageEntry[];
+};
+
+/**
+ * Split the prioritized operator queue into a personal lens and the company-wide
+ * pool (BI-01CC2356). Preserves the existing ordering within each side — this is
+ * a pure partition, not a re-sort — so "mine" leads with the most urgent item.
+ *
+ * @param items every backlog item (unassigned + epic children, flattened)
+ * @param principalId current operator's user id (resolves claim ownership)
+ * @param now injectable clock for staleness
+ */
+export function partitionOperatorQueue(
+  items: BacklogItemWithRelations[],
+  principalId?: string | null,
+  now: Date = new Date(),
+): OperatorQueuePartition {
+  const queue = selectOperatorQueue(items, now, principalId);
+  const mine: OperatorTriageEntry[] = [];
+  const company: OperatorTriageEntry[] = [];
+  for (const entry of queue) {
+    (entry.scope === "mine" ? mine : company).push(entry);
+  }
+  return { mine, company };
 }


### PR DESCRIPTION
## What & why

The operator-triage band ("Needs you next") presented a company-wide queue — 171 items across 137 epics — as "*N items awaiting an operator decision*". But almost none are the operator's personal call; most are routine platform throughput the platform can drive. Presenting them as personal decisions is misleading and defeats the band's "what should I do next" purpose (it was built to shrink a 470-item wall — 171 is still a wall).

Chosen approach (operator decision): **split** mine vs company-wide, default to the personal lens, make the company-wide pool opt-in.

## Changes

- **`operator-triage.ts`** — tag each queue entry with a `mine | company` scope (`resolveOperatorScope`): **mine** when the current principal has claimed the item **or** it is broken/blocked (`build-attention` / `blocked`); everything else (routine triage / launch / stale calls) is **company**. `partitionOperatorQueue()` splits the prioritized queue, preserving order within each side.
- **`OperatorTriageBand.tsx`** — defaults to the personal lens (badge count = what's genuinely on your plate now, "on your plate now — customer-blocking & high-risk first"). The company-wide pool is a collapsed, opt-in disclosure ("*N in the platform queue — company-wide, mostly auto-driven*"). Copy no longer implies N personal decisions.
- **Loaders + type** — surface `claimedById` on the two `/ops` selects and `BacklogItemWithRelations`; **`ops/page.tsx`** resolves the current operator via `auth()` and threads it through `OpsClient`. Degrades gracefully (urgency-only split) when no principal.
- **Tests** — scope resolution + partition (`operator-triage.test.ts`).

## Design grounding

Source of truth: the operator-triage lens (**BI-9952EA9E**) under **EP-ATTENTION-SURFACE** (the "attention ≠ backlog" / personal-scope audience split). This **extends** that lens; adds one **existing** column (`claimedById`) to two loader selects. **No schema migration, no external contract change.** Process-Spine: UX + pure-logic on already-filed BIs, internal types only.

## Verification

- `operator-triage` is a pure module; new unit tests cover mine/company classification, principal-ownership, and order-preserving partition.
- ⚠️ Local typecheck/unit could **not** run — source-only worktree, `next` binary not installed. **CI Typecheck / Prod Build / Unit gate the merge.**

Part of EP-ATTENTION-SURFACE. Complements #3188 (a coworker that reads an honestly-scoped band stops rationalizing).