### PR TITLE
docs: capture DPF market vision and ecosystem positioning

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Domain-specific operating guides (admin, AI workforce, build studio, compliance,
 
 ## Market proof
 
+- [DPF Market Vision](marketing/dpf-market-vision.md) — public positioning for DPF as an AI-operated company platform: market, competitors, adapter-to-native strategy, and priority roadmap.
 - [Persona Library](personas/README.md) — evidence-backed archetype stories that double as marketing substrate and re-runnable dogfood scenarios.
 - [Dale HVAC](personas/dale-hvac.md), [Linda Clinic](personas/linda-clinic.md), and [Marisol Retail](personas/marisol-retail.md) are the current proof set for vertical workspace homes.
 
@@ -37,6 +38,7 @@ Domain-specific operating guides (admin, AI workforce, build studio, compliance,
 
 - [Repo README](../README.md) is the source-facing project overview and install posture.
 - [index.html](index.html) is the public pre-install website and marketing tour.
+- [marketing/dpf-market-vision.md](marketing/dpf-market-vision.md) is the product-positioning and competitor-framing narrative for the company operating platform vision.
 - [user-guide/market-archetypes.md](user-guide/market-archetypes.md) is the canonical archetype/coworker narrative for user-facing docs.
 - [user-guide/](user-guide/) is operational product help and contextual in-app documentation.
 - [architecture/](architecture/) is current architecture, standards, and conformance context.

--- a/docs/architecture/archetype-owner-positioning.md
+++ b/docs/architecture/archetype-owner-positioning.md
@@ -12,6 +12,12 @@ The promise is not "AI for small business" in the abstract. The promise is:
 
 > Keep doing the work customers pay you for. Give the work around the work to governed AI coworkers.
 
+The broader market thesis is now:
+
+> Integrate at the edge. Simplify in the core. Generalize for the ecosystem.
+
+DPF should meet owners where they are: QuickBooks for accounting, Stripe or Square for payments, Gusto or ADP for payroll, HubSpot or Salesforce for CRM, Zendesk or Jira Service Management for tickets, Slack or Microsoft 365 for communication, Shopify or POS systems for commerce, and vertical tools where regulation or specialization demands them. Those systems are bridges and benchmarks, not the final architecture. When a workflow is broadly useful across companies, DPF should absorb it into native company primitives so the next owner does not inherit the same brittle software stack.
+
 The "work around the work" is the necessary-evil layer that steals owner time:
 
 - capturing enough information to quote, book, dispatch, or qualify the work
@@ -37,6 +43,7 @@ DPF should separate what can be marketed as available today from what belongs in
 | Owner cockpit | Workspace/twin surfaces can frame work by archetype and expose current portal/customer/finance/workflow state. | The daily board becomes the owner's command center for exceptions, capacity, next best actions, and work that needs judgment. | Do not imply every vertical cockpit is finished until workspace/twin routes are acceptance-tested. |
 | Marketing | Archetype-aware offers, proof prompts, campaign ideas, and strategy inputs are defined as the customer marketing workspace direction. | Marketing coworker becomes the owner's research/draft/sequence assistant for local campaigns, proof assets, funnel review, and periodic strategy refresh. | Do not imply channel integrations, attribution, or automatic posting are complete unless verified. |
 | Operations | Shared mechanics cover intake, scheduling, inbox, customer records, finance drafts, workbooks, and selected vertical modules. | Field dispatch, rental capacity, project milestones, membership, donations, account relationships, and regulated handoffs become first-class vertical loops. | Do not imply DPF replaces core EHR, core banking, ticketing seat maps, payment rails, payroll, or full accounting systems. |
+| Ecosystem absorption | DPF has native routes and adapters across finance, HR, CRM, customer, knowledge, inventory, integrations, and work tracking; connector scorecards benchmark the surrounding SaaS ecosystem. | Adapters become migration bridges and learning surfaces. Shared primitives for Party, Work, Money, Asset, Knowledge, and Authority absorb repeatable workflows into a coherent operating platform. | Do not sell every vendor integration as native, or native aspiration as delivered parity. State the bridge-vs-native boundary clearly. |
 
 ## 3. Owner Promise Diagram
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Open Digital Product Factory — Documentation Overview</title>
-<meta name="description" content="A pre-install tour of the Open Digital Product Factory: what it does, how it is governed, and where to read the user guide, architecture, and specifications." />
+<meta name="description" content="A pre-install tour of the Open Digital Product Factory: the open AI-operated company platform, what it does, how it is governed, and where to read the user guide, architecture, and specifications." />
 <style>
   :root {
     --bg: #0b0d10;
@@ -389,7 +389,7 @@
     <img class="hero-logo" src="assets/logos/OpenDigitalProductFactory.png" alt="Open Digital Product Factory" width="934" height="688" />
     <h1>Open Digital Product Factory</h1>
     <p class="lede">
-      An open platform that runs your business your way. A small team gets a public website, a back office, and AI coworkers that already speak your trade &mdash; HVAC jobs, clinic visits, retail orders, member gifts, HOA requests. Every important action stays under your control, on your own computers.
+      An open AI-operated company platform that helps small teams run the business, not the software stack. You get a public website, a back office, and AI coworkers that already speak your trade &mdash; HVAC jobs, clinic visits, retail orders, member gifts, HOA requests. Edge integrations meet the tools you already use; the common workflows become simpler native capability over time. Every important action stays under your control, on your own computers.
     </p>
     <div class="cta-row">
       <a class="btn primary" href="#audience">Is it for me?</a>
@@ -413,6 +413,10 @@
         <span>Pick what you do &mdash; the storefront, coworker vocabulary, daily boards, scheduling, and finance defaults all reshape to match. No blank-canvas setup.</span>
       </div>
       <div class="hero-highlight">
+        <strong>Integrates at the edge, simplifies in the core</strong>
+        <span>QuickBooks, Stripe, HubSpot, ADP, Microsoft 365 and similar tools can be bridges, while DPF keeps the company primitives coherent.</span>
+      </div>
+      <div class="hero-highlight">
         <strong>Autonomy with inspectable judgment</strong>
         <span>WWMD asks the founder-kernel wiki how to resolve ambiguity, then returns a confidence-scored rationale and audit trail.</span>
       </div>
@@ -424,6 +428,7 @@
   <div class="toc-inner">
     <span class="toc-label">Jump to</span>
     <a href="#audience">Who it&rsquo;s for</a>
+    <a href="#market-vision">Market vision</a>
     <a href="#find-your-business">Find your business</a>
     <a href="#mobile">Mobile vision</a>
     <a href="#install">Install</a>
@@ -507,12 +512,12 @@
         <p><strong style="color:var(--accent-2);">Projects &amp; rentals.</strong> Equipment &amp; storage rental, home building, professional services, software. Value delivered over time under a scope or agreement.</p>
       </a>
       <a class="card" style="display:block; border-style:dashed;" href="/business-types/">
-        <h3>See all 19 &rarr;</h3>
+        <h3>See all 21 &rarr;</h3>
         <p>Every business type gets its own page &mdash; the value we deliver, the problems we solve, a business-model diagram, and the capabilities. <strong>Explore the full catalogue.</strong></p>
       </a>
     </div>
     <div class="note" style="margin-top:14px;">
-      Fifteen market categories and 56 ready business types ship in the box. Don&rsquo;t see an exact match? They&rsquo;re starting points &mdash; setup adapts further to your specifics, and your coworkers keep tailoring as you go.
+      Twenty-one market categories and 95 ready archetypes ship in the box. Don&rsquo;t see an exact match? They&rsquo;re starting points &mdash; setup adapts further to your specifics, and your coworkers keep tailoring as you go.
     </div>
   </section>
 
@@ -662,6 +667,38 @@ bash install-dpf.sh</code></pre>
     </div>
   </section>
 
+  <section id="market-vision">
+    <h2>Run the company, not the software stack</h2>
+    <p class="sub">
+      Most small and mid-sized companies are forced to stitch together accounting, payroll, CRM, support, identity, payments, work management, documents, and vertical tools. The owner or employee becomes the integration layer. DPF&rsquo;s market thesis is different: connect at the edge where a company already depends on outside systems, then absorb the repeatable company-running workflows into one governed native core.
+    </p>
+    <div class="pillars">
+      <div class="pillar">
+        <div class="tag">Market</div>
+        <strong>AI changes the operating model.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">The opportunity is not another app with an AI chat box. It is a company platform where AI coworkers handle the work around the work: context gathering, routing, drafting, reconciliation, evidence, follow-up, and decision preparation.</p>
+      </div>
+      <div class="pillar">
+        <div class="tag">Competitors</div>
+        <strong>The ecosystem becomes the benchmark.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Workday, QuickBooks, WorkOS, Stripe, Plaid, HubSpot, Zendesk, Slack, Asana, Gusto, ADP, Shopify, Xero and others show the capability map. DPF should bridge them first, then native-build the common workflows when doing so removes complexity for many installs.</p>
+      </div>
+      <div class="pillar">
+        <div class="tag">Architecture</div>
+        <strong>Shared company primitives beat brittle integrations.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">DPF organizes around Party, Work, Money, Asset, Knowledge, and Authority primitives. Adapters feed those primitives; AI operates over them; humans approve high-impact actions; receipts remain inspectable.</p>
+      </div>
+      <div class="pillar">
+        <div class="tag">Ecosystem</div>
+        <strong>Missing functionality should compound.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">When one install needs a missing workflow, the goal is to build it, generalize it, merge it, and let the next company benefit &mdash; not leave it as a private one-off integration.</p>
+      </div>
+    </div>
+    <p class="note" style="margin-top:14px;">
+      Strategy detail: <a href="/marketing/dpf-market-vision">DPF Market Vision</a> explains the market, competitor map, adapter-to-native strategy, roadmap priorities, and current-state guardrails.
+    </p>
+  </section>
+
   <section id="what-it-does">
     <h2>What you can do with it</h2>
     <p class="sub">A condensed view of the capability surface. Each capability has its own section in the user guide. Capabilities are aligned to the IT4IT v3.0.1 value streams (Evaluate, Explore, Integrate, Deploy, Release, Operate) so governance and lifecycle stay in lock-step with how the rest of your IT estate is modelled.</p>
@@ -712,7 +749,7 @@ bash install-dpf.sh</code></pre>
       <div class="pillar">
         <div class="tag">Archetypes</div>
         <strong>Pick a market archetype &mdash; the platform reshapes itself.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Fifteen market categories and 56 leaf archetype templates ship with the platform &mdash; spanning small-business services through banking and credit unions, civic bodies (municipalities, utilities, law enforcement), and rental/shared-asset operators, plus a B2B wholesale-distribution archetype that derives a partner/reseller program from its operating-model axes. Choosing one bootstraps the customer portal, vocabulary, booking and form rules, finance assumptions, marketing posture, and internal worker-home direction. The archetype is the single source of truth for industry; downstream surfaces read from it rather than from a separately editable string.</p>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Twenty-one market categories and 95 leaf archetype templates ship with the platform &mdash; spanning small-business services through banking and credit unions, civic bodies (municipalities, utilities, law enforcement), rental/shared-asset operators, media, live events, field dispatch, and more. Choosing one bootstraps the customer portal, vocabulary, booking and form rules, finance assumptions, marketing posture, and internal worker-home direction. The archetype is the single source of truth for industry; downstream surfaces read from it rather than from a separately editable string.</p>
       </div>
       <div class="pillar">
         <div class="tag">Common Skills</div>
@@ -730,7 +767,7 @@ bash install-dpf.sh</code></pre>
   <section id="archetypes">
     <h2>The full business catalogue</h2>
     <p class="sub">
-      Fifteen market categories and 56 ready business types ship in the box. Each card opens a dedicated page with that business&rsquo;s model, a value-stream diagram, the problems we solve, and the capabilities we provide. Pick what you do and the platform reshapes itself &mdash; storefront, vocabulary, scheduling, finance, and compliance defaults all follow. <a href="/business-types/">Browse the grouped catalogue &rarr;</a>
+      Twenty-one market categories and 95 ready archetypes ship in the box. Each card opens a dedicated page with that business&rsquo;s model, a value-stream diagram, the problems we solve, and the capabilities we provide. Pick what you do and the platform reshapes itself &mdash; storefront, vocabulary, scheduling, finance, and compliance defaults all follow. <a href="/business-types/">Browse the grouped catalogue &rarr;</a>
     </p>
     <p class="sub" style="font-size:13px; margin-top:-8px;">
       <em>For builders &amp; resellers:</em> internally each is a market <strong>archetype</strong> &mdash; the bootstrap mechanism and single source of truth for industry that every downstream surface reads from. It also drives internal <strong>workspace homes</strong> (dispatch boards for trades, appointment-readiness for clinics, merchandising for retail). <strong>Detailed guide:</strong> <a href="/user-guide/market-archetypes">market-archetypes</a>.
@@ -1402,8 +1439,8 @@ bash install-dpf.sh</code></pre>
       </div>
       <div class="pillar">
         <div class="tag">Customer-brought integrations</div>
-        <strong>The platform is a conduit, not a broker.</strong>
-        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Enterprise integrations (ADP, HRIS, ERP, banking) use your accounts, your credentials, and your vendor agreements. The platform connects to them on your behalf; it never enrolls itself as a partner of those vendors.</p>
+        <strong>The platform is a conduit first, then an absorber.</strong>
+        <p style="color:var(--fg-muted); margin:6px 0 0; font-size:14px;">Enterprise integrations (ADP, HRIS, ERP, banking) use your accounts, your credentials, and your vendor agreements. The platform connects on your behalf, learns from the workflow, and only promotes broadly useful capability into native DPF once mapping, reconciliation, authority, rollback, and evidence are proven.</p>
       </div>
       <div class="pillar">
         <div class="tag">Obfuscated, not anonymous</div>
@@ -1612,7 +1649,7 @@ bash install-dpf.sh</code></pre>
           <td>Default-deny grants, route-scoped agent identity, immutable directive injection, audit log all live.</td>
         </tr>
         <tr>
-          <td>Archetypes (15 categories, 56 leaf templates)</td>
+          <td>Archetypes (21 categories, 95 leaf templates)</td>
           <td><strong>Production</strong></td>
           <td>Bootstrap on storefront setup; sections, vocabulary, finance profile, design system, marketing posture, and workspace-home direction seeded.</td>
         </tr>
@@ -1813,8 +1850,16 @@ bash install-dpf.sh</code></pre>
           <td>Fork-based contribution so installs without upstream write access can still contribute. Replaces the current upstream-write-token model now that the repo is public.</td>
         </tr>
         <tr>
+          <td><strong>Company operations parity map</strong></td>
+          <td>WorkOS, Workday, QuickBooks, and adjacent ecosystem analysis translated into product lanes for IAM, people/HCM, workforce, payroll, finance/accounting, QuickBooks coexistence, planning, spend/procurement, and talent. This is the market-backed roadmap for the company operating platform DPF wants to become.</td>
+        </tr>
+        <tr>
+          <td><strong>Ecosystem absorption architecture</strong></td>
+          <td>Adapter-to-native doctrine, external-entity crosswalks, graduation gates, event/action/receipt bus, and shared primitives for Party, Work, Money, Asset, Knowledge, and Authority. The goal is to turn useful outside-system workflows into a better engineered DPF whole instead of brittle one-off integrations.</td>
+        </tr>
+        <tr>
           <td><strong>Connector factory framework</strong></td>
-          <td>A repeatable factory for adding integrations (HRIS, ERP, banking, CRM) under the conduit-not-broker stance &mdash; customer brings their own account and credentials.</td>
+          <td>A repeatable factory for adding integrations (HRIS, ERP, banking, CRM) under the conduit-not-broker stance &mdash; customer brings their own account and credentials. Connectors are bridges and evidence sources; native promotion waits for mapping, reconciliation, authority, rollback/export, and compliance gates.</td>
         </tr>
         <tr>
           <td><strong>ADP / payroll MCP integration</strong></td>
@@ -1945,7 +1990,7 @@ bash install-dpf.sh</code></pre>
       </div>
       <div class="card">
         <h3>What does the install include?</h3>
-        <p>Portal, init container, Postgres, Neo4j, Qdrant, Inngest, Redis, the local model runner, and on-demand sandbox containers. Fifteen market categories, 56 leaf archetype templates, purposed coworkers, the skill registry, and a seeded role hierarchy come pre-loaded.</p>
+        <p>Portal, init container, Postgres, Neo4j, Qdrant, Inngest, Redis, the local model runner, and on-demand sandbox containers. Twenty-one market categories, 95 leaf archetype templates, purposed coworkers, the skill registry, and a seeded role hierarchy come pre-loaded.</p>
       </div>
       <div class="card">
         <h3>How do I uninstall?</h3>

--- a/docs/marketing/dpf-market-vision.md
+++ b/docs/marketing/dpf-market-vision.md
@@ -1,0 +1,130 @@
+# DPF Market Vision
+
+**Status:** Draft - 2026-07-19  
+**Scope:** Public positioning, competitor framing, and roadmap translation for the product DPF wants to create and sell.  
+**Related:** [Documentation overview](../index.html), [Archetype Owner Positioning](../architecture/archetype-owner-positioning.md), [Connector Benchmark Coverage Matrix](../superpowers/plans/2026-07-16-connector-benchmark-coverage-matrix.md), [Connector Family Benchmark Scorecards](../superpowers/plans/2026-07-16-connector-family-benchmark-scorecards.md)
+
+## 1. Thesis
+
+DPF is not trying to become another integration dashboard. It is an open, AI-operated company platform that starts with the work a business owner is trying to run, connects to the systems they already have, and gradually absorbs broadly useful functionality into a simpler native whole.
+
+The short form:
+
+> Integrate at the edge. Simplify in the core. Generalize for the ecosystem.
+
+External systems are useful bridges. They carry current accounting, payroll, payments, identity, CRM, support, collaboration, and compliance reality. But they should not define the long-term architecture. DPF should learn from those systems, normalize their records into company primitives, and build the common company-running workflows natively when doing so removes complexity for many installs.
+
+## 2. The Market Problem
+
+Small and mid-sized companies are asked to run like enterprises, but they do not have enterprise implementation teams. Their daily operating stack often sprawls across:
+
+- accounting, payroll, banking, payments, tax, and spend tools
+- CRM, marketing, quotes, orders, and customer support tools
+- HR, scheduling, time, benefits, and performance tools
+- identity, directory, access, device, and security tools
+- chat, email, project management, docs, tickets, and knowledge tools
+- vertical systems such as POS, ecommerce, field service, booking, EHR, core banking, ticketing, LMS, PSA, or RMM
+
+Each tool solves a slice. The owner or employee becomes the integration layer: copying context, reconciling facts, chasing approvals, explaining what changed, and deciding which system is true.
+
+AI changes the economics. The right product is not a pile of separate tools with an AI chat box on top. The right product is a governed operating layer where AI coworkers handle the complexity around the work, humans keep authority, and the platform keeps a coherent record.
+
+## 3. Product Positioning
+
+DPF should be positioned as:
+
+> The open company operating platform for small teams that want AI coworkers, real business workflows, and control over their own data.
+
+What that means in practice:
+
+- **Company-first, not app-first.** People, work, money, assets, knowledge, and authority are native primitives.
+- **Archetype-led.** The platform starts from the kind of business being run, then shapes vocabulary, intake, scheduling, finance, compliance, and daily work.
+- **AI-operated, human-authorized.** Coworkers draft, interpret, route, reconcile, and prepare decisions; humans approve consequential actions.
+- **Adapter-aware, not adapter-owned.** Workday, QuickBooks, WorkOS, Stripe, Plaid, HubSpot, Zendesk, Slack, Asana, ADP, Gusto, Xero, Shopify, and similar systems are bridges and benchmarks, not the architectural center.
+- **Open and compounding.** Missing functionality can be built once, reviewed, merged, and made available to the ecosystem instead of remaining a private workaround.
+
+## 4. Competitor And Ecosystem Map
+
+This map is not a claim that DPF matches every product today. It names where the market is clustered and what DPF should absorb, connect to, or leave provider-led.
+
+| Ecosystem | Examples | Market role | DPF posture |
+| --- | --- | --- | --- |
+| Enterprise HCM / finance suites | Workday, SAP, Oracle | System of record for enterprise people, payroll, finance, planning | Use as north-star benchmarks; absorb the simpler company-running workflows over time. |
+| SMB accounting and payroll | QuickBooks, Xero, Gusto, ADP | Book of record, payroll compliance, accountant workflow | Bridge deeply first; make finance ops native only after reconciliation, controls, and trust are proven. |
+| Identity and access | WorkOS, Okta, Entra, Google Workspace | SSO, directory, provisioning, audit, access policy | Build DPF-native authority; keep IdPs as edge identity/directory adapters. |
+| Payments, banking, spend | Stripe, Plaid, Square, BILL, Ramp, Brex | Money movement, bank data, cards, AP/payment rails | Keep payment and banking rails provider-led; absorb reconciliation, approval, evidence, and operating workflow. |
+| CRM, marketing, support | HubSpot, Salesforce, Zendesk, Freshdesk, Mailchimp | Customer record, pipeline, campaigns, support tickets | Absorb customer/work primitives; use adapters for migration, coexistence, and channel reach. |
+| Collaboration and work management | Microsoft 365, Google Workspace, Slack, Teams, Asana, Jira, ClickUp, Notion, Confluence | Messages, tasks, docs, knowledge, team coordination | DPF owns the work/knowledge spine; external tools sync or provide evidence. |
+| Commerce and vertical systems | Shopify, Square, POS, booking, field service, LMS, EHR, core banking, PSA/RMM | Industry-specific execution systems | Absorb common SMB workflows where safe; leave regulated or specialized systems provider-led until replacement evidence exists. |
+
+## 5. Absorb, Combine, Refactor
+
+The long-term product should be engineered around shared primitives, not vendor-shaped silos.
+
+| Primitive | Absorbs concepts from | Native DPF direction |
+| --- | --- | --- |
+| Party | customers, contacts, workers, suppliers, requesters, members, patients, donors | One governed model for who is involved, with role-specific vocabulary and permissions. |
+| Work | tasks, tickets, cases, approvals, projects, service requests, onboarding steps | One work spine with status, owner, evidence, SLA/priority, handoff, and AI coworker routing. |
+| Money | invoices, bills, expenses, payments, payouts, taxes, journal entries, payroll packets | One finance spine with ledger integrity, reconciliation, approval, close, and provider bridges. |
+| Asset | products, inventory, devices, software, fixed assets, rental assets, service equipment | One asset spine that supports commerce, operations, IT, finance, and compliance views. |
+| Knowledge | documents, policies, contracts, help articles, filings, receipts, source evidence | One knowledge/evidence layer with provenance, classification, review state, and reuse. |
+| Authority | identity, roles, approvals, consent, delegated access, audit logs | One authority plane for humans, AI coworkers, connectors, and external agents. |
+
+This is the main refactor direction: each absorbed ecosystem capability should strengthen one of these primitives instead of adding another isolated module.
+
+## 6. Prioritization
+
+Recommended sequencing:
+
+1. **Trustworthy finance plus QuickBooks/Xero/Stripe coexistence.** Invoices, bills, expenses, banking, reconciliation, close, reporting, accountant review, and book-of-record posture.
+2. **People and workforce core.** Worker, position, org, time, absence, scheduling, staffing, and manager/employee self-service.
+3. **Payroll bridge and compliance evidence.** Payroll packets, provider adapters, GL posting, payslips, and stop-rules before native payroll expansion.
+4. **Customer, revenue, and support work spine.** Leads, customers, opportunities, quotes, orders, tickets, cases, and campaigns mapped into DPF work.
+5. **Planning and analytics.** Budget, cash flow, workforce/finance scenarios, profitability, KPI dashboards, and AI explanations grounded in source records.
+6. **Commerce, inventory, procurement, assets, and vertical loops.** Absorb the repeatable SMB workflows; keep regulated or highly specialized systems behind adapters until the evidence bar is met.
+
+## 7. Current-State Guardrails
+
+Marketing should be ambitious but honest.
+
+- Do not say DPF replaces payroll tax filing, bank/payment rails, licensed clinical systems, legal advisors, core banking systems, public-safety systems, or mature enterprise suites today.
+- Do say DPF is building toward a unified company operating platform where those systems can be bridged, simplified, and sometimes displaced by native capability.
+- Do not sell integrations as the destination.
+- Do sell integrations as the bridge into a cleaner operating model.
+- Do not claim AI acts without control.
+- Do claim AI coworkers reduce employee complexity while humans retain authority and the platform keeps receipts.
+
+## 8. Message House
+
+**Headline:** Run the company, not the software stack.
+
+**Subhead:** DPF gives small teams a company operating platform with AI coworkers, business-specific workflows, and customer-brought integrations that can become native capability over time.
+
+**Proof points:**
+
+- 95 seeded archetypes across 21 categories shape the portal, vocabulary, coworker framing, finance defaults, and operating model.
+- Native finance, HR, CRM, customer, inventory, knowledge, work, authority, audit, and integration substrate already exists.
+- QuickBooks, Stripe, HubSpot, ADP, Microsoft 365, WhatsApp, Instagram, Google marketing, and related connectors are already represented in the connector benchmark and adapter work.
+- WorkOS, Workday, QuickBooks, and the wider SaaS ecosystem now map to explicit DPF epics and backlog lanes.
+- Build Studio and the Hive Mind turn missing functionality into shared product improvement instead of isolated custom work.
+
+**Strategic line:** DPF uses adapters to meet the company where it is, then absorbs the workflows that should belong to the whole ecosystem.
+
+## 9. Backlog Anchors
+
+The product strategy is tracked in the backlog, not only in prose:
+
+- `EP-COMPANY-OPS-PARITY` - Workday, QuickBooks, WorkOS, and company-operations parity map.
+- `EP-ECOSYSTEM-ABSORPTION-ARCH` - adapter bridges into native company primitives.
+- `EP-FINANCE-ACCOUNTING-CORE` - ledger, AR, AP, banking, reporting, and close.
+- `EP-QUICKBOOKS-ACCOUNTING-BRIDGE` - import, sync, reconciliation, and book-of-record coexistence.
+- `EP-PEOPLE-HCM-CORE` - worker, position, organization, and employee lifecycle.
+- `EP-WORKFORCE-OPS` - time, absence, scheduling, staffing, and labor optimization.
+- `EP-PAYROLL-COMP-BENEFITS` - controlled payroll readiness and provider bridge.
+- `EP-PLANNING-ANALYTICS` - budgets, forecasts, profitability, and workforce-finance insight.
+- `EP-SPEND-PROCUREMENT-ASSETS` - suppliers, purchasing, inventory, and fixed assets.
+- `EP-TALENT-SKILLS-PERFORMANCE` - recruiting, reviews, learning, and growth.
+
+## 10. Sources And Market Signals
+
+This positioning is grounded in the current vendor/ecosystem review completed on 2026-07-19 and the DPF connector scorecards already in this repository. Public vendor sources checked include Workday, QuickBooks, WorkOS, Rippling, Gusto, BILL, Stripe, Plaid, Salesforce, Zendesk, Slack, and Asana product/marketplace pages. Treat their specific feature sets as time-sensitive; refresh the source pass before using this document for investor, partner, or procurement material.


### PR DESCRIPTION
## Summary
- Adds a DPF Market Vision page covering market thesis, competitor/ecosystem map, adapter-to-native strategy, shared primitives, prioritization, and guardrails.
- Updates the public docs overview with the AI-operated company platform positioning, market vision section, ecosystem absorption roadmap lanes, and current 21 category / 95 archetype count.
- Links the new market vision doc from the docs README and extends archetype owner positioning with the edge-adapter/native-core thesis.

## Verification
- git diff --check
- rg -n "Fifteen market|15 categories|56 leaf|56 ready|See all 19" docs/index.html docs/README.md docs/architecture/archetype-owner-positioning.md docs/marketing/dpf-market-vision.md (no matches)
- Pre-commit gitleaks scan passed during commit

## Backlog
- Captured BI-COP-008 under EP-COMPANY-OPS-PARITY for public market positioning and competitor narrative.