### PR TITLE
Fix process-spine readiness gaps

### DIFF
--- a/docs/superpowers/specs/2026-07-19-process-spine-skill-exposure-health-design.md
+++ b/docs/superpowers/specs/2026-07-19-process-spine-skill-exposure-health-design.md
@@ -71,6 +71,11 @@ pre-PR gate contract in `docs/testing/pre-pr-gate.md`, and code substrate
 `scripts/sandbox-freshness-preflight.mjs`; this change repairs readiness and
 sandbox-evidence behavior without changing UI routes or coworker authority.
 
+UX-Fit-Decision: fits-with-guardrails. No app route or user-facing control
+changes; the readiness output reduces operator cognitive load by naming the
+plain-language difference between DPF skills installed on disk and DPF-native
+replacement skills loaded/exposed in the active session.
+
 ## Design
 
 The canonical replacement map is

--- a/docs/superpowers/specs/2026-07-19-process-spine-skill-exposure-health-design.md
+++ b/docs/superpowers/specs/2026-07-19-process-spine-skill-exposure-health-design.md
@@ -65,6 +65,12 @@ testable while honoring the destructive-action boundary: DPF can disable known
 competitive process plugins where a client adapter is proven, but it does not
 delete user-owned local skill state.
 
+Design-Grounding-Decision: reviewed this process-spine exposure spec, the
+pre-PR gate contract in `docs/testing/pre-pr-gate.md`, and code substrate
+`packages/dpf-skill-pack/hooks/process-spine-health-check.mjs` plus
+`scripts/sandbox-freshness-preflight.mjs`; this change repairs readiness and
+sandbox-evidence behavior without changing UI routes or coworker authority.
+
 ## Design
 
 The canonical replacement map is

--- a/docs/superpowers/specs/2026-07-19-process-spine-skill-exposure-health-design.md
+++ b/docs/superpowers/specs/2026-07-19-process-spine-skill-exposure-health-design.md
@@ -6,6 +6,7 @@ decision-ledger:
   - DI-DEB2623C6DAB
   - DI-84BA6E9B2318
   - DI-15E908812733
+  - DI-F548CFA4095C
 related:
   - packages/dpf-skill-pack/process-spine-replacements.json
   - packages/dpf-skill-pack/hooks/process-spine-health-check.mjs
@@ -87,9 +88,10 @@ evidence supplied by a client through:
 - `DPF_PROCESS_SPINE_EXPOSED_SKILLS`
 
 If no active evidence exists, the exposed state is `unknown`. That is deliberate:
-installed files do not prove the current client loaded the skills. When active
-evidence exists and a retired generic process skill is visible without its DPF
-replacement, the checker warns before work begins.
+installed files do not prove the current client loaded the skills. `unknown` is
+a readiness warning, not a pass. When active evidence exists and a retired
+generic process skill is visible without its DPF replacement, the checker also
+warns before work begins.
 
 The dependency-free Python updater reads the same JSON map and prints the same
 plain-language installed-vs-exposed readiness summary. The PowerShell and POSIX
@@ -141,9 +143,46 @@ config. Unknown invalid TOML remains fail-closed instead of guessed.
 
 Codex Desktop does not currently provide a non-interactive active-skill-list API
 to hooks or bootstrap. For those clients the health check reports active
-exposure as `unknown` and names the restart/repair action. A future client
+exposure as `unknown`, warns before work begins, and names the restart/repair
+action. A future client
 adapter should populate one of the `DPF_PROCESS_SPINE_EXPOSED_SKILLS*` inputs so
 the check can become fully verified instead of proxy-based.
 
 Follow-up: `BI-BCA162CF` covers client-specific active skill exposure adapters
 as each external client exposes a supported API.
+
+## Follow-up Substrate Repair
+
+After PR #3292, the same process-spine objective exposed a second evidence gap:
+the shared local-CI sandbox could keep a stale top-level `vitest` package while
+the lockfile required a newer runner. That made the unit-test gate fail inside
+the runner before the freshness preflight could classify the sandbox as stale.
+
+`principle_decide` was run for the follow-up scope. Ledger:
+`DI-F548CFA4095C`.
+
+Options:
+
+- `sandbox-drift-only`: repair only the local-CI freshness detector.
+- `active-skill-exposure-only`: repair only active-skill readiness warning
+  behavior.
+- `bundle-both`: repair both because both are process-spine evidence gaps.
+
+Recommendation: `bundle-both`, high confidence, margin `0.646`. The durable
+repair adds `vitest` to the local-CI freshness sentinels and removes stale
+resolved package links inside the sandbox before the single governed
+`pnpm install --frozen-lockfile` convergence pass. The Vitest sentinel checks
+both the locked version and runnable entrypoint imports so a broken runner
+package is sandbox drift, not product test evidence. If that re-check still
+sees dependency drift, the preflight runs one bounded
+`pnpm install --force --frozen-lockfile` retry to refresh the sandbox store/link
+graph. If the dedicated `.local-ci-runner` scratch checkout is still stale after
+that native retry, the preflight resets that scratch checkout's own
+`node_modules` and reinstalls from the lockfile. The convergence lock lives in
+git-private state outside `node_modules`, so a reset cannot erase its duplicate
+install guard. A red sandbox remains classified as `blocked_sandbox_drift`,
+never product evidence.
+
+Follow-up: `BI-4D852EC2` tracks the remaining root-cause repair when the
+dedicated local-CI scratch runner recreates a stale or incomplete Vitest package
+even after native pnpm convergence and scoped scratch `node_modules` reset.

