### PR TITLE
fix(opencode): trim local task prompts to served context window (BI-B195F224)

### DIFF
--- a/apps/web/lib/integrate/opencode-dispatch.test.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.test.ts
@@ -18,11 +18,13 @@ import {
   detectOpencodeFatalError,
   buildOpencodeRunnerScript,
   recordOpencodeCapacityFailure,
+} from "./opencode-dispatch";
+import {
   estimatePromptTokens,
   computeInputTokenBudget,
   trimTaskPromptToContext,
   OPENCODE_OUTPUT_RESERVE_MIN_TOKENS,
-} from "./opencode-dispatch";
+} from "./opencode-task-context-budget";
 
 describe("trimTaskPromptToContext (BI-B195F224)", () => {
   const samplePrompt = [

--- a/apps/web/lib/integrate/opencode-dispatch.test.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.test.ts
@@ -18,7 +18,132 @@ import {
   detectOpencodeFatalError,
   buildOpencodeRunnerScript,
   recordOpencodeCapacityFailure,
+  estimatePromptTokens,
+  computeInputTokenBudget,
+  trimTaskPromptToContext,
+  OPENCODE_OUTPUT_RESERVE_MIN_TOKENS,
 } from "./opencode-dispatch";
+
+describe("trimTaskPromptToContext (BI-B195F224)", () => {
+  const samplePrompt = [
+    "You are a software engineer building Next.js server actions.",
+    "",
+    "PROJECT CONTEXT:",
+    "A".repeat(4_000),
+    "",
+    "RESULTS FROM PRIOR TASKS:",
+    "B".repeat(3_000),
+    "",
+    "DPF BUILD DISCIPLINE (MANDATORY):",
+    "- GROUND DOMAIN FACTS",
+    "",
+    "CRITICAL: This is a pnpm monorepo. Working directory is /workspace.",
+    "",
+    "TASK: Build accessible calendar grid component",
+    "",
+    "Implement the calendar grid with keyboard navigation.",
+    "",
+    "FILES (use these exact paths):",
+    "- apps/web/components/calendar-grid.tsx (create): accessible grid",
+    "",
+    "TEST FIRST: write vitest for keyboard nav",
+    "VERIFY: pnpm --filter web exec vitest run",
+  ].join("\n");
+
+  it("estimates ~chars/4", () => {
+    expect(estimatePromptTokens("abcd")).toBe(1);
+    expect(estimatePromptTokens("a".repeat(8))).toBe(2);
+  });
+
+  it("reserves output headroom inside the served window", () => {
+    // 131072 * 0.15 = 19660.8 → clamped to MAX 8192
+    const budget = computeInputTokenBudget(131_072);
+    expect(budget).toBe(131_072 - 8_192);
+    // tiny window: still leave MIN reserve, budget floored at MIN_INPUT
+    const small = computeInputTokenBudget(3_000);
+    expect(small).toBeGreaterThanOrEqual(OPENCODE_OUTPUT_RESERVE_MIN_TOKENS > 3_000 ? 1_024 : 3_000 - OPENCODE_OUTPUT_RESERVE_MIN_TOKENS);
+  });
+
+  it("passes through when served context is unknown", () => {
+    const res = trimTaskPromptToContext({ prompt: samplePrompt, servedContextTokens: null });
+    expect(res.fit).toBe(true);
+    expect(res.trimmed).toBe(false);
+    expect(res.prompt).toBe(samplePrompt);
+    expect(res.budgetTokens).toBeNull();
+  });
+
+  it("does not trim when the prompt already fits", () => {
+    const res = trimTaskPromptToContext({
+      prompt: samplePrompt,
+      servedContextTokens: 131_072,
+    });
+    expect(res.fit).toBe(true);
+    expect(res.trimmed).toBe(false);
+    expect(res.prompt).toBe(samplePrompt);
+    expect(res.estimatedTokens).toBeLessThanOrEqual(res.budgetTokens!);
+  });
+
+  it("trims prior results then project context to fit a tight local window", () => {
+    // Oversized soft context (~40k chars ≈ 10k tokens) vs a 4k-token input budget.
+    const bulky = [
+      "You are a software engineer.",
+      "",
+      "PROJECT CONTEXT:",
+      "P".repeat(20_000),
+      "",
+      "RESULTS FROM PRIOR TASKS:",
+      "R".repeat(20_000),
+      "",
+      "DPF BUILD DISCIPLINE (MANDATORY):",
+      "- GROUND DOMAIN FACTS",
+      "",
+      "CRITICAL: This is a pnpm monorepo. Working directory is /workspace.",
+      "",
+      "TASK: Build accessible calendar grid component",
+      "",
+      "Implement the calendar grid with keyboard navigation.",
+      "",
+      "FILES (use these exact paths):",
+      "- apps/web/components/calendar-grid.tsx (create): accessible grid",
+      "",
+      "TEST FIRST: write vitest for keyboard nav",
+      "VERIFY: pnpm --filter web exec vitest run",
+    ].join("\n");
+    const res = trimTaskPromptToContext({
+      prompt: bulky,
+      servedContextTokens: 5_000,
+      outputReserveTokens: 1_000, // budget = 4000 tokens ≈ 16k chars
+    });
+    expect(res.fit).toBe(true);
+    expect(res.trimmed).toBe(true);
+    expect(res.estimatedTokens).toBeLessThanOrEqual(res.budgetTokens!);
+    // Task core must survive
+    expect(res.prompt).toContain("CRITICAL:");
+    expect(res.prompt).toContain("TASK: Build accessible calendar grid component");
+    expect(res.prompt).toContain("calendar-grid.tsx");
+    // Soft bulk should be reduced
+    expect(res.prompt.length).toBeLessThan(bulky.length);
+    expect(res.prompt).toMatch(/trimmed to fit local model context window/i);
+  });
+
+  it("fails closed with an actionable message when the task core alone exceeds budget", () => {
+    const hugeCore = [
+      "ROLE preamble",
+      "",
+      "CRITICAL: monorepo root",
+      "TASK: impossible",
+      "X".repeat(20_000),
+    ].join("\n");
+    const res = trimTaskPromptToContext({
+      prompt: hugeCore,
+      servedContextTokens: 2_500,
+      outputReserveTokens: 1_000, // budget = 1500 tokens ≈ 6k chars; core is ~5k tokens
+    });
+    expect(res.fit).toBe(false);
+    expect(res.reason).toMatch(/exceeds the local model input budget/i);
+    expect(res.reason).toMatch(/cloud|context window/i);
+  });
+});
 
 describe("detectOpencodeFatalError", () => {
   it("detects a llama.cpp ContextOverflowError in the stream", () => {

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -42,6 +42,7 @@ import { resolveBuildWorkdir } from "./sandbox/build-branch";
 import { classifyProviderCapacity } from "@/lib/routing/provider-capacity";
 import { withLocalInferenceLock } from "@/lib/queue/resource-lane";
 import { recordProviderCapacityStatus } from "@/lib/routing/provider-capacity/store";
+import { formatTrimProgressMessage, trimTaskPromptToContext } from "./opencode-task-context-budget";
 
 const DEFAULT_SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 
@@ -52,21 +53,6 @@ const OPENCODE_SCHEMA_TASK_TIMEOUT_MS = Number(process.env.OPENCODE_SCHEMA_TASK_
 // outright. Advisory floor — /v1/models rarely exposes context length, so this
 // is enforced only when the endpoint reports it (see preflightLocalEndpoint).
 export const OPENCODE_MIN_CONTEXT_TOKENS = Number(process.env.OPENCODE_MIN_CONTEXT_TOKENS) || 22_000;
-
-// BI-B195F224 — local ContextOverflowError guard. When the endpoint reports a
-// served n_ctx, reserve headroom for model output + agent-loop overhead so the
-// assembled task prompt cannot push the request over the window mid-dispatch.
-// Heuristic ~chars/4 matches tak/context-pressure and context-economy-metrics.
-export const OPENCODE_CHARS_PER_TOKEN = 4;
-export const OPENCODE_OUTPUT_RESERVE_RATIO = 0.15;
-export const OPENCODE_OUTPUT_RESERVE_MIN_TOKENS = 2_048;
-export const OPENCODE_OUTPUT_RESERVE_MAX_TOKENS = 8_192;
-/** Minimum tokens left for the prompt after reserve (below this we fail early). */
-export const OPENCODE_MIN_INPUT_BUDGET_TOKENS = 1_024;
-
-const PRIOR_RESULTS_MARKER = "RESULTS FROM PRIOR TASKS:";
-const PROJECT_CONTEXT_MARKER = "PROJECT CONTEXT:";
-const TASK_CORE_MARKER = "CRITICAL:";
 
 export type OpencodeResult = {
   content: string;
@@ -277,205 +263,9 @@ type OpencodeDispatchTarget = OpencodeProviderConfigTarget & {
   apiKeyValue: string;
   portalBaseUrl: string;
   sandboxBaseUrl: string;
-  /**
-   * Served context window (tokens) for local/ollama preflight, when known.
-   * Used to trim the assembled task prompt before write (BI-B195F224).
-   * null/undefined for remote OpenCode providers or when the runtime omits it.
-   */
+  /** Served n_ctx for local preflight (BI-B195F224 trim); null when unknown. */
   servedContextTokens?: number | null;
 };
-
-/**
- * Rough prompt token estimate (~chars/4). Pure — matches the rest of the
- * context-economy surface so budgets are comparable across modules.
- */
-export function estimatePromptTokens(text: string): number {
-  if (!text) return 0;
-  return Math.ceil(text.length / OPENCODE_CHARS_PER_TOKEN);
-}
-
-/**
- * Input-token budget = served window minus output/overhead reserve.
- * Reserve scales with window size, clamped to [MIN, MAX].
- */
-export function computeInputTokenBudget(
-  servedContextTokens: number,
-  outputReserveTokens?: number,
-): number {
-  const reserve =
-    typeof outputReserveTokens === "number" && outputReserveTokens >= 0
-      ? outputReserveTokens
-      : Math.min(
-          OPENCODE_OUTPUT_RESERVE_MAX_TOKENS,
-          Math.max(
-            OPENCODE_OUTPUT_RESERVE_MIN_TOKENS,
-            Math.floor(servedContextTokens * OPENCODE_OUTPUT_RESERVE_RATIO),
-          ),
-        );
-  return Math.max(OPENCODE_MIN_INPUT_BUDGET_TOKENS, servedContextTokens - reserve);
-}
-
-export type TrimTaskPromptResult = {
-  prompt: string;
-  estimatedTokens: number;
-  budgetTokens: number | null;
-  trimmed: boolean;
-  /** false when even the task core cannot fit the budget */
-  fit: boolean;
-  reason: string | null;
-};
-
-function shrinkSectionBody(prompt: string, marker: string, targetBodyChars: number): string {
-  const idx = prompt.indexOf(marker);
-  if (idx < 0) return prompt;
-  const bodyStart = idx + marker.length;
-  // Body runs until the next double-newline block that starts a known header,
-  // or the CRITICAL task-core marker — keep structure intact.
-  const after = prompt.slice(bodyStart);
-  const nextHeaderMatch = after.search(
-    /\n\n(?:RESULTS FROM PRIOR TASKS:|DPF BUILD DISCIPLINE|CRITICAL:|TASK:)/,
-  );
-  const bodyEnd = nextHeaderMatch >= 0 ? bodyStart + nextHeaderMatch : prompt.length;
-  const body = prompt.slice(bodyStart, bodyEnd);
-  if (body.length <= targetBodyChars) return prompt;
-  const note =
-    targetBodyChars <= 0
-      ? "\n(omitted to fit local model context window)"
-      : `\n${body.slice(0, Math.max(0, targetBodyChars - 48)).trimEnd()}\n…(trimmed to fit local model context window)`;
-  return prompt.slice(0, bodyStart) + note + prompt.slice(bodyEnd);
-}
-
-/**
- * Fit an assembled specialist task prompt into the local model's served context
- * window (minus output reserve). Prefer trimming soft context first:
- *   1) RESULTS FROM PRIOR TASKS
- *   2) PROJECT CONTEXT
- * then hard-trim the pre-CRITICAL head if still over. Never drop the task core
- * (CRITICAL… through VERIFY); if that alone exceeds the budget, return fit:false
- * with an actionable "use cloud / raise context" message instead of a mid-run
- * ContextOverflowError (BI-B195F224).
- *
- * When servedContextTokens is null/undefined/<=0, the prompt is passed through
- * unchanged (remote OpenCode / unknown window).
- */
-export function trimTaskPromptToContext(params: {
-  prompt: string;
-  servedContextTokens: number | null | undefined;
-  outputReserveTokens?: number;
-}): TrimTaskPromptResult {
-  const prompt = params.prompt ?? "";
-  const estimated = estimatePromptTokens(prompt);
-  const served = params.servedContextTokens;
-
-  if (served == null || served <= 0) {
-    return {
-      prompt,
-      estimatedTokens: estimated,
-      budgetTokens: null,
-      trimmed: false,
-      fit: true,
-      reason: null,
-    };
-  }
-
-  const budget = computeInputTokenBudget(served, params.outputReserveTokens);
-  const budgetChars = budget * OPENCODE_CHARS_PER_TOKEN;
-
-  if (estimated <= budget) {
-    return {
-      prompt,
-      estimatedTokens: estimated,
-      budgetTokens: budget,
-      trimmed: false,
-      fit: true,
-      reason: null,
-    };
-  }
-
-  let next = prompt;
-  let trimmed = false;
-
-  // 1) Drop / shrink prior-results first (most disposable on later tasks).
-  if (estimatePromptTokens(next) > budget && next.includes(PRIOR_RESULTS_MARKER)) {
-    const overChars = estimatePromptTokens(next) * OPENCODE_CHARS_PER_TOKEN - budgetChars;
-    const idx = next.indexOf(PRIOR_RESULTS_MARKER);
-    const after = next.slice(idx + PRIOR_RESULTS_MARKER.length);
-    const nextHeaderMatch = after.search(/\n\n(?:DPF BUILD DISCIPLINE|CRITICAL:|TASK:)/);
-    const bodyLen = nextHeaderMatch >= 0 ? nextHeaderMatch : after.length;
-    const targetBody = Math.max(0, bodyLen - overChars - 64);
-    next = shrinkSectionBody(next, PRIOR_RESULTS_MARKER, targetBody);
-    trimmed = true;
-  }
-
-  // 2) Shrink PROJECT CONTEXT.
-  if (estimatePromptTokens(next) > budget && next.includes(PROJECT_CONTEXT_MARKER)) {
-    const overChars = estimatePromptTokens(next) * OPENCODE_CHARS_PER_TOKEN - budgetChars;
-    const idx = next.indexOf(PROJECT_CONTEXT_MARKER);
-    const after = next.slice(idx + PROJECT_CONTEXT_MARKER.length);
-    const nextHeaderMatch = after.search(
-      /\n\n(?:RESULTS FROM PRIOR TASKS:|DPF BUILD DISCIPLINE|CRITICAL:|TASK:)/,
-    );
-    const bodyLen = nextHeaderMatch >= 0 ? nextHeaderMatch : after.length;
-    const targetBody = Math.max(0, bodyLen - overChars - 64);
-    next = shrinkSectionBody(next, PROJECT_CONTEXT_MARKER, targetBody);
-    trimmed = true;
-  }
-
-  // 3) If still over, hard-trim the pre-CRITICAL head (role + discipline) while
-  // keeping the task core intact.
-  const coreIdx = next.indexOf(TASK_CORE_MARKER);
-  if (estimatePromptTokens(next) > budget && coreIdx > 0) {
-    const core = next.slice(coreIdx);
-    const coreTokens = estimatePromptTokens(core);
-    if (coreTokens >= budget) {
-      // Core alone does not fit — fail closed with an actionable message.
-      return {
-        prompt: next,
-        estimatedTokens: estimatePromptTokens(next),
-        budgetTokens: budget,
-        trimmed: true,
-        fit: false,
-        reason:
-          `Task prompt core (~${coreTokens} tokens) exceeds the local model input budget ` +
-          `(${budget} of ${served} served context tokens after output reserve). ` +
-          `Raise the local context window (Build Runtime > local model) or route this build to a cloud coding model.`,
-      };
-    }
-    const headBudgetChars = (budget - coreTokens) * OPENCODE_CHARS_PER_TOKEN;
-    const head = next.slice(0, coreIdx);
-    const keptHead =
-      headBudgetChars <= 80
-        ? "(role context trimmed to fit local model window)\n\n"
-        : `${head.slice(0, Math.max(0, headBudgetChars - 60)).trimEnd()}\n…(trimmed to fit local model context window)\n\n`;
-    next = keptHead + core;
-    trimmed = true;
-  }
-
-  const finalTokens = estimatePromptTokens(next);
-  if (finalTokens > budget) {
-    // No CRITICAL marker or still over after best-effort trim — fail early.
-    return {
-      prompt: next,
-      estimatedTokens: finalTokens,
-      budgetTokens: budget,
-      trimmed: true,
-      fit: false,
-      reason:
-        `Assembled task prompt (~${finalTokens} tokens) exceeds the local model input budget ` +
-        `(${budget} of ${served} served context tokens after output reserve). ` +
-        `Raise the local context window or route this build to a cloud coding model.`,
-    };
-  }
-
-  return {
-    prompt: next,
-    estimatedTokens: finalTokens,
-    budgetTokens: budget,
-    trimmed,
-    fit: true,
-    reason: null,
-  };
-}
 
 function localOpencodeTarget(sandboxBaseUrl: string, model: string): OpencodeProviderConfigTarget {
   return {
@@ -602,8 +392,6 @@ async function resolveOpencodeDispatchTarget(params: {
         apiKeyValue: "local",
         portalBaseUrl,
         sandboxBaseUrl,
-        // Prefer the authoritative DMR served window; fall back to /v1/models
-        // when the configure API is unavailable (BI-B195F224 trim path).
         servedContextTokens: pre.servedContextTokens ?? pre.reportedContextTokens ?? null,
       },
     };
@@ -703,12 +491,7 @@ export async function dispatchOpencodeTask(params: {
   const startedAt = new Date();
   const startMs = Date.now();
 
-  // Resolve the endpoint the PORTAL uses (for preflight) and the rewritten URL
-  // the SANDBOX uses (for the actual run).
-  // the SANDBOX uses (for the actual run). Local endpoints keep the hard
-  // preflight; credentialed remote OpenCode providers resolve through
-  // ModelProvider + CredentialEntry because their /models behavior can vary by
-  // account entitlement.
+  // Local: hard preflight. Remote OpenCode: ModelProvider + CredentialEntry.
   const targetResult = await resolveOpencodeDispatchTarget({
     providerId,
     requestedModel: params.model ?? "",
@@ -739,51 +522,25 @@ export async function dispatchOpencodeTask(params: {
   }
 
   const instructions = buildOpencodeInstructions(role, buildContext, priorResults);
-  const assembledPrompt = buildSpecialistTaskPrompt({ task, instructions, workdir });
-  // BI-B195F224: when the local endpoint reports a served window, trim soft
-  // context (prior results / project context) so the request stays under n_ctx
-  // with output reserve — or fail early with an actionable message instead of a
-  // mid-run ContextOverflowError.
+  // BI-B195F224: trim soft context to served n_ctx (or fail early with action).
   const fitted = trimTaskPromptToContext({
-    prompt: assembledPrompt,
+    prompt: buildSpecialistTaskPrompt({ task, instructions, workdir }),
     servedContextTokens: target.servedContextTokens,
   });
   if (!fitted.fit) {
     const blocked = fitted.reason ?? "Task prompt exceeds local model context window.";
-    console.error(
-      sanitizeForLog(`[opencode-dispatch] Task "${task.title}" blocked: ${blocked}`),
-    );
+    console.error(sanitizeForLog(`[opencode-dispatch] Task "${task.title}" blocked: ${blocked}`));
     await recordBuildDispatchAttempt({
-      buildId: params.buildId,
-      taskTitle: task.title,
-      specialist: role,
-      providerId,
-      model,
-      startedAt,
-      completedAt: new Date(),
-      durationMs: Date.now() - startMs,
-      exitCode: null,
-      success: false,
-      stdout: "",
-      stderr: blocked,
+      buildId: params.buildId, taskTitle: task.title, specialist: role, providerId, model,
+      startedAt, completedAt: new Date(), durationMs: Date.now() - startMs,
+      exitCode: null, success: false, stdout: "", stderr: blocked,
     }).catch(() => {});
-    return {
-      content: `BLOCKED: ${blocked}`,
-      success: false,
-      executedTools: [],
-      durationMs: Date.now() - startMs,
-    };
+    return { content: `BLOCKED: ${blocked}`, success: false, executedTools: [], durationMs: Date.now() - startMs };
   }
   if (fitted.trimmed) {
-    console.log(
-      sanitizeForLog(
-        `[opencode-dispatch] Trimmed task context for "${task.title}" to fit local window ` +
-          `(~${fitted.estimatedTokens}/${fitted.budgetTokens} input tokens; served=${target.servedContextTokens})`,
-      ),
-    );
-    params.onProgress?.(
-      `Trimmed task context to fit local model window (~${fitted.estimatedTokens}/${fitted.budgetTokens} tokens)`,
-    );
+    const msg = formatTrimProgressMessage(fitted, target.servedContextTokens);
+    console.log(sanitizeForLog(`[opencode-dispatch] ${msg} task=${JSON.stringify(task.title)}`));
+    params.onProgress?.(msg);
   }
   const taskPrompt = fitted.prompt;
 

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -529,7 +529,12 @@ export async function dispatchOpencodeTask(params: {
   });
   if (!fitted.fit) {
     const blocked = fitted.reason ?? "Task prompt exceeds local model context window.";
-    console.error(sanitizeForLog(`[opencode-dispatch] Task "${task.title}" blocked: ${blocked}`));
+    // task.title is operator/BI-authored (CWE-117); sanitize each arg before log.
+    console.error(
+      "[opencode-dispatch] Task %s blocked: %s",
+      sanitizeForLog(task.title),
+      sanitizeForLog(blocked),
+    );
     await recordBuildDispatchAttempt({
       buildId: params.buildId, taskTitle: task.title, specialist: role, providerId, model,
       startedAt, completedAt: new Date(), durationMs: Date.now() - startMs,
@@ -539,7 +544,11 @@ export async function dispatchOpencodeTask(params: {
   }
   if (fitted.trimmed) {
     const msg = formatTrimProgressMessage(fitted, target.servedContextTokens);
-    console.log(sanitizeForLog(`[opencode-dispatch] ${msg} task=${JSON.stringify(task.title)}`));
+    console.log(
+      "[opencode-dispatch] %s task=%s",
+      sanitizeForLog(msg),
+      sanitizeForLog(task.title),
+    );
     params.onProgress?.(msg);
   }
   const taskPrompt = fitted.prompt;

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -522,19 +522,14 @@ export async function dispatchOpencodeTask(params: {
   }
 
   const instructions = buildOpencodeInstructions(role, buildContext, priorResults);
-  // BI-B195F224: trim soft context to served n_ctx (or fail early with action).
+  // BI-B195F224: trim to served n_ctx or fail early (CWE-117: sanitize log args).
   const fitted = trimTaskPromptToContext({
     prompt: buildSpecialistTaskPrompt({ task, instructions, workdir }),
     servedContextTokens: target.servedContextTokens,
   });
   if (!fitted.fit) {
     const blocked = fitted.reason ?? "Task prompt exceeds local model context window.";
-    // task.title is operator/BI-authored (CWE-117); sanitize each arg before log.
-    console.error(
-      "[opencode-dispatch] Task %s blocked: %s",
-      sanitizeForLog(task.title),
-      sanitizeForLog(blocked),
-    );
+    console.error("[opencode-dispatch] Task %s blocked: %s", sanitizeForLog(task.title), sanitizeForLog(blocked));
     await recordBuildDispatchAttempt({
       buildId: params.buildId, taskTitle: task.title, specialist: role, providerId, model,
       startedAt, completedAt: new Date(), durationMs: Date.now() - startMs,
@@ -544,11 +539,7 @@ export async function dispatchOpencodeTask(params: {
   }
   if (fitted.trimmed) {
     const msg = formatTrimProgressMessage(fitted, target.servedContextTokens);
-    console.log(
-      "[opencode-dispatch] %s task=%s",
-      sanitizeForLog(msg),
-      sanitizeForLog(task.title),
-    );
+    console.log("[opencode-dispatch] %s task=%s", sanitizeForLog(msg), sanitizeForLog(task.title));
     params.onProgress?.(msg);
   }
   const taskPrompt = fitted.prompt;

--- a/apps/web/lib/integrate/opencode-dispatch.ts
+++ b/apps/web/lib/integrate/opencode-dispatch.ts
@@ -53,6 +53,21 @@ const OPENCODE_SCHEMA_TASK_TIMEOUT_MS = Number(process.env.OPENCODE_SCHEMA_TASK_
 // is enforced only when the endpoint reports it (see preflightLocalEndpoint).
 export const OPENCODE_MIN_CONTEXT_TOKENS = Number(process.env.OPENCODE_MIN_CONTEXT_TOKENS) || 22_000;
 
+// BI-B195F224 — local ContextOverflowError guard. When the endpoint reports a
+// served n_ctx, reserve headroom for model output + agent-loop overhead so the
+// assembled task prompt cannot push the request over the window mid-dispatch.
+// Heuristic ~chars/4 matches tak/context-pressure and context-economy-metrics.
+export const OPENCODE_CHARS_PER_TOKEN = 4;
+export const OPENCODE_OUTPUT_RESERVE_RATIO = 0.15;
+export const OPENCODE_OUTPUT_RESERVE_MIN_TOKENS = 2_048;
+export const OPENCODE_OUTPUT_RESERVE_MAX_TOKENS = 8_192;
+/** Minimum tokens left for the prompt after reserve (below this we fail early). */
+export const OPENCODE_MIN_INPUT_BUDGET_TOKENS = 1_024;
+
+const PRIOR_RESULTS_MARKER = "RESULTS FROM PRIOR TASKS:";
+const PROJECT_CONTEXT_MARKER = "PROJECT CONTEXT:";
+const TASK_CORE_MARKER = "CRITICAL:";
+
 export type OpencodeResult = {
   content: string;
   success: boolean;
@@ -262,7 +277,205 @@ type OpencodeDispatchTarget = OpencodeProviderConfigTarget & {
   apiKeyValue: string;
   portalBaseUrl: string;
   sandboxBaseUrl: string;
+  /**
+   * Served context window (tokens) for local/ollama preflight, when known.
+   * Used to trim the assembled task prompt before write (BI-B195F224).
+   * null/undefined for remote OpenCode providers or when the runtime omits it.
+   */
+  servedContextTokens?: number | null;
 };
+
+/**
+ * Rough prompt token estimate (~chars/4). Pure — matches the rest of the
+ * context-economy surface so budgets are comparable across modules.
+ */
+export function estimatePromptTokens(text: string): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / OPENCODE_CHARS_PER_TOKEN);
+}
+
+/**
+ * Input-token budget = served window minus output/overhead reserve.
+ * Reserve scales with window size, clamped to [MIN, MAX].
+ */
+export function computeInputTokenBudget(
+  servedContextTokens: number,
+  outputReserveTokens?: number,
+): number {
+  const reserve =
+    typeof outputReserveTokens === "number" && outputReserveTokens >= 0
+      ? outputReserveTokens
+      : Math.min(
+          OPENCODE_OUTPUT_RESERVE_MAX_TOKENS,
+          Math.max(
+            OPENCODE_OUTPUT_RESERVE_MIN_TOKENS,
+            Math.floor(servedContextTokens * OPENCODE_OUTPUT_RESERVE_RATIO),
+          ),
+        );
+  return Math.max(OPENCODE_MIN_INPUT_BUDGET_TOKENS, servedContextTokens - reserve);
+}
+
+export type TrimTaskPromptResult = {
+  prompt: string;
+  estimatedTokens: number;
+  budgetTokens: number | null;
+  trimmed: boolean;
+  /** false when even the task core cannot fit the budget */
+  fit: boolean;
+  reason: string | null;
+};
+
+function shrinkSectionBody(prompt: string, marker: string, targetBodyChars: number): string {
+  const idx = prompt.indexOf(marker);
+  if (idx < 0) return prompt;
+  const bodyStart = idx + marker.length;
+  // Body runs until the next double-newline block that starts a known header,
+  // or the CRITICAL task-core marker — keep structure intact.
+  const after = prompt.slice(bodyStart);
+  const nextHeaderMatch = after.search(
+    /\n\n(?:RESULTS FROM PRIOR TASKS:|DPF BUILD DISCIPLINE|CRITICAL:|TASK:)/,
+  );
+  const bodyEnd = nextHeaderMatch >= 0 ? bodyStart + nextHeaderMatch : prompt.length;
+  const body = prompt.slice(bodyStart, bodyEnd);
+  if (body.length <= targetBodyChars) return prompt;
+  const note =
+    targetBodyChars <= 0
+      ? "\n(omitted to fit local model context window)"
+      : `\n${body.slice(0, Math.max(0, targetBodyChars - 48)).trimEnd()}\n…(trimmed to fit local model context window)`;
+  return prompt.slice(0, bodyStart) + note + prompt.slice(bodyEnd);
+}
+
+/**
+ * Fit an assembled specialist task prompt into the local model's served context
+ * window (minus output reserve). Prefer trimming soft context first:
+ *   1) RESULTS FROM PRIOR TASKS
+ *   2) PROJECT CONTEXT
+ * then hard-trim the pre-CRITICAL head if still over. Never drop the task core
+ * (CRITICAL… through VERIFY); if that alone exceeds the budget, return fit:false
+ * with an actionable "use cloud / raise context" message instead of a mid-run
+ * ContextOverflowError (BI-B195F224).
+ *
+ * When servedContextTokens is null/undefined/<=0, the prompt is passed through
+ * unchanged (remote OpenCode / unknown window).
+ */
+export function trimTaskPromptToContext(params: {
+  prompt: string;
+  servedContextTokens: number | null | undefined;
+  outputReserveTokens?: number;
+}): TrimTaskPromptResult {
+  const prompt = params.prompt ?? "";
+  const estimated = estimatePromptTokens(prompt);
+  const served = params.servedContextTokens;
+
+  if (served == null || served <= 0) {
+    return {
+      prompt,
+      estimatedTokens: estimated,
+      budgetTokens: null,
+      trimmed: false,
+      fit: true,
+      reason: null,
+    };
+  }
+
+  const budget = computeInputTokenBudget(served, params.outputReserveTokens);
+  const budgetChars = budget * OPENCODE_CHARS_PER_TOKEN;
+
+  if (estimated <= budget) {
+    return {
+      prompt,
+      estimatedTokens: estimated,
+      budgetTokens: budget,
+      trimmed: false,
+      fit: true,
+      reason: null,
+    };
+  }
+
+  let next = prompt;
+  let trimmed = false;
+
+  // 1) Drop / shrink prior-results first (most disposable on later tasks).
+  if (estimatePromptTokens(next) > budget && next.includes(PRIOR_RESULTS_MARKER)) {
+    const overChars = estimatePromptTokens(next) * OPENCODE_CHARS_PER_TOKEN - budgetChars;
+    const idx = next.indexOf(PRIOR_RESULTS_MARKER);
+    const after = next.slice(idx + PRIOR_RESULTS_MARKER.length);
+    const nextHeaderMatch = after.search(/\n\n(?:DPF BUILD DISCIPLINE|CRITICAL:|TASK:)/);
+    const bodyLen = nextHeaderMatch >= 0 ? nextHeaderMatch : after.length;
+    const targetBody = Math.max(0, bodyLen - overChars - 64);
+    next = shrinkSectionBody(next, PRIOR_RESULTS_MARKER, targetBody);
+    trimmed = true;
+  }
+
+  // 2) Shrink PROJECT CONTEXT.
+  if (estimatePromptTokens(next) > budget && next.includes(PROJECT_CONTEXT_MARKER)) {
+    const overChars = estimatePromptTokens(next) * OPENCODE_CHARS_PER_TOKEN - budgetChars;
+    const idx = next.indexOf(PROJECT_CONTEXT_MARKER);
+    const after = next.slice(idx + PROJECT_CONTEXT_MARKER.length);
+    const nextHeaderMatch = after.search(
+      /\n\n(?:RESULTS FROM PRIOR TASKS:|DPF BUILD DISCIPLINE|CRITICAL:|TASK:)/,
+    );
+    const bodyLen = nextHeaderMatch >= 0 ? nextHeaderMatch : after.length;
+    const targetBody = Math.max(0, bodyLen - overChars - 64);
+    next = shrinkSectionBody(next, PROJECT_CONTEXT_MARKER, targetBody);
+    trimmed = true;
+  }
+
+  // 3) If still over, hard-trim the pre-CRITICAL head (role + discipline) while
+  // keeping the task core intact.
+  const coreIdx = next.indexOf(TASK_CORE_MARKER);
+  if (estimatePromptTokens(next) > budget && coreIdx > 0) {
+    const core = next.slice(coreIdx);
+    const coreTokens = estimatePromptTokens(core);
+    if (coreTokens >= budget) {
+      // Core alone does not fit — fail closed with an actionable message.
+      return {
+        prompt: next,
+        estimatedTokens: estimatePromptTokens(next),
+        budgetTokens: budget,
+        trimmed: true,
+        fit: false,
+        reason:
+          `Task prompt core (~${coreTokens} tokens) exceeds the local model input budget ` +
+          `(${budget} of ${served} served context tokens after output reserve). ` +
+          `Raise the local context window (Build Runtime > local model) or route this build to a cloud coding model.`,
+      };
+    }
+    const headBudgetChars = (budget - coreTokens) * OPENCODE_CHARS_PER_TOKEN;
+    const head = next.slice(0, coreIdx);
+    const keptHead =
+      headBudgetChars <= 80
+        ? "(role context trimmed to fit local model window)\n\n"
+        : `${head.slice(0, Math.max(0, headBudgetChars - 60)).trimEnd()}\n…(trimmed to fit local model context window)\n\n`;
+    next = keptHead + core;
+    trimmed = true;
+  }
+
+  const finalTokens = estimatePromptTokens(next);
+  if (finalTokens > budget) {
+    // No CRITICAL marker or still over after best-effort trim — fail early.
+    return {
+      prompt: next,
+      estimatedTokens: finalTokens,
+      budgetTokens: budget,
+      trimmed: true,
+      fit: false,
+      reason:
+        `Assembled task prompt (~${finalTokens} tokens) exceeds the local model input budget ` +
+        `(${budget} of ${served} served context tokens after output reserve). ` +
+        `Raise the local context window or route this build to a cloud coding model.`,
+    };
+  }
+
+  return {
+    prompt: next,
+    estimatedTokens: finalTokens,
+    budgetTokens: budget,
+    trimmed,
+    fit: true,
+    reason: null,
+  };
+}
 
 function localOpencodeTarget(sandboxBaseUrl: string, model: string): OpencodeProviderConfigTarget {
   return {
@@ -389,6 +602,9 @@ async function resolveOpencodeDispatchTarget(params: {
         apiKeyValue: "local",
         portalBaseUrl,
         sandboxBaseUrl,
+        // Prefer the authoritative DMR served window; fall back to /v1/models
+        // when the configure API is unavailable (BI-B195F224 trim path).
+        servedContextTokens: pre.servedContextTokens ?? pre.reportedContextTokens ?? null,
       },
     };
   }
@@ -523,7 +739,53 @@ export async function dispatchOpencodeTask(params: {
   }
 
   const instructions = buildOpencodeInstructions(role, buildContext, priorResults);
-  const taskPrompt = buildSpecialistTaskPrompt({ task, instructions, workdir });
+  const assembledPrompt = buildSpecialistTaskPrompt({ task, instructions, workdir });
+  // BI-B195F224: when the local endpoint reports a served window, trim soft
+  // context (prior results / project context) so the request stays under n_ctx
+  // with output reserve — or fail early with an actionable message instead of a
+  // mid-run ContextOverflowError.
+  const fitted = trimTaskPromptToContext({
+    prompt: assembledPrompt,
+    servedContextTokens: target.servedContextTokens,
+  });
+  if (!fitted.fit) {
+    const blocked = fitted.reason ?? "Task prompt exceeds local model context window.";
+    console.error(
+      sanitizeForLog(`[opencode-dispatch] Task "${task.title}" blocked: ${blocked}`),
+    );
+    await recordBuildDispatchAttempt({
+      buildId: params.buildId,
+      taskTitle: task.title,
+      specialist: role,
+      providerId,
+      model,
+      startedAt,
+      completedAt: new Date(),
+      durationMs: Date.now() - startMs,
+      exitCode: null,
+      success: false,
+      stdout: "",
+      stderr: blocked,
+    }).catch(() => {});
+    return {
+      content: `BLOCKED: ${blocked}`,
+      success: false,
+      executedTools: [],
+      durationMs: Date.now() - startMs,
+    };
+  }
+  if (fitted.trimmed) {
+    console.log(
+      sanitizeForLog(
+        `[opencode-dispatch] Trimmed task context for "${task.title}" to fit local window ` +
+          `(~${fitted.estimatedTokens}/${fitted.budgetTokens} input tokens; served=${target.servedContextTokens})`,
+      ),
+    );
+    params.onProgress?.(
+      `Trimmed task context to fit local model window (~${fitted.estimatedTokens}/${fitted.budgetTokens} tokens)`,
+    );
+  }
+  const taskPrompt = fitted.prompt;
 
   try {
     // Write the opencode provider config for the node user (global path, applies

--- a/apps/web/lib/integrate/opencode-task-context-budget.ts
+++ b/apps/web/lib/integrate/opencode-task-context-budget.ts
@@ -1,0 +1,215 @@
+// apps/web/lib/integrate/opencode-task-context-budget.ts
+//
+// Pure helpers that fit an assembled OpenCode specialist task prompt into the
+// local model's served context window (BI-B195F224). Kept in its own module so
+// opencode-dispatch stays under the module-size hard cap and does not become a
+// new production hotspot.
+
+// Heuristic ~chars/4 matches tak/context-pressure and context-economy-metrics.
+export const OPENCODE_CHARS_PER_TOKEN = 4;
+export const OPENCODE_OUTPUT_RESERVE_RATIO = 0.15;
+export const OPENCODE_OUTPUT_RESERVE_MIN_TOKENS = 2_048;
+export const OPENCODE_OUTPUT_RESERVE_MAX_TOKENS = 8_192;
+/** Minimum tokens left for the prompt after reserve (below this we fail early). */
+export const OPENCODE_MIN_INPUT_BUDGET_TOKENS = 1_024;
+
+const PRIOR_RESULTS_MARKER = "RESULTS FROM PRIOR TASKS:";
+const PROJECT_CONTEXT_MARKER = "PROJECT CONTEXT:";
+const TASK_CORE_MARKER = "CRITICAL:";
+
+/**
+ * Rough prompt token estimate (~chars/4). Pure — matches the rest of the
+ * context-economy surface so budgets are comparable across modules.
+ */
+export function estimatePromptTokens(text: string): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / OPENCODE_CHARS_PER_TOKEN);
+}
+
+/**
+ * Input-token budget = served window minus output/overhead reserve.
+ * Reserve scales with window size, clamped to [MIN, MAX].
+ */
+export function computeInputTokenBudget(
+  servedContextTokens: number,
+  outputReserveTokens?: number,
+): number {
+  const reserve =
+    typeof outputReserveTokens === "number" && outputReserveTokens >= 0
+      ? outputReserveTokens
+      : Math.min(
+          OPENCODE_OUTPUT_RESERVE_MAX_TOKENS,
+          Math.max(
+            OPENCODE_OUTPUT_RESERVE_MIN_TOKENS,
+            Math.floor(servedContextTokens * OPENCODE_OUTPUT_RESERVE_RATIO),
+          ),
+        );
+  return Math.max(OPENCODE_MIN_INPUT_BUDGET_TOKENS, servedContextTokens - reserve);
+}
+
+export type TrimTaskPromptResult = {
+  prompt: string;
+  estimatedTokens: number;
+  budgetTokens: number | null;
+  trimmed: boolean;
+  /** false when even the task core cannot fit the budget */
+  fit: boolean;
+  reason: string | null;
+};
+
+function shrinkSectionBody(prompt: string, marker: string, targetBodyChars: number): string {
+  const idx = prompt.indexOf(marker);
+  if (idx < 0) return prompt;
+  const bodyStart = idx + marker.length;
+  // Body runs until the next double-newline block that starts a known header,
+  // or the CRITICAL task-core marker — keep structure intact.
+  const after = prompt.slice(bodyStart);
+  const nextHeaderMatch = after.search(
+    /\n\n(?:RESULTS FROM PRIOR TASKS:|DPF BUILD DISCIPLINE|CRITICAL:|TASK:)/,
+  );
+  const bodyEnd = nextHeaderMatch >= 0 ? bodyStart + nextHeaderMatch : prompt.length;
+  const body = prompt.slice(bodyStart, bodyEnd);
+  if (body.length <= targetBodyChars) return prompt;
+  const note =
+    targetBodyChars <= 0
+      ? "\n(omitted to fit local model context window)"
+      : `\n${body.slice(0, Math.max(0, targetBodyChars - 48)).trimEnd()}\n…(trimmed to fit local model context window)`;
+  return prompt.slice(0, bodyStart) + note + prompt.slice(bodyEnd);
+}
+
+/**
+ * Fit an assembled specialist task prompt into the local model's served context
+ * window (minus output reserve). Prefer trimming soft context first:
+ *   1) RESULTS FROM PRIOR TASKS
+ *   2) PROJECT CONTEXT
+ * then hard-trim the pre-CRITICAL head if still over. Never drop the task core
+ * (CRITICAL… through VERIFY); if that alone exceeds the budget, return fit:false
+ * with an actionable "use cloud / raise context" message instead of a mid-run
+ * ContextOverflowError (BI-B195F224).
+ *
+ * When servedContextTokens is null/undefined/<=0, the prompt is passed through
+ * unchanged (remote OpenCode / unknown window).
+ */
+export function trimTaskPromptToContext(params: {
+  prompt: string;
+  servedContextTokens: number | null | undefined;
+  outputReserveTokens?: number;
+}): TrimTaskPromptResult {
+  const prompt = params.prompt ?? "";
+  const estimated = estimatePromptTokens(prompt);
+  const served = params.servedContextTokens;
+
+  if (served == null || served <= 0) {
+    return {
+      prompt,
+      estimatedTokens: estimated,
+      budgetTokens: null,
+      trimmed: false,
+      fit: true,
+      reason: null,
+    };
+  }
+
+  const budget = computeInputTokenBudget(served, params.outputReserveTokens);
+  const budgetChars = budget * OPENCODE_CHARS_PER_TOKEN;
+
+  if (estimated <= budget) {
+    return {
+      prompt,
+      estimatedTokens: estimated,
+      budgetTokens: budget,
+      trimmed: false,
+      fit: true,
+      reason: null,
+    };
+  }
+
+  let next = prompt;
+  let trimmed = false;
+
+  // 1) Drop / shrink prior-results first (most disposable on later tasks).
+  if (estimatePromptTokens(next) > budget && next.includes(PRIOR_RESULTS_MARKER)) {
+    const overChars = estimatePromptTokens(next) * OPENCODE_CHARS_PER_TOKEN - budgetChars;
+    const idx = next.indexOf(PRIOR_RESULTS_MARKER);
+    const after = next.slice(idx + PRIOR_RESULTS_MARKER.length);
+    const nextHeaderMatch = after.search(/\n\n(?:DPF BUILD DISCIPLINE|CRITICAL:|TASK:)/);
+    const bodyLen = nextHeaderMatch >= 0 ? nextHeaderMatch : after.length;
+    const targetBody = Math.max(0, bodyLen - overChars - 64);
+    next = shrinkSectionBody(next, PRIOR_RESULTS_MARKER, targetBody);
+    trimmed = true;
+  }
+
+  // 2) Shrink PROJECT CONTEXT.
+  if (estimatePromptTokens(next) > budget && next.includes(PROJECT_CONTEXT_MARKER)) {
+    const overChars = estimatePromptTokens(next) * OPENCODE_CHARS_PER_TOKEN - budgetChars;
+    const idx = next.indexOf(PROJECT_CONTEXT_MARKER);
+    const after = next.slice(idx + PROJECT_CONTEXT_MARKER.length);
+    const nextHeaderMatch = after.search(
+      /\n\n(?:RESULTS FROM PRIOR TASKS:|DPF BUILD DISCIPLINE|CRITICAL:|TASK:)/,
+    );
+    const bodyLen = nextHeaderMatch >= 0 ? nextHeaderMatch : after.length;
+    const targetBody = Math.max(0, bodyLen - overChars - 64);
+    next = shrinkSectionBody(next, PROJECT_CONTEXT_MARKER, targetBody);
+    trimmed = true;
+  }
+
+  // 3) If still over, hard-trim the pre-CRITICAL head (role + discipline) while
+  // keeping the task core intact.
+  const coreIdx = next.indexOf(TASK_CORE_MARKER);
+  if (estimatePromptTokens(next) > budget && coreIdx > 0) {
+    const core = next.slice(coreIdx);
+    const coreTokens = estimatePromptTokens(core);
+    if (coreTokens >= budget) {
+      // Core alone does not fit — fail closed with an actionable message.
+      return {
+        prompt: next,
+        estimatedTokens: estimatePromptTokens(next),
+        budgetTokens: budget,
+        trimmed: true,
+        fit: false,
+        reason:
+          `Task prompt core (~${coreTokens} tokens) exceeds the local model input budget ` +
+          `(${budget} of ${served} served context tokens after output reserve). ` +
+          `Raise the local context window (Build Runtime > local model) or route this build to a cloud coding model.`,
+      };
+    }
+    const headBudgetChars = (budget - coreTokens) * OPENCODE_CHARS_PER_TOKEN;
+    const head = next.slice(0, coreIdx);
+    const keptHead =
+      headBudgetChars <= 80
+        ? "(role context trimmed to fit local model window)\n\n"
+        : `${head.slice(0, Math.max(0, headBudgetChars - 60)).trimEnd()}\n…(trimmed to fit local model context window)\n\n`;
+    next = keptHead + core;
+    trimmed = true;
+  }
+
+  const finalTokens = estimatePromptTokens(next);
+  if (finalTokens > budget) {
+    // No CRITICAL marker or still over after best-effort trim — fail early.
+    return {
+      prompt: next,
+      estimatedTokens: finalTokens,
+      budgetTokens: budget,
+      trimmed: true,
+      fit: false,
+      reason:
+        `Assembled task prompt (~${finalTokens} tokens) exceeds the local model input budget ` +
+        `(${budget} of ${served} served context tokens after output reserve). ` +
+        `Raise the local context window or route this build to a cloud coding model.`,
+    };
+  }
+
+  return {
+    prompt: next,
+    estimatedTokens: finalTokens,
+    budgetTokens: budget,
+    trimmed,
+    fit: true,
+    reason: null,
+  };
+}
+
+/** One-line log/progress summary when a prompt was trimmed to fit. */
+export function formatTrimProgressMessage(fitted: TrimTaskPromptResult, served: number | null | undefined): string {
+  return `Trimmed task context to fit local model window (~${fitted.estimatedTokens}/${fitted.budgetTokens} tokens; served=${served ?? "?"})`;
+}


### PR DESCRIPTION
## Summary
- Local OpenCode dispatch now trims assembled specialist task prompts to the endpoint's **served context window** (minus output reserve) before writing the prompt file, fixing mid-task `ContextOverflowError` on all-local medium builds (BI-B195F224).
- Soft context is trimmed first (`RESULTS FROM PRIOR TASKS`, then `PROJECT CONTEXT`); the task core (`CRITICAL`…`VERIFY`) is preserved. If the core alone cannot fit, dispatch fails early with an actionable raise-window / use-cloud message instead of a silent fatal.
- Pure helpers (`estimatePromptTokens`, `computeInputTokenBudget`, `trimTaskPromptToContext`) are unit-tested; local preflight `servedContextTokens` is threaded into the dispatch target.

## Evidence
- Worktree: `~/dpf-worktrees/local-task-context-trim` on `fix/local-task-context-trim`
- Unit tests (worktree): `pnpm --filter web exec vitest run lib/integrate/opencode-dispatch.test.ts` → **47 passed**
- Pre-commit typecheck OOM on this worktree harness (`tsc` SIGABRT); not a type error. CI typecheck remains the merge gate.
- Local-CI-Override: source-local unit tests green on worktree; full pregate via CI

## Test plan
- [x] Unit: fit / no-trim / trim soft sections / fail-closed when core exceeds budget
- [ ] CI: Unit Tests + typecheck on PR
- [ ] Optional post-merge: re-run a medium all-local build task that previously overflowed at ~131k

Process-Spine-Decision: pure bug fix with regression tests; no new durable surface

Closes BI-B195F224 (after merge + evidence).