### PR TITLE
feat(workforce): calendar projection + 'a message is not leave' flow — Phase 7 core (BI-4AD09A35)

### DIFF
--- a/apps/web/lib/workforce/staffing/projections/assignment-to-calendar.ts
+++ b/apps/web/lib/workforce/staffing/projections/assignment-to-calendar.ts
@@ -1,0 +1,69 @@
+/**
+ * Confirmed-assignment → calendar projection (EP-WORKFORCE-OPS / BI-4AD09A35
+ * Phase 7). Spec §5.2 + §4: the staffing domain is authoritative; the calendar
+ * is a PROJECTION. A confirmed assignment projects into a `CalendarEventView`
+ * for display and free/busy — it never becomes a second canonical copy, and a
+ * calendar event never establishes an assignment (the arrow points one way).
+ *
+ * Pure transform: staffing records in, calendar-view rows out. Only confirmed/
+ * published assignments project (a proposed assignment is not on anyone's
+ * calendar yet). The projection is idempotent by (organization, source
+ * assignment id) so re-projecting never duplicates (spec §5.3).
+ */
+
+export type ProjectableAssignment = {
+  assignmentId: string;
+  employeeProfileId: string;
+  lifecycle: string;
+  shift: {
+    shiftId: string;
+    startAt: string;
+    endAt: string;
+    timezone: string;
+    roleLabel: string | null;
+    workLocationId: string | null;
+  };
+};
+
+/** A read-only calendar projection of a confirmed staffing assignment. */
+export type StaffingCalendarProjection = {
+  /** Idempotency key — stable per source assignment (spec §5.3). */
+  sourceRef: string;
+  ownerEmployeeId: string;
+  startAt: string;
+  endAt: string;
+  timezone: string;
+  title: string;
+  category: "staffing";
+  /** Marks this as a projection, so calendar write paths never treat it as a
+   *  native editable event or an assignment authority. */
+  readonly: true;
+};
+
+const PROJECTABLE = new Set(["confirmed", "published", "completed", "on_site"]);
+
+/**
+ * Project the confirmed assignments in a set into calendar-view rows. Non-
+ * confirmed assignments are skipped (they are not yet on a calendar). The title
+ * is the shift's role label — a staffing shift is not private, but it also
+ * carries no personal detail beyond the role.
+ */
+export function projectAssignmentsToCalendar(
+  assignments: ProjectableAssignment[],
+): StaffingCalendarProjection[] {
+  const out: StaffingCalendarProjection[] = [];
+  for (const a of assignments) {
+    if (!PROJECTABLE.has(a.lifecycle)) continue;
+    out.push({
+      sourceRef: `staffing-assignment:${a.assignmentId}`,
+      ownerEmployeeId: a.employeeProfileId,
+      startAt: a.shift.startAt,
+      endAt: a.shift.endAt,
+      timezone: a.shift.timezone,
+      title: a.shift.roleLabel ?? "Scheduled shift",
+      category: "staffing",
+      readonly: true,
+    });
+  }
+  return out;
+}

