### PR TITLE
chore(ui): finish async-activity rollout tail + tighten guard scope

### DIFF
--- a/apps/web/components/build/EvidenceSummary.tsx
+++ b/apps/web/components/build/EvidenceSummary.tsx
@@ -2,6 +2,7 @@
 
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
 import { safeRenderValue } from "@/lib/safe-render";
+import { Skeleton } from "@/components/ui/Skeleton";
 
 type Props = {
   build: FeatureBuildRow;
@@ -11,12 +12,12 @@ type Props = {
 export function EvidenceSummary({ build, loading }: Props) {
   if (loading) {
     return (
-      <div className="space-y-2 animate-fade-in">
-        <div className="h-3 w-28 bg-[var(--dpf-surface-2)] rounded animate-pulse" />
+      <div className="space-y-2 animate-fade-in" aria-busy="true">
+        <Skeleton width={112} height={12} />
         {[1, 2, 3, 4, 5].map((i) => (
-          <div key={i} className="flex items-center gap-2 px-3 py-2.5 rounded bg-[var(--dpf-surface-2)] animate-pulse">
-            <div className="w-2 h-2 rounded-full bg-[var(--dpf-border)]" />
-            <div className="h-3 flex-1 bg-[var(--dpf-border)] rounded" style={{ width: `${50 + i * 6}%` }} />
+          <div key={i} className="flex items-center gap-2 px-3 py-2.5 rounded bg-[var(--dpf-surface-2)]">
+            <Skeleton circle width={8} height={8} />
+            <Skeleton height={12} width={`${50 + i * 6}%`} />
           </div>
         ))}
       </div>

--- a/apps/web/components/platform/OllamaManagement.tsx
+++ b/apps/web/components/platform/OllamaManagement.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition, useEffect } from "react";
+import { InlineBusy } from "@/components/ui/InlineBusy";
 import {
   listOllamaModels,
   getOllamaRunningModels,
@@ -429,8 +430,8 @@ export function OllamaManagement({ canWrite, vramGb, providerId }: Props) {
         )}
 
         {!loaded && isPending && (
-          <div style={{ color: "var(--dpf-muted)", fontSize: 12, padding: "16px 0", textAlign: "center" }}>
-            <span className="animate-pulse">Loading models…</span>
+          <div style={{ color: "var(--dpf-muted)", fontSize: 12, padding: "16px 0", display: "flex", justifyContent: "center" }}>
+            <InlineBusy label="Loading models…" />
           </div>
         )}
 

--- a/scripts/check-no-hand-rolled-loading.mjs
+++ b/scripts/check-no-hand-rolled-loading.mjs
@@ -38,6 +38,12 @@ const BASELINE_PATH = join(REPO_ROOT, "scripts", "hand-rolled-loading-baseline.t
 // The canonical home for loading motion — never counted against the baseline.
 const UI_HOME = join("apps", "web", "components", "ui").replace(/\\/g, "/");
 
+// apps/web/lib is logic + prompt/template text, not rendered UI. The class
+// names appear there only inside STRING literals that teach generated code the
+// loading patterns (e.g. specialist-prompts.ts, tak/route-context-map.ts) — not
+// real indicators, so they are out of the guard's scope.
+const LIB_HOME = join("apps", "web", "lib").replace(/\\/g, "/");
+
 // Raw Tailwind loading-animation utility classes used inline instead of a
 // ui/ primitive. `animate-[spin|pulse]` covers the arbitrary-value form too.
 export const HAND_ROLLED_RE = /\banimate-(?:spin|pulse|\[spin|\[pulse)/g;
@@ -69,6 +75,7 @@ export function scan() {
   for (const file of walk(SCAN_DIR)) {
     const rel = relative(REPO_ROOT, file).replace(/\\/g, "/");
     if (rel.startsWith(`${UI_HOME}/`)) continue;
+    if (rel.startsWith(`${LIB_HOME}/`)) continue;
     const body = readFileSync(file, "utf8");
     const n = (body.match(HAND_ROLLED_RE) ?? []).length;
     if (n > 0) counts[rel] = n;

--- a/scripts/hand-rolled-loading-baseline.txt
+++ b/scripts/hand-rolled-loading-baseline.txt
@@ -4,13 +4,11 @@ apps/web/components/build-studio/PreviewFrame.tsx	2
 apps/web/components/build-studio/StepTracker.tsx	1
 apps/web/components/build-studio/cards/VerificationStripCard.tsx	1
 apps/web/components/build/ClaimBadge.tsx	1
-apps/web/components/build/EvidenceSummary.tsx	2
 apps/web/components/build/FeatureBriefPanel.tsx	2
 apps/web/components/build/VoiceRationalePlayer.tsx	1
 apps/web/components/inventory/TopologyGraph.tsx	1
 apps/web/components/monitoring/AiCoworkerHealthPanel.tsx	1
 apps/web/components/monitoring/PlatformHealthIndicator.tsx	2
-apps/web/components/platform/OllamaManagement.tsx	1
 apps/web/components/platform/OperationsMapLiveShell.tsx	1
 apps/web/components/platform/ProviderDetailForm.tsx	2
 apps/web/components/platform/development/change-lanes/ChangeLaneSourceSummary.tsx	1
@@ -18,5 +16,3 @@ apps/web/components/portfolio/PlatformHealthStrip.tsx	1
 apps/web/components/twin/CapacityChips.tsx	1
 apps/web/components/wiki/VoiceProfileSetup.tsx	2
 apps/web/components/workspace/CalendarSyncPanel.tsx	1
-apps/web/lib/integrate/specialist-prompts.ts	3
-apps/web/lib/tak/route-context-map.ts	2


### PR DESCRIPTION
## Why

Final rollout batch under **BI-BBA388A1** (after #3232, #3241, #3247). Migrates the last two genuine loading affordances and removes guard false positives. The ratchet baseline drops **22 → 18 files** (32 → 24 occurrences).

## What changed

- **`EvidenceSummary`** — hand-rolled `animate-pulse` skeleton bars → `ui/Skeleton` (with `aria-busy` on the loading region).
- **`OllamaManagement`** — the "Loading models…" `animate-pulse` text → `InlineBusy`.
- **Guard scope** — exclude `apps/web/lib/` from the ratchet scan. The class names there appear only inside prompt/template **string literals** that teach generated code the loading patterns (`specialist-prompts.ts`, `tak/route-context-map.ts`) — not rendered UI, so they were false positives.

## What's deliberately left (and why the rollout is now substantively complete)

The remaining 18 baselined files are **out of the loading pattern by design**:
- **Semantic status dots** (`PlatformHealthIndicator`, `ClaimBadge`, `PreviewFrame` live-dots, `AiCoworkerHealthPanel`, …) — these communicate *state*, not loading.
- **Cell-pulse activity overlays** (`StepTracker`, `VerificationStripCard`) — ambient activity, not a load placeholder.

Both inherit the global reduced-motion guard, and the ratchet blocks any *new* hand-rolled indicator. Also note the platform's autonomous builds are migrating some sites concurrently (e.g. `FeatureBriefPanel`'s skeleton block was already done on `main`).

## Verification

- ✅ Typecheck — `tsc --noEmit`: **0 errors** (after regenerating the Prisma client for `main`'s newer schema).
- ✅ Guard — self-test + full repo guard loop (22 guards, incl. the updated hand-rolled-loading ratchet): **green**.
- Production build: run authoritatively by CI (the local Windows build hangs at "Finalizing page optimization" on this host — environmental Turbopack issue, not a code error).

UX-Fit-Decision: progressive-disclosure / low cognitive-load — swaps hand-rolled loading markup for the canonical primitives and narrows the guard to real UI; no new operator-facing inputs or controls. Scored on human_cognitive_load.

Design-Grounding-Decision: reviewed docs/superpowers + the async-activity standard in docs/platform-usability-standards.md (#3232); reviewed the ui/ primitives, the repo guard loop, and the remaining animate-pulse sites under apps/web/components/, classifying each as loading vs semantic state. Mechanical migration onto the existing ui/ primitives + a guard-scope narrowing; no routing/queue/contract change.

Local-CI-Override: Verified in a compile-ready worktree at the PR head — `tsc --noEmit` (0 errors) and the full repo guard loop (22 guards) green. CI runs the authoritative production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
