### PR TITLE
feat(asset-intel): correlate discovered devices with managed customer CIs — read-model bridge (BI-828998DC)

### DIFF
--- a/apps/web/lib/customer-estate/account-estate-summary.test.ts
+++ b/apps/web/lib/customer-estate/account-estate-summary.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockPrisma } = vi.hoisted(() => ({
+const { mockPrisma, mockCorrelate } = vi.hoisted(() => ({
   mockPrisma: {
     customerSite: {
       findMany: vi.fn(),
@@ -8,10 +8,16 @@ const { mockPrisma } = vi.hoisted(() => ({
     customerConfigurationItem: {
       findMany: vi.fn(),
     },
+    inventoryEntity: {
+      findMany: vi.fn(),
+    },
   },
+  // The correlation logic itself is covered by inventory-cci-bridge.test.ts; here it is a
+  // controllable stub so the summary test stays focused on the summary's own aggregation.
+  mockCorrelate: vi.fn(),
 }));
 
-vi.mock("@dpf/db", () => ({ prisma: mockPrisma }));
+vi.mock("@dpf/db", () => ({ prisma: mockPrisma, correlateDiscoveryToEstate: mockCorrelate }));
 
 import { loadCustomerEstateSummary } from "./account-estate-summary";
 
@@ -19,6 +25,10 @@ describe("loadCustomerEstateSummary", () => {
   beforeEach(() => {
     mockPrisma.customerSite.findMany.mockReset();
     mockPrisma.customerConfigurationItem.findMany.mockReset();
+    mockPrisma.inventoryEntity.findMany.mockReset();
+    mockPrisma.inventoryEntity.findMany.mockResolvedValue([]);
+    mockCorrelate.mockReset();
+    mockCorrelate.mockReturnValue({ matches: [], managedAndDiscovered: 0, managedNotDiscovered: 0, discoveredNotManaged: 0 });
   });
 
   it("summarizes site, lifecycle, and recurring-license attention", async () => {
@@ -95,6 +105,29 @@ describe("loadCustomerEstateSummary", () => {
     expect(summary.topAttentionItems[0]).toMatchObject({
       name: "SentinelOne Complete",
       recommendedAction: "renew",
+    });
+  });
+
+  it("surfaces the discovery↔managed-CI correlation counts (BI-828998DC)", async () => {
+    mockPrisma.customerSite.findMany.mockResolvedValue([]);
+    mockPrisma.customerConfigurationItem.findMany.mockResolvedValue([]);
+    mockPrisma.inventoryEntity.findMany.mockResolvedValue([
+      { id: "e-1", manufacturer: "Dell", productModel: "PowerEdge R750", name: "srv", customerAccountId: "acct-1", customerSiteId: null, properties: {} },
+    ]);
+    mockCorrelate.mockReturnValue({
+      matches: [{ inventoryEntityId: "e-1", configurationItemId: "cci-1", method: "model", confidence: 0.8 }],
+      managedAndDiscovered: 1,
+      managedNotDiscovered: 3,
+      discoveredNotManaged: 2,
+    });
+
+    const summary = await loadCustomerEstateSummary("acct-1");
+
+    expect(mockPrisma.inventoryEntity.findMany).toHaveBeenCalled();
+    expect(summary.discoveryCorrelation).toEqual({
+      managedAndDiscovered: 1,
+      managedNotDiscovered: 3,
+      discoveredNotManaged: 2,
     });
   });
 });

--- a/apps/web/lib/customer-estate/account-estate-summary.ts
+++ b/apps/web/lib/customer-estate/account-estate-summary.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@dpf/db";
 import type { Prisma } from "@dpf/db";
+import { correlateDiscoveryToEstate } from "@dpf/db";
 
 import { buildLifecycleReviewQueue } from "@/lib/shared/lifecycle-review";
 import { evaluateTechnologyLifecycle } from "./lifecycle-evaluation";
@@ -75,6 +76,16 @@ type CustomerEstateSummary = {
     recommendedAction: string;
     attentionLevel: string;
   }>;
+  // HAM Phase D2 (BI-828998DC): read-model correlation of the customer's DISCOVERED estate
+  // (InventoryEntity) against its MANAGED CIs (CustomerConfigurationItem). No authority move.
+  discoveryCorrelation: {
+    /** Managed CIs a discovered device corresponds to. */
+    managedAndDiscovered: number;
+    /** Managed CIs not seen in discovery — undiscovered / offline / out-of-scope. */
+    managedNotDiscovered: number;
+    /** Discovered devices with no managed CI — shadow / unmanaged estate. */
+    discoveredNotManaged: number;
+  };
 };
 
 const ATTENTION_ORDER: Record<string, number> = {
@@ -94,6 +105,13 @@ const CUSTOMER_CONFIGURATION_ITEM_SELECT: Prisma.CustomerConfigurationItemSelect
   supportModel: true,
   observedVersion: true,
   normalizedVersion: true,
+  // BI-828998DC bridge match keys.
+  manufacturer: true,
+  vendorName: true,
+  productModel: true,
+  productName: true,
+  serialNumber: true,
+  assetTag: true,
   warrantyEndAt: true,
   endOfSupportAt: true,
   endOfLifeAt: true,
@@ -109,7 +127,7 @@ export async function loadCustomerEstateSummary(
   accountId: string,
   asOf: Date = new Date(),
 ): Promise<CustomerEstateSummary> {
-  const [sites, configurationItems] = await Promise.all([
+  const [sites, configurationItems, discoveredDevices] = await Promise.all([
     prisma.customerSite.findMany({
       where: { accountId },
       select: {
@@ -123,7 +141,44 @@ export async function loadCustomerEstateSummary(
       select: CUSTOMER_CONFIGURATION_ITEM_SELECT,
       orderBy: { name: "asc" },
     }),
+    // HAM D2 (BI-828998DC): the account's discovered devices, for read-model correlation.
+    prisma.inventoryEntity.findMany({
+      where: { customerAccountId: accountId, status: { not: "stale" } },
+      select: {
+        id: true,
+        manufacturer: true,
+        productModel: true,
+        name: true,
+        customerAccountId: true,
+        customerSiteId: true,
+        properties: true,
+      },
+    }),
   ]);
+
+  // Correlate discovered devices with managed CIs (read-model, no authority move / no persistence).
+  const discoveryCorrelation = correlateDiscoveryToEstate(
+    discoveredDevices.map((d) => ({
+      id: d.id,
+      manufacturer: d.manufacturer,
+      productModel: d.productModel,
+      name: d.name,
+      customerAccountId: d.customerAccountId,
+      customerSiteId: d.customerSiteId,
+      properties: d.properties as Record<string, unknown> | null,
+    })),
+    configurationItems.map((c) => ({
+      id: c.id,
+      accountId,
+      siteId: c.siteId,
+      manufacturer: c.manufacturer,
+      vendorName: c.vendorName,
+      productModel: c.productModel,
+      productName: c.productName,
+      serialNumber: c.serialNumber,
+      assetTag: c.assetTag,
+    })),
+  );
 
   const evaluatedItems = configurationItems.map((item) => ({
     ...item,
@@ -260,5 +315,10 @@ export async function loadCustomerEstateSummary(
       recommendedAction: item.lifecycle.recommendedAction,
       attentionLevel: item.lifecycle.attentionLevel,
     })),
+    discoveryCorrelation: {
+      managedAndDiscovered: discoveryCorrelation.managedAndDiscovered,
+      managedNotDiscovered: discoveryCorrelation.managedNotDiscovered,
+      discoveredNotManaged: discoveryCorrelation.discoveredNotManaged,
+    },
   };
 }

--- a/docs/superpowers/specs/2026-07-17-hardware-asset-intelligence-phase-d-design.md
+++ b/docs/superpowers/specs/2026-07-17-hardware-asset-intelligence-phase-d-design.md
@@ -148,7 +148,7 @@ Proposed BIs:
 
 Proposed BIs after D1 evidence:
 
-5. **BI-828998DC - InventoryEntity <-> CustomerConfigurationItem bridge** - define matching rules and read-model joins for customer/site equipment records without moving authority.
+5. **BI-828998DC - InventoryEntity <-> CustomerConfigurationItem bridge** - define matching rules and read-model joins for customer/site equipment records without moving authority. **Read-model matcher LANDED** (kernel decision DI-56B99A37FA40 chose the read-model over a nullable-FK / link-table persist — a fuzzy match must not be asserted authoritative without human confirmation). `packages/db/src/inventory-cci-bridge.ts`: `matchInventoryEntityToCci` matches a discovered device to a managed CI **within customer/site scope** by serial → asset-tag → manufacturer+model precedence (fail-closed below model — a false link is worse than an unmatched device; discovery collects no serial/asset-tag today so matches are model-level), and `correlateDiscoveryToEstate` buckets an account into managed-and-discovered / managed-not-discovered / discovered-not-managed (shadow). Surfaced read-only on the customer-estate summary (`loadCustomerEstateSummary.discoveryCorrelation`) — **no authority move, no persistence**. Persisting a *confirmed* link (a link table + human confirmation workflow) is the deliberate D2 follow-up once match quality is validated; a firmware-GUID/serial collector would raise the match rate.
 6. **BI-1093AF1C - InventoryEntity <-> FixedAsset bridge** - define optional serial/assetTag/catalogIdentity matching and origin trace fields needed before any finance-facing HAM automation.
 
 ### Deferred initiative - Full HAM financial lifecycle

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -394,6 +394,9 @@ export * from "./catalog-enrichment-sweep";
 // under a batching + per-run inference budget cost guardrail. Pure engine; the governed
 // apps/web runner wires the real prisma + a minimize_cost inference fn.
 export * from "./catalog-identity-inference";
+// HAM Phase D2 (BI-828998DC, spec §7): read-model correlation of discovered InventoryEntity
+// to managed CustomerConfigurationItem — no authority move, no persistence.
+export * from "./inventory-cci-bridge";
 export * from "./device-placement";
 export * from "./portfolio-sources";
 export * from "./backlog-portfolio";

--- a/packages/db/src/inventory-cci-bridge.test.ts
+++ b/packages/db/src/inventory-cci-bridge.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  correlateDiscoveryToEstate,
+  matchInventoryEntityToCci,
+  type BridgeConfigurationItem,
+  type BridgeInventoryEntity,
+} from "./inventory-cci-bridge";
+
+const cci = (over: Partial<BridgeConfigurationItem>): BridgeConfigurationItem => ({
+  id: "cci-1",
+  accountId: "acct-1",
+  siteId: null,
+  manufacturer: "Dell",
+  vendorName: null,
+  productModel: "PowerEdge R750",
+  productName: null,
+  serialNumber: null,
+  assetTag: null,
+  ...over,
+});
+
+const entity = (over: Partial<BridgeInventoryEntity>): BridgeInventoryEntity => ({
+  id: "e-1",
+  manufacturer: "Dell",
+  productModel: "PowerEdge R750",
+  name: "srv-01",
+  customerAccountId: "acct-1",
+  customerSiteId: null,
+  properties: null,
+  ...over,
+});
+
+describe("matchInventoryEntityToCci", () => {
+  it("matches on serial number first (exact, case-insensitive)", () => {
+    const m = matchInventoryEntityToCci(
+      entity({ properties: { serialNumber: "ABC123" }, productModel: "wrong" }),
+      [cci({ id: "cci-serial", serialNumber: "abc123", productModel: "irrelevant" })],
+    );
+    expect(m).toEqual({ inventoryEntityId: "e-1", configurationItemId: "cci-serial", method: "serial", confidence: 0.99 });
+  });
+
+  it("matches on asset tag when there is no serial", () => {
+    const m = matchInventoryEntityToCci(
+      entity({ properties: { assetTag: "AT-9" }, manufacturer: null, productModel: null }),
+      [cci({ id: "cci-tag", assetTag: "AT-9" })],
+    );
+    expect(m?.method).toBe("asset_tag");
+    expect(m?.confidence).toBe(0.95);
+  });
+
+  it("falls back to manufacturer+model match", () => {
+    const m = matchInventoryEntityToCci(entity({}), [cci({ id: "cci-model" })]);
+    expect(m).toEqual({ inventoryEntityId: "e-1", configurationItemId: "cci-model", method: "model", confidence: 0.8 });
+  });
+
+  it("does NOT match a different manufacturer even with the same model string", () => {
+    expect(matchInventoryEntityToCci(entity({ manufacturer: "HP" }), [cci({})])).toBeNull();
+  });
+
+  it("never crosses customer account scope", () => {
+    expect(matchInventoryEntityToCci(entity({ customerAccountId: "acct-2" }), [cci({})])).toBeNull();
+  });
+
+  it("does not match across sites when both name a site", () => {
+    expect(
+      matchInventoryEntityToCci(entity({ customerSiteId: "site-a" }), [cci({ siteId: "site-b" })]),
+    ).toBeNull();
+    // …but an account-level match is allowed when the device has no site yet.
+    expect(
+      matchInventoryEntityToCci(entity({ customerSiteId: null }), [cci({ siteId: "site-b" })]),
+    ).not.toBeNull();
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(matchInventoryEntityToCci(entity({ manufacturer: "Acme", productModel: "Nonesuch" }), [cci({})])).toBeNull();
+  });
+});
+
+describe("correlateDiscoveryToEstate", () => {
+  it("buckets managed-and-discovered, managed-not-discovered, and shadow devices", () => {
+    const ccis = [
+      cci({ id: "cci-r750", productModel: "PowerEdge R750" }),
+      cci({ id: "cci-r640", productModel: "PowerEdge R640" }), // managed, never discovered
+    ];
+    const entities = [
+      entity({ id: "e-r750", productModel: "PowerEdge R750" }), // matches cci-r750
+      entity({ id: "e-shadow", manufacturer: "Ubiquiti", productModel: "UDM Pro" }), // no CCI → shadow
+    ];
+
+    const result = correlateDiscoveryToEstate(entities, ccis);
+    expect(result.managedAndDiscovered).toBe(1);
+    expect(result.managedNotDiscovered).toBe(1); // cci-r640
+    expect(result.discoveredNotManaged).toBe(1); // e-shadow
+    expect(result.matches).toEqual([
+      { inventoryEntityId: "e-r750", configurationItemId: "cci-r750", method: "model", confidence: 0.8 },
+    ]);
+  });
+
+  it("counts an empty estate cleanly", () => {
+    expect(correlateDiscoveryToEstate([], [])).toEqual({
+      matches: [],
+      managedAndDiscovered: 0,
+      managedNotDiscovered: 0,
+      discoveredNotManaged: 0,
+    });
+  });
+});

--- a/packages/db/src/inventory-cci-bridge.ts
+++ b/packages/db/src/inventory-cci-bridge.ts
@@ -1,0 +1,159 @@
+// InventoryEntity ↔ CustomerConfigurationItem bridge (BI-828998DC, HAM Phase D2, spec §7).
+//
+// Correlates DISCOVERED devices (InventoryEntity) with MANAGED customer equipment
+// (CustomerConfigurationItem) for the customer-estate view — "which managed CIs do we
+// actually see in discovery, and which discovered devices aren't managed CIs (shadow)?".
+//
+// This is a READ-MODEL match (kernel decision DI-56B99A37FA40): it MOVES NO AUTHORITY and
+// persists nothing. Discovery does not collect serial/asset-tag today, so most matches are
+// model-level and confidence-scored — never asserted as an authoritative link. Persisting a
+// confirmed link (a link table + human confirmation) is the deliberate D2 follow-up. Pure
+// and fixture-tested; the caller passes already-loaded, same-account rows.
+
+/** Minimal discovered-device shape the matcher needs. */
+export type BridgeInventoryEntity = {
+  id: string;
+  manufacturer: string | null;
+  productModel: string | null;
+  name: string;
+  customerAccountId: string | null;
+  customerSiteId: string | null;
+  /** Discovery `properties` — may carry serialNumber / assetTag when a collector supplies them. */
+  properties?: Record<string, unknown> | null;
+};
+
+/** Minimal managed-CI shape the matcher needs. */
+export type BridgeConfigurationItem = {
+  id: string;
+  accountId: string;
+  siteId: string | null;
+  manufacturer: string | null;
+  vendorName: string | null;
+  productModel: string | null;
+  productName: string | null;
+  serialNumber: string | null;
+  assetTag: string | null;
+};
+
+/** How a discovered device was matched to a managed CI — strongest first. */
+export type BridgeMatchMethod = "serial" | "asset_tag" | "model";
+
+export type BridgeMatch = {
+  inventoryEntityId: string;
+  configurationItemId: string;
+  method: BridgeMatchMethod;
+  confidence: number;
+};
+
+const CONFIDENCE: Record<BridgeMatchMethod, number> = {
+  serial: 0.99,
+  asset_tag: 0.95,
+  model: 0.8,
+};
+
+function norm(value: string | null | undefined): string {
+  return (value ?? "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function propString(props: Record<string, unknown> | null | undefined, ...keys: string[]): string | null {
+  if (!props) return null;
+  for (const k of keys) {
+    const v = props[k];
+    if (typeof v === "string" && v.trim() !== "") return v.trim();
+  }
+  return null;
+}
+
+/** True when the two rows can legally be the same physical asset: same account, and — when
+ *  BOTH name a site — the same site. A missing site on either side allows an account-level
+ *  match (a discovered device not yet site-attributed can still be a managed CI). */
+function scopeCompatible(entity: BridgeInventoryEntity, cci: BridgeConfigurationItem): boolean {
+  if (entity.customerAccountId === null || entity.customerAccountId !== cci.accountId) return false;
+  if (entity.customerSiteId && cci.siteId && entity.customerSiteId !== cci.siteId) return false;
+  return true;
+}
+
+/**
+ * Best match for one discovered device among a set of managed CIs, or null. Precedence:
+ * serial (exact) → asset tag (exact) → manufacturer+model (normalized). Weaker-than-model
+ * signals do NOT match — a false link is worse than an unmatched device (fail-closed).
+ * Never crosses customer/site scope.
+ */
+export function matchInventoryEntityToCci(
+  entity: BridgeInventoryEntity,
+  ccis: BridgeConfigurationItem[],
+): BridgeMatch | null {
+  const candidates = ccis.filter((c) => scopeCompatible(entity, c));
+  if (candidates.length === 0) return null;
+
+  const entitySerial = propString(entity.properties, "serialNumber", "serial");
+  const entityAssetTag = propString(entity.properties, "assetTag", "asset_tag");
+  const entityVendor = norm(entity.manufacturer);
+  const entityModel = norm(entity.productModel) || norm(entity.name);
+
+  const make = (cci: BridgeConfigurationItem, method: BridgeMatchMethod): BridgeMatch => ({
+    inventoryEntityId: entity.id,
+    configurationItemId: cci.id,
+    method,
+    confidence: CONFIDENCE[method],
+  });
+
+  if (entitySerial) {
+    const bySerial = candidates.find((c) => c.serialNumber && norm(c.serialNumber) === norm(entitySerial));
+    if (bySerial) return make(bySerial, "serial");
+  }
+  if (entityAssetTag) {
+    const byTag = candidates.find((c) => c.assetTag && norm(c.assetTag) === norm(entityAssetTag));
+    if (byTag) return make(byTag, "asset_tag");
+  }
+  if (entityVendor && entityModel) {
+    const byModel = candidates.find((c) => {
+      const cciVendor = norm(c.manufacturer) || norm(c.vendorName);
+      const cciModel = norm(c.productModel) || norm(c.productName);
+      return cciVendor === entityVendor && cciModel !== "" && (cciModel === entityModel || entityModel.includes(cciModel) || cciModel.includes(entityModel));
+    });
+    if (byModel) return make(byModel, "model");
+  }
+  return null;
+}
+
+export type EstateCorrelation = {
+  matches: BridgeMatch[];
+  /** Managed CIs that a discovered device corresponds to. */
+  managedAndDiscovered: number;
+  /** Managed CIs with no discovered device — undiscovered / offline / out-of-scope. */
+  managedNotDiscovered: number;
+  /** Discovered devices with no managed CI — shadow / unmanaged estate. */
+  discoveredNotManaged: number;
+};
+
+/**
+ * Correlate a customer account's discovered devices with its managed CIs. Each discovered
+ * device claims at most one CI (its best match); each CI is counted discovered once any
+ * device matches it. Read-only — the caller decides what to surface.
+ */
+export function correlateDiscoveryToEstate(
+  entities: BridgeInventoryEntity[],
+  ccis: BridgeConfigurationItem[],
+): EstateCorrelation {
+  const matches: BridgeMatch[] = [];
+  const matchedCcis = new Set<string>();
+  let discoveredNotManaged = 0;
+
+  for (const entity of entities) {
+    const match = matchInventoryEntityToCci(entity, ccis);
+    if (match) {
+      matches.push(match);
+      matchedCcis.add(match.configurationItemId);
+    } else {
+      discoveredNotManaged += 1;
+    }
+  }
+
+  return {
+    matches,
+    managedAndDiscovered: matchedCcis.size,
+    managedNotDiscovered: ccis.length - matchedCcis.size,
+    discoveredNotManaged,
+  };
+}


### PR DESCRIPTION
## What

HAM Phase D2 (spec §7). Bridges **discovered** devices (`InventoryEntity`) to **managed** customer equipment (`CustomerConfigurationItem`) so the customer-estate view answers *"which managed CIs do we actually see in discovery, and which discovered devices are unmanaged (shadow)?"* — directly serving the early-adopter customer-estate-management scenario.

**Kernel decision DI-56B99A37FA40** chose a **read-model matcher** over a nullable-FK / link-table persist (composite 8.0 vs 4.5 / 7.4): a fuzzy match must not be asserted authoritative without human confirmation (Human-in-the-Loop, Least-Privilege). So — **no authority move, no schema, no migration, no persistence.**

`packages/db/src/inventory-cci-bridge.ts` (pure, fixture-tested):
- **`matchInventoryEntityToCci`** — best match for a discovered device **within customer/site scope**, precedence serial → asset-tag → manufacturer+model. **Fail-closed below model** (a false link is worse than an unmatched device); never crosses account/site scope. Discovery collects no serial/asset-tag today, so matches are model-level and confidence-scored (0.8).
- **`correlateDiscoveryToEstate`** — buckets an account into `managedAndDiscovered` / `managedNotDiscovered` / `discoveredNotManaged` (shadow), read-only.

Surfaced on the customer-estate summary (`loadCustomerEstateSummary.discoveryCorrelation`): loads the account's `InventoryEntity` rows alongside its CIs and correlates at read time.

## Follow-ups (deliberate, D2)
Persisting a **confirmed** link (a link table + human-confirmation workflow) once match quality is validated; a serial/GUID collector to raise the match rate.

## Tests
`inventory-cci-bridge.test.ts` (serial/tag/model precedence, scope isolation, shadow bucketing) + `account-estate-summary.test.ts` (correlation surfaced; mock updated for the new `inventoryEntity` query + `correlateDiscoveryToEstate` export).

## Notes
Source-only worktree; CI is the verification gate. No schema/migration. No new file crosses the 800-LOC ceiling.

Design-Grounding-Decision: BI-828998DC — HAM Phase D2 InventoryEntity↔CCI read-model bridge (spec §7). Spec §7/§6 = design evidence; `inventory-cci-bridge.ts` + the estate-summary correlation = code evidence.

Process-Spine-Decision: the new bridge module is the read-model join the HAM spec §7 calls for; it reuses the existing customer-estate summary + both models' rows without moving authority or adding schema. HAM spec §6 doc updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)