### PR TITLE
fix(self-upgrade): stop promoter DPF_STATE_DIR=/dpf-state leaking into portal-recreate compose (BI-25FEB6BA)

### DIFF
--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -120,6 +120,20 @@ if [[ $_dry_run -eq 0 ]]; then
   trap '_rc=$?; if [[ $_rc -ne 0 ]]; then _restore_capability_snapshot; fi' EXIT
 fi
 
+# The promoter runs with DPF_STATE_DIR=/dpf-state so the steps above can read the
+# install snapshot from its own mount. That value must NOT leak into the compose
+# recreates below: the portal service binds `${DPF_STATE_DIR:-${HOME}/.dpf}:/dpf-state`,
+# and Docker Compose lets the shell env override --env-file, so /dpf-state would be
+# used as the HOST source — which Docker Desktop cannot share (mounts denied at
+# step=migrate; BI-25FEB6BA, a #3272 regression). Re-point DPF_STATE_DIR to the
+# install's host state dir (from the compose env file) for every compose call below.
+# Do NOT `unset` it — an unset DPF_STATE_DIR falls back to ${HOME}/.dpf = /root/.dpf
+# under the root-run promoter, reintroducing the original mounts-denied bug (#3262).
+if [[ -n "${PROMOTE_COMPOSE_ENV_FILE:-}" && -f "$PROMOTE_COMPOSE_ENV_FILE" ]]; then
+  _host_state_dir="$(sed -n 's/^DPF_STATE_DIR=//p' "$PROMOTE_COMPOSE_ENV_FILE" | tail -1)"
+  if [[ -n "$_host_state_dir" ]]; then export DPF_STATE_DIR="$_host_state_dir"; fi
+fi
+
 # Compose chain used to rebuild/recreate the portal. The orchestrator passes
 # PROMOTE_COMPOSE_FILES (space-separated, relative to PROMOTE_SOURCE) carrying
 # the platform-correct chain the install was created with — base + the host


### PR DESCRIPTION
## Why
A #3272 regression: every Docker-Desktop install (macOS/Windows) on #3272+ fails its self-upgrade at `step=migrate` with `mounts denied: The path /dpf-state is not shared from the host`.

## Mechanism
#3272 launches the promoter with `-e DPF_STATE_DIR=/dpf-state` so promote.sh reads the install snapshot from its own mount. But promote.sh recreates postgres/portal-init/portal via `docker compose --env-file <install .env>`, and **Compose lets the shell env override `--env-file`**. So the promoter's `DPF_STATE_DIR=/dpf-state` beats the install's `.env` value, and the portal bind `${DPF_STATE_DIR:-${HOME}/.dpf}:/dpf-state` resolves the **host** side to the container path `/dpf-state` — which Docker Desktop can't share.

## Fix
After the promoter's own `/dpf-state` reads and before the compose recreates, re-point `DPF_STATE_DIR` to the install's host state dir (read from the compose env file). **Not `unset`** — an unset value falls back to `${HOME}/.dpf = /root/.dpf` under the root-run promoter, reintroducing the original #3262 mounts-denied bug.

## Regression proof
Pre-#3272 the promoter didn't set `DPF_STATE_DIR` for a plain `--self-upgrade`, so compose used the `.env` value and worked (`SUR-CFC9A832` succeeded on d151684). Post-#3272 a forced run cleared readiness then died at `step=migrate` (`SUR-BVER2-c1061`). Verified the fix on a live macOS install (portal rebuilt with the baked fix, forced self-upgrade re-run).

Refs BI-25FEB6BA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)