### PR TITLE
fix(self-upgrade): derive host identity in the candidate promoter (BI-D47955AF)

### DIFF
--- a/.github/workflows/self-upgrade-acceptance.yml
+++ b/.github/workflows/self-upgrade-acceptance.yml
@@ -108,6 +108,10 @@ jobs:
             --candidate-ref "$candidate_ref" \
             --project "$DPF_N1_PROJECT" \
             --evidence-dir "$DPF_N1_EVIDENCE"
+      # BI-D47955AF: deliberately sends NO DPF_HOST_* env, because the real N-1 caller
+      # (a portal built before the host-identity contract) cannot send it. Readiness must
+      # derive identity from the mounted install-state or every existing install wedges.
+      # The refusal step below keeps the explicit-env path covered.
       - name: Candidate readiness succeeds without quiescence
         run: |
           printf '\357\273\277%s\n' '{"schemaVersion":1,"installerVersion":"acceptance","platform":"linux","arch":"amd64","installPath":"/opt/dpf","stateDir":"/dpf-state","composeProjectName":"dpf"}' > "$RUNNER_TEMP/dpf-state/install-state.json"
@@ -116,9 +120,6 @@ jobs:
             -v "$RUNNER_TEMP/dpf-state:/dpf-state:ro" \
             -v "$RUNNER_TEMP/dpf-backups:/backups:ro" \
             -e DPF_PROMOTER_STATE_DIR=/dpf-state \
-            -e DPF_HOST_PLATFORM=linux \
-            -e DPF_HOST_ARCH=amd64 \
-            -e DPF_HOST_IDENTITY_PROVENANCE=explicit \
             -e DPF_PROMOTER_DOCKER_PREFLIGHT=ready \
             -e PROMOTE_SOURCE=/host-source \
             -e PROMOTE_TARGET_SHA="$GITHUB_SHA" \

