### PR TITLE
fix(security): close TOCTOU file-system race in docs-asset route (CodeQL #323)

### DIFF
--- a/apps/web/app/api/docs-asset/[...path]/route.ts
+++ b/apps/web/app/api/docs-asset/[...path]/route.ts
@@ -36,18 +36,35 @@ export async function GET(_req: Request, { params }: { params: Promise<{ path: s
   }
   const ext = path.extname(resolved).toLowerCase();
   const contentType = CONTENT_TYPES[ext];
-  if (!contentType || !fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+  if (!contentType) {
     return new NextResponse("Not found", { status: 404 });
   }
 
-  const body = fs.readFileSync(resolved);
-  return new NextResponse(body, {
-    status: 200,
-    headers: {
-      "Content-Type": contentType,
-      "Cache-Control": "public, max-age=3600",
-      // SVGs are sanitized at render time; still forbid inline script execution.
-      "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'; img-src data:",
-    },
-  });
+  // Read via a single file descriptor to avoid a check-then-read (TOCTOU) race:
+  // fstat and read operate on the same open inode, so the file cannot be swapped
+  // between the "is it a regular file?" check and the read.
+  let fd: number;
+  try {
+    fd = fs.openSync(resolved, "r");
+  } catch {
+    // Missing file (ENOENT), or anything else that prevents opening — treat as 404.
+    return new NextResponse("Not found", { status: 404 });
+  }
+  try {
+    if (!fs.fstatSync(fd).isFile()) {
+      return new NextResponse("Not found", { status: 404 });
+    }
+    const body = fs.readFileSync(fd);
+    return new NextResponse(body, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=3600",
+        // SVGs are sanitized at render time; still forbid inline script execution.
+        "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'; img-src data:",
+      },
+    });
+  } finally {
+    fs.closeSync(fd);
+  }
 }


### PR DESCRIPTION
## Summary

Closes the open GitHub code-scanning (CodeQL) **high** alert [#323](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/security/code-scanning/323) — `js/file-system-race` (TOCTOU) in `apps/web/app/api/docs-asset/[...path]/route.ts`.

The handler checked `existsSync` + `statSync().isFile()` on the resolved path and then did a **separate** `readFileSync(resolved)` — a check-then-read window where the file could be swapped between the two operations. Fixed by reading through a single file descriptor: `openSync` → `fstatSync(fd).isFile()` → `readFileSync(fd)`, in a `try/finally` that always closes the fd. The stat and read now operate on the same open inode.

Behaviour is unchanged: a missing path or a directory (`EISDIR`) still returns 404, and the existing path-traversal guard is untouched.

## Scope note

This PR originally also touched `OperatorCockpit.test.tsx` for the companion alert **#324** (`js/incomplete-multi-character-sanitization`). That alert was resolved independently on `main` by #3218 (which removed the unsafe markup sanitizer), so this PR was rebased onto the current `main` and now carries **only** the route fix.

## Verification

- Rebased onto latest `main`; PR is mergeable and scoped to the single route file.
- Source-only worktree (dev toolchain not installed), so local typecheck/vitest pregates could not run; **CI gates typecheck, prod build, and unit tests**, and CodeQL re-scans the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)