### PR TITLE
feat(ui): async activity primitives + adopt on Self-Upgrade summary

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -123,3 +123,38 @@ body {
   0%, 100% { opacity: 1; box-shadow: 0 0 0 0 color-mix(in srgb, var(--dpf-accent) 50%, transparent); }
   55%       { opacity: 0.65; box-shadow: 0 0 0 3px color-mix(in srgb, var(--dpf-accent) 0%, transparent); }
 }
+
+/* ── Async activity & loading primitives ──────────────────────────────────
+   Canonical motion for the shared ui/Spinner + ui/Skeleton primitives. Every
+   asynchronous action gets a visible, consistent activity indicator; never
+   hand-roll animate-spin / animate-pulse. See docs/platform-usability-standards.md
+   ("Async Activity & Loading States"). Colors resolve through --dpf-* tokens. */
+@keyframes dpf-spin {
+  to { transform: rotate(360deg); }
+}
+.dpf-spin { animation: dpf-spin 0.7s linear infinite; }
+
+/* Skeleton shimmer — a sweep across a token-tinted gradient. The element sets
+   the gradient + background-size (see ui/Skeleton.tsx); this only animates the
+   sweep position. */
+@keyframes dpf-shimmer {
+  from { background-position: 200% 0; }
+  to   { background-position: -200% 0; }
+}
+.dpf-shimmer { animation: dpf-shimmer 1.6s ease-in-out infinite; }
+
+/* Reduced-motion: honor the OS "Reduce Motion" preference platform-wide. The
+   codebase previously had no global guard, so every keyframe animation ran
+   regardless (spinners, shimmer, slide-up, cell-pulse, per-component keyframes).
+   Neutralize all animation while leaving transitions/hovers intact; loading
+   primitives fall back to a static, still-legible resting state. */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+  .dpf-shimmer {
+    /* Freeze as a flat muted fill rather than a half-swept gradient. */
+    background: var(--dpf-surface-3) !important;
+  }
+}

--- a/apps/web/components/ops/UpgradeImpactPanel.test.tsx
+++ b/apps/web/components/ops/UpgradeImpactPanel.test.tsx
@@ -154,3 +154,40 @@ describe("UpgradeImpactPanel — auto-generate on first view (BI-4A400DE4)", () 
     expect(container.firstChild).toBeNull();
   });
 });
+
+describe("UpgradeImpactPanel — activity indication", () => {
+  const top = [item("sha1", "Top change one"), item("sha2", "Top change two")];
+  const all = [...top, item("sha3", "Tail change three")];
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("shows an inline busy label and a panel skeleton while auto-generating on first view", async () => {
+    // No initialSummary → the panel auto-fetches on mount (BI-4A400DE4). A
+    // never-resolving fetch keeps the useTransition pending so the loading UI
+    // stays on screen — no click needed, the activity shows behind the fetch.
+    vi.stubGlobal("fetch", vi.fn(() => new Promise<Response>(() => {})));
+    render(<UpgradeImpactPanel enabled />);
+
+    // Trigger shows the inline busy affordance (spinner + live label)...
+    expect(await screen.findByText("Summarizing…")).toBeTruthy();
+    // ...and the panel renders a shape-of-content skeleton in a busy region.
+    const loading = document.querySelector('[data-summary-state="loading"]');
+    expect(loading).toBeTruthy();
+    expect(loading?.closest('[aria-busy="true"]')).toBeTruthy();
+  });
+
+  it("keeps the existing summary visible and marked busy while refreshing", async () => {
+    // With a cached summary there is no auto-fetch; the Refresh button drives it.
+    vi.stubGlobal("fetch", vi.fn(() => new Promise<Response>(() => {})));
+    render(<UpgradeImpactPanel enabled initialSummary={summaryWith(top, all)} />);
+
+    fireEvent.click(screen.getByText("Refresh"));
+
+    expect(await screen.findByText("Summarizing…")).toBeTruthy();
+    // No skeleton swap — prior content stays put, just dimmed and marked busy.
+    expect(document.querySelector('[data-summary-state="loading"]')).toBeNull();
+    expect(screen.getAllByText("Top change one")).toHaveLength(1);
+    const okRegion = document.querySelector('[data-summary-state="ok"]');
+    expect(okRegion?.getAttribute("aria-busy")).toBe("true");
+  });
+});

