### PR TITLE
fix(self-upgrade): restore promoter JIT build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -257,9 +257,13 @@ RUN if [ -n "$DPF_PLATFORM_VERSION" ]; then \
 # Promoter build context (autonomous deployment pipeline)
 # These files let the portal build the dpf-promoter image on first use.
 COPY Dockerfile.promoter /promoter/Dockerfile.promoter
-COPY scripts/promote.sh /promoter/promote.sh
-COPY Dockerfile /promoter/portal.Dockerfile
-RUN chmod +x /promoter/promote.sh
+COPY scripts/promote.sh /promoter/scripts/promote.sh
+COPY Dockerfile /promoter/Dockerfile
+COPY scripts/apply-runtime-capability-transition.mjs /promoter/scripts/apply-runtime-capability-transition.mjs
+COPY scripts/runtime-transition-authority.mjs /promoter/scripts/runtime-transition-authority.mjs
+COPY scripts/rotate-runtime-transition-secret.mjs /promoter/scripts/rotate-runtime-transition-secret.mjs
+COPY scripts/installer/validate-install-state.mjs /promoter/scripts/installer/validate-install-state.mjs
+COPY scripts/installer/install-state.schema.json /promoter/scripts/installer/install-state.schema.json
 
 EXPOSE 3000
 # Self-upgrade image-identity guard (BI-5B6C1C35, spec §4.3): the running portal

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -234,9 +234,9 @@ describe("PROMOTER_JIT_BUILD_SCRIPT", () => {
   it("builds from the portal's baked-in /promoter/ layout and tags dpf-promoter", () => {
     // The recipe must consume the files the Dockerfile copies to /promoter/ and
     // produce the default local tag isPromoterAvailable() looks for.
-    expect(PROMOTER_JIT_BUILD_SCRIPT).toContain("/promoter/portal.Dockerfile");
+    expect(PROMOTER_JIT_BUILD_SCRIPT).toContain("/promoter/Dockerfile");
     expect(PROMOTER_JIT_BUILD_SCRIPT).toContain("/promoter/Dockerfile.promoter");
-    expect(PROMOTER_JIT_BUILD_SCRIPT).toContain("/promoter/promote.sh");
+    expect(PROMOTER_JIT_BUILD_SCRIPT).toContain("/promoter/scripts/promote.sh");
     expect(PROMOTER_JIT_BUILD_SCRIPT).toContain("docker build -t dpf-promoter -f Dockerfile.promoter");
   });
 

--- a/apps/web/lib/self-upgrade/promoter.ts
+++ b/apps/web/lib/self-upgrade/promoter.ts
@@ -286,7 +286,7 @@ export async function isPromoterAvailable(promoterImage?: string): Promise<boole
 /**
  * The just-in-time promoter build recipe. The build inputs are baked into the
  * portal image at `/promoter/` (see Dockerfile `COPY … /promoter/*`), laid out
- * to mirror the repo root — `portal.Dockerfile` (the portal build),
+ * to mirror the repo root — `Dockerfile` (the portal build),
  * `Dockerfile.promoter`, and `scripts/promote.sh`. Building from a temp dir with
  * that layout lets the same `Dockerfile.promoter` build the promoter image from
  * inside the portal container, with no host clone. This is the exact recipe the
@@ -297,13 +297,17 @@ export async function isPromoterAvailable(promoterImage?: string): Promise<boole
  * `sh -c` without shell-injection risk.
  */
 export const PROMOTER_JIT_BUILD_SCRIPT =
-  "BDIR=$(mktemp -d) && " +
-  "cp /promoter/portal.Dockerfile $BDIR/Dockerfile && " +
-  "cp /promoter/Dockerfile.promoter $BDIR/Dockerfile.promoter && " +
-  "mkdir -p $BDIR/scripts && " +
-  "cp /promoter/promote.sh $BDIR/scripts/promote.sh && " +
-  "tar -C $BDIR -c . | docker build -t dpf-promoter -f Dockerfile.promoter - && " +
-  "rm -rf $BDIR";
+  "BDIR=$(mktemp -d) && trap 'rm -rf \"$BDIR\"' EXIT && " +
+  "cp /promoter/Dockerfile \"$BDIR/Dockerfile\" && " +
+  "cp /promoter/Dockerfile.promoter \"$BDIR/Dockerfile.promoter\" && " +
+  "mkdir -p \"$BDIR/scripts\" && mkdir -p \"$BDIR/scripts/installer\" && " +
+  "cp /promoter/scripts/promote.sh \"$BDIR/scripts/promote.sh\" && " +
+  "cp /promoter/scripts/apply-runtime-capability-transition.mjs \"$BDIR/scripts/apply-runtime-capability-transition.mjs\" && " +
+  "cp /promoter/scripts/runtime-transition-authority.mjs \"$BDIR/scripts/runtime-transition-authority.mjs\" && " +
+  "cp /promoter/scripts/rotate-runtime-transition-secret.mjs \"$BDIR/scripts/rotate-runtime-transition-secret.mjs\" && " +
+  "cp /promoter/scripts/installer/validate-install-state.mjs \"$BDIR/scripts/installer/validate-install-state.mjs\" && " +
+  "cp /promoter/scripts/installer/install-state.schema.json \"$BDIR/scripts/installer/install-state.schema.json\" && " +
+  "tar -C \"$BDIR\" -c . | docker build -t dpf-promoter -f Dockerfile.promoter -";
 
 /**
  * Whether the configured promoter image can be built here from the portal's

--- a/docs/superpowers/plans/2026-07-18-self-upgrade-promoter-jit-context.md
+++ b/docs/superpowers/plans/2026-07-18-self-upgrade-promoter-jit-context.md
@@ -1,0 +1,61 @@
+# Self-Upgrade Promoter JIT Context Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore automatic self-upgrade by keeping the portal-baked JIT promoter build context complete when `Dockerfile.promoter` gains required inputs.
+
+**Architecture:** `Dockerfile.promoter` remains the source of truth for promoter build inputs. A repository contract test will verify that every local `COPY` source required by that Dockerfile is both baked into the portal's `/promoter/` directory and staged by `PROMOTER_JIT_BUILD_SCRIPT`; the production fix adds the five runtime-transition inputs currently omitted from both paths.
+
+**Tech Stack:** Docker multi-stage builds, Node.js test runner, TypeScript/Vitest, POSIX shell.
+
+---
+
+## Chunk 1: Regression contract and fix
+
+### Task 1: Prove the JIT context is incomplete
+
+**Files:**
+- Modify: `scripts/promoter-build-context.test.mjs`
+- Read: `Dockerfile.promoter`
+- Read: `Dockerfile`
+- Read: `apps/web/lib/self-upgrade/promoter.ts`
+
+- [x] Add a test that parses local `COPY` sources from `Dockerfile.promoter` and asserts each source is represented in both the portal `/promoter/` bake section and `PROMOTER_JIT_BUILD_SCRIPT` staging recipe.
+- [x] Run `node --test scripts/promoter-build-context.test.mjs` and confirm it fails before production files change.
+
+### Task 2: Restore the complete context
+
+**Files:**
+- Modify: `Dockerfile`
+- Modify: `apps/web/lib/self-upgrade/promoter.ts`
+- Test: `scripts/promoter-build-context.test.mjs`
+- Test: `apps/web/lib/self-upgrade/promoter.test.ts`
+
+- [x] Bake each runtime-transition script and installer validator/schema required by `Dockerfile.promoter` into the portal's `/promoter/` context, preserving their relative `scripts/` paths.
+- [x] Update `PROMOTER_JIT_BUILD_SCRIPT` to stage the same files and directories into its temporary build context.
+- [x] Run `node --test scripts/promoter-build-context.test.mjs` and confirm it passes.
+- [x] Run `pnpm --filter web exec vitest run lib/self-upgrade/promoter.test.ts lib/queue/functions/self-upgrade.test.ts` and confirm it passes.
+
+## Chunk 2: Verification and delivery
+
+### Task 3: Verify the real build path
+
+**Files:**
+- Verify: `Dockerfile.promoter`
+- Verify: `Dockerfile`
+- Verify: `apps/web/lib/self-upgrade/promoter.ts`
+
+- [x] Build the corrected promoter context using an isolated Docker tag.
+- [x] Confirm `docker build -f Dockerfile.promoter -` succeeds with the complete context.
+- [x] Run `pnpm --filter web typecheck` and the production build from the compile-ready worktree.
+
+### Task 4: Publish the fix
+
+**Files:**
+- Commit the files above with DCO sign-off.
+
+- [x] Review the final diff for one-concern scope and retained user changes.
+- [ ] Commit with `git commit -s`.
+- [ ] Push `fix/self-upgrade-promoter-build`.
+- [ ] Open a ready-for-review PR against `main` with reproduction and verification evidence.
+- [ ] Monitor required checks and address any failures before handoff.

--- a/docs/superpowers/plans/2026-07-18-self-upgrade-promoter-jit-context.md
+++ b/docs/superpowers/plans/2026-07-18-self-upgrade-promoter-jit-context.md
@@ -1,6 +1,6 @@
 # Self-Upgrade Promoter JIT Context Fix Implementation Plan
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED: Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` for the completion gate, and `dpf-pr-with-dco` for delivery. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Restore automatic self-upgrade by keeping the portal-baked JIT promoter build context complete when `Dockerfile.promoter` gains required inputs.
 

--- a/scripts/promoter-build-context.test.mjs
+++ b/scripts/promoter-build-context.test.mjs
@@ -1,9 +1,37 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { access, readFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, posix, resolve } from "node:path";
 
 const root = resolve(dirname(new URL(import.meta.url).pathname.replace(/^\/(.:\/)/, "$1")), "..");
+
+function parseSimpleLocalCopySources(dockerfile) {
+  const instructions = dockerfile
+    .replace(/\\\r?\n\s*/g, " ")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^COPY(?:\s|$)/i.test(line));
+
+  return instructions.map((instruction) => {
+    const match = /^COPY\s+(\S+)\s+(\S+)$/i.exec(instruction);
+    assert.ok(
+      match && !match[1].startsWith("--"),
+      `unsupported Dockerfile.promoter COPY form: ${instruction}`,
+    );
+    return match[1];
+  });
+}
+
+test("promoter COPY parser fails closed on forms the contract does not support", () => {
+  assert.throws(
+    () => parseSimpleLocalCopySources('COPY ["one", "two", "/dest/"]'),
+    /unsupported Dockerfile\.promoter COPY form/,
+  );
+  assert.throws(
+    () => parseSimpleLocalCopySources("COPY --chmod=755 one /dest/"),
+    /unsupported Dockerfile\.promoter COPY form/,
+  );
+});
 
 test("promoter image contains the install-state validator at its import-resolved paths", async () => {
   const dockerfile = await readFile(join(root, "Dockerfile.promoter"), "utf8");
@@ -12,4 +40,38 @@ test("promoter image contains the install-state validator at its import-resolved
   assert.match(dockerfile, /COPY scripts\/rotate-runtime-transition-secret\.mjs \/promoter\/rotate-runtime-transition-secret\.mjs/);
   await access(join(root, "scripts", "installer", "validate-install-state.mjs"));
   await access(join(root, "scripts", "installer", "install-state.schema.json"));
+});
+
+test("portal-baked JIT context includes every local Dockerfile.promoter COPY source", async () => {
+  const [promoterDockerfile, portalDockerfile, promoterSource] = await Promise.all([
+    readFile(join(root, "Dockerfile.promoter"), "utf8"),
+    readFile(join(root, "Dockerfile"), "utf8"),
+    readFile(join(root, "apps", "web", "lib", "self-upgrade", "promoter.ts"), "utf8"),
+  ]);
+  const localCopySources = parseSimpleLocalCopySources(promoterDockerfile);
+  const portalDockerfileLines = new Set(portalDockerfile.split(/\r?\n/).map((line) => line.trim()));
+  const jitScriptSource = promoterSource.replaceAll('\\"', '"');
+
+  assert.ok(localCopySources.length > 0, "Dockerfile.promoter must have local COPY inputs");
+  for (const source of localCopySources) {
+    const parent = posix.dirname(source);
+    assert.ok(
+      portalDockerfileLines.has(`COPY ${source} /promoter/${source}`),
+      `portal image must bake ${source} at its context-relative path`,
+    );
+    if (parent !== ".") {
+      assert.ok(
+        jitScriptSource.includes(`mkdir -p "$BDIR/${parent}"`),
+        `JIT build must create ${parent}`,
+      );
+    }
+    assert.ok(
+      jitScriptSource.includes(`cp /promoter/${source} "$BDIR/${source}"`),
+      `JIT build must stage ${source} at its context-relative path`,
+    );
+  }
+  assert.ok(
+    jitScriptSource.includes(`trap 'rm -rf "$BDIR"' EXIT`),
+    "JIT build must clean up its temp directory on success and failure",
+  );
 });


### PR DESCRIPTION
## Summary
- restore every `Dockerfile.promoter` input to the portal-baked `/promoter` payload
- stage the complete context in the automatic JIT promoter build and clean temporary contexts on every exit
- add a fail-closed contract test so future promoter `COPY` additions cannot silently bypass JIT packaging

## Root cause
PR #3262 added five runtime-transition inputs to `Dockerfile.promoter`, but the portal image and `PROMOTER_JIT_BUILD_SCRIPT` continued packaging only the original Dockerfile and promotion script. The portal's automatic build therefore failed at `COPY scripts/apply-runtime-capability-transition.mjs` and reported `promoter-unavailable` before drain.

## Verification
- `node --test scripts/promoter-build-context.test.mjs` — 3/3 passed
- focused self-upgrade Vitest — 107/107 passed
- `pnpm --filter web typecheck` — passed
- `docker build -f Dockerfile.promoter -t dpf-promoter-jit-test .` — passed
- `pnpm --filter web build` — passed
- governed local-CI convergence gate — passed (lease `NPEL-6C91903BDE`, evidence `cmrqgi84t23gl01qeqv38kksw`)