### PR TITLE
docs: plan governed LLM provider onboarding

### DIFF
--- a/docs/superpowers/plans/2026-07-19-governed-llm-provider-onboarding.md
+++ b/docs/superpowers/plans/2026-07-19-governed-llm-provider-onboarding.md
@@ -128,6 +128,48 @@ Usability verification must demonstrate that representative non-technical partic
 
 Run formative sessions with at least five representative participants. Passing means at least 80% answer all five correctly and complete the safe path without opening technical evidence. Qualitative feedback must also confirm that the flow feels protective and competent rather than punitive, confusing, or falsely reassuring.
 
+## Grounded questions and answers contract
+
+The same Data Governance coworker remains available during onboarding and from the provider detail experience afterward. A non-technical operator can ask follow-up questions in ordinary language—“Can I use this for customer emails?”, “Why does a business account matter?”, “Does this stay in Europe?”, or “What do I need before payroll data is allowed?”—without knowing which regulation, provider document, or technical setting to inspect.
+
+Reliability means evidence-grounded answers with a safe refusal boundary, not merely fluent prose. Every material answer must satisfy this contract:
+
+1. **Answer the business question first.** Start with a direct `Yes`, `No`, `Only if`, or `DPF cannot confirm this yet`, followed by the practical consequence for the operator’s intended work.
+2. **Substantiate every material claim.** Link claims about law, regulation, provider behavior, account terms, regions, training, retention, or contractual controls to the exact supporting source. Show source title, publisher, effective/published date, last checked date, and applicable jurisdiction/provider/account class.
+3. **Prefer authoritative sources.** Use primary legislation, regulators, standards bodies, and current first-party provider contracts/policies. Profession-corpus pages organize and explain those sources; they are not allowed to turn an uncited summary into authority.
+4. **Separate evidence from advice.** Mark what the source states, what the organization declared, what DPF verified technically, and what AGT-902 recommends. Never present an inference or operator declaration as a verified provider fact.
+5. **Expose scope and uncertainty.** State which workload, data class, jurisdiction, account, provider service, region, and evidence date the answer covers. If facts are missing, stale, conflicting, or outside corpus coverage, say so and ask the smallest useful follow-up question.
+6. **Abstain safely.** When the evidence does not support a reliable answer, AGT-902 returns `cannot_substantiate` with the missing fact, safe interim behavior, and appropriate next reviewer. It must not fill gaps from general model memory.
+7. **Keep advice and enforcement aligned.** The answer may explain or recommend a narrower posture; it cannot silently broaden the compiled provider allowance. A change in advice becomes a proposed posture revision requiring explicit operator review.
+8. **Protect the question itself.** Build the smallest necessary A2A/retrieval packet, keep the cold-start consultation local, and apply the same pre-egress policy if a later eligible cloud model assists. Do not include secrets or unrelated company/customer data in retrieval queries or citations.
+9. **Make references usable.** Put compact inline references next to the claims they support and offer a “Review sources” disclosure with the relevant excerpt/context and direct link. Do not make the operator search a generic bibliography or read a regulation list to discover which claim a source supports.
+10. **Preserve an audit trail without sensitive prose.** Record question category, evidence/source ids and versions, answer state, posture version, citation validation result, and escalation—not the raw sensitive values that may appear in the question.
+
+### Structured answer contract
+
+The A2A response and deterministic fallback share one validated shape:
+
+- `answerState`: `substantiated | conditional | cannot_substantiate`;
+- `directAnswer` and `practicalMeaning` in plain language;
+- `appliesTo`: jurisdiction, provider/service, account class, region, workload, and data classes;
+- `evidenceClaims`: claim id, concise claim, source id, supporting location/excerpt bounds, publisher, effective date, last checked date, and evidence strength;
+- `organizationFactsUsed`, separated by declared versus technically verified;
+- `missingFacts` and one follow-up question when needed;
+- `recommendation`, `safeInterimBehavior`, and `requiredReviewer` where applicable;
+- `proposedPostureChange`, which defaults to none and never applies automatically;
+- `policyVersion`, `corpusVersion`, and answer timestamp.
+
+The user-facing answer is generated only from this validated structure. If a citation is missing, does not support its claim, is stale beyond policy, or applies to a different provider service/account class, the affected claim is removed and the answer becomes conditional or `cannot_substantiate`.
+
+### Reliability evidence
+
+- Maintain a versioned golden-question suite spanning ordinary small-business, EMEA/UK transfer, healthcare, financial, employment, public-sector, consumer-account, business/API-account, region, retention/training, stale-evidence, conflicting-source, and out-of-scope questions.
+- Require 100% citation presence for material external claims and zero known unsupported material claims in the golden suite. Citation validation checks entailment and applicability, not merely that a URL exists.
+- Score direct-answer correctness, source authority, source freshness, claim/citation alignment, scope accuracy, safe abstention, follow-up quality, plain-language readability, policy consistency, and sensitive-data leakage.
+- Include adversarial questions that invite overconfidence, ask about a similarly named provider product, rely on outdated terms, or omit the account class/jurisdiction.
+- Test both the bundled local model and deterministic fallback. A stronger approved model may improve explanation, but it must pass the same structure and evidence gates.
+- Route missing-topic, weak-retrieval, stale-source, and citation-mismatch findings through the existing `ProfessionCorpusUsageStat` / `ProfessionCorpusGap` learning loop for governed corpus repair.
+
 ## Governed decision contract
 
 Implement one pure, versioned evaluation contract shared by onboarding, provider activation, provider settings, and routing.
@@ -224,8 +266,11 @@ Each phase is one independently reviewable concern/PR. Build Studio should promo
 3. Define the A2A objective/result schema around the Phase 1 contract. The COO gathers facts and calls `request_coworker`; AGT-902 assesses and cites; the COO explains.
 4. Keep the initial response within the local served-model/tool budget. Retrieve only the relevant jurisdiction/industry pages and return a concise result.
 5. Add a deterministic no-LLM fallback that computes the same verdict from captured facts and clearly marks missing evidence.
+6. Implement the grounded questions-and-answers contract for onboarding and later provider-detail follow-ups, using the same AGT-902 A2A path rather than a second compliance chatbot.
+7. Resolve references at claim level and validate source authority, freshness, applicability, and claim support before rendering an answer.
+8. Add a compact inline-reference and “Review sources” projection to the existing coworker conversation; do not create a separate knowledge or compliance route.
 
-**Verification:** corpus-source and freshness tests; AGT-902 wiring test; A2A chain-of-custody test; local-only onboarding simulation with the cloud providers disabled; structured-output/fallback equivalence scenarios.
+**Verification:** corpus-source and freshness tests; AGT-902 wiring test; A2A chain-of-custody test; local-only onboarding simulation with the cloud providers disabled; structured-output/fallback equivalence scenarios; golden-question and adversarial suites; claim-level citation presence/entailment/applicability checks; stale/conflicting/missing evidence abstention; first-viewport answer and source-disclosure browser verification.
 
 **Rollback:** corpus and prompt changes are reversible and do not activate providers. If the A2A call fails, the deterministic evaluator remains authoritative.
 
@@ -352,6 +397,10 @@ At minimum, the end-to-end suite must cover:
 13. A first-time, non-technical operator chooses between a personal account, business-managed cloud account, and local inference: the flow recommends one path, explains the practical consequence without jargon, previews what DPF will enforce, and the operator correctly identifies the safe choice without opening technical evidence.
 14. DPF blocks a cloud request after setup because a tool result adds customer data: the explanation names what was protected, states what DPF did, and offers one useful recovery action without displaying the detected value or a raw policy code.
 15. Provider evidence is missing or stale: the product says what it could and could not verify, avoids a compliance claim, restricts the route, and directs the operator to the exact evidence or qualified review needed.
