### PR TITLE
feat(workforce): solver adapter + post-solve validation — Phase 3 core (BI-4AD09A35)

### DIFF
--- a/apps/web/lib/workforce/staffing/solver/adapter.test.ts
+++ b/apps/web/lib/workforce/staffing/solver/adapter.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { MockGreedySolver } from "./mock-adapter";
+import { validateSolverResult, validateSolverOption } from "./validate-after-solve";
+import type { NormalizedStaffingProblem } from "../constraints/types";
+import type { SolverOption } from "./adapter";
+
+// EP-WORKFORCE-OPS / BI-4AD09A35 Phase 3 — solver adapter contract + the
+// independent post-solve validation gate (spec §7.3).
+
+function zi(at: string) {
+  return { at, timezone: "America/Los_Angeles" };
+}
+
+function problem(partial: Partial<NormalizedStaffingProblem> = {}): NormalizedStaffingProblem {
+  return {
+    organizationId: "org-1",
+    jurisdiction: { country: "US", region: "US-CA", resolved: true },
+    employees: [],
+    shifts: [],
+    assignments: [],
+    rules: [],
+    ...partial,
+  };
+}
+
+const shift = (id: string, start: string, end: string, req: string[] = []) => ({
+  shiftId: id,
+  interval: { start: zi(start), end: zi(end) },
+  workLocationId: null,
+  requiredCredentials: req,
+});
+const emp = (id: string, creds: Array<{ key: string; expiresAt: string | null }> = []) => ({
+  employeeProfileId: id,
+  credentials: creds,
+  capabilities: [],
+  roleKey: null,
+  employmentType: null,
+});
+
+describe("MockGreedySolver", () => {
+  it("is deterministic — same input yields the same output", async () => {
+    const p = problem({
+      shifts: [shift("s2", "2026-08-01T16:00:00Z", "2026-08-01T20:00:00Z"), shift("s1", "2026-08-01T08:00:00Z", "2026-08-01T12:00:00Z")],
+      employees: [emp("e2"), emp("e1")],
+    });
+    const solver = new MockGreedySolver();
+    const a = await solver.solve(p);
+    const b = await solver.solve(p);
+    expect(a).toEqual(b);
+    expect(a.status).toBe("feasible");
+  });
+
+  it("returns an honest 'infeasible' with unfilled shifts rather than fabricating a fill", async () => {
+    // Two concurrent shifts, one employee — the second cannot be filled.
+    const p = problem({
+      shifts: [
+        shift("s1", "2026-08-01T08:00:00Z", "2026-08-01T12:00:00Z"),
+        shift("s2", "2026-08-01T08:00:00Z", "2026-08-01T12:00:00Z"),
+      ],
+      employees: [emp("e1")],
+    });
+    const result = await new MockGreedySolver().solve(p);
+    expect(result.status).toBe("infeasible");
+    expect(result.options[0].unfilledShiftIds).toEqual(["s2"]);
+    expect(result.options[0].assignments).toHaveLength(1);
+  });
+
+  it("respects credential eligibility when filling", async () => {
+    const p = problem({
+      shifts: [shift("s1", "2026-08-01T08:00:00Z", "2026-08-01T12:00:00Z", ["rbs_alcohol"])],
+      employees: [emp("e1"), emp("e2", [{ key: "rbs_alcohol", expiresAt: "2027-01-01T00:00:00Z" }])],
+    });
+    const result = await new MockGreedySolver().solve(p);
+    expect(result.options[0].assignments).toEqual([{ shiftId: "s1", employeeProfileId: "e2" }]);
+  });
+});
+
+describe("validate-after-solve (spec §7.3 — solver is untrusted)", () => {
+  it("certifies a clean option as publishable", async () => {
+    const p = problem({
+      shifts: [shift("s1", "2026-08-01T08:00:00Z", "2026-08-01T12:00:00Z")],
+      employees: [emp("e1")],
+      rules: [{ ruleId: "no-overlap", predicateType: "no_overlap", severity: "hard", legallyWaivable: false, parameters: {} }],
+    });
+    const result = await new MockGreedySolver().solve(p);
+    const validated = validateSolverResult(p, result.options);
+    expect(validated[0].publishable).toBe(true);
+    expect(validated[0].evaluation.feasible).toBe(true);
+  });
+
+  it("rejects a solver option that violates a hard rule the solver ignored", () => {
+    // A malicious/buggy solver double-books e1 across two overlapping shifts.
+    const p = problem({
+      shifts: [
+        shift("s1", "2026-08-01T08:00:00Z", "2026-08-01T12:00:00Z"),
+        shift("s2", "2026-08-01T10:00:00Z", "2026-08-01T14:00:00Z"),
+      ],
+      employees: [emp("e1")],
+      rules: [{ ruleId: "no-overlap", predicateType: "no_overlap", severity: "hard", legallyWaivable: false, parameters: {} }],
+    });
+    const rogueOption: SolverOption = {
+      assignments: [
+        { shiftId: "s1", employeeProfileId: "e1" },
+        { shiftId: "s2", employeeProfileId: "e1" },
+      ],
+      score: 2,
+      unfilledShiftIds: [],
+      hardViolationCount: 0, // the solver claims zero — DPF must not trust that
+    };
+    const validated = validateSolverOption(p, rogueOption);
+    expect(validated.publishable).toBe(false);
+    expect(validated.evaluation.feasible).toBe(false);
+    expect(validated.evaluation.violations[0].predicateType).toBe("no_overlap");
+  });
+
+  it("withholds publish when the jurisdiction is unresolved (fail-closed)", () => {
+    const p = problem({
+      jurisdiction: { country: null, region: null, resolved: false },
+      shifts: [shift("s1", "2026-08-01T08:00:00Z", "2026-08-01T12:00:00Z", ["license"])],
+      employees: [emp("e1", [{ key: "license", expiresAt: null }])],
+      rules: [{ ruleId: "cred", predicateType: "credential_eligibility", severity: "hard", legallyWaivable: false, parameters: {} }],
+    });
+    const validated = validateSolverOption(p, {
+      assignments: [{ shiftId: "s1", employeeProfileId: "e1" }],
+      score: 1,
+      unfilledShiftIds: [],
+      hardViolationCount: 0,
+    });
+    expect(validated.publishable).toBe(false);
+    expect(validated.evaluation.requiresPolicyReview).toBe(true);
+  });
+});

