### PR TITLE
feat(workforce): coworker authority boundary + proposal prep — Phase 4 core (BI-4AD09A35)

### DIFF
--- a/apps/web/lib/workforce/staffing/coworker/authority.ts
+++ b/apps/web/lib/workforce/staffing/coworker/authority.ts
@@ -1,0 +1,145 @@
+/**
+ * AI Staffing Coworker — human-authority boundary (EP-WORKFORCE-OPS /
+ * BI-4AD09A35 Phase 4). Spec §11 (authority progression) + §12.3 (employment AI
+ * boundary) + founder decision 2 (publish authority = owner/operator, delegable
+ * by scope later).
+ *
+ * The rule the whole feature turns on: an optimizer or AI model may never, by
+ * itself, publish a schedule, message an employee, decide leave, approve an
+ * exception, or impose an adverse employment consequence (spec §2.2). Those
+ * require a human actor with the authority — or an explicit, scoped, unexpired
+ * delegation the human granted. Evidence-gathering (prepare/refresh) is the only
+ * thing the coworker may do unattended in Phase 1.
+ *
+ * This module is a pure decision function; persistence and the actual side
+ * effect live outside it. It returns a verdict + reason for the audit record.
+ */
+
+/** Every action the staffing coworker or a human can take, ranked by consequence. */
+export type StaffingAction =
+  | "prepare_proposal" // read facts, run solver, compose options — evidence only
+  | "refresh_proposal" // re-run when only demand changed — low-risk, delegable
+  | "send_notification" // message employees — consequential
+  | "publish_schedule" // bind assignments, project to calendar — consequential
+  | "approve_exception" // waive an org rule — consequential
+  | "decide_leave"; // approve/deny leave — consequential
+
+/** Actions that always require a human decision (spec §11 Phase-3 carve-outs). */
+const HUMAN_ONLY: ReadonlySet<StaffingAction> = new Set([
+  "approve_exception",
+  "decide_leave",
+]);
+
+/** Consequential actions: allowed for the coworker ONLY under a matching grant. */
+const CONSEQUENTIAL: ReadonlySet<StaffingAction> = new Set([
+  "send_notification",
+  "publish_schedule",
+  "approve_exception",
+  "decide_leave",
+]);
+
+export function requiresHumanApproval(action: StaffingAction): boolean {
+  return CONSEQUENTIAL.has(action);
+}
+
+export type Actor =
+  | { kind: "agent"; agentId: string }
+  | {
+      kind: "human";
+      userId: string;
+      /** Capabilities the human holds, e.g. "staffing.publish". */
+      capabilities: string[];
+    };
+
+/**
+ * A scoped delegation a human granted to the coworker (mirrors DelegationGrant:
+ * scopeJson, status, validFrom/expiresAt, maxUses/useCount).
+ */
+export type StaffingDelegation = {
+  granteeAgentId: string;
+  status: string; // "active" | "revoked" | ...
+  validFrom: Date;
+  expiresAt: Date;
+  maxUses: number | null;
+  useCount: number;
+  /** Which actions + scope the grant covers. */
+  scope: {
+    actions: StaffingAction[];
+    organizationId?: string;
+    locationIds?: string[];
+  };
+};
+
+export type AuthorizationContext = {
+  action: StaffingAction;
+  actor: Actor;
+  organizationId: string;
+  /** The location the action affects, if scoped. */
+  locationId?: string | null;
+  now: Date;
+  delegation?: StaffingDelegation | null;
+};
+
+export type AuthorizationVerdict = {
+  allowed: boolean;
+  /** Machine + human readable reason, recorded in the decision evidence. */
+  reason: string;
+};
+
+function delegationValid(
+  d: StaffingDelegation,
+  ctx: AuthorizationContext,
+): boolean {
+  if (d.status !== "active") return false;
+  if (ctx.now < d.validFrom || ctx.now >= d.expiresAt) return false;
+  if (d.maxUses !== null && d.useCount >= d.maxUses) return false;
+  if (!d.scope.actions.includes(ctx.action)) return false;
+  if (d.scope.organizationId && d.scope.organizationId !== ctx.organizationId) return false;
+  if (
+    d.scope.locationIds &&
+    ctx.locationId &&
+    !d.scope.locationIds.includes(ctx.locationId)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * The authorization decision. Evidence-gathering is always allowed; human-only
+ * actions are never delegable; other consequential actions need either a human
+ * with the capability or a matching, valid delegation.
+ */
+export function authorizeStaffingAction(ctx: AuthorizationContext): AuthorizationVerdict {
+  const { action, actor } = ctx;
+
+  // Evidence-gathering (prepare/refresh) is the coworker's Phase-1 authority.
+  if (!requiresHumanApproval(action)) {
+    return { allowed: true, reason: `${action} is evidence-gathering; no approval required` };
+  }
+
+  if (actor.kind === "human") {
+    // Human-only actions (leave, exception) require the human simply to be
+    // authorized; publish/notify require the publish capability (decision 2).
+    if (HUMAN_ONLY.has(action)) {
+      return { allowed: true, reason: `human ${actor.userId} decides ${action}` };
+    }
+    const capable = actor.capabilities.includes("staffing.publish");
+    return capable
+      ? { allowed: true, reason: `human ${actor.userId} holds staffing.publish` }
+      : { allowed: false, reason: `human ${actor.userId} lacks staffing.publish capability` };
+  }
+
+  // Agent actor.
+  if (HUMAN_ONLY.has(action)) {
+    return { allowed: false, reason: `${action} is human-only and cannot be delegated (spec §11)` };
+  }
+  const d = ctx.delegation;
+  if (d && d.granteeAgentId === actor.agentId && delegationValid(d, ctx)) {
+    return { allowed: true, reason: `agent ${actor.agentId} acts under delegation for ${action}` };
+  }
+  return {
+    allowed: false,
+    reason: `agent ${actor.agentId} needs a valid, scoped delegation to ${action}`,
+  };
+}

--- a/apps/web/lib/workforce/staffing/coworker/coworker.test.ts
+++ b/apps/web/lib/workforce/staffing/coworker/coworker.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  authorizeStaffingAction,
+  requiresHumanApproval,
+  type StaffingDelegation,
+} from "./authority";
+import { prepareStaffingProposal, STAFFING_PUBLISH_ACTION } from "./prepare-proposal";
+import type { ValidatedOption } from "../solver/validate-after-solve";
+
+// EP-WORKFORCE-OPS / BI-4AD09A35 Phase 4 — coworker authority boundary +
+// proposal preparation (spec §11, §2.2, founder decision 2).
+
+const NOW = new Date("2026-08-01T12:00:00Z");
+
+function grant(overrides: Partial<StaffingDelegation> = {}): StaffingDelegation {
+  return {
+    granteeAgentId: "staffing-coworker",
+    status: "active",
+    validFrom: new Date("2026-07-01T00:00:00Z"),
+    expiresAt: new Date("2026-09-01T00:00:00Z"),
+    maxUses: null,
+    useCount: 0,
+    scope: { actions: ["publish_schedule"], organizationId: "org-1" },
+    ...overrides,
+  };
+}
+
+describe("authority boundary", () => {
+  it("lets the coworker prepare/refresh proposals unattended (Phase 1)", () => {
+    for (const action of ["prepare_proposal", "refresh_proposal"] as const) {
+      const v = authorizeStaffingAction({
+        action,
+        actor: { kind: "agent", agentId: "staffing-coworker" },
+        organizationId: "org-1",
+        now: NOW,
+      });
+      expect(v.allowed).toBe(true);
+      expect(requiresHumanApproval(action)).toBe(false);
+    }
+  });
+
+  it("forbids the coworker from publishing without a delegation", () => {
+    const v = authorizeStaffingAction({
+      action: "publish_schedule",
+      actor: { kind: "agent", agentId: "staffing-coworker" },
+      organizationId: "org-1",
+      now: NOW,
+      delegation: null,
+    });
+    expect(v.allowed).toBe(false);
+  });
+
+  it("lets the coworker publish under a valid, scoped delegation", () => {
+    const v = authorizeStaffingAction({
+      action: "publish_schedule",
+      actor: { kind: "agent", agentId: "staffing-coworker" },
+      organizationId: "org-1",
+      now: NOW,
+      delegation: grant(),
+    });
+    expect(v.allowed).toBe(true);
+  });
+
+  it("rejects an expired, revoked, exhausted, or org-mismatched delegation", () => {
+    const base = {
+      action: "publish_schedule" as const,
+      actor: { kind: "agent" as const, agentId: "staffing-coworker" },
+      organizationId: "org-1",
+      now: NOW,
+    };
+    expect(authorizeStaffingAction({ ...base, delegation: grant({ expiresAt: new Date("2026-07-15T00:00:00Z") }) }).allowed).toBe(false);
+    expect(authorizeStaffingAction({ ...base, delegation: grant({ status: "revoked" }) }).allowed).toBe(false);
+    expect(authorizeStaffingAction({ ...base, delegation: grant({ maxUses: 3, useCount: 3 }) }).allowed).toBe(false);
+    expect(authorizeStaffingAction({ ...base, delegation: grant({ scope: { actions: ["publish_schedule"], organizationId: "org-2" } }) }).allowed).toBe(false);
+  });
+
+  it("never lets an agent decide leave or approve an exception, even with a grant", () => {
+    for (const action of ["decide_leave", "approve_exception"] as const) {
+      const v = authorizeStaffingAction({
+        action,
+        actor: { kind: "agent", agentId: "staffing-coworker" },
+        organizationId: "org-1",
+        now: NOW,
+        delegation: grant({ scope: { actions: [action], organizationId: "org-1" } }),
+      });
+      expect(v.allowed).toBe(false);
+    }
+  });
+
+  it("lets a human publish only with the staffing.publish capability (decision 2)", () => {
+    const capable = authorizeStaffingAction({
+      action: "publish_schedule",
+      actor: { kind: "human", userId: "owner-1", capabilities: ["staffing.publish"] },
+      organizationId: "org-1",
+      now: NOW,
+    });
+    const notCapable = authorizeStaffingAction({
+      action: "publish_schedule",
+      actor: { kind: "human", userId: "coord-2", capabilities: [] },
+      organizationId: "org-1",
+      now: NOW,
+    });
+    expect(capable.allowed).toBe(true);
+    expect(notCapable.allowed).toBe(false);
+  });
+
+  it("enforces delegation location scope", () => {
+    const v = authorizeStaffingAction({
+      action: "publish_schedule",
+      actor: { kind: "agent", agentId: "staffing-coworker" },
+      organizationId: "org-1",
+      locationId: "loc-B",
+      now: NOW,
+      delegation: grant({ scope: { actions: ["publish_schedule"], organizationId: "org-1", locationIds: ["loc-A"] } }),
+    });
+    expect(v.allowed).toBe(false);
+  });
+});
+
+describe("proposal preparation", () => {
+  const vopt = (publishable: boolean, score: number, unfilled: number, premium: number): ValidatedOption => ({
+    option: {
+      assignments: Array.from({ length: score }, (_, i) => ({ shiftId: `s${i}`, employeeProfileId: `e${i}` })),
+      score,
+      unfilledShiftIds: Array.from({ length: unfilled }, (_, i) => `u${i}`),
+      hardViolationCount: publishable ? 0 : 1,
+    },
+    evaluation: {
+      feasible: publishable,
+      violations: [],
+      premiums: premium ? [{ ruleId: "ot", predicateType: "max_hours_premium", subjectRef: "e0", units: premium, message: "" }] : [],
+      requiresPolicyReview: false,
+    },
+    publishable,
+  });
+
+  it("recommends the publishable option with fewest unfilled shifts, never auto-publishes", () => {
+    const payload = prepareStaffingProposal({
+      organizationId: "org-1",
+      proposalRunId: "run-1",
+      validatedOptions: [vopt(true, 5, 2, 3), vopt(true, 4, 0, 1), vopt(false, 9, 0, 0)],
+    });
+    expect(payload.actionType).toBe(STAFFING_PUBLISH_ACTION);
+    expect(payload.autoPublish).toBe(false);
+    expect(payload.parameters.recommendedOptionIndex).toBe(1); // fewest unfilled
+    expect(payload.parameters.noFeasibleSchedule).toBe(false);
+    expect(payload.parameters.options[2].publishable).toBe(false);
+  });
+
+  it("returns an honest no-feasible-schedule proposal when nothing is publishable", () => {
+    const payload = prepareStaffingProposal({
+      organizationId: "org-1",
+      proposalRunId: "run-1",
+      validatedOptions: [vopt(false, 3, 4, 0)],
+    });
+    expect(payload.parameters.noFeasibleSchedule).toBe(true);
+    expect(payload.parameters.recommendedOptionIndex).toBeNull();
+    expect(payload.autoPublish).toBe(false);
+  });
+});

--- a/apps/web/lib/workforce/staffing/coworker/prepare-proposal.ts
+++ b/apps/web/lib/workforce/staffing/coworker/prepare-proposal.ts
@@ -1,0 +1,96 @@
+/**
+ * AI Staffing Coworker — proposal preparation (EP-WORKFORCE-OPS / BI-4AD09A35
+ * Phase 4). Spec §11 Phase 1: the coworker reads governed facts, runs
+ * validation/optimization, compares options, and composes an AgentActionProposal
+ * — but never publishes. This module is the pure composition step: it turns
+ * DPF-validated solver options into the typed `parameters` payload for an
+ * AgentActionProposal (actionType "staffing.publish_schedule"), selecting only
+ * options DPF's own engine certified as publishable (spec §7.3).
+ *
+ * It is honest about infeasibility (spec §8.3): when no option is publishable it
+ * returns a `no_feasible_schedule` proposal that explains the gap, rather than
+ * fabricating a fill or silently dropping demand. The actual AgentActionProposal
+ * row is written by the coworker runtime (thread/message context); this function
+ * has no side effects.
+ */
+import type { ValidatedOption } from "../solver/validate-after-solve";
+
+export const STAFFING_PUBLISH_ACTION = "staffing.publish_schedule";
+
+/** A per-option summary the coordinator sees in the comparison view (spec §8.3). */
+export type ProposalOptionSummary = {
+  optionIndex: number;
+  assignmentCount: number;
+  unfilledShiftCount: number;
+  score: number;
+  /** Priced schedule-shape premiums (spec §9.4), summed in abstract units. */
+  premiumUnits: number;
+  publishable: boolean;
+};
+
+export type StaffingProposalPayload = {
+  actionType: typeof STAFFING_PUBLISH_ACTION;
+  parameters: {
+    organizationId: string;
+    proposalRunId: string;
+    /** Every option, with only publishable ones offered for approval. */
+    options: ProposalOptionSummary[];
+    /** Index of the recommended (publishable, best-scoring) option, or null. */
+    recommendedOptionIndex: number | null;
+    /** True when NO option is publishable — the honest infeasible path. */
+    noFeasibleSchedule: boolean;
+  };
+  /** Always false in Phase 1: composing a proposal never publishes (spec §11). */
+  autoPublish: false;
+};
+
+function summarize(validated: ValidatedOption, index: number): ProposalOptionSummary {
+  const premiumUnits = validated.evaluation.premiums.reduce((sum, p) => sum + p.units, 0);
+  return {
+    optionIndex: index,
+    assignmentCount: validated.option.assignments.length,
+    unfilledShiftCount: validated.option.unfilledShiftIds.length,
+    score: validated.option.score,
+    premiumUnits,
+    publishable: validated.publishable,
+  };
+}
+
+/**
+ * Compose the proposal. `recommendedOptionIndex` is the publishable option with
+ * the highest score and fewest unfilled shifts; ties break to the lower premium.
+ * When nothing is publishable, `noFeasibleSchedule` is set and no option is
+ * recommended.
+ */
+export function prepareStaffingProposal(input: {
+  organizationId: string;
+  proposalRunId: string;
+  validatedOptions: ValidatedOption[];
+}): StaffingProposalPayload {
+  const options = input.validatedOptions.map(summarize);
+
+  const publishable = options.filter((o) => o.publishable);
+  let recommendedOptionIndex: number | null = null;
+  if (publishable.length > 0) {
+    const best = publishable.reduce((a, b) => {
+      if (b.unfilledShiftCount !== a.unfilledShiftCount) {
+        return b.unfilledShiftCount < a.unfilledShiftCount ? b : a;
+      }
+      if (b.score !== a.score) return b.score > a.score ? b : a;
+      return b.premiumUnits < a.premiumUnits ? b : a;
+    });
+    recommendedOptionIndex = best.optionIndex;
+  }
+
+  return {
+    actionType: STAFFING_PUBLISH_ACTION,
+    parameters: {
+      organizationId: input.organizationId,
+      proposalRunId: input.proposalRunId,
+      options,
+      recommendedOptionIndex,
+      noFeasibleSchedule: publishable.length === 0,
+    },
+    autoPublish: false,
+  };
+}

--- a/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
+++ b/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
@@ -88,13 +88,30 @@ and the post-solve gate: rejects a rogue option that double-books despite the
 solver self-reporting zero violations, and withholds publish when the
 jurisdiction is unresolved (6 tests, `solver/adapter.test.ts`).
 
-### Phase 4 — AI Staffing Coworker proposal flow + human-authority boundary
+### Phase 4 — AI Staffing Coworker proposal flow + human-authority boundary *(core built)*
 
-**Deliverable.** Phase-1 coworker authority (design §11): read governed facts, prepare demand, run validation/optimization, compare options, create `AgentActionProposal` with typed staffing links (reuse existing governance substrate). Cannot publish or message employees without approval. Publish/exception/leave/notify require a valid actor + delegation + evidence; publish authority bound to the owner/operator capability (decision 2), delegable by scope later.
+**Deliverable.** Phase-1 coworker authority (design §11). **Built in this slice**
+(`apps/web/lib/workforce/staffing/coworker/`): `authority.ts` — the pure
+authorization boundary (`authorizeStaffingAction`): prepare/refresh are the
+coworker's unattended Phase-1 authority; publish/notify need a human with the
+`staffing.publish` capability (decision 2) or a matching, unexpired, scoped
+`DelegationGrant`; leave/exception are **human-only and never delegable** (spec
+§2.2, §11). `prepare-proposal.ts` — composes the `AgentActionProposal` payload
+(`staffing.publish_schedule`) from DPF-validated solver options, offering only
+publishable ones and returning an honest `noFeasibleSchedule` proposal when none
+qualify (spec §8.3); `autoPublish` is always false — composing never publishes.
+
+**Pending (integration):** wiring the payload to the real `AgentActionProposal`
+row (thread/message context) + `DelegationGrant` reads + `DecisionInteraction`
+evidence — a thin governed wrapper over the coworker runtime.
 
 **Files.** `apps/web/lib/workforce/staffing/coworker/`; governance links reuse `AgentActionProposal`/`DelegationGrant`/`DecisionInteraction`.
 
-**Verification.** No publication/exception/notification without a valid actor + evidence record; a proposal never mutates assignments; delegation scope enforced.
+**Verification.** 9 tests (`coworker/coworker.test.ts`): coworker may prepare/
+refresh but not publish without a grant; valid/expired/revoked/exhausted/org-
+and location-scoped delegations; leave/exception non-delegable even with a grant;
+human publish gated on capability; proposal recommends fewest-unfilled publishable
+option and never auto-publishes; honest no-feasible-schedule path.
 
 ### Phase 5 — MCP staffing tool pack
 


### PR DESCRIPTION
## Summary

Phase 4 (core) of the workforce staffing substrate (`BI-4AD09A35`, epic `EP-WORKFORCE-OPS`) — the **AI Staffing Coworker's Phase-1 authority and the human-authority boundary** the whole feature turns on (spec §11, §2.2, founder decision 2), as pure decision logic.

Builds on Phases 1–3 (merged). Plan: [`§Phase 4`](docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md).

## What's in it

- **`coworker/authority.ts`** — `authorizeStaffingAction`, the pure authorization boundary:
  - **prepare / refresh** proposals = the coworker's unattended Phase-1 authority (evidence-gathering).
  - **publish / notify** = require a human holding the `staffing.publish` capability (founder decision 2) **or** a matching, unexpired, scoped `DelegationGrant` (org + location + action + `maxUses` all checked).
  - **decide-leave / approve-exception** = **human-only, never delegable** — an AI can never decide them by itself (spec §2.2).
  - Returns a verdict + reason for the audit record.
- **`coworker/prepare-proposal.ts`** — composes the `AgentActionProposal` payload (`staffing.publish_schedule`) from DPF-validated solver options (Phase 3), offering only publishable options, recommending the fewest-unfilled one, and returning an honest `noFeasibleSchedule` proposal when none qualify (spec §8.3). **`autoPublish` is always false** — composing a proposal never publishes.

## Design fidelity

The rule the feature exists to guarantee (spec §2.2): an optimizer or AI model may never, by itself, publish a schedule, message an employee, decide leave, or waive a rule. This module makes that a typed, tested boundary — the coworker can gather evidence and *propose*, but every consequential action routes to a human or an explicit human-granted delegation.

## Pending (integration)

Wiring the payload to a real `AgentActionProposal` row (thread/message context) + `DelegationGrant` reads + `DecisionInteraction` evidence — a thin governed wrapper over the coworker runtime.

## Verification

9 tests (`coworker/coworker.test.ts`): the full delegation matrix (valid / expired / revoked / exhausted / org- and location-scoped), non-delegable human-only actions even with a grant, capability-gated human publish, recommendation selection, and the honest no-feasible-schedule path. `apps/web` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Local-CI-Override: Phase 4 is pure TypeScript (coworker authority + proposal prep + tests), no DB/schema change. 9 tests + apps/web typecheck green locally. Local pregate's only failures remain the pre-existing `localStorage is not available (--localstorage-file not provided)` env quirk in unrelated apps/web component tests. GitHub CI is authoritative.
