### PR TITLE
feat(ci): ratchet that stops an N-1 harness simulating its own fix (BI-D47955AF)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,32 @@ jobs:
       - name: Run guard
         run: node scripts/check-compose-env-contract.mjs
 
+  n-minus-one-caller-honesty:
+    name: N-1 Caller Honesty
+    runs-on: ubuntu-latest
+    # BI-D47955AF. The promoter is CANDIDATE-owned but CALLER-launched, so a PR can
+    # add a requirement to the candidate AND the caller-side plumbing that satisfies
+    # it, and ship green — because the N-1 harness supplies the new environment by
+    # hand. #3282 did exactly that twice (readiness host identity, then the signed
+    # migration handoff) and wedged every pre-existing install: the deployed portal
+    # cannot send the keys, and the upgrade that would teach it to IS the blocked
+    # upgrade. This guard fails a PR whose compatibility harness passes the candidate
+    # promoter any env key the caller at the MERGE BASE does not itself send.
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The baseline caller is read at the merge base; a shallow clone has no
+          # merge base to read, and the guard would exit 2 (cannot evaluate).
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24
+      - name: Guard unit tests
+        run: node --test scripts/check-n-minus-one-caller-honesty.test.mjs
+      - name: Run guard
+        run: node scripts/check-n-minus-one-caller-honesty.mjs
+
   module-size-guard:
     name: Module Size Guard
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "check:bundle-boundaries": "node scripts/check-bundle-boundaries.mjs",
     "check:diagram-dependency-pins": "node scripts/check-diagram-dependency-pins.mjs",
     "check:reporting-composition": "node scripts/check-reporting-composition.mjs",
+    "check:n1-caller-honesty": "node scripts/check-n-minus-one-caller-honesty.mjs",
     "check:module-size": "node scripts/check-module-size.mjs",
     "check:data-impact": "node scripts/check-data-impact.mjs",
     "measure:substrate": "node scripts/measure-platform-substrate.mjs --json",

