### PR TITLE
fix(backlog): atomic claim-on-start + stale-claim reaper (BI-B62B9F1E)

### DIFF
--- a/apps/web/lib/backlog/claim-on-start.test.ts
+++ b/apps/web/lib/backlog/claim-on-start.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  STALE_BACKLOG_CLAIM_MS,
+  isActivelyClaimedByOther,
+  buildAtomicClaimWhere,
+  buildClaimAcquireData,
+  tryAcquireBacklogClaimAtomic,
+  reapStaleBacklogClaims,
+} from "./claim-on-start";
+
+const NOW = new Date("2026-07-18T12:00:00.000Z");
+
+describe("isActivelyClaimedByOther", () => {
+  it("is false when claim is free", () => {
+    expect(
+      isActivelyClaimedByOther(
+        { claimStatus: null, claimedById: null, claimedByAgentId: null, claimedAt: null },
+        { userId: "u1", agentId: "a1", now: NOW },
+      ),
+    ).toBe(false);
+  });
+
+  it("is true when another session holds a fresh active claim", () => {
+    expect(
+      isActivelyClaimedByOther(
+        {
+          claimStatus: "active",
+          claimedById: "u2",
+          claimedByAgentId: "a2",
+          claimedAt: new Date(NOW.getTime() - 60_000),
+        },
+        { userId: "u1", agentId: "a1", now: NOW },
+      ),
+    ).toBe(true);
+  });
+
+  it("is false when the claim is stale (dead session)", () => {
+    expect(
+      isActivelyClaimedByOther(
+        {
+          claimStatus: "active",
+          claimedById: "u2",
+          claimedByAgentId: "a2",
+          claimedAt: new Date(NOW.getTime() - STALE_BACKLOG_CLAIM_MS - 1),
+        },
+        { userId: "u1", agentId: "a1", now: NOW },
+      ),
+    ).toBe(false);
+  });
+
+  it("is false when the caller already owns the claim", () => {
+    expect(
+      isActivelyClaimedByOther(
+        {
+          claimStatus: "active",
+          claimedById: "u1",
+          claimedByAgentId: "a1",
+          claimedAt: new Date(NOW.getTime() - 60_000),
+        },
+        { userId: "u1", agentId: "a1", now: NOW },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("buildAtomicClaimWhere", () => {
+  it("matches only the row id when force=true", () => {
+    expect(buildAtomicClaimWhere("row-1", { userId: "u1", agentId: "a1", force: true })).toEqual({
+      id: "row-1",
+    });
+  });
+
+  it("allows free, non-active, stale, or owned claims without force", () => {
+    const where = buildAtomicClaimWhere("row-1", {
+      userId: "u1",
+      agentId: "a1",
+      force: false,
+      now: NOW,
+    }) as { id: string; OR: unknown[] };
+    expect(where.id).toBe("row-1");
+    expect(where.OR).toEqual(
+      expect.arrayContaining([
+        { claimStatus: null },
+        { claimStatus: { not: "active" } },
+        { claimedAt: null },
+        { claimedAt: { lt: new Date(NOW.getTime() - STALE_BACKLOG_CLAIM_MS) } },
+        {
+          AND: [
+            { claimStatus: "active" },
+            { OR: [{ claimedById: "u1" }, { claimedByAgentId: "a1" }] },
+          ],
+        },
+      ]),
+    );
+  });
+});
+
+describe("tryAcquireBacklogClaimAtomic", () => {
+  it("wins when updateMany affects one row", async () => {
+    const db = {
+      backlogItem: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findUnique: vi.fn(),
+      },
+    };
+    const res = await tryAcquireBacklogClaimAtomic({
+      db,
+      itemRowId: "row-1",
+      userId: "u1",
+      agentId: "a1",
+      now: NOW,
+    });
+    expect(res).toEqual({ ok: true, forced: false });
+    expect(db.backlogItem.updateMany).toHaveBeenCalledWith({
+      where: buildAtomicClaimWhere("row-1", { userId: "u1", agentId: "a1", force: false, now: NOW }),
+      data: buildClaimAcquireData({ userId: "u1", agentId: "a1", now: NOW }),
+    });
+    expect(db.backlogItem.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns claim_conflict when updateMany affects zero rows (race loser)", async () => {
+    const db = {
+      backlogItem: {
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+        findUnique: vi.fn().mockResolvedValue({
+          claimStatus: "active",
+          claimedById: "u2",
+          claimedByAgentId: "a2",
+          claimedAt: new Date(NOW.getTime() - 120_000),
+        }),
+      },
+    };
+    const res = await tryAcquireBacklogClaimAtomic({
+      db,
+      itemRowId: "row-1",
+      userId: "u1",
+      agentId: "a1",
+      now: NOW,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected conflict");
+    expect(res.error).toBe("claim_conflict");
+    expect(res.claimedById).toBe("u2");
+    expect(res.claimedByAgentId).toBe("a2");
+  });
+
+  it("force takeover uses unrestricted where", async () => {
+    const db = {
+      backlogItem: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findUnique: vi.fn(),
+      },
+    };
+    const res = await tryAcquireBacklogClaimAtomic({
+      db,
+      itemRowId: "row-1",
+      userId: "u1",
+      agentId: "a1",
+      force: true,
+      now: NOW,
+    });
+    expect(res).toEqual({ ok: true, forced: true });
+    expect(db.backlogItem.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "row-1" } }),
+    );
+  });
+});
+
+describe("reapStaleBacklogClaims", () => {
+  it("releases active claims older than the stale window", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 3 });
+    const res = await reapStaleBacklogClaims({
+      db: { backlogItem: { updateMany } },
+      now: NOW,
+    });
+    expect(res).toEqual({ reaped: 3 });
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        claimStatus: "active",
+        claimedAt: { lt: new Date(NOW.getTime() - STALE_BACKLOG_CLAIM_MS) },
+      },
+      data: { claimStatus: "released" },
+    });
+  });
+});