--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -170,6 +170,21 @@ depending on a host `env` executable. This keeps the 8 GiB `NODE_OPTIONS`
 headroom on both POSIX and Windows typecheck paths; the production build may
 still use the host-specific strategy selected by the plan.
 
+The sandbox-freshness step checks the load-bearing runtime and gate packages,
+including the Vitest runner used by the next step. Vitest is checked for both
+locked version and runnable entrypoint imports, so an incomplete package cannot
+be recorded as a product test failure. If a stale top-level package link
+survives in the scratch worktree, the preflight removes only the stale package
+link inside the sandbox's own `node_modules` before its single governed
+`pnpm install --frozen-lockfile` convergence pass. If the re-check still sees
+dependency drift, it runs one bounded `pnpm install --force --frozen-lockfile`
+retry to refresh the sandbox store/link graph; a second red verdict remains
+`blocked_sandbox_drift`, never product evidence. The dedicated
+`.local-ci-runner` scratch checkout has one final native recovery path: reset
+that scratch checkout's own `node_modules` and reinstall from the lockfile. The
+convergence lock lives in git-private state, outside `node_modules`, so the
+reset cannot erase its own duplicate-install guard.
+
 The network-disconnect proof is encoded in
 `tests/release/local-ci-gate-contract.test.mjs`: the contract denies network
 Git verbs during `gate-worktree.sh`, records local-only evidence with

--- a/packages/dpf-skill-pack/hooks/process-spine-health-check.mjs
+++ b/packages/dpf-skill-pack/hooks/process-spine-health-check.mjs
@@ -6,7 +6,7 @@
 //   2. exposed-in-session: the active client reports which skills are visible.
 //
 // Most clients do not expose active skill state to hooks yet. In that case the
-// check reports "unknown" rather than pretending install equals loaded.
+// check warns "unknown" rather than pretending install equals loaded.
 
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -116,9 +116,10 @@ export function assessProcessSpine({
         }))
     : [];
 
+  const exposureUnknown = exposed === null;
   const severity = missingInstalled.length > 0
     ? "fail"
-    : conflicts.length > 0 || missingDpfExposed.length > 0
+    : exposureUnknown || conflicts.length > 0 || missingDpfExposed.length > 0
       ? "warn"
       : "ok";
 
@@ -143,6 +144,7 @@ export function assessProcessSpine({
           total: rows.length,
           present: null,
           missingDpfSkills: [],
+          message: "client did not provide active skill evidence; DPF cannot prove replacements are loaded",
         },
     conflicts,
   };
@@ -172,7 +174,7 @@ export function renderProcessSpineSummary(verdict) {
     }
   } else {
     lines.push(
-      "  DPF-native replacement skills loaded/exposed in this session: unknown (this client did not provide active skill evidence).",
+      "  DPF-native replacement skills loaded/exposed in this session: UNKNOWN - this client did not provide active skill evidence; DPF cannot prove replacements are loaded.",
     );
   }
 

--- a/packages/dpf-skill-pack/hooks/process-spine-health.test.mjs
+++ b/packages/dpf-skill-pack/hooks/process-spine-health.test.mjs
@@ -83,6 +83,31 @@ test("flags generic superpowers brainstorming present while dpf-brainstorming is
   assert.match(renderProcessSpineSummary(verdict).join("\n"), /DPF-native replacement skills are not active/);
 });
 
