### PR TITLE
fix(build): decomposition children inherit intake from parent (BI-FF8ABFCB)

### DIFF
--- a/apps/web/lib/build/approve-decomposition.ts
+++ b/apps/web/lib/build/approve-decomposition.ts
@@ -28,9 +28,13 @@
 // violation per the invariant module's discipline.
 
 import { prisma } from "@dpf/db";
-import { generateBuildId } from "@/lib/explore/feature-build-types";
+import { generateBuildId, normalizeHappyPathState } from "@/lib/explore/feature-build-types";
 import type { BuildDesignDoc, ReviewResult } from "@/lib/explore/feature-build-types";
 import { isPlanReviewOscillating } from "@/lib/build/plan-oscillation-decomposition";
+import {
+  applyChildIntakeToPlan,
+  buildDecompositionChildIntakePatch,
+} from "./decomposition-child-intake";
 
 import {
   candidateToChildDesignDocs,
@@ -172,6 +176,7 @@ export async function approveDecomposition(
       designDoc: true,
       designReview: true,
       planReview: true,
+      plan: true,
       parentEpicId: true,
       originatingBacklogItemId: true,
       digitalProductId: true,
@@ -340,12 +345,31 @@ export async function approveDecomposition(
       },
     });
 
+    // Children go straight to `plan`, so they never pass through the ideate
+    // reviewDesignDoc step that normally populates plan.happyPathState.intake.
+    // Without it they hard-block at the plan→build gate ("Intake is incomplete")
+    // and churn forever (BI-FF8ABFCB). Derive each child's intake from the
+    // parent build's intake (same epic/backlog/taxonomy, child-specific goal).
+    const parentIntake = normalizeHappyPathState(
+      (build.plan as Record<string, unknown> | null)?.["happyPathState"],
+    ).intake;
+
     // Create children with real epic.id.
     const orderToRealBuildId = new Map<number, string>();
     const orderToRealRowId = new Map<number, string>();
     for (let i = 0; i < childDocs.length; i++) {
       const child = childDocs[i]!;
       const childBuildLogical = childBuildLogicalIds[i]!;
+      const childPlan = applyChildIntakeToPlan(
+        null,
+        buildDecompositionChildIntakePatch({
+          parentIntake,
+          epicSemanticId: createdEpic.epicId,
+          childTitle: child.title,
+          childOriginatingBacklogItemId: build.originatingBacklogItemId ?? null,
+          childBuildId: childBuildLogical,
+        }),
+      );
       const created = await tx.featureBuild.create({
         data: {
           buildId: childBuildLogical,
@@ -355,6 +379,7 @@ export async function approveDecomposition(
           childOrder: child.childOrder,
           designDoc: child.designDoc as never,
           designReview: review as never,
+          plan: childPlan as never,
           createdById: args.userId,
           ...(build.originatingBacklogItemId
             ? { originatingBacklogItemId: build.originatingBacklogItemId }

--- a/apps/web/lib/build/decomposition-child-intake.test.ts
+++ b/apps/web/lib/build/decomposition-child-intake.test.ts
@@ -1,0 +1,130 @@
+// apps/web/lib/build/decomposition-child-intake.test.ts
+//
+// BI-FF8ABFCB — child intake derivation + self-heal.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildDecompositionChildIntakePatch,
+  healDecompositionChildIntake,
+  type HealChildIntakeDb,
+} from "./decomposition-child-intake";
+import { isHappyPathIntakeReady, normalizeHappyPathState } from "@/lib/explore/feature-build-types";
+
+const parentIntake = {
+  status: "ready" as const,
+  epicId: "EP-PARTNER-CHANNEL",
+  backlogItemId: "BI-DE47EC0B",
+  taxonomyNodeId: "triaged-bi:cmq05mt4t00ib01qpvz2ts6zu",
+  constrainedGoal: "Phase 2: Partner identity",
+  failureReason: null,
+};
+
+describe("buildDecompositionChildIntakePatch", () => {
+  it("inherits parent backlog + taxonomy, anchors on the child's own epic, uses child title as goal", () => {
+    const patch = buildDecompositionChildIntakePatch({
+      parentIntake,
+      epicSemanticId: "EP-043E34AE",
+      childTitle: "Program setup and partner-account parts truck",
+      childOriginatingBacklogItemId: "cmq-child-bi",
+      childBuildId: "FB-CHILD",
+    });
+    expect(patch).toEqual({
+      status: "ready",
+      epicId: "EP-043E34AE",
+      backlogItemId: "BI-DE47EC0B",
+      taxonomyNodeId: "triaged-bi:cmq05mt4t00ib01qpvz2ts6zu",
+      constrainedGoal: "Program setup and partner-account parts truck",
+    });
+  });
+
+  it("produces an intake that satisfies the plan gate (isHappyPathIntakeReady)", () => {
+    const patch = buildDecompositionChildIntakePatch({
+      parentIntake,
+      epicSemanticId: "EP-043E34AE",
+      childTitle: "child",
+      childOriginatingBacklogItemId: "bi",
+      childBuildId: "FB-C",
+    });
+    const state = normalizeHappyPathState({ intake: patch });
+    expect(isHappyPathIntakeReady(state)).toBe(true);
+  });
+
+  it("falls back to a provenance taxonomy anchor when the parent lacks one", () => {
+    const patch = buildDecompositionChildIntakePatch({
+      parentIntake: { ...parentIntake, taxonomyNodeId: null },
+      epicSemanticId: "EP-X",
+      childTitle: "c",
+      childOriginatingBacklogItemId: "cmq-bi-row",
+      childBuildId: "FB-C",
+    });
+    expect(patch.taxonomyNodeId).toBe("triaged-bi:cmq-bi-row");
+  });
+
+  it("falls back to the child's originating BI when the parent intake has no backlogItemId", () => {
+    const patch = buildDecompositionChildIntakePatch({
+      parentIntake: { ...parentIntake, backlogItemId: null },
+      epicSemanticId: "EP-X",
+      childTitle: "c",
+      childOriginatingBacklogItemId: "cmq-bi-row",
+      childBuildId: "FB-C",
+    });
+    expect(patch.backlogItemId).toBe("cmq-bi-row");
+  });
+});
+
+describe("healDecompositionChildIntake", () => {
+  function makeDb(parentPlan: unknown): { db: HealChildIntakeDb; updates: Array<{ where: unknown; data: unknown }> } {
+    const updates: Array<{ where: unknown; data: unknown }> = [];
+    const db: HealChildIntakeDb = {
+      epic: { findUnique: vi.fn(async () => ({ epicId: "EP-043E34AE" })) },
+      featureBuild: {
+        findFirst: vi.fn(async () => ({ plan: parentPlan })),
+        update: vi.fn(async (args) => {
+          updates.push(args);
+          return {};
+        }),
+      },
+    };
+    return { db, updates };
+  }
+
+  it("backfills a child's missing intake from the superseded parent and persists it", async () => {
+    const { db, updates } = makeDb({ happyPathState: { intake: parentIntake } });
+    const healed = await healDecompositionChildIntake({
+      child: {
+        buildId: "FB-CHILD",
+        title: "Ops gate and scope fence truck",
+        parentEpicId: "epic-row-1",
+        originatingBacklogItemId: "cmq-child-bi",
+        plan: null,
+      },
+      db,
+    });
+    expect(healed).toBe(true);
+    expect(updates).toHaveLength(1);
+    const written = normalizeHappyPathState(
+      (updates[0]!.data as { plan: { happyPathState: unknown } }).plan.happyPathState,
+    );
+    expect(isHappyPathIntakeReady(written)).toBe(true);
+    expect(written.intake.epicId).toBe("EP-043E34AE");
+    expect(written.intake.backlogItemId).toBe("BI-DE47EC0B");
+    expect(written.intake.constrainedGoal).toBe("Ops gate and scope fence truck");
+  });
+
+  it("is a no-op when the child's intake is already ready", async () => {
+    const { db, updates } = makeDb({ happyPathState: { intake: parentIntake } });
+    const healed = await healDecompositionChildIntake({
+      child: {
+        buildId: "FB-READY",
+        title: "already fine",
+        parentEpicId: "epic-row-1",
+        originatingBacklogItemId: "bi",
+        plan: { happyPathState: { intake: parentIntake } },
+      },
+      db,
+    });
+    expect(healed).toBe(false);
+    expect(updates).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/build/decomposition-child-intake.ts
+++ b/apps/web/lib/build/decomposition-child-intake.ts
@@ -1,0 +1,141 @@
+// apps/web/lib/build/decomposition-child-intake.ts
+//
+// BI-FF8ABFCB — decomposition children are created directly in `plan` (see
+// approve-decomposition.ts) with the parent's designDoc copied, but WITHOUT a
+// `plan.happyPathState.intake`. The plan→build gate (checkPhaseGate →
+// isHappyPathIntakeReady) requires taxonomyNodeId + backlogItemId + epicId +
+// constrainedGoal, so an intake-less child hard-blocks with "Intake is
+// incomplete" and the resume reconciler re-dispatches it forever (burning
+// plan-generation spend). Surfaced at scale by the BI-C4F828B7 autopilot
+// auto-decompose wave: 86/86 children had intake=null.
+//
+// This module derives a child's intake from its parent (the pre-decomposition
+// build, which had complete intake) and is used by two paths:
+//   - fix-forward: approveDecomposition sets it at child-creation time.
+//   - self-heal:   the plan resume path backfills already-created children.
+
+import {
+  deriveIntakeTaxonomyAnchor,
+  isHappyPathIntakeReady,
+  mergeHappyPathStateIntoPlan,
+  normalizeHappyPathState,
+  type HappyPathIntakeState,
+} from "@/lib/explore/feature-build-types";
+
+export type DecompositionChildIntakePatch = {
+  status: "ready";
+  epicId: string;
+  backlogItemId: string | null;
+  taxonomyNodeId: string | null;
+  constrainedGoal: string;
+};
+
+/**
+ * Pure: derive a child's intake from the parent's intake + the child's identity.
+ * - `epicId` anchors on the child's own decomposition Epic (its `parentEpicId`),
+ *   not the parent build's pre-decomposition epic.
+ * - `backlogItemId` / `taxonomyNodeId` inherit from the parent; taxonomy falls
+ *   back to the provenance anchor (`triaged-bi:<id>` / `adhoc-build:<id>`) so the
+ *   result always satisfies `isHappyPathIntakeReady`.
+ * - `constrainedGoal` is the child's scope title (each child is a distinct slice).
+ */
+export function buildDecompositionChildIntakePatch(args: {
+  parentIntake: HappyPathIntakeState | null | undefined;
+  epicSemanticId: string;
+  childTitle: string;
+  childOriginatingBacklogItemId: string | null | undefined;
+  childBuildId: string;
+}): DecompositionChildIntakePatch {
+  const parent = args.parentIntake ?? null;
+  const taxonomyNodeId =
+    parent?.taxonomyNodeId ??
+    deriveIntakeTaxonomyAnchor({
+      taxonomyNodeId: null,
+      originatingBacklogItemId: args.childOriginatingBacklogItemId,
+      buildId: args.childBuildId,
+    });
+  const constrainedGoal =
+    args.childTitle.trim().slice(0, 280) || "Decomposed child build";
+  return {
+    status: "ready",
+    epicId: args.epicSemanticId,
+    backlogItemId: parent?.backlogItemId ?? args.childOriginatingBacklogItemId ?? null,
+    taxonomyNodeId,
+    constrainedGoal,
+  };
+}
+
+/** Merge a derived child intake patch into a plan JSON (or a fresh plan). */
+export function applyChildIntakeToPlan(
+  plan: Record<string, unknown> | null | undefined,
+  patch: DecompositionChildIntakePatch,
+): Record<string, unknown> {
+  return mergeHappyPathStateIntoPlan(plan, { intake: patch });
+}
+
+// ---------------------------------------------------------------------------
+// Self-heal (DB) — backfill intake for an already-created plan-phase child.
+// ---------------------------------------------------------------------------
+
+export type HealChildIntakeDb = {
+  epic: { findUnique: (args: { where: { id: string }; select: { epicId: true } }) => Promise<{ epicId: string } | null> };
+  featureBuild: {
+    findFirst: (args: {
+      where: { supersededByEpicId: string };
+      select: { plan: true };
+    }) => Promise<{ plan: unknown } | null>;
+    update: (args: { where: { buildId: string }; data: { plan: unknown } }) => Promise<unknown>;
+  };
+};
+
+export type HealChildIntakeInput = {
+  child: {
+    buildId: string;
+    title: string;
+    parentEpicId: string;
+    originatingBacklogItemId: string | null;
+    plan: unknown;
+  };
+  db?: HealChildIntakeDb;
+};
+
+/**
+ * Backfill a decomposition child's intake from its superseded parent build.
+ * Idempotent: returns false (no-op) when the child's intake is already ready or
+ * the child is not a decomposition child. Returns true when it wrote a heal.
+ */
+export async function healDecompositionChildIntake(
+  input: HealChildIntakeInput,
+): Promise<boolean> {
+  const { child } = input;
+  const planRec = (child.plan ?? null) as Record<string, unknown> | null;
+  const happy = normalizeHappyPathState(planRec?.["happyPathState"]);
+  if (isHappyPathIntakeReady(happy)) return false;
+
+  const db: HealChildIntakeDb =
+    input.db ?? ((await import("@dpf/db")).prisma as unknown as HealChildIntakeDb);
+
+  // The child's decomposition Epic (semantic id) + the superseded parent build
+  // (whose supersededByEpicId points at that same Epic row) carry the anchors.
+  const [epic, parent] = await Promise.all([
+    db.epic.findUnique({ where: { id: child.parentEpicId }, select: { epicId: true } }),
+    db.featureBuild.findFirst({
+      where: { supersededByEpicId: child.parentEpicId },
+      select: { plan: true },
+    }),
+  ]);
+
+  const parentPlan = (parent?.plan ?? null) as Record<string, unknown> | null;
+  const parentIntake = normalizeHappyPathState(parentPlan?.["happyPathState"]).intake;
+
+  const patch = buildDecompositionChildIntakePatch({
+    parentIntake,
+    epicSemanticId: epic?.epicId ?? child.parentEpicId,
+    childTitle: child.title,
+    childOriginatingBacklogItemId: child.originatingBacklogItemId,
+    childBuildId: child.buildId,
+  });
+  const newPlan = applyChildIntakeToPlan(planRec, patch);
+  await db.featureBuild.update({ where: { buildId: child.buildId }, data: { plan: newPlan } });
+  return true;
+}

--- a/apps/web/lib/integrate/resume-pre-build-phase.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.ts
@@ -239,6 +239,7 @@ export async function resumePreBuildPhase(params: {
     const build = await prisma.featureBuild.findUnique({
       where: { buildId },
       select: {
+        title: true,
         designDoc: true,
         buildPlan: true,
         planReview: true,
@@ -406,6 +407,41 @@ export async function resumePreBuildPhase(params: {
     }
 
     if (phase === "plan") {
+      // Self-heal (BI-FF8ABFCB): a decomposition child is created directly in
+      // `plan` with no plan.happyPathState.intake, so it hard-blocks at the
+      // plan→build gate ("Intake is incomplete") and churns on every resume.
+      // Backfill its intake from the superseded parent build before doing any
+      // (expensive) plan work, so it can actually advance. Idempotent: no-op
+      // once intake is ready or for non-child builds. Fixed forward at
+      // child-creation time in approve-decomposition.ts; this heals the builds
+      // created before that fix shipped.
+      if (build.parentEpicId != null) {
+        try {
+          const { healDecompositionChildIntake } = await import(
+            "@/lib/build/decomposition-child-intake"
+          );
+          const healed = await healDecompositionChildIntake({
+            child: {
+              buildId,
+              title: (build as { title?: string }).title ?? "",
+              parentEpicId: build.parentEpicId,
+              originatingBacklogItemId: build.originatingBacklogItemId ?? null,
+              plan: build.plan,
+            },
+          });
+          if (healed) {
+            return {
+              kind: "resumed",
+              phase,
+              via: "healDecompositionChildIntake",
+              detail: "backfilled decomposition child intake from parent; gate unblocked for next dispatch",
+            };
+          }
+        } catch (err) {
+          // Non-fatal — fall through to the normal plan resume path.
+          console.warn("[resume-pre-build-phase] child intake heal failed:", { buildId }, err);
+        }
+      }
       if (!hasPlanTasks(build.buildPlan)) {
         // No plan yet — re-dispatch plan generation. The dispatcher auto-runs
         // reviewBuildPlan, which advances plan->build when the gate is satisfied.

--- a/docs/superpowers/plans/2026-07-18-decomposition-child-intake-inheritance.md
+++ b/docs/superpowers/plans/2026-07-18-decomposition-child-intake-inheritance.md
@@ -1,0 +1,57 @@
+# Decomposition children must inherit intake from their parent
+
+**BI:** BI-FF8ABFCB (surfaced babysitting the BI-C4F828B7 auto-decompose wave)
+**Status:** implemented
+**Date:** 2026-07-18
+
+## Problem
+
+`approveDecomposition` (`apps/web/lib/build/approve-decomposition.ts`) creates child
+FeatureBuilds directly in `phase="plan"` with the parent's `designDoc`/`designReview`
+copied, but **never sets `plan.happyPathState.intake`**. The plan→build gate
+(`checkPhaseGate` → `isHappyPathIntakeReady`) requires `taxonomyNodeId` +
+`backlogItemId` + `epicId` + `constrainedGoal` — all null on children — so every
+child hard-blocks with *"Intake is incomplete"* and the resume reconciler
+re-dispatches it forever, burning plan-generation spend.
+
+Children skip the ideate `reviewDesignDoc` step that normally auto-populates intake,
+so nothing ever fills it in. Pre-existing defect (operator-driven `approve_decomposition`
+hits it too); the BI-C4F828B7 autopilot auto-decompose fired it at scale — **86/86
+children of the drain wave had `intake = null`**, all stuck churning in `plan`.
+
+## Fix (fix-forward + self-heal)
+
+New module `apps/web/lib/build/decomposition-child-intake.ts`:
+
+- `buildDecompositionChildIntakePatch({ parentIntake, epicSemanticId, childTitle,
+  childOriginatingBacklogItemId, childBuildId })` — pure derivation:
+  - `epicId` = the child's own decomposition Epic (its `parentEpicId`).
+  - `backlogItemId` / `taxonomyNodeId` inherit from the parent; taxonomy falls back
+    to the provenance anchor (`triaged-bi:<id>` / `adhoc-build:<id>`), so the result
+    always satisfies `isHappyPathIntakeReady`.
+  - `constrainedGoal` = the child scope title (each child is a distinct slice).
+- `healDecompositionChildIntake({ child, db? })` — DB self-heal: for a `plan`-phase
+  child with incomplete intake, derive it from the **superseded parent build**
+  (`supersededByEpicId = child.parentEpicId`) + the Epic's semantic id, and persist.
+  Idempotent.
+
+Wiring:
+1. **Fix-forward** — `approveDecomposition` computes `parentIntake` once and sets each
+   child's `plan` via `applyChildIntakeToPlan(null, buildDecompositionChildIntakePatch(...))`
+   at creation time.
+2. **Self-heal** — `resume-pre-build-phase.ts`, at the top of the `phase === "plan"`
+   branch, calls `healDecompositionChildIntake` for any child (`parentEpicId != null`)
+   before doing plan work, so the builds created **before** this fix (the 86 stuck
+   wave children) unblock on their next resume tick after deploy. Non-fatal on error
+   (falls through to the normal resume path).
+
+## Verification
+
+- `apps/web/lib/build/decomposition-child-intake.test.ts` — 6 tests (inheritance,
+  gate-readiness, taxonomy/backlog fallbacks, self-heal write, self-heal no-op).
+- Existing `approve-decomposition` + `resume-pre-build-phase` suites pass (50 total),
+  no regression.
+- Full-workspace `tsc --noEmit` clean.
+
+Live: expected to drain the 86 stuck children (intake backfilled on resume → plan
+gate clears → advance to build) once deployed.


### PR DESCRIPTION
## Problem (found babysitting the BI-C4F828B7 auto-decompose wave)

`approveDecomposition` creates child FeatureBuilds directly in `phase="plan"` with the parent's `designDoc` copied, but **never sets `plan.happyPathState.intake`**. The plan→build gate (`isHappyPathIntakeReady`) requires `taxonomyNodeId` + `backlogItemId` + `epicId` + `constrainedGoal` — all null on children — so every child hard-blocks with *"Intake is incomplete"* and the resume reconciler re-dispatches it forever.

Children skip the ideate `reviewDesignDoc` step that normally auto-populates intake, so nothing fills it. Pre-existing defect (operator-driven decomposition hits it too); BI-C4F828B7's autopilot auto-decompose fired it at scale — **86/86 children of the drain wave had `intake = null`**, all churning in `plan` (`plan_dispatch` fired 219× in 30 min, 0 advancing).

## Fix — fix-forward + self-heal

New `apps/web/lib/build/decomposition-child-intake.ts`:
- `buildDecompositionChildIntakePatch(...)` — pure: inherits parent `backlogItemId`/`taxonomyNodeId`, anchors `epicId` on the child's own decomposition Epic, uses the child scope title as `constrainedGoal`; always satisfies `isHappyPathIntakeReady` (taxonomy falls back to the `triaged-bi:`/`adhoc-build:` provenance anchor).
- `healDecompositionChildIntake(...)` — DB self-heal: derives a stuck child's intake from the **superseded parent build** and persists it. Idempotent.

Wiring:
1. **Fix-forward** — `approveDecomposition` sets each child's intake at creation time.
2. **Self-heal** — `resume-pre-build-phase.ts` heals already-created children at the top of the `plan` branch, so the **86 pre-fix stuck children unblock on their next resume tick** after deploy (non-fatal on error).

## Verification
- **6 new unit tests** (inheritance, gate-readiness, taxonomy/backlog fallbacks, self-heal write + no-op) + existing `approve-decomposition`/`resume-pre-build-phase` suites — **50 pass**, no regression.
- Full-workspace `pnpm typecheck` (heap-raised) — clean.
- Module-size OK.

Plan: `docs/superpowers/plans/2026-07-18-decomposition-child-intake-inheritance.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)