--- a/apps/web/lib/backlog/claim-on-start.ts
+++ b/apps/web/lib/backlog/claim-on-start.ts
@@ -1,0 +1,217 @@
+// apps/web/lib/backlog/claim-on-start.ts
+//
+// Atomic BacklogItem claim-on-start (BI-B62B9F1E / concurrency analysis R5).
+//
+// The previous gate read claim freshness then UPDATEd inside a transaction —
+// two sessions could both pass the pre-transaction check and both claim
+// (classic TOCTOU). The fix mirrors NonProductionEnvironmentLease: the
+// database row update IS the gate. Concurrent UPDATEs on the same row
+// serialize; the loser's WHERE no longer matches and count stays 0.
+//
+// Shape (single BacklogItem row, not a lease CREATE):
+//   UPDATE ... WHERE id = $id AND (claim free | stale | owned-by-caller | force)
+//   → count === 1 win, count === 0 conflict
+//
+// Stale claims (older than STALE_BACKLOG_CLAIM_MS) are reclaimable inline and
+// are also swept by reapStaleBacklogClaims so dead-session "active" rows do
+// not linger as operator noise.
+
+export const STALE_BACKLOG_CLAIM_MS = 12 * 60 * 60 * 1000;
+
+export type BacklogClaimSnapshot = {
+  claimStatus: string | null;
+  claimedById: string | null;
+  claimedByAgentId: string | null;
+  claimedAt: Date | string | null;
+};
+
+export type ClaimAcquireInput = {
+  userId: string;
+  agentId: string | null;
+  force?: boolean;
+  now?: Date;
+};
+
+/**
+ * Pure predicate: does this snapshot represent a fresh active claim held by
+ * someone other than the caller? Used by unit tests and advisory pre-checks;
+ * the atomic write path does not rely on it for correctness.
+ */
+export function isActivelyClaimedByOther(
+  snapshot: BacklogClaimSnapshot,
+  input: ClaimAcquireInput,
+): boolean {
+  if (snapshot.claimStatus !== "active") return false;
+  if (!snapshot.claimedById && !snapshot.claimedByAgentId) return false;
+  const claimedAtMs = snapshot.claimedAt ? new Date(snapshot.claimedAt).getTime() : 0;
+  const nowMs = (input.now ?? new Date()).getTime();
+  if (!claimedAtMs || nowMs - claimedAtMs >= STALE_BACKLOG_CLAIM_MS) return false;
+  const ownedByCaller =
+    (snapshot.claimedById != null && snapshot.claimedById === input.userId) ||
+    (snapshot.claimedByAgentId != null &&
+      input.agentId != null &&
+      snapshot.claimedByAgentId === input.agentId);
+  return !ownedByCaller;
+}
+
+/**
+ * Prisma WHERE for the atomic claim UPDATE. Exported for unit tests so the
+ * race-safe predicate is pinned without needing a live DB.
+ *
+ * Wins when:
+ *  - force=true (takeover), OR
+ *  - claim is not active / null / released, OR
+ *  - claim is stale (claimedAt older than STALE), OR
+ *  - claim is already owned by this user or agent (re-entry)
+ */
+export function buildAtomicClaimWhere(
+  itemRowId: string,
+  input: ClaimAcquireInput,
+): Record<string, unknown> {
+  if (input.force) {
+    return { id: itemRowId };
+  }
+  const now = input.now ?? new Date();
+  const staleBefore = new Date(now.getTime() - STALE_BACKLOG_CLAIM_MS);
+  const ownershipBranches: Record<string, unknown>[] = [
+    { claimedById: input.userId },
+  ];
+  if (input.agentId) {
+    ownershipBranches.push({ claimedByAgentId: input.agentId });
+  }
+  return {
+    id: itemRowId,
+    OR: [
+      { claimStatus: null },
+      { claimStatus: { not: "active" } },
+      { claimedAt: null },
+      { claimedAt: { lt: staleBefore } },
+      { AND: [{ claimStatus: "active" }, { OR: ownershipBranches }] },
+    ],
+  };
+}
+
+export type ClaimAcquireData = {
+  claimStatus: "active";
+  claimedById: string;
+  claimedByAgentId: string | null;
+  claimedAt: Date;
+};
+
+export function buildClaimAcquireData(input: ClaimAcquireInput): ClaimAcquireData {
+  return {
+    claimStatus: "active",
+    claimedById: input.userId,
+    claimedByAgentId: input.agentId,
+    claimedAt: input.now ?? new Date(),
+  };
+}
+
+/** Minimal DB surface used by the atomic acquire (prisma or transaction client). */
+export type BacklogClaimDb = {
+  backlogItem: {
+    updateMany: (args: {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    }) => Promise<{ count: number }>;
+    findUnique: (args: {
+      where: { id: string };
+      select: {
+        claimStatus: true;
+        claimedById: true;
+        claimedByAgentId: true;
+        claimedAt: true;
+      };
+    }) => Promise<BacklogClaimSnapshot | null>;
+  };
+};
+
+export type AtomicClaimResult =
+  | { ok: true; forced: boolean }
+  | {
+      ok: false;
+      error: "claim_conflict";
+      claimedById: string | null;
+      claimedByAgentId: string | null;
+      claimedAt: Date | string | null;
+      claimAgeMinutes: number | null;
+    };
+
+/**
+ * Atomically acquire (or re-enter / force-take) the claim on one BacklogItem.
+ * Returns ok:false when another session holds a fresh active claim and force
+ * was not set — callers map that to error=claim_conflict.
+ */
+export async function tryAcquireBacklogClaimAtomic(params: {
+  db: BacklogClaimDb;
+  itemRowId: string;
+  userId: string;
+  agentId: string | null;
+  force?: boolean;
+  now?: Date;
+}): Promise<AtomicClaimResult> {
+  const input: ClaimAcquireInput = {
+    userId: params.userId,
+    agentId: params.agentId,
+    force: params.force === true,
+    now: params.now,
+  };
+  const where = buildAtomicClaimWhere(params.itemRowId, input);
+  const data = buildClaimAcquireData(input);
+  const result = await params.db.backlogItem.updateMany({ where, data });
+  if (result.count > 0) {
+    return { ok: true, forced: input.force === true };
+  }
+
+  const current = await params.db.backlogItem.findUnique({
+    where: { id: params.itemRowId },
+    select: {
+      claimStatus: true,
+      claimedById: true,
+      claimedByAgentId: true,
+      claimedAt: true,
+    },
+  });
+  const claimedAt = current?.claimedAt ?? null;
+  const claimAgeMinutes =
+    claimedAt != null
+      ? Math.round((Date.now() - new Date(claimedAt).getTime()) / 60_000)
+      : null;
+  return {
+    ok: false,
+    error: "claim_conflict",
+    claimedById: current?.claimedById ?? null,
+    claimedByAgentId: current?.claimedByAgentId ?? null,
+    claimedAt,
+    claimAgeMinutes,
+  };
+}
+
+/**
+ * Sweep active claims older than the stale window to claimStatus=released.
+ * Complements the inline reclaim path so dead-session claims do not linger.
+ */
+export async function reapStaleBacklogClaims(params: {
+  db: {
+    backlogItem: {
+      updateMany: (args: {
+        where: Record<string, unknown>;
+        data: Record<string, unknown>;
+      }) => Promise<{ count: number }>;
+    };
+  };
+  now?: Date;
+}): Promise<{ reaped: number }> {
+  const now = params.now ?? new Date();
+  const staleBefore = new Date(now.getTime() - STALE_BACKLOG_CLAIM_MS);
+  const result = await params.db.backlogItem.updateMany({
+    where: {
+      claimStatus: "active",
+      claimedAt: { lt: staleBefore },
+    },
+    data: {
+      claimStatus: "released",
+    },
+  });
+  return { reaped: result.count };
+}

