### PR TITLE
fix(self-upgrade): mount lifecycle state in promoter

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.test.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.test.ts
@@ -493,22 +493,22 @@ describe("success path", () => {
     expect(result).toMatchObject({ skipped: true, reason: "activity-in-flight" });
     expect(mocks.startQuiescence).not.toHaveBeenCalled();
   });
-
   it("runs the promoter with the host install path, backup, image, and health paths", async () => {
+    vi.stubEnv("DPF_STATE_DIR_HOST", "/Users/me/.dpf");
     await runSelfUpgrade({ triggeredBy: "ops" });
     expect(mocks.runPromoter).toHaveBeenCalledWith(
       expect.objectContaining({
-        // The promoter is launched as a sibling container against the HOST
-        // install path (daemon-resolved), not an in-portal source path.
+        // Promoter mounts daemon-resolved host paths, never portal paths.
         hostInstallPath: "/Users/me/dpf",
         targetSha: "abc1234deadbeef",
         backupPath: "/backups/self-upgrade/SUR-AAAABBBB",
         healthUrl: "http://localhost:3000/api/health",
         promoterImage: "dpf-promoter",
+        stateDirHostPath: "/Users/me/.dpf",
       }),
     );
+    vi.unstubAllEnvs();
   });
-
   it("emits upgrade.succeeded notification on promoter success", async () => {
     await runSelfUpgrade({ triggeredBy: "ops" });
     expect(mocks.emitUpgradeEvent).toHaveBeenCalledWith(

--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -578,9 +578,8 @@ export async function runSelfUpgrade(
   try {
     const { runPromoter } = await loadPromoterRuntime();
     result = await runPromoter({
-      // HOST path of the install tree, bind-mounted into the promoter
-      // container. Daemon-resolved, so it must be a host path (not an
-      // in-portal path). hostSourceMountPath is the in-container mount and
+      // HOST path of the install tree, bind-mounted into the promoter container.
+      // Daemon-resolved host path, not an in-portal path; hostSourceMountPath
       // is no longer passed — runPromoter mounts to a fixed /host-source.
       // BI-A8A7CCFD — when isolated workspace is on, the promoter builds from
       // the workspace HOST path (which holds the merged tree), not the
@@ -603,6 +602,7 @@ export async function runSelfUpgrade(
       composeProject,
       healthUrl: config.healthUrl ?? process.env.PROMOTE_HEALTH_URL ?? "",
       promoterImage: config.promoterImage,
+      stateDirHostPath: process.env.DPF_STATE_DIR_HOST,
       dryRun: params.dryRun,
       // Deterministic name so a stalled build can be force-removed by name on
       // timeout (runPromoter) or by the watchdog backstop. docker names allow

--- a/apps/web/lib/self-upgrade/promoter.test.ts
+++ b/apps/web/lib/self-upgrade/promoter.test.ts
@@ -73,6 +73,12 @@ describe("buildPromoterCommand", () => {
     expect(args).toContain("/Users/me/dpf:/host-source:ro");
   });
 
+  it("mounts lifecycle state for an ordinary self-upgrade", () => {
+    const { args } = buildPromoterCommand({ ...BASE, stateDirHostPath: "/host/.dpf" });
+    expect(args).toContain("/host/.dpf:/dpf-state");
+    expect(args).toContain("DPF_STATE_DIR=/dpf-state");
+  });
+
   it("gives transition mode only the state mount as writable and signs fixed protocol env", () => {
     const envelope = "e".repeat(16);
     const { args } = buildPromoterCommand({ ...BASE, runtimeCapabilityTransitionId: "RCT-123", stateDirHostPath: "/host/.dpf", runtimeCapabilityEnvelope: envelope, runtimeCapabilitySignature: "a".repeat(64), runtimeCapabilitySecretFileHostPath: "/host/.dpf/transition-secret", composeFiles: ["docker-compose.yml"], composeProject: "dpf" });

--- a/apps/web/lib/self-upgrade/promoter.ts
+++ b/apps/web/lib/self-upgrade/promoter.ts
@@ -191,6 +191,13 @@ export function buildPromoterCommand(
     args.push("-v", `${params.composeEnvFileHostPath}:${PROMOTER_COMPOSE_ENV_FILE}:ro`);
   }
 
+  // promote.sh resolves the install's governed capability projection before
+  // every portal rebuild, including ordinary self-upgrades. Mount lifecycle
+  // state for every mode rather than only transition-authority calls.
+  if (params.stateDirHostPath) {
+    args.push("-v", `${params.stateDirHostPath}:/dpf-state`, "-e", "DPF_STATE_DIR=/dpf-state");
+  }
+
   args.push(
     "-e",
     `PROMOTE_SOURCE=${PROMOTER_CONTAINER_SOURCE}`,
@@ -220,13 +227,12 @@ export function buildPromoterCommand(
   if (params.runtimeTransitionAuthorityOperation) {
     if (!params.stateDirHostPath || (!["reconcile", "rotate-secret"].includes(params.runtimeTransitionAuthorityOperation) && !params.runtimeCapabilityTransitionId) ||
       (params.runtimeTransitionAuthorityOperation === "release" && !params.runtimeTransitionAuthorityToken)) throw new Error("runtime_transition_authority_protocol_incomplete");
-    args.push("-v", `${params.stateDirHostPath}:/dpf-state`, "-e", "DPF_STATE_DIR=/dpf-state");
     if (params.runtimeTransitionAuthorityOperation === "reconcile") args.push("-e", `DPF_ACTIVE_RUNTIME_TRANSITION_IDS=${(params.runtimeTransitionActiveIds ?? []).join(",")}`);
   } else if (params.runtimeCapabilityTransitionId) {
     if (!params.stateDirHostPath || !params.runtimeCapabilityEnvelope || !params.runtimeCapabilitySignature || !params.runtimeCapabilitySecretFileHostPath) {
       throw new Error("runtime_transition_protocol_incomplete");
     }
-    args.push("-v", `${params.stateDirHostPath}:/dpf-state`, "-v", `${params.runtimeCapabilitySecretFileHostPath}:/run/secrets/dpf-runtime-transition:ro`);
+    args.push("-v", `${params.runtimeCapabilitySecretFileHostPath}:/run/secrets/dpf-runtime-transition:ro`);
     args.push("-e", `DPF_STATE_DIR=/dpf-state`, "-e", `DPF_RUNTIME_TRANSITION_ENVELOPE=${params.runtimeCapabilityEnvelope}`,
       "-e", `DPF_RUNTIME_TRANSITION_SIGNATURE=${params.runtimeCapabilitySignature}`);
   }


### PR DESCRIPTION
## Summary
- pass the host lifecycle-state path into every self-upgrade promoter launch
- mount the state directory for ordinary self-upgrades as well as transition operations
- add regression coverage at both the orchestrator and Docker command boundaries

## Root cause
The capability projection gate in promote.sh now requires install-state.json, but buildPromoterCommand only mounted DPF_STATE_DIR_HOST for runtime-transition modes. Normal self-upgrade therefore failed closed with capability_state_stale even when valid lifecycle state existed.

## Verification
- Focused Vitest: 114 tests passed across promoter.test.ts and self-upgrade.test.ts
- git diff --check: passed
- staged Gitleaks scan: passed
- Shared local-CI sandbox: lease was occupied for the full bounded wait; CI remains the authoritative full build gate for this source-only worktree

Process-Spine-Decision: Focused two-file launch-contract correction with regression tests; no new architecture or operational contract, so no separate spec or plan is needed.