### PR TITLE
doc(data): Data Management Governance rev. 2 — founder-revised design + reconciled plan

### DIFF
--- a/docs/superpowers/plans/2026-07-17-data-management-governance-plan.md
+++ b/docs/superpowers/plans/2026-07-17-data-management-governance-plan.md
@@ -1,96 +1,1095 @@
 # Data Management Governance — Implementation Plan
 
-- **Date:** 2026-07-17
-- **Spec:** `docs/superpowers/specs/2026-07-17-data-management-governance-design.md`
-- **Epics:** EP-DATA-GOVERNANCE (new), EP-DATA-RETENTION (reopened)
-- **Capsule:** WC-450D7558
+> **For agentic workers:** REQUIRED: execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR (Delivery rule 1). Use the DPF-native skills: `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the per-BI completion gate before any success claim, and `dpf-pr-with-dco` for handoff, with a code review pass before requesting merge. The upstream `superpowers:*` skill names are retired in this repo and must not be invoked (see `docs/superpowers/specs/2026-05-30-dpf-native-skill-equivalents-design.md`).
 
-Phases are ordered so that (1) the classification spine lands before everything that consumes it, (2) the highest-risk live exposure (agent-memory embeddings) is closed immediately without waiting for the spine, and (3) enforcement gates land before large enrollment waves so new work cannot regress while we fix old debt. Each backlog item is independently shippable and PR-sized (or explicitly xlarge for decomposition at build time).
+**Goal:** Build an embedded, enforceable data-governance control plane in which every persistent asset, MDM domain, lifecycle action, derived copy, AI exposure, and policy decision has an accountable owner, machine-checkable contract, enforcement point, and evidence.
 
-## Phase 0 — Stop the live exposure (no dependencies)
+**Architecture:** A source-controlled logical data-asset inventory composes typed classification, lifecycle, MDM, processing-purpose, derived-copy, protection, and executable-policy modules. Organization-specific processing activities, exceptions, holds, conflicts, and evidence are persisted. One pure in-process PDP feeds many PEPs. The `/admin/data` workspace exposes the same contracts in plain language.
 
-**BI-DG-001 — Sensitivity gate + deletion propagation for agent-memory embeddings** (`feature`, medium)
-`storeConversationMemory` honors the request's already-computed route sensitivity before writing to Qdrant `agent-memory`: `restricted` → skip storage; `confidential` → store with masked preview (no raw `contentPreview`, no PII fields in payload) per policy. Add deletion propagation: deleting an `AgentMessage`/`AgentThread` (including the retention sweep's `purgeStaleAgentThreads` handler) enqueues `deleteVectors` for the affected message ids. Tests: restricted-route turn produces no vector; purged thread leaves no orphan vectors.
-*Files:* `apps/web/lib/inference/semantic-memory.ts`, `apps/web/lib/actions/agent-coworker.ts`, `apps/web/lib/operate/retention/policies.ts` (custom handler), queue function for vector cleanup.
+**Tech stack:** Next.js 16, TypeScript, Prisma 7/Postgres 16, Neo4j 5, Qdrant, Inngest queue functions, Vitest, report-kit, DPF MCP, and the shared local-integration CI lease.
 
-## Phase 1 — Classification spine + growth observability
+**Spec:** `docs/superpowers/specs/2026-07-17-data-management-governance-design.md`
 
-**BI-DG-002 — Data classification registry with build-failing coverage tests** (`feature`, large)
-`apps/web/lib/govern/data-classes.ts` per spec §5.1: closed unions, one entry per Prisma model (~385 — bulk-classified by category with the sensitive minority given field-level entries), `subjectKind` links, `lifecycleClass` total function, `projectionPolicy`, `residencyClass`, `regulatoryBases`. Test suite validates: full coverage against `parsePrismaSchema` facts; purge/retained cross-consistency with the retention registry; invariant rules (credential-secret never embedded; restricted never raw-embedded). Registry projects into the EA data-model mirror as element properties.
+**Live work:** EP-DATA-GOVERNANCE (`BI-DG-001` through `BI-DG-016`), EP-DATA-RETENTION (`BI-DR-101` through `BI-DR-107`), and EP-MDM (`BI-MDM-201` through `BI-MDM-203`). Existing BI IDs are retained; do not invent replacements. Assigned on 2026-07-17 backlog reconciliation: durable operation journal = `BI-DG-014` (Task 4B), first legacy classification wave = `BI-DG-015` (Task 4A; each subsequent wave is filed as its predecessor closes), workspace consolidation = `BI-DG-016` (Task 21), MDM readiness/crosswalks = `BI-MDM-201` (Task 5A), MDM survivorship/provenance = `BI-MDM-202` (Task 5B), MDM autonomy/publish/retraction = `BI-MDM-203` (Task 5C). Still deliberately deferred to their in-plan gates: one BI per approved protected-field family (after `BI-DG-007` core), one BI per approved DR-107 partition stream (after measured approval), and one BI per subject-request copy adapter plus the activation BI (after `BI-DG-008` core).
 
-**BI-DG-003 — Data-Impact Gate CI check + Build Studio prompt rule + AGENTS.md §11 addendum** (`tool`, medium)
-`scripts/check-data-impact.mjs` + workflow job per spec §5.6: PRs adding/renaming Prisma models must touch `data-classes.ts` or carry `Data-Steward-Decision:` trailer. Red-team fixture tests. Matching rule added to `build-agent-prompts.ts`; AGENTS.md documents the gate (pointer to spec).
+---
 
-**BI-DR-101 — Table growth observability + Data Management admin surface** (`feature`, large)
-Scheduled collector sampling `pg_total_relation_size`/`reltuples` into a purge-enrolled time-series table + Prometheus export. Admin page (report-kit, UX-fit gated) rendering: retention matrix from the classification registry (enrolled/retained/capped/unbounded), current sizes + growth rates, last sweep results from `ScheduledJob.metadata.recentRuns`, dry-run preview button (existing `dryRun` event). Alert (PlatformIssueReport) when an `unbounded-accepted` or unclassified table exceeds growth thresholds.
+## Delivery rules
 
-**BI-DG-004 — Steward drift detectors for data governance** (`feature`, small)
-Extend `runDataArchitectureSteward` with `unclassified-model`, `unenrolled-growth-table`, `classification-projection-conflict` detectors filing self-healing `EaConformanceIssue` rows.
+1. One BI, one topic branch, one worktree, one ready-for-review PR. Start each from current `origin/main`; do not stack all phases on one branch.
+2. Query the live backlog and current schema at the start of every BI. This plan's research baseline was 495 Prisma models at `origin/main` `5834e7548`; it is not a permanent count.
+3. Tests fail before production code changes. Every new executable policy includes allow, deny, review/obligation, unknown-context, and expiry/precedence vectors.
+4. No new generic registry, policy table, log, receipt, or admin page until the implementer re-checks current overlap. Reuse and adapt the substrate named in the spec.
+5. Runtime-bound build, migration, queue, cross-store, and UX evidence comes from the canonical install or a lease on `local-integration-ci`, never a worktree-only runtime claim.
+6. Each migration is immutable after commit, includes any data backfill, and uses `pnpm --filter @dpf/db exec prisma ...`, never `npx`.
+7. Any new route, UI, agent, or workflow gets UX-fit evidence. Use report-kit, theme tokens, accessible text alternatives, and in-app dialogs.
+8. Every PR updates its live BI through MCP and records execution evidence. A local-only green check is not completion.
 
-## Phase 2 — Lifecycle completion (EP-DATA-RETENTION reopened)
+### Per-BI completion gate (applies to every implementation task)
 
-**BI-DR-102 — Enroll ranked unbounded tables in the retention registry** (`chore`, large)
-Per-table policy decisions from spec §5.2.2: `UserFact` (superseded-fact purge; active facts exempt), `PortfolioQualityIssue` (resolved > 180d), `BacklogItemActivity`, `AdminActivity`, `Activity` (CRM — respect regulated floors), `IntegrationToolCallLog`, `RouteOutcome`, `ToolExecutionReceipt`/`CoworkerActionEnvelope`/`AgentActionProposal` (365d audit alignment), `EdgeEvent`/`ChangeEvent`/`RemoteAction` (terminal-state-aware), discovery observation streams, `InboundChannelMessage`/`WorkItemMessage` (chat-class), `IntegrationImportStagedRecord`. Purge indexes migration where composite-only indexes would seq-scan (follow `20260614180000` precedent).
+No later task supplies missing evidence for an earlier PR. Before marking any BI task complete, its agent must:
 
-**BI-DR-103 — Revision-cap executor strategy for version/snapshot tables** (`feature`, medium)
-New `revision-cap` strategy in `execute.ts` (`keepLast N` + `maxAgeDays`, never dropping current/published) enrolling the 13 revision/snapshot tables (spec §5.2.3).
+- [ ] Run the task's targeted red/green tests and affected-package typecheck with zero failures.
+- [ ] Claim `local-integration-ci` through MCP, recording the BI, branch, and SHA.
+- [ ] Run `pnpm --filter web build` in the leased canonical verification workspace with zero errors.
+- [ ] If the BI owns a migration, run `pnpm --filter @dpf/db exec prisma migrate deploy` there and record the applied migration name; otherwise record “no migration.”
+- [ ] Exercise that BI's affected runtime/queue/cross-store/UX path, including its stated failure and permission states.
+- [ ] Record commands, output, SHA, migration verdict, and UX/runtime result through `record_execution_evidence` against that BI.
+- [ ] Release the environment lease in a `finally` path.
+- [ ] Run the in-scope secret scan and `pnpm pr:health`, create a DCO-signed commit (`git commit -s`), push the branch, and open a regular ready-for-review PR only when every gate is green.
 
-**BI-DR-104 — Status-aware datasets (old Slice 3)** (`feature`, medium)
-Terminal-state-aware enrollment for `TaskRun`/`TaskMessage`/`TaskArtifact`/`TaskNode`, `DecisionInteraction` (+ `EscalationCapture`/`DeferralCapture`).
+Unless a task says that measured deferral is its intended result, every verification block below expects all listed tests to pass and typecheck to exit zero. A failing test for an unrelated baseline defect is recorded and handled under the project blocker rule; it is never reported as a pass.
 
-**BI-DR-105 — Legal hold + disposition evidence** (`feature`, large)
-`LegalHold` model (scope = classification categories and/or subject; operator-gated create/release, audited) checked by the sweep engine before any delete; `DispositionRecord` written by every destructive lifecycle action (policy, count, cutoff, checksum). Precedence tests: retention > deletion; longest wins; hold suspends all. Blocks: BI-DG-008 (erasure must respect holds).
+### Migration checklist (applies to every migration-owning task)
 
-**BI-DR-106 — Archival tier: export-then-delete with evidence (old Slice 5)** (`feature`, large)
-Per-policy `archive: true` → compressed, checksummed export to the backup volume before delete; restore runbook; disposition record links the artifact.
+- [ ] Run the named creation command from the task, inspect the generated `packages/db/prisma/migrations/<timestamp>_<name>/migration.sql`, and replace the placeholder path in the BI evidence with the immutable generated path.
+- [ ] Put any data backfill in that same migration. If no backfill is required, add an explicit SQL comment and state why in the BI evidence.
+- [ ] Add an invariant query/test that distinguishes complete, partial, and duplicate backfill results.
+- [ ] Run schema validation before creation, targeted tests after creation, and `prisma migrate deploy` under the per-BI leased completion gate.
 
-**BI-DR-107 — Partition-drop strategy for top event streams (old Slice 6)** (`feature`, xlarge)
-Registry `strategy: "delete" | "partition-drop"`; migrate the largest streams (per BI-DR-101 data — expected: `ToolExecution`, `AdapterRunTelemetry`, `EdgeEvent`/`SecurityEvent`) to native range partitions with automated create/drop maintenance. Defer trigger: size thresholds from observability, not calendar.
+## Refactoring budget — 20% of delivery capacity
 
-## Phase 3 — Projection governance
+This allocation is a delivery constraint, not optional cleanup:
 
-**BI-DG-005 — Projection contract registry + scope enforcement** (`feature`, large)
-`apps/web/lib/govern/projection-contracts.ts` covering the six families (spec §5.3); build-failing test that each contract's payload class satisfies every source model's `projectionPolicy`; content-class contracts route through the masking service (after BI-DG-007; interim: sensitivity gate from BI-DG-001).
+| Refactoring outcome | Capacity |
+|---|---:|
+| Split the governance spine into focused typed modules and remove duplicated classifications | 5% |
+| Consolidate PDP/PEP evaluation used by MCP, UI, MDM, AI context, projection, and lifecycle | 5% |
+| Adapt existing MDM domain/crosswalk/trust/receipt services instead of parallel models | 3% |
+| Generalize derived-copy cleanup, reconciliation, and staleness adapters | 3% |
+| Consolidate data UI under `/admin/data` and replace hand-built status widgets with report-kit | 4% |
+| **Total** | **20%** |
 
-**BI-DG-006 — Deletion propagation + orphan reconciliation + dark-projection alerts** (`feature`, large)
-EA-mirror tombstones drive Neo4j `deleteEaElement`/`deleteEaRelationship`; entity deletes enqueue projection-cleanup (Neo4j DETACH DELETE, Qdrant deleteVectors); weekly orphan-reconciliation job (extends `infra-prune`) diffing targets against sources; shared staleness monitor generalizing the code-graph escalation to every contract (SLA per contract, self-healing conformance issues).
+If schedule pressure appears, reduce feature breadth or move a whole BI; do not collapse these boundaries into a monolith.
 
-## Phase 4 — Protection plane
+---
 
-**BI-DG-007 — Field encryption service + key hierarchy + crypto-shredding** (`feature`, xlarge)
-Extend `credential-crypto` to master→purpose→per-subject wrapped keys; app-layer encryption of registry `sensitiveFields` at the model-access seam; fail-loud on missing key outside development; broadened prod guard. Migration encrypts existing plaintext PII (`StorefrontInquiry`, donors, orders contact fields, `UserFact.value` where sensitive, transcripts). Blocks: BI-DG-008.
+## Chunk 0 — Reconcile the live baseline and delivery backlog
 
-**BI-DG-008 — DSAR + erasure flows (subject access, anonymize-in-place, derived-copy cleanup)** (`feature`, xlarge)
-Subject-access export via registry `subjectKind` correlation; erasure = anonymize-in-place for FK-heavy regulated rows + crypto-shred subject key + derived-copy cleanup enumerated from projection contracts; legal-hold conflict surfacing (Art. 17(3)); operator-gated MCP/admin actions; disposition records. Blocked by: BI-DR-105, BI-DG-005, BI-DG-007.
+### Task 0: Rebase the facts before implementation
 
-**BI-DG-009 — Mask-before-context service for AI exposure** (`feature`, large)
-`maskForContext(payload, {purpose, principal, sensitivityCeiling})` applied at coworker context assembly, semantic-memory storage (supersedes the interim gate's masking), and tool-result shaping; driven by registry `sensitiveFields` × caller clearance × declared purpose. Outputs inherit source sensitivity via envelope/receipt records.
+**Files:**
 
-**BI-DG-010 — Tamper-evident audit chain** (`feature`, medium)
-`prevHash`/`rowHash` chaining on audit-class tables (`ComplianceAuditLog`, `SecurityEvent`, `AuthorizationDecisionLog`, `ToolExecutionReceipt`); periodic chain-verification job filing conformance issue on break; documented as the SEC 17a-4 audit-trail posture.
+- Read: `AGENTS.md`
+- Read: `packages/db/prisma/schema.prisma`
+- Read: `docs/superpowers/specs/2026-05-31-master-data-management-alignment-design.md`
+- Read: `docs/superpowers/specs/2026-07-04-mdm-write-time-dedup-and-lifecycle-design.md`
+- Read: `docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md`
+- Modify only if facts changed: this spec and plan
 
-## Phase 5 — Policy plane
+**Steps:**
 
-**BI-DG-011 — Archetype compliance packs** (`feature`, medium)
-Typed `compliancePack` on the archetype registry (regulation refs, default sensitivity tier, retention-floor key, PHI/CHD flags) authored for the existing archetype set (BIAN/healthcare from existing spec material); `compliance-library.ts` + `industry-floors.ts` consume it, retiring string-matching as the source (kept as fallback for unknown archetypes).
+- [ ] Confirm the worktree is on a non-main topic branch with `git status --short --branch` and `git branch --show-current`.
+- [ ] Fetch `origin` and start the implementation branch/worktree from current `origin/main` using the repository's worktree procedure and bootstrap script.
+- [ ] Query `EP-DATA-GOVERNANCE`, `EP-DATA-RETENTION`, and `EP-MDM` through DPF MCP; record current statuses, acceptance criteria, dependencies, and ownership.
+- [ ] Count and inventory current Prisma models from `packages/db/prisma/schema.prisma`; compare the result with the logical asset registry if it already exists.
+- [ ] Re-audit current routes, MDM files, retention registries, projection stores, compliance policy models, and receipt models. Treat unexpected new overlap as a design input, not something to work around.
+- [ ] Through MCP, update the affected existing BI acceptance criteria to reference the revised spec.
+- [ ] Through MCP, create or link non-overlapping items only where no live item already covers the scope:
+  - one legacy classification/lifecycle wave per bounded data domain;
+  - one durable data-control operation journal item under EP-DATA-GOVERNANCE;
+  - separate EP-MDM items for readiness/crosswalks, survivorship/provenance, and autonomy/publish/retraction;
+  - one protection rollout item per approved field family after the key-service core;
+  - one final `/admin/data` consolidation/redirect/usability item after capability-owning pages land.
+- [ ] Update this plan's work-package headings with the assigned real BI IDs before an agent executes them. A heading that still says “assigned in Task 0” is a planning template, not an executable work claim.
+- [ ] Replace every “discovered in Task 0,” `<family>`, `<model>`, and “exact ... recorded in the BI” placeholder with the rebased exact create/modify/test paths before claiming that BI. Do not execute a template with unresolved files.
+- [ ] Do not place supplier-pilot work into the new MDM governance item; the existing supplier pilot remains its own domain rollout.
+- [ ] Record a Work Capsule decision note with the new baseline SHA, model count, and chosen BI mapping.
 
-**BI-DG-012 — Data policy decision point (MCP tools) + steward skill extension** (`tool`, large)
-`get_data_policy` + `check_data_action` (grant-scoped, concise, provenance-free descriptions per context-economy standards; DSAR/hold ops behind operator-gated write grants); extend `dpf-data-architecture-steward` skill with classification stewardship (machine-suggest → human-confirm for new models) and PDP usage guidance; seed for in-portal coworkers.
+**Verification:**
 
-**BI-DG-013 — Operator + user documentation** (`doc`, small)
-User-guide page (plain language: what the platform keeps/protects/purges, holds, DSAR); ops runbook (hold management, erasure, archival restore, partition maintenance); AGENTS.md pointer already landed in BI-DG-003.
-
-## Dependency graph
-
+```powershell
+git status --short --branch
+git rev-parse origin/main
+(git show origin/main:packages/db/prisma/schema.prisma | Select-String '^model ').Count
 ```
-Phase 0: DG-001 (independent, ship first)
-Phase 1: DG-002 ──► DG-003, DG-004, DR-101
-Phase 2: DR-102..104 (after DG-002 lifecycle classes); DR-105 ──► DG-008; DR-106; DR-107 (after DR-101 data)
-Phase 3: DG-005 (after DG-002) ──► DG-006, DG-008
-Phase 4: DG-007 ──► DG-008; DG-009 (after DG-002, DG-005); DG-010 independent
-Phase 5: DG-011 (after DG-002); DG-012 (after DG-005/DG-009); DG-013 last
+
+Expected: topic branch, current fetched SHA, and a fresh model count recorded in the capsule. No source edits occur until backlog ownership and overlap are resolved.
+
+---
+
+## Chunk 1 — Stop the exposure and establish the control spine
+
+### Task 1: BI-DG-001 — Gate and clean up semantic memory
+
+**Files:**
+
+- Modify: `apps/web/lib/inference/semantic-memory.ts`
+- Modify: `apps/web/lib/inference/semantic-memory.test.ts`
+- Create: `apps/web/lib/inference/semantic-memory-cleanup.ts`
+- Create: `apps/web/lib/inference/semantic-memory-cleanup.test.ts`
+- Modify: `apps/web/lib/actions/agent-coworker.ts`
+- Modify: `apps/web/lib/operate/retention/policies.ts`
+- Modify: `apps/web/lib/queue/functions/index.ts`
+
+**Steps:**
+
+- [ ] Write a failing test proving a `restricted` turn cannot write raw content or a raw preview to Qdrant.
+- [ ] Write a failing test proving a `confidential` turn passes through a deterministic masking seam before vector storage.
+- [ ] Write a failing test proving message/thread purge requests vector deletion by stable source identifiers and is idempotent.
+- [ ] Write a failing reconciliation test that reports and removes a vector whose source message no longer exists.
+- [ ] Run the targeted tests and confirm the failures are for missing policy/cleanup behavior.
+- [ ] Pass route sensitivity and declared purpose into the semantic-memory write input; do not recompute a competing sensitivity.
+- [ ] Implement fail-closed storage behavior: restricted skips content storage; confidential uses the interim deterministic mask; public/internal preserve current behavior until field policy lands.
+- [ ] Store source identifiers required for deletion without adding sensitive values to Qdrant payload metadata.
+- [ ] Implement idempotent batch cleanup and connect message/thread retention deletion to it.
+- [ ] Emit bounded cleanup evidence: collection, source kind, candidate/removed/failed counts, and error codes — never raw content.
+- [ ] Run targeted tests, web typecheck, and secret scan.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/inference/semantic-memory.test.ts lib/inference/semantic-memory-cleanup.test.ts
+pnpm --filter web typecheck
+pnpm security:secrets
 ```
 
