### PR TITLE
feat(asset-intel): AI identity-resolution fallback for the ambiguous tail + inference cost guardrail (BI-85359521)

### DIFF
--- a/apps/web/lib/asset-intelligence/identity-inference-constants.ts
+++ b/apps/web/lib/asset-intelligence/identity-inference-constants.ts
@@ -1,0 +1,31 @@
+/**
+ * AI identity-resolution fallback schedule constants (EP-ASSET-INTELLIGENCE, spec §4.2/§8).
+ * Kept separate from the Inngest function so the scheduled-jobs catalog and its parity
+ * test can import the ids without pulling in the queue runtime.
+ */
+export const IDENTITY_INFERENCE_JOB_ID = "identity-inference-fallback";
+export const IDENTITY_INFERENCE_JOB_NAME = "AI identity-resolution fallback";
+export const IDENTITY_INFERENCE_SCHEDULED_INNGEST_ID = "ops/identity-inference-fallback-scheduled";
+export const IDENTITY_INFERENCE_REQUESTED_INNGEST_ID = "ops/identity-inference-fallback-requested";
+export const IDENTITY_INFERENCE_REQUESTED_EVENT = "ops/identity-inference-fallback.requested";
+/**
+ * Weekly on Tuesday at 04:43 UTC — a day after the catalog-enrichment sweep (Mon 04:37)
+ * so freshly-enriched CatalogIdentities exist before the AI resolves the tail. The odd
+ * 04:43 minute keeps it off the shared 04:00/05:00 ticks (scheduling-map contention
+ * guard: no cron shared by 3+ jobs). Keep this literal in sync with the catalog entry
+ * in scheduled-jobs/catalog.ts.
+ */
+export const IDENTITY_INFERENCE_CRON = "43 4 * * 2";
+export const IDENTITY_INFERENCE_CADENCE = "Weekly on Tuesday at 04:43 UTC";
+/** Per-poll scan bound — Vercel-friendly; repeated polls rotate through the tail. */
+export const IDENTITY_INFERENCE_SCAN_LIMIT = 200;
+/** Entities per model call — the batch half of the cost guardrail (spec §4.2). */
+export const IDENTITY_INFERENCE_BATCH_SIZE = 20;
+/**
+ * Per-run inference-token budget cap — the budget half of the cost guardrail. Bounds a
+ * single pass so a 10k+-entity estate cannot blow the AI budget in one sweep; the
+ * remainder is picked up on the next poll (stalest-first rotation).
+ */
+export const IDENTITY_INFERENCE_TOKEN_BUDGET = 200_000;
+/** Hard backstop on model calls per run, independent of tokens. */
+export const IDENTITY_INFERENCE_MAX_CALLS = 25;

--- a/apps/web/lib/asset-intelligence/identity-inference-runner.test.ts
+++ b/apps/web/lib/asset-intelligence/identity-inference-runner.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { parseProposals } from "./identity-inference-runner";
+
+const ids = new Set(["e1", "e2"]);
+
+describe("parseProposals", () => {
+  it("parses a plain JSON array of proposals", () => {
+    const content = JSON.stringify([
+      { entityId: "e1", manufacturer: "PostgreSQL Global Dev Group", product: "PostgreSQL", productVersion: "16", edition: null, part: "a", confidence: 0.95 },
+    ]);
+    const out = parseProposals(content, ids);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ entityId: "e1", manufacturer: "PostgreSQL Global Dev Group", product: "PostgreSQL", part: "a", confidence: 0.95 });
+  });
+
+  it("strips markdown code fences", () => {
+    const content = "```json\n[{\"entityId\":\"e1\",\"manufacturer\":\"Nginx\",\"product\":\"Nginx\",\"confidence\":0.9}]\n```";
+    expect(parseProposals(content, ids)).toHaveLength(1);
+  });
+
+  it("tolerates leading prose before the array", () => {
+    const content = 'Here are the identifications:\n[{"entityId":"e2","manufacturer":"Redis","product":"Redis","confidence":0.8}]';
+    const out = parseProposals(content, ids);
+    expect(out[0].entityId).toBe("e2");
+  });
+
+  it("drops proposals for entities not in the batch", () => {
+    const content = JSON.stringify([
+      { entityId: "e1", manufacturer: "A", product: "B", confidence: 0.9 },
+      { entityId: "STRAY", manufacturer: "C", product: "D", confidence: 0.9 },
+    ]);
+    const out = parseProposals(content, ids);
+    expect(out.map((p) => p.entityId)).toEqual(["e1"]);
+  });
+
+  it("drops proposals missing manufacturer or product", () => {
+    const content = JSON.stringify([
+      { entityId: "e1", manufacturer: "", product: "B", confidence: 0.9 },
+      { entityId: "e2", manufacturer: "C", product: "", confidence: 0.9 },
+    ]);
+    expect(parseProposals(content, ids)).toHaveLength(0);
+  });
+
+  it("clamps confidence to [0,1] and defaults an invalid part to 'a'", () => {
+    const content = JSON.stringify([
+      { entityId: "e1", manufacturer: "A", product: "B", part: "x", confidence: 5 },
+    ]);
+    const out = parseProposals(content, ids);
+    expect(out[0].confidence).toBe(1);
+    expect(out[0].part).toBe("a");
+  });
+
+  it("defaults a missing/invalid confidence to 0", () => {
+    const content = JSON.stringify([{ entityId: "e1", manufacturer: "A", product: "B" }]);
+    expect(parseProposals(content, ids)[0].confidence).toBe(0);
+  });
+
+  it("returns [] on non-JSON or non-array content", () => {
+    expect(parseProposals("I could not identify these.", ids)).toEqual([]);
+    expect(parseProposals('{"entityId":"e1"}', ids)).toEqual([]);
+    expect(parseProposals("", ids)).toEqual([]);
+  });
+});

