### PR TITLE
feat(proactivity): consolidated coworker proactivity confirm/adjust view

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/page.tsx
@@ -270,6 +270,26 @@ export default async function WikiBrowsePage({
         </Link>
       </div>
 
+      {/* Proactivity — how much each coworker acts on its own (BI-65D622EA) */}
+      <div className="mt-3 rounded-lg border border-[var(--dpf-border)] p-4 flex items-center justify-between">
+        <div>
+          <p className="font-medium text-sm text-[var(--dpf-text)]">
+            Coworker proactivity
+          </p>
+          <p className="text-xs text-[var(--dpf-muted)] mt-0.5">
+            Confirm or adjust how much each coworker acts on its own. Defaults come
+            from your industry&rsquo;s risk posture; money and public actions always
+            come to you.
+          </p>
+        </div>
+        <Link
+          href="/coworker-decisions/proactivity"
+          className="text-sm text-[var(--dpf-accent)] hover:underline shrink-0 ml-4"
+        >
+          Adjust →
+        </Link>
+      </div>
+
       {/* Retained kernel material — the drill-in, one level below the hub. */}
       <section id="governing-material" className="mt-10 scroll-mt-6">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-3">

--- a/apps/web/app/(shell)/coworker-decisions/proactivity/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/proactivity/page.tsx
@@ -1,0 +1,72 @@
+// Consolidated proactivity confirm/adjust view (BI-65D622EA). Lives under the
+// coworker-decisions governance hub — no new top-level navigation. Server
+// component; reuses the roster query, the batched override read, the pure
+// resolver projection, and the shared adjust control. Spec:
+// docs/superpowers/specs/2026-07-17-needs-you-cognitive-load-redesign-design.md
+// (deferred surface: proactivity confirm/adjust).
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { getCoworkerProactivityPreferences } from "@/lib/actions/proactivity";
+import {
+  deriveProactivityRoster,
+  type ProactivityRosterAgent,
+} from "@/lib/proactivity/proactivity-roster";
+import { ProactivityRosterList } from "@/components/proactivity/ProactivityRosterList";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Coworker proactivity",
+};
+
+export default async function CoworkerProactivityPage() {
+  const session = await auth();
+  if (!session?.user) redirect("/login");
+
+  const agents = await prisma.agent.findMany({
+    where: { archived: false },
+    orderBy: [{ tier: "asc" }, { name: "asc" }],
+    select: { agentId: true, name: true, displayName: true, role: true, kind: true },
+  });
+  const roster: ProactivityRosterAgent[] = agents.map((agent) => ({
+    agentId: agent.agentId,
+    displayName: agent.displayName || agent.name,
+    role: agent.role ?? agent.kind,
+  }));
+  const overrides = await getCoworkerProactivityPreferences(roster.map((r) => r.agentId));
+  const rows = deriveProactivityRoster(roster, overrides);
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-6">
+      <nav className="mb-4 text-sm text-[var(--dpf-muted)]">
+        <Link href="/coworker-decisions" className="hover:text-[var(--dpf-text)]">
+          Coworker Decision Engine
+        </Link>
+        <span className="mx-2">/</span>
+        <span className="text-[var(--dpf-text)]">Proactivity</span>
+      </nav>
+
+      <header className="mb-5">
+        <h1 className="mb-1 text-2xl font-semibold text-[var(--dpf-text)]">
+          How much each coworker acts on its own
+        </h1>
+        <p className="max-w-prose text-sm text-[var(--dpf-muted)]">
+          These levels were set from your industry&rsquo;s risk posture, so you didn&rsquo;t start
+          from scratch. Confirm them, or change any coworker. A more assertive setting lets a
+          coworker handle routine work and only tell you after; a more reactive setting asks you
+          first.
+        </p>
+        <p className="mt-2 max-w-prose text-xs text-[var(--dpf-muted)]">
+          Two things always come to you no matter the setting: money leaving the business, and
+          anything that goes public.
+        </p>
+      </header>
+
+      <ProactivityRosterList rows={rows} />
+    </div>
+  );
+}

