### PR TITLE
fix(docs): regenerate the doc index for the market-vision page

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 524,
+  "pageCount": 525,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -3821,6 +3821,25 @@
         "category-contact-sheets",
         "visual-guardrails",
         "next-production-pass"
+      ]
+    },
+    "docs/marketing/dpf-market-vision.md": {
+      "publicHref": "/marketing/dpf-market-vision/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "dpf-market-vision",
+        "1-thesis",
+        "2-the-market-problem",
+        "3-product-positioning",
+        "4-competitor-and-ecosystem-map",
+        "5-absorb-combine-refactor",
+        "6-prioritization",
+        "7-current-state-guardrails",
+        "8-message-house",
+        "9-backlog-anchors",
+        "10-sources-and-market-signals"
       ]
     },
     "docs/operations/antigravity-cli-onboarding.md": {


### PR DESCRIPTION
## `main` is red, and it blocks every open PR

[#3284](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3284) added `docs/marketing/dpf-market-vision.md` without regenerating `apps/web/lib/docs/doc-index.generated.json`. The **Docs Link Integrity** job fails at its very first step:

```
doc-index.generated.json is stale. Run: node scripts/gen-doc-index.mjs
```

That job deliberately has no `heavy` gate — it runs on every PR — and PR checks evaluate the *merge ref*, so a stale index on `main` turns the check red on branches that touch no docs at all. Confirmed failing on `main` @ `e092d56d4` and inherited by unrelated PRs.

## Change

Regenerated output only — page count 524 → 525, plus the new page's entry and anchors. No hand edits.

## Verification

- `node scripts/gen-doc-index.mjs --check` → fresh (525 pages)
- `node --test scripts/check-doc-links.test.mjs` → 16/16
- `node scripts/check-doc-links.mjs` → PASS, no error-level findings
- `node scripts/render-doc-diagrams.mjs --check` → fresh (5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
