### PR TITLE
fix(runtime): advisory-lock $queryRaw crashes promote/start under Prisma 7.8 — use $executeRaw (BI-8BA6AC56)

### DIFF
--- a/apps/web/lib/governed-backlog-tee-up.ts
+++ b/apps/web/lib/governed-backlog-tee-up.ts
@@ -238,7 +238,7 @@ export async function promoteBacklogItemToBuildDraft(
   input: PromoteBacklogItemToBuildDraftInput,
 ): Promise<PromoteBacklogItemToBuildDraftResult> {
   const { tx, itemId, userId, governedBacklogEnabled, activity } = input;
-  if ("$queryRaw" in tx && "platformCapability" in tx && "runtimeCapabilityTransition" in tx) {
+  if ("$executeRaw" in tx && "platformCapability" in tx && "runtimeCapabilityTransition" in tx) {
     await admitRuntimeGuardedWork(tx as never, "build-studio-active");
   }
   const item = await tx.backlogItem.findUnique({

--- a/apps/web/lib/platform-runtime/transition-coordinator.test.ts
+++ b/apps/web/lib/platform-runtime/transition-coordinator.test.ts
@@ -127,7 +127,7 @@ describe("runtime capability transition coordinator", () => {
 
   it("rechecks attributed work under the receipt lock and returns drain_required", async () => {
     const model = { findFirst: vi.fn(async () => null), findUnique: vi.fn(async () => null), create: vi.fn(), updateMany: vi.fn() };
-    const tx = { $queryRaw: vi.fn(async () => []), runtimeCapabilityTransition: model };
+    const tx = { $executeRaw: vi.fn(async () => []), runtimeCapabilityTransition: model };
     const receipts = createPrismaRuntimeTransitionReceipts({ runtimeCapabilityTransition: model, $transaction: vi.fn(async (fn) => fn(tx)) } as never);
     const d = deps({ receipts, recheckAttributedWork: vi.fn(async () => ({ "build-studio-active": 1 })) });
     await expect(coordinateRuntimeCapabilityTransition(request, d)).resolves.toEqual({ status: "drain_required", blockingCounts: { "build-studio-active": 1 } });
@@ -137,12 +137,12 @@ describe("runtime capability transition coordinator", () => {
 
   it("creates sorted durable receipts under an advisory lock and serializable transaction", async () => {
     const model = { findFirst: vi.fn(async () => null), findUnique: vi.fn(async () => null), create: vi.fn(async () => ({})), updateMany: vi.fn(async () => ({ count: 1 })) };
-    const tx = { $queryRaw: vi.fn(async () => []), runtimeCapabilityTransition: model };
+    const tx = { $executeRaw: vi.fn(async () => []), runtimeCapabilityTransition: model };
     const prisma = { runtimeCapabilityTransition: model, $transaction: vi.fn(async (fn) => fn(tx)) };
     const receipts = createPrismaRuntimeTransitionReceipts(prisma as never);
     const envelope = { ...persistedEnvelope, previousKeys: ["z", "a"], desiredKeys: ["z", "b"], previousProfiles: [], desiredProfiles: [] };
     await expect(receipts.createPending({ ...request, previousKeys: ["z", "a"], desiredKeys: ["z", "b"], previousProfiles: [], desiredProfiles: [], previousStateHash: "before", desiredStateHash: "after", envelope, envelopeSignature: "a".repeat(64) })).resolves.toEqual({ created: true, envelope, envelopeSignature: "a".repeat(64) });
-    expect(tx.$queryRaw).toHaveBeenCalledOnce();
+    expect(tx.$executeRaw).toHaveBeenCalledOnce();
     expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), { isolationLevel: "Serializable" });
     expect(model.create).toHaveBeenCalledWith({ data: expect.objectContaining({ previousKeys: ["a", "z"], desiredKeys: ["b", "z"], status: "pending" }) });
   });
@@ -150,7 +150,7 @@ describe("runtime capability transition coordinator", () => {
   it("reconciles an idempotent transition-id retry without creating another row", async () => {
     const identity = persistedEnvelope;
     const model = { findFirst: vi.fn(), findUnique: vi.fn(async () => ({ status: "host_applied", ...identity, envelope: identity, envelopeSignature: "a".repeat(64) })), create: vi.fn(), updateMany: vi.fn() };
-    const tx = { $queryRaw: vi.fn(async () => []), runtimeCapabilityTransition: model };
+    const tx = { $executeRaw: vi.fn(async () => []), runtimeCapabilityTransition: model };
     const prisma = { runtimeCapabilityTransition: model, $transaction: vi.fn(async (fn) => fn(tx)) };
     const receipts = createPrismaRuntimeTransitionReceipts(prisma as never);
     await expect(receipts.createPending({ ...request, previousProfiles: ["build"], desiredProfiles: [], previousStateHash: "before", desiredStateHash: "after", envelope: identity, envelopeSignature: "a".repeat(64) })).resolves.toEqual({ created: false, kind: "replay", status: "host_applied", envelope: identity, envelopeSignature: "a".repeat(64) });
@@ -159,14 +159,14 @@ describe("runtime capability transition coordinator", () => {
 
   it("fails closed when a replayed transition id carries a different immutable envelope", async () => {
     const model = { findFirst: vi.fn(), findUnique: vi.fn(async () => ({ status: "pending", catalogHash: request.catalogHash, previousStateHash: "different", desiredStateHash: "after", previousKeys: [...request.previousKeys], desiredKeys: [...request.desiredKeys] })), create: vi.fn(), updateMany: vi.fn() };
-    const tx = { $queryRaw: vi.fn(async () => []), runtimeCapabilityTransition: model };
+    const tx = { $executeRaw: vi.fn(async () => []), runtimeCapabilityTransition: model };
     const receipts = createPrismaRuntimeTransitionReceipts({ runtimeCapabilityTransition: model, $transaction: vi.fn(async (fn) => fn(tx)) } as never);
     await expect(receipts.createPending({ ...request, previousProfiles: ["build"], desiredProfiles: [], previousStateHash: "before", desiredStateHash: "after", envelope: {} as never, envelopeSignature: "a".repeat(64) })).rejects.toThrow("transition_id_conflict");
   });
 
   it("surfaces a different active receipt as transition_in_progress through the Prisma repository", async () => {
     const model = { findUnique: vi.fn(async () => null), findFirst: vi.fn(async () => ({ transitionId: "RCT-OTHER", status: "applying" })), create: vi.fn(), updateMany: vi.fn() };
-    const tx = { $queryRaw: vi.fn(async () => []), runtimeCapabilityTransition: model };
+    const tx = { $executeRaw: vi.fn(async () => []), runtimeCapabilityTransition: model };
     const receipts = createPrismaRuntimeTransitionReceipts({ runtimeCapabilityTransition: model, $transaction: vi.fn(async (fn) => fn(tx)) } as never);
     const d = deps({ receipts });
     await expect(coordinateRuntimeCapabilityTransition(request, d)).resolves.toEqual({ status: "transition_in_progress" });

--- a/apps/web/lib/platform-runtime/transition-coordinator.ts
+++ b/apps/web/lib/platform-runtime/transition-coordinator.ts
@@ -60,7 +60,7 @@ type TransitionModel = {
 };
 type CapabilityModel = { updateMany(args: unknown): Promise<{ count: number }> };
 type EventModel = { create(args: unknown): Promise<unknown> };
-type TransitionTx = { $queryRaw(strings: TemplateStringsArray, ...values: unknown[]): Promise<unknown>; runtimeCapabilityTransition: TransitionModel; platformCapability: CapabilityModel; runtimeCapabilityTransitionEvent: EventModel };
+type TransitionTx = { $executeRaw(strings: TemplateStringsArray, ...values: unknown[]): Promise<unknown>; runtimeCapabilityTransition: TransitionModel; platformCapability: CapabilityModel; runtimeCapabilityTransitionEvent: EventModel };
 type TransitionPrisma = {
   runtimeCapabilityTransition: TransitionModel;
   $transaction<T>(operation: (tx: TransitionTx) => Promise<T>, options: { isolationLevel: "Serializable" }): Promise<T>;
@@ -71,7 +71,9 @@ export function createPrismaRuntimeTransitionReceipts(prisma: TransitionPrisma):
     createPending: (input) => prisma.$transaction(async (tx) => {
       // Fixed SQL with no interpolation: the transaction-scoped lock serializes
       // the read/create pair before the partial unique index supplies backstop.
-      await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext('runtime-capability-transition'))`;
+      // BI-8BA6AC56: $executeRaw not $queryRaw — pg_advisory_xact_lock returns void,
+      // which Prisma 7.8's driver adapter can't deserialize from $queryRaw (P2010).
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('runtime-capability-transition'))`;
       const replay = await tx.runtimeCapabilityTransition.findUnique({ where: { transitionId: input.transitionId }, select: { status: true, catalogHash: true, previousStateHash: true, desiredStateHash: true, previousKeys: true, desiredKeys: true, previousProfiles: true, desiredProfiles: true, previousServices: true, desiredServices: true, envelope: true, envelopeSignature: true } });
       if (replay) {
         const same = replay.catalogHash === input.catalogHash && replay.previousStateHash === input.previousStateHash && replay.desiredStateHash === input.desiredStateHash && JSON.stringify(replay.previousKeys) === JSON.stringify([...input.previousKeys].sort()) && JSON.stringify(replay.desiredKeys) === JSON.stringify([...input.desiredKeys].sort()) && JSON.stringify(replay.previousProfiles) === JSON.stringify(input.previousProfiles) && JSON.stringify(replay.desiredProfiles) === JSON.stringify(input.desiredProfiles) && JSON.stringify(replay.previousServices) === JSON.stringify(input.previousServices ?? []) && JSON.stringify(replay.desiredServices) === JSON.stringify(input.desiredServices ?? []);
@@ -110,7 +112,8 @@ export function createPrismaRuntimeTransitionReceipts(prisma: TransitionPrisma):
     markHostOutcome: (transitionId, receipt) => prisma.$transaction(async (tx) => { const status = receipt.status === "rolled_back" ? "rolled_back" : receipt.status === "rollback_failed" ? "rollback_failed" : "failed"; const r = await tx.runtimeCapabilityTransition.updateMany({ where: { transitionId, status: { in: ["pending", "applying"] } }, data: { status, hostReceipt: receipt, failure: { code: receipt.failure ?? status }, completedAt: new Date() } }); if (r.count !== 1) throw new Error("runtime_transition_cas_failed"); await tx.runtimeCapabilityTransitionEvent.create({ data: { transitionId, outcome: status, detail: { receipt } } }); }, { isolationLevel: "Serializable" }),
     markHostApplied: async (transitionId) => { const r = await prisma.runtimeCapabilityTransition.updateMany({ where: { transitionId, status: { in: ["pending", "applying"] } }, data: { status: "host_applied", hostAppliedAt: new Date() } }); if (r.count !== 1) throw new Error("runtime_transition_cas_failed"); },
     commitSuccess: (transitionId, receipt, desiredStates) => prisma.$transaction(async (tx) => {
-      await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext('runtime-capability-transition'))`;
+      // BI-8BA6AC56: $executeRaw — void-returning advisory lock crashes $queryRaw under Prisma 7.8.
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('runtime-capability-transition'))`;
       for (const [capabilityId, state] of Object.entries(desiredStates)) {
         const updated = await tx.platformCapability.updateMany({ where: { capabilityId }, data: { state } });
         if (updated.count !== 1) throw new Error(`runtime_capability_missing:${capabilityId}`);

--- a/apps/web/lib/platform-runtime/work-admission.test.ts
+++ b/apps/web/lib/platform-runtime/work-admission.test.ts
@@ -2,15 +2,27 @@ import { describe, expect, it, vi } from "vitest";
 import { admitRuntimeGuardedWork } from "./work-admission";
 
 describe("runtime guarded work admission", () => {
-  it("takes the transition advisory lock before checking disabled and draining capabilities", async () => {
+  it("takes the transition advisory lock (via $executeRaw) before checking disabled and draining capabilities", async () => {
+    // BI-8BA6AC56 regression: the lock is pg_advisory_xact_lock, which returns
+    // `void`. Prisma 7.8's driver adapter throws P2010 (UnsupportedNativeDataType)
+    // deserializing a void column from $queryRaw — which crashed EVERY Build Studio
+    // promote/start. The lock must be acquired with $executeRaw (no result-set
+    // deserialization). The $queryRaw spy below throws to pin that regression.
     const calls: string[] = [];
     const tx = {
-      $queryRaw: vi.fn(async () => { calls.push("lock"); return []; }),
+      $executeRaw: vi.fn(async (..._args: unknown[]) => { calls.push("lock"); return 1; }),
+      $queryRaw: vi.fn(() => {
+        throw new Error("advisory lock must use $executeRaw (void column crashes $queryRaw under Prisma 7.8)");
+      }),
       platformCapability: { findMany: vi.fn(async () => { calls.push("capabilities"); return []; }) },
       runtimeCapabilityTransition: { findFirst: vi.fn(async () => { calls.push("transition"); return null; }) },
     };
     await admitRuntimeGuardedWork(tx, "task-run:proactive");
     expect(calls).toEqual(["lock", "capabilities", "transition"]);
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(tx.$queryRaw).not.toHaveBeenCalled();
+    const strings = tx.$executeRaw.mock.calls[0][0] as unknown as string[];
+    expect(strings.join("")).toContain("pg_advisory_xact_lock");
   });
 
   it("does not let an unrelated already-disabled capability suppress a shared source", async () => {
@@ -34,7 +46,7 @@ type ActiveTransition = { previousKeys: string[]; desiredKeys: string[] };
 
 function fakeTx(input: { capabilities?: CapabilityRow[]; transition?: ActiveTransition }) {
   return {
-    $queryRaw: vi.fn(async () => []),
+    $executeRaw: vi.fn(async () => 1),
     platformCapability: { findMany: vi.fn(async () => input.capabilities ?? []) },
     runtimeCapabilityTransition: { findFirst: vi.fn(async () => input.transition ?? null) },
   };

--- a/apps/web/lib/platform-runtime/work-admission.ts
+++ b/apps/web/lib/platform-runtime/work-admission.ts
@@ -3,7 +3,7 @@ import type { RuntimeWorkGuard } from "./work-attribution";
 const ACTIVE_TRANSITION_STATUSES = ["pending", "applying", "host_applied", "compensating"] as const;
 
 type AdmissionTx = {
-  $queryRaw(strings: TemplateStringsArray, ...values: unknown[]): Promise<unknown>;
+  $executeRaw(strings: TemplateStringsArray, ...values: unknown[]): Promise<unknown>;
   platformCapability: { findMany(args: unknown): Promise<Array<{ capabilityId: string; state: string; manifest: unknown }>> };
   runtimeCapabilityTransition: { findFirst(args: unknown): Promise<{ previousKeys: string[]; desiredKeys: string[] } | null> };
 };
@@ -23,7 +23,12 @@ function guardsFromManifest(manifest: unknown): string[] {
  * between the coordinator's drain count and a producer's insert.
  */
 export async function admitRuntimeGuardedWork(tx: AdmissionTx, guard: RuntimeWorkGuard): Promise<void> {
-  await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext('runtime-capability-transition'))`;
+  // BI-8BA6AC56: acquire the lock via $executeRaw, NOT $queryRaw. pg_advisory_xact_lock
+  // returns `void`, and Prisma 7.8's driver adapter throws UnsupportedNativeDataType
+  // (P2010) trying to deserialize a void column from $queryRaw — which crashed every
+  // Build Studio promote/start (this is the admission gate). $executeRaw runs the
+  // statement without deserializing a result set (matches care-appointment-repository).
+  await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('runtime-capability-transition'))`;
   const capabilities = await tx.platformCapability.findMany({
     where: { capabilityId: { startsWith: "runtime:" } },
     select: { capabilityId: true, state: true, manifest: true },


### PR DESCRIPTION
## What & why (BI-8BA6AC56)

Clicking **Rebuild** or **Start build** on any `/ops` backlog row crashes with a Server Components render error, and the item never promotes. Found while functionally verifying the new Rebuild button (#3263) on the live install — the button is correct, but the promote path behind it is broken.

**Root cause:** the runtime admission gate acquires a transaction advisory lock:
```js
tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext('runtime-capability-transition'))`
```
`pg_advisory_xact_lock` returns **`void`**, and Prisma **7.8**'s driver adapter throws `P2010 UnsupportedNativeDataType` deserializing a void column from `$queryRaw`. `admitRuntimeGuardedWork` runs on the promote path (`startBacklogBuild → promoteBacklogItemToBuildDraft`), so **every Build Studio promote/start/rebuild crashed on the live install** — very likely a major driver of the recent build-abandonment churn.

## Fix

Acquire the void-returning lock with **`$executeRaw`** (no result-set deserialization), matching the already-correct pattern in `care-appointment-repository.ts`:

- `apps/web/lib/platform-runtime/work-admission.ts` — the promote-path admission gate
- `apps/web/lib/platform-runtime/transition-coordinator.ts` — `createPending` + `commitSuccess`
- `apps/web/lib/governed-backlog-tee-up.ts` — the promote guard now checks `"$executeRaw" in tx`
- Existing tx mocks in both test files updated to `$executeRaw`; `work-admission.test.ts` gains a regression assertion (lock uses `$executeRaw`, never `$queryRaw`).

## Verification

- **4/4** assertions on `work-admission.ts` via a Node-24 strip-types standalone harness: lock acquired via `$executeRaw`, `$queryRaw` never called, draining-rejection + admit behavior preserved.
- ⚠️ Local typecheck/vitest can't run in this source-only worktree (`next`/`vitest` bins unresolved); pre-commit typecheck hook env-blocked and overridden (`DPF_SKIP_TYPECHECK=1`). **CI runs the authoritative Unit / Typecheck / Prod-Build gates.**
- **Final functional gate:** click Rebuild on the live install after deploy — should now create a fresh draft with no P2010 crash. (This unblocks clearing the six stranded items from #3263.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