+test("warns when installed skills cannot be proven exposed in the active session", () => {
+  const verdict = assessProcessSpine({
+    skillPackRoot: makeSkillPack(),
+    exposedSkills: null,
+  });
+
+  assert.equal(verdict.installed.ok, true);
+  assert.equal(verdict.exposed.state, "unknown");
+  assert.equal(verdict.severity, "warn");
+  const summary = renderProcessSpineSummary(verdict).join("\n");
+  assert.match(summary, /UNKNOWN/);
+  assert.match(summary, /cannot prove replacements are loaded/);
+});
+
+test("reports fully exposed DPF replacements as healthy", () => {
+  const verdict = assessProcessSpine({
+    skillPackRoot: makeSkillPack(),
+    exposedSkills: REQUIRED_REPLACEMENT_SLUGS,
+  });
+
+  assert.equal(verdict.installed.ok, true);
+  assert.equal(verdict.exposed.state, "verified");
+  assert.equal(verdict.severity, "ok");
+});
+
 test("reports missing plugin files as installed-state failure", () => {
   const verdict = assessProcessSpine({
     skillPackRoot: makeSkillPack(["dpf-brainstorming"]),

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -202,10 +202,11 @@ def assess_process_spine_health(
         for row in rows
         if exposed is not None and row["genericExposed"] and not row["dpfExposed"]
     ]
+    exposure_unknown = exposed is None
     severity = "ok"
     if missing_installed:
         severity = "fail"
-    elif conflicts or missing_exposed:
+    elif exposure_unknown or conflicts or missing_exposed:
         severity = "warn"
 
     return {
@@ -222,6 +223,11 @@ def assess_process_spine_health(
             "total": len(rows),
             "present": (len(rows) - len(missing_exposed)) if exposed is not None else None,
             "missingDpfSkills": missing_exposed,
+            "message": (
+                None
+                if exposed is not None
+                else "client did not provide active skill evidence; DPF cannot prove replacements are loaded"
+            ),
         },
         "conflicts": conflicts,
     }
@@ -255,8 +261,9 @@ def render_process_spine_health(verdict: dict[str, Any]) -> list[str]:
             )
     else:
         lines.append(
-            "  DPF-native replacement skills loaded/exposed in this session: unknown "
-            "(this client did not provide active skill evidence)."
+            "  DPF-native replacement skills loaded/exposed in this session: UNKNOWN - "
+            "this client did not provide active skill evidence; DPF cannot prove "
+            "replacements are loaded."
         )
 
     if verdict["conflicts"]:

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -469,6 +469,16 @@ class ProcessSpineHealthTest(unittest.TestCase):
         text = "\n".join(updater.render_process_spine_health(verdict))
         self.assertIn("DPF-native replacement skills are not active", text)
 
+    def test_unknown_active_skill_evidence_is_readiness_warning(self) -> None:
+        skill_pack = Path(__file__).resolve().parents[1]
+        verdict = updater.assess_process_spine_health(skill_pack, exposed_skills=None)
+        self.assertTrue(verdict["installed"]["ok"])
+        self.assertEqual(verdict["exposed"]["state"], "unknown")
+        self.assertEqual(verdict["severity"], "warn")
+        text = "\n".join(updater.render_process_spine_health(verdict))
+        self.assertIn("UNKNOWN", text)
+        self.assertIn("cannot prove replacements are loaded", text)
+
 
 class CodexHookTrustTest(unittest.TestCase):
     def test_trust_pending_when_no_state_file(self) -> None:

--- a/scripts/lib/sandbox-freshness.mjs
+++ b/scripts/lib/sandbox-freshness.mjs
@@ -12,6 +12,8 @@
 // a red sandbox is reported as SANDBOX_DRIFT — never as product evidence.
 // Filesystem/process collection lives in scripts/sandbox-freshness-preflight.mjs.
 
+import path from "node:path";
+
 /**
  * Packages whose on-disk resolution must match the lockfile before any build
  * evidence is trustworthy. `importers` lists the workspace dirs (relative to
@@ -25,6 +27,11 @@ export const CRITICAL_PACKAGES = [
   { name: "react-dom", importers: ["apps/web"] },
   { name: "typescript", importers: ["apps/web", "."] },
   { name: "prisma", importers: ["packages/db", "."] },
+  {
+    name: "vitest",
+    importers: ["apps/web", "packages/db", "packages/dpf-bootstrap", "."],
+    entrypointImportChecks: ["dist/cli.js"],
+  },
 ];
 
 /** Strip a pnpm peer-dependency suffix: "16.2.9(@babel/core@7.29.7)(...)" -> "16.2.9". */
@@ -151,7 +158,7 @@ export function parseEtimeMinutes(etime) {
  *   nodeModulesPresent: boolean,
  *   installedLockPresent: boolean,
  *   lockfilesDiffer?: boolean,
- *   packages: [{ name, importer, lockedVersion, installedLockVersion, resolvedVersion, linkTarget, missing }],
+ *   packages: [{ name, importer, lockedVersion, installedLockVersion, resolvedVersion, linkTarget, missing, missingEntrypointImports }],
  *   installProcesses: [{ pid, etime, etimeMinutes, command }],
  * }
  *
@@ -228,6 +235,13 @@ export function evaluateFreshness(state) {
         message: `${pkg.importer}/node_modules/${pkg.name} resolves to ${pkg.resolvedVersion}${pkg.linkTarget ? ` (link -> ${pkg.linkTarget})` : ""} but pnpm-lock.yaml requires ${pkg.lockedVersion}`,
       });
     }
+    if (Array.isArray(pkg.missingEntrypointImports) && pkg.missingEntrypointImports.length > 0) {
+      failures.push({
+        kind: "package_broken",
+        package: pkg.name,
+        message: `${pkg.importer}/node_modules/${pkg.name} is incomplete: ${pkg.missingEntrypointImports.join(", ")} missing`,
+      });
+    }
   }
 
   let verdict = "green";
@@ -237,6 +251,47 @@ export function evaluateFreshness(state) {
     verdict = "sandbox_drift";
   }
   return { verdict, failures };