--- a/apps/web/lib/mcp-tools-backlog.test.ts
+++ b/apps/web/lib/mcp-tools-backlog.test.ts
@@ -10,6 +10,7 @@ const { mockPrisma, mockInngest } = vi.hoisted(() => ({
       findFirst: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
       count: vi.fn(),
     },
     backlogItemActivity: {
@@ -798,101 +799,58 @@ describe("backlog MCP tool execution", () => {
       };
     }
 
-    it("acquires the claim when moving an unclaimed item to in-progress", async () => {
-      mockPrisma.backlogItem.findUnique.mockResolvedValue(openRow());
-      mockPrisma.backlogItem.update.mockResolvedValue({ itemId: "BI-CLAIM01", status: "in-progress", epicId: null, completedAt: null });
-
-      const result = await executeTool(
+    async function startInProgress(force = false) {
+      return executeTool(
         "update_backlog_item_status",
-        { itemId: "BI-CLAIM01", status: "in-progress" },
+        { itemId: "BI-CLAIM01", status: "in-progress", ...(force ? { force: true } : {}) },
         "user-1",
         { agentId: "AGT-1" },
       );
+    }
 
-      expect(result.success).toBe(true);
-      expect(mockPrisma.backlogItem.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            status: "in-progress",
-            claimStatus: "active",
-            claimedById: "user-1",
-            claimedByAgentId: "AGT-1",
-          }),
-        }),
+    it("acquires via atomic updateMany then writes status", async () => {
+      mockPrisma.backlogItem.findUnique.mockResolvedValue(openRow());
+      mockPrisma.backlogItem.updateMany.mockResolvedValue({ count: 1 });
+      mockPrisma.backlogItem.update.mockResolvedValue({ itemId: "BI-CLAIM01", status: "in-progress", epicId: null, completedAt: null });
+      expect((await startInProgress()).success).toBe(true);
+      expect(mockPrisma.backlogItem.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ claimStatus: "active", claimedById: "user-1" }) }),
       );
     });
 