+16. A non-technical operator asks whether their personal provider account can process customer emails: AGT-902 gives a direct workload-specific answer, cites the applicable current provider terms and privacy basis beside the supported claims, distinguishes declared account ownership from verified facts, and explains the safe next action.
+17. The operator asks whether data “stays in Europe,” but the configured provider service/region or contract evidence is missing: the coworker asks the smallest clarifying question or returns `cannot_substantiate`, keeps the interim route restricted, and does not substitute a general GDPR explanation for the missing provider fact.
+18. Two current authoritative sources appear to conflict or a provider source changed after the corpus summary: the answer exposes the conflict/date, avoids a definitive claim, identifies which source controls or which reviewer must decide, and files the corpus freshness gap.
+19. A citation URL is valid but its text does not support the generated claim or applies to a different account class: validation removes the claim, downgrades the answer state, and prevents the unsupported advice from reaching the operator.
 
 ## Research and standards grounding
 
@@ -405,3 +454,7 @@ The implementation should cite primary legal/regulatory texts in the profession 
 - First-viewport business copy meets the platform readability target and does not expose unexplained provider, routing, privacy, or regulatory jargon.
 - Representative non-technical participants can state the recommendation, data movement, automatic safeguards, missing action, and later review location with at least the comprehension threshold defined above.
 - Operators experience restrictions as evidence that DPF is protecting their business: every block explains the protected concern, the action DPF took, and one safe recovery path.
+- Operators can ask natural-language follow-up questions during onboarding and later from the provider detail experience without navigating to a separate compliance tool.
+- Every material external claim in the governed evaluation suite has an authoritative, current, applicable, claim-level reference; unsupported claims are withheld rather than merely accompanied by a generic link.
+- AGT-902 clearly separates sourced facts, organization declarations, technical verification, recommendation, uncertainty, and required human review.
+- Missing, stale, conflicting, or inapplicable evidence produces a safe conditional/abstaining answer and cannot broaden routing posture.

--- a/docs/superpowers/plans/2026-07-19-governed-llm-provider-onboarding.md
+++ b/docs/superpowers/plans/2026-07-19-governed-llm-provider-onboarding.md
@@ -22,6 +22,7 @@ The implementation is complete only when guidance and enforcement agree:
 - failure is closed: use a cleared local route when it is capable, otherwise block and explain the recovery action;
 - audit evidence is useful without retaining unnecessary raw prompts, credentials, or personal data;
 - the same posture is visible and repairable after onboarding at `/platform/ai/providers`.
+- a non-technical operator can understand what DPF recommends, what it will prevent, and what decision still belongs to them without learning provider or regulatory jargon first.
 
 This is decision support and technical policy enforcement, not legal advice or a claim of “absolute compliance.” A regulated or ambiguous posture must say what is known, what evidence is missing, and when qualified human review is required.
 
@@ -73,6 +74,59 @@ This work must extend the following sources of truth instead of creating paralle
 - Recovery: unknown account class, missing evidence, unreachable local runtime, or inadequate local capability must produce a clear blocked/conditional state and a route to repair it.
 - Lifecycle: the provider page must show posture, evidence age, allowed data classes/workloads, and reassessment action after onboarding.
 - Theme/accessibility: use shared tokens and status components; convey status in text as well as color; keep keyboard and screen-reader behavior in the existing setup/provider interaction patterns.
+
+**UX fit review — governed provider onboarding**
+
+- Decision: `fits-with-guardrails`.
+- Owning area: Platform, embedded contextually in setup.
+- Route family: `/platform/ai/providers` and its existing provider detail routes.
+- Primary persona: a founder/operator choosing AI services without technical, privacy, security, or procurement expertise.
+- Navigation layer touched: setup workflow and local/contextual actions only; no global or section navigation change.
+- Reuse/convergence: existing setup overlay, coworker panel, provider detail form, routing-eligibility projection, shared status/loading primitives, and native progressive-disclosure patterns.
+- Source truth: the versioned provider-governance posture compiled from organization, workload, provider, account, and evidence facts.
+- Empty/failure behavior: safe restricted posture plus one honest recovery action; never an empty scorecard, raw `unknown`, or a green status inferred from connectivity alone.
+- AI boundary: consultation and explanation may start through visible A2A; provider activation and any broadened allowance require explicit operator action.
+- Evidence before merge: plain-language/readability checks, fresh-install and failure-state browser exercises, mobile/keyboard/screen-reader coverage, and comprehension/usability testing with non-technical participants.
+- Captured in: this plan’s trust contract, Phase 3 verification, cross-phase scenarios, and definition of done.
+
+## Trust and confidence experience contract
+
+DPF should feel like a knowledgeable coworker keeping the operator out of avoidable trouble—not like a compliance questionnaire, a frightening warning wall, or a provider catalog that leaves the hard decision to them. Confidence must come from demonstrated competence and visible control, never from vague reassurance.
+
+Every provider decision experience follows this sequence:
+
+1. **Translate the decision.** Start with the business question: “What kind of information will you use, and who could be affected?” Explain unfamiliar terms in place. Do not require the operator to know “DPA,” “controller,” “data residency,” or provider account taxonomy before proceeding.
+2. **Recommend a safe default.** DPF makes a clear recommendation based on the company and intended work. The operator should not have to compare technical specifications or interpret provider terms unaided.
+3. **Show the reason in human terms.** Lead with the practical consequence: what may leave the business, where it may go, who controls the account, and what DPF will allow or prevent. Put formal basis, source dates, and technical detail behind progressive disclosure.
+4. **Demonstrate the safeguard.** State the protection as an active behavior: “DPF will keep customer records on this device,” “DPF will block this provider for payroll work,” or “DPF will ask you before enabling cloud use.” Do not use a generic green shield or “compliant” badge as a substitute for the behavior.
+5. **Give one next action.** Offer the safest useful action first—use local, create/connect a business-managed account, provide missing evidence, or ask a qualified reviewer. Avoid multi-option warning dialogs that make the operator design the policy.
+6. **Keep protecting after setup.** Recheck every route and surface a calm, specific explanation when DPF prevents an unsafe action. The product should make the safe choice easy and the unsafe choice difficult or unavailable.
+7. **Be honest about the boundary.** Say when DPF lacks evidence, when a provider’s terms may have changed, or when legal/DPO/security review is appropriate. “We need one more fact before using this provider for customer data” builds more trust than an unsupported assurance.
+
+### Copy and interaction rules
+
+- Default business-facing copy targets Flesch–Kincaid grade 9 or lower and reading ease 55 or higher, following `docs/platform-usability-standards.md`.
+- Lead with familiar language. Show the formal term second when it helps: “A business data agreement (DPA).”
+- Avoid blame and alarmism. Prefer “This personal account is fine for public drafts, but DPF will not send customer or employee information to it” over “Compliance violation.”
+- Avoid legal conclusions and absolute claims such as “fully compliant,” “zero leak,” “risk-free,” or “DPF guarantees compliance.”
+- Distinguish four evidence levels in plain language: what the operator told DPF, what DPF verified technically, what provider/contract sources state, and what DPF inferred from policy.
+- Never expose confidence percentages, raw policy ids, model scores, regulation lists, or routing internals in the first viewport. They remain available in “Why?” / “Review evidence” for reviewers who need them.
+- During the A2A consultation, show a short, reassuring activity label such as “Checking this choice against your business and data needs,” then summarize what information was shared with the specialist.
+- A blocked state always names the protected business concern and gives one recovery action. It does not dead-end or suggest bypassing the safeguard.
+- Confirmation copy previews the effect before activation: permitted work, excluded work, destination/region, and how to change the decision later.
+- Persistent status language describes behavior (`Customer data stays local`, `Cloud allowed for public content only`) rather than abstract grades (`Low risk`, `Tier 2`, `Clearance 3`).
+
+### Confidence evidence
+
+Usability verification must demonstrate that representative non-technical participants can answer these questions after the flow without help:
+
+1. Which provider/account does DPF recommend, and why?
+2. What information may leave the installation?
+3. What will DPF automatically block or keep local?
+4. What fact or action is still missing?
+5. Where can the operator review or change the decision later?
+
+Run formative sessions with at least five representative participants. Passing means at least 80% answer all five correctly and complete the safe path without opening technical evidence. Qualitative feedback must also confirm that the flow feels protective and competent rather than punitive, confusing, or falsely reassuring.
 
 ## Governed decision contract
 
