### PR TITLE
fix(ops): abandoned builds offer Rebuild, not a dead-draft Resume (BI-99D896CF)

### DIFF
--- a/apps/web/components/ops/BacklogItemRow.tsx
+++ b/apps/web/components/ops/BacklogItemRow.tsx
@@ -3,7 +3,7 @@
 import { memo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { AlertTriangle, ExternalLink, Play } from "lucide-react";
+import { AlertTriangle, ExternalLink, Play, RotateCcw } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { deleteBacklogItem, escalateBacklogItemUpstream } from "@/lib/actions/backlog";
 import { startBacklogBuild } from "@/lib/actions/backlog-build";
@@ -217,16 +217,28 @@ function BacklogBuildActionButton({
   isPending: boolean;
   onStart: () => void;
 }) {
-  if (action.kind === "start") {
+  if (action.kind === "start" || action.kind === "rebuild") {
+    // "rebuild" fires the same server action as "start"; startBacklogBuild
+    // (BI-08AE51DC) detaches the abandoned draft and promotes a fresh one, so the
+    // operator gets a real terminal action instead of a Resume link that
+    // re-strands the dead draft (BI-99D896CF).
+    const isRebuild = action.kind === "rebuild";
     return (
       <button
         onClick={onStart}
         disabled={isPending}
         className="inline-flex items-center gap-1 rounded border border-[var(--dpf-accent)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--dpf-accent)] transition-colors hover:bg-[var(--dpf-accent-soft)] disabled:cursor-not-allowed disabled:opacity-50"
-        aria-label="Start Build Studio draft"
+        aria-label={isRebuild ? "Rebuild — start a fresh Build Studio draft" : "Start Build Studio draft"}
+        title={isRebuild ? "The previous draft was abandoned. Start a fresh build." : undefined}
       >
-        {isPending ? <Spinner size="xs" tone="current" presentational /> : <Play className="h-3 w-3" />}
-        <span>{isPending ? "Starting" : action.label}</span>
+        {isPending ? (
+          <Spinner size="xs" tone="current" presentational />
+        ) : isRebuild ? (
+          <RotateCcw className="h-3 w-3" />
+        ) : (
+          <Play className="h-3 w-3" />
+        )}
+        <span>{isPending ? (isRebuild ? "Rebuilding" : "Starting") : action.label}</span>
       </button>
     );
   }

--- a/apps/web/lib/backlog-build-action-state.test.ts
+++ b/apps/web/lib/backlog-build-action-state.test.ts
@@ -33,6 +33,22 @@ describe("resolveBacklogBuildActionState", () => {
     });
   });
 
+  it("offers Rebuild (a fresh draft) for an abandoned dead draft instead of resuming the corpse", () => {
+    // BI-99D896CF: an abandoned build is a dead draft — resuming it re-strands.
+    // startBacklogBuild (BI-08AE51DC) detaches it and promotes a fresh draft, so
+    // the row must offer a Rebuild action, not a Resume link into the corpse.
+    expect(resolveBacklogBuildActionState({
+      ...baseItem,
+      activeBuildId: "feature-build-row-1",
+      activeBuild: { buildId: "FB-DEAD0001", phase: "abandoned" },
+    })).toEqual({
+      kind: "rebuild",
+      label: "Rebuild",
+      href: null,
+      disabled: false,
+    });
+  });
+
   it("opens a completed linked build as history", () => {
     expect(resolveBacklogBuildActionState({
       ...baseItem,

--- a/apps/web/lib/backlog-build-action-state.ts
+++ b/apps/web/lib/backlog-build-action-state.ts
@@ -17,6 +17,12 @@ export type BacklogBuildActionState =
     disabled: false;
   }
   | {
+    kind: "rebuild";
+    label: "Rebuild";
+    href: null;
+    disabled: false;
+  }
+  | {
     kind: "resume";
     label: "Resume build";
     href: string;
@@ -38,13 +44,29 @@ export type BacklogBuildActionState =
 
 const BUILD_READY_EFFORT_SIZES = new Set(["small", "medium", "large"]);
 const HISTORICAL_BUILD_PHASES = new Set(["complete", "failed"]);
+// A dead draft the operator can neither resume nor learn from. startBacklogBuild
+// (BI-08AE51DC) already detaches these and promotes a FRESH draft, so the row
+// must offer a Rebuild action rather than a Resume link into the corpse — the
+// missing frontend half of that fix (BI-99D896CF). Mirrors the "abandoned" entry
+// in backlog-build.ts TERMINAL_BUILD_PHASES; "panicked" is intentionally excluded
+// because startBacklogBuild still treats it as live (routes to the existing build).
+const DEAD_DRAFT_PHASES = new Set(["abandoned"]);
 
 export function resolveBacklogBuildActionState(
   item: BacklogBuildActionItem,
 ): BacklogBuildActionState {
   if (item.activeBuild?.buildId) {
+    const phase = item.activeBuild.phase ?? "";
     const href = `/build?buildId=${encodeURIComponent(item.activeBuild.buildId)}`;
-    if (HISTORICAL_BUILD_PHASES.has(item.activeBuild.phase ?? "")) {
+    if (DEAD_DRAFT_PHASES.has(phase)) {
+      return {
+        kind: "rebuild",
+        label: "Rebuild",
+        href: null,
+        disabled: false,
+      };
+    }
+    if (HISTORICAL_BUILD_PHASES.has(phase)) {
       return {
         kind: "open",
         label: "Open build",

--- a/apps/web/lib/ops/operator-triage.test.ts
+++ b/apps/web/lib/ops/operator-triage.test.ts
@@ -70,6 +70,14 @@ describe("classifyOperatorReason", () => {
     );
   });
 
+  it("flags an abandoned linked build as build-attention", () => {
+    expect(
+      classifyOperatorReason(
+        item({ activeBuildId: "b1", activeBuild: { buildId: "b1", phase: "abandoned" } }),
+      ),
+    ).toBe("build-attention");
+  });
+
   it("flags a blocked claim as blocked", () => {
     expect(classifyOperatorReason(item({ claimStatus: "blocked" }))).toBe("blocked");
   });
@@ -148,6 +156,46 @@ describe("selectOperatorQueue", () => {
     expect(queue[0]?.item.itemId).toBe("BI-BUG");
     expect(queue[0]?.blocksBusinessOutcome).toBe(true);
     expect(queue[1]?.blocksBusinessOutcome).toBe(false);
+  });
+
+  it("demotes a chronically-stranded abandoned build below fresh build-attention (BI-99D896CF age-out)", () => {
+    // A build abandoned 60 days ago that keeps re-abandoning should not lead the
+    // personal lens over a build that just failed — the operator needs the fresh
+    // failure first. Both are build-attention/mine with businessScore 0; age-out
+    // lowers the chronic strand's risk contribution so it sinks within the tier.
+    const freshFail = item({
+      itemId: "BI-FRESH",
+      activeBuildId: "b1",
+      activeBuild: { buildId: "b1", phase: "failed" },
+      updatedAt: daysAgo(1),
+    });
+    const chronic = item({
+      itemId: "BI-CHRONIC",
+      activeBuildId: "b2",
+      activeBuild: { buildId: "b2", phase: "abandoned" },
+      updatedAt: daysAgo(60),
+    });
+    const queue = selectOperatorQueue([chronic, freshFail], NOW);
+    expect(queue.map((e) => e.item.itemId)).toEqual(["BI-FRESH", "BI-CHRONIC"]);
+  });
+
+  it("keeps a recently-abandoned build at full build-attention urgency (not yet chronic)", () => {
+    // Under the chronic threshold (14d), an abandoned build is still urgent — it
+    // ties with a failed build on risk and the older one leads by staleness.
+    const recentAbandon = item({
+      itemId: "BI-RECENT",
+      activeBuildId: "b1",
+      activeBuild: { buildId: "b1", phase: "abandoned" },
+      updatedAt: daysAgo(2),
+    });
+    const olderFail = item({
+      itemId: "BI-OLDFAIL",
+      activeBuildId: "b2",
+      activeBuild: { buildId: "b2", phase: "failed" },
+      updatedAt: daysAgo(5),
+    });
+    const queue = selectOperatorQueue([recentAbandon, olderFail], NOW);
+    expect(queue.map((e) => e.item.itemId)).toEqual(["BI-OLDFAIL", "BI-RECENT"]);
   });
 
   it("uses staleness as the tiebreaker when business and risk tie", () => {

--- a/apps/web/lib/ops/operator-triage.ts
+++ b/apps/web/lib/ops/operator-triage.ts
@@ -65,12 +65,29 @@ const TERMINAL_STATUSES = new Set(["done", "deferred"]);
 const CLOSED_TRIAGE_OUTCOMES = new Set(["discard", "duplicate", "defer"]);
 const FAILED_BUILD_PHASES = new Set(["failed", "panicked", "abandoned"]);
 
+// BI-99D896CF age-out: an abandoned draft that has sat untouched this long keeps
+// re-abandoning without progress. It still needs a human (rebuild or retire), so
+// it stays on the personal lens — but it should not lead over a build that just
+// failed, so its risk contribution is bought down once it crosses the threshold.
+const DEAD_DRAFT_PHASES = new Set(["abandoned"]);
+const CHRONIC_STRAND_DAYS = 14;
+const CHRONIC_STRAND_RISK_PENALTY = 3;
+
 const DAY_MS = 1000 * 60 * 60 * 24;
 
 function daysBetween(from: Date | null | undefined, now: Date): number {
   if (!from) return 0;
   const ms = now.getTime() - new Date(from).getTime();
   return ms > 0 ? ms / DAY_MS : 0;
+}
+
+/** True when a linked build has been abandoned and left untouched past the
+ *  chronic threshold — a strand that keeps re-abandoning rather than a fresh
+ *  failure the operator has not yet seen. */
+function isChronicallyStrandedBuild(item: BacklogItemWithRelations, now: Date): boolean {
+  const phase = item.activeBuild?.phase ?? null;
+  if (!phase || !DEAD_DRAFT_PHASES.has(phase)) return false;
+  return daysBetween(item.updatedAt, now) >= CHRONIC_STRAND_DAYS;
 }
 
 /** The severity a given operator reason contributes to the risk key: a broken
@@ -175,13 +192,16 @@ export function selectOperatorQueue(
   for (const item of items) {
     const reason = classifyOperatorReason(item);
     if (!reason) continue;
+    const chronicPenalty = isChronicallyStrandedBuild(item, now)
+      ? CHRONIC_STRAND_RISK_PENALTY
+      : 0;
     entries.push({
       item,
       reason,
       blocksBusinessOutcome: blocksBusinessOutcome(item),
       scope: resolveOperatorScope(item, reason, principalId),
       businessScore: businessScore(item),
-      riskScore: riskScore(item, reason),
+      riskScore: riskScore(item, reason) - chronicPenalty,
       stalenessDays: daysBetween(item.stalenessDetectedAt ?? item.updatedAt, now),
     });
   }


### PR DESCRIPTION
## What & why

Operator report: the `/ops` → Backlog **"Needs you next"** band shows a set of "BUILD NEEDS ATTENTION" items that **cannot be resolved**. Six items sat there — auto-detected features whose Build Studio build **abandoned** (e.g. `BI-70DD03D8` Voice Slice 1.6 has 4 abandoned drafts; `BI-8954667A` Clinic scheduler has 3), some ~2 months old. The only offered action was **"Resume build"**, a link into the *dead* draft that re-abandons on click. No button ended the item, so it churned forever.

Filed as **BI-99D896CF** (EP-ATTENTION-SURFACE).

## Root cause

Two phase-sets disagreed:

| Module | Set | Effect on `abandoned` |
|---|---|---|
| `lib/ops/operator-triage.ts` | `FAILED_BUILD_PHASES = {failed, panicked, abandoned}` | → `build-attention` → lands on the operator's plate (correct — it does need a human) |
| `lib/backlog-build-action-state.ts` | `HISTORICAL_BUILD_PHASES = {complete, failed}` | `abandoned` not terminal → falls through to **"Resume build"** linking the dead draft |

The **backend was already fixed** — `startBacklogBuild` (BI-08AE51DC) treats `abandoned` as terminal, detaches the corpse, and promotes a fresh draft. Its own comment names this exact incident: *"the un-audited bulk-abandon incident that set phase='abandoned' … left the item permanently wedged."* This PR lands the **missing frontend half**.

## Change

- **`backlog-build-action-state.ts`** — `abandoned` → new `rebuild` action (fires the already-fixed server action → fresh draft) instead of `resume`. `complete`/`failed` still → `open`; live builds still → `resume`.
- **`operator-triage.ts`** — chronically-stranded abandoned builds (>14d untouched) get their risk contribution bought down (`-3`), so a 2-month dead strand no longer outranks a build that just failed. Stays on the personal lens — it still needs a rebuild-or-retire call.
- **`BacklogItemRow.tsx`** — renders `rebuild` as a **Rebuild** action button (RotateCcw, `Rebuilding…` pending state).

## Not done (deliberately)

The band itself is **not** removed. `OperatorTriageBand` (BI-9952EA9E) + the mine/company split (BI-01CC2356, shipped 2026-07-18) are current, tested, and distinct from the `/workspace/inbox` attention inbox — deleting it would regress just-shipped work.

## Verification

- **7/7 assertions** on the two pure modules via a Node-24 strip-types standalone harness: `abandoned → rebuild`; no regression on `resume`/`open`/`start`; `abandoned → build-attention`; age-out demotes chronic strands while keeping recent ones urgent.
- New unit tests added to both suites (`backlog-build-action-state.test.ts`, `operator-triage.test.ts`).
- ⚠️ **Local typecheck/vitest could not run** in this source-only worktree (incomplete `node_modules`: `next`/`vitest`/`@types` unresolved). The pre-commit typecheck hook was env-blocked and overridden with `DPF_SKIP_TYPECHECK=1`. **CI runs the authoritative Unit / Typecheck / Prod-Build gates** — please rely on those.

## Decision trail

- Approach ratified by the operator via `principle_decide` (callingSurface `backlog-needs-you-band`); the initial "remove the duplicate band" framing was **corrected** after sweeping `origin/main` (the band is not a duplicate). Recorded on BI-99D896CF.
- `Design-Grounding-Decision` and `Docs-Impact-Decision` trailers in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