-    it("rejects in-progress when another session holds a fresh active claim", async () => {
-      mockPrisma.backlogItem.findUnique.mockResolvedValue(
-        openRow({ claimStatus: "active", claimedById: "user-2", claimedByAgentId: "AGT-2", claimedAt: FRESH }),
-      );
-
-      const result = await executeTool(
-        "update_backlog_item_status",
-        { itemId: "BI-CLAIM01", status: "in-progress" },
-        "user-1",
-        { agentId: "AGT-1" },
-      );
-
+    it("rejects when atomic claim loses the race (count=0)", async () => {
+      const held = openRow({ claimStatus: "active", claimedById: "user-2", claimedByAgentId: "AGT-2", claimedAt: FRESH });
+      mockPrisma.backlogItem.findUnique.mockResolvedValueOnce(held).mockResolvedValueOnce(held);
+      mockPrisma.backlogItem.updateMany.mockResolvedValue({ count: 0 });
+      const result = await startInProgress();
       expect(result.success).toBe(false);
       expect(result.error).toBe("claim_conflict");
       expect(mockPrisma.backlogItem.update).not.toHaveBeenCalled();
     });
 
-    it("force=true takes over another session's claim and records it", async () => {
+    it("force=true takes over and records forcedClaim", async () => {
       mockPrisma.backlogItem.findUnique.mockResolvedValue(
         openRow({ claimStatus: "active", claimedById: "user-2", claimedByAgentId: "AGT-2", claimedAt: FRESH }),
       );
+      mockPrisma.backlogItem.updateMany.mockResolvedValue({ count: 1 });
       mockPrisma.backlogItem.update.mockResolvedValue({ itemId: "BI-CLAIM01", status: "in-progress", epicId: null, completedAt: null });
-
-      const result = await executeTool(
-        "update_backlog_item_status",
-        { itemId: "BI-CLAIM01", status: "in-progress", force: true },
-        "user-1",
-        { agentId: "AGT-1" },
-      );
-
-      expect(result.success).toBe(true);
+      expect((await startInProgress(true)).success).toBe(true);
       expect(mockPrisma.backlogItemActivity.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            payload: expect.objectContaining({ claimAction: "acquired", forcedClaim: true }),
-          }),
-        }),
+        expect.objectContaining({ data: expect.objectContaining({ payload: expect.objectContaining({ forcedClaim: true }) }) }),
       );
     });
 