--- a/apps/web/lib/workforce/staffing/projections/candidate-fact-flow.ts
+++ b/apps/web/lib/workforce/staffing/projections/candidate-fact-flow.ts
@@ -1,0 +1,91 @@
+/**
+ * Time-off-intent candidate-fact flow (EP-WORKFORCE-OPS / BI-4AD09A35 Phase 7).
+ * Spec §2.2, §10, §11: a message, a "busy" calendar block, or a learned pattern
+ * is NEVER an approved leave request. Communication-derived intent enters as a
+ * bounded `WorkforceCandidateFact`, and only an employee-confirmed fact becomes a
+ * pending `LeaveRequest` — which still requires the configured approver before it
+ * is approved leave (a hard unavailability). This module is the pure state
+ * machine for that pipeline; it performs no writes and can never emit an approved
+ * leave.
+ *
+ * The flow (spec §11):
+ *   provider event -> candidate fact (time_off_intent)
+ *     -> employee confirm/edit/reject
+ *     -> LeaveRequest(pending)      [confirm only]
+ *     -> authorized approval        [OUT OF SCOPE HERE — human decides]
+ */
+
+export type CandidateFact = {
+  candidateFactId: string;
+  subjectEmployeeProfileId: string | null;
+  kind: string; // "time_off_intent" | ...
+  reviewState: string; // "pending" | "confirmed" | "edited" | "rejected"
+  extractedValue: { startDate?: string; endDate?: string; leaveType?: string } | null;
+  identityResolution: string; // "unresolved" | "resolved" | "ambiguous"
+  confidence: number | null;
+};
+
+export type EmployeeReview =
+  | { action: "confirm" }
+  | { action: "edit"; startDate: string; endDate: string; leaveType?: string }
+  | { action: "reject" };
+
+/** A pending LeaveRequest payload — the ONLY thing a confirmed intent promotes
+ *  to. It is `pending`, never approved: an approver still decides (spec §11). */
+export type PendingLeaveRequestDraft = {
+  employeeProfileId: string;
+  leaveType: string;
+  startDate: string;
+  endDate: string;
+  status: "pending";
+  sourceCandidateFactId: string;
+};
+
+export type FlowResult =
+  | { outcome: "promoted"; draft: PendingLeaveRequestDraft; nextReviewState: "confirmed" }
+  | { outcome: "rejected"; nextReviewState: "rejected" }
+  | { outcome: "blocked"; reason: string };
+
+/**
+ * Apply an employee review to a candidate fact. A confirm/edit on a time-off
+ * intent with a resolved subject and dates promotes to a PENDING leave draft;
+ * anything else is blocked (never silently promoted). Identity must be resolved
+ * — an ambiguous or unresolved subject can never generate a leave request
+ * (spec §10 identity resolution; §2.2 never treat unread/inferred as approved).
+ */
+export function applyEmployeeReview(fact: CandidateFact, review: EmployeeReview): FlowResult {
+  if (fact.kind !== "time_off_intent") {
+    return { outcome: "blocked", reason: `candidate fact kind "${fact.kind}" is not a time-off intent` };
+  }
+  if (review.action === "reject") {
+    return { outcome: "rejected", nextReviewState: "rejected" };
+  }
+  if (fact.subjectEmployeeProfileId === null || fact.identityResolution !== "resolved") {
+    return { outcome: "blocked", reason: "subject identity is not resolved; cannot create a leave request" };
+  }
+
+  const start = review.action === "edit" ? review.startDate : fact.extractedValue?.startDate;
+  const end = review.action === "edit" ? review.endDate : fact.extractedValue?.endDate;
+  const leaveType =
+    (review.action === "edit" ? review.leaveType : fact.extractedValue?.leaveType) ?? "unspecified";
+
+  if (!start || !end) {
+    return { outcome: "blocked", reason: "confirmed intent is missing start/end dates" };
+  }
+  if (new Date(end).getTime() < new Date(start).getTime()) {
+    return { outcome: "blocked", reason: "end date precedes start date" };
+  }
+
+  return {
+    outcome: "promoted",
+    nextReviewState: "confirmed",
+    draft: {
+      employeeProfileId: fact.subjectEmployeeProfileId,
+      leaveType,
+      startDate: start,
+      endDate: end,
+      status: "pending",
+      sourceCandidateFactId: fact.candidateFactId,
+    },
+  };
+}

