### PR TITLE
feat(discovery): capture UniFi device serial into InventoryEntity.properties (estate-bridge prerequisite)

### DIFF
--- a/packages/db/src/discovery-collectors/unifi.test.ts
+++ b/packages/db/src/discovery-collectors/unifi.test.ts
@@ -15,6 +15,7 @@ function makeDevices() {
         name: "UDM Pro",
         type: "udm",
         version: "4.0.6",
+        serial: "UDMPRO-SN-001",
         adopted: true,
         state: 1,
         num_sta: 15,
@@ -154,11 +155,15 @@ describe("collectUnifiDiscovery", () => {
     expect(router!.externalRef).toBe("unifi-device:aa:bb:cc:dd:ee:01");
     expect(router!.attributes?.model).toBe("UDM-Pro");
     expect(router!.attributes?.osiLayer).toBe(3);
+    // Serial captured under the canonical key the estate bridges read (BI-828998DC).
+    expect(router!.attributes?.serialNumber).toBe("UDMPRO-SN-001");
 
     const sw = result.items.find((i) => i.itemType === "switch");
     expect(sw).toBeDefined();
     expect(sw!.name).toBe("Main Switch");
     expect(sw!.attributes?.osiLayer).toBe(2);
+    // A device with no serial in the API carries no serialNumber key (not an empty string).
+    expect(sw!.attributes && "serialNumber" in sw!.attributes).toBe(false);
 
     const ap = result.items.find((i) => i.itemType === "access_point");
     expect(ap).toBeDefined();

--- a/packages/db/src/discovery-collectors/unifi.ts
+++ b/packages/db/src/discovery-collectors/unifi.ts
@@ -41,6 +41,9 @@ type UnifiDevice = {
   name?: string;
   type: string; // ugw, udm, uxg, usw, uap
   version?: string;
+  // Hardware serial the UniFi controller reports per device — the canonical asset match
+  // key for the estate bridges (BI-828998DC / BI-1093AF1C). Optional; absent on some models.
+  serial?: string;
   adopted?: boolean;
   state?: number; // 1 = connected
   port_table?: UnifiDevicePort[];
@@ -286,6 +289,8 @@ export async function collectUnifiDiscovery(
         osiLayerName: mapping.osiLayerName,
         networkAddress: device.ip,
         protocolFamily: "ipv4",
+        // Canonical serial key the estate bridges read off InventoryEntity.properties.
+        ...(device.serial ? { serialNumber: device.serial } : {}),
       },
     });
 


### PR DESCRIPTION
## What

Unblocks the strongest estate-bridge match key. The `InventoryEntity ↔ CustomerConfigurationItem` bridge (#3240) and the deferred `InventoryEntity ↔ FixedAsset` bridge both key on `serialNumber`, but discovery collected none — so serial matching never fired. The UniFi controller reports a hardware `serial` per device; the collector fetched the device objects but dropped that field.

Adds `serial` to the `UnifiDevice` shape and maps it into `attributes.serialNumber` — the canonical key the bridges read off `InventoryEntity.properties` via the normalize passthrough. Written **only when the API supplies it** (a device with no serial carries no key, not an empty string), so the bridge's serial path stays fail-closed.

## Impact
- Serial matching becomes **functional** for UniFi network gear — the estate class an MSP most needs correlated to managed CIs.
- **Re-opens BI-1093AF1C** (the FixedAsset bridge): `FixedAsset.serialNumber` and `InventoryEntity.properties.serialNumber` are now a shared key, so that bridge is no longer non-functional.

## Follow-up collector sources
SNMP `entPhysicalSerialNum` (ENTITY-MIB walk) and host DMI/SMBIOS serial.

## Test
`unifi.test.ts` — the collector emits `serialNumber` for a device that reports one and omits the key for one that doesn't.

Design-Grounding-Decision: BI-828998DC — the serial-collector prerequisite for the HAM D2 estate bridges (spec §7 + the "serial/GUID collector raises match rate" follow-up noted on #3240). The bridge modules = design evidence; the UniFi serial capture = code evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)