### PR TITLE
fix(install-state): allow agentToolchain.antigravityWired in the v1 schema (unblocks #3282 migration for legacy installs)

### DIFF
--- a/scripts/installer/install-state.v1.schema.json
+++ b/scripts/installer/install-state.v1.schema.json
@@ -40,6 +40,7 @@
         "claudeCodeWired": { "type": "boolean" },
         "codexWired": { "type": "boolean" },
         "grokWired": { "type": "boolean" },
+        "antigravityWired": { "type": "boolean" },
         "memorySeededAt": { "type": ["string", "null"], "format": "date-time" },
         "mcpReadiness": {
           "oneOf": [

--- a/scripts/installer/validate-install-state.test.mjs
+++ b/scripts/installer/validate-install-state.test.mjs
@@ -142,6 +142,24 @@ test("allows agentToolchain.antigravityWired (5th CLI) — BI-F7823007 schema dr
   assert.deepEqual(await validateInstallState(withAntigravity), { valid: true, errors: [] });
 });
 
+test("allows agentToolchain.antigravityWired on a legacy v1 state (the toolchain writes it; v1 must migrate cleanly)", async () => {
+  // #3282's v1 schema dropped antigravityWired that #3280 added, but the live
+  // toolchain (dpf-bootstrap-agent-toolchain.sh) still writes it — so real v1
+  // states carry it and must validate, or the governed migration throws on them.
+  const v1WithAntigravity = {
+    schemaVersion: 1,
+    installerVersion: "2026.07.17",
+    platform: "linux",
+    arch: "amd64",
+    composeProjectName: "dpf",
+    composeFiles: ["docker-compose.yml"],
+    resourceLabels: { dpf: "true" },
+    autostart: { enabled: true, kind: "systemd-user" },
+    agentToolchain: { ...legacyAgentToolchain, antigravityWired: true },
+  };
+  assert.deepEqual(await validateInstallState(v1WithAntigravity), { valid: true, errors: [] });
+});
+
 test("enforces nested, format, uniqueness, and additional-property constraints", async () => {
   const result = await validateInstallState({
     ...valid,


### PR DESCRIPTION
## Why
Evaluating the latest build (#3282, `migrate legacy install state through governed promotion`) against a live legacy install surfaced a **blocking regression**: #3282's governed migration throws on any `schemaVersion:1` state that carries `agentToolchain.antigravityWired`.

## Mechanism
- #3282 split `install-state.schema.json` into versioned `v1`/`v2` files. The **v1** schema was cut from the pre-#3280 flat schema and **omits `antigravityWired`** (v2 has it).
- The live toolchain (`dpf-bootstrap-agent-toolchain.sh:779`) **still writes `antigravityWired`** into `agentToolchain` regardless of schemaVersion, so real legacy v1 states carry it.
- `migrate-install-state.mjs` **strictly validates the v1 source** (`parseAndValidateInstallStateBytes` → throw) before migrating. So the field trips `$.agentToolchain.antigravityWired: additionalProperties`, the migration throws, and the self-upgrade dies at readiness.

The existing `antigravityWired` test only exercised a **v2** base state, so the gap merged unnoticed.

## Fix
- Add `antigravityWired` as an optional boolean to `install-state.v1.schema.json` (mirrors v2).
- Add a **v1** regression test (the field on a legacy v1 state validates).

## Verified
Against a live macOS install's real v1 state: `install-state invalid: $.agentToolchain.antigravityWired: additionalProperties` **before**, `install-state valid` **after**. Both antigravityWired tests green.

Refs #3282, #3280, BI-F7823007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)