--- a/apps/web/lib/workforce/staffing/projections/projections.test.ts
+++ b/apps/web/lib/workforce/staffing/projections/projections.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { projectAssignmentsToCalendar, type ProjectableAssignment } from "./assignment-to-calendar";
+import { applyEmployeeReview, type CandidateFact } from "./candidate-fact-flow";
+
+// EP-WORKFORCE-OPS / BI-4AD09A35 Phase 7 — calendar projection + the
+// "a message is not leave" candidate-fact flow (spec §2.2, §5.2, §10, §11).
+
+function assignment(id: string, lifecycle: string): ProjectableAssignment {
+  return {
+    assignmentId: id,
+    employeeProfileId: "e1",
+    lifecycle,
+    shift: {
+      shiftId: `s-${id}`,
+      startAt: "2026-08-01T16:00:00Z",
+      endAt: "2026-08-01T20:00:00Z",
+      timezone: "America/Los_Angeles",
+      roleLabel: "Front desk",
+      workLocationId: "loc-A",
+    },
+  };
+}
+
+describe("projectAssignmentsToCalendar", () => {
+  it("projects only confirmed/published assignments, marked read-only", () => {
+    const rows = projectAssignmentsToCalendar([
+      assignment("a1", "confirmed"),
+      assignment("a2", "proposed"),
+      assignment("a3", "published"),
+      assignment("a4", "withdrawn"),
+    ]);
+    expect(rows.map((r) => r.sourceRef)).toEqual([
+      "staffing-assignment:a1",
+      "staffing-assignment:a3",
+    ]);
+    expect(rows.every((r) => r.readonly === true && r.category === "staffing")).toBe(true);
+  });
+
+  it("uses a stable idempotency key per source assignment", () => {
+    const once = projectAssignmentsToCalendar([assignment("a1", "confirmed")]);
+    const twice = projectAssignmentsToCalendar([assignment("a1", "confirmed")]);
+    expect(once[0].sourceRef).toBe(twice[0].sourceRef);
+  });
+});
+
+describe("candidate-fact flow — a message is not leave (spec §2.2)", () => {
+  function fact(overrides: Partial<CandidateFact> = {}): CandidateFact {
+    return {
+      candidateFactId: "cf1",
+      subjectEmployeeProfileId: "e1",
+      kind: "time_off_intent",
+      reviewState: "pending",
+      extractedValue: { startDate: "2026-08-10", endDate: "2026-08-12", leaveType: "vacation" },
+      identityResolution: "resolved",
+      confidence: 0.9,
+      ...overrides,
+    };
+  }
+
+  it("promotes a confirmed intent only to a PENDING leave request, never approved", () => {
+    const result = applyEmployeeReview(fact(), { action: "confirm" });
+    expect(result.outcome).toBe("promoted");
+    if (result.outcome === "promoted") {
+      expect(result.draft.status).toBe("pending");
+      expect(result.draft.sourceCandidateFactId).toBe("cf1");
+      expect(result.draft.startDate).toBe("2026-08-10");
+    }
+  });
+
+  it("never promotes when identity is unresolved or ambiguous", () => {
+    expect(applyEmployeeReview(fact({ identityResolution: "ambiguous" }), { action: "confirm" }).outcome).toBe("blocked");
+    expect(applyEmployeeReview(fact({ subjectEmployeeProfileId: null, identityResolution: "unresolved" }), { action: "confirm" }).outcome).toBe("blocked");
+  });
+
+  it("never promotes a non-time-off candidate fact", () => {
+    expect(applyEmployeeReview(fact({ kind: "availability_hint" }), { action: "confirm" }).outcome).toBe("blocked");
+  });
+
+  it("rejects on employee reject, producing no leave draft", () => {
+    const result = applyEmployeeReview(fact(), { action: "reject" });
+    expect(result.outcome).toBe("rejected");
+  });
+
+  it("honors an employee edit of the dates", () => {
+    const result = applyEmployeeReview(fact({ extractedValue: null }), {
+      action: "edit",
+      startDate: "2026-09-01",
+      endDate: "2026-09-03",
+      leaveType: "personal",
+    });
+    expect(result.outcome).toBe("promoted");
+    if (result.outcome === "promoted") {
+      expect(result.draft.startDate).toBe("2026-09-01");
+      expect(result.draft.leaveType).toBe("personal");
+    }
+  });
+
+  it("blocks an inverted or incomplete date range", () => {
+    expect(applyEmployeeReview(fact({ extractedValue: { startDate: "2026-08-12", endDate: "2026-08-10" } }), { action: "confirm" }).outcome).toBe("blocked");
+    expect(applyEmployeeReview(fact({ extractedValue: { startDate: "2026-08-10" } }), { action: "confirm" }).outcome).toBe("blocked");
+  });
+});

--- a/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
+++ b/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
@@ -129,9 +129,30 @@ option and never auto-publishes; honest no-feasible-schedule path.
 
 **Verification.** Live portal (contributor preview :3001) — coordinator happy path, employee correction, infeasible ("no feasible schedule") explanation without fabricated fill, private-title redaction, keyboard/accessible table operation, employee-timezone clarity.
 
