### PR TITLE
feat(finance): org locale/currency spine — retire the British-by-default bias

### DIFF
--- a/apps/web/lib/actions/currency.ts
+++ b/apps/web/lib/actions/currency.ts
@@ -2,6 +2,8 @@
 
 import { prisma } from "@dpf/db";
 
+import { deriveLocaleCurrencyFromCountry } from "@/lib/org-locale/org-locale";
+
 // ─── Hardcoded fallback rates (GBP base) ──────────────────────────────────────
 
 const FALLBACK_RATES: Record<string, Record<string, number>> = {
@@ -28,6 +30,32 @@ export async function updateBaseCurrency(currency: string) {
   return prisma.orgSettings.update({
     where: { id: settings.id },
     data: { baseCurrency: currency },
+  });
+}
+
+// ─── applyOrgCountry ──────────────────────────────────────────────────────────
+
+/**
+ * Sync the org's locale/currency spine from its home country (EP-ORG-LOCALE-
+ * CURRENCY). Called wherever onboarding captures the operator's country. Always
+ * records `countryCode`; initializes `baseCurrency` + `locale` from the country
+ * ONLY the first time a country is captured, so a later explicit operator
+ * currency choice (via `updateBaseCurrency`) is never clobbered.
+ */
+export async function applyOrgCountry(countryCode: string | null | undefined) {
+  const iso = countryCode?.trim().toUpperCase() || null;
+  if (!iso) return null;
+
+  const settings = await getOrgSettings();
+  const isFirstCountry = !settings.countryCode;
+  const derived = deriveLocaleCurrencyFromCountry(iso);
+
+  return prisma.orgSettings.update({
+    where: { id: settings.id },
+    data: {
+      countryCode: iso,
+      ...(isFirstCountry ? { baseCurrency: derived.currency, locale: derived.locale } : {}),
+    },
   });
 }
 

--- a/apps/web/lib/actions/tax-remittance.ts
+++ b/apps/web/lib/actions/tax-remittance.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { prisma } from "@dpf/db";
+import { applyOrgCountry } from "@/lib/actions/currency";
 import { auth } from "@/lib/auth";
 import { encryptSecret } from "@/lib/govern/credential-crypto";
 import { can } from "@/lib/permissions";
@@ -121,6 +122,11 @@ export async function updateOrganizationTaxProfile(input: UpdateOrganizationTaxP
       notes: nullableString(parsed.notes),
     },
   });
+
+  // Onboarding captured the operator's home country here — sync it to the org's
+  // locale/currency spine so a US business is USD/en-US, not GBP/Europe-London
+  // (EP-ORG-LOCALE-CURRENCY). Non-fatal: a sync failure must not fail tax setup.
+  await applyOrgCountry(updated.homeCountryCode).catch(() => null);
 
   const registrations = await prisma.taxRegistration.findMany({
     where: { organizationTaxProfileId: profile.id },

--- a/apps/web/lib/actions/tax-remittance.ts
+++ b/apps/web/lib/actions/tax-remittance.ts
@@ -64,7 +64,6 @@ async function requireManageFinance() {
   ) {
     throw new Error("Unauthorized");
   }
-
   return user;
 }
 
@@ -72,7 +71,6 @@ async function requireOrganization() {
   const organization = await prisma.organization.findFirst({
     orderBy: { createdAt: "asc" },
   });
-
   if (!organization) {
     throw new Error("No organization configured");
   }
@@ -122,11 +120,7 @@ export async function updateOrganizationTaxProfile(input: UpdateOrganizationTaxP
       notes: nullableString(parsed.notes),
     },
   });