--- a/apps/web/lib/self-upgrade/config.ts
+++ b/apps/web/lib/self-upgrade/config.ts
@@ -30,7 +30,7 @@ export type SelfUpgradeReadinessMode = "enforced" | "legacy-bootstrap";
 export type SelfUpgradeHostIdentity = {
   platform: "win32" | "darwin" | "linux";
   arch: "amd64" | "arm64" | "x86_64";
-  provenance: "explicit" | "legacy-windows-paths";
+  provenance: "explicit" | "install-state" | "legacy-windows-paths";
 };
 
 export function resolveSelfUpgradeHostIdentity(env: Record<string, string | undefined> = process.env, state: Record<string, unknown> = {}): SelfUpgradeHostIdentity {

--- a/apps/web/lib/self-upgrade/promote-script-contract.test.ts
+++ b/apps/web/lib/self-upgrade/promote-script-contract.test.ts
@@ -50,7 +50,9 @@ it("verifies the signed install-state handoff before reading the promotion proje
 it("projects legacy install state through valid dynamic ESM before readiness", () => {
   const source = readFileSync(join(REPO_ROOT, "scripts", "promote.sh"), "utf8");
   expect(source.match(/--overlay promote --migrate/g)).toHaveLength(2);
-  expect(source).toContain('await import(process.env.PROMOTER_DIR + "/installer/migrate-install-state.mjs")');
+  // Dynamic import, and via a file:// URL — a bare absolute path is not a legal ESM
+  // specifier on Windows, which silently sank the whole readiness projection there.
+  expect(source).toContain('await import(pathToFileURL(process.env.PROMOTER_DIR + "/installer/migrate-install-state.mjs").href)');
   expect(source).not.toContain('from process.env.PROMOTER_DIR');
 });
 
@@ -61,7 +63,7 @@ const BASE_ENV: Record<string, string> = {
   PROMOTE_HEALTH_URL: "http://localhost:3000/api/health",
 };
 
-function runScript(env: Record<string, string | undefined>, extraArgs: string[] = []) {
+function runScript(env: Record<string, string | undefined>, extraArgs: string[] = [], stateOverrides: Record<string, unknown> = {}) {
   const marker = basename(env.PROMOTE_SOURCE ?? "source").replace(/[^A-Za-z0-9-]/g, "-");
   const root = mkdtempSync(join(tmpdir(), `dpf-promote-contract-${marker}-`));
   try {
@@ -77,7 +79,7 @@ function runScript(env: Record<string, string | undefined>, extraArgs: string[] 
     const enabledRuntimeCapabilities = ["runtime:core"];
     const stateLines = catalog.capabilities.map(({ capabilityId }) => `${capabilityId}=${enabledRuntimeCapabilities.includes(capabilityId) ? "active" : "disabled"}`).sort().join("\n");
     const capabilityStateVersion = createHash("sha256").update(`${catalog.catalogHash}\n${stateLines}`).digest("hex");
-    writeFileSync(join(stateDir, "install-state.json"), JSON.stringify({ platform: "linux", enabledRuntimeCapabilities, capabilityCatalogHash: catalog.catalogHash, capabilityStateVersion }));
+    writeFileSync(join(stateDir, "install-state.json"), JSON.stringify({ platform: "linux", enabledRuntimeCapabilities, capabilityCatalogHash: catalog.catalogHash, capabilityStateVersion, ...stateOverrides }));
 
     const mapped = { ...env };
     if (mapped.PROMOTE_SOURCE !== undefined) mapped.PROMOTE_SOURCE = resolveBashPath(source);
@@ -90,6 +92,24 @@ function runScript(env: Record<string, string | undefined>, extraArgs: string[] 
     rmSync(root, { recursive: true, force: true });
   }
 }
+
+// BI-D47955AF. The promoter is candidate-owned but launched by the DEPLOYED portal, so an
+// N-1 caller (any portal built before the host-identity contract landed) sends no DPF_HOST_*
+// env and never can. Readiness must derive identity from the install-state it already mounts
+// — demanding it from the caller wedges every pre-existing install, because the upgrade that
+// teaches the caller to send it IS the blocked upgrade.
+describe.skipIf(!BASH_AVAILABLE)("promote.sh --readiness host identity", () => {
+  it("resolves installer-owned identity when the N-1 caller sends no DPF_HOST_* env", () => {
+    const result = runScript(BASE_ENV, ["--readiness"], { platform: "linux", arch: "amd64" });
+    expect(result.stdout).toContain('"stage":"preflight"');
+    expect(result.stdout).not.toContain("host_identity_missing");
+  });
+
+  it("fails closed when install-state carries no resolvable identity", () => {
+    const result = runScript(BASE_ENV, ["--readiness"], { platform: "unsupported", arch: "unknown" });
+    expect(result.stdout).toContain("host_identity_missing");
+  });
+});
 
 describe.skipIf(!BASH_AVAILABLE)("promote.sh --self-upgrade contract", () => {
   describe("required variables", () => {

--- a/scripts/installer/resolve-host-identity.mjs
+++ b/scripts/installer/resolve-host-identity.mjs
@@ -22,6 +22,21 @@ export function resolveHostIdentity({ state, env = {} }) {
   const installDrive = drive(env.DPF_HOST_INSTALL_PATH);
   const stateDrive = drive(env.DPF_STATE_DIR_HOST);
   const canonicalArch = ["amd64", "x86_64", "arm64"].includes(state.arch) ? state.arch : undefined;
+
+  // Installer-owned state identity. `.env` DPF_HOST_* and install-state platform/arch are
+  // written by the same installer at the same moment, so a canonical pair here carries the
+  // same authority as the explicit env — and it is the ONLY evidence an N-1 caller (a portal
+  // built before the readiness contract) can hand the promoter. Refusing it wedges the
+  // install: the upgrade that teaches the caller to send the env IS the blocked upgrade.
+  // Container `process.platform` / daemon OS remains off limits.
+  if (PLATFORMS.has(state.platform) && canonicalArch) {
+    const [platform, capabilityHostPlatform] = PLATFORMS.get(state.platform);
+    const pathEvidence = [env.DPF_HOST_INSTALL_PATH, env.DPF_STATE_DIR_HOST].filter((value) => typeof value === "string" && value.length > 0);
+    const windowsPaths = [installDrive, stateDrive].filter(Boolean).length;
+    if (pathEvidence.length > 0 && (platform === "win32" ? windowsPaths !== pathEvidence.length : windowsPaths > 0)) throw new Error("host_identity_contradictory");
+    return { platform, arch: canonicalArch, capabilityHostPlatform, provenance: "install-state" };
+  }
+
   if (state.platform === "unsupported" && installDrive && stateDrive && canonicalArch) {
     if (drive(state.installPath) !== installDrive || drive(state.stateDir) !== stateDrive) throw new Error("host_identity_contradictory");
     return { platform: "win32", arch: canonicalArch, capabilityHostPlatform: "windows", provenance: "legacy-windows-paths" };

--- a/scripts/installer/resolve-host-identity.test.mjs
+++ b/scripts/installer/resolve-host-identity.test.mjs
@@ -13,6 +13,26 @@ for (const [env, expected] of [
   assert.deepEqual(resolveHostIdentity({ state: {}, env }), { ...expected, provenance: "explicit" });
 });
 
+// An N-1 caller (any portal built before the readiness contract landed) sends no
+// DPF_HOST_* env at all. Canonical platform/arch in install-state.json is written by
+// the installer itself — the same authority tier as the .env keys — so it resolves
+// rather than failing closed and wedging the install. Container `process.platform` is
+// still never consulted.
+for (const [state, expected] of [
+  [{ platform: "win32", arch: "amd64" }, { platform: "win32", arch: "amd64", capabilityHostPlatform: "windows" }],
+  [{ platform: "windows", arch: "x86_64" }, { platform: "win32", arch: "x86_64", capabilityHostPlatform: "windows" }],
+  [{ platform: "linux", arch: "amd64" }, { platform: "linux", arch: "amd64", capabilityHostPlatform: "linux" }],
+  [{ platform: "macos", arch: "arm64" }, { platform: "darwin", arch: "arm64", capabilityHostPlatform: "macos" }],
+]) test(`installer-owned install-state resolves without caller env: ${state.platform}/${state.arch}`, () => {
+  assert.deepEqual(resolveHostIdentity({ state, env: {} }), { ...expected, provenance: "install-state" });
+});
+
+test("install-state identity still cross-checks the host path evidence it is given", () => {
+  assert.deepEqual(resolveHostIdentity({ state: { platform: "win32", arch: "amd64" }, env: { DPF_HOST_INSTALL_PATH: "D:\\DPF", DPF_STATE_DIR_HOST: "C:\\.dpf" } }), {
+    platform: "win32", arch: "amd64", capabilityHostPlatform: "windows", provenance: "install-state",
+  });
+});
+
 test("bounded legacy Windows evidence resolves an unsupported state", () => {
   assert.deepEqual(resolveHostIdentity({ state: { platform: "unsupported", arch: "amd64", installPath: "D:\\DPF", stateDir: "C:\\.dpf" }, env: { DPF_HOST_INSTALL_PATH: "D:\\DPF", DPF_STATE_DIR_HOST: "C:\\.dpf" } }), {
     platform: "win32", arch: "amd64", capabilityHostPlatform: "windows", provenance: "legacy-windows-paths",
@@ -22,8 +42,11 @@ test("bounded legacy Windows evidence resolves an unsupported state", () => {
 for (const [input, error] of [
   [{ state: { platform: "unsupported", arch: "x64" }, env: { DPF_HOST_INSTALL_PATH: "D:\\DPF", DPF_STATE_DIR_HOST: "D:\\.dpf" } }, "host_identity_unverifiable"],
   [{ state: { platform: "unsupported", arch: "amd64", installPath: "D:\\DPF", stateDir: "C:\\.dpf" }, env: { DPF_HOST_INSTALL_PATH: "E:\\DPF", DPF_STATE_DIR_HOST: "C:\\.dpf" } }, "host_identity_contradictory"],
-  [{ state: { platform: "linux", arch: "amd64" }, env: {} }, "host_identity_unverifiable"],
+  [{ state: { platform: "linux", arch: "x64" }, env: {} }, "host_identity_unverifiable"],
+  [{ state: { platform: "unsupported", arch: "amd64" }, env: {} }, "host_identity_unverifiable"],
   [{ state: { platform: "win32", arch: "amd64" }, env: { DPF_HOST_PLATFORM: "linux", DPF_HOST_ARCH: "amd64" } }, "host_identity_contradictory"],
+  [{ state: { platform: "linux", arch: "amd64" }, env: { DPF_HOST_INSTALL_PATH: "D:\\DPF", DPF_STATE_DIR_HOST: "C:\\.dpf" } }, "host_identity_contradictory"],
+  [{ state: { platform: "win32", arch: "amd64" }, env: { DPF_HOST_INSTALL_PATH: "/opt/dpf", DPF_STATE_DIR_HOST: "/var/lib/dpf" } }, "host_identity_contradictory"],
 ]) test(`fails closed: ${error} ${JSON.stringify(input)}`, () => {
   assert.throws(() => resolveHostIdentity(input), new RegExp(error));
 });

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -68,12 +68,25 @@ if [[ $_readiness -eq 1 ]]; then
   if [[ ! -f "$_profile_adapter" ]] || ! node "$_profile_adapter" --state "$_state_file" --overlay promote --migrate >/dev/null 2>&1; then
     _readiness_failures+=(capability_projection_failed)
   fi
+  # Host identity is resolved by the shipped resolver, not read raw from the caller's env.
+  # The promoter is candidate-owned but launched by the DEPLOYED portal, so an N-1 caller
+  # sends no DPF_HOST_* and never can - demanding it wedges every pre-existing install,
+  # since the upgrade that teaches the caller to send it IS the blocked upgrade. The
+  # resolver still prefers explicit env, falls back to the installer-owned identity in the
+  # mounted install-state, and fails closed on contradictory or unverifiable evidence.
   _migration_projection=""
-  if [[ -n "${DPF_HOST_PLATFORM:-}" && -n "${DPF_HOST_ARCH:-}" ]]; then
-    _migration_projection="$(STATE_FILE="$_state_file" PROMOTER_DIR="$_promoter_dir" node --input-type=module -e '
-      import { readFile } from "node:fs/promises"; const { projectInstallState } = await import(process.env.PROMOTER_DIR + "/installer/migrate-install-state.mjs");
+  _host_identity="$(STATE_FILE="$_state_file" PROMOTER_DIR="$_promoter_dir" node --input-type=module -e '
+    import { readFile } from "node:fs/promises"; import { pathToFileURL } from "node:url";
+    const { resolveHostIdentity } = await import(pathToFileURL(process.env.PROMOTER_DIR + "/installer/resolve-host-identity.mjs").href);
+    const state=JSON.parse((await readFile(process.env.STATE_FILE)).toString("utf8").replace(/^\uFEFF/,""));
+    process.stdout.write(JSON.stringify(resolveHostIdentity({state,env:process.env})));
+  ' 2>/dev/null)" || _host_identity=""
+  if [[ -n "$_host_identity" ]]; then
+    _migration_projection="$(STATE_FILE="$_state_file" PROMOTER_DIR="$_promoter_dir" DPF_HOST_IDENTITY="$_host_identity" node --input-type=module -e '
+      import { readFile } from "node:fs/promises"; import { pathToFileURL } from "node:url";
+      const { projectInstallState } = await import(pathToFileURL(process.env.PROMOTER_DIR + "/installer/migrate-install-state.mjs").href);
       const bytes=await readFile(process.env.STATE_FILE); const source=JSON.parse(bytes.toString("utf8").replace(/^\uFEFF/,"")); const catalog=JSON.parse(await readFile(process.env.PROMOTER_DIR+"/capability-service-catalog.generated.json","utf8"));
-      const p=process.env.DPF_HOST_PLATFORM; const hostIdentity={platform:p,arch:process.env.DPF_HOST_ARCH,provenance:process.env.DPF_HOST_IDENTITY_PROVENANCE,capabilityHostPlatform:p==="win32"?"windows":p==="darwin"?"macos":p};
+      const hostIdentity=JSON.parse(process.env.DPF_HOST_IDENTITY);
       const r=await projectInstallState({bytes,hostIdentity,catalog}); process.stdout.write(JSON.stringify({sourceHash:r.sourceHash,projectionHash:r.projectionHash,migrationRequired:r.migrationRequired,fromSchemaVersion:source.schemaVersion??1,toSchemaVersion:r.projectedState.schemaVersion}));
     ' 2>/dev/null)" || _readiness_failures+=(install_state_projection_failed)
   else

--- a/scripts/test-n-minus-one-upgrade.mjs
+++ b/scripts/test-n-minus-one-upgrade.mjs
@@ -29,8 +29,11 @@ export function buildPromoterReadinessDockerArgs({ candidateDigest, source, stat
   return ["run", "--rm", "--read-only",
     "-v", `${source}:/host-source:ro`, "-v", `${state}:/dpf-state:ro`, "-v", `${backups}:/backups:ro`,
     "-v", `${secret}:/run/secrets/dpf-runtime-transition:ro`,
-    "-e", "DPF_PROMOTER_STATE_DIR=/dpf-state", "-e", "DPF_HOST_PLATFORM=linux", "-e", "DPF_HOST_ARCH=amd64",
-    "-e", "DPF_HOST_IDENTITY_PROVENANCE=explicit", "-e", "DPF_PROMOTER_DOCKER_PREFLIGHT=ready",
+    // BI-D47955AF: no DPF_HOST_* here, deliberately. The promoter is candidate-owned but
+    // launched by the DEPLOYED portal, so the genuine N-1 caller sends nothing and never
+    // can. Injecting the env simulated a post-fix caller and let a readiness gate that
+    // hard-required it ship green, wedging every pre-existing install.
+    "-e", "DPF_PROMOTER_STATE_DIR=/dpf-state", "-e", "DPF_PROMOTER_DOCKER_PREFLIGHT=ready",
     "-e", "DPF_RUNTIME_TRANSITION_SECRET_FILE=/run/secrets/dpf-runtime-transition", "-e", `DPF_PROMOTER_DIGEST=${candidateDigest}`,
     "-e", "PROMOTE_SOURCE=/host-source", "-e", `PROMOTE_TARGET_SHA=${targetSha}`, "-e", `PROMOTE_COMPOSE_PROJECT=${project}`,
     "-e", "PROMOTE_BACKUP_PATH=/backups/recovery", "-e", "PROMOTE_HEALTH_URL=http://host.docker.internal:3000/api/health",

--- a/scripts/test-n-minus-one-upgrade.test.mjs
+++ b/scripts/test-n-minus-one-upgrade.test.mjs
@@ -242,8 +242,13 @@ test("runtime readiness supplies the complete state, secret, digest, mount, and 
   for (const required of [
     "/candidate:/host-source:ro", "/state:/dpf-state:ro", "/backups:/backups:ro", "/secret:/run/secrets/dpf-runtime-transition:ro",
     "DPF_PROMOTER_STATE_DIR=/dpf-state", "DPF_RUNTIME_TRANSITION_SECRET_FILE=/run/secrets/dpf-runtime-transition",
-    `DPF_PROMOTER_DIGEST=${digest}`, "DPF_HOST_PLATFORM=linux", "DPF_HOST_ARCH=amd64", "--readiness --json",
+    `DPF_PROMOTER_DIGEST=${digest}`, "--readiness --json",
   ]) assert.ok(rendered.includes(required), required);
+  // The genuine N-1 caller cannot supply host identity; readiness must derive it from the
+  // mounted install-state. Injecting it here would re-blind this guard (BI-D47955AF).
+  for (const forbidden of ["DPF_HOST_PLATFORM", "DPF_HOST_ARCH", "DPF_HOST_IDENTITY_PROVENANCE"]) {
+    assert.ok(!rendered.includes(forbidden), forbidden);
+  }
 });
 
 test("governed promotion invokes the signed promoter with writable state and recovery mounts", async () => {


### PR DESCRIPTION
## The break

Every pre-#3282 install can no longer self-upgrade. `SUR-75BF175D` on the live box:

```
promoter-readiness-failed: Promoter readiness check failed: host_identity_missing
```

The promoter is **candidate-owned** — built from the *target* commit — but launched by the **deployed** portal. #3282 added a readiness gate to the candidate's `scripts/promote.sh` that exits 78 unless `DPF_HOST_PLATFORM`/`DPF_HOST_ARCH` are in its environment, while the caller-side plumbing that sends them landed in the *same* PR (`apps/web/lib/self-upgrade/promoter.ts:256`).

```
$ git cat-file -p bf43bf22:apps/web/lib/self-upgrade/promoter.ts | grep -c DPF_HOST_PLATFORM
0
```

So the new promoter demands env the deployed portal cannot send — and the upgrade that teaches the caller to send it *is* the blocked upgrade. Self-healing is impossible from the caller side.

## The fix

Candidate-side, because that is the only side a wedged install can pull. Once this is on `main`, a wedged portal picks up the new candidate promoter on its next attempt and readiness passes.

- **`scripts/promote.sh`** resolves host identity through `resolve-host-identity.mjs`, already baked into the promoter image (`Dockerfile.promoter:23`), instead of reading raw caller env. Explicit env still wins; the mounted `install-state.json` is the fallback; contradictory or unverifiable evidence still fails closed with `host_identity_missing`.
- **`scripts/installer/resolve-host-identity.mjs`** accepts a canonical `state.platform`/`state.arch` pair (new provenance `install-state`). Previously only a literal `"unsupported"` platform got a fallback, so this box — which records a perfectly good `win32`/`amd64` — threw `host_identity_unverifiable` even from a fixed portal, because existing `.env` files predate the `DPF_HOST_*` keys. It cross-checks whatever host-path evidence it is given; container `process.platform` stays off limits per the original doctrine.
- Both inline ESM imports go through `pathToFileURL`. A bare absolute path is not a legal ESM specifier on Windows, which silently sank the whole readiness projection there.

## Why CI was green when it shipped

`scripts/test-n-minus-one-upgrade.mjs` hard-coded `-e DPF_HOST_PLATFORM=linux` when invoking the candidate promoter — simulating a *post*-fix caller, so the genuine N-1 caller was never exercised. It now sends nothing, and the unit test asserts those keys are **absent** so the guard cannot be re-blinded. The acceptance workflow's success step drops the env too; the refusal step keeps explicit-env coverage.

## Verification

Resolving against the live install's real `install-state.json`:

```json
{"platform":"win32","arch":"amd64","capabilityHostPlatform":"windows","provenance":"install-state"}
```

- `promote-script-contract` **27/27**, including a new N-1 readiness case that went red→green on this change (it reproduced the exact production `host_identity_missing`)
- `resolve-host-identity` 18/18 · `test-n-minus-one-upgrade` 26/26 · `lifecycle-parity` 11/11 · queue `self-upgrade` 91/91
- `apps/web/lib/self-upgrade` 529/530 — the single failure is **pre-existing on `origin/main`** (reproduced with `promote.sh` reverted) and filed as `BI-F2372F5B`
- Web typecheck clean on a full local install

🤖 Generated with [Claude Code](https://claude.com/claude-code)