--- a/apps/web/lib/workforce/staffing/solver/adapter.ts
+++ b/apps/web/lib/workforce/staffing/solver/adapter.ts
@@ -1,0 +1,74 @@
+/**
+ * Provider-neutral staffing solver adapter (EP-WORKFORCE-OPS / BI-4AD09A35
+ * Phase 3). Spec §7.3 — the solver boundary. The adapter accepts a NORMALIZED,
+ * versioned problem and returns candidate solutions plus machine-readable score
+ * and violation detail. It has NO authority: it cannot read the database, send
+ * notifications, publish shifts, or decide exceptions. Identity resolution,
+ * rule applicability, authorization, persistence, and the independent hard-rule
+ * validation-after-solve all happen in DPF, outside the solver.
+ *
+ * The kernel selected Timefold as the first stack to validate in the packaging
+ * spike (DI-78788D22BE65); OR-Tools CP-SAT is the documented fallback. Both map
+ * to THIS contract — provider enums must never leak into the core model (spec
+ * §14.1). The Timefold/OR-Tools sidecar is a separate infrastructure spike; this
+ * module is the pure contract plus a deterministic in-process mock used for
+ * fixtures and post-solve-validation tests.
+ */
+import type { NormalizedStaffingProblem } from "../constraints/types";
+
+/**
+ * Terminal solve status. Mirrors the CP-SAT status model (spec §7.3) and the
+ * StaffingProposalRun.status lifecycle so persistence is a direct mapping.
+ */
+export type SolveStatus =
+  | "optimal"
+  | "feasible"
+  | "infeasible"
+  | "unknown"
+  | "timeout"
+  | "error";
+
+export type SolveOptions = {
+  /** Wall-clock budget; the adapter must return a terminal status by then. */
+  timeLimitMs?: number;
+  /** Cap on the number of distinct candidate options returned (spec §8.3: 2–4). */
+  maxOptions?: number;
+  /** Determinism seed — same seed + same input ⇒ same output (spec §15 parity). */
+  seed?: number;
+};
+
+/** One proposed person↔shift binding within a candidate option. */
+export type SolverCandidateAssignment = {
+  shiftId: string;
+  employeeProfileId: string;
+};
+
+/** A single candidate schedule the solver returns. Never persisted as-is until
+ *  DPF has re-validated it (see validate-after-solve). */
+export type SolverOption = {
+  assignments: SolverCandidateAssignment[];
+  /** Decomposable objective score in solver-native units (spec §8.2). */
+  score: number;
+  /** Shift ids the option could not fill — surfaced honestly, never faked. */
+  unfilledShiftIds: string[];
+  /** The solver's own count of hard-rule violations it could not avoid. */
+  hardViolationCount: number;
+};
+
+export type SolverResult = {
+  status: SolveStatus;
+  options: SolverOption[];
+  solverProvider: string;
+  solverVersion: string;
+  timeLimitMs: number | null;
+};
+
+/**
+ * The adapter contract. A single method that maps a normalized problem to
+ * candidate solutions. Deliberately pure: input in, result out, no side effects.
+ */
+export interface SolverAdapter {
+  readonly provider: string;
+  readonly version: string;
+  solve(problem: NormalizedStaffingProblem, options?: SolveOptions): Promise<SolverResult>;
+}

