### PR TITLE
feat(tak): role-derived grant baseline mechanism (EP-31815F97 S1, BI-56E9CEC2)

### DIFF
--- a/apps/web/lib/tak/role-grant-baseline.test.ts
+++ b/apps/web/lib/tak/role-grant-baseline.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveRoleBaselineGrants,
+  computeGrantDelta,
+  resolveEffectiveGrants,
+  describeAgentGrants,
+  normalizeValueStream,
+  VALUE_STREAM_READ_BASELINE,
+} from "./role-grant-baseline";
+import { COWORKER_READ_BASELINE_GRANTS } from "./agent-grants";
+
+describe("deriveRoleBaselineGrants", () => {
+  it("is the universal read baseline for an unknown/absent value stream", () => {
+    expect(deriveRoleBaselineGrants({ valueStream: null })).toEqual(
+      [...COWORKER_READ_BASELINE_GRANTS].sort(),
+    );
+    expect(deriveRoleBaselineGrants({ valueStream: "not-a-stream" })).toEqual(
+      [...COWORKER_READ_BASELINE_GRANTS].sort(),
+    );
+  });
+
+  it("adds the value stream's read grants on top of the universal baseline", () => {
+    const integrate = deriveRoleBaselineGrants({ valueStream: "integrate" });
+    for (const g of COWORKER_READ_BASELINE_GRANTS) expect(integrate).toContain(g);
+    expect(integrate).toContain("backlog_read");
+    expect(integrate).toContain("architecture_read");
+  });
+
+  it("normalizes case/whitespace in the value stream", () => {
+    expect(deriveRoleBaselineGrants({ valueStream: " Operate " })).toEqual(
+      deriveRoleBaselineGrants({ valueStream: "operate" }),
+    );
+  });
+
+  it("BASELINE IS READ-ONLY — no write/act grant is ever in any role baseline (INV-A1)", () => {
+    for (const [vs, grants] of Object.entries(VALUE_STREAM_READ_BASELINE)) {
+      for (const g of grants) {
+        expect(g.endsWith("_read"), `${vs} baseline grant ${g} is not read-only`).toBe(true);
+      }
+    }
+    for (const vs of ["evaluate", "integrate", "operate", "consume", "cross-cutting"]) {
+      for (const g of deriveRoleBaselineGrants({ valueStream: vs })) {
+        expect(g.endsWith("_read"), `${vs} derived baseline ${g} is not read-only`).toBe(true);
+      }
+    }
+  });
+});
+
+describe("computeGrantDelta / resolveEffectiveGrants round-trip", () => {
+  it("splits effective grants into escalations (added) and withheld (removed)", () => {
+    const baseline = deriveRoleBaselineGrants({ valueStream: "integrate" });
+    const effective = [...baseline.filter((g) => g !== "backlog_read"), "backlog_write", "sandbox_execute"];
+    const delta = computeGrantDelta(baseline, effective);
+    expect(delta.added).toEqual(["backlog_write", "sandbox_execute"]);
+    expect(delta.removed).toEqual(["backlog_read"]);
+  });
+
+  it("resolveEffectiveGrants(baseline, delta) reconstructs the effective set", () => {
+    const baseline = deriveRoleBaselineGrants({ valueStream: "operate" });
+    const effective = [...baseline, "incident_respond", "admin_write"].sort();
+    const delta = computeGrantDelta(baseline, effective);
+    expect(resolveEffectiveGrants(baseline, delta)).toEqual(effective);
+  });
+});
+
+describe("describeAgentGrants (the operator surface)", () => {
+  it("surfaces write escalations as the least-privilege attention set", () => {
+    const desc = describeAgentGrants(
+      { valueStream: "integrate" },
+      [
+        ...deriveRoleBaselineGrants({ valueStream: "integrate" }),
+        "backlog_write",
+        "sandbox_execute",
+        "telemetry_read",
+      ],
+    );
+    expect(desc.escalations).toContain("backlog_write");
+    expect(desc.escalations).toContain("telemetry_read");
+    expect(desc.writeEscalations.sort()).toEqual(["backlog_write", "sandbox_execute"]);
+    expect(desc.writeEscalations).not.toContain("telemetry_read");
+  });
+
+  it("a coworker with only its baseline has zero escalations (the conservative default)", () => {
+    const desc = describeAgentGrants(
+      { valueStream: "evaluate" },
+      deriveRoleBaselineGrants({ valueStream: "evaluate" }),
+    );
+    expect(desc.escalations).toEqual([]);
+    expect(desc.writeEscalations).toEqual([]);
+    expect(desc.withheld).toEqual([]);
+  });
+});
+
+describe("normalizeValueStream", () => {
+  it("maps known streams and rejects unknown", () => {
+    expect(normalizeValueStream("Integrate")).toBe("integrate");
+    expect(normalizeValueStream("cross-cutting")).toBe("cross-cutting");
+    expect(normalizeValueStream("marketing")).toBeNull();
+    expect(normalizeValueStream(null)).toBeNull();
+  });
+});

