### PR TITLE
fix(build): reap stalled-after-activity builds — close the watchdog detect→remediate loop (BI-EB33BD37)

### DIFF
--- a/apps/web/lib/build/inert-build-reaper.test.ts
+++ b/apps/web/lib/build/inert-build-reaper.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { isInertBuildReapable, INERT_BUILD_REAP_MS } from "./inert-build-reaper";
+import {
+  isInertBuildReapable,
+  isStalledBuildReapable,
+  INERT_BUILD_REAP_MS,
+  STALLED_BUILD_REAP_MS,
+} from "./inert-build-reaper";
 
 const NOW = new Date("2026-06-19T16:00:00.000Z");
 const thresholdMs = 3 * 60 * 60 * 1000; // 3h
@@ -60,5 +65,64 @@ describe("isInertBuildReapable", () => {
   it("exports a sane default threshold (a few hours)", () => {
     expect(INERT_BUILD_REAP_MS).toBeGreaterThanOrEqual(60 * 60 * 1000);
     expect(INERT_BUILD_REAP_MS).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
+  });
+});
+
+describe("isStalledBuildReapable (BI-EB33BD37 — stalled-after-activity remediation)", () => {
+  const staleMs = 6 * 60 * 60 * 1000; // 6h
+
+  function stalledBase(
+    overrides: Partial<Parameters<typeof isStalledBuildReapable>[0]> = {},
+  ) {
+    return {
+      phase: "build",
+      abandonedAt: null as Date | null,
+      parentEpicId: null as string | null,
+      activityCount: 500, // did substantial work
+      liveTaskRunCount: 0, // watchdog already marked its runs stalled
+      lastActivityAt: new Date(NOW.getTime() - 12 * 60 * 60 * 1000), // silent 12h
+      now: NOW,
+      staleMs,
+      ...overrides,
+    };
+  }
+
+  it("reaps a build that did work then went silent past the stale window", () => {
+    expect(isStalledBuildReapable(stalledBase())).toBe(true);
+    expect(isStalledBuildReapable(stalledBase({ phase: "review" }))).toBe(true);
+  });
+
+  it("does NOT reap a build with a live task run (genuinely working)", () => {
+    expect(isStalledBuildReapable(stalledBase({ liveTaskRunCount: 1 }))).toBe(false);
+  });
+
+  it("does NOT reap a build whose last activity is within the stale window", () => {
+    expect(
+      isStalledBuildReapable(
+        stalledBase({ lastActivityAt: new Date(NOW.getTime() - 60 * 1000) }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT reap a zero-activity build (that is the inert reaper's job)", () => {
+    expect(isStalledBuildReapable(stalledBase({ activityCount: 0 }))).toBe(false);
+  });
+
+  it("stays conservative when last activity is unknown", () => {
+    expect(isStalledBuildReapable(stalledBase({ lastActivityAt: null }))).toBe(false);
+  });
+
+  it("only stalls active phases — not ideate/plan/ship or terminal phases", () => {
+    for (const phase of ["ideate", "plan", "ship", "complete", "failed", "abandoned"]) {
+      expect(isStalledBuildReapable(stalledBase({ phase }))).toBe(false);
+    }
+  });
+
+  it("does NOT reap an epic-decomposed child", () => {
+    expect(isStalledBuildReapable(stalledBase({ parentEpicId: "EP-123" }))).toBe(false);
+  });
+
+  it("exports a conservative default well beyond a healthy activity gap", () => {
+    expect(STALLED_BUILD_REAP_MS).toBeGreaterThanOrEqual(2 * 60 * 60 * 1000);
   });
 });

--- a/apps/web/lib/build/inert-build-reaper.ts
+++ b/apps/web/lib/build/inert-build-reaper.ts
@@ -56,7 +56,57 @@ export function isInertBuildReapable(args: {
 }
 
 /**
- * DB wrapper — find inert builds and abandon them, freeing their WIP slots.
+ * Default stalled-after-activity threshold: 6h with no BuildActivity = a build
+ * that DID work then froze. Override with BUILD_STALLED_REAP_MS.
+ *
+ * Deliberately far larger than any healthy step's activity gap (real builds emit
+ * BuildActivity every few minutes), so a genuinely-long-running step is never
+ * mistaken for stalled.
+ */
+export const STALLED_BUILD_REAP_MS = Number(process.env.BUILD_STALLED_REAP_MS) || 6 * 60 * 60 * 1000;
+
+/**
+ * Pure decision: is this build STALLED-AFTER-ACTIVITY and safe to reap? No DB.
+ * Unit-tested. This is the remediation half of the watchdog detect→remediate
+ * loop (BI-EB33BD37) — the companion to {@link isInertBuildReapable}, which only
+ * covers zero-activity dead-on-arrival builds. A build that produced work and
+ * then went silent (e.g. FB-CCEC4210: build orchestration completed, then a
+ * heartbeat_timeout, then 3 days frozen in `build`) was covered by neither the
+ * inert reaper (activityCount>0) nor the 7-day ideate/plan abandon age-out.
+ *
+ * SAFETY: the `liveTaskRunCount > 0` guard is load-bearing. A genuinely-working
+ * build always has a live TaskRun; the watchdog marks stalled runs non-live
+ * BEFORE this runs (same sweep — taskrun-watchdog.ts), so this only ever fires
+ * on a build whose runs are already stalled/done and whose last activity is old.
+ * Abandon is reversible: re-promote the backlog item to retry cleanly.
+ */
+export function isStalledBuildReapable(args: {
+  phase: string;
+  abandonedAt: Date | null;
+  parentEpicId: string | null;
+  activityCount: number;
+  liveTaskRunCount: number;
+  lastActivityAt: Date | null;
+  now: Date;
+  staleMs: number;
+}): boolean {
+  const { phase, abandonedAt, parentEpicId, activityCount, liveTaskRunCount, lastActivityAt, now, staleMs } = args;
+  if (abandonedAt) return false;
+  if (parentEpicId) return false; // epic-decomposed child — coordinated elsewhere
+  // Only the active EXECUTION phases can stall-after-activity here (matches the
+  // UI stall definition, BI-46204009). ideate/plan are coworker-custody and are
+  // covered by the 7-day age-out (BI-A009313E) + the zero-activity inert reaper;
+  // ship/complete/failed/abandoned own their own flows.
+  if (phase !== "build" && phase !== "review") return false;
+  if (liveTaskRunCount > 0) return false; // actively running right now — never reap
+  if (activityCount === 0) return false; // zero activity is the inert reaper's job
+  if (!lastActivityAt) return false; // unknown freshness — stay conservative
+  return now.getTime() - lastActivityAt.getTime() > staleMs;
+}
+
+/**
+ * DB wrapper — find inert AND stalled-after-activity builds and abandon them,
+ * freeing their WIP slots (BI-8F45BA74 + BI-EB33BD37).
  * Returns the count reaped. Best-effort per row (one tx each) so a single
  * failure never aborts the sweep. Re-checks under the transaction to avoid
  * racing a build that just came alive between the scan and the write.
@@ -64,9 +114,12 @@ export function isInertBuildReapable(args: {
 export async function reapInertStuckBuilds(
   now: Date = new Date(),
   thresholdMs: number = INERT_BUILD_REAP_MS,
+  staleAfterActivityMs: number = STALLED_BUILD_REAP_MS,
 ): Promise<number> {
   const { prisma } = await import("@dpf/db");
-  const cutoff = new Date(now.getTime() - thresholdMs);
+  // Coarse cutoff is the SMALLER of the two thresholds so neither an inert nor a
+  // stalled candidate is excluded before the precise per-candidate check.
+  const cutoff = new Date(now.getTime() - Math.min(thresholdMs, staleAfterActivityMs));
 
   // Coarse scalar filter (indexed); per-candidate activity/taskrun checks below.
   const candidates = await prisma.featureBuild.findMany({
@@ -83,26 +136,45 @@ export async function reapInertStuckBuilds(
 
   let reaped = 0;
   for (const c of candidates) {
-    const [activityCount, liveTaskRunCount] = await Promise.all([
+    const [activityCount, liveTaskRunCount, lastActivity] = await Promise.all([
       prisma.buildActivity.count({ where: { buildId: c.buildId } }),
       prisma.taskRun.count({ where: { buildId: c.buildId, status: { in: [...TASK_LIVE_STATES] } } }),
+      prisma.buildActivity.findFirst({
+        where: { buildId: c.buildId },
+        orderBy: { createdAt: "desc" },
+        select: { createdAt: true },
+      }),
     ]);
-    if (
-      !isInertBuildReapable({
+    const lastActivityAt = lastActivity?.createdAt ?? null;
+
+    const inert = isInertBuildReapable({
+      phase: c.phase,
+      abandonedAt: null,
+      parentEpicId: null,
+      createdAt: c.createdAt,
+      activityCount,
+      liveTaskRunCount,
+      now,
+      thresholdMs,
+    });
+    const stalled =
+      !inert &&
+      isStalledBuildReapable({
         phase: c.phase,
         abandonedAt: null,
         parentEpicId: null,
-        createdAt: c.createdAt,
         activityCount,
         liveTaskRunCount,
+        lastActivityAt,
         now,
-        thresholdMs,
-      })
-    ) {
-      continue;
-    }
+        staleMs: staleAfterActivityMs,
+      });
+    if (!inert && !stalled) continue;
 
     const hoursOld = Math.round((now.getTime() - c.createdAt.getTime()) / 3_600_000);
+    const staleHours = lastActivityAt
+      ? Math.round((now.getTime() - lastActivityAt.getTime()) / 3_600_000)
+      : hoursOld;
     try {
       await prisma.$transaction(async (tx) => {
         // Re-check under the row: don't reap a build that just came alive.
@@ -111,33 +183,51 @@ export async function reapInertStuckBuilds(
           select: { phase: true, abandonedAt: true },
         });
         if (!fresh || fresh.abandonedAt || TERMINAL_BUILD_PHASES.includes(fresh.phase)) return;
-        const recount = await tx.buildActivity.count({ where: { buildId: c.buildId } });
-        if (recount > 0) return;
+
+        if (inert) {
+          const recount = await tx.buildActivity.count({ where: { buildId: c.buildId } });
+          if (recount > 0) return; // gained activity since the scan — no longer inert
+        } else {
+          // Stalled: bail if it came alive since the scan — a live task run, or a
+          // fresh BuildActivity within the stale window.
+          const [liveNow, freshLast] = await Promise.all([
+            tx.taskRun.count({ where: { buildId: c.buildId, status: { in: [...TASK_LIVE_STATES] } } }),
+            tx.buildActivity.findFirst({
+              where: { buildId: c.buildId },
+              orderBy: { createdAt: "desc" },
+              select: { createdAt: true },
+            }),
+          ]);
+          if (liveNow > 0) return;
+          if (!freshLast || now.getTime() - freshLast.createdAt.getTime() <= staleAfterActivityMs) return;
+        }
+
+        const abandonReason = inert
+          ? `Auto-reaped: inert build — no activity for >${Math.round(thresholdMs / 3_600_000)}h, ` +
+            `stuck in ${c.phase}. Freed a Build Studio WIP slot; re-promote the backlog item to retry. (BI-8F45BA74)`
+          : `Auto-reaped: stalled build — did work then no activity for >${Math.round(staleAfterActivityMs / 3_600_000)}h ` +
+            `with no live task run, stuck in ${c.phase}. Freed a Build Studio WIP slot; re-promote the backlog item to retry. (BI-EB33BD37)`;
 
         await tx.featureBuild.update({
           where: { buildId: c.buildId },
-          data: {
-            phase: "abandoned",
-            abandonedAt: now,
-            abandonReason:
-              `Auto-reaped: inert build — no activity for >${Math.round(thresholdMs / 3_600_000)}h, ` +
-              `stuck in ${c.phase}. Freed a Build Studio WIP slot; re-promote the backlog item to retry. (BI-8F45BA74)`,
-          },
+          data: { phase: "abandoned", abandonedAt: now, abandonReason },
         });
         await tx.buildActivity.create({
           data: {
             buildId: c.buildId,
-            tool: "watchdog:reap-inert",
-            summary: `Reaped inert build (${hoursOld}h old, 0 activity in ${c.phase}) to free a WIP slot.`,
+            tool: inert ? "watchdog:reap-inert" : "watchdog:reap-stalled",
+            summary: inert
+              ? `Reaped inert build (${hoursOld}h old, 0 activity in ${c.phase}) to free a WIP slot.`
+              : `Reaped stalled build (last activity ${staleHours}h ago, no live run in ${c.phase}) to free a WIP slot.`,
           },
         });
       });
       reaped += 1;
       console.warn(
-        `[inert-build-reaper] reaped inert build ${c.buildId} (${hoursOld}h old, phase=${c.phase}, 0 activity)`,
+        `[inert-build-reaper] reaped ${inert ? "inert" : "stalled"} build ${c.buildId} (${hoursOld}h old, phase=${c.phase}, last activity ${staleHours}h ago)`,
       );
     } catch (err) {
-      console.warn(`[inert-build-reaper] failed to reap inert build ${c.buildId}:`, err);
+      console.warn(`[inert-build-reaper] failed to reap build ${c.buildId}:`, err);
     }
   }
   return reaped;


### PR DESCRIPTION
## Why

Root-cause half of the stalled-build problem (companion to #3257, the display-honesty half). **BI-EB33BD37.**

The watchdog **detects** build/review stalls (marks TaskRuns stalled, writes a `watchdog:stall` event) but never **remediated** a build that did work and then froze — the inert reaper only handled **zero-activity** builds, and the 7-day age-out only covers ideate/plan. So `FB-CCEC4210` sat in `build` for ~3 days (787 activity events, then silent), holding a WIP slot and rendering as "Working."

## What changed

Extended `apps/web/lib/build/inert-build-reaper.ts` — already invoked each watchdog sweep (`taskrun-watchdog.ts:266`) — with a **stalled-after-activity** reap path:

- **`isStalledBuildReapable`** (pure, unit-tested): `build`/`review` phase, has activity, **no live TaskRun**, and last `BuildActivity` older than `STALLED_BUILD_REAP_MS` (6h default; `BUILD_STALLED_REAP_MS` override).
- The **`liveTaskRunCount === 0` guard is load-bearing**: a genuinely-working build always has a live run, and the watchdog marks stalled runs non-live earlier in the *same* sweep — so this only ever fires on already-stalled builds. That's the safe sequencing that avoids the healthy-build-marked-failed regression the `shouldSurfaceBuildFailure` guard was added to prevent.
- Abandon is **reversible** (re-promote the backlog item to retry). An under-tx re-check bails if the build came alive since the scan (a live run or fresh activity).
- Restricted to `build`/`review` (matches the UI stall definition, BI-46204009); ideate/plan keep the 7-day cap; ship/terminal own their flows. The existing zero-activity inert path is unchanged.

Result: `FB-CCEC4210`-shaped zombies now get abandoned within the stale window, freeing the WIP slot and surfacing an honest reason — instead of lingering forever.

## Verification

- ✅ Typecheck — `tsc --noEmit`: **0 errors**.
- ✅ Unit — `vitest lib/build/inert-build-reaper.test.ts`: **18 passed** (8 new: stalled build/review reapable; live-run / fresh-activity / zero-activity / unknown-freshness / ideate-plan-ship-terminal / epic-child all NOT reapable).

Local-CI-Override: verified in a compile-ready worktree — `tsc --noEmit` (0 errors) and the reaper unit suite (18 passed). CI runs the authoritative production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