--- a/scripts/check-n-minus-one-caller-honesty.mjs
+++ b/scripts/check-n-minus-one-caller-honesty.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// N-1 caller-honesty ratchet (BI-D47955AF follow-up).
+//
+// The self-upgrade promoter is CANDIDATE-owned (built from the target commit)
+// but CALLER-launched (run by the portal that is still deployed). That split is
+// what makes an upgrade able to fix its own caller — and it is also a trapdoor:
+// a PR can add a readiness requirement to the candidate's promote.sh AND the
+// caller-side plumbing that satisfies it, and ship green, because the N-1
+// acceptance harness supplies the new environment by hand. The harness ends up
+// testing the post-fix world, while the real N-1 caller can never reach it.
+//
+// That is exactly how PR #3282 wedged every pre-existing install: readiness
+// began requiring DPF_HOST_PLATFORM/DPF_HOST_ARCH, the deployed portal had no
+// code to send them, and the harness hard-coded `-e DPF_HOST_PLATFORM=linux`
+// so nothing went red. The upgrade that teaches the caller to send them WAS the
+// blocked upgrade.
+//
+// The invariant this enforces:
+//
+//   A compatibility harness may not hand the candidate promoter any environment
+//   key that the BASELINE caller does not itself pass.
+//
+// Baseline = the caller as it exists at the merge base (what is actually
+// deployed out there), not as this PR leaves it. Anything the harness supplies
+// beyond that is a simulation of a caller that does not exist yet.
+//
+// Usage:
+//   node scripts/check-n-minus-one-caller-honesty.mjs [--base <ref>] [--json]
+//
+// Exit 0 = honest, 1 = violation, 2 = could not evaluate (missing base ref).
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const CALLER_SOURCE = "apps/web/lib/self-upgrade/promoter.ts";
+const HARNESS_SOURCE = "scripts/test-n-minus-one-upgrade.mjs";
+const ACCEPTANCE_WORKFLOW = ".github/workflows/self-upgrade-acceptance.yml";
+
+// Keys the harness owns because they describe the TEST RIG, not the caller
+// contract: they select which promoter image to exercise, point it at throwaway
+// mounts, and stub the docker preflight a real portal performs for itself.
+// Every entry needs a reason — this list is the only way to weaken the ratchet,
+// so it stays short and argued.
+// Kept deliberately minimal: every entry here is a hole in the ratchet, so a key
+// earns a place only when the real caller genuinely cannot be its source. Keys
+// the caller DOES pass need no entry — the subset check already accepts them.
+const HARNESS_SCAFFOLDING = new Map([
+  ["DPF_RUNTIME_TRANSITION_SECRET_FILE", "rig points at a throwaway secret path; the portal bind-mounts the install's secret to the promoter's default location instead"],
+  ["COMPOSE_PARALLEL_LIMIT", "bounds hosted-runner concurrency; not part of the promoter contract"],
+]);
+
+function git(args) {
+  return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf8", maxBuffer: 1e8 });
+}
+
+function readAtRef(ref, path) {
+  try {
+    return git(["show", `${ref}:${path}`]);
+  } catch {
+    return null;
+  }
+}
+
+// Single-pass scanner over code, comments, and the three string forms. A plain
+// regex is not enough: an apostrophe in prose ("the promoter's contract") reads
+// as a quote and desynchronizes everything after it, silently under-reporting
+// what the caller sends — which in a ratchet means false PASSES on the honesty
+// check and false FAILS on the baseline. Comments are skipped, not tokenized.
+export function scanStringLiterals(source) {
+  const literals = [];
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (ch === "/" && next === "/") {
+      while (i < source.length && source[i] !== "\n") i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) i += 1;
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      let value = "";
+      i += 1;
+      while (i < source.length && source[i] !== quote) {
+        if (source[i] === "\\") {
+          value += source[i + 1] ?? "";
+          i += 2;
+          continue;
+        }
+        value += source[i];
+        i += 1;
+      }
+      i += 1;
+      literals.push(value);
+      continue;
+    }
+    i += 1;
+  }
+  return literals;
+}
+
+// When a literal is exactly "-e", the next literal carries the env assignment.
+// Robust to the multi-line args.push(...) formatting both files use.
+export function extractDockerEnvKeys(source) {
+  const literals = scanStringLiterals(source);
+  const keys = new Set();
+  literals.forEach((literal, index) => {
+    if (literal !== "-e") return;
+    const key = /^([A-Z][A-Z0-9_]*)=/.exec(literals[index + 1] ?? "")?.[1];
+    if (key) keys.add(key);
+  });
+  return keys;
+}
+
+// `-e KEY=value` / `-e KEY` as written in a workflow run: block.
+export function extractWorkflowEnvKeys(source) {
+  const keys = new Set();
+  for (const match of source.matchAll(/-e\s+([A-Z][A-Z0-9_]*)=/g)) keys.add(match[1]);
+  return keys;
+}
+
+export function findViolations({ baselineCallerKeys, harnessKeys, scaffolding = HARNESS_SCAFFOLDING }) {
+  return [...harnessKeys]
+    .filter((key) => !scaffolding.has(key) && !baselineCallerKeys.has(key))
+    .sort();
+}
+
+function resolveBaseRef(explicit) {
+  if (explicit) return explicit;
+  for (const candidate of ["origin/main", "main"]) {
+    try {
+      git(["rev-parse", "--verify", "--quiet", candidate]);
+      return candidate;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return null;
+}
+
+function main(argv) {
+  const asJson = argv.includes("--json");
+  const baseIndex = argv.indexOf("--base");
+  const baseRef = resolveBaseRef(baseIndex >= 0 ? argv[baseIndex + 1] : undefined);
+
+  if (!baseRef) {
+    console.error("[n1-caller-honesty] no base ref (origin/main or main) — cannot establish the baseline caller.");
+    return 2;
+  }
+
+  let mergeBase;
+  try {
+    mergeBase = git(["merge-base", "HEAD", baseRef]).trim();
+  } catch {
+    console.error(`[n1-caller-honesty] no merge base with ${baseRef} — cannot establish the baseline caller.`);
+    return 2;
+  }
+
+  const baselineCaller = readAtRef(mergeBase, CALLER_SOURCE);
+  if (baselineCaller === null) {
+    console.error(`[n1-caller-honesty] ${CALLER_SOURCE} absent at ${mergeBase.slice(0, 9)} — cannot establish the baseline caller.`);
+    return 2;
+  }
+
+  const baselineCallerKeys = extractDockerEnvKeys(baselineCaller);
+  const harnessKeys = new Set([
+    ...extractDockerEnvKeys(readFileSync(join(REPO_ROOT, HARNESS_SOURCE), "utf8")),
+    ...extractWorkflowEnvKeys(readFileSync(join(REPO_ROOT, ACCEPTANCE_WORKFLOW), "utf8")),
+  ]);
+
+  const violations = findViolations({ baselineCallerKeys, harnessKeys });
+  const report = {
+    baseRef,
+    mergeBase,
+    baselineCallerKeyCount: baselineCallerKeys.size,
+    harnessKeyCount: harnessKeys.size,
+    violations,
+  };
+
+  if (asJson) console.log(JSON.stringify(report, null, 2));
+
+  if (violations.length > 0) {
+    if (!asJson) {
+      console.error("[n1-caller-honesty] FAIL — the N-1 harness supplies environment the deployed caller cannot.\n");
+      for (const key of violations) {
+        console.error(`  ${key}`);
+        console.error(`    ${HARNESS_SOURCE} / ${ACCEPTANCE_WORKFLOW} pass this to the candidate promoter,`);
+        console.error(`    but ${CALLER_SOURCE} at ${mergeBase.slice(0, 9)} never sends it.`);
+      }
+      console.error("\nThe harness is testing a caller that is not deployed anywhere. If the candidate");
+      console.error("now requires this key, every existing install is wedged: it cannot supply the key,");
+      console.error("and the upgrade that would teach it to IS the blocked upgrade.\n");
+      console.error("Fix the candidate to derive the value from substrate it already has (mounted");
+      console.error("install-state, the compose env file), or stage the requirement across two");
+      console.error("releases — caller first, requirement second. Do NOT make the harness supply it.");
+      console.error(`\nIf this key is genuinely test-rig plumbing, add it to HARNESS_SCAFFOLDING in`);
+      console.error(`${"scripts/check-n-minus-one-caller-honesty.mjs"} with a reason.`);
+    }
+    return 1;
+  }
+
+  if (!asJson) {
+    console.log(`[n1-caller-honesty] OK — harness passes ${harnessKeys.size} env key(s), none beyond what the baseline caller at ${mergeBase.slice(0, 9)} sends.`);
+  }
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, "/")}`).href) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/check-n-minus-one-caller-honesty.test.mjs
+++ b/scripts/check-n-minus-one-caller-honesty.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+
+import {
+  extractDockerEnvKeys,
+  extractWorkflowEnvKeys,
+  findViolations,
+  scanStringLiterals,
+} from "./check-n-minus-one-caller-honesty.mjs";
+
+// The incident this ratchet exists for. #3282 added a readiness requirement to
+// the candidate AND the caller-side plumbing satisfying it, and shipped green
+// because the harness hard-coded the new environment.
+const PR_3282 = "c5cccd89b6834ad826bcadfc8ae58914b63f5d7f";
+
+function showAtRef(ref, path) {
+  try {
+    return execFileSync("git", ["show", `${ref}:${path}`], { encoding: "utf8", maxBuffer: 1e8 });
+  } catch {
+    return null;
+  }
+}
+
+test("scanner skips comments so prose apostrophes cannot desynchronize it", () => {
+  const source = `
+    // the promoter's contract isn't a string
+    /* neither is this one's */
+    args.push("-e", \`PROMOTE_COMPOSE_PROJECT=\${params.composeProject || "dpf"}\`);
+  `;
+  assert.deepEqual(extractDockerEnvKeys(source), new Set(["PROMOTE_COMPOSE_PROJECT"]));
+});
+
+test("scanner keeps // inside a string literal", () => {
+  assert.deepEqual(scanStringLiterals('const u = "http://host/x"; k("-e", "A=1")'), ["http://host/x", "-e", "A=1"]);
+});
+
+test("extracts env keys across multi-line arg arrays", () => {
+  const source = `args.push(
+    "-e",
+    \`PROMOTE_TARGET_SHA=\${sha}\`,
+    "-v", "/a:/b:ro",
+    "-e",
+    "DPF_STATE_DIR=/dpf-state",
+  );`;
+  assert.deepEqual(extractDockerEnvKeys(source), new Set(["PROMOTE_TARGET_SHA", "DPF_STATE_DIR"]));
+});
+
+test("a -v mount value is never mistaken for an env key", () => {
+  assert.deepEqual(extractDockerEnvKeys('args.push("-v", "STATE=/x:/y:ro")'), new Set());
+});
+
+test("reads -e pairs out of a workflow run block", () => {
+  const workflow = `
+        run: |
+          docker run --rm \\
+            -e DPF_PROMOTER_STATE_DIR=/dpf-state \\
+            -e PROMOTE_TARGET_SHA="$GITHUB_SHA" \\
+            "$IMAGE" --readiness --json
+  `;
+  assert.deepEqual(extractWorkflowEnvKeys(workflow), new Set(["DPF_PROMOTER_STATE_DIR", "PROMOTE_TARGET_SHA"]));
+});
+
+test("harness keys the baseline caller also sends are honest", () => {
+  const violations = findViolations({
+    baselineCallerKeys: new Set(["PROMOTE_TARGET_SHA", "DPF_HOST_PLATFORM"]),
+    harnessKeys: new Set(["PROMOTE_TARGET_SHA", "DPF_HOST_PLATFORM"]),
+    scaffolding: new Map(),
+  });
+  assert.deepEqual(violations, []);
+});
+
+test("a harness key the baseline caller cannot send is a violation", () => {
+  const violations = findViolations({
+    baselineCallerKeys: new Set(["PROMOTE_TARGET_SHA"]),
+    harnessKeys: new Set(["PROMOTE_TARGET_SHA", "DPF_HOST_PLATFORM"]),
+    scaffolding: new Map(),
+  });
+  assert.deepEqual(violations, ["DPF_HOST_PLATFORM"]);
+});
+
+test("declared scaffolding is exempt", () => {
+  const violations = findViolations({
+    baselineCallerKeys: new Set(),
+    harnessKeys: new Set(["COMPOSE_PARALLEL_LIMIT"]),
+    scaffolding: new Map([["COMPOSE_PARALLEL_LIMIT", "runner concurrency"]]),
+  });
+  assert.deepEqual(violations, []);
+});
+
+// The regression proof: replay the real #3282 tree and assert the ratchet would
+// have blocked it, naming the keys that actually wedged every install.
+test("would have blocked PR #3282 before it wedged every pre-existing install", (t) => {
+  const baselineCaller = showAtRef(`${PR_3282}^`, "apps/web/lib/self-upgrade/promoter.ts");
+  const harnessAtPr = showAtRef(PR_3282, "scripts/test-n-minus-one-upgrade.mjs");
+  const workflowAtPr = showAtRef(PR_3282, ".github/workflows/self-upgrade-acceptance.yml");
+  if (!baselineCaller || !harnessAtPr || !workflowAtPr) {
+    t.skip("history for #3282 unavailable (shallow clone)");
+    return;
+  }
+
+  const violations = findViolations({
+    baselineCallerKeys: extractDockerEnvKeys(baselineCaller),
+    harnessKeys: new Set([...extractDockerEnvKeys(harnessAtPr), ...extractWorkflowEnvKeys(workflowAtPr)]),
+  });
+
+  for (const wedging of ["DPF_HOST_PLATFORM", "DPF_HOST_ARCH", "DPF_HOST_IDENTITY_PROVENANCE"]) {
+    assert.ok(violations.includes(wedging), `${wedging} should be reported`);
+  }
+  // Same PR, same trapdoor, one gate later: promote.sh's signed migration
+  // handoff. The deployed portal cannot send these either.
+  for (const handoff of ["DPF_INSTALL_STATE_MIGRATION_ENVELOPE", "DPF_INSTALL_STATE_MIGRATION_SIGNATURE"]) {
+    assert.ok(violations.includes(handoff), `${handoff} should be reported`);
+  }
+});