-
-  // Onboarding captured the operator's home country here — sync it to the org's
-  // locale/currency spine so a US business is USD/en-US, not GBP/Europe-London
-  // (EP-ORG-LOCALE-CURRENCY). Non-fatal: a sync failure must not fail tax setup.
-  await applyOrgCountry(updated.homeCountryCode).catch(() => null);
+  await applyOrgCountry(updated.homeCountryCode).catch(() => null); // EP-ORG-LOCALE-CURRENCY: sync org currency/locale from the captured home country (non-fatal)
 
   const registrations = await prisma.taxRegistration.findMany({
     where: { organizationTaxProfileId: profile.id },

--- a/apps/web/lib/org-locale/org-locale.test.ts
+++ b/apps/web/lib/org-locale/org-locale.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_LOCALE_CURRENCY,
+  deriveLocaleCurrencyFromCountry,
+  formatMoney,
+  localeForCurrency,
+  resolveOrgLocale,
+  type OrgLocaleClient,
+} from "./org-locale";
+
+describe("deriveLocaleCurrencyFromCountry", () => {
+  it("maps common operator countries to their currency + locale", () => {
+    expect(deriveLocaleCurrencyFromCountry("US")).toEqual({ currency: "USD", locale: "en-US" });
+    expect(deriveLocaleCurrencyFromCountry("GB")).toEqual({ currency: "GBP", locale: "en-GB" });
+    expect(deriveLocaleCurrencyFromCountry("AU")).toEqual({ currency: "AUD", locale: "en-AU" });
+    expect(deriveLocaleCurrencyFromCountry("DE")).toEqual({ currency: "EUR", locale: "de-DE" });
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(deriveLocaleCurrencyFromCountry(" us ")).toEqual({ currency: "USD", locale: "en-US" });
+    expect(deriveLocaleCurrencyFromCountry("gb")).toEqual({ currency: "GBP", locale: "en-GB" });
+  });
+
+  it("falls back to the neutral default for unknown/empty country", () => {
+    expect(deriveLocaleCurrencyFromCountry(null)).toEqual(DEFAULT_LOCALE_CURRENCY);
+    expect(deriveLocaleCurrencyFromCountry("")).toEqual(DEFAULT_LOCALE_CURRENCY);
+    expect(deriveLocaleCurrencyFromCountry("ZZ")).toEqual(DEFAULT_LOCALE_CURRENCY);
+  });
+});
+
+describe("formatMoney", () => {
+  it("formats in the currency's own locale by default (no more en-GB for USD)", () => {
+    expect(formatMoney(1234, "USD")).toBe("$1,234");
+    expect(formatMoney(1234, "GBP")).toBe("£1,234");
+  });
+
+  it("honours an explicit locale", () => {
+    // en-US grouping with a USD symbol regardless of caller default.
+    expect(formatMoney(1000000, "USD", "en-US")).toBe("$1,000,000");
+  });
+
+  it("rounds to whole units by default and respects maximumFractionDigits", () => {
+    expect(formatMoney(1234.56, "USD")).toBe("$1,235");
+    expect(formatMoney(1234.5, "USD", "en-US", { maximumFractionDigits: 2 })).toBe("$1,234.50");
+  });
+
+  it("emits a bare grouped number when the currency is unknown", () => {
+    expect(formatMoney(1500, null)).toBe("1,500");
+  });
+
+  it("falls back to a bare number for an invalid ISO currency code", () => {
+    expect(formatMoney(1500, "NOTREAL")).toBe("1,500");
+  });
+});
+
+describe("localeForCurrency", () => {
+  it("maps a currency to a display locale, else en-US", () => {
+    expect(localeForCurrency("GBP")).toBe("en-GB");
+    expect(localeForCurrency("EUR")).toBe("en-IE");
+    expect(localeForCurrency(null)).toBe("en-US");
+    expect(localeForCurrency("ZZZ")).toBe("en-US");
+  });
+});
+
+describe("resolveOrgLocale", () => {
+  const client = (row: unknown): OrgLocaleClient => ({
+    orgSettings: { findFirst: async () => row as never },
+  });
+
+  it("returns the default when there is no settings row", async () => {
+    expect(await resolveOrgLocale(client(null))).toEqual({ currency: "USD", locale: "en-US", countryCode: null });
+  });
+
+  it("uses the operator-set baseCurrency + locale", async () => {
+    const out = await resolveOrgLocale(client({ baseCurrency: "USD", locale: "en-US", countryCode: "US" }));
+    expect(out).toEqual({ currency: "USD", locale: "en-US", countryCode: "US" });
+  });
+
+  it("derives from countryCode when currency/locale are blank", async () => {
+    const out = await resolveOrgLocale(client({ baseCurrency: "", locale: "", countryCode: "au" }));
+    expect(out).toEqual({ currency: "AUD", locale: "en-AU", countryCode: "AU" });
+  });
+
+  it("never throws when the query fails — degrades to the default", async () => {
+    const failing: OrgLocaleClient = {
+      orgSettings: { findFirst: async () => { throw new Error("db down"); } },
+    };
+    expect(await resolveOrgLocale(failing)).toEqual({ currency: "USD", locale: "en-US", countryCode: null });
+  });
+});

--- a/apps/web/lib/org-locale/org-locale.ts
+++ b/apps/web/lib/org-locale/org-locale.ts
@@ -1,0 +1,158 @@
+// apps/web/lib/org-locale/org-locale.ts
+//
+// The single source of truth for "what currency, locale, and country does THIS
+// org operate in" (EP-ORG-LOCALE-CURRENCY / BI-0530BB74). DPF was British-by-
+// default — `currency` defaulted to GBP across the schema, `StorefrontConfig`
+// defaulted to Europe/London, and money was formatted per-surface with ad-hoc
+// `toLocaleString("en-GB")`. For a non-UK operator every money + date surface
+// rendered the wrong locale.
+//
+// This module makes the org's locale/currency DERIVED from the operator's own
+// country (never a hardcoded foreign default) and gives every surface one
+// formatter + one resolver to adopt. `OrgSettings` is the persisted spine
+// (baseCurrency / locale / countryCode); this is the pure logic over it.
+//
+// PURE + DB-free except `resolveOrgLocale`, which takes an injected client so it
+// stays test-friendly (mirrors the living-business-snapshot idiom).
+
+export interface LocaleCurrency {
+  currency: string;
+  locale: string;
+}
+
+/** The neutral fallback when the org's country is unknown. USD/en-US matches the
+ *  OrgSettings application default; it is a last resort, not a claim about the
+ *  operator — onboarding derivation (below) should set the real values. */
+export const DEFAULT_LOCALE_CURRENCY: LocaleCurrency = { currency: "USD", locale: "en-US" };
+
+/**
+ * ISO-3166 alpha-2 country → its default operating currency + BCP-47 locale.
+ * Covers the common operator countries; anything unlisted derives the neutral
+ * default. Deliberately small and hand-curated (not a full ISO table) — the goal
+ * is "stop defaulting a US business to GBP", not exhaustive i18n.
+ */
+const COUNTRY_LOCALE_CURRENCY: Record<string, LocaleCurrency> = {
+  US: { currency: "USD", locale: "en-US" },
+  GB: { currency: "GBP", locale: "en-GB" },
+  IE: { currency: "EUR", locale: "en-IE" },
+  DE: { currency: "EUR", locale: "de-DE" },
+  FR: { currency: "EUR", locale: "fr-FR" },
+  ES: { currency: "EUR", locale: "es-ES" },
+  IT: { currency: "EUR", locale: "it-IT" },
+  NL: { currency: "EUR", locale: "nl-NL" },
+  PT: { currency: "EUR", locale: "pt-PT" },
+  AT: { currency: "EUR", locale: "de-AT" },
+  BE: { currency: "EUR", locale: "nl-BE" },
+  FI: { currency: "EUR", locale: "fi-FI" },
+  CA: { currency: "CAD", locale: "en-CA" },
+  AU: { currency: "AUD", locale: "en-AU" },
+  NZ: { currency: "NZD", locale: "en-NZ" },
+  CH: { currency: "CHF", locale: "de-CH" },
+  SE: { currency: "SEK", locale: "sv-SE" },
+  NO: { currency: "NOK", locale: "nb-NO" },
+  DK: { currency: "DKK", locale: "da-DK" },
+  PL: { currency: "PLN", locale: "pl-PL" },
+  JP: { currency: "JPY", locale: "ja-JP" },
+  CN: { currency: "CNY", locale: "zh-CN" },
+  IN: { currency: "INR", locale: "en-IN" },
+  SG: { currency: "SGD", locale: "en-SG" },
+  HK: { currency: "HKD", locale: "en-HK" },
+  AE: { currency: "AED", locale: "en-AE" },
+  ZA: { currency: "ZAR", locale: "en-ZA" },
+  MX: { currency: "MXN", locale: "es-MX" },
+  BR: { currency: "BRL", locale: "pt-BR" },
+  AR: { currency: "ARS", locale: "es-AR" },
+};
+
+/** Currency → a sensible display locale, for when only the currency is known
+ *  (e.g. a persisted amount whose row carries a currency but the org has no
+ *  locale set). Falls back to en-US. */
+const CURRENCY_DEFAULT_LOCALE: Record<string, string> = {
+  USD: "en-US", GBP: "en-GB", EUR: "en-IE", CAD: "en-CA", AUD: "en-AU",
+  NZD: "en-NZ", CHF: "de-CH", SEK: "sv-SE", NOK: "nb-NO", DKK: "da-DK",
+  PLN: "pl-PL", JPY: "ja-JP", CNY: "zh-CN", INR: "en-IN", SGD: "en-SG",
+  HKD: "en-HK", AED: "en-AE", ZAR: "en-ZA", MXN: "es-MX", BRL: "pt-BR", ARS: "es-AR",
+};
+
+/** Derive the operating currency + locale from an ISO-3166 alpha-2 country code. */
+export function deriveLocaleCurrencyFromCountry(iso2: string | null | undefined): LocaleCurrency {
+  if (!iso2) return { ...DEFAULT_LOCALE_CURRENCY };
+  return { ...(COUNTRY_LOCALE_CURRENCY[iso2.trim().toUpperCase()] ?? DEFAULT_LOCALE_CURRENCY) };
+}
+
+/** A display locale for a currency when the org locale is unknown. */
+export function localeForCurrency(currency: string | null | undefined): string {
+  return (currency && CURRENCY_DEFAULT_LOCALE[currency.toUpperCase()]) ?? "en-US";
+}
+
+/**
+ * Format an amount as money in a specific currency + locale — the one formatter
+ * every surface should adopt (replacing per-file `toLocaleString("en-GB")` and
+ * hand-rolled symbol maps). `locale` defaults to the currency's own locale so a
+ * USD amount never renders with en-GB grouping. When the currency is unknown we
+ * emit a bare, locale-neutral grouped number rather than guessing a symbol.
+ */
+export function formatMoney(
+  amount: number,
+  currency: string | null | undefined,
+  locale?: string | null,
+  opts?: { maximumFractionDigits?: number },
+): string {
+  const maximumFractionDigits = opts?.maximumFractionDigits ?? 0;
+  const value = maximumFractionDigits === 0 ? Math.round(amount) : amount;
+  if (currency) {
+    try {
+      return new Intl.NumberFormat(locale ?? localeForCurrency(currency), {
+        style: "currency",
+        currency,
+        maximumFractionDigits,
+      }).format(value);
+    } catch {
+      // Unknown ISO currency code — fall through to a bare number.
+    }
+  }
+  return value.toLocaleString(locale ?? "en-US", { maximumFractionDigits });
+}
+
+// ─────────────────────────── the org resolver ───────────────────────────────
+
+export interface OrgLocaleSettings {
+  currency: string;
+  locale: string;
+  countryCode: string | null;
+}
+
+/** Narrow structural client — satisfied by the real PrismaClient and test fakes. */
+export interface OrgLocaleClient {
+  orgSettings: {
+    findFirst: (args: unknown) => Promise<{
+      baseCurrency?: string | null;
+      locale?: string | null;
+      countryCode?: string | null;
+    } | null>;
+  };
+}
+
+/**
+ * Resolve the deployment org's operating currency + locale from `OrgSettings`
+ * (the single-org spine). Currency comes from the operator-set `baseCurrency`;
+ * locale from `locale`; both fall back to derivation from `countryCode`, then to
+ * the neutral default. Never throws for a missing settings row — a brand-new
+ * deployment resolves to the default until onboarding sets the country.
+ */
+export async function resolveOrgLocale(db: OrgLocaleClient): Promise<OrgLocaleSettings> {
+  const settings = await (
+    db.orgSettings?.findFirst({ select: { baseCurrency: true, locale: true, countryCode: true } }) ??
+    Promise.resolve(null)
+  ).catch(() => null);
+
+  if (!settings) return { ...DEFAULT_LOCALE_CURRENCY, countryCode: null };
+
+  const countryCode = settings.countryCode?.trim().toUpperCase() || null;
+  const derived = deriveLocaleCurrencyFromCountry(countryCode);
+  return {
+    currency: settings.baseCurrency || derived.currency,
+    locale: settings.locale || derived.locale,
+    countryCode,
+  };
+}

--- a/apps/web/lib/twin/living-business-snapshot.test.ts
+++ b/apps/web/lib/twin/living-business-snapshot.test.ts
@@ -271,6 +271,9 @@ describe("loadLivingBusinessSnapshot — loader", () => {
       storefrontConfig: {
         findFirst: async () => ({ archetype: { archetypeId: "restaurant", name: "Dine-in restaurant" } }),
       },
+      // Org is US → the twin renders USD regardless of any legacy GBP-denominated
+      // bill row (currency comes from OrgSettings, not the bill).
+      orgSettings: { findFirst: async () => ({ baseCurrency: "USD", locale: "en-US", countryCode: "US" }) },
       bill: { findMany: async () => [{ amountDue: 500, dueDate: NOW, status: "open", currency: "GBP" }] },
       taxObligationPeriod: { findMany: async () => [{ dueDate: new Date("2026-07-20T00:00:00Z"), status: "open", filedAt: null }] },
       obligation: { findMany: async () => [] },
@@ -295,8 +298,8 @@ describe("loadLivingBusinessSnapshot — loader", () => {
     // presence carries both the human and the AI coworker
     expect(snap!.presence.some((p) => p.kind === "ai")).toBe(true);
     expect(snap!.presence.some((p) => p.kind === "human")).toBe(true);
-    // finance is real
-    expect(snap!.utility.find((m) => m.key === "bills")!.value).toContain("£500");
+    // finance renders the ORG currency (USD), not the legacy GBP bill row
+    expect(snap!.utility.find((m) => m.key === "bills")!.value).toContain("$500");
     // a pending booking becomes queue demand + a cog proposal
     expect(snap!.queues[0].items.length).toBeGreaterThan(0);
     expect(snap!.cog).toBeTruthy();

--- a/apps/web/lib/twin/living-business-snapshot.ts
+++ b/apps/web/lib/twin/living-business-snapshot.ts
@@ -27,6 +27,12 @@ import { buildStageFlow, type StageDemand } from "./stage-flow";
 
 import type { Intent } from "@/components/ui/report-kit";
 import {
+  formatMoney,
+  resolveOrgLocale,
+  type OrgLocaleClient,
+  type OrgLocaleSettings,
+} from "@/lib/org-locale/org-locale";
+import {
   loadWorkforceRoster,
   type WorkforceMember,
   type WorkforceRosterClient,
@@ -49,7 +55,7 @@ import type {
 
 // ── Structural client (satisfied by the real PrismaClient and by test fakes) ──
 type FindMany = (args: unknown) => Promise<unknown>;
-export type LivingBusinessClient = WorkforceRosterClient & {
+export type LivingBusinessClient = WorkforceRosterClient & OrgLocaleClient & {
   storefrontConfig: { findFirst: (args: unknown) => Promise<unknown> };
   bill: { findMany: FindMany };
   /** Optional — outcomes (paid-invoice revenue) degrade to empty if absent. */
@@ -137,28 +143,10 @@ function monthDay(d: Date): string {
 function isWalkInWait(b: { scheduledAt: Date | null }): boolean {
   return b.scheduledAt == null;
 }
-// Money is formatted from its OWN currency's locale so a USD amount never renders
-// with en-GB grouping/symbol (and vice-versa). This removes the previous
-// hardcoded `en-GB`; the org-level currency/locale source (so the whole platform
-// stops defaulting to GBP for a non-UK operator) is the follow-on remediation
-// tracked in EP-ORG-LOCALE-CURRENCY. When the currency is unknown we format a
-// bare, locale-neutral grouped number rather than guessing a symbol.
-const CURRENCY_LOCALE: Record<string, string> = { GBP: "en-GB", USD: "en-US", EUR: "en-IE" };
-export function formatMoney(amount: number, code: string | null): string {
-  const value = Math.round(amount);
-  if (code) {
-    try {
-      return new Intl.NumberFormat(CURRENCY_LOCALE[code] ?? "en-US", {
-        style: "currency",
-        currency: code,
-        maximumFractionDigits: 0,
-      }).format(value);
-    } catch {
-      // Unknown ISO code — fall through to a bare number.
-    }
-  }
-  return value.toLocaleString("en-US");
-}
+// Money formatting + the org's currency/locale now come from the shared
+// `@/lib/org-locale` spine (EP-ORG-LOCALE-CURRENCY) so the twin renders the
+// org's real currency (from OrgSettings, derived from the operator's country)
+// instead of inferring it from whichever bill row happened to carry one.
 
 // ─────────────────────────── pure mapping helpers ───────────────────────────
 
@@ -282,6 +270,7 @@ export function financeToUtility(input: {
   billsDueCount: number;
   billsDueAmount: number;
   currency: string | null;
+  locale?: string | null;
   nextTaxDueDays: number | null;
   complianceOpenCount: number;
   coworkerGaps: number;
@@ -300,7 +289,7 @@ export function financeToUtility(input: {
       label: "Bills due",
       value:
         input.billsDueCount > 0
-          ? `${input.billsDueCount} · ${formatMoney(input.billsDueAmount, input.currency)}`
+          ? `${input.billsDueCount} · ${formatMoney(input.billsDueAmount, input.currency, input.locale)}`
           : "None due",
       intent: input.billsDueCount > 0 ? "warning" : "success",
       hint: "Next 7 days",
@@ -486,7 +475,7 @@ export async function loadLivingBusinessSnapshot(opts?: {
   const profile: TwinProfile = deriveTwinProfile(def);
 
   const in90 = new Date(now.getTime() - 90 * 86_400_000);
-  const [roster, bills, taxPeriods, obligations, bookings, providers, paidInvoices] = await Promise.all([
+  const [roster, bills, taxPeriods, obligations, bookings, providers, paidInvoices, orgLocale] = await Promise.all([
     loadWorkforceRoster({ db }).catch(() => ({ members: [], summary: { total: 0, humans: 0, agents: 0, agentsWithUnmetNeeds: 0 } })),
     db.bill
       .findMany({
@@ -530,11 +519,15 @@ export async function loadLivingBusinessSnapshot(opts?: {
           })
           .catch(() => [])
       : Promise.resolve([])) as Promise<InvoiceRow[]>,
+    resolveOrgLocale(db),
   ]);
 
   const members = roster.members;
   const billsDueAmount = bills.reduce((sum, b) => sum + toNum(b.amountDue), 0);
-  const currency = bills.find((b) => b.currency)?.currency ?? null;
+  // The org's own currency + locale (from OrgSettings, derived from the operator's
+  // country) is authoritative for every money surface here — never inferred from
+  // whichever bill/invoice row happened to carry a currency.
+  const { currency: orgCurrency, locale: orgLocaleStr } = orgLocale as OrgLocaleSettings;
   const nextTaxDueDays =
     taxPeriods[0]?.dueDate != null ? Math.max(0, daysBetween(now, taxPeriods[0].dueDate)) : null;
   const complianceOpenCount = obligations.filter(
@@ -596,12 +589,11 @@ export async function loadLivingBusinessSnapshot(opts?: {
   // Customer outcomes (workstream D): revenue realized in the last 90 days + the
   // count of settled+paid work — the proof the business is producing.
   const paidRevenue = paidInvoices.reduce((sum, inv) => sum + toNum(inv.totalAmount), 0);
-  const revenueCurrency = paidInvoices.find((i) => i.currency)?.currency ?? currency;
   const outcomes: TwinOutcome[] = [
     {
       key: "revenue",
       label: "Revenue in",
-      value: formatMoney(paidRevenue, revenueCurrency),
+      value: formatMoney(paidRevenue, orgCurrency, orgLocaleStr),
       intent: "success",
       hint: "Paid · 90 days",
     },
@@ -642,7 +634,8 @@ export async function loadLivingBusinessSnapshot(opts?: {
     utility: financeToUtility({
       billsDueCount: bills.length,
       billsDueAmount,
-      currency,
+      currency: orgCurrency,
+      locale: orgLocaleStr,
       nextTaxDueDays,
       complianceOpenCount,
       coworkerGaps: roster.summary.agentsWithUnmetNeeds,

--- a/apps/web/lib/workspace-home/twin-panel-data.test.ts
+++ b/apps/web/lib/workspace-home/twin-panel-data.test.ts
@@ -37,6 +37,8 @@ function fakeDb(configured: { archetypeId: string; name: string } | null) {
       ],
     },
     storefrontConfig: { findFirst: async () => (configured ? { archetype: configured } : null) },
+    // Org is US → the twin renders USD (from OrgSettings), not the legacy GBP bill row.
+    orgSettings: { findFirst: async () => ({ baseCurrency: "USD", locale: "en-US", countryCode: "US" }) },
     bill: { findMany: async () => [{ amountDue: 500, dueDate: NOW, status: "open", currency: "GBP" }] },
     taxObligationPeriod: { findMany: async () => [] },
     obligation: { findMany: async () => [] },
@@ -107,8 +109,8 @@ describe("loadWorkspaceTwinPresentation — live overlay", () => {
     expect(result!.demo).toBe(false);
     // live presence carries the real workforce (a human + an AI coworker)
     expect(result!.snapshot.presence.some((p) => p.kind === "ai")).toBe(true);
-    // real finance flows through
-    expect(result!.snapshot.utility.find((m) => m.key === "bills")!.value).toContain("£500");
+    // real finance flows through, rendered in the ORG currency (USD), not the GBP bill row
+    expect(result!.snapshot.utility.find((m) => m.key === "bills")!.value).toContain("$500");
     // home-mount condensing still applies to the live snapshot
     expect(result!.snapshot.cog).toBeUndefined();
     expect(result!.snapshot.quests).toEqual([]);

--- a/changes/org-locale-currency-spine.data-impact.json
+++ b/changes/org-locale-currency-spine.data-impact.json
@@ -1,0 +1,28 @@
+{
+  "version": "1",
+  "accountableOwner": "Mark Bodman (markdbodman@gmail.com)",
+  "summary": "EP-ORG-LOCALE-CURRENCY / BI-0530BB74. Adds the org locale/currency spine (OrgSettings.locale + countryCode) and retires the British-by-default column defaults (currency GBP->USD on ~24 finance/commerce models; StorefrontConfig.timezone Europe/London->UTC). Default-only changes add NO new persistent data and never re-denominate existing rows; the only new persistent fields are the two OrgSettings columns below.",
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "OrgSettings",
+      "lifecycleDisposition": "retain-for-org-lifetime",
+      "fields": [
+        {
+          "name": "locale",
+          "resolution": "not-applicable",
+          "reason": "Operational display preference (BCP-47 locale) for money/date formatting; not personal data and not tied to a data subject.",
+          "provenance": "Derived at onboarding from the operator's home country (OrganizationTaxProfile.homeCountryCode) or set explicitly by the operator; default en-US.",
+          "flags": []
+        },
+        {
+          "name": "countryCode",
+          "resolution": "not-applicable",
+          "reason": "The organisation's own home country (ISO-3166 alpha-2), business-configuration data used to derive currency/locale; not a data subject's personal attribute.",
+          "provenance": "Synced from the operator-provided OrganizationTaxProfile.homeCountryCode at onboarding via applyOrgCountry(); nullable until captured.",
+          "flags": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-18-org-locale-currency-spine.md
+++ b/docs/superpowers/plans/2026-07-18-org-locale-currency-spine.md
@@ -1,0 +1,75 @@
+# Org locale & currency spine — retire the British-by-default bias
+
+- **Epic:** EP-ORG-LOCALE-CURRENCY
+- **Backlog item:** BI-0530BB74
+- **Kernel decision ledger:** DI-92BCDA20FB94
+- **Status:** Phase 1 implemented (this PR); Phases 2–3 follow-up.
+
+## Problem
+
+DPF was British-by-default. `currency` defaulted to `GBP` across ~24
+finance/commerce models, `StorefrontConfig.timezone` defaulted to
+`Europe/London`, and money was formatted per-surface with ad-hoc
+`toLocaleString("en-GB")`. There was **no org-level currency/locale/country
+source**, so a non-UK operator (e.g. a US business) saw `£`, en-GB grouping, and
+UK dates everywhere — including the operational twin the operator flagged.
+
+Substrate that already existed and is reused rather than reinvented:
+- `OrgSettings` — the single-org settings singleton, with `baseCurrency` (app
+  create-default was already `USD`, but the schema column default was `GBP`).
+- `OrganizationTaxProfile.homeCountryCode` / `OrganizationLicenseProfile.homeCountryCode`
+  — onboarding already captures the operator's home country.
+- `apps/web/lib/actions/currency.ts` — `getOrgSettings` / `updateBaseCurrency`.
+
+## Design
+
+`OrgSettings` becomes the canonical locale/currency source of truth; the org's
+values are **derived from the operator's own country**, never a hardcoded foreign
+default. One shared module gives every surface a resolver + a formatter.
+
+### Phase 1 — spine + the twin (this PR)
+
+1. **`apps/web/lib/org-locale/org-locale.ts`** (pure + one injected-client
+   resolver):
+   - `deriveLocaleCurrencyFromCountry(iso2)` — ISO-3166 alpha-2 → `{currency, locale}`
+     (curated map of common operator countries; unknown → neutral `USD/en-US`).
+   - `formatMoney(amount, currency, locale?, opts?)` — the one money formatter
+     (Intl, currency's own locale by default). Replaces per-file `en-GB` hardcoding.
+   - `resolveOrgLocale(db)` — reads `OrgSettings`, falls back to country
+     derivation then the neutral default; never throws.
+2. **`OrgSettings`** gains `locale` (`@default("en-US")`) and `countryCode`;
+   `baseCurrency` default flips `GBP → USD`.
+3. **Schema defaults**: the ~24 `@default("GBP")` currency columns → `USD`;
+   `StorefrontConfig.timezone` `Europe/London → UTC`. Migration
+   `20260718120000_org_locale_currency_spine` (defaults + backfill of the
+   existing `OrgSettings` row: `locale` from `baseCurrency`, `countryCode` from
+   the tax profile). **Existing amounts are not re-denominated.**
+4. **Operational twin** (`lib/twin/living-business-snapshot.ts`) reads
+   `resolveOrgLocale` for currency + locale instead of inferring currency from a
+   bill row, and formats via the shared `formatMoney`.
+5. **Onboarding wiring**: `applyOrgCountry(countryCode)` (in `currency.ts`) syncs
+   `OrgSettings.countryCode` + initializes currency/locale from the country the
+   first time it is captured; called from `updateOrganizationTaxProfile`.
+
+### Phase 2 — adopt the shared formatter everywhere (follow-up)
+
+~40 surfaces still format money with local helpers (`formatMoney`,
+`formatCurrency`, inline `Intl`/symbol maps) across finance tables, invoices,
+bills, CRM, storefront. Mechanically migrate them to `@/lib/org-locale`
+`formatMoney` + `resolveOrgLocale`, verifying each surface on the running portal.
+This is deferred because it needs per-surface functional verification, not a
+blind sweep.
+
+### Phase 3 — existing-data re-denomination (follow-up, operator-visible)
+
+For an install that already wrote real `GBP` rows, decide (with the operator)
+whether to re-denominate or leave historical amounts. Never silently relabel a
+persisted amount's currency.
+
+## Verification
+
+- Phase 1: `org-locale.test.ts` (pure derivation/format/resolve) + updated
+  `living-business-snapshot.test.ts` (twin renders the org currency, not the bill
+  row). CI typecheck/build/unit gate the migration + schema.
+- Functional: a fresh US-country install (or `OrgSettings.countryCode = "US"`)
+  renders `$` + US grouping on the twin; GBP no longer appears by default.

--- a/packages/db/prisma/migrations/20260718120000_org_locale_currency_spine/migration.sql
+++ b/packages/db/prisma/migrations/20260718120000_org_locale_currency_spine/migration.sql
@@ -1,0 +1,84 @@
+-- EP-ORG-LOCALE-CURRENCY / BI-0530BB74 — retire the British-by-default bias.
+--
+-- DPF defaulted `currency` to GBP across ~two dozen finance/commerce models and
+-- StorefrontConfig.timezone to Europe/London, with no org-level locale source.
+-- This migration:
+--   1. Extends OrgSettings (the single-org spine) into the locale/currency source
+--      of truth: adds `locale` + `countryCode`, and flips baseCurrency's DEFAULT
+--      from GBP to the neutral USD (matching the app-create default).
+--   2. Flips the hardcoded GBP column DEFAULTs to USD so new rows are no longer
+--      British-by-default. Existing amounts are NOT re-denominated — changing a
+--      column DEFAULT never rewrites existing rows, and silently relabelling a
+--      persisted amount's currency would be wrong. Re-denomination of any real
+--      GBP data is a separate, operator-visible decision under EP-ORG-LOCALE-CURRENCY.
+--   3. Flips StorefrontConfig.timezone DEFAULT to the neutral UTC.
+--   4. Backfills the existing OrgSettings singleton: locale derived from its
+--      baseCurrency, countryCode from the org's tax profile home country when set.
+
+-- 1. OrgSettings: new locale/currency spine columns + neutral baseCurrency default.
+ALTER TABLE "OrgSettings"
+  ADD COLUMN "locale" TEXT NOT NULL DEFAULT 'en-US',
+  ADD COLUMN "countryCode" TEXT;
+
+ALTER TABLE "OrgSettings" ALTER COLUMN "baseCurrency" SET DEFAULT 'USD';
+
+-- 2. Flip the hardcoded GBP column defaults to USD (new-row defaults only).
+ALTER TABLE "CustomerAccount" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "CustomerConfigurationItem" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "Opportunity" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "Quote" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "SalesOrder" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "Subscription" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "TaxLiabilityEntry" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "StorefrontItem" ALTER COLUMN "priceCurrency" SET DEFAULT 'USD';
+ALTER TABLE "StorefrontOrder" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "RentalAgreement" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "StorefrontDonation" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "Invoice" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "Payment" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "Supplier" ALTER COLUMN "defaultCurrency" SET DEFAULT 'USD';
+ALTER TABLE "Bill" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "PurchaseOrder" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "BankAccount" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "RecurringSchedule" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "ExpenseClaim" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "ExpenseItem" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "FixedAsset" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "LedgerAccount" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "JournalEntry" ALTER COLUMN "currency" SET DEFAULT 'USD';
+ALTER TABLE "JournalLine" ALTER COLUMN "currency" SET DEFAULT 'USD';
+
+-- 3. StorefrontConfig: neutral timezone default (was Europe/London).
+ALTER TABLE "StorefrontConfig" ALTER COLUMN "timezone" SET DEFAULT 'UTC';
+
+-- 4. Backfill the existing single-org OrgSettings row.
+--    countryCode from the org's tax profile home country (single-org install).
+UPDATE "OrgSettings"
+SET "countryCode" = (
+  SELECT UPPER("homeCountryCode")
+  FROM "OrganizationTaxProfile"
+  WHERE "homeCountryCode" IS NOT NULL AND "homeCountryCode" <> ''
+  ORDER BY "updatedAt" DESC
+  LIMIT 1
+)
+WHERE "countryCode" IS NULL;
+
+--    locale derived from the established baseCurrency signal (so an existing GBP
+--    install reads en-GB, a USD install en-US, etc.).
+UPDATE "OrgSettings"
+SET "locale" = CASE "baseCurrency"
+  WHEN 'GBP' THEN 'en-GB'
+  WHEN 'EUR' THEN 'en-IE'
+  WHEN 'AUD' THEN 'en-AU'
+  WHEN 'CAD' THEN 'en-CA'
+  WHEN 'NZD' THEN 'en-NZ'
+  WHEN 'CHF' THEN 'de-CH'
+  WHEN 'SEK' THEN 'sv-SE'
+  WHEN 'NOK' THEN 'nb-NO'
+  WHEN 'DKK' THEN 'da-DK'
+  WHEN 'JPY' THEN 'ja-JP'
+  WHEN 'INR' THEN 'en-IN'
+  WHEN 'SGD' THEN 'en-SG'
+  WHEN 'ZAR' THEN 'en-ZA'
+  ELSE 'en-US'
+END;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3087,7 +3087,7 @@ model CustomerAccount {
   industry               String?
   employeeCount          Int?
   annualRevenue          Decimal?
-  currency               String                      @default("GBP")
+  currency               String                      @default("USD")
   notes                  String?
   sourceSystem           String?
   sourceId               String?
@@ -3281,7 +3281,7 @@ model CustomerConfigurationItem {
   customerChargeModel   String?
   unitCost              Decimal?        @db.Decimal(12, 2)
   customerUnitPrice     Decimal?        @db.Decimal(12, 2)
-  currency              String          @default("GBP")
+  currency              String          @default("USD")
   properties            Json?
   createdAt             DateTime        @default(now())
   updatedAt             DateTime        @updatedAt
@@ -3552,7 +3552,7 @@ model Opportunity {
   isDormant      Boolean   @default(false)
   probability    Int       @default(10) // 0-100%
   expectedValue  Decimal?
-  currency       String    @default("GBP")
+  currency       String    @default("USD")
   expectedClose  DateTime?
   actualClose    DateTime?
   lostReason     String?
@@ -3600,7 +3600,7 @@ model Quote {
   discountValue Decimal   @default(0)
   taxAmount     Decimal   @default(0)
   totalAmount   Decimal
-  currency      String    @default("GBP")
+  currency      String    @default("USD")
   terms         String?
   notes         String?
   // Public accept-link token (mirrors Invoice.payToken): possession authorizes
@@ -3653,7 +3653,7 @@ model SalesOrder {
   quoteId     String    @unique // 1:1 with accepted Quote
   accountId   String
   totalAmount Decimal
-  currency    String    @default("GBP")
+  currency    String    @default("USD")
   fulfilledAt DateTime?
   cancelledAt DateTime?
   notes       String?
@@ -3684,7 +3684,7 @@ model Subscription {
   planName        String // e.g. "DPF Managed Instance — Support & Hosting"
   billingCadence  String    @default("annual") // monthly | quarterly | annual
   totalValue      Decimal
-  currency        String    @default("GBP")
+  currency        String    @default("USD")
   startDate       DateTime  @default(now())
   renewalDate     DateTime
   endDate         DateTime?
@@ -4065,7 +4065,7 @@ model TaxLiabilityEntry {
   direction                String
   taxableAmount            Decimal  @default(0)
   taxAmount                Decimal  @default(0)
-  currency                 String   @default("GBP")
+  currency                 String   @default("USD")
   notes                    String?
   occurredAt               DateTime
   createdAt                DateTime @default(now())
@@ -8561,7 +8561,7 @@ model StorefrontConfig {
   designSystem          Json?
   isPublished           Boolean                          @default(false)
   customDomain          String?
-  timezone              String                           @default("Europe/London")
+  timezone              String                           @default("UTC")
   portfolioId           String?
   createdAt             DateTime                         @default(now())
   updatedAt             DateTime                         @updatedAt
@@ -9084,7 +9084,7 @@ model StorefrontItem {
   description         String?
   category            String?
   priceAmount         Decimal?
-  priceCurrency       String                          @default("GBP")
+  priceCurrency       String                          @default("USD")
   priceType           String?
   imageUrl            String?
   ctaType             String
@@ -9730,7 +9730,7 @@ model StorefrontOrder {
   deliveryAddress   Json?
   items             Json
   totalAmount       Decimal
-  currency          String           @default("GBP")
+  currency          String           @default("USD")
   status            String           @default("pending")
   createdAt         DateTime         @default(now())
   updatedAt         DateTime         @updatedAt
@@ -9786,7 +9786,7 @@ model RentalAgreement {
   pricingModel         String    @default("per-day") // per-day|per-week|usage-based|fixed
   rateAmount           Decimal?
   depositAmount        Decimal?
-  currency             String    @default("GBP")
+  currency             String    @default("USD")
   status               String    @default("reserved") // reserved|verified|active|returned|closed|cancelled
   verificationStatus   String    @default("not-required") // not-required|pending|verified|failed
   checkoutConditionId  String?   @unique
@@ -9947,7 +9947,7 @@ model StorefrontDonation {
   donorEmail        String
   donorName         String?
   amount            Decimal
-  currency          String           @default("GBP")
+  currency          String           @default("USD")
   campaignId        String?
   message           String?
   isAnonymous       Boolean          @default(false)
@@ -10057,7 +10057,7 @@ model Invoice {
   sourceId          String?
   issueDate         DateTime  @default(now())
   dueDate           DateTime
-  currency          String    @default("GBP")
+  currency          String    @default("USD")
   subtotal          Decimal
   taxAmount         Decimal   @default(0)
   discountAmount    Decimal   @default(0)
@@ -10127,7 +10127,7 @@ model Payment {
   method             String
   status             String    @default("pending")
   amount             Decimal
-  currency           String    @default("GBP")
+  currency           String    @default("USD")
   exchangeRate       Decimal   @default(1)
   baseCurrencyAmount Decimal?
   reference          String?
@@ -10182,7 +10182,7 @@ model Supplier {
   address         Json?
   taxId           String?
   paymentTerms    String?  @default("Net 30")
-  defaultCurrency String   @default("GBP")
+  defaultCurrency String   @default("USD")
   status          String   @default("active")
   bankDetails     Json?
   notes           String?
@@ -10384,7 +10384,7 @@ model Bill {
   invoiceRef         String?
   issueDate          DateTime
   dueDate            DateTime
-  currency           String   @default("GBP")
+  currency           String   @default("USD")
   subtotal           Decimal
   taxAmount          Decimal  @default(0)
   totalAmount        Decimal
@@ -10435,7 +10435,7 @@ model PurchaseOrder {
   poNumber     String    @unique
   supplierId   String
   status       String    @default("draft")
-  currency     String    @default("GBP")
+  currency     String    @default("USD")
   subtotal     Decimal
   taxAmount    Decimal   @default(0)
   totalAmount  Decimal
@@ -10537,7 +10537,7 @@ model BankAccount {
   sortCode         String?
   iban             String?
   swift            String?
-  currency         String    @default("GBP")
+  currency         String    @default("USD")
   accountType      String    @default("current")
   isDefault        Boolean   @default(false)
   openingBalance   Decimal   @default(0)
@@ -10599,7 +10599,7 @@ model RecurringSchedule {
   name            String
   frequency       String
   amount          Decimal
-  currency        String    @default("GBP")
+  currency        String    @default("USD")
   startDate       DateTime
   endDate         DateTime?
   nextInvoiceDate DateTime
@@ -10690,7 +10690,7 @@ model ExpenseClaim {
   status         String    @default("draft")
   title          String
   totalAmount    Decimal
-  currency       String    @default("GBP")
+  currency       String    @default("USD")
   submittedAt    DateTime?
   approvedById   String?
   approvedAt     DateTime?
@@ -10716,7 +10716,7 @@ model ExpenseItem {
   category       String
   description    String
   amount         Decimal
-  currency       String   @default("GBP")
+  currency       String   @default("USD")
   receiptUrl     String?
   taxReclaimable Boolean  @default(false)
   taxAmount      Decimal  @default(0)
@@ -10738,7 +10738,7 @@ model FixedAsset {
   category                String
   purchaseDate            DateTime
   purchaseCost            Decimal
-  currency                String    @default("GBP")
+  currency                String    @default("USD")
   depreciationMethod      String    @default("straight_line")
   usefulLifeMonths        Int
   residualValue           Decimal   @default(0)
@@ -10791,7 +10791,13 @@ model Complaint {
 
 model OrgSettings {
   id                 String    @id @default(cuid())
-  baseCurrency       String    @default("GBP")
+  // The single-org locale/currency spine (EP-ORG-LOCALE-CURRENCY). baseCurrency
+  // + locale are the operator-facing money-format source; countryCode is the ISO
+  // alpha-2 the two are derived from at onboarding (see lib/org-locale). Default
+  // is the neutral USD/en-US, NOT a hardcoded foreign GBP/Europe-London.
+  baseCurrency       String    @default("USD")
+  locale             String    @default("en-US")
+  countryCode        String?
   autoFetchRates     Boolean   @default(true)
   lastRateFetchAt    DateTime?
   // Archetype finance profile actually applied during setup. Lets surfaces
@@ -13543,7 +13549,7 @@ model LedgerAccount {
   parentId       String? // hierarchical roll-up within the chart
   isActive       Boolean  @default(true)
   isControl      Boolean  @default(false) // control/reconciliation account (AR, AP, bank)
-  currency       String   @default("GBP")
+  currency       String   @default("USD")
   description    String?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
@@ -13570,7 +13576,7 @@ model JournalEntry {
   source         String    @default("manual")
   sourceType     String? // originating sub-ledger model, e.g. "Invoice"
   sourceId       String? // originating document id
-  currency       String    @default("GBP")
+  currency       String    @default("USD")
   postedAt       DateTime?
   postedById     String?
   reversalOfId   String?   @unique // set when this entry reverses another
@@ -13600,7 +13606,7 @@ model JournalLine {
   // Decimal. The posting service enforces sum(debit) == sum(credit) per entry.
   debit             Decimal  @default(0)
   credit            Decimal  @default(0)
-  currency          String   @default("GBP")
+  currency          String   @default("USD")
   description       String?
   // Optional analytical dimensions (ACDOCA-style rich line): who the posting relates to.
   customerAccountId String?

--- a/packages/db/scripts/schema-regression-guard.mjs
+++ b/packages/db/scripts/schema-regression-guard.mjs
@@ -140,6 +140,24 @@ function isOptionalityWidening(baseLine, headLine) {
   return base.suffix === head.suffix;
 }
 
+// A change to a column's `@default(...)` value is NOT a regression: it only
+// affects new inserts, never existing rows, and the field/type/other attributes
+// are unchanged. Tolerate it the same way optionality-widening is tolerated, so
+// a legitimate default change (e.g. GBP -> USD to retire a locale bias) isn't
+// misread as a field removal. Same field name + type, and the suffixes are
+// identical once each side's `@default(...)` argument is normalized away.
+function normalizeDefaultArg(suffix) {
+  return suffix.replace(/@default\([^)]*\)/, "@default()").trim();
+}
+function isDefaultValueChange(baseLine, headLine) {
+  const base = parseModelFieldLine(baseLine);
+  const head = parseModelFieldLine(headLine);
+  if (!base || !head) return false;
+  if (base.name !== head.name || base.type !== head.type) return false;
+  if (!/@default\(/.test(base.suffix) || !/@default\(/.test(head.suffix)) return false;
+  return normalizeDefaultArg(base.suffix) === normalizeDefaultArg(head.suffix);
+}
+
 // Fields intentionally removed via a steward-reviewed migration (AGENTS.md §11).
 // Each entry is "Model.field". The guard skips these specific removals so an
 // approved schema-convergence migration can land, while still blocking every
@@ -187,6 +205,11 @@ export function diffSchemas(base, head, allowlist = INTENTIONAL_FIELD_REMOVALS) 
           isOptionalityWidening(line, headLine),
         );
         if (equivalentWidening) continue;
+        // A default-value-only change is not a removal (new-insert default only).
+        const defaultOnlyChange = [...headLines].some((headLine) =>
+          isDefaultValueChange(line, headLine),
+        );
+        if (defaultOnlyChange) continue;
         // Sanctioned, steward-reviewed removals are skipped; everything else
         // (accidental drops) still regresses.
         const parsed = parseModelFieldLine(line);

--- a/packages/db/scripts/schema-regression-guard.test.ts
+++ b/packages/db/scripts/schema-regression-guard.test.ts
@@ -100,6 +100,33 @@ describe("schema-regression-guard", () => {
     expect(regressions(before, BASE)).toEqual([]);
   });
 
+  it("tolerates a column default-value change (not a removal)", () => {
+    // Changing @default only affects new inserts, never existing rows —
+    // e.g. retiring a GBP-by-default bias to USD (EP-ORG-LOCALE-CURRENCY).
+    const withDefault = BASE.replace(
+      /name      String/,
+      'name      String   @default("GBP")',
+    );
+    const flipped = BASE.replace(
+      /name      String/,
+      'name      String   @default("USD")',
+    );
+    expect(regressions(withDefault, flipped)).toEqual([]);
+  });
+
+  it("still flags a field removal even when another field's default changed", () => {
+    const withDefault = BASE.replace(
+      /name      String/,
+      'name      String   @default("GBP")',
+    );
+    const flippedAndDropped = BASE
+      .replace(/name      String/, 'name      String   @default("USD")')
+      .replace(/  ownerId   String\?\n/, "");
+    const found = regressions(withDefault, flippedAndDropped);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatch(/ownerId/);
+  });
+
   it("passes when a required relation field is widened to optional", () => {
     const before = `
 model SupplierContract {


### PR DESCRIPTION
## What & why

**EP-ORG-LOCALE-CURRENCY / BI-0530BB74.** DPF was British-by-default: `currency`
defaulted to `GBP` across ~24 finance/commerce models, `StorefrontConfig.timezone`
to `Europe/London`, and money was formatted per-surface with hardcoded
`toLocaleString("en-GB")` — with **no org-level locale source**. A US operator saw
`£` / en-GB everywhere, including the operational twin they flagged.

This makes the org's currency + locale **derived from the operator's own country**,
never a hardcoded foreign default. It builds on the existing `OrgSettings` spine
rather than inventing a new one.

## Phase 1 (this PR)

- **Shared spine** `apps/web/lib/org-locale/org-locale.ts` (pure + one injected-client resolver, fully unit-tested):
  - `deriveLocaleCurrencyFromCountry(iso2)` — ISO country → `{currency, locale}` (curated common-country map; unknown → neutral `USD/en-US`).
  - `formatMoney(amount, currency, locale?)` — **one** Intl formatter, the currency's own locale by default (replaces per-file `en-GB`).
  - `resolveOrgLocale(db)` — reads `OrgSettings`, falls back to country-derivation then the neutral default; never throws.
- **`OrgSettings` is the source of truth**: adds `locale` (`@default("en-US")`) + `countryCode`; `baseCurrency` default flips `GBP → USD` (matching the existing app-create default).
- **Schema defaults**: the ~24 `@default("GBP")` currency columns → `USD`; `StorefrontConfig.timezone` `Europe/London → UTC`. Migration `20260718120000_org_locale_currency_spine` (defaults + backfill of the existing `OrgSettings` row). **Existing amounts are NOT re-denominated** — a default change never rewrites rows, and silently relabelling a persisted amount's currency would be wrong.
- **Operational twin** now reads `resolveOrgLocale` for currency + locale instead of inferring currency from a bill row, and formats via the shared `formatMoney`. This is what makes the twin's `£ → $` actually flip once the org's country is US.
- **Onboarding**: `applyOrgCountry()` syncs `OrgSettings.countryCode` + initializes currency/locale from the country the first time it is captured (never clobbers a later explicit operator choice); called from `updateOrganizationTaxProfile`.
- **Guard fix**: `schema-regression-guard.mjs` now tolerates a column *default-value* change (same field name+type, only `@default` differs) — a default flip only affects new inserts, so it is not a field removal. Previously every default change tripped a false "removed field".

## Deferred (tracked under the epic)

- Adopting the shared `formatMoney`/`resolveOrgLocale` across the ~40 remaining ad-hoc money surfaces (finance tables, invoices, bills, CRM, storefront) — mechanical, but needs per-surface functional verification on the running portal.
- Any existing-GBP-data re-denomination — an operator-visible decision, not a silent relabel.

## Verification

- `apps/web/lib/org-locale/org-locale.test.ts` — pure derivation / format / resolve.
- Updated `apps/web/lib/twin/living-business-snapshot.test.ts` — the twin renders the **org** currency (USD), not a legacy GBP bill row.
- `packages/db/scripts/schema-regression-guard.test.ts` — default-change tolerance + still-flags-real-removals.
- Data-impact manifest: `changes/org-locale-currency-spine.data-impact.json`.
- Plan: `docs/superpowers/plans/2026-07-18-org-locale-currency-spine.md`.

Design-Grounding-Decision: grounded — plan `docs/superpowers/plans/2026-07-18-org-locale-currency-spine.md`; implementation in `apps/web/lib/org-locale/`, `apps/web/lib/twin/`, `apps/web/lib/actions/`, `packages/db/prisma/schema.prisma`.
Docs-Impact-Decision: docs added — implementation plan under `docs/superpowers/plans/`.

> Note: local typecheck pre-gate was env-blocked (source-only worktree, no `node_modules`); CI typecheck / prod build / unit / data-impact / schema-regression gates run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
