### PR TITLE
fix(tak): progress-aware stuck detection for repeated read tools (BI-PIR-2fc2106c)

### DIFF
--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -3,7 +3,12 @@
 // This is the core behavioral difference between a chatbot and an agent.
 
 import { routeAndCall, type RoutedInferenceResult } from "@/lib/routed-inference";
-import { detectRepeatedToolCall, recordRepeatedToolIssue } from "@/lib/tak/runtime-issues";
+import {
+  detectRepeatedToolCall,
+  detectApproachingRepeatedToolCall,
+  buildNoProgressNudgeMessage,
+  recordRepeatedToolIssue,
+} from "@/lib/tak/runtime-issues";
 import { isRedundantReaskQuestion } from "@/lib/tak/conversation-intent";
 import { PLATFORM_TOOLS, toolsToOpenAIFormat, type ToolDefinition, type ToolResult } from "@/lib/mcp-tools";
 import { LOAD_TOOLS_TOOL_NAME, selectLoadableTools } from "@/lib/actions/coworker-tool-budget";
@@ -1368,6 +1373,8 @@ export async function runAgenticLoop(params: {
   const executedTools: AgenticResult["executedTools"] = [];
   let lastResult: RoutedInferenceResult | null = null;
   let continuationNudges = 0;
+  // BI-PIR-2fc2106c: one soft no-progress nudge per args signature.
+  const noProgressNudgedSigs = new Set<string>();
   let fabricationRetries = 0;
   let frustrationCount = 0;
   // Evidence-integrity gate (INV-1). Decide once whether this turn's answer
@@ -1605,47 +1612,28 @@ export async function runAgenticLoop(params: {
       };
     }
 
-    // Repetition detector — extracted to lib/tak/runtime-issues.ts so the
-    // existing "agent stuck" PlatformIssueReport write and the new reflection
-    // trigger share one detection site.
-    //
-    // No special-casing for review tools. reviewDesignDoc/reviewBuildPlan take no args,
-    // so every call hashes identically — 3 calls trips the guard. This caps the agent at
-    // 2 revision attempts per review, which is enough. If the design/plan still fails after
-    // 2 revisions the user needs to intervene.
+    // Repetition detector (runtime-issues). BI-PIR-2fc2106c: no-progress hard-stops
+    // without warm-up; soft-nudge once at threshold-1 for identical successes.
     const repeated = detectRepeatedToolCall({ executedTools, iteration });
     if (repeated) {
-      console.warn(
-        `[agentic-loop] stuck: ${repeated.toolName} called ${repeated.count}x with same args in last 40 calls.${repeated.reasonHint}`,
-      );
+      console.warn(`[agentic-loop] stuck: ${repeated.toolName} x${repeated.count} same args.${repeated.reasonHint}`);
       const content = buildRepeatedToolStopMessage({
-        toolName: repeated.toolName,
-        count: repeated.count,
-        routeContext,
-        reasonHint: repeated.reasonHint,
+        toolName: repeated.toolName, count: repeated.count, routeContext, reasonHint: repeated.reasonHint,
       });
       await recordRepeatedToolIssue({
-        repeated,
-        routeContext: routeContext ?? null,
-        userId,
-        agentId: agentId ?? null,
-        threadId: threadId ?? null,
-        taskRunId: taskRunId ?? null,
+        repeated, routeContext: routeContext ?? null, userId,
+        agentId: agentId ?? null, threadId: threadId ?? null, taskRunId: taskRunId ?? null,
       });
-      // Return immediately — do NOT make another inference call here.
-      // The summary inference call was the source of 300s hangs when the preferred provider
-      // was unavailable. The executedTools list already contains the full work history.
       return {
-        content,
-        providerId: "",
-        modelId: "",
-        downgraded: false,
-        downgradeMessage: null,
-        totalInputTokens,
-        totalOutputTokens,
-        executedTools,
-        proposal: null,
+        content, providerId: "", modelId: "", downgraded: false, downgradeMessage: null,
+        totalInputTokens, totalOutputTokens, executedTools, proposal: null,
       };
+    }
+    const approaching = detectApproachingRepeatedToolCall({ executedTools });
+    if (approaching && !noProgressNudgedSigs.has(approaching.signature)) {
+      noProgressNudgedSigs.add(approaching.signature);
+      console.warn(`[agentic-loop] no-progress nudge: ${approaching.toolName} x${approaching.count}`);
+      messages = [...messages, { role: "user" as const, content: buildNoProgressNudgeMessage(approaching) }];
     }
 
     // Dynamic tool descriptions: annotate tools that failed earlier in this session

--- a/apps/web/lib/tak/runtime-issues.test.ts
+++ b/apps/web/lib/tak/runtime-issues.test.ts
@@ -138,7 +138,7 @@ describe("recordRepeatedToolIssue", () => {
 
   it("writes a PlatformIssueReport with the expected fields and source coworker_runtime", async () => {
     const result = await recordRepeatedToolIssue({
-      repeated: { toolName: "create_backlog_item", count: 3, signature: "s", reasonHint: "" },
+      repeated: { toolName: "create_backlog_item", count: 3, signature: "s", reasonHint: "", noProgress: false },
       routeContext: "/customer",
       userId: "user-1",
       agentId: "AGT-1",
@@ -160,7 +160,7 @@ describe("recordRepeatedToolIssue", () => {
 
   it("skips writing on /build routes (Build Studio owns its own verification)", async () => {
     const result = await recordRepeatedToolIssue({
-      repeated: { toolName: "x", count: 3, signature: "s", reasonHint: "" },
+      repeated: { toolName: "x", count: 3, signature: "s", reasonHint: "", noProgress: false },
       routeContext: "/build/feature-123",
       userId: "u",
       agentId: "a",
@@ -174,7 +174,7 @@ describe("recordRepeatedToolIssue", () => {
   it("returns null on DB failure but does not throw", async () => {
     create.mockRejectedValue(new Error("db down"));
     const result = await recordRepeatedToolIssue({
-      repeated: { toolName: "x", count: 3, signature: "s", reasonHint: "" },
+      repeated: { toolName: "x", count: 3, signature: "s", reasonHint: "", noProgress: false },
       routeContext: "/customer",
       userId: "u",
       agentId: "a",

--- a/apps/web/lib/tak/runtime-issues.test.ts
+++ b/apps/web/lib/tak/runtime-issues.test.ts
@@ -10,6 +10,8 @@ vi.mock("@dpf/db", () => ({
 
 import {
   detectRepeatedToolCall,
+  detectApproachingRepeatedToolCall,
+  buildNoProgressNudgeMessage,
   recordRepeatedToolIssue,
   type ExecutedToolRecord,
 } from "./runtime-issues";
@@ -24,17 +26,39 @@ describe("detectRepeatedToolCall", () => {
     expect(detectRepeatedToolCall({ executedTools, iteration: 10 })).toBeNull();
   });
 
-  it("returns null when iteration <= 5 (loop warm-up window)", () => {
-    const executedTools = [makeCall("a"), makeCall("a"), makeCall("a")];
+  it("keeps warm-up for failing retries (iteration <= 5, changing outcomes)", () => {
+    // Failures with the same error still share a fingerprint — warm-up applies
+    // only when noProgress is false (mixed or failing). Use mixed results.
+    const executedTools: ExecutedToolRecord[] = [
+      { name: "a", args: {}, result: { success: false, error: "e1" } },
+      { name: "a", args: {}, result: { success: false, error: "e2" } },
+      { name: "a", args: {}, result: { success: false, error: "e3" } },
+    ];
     expect(detectRepeatedToolCall({ executedTools, iteration: 5 })).toBeNull();
   });
 
-  it("flags 3 identical calls within the window", () => {
+  it("hard-stops no-progress success loops even during warm-up (BI-PIR-2fc2106c)", () => {
+    // query_backlog ×3 with identical successful results — stop without waiting for iter>5
+    const executedTools = [
+      makeCall("query_backlog", { status: "open" }),
+      makeCall("query_backlog", { status: "open" }),
+      makeCall("query_backlog", { status: "open" }),
+    ];
+    const result = detectRepeatedToolCall({ executedTools, iteration: 3 });
+    expect(result).not.toBeNull();
+    expect(result?.toolName).toBe("query_backlog");
+    expect(result?.noProgress).toBe(true);
+    expect(result?.reasonHint).toMatch(/no progress/i);
+  });
+
+  it("flags 3 identical successful calls within the window", () => {
     const executedTools = [makeCall("a"), makeCall("a"), makeCall("a")];
     const result = detectRepeatedToolCall({ executedTools, iteration: 10 });
     expect(result).not.toBeNull();
     expect(result?.toolName).toBe("a");
     expect(result?.count).toBe(3);
+    // Generic tool names are not read-like; noProgress flag stays false.
+    expect(result?.noProgress).toBe(false);
   });
 
   it("treats differently-keyed args as distinct calls", () => {
@@ -67,14 +91,41 @@ describe("detectRepeatedToolCall", () => {
     expect(detectRepeatedToolCall({ executedTools, iteration: 10, window: 2 })).toBeNull();
   });
 
-  it("surfaces the last failure error as a reasonHint", () => {
+  it("surfaces the last failure error as a reasonHint when outcomes change", () => {
     const executedTools: ExecutedToolRecord[] = [
-      { name: "a", args: {}, result: { success: true } },
+      { name: "a", args: {}, result: { success: false, error: "timeout after 30s" } },
       { name: "a", args: {}, result: { success: false, error: "timeout after 30s" } },
       { name: "a", args: {}, result: { success: false, error: "timeout after 30s" } },
     ];
+    // Same error fingerprint + all failures → noProgress requires all success;
+    // this path uses warm-up unless iteration > 5
+    const warm = detectRepeatedToolCall({ executedTools, iteration: 5 });
+    expect(warm).toBeNull();
     const result = detectRepeatedToolCall({ executedTools, iteration: 10 });
     expect(result?.reasonHint).toContain("timeout after 30s");
+    expect(result?.noProgress).toBe(false);
+  });
+});
+
+describe("detectApproachingRepeatedToolCall + nudge (BI-PIR-2fc2106c)", () => {
+  it("flags 2 identical successful reads as approaching (soft nudge)", () => {
+    const executedTools = [
+      makeCall("query_backlog", { status: "open" }),
+      makeCall("query_backlog", { status: "open" }),
+    ];
+    const approaching = detectApproachingRepeatedToolCall({ executedTools });
+    expect(approaching).not.toBeNull();
+    expect(approaching?.count).toBe(2);
+    expect(approaching?.noProgress).toBe(true);
+    expect(buildNoProgressNudgeMessage(approaching!)).toMatch(/Do NOT call query_backlog again/);
+  });
+
+  it("does not soft-nudge after a single call", () => {
+    expect(
+      detectApproachingRepeatedToolCall({
+        executedTools: [makeCall("query_backlog")],
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/lib/tak/runtime-issues.ts
+++ b/apps/web/lib/tak/runtime-issues.ts
@@ -3,6 +3,11 @@
 // Extracted from apps/web/lib/tak/agentic-loop.ts so both the existing
 // "agent stuck" PlatformIssueReport write and the new reflection trigger
 // in apps/web/lib/tak/reflection-triggers.ts share one detection site.
+//
+// BI-PIR-2fc2106c: progress-aware. Identical args + identical successful
+// results = no progress — hard-stop without waiting for the iteration>5
+// warm-up. Approaching repeats (count == threshold-1) surface a soft nudge
+// so the model can change strategy before the hard stop.
 
 import { createHash, randomUUID } from "crypto";
 
@@ -19,19 +24,105 @@ export type RepeatedToolIssue = {
   count: number;
   signature: string;
   reasonHint: string;
+  /** True when every matching call returned the same successful outcome. */
+  noProgress: boolean;
 };
 
 const DEFAULT_WINDOW = 40;
 const DEFAULT_THRESHOLD = 3;
+
+function stableArgsHash(args: Record<string, unknown> | undefined): string {
+  const obj = args ?? {};
+  const argsJson = JSON.stringify(obj, Object.keys(obj).sort());
+  return createHash("sha1").update(argsJson).digest("hex").slice(0, 12);
+}
+
+/** Fingerprint of the tool *outcome* used for progress detection. */
+export function toolResultFingerprint(result: ExecutedToolRecord["result"]): string {
+  const payload = JSON.stringify({
+    success: result.success,
+    error: result.error ?? null,
+    message: result.message ?? null,
+  });
+  return createHash("sha1").update(payload).digest("hex").slice(0, 12);
+}
+
+type SigStats = {
+  count: number;
+  lastResult: ExecutedToolRecord["result"];
+  /** Distinct outcome fingerprints seen for this args signature. */
+  resultFingerprints: Set<string>;
+  successCount: number;
+};
+
+function collectSignatureStats(
+  executedTools: ExecutedToolRecord[],
+  window: number,
+): Map<string, SigStats> {
+  const stats = new Map<string, SigStats>();
+  const slice = executedTools.slice(-window);
+  for (const t of slice) {
+    const sig = `${t.name}:${stableArgsHash(t.args)}`;
+    const fp = toolResultFingerprint(t.result);
+    const existing = stats.get(sig);
+    if (!existing) {
+      stats.set(sig, {
+        count: 1,
+        lastResult: t.result,
+        resultFingerprints: new Set([fp]),
+        successCount: t.result.success ? 1 : 0,
+      });
+    } else {
+      existing.count += 1;
+      existing.lastResult = t.result;
+      existing.resultFingerprints.add(fp);
+      if (t.result.success) existing.successCount += 1;
+    }
+  }
+  return stats;
+}
+
+function isNoProgress(stats: SigStats): boolean {
+  // All successes and a single outcome fingerprint → re-reading the same answer.
+  return (
+    stats.successCount === stats.count &&
+    stats.resultFingerprints.size === 1 &&
+    stats.count >= 2
+  );
+}
+
+/** Read/list tools where identical success means no new information (BI-PIR-2fc2106c). */
+export function isReadLikeToolName(toolName: string): boolean {
+  return /^(query_|list_|get_|search_|read_|describe_|find_|wiki_)/i.test(toolName);
+}
+
+function toIssue(
+  signature: string,
+  stats: SigStats,
+  noProgress: boolean,
+): RepeatedToolIssue {
+  const toolName = signature.split(":")[0] ?? signature;
+  const lr = stats.lastResult;
+  let reasonHint = "";
+  if (noProgress) {
+    reasonHint =
+      " Identical successful results — no progress (same data returned each time).";
+  } else if (lr && !lr.success && lr.error) {
+    reasonHint = ` Last error: ${lr.error.slice(0, 120)}.`;
+  }
+  return { toolName, count: stats.count, signature, reasonHint, noProgress };
+}
 
 /**
  * Detect a tool that has been called with identical arguments at least
  * `threshold` times within the trailing `window` slice of executedTools.
  * Returns null when no repeated-call pattern is present.
  *
- * Hashing: sha1 over JSON.stringify with keys sorted for a stable canonical
- * form. This matches the historical inline behavior so existing
- * PlatformIssueReport rows correlate cleanly across the rename.
+ * Progress-aware (BI-PIR-2fc2106c):
+ * - Same args + same successful results → hard stop even during the early
+ *   iteration warm-up (the agent is stuck, not exploring).
+ * - Same args with changing results (e.g. retries after failure) still
+ *   respect iteration > 5 so legitimate recovery has room.
  */
 export function detectRepeatedToolCall(input: {
   executedTools: ExecutedToolRecord[];
@@ -41,36 +132,56 @@ export function detectRepeatedToolCall(input: {
 }): RepeatedToolIssue | null {
   const window = input.window ?? DEFAULT_WINDOW;
   const threshold = input.threshold ?? DEFAULT_THRESHOLD;
+  const statsMap = collectSignatureStats(input.executedTools, window);
 
-  const counts = new Map<string, number>();
-  const lastResult = new Map<string, ExecutedToolRecord["result"]>();
-  const slice = input.executedTools.slice(-window);
-  for (const t of slice) {
-    const argsJson = JSON.stringify(
-      t.args ?? {},
-      Object.keys((t.args as Record<string, unknown>) ?? {}).sort(),
-    );
-    const argsHash = createHash("sha1").update(argsJson).digest("hex").slice(0, 12);
-    const sig = `${t.name}:${argsHash}`;
-    counts.set(sig, (counts.get(sig) ?? 0) + 1);
-    lastResult.set(sig, t.result);
-  }
-
-  // The historical inline check additionally requires iteration > 5 to give
-  // the loop room to make legitimate progress before the guard fires; keep
-  // the same guard here so behavior is byte-identical.
-  if (input.iteration <= 5) return null;
-
-  const repeated = [...counts.entries()].find(([, n]) => n >= threshold);
+  const repeated = [...statsMap.entries()].find(([, s]) => s.count >= threshold);
   if (!repeated) return null;
 
-  const [signature, count] = repeated;
+  const [signature, stats] = repeated;
   const toolName = signature.split(":")[0] ?? signature;
-  const lr = lastResult.get(signature);
-  const reasonHint = lr && !lr.success && lr.error
-    ? ` Last error: ${lr.error.slice(0, 120)}.`
-    : "";
-  return { toolName, count, signature, reasonHint };
+  const noProgress = isNoProgress(stats) && isReadLikeToolName(toolName);
+
+  // Warm-up only applies when the agent might still be making progress
+  // (changing outcomes or non-read tools like review/save). Read-like
+  // no-progress loops stop immediately.
+  if (!noProgress && input.iteration <= 5) return null;
+
+  return toIssue(signature, stats, noProgress);
+}
+
+/**
+ * Soft-nudge signal: same args repeated `threshold - 1` times with no
+ * progress. The loop injects a user message so the model can change tools
+ * before the hard stop at `threshold`.
+ */
+export function detectApproachingRepeatedToolCall(input: {
+  executedTools: ExecutedToolRecord[];
+  window?: number;
+  threshold?: number;
+}): RepeatedToolIssue | null {
+  const window = input.window ?? DEFAULT_WINDOW;
+  const threshold = input.threshold ?? DEFAULT_THRESHOLD;
+  const approachAt = Math.max(2, threshold - 1);
+  const statsMap = collectSignatureStats(input.executedTools, window);
+
+  // Prefer read-like no-progress signatures (query_backlog etc.).
+  for (const [signature, stats] of statsMap) {
+    if (stats.count !== approachAt) continue;
+    const toolName = signature.split(":")[0] ?? signature;
+    if (!isReadLikeToolName(toolName) || !isNoProgress(stats)) continue;
+    return toIssue(signature, stats, true);
+  }
+  return null;
+}
+
+/** User-message content injected when a no-progress repeat is approaching. */
+export function buildNoProgressNudgeMessage(issue: RepeatedToolIssue): string {
+  return (
+    `[System notice] You already called ${issue.toolName} ${issue.count} times with the same arguments ` +
+    `and got the same successful result — there is no new information. Do NOT call ${issue.toolName} again ` +
+    `with those arguments. Use the data you already have, change the arguments, or call a different tool. ` +
+    `Repeating the same call will stop the run.`
+  );
 }
 
 const BUILD_ROUTE_PATTERN = /^\/build(\/|$)/;


### PR DESCRIPTION
## Summary
- Fix **agent_stuck** loops where read tools like `query_backlog` were called repeatedly with the same args and same successful results until a late hard stop (PIR-DA11C / BI-PIR-2fc2106c).
- **Progress detection:** fingerprint tool outcomes; identical args + identical success = no progress.
- **Hard stop early** for read-like tools (`query_*`, `list_*`, `get_*`, `search_*`, …) without waiting for the iteration>5 warm-up.
- **Soft nudge** once at count = threshold−1 so the model can use existing data or change tools before the hard stop.
- Review/write tools keep the classic same-args + warm-up behavior (3 review cycles still allowed).

## Design grounding
- Existing specs/plans reviewed:
  - Agent stuck / repeated-tool path is implementation-level (PlatformIssueReport type=agent_stuck); no separate UX/nav design — behavior lives in `runtime-issues.ts` + agentic loop.
  - Process-spine related: agentic loop tool repetition is a loop-control guard, not a new workflow surface.
- Current code substrate reviewed:
  - `apps/web/lib/tak/runtime-issues.ts` (`detectRepeatedToolCall`, `recordRepeatedToolIssue`)
  - `apps/web/lib/tak/agentic-loop.ts` (hard-stop site + soft-nudge injection)
  - `apps/web/lib/tak/reflection-triggers.ts` (consumes agent_stuck reports)
- Source of truth:
  - Repeated-tool detection remains in `runtime-issues.ts`; agentic-loop only calls it and injects one soft nudge per signature.
- Decision:
  - Extend the existing detector with outcome fingerprinting + read-like early hard-stop + soft nudge; do not invent a parallel stuck-loop subsystem or change coworker UX routes/nav.

Design-Grounding-Decision: reviewed agentic-loop + runtime-issues substrate and agent_stuck PIR path; localized loop-guard fix for no-progress read-tool repeats, no contract/routing/UX surface change.

## Evidence
- Worktree: `fix/agent-stuck-progress`
- Unit tests: `pnpm --filter web exec vitest run lib/tak/runtime-issues.test.ts lib/tak/agentic-loop.test.ts` → **114 passed**
- Local-CI-Override: source-local unit tests green on worktree; full pregate via CI

## Test plan
- [x] No-progress query_backlog ×3 hard-stops at iteration 3
- [x] Soft nudge at ×2 identical successful reads
- [x] Failing retries still get warm-up
- [x] 3-cycle plan review path still completes 6 tool calls then stops
- [ ] CI Unit Tests + typecheck

Process-Spine-Decision: pure bug fix with regression tests; no new durable surface