--- a/apps/web/lib/asset-intelligence/identity-inference-runner.ts
+++ b/apps/web/lib/asset-intelligence/identity-inference-runner.ts
@@ -1,0 +1,200 @@
+// AI identity-resolution fallback runner (EP-ASSET-INTELLIGENCE, spec §4.2/§8).
+//
+// Wires the pure @dpf/db engine to (a) the real prisma client and (b) a cheap-model
+// inference fn built on routeAndCall(budgetClass="minimize_cost") — dynamic model
+// discovery, NO vendor pinning. Maintains the ScheduledJob bookkeeping row and honors
+// the per-job enabled kill switch, like the other governed sweeps.
+//
+// The cost guardrail lives in the engine: the model calls are batched and the runner
+// passes a per-run token budget + hard call cap so a 10k+-entity estate cannot blow
+// the AI budget in one pass.
+
+import type { IdentityInferenceResult, ProposedIdentity, UnresolvedEntityRow } from "@dpf/db";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+import {
+  IDENTITY_INFERENCE_JOB_ID,
+  IDENTITY_INFERENCE_JOB_NAME,
+  IDENTITY_INFERENCE_SCAN_LIMIT,
+  IDENTITY_INFERENCE_BATCH_SIZE,
+  IDENTITY_INFERENCE_TOKEN_BUDGET,
+  IDENTITY_INFERENCE_MAX_CALLS,
+} from "./identity-inference-constants";
+
+export type IdentityInferenceRunOutcome =
+  | ({ skipped: false } & IdentityInferenceResult)
+  | { skipped: true; reason: string };
+
+const SYSTEM_PROMPT =
+  "You are a software/hardware asset-identification assistant. Given discovery signals " +
+  "for unidentified inventory items, return the canonical vendor + product for each item " +
+  "you can confidently identify. Use official manufacturer and product names (e.g. " +
+  '"PostgreSQL Global Development Group" / "PostgreSQL"). Reply with ONLY a JSON array; ' +
+  "omit any item you cannot confidently identify. Each element: " +
+  '{"entityId": string, "manufacturer": string, "product": string, "productVersion": string|null, ' +
+  '"edition": string|null, "part": "a"|"o"|"h", "confidence": number between 0 and 1}. ' +
+  "part = a for application/software, o for operating system, h for hardware. " +
+  "Do not invent an identity you are unsure of — a lower confidence is correct for a guess.";
+
+function buildBatchPrompt(batch: UnresolvedEntityRow[]): string {
+  const items = batch.map((e) => ({
+    entityId: e.id,
+    name: e.name,
+    entityType: e.entityType,
+    manufacturer: e.manufacturer,
+    productModel: e.productModel,
+    observedVersion: e.observedVersion ?? e.normalizedVersion,
+    // A compact slice of raw properties as extra signal, capped so one noisy row
+    // cannot balloon the prompt (context/token economy).
+    signals: truncateSignals(e.properties),
+  }));
+  return `Identify these ${batch.length} inventory items:\n${JSON.stringify(items)}`;
+}
+
+function truncateSignals(properties: unknown): unknown {
+  if (!properties || typeof properties !== "object") return {};
+  const entries = Object.entries(properties as Record<string, unknown>).slice(0, 12);
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of entries) {
+    out[k] = typeof v === "string" ? v.slice(0, 120) : v;
+  }
+  return out;
+}
+
+/** Strip markdown fences and parse the model's JSON array of proposals. Never throws. */
+export function parseProposals(content: string, batchIds: Set<string>): ProposedIdentity[] {
+  const trimmed = content.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "");
+  // Tolerate leading prose before the array.
+  const start = trimmed.indexOf("[");
+  const end = trimmed.lastIndexOf("]");
+  if (start === -1 || end === -1 || end <= start) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed.slice(start, end + 1));
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: ProposedIdentity[] = [];
+  for (const raw of parsed) {
+    if (!raw || typeof raw !== "object") continue;
+    const r = raw as Record<string, unknown>;
+    const entityId = typeof r.entityId === "string" ? r.entityId : null;
+    const manufacturer = typeof r.manufacturer === "string" ? r.manufacturer : "";
+    const product = typeof r.product === "string" ? r.product : "";
+    if (!entityId || !batchIds.has(entityId) || !manufacturer || !product) continue;
+    const confidence =
+      typeof r.confidence === "number" && Number.isFinite(r.confidence)
+        ? Math.max(0, Math.min(1, r.confidence))
+        : 0;
+    const part = r.part === "o" || r.part === "h" ? r.part : "a";
+    out.push({
+      entityId,
+      manufacturer,
+      product,
+      productVersion: typeof r.productVersion === "string" ? r.productVersion : null,
+      edition: typeof r.edition === "string" ? r.edition : null,
+      part,
+      confidence,
+    });
+  }
+  return out;
+}
+
+/**
+ * Run one bounded AI identity-resolution pass and record it against the ScheduledJob
+ * row. Never throws — inference/DB errors are reflected in the row's lastStatus and a
+ * failure count in the result.
+ */
+export async function runIdentityInferenceFallbackJob(
+  options: { scanLimit?: number } = {},
+): Promise<IdentityInferenceRunOutcome> {
+  const { prisma, runIdentityInferenceFallback } = await import("@dpf/db");
+  const { computeNextRunAt } = await import("@/lib/ai-provider-types");
+
+  const job = await prisma.scheduledJob.upsert({
+    where: { jobId: IDENTITY_INFERENCE_JOB_ID },
+    create: {
+      jobId: IDENTITY_INFERENCE_JOB_ID,
+      name: IDENTITY_INFERENCE_JOB_NAME,
+      schedule: "weekly",
+      category: "editable",
+      nextRunAt: computeNextRunAt("weekly", new Date()),
+    },
+    update: {},
+    select: { enabled: true, schedule: true },
+  });
+
+  if (job.enabled === false) {
+    return { skipped: true, reason: "disabled" };
+  }
+
+  await prisma.scheduledJob
+    .update({
+      where: { jobId: IDENTITY_INFERENCE_JOB_ID },
+      data: { lastRunAt: new Date(), lastStatus: "running" },
+    })
+    .catch(() => {});
+
+  // The injectable cheap-model inference fn. Contracted not to throw — a failed batch
+  // resolves nothing (empty proposals) but still reports its token spend so the engine
+  // budget still decrements and the loop makes forward progress.
+  const infer = async (batch: UnresolvedEntityRow[]) => {
+    const batchIds = new Set(batch.map((e) => e.id));
+    try {
+      const { routeAndCall } = await import("@/lib/inference/routed-inference");
+      const routed = await routeAndCall(
+        [{ role: "user", content: buildBatchPrompt(batch) }],
+        SYSTEM_PROMPT,
+        "internal",
+        { taskType: "utility_identity_resolution", budgetClass: "minimize_cost", persistDecision: false },
+      );
+      return {
+        proposals: parseProposals(routed.content, batchIds),
+        tokensUsed: (routed.inputTokens ?? 0) + (routed.outputTokens ?? 0),
+      };
+    } catch {
+      // Estimate a token cost for a failed call so a persistently-failing provider
+      // still exhausts the budget instead of looping the whole scan.
+      return { proposals: [] as ProposedIdentity[], tokensUsed: 1000 };
+    }
+  };
+
+  try {
+    const result = await runIdentityInferenceFallback(
+      // The @dpf/db engine types its prisma surface as a minimal hand-rolled client
+      // shape (method-shorthand, so bivariant); the real client satisfies it structurally.
+      prisma as unknown as Parameters<typeof runIdentityInferenceFallback>[0],
+      infer,
+      {
+        scanLimit: options.scanLimit ?? IDENTITY_INFERENCE_SCAN_LIMIT,
+        batchSize: IDENTITY_INFERENCE_BATCH_SIZE,
+        maxInferenceTokens: IDENTITY_INFERENCE_TOKEN_BUDGET,
+        maxInferenceCalls: IDENTITY_INFERENCE_MAX_CALLS,
+      },
+    );
+
+    const now = new Date();
+    await prisma.scheduledJob
+      .update({
+        where: { jobId: IDENTITY_INFERENCE_JOB_ID },
+        data: {
+          lastRunAt: now,
+          lastStatus: result.failures > 0 ? "partial" : "ok",
+          lastError: result.failures > 0 ? `${result.failures} failure(s)` : null,
+          nextRunAt: computeNextRunAt(job.schedule, now),
+        },
+      })
+      .catch(() => {});
+
+    return { skipped: false, ...result };
+  } catch (err: unknown) {
+    const message = getErrorMessage(err);
+    await prisma.scheduledJob
+      .update({
+        where: { jobId: IDENTITY_INFERENCE_JOB_ID },
+        data: { lastRunAt: new Date(), lastStatus: "error", lastError: message },
+      })
+      .catch(() => {});
+    return { skipped: true, reason: `error: ${message}` };
+  }
+}

--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -34,6 +34,14 @@ import {
   CATALOG_SWEEP_CRON,
   CATALOG_SWEEP_CADENCE,
 } from "@/lib/asset-intelligence/catalog-sweep-constants";
+import {
+  IDENTITY_INFERENCE_JOB_ID,
+  IDENTITY_INFERENCE_JOB_NAME,
+  IDENTITY_INFERENCE_SCHEDULED_INNGEST_ID,
+  IDENTITY_INFERENCE_REQUESTED_EVENT,
+  IDENTITY_INFERENCE_CRON,
+  IDENTITY_INFERENCE_CADENCE,
+} from "@/lib/asset-intelligence/identity-inference-constants";
 
 /** core = platform-integrity cron, operator read-only. editable = cadence
  *  may be tuned by an operator after install. */
@@ -571,6 +579,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
     category: "editable",
     tracksRunData: true,
     runNowEvent: CATALOG_SWEEP_REQUESTED_EVENT,
+  },
+  {
+    jobId: IDENTITY_INFERENCE_JOB_ID,
+    inngestId: IDENTITY_INFERENCE_SCHEDULED_INNGEST_ID,
+    name: IDENTITY_INFERENCE_JOB_NAME,
+    purpose:
+      "EP-ASSET-INTELLIGENCE (spec §4.2/§8): resolves the ambiguous tail of inventory items that deterministic fingerprint rules could not identify, using a cheap model (batched + per-run inference budget cap). Logs each AI resolution, promotes repeated ones to shadow fingerprint rules, and auto-applies only at high confidence. If it stops, unidentified estate items never gain a canonical identity or support-lifecycle posture.",
+    cron: IDENTITY_INFERENCE_CRON,
+    cadence: IDENTITY_INFERENCE_CADENCE,
+    category: "editable",
+    tracksRunData: true,
+    runNowEvent: IDENTITY_INFERENCE_REQUESTED_EVENT,
   },
   {
     jobId: "coworker-certification",

--- a/apps/web/lib/queue/functions/identity-inference-fallback.ts
+++ b/apps/web/lib/queue/functions/identity-inference-fallback.ts
@@ -1,0 +1,57 @@
+// AI identity-resolution fallback (EP-ASSET-INTELLIGENCE, spec §4.2/§8).
+//
+// Turns the pure @dpf/db AI-fallback engine into a governed autonomous loop: a weekly
+// cron pass over the unresolved InventoryEntity tail plus a manual "run now" event for
+// the admin Scheduled Jobs surface. Quiescence-gated (skips during a self-upgrade
+// drain) and honors the ScheduledJob.enabled kill switch inside the runner. The
+// batching + per-run inference budget cost guardrail lives in the engine + runner.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+import {
+  IDENTITY_INFERENCE_CRON,
+  IDENTITY_INFERENCE_REQUESTED_EVENT,
+  IDENTITY_INFERENCE_SCHEDULED_INNGEST_ID,
+  IDENTITY_INFERENCE_REQUESTED_INNGEST_ID,
+} from "@/lib/asset-intelligence/identity-inference-constants";
+
+export const identityInferenceFallbackScheduled = inngest.createFunction(
+  {
+    id: IDENTITY_INFERENCE_SCHEDULED_INNGEST_ID,
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    triggers: [cron(IDENTITY_INFERENCE_CRON)],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+    return step.run("identity-inference-fallback", async () => {
+      const { runIdentityInferenceFallbackJob } = await import(
+        "@/lib/asset-intelligence/identity-inference-runner"
+      );
+      return runIdentityInferenceFallbackJob();
+    });
+  },
+);
+
+// Manual one-shot trigger for the admin "run now" action; supports an optional smaller
+// scan limit for a quick poll.
+export const identityInferenceFallbackRequested = inngest.createFunction(
+  {
+    id: IDENTITY_INFERENCE_REQUESTED_INNGEST_ID,
+    retries: 1,
+    triggers: [{ event: IDENTITY_INFERENCE_REQUESTED_EVENT }],
+  },
+  async ({ event, step }) => {
+    const scanLimit = (event.data as { scanLimit?: number } | undefined)?.scanLimit;
+    return step.run("identity-inference-fallback-manual", async () => {
+      const { runIdentityInferenceFallbackJob } = await import(
+        "@/lib/asset-intelligence/identity-inference-runner"
+      );
+      return runIdentityInferenceFallbackJob(
+        typeof scanLimit === "number" ? { scanLimit } : {},
+      );
+    });
+  },
+);

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -72,6 +72,10 @@ import {
   catalogEnrichmentSweepScheduled,
   catalogEnrichmentSweepRequested,
 } from "./catalog-enrichment-sweep";
