### PR TITLE
fix(verify): always probe portal host mounts for git ancestry (BI-1D55A2AD)

### DIFF
--- a/apps/web/lib/verify/git-ancestry.test.ts
+++ b/apps/web/lib/verify/git-ancestry.test.ts
@@ -64,13 +64,13 @@ describe("ancestryFailureDetail", () => {
 });
 
 describe("gitRepoRootCandidates", () => {
-  it("prefers DPF_REPO_ROOT then cwd", () => {
+  it("prefers DPF_REPO_ROOT then well-known portal mounts then cwd (BI-1D55A2AD)", () => {
     expect(
       gitRepoRootCandidates(
         { DPF_REPO_ROOT: "/clone", DPF_GIT_WORK_TREE: "/clone" } as unknown as NodeJS.ProcessEnv,
         "/cwd",
       ),
-    ).toEqual(["/clone", "/cwd"]);
+    ).toEqual(["/clone", "/host-dpf", "/host-source", "/workspace", "/cwd"]);
   });
 
   it("derives work tree from GIT_DIR ending in .git", () => {
@@ -79,7 +79,17 @@ describe("gitRepoRootCandidates", () => {
         { GIT_DIR: "/clone/.git" } as unknown as NodeJS.ProcessEnv,
         "/cwd",
       ),
-    ).toEqual(["/clone", "/cwd"]);
+    ).toEqual(["/clone", "/host-dpf", "/host-source", "/workspace", "/cwd"]);
+  });
+
+  it("includes PROJECT_ROOT and does not depend on cwd being the repo", () => {
+    const roots = gitRepoRootCandidates(
+      { PROJECT_ROOT: "/app-project" } as unknown as NodeJS.ProcessEnv,
+      "/app",
+    );
+    expect(roots[0]).toBe("/app-project");
+    expect(roots).toContain("/host-dpf");
+    expect(roots).toContain("/app");
   });
 });
 

--- a/apps/web/lib/verify/git-ancestry.ts
+++ b/apps/web/lib/verify/git-ancestry.ts
@@ -98,6 +98,17 @@ export function ancestryFailureDetail(kind: AncestryFailureKind): string {
  * Candidate directories to run git ancestry in. Pure over env + cwd so tests
  * can inject without mutating process.env.
  */
+/**
+ * Well-known in-container / install mounts that often hold the DPF clone even
+ * when DPF_REPO_ROOT was never exported into the portal process (BI-1D55A2AD).
+ * Order is least→most specific so env still wins via push-first.
+ */
+export const WELL_KNOWN_PORTAL_REPO_ROOTS = Object.freeze([
+  "/host-dpf", // docker-compose host install bind (DPF_HOST_INSTALL_PATH)
+  "/host-source", // promoter / self-upgrade host source mount
+  "/workspace", // dpf-source-code volume used by some portal images
+]);
+
 export function gitRepoRootCandidates(
   env: NodeJS.ProcessEnv = process.env,
   cwd: string = process.cwd(),
@@ -109,12 +120,19 @@ export function gitRepoRootCandidates(
   };
   push(env.DPF_REPO_ROOT);
   push(env.DPF_GIT_WORK_TREE);
+  push(env.PROJECT_ROOT);
   // GIT_DIR is a .git path — use its parent as work tree when it ends with .git
   const gitDir = (env.GIT_DIR ?? "").trim();
   if (gitDir.endsWith("/.git") || gitDir.endsWith("\\.git")) {
     push(gitDir.slice(0, -5));
   } else {
     push(gitDir || undefined);
+  }
+  // Portal containers often do not have process.cwd() === the Git work tree
+  // (Next runs under /app). Always try the compose-standard host mounts so a
+  // normal local install can compute ancestry without ad-hoc discovery.
+  for (const wellKnown of WELL_KNOWN_PORTAL_REPO_ROOTS) {
+    push(wellKnown);
   }
   push(cwd);
   return roots;


### PR DESCRIPTION
## Summary
- Expand `gitRepoRootCandidates` with well-known portal mounts (`/host-dpf`, `/host-source`, `/workspace`) and `PROJECT_ROOT`.
- MCP live-readiness preflight no longer requires `process.cwd()` to be the Git work tree (BI-1D55A2AD).

## Test plan
- [x] vitest `lib/verify/git-ancestry.test.ts` → 15 passed

Process-Spine-Decision: pure candidate expansion + unit tests for shipped preflight helper.
Design-Grounding-Decision: grounded in docker-compose `/host-dpf` mount + #3144/#3173 ancestry path.
Local-CI-Override: vitest 15/15 on worktree.