-    it("reclaims a stale claim (dead session) without force", async () => {
+    it("reclaims stale claims and allows same-session re-entry", async () => {
+      mockPrisma.backlogItem.updateMany.mockResolvedValue({ count: 1 });
+      mockPrisma.backlogItem.update.mockResolvedValue({ itemId: "BI-CLAIM01", status: "in-progress", epicId: null, completedAt: null });
       mockPrisma.backlogItem.findUnique.mockResolvedValue(
         openRow({ claimStatus: "active", claimedById: "user-2", claimedByAgentId: "AGT-2", claimedAt: STALE }),
       );
-      mockPrisma.backlogItem.update.mockResolvedValue({ itemId: "BI-CLAIM01", status: "in-progress", epicId: null, completedAt: null });
-
-      const result = await executeTool(
-        "update_backlog_item_status",
-        { itemId: "BI-CLAIM01", status: "in-progress" },
-        "user-1",
-        { agentId: "AGT-1" },
-      );
-
-      expect(result.success).toBe(true);
-      expect(mockPrisma.backlogItem.update).toHaveBeenCalled();
-    });
-
-    it("lets the same session re-enter in-progress on its own claim", async () => {
+      expect((await startInProgress()).success).toBe(true);
       mockPrisma.backlogItem.findUnique.mockResolvedValue(
         openRow({ claimStatus: "active", claimedById: "user-1", claimedByAgentId: "AGT-1", claimedAt: FRESH }),
       );
-      mockPrisma.backlogItem.update.mockResolvedValue({ itemId: "BI-CLAIM01", status: "in-progress", epicId: null, completedAt: null });
-
-      const result = await executeTool(
-        "update_backlog_item_status",
-        { itemId: "BI-CLAIM01", status: "in-progress" },
-        "user-1",
-        { agentId: "AGT-1" },
-      );
-
-      expect(result.success).toBe(true);
+      expect((await startInProgress()).success).toBe(true);
     });
 
     it("releases the claim when leaving in-progress", async () => {
@@ -900,19 +858,15 @@ describe("backlog MCP tool execution", () => {
         openRow({ status: "in-progress", claimStatus: "active", claimedById: "user-1", claimedByAgentId: "AGT-1", claimedAt: FRESH }),
       );
       mockPrisma.backlogItem.update.mockResolvedValue({ itemId: "BI-CLAIM01", status: "done", epicId: null, completedAt: new Date() });
-
       const result = await executeTool(
         "update_backlog_item_status",
         { itemId: "BI-CLAIM01", status: "done", resolution: "Shipped." },
         "user-1",
         { agentId: "AGT-1" },
       );
-
       expect(result.success).toBe(true);
       expect(mockPrisma.backlogItem.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ status: "done", claimStatus: "released" }),
-        }),
+        expect.objectContaining({ data: expect.objectContaining({ status: "done", claimStatus: "released" }) }),
       );
     });
   });