@@ -198,8 +252,10 @@ Each phase is one independently reviewable concern/PR. Build Studio should promo
 5. Change `activateProvider()` so cloud clearance is derived from approved posture, not merely from provider category. Eliminate the current blanket cloud default of public/internal/confidential.
 6. Allow a restricted evaluation mode for public/synthetic tests when company/account evidence is incomplete. Never infer general business clearance from a successful API call.
 7. Existing local bootstrap remains available, but its capability/clearance is evaluated rather than presumed.
+8. Implement the trust contract: plain-language question framing, active-safeguard statements, one recommended next action, evidence-level labels, activation-effect preview, and calm blocked/recovery states.
+9. Add a persistent behavioral summary on the provider detail surface so the operator can later see what DPF is protecting without reconstructing the onboarding conversation.
 
-**Verification:** step-order and migration-of-in-progress-setup tests; activation-path invariants; personal-account, business-account, unknown-account, EMEA, regulated, skip, and A2A-failure UI scenarios; keyboard/screen-reader checks; live UX verification in the governed nonprod environment.
+**Verification:** step-order and migration-of-in-progress-setup tests; activation-path invariants; personal-account, business-account, unknown-account, EMEA, regulated, skip, and A2A-failure UI scenarios; grade-9/readability checks for first-viewport business copy; comprehension testing against the five confidence questions; keyboard/screen-reader checks; mobile and live UX verification in the governed nonprod environment.
 
 **Rollback:** preserve captured posture while feature-flagging the activation gate. A rollback may restore the old setup order, but must not broaden a provider whose posture was explicitly restricted.
 
@@ -293,6 +349,9 @@ At minimum, the end-to-end suite must cover:
 10. Evidence expires or the company adds an EMEA customer market: posture is invalidated, attention appears, and cloud allowance narrows until reassessed.
 11. A coworker proposes a destructive external action during setup: the existing `CoworkerActionEnvelope` requires explicit approval and preserves chain of custody.
 12. Retention runs under a regulated industry floor or active hold: required evidence remains; eligible operational telemetry is purged without orphaning relations.
+13. A first-time, non-technical operator chooses between a personal account, business-managed cloud account, and local inference: the flow recommends one path, explains the practical consequence without jargon, previews what DPF will enforce, and the operator correctly identifies the safe choice without opening technical evidence.
+14. DPF blocks a cloud request after setup because a tool result adds customer data: the explanation names what was protected, states what DPF did, and offers one useful recovery action without displaying the detected value or a raw policy code.
+15. Provider evidence is missing or stale: the product says what it could and could not verify, avoids a compliance claim, restricts the route, and directs the operator to the exact evidence or qualified review needed.
 
 ## Research and standards grounding
 
@@ -343,3 +402,6 @@ The implementation should cite primary legal/regulatory texts in the profession 
 - Existing active providers are reassessed without fabricated facts, and operators have a clear repair path.
 - Legal/compliance corpus sources are primary, dated, and included in freshness/evidence tests.
 - Live UX verification confirms the first-viewport recommendation, details, skip/restriction behavior, A2A consultation, provider repair, and failure states.
+- First-viewport business copy meets the platform readability target and does not expose unexplained provider, routing, privacy, or regulatory jargon.
+- Representative non-technical participants can state the recommendation, data movement, automatic safeguards, missing action, and later review location with at least the comprehension threshold defined above.
+- Operators experience restrictions as evidence that DPF is protecting their business: every block explains the protected concern, the action DPF took, and one safe recovery path.

--- a/docs/superpowers/plans/2026-07-19-governed-llm-provider-onboarding.md
+++ b/docs/superpowers/plans/2026-07-19-governed-llm-provider-onboarding.md
@@ -81,6 +81,7 @@ This work must extend the following sources of truth instead of creating paralle
 - Owning area: Platform, embedded contextually in setup.
 - Route family: `/platform/ai/providers` and its existing provider detail routes.
 - Primary persona: a founder/operator choosing AI services without technical, privacy, security, or procurement expertise.
+- Primary coworker persona: the COO—the owner’s enduring operational counterpart who has their back, owns the conversation, and coordinates specialist expertise on their behalf.
 - Navigation layer touched: setup workflow and local/contextual actions only; no global or section navigation change.
 - Reuse/convergence: existing setup overlay, coworker panel, provider detail form, routing-eligibility projection, shared status/loading primitives, and native progressive-disclosure patterns.
 - Source truth: the versioned provider-governance posture compiled from organization, workload, provider, account, and evidence facts.
@@ -92,6 +93,18 @@ This work must extend the following sources of truth instead of creating paralle
 ## Trust and confidence experience contract
 
 DPF should feel like a knowledgeable coworker keeping the operator out of avoidable trouble—not like a compliance questionnaire, a frightening warning wall, or a provider catalog that leaves the hard decision to them. Confidence must come from demonstrated competence and visible control, never from vague reassurance.
+
+The COO is the human-facing relationship throughout this experience. The owner should not need to know which specialist coworker, corpus, model, or policy engine to ask. They ask the COO; the COO recognizes when data-governance expertise is needed, consults AGT-902 through A2A, checks the substantiation, and returns one coherent answer in the existing conversation. The COO remains accountable for helping the owner understand the choice and complete the safe next step.
+
+“Has the owner’s back” has specific interaction meaning:
+
+- the COO notices material risk and missing evidence without waiting for the owner to use compliance vocabulary;
+- the COO raises concerns early, calmly, and in the context of the owner’s intended work;
+- the COO does the coordination and synthesis instead of handing the owner to another chatbot or exposing an agent directory;
+- the COO can say “I checked this with our data-governance specialist” and show the supporting references, while remaining the speaker and guide;
+- the COO remembers the confirmed company/provider posture within governed context and does not make the owner repeat it unnecessarily;
+- the COO follows a blocked or conditional answer with the next useful action and stays with the owner through resolution;
+- the COO is candid about uncertainty and brings in a qualified human when needed rather than protecting the appearance of competence by guessing.
 
 Every provider decision experience follows this sequence:
 
@@ -130,7 +143,7 @@ Run formative sessions with at least five representative participants. Passing m
 
 ## Grounded questions and answers contract
 
