### PR TITLE
feat(discovery): write IdentityResolutionLog audit rows on rule-resolved matches

### DIFF
--- a/packages/db/src/discovery-normalize.ts
+++ b/packages/db/src/discovery-normalize.ts
@@ -50,6 +50,10 @@ export type NormalizedInventoryEntity = {
   catalogIdentityId?: string | null;
   identityStatus?: string | null;
   identityConfidence?: number | null;
+  // The DiscoveryFingerprintRule that produced the resolution — carried so the
+  // resolution-lineage audit (IdentityResolutionLog, spec §4.1) can point back
+  // at the rule the `improve-fingerprint-rule` coworker skill refines.
+  fingerprintRuleId?: string | null;
   properties: Record<string, unknown>;
 };
 
@@ -162,6 +166,7 @@ function fingerprintAttribution(
     candidateTaxonomy: [],
     evidence: {
       source: "discovery-fingerprint",
+      ruleId: match.ruleId,
       ruleKey: match.ruleKey,
       identityConfidence: match.identityConfidence,
       taxonomyConfidence: match.taxonomyConfidence,
@@ -171,6 +176,9 @@ function fingerprintAttribution(
     catalogIdentityId: match.catalogIdentityId,
     identityStatus: match.catalogIdentityId ? "rule_resolved" : null,
     identityConfidence: match.identityConfidence,
+    // Only carry the rule id when it actually resolved a canonical identity —
+    // an unlinked rule match leaves the lineage FK null (spec §4.1).
+    fingerprintRuleId: match.catalogIdentityId ? match.ruleId : null,
   };
 }
 
@@ -187,6 +195,8 @@ type DerivedAttribution = {
   catalogIdentityId?: string | null;
   identityStatus?: string | null;
   identityConfidence?: number | null;
+  // The matched DiscoveryFingerprintRule id (resolution-lineage audit, spec §4.1).
+  fingerprintRuleId?: string | null;
 };
 
 function mapEntityType(itemType: string): string {
@@ -303,6 +313,7 @@ function normalizeItem(
     catalogIdentityId: attributed.catalogIdentityId ?? null,
     identityStatus: attributed.identityStatus ?? null,
     identityConfidence: attributed.identityConfidence ?? null,
+    fingerprintRuleId: attributed.fingerprintRuleId ?? null,
     providerView: attributed.portfolioSlug ?? "foundational",
     properties: {
       ...(item.attributes ?? {}),

--- a/packages/db/src/discovery-sync.test.ts
+++ b/packages/db/src/discovery-sync.test.ts
@@ -585,4 +585,152 @@ describe("persistBootstrapDiscoveryRun", () => {
       { relationshipKey: "rel:k2", connectId: tupleId },
     ]);
   });
+
+  describe("IdentityResolutionLog audit (spec §4.1)", () => {
+    // A rule-resolved entity fixture: the fingerprint pipeline attributed it to a
+    // CatalogIdentity, so discovery-sync must record the resolution lineage.
+    const ruleResolvedRun = {
+      discoveredItems: [
+        {
+          discoveredKey: "dpf_bootstrap:database:database:pg-primary",
+          sourceKind: "dpf_bootstrap",
+          itemType: "database",
+          name: "pg-primary",
+          externalRef: "database:pg-primary",
+          attributes: {},
+        },
+      ],
+      inventoryEntities: [
+        {
+          entityKey: "database:instance:pg-primary",
+          entityType: "database",
+          name: "pg-primary",
+          discoveredKey: "dpf_bootstrap:database:database:pg-primary",
+          portfolioSlug: "foundational",
+          taxonomyNodeId: "foundational/data/relational_database",
+          attributionStatus: "attributed" as const,
+          attributionMethod: "rule" as const,
+          attributionConfidence: 0.98,
+          attributionEvidence: {
+            source: "discovery-fingerprint",
+            ruleId: "rule-postgres",
+            ruleKey: "postgres_server",
+          },
+          catalogIdentityId: "ci-postgres",
+          identityStatus: "rule_resolved",
+          identityConfidence: 0.98,
+          fingerprintRuleId: "rule-postgres",
+          providerView: "foundational",
+          properties: {},
+        },
+      ],
+      inventoryRelationships: [],
+      softwareEvidence: [],
+    };
+
+    function buildDb(
+      findFirst: () => Promise<{ id: string } | null>,
+      resolutionLogCreates: Array<Record<string, unknown>>,
+    ) {
+      return {
+        $transaction: async <T>(fn: (tx: any) => Promise<T>): Promise<T> => fn({
+          discoveryRun: { create: async () => ({ id: "run-res" }) },
+          inventoryEntity: {
+            findMany: async () => [],
+            upsert: async ({ where }: { where: { entityKey: string } }) => ({
+              id: `entity:${where.entityKey}`,
+              entityKey: where.entityKey,
+            }),
+            updateMany: async () => ({ count: 0 }),
+          },
+          discoveredItem: {
+            create: async ({ data }: { data: { observedKey: string } }) => ({
+              id: `discovered:${data.observedKey}`,
+            }),
+          },
+          discoveredSoftwareEvidence: { upsert: async () => ({}) },
+          inventoryRelationship: {
+            findMany: async () => [],
+            upsert: async () => ({ id: "rel", relationshipKey: "rel" }),
+            updateMany: async () => ({ count: 0 }),
+          },
+          discoveredRelationship: { create: async () => ({}) },
+          portfolioQualityIssue: { findMany: async () => [], upsert: async () => ({}) },
+          identityResolutionLog: {
+            findFirst,
+            create: async ({ data }: { data: Record<string, unknown> }) => {
+              resolutionLogCreates.push(data);
+              return {};
+            },
+          },
+        }),
+      };
+    }
+
+    it("writes a rule resolution-log row on a first-time rule-resolved match", async () => {
+      const resolutionLogCreates: Array<Record<string, unknown>> = [];
+      const db = buildDb(async () => null, resolutionLogCreates);
+
+      await persistBootstrapDiscoveryRun(db, ruleResolvedRun, {
+        runKey: "run-res",
+        sourceSlug: "dpf_bootstrap",
+      }, {
+        projectInventoryEntity: async () => undefined,
+        projectInventoryRelationship: async () => undefined,
+      });
+
+      expect(resolutionLogCreates).toHaveLength(1);
+      expect(resolutionLogCreates[0]).toMatchObject({
+        inventoryEntityId: "entity:database:instance:pg-primary",
+        catalogIdentityId: "ci-postgres",
+        fingerprintRuleId: "rule-postgres",
+        resolutionType: "rule",
+        confidence: 0.98,
+        discoveryRunId: "run-res",
+      });
+    });
+
+    it("does not append a duplicate row when the same resolution already exists", async () => {
+      const resolutionLogCreates: Array<Record<string, unknown>> = [];
+      const db = buildDb(async () => ({ id: "existing-log" }), resolutionLogCreates);
+
+      await persistBootstrapDiscoveryRun(db, ruleResolvedRun, {
+        runKey: "run-res",
+        sourceSlug: "dpf_bootstrap",
+      }, {
+        projectInventoryEntity: async () => undefined,
+        projectInventoryRelationship: async () => undefined,
+      });
+
+      expect(resolutionLogCreates).toHaveLength(0);
+    });
+
+    it("writes no resolution-log row for a heuristic entity with no catalog identity", async () => {
+      const resolutionLogCreates: Array<Record<string, unknown>> = [];
+      const db = buildDb(async () => null, resolutionLogCreates);
+
+      await persistBootstrapDiscoveryRun(db, {
+        ...ruleResolvedRun,
+        inventoryEntities: [
+          {
+            ...ruleResolvedRun.inventoryEntities[0]!,
+            attributionStatus: "needs_review" as const,
+            attributionMethod: "heuristic" as const,
+            catalogIdentityId: null,
+            identityStatus: null,
+            identityConfidence: null,
+            fingerprintRuleId: null,
+          },
+        ],
+      }, {
+        runKey: "run-res",
+        sourceSlug: "dpf_bootstrap",
+      }, {
+        projectInventoryEntity: async () => undefined,
+        projectInventoryRelationship: async () => undefined,
+      });
+
+      expect(resolutionLogCreates).toHaveLength(0);
+    });
+  });
 });