### PR DESCRIPTION
Follow-up to [#3286](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3286): that PR fixed the break, this one stops the class from shipping green again.

## The trapdoor

The promoter is **candidate-owned** (built from the target commit) but **caller-launched** (run by the portal still deployed). That split is what lets an upgrade fix its own caller — and it's a trapdoor: a PR can add a requirement to the candidate *and* the caller-side plumbing that satisfies it, and ship green, because the N-1 acceptance harness supplies the new environment **by hand**. The harness ends up testing a caller that is not deployed anywhere.

#3282 did exactly that and wedged every pre-existing install. CI was green.

## The invariant

> A compatibility harness may not hand the candidate promoter any environment key that the **baseline** caller does not itself pass.

Baseline = the caller at the **merge base** (what's actually deployed), not as the PR leaves it. Anything beyond that simulates a caller that doesn't exist yet.

Escape hatch is a deliberately tiny `HARNESS_SCAFFOLDING` map — 2 entries, each with a stated reason. Keys the caller *does* send need no entry; the subset check already accepts them.

## Proven against the incident, not asserted

Replaying the real #3282 tree, the guard reports six violations — including the three that wedged the fleet:

```
DPF_HOST_PLATFORM, DPF_HOST_ARCH, DPF_HOST_IDENTITY_PROVENANCE
DPF_INSTALL_STATE_MIGRATION_ENVELOPE, DPF_INSTALL_STATE_MIGRATION_SIGNATURE, DPF_SELF_UPGRADE_RUN_ID
```

That replay is a **checked-in test**, so this is demonstrated rather than claimed.

## ⚠️ It immediately found a second live blocker

The guard surfaced a second instance of the same trapdoor in #3282, which hadn't bitten only because readiness fails first:

- `scripts/promote.sh:127` (added by #3282) requires `DPF_INSTALL_STATE_MIGRATION_ENVELOPE` + `_SIGNATURE`, exit 78
- the deployed portal (`bf43bf22`) has **zero** references to either

So **#3286 clears gate 1 of 2** — the install is still wedged at the promotion path. Filed as `BI-76651B7B` with a proposed fix (the promoter self-issues the envelope from its own readiness projection, preserving the anti-TOCTOU binding). This PR adds the detector, not that fix.

## Implementation note

The env extractor is a single-pass scanner over code, comments, and all three string forms — not a regex. An apostrophe in prose (`the promoter's contract`) reads as a quote and desynchronizes a naive tokenizer, which *under-reports* what the caller sends — false PASSES in a ratchet. Caught during development; covered by tests.

The CI job uses `fetch-depth: 0`; a shallow clone has no merge base to read and the guard would exit 2 (cannot evaluate) rather than pass.

## Verification

- `node --test scripts/check-n-minus-one-caller-honesty.test.mjs` → **9/9**
- guard exits 0 on this branch (baseline `94163f1c9`), and would exit 1 on #3282
- kernel-routed before choosing the approach: `principle_decide` → `DI-F4F1C057C5FA`, high confidence, margin 1.05

🤖 Generated with [Claude Code](https://claude.com/claude-code)