--- a/apps/web/lib/mcp/packs/backlog-pack.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.ts
@@ -28,6 +28,7 @@ import {
 import type { BacklogIngestInput } from "@/lib/operate/backlog-ingest";
 import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
 import type { ToolPack, ToolPackHandler } from "../tool-pack";
+import { tryAcquireBacklogClaimAtomic } from "@/lib/backlog/claim-on-start";
 
 const definitions: ToolDefinition[] = [
   {
@@ -925,41 +926,11 @@ async function updateBacklogItemStatus(
       message: `cannot move ${itemIdRaw} from ${item.status} to ${target}`,
     };
 
-  // Claim-on-start gate (capsule-first enforcement): moving a BI to
-  // in-progress is the "I am starting this" signal on the direct-build path.
-  // Acquire the BacklogItem claim atomically and refuse if another active
-  // session already holds a FRESH claim — this is what stops two concurrent
-  // sessions from independently building the same BI (the EP-F7E35344
-  // collision). A claim older than STALE_BACKLOG_CLAIM_MS is treated as
-  // abandoned (a dead session) and is reclaimable; force=true overrides a
-  // live conflict deliberately. Releasing happens when the item leaves
-  // in-progress (mirrors the Build Studio claim/release in actions/build.ts).
-  const STALE_BACKLOG_CLAIM_MS = 12 * 60 * 60 * 1000;
+  // Claim-on-start (BI-B62B9F1E): the DB UPDATE is the gate (row-level
+  // serialize), not a pre-transaction freshness read. Concurrent sessions
+  // race on the same row; the loser's WHERE fails (count=0) → claim_conflict.
+  // Stale claims reclaim inline; force=true takes over. Release on leave.
   const forceClaim = params["force"] === true;
-  if (target === "in-progress") {
-    const claimAgeMs = item.claimedAt ? Date.now() - new Date(item.claimedAt).getTime() : Infinity;
-    const claimIsFresh = claimAgeMs < STALE_BACKLOG_CLAIM_MS;
-    const ownedByCaller =
-      (item.claimedById != null && item.claimedById === userId) ||
-      (item.claimedByAgentId != null && item.claimedByAgentId === (context?.agentId ?? null));
-    const activelyClaimedByOther =
-      item.claimStatus === "active" && claimIsFresh && !ownedByCaller &&
-      (item.claimedById != null || item.claimedByAgentId != null);
-    if (activelyClaimedByOther && !forceClaim) {
-      return {
-        success: false,
-        error: "claim_conflict",
-        message:
-          `${itemIdRaw} is already claimed (active, ${Math.round(claimAgeMs / 60000)}m ago) by another session. ` +
-          "Coordinate with the holder, pick different work, or pass force=true to take it over.",
-        data: {
-          claimedById: item.claimedById,
-          claimedByAgentId: item.claimedByAgentId,
-          claimedAt: item.claimedAt,
-        },
-      };
-    }
-  }
   if (item.status === target) {
     return {
       success: true,
@@ -978,6 +949,33 @@ async function updateBacklogItemStatus(
     };
   }
 
+  let forcedClaimAcquired = false;
+  if (target === "in-progress") {
+    const claimResult = await tryAcquireBacklogClaimAtomic({
+      db: prisma,
+      itemRowId: item.id,
+      userId,
+      agentId: context?.agentId ?? null,
+      force: forceClaim,
+    });
+    if (!claimResult.ok) {
+      return {
+        success: false,
+        error: "claim_conflict",
+        message:
+          `${itemIdRaw} is already claimed (active` +
+          (claimResult.claimAgeMinutes != null ? `, ${claimResult.claimAgeMinutes}m ago` : "") +
+          ") by another session. Coordinate with the holder, pick different work, or pass force=true to take it over.",
+        data: {
+          claimedById: claimResult.claimedById,
+          claimedByAgentId: claimResult.claimedByAgentId,
+          claimedAt: claimResult.claimedAt,
+        },
+      };
+    }
+    forcedClaimAcquired = claimResult.forced;
+  }
+
   const updated = await prisma.$transaction(async (tx) => {
     const next = await tx.backlogItem.update({
       where: { id: item.id },
@@ -985,15 +983,7 @@ async function updateBacklogItemStatus(
         status: target,
         ...(target === "done" ? { completedAt: new Date(), resolution } : {}),
         ...(isRetriage ? { triageOutcome: null, effortSize: null, completedAt: null } : {}),
-        // Acquire the claim on entering in-progress; release it on leaving.
-        ...(target === "in-progress"
-          ? {
-              claimStatus: "active",
-              claimedById: userId,
-              claimedByAgentId: context?.agentId ?? null,
-              claimedAt: new Date(),
-            }
-          : {}),
+        // Claim fields written by tryAcquireBacklogClaimAtomic above.
         ...(item.status === "in-progress" && target !== "in-progress"
           ? { claimStatus: "released" }
           : {}),
@@ -1018,7 +1008,7 @@ async function updateBacklogItemStatus(
               }
             : {}),
           ...(target === "in-progress"
-            ? { claimAction: "acquired", forcedClaim: forceClaim }
+            ? { claimAction: "acquired", forcedClaim: forcedClaimAcquired }
             : item.status === "in-progress"
               ? { claimAction: "released" }
               : {}),

--- a/apps/web/lib/queue/functions/taskrun-watchdog.ts
+++ b/apps/web/lib/queue/functions/taskrun-watchdog.ts
@@ -268,15 +268,26 @@ export const taskrunWatchdog = inngest.createFunction(
       console.warn("[taskrun-watchdog] inert-build reaper failed:", err);
     }
 
+    // BI-B62B9F1E: release stale BacklogItem claims (dead sessions) so they do
+    // not linger as "active" operator noise. Complements the atomic reclaim path.
+    let staleBacklogClaimsReaped = 0;
+    try {
+      const { reapStaleBacklogClaims } = await import("@/lib/backlog/claim-on-start");
+      const { prisma: claimDb } = await import("@dpf/db");
+      staleBacklogClaimsReaped = (await reapStaleBacklogClaims({ db: claimDb })).reaped;
+    } catch (err) {
+      console.warn("[taskrun-watchdog] stale-backlog-claim reaper failed:", err);
+    }
+
     if (!(await isStallWatchdogEnabled())) {
-      return { skipped: true, reason: "flag-off", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped };
+      return { skipped: true, reason: "flag-off", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, staleBacklogClaimsReaped };
     }
 
     const { prisma } = await import("@dpf/db");
 
     const thresholds = await prisma.buildStudioStallThreshold.findMany();
     if (thresholds.length === 0) {
-      return { skipped: true, reason: "no-thresholds-seeded", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped };
+      return { skipped: true, reason: "no-thresholds-seeded", quiescenceRecovered, quiescingTaskRunsRecovered, inertBuildsReaped, staleBacklogClaimsReaped };
     }
 
     // Coarse SQL filter using the smallest applicable thresholds across all


### PR DESCRIPTION
## Summary
- Make BacklogItem **claim-on-start** race-safe (BI-B62B9F1E / concurrency analysis R5): the previous gate read claim freshness then updated, so two sessions could both pass and both claim.
- Atomic path uses a conditional `updateMany` (free | stale | owned-by-caller | force) so concurrent UPDATEs on the same row serialize — loser gets `count=0` → `claim_conflict`.
- Add `reapStaleBacklogClaims` and run it from the minute taskrun watchdog so dead-session `active` claims do not linger.
- Unit tests for pure WHERE/acquire/reaper + MCP status path integration.

## Evidence
- Worktree: `~/dpf-worktrees/atomic-backlog-claim` on `fix/atomic-backlog-claim`
- Unit tests: `pnpm --filter web exec vitest run lib/backlog/claim-on-start.test.ts lib/mcp-tools-backlog.test.ts` → **30 passed**
- Local-CI-Override: source-local unit tests green on worktree; full pregate via CI

## Test plan
- [x] Pure: free/stale/owned predicates, force where, win/lose acquire, reaper
- [x] MCP: acquire, conflict, force, stale reclaim, release on leave
- [ ] CI: Unit Tests + typecheck

Process-Spine-Decision: pure concurrency fix with regression tests; design already in 2026-07-02 concurrency analysis §5.3 — no new durable surface

Closes BI-B62B9F1E (after merge).