--- a/apps/web/lib/workforce/staffing/solver/mock-adapter.ts
+++ b/apps/web/lib/workforce/staffing/solver/mock-adapter.ts
@@ -1,0 +1,99 @@
+/**
+ * Deterministic in-process mock solver (EP-WORKFORCE-OPS / BI-4AD09A35 Phase 3).
+ * NOT the production solver — it exists so the adapter contract, the
+ * validate-after-solve gate, and the proposal flow can be exercised in fixtures
+ * without the Timefold/OR-Tools sidecar (a separate infra spike). A greedy,
+ * fully deterministic assignment: stable input ⇒ stable output (spec §15 parity).
+ *
+ * It intentionally respects only credential eligibility and non-double-booking
+ * so tests can also feed it a problem where it is FORCED to leave demand
+ * unfilled rather than fabricate an infeasible assignment — proving the honest
+ * "no feasible schedule" path (spec §8.3).
+ */
+import type { NormalizedStaffingProblem } from "../constraints/types";
+import type {
+  SolveOptions,
+  SolverAdapter,
+  SolverCandidateAssignment,
+  SolverResult,
+} from "./adapter";
+
+function credentialValidAt(
+  employee: NormalizedStaffingProblem["employees"][number],
+  requiredKey: string,
+  atMs: number,
+): boolean {
+  const held = employee.credentials.find((c) => c.key === requiredKey);
+  return Boolean(held && (held.expiresAt === null || new Date(held.expiresAt).getTime() >= atMs));
+}
+
+function overlaps(
+  a: NormalizedStaffingProblem["shifts"][number]["interval"],
+  b: NormalizedStaffingProblem["shifts"][number]["interval"],
+): boolean {
+  const aStart = new Date(a.start.at).getTime();
+  const aEnd = new Date(a.end.at).getTime();
+  const bStart = new Date(b.start.at).getTime();
+  const bEnd = new Date(b.end.at).getTime();
+  return aStart < bEnd && bStart < aEnd;
+}
+
+export class MockGreedySolver implements SolverAdapter {
+  readonly provider = "mock-greedy";
+  readonly version = "1.0.0";
+
+  async solve(
+    problem: NormalizedStaffingProblem,
+    options?: SolveOptions,
+  ): Promise<SolverResult> {
+    // Deterministic ordering: shifts by start then id, employees by id.
+    const shifts = [...problem.shifts].sort(
+      (a, b) =>
+        new Date(a.interval.start.at).getTime() - new Date(b.interval.start.at).getTime() ||
+        a.shiftId.localeCompare(b.shiftId),
+    );
+    const employees = [...problem.employees].sort((a, b) =>
+      a.employeeProfileId.localeCompare(b.employeeProfileId),
+    );
+
+    const assignments: SolverCandidateAssignment[] = [];
+    const unfilledShiftIds: string[] = [];
+    const takenIntervalsByEmployee = new Map<string, typeof shifts[number]["interval"][]>();
+
+    for (const shift of shifts) {
+      const startMs = new Date(shift.interval.start.at).getTime();
+      const pick = employees.find((e) => {
+        const hasCreds = shift.requiredCredentials.every((key) =>
+          credentialValidAt(e, key, startMs),
+        );
+        if (!hasCreds) return false;
+        const taken = takenIntervalsByEmployee.get(e.employeeProfileId) ?? [];
+        return !taken.some((iv) => overlaps(iv, shift.interval));
+      });
+      if (!pick) {
+        unfilledShiftIds.push(shift.shiftId);
+        continue;
+      }
+      assignments.push({ shiftId: shift.shiftId, employeeProfileId: pick.employeeProfileId });
+      const taken = takenIntervalsByEmployee.get(pick.employeeProfileId) ?? [];
+      taken.push(shift.interval);
+      takenIntervalsByEmployee.set(pick.employeeProfileId, taken);
+    }
+
+    const status = unfilledShiftIds.length === 0 ? "feasible" : "infeasible";
+    return {
+      status,
+      options: [
+        {
+          assignments,
+          score: assignments.length,
+          unfilledShiftIds,
+          hardViolationCount: 0,
+        },
+      ],
+      solverProvider: this.provider,
+      solverVersion: this.version,
+      timeLimitMs: options?.timeLimitMs ?? null,
+    };
+  }
+}