--- a/apps/web/components/proactivity/ProactivityRosterList.test.tsx
+++ b/apps/web/components/proactivity/ProactivityRosterList.test.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/actions/proactivity", () => ({
+  saveCoworkerProactivityPreference: vi.fn(),
+}));
+
+import { ProactivityRosterList } from "./ProactivityRosterList";
+import type { ProactivityRosterRow } from "@/lib/proactivity/proactivity-roster";
+
+const rows: ProactivityRosterRow[] = [
+  {
+    agentId: "coo",
+    displayName: "Chief Operating Officer",
+    role: "orchestrator",
+    level: "balanced",
+    isOverride: false,
+    explanation: "Derived from the business risk posture.",
+  },
+  {
+    agentId: "bookkeeper",
+    displayName: "Bookkeeper",
+    role: "analyst",
+    level: "assertive",
+    isOverride: true,
+    explanation: "Owner override.",
+  },
+];
+
+describe("ProactivityRosterList", () => {
+  it("labels a derived default and an owner override distinctly", () => {
+    const html = renderToStaticMarkup(<ProactivityRosterList rows={rows} />);
+    expect(html).toContain("Chief Operating Officer");
+    expect(html).toContain("From your industry");
+    expect(html).toContain("Bookkeeper");
+    expect(html).toContain("You set this");
+  });
+
+  it("shows an empty message when there are no coworkers", () => {
+    const html = renderToStaticMarkup(<ProactivityRosterList rows={[]} />);
+    expect(html).toContain("No coworkers to configure yet.");
+  });
+});

