### PR TITLE
fix(self-upgrade): harden readiness preflight — backups default, antigravity schema, capability_state_stale classifier

### DIFF
--- a/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
@@ -152,6 +152,23 @@ describe("classifyBuildFailure", () => {
     expect(c.failingTrace).toContain("mounts denied");
   });
 
+  it("classifies the capability_state_stale preflight abort instead of leaving it unknown (BI-B132DF1D)", () => {
+    // The real fleet symptom: promote.sh's capability preflight aborts in ~4s
+    // before any build, and the wrapper reported it as "unknown (unclassified)".
+    const log = [
+      "[build-failure-class] unknown (unclassified)",
+      "--- stderr (tail) ---",
+      "error: capability_state_stale",
+    ].join("\n");
+    const c = classifyBuildFailure({ log });
+    expect(c.class).toBe("capability-state-preflight-unavailable");
+    expect(c.class).not.toBe("unknown");
+    expect(c.summary).toContain("MISLABEL");
+    expect(c.summary).toContain("#3272");
+    expect(c.isMainDefectVsEnvironment).toBe("environment");
+    expect(c.failingTrace).toContain("capability_state_stale");
+  });
+
   it("keeps an unrelated mounts-denied path out of the state-dir advice", () => {
     const log = "Error response from daemon: mounts denied: The path /some/other/vol is not shared from the host.";
     const c = classifyBuildFailure({ log });

--- a/apps/web/lib/self-upgrade/build-failure-classifier.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.ts
@@ -85,6 +85,14 @@ export type BuildFailureClass =
   // Desktop won't share it — the run dies silently at step=migrate. Fixed by
   // pinning DPF_STATE_DIR to an absolute shared host path in the install .env.
   | "docker-mount-denied"
+  // promote.sh's capability preflight aborted with `error: capability_state_stale`
+  // — a MISLABEL: it means /dpf-state/install-state.json (or the compose-profile
+  // adapter) was not available inside the promoter, not that capability state is
+  // stale. Root cause is a promoter launcher predating the /dpf-state self-upgrade
+  // mount (#3272) running a promote.sh that requires it (#3266); an install
+  // deployed in that window can't self-heal (BI-B132DF1D). Version-skew, not a
+  // defect in this run's code.
+  | "capability-state-preflight-unavailable"
   | "unknown";
 
 export type BuildFailureClassification = {
@@ -153,6 +161,12 @@ const MOUNTS_DENIED_PLAYBOOK = "docs/runbooks/2026-07-18-self-upgrade-mounts-den
 // unshareable /root/.dpf (#3262). Deliberately specific so an ordinary bad
 // bind-mount stays unclassified rather than being swept into the state-dir fix.
 const MOUNTS_DENIED = /mounts denied:[\s\S]{0,120}?path\s+(\S+)\s+is not shared from the host/i;
+// promote.sh's capability preflight aborts with exactly this line when the
+// governed install snapshot or the compose-profile adapter is not resolvable in
+// the promoter (a missing /dpf-state mount, not a genuinely stale state). Anchor
+// on the emitted string; the wrapper "unknown (unclassified)" was the live
+// symptom this rule replaces (BI-B132DF1D).
+const CAPABILITY_STATE_STALE = /^error: capability_state_stale$/im;
 // `CREATE EXTENSION vector` on a Postgres image without pgvector: the canonical
 // Postgres errors are `extension "vector" is not available` and a `DETAIL: Could
 // not open extension control file ".../vector.control"`. Deliberately anchored on
@@ -218,6 +232,21 @@ export function classifyBuildFailure(
         : `Docker Desktop refused to share the host path ${deniedPath} into a self-upgrade container. Point the mount at an absolute path Docker Desktop shares (Docker → Settings → Resources → File Sharing) — or provision the DPF_STATE_DIR / DPF_*_HOST_PATH env var the mount relies on in the install .env.`,
       playbookLink: MOUNTS_DENIED_PLAYBOOK,
       failingTrace: traceAround(log, MOUNTS_DENIED),
+      isMainDefectVsEnvironment: "environment",
+    };
+  }
+
+  // promote.sh's capability preflight aborted before any build (`error:
+  // capability_state_stale`). Decisive and precedes the build output, like the
+  // mount-denied case — classify it here so it stops surfacing as
+  // "unknown (unclassified)" pointing at the wrong playbook (BI-B132DF1D).
+  if (CAPABILITY_STATE_STALE.test(log)) {
+    return {
+      class: "capability-state-preflight-unavailable",
+      summary:
+        "promote.sh's capability preflight aborted with `error: capability_state_stale` — a MISLABEL: it means the governed install snapshot (/dpf-state/install-state.json) or the compose-profile adapter was not available inside the promoter, not that capability state is genuinely stale. Root cause is a promoter launcher predating the /dpf-state self-upgrade mount (#3272) running a promote.sh that already requires it (#3266): an install deployed in that window cannot self-heal and must be bootstrapped out-of-band onto a portal >= #3272 (BI-B132DF1D). Version-skew / environment, not a defect in this run's code.",
+      playbookLink: SPEC,
+      failingTrace: traceAround(log, CAPABILITY_STATE_STALE),
       isMainDefectVsEnvironment: "environment",
     };
   }

--- a/apps/web/lib/self-upgrade/preflight.test.ts
+++ b/apps/web/lib/self-upgrade/preflight.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolveReadinessBackupHostPath } from "./preflight";
+
+describe("resolveReadinessBackupHostPath (BI-E2625B79)", () => {
+  it("uses an explicit DPF_BACKUPS_HOST_PATH when set", () => {
+    expect(resolveReadinessBackupHostPath("/vol/backups", "/opt/dpf")).toBe("/vol/backups");
+  });
+
+  it("falls back to <install>/backups when the env var is EMPTY (the documented compose default)", () => {
+    // .env ships DPF_BACKUPS_HOST_PATH= empty by design; a plain `?? undefined`
+    // leaks "" through and skips the /backups mount -> recovery_parent_unavailable.
+    expect(resolveReadinessBackupHostPath("", "/opt/dpf")).toBe("/opt/dpf/backups");
+  });
+
+  it("falls back to <install>/backups when the env var is unset", () => {
+    expect(resolveReadinessBackupHostPath(undefined, "/opt/dpf")).toBe("/opt/dpf/backups");
+  });
+
+  it("treats whitespace-only as unset and strips a trailing slash from the install path", () => {
+    expect(resolveReadinessBackupHostPath("   ", "/opt/dpf/")).toBe("/opt/dpf/backups");
+  });
+});

--- a/apps/web/lib/self-upgrade/preflight.ts
+++ b/apps/web/lib/self-upgrade/preflight.ts
@@ -13,6 +13,24 @@ export type CandidatePreflightResult =
   | { ok: true; resolvedPromoterDigest?: string }
   | { ok: false; reason: "promoter-readiness-failed" };
 
+/**
+ * Resolve the host path bound to /backups in the readiness container, mirroring
+ * the compose-level default `${DPF_BACKUPS_HOST_PATH:-${DPF_HOST_INSTALL_PATH}/backups}`.
+ * DPF_BACKUPS_HOST_PATH ships EMPTY by design (compose fills the default), so an
+ * empty/whitespace value must be treated as unset — a plain `?? undefined` only
+ * catches undefined and leaks "" through, which skips the /backups mount and makes
+ * the readiness preflight fail `recovery_parent_unavailable`. BI-E2625B79.
+ */
+export function resolveReadinessBackupHostPath(
+  backupsHostPathEnv: string | undefined,
+  canonicalInstallPath: string,
+): string | undefined {
+  const explicit = backupsHostPathEnv?.trim();
+  if (explicit) return explicit;
+  const root = canonicalInstallPath.replace(/\/$/, "");
+  return root ? `${root}/backups` : undefined;
+}
+
 export async function runCandidatePreflight(params: {
   dryRun?: boolean;
   readinessMode?: string;
@@ -58,7 +76,7 @@ export async function runCandidatePreflight(params: {
       hostInstallPath: params.hostInstallPath,
       targetSha: params.targetSha,
       backupPath: process.env.PROMOTE_BACKUP_PATH ?? `/backups/self-upgrade/${params.runId}`,
-      backupHostPath: process.env.DPF_BACKUPS_HOST_PATH ?? undefined,
+      backupHostPath: resolveReadinessBackupHostPath(process.env.DPF_BACKUPS_HOST_PATH, params.canonicalInstallPath),
       composeEnvFileHostPath: params.canonicalInstallPath
         ? `${params.canonicalInstallPath.replace(/\/$/, "")}/.env`
         : undefined,

--- a/scripts/installer/install-state.schema.json
+++ b/scripts/installer/install-state.schema.json
@@ -163,6 +163,7 @@
         "claudeCodeWired": { "type": "boolean" },
         "codexWired": { "type": "boolean" },
         "grokWired": { "type": "boolean" },
+        "antigravityWired": { "type": "boolean" },
         "memorySeededAt": { "type": ["string", "null"], "format": "date-time" },
         "mcpReadiness": {
           "oneOf": [

--- a/scripts/installer/validate-install-state.test.mjs
+++ b/scripts/installer/validate-install-state.test.mjs
@@ -22,6 +22,26 @@ test("validates the canonical install-state schema", async () => {
   assert.deepEqual(await validateInstallState(valid), { valid: true, errors: [] });
 });
 
+test("allows agentToolchain.antigravityWired (5th CLI) — BI-F7823007 schema drift", async () => {
+  const withAntigravity = {
+    ...valid,
+    agentToolchain: {
+      appliedAt: "2026-07-18T00:00:00Z",
+      dpfPlatformVersion: "0.2.2",
+      superpowersVersion: null,
+      claudeCodeWired: true,
+      codexWired: true,
+      grokWired: true,
+      antigravityWired: true,
+      memorySeededAt: "2026-07-18T00:00:00Z",
+      mcpReadiness: { ok: true, toolCount: 222, observedAt: "2026-07-18T00:00:00Z" },
+      smokeTest: { result: "skipped", reason: "no_token" },
+      readinessState: "ready",
+    },
+  };
+  assert.deepEqual(await validateInstallState(withAntigravity), { valid: true, errors: [] });
+});
+
 test("enforces nested, format, uniqueness, and additional-property constraints", async () => {
   const result = await validateInstallState({
     ...valid,


### PR DESCRIPTION
## Why
Surfaced recovering a live install stuck at the **enforced promoter-readiness gate**. Three independent, low-risk robustness fixes; each removes a real self-upgrade blocker or misdiagnosis.

## What

**1. Readiness preflight ignored the compose backups default → `recovery_parent_unavailable` (BI-E2625B79)**
`.env` ships `DPF_BACKUPS_HOST_PATH=` empty by design (compose fills `${DPF_BACKUPS_HOST_PATH:-${DPF_HOST_INSTALL_PATH}/backups}`). `preflight.ts` used `process.env.DPF_BACKUPS_HOST_PATH ?? undefined` — `??` doesn't catch empty string, so `""` leaked through, the `/backups` mount was skipped, and the readiness container failed `recovery_parent_unavailable`. Now defaults to `<install>/backups`, treating empty/whitespace as unset. Hits any install left at the default (fleet-wide).

**2. `agentToolchain.antigravityWired` rejected by the schema → contributes to `install_state_invalid` (BI-F7823007)**
The toolchain writer emits `antigravityWired` (the 5th CLI) but `install-state.schema.json` had `additionalProperties: false` without it, so `validate-install-state.mjs` rejected any real state. Added it as an optional boolean (mirrors `claudeCodeWired`/`codexWired`/`grokWired`). Verified against a live install-state: the `antigravityWired` error is gone.

**3. `capability_state_stale` surfaced as "unknown (unclassified)" (BI-B132DF1D, diagnostics half)**
Added a `build-failure-classifier` rule so the promote.sh capability-preflight abort is classified with an accurate summary + correct remediation instead of the misleading generic playbook.

## Tests
- `validate-install-state.test.mjs`: `antigravityWired` now validates (ran locally, green).
- `build-failure-classifier.test.ts`: `capability_state_stale` classifies (not `unknown`).
- `preflight.test.ts` (new): `resolveReadinessBackupHostPath` — explicit / empty / unset / whitespace.
(TS tests validated by CI — the worktree has no node_modules.)

## Scope / out of scope
Deliberately does **not** include the install-state capability-field **backfill migration** (`enabledRuntimeCapabilities`/`capabilityCatalogHash`/`capabilityStateVersion`) or the promote.sh **tolerant-preflight** change. Those overlap an in-flight `install-state-readiness-migration` design and are tracked on BI-B132DF1D. **Heads-up to that author:** this touches `preflight.ts`, `install-state.schema.json`, and `build-failure-classifier.ts` — reconcile if in flight.

Refs BI-E2625B79, BI-F7823007, BI-B132DF1D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)