### PR TITLE
fix: refresh cached DPF plugins on bootstrap

### DIFF
--- a/docs/superpowers/plans/2026-07-19-plan-backlog-coverage-enforcement.md
+++ b/docs/superpowers/plans/2026-07-19-plan-backlog-coverage-enforcement.md
@@ -68,3 +68,12 @@ Run targeted tests and web typecheck in the compile-ready worktree. Lease `local
 ## Architecture review
 
 The DPF architecture-review pass is aligned. The correction reuses `BacklogItem`, `BacklogItemActivity`, Work Capsule branch claims, the existing decomposition transaction, MCP tool packs, and the versioned plugin installer; it adds no table, lifecycle enum, or competing plan registry. The review identified two atomicity/distribution risks that were folded into implementation: the Build Studio atomic override now writes its design update and coverage activity in one transaction, and the standalone updater explicitly installs the write guard into Codex and Grok hook planes rather than assuming bundled plugin hooks are live. The one-time bootstrap receipt uses governed manual evidence because the dedicated recorder cannot precede its own landing; the read tool validates that envelope with the same live invariant.
+
+## Post-merge acceptance correction
+
+The first real 0.2.3 refresh proved that copying the managed plugin and invoking each CLI's `install` command was insufficient: Claude retained an older cached plugin, while Grok rejected the duplicate install and retained 0.2.2. The updater must therefore exercise each client's replacement path, not merely report that the marketplace and managed copy converged.
+
+- Claude runs `plugin update` after marketplace registration and installation so an existing cache advances to the manifest version.
+- Grok detects an installed DPF plugin, preserves its data, uninstalls the stale cache, and reinstalls from the refreshed managed copy.
+- Plugin manifests advance to 0.2.4 and the process-spine version advances to 2026.07.20.1 so new sessions have explicit refresh boundaries.
+- Fixture tests cover both a fresh Grok install and stale-cache replacement, plus the Claude update command.

--- a/packages/dpf-skill-pack/.antigravity-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.antigravity-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dpf-platform",
   "description": "DPF-native agent skills for Google Antigravity contributors. Single-source-of-truth contract: superset SKILL.md frontmatter feeds external Antigravity users (agy CLI + IDE) and in-portal coworkers alike. Hook consumption on the Antigravity surface is pending functional confirmation (EP-ANTIGRAVITY-001 evidence gate BI-47A81FEB) — until confirmed, comply with the lease/worktree contract by construction. See README.md.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": {
     "name": "Digital Product Factory",
     "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"

--- a/packages/dpf-skill-pack/.claude-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dpf-platform",
   "description": "DPF-native agent skills for both Claude Code contributors (plugin namespace dpf-platform:*) and in-portal coworkers (seeded as SkillDefinition rows by the extended seed-skills.ts loader). Single-source-of-truth contract: superset SKILL.md frontmatter feeds both surfaces from one file per skill. See README.md.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": {
     "name": "Digital Product Factory",
     "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"

--- a/packages/dpf-skill-pack/.codex-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dpf-platform",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "DPF-native agent skills for contributor sessions and in-portal coworkers.",
   "author": {
     "name": "Digital Product Factory",

--- a/packages/dpf-skill-pack/.grok-plugin/plugin.json
+++ b/packages/dpf-skill-pack/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dpf-platform",
   "description": "DPF-native agent skills for Grok contributors. Single-source-of-truth contract: superset SKILL.md frontmatter feeds both external Grok users and in-portal coworkers. See README.md.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": {
     "name": "Digital Product Factory",
     "url": "https://github.com/OpenDigitalProductFactory/opendigitalproductfactory"

--- a/packages/dpf-skill-pack/process-spine-version.mjs
+++ b/packages/dpf-skill-pack/process-spine-version.mjs
@@ -2,4 +2,4 @@
 // Bump when hook wiring, skill-pack distribution, or spine enforcement changes
 // so installs can detect drift and re-run bootstrap.
 
-export const PROCESS_SPINE_VERSION = "2026.07.19.1";
+export const PROCESS_SPINE_VERSION = "2026.07.20.1";

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain.py
@@ -282,7 +282,8 @@ def render_process_spine_cleanup_policy(policy: dict[str, Any]) -> list[str]:
     mode = str(policy.get("mode", "unspecified"))
     lines.append(
         f"  Policy: {mode} - rerun bootstrap/updater after DPF skill-pack changes; "
-        "safe adapters never delete user-owned skill files or plugin caches."
+        "safe adapters preserve user-owned skills and unmanaged plugin data. A managed "
+        "DPF client cache may be replaced through that client's plugin CLI."
     )
     for client in policy.get("clients", []):
         name = str(client.get("client", "client")).capitalize()
@@ -552,12 +553,13 @@ def install_claude_plugin(home: Path, dry_run: bool) -> str:
     commands = [
         [claude, "plugin", "marketplace", "add", str(marketplace_root), "--scope", "local"],
         [claude, "plugin", "install", f"{PLUGIN_NAME}@{MARKETPLACE_NAME}", "--scope", "local"],
+        [claude, "plugin", "update", f"{PLUGIN_NAME}@{MARKETPLACE_NAME}", "--scope", "local"],
     ]
     for command in commands:
         result = subprocess.run(command, cwd=str(marketplace_root), capture_output=True, text=True)
         if result.returncode != 0:
             return f"failed: {' '.join(command[:3])} exited {result.returncode}"
-    return "installed"
+    return "installed and refreshed"
 
 
 def resolve_codex_binary() -> str | None:
@@ -685,6 +687,31 @@ def install_grok_plugin(managed: Path, dry_run: bool) -> str:
         return "skipped: Grok CLI not found"
     if dry_run:
         return f"dry-run: would install {PLUGIN_NAME} from {managed}"
+
+    list_result = subprocess.run(
+        [grok, "plugin", "list", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if list_result.returncode != 0:
+        return f"failed: grok plugin list exited {list_result.returncode}"
+    try:
+        installed_plugins = json.loads(list_result.stdout or "[]")
+    except json.JSONDecodeError:
+        return "failed: grok plugin list returned invalid JSON"
+    already_installed = any(
+        isinstance(plugin, dict) and plugin.get("name") == PLUGIN_NAME
+        for plugin in installed_plugins
+    )
+    if already_installed:
+        uninstall_result = subprocess.run(
+            [grok, "plugin", "uninstall", PLUGIN_NAME, "--confirm", "--keep-data"],
+            capture_output=True,
+            text=True,
+        )
+        if uninstall_result.returncode != 0:
+            return f"failed: grok plugin uninstall exited {uninstall_result.returncode}"
+
     result = subprocess.run(
         [grok, "plugin", "install", str(managed), "--trust"],
         capture_output=True,
@@ -692,7 +719,7 @@ def install_grok_plugin(managed: Path, dry_run: bool) -> str:
     )
     if result.returncode != 0:
         return f"failed: grok plugin install exited {result.returncode}"
-    return "installed"
+    return "reinstalled" if already_installed else "installed"
 
 
 # PreToolUse guards to wire into Grok's hook plane. Blocking safety/decision

--- a/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
+++ b/packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py
@@ -356,7 +356,7 @@ class GrokInstallTest(unittest.TestCase):
     def test_install_invokes_grok_plugin_install_trust_from_managed(self) -> None:
         class _Result:
             returncode = 0
-            stdout = ""
+            stdout = "[]"
             stderr = ""
 
         with patch.object(updater, "resolve_grok_binary", return_value="/fake/grok"), patch(
@@ -364,9 +364,36 @@ class GrokInstallTest(unittest.TestCase):
         ) as run:
             status = updater.install_grok_plugin(Path("/tmp/managed"), dry_run=False)
         self.assertEqual(status, "installed")
-        run.assert_called_once()
-        argv = run.call_args[0][0]
+        self.assertEqual(run.call_count, 2)
+        self.assertEqual(run.call_args_list[0][0][0], ["/fake/grok", "plugin", "list", "--json"])
+        argv = run.call_args_list[1][0][0]
         self.assertEqual(argv, ["/fake/grok", "plugin", "install", str(Path("/tmp/managed")), "--trust"])
+
+    def test_existing_grok_plugin_is_reinstalled_from_refreshed_managed_copy(self) -> None:
+        class _Result:
+            def __init__(self, stdout: str = "") -> None:
+                self.returncode = 0
+                self.stdout = stdout
+                self.stderr = ""
+
+        results = [
+            _Result('[{"name":"dpf-platform","version":"0.2.2"}]'),
+            _Result(),
+            _Result(),
+        ]
+        with patch.object(updater, "resolve_grok_binary", return_value="/fake/grok"), patch(
+            "subprocess.run", side_effect=results
+        ) as run:
+            status = updater.install_grok_plugin(Path("/tmp/managed"), dry_run=False)
+        self.assertEqual(status, "reinstalled")
+        self.assertEqual(
+            [call[0][0] for call in run.call_args_list],
+            [
+                ["/fake/grok", "plugin", "list", "--json"],
+                ["/fake/grok", "plugin", "uninstall", "dpf-platform", "--confirm", "--keep-data"],
+                ["/fake/grok", "plugin", "install", str(Path("/tmp/managed")), "--trust"],
+            ],
+        )
 
     def test_install_reports_failure_without_raising(self) -> None:
         class _Result:
@@ -379,6 +406,28 @@ class GrokInstallTest(unittest.TestCase):
         ):
             status = updater.install_grok_plugin(Path("/tmp/managed"), dry_run=False)
         self.assertIn("failed", status)
+
+
+class ClaudeInstallTest(unittest.TestCase):
+    def test_install_also_updates_an_existing_cached_plugin(self) -> None:
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        with patch.object(updater, "resolve_claude_binary", return_value="/fake/claude"), patch(
+            "subprocess.run", return_value=_Result()
+        ) as run:
+            status = updater.install_claude_plugin(Path("/tmp/home"), dry_run=False)
+        self.assertEqual(status, "installed and refreshed")
+        self.assertEqual(
+            [call[0][0] for call in run.call_args_list],
+            [
+                ["/fake/claude", "plugin", "marketplace", "add", "/tmp/home/.agents/plugins", "--scope", "local"],
+                ["/fake/claude", "plugin", "install", "dpf-platform@dpf-platform-local", "--scope", "local"],
+                ["/fake/claude", "plugin", "update", "dpf-platform@dpf-platform-local", "--scope", "local"],
+            ],
+        )
 
 
 class AntigravityMcpConfigTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- make the standalone DPF updater refresh an existing Claude cache after marketplace/install convergence
- make Grok replace its managed DPF cache through the client CLI while preserving plugin data
- advance plugin and process-spine versions so new external-agent tasks can detect and load the correction

## Governed work

- Backlog item: BI-C24C83FA
- Parent implementation: #3307
- Decision: DI-150BA6EB980F
- Plan: docs/superpowers/plans/2026-07-19-plan-backlog-coverage-enforcement.md

## Verification

- `python3 -m unittest packages/dpf-skill-pack/scripts/update_agent_toolchain_test.py` — 32 passed, 4 skipped
- plugin/process fixture suite — 171 passed
- actual updater refresh — Claude local 0.2.4; Grok 0.2.4; installed guard hashes match source
- local merged-code gate — 414 migrations, full tests, typecheck, production build passed for ba4021647
- staged/tree Gitleaks — passed

## Process attestations

Process-Spine-Decision: The existing governed plan is updated with the post-merge acceptance finding; no separate design is needed because this PR corrects distribution of the already-approved cross-surface invariant.
Seed-Fit-Decision: global-default — plugin manifests and bootstrap behavior must converge identically for every DPF external-agent install.