--- a/apps/web/components/proactivity/ProactivityRosterList.tsx
+++ b/apps/web/components/proactivity/ProactivityRosterList.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+// Consolidated owner-facing proactivity roster (BI-65D622EA). Reuses the shared
+// ProactivityLevelControl and the existing saveCoworkerProactivityPreference
+// write path — this is the aggregated confirm/adjust surface, not a new engine.
+
+import { useState } from "react";
+
+import { ProactivityLevelControl } from "@/components/proactivity/ProactivityLevelControl";
+import { saveCoworkerProactivityPreference } from "@/lib/actions/proactivity";
+import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
+import type { ProactivityRosterRow } from "@/lib/proactivity/proactivity-roster";
+
+type RowState = { level: ProactivityLevel; isOverride: boolean };
+
+export function ProactivityRosterList({ rows }: { rows: ProactivityRosterRow[] }) {
+  const [state, setState] = useState<Record<string, RowState>>(() =>
+    Object.fromEntries(
+      rows.map((row) => [row.agentId, { level: row.level, isOverride: row.isOverride }]),
+    ),
+  );
+
+  function change(agentId: string, next: ProactivityLevel) {
+    setState((prev) => ({ ...prev, [agentId]: { level: next, isOverride: true } }));
+    // Fire-and-forget: the setting persists to a UserFact; a save hiccup must not
+    // block the UI. The value re-derives from the server on next load.
+    saveCoworkerProactivityPreference(agentId, next).catch(() => {});
+  }
+
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-[var(--dpf-muted)]">No coworkers to configure yet.</p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-[var(--dpf-border)] rounded-lg border border-[var(--dpf-border)]">
+      {rows.map((row) => {
+        const current = state[row.agentId] ?? { level: row.level, isOverride: row.isOverride };
+        return (
+          <li
+            key={row.agentId}
+            className="flex items-center justify-between gap-4 px-4 py-3"
+          >
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-[var(--dpf-text)]">
+                {row.displayName}
+              </p>
+              <p className="truncate text-xs text-[var(--dpf-muted)]">
+                {row.role}
+                {" · "}
+                {current.isOverride ? "You set this" : "From your industry"}
+              </p>
+            </div>
+            <ProactivityLevelControl
+              value={current.level}
+              onChange={(next) => change(row.agentId, next)}
+            />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/lib/actions/proactivity.ts
+++ b/apps/web/lib/actions/proactivity.ts
@@ -55,6 +55,38 @@ export async function getCoworkerProactivityPreference(agentId: string): Promise
   return readProactivityLevel(fact?.value);
 }
 
+/** Batched read of the owner's proactivity overrides for many coworkers in one
+ *  query — powers the consolidated roster (BI-65D622EA) without an N+1. Returns
+ *  only agents that carry an explicit override; the rest fall back to the
+ *  posture-derived default at the resolver. */
+export async function getCoworkerProactivityPreferences(
+  agentIds: string[],
+): Promise<Record<string, ProactivityLevel>> {
+  const user = await currentUser();
+  if (!user || agentIds.length === 0) return {};
+
+  const keyToAgent = new Map(agentIds.map((id) => [proactivityAgentFactKey(id), id]));
+  const facts = await prisma.userFact.findMany({
+    where: {
+      userId: user.id,
+      category: PROACTIVITY_FACT_CATEGORY,
+      key: { in: [...keyToAgent.keys()] },
+      supersededAt: null,
+    },
+    select: { key: true, value: true },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  const out: Record<string, ProactivityLevel> = {};
+  for (const fact of facts) {
+    const agentId = keyToAgent.get(fact.key);
+    if (!agentId || out[agentId]) continue; // most-recent wins (orderBy desc)
+    const level = readProactivityLevel(fact.value);
+    if (level) out[agentId] = level;
+  }
+  return out;
+}
+
 export async function saveCoworkerProactivityPreference(
   agentId: string,
   level: ProactivityLevel,

--- a/apps/web/lib/docs/doc-impact.generated.json
+++ b/apps/web/lib/docs/doc-impact.generated.json
@@ -258,11 +258,17 @@
     ]
   },
   "codeToDocs": {
+    "apps/web/app/(shell)/coworker-decisions/proactivity/page.tsx": [
+      "docs/user-guide/ai-workforce/coworker-proactivity.md"
+    ],
     "apps/web/components/attention/AttentionInbox.tsx": [
       "docs/user-guide/workspace/attention-inbox.md"
     ],
     "apps/web/components/attention/OwnerDecisionCards.tsx": [
       "docs/user-guide/workspace/attention-inbox.md"
+    ],
+    "apps/web/components/proactivity/ProactivityRosterList.tsx": [
+      "docs/user-guide/ai-workforce/coworker-proactivity.md"
     ],
     "apps/web/lib/ai-inference.ts": [
       "docs/user-guide/ai-workforce/connecting-providers.md"
@@ -272,6 +278,9 @@
     ],
     "apps/web/lib/integrate/build-orchestrator.ts": [
       "docs/user-guide/build-studio/index.md"
+    ],
+    "apps/web/lib/proactivity/proactivity-roster.ts": [
+      "docs/user-guide/ai-workforce/coworker-proactivity.md"
     ],
     "scripts/dpf-bootstrap-agent-toolchain.ps1": [
       "docs/user-guide/getting-started/agent-dev-environments.md"
@@ -462,6 +471,11 @@
   "docToCode": {
     "docs/user-guide/ai-workforce/connecting-providers.md": [
       "apps/web/lib/ai-inference.ts"
+    ],
+    "docs/user-guide/ai-workforce/coworker-proactivity.md": [
+      "apps/web/app/(shell)/coworker-decisions/proactivity/page.tsx",
+      "apps/web/components/proactivity/ProactivityRosterList.tsx",
+      "apps/web/lib/proactivity/proactivity-roster.ts"
     ],
     "docs/user-guide/build-studio/index.md": [
       "apps/web/lib/integrate/build-orchestrator.ts"

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 517,
+  "pageCount": 518,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -7904,6 +7904,19 @@
         "finance-bridge",
         "where-to-review-it",
         "troubleshooting"
+      ]
+    },
+    "docs/user-guide/ai-workforce/coworker-proactivity.md": {
+      "publicHref": "/user-guide/ai-workforce/coworker-proactivity/",
+      "portalHref": "/docs/ai-workforce/coworker-proactivity",
+      "publishedPublic": true,
+      "publishedPortal": true,
+      "anchors": [
+        "what-this-covers",
+        "how-the-defaults-are-set",
+        "the-levels",
+        "the-two-hard-floors",
+        "what-you-can-do"
       ]
     },
     "docs/user-guide/ai-workforce/decision-perspective-in-practice.md": {

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 568,
+  "routeCount": 569,
   "routes": [
     {
       "routePath": "/",
@@ -3850,6 +3850,16 @@
         "profileId"
       ],
       "file": "apps/web/app/(shell)/coworker-decisions/perspectives/[profileId]/voice/page.tsx"
+    },
+    {
+      "routePath": "/coworker-decisions/proactivity",
+      "kind": "page",
+      "segments": [
+        "coworker-decisions",
+        "proactivity"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/(shell)/coworker-decisions/proactivity/page.tsx"
     },
     {
       "routePath": "/coworker-decisions/review",

--- a/apps/web/lib/proactivity/proactivity-roster.test.ts
+++ b/apps/web/lib/proactivity/proactivity-roster.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveProactivityRoster } from "./proactivity-roster";
+import { PROACTIVITY_LEVELS } from "./proactivity-types";
+
+const agents = [
+  { agentId: "coo", displayName: "Chief Operating Officer", role: "orchestrator" },
+  { agentId: "bookkeeper", displayName: "Bookkeeper", role: "analyst" },
+];
+
+describe("deriveProactivityRoster", () => {
+  it("uses the owner override level and marks the row as owner-set", () => {
+    const rows = deriveProactivityRoster(agents, { bookkeeper: "assertive" });
+    const book = rows.find((row) => row.agentId === "bookkeeper");
+    expect(book?.isOverride).toBe(true);
+    expect(book?.level).toBe("assertive");
+  });
+
+  it("falls back to a posture-derived default when there is no override", () => {
+    const rows = deriveProactivityRoster(agents, {});
+    for (const row of rows) {
+      expect(row.isOverride).toBe(false);
+      expect(PROACTIVITY_LEVELS).toContain(row.level);
+      expect(typeof row.explanation).toBe("string");
+    }
+  });
+
+  it("preserves each coworker's identity fields in order", () => {
+    const rows = deriveProactivityRoster(agents, {});
+    expect(rows.map((row) => row.displayName)).toEqual([
+      "Chief Operating Officer",
+      "Bookkeeper",
+    ]);
+    expect(rows.map((row) => row.role)).toEqual(["orchestrator", "analyst"]);
+  });
+});

--- a/apps/web/lib/proactivity/proactivity-roster.ts
+++ b/apps/web/lib/proactivity/proactivity-roster.ts
@@ -1,0 +1,47 @@
+// Consolidated owner-facing proactivity roster (BI-65D622EA). One place that
+// lists every coworker with the proactivity level it acts at, states that the
+// default was DERIVED from the business risk posture, and lets the owner confirm
+// or adjust each one. The per-agent adjust already lives on the coworker profile
+// (CoworkerProfilePanel); this is the aggregated view, reusing the same resolver
+// and the same saveCoworkerProactivityPreference write path. Spec:
+// docs/superpowers/specs/2026-07-17-needs-you-cognitive-load-redesign-design.md
+// (deferred surface: proactivity confirm/adjust).
+
+import { resolveProactivityPlan, resolveProactivityPlanForLevel } from "./proactivity-resolver";
+import type { ProactivityLevel } from "./proactivity-types";
+
+export type ProactivityRosterAgent = {
+  agentId: string;
+  displayName: string;
+  role: string;
+};
+
+export type ProactivityRosterRow = ProactivityRosterAgent & {
+  level: ProactivityLevel;
+  /** True when the owner has overridden the derived default. */
+  isOverride: boolean;
+  /** Plain-language origin of the level shown. */
+  explanation: string;
+};
+
+/** Pure projection: given the coworker list and any owner overrides, resolve the
+ *  level each coworker acts at. When no override exists the resolver returns the
+ *  posture-derived default; an override marks the row as owner-set. */
+export function deriveProactivityRoster(
+  agents: ProactivityRosterAgent[],
+  overrides: Record<string, ProactivityLevel>,
+): ProactivityRosterRow[] {
+  return agents.map((agent) => {
+    const input = { activityFamily: "scheduled-task", agentId: agent.agentId } as const;
+    const saved = overrides[agent.agentId];
+    const plan = saved
+      ? resolveProactivityPlanForLevel(input, saved, "user-override")
+      : resolveProactivityPlan(input);
+    return {
+      ...agent,
+      level: plan.resolvedLevel,
+      isOverride: Boolean(saved),
+      explanation: plan.explanation,
+    };
+  });
+}

--- a/docs/user-guide/ai-workforce/coworker-proactivity.md
+++ b/docs/user-guide/ai-workforce/coworker-proactivity.md
@@ -1,0 +1,40 @@
+---
+title: "Coworker Proactivity"
+area: ai-workforce
+order: 6
+relatedCode:
+  - apps/web/app/(shell)/coworker-decisions/proactivity/page.tsx
+  - apps/web/components/proactivity/ProactivityRosterList.tsx
+  - apps/web/lib/proactivity/proactivity-roster.ts
+---
+
+## What This Covers
+
+**Proactivity** is how much a coworker acts on its own before it involves you. The consolidated view lives at **Coworker Decision Engine → Coworker proactivity**, and lists every coworker with the level it currently acts at.
+
+## How the Defaults Are Set
+
+You don't start from a blank slate. Each coworker's default level is **derived from your industry's risk posture** — a plumbing company and a hospital get different starting points. A row marked *"From your industry"* is running that derived default; *"You set this"* means you changed it.
+
+## The Levels
+
+- **Reactive** — asks you before most things. You see the most.
+- **Balanced** — handles routine work and logs it; brings real business choices to you.
+- **Assertive** — acts and tells you after. You see the least.
+
+## The Two Hard Floors
+
+No proactivity setting can bypass them:
+
+- **Money leaving the business** always comes to you.
+- **Anything that goes public** always comes to you.
+
+## What You Can Do
+
+- **Confirm** the derived levels if they look right.
+- **Adjust** any coworker in place — the change saves immediately and takes effect on its next scheduled work.
+- A coworker may also **propose** its own adjustment after a repeated pattern; you accept, keep, or narrow it from the ["Needs you" inbox](../workspace/attention-inbox.md).
+
+---
+
+*Part of the [cognitive-load redesign](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/blob/main/docs/superpowers/specs/2026-07-17-needs-you-cognitive-load-redesign-design.md). The per-coworker control also appears on each coworker's profile; this page is the one-place confirm/adjust view.*

--- a/docs/user-guide/wiki/index.md
+++ b/docs/user-guide/wiki/index.md
@@ -28,6 +28,8 @@ Coworkers can retrieve wiki context, propose edits, and use principles as govern
 
 WWMD uses the same wiki substrate for decision support. It retrieves relevant principles, compares candidate options against multiple dimensions, and returns a recommendation, arbitration, escalation, or deferral with confidence and sources attached. See [Autonomy, WWMD, and trusted coworker decisions](../../architecture/autonomy-and-wwmd.md).
 
+How much each coworker acts on its own — its proactivity — is set from your industry's risk posture and can be confirmed or adjusted per coworker. See [Coworker Proactivity](../ai-workforce/coworker-proactivity.md).
+
 ## What To Watch
 
 - pages marked draft being cited as established policy


### PR DESCRIPTION
## What

`BI-65D622EA` — the second residual from the needs-you cognitive-load redesign.

Per-coworker proactivity was adjustable only by visiting each coworker's profile. This adds one **owner-facing consolidated view** under the Coworker Decision Engine hub (`/coworker-decisions/proactivity`) that lists every coworker with the level it acts at, states the default was **derived from the business risk posture** (confirm, don't ask cold), and lets the owner confirm or adjust each one in place.

- Reuses the existing proactivity **resolver**, the shared **`ProactivityLevelControl`**, and the existing **`saveCoworkerProactivityPreference`** write path — the aggregated surface the per-agent panel lacked, not a new engine.
- Rows marked *"From your industry"* run the derived default; *"You set this"* is an owner override.
- The two hard floors (money out, anything public) are shown as always coming to the owner regardless of the setting.
- A batched override read (`getCoworkerProactivityPreferences`) avoids an N+1 across the roster.
- No new top-level navigation — it lives under the existing coworker-decisions hub (placement confirmed with the operator).

## Design grounding

Extends `docs/superpowers/specs/2026-07-17-needs-you-cognitive-load-redesign-design.md` (deferred surface: proactivity confirm/adjust) and `BI-65D622EA`. New user-guide page `docs/user-guide/ai-workforce/coworker-proactivity.md`. Reuses existing resolver + write path — no new contract.

## Verification

Added unit tests: `proactivity-roster.test.ts` (override honored, derived fallback, identity preserved) and `ProactivityRosterList.test.tsx` (derived vs owner-set labels, empty state). Local typecheck/unit run was blocked by a source-only worktree (no `next`/`vitest` binaries); the required CI **Typecheck** and **Unit Tests** gates verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)