+import {
+  identityInferenceFallbackScheduled,
+  identityInferenceFallbackRequested,
+} from "./identity-inference-fallback";
 import { canonicalImprovementDigest } from "./canonical-improvement-digest";
 import {
   coworkerCertificationNightly,
@@ -125,6 +129,7 @@ export const scheduledFunctions = [
   siemCorrelationSweep,       // BI-6D9496F1: EP-SOVEREIGN-SOC P1 — project internal audit -> SecurityEvent + run detection rules, every 15m
   patchAssessmentSweep,       // EP-PATCH-MANAGEMENT P0: daily estate patch posture sweep (OSV+KEV -> AssuranceFinding), 05:00
   catalogEnrichmentSweepScheduled, // EP-ASSET-INTELLIGENCE: weekly CatalogIdentity enrichment loop (endoflife.date + CPE + SBOM), Mon 04:37
+  identityInferenceFallbackScheduled, // EP-ASSET-INTELLIGENCE: weekly cheap-model AI resolution of the unresolved-identity tail (batched, budget-capped), Tue 04:43
   remoteActionClaimTimeout,   // EP-REMOTE-ACTION P2: time out stale claimed RemoteActions so the pull queue can't wedge, every 10m (flag-gated)
   coworkerCertificationNightly, // EP-COWORKER-LIFECYCLE P2 (BI-DE9CC88B): nightly golden-journey certification of every roster coworker, 04:40
   canonicalImprovementDigest, // BI-8996BBBB: weekly [reference-doc] proposal digest -> canonical-source chore BI
@@ -159,6 +164,7 @@ export const eventFunctions = [
   inngestRetentionSweepRequested, // BI-0AB96FE7: operator "run now" / dry-run for the Inngest retention sweep
   mdmStewardSweepRequested, // EP-4A12A7CB slice 4: Data Steward "run now" / dry-run
   catalogEnrichmentSweepRequested, // EP-ASSET-INTELLIGENCE: catalog enrichment "run now" (poll-on-request)
+  identityInferenceFallbackRequested, // EP-ASSET-INTELLIGENCE: AI identity-resolution fallback "run now" (poll-on-request)
   coworkerCertificationRunNow, // EP-COWORKER-LIFECYCLE P2 (BI-DE9CC88B): operator "run now" certification sweep
   semanticMemoryReconcileRequested, // BI-DG-001: operator "run now" semantic-memory orphan reconciliation
 ];

--- a/docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md
+++ b/docs/superpowers/specs/2026-07-16-software-asset-intelligence-enrichment-design.md
@@ -72,6 +72,8 @@ A **decoupled, continuous** stage (not one-shot), triggered on promotion + weekl
 
 Writes results onto `InventoryEntity` / `DigitalProduct` (§4.3), with lineage in `IdentityResolutionLog`.
 
+**AI fallback — LANDED (BI-85359521).** The cheap-model fallback deferred from BI-27EE2AF7 is built as a **decoupled governed stage** (the altitude the kernel selected — DI-7D4E383E9944 — over inlining in `discovery-normalize` or folding into the CatalogIdentity enrichment sweep). Engine: `packages/db/src/catalog-identity-inference.ts` (`runIdentityInferenceFallback`) — a pure loop over an injectable inference fn + client that scans unresolved `InventoryEntity` (catalogIdentityId null / identityStatus in {null, needs_review, needs_reresolve}, never `human_confirmed`) stalest-first, and per proposal: writes an `IdentityResolutionLog(resolutionType='ai_resolved')` row, keeps `InventoryEntity.catalogIdentityId` untouched during the shadow window, promotes repeated identical resolutions of an entity to a `status='shadow'` `DiscoveryFingerprintRule`, and auto-applies the identity **only at confidence ≥ 0.97**. A contradicting `human_confirmed`/`human_corrected` resolution demotes the shadow rule to `rejected`, and a `human_confirmed` identity is never overwritten (§4.1). **Cost guardrail:** the model calls are **batched** (`batchSize`) and bounded by a **per-run inference-token budget cap** + hard call cap, so a 10k+-entity estate cannot blow the AI budget in one pass; the remainder rotates in on the next poll. Governed home: `apps/web/lib/asset-intelligence/identity-inference-{constants,runner}.ts` + the `identity-inference-fallback` scheduled Inngest job (weekly Tue 04:43 + a run-now event), wiring the real prisma and a `routeAndCall(budgetClass="minimize_cost")` inference fn (dynamic model discovery, no vendor pinning).
+
 ### 4.3 Existing-model updates
 
 `InventoryEntity` gains: `catalogIdentityId` (FK), `identityStatus`/`identityConfidence`, `updatePosture` (`unknown|current|behind|ahead`) + source + confidence, `latestKnownVersion`, `supportLifecycleSource`/`supportLifecycleConfidence`. `DigitalProduct` gains: `enrichmentStatus` (`pending|enriched|partial|failed`), `lastEnrichedAt`. The dangling `softwareIdentityId` is resolved **in the same migration that lands `CatalogIdentity`** (rename→`legacySoftwareIdentityId` + join, or drop-with-evidence) — post-state invariant: no discovery/inventory field points at a non-existent table (2026-04-18 §7.4).
@@ -128,6 +130,7 @@ This is the kernel/org-overlay pattern again: component catalog entries are kern
 - Canonical models + dangling-FK fix — **BI-74579817**
 - Enrichment fields on InventoryEntity/DigitalProduct — **BI-70469721**
 - enrich-digital-product pipeline + estate-specialist tools + cost guardrail — **BI-27EE2AF7**
+- AI-assisted identity-resolution fallback for the ambiguous tail + per-run inference cost guardrail — **BI-85359521** — **LANDED** (the cheap-model fallback deferred from BI-27EE2AF7; engine `packages/db/src/catalog-identity-inference.ts`, governed weekly Inngest job `identity-inference-fallback`; shadow window + auto-promote at ≥0.97 + human-precedence demotion + batched/budget-capped guardrail). See §4.2.
 - FingerprintRule catalog + legacy warm-start — **BI-0528AD01**
 
 **Phase B — Open support-lifecycle & vuln feeds:**

--- a/packages/db/src/catalog-identity-inference.test.ts
+++ b/packages/db/src/catalog-identity-inference.test.ts
@@ -1,0 +1,494 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  runIdentityInferenceFallback,
+  demoteHumanContradictedShadowRules,
+  identityKeyForProposal,
+  type IdentityInferenceClient,
+  type IdentityInferenceFn,
+  type ProposedIdentity,
+  type UnresolvedEntityRow,
+} from "./catalog-identity-inference";
+
+// ─── In-memory fake prisma surface ───────────────────────────────────────────
+
+type EntityRow = UnresolvedEntityRow & {
+  catalogIdentityId: string | null;
+  lastSeenAt: number;
+  identityConfidence: number | null;
+};
+type LogRow = {
+  id: string;
+  inventoryEntityId: string | null;
+  catalogIdentityId: string | null;
+  resolutionType: string;
+  confidence: number | null;
+  evidence: unknown;
+};
+type IdentityRow = { id: string; identityKey: string; source: string };
+type RuleRow = {
+  id: string;
+  ruleKey: string;
+  status: string;
+  catalogIdentityId: string | null;
+  sourceObservationIds: string[];
+};
+
+function makeDb(seed: {
+  entities?: EntityRow[];
+  logs?: LogRow[];
+  rules?: RuleRow[];
+}) {
+  const entities = seed.entities ?? [];
+  const logs: LogRow[] = seed.logs ?? [];
+  const identities: IdentityRow[] = [];
+  const rules: RuleRow[] = seed.rules ?? [];
+  let seq = 0;
+  const nextId = (p: string) => `${p}-${++seq}`;
+
+  const isUnresolved = (e: EntityRow) =>
+    e.catalogIdentityId === null &&
+    (e.identityStatus === null ||
+      ["unresolved", "needs_review", "needs_reresolve"].includes(e.identityStatus));
+
+  const db: IdentityInferenceClient = {
+    inventoryEntity: {
+      count: async () => entities.filter(isUnresolved).length,
+      findMany: async (args: unknown) => {
+        const { take } = (args ?? {}) as { take?: number };
+        return entities
+          .filter(isUnresolved)
+          .sort((a, b) => a.lastSeenAt - b.lastSeenAt)
+          .slice(0, take ?? entities.length)
+          .map((e) => ({
+            id: e.id,
+            name: e.name,
+            entityType: e.entityType,
+            manufacturer: e.manufacturer,
+            productModel: e.productModel,
+            observedVersion: e.observedVersion,
+            normalizedVersion: e.normalizedVersion,
+            identityStatus: e.identityStatus,
+            properties: e.properties,
+          }));
+      },
+      updateMany: async ({ where, data }) => {
+        const target = entities.find((e) => e.id === where.id);
+        if (!target) return { count: 0 };
+        if (where.identityStatus?.not && target.identityStatus === where.identityStatus.not) {
+          return { count: 0 };
+        }
+        target.catalogIdentityId = data.catalogIdentityId;
+        target.identityStatus = data.identityStatus;
+        target.identityConfidence = data.identityConfidence;
+        return { count: 1 };
+      },
+    },
+    identityResolutionLog: {
+      findMany: async ({ where }) =>
+        logs
+          .filter(
+            (l) =>
+              l.inventoryEntityId === where.inventoryEntityId &&
+              l.resolutionType === where.resolutionType,
+          )
+          .map((l) => ({ id: l.id, catalogIdentityId: l.catalogIdentityId })),
+      findFirst: async (args: unknown) => {
+        const { where } = (args ?? {}) as {
+          where: { inventoryEntityId: string; resolutionType: { in: string[] } };
+        };
+        const found = logs.find(
+          (l) =>
+            l.inventoryEntityId === where.inventoryEntityId &&
+            where.resolutionType.in.includes(l.resolutionType),
+        );
+        return found ? { id: found.id, catalogIdentityId: found.catalogIdentityId } : null;
+      },
+      create: async ({ data }) => {
+        logs.push({
+          id: nextId("log"),
+          inventoryEntityId: (data.inventoryEntityId as string) ?? null,
+          catalogIdentityId: (data.catalogIdentityId as string) ?? null,
+          resolutionType: data.resolutionType as string,
+          confidence: (data.confidence as number) ?? null,
+          evidence: data.evidence,
+        });
+        return {};
+      },
+    },
+    catalogIdentity: {
+      upsert: async ({ where, create }) => {
+        const existing = identities.find((i) => i.identityKey === where.identityKey);
+        if (existing) {
+          existing.source = "ai_resolved";
+          return { id: existing.id };
+        }
+        const row = { id: nextId("ci"), identityKey: where.identityKey, source: create.source as string };
+        identities.push(row);
+        return { id: row.id };
+      },
+    },
+    discoveryFingerprintRule: {
+      findMany: async ({ where }) =>
+        rules
+          .filter((r) => r.status === where.status)
+          .map((r) => ({
+            id: r.id,
+            catalogIdentityId: r.catalogIdentityId,
+            sourceObservationIds: r.sourceObservationIds,
+          })),
+      findFirst: async ({ where }) => {
+        const found = rules.find((r) => r.ruleKey === where.ruleKey);
+        return found ? { id: found.id } : null;
+      },
+      create: async ({ data }) => {
+        rules.push({
+          id: nextId("rule"),
+          ruleKey: data.ruleKey as string,
+          status: data.status as string,
+          catalogIdentityId: (data.catalogIdentityId as string) ?? null,
+          sourceObservationIds: (data.sourceObservationIds as string[]) ?? [],
+        });
+        return {};
+      },
+      updateMany: async ({ where, data }) => {
+        let count = 0;
+        for (const r of rules) {
+          if (where.id.in.includes(r.id)) {
+            r.status = data.status;
+            count += 1;
+          }
+        }
+        return { count };
+      },
+    },
+  };
+
+  return { db, entities, logs, identities, rules };
+}
+
+function entity(id: string, over: Partial<EntityRow> = {}): EntityRow {
+  return {
+    id,
+    name: over.name ?? `entity-${id}`,
+    entityType: over.entityType ?? "application",
+    manufacturer: over.manufacturer ?? null,
+    productModel: over.productModel ?? null,
+    observedVersion: over.observedVersion ?? null,
+    normalizedVersion: over.normalizedVersion ?? null,
+    identityStatus: over.identityStatus ?? null,
+    properties: over.properties ?? {},
+    catalogIdentityId: over.catalogIdentityId ?? null,
+    lastSeenAt: over.lastSeenAt ?? 0,
+    identityConfidence: over.identityConfidence ?? null,
+  };
+}
+
+/** An inference fn that resolves each entity to a fixed proposal at a chosen confidence. */
+function inferAll(
+  proposal: (e: UnresolvedEntityRow) => Omit<ProposedIdentity, "entityId"> | null,
+  tokensPerCall = 100,
+): IdentityInferenceFn {
+  return async (batch) => ({
+    proposals: batch
+      .map((e) => {
+        const p = proposal(e);
+        return p ? { entityId: e.id, ...p } : null;
+      })
+      .filter((p): p is ProposedIdentity => p !== null),
+    tokensUsed: tokensPerCall,
+  });
+}
+
+// ─── identityKeyForProposal ──────────────────────────────────────────────────
+
+describe("identityKeyForProposal", () => {
+  it("builds a slugged part:manufacturer:product:version:edition key", () => {
+    expect(
+      identityKeyForProposal({
+        manufacturer: "PostgreSQL Global Dev Group",
+        product: "PostgreSQL",
+        productVersion: "16.2",
+        edition: null,
+        part: "a",
+      }),
+    ).toBe("a:postgresql-global-dev-group:postgresql:16-2:");
+  });
+
+  it("defaults part to 'a' and tolerates missing version/edition", () => {
+    expect(identityKeyForProposal({ manufacturer: "Nginx", product: "Nginx" })).toBe(
+      "a:nginx:nginx::",
+    );
+  });
+});
+
+// ─── shadow window: log-only, no catalogIdentityId ───────────────────────────
+
+describe("runIdentityInferenceFallback — shadow window", () => {
+  it("logs ai_resolved but does NOT write catalogIdentityId below the auto-apply threshold", async () => {
+    const { db, entities, logs } = makeDb({ entities: [entity("e1")] });
+    const result = await runIdentityInferenceFallback(
+      db,
+      inferAll(() => ({ manufacturer: "Acme", product: "Widget", confidence: 0.8 })),
+    );
+
+    expect(result.aiResolutionsLogged).toBe(1);
+    expect(result.autoApplied).toBe(0);
+    expect(result.shadowRulesPromoted).toBe(0);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].resolutionType).toBe("ai_resolved");
+    // Shadow window: the entity's canonical link is untouched.
+    expect(entities[0].catalogIdentityId).toBeNull();
+    expect(entities[0].identityStatus).toBeNull();
+  });
+
+  it("ignores a proposal with no manufacturer/product (never fabricates an identity)", async () => {
+    const { db, logs } = makeDb({ entities: [entity("e1")] });
+    const result = await runIdentityInferenceFallback(
+      db,
+      inferAll(() => ({ manufacturer: "", product: "", confidence: 0.99 })),
+    );
+    expect(result.proposalsReceived).toBe(1);
+    expect(result.aiResolutionsLogged).toBe(0);
+    expect(result.autoApplied).toBe(0);
+    expect(logs).toHaveLength(0);
+  });
+
+  it("resolves nothing when the model omits the entity", async () => {
+    const { db, entities } = makeDb({ entities: [entity("e1")] });
+    const result = await runIdentityInferenceFallback(db, inferAll(() => null));
+    expect(result.entitiesInferred).toBe(1);
+    expect(result.proposalsReceived).toBe(0);
+    expect(result.aiResolutionsLogged).toBe(0);
+    expect(entities[0].catalogIdentityId).toBeNull();
+  });
+});
+
+// ─── auto-apply at >= 0.97 ───────────────────────────────────────────────────
+
+describe("runIdentityInferenceFallback — auto-apply", () => {
+  it("writes catalogIdentityId + identityStatus at confidence >= 0.97", async () => {
+    const { db, entities } = makeDb({ entities: [entity("e1")] });
+    const result = await runIdentityInferenceFallback(
+      db,
+      inferAll(() => ({ manufacturer: "Acme", product: "Widget", confidence: 0.98 })),
+    );
+    expect(result.autoApplied).toBe(1);
+    expect(entities[0].catalogIdentityId).not.toBeNull();
+    expect(entities[0].identityStatus).toBe("ai_resolved");
+    expect(entities[0].identityConfidence).toBe(0.98);
+  });
+
+  it("respects a custom autoApplyThreshold", async () => {
+    const { db, entities } = makeDb({ entities: [entity("e1")] });
+    const result = await runIdentityInferenceFallback(
+      db,
+      inferAll(() => ({ manufacturer: "Acme", product: "Widget", confidence: 0.9 })),
+      { autoApplyThreshold: 0.85 },
+    );
+    expect(result.autoApplied).toBe(1);
+    expect(entities[0].catalogIdentityId).not.toBeNull();
+  });
+
+  it("NEVER overwrites a human_confirmed identity", async () => {
+    // The scan excludes it (identityStatus not in the unresolved set), and even if it
+    // reached the write the guard blocks it. Assert the scan exclusion here.
+    const { db, entities } = makeDb({
+      entities: [entity("e1", { identityStatus: "human_confirmed" })],
+    });
+    const result = await runIdentityInferenceFallback(
+      db,
+      inferAll(() => ({ manufacturer: "Acme", product: "Widget", confidence: 0.99 })),
+    );
+    expect(result.entitiesScanned).toBe(0);
+    expect(result.autoApplied).toBe(0);
+    expect(entities[0].identityStatus).toBe("human_confirmed");
+  });
+});
+
+// ─── shadow rule promotion ───────────────────────────────────────────────────
+
+describe("runIdentityInferenceFallback — shadow rule promotion", () => {
+  it("promotes a shadow rule after N identical resolutions of the same entity", async () => {
+    const seed = makeDb({ entities: [entity("e1")] });
+    const infer = inferAll(() => ({ manufacturer: "Acme", product: "Widget", confidence: 0.8 }));
+
+    // Runs 1 and 2: below threshold (3) — log only, no rule.
+    await runIdentityInferenceFallback(seed.db, infer, { shadowPromotionThreshold: 3 });
+    let r = await runIdentityInferenceFallback(seed.db, infer, { shadowPromotionThreshold: 3 });
+    expect(r.shadowRulesPromoted).toBe(0);
+    expect(seed.rules).toHaveLength(0);
+
+    // Run 3: the 3rd identical resolution crosses the bar → shadow rule.
+    r = await runIdentityInferenceFallback(seed.db, infer, { shadowPromotionThreshold: 3 });
+    expect(r.shadowRulesPromoted).toBe(1);
+    expect(seed.rules).toHaveLength(1);
+    expect(seed.rules[0].status).toBe("shadow");
+    expect(seed.rules[0].sourceObservationIds).toEqual(["e1"]);
+
+    // Run 4: entity is now settled into shadow (>= threshold logs) → skipped, not re-inferred.
+    r = await runIdentityInferenceFallback(seed.db, infer, { shadowPromotionThreshold: 3 });
+    expect(r.entitiesInferred).toBe(0);
+    expect(r.shadowRulesPromoted).toBe(0);
+    expect(seed.rules).toHaveLength(1); // idempotent — no duplicate rule.
+  });
+
+  it("does not promote when the AI is inconsistent (different identity each run)", async () => {
+    const seed = makeDb({ entities: [entity("e1")] });
+    let n = 0;
+    const infer: IdentityInferenceFn = async (batch) => ({
+      proposals: batch.map((e) => ({
+        entityId: e.id,
+        manufacturer: "Acme",
+        product: `Widget${n++}`,
+        confidence: 0.8,
+      })),
+      tokensUsed: 50,
+    });
+    await runIdentityInferenceFallback(seed.db, infer, { shadowPromotionThreshold: 3 });
+    await runIdentityInferenceFallback(seed.db, infer, { shadowPromotionThreshold: 3 });
+    const r = await runIdentityInferenceFallback(seed.db, infer, { shadowPromotionThreshold: 3 });
+    expect(r.shadowRulesPromoted).toBe(0);
+    expect(seed.rules).toHaveLength(0);
+  });
+});
+
+// ─── cost guardrail: batching + per-run budget cap ───────────────────────────
+
+describe("runIdentityInferenceFallback — cost guardrail", () => {
+  it("batches entities per inference call", async () => {
+    const ents = Array.from({ length: 45 }, (_, i) => entity(`e${i}`, { lastSeenAt: i }));
+    const { db } = makeDb({ entities: ents });
+    let calls = 0;
+    let maxBatch = 0;
+    const infer: IdentityInferenceFn = async (batch) => {
+      calls += 1;
+      maxBatch = Math.max(maxBatch, batch.length);
+      return { proposals: [], tokensUsed: 10 };
+    };
+    const r = await runIdentityInferenceFallback(db, infer, { batchSize: 20 });
+    expect(maxBatch).toBe(20);
+    expect(calls).toBe(3); // 20 + 20 + 5
+    expect(r.inferenceCalls).toBe(3);
+  });
+
+  it("stops dispatching once the per-run token budget is exhausted", async () => {
+    const ents = Array.from({ length: 100 }, (_, i) => entity(`e${i}`, { lastSeenAt: i }));
+    const { db } = makeDb({ entities: ents });
+    const infer: IdentityInferenceFn = async () => ({ proposals: [], tokensUsed: 500 });
+    const r = await runIdentityInferenceFallback(db, infer, {
+      batchSize: 10,
+      maxInferenceTokens: 1000, // budget covers ~2 calls (500 each) before the 3rd is blocked.
+    });
+    expect(r.budgetExhausted).toBe(true);
+    expect(r.inferenceCalls).toBe(2);
+    expect(r.inferenceTokensSpent).toBe(1000);
+  });
+
+  it("enforces the hard inference-call cap", async () => {
+    const ents = Array.from({ length: 100 }, (_, i) => entity(`e${i}`, { lastSeenAt: i }));
+    const { db } = makeDb({ entities: ents });
+    const infer: IdentityInferenceFn = async () => ({ proposals: [], tokensUsed: 1 });
+    const r = await runIdentityInferenceFallback(db, infer, {
+      batchSize: 5,
+      maxInferenceCalls: 3,
+      maxInferenceTokens: 10_000_000,
+    });
+    expect(r.budgetExhausted).toBe(true);
+    expect(r.inferenceCalls).toBe(3);
+  });
+
+  it("reports the total unresolved count for coverage even when bounded", async () => {
+    const ents = Array.from({ length: 30 }, (_, i) => entity(`e${i}`, { lastSeenAt: i }));
+    const { db } = makeDb({ entities: ents });
+    const r = await runIdentityInferenceFallback(db, inferAll(() => null), { scanLimit: 10 });
+    expect(r.unresolvedTotal).toBe(30);
+    expect(r.entitiesScanned).toBe(10);
+  });
+});
+
+// ─── human demotion of a contradicted shadow rule ────────────────────────────
+
+describe("demoteHumanContradictedShadowRules", () => {
+  it("rejects a shadow rule when a human resolved its source entity to a different identity", async () => {
+    const { db, rules } = makeDb({
+      rules: [
+        {
+          id: "rule-x",
+          ruleKey: "ai-shadow:e1:a:acme:widget::",
+          status: "shadow",
+          catalogIdentityId: "ci-widget",
+          sourceObservationIds: ["e1"],
+        },
+      ],
+      logs: [
+        {
+          id: "log-h",
+          inventoryEntityId: "e1",
+          catalogIdentityId: "ci-gadget", // human landed on a DIFFERENT identity
+          resolutionType: "human_confirmed",
+          confidence: 1,
+          evidence: {},
+        },
+      ],
+    });
+    const demoted = await demoteHumanContradictedShadowRules(db);
+    expect(demoted).toBe(1);
+    expect(rules[0].status).toBe("rejected");
+  });
+
+  it("leaves a shadow rule alone when the human confirms the SAME identity", async () => {
+    const { db, rules } = makeDb({
+      rules: [
+        {
+          id: "rule-x",
+          ruleKey: "ai-shadow:e1:a:acme:widget::",
+          status: "shadow",
+          catalogIdentityId: "ci-widget",
+          sourceObservationIds: ["e1"],
+        },
+      ],
+      logs: [
+        {
+          id: "log-h",
+          inventoryEntityId: "e1",
+          catalogIdentityId: "ci-widget", // same identity — no contradiction
+          resolutionType: "human_confirmed",
+          confidence: 1,
+          evidence: {},
+        },
+      ],
+    });
+    const demoted = await demoteHumanContradictedShadowRules(db);
+    expect(demoted).toBe(0);
+    expect(rules[0].status).toBe("shadow");
+  });
+
+  it("is invoked at the start of a run and reported in the result", async () => {
+    const { db, rules } = makeDb({
+      entities: [],
+      rules: [
+        {
+          id: "rule-x",
+          ruleKey: "ai-shadow:e1:a:acme:widget::",
+          status: "shadow",
+          catalogIdentityId: "ci-widget",
+          sourceObservationIds: ["e1"],
+        },
+      ],
+      logs: [
+        {
+          id: "log-h",
+          inventoryEntityId: "e1",
+          catalogIdentityId: "ci-other",
+          resolutionType: "human_corrected",
+          confidence: 1,
+          evidence: {},
+        },
+      ],
+    });
+    const r = await runIdentityInferenceFallback(db, inferAll(() => null));
+    expect(r.shadowRulesDemoted).toBe(1);
+    expect(rules[0].status).toBe("rejected");
+  });
+});