-## Verification per phase
+Expected: restricted raw-write test, masked confidential-write test, idempotent deletion test, and orphan-reconciliation test all pass.
 
-Every BI carries unit tests in-package; runtime-bound gates (production build, migration apply, live UX/sweep evidence) run on the canonical install or the shared local-CI convergence lease per AGENTS.md §5, with `record_execution_evidence`. Red-team gate fixtures land with BI-DG-003 and stay in CI permanently.
+### Task 2: BI-DG-002 — Create the composed logical data-control spine
+
+**Files:**
+
+- Create: `apps/web/lib/govern/data/taxonomy.ts`
+- Create: `apps/web/lib/govern/data/assets.ts`
+- Create: `apps/web/lib/govern/data/legacy-coverage-baseline.ts`
+- Create: `apps/web/lib/govern/data/processing-activities.ts`
+- Create: `apps/web/lib/govern/data/lifecycle-classes.ts`
+- Create: `apps/web/lib/govern/data/derived-data-contracts.ts`
+- Create: `apps/web/lib/govern/data/executable-policies.ts`
+- Create: `apps/web/lib/govern/data/policy-decision.ts`
+- Create: `apps/web/lib/govern/data/policy-enforcement.ts`
+- Create: `apps/web/lib/govern/data/coverage.ts`
+- Create: matching `*.test.ts` files for each module
+- Modify: `apps/web/lib/ea/data-model-mirror-apply.ts`
+
+**Steps:**
+
+- [ ] Write the closed unions and normative types from spec §§6.1, 6.5, and 6.7. Keep sensitivity, category, criticality, quality, residency, MDM domain, lifecycle, and purpose independent.
+- [ ] Write failing tests for stable `DataAssetId`/`DataFieldId`, plural executable subject locators, field resolution/provenance, label state/source, and field-level protection metadata.
+- [ ] Reuse `parsePrismaSchema` from `apps/web/lib/integrate/code-graph/extractors/prisma-schema-adapter.ts` to write a failing total-coverage test against the current schema.
+- [ ] Generate denominators independently from Prisma, projection producers, PEP entry points, destructive handlers, and MDM domains.
+- [ ] Seed stable model-level asset identities and valid inherited defaults where a reviewed domain rule exists. Put every pre-existing unresolved model/field/contract into the immutable legacy baseline with owner, risk, remediation BI, and deadline; never invent a blanket “internal/standard” classification to make coverage green.
+- [ ] Make new/changed models and fields fail immediately when unresolved; prove legacy entries cannot grow, transfer to a new object, or hide a changed object.
+- [ ] Write failing cross-registry tests: every asset has a lifecycle; every MDM domain maps to an asset; every content projection maps to field policy; prohibited fields cannot be persisted/projected; stable IDs are unique.
+- [ ] Implement pure lookup and composition functions. No database calls are allowed in these modules.
+- [ ] Add logical asset/classification properties to the existing EA mirror output; do not create another ERD or lineage graph.
+- [ ] Add a generated inventory summary used by UI and gates without exposing live values.
+- [ ] Confirm no focused module exceeds 500 lines without an explicit decomposition note.
+- [ ] Run registry tests and typecheck.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/govern/data
+pnpm --filter web exec vitest run lib/ea/data-model-mirror-apply.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: current Prisma facts are fully accounted for as governed/inherited/not-applicable or as named immutable legacy gaps; new/changed coverage is 100%, the baseline cannot grow, and every invariant violation names the exact asset/field.
+
+### Task 3: BI-DG-003 — Add the content-based Data-Impact Gate
+
+**Files:**
+
+- Create: `scripts/check-data-impact.mjs`
+- Create: `scripts/check-data-impact.test.mjs`
+- Create: `docs/testing/fixtures/data-impact/`
+- Modify: `package.json`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `apps/web/lib/integrate/build-agent-prompts.ts`
+- Modify: `AGENTS.md`
+
+**Steps:**
+
+- [ ] Create red fixtures for an unregistered model, sensitive field without field policy, uncontracted projection, MDM domain without publish/lifecycle contract, and destructive executor without a hold check.
+- [ ] Create green fixtures for a complete `DataImpactManifest` and a structured, unexpired exception.
+- [ ] Write a failing gate test that inspects changed schema/migration/projection/context/MDM/lifecycle surfaces, not merely whether one registry file changed.
+- [ ] Define the manifest schema with asset IDs, change kinds, policy decisions, accountable owner, affected copies, migration/backfill, and tests.
+- [ ] Define exception fields: scope, approver, rationale, compensating control, expiry, and remediation BI. Reject exceptions for asset/lifecycle coverage and prohibited storage.
+- [ ] Implement deterministic errors suitable for CI and Build Studio. Do not print data values or provenance noise in tool descriptions.
+- [ ] Add the gate to local/CI scripts and the Build Studio prompt contract.
+- [ ] Add a concise `AGENTS.md` pointer to the design; keep detailed doctrine here.
+- [ ] Run gate tests against every red/green fixture.
+
+**Verification:**
+
+```powershell
+node --test scripts/check-data-impact.test.mjs
+node scripts/check-data-impact.mjs
+pnpm --filter web typecheck
+```
+
+Expected: every red fixture fails for its intended reason; complete current source passes.
+
+### Task 4: BI-DG-004 — Detect governance drift at runtime
+
+**Files:**
+
+- Modify: `apps/web/lib/ea/data-architecture-steward.ts`
+- Modify: `apps/web/lib/ea/data-architecture-steward-apply.ts`
+- Modify: `apps/web/lib/ea/data-architecture-steward.test.ts`
+- Modify: `apps/web/lib/ea/data-architecture-steward-apply.test.ts`
+
+**Steps:**
+
+- [ ] Write failing tests for `unclassified-asset`, `unowned-domain`, `unenrolled-growth`, `mdm-contract-gap`, `projection-policy-conflict`, and `expired-data-exception` findings.
+- [ ] Implement pure detectors using the control-spine inventory and measured runtime metadata.
+- [ ] Use stable conformance-issue keys so repeat runs refresh rather than duplicate findings.
+- [ ] Auto-resolve findings only after the underlying conformance check passes.
+- [ ] Make missing runtime measurement an “unknown” finding rather than a false green.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/ea/data-architecture-steward.test.ts lib/ea/data-architecture-steward-apply.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: each drift class opens one stable finding, repeated runs refresh it, unknown evidence is not green, and remediation auto-resolves it.
+
+### Task 4A: BI-DG-015 — Data-domain coverage wave 1
+
+Repeat this task on one bounded data domain per BI/branch until the immutable baseline reaches zero. `BI-DG-015` is wave 1; file each subsequent wave as its predecessor closes.
+
+**Files:**
+
+- Modify: `apps/web/lib/govern/data/assets.ts`
+- Modify: `apps/web/lib/govern/data/lifecycle-classes.ts`
+- Modify: `apps/web/lib/govern/data/legacy-coverage-baseline.ts`
+- Modify: matching focused tests under `apps/web/lib/govern/data/`
+
+**Steps:**
+
+- [ ] Select only the baseline entries owned by the BI's domain; confirm owner/steward and source fields against the rebased schema.
+- [ ] Write failing cases for the domain's sensitive/subject/prohibited/projected fields and lifecycle rules, then run them and observe the intended coverage failures.
+- [ ] Classify each field as governed, inherited, or not-applicable with reason/provenance; add executable subject locators and protection/purpose metadata where required.
+- [ ] Remove only resolved baseline entries and prove the denominator is unchanged.
+- [ ] Run control-spine tests, Data-Impact Gate fixtures, and the per-BI completion gate.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/govern/data
+pnpm --filter web typecheck
+node scripts/check-data-impact.mjs
+```
+
+Expected: the selected domain has no unresolved entries, the baseline decreases by the exact resolved set, and no other domain changes.
+
+### Task 4B: BI-DG-014 — Durable data-control operation journal
+
+**Files:**
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/<timestamp>_add_data_control_operation/migration.sql`
+- Create: `packages/db/src/data-control-operation-schema.test.ts`
+- Create: `apps/web/lib/govern/data/control-operation.ts`
+- Create: `apps/web/lib/govern/data/control-operation.test.ts`
+- Create: `apps/web/lib/queue/functions/data-control-operation.ts`
+- Modify: `apps/web/lib/queue/functions/index.ts`
+
+**Steps:**
+
+- [ ] Write failing schema and service tests for durable intent before mutation, exact input/policy/hold/authority snapshot, unique idempotency key, operation states, per-target checkpoints, and retry time.
+- [ ] Write crash-point tests before/after intent, source mutation, outbox enqueue, external effect, verification, compensation, and terminal evidence; assert no false `reconciled` state or double effect.
+- [ ] Run the tests and confirm they fail because the journal/outbox contract does not exist.
+- [ ] Add `DataControlOperation` and `DataControlOperationStep` models plus indexes for status/retry, organization/action, and operation/target. No data backfill is required because no legacy operation can be reconstructed truthfully.
+- [ ] Run `pnpm --filter @dpf/db exec prisma migrate dev --name add_data_control_operation`; inspect the generated immutable SQL and retain its explicit no-backfill comment.
+- [ ] Implement transactional intent/outbox creation, single-use authorization binding, idempotent step claims, verification, retry, compensation, and terminal state rules from spec §6.3.
+- [ ] Prove a non-compensable target remains `partially-complete`, files a governed case, and cannot emit terminal-success evidence.
+- [ ] Register the queue function and run the per-BI migration/completion gates.
+
+**Verification:**
+
+```powershell
+pnpm --filter @dpf/db exec vitest run src/data-control-operation-schema.test.ts
+pnpm --filter web exec vitest run lib/govern/data/control-operation.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: every injected crash resumes idempotently or reaches a visible failed/partial/compensated state; only fully verified targets reach `reconciled`.
+
+---
+
+## Chunk 2 — Govern MDM and establish the product shell
+
+### Task 5A: BI-MDM-201 — MDM readiness and crosswalk hardening
+
+**Files:**
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/<timestamp>_add_mdm_identity_observation/migration.sql`
+- Create: `apps/web/lib/mdm/governance-contract.ts`
+- Create: `apps/web/lib/mdm/governance-contract.test.ts`
+- Modify: `apps/web/lib/mdm/domain-registry.ts`
+- Modify: `apps/web/lib/mdm/domain-registry.test.ts`
+- Modify: `apps/web/lib/mdm/crosswalk.ts`
+- Modify: `apps/web/lib/mdm/match-candidate.ts`
+- Modify: `apps/web/lib/mdm/match-candidate.test.ts`
+
+**Steps:**
+
+- [ ] Write failing tests for the per-domain `absent | pilot | supported | enforced` capability matrix and `none | source-only | full` reversibility class.
+- [ ] Write failing identity tests proving `PrincipalAlias` resolves identity while a protected source-observation record separately carries issuer, observed/last-seen time, evidence/trust, status, and lifecycle.
+- [ ] Run the tests and observe missing readiness/observation behavior.
+- [ ] Add `MasterIdentitySourceObservation`; run `pnpm --filter @dpf/db exec prisma migrate dev --name add_mdm_identity_observation`. No legacy observation backfill is allowed because missing provenance cannot be reconstructed.
+- [ ] Require every domain to link logical asset, owner/steward, dedup gate, quality SLO, lifecycle, and declared capability status.
+- [ ] Invalidate/rescore candidate sets when source, canonical version, normalization, or match configuration changes; bind previews to exact versions.
+- [ ] Keep `MasterDataSourceRef` for non-identity sources and enroll both source-reference types in lifecycle/protection policy.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/mdm/governance-contract.test.ts lib/mdm/domain-registry.test.ts lib/mdm/match-candidate.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: readiness is evidence-derived, stale candidates fail, and identity continuity no longer conflates alias resolution with source observation.
+
+### Task 5B: BI-MDM-202 — Survivorship and protected provenance
+
+**Files:**
+
+- Modify: `apps/web/lib/mdm/match-config.ts`
+- Modify: `apps/web/lib/mdm/match-config.test.ts`
+- Modify: `apps/web/lib/mdm/history.ts`
+- Modify: `apps/web/lib/mdm/merge.ts`
+- Modify: `apps/web/lib/mdm/merge.test.ts`
+- Modify: `apps/web/lib/mdm/unmerge.test.ts`
+- Modify: `apps/web/lib/mdm/governance-contract.ts`
+
+**Steps:**
+
+- [ ] Write failing tests that separate candidate, match, merge, survivorship, and publish decisions and reject a stale/concurrently changed preview.
+- [ ] Add versioned strategies `pinned-human`, `source-priority`, `verified-value`, `most-recent`, `most-complete`, and `keep-survivor`, with explicit missing/null/cleared/invalid semantics.
+- [ ] Write failing provenance tests for minimized candidates, source refs, winning rule/version, actor, confidence, and time; prove a lower-authority run cannot replace a pinned value.
+- [ ] Route merge/unmerge/survivorship through the durable operation journal and typed `AuthorizationDecisionLog` rationale.
+- [ ] Apply field policy to new history/snapshot writes so sensitive values are omitted, redacted, tokenized, or separately encrypted; assign legacy plaintext history to a protected-field rollout BI rather than silently copying it.
+- [ ] Prove limited reversibility remains visible and prevents autonomous merge.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/mdm/match-config.test.ts lib/mdm/merge.test.ts lib/mdm/unmerge.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: survivorship is independent, versioned, concurrency-safe, pinned-value safe, and its evidence cannot leak governed plaintext.
+
+### Task 5C: BI-MDM-203 — Graduated autonomy and publish/retraction
+
+**Files:**
+
+- Modify: `apps/web/lib/mdm/autonomous-steward.ts`
+- Modify: `apps/web/lib/mdm/autonomous-steward.test.ts`
+- Modify: `apps/web/lib/mdm/publish.ts`
+- Modify: `apps/web/lib/mdm/merge.ts`
+- Modify: `apps/web/app/(shell)/admin/data/stewardship/page.tsx`
+
+**Steps:**
+
+- [ ] Write failing risk-tier tests covering match kind, reversibility, identity/regulation, value/impact, conflict, cross-domain, stale preview, and per-run cap.
+- [ ] Write failing publish tests for contract compatibility, consumer acknowledgment, stale critical data, correction/retraction, and partial downstream reconciliation.
+- [ ] Permit autonomous exact low-risk actions only for domains whose capability/reversibility matrix and operation evidence are enforced; route all other cases to steward review.
+- [ ] Extend published data with contract/domain version, canonical ID, `asOf`, protected provenance summary, TrustAssessment, asset/classification, permitted purposes, and obligations.
+- [ ] Keep publish/retract operations partial until consumers acknowledge or a governed failure remains visible.
+- [ ] Expose readiness, risk, preview, publish status, and undo/retraction in the Stewardship route.
+- [ ] Run the supplier pilot against the contracts in its existing BI; customer-domain success cannot close supplier readiness.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/mdm/autonomous-steward.test.ts lib/mdm/merge.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: risky autonomy is denied/reviewed, publish rollout/retraction is reconcilable, and pilot capabilities are never shown as enforced.
+
+### Task 6: BI-DR-101 — Add growth observability and the `/admin/data` shell
+
+**Files:**
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/<timestamp>_add_data_growth_sample/migration.sql`
+- Create: `apps/web/lib/operate/retention/growth.ts`
+- Create: `apps/web/lib/operate/retention/growth.test.ts`
+- Create: `apps/web/lib/queue/functions/data-growth-snapshot.ts`
+- Modify: `apps/web/lib/queue/functions/index.ts`
+- Create: `apps/web/app/(shell)/admin/data/layout.tsx`
+- Create: `apps/web/app/(shell)/admin/data/page.tsx`
+- Create: `apps/web/app/(shell)/admin/data/catalog/page.tsx`
+- Create: `apps/web/app/(shell)/admin/data/stewardship/page.tsx`
+- Create: `apps/web/app/(shell)/admin/data/lifecycle/page.tsx`
+- Create: `apps/web/app/(shell)/admin/data/policy-privacy/page.tsx`
+- Modify: `apps/web/components/admin/admin-nav.ts`
+
+**Steps:**
+
+- [ ] Write tests for bounded `pg_total_relation_size`/row-estimate sampling, interval rollups, pruning, growth-rate calculation, unknown measurement, and threshold state.
+- [ ] Add a purge-enrolled `DataGrowthSample` model with indexes for asset/time and a migration containing its retention setup.
+- [ ] Run `pnpm --filter @dpf/db exec prisma migrate dev --name add_data_growth_sample`; the generated migration states “no backfill” because rates begin only after two observed samples.
+- [ ] Implement a read-only collector with an explicit model allowlist derived from the logical asset registry; never interpolate an unvalidated identifier.
+- [ ] Export aggregate control metrics without table contents or sensitive values.
+- [ ] File/refresh/resolve `PlatformIssueReport` entries for critical growth, unknown measurement, and accepted-unbounded assets above threshold.
+- [ ] Add the stable top-level Admin → Data Management destination and five peer routes: Overview, Catalog, Stewardship, Lifecycle, Policy & Privacy. Every tab resolves locally in this BI; Stewardship and Policy & Privacy may render honest transitional content/deep links until their owning capabilities land, but cannot navigate to a nonexistent peer.
+- [ ] Build the first viewport with no more than five report-kit `StatCard`s plus an attention table, filters, status badges, and export.
+- [ ] Populate Catalog from the source-controlled inventory and link each asset to `/ea/data-model` rather than embedding another ERD.
+- [ ] Populate Lifecycle with disposition, measured size/growth, last sweep, next action, and dry-run entry point.
+- [ ] Test loading, empty, error, permission, long-label, dark/light theme, keyboard, and mobile-width states.
+
+**Verification:**
+
+```powershell
+pnpm --filter @dpf/db exec prisma validate
+pnpm --filter web exec vitest run lib/operate/retention/growth.test.ts
+pnpm --filter web typecheck
+```
+
+Runtime evidence: migration applies; two snapshots produce a rate; retention prunes samples; `/admin/data`, `/catalog`, and `/lifecycle` pass UX verification.
+
+Expected: growth is measured without data values, all five peer routes resolve with honest states, and alerts/rollups/pruning behave deterministically.
+
+---
+
+## Chunk 3 — Complete lifecycle governance
+
+### Task 7: BI-DR-102 — Enroll ranked unbounded datasets
+
+**Files:**
+
+- Modify: `apps/web/lib/operate/retention/policies.ts`
+- Modify: `apps/web/lib/operate/retention/retention.test.ts`
+- Modify: `packages/db/prisma/schema.prisma` only for required purge indexes
+- Add: `packages/db/prisma/migrations/<timestamp>_add_retention_purge_indexes/migration.sql`
+
+**Steps:**
+
+- [ ] Use `DataGrowthSample` evidence to rank unenrolled assets; do not copy the research-baseline ranking blindly.
+- [ ] Write a failing policy test for every family, including active/current/regulated exclusions.
+- [ ] Run the tests and observe the intended unenrolled/missing-strategy failures.
+- [ ] For each ranked asset, document owner, trigger, minimum, maximum, terminal-state rule, hold scope, action, batch cap, and evidence class in `lifecycle-classes.ts` before adding an executor policy.
+- [ ] Cover at minimum the currently verified families: memory facts, quality findings, backlog/admin activities, tool/integration receipts, route outcomes, coworker envelopes, edge/federation events, discovery observations, MDM evidence/tasks/history, staged imports, and message streams.
+- [ ] Add only query-supported indexes shown necessary by `EXPLAIN` on representative volume.
+- [ ] Run `pnpm --filter @dpf/db exec prisma migrate dev --name add_retention_purge_indexes`; the generated migration contains only reviewed indexes and an explicit no-backfill comment.
+- [ ] Run dry-run and bounded delete/anonymize tests; prove the candidate set equals the executed set absent concurrent writes.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/operate/retention/retention.test.ts
+pnpm --filter @dpf/db exec prisma validate
+pnpm --filter web typecheck
+```
+
+Expected: every selected family has a tested lifecycle decision, active/current/regulated rows remain excluded, and any index migration is evidence-backed.
+
+### Task 8: BI-DR-103 — Add the revision-cap strategy
+
+**Files:**
+
+- Modify: `apps/web/lib/operate/retention/execute.ts`
+- Modify: `apps/web/lib/operate/retention/policies.ts`
+- Modify: `apps/web/lib/operate/retention/retention.test.ts`
+
+**Steps:**
+
+- [ ] Write failing tests for `keepLast`, `maxAgeDays`, ties, current/published protection, active parent protection, empty history, and idempotent rerun.
+- [ ] Implement one `revision-cap` strategy used by all revision/snapshot families; do not add per-model loops.
+- [ ] Enumerate current revision/snapshot models from the rebased schema and enroll each explicitly.
+- [ ] Prove regulated and active objects remain excluded.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/operate/retention/retention.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: the shared executor keeps the configured current/published/recent revisions and removes only the deterministic excess set.
+
+### Task 9: BI-DR-104 — Add status-aware lifecycle strategies
+
+**Files:**
+
+- Modify: `apps/web/lib/operate/retention/execute.ts`
+- Modify: `apps/web/lib/operate/retention/policies.ts`
+- Modify: `apps/web/lib/operate/retention/retention.test.ts`
+- Modify: `apps/web/lib/govern/data/lifecycle-classes.ts`
+
+**Steps:**
+
+- [ ] Write failing status-aware tests for task runs/messages/artifacts/nodes, decision interactions, escalation/deferral captures, and any new terminal-state families found in Task 0.
+- [ ] Add terminal-state predicates as data in lifecycle classes, with common executor logic.
+- [ ] Prove parent/child eligibility is deterministic when terminal timestamps differ.
+- [ ] Prove active, retryable, held, and regulated objects remain excluded.
+- [ ] Run dry-run and execution against the same fixture and assert identical eligible IDs absent concurrent writes.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/operate/retention/retention.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: terminal-state eligibility is deterministic and dry-run/execution agree while active, retryable, held, and regulated records remain untouched.
+
+### Task 10: BI-DR-105 — Add holds, policy conflicts, and disposition evidence
+
+**Files:**
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/<timestamp>_add_data_lifecycle_evidence/migration.sql`
+- Create: `apps/web/lib/operate/retention/holds.ts`
+- Create: `apps/web/lib/operate/retention/lifecycle-decision.ts`
+- Create: `apps/web/lib/operate/retention/disposition-evidence.ts`
+- Create: `apps/web/lib/operate/retention/holds.test.ts`
+- Create: `apps/web/lib/operate/retention/lifecycle-decision.test.ts`
+- Create: `apps/web/lib/operate/retention/disposition-evidence.test.ts`
+- Modify: `apps/web/lib/operate/retention/execute.ts`
+- Create: `apps/web/lib/actions/data-lifecycle.ts`
+
+**Steps:**
+
+- [ ] Write failing pure-decision tests for multiple minima, multiple maxima, no minimum, no maximum, urgent issued hold, scope revision, late-arriving match, overlapping release, failed destination acknowledgment, restore reapplication, erasure exception, and `retainUntil > deleteNoLaterThan` conflict.
+- [ ] Run the tests and confirm they fail because append-only hold scope/delivery state and lifecycle conflict records do not exist.
+- [ ] Add dedicated `LegalHold`, `LegalHoldRevision`, `LegalHoldDelivery`, `DataPolicyConflict`, and `DispositionRecord` models. Store stable asset/subject/domain scope and policy versions; do not store mutable SQL as authority.
+- [ ] Run `pnpm --filter @dpf/db exec prisma migrate dev --name add_data_lifecycle_evidence`; no legacy hold backfill is possible, while any disposition backfill must remain empty rather than invent evidence.
+- [ ] Implement the lifecycle decision algebra from spec §6.6. A conflict returns no destructive action.
+- [ ] Make authorized urgent issuance effective atomically before asynchronous propagation; continuously resolve new aliases/data/contracts, record per-store acknowledgments, and prove a missing/failed check fails closed.
+- [ ] Re-evaluate every overlapping hold before release and replay active holds/disposition tombstones before restored data becomes available.
+- [ ] Write disposition receipts with identifier digests and counts, not copied row values.
+- [ ] Add operator-gated create/review/release actions with preview and separate release authority where configured.
+- [ ] Add property-based or table-driven tests showing policy input order cannot change the outcome.
+
+**Verification:**
+
+```powershell
+pnpm --filter @dpf/db exec prisma validate
+pnpm --filter web exec vitest run lib/operate/retention/holds.test.ts lib/operate/retention/lifecycle-decision.test.ts lib/operate/retention/disposition-evidence.test.ts
+pnpm --filter web typecheck
+```
+
+Runtime evidence: migration applies, held rows remain untouched, conflicts create cases, and an eligible capped batch writes a reconciled disposition receipt.
+
+Expected: urgent/revised/overlapping holds propagate and survive restore, conflicts never mutate, and disposition is complete only after target reconciliation.
+
+### Task 11: BI-DR-106 — Archive before destructive disposition
+
+**Files:**
+
+- Create: `apps/web/lib/operate/retention/archive.ts`
+- Create: `apps/web/lib/operate/retention/archive.test.ts`
+- Modify: `apps/web/lib/operate/retention/execute.ts`
+- Create: `docs/operations/data-archive-restore.md`
+
+**Steps:**
+
+- [ ] Write failing tests for export failure, checksum failure, evidence-write failure, repeated request, partial batch, and restore validation.
+- [ ] Implement stream-to-compressed-artifact with manifest, schema/asset/policy version, count, checksum, destination, and encryption metadata.
+- [ ] Require verified archive and receipt before source deletion.
+- [ ] Make reruns idempotent by disposition operation ID.
+- [ ] Add a restore rehearsal that writes to an isolated verification target and compares count/digest before promotion.
+- [ ] Document recovery, key requirements, scope, and evidence lookup.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/operate/retention/archive.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: deletion cannot start before a verified archive/receipt, retries are idempotent, and isolated restore reproduces the recorded count/digest.
+
+### Task 12: BI-DR-107 — Decide and decompose measured partition candidates
+
+**Files:**
+
+- Modify: `apps/web/lib/govern/data/lifecycle-classes.ts`
+- Add per approved stream BI: `packages/db/prisma/migrations/<timestamp>_partition_<model>_by_<key>/migration.sql`
+- Create: `apps/web/lib/operate/retention/partition-maintenance.ts`
+- Create: `apps/web/lib/operate/retention/partition-maintenance.test.ts`
+- Modify if needed: `docs/install/platform-support-watchlist.md`
+
+**Steps:**
+
+- [ ] Use growth evidence to produce a decision record for each candidate: size/rate, retention-aligned key, FK constraints, downtime/rewrite, restore, and expected benefit.
+- [ ] Defer any candidate that lacks sufficient evidence. Deferral is a successful outcome, not pressure to partition.
+- [ ] For each approved candidate, create a separate live BI and branch before implementation; one physical table/partition key per PR. DR-107 owns the measured decision/decomposition, not a multi-table migration sweep.
+- [ ] Require DR-105 hold delivery and DR-106 archive/restore evidence before any partition implementation BI starts.
+- [ ] Rehearse the migration against production-like volume in the leased sandbox, including rollback/restore.
+- [ ] In each implementation BI, run `pnpm --filter @dpf/db exec prisma migrate dev --name partition_<model>_by_<key>` and keep any row movement/backfill in that generated migration.
+- [ ] Add future-partition creation, missing-partition alert, retention-boundary drop, hold exclusion, archive-before-drop, and disposition evidence.
+- [ ] Prove a held partition cannot be dropped and a failed archive cannot advance.
+
+**Verification:** migration apply and rehearsal evidence from the shared local-integration CI environment; no direct rebuild of the main portal.
+
+Expected: unsupported candidates are explicitly deferred; each approved stream has its own BI and only rehearsed hold/archive-safe migrations proceed.
+
+---
+
+## Chunk 4 — Govern lineage and every derived copy
+
+### Task 13: BI-DG-005 — Complete derived-data contracts and scope enforcement
+
+**Files:**
+
+- Modify: `apps/web/lib/govern/data/derived-data-contracts.ts`
+- Modify: `apps/web/lib/govern/data/derived-data-contracts.test.ts`
+- Modify: `packages/db/src/projection-egress.ts`
+- Modify: `packages/db/src/projection-egress.test.ts`
+- Modify: each projection registration adapter discovered in Task 0
+
+**Steps:**
+
+- [ ] Inventory Neo4j, Qdrant, EA, discovery, SysML, code-graph, cache, export, backup, and federation copy families on rebased source.
+- [ ] Write a failing total-coverage test requiring every copy producer to reference one stable `DerivedDataContractId`.
+- [ ] Write failing tests that content payloads cannot exceed field policy, projections cannot self-declassify, and unsupported purpose/destination fails closed.
+- [ ] Run both suites and observe missing-contract/policy failures.
+- [ ] Add purpose, owner, sources/fields, destination, payload class, transform, classification propagation, residency, SLO, lifecycle, delete locator, reconciliation, and evidence to every contract.
+- [ ] Adapt the existing federation `ProjectionContract` to the shared contract; do not rename or repurpose its persisted boundary.
+- [ ] Declare the required `DataPepKind` and parameterized obligations for every contract, and make conformance fail when no registered PEP capability can satisfy them. Runtime activation waits for BI-DG-012.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/govern/data/derived-data-contracts.test.ts
+pnpm --filter @dpf/db exec vitest run src/projection-egress.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: every discovered producer has one contract, invalid payload/purpose/destination combinations fail, and required obligations map to a declared PEP capability.
+
+### Task 14: BI-DG-006 — Generalize cleanup, reconciliation, and staleness
+
+**Files:**
+
+- Create: `apps/web/lib/govern/data/derived-copy-health.ts`
+- Create: `apps/web/lib/govern/data/derived-copy-health.test.ts`
+- Create: `apps/web/lib/queue/functions/derived-copy-reconcile.ts`
+- Modify: `apps/web/lib/queue/functions/index.ts`
+- Modify: `apps/web/lib/ea/data-model-mirror-apply.ts`
+- Modify: `apps/web/lib/ea/data-model-mirror-apply.test.ts`
+- Modify: `apps/web/lib/actions/ea.ts`
+- Modify: `apps/web/lib/actions/ea.test.ts`
+- Modify: `apps/web/lib/inference/semantic-memory-cleanup.ts`
+- Modify: `apps/web/lib/operate/scheduled-jobs/staleness-escalation.ts`
+- Modify: `apps/web/lib/operate/scheduled-jobs/staleness-escalation.test.ts`
+- Modify: `apps/web/lib/queue/functions/code-graph-reconcile.ts`
+
+**Steps:**
+
+- [ ] Write failing contract tests for `deleteBySource`, `findOrphans`, `lastSuccessfulProjection`, `healthEvidence`, idempotent replay, bounded cursor, and partial operation state.
+- [ ] Run the tests and observe the missing shared adapter behavior.
+- [ ] Implement the small adapter contract for Neo4j and Qdrant first; add other stores only when an actual contract needs them.
+- [ ] Make EA tombstones drive Neo4j deletion and prove repeat delivery is safe.
+- [ ] Generalize the code-graph dark-projection escalation without regressing its current behavior.
+- [ ] Reconcile in bounded pages with a dry-run and per-contract cap.
+- [ ] File/refresh/resolve one stable issue per contract and error class.
+- [ ] Feed stale/orphan/cleanup metrics to `/admin/data` Overview and asset detail.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/govern/data/derived-copy-health.test.ts lib/inference/semantic-memory-cleanup.test.ts lib/integrate/code-graph
+pnpm --filter web typecheck
+```
+
+Runtime evidence: delete a sandbox source fixture, observe contracted cleanup in Neo4j/Qdrant, simulate a missed event, reconcile the orphan, and verify issue open/recovery.
+
+Expected: cleanup is idempotent and checkpointed, missed events reconcile, and stale/partial contracts remain visible until verified recovery.
+
+---
+
+## Chunk 5 — Purpose, policy, protection, and subject rights
+
+### Task 15: BI-DG-011 — Replace compliance string matching with governed processing activities
+
+**Files:**
+
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/<timestamp>_add_data_processing_governance/migration.sql`
+- Create: `packages/db/src/data-processing-governance-schema.test.ts`
+- Create: `apps/web/lib/govern/data/processing-activity-service.ts`
+- Create: `apps/web/lib/govern/data/processing-activity-service.test.ts`
+- Modify: `apps/web/lib/compliance-library.ts`
+- Modify: `packages/db/src/regulation-applicability.ts`
+- Modify: `apps/web/lib/operate/retention/industry-floors.ts`
+- Modify: `packages/storefront-templates/src/archetypes/index.ts`
+- Modify: `packages/storefront-templates/src/archetypes/archetypes.test.ts`
+
+**Steps:**
+
+- [ ] Write failing schema/service/applicability tests for required fields, policy links, exception expiry, unknown applicability, and string matching no longer being authoritative.
+- [ ] Run the targeted tests and observe failures for the missing persisted governance model/service.
+- [ ] Add `DataProcessingActivity` and `DataPolicyException` models with stable IDs, owner, purpose, asset/subject scope, authority links, recipients/destinations, transfer/residency, lifecycle, risk/review, status/effective dates, and approval/expiry controls.
+- [ ] Run `pnpm --filter @dpf/db exec prisma migrate dev --name add_data_processing_governance`. Its inline SQL backfill creates provenance-linked inactive/review records for known existing settings; it never infers and activates a legal basis.
+- [ ] Seed archetype templates in `packages/storefront-templates/src/archetypes/index.ts`; do not create organization-specific active records silently.
+- [ ] Connect human `Policy`/`PolicyRequirement` records to executable policy IDs instead of merging their schemas.
+- [ ] Implement exception validation: scope, approver, rationale, compensating control, expiry, and remediation item are mandatory.
+- [ ] Migrate existing applicable settings with provenance and require confirmation where legal basis cannot be safely inferred.
+
+**Verification:**
+
+```powershell
+pnpm --filter @dpf/db exec prisma validate
+pnpm --filter @dpf/db exec vitest run src/data-processing-governance-schema.test.ts src/regulation-applicability.test.ts
+pnpm --filter web exec vitest run lib/govern/data/processing-activity-service.test.ts lib/compliance-library.test.ts lib/operate/retention/retention.test.ts
+pnpm --filter @dpf/storefront-templates exec vitest run src/archetypes/archetypes.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: applicability comes from confirmed processing activities/executable policy, unknown stays review, and exceptions cannot activate without complete approval/expiry data.
+
+### Task 16: BI-DG-012 — Implement one PDP, PEP adapters, and explanation tools
+
+**Files:**
+
+- Modify: `apps/web/lib/govern/data/executable-policies.ts`
+- Modify: `apps/web/lib/govern/data/policy-decision.ts`
+- Modify: `apps/web/lib/govern/data/policy-enforcement.ts`
+- Modify: `apps/web/lib/govern/data/executable-policies.test.ts`
+- Modify: `apps/web/lib/govern/data/policy-decision.test.ts`
+- Modify: `apps/web/lib/govern/data/policy-enforcement.test.ts`
+- Create: `apps/web/lib/mcp/packs/data-governance-pack.ts`
+- Create: `apps/web/lib/mcp/packs/data-governance-pack.test.ts`
+- Modify: `apps/web/lib/mcp/pack-registry.ts`
+- Modify: `apps/web/lib/mcp-tools.ts`
+- Modify: `apps/web/app/(shell)/admin/data/policy-privacy/page.tsx`
+- Modify: `packages/dpf-skill-pack/skills/dpf-data-architecture-steward/SKILL.md`
+
+**Steps:**
+
+- [ ] Write failing type/decision vectors for parameterized obligations, allow, allow-with-obligations, review, deny, unsupported PEP obligation, unknown context, strict-source propagation, expired exception, hard-constraint conflict, version/authority/hold invalidation, cache-key mismatch, and single-use replay.
+- [ ] Run the targeted tests and observe failures for the missing typed contract/capability/invalidations.
+- [ ] Implement the exact input/output contract from spec §6.5 as a pure deterministic evaluator.
+- [ ] Define explicit policy ordering by hard constraint, confirmed authority, consent/contract, organization policy, approved exception, effect, specificity, and effective version. Do not depend on array order.
+- [ ] Add a PEP capability matrix and fail conformance when a required obligation/profile is unsupported.
+- [ ] Implement reusable PEP adapters for server action, MDM action, context/memory, derived copy, and lifecycle action.
+- [ ] Bind side effects to one-time durable-operation authorizations and revalidate current authority, hold, classification, and policy immediately before mutation; restrict cacheable decisions to exact versioned read keys.
+- [ ] Persist high-risk decisions in `AuthorizationDecisionLog` with typed rationale and no raw data values.
+- [ ] Expose concise `get_data_policy` and `check_data_action` explanation/simulation tools around the same evaluator. Keep descriptions provenance-free and results capped.
+- [ ] Add the Policy & Privacy simulator view with explicit principal/action/asset/field/purpose/destination input and obligation/capability explanation.
+- [ ] Prove direct calls to protected executors without a PEP token/decision fail closed.
+- [ ] Extend the steward skill to propose classification and explain decisions; it cannot approve its own exception or high-risk action.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/govern/data/policy-decision.test.ts lib/govern/data/policy-enforcement.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: policy ordering is deterministic, unsupported obligations and stale/replayed side effects fail closed, and MCP/UI explain the same evaluator result.
+
+### Task 17: BI-DG-009 — Enforce mask-before-context
+
+**Files:**
+
+- Create: `apps/web/lib/govern/data/mask-for-context.ts`
+- Create: `apps/web/lib/govern/data/mask-for-context.test.ts`
+- Modify: `apps/web/lib/actions/agent-coworker.ts`
+- Modify: `apps/web/lib/inference/semantic-memory.ts`
+- Modify: `apps/web/lib/tak/tool-result-budget.ts`
+- Modify: `apps/web/lib/tak/tool-result-budget.test.ts`
+
+**Steps:**
+
+- [ ] Write failing tests for omit/redact/partial/tokenize/aggregate/pass-through, nested objects, arrays, nulls, unknown fields, mixed asset payloads, purpose/destination change, and output classification inheritance.
+- [ ] Run the tests and observe the missing masking service failure.
+- [ ] Implement the typed transforms and default sensitive unknown fields to omit.
+- [ ] Apply masking before prompt serialization, vector storage, preview/log construction, and tool-result return.
+- [ ] Require a PDP decision and field metadata; never accept an arbitrary caller-supplied mask list as authority.
+- [ ] Add a plaintext canary test proving a restricted fixture never reaches captured context, vector payload, receipt, or log.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/govern/data/mask-for-context.test.ts lib/inference/semantic-memory.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: the plaintext canary is absent from prompts, memory, previews, tool results, logs, and receipts under every restricted/confidential fixture.
+
+### Task 18: BI-DG-007 — Add the key-service and protected-field core
+
+**Files:**
+
+- Refactor: `apps/web/lib/govern/credential-crypto.ts`
+- Create: `apps/web/lib/govern/data/key-service.ts`
+- Create: `apps/web/lib/govern/data/protected-field.ts`
+- Create: `apps/web/lib/govern/data/key-service.test.ts`
+- Create: `apps/web/lib/govern/data/protected-field.test.ts`
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/<timestamp>_add_protected_data_key/migration.sql`
+- Create: `packages/db/src/protected-data-key-schema.test.ts`
+- Create: `docs/operations/data-key-rotation-and-recovery.md`
+
+**Steps:**
+
+- [ ] Write key-service tests for tenant/domain/record/subject scope, rotation, wrong key, missing key, corrupted ciphertext, old format, restore, and fail-loud outside development.
+- [ ] Write failing schema tests for tenant-isolated wrapped-key identity, key/profile/version/status, recovery authority, rotation, compromise/revocation, and destruction evidence.
+- [ ] Run the tests and observe the missing core service/schema failures.
+- [ ] Add only wrapped-key/protection-profile metadata; run `pnpm --filter @dpf/db exec prisma migrate dev --name add_protected_data_key`. There is no legacy key backfill because no protected field is activated in this BI.
+- [ ] Keep KEK material outside Postgres and protected backups; store only wrapped DEK metadata and versioned ciphertext.
+- [ ] Implement one versioned ciphertext envelope and model-access helper. Do not add ad hoc encryption calls to routes.
+- [ ] Add keyed lookup tokens only for approved exact-match needs; never log raw values or tokens.
+- [ ] Rehearse rotation, KEK unavailability, lost/revoked/compromised key, cross-tenant denial, backup restore, and rollback before enabling any field family.
+- [ ] Document that key destruction is defense in depth and requires copy/exception evidence.
+
+**Verification:**
+
+```powershell
+pnpm --filter @dpf/db exec prisma validate
+pnpm --filter @dpf/db exec vitest run src/protected-data-key-schema.test.ts
+pnpm --filter web exec vitest run lib/govern/credential-crypto.test.ts lib/govern/data/key-service.test.ts lib/govern/data/protected-field.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: the key lifecycle is tenant-isolated, versioned, recoverable, rotatable, revocable, and fail-loud; no business field changes storage format in this PR.
+
+### Task 18A: Protected-field family rollout — three real BI IDs per family assigned in Task 0
+
+Task 0 replaces `<family>` and the service paths below with the exact approved field family. One family is delivered as three independently green PRs so application-key encryption never pretends to be a SQL backfill.
+
+**Files:**
+
+- Modify: `apps/web/lib/govern/data/assets.ts`
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/<timestamp>_prepare_<family>_protection/migration.sql`
+- Modify: the exact canonical model-access service recorded in the BI
+- Create: a focused `<family>-protection.test.ts` beside that service
+- Add later: `packages/db/prisma/migrations/<timestamp>_enforce_<family>_protection/migration.sql`
+
+**Steps:**
+
+- [ ] **Prepare BI:** document field threat/search/cardinality/backup analysis and choose minimize, mask, tokenize, encrypt, or access-only. Write failing dual-read/write tests, add shadow protected columns with `prisma migrate dev --name prepare_<family>_protection`, and enable versioned dual-write. Its SQL explicitly performs no backfill.
+- [ ] **Backfill-operation BI:** use `DataControlOperation` checkpoints to encrypt/tokenize existing rows through the key service in capped idempotent pages. Keep plaintext authoritative during failure; record counts/digests and prove retry/rotation/restore. This BI owns no schema migration.
+- [ ] **Enforce BI:** after the backfill invariant proves zero missing/invalid rows, switch reads to protected values, stop plaintext writes, and run `prisma migrate dev --name enforce_<family>_protection` to enforce/drop or null legacy storage. The migration contains an invariant guard, not a hidden backfill.
+- [ ] Apply field policy to associated history, snapshot, receipt, log, export, and lookup-token paths in the same family; raw values cannot escape into evidence.
+- [ ] Run the per-BI completion gate after each of the three branches. Do not start a family until its exact BIs and files are in the live backlog.
+
+Expected: no PR mixes schema preparation, application-key backfill, and destructive cutover; rollback remains possible until the separately verified enforce BI.
+
+### Task 19: BI-DG-008 — Implement the subject-request case and Postgres discovery core
+
+**Files:**
+
+- Create: `apps/web/lib/govern/data/subject-locator.ts`
+- Create: `apps/web/lib/govern/data/subject-request.ts`
+- Create: `apps/web/lib/govern/data/subject-request.test.ts`
+- Create: `apps/web/lib/actions/data-subject-requests.ts`
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/<timestamp>_add_data_subject_request/migration.sql`
+- Create: `packages/db/src/data-subject-request-schema.test.ts`
+- Modify: `apps/web/app/(shell)/admin/data/policy-privacy/page.tsx`
+
+**Steps:**
+
+- [ ] Write failing identity/authority tests across `Principal`, `PrincipalAlias`, identity source observations, and MDM crosswalks, with ambiguity routed to review.
+- [ ] Write failing case/discovery tests for multiple locators, shared records, frozen scope revision, active hold, exception, missing adapter, and incomplete target.
+- [ ] Run the tests and observe the missing case/target state failures.
+- [ ] Add `DataSubjectRequest` and `DataSubjectRequestTarget`; run `pnpm --filter @dpf/db exec prisma migrate dev --name add_data_subject_request`. No backfill is allowed because historical requests cannot be reconstructed.
+- [ ] Build the durable workflow: verify identity/authority, discover, freeze scope revision, review exceptions, preview, authorize, execute through `DataControlOperation`, reconcile, and issue completeness evidence.
+- [ ] Implement only the Postgres authoritative-row adapter in this BI; choose export/delete/anonymize/detach/restrict/key-destroy/conflict per asset policy.
+- [ ] Keep exports encrypted, time-limited, access-audited, and separated from unrelated subjects.
+- [ ] Keep the execute action feature-disabled until every required copy adapter reports supported; surface unsupported/incomplete rather than a success control.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/govern/data/subject-request.test.ts lib/operate/retention/lifecycle-decision.test.ts lib/mdm
+pnpm --filter @dpf/db exec vitest run src/data-subject-request-schema.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: subject cases are authorized, durable, scope-versioned, and honest about unsupported copies; only Postgres execution is enabled in this PR.
+
+### Task 19A: Subject-request copy adapters and activation — real BI IDs assigned in Task 0
+
+Create one BI/PR per actual adapter discovered from `DerivedDataContract`: Neo4j, Qdrant, MDM aliases/source observations, archives/exports, backups/tombstones, and any additional store. Each BI names exact files before work starts.
+
+- [ ] Write a failing contract test for discover, export, delete/anonymize/restrict where supported, idempotency, hold/exception, checkpoint, and reconciliation.
+- [ ] Implement that one adapter through `DataControlOperation`; a non-compensable failure remains partial and blocks case completion.
+- [ ] Add a mutation test that removes the adapter and proves the independently generated coverage denominator fails.
+- [ ] After all required adapters land, use a separate activation BI to enable execution in Policy & Privacy and run one access plus one erase/anonymize fixture across every contracted store.
+- [ ] Run the per-BI completion gate for each adapter and activation branch.
+
+Expected: no adapter PR claims end-to-end DSAR completion; the activation PR is the first point at which cross-store completeness may be reported.
+
+### Task 20: BI-DG-010 — Add tamper-evidence verification without compliance overclaim
+
+**Files:**
+
+- Create: `apps/web/lib/govern/data/audit-integrity.ts`
+- Create: `apps/web/lib/govern/data/audit-integrity.test.ts`
+- Create: `apps/web/lib/queue/functions/audit-integrity-check.ts`
+- Modify: `apps/web/lib/queue/functions/index.ts`
+- Create: `docs/operations/audit-integrity.md`
+
+**Steps:**
+
+- [ ] Write failing tests for canonicalization, mutation, deletion, insertion, reordering, batch boundary, algorithm/key upgrade, duplicate/late event, field-policy redaction, and partial failure.
+- [ ] Run the tests and observe the missing integrity implementation.
+- [ ] Implement canonical serialization, domain separation, chain/batch boundaries, algorithm/version, late-arrival handling, and key/root storage.
+- [ ] Hash-link or Merkle-batch high-value decision/disposition receipts without copying sensitive payload values.
+- [ ] Apply source field policy to every included receipt and use canonicalized keyed digests where identifiers are required.
+- [ ] Write signed/hashed roots to an independent evidence location and store only the non-sensitive reference in the primary database.
+- [ ] Schedule verification and file/resolve a conformance issue on break/recovery.
+- [ ] Document supported integrity guarantees and explicitly exclude a claim of SEC 17a-4 certification without separate WORM/audit-trail assessment.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run lib/govern/data/audit-integrity.test.ts
+pnpm --filter web typecheck
+```
+
+Expected: every integrity mutation fixture is detected, protected fields remain protected in evidence, and independent-root verification opens/resolves one stable issue.
+
+---
+
+## Chunk 6 — Consolidate the product experience and finish the control loop
+
+### Task 21: BI-DG-016 — Workspace consolidation and usability acceptance
+
+**Files:**
+
+- Modify: `apps/web/app/(shell)/admin/data/layout.tsx`
+- Modify: `apps/web/app/(shell)/admin/data/page.tsx`
+- Modify: `apps/web/app/(shell)/admin/data/catalog/page.tsx`
+- Modify: `apps/web/app/(shell)/admin/data/stewardship/page.tsx`
+- Modify: `apps/web/app/(shell)/admin/data/lifecycle/page.tsx`
+- Modify: `apps/web/app/(shell)/admin/data/policy-privacy/page.tsx`
+- Refactor: `apps/web/app/(shell)/admin/data-stewardship/page.tsx` to redirect after parity
+- Refactor: `apps/web/app/(shell)/admin/reference-data/page.tsx` to redirect or deep-link after parity
+- Modify: `apps/web/components/admin/admin-nav.ts`
+- Create: `apps/web/components/data-management/DataManagementShell.tsx`
+- Create: `apps/web/components/data-management/DataManagementShell.test.tsx`
+- Create: `apps/web/components/data-management/DataAttentionTable.tsx`
+- Create: `apps/web/components/data-management/DataAttentionTable.test.tsx`
+- Create: `apps/web/components/data-management/MdmResolutionPanel.tsx`
+- Create: `apps/web/components/data-management/MdmResolutionPanel.test.tsx`
+- Create: `apps/web/components/data-management/PolicySimulator.tsx`
+- Create: `apps/web/components/data-management/PolicySimulator.test.tsx`
+- Create: `apps/web/app/(shell)/admin/data/data-management-routes.test.ts`
+
+**Steps:**
+
+- [ ] Write route/permission tests for the five stable tabs and legacy redirects.
+- [ ] Verify capability-owning PRs already provide stewardship, lifecycle, policy simulation, processing activities, subject requests, and operation evidence; this PR does not reimplement their services.
+- [ ] Confirm parity for legacy stewardship behavior before enabling redirects: scorecards, review queue, match rules, merge/unmerge, crosswalks, history, autonomous controls, and supplier pilot status.
+- [ ] Replace page-local KPI/filter/table implementations with report-kit `StatCard`, `StatusBadge`, `FilterBar`, `DataTable`, `Chart`, and `ExportButton` where the component semantics fit.
+- [ ] Consolidate survivorship compare/preview presentation with source trust, winning rule/version, pinned state, confidence/risk, downstream impact, and actual reversibility class.
+- [ ] Consolidate Policy & Privacy local subviews without creating another rule engine or evidence store.
+- [ ] Keep `/ea/data-model` authoritative for ERD/technical lineage and `/compliance` authoritative for obligation/control assurance; use deep links and shared IDs.
+- [ ] Use plain first-level labels and progressive disclosure for policy IDs/JSON.
+- [ ] Add role-filtered attention queues and an “Ask Data Steward” preview that shows scope, tools/actions, authority, and confirmation boundary before launch.
+- [ ] Add loading, empty, partial-data, permission, policy-unknown, stale, error, and successful-action states.
+- [ ] Use in-app dialogs for merge, unmerge, hold release, lifecycle execution, erasure, exception approval, and other consequential actions.
+- [ ] Verify keyboard, focus, screen-reader labels, status text, chart alternatives, responsive behavior, and theme tokens.
+- [ ] Run the fixed six-task safe fixture from spec §7 with at least three schema-unfamiliar representative operators at 1280×720 and 390×844; require ≥90% unaided completion, zero critical wrong/destructive actions, median ≤3 minutes, and WCAG 2.2 AA/keyboard evidence.
+
+**Verification:**
+
+```powershell
+pnpm --filter web exec vitest run 'app/(shell)/admin/data' components/data-management
+pnpm --filter web typecheck
+```
+
+Expected: legacy redirects preserve parity, role-filtered/degraded states are honest, and the measured usability/accessibility thresholds pass.
+
+### Task 22: BI-DG-013 — Publish operator and user guidance
+
+**Files:**
+
+- Create: `docs/operations/data-management.md`
+- Create: `docs/operations/data-policy-and-exceptions.md`
+- Create: `docs/operations/data-subject-requests.md`
+- Create: `docs/operations/mdm-stewardship.md`
+- Create: `docs/user-guide/admin/data-management.md`
+- Modify: `docs/operations/install.md` only if deployment/worker prerequisites changed
+- Modify: `docs/user-guide/admin/index.md`
+
+**Steps:**
+
+- [ ] Document roles and decision rights, using the accountability map from the spec.
+- [ ] Document how to interpret Overview, Catalog, Stewardship, Lifecycle, and Policy & Privacy in plain language.
+- [ ] Document policy simulation, exception expiry, hold create/release, dry-run/disposition, MDM resolution/unmerge, subject requests, archive restore, key recovery, and integrity alerts.
+- [ ] Separate legal facts, platform behavior, organization-configurable defaults, and examples.
+- [ ] Link to the governing spec rather than duplicating architecture rules.
+- [ ] Validate every local link and screenshot/route against the served product.
+
+**Verification:**
+
+```powershell
+pnpm check:doc-links
+```
+
+Expected: documentation index generation, internal-link tests, and diagram checks exit zero; every documented route matches the served portal.
+
+### Task 23: Integrated program verification and handoff
+
+This is a cross-program regression/exit review. It cannot retroactively satisfy a missing per-BI build, migration, runtime, UX, evidence, push, or PR gate.
+
+**Files:**
+
+- Modify: this plan only to record final evidence links if project convention requires it
+- Modify: live BIs, Work Capsules, and execution-evidence records through MCP
+
+**Steps:**
+
+- [ ] Run all affected unit suites and full web typecheck.
+- [ ] Claim `local-integration-ci`, run the production build, apply migrations to the verification database, and record exact command/output evidence.
+- [ ] Run schema/registry/gate mutation fixtures.
+- [ ] Run semantic-memory storage/delete/reconcile, MDM match/merge/survivorship/publish/unmerge, lifecycle/hold/conflict/archive, policy/PDP/PEP, masking/encryption, subject request, and integrity-break scenarios.
+- [ ] Verify `/admin/data` end to end, including permissions, accessibility, theme, narrow viewport, empty/error states, exports, dialogs, redirects, and deep links.
+- [ ] Run `pnpm pr:health` and fix every in-scope failure.
+- [ ] Record canonical-runtime evidence for each BI, release the environment lease, update live statuses, push signed commits, and open regular ready-for-review PRs only when each branch is independently green.
+
+**Canonical commands:**
+
+```powershell
+pnpm --filter web exec vitest run
+pnpm --filter web typecheck
+pnpm security:secrets
+pnpm pr:health
+```
+
+The production build, migration apply, and UX/cross-store scenarios run under the leased shared environment or governed canonical install as required by `AGENTS.md`; their evidence records must name the source SHA.
+
+Expected: every program exit criterion is backed by current-SHA canonical-runtime evidence; this regression pass finds no gap hidden by earlier per-BI evidence.
+
+---
+
+## Dependency and PR sequence
+
+```text
+DG-001                         immediate and independent
+DG-002 -> DG-003, DG-004, domain coverage waves, DR-101, MDM-5A, DG-005, DG-011, DG-007-core
+operation-journal + DG-011 -> DG-012
+MDM-5A + operation-journal + DG-012 -> MDM-5B; MDM-5B + DR-101 -> MDM-5C
+DR-101 -> DR-102 -> DR-103 and DR-104 -> DR-105 -> DR-106 -> DR-107 decision/decomposition
+DR-105 + DR-106 + measured approval -> each DR-107 stream implementation BI
+DG-001 + DG-005 + operation-journal + DG-012 -> DG-006
+DG-001 + DG-002 + DG-012 -> DG-009
+DG-002 -> DG-007-core -> each three-PR protected-field rollout
+DR-105 + DG-005/DG-006 + operation-journal + DG-012 + DG-007-core -> DG-008 core -> per-store adapters -> activation
+stable protected decision/disposition receipts -> DG-010
+DR-101 shell + capability-owning UI PRs -> workspace consolidation -> DG-013 -> integrated verification
+```
+
+No dependency authorizes a multi-concern PR. If an interface is needed early, land the smallest typed interface and tests in its owning BI; consumers follow in separate branches.
+
+## Program exit criteria
+
+- Current Prisma schema has 100% logical asset and lifecycle coverage.
+- Every MDM domain has governed ownership, dedup, survivorship, quality, lifecycle, autonomy, and publish contracts.
+- Every content-bearing derived copy has a policy decision, cleanup path, reconciliation, staleness SLO, and evidence.
+- Every destructive executor checks holds and emits disposition evidence; policy conflicts do not delete.
+- Every protected AI/context path masks before serialization or storage.
+- High-risk fields have an approved protection choice and tested key/recovery path.
+- Subject access/erasure completes across canonical and derived stores or remains visibly incomplete with a governed reason.
+- Gate mutation tests prove missing assets, PEPs, MDM contracts, cleanup handlers, hold checks, and exception expiry fail.
+- `/admin/data` passes the non-specialist usability and accessibility script.
+- All affected PRs have canonical-runtime evidence, signed commits, pushed branches, green CI, and updated live backlog state.

--- a/docs/superpowers/specs/2026-07-17-data-management-governance-design.md
+++ b/docs/superpowers/specs/2026-07-17-data-management-governance-design.md
@@ -1,218 +1,567 @@
 # Data Management Governance — Design
 
 - **Date:** 2026-07-17
-- **Status:** Approved for planning (research complete; plan at `docs/superpowers/plans/2026-07-17-data-management-governance-plan.md`)
-- **Epics:** EP-DATA-GOVERNANCE (new umbrella), EP-DATA-RETENTION (reopened for lifecycle completion); composes with EP-ESTATE-SOVEREIGNTY, EP-MDM, EP-GRC-001, EP-PLATFORM-SUBSTRATE-CONVERGENCE (BI-PSC-006 bounded contexts)
-- **Author:** Claude (external surface), capsule WC-450D7558
-- **Goal statement (founder, 2026-07-17):** better data management across (1) projection of tables into the graph, (2) forever-growing tables, (3) retention rules and access sensitivities per industry (patient records, financial records), (4) see/work-with vs. retain distinction, (5) sovereignty — where stored vs. where accessed, (6) encryption and masked exposure, (7) no coworker or human should need to personally know every regulation, and (8) processes so no future feature ships with these concerns unhandled.
+- **Status:** Revised design (rev. 2) — founder-reviewed; substrate references validated against `origin/main` `5834e7548`; backlog reconciled 2026-07-17 (BI-DG-014..016, BI-MDM-201..203 assigned)
+- **Plan:** `docs/superpowers/plans/2026-07-17-data-management-governance-plan.md`
+- **Epics:** EP-DATA-GOVERNANCE, EP-DATA-RETENTION, and EP-MDM; composes with EP-ESTATE-SOVEREIGNTY, EP-GRC-001, and EP-PLATFORM-SUBSTRATE-CONVERGENCE
+- **Capsule:** WC-450D7558
+- **Research baseline:** live MCP backlog on 2026-07-17 plus `origin/main` at `5834e7548` (PR #3182), containing 495 Prisma models. The local topic worktree is older, so implementation must rebase and repeat the inventory before changing code.
 
-## 1. Problem
+## 1. Executive decision
 
-Data is the "I" in IT and the highest-consequence asset the platform holds. A data leak or an unmet retention obligation can end a customer's business — or DPF's credibility. Today the platform has strong *pockets* of data governance but no *system* of it:
+DPF will implement a **composed data-control spine**: one stable logical identity for each governed data asset, with separate typed registries for classification, lifecycle, processing purpose, projection, protection, ownership, and Master Data Management (MDM). Runtime records hold organization-specific approvals, exceptions, legal holds, steward work, and evidence. They do not replace source-controlled platform defaults.
 
-1. **Classification stops at routes and agents.** A 4-level sensitivity taxonomy (`public|internal|confidential|restricted`) classifies routes, coworkers, and AI endpoints (`apps/web/lib/tak/agent-sensitivity.ts`) — but **no table, column, or record carries a classification**. There is no registry saying "StorefrontInquiry.customerEmail is personal data" or "AgentMessage.content is customer content." Every downstream control (masking, encryption, projection scope, retention) lacks its anchor.
-2. **Lifecycle covers 19 of ~385 models.** The EP-DATA-RETENTION engine (`apps/web/lib/operate/retention/`) is a sound declarative registry — but the ranked worst unbounded growers are unenrolled: `UserFact` (coworker memory, supersession chains never pruned), `PortfolioQualityIssue` (written every minute by the alert bridge), `BacklogItemActivity`, `AdminActivity`, `IntegrationToolCallLog`, `RouteOutcome`, `ToolExecutionReceipt`, `CoworkerActionEnvelope`, edge/federation streams (`EdgeEvent`, `ChangeEvent`, `RemoteAction`), discovery streams, and all 13 revision/snapshot tables. **Zero growth observability exists** — no table-size metric, no admin view of the retention matrix, no alert as unenrolled tables grow.
-3. **Projection into graph/embeddings is governed six different ways.** Six projection families (Prisma→EA ERD, schema drift steward, code graph→Neo4j, 14 SysML parity domains, discovery→portfolio+Neo4j, 4 Qdrant embedding collections) each hand-roll scope, triggers, deletion, and staleness. Deletion semantics diverge sharply: code-graph hard-deletes, the EA mirror soft-tombstones (`mirrorRemoved`) without driving Neo4j deletes (orphan risk), Qdrant `agent-memory` has **no deletion path at all**. Most are fire-and-forget with no "this projection has been dark for N hours" signal (the code-graph reconciler gained one only after a 13-day silent outage).
-4. **Sensitive content flows into derived stores ungated.** Coworker conversation content is embedded into Qdrant `agent-memory` on every turn — raw content, 300-char preview, userId — with **no sensitivity gate at storage time**, even though the same request computes route sensitivity to gate *provider selection* (`apps/web/lib/actions/agent-coworker.ts`, `apps/web/lib/inference/semantic-memory.ts`). Embeddings persist after source deletion.
-5. **See/work-with vs. retain is not separated.** Encryption covers only credentials/tokens/API keys (`credential-crypto.ts`). Customer PII (`StorefrontInquiry`, `StorefrontOrder`, donors, CRM engagements), coworker chat, memory facts, and raw transcripts are plaintext. No field-level masking exists for AI exposure — sensitivity gates *which provider* sees a prompt, never *which fields* enter the context. No DSAR/erasure flow exists (explicitly deferred by the retention spec). Audit "immutability" is append-only convention with no tamper evidence.
-6. **Compliance knowledge is derived by string-matching, not modeled.** Archetypes carry no typed regulatory metadata; `compliance-library.ts` string-matches archetype ids and `BusinessContext` flags at runtime. Retention industry floors exist, but nothing tells a coworker (or a Build Studio agent adding a table) *what regime applies to which data*.
-7. **Nothing stops the next feature from repeating all of the above.** New Prisma models ship with no forced lifecycle, classification, or projection decision. The platform's own history proves passive doctrine fails (§12 UX-Fit gate exists because a documented rule was ignored); data needs the same enforced-gate treatment.
+MDM is a first-class plane of this design. DPF already has a strong MDM substrate — domain ownership, identity and non-identity crosswalks, write-time duplicate prevention, match configuration, steward tasks, reversible merge/unmerge, attribute history, TrustAssessment publishing, enrichment proposals, and an autonomous Data Steward. This design governs those capabilities and connects them to data classification, purpose, retention, privacy, projection, and policy enforcement. It does not build a second golden-record database.
 
-## 2. Goals / Non-goals
+The operator experience will be an attention-first **Data Management** workspace. A non-specialist should be able to answer five questions without knowing a regulation or database name:
 
-**Goals**
+1. What data do we have, and who is accountable for it?
+2. Which records are trusted master data, and which need steward review?
+3. What are we allowed to do with the data for this purpose?
+4. How long must we keep it, and when must we delete it?
+5. Where are its copies, and did the required control actually run?
 
-- **G1 — One classification spine.** A single, code-defined, test-guarded data classification registry covering every Prisma model (and sensitive fields), from which lifecycle, projection, masking, encryption, residency, and retention policies all derive. Policies bind to classifications, never to physical table names.
-- **G2 — Complete the lifecycle surface.** Every model has an explicit lifecycle disposition: enrolled purge policy, regulated retention, revision cap, or a deliberate `unbounded-accepted` with rationale. Growth becomes observable and alertable.
-- **G3 — Correct retention algebra.** Three distinct modeled concepts — retention floor (regulated minimum), deletion mandate (maximum), and **legal hold** (a separate, superior object that suspends disposition) — with Purview-style precedence: retention beats deletion until expiry; longest retention wins; hold trumps everything. Disposition produces evidence.
-- **G4 — Governed projection.** One projection-contract registry for all graph/embedding/derived-store pipelines: classification-aware scope, deletion propagation (tombstones drive Neo4j/Qdrant deletes), and uniform dark-projection staleness escalation.
-- **G5 — Protection plane.** Field-level envelope encryption for personal data with per-subject keys (crypto-shredding capable); classification-driven masking **before context assembly** for AI exposure; DSAR/erasure flows that enumerate derived copies (Qdrant, Neo4j, logs); hash-chained tamper evidence on audit tables.
-- **G6 — Compliance knowledge modeled once.** Typed regulatory metadata on archetypes feeding classification defaults and retention floors; a policy decision point (MCP tools) coworkers and humans *ask* instead of *know*.
-- **G7 — Enforced forward process.** A CI **Data-Impact Gate**: any PR that adds/changes a Prisma model must carry a classification-registry entry and lifecycle disposition, or an explicit `Data-Steward-Decision:` attestation — same enforced-gate pattern as the Spec/Plan/Doc and UX-Fit gates.
+## 2. Problem
 
-**Non-goals**
+DPF has effective controls in isolated domains but no end-to-end control system:
 
-- Building a general-purpose data catalog product (OpenMetadata/DataHub scale). We adopt their *models*, scoped to DPF's own schema and stores.
-- Replacing the existing retention engine — it is extended, not rewritten.
-- CADA assurance items already owned by EP-ESTATE-SOVEREIGNTY (SBOM signing, EU-steward posture, estate assessment) — this design supplies the classification/residency substrate they consume; those BIs stay in their epic.
-- Master-data survivorship/crosswalk (EP-MDM owns canonical-record stewardship).
-- Multi-region physical storage topology. DPF is local-first single-install today; residency classes and the local-only inference gate are the sovereignty controls in scope. Physical geo-sharding arrives with the cloud/TAPPaaS deployment work.
-- Clinical-record (EHR-class) data modeling. DPF does not model diagnoses/charts today; the design covers the personal data the platform *does* hold and the floors healthcare archetypes require.
+1. **No governed asset identity or field classification.** The route and agent sensitivity taxonomy (`public | internal | confidential | restricted`) does not classify Prisma models or fields. Downstream masking, encryption, projection, purpose, retention, and subject-rights controls therefore lack a shared anchor.
+2. **Lifecycle coverage is incomplete.** The retention engine covers a small minority of the 495-model research baseline. High-growth events, activity logs, receipts, observations, MDM history, steward tasks, revisions, and vectors can grow indefinitely. There is no complete disposition matrix or growth SLO.
+3. **Derived copies are governed independently.** Neo4j, Qdrant, EA mirrors, discovery projections, SysML parity, federation, and code-graph pipelines use different scope, deletion, and staleness conventions. Raw conversation content can reach semantic memory without a storage-time field policy, and a source deletion does not reliably remove every derived copy.
+4. **Purpose and retention are conflated with access.** A principal may be allowed to use a field for one purpose but not another, while a record may need to be retained even when nobody may use it operationally. DPF cannot express that distinction consistently today.
+5. **Protection is narrow.** Credential secrets are encrypted, but high-risk personal and customer content is generally plaintext. Masking is not enforced before AI context assembly. There is no complete data-subject access/erasure workflow or cryptographic tamper-evidence check.
+6. **Compliance knowledge is duplicated and inferred.** Archetype and business-context strings drive some applicability logic, but there is no governed processing-activity inventory connecting purpose, data categories, subjects, legal basis, recipients, location, lifecycle, and accountable owner.
+7. **Existing MDM decisions are not connected to wider governance.** Crosswalks, survivorship, merge history, trust scores, and published master views do not yet carry a complete classification, lifecycle, purpose, policy-version, and evidence contract. Autonomous merges need risk-tiered authority rather than a single global posture.
+8. **The product surface is fragmented.** `/admin/data-stewardship`, `/admin/reference-data`, `/ea/data-model`, retention jobs, backups, and compliance evidence are separate destinations. The current stewardship view also predates report-kit conventions.
+9. **The next feature can repeat the debt.** A new persistent model or projection can ship without an explicit owner, classification, master-data role, lifecycle, subject locator, purpose, or copy-cleanup decision.
 
-## 3. Research & Benchmarking
+## 3. Goals and non-goals
 
-Read data models, not feature lists. Full source list at the end of this section.
+### Goals
 
-### Open source
+- **G1 — Complete, stable asset inventory.** Every persistent model and governed field maps to a stable logical `DataAssetId`, independent of physical table renames.
+- **G2 — Separated control axes.** Sensitivity, semantic category, criticality, master-data domain, subject relationship, purpose, lifecycle, residency, and quality remain independent and composable.
+- **G3 — Accountable governance.** Every governed domain has an accountable owner, a steward, a custodian, decision rights, review cadence, and measurable control SLOs.
+- **G4 — MDM as a governed plane.** Master-data identity, source crosswalk, match, merge, survivorship, quality, publish, hierarchy/reference-data, and stewardship decisions share the same policy and evidence contracts.
+- **G5 — Correct lifecycle decisions.** Retention minima, deletion maxima, legal holds, erasure requests, archival, anonymization, and exceptions are distinct concepts with explicit conflict handling.
+- **G6 — Governed copies.** Every graph, vector, cache, export, federation, or other derived copy has a contract for purpose, permitted fields, transformation, classification inheritance, retention, deletion, reconciliation, and staleness.
+- **G7 — Enforceable policy.** One in-process Policy Decision Point (PDP) produces versioned, explainable decisions; Policy Enforcement Points (PEPs) apply obligations at reads, writes, AI context, projections, MDM operations, and disposition.
+- **G8 — Proportionate protection and privacy operations.** High-risk fields receive encryption or tokenization at an audited access seam; masking precedes AI context; subject access and erasure enumerate authoritative and derived copies.
+- **G9 — Prevent regression.** CI and runtime stewardship make missing governance decisions visible and, for new persistent surfaces, merge-blocking.
+- **G10 — Usable product experience.** An attention-first workspace lets non-specialists discover risk, act safely, simulate policy, review MDM exceptions, and retrieve evidence.
 
-- **OpenMetadata** — JSON-Schema entity model. Adopted: hierarchical `Classification→Tag` with `mutuallyExclusive`, column-level tag labels carrying `labelType` (Manual/Automated/Propagated) and `state` (Suggested/Confirmed) — machine-classify-human-confirm lives in the data model; `lifeCycle` aspect (created/updated/accessed audit) feeding ROT ("is this data even used") detection; policies as `{effect, operations, resources, condition}` where conditions match on tags (`matchAnyTag('PII.Sensitive')`), deny-first. **Rejected:** `retentionPeriod` as descriptive-only metadata — unenforced retention declarations drift; in DPF an unenforced declaration is a conformance finding, not a feature.
-- **DataHub (Acryl)** — entity/aspect/URN graph. Adopted: the catalog-stays-declarative / event-driven-actions split (DataHub Actions) — our queue functions react to "classification changed"/"retention expired"; typed Structured Properties as precedent for registry fields. **Rejected:** the Kafka+Elasticsearch deployment stack — DPF already has Postgres+Neo4j+Qdrant.
-- **Apache Atlas** — classification as a metatype with **propagation along lineage** (per-edge opt-out), classification attributes, and `validityPeriods`. Adopted: propagate classifications along DPF's own projection edges (a `restricted` source taints its projections). **Rejected:** HBase/Solr substrate; enforcement-by-Ranger pairing (we enforce in our own runtime).
+### Non-goals
 
-### Commercial
+- Replacing OpenMetadata, DataHub, or a general enterprise catalog. DPF needs an embedded control plane for its own schema and stores.
+- Replacing domain tables with a separate MDM hub. The domain table remains canonical; MDM governs identity, quality, provenance, resolution, and publishing around it.
+- Replacing the existing retention engine, compliance engine, trust vector, identity model, MDM services, or federation `ProjectionContract`. This design composes and refactors them.
+- Claiming legal certification. The platform supplies controls and evidence; organization-specific legal interpretation and formal regulatory assessments remain governed human decisions.
+- Universal encryption of every field. Protection is selected by risk, access pattern, search requirements, and key-recovery design.
+- Multi-region storage topology in this epic. The model records residency and transfer constraints that future deployment substrates enforce.
 
-- **Microsoft Purview** — the most complete retention lifecycle model. Adopted: the retention-label anatomy (duration + trigger event + end-of-retention action + disposition review), the precedence algebra (retention > deletion; longest retention wins; explicit label > broad policy), **legal hold as a separate superior object** (Preservation Lock satisfies SEC 17a-4 hold-beyond-retention), disposition records as proof-of-destruction, and the DSPM-for-AI pattern (agents honor the *user's* ACLs; sensitivity labels block agent processing; outputs inherit source labels). **Rejected:** the split-brain of two disconnected taxonomies (Data Map classifications vs. compliance-portal labels) — DPF gets exactly one taxonomy.
-- **Collibra** — policy-as-asset (a Retention Policy is itself a governed asset related to data categories). Adopted: policies are first-class, discoverable records. **Rejected:** the BPMN/stewardship-committee operating model — DPF's stewards are AI coworkers; keep the model, discard the process weight.
-- **Immuta** — ABAC enforcement at query time: policies bind to (user attributes × data tags × declared **purpose**), so policy count stays flat as tables multiply, and an *agent is just another subject with attributes and a purpose* — nothing agent-specific to build. Adopted wholesale as the policy-decision-point shape. **BigID** — adopted: correlation of data to *subjects* (prerequisite for DSAR), ROT surfacing as deletion *candidates*, and native deletion executors that close the policy→action loop.
+## 4. Research and benchmarking
 
-### Regulatory baseline
+### 4.1 Standards and governance frameworks
 
-| Regime | Requirement | Direction |
+- [ISO/IEC 38505-1](https://www.iso.org/standard/56639.html) and [ISO/IEC TR 38505-2](https://www.iso.org/standard/70911.html) frame data as an organizational governance concern and use an accountability map. Adopted: explicit decision rights and accountable data owners, not an IT-only catalog.
+- [ISO 8000-51:2023](https://www.iso.org/standard/78708.html) covers exchangeable data-governance policy statements and automated conformance testing. Adopted: stable policy identifiers, versions, referenced specifications, and executable test vectors.
+- [ISO 8000-61:2016](https://www.iso.org/standard/63086.html) defines a data-quality management process reference model. Adopted: quality rules, measurement, remediation, and process maturity are separate from a one-time score.
+- [ISO 8000-110:2021](https://www.iso.org/standard/78501.html) covers machine-checkable exchange of characteristic master data and explicitly notes that provenance and accuracy require an overall quality strategy. Adopted: master publishing contracts must carry formal semantics, conformance, provenance, and quality — not only a payload.
+- [NIST SP 800-162](https://csrc.nist.gov/pubs/sp/800/162/upd2/final) models attribute-based access control with subject, object, action, and environment attributes. Adopted: purpose and destination join principal and asset attributes in the decision input.
+- [NIST SP 800-57 Part 1 Rev. 5](https://csrc.nist.gov/pubs/sp/800/57/pt1/r5/final) treats key generation, distribution, storage, use, recovery, revocation, compromise, and destruction as a lifecycle. Adopted: tenant-isolated key scope, availability/recovery objectives, compromise response, versioning, rotation, and destruction evidence are designed before encrypted field rollout.
+- [NIST CSF 2.0](https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.29.pdf) elevates Govern alongside Identify, Protect, Detect, Respond, and Recover. Adopted: roles, policy, oversight, and evidence are product capabilities, not documentation afterthoughts.
+- [DCAM v3](https://edmcouncil.org/frameworks/dcam/) treats data strategy, architecture, quality, governance, control, privacy, security, AI, and measurable capability maturity as a connected program. Adopted: one scorecard with leading and lagging indicators. DPF does not claim DCAM certification.
+
+### 4.2 Open-source product patterns
+
+- [OpenMetadata classifications](https://docs.open-metadata.org/v1.13.x-SNAPSHOT/how-to-guides/data-governance/classification/classification) distinguish mutually exclusive classification from multi-label categorization. Its [TagLabel model](https://docs.open-metadata.org/v1.6.x/main-concepts/metadata-standard/schemas/type/taglabel) also separates suggested, confirmed, manual, and propagated labels. Adopted: separate axes, provenance, and machine-suggest/human-confirm. Rejected: descriptive retention with no executor.
+- [DataHub's entity/aspect model](https://github.com/datahub-project/datahub/blob/master/docs/what-is-datahub/datahub-concepts.md) attaches independently evolving metadata aspects to stable entity identifiers. Adopted: a stable logical asset key with composed typed aspects. Rejected: its operational stack; DPF already has Postgres, Neo4j, and Qdrant.
+- [Apache Atlas](https://atlas.apache.org/2.0.0/index.html) propagates classifications over lineage, while its [classification model](https://atlas.apache.org/api/v2/json_AtlasClassification.html) records validity and propagation behavior. Adopted: derived copies inherit relevant restrictions, with explicit transform/declassification evidence instead of arbitrary opt-out.
+- [Open Policy Agent deployment guidance](https://www.openpolicyagent.org/docs/deploy) separates policy decisions from enforcement. Adopted: a single evaluator and many PEPs. DPF will implement the small in-process contract first rather than adopt an external service before the Tool Evaluation Pipeline.
+
+Open-source MDM/reconciliation models were reviewed separately from catalogs:
+
+- [Pimcore Data Objects](https://docs.pimcore.com/platform/Pimcore/Objects/) use typed classes, relations, inheritance, variants, and classification stores, while [workflow management](https://docs.pimcore.com/platform/Pimcore/Workflow_Management/) supplies stateful stewardship transitions. Adopted: typed multi-domain master objects and explicit stewardship state. Rejected: runtime visual schema definition as authority; DPF's platform schema remains source-controlled.
+- [OpenRefine's reconciliation API](https://openrefine.org/docs/technical-reference/reconciliation-api) returns ranked candidates in an identifier space, and its [review model](https://openrefine.org/docs/manual/reconciling) preserves judgment and candidate history. Adopted: candidate generation is not a match decision, strong identifiers scope resolution, and bulk judgments remain reversible. Rejected: spreadsheet/project state as the master system of record.
+- [Apache Unomi's profile and alias model](https://unomi.apache.org/manual/latest/) demonstrates identity continuity through aliases and pluggable property-merge strategies, while warning that merging on an unauthenticated identifier is a security risk. Adopted: authenticated identity evidence, alias continuity, and property-specific resolution. Rejected: deleting merged profiles before DPF has proven downstream compensation and retraction.
+
+### 4.3 Commercial product patterns
+
+- [Microsoft Purview Data Governance](https://learn.microsoft.com/en-us/purview/data-governance-overview) separates governance-office, owner, steward, and consumer roles and connects catalog, quality, lineage, policy, and health. Its [lifecycle guidance](https://learn.microsoft.com/en-us/purview/manage-data-governance) treats disposition evidence as part of control operation. Adopted: role-specific workspaces, attention queues, lifecycle labels, and proof. Rejected: separate taxonomies that can drift between catalog and compliance products.
+- [Reltio survivorship](https://docs.reltio.com/en/objectives/resolve-potential-matches/potential-matching-at-a-glance/potential-matching-navigation/design-survivorship-rules) explicitly separates the value-selection rule from the merge operation, and [crosswalks](https://docs.reltio.com/en/objectives/model-data/data-modeling-at-a-glance/data-modeling-operation/define-crosswalks-for-data-sources/crosswalks) preserve contributing source identity. Adopted: value-level provenance, pinned human values, source/recency/quality strategies, and survivorship version independent of merge version.
+- Informatica's [Data Steward Guide](https://docs.informatica.com/content/dam/source/GUID-6/GUID-671C5A40-BDC0-40DE-A0D0-256E9162966D/11/en/MDM_102_DataStewardGuide_en.pdf) centers review tasks, match evidence, merge preview, and controlled resolution. Adopted: one explainable work queue and reversible actions. Rejected: requiring a heavyweight stewardship organization for ordinary low-risk exact matches.
+- [Immuta purpose-based controls](https://documentation.immuta.com/2026.1/governance/author-policies-for-data-access-control/projects-and-purpose-based-access-control/projects-and-purpose-controls/getting-started) make declared purpose part of authorization. Adopted: purpose-bound decisions and obligations. Rejected: table-specific policy proliferation.
+
+Commercial failure-mode research changed the MDM contract: dependency vetoes, stale previews, cross-domain conflicts, null/delete semantics, pinned values, publish-version rollout, retraction, and unmerge limitations are modeled explicitly. “Merge succeeded” is not complete until downstream consumers reconcile or a visible partial-completion case remains.
+
+### 4.4 Regulatory corrections and design implications
+
+| Regime | Verified implication | Design response |
 |---|---|---|
-| GDPR Art. 5(1)(e), 17 | Storage limitation; right to erasure. EDPB: pseudonymization alone is **not** erasure — derived copies (caches, indexes, vectors) count | Deletion maximum + on-trigger |
-| HIPAA 45 CFR 164.316 | Documentation/audit logs 6y; PHI safeguards (encryption addressable, access controls, audit trails); record retention itself is state law | Retention minimum |
-| SOX / SEC 17a-4 | 6–7y financial records; WORM **or** complete time-stamped audit trail (2022 amendment); system must support hold beyond retention | Retention minimum + hold |
-| PCI DSS v4 | Never store SAD post-auth; CHD only with need + quarterly purge; logs 12mo | Deletion mandate + log minimum |
+| [GDPR Articles 5, 17, 24 and 25](https://eur-lex.europa.eu/eli/reg/2016/679/) | Storage limitation, erasure rights and exceptions, accountability, and data protection by design/default. Pseudonymized data can remain personal data. | Model deletion maxima and exceptions; enumerate derived copies; do not call pseudonymization or key destruction universal legal erasure. |
+| [HIPAA Security Rule audit protocol](https://www.hhs.gov/hipaa/for-professionals/compliance-enforcement/audit/protocol/index.html) | The six-year federal period applies to required Security Rule documentation under 45 CFR 164.316; HIPAA does not create one universal medical-record retention period. | Keep security documentation and evidence floors distinct from state/contract clinical-record floors. |
+| [SEC 17a-4 electronic recordkeeping amendments](https://www.sec.gov/investment/amendments-electronic-recordkeeping-requirements-broker-dealers) | A broker-dealer may use WORM or a complete time-stamped audit-trail alternative with record recreation and production capabilities. | Hash chaining is tamper evidence only; a separate control assessment must prove the full audit-trail or WORM posture. |
+| [PCI SSC FAQ 1154](https://www.pcisecuritystandards.org/faqs/1154/) and [PCI DSS v4 SAQ C](https://www.pcisecuritystandards.org/documents/PCI-DSS-v4-0-SAQ-C.pdf) | Sensitive authentication data must not be stored after authorization even if encrypted; audit history is retained for at least 12 months with recent history immediately available. | A deletion prohibition outranks ordinary retention configuration; validation blocks storage of prohibited fields. |
 
-The industry-consensus conflict resolution (retention wins until expiry → then deletion executes; hold suspends all disposition) requires **three modeled concepts, not one "retention period" field** — the single most important schema decision in this design.
+The key correction is that there is no safe universal slogan such as “retention always wins.” DPF evaluates applicable minima, maxima, holds, and exceptions. When authorities conflict, it creates a governed conflict requiring an accountable decision; it does not silently retain or delete.
 
-### Technical patterns (Postgres substrate)
+## 5. Existing substrate — extend, do not duplicate
 
-Adopted: pg_partman-style declarative lifecycle class per table with partition-drop for the largest streams (DELETE-loop purging causes bloat/vacuum storms; partitioning cannot be retrofitted without a rewrite — hence lifecycle-class-at-creation via the gate); archive-before-drop emitting evidence (what/where/checksum); app-layer envelope encryption over pgcrypto (keys never touch the DB server); **crypto-shredding** (per-subject keys; erasure = key destruction, covering backups and immutable logs); anonymize-in-place for FK-heavy erasure (overwrite PII columns, keep the row, tombstone `anonymizedAt`, purge derived copies); RLS keyed on org/region as the residency enforcement primitive when multi-tenant/multi-region arrives.
+| Existing capability on `origin/main` | Design relationship |
+|---|---|
+| Retention registries and batched, dry-run, kill-switched sweep under `apps/web/lib/operate/retention/` | Extend with total disposition coverage, event triggers, holds, evidence, archive, revision caps, and measured partition thresholds. |
+| Route/agent sensitivity and local-only inference gates | Reuse the vocabulary but classify assets and fields separately from routes. |
+| EA data-model mirror, data-architecture steward, code-graph staleness escalation | Feed asset metadata to the ERD and generalize drift/staleness controls. Do not create a second ERD. |
+| `ProjectionContract` for federation egress | Keep its federation boundary. Introduce a typed in-process `DerivedDataContract` for all derived copies, with an adapter to federation contracts. |
+| `Policy`, `PolicyRequirement`, and generic `PolicyRule` models | Keep human policy documents and generic business rules separate from typed executable data policies; connect them by stable policy IDs. |
+| `Principal`/`PrincipalAlias` | Use for canonical identity and alias resolution. Add protected source-observation provenance where MDM needs observation history; an authentication alias is not the whole crosswalk record. |
+| MDM domain registry, `MasterDataSourceRef`, match config, steward queue, merge/unmerge paths, attribute history, TrustAssessment publishing, enrichment, batch scan, and autonomous steward | Govern and extend, but do not assume uniform maturity. Current reversibility and publishing are domain-limited; supplier remains the open domain pilot at the research baseline. |
+| Credential AES-256-GCM helper | Refactor into a reviewed key service; do not copy its development plaintext fallback into personal-data paths. |
+| Compliance obligations, controls, evidence, jurisdiction, and archetype applicability | Consume processing activities and executable policy results instead of duplicating regulation logic in prompts. |
+| `AuthorizationDecisionLog`, `ToolExecutionReceipt`, and other evidence envelopes | Reuse where their semantics fit; add a typed data-policy envelope before adding another generic log table. |
 
-### Anti-patterns identified
+## 6. Architecture
 
-Soft-delete marketed as erasure (EDPB-rejected); a single retention field carrying three regimes; per-agent regulation knowledge in prompts (duplicated, drifting, unauditable — the entire industry direction is centralize-and-enforce, expose-as-context); catalog-only retention metadata; advisory enforcement with silent failure (enforcement without emitted evidence is indistinguishable from no enforcement); physical-asset-bound policies that break on every migration.
-
-**Sources:** OpenMetadata `policy.json`/`rule.json`/`lifeCycle.json` (GitHub, raw); docs.datahub.com (metadata-model, policies, actions, structured-properties); atlas.apache.org (TypeSystem, ClassificationPropagation); learn.microsoft.com/purview (retention, data-lifecycle-management, data-map-classification, dspm-for-ai); Collibra operating-model + retention-policy docs; documentation.immuta.com (subscription/data policies); bigid.com (lifecycle, deletion); SEC 17a-4 analyses (min.io/cohasset, archondatastore); crunchydata + AWS pg_partman archive-then-drop; EDPB pseudonymization guidance analyses.
-
-## 4. Current substrate (verified on origin/main — extend, don't duplicate)
-
-| Exists today | Where | This design's relationship |
-|---|---|---|
-| Declarative retention engine: `PURGE_POLICIES` (19 models), `RETAINED_DATASETS` (40+ regulated, statutory bases), industry floors (banking/professional 7y, healthcare 6y, public 3y), nightly batched sweep, kill switch, dry-run, build-failing regulated-exclusion test | `apps/web/lib/operate/retention/`, spec `2026-06-14-data-retention-lifecycle-governance-design.md` | Extend: new enrollments, revision caps, legal hold, archival, partition strategy (its own §9 slices 3–6) |
-| Route/agent/endpoint sensitivity taxonomy + local-only residency gate in routing | `apps/web/lib/tak/agent-sensitivity.ts`, `routing/pipeline-v2.ts`, `inference/local-only.ts` | Reuse the 4-level taxonomy as the sensitivity axis of the data classification registry; extend gating from provider-selection to storage & context |
-| Prisma→EA data-model mirror + drift steward (`EaConformanceIssue`, self-healing), nightly | `apps/web/lib/ea/data-model-mirror-apply.ts`, `data-architecture-steward-apply.ts`, EP-DATA-ARCH | The classification registry projects into this ERD; new drift detectors (unclassified-model, unenrolled-growth-table) join the steward |
-| Code graph reconciler with the only staleness-escalation pattern (advisory lock, checksum increments, dark-after-N-failures → `PlatformIssueReport`) | `apps/web/lib/integrate/code-graph/` | Template for uniform projection-health escalation |
-| Discovery promotion policy (the richest scope governance: taxonomy-config authority, structural denylists, provenance classifier, confidence gate, self-healing demotion) | `packages/db/src/discovery-promotion-policy.ts` | Template for projection contracts; terminal-skip noise fix already in flight (BI-62846516 / PR #3163) — not re-filed here |
-| Credential encryption (AES-256-GCM envelope, `enc:` format) | `apps/web/lib/govern/credential-crypto.ts` | Extend to a key-hierarchy service with per-subject data keys; fix dev-plaintext fallback + narrow prod guard |
-| Compliance engine (obligation/control/evidence), regulation applicability, jurisdiction capture, BIAN archetypes | `compliance-library.ts`, `regulation-applicability.ts`, `BusinessContext`, EP-GRC-001 specs | Consumes classification; archetype compliance metadata feeds it typed instead of string-matched |
-| Federation egress allowlists (`ProjectionContract.fieldAllowList`, `retentionClass`, `cadaPosture`), edge raw-stays-local boundary | `schema.prisma` federation models, EP-MSP-FEDERATION, EP-SOVEREIGN-SOC | The cross-install precedent for in-install projection contracts; naming aligned |
-| Enforced CI gate pattern with attestation trailers | `scripts/check-spec-plan-doc.mjs`, `scripts/check-ux-fit-decision.mjs` | Data-Impact Gate is the third instance of this proven pattern |
-
-## 5. Architecture — five planes on one spine
-
-```
-                    ┌──────────────────────────────────────────────┐
-                    │  CLASSIFICATION SPINE (plane 0)              │
-                    │  data-classes.ts — every model & sensitive   │
-                    │  field → {category, sensitivity, subjectKind,│
-                    │  lifecycleClass, projectionPolicy,           │
-                    │  residencyClass, regulatoryBases[]}          │
-                    │  Coverage test: unclassified model = red CI  │
-                    └───────┬──────────┬──────────┬───────┬────────┘
-                            │          │          │       │
-             ┌──────────────▼──┐ ┌─────▼─────┐ ┌──▼───────▼─────┐ ┌─────────────────┐
-             │ LIFECYCLE plane │ │ PROJECTION│ │ PROTECTION     │ │ POLICY plane    │
-             │ retention       │ │ plane     │ │ plane          │ │ PDP: MCP tools +│
-             │ registry +      │ │ projection│ │ field crypto,  │ │ archetype       │
-             │ legal holds +   │ │ contracts,│ │ mask-before-   │ │ compliance packs│
-             │ disposition     │ │ deletion  │ │ context, DSAR/ │ │ + Data Steward  │
-             │ evidence +      │ │ propagate,│ │ erasure, hash- │ │ skill — agents  │
-             │ growth observ.  │ │ dark-proj │ │ chained audit  │ │ ask, never know │
-             └─────────────────┘ │ alerts    │ └────────────────┘ └─────────────────┘
-                                 └───────────┘
-             ┌────────────────────────────────────────────────────────────────────┐
-             │ PROCESS plane: Data-Impact Gate (CI) + steward drift detectors     │
-             │ — no future model ships without a classification & lifecycle call  │
-             └────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    A["Logical data-asset inventory"] --> C["Classification and ownership"]
+    A --> M["Master Data Management"]
+    A --> L["Lifecycle and legal holds"]
+    A --> X["Lineage and derived-copy contracts"]
+    A --> P["Purpose and processing activities"]
+    C --> D["Policy Decision Point"]
+    M --> D
+    L --> D
+    X --> D
+    P --> D
+    D --> E["Policy Enforcement Points"]
+    E --> R["Reads, tools, and AI context"]
+    E --> J["Durable operation journal and outbox"]
+    J --> W["Writes and MDM decisions"]
+    J --> Q["Graph, vector, export, and federation"]
+    J --> Z["Retention, erasure, and disposition"]
+    W --> V["Decision and control evidence"]
+    R --> V
+    Q --> V
+    Z --> V
+    V --> O["Data Management workspace and SLOs"]
 ```
 
-### 5.1 Plane 0 — Classification spine (`apps/web/lib/govern/data-classes.ts`)
+### 6.1 Logical asset inventory and separated axes
 
-Code-defined registry (same auditable, drift-free, test-guarded pattern as `PURGE_POLICIES`), one entry per Prisma model:
+The source-controlled registry is the platform default and CI contract. It is composed from focused modules rather than one unmaintainable file:
 
 ```ts
