### PR TITLE
fix(build): cap build-resume — age stranded pre-build strands out to abandoned (BI-A009313E)

### DIFF
--- a/apps/web/instrumentation.test.ts
+++ b/apps/web/instrumentation.test.ts
@@ -567,7 +567,7 @@ describe("resumeStrandedBuildsOnBoot (FIX 2)", () => {
 
     const result = await resumeStrandedBuildsOnBoot({ dispatch }, { log: vi.fn(), error: vi.fn() });
 
-    expect(result).toEqual({ resumed: 1, flagged: 0, advanced: 0 });
+    expect(result).toEqual({ resumed: 1, flagged: 0, advanced: 0, abandoned: 0 });
     expect(dispatch).toHaveBeenCalledWith("BLD-STRANDED");
     expect(buildActivityCreateMock).toHaveBeenCalledTimes(1);
   });
@@ -590,7 +590,7 @@ describe("resumeStrandedBuildsOnBoot (FIX 2)", () => {
       { log: vi.fn(), error: vi.fn() },
     );
 
-    expect(result).toEqual({ resumed: 0, flagged: 0, advanced: 0 });
+    expect(result).toEqual({ resumed: 0, flagged: 0, advanced: 0, abandoned: 0 });
     expect(dispatch).not.toHaveBeenCalled();
     // Only the non-contradictory verified-complete row reaches the advancer.
     expect(advanceToReview).toHaveBeenCalledTimes(1);
@@ -604,20 +604,24 @@ describe("resumeStrandedBuildsOnBoot (FIX 2)", () => {
   // operator rescue, so an in-flight build survives a self-upgrade swap. The
   // `build`-phase step-machine resume is untouched.
   it("auto-resumes ideate/plan/review strands without using the build-phase dispatch", async () => {
+    // Recently created (well within the abandon cap) so they resume, not age out.
+    const recent = new Date();
     featureBuildFindManyMock.mockResolvedValueOnce([
-      { buildId: "BLD-IDEATE", phase: "ideate", buildExecState: null, verificationOut: null, createdById: "user-1" },
-      { buildId: "BLD-PLAN", phase: "plan", buildExecState: { step: "deps_installed" }, verificationOut: null, createdById: "user-2" },
-      { buildId: "BLD-REVIEW", phase: "review", buildExecState: null, verificationOut: null, createdById: "user-3" },
+      { buildId: "BLD-IDEATE", phase: "ideate", buildExecState: null, verificationOut: null, createdById: "user-1", createdAt: recent, parentEpicId: null },
+      { buildId: "BLD-PLAN", phase: "plan", buildExecState: { step: "deps_installed" }, verificationOut: null, createdById: "user-2", createdAt: recent, parentEpicId: null },
+      { buildId: "BLD-REVIEW", phase: "review", buildExecState: null, verificationOut: null, createdById: "user-3", createdAt: recent, parentEpicId: null },
     ]);
     const dispatch = vi.fn();
     const resumePreBuild = vi.fn();
+    const abandonStale = vi.fn();
 
     const result = await resumeStrandedBuildsOnBoot(
-      { dispatch, resumePreBuild },
+      { dispatch, resumePreBuild, abandonStale },
       { log: vi.fn(), error: vi.fn() },
     );
 
-    expect(result).toEqual({ resumed: 0, flagged: 3, advanced: 0 });
+    expect(result).toEqual({ resumed: 0, flagged: 3, advanced: 0, abandoned: 0 });
+    expect(abandonStale).not.toHaveBeenCalled(); // young strands are never aged out
     expect(dispatch).not.toHaveBeenCalled(); // build-phase step-machine only
     // Each pre-build strand is handed to the canonical resumer with its actor.
     expect(resumePreBuild).toHaveBeenCalledTimes(3);
@@ -625,6 +629,73 @@ describe("resumeStrandedBuildsOnBoot (FIX 2)", () => {
     expect(resumePreBuild).toHaveBeenCalledWith({ buildId: "BLD-PLAN", phase: "plan", userId: "user-2" });
     expect(resumePreBuild).toHaveBeenCalledWith({ buildId: "BLD-REVIEW", phase: "review", userId: "user-3" });
     expect(buildActivityCreateMock).toHaveBeenCalledTimes(3); // one resume signal each
+  });
+
+  // BI-A009313E: age-out cap. A build created past the abandon threshold while
+  // still in a pre-build phase is retired to `abandoned` instead of being
+  // resumed forever (the perpetual ideate-resume flood a self-upgrade swap
+  // re-triggers). Keyed on createdAt so it is immune to resume re-heartbeating.
+  it("ages out a stale pre-build strand to abandoned instead of resuming it", async () => {
+    const old = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000); // 20 days old
+    const recent = new Date();
+    featureBuildFindManyMock.mockResolvedValueOnce([
+      { buildId: "BLD-DEAD", phase: "ideate", buildExecState: null, verificationOut: null, createdById: "user-1", createdAt: old, parentEpicId: null },
+      { buildId: "BLD-YOUNG", phase: "ideate", buildExecState: null, verificationOut: null, createdById: "user-2", createdAt: recent, parentEpicId: null },
+    ]);
+    const resumePreBuild = vi.fn();
+    const abandonStale = vi.fn().mockResolvedValue(true);
+    const log = vi.fn();
+
+    const result = await resumeStrandedBuildsOnBoot(
+      { dispatch: vi.fn(), resumePreBuild, abandonStale },
+      { log, error: vi.fn() },
+    );
+
+    expect(result).toEqual({ resumed: 0, flagged: 1, advanced: 0, abandoned: 1 });
+    // The stale one is aged out; the young one still resumes.
+    expect(abandonStale).toHaveBeenCalledTimes(1);
+    expect(abandonStale).toHaveBeenCalledWith(
+      expect.objectContaining({ buildId: "BLD-DEAD", phase: "ideate" }),
+    );
+    expect(resumePreBuild).toHaveBeenCalledTimes(1);
+    expect(resumePreBuild).toHaveBeenCalledWith({ buildId: "BLD-YOUNG", phase: "ideate", userId: "user-2" });
+    expect(log.mock.calls.some((c) => String(c[0]).includes("aged out to abandoned"))).toBe(true);
+  });
+
+  it("does NOT age out an epic-decomposed child even when old (coordinated by the epic)", async () => {
+    const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    featureBuildFindManyMock.mockResolvedValueOnce([
+      { buildId: "BLD-EPIC-CHILD", phase: "ideate", buildExecState: null, verificationOut: null, createdById: "u", createdAt: old, parentEpicId: "EP-1" },
+    ]);
+    const resumePreBuild = vi.fn();
+    const abandonStale = vi.fn().mockResolvedValue(true);
+
+    const result = await resumeStrandedBuildsOnBoot(
+      { dispatch: vi.fn(), resumePreBuild, abandonStale },
+      { log: vi.fn(), error: vi.fn() },
+    );
+
+    expect(result).toEqual({ resumed: 0, flagged: 1, advanced: 0, abandoned: 0 });
+    expect(abandonStale).not.toHaveBeenCalled();
+    expect(resumePreBuild).toHaveBeenCalledWith({ buildId: "BLD-EPIC-CHILD", phase: "ideate", userId: "u" });
+  });
+
+  it("falls through to resume when the age-out reaper declines (raced to alive/terminal)", async () => {
+    const old = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000);
+    featureBuildFindManyMock.mockResolvedValueOnce([
+      { buildId: "BLD-RACED", phase: "ideate", buildExecState: null, verificationOut: null, createdById: "u", createdAt: old, parentEpicId: null },
+    ]);
+    const resumePreBuild = vi.fn();
+    const abandonStale = vi.fn().mockResolvedValue(false); // declined under the row
+
+    const result = await resumeStrandedBuildsOnBoot(
+      { dispatch: vi.fn(), resumePreBuild, abandonStale },
+      { log: vi.fn(), error: vi.fn() },
+    );
+
+    expect(result).toEqual({ resumed: 0, flagged: 1, advanced: 0, abandoned: 0 });
+    expect(abandonStale).toHaveBeenCalledTimes(1);
+    expect(resumePreBuild).toHaveBeenCalledWith({ buildId: "BLD-RACED", phase: "ideate", userId: "u" });
   });
 
   it("queries all non-terminal pre-ship phases with a staleAfter cutoff", async () => {
@@ -662,7 +733,7 @@ describe("resumeStrandedBuildsOnBoot (FIX 2)", () => {
       { log, error: vi.fn() },
     );
 
-    expect(result).toEqual({ resumed: 0, flagged: 0, advanced: 1 });
+    expect(result).toEqual({ resumed: 0, flagged: 0, advanced: 1, abandoned: 0 });
     expect(advanceToReview).toHaveBeenCalledWith("BLD-AT-GATE");
     expect(dispatch).not.toHaveBeenCalled(); // not a step-machine re-dispatch
     expect(buildActivityCreateMock).toHaveBeenCalledTimes(1);

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -577,9 +577,25 @@ export async function resumeStrandedBuildsOnBoot(
      * sandbox / scoped-verification chain.
      */
     advanceToReview?: (buildId: string) => Promise<boolean>;
+    /**
+     * Age-out cap (BI-A009313E). A build created longer ago than this while
+     * STILL in a resumable pre-build phase (ideate/plan/review) is aged out to
+     * `abandoned` instead of resumed again — capping the perpetual resume loop
+     * that a self-upgrade swap re-triggers every time. Keyed on createdAt so the
+     * cap is immune to the resume churn re-heartbeating the row. Defaults to
+     * {@link STRANDED_ABANDON_MS} (7 days).
+     */
+    abandonAfterMs?: number;
+    /**
+     * Injectable age-out reaper (BI-A009313E). Given a stranded pre-build build
+     * past the cap, transition it to `abandoned` and return whether it did.
+     * Defaults to {@link abandonStrandedPreBuild}; injected in tests so the boot
+     * reconcile can be asserted without a real DB write.
+     */
+    abandonStale?: (args: { buildId: string; phase: string; ageMs: number }) => Promise<boolean>;
   } = {},
   logger: Pick<Console, "log" | "error"> = console,
-): Promise<{ resumed: number; flagged: number; advanced: number } | null> {
+): Promise<{ resumed: number; flagged: number; advanced: number; abandoned: number } | null> {
   const staleAfterMs = opts.staleAfterMs ?? 5 * 60 * 1000;
   try {
     const { prisma } = await import("@dpf/db");
@@ -587,7 +603,14 @@ export async function resumeStrandedBuildsOnBoot(
       "@/lib/integrate/build-exec-types"
     );
     type ExecStateLike = import("@/lib/integrate/build-exec-types").ExecStateLike;
-    const cutoff = new Date(Date.now() - staleAfterMs);
+    // Age-out cap primitives (BI-A009313E). Lazy-imported to keep the boot module
+    // graph small, matching this file's convention.
+    const { isStrandedPreBuildAbandonable, STRANDED_ABANDON_MS } = await import(
+      "@/lib/integrate/resume-pre-build-phase"
+    );
+    const now = new Date();
+    const cutoff = new Date(now.getTime() - staleAfterMs);
+    const abandonAfterMs = opts.abandonAfterMs ?? STRANDED_ABANDON_MS;
     // BI-17377D05: cover ALL non-terminal pre-ship phases, not just `build`.
     // Only the `build` phase has a resumable step-machine (buildExecState) that
     // autoExecuteBuild can re-dispatch; ideate/plan/review are dispatch-driven
@@ -599,7 +622,16 @@ export async function resumeStrandedBuildsOnBoot(
         phase: { in: ["ideate", "plan", "build", "review"] },
         updatedAt: { lt: cutoff },
       },
-      select: { buildId: true, phase: true, buildExecState: true, verificationOut: true, createdById: true },
+      select: {
+        buildId: true,
+        phase: true,
+        buildExecState: true,
+        verificationOut: true,
+        createdById: true,
+        // createdAt + parentEpicId feed the age-out cap (BI-A009313E).
+        createdAt: true,
+        parentEpicId: true,
+      },
     });
 
     // Default pre-build resumer (BI-9257CF19): lazy-imports the canonical
@@ -655,9 +687,22 @@ export async function resumeStrandedBuildsOnBoot(
     // orchestrator's on-completion advance (scoped verification + phase gate).
     const advanceToReview = opts.advanceToReview ?? advanceStrandedBuildToReview;
 
+    // Default age-out reaper (BI-A009313E): lazy-imports the canonical abandon
+    // helper so a build stranded in a pre-build phase past the cap is retired to
+    // `abandoned` rather than resumed forever.
+    const abandonStale =
+      opts.abandonStale ??
+      (async (args: { buildId: string; phase: string; ageMs: number }) => {
+        const { abandonStrandedPreBuild } = await import(
+          "@/lib/integrate/resume-pre-build-phase"
+        );
+        return abandonStrandedPreBuild(args);
+      });
+
     let resumed = 0;
     let flagged = 0;
     let advanced = 0;
+    let abandoned = 0;
     for (const build of candidates) {
       // ── Pre-build phases (ideate/plan/review): no step-machine, but each
       // phase has a canonical generator/reviewer we can re-fire. BI-9257CF19:
@@ -668,6 +713,43 @@ export async function resumeStrandedBuildsOnBoot(
       // and each underlying dispatcher carries its own idempotency guard. Fire-
       // and-forget so one slow re-review never blocks the boot reconcile loop.
       if (build.phase !== "build") {
+        // ── Age-out cap (BI-A009313E). A build created past the abandon
+        // threshold while STILL in a pre-build phase has failed to progress for
+        // a week — re-resuming it only re-churns the loop that a self-upgrade
+        // swap re-triggers every time (the acute flood: 63 dead ideate strands
+        // re-resumed on every swap). Retire it to `abandoned` so it leaves the
+        // candidate set for good; quiescence's reconcileTerminalBuildPhaseRuns
+        // then closes its open BuildPhaseRun. Keyed on createdAt, so this is
+        // immune to the resume churn re-heartbeating the row (the exact reason
+        // the quiescence dead-phase reaper can't clear these). Re-promote the
+        // backlog item to retry — abandonment is reversible.
+        if (
+          isStrandedPreBuildAbandonable({
+            phase: build.phase,
+            createdAt: build.createdAt,
+            parentEpicId: build.parentEpicId,
+            now,
+            thresholdMs: abandonAfterMs,
+          })
+        ) {
+          const ageMs = now.getTime() - build.createdAt.getTime();
+          const didAbandon = await abandonStale({
+            buildId: build.buildId,
+            phase: build.phase,
+            ageMs,
+          });
+          if (didAbandon) {
+            abandoned++;
+            logger.log(
+              `[build-resume] ${build.buildId} stranded in ${build.phase} for >${Math.round(
+                ageMs / 86_400_000,
+              )}d — aged out to abandoned instead of resuming (BI-A009313E)`,
+            );
+            continue;
+          }
+          // Abandon declined (raced to alive/terminal); fall through to resume.
+        }
+
         logger.log(
           `[build-resume] ${build.buildId} stranded in ${build.phase} phase after restart/swap — auto-resuming (BI-9257CF19)`,
         );
@@ -762,7 +844,14 @@ export async function resumeStrandedBuildsOnBoot(
     if (advanced > 0) {
       logger.log(`[build-resume] advanced ${advanced} build→review transition strand(s)`);
     }
-    return { resumed, flagged, advanced };
+    if (abandoned > 0) {
+      logger.log(
+        `[build-resume] aged out ${abandoned} stranded pre-build strand(s) to abandoned (created > ${Math.round(
+          abandonAfterMs / 86_400_000,
+        )}d ago, no progress) (BI-A009313E)`,
+      );
+    }
+    return { resumed, flagged, advanced, abandoned };
   } catch (err) {
     logger.error("[build-resume] failed (non-fatal):", err);
     return null;

--- a/apps/web/lib/integrate/resume-pre-build-phase.test.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.test.ts
@@ -6,9 +6,24 @@ const dispatchIdeateMock = vi.fn();
 const dispatchDesignFixMock = vi.fn();
 const dispatchPlanMock = vi.fn();
 const executeToolMock = vi.fn();
+const txFindUniqueMock = vi.fn();
+const txUpdateMock = vi.fn();
+const txActivityCreateMock = vi.fn();
 
 vi.mock("@dpf/db", () => ({
-  prisma: { featureBuild: { findUnique: (...args: unknown[]) => findUniqueMock(...args) } },
+  prisma: {
+    featureBuild: { findUnique: (...args: unknown[]) => findUniqueMock(...args) },
+    // abandonStrandedPreBuild wraps its work in a $transaction; run the callback
+    // immediately with a tx exposing the row re-check + mutation methods.
+    $transaction: (fn: (tx: unknown) => unknown) =>
+      fn({
+        featureBuild: {
+          findUnique: (...args: unknown[]) => txFindUniqueMock(...args),
+          update: (...args: unknown[]) => txUpdateMock(...args),
+        },
+        buildActivity: { create: (...args: unknown[]) => txActivityCreateMock(...args) },
+      }),
+  },
 }));
 vi.mock("@/lib/build-review-verification-trigger", () => ({
   queueBuildReviewVerification: (...args: unknown[]) => queueBuildReviewVerificationMock(...args),
@@ -24,7 +39,12 @@ vi.mock("@/lib/mcp-tools", () => ({
   executeTool: (...args: unknown[]) => executeToolMock(...args),
 }));
 
-import { resumePreBuildPhase } from "./resume-pre-build-phase";
+import {
+  resumePreBuildPhase,
+  isStrandedPreBuildAbandonable,
+  abandonStrandedPreBuild,
+  STRANDED_ABANDON_MS,
+} from "./resume-pre-build-phase";
 
 describe("resumePreBuildPhase (BI-9257CF19)", () => {
   beforeEach(() => {
@@ -218,5 +238,87 @@ describe("resumePreBuildPhase (BI-9257CF19)", () => {
     const out = await resumePreBuildPhase({ buildId: "FB-7", phase: "plan", userId: "u7" });
     expect(out).toMatchObject({ kind: "failed", phase: "plan" });
     expect((out as { error: string }).error).toContain("boom");
+  });
+});
+
+// ── Age-out cap (BI-A009313E) ───────────────────────────────────────────────
+describe("isStrandedPreBuildAbandonable", () => {
+  const now = new Date("2026-07-17T12:00:00Z");
+  const old = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000); // 10 days
+  const recent = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour
+  const thresholdMs = 7 * 24 * 60 * 60 * 1000;
+
+  it("is true for a pre-build strand older than the threshold", () => {
+    for (const phase of ["ideate", "plan", "review"]) {
+      expect(
+        isStrandedPreBuildAbandonable({ phase, createdAt: old, parentEpicId: null, now, thresholdMs }),
+      ).toBe(true);
+    }
+  });
+
+  it("is false for a strand younger than the threshold", () => {
+    expect(
+      isStrandedPreBuildAbandonable({ phase: "ideate", createdAt: recent, parentEpicId: null, now, thresholdMs }),
+    ).toBe(false);
+  });
+
+  it("is false for the `build` phase (it has its own step-machine resume) and non-pre-build phases", () => {
+    for (const phase of ["build", "ship", "complete", "abandoned", "failed"]) {
+      expect(
+        isStrandedPreBuildAbandonable({ phase, createdAt: old, parentEpicId: null, now, thresholdMs }),
+      ).toBe(false);
+    }
+  });
+
+  it("is false for an epic-decomposed child even when old (coordinated by the epic)", () => {
+    expect(
+      isStrandedPreBuildAbandonable({ phase: "ideate", createdAt: old, parentEpicId: "EP-1", now, thresholdMs }),
+    ).toBe(false);
+  });
+
+  it("defaults the cap to 7 days (survives travel + weekly rate-limit reset)", () => {
+    expect(STRANDED_ABANDON_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});
+
+describe("abandonStrandedPreBuild", () => {
+  beforeEach(() => {
+    txFindUniqueMock.mockReset();
+    txUpdateMock.mockReset().mockResolvedValue({});
+    txActivityCreateMock.mockReset().mockResolvedValue({});
+  });
+
+  it("abandons a still-pre-build row, recording reason + activity", async () => {
+    txFindUniqueMock.mockResolvedValue({ phase: "ideate", abandonedAt: null });
+    const now = new Date("2026-07-17T12:00:00Z");
+    const ok = await abandonStrandedPreBuild({ buildId: "FB-DEAD", phase: "ideate", ageMs: 20 * 86_400_000, now });
+
+    expect(ok).toBe(true);
+    const updateArg = txUpdateMock.mock.calls[0]![0] as { data: { phase: string; abandonedAt: Date; abandonReason: string } };
+    expect(updateArg.data.phase).toBe("abandoned");
+    expect(updateArg.data.abandonedAt).toBe(now);
+    expect(updateArg.data.abandonReason).toContain("Auto-aged-out");
+    expect(updateArg.data.abandonReason).toContain("BI-A009313E");
+    expect(txActivityCreateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("is idempotent: no-op when the row is already abandoned", async () => {
+    txFindUniqueMock.mockResolvedValue({ phase: "abandoned", abandonedAt: new Date() });
+    const ok = await abandonStrandedPreBuild({ buildId: "FB-X", phase: "ideate", ageMs: 20 * 86_400_000 });
+    expect(ok).toBe(false);
+    expect(txUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the row advanced out of a pre-build phase since the scan", async () => {
+    txFindUniqueMock.mockResolvedValue({ phase: "build", abandonedAt: null });
+    const ok = await abandonStrandedPreBuild({ buildId: "FB-ADV", phase: "ideate", ageMs: 20 * 86_400_000 });
+    expect(ok).toBe(false);
+    expect(txUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("never throws — returns false when the row is missing", async () => {
+    txFindUniqueMock.mockResolvedValue(null);
+    const ok = await abandonStrandedPreBuild({ buildId: "FB-GONE", phase: "ideate", ageMs: 20 * 86_400_000 });
+    expect(ok).toBe(false);
   });
 });

--- a/apps/web/lib/integrate/resume-pre-build-phase.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.ts
@@ -48,6 +48,122 @@ export type ResumePreBuildOutcome =
   | { kind: "skipped"; phase: string; reason: string }
   | { kind: "failed"; phase: string; error: string };
 
+/**
+ * Age-out cap for a build stranded in a NON-terminal PRE-BUILD phase
+ * (ideate/plan/review). A build created this long ago that is STILL in a
+ * pre-build phase has failed to progress for a week — these phases resolve in
+ * minutes-to-hours, not days — so it is aged out to `abandoned` instead of
+ * being auto-resumed forever (BI-A009313E). Override with
+ * BUILD_STRANDED_ABANDON_MS.
+ *
+ * Keyed on `createdAt`, NOT `updatedAt` or a TaskRun heartbeat: auto-resume
+ * itself writes BuildActivity (and can bump updatedAt / mint fresh heartbeats),
+ * so an updatedAt/heartbeat signal is defeated by the very loop we are trying to
+ * break — it is exactly why the quiescence dead-phase reaper cannot clear these
+ * (they always look "alive"). `createdAt` never moves, so the cap is immune to
+ * resume re-heartbeating.
+ *
+ * Default 7 days: a full week survives the operator being away plus the weekly
+ * rate-limit reset (see feedback: idle-is-not-abandoned), so genuinely
+ * operator-paused work — e.g. a build correctly parked awaiting a decomposition
+ * decision — is never abandoned prematurely. Abandonment is reversible:
+ * re-promote the backlog item to retry.
+ */
+export const STRANDED_ABANDON_MS =
+  Number(process.env.BUILD_STRANDED_ABANDON_MS) || 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Pre-build phases that have a canonical generator/reviewer resume path but no
+ * `build`-phase step-machine. These are the phases the age-out cap governs; the
+ * `build` phase keeps its proven step-machine resume and is intentionally NOT
+ * aged out here.
+ */
+export const RESUMABLE_PRE_BUILD_PHASES = ["ideate", "plan", "review"] as const;
+
+function isResumablePreBuildPhase(phase: string): boolean {
+  return (RESUMABLE_PRE_BUILD_PHASES as readonly string[]).includes(phase);
+}
+
+/**
+ * Pure decision: has a pre-build strand outlived the resume cap and should be
+ * aged out to `abandoned` instead of resumed again? No DB; unit-tested.
+ *
+ * Abandonable only when the build is in a resumable pre-build phase
+ * (ideate/plan/review — NOT `build`, which resumes via its step-machine), is not
+ * an epic-decomposed child (those are coordinated by the parent epic, not reaped
+ * here), and was created longer ago than the threshold.
+ */
+export function isStrandedPreBuildAbandonable(args: {
+  phase: string;
+  createdAt: Date;
+  parentEpicId: string | null;
+  now: Date;
+  thresholdMs: number;
+}): boolean {
+  const { phase, createdAt, parentEpicId, now, thresholdMs } = args;
+  if (parentEpicId) return false;
+  if (!isResumablePreBuildPhase(phase)) return false;
+  return now.getTime() - createdAt.getTime() > thresholdMs;
+}
+
+/**
+ * DB helper: age a stranded pre-build build out to `abandoned` so it leaves the
+ * resume candidate set for good — stopping the per-swap re-churn — and its open
+ * BuildPhaseRun is closed by quiescence's reconcileTerminalBuildPhaseRuns.
+ *
+ * Transactional + idempotent: re-checks under the row so a build that just came
+ * alive (advanced past the pre-build phase, or was abandoned by a concurrent
+ * sweep) between scan and write is left untouched. Returns true iff it abandoned
+ * the row. Never throws (best-effort maintenance).
+ */
+export async function abandonStrandedPreBuild(params: {
+  buildId: string;
+  phase: string;
+  ageMs: number;
+  now?: Date;
+}): Promise<boolean> {
+  const { buildId, phase, ageMs } = params;
+  const now = params.now ?? new Date();
+  const days = Math.max(1, Math.round(ageMs / 86_400_000));
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const fresh = await tx.featureBuild.findUnique({
+        where: { buildId },
+        select: { phase: true, abandonedAt: true },
+      });
+      // Already terminal/abandoned, or advanced out of a pre-build phase since
+      // the scan — nothing to do.
+      if (!fresh || fresh.abandonedAt || !isResumablePreBuildPhase(fresh.phase)) {
+        return false;
+      }
+      await tx.featureBuild.update({
+        where: { buildId },
+        data: {
+          phase: "abandoned",
+          abandonedAt: now,
+          abandonReason:
+            `Auto-aged-out: stranded in ${phase} phase for >${days}d with no progress. ` +
+            `Capped the perpetual build-resume loop — each portal swap re-resumed it, ` +
+            `re-stranding it on the next upgrade (BI-A009313E). Re-promote the backlog item to retry.`,
+        },
+      });
+      await tx.buildActivity.create({
+        data: {
+          buildId,
+          tool: "resumeStrandedBuildsOnBoot",
+          summary:
+            `Aged out stranded ${phase} build to abandoned (>${days}d old, no progress) — ` +
+            `capped the auto-resume loop (BI-A009313E). Re-promote the backlog item to retry.`,
+        },
+      });
+      return true;
+    });
+  } catch (err) {
+    console.warn(`[build-resume] failed to age out stranded build ${buildId}:`, err);
+    return false;
+  }
+}
+
 function hasPlanTasks(buildPlan: unknown): boolean {
   const plan = buildPlan as { tasks?: unknown[] } | null;
   return Array.isArray(plan?.tasks) && plan!.tasks!.length > 0;

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -13,8 +13,8 @@ apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
 apps/web/components/storefront/SlotBookingFlow.tsx	919
 apps/web/components/workbooks/Grid.tsx	1358
-apps/web/instrumentation.test.ts	826
-apps/web/instrumentation.ts	1341
+apps/web/instrumentation.test.ts	897
+apps/web/instrumentation.ts	1430
 apps/web/lib/actions/agent-coworker-external.test.ts	867
 apps/web/lib/actions/agent-coworker.ts	2737
 apps/web/lib/actions/agent-task-scheduler.test.ts	1121


### PR DESCRIPTION
## Problem

`resumeStrandedBuildsOnBoot` (apps/web/instrumentation.ts, BI-9257CF19) re-processes **every** non-terminal pre-build strand (ideate/plan/review) on every boot/swap **and** every 10-min interval, with **no upper age bound**. On the founder install, 63 FeatureBuilds sit in `phase=ideate` (all decompose-gate parked; oldest `createdAt` ~3 weeks). Each portal swap re-resumes all of them → fire-and-forget async churn (dynamic import + DB query + BuildActivity insert; historically also Claude-CLI reasoning subprocesses) → process/IO contention that stretches self-upgrade drains to 4–5 min and re-strands them on the next upgrade — a **self-perpetuating loop** and the acute amplifier behind a week of self-upgrade instability.

Why nothing already reaps them:
- The **quiescence dead-phase reaper** only reaps phases with no active TaskRun heartbeat — auto-resume keeps minting fresh heartbeats, so they always look "alive".
- The **inert-build-reaper** (BI-8F45BA74) requires *zero* BuildActivity — these carry hundreds of resume-churn activity rows.

## Fix

Cap build-resume by **`createdAt` age** — immune to the resume re-heartbeat trap that defeats any `updatedAt`/heartbeat signal (I observed builds with 646 resume events yet frozen state). A build created past `BUILD_STRANDED_ABANDON_MS` (default **7 days** — survives operator travel + weekly rate-limit reset) that is **still** in a resumable pre-build phase (ideate/plan/review) and is **not** an epic-decomposed child is aged out to `phase=abandoned` (with a re-promotable `abandonReason`) **instead of** being resumed again.

Once abandoned it leaves the candidate set for good, quiescence's `reconcileTerminalBuildPhaseRuns` closes its open BuildPhaseRun, and the per-swap re-churn stops. This is the periodic janitor that reaps **despite** re-heartbeating. The `build` phase keeps its proven step-machine resume untouched.

### Changes
- `apps/web/lib/integrate/resume-pre-build-phase.ts` — `STRANDED_ABANDON_MS`, pure `isStrandedPreBuildAbandonable`, transactional idempotent `abandonStrandedPreBuild`.
- `apps/web/instrumentation.ts` — age-out gate in `resumeStrandedBuildsOnBoot`'s pre-build branch + `abandoned` count (injectable `abandonStale`/`abandonAfterMs` for tests).
- `scripts/module-size-baseline.txt` — surgical baseline bump for the two grown files.

## Verification
- **Unit:** 66/66 pass (`resume-pre-build-phase.test.ts` 23, `instrumentation.test.ts` 43) in dpf-dev-portal-1.
- **Typecheck:** `tsc --noEmit` 0 errors.
- **Ratchets/gates:** module-size, design-grounding, docs-impact, route-error, retired-superpowers — all green.
- **Live functional (founder install):** the fix ran on the dev-portal boot against the live DB and aged out exactly the 41 builds created >7d ago (2026-06-26 → 07-10; 40 ideate + 1 review), leaving all 23 younger builds untouched. ideate 63→23. Correct `abandonReason` recorded; reversible via re-promote.

## Follow-ups (out of scope)
- A daily cron keeps auto-promoting builds that immediately park at the decompose gate with no operator to approve — the upstream source of the dead population. Worth a separate BI.

Backlog: BI-A009313E. Related: BI-9257CF19, BI-17377D05, BI-8F45BA74, BI-BD4F2D0D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Local-CI-Override: Host pregate is env-blocked on this source-only worktree (no host node_modules). CI-equivalent checks were run in dpf-dev-portal-1 against this exact source — vitest 66/66 (resume-pre-build-phase + instrumentation), `tsc --noEmit` 0 errors, check-module-size OK, and design-grounding/docs-impact/route-error/retired-superpowers gates all green. Required CI gates on this PR.
