### PR TITLE
feat(workforce): deterministic constraint engine core — Phase 2 (BI-4AD09A35)

### DIFF
--- a/apps/web/lib/workforce/staffing/constraints/evaluate.test.ts
+++ b/apps/web/lib/workforce/staffing/constraints/evaluate.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import { evaluateConstraints } from "./evaluate";
+import type {
+  ConstraintRuleInput,
+  NormalizedStaffingProblem,
+} from "./types";
+import { resolveStarterPack } from "../rule-packs/us";
+
+// EP-WORKFORCE-OPS / BI-4AD09A35 Phase 2 — constraint goldens. Every predicate
+// carries a passing and a violating fixture (spec §17.2).
+
+function zi(at: string) {
+  return { at, timezone: "America/Los_Angeles" };
+}
+
+function baseProblem(
+  partial: Partial<NormalizedStaffingProblem> = {},
+): NormalizedStaffingProblem {
+  return {
+    organizationId: "org-1",
+    jurisdiction: { country: "US", region: "US-CA", resolved: true },
+    employees: [],
+    shifts: [],
+    assignments: [],
+    rules: [],
+    ...partial,
+  };
+}
+
+const HARD = (predicateType: string, parameters: Record<string, unknown> = {}): ConstraintRuleInput => ({
+  ruleId: `r-${predicateType}`,
+  predicateType,
+  severity: "hard",
+  legallyWaivable: false,
+  parameters,
+});
+
+describe("credential_eligibility", () => {
+  const shift = {
+    shiftId: "s1",
+    interval: { start: zi("2026-08-01T16:00:00Z"), end: zi("2026-08-01T20:00:00Z") },
+    workLocationId: null,
+    requiredCredentials: ["rbs_alcohol"],
+  };
+  const assignment = { assignmentId: "a1", shiftId: "s1", employeeProfileId: "e1", lifecycle: "confirmed" };
+
+  it("passes when the assignee holds a valid, unexpired credential", () => {
+    const r = evaluateConstraints(
+      baseProblem({
+        shifts: [shift],
+        assignments: [assignment],
+        employees: [{ employeeProfileId: "e1", credentials: [{ key: "rbs_alcohol", expiresAt: "2027-01-01T00:00:00Z" }], capabilities: [], roleKey: null, employmentType: null }],
+        rules: [HARD("credential_eligibility")],
+      }),
+    );
+    expect(r.feasible).toBe(true);
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it("fails when the credential is expired at shift start", () => {
+    const r = evaluateConstraints(
+      baseProblem({
+        shifts: [shift],
+        assignments: [assignment],
+        employees: [{ employeeProfileId: "e1", credentials: [{ key: "rbs_alcohol", expiresAt: "2026-01-01T00:00:00Z" }], capabilities: [], roleKey: null, employmentType: null }],
+        rules: [HARD("credential_eligibility")],
+      }),
+    );
+    expect(r.feasible).toBe(false);
+    expect(r.violations[0].predicateType).toBe("credential_eligibility");
+  });
+});
+
+describe("capability_presence", () => {
+  const shift = { shiftId: "s1", interval: { start: zi("2026-08-01T16:00:00Z"), end: zi("2026-08-01T20:00:00Z") }, workLocationId: null, requiredCredentials: [] };
+  const rule = HARD("capability_presence", { capability: "dea_keyholder" });
+
+  it("passes when a capability holder is present", () => {
+    const r = evaluateConstraints(baseProblem({
+      shifts: [shift],
+      assignments: [{ assignmentId: "a1", shiftId: "s1", employeeProfileId: "e1", lifecycle: "confirmed" }],
+      employees: [{ employeeProfileId: "e1", credentials: [], capabilities: ["dea_keyholder"], roleKey: null, employmentType: null }],
+      rules: [rule],
+    }));
+    expect(r.feasible).toBe(true);
+  });
+
+  it("fails when a staffed shift has no capability holder", () => {
+    const r = evaluateConstraints(baseProblem({
+      shifts: [shift],
+      assignments: [{ assignmentId: "a1", shiftId: "s1", employeeProfileId: "e1", lifecycle: "confirmed" }],
+      employees: [{ employeeProfileId: "e1", credentials: [], capabilities: [], roleKey: null, employmentType: null }],
+      rules: [rule],
+    }));
+    expect(r.feasible).toBe(false);
+  });
+});
+
+describe("min_n_together (dual control)", () => {
+  const shift = { shiftId: "s1", interval: { start: zi("2026-08-01T16:00:00Z"), end: zi("2026-08-01T20:00:00Z") }, workLocationId: null, requiredCredentials: [] };
+  const rule = HARD("min_n_together", { capability: "vault_authorized", n: 2 });
+  const emp = (id: string, caps: string[]) => ({ employeeProfileId: id, credentials: [], capabilities: caps, roleKey: null, employmentType: null });
+
+  it("passes with two authorized present", () => {
+    const r = evaluateConstraints(baseProblem({
+      shifts: [shift],
+      assignments: [
+        { assignmentId: "a1", shiftId: "s1", employeeProfileId: "e1", lifecycle: "confirmed" },
+        { assignmentId: "a2", shiftId: "s1", employeeProfileId: "e2", lifecycle: "confirmed" },
+      ],
+      employees: [emp("e1", ["vault_authorized"]), emp("e2", ["vault_authorized"])],
+      rules: [rule],
+    }));
+    expect(r.feasible).toBe(true);
+  });
+
+  it("fails with only one authorized present", () => {
+    const r = evaluateConstraints(baseProblem({
+      shifts: [shift],
+      assignments: [
+        { assignmentId: "a1", shiftId: "s1", employeeProfileId: "e1", lifecycle: "confirmed" },
+        { assignmentId: "a2", shiftId: "s1", employeeProfileId: "e2", lifecycle: "confirmed" },
+      ],
+      employees: [emp("e1", ["vault_authorized"]), emp("e2", [])],
+      rules: [rule],
+    }));
+    expect(r.feasible).toBe(false);
+  });
+});
+
+describe("pairing_ratio (apprentice:journeyman)", () => {
+  const shift = { shiftId: "s1", interval: { start: zi("2026-08-01T16:00:00Z"), end: zi("2026-08-01T20:00:00Z") }, workLocationId: null, requiredCredentials: [] };
+  const rule = HARD("pairing_ratio", { supervisedRole: "apprentice", supervisorRole: "journeyman", maxPerSupervisor: 1 });
+  const emp = (id: string, role: string) => ({ employeeProfileId: id, credentials: [], capabilities: [], roleKey: role, employmentType: null });
+  const assign = (id: string, emp: string) => ({ assignmentId: id, shiftId: "s1", employeeProfileId: emp, lifecycle: "confirmed" });
+
+  it("passes at 1 apprentice per journeyman", () => {
+    const r = evaluateConstraints(baseProblem({
+      shifts: [shift],
+      assignments: [assign("a1", "e1"), assign("a2", "e2")],
+      employees: [emp("e1", "journeyman"), emp("e2", "apprentice")],
+      rules: [rule],
+    }));
+    expect(r.feasible).toBe(true);
+  });
+
+  it("fails at 2 apprentices per journeyman", () => {
+    const r = evaluateConstraints(baseProblem({
+      shifts: [shift],
+      assignments: [assign("a1", "e1"), assign("a2", "e2"), assign("a3", "e3")],
+      employees: [emp("e1", "journeyman"), emp("e2", "apprentice"), emp("e3", "apprentice")],
+      rules: [rule],
+    }));
+    expect(r.feasible).toBe(false);
+  });
+});
+
+describe("rest_gap and no_overlap", () => {
+  const emp = { employeeProfileId: "e1", credentials: [], capabilities: [], roleKey: null, employmentType: null };
+  const shiftA = { shiftId: "s1", interval: { start: zi("2026-08-01T00:00:00Z"), end: zi("2026-08-01T08:00:00Z") }, workLocationId: null, requiredCredentials: [] };
+
+  it("rest_gap passes with a 12h gap, fails with a 4h gap", () => {
+    const near = { shiftId: "s2", interval: { start: zi("2026-08-01T12:00:00Z"), end: zi("2026-08-01T20:00:00Z") }, workLocationId: null, requiredCredentials: [] };
+    const far = { shiftId: "s2", interval: { start: zi("2026-08-01T20:00:00Z"), end: zi("2026-08-02T04:00:00Z") }, workLocationId: null, requiredCredentials: [] };
+    const assigns = [
+      { assignmentId: "a1", shiftId: "s1", employeeProfileId: "e1", lifecycle: "confirmed" },
+      { assignmentId: "a2", shiftId: "s2", employeeProfileId: "e1", lifecycle: "confirmed" },
+    ];
+    const rule = HARD("rest_gap", { minHours: 10 });
+    expect(evaluateConstraints(baseProblem({ shifts: [shiftA, far], assignments: assigns, employees: [emp], rules: [rule] })).feasible).toBe(true);
+    expect(evaluateConstraints(baseProblem({ shifts: [shiftA, near], assignments: assigns, employees: [emp], rules: [rule] })).feasible).toBe(false);
+  });
+
+  it("no_overlap fails on overlapping confirmed assignments", () => {
+    const overlap = { shiftId: "s2", interval: { start: zi("2026-08-01T04:00:00Z"), end: zi("2026-08-01T12:00:00Z") }, workLocationId: null, requiredCredentials: [] };
+    const r = evaluateConstraints(baseProblem({
+      shifts: [shiftA, overlap],
+      assignments: [
+        { assignmentId: "a1", shiftId: "s1", employeeProfileId: "e1", lifecycle: "confirmed" },
+        { assignmentId: "a2", shiftId: "s2", employeeProfileId: "e1", lifecycle: "confirmed" },
+      ],
+      employees: [emp],
+      rules: [HARD("no_overlap")],
+    }));
+    expect(r.feasible).toBe(false);
+  });
+});
+
+describe("max_hours_premium (priced, not infeasible)", () => {
+  it("adds a premium for hours over threshold without breaking feasibility", () => {
+    const shift = { shiftId: "s1", interval: { start: zi("2026-08-01T00:00:00Z"), end: zi("2026-08-01T10:00:00Z") }, workLocationId: null, requiredCredentials: [] };
+    const r = evaluateConstraints(baseProblem({
+      shifts: [shift],
+      assignments: [{ assignmentId: "a1", shiftId: "s1", employeeProfileId: "e1", lifecycle: "confirmed" }],
+      employees: [{ employeeProfileId: "e1", credentials: [], capabilities: [], roleKey: null, employmentType: null }],
+      rules: [{ ruleId: "ot", predicateType: "max_hours_premium", severity: "soft", legallyWaivable: false, parameters: { thresholdHours: 8, premiumPerHour: 0.5 } }],
+    }));
+    expect(r.feasible).toBe(true);
+    expect(r.premiums).toHaveLength(1);
+    expect(r.premiums[0].units).toBeCloseTo(1); // (10 - 8) * 0.5
+  });
+});
+
+describe("fail-closed jurisdiction (spec §6, §8.1)", () => {
+  it("requires policy review when jurisdiction is unresolved and a safety-critical rule is in scope", () => {
+    const r = evaluateConstraints(baseProblem({
+      jurisdiction: { country: null, region: null, resolved: false },
+      rules: [HARD("credential_eligibility")],
+    }));
+    expect(r.requiresPolicyReview).toBe(true);
+    expect(r.feasible).toBe(false);
+  });
+
+  it("treats an unknown hard predicate as review-required, not silently feasible", () => {
+    const r = evaluateConstraints(baseProblem({
+      rules: [HARD("some_unimplemented_family")],
+    }));
+    expect(r.requiresPolicyReview).toBe(true);
+    expect(r.feasible).toBe(false);
+  });
+});
+
+describe("resolveStarterPack", () => {
+  it("returns federal + CA for US-CA, federal for other US, null otherwise", () => {
+    expect(resolveStarterPack("US-CA")?.some((r) => r.ruleId === "us-ca-daily-overtime")).toBe(true);
+    expect(resolveStarterPack("US-NV")?.every((r) => r.ruleId.startsWith("us-flsa") || r.ruleId.startsWith("us-no"))).toBe(true);
+    expect(resolveStarterPack(null)).toBeNull();
+    expect(resolveStarterPack("GB")).toBeNull();
+  });
+});

--- a/apps/web/lib/workforce/staffing/constraints/evaluate.ts
+++ b/apps/web/lib/workforce/staffing/constraints/evaluate.ts
@@ -1,0 +1,104 @@
+/**
+ * Constraint engine entry point (EP-WORKFORCE-OPS / BI-4AD09A35 Phase 2).
+ * Dispatches each rule to its predicate evaluator and aggregates the result.
+ * Deterministic and side-effect-free (spec §7.3, §8.1): hard-rule feasibility is
+ * decided here, in DPF, independent of any solver.
+ *
+ * Fail-closed contract (spec §6, §8.1): when the jurisdiction is unresolved and
+ * a safety-critical rule is in scope, the result is flagged
+ * `requiresPolicyReview` and the caller must withhold a publishable proposal —
+ * the engine never assumes United States defaults for an unresolved location.
+ */
+import {
+  capabilityPresence,
+  credentialEligibility,
+  maxHoursPremium,
+  minNTogether,
+  noOverlap,
+  pairingRatio,
+  restGap,
+} from "./predicates";
+import type {
+  ConstraintRuleInput,
+  EvaluationResult,
+  NormalizedStaffingProblem,
+  PredicateEvaluator,
+} from "./types";
+
+/**
+ * The predicate registry. Add a §9.8 family by adding one entry — the loop
+ * below is closed over this map and needs no change.
+ */
+export const PREDICATE_REGISTRY: Record<string, PredicateEvaluator> = {
+  credential_eligibility: credentialEligibility,
+  capability_presence: capabilityPresence,
+  min_n_together: minNTogether,
+  pairing_ratio: pairingRatio,
+  rest_gap: restGap,
+  no_overlap: noOverlap,
+  max_hours_premium: maxHoursPremium,
+};
+
+/**
+ * Safety-critical hard-rule families: when the jurisdiction is unresolved these
+ * cannot be silently skipped — their presence forces a policy-review verdict
+ * rather than a false "feasible" (spec §8.1: unknown means review-required for
+ * safety-critical eligibility).
+ */
+const SAFETY_CRITICAL = new Set([
+  "credential_eligibility",
+  "capability_presence",
+  "min_n_together",
+  "pairing_ratio",
+]);
+
+function ruleApplies(rule: ConstraintRuleInput, problem: NormalizedStaffingProblem): boolean {
+  const region = rule.applicability?.jurisdictionRegion;
+  if (region && region !== problem.jurisdiction.region) return false;
+  return true;
+}
+
+export function evaluateConstraints(
+  problem: NormalizedStaffingProblem,
+): EvaluationResult {
+  const result: EvaluationResult = {
+    feasible: true,
+    violations: [],
+    premiums: [],
+    requiresPolicyReview: false,
+  };
+
+  const applicable = problem.rules.filter((r) => ruleApplies(r, problem));
+
+  // Fail-closed: an unresolved jurisdiction plus any in-scope safety-critical
+  // rule means we cannot certify feasibility — flag for review and stop.
+  if (!problem.jurisdiction.resolved) {
+    const hasSafetyCritical = applicable.some((r) => SAFETY_CRITICAL.has(r.predicateType));
+    if (hasSafetyCritical || applicable.length === 0) {
+      result.requiresPolicyReview = true;
+      result.feasible = false;
+      return result;
+    }
+  }
+
+  for (const rule of applicable) {
+    const evaluator = PREDICATE_REGISTRY[rule.predicateType];
+    if (!evaluator) {
+      // An unknown predicate on a hard rule cannot be waved through — treat it
+      // as review-required rather than silently ignored (spec §8.1).
+      if (rule.severity === "hard") {
+        result.requiresPolicyReview = true;
+        result.feasible = false;
+      }
+      continue;
+    }
+    const { violations, premiums } = evaluator(rule, problem);
+    if (violations?.length) {
+      if (rule.severity === "hard") result.feasible = false;
+      result.violations.push(...violations);
+    }
+    if (premiums?.length) result.premiums.push(...premiums);
+  }
+
+  return result;
+}

--- a/apps/web/lib/workforce/staffing/constraints/predicates.ts
+++ b/apps/web/lib/workforce/staffing/constraints/predicates.ts
@@ -1,0 +1,271 @@
+/**
+ * Constraint predicate evaluators (EP-WORKFORCE-OPS / BI-4AD09A35 Phase 2).
+ * Each evaluator is pure and deterministic (spec §8.1). This is the load-bearing
+ * subset for the first golden model (appointment coverage + field crew); the
+ * registry in `evaluate.ts` is designed so the remaining §9.8 families are added
+ * as sibling evaluators without touching the loop.
+ *
+ * Convention: "unknown is not automatically false" (spec §8.1). For
+ * safety-critical eligibility (credentials) unknown means a violation/review;
+ * for a soft premium unknown means no contribution.
+ */
+import type {
+  AssignmentInput,
+  ConstraintRuleInput,
+  ConstraintViolation,
+  NormalizedStaffingProblem,
+  PredicateEvaluator,
+  ShiftInput,
+} from "./types";
+
+const HOUR_MS = 3_600_000;
+
+function hoursBetween(aIso: string, bIso: string): number {
+  return Math.abs(new Date(aIso).getTime() - new Date(bIso).getTime()) / HOUR_MS;
+}
+
+function shiftById(problem: NormalizedStaffingProblem, shiftId: string): ShiftInput | undefined {
+  return problem.shifts.find((s) => s.shiftId === shiftId);
+}
+
+/** Confirmed/published assignments are the ones that bind hard rules. */
+function bindingAssignments(problem: NormalizedStaffingProblem): AssignmentInput[] {
+  return problem.assignments.filter(
+    (a) => a.lifecycle === "confirmed" || a.lifecycle === "completed",
+  );
+}
+
+function violation(
+  rule: ConstraintRuleInput,
+  subjectRef: string,
+  message: string,
+): ConstraintViolation {
+  return {
+    ruleId: rule.ruleId,
+    predicateType: rule.predicateType,
+    subjectRef,
+    message,
+    waivable: rule.legallyWaivable,
+    sourcePolicyUrl: rule.sourcePolicyUrl ?? null,
+  };
+}
+
+/**
+ * credential_eligibility — every assignee holds each credential the shift
+ * requires, unexpired at the shift start. Expiry auto-de-eligibles (spec §9.3);
+ * a missing/unknown credential is a violation because credential eligibility is
+ * safety-critical (spec §8.1).
+ */
+export const credentialEligibility: PredicateEvaluator = (rule, problem) => {
+  const violations: ConstraintViolation[] = [];
+  for (const assignment of bindingAssignments(problem)) {
+    const shift = shiftById(problem, assignment.shiftId);
+    const employee = problem.employees.find(
+      (e) => e.employeeProfileId === assignment.employeeProfileId,
+    );
+    if (!shift || !employee) continue;
+    const startMs = new Date(shift.interval.start.at).getTime();
+    for (const required of shift.requiredCredentials) {
+      const held = employee.credentials.find((c) => c.key === required);
+      const validAtStart =
+        held && (held.expiresAt === null || new Date(held.expiresAt).getTime() >= startMs);
+      if (!validAtStart) {
+        violations.push(
+          violation(
+            rule,
+            assignment.assignmentId,
+            `assignee lacks a valid "${required}" credential at shift start`,
+          ),
+        );
+      }
+    }
+  }
+  return { violations };
+};
+
+/**
+ * capability_presence — a named-capability holder must be present on the shift
+ * (spec §9.3): DEA key-holder, supervising clinician, competent person, etc.
+ * `parameters.capability` names the required capability.
+ */
+export const capabilityPresence: PredicateEvaluator = (rule, problem) => {
+  const capability = String(rule.parameters.capability ?? "");
+  const violations: ConstraintViolation[] = [];
+  const byShift = groupAssigneesByShift(problem);
+  for (const shift of problem.shifts) {
+    const assignees = byShift.get(shift.shiftId) ?? [];
+    const present = assignees.some((e) => e.capabilities.includes(capability));
+    if (assignees.length > 0 && !present) {
+      violations.push(
+        violation(rule, shift.shiftId, `no assignee with capability "${capability}" is present`),
+      );
+    }
+  }
+  return { violations };
+};
+
+/**
+ * min_n_together — at least N assignees holding a capability must be
+ * simultaneously present on a shift (spec §9.3): banking dual control, UL 827
+ * operator minimums, two-person rules. `parameters.capability`, `parameters.n`.
+ */
+export const minNTogether: PredicateEvaluator = (rule, problem) => {
+  const capability = String(rule.parameters.capability ?? "");
+  const n = Number(rule.parameters.n ?? 2);
+  const violations: ConstraintViolation[] = [];
+  const byShift = groupAssigneesByShift(problem);
+  for (const shift of problem.shifts) {
+    const assignees = byShift.get(shift.shiftId) ?? [];
+    if (assignees.length === 0) continue;
+    const count = assignees.filter((e) => e.capabilities.includes(capability)).length;
+    if (count < n) {
+      violations.push(
+        violation(
+          rule,
+          shift.shiftId,
+          `needs ${n} present with "${capability}"; found ${count}`,
+        ),
+      );
+    }
+  }
+  return { violations };
+};
+
+/**
+ * pairing_ratio — a supervised role's headcount may not exceed a ratio of the
+ * supervising role's headcount on a shift (spec §9.3): apprentice:journeyman
+ * ratios. `parameters.supervisedRole`, `parameters.supervisorRole`,
+ * `parameters.maxPerSupervisor`.
+ */
+export const pairingRatio: PredicateEvaluator = (rule, problem) => {
+  const supervised = String(rule.parameters.supervisedRole ?? "");
+  const supervisor = String(rule.parameters.supervisorRole ?? "");
+  const maxPer = Number(rule.parameters.maxPerSupervisor ?? 1);
+  const violations: ConstraintViolation[] = [];
+  const byShift = groupAssigneesByShift(problem);
+  for (const shift of problem.shifts) {
+    const assignees = byShift.get(shift.shiftId) ?? [];
+    const supervisors = assignees.filter((e) => e.roleKey === supervisor).length;
+    const supervisedCount = assignees.filter((e) => e.roleKey === supervised).length;
+    if (supervisedCount > 0 && supervisedCount > supervisors * maxPer) {
+      violations.push(
+        violation(
+          rule,
+          shift.shiftId,
+          `${supervisedCount} ${supervised} exceed ${maxPer}×${supervisors} ${supervisor}`,
+        ),
+      );
+    }
+  }
+  return { violations };
+};
+
+/**
+ * rest_gap — an employee's consecutive shifts must be separated by at least the
+ * configured turnaround (spec §9.4: clopening / IATSE turnaround). Uses instants
+ * so DST is handled by the underlying UTC arithmetic. `parameters.minHours`.
+ */
+export const restGap: PredicateEvaluator = (rule, problem) => {
+  const minHours = Number(rule.parameters.minHours ?? 10);
+  const violations: ConstraintViolation[] = [];
+  for (const employee of problem.employees) {
+    const intervals = employeeIntervals(problem, employee.employeeProfileId).sort(
+      (a, b) => new Date(a.start.at).getTime() - new Date(b.start.at).getTime(),
+    );
+    for (let i = 1; i < intervals.length; i++) {
+      const gap = hoursBetween(intervals[i - 1].end.at, intervals[i].start.at);
+      if (gap < minHours) {
+        violations.push(
+          violation(
+            rule,
+            employee.employeeProfileId,
+            `rest gap ${gap.toFixed(1)}h < required ${minHours}h`,
+          ),
+        );
+      }
+    }
+  }
+  return { violations };
+};
+
+/**
+ * no_overlap — an employee cannot hold two overlapping binding assignments
+ * (spec §5.3). This invariant is unconditional; a typed operating model that
+ * permits overlap would carry an explicit exception, not silence.
+ */
+export const noOverlap: PredicateEvaluator = (rule, problem) => {
+  const violations: ConstraintViolation[] = [];
+  for (const employee of problem.employees) {
+    const intervals = employeeIntervals(problem, employee.employeeProfileId).sort(
+      (a, b) => new Date(a.start.at).getTime() - new Date(b.start.at).getTime(),
+    );
+    for (let i = 1; i < intervals.length; i++) {
+      const prevEnd = new Date(intervals[i - 1].end.at).getTime();
+      const curStart = new Date(intervals[i].start.at).getTime();
+      if (curStart < prevEnd) {
+        violations.push(
+          violation(
+            rule,
+            employee.employeeProfileId,
+            "holds overlapping confirmed assignments",
+          ),
+        );
+      }
+    }
+  }
+  return { violations };
+};
+
+/**
+ * max_hours_premium — a SOFT, priced schedule-shape cost (spec §9.4): hours an
+ * employee works beyond a threshold in the problem window accrue premium units,
+ * rather than making the schedule infeasible. `parameters.thresholdHours`,
+ * `parameters.premiumPerHour`.
+ */
+export const maxHoursPremium: PredicateEvaluator = (rule, problem) => {
+  const threshold = Number(rule.parameters.thresholdHours ?? 40);
+  const premiumPerHour = Number(rule.parameters.premiumPerHour ?? 0.5);
+  const premiums = [];
+  for (const employee of problem.employees) {
+    const total = employeeIntervals(problem, employee.employeeProfileId).reduce(
+      (sum, iv) => sum + hoursBetween(iv.start.at, iv.end.at),
+      0,
+    );
+    if (total > threshold) {
+      premiums.push({
+        ruleId: rule.ruleId,
+        predicateType: rule.predicateType,
+        subjectRef: employee.employeeProfileId,
+        units: (total - threshold) * premiumPerHour,
+        message: `${(total - threshold).toFixed(1)}h over ${threshold}h threshold`,
+      });
+    }
+  }
+  return { premiums };
+};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function groupAssigneesByShift(problem: NormalizedStaffingProblem) {
+  const map = new Map<string, NormalizedStaffingProblem["employees"]>();
+  for (const assignment of bindingAssignments(problem)) {
+    const employee = problem.employees.find(
+      (e) => e.employeeProfileId === assignment.employeeProfileId,
+    );
+    if (!employee) continue;
+    const list = map.get(assignment.shiftId) ?? [];
+    list.push(employee);
+    map.set(assignment.shiftId, list);
+  }
+  return map;
+}
+
+function employeeIntervals(problem: NormalizedStaffingProblem, employeeProfileId: string) {
+  const intervals: ShiftInput["interval"][] = [];
+  for (const assignment of bindingAssignments(problem)) {
+    if (assignment.employeeProfileId !== employeeProfileId) continue;
+    const shift = shiftById(problem, assignment.shiftId);
+    if (shift) intervals.push(shift.interval);
+  }
+  return intervals;
+}

--- a/apps/web/lib/workforce/staffing/constraints/types.ts
+++ b/apps/web/lib/workforce/staffing/constraints/types.ts
@@ -1,0 +1,126 @@
+/**
+ * Workforce staffing — deterministic constraint model (EP-WORKFORCE-OPS /
+ * BI-4AD09A35 Phase 2). Spec §8 (constraint & objective model) + §9.8 (variable
+ * families). These types are the normalized, versioned problem the constraint
+ * engine evaluates and, later, the solver adapter (Phase 3) consumes. Evaluation
+ * is pure and side-effect-free: it reads a snapshot and returns violations +
+ * priced premiums, never touching the database.
+ *
+ * The engine is deterministic and independent of any solver: a solver may
+ * PROPOSE assignments, but hard-rule feasibility is always validated here, in
+ * DPF, after the solve (spec §7.3).
+ */
+
+/** Instant + the timezone the scheduling decision is anchored in (spec §5.3). */
+export type ZonedInstant = {
+  /** UTC instant. */
+  at: string;
+  /** IANA timezone the local-clock rules apply in, e.g. "America/Los_Angeles". */
+  timezone: string;
+};
+
+/** Where the work happens — drives jurisdiction resolution (spec §6). */
+export type JurisdictionContext = {
+  country: string | null;
+  /** State/province/region subdivision code, e.g. "US-CA". */
+  region: string | null;
+  /** True once the deploying org's employsIn + work location resolve a pack. */
+  resolved: boolean;
+};
+
+export type EmployeeInput = {
+  employeeProfileId: string;
+  /** Credential keys the employee currently holds, with expiry (spec §9.3). */
+  credentials: Array<{ key: string; expiresAt: string | null }>;
+  /** Capability keys the employee is authorized for (e.g. "dea_keyholder"). */
+  capabilities: string[];
+  /** Role key used by pairing-ratio rules (e.g. "journeyman", "apprentice"). */
+  roleKey: string | null;
+  employmentType: string | null;
+};
+
+export type ShiftInput = {
+  shiftId: string;
+  interval: { start: ZonedInstant; end: ZonedInstant };
+  workLocationId: string | null;
+  /** Credentials the shift's role requires of every assignee. */
+  requiredCredentials: string[];
+};
+
+export type AssignmentInput = {
+  assignmentId: string;
+  shiftId: string;
+  employeeProfileId: string;
+  /** Only confirmed/published assignments bind hard rules like non-overlap. */
+  lifecycle: string;
+};
+
+/**
+ * A rule instance drawn from a StaffingConstraintRule row (or a starter pack).
+ * `predicateType` selects the evaluator; `parameters` is the typed payload for
+ * that predicate; `applicability` scopes it (spec §6).
+ */
+export type ConstraintRuleInput = {
+  ruleId: string;
+  predicateType: string;
+  severity: "hard" | "soft";
+  legallyWaivable: boolean;
+  parameters: Record<string, unknown>;
+  applicability?: {
+    jurisdictionRegion?: string | null;
+    employmentType?: string | null;
+  };
+  sourcePolicyUrl?: string | null;
+};
+
+export type NormalizedStaffingProblem = {
+  organizationId: string;
+  jurisdiction: JurisdictionContext;
+  employees: EmployeeInput[];
+  shifts: ShiftInput[];
+  assignments: AssignmentInput[];
+  rules: ConstraintRuleInput[];
+};
+
+/** A hard-rule breach. `waivable` gates whether an exception request is allowed. */
+export type ConstraintViolation = {
+  ruleId: string;
+  predicateType: string;
+  subjectRef: string;
+  message: string;
+  waivable: boolean;
+  sourcePolicyUrl?: string | null;
+};
+
+/**
+ * A priced schedule-shape cost (spec §9.4): a feasible schedule can still be an
+ * expensive one. Premiums never make a schedule infeasible; they surface in the
+ * objective decomposition in currency-neutral units the caller monetizes.
+ */
+export type PremiumLine = {
+  ruleId: string;
+  predicateType: string;
+  subjectRef: string;
+  /** Abstract cost units (e.g. premium-hours) the caller prices per §8.2. */
+  units: number;
+  message: string;
+};
+
+export type EvaluationResult = {
+  feasible: boolean;
+  violations: ConstraintViolation[];
+  premiums: PremiumLine[];
+  /**
+   * True when a safety-critical rule could not be evaluated because the
+   * jurisdiction/policy is unresolved. The caller must withhold a publishable
+   * proposal and return "requires policy review" (spec §6, §8.1) — unknown data
+   * is not automatically false for safety-critical eligibility.
+   */
+  requiresPolicyReview: boolean;
+};
+
+/** Pure evaluator for one predicate family. Returns violations and/or premiums. */
+export type PredicateEvaluator = (
+  rule: ConstraintRuleInput,
+  problem: NormalizedStaffingProblem,
+) => { violations?: ConstraintViolation[]; premiums?: PremiumLine[] };

--- a/apps/web/lib/workforce/staffing/rule-packs/us.ts
+++ b/apps/web/lib/workforce/staffing/rule-packs/us.ts
@@ -1,0 +1,61 @@
+/**
+ * US starter rule packs (EP-WORKFORCE-OPS / BI-4AD09A35 Phase 2). Federal (FLSA)
+ * baseline + a California overlay — chosen as the first reviewed pack because CA
+ * exercises the most variable families (daily overtime, rest gaps, meal
+ * premiums, reporting-time). Spec §6, §9.4, §10.3, founder decision 5.
+ *
+ * These are DPF-supplied STARTER packs. Each rule carries its source URL,
+ * severity, and legal-waivability; the deploying organization remains
+ * responsible for validating labor rules with qualified counsel (spec §6). A
+ * pack is authoritative for an organization only once its `employsIn` +
+ * work-location jurisdiction resolve (spec §6 — otherwise the engine fails
+ * closed to "requires policy review").
+ */
+import type { ConstraintRuleInput } from "../constraints/types";
+
+/** FLSA baseline — applies wherever US federal law governs. */
+export const US_FEDERAL_PACK: ConstraintRuleInput[] = [
+  {
+    ruleId: "us-flsa-weekly-overtime",
+    predicateType: "max_hours_premium",
+    severity: "soft",
+    legallyWaivable: false,
+    parameters: { thresholdHours: 40, premiumPerHour: 0.5 },
+    sourcePolicyUrl: "https://www.dol.gov/agencies/whd/overtime",
+  },
+  {
+    // The non-overlap invariant is universal; encoded as a rule so it appears in
+    // the same evaluation ledger as jurisdiction rules.
+    ruleId: "us-no-overlapping-assignments",
+    predicateType: "no_overlap",
+    severity: "hard",
+    legallyWaivable: false,
+    parameters: {},
+    sourcePolicyUrl: null,
+  },
+];
+
+/** California overlay — layered on top of the federal pack (spec §6 hierarchy). */
+export const US_CALIFORNIA_PACK: ConstraintRuleInput[] = [
+  {
+    ruleId: "us-ca-daily-overtime",
+    predicateType: "max_hours_premium",
+    severity: "soft",
+    legallyWaivable: false,
+    parameters: { thresholdHours: 8, premiumPerHour: 0.5 },
+    applicability: { jurisdictionRegion: "US-CA" },
+    sourcePolicyUrl:
+      "https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=LAB&sectionNum=510.",
+  },
+];
+
+/**
+ * Resolve the applicable starter pack for a jurisdiction. Returns null when the
+ * jurisdiction is unresolved or unsupported — the caller then fails closed to
+ * "requires policy review" rather than assuming US defaults (spec §6).
+ */
+export function resolveStarterPack(region: string | null): ConstraintRuleInput[] | null {
+  if (region === "US-CA") return [...US_FEDERAL_PACK, ...US_CALIFORNIA_PACK];
+  if (region && region.startsWith("US-")) return [...US_FEDERAL_PACK];
+  return null;
+}

--- a/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
+++ b/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
@@ -6,8 +6,8 @@
 | Epic | `EP-WORKFORCE-OPS` |
 | Design spec | [`2026-07-17-organization-workforce-staffing-scheduling-design.md`](../specs/2026-07-17-organization-workforce-staffing-scheduling-design.md) |
 | Kernel records | `DI-C8BF6362B44C` (architecture: DPF domain + open solver adapter) · `DI-78788D22BE65` (solver-first: Timefold) |
-| Branch | `feat/workforce-staffing-substrate` (off `origin/main` @ `93a1e23b4`) |
-| Status | Phased plan; Phase 1 ready to build |
+| Branch | `feat/workforce-staffing-substrate` (Phase 1) · `feat/workforce-staffing-constraints` (Phase 2) |
+| Status | Phase 1 built + PR'd (#3204); Phase 2 constraint core built |
 
 ## Founder decisions applied (design §18)
 
@@ -42,13 +42,28 @@ Each phase becomes a child BI under `EP-WORKFORCE-OPS`. Phase 1 ships independen
 
 **Risk/rollback.** Additive migration referencing existing PKs — no change to existing tables; rollback = down-migration dropping the new tables (nothing else references staffing yet).
 
-### Phase 2 — Deterministic constraint & rule-pack engine
+### Phase 2 — Deterministic constraint & rule-pack engine *(core built)*
 
-**Deliverable.** Typed `StaffingConstraintRule` predicate registry implementing the §9.8 families (eligibility/credential-expiry, capability-presence, minimum-N-together, pairing-ratio, headcount-formula, rest-gap/turnaround-clock, per-employee-group overtime-regime selection, schedule-shape premium producing **cost** not infeasibility). Rule-pack loader (config: source URLs, effective dates, review owner, test cases). US-federal + California starter pack. Unknown jurisdiction → **requires policy review**, fail-closed (never assume US defaults).
+**Deliverable.** Typed predicate registry implementing the §9.8 families + a
+starter rule-pack. **Built in this slice** ([`apps/web/lib/workforce/staffing/`](../../../apps/web/lib/workforce/staffing/)):
+the normalized problem model (`constraints/types.ts`), seven predicates
+(`constraints/predicates.ts`) — `credential_eligibility` (expiry-aware),
+`capability_presence`, `min_n_together` (dual control), `pairing_ratio`
+(apprentice:journeyman), `rest_gap`/turnaround, `no_overlap`, and
+`max_hours_premium` (priced, not infeasible) — the registry + fail-closed
+evaluation loop (`constraints/evaluate.ts`), and the US-federal + California
+starter pack (`rule-packs/us.ts`). Unknown jurisdiction OR an unknown hard
+predicate → **requires policy review**, fail-closed (never assume US defaults).
 
-**Files.** `apps/web/lib/workforce/staffing/constraints/` (predicate registry + evaluators); `apps/web/lib/workforce/staffing/rule-packs/us-federal.ts`, `.../us-california.ts`.
+**Follow-up (same phase, later PRs):** the remaining §9.8 families
+(fair-workweek predictability pay, meal/reporting-time premiums, minor-hour
+windows, on-call compensability, headcount-formula, per-group overtime-regime
+selection), effective-dating, and DB-backed rule loading from
+`StaffingConstraintRule` rows.
 
-**Verification.** Constraint goldens — every rule in the pack ships one passing and one violating fixture; unknown-jurisdiction fail-closed test; overtime-regime selection test (FLSA-40 vs CA daily-OT).
+**Verification.** Constraint goldens — passing + violating fixture per predicate,
+unknown-jurisdiction and unknown-predicate fail-closed tests, priced-premium
+test, starter-pack resolver test (14 tests, `constraints/evaluate.test.ts`).
 
 ### Phase 3 — Solver adapter + Timefold packaging spike
 


### PR DESCRIPTION
## Summary

Phase 2 of the workforce staffing substrate (`BI-4AD09A35`, epic `EP-WORKFORCE-OPS`) — the **deterministic constraint engine core**. This is the side-effect-free module that validates staffing feasibility in DPF, independent of any solver (spec §7.3, §8). A later solver may *propose* assignments; hard-rule feasibility is always decided here.

Builds on Phase 1 (#3204, merged). Plan: [`§Phase 2`](docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md).

## What's in it

- **`constraints/types.ts`** — the normalized, versioned problem model (`NormalizedStaffingProblem`) + result types (`violations` + priced `premiums` + `requiresPolicyReview`).
- **`constraints/predicates.ts`** — seven pure evaluators covering the first golden model (appointment coverage + field crew):
  - `credential_eligibility` (expiry-aware, safety-critical), `capability_presence` (named-capability presence — DEA key-holder, competent person), `min_n_together` (dual control / two-person), `pairing_ratio` (apprentice:journeyman), `rest_gap` (turnaround/clopening), `no_overlap`, and `max_hours_premium` — a **SOFT priced cost, not an infeasibility** (spec §9.4: a feasible schedule can still be expensive).
- **`constraints/evaluate.ts`** — the predicate registry + evaluation loop with the **fail-closed contract**: an unresolved jurisdiction *or* an unknown hard predicate in safety-critical scope returns `requiresPolicyReview`, never a false "feasible" and never an assumed US default (spec §6, §8.1).
- **`rule-packs/us.ts`** — the US-federal (FLSA) + California starter pack (founder decision 5), each rule carrying its source URL, severity, and legal-waivability.

## Design fidelity

- **Unknown is not automatically false** (spec §8.1): safety-critical eligibility fails closed to review; soft premiums contribute nothing when unknown.
- **Solver-independent** (spec §7.3): the engine reads a snapshot and returns a verdict; it never touches the DB. Phase 3's solver adapter will run this same engine for independent post-solve validation.
- The registry is closed over a map — remaining §9.8 families (fair-workweek predictability pay, meal/reporting-time premiums, minor-hour windows, on-call compensability, headcount-formula, per-group overtime-regime selection), effective-dating, and DB-backed rule loading are additive follow-ups (tracked in the plan).

## Verification

14 constraint goldens — a passing and a violating fixture per predicate, unknown-jurisdiction and unknown-predicate fail-closed cases, the priced-premium case, and the starter-pack resolver. `apps/web` typecheck + ratchet-guard loop clean.

Later phases (own PRs): solver adapter + Timefold spike → coworker proposal flow → MCP staffing pack → People→Staffing UX → calendar/comms projections → full verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Local-CI-Override: Phase 2 is pure TypeScript (constraint engine + golden tests), no DB/schema change. 14 tests + ratchet-guard loop + apps/web typecheck green locally. Local pregate's only failures remain the pre-existing `localStorage is not available (--localstorage-file not provided)` env quirk in unrelated apps/web component tests. GitHub CI is authoritative.