--- a/packages/db/src/discovery-sync.ts
+++ b/packages/db/src/discovery-sync.ts
@@ -89,6 +89,21 @@ type DiscoverySyncTx = {
       update: Record<string, unknown>;
     }): Promise<unknown>;
   };
+  // Resolution-lineage audit (spec §4.1) — one row per NEW rule-resolved identity
+  // for an entity. findFirst is the idempotency guard so a repeated sweep that
+  // re-resolves the same entity→identity does not append a duplicate audit row;
+  // a resolution to a *different* CatalogIdentity does write a fresh lineage row.
+  identityResolutionLog: {
+    findFirst(args: {
+      where: {
+        inventoryEntityId: string;
+        catalogIdentityId: string;
+        resolutionType: string;
+      };
+      select: { id: true };
+    }): Promise<{ id: string } | null>;
+    create(args: { data: Record<string, unknown> }): Promise<unknown>;
+  };
   inventoryRelationship: {
     findMany(args: {
       where?: {
@@ -443,6 +458,37 @@ export async function persistBootstrapDiscoveryRun(
 
       entityIdsByDiscoveredKey.set(entity.discoveredKey, persistedEntity.id);
       entityIdsByEntityKey.set(entity.entityKey, persistedEntity.id);
+
+      // Resolution-lineage audit (spec §4.1). A deterministic fingerprint-rule
+      // match that resolved a CatalogIdentity writes an IdentityResolutionLog
+      // row (resolutionType='rule'). Idempotent: only the first resolution of
+      // this entity→identity is recorded, so a weekly re-sweep of an unchanged
+      // estate does not grow the audit log. A later resolution to a different
+      // identity writes a new lineage row. Human-confirmed rows are authored
+      // elsewhere and are never touched by this rule path (spec §4.1).
+      if (entity.catalogIdentityId && entity.identityStatus === "rule_resolved") {
+        const existingLog = await tx.identityResolutionLog.findFirst({
+          where: {
+            inventoryEntityId: persistedEntity.id,
+            catalogIdentityId: entity.catalogIdentityId,
+            resolutionType: "rule",
+          },
+          select: { id: true },
+        });
+        if (existingLog === null) {
+          await tx.identityResolutionLog.create({
+            data: {
+              inventoryEntityId: persistedEntity.id,
+              catalogIdentityId: entity.catalogIdentityId,
+              fingerprintRuleId: entity.fingerprintRuleId ?? null,
+              resolutionType: "rule",
+              confidence: entity.identityConfidence ?? null,
+              evidence: entity.attributionEvidence ?? null,
+              discoveryRunId: run.id,
+            },
+          });
+        }
+      }
 
       if (existed) {
         updatedEntities += 1;

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -66,5 +66,5 @@ apps/web/lib/work-capsules/work-capsule-store.ts	1042
 apps/web/lib/workbooks/platform-tables.ts	938
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace/command-center.ts	1118
-packages/db/src/discovery-sync.ts	837
+packages/db/src/discovery-sync.ts	883
 packages/db/src/wiki-store.test.ts	824


### PR DESCRIPTION
## What

When discovery-sync persists an `InventoryEntity` whose identity was resolved by a deterministic fingerprint rule (`identityStatus='rule_resolved'`), it now writes an **`IdentityResolutionLog`** row (`resolutionType='rule'`, `catalogIdentityId`, `confidence`, `evidence`, `discoveryRunId`) — the resolution lineage the enrich-pipeline design (spec §4.2: *"Writes results … with lineage in `IdentityResolutionLog`"*) deferred.

## Why this shape

- **Append-only audit, idempotent.** `IdentityResolutionLog` is a lineage log with no unique constraint (so no migration). A `findFirst` on `(inventoryEntityId, catalogIdentityId, resolutionType='rule')` guards the `create` so a weekly re-sweep of an unchanged estate does **not** grow the log; a resolution to a *different* `CatalogIdentity` writes a fresh lineage row (real change → real audit row).
- **Rule id threaded** through `discovery-normalize` so the row's `fingerprintRuleId` points back at the rule the estate-specialist `improve-fingerprint-rule` coworker skill refines (spec §4.6).
- **Human-confirmed rows untouched** — this path only ever writes `resolutionType='rule'` (spec §4.1: *"Human-confirmed rows are never overwritten by a rule"*).

## Tests

`packages/db/src/discovery-sync.test.ts` — first resolution writes a row; a duplicate resolution is skipped; a heuristic entity with no catalog identity writes nothing.

## Notes

- Source-only worktree (no local toolchain); CI is the verification gate.
- `scripts/module-size-baseline.txt`: `discovery-sync.ts` 837 → 883 (surgical bump, additive audit write).

Design-Grounding-Decision: BI-27EE2AF7 — completes the pipeline's `IdentityResolutionLog` lineage write (spec §4.2). Spec §4.1/§4.2 = design evidence; `discovery-sync.ts` + `discovery-normalize.ts` = code evidence.

Process-Spine-Decision: extends the existing discovery-sync persistence spine with an audit write; no new module, <120 non-test source lines added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)