--- a/apps/web/lib/tak/role-grant-baseline.ts
+++ b/apps/web/lib/tak/role-grant-baseline.ts
@@ -1,0 +1,147 @@
+// apps/web/lib/tak/role-grant-baseline.ts
+//
+// EP-31815F97 S1 (BI-56E9CEC2). Derive a conservative, ROLE-based grant baseline
+// from a coworker's role (its IT4IT value stream), so per-agent grants become
+// DELTAS-from-baseline instead of a hand-listed flat ~74-key set. This is the RBAC
+// floor of the layered authority model: default authority = universal read
+// baseline + the role's read baseline; every WRITE/act grant is an explicit,
+// visible escalation (INV-A1, least-privilege / deny-by-default).
+//
+// The baseline is READ-ONLY by construction — writes are never baseline, always
+// deltas — so "role baseline (context) + your escalations (the surface to
+// review)" replaces the flat dropdown, and least-privilege is the default.
+//
+// Keyed on `valueStream`, the same 8-value IT4IT taxonomy that keys
+// ValueStreamTeamRole (workerType ai-agent | human | either), so this model
+// extends from coworkers to human roles without a rewrite (S4/follow-on). Pure;
+// unit-tests without Prisma.
+
+import { COWORKER_READ_BASELINE_GRANTS } from "./agent-grants";
+
+export type ValueStream =
+  | "evaluate"
+  | "explore"
+  | "integrate"
+  | "deploy"
+  | "release"
+  | "consume"
+  | "operate"
+  | "cross-cutting";
+
+const VALUE_STREAMS: readonly ValueStream[] = [
+  "evaluate",
+  "explore",
+  "integrate",
+  "deploy",
+  "release",
+  "consume",
+  "operate",
+  "cross-cutting",
+];
+
+/**
+ * Extra READ grants a value stream routinely needs on top of the universal read
+ * baseline (COWORKER_READ_BASELINE_GRANTS). CONSERVATIVE and READ-ONLY: this is
+ * what a role of this stream reads, never what it may change. DRAFT — the
+ * per-stream bundles define what every coworker of that stream can READ, so the
+ * table is founder-reviewable; adding a stream key here is the whole change.
+ */
+export const VALUE_STREAM_READ_BASELINE: Record<ValueStream, readonly string[]> = {
+  evaluate: ["portfolio_read", "telemetry_read"],
+  explore: ["portfolio_read"],
+  integrate: ["backlog_read", "architecture_read", "spec_plan_read"],
+  deploy: ["telemetry_read", "release_plan_read"],
+  release: ["release_plan_read"],
+  consume: ["crm_read", "consumer_read", "marketing_read"],
+  operate: ["telemetry_read", "admin_read"],
+  "cross-cutting": [],
+};
+
+const unique = (xs: readonly string[]): string[] => Array.from(new Set(xs));
+
+/** Normalize an arbitrary/legacy valueStream string to a known ValueStream, or
+ *  null when unrecognized (then only the universal read baseline applies). */
+export function normalizeValueStream(vs: string | null | undefined): ValueStream | null {
+  if (!vs) return null;
+  const v = vs.trim().toLowerCase();
+  return (VALUE_STREAMS as readonly string[]).includes(v) ? (v as ValueStream) : null;
+}
+
+/**
+ * The conservative role baseline: universal read baseline ∪ the value stream's
+ * read baseline. READ-ONLY — never contains a write/act grant (asserted by the
+ * unit tests). An unknown value stream falls back to the universal read baseline.
+ */
+export function deriveRoleBaselineGrants(role: { valueStream?: string | null }): string[] {
+  const vs = normalizeValueStream(role.valueStream);
+  const streamReads = vs ? VALUE_STREAM_READ_BASELINE[vs] : [];
+  return unique([...COWORKER_READ_BASELINE_GRANTS, ...streamReads]).sort();
+}
+
+export interface GrantDelta {
+  /** Escalations beyond the role baseline — the operator's real review surface. */
+  added: string[];
+  /** Baseline grants explicitly withheld from this coworker (rare). */
+  removed: string[];
+}
+
+/** Express an effective grant set as a delta from a role baseline. */
+export function computeGrantDelta(
+  baseline: readonly string[],
+  effective: readonly string[],
+): GrantDelta {
+  const b = new Set(baseline);
+  const e = new Set(effective);
+  return {
+    added: [...e].filter((g) => !b.has(g)).sort(),
+    removed: [...b].filter((g) => !e.has(g)).sort(),
+  };
+}
+
+/** Reconstruct effective grants from a baseline + delta (inverse of computeGrantDelta). */
+export function resolveEffectiveGrants(
+  baseline: readonly string[],
+  delta: GrantDelta,
+): string[] {
+  const set = new Set(baseline);
+  for (const g of delta.removed) set.delete(g);
+  for (const g of delta.added) set.add(g);
+  return [...set].sort();
+}
+
+export interface AgentGrantDescription {
+  valueStream: ValueStream | null;
+  /** Role baseline (read-only context — not the edit surface). */
+  baseline: string[];
+  /** Grants beyond baseline (added deltas) — what an operator reviews/edits. */
+  escalations: string[];
+  /** Baseline grants withheld (removed deltas). */
+  withheld: string[];
+  /** The full effective grant set. */
+  effective: string[];
+  /** Escalations that are WRITES/acts (not `*_read`) — the least-privilege
+   *  attention surface: every non-read escalation is a deliberate authority grant. */
+  writeEscalations: string[];
+}
+
+/**
+ * The operator-facing description of a coworker's authority: baseline (role
+ * context) + escalations (the surface to review) + effective set. Replaces the
+ * flat ~74-key dropdown so an operator adjusts a small delta and sees exactly
+ * which non-read authorities were granted beyond the conservative floor.
+ */
+export function describeAgentGrants(
+  role: { valueStream?: string | null },
+  effectiveGrants: readonly string[],
+): AgentGrantDescription {
+  const baseline = deriveRoleBaselineGrants(role);
+  const delta = computeGrantDelta(baseline, effectiveGrants);
+  return {
+    valueStream: normalizeValueStream(role.valueStream),
+    baseline,
+    escalations: delta.added,
+    withheld: delta.removed,
+    effective: unique([...effectiveGrants]).sort(),
+    writeEscalations: delta.added.filter((g) => !g.endsWith("_read")),
+  };
+}