-type DataClassEntry = {
-  model: string;                          // Prisma model name (validated against schema facts)
-  category: DataCategory;                 // closed union: personal-data | customer-content | financial-record |
-                                          // health-adjacent | credential-secret | audit-log | telemetry |
-                                          // knowledge-content | config | master-data | derived-projection
-  sensitivity: RouteSensitivity;          // reuse public|internal|confidential|restricted
-  subjectKind?: "user" | "customer-contact" | "employee" | "counterparty"; // BigID-style subject link for DSAR
-  sensitiveFields?: string[];             // column-level PII/PHI-adjacent fields (masking + encryption targets)
-  lifecycleClass:                          // the G2 total function — every model, an explicit answer
-    | { kind: "purge"; categoryRef: RetentionCategory }        // enrolled in PURGE_POLICIES
-    | { kind: "retained"; basisRef: string }                   // RETAINED_DATASETS statutory hold
-    | { kind: "revision-capped"; keepLast: number; maxAgeDays: number }
-    | { kind: "bounded-by-entity" }                            // master data, real-world cardinality
-    | { kind: "unbounded-accepted"; rationale: string };       // deliberate, visible, alertable
-  projectionPolicy: {                     // may this data leave Postgres, and in what form?
-    eaGraph: "structure-only" | "forbidden";
-    neo4j: "allowed" | "metadata-only" | "forbidden";
-    embeddings: "allowed" | "masked-only" | "forbidden";
-    federation: "contract-gated" | "forbidden";               // aligns with ProjectionContract
+type DataAssetId = `data:${string}`;
+type DataFieldId = `${DataAssetId}#${string}`;
+
+type DataFieldDefinition = {
+  id: DataFieldId;
+  physicalName: string;
+  resolution: "inherited" | "governed" | "not-applicable";
+  resolutionReason: string;
+  categories?: DataCategory[];
+  sensitivity?: DataSensitivity;
+  subjectRoles?: SubjectLocator[];
+  collectionRule?: "allowed" | "minimize" | "prohibited";
+  protection?: ProtectionProfileKey;
+  purposeCapabilities?: ProcessingPurposeKey[];
+  lifecycleOverride?: LifecycleClassKey;
+  projectionOverride?: ProjectionClass;
+  provenance: ClassificationProvenance;
+};
+
+type DataAssetDefinition = {
+  id: DataAssetId;
+  physical: { prismaModel: string };
+  fields: DataFieldDefinition[];
+  domain: string;
+  ownerRole: string;
+  stewardRole: string;
+  categories: DataCategory[];
+  sensitivity: DataSensitivity;
+  criticality: DataCriticality;
+  subjectLocators: SubjectLocator[];
+  masterDataDomain?: MasterDataDomainKey;
+  lifecycleClass: LifecycleClassKey;
+  purposeCapabilities: ProcessingPurposeKey[];
+  residencyClass: ResidencyClassKey;
+  projectionClass: ProjectionClass;
+  classification: {
+    state: "suggested" | "confirmed";
+    source: "manual" | "inferred" | "propagated";
+    effectiveFrom: string;
   };
-  residencyClass: "local-only" | "sovereign-preferred" | "unrestricted";
-  regulatoryBases?: string[];             // e.g. ["gdpr-art5", "hipaa-164.316", "sec-17a4", "pci-dss-3.2"]
 };
 ```
 
-Enforcement tests (build-failing, like the regulated-exclusion guard): every model in `parsePrismaSchema` facts has exactly one entry; every `lifecycleClass: purge` entry has a matching `PURGE_POLICIES` row and vice versa; every `RETAINED_DATASETS` model is `retained`; `credential-secret` ⇒ `embeddings: "forbidden"`; `restricted` ⇒ `embeddings: "masked-only" | "forbidden"`. Classification **propagates along projection edges** (Atlas pattern): a projection target inherits the strictest source classification unless the contract narrows the payload (structure-only/metadata-only).
+Design rules:
 
-The registry projects into the EA data-model mirror as element properties, so the `/ea/data-model` ERD shows classification + lifecycle per model, and the data-architecture steward gains detectors: `unclassified-model`, `unenrolled-growth-table` (append-only shape detected via schema facts but lifecycleClass missing/unbounded without rationale), `classification-projection-conflict`.
+- Policies bind to logical asset IDs, categories, fields, domains, purposes, and subject types — never only to physical table names.
+- `sensitivity`, `category`, `criticality`, `masterDataDomain`, and `quality` are independent axes. “Customer master” is not a sensitivity and “restricted” is not a retention class.
+- `subjectLocators` is plural and executable. A row can relate to an account, contact, employee, or other subject through different paths.
+- Field facts are generated independently from Prisma; governance annotations are curated. Every Prisma field must resolve to `inherited`, `governed`, or `not-applicable` with a reason and provenance. The coverage test detects new/renamed physical fields while stable logical field IDs preserve policy history.
+- Field-level overrides are required for sensitive, prohibited, encrypted, masked, subject-identifying, and projected fields. Model defaults cover ordinary inherited fields; `not-applicable` is an explicit reviewed decision, never absence.
+- `purposeCapabilities` means purposes the platform implementation can technically support. It is not legal applicability or organization authorization. Active organization-specific purposes come only from confirmed `DataProcessingActivity` records and executable policy.
+- Runtime organization overrides can only narrow use, lengthen an applicable minimum, shorten an optional maximum, or add controls unless an approved, expiring exception authorizes otherwise.
 
-### 5.2 Lifecycle plane (extends EP-DATA-RETENTION)
+Proposed module boundary:
 
-1. **Growth observability first** (you cannot manage what you cannot see): a scheduled collector samples `pg_total_relation_size`/`reltuples` per table into a small time-series (itself purge-enrolled), exports Prometheus metrics, and an admin Data Management surface (report-kit) shows the retention matrix (enrolled/retained/capped/unbounded per the registry), current sizes, growth rates, last-sweep results, and dry-run preview — completing the old spec's Slice 4 with the visibility that was missing.
-2. **Enroll the ranked offenders** with per-table policy decisions: `UserFact` (purge superseded facts after window; active facts are memory, not log), `PortfolioQualityIssue` (purge resolved after 180d), `BacklogItemActivity`, `AdminActivity`, `Activity` (CRM, respecting regulated floors), `IntegrationToolCallLog`, `RouteOutcome`, `ToolExecutionReceipt` + `CoworkerActionEnvelope` + `AgentActionProposal` (align with `ToolExecution` 365d audit window), `EdgeEvent`/`ChangeEvent`/`RemoteAction` (terminal-state-aware), discovery observation streams, `InboundChannelMessage`/`WorkItemMessage` (chat-class 545d), import staging.
-3. **Revision caps**: `keepLast N + maxAge` executor strategy for the 13 revision/snapshot tables (`WikiPageRevision`, `DocumentVersion`, `PromptRevision`, `EaSnapshot`, …) — never dropping the current/published revision.
-4. **Status-aware datasets** (old Slice 3): `TaskRun`/`TaskMessage`/`TaskArtifact`/`DecisionInteraction` purged only in terminal states past window.
-5. **Legal hold + disposition evidence** (G3): `LegalHold` model (scope = classification categories and/or subject; suspends all disposition; operator-gated create/release, both audited) checked by the sweep before any delete; `DispositionRecord` evidence rows (what, why, policy, count, checksum) emitted by every destructive action — enforcement without evidence is indistinguishable from no enforcement.
-6. **Archival tier** (old Slice 5): export-then-delete (compressed, checksummed, to the backup volume location) for categories marked archival; restore path documented.
-7. **Partition-drop strategy** (old Slice 6): registry gains per-policy `strategy: "delete" | "partition-drop"`; the top event streams migrate to native range partitions once size thresholds trip (observability from #1 tells us when); new append-only tables declare a lifecycle class at the gate so partitioning is a birth decision, not a retrofit.
+```text
+apps/web/lib/govern/data/
+  taxonomy.ts                 # closed types and precedence vocabulary
+  assets.ts                   # logical asset registry and lookup
+  processing-activities.ts    # platform defaults and archetype templates
+  lifecycle-classes.ts        # lifecycle declarations, not executors
+  derived-data-contracts.ts   # graph/vector/cache/export/federation contracts
+  executable-policies.ts      # versioned policy-as-data definitions
+  policy-decision.ts          # pure evaluator
+  policy-enforcement.ts       # reusable PEP adapters
+  control-operation.ts        # durable intent, outbox, checkpoints, recovery
+  coverage.ts                 # schema/registry/contract conformance
+```
 
-### 5.3 Projection plane
+### 6.2 Governance operating model
 
-A `PROJECTION_CONTRACTS` registry (`apps/web/lib/govern/projection-contracts.ts`) — one entry per pipeline family (EA mirror, steward, code graph, 14 SysML parity domains as one family, discovery→portfolio, discovery→Neo4j, entity→Neo4j syncs, 4 Qdrant collections): declared source models, target store, payload class (`structure-only | metadata-only | content`), trigger, deletion-propagation mode, staleness SLA. Enforcement:
+Each data domain has an accountability map:
 
-- **Scope**: contract payload class must satisfy every source model's `projectionPolicy` (build-failing test). Content payloads (embeddings) route through the masking service (§5.4) when any source field is sensitive.
-- **Deletion propagation**: the EA mirror's `mirrorRemoved` tombstone now drives `deleteEaElement`/`deleteEaRelationship` in Neo4j; entity deletes enqueue projection-cleanup events (Neo4j `DETACH DELETE`, Qdrant `deleteVectors`); a weekly orphan-reconciliation job diffs each target store against its source and reports/removes orphans (extending `infra-prune`).
-- **Uniform dark-projection escalation**: generalize the code-graph pattern — every contract records last-success; a shared monitor files/auto-resolves `EaConformanceIssue`/`PlatformIssueReport` when a projection exceeds its staleness SLA. Fire-and-forget stays (Postgres remains authority; projections never fail the caller) but silence no longer does.
-- **Immediate fix (ships first):** Qdrant `agent-memory` gains (a) a storage-time sensitivity gate honoring the already-computed route sensitivity (restricted → skip or mask per policy), and (b) deletion propagation from `AgentMessage`/thread deletion and from the `AgentThread` retention purge handler — closing the loop the retention sweep currently leaves open (vectors outliving purged chat).
+| Role | Accountable decisions | Cannot do alone |
+|---|---|---|
+| Organization data executive / platform administrator | Approves policy classes, risk appetite, high-impact exceptions, and domain ownership | Cannot erase or release holds without recorded authority and preview |
+| Data owner | Accepts quality/lifecycle SLOs, intended purposes, master-data publish contract, and residual risk for a domain | Cannot approve an exception they requested when separation is required |
+| Data Steward coworker | Proposes classifications, resolves ordinary quality tasks, runs safe deterministic remediation, and explains policy | Cannot self-approve high-risk merge, policy exception, identity conflict, or hold release |
+| Data custodian | Implements storage, keys, backups, indexes, projection cleanup, and restoration | Cannot define business purpose or legal basis |
+| Privacy/compliance authority | Approves regulated processing, erasure conflicts, transfers, holds, and exceptions | Cannot silently mutate technical policy without versioned change evidence |
+| Consumer/coworker | Uses data for a declared purpose within policy obligations | Cannot choose its own clearance or bypass the PDP/PEP |
 
-### 5.4 Protection plane
+Governance cadence:
 
-- **Key hierarchy + field encryption**: extend `credential-crypto` into a small key service — master key (existing env) → purpose keys → **per-subject data keys** (stored wrapped, keyed by `subjectKind`+id). Encrypt registry-listed `sensitiveFields` at the application layer (helpers at the model-access seam; Prisma middleware/extension). Crypto-shredding: subject erasure destroys the subject key, invalidating backups and archives without row surgery. Fix the dev-mode plaintext fallback (fail-loud outside `NODE_ENV=development`) and broaden the prod guard beyond `CredentialEntry` counts.
-- **Mask-before-context** (the "masked exposure" requirement): a `maskForContext(payload, {purpose, principal, sensitivityCeiling})` service applied **at context assembly** — coworker prompt building, semantic-memory storage, tool-result shaping — driven by `sensitiveFields` + sensitivity vs. the caller's clearance and declared purpose (Immuta shape: subject attributes × data tags × purpose). Masking is enforcement, not prompt instructions. Outputs inherit source sensitivity (Purview pattern) via the existing envelope/receipt records.
-- **DSAR / erasure**: subject-access export (all rows whose registry entry carries the requesting `subjectKind`+id, via the subject correlation the registry provides) and erasure flows: anonymize-in-place for FK-heavy regulated rows (overwrite `sensitiveFields`, set `anonymizedAt`, retain the skeleton for statutory bases), crypto-shred the subject key, and enumerate **derived-copy targets** (Qdrant vectors, Neo4j nodes, notification rows, caches) from the projection contracts — EDPB-compliant because the contracts make derived copies enumerable. Legal hold blocks erasure with an operator-visible conflict record (GDPR Art. 17(3) exemptions are real; the conflict is surfaced, not silently resolved).
-- **Tamper-evident audit**: hash-chain (`prevHash`+`rowHash`) on the audit-class tables (`ToolExecution` receipts, `ComplianceAuditLog`, `SecurityEvent`, `AuthorizationDecisionLog`) with a periodic chain-verification job filing a conformance issue on break — satisfying the SEC 17a-4 audit-trail alternative to WORM with app-level machinery.
+- **On change:** impact analysis, policy simulation, owner/steward approval when risk requires it, versioned effective date, and conformance tests.
+- **Daily:** stale projection, overdue deletion, expiring exception, unowned asset, and critical MDM task detection.
+- **Monthly:** domain quality/lifecycle review and exception burn-down.
+- **Quarterly:** access/purpose, policy, retention, key rotation, and high-risk MDM autonomy review.
+- **Annually or on material change:** processing-activity, regulatory applicability, transfer, and control design review.
 
-### 5.5 Policy plane — so nobody has to know
+Every exception is scoped, justified, approved, time-bounded, tied to compensating controls, and automatically returns to review before expiry. An attestation without owner, expiry, and evidence is not an exception.
 
-- **Archetype compliance packs**: typed `compliancePack` metadata on the archetype registry (applicable regulation refs, default data-sensitivity tier, retention-floor key, PHI/CHD handling flags) replacing runtime string-matching as the *source*; `compliance-library.ts` and `industry-floors.ts` read it. BIAN/healthcare packs authored from the existing spec material.
-- **Policy Decision Point (MCP + in-process)**: consolidated, grant-scoped tools (respecting the ~15-tool local budget — extend existing surfaces where possible): `get_data_policy(model|field, purpose)` → classification, lifecycle, masking requirement, residency, statutory bases, in plain language; `check_data_action(action, target, purpose)` → allow/deny/mask-first with reasons (the door coworkers ask before touching data); DSAR/hold operations behind operator-gated grants. The `dpf-data-architecture-steward` skill extends to steward classification (propose entries for new models — machine-suggest, human-confirm, the OpenMetadata `Suggested/Confirmed` state pair) and the catalog serves as agent-readable context, never as per-agent prompt regulation text.
-- **Operator surface**: the admin Data Management page (§5.2.1) is also where a non-technical operator sees, in plain language, what the platform keeps, protects, and purges — progressive disclosure, report-kit components, UX-fit gated.
+### 6.3 Durable control operations and crash consistency
 
-### 5.6 Process plane — no future regressions
+Every multi-step or consequential data action uses one durable `DataControlOperation` journal. This closes the failure window between mutation and evidence and gives Postgres, Neo4j, Qdrant, archives, exports, backups, and downstream master-data consumers one recovery contract.
 
-- **Data-Impact Gate (CI, enforced)**: `scripts/check-data-impact.mjs` — a PR touching `schema.prisma` migrations/models must either (a) touch `data-classes.ts` with entries for every added/renamed model (the coverage test then validates content), or (b) carry a `Data-Steward-Decision:` trailer explaining why not (e.g., a rename with no data-shape change). Surface-agnostic (reads evidence, not provenance), same contract as the Spec/Plan/Doc and UX-Fit gates. Build Studio agent prompts gain the matching rule so embedded builds comply by construction.
-- **Steward drift detectors** (§5.1) catch what slips past PR review at runtime, self-healing like existing conformance issues.
-- **AGENTS.md §11 addendum** documenting the gate and pointing here (single source of truth).
+An operation persists **intent before mutation** with organization, actor/authority, action, logical assets/fields, purpose, canonical input hash, asset/classification/policy versions, hold-scope revisions, approvals, risk, idempotency key, and requested targets. It then advances through explicit states:
 
-## 6. Epic & backlog mapping
+```text
+planned -> authorized -> executing -> reconciled
+                    \-> partially-complete -> executing | compensating
+                    \-> failed
+compensating -> compensated | partially-complete
+```
 
-- **EP-DATA-RETENTION (reopen)** — lifecycle plane: growth observability + admin surface; ranked enrollments; revision caps; status-aware datasets; legal hold + disposition evidence; archival tier; partition strategy.
-- **EP-DATA-GOVERNANCE (new umbrella)** — classification spine + coverage tests; Data-Impact Gate; agent-memory sensitivity gate + deletion propagation (first ship); projection contracts + orphan reconciliation + dark-projection alerts; field encryption + key hierarchy; mask-before-context; DSAR/erasure; tamper-evident audit; archetype compliance packs; PDP tools + steward skill; docs.
-- **EP-ESTATE-SOVEREIGNTY** — unchanged; consumes `residencyClass` (a linking note added there, no duplicate BIs).
-- Ordering, sizes, and acceptance criteria: see the plan.
+Each target has a durable step/checkpoint (`pending | executing | applied | verified | failed | compensated`) with attempt, cursor, target receipt, error class, and retry time. A source-row mutation and its outbox/checkpoint are written in the same Postgres transaction. External effects are idempotent by operation/step key. Verification, not a successful API response alone, moves a step to `verified`.
 
-## 7. Safety properties
+Rules:
 
-1. Every destructive lifecycle action: backup-ordered, batched, capped, kill-switched, dry-runnable (inherited engine properties) + now hold-checked and evidence-emitting.
-2. Classification/coverage/contract rules are **build-failing tests** — drift cannot merge.
-3. Regulated floors only lengthen; holds only suspend; nothing in this design can shorten a statutory retention.
-4. Masking/encryption are enforcement-layer, never prompt-layer.
-5. Projections remain fire-and-forget for availability, but dark projections escalate within their SLA.
-6. Erasure enumerates derived copies from contracts; crypto-shredding covers what enumeration cannot reach (backups).
-7. All new operator actions (hold create/release, erasure, archival restore) are operator-gated and audited.
+- A side-effecting PEP accepts a one-time authorization bound to the operation, actor authority, action, exact input hash, policy versions, and target PEP. It revalidates current authority and active hold scope immediately before mutation.
+- A crash or timeout resumes from durable checkpoints. It never fabricates a receipt from intended work.
+- Compensation is operation-specific. If a target cannot be compensated or retracted, the operation remains `partially-complete`, blocks a false-success state, and opens a governed case.
+- Terminal evidence is emitted only after target reconciliation. Evidence creation itself is an operation step, so “mutation succeeded but receipt failed” remains recoverable and visible.
+- MDM merge/unmerge, survivorship publish/retract, legal-hold issue/release, archive, disposition, projection cleanup, and subject access/erasure all use this contract.
 
-## 8. Verification
+Existing `AuthorizationDecisionLog`, `ToolExecutionReceipt`, queue functions, and domain audit rows remain evidence/adapters; they do not replace the operation journal because they lack a shared cross-store checkpoint state machine.
 
-Unit: registry coverage/consistency suites, precedence algebra (retention/deletion/hold), masking service, key hierarchy + shredding, chain verification. Runtime-bound (canonical install / shared local-CI lease per AGENTS.md §5): sweep with holds honored + disposition records written; agent-memory gate observed live (restricted route → no raw vector); erasure end-to-end including Qdrant/Neo4j cleanup; admin surface UX; migration applies. Gate: red-team PRs (new model without classification must fail CI; regulated model enrolled for purge must fail).
+### 6.4 Master Data Management plane
 
-## 9. References
+The MDM plane owns **identity, provenance, conformance, quality, resolution, survivorship, and trusted publication** for shared business entities.
 
-- Prior specs this extends: `2026-06-14-data-retention-lifecycle-governance-design.md`, `2026-06-06-data-architecture-self-maintenance-design.md`, `2026-04-30-discovery-portfolio-gap-closure-design.md`, `2026-03-17-shared-memory-vector-db-design.md`, `2026-06-19-estate-sovereignty-governance-design.md`, `2026-03-17-compliance-engine-core-design.md`, `2026-06-09-bian-banking-archetypes-design.md`, `docs/architecture/2026-06-19-cada-cloud-sovereignty-architecture-note.md`.
-- Kernel principles: `data-sovereignty-follows-control`, `one-data-model`, `trust-the-data-spine`, `schema-audit-before-features`, `governance-approves-evidence-not-provenance`, `fix-the-seed-not-the-runtime`.
-- Research sources: §3.
+Maturity is never inferred from the existence of a domain-registry row. Every domain publishes a capability/readiness matrix with `absent | pilot | supported | enforced` for identity, source observation, candidate generation, merge, survivorship, quality, publish, lifecycle, autonomy, and downstream reconciliation. It also declares `reversibilityClass: none | source-only | full`. The matrix is produced from conformance tests and live evidence; supplier remains visibly pilot until its existing rollout BI passes. UI and policy cannot describe a pilot capability as enforced.
+
+1. **Canonical ownership:** domain tables remain the system of record. `MASTER_DATA_DOMAINS` declares the canonical model, stable business identifier, owner, steward, match policy, publish contract, quality SLO, and lifecycle class.
+2. **Crosswalks:** identity-bearing aliases use `PrincipalAlias`, but protected source-observation records carry issuer, observed/last-seen times, evidence/trust, and lifecycle. Non-identity external source links use `MasterDataSourceRef`. A crosswalk is not a second canonical record, and an authentication alias is not sufficient provenance by itself.
+3. **Match and merge are separate decisions:** candidate generation, match classification, merge, and publish each emit their own policy/version/evidence. “Possible duplicate” never means “same entity.” Candidate sets are invalidated or rescored when a contributing source, normalization rule, match config, or canonical version changes. A merge preview binds exact source/canonical versions and fails stale under concurrent change.
+4. **Survivorship is separate from merge:** each mastered attribute selects a strategy such as pinned-human, source-priority, verified-value, recency, completeness, or keep-survivor. Rules explicitly distinguish missing, null, cleared/deleted, invalid, and intentionally blank values. The protected winner receipt records minimized candidate evidence, source crosswalks, rule version, actor, confidence, and time. A human-pinned value cannot be overwritten by a lower-authority automated run.
+5. **Quality is operational:** accuracy/validation, completeness, consistency, uniqueness, freshness, and provenance feed the shared `TrustAssessment`. Threshold failures open or refresh a steward task; they do not merely lower a dashboard score.
+6. **Publishing is a contract:** the published read model carries domain/version, canonical ID, attribute provenance summary, trust assessment, classification, permitted purpose, policy obligations, and `asOf`. Contract rollout declares compatibility window, consumer acknowledgments, reindex/backfill, and cutover. Merge reversal, invalidated source, or policy change can emit a retraction/correction; completion waits for downstream reconciliation.
+7. **Reference data and hierarchies:** codes, replacements, parent-child relationships, source transcodes, effective dates, and deprecations are mastered. Referential changes are versioned and impact-simulated before publish.
+8. **Lifecycle:** source observations, crosswalks, match evidence, steward tasks, tombstones, merge lineage, attribute history, and published copies each have an explicit lifecycle. Legal hold and erasure follow the canonical subject/entity across aliases and source refs.
+9. **Graduated autonomy:** deterministic, low-impact exact matches may auto-link or auto-merge within a per-run cap only when `reversibilityClass` and downstream reconciliation are proven for that domain/action. Fuzzy, conflicting, identity-bearing, regulated, high-value, cross-domain, stale-preview, or limited-reversibility cases require review. Confidence is necessary but never the only risk signal.
+10. **Conformance:** every MDM domain must map to a governed asset, lifecycle class, quality SLO, publish contract, and protection policy. Every MDM write path must use the dedup coverage registry.
+
+This resolves the tension between the earlier “never auto-merge” posture and the current autonomous steward: automation is allowed only by risk-tiered executable policy, is capped, uses the durable operation journal, and is limited to domains where compensation and downstream reconciliation are demonstrated.
+
+### 6.5 Processing activities and executable policy
+
+A `DataProcessingActivity` is the organization-specific record of why data is processed. Archetypes may propose templates, but an accountable owner confirms applicability. Minimum fields:
+
+- stable ID, name, purpose, owner, status, effective/review dates;
+- data asset/category/field scope and subject types;
+- legal/contractual basis references and controller/processor posture where applicable;
+- recipients, destinations, residency/transfer constraints, and derived-copy contracts;
+- lifecycle classes, erasure exceptions, high-risk/DPIA flags, and linked controls/evidence.
+
+Executable data policies are typed, versioned, testable platform rules. Existing `Policy` records remain the human-readable policy documents; a stable link connects the executable rule to its authority and requirement.
+
+```ts
+type DataPolicyInput = {
+  organizationId: string;
+  principal: PrincipalAttributes;
+  action: DataAction;
+  asset: DataAssetId;
+  fields?: DataFieldId[];
+  purpose: ProcessingPurposeKey;
+  environment: EnvironmentAttributes;
+  destination?: DestinationAttributes;
+};
+
+type DataObligation =
+  | { kind: "mask"; fields: DataFieldId[]; profileId: string }
+  | { kind: "encrypt"; fields: DataFieldId[]; protectionProfileId: string }
+  | { kind: "destination"; allowedClasses: DestinationClass[] }
+  | { kind: "log-use"; evidenceClass: string; minimumRetentionClass: string }
+  | { kind: "human-approval"; authorityRole: string; separationOfDuties: boolean }
+  | { kind: "delete-derived-copy"; contractIds: string[]; deadlineSeconds: number }
+  | { kind: "disposition-evidence"; evidenceProfileId: string };
+
+type DataPolicyDecision = {
+  decisionId: string;
+  organizationId: string;
+  inputHash: string;
+  pepKind: DataPepKind;
+  effect: "allow" | "allow-with-obligations" | "review" | "deny";
+  obligations: DataObligation[];
+  matchedPolicyVersions: string[];
+  assetVersion: string;
+  classificationVersion: string;
+  authorityVersion: string;
+  explanationCode: string;
+  issuedAt: string;
+  expiresAt: string;
+  replay: "single-use" | "read-cacheable";
+  cacheKey?: string;
+};
+```
+
+The PDP is a pure in-process evaluator. MCP tools such as `get_data_policy` and `check_data_action` explain and simulate the same evaluator; they are not the security boundary. PEPs enforce decisions at:
+
+- API/server-action writes and high-risk reads;
+- MDM candidate, merge, survivorship, unmerge, and publish actions;
+- coworker context assembly, memory storage, retrieval, and tool-result shaping;
+- Neo4j, Qdrant, cache, export, backup, and federation projections;
+- retention, archival, legal-hold, DSAR, anonymization, and erasure executors.
+
+Unknown or invalid policy context fails closed for restricted data, external destinations, destructive actions, prohibited storage, and identity/regulated MDM cases. Lower-risk ambiguity routes to review; it never silently becomes allow.
+
+Each PEP declares a capability matrix of obligation kinds and profiles it can enforce. CI rejects a policy/PEP combination whose obligations exceed that matrix. A side-effecting decision is single-use, bound to the durable operation and exact input hash, and cannot be replayed for a different actor, target, purpose, destination, or organization. Immediately before mutation the PEP revalidates authority, active holds, policy/classification versions, and operation state to close time-of-check/time-of-use gaps.
+
+Read caching is allowed only with an exact cache key containing organization, principal/authority epoch, action, asset/field/classification versions, purpose, destination, environment class, and policy bundle version. Hold, role, exception, policy, classification, or processing-activity changes advance an invalidation epoch. Destructive and MDM decisions are never served from a reusable cache.
+
+The precedence lattice is explicit and non-waivable: prohibited collection/storage and active preservation constraints are hard constraints; conflict between hard constraints produces `review` and no mutation. Confirmed applicable mandatory authority is evaluated next, followed by consent/contract where applicable, organization policy, and then an approved exception only where the governing authority permits exception. Within the same level, deny/review outranks allow, narrower scope outranks broad scope, and effective-date/version rules are deterministic. Array order never decides policy.
+
+### 6.6 Lifecycle algebra and evidence
+
+Each lifecycle class declares:
+
+- trigger event (`created`, `closed`, `last-active`, `contract-ended`, `subject-request`, or domain event);
+- zero or more retention minima and deletion maxima with authority and scope;
+- operational/archive phases and permitted transformations;
+- disposition action (`delete`, `anonymize`, `aggregate`, `archive`, `partition-drop`, or `review`);
+- hold applicability, exception paths, and evidence requirements.
+
+Evaluation produces dates and conflicts, not one overloaded duration:
+
+```text
+retainUntil       = latest applicable minimum date
+deleteNoLaterThan = earliest applicable maximum date
+eligible          = now >= retainUntil AND no active hold
+conflict          = active obligation cannot satisfy both dates or requested action
+```
+
+An active legal hold blocks routine deletion and anonymization for every matching scope revision. A hold uses append-only revisions and `draft -> issued -> released` state. An authorized urgent issuance becomes effective atomically with its durable operation intent; preview is useful for planned holds but cannot delay preservation. This supports the reasonable-preservation expectation in [Federal Rule of Civil Procedure 37(e)](https://www.law.cornell.edu/rules/frcp/rule_37).
+
+After issuance, scope resolution continues: new aliases, late-arriving records, new derived-copy contracts, and restored data are evaluated against every active revision. Each custodian/store records propagation acknowledgment, matched count/digest, checkpoint, failure, and retry. Overlapping holds are evaluated independently; releasing one cannot release data still matched by another. Release requires the configured authority, a fresh overlap evaluation, downstream acknowledgments, and a durable receipt. Backup restore replays active holds and disposition tombstones before ordinary processing resumes.
+
+If `retainUntil > deleteNoLaterThan`, or an erasure request conflicts with a hold or exemption, the executor does nothing destructive and creates a policy-conflict case. The responsible authority resolves it through a versioned decision.
+
+Every destructive or irreversible action runs through the durable operation journal and writes a disposition receipt containing asset and policy versions, trigger/cutoff, matched hold revisions, target stores, candidate and affected counts, a keyed canonical identifier digest rather than raw sensitive values, archive checksum where relevant, executor, approvals, start/end, per-target failures, and reconciliation result.
+
+Growth observability determines partitioning. Partition migration is allowed only after measured write rate/size, retention-aligned partition key, FK impact, restore procedure, and rehearsal evidence justify its operational cost.
+
+### 6.7 Derived-data and lineage contracts
+
+Every derived copy has a stable `DerivedDataContractId` with:
+
+- source assets/fields and target store/collection;
+- business purpose, owner, processor, destination, and residency;
+- payload class (`structure | metadata | masked-content | content`);
+- transformation/masking and classification propagation rules;
+- trigger, delivery SLO, recovery point, and staleness threshold;
+- lifecycle, source-delete propagation, subject/entity locator, and orphan-reconciliation method;
+- policy versions, schema/contract version, health state, and evidence sink.
+
+The strictest relevant source restriction propagates unless a recorded transform produces a less-identifying output and the PDP authorizes the resulting class. A projection cannot self-declassify. Source deletion emits cleanup work; reconciliation detects missed events. Fire-and-forget availability remains acceptable only when darkness and orphans become visible within the contract SLO.
+
+The first remediation remains semantic memory: restricted turns do not store raw content; confidential content is masked according to field policy; message/thread/lifecycle deletion removes matching vectors; reconciliation proves no orphan remains.
+
+### 6.8 Protection and privacy operations
+
+- **Data minimization first:** prohibit collection/storage where a rule requires it (for example, post-authorization sensitive authentication data). Encryption does not make prohibited storage acceptable.
+- **Envelope encryption by risk:** keys remain outside Postgres and its backups. A key-encryption key wraps data-encryption keys. Scope may be tenant, domain, record, or subject depending cardinality and shared-subject semantics; per-subject keys are used only where one subject boundary is real and recoverable. Tenant separation is cryptographic as well as logical.
+- **Key operations are a lifecycle:** each protection profile defines KEK/DEK owner, availability and recovery objectives, escrow/recovery authority, rotation and retirement, compromise blast radius, revocation, tenant isolation, backup/restore, and destruction evidence. A field family cannot enable enforcement until loss and compromise drills pass.
+- **Migration-safe format:** ciphertext records include algorithm, key ID/version, nonce/tag, and format version. Read-old/write-new, backfill, rotation, restore, and loss drills are designed before field rollout.
+- **Tokenization/search indexes:** deterministic lookup requirements use reviewed tokens or keyed indexes, never raw values or deterministic encryption by default.
+- **Crypto-shredding is defense in depth:** destroying a key can render remaining ciphertext inaccessible, but the erasure receipt must still account for plaintext copies, caches, exports, keys, legal exceptions, and backups.
+- **Mask before context:** typed values are masked before coworker prompts, memory, tool results, previews, logs, and exports according to principal, purpose, field policy, and destination. Prompt instructions are not enforcement.
+- **Evidence is governed data:** history, merge snapshots, candidate evidence, receipts, exports, logs, and disposition records inherit the source field policy. Existing stringified MDM old/new values must migrate to omitted, redacted, tokenized, or separately encrypted representations. Predictable identifiers use canonicalized keyed digests with key ID/rotation, never unsalted hashes presented as privacy.
+- **Subject operations:** DSAR discovery resolves identity through `Principal`/`PrincipalAlias` and relevant MDM crosswalks, queries executable subject locators, follows derived-data contracts, and records completeness. Erasure selects delete, anonymize, detach, restrict, or conflict per asset.
+- **Tamper evidence:** append-only receipts are hash-linked or Merkle-batched and periodically verified, with roots stored in an independent evidence location. This detects mutation; it does not by itself certify SEC 17a-4 compliance.
+
+### 6.9 Forward process and conformance gates
+
+The Data-Impact Gate is content-based, not a “file touched” check.
+
+Rollout uses a **non-growing ratchet**. From the first gate PR, every new or changed persistent surface must satisfy the full contract. Pre-existing gaps are captured once in an immutable generated baseline; each entry names the independently discovered object, owner, risk, remediation BI, and deadline. A baseline gap cannot hide a changed object, cannot be copied to a new object, and cannot grow. Domain waves burn it down to zero. This prevents both a flag-day block on enabling infrastructure and meaningless blanket defaults.
+
+Denominators are generated without consulting the registry being measured: Prisma supplies models/fields, the producer inventory supplies projections, the PEP entry-point registry supplies enforcement points, the destructive-handler registry supplies hold/evidence coverage, and `MASTER_DATA_DOMAINS` supplies MDM domains. A registry cannot declare itself complete.
+
+For any added/changed persistent model, field, migration, projection, AI context source, MDM domain, or lifecycle executor, the PR must include a generated `DataImpactManifest` describing affected logical assets and decisions. CI validates that:
+
+- every changed Prisma model has a stable asset and lifecycle disposition, and every field resolves to inherited/governed/not-applicable with reason/provenance;
+- sensitive/subject/prohibited fields have governed field policy;
+- new master-data domains have ownership, crosswalk, match, quality, lifecycle, and publish contracts;
+- new projections have derived-data contracts and cleanup/reconciliation tests;
+- destructive paths check holds and write disposition evidence;
+- processing purposes and PEP coverage exist where required;
+- executable policies have positive, denial, obligation, unknown-context, precedence, and exception-expiry test vectors.
+
+A structured exception may cover a genuinely temporary gap, but must name scope, accountable approver, rationale, compensating control, expiry, and remediation item. It cannot waive asset/lifecycle coverage for a new persistent model or permit prohibited storage. The Data Steward continuously detects runtime drift after merge.
+
+## 7. Product and information architecture
+
+Create a stable `/admin/data` operational workspace under a top-level Admin → Data Management destination, not under Configuration. The primary persona for the first viewport is the **Data Steward** responsible for daily exceptions and control health. Data owners, custodians, privacy/compliance authorities, and platform administrators receive role-filtered queues and shortcuts to their corresponding view. Keep five peer destinations:
+
+1. **Overview** — attention queue, control health, domain scorecards, expiring exceptions, overdue deletion, stale copies, unowned assets, and MDM work aging.
+2. **Catalog** — searchable logical assets and fields; plain-language classification, owner/steward, purposes, lifecycle, subject links, copies, and an advanced metadata drawer. Deep-link to `/ea/data-model` for ERD/lineage rather than duplicate it.
+3. **Stewardship** — evolve `/admin/data-stewardship`; duplicate/match tasks, survivorship comparison, source crosswalks, value provenance, reference data/hierarchy work, publish preview, and reversible merge/unmerge.
+4. **Lifecycle** — retention and deletion matrix, growth trends, holds, archive, dry-run preview, conflicts, disposition history, and copy cleanup.
+5. **Policy & Privacy** — local subviews for policy simulation, processing activities, protection coverage, exceptions, subject requests, and data-control evidence. Link to `/compliance` for broader obligation/control assurance instead of copying that workspace.
+
+Route migration keeps redirects from `/admin/data-stewardship` and `/admin/reference-data` after equivalent subroutes exist. Existing bookmarks remain valid during transition.
+
+First-viewport UI uses report-kit primitives and no more than five summary cards. Preferred labels are “Needs attention,” “Protected,” “Kept until,” “Copies,” “Owner,” and “Why this decision.” Advanced policy IDs and JSON stay behind progressive disclosure.
+
+Attention queues are role-filtered and never imply a hidden capability is healthy: missing measurement, stale policy, unavailable key service, partial operation, permission denial, and unsupported MDM domain each have an honest degraded state. “Ask Data Steward” opens a preview showing scope, proposed tools/actions, decision authority, and confirmation boundary; it does not silently launch remediation.
+
+Key flows:
+
+- **Confirm classification:** suggested changes → affected-policy preview → confirm/reject → effective version and receipt.
+- **Resolve master record:** compare candidates and source values → see rule/confidence/risk → preview downstream impact → merge/link/distinct → undo path and receipt.
+- **Simulate a data action:** choose principal/action/asset/purpose/destination → see allow/review/deny and obligations → inspect matching policy versions.
+- **Create/release hold:** resolve scope → preview records/copies → approve → verify executor checks; release requires separate authority where configured.
+- **Run lifecycle:** dry-run → conflicts/holds → approve capped batch → reconcile all stores → download evidence.
+- **Subject request:** verify identity → discover canonical and derived copies → review exceptions → export/erase/anonymize → completeness receipt.
+
+All irreversible actions use an in-app dialog, clear scope and consequence, explicit confirmation, and result evidence. Tables and charts include text alternatives, keyboard operation, accessible status text, export, filters, and theme-aware tokens.
+
+UX acceptance uses a fixed safe fixture and the six task scripts above at 1280×720 and 390×844. At least three representative operators who are unfamiliar with the schema attempt the scripts: at least 90% of tasks complete without assistance, zero critical errors trigger or authorize the wrong destructive action, and the median task time is at most three minutes excluding queued execution. All tasks must be keyboard-completable with visible focus, programmatic names/status, chart/table text alternatives, and automated WCAG 2.2 AA checks. Permission, empty, loading, stale, unknown, partial-operation, and failure fixtures are reviewed separately; they cannot masquerade as zero/healthy.
+
+## 8. Metrics and service levels
+
+Hard conformance targets at program exit:
+
+- 100% of Prisma models have a logical asset and lifecycle disposition.
+- 100% of governed sensitive/subject/prohibited fields have field policy.
+- 100% of MDM domains have ownership, quality, lifecycle, dedup coverage, and publish contracts.
+- 100% of destructive lifecycle actions perform a hold check and emit disposition evidence.
+- 100% of content-bearing derived copies have deletion propagation and reconciliation tests.
+- 100% of restricted/external/destructive policy decisions fail closed when required context is unknown.
+
+From the first enabling PR, new/changed-surface coverage is 100% and the legacy gap baseline may only decrease. The workspace reports both numbers separately; it never presents ratchet compliance as whole-estate completion.
+
+Operational SLOs are organization-configurable but must be visible by domain:
+
+- unowned assets, unconfirmed high-risk classifications, and expired exceptions;
+- MDM duplicate rate, task age, auto-decision reversal rate, pinned-value violations, quality dimensions, and publish freshness;
+- table growth, overdue disposition, hold conflicts, archive/restore success, and disposition reconciliation;
+- projection staleness, orphan count, cleanup latency, and failed destination obligations;
+- protected-field/key-version coverage, rotation age, masking failures, and plaintext-detection findings;
+- DSAR discovery completeness, response age, unresolved exceptions, and derived-copy cleanup completion;
+- PDP allow/review/deny/obligation counts and PEP coverage — never raw sensitive values in metrics.
+
+The initial release establishes baselines before setting numeric alert thresholds. CI coverage targets above are immediate, not aspirational.
+
+## 9. Safety properties
+
+1. No destructive lifecycle or subject-rights action runs without dry-run, cap, hold check, authorization, and evidence.
+2. Unknown regulated, restricted, external, prohibited-storage, or destructive policy context never silently allows.
+3. MDM auto-decisions are policy-scoped, reversible, capped, and excluded for high-risk classes.
+4. A source deletion is incomplete until contracted copies reconcile or the failure is visible.
+5. Encryption keys are isolated from the protected data and backups; key loss and recovery are tested before rollout.
+6. Classification changes are versioned and impact-simulated before they alter access, retention, projection, or MDM behavior.
+7. Policy exceptions expire and cannot erase their own audit trail.
+8. Hash chaining is described as tamper evidence, not legal certification.
+9. No agent prompt is the source of regulatory truth or an enforcement point.
+10. Data values never appear in control-health metrics, gate output, hashes-to-display, or ordinary decision explanations.
+11. Consequential cross-store actions cannot report success until their durable operation reaches `reconciled`; partial completion remains visible and retryable.
+12. Governance history and evidence inherit field protection and lifecycle; an audit table is not a license to duplicate plaintext.
+
+## 10. Delivery boundaries and refactoring allocation
+
+This is a program design, not one PR. Each live BI remains independently reviewable; affected acceptance criteria are reconciled through MCP after this revised design is approved.
+
+Approximately **20% of delivery capacity is reserved for architectural refactoring**, primarily:
+
+- replacing a proposed monolithic `data-classes.ts` with the focused module boundary in §6.1;
+- consolidating policy evaluation so MCP, UI, retention, projections, and MDM do not implement separate rule engines;
+- adapting existing MDM domain, trust, crosswalk, and steward services rather than adding parallel concepts;
+- refactoring `/admin/data-stewardship` hand-built status UI into report-kit and the stable `/admin/data` information architecture;
+- introducing common derived-copy health/cleanup adapters rather than one monitor per store;
+- reusing evidence envelopes and existing policy documents where semantics fit, after a schema-overlap audit.
+
+The implementation sequence and exact verification gates are in the companion plan.
+
+## 11. Verification strategy
+
+- **Static conformance:** independently generated Prisma model/field denominators, field-resolution/policy coverage, lifecycle totality, MDM capability matrix, derived-copy contracts, PEP capability matrix, destructive-handler inventory, policy/authority links, ratchet baseline, and gate fixtures.
+- **Decision vectors:** allow, deny, review, parameterized obligations, unsupported obligation/PEP, strict-source propagation, policy/authority/hold invalidation, single-use replay denial, exception expiry, unknown context, conflicting minima/maxima, and active hold.
+- **Durable operations:** crash before/after each mutation/checkpoint/evidence step, duplicate delivery, retry, compensation, non-compensable partial state, stale authorization, and recovery to reconciled without double effect.
+- **MDM:** exact and fuzzy candidates, source-change invalidation, stale/concurrent preview, cross-domain conflict, missing/null/cleared value semantics, pinned survivorship, protected source/value provenance, reversibility classes, publish rollout/retraction/freshness, lifecycle, and high-risk autonomy denial.
+- **Protection:** encryption round trip and rotation, old/new format migration, missing-key fail-loud, mask-before-context, plaintext scanning, and key-loss/restore rehearsal.
+- **Lifecycle:** event dates, minima/maxima conflict, urgent hold issue, append-only scope revision, late-arriving match, overlapping release, propagation failure/retry, restore reapplication, erasure exception, dry-run equivalence, capped batch, archive checksum/restore, partition rehearsal, and disposition reconciliation.
+- **Derived copies:** source delete to Neo4j/Qdrant cleanup, missed-event orphan reconciliation, staleness escalation/recovery, and classification/purpose propagation.
+- **Product UX:** primary tasks at `/admin/data`, accessible dialogs/tables/charts, plain-language comprehension, empty/loading/error/permission states, and deep-link/redirect continuity.
+- **Mutation tests:** remove an asset entry, MDM publish contract, PEP, cleanup handler, hold check, or exception expiry and prove the gate/test fails.
+- **Runtime evidence:** production build, migration application, worker execution, live UX, and cross-store cleanup run only through the canonical install or the leased local-integration CI environment per `AGENTS.md`.
+
+## 12. Decisions and deferred questions
+
+### Decided
+
+- Use a composed logical control spine, not one large registry and not a mutable catalog-first rewrite.
+- Give every Prisma field a stable governed resolution and measure coverage from independently generated source facts.
+- Use a durable intent/outbox/checkpoint journal for consequential cross-store operations.
+- MDM is part of data governance, while canonical business rows remain in domain tables.
+- Use graduated MDM autonomy with human-pinned survivorship protection.
+- Separate PDP decisions from PEP enforcement; MCP tools explain the same evaluator.
+- Treat retention minima, deletion maxima, holds, requests, and exceptions separately; conflicts become cases.
+- Use risk-scoped envelope encryption; do not promise universal per-subject crypto-shredding.
+- Consolidate the operational experience under top-level Admin → Data Management (`/admin/data`) without duplicating EA or compliance workspaces.
+
+### Deferred until measured or legally reviewed
+
+- Which event streams justify physical partition conversion after growth baselines.
+- Exact organization/industry retention durations beyond already verified platform defaults.
+- Which fields need encryption versus tokenization, masking, minimization, or access-only protection.
+- Whether any deployment needs an external PDP or enterprise catalog after the embedded contracts are proven.
+- Formal SEC 17a-4, HIPAA, PCI, GDPR, or other certification/attestation scope for a particular customer.
+
+## 13. Project references
+
+- `docs/superpowers/specs/2026-05-31-master-data-management-alignment-design.md`
+- `docs/superpowers/specs/2026-07-04-mdm-write-time-dedup-and-lifecycle-design.md`
+- `docs/superpowers/plans/2026-06-06-master-data-management-foundation.md`
+- `docs/superpowers/specs/2026-06-14-data-retention-lifecycle-governance-design.md`
+- `docs/superpowers/specs/2026-06-06-data-architecture-self-maintenance-design.md`
+- `docs/superpowers/specs/2026-05-26-graph-data-trust-vector-design.md`
+- `docs/superpowers/specs/2026-06-19-estate-sovereignty-governance-design.md`
+- `docs/superpowers/specs/2026-03-17-compliance-engine-core-design.md`
+- `docs/architecture/context-engineering-standards.md`
+- `apps/web/components/ui/report-kit/README.md`


### PR DESCRIPTION
## Summary

Rev. 2 of the Data Management Governance spec + plan (supersedes the #3185 text in place). The founder review substantially deepened the design; this PR lands the revised text after a validation pass.

**What changed in rev. 2 (founder review):**
- **MDM is a first-class governed plane** over the existing `apps/web/lib/mdm` substrate (readiness matrix, identity source observations, survivorship strategies with pinned-value protection, graduated autonomy, publish/retraction contracts)
- **Stable logical asset identity** (`DataAssetId`/`DataFieldId`) with a total field-resolution contract (inherited/governed/not-applicable + provenance) over the corrected 495-model baseline
- **Purpose axis**: persisted `DataProcessingActivity` records replace compliance string-matching as authority
- **Durable `DataControlOperation` journal** (intent-before-mutation, outbox, per-target checkpoints, compensation) closing the mutation-vs-evidence failure window
- **PDP/PEP architecture** with typed obligations, explicit precedence lattice, fail-closed unknowns, single-use side-effect authorizations
- **Regulatory corrections**: no "retention always wins" slogan — minima/maxima/holds/exceptions evaluate independently and conflicts become governed cases; SAD storage prohibition outranks retention; hash chaining is evidence, not certification
- **Non-growing ratchet** rollout for the Data-Impact Gate (immutable legacy baseline, no flag day, no blanket defaults)
- **`/admin/data` attention-first workspace** with measured usability acceptance (≥90% unaided completion, WCAG 2.2 AA) and a 20% refactoring budget

**Validation pass (this session):**
- All file paths referenced by the plan verified present on `origin/main` `5834e7548`; model count 495 confirmed
- Fixed retired `superpowers:*` skill references → DPF-native equivalents (`dpf-tdd`, `dpf-local-merge-ci-before-push`, `dpf-pr-with-dco`)
- Backlog reconciled via MCP: created **BI-DG-014** (operation journal), **BI-DG-015** (coverage wave 1), **BI-DG-016** (workspace consolidation), **BI-MDM-201..203** (MDM governance under EP-MDM); updated 15 existing BI bodies to rev. 2 scope; plan work-package headings now carry the real IDs

Docs-only change; work capsule WC-450D7558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)