+}
+
+function isInsidePath(parent, child) {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return relative === "" || (relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function isNodeModulesPath(rootDir, candidate) {
+  const relative = path.relative(path.resolve(rootDir), path.resolve(candidate));
+  return relative.split(path.sep).includes("node_modules");
+}
+
+/**
+ * Return package link/dir paths that are safe for the preflight to remove
+ * before its single governed `pnpm install` convergence pass. This is only for
+ * stale resolved packages inside the sandbox's own node_modules tree; outside
+ * paths and unresolved/missing packages are intentionally ignored.
+ */
+export function stalePackagePathsForRelink(state, rootDir) {
+  const seen = new Set();
+  const paths = [];
+  for (const pkg of state.packages ?? []) {
+    const versionDrift = pkg.lockedVersion && pkg.resolvedVersion && pkg.resolvedVersion !== pkg.lockedVersion;
+    if (!versionDrift || !pkg.resolvedFrom) continue;
+    const candidate = path.resolve(rootDir, pkg.resolvedFrom);
+    if (!isInsidePath(rootDir, candidate) || !isNodeModulesPath(rootDir, candidate)) continue;
+    if (seen.has(candidate)) continue;
+    seen.add(candidate);
+    paths.push(candidate);
+  }
+  return paths;
+}
+
+export function shouldForceConvergenceAfterInstall(evaluation) {
+  if (!evaluation || evaluation.verdict === "green") return false;
+  return (evaluation.failures ?? []).some((failure) => [
+    "installed_lock_stale",
+    "package_broken",
+    "package_missing",
+    "version_drift",
+  ].includes(failure.kind));
 }
 
 /** Exit codes for the preflight CLI — deliberately distinct from a product build failure (1). */

--- a/scripts/lib/sandbox-freshness.test.mjs
+++ b/scripts/lib/sandbox-freshness.test.mjs
@@ -1,8 +1,10 @@
 // Unit tests for the sandbox freshness decision core (BI-ECDF9520).
 // node --test scripts/lib/sandbox-freshness.test.mjs — no docker/daemon needed.
 import assert from "node:assert/strict";
+import path from "node:path";
 import { test } from "node:test";
 import {
+  CRITICAL_PACKAGES,
   EXIT_GREEN,
   EXIT_SANDBOX_DRIFT,
   EXIT_SANDBOX_NOT_READY,
@@ -14,6 +16,8 @@ import {
   isPnpmInstallCommand,
   parseEtimeMinutes,
   parseLockedVersion,
+  shouldForceConvergenceAfterInstall,
+  stalePackagePathsForRelink,
 } from "./sandbox-freshness.mjs";
 
 const LOCKFILE = `lockfileVersion: '9.0'
@@ -40,6 +44,9 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(vite@8.1.4)
 
   packages/db:
     devDependencies:
@@ -63,6 +70,7 @@ test("parseLockedVersion reads importer-scoped resolved versions", () => {
   assert.equal(parseLockedVersion(LOCKFILE, "apps/web", "next"), "16.2.9");
   assert.equal(parseLockedVersion(LOCKFILE, "apps/web", "react"), "19.2.7");
   assert.equal(parseLockedVersion(LOCKFILE, "apps/web", "react-dom"), "19.2.7");
+  assert.equal(parseLockedVersion(LOCKFILE, "apps/web", "vitest"), "4.1.10");
   assert.equal(parseLockedVersion(LOCKFILE, ".", "typescript"), "5.9.3");
   assert.equal(parseLockedVersion(LOCKFILE, "packages/db", "prisma"), "6.19.1");
   // Not in that importer / not in the file at all.
@@ -70,6 +78,12 @@ test("parseLockedVersion reads importer-scoped resolved versions", () => {
   assert.equal(parseLockedVersion(LOCKFILE, "apps/web", "left-pad"), "");
   // Must not leak into the top-level packages: section.
   assert.equal(parseLockedVersion(LOCKFILE, "packages", "next"), "");
+});
+
+test("critical package sentinels include the unit-test runner used by local-CI", () => {
+  const vitest = CRITICAL_PACKAGES.find((pkg) => pkg.name === "vitest");
+  assert.ok(vitest, "vitest must be checked before recording local-CI test evidence");
+  assert.ok(vitest.importers.includes("apps/web"));
 });
 
 test("isPnpmInstallCommand is token-exact", () => {
@@ -144,6 +158,84 @@ test("evaluateFreshness flags the incident shape: stale next link vs newer lockf
   assert.match(failures[0].message, /16\.2\.7/);
   assert.match(failures[0].message, /16\.2\.9/);
   assert.match(failures[0].message, /next@16\.2\.7/);
+});
+
+test("evaluateFreshness flags stale vitest before a missing CLI chunk becomes product evidence", () => {
+  const state = baseState();
+  state.packages.push({
+    name: "vitest",
+    importer: "apps/web",
+    lockedVersion: "4.1.10",
+    installedLockVersion: "4.1.10",
+    resolvedVersion: "4.1.9",
+    linkTarget: "../../../node_modules/.pnpm/vitest@4.1.9_hash/node_modules/vitest",
+    resolvedFrom: "/sandbox/node_modules/vitest",
+    missing: false,
+  });
+  const { verdict, failures } = evaluateFreshness(state);
+  assert.equal(verdict, "sandbox_drift");
+  assert.ok(failures.some((failure) => failure.kind === "version_drift" && failure.package === "vitest"));
+});
+
+test("evaluateFreshness flags broken package entrypoints as sandbox drift", () => {
+  const state = baseState();
+  state.packages.push({
+    name: "vitest",
+    importer: "apps/web",
+    lockedVersion: "4.1.10",
+    installedLockVersion: "4.1.10",
+    resolvedVersion: "4.1.10",
+    missingEntrypointImports: ["dist/chunks/cac.missing.js"],
+    missing: false,
+  });
+  const { verdict, failures } = evaluateFreshness(state);
+  assert.equal(verdict, "sandbox_drift");
+  assert.ok(failures.some((failure) => failure.kind === "package_broken" && failure.package === "vitest"));
+});
+
+
+test("stalePackagePathsForRelink returns only stale package links inside sandbox node_modules", () => {
+  const root = path.resolve("tmp", "dpf-local-ci");
+  const insideVitest = path.join(root, "node_modules", "vitest");
+  const outsideNext = path.resolve(root, "..", "outside", "node_modules", "next");
+  const state = baseState({
+    packages: [
+      {
+        name: "vitest",
+        importer: "apps/web",
+        lockedVersion: "4.1.10",
+        resolvedVersion: "4.1.9",
+        resolvedFrom: insideVitest,
+      },
+      {
+        name: "next",
+        importer: "apps/web",
+        lockedVersion: "16.2.9",
+        resolvedVersion: "16.2.7",
+        resolvedFrom: outsideNext,
+      },
+      {
+        name: "react",
+        importer: "apps/web",
+        lockedVersion: "19.2.7",
+        resolvedVersion: "19.2.7",
+        resolvedFrom: path.join(root, "node_modules", "react"),
+      },
+    ],
+  });
+  assert.deepEqual(stalePackagePathsForRelink(state, root), [insideVitest]);
+});
+
+test("shouldForceConvergenceAfterInstall is limited to dependency drift after install", () => {
+  assert.equal(shouldForceConvergenceAfterInstall({ verdict: "green", failures: [] }), false);
+  assert.equal(shouldForceConvergenceAfterInstall({
+    verdict: "sandbox_drift",
+    failures: [{ kind: "version_drift", package: "vitest" }],
+  }), true);
+  assert.equal(shouldForceConvergenceAfterInstall({
+    verdict: "sandbox_not_ready",
+    failures: [{ kind: "install_in_progress" }],
+  }), false);
 });
 
 test("evaluateFreshness flags a whole-lockfile mismatch the sentinels can't see (new dep added)", () => {

--- a/scripts/sandbox-freshness-preflight.mjs
+++ b/scripts/sandbox-freshness-preflight.mjs
@@ -5,7 +5,7 @@
 // Asserts, deterministically:
 //   1. the checkout matches the requested branch/SHA,
 //   2. node_modules/.pnpm/lock.yaml matches the checked-in pnpm-lock.yaml for
-//      the critical packages (next, react, react-dom, typescript, prisma),
+//      the critical packages (next, react, react-dom, typescript, prisma, vitest),
 //   3. the workspace links (e.g. apps/web/node_modules/next) resolve on disk
 //      to the locked versions — this is the check that catches a stale
 //      next@16.2.7 store link while the lockfile requires 16.2.9,
@@ -34,6 +34,8 @@ import {
   evaluateFreshness,
   exitCodeForVerdict,
   parseLockedVersion,
+  shouldForceConvergenceAfterInstall,
+  stalePackagePathsForRelink,
 } from "./lib/sandbox-freshness.mjs";
 
 const CONVERGE_LOCK_STALE_MS = 30 * 60_000;
@@ -113,6 +115,24 @@ function resolvePackageOnDisk(importerDir, name) {
   return { missing: true, resolvedVersion: "", linkTarget: lastLinkTarget, realPath: "", resolvedFrom: "" };
 }
 
+function missingEntrypointImports(packageDir, entrypoints = []) {
+  const missing = [];
+  for (const entrypoint of entrypoints) {
+    const entryPath = path.join(packageDir, entrypoint);
+    const source = readFileIfExists(entryPath);
+    if (!source) {
+      missing.push(entrypoint);
+      continue;
+    }
+    for (const match of source.matchAll(/(?:import|export)\s+(?:[^'"]*?\s+from\s+)?["'](\.[^"']+)["']/g)) {
+      const specifier = match[1];
+      const candidate = path.resolve(path.dirname(entryPath), specifier);
+      if (!fs.existsSync(candidate)) missing.push(path.relative(packageDir, candidate));
+    }
+  }
+  return [...new Set(missing)];
+}
+
 function collectState() {
   const lockfileText = readFileIfExists(path.join(rootDir, "pnpm-lock.yaml"));
   const installedLockPath = path.join(rootDir, "node_modules", ".pnpm", "lock.yaml");
@@ -141,6 +161,7 @@ function collectState() {
       resolvedVersion: onDisk.resolvedVersion,
       linkTarget: onDisk.linkTarget,
       resolvedFrom: onDisk.resolvedFrom,
+      missingEntrypointImports: onDisk.missing ? [] : missingEntrypointImports(onDisk.realPath, spec.entrypointImportChecks),
       missing: onDisk.missing,
     });
   }
@@ -214,7 +235,8 @@ if (state.installProcesses.length > 0) {
   finish(state, evaluation, { attempted: false, reason: "install_already_running" });
 }
 
-const lockDir = path.join(rootDir, "node_modules", ".dpf-freshness-converge.lock");
+const gitLockPath = git(rootDir, ["rev-parse", "--git-path", "dpf-freshness-converge.lock"]);
+const lockDir = gitLockPath ? path.resolve(rootDir, gitLockPath) : path.join(rootDir, ".dpf-freshness-converge.lock");
 try {
   fs.mkdirSync(lockDir, { recursive: false });
 } catch {
@@ -241,35 +263,103 @@ try {
 // apps/web/node_modules/next remained unresolvable). Removing pnpm's private
 // state forces a real link-reconciliation pass; the store stays warm, so this
 // costs seconds, not a re-download.
-for (const staleState of [
-  path.join(rootDir, "node_modules", ".pnpm", "lock.yaml"),
-  path.join(rootDir, "node_modules", ".modules.yaml"),
-]) {
-  try {
-    fs.rmSync(staleState, { force: true });
-  } catch (error) {
-    console.error(`[sandbox-freshness] could not clear ${staleState}: ${error.message}`);
+function clearPnpmInstallState() {
+  for (const staleState of [
+    path.join(rootDir, "node_modules", ".pnpm", "lock.yaml"),
+    path.join(rootDir, "node_modules", ".modules.yaml"),
+  ]) {
+    try {
+      fs.rmSync(staleState, { force: true });
+    } catch (error) {
+      console.error(`[sandbox-freshness] could not clear ${staleState}: ${error.message}`);
+    }
   }
 }
 
-const convergeCommand = ["pnpm", "install", "--frozen-lockfile", "--config.confirmModulesPurge=false"];
-log(`drift detected; converging with: ${convergeCommand.join(" ")}`);
-const startedAt = Date.now();
-const install = spawnSync(convergeCommand[0], convergeCommand.slice(1), {
-  cwd: rootDir,
-  stdio: quiet ? "ignore" : "inherit",
-  shell: process.platform === "win32",
-});
-fs.rmSync(lockDir, { recursive: true, force: true });
-convergence = {
-  attempted: true,
-  command: convergeCommand.join(" "),
-  exitCode: install.status ?? 1,
-  durationMs: Date.now() - startedAt,
-};
+function clearStalePackageLinks(packageState) {
+  for (const stalePackagePath of stalePackagePathsForRelink(packageState, rootDir)) {
+    try {
+      fs.rmSync(stalePackagePath, { recursive: true, force: true });
+      log(`removed stale package link before relink: ${path.relative(rootDir, stalePackagePath)}`);
+    } catch (error) {
+      console.error(`[sandbox-freshness] could not clear stale package link ${stalePackagePath}: ${error.message}`);
+    }
+  }
+}
 
-state = collectState();
-evaluation = evaluateFreshness(state);
+function canResetNodeModules() {
+  return path.basename(rootDir).toLowerCase() === ".local-ci-runner"
+    || process.env.DPF_ALLOW_SANDBOX_NODE_MODULES_RESET === "1";
+}
+
+function resetSandboxNodeModules() {
+  if (!canResetNodeModules()) return false;
+  const target = path.join(rootDir, "node_modules");
+  const resolved = path.resolve(target);
+  if (path.relative(rootDir, resolved) !== "node_modules") return false;
+  try {
+    const stat = fs.lstatSync(resolved);
+    if (stat.isSymbolicLink()) {
+      console.error(`[sandbox-freshness] refusing full node_modules reset because ${resolved} is a symlink/junction`);
+      return false;
+    }
+  } catch {
+    return true;
+  }
+  fs.rmSync(resolved, { recursive: true, force: true });
+  log("reset scratch sandbox node_modules after package-level convergence could not repair dependency drift");
+  return true;
+}
+
+function runConvergenceAttempt(packageState, { force = false, resetNodeModules = false } = {}) {
+  if (resetNodeModules) resetSandboxNodeModules();
+  clearPnpmInstallState();
+  clearStalePackageLinks(packageState);
+  const convergeCommand = ["pnpm", "install"];
+  if (force) convergeCommand.push("--force");
+  convergeCommand.push("--frozen-lockfile", "--config.confirmModulesPurge=false");
+  log(`drift detected; converging with: ${convergeCommand.join(" ")}`);
+  const startedAt = Date.now();
+  const install = spawnSync(convergeCommand[0], convergeCommand.slice(1), {
+    cwd: rootDir,
+    stdio: quiet ? "ignore" : "inherit",
+    shell: process.platform === "win32",
+  });
+  return {
+    attempted: true,
+    command: convergeCommand.join(" "),
+    exitCode: install.status ?? 1,
+    durationMs: Date.now() - startedAt,
+    resetNodeModules,
+  };
+}
+
+const attempts = [];
+try {
+  attempts.push(runConvergenceAttempt(state));
+  convergence = { ...attempts[attempts.length - 1], attempts };
+  state = collectState();
+  evaluation = evaluateFreshness(state);
+
+  if (shouldForceConvergenceAfterInstall(evaluation)) {
+    log("first convergence left dependency drift; retrying once with --force to refresh the sandbox store/link graph");
+    attempts.push(runConvergenceAttempt(state, { force: true }));
+    convergence = { ...attempts[attempts.length - 1], attempts };
+    state = collectState();
+    evaluation = evaluateFreshness(state);
+  }
+
+  if (shouldForceConvergenceAfterInstall(evaluation) && canResetNodeModules()) {
+    log("forced convergence left dependency drift; resetting scratch node_modules once and reinstalling from the lockfile");
+    attempts.push(runConvergenceAttempt(state, { resetNodeModules: true }));
+    convergence = { ...attempts[attempts.length - 1], attempts };
+    state = collectState();
+    evaluation = evaluateFreshness(state);
+  }
+} finally {
+  fs.rmSync(lockDir, { recursive: true, force: true });
+}
+
 if (convergence.exitCode !== 0 && evaluation.verdict === "green") {
   // Trust the re-check, but surface the installer's own failure.
   evaluation = {

--- a/scripts/sandbox-freshness-preflight.test.mjs
+++ b/scripts/sandbox-freshness-preflight.test.mjs
@@ -2,7 +2,8 @@
 // Builds a fake pnpm-style workspace on disk — store dirs under
 // node_modules/.pnpm plus workspace symlinks — and asserts the CLI detects the
 // exact incident shape (apps/web/node_modules/next -> next@16.2.7 store path
-// while pnpm-lock.yaml requires 16.2.9) with the reserved exit codes.
+// while pnpm-lock.yaml requires 16.2.9, and the same shape for vitest) with the
+// reserved exit codes.
 // node --test scripts/sandbox-freshness-preflight.test.mjs — pure node, no docker.
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
@@ -10,8 +11,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
-const cli = new URL("./sandbox-freshness-preflight.mjs", import.meta.url).pathname;
+const cli = fileURLToPath(new URL("./sandbox-freshness-preflight.mjs", import.meta.url));
 
 const PACKAGES = [
   { name: "next", importer: "apps/web", version: "16.2.9" },
@@ -19,6 +21,7 @@ const PACKAGES = [
   { name: "react-dom", importer: "apps/web", version: "19.2.7" },
   { name: "typescript", importer: ".", version: "5.9.3" },
   { name: "prisma", importer: "packages/db", version: "6.19.1" },
+  { name: "vitest", importer: "apps/web", version: "4.1.10" },
 ];
 
 function lockfileText(versions) {
@@ -55,9 +58,14 @@ function scaffold({ installedVersions = {}, lockedVersions = {}, installedLockVe
     const storeDir = join(root, "node_modules", ".pnpm", `${pkg.name}@${version}_fakehash`, "node_modules", pkg.name);
     mkdirSync(storeDir, { recursive: true });
     writeFileSync(join(storeDir, "package.json"), JSON.stringify({ name: pkg.name, version }));
+    if (pkg.name === "vitest") {
+      mkdirSync(join(storeDir, "dist", "chunks"), { recursive: true });
+      writeFileSync(join(storeDir, "dist", "cli.js"), "import './chunks/cac.ok.js';\n");
+      writeFileSync(join(storeDir, "dist", "chunks", "cac.ok.js"), "export default {};\n");
+    }
     const importerNodeModules = pkg.importer === "." ? join(root, "node_modules") : join(root, pkg.importer, "node_modules");
     mkdirSync(importerNodeModules, { recursive: true });
-    symlinkSync(storeDir, join(importerNodeModules, pkg.name), "dir");
+    symlinkSync(storeDir, join(importerNodeModules, pkg.name), process.platform === "win32" ? "junction" : "dir");
   }
   return root;
 }
@@ -106,6 +114,32 @@ test("detects the incident: stale next@16.2.7 store link while lockfile requires
   rmSync(root, { recursive: true, force: true });
 });
 
+test("detects stale vitest before the test runner fails on missing packaged chunks", () => {
+  const root = scaffold({
+    installedVersions: { vitest: "4.1.9" },
+    lockedVersions: { vitest: "4.1.10" },
+    installedLockVersions: { vitest: "4.1.9" },
+  });
+  const { result, report } = runPreflight(root);
+  assert.equal(result.status, 3, `expected SANDBOX_DRIFT exit 3, got ${result.status}\n${result.stderr}`);
+  assert.equal(report.verdict, "sandbox_drift");
+  assert.ok(report.failures.some((f) => f.kind === "version_drift" && f.package === "vitest"));
+  const vitest = report.packages.find((p) => p.name === "vitest");
+  assert.equal(vitest.lockedVersion, "4.1.10");
+  assert.equal(vitest.resolvedVersion, "4.1.9");
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("detects a broken vitest entrypoint even when package.json reports the locked version", () => {
+  const root = scaffold();
+  rmSync(join(root, "node_modules", ".pnpm", "vitest@4.1.10_fakehash", "node_modules", "vitest", "dist", "chunks", "cac.ok.js"), { force: true });
+  const { result, report } = runPreflight(root);
+  assert.equal(result.status, 3, `expected SANDBOX_DRIFT exit 3, got ${result.status}\n${result.stderr}`);
+  assert.ok(report.failures.some((f) => f.kind === "package_broken" && f.package === "vitest"));
+  assert.match(result.stderr, /incomplete/);
+  rmSync(root, { recursive: true, force: true });
+});
+
 test("resolves hoisted layouts (node-linker=hoisted) via Node-style walk-up", () => {
   // No per-importer links at all: packages live flat at the root node_modules,
   // as pnpm's hoisted linker (and npm) lay them out. The runtime resolves
@@ -120,13 +154,18 @@ test("resolves hoisted layouts (node-linker=hoisted) via Node-style walk-up", ()
     const dir = join(root, "node_modules", pkg.name);
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "package.json"), JSON.stringify({ name: pkg.name, version: pkg.version }));
+    if (pkg.name === "vitest") {
+      mkdirSync(join(dir, "dist", "chunks"), { recursive: true });
+      writeFileSync(join(dir, "dist", "cli.js"), "import './chunks/cac.ok.js';\n");
+      writeFileSync(join(dir, "dist", "chunks", "cac.ok.js"), "export default {};\n");
+    }
   }
   const { result, report } = runPreflight(root);
   assert.equal(result.status, 0, result.stderr);
   assert.equal(report.verdict, "green");
   const next = report.packages.find((p) => p.name === "next");
   assert.equal(next.resolvedVersion, "16.2.9");
-  assert.match(next.resolvedFrom, /node_modules\/next$/);
+  assert.match(next.resolvedFrom, /node_modules[\\/]next$/);
   rmSync(root, { recursive: true, force: true });
 });
 
@@ -161,7 +200,7 @@ test("--converge refuses a duplicate convergence while the lock is held", () => 
     installedVersions: { next: "16.2.7" },
     lockedVersions: { next: "16.2.9" },
   });
-  mkdirSync(join(root, "node_modules", ".dpf-freshness-converge.lock"), { recursive: true });
+  mkdirSync(join(root, ".dpf-freshness-converge.lock"), { recursive: true });
   const { result, report } = runPreflight(root, ["--converge"]);
   assert.equal(result.status, 4, `${result.stdout}\n${result.stderr}`);
   assert.equal(report.convergence.attempted, false);


### PR DESCRIPTION
## Summary
- warn at session start when DPF-native replacement skills are installed but active exposure cannot be proven
- keep bootstrap/readiness output plain-language and distinct between installed-on-disk and loaded/exposed-in-session evidence
- classify stale or incomplete Vitest in the local-CI scratch runner as sandbox drift before product gates run, with bounded native repair attempts and scoped scratch reset
- record follow-up BI-4D852EC2 for the remaining pnpm hoisted runner root cause

## Verification
- `node --test scripts/lib/sandbox-freshness.test.mjs scripts/sandbox-freshness-preflight.test.mjs`
- `node --test packages/dpf-skill-pack/hooks/process-spine-health.test.mjs`
- `python packages\dpf-skill-pack\scripts\update_agent_toolchain_test.py`
- `node packages\dpf-skill-pack\hooks\process-spine-health-check.mjs --hook`
- `node scripts\check-no-retired-superpowers-skills.mjs`
- `git diff --check`

## Runtime evidence
- `node scripts\sandbox-freshness-preflight.mjs --dir D:\DPF-worktrees\.local-ci-runner` fails closed with `sandbox_drift` for stale/incomplete Vitest.
- Remaining root-cause repair is tracked as BI-4D852EC2; this PR prevents that drift from being recorded as product test evidence.

Process-Spine-Decision: DI-F548CFA4095C
Local-CI-Override: local-CI sandbox preflight fails closed with sandbox_drift for stale/incomplete Vitest in D:\DPF-worktrees\.local-ci-runner; root-cause repair is tracked as BI-4D852EC2 and capsule WC-5115B693 evidence. Focused source tests and guards passed; this PR prevents broken runner state from becoming product evidence.

Design-Grounding-Decision: reviewed docs/superpowers/specs/2026-07-19-process-spine-skill-exposure-health-design.md, docs/testing/pre-pr-gate.md, and code substrate packages/dpf-skill-pack/hooks/process-spine-health-check.mjs plus scripts/sandbox-freshness-preflight.mjs; this is a process-spine readiness and sandbox-evidence repair, with no UI route or coworker authority change.

UX-Fit-Decision: fits-with-guardrails. No app route or user-facing control changes; readiness output reduces operator cognitive load by distinguishing installed-on-disk from loaded/exposed-in-session in plain language.
Seed-Fit-Decision: global-default
