### PR TITLE
fix(build-studio): dynamically fail over engines

### DIFF
--- a/apps/web/components/build/BuildProgressOperationalPanel.test.tsx
+++ b/apps/web/components/build/BuildProgressOperationalPanel.test.tsx
@@ -132,6 +132,10 @@ function makeProjection(): BuildProgressVisibility {
       minutesQuiet: 7,
       lastObservableSignalAt: "2026-05-18T11:53:00.000Z",
     },
+    engineSelection: {
+      summary: "Build engine selection: codex. Reason: Claude credential expired; Codex is healthy.",
+      observedAt: "2026-05-18T11:52:00.000Z",
+    },
     phaseRuns: [],
   };
 }
@@ -150,6 +154,8 @@ describe("BuildProgressOperationalPanel", () => {
     expect(screen.getByText("Dispatch")).toBeInTheDocument();
     expect(screen.getByText("Verification")).toBeInTheDocument();
     expect(screen.getByText("Agent has been quiet for 7m")).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Build engine selection" })).toHaveTextContent("codex");
+    expect(screen.getByRole("region", { name: "Build engine selection" })).toHaveTextContent("Claude credential expired");
     expect(screen.getByRole("link", { name: "view last action" })).toHaveAttribute("href", "#build-dispatch-history");
   });
 });

--- a/apps/web/components/build/BuildProgressOperationalPanel.tsx
+++ b/apps/web/components/build/BuildProgressOperationalPanel.tsx
@@ -102,6 +102,13 @@ export function BuildProgressOperationalPanel({ projection, engineerView = false
           )}
         </section>
 
+        {projection.engineSelection && (
+          <section className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3" aria-label="Build engine selection">
+            <p className="text-[11px] font-semibold uppercase text-[var(--dpf-muted)]">Execution engine</p>
+            <p className="mt-1 text-sm text-[var(--dpf-text)]">{projection.engineSelection.summary}</p>
+          </section>
+        )}
+
         <section className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
           <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Task list</h3>
           <div className="mt-2 space-y-1">

--- a/apps/web/components/platform/BuildStudioConfigForm.test.ts
+++ b/apps/web/components/platform/BuildStudioConfigForm.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { shouldShowPinnedEngineMissingWarning } from "@/components/platform/BuildStudioConfigForm";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "@/components/platform/build-studio-route-copy";
 
 describe("Build Studio runtime route copy", () => {
@@ -7,5 +8,25 @@ describe("Build Studio runtime route copy", () => {
     expect(BUILD_STUDIO_CONFIG_ROUTE_COPY.description).toContain("configure how builds run");
     expect(BUILD_STUDIO_CONFIG_ROUTE_COPY.openStudioLabel).toBe("Open Build Studio");
     expect(BUILD_STUDIO_CONFIG_ROUTE_COPY.openStudioHref).toBe("/build");
+  });
+});
+
+describe("Build Studio engine readiness projection", () => {
+  it("does not describe a legacy engine choice as selected while Auto chose another engine", () => {
+    expect(shouldShowPinnedEngineMissingWarning({
+      enginePolicy: "auto",
+      provider: "opencode",
+      probing: false,
+      present: false,
+    })).toBe(false);
+  });
+
+  it("keeps the actionable missing-engine warning for an explicit hard pin", () => {
+    expect(shouldShowPinnedEngineMissingWarning({
+      enginePolicy: "pinned",
+      provider: "opencode",
+      probing: false,
+      present: false,
+    })).toBe(true);
   });
 });