--- a/docs/superpowers/plans/2026-07-17-ep-31815f97-s1-role-grant-baseline-plan.md
+++ b/docs/superpowers/plans/2026-07-17-ep-31815f97-s1-role-grant-baseline-plan.md
@@ -1,0 +1,37 @@
+# EP-31815F97 S1 — role-derived RBAC baseline (coworker-first)
+
+**Epic:** EP-31815F97 · **BI:** BI-56E9CEC2 · **Spec:** `docs/superpowers/specs/2026-07-17-coworker-authority-model-completion-design.md` (§3 S1) · **Kernel scope:** DI-B812A3E7713C (option A, high confidence)
+
+## Goal
+
+Replace the hand-listed, per-agent flat ~74-key grant set (which is *why* 19/20 coworker grant sources diverge, and *why* the CapabilitiesEditor is a flat dropdown) with a conservative **role-derived baseline + deltas**: default authority = universal read baseline + the role's read baseline; every write/act grant is an explicit, visible escalation (INV-A1, least-privilege). Built on the `valueStream` key that also keys `ValueStreamTeamRole` (workerType ai-agent|human|either), so it extends to human roles in a follow-on rather than being rewritten.
+
+## Design grounding
+
+Existing specs/plans reviewed (via search_specs_and_plans): docs/superpowers/specs/2026-07-17-coworker-authority-model-completion-design.md; docs/superpowers/specs/2026-04-02-ai-workforce-consolidation-design.md ("two authorization models… no unified way to determine what an agent is allowed to do"); docs/superpowers/specs/2026-06-26-coworker-management-consolidation-design.md ("5–7 surfaces, ~15–20 clicks"). Current code substrate reviewed: apps/web/lib/tak/agent-grants.ts (COWORKER_READ_BASELINE_GRANTS, TOOL_TO_GRANTS, GRANT_IMPLICATIONS, knownGrantKeys), packages/db/src/workforce-seed.ts (HARDCODED_COWORKER_GRANTS, valueStream seeds), packages/db/prisma/schema.prisma (ValueStreamTeamRole ~10038 — the shared abstraction), apps/web/components/platform/coworker-record/CapabilitiesEditor.tsx.
+
+Design-Grounding-Decision: extends the EP-31815F97 spec §3 S1 (kernel scope DI-B812A3E7713C, option A); no authority change in this slice — the baseline is READ-ONLY and display-only (describeAgentGrants); no enforcement path consumes it yet. Coworker authority unchanged (INV-3).
+
+## What shipped (this PR — the mechanism)
+
+`apps/web/lib/tak/role-grant-baseline.ts` (pure):
+- `VALUE_STREAM_READ_BASELINE: Record<ValueStream, grantKey[]>` — conservative, **read-only** per-stream reads on top of `COWORKER_READ_BASELINE_GRANTS`. DRAFT — founder-reviewable (it defines what every coworker of a stream may READ).
+- `deriveRoleBaselineGrants(role)` — universal ∪ stream read baseline; unknown stream → universal only.
+- `computeGrantDelta` / `resolveEffectiveGrants` — express/reconstruct effective grants as baseline ⊕ delta.
+- `describeAgentGrants(role, effective)` → `{ baseline, escalations, withheld, effective, writeEscalations }` — the operator surface: baseline is context, `escalations` are the edit surface, `writeEscalations` (non-`*_read` adds) are the least-privilege attention set.
+- A test enforces **the baseline is read-only** (no `*_write`/act grant ever in any baseline).
+
+## Follow-on (next PRs, founder-steered)
+
+1. **CapabilitiesEditor UX** — render `describeAgentGrants`: role baseline chips (read-only context) + "Escalations beyond baseline" (the editable delta, write-escalations flagged), replacing the flat ~74-key dropdown. Needs dpf-ux-fit-review + portal verification.
+2. **Divergence reconciliation (BI-56E9CEC2)** — make effective coworker grants = role baseline ⊕ per-agent delta at resolution, so the DB-seed vs JSON divergence collapses to a single delta source over a shared baseline (authority-sensitive; founder confirms the table first).
+3. **Human extension (S4)** — apply the same baseline/delta over `ValueStreamTeamRole` for `workerType: human|either`, bridging the PERMISSIONS namespace.
+
+## Verification
+
+- `pnpm --filter web exec vitest run lib/tak/role-grant-baseline.test.ts`
+- `pnpm --filter web typecheck && pnpm --filter web build`
+
+## Non-regression
+
+Display-only + read-only baseline; nothing consumes it to change authority yet (INV-3). The value-stream table is conservative by construction (a test fails if any baseline grant is not `*_read`).


