### PR TITLE
fix(self-upgrade): compose-parity backup host path on promoter path (BI-E2625B79)

### DIFF
--- a/apps/web/lib/queue/functions/self-upgrade.ts
+++ b/apps/web/lib/queue/functions/self-upgrade.ts
@@ -19,7 +19,7 @@ import { prepareUpgradeSource, defaultGitRunner } from "@/lib/self-upgrade/prepa
 // NOT be statically imported into this server bundle entrypoint (BI-98AF1066);
 // that is what the dynamic loadPromoterRuntime() below is for.
 import { PROMOTER_ALREADY_RUNNING_EXIT_CODE } from "@/lib/self-upgrade/promoter-exit-codes";
-import { runCandidatePreflight } from "@/lib/self-upgrade/preflight";
+import { resolveReadinessBackupHostPath, runCandidatePreflight } from "@/lib/self-upgrade/preflight";
 import { getDeployedSha, isFeatureBuildDeployed } from "@/lib/self-upgrade/completion";
 import {
   classifyBuildFailure,
@@ -647,7 +647,7 @@ export async function runSelfUpgrade(
       // tree's HEAD and cross-checks against it.
       targetSha: builtStamp,
       backupPath: process.env.PROMOTE_BACKUP_PATH ?? `/backups/self-upgrade/${run.runId}`,
-      backupHostPath: process.env.DPF_BACKUPS_HOST_PATH ?? undefined,
+      backupHostPath: resolveReadinessBackupHostPath(process.env.DPF_BACKUPS_HOST_PATH, hostInstallPathResolved ?? ""),
       composeEnvFileHostPath: hostInstallPathResolved
         ? `${hostInstallPathResolved.replace(/\/$/, "")}/.env`
         : undefined,


### PR DESCRIPTION
## Summary
- Close the remaining half of **BI-E2625B79**: readiness already defaults empty `DPF_BACKUPS_HOST_PATH` to \`<install>/backups\` via \`resolveReadinessBackupHostPath\`.
- The **actual promoter** path in \`self-upgrade.ts\` still used \`process.env.DPF_BACKUPS_HOST_PATH ?? undefined\`, so an empty env (the documented default) skipped the \`/backups\` mount on promote.
- Wire promoter \`backupHostPath\` through the same helper so empty/unset matches compose + readiness.

## Evidence
- Worktree: \`fix/backup-host-path-default\`
- Existing unit tests: \`pnpm --filter web exec vitest run lib/self-upgrade/preflight.test.ts\` → **6 passed** (empty / unset / whitespace fallbacks)
- Local-CI-Override: source-local unit tests green; full pregate via CI

## Test plan
- [x] \`resolveReadinessBackupHostPath(\"\", install)\` → \`install/backups\`
- [x] Promoter call site uses the helper (diff)
- [ ] CI typecheck / unit tests

Process-Spine-Decision: pure bug fix; readiness helper already tested; no new durable surface