### PR TITLE
test: remove unsafe markup sanitizer

### DIFF
--- a/apps/web/components/workspace-home/OperatorCockpit.test.tsx
+++ b/apps/web/components/workspace-home/OperatorCockpit.test.tsx
@@ -31,7 +31,6 @@ function item(
 }
 
 const NOW = Date.parse("2026-07-11T12:00:00.000Z");
-const textOf = (html: string) => html.replace(/<[^>]+>/g, "");
 
 describe("OperatorCockpitView", () => {
   it("leads with the calm owner count and shared decision cards", () => {
@@ -75,7 +74,7 @@ describe("OperatorCockpitView", () => {
     );
 
     expect(html).toContain("Nothing needs you right now.");
-    expect(textOf(html)).toContain("Your digital team is handling 1 item");
+    expect(html).toContain("Your digital team is handling</span> 1 item");
     expect(html).toContain("no action needed");
     expect(html).not.toContain("qdrant is offline");
   });


### PR DESCRIPTION
## Summary

- follow up merged PR #3212 by removing the test-only regular expression that CodeQL identified as incomplete multi-character sanitization
- assert the exact React static-markup boundary directly; no owner-facing runtime behavior changes
- keep the security correction isolated to one test file on a fresh branch from current `main`

## Verification

- [x] focused `OperatorCockpit.test.tsx`: 3 tests passed
- [x] shared local-CI full suite: 1,962 files passed, 4 skipped; 16,991 tests passed
- [x] TypeScript typecheck
- [x] Prisma migration deploy
- [x] production Docker build
- [x] pre-push exact-sha gate

Local-CI-Evidence: cmrpewqqb0n1x01pkp9yizdgy (fix/needs-you-codeql-sanitizer@41f7ed000da0)

Process-Spine-Decision: This is a test-only CodeQL remediation with no product behavior or documentation impact.