### PR TITLE
feat(attention): reassuring caught-up empty state for the owner inbox

### DIFF
--- a/apps/web/components/attention/AttentionInbox.test.tsx
+++ b/apps/web/components/attention/AttentionInbox.test.tsx
@@ -28,6 +28,27 @@ function bill(): AttentionItem {
   };
 }
 
+function platformHealth(): AttentionItem {
+  return {
+    id: "platform-health:qdrant",
+    source: "platform-health",
+    title: "qdrant is offline",
+    context: "Vector store degraded",
+    decisionClass: { scorability: "unscorable" },
+    riskClass: "bounded-write",
+    triage: {
+      timeToAct: "none",
+      residueReason: "no-self-heal",
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: "2026-07-17T12:00:00.000Z",
+    actions: [{ kind: "open-in-context", label: "Open health", href: "/ops/health" }],
+    deepLink: "/ops/health",
+    audience: { operator: true },
+  };
+}
+
 describe("AttentionInbox", () => {
   it("renders the full owner projection without exposing the raw title by default", () => {
     const projection = buildOwnerAttentionProjection([bill()], {
@@ -42,5 +63,39 @@ describe("AttentionInbox", () => {
     expect(html).toContain("Approve this bill?");
     expect(html).not.toContain("Approve bill BILL-1");
     expect(html).not.toContain("Open in Operations");
+  });
+
+  it("shows a reassuring caught-up state when nothing needs the owner", () => {
+    const projection = buildOwnerAttentionProjection([], {
+      fallbackLevel: "balanced",
+      nowMs: Date.parse("2026-07-17T18:00:00Z"),
+    });
+    const html = renderToStaticMarkup(
+      <AttentionInbox projection={projection} failedSources={[]} />,
+    );
+
+    expect(html).toContain("0 things need you today");
+    expect(html).toContain("all caught up");
+    expect(html).not.toContain("Your digital team is handling");
+  });
+
+  it("names what the digital team is handling in the caught-up state", () => {
+    const projection = buildOwnerAttentionProjection([platformHealth()], {
+      fallbackLevel: "balanced",
+      nowMs: Date.parse("2026-07-17T18:00:00Z"),
+    });
+    // The technical item routes to the custodian lane, so the owner count is zero.
+    expect(projection.count).toBe(0);
+    expect(projection.custodian).toHaveLength(1);
+
+    const html = renderToStaticMarkup(
+      <AttentionInbox projection={projection} failedSources={[]} />,
+    );
+
+    expect(html).toContain("0 things need you today");
+    expect(html).toContain("all caught up");
+    expect(html).toContain("Your digital team is handling 1 item");
+    // The raw technical title is never surfaced to the owner.
+    expect(html).not.toContain("qdrant is offline");
   });
 });

--- a/apps/web/components/attention/AttentionInbox.tsx
+++ b/apps/web/components/attention/AttentionInbox.tsx
@@ -5,7 +5,11 @@ import type { OwnerAttentionProjection } from "@/lib/attention/owner-projection"
 import type { AttentionSource } from "@/lib/attention/types";
 import type { WeeklyDigestDisposition } from "@/lib/attention/weekly-digest-preferences";
 import { OwnerDecisionCards } from "./OwnerDecisionCards";
-import { DigitalTeamHandlingStrip, OwnerAttentionCount } from "./OwnerAttentionStatus";
+import {
+  DigitalTeamHandlingStrip,
+  OwnerAllCaughtUp,
+  OwnerAttentionCount,
+} from "./OwnerAttentionStatus";
 import { WeeklyDigestPanel } from "./WeeklyDigestPanel";
 
 export function AttentionInbox({
@@ -30,7 +34,12 @@ export function AttentionInbox({
       <div>
         <OwnerAttentionCount count={projection.count} />
         {projection.count === 0 ? (
-          <p className="mt-1 text-sm text-[var(--dpf-muted)]">Nothing needs you right now.</p>
+          <div className="mt-2">
+            <OwnerAllCaughtUp
+              handlingCount={projection.custodian.length}
+              examples={projection.custodian.slice(0, 3).map((entry) => entry.card.headline)}
+            />
+          </div>
         ) : (
           <p className="mt-1 max-w-2xl text-sm leading-relaxed text-[var(--dpf-muted)]">
             Review the business choices below. Open technical detail only when a builder or your
@@ -42,7 +51,7 @@ export function AttentionInbox({
       {projection.count > 0 ? <OwnerDecisionCards entries={projection.needsYouNow} /> : null}
 
       <DigitalTeamHandlingStrip
-        custodianCount={projection.custodian.length}
+        custodianCount={projection.count === 0 ? 0 : projection.custodian.length}
         digestCount={digestDisposition ? 0 : projection.weeklyDigest.length}
       />
 

--- a/apps/web/components/attention/OwnerAttentionStatus.tsx
+++ b/apps/web/components/attention/OwnerAttentionStatus.tsx
@@ -1,3 +1,37 @@
+export function OwnerAllCaughtUp({
+  handlingCount,
+  examples,
+}: {
+  handlingCount: number;
+  examples: string[];
+}) {
+  return (
+    <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-4">
+      <p className="text-sm font-semibold text-[var(--dpf-text)]">You&apos;re all caught up</p>
+      <p className="mt-1 text-sm text-[var(--dpf-muted)]">
+        Nothing needs a decision from you right now.
+      </p>
+      {handlingCount > 0 ? (
+        <div className="mt-3 border-t border-[var(--dpf-border)] pt-3">
+          <p className="text-xs font-semibold text-[var(--dpf-text)]">
+            Your digital team is handling {handlingCount} {handlingCount === 1 ? "item" : "items"} —
+            no action needed.
+          </p>
+          {examples.length > 0 ? (
+            <ul className="mt-1 space-y-1">
+              {examples.map((headline, index) => (
+                <li key={index} className="text-xs text-[var(--dpf-muted)]">
+                  — {headline}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export function OwnerAttentionCount({ count }: { count: number }) {
   return (
     <p className="text-sm font-semibold text-[var(--dpf-text)]">

--- a/docs/user-guide/workspace/attention-inbox.md
+++ b/docs/user-guide/workspace/attention-inbox.md
@@ -28,6 +28,7 @@ Folding "a human must decide this now" into the backlog is a category error: the
 - **Every card explains the decision.** The top of the card gives a short question, why it matters, what happens if you do nothing, the recommendation, and no more than three plain choices. It never invents a confidence score.
 - **Technical detail is preserved.** Open **Technical detail** to see the original title, source, work fields, linked identifiers, detection details, and builder actions. That information is moved one click down, not deleted.
 - **A projection, not another queue.** The inbox is a read-only view *over* each area's own records; it is not a second backlog or ticket tracker. Acting on an item updates the record in its home area.
+- **An empty inbox is a good day.** When nothing needs a decision, the inbox shows **"You're all caught up"** — and, when relevant, a short summary of what your digital team is handling on its own. An empty inbox is reassurance, not an unfinished list.
 
 ## What Shows Up Here
 


### PR DESCRIPTION
## What

`BI-5547A4F2` — the residual empty-state polish from the needs-you cognitive-load redesign.

When nothing needs the owner, the inbox showed a bare "Nothing needs you right now." This replaces it with a reassuring **"You're all caught up"** block that also names what the digital team is handling (a count plus up to three plain-language examples), so an empty inbox reads as a good day, not an idle/broken one.

Composes onto the merged redesign (#3212): reuses `OwnerAttentionProjection.custodian` entries and `OwnerAttentionStatus`. The custodian count moves into the caught-up block so the handling strip doesn't duplicate it.

## Design grounding

Extends `docs/superpowers/specs/2026-07-17-needs-you-cognitive-load-redesign-design.md` (deferred surface: empty state) and `BI-5547A4F2`. No contract change — a new presentational component plus wiring.

## Verification

Added two unit tests (empty projection → caught-up; custodian-only → "handling 1 item", raw title never surfaced). Local typecheck/unit run was blocked by a source-only worktree (no `next`/`vitest` binaries in available deps); the required CI **Typecheck** and **Unit Tests** gates verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)