### PR TITLE
feat(workforce): clopening-premium + max-consecutive-days predicates (BI-4AD09A35)

### DIFF
--- a/apps/web/lib/workforce/staffing/constraints/evaluate.test.ts
+++ b/apps/web/lib/workforce/staffing/constraints/evaluate.test.ts
@@ -201,6 +201,39 @@ describe("max_hours_premium (priced, not infeasible)", () => {
   });
 });
 
+describe("clopening_premium (soft, priced) vs rest_gap (hard)", () => {
+  const emp = { employeeProfileId: "e1", credentials: [], capabilities: [], roleKey: null, employmentType: null };
+  const shiftA = { shiftId: "s1", interval: { start: zi("2026-08-01T00:00:00Z"), end: zi("2026-08-01T08:00:00Z") }, workLocationId: null, requiredCredentials: [] };
+  const near = { shiftId: "s2", interval: { start: zi("2026-08-01T14:00:00Z"), end: zi("2026-08-01T22:00:00Z") }, workLocationId: null, requiredCredentials: [] };
+  const assigns = [
+    { assignmentId: "a1", shiftId: "s1", employeeProfileId: "e1", lifecycle: "confirmed" },
+    { assignmentId: "a2", shiftId: "s2", employeeProfileId: "e1", lifecycle: "confirmed" },
+  ];
+
+  it("prices a short turnaround as a premium without breaking feasibility", () => {
+    const r = evaluateConstraints(baseProblem({
+      shifts: [shiftA, near], assignments: assigns, employees: [emp],
+      rules: [{ ruleId: "clop", predicateType: "clopening_premium", severity: "soft", legallyWaivable: false, parameters: { minHours: 11, premiumUnits: 1 } }],
+    }));
+    expect(r.feasible).toBe(true); // 6h turnaround < 11h — priced, not infeasible
+    expect(r.premiums).toHaveLength(1);
+  });
+});
+
+describe("max_consecutive_days (hard, fatigue)", () => {
+  const emp = { employeeProfileId: "e1", credentials: [], capabilities: [], roleKey: null, employmentType: null };
+  const day = (n: number) => ({ shiftId: `s${n}`, interval: { start: zi(`2026-08-0${n}T09:00:00Z`), end: zi(`2026-08-0${n}T17:00:00Z`) }, workLocationId: null, requiredCredentials: [] });
+  const assign = (n: number) => ({ assignmentId: `a${n}`, shiftId: `s${n}`, employeeProfileId: "e1", lifecycle: "confirmed" });
+  const rule = HARD("max_consecutive_days", { maxDays: 6 });
+
+  it("passes at 6 consecutive days, fails at 7", () => {
+    const six = evaluateConstraints(baseProblem({ shifts: [1,2,3,4,5,6].map(day), assignments: [1,2,3,4,5,6].map(assign), employees: [emp], rules: [rule] }));
+    expect(six.feasible).toBe(true);
+    const seven = evaluateConstraints(baseProblem({ shifts: [1,2,3,4,5,6,7].map(day), assignments: [1,2,3,4,5,6,7].map(assign), employees: [emp], rules: [rule] }));
+    expect(seven.feasible).toBe(false);
+  });
+});
+
 describe("fail-closed jurisdiction (spec §6, §8.1)", () => {
   it("requires policy review when jurisdiction is unresolved and a safety-critical rule is in scope", () => {
     const r = evaluateConstraints(baseProblem({

--- a/apps/web/lib/workforce/staffing/constraints/evaluate.ts
+++ b/apps/web/lib/workforce/staffing/constraints/evaluate.ts
@@ -11,7 +11,9 @@
  */
 import {
   capabilityPresence,
+  clopeningPremium,
   credentialEligibility,
+  maxConsecutiveDays,
   maxHoursPremium,
   minNTogether,
   noOverlap,
@@ -37,6 +39,8 @@ export const PREDICATE_REGISTRY: Record<string, PredicateEvaluator> = {
   rest_gap: restGap,
   no_overlap: noOverlap,
   max_hours_premium: maxHoursPremium,
+  clopening_premium: clopeningPremium,
+  max_consecutive_days: maxConsecutiveDays,
 };
 
 /**

--- a/apps/web/lib/workforce/staffing/constraints/predicates.ts
+++ b/apps/web/lib/workforce/staffing/constraints/predicates.ts
@@ -244,6 +244,76 @@ export const maxHoursPremium: PredicateEvaluator = (rule, problem) => {
   return { premiums };
 };
 
+/**
+ * clopening_premium — a SOFT, priced cost (spec §9.4) for a short turnaround
+ * between an employee's consecutive shifts: the payable "clopening" premium that
+ * fair-workweek laws attach (e.g. NYC $100, Chicago 1.25×). Distinct from the
+ * HARD `rest_gap`: some jurisdictions forbid a short gap outright (hard), others
+ * merely price it (this). `parameters.minHours`, `parameters.premiumUnits`.
+ */
+export const clopeningPremium: PredicateEvaluator = (rule, problem) => {
+  const minHours = Number(rule.parameters.minHours ?? 11);
+  const premiumUnits = Number(rule.parameters.premiumUnits ?? 1);
+  const premiums = [];
+  for (const employee of problem.employees) {
+    const intervals = employeeIntervals(problem, employee.employeeProfileId).sort(
+      (a, b) => new Date(a.start.at).getTime() - new Date(b.start.at).getTime(),
+    );
+    for (let i = 1; i < intervals.length; i++) {
+      const gap = hoursBetween(intervals[i - 1].end.at, intervals[i].start.at);
+      if (gap < minHours) {
+        premiums.push({
+          ruleId: rule.ruleId,
+          predicateType: rule.predicateType,
+          subjectRef: employee.employeeProfileId,
+          units: premiumUnits,
+          message: `clopening premium: ${gap.toFixed(1)}h turnaround < ${minHours}h`,
+        });
+      }
+    }
+  }
+  return { premiums };
+};
+
+/**
+ * max_consecutive_days — HARD: an employee may not work more than N consecutive
+ * calendar days (spec §9.4 fatigue / day-of-rest rules, e.g. IL ODRISA one-day-
+ * rest-in-seven). Day is the UTC date of the shift start — a documented
+ * approximation; the effective-dated pack refines to the decision timezone.
+ * `parameters.maxDays`.
+ */
+export const maxConsecutiveDays: PredicateEvaluator = (rule, problem) => {
+  const maxDays = Number(rule.parameters.maxDays ?? 6);
+  const violations: ConstraintViolation[] = [];
+  for (const employee of problem.employees) {
+    const days = Array.from(
+      new Set(
+        employeeIntervals(problem, employee.employeeProfileId).map((iv) =>
+          iv.start.at.slice(0, 10),
+        ),
+      ),
+    ).sort();
+    let run = days.length > 0 ? 1 : 0;
+    let longest = run;
+    for (let i = 1; i < days.length; i++) {
+      const prev = new Date(`${days[i - 1]}T00:00:00Z`).getTime();
+      const cur = new Date(`${days[i]}T00:00:00Z`).getTime();
+      run = cur - prev === 86_400_000 ? run + 1 : 1;
+      if (run > longest) longest = run;
+    }
+    if (longest > maxDays) {
+      violations.push(
+        violation(
+          rule,
+          employee.employeeProfileId,
+          `${longest} consecutive days worked > max ${maxDays}`,
+        ),
+      );
+    }
+  }
+  return { violations };
+};
+
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 function groupAssigneesByShift(problem: NormalizedStaffingProblem) {

--- a/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
+++ b/docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md
@@ -55,11 +55,13 @@ evaluation loop (`constraints/evaluate.ts`), and the US-federal + California
 starter pack (`rule-packs/us.ts`). Unknown jurisdiction OR an unknown hard
 predicate → **requires policy review**, fail-closed (never assume US defaults).
 
-**Follow-up (same phase, later PRs):** the remaining §9.8 families
-(fair-workweek predictability pay, meal/reporting-time premiums, minor-hour
-windows, on-call compensability, headcount-formula, per-group overtime-regime
-selection), effective-dating, and DB-backed rule loading from
-`StaffingConstraintRule` rows.
+**Follow-up (same phase, later PRs):** `clopening_premium` (soft, priced — the
+payable fair-workweek clopening penalty, distinct from hard `rest_gap`) and
+`max_consecutive_days` (hard fatigue / one-day-rest-in-seven) are now landed
+(9 predicates total). Still open: fair-workweek predictability pay, meal/
+reporting-time premiums, minor-hour windows, on-call compensability, headcount-
+formula, per-group overtime-regime selection, effective-dating, and DB-backed
+rule loading from `StaffingConstraintRule` rows.
 
 **Verification.** Constraint goldens — passing + violating fixture per predicate,
 unknown-jurisdiction and unknown-predicate fail-closed tests, priced-premium


### PR DESCRIPTION
## Summary

Two more §9.8 constraint families on the merged Phase 2 engine (the plan lists these as follow-ups) — bringing the predicate registry to 9.

Plan: [`§Phase 2`](docs/superpowers/plans/2026-07-17-workforce-staffing-substrate-implementation.md).

## What's in it

- **`clopening_premium`** — a SOFT, priced cost for a short turnaround between an employee's consecutive shifts: the payable fair-workweek clopening penalty (e.g. NYC $100, Chicago 1.25×). Distinct from the HARD `rest_gap` — some jurisdictions forbid the short gap outright, others merely price it. Produces a premium, never infeasibility (spec §9.4).
- **`max_consecutive_days`** — HARD fatigue / one-day-rest-in-seven (e.g. IL ODRISA): an employee may not work more than N consecutive calendar days.

Both registered in the predicate registry; no new model or shared-registry changes.

## Verification

16 constraint goldens (2 new): clopening priced-not-infeasible; consecutive-days passes at 6, fails at 7. `apps/web` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Local-CI-Override: Additive pure predicates + tests, no DB/schema change. 16 constraint goldens + apps/web typecheck green locally. Local pregate's other failures are the pre-existing `localStorage is not available (--localstorage-file not provided)` env quirk in unrelated apps/web component tests. GitHub CI authoritative.