### PR DESCRIPTION
The RBAC-floor mechanism for **EP-31815F97** — derive a conservative, read-only grant baseline from a coworker's role (IT4IT `valueStream`) so per-agent grants become **deltas-from-baseline** instead of a hand-listed flat ~74-key set. Kernel scope DI-B812A3E7713C (option A, coworker-first on the shared `ValueStreamTeamRole` abstraction — extends to humans next). Foundation PR: **pure, read-only, display-only — no authority change yet**; the CapabilitiesEditor UX + the divergence reconciliation follow, founder-steered.

## What ships

`role-grant-baseline.ts` (pure): `VALUE_STREAM_READ_BASELINE` (conservative read-only per stream), `deriveRoleBaselineGrants`, `computeGrantDelta`/`resolveEffectiveGrants`, `describeAgentGrants → { baseline, escalations, withheld, effective, writeEscalations }`. A test enforces the baseline is **read-only** (INV-A1) — every write/act is a visible escalation, never baseline.

## Effect (real coworkers)

| Coworker | valueStream | baseline (reads) | escalations | **write escalations = the review surface** |
|---|---|---|---|---|
| ops-coordinator | integrate | 8 | 3 | **2** (backlog_write, backlog_triage) |
| build-specialist | integrate | 8 | 10 | **8** (deploy/iac/sandbox/…) |
| platform-engineer | operate | 7 | 2 | **1** (admin_write) |
| marketing-specialist | consume | 8 | 1 | **1** (marketing_write) |

Replaces the flat ~74-key dropdown with "role baseline + a handful of escalations, writes flagged".

## Follow-on (founder-steered)

CapabilitiesEditor UX (baseline chips + escalations, write-flagged) with dpf-ux-fit-review; divergence reconciliation (BI-56E9CEC2); human extension over ValueStreamTeamRole (S4).

## Local-CI-Override

Pushed with `DPF_SKIP_PREPUSH_GATE=1`: web typecheck + build + 9 tests + module-size green in a fresh `origin/main` worktree. Pure read-only/display-only module. Pregate's localStorage-env failures are pre-existing + unrelated. GitHub CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)