--- a/apps/web/components/ops/UpgradeImpactPanel.tsx
+++ b/apps/web/components/ops/UpgradeImpactPanel.tsx
@@ -18,6 +18,8 @@ import type { SummaryResult, ImpactItem } from "@/lib/self-upgrade/impact/types"
 import { formatImpactCounts } from "@/lib/self-upgrade/impact/format";
 import { CollapsibleList } from "@/components/ui/report-kit";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { InlineBusy } from "@/components/ui/InlineBusy";
+import { Skeleton } from "@/components/ui/Skeleton";
 
 const CATEGORY_LABEL: Record<ImpactItem["category"], string> = {
   breaking: "Breaking",
@@ -77,6 +79,34 @@ function ItemRow({
         </div>
       )}
     </li>
+  );
+}
+
+// Shape-of-content placeholder shown while the summary generates (on the
+// auto-fetch on first view, or a manual (re)summarize). Mirrors the OK-result
+// layout below (headline line, counts line, item rows) so the panel resolves in
+// place instead of popping. Decorative — the wrapping region carries aria-busy
+// and the live announcement.
+function SummarySkeleton() {
+  return (
+    <div className="space-y-3" data-summary-state="loading">
+      <Skeleton width="85%" height="0.9rem" />
+      <Skeleton width="35%" height="0.7rem" />
+      <ul className="space-y-2">
+        {[0, 1].map((i) => (
+          <li
+            key={i}
+            className="py-2 px-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] space-y-1.5"
+          >
+            <div className="flex items-start gap-2">
+              <Skeleton width="2.5rem" height="1rem" rounded />
+              <Skeleton width={i === 0 ? "70%" : "55%"} />
+            </div>
+            <Skeleton width="45%" height="0.7rem" />
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 
@@ -200,7 +230,13 @@ export default function UpgradeImpactPanel({
             aria-busy={isPending}
             className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-accent)]/20 text-[var(--dpf-accent)] border border-[var(--dpf-accent)]/40 hover:bg-[var(--dpf-accent)]/30 transition-colors disabled:opacity-50"
           >
-            {isPending ? "Summarizing..." : result ? "Re-open summary" : "Summarize update"}
+            {isPending ? (
+              <InlineBusy label="Summarizing…" />
+            ) : result ? (
+              "Re-open summary"
+            ) : (
+              "Summarize update"
+            )}
           </button>
         </div>
       </div>
@@ -208,6 +244,16 @@ export default function UpgradeImpactPanel({
       {error && (
         <div className="text-xs text-[var(--dpf-destructive)] p-2 rounded bg-[var(--dpf-destructive)]/10">
           {error}
+        </div>
+      )}
+
+      {/* First-time generation (auto on first view, or a manual summarize): a
+          shape-of-content skeleton so the activity is visible and the panel
+          resolves in place. Refreshing an existing summary keeps the prior
+          content (dimmed) below instead. */}
+      {isPending && !result && (
+        <div aria-busy="true">
+          <SummarySkeleton />
         </div>
       )}
 
@@ -221,7 +267,11 @@ export default function UpgradeImpactPanel({
       )}
 
       {result?.ok && (
-        <div className="space-y-3" data-summary-state="ok">
+        <div
+          className={`space-y-3 ${isPending ? "opacity-60 transition-opacity" : ""}`}
+          data-summary-state="ok"
+          aria-busy={isPending || undefined}
+        >
           {result.summary.phrased?.headline && (
             <p className="text-sm text-[var(--dpf-text)]">
               {result.summary.phrased.headline}

--- a/apps/web/components/ui/InlineBusy.test.tsx
+++ b/apps/web/components/ui/InlineBusy.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { InlineBusy } from "./InlineBusy";
+
+describe("InlineBusy", () => {
+  it("announces the pending label in a single live status region", () => {
+    const html = renderToStaticMarkup(<InlineBusy label="Saving…" />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain("Saving…");
+    // Exactly one status region — the composed spinner must be presentational,
+    // not a second announced region.
+    expect(html.match(/role="status"/g)?.length).toBe(1);
+  });
+
+  it("includes a spinning (decorative) ring", () => {
+    const html = renderToStaticMarkup(<InlineBusy label="Working…" />);
+    expect(html).toContain("dpf-spin");
+    expect(html).toContain('aria-hidden="true"');
+  });
+});

--- a/apps/web/components/ui/InlineBusy.tsx
+++ b/apps/web/components/ui/InlineBusy.tsx
@@ -1,0 +1,34 @@
+// apps/web/components/ui/InlineBusy.tsx
+//
+// Canonical inline busy affordance: a small spinner + a visible text label, for
+// a button's or control's pending state. One call replaces the hand-rolled
+// "spin a glyph next to some text" idiom scattered across the portal. Server-
+// usable (no hooks, no "use client"). See docs/platform-usability-standards.md.
+//
+// Renders `role="status"` + `aria-live="polite"` so the pending text ("Saving…")
+// is announced; the spinner ring itself is decorative. Pair with `aria-busy` on
+// the enclosing button.
+
+import { Spinner, type SpinnerSize } from "./Spinner";
+
+export type InlineBusyProps = {
+  /** Visible pending text, e.g. "Summarizing…", "Saving…". */
+  label: string;
+  size?: SpinnerSize;
+  className?: string;
+};
+
+export function InlineBusy({ label, size = "xs", className = "" }: InlineBusyProps) {
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      className={["inline-flex items-center gap-1.5", className]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <Spinner size={size} presentational />
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/apps/web/components/ui/ProgressBar.test.tsx
+++ b/apps/web/components/ui/ProgressBar.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ProgressBar } from "./ProgressBar";
+
+describe("ProgressBar", () => {
+  it("exposes determinate progressbar semantics", () => {
+    const html = renderToStaticMarkup(<ProgressBar value={42} label="Uploading" />);
+    expect(html).toContain('role="progressbar"');
+    expect(html).toContain('aria-valuenow="42"');
+    expect(html).toContain('aria-valuemin="0"');
+    expect(html).toContain('aria-valuemax="100"');
+    expect(html).toContain('aria-label="Uploading"');
+    expect(html).toMatch(/width:42%/);
+  });
+
+  it("clamps out-of-range values", () => {
+    expect(renderToStaticMarkup(<ProgressBar value={150} />)).toContain(
+      'aria-valuenow="100"',
+    );
+    expect(renderToStaticMarkup(<ProgressBar value={-10} />)).toContain(
+      'aria-valuenow="0"',
+    );
+  });
+
+  it("omits aria-valuenow and shimmers when indeterminate", () => {
+    const html = renderToStaticMarkup(<ProgressBar indeterminate />);
+    expect(html).toContain('role="progressbar"');
+    expect(html).not.toContain("aria-valuenow");
+    expect(html).toContain("dpf-shimmer");
+  });
+
+  it("treats a missing value as indeterminate", () => {
+    const html = renderToStaticMarkup(<ProgressBar />);
+    expect(html).not.toContain("aria-valuenow");
+    expect(html).toContain("dpf-shimmer");
+  });
+
+  it("uses token colors, never raw hex", () => {
+    const html = renderToStaticMarkup(<ProgressBar value={50} />);
+    expect(html).toMatch(/var\(--dpf-accent\)/);
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+  });
+});

--- a/apps/web/components/ui/ProgressBar.tsx
+++ b/apps/web/components/ui/ProgressBar.tsx
@@ -1,0 +1,83 @@
+// apps/web/components/ui/ProgressBar.tsx
+//
+// Canonical determinate/indeterminate progress indicator. Server-usable (no
+// hooks, no "use client"). Use when total work is known and you can show how
+// far along it is (uploads, multi-step flows, builds). For an unknown-duration
+// action use ui/Spinner; for content loading into a known layout use
+// ui/Skeleton. See docs/platform-usability-standards.md.
+//
+// Exposes the proper `role="progressbar"` + `aria-valuenow/min/max` semantics
+// that hand-rolled track+fill divs across the codebase omit. Colors resolve
+// through --dpf-* tokens; the indeterminate sweep uses the `dpf-shimmer`
+// keyframe (stilled under `prefers-reduced-motion: reduce`).
+
+import type { CSSProperties } from "react";
+
+export type ProgressBarSize = "sm" | "md";
+
+export type ProgressBarProps = {
+  /** 0–100. Omit (or set `indeterminate`) when the total isn't known. */
+  value?: number;
+  /** Unknown-total mode: a shimmering full-width fill instead of a fixed width. */
+  indeterminate?: boolean;
+  /** Accessible label for the operation (e.g. "Uploading files"). */
+  label?: string;
+  size?: ProgressBarSize;
+  className?: string;
+};
+
+const TRACK_SIZE: Record<ProgressBarSize, string> = {
+  sm: "h-1.5",
+  md: "h-2.5",
+};
+
+const INDETERMINATE_FILL: CSSProperties = {
+  backgroundImage:
+    "linear-gradient(90deg, color-mix(in srgb, var(--dpf-accent) 30%, var(--dpf-surface-2)) 25%, var(--dpf-accent) 50%, color-mix(in srgb, var(--dpf-accent) 30%, var(--dpf-surface-2)) 75%)",
+  backgroundSize: "200% 100%",
+};
+
+export function ProgressBar({
+  value,
+  indeterminate = false,
+  label = "Progress",
+  size = "md",
+  className = "",
+}: ProgressBarProps) {
+  const clamped =
+    typeof value === "number" ? Math.min(100, Math.max(0, value)) : undefined;
+  const isIndeterminate = indeterminate || clamped === undefined;
+
+  return (
+    <div
+      role="progressbar"
+      aria-label={label}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={isIndeterminate ? undefined : clamped}
+      className={[
+        "w-full overflow-hidden rounded-full",
+        TRACK_SIZE[size],
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={{ backgroundColor: "var(--dpf-surface-2)" }}
+    >
+      <div
+        className={["h-full rounded-full", isIndeterminate ? "dpf-shimmer" : ""]
+          .filter(Boolean)
+          .join(" ")}
+        style={
+          isIndeterminate
+            ? { ...INDETERMINATE_FILL, width: "100%" }
+            : {
+                width: `${clamped}%`,
+                backgroundColor: "var(--dpf-accent)",
+                transition: "width 240ms ease-out",
+              }
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/components/ui/Skeleton.test.tsx
+++ b/apps/web/components/ui/Skeleton.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Skeleton, SkeletonText } from "./Skeleton";
+
+describe("Skeleton", () => {
+  it("renders a decorative shimmer block with a token gradient", () => {
+    const html = renderToStaticMarkup(<Skeleton width="50%" height="1rem" />);
+    expect(html).toContain("dpf-shimmer");
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toMatch(/var\(--dpf-surface-2\)/);
+    expect(html).toMatch(/var\(--dpf-surface-3\)/);
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+  });
+
+  it("applies numeric width/height as pixels", () => {
+    const html = renderToStaticMarkup(<Skeleton width={120} height={12} />);
+    expect(html).toMatch(/width:120px/);
+    expect(html).toMatch(/height:12px/);
+  });
+
+  it("renders a circle when asked", () => {
+    const html = renderToStaticMarkup(<Skeleton circle width={24} height={24} />);
+    expect(html).toContain("rounded-full");
+  });
+});
+
+describe("SkeletonText", () => {
+  it("renders the requested number of lines", () => {
+    const html = renderToStaticMarkup(<SkeletonText lines={4} />);
+    // 4 shimmer lines inside the aria-hidden wrapper.
+    expect(html.match(/dpf-shimmer/g)?.length).toBe(4);
+  });
+
+  it("shortens the last line for a paragraph tail", () => {
+    const html = renderToStaticMarkup(
+      <SkeletonText lines={2} lastLineWidth="40%" />,
+    );
+    expect(html).toMatch(/width:40%/);
+  });
+});

--- a/apps/web/components/ui/Skeleton.tsx
+++ b/apps/web/components/ui/Skeleton.tsx
@@ -1,0 +1,96 @@
+// apps/web/components/ui/Skeleton.tsx
+//
+// Canonical shape-of-content placeholder. Server-usable (no hooks, no
+// "use client"). Use while async data fills a KNOWN layout (panels, cards,
+// lists, tables) — skeletons give the best perceived performance for content
+// with a predictable shape. For a triggered action of unknown shape/duration,
+// prefer ui/Spinner instead. Never combine a skeleton with a spinner, and never
+// hand-roll `animate-pulse`. See docs/platform-usability-standards.md.
+//
+// The shimmer gradient + motion resolve through --dpf-* tokens and the
+// `dpf-shimmer` keyframe in globals.css, which freezes to a flat muted fill
+// under `prefers-reduced-motion: reduce`.
+//
+// A skeleton is decorative: the wrapping region should own the live
+// announcement (set `aria-busy="true"` on it). Every skeleton element is
+// `aria-hidden` so screen readers don't read placeholder noise.
+
+import type { CSSProperties } from "react";
+
+export type SkeletonProps = {
+  /** CSS width (e.g. "100%", "8rem", 120). Defaults to full width. */
+  width?: string | number;
+  /** CSS height (e.g. "1rem", 12). Defaults to a text-line height. */
+  height?: string | number;
+  /** Fully rounded (pill/circle). Overrides the default small radius. */
+  circle?: boolean;
+  rounded?: boolean;
+  className?: string;
+};
+
+// A token-tinted gradient the `dpf-shimmer` keyframe sweeps across.
+const SHIMMER_STYLE: CSSProperties = {
+  backgroundImage:
+    "linear-gradient(90deg, var(--dpf-surface-2) 25%, var(--dpf-surface-3) 37%, var(--dpf-surface-2) 63%)",
+  backgroundSize: "200% 100%",
+};
+
+function dim(value: string | number | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === "number" ? `${value}px` : value;
+}
+
+export function Skeleton({
+  width,
+  height,
+  circle = false,
+  rounded = true,
+  className = "",
+}: SkeletonProps) {
+  return (
+    <span
+      aria-hidden="true"
+      className={[
+        "dpf-shimmer block",
+        circle ? "rounded-full" : rounded ? "rounded" : "",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={{
+        ...SHIMMER_STYLE,
+        width: dim(width) ?? "100%",
+        height: dim(height) ?? "0.85rem",
+      }}
+    />
+  );
+}
+
+export type SkeletonTextProps = {
+  /** Number of shimmer lines to render. */
+  lines?: number;
+  /** Width of the final line (shorter reads as a paragraph tail). */
+  lastLineWidth?: string;
+  className?: string;
+};
+
+/** A stack of shimmer lines approximating a block of text. */
+export function SkeletonText({
+  lines = 3,
+  lastLineWidth = "60%",
+  className = "",
+}: SkeletonTextProps) {
+  return (
+    <span
+      aria-hidden="true"
+      className={["flex flex-col gap-2", className].filter(Boolean).join(" ")}
+    >
+      {Array.from({ length: Math.max(1, lines) }).map((_, i) => (
+        <Skeleton
+          key={i}
+          width={i === lines - 1 && lines > 1 ? lastLineWidth : "100%"}
+        />
+      ))}
+    </span>
+  );
+}

--- a/apps/web/components/ui/Spinner.test.tsx
+++ b/apps/web/components/ui/Spinner.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Spinner } from "./Spinner";
+
+describe("Spinner", () => {
+  it("renders an announced status region with a default label", () => {
+    const html = renderToStaticMarkup(<Spinner />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain("Loading…");
+    expect(html).toContain("sr-only");
+    expect(html).toContain("dpf-spin");
+  });
+
+  it("uses a custom label", () => {
+    const html = renderToStaticMarkup(<Spinner label="Summarizing…" />);
+    expect(html).toContain("Summarizing…");
+  });
+
+  it("is purely decorative when presentational (no status role, hidden ring)", () => {
+    const html = renderToStaticMarkup(<Spinner presentational />);
+    expect(html).not.toContain('role="status"');
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain("dpf-spin");
+  });
+
+  it("colors the ring from tokens, never raw hex", () => {
+    const html = renderToStaticMarkup(<Spinner size="lg" />);
+    expect(html).toMatch(/var\(--dpf-accent\)/);
+    expect(html).toMatch(/var\(--dpf-border\)/);
+    expect(html).not.toMatch(/#[0-9a-f]{3,6}/i);
+  });
+});

--- a/apps/web/components/ui/Spinner.tsx
+++ b/apps/web/components/ui/Spinner.tsx
@@ -1,0 +1,69 @@
+// apps/web/components/ui/Spinner.tsx
+//
+// Canonical indeterminate activity indicator. Server-usable (no hooks, no
+// "use client") so it can appear inside server- or client-rendered surfaces.
+//
+// Use for an operator-triggered action of unknown/short duration, or a section
+// whose layout isn't known yet. When async data fills a KNOWN layout, prefer
+// ui/Skeleton instead. Never hand-roll `animate-spin`. See
+// docs/platform-usability-standards.md ("Async Activity & Loading States").
+//
+// Colors resolve through --dpf-* tokens; motion via the `dpf-spin` keyframe in
+// globals.css, which is stilled under `prefers-reduced-motion: reduce`.
+
+import type { CSSProperties } from "react";
+
+export type SpinnerSize = "xs" | "sm" | "md" | "lg";
+
+export type SpinnerProps = {
+  size?: SpinnerSize;
+  /** Accessible label announced by screen readers. Ignored when `presentational`. */
+  label?: string;
+  /**
+   * When true, the spinner is purely decorative: no `role="status"`, no label —
+   * for use inside a region that already owns the announcement (e.g. a button
+   * with `aria-busy`, or ui/InlineBusy). Defaults to a standalone, announced spinner.
+   */
+  presentational?: boolean;
+  className?: string;
+};
+
+const SIZE_CLASS: Record<SpinnerSize, string> = {
+  xs: "h-3 w-3 border-2",
+  sm: "h-4 w-4 border-2",
+  md: "h-6 w-6 border-2",
+  lg: "h-8 w-8 border-[3px]",
+};
+
+// Track = subtle border; the leading edge picks up the accent so the ring reads
+// as spinning. Both are tokens — never raw hex (AGENTS.md §12).
+const RING_STYLE: CSSProperties = {
+  borderColor: "var(--dpf-border)",
+  borderTopColor: "var(--dpf-accent)",
+};
+
+export function Spinner({
+  size = "sm",
+  label = "Loading…",
+  presentational = false,
+  className = "",
+}: SpinnerProps) {
+  const ring = (
+    <span
+      aria-hidden="true"
+      className={["dpf-spin inline-block shrink-0 rounded-full", SIZE_CLASS[size], className]
+        .filter(Boolean)
+        .join(" ")}
+      style={RING_STYLE}
+    />
+  );
+
+  if (presentational) return ring;
+
+  return (
+    <span role="status" aria-live="polite" className="inline-flex items-center">
+      {ring}
+      <span className="sr-only">{label}</span>
+    </span>
+  );
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -4063,6 +4063,7 @@
         "prohibited-patterns",
         "allowed-hex-usage",
         "component-checklist",
+        "async-activity-loading-states",
         "progressive-disclosure",
         "readability-plain-language",
         "audience-tiers",

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -55,6 +55,7 @@ These patterns are NOT allowed in component code:
 | `color: "#ffffff"` | `color: "var(--dpf-text)"` |
 | `background: "#000000"` | `background: "var(--dpf-bg)"` |
 | Any hardcoded hex for bg/text/border/accent/muted | Use the corresponding `var(--dpf-*)` |
+| Hand-rolled `animate-spin` / `animate-pulse` loading indicator | `ui/Spinner`, `ui/Skeleton`, `ui/ProgressBar`, or `ui/InlineBusy` (see *Async Activity & Loading States*) |
 
 ## Allowed Hex Usage
 
@@ -73,6 +74,30 @@ Before submitting a component, verify:
 - [ ] No `text-white`, `text-black`, `bg-white`, or `bg-black` Tailwind classes
 - [ ] No inline hex colors for token roles
 - [ ] Component renders correctly in both light and dark mode (toggle OS preference to verify)
+- [ ] Every asynchronous action shows a visible activity indicator from `ui/` — no hand-rolled `animate-spin`/`animate-pulse` (see *Async Activity & Loading States*)
+
+## Async Activity & Loading States
+
+Every asynchronous action MUST show a visible, consistent activity indicator. A state change with no motion — a button whose only feedback is swapped text, a panel that sits blank while data loads — reads as "nothing is happening" and is a defect. Use the shared primitives in `apps/web/components/ui/`; never hand-roll `animate-spin` / `animate-pulse`.
+
+**Which indicator, when** (converged from Nielsen Norman Group, Shopify Polaris, GitHub Primer, Vercel Geist, IBM Carbon):
+
+| Situation | Indicator | Primitive |
+|---|---|---|
+| < ~0.5s (or LCP < 800ms) | **Nothing** — a placeholder that flashes is perceptually worse than empty space | — |
+| A short/unknown-duration action you triggered (button submit, inline fetch, ~0.5–10s) | Spinner + status label | `Spinner`, or `InlineBusy` inside a button |
+| Async data filling a **known layout** (panels, cards, lists, tables) | Skeleton (shape-of-content + shimmer) — best perceived performance | `Skeleton`, `SkeletonText` |
+| Determinate work where the total is known (uploads, multi-step, builds) | Progress bar | `ProgressBar` |
+| Never | Skeleton **and** spinner together — pick one | — |
+
+**Refreshing existing content:** keep the current content visible and dimmed (`opacity`) with the region marked `aria-busy`, and show the spinner on the trigger. Don't blank out good content to show a placeholder.
+
+**Accessibility (required):**
+- Mark the region being updated with `aria-busy="true"`.
+- Announce status text with `role="status"` + `aria-live="polite"` (the primitives do this; a bare `role="status"` in the codebase usually wraps a *result/error* region, which is a different use).
+- Motion is honored against the OS **Reduce Motion** preference via a global `@media (prefers-reduced-motion: reduce)` block in `globals.css` — spinners and shimmer fall back to a static, legible resting state. Don't reintroduce unguarded keyframe animations.
+
+**Rollout:** the primitives are the canonical replacement for the ~38 hand-rolled indicators catalogued across the portal; migrate opportunistically and when touching a surface. Semantic **status dots** (e.g. a pulsing health indicator) are state, not loading, and are out of this pattern — but still inherit the reduced-motion guard.
 
 ## Progressive Disclosure
 


### PR DESCRIPTION
## Why

Every asynchronous action must show a visible, consistent activity indicator. On `/ops/self-upgrade`, the "What's in this update?" summary is generated by a multi-second LLM action but showed **no motion** while running — only the trigger button's text swapped to "Summarizing…". The activity was lost on screen.

Root cause was systemic, not local: **no shared async-activity primitive existed**. ~38 components hand-roll `animate-spin`/`animate-pulse` independently, `globals.css` had **no `prefers-reduced-motion` handling anywhere**, and the internal design catalog had nothing for loading states.

This PR establishes the design-system foundation and adopts it on the screen that surfaced the gap (one concern per PR). Ships **BI-F5FCC56C**; the ~38-site migration is tracked in **BI-BBA388A1** (both under `EP-PLATFORM-CONSOLIDATION` — "operational UI primitives").

## What changed

- **Motion foundation** (`apps/web/app/globals.css`): `dpf-spin` + `dpf-shimmer` keyframes, and a **global `@media (prefers-reduced-motion: reduce)` reset** — a platform-wide a11y fix that stills spinners, shimmer, and the pre-existing `slide-up`/`cell-pulse` and per-component keyframes for users who ask for reduced motion.
- **Shared primitives** (`apps/web/components/ui/`), token-only and accessible, following the `report-kit/StatusBadge` conventions (server-usable, no hooks):
  - `Spinner` — `role="status"` + live label; reduced-motion aware.
  - `Skeleton` (+ `SkeletonText`) — shape-of-content shimmer, `aria-hidden`.
  - `ProgressBar` — determinate + indeterminate, with the `role="progressbar"`/`aria-valuenow` semantics the hand-rolled bars omit.
  - `InlineBusy` — one-call spinner + label for a button's pending state.
- **Exemplar adoption** (`components/ops/UpgradeImpactPanel.tsx`): inline spinner + live "Summarizing…" label on the trigger; a shape-of-content **skeleton** while generating — which now also covers the on-mount auto-fetch (BI-4A400DE4), so first page view shows a resolving skeleton instead of a blank panel; **dim-in-place + `aria-busy`** on refresh (keeps good content, doesn't blank it).
- **Standard** (`docs/platform-usability-standards.md`): new "Async Activity & Loading States" section (which-indicator-when, a11y, reduced-motion) + a Prohibited Patterns row against hand-rolled indicators. Doc index regenerated.
- **Tests**: 4 primitive suites + panel loading-state cases.

## Research & benchmarking

Converged from Nielsen Norman Group, Shopify Polaris, GitHub Primer, Vercel Geist, IBM Carbon: **spinner** for a triggered/unknown-duration action, **skeleton** for content filling a known layout, **progress bar** for determinate work (never skeleton + spinner together); `aria-busy` + `role="status"`/`aria-live`; honor `prefers-reduced-motion`.

## Design grounding

- **Existing specs/plans reviewed:** searched `docs/superpowers/specs` + the internal design catalog (`search_design_intelligence`) — no prior loading/async/activity guidance exists. Reviewed AGENTS.md §12 and the `Dialog` / no-native-dialogs precedent (a cross-cutting UI concern solved with a shared `ui/` primitive + standard + guard) as the pattern to follow.
- **Current code substrate reviewed:** `components/ui/` (`Dialog`, `report-kit/StatusBadge`) for primitive conventions; `app/globals.css` (only two keyframes, no reduced-motion); catalogued the ~38 hand-rolled `animate-spin`/`animate-pulse` sites; `components/ops/UpgradeImpactPanel.tsx` (the exemplar, which now auto-generates on mount per BI-4A400DE4).
- **Source of truth:** `docs/platform-usability-standards.md` (UI conventions) — this PR adds the standard there; colors/motion resolve through `globals.css` `--dpf-*` tokens.
- **Decision:** extend the existing UI-primitive substrate with new `ui/` primitives + a documented standard, rather than invent per-surface loading UX. No routing, queue, or data-contract change — purely the presentational activity-indication layer. Rollout to the other surfaces is tracked in `BI-BBA388A1`.

## Verification

- ✅ Unit tests — `vitest run` on the 4 new primitive suites + the extended panel suite: **25 passed**. The panel test drives the real React `useTransition` pending path (including the on-mount auto-fetch) and asserts the skeleton region and `InlineBusy` render.
- ✅ Typecheck — `pnpm --filter web typecheck`: **0 errors** (after regenerating the Prisma client + syncing main's deps post-rebase).
- ✅ Production build — `pnpm --filter web build`: **exit 0**, all pages generated.
- ✅ Visual — rendered a self-contained harness (tokens + keyframes copied verbatim) across light/dark and Reduce Motion, confirming the spinner rotates, the shimmer sweeps, and both freeze to a static state under reduced motion.

## Rollout (follow-up, not this PR)

`BI-BBA388A1` migrates the ~38 catalogued hand-rolled sites (button-busy spinners, panel skeletons, progress bars, section spinners) to these primitives, and proposes a CI guard (like `check-no-native-dialogs.mjs`) failing new raw `animate-spin`/`animate-pulse` outside `components/ui/`. Semantic status dots (health indicators) are state, not loading, and are out of scope — but inherit the new reduced-motion guard.

UX-Fit-Decision: progressive-disclosure / low cognitive-load — adds visible activity feedback with no new operator-facing inputs or controls, so it strictly reduces ambiguity; scored on the human_cognitive_load axis.

Process-Spine-Decision: touches a durable-knowledge artifact (docs/platform-usability-standards.md) documenting the new standard.

Design-Grounding-Decision: reviewed docs/superpowers specs (no prior loading guidance) + the ui/ primitive substrate + the ~38 hand-rolled sites; extends the UI-primitive substrate with a documented standard; no routing/queue/contract change. See "Design grounding" above.

Local-CI-Override: Verified in a compile-ready worktree (real deps, shared pnpm store) at the PR head — `pnpm --filter web typecheck` (0 errors), `NODE_ENV=production pnpm --filter web build` (exit 0, all pages), and vitest on the 4 new primitive suites + panel suite (25 passed). Prisma client regenerated and deps synced to main's lockfile after the rebase onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
