### PR TITLE
fix: recognize current Claude Code version output

### DIFF
--- a/packages/db/data/build-engines.json
+++ b/packages/db/data/build-engines.json
@@ -3,7 +3,7 @@
     "binary": "claude",
     "verify": {
       "command": "claude --version",
-      "versionRegex": "claude[- ]cli[/ ]([0-9.]+)"
+      "versionRegex": "([0-9]+\\.[0-9]+\\.[0-9]+)"
     },
     "bakeInDefault": true,
     "recipes": [

--- a/packages/db/scripts/sync-engine-registry.test.ts
+++ b/packages/db/scripts/sync-engine-registry.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { vi, describe, it, expect } from 'vitest';
 import path from 'path';
-import { writeFileSync, mkdtempSync } from 'fs';
+import { readFileSync, writeFileSync, mkdtempSync } from 'fs';
 import os from 'os';
 import { syncEngineRegistry, enginesMissingMuslSafeRecipe } from './sync-engine-registry';
 
@@ -24,6 +24,21 @@ describe("enginesMissingMuslSafeRecipe", () => {
 });
 
 const dataPath = path.join(__dirname, '../data/build-engines.json');
+
+describe('canonical engine registry', () => {
+  it('recognizes current and legacy Claude Code versions without accepting malformed output', () => {
+    const registry = JSON.parse(readFileSync(dataPath, 'utf-8')) as {
+      claude: { verify: { versionRegex: string } };
+    };
+    const extractVersion = (stdout: string) =>
+      new RegExp(registry.claude.verify.versionRegex).exec(stdout)?.[1] ?? null;
+
+    expect(extractVersion('2.1.215 (Claude Code)\n')).toBe('2.1.215');
+    expect(extractVersion('claude-cli/1.5.0\n')).toBe('1.5.0');
+    expect(extractVersion('Claude Code\n')).toBeNull();
+    expect(extractVersion('')).toBeNull();
+  });
+});
 
 const now = new Date();
 const mockResult = { createdAt: now, updatedAt: now };


### PR DESCRIPTION
## Summary
- recognize current `X.Y.Z (Claude Code)` version output in the canonical build-engine registry
- preserve legacy `claude-cli/X.Y.Z` readiness detection
- reject empty and malformed output with a strict three-part semantic-version capture
- resolves BI-7C1F98AA

## Root cause
The shared readiness probe already supports regex-based extraction, but the seeded Claude descriptor only matched the obsolete `claude-cli/...` label. Startup registry reconciliation therefore persisted a parser that rejected the current CLI's valid output and mislabeled an installed binary as absent.

## Verification
- [x] registry sync tests: 5 passed
- [x] shared probe/readiness/badge tests: 20 passed
- [x] DB package typecheck
- [x] web typecheck with 8 GB Node heap
- [x] merged-code local-CI production build
- [x] DCO and secret scan

## Runtime behavior
Binary presence remains distinct from credential readiness. The Build Runtime form continues to show the engine installation badge separately from the Anthropic credential requirement.

Seed-Fit-Decision: global-default

Process-Spine-Decision: localized registry parser bugfix with invariant coverage; existing build-engine provisioning and readiness contracts remain authoritative.
