### PR TITLE
feat(nonprod): accept antigravity as ownerProvider (BI-FA5F49C6)

### DIFF
--- a/apps/web/lib/mcp-tools-nonprod-environments.test.ts
+++ b/apps/web/lib/mcp-tools-nonprod-environments.test.ts
@@ -18,7 +18,11 @@ vi.mock("@/lib/kernel/load-enforceable-principles", () => ({
   loadEnforceablePrinciples: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("@/lib/nonprod/environment-lease", () => ({
+vi.mock("@/lib/nonprod/environment-lease", async (importOriginal) => ({
+  // Spread the real module so non-mocked exports (e.g. NONPROD_OWNER_PROVIDERS,
+  // now read by claimNonprodEnvironmentLeaseHandler) remain defined; override
+  // only the DB-touching functions with mocks.
+  ...(await importOriginal<typeof import("@/lib/nonprod/environment-lease")>()),
   listActiveNonprodEnvironmentLeases: mockListActiveNonprodEnvironmentLeases,
   claimNonprodEnvironmentLease: mockClaimNonprodEnvironmentLease,
   releaseNonprodEnvironmentLease: mockReleaseNonprodEnvironmentLease,

--- a/apps/web/lib/mcp/packs/nonprod-lease-pack.ts
+++ b/apps/web/lib/mcp/packs/nonprod-lease-pack.ts
@@ -43,7 +43,10 @@ const definitions: ToolDefinition[] = [
       type: "object",
       properties: {
         environmentKey: { type: "string", enum: ["active-candidate", "local-integration-ci"] },
-        ownerProvider: { type: "string", enum: ["build-studio", "claude", "codex", "grok", "coworker"] },
+        ownerProvider: {
+          type: "string",
+          enum: ["build-studio", "claude", "codex", "grok", "antigravity", "coworker"],
+        },
         ownerSessionId: { type: "string" },
         purpose: { type: "string" },
         url: { type: "string" },
@@ -139,7 +142,8 @@ async function claimNonprodEnvironmentLeaseHandler(params: Record<string, unknow
   if (!["active-candidate", "local-integration-ci"].includes(environmentKey)) {
     return { success: false, error: "invalid_environment_key", message: `Unsupported environmentKey: ${environmentKey}` };
   }
-  if (!["build-studio", "claude", "codex", "coworker"].includes(ownerProvider)) {
+  const { NONPROD_OWNER_PROVIDERS } = await import("@/lib/nonprod/environment-lease");
+  if (!(NONPROD_OWNER_PROVIDERS as readonly string[]).includes(ownerProvider)) {
     return { success: false, error: "invalid_owner_provider", message: `Unsupported ownerProvider: ${ownerProvider}` };
   }
   const expiresAt = new Date(expiresAtText);
@@ -149,7 +153,7 @@ async function claimNonprodEnvironmentLeaseHandler(params: Record<string, unknow
 
   const result = await claimNonprodEnvironmentLease({
     environmentKey: environmentKey as "active-candidate" | "local-integration-ci",
-    ownerProvider: ownerProvider as "build-studio" | "claude" | "codex" | "coworker",
+    ownerProvider: ownerProvider as (typeof NONPROD_OWNER_PROVIDERS)[number],
     ownerSessionId,
     purpose,
     url,

--- a/apps/web/lib/nonprod/environment-lease.test.ts
+++ b/apps/web/lib/nonprod/environment-lease.test.ts
@@ -8,6 +8,7 @@ import {
   reapExpiredNonprodEnvironmentLeases,
   MAX_LEASE_TTL_MS,
   DEFAULT_LEASE_TTL_MS,
+  NONPROD_OWNER_PROVIDERS,
 } from "./environment-lease";
 
 function db() {
@@ -23,6 +24,15 @@ function db() {
   };
 }
 
+describe("NONPROD_OWNER_PROVIDERS", () => {
+  it("includes antigravity alongside the peer host-worktree surfaces (BI-FA5F49C6)", () => {
+    expect(NONPROD_OWNER_PROVIDERS).toEqual(
+      expect.arrayContaining(["build-studio", "claude", "codex", "grok", "antigravity", "coworker"]),
+    );
+    expect(NONPROD_OWNER_PROVIDERS).toHaveLength(6);
+  });
+});
+
 describe("non-production environment leases", () => {
   it("lists active, unexpired leases", async () => {
     const mockDb = db();
@@ -37,6 +47,25 @@ describe("non-production environment leases", () => {
         expiresAt: { gt: new Date("2026-05-26T17:00:00.000Z") },
       },
       orderBy: { createdAt: "desc" },
+    });
+  });
+
+  it("claims an available environment for antigravity as ownerProvider", async () => {
+    const mockDb = db();
+    const result = await claimNonprodEnvironmentLease({
+      db: mockDb as never,
+      environmentKey: "active-candidate",
+      ownerProvider: "antigravity",
+      ownerSessionId: "session-agy-1",
+      purpose: "UX verification",
+      url: "http://127.0.0.1:3001",
+      ports: [3001],
+      expiresAt: new Date("2026-05-26T17:15:00.000Z"),
+      now: new Date("2026-05-26T17:00:00.000Z"),
+    });
+    expect(result.status).toBe("claimed");
+    expect(mockDb.nonProductionEnvironmentLease.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ ownerProvider: "antigravity" }),
     });
   });
 

--- a/apps/web/lib/nonprod/environment-lease.ts
+++ b/apps/web/lib/nonprod/environment-lease.ts
@@ -2,7 +2,23 @@ import { randomUUID } from "node:crypto";
 import { prisma } from "@dpf/db";
 
 export type NonprodEnvironmentKey = "active-candidate" | "local-integration-ci";
-export type NonprodOwnerProvider = "build-studio" | "claude" | "codex" | "coworker";
+/** Host-worktree coding surfaces + BS/coworker that may claim a shared nonprod lease. */
+export type NonprodOwnerProvider =
+  | "build-studio"
+  | "claude"
+  | "codex"
+  | "grok"
+  | "antigravity"
+  | "coworker";
+
+export const NONPROD_OWNER_PROVIDERS: readonly NonprodOwnerProvider[] = [
+  "build-studio",
+  "claude",
+  "codex",
+  "grok",
+  "antigravity",
+  "coworker",
+] as const;
 
 type LeaseDb = Pick<typeof prisma, "nonProductionEnvironmentLease">;
 

--- a/apps/web/lib/nonprod/local-integration.ts
+++ b/apps/web/lib/nonprod/local-integration.ts
@@ -3,7 +3,7 @@ import { recordExternalEvidence } from "@/lib/actions/external-evidence";
 
 export type LocalIntegrationResultInput = {
   actorUserId: string;
-  provider: "build-studio" | "claude" | "codex" | "coworker";
+  provider: "build-studio" | "claude" | "codex" | "grok" | "antigravity" | "coworker";
   externalSessionId: string;
   routeContext: string;
   buildId?: string;


### PR DESCRIPTION
## Summary
- Add `antigravity` (and `grok`) to `NonprodOwnerProvider` / claim allowlist / MCP lease enum.
- Unit tests cover the closed set and a successful antigravity claim (BI-FA5F49C6).

## Test plan
- [x] vitest `lib/nonprod/environment-lease.test.ts` → 16 passed

Process-Spine-Decision: enum + allowlist alignment with unit tests.
Design-Grounding-Decision: grounded in EP-ANTIGRAVITY-001 peer surface + nonprod lease pack.
Local-CI-Override: vitest 16/16 on worktree.