-### Phase 7 — Calendar & comms projections
+### Phase 7 — Calendar & comms projections *(pure projections built)*
 
-**Deliverable.** Project confirmed assignments into `CalendarEventView` (no second canonical calendar copy); harden `calendar-data.ts` `employeeProfileId` scoping (§3.3 prerequisite) before private staffing projections depend on it. Comms candidate-fact flow (time-off intent → employee confirmation → `LeaveRequest(pending)` → approved-leave hard constraint → repair proposal); minimal source envelope only.
+**Deliverable.** Project confirmed assignments into the calendar; the
+time-off-intent comms flow. **Built in this slice**
+(`apps/web/lib/workforce/staffing/projections/`): `assignment-to-calendar.ts` —
+`projectAssignmentsToCalendar` projects only confirmed/published assignments into
+read-only, idempotent (`sourceRef`) calendar-view rows (staffing is authoritative;
+the calendar is a one-way projection, never a second canonical copy — spec §5.2);
+`candidate-fact-flow.ts` — `applyEmployeeReview`, the pure state machine that
+enforces **a message is not leave** (spec §2.2): a time-off intent promotes only
+to a *pending* `LeaveRequest` and only after employee confirmation with a resolved
+identity — never approved leave, never from an unresolved/ambiguous subject or a
+non-intent fact.
+
+**Pending — needs the live substrate:** wiring the projection into
+`CalendarEventView` writes and hardening `calendar-data.ts` `employeeProfileId`
+scoping (§3.3 prerequisite); persisting the pending `LeaveRequest` through the
+governed leave workflow; the impacted-schedule repair proposal.
+
+**Verification.** 8 tests (`projections/projections.test.ts`): projection filters
+to confirmed/published + read-only + stable idempotency key; and the
+message-is-not-leave matrix — pending-only promotion, block on unresolved/
+ambiguous identity, block on non-intent kind, reject path, employee date edit,
+inverted/incomplete range block.
 
 **Files.** `apps/web/lib/workforce/calendar-data.ts` (scoping fix); `apps/web/lib/workforce/staffing/projections/`; candidate-fact ingestion module.
 


### PR DESCRIPTION
## Summary

Phase 7 (core) of the workforce staffing substrate (`BI-4AD09A35`, epic `EP-WORKFORCE-OPS`) — the **pure projection and comms logic**: confirmed assignments project into the calendar, and communication-derived time-off intent is kept honest.

Plan: [`§Phase 7`](docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md).

## What's in it

- **`projections/assignment-to-calendar.ts`** — `projectAssignmentsToCalendar` projects only confirmed/published assignments into **read-only, idempotent** (`sourceRef`) calendar-view rows. Staffing stays authoritative; the calendar is a **one-way projection** — never a second canonical copy, never an assignment authority (spec §5.2, §4).
- **`projections/candidate-fact-flow.ts`** — `applyEmployeeReview`, the pure state machine enforcing **"a message is not leave"** (spec §2.2): a time-off intent promotes **only to a `pending` LeaveRequest**, and only after employee confirmation with a **resolved identity**. It can never emit approved leave, never promote an unresolved/ambiguous subject, and never promote a non-intent candidate fact.

## Design fidelity

Two of the design's sharpest guarantees, made into tested code: the calendar can't masquerade as staffing authority, and an unread message / inferred pattern / busy block can't become approved leave.

## Pending — needs the live substrate

Wiring the projection into `CalendarEventView` writes + hardening `calendar-data.ts` `employeeProfileId` scoping (§3.3); persisting the pending `LeaveRequest` through the governed leave workflow; the impacted-schedule repair proposal.

## Verification

8 tests (`projections/projections.test.ts`): projection filtering / read-only / idempotency, and the message-is-not-leave matrix (pending-only promotion, identity gates, non-intent block, reject path, employee date edit, inverted/incomplete-range block). `apps/web` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Local-CI-Override: Phase 7 pure projection/comms logic + tests, no DB/schema change. 8 tests + apps/web typecheck green locally. Local pregate's other failures are the pre-existing `localStorage is not available (--localstorage-file not provided)` env quirk in unrelated apps/web component tests. GitHub CI authoritative.