### PR TITLE
fix(build): auto-resolve the decompose gate on resume too (BI-C4F828B7 follow-up)

### DIFF
--- a/apps/web/lib/integrate/resume-pre-build-phase.test.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.test.ts
@@ -9,10 +9,13 @@ const executeToolMock = vi.fn();
 const txFindUniqueMock = vi.fn();
 const txUpdateMock = vi.fn();
 const txActivityCreateMock = vi.fn();
+const platformDevConfigFindUniqueMock = vi.fn();
+const autoResolveDecomposeMock = vi.fn();
 
 vi.mock("@dpf/db", () => ({
   prisma: {
     featureBuild: { findUnique: (...args: unknown[]) => findUniqueMock(...args) },
+    platformDevConfig: { findUnique: (...args: unknown[]) => platformDevConfigFindUniqueMock(...args) },
     // abandonStrandedPreBuild wraps its work in a $transaction; run the callback
     // immediately with a tx exposing the row re-check + mutation methods.
     $transaction: (fn: (tx: unknown) => unknown) =>
@@ -24,6 +27,9 @@ vi.mock("@dpf/db", () => ({
         buildActivity: { create: (...args: unknown[]) => txActivityCreateMock(...args) },
       }),
   },
+}));
+vi.mock("@/lib/build/auto-resolve-decompose-gate", () => ({
+  autoResolveDecomposeRequiredGate: (...args: unknown[]) => autoResolveDecomposeMock(...args),
 }));
 vi.mock("@/lib/build-review-verification-trigger", () => ({
   queueBuildReviewVerification: (...args: unknown[]) => queueBuildReviewVerificationMock(...args),
@@ -54,6 +60,10 @@ describe("resumePreBuildPhase (BI-9257CF19)", () => {
     dispatchDesignFixMock.mockReset().mockResolvedValue({ kind: "repaired", rounds: 1 });
     dispatchPlanMock.mockReset().mockResolvedValue({ kind: "dispatched-success" });
     executeToolMock.mockReset().mockResolvedValue({ success: true, message: "Plan review: pass." });
+    // Default to a non-governed install so the existing park-guard tests exercise
+    // the operator-driven behavior; governed autopilot tests override this.
+    platformDevConfigFindUniqueMock.mockReset().mockResolvedValue({ governedBacklogEnabled: false });
+    autoResolveDecomposeMock.mockReset().mockResolvedValue({ action: "park" });
   });
 
   it("re-queues review verification for a stranded review-phase build", async () => {
@@ -158,6 +168,62 @@ describe("resumePreBuildPhase (BI-9257CF19)", () => {
     expect(dispatchDesignFixMock).not.toHaveBeenCalled();
     expect(out.kind).toBe("skipped");
     expect((out as { reason: string }).reason).toContain("candidates already exist");
+  });
+
+  // ── Governed-backlog autopilot (BI-C4F828B7) ─────────────────────────────
+  // On a governed install an auto-promoted parked build is resolved
+  // autonomously here (the reviewDesignDoc gate never sees an ALREADY-parked
+  // build — it is short-circuited on every resume), instead of parking forever.
+  it("auto-decomposes a parked governed-autopilot build instead of parking it", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { problemStatement: "p" },
+      buildPlan: null,
+      designReview: {
+        decision: "pass",
+        sizeAssessment: { decision: "decompose-required" },
+        decompositionCandidates: { latest: [{ candidateId: "candidate-1", childScopes: [] }] },
+      },
+      originatingBacklogItemId: "bi-1",
+      parentEpicId: null,
+    });
+    platformDevConfigFindUniqueMock.mockResolvedValue({ governedBacklogEnabled: true });
+    autoResolveDecomposeMock.mockResolvedValue({
+      action: "decomposed",
+      epicId: "EP-XYZ",
+      childBuildIds: ["FB-C1", "FB-C2"],
+      candidateId: "candidate-1",
+    });
+    const out = await resumePreBuildPhase({ buildId: "FB-AP", phase: "ideate", userId: "uAP" });
+
+    expect(autoResolveDecomposeMock).toHaveBeenCalledOnce();
+    // Did NOT fall back to the propose-and-park path.
+    expect(executeToolMock).not.toHaveBeenCalled();
+    expect(dispatchIdeateMock).not.toHaveBeenCalled();
+    expect(out).toMatchObject({ kind: "resumed", via: "autoResolveDecomposeRequiredGate" });
+  });
+
+  it("advances a parked governed-autopilot build after an auto-override (re-runs review, does not park)", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { problemStatement: "p" },
+      buildPlan: null,
+      designReview: {
+        decision: "pass",
+        sizeAssessment: { decision: "decompose-required" },
+      },
+      originatingBacklogItemId: "bi-1",
+      parentEpicId: null,
+    });
+    platformDevConfigFindUniqueMock.mockResolvedValue({ governedBacklogEnabled: true });
+    autoResolveDecomposeMock.mockResolvedValue({
+      action: "overridden",
+      rationale: "no candidates",
+      reason: "no-candidates",
+    });
+    const out = await resumePreBuildPhase({ buildId: "FB-AO", phase: "ideate", userId: "uAO" });
+
+    // Override recorded → falls through to re-run reviewDesignDoc so it advances.
+    expect(executeToolMock).toHaveBeenCalledWith("reviewDesignDoc", { buildId: "FB-AO" }, "uAO", { featureBuildId: "FB-AO" });
+    expect(out).toMatchObject({ kind: "resumed", via: "executeTool:reviewDesignDoc" });
   });
 
   it("does NOT park a decompose-required build once an operator override is recorded — re-runs review so it can advance", async () => {

--- a/apps/web/lib/integrate/resume-pre-build-phase.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.ts
@@ -238,7 +238,15 @@ export async function resumePreBuildPhase(params: {
 
     const build = await prisma.featureBuild.findUnique({
       where: { buildId },
-      select: { designDoc: true, buildPlan: true, planReview: true, designReview: true, plan: true },
+      select: {
+        designDoc: true,
+        buildPlan: true,
+        planReview: true,
+        designReview: true,
+        plan: true,
+        originatingBacklogItemId: true,
+        parentEpicId: true,
+      },
     });
     if (!build) {
       return { kind: "failed", phase, error: "build not found" };
@@ -262,37 +270,87 @@ export async function resumePreBuildPhase(params: {
       // blocker is a pending human decision.
       const designReviewForGate = build.designReview as DesignReviewForGate;
       if (isParkedAtDecomposeGate(designReviewForGate)) {
-        if (hasDecompositionCandidates(designReviewForGate)) {
+        // Governed-backlog autopilot (BI-C4F828B7): rather than park an
+        // auto-promoted build here forever (nobody clicks approve on an
+        // unattended install → the daily tee-up keeps minting more), resolve
+        // the gate autonomously — the same path reviewDesignDoc now takes. This
+        // is what actually drains the parked-ideate backlog: the reviewDesignDoc
+        // gate only fires for builds flowing through review, but a build that is
+        // ALREADY parked is short-circuited here on every resume and never
+        // reaches that gate. Operator-driven / non-governed builds fall through
+        // to the original propose-once-and-park behavior below.
+        let overriddenMonolithic = false;
+        const governedConfig = await prisma.platformDevConfig.findUnique({
+          where: { id: "singleton" },
+          select: { governedBacklogEnabled: true },
+        });
+        if (
+          governedConfig?.governedBacklogEnabled === true &&
+          build.originatingBacklogItemId != null
+        ) {
+          const { autoResolveDecomposeRequiredGate } = await import(
+            "@/lib/build/auto-resolve-decompose-gate"
+          );
+          const auto = await autoResolveDecomposeRequiredGate({
+            build: {
+              buildId,
+              parentEpicId: build.parentEpicId ?? null,
+              originatingBacklogItemId: build.originatingBacklogItemId ?? null,
+              designReview: build.designReview,
+            },
+            userId,
+            governedBacklogEnabled: true,
+          });
+          if (auto.action === "decomposed") {
+            return {
+              kind: "resumed",
+              phase,
+              via: "autoResolveDecomposeRequiredGate",
+              detail: `auto-decomposed into ${auto.childBuildIds.length} child build(s) under Epic ${auto.epicId}`,
+            };
+          }
+          if (auto.action === "overridden") {
+            // Monolithic override recorded — the gate no longer blocks. Fall
+            // through to the normal review re-run below, which now advances
+            // ideate -> plan.
+            overriddenMonolithic = true;
+          }
+        }
+        if (overriddenMonolithic) {
+          // Skip the park block; continue to the design-doc / review-rerun path.
+        } else if (hasDecompositionCandidates(designReviewForGate)) {
           return {
             kind: "skipped",
             phase,
             reason:
               "design passed review but size=decompose-required and candidates already exist — parked awaiting approve_decomposition or record_decomposition_override (NOT re-dispatching ideate or re-running review).",
           };
+        } else {
+          // No candidates yet: generate them ONCE so the operator has something
+          // to approve. This is the productive alternative to re-ideating — it
+          // never throws (propose_build_decomposition returns a structured
+          // ToolResult) and is self-idempotent (the branch above short-circuits
+          // next time).
+          const { executeTool } = await import("@/lib/mcp-tools");
+          const result = await executeTool(
+            "propose_build_decomposition",
+            { buildId },
+            userId,
+            { featureBuildId: buildId },
+          );
+          const detail = result.success
+            ? `proposed decomposition candidates for operator approval (${
+                typeof result.message === "string" ? result.message.slice(0, 120) : "ok"
+              })`
+            : `propose_build_decomposition produced no candidates (${String(
+                result.error ?? result.message ?? "unknown",
+              ).slice(0, 120)}) — left parked for operator`;
+          return {
+            kind: "skipped",
+            phase,
+            reason: `design passed review but size=decompose-required — ${detail}; parked awaiting approve_decomposition or override (NOT re-dispatching ideate).`,
+          };
         }
-        // No candidates yet: generate them ONCE so the operator has something to
-        // approve. This is the productive alternative to re-ideating — it never
-        // throws (propose_build_decomposition returns a structured ToolResult)
-        // and is self-idempotent (the branch above short-circuits next time).
-        const { executeTool } = await import("@/lib/mcp-tools");
-        const result = await executeTool(
-          "propose_build_decomposition",
-          { buildId },
-          userId,
-          { featureBuildId: buildId },
-        );
-        const detail = result.success
-          ? `proposed decomposition candidates for operator approval (${
-              typeof result.message === "string" ? result.message.slice(0, 120) : "ok"
-            })`
-          : `propose_build_decomposition produced no candidates (${String(
-              result.error ?? result.message ?? "unknown",
-            ).slice(0, 120)}) — left parked for operator`;
-        return {
-          kind: "skipped",
-          phase,
-          reason: `design passed review but size=decompose-required — ${detail}; parked awaiting approve_decomposition or override (NOT re-dispatching ideate).`,
-        };
       }
 
       if (!hasDesignDoc(build.designDoc)) {

--- a/docs/superpowers/plans/2026-07-17-autopilot-decompose-gate-auto-resolve.md
+++ b/docs/superpowers/plans/2026-07-17-autopilot-decompose-gate-auto-resolve.md
@@ -77,6 +77,30 @@ build select):
 - `overridden` → the monolithic override is recorded in the DB; fall through to
   the normal phase-advance logic.
 
+### Wiring — the second gate (follow-up, same BI)
+
+The `reviewDesignDoc` gate only fires for builds *flowing through* review. A build
+that is **already parked** at `decompose-required` is short-circuited earlier, on
+every resume tick, by a **second, independent gate**: `isParkedAtDecomposeGate` in
+`apps/web/lib/integrate/resume-pre-build-phase.ts` (BI-BD4F2D0D — added to stop an
+earlier resume↔gate loop). It refuses to re-dispatch ideate / re-run review and
+just proposes candidates once, then parks — so the auto-resolve in `reviewDesignDoc`
+is **never reached** for the existing backlog of parked builds.
+
+Live evidence (founder install, post-deploy): 23 builds still parked, `auto-decompose`
+fired 0 times, and `resumeStrandedBuildsOnBoot` logged "skipped … parked awaiting
+approve" ~938× in 3h. So the same auto-resolve is wired into this second gate:
+
+- On the `isParkedAtDecomposeGate` branch, for a governed + backlog-originated build,
+  call `autoResolveDecomposeRequiredGate` (same orchestrator).
+- `decomposed` → return `resumed` (parent superseded; children dispatched).
+- `overridden` → fall through to the normal review re-run (now advances past the gate).
+- `park` / not-eligible → the original propose-once-and-park behavior is preserved
+  for operator-driven / non-governed installs.
+
+This is what actually drains the existing parked-ideate backlog and closes the loop
+for any build resumed after a restart.
+
 ## Why not the alternatives
 
 - **Backpressure / human-queue** (park but bounded, or route to a decision


### PR DESCRIPTION
## Why this follow-up exists

PR #3201 wired autopilot auto-decompose into the **`reviewDesignDoc`** gate. After it merged and deployed, the loop **did not actually break** on the founder install:

- Still **23 builds parked** in `ideate`, `auto-decompose` fired **0 times**.
- `resumeStrandedBuildsOnBoot` logged *"skipped — size=decompose-required … parked awaiting approve"* **~938× in 3h**.

**Root cause:** a **second, independent decompose gate** — `isParkedAtDecomposeGate` in [`resume-pre-build-phase.ts`](apps/web/lib/integrate/resume-pre-build-phase.ts) (BI-BD4F2D0D, added to stop an earlier resume↔gate loop) — short-circuits an **already-parked** build on every resume tick, *before* it can reach the `reviewDesignDoc` gate. So PR #3201 only helped builds *flowing through* review — never the existing parked backlog, nor any build resumed after a restart.

## Fix

Wire the same orchestrator (`autoResolveDecomposeRequiredGate`, shipped in #3201) into that second gate. For a **governed + backlog-originated** parked build:

- `decomposed` → return `resumed` (parent superseded into the Epic; children dispatched to `plan`).
- `overridden` → fall through to the normal review re-run, which now advances `ideate → plan`.
- `park` / non-governed / operator-driven → **preserve** the original propose-candidates-once-and-park behavior unchanged.

This is what actually drains the existing parked-ideate backlog and closes the loop for any build resumed after a restart.

## Verification
- **2 new resume tests** (auto-decompose path + auto-override fall-through) + existing park-guard tests pass — **25 resume + 8 orchestrator = 33**.
- Full-workspace `pnpm typecheck` (heap-raised, as CI) — clean.
- Module-size check OK (no bump needed).
- Plan doc [2026-07-17-autopilot-decompose-gate-auto-resolve.md](docs/superpowers/plans/2026-07-17-autopilot-decompose-gate-auto-resolve.md) updated with the second-gate section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)