--- a/packages/db/src/catalog-identity-inference.ts
+++ b/packages/db/src/catalog-identity-inference.ts
@@ -1,0 +1,556 @@
+// AI-assisted identity-resolution fallback (EP-ASSET-INTELLIGENCE, spec §4.2 / §8).
+//
+// Deterministic fingerprint rules (discovery-normalize) resolve only the confident
+// head of an estate; entities whose day-one signals match no rule land with
+// catalogIdentityId=null / identityStatus in {null, needs_review, needs_reresolve}
+// — the "ambiguous tail". This module is the decoupled, cost-guarded stage that
+// resolves that tail with a cheap model (spec §4.2: "a cheap-model fallback resolves
+// the ambiguous tail"). It is the altitude the kernel selected (DI-7D4E383E9944):
+// a new decoupled stage, not inline in the hot discovery-normalize path nor folded
+// into the CatalogIdentity enrichment sweep.
+//
+// Shadow discipline (spec §8 auto-promote path):
+//   - Each AI resolution writes an IdentityResolutionLog row (resolutionType='ai_resolved').
+//   - During the shadow window it does NOT write InventoryEntity.catalogIdentityId.
+//   - Repeated identical AI resolutions of the same entity promote a status='shadow'
+//     DiscoveryFingerprintRule (append-only lineage; the rule generalizes the signal).
+//   - Only a confidence >= autoApplyThreshold (0.97) resolution auto-applies the
+//     identity (writes catalogIdentityId + identityStatus='ai_resolved').
+//   - A contradicting human_confirmed / human_corrected resolution demotes the shadow
+//     rule to 'rejected', and a human_confirmed InventoryEntity identity is NEVER
+//     overwritten (spec §4.1 / §6.3.1) — the scan excludes it and the auto-apply
+//     write is additionally guarded.
+//
+// Cost guardrail (spec §4.2 / gap-closure §11 Q2): the model calls are BATCHED and
+// bounded by a per-run inference-token budget cap plus a hard call cap, so a
+// 10k+-entity estate cannot blow the budget in one pass. Stalest-first + poll-on-
+// request, the same governed-loop shape as catalog-enrichment-sweep.ts.
+//
+// Pure orchestration over an injectable inference fn + client (no prisma import), so
+// it stays unit-testable with mocks — the governed apps/web runner wires the real
+// prisma + a routeAndCall(minimize_cost) inference fn (dynamic model discovery, no
+// vendor pinning).
+
+/** One unresolved InventoryEntity the AI fallback will attempt to identify. */
+export type UnresolvedEntityRow = {
+  id: string;
+  name: string;
+  entityType: string;
+  manufacturer: string | null;
+  productModel: string | null;
+  observedVersion: string | null;
+  normalizedVersion: string | null;
+  identityStatus: string | null;
+  properties: unknown;
+};
+
+/** An identity the model proposes for one entity. */
+export type ProposedIdentity = {
+  /** The UnresolvedEntityRow.id this proposal resolves. */
+  entityId: string;
+  manufacturer: string;
+  product: string;
+  productVersion?: string | null;
+  edition?: string | null;
+  /** CPE 2.3 part: a (application) | o (os) | h (hardware). Defaults to 'a'. */
+  part?: string;
+  /** 0..1 self-reported confidence; auto-apply only clears at autoApplyThreshold. */
+  confidence: number;
+  /** Optional evidence packet echoed into the IdentityResolutionLog row. */
+  evidence?: Record<string, unknown>;
+};
+
+/**
+ * The injectable inference fn: takes a batch of unresolved entities and returns the
+ * subset it could confidently identify (entities it cannot resolve are omitted), plus
+ * the tokens the call consumed so the runner can enforce the per-run budget cap. It
+ * must never throw — a failed batch returns `{ proposals: [], tokensUsed }` so the
+ * loop degrades to "resolved nothing this batch" rather than aborting the run.
+ */
+export type IdentityInferenceFn = (
+  batch: UnresolvedEntityRow[],
+) => Promise<{ proposals: ProposedIdentity[]; tokensUsed: number }>;
+
+export type IdentityInferenceOptions = {
+  /** Max unresolved entities to scan per run (stalest-first). Default 200. */
+  scanLimit?: number;
+  /** Entities per inference call — the batch half of the cost guardrail. Default 20. */
+  batchSize?: number;
+  /**
+   * Per-run inference-token budget cap. Once cumulative tokensUsed reaches this, no
+   * further batch is dispatched (the budget half of the cost guardrail). Default 200_000.
+   */
+  maxInferenceTokens?: number;
+  /** Hard backstop on inference calls per run, independent of tokens. Default 25. */
+  maxInferenceCalls?: number;
+  /**
+   * Repeated identical AI resolutions of one entity needed before a shadow rule is
+   * promoted (spec §8). Default 3. Below-threshold resolutions only log lineage.
+   */
+  shadowPromotionThreshold?: number;
+  /**
+   * Confidence at/above which an AI resolution auto-applies catalogIdentityId
+   * (spec §8 auto-promote path). Default 0.97.
+   */
+  autoApplyThreshold?: number;
+};
+
+const DEFAULTS = {
+  scanLimit: 200,
+  batchSize: 20,
+  maxInferenceTokens: 200_000,
+  maxInferenceCalls: 25,
+  shadowPromotionThreshold: 3,
+  autoApplyThreshold: 0.97,
+} as const;
+
+export type IdentityInferenceResult = {
+  /** Total unresolved entities (for coverage reporting — a bounded run is not full coverage). */
+  unresolvedTotal: number;
+  /** Candidates examined this run (<= scanLimit). */
+  entitiesScanned: number;
+  /** Entities actually sent to the model (skips those already settled into shadow). */
+  entitiesInferred: number;
+  /** Proposals the model returned. */
+  proposalsReceived: number;
+  /** IdentityResolutionLog(ai_resolved) rows written. */
+  aiResolutionsLogged: number;
+  /** Shadow DiscoveryFingerprintRules promoted this run. */
+  shadowRulesPromoted: number;
+  /** Entities auto-applied (confidence >= threshold → catalogIdentityId written). */
+  autoApplied: number;
+  /** Shadow rules demoted to 'rejected' by a contradicting human resolution. */
+  shadowRulesDemoted: number;
+  inferenceCalls: number;
+  inferenceTokensSpent: number;
+  /** True when the token/call budget stopped the run before the scan was exhausted. */
+  budgetExhausted: boolean;
+  failures: number;
+};
+
+// ─── Minimal prisma surface (mock-friendly; real client satisfies structurally) ──
+
+type AiResolvedLogRow = { id: string; catalogIdentityId: string | null };
+
+type ShadowRuleRow = {
+  id: string;
+  catalogIdentityId: string | null;
+  sourceObservationIds: string[];
+};
+
+export type IdentityInferenceClient = {
+  inventoryEntity: {
+    count(args?: unknown): Promise<number>;
+    findMany(args: unknown): Promise<UnresolvedEntityRow[]>;
+    updateMany(args: {
+      where: { id: string; identityStatus?: { not: string } };
+      data: { catalogIdentityId: string; identityStatus: string; identityConfidence: number };
+    }): Promise<{ count: number }>;
+  };
+  identityResolutionLog: {
+    findMany(args: {
+      where: { inventoryEntityId: string; resolutionType: string };
+      select: { id: true; catalogIdentityId: true };
+    }): Promise<AiResolvedLogRow[]>;
+    findFirst(args: unknown): Promise<{ id: string; catalogIdentityId: string | null } | null>;
+    create(args: { data: Record<string, unknown> }): Promise<unknown>;
+  };
+  catalogIdentity: {
+    upsert(args: {
+      where: { identityKey: string };
+      update: Record<string, unknown>;
+      create: Record<string, unknown>;
+      select: { id: true };
+    }): Promise<{ id: string }>;
+  };
+  discoveryFingerprintRule: {
+    findMany(args: {
+      where: { status: string };
+      select: { id: true; catalogIdentityId: true; sourceObservationIds: true };
+    }): Promise<ShadowRuleRow[]>;
+    findFirst(args: {
+      where: { ruleKey: string };
+      select: { id: true };
+    }): Promise<{ id: string } | null>;
+    create(args: { data: Record<string, unknown> }): Promise<unknown>;
+    updateMany(args: {
+      where: { id: { in: string[] } };
+      data: { status: string };
+    }): Promise<{ count: number }>;
+  };
+};
+
+// ─── Pure helpers ────────────────────────────────────────────────────────────
+
+const slug = (s: string): string =>
+  s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+
+/**
+ * Stable canonical key for a proposed identity, aligned with deriveCatalogIdentity's
+ * `part:manufacturer:product` scheme but extended with version+edition so distinct
+ * versions resolve to distinct CatalogIdentity rows (each carries its own lifecycle
+ * milestones). The `:` separator is safe — slug() strips it from every field.
+ */
+export function identityKeyForProposal(p: {
+  manufacturer: string;
+  product: string;
+  productVersion?: string | null;
+  edition?: string | null;
+  part?: string;
+}): string {
+  return [
+    p.part && p.part.trim() ? p.part.trim() : "a",
+    slug(p.manufacturer),
+    slug(p.product),
+    slug(p.productVersion ?? ""),
+    slug(p.edition ?? ""),
+  ].join(":");
+}
+
+/** Deterministic shadow-rule key for an (entity, identity) promotion. */
+function shadowRuleKey(entityId: string, identityKey: string): string {
+  return `ai-shadow:${entityId}:${identityKey}`;
+}
+
+function normalizeProposal(p: ProposedIdentity): {
+  ok: boolean;
+  manufacturer: string;
+  product: string;
+  productVersion: string | null;
+  edition: string | null;
+  part: string;
+  identityKey: string;
+} {
+  const manufacturer = (p.manufacturer ?? "").trim();
+  const product = (p.product ?? "").trim();
+  const part = p.part && p.part.trim() ? p.part.trim() : "a";
+  const productVersion = p.productVersion?.trim() ? p.productVersion.trim() : null;
+  const edition = p.edition?.trim() ? p.edition.trim() : null;
+  const identityKey = identityKeyForProposal({ manufacturer, product, productVersion, edition, part });
+  // A proposal with no manufacturer+product cannot key a canonical identity — reject it
+  // (never fabricate an identity from a blank; spec §4.1 raw strings never leak a name).
+  const ok = manufacturer.length > 0 && product.length > 0;
+  return { ok, manufacturer, product, productVersion, edition, part, identityKey };
+}
+
+// ─── Demotion: humans win (spec §4.1 / §6.3.1) ───────────────────────────────
+
+/**
+ * Reject any shadow rule contradicted by a human. A shadow rule carries its source
+ * entity id in `sourceObservationIds`; if a human_confirmed / human_corrected
+ * IdentityResolutionLog exists for that entity resolving to a DIFFERENT
+ * CatalogIdentity, the human overrides the AI-promoted rule and it is set to
+ * 'rejected'. Runs before inference so a rejected rule is not re-promoted the same pass.
+ */
+export async function demoteHumanContradictedShadowRules(
+  db: IdentityInferenceClient,
+): Promise<number> {
+  const shadowRules = await db.discoveryFingerprintRule.findMany({
+    where: { status: "shadow" },
+    select: { id: true, catalogIdentityId: true, sourceObservationIds: true },
+  });
+
+  const toReject: string[] = [];
+  for (const rule of shadowRules) {
+    const sourceEntityId = rule.sourceObservationIds[0];
+    if (!sourceEntityId) continue;
+    const humanLog = await db.identityResolutionLog.findFirst({
+      where: {
+        inventoryEntityId: sourceEntityId,
+        resolutionType: { in: ["human_confirmed", "human_corrected"] },
+      },
+      select: { id: true, catalogIdentityId: true },
+    });
+    // A human resolution that lands on a DIFFERENT identity than the shadow rule
+    // contradicts it. A human confirming the SAME identity leaves it shadow (it will
+    // graduate through the normal promotion path).
+    if (humanLog && humanLog.catalogIdentityId !== rule.catalogIdentityId) {
+      toReject.push(rule.id);
+    }
+  }
+
+  if (toReject.length === 0) return 0;
+  const { count } = await db.discoveryFingerprintRule.updateMany({
+    where: { id: { in: toReject } },
+    data: { status: "rejected" },
+  });
+  return count;
+}
+
+// ─── Main loop ───────────────────────────────────────────────────────────────
+
+/**
+ * Run one bounded, budget-capped AI identity-resolution pass over the unresolved
+ * tail. Idempotent and safe to call repeatedly; per-entity failures are counted,
+ * never fatal. Never writes over a human_confirmed identity.
+ */
+export async function runIdentityInferenceFallback(
+  db: IdentityInferenceClient,
+  infer: IdentityInferenceFn,
+  options: IdentityInferenceOptions = {},
+): Promise<IdentityInferenceResult> {
+  const scanLimit = options.scanLimit ?? DEFAULTS.scanLimit;
+  const batchSize = Math.max(1, options.batchSize ?? DEFAULTS.batchSize);
+  const maxInferenceTokens = options.maxInferenceTokens ?? DEFAULTS.maxInferenceTokens;
+  const maxInferenceCalls = options.maxInferenceCalls ?? DEFAULTS.maxInferenceCalls;
+  const promotionThreshold = Math.max(1, options.shadowPromotionThreshold ?? DEFAULTS.shadowPromotionThreshold);
+  const autoApplyThreshold = options.autoApplyThreshold ?? DEFAULTS.autoApplyThreshold;
+
+  const result: IdentityInferenceResult = {
+    unresolvedTotal: 0,
+    entitiesScanned: 0,
+    entitiesInferred: 0,
+    proposalsReceived: 0,
+    aiResolutionsLogged: 0,
+    shadowRulesPromoted: 0,
+    autoApplied: 0,
+    shadowRulesDemoted: 0,
+    inferenceCalls: 0,
+    inferenceTokensSpent: 0,
+    budgetExhausted: false,
+    failures: 0,
+  };
+
+  // Humans win first, so a rejected rule is not re-promoted in the same pass.
+  try {
+    result.shadowRulesDemoted = await demoteHumanContradictedShadowRules(db);
+  } catch {
+    result.failures += 1;
+  }
+
+  const unresolvedWhere = {
+    catalogIdentityId: null,
+    OR: [
+      { identityStatus: null },
+      { identityStatus: { in: ["unresolved", "needs_review", "needs_reresolve"] } },
+    ],
+  };
+
+  result.unresolvedTotal = await db.inventoryEntity.count({ where: unresolvedWhere });
+
+  const candidates = await db.inventoryEntity.findMany({
+    where: unresolvedWhere,
+    // Stalest-first so repeated polls rotate through the whole tail. An auto-applied
+    // entity leaves the pool (catalogIdentityId set); a shadow-settled one is skipped
+    // below, so forward progress is guaranteed without a cursor.
+    orderBy: { lastSeenAt: "asc" },
+    take: scanLimit,
+    select: {
+      id: true,
+      name: true,
+      entityType: true,
+      manufacturer: true,
+      productModel: true,
+      observedVersion: true,
+      normalizedVersion: true,
+      identityStatus: true,
+      properties: true,
+    },
+  });
+  result.entitiesScanned = candidates.length;
+
+  // Pre-load each candidate's prior ai_resolved lineage so we can (a) skip entities
+  // already settled into shadow (>= threshold prior resolutions — awaiting a human or
+  // a fresher discovery signal) and (b) compute the identical-resolution count for
+  // promotion. Bounded by scanLimit.
+  const priorLogsByEntity = new Map<string, AiResolvedLogRow[]>();
+  const toInfer: UnresolvedEntityRow[] = [];
+  for (const entity of candidates) {
+    let priorLogs: AiResolvedLogRow[] = [];
+    try {
+      priorLogs = await db.identityResolutionLog.findMany({
+        where: { inventoryEntityId: entity.id, resolutionType: "ai_resolved" },
+        select: { id: true, catalogIdentityId: true },
+      });
+    } catch {
+      result.failures += 1;
+    }
+    priorLogsByEntity.set(entity.id, priorLogs);
+    // Already settled into shadow — do not burn budget re-inferring it.
+    if (priorLogs.length < promotionThreshold) {
+      toInfer.push(entity);
+    }
+  }
+
+  // Batched, budget-capped inference loop.
+  for (let i = 0; i < toInfer.length; i += batchSize) {
+    if (result.inferenceCalls >= maxInferenceCalls || result.inferenceTokensSpent >= maxInferenceTokens) {
+      result.budgetExhausted = true;
+      break;
+    }
+    const batch = toInfer.slice(i, i + batchSize);
+
+    let proposals: ProposedIdentity[] = [];
+    try {
+      const inference = await infer(batch);
+      proposals = inference.proposals;
+      result.inferenceTokensSpent += Math.max(0, inference.tokensUsed || 0);
+      result.inferenceCalls += 1;
+      result.entitiesInferred += batch.length;
+    } catch {
+      // The inference fn is contracted not to throw, but stay defensive: count the
+      // batch as a failure and keep going rather than aborting the whole run.
+      result.failures += 1;
+      result.inferenceCalls += 1;
+      continue;
+    }
+
+    const byEntityId = new Map(batch.map((e) => [e.id, e]));
+    for (const proposal of proposals) {
+      const entity = byEntityId.get(proposal.entityId);
+      if (!entity) continue; // proposal for an entity not in this batch — ignore.
+      result.proposalsReceived += 1;
+      try {
+        await processProposal(db, entity, proposal, {
+          priorLogs: priorLogsByEntity.get(entity.id) ?? [],
+          promotionThreshold,
+          autoApplyThreshold,
+          result,
+        });
+      } catch {
+        result.failures += 1;
+      }
+    }
+  }
+
+  return result;
+}
+
+async function processProposal(
+  db: IdentityInferenceClient,
+  entity: UnresolvedEntityRow,
+  proposal: ProposedIdentity,
+  ctx: {
+    priorLogs: AiResolvedLogRow[];
+    promotionThreshold: number;
+    autoApplyThreshold: number;
+    result: IdentityInferenceResult;
+  },
+): Promise<void> {
+  const { result } = ctx;
+  const norm = normalizeProposal(proposal);
+  if (!norm.ok) return; // never fabricate an identity from a blank proposal.
+
+  // Materialize the canonical CatalogIdentity (idempotent on identityKey). Needed as
+  // the FK target for the resolution-log row, the shadow-rule link, and any auto-apply.
+  const confidence = Number.isFinite(proposal.confidence) ? proposal.confidence : 0;
+  const identity = await db.catalogIdentity.upsert({
+    where: { identityKey: norm.identityKey },
+    update: {
+      part: norm.part,
+      manufacturer: norm.manufacturer,
+      product: norm.product,
+      productVersion: norm.productVersion,
+      edition: norm.edition,
+      source: "ai_resolved",
+    },
+    create: {
+      identityKey: norm.identityKey,
+      part: norm.part,
+      manufacturer: norm.manufacturer,
+      product: norm.product,
+      productVersion: norm.productVersion,
+      edition: norm.edition,
+      source: "ai_resolved",
+      confidence,
+    },
+    select: { id: true },
+  });
+
+  // Append the ai_resolved lineage row (spec §4.1). Always written on a valid
+  // proposal — the shadow window keeps InventoryEntity.catalogIdentityId untouched
+  // until either promotion+auto-apply or a human confirmation.
+  await db.identityResolutionLog.create({
+    data: {
+      inventoryEntityId: entity.id,
+      catalogIdentityId: identity.id,
+      resolutionType: "ai_resolved",
+      confidence,
+      evidence: {
+        proposedIdentityKey: norm.identityKey,
+        manufacturer: norm.manufacturer,
+        product: norm.product,
+        productVersion: norm.productVersion,
+        edition: norm.edition,
+        part: norm.part,
+        signals: {
+          name: entity.name,
+          entityType: entity.entityType,
+          manufacturer: entity.manufacturer,
+          productModel: entity.productModel,
+          observedVersion: entity.observedVersion,
+        },
+        ...(proposal.evidence ? { model: proposal.evidence } : {}),
+      },
+    },
+  });
+  result.aiResolutionsLogged += 1;
+
+  // Count identical prior resolutions of THIS entity to THIS identity. Repeated
+  // identical resolutions (the AI is consistent about this entity) promote a shadow
+  // rule; an inconsistent AI (different identity each time) never crosses the bar.
+  const identicalPrior = ctx.priorLogs.filter((l) => l.catalogIdentityId === identity.id).length;
+  const identicalTotal = identicalPrior + 1; // include the row we just wrote.
+  if (identicalTotal >= ctx.promotionThreshold) {
+    await ensureShadowRule(db, entity, identity.id, norm, confidence, result);
+  }
+
+  // Auto-apply only for a high-confidence resolution (spec §8). The updateMany guard
+  // (identityStatus not human_confirmed) is belt-and-braces on top of the scan
+  // exclusion — a human_confirmed identity is NEVER overwritten (spec §4.1).
+  if (confidence >= ctx.autoApplyThreshold) {
+    const { count } = await db.inventoryEntity.updateMany({
+      where: { id: entity.id, identityStatus: { not: "human_confirmed" } },
+      data: {
+        catalogIdentityId: identity.id,
+        identityStatus: "ai_resolved",
+        identityConfidence: confidence,
+      },
+    });
+    if (count > 0) result.autoApplied += 1;
+  }
+}
+
+async function ensureShadowRule(
+  db: IdentityInferenceClient,
+  entity: UnresolvedEntityRow,
+  catalogIdentityId: string,
+  norm: ReturnType<typeof normalizeProposal>,
+  confidence: number,
+  result: IdentityInferenceResult,
+): Promise<void> {
+  const ruleKey = shadowRuleKey(entity.id, norm.identityKey);
+  const existing = await db.discoveryFingerprintRule.findFirst({
+    where: { ruleKey },
+    select: { id: true },
+  });
+  if (existing) return; // already promoted — idempotent.
+
+  await db.discoveryFingerprintRule.create({
+    data: {
+      ruleKey,
+      status: "shadow",
+      scope: "global",
+      source: "auto_promoted",
+      // A minimal name/type match expression derived from the entity's stable signals.
+      // Kept advisory during the shadow window — no deterministic auto-attribution
+      // happens off a shadow rule; only 'active' rules match in discovery-normalize.
+      matchExpression: {
+        entityType: entity.entityType,
+        name: entity.name,
+      },
+      resolvedIdentity: {
+        kind: norm.part === "h" ? "hardware" : norm.part === "o" ? "os" : "software",
+        name: norm.product,
+        vendor: norm.manufacturer,
+      },
+      catalogIdentityId,
+      identityConfidence: confidence,
+      taxonomyConfidence: 0,
+      // Source lineage: the entity that promoted this rule. Used by the demotion pass
+      // to detect a contradicting human resolution.
+      sourceObservationIds: [entity.id],
+    },
+  });
+  result.shadowRulesPromoted += 1;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -389,6 +389,11 @@ export * from "./enrich-digital-product";
 // — the governed loop that runs the endoflife.date / CPE / SBOM feeds over the
 // CatalogIdentity spine. The per-feed modules stay internal; the sweep is the surface.
 export * from "./catalog-enrichment-sweep";
+// Asset-intelligence AI identity-resolution fallback (EP-ASSET-INTELLIGENCE, spec §4.2/§8)
+// — the cheap-model fallback for the ambiguous tail deterministic rules don't resolve,
+// under a batching + per-run inference budget cost guardrail. Pure engine; the governed
+// apps/web runner wires the real prisma + a minimize_cost inference fn.
+export * from "./catalog-identity-inference";
 export * from "./device-placement";
 export * from "./portfolio-sources";
 export * from "./backlog-portfolio";


### PR DESCRIPTION
## What

The cheap-model **AI identity-resolution fallback** deferred from BI-27EE2AF7 (EP-ASSET-INTELLIGENCE, spec §4.2). Deterministic fingerprint rules resolve only the confident head of an estate; entities whose day-one signals match no rule land with `catalogIdentityId=null` / `identityStatus in {null, needs_review, needs_reresolve}` — the ambiguous tail. This resolves that tail with a cheap model.

## Altitude decision (kernel)

Where the fallback hooks in was routed through `principle_decide` (DI-7D4E383E9944, **high** confidence, no commandment conflict): **new decoupled stage** (composite 9.62) over inlining in `discovery-normalize` (2.41) or folding into the catalog-enrichment sweep (6.54).

## How

**Engine** — `packages/db/src/catalog-identity-inference.ts` (pure orchestration over an injectable inference fn + client, no prisma import). Scans the unresolved `InventoryEntity` tail (never `human_confirmed`) stalest-first and per proposal:
- writes an `IdentityResolutionLog(resolutionType='ai_resolved')` row (lineage, spec §4.1);
- keeps `InventoryEntity.catalogIdentityId` **untouched during the shadow window**;
- promotes **repeated identical** resolutions of an entity to a `status='shadow'` `DiscoveryFingerprintRule`;
- **auto-applies** the identity only at **confidence ≥ 0.97** (spec §8 auto-promote path);
- **demotes** a shadow rule to `rejected` when a `human_confirmed`/`human_corrected` resolution contradicts it, and **never overwrites** a `human_confirmed` identity (spec §4.1 / §6.3.1).

**Cost guardrail** (spec §4.2 / gap-closure §11 Q2): model calls are **batched** and bounded by a **per-run inference-token budget cap** + hard call cap, so a 10k+-entity estate cannot blow the AI budget in one pass; the remainder rotates in on the next poll (stalest-first).

**Governed home** — `apps/web/lib/asset-intelligence/identity-inference-{constants,runner}.ts` + the `identity-inference-fallback` scheduled Inngest job (weekly Tue 04:43 + a run-now event), wiring the real prisma and a `routeAndCall(budgetClass="minimize_cost")` inference fn (dynamic model discovery, **no vendor pinning**). Registered in the queue function index + the Scheduled Jobs catalog.

## Tests (local, green)

- `catalog-identity-inference.test.ts` — 17 cases: shadow window (log-only, no fabrication), auto-apply at ≥0.97 + human-confirmed never overwritten, shadow-rule promotion after N identical resolutions (+ no-promote when the AI is inconsistent), cost guardrail (batching, token-budget stop, hard call cap, coverage reporting), human demotion.
- `identity-inference-runner.test.ts` — 8 proposal-parser cases (fences, prose, batch filtering, clamping, non-JSON).
- `queue/functions/index.test.ts` + `scheduling-map.test.ts` parity/contention guards pass.
- `@dpf/db` typecheck clean; web tsc clean except a pre-existing missing-dep in an untouched file.

Spec §4.2/§5 updated (LANDED).

Design-Grounding-Decision: BI-85359521
Process-Spine-Decision: spec 2026-07-16-software-asset-intelligence-enrichment-design.md updated alongside the new modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)