### PR TITLE
fix(self-upgrade): make promoter launch idempotent per runId (SUR-E2BF265E)

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -120,7 +120,10 @@ vi.mock("@/lib/self-upgrade/run-store", () => ({
   getLatestSucceededRun: mocks.getLatestSucceededRun,
 }));
 
-vi.mock("@/lib/self-upgrade/promoter", () => ({
+vi.mock("@/lib/self-upgrade/promoter", async (importOriginal) => ({
+  // Keep the real pure exports (constants like PROMOTER_ALREADY_RUNNING_EXIT_CODE
+  // that the orchestrator imports statically) and mock only the spawn-heavy fns.
+  ...(await importOriginal<typeof import("@/lib/self-upgrade/promoter")>()),
   runPromoter: mocks.runPromoter,
   isPromoterAvailable: mocks.isPromoterAvailable,
   ensurePromoterImage: mocks.ensurePromoterImage,
@@ -164,6 +167,7 @@ import {
   runSelfUpgrade,
 } from "./self-upgrade";
 import { allFunctions } from "./index";
+import { PROMOTER_ALREADY_RUNNING_EXIT_CODE } from "@/lib/self-upgrade/promoter";
 
 /**
  * Helper to set up startQuiescence to return a successful ready-to-swap
@@ -771,6 +775,21 @@ describe("failure path", () => {
     mocks.runPromoter.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "promote script failed" });
     const result = await runSelfUpgrade({ triggeredBy: "ops" });
     expect(result).toMatchObject({ ok: false, status: "failed", runId: "SUR-FAILTEST" });
+  });
+
+  it("defers (does NOT fail) when a promoter for this run is already building (SUR-E2BF265E)", async () => {
+    // runPromoter's idempotency guard declines to launch a duplicate and reports
+    // the sentinel. The orchestrator must leave run state untouched — no failRun,
+    // no cooldown — so a healthy in-flight build is never recorded as failed.
+    mocks.runPromoter.mockResolvedValue({
+      exitCode: PROMOTER_ALREADY_RUNNING_EXIT_CODE,
+      stdout: "",
+      stderr: "[promoter-already-running] deferring to it",
+    });
+    const result = await runSelfUpgrade({ triggeredBy: "ops" });
+    expect(result).toMatchObject({ ok: true, status: "already-in-flight", runId: "SUR-FAILTEST" });
+    expect(mocks.failRun).not.toHaveBeenCalled();
+    expect(mocks.recordCooldown).not.toHaveBeenCalled();
   });
 
   // The failure excerpt now LEADS with a build-failure classification and

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -12,6 +12,10 @@ import {
   evaluateReleaseBatch,
 } from "@/lib/self-upgrade/release-batch";
 import { prepareUpgradeSource, defaultGitRunner } from "@/lib/self-upgrade/prepare-source";
+// Pure constant from a spawn-free module — the host-only ./promoter runtime must
+// NOT be statically imported into this server bundle entrypoint (BI-98AF1066);
+// that is what the dynamic loadPromoterRuntime() below is for.
+import { PROMOTER_ALREADY_RUNNING_EXIT_CODE } from "@/lib/self-upgrade/promoter-exit-codes";
 import { getDeployedSha, isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";
 import {
   classifyBuildFailure,
@@ -615,6 +619,23 @@ export async function runSelfUpgrade(
     await recordCooldown(now, cooldownMinutes);
     await emitUpgradeEvent({ type: "upgrade.failed", runId: run.runId });
     return { ok: false, status: "failed", runId: run.runId, quiescenceRunId, excerpt: msg };
+  }
+
+  if (result.exitCode === PROMOTER_ALREADY_RUNNING_EXIT_CODE) {
+    // A concurrent/retried dispatch for THIS runId found a promoter already
+    // building it (runPromoter's idempotency guard declined to launch a
+    // duplicate). Leave run state untouched — the owning dispatch, and as a
+    // backstop the stuck-run watchdog, finalizes the run. Calling failRun here
+    // is exactly the SUR-E2BF265E defect: a healthy in-flight build recorded as
+    // failed because a second `docker run` collided on the deterministic name.
+    // No cooldown, no failure event — this dispatch is a no-op, not a failure.
+    return {
+      ok: true,
+      status: "already-in-flight",
+      runId: run.runId,
+      quiescenceRunId,
+      note: result.stderr.trim(),
+    };
   }
 
   if (result.exitCode === 0) {

--- a/apps/web/lib/self-upgrade/promoter-exit-codes.ts
+++ b/apps/web/lib/self-upgrade/promoter-exit-codes.ts
@@ -1,0 +1,21 @@
+/**
+ * Promoter subprocess exit-code contract, kept in a dedicated PURE module (no
+ * `node:child_process` / Docker imports). Server bundle entrypoints — Inngest
+ * functions, routes, server actions — must NOT statically import the host-only
+ * promoter runtime (`./promoter`, which spawns docker); the bundle-boundary
+ * guard (BI-98AF1066) enforces that. Those callers import these constants from
+ * here instead, and `./promoter` re-exports them for its own callers and tests.
+ */
+
+/**
+ * Internal sentinel `runPromoter` reports when it DECLINES to launch because a
+ * promoter for this run is already building — a concurrent or retried dispatch
+ * of the SAME runId. Not a real process exit code: the orchestrator special-
+ * cases it to defer to the owning dispatch instead of recording a failure.
+ *
+ * Without the guard, the deterministic `docker run --name dpf-promoter-<runId>`
+ * of the second dispatch collides ("The container name is already in use") and
+ * the orchestrator marked a HEALTHY in-flight build as failed (SUR-E2BF265E:
+ * the first promoter was past Step 40/119 when the run flipped to `failed`).
+ */
+export const PROMOTER_ALREADY_RUNNING_EXIT_CODE = 188;

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -6,7 +6,10 @@ import { join, resolve } from "node:path";
 import {
   buildPromoterCommand,
   decidePromoterEnsureAction,
+  decidePromoterLaunch,
+  interpretContainerInspect,
   isJitBuildablePromoterImage,
+  PROMOTER_ALREADY_RUNNING_EXIT_CODE,
   PROMOTER_JIT_BUILD_SCRIPT,
   PROMOTER_TIMEOUT_EXIT_CODE,
   resolvePromoterTimeoutMs,
@@ -172,6 +175,44 @@ describe("buildPromoterCommand", () => {
     const joined = buildPromoterCommand(BASE).args.join(" ");
     expect(joined).not.toContain("PROMOTE_COMPOSE_FILES=");
     expect(joined).not.toContain("PROMOTE_COMPOSE_PROJECT=");
+  });
+});
+
+describe("promoter launch idempotency (SUR-E2BF265E)", () => {
+  // The defect: the promoter container name is deterministic
+  // (`dpf-promoter-<runId>`), so a concurrent/retried dispatch of the SAME run
+  // issued a second `docker run --name dpf-promoter-SUR-E2BF265E`, hit
+  // "The container name is already in use", and the orchestrator recorded a
+  // build FAILURE — while the first promoter was still healthily building
+  // (past Step 40/119). runPromoter must first inspect the name and defer.
+
+  it("classifies docker inspect .State.Running output into a container state", () => {
+    // `docker inspect -f '{{.State.Running}}' <name>` — exit 0 + "true" while a
+    // build runs, exit 0 + "false" for an exited corpse `--rm` never cleaned,
+    // nonzero when there is no such container.
+    expect(interpretContainerInspect(0, "true\n")).toBe("running");
+    expect(interpretContainerInspect(0, "false\n")).toBe("present");
+    expect(interpretContainerInspect(1, "")).toBe("absent");
+  });
+
+  it("defers to an already-running promoter instead of relaunching and colliding", () => {
+    expect(decidePromoterLaunch("running")).toBe("defer");
+  });
+
+  it("reclaims a dead corpse (--rm never fired) before a fresh launch", () => {
+    expect(decidePromoterLaunch("present")).toBe("reclaim");
+  });
+
+  it("launches normally when no container by that name exists", () => {
+    expect(decidePromoterLaunch("absent")).toBe("launch");
+  });
+
+  it("signals a defer with a distinct sentinel exit code, never a real failure or timeout", () => {
+    // The orchestrator special-cases this code to leave run state untouched
+    // instead of calling failRun — so it must not collide with 0 (success) or
+    // the timeout code (a real failure the orchestrator DOES record).
+    expect(PROMOTER_ALREADY_RUNNING_EXIT_CODE).not.toBe(0);
+    expect(PROMOTER_ALREADY_RUNNING_EXIT_CODE).not.toBe(PROMOTER_TIMEOUT_EXIT_CODE);
   });
 });
 

--- a/apps/web/lib/self-upgrade/promoter.ts
+++ b/apps/web/lib/self-upgrade/promoter.ts
@@ -442,6 +442,77 @@ export async function ensurePromoterImage(
 /** Exit code runPromoter reports when it kills a promoter that blew its budget. */
 export const PROMOTER_TIMEOUT_EXIT_CODE = 124; // GNU `timeout` convention.
 
+// The already-running sentinel lives in a PURE sibling module so server bundle
+// entrypoints (the Inngest orchestrator) can import it statically without
+// pulling this Docker-spawning module into the bundle (BI-98AF1066). Re-exported
+// here for runPromoter's own use and the unit tests that import from ./promoter.
+export { PROMOTER_ALREADY_RUNNING_EXIT_CODE } from "./promoter-exit-codes";
+import { PROMOTER_ALREADY_RUNNING_EXIT_CODE } from "./promoter-exit-codes";
+
+export type PromoterContainerState =
+  | "running" // an active promoter is building this run right now
+  | "present" // a container with the name exists but is not running (dead corpse)
+  | "absent"; // no such container
+
+/**
+ * Classify `docker inspect -f '{{.State.Running}}' <name>` output. Pure so the
+ * mapping is unit-testable without a daemon. A nonzero exit is docker's "no such
+ * object" — absent. `true` is a live build; anything else (e.g. `false` for an
+ * exited container `--rm` never cleaned) is present-but-dead.
+ */
+export function interpretContainerInspect(
+  exitCode: number,
+  stdout: string,
+): PromoterContainerState {
+  if (exitCode !== 0) return "absent";
+  return stdout.trim() === "true" ? "running" : "present";
+}
+
+/**
+ * Decide how to launch given the state of a same-named container. Pure.
+ * - running  → `defer`: another dispatch of this runId is already building; a
+ *   second `docker run --name` would collide and false-fail that healthy build.
+ * - present  → `reclaim`: a dead corpse holds the name (crash/daemon restart
+ *   left it, `--rm` never fired); force-remove it, then launch fresh.
+ * - absent   → `launch`: nothing in the way.
+ */
+export function decidePromoterLaunch(
+  state: PromoterContainerState,
+): "defer" | "reclaim" | "launch" {
+  if (state === "running") return "defer";
+  if (state === "present") return "reclaim";
+  return "launch";
+}
+
+/**
+ * Inspect a promoter container by name. Never throws: resolves "absent" when
+ * docker is unreachable or no such container exists, so the launch path treats
+ * an inspect failure as "nothing in the way" and proceeds normally.
+ */
+export async function inspectPromoterContainerState(
+  name: string,
+): Promise<PromoterContainerState> {
+  if (!name) return "absent";
+  return new Promise((resolve) => {
+    try {
+      const child = spawn("docker", ["inspect", "-f", "{{.State.Running}}", name], {
+        env: { ...process.env },
+      });
+      let stdout = "";
+      child.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk;
+      });
+      child.stderr?.on("data", () => {});
+      child.on("close", (code: number | null) =>
+        resolve(interpretContainerInspect(code ?? 1, stdout)),
+      );
+      child.on("error", () => resolve("absent"));
+    } catch {
+      resolve("absent");
+    }
+  });
+}
+
 /** Default hard budget for the promoter subprocess: 25 min (env-overridable). */
 export function resolvePromoterTimeoutMs(params: PromoterParams): number {
   if (typeof params.timeoutMs === "number" && params.timeoutMs > 0) return params.timeoutMs;
@@ -528,6 +599,28 @@ export async function runProcessWithBudget(
 }
 
 export async function runPromoter(params: PromoterParams): Promise<PromoterResult> {
+  // Idempotency guard (SUR-E2BF265E). The container name is deterministic
+  // (`dpf-promoter-<runId>`), so a concurrent or retried dispatch of the SAME
+  // run reaching here would issue a second `docker run --name <name>` and hit
+  // "The container name is already in use" — recorded by the orchestrator as a
+  // build FAILURE even though the first promoter is still healthily building.
+  const name = params.containerName;
+  if (name) {
+    const action = decidePromoterLaunch(await inspectPromoterContainerState(name));
+    if (action === "defer") {
+      return {
+        exitCode: PROMOTER_ALREADY_RUNNING_EXIT_CODE,
+        stdout: "",
+        stderr: `[promoter-already-running] a promoter container named ${name} is already building this run; deferring to it instead of launching a duplicate.`,
+      };
+    }
+    if (action === "reclaim") {
+      // A prior promoter for this run exists but is no longer running — a
+      // crash/daemon-restart corpse `--rm` never cleaned. Remove it so the fresh
+      // launch below doesn't collide on the name.
+      await forceRemovePromoterContainer(name);
+    }
+  }
   const { command, args } = buildPromoterCommand(params);
   // Hard wall-clock bound. Without it a stalled `docker build` (SUR-756751D1: an
   // `apk add` fetch that crawled for 52 min) never closes, so `await runPromoter`

--- a/docs/superpowers/decisions/2026-07-18-self-upgrade-promoter-idempotent-launch.md
+++ b/docs/superpowers/decisions/2026-07-18-self-upgrade-promoter-idempotent-launch.md
@@ -1,0 +1,55 @@
+# Self-Upgrade Promoter Idempotent Launch
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-07-18 |
+| Status | Accepted |
+| Incident | SUR-E2BF265E |
+| Guard | BI-98AF1066 (bundle boundary) |
+
+## Context
+
+The promoter container name is deterministic — `dpf-promoter-<runId>` — added
+so the timeout path and the watchdog backstop can `docker rm -f` a hung build by
+name (SUR-756751D1). The launch itself, however, was **not idempotent**: when a
+second dispatch of the *same* runId reached `runPromoter` (an Inngest retry, a
+duplicate trigger event, or the stuck-run reconciler), it issued a second
+`docker run --name dpf-promoter-<runId>`. Docker refused with "The container
+name is already in use", and the orchestrator recorded that collision as a build
+**failure** — for a run whose *first* promoter was still healthily building.
+
+Live symptom: run **SUR-E2BF265E** flipped to `failed` 4 seconds after starting
+while its promoter container was past Step 40/119 (`next build`). The persisted
+`failureLog` was the docker name-conflict, not a real build error. The false
+failure also triggered a cooldown, delaying the next legitimate attempt.
+
+## Decision
+
+`runPromoter` inspects the deterministic container name before launching and
+acts on its state (pure, unit-tested helpers `interpretContainerInspect` +
+`decidePromoterLaunch`):
+
+- **running** → *defer*: return the internal sentinel
+  `PROMOTER_ALREADY_RUNNING_EXIT_CODE`. The orchestrator special-cases it to
+  leave run state untouched (no `failRun`, no cooldown, no `upgrade.failed`
+  event) and lets the owning dispatch — and, as a backstop, the stuck-run
+  watchdog — finalize the run.
+- **present** (an exited corpse `--rm` never cleaned, e.g. after a daemon
+  restart) → *reclaim*: `docker rm -f` it, then launch fresh.
+- **absent** → *launch* normally.
+
+The sentinel constant lives in a dedicated spawn-free module
+`apps/web/lib/self-upgrade/promoter-exit-codes.ts` so the Inngest orchestrator
+imports it **statically** without pulling the Docker-spawning `./promoter`
+runtime into the server bundle — the boundary the bundle-boundary guard
+(BI-98AF1066) enforces; the host-only runtime is still reached only through the
+dynamic `loadPromoterRuntime()`.
+
+## Scope / follow-ups (not in this change)
+
+- A deferring dispatch that started its own quiescence run leaves that record for
+  the watchdog rather than finalizing it here — a known follow-up, not a
+  regression over the prior false-fail behavior.
+- Surfacing skip/failure **reasons** per row in the Self-Upgrade *Run History*
+  table (persisted on `SelfUpgradeRun.reason` / `.failureLog` but not rendered)
+  is a separate UI change.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -40,14 +40,14 @@ apps/web/lib/integrate/build-agent-prompts.ts	1064
 apps/web/lib/integrate/build-orchestrator.ts	1779
 apps/web/lib/integrate/sandbox/build-branch.ts	852
 apps/web/lib/marketing.ts	1367
-apps/web/lib/mcp-tools-backlog.test.ts	920
+apps/web/lib/mcp-tools-backlog.test.ts	874
 apps/web/lib/mcp-tools.ts	2007
-apps/web/lib/mcp/packs/backlog-pack.ts	1328
+apps/web/lib/mcp/packs/backlog-pack.ts	1318
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	858
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
 apps/web/lib/navigation/portal-navigation-model.ts	937
 apps/web/lib/operate/coworker-regression-detector.ts	935
-apps/web/lib/queue/functions/self-upgrade.test.ts	1335
+apps/web/lib/queue/functions/self-upgrade.test.ts	1354
 apps/web/lib/routing/chat-adapter.test.ts	820
 apps/web/lib/routing/fallback.test.ts	1038
 apps/web/lib/self-upgrade/quiescence.test.ts	865


### PR DESCRIPTION
## Problem

Self-upgrade run **SUR-E2BF265E** was recorded as `failed` 4 seconds after starting — while its promoter container was **healthily building** (past Step 40/119, `next build`). The persisted `failureLog` was:

```
docker: Error response from daemon: Conflict. The container name
"/dpf-promoter-SUR-E2BF265E" is already in use by container "bea874ad…".
```

The promoter container name is **deterministic** (`dpf-promoter-<runId>`, added in #2808 so the timeout path / watchdog can `docker rm -f` a hung build by name). When a **second dispatch of the same runId** reaches `runPromoter` — a retry, a duplicate trigger event, or the stuck-run reconciler — it issues a second `docker run --name dpf-promoter-<runId>`, collides on the name, and the orchestrator records a build **failure** for a run that is actually building fine. A healthy in-flight upgrade gets marked failed (and cools down), purely from a launch-time name collision.

## Fix

`runPromoter` is now **idempotent per runId**. Before launching, it inspects the deterministic container name and decides:

- **running** → *defer*: return an internal sentinel (`PROMOTER_ALREADY_RUNNING_EXIT_CODE`) so the orchestrator leaves run state untouched and lets the owning dispatch finalize it — **no `failRun`, no cooldown, no `upgrade.failed` event**. Replaces false-failing a healthy build.
- **present** (dead corpse `--rm` never cleaned) → *reclaim*: `docker rm -f` it, then launch fresh.
- **absent** → *launch* normally.

The classification (`interpretContainerInspect`) and the launch decision (`decidePromoterLaunch`) are **pure and unit-tested without a daemon**, matching the module's existing "separated so it's unit-testable" pattern (`runProcessWithBudget`).

## Tests

- `promoter.test.ts` — new `promoter launch idempotency (SUR-E2BF265E)` block: inspect classification, defer/reclaim/launch decisions, sentinel distinctness.
- `self-upgrade.test.ts` — new orchestrator test: sentinel exit → `already-in-flight`, asserts `failRun` and `recordCooldown` are **not** called. Also fixed the `vi.mock("…/promoter")` to use `importOriginal` so the real constant flows through the mock (this is what the local-CI gate caught).
- Own gates green: `promoter.test.ts` 36/36, `self-upgrade.test.ts` 77/77, `tsc --noEmit` clean. The full `pnpm run pregate` is red **only** on pre-existing main-red UI component tests unrelated to this diff (see the `Local-CI-Override` trailer); GitHub required checks are authoritative.

## Scope notes (not in this PR)

- The **live** upgrade to `1c157563a` has not applied on the reporting install (portal still on `39782ef1…`); a re-trigger is the operational follow-up.
- When the second (deferring) dispatch has its own quiescence run, that quiescence record is left for the watchdog rather than finalized here — a known follow-up, not a regression.
- Surfacing skip/failure **reasons** in the Self-Upgrade *Run History* table (they are persisted but not rendered per-row) is a separate UI change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Local-CI-Override: pregate red is pre-existing main-red UI component tests (AgentFAB/BuildStudioDetailsDrawer/BuildStudioHeaderLayout — fail 3/3 on a clean origin/main base); this diff touches only self-upgrade lib + orchestrator. Own gates green: promoter.test.ts 36/36, self-upgrade.test.ts 77/77, tsc --noEmit clean.
