### PR TITLE
feat(govern): gate semantic memory by sensitivity + propagate deletions (BI-DG-001)

### DIFF
--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -2375,6 +2375,10 @@ export async function sendMessage(input: {
       agentId: agent.agentId,
       routeContext: input.routeContext,
       threadId: input.threadId,
+      // BI-DG-001: pass the resolved sensitivity + declared purpose into the
+      // derived-copy write (gate fails closed on restricted, masks confidential).
+      sensitivity: agent.sensitivity,
+      purpose: "coworker-semantic-recall",
       operatingProfileFingerprint: memoryOperatingProfileFingerprint,
     };
     // Skip trivial messages that add noise to semantic search

--- a/apps/web/lib/inference/semantic-memory-cleanup.test.ts
+++ b/apps/web/lib/inference/semantic-memory-cleanup.test.ts
@@ -1,0 +1,139 @@
+// apps/web/lib/inference/semantic-memory-cleanup.test.ts
+// BI-DG-001: deletion propagation + orphan reconciliation for semantic memory.
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  deleteVectors: vi.fn().mockResolvedValue(undefined),
+  scrollPoints: vi.fn().mockResolvedValue([]),
+  QDRANT_COLLECTIONS: {
+    AGENT_MEMORY: "agent-memory",
+    PLATFORM_KNOWLEDGE: "platform-knowledge",
+  },
+}));
+
+describe("purgeConversationVectorsBySource", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("requests vector deletion keyed on the stable thread identifier", async () => {
+    const { scrollPoints, deleteVectors } = await import("@dpf/db");
+    vi.mocked(scrollPoints).mockResolvedValueOnce([
+      { id: 1, payload: { threadId: "thread-1", messageId: "m-1" } },
+    ]);
+
+    const { purgeConversationVectorsBySource } = await import("./semantic-memory-cleanup");
+    const evidence = await purgeConversationVectorsBySource({ threadIds: ["thread-1"] });
+
+    const expectedFilter = { should: [{ key: "threadId", match: { any: ["thread-1"] } }] };
+    expect(scrollPoints).toHaveBeenCalledWith("agent-memory", expectedFilter, expect.any(Number));
+    expect(deleteVectors).toHaveBeenCalledWith("agent-memory", expectedFilter);
+    expect(evidence).toMatchObject({
+      collection: "agent-memory",
+      sourceKind: "thread",
+      candidates: 1,
+      removed: 1,
+      failed: 0,
+    });
+  });
+
+  it("requests deletion keyed on message identifiers", async () => {
+    const { scrollPoints, deleteVectors } = await import("@dpf/db");
+    vi.mocked(scrollPoints).mockResolvedValueOnce([
+      { id: 2, payload: { messageId: "m-2" } },
+    ]);
+
+    const { purgeConversationVectorsBySource } = await import("./semantic-memory-cleanup");
+    const evidence = await purgeConversationVectorsBySource({ messageIds: ["m-2"] });
+
+    const expectedFilter = { should: [{ key: "messageId", match: { any: ["m-2"] } }] };
+    expect(deleteVectors).toHaveBeenCalledWith("agent-memory", expectedFilter);
+    expect(evidence.sourceKind).toBe("message");
+    expect(evidence.removed).toBe(1);
+  });
+
+  it("is idempotent — a second pass finds no candidates and removes nothing", async () => {
+    const { scrollPoints, deleteVectors } = await import("@dpf/db");
+    vi.mocked(scrollPoints)
+      .mockResolvedValueOnce([{ id: 1, payload: { threadId: "thread-1" } }]) // first pass
+      .mockResolvedValueOnce([]); // second pass — already clean
+
+    const { purgeConversationVectorsBySource } = await import("./semantic-memory-cleanup");
+
+    const first = await purgeConversationVectorsBySource({ threadIds: ["thread-1"] });
+    const second = await purgeConversationVectorsBySource({ threadIds: ["thread-1"] });
+
+    expect(first.removed).toBe(1);
+    expect(second.removed).toBe(0);
+    expect(second.failed).toBe(0);
+    // No throw on the repeat; deletion issued only when candidates exist.
+    expect(deleteVectors).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when neither identifier set is provided", async () => {
+    const { scrollPoints, deleteVectors } = await import("@dpf/db");
+    const { purgeConversationVectorsBySource } = await import("./semantic-memory-cleanup");
+
+    const evidence = await purgeConversationVectorsBySource({});
+
+    expect(scrollPoints).not.toHaveBeenCalled();
+    expect(deleteVectors).not.toHaveBeenCalled();
+    expect(evidence.removed).toBe(0);
+  });
+});
+
+describe("reconcileOrphanConversationVectors", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("reports and removes a vector whose source message no longer exists", async () => {
+    const { deleteVectors } = await import("@dpf/db");
+    const { reconcileOrphanConversationVectors } = await import("./semantic-memory-cleanup");
+
+    const evidence = await reconcileOrphanConversationVectors({
+      candidateMessageIds: ["m-live", "m-orphan"],
+      // Only m-live still exists in the source of record.
+      existsResolver: async () => new Set(["m-live"]),
+    });
+
+    expect(evidence.orphanMessageIds).toEqual(["m-orphan"]);
+    expect(evidence.removed).toBe(1);
+    expect(evidence.failed).toBe(0);
+    expect(deleteVectors).toHaveBeenCalledWith("agent-memory", {
+      must: [{ key: "messageId", match: { any: ["m-orphan"] } }],
+    });
+  });
+
+  it("removes nothing when every candidate source still exists (idempotent)", async () => {
+    const { deleteVectors } = await import("@dpf/db");
+    const { reconcileOrphanConversationVectors } = await import("./semantic-memory-cleanup");
+
+    const evidence = await reconcileOrphanConversationVectors({
+      candidateMessageIds: ["m-live"],
+      existsResolver: async () => new Set(["m-live"]),
+    });
+
+    expect(evidence.orphanMessageIds).toEqual([]);
+    expect(evidence.removed).toBe(0);
+    expect(deleteVectors).not.toHaveBeenCalled();
+  });
+
+  it("records a failure code without throwing when the existence check fails", async () => {
+    const { reconcileOrphanConversationVectors } = await import("./semantic-memory-cleanup");
+
+    const evidence = await reconcileOrphanConversationVectors({
+      candidateMessageIds: ["m-1"],
+      existsResolver: async () => {
+        throw new Error("db unavailable");
+      },
+    });
+
+    expect(evidence.removed).toBe(0);
+    expect(evidence.failed).toBe(1);
+    expect(evidence.errorCodes).toContain("Error");
+  });
+});

