### PR TITLE
feat(routing): enforce provider policy fences

### DIFF
--- a/apps/web/lib/inference/phase-enable-candidates.test.ts
+++ b/apps/web/lib/inference/phase-enable-candidates.test.ts
@@ -145,6 +145,22 @@ describe("selectEnableCandidatesForContract", () => {
     expect(selectEnableCandidatesForContract(contract, [cloud])).toHaveLength(0);
   });
 
+  it("uses the live router allowlist when projecting enable candidates", () => {
+    const contract = makeContract({ allowedProviders: ["anthropic"] });
+    const anthropic = makeProvider({ providerId: "anthropic" });
+    const openai = makeProvider({ providerId: "openai" });
+
+    expect(selectEnableCandidatesForContract(contract, [openai, anthropic]))
+      .toEqual([expect.objectContaining({ providerId: "anthropic" })]);
+  });
+
+  it("uses the live router denylist when projecting enable candidates", () => {
+    const contract = makeContract({ deniedProviders: ["openai"] });
+    const openai = makeProvider({ providerId: "openai" });
+
+    expect(selectEnableCandidatesForContract(contract, [openai])).toHaveLength(0);
+  });
+
   it("flags a disabled provider that still needs credentials instead of a one-click enable", () => {
     const contract = makeContract();
     const provider = makeProvider({

--- a/apps/web/lib/routing/pipeline-v2.provider-policy.test.ts
+++ b/apps/web/lib/routing/pipeline-v2.provider-policy.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EndpointManifest } from "./types";
+import type { RequestContract } from "./request-contract";
+import { EMPTY_CAPABILITIES, EMPTY_PRICING } from "./model-card-types";
+import { getExclusionReasonV2, routeEndpointV2 } from "./pipeline-v2";
+
+vi.mock("./champion-challenger", () => ({
+  selectRecipeWithExploration: vi.fn().mockResolvedValue({
+    recipe: null,
+    explorationMode: "champion",
+  }),
+}));
+
+function makeEndpoint(overrides: Partial<EndpointManifest> = {}): EndpointManifest {
+  return {
+    id: "ep-default",
+    providerId: "test",
+    modelId: "test-model",
+    name: "Default Endpoint",
+    endpointType: "chat",
+    status: "active",
+    providerTier: "user_configured",
+    sensitivityClearance: ["public", "internal"],
+    supportsToolUse: true,
+    supportsStructuredOutput: true,
+    supportsStreaming: true,
+    maxContextTokens: 128000,
+    maxOutputTokens: 4096,
+    modelRestrictions: [],
+    reasoning: 70,
+    codegen: 70,
+    toolFidelity: 70,
+    instructionFollowing: 70,
+    structuredOutput: 70,
+    conversational: 70,
+    contextRetention: 70,
+    customScores: {},
+    avgLatencyMs: 1000,
+    recentFailureRate: 0,
+    costPerOutputMToken: 10,
+    profileSource: "seed",
+    profileConfidence: "medium",
+    retiredAt: null,
+    modelClass: "chat",
+    modelFamily: null,
+    inputModalities: ["text"],
+    outputModalities: ["text"],
+    capabilities: {
+      ...EMPTY_CAPABILITIES,
+      toolUse: true,
+      structuredOutput: true,
+      streaming: true,
+    },
+    pricing: { ...EMPTY_PRICING, inputPerMToken: 3, outputPerMToken: 15 },
+    supportedParameters: [],
+    deprecationDate: null,
+    metadataSource: "inferred",
+    metadataConfidence: "low",
+    perRequestLimits: null,
+    ...overrides,
+  };
+}
+
+function makeContract(overrides: Partial<RequestContract> = {}): RequestContract {
+  return {
+    contractId: "provider-policy-test-contract",
+    contractFamily: "sync.test",
+    taskType: "reasoning",
+    modality: { input: ["text"], output: ["text"] },
+    interactionMode: "sync",
+    sensitivity: "internal",
+    requiresTools: false,
+    requiresStrictSchema: false,
+    requiresStreaming: false,
+    estimatedInputTokens: 1000,
+    estimatedOutputTokens: 500,
+    reasoningDepth: "medium",
+    budgetClass: "balanced",
+    ...overrides,
+  };
+}
+
+const cheapModel = makeEndpoint({
+  id: "ep-cheap",
+  providerId: "openai",
+  modelId: "gpt-4o-mini",
+  name: "GPT-4o Mini",
+  reasoning: 55,
+  costPerOutputMToken: 0.6,
+  pricing: { ...EMPTY_PRICING, inputPerMToken: 0.15, outputPerMToken: 0.6 },
+});
+
+const qualityModel = makeEndpoint({
+  id: "ep-quality",
+  providerId: "anthropic",
+  modelId: "claude-sonnet-4-5",
+  name: "Claude Sonnet",
+  reasoning: 90,
+  costPerOutputMToken: 15,
+});
+
+beforeEach(async () => {
+  const { _resetAllTracking } = await import("./rate-tracker");
+  _resetAllTracking();
+});
+
+describe("provider policy hard filters", () => {
+  it("excludes providers outside an explicit allowlist", () => {
+    const contract = makeContract({ allowedProviders: ["anthropic"] });
+    expect(getExclusionReasonV2(cheapModel, contract)).toContain("allowlist");
+    expect(getExclusionReasonV2(qualityModel, contract)).toBeNull();
+  });
+
+  it("lets an explicit denylist win when a provider is also allowed", () => {
+    const contract = makeContract({
+      allowedProviders: ["openai"],
+      deniedProviders: ["openai"],
+    });
+    expect(getExclusionReasonV2(cheapModel, contract)).toContain("denylist");
+  });
+
+  it("treats an explicit empty allowlist as deny all", () => {
+    const contract = makeContract({ allowedProviders: [] });
+    expect(getExclusionReasonV2(qualityModel, contract)).toContain("allowlist");
+  });
+
+  it("enforces an allowlist before cost ranking", async () => {
+    const decision = await routeEndpointV2(
+      [cheapModel, qualityModel],
+      makeContract({
+        budgetClass: "minimize_cost",
+        allowedProviders: ["anthropic"],
+      }),
+      [],
+      [],
+    );
+
+    expect(decision.selectedEndpoint).toBe("ep-quality");
+    expect(decision.candidates.find((candidate) => candidate.endpointId === "ep-cheap"))
+      .toMatchObject({ excluded: true, excludedReason: expect.stringContaining("allowlist") });
+  });
+
+  it("enforces a denylist even when the denied provider is cheapest", async () => {
+    const decision = await routeEndpointV2(
+      [cheapModel, qualityModel],
+      makeContract({
+        budgetClass: "minimize_cost",
+        deniedProviders: ["openai"],
+      }),
+      [],
+      [],
+    );
+
+    expect(decision.selectedEndpoint).toBe("ep-quality");
+    expect(decision.candidates.find((candidate) => candidate.endpointId === "ep-cheap"))
+      .toMatchObject({ excluded: true, excludedReason: expect.stringContaining("denylist") });
+  });
+
+  it("returns no route when every provider is outside the effective allow set", async () => {
+    const decision = await routeEndpointV2(
+      [cheapModel, qualityModel],
+      makeContract({ allowedProviders: [] }),
+      [],
+      [],
+    );
+
+    expect(decision.selectedEndpoint).toBeNull();
+    expect(decision.selectedModelId).toBeNull();
+    expect(decision.excludedCount).toBe(2);
+  });
+
+  it("never puts a disallowed provider back into the fallback chain", async () => {
+    const secondAnthropic = makeEndpoint({
+      id: "ep-anthropic-2",
+      providerId: "anthropic",
+      modelId: "claude-haiku",
+    });
+    const decision = await routeEndpointV2(
+      [cheapModel, qualityModel, secondAnthropic],
+      makeContract({ allowedProviders: ["anthropic"] }),
+      [],
+      [],
+    );
+
+    expect(decision.fallbackChain).not.toContain("ep-cheap");
+    expect(decision.fallbackChain).toEqual(
+      expect.arrayContaining(["ep-quality", "ep-anthropic-2"]),
+    );
+  });
+
+  it("does not let a pinned override bypass a provider denylist", async () => {
+    const decision = await routeEndpointV2(
+      [cheapModel, qualityModel],
+      makeContract({ deniedProviders: ["openai"] }),
+      [],
+      [{
+        endpointId: "ep-cheap",
+        taskType: "reasoning",
+        pinned: true,
+        blocked: false,
+      }],
+    );
+
+    expect(decision.selectedEndpoint).toBe("ep-quality");
+    expect(decision.candidates.find((candidate) => candidate.endpointId === "ep-cheap"))
+      .toMatchObject({ excluded: true, excludedReason: expect.stringContaining("denylist") });
+  });
+});

--- a/apps/web/lib/routing/pipeline-v2.test.ts
+++ b/apps/web/lib/routing/pipeline-v2.test.ts
@@ -209,25 +209,6 @@ describe("getExclusionReasonV2", () => {
     expect(getExclusionReasonV2(localModel, contract)).toBeNull();
   });
 
-  it("excludes providers outside an explicit allowlist", () => {
-    const contract = makeContract({ allowedProviders: ["anthropic"] });
-    expect(getExclusionReasonV2(cheapModel, contract)).toContain("allowlist");
-    expect(getExclusionReasonV2(qualityModel, contract)).toBeNull();
-  });
-
-  it("lets an explicit denylist win when a provider is also allowed", () => {
-    const contract = makeContract({
-      allowedProviders: ["openai"],
-      deniedProviders: ["openai"],
-    });
-    expect(getExclusionReasonV2(cheapModel, contract)).toContain("denylist");
-  });
-
-  it("treats an explicit empty allowlist as deny all", () => {
-    const contract = makeContract({ allowedProviders: [] });
-    expect(getExclusionReasonV2(qualityModel, contract)).toContain("allowlist");
-  });
-
   it("excludes models lacking pdf input for file modality", () => {
     const noPdf = makeEndpoint({
       capabilities: { ...EMPTY_CAPABILITIES, toolUse: true, streaming: true },
@@ -424,88 +405,6 @@ describe("routeEndpointV2", () => {
       c => c.excluded && c.excludedReason?.includes("local_only"),
     );
     expect(cloudExcluded.length).toBe(2);
-  });
-
-  it("enforces an allowlist before cost ranking", async () => {
-    const decision = await routeEndpointV2(
-      [cheapModel, qualityModel],
-      makeContract({
-        budgetClass: "minimize_cost",
-        allowedProviders: ["anthropic"],
-      }),
-      [],
-      [],
-    );
-
-    expect(decision.selectedEndpoint).toBe("ep-quality");
-    expect(decision.candidates.find((candidate) => candidate.endpointId === "ep-cheap"))
-      .toMatchObject({ excluded: true, excludedReason: expect.stringContaining("allowlist") });
-  });
-
-  it("enforces a denylist even when the denied provider is cheapest", async () => {
-    const decision = await routeEndpointV2(
-      [cheapModel, qualityModel],
-      makeContract({
-        budgetClass: "minimize_cost",
-        deniedProviders: ["openai"],
-      }),
-      [],
-      [],
-    );
-
-    expect(decision.selectedEndpoint).toBe("ep-quality");
-    expect(decision.candidates.find((candidate) => candidate.endpointId === "ep-cheap"))
-      .toMatchObject({ excluded: true, excludedReason: expect.stringContaining("denylist") });
-  });
-
-  it("returns no route when every provider is outside the effective allow set", async () => {
-    const decision = await routeEndpointV2(
-      [cheapModel, qualityModel],
-      makeContract({ allowedProviders: [] }),
-      [],
-      [],
-    );
-
-    expect(decision.selectedEndpoint).toBeNull();
-    expect(decision.selectedModelId).toBeNull();
-    expect(decision.excludedCount).toBe(2);
-  });
-
-  it("never puts a disallowed provider back into the fallback chain", async () => {
-    const secondAnthropic = makeEndpoint({
-      id: "ep-anthropic-2",
-      providerId: "anthropic",
-      modelId: "claude-haiku",
-    });
-    const decision = await routeEndpointV2(
-      [cheapModel, qualityModel, secondAnthropic],
-      makeContract({ allowedProviders: ["anthropic"] }),
-      [],
-      [],
-    );
-
-    expect(decision.fallbackChain).not.toContain("ep-cheap");
-    expect(decision.fallbackChain).toEqual(
-      expect.arrayContaining(["ep-quality", "ep-anthropic-2"]),
-    );
-  });
-
-  it("does not let a pinned override bypass a provider denylist", async () => {
-    const decision = await routeEndpointV2(
-      [cheapModel, qualityModel],
-      makeContract({ deniedProviders: ["openai"] }),
-      [],
-      [{
-        endpointId: "ep-cheap",
-        taskType: "reasoning",
-        pinned: true,
-        blocked: false,
-      }],
-    );
-
-    expect(decision.selectedEndpoint).toBe("ep-quality");
-    expect(decision.candidates.find((candidate) => candidate.endpointId === "ep-cheap"))
-      .toMatchObject({ excluded: true, excludedReason: expect.stringContaining("denylist") });
   });
 
   it("prefers cheaper model for minimize_cost budget", async () => {

--- a/apps/web/lib/routing/pipeline-v2.test.ts
+++ b/apps/web/lib/routing/pipeline-v2.test.ts
@@ -209,6 +209,25 @@ describe("getExclusionReasonV2", () => {
     expect(getExclusionReasonV2(localModel, contract)).toBeNull();
   });
 
+  it("excludes providers outside an explicit allowlist", () => {
+    const contract = makeContract({ allowedProviders: ["anthropic"] });
+    expect(getExclusionReasonV2(cheapModel, contract)).toContain("allowlist");
+    expect(getExclusionReasonV2(qualityModel, contract)).toBeNull();
+  });
+
+  it("lets an explicit denylist win when a provider is also allowed", () => {
+    const contract = makeContract({
+      allowedProviders: ["openai"],
+      deniedProviders: ["openai"],
+    });
+    expect(getExclusionReasonV2(cheapModel, contract)).toContain("denylist");
+  });
+
+  it("treats an explicit empty allowlist as deny all", () => {
+    const contract = makeContract({ allowedProviders: [] });
+    expect(getExclusionReasonV2(qualityModel, contract)).toContain("allowlist");
+  });
+
   it("excludes models lacking pdf input for file modality", () => {
     const noPdf = makeEndpoint({
       capabilities: { ...EMPTY_CAPABILITIES, toolUse: true, streaming: true },
@@ -405,6 +424,88 @@ describe("routeEndpointV2", () => {
       c => c.excluded && c.excludedReason?.includes("local_only"),
     );
     expect(cloudExcluded.length).toBe(2);
+  });
+
+  it("enforces an allowlist before cost ranking", async () => {
+    const decision = await routeEndpointV2(
+      [cheapModel, qualityModel],
+      makeContract({
+        budgetClass: "minimize_cost",
+        allowedProviders: ["anthropic"],
+      }),
+      [],
+      [],
+    );
+
+    expect(decision.selectedEndpoint).toBe("ep-quality");
+    expect(decision.candidates.find((candidate) => candidate.endpointId === "ep-cheap"))
+      .toMatchObject({ excluded: true, excludedReason: expect.stringContaining("allowlist") });
+  });
+
+  it("enforces a denylist even when the denied provider is cheapest", async () => {
+    const decision = await routeEndpointV2(
+      [cheapModel, qualityModel],
+      makeContract({
+        budgetClass: "minimize_cost",
+        deniedProviders: ["openai"],
+      }),
+      [],
+      [],
+    );
+
+    expect(decision.selectedEndpoint).toBe("ep-quality");
+    expect(decision.candidates.find((candidate) => candidate.endpointId === "ep-cheap"))
+      .toMatchObject({ excluded: true, excludedReason: expect.stringContaining("denylist") });
+  });
+
+  it("returns no route when every provider is outside the effective allow set", async () => {
+    const decision = await routeEndpointV2(
+      [cheapModel, qualityModel],
+      makeContract({ allowedProviders: [] }),
+      [],
+      [],
+    );
+
+    expect(decision.selectedEndpoint).toBeNull();
+    expect(decision.selectedModelId).toBeNull();
+    expect(decision.excludedCount).toBe(2);
+  });
+
+  it("never puts a disallowed provider back into the fallback chain", async () => {
+    const secondAnthropic = makeEndpoint({
+      id: "ep-anthropic-2",
+      providerId: "anthropic",
+      modelId: "claude-haiku",
+    });
+    const decision = await routeEndpointV2(
+      [cheapModel, qualityModel, secondAnthropic],
+      makeContract({ allowedProviders: ["anthropic"] }),
+      [],
+      [],
+    );
+
+    expect(decision.fallbackChain).not.toContain("ep-cheap");
+    expect(decision.fallbackChain).toEqual(
+      expect.arrayContaining(["ep-quality", "ep-anthropic-2"]),
+    );
+  });
+
+  it("does not let a pinned override bypass a provider denylist", async () => {
+    const decision = await routeEndpointV2(
+      [cheapModel, qualityModel],
+      makeContract({ deniedProviders: ["openai"] }),
+      [],
+      [{
+        endpointId: "ep-cheap",
+        taskType: "reasoning",
+        pinned: true,
+        blocked: false,
+      }],
+    );
+
+    expect(decision.selectedEndpoint).toBe("ep-quality");
+    expect(decision.candidates.find((candidate) => candidate.endpointId === "ep-cheap"))
+      .toMatchObject({ excluded: true, excludedReason: expect.stringContaining("denylist") });
   });
 
   it("prefers cheaper model for minimize_cost budget", async () => {

--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -45,6 +45,24 @@ import {
 
 // ── Stage 3: Hard filter (V2 — contract-based) ──────────────────────────────
 
+function getProviderConstraintExclusionReason(
+  ep: EndpointManifest,
+  contract: RequestContract,
+): string | null {
+  if (contract.deniedProviders?.includes(ep.providerId)) {
+    return `Provider '${ep.providerId}' is excluded by the request denylist`;
+  }
+
+  if (
+    contract.allowedProviders !== undefined &&
+    !contract.allowedProviders.includes(ep.providerId)
+  ) {
+    return `Provider '${ep.providerId}' is outside the request allowlist`;
+  }
+
+  return null;
+}
+
 /**
  * Determine why an endpoint should be excluded based on a RequestContract,
  * or null if the endpoint is eligible.
@@ -56,6 +74,11 @@ export function getExclusionReasonV2(
   ep: EndpointManifest,
   contract: RequestContract,
 ): string | null {
+  // Provider policy is a hard fence. Deny is evaluated before allow so an
+  // accidental overlap cannot broaden eligibility.
+  const providerConstraintReason = getProviderConstraintExclusionReason(ep, contract);
+  if (providerConstraintReason) return providerConstraintReason;
+
   // EP-AGENT-CAP-002: Agent capability floor — hard filter, non-negotiable.
   // Must run BEFORE status/graceful-degradation checks so a tool-incapable
   // endpoint is never selected even in degraded mode.
@@ -330,7 +353,11 @@ export async function routeEndpointV2(
 
   if (pinnedOverride) {
     const pinnedEp = endpoints.find((e) => e.id === pinnedOverride.endpointId);
-    if (pinnedEp) {
+    // A pin is a routing preference, not authority to bypass a provider fence.
+    // When the pinned provider is outside the effective set, continue through
+    // the normal pipeline so it is excluded with the canonical hard-filter
+    // reason and another eligible endpoint may be selected.
+    if (pinnedEp && getProviderConstraintExclusionReason(pinnedEp, contract) === null) {
       // Use legacy computeFitness for pin override scoring
       const dummyReq = {
         taskType: contract.taskType,

--- a/apps/web/lib/routing/request-contract.test.ts
+++ b/apps/web/lib/routing/request-contract.test.ts
@@ -306,6 +306,34 @@ describe("inferContract – route context overrides", () => {
     expect(contract.allowedProviders).toEqual(["anthropic", "openai"]);
   });
 
+  it("normalizes provider allow and deny constraints deterministically", async () => {
+    const contract = await inferContract(
+      "greeting",
+      SIMPLE_MESSAGES,
+      undefined,
+      undefined,
+      {
+        allowedProviders: [" openai ", "anthropic", "openai", ""],
+        deniedProviders: ["zai", " anthropic ", "zai", "   "],
+      },
+    );
+
+    expect(contract.allowedProviders).toEqual(["anthropic", "openai"]);
+    expect(contract.deniedProviders).toEqual(["anthropic", "zai"]);
+  });
+
+  it("preserves an explicitly empty allowlist as a deny-all constraint", async () => {
+    const contract = await inferContract(
+      "greeting",
+      SIMPLE_MESSAGES,
+      undefined,
+      undefined,
+      { allowedProviders: ["", "   "] },
+    );
+
+    expect(contract.allowedProviders).toEqual([]);
+  });
+
   it("applies residencyPolicy from routeContext", async () => {
     const contract = await inferContract(
       "greeting",

--- a/apps/web/lib/routing/request-contract.ts
+++ b/apps/web/lib/routing/request-contract.ts
@@ -52,6 +52,7 @@ export interface RequestContract {
   // ── Constraints ────────────────────────────────────────────────
   maxLatencyMs?: number;
   allowedProviders?: string[];
+  deniedProviders?: string[];
   residencyPolicy?: "local_only" | "approved_cloud" | "any_enabled";
 
   // ── EP-INF-009c: Model class constraint ───────────────────────
@@ -111,6 +112,10 @@ const BLOCK_TYPE_TO_MODALITY: Record<string, "image" | "audio" | "file" | "video
   video: "video",
 };
 
+function normalizeProviderIds(providerIds: string[]): string[] {
+  return [...new Set(providerIds.map((providerId) => providerId.trim()).filter(Boolean))].sort();
+}
+
 // ── Contract inference ──────────────────────────────────────────────────────
 
 export async function inferContract(
@@ -125,6 +130,7 @@ export async function inferContract(
     budgetClass?: string;
     residencyPolicy?: string;
     allowedProviders?: string[];
+    deniedProviders?: string[];
     requiresCodeExecution?: boolean;
     requiresWebSearch?: boolean;
     requiresComputerUse?: boolean;
@@ -285,7 +291,10 @@ export async function inferContract(
     contract.maxLatencyMs = routeContext.maxLatencyMs;
   }
   if (routeContext?.allowedProviders !== undefined) {
-    contract.allowedProviders = routeContext.allowedProviders;
+    contract.allowedProviders = normalizeProviderIds(routeContext.allowedProviders);
+  }
+  if (routeContext?.deniedProviders !== undefined) {
+    contract.deniedProviders = normalizeProviderIds(routeContext.deniedProviders);
   }
   // residencyPolicy: caller override wins, else the task requirement's policy
   // (e.g. email triage hardened to "local_only" by an operator). Unset when

--- a/docs/user-guide/ai-workforce/model-routing-lifecycle.md
+++ b/docs/user-guide/ai-workforce/model-routing-lifecycle.md
@@ -95,14 +95,18 @@ When an agent needs to call an LLM, the routing pipeline runs in this order:
 2. **Convert tier to minimum dimensions.** For example, `frontier` becomes `{ codegen: 85, toolFidelity: 85, reasoning: 85 }`.
 3. **Load all endpoint manifests.** Query `ModelProfile` where `modelStatus` is `active` or `degraded`, joined with `ModelProvider` where `status` is `active` or `degraded`.
 4. **Hard filter (V2 pipeline).** Exclude models that fail any of:
+   - Provider is outside `RequestContract.allowedProviders`
+   - Provider is present in `RequestContract.deniedProviders` (deny wins if both lists contain it)
    - Status not active/degraded
    - Model class not `chat` or `reasoning`
    - Sensitivity clearance doesn't cover the request
    - Missing required capability (e.g., tool use)
    - Any dimension score below the minimum threshold
 5. **Rank by cost-per-success.** Estimate success probability for each remaining model. With `quality_first` budget, rank by success probability alone. With `minimize_cost`, rank by cost efficiency.
-6. **Apply provider pin override.** If the agent has a `pinnedProviderId`, swap the pinned provider to the front of the list (V2-selected model becomes first fallback).
-7. **Dispatch with fallback chain.** Try the selected model. If it fails with an inference error, try the next model in the chain.
+6. **Apply provider pin preference.** A pin may select its configured provider only when that provider remains inside the request's hard allow/deny policy. A pin cannot override a provider fence.
+7. **Dispatch with the eligible fallback chain.** Try the selected model, then the next eligible model after an inference error. A provider excluded by the request policy never reappears in fallback.
+
+Provider allow/deny constraints are request-level hard policy, distinct from the provider registry's `modelRestrictions` discovery allowlist. An explicitly empty `allowedProviders` list means no provider is eligible; routing returns no endpoint rather than treating the empty list as “allow any.” Cost, quality, provider health, capacity, and pin preferences only rank the providers that remain after the hard filter.
 
 ## How Routing Adapts Over Time
 
@@ -148,7 +152,7 @@ Local models are automatically discovered and profiled. They are assigned the `b
 
 **Agent uses wrong model:**
 - Check `AgentModelConfig` in the database
-- The `pinnedProviderId` / `pinnedModelId` override all other routing decisions
+- `pinnedProviderId` / `pinnedModelId` are preferences within the request's hard provider, residency, sensitivity, and capability constraints
 - If no pin is set, routing selects based on dimension scores and budget class
 
 **Models missing after connecting a provider:**


### PR DESCRIPTION
## Summary
- enforce request-level provider allow/deny constraints in the V2 routing hard-filter before ranking
- make deny win on overlap, preserve explicit empty allowlists as deny-all, and prevent pinned or fallback endpoints from bypassing provider policy
- keep provider setup candidate previews aligned by reusing the canonical exclusion function and document the contract

Implements BI-AIPS-002 in EP-AI-PROVIDER-SUITABILITY.

## Test plan
- [x] TDD red: 12 intended failures across request contract, V2 pipeline, and phase enable-candidate projections
- [x] Focused Vitest: 127/127 passing
- [x] Governed merged-code full Vitest on the production commit: 17,518 passing, 65 skipped, 18 todo
- [x] Module Size Guard after test split: pass (`pipeline-v2.test.ts` 768 LOC; policy suite 208 LOC)
- [x] `pnpm --filter web typecheck`: clean on final SHA
- [x] production `next build`: pass on final SHA (compiled, TypeScript, page generation, and route collection)
- [x] migration deploy against isolated local-CI Postgres: 413 migrations found; pending migration applied cleanly
- [x] docs index/link checks: pass
- [x] UX verification: n/a — routing contract and tests only; no UI surface changed

Final local integration evidence: `cmrseisbv01os01s4i4o2aril`, branch SHA `4dfeb6137d98b0ba942d9f42f60531a2f1ce34ec`.

Overlap sweep: PR #3297 is documentation-only on a different surface; no routing overlap.

A separate pre-existing gate portability defect discovered during verification is tracked as BI-254F31A5; it is not part of this concern.
