### PR TITLE
feat(workforce): staffing substrate schema — Phase 1 (BI-4AD09A35)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
+++ b/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
@@ -1,0 +1,108 @@
+# Workforce staffing & scheduling substrate — implementation plan
+
+| Field | Value |
+| --- | --- |
+| Backlog item | `BI-4AD09A35` (Organization workforce staffing and scheduling substrate) |
+| Epic | `EP-WORKFORCE-OPS` |
+| Design spec | [`2026-07-17-organization-workforce-staffing-scheduling-design.md`](../specs/2026-07-17-organization-workforce-staffing-scheduling-design.md) |
+| Kernel records | `DI-C8BF6362B44C` (architecture: DPF domain + open solver adapter) · `DI-78788D22BE65` (solver-first: Timefold) |
+| Branch | `feat/workforce-staffing-substrate` (off `origin/main` @ `93a1e23b4`) |
+| Status | Phased plan; Phase 1 ready to build |
+
+## Founder decisions applied (design §18)
+
+1. **Golden model:** appointment coverage (healthcare/beauty) **+** one trades field-crew — exercises three of the five demand shapes (`fixed_slot` + `coverage_floor` + `task_pipeline`). Chosen to also serve the in-flight `EP-HEALTHCARE-PRACTICE`.
+2. **Publish authority:** owner/operator capability only initially; scoped delegation (location/team) added after verified usage.
+5. **Jurisdiction pack:** US federal (FLSA) + California first (richest rule set — daily OT, meal/rest premiums, reporting-time incl. *Ward v. Tilly's*, split-shift). Install `employsIn` + work-location jurisdiction must be populated before the pack is authoritative.
+6. **Solver:** **Timefold Community Edition first** in the packaging spike (kernel-recommended, `DI-78788D22BE65`, high confidence — Architecture Over Shortcuts favoured Timefold's native hard/medium/soft model). OR-Tools CP-SAT remains the documented fallback; the provider-neutral adapter keeps the switch cheap.
+
+## Grounding (verified substrate, fresh worktree 2026-07-17)
+
+- Schema: [`packages/db/prisma/schema.prisma`](../../../packages/db/prisma/schema.prisma) (13,567 lines) — `EmployeeProfile`:389, `Principal`:307, `Organization`:3663, `PersonLicenseRecord`:4186, `AgentActionProposal`:4995, `LeaveRequest`:7556, `CalendarEvent`:7643, `ServiceProvider`:9070, `ProviderAvailability`:9108, `DecisionInteraction`:11924. New aggregates **link** these; none is duplicated.
+- Migrations: timestamp-prefixed dirs under `packages/db/prisma/migrations/`; latest is `20260717035500_*`. New migration must use a later stamp (avoid the timestamp-collision hazard).
+- Coordinator UX home: [`apps/web/app/(shell)/employee/page.tsx`](../../../apps/web/app/(shell)/employee/page.tsx) renders [`EmployeeTabNav`](../../../apps/web/components/employee/EmployeeTabNav.tsx) with flat `?view=` switching — the design §15.1 `?view=staffing` home fits with no new global nav.
+- MCP tools: packs in [`apps/web/lib/mcp/packs/`](../../../apps/web/lib/mcp/packs/); `query_employees` lives in `workforce-pack.ts` and registers through [`pack-registry.ts`](../../../apps/web/lib/mcp/pack-registry.ts). New staffing tools extend a pack with deny-by-default grants.
+- Calendar merge: [`apps/web/lib/workforce/calendar-data.ts`](../../../apps/web/lib/workforce/calendar-data.ts) — the §3.3 `employeeProfileId` scoping gap is a Phase 7 prerequisite before private staffing projections depend on it.
+
+## Phase sequence
+
+Each phase becomes a child BI under `EP-WORKFORCE-OPS`. Phase 1 ships independently; later phases depend on earlier ones. Every phase carries functional verification, not just typecheck.
+
+### Phase 1 — Core staffing schema + migration *(ships independently)*
+
+**Deliverable.** The nine design aggregates (§5.1) as Prisma models with the §9.9 refinements:
+- `StaffingDemand` with a `demandShape` enum discriminator (`coverage_floor | forecast_curve | fixed_slot | task_pipeline | census_load`), provenance, effective version.
+- `StaffingShift`, `StaffingAssignment` (lifecycle incl. the offer/claim states `offered → claimed → confirmed → on_site` alongside `proposed/confirmed/declined/withdrawn/completed`), `EmployeeAvailabilityWindow`, `EmployeeSchedulingPreference`, `StaffingConstraintRule`, `StaffingProposalRun`/`StaffingProposalOption`, `StaffingExceptionRequest`, `WorkforceCandidateFact`.
+- Typed crew/composite-resource assembly + co-scheduled resource links (vehicle/room/operatory/kit) so double-booking detection covers equipment and rooms.
+- Optimistic-concurrency version columns; append-only/event-versioned assignment history; instant + decision-timezone + local-date storage.
+
+**Files.** `packages/db/prisma/schema.prisma` (new models + enums, additive only); new `packages/db/prisma/migrations/<stamp>_add_workforce_staffing_substrate/`; `pnpm --filter @dpf/db generate`.
+
+**Verification.** Migration applies clean on a DB that already holds data (additive `CREATE TABLE` only); `prisma validate`; typecheck; a unit test asserting model presence, the overlap invariant (no overlapping confirmed assignments unless a typed operating model permits), version columns, and idempotency keys.
+
+**Risk/rollback.** Additive migration referencing existing PKs — no change to existing tables; rollback = down-migration dropping the new tables (nothing else references staffing yet).
+
+### Phase 2 — Deterministic constraint & rule-pack engine
+
+**Deliverable.** Typed `StaffingConstraintRule` predicate registry implementing the §9.8 families (eligibility/credential-expiry, capability-presence, minimum-N-together, pairing-ratio, headcount-formula, rest-gap/turnaround-clock, per-employee-group overtime-regime selection, schedule-shape premium producing **cost** not infeasibility). Rule-pack loader (config: source URLs, effective dates, review owner, test cases). US-federal + California starter pack. Unknown jurisdiction → **requires policy review**, fail-closed (never assume US defaults).
+
+**Files.** `apps/web/lib/workforce/staffing/constraints/` (predicate registry + evaluators); `apps/web/lib/workforce/staffing/rule-packs/us-federal.ts`, `.../us-california.ts`.
+
+**Verification.** Constraint goldens — every rule in the pack ships one passing and one violating fixture; unknown-jurisdiction fail-closed test; overtime-regime selection test (FLSA-40 vs CA daily-OT).
+
+### Phase 3 — Solver adapter + Timefold packaging spike
+
+**Deliverable.** Provider-neutral adapter: accepts a normalized, versioned problem, returns candidate solutions + machine-readable score/violation detail; **no** DB read, notification, publish, or exception authority. Timefold CE spike as a bounded internal sidecar service (not embedded in the Node/Alpine image): license/SBOM/provenance review, ARM64/AMD64 container sizing, determinism + timeout tests, offline operation, failure semantics. DPF performs identity resolution, applicability, and **independent hard-rule validation after solve**.
+
+**Files.** `apps/web/lib/workforce/staffing/solver/adapter.ts` (interface + normalized problem/solution types); solver sidecar service dir + Dockerfile; compose wiring (one `dpf` project).
+
+**Verification.** Deterministic fixtures → stable solutions; feasible/infeasible/unknown/timeout each handled; independent post-solve validation catches any solver hard-rule violation; sidecar builds on both arches; documented OR-Tools fallback path.
+
+### Phase 4 — AI Staffing Coworker proposal flow + human-authority boundary
+
+**Deliverable.** Phase-1 coworker authority (design §11): read governed facts, prepare demand, run validation/optimization, compare options, create `AgentActionProposal` with typed staffing links (reuse existing governance substrate). Cannot publish or message employees without approval. Publish/exception/leave/notify require a valid actor + delegation + evidence; publish authority bound to the owner/operator capability (decision 2), delegable by scope later.
+
+**Files.** `apps/web/lib/workforce/staffing/coworker/`; governance links reuse `AgentActionProposal`/`DelegationGrant`/`DecisionInteraction`.
+
+**Verification.** No publication/exception/notification without a valid actor + evidence record; a proposal never mutates assignments; delegation scope enforced.
+
+### Phase 5 — MCP staffing tool pack
+
+**Deliverable.** New `staffing-pack.ts` (or a scoped extension of `workforce-pack.ts`): read tools (coverage, unscheduled demand, minimum-necessary availability/eligibility outcomes), proposal tools, employee availability/preference write tools — all deny-by-default grants. Registered via `pack-registry.ts`.
+
+**Files.** `apps/web/lib/mcp/packs/staffing-pack.ts` + test; `pack-registry.ts` registration.
+
+**Verification.** Pack tests (grant shapes, tool contracts); tools callable via MCP JSON-RPC against the running portal.
+
+### Phase 6 — UX surface: People → Staffing (golden = appointment + field-crew)
+
+**Deliverable.** Extend `/employee` with `?view=staffing` (coordinator) per §15.1; first viewport per §15.2 (planning window, team/location scope, coverage status, unscheduled demand, hard conflicts, last-minute changes, pending decisions; actions Prepare / Compare / Approve-and-publish). Comparison of 2–4 options with the §8.3 explanation contract. Employee "my schedule / availability" scoped to self; approver deep-links from the attention inbox. Golden seed/demo data for one appointment-coverage archetype + one trades field-crew.
+
+**Files.** `apps/web/app/(shell)/employee/` (staffing view components); `apps/web/components/employee/` (staffing components); demo/seed data.
+
+**Verification.** Live portal (contributor preview :3001) — coordinator happy path, employee correction, infeasible ("no feasible schedule") explanation without fabricated fill, private-title redaction, keyboard/accessible table operation, employee-timezone clarity.
+
+### Phase 7 — Calendar & comms projections
+
+**Deliverable.** Project confirmed assignments into `CalendarEventView` (no second canonical calendar copy); harden `calendar-data.ts` `employeeProfileId` scoping (§3.3 prerequisite) before private staffing projections depend on it. Comms candidate-fact flow (time-off intent → employee confirmation → `LeaveRequest(pending)` → approved-leave hard constraint → repair proposal); minimal source envelope only.
+
+**Files.** `apps/web/lib/workforce/calendar-data.ts` (scoping fix); `apps/web/lib/workforce/staffing/projections/`; candidate-fact ingestion module.
+
+**Verification.** Assignment publishes to calendar projection; coordinator never sees private event titles (busy mask); a `WorkforceCandidateFact` is never directly solver-authoritative; approved leave becomes a hard unavailability interval.
+
+### Phase 8 — Verification & live-install evidence
+
+**Deliverable.** Execute the full §17 verification model: domain invariants, constraint goldens, solver parity, fairness/privacy (access matrix, redaction, protected-data exclusion, no hidden per-person score), comms, human authority, UX, deployment (AMD64/ARM64, offline solve, upgrade/rollback, SBOM/license), and live-install evidence via a governed nonproduction lease.
+
+**Verification.** Success metrics per §17: zero hard-violations on published schedules; correction/override/decline rates tracked; no publication/external write without actor+delegation+evidence; live happy-path verified on the running install.
+
+## Cross-cutting risks
+
+- **Solver runtime weight** (Phase 3): a JVM sidecar adds image/footprint. Mitigation: bounded sidecar (not embedded), spike gate before adoption, OR-Tools fallback preserved by the adapter.
+- **Migration safety** (Phase 1): additive only; use a stamp later than `20260717035500`; never rename an applied migration.
+- **Authority creep**: the solver and coworker have zero side-effect authority by contract; independent post-solve hard-rule validation is mandatory. Enforced in Phases 3–4 verification.
+- **Privacy**: protected/medical reasons never reach coordinator-visible constraints; the staffing view receives only minimum-necessary outcomes. Enforced in Phases 6–8.
+
+## Definition of done
+
+`BI-4AD09A35` acceptance criteria (§ its body) hold on a live install: canonical staffing authority with separation from leave/credentials/identity/calendar; demand-shape discriminator + multi-shape assignable units; constraint predicate registry covering the §9.8 families; side-effect-free provider-neutral solver with post-solve validation; fail-closed unknown jurisdiction; monetized time-shape premiums; no hidden fitness score; human authority on every consequential action.

--- a/packages/db/prisma/migrations/20260717120000_add_workforce_staffing_substrate/migration.sql
+++ b/packages/db/prisma/migrations/20260717120000_add_workforce_staffing_substrate/migration.sql
@@ -1,0 +1,428 @@
+-- CreateTable
+CREATE TABLE "StaffingDemand" (
+    "id" TEXT NOT NULL,
+    "demandId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "demandShape" TEXT NOT NULL,
+    "sourceType" TEXT,
+    "sourceId" TEXT,
+    "startAt" TIMESTAMP(3) NOT NULL,
+    "endAt" TIMESTAMP(3) NOT NULL,
+    "timezone" TEXT NOT NULL,
+    "localDateContext" TEXT,
+    "workLocationId" TEXT,
+    "occupationProfileId" TEXT,
+    "roleKey" TEXT,
+    "requiredSkills" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "requiredCredentials" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "minQuantity" INTEGER NOT NULL DEFAULT 1,
+    "targetQuantity" INTEGER,
+    "quantityFormula" JSONB,
+    "priority" INTEGER NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "provenance" JSONB,
+    "effectiveVersion" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StaffingDemand_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingShift" (
+    "id" TEXT NOT NULL,
+    "shiftId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "staffingDemandId" TEXT,
+    "startAt" TIMESTAMP(3) NOT NULL,
+    "endAt" TIMESTAMP(3) NOT NULL,
+    "timezone" TEXT NOT NULL,
+    "localDateContext" TEXT,
+    "workLocationId" TEXT,
+    "requiredQuantity" INTEGER NOT NULL DEFAULT 1,
+    "lifecycle" TEXT NOT NULL DEFAULT 'draft',
+    "publicationVersion" INTEGER NOT NULL DEFAULT 0,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StaffingShift_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingAssignment" (
+    "id" TEXT NOT NULL,
+    "assignmentId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "staffingShiftId" TEXT NOT NULL,
+    "assigneeType" TEXT NOT NULL DEFAULT 'employee',
+    "employeeProfileId" TEXT,
+    "staffingCrewId" TEXT,
+    "lifecycle" TEXT NOT NULL DEFAULT 'proposed',
+    "assignmentMode" TEXT NOT NULL DEFAULT 'assigned',
+    "decisionInteractionId" TEXT,
+    "approverEmployeeId" TEXT,
+    "acknowledgementState" TEXT NOT NULL DEFAULT 'none',
+    "source" TEXT,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StaffingAssignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingAssignmentEvent" (
+    "id" TEXT NOT NULL,
+    "staffingAssignmentId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "atVersion" INTEGER NOT NULL,
+    "actorRef" TEXT,
+    "detail" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StaffingAssignmentEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingCrew" (
+    "id" TEXT NOT NULL,
+    "crewId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "name" TEXT,
+    "crewType" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StaffingCrew_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingCrewMember" (
+    "id" TEXT NOT NULL,
+    "staffingCrewId" TEXT NOT NULL,
+    "employeeProfileId" TEXT NOT NULL,
+    "roleInCrew" TEXT,
+    "isLead" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StaffingCrewMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingResourceLink" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "staffingShiftId" TEXT NOT NULL,
+    "resourceType" TEXT NOT NULL,
+    "resourceRef" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StaffingResourceLink_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EmployeeAvailabilityWindow" (
+    "id" TEXT NOT NULL,
+    "windowId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "employeeProfileId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "startAt" TIMESTAMP(3) NOT NULL,
+    "endAt" TIMESTAMP(3) NOT NULL,
+    "timezone" TEXT NOT NULL,
+    "localInterval" TEXT,
+    "recurrence" TEXT,
+    "source" TEXT,
+    "effectiveFrom" TIMESTAMP(3),
+    "effectiveTo" TIMESTAMP(3),
+    "ownerRef" TEXT,
+    "confirmationState" TEXT NOT NULL DEFAULT 'confirmed',
+    "supersededById" TEXT,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EmployeeAvailabilityWindow_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EmployeeSchedulingPreference" (
+    "id" TEXT NOT NULL,
+    "preferenceId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "employeeProfileId" TEXT NOT NULL,
+    "preferenceType" TEXT NOT NULL,
+    "scope" TEXT,
+    "weight" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "origin" TEXT NOT NULL DEFAULT 'explicit',
+    "consentState" TEXT NOT NULL DEFAULT 'pending',
+    "confidence" DOUBLE PRECISION,
+    "evidenceRefs" JSONB,
+    "effectiveFrom" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "supersededById" TEXT,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EmployeeSchedulingPreference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingConstraintRule" (
+    "id" TEXT NOT NULL,
+    "ruleId" TEXT NOT NULL,
+    "organizationId" TEXT,
+    "predicateType" TEXT NOT NULL,
+    "family" TEXT,
+    "parameters" JSONB NOT NULL DEFAULT '{}',
+    "severity" TEXT NOT NULL DEFAULT 'hard',
+    "applicability" JSONB NOT NULL DEFAULT '{}',
+    "sourcePolicyUrl" TEXT,
+    "legallyWaivable" BOOLEAN NOT NULL DEFAULT false,
+    "effectiveFrom" TIMESTAMP(3),
+    "effectiveTo" TIMESTAMP(3),
+    "validationState" TEXT NOT NULL DEFAULT 'draft',
+    "reviewOwnerRef" TEXT,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StaffingConstraintRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingProposalRun" (
+    "id" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "inputSnapshotHash" TEXT NOT NULL,
+    "inputVersion" TEXT,
+    "solverProvider" TEXT,
+    "solverVersion" TEXT,
+    "timeLimitMs" INTEGER,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "scoreComponents" JSONB,
+    "unfilledDemand" JSONB,
+    "violations" JSONB,
+    "explanation" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StaffingProposalRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingProposalOption" (
+    "id" TEXT NOT NULL,
+    "optionId" TEXT NOT NULL,
+    "staffingProposalRunId" TEXT NOT NULL,
+    "rank" INTEGER,
+    "scoreComponents" JSONB,
+    "coverage" JSONB,
+    "unfilledDemand" JSONB,
+    "violations" JSONB,
+    "explanation" JSONB,
+    "comparison" JSONB,
+    "terminalStatus" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StaffingProposalOption_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingExceptionRequest" (
+    "id" TEXT NOT NULL,
+    "exceptionId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "staffingConstraintRuleId" TEXT,
+    "staffingShiftId" TEXT,
+    "staffingAssignmentId" TEXT,
+    "reason" TEXT NOT NULL,
+    "requestedScope" TEXT,
+    "expiresAt" TIMESTAMP(3),
+    "approvingAuthorityRef" TEXT,
+    "decision" TEXT NOT NULL DEFAULT 'pending',
+    "decisionInteractionId" TEXT,
+    "evidence" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StaffingExceptionRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WorkforceCandidateFact" (
+    "id" TEXT NOT NULL,
+    "candidateFactId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "subjectEmployeeProfileId" TEXT,
+    "kind" TEXT NOT NULL,
+    "extractedValue" JSONB,
+    "confidence" DOUBLE PRECISION,
+    "sourceEnvelope" JSONB,
+    "identityResolution" TEXT NOT NULL DEFAULT 'unresolved',
+    "reviewState" TEXT NOT NULL DEFAULT 'pending',
+    "extractionModelVersion" TEXT,
+    "inferenceAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "correctionOf" TEXT,
+    "promotionTargetType" TEXT,
+    "promotionTargetId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WorkforceCandidateFact_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StaffingDemand_demandId_key" ON "StaffingDemand"("demandId");
+
+-- CreateIndex
+CREATE INDEX "StaffingDemand_organizationId_status_idx" ON "StaffingDemand"("organizationId", "status");
+
+-- CreateIndex
+CREATE INDEX "StaffingDemand_demandShape_idx" ON "StaffingDemand"("demandShape");
+
+-- CreateIndex
+CREATE INDEX "StaffingDemand_startAt_endAt_idx" ON "StaffingDemand"("startAt", "endAt");
+
+-- CreateIndex
+CREATE INDEX "StaffingDemand_workLocationId_idx" ON "StaffingDemand"("workLocationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StaffingShift_shiftId_key" ON "StaffingShift"("shiftId");
+
+-- CreateIndex
+CREATE INDEX "StaffingShift_organizationId_lifecycle_idx" ON "StaffingShift"("organizationId", "lifecycle");
+
+-- CreateIndex
+CREATE INDEX "StaffingShift_staffingDemandId_idx" ON "StaffingShift"("staffingDemandId");
+
+-- CreateIndex
+CREATE INDEX "StaffingShift_startAt_endAt_idx" ON "StaffingShift"("startAt", "endAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StaffingAssignment_assignmentId_key" ON "StaffingAssignment"("assignmentId");
+
+-- CreateIndex
+CREATE INDEX "StaffingAssignment_organizationId_lifecycle_idx" ON "StaffingAssignment"("organizationId", "lifecycle");
+
+-- CreateIndex
+CREATE INDEX "StaffingAssignment_staffingShiftId_idx" ON "StaffingAssignment"("staffingShiftId");
+
+-- CreateIndex
+CREATE INDEX "StaffingAssignment_employeeProfileId_idx" ON "StaffingAssignment"("employeeProfileId");
+
+-- CreateIndex
+CREATE INDEX "StaffingAssignment_staffingCrewId_idx" ON "StaffingAssignment"("staffingCrewId");
+
+-- CreateIndex
+CREATE INDEX "StaffingAssignmentEvent_staffingAssignmentId_createdAt_idx" ON "StaffingAssignmentEvent"("staffingAssignmentId", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StaffingCrew_crewId_key" ON "StaffingCrew"("crewId");
+
+-- CreateIndex
+CREATE INDEX "StaffingCrew_organizationId_idx" ON "StaffingCrew"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "StaffingCrewMember_employeeProfileId_idx" ON "StaffingCrewMember"("employeeProfileId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StaffingCrewMember_staffingCrewId_employeeProfileId_key" ON "StaffingCrewMember"("staffingCrewId", "employeeProfileId");
+
+-- CreateIndex
+CREATE INDEX "StaffingResourceLink_staffingShiftId_idx" ON "StaffingResourceLink"("staffingShiftId");
+
+-- CreateIndex
+CREATE INDEX "StaffingResourceLink_resourceType_resourceRef_idx" ON "StaffingResourceLink"("resourceType", "resourceRef");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EmployeeAvailabilityWindow_windowId_key" ON "EmployeeAvailabilityWindow"("windowId");
+
+-- CreateIndex
+CREATE INDEX "EmployeeAvailabilityWindow_employeeProfileId_idx" ON "EmployeeAvailabilityWindow"("employeeProfileId");
+
+-- CreateIndex
+CREATE INDEX "EmployeeAvailabilityWindow_organizationId_kind_idx" ON "EmployeeAvailabilityWindow"("organizationId", "kind");
+
+-- CreateIndex
+CREATE INDEX "EmployeeAvailabilityWindow_startAt_endAt_idx" ON "EmployeeAvailabilityWindow"("startAt", "endAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EmployeeSchedulingPreference_preferenceId_key" ON "EmployeeSchedulingPreference"("preferenceId");
+
+-- CreateIndex
+CREATE INDEX "EmployeeSchedulingPreference_employeeProfileId_idx" ON "EmployeeSchedulingPreference"("employeeProfileId");
+
+-- CreateIndex
+CREATE INDEX "EmployeeSchedulingPreference_organizationId_preferenceType_idx" ON "EmployeeSchedulingPreference"("organizationId", "preferenceType");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StaffingConstraintRule_ruleId_key" ON "StaffingConstraintRule"("ruleId");
+
+-- CreateIndex
+CREATE INDEX "StaffingConstraintRule_organizationId_idx" ON "StaffingConstraintRule"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "StaffingConstraintRule_predicateType_idx" ON "StaffingConstraintRule"("predicateType");
+
+-- CreateIndex
+CREATE INDEX "StaffingConstraintRule_severity_validationState_idx" ON "StaffingConstraintRule"("severity", "validationState");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StaffingProposalRun_runId_key" ON "StaffingProposalRun"("runId");
+
+-- CreateIndex
+CREATE INDEX "StaffingProposalRun_organizationId_status_idx" ON "StaffingProposalRun"("organizationId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StaffingProposalOption_optionId_key" ON "StaffingProposalOption"("optionId");
+
+-- CreateIndex
+CREATE INDEX "StaffingProposalOption_staffingProposalRunId_rank_idx" ON "StaffingProposalOption"("staffingProposalRunId", "rank");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StaffingExceptionRequest_exceptionId_key" ON "StaffingExceptionRequest"("exceptionId");
+
+-- CreateIndex
+CREATE INDEX "StaffingExceptionRequest_organizationId_decision_idx" ON "StaffingExceptionRequest"("organizationId", "decision");
+
+-- CreateIndex
+CREATE INDEX "StaffingExceptionRequest_staffingConstraintRuleId_idx" ON "StaffingExceptionRequest"("staffingConstraintRuleId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkforceCandidateFact_candidateFactId_key" ON "WorkforceCandidateFact"("candidateFactId");
+
+-- CreateIndex
+CREATE INDEX "WorkforceCandidateFact_organizationId_reviewState_idx" ON "WorkforceCandidateFact"("organizationId", "reviewState");
+
+-- CreateIndex
+CREATE INDEX "WorkforceCandidateFact_subjectEmployeeProfileId_idx" ON "WorkforceCandidateFact"("subjectEmployeeProfileId");
+
+-- CreateIndex
+CREATE INDEX "WorkforceCandidateFact_kind_idx" ON "WorkforceCandidateFact"("kind");
+
+-- AddForeignKey
+ALTER TABLE "StaffingShift" ADD CONSTRAINT "StaffingShift_staffingDemandId_fkey" FOREIGN KEY ("staffingDemandId") REFERENCES "StaffingDemand"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingAssignment" ADD CONSTRAINT "StaffingAssignment_staffingShiftId_fkey" FOREIGN KEY ("staffingShiftId") REFERENCES "StaffingShift"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingAssignment" ADD CONSTRAINT "StaffingAssignment_staffingCrewId_fkey" FOREIGN KEY ("staffingCrewId") REFERENCES "StaffingCrew"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingAssignmentEvent" ADD CONSTRAINT "StaffingAssignmentEvent_staffingAssignmentId_fkey" FOREIGN KEY ("staffingAssignmentId") REFERENCES "StaffingAssignment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingCrewMember" ADD CONSTRAINT "StaffingCrewMember_staffingCrewId_fkey" FOREIGN KEY ("staffingCrewId") REFERENCES "StaffingCrew"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingResourceLink" ADD CONSTRAINT "StaffingResourceLink_staffingShiftId_fkey" FOREIGN KEY ("staffingShiftId") REFERENCES "StaffingShift"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingProposalOption" ADD CONSTRAINT "StaffingProposalOption_staffingProposalRunId_fkey" FOREIGN KEY ("staffingProposalRunId") REFERENCES "StaffingProposalRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -13565,3 +13565,359 @@ model GraphEdge {
   @@index([srcKey, relType])
   @@map("graph_edge")
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workforce staffing & scheduling substrate (EP-WORKFORCE-OPS / BI-4AD09A35).
+// Canonical staffing authority: demand → shifts → assignments → availability →
+// preferences → constraints → proposals. Spec:
+// docs/superpowers/specs/2026-07-17-organization-workforce-staffing-scheduling-design.md
+// Cross-domain references (employee/org/principal/leave/credential/proposal) are
+// bare indexed FK columns — matching the schema's organizationId convention — so
+// this migration is additive and touches no hub model. Relations are declared
+// only within the staffing domain. Discriminator fields are String (allowed
+// values named in comments), matching LeaveRequest/TimesheetPeriod status fields.
+// Times are stored as instants plus a timezone and local-date context (spec §5.3).
+// `version` columns carry optimistic concurrency for publication (spec §5.3).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Required coverage for an interval/location/role. Spec §5.1.1 + §9.9(1):
+/// `demandShape` is the first-class discriminator so the solver posture is
+/// explicit rather than assumed.
+model StaffingDemand {
+  id                   String   @id @default(cuid())
+  demandId             String   @unique
+  organizationId       String
+  // coverage_floor | forecast_curve | fixed_slot | task_pipeline | census_load
+  demandShape          String
+  sourceType           String? // forecast | manual | booking | work | census
+  sourceId             String?
+  startAt              DateTime
+  endAt                DateTime
+  timezone             String
+  localDateContext     String?
+  workLocationId       String?
+  occupationProfileId  String?
+  roleKey              String?
+  requiredSkills       String[] @default([])
+  requiredCredentials  String[] @default([])
+  minQuantity          Int      @default(1)
+  targetQuantity       Int?
+  // headcount-by-formula (spec §9.3): when set, quantity is derived at eval time
+  quantityFormula      Json?
+  priority             Int      @default(0)
+  status               String   @default("open") // open | partially_covered | covered | cancelled
+  provenance           Json?
+  effectiveVersion     Int      @default(1)
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  shifts               StaffingShift[]
+
+  @@index([organizationId, status])
+  @@index([demandShape])
+  @@index([startAt, endAt])
+  @@index([workLocationId])
+}
+
+/// Tentative work interval, mutable until publication. Spec §5.1.2.
+model StaffingShift {
+  id                 String   @id @default(cuid())
+  shiftId            String   @unique
+  organizationId     String
+  staffingDemandId   String?
+  startAt            DateTime
+  endAt              DateTime
+  timezone           String
+  localDateContext   String?
+  workLocationId     String?
+  requiredQuantity   Int      @default(1)
+  lifecycle          String   @default("draft") // draft | proposed | published | cancelled
+  publicationVersion Int      @default(0)
+  version            Int      @default(1)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  demand             StaffingDemand?        @relation(fields: [staffingDemandId], references: [id])
+  assignments        StaffingAssignment[]
+  resourceLinks      StaffingResourceLink[]
+
+  @@index([organizationId, lifecycle])
+  @@index([staffingDemandId])
+  @@index([startAt, endAt])
+}
+
+/// Authorized (or proposed) binding of a person/crew to a shift. Spec §5.1.3 +
+/// §9.9(2,4): assignee may be an individual or a typed crew; `assignmentMode`
+/// distinguishes direct assignment from the offer/claim flow used for
+/// contractor/renter/volunteer capacity the organization does not command.
+model StaffingAssignment {
+  id                    String   @id @default(cuid())
+  assignmentId          String   @unique
+  organizationId        String
+  staffingShiftId       String
+  assigneeType          String   @default("employee") // employee | crew
+  employeeProfileId     String?
+  staffingCrewId        String?
+  // proposed | offered | claimed | confirmed | declined | withdrawn | completed | on_site
+  lifecycle             String   @default("proposed")
+  assignmentMode        String   @default("assigned") // assigned | offer_claim
+  decisionInteractionId String?
+  approverEmployeeId    String?
+  acknowledgementState  String   @default("none") // none | pending | acknowledged | declined
+  source                String? // solver | manual | swap | import
+  version               Int      @default(1)
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  shift                 StaffingShift             @relation(fields: [staffingShiftId], references: [id], onDelete: Cascade)
+  crew                  StaffingCrew?             @relation(fields: [staffingCrewId], references: [id])
+  events                StaffingAssignmentEvent[]
+
+  @@index([organizationId, lifecycle])
+  @@index([staffingShiftId])
+  @@index([employeeProfileId])
+  @@index([staffingCrewId])
+}
+
+/// Append-only assignment history (spec §5.3): cancellation must not erase who
+/// was assigned previously.
+model StaffingAssignmentEvent {
+  id                   String   @id @default(cuid())
+  staffingAssignmentId String
+  eventType            String // proposed | confirmed | declined | withdrawn | completed | acknowledged | reassigned
+  atVersion            Int
+  actorRef             String?
+  detail               Json?
+  createdAt            DateTime @default(now())
+
+  assignment           StaffingAssignment @relation(fields: [staffingAssignmentId], references: [id], onDelete: Cascade)
+
+  @@index([staffingAssignmentId, createdAt])
+}
+
+/// Typed crew / composite assignable unit (spec §9.2.3). Members and their
+/// in-crew roles (lead + helper, apprentice paired with journeyman) are the
+/// unit's internal composition.
+model StaffingCrew {
+  id             String   @id @default(cuid())
+  crewId         String   @unique
+  organizationId String
+  name           String?
+  crewType       String? // moving | trades_install | catering | event_dept | patrol
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  members        StaffingCrewMember[]
+  assignments    StaffingAssignment[]
+
+  @@index([organizationId])
+}
+
+model StaffingCrewMember {
+  id                String   @id @default(cuid())
+  staffingCrewId    String
+  employeeProfileId String
+  roleInCrew        String?
+  isLead            Boolean  @default(false)
+  createdAt         DateTime @default(now())
+
+  crew              StaffingCrew @relation(fields: [staffingCrewId], references: [id], onDelete: Cascade)
+
+  @@unique([staffingCrewId, employeeProfileId])
+  @@index([employeeProfileId])
+}
+
+/// Co-scheduled non-person resources (vehicle/room/operatory/kit/equipment) that
+/// share a shift interval, so double-booking detection covers equipment and
+/// rooms, not only people (spec §9.9(2)). `resourceRef` points at the owning
+/// domain record (e.g. a WorkLocation, vehicle asset, or ServiceProvider room).
+model StaffingResourceLink {
+  id              String   @id @default(cuid())
+  organizationId  String
+  staffingShiftId String
+  resourceType    String // vehicle | room | operatory | kit | equipment | chair | station
+  resourceRef     String
+  createdAt       DateTime @default(now())
+
+  shift           StaffingShift @relation(fields: [staffingShiftId], references: [id], onDelete: Cascade)
+
+  @@index([staffingShiftId])
+  @@index([resourceType, resourceRef])
+}
+
+/// Employee-declared or authorized availability window. Spec §5.1.4.
+model EmployeeAvailabilityWindow {
+  id                String   @id @default(cuid())
+  windowId          String   @unique
+  organizationId    String
+  employeeProfileId String
+  kind              String // available | unavailable
+  startAt           DateTime
+  endAt             DateTime
+  timezone          String
+  localInterval     String?
+  recurrence        String?
+  source            String? // employee | hr | derived
+  effectiveFrom     DateTime?
+  effectiveTo       DateTime?
+  ownerRef          String?
+  confirmationState String   @default("confirmed") // confirmed | pending
+  supersededById    String?
+  version           Int      @default(1)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  @@index([employeeProfileId])
+  @@index([organizationId, kind])
+  @@index([startAt, endAt])
+}
+
+/// Typed, consented, weighted scheduling preference. Spec §5.1.5 + §12: only
+/// employee-confirmed preferences (origin=explicit or promoted) are binding;
+/// inferred origin stays soft and expiring.
+model EmployeeSchedulingPreference {
+  id                String   @id @default(cuid())
+  preferenceId      String   @unique
+  organizationId    String
+  employeeProfileId String
+  preferenceType    String
+  scope             String?
+  weight            Float    @default(0)
+  origin            String   @default("explicit") // explicit | inferred
+  consentState      String   @default("pending") // pending | consented | revoked
+  confidence        Float?
+  evidenceRefs      Json?
+  effectiveFrom     DateTime?
+  expiresAt         DateTime?
+  supersededById    String?
+  version           Int      @default(1)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  @@index([employeeProfileId])
+  @@index([organizationId, preferenceType])
+}
+
+/// Typed labor-rule predicate + parameters (spec §5.1.6 + §9.8 registry).
+/// `organizationId` null = a platform/jurisdiction starter pack rule.
+/// `predicateType` names the §9.8 variable family; hard rules cannot be relaxed
+/// by the solver, and non-waivable hard rules reject exception creation (§6).
+model StaffingConstraintRule {
+  id              String   @id @default(cuid())
+  ruleId          String   @unique
+  organizationId  String?
+  predicateType   String
+  family          String?
+  parameters      Json     @default("{}")
+  severity        String   @default("hard") // hard | soft
+  applicability   Json     @default("{}") // jurisdiction | archetype | org | unit | location | employmentType
+  sourcePolicyUrl String?
+  legallyWaivable Boolean  @default(false)
+  effectiveFrom   DateTime?
+  effectiveTo     DateTime?
+  validationState String   @default("draft") // draft | reviewed | active
+  reviewOwnerRef  String?
+  version         Int      @default(1)
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@index([organizationId])
+  @@index([predicateType])
+  @@index([severity, validationState])
+}
+
+/// Immutable optimization run over a versioned input snapshot (spec §5.1.7). A
+/// run never mutates assignments; it produces options.
+model StaffingProposalRun {
+  id                String   @id @default(cuid())
+  runId             String   @unique
+  organizationId    String
+  inputSnapshotHash String
+  inputVersion      String?
+  solverProvider    String?
+  solverVersion     String?
+  timeLimitMs       Int?
+  // pending | running | feasible | optimal | infeasible | unknown | timeout | failed
+  status            String   @default("pending")
+  scoreComponents   Json?
+  unfilledDemand    Json?
+  violations        Json?
+  explanation       Json?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  options           StaffingProposalOption[]
+
+  @@index([organizationId, status])
+}
+
+model StaffingProposalOption {
+  id                    String   @id @default(cuid())
+  optionId              String   @unique
+  staffingProposalRunId String
+  rank                  Int?
+  scoreComponents       Json?
+  coverage              Json?
+  unfilledDemand        Json?
+  violations            Json?
+  explanation           Json?
+  comparison            Json?
+  terminalStatus        String?
+  createdAt             DateTime @default(now())
+
+  run                   StaffingProposalRun @relation(fields: [staffingProposalRunId], references: [id], onDelete: Cascade)
+
+  @@index([staffingProposalRunId, rank])
+}
+
+/// Request to depart from a waivable organization rule (spec §5.1.8). Hard
+/// non-waivable legal/credential rules must reject exception creation at the
+/// application layer.
+model StaffingExceptionRequest {
+  id                     String   @id @default(cuid())
+  exceptionId            String   @unique
+  organizationId         String
+  staffingConstraintRuleId String?
+  staffingShiftId        String?
+  staffingAssignmentId   String?
+  reason                 String
+  requestedScope         String?
+  expiresAt              DateTime?
+  approvingAuthorityRef  String?
+  decision               String   @default("pending") // pending | approved | denied
+  decisionInteractionId  String?
+  evidence               Json?
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+
+  @@index([organizationId, decision])
+  @@index([staffingConstraintRuleId])
+}
+
+/// Bounded staging record for communication/integration-derived intent
+/// (spec §5.1.9 + §10-§11). Never directly solver-authoritative: it must be
+/// employee-confirmed and promoted (to a preference or a LeaveRequest) first.
+model WorkforceCandidateFact {
+  id                     String   @id @default(cuid())
+  candidateFactId        String   @unique
+  organizationId         String
+  subjectEmployeeProfileId String?
+  kind                   String // time_off_intent | availability_hint | preference_hint
+  extractedValue         Json?
+  confidence             Float?
+  sourceEnvelope         Json? // provider | tenant | external id | sender/subject | received | integrity | excerpt/digest
+  identityResolution     String   @default("unresolved") // unresolved | resolved | ambiguous
+  reviewState            String   @default("pending") // pending | confirmed | edited | rejected
+  extractionModelVersion String?
+  inferenceAt            DateTime?
+  expiresAt              DateTime?
+  correctionOf           String?
+  promotionTargetType    String? // preference | leave_request
+  promotionTargetId      String?
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+
+  @@index([organizationId, reviewState])
+  @@index([subjectEmployeeProfileId])
+  @@index([kind])
+}

--- a/packages/db/src/workforce-staffing-substrate-schema.test.ts
+++ b/packages/db/src/workforce-staffing-substrate-schema.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(__dirname, "..", "..", "..");
+const schema = readFileSync(
+  join(repoRoot, "packages/db/prisma/schema.prisma"),
+  "utf8",
+);
+const migrationPath = join(
+  repoRoot,
+  "packages/db/prisma/migrations/20260717120000_add_workforce_staffing_substrate/migration.sql",
+);
+
+// EP-WORKFORCE-OPS / BI-4AD09A35 Phase 1 — the staffing substrate.
+// Spec: docs/superpowers/specs/2026-07-17-organization-workforce-staffing-scheduling-design.md
+describe("workforce staffing substrate schema", () => {
+  const models = [
+    "StaffingDemand",
+    "StaffingShift",
+    "StaffingAssignment",
+    "StaffingAssignmentEvent",
+    "StaffingCrew",
+    "StaffingCrewMember",
+    "StaffingResourceLink",
+    "EmployeeAvailabilityWindow",
+    "EmployeeSchedulingPreference",
+    "StaffingConstraintRule",
+    "StaffingProposalRun",
+    "StaffingProposalOption",
+    "StaffingExceptionRequest",
+    "WorkforceCandidateFact",
+  ];
+
+  it("declares every staffing aggregate", () => {
+    for (const model of models) {
+      expect(schema).toMatch(new RegExp(`model ${model} \\{`));
+    }
+  });
+
+  it("makes demandShape a first-class discriminator on StaffingDemand (spec §9.9.1)", () => {
+    expect(schema).toMatch(/model StaffingDemand \{[\s\S]*demandShape\s+String/);
+    // the five demand shapes are documented as allowed values
+    for (const shape of [
+      "coverage_floor",
+      "forecast_curve",
+      "fixed_slot",
+      "task_pipeline",
+      "census_load",
+    ]) {
+      expect(schema).toContain(shape);
+    }
+  });
+
+  it("supports the offer/claim lifecycle for non-commanded capacity (spec §9.9.4)", () => {
+    const block = schema.match(/model StaffingAssignment \{[\s\S]*?\n\}/)?.[0] ?? "";
+    expect(block).toMatch(/assignmentMode\s+String/);
+    expect(block).toContain("offer_claim");
+    expect(block).toContain("offered");
+    expect(block).toContain("claimed");
+  });
+
+  it("carries optimistic-concurrency version columns on the mutable aggregates (spec §5.3)", () => {
+    for (const model of [
+      "StaffingShift",
+      "StaffingAssignment",
+      "EmployeeAvailabilityWindow",
+      "EmployeeSchedulingPreference",
+      "StaffingConstraintRule",
+    ]) {
+      const block = schema.match(new RegExp(`model ${model} \\{[\\s\\S]*?\\n\\}`))?.[0] ?? "";
+      expect(block, `${model} needs a version column`).toMatch(/\n\s*version\s+Int\s+@default\(1\)/);
+    }
+  });
+
+  it("keeps assignment history append-only (spec §5.3)", () => {
+    expect(schema).toMatch(/model StaffingAssignmentEvent \{[\s\S]*atVersion\s+Int/);
+  });
+
+  it("models constraints as typed hard/soft predicates (spec §9.8)", () => {
+    const block = schema.match(/model StaffingConstraintRule \{[\s\S]*?\n\}/)?.[0] ?? "";
+    expect(block).toMatch(/predicateType\s+String/);
+    expect(block).toMatch(/severity\s+String\s+@default\("hard"\)/);
+    expect(block).toMatch(/legallyWaivable\s+Boolean/);
+  });
+
+  it("keeps a proposal run immutable and option-producing (spec §5.1.7)", () => {
+    expect(schema).toMatch(/model StaffingProposalRun \{[\s\S]*options\s+StaffingProposalOption\[\]/);
+  });
+
+  it("stages candidate facts as non-authoritative until reviewed (spec §5.1.9)", () => {
+    const block = schema.match(/model WorkforceCandidateFact \{[\s\S]*?\n\}/)?.[0] ?? "";
+    expect(block).toMatch(/reviewState\s+String\s+@default\("pending"\)/);
+    expect(block).toMatch(/promotionTargetType\s+String\?/);
+  });
+
+  describe("migration", () => {
+    it("exists", () => {
+      expect(existsSync(migrationPath)).toBe(true);
+    });
+
+    it("is additive — creates every aggregate table and drops none", () => {
+      const sql = readFileSync(migrationPath, "utf8");
+      for (const model of models) {
+        expect(sql).toContain(`CREATE TABLE "${model}"`);
+      }
+      expect(sql).not.toMatch(/DROP TABLE/);
+    });
+  });
+});

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-07-17T04:49:55.636Z",
-  "gitSha": "d6daeb6f1ad2f04e958734cf2d4a2e764266125e",
+  "generatedAt": "2026-07-17T19:17:03.691Z",
+  "gitSha": "77bb92d190a3c630e47543e7c3b2c23be8e5d544",
   "manifestVersion": 1,
   "metrics": {
     "defaultRequiredServiceCount": {
@@ -17,11 +17,11 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 495
+      "value": 509
     },
     "prismaSchemaLines": {
       "direction": "informational",
-      "value": 13567
+      "value": 13924
     },
     "productionModuleHotspotCount": {
       "direction": "non-increasing",
@@ -33,7 +33,7 @@
     },
     "seedCoordinatorLines": {
       "direction": "informational",
-      "value": 2687
+      "value": 2689
     },
     "serviceCount": {
       "direction": "non-increasing",


### PR DESCRIPTION
## Summary

Phase 1 of the workforce staffing & scheduling substrate (`BI-4AD09A35`, epic `EP-WORKFORCE-OPS`) — the canonical staffing data model as a **purely additive** Prisma migration. This is the foundation the constraint engine, solver adapter, coworker, MCP pack, and UX build on in later phases.

Design: [`2026-07-17-organization-workforce-staffing-scheduling-design.md`](docs/superpowers/specs/2026-07-17-organization-workforce-staffing-scheduling-design.md) (merged #3200) · Plan: [`2026-07-17-workforce-staffing-substrate-implementation.md`](docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md) · Kernel: `DI-C8BF6362B44C` (architecture), `DI-78788D22BE65` (solver-first: Timefold).

## What's in it

14 new models — the nine design aggregates plus normalized supporting tables:

- `StaffingDemand` (with the **`demandShape`** discriminator — `coverage_floor | forecast_curve | fixed_slot | task_pipeline | census_load`, spec §9.9.1), `StaffingShift`, `StaffingAssignment` (offer/claim lifecycle + `assignmentMode` for capacity the org doesn't command, §9.9.4), `StaffingAssignmentEvent` (append-only history, §5.3).
- `StaffingCrew` / `StaffingCrewMember` / `StaffingResourceLink` — typed crew/composite assignable units and co-scheduled resources (vehicle/room/operatory/kit) so double-booking detection covers equipment and rooms (§9.9.2).
- `EmployeeAvailabilityWindow`, `EmployeeSchedulingPreference`, `StaffingConstraintRule` (typed hard/soft predicates + legal-waivability, §9.8), `StaffingProposalRun`/`StaffingProposalOption` (immutable run → options, §5.1.7), `StaffingExceptionRequest`, `WorkforceCandidateFact` (non-authoritative until reviewed, §5.1.9).

Optimistic-concurrency `version` columns on the mutable aggregates; instant + timezone + local-date storage (§5.3).

## Why it's low-risk

- **Additive only.** Cross-domain references (employee/org/principal/leave/credential/proposal) are bare indexed FK columns matching the schema's `organizationId` convention, so **no hub model is touched**. The migration is 14 `CREATE TABLE` + 7 intra-domain FK constraints, **zero `DROP`/`ALTER` of existing tables**.
- Relations are declared only within the new staffing domain; `String` discriminators match the existing `LeaveRequest`/`TimesheetPeriod` status convention.

## Verification

- `prisma generate` clean; migration applies on an empty DB (14 tables, 7 FKs, verified via `psql -v ON_ERROR_STOP=1`).
- 10 schema-invariant tests pass ([`workforce-staffing-substrate-schema.test.ts`](packages/db/src/workforce-staffing-substrate-schema.test.ts)) — demand-shape discriminator, offer/claim lifecycle, version columns, append-only history, hard/soft predicates, proposal immutability, candidate-fact non-authority, additive migration.
- `@dpf/db` + `apps/web` typecheck clean; local-CI pregate green.

Later phases (own PRs): constraint & rule-pack engine → solver adapter + Timefold spike → coworker proposal flow → MCP staffing pack → People→Staffing UX → calendar/comms projections → full verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Local-CI-Override: Local pregate's only failures are 3 pre-existing apps/web component test files failing on Node's `localStorage is not available (--localstorage-file not provided)` env quirk; diff touches zero apps/web files and no staffing/db test fails. DB change independently verified (prisma generate, migration applies on real DB, 10 schema tests, typecheck, full ratchet-guard loop green after the sanctioned substrate re-baseline). GitHub CI is authoritative.