--- a/apps/web/lib/inference/semantic-memory-cleanup.ts
+++ b/apps/web/lib/inference/semantic-memory-cleanup.ts
@@ -15,10 +15,16 @@ import {
   type QdrantFilter,
 } from "@dpf/db";
 
-const AGENT_MEMORY = QDRANT_COLLECTIONS.AGENT_MEMORY;
-
 /** Upper bound on how many candidate points one cleanup/reconcile pass inspects. */
 export const SEMANTIC_MEMORY_SCAN_LIMIT = 5000;
+
+// Read the collection name lazily (inside functions), never at module load: this
+// module is pulled in transitively by the queue barrel, and reading an imported
+// `@dpf/db` value at top level can hit a mocked/circular-init `undefined` and crash
+// unrelated importers before any function runs.
+function agentMemoryCollection(): string {
+  return QDRANT_COLLECTIONS.AGENT_MEMORY;
+}
 
 export type CleanupSourceKind = "message" | "thread" | "orphan-reconcile";
 
@@ -60,6 +66,7 @@ export async function purgeConversationVectorsBySource(params: {
   messageIds?: string[];
   threadIds?: string[];
 }): Promise<CleanupEvidence> {
+  const AGENT_MEMORY = agentMemoryCollection();
   const messageIds = dedupe(params.messageIds);
   const threadIds = dedupe(params.threadIds);
   const sourceKind: CleanupSourceKind = threadIds.length > 0 ? "thread" : "message";
@@ -106,6 +113,7 @@ export async function reconcileOrphanConversationVectors(params: {
   existsResolver: (messageIds: string[]) => Promise<Set<string>>;
   cappedAtScan?: boolean;
 }): Promise<CleanupEvidence & { orphanMessageIds: string[] }> {
+  const AGENT_MEMORY = agentMemoryCollection();
   const candidateMessageIds = dedupe(params.candidateMessageIds);
   const evidence: CleanupEvidence & { orphanMessageIds: string[] } = {
     collection: AGENT_MEMORY,

--- a/apps/web/lib/inference/semantic-memory-cleanup.ts
+++ b/apps/web/lib/inference/semantic-memory-cleanup.ts
@@ -1,0 +1,143 @@
+// apps/web/lib/inference/semantic-memory-cleanup.ts
+// BI-DG-001: deletion propagation + orphan reconciliation for the semantic-memory
+// derived copy. Semantic memory is a projection of coworker conversation
+// (spec §"Derived-data contracts"): a source deletion must remove the matching
+// vectors, and a scheduled reconciliation must detect and remove vectors whose
+// source turn no longer exists ("darkness and orphans become visible within the
+// contract SLO"). Both paths are idempotent and emit bounded evidence — counts and
+// error codes only, never raw content.
+
+import {
+  deleteVectors,
+  scrollPoints,
+  QDRANT_COLLECTIONS,
+  type MatchClause,
+  type QdrantFilter,
+} from "@dpf/db";
+
+const AGENT_MEMORY = QDRANT_COLLECTIONS.AGENT_MEMORY;
+
+/** Upper bound on how many candidate points one cleanup/reconcile pass inspects. */
+export const SEMANTIC_MEMORY_SCAN_LIMIT = 5000;
+
+export type CleanupSourceKind = "message" | "thread" | "orphan-reconcile";
+
+/** Bounded, non-sensitive cleanup evidence (never carries raw content). */
+export interface CleanupEvidence {
+  collection: string;
+  sourceKind: CleanupSourceKind;
+  candidates: number;
+  removed: number;
+  failed: number;
+  errorCodes: string[];
+  /** True when the scan hit SEMANTIC_MEMORY_SCAN_LIMIT and more may remain. */
+  cappedAtScan: boolean;
+}
+
+function dedupe(ids: string[] | undefined): string[] {
+  return ids ? [...new Set(ids.filter((id) => typeof id === "string" && id.length > 0))] : [];
+}
+
+function anyClause(key: string, values: string[]): MatchClause {
+  return { key, match: { any: values } };
+}
+
+function errorCodeOf(err: unknown): string {
+  if (err && typeof err === "object" && "code" in err && typeof err.code === "string") {
+    return err.code;
+  }
+  if (err instanceof Error) return err.name;
+  return "unknown";
+}
+
+/**
+ * Remove semantic-memory vectors for the given source message and/or thread
+ * identifiers. Idempotent: re-running after the vectors are gone finds no
+ * candidates and removes nothing. Deletion is keyed only on stable source
+ * identifiers already present in the payload — no sensitive value is required.
+ */
+export async function purgeConversationVectorsBySource(params: {
+  messageIds?: string[];
+  threadIds?: string[];
+}): Promise<CleanupEvidence> {
+  const messageIds = dedupe(params.messageIds);
+  const threadIds = dedupe(params.threadIds);
+  const sourceKind: CleanupSourceKind = threadIds.length > 0 ? "thread" : "message";
+
+  const evidence: CleanupEvidence = {
+    collection: AGENT_MEMORY,
+    sourceKind,
+    candidates: 0,
+    removed: 0,
+    failed: 0,
+    errorCodes: [],
+    cappedAtScan: false,
+  };
+
+  const should: MatchClause[] = [];
+  if (messageIds.length > 0) should.push(anyClause("messageId", messageIds));
+  if (threadIds.length > 0) should.push(anyClause("threadId", threadIds));
+  if (should.length === 0) return evidence; // nothing requested — idempotent no-op
+
+  const filter: QdrantFilter = { should };
+  try {
+    const candidates = await scrollPoints(AGENT_MEMORY, filter, SEMANTIC_MEMORY_SCAN_LIMIT);
+    evidence.candidates = candidates.length;
+    evidence.cappedAtScan = candidates.length >= SEMANTIC_MEMORY_SCAN_LIMIT;
+    if (candidates.length === 0) return evidence; // already clean — idempotent
+    await deleteVectors(AGENT_MEMORY, filter);
+    evidence.removed = candidates.length;
+  } catch (err) {
+    evidence.failed = evidence.candidates || messageIds.length + threadIds.length;
+    evidence.errorCodes.push(errorCodeOf(err));
+  }
+  return evidence;
+}
+
+/**
+ * Reconcile a set of candidate message identifiers against their live source and
+ * remove the vectors whose source turn no longer exists. `existsResolver` returns
+ * the subset of ids that still exist (injected so this module stays free of a
+ * Postgres dependency and is unit-testable). Idempotent: once orphans are removed a
+ * subsequent pass finds none.
+ */
+export async function reconcileOrphanConversationVectors(params: {
+  candidateMessageIds: string[];
+  existsResolver: (messageIds: string[]) => Promise<Set<string>>;
+  cappedAtScan?: boolean;
+}): Promise<CleanupEvidence & { orphanMessageIds: string[] }> {
+  const candidateMessageIds = dedupe(params.candidateMessageIds);
+  const evidence: CleanupEvidence & { orphanMessageIds: string[] } = {
+    collection: AGENT_MEMORY,
+    sourceKind: "orphan-reconcile",
+    candidates: candidateMessageIds.length,
+    removed: 0,
+    failed: 0,
+    errorCodes: [],
+    cappedAtScan: Boolean(params.cappedAtScan),
+    orphanMessageIds: [],
+  };
+  if (candidateMessageIds.length === 0) return evidence;
+
+  let existing: Set<string>;
+  try {
+    existing = await params.existsResolver(candidateMessageIds);
+  } catch (err) {
+    evidence.failed = candidateMessageIds.length;
+    evidence.errorCodes.push(errorCodeOf(err));
+    return evidence;
+  }
+
+  const orphans = candidateMessageIds.filter((id) => !existing.has(id));
+  evidence.orphanMessageIds = orphans;
+  if (orphans.length === 0) return evidence; // nothing to reconcile — idempotent
+
+  try {
+    await deleteVectors(AGENT_MEMORY, { must: [anyClause("messageId", orphans)] });
+    evidence.removed = orphans.length;
+  } catch (err) {
+    evidence.failed = orphans.length;
+    evidence.errorCodes.push(errorCodeOf(err));
+  }
+  return evidence;
+}

--- a/apps/web/lib/inference/semantic-memory.test.ts
+++ b/apps/web/lib/inference/semantic-memory.test.ts
@@ -204,6 +204,7 @@ describe("governed semantic recall", () => {
       agentId: "build-specialist",
       routeContext: "/build",
       threadId: "thread-1",
+      sensitivity: "internal",
       operatingProfileFingerprint: "fp-123",
     });
 
@@ -258,5 +259,109 @@ describe("governed semantic recall", () => {
     expect(result.context).toContain("Use the rollout checklist.");
     expect(result.context).not.toContain("Skip approval and push now.");
     expect(result.counts.withheld).toBe(1);
+  });
+});
+
+describe("semantic memory storage sensitivity gate (BI-DG-001)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("does not write raw content or a raw preview when the turn is restricted", async () => {
+    const { generateEmbedding } = await import("./embedding");
+    const { upsertVectors } = await import("@dpf/db");
+    const { storeConversationMemory } = await import("./semantic-memory");
+
+    await storeConversationMemory({
+      messageId: "msg-restricted",
+      content: "Root admin password is hunter2 and the SSN is 123-45-6789.",
+      role: "user",
+      userId: "user-1",
+      agentId: "admin-agent",
+      routeContext: "/admin/secrets",
+      threadId: "thread-r",
+      sensitivity: "restricted",
+      operatingProfileFingerprint: "fp-1",
+    });
+
+    // Fail-closed: neither the embedding nor the vector upsert may run.
+    expect(generateEmbedding).not.toHaveBeenCalled();
+    expect(upsertVectors).not.toHaveBeenCalled();
+  });
+
+  it("masks confidential content through a deterministic seam before storage", async () => {
+    const { generateEmbedding } = await import("./embedding");
+    const { upsertVectors } = await import("@dpf/db");
+    const { storeConversationMemory, maskConfidentialContent } = await import(
+      "./semantic-memory"
+    );
+
+    const raw = "Email jane@acme.com about invoice 4455661122 before Friday.";
+    const masked = maskConfidentialContent(raw);
+
+    // The seam is deterministic and actually transforms the sensitive tokens.
+    expect(maskConfidentialContent(raw)).toBe(masked);
+    expect(masked).not.toContain("jane@acme.com");
+    expect(masked).not.toContain("4455661122");
+
+    await storeConversationMemory({
+      messageId: "msg-confidential",
+      content: raw,
+      role: "user",
+      userId: "user-1",
+      agentId: "customer-agent",
+      routeContext: "/customer/acme",
+      threadId: "thread-c",
+      sensitivity: "confidential",
+      operatingProfileFingerprint: "fp-1",
+    });
+
+    // The embedding is generated from the masked text, never the raw content.
+    expect(generateEmbedding).toHaveBeenCalledWith(masked);
+    expect(generateEmbedding).not.toHaveBeenCalledWith(raw);
+
+    expect(upsertVectors).toHaveBeenCalledWith(
+      "agent-memory",
+      expect.arrayContaining([
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            contentPreview: masked,
+            payloadClass: "masked-content",
+            sensitivity: "confidential",
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("preserves raw storage for internal turns and tags the payload class", async () => {
+    const { upsertVectors } = await import("@dpf/db");
+    const { storeConversationMemory } = await import("./semantic-memory");
+
+    await storeConversationMemory({
+      messageId: "msg-internal",
+      content: "Let us reorder the backlog for next sprint.",
+      role: "assistant",
+      userId: "user-1",
+      agentId: "build-specialist",
+      routeContext: "/build",
+      threadId: "thread-i",
+      sensitivity: "internal",
+    });
+
+    expect(upsertVectors).toHaveBeenCalledWith(
+      "agent-memory",
+      expect.arrayContaining([
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            contentPreview: "Let us reorder the backlog for next sprint.",
+            payloadClass: "content",
+            sensitivity: "internal",
+            purpose: "coworker-semantic-recall",
+          }),
+        }),
+      ]),
+    );
   });
 });

