### PR TITLE
feat(asset-intel): expose enrichment as MCP tools + estate-specialist grants & skills (BI-1D25BC3C)

### DIFF
--- a/apps/web/lib/mcp/packs/discovery-inventory-pack.test.ts
+++ b/apps/web/lib/mcp/packs/discovery-inventory-pack.test.ts
@@ -22,6 +22,8 @@ vi.mock("@/lib/actions/inventory", () => inventory);
 const db = vi.hoisted(() => ({
   DISCOVERY_TRIAGE_AGENT_ID: "agent-discovery-triage",
   prisma: { taxonomyNode: { findFirst: vi.fn() } },
+  enrichDigitalProduct: vi.fn(),
+  requestReEnrichment: vi.fn(),
 }));
 vi.mock("@dpf/db", () => db);
 
@@ -35,6 +37,8 @@ const EXPECTED_TOOLS = [
   "attribute_entity_to_product",
   "dismiss_entity",
   "resolve_portfolio_quality_issue",
+  "enrich_digital_product",
+  "request_re_enrichment",
   "configure_gateway_scan",
 ];
 
@@ -45,6 +49,8 @@ const EXPECTED_GRANTS: Record<string, string[]> = {
   attribute_entity_to_product: ["registry_write"],
   dismiss_entity: ["registry_write"],
   resolve_portfolio_quality_issue: ["registry_write"],
+  enrich_digital_product: ["enrichment_write"],
+  request_re_enrichment: ["enrichment_write"],
   configure_gateway_scan: ["agent_control_read"],
 };
 
