### PR TITLE
fix(self-upgrade): classify the #3282 migration-handoff crossing block (BI-BE8BBDE9)

### DIFF
--- a/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.test.ts
@@ -194,6 +194,24 @@ describe("classifyBuildFailure", () => {
     expect(c.failingTrace).toContain("capability_state_stale");
   });
 
+  it("classifies the #3282 migration-handoff crossing block instead of leaving it unknown (BI-BE8BBDE9)", () => {
+    // Live symptom on a pre-#3282 install: readiness passes, promote.sh exits 78,
+    // and the wrapper reported it as "unknown (unclassified)" with the wrong playbook.
+    const log = [
+      "[build-failure-class] unknown (unclassified)",
+      "--- stderr (tail) ---",
+      "error: install_state_migration_handoff_missing",
+    ].join("\n");
+    const c = classifyBuildFailure({ log });
+    expect(c.class).toBe("install-state-migration-handoff-missing");
+    expect(c.class).not.toBe("unknown");
+    // Must steer to the out-of-band crossing bootstrap, not a retry/rebuild.
+    expect(c.summary).toContain("Do NOT retry");
+    expect(c.summary).toContain("runtime-transition.secret");
+    expect(c.isMainDefectVsEnvironment).toBe("environment");
+    expect(c.failingTrace).toContain("install_state_migration_handoff_missing");
+  });
+
   it("keeps an unrelated mounts-denied path out of the state-dir advice", () => {
     const log = "Error response from daemon: mounts denied: The path /some/other/vol is not shared from the host.";
     const c = classifyBuildFailure({ log });

--- a/apps/web/lib/self-upgrade/build-failure-classifier.ts
+++ b/apps/web/lib/self-upgrade/build-failure-classifier.ts
@@ -97,6 +97,12 @@ export type BuildFailureClass =
   // deployed in that window can't self-heal (BI-B132DF1D). Version-skew, not a
   // defect in this run's code.
   | "capability-state-preflight-unavailable"
+  // promote.sh (#3282) requires a SIGNED install-state migration handoff
+  // (DPF_INSTALL_STATE_MIGRATION_ENVELOPE + _SIGNATURE) that only a #3282+
+  // launcher constructs. A pre-#3282 portal cannot produce it, so a legacy
+  // install cannot self-upgrade INTO #3282 — the fix is the documented
+  // out-of-band crossing bootstrap, never a rebuild or a retry (BI-BE8BBDE9).
+  | "install-state-migration-handoff-missing"
   | "unknown";
 
 export type BuildFailureClassification = {
@@ -178,6 +184,11 @@ const MOUNTS_DENIED = /mounts denied:[\s\S]{0,120}?path\s+(\S+)\s+is not shared 
 // on the emitted string; the wrapper "unknown (unclassified)" was the live
 // symptom this rule replaces (BI-B132DF1D).
 const CAPABILITY_STATE_STALE = /^error: capability_state_stale$/im;
+// promote.sh (#3282) exits 78 with exactly this line when the signed install-state
+// migration handoff was not supplied by the launcher. Anchor on the emitted string;
+// like capability_state_stale above, the live symptom this rule replaces was the
+// misleading "unknown (unclassified)" wrapper pointing at the wrong playbook.
+const MIGRATION_HANDOFF_MISSING = /^error: install_state_migration_handoff_missing$/im;
 // `CREATE EXTENSION vector` on a Postgres image without pgvector: the canonical
 // Postgres errors are `extension "vector" is not available` and a `DETAIL: Could
 // not open extension control file ".../vector.control"`. Deliberately anchored on
@@ -272,6 +283,21 @@ export function classifyBuildFailure(
         "promote.sh's capability preflight aborted with `error: capability_state_stale` — a MISLABEL: it means the governed install snapshot (/dpf-state/install-state.json) or the compose-profile adapter was not available inside the promoter, not that capability state is genuinely stale. Root cause is a promoter launcher predating the /dpf-state self-upgrade mount (#3272) running a promote.sh that already requires it (#3266): an install deployed in that window cannot self-heal and must be bootstrapped out-of-band onto a portal >= #3272 (BI-B132DF1D). Version-skew / environment, not a defect in this run's code.",
       playbookLink: SPEC,
       failingTrace: traceAround(log, CAPABILITY_STATE_STALE),
+      isMainDefectVsEnvironment: "environment",
+    };
+  }
+
+  // promote.sh (#3282) refused to migrate because the launcher supplied no signed
+  // migration handoff. Decisive and precedes any build output, like the two cases
+  // above — classify it so a legacy install crossing into #3282 is sent to the
+  // bootstrap procedure instead of "unknown (unclassified)" (BI-BE8BBDE9).
+  if (MIGRATION_HANDOFF_MISSING.test(log)) {
+    return {
+      class: "install-state-migration-handoff-missing",
+      summary:
+        "promote.sh refused the governed install-state migration because the signed handoff (DPF_INSTALL_STATE_MIGRATION_ENVELOPE + DPF_INSTALL_STATE_MIGRATION_SIGNATURE) was not supplied. Only a #3282+ launcher builds and signs that envelope (signing also needs /dpf-state/runtime-transition.secret), so an install still running a PRE-#3282 portal cannot self-upgrade INTO #3282 — every fix ships into a version the install cannot reach. Do NOT retry or rebuild: the run will fail identically. Cross the boundary once, out-of-band (build the portal from current origin/main, initialize the transition secret via scripts/rotate-runtime-transition-secret.mjs --initialize, set DPF_HOST_PLATFORM/DPF_HOST_ARCH in the install .env to match install-state, then recreate portal+portal-init). After that the launcher can sign handoffs and self-upgrade resumes normally (BI-BE8BBDE9). Version-skew / environment, not a defect in this run's code.",
+      playbookLink: SPEC,
+      failingTrace: traceAround(log, MIGRATION_HANDOFF_MISSING),
       isMainDefectVsEnvironment: "environment",
     };
   }


### PR DESCRIPTION
## Why
A pre-#3282 install that tries to self-upgrade into #3282 fails with:
```
[build-failure-class] unknown (unclassified)
--- stderr (tail) ---
error: install_state_migration_handoff_missing
```
The classifier has no rule for it, so it points at the procedural-verification playbook — the **wrong remedy**. That invites a retry or a hand-rebuild, which fails identically every time.

## The condition
`promote.sh` (#3282) exits 78 when the launcher supplies no signed handoff (`DPF_INSTALL_STATE_MIGRATION_ENVELOPE` + `_SIGNATURE`). Only a **#3282+ launcher** builds and signs that envelope, and signing needs `/dpf-state/runtime-transition.secret`. So a pre-#3282 install **cannot self-upgrade INTO #3282** — every fix ships into a version it can't reach. It's a closed loop, not a build defect.

## Fix
Classify it as `install-state-migration-handoff-missing` (environment, not a main defect) and steer to the one-time **out-of-band crossing bootstrap**: build the portal from current origin/main, `rotate-runtime-transition-secret.mjs --initialize`, set `DPF_HOST_PLATFORM`/`DPF_HOST_ARCH` in the install `.env` to match install-state, recreate portal+portal-init. After that the launcher can sign handoffs and self-upgrade resumes normally.

Same gap and fix shape as the `capability_state_stale` rule added in #3280. Verified live: that bootstrap unstuck a real macOS install (self-upgrade succeeded, install-state migrated schemaVersion 1→2).

Refs BI-BE8BBDE9, #3282, #3286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)