-The same Data Governance coworker remains available during onboarding and from the provider detail experience afterward. A non-technical operator can ask follow-up questions in ordinary language—“Can I use this for customer emails?”, “Why does a business account matter?”, “Does this stay in Europe?”, or “What do I need before payroll data is allowed?”—without knowing which regulation, provider document, or technical setting to inspect.
+The COO remains available during onboarding and from the provider detail experience afterward, using AGT-902 as the responsible data-governance specialist behind the existing A2A boundary. A non-technical operator can ask the COO follow-up questions in ordinary language—“Can I use this for customer emails?”, “Why does a business account matter?”, “Does this stay in Europe?”, or “What do I need before payroll data is allowed?”—without knowing which coworker, regulation, provider document, or technical setting to inspect.
 
 Reliability means evidence-grounded answers with a safe refusal boundary, not merely fluent prose. Every material answer must satisfy this contract:
 
@@ -147,7 +160,7 @@ Reliability means evidence-grounded answers with a safe refusal boundary, not me
 
 ### Structured answer contract
 
-The A2A response and deterministic fallback share one validated shape:
+The specialist A2A response and deterministic fallback share one validated shape, which the COO consumes and explains:
 
 - `answerState`: `substantiated | conditional | cannot_substantiate`;
 - `directAnswer` and `practicalMeaning` in plain language;
@@ -246,9 +259,9 @@ Each phase is one independently reviewable concern/PR. Build Studio should promo
 
 **Rollback:** evaluator remains dark/read-only until Phase 3. If a migration is needed, make it additive and preserve current provider state; disabling the feature flag restores current behavior without deleting evidence.
 
-### Phase 2 — Legal/compliance corpus and AGT-902 A2A advice
+### Phase 2 — COO-led legal/compliance advice through AGT-902 A2A
 
-**Deliverable:** The Data Governance coworker can return a small, cited, structured provider recommendation from company/workload context while the install is local-only.
+**Deliverable:** The COO can give the owner a small, cited, structured provider recommendation from company/workload context while the install is local-only, consulting AGT-902 behind the scenes without transferring ownership of the conversation.
 
 **Files likely affected:**
 
@@ -269,8 +282,10 @@ Each phase is one independently reviewable concern/PR. Build Studio should promo
 6. Implement the grounded questions-and-answers contract for onboarding and later provider-detail follow-ups, using the same AGT-902 A2A path rather than a second compliance chatbot.
 7. Resolve references at claim level and validate source authority, freshness, applicability, and claim support before rendering an answer.
 8. Add a compact inline-reference and “Review sources” projection to the existing coworker conversation; do not create a separate knowledge or compliance route.
+9. Preserve one human-facing thread and COO voice. The UI may show that the COO consulted the Data Governance specialist and what bounded context was shared, but it must not require the owner to open, summon, or manage AGT-902 directly.
+10. Ensure the COO owns follow-through: missing evidence, a required account change, or human review becomes a guided next action in the same conversation rather than a specialist handoff dead end.
 
-**Verification:** corpus-source and freshness tests; AGT-902 wiring test; A2A chain-of-custody test; local-only onboarding simulation with the cloud providers disabled; structured-output/fallback equivalence scenarios; golden-question and adversarial suites; claim-level citation presence/entailment/applicability checks; stale/conflicting/missing evidence abstention; first-viewport answer and source-disclosure browser verification.
+**Verification:** corpus-source and freshness tests; AGT-902 wiring test; A2A chain-of-custody test; local-only onboarding simulation with the cloud providers disabled; structured-output/fallback equivalence scenarios; golden-question and adversarial suites; claim-level citation presence/entailment/applicability checks; stale/conflicting/missing evidence abstention; first-viewport answer and source-disclosure browser verification; conversation-continuity test proving the owner asks and receives the answer from the COO while the specialist consultation remains visible evidence rather than a second user-managed persona.
 
 **Rollback:** corpus and prompt changes are reversible and do not activate providers. If the A2A call fails, the deterministic evaluator remains authoritative.
 
@@ -401,6 +416,8 @@ At minimum, the end-to-end suite must cover:
 17. The operator asks whether data “stays in Europe,” but the configured provider service/region or contract evidence is missing: the coworker asks the smallest clarifying question or returns `cannot_substantiate`, keeps the interim route restricted, and does not substitute a general GDPR explanation for the missing provider fact.
 18. Two current authoritative sources appear to conflict or a provider source changed after the corpus summary: the answer exposes the conflict/date, avoids a definitive claim, identifies which source controls or which reviewer must decide, and files the corpus freshness gap.
 19. A citation URL is valid but its text does not support the generated claim or applies to a different account class: validation removes the claim, downgrades the answer state, and prevents the unsupported advice from reaching the operator.
+20. The owner asks the COO a provider-compliance question: the COO recognizes the capability boundary, consults AGT-902 through A2A, validates and synthesizes the result, and answers in the same thread. The owner sees that specialist expertise was consulted but is never told to locate, summon, or continue with a different coworker.
+21. AGT-902 needs one more fact or qualified human review: the COO asks the clarifying question or guides the escalation, keeps the safe interim posture, and remains the owner’s point of contact through resolution.
 
 ## Research and standards grounding
 
@@ -458,3 +475,5 @@ The implementation should cite primary legal/regulatory texts in the profession 
 - Every material external claim in the governed evaluation suite has an authoritative, current, applicable, claim-level reference; unsupported claims are withheld rather than merely accompanied by a generic link.
 - AGT-902 clearly separates sourced facts, organization declarations, technical verification, recommendation, uncertainty, and required human review.
 - Missing, stale, conflicting, or inapplicable evidence produces a safe conditional/abstaining answer and cannot broaden routing posture.
+- The COO is the single human-facing owner of onboarding and follow-up provider guidance; AGT-902 supplies governed specialist evidence through A2A without becoming a separate journey the owner must manage.
+- Usability participants consistently identify the COO as the coworker looking out for the business and can explain that the COO consults specialists when needed.

--- a/docs/superpowers/plans/2026-07-19-governed-llm-provider-onboarding.md
+++ b/docs/superpowers/plans/2026-07-19-governed-llm-provider-onboarding.md
@@ -454,6 +454,12 @@ The implementation should cite primary legal/regulatory texts in the profession 
 - **Retention conflict:** privacy deletion and regulated audit/incident retention can conflict. The existing policy registry, floors, and holds arbitrate; no universal short window.
 - **Related work:** coordinate healthcare-specific scenarios with BI-HEALTHCARE-053 and coworker authority work with EP-31815F97 rather than duplicating their controls.
 
+### Future extension — owner-chosen conversational name for the COO
+
+Tracked separately as **BI-ADEF2982**. A future setup step may let the owner keep “COO,” select a suggested form of address, or enter an organization-visible conversational name for the standing COO. This is intentionally not part of the provider-governance delivery phases and does not block them.
+
+The extension must layer presentation over the stable identity rather than rename the agent: `AGT-ORCH-000`, canonical `Agent.displayName = COO`, role, grants, A2A routing, and authenticated action attribution remain unchanged. A role-preserving presentation such as “<chosen name> · AI COO” keeps the relationship warm while remaining honest. The feature requires explicit reconsideration of the ratified role-only decision in `docs/superpowers/specs/2026-07-18-coo-persona-attribution-contract-design.md`, organization-scoped persistence review, setup-to-standing-COO handoff coverage, safe default/skip, later edit/clear, and usability evidence that owners do not mistake personalization for human identity or expanded authority.
+
 ## Definition of done
 
 - The plan’s six phases have shipped through separate reviewable PRs with the mandatory build gate appropriate to each phase.

