### PR TITLE
doc(agents): clarify channel adapter unsupported capability rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Tool-specific files (`CLAUDE.md`, `.cursor/rules/`, `.clinerules/`, `.github/cop
 - **Skills** live in `skills/<category>/<name>.skill.md`, seeded to `SkillDefinition` + `SkillAssignment`. Belong to coworkers, not routes.
 - **Portal archetype.** `StorefrontConfig.archetypeId` is the single source of truth for portal industry. `Organization.industry` and `BusinessContext.industry` are derived. Vocabulary resolution: `resolveVocabularyKey({ archetypeCategory, industry })` — archetype wins.
 - **Portal routes.** Internal management lives at `/storefront`. `/portal` is reserved for external/customer experience. `/admin/storefront`, `/admin/business-context`, `/admin/operating-hours` are legacy redirects.
+- **Channel adapter capabilities (BI-IMP-27126FA9).** When an operation is contractually defined on a channel adapter interface but operationally unsupported by a specific provider, the adapter must explicitly signal support status using capability flags rather than silent failure. Unimplemented methods must throw a typed error or return a structured unsupported response (e.g., throwing an `IntegrationApiError` with status code `UNSUPPORTED_OPERATION` or returning a `supported: false` status) to allow the caller to degrade gracefully. For example, a marketing channel adapter that contractually implements engagement tracking but lacks underlying API support on a specific provider must advertise this via its capability registration.
 
 ## 3. Strongly-Typed String Enums (mandatory)
 


### PR DESCRIPTION
## Summary

This change adds a channel adapter capability guidelines section under Section 2 (Project Architecture) of `AGENTS.md` to resolve the automated-detection documentation gap described in `BI-IMP-27126FA9`.

## Changes

- Updated `AGENTS.md` under section 2 to include a new **Channel adapter capabilities (BI-IMP-27126FA9)** guideline detailing how adapters must signal support status using capability flags or return structured unsupported responses rather than silent failure or raw crash.

## Test plan

- [x] **Source-only change** (types, isolated unit logic, doc, schema-only)
  - [x] `pnpm typecheck` (worktree OK)
  - [x] Targeted unit tests (worktree OK; name the file(s) run) - None required for doc only.

### Verification evidence

- MCP evidence recorded under `WC-0DD9DDDB` using `record_external_development_evidence` tool:
  - Provider: `antigravity`
  - Backlog Item: `BI-IMP-27126FA9`
  - Branch: `feat/BI-IMP-27126FA9-adapter-capabilities`
  - Worktree Path: `/Users/markbodman/dpf-worktrees/BI-IMP-27126FA9`
  - Commits: `77724dc64317eacaf1a0f9eaa2a3f95f7a3eb03c`
  - Evidence Record ID: `cmrpg7slg01lc01pkk32ddn1i`

## Related issues / Epic

Closes `BI-IMP-27126FA9`

## Epic / Backlog linkage (for multi-BI work)

N/A

## Overlap sweep

```
3225	doc(agents): add metadata governance guidelines under section 11	feat/BI-IMP-FA900452-metadata-governance	OPEN	2026-07-17T21:23:05Z
3224	feat(coworkers): planner-driven capability broker (EP-E431FC8A Phase 3, BI-FB0A5C82)	feat/ep-e431-phase3	OPEN	2026-07-17T21:15:24Z
3223	feat(nonprod): accept antigravity as ownerProvider (BI-FA5F49C6)	fix/antigravity-owner-provider	OPEN	2026-07-17T21:13:10Z
3222	fix(verify): always probe portal host mounts for git ancestry (BI-1D55A2AD)	fix/portal-preflight-repo-root	OPEN	2026-07-17T21:13:08Z
3220	fix(security): clear two CodeQL high alerts (TOCTOU + incomplete sanitization)	claude/security-issues-1e9b49	OPEN	2026-07-17T21:06:49Z
```

## Notes for the reviewer

Trivial doc-only update to satisfy `BI-IMP-27126FA9`.