--- a/apps/web/lib/workforce/staffing/solver/validate-after-solve.ts
+++ b/apps/web/lib/workforce/staffing/solver/validate-after-solve.ts
@@ -1,0 +1,56 @@
+/**
+ * Independent post-solve validation (EP-WORKFORCE-OPS / BI-4AD09A35 Phase 3).
+ * Spec §7.3 + §15.3: after a solver returns candidate options, DPF re-runs its
+ * own deterministic hard-rule engine over the proposed assignments. The solver
+ * is UNTRUSTED — "the solver recommended it" is not a defensible rationale
+ * (spec §14.3). An option is only publishable if DPF's own engine agrees it is
+ * feasible; a hard violation the solver missed (or introduced) is caught here.
+ */
+import { evaluateConstraints } from "../constraints/evaluate";
+import type {
+  EvaluationResult,
+  NormalizedStaffingProblem,
+} from "../constraints/types";
+import type { SolverOption } from "./adapter";
+
+export type ValidatedOption = {
+  option: SolverOption;
+  evaluation: EvaluationResult;
+  /** True only when DPF's own engine certifies the option (no hard violations,
+   *  no policy-review gap) — the gate for offering the option for approval. */
+  publishable: boolean;
+};
+
+/**
+ * Re-evaluate one solver option against the problem's rules by treating its
+ * proposed bindings as confirmed assignments and running the DPF constraint
+ * engine. Returns DPF's verdict, independent of the solver's self-report.
+ */
+export function validateSolverOption(
+  problem: NormalizedStaffingProblem,
+  option: SolverOption,
+): ValidatedOption {
+  const problemWithOption: NormalizedStaffingProblem = {
+    ...problem,
+    assignments: option.assignments.map((a, i) => ({
+      assignmentId: `proposed-${i}`,
+      shiftId: a.shiftId,
+      employeeProfileId: a.employeeProfileId,
+      lifecycle: "confirmed",
+    })),
+  };
+  const evaluation = evaluateConstraints(problemWithOption);
+  return {
+    option,
+    evaluation,
+    publishable: evaluation.feasible && !evaluation.requiresPolicyReview,
+  };
+}
+
+/** Validate every option a solver returned; callers offer only publishable ones. */
+export function validateSolverResult(
+  problem: NormalizedStaffingProblem,
+  options: SolverOption[],
+): ValidatedOption[] {
+  return options.map((option) => validateSolverOption(problem, option));
+}

--- a/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
+++ b/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
@@ -65,13 +65,28 @@ selection), effective-dating, and DB-backed rule loading from
 unknown-jurisdiction and unknown-predicate fail-closed tests, priced-premium
 test, starter-pack resolver test (14 tests, `constraints/evaluate.test.ts`).
 
-### Phase 3 — Solver adapter + Timefold packaging spike
+### Phase 3 — Solver adapter + Timefold packaging spike *(contract + validation built; sidecar spike pending)*
 
-**Deliverable.** Provider-neutral adapter: accepts a normalized, versioned problem, returns candidate solutions + machine-readable score/violation detail; **no** DB read, notification, publish, or exception authority. Timefold CE spike as a bounded internal sidecar service (not embedded in the Node/Alpine image): license/SBOM/provenance review, ARM64/AMD64 container sizing, determinism + timeout tests, offline operation, failure semantics. DPF performs identity resolution, applicability, and **independent hard-rule validation after solve**.
+**Deliverable.** Provider-neutral adapter contract + the independent
+post-solve validation gate. **Built in this slice** (`apps/web/lib/workforce/staffing/solver/`):
+`adapter.ts` (the `SolverAdapter` interface — a single pure `solve(problem,
+options)`; `SolveStatus` mirrors the CP-SAT/StaffingProposalRun status model; no
+DB/notify/publish authority); `validate-after-solve.ts` (re-runs the Phase 2
+constraint engine over the solver's proposed bindings — the solver is UNTRUSTED,
+"the solver recommended it" is not a rationale, spec §7.3/§14.3); `mock-adapter.ts`
+(a deterministic greedy solver for fixtures, honest about unfilled demand).
 
