### PR TITLE
fix(coworker): close interaction surface gaps

### DIFF
--- a/apps/web/components/build/BuildCustomerStatusBand.test.tsx
+++ b/apps/web/components/build/BuildCustomerStatusBand.test.tsx
@@ -10,6 +10,9 @@ function status(over: Partial<BuildStudioCustomerStatus> = {}): BuildStudioCusto
     whatIsBeingBuilt: "Add invoicing",
     lifecyclePosition: "In progress",
     worker: "Work in progress",
+    evidence: "Work capsule is actively executing.",
+    nextAction: "continue implementation until verification evidence is ready.",
+    owner: "Build Studio build agent",
     needsYou: false,
     ...over,
   };
@@ -20,6 +23,16 @@ describe("BuildCustomerStatusBand", () => {
     const html = renderToStaticMarkup(<BuildCustomerStatusBand status={status()} />);
     expect(html).toContain("In progress");
     expect(html).toContain("Work in progress");
+  });
+
+  it("renders evidence, next action, and owner for operational closeout", () => {
+    const html = renderToStaticMarkup(<BuildCustomerStatusBand status={status()} />);
+    expect(html).toContain("Evidence:");
+    expect(html).toContain("Work capsule is actively executing.");
+    expect(html).toContain("Next action:");
+    expect(html).toContain("continue implementation until verification evidence is ready.");
+    expect(html).toContain("Owner:");
+    expect(html).toContain("Build Studio build agent");
   });
 
   it("shows the 'Needs you' pill only when the work needs the operator", () => {

--- a/apps/web/components/build/BuildCustomerStatusBand.tsx
+++ b/apps/web/components/build/BuildCustomerStatusBand.tsx
@@ -21,6 +21,15 @@ export function BuildCustomerStatusBand({ status }: { status: BuildStudioCustome
           <p className="m-0 text-[11px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">Status</p>
           <p className="m-0 mt-0.5 text-sm font-semibold text-[var(--dpf-text)]">{status.lifecyclePosition}</p>
           <p className="m-0 mt-0.5 text-xs text-[var(--dpf-muted)]">{status.worker}</p>
+          <p className="m-0 mt-1 text-[11px] leading-relaxed text-[var(--dpf-muted)]">
+            Evidence: {status.evidence}
+          </p>
+          <p className="m-0 mt-0.5 text-[11px] leading-relaxed text-[var(--dpf-text)]">
+            Next action: {status.nextAction}
+          </p>
+          <p className="m-0 mt-0.5 text-[11px] leading-relaxed text-[var(--dpf-muted)]">
+            Owner: {status.owner}
+          </p>
         </div>
         {status.needsYou && (
           <span className={NEEDS_YOU_PILL} data-testid="build-customer-status-needs-you">

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -41,7 +41,10 @@ import { resolveReadingLevelForRoute } from "@/lib/readability/policy";
 import type { QuestionPacket } from "@/lib/tak/question-packet";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
 import type { PortalContextEnvelope } from "@/lib/portal-context";
-import { formatCoworkerOperationalCloseout } from "@/lib/tak/coworker-interaction-contract";
+import {
+  formatCoworkerOperationalCloseout,
+  formatCoworkerOperationalMessage,
+} from "@/lib/tak/coworker-interaction-contract";
 import {
   extractInvokedSkillId,
   getSkillsForAgent,
@@ -248,18 +251,66 @@ async function summariseIdeateOutcome(
   const head = `I've researched the codebase and drafted the design.\n\n**Approach:** ${approach.slice(0, 300)}\n\n`;
 
   if (!reviewPassed) {
-    return `${head}Design review flagged some issues — I'll revise and re-run the review.`;
+    return formatCoworkerOperationalMessage({
+      summary: `${head}Design review flagged issues in the draft.`,
+      status: "needs revision",
+      evidence: `design review did not pass for build ${buildId}.`,
+      nextAction: "revise the design evidence and rerun the design review.",
+      owner: "Build Studio ideate agent",
+    });
   }
 
   if (currentPhase === "plan") {
-    return `${head}Design review passed and we're now in the Plan phase. I'll draft the implementation plan next.`;
+    return formatCoworkerOperationalMessage({
+      summary: `${head}Design review passed and the build advanced to the Plan phase.`,
+      status: "ready for planning",
+      evidence: `design review passed for build ${buildId}; current phase is plan.`,
+      nextAction: "draft the implementation plan.",
+      owner: "Build Studio planning agent",
+    });
   }
   if (currentPhase === "ideate") {
     // Review passed but auto-advance gate held us. Make the blocker visible
     // instead of asking a rhetorical "ready?" question.
-    return `${head}Design review passed, but the phase gate is holding advance (usually missing intake anchors — taxonomy, backlog, epic, or a constrained goal). I'll complete the remaining anchors and retry.`;
+    return formatCoworkerOperationalMessage({
+      summary: `${head}Design review passed, but the phase gate is holding advance.`,
+      status: "blocked before planning",
+      evidence: `build ${buildId} is still in ideate; an intake anchor such as taxonomy, backlog, epic, or constrained goal is missing.`,
+      nextAction: "complete the missing intake anchor and retry the phase advance.",
+      owner: "Build Studio ideate agent",
+    });
   }
-  return `${head}Design review passed. Current phase: ${currentPhase ?? "unknown"}.`;
+  return formatCoworkerOperationalMessage({
+    summary: `${head}Design review passed, but the current phase could not be confirmed.`,
+    status: "needs review",
+    evidence: `build ${buildId} phase is ${currentPhase ?? "unknown"} after design review.`,
+    nextAction: "refresh the build phase state before proceeding.",
+    owner: "Build Studio",
+  });
+}
+
+function formatIncompleteIdeateDesignMessage(buildId: string): string {
+  return formatCoworkerOperationalMessage({
+    summary: "The codebase research ran but did not produce a complete design.",
+    status: "blocked before planning",
+    evidence: `research output for build ${buildId} was missing a usable proposed approach.`,
+    nextAction: "rerun ideate research with the existing build context and verify codebase access first.",
+    owner: "Build Studio ideate agent",
+  });
+}
+
+function formatIdeateResearchIssueMessage(args: {
+  summary: string;
+  evidence: string;
+  nextAction: string;
+}): string {
+  return formatCoworkerOperationalMessage({
+    summary: args.summary,
+    status: "needs revision",
+    evidence: args.evidence,
+    nextAction: args.nextAction,
+    owner: "Build Studio ideate agent",
+  });
 }
 
 // ─── Server Actions ─────────────────────────────────────────────────────────
@@ -2144,7 +2195,7 @@ export async function sendMessage(input: {
               if (approach.length < 30) {
                 // Design doc saved but approach is blank — research engine produced an empty doc.
                 console.log(`[coworker] Approach too short (${approach.length} chars) — treating as empty doc`);
-                responseContent = "The codebase research ran but didn't produce a complete design. The research engine may have had trouble accessing the codebase. Please try starting the feature again — if the problem persists, check that the sandbox is running.";
+                responseContent = formatIncompleteIdeateDesignMessage(resolvedBuildId);
               } else {
                 // Run the design doc review
                 console.log(`[coworker] Running reviewDesignDoc...`);
@@ -2184,7 +2235,7 @@ export async function sendMessage(input: {
                   // An empty approach means the research engine ran but produced a blank doc.
                   const approach = String(rawDoc.proposedApproach ?? "").trim();
                   if (approach.length < 30) {
-                    responseContent = "The codebase research ran but didn't produce a complete design. The research engine may have had trouble accessing the codebase. Please try starting the feature again — if the problem persists, check that the sandbox is running.";
+                    responseContent = formatIncompleteIdeateDesignMessage(resolvedBuildId);
                   } else {
                     agentEventBus.emit(input.threadId, { type: "tool:start", tool: "design_review", iteration: 0 });
                     const reviewResult = await executeTool("reviewDesignDoc", { buildId: resolvedBuildId }, user.id!, { routeContext: input.routeContext });
@@ -2198,16 +2249,36 @@ export async function sendMessage(input: {
                     );
                   }
                 } else {
-                  responseContent = `Research completed. ${retryResult.message ?? "Please describe what you'd like me to focus on for this feature."}`;
+                  responseContent = formatIdeateResearchIssueMessage({
+                    summary: `Research completed, but the patched design evidence was not accepted.${retryResult.message ? ` ${retryResult.message}` : ""}`,
+                    evidence: `saveBuildEvidence rejected the patched design document for build ${resolvedBuildId}.`,
+                    nextAction: "revise the design evidence and rerun ideate review.",
+                  });
                 }
               } else {
-                responseContent = `Research completed but the design doc needs revision. ${saveResult.message ?? "Please provide more context about the feature."}`;
+                responseContent = formatIdeateResearchIssueMessage({
+                  summary: `Research completed, but the design document needs revision.${saveResult.message ? ` ${saveResult.message}` : ""}`,
+                  evidence: `saveBuildEvidence did not accept the design document for build ${resolvedBuildId}.`,
+                  nextAction: "revise the design document and rerun design review.",
+                });
               }
             }
           } else {
             responseContent = ideateResult.error
-              ? `Research encountered an issue: ${ideateResult.error}`
-              : "Research completed but I couldn't generate a structured design. Let me try a different approach.";
+              ? formatCoworkerOperationalMessage({
+                summary: `Research encountered an issue: ${ideateResult.error}`,
+                status: "blocked before planning",
+                evidence: `ideate research failed for build ${resolvedBuildId}: ${ideateResult.error}`,
+                nextAction: "rerun ideate research after confirming codebase access and provider availability.",
+                owner: "Build Studio ideate agent",
+              })
+              : formatCoworkerOperationalMessage({
+                summary: "Research completed but did not generate a structured design.",
+                status: "blocked before planning",
+                evidence: `ideate research for build ${resolvedBuildId} returned no structured design document.`,
+                nextAction: "rerun ideate research with a narrower feature goal and save the structured design evidence.",
+                owner: "Build Studio ideate agent",
+              });
           }
 
           // Clear the research request
@@ -2288,11 +2359,29 @@ export async function sendMessage(input: {
       let sysContent: string;
       if (e.attempts.length > 0) {
         const failureDetails = e.attempts.map((a) => `${a.providerId}: ${a.error.slice(0, 200)}`).join("; ");
-        sysContent = `All AI providers failed: ${failureDetails}. Check configuration in Platform > AI Providers.`;
+        sysContent = formatCoworkerOperationalMessage({
+          summary: "All AI providers failed for this coworker turn.",
+          status: "blocked",
+          evidence: failureDetails,
+          nextAction: "restore or switch the configured AI provider in Platform > AI Providers, then retry the coworker turn.",
+          owner: "operator/admin",
+        });
       } else if (inactiveProviders.length > 0) {
-        sysContent = `AI co-workers are temporarily offline. Type "re-enable" to reactivate a provider, or visit Platform > AI Providers.`;
+        sysContent = formatCoworkerOperationalMessage({
+          summary: "AI coworkers are temporarily offline because configured providers are inactive.",
+          status: "blocked",
+          evidence: `${inactiveProviders.length} provider${inactiveProviders.length === 1 ? "" : "s"} are inactive: ${inactiveProviders.map((p) => p.name || p.providerId).join(", ")}.`,
+          nextAction: "reactivate a provider from Platform > AI Providers, then retry the coworker turn.",
+          owner: "operator/admin",
+        });
       } else {
-        sysContent = "No AI providers are configured. An administrator can set them up from Platform > AI Providers.";
+        sysContent = formatCoworkerOperationalMessage({
+          summary: "No AI providers are configured for coworker responses.",
+          status: "blocked",
+          evidence: "provider lookup found no active or inactive model providers for this route.",
+          nextAction: "configure at least one AI provider in Platform > AI Providers.",
+          owner: "operator/admin",
+        });
       }
 
       const sysMsg = await prisma.agentMessage.create({

--- a/apps/web/lib/actions/agent-coworker.ts
+++ b/apps/web/lib/actions/agent-coworker.ts
@@ -41,10 +41,14 @@ import { resolveReadingLevelForRoute } from "@/lib/readability/policy";
 import type { QuestionPacket } from "@/lib/tak/question-packet";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
 import type { PortalContextEnvelope } from "@/lib/portal-context";
+import { formatCoworkerOperationalCloseout } from "@/lib/tak/coworker-interaction-contract";
 import {
-  formatCoworkerOperationalCloseout,
-  formatCoworkerOperationalMessage,
-} from "@/lib/tak/coworker-interaction-contract";
+  formatIdeateResearchIssueMessage,
+  formatIdeateResearchResultMessage,
+  formatIncompleteIdeateDesignMessage,
+  formatProviderUnavailableMessage,
+  summariseIdeateOutcome,
+} from "@/lib/tak/coworker-operational-messages";
 import {
   extractInvokedSkillId,
   getSkillsForAgent,
@@ -223,94 +227,6 @@ async function persistCoworkerResponseArtifact(input: {
   } catch (error) {
     console.warn("[portal-context] Failed to persist coworker response artifact", error);
   }
-}
-
-/**
- * Build the coworker's chat summary of the ideate-research + design-review
- * outcome. Reads the build's CURRENT phase after the review tool finished
- * (the review tool auto-advances to plan when the gate is satisfied) so the
- * message reflects what ACTUALLY happened rather than a stale "Ready to
- * move to the planning phase?" question that sends users in circles.
- */
-async function summariseIdeateOutcome(
-  approach: string,
-  reviewPassed: boolean,
-  buildId: string,
-): Promise<string> {
-  let currentPhase: string | null = null;
-  try {
-    const refreshed = await prisma.featureBuild.findUnique({
-      where: { buildId },
-      select: { phase: true },
-    });
-    currentPhase = refreshed?.phase ?? null;
-  } catch {
-    // Non-fatal — fall through to a generic message below.
-  }
-
-  const head = `I've researched the codebase and drafted the design.\n\n**Approach:** ${approach.slice(0, 300)}\n\n`;
-
-  if (!reviewPassed) {
-    return formatCoworkerOperationalMessage({
-      summary: `${head}Design review flagged issues in the draft.`,
-      status: "needs revision",
-      evidence: `design review did not pass for build ${buildId}.`,
-      nextAction: "revise the design evidence and rerun the design review.",
-      owner: "Build Studio ideate agent",
-    });
-  }
-
-  if (currentPhase === "plan") {
-    return formatCoworkerOperationalMessage({
-      summary: `${head}Design review passed and the build advanced to the Plan phase.`,
-      status: "ready for planning",
-      evidence: `design review passed for build ${buildId}; current phase is plan.`,
-      nextAction: "draft the implementation plan.",
-      owner: "Build Studio planning agent",
-    });
-  }
-  if (currentPhase === "ideate") {
-    // Review passed but auto-advance gate held us. Make the blocker visible
-    // instead of asking a rhetorical "ready?" question.
-    return formatCoworkerOperationalMessage({
-      summary: `${head}Design review passed, but the phase gate is holding advance.`,
-      status: "blocked before planning",
-      evidence: `build ${buildId} is still in ideate; an intake anchor such as taxonomy, backlog, epic, or constrained goal is missing.`,
-      nextAction: "complete the missing intake anchor and retry the phase advance.",
-      owner: "Build Studio ideate agent",
-    });
-  }
-  return formatCoworkerOperationalMessage({
-    summary: `${head}Design review passed, but the current phase could not be confirmed.`,
-    status: "needs review",
-    evidence: `build ${buildId} phase is ${currentPhase ?? "unknown"} after design review.`,
-    nextAction: "refresh the build phase state before proceeding.",
-    owner: "Build Studio",
-  });
-}
-
-function formatIncompleteIdeateDesignMessage(buildId: string): string {
-  return formatCoworkerOperationalMessage({
-    summary: "The codebase research ran but did not produce a complete design.",
-    status: "blocked before planning",
-    evidence: `research output for build ${buildId} was missing a usable proposed approach.`,
-    nextAction: "rerun ideate research with the existing build context and verify codebase access first.",
-    owner: "Build Studio ideate agent",
-  });
-}
-
-function formatIdeateResearchIssueMessage(args: {
-  summary: string;
-  evidence: string;
-  nextAction: string;
-}): string {
-  return formatCoworkerOperationalMessage({
-    summary: args.summary,
-    status: "needs revision",
-    evidence: args.evidence,
-    nextAction: args.nextAction,
-    owner: "Build Studio ideate agent",
-  });
 }
 
 // ─── Server Actions ─────────────────────────────────────────────────────────
@@ -2264,21 +2180,10 @@ export async function sendMessage(input: {
               }
             }
           } else {
-            responseContent = ideateResult.error
-              ? formatCoworkerOperationalMessage({
-                summary: `Research encountered an issue: ${ideateResult.error}`,
-                status: "blocked before planning",
-                evidence: `ideate research failed for build ${resolvedBuildId}: ${ideateResult.error}`,
-                nextAction: "rerun ideate research after confirming codebase access and provider availability.",
-                owner: "Build Studio ideate agent",
-              })
-              : formatCoworkerOperationalMessage({
-                summary: "Research completed but did not generate a structured design.",
-                status: "blocked before planning",
-                evidence: `ideate research for build ${resolvedBuildId} returned no structured design document.`,
-                nextAction: "rerun ideate research with a narrower feature goal and save the structured design evidence.",
-                owner: "Build Studio ideate agent",
-              });
+            responseContent = formatIdeateResearchResultMessage({
+              buildId: resolvedBuildId,
+              error: ideateResult.error,
+            });
           }
 
           // Clear the research request
@@ -2356,33 +2261,10 @@ export async function sendMessage(input: {
 
       responseContent = generateCannedResponse(agent.agentId, input.routeContext, user.platformRole);
 
-      let sysContent: string;
-      if (e.attempts.length > 0) {
-        const failureDetails = e.attempts.map((a) => `${a.providerId}: ${a.error.slice(0, 200)}`).join("; ");
-        sysContent = formatCoworkerOperationalMessage({
-          summary: "All AI providers failed for this coworker turn.",
-          status: "blocked",
-          evidence: failureDetails,
-          nextAction: "restore or switch the configured AI provider in Platform > AI Providers, then retry the coworker turn.",
-          owner: "operator/admin",
-        });
-      } else if (inactiveProviders.length > 0) {
-        sysContent = formatCoworkerOperationalMessage({
-          summary: "AI coworkers are temporarily offline because configured providers are inactive.",
-          status: "blocked",
-          evidence: `${inactiveProviders.length} provider${inactiveProviders.length === 1 ? "" : "s"} are inactive: ${inactiveProviders.map((p) => p.name || p.providerId).join(", ")}.`,
-          nextAction: "reactivate a provider from Platform > AI Providers, then retry the coworker turn.",
-          owner: "operator/admin",
-        });
-      } else {
-        sysContent = formatCoworkerOperationalMessage({
-          summary: "No AI providers are configured for coworker responses.",
-          status: "blocked",
-          evidence: "provider lookup found no active or inactive model providers for this route.",
-          nextAction: "configure at least one AI provider in Platform > AI Providers.",
-          owner: "operator/admin",
-        });
-      }
+      const sysContent = formatProviderUnavailableMessage({
+        attempts: e.attempts,
+        inactiveProviders,
+      });
 
       const sysMsg = await prisma.agentMessage.create({
         data: {

--- a/apps/web/lib/build/customer-status-projection.test.ts
+++ b/apps/web/lib/build/customer-status-projection.test.ts
@@ -13,6 +13,9 @@ describe("projectBuildStudioCustomerStatus (BI-BB13B599)", () => {
     expect(status.whatIsBeingBuilt).toBe("Add a dark-mode toggle");
     expect(status.lifecyclePosition).toBe("Automated work in progress");
     expect(status.worker).toBe("Automated build in progress");
+    expect(status.evidence).toContain("blocked on a system");
+    expect(status.nextAction).toContain("clear the system or runtime blocker");
+    expect(status.owner).toBe("Build Studio / operator");
     expect(status.needsYou).toBe(true);
   });
 
@@ -23,6 +26,8 @@ describe("projectBuildStudioCustomerStatus (BI-BB13B599)", () => {
     });
     expect(status.lifecyclePosition).toBe("In progress");
     expect(status.worker).toBe("Work in progress");
+    expect(status.nextAction).toContain("continue implementation");
+    expect(status.owner).toBe("Build Studio build agent");
     expect(status.needsYou).toBe(false);
   });
 
@@ -33,6 +38,8 @@ describe("projectBuildStudioCustomerStatus (BI-BB13B599)", () => {
     });
     expect(status.lifecyclePosition).toBe("Done");
     expect(status.worker).toBe("Finished");
+    expect(status.nextAction).toContain("review the completed work");
+    expect(status.owner).toBe("reviewer");
     expect(status.needsYou).toBe(false);
   });
 
@@ -49,6 +56,9 @@ describe("projectBuildStudioCustomerStatus (BI-BB13B599)", () => {
     const status = projectBuildStudioCustomerStatus({ build, capsule: null });
     expect(status.lifecyclePosition).toBe("Building it");
     expect(status.worker).toBe("Work in progress");
+    expect(status.evidence).toBe("Build Studio phase is build.");
+    expect(status.nextAction).toContain("continue implementation");
+    expect(status.owner).toBe("Build Studio build agent");
     expect(status.needsYou).toBe(false);
   });
 
@@ -59,6 +69,8 @@ describe("projectBuildStudioCustomerStatus (BI-BB13B599)", () => {
     });
     expect(status.needsYou).toBe(true);
     expect(status.worker).toBe("Hit a problem");
+    expect(status.nextAction).toContain("resolve the failure");
+    expect(status.owner).toBe("Build Studio / operator");
   });
 
   it("is business-safe by construction — never leaks an executor name to the customer", () => {

--- a/apps/web/lib/build/customer-status-projection.ts
+++ b/apps/web/lib/build/customer-status-projection.ts
@@ -21,6 +21,12 @@ export interface BuildStudioCustomerStatus {
   lifecyclePosition: string;
   /** Who/what is working, translated to business-safe language — never an executor name. */
   worker: string;
+  /** Plain evidence behind the status, safe for customer/operator display. */
+  evidence: string;
+  /** One concrete next action that moves the work forward. */
+  nextAction: string;
+  /** The accountable owner for the next action. */
+  owner: string;
   /** True when the work is waiting on the human (surfaces "Needs you"). */
   needsYou: boolean;
 }
@@ -79,21 +85,92 @@ function workerLabel(state: WorkCaseState): string {
   }
 }
 
+function nextActionForState(state: WorkCaseState): { nextAction: string; owner: string } {
+  switch (state) {
+    case "waiting-on-person":
+    case "awaiting-decision":
+      return {
+        nextAction: "answer the requested decision so the work can continue.",
+        owner: "human decision-maker",
+      };
+    case "waiting-on-system":
+      return {
+        nextAction: "clear the system or runtime blocker, then resume the build.",
+        owner: "Build Studio / operator",
+      };
+    case "verifying":
+      return {
+        nextAction: "finish verification and record the result.",
+        owner: "Build Studio review agent",
+      };
+    case "resolved":
+    case "closed":
+      return {
+        nextAction: "review the completed work and promote or merge it if accepted.",
+        owner: "reviewer",
+      };
+    case "cancelled":
+      return {
+        nextAction: "restart the work only if the business priority still stands.",
+        owner: "human decision-maker",
+      };
+    case "intake":
+    case "triage":
+      return {
+        nextAction: "finish scoping the request and confirm it is ready to build.",
+        owner: "Build Studio",
+      };
+    case "active":
+    default:
+      return {
+        nextAction: "continue implementation until verification evidence is ready.",
+        owner: "Build Studio build agent",
+      };
+  }
+}
+
+function nextActionForPhase(phase: BuildPhase): { nextAction: string; owner: string } {
+  switch (phase) {
+    case "ideate":
+      return { nextAction: "finish the design brief and review it.", owner: "Build Studio ideate agent" };
+    case "plan":
+      return { nextAction: "draft and review the implementation plan.", owner: "Build Studio planning agent" };
+    case "build":
+      return { nextAction: "continue implementation until verification evidence is ready.", owner: "Build Studio build agent" };
+    case "review":
+      return { nextAction: "finish tests, UX checks, and acceptance review.", owner: "Build Studio review agent" };
+    case "ship":
+      return { nextAction: "complete the PR or promotion handoff.", owner: "Build Studio ship agent" };
+    case "complete":
+      return { nextAction: "review the completed work and promote or merge it if accepted.", owner: "reviewer" };
+    case "failed":
+      return { nextAction: "resolve the failure and rerun the affected phase.", owner: "Build Studio / operator" };
+    case "abandoned":
+    default:
+      return { nextAction: "restart the work only if the business priority still stands.", owner: "human decision-maker" };
+  }
+}
+
 export function projectBuildStudioCustomerStatus(args: {
   build: { title: string; phase: BuildPhase };
   capsule: { capsuleId: string; status: string } | null;
 }): BuildStudioCustomerStatus {
   if (args.capsule) {
     const projection = projectWorkCaseState({ capsule: args.capsule });
+    const action = nextActionForState(projection.state);
     return {
       whatIsBeingBuilt: args.build.title,
       lifecyclePosition: STATE_PLAIN[projection.state],
       worker: workerLabel(projection.state),
+      evidence: projection.reason,
+      nextAction: action.nextAction,
+      owner: action.owner,
       needsYou: NEEDS_YOU_STATES.has(projection.state),
     };
   }
 
   // No capsule linked yet: degrade to a phase-only plain status.
+  const action = nextActionForPhase(args.build.phase);
   return {
     whatIsBeingBuilt: args.build.title,
     lifecyclePosition: PHASE_PLAIN[args.build.phase],
@@ -103,6 +180,9 @@ export function projectBuildStudioCustomerStatus(args: {
         : args.build.phase === "failed"
           ? "Hit a problem"
           : "Work in progress",
+    evidence: `Build Studio phase is ${args.build.phase}.`,
+    nextAction: action.nextAction,
+    owner: action.owner,
     needsYou: args.build.phase === "failed",
   };
 }

--- a/apps/web/lib/tak/coworker-interaction-contract.test.ts
+++ b/apps/web/lib/tak/coworker-interaction-contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   COWORKER_INTERACTION_CONTRACT_HEADING,
   formatCoworkerOperationalCloseout,
+  formatCoworkerOperationalMessage,
   withCoworkerInteractionContract,
 } from "./coworker-interaction-contract";
 
@@ -49,6 +50,23 @@ describe("coworker interaction contract", () => {
       "Evidence: typecheck and scoped tests passed on branch feat/example",
       "Next action: open the governed PR",
       "Owner: agent",
+    ].join("\n"));
+  });
+
+  it("formats deterministic summary messages with an operational closeout", () => {
+    expect(formatCoworkerOperationalMessage({
+      summary: "Research completed but needs one repair.",
+      status: "needs revision",
+      evidence: "design review found a missing codebase audit",
+      nextAction: "patch the evidence and rerun design review",
+      owner: "Build Studio ideate agent",
+    })).toBe([
+      "Research completed but needs one repair.",
+      "",
+      "Status: needs revision",
+      "Evidence: design review found a missing codebase audit",
+      "Next action: patch the evidence and rerun design review",
+      "Owner: Build Studio ideate agent",
     ].join("\n"));
   });
 });

--- a/apps/web/lib/tak/coworker-interaction-contract.ts
+++ b/apps/web/lib/tak/coworker-interaction-contract.ts
@@ -36,6 +36,10 @@ export type CoworkerOperationalCloseout = {
   owner: string;
 };
 
+export type CoworkerOperationalMessage = CoworkerOperationalCloseout & {
+  summary: string;
+};
+
 export function withCoworkerInteractionContract(prompt: string): string {
   if (prompt.includes(COWORKER_INTERACTION_CONTRACT_HEADING)) {
     return prompt;
@@ -54,4 +58,8 @@ export function formatCoworkerOperationalCloseout(closeout: CoworkerOperationalC
     `Next action: ${closeout.nextAction}`,
     `Owner: ${closeout.owner}`,
   ].join("\n");
+}
+
+export function formatCoworkerOperationalMessage(message: CoworkerOperationalMessage): string {
+  return `${message.summary.trim()}\n\n${formatCoworkerOperationalCloseout(message)}`;
 }

--- a/apps/web/lib/tak/coworker-operational-messages.test.ts
+++ b/apps/web/lib/tak/coworker-operational-messages.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatIdeateOutcomeMessage,
+  formatIncompleteIdeateDesignMessage,
+  formatProviderUnavailableMessage,
+} from "./coworker-operational-messages";
+
+describe("coworker operational messages", () => {
+  it("formats ideate outcome messages with current phase evidence", () => {
+    const message = formatIdeateOutcomeMessage({
+      approach: "Use the existing Build Studio projection and render the missing operational fields.",
+      reviewPassed: true,
+      buildId: "FB-1234",
+      currentPhase: "plan",
+    });
+
+    expect(message).toContain("Status: ready for planning");
+    expect(message).toContain("Evidence: design review passed for build FB-1234; current phase is plan.");
+    expect(message).toContain("Next action: draft the implementation plan.");
+    expect(message).toContain("Owner: Build Studio planning agent");
+  });
+
+  it("formats incomplete ideate design messages with an owner", () => {
+    const message = formatIncompleteIdeateDesignMessage("FB-5678");
+
+    expect(message).toContain("Status: blocked before planning");
+    expect(message).toContain("Evidence: research output for build FB-5678 was missing a usable proposed approach.");
+    expect(message).toContain("Owner: Build Studio ideate agent");
+  });
+
+  it("formats provider failure messages with concrete operator action", () => {
+    const message = formatProviderUnavailableMessage({
+      attempts: [{ providerId: "openai", error: "quota exceeded" }],
+      inactiveProviders: [],
+    });
+
+    expect(message).toContain("Status: blocked");
+    expect(message).toContain("Evidence: openai: quota exceeded");
+    expect(message).toContain("Next action: restore or switch the configured AI provider");
+    expect(message).toContain("Owner: operator/admin");
+  });
+});

--- a/apps/web/lib/tak/coworker-operational-messages.ts
+++ b/apps/web/lib/tak/coworker-operational-messages.ts
@@ -1,0 +1,155 @@
+import { prisma } from "@dpf/db";
+import { formatCoworkerOperationalMessage } from "./coworker-interaction-contract";
+
+/**
+ * Build the coworker's chat summary of the ideate-research + design-review
+ * outcome using the build phase after the review tool had a chance to advance.
+ */
+export async function summariseIdeateOutcome(
+  approach: string,
+  reviewPassed: boolean,
+  buildId: string,
+): Promise<string> {
+  let currentPhase: string | null = null;
+  try {
+    const refreshed = await prisma.featureBuild.findUnique({
+      where: { buildId },
+      select: { phase: true },
+    });
+    currentPhase = refreshed?.phase ?? null;
+  } catch {
+    // Non-fatal: the formatted fallback will name the phase as unknown.
+  }
+
+  return formatIdeateOutcomeMessage({ approach, reviewPassed, buildId, currentPhase });
+}
+
+export function formatIdeateOutcomeMessage(args: {
+  approach: string;
+  reviewPassed: boolean;
+  buildId: string;
+  currentPhase: string | null;
+}): string {
+  const head = `I've researched the codebase and drafted the design.\n\n**Approach:** ${args.approach.slice(0, 300)}\n\n`;
+
+  if (!args.reviewPassed) {
+    return formatCoworkerOperationalMessage({
+      summary: `${head}Design review flagged issues in the draft.`,
+      status: "needs revision",
+      evidence: `design review did not pass for build ${args.buildId}.`,
+      nextAction: "revise the design evidence and rerun the design review.",
+      owner: "Build Studio ideate agent",
+    });
+  }
+
+  if (args.currentPhase === "plan") {
+    return formatCoworkerOperationalMessage({
+      summary: `${head}Design review passed and the build advanced to the Plan phase.`,
+      status: "ready for planning",
+      evidence: `design review passed for build ${args.buildId}; current phase is plan.`,
+      nextAction: "draft the implementation plan.",
+      owner: "Build Studio planning agent",
+    });
+  }
+
+  if (args.currentPhase === "ideate") {
+    return formatCoworkerOperationalMessage({
+      summary: `${head}Design review passed, but the phase gate is holding advance.`,
+      status: "blocked before planning",
+      evidence: `build ${args.buildId} is still in ideate; an intake anchor such as taxonomy, backlog, epic, or constrained goal is missing.`,
+      nextAction: "complete the missing intake anchor and retry the phase advance.",
+      owner: "Build Studio ideate agent",
+    });
+  }
+
+  return formatCoworkerOperationalMessage({
+    summary: `${head}Design review passed, but the current phase could not be confirmed.`,
+    status: "needs review",
+    evidence: `build ${args.buildId} phase is ${args.currentPhase ?? "unknown"} after design review.`,
+    nextAction: "refresh the build phase state before proceeding.",
+    owner: "Build Studio",
+  });
+}
+
+export function formatIncompleteIdeateDesignMessage(buildId: string): string {
+  return formatCoworkerOperationalMessage({
+    summary: "The codebase research ran but did not produce a complete design.",
+    status: "blocked before planning",
+    evidence: `research output for build ${buildId} was missing a usable proposed approach.`,
+    nextAction: "rerun ideate research with the existing build context and verify codebase access first.",
+    owner: "Build Studio ideate agent",
+  });
+}
+
+export function formatIdeateResearchIssueMessage(args: {
+  summary: string;
+  evidence: string;
+  nextAction: string;
+}): string {
+  return formatCoworkerOperationalMessage({
+    summary: args.summary,
+    status: "needs revision",
+    evidence: args.evidence,
+    nextAction: args.nextAction,
+    owner: "Build Studio ideate agent",
+  });
+}
+
+export function formatIdeateResearchResultMessage(args: {
+  buildId: string;
+  error?: string | null;
+}): string {
+  if (args.error) {
+    return formatCoworkerOperationalMessage({
+      summary: `Research encountered an issue: ${args.error}`,
+      status: "blocked before planning",
+      evidence: `ideate research failed for build ${args.buildId}: ${args.error}`,
+      nextAction: "rerun ideate research after confirming codebase access and provider availability.",
+      owner: "Build Studio ideate agent",
+    });
+  }
+
+  return formatCoworkerOperationalMessage({
+    summary: "Research completed but did not generate a structured design.",
+    status: "blocked before planning",
+    evidence: `ideate research for build ${args.buildId} returned no structured design document.`,
+    nextAction: "rerun ideate research with a narrower feature goal and save the structured design evidence.",
+    owner: "Build Studio ideate agent",
+  });
+}
+
+export function formatProviderUnavailableMessage(args: {
+  attempts: ReadonlyArray<{ providerId: string; error: string }>;
+  inactiveProviders: ReadonlyArray<{ providerId: string; name: string | null }>;
+}): string {
+  if (args.attempts.length > 0) {
+    const failureDetails = args.attempts
+      .map((attempt) => `${attempt.providerId}: ${attempt.error.slice(0, 200)}`)
+      .join("; ");
+    return formatCoworkerOperationalMessage({
+      summary: "All AI providers failed for this coworker turn.",
+      status: "blocked",
+      evidence: failureDetails,
+      nextAction: "restore or switch the configured AI provider in Platform > AI Providers, then retry the coworker turn.",
+      owner: "operator/admin",
+    });
+  }
+
+  if (args.inactiveProviders.length > 0) {
+    return formatCoworkerOperationalMessage({
+      summary: "AI coworkers are temporarily offline because configured providers are inactive.",
+      status: "blocked",
+      evidence: `${args.inactiveProviders.length} provider${args.inactiveProviders.length === 1 ? "" : "s"} are inactive: ${args.inactiveProviders.map((provider) => provider.name || provider.providerId).join(", ")}.`,
+      nextAction: "reactivate a provider from Platform > AI Providers, then retry the coworker turn.",
+      owner: "operator/admin",
+    });
+  }
+
+  return formatCoworkerOperationalMessage({
+    summary: "No AI providers are configured for coworker responses.",
+    status: "blocked",
+    evidence: "provider lookup found no active or inactive model providers for this route.",
+    nextAction: "configure at least one AI provider in Platform > AI Providers.",
+    owner: "operator/admin",
+  });
+}

--- a/docs/superpowers/plans/2026-07-20-coworker-interaction-surface-gap-followup.md
+++ b/docs/superpowers/plans/2026-07-20-coworker-interaction-surface-gap-followup.md
@@ -1,0 +1,29 @@
+# Coworker Interaction Contract - Surface Gap Follow-up
+
+## Status
+
+PR #1406 shipped the shared coworker interaction contract, and later work extended it with clarify-vs-proceed and button-decision guidance. This follow-up closes two remaining implementation gaps: deterministic coworker fallback strings and the Build Studio customer status band.
+
+## Evidence
+
+- `apps/web/lib/tak/coworker-interaction-contract.ts` is the shared prompt/formatter choke point for operational closeouts.
+- `apps/web/lib/actions/agent-coworker.ts` still contained hardcoded ideate/provider failure messages that ended without a consistent status, evidence, next action, and owner.
+- `apps/web/lib/build/customer-status-projection.ts` and `apps/web/components/build/BuildCustomerStatusBand.tsx` projected status and worker labels but did not expose evidence, next action, or owner.
+
+## Change
+
+- Add a shared deterministic formatter for summary-plus-closeout coworker messages.
+- Route ideate fallback and provider failure messages through the formatter.
+- Extend the Build Studio customer status projection with evidence, next action, and owner.
+- Render those operational fields in the status band and cover them with targeted tests.
+
+## Verification Plan
+
+- Targeted unit/render tests for the closeout formatter, status projection, and status band.
+- Web typecheck.
+- Production web build.
+- Contributor-preview UX observation of the Build Studio status band showing Evidence, Next action, and Owner.
+
+## Next Action
+
+Owner: reviewer. Review the follow-up PR, then let CI validate the pushed branch before merge queue admission.

--- a/docs/superpowers/plans/2026-07-20-coworker-interaction-surface-gap-followup.md
+++ b/docs/superpowers/plans/2026-07-20-coworker-interaction-surface-gap-followup.md
@@ -17,6 +17,22 @@ PR #1406 shipped the shared coworker interaction contract, and later work extend
 - Extend the Build Studio customer status projection with evidence, next action, and owner.
 - Render those operational fields in the status band and cover them with targeted tests.
 
+## Design grounding
+
+- Existing specs/plans reviewed:
+  - `docs/superpowers/specs/2026-07-16-coworker-button-decision-interface.md`
+  - `docs/superpowers/plans/2026-07-11-p6-ambiguity-clarify-vs-proceed.md`
+- Current code substrate reviewed:
+  - `apps/web/lib/tak/coworker-interaction-contract.ts`
+  - `apps/web/lib/actions/agent-coworker.ts`
+  - `apps/web/lib/build/customer-status-projection.ts`
+  - `apps/web/components/build/BuildCustomerStatusBand.tsx`
+- Source of truth:
+  - The shared coworker interaction contract owns the required operational closeout fields.
+  - Build Studio customer status projection owns business-safe status evidence for the status band.
+- Decision:
+  - Keep the shared contract as the prompt/formatter choke point, move deterministic message builders into a focused TAK helper module, and render evidence/next action/owner through the existing status band rather than adding a parallel status surface.
+
 ## Verification Plan
 
 - Targeted unit/render tests for the closeout formatter, status projection, and status band.


### PR DESCRIPTION
## Summary
- Closes the remaining deterministic coworker-message gaps by routing ideate fallback and provider failure messages through the shared operational closeout formatter.
- Extends the Build Studio customer status projection and status band with evidence, next action, and owner fields.
- Extracts deterministic operational message builders out of the large coworker action file so the module-size ratchet stays tight.
- Adds durable design-grounding evidence for the interaction-contract surface gap audit.

## Test plan
- [x] `pnpm --filter web exec vitest run lib/tak/coworker-operational-messages.test.ts lib/tak/coworker-interaction-contract.test.ts lib/build/customer-status-projection.test.ts components/build/BuildCustomerStatusBand.test.tsx` — 4 files / 19 tests passed.
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck` — passed after rebase onto current `origin/main`.
- [x] `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build` — passed before rebase; only pre-existing Edge Runtime / NFT tracing warnings were emitted.
- [x] `node scripts/check-module-size.mjs` — passed after rebase; `agent-coworker.ts` is 2,758 lines versus the 2,788-line baseline.
- [x] `PR_BODY="$(gh pr view 3306 --json body --jq .body)" BASE_SHA=origin/main node scripts/check-design-grounding-decision.mjs` — passed after rebase with the durable design-grounding note.
- [x] Contributor preview UX check on `http://localhost:3001/build?buildId=FB-317F31F2` — Playwright observed the status band rendering `Evidence: Work capsule is actively executing.`, `Next action: continue implementation until verification evidence is ready.`, and `Owner: Build Studio build agent`. Screenshot: `/tmp/dpf-coworker-status-band.png`.
- [x] Pre-commit hook — staged gitleaks scan passed and scoped typecheck passed on both commits.

## Design grounding
- Existing specs/plans reviewed: `docs/superpowers/specs/2026-07-16-coworker-button-decision-interface.md`; `docs/superpowers/plans/2026-07-11-p6-ambiguity-clarify-vs-proceed.md`.
- Current code substrate reviewed: `apps/web/lib/tak/coworker-interaction-contract.ts`; `apps/web/lib/actions/agent-coworker.ts`; `apps/web/lib/build/customer-status-projection.ts`; `apps/web/components/build/BuildCustomerStatusBand.tsx`.
- Source of truth: shared coworker interaction contract owns required operational closeout fields; Build Studio customer status projection owns business-safe status evidence for the status band.
- Decision: keep the shared contract as the prompt/formatter choke point, move deterministic message builders into a focused TAK helper module, and render evidence/next action/owner through the existing status band.

## Operations
- Branch rebased onto current `origin/main` (`c7c2705a4a4eeae05a1b6751f1c98325d982ba1c`) so policy gates compare only this PR's diff.
- Overlap sweep before push: open PRs #3304 (`fix/claude-readiness-version`) and #3303 (`fix/build-studio-engine-failover`) did not overlap this interaction closeout/status projection change; #3303 has since landed on main and is included in the rebase.
- Pre-push local-CI gate: push-time override recorded for `feat/coworker-interaction-surface-gaps@ffb7ef84bc4e0e30a9dfc118d6003f0e98d4b4aa` because the branch was rebased onto current main and module-size, design-grounding, targeted Vitest, and web typecheck passed locally.

UX-Fit-Decision: localized status-band copy addition; existing band layout retained, no new user input/control, cognitive load reduced by naming evidence/next action/owner inline.
Docs-Impact-Decision: no user-guide behavior change beyond the status band fields documented by this PR's durable plan note; no Build Studio user-guide workflow update needed.
Seed-Fit-Decision: reject-as-seed
Local-CI-Override: rebased onto current main; module-size, design-grounding, targeted vitest, and web typecheck passed