--- a/apps/web/components/platform/BuildStudioConfigForm.test.ts
+++ b/apps/web/components/platform/BuildStudioConfigForm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { shouldShowPinnedEngineMissingWarning } from "@/components/platform/BuildStudioConfigForm";
+import { shouldShowPinnedEngineMissingWarning } from "@/components/platform/build-studio-config-form-model";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "@/components/platform/build-studio-route-copy";
 
 describe("Build Studio runtime route copy", () => {

--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -4,9 +4,7 @@ import { useState, useTransition, useEffect, useRef } from "react";
 import Link from "next/link";
 import { saveBuildStudioConfig, checkLocalEndpoint, applyLocalModelContext } from "@/lib/actions/build-studio";
 import { probeBuildEnginesAction } from "@/lib/actions/build-engine-actions";
-import type { BuildStudioDispatchConfig } from "@/lib/integrate/build-studio-config";
 import type { LocalEndpointPreflight } from "@/lib/integrate/opencode-dispatch";
-import type { ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "./build-studio-route-copy";
 import { ContributorMcpReadinessCard } from "./ContributorMcpReadinessCard";
 import {
@@ -14,59 +12,8 @@ import {
   isConfigured,
   ProviderRadio,
   type EngineReadinessBadge,
-  type ProviderOption,
 } from "./BuildStudioProviderControls";
-
-type Props = {
-  config: BuildStudioDispatchConfig;
-  claudeProviders: ProviderOption[];
-  codexProviders: ProviderOption[];
-  grokProviders: ProviderOption[];
-  opencodeProviders: ProviderOption[];
-  contributorMcpReadiness: ContributorMcpReadiness;
-  /** Per-engine sandbox readiness (engineId → last probe), keyed "claude"|"codex"|"grok". */
-  engineReadiness?: Record<string, EngineReadinessBadge>;
-  baseUrl: string;
-  canWrite: boolean;
-};
-
-const CLAUDE_MODELS = [
-  { value: "haiku", label: "Haiku", desc: "fastest, cheapest" },
-  { value: "sonnet", label: "Sonnet", desc: "best balance", recommended: true },
-  { value: "opus", label: "Opus", desc: "most capable, slower" },
-];
-
-function describeOpenCodeProvider(providerId: string, providers: ProviderOption[]): {
-  label: string;
-  desc: string;
-  isLocal: boolean;
-  providerName: string;
-} {
-  const selected = providers.find((p) => p.providerId === providerId) ?? providers[0];
-  const selectedId = selected?.providerId ?? providerId;
-  const isLocal = selectedId === "local" || selectedId === "ollama" || selectedId === "";
-  const providerName = selected?.name ?? "OpenCode";
-  return {
-    label: isLocal ? "Local model (OpenCode) (Preview)" : `${providerName} (OpenCode) (Preview)`,
-    desc: isLocal
-      ? "Your own local LLM · no credential, runs offline"
-      : `${providerName} via OpenCode · uses inherited provider credentials`,
-    isLocal,
-    providerName,
-  };
-}
-
-export function shouldShowPinnedEngineMissingWarning(input: {
-  enginePolicy: "auto" | "pinned";
-  provider: string;
-  probing: boolean;
-  present: boolean | null | undefined;
-}): boolean {
-  return input.enginePolicy === "pinned"
-    && ["claude", "codex", "grok", "opencode"].includes(input.provider)
-    && !input.probing
-    && input.present === false;
-}
+import { CLAUDE_MODELS, describeOpenCodeProvider, shouldShowPinnedEngineMissingWarning, type BuildStudioConfigFormProps } from "./build-studio-config-form-model";
 
 export function BuildStudioConfigForm({
   config,
@@ -78,7 +25,7 @@ export function BuildStudioConfigForm({
   engineReadiness,
   baseUrl,
   canWrite,
-}: Props) {
+}: BuildStudioConfigFormProps) {
   const [provider, setProvider] = useState(config.provider);
   const [enginePolicy, setEnginePolicy] = useState<"auto" | "pinned">(
     config.enginePolicy === "pinned" ? "pinned" : "auto",

--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -56,6 +56,18 @@ function describeOpenCodeProvider(providerId: string, providers: ProviderOption[
   };
 }
 
+export function shouldShowPinnedEngineMissingWarning(input: {
+  enginePolicy: "auto" | "pinned";
+  provider: string;
+  probing: boolean;
+  present: boolean | null | undefined;
+}): boolean {
+  return input.enginePolicy === "pinned"
+    && ["claude", "codex", "grok", "opencode"].includes(input.provider)
+    && !input.probing
+    && input.present === false;
+}
+
 export function BuildStudioConfigForm({
   config,
   claudeProviders,
@@ -68,6 +80,9 @@ export function BuildStudioConfigForm({
   canWrite,
 }: Props) {
   const [provider, setProvider] = useState(config.provider);
+  const [enginePolicy, setEnginePolicy] = useState<"auto" | "pinned">(
+    config.enginePolicy === "pinned" ? "pinned" : "auto",
+  );
   const [claudeProviderId, setClaudeProviderId] = useState(config.claudeProviderId);
   const [codexProviderId, setCodexProviderId] = useState(config.codexProviderId);
   const [grokProviderId, setGrokProviderId] = useState(config.grokProviderId);
@@ -94,6 +109,7 @@ export function BuildStudioConfigForm({
   // BI-E06BB38A: technical knobs (raw context window, manual model, Apply/Test)
   // live behind this disclosure so the default view never asks for a token count.
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [showModelAdvanced, setShowModelAdvanced] = useState(false);
   // Tracks the last opencode providerId we preflighted, so switching the
   // selected local provider (e.g. local → Ollama) re-probes the new endpoint
   // instead of showing the previous provider's stale readiness.
@@ -216,6 +232,8 @@ export function BuildStudioConfigForm({
       try {
         await saveBuildStudioConfig({
           provider,
+          enginePolicy,
+          pinnedEngine: enginePolicy === "pinned" ? provider : null,
           claudeProviderId,
           codexProviderId,
           grokProviderId,
@@ -319,7 +337,7 @@ export function BuildStudioConfigForm({
               Build Dispatch Engine
             </div>
             <p style={{ fontSize: 11, color: "var(--dpf-muted)", margin: 0 }}>
-              Choose which CLI agent executes build tasks in the sandbox.
+              Auto selects the best healthy engine for each task inside your policy boundaries.
             </p>
           </div>
           {canWrite && (
@@ -352,12 +370,45 @@ export function BuildStudioConfigForm({
           )}
         </div>
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <label style={{ display: "flex", alignItems: "flex-start", gap: 8, padding: "10px 12px", border: `1px solid ${enginePolicy === "auto" ? "var(--dpf-accent)" : "var(--dpf-border)"}`, borderRadius: 8, cursor: canWrite ? "pointer" : "default" }}>
+          <input
+            type="radio"
+            name="enginePolicy"
+            value="auto"
+            checked={enginePolicy === "auto"}
+            onChange={() => setEnginePolicy("auto")}
+            disabled={!canWrite}
+          />
+          <span>
+            <strong style={{ color: "var(--dpf-text)", fontSize: 12 }}>Auto (recommended)</strong>
+            <span style={{ display: "block", color: "var(--dpf-muted)", fontSize: 11, marginTop: 2 }}>
+              Selected now: {config.selection?.selected?.engine ?? config.provider}. {config.selection?.reason ?? "Selection updates from live readiness and routing evidence."}
+            </span>
+            {config.selection && config.selection.fallbackChain.length > 0 && (
+              <span style={{ display: "block", color: "var(--dpf-muted)", fontSize: 10, marginTop: 2 }}>
+                Fallback: {config.selection.fallbackChain.map((entry) => entry.engine).join(" → ")}
+              </span>
+            )}
+          </span>
+        </label>
+        <button
+          type="button"
+          onClick={() => setShowAdvanced((shown) => !shown)}
+          aria-expanded={showAdvanced}
+          style={{ marginTop: 8, padding: 0, border: 0, background: "transparent", color: "var(--dpf-accent)", fontSize: 11, cursor: "pointer" }}
+        >
+          {showAdvanced ? "Hide advanced execution policy" : "Advanced execution policy"}
+        </button>
+
+        {showAdvanced && <div style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 8 }}>
+          <p style={{ margin: 0, color: "var(--dpf-warning)", fontSize: 10 }}>
+            Hard pinning disables automatic fallback. Use it only for deliberate diagnostics or controlled tests.
+          </p>
           <ProviderRadio
             name="provider"
             value="claude"
             checked={provider === "claude"}
-            onChange={() => setProvider("claude")}
+            onChange={() => { setProvider("claude"); setEnginePolicy("pinned"); }}
             disabled={!canWrite || !hasClaudeCreds}
             label="Claude Code CLI"
             desc="Anthropic models"
@@ -369,7 +420,7 @@ export function BuildStudioConfigForm({
             name="provider"
             value="codex"
             checked={provider === "codex"}
-            onChange={() => setProvider("codex")}
+            onChange={() => { setProvider("codex"); setEnginePolicy("pinned"); }}
             disabled={!canWrite || !hasCodexCreds}
             label="Codex CLI"
             desc="OpenAI models"
@@ -381,7 +432,7 @@ export function BuildStudioConfigForm({
             name="provider"
             value="grok"
             checked={provider === "grok"}
-            onChange={() => setProvider("grok")}
+            onChange={() => { setProvider("grok"); setEnginePolicy("pinned"); }}
             disabled={!canWrite || !hasGrokCreds}
             label="Grok CLI (Preview)"
             desc="xAI models · headless grok -p"
@@ -393,7 +444,7 @@ export function BuildStudioConfigForm({
             name="provider"
             value="opencode"
             checked={provider === "opencode"}
-            onChange={() => setProvider("opencode")}
+            onChange={() => { setProvider("opencode"); setEnginePolicy("pinned"); }}
             disabled={!canWrite || !hasOpencodeProvider}
             label={openCodeDescription.label}
             desc={openCodeDescription.desc}
@@ -405,15 +456,18 @@ export function BuildStudioConfigForm({
             name="provider"
             value="agentic"
             checked={provider === "agentic"}
-            onChange={() => setProvider("agentic")}
+            onChange={() => { setProvider("agentic"); setEnginePolicy("pinned"); }}
             disabled={!canWrite}
             label="Agentic Loop (Legacy)"
             desc="Built-in tool-calling loop"
           />
-        </div>
-        {(provider === "claude" || provider === "codex" || provider === "grok" || provider === "opencode") &&
-          !probingIds.includes(provider) &&
-          readiness[provider]?.present === false && (
+        </div>}
+        {shouldShowPinnedEngineMissingWarning({
+          enginePolicy,
+          provider,
+          probing: probingIds.includes(provider),
+          present: readiness[provider]?.present,
+        }) && (
             <div role="status" style={{ marginTop: 10, fontSize: 11, color: "var(--dpf-warning)" }}>
               ⚠ {provider.charAt(0).toUpperCase() + provider.slice(1)} is selected but not installed in the sandbox —
               builds dispatched to it will fail until you provision it (use the “Provision … in sandbox” button above).
@@ -676,8 +730,8 @@ export function BuildStudioConfigForm({
                 <>
                   <button
                     type="button"
-                    onClick={() => setShowAdvanced(v => !v)}
-                    aria-expanded={showAdvanced}
+                    onClick={() => setShowModelAdvanced(v => !v)}
+                    aria-expanded={showModelAdvanced}
                     style={{
                       display: "flex",
                       alignItems: "center",
@@ -688,12 +742,12 @@ export function BuildStudioConfigForm({
                       color: "var(--dpf-muted)",
                       fontSize: 11,
                       padding: 0,
-                      marginBottom: showAdvanced ? 8 : 0,
+                      marginBottom: showModelAdvanced ? 8 : 0,
                     }}
                   >
-                    <span>{showAdvanced ? "▾" : "▸"}</span> Advanced
+                    <span>{showModelAdvanced ? "▾" : "▸"}</span> Advanced
                   </button>
-                  {showAdvanced && (
+                  {showModelAdvanced && (
                     <div style={{ borderLeft: "2px solid var(--dpf-border)", paddingLeft: 12, display: "flex", flexDirection: "column", gap: 8 }}>
                       <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12, color: "var(--dpf-text)" }}>
                         Model:

--- a/apps/web/components/platform/build-studio-config-form-model.ts
+++ b/apps/web/components/platform/build-studio-config-form-model.ts
@@ -1,0 +1,48 @@
+import type { BuildStudioDispatchConfig } from "@/lib/integrate/build-studio-config";
+import type { ContributorMcpReadiness } from "@/lib/mcp/contributor-readiness";
+import type { EngineReadinessBadge, ProviderOption } from "./BuildStudioProviderControls";
+
+export type BuildStudioConfigFormProps = {
+  config: BuildStudioDispatchConfig;
+  claudeProviders: ProviderOption[];
+  codexProviders: ProviderOption[];
+  grokProviders: ProviderOption[];
+  opencodeProviders: ProviderOption[];
+  contributorMcpReadiness: ContributorMcpReadiness;
+  engineReadiness?: Record<string, EngineReadinessBadge>;
+  baseUrl: string;
+  canWrite: boolean;
+};
+
+export const CLAUDE_MODELS = [
+  { value: "haiku", label: "Haiku", desc: "fastest, cheapest" },
+  { value: "sonnet", label: "Sonnet", desc: "best balance", recommended: true },
+  { value: "opus", label: "Opus", desc: "most capable, slower" },
+];
+
+export function describeOpenCodeProvider(providerId: string, providers: ProviderOption[]) {
+  const selected = providers.find((provider) => provider.providerId === providerId) ?? providers[0];
+  const selectedId = selected?.providerId ?? providerId;
+  const isLocal = selectedId === "local" || selectedId === "ollama" || selectedId === "";
+  const providerName = selected?.name ?? "OpenCode";
+  return {
+    label: isLocal ? "Local model (OpenCode) (Preview)" : `${providerName} (OpenCode) (Preview)`,
+    desc: isLocal
+      ? "Your own local LLM · no credential, runs offline"
+      : `${providerName} via OpenCode · uses inherited provider credentials`,
+    isLocal,
+    providerName,
+  };
+}
+
+export function shouldShowPinnedEngineMissingWarning(input: {
+  enginePolicy: "auto" | "pinned";
+  provider: string;
+  probing: boolean;
+  present: boolean | null | undefined;
+}): boolean {
+  return input.enginePolicy === "pinned"
+    && ["claude", "codex", "grok", "opencode"].includes(input.provider)
+    && !input.probing
+    && input.present === false;
+}

--- a/apps/web/lib/actions/build-studio.ts
+++ b/apps/web/lib/actions/build-studio.ts
@@ -24,6 +24,11 @@ export async function saveBuildStudioConfig(
   if (!VALID_ENGINES.has(config.provider)) {
     throw new Error(`Invalid provider engine: ${config.provider}`);
   }
+  const enginePolicy = config.enginePolicy === "pinned" ? "pinned" : "auto";
+  const pinnedEngine = enginePolicy === "pinned" ? (config.pinnedEngine ?? config.provider) : null;
+  if (pinnedEngine !== null && !VALID_ENGINES.has(pinnedEngine)) {
+    throw new Error(`Invalid pinned build engine: ${pinnedEngine}`);
+  }
 
   // Validate provider IDs dynamically against what's in the DB
   if (config.claudeProviderId) {
@@ -63,10 +68,24 @@ export async function saveBuildStudioConfig(
     throw new Error(`Invalid Claude model: ${config.claudeModel}`);
   }
 
+  const storedConfig = {
+    provider: config.provider,
+    enginePolicy,
+    pinnedEngine,
+    claudeProviderId: config.claudeProviderId,
+    codexProviderId: config.codexProviderId,
+    grokProviderId: config.grokProviderId,
+    opencodeProviderId: config.opencodeProviderId,
+    claudeModel: config.claudeModel,
+    codexModel: config.codexModel,
+    grokModel: config.grokModel,
+    opencodeModel: config.opencodeModel,
+  } satisfies BuildStudioDispatchConfig;
+
   await prisma.platformConfig.upsert({
     where: { key: "build-studio-dispatch" },
-    update: { value: config as unknown as Prisma.InputJsonValue },
-    create: { key: "build-studio-dispatch", value: config as unknown as Prisma.InputJsonValue },
+    update: { value: storedConfig as unknown as Prisma.InputJsonValue },
+    create: { key: "build-studio-dispatch", value: storedConfig as unknown as Prisma.InputJsonValue },
   });
 
   return { ok: true };

--- a/apps/web/lib/build/progress-visibility.ts
+++ b/apps/web/lib/build/progress-visibility.ts
@@ -77,6 +77,11 @@ export type BuildProgressVisibility = {
     kind: InferenceFailureKind | null;
     observedAt: string | null;
   };
+  /** Latest Build Studio engine decision, projected from BuildActivity. */
+  engineSelection?: {
+    summary: string;
+    observedAt: string;
+  } | null;
   /** Phase-level cost rollup; empty array when BuildPhaseRun rows don't exist yet */
   phaseRuns: PhaseRunSummary[];
   /**
@@ -104,6 +109,7 @@ export function buildProgressProjectionFromParts(args: {
   lastAssistant?: { content: string | null; createdAt: Date | string | null } | null;
   phaseRuns?: PhaseRunSummary[];
   evidenceTimeline?: UnifiedEvidenceTimelineEvent[];
+  engineSelection?: { summary: string; observedAt: Date | string } | null;
 }): BuildProgressVisibility {
   const now = args.now ?? new Date();
   const conflicts = getProgressConflicts(args.dbTasks.source, args.chatSnapshots);
@@ -154,6 +160,12 @@ export function buildProgressProjectionFromParts(args: {
       lastObservableSignalAt,
     },
     inferenceFailure,
+    engineSelection: args.engineSelection
+      ? {
+          summary: args.engineSelection.summary,
+          observedAt: new Date(args.engineSelection.observedAt).toISOString(),
+        }
+      : null,
     phaseRuns: args.phaseRuns ?? [],
     evidenceTimeline: args.evidenceTimeline ?? [],
   };
@@ -259,6 +271,11 @@ export async function getBuildProgressVisibility(buildId: string): Promise<Build
 
   // chatMessages is ordered createdAt desc, so [0] is the newest assistant turn.
   const newestAssistant = chatMessages[0] ?? null;
+  const engineSelectionActivity = await prisma.buildActivity.findFirst({
+    where: { buildId, tool: "engine_selection" },
+    orderBy: { createdAt: "desc" },
+    select: { summary: true, createdAt: true },
+  });
 
   return buildProgressProjectionFromParts({
     buildId,
@@ -273,6 +290,9 @@ export async function getBuildProgressVisibility(buildId: string): Promise<Build
       : null,
     phaseRuns,
     evidenceTimeline,
+    engineSelection: engineSelectionActivity
+      ? { summary: engineSelectionActivity.summary, observedAt: engineSelectionActivity.createdAt }
+      : null,
   });
 }
 

--- a/apps/web/lib/inference/phase-model-resolution.test.ts
+++ b/apps/web/lib/inference/phase-model-resolution.test.ts
@@ -7,7 +7,7 @@ const mockPreviewRoute = vi.fn();
 const mockPreflight = vi.fn();
 
 vi.mock("@/lib/integrate/build-studio-config", () => ({
-  getBuildStudioConfig: () => mockGetConfig(),
+  getBuildStudioConfig: async () => withSelection(await mockGetConfig()),
 }));
 vi.mock("@/lib/inference/routed-inference", () => ({
   previewRoute: (...args: unknown[]) => mockPreviewRoute(...args),
@@ -47,6 +47,55 @@ const OPENCODE_CONFIG = {
   grokModel: "",
   opencodeModel: "qwen3-coder",
 };
+
+function withSelection<T extends {
+  provider: "claude" | "codex" | "grok" | "opencode" | "agentic";
+  claudeProviderId: string;
+  codexProviderId: string;
+  grokProviderId: string;
+  opencodeProviderId: string;
+  claudeModel: string;
+  opencodeModel: string;
+}>(config: T) {
+  if ("selection" in config) return config;
+  const providerId = config.provider === "claude"
+    ? config.claudeProviderId
+    : config.provider === "codex"
+      ? config.codexProviderId
+      : config.provider === "grok"
+        ? config.grokProviderId
+        : config.opencodeProviderId || "chatgpt";
+  return {
+    ...config,
+    enginePolicy: "auto" as const,
+    pinnedEngine: null,
+    selection: {
+      status: "selected" as const,
+      policy: { mode: "auto" as const, pinnedEngine: null },
+      selected: {
+        engine: config.provider,
+        providerId,
+        modelId: config.provider === "opencode" ? config.opencodeModel : config.provider === "claude" ? config.claudeModel : null,
+        local: config.provider === "opencode",
+        registered: true,
+        present: true,
+        providerStatus: "active",
+        authMethod: config.provider === "opencode" ? "none" : "oauth",
+        credentialStatus: config.provider === "opencode" ? null : "active",
+        credentialExpiresAt: null,
+        providerCapacityState: "available",
+        providerRetryAt: null,
+        cliRetryAt: null,
+        providerHealth: "healthy" as const,
+      },
+      reason: `Selected ${providerId} through routeEndpointV2.`,
+      rejected: [],
+      fallbackChain: [],
+      fallbackDisabled: false,
+      action: null,
+    },
+  };
+}
 
 function cloudWinner() {
   return {
@@ -144,7 +193,7 @@ describe("resolveModelSelectionByPhase — the local-but-cloud blind spot", () =
 
   it("flags every reasoning phase that routes to cloud when the build engine is Local (OpenCode)", async () => {
     mockGetConfig.mockResolvedValue(OPENCODE_CONFIG);
-    mockPreviewRoute.mockResolvedValue(cloudWinner()); // ideate, plan, design-review, plan-review
+    mockPreviewRoute.mockResolvedValue(cloudWinner()); // plan, design-review, plan-review
     mockPreflight.mockResolvedValue(HEALTHY_PREFLIGHT); // build (local)
 
     const overview = await resolveModelSelectionByPhase();
@@ -156,7 +205,11 @@ describe("resolveModelSelectionByPhase — the local-but-cloud blind spot", () =
     expect(build.isLocal).toBe(true);
     expect(build.mechanism).toBe("local-opencode");
 
-    for (const phase of ["ideate", "plan", "design-review", "plan-review"] as const) {
+    const ideate = overview.phases.find((phase) => phase.phase === "ideate")!;
+    expect(ideate.isLocal).toBe(true);
+    expect(ideate.providerId).toBe("local");
+
+    for (const phase of ["plan", "design-review", "plan-review"] as const) {
       const p = overview.phases.find((x) => x.phase === phase)!;
       expect(p.isLocal).toBe(false);
       expect(p.flags.some((f) => f.code === "local-intent-cloud-reasoning")).toBe(true);
@@ -236,14 +289,14 @@ describe("resolveModelSelectionByPhase — non-local engines", () => {
     expect(ideate.providerId).toBe("anthropic");
 
     const build = overview.phases.find((p) => p.phase === "build")!;
-    expect(build.mechanism).toBe("routed");
-    expect(build.flags.some((f) => f.code === "build-engine-not-applied")).toBe(true);
+    expect(build.mechanism).toBe("vendor-cli");
+    expect(build.providerId).toBe("anthropic");
 
     // Not opencode → no local-intent mismatch flag anywhere.
     expect(overview.flags.some((f) => f.code === "local-intent-cloud-reasoning")).toBe(false);
   });
 
-  it("marks ideate unsupported under the Agentic Loop engine", async () => {
+  it("reports the selector's supported agentic fallback for Ideate", async () => {
     mockGetConfig.mockResolvedValue({
       ...OPENCODE_CONFIG,
       provider: "agentic" as const,
@@ -254,8 +307,9 @@ describe("resolveModelSelectionByPhase — non-local engines", () => {
 
     const overview = await resolveModelSelectionByPhase();
     const ideate = overview.phases.find((p) => p.phase === "ideate")!;
-    expect(ideate.mechanism).toBe("unsupported");
-    expect(ideate.flags.some((f) => f.code === "ideate-agentic-unsupported")).toBe(true);
+    expect(ideate.mechanism).toBe("routed");
+    expect(ideate.providerId).toBe("chatgpt");
+    expect(ideate.flags).toEqual([]);
   });
 
   it("surfaces a configuration gap when no providers are eligible", async () => {
@@ -264,6 +318,16 @@ describe("resolveModelSelectionByPhase — non-local engines", () => {
       provider: "agentic" as const,
       opencodeProviderId: "",
       opencodeModel: "",
+      selection: {
+        status: "blocked" as const,
+        policy: { mode: "auto" as const, pinnedEngine: null },
+        selected: null,
+        reason: "No endpoint satisfied the Build Studio contract.",
+        rejected: [],
+        fallbackChain: [],
+        fallbackDisabled: false,
+        action: "Connect one allowed provider and retry.",
+      },
     });
     mockPreviewRoute.mockRejectedValue(new Error("No active endpoint manifests found."));
 

--- a/apps/web/lib/inference/phase-model-resolution.ts
+++ b/apps/web/lib/inference/phase-model-resolution.ts
@@ -136,21 +136,14 @@ export interface ModelSelectionOverview {
 
 // ─── Phase routing contracts (must mirror the real call sites exactly) ─────────
 //
-// These are the EXACT routeAndCall options each routed phase passes in code, so
-// previewRoute predicts the same winner. Keep in sync with:
+// These are the exact routeAndCall options for portal-routed reasoning phases.
+// Ideate and Build consume the shared Build Studio selector result directly.
+// Keep the remaining previews in sync with:
 //   plan            → plan-on-approval.ts   routeAndCall(..., "internal", { budgetClass: "quality_first" })
 //   design/plan-rev → build.ts              routeAndCall(..., "internal", { taskType: "analysis" })
-//   ideate(opencode)→ ideate-dispatch.ts    routeAndCall(..., "internal", { budgetClass: "quality_first" })
-//   build(agentic)  → build-pipeline.ts     runAgenticLoop({ taskType: "analysis", requireTools: true, tools })
 
 const REASONING_SAMPLE =
   "Produce a structured implementation plan for a small feature change.";
-/** A non-empty tools array makes inferContract set requiresTools=true (build agentic loop). */
-const BUILD_SENTINEL_TOOLS: Array<Record<string, unknown>> = [
-  { name: "edit_sandbox_file" },
-  { name: "run_sandbox_tests" },
-];
-
 export function buildEngineLabel(provider: BuildStudioDispatchConfig["provider"]): string {
   switch (provider) {
     case "claude":
@@ -269,69 +262,24 @@ async function resolveIdeatePhase(
   config: BuildStudioDispatchConfig,
 ): Promise<PhaseResolution> {
   const engine = buildEngineLabel(config.provider);
-
-  if (config.provider === "opencode") {
-    // Subtle: ideate-opencode does NOT use the local runner — it calls
-    // routeAndCall (conversation/quality_first), so it routes like any other
-    // reasoning phase and lands on cloud on a mixed install.
-    const res = await resolveRoutedPhase({
-      phase: "ideate",
-      label: "Ideate",
-      engine,
-      governedBy: "providers-routing",
-      sample: "Research and draft a design document for a small feature.",
-      opts: { budgetClass: "quality_first" },
-    });
-    res.flags.push({
-      severity: "info",
-      code: "ideate-opencode-routes",
-      message:
-        "Ideate runs through portal routing even though the build engine is Local (OpenCode); it does not invoke the local runner directly.",
-      remediation:
-        "Expect ideate to follow Providers & Routing, not the local model — the local engine only changes the build phase.",
-    });
-    return res;
-  }
-
-  if (config.provider === "claude" || config.provider === "codex" || config.provider === "grok") {
-    const providerId =
-      config.provider === "claude"
-        ? config.claudeProviderId
-        : config.provider === "codex"
-          ? config.codexProviderId
-          : config.grokProviderId;
-    const model =
-      config.provider === "claude"
-        ? config.claudeModel
-        : config.provider === "grok"
-          ? config.grokModel
-          : config.codexModel;
-    const flags: PhaseFlag[] = [];
-    if (!providerId) {
-      flags.push({
-        severity: "error",
-        code: "ideate-no-credential",
-        message: `Ideate engine is ${engine} but no ${config.provider} provider credential is configured.`,
-        remediation: `Connect a ${config.provider} provider in Providers & Routing, or change the Build Runtime engine.`,
-      });
-    }
+  const selection = config.selection;
+  if (selection?.status === "selected" && selection.selected) {
     return {
       phase: "ideate",
       label: "Ideate",
       governedBy: "build-runtime",
-      mechanism: "vendor-cli",
+      mechanism: selection.selected.engine === "agentic" ? "routed" : "vendor-cli",
       engine,
-      providerId: providerId || null,
-      modelId: model || "(provider default)",
-      isLocal: false,
-      providerTier: "user_configured",
+      providerId: selection.selected.providerId,
+      modelId: selection.selected.modelId || "(provider default)",
+      isLocal: selection.selected.local,
+      providerTier: selection.selected.local ? "bundled" : "user_configured",
       contextTokens: null,
-      rationale: `Build Runtime engine ${engine}: ideate dispatches the ${config.provider} CLI in the sandbox.`,
-      flags,
+      rationale: selection.reason,
+      flags: [],
     };
   }
 
-  // agentic — ideate has no agentic dispatch path (falls through to an auth error).
   return {
     phase: "ideate",
     label: "Ideate",
@@ -343,16 +291,13 @@ async function resolveIdeatePhase(
     isLocal: null,
     providerTier: null,
     contextTokens: null,
-    rationale:
-      "The Agentic Loop engine has no ideate dispatch path; ideate requires a CLI or the local engine.",
+    rationale: selection?.reason ?? "No Build Studio engine selection is available.",
     flags: [
       {
-        severity: "warning",
-        code: "ideate-agentic-unsupported",
-        message:
-          "Ideate cannot run under the Agentic Loop engine (it falls through to an auth error).",
-        remediation:
-          "Select Claude / Codex / Grok or Local (OpenCode) as the Build Runtime engine to run ideate.",
+        severity: "error",
+        code: "ideate-no-eligible-engine",
+        message: "No allowed healthy engine can run Ideate.",
+        remediation: selection?.action ?? "Restore one allowed engine in AI Readiness and retry.",
       },
     ],
   };
@@ -362,6 +307,28 @@ async function resolveBuildPhase(
   config: BuildStudioDispatchConfig,
 ): Promise<PhaseResolution> {
   const engine = buildEngineLabel(config.provider);
+  const selection = config.selection;
+  if (!selection || selection.status === "blocked" || !selection.selected) {
+    return {
+      phase: "build",
+      label: "Build (code generation)",
+      governedBy: "build-runtime",
+      mechanism: "unsupported",
+      engine,
+      providerId: null,
+      modelId: null,
+      isLocal: null,
+      providerTier: null,
+      contextTokens: null,
+      rationale: selection?.reason ?? "No Build Studio engine selection is available.",
+      flags: [{
+        severity: "error",
+        code: "build-no-eligible-engine",
+        message: "No allowed healthy engine can run the build phase.",
+        remediation: selection?.action ?? "Restore one allowed engine in AI Readiness and retry.",
+      }],
+    };
+  }
 
   if (config.provider === "opencode") {
     const flags: PhaseFlag[] = [];
@@ -435,31 +402,25 @@ async function resolveBuildPhase(
       isLocal: true,
       providerTier: "bundled",
       contextTokens,
-      rationale:
-        "Build Runtime engine Local (OpenCode): the build dispatches the opencode CLI against the install's local model endpoint.",
+      rationale: selection.reason,
       flags,
     };
   }
 
-  // claude / codex / grok / agentic → runAgenticLoop → routeAndCall(analysis, requireTools).
-  const res = await resolveRoutedPhase({
+  return {
     phase: "build",
     label: "Build (code generation)",
+    governedBy: "build-runtime",
+    mechanism: selection.selected.engine === "agentic" ? "routed" : "vendor-cli",
     engine,
-    governedBy: "providers-routing",
-    sample: REASONING_SAMPLE,
-    opts: { taskType: "analysis", requireTools: true, tools: BUILD_SENTINEL_TOOLS },
-  });
-  if (config.provider !== "agentic") {
-    res.flags.push({
-      severity: "info",
-      code: "build-engine-not-applied",
-      message: `Build Runtime engine is ${engine}, but the build phase runs through the agentic loop and routes via Providers & Routing — the selected CLI governs only the ideate phase, not the build.`,
-      remediation:
-        "To build with a local model, set the Build Runtime engine to Local (OpenCode).",
-    });
-  }
-  return res;
+    providerId: selection.selected.providerId,
+    modelId: selection.selected.modelId || "(provider default)",
+    isLocal: selection.selected.local,
+    providerTier: selection.selected.local ? "bundled" : "user_configured",
+    contextTokens: null,
+    rationale: selection.reason,
+    flags: [],
+  };
 }
 
 // ─── Top-level resolver ────────────────────────────────────────────────────────

--- a/apps/web/lib/inference/routed-inference-options.ts
+++ b/apps/web/lib/inference/routed-inference-options.ts
@@ -1,0 +1,41 @@
+import type { ActivityContract } from "@/lib/routing/activity-contract";
+import type { ModelClass } from "@/lib/routing/model-card-types";
+import type { RequestContract } from "@/lib/routing/request-contract";
+import type { RouteDecisionActor } from "@/lib/routing/route-decision-attribution";
+
+/** Caller-owned constraints and preferences for canonical routing plus dispatch. */
+export interface RouteAndCallOptions {
+  tools?: Array<Record<string, unknown>>;
+  taskType?: string;
+  preferredProviderId?: string;
+  preferredModelId?: string;
+  requiresCodeExecution?: boolean;
+  requiresWebSearch?: boolean;
+  requiresComputerUse?: boolean;
+  budgetClass?: "minimize_cost" | "balanced" | "quality_first";
+  /** Hard provider boundary compiled by caller-owned policy/readiness. */
+  allowedProviders?: string[];
+  /** Providers explicitly forbidden by caller-owned policy. */
+  deniedProviders?: string[];
+  /** Hard residency boundary. Never widened by fallback. */
+  residencyPolicy?: RequestContract["residencyPolicy"];
+  modelTier?: "local" | "robust";
+  minimumDimensions?: Record<string, number>;
+  requiredModelClass?: ModelClass;
+  interactionMode?: "sync" | "background";
+  threadId?: string;
+  maxDurationMs?: number;
+  persistDecision?: boolean;
+  /** Forbid capability degradation that strips required tools. */
+  requireTools?: boolean;
+  minimumCapabilities?: import("@/lib/routing/agent-capability-types").AgentMinimumCapabilities;
+  agentMinimumContextTokens?: number;
+  agentId?: string;
+  agentMessageId?: string;
+  routingActor?: RouteDecisionActor;
+  effort?: "low" | "medium" | "high" | "max";
+  previousResponseId?: string;
+  activityContract?: ActivityContract;
+  agentDisplayName?: string;
+  mcpSession?: import("@/lib/routing/adapter-types").AdapterMcpSession;
+}

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -101,6 +101,12 @@ export interface RouteAndCallOptions {
   requiresComputerUse?: boolean;
   /** Budget posture override. */
   budgetClass?: "minimize_cost" | "balanced" | "quality_first";
+  /** Hard provider boundary compiled by a caller-owned policy/readiness layer. */
+  allowedProviders?: string[];
+  /** Providers explicitly forbidden by caller-owned policy. */
+  deniedProviders?: string[];
+  /** Hard residency boundary. Never widened by fallback. */
+  residencyPolicy?: RequestContract["residencyPolicy"];
   /** EP-MODEL-TIER-ROUTING: capability tier for this call. "local" forces
    *  residencyPolicy=local_only (keeps small/simple work on the on-box model);
    *  "robust" leaves routing free to prefer a frontier endpoint. Unset = today's
@@ -267,14 +273,17 @@ async function prepareRoute(
       // per-dimension max-merge in inferContract, which the posture can raise but
       // not drop below. See docs/design/2026-06-25-coworker-work-orchestration.md.)
       budgetClass: posture?.routeContext.budgetClass ?? options?.budgetClass,
+      allowedProviders: options?.allowedProviders,
+      deniedProviders: options?.deniedProviders,
+      residencyPolicy:
+        options?.modelTier === "local" || localOnlyInference
+          ? "local_only"
+          : options?.residencyPolicy,
       requiredModelClass: options?.requiredModelClass,
       // EP-MODEL-TIER-ROUTING: a "local"-tier call forces local_only (keep
       // small/simple work on-box) even when the global switch is off; "robust"
       // leaves routing free to prefer a frontier endpoint. The global local-only
       // switch still wins for every call (the sovereign master toggle).
-      ...(options?.modelTier === "local" || localOnlyInference
-        ? { residencyPolicy: "local_only" as const }
-        : {}),
     },
   );
 

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -16,8 +16,6 @@ import type {
   EndpointOverride,
 } from "@/lib/routing/types";
 import type { RouteSensitivity } from "@/lib/agent-sensitivity";
-import type { ModelClass } from "@/lib/routing/model-card-types";
-import type { ActivityContract } from "@/lib/routing/activity-contract";
 import { inferContract } from "@/lib/routing/request-contract";
 import type { RequestContract } from "@/lib/routing/request-contract";
 import {
@@ -36,7 +34,8 @@ import { prisma } from "@dpf/db";
 import { getLocalOnlyInference } from "@/lib/inference/local-only";
 import { resolveDispatchPosture, type DispatchPosture } from "@/lib/golden-triangle/dispatch";
 import { logTokenUsage } from "@/lib/ai-inference";
-import type { RouteDecisionActor } from "@/lib/routing/route-decision-attribution";
+import type { RouteAndCallOptions } from "./routed-inference-options";
+export type { RouteAndCallOptions } from "./routed-inference-options";
 
 // ─── Result type ────────────────────────────────────────────────────────────
 
@@ -85,121 +84,6 @@ export class NoEligibleEndpointsError extends Error {
 }
 
 // ─── Options ────────────────────────────────────────────────────────────────
-
-export interface RouteAndCallOptions {
-  /** Tools to provide to the model. Also sets requiresTools on the contract. */
-  tools?: Array<Record<string, unknown>>;
-  /** Task type override. Defaults to "conversation". */
-  taskType?: string;
-  /** Prefer a specific provider (hard override when set by agent config). */
-  preferredProviderId?: string;
-  /** Prefer a specific model ID (swaps within provider candidates). */
-  preferredModelId?: string;
-  /** Specialized capability requirements. */
-  requiresCodeExecution?: boolean;
-  requiresWebSearch?: boolean;
-  requiresComputerUse?: boolean;
-  /** Budget posture override. */
-  budgetClass?: "minimize_cost" | "balanced" | "quality_first";
-  /** Hard provider boundary compiled by a caller-owned policy/readiness layer. */
-  allowedProviders?: string[];
-  /** Providers explicitly forbidden by caller-owned policy. */
-  deniedProviders?: string[];
-  /** Hard residency boundary. Never widened by fallback. */
-  residencyPolicy?: RequestContract["residencyPolicy"];
-  /** EP-MODEL-TIER-ROUTING: capability tier for this call. "local" forces
-   *  residencyPolicy=local_only (keeps small/simple work on the on-box model);
-   *  "robust" leaves routing free to prefer a frontier endpoint. Unset = today's
-   *  behavior (governed only by the global local-only switch). */
-  modelTier?: "local" | "robust";
-  /** Minimum dimension scores (0-100) models must meet. Models below any threshold are excluded. */
-  minimumDimensions?: Record<string, number>;
-  /** EP-INF-009c: Route to a specific model class (e.g., "image_gen", "embedding"). */
-  requiredModelClass?: ModelClass;
-  /** EP-INF-009d: "background" starts async operation, returns immediately with asyncOperationId. */
-  interactionMode?: "sync" | "background";
-  /** EP-INF-009d: Thread ID for SSE progress events (required for background mode). */
-  threadId?: string;
-  /** EP-INF-009d: Max duration for async operations (ms). Default: 15 minutes. */
-  maxDurationMs?: number;
-  /** Persist the route decision to the audit log. Default: true. */
-  persistDecision?: boolean;
-  /**
-   * When true, tool stripping is forbidden. If no tool-capable endpoint is
-   * available, throw NoEligibleEndpointsError instead of silently degrading
-   * to generic no-tool chat. Use for Build Studio and other tool-dependent
-   * workflows where removing tools changes the task semantics.
-   */
-  requireTools?: boolean;
-  /**
-   * EP-AGENT-CAP-002: Agent-level minimum capability floor.
-   * When set, endpoints that don't satisfy all declared capabilities are
-   * excluded BEFORE graceful tool-stripping. Use DEFAULT_MINIMUM_CAPABILITIES
-   * ({ toolUse: true }) for standard coworkers.
-   */
-  minimumCapabilities?: import("@/lib/routing/agent-capability-types").AgentMinimumCapabilities;
-  /**
-   * EP-AGENT-CAP-002: Minimum context window tokens required by the agent (for RAG).
-   * Merged with task-level minContextTokens — the stricter value wins.
-   * Null = system default (16000 tokens). Read from AgentModelConfig.minimumContextTokens.
-   */
-  agentMinimumContextTokens?: number;
-  /**
-   * EP-AGENT-CAP-002: Agent identifier for error correlation.
-   * Set from agentId in agentic-loop.ts so NoEligibleEndpointsError can surface
-   * which agent triggered the capability floor violation.
-   */
-  agentId?: string;
-  /**
-   * Pre-allocated AgentMessage id for the assistant turn this call belongs to.
-   * Threaded down to AdapterRunTelemetry rows so the badge/cost-rollup join
-   * (telemetry.agentMessageId → AgentMessage.id) can succeed even though the
-   * AgentMessage row is persisted only after the agentic loop returns. The
-   * caller (agent-coworker.sendMessage) allocates the id with `randomUUID()`
-   * before starting the loop and uses the same id when creating the row.
-   */
-  agentMessageId?: string;
-  /**
-   * Actor responsible for this routing decision. Agent calls normally set
-   * agentId; system utilities and schedulers should set this explicitly so
-   * RouteDecisionLog never lands as an unattributed audit event.
-   */
-  routingActor?: RouteDecisionActor;
-  /**
-   * EP-INF-013: Reasoning effort hint for the selected model.
-   *   low    — no extended thinking; fast and cheap (default when omitted)
-   *   medium — moderate thinking budget (~8k tokens for Anthropic)
-   *   high   — extended thinking (~32k tokens; recommended for code-gen / Build Studio)
-   *   max    — maximum budget (~64k tokens; Opus-only)
-   * Translated per-provider: Anthropic → thinking.budget_tokens, OpenAI → reasoning_effort.
-   * Ignored by providers that do not support extended reasoning.
-   */
-  effort?: "low" | "medium" | "high" | "max";
-  /** Responses API: chain to a previous response for conversation state. */
-  previousResponseId?: string;
-  /**
-   * Activity-level routing contract for task-aware harness binding. When set,
-   * the selected RouteDecision.executionPlan carries harness metadata for
-   * evidence, evaluation, and future activity-specific prompt/context assembly.
-   */
-  activityContract?: ActivityContract;
-  /**
-   * Display name of the coworker invoking this call (e.g. "AI Ops Engineer").
-   * When tools are stripped due to model capability limits, this name is
-   * preserved in the degraded system prompt so the model can identify itself
-   * and explain its limited state — rather than becoming a generic assistant.
-   */
-  agentDisplayName?: string;
-  /**
-   * Caller context for adapters that need to mint MCP credentials. When the
-   * Claude CLI execution adapter is the selected endpoint and `mcpSession` is
-   * present, the adapter mounts `/api/mcp/v1` via `--mcp-config` using a
-   * short-lived JWT issued for this user/agent/thread. Absent for non-coworker
-   * inference (eval runners, background jobs without an attributable owner) —
-   * the cli-adapter then falls back to the legacy text-described tool path.
-   */
-  mcpSession?: import("@/lib/routing/adapter-types").AdapterMcpSession;
-}
 
 // ─── Route preparation (shared by routeAndCall + previewRoute) ───────────────
 

--- a/apps/web/lib/integrate/build-engine-selection-runtime.ts
+++ b/apps/web/lib/integrate/build-engine-selection-runtime.ts
@@ -1,0 +1,269 @@
+import { prisma } from "@dpf/db";
+
+import { getLocalOnlyInference } from "@/lib/inference/local-only";
+import { previewRoute } from "@/lib/inference/routed-inference";
+import { resolveCredentialProviderId } from "@/lib/inference/ai-provider-internals";
+import { loadProviderHealthBatch } from "@/lib/routing/provider-health-loader";
+import { cliAdapterTypeForProvider } from "@/lib/routing/provider-routing-eligibility";
+import type { SensitivityLevel } from "@/lib/routing/types";
+import {
+  qualifyBuildEngineCandidates,
+  selectBuildEngineFromCandidates,
+  type BuildEngineCandidate,
+  type BuildEngineId,
+  type BuildEnginePolicy,
+  type BuildEngineRouteResult,
+  type BuildEngineSelection,
+} from "./build-engine-selection";
+
+export type BuildEnginePreferenceConfig = {
+  claudeProviderId: string;
+  codexProviderId: string;
+  grokProviderId: string;
+  opencodeProviderId: string;
+  claudeModel: string;
+  codexModel: string;
+  grokModel: string;
+  opencodeModel: string;
+};
+
+type ResolveOptions = {
+  policy: BuildEnginePolicy;
+  modelTier?: "local" | "robust";
+  sensitivity?: SensitivityLevel;
+  nowMs?: number;
+};
+
+function configuredProviderForEngine(
+  engine: Exclude<BuildEngineId, "agentic">,
+  config: BuildEnginePreferenceConfig,
+): string {
+  switch (engine) {
+    case "claude": return config.claudeProviderId;
+    case "codex": return config.codexProviderId;
+    case "grok": return config.grokProviderId;
+    case "opencode": return config.opencodeProviderId;
+  }
+}
+
+function configuredModelForEngine(
+  engine: BuildEngineId,
+  config: BuildEnginePreferenceConfig,
+): string | null {
+  switch (engine) {
+    case "claude": return config.claudeModel || null;
+    case "codex": return config.codexModel || null;
+    case "grok": return config.grokModel || null;
+    case "opencode": return config.opencodeModel || null;
+    case "agentic": return null;
+  }
+}
+
+function providerIsLocal(provider: { providerId: string; category: string | null; authMethod: string }): boolean {
+  return provider.authMethod === "none"
+    || provider.category === "local"
+    || provider.providerId === "local"
+    || provider.providerId === "ollama";
+}
+
+function fallbackProviderOrder(decision: {
+  fallbackChain: string[];
+  candidates: Array<{ endpointId: string; providerId: string }>;
+  selectedEndpoint: string | null;
+}): string[] {
+  const providerByEndpoint = new Map(
+    decision.candidates.map((candidate) => [candidate.endpointId, candidate.providerId]),
+  );
+  const seen = new Set<string>();
+  const providers: string[] = [];
+  for (const endpointId of decision.fallbackChain) {
+    if (endpointId === decision.selectedEndpoint) continue;
+    const providerId = providerByEndpoint.get(endpointId);
+    if (!providerId || seen.has(providerId)) continue;
+    seen.add(providerId);
+    providers.push(providerId);
+  }
+  return providers;
+}
+
+export async function resolveBuildEngineSelection(
+  config: BuildEnginePreferenceConfig,
+  opts: ResolveOptions,
+): Promise<BuildEngineSelection> {
+  const nowMs = opts.nowMs ?? Date.now();
+  const providers = await prisma.modelProvider.findMany({
+    where: {
+      retiredAt: null,
+      endpointType: { not: "service" },
+    },
+    select: {
+      providerId: true,
+      status: true,
+      authMethod: true,
+      cliEngine: true,
+      category: true,
+    },
+  });
+
+  const preferredProviderIds = new Map<Exclude<BuildEngineId, "agentic">, string>(
+    (["claude", "codex", "grok", "opencode"] as const)
+      .map((engine) => [engine, configuredProviderForEngine(engine, config)] as const)
+      .filter((entry) => entry[1].length > 0),
+  );
+  const structuralProviders = providers.filter((provider) => {
+    if (provider.cliEngine === "claude" || provider.cliEngine === "codex" || provider.cliEngine === "grok" || provider.cliEngine === "opencode") {
+      const preferred = preferredProviderIds.get(provider.cliEngine);
+      return !preferred || preferred === provider.providerId;
+    }
+    return provider.cliEngine === null;
+  });
+  const providerIds = structuralProviders.map((provider) => provider.providerId);
+  const credentialIds = [...new Set(providerIds.map(resolveCredentialProviderId))];
+
+  const [credentials, engines, capacities, cliPools, healthByProvider, localOnlySetting] = await Promise.all([
+    prisma.credentialEntry.findMany({
+      where: { providerId: { in: credentialIds } },
+      select: {
+        providerId: true,
+        status: true,
+        tokenExpiresAt: true,
+        secretRef: true,
+        cachedToken: true,
+        clientId: true,
+        clientSecret: true,
+      },
+    }),
+    prisma.buildEngine.findMany({
+      select: { engineId: true, state: { select: { present: true } } },
+    }),
+    prisma.providerCapacityStatus.findMany({
+      where: { providerId: { in: providerIds } },
+      select: { providerId: true, state: true, retryAt: true },
+    }),
+    prisma.cliPoolStatus.findMany({
+      select: { adapterType: true, resetAt: true },
+    }),
+    loadProviderHealthBatch(providerIds, { now: nowMs }),
+    getLocalOnlyInference(),
+  ]);
+
+  const credentialById = new Map(credentials.map((row) => [row.providerId, row]));
+  const engineById = new Map(engines.map((row) => [row.engineId, row]));
+  const capacityByProvider = new Map(capacities.map((row) => [row.providerId, row]));
+  const cliRetryByAdapter = new Map(cliPools.map((row) => [row.adapterType, row.resetAt?.getTime() ?? null]));
+
+  const candidates: BuildEngineCandidate[] = structuralProviders.flatMap((provider) => {
+    const engine: BuildEngineId =
+      provider.cliEngine === "claude"
+      || provider.cliEngine === "codex"
+      || provider.cliEngine === "grok"
+      || provider.cliEngine === "opencode"
+        ? provider.cliEngine
+        : "agentic";
+    const engineRow = engine === "agentic" ? null : engineById.get(engine);
+    const credential = credentialById.get(resolveCredentialProviderId(provider.providerId));
+    const hasCredentialMaterial = provider.authMethod === "none"
+      || Boolean(
+        credential?.secretRef
+        || credential?.cachedToken
+        || (credential?.clientId && credential?.clientSecret),
+      );
+    const capacity = capacityByProvider.get(provider.providerId);
+    const cliAdapter = cliAdapterTypeForProvider(provider.providerId);
+    const healthEntry = healthByProvider.get(provider.providerId);
+    const providerHealth = healthEntry?.status === "fulfilled"
+      ? healthEntry.value.status
+      : "unknown";
+    return [{
+      engine,
+      providerId: provider.providerId,
+      modelId: configuredModelForEngine(engine, config),
+      local: providerIsLocal(provider),
+      registered: engine === "agentic" || engineRow !== undefined,
+      present: engine === "agentic" || engineRow?.state?.present === true,
+      providerStatus: provider.status,
+      authMethod: provider.authMethod,
+      credentialStatus: hasCredentialMaterial ? credential?.status ?? null : null,
+      credentialExpiresAt: credential?.tokenExpiresAt?.getTime() ?? null,
+      providerCapacityState: capacity?.state ?? null,
+      providerRetryAt: capacity?.retryAt?.getTime() ?? null,
+      cliRetryAt: cliAdapter ? cliRetryByAdapter.get(cliAdapter) ?? null : null,
+      providerHealth,
+    }];
+  });
+
+  const localOnly = localOnlySetting || opts.modelTier === "local";
+  const qualification = qualifyBuildEngineCandidates({
+    policy: opts.policy,
+    candidates,
+    localOnly,
+    nowMs,
+  });
+  let route: BuildEngineRouteResult;
+  if (qualification.eligible.length === 0) {
+    route = {
+      selectedProviderId: null,
+      selectedModelId: null,
+      reason: "No engine passed Build Studio readiness and policy qualification.",
+      fallbackProviderIds: [],
+      rejectedProviders: [],
+    };
+  } else {
+    try {
+      const preview = await previewRoute(
+        [{ role: "user", content: "Generate and modify source code for a Build Studio task." }],
+        opts.sensitivity ?? "internal",
+        {
+          taskType: "code-gen",
+          tools: [{ name: "edit_sandbox_file" }, { name: "run_sandbox_tests" }],
+          requireTools: true,
+          budgetClass: "quality_first",
+          allowedProviders: [...new Set(qualification.eligible.map((candidate) => candidate.providerId))],
+          residencyPolicy: localOnly ? "local_only" : "any_enabled",
+          ...(opts.modelTier ? { modelTier: opts.modelTier } : {}),
+        },
+      );
+      route = {
+        selectedProviderId: preview.selectedManifest?.providerId ?? null,
+        selectedModelId: preview.decision.selectedModelId,
+        reason: preview.decision.reason,
+        fallbackProviderIds: fallbackProviderOrder(preview.decision),
+        rejectedProviders: preview.decision.candidates
+          .filter((candidate) => candidate.excluded)
+          .map((candidate) => ({
+            providerId: candidate.providerId,
+            reason: candidate.excludedReason ?? "Excluded by the Build Studio route contract.",
+          })),
+      };
+    } catch (error) {
+      route = {
+        selectedProviderId: null,
+        selectedModelId: null,
+        reason: error instanceof Error ? error.message : "Build Studio route preview failed.",
+        fallbackProviderIds: [],
+        rejectedProviders: [],
+      };
+    }
+  }
+
+  return selectBuildEngineFromCandidates({
+    policy: opts.policy,
+    candidates,
+    route,
+    localOnly,
+    nowMs,
+  });
+}
+
+export function formatBuildEngineSelectionEvidence(selection: BuildEngineSelection): string {
+  const selected = selection.selected
+    ? `${selection.selected.engine} (provider=${selection.selected.providerId}, model=${selection.selected.modelId || "provider default"})`
+    : "none";
+  const fallbacks = selection.fallbackChain.length > 0
+    ? selection.fallbackChain.map((entry) => `${entry.engine}:${entry.providerId}`).join(" -> ")
+    : "none";
+  const rejected = selection.rejected.length > 0
+    ? selection.rejected.map((entry) => `${entry.engine}:${entry.providerId} [${entry.code}: ${entry.reason}]`).join(", ")
+    : "none";
+  return `Build engine selection: ${selected}. Reason: ${selection.reason} Fallback chain: ${fallbacks}. Rejected: ${rejected}.`;
+}

--- a/apps/web/lib/integrate/build-engine-selection.test.ts
+++ b/apps/web/lib/integrate/build-engine-selection.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyRetrySafePreDispatchFailure,
+  selectBuildEngineFromCandidates,
+  type BuildEngineCandidate,
+  type BuildEngineRouteResult,
+} from "./build-engine-selection";
+
+const NOW = Date.parse("2026-07-19T23:30:00.000Z");
+
+function candidate(
+  engine: BuildEngineCandidate["engine"],
+  providerId: string,
+  overrides: Partial<BuildEngineCandidate> = {},
+): BuildEngineCandidate {
+  return {
+    engine,
+    providerId,
+    modelId: `${engine}-model`,
+    local: engine === "opencode",
+    registered: engine === "agentic" ? true : true,
+    present: engine === "agentic" ? true : true,
+    providerStatus: "active",
+    authMethod: engine === "opencode" ? "none" : "oauth",
+    credentialStatus: engine === "opencode" ? null : "active",
+    credentialExpiresAt: engine === "opencode" ? null : NOW + 60_000,
+    providerCapacityState: "available",
+    providerRetryAt: null,
+    cliRetryAt: null,
+    providerHealth: "healthy",
+    ...overrides,
+  };
+}
+
+function route(
+  selectedProviderId: string | null,
+  fallbackProviderIds: string[] = [],
+): BuildEngineRouteResult {
+  return {
+    selectedProviderId,
+    selectedModelId: selectedProviderId ? `${selectedProviderId}-model` : null,
+    reason: selectedProviderId
+      ? `Selected ${selectedProviderId} through routeEndpointV2.`
+      : "No endpoint satisfied the Build Studio contract.",
+    fallbackProviderIds,
+    rejectedProviders: [],
+  };
+}
+
+describe("selectBuildEngineFromCandidates", () => {
+  it("selects healthy Codex before dispatch when Claude OAuth is expired", () => {
+    const result = selectBuildEngineFromCandidates({
+      policy: { mode: "auto", pinnedEngine: null },
+      candidates: [
+        candidate("claude", "anthropic-sub", { credentialExpiresAt: NOW - 1 }),
+        candidate("codex", "codex"),
+      ],
+      route: route("codex"),
+      localOnly: false,
+      nowMs: NOW,
+    });
+
+    expect(result.status).toBe("selected");
+    expect(result.selected?.engine).toBe("codex");
+    expect(result.rejected).toContainEqual(expect.objectContaining({
+      engine: "claude",
+      providerId: "anthropic-sub",
+      code: "credential-expired",
+    }));
+  });
+
+  it("excludes a saturated Codex pool and selects another eligible engine", () => {
+    const result = selectBuildEngineFromCandidates({
+      policy: { mode: "auto", pinnedEngine: null },
+      candidates: [
+        candidate("codex", "codex", { cliRetryAt: NOW + 30_000 }),
+        candidate("claude", "anthropic-sub"),
+      ],
+      route: route("anthropic-sub"),
+      localOnly: false,
+      nowMs: NOW,
+    });
+
+    expect(result.selected?.engine).toBe("claude");
+    expect(result.rejected).toContainEqual(expect.objectContaining({
+      providerId: "codex",
+      code: "capacity-retry-window",
+    }));
+  });
+
+  it("never crosses a local-only boundary", () => {
+    const result = selectBuildEngineFromCandidates({
+      policy: { mode: "auto", pinnedEngine: null },
+      candidates: [candidate("claude", "anthropic-sub"), candidate("opencode", "local")],
+      route: route("local"),
+      localOnly: true,
+      nowMs: NOW,
+    });
+
+    expect(result.selected?.engine).toBe("opencode");
+    expect(result.rejected).toContainEqual(expect.objectContaining({
+      engine: "claude",
+      code: "residency-local-only",
+    }));
+  });
+
+  it("does not fail over an explicit hard pin", () => {
+    const result = selectBuildEngineFromCandidates({
+      policy: { mode: "pinned", pinnedEngine: "claude" },
+      candidates: [
+        candidate("claude", "anthropic-sub", { credentialStatus: "expired" }),
+        candidate("codex", "codex"),
+      ],
+      route: route("codex"),
+      localOnly: false,
+      nowMs: NOW,
+    });
+
+    expect(result.status).toBe("blocked");
+    expect(result.selected).toBeNull();
+    expect(result.fallbackDisabled).toBe(true);
+    expect(result.action).toMatch(/automatic fallback was disabled/i);
+  });
+
+  it("blocks before phase work with one actionable explanation when no engine is eligible", () => {
+    const result = selectBuildEngineFromCandidates({
+      policy: { mode: "auto", pinnedEngine: null },
+      candidates: [
+        candidate("claude", "anthropic-sub", { present: false }),
+        candidate("codex", "codex", { providerCapacityState: "reauth_required" }),
+      ],
+      route: route(null),
+      localOnly: false,
+      nowMs: NOW,
+    });
+
+    expect(result.status).toBe("blocked");
+    expect(result.action).toMatch(/connect, provision, or wait/i);
+    expect(result.rejected).toHaveLength(2);
+  });
+
+  it("projects the router fallback chain and rationale without re-ranking it", () => {
+    const result = selectBuildEngineFromCandidates({
+      policy: { mode: "auto", pinnedEngine: null },
+      candidates: [
+        candidate("claude", "anthropic-sub"),
+        candidate("codex", "codex"),
+        candidate("opencode", "local"),
+      ],
+      route: route("anthropic-sub", ["codex", "local"]),
+      localOnly: false,
+      nowMs: NOW,
+    });
+
+    expect(result.reason).toBe("Selected anthropic-sub through routeEndpointV2.");
+    expect(result.fallbackChain.map((entry) => entry.engine)).toEqual(["codex", "opencode"]);
+  });
+});
+
+describe("classifyRetrySafePreDispatchFailure", () => {
+  it.each([
+    "Auth error: OAuth token expired",
+    "rate limited before dispatch; retry-after: 30",
+    "CLI unavailable: executable not found",
+  ])("permits one pre-dispatch fallback for %s", (message) => {
+    expect(classifyRetrySafePreDispatchFailure({ message, durationMs: 0 })).not.toBeNull();
+  });
+
+  it("does not retry after work may have started", () => {
+    expect(classifyRetrySafePreDispatchFailure({
+      message: "Auth error after agent edited files",
+      durationMs: 250,
+      sideEffectsStarted: true,
+    })).toBeNull();
+  });
+
+  it("recognizes the observed short OAuth startup failure as pre-dispatch", () => {
+    expect(classifyRetrySafePreDispatchFailure({
+      message: "OAuth token has expired",
+      durationMs: 300,
+    })).toBe("auth");
+  });
+});

--- a/apps/web/lib/integrate/build-engine-selection.ts
+++ b/apps/web/lib/integrate/build-engine-selection.ts
@@ -1,0 +1,305 @@
+import { capacityRoutingExclusionReason } from "@/lib/routing/capacity-routing-exclude";
+
+export const BUILD_ENGINE_IDS = ["claude", "codex", "grok", "opencode", "agentic"] as const;
+export type BuildEngineId = (typeof BUILD_ENGINE_IDS)[number];
+
+export type BuildEnginePolicy = {
+  mode: "auto" | "pinned";
+  pinnedEngine: BuildEngineId | null;
+};
+
+export type BuildEngineCandidate = {
+  engine: BuildEngineId;
+  providerId: string;
+  modelId: string | null;
+  local: boolean;
+  registered: boolean;
+  present: boolean;
+  providerStatus: string;
+  authMethod: string;
+  credentialStatus: string | null;
+  credentialExpiresAt: number | null;
+  providerCapacityState: string | null;
+  providerRetryAt: number | null;
+  cliRetryAt: number | null;
+  providerHealth:
+    | "healthy"
+    | "unknown"
+    | "rate_limited"
+    | "needs_reauth"
+    | "billing"
+    | "cooling_down"
+    | "degraded"
+    | "unconfigured";
+};
+
+export type BuildEngineRejectionCode =
+  | "hard-pin-boundary"
+  | "residency-local-only"
+  | "engine-not-registered"
+  | "engine-unhealthy"
+  | "provider-disabled"
+  | "credential-missing"
+  | "credential-expired"
+  | "credential-auth-failed"
+  | "capacity-retry-window"
+  | "provider-unhealthy"
+  | "route-contract";
+
+export type BuildEngineRejection = {
+  engine: BuildEngineId;
+  providerId: string;
+  code: BuildEngineRejectionCode;
+  reason: string;
+};
+
+export type BuildEngineRouteResult = {
+  selectedProviderId: string | null;
+  selectedModelId: string | null;
+  reason: string;
+  /** Provider order from routeEndpointV2 after the winner (already ranked). */
+  fallbackProviderIds: string[];
+  rejectedProviders: Array<{ providerId: string; reason: string }>;
+};
+
+export type BuildEngineSelection = {
+  status: "selected" | "blocked";
+  policy: BuildEnginePolicy;
+  selected: BuildEngineCandidate | null;
+  reason: string;
+  rejected: BuildEngineRejection[];
+  fallbackChain: BuildEngineCandidate[];
+  fallbackDisabled: boolean;
+  action: string | null;
+};
+
+const AUTH_FAILED_CREDENTIAL_STATUSES = new Set([
+  "auth_failed",
+  "error",
+  "invalid",
+  "revoked",
+  "unconfigured",
+]);
+const UNHEALTHY_PROVIDER_STATES = new Set([
+  "rate_limited",
+  "needs_reauth",
+  "billing",
+  "cooling_down",
+  "degraded",
+  "unconfigured",
+]);
+
+function rejectionForCandidate(args: {
+  candidate: BuildEngineCandidate;
+  policy: BuildEnginePolicy;
+  localOnly: boolean;
+  nowMs: number;
+}): BuildEngineRejection | null {
+  const { candidate, policy, localOnly, nowMs } = args;
+  const reject = (code: BuildEngineRejectionCode, reason: string): BuildEngineRejection => ({
+    engine: candidate.engine,
+    providerId: candidate.providerId,
+    code,
+    reason,
+  });
+
+  if (
+    policy.mode === "pinned"
+    && policy.pinnedEngine !== null
+    && candidate.engine !== policy.pinnedEngine
+  ) {
+    return reject("hard-pin-boundary", `Excluded by the explicit ${policy.pinnedEngine} hard pin.`);
+  }
+  if (localOnly && !candidate.local) {
+    return reject("residency-local-only", "Cloud execution is outside the local-only residency boundary.");
+  }
+  if (!candidate.registered) {
+    return reject("engine-not-registered", "The execution adapter is not registered on this install.");
+  }
+  if (!candidate.present) {
+    return reject("engine-unhealthy", "The build engine is absent or its latest readiness probe failed.");
+  }
+  if (candidate.providerStatus !== "active") {
+    return reject("provider-disabled", "The provider is not enabled for routing.");
+  }
+
+  const requiresCredential = candidate.authMethod.toLowerCase() !== "none";
+  if (requiresCredential && candidate.credentialStatus === null) {
+    return reject("credential-missing", "No credential is connected for this provider.");
+  }
+  const credentialStatus = candidate.credentialStatus?.toLowerCase() ?? null;
+  if (requiresCredential && credentialStatus !== null && credentialStatus === "expired") {
+    return reject("credential-expired", "The connected credential is marked expired.");
+  }
+  if (requiresCredential && credentialStatus !== null && AUTH_FAILED_CREDENTIAL_STATUSES.has(credentialStatus)) {
+    return reject(
+      "credential-auth-failed",
+      `The connected credential is not usable (${credentialStatus}).`,
+    );
+  }
+  if (
+    requiresCredential
+    && candidate.credentialExpiresAt !== null
+    && candidate.credentialExpiresAt <= nowMs
+  ) {
+    return reject("credential-expired", "The connected credential has expired.");
+  }
+  if (candidate.cliRetryAt !== null && candidate.cliRetryAt > nowMs) {
+    return reject(
+      "capacity-retry-window",
+      `The CLI pool is in a retry window until ${new Date(candidate.cliRetryAt).toISOString()}.`,
+    );
+  }
+  const capacityReason = capacityRoutingExclusionReason(
+    candidate.providerCapacityState
+      ? { state: candidate.providerCapacityState, retryAtMs: candidate.providerRetryAt }
+      : null,
+    nowMs,
+  );
+  if (capacityReason) {
+    return reject("capacity-retry-window", capacityReason);
+  }
+  if (UNHEALTHY_PROVIDER_STATES.has(candidate.providerHealth)) {
+    return reject("provider-unhealthy", `Provider health is ${candidate.providerHealth}.`);
+  }
+  return null;
+}
+
+function uniqueCandidatesInProviderOrder(
+  providerIds: readonly string[],
+  eligible: readonly BuildEngineCandidate[],
+  selected?: BuildEngineCandidate | null,
+): BuildEngineCandidate[] {
+  const byProvider = new Map<string, BuildEngineCandidate[]>();
+  for (const candidate of eligible) {
+    const bucket = byProvider.get(candidate.providerId) ?? [];
+    bucket.push(candidate);
+    byProvider.set(candidate.providerId, bucket);
+  }
+  const seenEngines = new Set<BuildEngineId>(selected ? [selected.engine] : []);
+  const result: BuildEngineCandidate[] = [];
+  for (const providerId of providerIds) {
+    const candidate = byProvider.get(providerId)?.[0];
+    if (!candidate || seenEngines.has(candidate.engine)) continue;
+    seenEngines.add(candidate.engine);
+    result.push(candidate);
+  }
+  return result;
+}
+
+/**
+ * Apply engine-only hard gates, then project the existing router's winner and
+ * fallback order. This function never scores or re-ranks candidates.
+ */
+export function qualifyBuildEngineCandidates(args: {
+  policy: BuildEnginePolicy;
+  candidates: BuildEngineCandidate[];
+  localOnly: boolean;
+  nowMs?: number;
+}): { eligible: BuildEngineCandidate[]; rejected: BuildEngineRejection[] } {
+  const nowMs = args.nowMs ?? Date.now();
+  const rejected: BuildEngineRejection[] = [];
+  const eligible: BuildEngineCandidate[] = [];
+  for (const candidate of args.candidates) {
+    const rejection = rejectionForCandidate({
+      candidate,
+      policy: args.policy,
+      localOnly: args.localOnly,
+      nowMs,
+    });
+    if (rejection) rejected.push(rejection);
+    else eligible.push(candidate);
+  }
+  return { eligible, rejected };
+}
+
+export function selectBuildEngineFromCandidates(args: {
+  policy: BuildEnginePolicy;
+  candidates: BuildEngineCandidate[];
+  route: BuildEngineRouteResult;
+  localOnly: boolean;
+  nowMs?: number;
+}): BuildEngineSelection {
+  const { eligible, rejected } = qualifyBuildEngineCandidates(args);
+
+  for (const routeRejection of args.route.rejectedProviders) {
+    for (const candidate of eligible.filter((entry) => entry.providerId === routeRejection.providerId)) {
+      rejected.push({
+        engine: candidate.engine,
+        providerId: candidate.providerId,
+        code: "route-contract",
+        reason: routeRejection.reason,
+      });
+    }
+  }
+
+  if (!args.route.selectedProviderId && args.route.rejectedProviders.length === 0) {
+    for (const candidate of eligible) {
+      rejected.push({
+        engine: candidate.engine,
+        providerId: candidate.providerId,
+        code: "route-contract",
+        reason: args.route.reason,
+      });
+    }
+  }
+
+  const selected = args.route.selectedProviderId
+    ? eligible.find((candidate) => candidate.providerId === args.route.selectedProviderId) ?? null
+    : null;
+  const pinned = args.policy.mode === "pinned";
+  if (!selected) {
+    const pinnedLabel = args.policy.pinnedEngine ?? "selected";
+    return {
+      status: "blocked",
+      policy: args.policy,
+      selected: null,
+      reason: pinned
+        ? `${pinnedLabel} is not eligible under the current readiness and routing contract.`
+        : args.route.reason,
+      rejected,
+      fallbackChain: [],
+      fallbackDisabled: pinned,
+      action: pinned
+        ? `Restore ${pinnedLabel} readiness or change Advanced execution policy; automatic fallback was disabled by the hard pin.`
+        : "Connect, provision, or wait for one allowed Build Studio engine, then retry.",
+    };
+  }
+
+  return {
+    status: "selected",
+    policy: args.policy,
+    selected,
+    reason: args.route.reason,
+    rejected,
+    fallbackChain: pinned
+      ? []
+      : uniqueCandidatesInProviderOrder(args.route.fallbackProviderIds, eligible, selected),
+    fallbackDisabled: pinned,
+    action: null,
+  };
+}
+
+export type RetrySafePreDispatchFailure = "auth" | "rate-limit" | "availability";
+
+/**
+ * Short startup failures in these classes occur before a CLI session can
+ * mutate phase state. The caller may consume at most one fallback candidate.
+ */
+export function classifyRetrySafePreDispatchFailure(input: {
+  message: string;
+  durationMs: number;
+  sideEffectsStarted?: boolean;
+}): RetrySafePreDispatchFailure | null {
+  // Authentication, quota, and connection failures can take a short process
+  // startup interval (the live OAuth failure took ~300ms) while still occurring
+  // before an agent session or sandbox mutation exists.
+  if (input.sideEffectsStarted || input.durationMs > 1_000) return null;
+  const message = input.message.toLowerCase();
+  if (/auth|oauth|credential|token.*expir|401/.test(message)) return "auth";
+  if (/rate.?limit|retry-after|quota|capacity/.test(message)) return "rate-limit";
+  if (/unavailable|not found|not installed|enoent|connection refused|cannot connect/.test(message)) {
+    return "availability";
+  }
+  return null;
+}

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -36,7 +36,9 @@ import type {
 import { mergeHappyPathStateIntoPlan } from "@/lib/explore/feature-build-types";
 import type { CodexResult } from "./codex-dispatch";
 import type { ClaudeResult } from "./claude-dispatch";
-import { getBuildStudioConfig } from "./build-studio-config";
+import { getBuildStudioConfig, type BuildStudioDispatchConfig } from "./build-studio-config";
+import { formatBuildEngineSelectionEvidence } from "./build-engine-selection-runtime";
+import { classifyRetrySafePreDispatchFailure, type BuildEngineCandidate } from "./build-engine-selection";
 import { assertAgentProviderCompatibility, type BuildAgentId } from "./sandbox/agent-runner-types";
 import { getBuildAgentRunner } from "./sandbox/agents";
 import { getBuildExecutionProvider } from "./sandbox/providers";
@@ -768,9 +770,11 @@ async function dispatchSpecialist(params: {
   parentThreadId: string;
   priorResults?: string;
   sessionId?: string;
+  dispatchConfig: BuildStudioDispatchConfig;
 }): Promise<SpecialistResult> {
-  const { task, userId, platformRole, isSuperuser, buildId, buildContext, parentThreadId, priorResults, sessionId } = params;
+  const { task, userId, platformRole, isSuperuser, buildId, buildContext, parentThreadId, priorResults, sessionId, dispatchConfig: config } = params;
   const role = task.specialist;
+  let agenticFallbackProviderId: string | null = null;
 
   // Emit dispatch event
   agentEventBus.emit(parentThreadId, {
@@ -781,8 +785,6 @@ async function dispatchSpecialist(params: {
   });
 
   // ─── CLI dispatch path: Codex or Claude Code running inside the sandbox ──
-  const config = await getBuildStudioConfig();
-
   if (config.provider === "codex" || config.provider === "claude" || config.provider === "grok" || config.provider === "opencode") {
     const onProgress = (message: string) => {
       agentEventBus.emit(parentThreadId, {
@@ -792,37 +794,65 @@ async function dispatchSpecialist(params: {
         message,
       });
     };
-    const { provider, runner } = resolveBuildProviderRunner({ agentId: config.provider });
     const containerId = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
-    const runResult = await runner.run(
-      provider,
-      {
-        id: containerId,
-        buildId,
-        providerId: provider.id,
-        containerId,
-      },
-      {
-        task,
-        buildId,
-        buildContext,
-        priorResults,
-        providerId: config.provider === "claude" ? config.claudeProviderId : config.provider === "grok" ? config.grokProviderId : config.provider === "opencode" ? config.opencodeProviderId : config.codexProviderId,
-        model: config.provider === "claude" ? config.claudeModel : config.provider === "grok" ? config.grokModel : config.provider === "opencode" ? config.opencodeModel : config.codexModel,
-        sessionId,
-        onProgress,
-      },
-    );
-    const cliResult: CodexResult | ClaudeResult = {
-      content: runResult.stdout || runResult.stderr,
-      success: runResult.exitCode === 0,
-      executedTools: [],
-      durationMs: runResult.durationMs,
-    };
+    const selectedCandidate = config.selection?.selected;
+    const cliAttempts: BuildEngineCandidate[] = selectedCandidate
+      ? [selectedCandidate, ...config.selection!.fallbackChain.slice(0, 1)]
+      : [];
+    let cliResult: CodexResult | ClaudeResult | null = null;
+    for (let attemptIndex = 0; attemptIndex < Math.max(1, cliAttempts.length); attemptIndex += 1) {
+      const candidate = cliAttempts[attemptIndex];
+      if (candidate?.engine === "agentic") {
+        agenticFallbackProviderId = candidate.providerId;
+        break;
+      }
+      const engine = candidate?.engine ?? config.provider;
+      const { provider, runner } = resolveBuildProviderRunner({ agentId: engine });
+      const runResult = await runner.run(
+        provider,
+        { id: containerId, buildId, providerId: provider.id, containerId },
+        {
+          task,
+          buildId,
+          buildContext,
+          priorResults,
+          providerId: candidate?.providerId
+            ?? (engine === "claude" ? config.claudeProviderId : engine === "grok" ? config.grokProviderId : engine === "opencode" ? config.opencodeProviderId : config.codexProviderId),
+          model: candidate?.modelId
+            ?? (engine === "claude" ? config.claudeModel : engine === "grok" ? config.grokModel : engine === "opencode" ? config.opencodeModel : config.codexModel),
+          sessionId,
+          onProgress,
+        },
+      );
+      cliResult = {
+        content: runResult.stdout || runResult.stderr,
+        success: runResult.exitCode === 0,
+        executedTools: [],
+        durationMs: runResult.durationMs,
+      };
+      if (cliResult.success) break;
+      const retryClass = classifyRetrySafePreDispatchFailure({
+        message: cliResult.content,
+        durationMs: cliResult.durationMs,
+      });
+      const next = cliAttempts[attemptIndex + 1];
+      if (!retryClass || !next || config.selection?.fallbackDisabled) break;
+      await prisma.buildActivity.create({
+        data: {
+          buildId,
+          tool: "engine_selection",
+          summary: `Build dispatch ${engine} ${retryClass} failure occurred before phase side effects; falling back once to ${next.engine} (provider=${next.providerId}).`,
+        },
+      }).catch(() => {});
+    }
 
-    const outcome = classifyOutcome(cliResult, role);
+    if (!cliResult && !agenticFallbackProviderId) {
+      throw new Error("Build engine selection returned no specialist dispatch attempt.");
+    }
 
-    if (isMissingSandboxToolSurfaceOutput(cliResult.content)) {
+    const outcome = cliResult ? classifyOutcome(cliResult, role) : "BLOCKED";
+
+    if (cliResult && isMissingSandboxToolSurfaceOutput(cliResult.content)) {
       agentEventBus.emit(parentThreadId, {
         type: "orchestrator:specialist_retry",
         buildId,
@@ -831,7 +861,7 @@ async function dispatchSpecialist(params: {
           "CLI session reported that the Build Studio sandbox tool set is not exposed; retrying through the platform agentic tool path.",
         attempt: 1,
       });
-    } else {
+    } else if (cliResult && !agenticFallbackProviderId) {
       agentEventBus.emit(parentThreadId, {
         type: "orchestrator:task_complete",
         buildId,
@@ -891,7 +921,9 @@ async function dispatchSpecialist(params: {
       routeContext: "/build",
       agentId,
       threadId: thread.id,
-      modelRequirements: modelReqs,
+      modelRequirements: agenticFallbackProviderId || config.selection?.selected?.engine === "agentic"
+        ? { ...modelReqs, allowedProviders: [agenticFallbackProviderId ?? config.selection!.selected!.providerId] }
+        : modelReqs,
       requireTools: true,
       onProgress: (event: AgentEvent) => agentEventBus.emit(parentThreadId, event),
     });
@@ -1063,10 +1095,40 @@ export async function runBuildOrchestrator(params: {
     console.warn("[orchestrator] Could not read prior task results, starting fresh:", err);
   }
 
-  // ─── Pre-flight check: verify CLI dispatch auth is available ─────────────
-  // Catch missing OAuth tokens BEFORE dispatching 14 tasks that all fail with
-  // the same auth error. One clear message is better than 14 cryptic ones.
-  const preflightConfig = await getBuildStudioConfig();
+  // ─── Pre-flight check: select one policy-qualified healthy engine ─────────
+  // The shared selector owns auth, health, capacity, residency, sensitivity,
+  // capability, and hard-pin gates before any specialist side effect begins.
+  const { deriveDeliverableSensitivity } = await import("@/lib/explore/build-process-matrix");
+  const buildSensitivity = deriveDeliverableSensitivity({ text: buildContext });
+  const preflightConfig = await getBuildStudioConfig({
+    sensitivity: buildSensitivity === "high" ? "confidential" : "internal",
+  });
+
+  if (preflightConfig.selection) {
+    await prisma.buildActivity.create({
+      data: {
+        buildId,
+        tool: "engine_selection",
+        summary: formatBuildEngineSelectionEvidence(preflightConfig.selection),
+      },
+    }).catch((err) => console.warn("[orchestrator] Could not persist engine selection evidence:", err));
+  }
+  if (!preflightConfig.selection || preflightConfig.selection.status === "blocked" || !preflightConfig.selection.selected) {
+    return {
+      content: formatCoworkerOperationalCloseout({
+        status: "blocked before implementation",
+        evidence: preflightConfig.selection?.reason ?? "Build Studio could not resolve an allowed healthy execution engine.",
+        nextAction: preflightConfig.selection?.action ?? "Review AI Readiness, restore one allowed engine, and retry implementation.",
+        owner: "operator/admin",
+      }),
+      totalTasks: 0,
+      completedTasks: 0,
+      failedTasks: 0,
+      specialistResults: [],
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+    };
+  }
 
   try {
     const buildRecord = await prisma.featureBuild.findUnique({
@@ -1094,91 +1156,6 @@ export async function runBuildOrchestrator(params: {
     }
   } catch (err) {
     console.warn("[orchestrator] Could not persist execution engine metadata:", err);
-  }
-
-  if (preflightConfig.provider === "codex" || preflightConfig.provider === "claude" || preflightConfig.provider === "grok") {
-    try {
-      const { getDecryptedCredential } = await import("@/lib/inference/ai-provider-internals");
-      const providerId = preflightConfig.provider === "claude"
-        ? preflightConfig.claudeProviderId
-        : preflightConfig.provider === "grok"
-          ? preflightConfig.grokProviderId
-          : preflightConfig.codexProviderId;
-      const cred = await getDecryptedCredential(providerId);
-      const hasAuth = preflightConfig.provider === "claude"
-        ? !!(cred?.cachedToken || cred?.secretRef)
-        : preflightConfig.provider === "grok"
-          ? !!cred?.cachedToken
-          : !!cred?.cachedToken;
-      if (!hasAuth) {
-        const label = preflightConfig.provider === "claude" ? "Claude / Anthropic" : preflightConfig.provider === "grok" ? "xAI / Grok" : "OpenAI / Codex";
-        const buildRecord = await prisma.featureBuild.findUnique({
-          where: { buildId },
-          select: { plan: true },
-        });
-        if (buildRecord) {
-          await prisma.featureBuild.update({
-            where: { buildId },
-            data: {
-              plan: mergeHappyPathStateIntoPlan(
-                (buildRecord.plan as Record<string, unknown> | null) ?? null,
-                {
-                  execution: {
-                    engine: preflightConfig.provider,
-                    source: null,
-                    status: "failed",
-                    failureStage: "connect",
-                  },
-                },
-              ) as import("@dpf/db").Prisma.InputJsonValue,
-            },
-          }).catch(() => {});
-        }
-        return {
-          content: formatCoworkerOperationalCloseout({
-            status: "blocked before implementation",
-            evidence: `the ${label} provider "${providerId}" is not connected.`,
-            nextAction: "connect the provider in Admin > AI Workforce > External Services, or switch providers in Build Studio.",
-            owner: "operator/admin",
-          }),
-          totalTasks: 0, completedTasks: 0, failedTasks: 0,
-          specialistResults: [], totalInputTokens: 0, totalOutputTokens: 0,
-        };
-      }
-    } catch {
-      const buildRecord = await prisma.featureBuild.findUnique({
-        where: { buildId },
-        select: { plan: true },
-      });
-      if (buildRecord) {
-        await prisma.featureBuild.update({
-          where: { buildId },
-          data: {
-            plan: mergeHappyPathStateIntoPlan(
-              (buildRecord.plan as Record<string, unknown> | null) ?? null,
-              {
-                execution: {
-                  engine: preflightConfig.provider,
-                  source: null,
-                  status: "failed",
-                  failureStage: "connect",
-                },
-              },
-            ) as import("@dpf/db").Prisma.InputJsonValue,
-          },
-        }).catch(() => {});
-      }
-      return {
-        content: formatCoworkerOperationalCloseout({
-          status: "blocked before implementation",
-          evidence: "Build Studio could not verify AI provider credentials.",
-          nextAction: "confirm at least one code generation provider is connected in Admin > AI Workforce, then retry implementation.",
-          owner: "operator/admin",
-        }),
-        totalTasks: 0, completedTasks: 0, failedTasks: 0,
-        specialistResults: [], totalInputTokens: 0, totalOutputTokens: 0,
-      };
-    }
   }
 
   // ─── Pre-flight check: sandbox test toolchain is loadable ────────────────
@@ -1269,14 +1246,7 @@ export async function runBuildOrchestrator(params: {
   // failure, now in the build phase. Serialize specialist dispatch for a local
   // engine; cloud subscription CLIs keep concurrency 2 for throughput within
   // their per-minute caps.
-  let localBuildEngine = false;
-  try {
-    const { getBuildStudioConfig } = await import("@/lib/integrate/build-studio-config");
-    const bsCfg = await getBuildStudioConfig();
-    localBuildEngine = bsCfg.provider === "opencode";
-  } catch {
-    /* default to cloud concurrency if the config read fails */
-  }
+  const localBuildEngine = preflightConfig.selection.selected.local;
   for (const phase of phases) {
     // Timeout check
     if (Date.now() - startTime > MAX_DURATION_ORCHESTRATOR_MS) {
@@ -1335,6 +1305,7 @@ export async function runBuildOrchestrator(params: {
             buildContext: scopedTaskContext,
             parentThreadId,
             priorResults: artifactSummaryForBatch || undefined,
+            dispatchConfig: preflightConfig,
             // sessionId omitted — see Layer 1 comment above
           });
           const artifactEntry = buildTaskArtifactEntry({
@@ -1513,6 +1484,7 @@ export async function runBuildOrchestrator(params: {
             };
             const res = await dispatchSpecialist({
               task: repairTask, userId, platformRole, isSuperuser, buildId, buildContext, parentThreadId,
+              dispatchConfig: preflightConfig,
             });
             allResults.push(res);
             return res.success;

--- a/apps/web/lib/integrate/build-studio-config.test.ts
+++ b/apps/web/lib/integrate/build-studio-config.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getBuildStudioConfig } from "./build-studio-config";
 
+const resolveSelection = vi.hoisted(() => vi.fn());
+vi.mock("./build-engine-selection-runtime", () => ({
+  resolveBuildEngineSelection: resolveSelection,
+}));
+
 vi.mock("@dpf/db", () => ({
   prisma: {
     platformConfig: {
@@ -28,8 +33,36 @@ function providerRow(
   return { providerId, status, authMethod } as Awaited<ReturnType<typeof prisma.modelProvider.findMany>>[number];
 }
 
-function credentialRow(status: "ok" | "configured" | "pending"): NonNullable<Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>> {
+function credentialRow(status: "active" | "configured" | "pending"): NonNullable<Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>> {
   return { status } as NonNullable<Awaited<ReturnType<typeof prisma.credentialEntry.findUnique>>>;
+}
+
+function selection(engine: "claude" | "codex" | "grok" | "opencode" | "agentic", providerId: string = engine) {
+  return {
+    status: "selected" as const,
+    policy: { mode: "auto" as const, pinnedEngine: null },
+    selected: {
+      engine,
+      providerId,
+      modelId: null,
+      local: engine === "opencode",
+      registered: true,
+      present: true,
+      providerStatus: "active",
+      authMethod: engine === "opencode" ? "none" : "oauth",
+      credentialStatus: engine === "opencode" ? null : "active",
+      credentialExpiresAt: null,
+      providerCapacityState: "available",
+      providerRetryAt: null,
+      cliRetryAt: null,
+      providerHealth: "healthy" as const,
+    },
+    reason: `Selected ${engine} through routeEndpointV2.`,
+    rejected: [],
+    fallbackChain: [],
+    fallbackDisabled: false,
+    action: null,
+  };
 }
 
 describe("getBuildStudioConfig", () => {
@@ -47,13 +80,16 @@ describe("getBuildStudioConfig", () => {
     delete process.env.OPENCODE_MODEL;
     mockProviderFindMany.mockResolvedValue([]);
     mockCredentialFindUnique.mockResolvedValue(null);
+    resolveSelection.mockResolvedValue(selection("agentic"));
   });
 
   it("returns defaults when no DB config and no env vars", async () => {
     mockFindUnique.mockResolvedValue(null);
     const config = await getBuildStudioConfig();
-    expect(config).toEqual({
+    expect(config).toMatchObject({
       provider: "agentic",
+      enginePolicy: "auto",
+      pinnedEngine: null,
       claudeProviderId: "",
       codexProviderId: "",
       grokProviderId: "",
@@ -63,6 +99,7 @@ describe("getBuildStudioConfig", () => {
       grokModel: "",
       opencodeModel: "",
     });
+    expect(config.selection?.selected?.engine).toBe("agentic");
   });
 
   it("reads config from PlatformConfig DB row", async () => {
@@ -78,8 +115,10 @@ describe("getBuildStudioConfig", () => {
       },
       updatedAt: new Date(),
     });
+    resolveSelection.mockResolvedValue(selection("claude", "anthropic"));
     const config = await getBuildStudioConfig();
     expect(config.provider).toBe("claude");
+    expect(config.enginePolicy).toBe("auto");
     expect(config.claudeProviderId).toBe("anthropic");
     expect(config.claudeModel).toBe("opus");
   });
@@ -89,14 +128,15 @@ describe("getBuildStudioConfig", () => {
       .mockResolvedValueOnce([providerRow("anthropic-sub")])
       .mockResolvedValueOnce([providerRow("chatgpt")]);
     mockCredentialFindUnique
-      .mockResolvedValueOnce(credentialRow("ok"))
-      .mockResolvedValueOnce(credentialRow("ok"));
+      .mockResolvedValueOnce(credentialRow("active"))
+      .mockResolvedValueOnce(credentialRow("active"));
     mockFindUnique.mockResolvedValue({
       id: "1",
       key: "build-studio-dispatch",
       value: { provider: "claude" },
       updatedAt: new Date(),
     });
+    resolveSelection.mockResolvedValue(selection("claude", "anthropic-sub"));
     const config = await getBuildStudioConfig();
     expect(config.provider).toBe("claude");
     expect(config.claudeProviderId).toBe("anthropic-sub");
@@ -104,12 +144,24 @@ describe("getBuildStudioConfig", () => {
     expect(config.claudeModel).toBe("sonnet");
   });
 
-  it("stays on agentic when env vars request claude but no configured cli provider exists", async () => {
+  it("treats an env engine override as a deliberate hard pin", async () => {
     mockFindUnique.mockResolvedValue(null);
     process.env.CLI_DISPATCH_PROVIDER = "claude";
     process.env.CLAUDE_CODE_MODEL = "opus";
+    resolveSelection.mockResolvedValue({
+      status: "blocked",
+      policy: { mode: "pinned", pinnedEngine: "claude" },
+      selected: null,
+      reason: "Claude is not ready.",
+      rejected: [],
+      fallbackChain: [],
+      fallbackDisabled: true,
+      action: "Restore Claude; automatic fallback was disabled by the hard pin.",
+    });
     const config = await getBuildStudioConfig();
-    expect(config.provider).toBe("agentic");
+    expect(config.provider).toBe("claude");
+    expect(config.enginePolicy).toBe("pinned");
+    expect(config.pinnedEngine).toBe("claude");
     expect(config.claudeModel).toBe("opus");
   });
 
@@ -119,9 +171,10 @@ describe("getBuildStudioConfig", () => {
       .mockResolvedValueOnce([providerRow("anthropic-sub")])
       .mockResolvedValueOnce([providerRow("chatgpt")]);
     mockCredentialFindUnique
-      .mockResolvedValueOnce(credentialRow("ok"))
-      .mockResolvedValueOnce(credentialRow("ok"));
+      .mockResolvedValueOnce(credentialRow("active"))
+      .mockResolvedValueOnce(credentialRow("active"));
 
+    resolveSelection.mockResolvedValue(selection("claude", "anthropic-sub"));
     const config = await getBuildStudioConfig();
     expect(config.provider).toBe("claude");
     expect(config.claudeProviderId).toBe("anthropic-sub");
@@ -134,9 +187,10 @@ describe("getBuildStudioConfig", () => {
       .mockResolvedValueOnce([providerRow("anthropic-sub", "inactive")])
       .mockResolvedValueOnce([providerRow("chatgpt", "active")]);
     mockCredentialFindUnique
-      .mockResolvedValueOnce(credentialRow("ok"))
-      .mockResolvedValueOnce(credentialRow("ok"));
+      .mockResolvedValueOnce(credentialRow("active"))
+      .mockResolvedValueOnce(credentialRow("active"));
 
+    resolveSelection.mockResolvedValue(selection("codex", "chatgpt"));
     const config = await getBuildStudioConfig();
 
     expect(config.provider).toBe("codex");
@@ -147,6 +201,7 @@ describe("getBuildStudioConfig", () => {
   it("falls back to legacy CODEX_DISPATCH=false as agentic", async () => {
     mockFindUnique.mockResolvedValue(null);
     process.env.CODEX_DISPATCH = "false";
+    resolveSelection.mockResolvedValue({ ...selection("agentic"), policy: { mode: "pinned", pinnedEngine: "agentic" }, fallbackDisabled: true });
     const config = await getBuildStudioConfig();
     expect(config.provider).toBe("agentic");
   });
@@ -162,6 +217,7 @@ describe("getBuildStudioConfig", () => {
     // No credentialEntry exists for the no-auth provider — must still detect.
     mockCredentialFindUnique.mockResolvedValue(null);
 
+    resolveSelection.mockResolvedValue(selection("opencode", "local"));
     const config = await getBuildStudioConfig();
 
     expect(config.provider).toBe("opencode");
@@ -175,8 +231,9 @@ describe("getBuildStudioConfig", () => {
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([providerRow("zai-coding", "active", "api_key")]);
-    mockCredentialFindUnique.mockResolvedValue(credentialRow("ok"));
+    mockCredentialFindUnique.mockResolvedValue(credentialRow("active"));
 
+    resolveSelection.mockResolvedValue(selection("opencode", "zai-coding"));
     const config = await getBuildStudioConfig();
 
     expect(config.provider).toBe("opencode");
@@ -190,8 +247,9 @@ describe("getBuildStudioConfig", () => {
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([providerRow("local", "active", "none")]);
-    mockCredentialFindUnique.mockResolvedValueOnce(credentialRow("ok"));
+    mockCredentialFindUnique.mockResolvedValueOnce(credentialRow("active"));
 
+    resolveSelection.mockResolvedValue(selection("claude", "anthropic-sub"));
     const config = await getBuildStudioConfig();
 
     expect(config.provider).toBe("claude");
@@ -208,6 +266,7 @@ describe("getBuildStudioConfig", () => {
       .mockResolvedValueOnce([providerRow("local", "active", "none")]);
     mockCredentialFindUnique.mockResolvedValue(null);
 
+    resolveSelection.mockResolvedValue({ ...selection("opencode", "local"), policy: { mode: "pinned", pinnedEngine: "opencode" }, fallbackDisabled: true });
     const config = await getBuildStudioConfig();
 
     expect(config.provider).toBe("opencode");

--- a/apps/web/lib/integrate/build-studio-config.ts
+++ b/apps/web/lib/integrate/build-studio-config.ts
@@ -7,10 +7,22 @@ import { prisma } from "@dpf/db";
 import type { BuildModelTier } from "@/lib/explore/build-process-matrix";
 import { DEFAULT_BUILD_POSTURE, coerceBuildPosture } from "@/lib/explore/build-rightsizing-dial";
 import type { GoldenTrianglePreference } from "@/lib/golden-triangle/types";
+import type { SensitivityLevel } from "@/lib/routing/types";
 import { resolveCredentialProviderId } from "@/lib/inference/ai-provider-internals";
+import type {
+  BuildEngineId,
+  BuildEnginePolicy,
+  BuildEngineSelection,
+} from "./build-engine-selection";
+import { resolveBuildEngineSelection } from "./build-engine-selection-runtime";
 
 export type BuildStudioDispatchConfig = {
-  provider: "claude" | "codex" | "grok" | "opencode" | "agentic";
+  provider: BuildEngineId;
+  /** Auto is the default. Pinned is an advanced, explicit no-fallback policy. */
+  enginePolicy?: BuildEnginePolicy["mode"];
+  pinnedEngine?: BuildEngineId | null;
+  /** Live derived evidence; never treated as stored operator configuration. */
+  selection?: BuildEngineSelection | null;
   claudeProviderId: string;
   codexProviderId: string;
   grokProviderId: string;
@@ -22,7 +34,10 @@ export type BuildStudioDispatchConfig = {
 };
 
 const DEFAULTS: BuildStudioDispatchConfig = {
-  provider: "agentic",   // safe default — no external provider needed
+  provider: "agentic",   // placeholder until the Auto selector resolves live state
+  enginePolicy: "auto",
+  pinnedEngine: null,
+  selection: null,
   claudeProviderId: "",
   codexProviderId: "",
   grokProviderId: "",
@@ -58,7 +73,7 @@ async function findConfiguredProvider(cliEngine: string): Promise<string> {
       where: { providerId: resolveCredentialProviderId(p.providerId) },
       select: { status: true },
     });
-    if (cred && (cred.status === "ok" || cred.status === "configured" || cred.status === "pending")) {
+    if (cred && (cred.status === "active" || cred.status === "pending" || cred.status === "configured")) {
       return p.providerId;
     }
   }
@@ -66,8 +81,8 @@ async function findConfiguredProvider(cliEngine: string): Promise<string> {
 }
 
 /**
- * Auto-detect the best dispatch provider based on what's configured.
- * Prefers active Claude over active Codex; falls back to agentic if nothing configured.
+ * Discover configured engine/provider identifiers. The canonical router—not
+ * discovery order—chooses the Auto winner.
  */
 async function autoDetectConfig(): Promise<BuildStudioDispatchConfig> {
   const claudeId = await findConfiguredProvider("claude");
@@ -75,25 +90,25 @@ async function autoDetectConfig(): Promise<BuildStudioDispatchConfig> {
   const grokId = await findConfiguredProvider("grok");
   const opencodeId = await findConfiguredProvider("opencode");
 
-  // Pick the first available CLI engine. Order: frontier CLIs first, then the
-  // local opencode runner — so a credential-free install with a healthy local
-  // provider lands on opencode rather than the legacy agentic fallback.
+  // Auto is the policy. The provider field is only a resolved-runtime
+  // projection, never an ordered static preference.
   let provider: BuildStudioDispatchConfig["provider"] = "agentic";
-  if (claudeId) provider = "claude";
-  else if (codexId) provider = "codex";
-  else if (grokId) provider = "grok";
-  else if (opencodeId) provider = "opencode";
+  let enginePolicy: BuildEnginePolicy["mode"] = "auto";
+  let pinnedEngine: BuildEngineId | null = null;
 
   // Env var override
   const envProvider = process.env.CLI_DISPATCH_PROVIDER ?? process.env.CODEX_DISPATCH;
-  if (envProvider === "claude" && claudeId) provider = "claude";
-  else if (envProvider === "codex" && codexId) provider = "codex";
-  else if (envProvider === "grok" && grokId) provider = "grok";
-  else if (envProvider === "opencode" && opencodeId) provider = "opencode";
-  else if (envProvider === "false" || envProvider === "agentic") provider = "agentic";
+  if (envProvider === "claude" || envProvider === "codex" || envProvider === "grok" || envProvider === "opencode" || envProvider === "agentic" || envProvider === "false") {
+    provider = envProvider === "false" ? "agentic" : envProvider;
+    enginePolicy = "pinned";
+    pinnedEngine = provider;
+  }
 
   return {
     provider,
+    enginePolicy,
+    pinnedEngine,
+    selection: null,
     claudeProviderId: process.env.CLAUDE_CODE_PROVIDER_ID ?? claudeId,
     codexProviderId: process.env.CODEX_PROVIDER_ID ?? codexId,
     grokProviderId: process.env.GROK_PROVIDER_ID ?? grokId,
@@ -120,6 +135,14 @@ async function resolveBaseBuildStudioConfig(): Promise<BuildStudioDispatchConfig
     return {
       ...DEFAULTS,
       ...saved,
+      // Legacy rows had only `provider`; they were ordinary setup choices, not
+      // an explicit no-fallback contract. They converge to Auto. Only the new
+      // enginePolicy="pinned" shape is a hard boundary.
+      enginePolicy: saved.enginePolicy === "pinned" ? "pinned" : "auto",
+      pinnedEngine: saved.enginePolicy === "pinned"
+        ? (saved.pinnedEngine ?? saved.provider ?? null)
+        : null,
+      selection: null,
       claudeProviderId: claudeId,
       codexProviderId: codexId,
       grokProviderId: grokId,
@@ -269,47 +292,26 @@ export async function getBuildGoldenTrianglePosture(): Promise<GoldenTrianglePre
 }
 
 /**
- * Resolve the first available robust (frontier) provider, preferring Claude >
- * Codex > Grok. Only active + credentialed providers qualify (the same
- * findConfiguredProvider gate the auto-detect uses). Returns null when no robust
- * engine is configured — the caller then falls back to the local/base config,
- * so a robust-tier build on a local-only install gracefully degrades to local.
- */
-async function resolveRobustProvider(): Promise<
-  { provider: "claude" | "codex" | "grok"; providerId: string } | null
-> {
-  const claudeId = await findConfiguredProvider("claude");
-  if (claudeId) return { provider: "claude", providerId: claudeId };
-  const codexId = await findConfiguredProvider("codex");
-  if (codexId) return { provider: "codex", providerId: codexId };
-  const grokId = await findConfiguredProvider("grok");
-  if (grokId) return { provider: "grok", providerId: grokId };
-  return null;
-}
-
-/**
- * Resolve the Build Studio dispatch config. With `opts.modelTier === "robust"`
- * AND tier routing enabled AND a robust provider configured, the config is
- * overridden to that frontier provider; otherwise the base (local/explicit)
- * config is returned unchanged. A default call (no opts) is byte-identical to
- * the pre-EP-MODEL-TIER-ROUTING behavior.
+ * Resolve Build Studio policy plus the live engine selected by the canonical
+ * router. Every preview and dispatch caller consumes this same result.
  */
 export async function getBuildStudioConfig(
-  opts?: { modelTier?: BuildModelTier },
+  opts?: { modelTier?: BuildModelTier; sensitivity?: SensitivityLevel },
 ): Promise<BuildStudioDispatchConfig> {
   const base = await resolveBaseBuildStudioConfig();
-  if (opts?.modelTier === "robust" && (await isModelTierRoutingEnabled())) {
-    const robust = await resolveRobustProvider();
-    if (robust) {
-      const idField =
-        robust.provider === "claude"
-          ? "claudeProviderId"
-          : robust.provider === "codex"
-            ? "codexProviderId"
-            : "grokProviderId";
-      return { ...base, provider: robust.provider, [idField]: robust.providerId };
-    }
-    // No robust engine configured — gracefully fall back to the base (local) config.
-  }
-  return base;
+  const policy: BuildEnginePolicy = base.enginePolicy === "pinned"
+    ? { mode: "pinned", pinnedEngine: base.pinnedEngine ?? base.provider }
+    : { mode: "auto", pinnedEngine: null };
+  const selection = await resolveBuildEngineSelection(base, {
+    policy,
+    ...(opts?.modelTier ? { modelTier: opts.modelTier } : {}),
+    ...(opts?.sensitivity ? { sensitivity: opts.sensitivity } : {}),
+  });
+  return {
+    ...base,
+    provider: selection.selected?.engine ?? policy.pinnedEngine ?? "agentic",
+    enginePolicy: policy.mode,
+    pinnedEngine: policy.pinnedEngine,
+    selection,
+  };
 }

--- a/apps/web/lib/integrate/ideate-dispatch.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.ts
@@ -449,13 +449,15 @@ export async function dispatchIdeateResearch(params: {
    *  path. "robust" lets routing prefer a frontier endpoint for large designs;
    *  "local"/undefined keeps it on the on-box model. */
   modelTier?: "local" | "robust";
+  sensitivity?: "public" | "internal" | "confidential" | "restricted";
   onProgress?: (message: string) => void;
 }): Promise<IdeateResult> {
   const dispatchEngine = params.dispatchEngine ?? "codex";
   const providerId = params.providerId || "";
   const model = params.model ?? "";
 
-  // Local-model engine (opencode): Ideate research runs through portal-side
+  // Routed engines (local OpenCode or the supported agentic fallback): Ideate
+  // research runs through portal-side
   // routing — the SAME routeAndCall path the Plan phase uses — not a vendor CLI.
   // The configured local model (e.g. qwen3-coder via Docker Model Runner)
   // generates the design doc with no credential and no egress. This is the last
@@ -463,7 +465,7 @@ export async function dispatchIdeateResearch(params: {
   // end-to-end off a local LLM: Plan already uses routeAndCall, Build dispatches
   // to the opencode runner, and now Ideate uses routing too instead of falling
   // through to the `codex exec` branch below. (BI-01D6A51B)
-  if (dispatchEngine === "opencode") {
+  if (dispatchEngine === "opencode" || dispatchEngine === "agentic") {
     const startMs = Date.now();
     try {
       // The frontier ideate path dispatches a CLI into the sandbox that actually
@@ -482,8 +484,9 @@ export async function dispatchIdeateResearch(params: {
         "You are a senior software architect producing a structured design document. Respond with the design document content only — no preamble.";
       const { designDoc, rawOutput } = await runLocalIdeateWithRetry(
         async (messages) => {
-          const response = await routeAndCall(messages, systemPrompt, "internal", {
+          const response = await routeAndCall(messages, systemPrompt, params.sensitivity ?? "internal", {
             budgetClass: "quality_first",
+            ...(providerId ? { allowedProviders: [providerId] } : {}),
             ...(params.modelTier ? { modelTier: params.modelTier } : {}),
           });
           return response.content ?? "";
@@ -501,7 +504,7 @@ export async function dispatchIdeateResearch(params: {
         durationMs: Date.now() - startMs,
         error: designDoc
           ? undefined
-          : "Local-model ideate output could not be parsed into a design document.",
+          : "Routed ideate output could not be parsed into a design document.",
       };
     } catch (err) {
       return {
@@ -509,7 +512,7 @@ export async function dispatchIdeateResearch(params: {
         rawOutput: "",
         success: false,
         durationMs: Date.now() - startMs,
-        error: `Local-model ideate failed: ${(err as Error).message}`,
+        error: `Routed ideate failed: ${(err as Error).message}`,
       };
     }
   }

--- a/apps/web/lib/integrate/ideate-on-approval.test.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.test.ts
@@ -43,6 +43,39 @@ import {
   dispatchDesignReviewFixLoop,
 } from "./ideate-on-approval";
 
+function engineSelection(
+  engine: "claude" | "codex" | "grok" | "opencode" | "agentic",
+  providerId: string,
+  fallbacks: Array<{ engine: "claude" | "codex" | "grok" | "opencode" | "agentic"; providerId: string }> = [],
+  modelId?: string,
+) {
+  const make = (entry: { engine: typeof engine; providerId: string }) => ({
+    ...entry,
+    modelId: modelId ?? (entry.engine === "claude" ? "sonnet" : null),
+    local: entry.engine === "opencode",
+    registered: true,
+    present: true,
+    providerStatus: "active",
+    authMethod: entry.engine === "opencode" ? "none" : "oauth",
+    credentialStatus: entry.engine === "opencode" ? null : "active",
+    credentialExpiresAt: null,
+    providerCapacityState: "available",
+    providerRetryAt: null,
+    cliRetryAt: null,
+    providerHealth: "healthy" as const,
+  });
+  return {
+    status: "selected" as const,
+    policy: { mode: "auto" as const, pinnedEngine: null },
+    selected: make({ engine, providerId }),
+    reason: `Selected ${providerId} through routeEndpointV2.`,
+    rejected: [],
+    fallbackChain: fallbacks.map(make),
+    fallbackDisabled: false,
+    action: null,
+  };
+}
+
 describe("dispatchIdeateForApprovedBuild", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -53,6 +86,7 @@ describe("dispatchIdeateForApprovedBuild", () => {
       codexProviderId: "",
       claudeModel: "sonnet",
       codexModel: "",
+      selection: engineSelection("claude", "anthropic-sub"),
     });
   });
 
@@ -109,6 +143,16 @@ describe("dispatchIdeateForApprovedBuild", () => {
       codexProviderId: "",
       claudeModel: "sonnet",
       codexModel: "",
+      selection: {
+        status: "blocked",
+        policy: { mode: "auto", pinnedEngine: null },
+        selected: null,
+        reason: "No eligible engine.",
+        rejected: [],
+        fallbackChain: [],
+        fallbackDisabled: false,
+        action: "Connect, provision, or wait for one allowed Build Studio engine, then retry.",
+      },
     });
 
     const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
@@ -131,6 +175,7 @@ describe("dispatchIdeateForApprovedBuild", () => {
       codexProviderId: "chatgpt",
       codexModel: "gpt-5.3-codex",
       claudeProviderId: "", grokProviderId: "", claudeModel: "", grokModel: "",
+      selection: engineSelection("opencode", "local", [], "docker.io/ai/qwen3-coder:latest"),
     });
     mockDispatchIdeateResearch.mockResolvedValue({
       success: true,
@@ -152,6 +197,42 @@ describe("dispatchIdeateForApprovedBuild", () => {
     expect(mockDispatchIdeateResearch).not.toHaveBeenCalledWith(
       expect.objectContaining({ providerId: "chatgpt" }),
     );
+  });
+
+  it("falls from a retry-safe pre-dispatch Claude auth failure to Codex once", async () => {
+    mockPrisma.featureBuild.findUnique
+      .mockResolvedValueOnce({ originatingBacklogItemId: "cmpcuid1", designDoc: null, title: "T", description: "D" })
+      .mockResolvedValueOnce({ designDoc: { problemStatement: "P" } });
+    mockPrisma.backlogItem.findUnique.mockResolvedValue({ title: "BI Title", body: "Body.", effortSize: "medium", workType: "bug" });
+    mockGetBuildStudioConfig.mockResolvedValue({
+      provider: "claude",
+      claudeProviderId: "anthropic-sub",
+      codexProviderId: "codex",
+      grokProviderId: "",
+      opencodeProviderId: "",
+      claudeModel: "sonnet",
+      codexModel: "",
+      grokModel: "",
+      opencodeModel: "",
+      selection: engineSelection("claude", "anthropic-sub", [{ engine: "codex", providerId: "codex" }]),
+    });
+    mockDispatchIdeateResearch
+      .mockResolvedValueOnce({ success: false, designDoc: null, rawOutput: "", durationMs: 0, error: "Auth error: OAuth token expired" })
+      .mockResolvedValueOnce({ success: true, designDoc: { problemStatement: "P" }, rawOutput: "{}", durationMs: 5 });
+    mockExecuteTool.mockResolvedValue({ success: true });
+
+    const outcome = await dispatchIdeateForApprovedBuild({ buildId: "FB-X", userId: "u-1" });
+
+    expect(outcome.kind).toBe("dispatched-success");
+    expect(mockDispatchIdeateResearch).toHaveBeenCalledTimes(2);
+    expect(mockDispatchIdeateResearch).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      dispatchEngine: "codex",
+      providerId: "codex",
+    }));
+    expect(mockPrisma.buildActivity.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ summary: expect.stringMatching(/falling back once to codex/i) }),
+    }));
+    expect(mockExecuteTool).toHaveBeenCalledTimes(2);
   });
 
   it("dispatches research and saves designDoc evidence on the happy path", async () => {
@@ -224,8 +305,8 @@ describe("dispatchIdeateForApprovedBuild", () => {
       "u-1",
       expect.any(Object),
     );
-    // Should write at least two activity rows: the "Dispatching..." log and the "Auto-dispatched..." success log.
-    expect(mockPrisma.buildActivity.create).toHaveBeenCalledTimes(2);
+    // Selection evidence, the dispatch log, and the saved success are visible.
+    expect(mockPrisma.buildActivity.create).toHaveBeenCalledTimes(3);
   });
 
   it("returns dispatched-failure when dispatchIdeateResearch reports failure", async () => {

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -33,6 +33,8 @@
 
 import { prisma } from "@dpf/db";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { classifyRetrySafePreDispatchFailure } from "./build-engine-selection";
+import { formatBuildEngineSelectionEvidence } from "./build-engine-selection-runtime";
 
 type DispatchOutcome =
   | { kind: "skipped-no-bi"; reason: string }
@@ -145,39 +147,30 @@ export async function dispatchIdeateForApprovedBuild(params: {
       return outcome;
     }
 
-    // Resolve dispatch provider config. The "agentic" default has no external
-    // provider — dispatchIdeateResearch would return an "auth error" anyway.
-    // Short-circuit to a clean skip with a meaningful BuildActivity row.
-    const { getBuildStudioConfig } = await import("@/lib/integrate/build-studio-config");
-    const config = await getBuildStudioConfig();
-    // BI-0F291741/local-tuning: resolve per the configured engine. Without the
-    // `opencode` branch this fell through to codexProviderId (cloud chatgpt),
-    // so a fully-local install (provider="opencode", opencodeProviderId="local")
-    // silently ran Ideate research on the cloud instead of the local model.
-    const providerId = config.provider === "claude"
-      ? config.claudeProviderId
-      : config.provider === "grok"
-        ? config.grokProviderId
-        : config.provider === "opencode"
-          ? config.opencodeProviderId
-          : config.codexProviderId;
+    const { getModelTier, deriveDeliverableSensitivity } = await import("@/lib/explore/build-process-matrix");
+    const { getBuildStudioConfig, isModelTierRoutingEnabled } = await import("@/lib/integrate/build-studio-config");
+    const modelTier = (await isModelTierRoutingEnabled())
+      ? getModelTier(null, bi.effortSize)
+      : undefined;
+    const deliverableSensitivity = deriveDeliverableSensitivity({
+      text: `${bi.title}\n${bi.body ?? ""}`,
+      workType: bi.workType,
+    });
+    const routingSensitivity = deliverableSensitivity === "high" ? "confidential" as const : "internal" as const;
 
-    if (config.provider === "agentic" || !providerId) {
+    // Resolve the same task-qualified selection used by model-selection preview
+    // and actual dispatch. A blocked result stops before phase work with one action.
+    const config = await getBuildStudioConfig({ modelTier, sensitivity: routingSensitivity });
+    const selection = config.selection;
+    if (!selection || selection.status === "blocked" || !selection.selected) {
       const outcome: DispatchOutcome = {
         kind: "skipped-no-provider",
-        reason: `No external CLI provider configured (provider=${config.provider}, providerId=${providerId || "(empty)"}). Configure Claude, Codex, or Grok in Admin > AI Providers to enable auto-dispatch.`,
+        reason: selection?.action ?? "No allowed healthy Build Studio engine remains. Review AI Readiness and retry.",
       };
       await logActivity(`Skipped auto-dispatch: ${outcome.reason}`);
       return outcome;
     }
-
-    const model = config.provider === "claude"
-      ? config.claudeModel
-      : config.provider === "grok"
-        ? config.grokModel
-        : config.provider === "opencode"
-          ? config.opencodeModel
-          : config.codexModel;
+    await logActivity(formatBuildEngineSelectionEvidence(selection));
 
     // The BI body is the canonical context for backlog-promoted drafts.
     // It typically contains problem statement, acceptance criteria, and
@@ -193,33 +186,43 @@ export async function dispatchIdeateForApprovedBuild(params: {
     ].filter((part) => part.trim().length > 0).join("\n\n");
 
     const startedAt = Date.now();
-    await logActivity(`Dispatching ideate research via ${config.provider} (provider=${providerId}, model=${model || "default"})`);
-
-    // EP-MODEL-TIER-ROUTING: route this build's ideate design generation to the
-    // model tier its size deserves — local for small/medium, robust/frontier for
-    // large/xlarge. Flag-gated; inert until DPF_BUILD_MODEL_TIER_ROUTING is on
-    // (and a robust endpoint + the global local-only switch off make robust route
-    // to cloud; otherwise it gracefully stays local).
-    const { getModelTier } = await import("@/lib/explore/build-process-matrix");
-    const { isModelTierRoutingEnabled } = await import("@/lib/integrate/build-studio-config");
-    const modelTier = (await isModelTierRoutingEnabled())
-      ? getModelTier(null, bi.effortSize) // tier is size-derived (P1); build.kind isn't in this select
-      : undefined;
 
     const { dispatchIdeateResearch } = await import("./ideate-dispatch");
-    const ideateResult = await dispatchIdeateResearch({
-      featureTitle,
-      featureDescription,
-      reusabilityScope: requestedReusabilityScope || "parameterizable",
-      userContext,
-      // businessContext: see select comment above — field does not exist on
-      // FeatureBuild. Passing undefined preserves the dispatch signature.
-      businessContext: undefined,
-      providerId,
-      model,
-      dispatchEngine: config.provider,
-      modelTier,
-    });
+    const attemptCandidates = [selection.selected, ...selection.fallbackChain.slice(0, 1)];
+    let ideateResult: Awaited<ReturnType<typeof dispatchIdeateResearch>> | null = null;
+    for (let attemptIndex = 0; attemptIndex < attemptCandidates.length; attemptIndex += 1) {
+      const attempt = attemptCandidates[attemptIndex]!;
+      await logActivity(
+        `${attemptIndex === 0 ? "Dispatching" : "Retrying"} ideate research via ${attempt.engine} `
+        + `(provider=${attempt.providerId}, model=${attempt.modelId || "default"})`,
+      );
+      ideateResult = await dispatchIdeateResearch({
+        featureTitle,
+        featureDescription,
+        reusabilityScope: requestedReusabilityScope || "parameterizable",
+        userContext,
+        businessContext: undefined,
+        providerId: attempt.providerId,
+        model: attempt.modelId ?? undefined,
+        dispatchEngine: attempt.engine,
+        modelTier,
+        sensitivity: routingSensitivity,
+      });
+      if (ideateResult.success) break;
+      const retryClass = classifyRetrySafePreDispatchFailure({
+        message: ideateResult.error ?? "",
+        durationMs: ideateResult.durationMs,
+      });
+      const next = attemptCandidates[attemptIndex + 1];
+      if (!retryClass || !next || selection.fallbackDisabled) break;
+      await logActivity(
+        `Ideate ${attempt.engine} ${retryClass} failure occurred before phase side effects; `
+        + `falling back once to ${next.engine} (provider=${next.providerId}).`,
+      );
+    }
+    if (!ideateResult) {
+      throw new Error("Build engine selection returned no Ideate dispatch attempt.");
+    }
 
     const durationMs = Date.now() - startedAt;
 

--- a/apps/web/lib/tak/agentic-loop.ts
+++ b/apps/web/lib/tak/agentic-loop.ts
@@ -328,6 +328,7 @@ type AgentRouteConfig = {
   budgetClass?: "minimize_cost" | "balanced" | "quality_first";
   preferredProviderId?: string;
   preferredModelId?: string;
+  allowedProviders?: string[];
   effort?: "low" | "medium" | "high" | "max";
 };
 
@@ -376,6 +377,9 @@ function resolveEffectiveAgentRouteConfig(params: {
             : {}),
           ...("preferredModelId" in params.modelRequirements
             ? { preferredModelId: params.modelRequirements.preferredModelId as string }
+            : {}),
+          ...("allowedProviders" in params.modelRequirements
+            ? { allowedProviders: params.modelRequirements.allowedProviders as string[] }
             : {}),
           ...("defaultEffort" in params.modelRequirements
             ? {

--- a/docs/superpowers/plans/2026-07-19-build-studio-engine-failover.md
+++ b/docs/superpowers/plans/2026-07-19-build-studio-engine-failover.md
@@ -1,0 +1,43 @@
+# Build Studio Dynamic Engine Failover Implementation Plan
+
+**Backlog item:** BI-92048C32
+
+**Epic:** EP-BS-UX-HARDENING
+**Design authority:** `docs/superpowers/specs/2026-06-28-ai-readiness-console-design.md` section 7.2
+
+## Goal
+
+Make Build Studio engine policy automatic by default, select only healthy/capable/policy-allowed engines through the canonical routing and capacity substrate, retry one safe pre-dispatch failure on the next eligible engine, and expose identical selection evidence to dispatch, `resolve_model_selection`, BuildActivity, progress, and the configuration UI.
+
+## Architecture
+
+Add one Build Studio engine selector beside the existing dispatch configuration. The selector performs engine-specific readiness/auth/retry-window qualification, then constrains and invokes the existing V2 endpoint router for capability, residency, sensitivity, context, tool, cost, health, and capacity decisions. The router's ordered endpoint result becomes the engine fallback chain. Stored configuration carries only Auto versus deliberate hard-pin policy and per-engine credential/model preferences; selected engine and rationale are derived live.
+
+## Delivery phases
+
+1. **Regression-first selector contract**
+   - Add failing tests for expired Claude selecting Codex, capacity exclusion, local-only, hard pin, no candidates, and route-decision evidence.
+   - Extend routed-inference preview options with typed provider allow/deny/residency constraints so preview and live routing share the same contract.
+
+2. **Dynamic configuration and dispatch**
+   - Implement the DB-backed selector over `BuildEngineState`, provider credentials, provider health/capacity, and CLI retry windows.
+   - Make Auto the default; retain Advanced hard pin with explicit no-fallback failure copy.
+   - Reuse the selector in Ideate and build dispatch. Allow one classified pre-side-effect retry for Ideate, guarded by the existing design-evidence idempotency boundary.
+
+3. **Evidence and operator visibility**
+   - Record selection, rejections, and fallback chain in BuildActivity.
+   - Project the latest selection through Build progress visibility.
+   - Show Auto, selected engine, rationale, and advanced pin controls in Build Studio configuration.
+   - Make `resolve_model_selection` consume the same live selection object.
+
+4. **Verification and delivery**
+   - Run focused Vitest suites and web typecheck in the worktree.
+   - Lease `local-integration-ci` for production build and authenticated UX verification of `/platform/ai/build-studio` plus Build progress evidence.
+   - Run merged-code CI, DCO-check, overlap sweep, push, open a ready PR, run `pnpm pr:health`, queue via merge queue, and record evidence on BI-92048C32.
+
+## Risks and rollback
+
+- **Risk:** stale readiness could exclude a usable engine. **Mitigation:** unknown health may remain eligible only when structural readiness and credentials are valid; explicit unhealthy/retry/auth states fail closed.
+- **Risk:** a retry duplicates work. **Mitigation:** retry only failures classified before dispatch side effects and only before design evidence is saved.
+- **Risk:** policy crossing during fallback. **Mitigation:** every fallback is produced inside the same hard routing contract; pinned mode has no fallback.
+- **Rollback:** restore the prior static config resolver and radio UI; no schema migration is required because policy lives in the existing PlatformConfig JSON.

--- a/docs/superpowers/specs/2026-06-28-ai-readiness-console-design.md
+++ b/docs/superpowers/specs/2026-06-28-ai-readiness-console-design.md
@@ -202,6 +202,14 @@ The default policy should be automatic:
 
 The Build Dispatch Engine radio group should move behind "Advanced execution policy" or become a segmented override with clear impact copy. The default row should say what will happen, not ask the operator to pick from engine names.
 
+The automatic policy is one capability- and policy-qualified selection, reused by `resolve_model_selection`, Ideate dispatch, and CLI-backed build dispatch. It is not a second load balancer: engine readiness and credentials narrow the provider set, then the existing `RequestContract` + `routeEndpointV2` pipeline supplies capability filtering, provider-policy fences, capacity scoring, the selected endpoint, and the ordered fallback chain.
+
+Before routing, Build Studio excludes an engine when its registered `BuildEngineState` is absent or not present, its credential is missing/expired/auth-failed, its CLI or provider retry window is active, or its provider is currently unhealthy. The route contract then enforces sensitivity, residency, tool, context, model-class, and cost posture. Hard policy always outranks score. Local-only work cannot cross to cloud; restricted/sensitive work cannot cross to an endpoint without clearance; an explicit operator hard pin cannot fall through to another engine.
+
+`Auto` is the default policy. A deliberate hard pin remains under Advanced execution policy for diagnostics and controlled tests. A pinned failure must name the failed engine and say that automatic fallback was disabled. In Auto mode, only a retry-safe failure before phase side effects (authentication, rate limit, or availability) may advance once to the next already-qualified engine. The retry uses the same phase idempotency guard and must not re-run a phase after evidence or source mutations begin.
+
+Every selection records the selected engine/provider/model, routing rationale, rejected candidates with reason codes, and the ordered fallback chain. BuildActivity and the progress projection expose the same evidence. If no allowed healthy candidate remains, the phase blocks before work with one actionable explanation; operator attention is not requested while an automatic candidate remains.
+
 ### 7.3 Tool access
 
 Tool Access should reuse `ContributorMcpReadiness`:
@@ -381,6 +389,7 @@ Required tests for implementation:
 - Unit tests proving Z.ai-style "model provider without tool support" is model supply, not a build engine.
 - Component tests that default provider setup does not render manual discover/profile/eval/probe/tier controls outside diagnostics.
 - Component tests that Build Studio default view renders the selected policy and one action, not five engine radios.
+- Selector tests for expired credentials, mid-pre-dispatch auth failure, active retry windows, shared capacity saturation, local-only policy, hard pins, no-candidate explanations, idempotent one-hop retry, and selection/evidence parity.
 - Existing `contributor-readiness` tests remain authoritative for MCP domain behavior.
 - `pnpm --filter web build` for TypeScript and Next build coverage.
 - UX verification on an authenticated install: visit `/platform/ai/readiness`, provider detail, Build Studio, and routing diagnostics.


### PR DESCRIPTION
## Summary
- make Auto the default Build Studio engine policy and qualify Claude, Codex, Grok, OpenCode/local, and agentic candidates against health, credentials, retry windows, capacity, residency, sensitivity, tools, context, cost, and explicit pin boundaries
- select through the canonical routing and capacity substrate, then use that exact result for resolve_model_selection and dispatch
- perform one idempotent retry-safe pre-dispatch fallback on auth, rate-limit, or availability failure while preserving hard-pin and local-only boundaries
- persist the selected engine, rationale, rejected candidates, and fallback chain in BuildActivity and progress visibility
- surface Auto selection rationale by default and retain deliberate hard pins behind an advanced disclosure
- update the existing AI readiness design and add the BI implementation plan

## Verification
- TDD regression coverage for expired Claude selecting Codex and one-hop auth fallback
- 8 affected Vitest suites: 122 passed, 5 existing todos
- web typecheck passed
- governed merged-code gate on origin/main: sandbox freshness green, 414 migrations checked, production Next.js build passed
- authenticated UX verification on /platform/ai/build-studio confirmed Auto default, selector rationale, advanced pins, and selector-consistent warnings

The default host-wide web test command also encounters the tracked unsupported host-runtime fixture failures outside this diff; the focused merged-code gate and GitHub supported-runtime checks are the binding evidence.

## Coordination
PR #3302 adds provider-suitability compilation without overlapping files. This selector calls the canonical router, so that policy is inherited when #3302 lands and no second suitability or load-balancing layer is introduced.

## Design grounding
- Existing specs/plans reviewed:
  - docs/superpowers/specs/2026-06-28-ai-readiness-console-design.md
  - docs/superpowers/specs/2026-04-20-routing-architecture-current.md
  - docs/superpowers/specs/2026-07-19-ai-provider-suitability-routing-design.md
  - docs/superpowers/plans/2026-07-19-build-studio-engine-failover.md
- Current code substrate reviewed:
  - apps/web/lib/integrate/ideate-dispatch.ts
  - apps/web/lib/integrate/build-studio-config.ts
  - apps/web/lib/integrate/build-orchestrator.ts
  - apps/web/lib/routing/
- Source of truth:
  - canonical routeEndpointV2 selection and capacity evidence, projected through one Build Studio selector
- Decision:
  - Build Studio owns eligibility and retry-safe phase dispatch; canonical routing owns scoring and ordering.

UX-Fit-Decision: progressive-disclosure; Auto is the recommended default with selected-engine rationale, while hard pins remain behind an Advanced execution policy control for deliberate tests.
Docs-Impact-Decision: the canonical AI readiness design was updated; no mapped user-guide page currently documents Build Studio engine-policy controls.
Local-CI-Evidence: cmrshru3b05lk01s4s944ko8p
Backlog-Item: BI-92048C32
Work-Capsule: WC-412CBEC9