### PR TITLE
fix(build-studio): preserve committed build-branch work on start_build resume (BI-8C6AA60E)

### DIFF
--- a/apps/web/lib/integrate/sandbox/build-branch.test.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.test.ts
@@ -19,6 +19,7 @@ import {
   resolveBuildWorkdir,
   getClientIdentity,
   wrapSandboxGitCommand,
+  shouldPreserveBuildBranchWork,
 } from "./build-branch";
 
 describe("wrapSandboxGitCommand", () => {
@@ -123,6 +124,74 @@ describe("wrapSandboxGitCommand", () => {
     // Commits only when there are staged changes; best-effort so a no-op never blocks.
     expect(command).toContain("git diff --cached --quiet --exit-code");
     expect(command).toContain("wip: preserve in-flight build work before branch switch");
+  });
+
+  // BI-8C6AA60E — review-phase start_build must not hard-reset a build branch
+  // that already carries generated code (commitsAhead / source delta / dirty).
+  describe("shouldPreserveBuildBranchWork (BI-8C6AA60E)", () => {
+    it("preserves when the build branch is ahead of the client fork", () => {
+      expect(
+        shouldPreserveBuildBranchWork({
+          status: "ahead",
+          aheadBy: 2,
+          localSourceChangeCount: 3,
+          dirty: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("preserves when source deltas exist even if status is classified as behind", () => {
+      // Defensive: misclassified currency must not wipe real source.
+      expect(
+        shouldPreserveBuildBranchWork({
+          status: "behind",
+          aheadBy: 0,
+          localSourceChangeCount: 5,
+          dirty: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("preserves dirty working trees", () => {
+      expect(
+        shouldPreserveBuildBranchWork({
+          status: "dirty",
+          aheadBy: 0,
+          localSourceChangeCount: 0,
+          dirty: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("preserves diverged branches (never hard-reset away real work)", () => {
+      expect(
+        shouldPreserveBuildBranchWork({
+          status: "diverged",
+          aheadBy: 1,
+          localSourceChangeCount: 2,
+          dirty: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("allows hard-reset only when the branch has no local work", () => {
+      expect(
+        shouldPreserveBuildBranchWork({
+          status: "behind",
+          aheadBy: 0,
+          localSourceChangeCount: 0,
+          dirty: false,
+        }),
+      ).toBe(false);
+      expect(
+        shouldPreserveBuildBranchWork({
+          status: "current",
+          aheadBy: 0,
+          localSourceChangeCount: 0,
+          dirty: false,
+        }),
+      ).toBe(false);
+    });
   });
 
   it("commits branch hygiene when tracked generated artifacts are pruned", () => {

--- a/apps/web/lib/integrate/sandbox/build-branch.test.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.test.ts
@@ -19,8 +19,8 @@ import {
   resolveBuildWorkdir,
   getClientIdentity,
   wrapSandboxGitCommand,
-  shouldPreserveBuildBranchWork,
 } from "./build-branch";
+import { shouldPreserveBuildBranchWork } from "./sandbox-source-currency";
 
 describe("wrapSandboxGitCommand", () => {
   it("excludes recursive cache and dependency directories from sandbox baseline commits", () => {

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -26,6 +26,7 @@ import {
   classifySandboxSourceCurrency,
   formatSandboxSourceCurrencySummary,
   parseSandboxSourceCurrencyProbeOutput,
+  shouldPreserveBuildBranchWork,
   type SandboxSourceCurrencySnapshot,
 } from "./sandbox-source-currency";
 
@@ -356,70 +357,29 @@ async function recordBuildSourceCurrency(
   }).catch(() => {});
 }
 
-/**
- * Whether a build/* branch already carries work that must survive a
- * start_build / review-phase resume. Pure predicate for BI-8C6AA60E:
- * hard-resetting a branch that is ahead (or has source deltas) of the
- * fork point wiped generated code and left ship with "no releasable changes".
- */
-export function shouldPreserveBuildBranchWork(
-  snapshot: Pick<
-    SandboxSourceCurrencySnapshot,
-    "status" | "aheadBy" | "localSourceChangeCount" | "dirty"
-  >,
-): boolean {
-  if (snapshot.dirty) return true;
-  if ((snapshot.aheadBy ?? 0) > 0) return true;
-  if ((snapshot.localSourceChangeCount ?? 0) > 0) return true;
-  if (snapshot.status === "ahead" || snapshot.status === "diverged") return true;
-  return false;
-}
-
 async function refreshCurrentBranchFromTarget(args: {
   buildId: string;
   branchName: string;
   targetRef: string;
   blockUnknown: boolean;
-  /**
-   * When true (build/* resume path), never hard-reset if the branch already
-   * has committed or dirty source work relative to targetRef (BI-8C6AA60E).
-   */
+  /** BI-8C6AA60E: skip hard-reset when build/* already has local work. */
   preserveExistingWork?: boolean;
 }): Promise<SandboxSourceCurrencySnapshot> {
   const before = await inspectCurrentSandboxSourceCurrency(args.targetRef);
 
-  if (
-    args.preserveExistingWork &&
-    shouldPreserveBuildBranchWork(before)
-  ) {
-    await recordBuildSourceCurrency(
-      args.buildId,
-      before,
-      `Preserved existing work on ${args.branchName} (aheadBy=${before.aheadBy ?? "?"} sourceDelta=${before.localSourceChangeCount ?? "?"}); skipped hard-reset to ${args.targetRef}.`,
-    );
-    console.log(
-      `[build-branch] Preserved ${JSON.stringify(args.branchName)} work ` +
-        `(status=${before.status}, aheadBy=${before.aheadBy}, sourceDelta=${before.localSourceChangeCount}); skip hard-reset`,
-    );
+  // Preserve ahead/dirty/source-delta build branches on resume (BI-8C6AA60E).
+  if (args.preserveExistingWork && shouldPreserveBuildBranchWork(before)) {
+    await recordBuildSourceCurrency(args.buildId, before, `Preserved work on ${args.branchName}; skipped hard-reset to ${args.targetRef}.`);
+    console.log(`[build-branch] Preserved ${JSON.stringify(args.branchName)} (status=${before.status}, aheadBy=${before.aheadBy}); skip hard-reset`);
     return before;
   }
 
   if (before.status === "behind") {
-    await recordBuildSourceCurrency(
-      args.buildId,
-      before,
-      `Auto-refreshing ${args.branchName} before Build Studio work starts.`,
-    );
-    await execSandboxGit(
-      `git -C ${WORKSPACE} reset --hard ${quoteGitPathspec(args.targetRef)}`,
-    );
+    await recordBuildSourceCurrency(args.buildId, before, `Auto-refreshing ${args.branchName} before Build Studio work starts.`);
+    await execSandboxGit(`git -C ${WORKSPACE} reset --hard ${quoteGitPathspec(args.targetRef)}`);
     await normalizeSandboxBranchArtifacts(args.branchName);
     const after = await inspectCurrentSandboxSourceCurrency(args.targetRef);
-    await recordBuildSourceCurrency(
-      args.buildId,
-      after,
-      `Auto-refreshed ${args.branchName}.`,
-    );
+    await recordBuildSourceCurrency(args.buildId, after, `Auto-refreshed ${args.branchName}.`);
     return after;
   }
 
@@ -772,16 +732,9 @@ export async function startBuildBranch(buildId: string): Promise<SandboxSourceCu
         `git -C ${WORKSPACE} checkout "${branchName}"`,
       );
       await normalizeSandboxBranchArtifacts(branchName);
-      // BI-8C6AA60E: review-phase resume re-enters start_build. A hard-reset to
-      // the client branch wiped commits that already passed build/review gates
-      // ("sandbox baseline" re-init → ship "no releasable changes"). Preserve
-      // any branch that is ahead / dirty / has source deltas vs the client fork.
+      // BI-8C6AA60E: preserve commitsAhead/source work on review-phase resume.
       await refreshCurrentBranchFromTarget({
-        buildId,
-        branchName,
-        targetRef: identity.clientBranch,
-        blockUnknown: true,
-        preserveExistingWork: true,
+        buildId, branchName, targetRef: identity.clientBranch, blockUnknown: true, preserveExistingWork: true,
       });
       console.log(`[build-branch] Resumed build branch: ${JSON.stringify(branchName)}`);
     } else {

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -356,13 +356,53 @@ async function recordBuildSourceCurrency(
   }).catch(() => {});
 }
 
+/**
+ * Whether a build/* branch already carries work that must survive a
+ * start_build / review-phase resume. Pure predicate for BI-8C6AA60E:
+ * hard-resetting a branch that is ahead (or has source deltas) of the
+ * fork point wiped generated code and left ship with "no releasable changes".
+ */
+export function shouldPreserveBuildBranchWork(
+  snapshot: Pick<
+    SandboxSourceCurrencySnapshot,
+    "status" | "aheadBy" | "localSourceChangeCount" | "dirty"
+  >,
+): boolean {
+  if (snapshot.dirty) return true;
+  if ((snapshot.aheadBy ?? 0) > 0) return true;
+  if ((snapshot.localSourceChangeCount ?? 0) > 0) return true;
+  if (snapshot.status === "ahead" || snapshot.status === "diverged") return true;
+  return false;
+}
+
 async function refreshCurrentBranchFromTarget(args: {
   buildId: string;
   branchName: string;
   targetRef: string;
   blockUnknown: boolean;
+  /**
+   * When true (build/* resume path), never hard-reset if the branch already
+   * has committed or dirty source work relative to targetRef (BI-8C6AA60E).
+   */
+  preserveExistingWork?: boolean;
 }): Promise<SandboxSourceCurrencySnapshot> {
   const before = await inspectCurrentSandboxSourceCurrency(args.targetRef);
+
+  if (
+    args.preserveExistingWork &&
+    shouldPreserveBuildBranchWork(before)
+  ) {
+    await recordBuildSourceCurrency(
+      args.buildId,
+      before,
+      `Preserved existing work on ${args.branchName} (aheadBy=${before.aheadBy ?? "?"} sourceDelta=${before.localSourceChangeCount ?? "?"}); skipped hard-reset to ${args.targetRef}.`,
+    );
+    console.log(
+      `[build-branch] Preserved ${JSON.stringify(args.branchName)} work ` +
+        `(status=${before.status}, aheadBy=${before.aheadBy}, sourceDelta=${before.localSourceChangeCount}); skip hard-reset`,
+    );
+    return before;
+  }
 
   if (before.status === "behind") {
     await recordBuildSourceCurrency(
@@ -732,11 +772,16 @@ export async function startBuildBranch(buildId: string): Promise<SandboxSourceCu
         `git -C ${WORKSPACE} checkout "${branchName}"`,
       );
       await normalizeSandboxBranchArtifacts(branchName);
+      // BI-8C6AA60E: review-phase resume re-enters start_build. A hard-reset to
+      // the client branch wiped commits that already passed build/review gates
+      // ("sandbox baseline" re-init → ship "no releasable changes"). Preserve
+      // any branch that is ahead / dirty / has source deltas vs the client fork.
       await refreshCurrentBranchFromTarget({
         buildId,
         branchName,
         targetRef: identity.clientBranch,
         blockUnknown: true,
+        preserveExistingWork: true,
       });
       console.log(`[build-branch] Resumed build branch: ${JSON.stringify(branchName)}`);
     } else {

--- a/apps/web/lib/integrate/sandbox/sandbox-source-currency.ts
+++ b/apps/web/lib/integrate/sandbox/sandbox-source-currency.ts
@@ -65,6 +65,25 @@ const SOURCE_DIFF_EXCLUDES = [
   ":!packages/db/generated/**",
 ] as const;
 
+/**
+ * Whether a build/* branch already carries work that must survive a
+ * start_build / review-phase resume (BI-8C6AA60E). Hard-resetting a branch that
+ * is ahead (or has source deltas) of the fork point wiped generated code and
+ * left ship with "no releasable changes".
+ */
+export function shouldPreserveBuildBranchWork(
+  snapshot: Pick<
+    SandboxSourceCurrencySnapshot,
+    "status" | "aheadBy" | "localSourceChangeCount" | "dirty"
+  >,
+): boolean {
+  if (snapshot.dirty) return true;
+  if ((snapshot.aheadBy ?? 0) > 0) return true;
+  if ((snapshot.localSourceChangeCount ?? 0) > 0) return true;
+  if (snapshot.status === "ahead" || snapshot.status === "diverged") return true;
+  return false;
+}
+
 export function classifySandboxSourceCurrency(
   input: SandboxSourceCurrencyInput,
 ): SandboxSourceCurrencySnapshot {


### PR DESCRIPTION
## Summary
- Review-phase resume re-enters `start_build` → `startBuildBranch`. When the `build/*` branch already existed, the resume path could **hard-reset** it to the client fork, wiping commits that had already passed build/review gates and leaving ship with "no releasable source changes" (BI-8C6AA60E).
- Add `shouldPreserveBuildBranchWork` and pass `preserveExistingWork: true` on the existing-branch resume path so any branch that is ahead, dirty, diverged, or has source deltas is preserved.
- Empty/behind branches with no local work can still hard-reset for a clean resume.

## Evidence
- Worktree: `~/dpf-worktrees/preserve-build-branch-work` on `fix/preserve-build-branch-work`
- Unit tests (worktree): `pnpm --filter web exec vitest run lib/integrate/sandbox/build-branch.test.ts` → **25 passed**
- Local-CI-Override: source-local unit tests green on worktree; full pregate via CI

## Test plan
- [x] Unit: preserve when ahead / source delta / dirty / diverged; allow refresh when empty-behind
- [ ] CI: Unit Tests + typecheck on PR
- [ ] Optional post-merge: resume start_build on a build branch with commitsAhead>0 and confirm HEAD is unchanged

Process-Spine-Decision: pure bug fix with regression tests; no new durable surface

Related: BI-53C14D19 (durable commit of generated work) partially landed in #3083; this is the complementary resume preserve guard.