-**Files.** `apps/web/lib/workforce/staffing/solver/adapter.ts` (interface + normalized problem/solution types); solver sidecar service dir + Dockerfile; compose wiring (one `dpf` project).
+**Pending — the infra spike** (separate PR, not pure-TS): Timefold CE sidecar
+(kernel `DI-78788D22BE65`) — license/SBOM/provenance, ARM64/AMD64 container
+sizing, determinism + timeout tests against the same fixtures, offline
+operation, `dpf`-compose wiring; OR-Tools CP-SAT fallback behind the same
+contract. Provider enums must not leak into the core (spec §14.1).
 
-**Verification.** Deterministic fixtures → stable solutions; feasible/infeasible/unknown/timeout each handled; independent post-solve validation catches any solver hard-rule violation; sidecar builds on both arches; documented OR-Tools fallback path.
+**Verification.** Deterministic mock (same input ⇒ same output), honest
+`infeasible` with unfilled shifts (no fabricated fill), credential-aware fill,
+and the post-solve gate: rejects a rogue option that double-books despite the
+solver self-reporting zero violations, and withholds publish when the
+jurisdiction is unresolved (6 tests, `solver/adapter.test.ts`).
 
 ### Phase 4 — AI Staffing Coworker proposal flow + human-authority boundary
 


### PR DESCRIPTION
## Summary

Phase 3 (core) of the workforce staffing substrate (`BI-4AD09A35`, epic `EP-WORKFORCE-OPS`) — the **solver boundary** (spec §7.3), pure-TypeScript half. Ships the provider-neutral contract every solver maps to, plus the load-bearing safety gate that re-validates solver output. The Timefold/OR-Tools JVM sidecar is a separate infrastructure spike (see below); nothing here embeds a non-Node runtime.

Builds on Phase 2 (#3206, merged). Plan: [`§Phase 3`](docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md).

## What's in it

- **`solver/adapter.ts`** — the `SolverAdapter` interface: a single pure `solve(problem, options) → SolverResult`. `SolveStatus` (`optimal|feasible|infeasible|unknown|timeout|error`) mirrors the CP-SAT status model and the `StaffingProposalRun.status` lifecycle, so persistence is a direct mapping. By construction the adapter has **no DB read, notification, publish, or exception authority** — input in, result out.
- **`solver/validate-after-solve.ts`** — the untrusted-solver gate: DPF re-runs its **own Phase 2 constraint engine** over the solver's proposed bindings and certifies publishability independently. "The solver recommended it" is not a defensible rationale (spec §14.3); a hard violation the solver missed *or introduced* is caught here.
- **`solver/mock-adapter.ts`** — a deterministic greedy solver for fixtures and the (Phase 4) proposal flow. Honest about unfilled demand — it returns `infeasible` with `unfilledShiftIds` rather than fabricating a fill (spec §8.3).

## Pending — the infra spike (separate PR)

The Timefold Community Edition sidecar (kernel `DI-78788D22BE65`, Timefold-first): license/SBOM/provenance review, ARM64/AMD64 container sizing, determinism + timeout tests against these same fixtures, offline operation, and `dpf`-compose wiring; OR-Tools CP-SAT fallback behind this same contract. Provider enums must not leak into the core model (spec §14.1).

## Verification

6 tests (`solver/adapter.test.ts`): deterministic mock (same input ⇒ same output), honest `infeasible`-with-unfilled-shifts, credential-aware fill, and the post-solve gate — **rejects a rogue option that double-books an employee despite the solver self-reporting zero violations**, and withholds publish when the jurisdiction is unresolved (fail-closed). `apps/web` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Local-CI-Override: Phase 3 is pure TypeScript (solver adapter contract + validation + mock + tests), no DB/schema change. 6 tests + apps/web typecheck green locally. Local pregate's only failures remain the pre-existing `localStorage is not available (--localstorage-file not provided)` env quirk in unrelated apps/web component tests. GitHub CI is authoritative.