--- a/docs/superpowers/plans/2026-07-19-governed-llm-provider-onboarding.md
+++ b/docs/superpowers/plans/2026-07-19-governed-llm-provider-onboarding.md
@@ -1,0 +1,345 @@
+# Governed LLM Provider Onboarding Implementation Plan
+
+**Backlog item:** BI-C98C6AB7
+
+**Status:** Ready for Build Studio planning and phased delivery
+
+**Date:** 2026-07-19
+
+**Scope:** Provider selection, account ownership, sovereignty, compliance-coworker advice, activation, routing enforcement, data-loss prevention, retention, and existing-install remediation
+
+## Outcome
+
+DPF must help a company decide whether an LLM provider and account are appropriate before credentials make that provider routable, then enforce the resulting decision on every inference route. The experience begins with a small local model, gathers the minimum company and workload context needed for a defensible recommendation, asks the Data Governance coworker for evidence-backed advice through the existing A2A interface, and presents one clear recommendation with its reason and next action.
+
+The implementation is complete only when guidance and enforcement agree:
+
+- a personal/consumer account is never silently treated as suitable for business data;
+- provider reachability is not mistaken for contractual or regulatory suitability;
+- the selected account, region, retention/training terms, workload, and data class compile into routing policy;
+- sensitive data is inspected immediately before external egress as defense in depth;
+- an unapproved cloud route is excluded even if it is technically healthy and inexpensive;
+- failure is closed: use a cleared local route when it is capable, otherwise block and explain the recovery action;
+- audit evidence is useful without retaining unnecessary raw prompts, credentials, or personal data;
+- the same posture is visible and repairable after onboarding at `/platform/ai/providers`.
+
+This is decision support and technical policy enforcement, not legal advice or a claim of “absolute compliance.” A regulated or ambiguous posture must say what is known, what evidence is missing, and when qualified human review is required.
+
+## Why the advisor review changes the plan
+
+The external review correctly identifies that education alone is too weak. Its useful contribution is a systemic control plane: inspect before egress, gate activation, enforce hard action floors, minimize retained payloads, and keep platform guardrails outside editable prompts. The implementation adopts that direction while changing mechanisms that would create false assurance.
+
+| Advisor proposal | Disposition | DPF implementation |
+| --- | --- | --- |
+| Local “Zero Leak” regex/NER interceptor before network calls | **Adopt with guardrails** | Add one canonical pre-egress policy stage for every routed inference. Structured `RequestContract` sensitivity and onboarding-derived data classes are primary; local content inspection is defense in depth. Redact only when task semantics and policy permit it; otherwise route locally or block. Regex/NER alone never establishes safety. |
+| Verify keys with `/v1/models` and infer consumer/business tier | **Split** | Keep the reachability/authentication/model-discovery handshake. Do not infer account class, training terms, DPA, residency, or enterprise controls from that endpoint. Require an operator declaration plus dated provider/contract evidence; use provider-specific account APIs only where they authoritatively expose a fact. Unknown evidence produces restricted or non-routable posture. |
+| Delete all raw payload histories after seven days | **Replace with policy-driven minimization** | Redact or avoid raw payloads at write time, then use the existing retention registry, industry floors, legal/incident holds, and dataset-specific windows. Do not put interceptor events into `DecisionInteraction` by default. Preserve compact policy-decision evidence in `RouteDecisionLog`/security audit surfaces without storing the sensitive value. |
+| Hard risk floors and physical approval for destructive multi-step actions | **Reuse existing substrate** | Keep destructive/outbound action approval in `CoworkerActionEnvelope`; do not create a parallel action-envelope model. Provider activation is an explicit operator act. Ordinary approved inference does not require repeated approval, but it must pass policy on every route. |
+| Archetype-locked immutable system preambles | **Adopt as defense in depth** | Reuse the immutable platform preamble and onboarding risk-envelope substrate. Add company jurisdiction, market, product/customer, account, and workload posture as governed context. Prompts explain and steer; routing, activation, authorization, and tool layers enforce. Archetype alone is not a compliance decision. |
+
+Two advisor assumptions are explicitly rejected:
+
+1. “Local” does not automatically mean compliant. Local capability, access control, encryption, host location, retention, and operational controls still matter.
+2. Fallback does not always mean “send to local.” If no local model is capable or cleared, DPF must block/escalate rather than silently degrade the work or leak data.
+
+## Existing substrate to extend
+
+This work must extend the following sources of truth instead of creating parallel concepts:
+
+- setup sequence and routes: `apps/web/lib/actions/setup-constants.ts`, `apps/web/components/setup/SetupOverlay.tsx`;
+- company/market derivation: `apps/web/lib/onboarding/archetype-business-context.ts`, `apps/web/lib/onboarding/capture-market-context.ts`, `StorefrontConfig.archetypeId`, and business-context records;
+- provider configuration and the one activation entry point: `ModelProvider`, `apps/web/lib/actions/ai-providers.ts`, `apps/web/lib/govern/activate-provider.ts`;
+- provider/operator UX: `apps/web/app/(shell)/platform/ai/providers/`, `apps/web/components/platform/ProviderDetailForm.tsx`, `apps/web/lib/routing/provider-routing-eligibility.ts`;
+- inference policy: `RequestContract.sensitivity`, `residencyPolicy`, `allowedProviders`, endpoint `sensitivityClearance`, and the canonical v2 routing pipeline;
+- audit: `RouteDecisionLog`, `AuthorizationDecisionLog`, `SecurityEvent`, and `ToolExecution` summaries rather than raw secret-bearing payloads;
+- destructive/outbound approvals: `CoworkerActionEnvelope`;
+- retention: `apps/web/lib/operate/retention/policies.ts`, industry floors, retained-dataset guard tests, and the existing retention engine;
+- A2A: `request_coworker`/`summon_coworker`, delegation chain of custody, the COO onboarding prompt, and AGT-902 Data Governance Agent;
+- profession knowledge: `docs/professions/legal-compliance/wiki/` and the generated/indexed profession corpus;
+- immutable prompt protection: the existing TAK platform preamble and onboarding risk-envelope/profile flow.
+
+`ModelProvider.catalogEntry` may hold typed, seeded vendor/service facts, but install-specific account declarations and evidence must remain distinguishable from catalog claims. The first delivery slice must complete a schema-impact check before choosing whether the install-specific posture fits typed fields on `ModelProvider` or needs a related evidence record. It must not create a second provider or credential aggregate.
+
+## Architecture and UX review
+
+**Architecture verdict: aligned with concerns.** The design reuses the canonical provider, request-contract, routing, retention, action-envelope, A2A, and corpus substrates. The key architecture constraint is to compile one governed provider/workload posture and consume it at activation, eligibility projection, and runtime routing. UI badges and coworker prose are projections of that policy result, never separate policy stores.
+
+**UX verdict: fits with guardrails.** Keep provider advice embedded in setup and on the existing provider pages; add no new global navigation, dashboard, or one-off compliance wizard.
+
+- Served persona: a solo founder or business operator who may not know the difference between a consumer subscription, API account, enterprise agreement, region, or data-processing term.
+- First viewport: one recommendation (`Recommended`, `Conditional`, or `Not suitable`), one plain-language reason, and one next action. Put evidence, citations, alternatives, and uncertainty behind “Why?” / “Review evidence.”
+- A2A boundary: show that the COO is consulting the Data Governance coworker and preserve the delegation/audit chain. The local model may initiate the structured consultation; it may not activate cloud or invent missing facts.
+- Skipping: company context may be deferred, but cloud activation must then remain restricted to public/synthetic evaluation data. Do not let “Skip” turn missing facts into approval.
+- Recovery: unknown account class, missing evidence, unreachable local runtime, or inadequate local capability must produce a clear blocked/conditional state and a route to repair it.
+- Lifecycle: the provider page must show posture, evidence age, allowed data classes/workloads, and reassessment action after onboarding.
+- Theme/accessibility: use shared tokens and status components; convey status in text as well as color; keep keyboard and screen-reader behavior in the existing setup/provider interaction patterns.
+
+## Governed decision contract
+
+Implement one pure, versioned evaluation contract shared by onboarding, provider activation, provider settings, and routing.
+
+### Inputs
+
+- organization country and exact operating/customer jurisdictions;
+- industry/market and applicable regulated-business signals;
+- products/services and customer types (consumer, children, patient, employee, financial client, public sector, etc.);
+- intended AI workloads;
+- declared input/output data classes and sensitivity;
+- required data residency/sovereignty posture;
+- provider/service/model and selected region;
+- credential owner (`organization` versus `individual`) and declared account class (`business_api`, `enterprise`, `consumer_subscription`, `unknown`);
+- provider terms relevant to training, retention, subprocessors, residency, access, and DPA/BAA/contract coverage;
+- evidence source, captured date, last verified date, and review/expiry date;
+- local runtime capability and clearance for the workload.
+
+Never store API keys, tokens, contract contents containing secrets, or detected sensitive values in this contract.
+
+### Result
+
+Return a stable structured result suitable for both a small local model and deterministic fallback:
+
+- `verdict`: `recommended | conditional | not_suitable | unknown`;
+- `allowedDataClasses` and `prohibitedDataClasses`;
+- `allowedWorkloadTags` and `prohibitedWorkloadTags`;
+- `residencyPolicy`: `local_only | approved_cloud` (do not generate `any_enabled` from onboarding);
+- `allowedProviders` and, where required, allowed regions/models;
+- `requiredActions` and missing evidence;
+- concise reason and user-facing explanation;
+- evidence citations and their dates;
+- policy version and evaluation timestamp;
+- escalation requirement.
+
+The result must be deterministic for a fixed input/evidence set. The coworker may explain, compare alternatives, and ask for missing facts, but cannot broaden the compiled allowance.
+
+### Enforcement semantics
+
+1. Activation is transactional: valid credentials plus discovery are necessary but insufficient. `activateProvider()` must receive or resolve an approved governance posture before a cloud provider becomes generally routable.
+2. A consumer/personal or unknown account is not silently forbidden for every possible use; it is restricted to explicitly allowed public/synthetic evaluation workloads unless authoritative evidence and company policy permit more.
+3. The runtime merges the onboarding posture with the per-request `RequestContract`. The stricter sensitivity, residency, provider, region, and workload constraint wins.
+4. Immediately before an external adapter sends bytes, a pre-egress guard revalidates the selected endpoint and inspects the final serialized request. This prevents alternate call paths or late prompt/tool-result additions from bypassing policy.
+5. Content inspection yields metadata only: categories, confidence, action, policy version, and salted/deterministic fingerprint where needed for correlation. It never logs the matched value.
+6. `redact` is allowed only when the policy identifies a safe transformation and the transformed payload still satisfies the task. Otherwise choose an eligible local route; if none exists, block with an operator-readable reason.
+7. Provider terms or organization facts changing invalidates/reassesses posture. Stale evidence cannot remain indefinitely “approved.”
+
+## Delivery sequence
+
+Each phase is one independently reviewable concern/PR. Build Studio should promote the phases separately rather than attempt one x-large implementation PR.
+
+### Phase 1 — Policy contract, evidence model, and deterministic fixtures
+
+**Deliverable:** A typed, pure provider-governance evaluator and persistence decision grounded in the existing schema.
+
+**Files likely affected:**
+
+- `apps/web/lib/govern/provider-governance-types.ts` (new);
+- `apps/web/lib/govern/evaluate-provider-posture.ts` (new);
+- colocated unit tests and scenario fixtures;
+- `packages/db/prisma/schema.prisma` and one new migration only if the schema-impact check proves existing typed fields/JSON cannot preserve install-specific evidence cleanly;
+- `packages/db/src/seed.ts` or the canonical provider-catalog seed owner for vendor/service facts;
+- `docs/superpowers/specs/2026-06-20-onboarding-intake-derivation-design.md` for the settled contract and source-of-truth map.
+
+**Tasks:**
+
+1. Trace every `ModelProvider.status = active` path and every inference adapter entry point; add invariants so the centralized activation and pre-egress paths remain complete.
+2. Separate seeded vendor facts from organization/account declarations and evidence. Define closed enums before any data uses them.
+3. Implement jurisdiction/workload/account/evidence evaluation as a side-effect-free function.
+4. Add fixtures for EMEA, UK, healthcare, financial services, public-sector, consumer-account, unknown-evidence, local-incapable, and mixed-workload cases.
+5. Define evidence freshness and invalidation rules; unknown or expired evidence narrows access.
+
+**Verification:** targeted evaluator/schema tests; migration apply if added; seed idempotency; enum and activation-path invariant tests.
+
+**Rollback:** evaluator remains dark/read-only until Phase 3. If a migration is needed, make it additive and preserve current provider state; disabling the feature flag restores current behavior without deleting evidence.
+
+### Phase 2 — Legal/compliance corpus and AGT-902 A2A advice
+
+**Deliverable:** The Data Governance coworker can return a small, cited, structured provider recommendation from company/workload context while the install is local-only.
+
+**Files likely affected:**
+
+- new or extended pages under `docs/professions/legal-compliance/wiki/` for provider-account governance, cross-border/provider due diligence, AI data minimization, and regulated-industry escalation;
+- profession-corpus manifest/index/seed owner and corpus evidence tests;
+- `prompts/specialist/data-governance-agent.prompt.md`;
+- `prompts/route-persona/onboarding-coo.prompt.md` (confirm actual canonical slug before edit);
+- `apps/web/lib/mcp/packs/coworker-pack.ts` only if the existing structured result cannot be carried without changing its generic A2A contract;
+- A2A/delegation/corpus wiring tests.
+
+**Tasks:**
+
+1. Add primary-source, dated corpus entries for GDPR/UK GDPR, EU AI Act, DORA/NIS2 triggers, sectoral privacy, ISO/IEC 42001 governance, provider contracts/DPA evidence, residency versus access sovereignty, data minimization, and account ownership.
+2. Correct AGT-902’s profession-corpus assignment so the legal/compliance pages are actually retrieved for this task.
+3. Define the A2A objective/result schema around the Phase 1 contract. The COO gathers facts and calls `request_coworker`; AGT-902 assesses and cites; the COO explains.
+4. Keep the initial response within the local served-model/tool budget. Retrieve only the relevant jurisdiction/industry pages and return a concise result.
+5. Add a deterministic no-LLM fallback that computes the same verdict from captured facts and clearly marks missing evidence.
+
+**Verification:** corpus-source and freshness tests; AGT-902 wiring test; A2A chain-of-custody test; local-only onboarding simulation with the cloud providers disabled; structured-output/fallback equivalence scenarios.
+
+**Rollback:** corpus and prompt changes are reversible and do not activate providers. If the A2A call fails, the deterministic evaluator remains authoritative.
+
+### Phase 3 — Reorder setup and gate provider activation
+
+**Deliverable:** Setup captures enough company/workload context before provider selection, then prevents an unsuitable or unknown cloud account from becoming broadly routable.
+
+**Files likely affected:**
+
+- `apps/web/lib/actions/setup-constants.ts` and tests;
+- `apps/web/components/setup/SetupOverlay.tsx` and setup progress/actions tests;
+- canonical business-context capture/derivation modules;
+- `apps/web/components/platform/ProviderDetailForm.tsx` and tests;
+- `apps/web/lib/actions/ai-providers.ts`;
+- `apps/web/lib/govern/activate-provider.ts` and tests;
+- provider detail/list pages and eligibility projection tests.
+
+**Tasks:**
+
+1. Move the minimum company-context checkpoint before `ai-providers`. Do not duplicate the full storefront/business form; reuse its data owner and progressively ask only missing high-value facts.
+2. During the provider step, ask who owns the credential/account, its class, region, intended workloads, and the evidence the operator can substantiate.
+3. Run the visible COO → AGT-902 consultation and render one recommendation/reason/action, with evidence details progressively disclosed.
+4. Separate “credentials verified” from “approved for these workloads.” `/v1/models` (or equivalent) establishes reachability/model access only.
+5. Change `activateProvider()` so cloud clearance is derived from approved posture, not merely from provider category. Eliminate the current blanket cloud default of public/internal/confidential.
+6. Allow a restricted evaluation mode for public/synthetic tests when company/account evidence is incomplete. Never infer general business clearance from a successful API call.
+7. Existing local bootstrap remains available, but its capability/clearance is evaluated rather than presumed.
+
+**Verification:** step-order and migration-of-in-progress-setup tests; activation-path invariants; personal-account, business-account, unknown-account, EMEA, regulated, skip, and A2A-failure UI scenarios; keyboard/screen-reader checks; live UX verification in the governed nonprod environment.
+
+**Rollback:** preserve captured posture while feature-flagging the activation gate. A rollback may restore the old setup order, but must not broaden a provider whose posture was explicitly restricted.
+
+### Phase 4 — Runtime policy compilation and pre-egress guard
+
+**Deliverable:** Every inference route enforces the onboarding decision, and the final external payload passes a local pre-egress classification/redaction/block decision.
+
+**Files likely affected:**
+
+- `apps/web/lib/routing/request-contract.ts` and tests;
+- `apps/web/lib/routing/pipeline-v2.ts`, loader/eligibility modules, and scenario tests;
+- `apps/web/lib/inference/routed-inference.ts` and canonical adapter dispatch;
+- a new focused module such as `apps/web/lib/inference/pre-egress-policy.ts` plus tests;
+- `packages/integration-shared/src/redact.ts` only where its existing integration-input behavior can safely be generalized; do not overload it with provider-governance policy;
+- routing decision logging/telemetry writers.
+
+**Tasks:**
+
+1. Compile the active organization/provider/workload posture into `residencyPolicy`, `allowedProviders`, sensitivity clearance, region/model constraints, and workload tags.
+2. Merge constraints monotonically: no caller, prompt, tool result, model choice, or fallback may loosen them.
+3. Add a final adapter-boundary guard after prompt/tool assembly and before network I/O. Cover chat, responses, image/audio/file payloads, and alternate provider adapters.
+4. Use structured data classification first; add configurable country/industry-aware recognizers for unstructured content. Treat automated detection as fallible and test false-positive/false-negative handling.
+5. Return one of `allow`, `transform`, `reroute`, or `block`. A transformation records which fields/categories changed, never their values.
+6. Route policy denials into `RouteDecisionLog.excludedTrace`/`policyRulesApplied` and security telemetry with compact, masked evidence. Do not create a `DecisionInteraction` for routine routing decisions.
+7. Guard every fallback. A provider rejected for policy cannot reappear later in the fallback chain.
+
+**Verification:** unit/property tests for monotonic constraint merging; adapter coverage invariant; adversarial payload tests; no-sensitive-value logging tests; local reroute and no-capable-local block scenarios; production build and governed runtime inference exercises.
+
+**Rollback:** ship in observe-only mode first, compare decisions without retaining raw payloads, then enforce by workload class. A kill switch may block all external egress; it must never mean bypass the guard.
+
+### Phase 5 — Data minimization, retention, and audit evidence
+
+**Deliverable:** Provider-governance and DLP events are auditable while raw sensitive content is minimized and lifecycle-managed under existing policy.
+
+**Files likely affected:**
+
+- telemetry/audit writers for `RouteDecisionLog`, `ToolExecution`, and `SecurityEvent`;
+- `apps/web/lib/operate/retention/policies.ts`, industry floors, retained-dataset list, engine tests, and admin retention projection;
+- schema/migration only if field-level masked summaries or holds cannot use existing structures;
+- data-retention design spec and operator documentation.
+
+**Tasks:**
+
+1. Inventory fields where prompts, tool arguments/results, A2A context, or detected data can be persisted. Classify necessity and eliminate raw storage where not required.
+2. Redact/pseudonymize at write time. Store policy id/version, category, action, provider/route, actor, timestamps, and correlation ids; do not retain matches.
+3. Extend the central retention registry instead of adding a seven-day cleanup job. Dataset windows remain category-specific; industry floors only lengthen; regulated/incident/legal holds prevent purge.
+4. Define status-aware `DecisionInteraction` retention separately if this work touches those records; do not assume vector weights/confidence are sufficient audit evidence.
+5. Surface retention/evidence posture on provider and audit pages without exposing payloads.
+
+**Verification:** seeded-secret/PII canary tests across DB audit fields and logs; retention dry-run/apply tests; industry-floor and hold tests; deletion batching/index tests; admin projection test.
+
+**Rollback:** retention changes begin in report-only mode. A purge can be disabled through the existing scheduled-job control; raw-at-write minimization remains because rollback must not reintroduce sensitive logging.
+
+### Phase 6 — Existing-install remediation and lifecycle reassessment
+
+**Deliverable:** Existing active cloud providers are classified and repaired without surprise data egress, and posture remains current after onboarding.
+
+**Files likely affected:**
+
+- provider reconciliation/attention-source modules;
+- provider list/detail UX;
+- boot/reconciliation scheduling owner;
+- provider governance actions and tests;
+- setup progress only if a targeted remediation checkpoint is reused.
+
+**Tasks:**
+
+1. Backfill existing cloud providers to `unknown` evidence posture without fabricating account class or contract facts.
+2. Preserve availability only for data/workloads already safe under the restricted posture; require reassessment before broader use.
+3. Create one actionable attention item per provider (deduplicated), linking to the existing provider detail page.
+4. Reassess on evidence expiry, provider/account/region change, organization jurisdiction/industry change, or relevant corpus/policy version change.
+5. Show last assessment, reason, evidence age, allowed workloads/data classes, and next review date.
+
+**Verification:** idempotent backfill/reconciliation tests; no silent clearance broadening; existing-install UX; evidence-expiry scenarios; full build gate and live happy-path verification.
+
+**Rollback:** remediation is idempotent and preserves evidence. Do not downgrade an explicit restriction during rollback; operators can reassess or disable the provider.
+
+## Cross-phase acceptance scenarios
+
+At minimum, the end-to-end suite must cover:
+
+1. A French healthcare company selects a personal consumer account for patient-summary work: not suitable; cloud remains excluded; capable cleared local is offered or the task blocks.
+2. A German B2B company supplies a business API account, EU region, current DPA/no-training evidence, and internal non-personal workload: conditional/recommended according to policy; only the evidenced region/provider is eligible.
+3. A UK company has valid credentials but unknown account/retention terms: handshake succeeds, governance remains unknown/restricted, and public synthetic evaluation is the maximum allowance.
+4. A US solo entrepreneur with no regulated data selects a consumer subscription for public marketing ideation: allowed only if provider terms and company policy substantiate that workload; the product explains the limitation.
+5. A financial-services user pastes an IBAN into a previously approved general cloud chat: pre-egress detection causes policy-driven transform/reroute/block; the raw IBAN appears nowhere in logs.
+6. A prompt starts internal but a tool result adds restricted personal data: final pre-egress evaluation catches the late addition.
+7. The approved provider fails: fallback considers only other providers allowed by the same posture; it never broadens to `any_enabled`.
+8. The local model is down or too weak: DPF blocks/escalates rather than claiming local fallback succeeded.
+9. AGT-902/A2A inference fails during onboarding: deterministic evaluation still produces the same enforcement result and a plainer explanation.
+10. Evidence expires or the company adds an EMEA customer market: posture is invalidated, attention appears, and cloud allowance narrows until reassessed.
+11. A coworker proposes a destructive external action during setup: the existing `CoworkerActionEnvelope` requires explicit approval and preserves chain of custody.
+12. Retention runs under a regulated industry floor or active hold: required evidence remains; eligible operational telemetry is purged without orphaning relations.
+
+## Research and standards grounding
+
+The implementation should cite primary legal/regulatory texts in the profession corpus. The following implementation references inform mechanism and UX, not legal conclusions:
+
+### Open-source patterns
+
+- [Microsoft Presidio](https://microsoft.github.io/presidio/) combines regex, checksums, rules, context, and NER for detection/anonymization and explicitly warns that automated detection cannot find all sensitive information. Adopt the layered recognizer pattern and its limitation; do not treat detection as the policy source.
+- [Open Policy Agent decision logs](https://www.openpolicyagent.org/docs/management-decision-logs) separate policy decision evidence from enforcement and provide masking before decision-log upload. Adopt decision ids, policy/version attribution, and masked audit evidence; DPF keeps its own policy/runtime rather than introducing OPA solely for this feature.
+- DPF’s own `RequestContract`/routing pipeline provides the policy-input and enforcement substrate; prefer extending it over introducing a second gateway.
+
+### Commercial patterns
+
+- [Microsoft Purview DLP](https://learn.microsoft.com/en-ca/purview/dlp-learn-about-dlp) applies policy to sensitive data at multiple transmission/activity locations and combines multiple detection techniques. Adopt policy-driven actions and endpoint/egress coverage, not a standalone regex list.
+- [Amazon Bedrock Guardrails sensitive-information filters](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) support configurable block or mask actions for inputs and outputs. Adopt the explicit per-policy action vocabulary; do not delegate DPF’s cross-provider governance to a provider-specific control.
+- Provider model-list/auth endpoints are connectivity evidence, not account-contract evidence. Each provider adapter must document exactly which facts its official APIs can and cannot prove.
+
+### Standards posture
+
+- Use ISO/IEC 42001 concepts for AI management-system responsibilities, documented controls, monitoring, and continual reassessment.
+- Use privacy-by-design/data-minimization principles and exact jurisdiction/sector sources rather than a single global “compliance” flag.
+- Treat data residency, access sovereignty, controller/processor obligations, and contractual evidence as related but distinct dimensions.
+- Keep human approval for destructive/outbound actions aligned with DPF’s existing action-envelope governance.
+
+## Dependencies and sequencing risks
+
+- **AGT-902 corpus assignment:** the coworker cannot give defensible advice until legal/compliance pages are actually in its retrieval scope.
+- **Local model capacity:** structured contracts and tight retrieval budgets are mandatory; free-form legal synthesis is not the cold-start dependency.
+- **Activation blast radius:** `activateProvider()` is used by OAuth, API keys, tests, seed/bootstrap, and linked providers. Phase 1 must inventory all callers and provide safe treatment for bootstrap/system providers.
+- **Alternate egress paths:** adapter coverage must be proven by an invariant test. A guard attached only to the chat UI is not sufficient.
+- **Existing installations:** immediately setting every active provider to unusable may disrupt operations; staged restriction must still prevent newly disallowed sensitive egress.
+- **False assurance:** the UI must distinguish declarations, provider-published facts, verified account facts, and inferred policy results.
+- **Detection quality:** false negatives demand structured classification and fail-closed rules; false positives require reviewable categories and safe recovery, never a bypass button that silently allows the same payload.
+- **Retention conflict:** privacy deletion and regulated audit/incident retention can conflict. The existing policy registry, floors, and holds arbitrate; no universal short window.
+- **Related work:** coordinate healthcare-specific scenarios with BI-HEALTHCARE-053 and coworker authority work with EP-31815F97 rather than duplicating their controls.
+
+## Definition of done
+
+- The plan’s six phases have shipped through separate reviewable PRs with the mandatory build gate appropriate to each phase.
+- A new install can complete the provider decision with only the local model and deterministic evaluator available.
+- Setup identifies the company, exact jurisdiction/market, product/customer posture, workloads, data classes, provider account ownership/class, region, and evidence before broad cloud activation.
+- COO → AGT-902 A2A advice is visible, cited, structured, and traceable to the human-originated setup session.
+- Provider posture is one source of truth consumed by activation, provider UX, and runtime routing.
+- Every external inference path has final pre-egress policy enforcement and masked audit evidence.
+- Personal/consumer and unknown accounts cannot silently receive business-confidential/restricted workloads.
+- Policy fallbacks never broaden provider, residency, sensitivity, region, or workload constraints.
+- Existing action envelopes, retention registry, and immutable platform preamble are reused rather than duplicated.
+- Existing active providers are reassessed without fabricated facts, and operators have a clear repair path.
+- Legal/compliance corpus sources are primary, dated, and included in freshness/evidence tests.
+- Live UX verification confirms the first-viewport recommendation, details, skip/restriction behavior, A2A consultation, provider repair, and failure states.


### PR DESCRIPTION
## Summary
- incorporate the external advisor review into BI-C98C6AB7
- distinguish adopted controls from mechanisms that would create false assurance
- decompose provider governance into six independently reviewable delivery phases
- ground the plan in existing DPF routing, A2A, retention, action-envelope, corpus, and provider substrates
- add a trust and confidence contract for non-technical operators, with plain-language safeguards and measurable comprehension evidence
- require grounded follow-up answers with validated claim-level references, explicit evidence scope, safe abstention, and golden/adversarial reliability tests
- establish the COO as the single owner-facing coworker who has the owners back and coordinates AGT-902 specialist expertise through A2A
- link deferred BI-ADEF2982 for an optional organization-scoped conversational name layered over the canonical COO identity

## Verification
- git diff --cached --check
- pnpm security:secrets:staged
- docs-only pre-push gate passed

## Notes
The owner asks the COO and receives one coherent answer in the same conversation. AGT-902 is a governed specialist behind that relationship, not another chatbot the owner must discover or manage. The optional future conversational name does not rename AGT-ORCH-000, alter authority, or replace authenticated attribution; it requires an explicit revisit of the ratified role-only persona decision before implementation.