### PR TITLE
feat(routing): compile provider suitability policy

### DIFF
--- a/apps/web/lib/actions/ai-providers.test.ts
+++ b/apps/web/lib/actions/ai-providers.test.ts
@@ -40,6 +40,8 @@ const {
 
 vi.mock("@dpf/db", () => ({
   prisma: mockPrisma,
+  ensureDefaultProviderConnection: vi.fn(),
+  refreshDefaultProviderConnectionOwners: vi.fn(),
 }));
 
 vi.mock("@/lib/auth", () => ({

--- a/apps/web/lib/actions/ai-providers.ts
+++ b/apps/web/lib/actions/ai-providers.ts
@@ -1,11 +1,10 @@
 "use server";
 
 import { lazyFs, lazyPath, lazyFsPromises } from "@/lib/shared/lazy-node";
-import { prisma } from "@dpf/db";
+import { ensureDefaultProviderConnection, prisma, refreshDefaultProviderConnectionOwners } from "@dpf/db";
 import { requireCapability } from "@/lib/actions/shared/guards";
 import {
-  computeNextRunAt,
-  getTestUrl,
+  buildProviderCatalogEntry, computeNextRunAt, getTestUrl,
   type RegistryProviderEntry,
 } from "@/lib/ai-provider-types";
 import { encryptSecret } from "@/lib/credential-crypto";
@@ -120,7 +119,7 @@ export async function syncProviderRegistry(): Promise<{ added: number; updated: 
           ...(entry.catalogVisibility !== undefined && { catalogVisibility: entry.catalogVisibility }),
           ...(entry.endpointType !== undefined      && { endpointType:      entry.endpointType }),
           ...(serviceKind !== undefined             && { serviceKind }),
-          ...(entry.catalogEntry !== undefined      && { catalogEntry:      entry.catalogEntry ?? undefined }),
+          ...(buildProviderCatalogEntry(entry) !== undefined && { catalogEntry: buildProviderCatalogEntry(entry) as import("@dpf/db").Prisma.InputJsonValue }),
           ...(entry.authorizeUrl !== undefined      && { authorizeUrl:      entry.authorizeUrl ?? null }),
           ...(entry.tokenUrl !== undefined          && { tokenUrl:          entry.tokenUrl ?? null }),
           ...(entry.oauthClientId !== undefined     && { oauthClientId:     entry.oauthClientId ?? null }),
@@ -154,7 +153,7 @@ export async function syncProviderRegistry(): Promise<{ added: number; updated: 
           catalogVisibility:    entry.catalogVisibility ?? "visible",
           ...(entry.endpointType !== undefined && { endpointType: entry.endpointType }),
           ...(serviceKind !== undefined && { serviceKind }),
-          ...(entry.catalogEntry !== undefined && entry.catalogEntry !== null && { catalogEntry: entry.catalogEntry }),
+          ...(buildProviderCatalogEntry(entry) !== undefined && { catalogEntry: buildProviderCatalogEntry(entry) as import("@dpf/db").Prisma.InputJsonValue }),
           authorizeUrl:         entry.authorizeUrl ?? null,
           tokenUrl:             entry.tokenUrl ?? null,
           oauthClientId:        entry.oauthClientId ?? null,
@@ -163,6 +162,7 @@ export async function syncProviderRegistry(): Promise<{ added: number; updated: 
       });
       added++;
     }
+    await ensureDefaultProviderConnection(prisma, entry, existing?.status);
   }
 
   const now = new Date();
@@ -309,7 +309,7 @@ export async function configureProvider(input: {
   // When a user configures a provider, the build system should automatically
   // pick it up without requiring manual Build Studio configuration.
   await autoConfigureBuildStudio(input.providerId);
-
+  await refreshDefaultProviderConnectionOwners(prisma, input.providerId);
   return {};
 }
 

--- a/apps/web/lib/ai-provider-route-context.test.ts
+++ b/apps/web/lib/ai-provider-route-context.test.ts
@@ -1,8 +1,29 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyProviderSuitabilityRouteContext,
   applyProviderRouteModelPreference,
   inferProviderIdFromRouteContext,
 } from "./ai-provider-route-context";
+import type { ProviderSuitabilityPolicy } from "./routing/provider-suitability/types";
+import { inferContract } from "./routing/request-contract";
+
+function policy(overrides: Partial<ProviderSuitabilityPolicy> = {}): ProviderSuitabilityPolicy {
+  return {
+    policyId: "aips-test",
+    organizationId: "org-1",
+    source: "onboarding",
+    effect: "allow",
+    allowedProviders: ["azure-openai", "local"],
+    deniedProviders: ["openai"],
+    allowedProviderConnectionIds: ["conn-azure", "conn-local"],
+    deniedProviderConnectionIds: ["conn-openai"],
+    residencyPolicy: "approved_cloud",
+    openRouterObligations: null,
+    explanations: [],
+    compilerVersion: "1.0.0",
+    ...overrides,
+  };
+}
 
 describe("AI provider route context", () => {
   it("extracts the provider id from provider detail routes", () => {
@@ -30,6 +51,53 @@ describe("AI provider route context", () => {
     }, "/platform/ai")).toEqual({
       defaultMinimumTier: "strong",
       preferredProviderId: "anthropic-sub",
+    });
+  });
+
+  it("composes provider suitability into inferContract route overrides", () => {
+    expect(applyProviderSuitabilityRouteContext({ budgetClass: "quality_first" }, policy())).toEqual({
+      budgetClass: "quality_first",
+      allowedProviders: ["azure-openai", "local"],
+      deniedProviders: ["openai"],
+      residencyPolicy: "approved_cloud",
+    });
+  });
+
+  it("intersects an existing allowlist and unions denials", () => {
+    expect(applyProviderSuitabilityRouteContext({
+      allowedProviders: ["local", "openai"],
+      deniedProviders: ["anthropic"],
+      residencyPolicy: "any_enabled",
+    }, policy())).toEqual({
+      allowedProviders: ["local"],
+      deniedProviders: ["anthropic", "openai"],
+      residencyPolicy: "approved_cloud",
+    });
+  });
+
+  it("preserves the stricter local-only residency bound", () => {
+    expect(applyProviderSuitabilityRouteContext({ residencyPolicy: "local_only" }, policy()).residencyPolicy)
+      .toBe("local_only");
+  });
+
+  it("compiles a deny effect to an explicit empty allowlist", () => {
+    expect(applyProviderSuitabilityRouteContext({}, policy({ effect: "deny", allowedProviders: [] })))
+      .toMatchObject({ allowedProviders: [], deniedProviders: ["openai"] });
+  });
+
+  it("feeds the compiled hard bounds into inferContract", async () => {
+    const routeContext = applyProviderSuitabilityRouteContext({}, policy());
+    const contract = await inferContract(
+      "summarization",
+      [{ role: "user", content: "Summarize this governed record." }],
+      undefined,
+      undefined,
+      routeContext,
+    );
+    expect(contract).toMatchObject({
+      allowedProviders: ["azure-openai", "local"],
+      deniedProviders: ["openai"],
+      residencyPolicy: "approved_cloud",
     });
   });
 });

--- a/apps/web/lib/ai-provider-route-context.ts
+++ b/apps/web/lib/ai-provider-route-context.ts
@@ -1,3 +1,57 @@
+import type { ProviderSuitabilityPolicy } from "./routing/provider-suitability/types";
+import type { RequestContract } from "./routing/request-contract";
+
+export type ProviderSuitabilityRouteContext = {
+  allowedProviders?: string[];
+  deniedProviders?: string[];
+  residencyPolicy?: RequestContract["residencyPolicy"];
+};
+
+function normalizeProviderIds(values: readonly string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort();
+}
+
+const RESIDENCY_RANK: Readonly<Record<NonNullable<RequestContract["residencyPolicy"]>, number>> = {
+  any_enabled: 0,
+  approved_cloud: 1,
+  local_only: 2,
+};
+
+/**
+ * Compose a compiled suitability policy into the caller overrides consumed by
+ * inferContract(). Existing hard bounds can only become stricter: allowlists
+ * intersect, denials union, and the strongest residency posture wins.
+ */
+export function applyProviderSuitabilityRouteContext<T extends Record<string, unknown>>(
+  routeContext: T & ProviderSuitabilityRouteContext,
+  policy: ProviderSuitabilityPolicy,
+): T & Required<ProviderSuitabilityRouteContext> {
+  const policyAllowed = normalizeProviderIds(policy.allowedProviders);
+  const existingAllowed = routeContext.allowedProviders === undefined
+    ? null
+    : normalizeProviderIds(routeContext.allowedProviders);
+  const allowedProviders = policy.effect === "deny"
+    ? []
+    : existingAllowed === null
+      ? policyAllowed
+      : existingAllowed.filter((providerId) => policyAllowed.includes(providerId));
+  const deniedProviders = normalizeProviderIds([
+    ...(routeContext.deniedProviders ?? []),
+    ...policy.deniedProviders,
+  ]);
+  const existingResidency = routeContext.residencyPolicy ?? "any_enabled";
+  const residencyPolicy = RESIDENCY_RANK[existingResidency] >= RESIDENCY_RANK[policy.residencyPolicy]
+    ? existingResidency
+    : policy.residencyPolicy;
+
+  return {
+    ...routeContext,
+    allowedProviders,
+    deniedProviders,
+    residencyPolicy,
+  };
+}
+
 export function inferProviderIdFromRouteContext(routeContext?: string | null): string | null {
   const match = routeContext?.match(/^\/platform\/ai\/providers\/([^/?#]+)/);
   if (!match?.[1]) return null;

--- a/apps/web/lib/govern/data/assets.ts
+++ b/apps/web/lib/govern/data/assets.ts
@@ -169,6 +169,25 @@ export function resolveField(
 
 const SEED_ASSETS: readonly DataAssetDefinition[] = [
   {
+    id: "data:ai-provider-connection",
+    physical: { prismaModel: "AiProviderConnection" },
+    domain: "ai-provider-governance",
+    ownerRole: "platform-owner",
+    stewardRole: "data-steward",
+    categories: ["configuration", "authorization", "security-audit"],
+    sensitivity: "confidential",
+    criticality: "mission-critical",
+    subjectLocators: [
+      { role: "organization", fieldPath: "organization" },
+    ],
+    lifecycleClass: "legal-evidence",
+    purposeCapabilities: ["platform-operations", "compliance-and-legal", "coworker-assistance"],
+    residencyClass: "local-only",
+    projectionClass: "metadata",
+    classification: { state: "confirmed", source: "manual", effectiveFrom: "2026-07-19" },
+    fields: [],
+  },
+  {
     id: "data:runtime-capability-transition-event",
     physical: { prismaModel: "RuntimeCapabilityTransitionEvent" },
     domain: "platform-runtime",

--- a/apps/web/lib/inference/ai-provider-types.ts
+++ b/apps/web/lib/inference/ai-provider-types.ts
@@ -179,6 +179,8 @@ export type ModelProfileRow = {
 
 export type RegistryProviderEntry = {
   providerId: string;
+  /** Stable vendor/catalog identity shared by channel-specific runtime aliases. */
+  catalogProviderId?: string;
   name: string;
   families: string[];
   category: "direct" | "router" | "agent" | "mcp-subscribed" | "mcp-internal";
@@ -205,12 +207,36 @@ export type RegistryProviderEntry = {
     pricingInfo?: string;
     enableUrl?: string;
   } | null;
+  /** Vendor/catalog capabilities only. Account evidence never belongs here. */
+  trustCatalog?: {
+    category: "direct" | "router" | "local" | "self-hosted";
+    jurisdictions: string[];
+    externalEgress: "none" | "provider-cloud" | "router-cloud" | "self-hosted-network" | "unknown";
+    supportsZdr: boolean | null;
+    supportsNoTraining: boolean | null;
+    supportsRegionalRouting: boolean | null;
+    supportedRegions: string[];
+    regionalEndpoints: Array<{
+      region: string;
+      baseUrl: string;
+      requiresEnterpriseEnablement: boolean;
+    }>;
+  };
   serviceKind?: "mcp" | "built_in" | null;
   authorizeUrl?: string | null;
   tokenUrl?: string | null;
   oauthClientId?: string | null;
   oauthRedirectUri?: string | null;
 };
+
+export function buildProviderCatalogEntry(entry: RegistryProviderEntry): Record<string, unknown> | undefined {
+  const value = {
+    ...(entry.catalogEntry ?? {}),
+    ...(entry.catalogProviderId ? { catalogProviderId: entry.catalogProviderId } : {}),
+    ...(entry.trustCatalog ? { trustCatalog: entry.trustCatalog } : {}),
+  };
+  return Object.keys(value).length > 0 ? value : undefined;
+}
 
 // ─── Model discovery ──────────────────────────────────────────────────────────
 

--- a/apps/web/lib/routing/provider-suitability/compile.test.ts
+++ b/apps/web/lib/routing/provider-suitability/compile.test.ts
@@ -1,0 +1,439 @@
+import { describe, expect, it } from "vitest";
+import type { DataPolicyDecision } from "@/lib/govern/data/policy-decision";
+import { compileAiProviderSuitabilityPolicy } from "./compile";
+import {
+  deriveProviderConnectionAccessPosture,
+  resolveProviderTrustFacts,
+} from "./provider-trust";
+import { deriveAiWorkloadDataProfile } from "./workload-profile";
+import type {
+  AiWorkloadClassKey,
+  BusinessSuitabilityProfile,
+  ProviderCatalogTrustFacts,
+  ProviderConnectionPosture,
+  ProviderTrustFacts,
+} from "./types";
+
+const BUSINESS: BusinessSuitabilityProfile = {
+  organizationId: "org-1",
+  archetypeId: "general-small-business",
+  archetypeCategory: "professional-services",
+  operatesIn: ["us"],
+  sellsTo: ["us"],
+  employsIn: ["us"],
+  dataResidency: [],
+  riskPosture: "balanced",
+};
+
+const ALLOW_DECISION: DataPolicyDecision = {
+  decisionId: "dpd-allow",
+  organizationId: "org-1",
+  inputHash: "hash",
+  effect: "allow",
+  obligations: [],
+  matchedPolicyVersions: [],
+  assetVersion: "1",
+  classificationVersion: "1",
+  authorityVersion: "1",
+  explanationCode: "allowed",
+  replay: "single-use",
+};
+
+function catalog(
+  providerId: string,
+  overrides: Partial<ProviderCatalogTrustFacts> = {},
+): ProviderCatalogTrustFacts {
+  return {
+    providerId,
+    catalogProviderId: providerId,
+    category: "direct",
+    jurisdictions: ["us"],
+    externalEgress: "provider-cloud",
+    supportsZdr: null,
+    supportsNoTraining: null,
+    supportsRegionalRouting: null,
+    supportedRegions: [],
+    regionalEndpoints: [],
+    ...overrides,
+  };
+}
+
+function connection(
+  providerId: string,
+  connectionId: string,
+  overrides: Partial<ProviderConnectionPosture> = {},
+): ProviderConnectionPosture {
+  return {
+    providerConnectionId: connectionId,
+    providerId,
+    executionChannel: "direct-api",
+    accountClass: "regular",
+    commercialBasis: "usage-metered",
+    authMethod: "api-key",
+    evidenceStatus: "unreviewed",
+    lastReviewedAt: null,
+    contractEvidence: {},
+    entitlements: {},
+    ...overrides,
+  };
+}
+
+function trust(
+  providerId: string,
+  connectionId: string,
+  connectionOverrides: Partial<ProviderConnectionPosture> = {},
+  catalogOverrides: Partial<ProviderCatalogTrustFacts> = {},
+): ProviderTrustFacts {
+  return resolveProviderTrustFacts({
+    catalog: catalog(providerId, catalogOverrides),
+    connection: connection(providerId, connectionId, connectionOverrides),
+  });
+}
+
+function compile(input: {
+  workloadClasses: AiWorkloadClassKey[];
+  providers: ProviderTrustFacts[];
+  business?: Partial<BusinessSuitabilityProfile>;
+  dataDecision?: DataPolicyDecision;
+}) {
+  return compileAiProviderSuitabilityPolicy({
+    businessProfile: { ...BUSINESS, ...input.business },
+    workloadProfiles: input.workloadClasses.map((workloadClass) =>
+      deriveAiWorkloadDataProfile({ workloadClass }),
+    ),
+    dataPolicyDecisions: [input.dataDecision ?? ALLOW_DECISION],
+    regulationResults: [],
+    providerFacts: input.providers,
+    source: "onboarding",
+  });
+}
+
+describe("AI workload data profiles", () => {
+  it.each([
+    ["public-marketing", "public", "unrestricted"],
+    ["health-phi", "restricted", "region-bound"],
+    ["student-records", "restricted", "region-bound"],
+    ["payments-finance", "restricted", "region-bound"],
+    ["source-code", "confidential", "region-bound"],
+    ["secrets-credentials", "restricted", "local-only"],
+  ] as const)("derives %s through the governed data vocabulary", (workloadClass, sensitivity, residencyClass) => {
+    const profile = deriveAiWorkloadDataProfile({ workloadClass });
+    expect(profile).toMatchObject({
+      workloadClass,
+      sensitivity,
+      residencyClass,
+      classificationKnown: true,
+      purpose: "coworker-assistance",
+    });
+    expect(profile.assetIds[0]).toMatch(/^data:/);
+    expect(profile.categories.length).toBeGreaterThan(0);
+  });
+});
+
+describe("connection-scoped provider trust", () => {
+  it("keeps account and contract evidence on the concrete connection", () => {
+    const regular = trust("anthropic", "conn-regular");
+    const enterprise = trust("anthropic", "conn-enterprise", {
+      accountClass: "enterprise",
+      commercialBasis: "enterprise-contract",
+      evidenceStatus: "contract-uploaded",
+      contractEvidence: { supplierContractId: "contract-1", baaOnFile: true },
+      entitlements: { zeroRetention: true, noTraining: true },
+    });
+
+    expect(regular.contractEvidence.baaOnFile).toBeUndefined();
+    expect(regular.entitlements.zeroRetention).toBeUndefined();
+    expect(enterprise.contractEvidence.baaOnFile).toBe(true);
+    expect(enterprise.providerConnectionId).toBe("conn-enterprise");
+  });
+
+  it.each([
+    ["api", "direct-api", "regular", "usage-metered", "api-key"],
+    ["subscription", "subscription-cli", "business-team", "subscription-included", "oauth"],
+    ["enterprise", "cloud-tenant", "enterprise", "enterprise-contract", "workload-identity"],
+    ["router", "hosted-router", "regular", "usage-metered", "api-key"],
+    ["local", "local-runtime", "regular", "local-compute", "local"],
+  ] as const)("derives the %s connection independently", (_label, executionChannel, accountClass, commercialBasis, authMethod) => {
+    const facts = trust("provider", `conn-${executionChannel}`, {
+      executionChannel,
+      accountClass,
+      commercialBasis,
+      authMethod,
+    });
+    expect(facts).toMatchObject({ executionChannel, accountClass, commercialBasis, authMethod });
+  });
+
+  it.each([
+    ["api", "direct", "provider-cloud", "api_key", null, false, "token", "direct-api", "usage-metered", "api-key"],
+    ["subscription", "direct", "provider-cloud", "oauth2_authorization_code", "claude", false, "token", "subscription-cli", "subscription-included", "oauth"],
+    ["cloud", "direct", "provider-cloud", "oauth2_client_credentials", null, true, "token", "cloud-tenant", "usage-metered", "workload-identity"],
+    ["router", "router", "router-cloud", "api_key", null, false, "token", "hosted-router", "usage-metered", "api-key"],
+    ["local", "local", "none", "none", "opencode", false, "compute", "local-runtime", "local-compute", "local"],
+  ] as const)(
+    "projects the %s channel from existing owner facts",
+    (_label, providerCategory, externalEgress, modelProviderAuthMethod, cliEngine, cloudTenant, costModel, executionChannel, commercialBasis, resolvedAuth) => {
+      const posture = deriveProviderConnectionAccessPosture({
+        providerConnectionId: `conn-${_label}`,
+        providerId: "provider",
+        providerCategory,
+        externalEgress,
+        modelProviderAuthMethod,
+        cliEngine,
+        cloudTenant,
+        costModel,
+      });
+      expect(posture).toMatchObject({
+        executionChannel,
+        commercialBasis,
+        authMethod: resolvedAuth,
+        accountClass: "unknown",
+        evidenceStatus: "unreviewed",
+      });
+    },
+  );
+
+  it("does not infer enterprise status from a linked contract", () => {
+    const posture = deriveProviderConnectionAccessPosture({
+      providerConnectionId: "conn-contracted",
+      providerId: "provider",
+      providerCategory: "direct",
+      externalEgress: "provider-cloud",
+      modelProviderAuthMethod: "api_key",
+      costModel: "token",
+      contractEvidence: { supplierContractId: "contract-1" },
+    });
+    expect(posture.accountClass).toBe("unknown");
+    expect(posture.commercialBasis).toBe("usage-metered");
+  });
+
+  it("does not turn a vendor capability into a connected-account entitlement", () => {
+    const result = compile({
+      workloadClasses: ["source-code"],
+      providers: [trust(
+        "provider",
+        "conn-team",
+        { accountClass: "business-team", evidenceStatus: "operator-attested" },
+        { supportsNoTraining: true },
+      )],
+    });
+    expect(result.effect).toBe("deny");
+    expect(result.deniedProviderConnectionIds).toEqual(["conn-team"]);
+    expect(result.explanations).toContainEqual(expect.objectContaining({
+      code: "business-account-unproven",
+    }));
+  });
+
+  it("changes the policy identity when connection evidence changes", () => {
+    const before = compile({
+      workloadClasses: ["source-code"],
+      providers: [trust("provider", "conn-team", {
+        accountClass: "business-team",
+        evidenceStatus: "operator-attested",
+      })],
+    });
+    const after = compile({
+      workloadClasses: ["source-code"],
+      providers: [trust("provider", "conn-team", {
+        accountClass: "business-team",
+        evidenceStatus: "operator-attested",
+        entitlements: { noTraining: true },
+      })],
+    });
+    expect(after.policyId).not.toBe(before.policyId);
+  });
+});
+
+describe("compileAiProviderSuitabilityPolicy", () => {
+  const local = () => trust("local", "conn-local", {}, {
+    category: "local",
+    jurisdictions: ["local"],
+    externalEgress: "none",
+  });
+
+  it("keeps dental PHI local unless a healthcare contract is proven", () => {
+    const result = compile({
+      workloadClasses: ["health-phi"],
+      business: { archetypeId: "dental-practice", archetypeCategory: "healthcare-wellness" },
+      providers: [
+        local(),
+        trust("anthropic", "conn-regular"),
+        trust("azure-openai", "conn-health", {
+          accountClass: "enterprise",
+          commercialBasis: "enterprise-contract",
+          evidenceStatus: "contract-uploaded",
+          contractEvidence: { supplierContractId: "contract-health", baaOnFile: true, dpaOnFile: true },
+          entitlements: { noTraining: true, zeroRetention: true },
+        }),
+      ],
+    });
+
+    expect(result.allowedProviders).toEqual(["azure-openai", "local"]);
+    expect(result.deniedProviders).toEqual(["anthropic"]);
+    expect(result.effect).toBe("allow");
+  });
+
+  it("allows ordinary hosted providers for public retail marketing", () => {
+    const result = compile({
+      workloadClasses: ["public-marketing"],
+      business: { archetypeId: "retail-store", archetypeCategory: "retail" },
+      providers: [local(), trust("openai", "conn-openai"), trust("openrouter", "conn-router", {}, {
+        category: "router",
+        externalEgress: "router-cloud",
+      })],
+    });
+    expect(result.effect).toBe("allow");
+    expect(result.allowedProviders).toEqual(["local", "openai", "openrouter"]);
+    expect(result.residencyPolicy).toBe("any_enabled");
+  });
+
+  it("requires financial review evidence for a credit union cloud route", () => {
+    const result = compile({
+      workloadClasses: ["payments-finance"],
+      business: { archetypeId: "credit-union", archetypeCategory: "banking-financial-services" },
+      providers: [local(), trust("openai", "conn-finance", {
+        accountClass: "enterprise",
+        commercialBasis: "enterprise-contract",
+        evidenceStatus: "contract-uploaded",
+        contractEvidence: {
+          supplierContractId: "contract-finance",
+          financialCustomerInfoReviewedAt: "2026-07-01T00:00:00.000Z",
+        },
+        entitlements: { noTraining: true },
+      })],
+    });
+    expect(result.allowedProviders).toEqual(["local", "openai"]);
+  });
+
+  it("leaves a training-company cloud route under review without student-data terms", () => {
+    const result = compile({
+      workloadClasses: ["student-records"],
+      business: { archetypeId: "training-company", archetypeCategory: "education-training" },
+      providers: [local(), trust("openai", "conn-training")],
+    });
+    expect(result.effect).toBe("review");
+    expect(result.allowedProviders).toEqual(["local"]);
+    expect(result.deniedProviders).toEqual(["openai"]);
+    expect(result.explanations.some((item) => item.code === "student-terms-unproven")).toBe(true);
+  });
+
+  it("keeps source code off an unproven personal account", () => {
+    const result = compile({
+      workloadClasses: ["source-code"],
+      business: { archetypeId: "software-platform", archetypeCategory: "software-platform" },
+      providers: [local(), trust("anthropic-sub", "conn-personal"), trust("anthropic", "conn-team", {
+        accountClass: "business-team",
+        evidenceStatus: "operator-attested",
+        entitlements: { noTraining: true },
+      })],
+    });
+    expect(result.allowedProviders).toEqual(["anthropic", "local"]);
+    expect(result.deniedProviders).toEqual(["anthropic-sub"]);
+  });
+
+  it("forces credentials to a non-egress connection", () => {
+    const result = compile({
+      workloadClasses: ["secrets-credentials"],
+      providers: [local(), trust("openai", "conn-openai")],
+    });
+    expect(result.residencyPolicy).toBe("local_only");
+    expect(result.allowedProviders).toEqual(["local"]);
+    expect(result.deniedProviders).toEqual(["openai"]);
+  });
+
+  it("fails unknown classification closed to local and review", () => {
+    const unknown = deriveAiWorkloadDataProfile({ workloadClass: "customer-records" });
+    unknown.classificationKnown = false;
+    const result = compileAiProviderSuitabilityPolicy({
+      businessProfile: BUSINESS,
+      workloadProfiles: [unknown],
+      dataPolicyDecisions: [ALLOW_DECISION],
+      regulationResults: [],
+      providerFacts: [local(), trust("openai", "conn-openai")],
+      source: "onboarding",
+    });
+    expect(result.effect).toBe("review");
+    expect(result.allowedProviders).toEqual(["local"]);
+    expect(result.explanations.some((item) => item.code === "classification-unknown")).toBe(true);
+  });
+
+  it("returns deny and no route when residency has no eligible connection", () => {
+    const result = compile({
+      workloadClasses: ["health-phi"],
+      business: { dataResidency: ["eu"] },
+      providers: [trust("openai", "conn-us")],
+    });
+    expect(result.effect).toBe("deny");
+    expect(result.allowedProviders).toEqual([]);
+    expect(result.deniedProviders).toEqual(["openai"]);
+  });
+
+  it("never transfers enterprise rights between two accounts for one provider slug", () => {
+    const result = compile({
+      workloadClasses: ["health-phi"],
+      providers: [
+        trust("anthropic", "conn-regular"),
+        trust("anthropic", "conn-enterprise", {
+          accountClass: "enterprise",
+          commercialBasis: "enterprise-contract",
+          evidenceStatus: "contract-uploaded",
+          contractEvidence: { supplierContractId: "contract-1", baaOnFile: true },
+          entitlements: { noTraining: true },
+        }),
+      ],
+    });
+    expect(result.allowedProviderConnectionIds).toEqual(["conn-enterprise"]);
+    expect(result.deniedProviderConnectionIds).toEqual(["conn-regular"]);
+    expect(result.allowedProviders).toEqual([]);
+    expect(result.effect).toBe("review");
+    expect(result.explanations.some((item) => item.code === "provider-connection-ambiguous")).toBe(true);
+  });
+
+  it("preserves a deny from the governed data PDP", () => {
+    const result = compile({
+      workloadClasses: ["customer-records"],
+      providers: [local(), trust("openai", "conn-openai")],
+      dataDecision: { ...ALLOW_DECISION, effect: "deny", explanationCode: "processing-authority-missing" },
+    });
+    expect(result.effect).toBe("deny");
+    expect(result.allowedProviders).toEqual([]);
+  });
+
+  it("requires review when a regulation is unresolved because its jurisdiction basis is undeclared", () => {
+    const result = compileAiProviderSuitabilityPolicy({
+      businessProfile: BUSINESS,
+      workloadProfiles: [deriveAiWorkloadDataProfile({ workloadClass: "public-marketing" })],
+      dataPolicyDecisions: [ALLOW_DECISION],
+      regulationResults: [{
+        regulationId: "regulation:example",
+        applicability: {
+          applies: false,
+          reason: "Selling jurisdiction is not declared.",
+          matchedBasis: [],
+          undeclared: true,
+        },
+      }],
+      providerFacts: [local(), trust("openai", "conn-openai")],
+      source: "onboarding",
+    });
+    expect(result.effect).toBe("review");
+    expect(result.explanations).toContainEqual(expect.objectContaining({
+      code: "regulation-applicability-unknown",
+    }));
+  });
+
+  it("honors a stricter Golden Triangle residency posture without relaxing workload policy", () => {
+    const result = compileAiProviderSuitabilityPolicy({
+      businessProfile: BUSINESS,
+      workloadProfiles: [deriveAiWorkloadDataProfile({ workloadClass: "public-marketing" })],
+      dataPolicyDecisions: [ALLOW_DECISION],
+      regulationResults: [],
+      providerFacts: [local(), trust("openai", "conn-openai")],
+      source: "onboarding",
+      activityClass: "owner-advice",
+      goldenTrianglePosture: { residencyPolicy: "local_only" },
+    });
+    expect(result.residencyPolicy).toBe("local_only");
+    expect(result.allowedProviders).toEqual(["local"]);
+    expect(result.deniedProviders).toEqual(["openai"]);
+  });
+});

--- a/apps/web/lib/routing/provider-suitability/compile.ts
+++ b/apps/web/lib/routing/provider-suitability/compile.ts
@@ -1,0 +1,333 @@
+import type {
+  AiWorkloadDataProfile,
+  CompileProviderSuitabilityInput,
+  OpenRouterPolicyObligations,
+  ProviderSuitabilityExplanation,
+  ProviderSuitabilityPolicy,
+  ProviderTrustFacts,
+} from "./types";
+
+export const PROVIDER_SUITABILITY_COMPILER_VERSION = "1.0.0";
+
+type ConnectionVerdict = {
+  allowed: boolean;
+  explanation?: ProviderSuitabilityExplanation;
+};
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalize(entry)]),
+    );
+  }
+  return value;
+}
+
+function stableHash(value: unknown): string {
+  const json = JSON.stringify(canonicalize(value));
+  let hash = 5381;
+  for (let index = 0; index < json.length; index += 1) {
+    hash = ((hash << 5) + hash) ^ json.charCodeAt(index);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function isLocal(facts: ProviderTrustFacts): boolean {
+  return facts.externalEgress === "none" || facts.executionChannel === "local-runtime";
+}
+
+function hasCurrentEvidence(facts: ProviderTrustFacts): boolean {
+  return facts.evidenceStatus === "operator-attested" || facts.evidenceStatus === "contract-uploaded";
+}
+
+function hasContract(facts: ProviderTrustFacts): boolean {
+  return Boolean(facts.contractEvidence.supplierContractId) && hasCurrentEvidence(facts);
+}
+
+function hasNoTraining(facts: ProviderTrustFacts): boolean {
+  return facts.entitlements.noTraining === true;
+}
+
+function regionEligible(facts: ProviderTrustFacts, requiredRegions: string[]): boolean {
+  if (requiredRegions.length === 0 || isLocal(facts)) return true;
+  if (facts.supportsRegionalRouting !== true || facts.entitlements.regionalProcessing !== true) return false;
+  const enabled = new Set((facts.entitlements.enabledRegions ?? []).map((region) => region.toLowerCase()));
+  return requiredRegions.every((region) => enabled.has(region.toLowerCase()));
+}
+
+function routerEligible(facts: ProviderTrustFacts): boolean {
+  if (facts.category !== "router") return true;
+  const passThrough = facts.routerPassThrough;
+  return Boolean(
+    passThrough?.exposesUnderlyingProvider &&
+      passThrough.supportsProviderAllowlist &&
+      passThrough.supportsProviderBlocklist &&
+      passThrough.supportsZdrFilter &&
+      passThrough.supportsDataCollectionDeny &&
+      passThrough.supportsBoundedFallbacks &&
+      facts.entitlements.zeroRetention === true,
+  );
+}
+
+function deny(
+  facts: ProviderTrustFacts,
+  code: string,
+  message: string,
+): ConnectionVerdict {
+  return {
+    allowed: false,
+    explanation: {
+      code,
+      message,
+      providerId: facts.providerId,
+      providerConnectionId: facts.providerConnectionId,
+    },
+  };
+}
+
+function evaluateConnection(
+  facts: ProviderTrustFacts,
+  profiles: AiWorkloadDataProfile[],
+  requiredRegions: string[],
+  postureRequiresLocal: boolean,
+): ConnectionVerdict {
+  if (facts.evidenceStatus === "expired" || facts.evidenceStatus === "rejected") {
+    return deny(facts, "provider-evidence-invalid", "Provider evidence is expired or rejected.");
+  }
+  if (profiles.some((profile) => !profile.classificationKnown) && !isLocal(facts)) {
+    return deny(facts, "classification-unknown", "Unknown data classification stays on a non-egress connection pending review.");
+  }
+  if ((postureRequiresLocal || profiles.some((profile) => profile.residencyClass === "local-only")) && !isLocal(facts)) {
+    return deny(facts, "local-only-required", "This workload is restricted to a non-egress connection.");
+  }
+  if (!regionEligible(facts, requiredRegions)) {
+    return deny(facts, "residency-unproven", "The connection has no proven entitlement for the required processing region.");
+  }
+  if (isLocal(facts)) return { allowed: true };
+
+  if (!routerEligible(facts) && facts.category === "router" && profiles.some((profile) => profile.sensitivity !== "public")) {
+    return deny(facts, "router-controls-unproven", "Restricted work requires bounded router providers, no collection, and proven zero retention.");
+  }
+
+  const classes = new Set(profiles.map((profile) => profile.workloadClass));
+  if (classes.has("secrets-credentials")) {
+    return deny(facts, "credentials-must-not-egress", "Credentials and secrets must not leave the controlled runtime.");
+  }
+  if (classes.has("health-phi")) {
+    if (!hasContract(facts) || facts.contractEvidence.baaOnFile !== true || !hasNoTraining(facts)) {
+      return deny(facts, "healthcare-contract-unproven", "Health information requires a proven contract, BAA, and no-training entitlement.");
+    }
+  }
+  if (classes.has("student-records")) {
+    if (!hasContract(facts) || !facts.contractEvidence.studentDataTermsReviewedAt || !hasNoTraining(facts)) {
+      return deny(facts, "student-terms-unproven", "Student records require reviewed student-data terms and a no-training entitlement.");
+    }
+  }
+  if (classes.has("payments-finance")) {
+    if (!hasContract(facts) || !facts.contractEvidence.financialCustomerInfoReviewedAt || !hasNoTraining(facts)) {
+      return deny(facts, "financial-oversight-unproven", "Financial records require a linked contract, reviewed customer-information controls, and no-training entitlement.");
+    }
+  }
+  if (classes.has("source-code")) {
+    const approvedAccount = facts.accountClass === "business-team" || facts.accountClass === "enterprise";
+    if (!approvedAccount || !hasCurrentEvidence(facts) || !hasNoTraining(facts)) {
+      return deny(facts, "business-account-unproven", "Source code requires a business or enterprise connection with proven no-training treatment.");
+    }
+  }
+
+  const otherRestricted = profiles.some(
+    (profile) =>
+      profile.sensitivity === "restricted" &&
+      !["health-phi", "student-records", "payments-finance", "secrets-credentials"].includes(profile.workloadClass),
+  );
+  if (otherRestricted && (!hasContract(facts) || !hasNoTraining(facts))) {
+    return deny(facts, "restricted-contract-unproven", "Restricted data requires a linked contract and proven no-training treatment.");
+  }
+
+  return { allowed: true };
+}
+
+function residencyPolicy(input: CompileProviderSuitabilityInput): ProviderSuitabilityPolicy["residencyPolicy"] {
+  let derived: ProviderSuitabilityPolicy["residencyPolicy"];
+  if (input.workloadProfiles.some((profile) => !profile.classificationKnown || profile.residencyClass === "local-only")) {
+    derived = "local_only";
+  } else if (
+    input.businessProfile.dataResidency.length > 0 ||
+    input.workloadProfiles.some(
+      (profile) => profile.residencyClass === "region-bound" || profile.sensitivity === "confidential" || profile.sensitivity === "restricted",
+    )
+  ) {
+    derived = "approved_cloud";
+  } else {
+    derived = "any_enabled";
+  }
+
+  const requested = input.goldenTrianglePosture?.residencyPolicy ?? "any_enabled";
+  const rank: Record<ProviderSuitabilityPolicy["residencyPolicy"], number> = {
+    any_enabled: 0,
+    approved_cloud: 1,
+    local_only: 2,
+  };
+  return rank[requested] > rank[derived] ? requested : derived;
+}
+
+function openRouterObligations(input: CompileProviderSuitabilityInput): OpenRouterPolicyObligations | null {
+  if (!input.providerFacts.some((facts) => facts.category === "router")) return null;
+  const restricted = input.workloadProfiles.some((profile) => profile.sensitivity !== "public");
+  return {
+    requireProviderAllowlist: restricted,
+    requireProviderBlocklist: restricted,
+    requireZdr: restricted,
+    denyDataCollection: restricted,
+    requireBoundedFallbacks: restricted,
+    requiredRegion: input.businessProfile.dataResidency[0]?.toLowerCase() ?? null,
+  };
+}
+
+export function compileAiProviderSuitabilityPolicy(
+  input: CompileProviderSuitabilityInput,
+): ProviderSuitabilityPolicy {
+  const policySeed = {
+    organizationId: input.businessProfile.organizationId,
+    businessProfile: {
+      archetypeId: input.businessProfile.archetypeId,
+      archetypeCategory: input.businessProfile.archetypeCategory,
+      operatesIn: sortedUnique(input.businessProfile.operatesIn),
+      sellsTo: sortedUnique(input.businessProfile.sellsTo),
+      employsIn: sortedUnique(input.businessProfile.employsIn),
+      dataResidency: sortedUnique(input.businessProfile.dataResidency),
+      riskPosture: input.businessProfile.riskPosture,
+    },
+    source: input.source,
+    activityClass: input.activityClass ?? null,
+    workloads: input.workloadProfiles
+      .map((profile) => [
+        profile.workloadClass,
+        profile.classificationKnown,
+        profile.sensitivity,
+        profile.residencyClass,
+        sortedUnique(profile.applicableRegulationIds),
+      ])
+      .sort(),
+    dataPolicyDecisions: input.dataPolicyDecisions
+      .map((decision) => [decision.decisionId, decision.inputHash, decision.effect])
+      .sort(),
+    providers: input.providerFacts
+      .map((facts) => [
+        facts.providerId,
+        facts.providerConnectionId,
+        facts.accountClass,
+        facts.evidenceStatus,
+        facts.lastReviewedAt,
+        facts.contractEvidence,
+        facts.entitlements,
+      ])
+      .sort(),
+    regulationResults: input.regulationResults
+      .map(({ regulationId, applicability }) => [regulationId, applicability.applies, applicability.undeclared])
+      .sort(),
+    goldenTriangleResidency: input.goldenTrianglePosture?.residencyPolicy ?? null,
+  };
+
+  if (input.dataPolicyDecisions.some((decision) => decision.effect === "deny")) {
+    return {
+      policyId: `aips-${stableHash(policySeed)}`,
+      organizationId: input.businessProfile.organizationId,
+      source: input.source,
+      effect: "deny",
+      allowedProviders: [],
+      deniedProviders: sortedUnique(input.providerFacts.map((facts) => facts.providerId)),
+      allowedProviderConnectionIds: [],
+      deniedProviderConnectionIds: sortedUnique(input.providerFacts.map((facts) => facts.providerConnectionId)),
+      residencyPolicy: residencyPolicy(input),
+      openRouterObligations: openRouterObligations(input),
+      explanations: [{ code: "data-policy-deny", message: "The governed data policy decision denies this processing." }],
+      compilerVersion: PROVIDER_SUITABILITY_COMPILER_VERSION,
+    };
+  }
+
+  const verdicts = input.providerFacts.map((facts) => ({
+    facts,
+    verdict: evaluateConnection(
+      facts,
+      input.workloadProfiles,
+      input.businessProfile.dataResidency,
+      input.goldenTrianglePosture?.residencyPolicy === "local_only",
+    ),
+  }));
+  const allowedConnections = verdicts.filter(({ verdict }) => verdict.allowed);
+  const deniedConnections = verdicts.filter(({ verdict }) => !verdict.allowed);
+  const explanations = deniedConnections.flatMap(({ verdict }) => verdict.explanation ? [verdict.explanation] : []);
+
+  const providerGroups = new Map<string, typeof verdicts>();
+  for (const item of verdicts) {
+    providerGroups.set(item.facts.providerId, [...(providerGroups.get(item.facts.providerId) ?? []), item]);
+  }
+
+  const allowedProviders: string[] = [];
+  const deniedProviders: string[] = [];
+  let ambiguous = false;
+  for (const [providerId, group] of providerGroups) {
+    const allowedCount = group.filter(({ verdict }) => verdict.allowed).length;
+    if (allowedCount === group.length) {
+      allowedProviders.push(providerId);
+    } else {
+      deniedProviders.push(providerId);
+      if (allowedCount > 0) {
+        ambiguous = true;
+        explanations.push({
+          code: "provider-connection-ambiguous",
+          message: "This provider has both approved and unapproved connections; provider-level routing remains blocked until a connection is selected explicitly.",
+          providerId,
+        });
+      }
+    }
+  }
+
+  const classificationUnknown = input.workloadProfiles.some((profile) => !profile.classificationKnown);
+  const dataReview = input.dataPolicyDecisions.some(
+    (decision) => decision.effect === "review" || decision.effect === "allow-with-obligations",
+  );
+  const regulationReview = input.regulationResults.some(({ applicability }) => applicability.undeclared);
+  for (const { regulationId, applicability } of input.regulationResults) {
+    if (applicability.undeclared) {
+      explanations.push({
+        code: "regulation-applicability-unknown",
+        message: `${regulationId} needs a declared jurisdiction basis before hosted processing can be approved.`,
+      });
+    }
+  }
+  const restrictedHostedUnavailable = input.workloadProfiles.some(
+    (profile) => profile.residencyClass === "region-bound" && profile.sensitivity === "restricted",
+  ) && !allowedConnections.some(({ facts }) => !isLocal(facts));
+
+  let effect: ProviderSuitabilityPolicy["effect"] = "allow";
+  if (allowedProviders.length === 0 && allowedConnections.length === 0) effect = "deny";
+  else if (classificationUnknown || dataReview || regulationReview || ambiguous || restrictedHostedUnavailable) effect = "review";
+
+  return {
+    policyId: `aips-${stableHash(policySeed)}`,
+    organizationId: input.businessProfile.organizationId,
+    source: input.source,
+    effect,
+    allowedProviders: sortedUnique(allowedProviders),
+    deniedProviders: sortedUnique(deniedProviders),
+    allowedProviderConnectionIds: sortedUnique(
+      allowedConnections.map(({ facts }) => facts.providerConnectionId),
+    ),
+    deniedProviderConnectionIds: sortedUnique(
+      deniedConnections.map(({ facts }) => facts.providerConnectionId),
+    ),
+    residencyPolicy: residencyPolicy(input),
+    openRouterObligations: openRouterObligations(input),
+    explanations,
+    compilerVersion: PROVIDER_SUITABILITY_COMPILER_VERSION,
+  };
+}

--- a/apps/web/lib/routing/provider-suitability/provider-trust.ts
+++ b/apps/web/lib/routing/provider-suitability/provider-trust.ts
@@ -1,0 +1,93 @@
+import type {
+  ProviderCatalogTrustFacts,
+  ProviderConnectionPosture,
+  ProviderConnectionSourceFacts,
+  ProviderTrustFacts,
+} from "./types";
+
+function sortedUnique(values: readonly string[] | undefined): string[] {
+  return [...new Set((values ?? []).map((value) => value.trim()).filter(Boolean))].sort();
+}
+
+function authMethod(value: string | null): ProviderConnectionPosture["authMethod"] {
+  if (value === "api_key") return "api-key";
+  if (value === "oauth2_authorization_code") return "oauth";
+  if (value === "oauth2_client_credentials") return "workload-identity";
+  if (value === "none") return "local";
+  return "unknown";
+}
+
+export function deriveProviderConnectionAccessPosture(
+  input: ProviderConnectionSourceFacts,
+): ProviderConnectionPosture {
+  const resolvedAuth = authMethod(input.modelProviderAuthMethod);
+  const executionChannel: ProviderConnectionPosture["executionChannel"] =
+    input.externalEgress === "none"
+      ? "local-runtime"
+      : input.providerCategory === "router"
+        ? "hosted-router"
+        : input.cloudTenant
+          ? "cloud-tenant"
+          : resolvedAuth === "oauth" && input.cliEngine
+            ? "subscription-cli"
+            : "direct-api";
+
+  const accountClass = input.accountClassAttestation ?? "unknown";
+  const commercialBasis =
+    input.commercialBasisAttestation ??
+    (executionChannel === "local-runtime"
+      ? "local-compute"
+      : executionChannel === "subscription-cli"
+        ? "subscription-included"
+        : input.costModel === "token"
+          ? "usage-metered"
+          : "unknown");
+
+  return {
+    providerConnectionId: input.providerConnectionId,
+    providerId: input.providerId,
+    executionChannel,
+    accountClass,
+    commercialBasis,
+    authMethod: resolvedAuth,
+    contractEvidence: { ...(input.contractEvidence ?? {}) },
+    entitlements: {
+      ...(input.entitlements ?? {}),
+      enabledRegions: sortedUnique(input.entitlements?.enabledRegions),
+    },
+    evidenceStatus: input.evidenceStatus ?? "unreviewed",
+    lastReviewedAt: input.lastReviewedAt ?? null,
+  };
+}
+
+/**
+ * Resolve catalog capability and connected-account posture without allowing
+ * vendor-wide facts to manufacture account entitlements. This is deliberately
+ * pure: DB/credential/finance adapters must first project their owned facts into
+ * the connection posture.
+ */
+export function resolveProviderTrustFacts(input: {
+  catalog: ProviderCatalogTrustFacts;
+  connection: ProviderConnectionPosture;
+}): ProviderTrustFacts {
+  if (input.catalog.providerId !== input.connection.providerId) {
+    throw new Error(
+      `provider trust mismatch: catalog ${input.catalog.providerId} != connection ${input.connection.providerId}`,
+    );
+  }
+
+  return {
+    ...input.catalog,
+    ...input.connection,
+    jurisdictions: sortedUnique(input.catalog.jurisdictions),
+    supportedRegions: sortedUnique(input.catalog.supportedRegions),
+    regionalEndpoints: [...input.catalog.regionalEndpoints]
+      .map((endpoint) => ({ ...endpoint, region: endpoint.region.toLowerCase() }))
+      .sort((a, b) => a.region.localeCompare(b.region)),
+    contractEvidence: { ...input.connection.contractEvidence },
+    entitlements: {
+      ...input.connection.entitlements,
+      enabledRegions: sortedUnique(input.connection.entitlements.enabledRegions),
+    },
+  };
+}

--- a/apps/web/lib/routing/provider-suitability/types.ts
+++ b/apps/web/lib/routing/provider-suitability/types.ts
@@ -1,0 +1,203 @@
+import type { ApplicabilityResult } from "@dpf/db/regulation-applicability";
+import type { DataPolicyDecision } from "@/lib/govern/data/policy-decision";
+import type {
+  DataAssetId,
+  DataCategory,
+  DataFieldId,
+  DataSensitivity,
+  ProcessingPurposeKey,
+  ResidencyClassKey,
+} from "@/lib/govern/data/taxonomy";
+import type { PostureOverride } from "@/lib/golden-triangle/types";
+import type { RequestContract } from "../request-contract";
+
+export type AiWorkloadClassKey =
+  | "public-marketing"
+  | "internal-operations"
+  | "customer-records"
+  | "employee-records"
+  | "payments-finance"
+  | "health-phi"
+  | "student-records"
+  | "legal-privileged"
+  | "security-logs"
+  | "public-sector-records"
+  | "regulated-decisioning"
+  | "source-code"
+  | "secrets-credentials";
+
+export type AiWorkloadDataProfile = {
+  workloadClass: AiWorkloadClassKey;
+  assetIds: DataAssetId[];
+  fieldIds?: DataFieldId[];
+  sensitivity: DataSensitivity;
+  categories: DataCategory[];
+  purpose: ProcessingPurposeKey;
+  residencyClass: ResidencyClassKey;
+  classificationKnown: boolean;
+  processingActivityId?: string;
+  applicableRegulationIds: string[];
+};
+
+export type ProviderCategory = "direct" | "router" | "local" | "self-hosted";
+export type ProviderExecutionChannel =
+  | "direct-api"
+  | "subscription-cli"
+  | "hosted-router"
+  | "cloud-tenant"
+  | "local-runtime";
+export type ProviderAccountClass = "regular" | "business-team" | "enterprise" | "unknown";
+export type ProviderCommercialBasis =
+  | "usage-metered"
+  | "subscription-included"
+  | "enterprise-contract"
+  | "local-compute"
+  | "unknown";
+export type ProviderConnectionAuthMethod =
+  | "api-key"
+  | "oauth"
+  | "workload-identity"
+  | "local"
+  | "unknown";
+
+export type ProviderCatalogTrustFacts = {
+  /** Runtime provider key. Catalog aliases may share catalogProviderId. */
+  providerId: string;
+  catalogProviderId: string;
+  category: ProviderCategory;
+  jurisdictions: string[];
+  externalEgress: "none" | "provider-cloud" | "router-cloud" | "self-hosted-network" | "unknown";
+  supportsZdr: boolean | null;
+  supportsNoTraining: boolean | null;
+  supportsRegionalRouting: boolean | null;
+  supportedRegions: string[];
+  regionalEndpoints: Array<{
+    region: string;
+    baseUrl: string;
+    requiresEnterpriseEnablement: boolean;
+  }>;
+  routerPassThrough?: {
+    exposesUnderlyingProvider: boolean;
+    supportsProviderAllowlist: boolean;
+    supportsProviderBlocklist: boolean;
+    supportsZdrFilter: boolean;
+    supportsDataCollectionDeny: boolean;
+    supportsBoundedFallbacks: boolean;
+  };
+};
+
+export type ProviderContractEvidence = {
+  supplierContractId?: string | null;
+  contractPlanName?: string | null;
+  dpaOnFile?: boolean | null;
+  baaAvailable?: boolean | null;
+  baaOnFile?: boolean | null;
+  dpaAvailable?: boolean | null;
+  serviceProviderOversightReviewedAt?: string | null;
+  studentDataTermsReviewedAt?: string | null;
+  financialCustomerInfoReviewedAt?: string | null;
+  fedrampEligible?: boolean | null;
+  soc2?: boolean | null;
+  iso27001?: boolean | null;
+};
+
+export type ProviderEntitlements = {
+  zeroRetention?: boolean | null;
+  noTraining?: boolean | null;
+  regionalProcessing?: boolean | null;
+  adminAuditControls?: boolean | null;
+  enterpriseSupportOrSla?: boolean | null;
+  enabledRegions?: string[];
+};
+
+export type ProviderConnectionPosture = {
+  providerConnectionId: string;
+  providerId: string;
+  executionChannel: ProviderExecutionChannel;
+  accountClass: ProviderAccountClass;
+  commercialBasis: ProviderCommercialBasis;
+  authMethod: ProviderConnectionAuthMethod;
+  contractEvidence: ProviderContractEvidence;
+  entitlements: ProviderEntitlements;
+  evidenceStatus: "unreviewed" | "operator-attested" | "contract-uploaded" | "expired" | "rejected";
+  lastReviewedAt: string | null;
+};
+
+/** Read projection of facts owned by provider/auth/finance/contract setup. */
+export type ProviderConnectionSourceFacts = {
+  providerConnectionId: string;
+  providerId: string;
+  providerCategory: ProviderCategory;
+  externalEgress: ProviderCatalogTrustFacts["externalEgress"];
+  modelProviderAuthMethod: string | null;
+  credentialStatus?: string | null;
+  cliEngine?: string | null;
+  costModel?: string | null;
+  cloudTenant?: boolean;
+  accountClassAttestation?: ProviderAccountClass;
+  commercialBasisAttestation?: ProviderCommercialBasis;
+  contractEvidence?: ProviderContractEvidence;
+  entitlements?: ProviderEntitlements;
+  evidenceStatus?: ProviderConnectionPosture["evidenceStatus"];
+  lastReviewedAt?: string | null;
+};
+
+export type ProviderTrustFacts = ProviderCatalogTrustFacts & ProviderConnectionPosture;
+
+export type BusinessSuitabilityProfile = {
+  organizationId: string;
+  archetypeId: string | null;
+  archetypeCategory: string | null;
+  operatesIn: string[];
+  sellsTo: string[];
+  employsIn: string[];
+  dataResidency: string[];
+  riskPosture: "conservative" | "balanced" | "progressive" | null;
+};
+
+export type RegulationSuitabilityResult = {
+  regulationId: string;
+  applicability: ApplicabilityResult;
+};
+
+export type ProviderSuitabilityExplanation = {
+  code: string;
+  message: string;
+  providerId?: string;
+  providerConnectionId?: string;
+};
+
+export type OpenRouterPolicyObligations = {
+  requireProviderAllowlist: boolean;
+  requireProviderBlocklist: boolean;
+  requireZdr: boolean;
+  denyDataCollection: boolean;
+  requireBoundedFallbacks: boolean;
+  requiredRegion: string | null;
+};
+
+export type ProviderSuitabilityPolicy = {
+  policyId: string;
+  organizationId: string;
+  source: "onboarding" | "admin" | "regulatory-review" | "default";
+  effect: "allow" | "review" | "deny";
+  allowedProviders: string[];
+  deniedProviders: string[];
+  allowedProviderConnectionIds: string[];
+  deniedProviderConnectionIds: string[];
+  residencyPolicy: NonNullable<RequestContract["residencyPolicy"]>;
+  openRouterObligations: OpenRouterPolicyObligations | null;
+  explanations: ProviderSuitabilityExplanation[];
+  compilerVersion: string;
+};
+
+export type CompileProviderSuitabilityInput = {
+  businessProfile: BusinessSuitabilityProfile;
+  workloadProfiles: AiWorkloadDataProfile[];
+  dataPolicyDecisions: DataPolicyDecision[];
+  regulationResults: RegulationSuitabilityResult[];
+  providerFacts: ProviderTrustFacts[];
+  source: ProviderSuitabilityPolicy["source"];
+  activityClass?: string;
+  goldenTrianglePosture?: PostureOverride;
+};

--- a/apps/web/lib/routing/provider-suitability/workload-profile.ts
+++ b/apps/web/lib/routing/provider-suitability/workload-profile.ts
@@ -1,0 +1,115 @@
+import type {
+  DataAssetId,
+  DataCategory,
+  DataSensitivity,
+  ResidencyClassKey,
+} from "@/lib/govern/data/taxonomy";
+import type { AiWorkloadClassKey, AiWorkloadDataProfile } from "./types";
+
+type WorkloadBinding = {
+  assetId: DataAssetId;
+  sensitivity: DataSensitivity;
+  categories: DataCategory[];
+  residencyClass: ResidencyClassKey;
+};
+
+const WORKLOAD_BINDINGS: Readonly<Record<AiWorkloadClassKey, WorkloadBinding>> = {
+  "public-marketing": {
+    assetId: "data:marketing-content",
+    sensitivity: "public",
+    categories: ["content"],
+    residencyClass: "unrestricted",
+  },
+  "internal-operations": {
+    assetId: "data:internal-operations",
+    sensitivity: "internal",
+    categories: ["operational"],
+    residencyClass: "unrestricted",
+  },
+  "customer-records": {
+    assetId: "data:customer-record",
+    sensitivity: "confidential",
+    categories: ["identity", "contact", "operational"],
+    residencyClass: "region-bound",
+  },
+  "employee-records": {
+    assetId: "data:employee-record",
+    sensitivity: "restricted",
+    categories: ["identity", "contact", "personal-attribute"],
+    residencyClass: "region-bound",
+  },
+  "payments-finance": {
+    assetId: "data:financial-record",
+    sensitivity: "restricted",
+    categories: ["financial", "identity"],
+    residencyClass: "region-bound",
+  },
+  "health-phi": {
+    assetId: "data:health-record",
+    sensitivity: "restricted",
+    categories: ["identity", "personal-attribute", "content"],
+    residencyClass: "region-bound",
+  },
+  "student-records": {
+    assetId: "data:student-record",
+    sensitivity: "restricted",
+    categories: ["identity", "personal-attribute", "content"],
+    residencyClass: "region-bound",
+  },
+  "legal-privileged": {
+    assetId: "data:legal-privileged-record",
+    sensitivity: "restricted",
+    categories: ["identity", "content", "operational"],
+    residencyClass: "region-bound",
+  },
+  "security-logs": {
+    assetId: "data:security-log",
+    sensitivity: "restricted",
+    categories: ["security-audit", "telemetry"],
+    residencyClass: "region-bound",
+  },
+  "public-sector-records": {
+    assetId: "data:public-sector-record",
+    sensitivity: "restricted",
+    categories: ["identity", "operational", "content"],
+    residencyClass: "region-bound",
+  },
+  "regulated-decisioning": {
+    assetId: "data:regulated-decision",
+    sensitivity: "restricted",
+    categories: ["identity", "personal-attribute", "derived-analytic"],
+    residencyClass: "region-bound",
+  },
+  "source-code": {
+    assetId: "data:source-code",
+    sensitivity: "confidential",
+    categories: ["content", "configuration"],
+    residencyClass: "region-bound",
+  },
+  "secrets-credentials": {
+    assetId: "data:credential-secret",
+    sensitivity: "restricted",
+    categories: ["credential-secret", "authorization"],
+    residencyClass: "local-only",
+  },
+};
+
+export function deriveAiWorkloadDataProfile(input: {
+  workloadClass: AiWorkloadClassKey;
+  classificationKnown?: boolean;
+  applicableRegulationIds?: string[];
+  processingActivityId?: string;
+}): AiWorkloadDataProfile {
+  const binding = WORKLOAD_BINDINGS[input.workloadClass];
+  return {
+    workloadClass: input.workloadClass,
+    assetIds: [binding.assetId],
+    sensitivity: binding.sensitivity,
+    categories: [...binding.categories],
+    purpose: "coworker-assistance",
+    residencyClass: binding.residencyClass,
+    classificationKnown: input.classificationKnown ?? true,
+    applicableRegulationIds: [...new Set(input.applicableRegulationIds ?? [])].sort(),
+    ...(input.processingActivityId ? { processingActivityId: input.processingActivityId } : {}),
+  };
+}

--- a/docs/data-impact/2026-07-19-ai-provider-connection.data-impact.json
+++ b/docs/data-impact/2026-07-19-ai-provider-connection.data-impact.json
@@ -1,0 +1,77 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [
+    "ModelProvider.catalogEntry: vendor capability and catalog identity only"
+  ],
+  "migration": {
+    "name": "20260719233000_ai_provider_connection",
+    "backfill": "one unreviewed default connection per existing non-transcription provider; no account class, contract, or entitlement is inferred"
+  },
+  "tests": [
+    "apps/web/lib/govern/data/coverage.live.test.ts",
+    "apps/web/lib/routing/provider-suitability/compile.test.ts",
+    "apps/web/lib/ai-provider-route-context.test.ts",
+    "packages/db/src/provider-trust-registry.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:ai-provider-connection",
+      "prismaModel": "AiProviderConnection",
+      "lifecycleDisposition": "legal-evidence retained with provider governance history",
+      "fields": [
+        {
+          "fieldId": "data:ai-provider-connection#connectionId",
+          "resolution": "governed",
+          "reason": "stable connection identity prevents account evidence from becoming provider-wide authorization",
+          "provenance": "provider setup and conservative seed projection"
+        },
+        {
+          "fieldId": "data:ai-provider-connection#organizationId",
+          "resolution": "governed",
+          "reason": "organization scope determines whose provider posture and contractual evidence may be used",
+          "provenance": "organization provider onboarding",
+          "flags": ["subject", "sensitive"],
+          "fieldPolicy": "local-only metadata; organization-scoped authorization required"
+        },
+        {
+          "fieldId": "data:ai-provider-connection#contractEvidence",
+          "resolution": "governed",
+          "reason": "contract review facts are connection-specific legal evidence and may not transfer across accounts",
+          "provenance": "operator attestation or reviewed supplier contract",
+          "flags": ["sensitive"],
+          "fieldPolicy": "fail closed unless current connection-scoped evidence is reviewed"
+        },
+        {
+          "fieldId": "data:ai-provider-connection#entitlements",
+          "resolution": "governed",
+          "reason": "zero-retention, no-training, regional-processing, and control entitlements must be proven for this connection",
+          "provenance": "operator attestation or reviewed provider account evidence",
+          "flags": ["sensitive"],
+          "fieldPolicy": "unknown by default; vendor capabilities never manufacture account entitlement"
+        },
+        {
+          "fieldId": "data:ai-provider-connection#accountClass",
+          "resolution": "governed",
+          "reason": "personal, team, and enterprise posture changes which workloads may be approved",
+          "provenance": "explicit account-class attestation",
+          "flags": ["sensitive"],
+          "fieldPolicy": "unknown by default; business or enterprise status requires current evidence"
+        }
+      ]
+    },
+    {
+      "kind": "policy",
+      "policyId": "ai-provider-suitability-compiler-v1",
+      "testVectors": {
+        "allow": true,
+        "deny": true,
+        "obligation": true,
+        "unknownContext": true,
+        "precedence": true,
+        "exceptionExpiry": true
+      }
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-19-ai-provider-suitability-routing.md
+++ b/docs/superpowers/plans/2026-07-19-ai-provider-suitability-routing.md
@@ -91,28 +91,42 @@ Reserve approximately 20% of delivery capacity for focused cleanup that makes th
 ### Task 3: BI-AIPS-003 - Trust Facts And Pure Suitability Compiler
 
 **Files:**
+- Modify: `packages/db/prisma/schema.prisma`
+- Add: `packages/db/prisma/migrations/20260719233000_ai_provider_connection/migration.sql`
+- Create: `packages/db/src/provider-connection.ts`
+- Modify: `packages/db/src/seed.ts`
+- Create: `packages/db/src/provider-trust-registry.test.ts`
 - Create: `apps/web/lib/routing/provider-suitability/types.ts`
 - Create: `apps/web/lib/routing/provider-suitability/workload-profile.ts`
 - Create: `apps/web/lib/routing/provider-suitability/provider-trust.ts`
 - Create: `apps/web/lib/routing/provider-suitability/compile.ts`
 - Create: `apps/web/lib/routing/provider-suitability/compile.test.ts`
 - Modify: `apps/web/lib/ai-provider-route-context.ts`
+- Modify: `apps/web/lib/inference/ai-provider-types.ts`
+- Modify: `apps/web/lib/actions/ai-providers.ts`
+- Modify: `apps/web/lib/actions/ai-providers.test.ts`
+- Modify: `apps/web/lib/govern/data/assets.ts`
+- Create: `docs/data-impact/2026-07-19-ai-provider-connection.data-impact.json`
 - Modify: `packages/db/data/providers-registry.json`
 - Test: `apps/web/lib/ai-provider-route-context.test.ts`
 - Test: provider-registry validation tests discovered by `pnpm --filter @dpf/db exec vitest run`
 
-- [ ] Write failing type/derivation tests for public marketing, health PHI, student records, financial records, source code, and credentials.
-- [ ] Import `DataAssetId`, `DataFieldId`, `DataSensitivity`, `DataCategory`, `ProcessingPurposeKey`, and `ResidencyClassKey` from `apps/web/lib/govern/data/taxonomy.ts`; do not redeclare them.
-- [ ] Write failing compiler tests for dental, retail, credit union, training, software, unknown-classification, conflicting-residency, and missing-contract cases.
-- [ ] Define provider facts in two layers: vendor/catalog facts in the existing provider registry; organization/account attestations remain separate inputs and default to unknown.
-- [ ] Derive a connection-scoped access posture from existing auth, credential, finance, contract, execution-adapter, and capacity owners: execution channel, account class, commercial basis, auth method, contract linkage, and proven entitlements.
-- [ ] Write failing tests for the same provider/model over regular metered API, subscription/OAuth or host CLI, enterprise-contracted API/cloud, router, and local connections. Prove evidence and enterprise rights never transfer between connections.
-- [ ] Audit whether one-row-per-`providerId` can support simultaneous accounts for one vendor. If not, introduce the smallest connection/profile identity that preserves `ModelProvider` as catalog ownership rather than encoding account tier in provider IDs.
-- [ ] Implement `compileAiProviderSuitabilityPolicy()` as a pure adapter over business context, `regulationApplies()` output, governed data/PDP output, activity/work context, provider facts, and Golden Triangle posture.
-- [ ] Return `allowedProviders`, `deniedProviders`, `residencyPolicy`, OpenRouter obligations, effect (`allow|review|deny`), and structured explanations. Never select an endpoint.
-- [ ] Pass the compiled route context into existing `inferContract()` composition.
-- [ ] Run targeted tests, web typecheck, registry validation, and production build.
-- [ ] Commit with DCO: `feat(routing): compile provider suitability policy`.
+**Governed data-model decision:** `DI-8902B7A5BE49` selects a separate
+`AiProviderConnection` identity. Existing provider rows are backfilled as
+unreviewed connections; no account tier, contract, or entitlement is inferred.
+
+- [x] Write failing type/derivation tests for public marketing, health PHI, student records, financial records, source code, and credentials.
+- [x] Import `DataAssetId`, `DataFieldId`, `DataSensitivity`, `DataCategory`, `ProcessingPurposeKey`, and `ResidencyClassKey` from `apps/web/lib/govern/data/taxonomy.ts`; do not redeclare them.
+- [x] Write failing compiler tests for dental, retail, credit union, training, software, unknown-classification, conflicting-residency, and missing-contract cases.
+- [x] Define provider facts in two layers: vendor/catalog facts in the existing provider registry; organization/account attestations remain separate inputs and default to unknown.
+- [x] Derive a connection-scoped access posture from existing auth, credential, finance, contract, execution-adapter, and capacity owners: execution channel, account class, commercial basis, auth method, contract linkage, and proven entitlements.
+- [x] Write failing tests for the same provider/model over regular metered API, subscription/OAuth or host CLI, enterprise-contracted API/cloud, router, and local connections. Prove evidence and enterprise rights never transfer between connections.
+- [x] Audit whether one-row-per-`providerId` can support simultaneous accounts for one vendor. If not, introduce the smallest connection/profile identity that preserves `ModelProvider` as catalog ownership rather than encoding account tier in provider IDs.
+- [x] Implement `compileAiProviderSuitabilityPolicy()` as a pure adapter over business context, `regulationApplies()` output, governed data/PDP output, activity/work context, provider facts, and Golden Triangle posture.
+- [x] Return `allowedProviders`, `deniedProviders`, `residencyPolicy`, OpenRouter obligations, effect (`allow|review|deny`), and structured explanations. Never select an endpoint.
+- [x] Pass the compiled route context into existing `inferContract()` composition.
+- [x] Run targeted tests, web typecheck, registry validation, and production build.
+- [x] Commit with DCO: `feat(routing): compile provider suitability policy`.
 
 ## Chunk 2: Guide Setup And Bound Router Providers
 

--- a/docs/superpowers/specs/2026-07-19-ai-provider-suitability-routing-design.md
+++ b/docs/superpowers/specs/2026-07-19-ai-provider-suitability-routing-design.md
@@ -339,6 +339,39 @@ DPF must therefore keep three layers separate:
 2. **Connected-account posture:** which execution channel and account class the installed credential actually represents.
 3. **Proven entitlement:** which contractual or account-level controls are enabled for that connection and remain within their review/expiry window.
 
+#### Connection Identity Decision (`BI-AIPS-003`)
+
+`ModelProvider.providerId` remains the catalog/runtime provider key. A separate
+`AiProviderConnection.connectionId` identifies the configured account or channel
+and owns its access posture. The connection references the canonical owners that
+already exist—`CredentialEntry`, `AiProviderFinanceProfile`, `SupplierContract`,
+and `ProviderCapacityStatus`—rather than copying their secrets, balances,
+contracts, or live capacity state.
+
+The provider registry may declare a `catalogProviderId` so channel aliases such
+as `anthropic` and `anthropic-sub`, or `openai`, `chatgpt`, and `codex`, share a
+vendor/catalog identity. Registry `trustCatalog` contains capabilities or
+unknowns only. It must never contain account class, contract evidence,
+entitlements, or evidence status.
+
+The migration creates one unreviewed default connection for each existing model
+provider channel other than transcription and links matching credential,
+finance, and capacity owners. The
+provider seed and registry sync create the same conservative default connection
+for fresh installs and newly added providers, then refresh links to those
+canonical owners without taking an owner already assigned to an explicit
+connection. Transcription services are excluded. No path infers a business or
+enterprise account, attaches a supplier contract, or grants an entitlement.
+This makes upgrades and cold starts fail closed.
+
+Until endpoint selection carries `connectionId`, a mixed provider slug—one
+approved connection and one unapproved connection—remains blocked at the
+provider fence. The compiler may explain which connection is approved, but it
+must not turn that connection's evidence into provider-wide authorization.
+
+This shape was selected by governed kernel decision `DI-8902B7A5BE49` with high
+confidence over provider-slug proliferation and a broad catalog-parent retrofit.
+
 An API key does not prove an enterprise contract. An OAuth subscription does not prove API rights or enterprise controls. A vendor advertising ZDR, regional processing, a BAA, DPA, SSO, audit administration, or an SLA does not prove the connected account is entitled to it. Unknown account class or entitlement remains `review` or `deny` for restricted work.
 
 For local providers:
@@ -839,7 +872,7 @@ Docs:
 3. What is the minimum provider trust catalog seed for launch: local, OpenAI, Anthropic, Google, Azure, Bedrock, OpenRouter, LiteLLM, Z.ai?
 4. Should the first UI be in `/platform/ai/providers`, `/setup`, or the AI Operations Map?
 5. Which verticals get the first governed data bindings and workload hints: healthcare, finance, education, source-code/Build Studio, or all four?
-6. Can the current one-row-per-`providerId` `ModelProvider` shape represent multiple simultaneous accounts for the same vendor, or should the first implementation introduce a connection/profile identity while preserving provider catalog identity?
+6. **Resolved by `BI-AIPS-003`:** one-row-per-`providerId` cannot safely carry simultaneous account evidence. Use `AiProviderConnection` for the configured account/channel while preserving `ModelProvider` and `catalogProviderId` as catalog/runtime identity.
 
 ## 18. Recommended First Implementation Slice
 

--- a/packages/db/data/providers-registry.json
+++ b/packages/db/data/providers-registry.json
@@ -33,7 +33,18 @@
       "setupDifficulty": "easy",
       "regulatoryNotes": "SOC 2 Type II certified. Suitable for most business data. Consult compliance team for healthcare/financial PII."
     },
-    "supportsToolUse": true
+    "supportsToolUse": true,
+    "catalogProviderId": "anthropic",
+    "trustCatalog": {
+      "category": "direct",
+      "jurisdictions": [],
+      "externalEgress": "provider-cloud",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "anthropic-sub",
@@ -61,8 +72,7 @@
     "tokenUrl": "https://platform.claude.com/v1/oauth/token",
     "oauthClientId": "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
     "oauthRedirectUri": null,
-    "modelRestrictions": [
-    ],
+    "modelRestrictions": [],
     "catalogVisibility": "visible",
     "userFacing": {
       "plainDescription": "Anthropic's Claude models accessed through a subscription plan.",
@@ -75,7 +85,18 @@
       "setupDifficulty": "easy",
       "regulatoryNotes": "Same as Anthropic. SOC 2 Type II certified."
     },
-    "supportsToolUse": true
+    "supportsToolUse": true,
+    "catalogProviderId": "anthropic",
+    "trustCatalog": {
+      "category": "direct",
+      "jurisdictions": [],
+      "externalEgress": "provider-cloud",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "openai",
@@ -111,7 +132,18 @@
       "setupDifficulty": "easy",
       "regulatoryNotes": "SOC 2 Type II certified. Enterprise tier available for stricter data handling."
     },
-    "supportsToolUse": true
+    "supportsToolUse": true,
+    "catalogProviderId": "openai",
+    "trustCatalog": {
+      "category": "direct",
+      "jurisdictions": [],
+      "externalEgress": "provider-cloud",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "zai",
@@ -146,7 +178,18 @@
       "setupDifficulty": "easy",
       "regulatoryNotes": "Review Z.ai terms and compliance documentation before using sensitive or regulated data."
     },
-    "supportsToolUse": true
+    "supportsToolUse": true,
+    "catalogProviderId": "zai",
+    "trustCatalog": {
+      "category": "direct",
+      "jurisdictions": [],
+      "externalEgress": "provider-cloud",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "zai-coding",
@@ -182,7 +225,18 @@
       "setupDifficulty": "easy",
       "regulatoryNotes": "Review Z.ai terms and compliance documentation before using sensitive or regulated code or data."
     },
-    "supportsToolUse": true
+    "supportsToolUse": true,
+    "catalogProviderId": "zai",
+    "trustCatalog": {
+      "category": "direct",
+      "jurisdictions": [],
+      "externalEgress": "provider-cloud",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "azure-openai",
@@ -218,7 +272,18 @@
       "setupDifficulty": "moderate",
       "regulatoryNotes": "Inherits Azure compliance certifications (ISO 27001, SOC 2, HIPAA BAA available). Strong choice for regulated industries."
     },
-    "supportsToolUse": true
+    "supportsToolUse": true,
+    "catalogProviderId": "microsoft",
+    "trustCatalog": {
+      "category": "direct",
+      "jurisdictions": [],
+      "externalEgress": "provider-cloud",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "gemini",
@@ -253,7 +318,18 @@
       "setupDifficulty": "easy",
       "regulatoryNotes": "SOC 2 Type II certified. Google Workspace customers have additional data processing agreements. Verify terms for sensitive data."
     },
-    "supportsToolUse": true
+    "supportsToolUse": true,
+    "catalogProviderId": "google",
+    "trustCatalog": {
+      "category": "direct",
+      "jurisdictions": [],
+      "externalEgress": "provider-cloud",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "bedrock",
@@ -288,6 +364,17 @@
       "dataResidency": "Your chosen AWS region. Data stays within your AWS account boundary.",
       "setupDifficulty": "complex",
       "regulatoryNotes": "Inherits AWS compliance certifications (ISO 27001, SOC 2, HIPAA, FedRAMP). Best choice for organisations with strict data sovereignty requirements."
+    },
+    "catalogProviderId": "aws",
+    "trustCatalog": {
+      "category": "direct",
+      "jurisdictions": [],
+      "externalEgress": "provider-cloud",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
     }
   },
   {
@@ -328,7 +415,20 @@
       "setupDifficulty": "automatic",
       "regulatoryNotes": "Maximum privacy. Suitable for all sensitivity levels including restricted/regulated data."
     },
-    "supportsToolUse": true
+    "supportsToolUse": true,
+    "catalogProviderId": "local",
+    "trustCatalog": {
+      "category": "local",
+      "jurisdictions": [
+        "local"
+      ],
+      "externalEgress": "none",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "ollama",
@@ -337,10 +437,22 @@
     "cliEngine": "opencode",
     "baseUrl": "http://localhost:11434",
     "authMethod": "none",
-    "supportedAuthMethods": ["none"],
+    "supportedAuthMethods": [
+      "none"
+    ],
     "authHeader": null,
     "costModel": "compute",
-    "families": ["llama3", "llama3.2", "mistral", "phi3", "gemma2", "gemma4", "qwen2", "qwen3", "deepseek"],
+    "families": [
+      "llama3",
+      "llama3.2",
+      "mistral",
+      "phi3",
+      "gemma2",
+      "gemma4",
+      "qwen2",
+      "qwen3",
+      "deepseek"
+    ],
     "computeWatts": 150,
     "electricityRateKwh": 0.12,
     "docsUrl": "https://ollama.com/docs",
@@ -359,7 +471,20 @@
       "setupDifficulty": "easy",
       "regulatoryNotes": "All data stays on your hardware."
     },
-    "supportsToolUse": true
+    "supportsToolUse": true,
+    "catalogProviderId": "ollama",
+    "trustCatalog": {
+      "category": "local",
+      "jurisdictions": [
+        "local"
+      ],
+      "externalEgress": "none",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "xai",
@@ -627,7 +752,18 @@
     "tokenUrl": "https://auth.openai.com/oauth/token",
     "oauthClientId": "app_EMoamEEZ73f0CkXaXp7hrann",
     "oauthRedirectUri": "http://localhost:1455/auth/callback",
-    "supportsToolUse": true
+    "supportsToolUse": true,
+    "catalogProviderId": "openai",
+    "trustCatalog": {
+      "category": "direct",
+      "jurisdictions": [],
+      "externalEgress": "provider-cloud",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "chatgpt",
@@ -667,7 +803,18 @@
       "setupDifficulty": "automatic",
       "regulatoryNotes": "SOC 2 Type II certified. Suitable for most business data."
     },
-    "supportsToolUse": true
+    "supportsToolUse": true,
+    "catalogProviderId": "openai",
+    "trustCatalog": {
+      "category": "direct",
+      "jurisdictions": [],
+      "externalEgress": "provider-cloud",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "openrouter",
@@ -698,6 +845,17 @@
       "dataResidency": "Depends on the underlying provider selected. OpenRouter routes requests but does not store content.",
       "setupDifficulty": "easy",
       "regulatoryNotes": "Review the terms of the specific underlying provider used. OpenRouter itself is a pass-through; compliance obligations rest with the provider."
+    },
+    "catalogProviderId": "openrouter",
+    "trustCatalog": {
+      "category": "router",
+      "jurisdictions": [],
+      "externalEgress": "router-cloud",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
     }
   },
   {
@@ -718,7 +876,18 @@
     "consoleUrl": null,
     "billingLabel": "Pay-per-use · rates vary by model",
     "costPerformanceNotes": null,
-    "catalogVisibility": "visible"
+    "catalogVisibility": "visible",
+    "catalogProviderId": "litellm",
+    "trustCatalog": {
+      "category": "router",
+      "jurisdictions": [],
+      "externalEgress": "unknown",
+      "supportsZdr": null,
+      "supportsNoTraining": null,
+      "supportsRegionalRouting": null,
+      "supportedRegions": [],
+      "regionalEndpoints": []
+    }
   },
   {
     "providerId": "portkey",

--- a/packages/db/prisma/migrations/20260719233000_ai_provider_connection/migration.sql
+++ b/packages/db/prisma/migrations/20260719233000_ai_provider_connection/migration.sql
@@ -1,0 +1,97 @@
+-- Separate provider catalog/runtime identity from a configured account/channel.
+-- Account class, contracts, and entitlements default to unknown/unreviewed so
+-- existing credentials never acquire enterprise rights during backfill.
+CREATE TABLE "AiProviderConnection" (
+    "id" TEXT NOT NULL,
+    "connectionId" TEXT NOT NULL,
+    "organizationId" TEXT,
+    "providerId" TEXT NOT NULL,
+    "credentialEntryId" TEXT,
+    "financeProfileId" TEXT,
+    "supplierContractId" TEXT,
+    "capacityStatusId" TEXT,
+    "label" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'unconfigured',
+    "executionChannel" TEXT NOT NULL,
+    "accountClass" TEXT NOT NULL DEFAULT 'unknown',
+    "commercialBasis" TEXT NOT NULL DEFAULT 'unknown',
+    "authMethod" TEXT NOT NULL DEFAULT 'unknown',
+    "contractEvidence" JSONB NOT NULL DEFAULT '{}',
+    "entitlements" JSONB NOT NULL DEFAULT '{}',
+    "evidenceStatus" TEXT NOT NULL DEFAULT 'unreviewed',
+    "lastReviewedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AiProviderConnection_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "AiProviderConnection_connectionId_key" ON "AiProviderConnection"("connectionId");
+CREATE UNIQUE INDEX "AiProviderConnection_credentialEntryId_key" ON "AiProviderConnection"("credentialEntryId");
+CREATE UNIQUE INDEX "AiProviderConnection_capacityStatusId_key" ON "AiProviderConnection"("capacityStatusId");
+CREATE INDEX "AiProviderConnection_organizationId_status_idx" ON "AiProviderConnection"("organizationId", "status");
+CREATE INDEX "AiProviderConnection_providerId_status_idx" ON "AiProviderConnection"("providerId", "status");
+CREATE INDEX "AiProviderConnection_financeProfileId_idx" ON "AiProviderConnection"("financeProfileId");
+CREATE INDEX "AiProviderConnection_supplierContractId_idx" ON "AiProviderConnection"("supplierContractId");
+
+ALTER TABLE "AiProviderConnection" ADD CONSTRAINT "AiProviderConnection_organizationId_fkey"
+  FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AiProviderConnection" ADD CONSTRAINT "AiProviderConnection_providerId_fkey"
+  FOREIGN KEY ("providerId") REFERENCES "ModelProvider"("providerId") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "AiProviderConnection" ADD CONSTRAINT "AiProviderConnection_credentialEntryId_fkey"
+  FOREIGN KEY ("credentialEntryId") REFERENCES "CredentialEntry"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "AiProviderConnection" ADD CONSTRAINT "AiProviderConnection_financeProfileId_fkey"
+  FOREIGN KEY ("financeProfileId") REFERENCES "AiProviderFinanceProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "AiProviderConnection" ADD CONSTRAINT "AiProviderConnection_supplierContractId_fkey"
+  FOREIGN KEY ("supplierContractId") REFERENCES "SupplierContract"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "AiProviderConnection" ADD CONSTRAINT "AiProviderConnection_capacityStatusId_fkey"
+  FOREIGN KEY ("capacityStatusId") REFERENCES "ProviderCapacityStatus"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+INSERT INTO "AiProviderConnection" (
+  "id",
+  "connectionId",
+  "providerId",
+  "credentialEntryId",
+  "financeProfileId",
+  "capacityStatusId",
+  "label",
+  "status",
+  "executionChannel",
+  "commercialBasis",
+  "authMethod",
+  "updatedAt"
+)
+SELECT
+  'aipc_' || md5(mp."providerId"),
+  'provider-default-' || mp."providerId",
+  mp."providerId",
+  ce."id",
+  fp."id",
+  pcs."id",
+  mp."name",
+  mp."status",
+  CASE
+    WHEN mp."providerId" IN ('local', 'ollama') THEN 'local-runtime'
+    WHEN mp."category" = 'router' THEN 'hosted-router'
+    WHEN mp."authMethod" = 'oauth2_authorization_code' THEN 'subscription-cli'
+    WHEN mp."providerId" IN ('azure-openai', 'bedrock') THEN 'cloud-tenant'
+    ELSE 'direct-api'
+  END,
+  CASE
+    WHEN mp."providerId" IN ('local', 'ollama') THEN 'local-compute'
+    WHEN mp."authMethod" = 'oauth2_authorization_code' THEN 'subscription-included'
+    ELSE 'unknown'
+  END,
+  CASE
+    WHEN mp."authMethod" = 'api_key' THEN 'api-key'
+    WHEN mp."authMethod" = 'oauth2_authorization_code' THEN 'oauth'
+    WHEN mp."authMethod" = 'oauth2_client_credentials' THEN 'workload-identity'
+    WHEN mp."authMethod" = 'none' THEN 'local'
+    ELSE 'unknown'
+  END,
+  CURRENT_TIMESTAMP
+FROM "ModelProvider" mp
+LEFT JOIN "CredentialEntry" ce ON ce."providerId" = mp."providerId"
+LEFT JOIN "AiProviderFinanceProfile" fp ON fp."providerId" = mp."providerId"
+LEFT JOIN "ProviderCapacityStatus" pcs ON pcs."providerId" = mp."providerId"
+WHERE mp."endpointType" <> 'transcription';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1862,6 +1862,7 @@ model CredentialEntry {
   cachedToken    String?
   tokenExpiresAt DateTime?
   refreshToken   String?
+  providerConnection AiProviderConnection?
 }
 
 // Polymorphic credentials for enterprise integrations (ADP, QuickBooks, Plaid, Workday, …).
@@ -2100,6 +2101,46 @@ model ModelProvider {
   modelProfiles            ModelProfile[]
   financeProfile           AiProviderFinanceProfile?
   capacityStatus           ProviderCapacityStatus?
+  connections              AiProviderConnection[]
+}
+
+// A configured account/channel for a provider catalog entry. Contract and
+// entitlement facts belong here so two accounts for one provider can never
+// inherit each other's evidence. ModelProvider remains the catalog/runtime
+// provider owner; this row is the organization-scoped access posture.
+model AiProviderConnection {
+  id                     String    @id @default(cuid())
+  connectionId           String    @unique
+  organizationId         String?
+  providerId             String
+  credentialEntryId      String?   @unique
+  financeProfileId       String?
+  supplierContractId     String?
+  capacityStatusId       String?   @unique
+  label                  String?
+  status                 String    @default("unconfigured")
+  executionChannel       String
+  accountClass           String    @default("unknown")
+  commercialBasis        String    @default("unknown")
+  authMethod             String    @default("unknown")
+  contractEvidence       Json      @default("{}")
+  entitlements           Json      @default("{}")
+  evidenceStatus         String    @default("unreviewed")
+  lastReviewedAt         DateTime?
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
+
+  organization           Organization?             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  provider               ModelProvider             @relation(fields: [providerId], references: [providerId], onDelete: Cascade)
+  credentialEntry        CredentialEntry?           @relation(fields: [credentialEntryId], references: [id], onDelete: SetNull)
+  financeProfile         AiProviderFinanceProfile? @relation(fields: [financeProfileId], references: [id], onDelete: SetNull)
+  supplierContract       SupplierContract?         @relation(fields: [supplierContractId], references: [id], onDelete: SetNull)
+  capacityStatus         ProviderCapacityStatus?   @relation(fields: [capacityStatusId], references: [id], onDelete: SetNull)
+
+  @@index([organizationId, status])
+  @@index([providerId, status])
+  @@index([financeProfileId])
+  @@index([supplierContractId])
 }
 
 model DiscoveredModel {
@@ -3796,6 +3837,7 @@ model Organization {
   careSchedulingPolicies        CareSchedulingPolicy[]
   careAppointments              CareAppointment[]
   careIntakePackets             CareIntakePacket[]
+  aiProviderConnections         AiProviderConnection[]
 }
 
 // EP-PARTNER-CHANNEL Phase 1b. Generic per-organization opt-in overlay on top of
@@ -10255,6 +10297,7 @@ model AiProviderFinanceProfile {
   supplier          Supplier?          @relation(fields: [supplierId], references: [id], onDelete: SetNull)
   supplierContracts SupplierContract[]
   financeWorkItems  FinanceWorkItem[]
+  providerConnections AiProviderConnection[]
 
   @@index([supplierId])
   @@index([status])
@@ -10298,6 +10341,7 @@ model SupplierContract {
   usageSnapshots      ContractUsageSnapshot[]
   financeWorkItems    FinanceWorkItem[]
   bills               Bill[]
+  providerConnections AiProviderConnection[]
 
   @@index([profileId])
   @@index([supplierId])
@@ -13048,6 +13092,7 @@ model ProviderCapacityStatus {
   createdAt             DateTime      @default(now())
   updatedAt             DateTime      @updatedAt
   provider              ModelProvider @relation(fields: [providerId], references: [providerId], onDelete: Cascade)
+  providerConnection    AiProviderConnection?
 
   @@index([state, retryAt])
   @@index([isHumanActionRequired, updatedAt])

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,5 +1,6 @@
 // packages/db/src/index.ts
 export { prisma } from "./client";
+export { ensureDefaultProviderConnection, refreshDefaultProviderConnectionOwners } from "./provider-connection";
 // Prisma is exported as both a value (for runtime helpers like Prisma.JsonNull,
 // Prisma.DbNull) and a type (for input/output type aliases).
 export { Prisma } from "../generated/client/client";

--- a/packages/db/src/provider-connection.ts
+++ b/packages/db/src/provider-connection.ts
@@ -1,0 +1,98 @@
+export type DefaultProviderConnectionSource = {
+  providerId: string;
+  name: string;
+  category: string;
+  authMethod: string;
+  endpointType?: string;
+};
+
+/**
+ * Conservative cold-start projection for a provider's default connection.
+ * It deliberately omits account class, evidence, contracts, and entitlements
+ * so database defaults keep every unreviewed connection fail-closed.
+ */
+export function buildDefaultProviderConnection(
+  entry: DefaultProviderConnectionSource,
+  status = "unconfigured",
+) {
+  if (entry.endpointType === "transcription") return undefined;
+  const local = entry.providerId === "local" || entry.providerId === "ollama";
+  const executionChannel = local
+    ? "local-runtime"
+    : entry.category === "router"
+      ? "hosted-router"
+      : entry.authMethod === "oauth2_authorization_code"
+        ? "subscription-cli"
+        : entry.providerId === "azure-openai" || entry.providerId === "bedrock"
+          ? "cloud-tenant"
+          : "direct-api";
+  const authMethod = entry.authMethod === "api_key"
+    ? "api-key"
+    : entry.authMethod === "oauth2_authorization_code"
+      ? "oauth"
+      : entry.authMethod === "oauth2_client_credentials"
+        ? "workload-identity"
+        : entry.authMethod === "none"
+          ? "local"
+          : "unknown";
+
+  return {
+    connectionId: `provider-default-${entry.providerId}`,
+    providerId: entry.providerId,
+    label: entry.name,
+    status,
+    executionChannel,
+    commercialBasis: local
+      ? "local-compute"
+      : entry.authMethod === "oauth2_authorization_code"
+        ? "subscription-included"
+        : "unknown",
+    authMethod,
+  };
+}
+
+export async function ensureDefaultProviderConnection(
+  prisma: PrismaClient,
+  entry: DefaultProviderConnectionSource,
+  status?: string,
+): Promise<void> {
+  const connection = buildDefaultProviderConnection(entry, status);
+  if (!connection) return;
+  await prisma.aiProviderConnection.upsert({
+    where: { connectionId: connection.connectionId },
+    update: { label: connection.label },
+    create: connection,
+  });
+  await refreshDefaultProviderConnectionOwners(prisma, entry.providerId);
+}
+
+export async function refreshDefaultProviderConnectionOwners(
+  prisma: PrismaClient,
+  providerId: string,
+): Promise<void> {
+  const connectionId = `provider-default-${providerId}`;
+  const [credential, financeProfile, capacityStatus] = await Promise.all([
+    prisma.credentialEntry.findUnique({
+      where: { providerId },
+      select: { id: true, providerConnection: { select: { connectionId: true } } },
+    }),
+    prisma.aiProviderFinanceProfile.findUnique({ where: { providerId }, select: { id: true } }),
+    prisma.providerCapacityStatus.findUnique({
+      where: { providerId },
+      select: { id: true, providerConnection: { select: { connectionId: true } } },
+    }),
+  ]);
+  await prisma.aiProviderConnection.updateMany({
+    where: { connectionId },
+    data: {
+      financeProfileId: financeProfile?.id ?? null,
+      ...(!credential?.providerConnection || credential.providerConnection.connectionId === connectionId
+        ? { credentialEntryId: credential?.id ?? null }
+        : {}),
+      ...(!capacityStatus?.providerConnection || capacityStatus.providerConnection.connectionId === connectionId
+        ? { capacityStatusId: capacityStatus?.id ?? null }
+        : {}),
+    },
+  });
+}
+import type { PrismaClient } from "../generated/client/client";

--- a/packages/db/src/provider-trust-registry.test.ts
+++ b/packages/db/src/provider-trust-registry.test.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildDefaultProviderConnection } from "./provider-connection";
+
+type TrustCatalog = {
+  category: string;
+  jurisdictions: string[];
+  externalEgress: string;
+  supportsZdr: boolean | null;
+  supportsNoTraining: boolean | null;
+  supportsRegionalRouting: boolean | null;
+  supportedRegions: string[];
+  regionalEndpoints: unknown[];
+};
+
+type ProviderEntry = {
+  providerId: string;
+  catalogProviderId?: string;
+  trustCatalog?: TrustCatalog & Record<string, unknown>;
+};
+
+const dataDir = join(import.meta.dirname, "..", "data");
+const registry = JSON.parse(
+  readFileSync(join(dataDir, "providers-registry.json"), "utf8"),
+) as ProviderEntry[];
+const byId = new Map(registry.map((entry) => [entry.providerId, entry]));
+
+describe("provider trust registry", () => {
+  it.each([
+    "anthropic",
+    "anthropic-sub",
+    "openai",
+    "zai",
+    "zai-coding",
+    "chatgpt",
+    "codex",
+    "azure-openai",
+    "gemini",
+    "bedrock",
+    "local",
+    "ollama",
+    "openrouter",
+    "litellm",
+  ])("declares conservative catalog trust facts for %s", (providerId) => {
+    const entry = byId.get(providerId);
+    expect(entry?.catalogProviderId).toBeTruthy();
+    expect(entry?.trustCatalog).toEqual(expect.objectContaining({
+      category: expect.any(String),
+      jurisdictions: expect.any(Array),
+      externalEgress: expect.any(String),
+      supportedRegions: expect.any(Array),
+      regionalEndpoints: expect.any(Array),
+    }));
+    expect(entry?.trustCatalog).toHaveProperty("supportsZdr");
+    expect(entry?.trustCatalog).toHaveProperty("supportsNoTraining");
+    expect(entry?.trustCatalog).toHaveProperty("supportsRegionalRouting");
+  });
+
+  it("groups channel aliases under a vendor catalog identity", () => {
+    expect(byId.get("anthropic")?.catalogProviderId).toBe("anthropic");
+    expect(byId.get("anthropic-sub")?.catalogProviderId).toBe("anthropic");
+    expect(byId.get("openai")?.catalogProviderId).toBe("openai");
+    expect(byId.get("chatgpt")?.catalogProviderId).toBe("openai");
+    expect(byId.get("codex")?.catalogProviderId).toBe("openai");
+    expect(byId.get("zai-coding")?.catalogProviderId).toBe("zai");
+  });
+
+  it("does not put connection evidence or account claims in vendor facts", () => {
+    for (const entry of registry) {
+      expect(entry.trustCatalog).not.toEqual(expect.objectContaining({
+        accountClass: expect.anything(),
+        contractEvidence: expect.anything(),
+        entitlements: expect.anything(),
+        evidenceStatus: expect.anything(),
+      }));
+    }
+  });
+
+  it("declares local execution as non-egress and routers as router egress", () => {
+    expect(byId.get("local")?.trustCatalog?.externalEgress).toBe("none");
+    expect(byId.get("ollama")?.trustCatalog?.externalEgress).toBe("none");
+    expect(byId.get("openrouter")?.trustCatalog).toMatchObject({
+      category: "router",
+      externalEgress: "router-cloud",
+    });
+  });
+});
+
+describe("provider connection schema", () => {
+  const schema = readFileSync(join(import.meta.dirname, "..", "prisma", "schema.prisma"), "utf8");
+  const migration = readFileSync(
+    join(
+      import.meta.dirname,
+      "..",
+      "prisma",
+      "migrations",
+      "20260719233000_ai_provider_connection",
+      "migration.sql",
+    ),
+    "utf8",
+  );
+
+  it("keeps connection posture separate from ModelProvider catalog ownership", () => {
+    expect(schema).toMatch(/model AiProviderConnection\s*\{/);
+    expect(schema).toMatch(/providerId\s+String/);
+    expect(schema).toMatch(/connectionId\s+String\s+@unique/);
+    expect(schema).toMatch(/provider\s+ModelProvider\s+@relation/);
+    expect(schema).toContain("@@index([providerId, status])");
+    expect(schema).toContain("@@index([supplierContractId])");
+  });
+
+  it("backfills model channels without creating connections for transcription services", () => {
+    expect(migration).toContain("WHERE mp.\"endpointType\" <> 'transcription'");
+    expect(migration).toContain("'provider-default-' || mp.\"providerId\"");
+    expect(migration).toContain("'unreviewed'");
+  });
+});
+
+describe("default provider connection", () => {
+  it.each([
+    ["openai", "direct", "api_key", undefined, "direct-api", "api-key"],
+    ["chatgpt", "direct", "oauth2_authorization_code", "responses", "subscription-cli", "oauth"],
+    ["azure-openai", "direct", "api_key", undefined, "cloud-tenant", "api-key"],
+    ["openrouter", "router", "api_key", undefined, "hosted-router", "api-key"],
+    ["local", "direct", "none", undefined, "local-runtime", "local"],
+  ] as const)("creates a conservative %s connection", (providerId, category, providerAuth, endpointType, executionChannel, authMethod) => {
+    expect(buildDefaultProviderConnection({
+      providerId,
+      name: providerId,
+      category,
+      authMethod: providerAuth,
+      ...(endpointType ? { endpointType } : {}),
+    })).toMatchObject({
+      connectionId: `provider-default-${providerId}`,
+      executionChannel,
+      authMethod,
+      commercialBasis: providerAuth === "oauth2_authorization_code"
+        ? "subscription-included"
+        : providerId === "local"
+          ? "local-compute"
+          : "unknown",
+    });
+  });
+
+  it("does not create an LLM connection for transcription", () => {
+    expect(buildDefaultProviderConnection({
+      providerId: "speaches",
+      name: "Local STT",
+      category: "direct",
+      authMethod: "none",
+      endpointType: "transcription",
+    })).toBeUndefined();
+  });
+});

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -81,6 +81,7 @@ import { buildTaxonomyNodeEntries, type TaxonomySeedRow } from "./taxonomy-seed-
 import { AGENT_MODEL_CONFIG_DEFAULTS } from "./agent-model-defaults.js";
 import { toModelProfileSeedCreateData } from "./model-profile-seed.js";
 import { deriveLocalModelCapabilityPrior, localInputModalities } from "./local-model-capabilities.js";
+import { ensureDefaultProviderConnection } from "./provider-connection.js";
 import { seedIntegrationCoverage } from "../scripts/seed-integration-coverage.js";
 import * as crypto from "crypto";
 import bcrypt from "bcryptjs";
@@ -1414,10 +1415,27 @@ async function seedProviderRegistry(): Promise<void> {
     return "mcp";
   }
 
+  function buildCatalogEntry(entry: Record<string, unknown>): Prisma.InputJsonValue | undefined {
+    const existing = entry.catalogEntry;
+    const value = {
+      ...(existing && typeof existing === "object" && !Array.isArray(existing)
+        ? existing as Record<string, unknown>
+        : {}),
+      ...(typeof entry.catalogProviderId === "string"
+        ? { catalogProviderId: entry.catalogProviderId }
+        : {}),
+      ...(entry.trustCatalog && typeof entry.trustCatalog === "object" && !Array.isArray(entry.trustCatalog)
+        ? { trustCatalog: entry.trustCatalog }
+        : {}),
+    };
+    return Object.keys(value).length > 0 ? value as Prisma.InputJsonValue : undefined;
+  }
+
   for (const entry of entries) {
     const providerId = entry.providerId as string;
     if (!providerId) continue;
     const serviceKind = inferServiceKind(entry);
+    const catalogEntry = buildCatalogEntry(entry);
 
     const existing = await prisma.modelProvider.findUnique({ where: { providerId } });
     if (existing) {
@@ -1475,6 +1493,7 @@ async function seedProviderRegistry(): Promise<void> {
           ...(entry.billingLabel !== undefined && { billingLabel: entry.billingLabel as string }),
           ...(entry.costPerformanceNotes !== undefined && { costPerformanceNotes: entry.costPerformanceNotes as string }),
           ...(entry.catalogVisibility !== undefined && { catalogVisibility: entry.catalogVisibility as string }),
+          ...(catalogEntry !== undefined && { catalogEntry }),
           ...(entry.endpointType !== undefined && { endpointType: entry.endpointType as string }),
           ...(serviceKind !== undefined && { serviceKind }),
           ...(entry.supportsToolUse !== undefined && { supportsToolUse: entry.supportsToolUse as boolean }),
@@ -1543,6 +1562,7 @@ async function seedProviderRegistry(): Promise<void> {
           billingLabel: (entry.billingLabel as string) ?? null,
           costPerformanceNotes: (entry.costPerformanceNotes as string) ?? null,
           catalogVisibility: (entry.catalogVisibility as string) ?? "visible",
+          ...(catalogEntry !== undefined && { catalogEntry }),
           ...(entry.endpointType !== undefined && { endpointType: entry.endpointType as string }),
           ...(serviceKind !== undefined && { serviceKind }),
           ...(entry.supportsToolUse !== undefined && { supportsToolUse: entry.supportsToolUse as boolean }),
@@ -1555,6 +1575,13 @@ async function seedProviderRegistry(): Promise<void> {
       });
       added++;
     }
+    await ensureDefaultProviderConnection(prisma, {
+      providerId,
+      name: String(entry.name ?? providerId),
+      category: String(entry.category ?? "direct"),
+      authMethod: String(entry.authMethod ?? "none"),
+      ...(typeof entry.endpointType === "string" ? { endpointType: entry.endpointType } : {}),
+    }, existing?.status);
   }
 
   console.log(`[seed] Provider registry: ${added} added, ${updated} updated (${entries.length} total)`);

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -1,11 +1,11 @@
 {
   "changeRationale": {
     "defaultRequiredServiceCount": "Capability-owned services moved behind deterministic Compose profiles; only PostgreSQL, portal initialization, and portal remain universal core.",
-    "prismaModelCount": "RuntimeCapabilityTransition plus its append-only event ledger provide one recoverable saga receipt and immutable terminal audit trail.",
+    "prismaModelCount": "AiProviderConnection separates provider catalog identity from organization-scoped account, credential, contract, entitlement, finance, and capacity evidence so suitability policy cannot infer business-safe use from a provider slug.",
     "serviceCount": "Linux Ollama is now explicitly catalogued as a host-specific runtime:external-ai service instead of remaining an ungoverned overlay-only container."
   },
-  "generatedAt": "2026-07-18T07:35:12.563Z",
-  "gitSha": "f8bf2816625e141badff37c0cf7a9372db31b186",
+  "generatedAt": "2026-07-20T00:12:00.000Z",
+  "gitSha": "c16edb843adf7d58b97e10ecbd60df8a1dfd67e1",
   "manifestVersion": 2,
   "metrics": {
     "defaultRequiredServiceCount": {
@@ -22,11 +22,11 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 512
+      "value": 513
     },
     "prismaSchemaLines": {
       "direction": "informational",
-      "value": 14010
+      "value": 14061
     },
     "productionModuleHotspotCount": {
       "direction": "non-increasing",
@@ -38,7 +38,7 @@
     },
     "seedCoordinatorLines": {
       "direction": "informational",
-      "value": 2689
+      "value": 2716
     },
     "serviceCount": {
       "direction": "non-increasing",


### PR DESCRIPTION
## Summary
- introduce connection-scoped AI provider trust posture so personal, business, enterprise, router, cloud-tenant, and local channels cannot inherit one another's evidence
- compile workload classification, business jurisdiction, data-policy, regulation-applicability, and owner posture into deterministic provider allow/deny fences consumed by `inferContract()`
- seed conservative catalog facts and fail-closed default connections across upgrades, fresh installs, and registry additions without inferring contracts or entitlements
- register provider connections in governed data coverage and document decision `DI-8902B7A5BE49`

## Verification
- merged with `origin/main` in the governed local-CI runner
- Prisma migration applied cleanly to pgvector Postgres
- affected web tests: 62 passed
- full `@dpf/db` suite: 1,581 passed
- web and DB typechecks passed
- production Docker build passed
- staged/tree secret scans, data-impact gate, docs guards, and module-size ratchet passed

The standard host full-web runner is currently affected by the tracked unsupported Node 26/localStorage harness defect (`BI-254F31A5`); GitHub's supported-runtime Unit Tests check remains the binding full-suite gate. The runner's incorrect preference for plain contributor-preview Postgres over pgvector is tracked as `BI-7430E579`.

## Coordination
- `packages/db/src/index.ts` also appears in #3300, but the edits are additive and on non-overlapping lines

Local-CI-Evidence: cmrsgfbol03xx01s4cwx3skcd
Local-CI-Override: After the passing merged-tree gate, only governance metadata changed: the required data-impact manifest/plan pointer and the substrate baseline acknowledgement for the approved AiProviderConnection model. Data-impact, docs, module-size, substrate, staged-secret, and tree-secret guards pass locally.
Seed-Fit-Decision: global-default
Backlog-Item: BI-AIPS-003
Work-Capsule: WC-6FFD1970