@@ -53,7 +59,7 @@ beforeEach(() => {
 });
 
 describe("discovery-inventory pack — registration", () => {
-  it("exposes exactly the seven discovery/inventory tools", () => {
+  it("exposes exactly the nine discovery/inventory tools", () => {
     expect(discoveryInventoryPack.definitions.map((d) => d.name).sort()).toEqual([...EXPECTED_TOOLS].sort());
     expect(Object.keys(discoveryInventoryPack.handlers).sort()).toEqual([...EXPECTED_TOOLS].sort());
   });
@@ -278,6 +284,59 @@ describe("discovery-inventory pack — handler behavior (delegation preserved)",
     expect(noName.error).toBe("missing_name");
     const noUrl = await discoveryInventoryPack.handlers.configure_gateway_scan({ name: "x" }, "u1");
     expect(noUrl.error).toBe("missing_endpoint_url");
+  });
+
+  it("enrich_digital_product requires a digitalProductId", async () => {
+    const res = await discoveryInventoryPack.handlers.enrich_digital_product({}, "u1");
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("missing_digital_product_id");
+  });
+
+  it("enrich_digital_product reports the enrichment summary", async () => {
+    db.enrichDigitalProduct.mockResolvedValue({
+      digitalProductId: "dp-1",
+      enrichmentStatus: "enriched",
+      identitiesEnriched: 2,
+      identitiesFailed: 0,
+      lifecycleMilestonesWritten: 5,
+    });
+    const res = await discoveryInventoryPack.handlers.enrich_digital_product({ digitalProductId: "dp-1" }, "u1");
+    expect(res.success).toBe(true);
+    expect(res.message).toContain("Enriched 2 identities");
+    expect(res.message).toContain("status enriched");
+  });
+
+  it("enrich_digital_product surfaces a missing product", async () => {
+    db.enrichDigitalProduct.mockResolvedValue({
+      digitalProductId: "missing",
+      enrichmentStatus: "failed",
+      identitiesEnriched: 0,
+      identitiesFailed: 0,
+      lifecycleMilestonesWritten: 0,
+    });
+    const res = await discoveryInventoryPack.handlers.enrich_digital_product({ digitalProductId: "missing" }, "u1");
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("digital_product_not_found");
+  });
+
+  it("request_re_enrichment requires a target", async () => {
+    const res = await discoveryInventoryPack.handlers.request_re_enrichment({}, "u1");
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("missing_target");
+  });
+
+  it("request_re_enrichment flags a product for re-enrichment", async () => {
+    db.requestReEnrichment.mockResolvedValue({ flaggedProduct: true, flaggedEntity: false });
+    const res = await discoveryInventoryPack.handlers.request_re_enrichment({ digitalProductId: "dp-1" }, "u1");
+    expect(res.success).toBe(true);
+    expect(res.message).toContain("product dp-1");
+  });
+
+  it("request_re_enrichment reports when nothing was flagged", async () => {
+    db.requestReEnrichment.mockResolvedValue({ flaggedProduct: false, flaggedEntity: false });
+    const res = await discoveryInventoryPack.handlers.request_re_enrichment({ inventoryEntityId: "gone" }, "u1");
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("target_not_found");
   });
 });
 

--- a/apps/web/lib/mcp/packs/discovery-inventory-pack.ts
+++ b/apps/web/lib/mcp/packs/discovery-inventory-pack.ts
@@ -152,6 +152,34 @@ const definitions: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "enrich_digital_product",
+    description: "Run enrichment now for one digital product: resolve the CPE 2.3 identity and endoflife.date support-lifecycle (EOL/EOS) for every CatalogIdentity its inventory entities map to, and stamp the product's enrichmentStatus. Use to refresh a product's support posture on demand instead of waiting for the weekly catalog sweep.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        digitalProductId: { type: "string", description: "DigitalProduct id (cuid) to enrich" },
+      },
+      required: ["digitalProductId"],
+    },
+    requiredCapability: "manage_provider_connections",
+    executionMode: "immediate",
+    sideEffect: true,
+  },
+  {
+    name: "request_re_enrichment",
+    description: "Flag a digital product (or a single inventory entity) for re-enrichment so the next catalog sweep re-resolves its identity + lifecycle. Sets the product's enrichmentStatus back to 'pending' and/or clears the entity's identity resolution. Human-confirmed identities are never overwritten.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        digitalProductId: { type: "string", description: "DigitalProduct id (cuid) to flag for re-enrichment" },
+        inventoryEntityId: { type: "string", description: "InventoryEntity id (cuid) to flag for re-resolution" },
+      },
+      required: [],
+    },
+    requiredCapability: "manage_provider_connections",
+    sideEffect: true,
+  },
+  {
     name: "configure_gateway_scan",
     description: "Create or update a DiscoveryConnection for an ARP/subnet gateway scan so physical LAN segments (e.g. 192.168.x) become visible. Use to resolve gateway_connection_needed issues.",
     inputSchema: {
@@ -300,6 +328,63 @@ async function resolvePortfolioQualityIssueHandler(params: Record<string, unknow
   };
 }
 
+async function enrichDigitalProductHandler(params: Record<string, unknown>): Promise<ToolResult> {
+  const digitalProductId = String(params["digitalProductId"] ?? "").trim();
+  if (!digitalProductId) {
+    return { success: false, message: "digitalProductId is required", error: "missing_digital_product_id" };
+  }
+
+  const { prisma, enrichDigitalProduct } = await import("@dpf/db");
+  const result = await enrichDigitalProduct(
+    // The @dpf/db enrichment module types its prisma surface as a minimal hand-rolled
+    // client (method-shorthand, bivariant); the real client satisfies it structurally.
+    prisma as unknown as Parameters<typeof enrichDigitalProduct>[0],
+    digitalProductId,
+    { eolFetch: fetch, nvdFetch: fetch },
+  );
+  if (result.enrichmentStatus === "failed" && result.identitiesEnriched === 0 && result.identitiesFailed === 0) {
+    return { success: false, message: `Digital product ${digitalProductId} not found`, error: "digital_product_not_found" };
+  }
+  return {
+    success: true,
+    entityId: digitalProductId,
+    message:
+      `Enriched ${result.identitiesEnriched} identit${result.identitiesEnriched === 1 ? "y" : "ies"} ` +
+      `(${result.lifecycleMilestonesWritten} lifecycle milestone${result.lifecycleMilestonesWritten === 1 ? "" : "s"}` +
+      `${result.identitiesFailed > 0 ? `, ${result.identitiesFailed} failed` : ""}); status ${result.enrichmentStatus}.`,
+    data: result as unknown as Record<string, unknown>,
+  };
+}
+
+async function requestReEnrichmentHandler(params: Record<string, unknown>): Promise<ToolResult> {
+  const digitalProductId = typeof params["digitalProductId"] === "string" ? params["digitalProductId"].trim() : "";
+  const inventoryEntityId = typeof params["inventoryEntityId"] === "string" ? params["inventoryEntityId"].trim() : "";
+  if (!digitalProductId && !inventoryEntityId) {
+    return { success: false, message: "Provide digitalProductId or inventoryEntityId", error: "missing_target" };
+  }
+
+  const { prisma, requestReEnrichment } = await import("@dpf/db");
+  const result = await requestReEnrichment(
+    prisma as unknown as Parameters<typeof requestReEnrichment>[0],
+    {
+      ...(digitalProductId ? { digitalProductId } : {}),
+      ...(inventoryEntityId ? { inventoryEntityId } : {}),
+    },
+  );
+  if (!result.flaggedProduct && !result.flaggedEntity) {
+    return { success: false, message: "Target not found — nothing flagged for re-enrichment", error: "target_not_found" };
+  }
+  const flagged = [
+    result.flaggedProduct ? `product ${digitalProductId}` : null,
+    result.flaggedEntity ? `entity ${inventoryEntityId}` : null,
+  ].filter(Boolean).join(" and ");
+  return {
+    success: true,
+    message: `Flagged ${flagged} for re-enrichment; the next catalog sweep will re-resolve it.`,
+    data: result as unknown as Record<string, unknown>,
+  };
+}
+
 async function configureGatewayScanHandler(params: Record<string, unknown>): Promise<ToolResult> {
   const name = String(params["name"] ?? "").trim();
   const endpointUrl = String(params["endpointUrl"] ?? "").trim();
@@ -346,6 +431,8 @@ const handlers: Record<string, ToolPackHandler> = {
   attribute_entity_to_product: (params) => attributeEntityToProductHandler(params),
   dismiss_entity: (params) => dismissEntityHandler(params),
   resolve_portfolio_quality_issue: (params) => resolvePortfolioQualityIssueHandler(params),
+  enrich_digital_product: (params) => enrichDigitalProductHandler(params),
+  request_re_enrichment: (params) => requestReEnrichmentHandler(params),
   configure_gateway_scan: (params) => configureGatewayScanHandler(params),
 };
 
@@ -360,6 +447,8 @@ export const discoveryInventoryPack: ToolPack = {
     attribute_entity_to_product: ["registry_write"],
     dismiss_entity: ["registry_write"],
     resolve_portfolio_quality_issue: ["registry_write"],
+    enrich_digital_product: ["enrichment_write"],
+    request_re_enrichment: ["enrichment_write"],
     configure_gateway_scan: ["agent_control_read"],
   },
 };

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -403,6 +403,12 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   attribute_entity_to_product: ["registry_write"],
   dismiss_entity: ["registry_write"],
   resolve_portfolio_quality_issue: ["registry_write"],
+  // Asset-intelligence enrichment (EP-ASSET-INTELLIGENCE, spec §4.6). A dedicated
+  // finer grant (Pseudo-User Contract direction) so enrichment mutation is scoped
+  // and auditable rather than folded into the broad registry_write — held today by
+  // the estate-specialist (AGT-WS-INVENTORY) via agent_registry.json.
+  enrich_digital_product: ["enrichment_write"],
+  request_re_enrichment: ["enrichment_write"],
   configure_gateway_scan: ["agent_control_read"],
 
   // UX / Page evaluation

--- a/docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md
+++ b/docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md
@@ -87,12 +87,13 @@ Writes results onto `InventoryEntity` / `DigitalProduct` (§4.3), with lineage i
 
 Support-lifecycle signal (`supportStatus`, `updatePosture`, `latestKnownVersion`, `supportEndsAt`) rendered on `/ops/patches` tiles and on the estate + `DigitalProduct` detail pages. EOL/patch findings write into the existing `AssuranceFinding` ledger (`findingKind`: `unsupported-component` = EOL, `missing-patch`) — **no parallel finding table** (respect the EP-ASSURANCE-LEDGER one-substrate rule).
 
-### 4.6 Coworker & skills — extend, don't add a role
+### 4.6 Coworker & skills — extend, don't add a role — **LANDED**
 
-No new AI coworker role is required. The **Digital Product Estate Specialist** (`AGT-WS-INVENTORY`, `estate-specialist` / `inventory-specialist` prompts) already owns the daily Discovery Taxonomy Gap Triage, support posture, and dependency mapping — enrichment is a direct extension of its existing remit. What it needs added:
+No new AI coworker role is required. The **Digital Product Estate Specialist** (`AGT-WS-INVENTORY`, `estate-specialist` / `inventory-specialist` prompts) already owns the daily Discovery Taxonomy Gap Triage, support posture, and dependency mapping — enrichment is a direct extension of its existing remit. What was added (BI-1D25BC3C):
 
-- **Tool grants** on `packages/db/data/agent_registry.json`: `enrich_digital_product`, `request_re_enrichment`, and `contribute_to_hive` (today it has only `portfolio_read`, `registry_read/write`, `backlog_read/write`, `agent_control_read`).
-- **New coworker skills** (2026-04-18 §9.3): `improve-fingerprint-rule` (propose/refine a `FingerprintRule` from a resolution-log entry) and `show-identity-resolution` (show the full `IdentityResolutionLog` lineage for an item). These are named coworker skills, not a new persona.
+- **MCP tools** in the discovery-inventory pack: `enrich_digital_product` (run CPE + endoflife enrichment now for one product's identities and stamp `enrichmentStatus`) and `request_re_enrichment` (flag a product/entity so the next catalog sweep re-resolves it). Backing logic: `packages/db/src/enrich-digital-product.ts` (`enrichCatalogIdentity` / `enrichDigitalProduct` / `requestReEnrichment`).
+- **Tool grants** on `packages/db/data/agent_registry.json`: a dedicated finer grant **`enrichment_write`** (Pseudo-User Contract direction — scoped + auditable, not folded into the broad `registry_write`) gates the two enrich tools and is held by the estate-specialist. `contribute_to_hive` is already authorized for it via its existing `backlog_write` grant.
+- **New coworker skills** (2026-04-18 §9.3): `skills/inventory/improve-fingerprint-rule.skill.md` (propose/refine a `DiscoveryFingerprintRule` from a resolution-log miss) and `skills/inventory/show-identity-resolution.skill.md` (show the full `IdentityResolutionLog` lineage for an item), both `assignTo: inventory-specialist`.
 - **Reuse the existing sharing agent/loop:** the hive-scout agent + `contribute_to_hive` + `run_hive_scout_ingest` + the built device-fingerprint contribution path (`packages/db/src/device-fingerprint-contribution.ts` — `buildFingerprintContribution`/`decideInboundActivation`) already carry the outbound/inbound "hive-mind" loop. Enrichment plugs into it rather than inventing a second one.
 
 ### 4.7 Cross-customer sharing — public vs proprietary (reuse the egress boundary)
@@ -136,7 +137,7 @@ This is the kernel/org-overlay pattern again: component catalog entries are kern
 - SBOM → CatalogIdentity enrichment bridge (component=public, occurrence=private) — **BI-19FD07F9** — bridge **landed** in `packages/db/src/sbom-catalog-bridge.ts` (`parsePurl` + `bomComponentToCatalogIdentity` + `upsertIdentitiesForComponents`: BomComponent PURL → canonical CatalogIdentity, `source='sbom'`; the private `BomComponentOccurrence` graph is untouched). Linking `BomComponent.catalogIdentityId` (needs a migration) is the follow-up.
 
 **Enablement (coworker + sharing):**
-- Estate-specialist enrichment skills + hive-contribution grants + public/proprietary egress classification — **BI-1D25BC3C**
+- Estate-specialist enrichment skills + hive-contribution grants + public/proprietary egress classification — **BI-1D25BC3C** — **LANDED (tools + grants + skills):** `enrich_digital_product` / `request_re_enrichment` MCP tools (backed by `packages/db/src/enrich-digital-product.ts`), a dedicated `enrichment_write` grant on the estate-specialist (`contribute_to_hive` already via `backlog_write`), and the `improve-fingerprint-rule` / `show-identity-resolution` coworker skills. See §4.6.
 
 **Phase C — SAM (roadmap):**
 - License entitlement & compliance (ELP, contracts, true-up) — **BI-E454034B**

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -3218,6 +3218,7 @@
           "agent_control_read",
           "backlog_read",
           "backlog_write",
+          "enrichment_write",
           "file_read",
           "portfolio_read",
           "registry_read",

--- a/packages/db/data/grant_catalog.json
+++ b/packages/db/data/grant_catalog.json
@@ -687,6 +687,17 @@
       "implies": []
     },
     {
+      "key": "enrichment_write",
+      "description": "Run software/asset enrichment on demand — resolve a product's CatalogIdentity CPE + endoflife.date support-lifecycle and flag items for re-enrichment (EP-ASSET-INTELLIGENCE). Scoped finer than registry_write so enrichment mutation is separately auditable.",
+      "category": "explore",
+      "sensitivity": "internal",
+      "honored_by_tools": [
+        "enrich_digital_product",
+        "request_re_enrichment"
+      ],
+      "implies": []
+    },
+    {
       "key": "email_config",
       "description": "Configure the organization's OWN outbound email (SMTP) \u2014 detect provider, save settings, send a test. Operator-gated (manage_provider_connections); DPF never relays mail on the operator's behalf.",
       "category": "integrate",

--- a/packages/db/src/enrich-digital-product.test.ts
+++ b/packages/db/src/enrich-digital-product.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveEolSlug,
+  enrichCatalogIdentity,
+  enrichDigitalProduct,
+  requestReEnrichment,
+  type EnrichDigitalProductClient,
+  type EnrichIdentityRow,
+  type ReEnrichmentClient,
+} from "./enrich-digital-product";
+
+const PG: EnrichIdentityRow = {
+  id: "ci-pg",
+  part: "a",
+  manufacturer: "PostgreSQL",
+  product: "PostgreSQL",
+  productVersion: "16",
+  edition: null,
+};
+
+function eolFetchStub(): typeof fetch {
+  return (async (url: string) => {
+    if (typeof url === "string" && url.includes("/products/postgresql/")) {
+      return {
+        ok: true,
+        json: async () => ({
+          result: { name: "postgresql", releases: [{ name: "16", isEol: false, eolFrom: "2028-11-09" }] },
+        }),
+      } as unknown as Response;
+    }
+    return { ok: false, json: async () => ({}) } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe("deriveEolSlug", () => {
+  it("matches the sweep derivation (lowercase-hyphenated)", () => {
+    expect(deriveEolSlug({ product: "PostgreSQL" })).toBe("postgresql");
+    expect(deriveEolSlug({ product: "SQL Server" })).toBe("sql-server");
+  });
+});
+
+describe("enrichCatalogIdentity", () => {
+  it("resolves CPE and writes lifecycle for a known product", async () => {
+    const cpeUpdates: string[] = [];
+    const milestones: string[] = [];
+    const db = {
+      catalogIdentity: { update: async ({ where }: { where: { id: string } }) => { cpeUpdates.push(where.id); return {}; } },
+      catalogLifecycleMilestone: {
+        upsert: async ({ create }: { create: { milestone: string } }) => { milestones.push(create.milestone); return {}; },
+      },
+    };
+
+    const r = await enrichCatalogIdentity(db, PG, { eolFetch: eolFetchStub() });
+
+    expect(cpeUpdates).toEqual(["ci-pg"]);
+    expect(r.cpe).toContain("cpe:2.3:a:postgresql:postgresql");
+    expect(r.lifecycleMatched).toBe(true);
+    expect(r.lifecycleMilestonesWritten).toBeGreaterThan(0);
+    expect(milestones.length).toBeGreaterThan(0);
+  });
+
+  it("resolves CPE but writes no lifecycle for an unknown endoflife product", async () => {
+    const db = {
+      catalogIdentity: { update: async () => ({}) },
+      catalogLifecycleMilestone: { upsert: async () => ({}) },
+    };
+    const r = await enrichCatalogIdentity(
+      db,
+      { ...PG, id: "ci-x", product: "MysteryApp" },
+      { eolFetch: eolFetchStub() },
+    );
+    expect(r.lifecycleMatched).toBe(false);
+    expect(r.lifecycleMilestonesWritten).toBe(0);
+  });
+});
+
+function buildProductClient(
+  identities: Array<EnrichIdentityRow | null>,
+  productUpdates: Array<{ enrichmentStatus: string }>,
+): EnrichDigitalProductClient {
+  return {
+    catalogIdentity: { update: async () => ({}) },
+    catalogLifecycleMilestone: { upsert: async () => ({}) },
+    digitalProduct: {
+      findUnique: async () => ({
+        id: "dp-1",
+        inventoryEntities: identities.map((catalogIdentity) => ({ catalogIdentity })),
+      }),
+      update: async ({ data }: { data: { enrichmentStatus: string; lastEnrichedAt: Date } }) => {
+        productUpdates.push({ enrichmentStatus: data.enrichmentStatus });
+        return {};
+      },
+    },
+  } as unknown as EnrichDigitalProductClient;
+}
+
+describe("enrichDigitalProduct", () => {
+  it("enriches distinct resolved identities and marks the product enriched", async () => {
+    const productUpdates: Array<{ enrichmentStatus: string }> = [];
+    // Two entities share ci-pg; dedup means one enrichment.
+    const db = buildProductClient([PG, PG, { ...PG, id: "ci-nginx", product: "nginx" }], productUpdates);
+
+    const r = await enrichDigitalProduct(db, "dp-1", { eolFetch: eolFetchStub() });
+
+    expect(r.identitiesEnriched).toBe(2); // ci-pg + ci-nginx (deduped)
+    expect(r.identitiesFailed).toBe(0);
+    expect(r.enrichmentStatus).toBe("enriched");
+    expect(productUpdates.at(-1)?.enrichmentStatus).toBe("enriched");
+  });
+
+  it("marks a product with no resolved identities as partial (awaiting a rule match)", async () => {
+    const productUpdates: Array<{ enrichmentStatus: string }> = [];
+    const db = buildProductClient([null], productUpdates);
+
+    const r = await enrichDigitalProduct(db, "dp-1", { eolFetch: eolFetchStub() });
+
+    expect(r.identitiesEnriched).toBe(0);
+    expect(r.enrichmentStatus).toBe("partial");
+  });
+
+  it("marks a missing product as failed and does not update", async () => {
+    const productUpdates: Array<{ enrichmentStatus: string }> = [];
+    const db = {
+      catalogIdentity: { update: async () => ({}) },
+      catalogLifecycleMilestone: { upsert: async () => ({}) },
+      digitalProduct: {
+        findUnique: async () => null,
+        update: async () => { productUpdates.push({ enrichmentStatus: "x" }); return {}; },
+      },
+    } as unknown as EnrichDigitalProductClient;
+
+    const r = await enrichDigitalProduct(db, "missing", {});
+
+    expect(r.enrichmentStatus).toBe("failed");
+    expect(productUpdates).toHaveLength(0);
+  });
+
+  it("marks failed when every identity throws", async () => {
+    const productUpdates: Array<{ enrichmentStatus: string }> = [];
+    const db = buildProductClient([PG], productUpdates);
+    db.catalogIdentity.update = (async () => { throw new Error("db down"); }) as EnrichDigitalProductClient["catalogIdentity"]["update"];
+
+    const r = await enrichDigitalProduct(db, "dp-1", { eolFetch: eolFetchStub() });
+
+    expect(r.identitiesFailed).toBe(1);
+    expect(r.enrichmentStatus).toBe("failed");
+    expect(productUpdates.at(-1)?.enrichmentStatus).toBe("failed");
+  });
+});
+
+describe("requestReEnrichment", () => {
+  it("flags a product back to pending", async () => {
+    const updates: Array<{ enrichmentStatus: string }> = [];
+    const db: ReEnrichmentClient = {
+      digitalProduct: {
+        update: async ({ data }: { data: { enrichmentStatus: string } }) => { updates.push(data); return {}; },
+      },
+      inventoryEntity: { updateMany: async () => ({ count: 0 }) },
+    };
+
+    const r = await requestReEnrichment(db, { digitalProductId: "dp-1" });
+
+    expect(r.flaggedProduct).toBe(true);
+    expect(r.flaggedEntity).toBe(false);
+    expect(updates).toEqual([{ enrichmentStatus: "pending" }]);
+  });
+
+  it("flags an entity for re-resolution when it exists", async () => {
+    const db: ReEnrichmentClient = {
+      digitalProduct: { update: async () => ({}) },
+      inventoryEntity: { updateMany: async () => ({ count: 1 }) },
+    };
+
+    const r = await requestReEnrichment(db, { inventoryEntityId: "e-1" });
+
+    expect(r.flaggedEntity).toBe(true);
+    expect(r.flaggedProduct).toBe(false);
+  });
+});

--- a/packages/db/src/enrich-digital-product.ts
+++ b/packages/db/src/enrich-digital-product.ts
@@ -1,0 +1,267 @@
+// On-demand enrichment for a single DigitalProduct (EP-ASSET-INTELLIGENCE, spec §4.2/§4.6).
+//
+// The MCP-tool entry point that lets the estate-specialist coworker enrich one product
+// (or flag it for re-enrichment) rather than wait for the weekly catalog sweep. Reuses
+// the already-built open-feed logic per identity — CPE 2.3 crosswalk + endoflife.date
+// support-lifecycle — over the CatalogIdentity rows the product's InventoryEntities
+// resolve to, then stamps DigitalProduct.enrichmentStatus / lastEnrichedAt.
+//
+// Pure orchestration over an injectable client + fetchers (no prisma import) so it stays
+// unit-testable; the MCP handler wires the real prisma + global fetch.
+
+import { resolveCatalogIdentityCpe, type CpeUpsertClient } from "./cpe-crosswalk";
+import {
+  fetchEolProduct,
+  upsertLifecycleForIdentity,
+  type LifecycleUpsertClient,
+} from "./endoflife-lifecycle";
+
+/** One CatalogIdentity row the per-identity enrichment needs. */
+export type EnrichIdentityRow = {
+  id: string;
+  part: string | null;
+  manufacturer: string;
+  product: string;
+  productVersion: string | null;
+  edition: string | null;
+};
+
+export type EnrichFetchers = {
+  /** endoflife.date fetcher; defaults to global fetch. */
+  eolFetch?: typeof fetch;
+  /** NVD CPE-dictionary fetcher; when omitted the CPE is deterministic-only. */
+  nvdFetch?: typeof fetch;
+};
+
+/**
+ * endoflife.date product slug from a CatalogIdentity's product name — best-effort,
+ * lowercase-hyphenated. Kept in lockstep with the scheduled sweep's derivation so a
+ * product enriched on demand and one enriched by the weekly loop resolve identically.
+ */
+export function deriveEolSlug(identity: { product: string }): string {
+  return identity.product
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+export type EnrichIdentityResult = {
+  cpe: string;
+  lifecycleMilestonesWritten: number;
+  lifecycleMatched: boolean;
+};
+
+/**
+ * Run the open feeds over one CatalogIdentity: resolve its CPE 2.3, then resolve +
+ * upsert its endoflife.date support-lifecycle milestones. Idempotent. Fetch/DB errors
+ * inside the feed helpers are already swallowed to []/null; a hard throw propagates to
+ * the caller, which decides partial-vs-failed.
+ */
+export async function enrichCatalogIdentity(
+  db: CpeUpsertClient & LifecycleUpsertClient,
+  identity: EnrichIdentityRow,
+  fetchers: EnrichFetchers = {},
+): Promise<EnrichIdentityResult> {
+  const cpe = await resolveCatalogIdentityCpe(
+    db,
+    {
+      id: identity.id,
+      part: identity.part,
+      manufacturer: identity.manufacturer,
+      product: identity.product,
+      productVersion: identity.productVersion,
+      edition: identity.edition,
+    },
+    fetchers.nvdFetch,
+  );
+
+  let lifecycleMilestonesWritten = 0;
+  let lifecycleMatched = false;
+  const slug = deriveEolSlug(identity);
+  if (slug) {
+    const product = await fetchEolProduct(slug, fetchers.eolFetch ?? fetch);
+    if (product) {
+      lifecycleMatched = true;
+      lifecycleMilestonesWritten = await upsertLifecycleForIdentity(
+        db,
+        identity.id,
+        product,
+        identity.productVersion,
+      );
+    }
+  }
+
+  return { cpe, lifecycleMilestonesWritten, lifecycleMatched };
+}
+
+/** Minimal prisma surface for enrichDigitalProduct — a superset of the feed clients. */
+export type EnrichDigitalProductClient = CpeUpsertClient &
+  LifecycleUpsertClient & {
+    digitalProduct: {
+      findUnique(args: {
+        where: { id: string };
+        select: {
+          id: true;
+          inventoryEntities: {
+            select: { catalogIdentity: { select: EnrichIdentitySelect } };
+          };
+        };
+      }): Promise<DigitalProductWithIdentities | null>;
+      update(args: {
+        where: { id: string };
+        data: { enrichmentStatus: string; lastEnrichedAt: Date };
+      }): Promise<unknown>;
+    };
+  };
+
+type EnrichIdentitySelect = {
+  id: true;
+  part: true;
+  manufacturer: true;
+  product: true;
+  productVersion: true;
+  edition: true;
+};
+
+type DigitalProductWithIdentities = {
+  id: string;
+  inventoryEntities: Array<{ catalogIdentity: EnrichIdentityRow | null }>;
+};
+
+export type EnrichDigitalProductResult = {
+  digitalProductId: string;
+  enrichmentStatus: "enriched" | "partial" | "failed";
+  identitiesEnriched: number;
+  identitiesFailed: number;
+  lifecycleMilestonesWritten: number;
+};
+
+/**
+ * Enrich every distinct CatalogIdentity the product's InventoryEntities resolve to, then
+ * stamp the product's enrichmentStatus:
+ *   - enriched — at least one identity, all succeeded
+ *   - partial  — some identities failed, or the product has no resolved identities yet
+ *   - failed   — every attempted identity threw
+ * Never throws; the outcome is reflected in the status + counts.
+ */
+export async function enrichDigitalProduct(
+  db: EnrichDigitalProductClient,
+  digitalProductId: string,
+  fetchers: EnrichFetchers = {},
+): Promise<EnrichDigitalProductResult> {
+  const identitySelect: EnrichIdentitySelect = {
+    id: true,
+    part: true,
+    manufacturer: true,
+    product: true,
+    productVersion: true,
+    edition: true,
+  };
+  const product = await db.digitalProduct.findUnique({
+    where: { id: digitalProductId },
+    select: {
+      id: true,
+      inventoryEntities: { select: { catalogIdentity: { select: identitySelect } } },
+    },
+  });
+
+  const result: EnrichDigitalProductResult = {
+    digitalProductId,
+    enrichmentStatus: "partial",
+    identitiesEnriched: 0,
+    identitiesFailed: 0,
+    lifecycleMilestonesWritten: 0,
+  };
+
+  if (product === null) {
+    result.enrichmentStatus = "failed";
+    return result;
+  }
+
+  // Distinct resolved identities (multiple entities can share one CatalogIdentity).
+  const identities = new Map<string, EnrichIdentityRow>();
+  for (const entity of product.inventoryEntities) {
+    if (entity.catalogIdentity) identities.set(entity.catalogIdentity.id, entity.catalogIdentity);
+  }
+
+  for (const identity of identities.values()) {
+    try {
+      const r = await enrichCatalogIdentity(db, identity, fetchers);
+      result.identitiesEnriched += 1;
+      result.lifecycleMilestonesWritten += r.lifecycleMilestonesWritten;
+    } catch {
+      result.identitiesFailed += 1;
+    }
+  }
+
+  // No resolved identities yet → nothing to enrich (leave as 'partial', the product is
+  // awaiting a discovery-rule match). All-failed → 'failed'. Otherwise 'enriched'.
+  if (identities.size === 0) {
+    result.enrichmentStatus = "partial";
+  } else if (result.identitiesEnriched === 0) {
+    result.enrichmentStatus = "failed";
+  } else if (result.identitiesFailed === 0) {
+    result.enrichmentStatus = "enriched";
+  } else {
+    result.enrichmentStatus = "partial";
+  }
+
+  await db.digitalProduct.update({
+    where: { id: digitalProductId },
+    data: { enrichmentStatus: result.enrichmentStatus, lastEnrichedAt: new Date() },
+  });
+
+  return result;
+}
+
+/** Minimal prisma surface for requestReEnrichment. */
+export type ReEnrichmentClient = {
+  digitalProduct: {
+    update(args: {
+      where: { id: string };
+      data: { enrichmentStatus: string };
+    }): Promise<unknown>;
+  };
+  inventoryEntity: {
+    updateMany(args: {
+      where: { id: string };
+      data: { identityStatus: string | null };
+    }): Promise<{ count: number }>;
+  };
+};
+
+export type ReEnrichmentTarget = { digitalProductId?: string; inventoryEntityId?: string };
+
+/**
+ * Flag a product or entity for re-enrichment so the next scheduled catalog sweep (or an
+ * explicit enrich_digital_product call) re-resolves it. A DigitalProduct is set back to
+ * enrichmentStatus='pending'; an InventoryEntity's identityStatus is cleared to
+ * 'needs_reresolve' so the sweep picks it up. Human-confirmed identities are not touched
+ * here — re-enrichment re-runs the deterministic + feed layers, never overwrites a
+ * human_confirmed resolution (spec §4.1). Returns which targets were flagged.
+ */
+export async function requestReEnrichment(
+  db: ReEnrichmentClient,
+  target: ReEnrichmentTarget,
+): Promise<{ flaggedProduct: boolean; flaggedEntity: boolean }> {
+  let flaggedProduct = false;
+  let flaggedEntity = false;
+
+  if (target.digitalProductId) {
+    await db.digitalProduct.update({
+      where: { id: target.digitalProductId },
+      data: { enrichmentStatus: "pending" },
+    });
+    flaggedProduct = true;
+  }
+
+  if (target.inventoryEntityId) {
+    const { count } = await db.inventoryEntity.updateMany({
+      where: { id: target.inventoryEntityId },
+      data: { identityStatus: "needs_reresolve" },
+    });
+    flaggedEntity = count > 0;
+  }
+
+  return { flaggedProduct, flaggedEntity };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -382,6 +382,9 @@ export * from "./discovery-fingerprint-policy";
 export * from "./discovery-fingerprint-rules";
 export * from "./discovery-mac-classification";
 export * from "./discovery-fingerprint-observation";
+// Asset-intelligence on-demand product enrichment (EP-ASSET-INTELLIGENCE, spec §4.2/§4.6)
+// — the enrich_digital_product / request_re_enrichment MCP tools' backing logic.
+export * from "./enrich-digital-product";
 export * from "./device-placement";
 export * from "./portfolio-sources";
 export * from "./backlog-portfolio";

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -54,7 +54,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	865
 apps/web/lib/self-upgrade/quiescence.ts	1469
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	903
-apps/web/lib/tak/agent-grants.ts	818
+apps/web/lib/tak/agent-grants.ts	824
 apps/web/lib/tak/agent-routing.ts	965
 apps/web/lib/tak/agentic-loop.test.ts	2240
 apps/web/lib/tak/agentic-loop.ts	2612

--- a/skills/inventory/improve-fingerprint-rule.skill.md
+++ b/skills/inventory/improve-fingerprint-rule.skill.md
@@ -1,0 +1,37 @@
+---
+name: improve-fingerprint-rule
+description: "Propose or refine a discovery fingerprint rule from an identity-resolution miss so the estate self-improves its normalization"
+category: inventory
+assignTo: ["inventory-specialist"]
+capability: "view_inventory"
+taskType: "analysis"
+triggerPattern: "fingerprint rule|improve rule|wrong identity|misidentified|resolution miss|refine rule|normalization rule"
+userInvocable: true
+agentInvocable: true
+allowedTools: [request_re_enrichment, create_backlog_item]
+composesFrom: [show-identity-resolution]
+contextRequirements: []
+riskBand: low
+---
+
+# Improve a Fingerprint Rule
+
+Turn an identity-resolution miss — a wrong `CatalogIdentity`, a low-confidence match, or an unresolved entity — into a concrete `DiscoveryFingerprintRule` improvement, closing the loop the enrichment pipeline depends on (spec §4.6).
+
+## Steps
+
+1. Start from the evidence. Use `show-identity-resolution` (compose) to read the item's `IdentityResolutionLog` — the matched rule (if any), its confidence, and the evidence packet. Use PAGE DATA for the entity currently open.
+2. Diagnose the miss:
+   - **No rule matched** — the entity is heuristic/unattributed; a new rule is needed.
+   - **Wrong identity** — an existing rule over-matched; its match expression needs a tighter guard or an excluded signal.
+   - **Low confidence** — the rule matched but below the auto-apply bar; the evidence families or confidence need adjustment.
+3. Draft the rule change against the observed raw evidence (vendor strings, package names, image tags, MAC OUI, ports). Name the exact `matchExpression` change and the target `CatalogIdentity` (manufacturer / product / part a·o·h). Never let a raw vendor string leak straight onto the canonical identity — the rule sets it (spec §4.1).
+4. File it as a tracked change with `create_backlog_item` (a `tool`/`chore` item under EP-ASSET-INTELLIGENCE) describing the rule, the evidence it should match, and the expected resolved identity. Seeded/shadow rules are promoted through the existing fingerprint-rule lifecycle — this skill proposes, it does not silently auto-activate a rule.
+5. Once the rule change lands, call `request_re_enrichment` for the affected product/entity so the next sweep re-resolves it with the improved rule.
+
+## Guidelines
+
+- **Deterministic first.** Prefer a precise fingerprint rule over relying on the AI fallback — a rule is reusable across every install (spec §2, §4.6).
+- **Never overwrite a human_confirmed resolution.** If the current identity is human-confirmed, a rule change must not silently flip it; surface the conflict for human review (spec §4.1).
+- **Public vs proprietary.** A rule for commodity tech (Windows, PostgreSQL, a common OSS library, a Dell model) is broadly reusable and eligible for the shared hive catalog; a rule keyed on proprietary/internal strings stays local-only and never egresses (spec §4.7). Flag which one you are proposing.
+- Keep the proposal specific and evidence-grounded — one rule, the exact signals, the expected identity. Do not batch unrelated rule changes into one item.

--- a/skills/inventory/show-identity-resolution.skill.md
+++ b/skills/inventory/show-identity-resolution.skill.md
@@ -1,0 +1,39 @@
+---
+name: show-identity-resolution
+description: "Show the full identity-resolution lineage (IdentityResolutionLog) for an inventory item — how its CatalogIdentity was decided and by which rule"
+category: inventory
+assignTo: ["inventory-specialist"]
+capability: "view_inventory"
+taskType: "analysis"
+triggerPattern: "identity resolution|how was this identified|resolution lineage|why this identity|fingerprint match|catalog identity"
+userInvocable: true
+agentInvocable: true
+allowedTools: []
+composesFrom: []
+contextRequirements: []
+riskBand: low
+---
+
+# Show Identity Resolution Lineage
+
+Explain how an inventory item's normalized identity (its `CatalogIdentity`) was decided — the resolution lineage recorded in `IdentityResolutionLog` (spec §4.1).
+
+## Steps
+
+1. Identify the item in question — an `InventoryEntity` or the `CatalogIdentity` it resolved to. Use PAGE DATA for the currently open entity/product when the user says "this one".
+2. Retrieve its `IdentityResolutionLog` rows (most recent first). Each row records:
+   - **resolutionType** — `rule` (deterministic fingerprint match), `ai_resolved`, `human_confirmed`, or `human_corrected`.
+   - **fingerprintRuleId** — the `DiscoveryFingerprintRule` that produced a rule resolution (when present).
+   - **confidence** and the **evidence** packet (matched rule key, resolved identity, source signals).
+   - **discoveryRunId** — the sweep that recorded it, and **createdAt**.
+3. Present the lineage as a short timeline:
+   - When first resolved, by what (rule key / AI / human), at what confidence.
+   - Any later change of identity (a new row to a different `CatalogIdentity`) and why.
+4. Show the current resolved identity: manufacturer / product / version / CPE, plus its support-lifecycle milestones if present.
+
+## Guidelines
+
+- This is **read-only** — never edit a resolution row. A wrong resolution is fixed by improving the rule (`improve-fingerprint-rule`) or a human correction, not by rewriting the audit log.
+- Call out when the current identity rests on a **human_confirmed** row — those are authoritative and are never overwritten by a rule (spec §4.1).
+- If the item has **no** `IdentityResolutionLog` rows, say so plainly: it was never resolved to a `CatalogIdentity` (heuristic or unattributed) — a candidate for `improve-fingerprint-rule`.
+- Do not invent lineage — report only the rows that exist.


### PR DESCRIPTION
## What

Makes the built enrichment logic **operable by the estate-specialist coworker** (`AGT-WS-INVENTORY`) — the enablement half of EP-ASSET-INTELLIGENCE (spec §4.6).

### MCP tools (discovery-inventory pack)
- **`enrich_digital_product(digitalProductId)`** — resolve CPE 2.3 + endoflife.date support-lifecycle for every `CatalogIdentity` the product's inventory entities map to, then stamp `DigitalProduct.enrichmentStatus` / `lastEnrichedAt`.
- **`request_re_enrichment({digitalProductId?, inventoryEntityId?})`** — flag a product back to `enrichmentStatus='pending'` and/or clear an entity's identity so the next catalog sweep re-resolves it. Never overwrites a human-confirmed identity.

Backing logic: `packages/db/src/enrich-digital-product.ts` (`enrichCatalogIdentity` / `enrichDigitalProduct` / `requestReEnrichment`) — pure, injectable-client, fixture-tested; handlers wire prisma + global `fetch`. `deriveEolSlug` matches the scheduled sweep so on-demand and weekly enrichment resolve identically.

### Grants — a dedicated finer grant `enrichment_write`
Chosen over reusing the broad `registry_write` via the kernel (`principle_decide`: composite **6.43 vs 3.06**, high confidence — Architecture-Over-Shortcuts + Least-Privilege).
- `agent-grants.ts` `TOOL_TO_GRANTS` maps both tools to `enrichment_write`.
- `agent_registry.json` grants `enrichment_write` to `AGT-WS-INVENTORY`. `contribute_to_hive` is already authorized for it via its existing `backlog_write` grant.
- `grant_catalog.json` documents the new key.

### Coworker skills (`assignTo: inventory-specialist`, spec §4.6)
- `skills/inventory/improve-fingerprint-rule.skill.md` — propose/refine a `DiscoveryFingerprintRule` from a resolution-log miss, then request re-enrichment.
- `skills/inventory/show-identity-resolution.skill.md` — show the `IdentityResolutionLog` lineage for an item.

## Tests
`enrich-digital-product.test.ts` (per-identity enrich, dedup, missing/partial/failed status, re-enrichment flags) + `discovery-inventory-pack.test.ts` (registration 7→9, grants mirror `TOOL_TO_GRANTS`, handler param-validation + summary paths).

## Notes
- Source-only worktree (no local toolchain); CI is the verification gate.
- No schema/migration. `enrich-digital-product.ts` imports the merged feed modules directly (same pattern as the sweep) — **independent of #3197**, touches disjoint files.
- `scripts/module-size-baseline.txt`: `agent-grants.ts` 818 → 824 (surgical).
- Spec §4.6/§5 updated to LANDED.

Design-Grounding-Decision: BI-1D25BC3C — estate-specialist enrichment skills + hive-contribution grants (spec §4.6). Spec §4.6 = design evidence; the pack + `enrich-digital-product.ts` + `agent_registry.json` = code evidence.

Seed-Fit-Decision: global-default — the estate-specialist is a platform-management coworker in every install and enrichment is a platform capability, so the `enrichment_write` grant + the two inventory skills belong in the global seed, not an archetype/vertical overlay.

Process-Spine-Decision: the new `enrich-digital-product` module is the tool surface the spec's §4.2/§4.6 pipeline design calls for; it reuses the merged feed modules rather than adding a parallel engine. Spec §4.6/§5 doc updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)