### PR TITLE
feat(proactivity): group the coworker roster by business area

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/proactivity/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/proactivity/page.tsx
@@ -30,12 +30,20 @@ export default async function CoworkerProactivityPage() {
   const agents = await prisma.agent.findMany({
     where: { archived: false },
     orderBy: [{ tier: "asc" }, { name: "asc" }],
-    select: { agentId: true, name: true, displayName: true, role: true, kind: true },
+    select: {
+      agentId: true,
+      name: true,
+      displayName: true,
+      role: true,
+      kind: true,
+      portfolio: { select: { slug: true } },
+    },
   });
   const roster: ProactivityRosterAgent[] = agents.map((agent) => ({
     agentId: agent.agentId,
     displayName: agent.displayName || agent.name,
     role: agent.role ?? agent.kind,
+    portfolioSlug: agent.portfolio?.slug ?? null,
   }));
   const overrides = await getCoworkerProactivityPreferences(roster.map((r) => r.agentId));
   const rows = deriveProactivityRoster(roster, overrides);

--- a/apps/web/components/proactivity/ProactivityRosterList.test.tsx
+++ b/apps/web/components/proactivity/ProactivityRosterList.test.tsx
@@ -8,6 +8,9 @@ vi.mock("@/lib/actions/proactivity", () => ({
 import { ProactivityRosterList } from "./ProactivityRosterList";
 import type { ProactivityRosterRow } from "@/lib/proactivity/proactivity-roster";
 
+const CUSTOMERS = { key: "products_and_services_sold", label: "Customers and sales", order: 1 };
+const PLATFORM = { key: "foundational", label: "Platform and back office", order: 4 };
+
 const rows: ProactivityRosterRow[] = [
   {
     agentId: "coo",
@@ -16,6 +19,7 @@ const rows: ProactivityRosterRow[] = [
     level: "balanced",
     isOverride: false,
     explanation: "Derived from the business risk posture.",
+    area: PLATFORM,
   },
   {
     agentId: "bookkeeper",
@@ -24,6 +28,7 @@ const rows: ProactivityRosterRow[] = [
     level: "assertive",
     isOverride: true,
     explanation: "Owner override.",
+    area: CUSTOMERS,
   },
 ];
 
@@ -34,6 +39,12 @@ describe("ProactivityRosterList", () => {
     expect(html).toContain("From your industry");
     expect(html).toContain("Bookkeeper");
     expect(html).toContain("You set this");
+  });
+
+  it("renders the coworkers grouped under their business-area headings", () => {
+    const html = renderToStaticMarkup(<ProactivityRosterList rows={rows} />);
+    expect(html).toContain("Customers and sales");
+    expect(html).toContain("Platform and back office");
   });
 
   it("shows an empty message when there are no coworkers", () => {

--- a/apps/web/components/proactivity/ProactivityRosterList.tsx
+++ b/apps/web/components/proactivity/ProactivityRosterList.tsx
@@ -9,7 +9,10 @@ import { useState } from "react";
 import { ProactivityLevelControl } from "@/components/proactivity/ProactivityLevelControl";
 import { saveCoworkerProactivityPreference } from "@/lib/actions/proactivity";
 import type { ProactivityLevel } from "@/lib/proactivity/proactivity-types";
-import type { ProactivityRosterRow } from "@/lib/proactivity/proactivity-roster";
+import {
+  groupRosterByArea,
+  type ProactivityRosterRow,
+} from "@/lib/proactivity/proactivity-roster";
 
 type RowState = { level: ProactivityLevel; isOverride: boolean };
 
@@ -33,32 +36,44 @@ export function ProactivityRosterList({ rows }: { rows: ProactivityRosterRow[] }
     );
   }
 
+  const groups = groupRosterByArea(rows);
+
   return (
-    <ul className="divide-y divide-[var(--dpf-border)] rounded-lg border border-[var(--dpf-border)]">
-      {rows.map((row) => {
-        const current = state[row.agentId] ?? { level: row.level, isOverride: row.isOverride };
-        return (
-          <li
-            key={row.agentId}
-            className="flex items-center justify-between gap-4 px-4 py-3"
-          >
-            <div className="min-w-0">
-              <p className="truncate text-sm font-medium text-[var(--dpf-text)]">
-                {row.displayName}
-              </p>
-              <p className="truncate text-xs text-[var(--dpf-muted)]">
-                {row.role}
-                {" · "}
-                {current.isOverride ? "You set this" : "From your industry"}
-              </p>
-            </div>
-            <ProactivityLevelControl
-              value={current.level}
-              onChange={(next) => change(row.agentId, next)}
-            />
-          </li>
-        );
-      })}
-    </ul>
+    <div className="space-y-6">
+      {groups.map((group) => (
+        <section key={group.area.key}>
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-[var(--dpf-muted)]">
+            {group.area.label}
+            <span className="ml-1.5 font-normal normal-case">({group.rows.length})</span>
+          </h2>
+          <ul className="divide-y divide-[var(--dpf-border)] rounded-lg border border-[var(--dpf-border)]">
+            {group.rows.map((row) => {
+              const current = state[row.agentId] ?? { level: row.level, isOverride: row.isOverride };
+              return (
+                <li
+                  key={row.agentId}
+                  className="flex items-center justify-between gap-4 px-4 py-3"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-[var(--dpf-text)]">
+                      {row.displayName}
+                    </p>
+                    <p className="truncate text-xs text-[var(--dpf-muted)]">
+                      {row.role}
+                      {" · "}
+                      {current.isOverride ? "You set this" : "From your industry"}
+                    </p>
+                  </div>
+                  <ProactivityLevelControl
+                    value={current.level}
+                    onChange={(next) => change(row.agentId, next)}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
   );
 }

--- a/apps/web/lib/proactivity/proactivity-roster.test.ts
+++ b/apps/web/lib/proactivity/proactivity-roster.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { deriveProactivityRoster } from "./proactivity-roster";
+import {
+  areaForPortfolio,
+  deriveProactivityRoster,
+  groupRosterByArea,
+} from "./proactivity-roster";
 import { PROACTIVITY_LEVELS } from "./proactivity-types";
 
 const agents = [
@@ -32,5 +36,31 @@ describe("deriveProactivityRoster", () => {
       "Bookkeeper",
     ]);
     expect(rows.map((row) => row.role)).toEqual(["orchestrator", "analyst"]);
+  });
+
+  it("maps a portfolio slug to a plain owner-facing area, else Other", () => {
+    expect(areaForPortfolio("products_and_services_sold").label).toBe("Customers and sales");
+    expect(areaForPortfolio("for_employees").label).toBe("Your team");
+    expect(areaForPortfolio("foundational").label).toBe("Platform and back office");
+    expect(areaForPortfolio(null).key).toBe("other");
+    expect(areaForPortfolio("nope").key).toBe("other");
+  });
+
+  it("groups rows into areas ordered from the customer inward", () => {
+    const rows = deriveProactivityRoster(
+      [
+        { agentId: "eng", displayName: "Platform Engineer", role: "operator", portfolioSlug: "foundational" },
+        { agentId: "sales", displayName: "Customer Advisor", role: "specialist", portfolioSlug: "products_and_services_sold" },
+        { agentId: "hr", displayName: "HR", role: "specialist", portfolioSlug: "for_employees" },
+      ],
+      {},
+    );
+    const groups = groupRosterByArea(rows);
+    expect(groups.map((group) => group.area.label)).toEqual([
+      "Customers and sales",
+      "Your team",
+      "Platform and back office",
+    ]);
+    expect(groups[0]?.rows[0]?.displayName).toBe("Customer Advisor");
   });
 });

--- a/apps/web/lib/proactivity/proactivity-roster.ts
+++ b/apps/web/lib/proactivity/proactivity-roster.ts
@@ -14,7 +14,32 @@ export type ProactivityRosterAgent = {
   agentId: string;
   displayName: string;
   role: string;
+  /** Canonical portfolio slug the coworker belongs to; drives the grouping. */
+  portfolioSlug?: string | null;
 };
+
+/** An owner-friendly business area, ordered from the customer inward (the same
+ *  outside-in axis the attention inbox uses), so the 100+ coworker roster reads
+ *  as a few navigable sections rather than a flat dump. */
+export type ProactivityArea = {
+  key: string;
+  label: string;
+  order: number;
+};
+
+// The four canonical portfolios → plain owner-facing area labels, customer-inward.
+const AREA_BY_PORTFOLIO: Record<string, { label: string; order: number }> = {
+  products_and_services_sold: { label: "Customers and sales", order: 1 },
+  for_employees: { label: "Your team", order: 2 },
+  manufacturing_and_delivery: { label: "Operations and delivery", order: 3 },
+  foundational: { label: "Platform and back office", order: 4 },
+};
+const OTHER_AREA: ProactivityArea = { key: "other", label: "Other", order: 5 };
+
+export function areaForPortfolio(slug: string | null | undefined): ProactivityArea {
+  const match = slug ? AREA_BY_PORTFOLIO[slug] : undefined;
+  return match ? { key: slug as string, label: match.label, order: match.order } : OTHER_AREA;
+}
 
 export type ProactivityRosterRow = ProactivityRosterAgent & {
   level: ProactivityLevel;
@@ -22,7 +47,26 @@ export type ProactivityRosterRow = ProactivityRosterAgent & {
   isOverride: boolean;
   /** Plain-language origin of the level shown. */
   explanation: string;
+  /** The business area this row is grouped under. */
+  area: ProactivityArea;
 };
+
+export type ProactivityAreaGroup = {
+  area: ProactivityArea;
+  rows: ProactivityRosterRow[];
+};
+
+/** Group resolved rows into owner-friendly areas, ordered customer-inward.
+ *  Coworker order within an area is preserved from the input. */
+export function groupRosterByArea(rows: ProactivityRosterRow[]): ProactivityAreaGroup[] {
+  const byKey = new Map<string, ProactivityAreaGroup>();
+  for (const row of rows) {
+    const existing = byKey.get(row.area.key);
+    if (existing) existing.rows.push(row);
+    else byKey.set(row.area.key, { area: row.area, rows: [row] });
+  }
+  return [...byKey.values()].sort((a, b) => a.area.order - b.area.order);
+}
 
 /** Pure projection: given the coworker list and any owner overrides, resolve the
  *  level each coworker acts at. When no override exists the resolver returns the
@@ -42,6 +86,7 @@ export function deriveProactivityRoster(
       level: plan.resolvedLevel,
       isOverride: Boolean(saved),
       explanation: plan.explanation,
+      area: areaForPortfolio(agent.portfolioSlug),
     };
   });
 }

--- a/docs/user-guide/ai-workforce/coworker-proactivity.md
+++ b/docs/user-guide/ai-workforce/coworker-proactivity.md
@@ -10,7 +10,7 @@ relatedCode:
 
 ## What This Covers
 
-**Proactivity** is how much a coworker acts on its own before it involves you. The consolidated view lives at **Coworker Decision Engine → Coworker proactivity**, and lists every coworker with the level it currently acts at.
+**Proactivity** is how much a coworker acts on its own before it involves you. The consolidated view lives at **Coworker Decision Engine → Coworker proactivity**, and lists every coworker with the level it currently acts at, **grouped by business area** — customers and sales, your team, operations and delivery, and platform and back office — so the roster reads as a few navigable sections instead of one long list.
 
 ## How the Defaults Are Set
 


### PR DESCRIPTION
## What

Driving the just-deployed proactivity view live surfaced a real cognitive-load problem: `/coworker-decisions/proactivity` listed **~100 coworkers flat**, most of them internal platform/build agents (Constraint Validation, IAC Execution, SOC Threat Hunter…) a non-technical owner doesn't recognize — the exact overwhelm this surface is meant to reduce.

Group the roster by each coworker's canonical **Portfolio** (already on `Agent.portfolioId`) into plain, owner-facing areas, ordered **customer-inward** — Customers and sales · Your team · Operations and delivery · Platform and back office — each a section with a count. Same outside-in axis the attention inbox uses. Adjust + derived/override state unchanged.

## Design grounding

Extends the proactivity confirm/adjust surface (`BI-65D622EA`); groups by the existing `Agent.portfolioId → Portfolio` (the 4 canonical roots), verified live: 56 Workforce / 19 Delivery / 16 Products-and-services / 13 Foundational. No new contract; doc updated.

## Verification

Added tests: `areaForPortfolio` mapping, `deriveProactivityRoster` carries area, `groupRosterByArea` orders customer-inward, and the list renders area headings. Local run blocked by a source-only worktree; required CI Typecheck + Unit Tests verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)