### PR TITLE
fix(build): Work Control status reflects activity freshness — stalled builds show "Needs you", not "Working"

### DIFF
--- a/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
+++ b/apps/web/components/build/BuildStudioHeaderLayout.test.tsx
@@ -538,6 +538,10 @@ describe("BuildStudio active-build header layout", () => {
         buildId: "FB-FOCUS",
         title: "Review customer entry gate",
         phase: "review",
+        // A genuinely-working build has a fresh heartbeat; without it the
+        // stall check (BI-46204009) correctly reclassifies a build/review build
+        // with a stale updatedAt as "Needs you", not "Working".
+        updatedAt: new Date(),
         originator: null,
       }),
       makeBuild({
@@ -546,6 +550,7 @@ describe("BuildStudio active-build header layout", () => {
         title: "Ship provider readiness check",
         phase: "build",
         buildExecState: { step: "code_generated" } as unknown as FeatureBuildRow["buildExecState"],
+        updatedAt: new Date(),
         originator: null,
       }),
       makeBuild({

--- a/apps/web/components/build/fleet-derivation.test.ts
+++ b/apps/web/components/build/fleet-derivation.test.ts
@@ -14,6 +14,7 @@ import {
   deriveQueueState,
   formatOperatorFocusHeader,
   formatFleetHeader,
+  isBuildStalled,
   isOperatorFocusEntry,
 } from "./fleet-derivation";
 import {
@@ -365,5 +366,45 @@ describe("deriveCoworkerActivityCount", () => {
     ];
     expect(deriveCoworkerActivityCount(builds)).toBe(3);
     expect(deriveCoworkerActivityCount([])).toBe(0);
+  });
+});
+
+describe("stall detection (BI-46204009) — status reflects activity freshness", () => {
+  const now = new Date("2026-07-18T00:00:00Z").getTime();
+  const fresh = new Date(now - 5 * 60 * 1000); // 5 min ago — healthy checkpoint cadence
+  const stale = new Date(now - 3 * 60 * 60 * 1000); // 3h ago — frozen
+
+  it("flags a build- or review-phase build with no recent update as stalled", () => {
+    expect(isBuildStalled(makeBuild({ phase: "build", updatedAt: stale }), now)).toBe(true);
+    expect(isBuildStalled(makeBuild({ phase: "review", updatedAt: stale }), now)).toBe(true);
+  });
+
+  it("does not flag a freshly-updated build as stalled", () => {
+    expect(isBuildStalled(makeBuild({ phase: "build", updatedAt: fresh }), now)).toBe(false);
+  });
+
+  it("never flags off-rail (ideate/plan) or terminal phases, even when stale", () => {
+    for (const phase of ["ideate", "plan", "ship", "complete"] as const) {
+      expect(isBuildStalled(makeBuild({ phase, updatedAt: stale }), now)).toBe(false);
+    }
+  });
+
+  it("reports a stalled build as blocked (not an animated running/Working badge)", () => {
+    const state = deriveQueueState(makeBuild({ phase: "build", updatedAt: stale }), now);
+    expect(state.kind).toBe("blocked");
+    if (state.kind === "blocked") expect(state.reason).toMatch(/^Stalled/);
+  });
+
+  it("keeps a fresh build-phase build as running", () => {
+    const state = deriveQueueState(
+      makeBuild({ phase: "build", updatedAt: fresh, buildExecState: null }),
+      now,
+    );
+    expect(state.kind).toBe("running");
+  });
+
+  it("routes a stalled build to Needs-you, and leaves a fresh one alone", () => {
+    expect(deriveNeedsAttention(makeBuild({ phase: "build", updatedAt: stale }), now)).toBe(true);
+    expect(deriveNeedsAttention(makeBuild({ phase: "build", updatedAt: fresh }), now)).toBe(false);
   });
 });

--- a/apps/web/components/build/fleet-derivation.ts
+++ b/apps/web/components/build/fleet-derivation.ts
@@ -10,6 +10,45 @@
 import type { FeatureBuildRow } from "@/lib/feature-build-types";
 import type { BuildQueueState } from "./QueueStateBadge";
 
+// BI-46204009: the fleet status must reflect ACTIVITY FRESHNESS, not just the
+// stored phase. A build frozen in an active phase (its watchdog stall never
+// remediated — see BI-EB33BD37) otherwise renders forever as an animated
+// "running / Working" badge, implying live work where there is none. A build in
+// build/review whose last update is older than this floor is treated as stalled
+// (→ needs-attention, off the "Working" count). Healthy builds checkpoint
+// FeatureBuild.updatedAt every few minutes, so a conservative 30-minute floor
+// avoids false positives on normal long-running steps. A BuildActivity-heartbeat
+// signal (tighter + join-based) is the ideal follow-up.
+export const STALL_THRESHOLD_MS = 30 * 60 * 1000;
+
+function updatedMs(build: Pick<FeatureBuildRow, "updatedAt">): number {
+  // updatedAt is typed Date but arrives as an ISO string after RSC
+  // serialization on the client — new Date() handles both.
+  return new Date(build.updatedAt).getTime();
+}
+
+/**
+ * True when a build sits in an active execution phase (build/review) but has had
+ * no update for longer than {@link STALL_THRESHOLD_MS} — i.e. it is frozen, not
+ * working. Only build/review can stall: ideate/plan are off-rail coworker
+ * custody and ship/complete/failed/abandoned are terminal-ish.
+ */
+export function isBuildStalled(
+  build: Pick<FeatureBuildRow, "phase" | "updatedAt">,
+  now: number = Date.now(),
+): boolean {
+  if (build.phase !== "build" && build.phase !== "review") return false;
+  const ms = updatedMs(build);
+  if (Number.isNaN(ms)) return false;
+  return now - ms > STALL_THRESHOLD_MS;
+}
+
+function stalledReason(build: Pick<FeatureBuildRow, "updatedAt">, now: number): string {
+  const mins = Math.round((now - updatedMs(build)) / 60000);
+  const label = mins >= 120 ? `${Math.round(mins / 60)}h` : `${mins} min`;
+  return `Stalled — no activity for ${label}. Needs attention.`;
+}
+
 /**
  * Derive a BuildQueueState from the FeatureBuildRow's phase + execution state.
  *
@@ -24,10 +63,18 @@ import type { BuildQueueState } from "./QueueStateBadge";
  * a passthrough from that source — the discriminated-union shape doesn't
  * change, so callers won't need to update.
  */
-export function deriveQueueState(build: FeatureBuildRow): BuildQueueState {
+export function deriveQueueState(build: FeatureBuildRow, now: number = Date.now()): BuildQueueState {
   // Terminal failure — operator needs to look.
   if (build.phase === "failed") {
     return { kind: "blocked", reason: "Build failed; reset or retry from the action card." };
+  }
+
+  // BI-46204009: a stalled build/review build is frozen, not running — never show
+  // it as a live "running/Working" badge. Surface it as blocked with the staleness
+  // so the operator sees it needs attention (deriveNeedsAttention agrees, moving it
+  // to the "Needs you" band and out of the "Working" count).
+  if (isBuildStalled(build, now)) {
+    return { kind: "blocked", reason: stalledReason(build, now) };
   }
 
   // Build phase: examine buildExecState for richer signal.
@@ -92,6 +139,7 @@ function humanizeStep(step: string): string {
  *
  * Heuristic — kept conservative so the attention dot stays meaningful:
  *   - phase=failed → yes (terminal)
+ *   - phase=build/review + no update for > STALL_THRESHOLD_MS (stalled) → yes
  *   - phase=build + buildExecState.error set → yes
  *   - planReview / designReview with decision="fail" → yes (waiting on revision)
  *   - phase=ship with no acceptanceMet → yes (operator decision needed)
@@ -100,8 +148,12 @@ function humanizeStep(step: string): string {
  * The fleet row renders this as the plain "Needs you" status so the cue is
  * readable without decoding symbols.
  */
-export function deriveNeedsAttention(build: FeatureBuildRow): boolean {
+export function deriveNeedsAttention(build: FeatureBuildRow, now: number = Date.now()): boolean {
   if (build.phase === "failed") return true;
+
+  // BI-46204009: a build frozen in an active phase (stalled watchdog, never
+  // remediated) needs the operator, not an animated "Working" badge.
+  if (isBuildStalled(build, now)) return true;
 
   if (build.phase === "build") {
     const exec = build.buildExecState as { error?: string | null } | null | undefined;


### PR DESCRIPTION
## Why

The /build Work Control panel showed a build as **"Working"** with an animated bar based purely on its stored `FeatureBuild.phase`, blind to whether anything was actually happening. Observed live: **FB-CCEC4210** ("Backlog → Build Studio autopilot pipeline") sat in `phase=build` for **~3 days** — `buildExecState=NULL`, `claimStatus=NULL`, last `BuildActivity` ~3 days ago, 0 events in the last 15 min — yet rendered as "Working," while **86 other builds** were genuinely churning (385 events/15 min). Fixes **BI-46204009**.

## What changed

`apps/web/components/build/fleet-derivation.ts` — the pure derivation now takes activity freshness into account. A build in `build`/`review` whose `updatedAt` is older than `STALL_THRESHOLD_MS` (30 min) is treated as **stalled**:
- `deriveQueueState` → `{ kind: "blocked", reason: "Stalled — no activity for …" }` (no animated running/Working glyph on the row).
- `deriveNeedsAttention` → `true`, so it moves to the **"Needs you"** band and out of the **"Working"** count (`BuildStudio.tsx` already excludes `needsAttention` entries from `deriveFleetCounts`).

Only `build`/`review` can stall — `ideate`/`plan` are off-rail coworker custody; `ship`/`complete`/`failed`/`abandoned` are terminal-ish. Healthy builds checkpoint `updatedAt` every few minutes (the genuinely-working review build in the repro was 8 min fresh), so a 30-minute floor avoids false positives. Reuses the existing `blocked` queue kind — no `QueueStateBadge` union change.

## Scope / follow-up

This is the **presentation-honesty** half. The **root cause** — the watchdog *detected* this build's stall (a `watchdog:stall` / `heartbeat_timeout in phase build` event at the freeze time) but never remediated it, and the 7-day abandon age-out only covers stranded ideate/plan — is tracked in **BI-EB33BD37** (next). A tighter `BuildActivity`-heartbeat freshness signal (vs the `updatedAt` proxy) is a natural refinement.

## Verification

- ✅ Typecheck — `tsc --noEmit`: **0 errors**.
- ✅ Unit — `vitest components/build/fleet-derivation.test.ts`: **33 passed** (26 existing + 6 new stall cases: stale build/review → stalled; fresh → running; ideate/plan/terminal never stall; stalled → blocked + Needs-you).

UX-Fit-Decision: progressive-disclosure / low cognitive-load — the status now tells the operator the truth (stalled → needs you) instead of a misleading "Working" animation; no new operator inputs. Scored on human_cognitive_load.

Design-Grounding-Decision: reviewed docs/superpowers + backlog (BI-297863B2 manual-abandon, BI-A1FC3EBB watchdog anomaly — neither covers status honesty); reviewed fleet-derivation.ts, BuildStudio.tsx band counting, QueueStateBadge, FeatureBuildRow (updatedAt already present), and the live DB repro. Extends the existing pure derivation contract with an activity-freshness input; reuses the "blocked" kind; no routing/queue/contract change.

Local-CI-Override: Verified in a compile-ready worktree at the PR head — `tsc --noEmit` (0 errors) and vitest (33 passed). CI runs the authoritative production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