--- a/apps/web/lib/inference/semantic-memory.ts
+++ b/apps/web/lib/inference/semantic-memory.ts
@@ -15,6 +15,7 @@ import {
   semanticMemoryErrors,
   semanticMemoryLatency,
 } from "@/lib/metrics";
+import type { RouteSensitivity } from "@/lib/tak/agent-sensitivity";
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -22,6 +23,62 @@ import {
 function extractRouteDomain(routeContext: string): string {
   const seg = routeContext.replace(/^\//, "").split("/")[0];
   return seg || "unknown";
+}
+
+// ─── BI-DG-001: storage-time sensitivity gate ───────────────────────────────
+// Semantic memory is a derived copy of coworker conversation (spec §"Derived-data
+// contracts"): it must not persist raw content whose source route/agent is
+// `restricted`, and `confidential` content passes through a deterministic masking
+// seam before it is embedded or previewed. The declared route/agent sensitivity is
+// supplied by the caller — this module never recomputes a competing sensitivity.
+
+/** Default declared processing purpose for the coworker recall projection. */
+export const SEMANTIC_MEMORY_PURPOSE = "coworker-semantic-recall";
+
+/** Payload class recorded on each stored vector, per the derived-data contract. */
+export type MemoryPayloadClass = "content" | "masked-content";
+
+const KNOWN_SENSITIVITIES: readonly RouteSensitivity[] = [
+  "public",
+  "internal",
+  "confidential",
+  "restricted",
+];
+
+/**
+ * Interim deterministic masking seam for `confidential` content. It is intentionally
+ * conservative and pure (same input → same output) so recall stays stable and the
+ * seam is unit-testable; field-level protection policy (later BIs) replaces the body
+ * without moving the call site. It never introduces randomness or timestamps.
+ */
+export function maskConfidentialContent(content: string): string {
+  return content
+    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "[email]")
+    .replace(/\b[A-Za-z0-9_-]{32,}\b/g, "[token]")
+    .replace(/\d[\d\s().+-]{4,}\d/g, "[number]");
+}
+
+/**
+ * Decide how (or whether) a conversation turn may be stored in the vector index.
+ * Fail-closed: `restricted` — or any value outside the known taxonomy — is blocked
+ * so neither the embedding nor a raw preview reaches the store. `confidential` is
+ * masked; `public`/`internal` preserve prior behavior until field policy lands.
+ */
+export function resolveMemoryStorageDisposition(
+  sensitivity: RouteSensitivity,
+  content: string,
+): { action: "store" | "block"; storedContent: string; payloadClass: MemoryPayloadClass } {
+  if (sensitivity === "restricted" || !KNOWN_SENSITIVITIES.includes(sensitivity)) {
+    return { action: "block", storedContent: "", payloadClass: "content" };
+  }
+  if (sensitivity === "confidential") {
+    return {
+      action: "store",
+      storedContent: maskConfidentialContent(content),
+      payloadClass: "masked-content",
+    };
+  }
+  return { action: "store", storedContent: content, payloadClass: "content" };
 }
 
 // ─── Store Conversation Memory ──────────────────────────────────────────────
@@ -34,11 +91,25 @@ export async function storeConversationMemory(params: {
   agentId: string;
   routeContext: string;
   threadId: string;
+  /** Declared route/agent sensitivity for this turn. Passed in by the caller;
+   *  never recomputed here. Absent/unknown values fail closed (no storage). */
+  sensitivity: RouteSensitivity;
+  /** Declared processing purpose for this derived copy. */
+  purpose?: string;
   operatingProfileFingerprint?: string | null;
 }): Promise<void> {
   const endTimer = semanticMemoryLatency.startTimer({ operation: "store" });
   try {
-    const embedding = await generateEmbedding(params.content);
+    const disposition = resolveMemoryStorageDisposition(params.sensitivity, params.content);
+    if (disposition.action === "block") {
+      // Fail-closed: restricted (or unrecognized) sensitivity never writes raw
+      // content or a raw preview to the vector store. Bounded evidence only.
+      semanticMemoryOps.inc({ operation: "store", status: "blocked" });
+      endTimer();
+      return;
+    }
+
+    const embedding = await generateEmbedding(disposition.storedContent);
     if (!embedding) {
       semanticMemoryOps.inc({ operation: "store", status: "skipped" });
       console.warn("[semantic-memory] store skipped — embedding unavailable");
@@ -58,7 +129,10 @@ export async function storeConversationMemory(params: {
           routeDomain: extractRouteDomain(params.routeContext),
           threadId: params.threadId,
           role: params.role,
-          contentPreview: params.content.slice(0, 300),
+          contentPreview: disposition.storedContent.slice(0, 300),
+          sensitivity: params.sensitivity,
+          payloadClass: disposition.payloadClass,
+          purpose: params.purpose ?? SEMANTIC_MEMORY_PURPOSE,
           operatingProfileFingerprint: params.operatingProfileFingerprint ?? null,
           timestamp: new Date().toISOString(),
         },

--- a/apps/web/lib/operate/retention/policies.ts
+++ b/apps/web/lib/operate/retention/policies.ts
@@ -155,6 +155,17 @@ export const purgeStaleAgentThreads: RetentionCustomPurge = async ({
       // Cascades AgentMessage + AgentAttachment via their onDelete: Cascade FKs.
       prisma.agentThread.deleteMany({ where: { id: { in: ids } } }),
     ]);
+    // BI-DG-001: propagate the source deletion to the derived semantic-memory
+    // vectors. Best-effort — the nightly reconcile sweep is the safety net for any
+    // miss — and never aborts the purge (the source rows are already gone).
+    try {
+      const { purgeConversationVectorsBySource } = await import(
+        "@/lib/inference/semantic-memory-cleanup"
+      );
+      await purgeConversationVectorsBySource({ threadIds: ids });
+    } catch (err) {
+      console.warn("[retention] semantic-memory vector cleanup failed:", err);
+    }
     deleted += threads.length;
     if (threads.length < take) break;
   }

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -252,6 +252,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     runNowEvent: "ops/mdm-steward.requested",
   },
   {
+    jobId: "semantic-memory-reconcile",
+    inngestId: "govern/semantic-memory-reconcile-scheduled",
+    name: "Semantic memory orphan reconciliation",
+    purpose:
+      "BI-DG-001 (EP-DATA-GOVERNANCE): removes agent-memory vectors whose source coworker turn has been purged, so a deleted conversation cannot linger in semantic recall. If it stops, orphaned vectors accumulate and a source deletion is never fully propagated to the derived copy. Editable so an operator can pause or run-now the sweep.",
+    cron: "10 5 * * *",
+    cadence: "Daily at 05:10",
+    category: "editable",
+    tracksRunData: false,
+    runNowEvent: "govern/semantic-memory-reconcile.requested",
+  },
+  {
     jobId: "discovery-prometheus-poll",
     inngestId: "ops/prometheus-poll",
     name: "Discovery: Prometheus poll",

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -74,6 +74,10 @@ import {
   coworkerCertificationRunNow,
 } from "./coworker-certification";
 import { memoryConsolidationNightly } from "./memory-consolidation-nightly";
+import {
+  semanticMemoryReconcileScheduled,
+  semanticMemoryReconcileRequested,
+} from "./semantic-memory-reconcile";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 
 export const scheduledFunctions = [
@@ -120,6 +124,7 @@ export const scheduledFunctions = [
   coworkerCertificationNightly, // EP-COWORKER-LIFECYCLE P2 (BI-DE9CC88B): nightly golden-journey certification of every roster coworker, 04:40
   canonicalImprovementDigest, // BI-8996BBBB: weekly [reference-doc] proposal digest -> canonical-source chore BI
   memoryConsolidationNightly, // BI-907C4327: EP-8C706944 P2 autoDream — nightly batch-dedupe + expire coworker notes / user facts, 04:20
+  semanticMemoryReconcileScheduled, // BI-DG-001: EP-DATA-GOVERNANCE — nightly orphan reconciliation of the semantic-memory derived copy, 04:50 (after retention sweep)
 ];
 
 export const eventFunctions = [
@@ -149,6 +154,7 @@ export const eventFunctions = [
   inngestRetentionSweepRequested, // BI-0AB96FE7: operator "run now" / dry-run for the Inngest retention sweep
   mdmStewardSweepRequested, // EP-4A12A7CB slice 4: Data Steward "run now" / dry-run
   coworkerCertificationRunNow, // EP-COWORKER-LIFECYCLE P2 (BI-DE9CC88B): operator "run now" certification sweep
+  semanticMemoryReconcileRequested, // BI-DG-001: operator "run now" semantic-memory orphan reconciliation
 ];
 
 export const allFunctions = [...scheduledFunctions, ...eventFunctions];

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -124,7 +124,7 @@ export const scheduledFunctions = [
   coworkerCertificationNightly, // EP-COWORKER-LIFECYCLE P2 (BI-DE9CC88B): nightly golden-journey certification of every roster coworker, 04:40
   canonicalImprovementDigest, // BI-8996BBBB: weekly [reference-doc] proposal digest -> canonical-source chore BI
   memoryConsolidationNightly, // BI-907C4327: EP-8C706944 P2 autoDream — nightly batch-dedupe + expire coworker notes / user facts, 04:20
-  semanticMemoryReconcileScheduled, // BI-DG-001: EP-DATA-GOVERNANCE — nightly orphan reconciliation of the semantic-memory derived copy, 04:50 (after retention sweep)
+  semanticMemoryReconcileScheduled, // BI-DG-001: EP-DATA-GOVERNANCE — nightly orphan reconciliation of the semantic-memory derived copy, 05:10 (after retention sweep)
 ];
 
 export const eventFunctions = [

--- a/apps/web/lib/queue/functions/semantic-memory-reconcile.ts
+++ b/apps/web/lib/queue/functions/semantic-memory-reconcile.ts
@@ -1,0 +1,86 @@
+// apps/web/lib/queue/functions/semantic-memory-reconcile.ts
+// BI-DG-001 (EP-DATA-GOVERNANCE): nightly orphan-reconciliation for the
+// semantic-memory derived copy. Retention purges and ad-hoc deletions propagate to
+// the vector store inline (best-effort); this scheduled sweep is the safety net that
+// makes any missed source-delete event visible and removes the orphaned vectors so a
+// purged conversation turn cannot linger in agent memory (spec §"Derived-data
+// contracts": "reconciliation proves no orphan remains"). Idempotent, quiescence-
+// gated, and concurrency-limited to one in-flight run.
+
+import { cron } from "inngest";
+import { prisma, scrollPoints, QDRANT_COLLECTIONS } from "@dpf/db";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import {
+  reconcileOrphanConversationVectors,
+  SEMANTIC_MEMORY_SCAN_LIMIT,
+  type CleanupEvidence,
+} from "@/lib/inference/semantic-memory-cleanup";
+
+/** 04:50 UTC daily — after the 04:00 retention sweep (which purges aged threads). */
+export const SEMANTIC_MEMORY_RECONCILE_CRON = "50 4 * * *";
+export const SEMANTIC_MEMORY_RECONCILE_SCHEDULED_INNGEST_ID =
+  "govern/semantic-memory-reconcile-scheduled";
+export const SEMANTIC_MEMORY_RECONCILE_REQUESTED_EVENT =
+  "govern/semantic-memory-reconcile.requested";
+export const SEMANTIC_MEMORY_RECONCILE_REQUESTED_INNGEST_ID =
+  "govern/semantic-memory-reconcile-requested";
+
+/**
+ * Scroll the agent-memory collection for candidate vectors, then remove any whose
+ * source AgentMessage no longer exists. Returns bounded evidence (counts + error
+ * codes only). The source-existence check is a batched Postgres lookup.
+ */
+export async function runSemanticMemoryReconcile(): Promise<
+  CleanupEvidence & { orphanMessageIds: string[] }
+> {
+  const points = await scrollPoints(
+    QDRANT_COLLECTIONS.AGENT_MEMORY,
+    {},
+    SEMANTIC_MEMORY_SCAN_LIMIT,
+  );
+  const candidateMessageIds = [
+    ...new Set(
+      points
+        .map((p) => String(p.payload["messageId"] ?? ""))
+        .filter((id) => id.length > 0),
+    ),
+  ];
+
+  return reconcileOrphanConversationVectors({
+    candidateMessageIds,
+    cappedAtScan: points.length >= SEMANTIC_MEMORY_SCAN_LIMIT,
+    existsResolver: async (ids) => {
+      const rows = await prisma.agentMessage.findMany({
+        where: { id: { in: ids } },
+        select: { id: true },
+      });
+      return new Set(rows.map((r) => r.id));
+    },
+  });
+}
+
+export const semanticMemoryReconcileScheduled = inngest.createFunction(
+  {
+    id: SEMANTIC_MEMORY_RECONCILE_SCHEDULED_INNGEST_ID,
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron(SEMANTIC_MEMORY_RECONCILE_CRON)],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+    return step.run("semantic-memory-reconcile", async () => runSemanticMemoryReconcile());
+  },
+);
+
+// Operator "run now" trigger (same reconciliation, on demand).
+export const semanticMemoryReconcileRequested = inngest.createFunction(
+  {
+    id: SEMANTIC_MEMORY_RECONCILE_REQUESTED_INNGEST_ID,
+    retries: 1,
+    triggers: [{ event: SEMANTIC_MEMORY_RECONCILE_REQUESTED_EVENT }],
+  },
+  async ({ step }) =>
+    step.run("semantic-memory-reconcile-manual", async () => runSemanticMemoryReconcile()),
+);

--- a/apps/web/lib/queue/functions/semantic-memory-reconcile.ts
+++ b/apps/web/lib/queue/functions/semantic-memory-reconcile.ts
@@ -17,8 +17,9 @@ import {
   type CleanupEvidence,
 } from "@/lib/inference/semantic-memory-cleanup";
 
-/** 04:50 UTC daily — after the 04:00 retention sweep (which purges aged threads). */
-export const SEMANTIC_MEMORY_RECONCILE_CRON = "50 4 * * *";
+/** 05:10 UTC daily — after the 04:00 retention sweep (which purges aged threads),
+ *  clear of the 04:20 memory-consolidation and 04:50 MDM-steward slots. */
+export const SEMANTIC_MEMORY_RECONCILE_CRON = "10 5 * * *";
 export const SEMANTIC_MEMORY_RECONCILE_SCHEDULED_INNGEST_ID =
   "govern/semantic-memory-reconcile-scheduled";
 export const SEMANTIC_MEMORY_RECONCILE_REQUESTED_EVENT =

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -16,7 +16,7 @@ apps/web/components/workbooks/Grid.tsx	1358
 apps/web/instrumentation.test.ts	826
 apps/web/instrumentation.ts	1341
 apps/web/lib/actions/agent-coworker-external.test.ts	867
-apps/web/lib/actions/agent-coworker.ts	2737
+apps/web/lib/actions/agent-coworker.ts	2741
 apps/web/lib/actions/agent-task-scheduler.test.ts	1121
 apps/web/lib/actions/ai-providers.ts	915
 apps/web/lib/actions/build-governed.test.ts	1142


### PR DESCRIPTION
## BI-DG-001 — Gate semantic memory by sensitivity + propagate deletions

First implementation slice of **EP-DATA-GOVERNANCE**, per the founder-approved rev. 2 design
(`docs/superpowers/specs/2026-07-17-data-management-governance-design.md`, §"Derived-data contracts";
plan Task 1). Spec + plan are on `main` via #3190. Branch rebased onto current `origin/main`.

### Problem
`storeConversationMemory` embedded every substantive coworker turn — raw content, a 300‑char raw
preview, and `userId` — into the `agent-memory` vector store with **no sensitivity gate** and **no
deletion path**. Vectors outlived purged chat, and `restricted`/`confidential` content was stored raw
even though the route/agent sensitivity is already computed on the same request.

### What changed
- **Storage-time sensitivity gate** (`semantic-memory.ts`): the caller passes the already‑resolved
  route/agent `sensitivity` + declared `purpose` in (no competing recompute).
  - `restricted` → **fail closed**: no embedding, no vector write.
  - `confidential` → **deterministic interim masking seam** (`maskConfidentialContent`) before embedding
    and preview. Field-level policy (later BIs) replaces the seam body without moving the call site.
  - `public`/`internal` → prior behavior preserved.
  - Payload now records `sensitivity`, `payloadClass` (`content` | `masked-content`), and `purpose`.
- **Deletion propagation + reconciliation** (`semantic-memory-cleanup.ts`):
  - `purgeConversationVectorsBySource({messageIds?, threadIds?})` — idempotent removal keyed on stable
    source identifiers already in the payload; bounded evidence (counts + error codes, never content).
  - `reconcileOrphanConversationVectors(...)` — removes vectors whose source turn no longer exists;
    source-existence is injected so the module stays Postgres-free and unit-testable.
  - Retention thread-purge (`operate/retention/policies.ts`) propagates deletes to the vector copy
    (best-effort; the sweep below is the safety net).
  - Nightly quiescence-gated queue sweep (`queue/functions/semantic-memory-reconcile.ts`, **05:10**) +
    operator "run now"; registered in `queue/functions/index.ts` and `scheduled-jobs/catalog.ts`.
- **Tests**: restricted no-write, confidential deterministic-mask, idempotent purge by source id,
  orphan reconciliation.

### Verification — CI-verified
Local vitest/typecheck could not run in this source-only worktree (shared pnpm store is missing the
`vite`/`next` binaries; no `local-integration-ci` lease this session), so per AGENTS.md §5 / the
worktree doctrine, **CI is the verifier**:

| Required check | Result |
|---|---|
| Typecheck | ✅ pass |
| Unit Tests (packages + web shards 1–4) | ✅ pass |
| Production Build | ✅ pass (green on the two prior identical-source commits; re-running on the catalog commit) |
| DCO | ✅ pass |

Advisory gates green: module-size ratchet, gitleaks, Spec/Plan/Doc (`Process-Spine-Decision:`
attestation), Design Grounding, docs integrity, etc.

**CI caught two real integration issues the missing-`vite` local env could not** (both fixed here):
import-time `@dpf/db` read in the cleanup module crashed barrel importers → now read lazily; new
scheduled cron lacked a `SCHEDULED_JOB_CATALOG` entry (parity drift-guard) → registered, and moved
04:50→05:10 to avoid the MDM-steward collision.

### Governed follow-ups (need an MCP-connected session — could not run here)
The DPF MCP tools were not connected in this non-interactive session, so these governed steps are
**owed** and not yet done:
1. Claim/record the Work Capsule, update **BI-DG-001** status, and `record_execution_evidence` with a
   leased prod-build + runtime exercise (fire-and-forget store path, restricted/confidential, a reconcile pass).
2. Proceed to **BI-DG-002** (composed logical data-control spine) — it unlocks the rest of the epic.

### Known bound (follow-up, not a blocker)
`reconcileOrphanConversationVectors` scans up to `SEMANTIC_MEMORY_SCAN_LIMIT` (5000) points/run with no
cursor; `cappedAtScan` is surfaced in evidence. Adequate for a single-org install where retention
bounds `agent-memory`; add cursor pagination if volume grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
