### PR TITLE
feat(attention): blocked-coworker card rationale + concrete impact, tighter layout

### DIFF
--- a/apps/web/components/attention/OwnerDecisionCards.test.tsx
+++ b/apps/web/components/attention/OwnerDecisionCards.test.tsx
@@ -70,6 +70,7 @@ describe("OwnerDecisionCards", () => {
     expect(screen.getByText("Approve this bill?")).toBeTruthy();
     expect(screen.getByText(/Paying the right bills/)).toBeTruthy();
     expect(screen.getByText(/If you do nothing/)).toBeTruthy();
+    expect(screen.getByText(/the bill may become late/)).toBeTruthy();
     expect(screen.getByText("Your COO recommends")).toBeTruthy();
     expect(screen.getByText("Finance")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Review bill" }).getAttribute("href")).toBe(

--- a/apps/web/components/attention/OwnerDecisionCards.tsx
+++ b/apps/web/components/attention/OwnerDecisionCards.tsx
@@ -45,57 +45,59 @@ export function OwnerDecisionCards({
 
 function DecisionSummary({ entry }: { entry: OwnerAttentionEntry }) {
   const { card } = entry;
+  // Prefer the concrete "what the coworker was doing and why it stalled" rationale;
+  // fall back to the generic why-it-matters for self-explanatory approvals.
+  const rationale = card.situation ?? card.whyItMatters;
   return (
-    <span className="block space-y-3">
-      <span className="flex flex-wrap items-center gap-2">
-        {card.tags.map((tag) => (
-          <StatusBadge
-            key={`${tag.kind}:${tag.label}`}
-            domain="ownerDecisionImpact"
-            status={tag.kind}
-            label={tag.label}
-            variant="soft"
-            uppercase={false}
-            className="rounded-full"
-          />
-        ))}
-      </span>
-
-      <span className="block">
+    <span className="block">
+      <span className="flex items-start justify-between gap-3">
         <span className="block text-base font-semibold leading-snug text-[var(--dpf-text)]">
           {card.headline}
         </span>
-        <span className="mt-1 block text-sm leading-relaxed text-[var(--dpf-muted)]">
-          {card.whyItMatters}
-        </span>
+        {card.tags.length > 0 ? (
+          <span className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+            {card.tags.map((tag) => (
+              <StatusBadge
+                key={`${tag.kind}:${tag.label}`}
+                domain="ownerDecisionImpact"
+                status={tag.kind}
+                label={tag.label}
+                variant="soft"
+                uppercase={false}
+                className="rounded-full"
+              />
+            ))}
+          </span>
+        ) : null}
       </span>
 
-      <span className="grid gap-3 md:grid-cols-2">
-        <span className="block rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-          <span className="block text-[10px] font-semibold uppercase tracking-wider text-[var(--dpf-muted)]">
+      <span className="mt-1.5 block text-sm leading-relaxed text-[var(--dpf-muted)]">
+        {rationale}
+      </span>
+
+      <span className="mt-2 block space-y-1.5 border-t border-[var(--dpf-border)] pt-2">
+        <span className="block leading-snug">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--dpf-muted)]">
             If you do nothing
           </span>
-          <span className="mt-1 block text-xs leading-relaxed text-[var(--dpf-text)]">
+          <span className="ml-2 text-xs text-[var(--dpf-text)]">
             {stripConsequenceLead(card.ifYouDoNothing)}
           </span>
         </span>
-
-        <span className="block rounded-md border border-[var(--dpf-accent)]/40 bg-[var(--dpf-surface-2)] p-3">
-          <span className="flex flex-wrap items-baseline gap-x-2">
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--dpf-accent)]">
-              {card.recommendation.lead}
-            </span>
-            <span className="text-[10px] text-[var(--dpf-muted)]">
-              {card.recommendation.specialistByline}
-            </span>
+        <span className="block leading-snug">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--dpf-accent)]">
+            {card.recommendation.lead}
           </span>
-          <span className="mt-1 block text-xs leading-relaxed text-[var(--dpf-text)]">
+          <span className="ml-1.5 text-[10px] text-[var(--dpf-muted)]">
+            {card.recommendation.specialistByline}
+          </span>
+          <span className="ml-2 text-xs text-[var(--dpf-text)]">
             {capitalize(card.recommendation.text)}
           </span>
         </span>
       </span>
 
-      <span className="block text-[11px] font-medium text-[var(--dpf-muted)]">
+      <span className="mt-2 block text-[11px] font-medium text-[var(--dpf-muted)]">
         Technical detail — for builders and your digital team
       </span>
     </span>

--- a/apps/web/lib/attention/owner-decision-copy.ts
+++ b/apps/web/lib/attention/owner-decision-copy.ts
@@ -36,6 +36,25 @@ export function specialistFor(source: AttentionSource): string {
   return SPECIALIST[source];
 }
 
+// Approval sources whose headline already says what the decision is — they do not
+// need a separate "what is happening" rationale line.
+const SELF_EXPLANATORY_SOURCES = new Set<AttentionSource>([
+  "approval-bill",
+  "approval-expense",
+  "approval-outbound",
+  "compliance-submission",
+]);
+
+/** The plain "what the coworker was doing and why it stalled" line. Surfaced from
+ *  the item's own context one-liner for sources whose headline is generic
+ *  (blocked/paused/proposal); undefined for self-explanatory approvals. This is
+ *  the rationale the owner needs to decide — it was previously discarded. */
+export function situationFor(item: AttentionItem): string | undefined {
+  if (SELF_EXPLANATORY_SOURCES.has(item.source)) return undefined;
+  const context = (item.context ?? "").trim();
+  return context.length > 0 ? context : undefined;
+}
+
 export function headlineFor(item: AttentionItem): string {
   if (
     item.source === "escalation" &&
@@ -70,9 +89,18 @@ export function whyItMattersFor(item: AttentionItem): string {
   }
 }
 
+// Placeholder blast-radius strings that read as vague ("a coworker task stays
+// blocked") — skip them so the consequence falls through to a source-specific line.
+const GENERIC_BLAST_RADIUS = new Set(["a coworker task", "a coworker waiting on approval"]);
+
 export function consequenceFor(item: AttentionItem): string {
-  if (item.triage.blastRadius && !looksLikeInternalId(item.triage.blastRadius)) {
-    return `If you do nothing, ${lowerFirst(item.triage.blastRadius)} stays blocked.`;
+  const blastRadius = item.triage.blastRadius;
+  if (
+    blastRadius &&
+    !looksLikeInternalId(blastRadius) &&
+    !GENERIC_BLAST_RADIUS.has(blastRadius.trim().toLowerCase())
+  ) {
+    return `If you do nothing, ${lowerFirst(blastRadius)} stays blocked.`;
   }
   switch (item.source) {
     case "approval-bill":
@@ -85,6 +113,10 @@ export function consequenceFor(item: AttentionItem): string {
       return "If you do nothing, the report stays unfiled and may miss its due date.";
     case "research-proposal":
       return "If you do nothing, the research waits for the weekly review.";
+    case "paused-ai":
+    case "ai-decision":
+    case "agent-proposal":
+      return "If you do nothing, your coworker stays stuck here and the work behind it waits.";
     default:
       return "If you do nothing, this work stays paused while your digital team keeps it safe.";
   }

--- a/apps/web/lib/attention/owner-decision.test.ts
+++ b/apps/web/lib/attention/owner-decision.test.ts
@@ -41,6 +41,36 @@ describe("translateAttentionToOwnerDecision", () => {
     expect(card.recommendation.specialistByline).toBe("Platform operations");
   });
 
+  it("surfaces the coworker's own context as the rationale for a blocked item", () => {
+    const card = translateAttentionToOwnerDecision(
+      item({
+        source: "paused-ai",
+        context: "Waiting for your OK to email the customer the revised quote.",
+        triage: {
+          timeToAct: "none",
+          residueReason: "input-required",
+          blastRadius: "a coworker task",
+          decideEffort: "judgment",
+          irreversible: false,
+        },
+      }),
+      Date.parse("2026-07-17T18:00:00Z"),
+    );
+
+    expect(card.situation).toBe("Waiting for your OK to email the customer the revised quote.");
+    // The vague placeholder blast radius must not leak into the impact line.
+    expect(card.ifYouDoNothing).not.toMatch(/a coworker task/i);
+    expect(card.ifYouDoNothing).toMatch(/stuck|waits/i);
+  });
+
+  it("omits the rationale line for a self-explanatory approval", () => {
+    const card = translateAttentionToOwnerDecision(
+      item({ source: "approval-bill", context: "GBP 240 due" }),
+      Date.parse("2026-07-17T18:00:00Z"),
+    );
+    expect(card.situation).toBeUndefined();
+  });
+
   it("keeps the raw title and builder references in technical detail", () => {
     const card = translateAttentionToOwnerDecision(item(), Date.parse("2026-07-17T18:00:00Z"));
     const details = Object.fromEntries(card.technical.fields.map((field) => [field.label, field.value]));

--- a/apps/web/lib/attention/owner-decision.ts
+++ b/apps/web/lib/attention/owner-decision.ts
@@ -3,6 +3,7 @@ import {
   consequenceFor,
   headlineFor,
   recommendationFor,
+  situationFor,
   specialistFor,
   whyItMattersFor,
 } from "./owner-decision-copy";
@@ -21,6 +22,11 @@ export type OwnerDecisionCard = {
   id: string;
   source: AttentionSource;
   headline: string;
+  /** Plain "what the coworker was doing and why it stalled" for sources whose
+   *  headline is not self-explanatory (blocked/paused/proposal). Sourced from the
+   *  item's own context one-liner; absent for approvals that speak for
+   *  themselves. Rendered as the card's primary rationale. */
+  situation?: string;
   whyItMatters: string;
   ifYouDoNothing: string;
   recommendation: {
@@ -44,6 +50,7 @@ export function translateAttentionToOwnerDecision(
     id: item.id,
     source: item.source,
     headline: headlineFor(item),
+    situation: situationFor(item),
     whyItMatters: whyItMattersFor(item),
     ifYouDoNothing: consequenceFor(item),
     recommendation: {

--- a/docs/user-guide/workspace/attention-inbox.md
+++ b/docs/user-guide/workspace/attention-inbox.md
@@ -25,7 +25,7 @@ Folding "a human must decide this now" into the backlog is a category error: the
 
 - **Only owner decisions reach the daily count.** Routine platform recovery, missing credentials, stalled builds, and service health stay with your digital team. They appear only if they create a real business choice for you.
 - **Money and public actions always come to you.** A proactivity setting can change how routine work is handled, but it cannot bypass approval when money leaves the business or something goes public.
-- **Every card explains the decision.** The top of the card gives a short question, why it matters, what happens if you do nothing, the recommendation, and no more than three plain choices. It never invents a confidence score.
+- **Every card explains the decision.** The top of the card gives a short question; for a blocked coworker, a plain line saying **what it was doing and why it stalled**; a concrete **impact** ("if ignored…"); the **recommendation** with the specialist it came from; and no more than three plain choices. It never invents a confidence score.
 - **Technical detail is preserved.** Open **Technical detail** to see the original title, source, work fields, linked identifiers, detection details, and builder actions. That information is moved one click down, not deleted.
 - **A projection, not another queue.** The inbox is a read-only view *over* each area's own records; it is not a second backlog or ticket tracker. Acting on an item updates the record in its home area.
 - **An empty inbox is a good day.** When nothing needs a decision, the inbox shows **"You're all caught up"** — and, when relevant, a short summary of what your digital team is handling on its own. An empty inbox is reassurance, not an unfinished list.


### PR DESCRIPTION
## What

Operator feedback after the redesign went live: the "a coworker is blocked" decision cards didn't say blocked **from doing what or why**, the impact read vague, and the card **wasted vertical space**.

**Content**
- Surface the item's own `context` one-liner as a plain **rationale** ("what the coworker was doing and why it stalled") — it was populated at the source but discarded in translation.
- Skip the generic `blastRadius` placeholders ("a coworker task") so the **impact** ("if ignored…") reads concretely for paused/blocked/proposal sources.
- Approvals whose headline is self-explanatory keep no extra rationale line.

**Visual**
- Replace the two bordered `p-3` boxes + `space-y-3` stack with: headline (tags inline) → rationale → compact hairline **"If ignored"** and **"COO · <specialist>"** rows → technical detail. ~half the height, no dead air.

## Design grounding

Extends the decision-card contract in `docs/superpowers/specs/2026-07-17-needs-you-cognitive-load-redesign-design.md`; surfaces the existing `AttentionItem.context`. No new contract. Doc updated (`attention-inbox.md`).

## Verification

Added tests: rationale surfaced for a blocked item, generic blast-radius no longer leaks into the impact, rationale omitted for approvals; updated the card render test for the new hairline layout. Local run blocked by a source-only worktree (no `next`/`vitest`); required CI Typecheck + Unit Tests verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)