### PR TITLE
Add external-agent PR readiness preflight

### DIFF
--- a/docs/superpowers/plans/2026-07-20-external-pr-readiness-orchestrator.md
+++ b/docs/superpowers/plans/2026-07-20-external-pr-readiness-orchestrator.md
@@ -1,0 +1,78 @@
+# External-Agent PR Readiness Orchestrator Implementation Plan
+
+> **For agentic workers:** Follow the repository `AGENTS.md` contract: one worktree and PR per independently shippable slice, tests before implementation, DCO-signed commits, governed runtime verification, and ready-only pull requests. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Backlog item:** `BI-E0D662DD`
+
+**Goal:** Add a source-local pre-PR readiness orchestrator that catches DPF governance and evidence issues before GitHub Actions is the first reporter.
+
+**Architecture:** A new `scripts/pr-readiness.mjs` CLI gathers Git state, computes the exact branch diff against fresh `origin/main`, validates PR-body trailers, runs existing local gate scripts, and prints a plain-language verdict. Pure decision logic lives in `scripts/pr-readiness/core.mjs` so Node tests can cover the policy without shelling out.
+
+**Tech Stack:** Node.js ESM, `node:test`, existing DPF gate scripts under `scripts/check-*.mjs`, and the existing shared-safe Git fetch helper.
+
+---
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-E0D662DD`
+- Receipt: `WC-6D2D82B8`
+- Dependencies: none
+- Rationale: The BI describes one independently shippable tool surface: a pre-PR readiness orchestrator for external agents. The gate coverage, trailer validation, diff hygiene, and operator output are all part of the same executable contract, so splitting them would create a partial tool that cannot satisfy the backlog outcome.
+
+## Design grounding
+
+- Existing specs/plans reviewed:
+  - `docs/superpowers/specs/2026-05-30-development-process-spine-design.md`
+  - `docs/superpowers/plans/2026-07-12-design-grounding-gate.md`
+  - `docs/superpowers/plans/2026-07-11-seed-contribution-fit-gate.md`
+  - `docs/testing/pr-health.md`
+- Current code substrate reviewed:
+  - `scripts/pr-health.mjs`
+  - `.github/workflows/ci.yml`
+  - `scripts/check-spec-plan-doc.mjs`
+  - `scripts/check-plan-backlog-coverage.mjs`
+  - `scripts/check-seed-fit-decision.mjs`
+  - `scripts/check-ux-fit-decision.mjs`
+  - `scripts/check-design-grounding-decision.mjs`
+  - `scripts/check-data-impact.mjs`
+  - `scripts/check-docs-impact.mjs`
+  - `scripts/check-doc-reference-integrity.mjs`
+  - `scripts/check-no-retired-superpowers-skills.mjs`
+  - `scripts/lib/git-fetch-shared-safe.mjs`
+- Source of truth: Existing CI gate scripts remain authoritative; the orchestrator composes them and adds pre-PR Git/trailer checks.
+- Decision: Add a separate `pr-readiness` preflight instead of broadening `pr-health`, because `pr-health` is intentionally post-PR and GitHub-state based.
+
+## Tasks
+
+### Task 1: Pure readiness policy
+
+**Files:**
+- Create: `scripts/pr-readiness/core.mjs`
+- Create: `scripts/pr-readiness.test.mjs`
+
+- [ ] Write failing tests for shallow history, ambiguous merge-base, dirty/unpushed work, missing DCO, trailer validation, and gate definition coverage.
+- [ ] Implement the smallest pure policy functions that make those tests pass.
+- [ ] Refactor the result model until every blocker/warning has a stable operator-facing message.
+
+### Task 2: CLI runner
+
+**Files:**
+- Create: `scripts/pr-readiness.mjs`
+- Modify: `package.json`
+
+- [ ] Add a CLI that fetches `origin/main` using the shared-safe helper.
+- [ ] Gather branch, merge-base, diff, working tree, ahead/behind, and commit trailer state with `git`.
+- [ ] Run the local gate script plan with `BASE_SHA=origin/main`, `PR_BODY`, `PR_LABELS_JSON=[]`, and `GITHUB_EVENT_NAME=pull_request`.
+- [ ] Add `pnpm pr:ready` as the operator entry point.
+
+### Task 3: Verification and delivery
+
+**Files:**
+- Test: `scripts/pr-readiness.test.mjs`
+- Test: affected existing gate scripts through the orchestrator
+
+- [ ] Run the new tests and the orchestrator against this branch.
+- [ ] Run relevant existing script tests for gates composed by the orchestrator.
+- [ ] Run source-local type/check gates that do not require the runtime sandbox.
+- [ ] Commit with DCO sign-off, push, and record evidence on `WC-6D2D82B8`.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check:lifecycle-surfaces": "node --test scripts/lifecycle-surface-policy.test.mjs",
     "test:endpoints": "tsx scripts/test-endpoints.ts",
     "verify:preflight": "tsx scripts/dpf-verify-preflight.ts",
+    "pr:ready": "node scripts/pr-readiness.mjs",
     "check:bundle-boundaries": "node scripts/check-bundle-boundaries.mjs",
     "check:diagram-dependency-pins": "node scripts/check-diagram-dependency-pins.mjs",
     "check:reporting-composition": "node scripts/check-reporting-composition.mjs",

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Pre-PR readiness orchestrator for external agents.
+//
+// `pr-health` answers "is an existing GitHub PR merge-ready?" This script
+// answers the earlier question: "is this local branch ready to become or re-enter
+// a PR without letting GitHub Actions discover the first obvious blocker?"
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { buildGatePlan, evaluateReadiness, formatReadinessReport } from "./pr-readiness/core.mjs";
+import { fetchOriginMainSharedSafe, isShallowRepository } from "./lib/git-fetch-shared-safe.mjs";
+
+function git(args, { allowFail = false } = {}) {
+  try {
+    return execFileSync("git", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch (error) {
+    if (allowFail) return error.stdout?.toString() ?? "";
+    throw error;
+  }
+}
+
+function parseArgs(argv) {
+  const args = { prBody: process.env.PR_BODY || "", prLabelsJson: process.env.PR_LABELS_JSON || "[]", runGates: true };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--pr-body-file") {
+      args.prBody = readFileSync(argv[++i], "utf8");
+    } else if (arg === "--pr-body") {
+      args.prBody = argv[++i] ?? "";
+    } else if (arg === "--labels-json") {
+      args.prLabelsJson = argv[++i] ?? "[]";
+    } else if (arg === "--skip-gates") {
+      args.runGates = false;
+    } else if (arg === "-h" || arg === "--help") {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function usage() {
+  return [
+    "Usage: node scripts/pr-readiness.mjs [--pr-body-file path | --pr-body text] [--labels-json json] [--skip-gates]",
+    "",
+    "Runs local pre-PR governance checks against the exact diff from current origin/main to HEAD.",
+    "Exit 0 means safe to open or queue the PR. Exit 1 means fix the listed blockers first.",
+  ].join("\n");
+}
+
+function readCommits() {
+  const raw = git(["log", "origin/main..HEAD", "--format=%H%x1f%s%x1f%B%x1e"], { allowFail: true });
+  return raw
+    .split("\x1e")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [sha, subject, ...bodyParts] = entry.split("\x1f");
+      return { sha: sha ?? "", subject: subject ?? "", body: bodyParts.join("\x1f") };
+    });
+}
+
+function readAheadBehind(upstream) {
+  if (!upstream) {
+    const ahead = Number.parseInt(git(["rev-list", "--count", "origin/main..HEAD"], { allowFail: true }).trim() || "0", 10);
+    return { ahead, behind: 0 };
+  }
+  const [behind, ahead] = git(["rev-list", "--left-right", "--count", `${upstream}...HEAD`], { allowFail: true })
+    .trim()
+    .split(/\s+/)
+    .map((n) => Number.parseInt(n || "0", 10));
+  return { ahead: Number.isFinite(ahead) ? ahead : 0, behind: Number.isFinite(behind) ? behind : 0 };
+}
+
+function readRepoState() {
+  fetchOriginMainSharedSafe((args) => git(args));
+
+  const branch = git(["rev-parse", "--abbrev-ref", "HEAD"]).trim();
+  const upstream = git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], { allowFail: true }).trim();
+  const aheadBehind = readAheadBehind(upstream);
+  const mergeBases = git(["merge-base", "--all", "origin/main", "HEAD"], { allowFail: true })
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const changedFiles = git(["diff", "--name-only", "origin/main...HEAD"], { allowFail: true })
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return {
+    branch,
+    isDetached: branch === "HEAD",
+    isShallow: isShallowRepository((args) => git(args)),
+    mergeBases,
+    changedFiles,
+    statusPorcelain: git(["status", "--porcelain"], { allowFail: true }),
+    upstream: upstream || null,
+    ahead: aheadBehind.ahead,
+    behind: aheadBehind.behind,
+    commits: readCommits(),
+  };
+}
+
+function runGate(gate) {
+  const [command, args] = gate.command;
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    env: { ...process.env, ...gate.env },
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return {
+    name: gate.name,
+    ok: result.status === 0,
+    exitCode: result.status ?? 1,
+    output: [result.stdout, result.stderr].filter(Boolean).join("\n").trim(),
+  };
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv);
+  } catch (error) {
+    console.error(`pr-readiness: ${error.message}`);
+    console.error(usage());
+    process.exit(2);
+  }
+  if (args.help) {
+    console.log(usage());
+    process.exit(0);
+  }
+
+  let repo;
+  try {
+    repo = readRepoState();
+  } catch (error) {
+    console.error(`pr-readiness: could not read repository state: ${error.message}`);
+    process.exit(2);
+  }
+
+  const gatePlan = buildGatePlan({ prBody: args.prBody, prLabelsJson: args.prLabelsJson });
+  const gateResults = args.runGates ? gatePlan.map(runGate) : [];
+  const verdict = evaluateReadiness({ repo, gateResults, prBody: args.prBody });
+  process.stdout.write(formatReadinessReport(verdict));
+  process.exit(verdict.ready ? 0 : 1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/pr-readiness.test.mjs
+++ b/scripts/pr-readiness.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildGatePlan,
+  evaluateReadiness,
+  formatReadinessReport,
+  parsePrBodyTrailers,
+  validatePrBodyTrailers,
+} from "./pr-readiness/core.mjs";
+
+const cleanRepo = {
+  branch: "feat/example",
+  isDetached: false,
+  isShallow: false,
+  mergeBases: ["abc123"],
+  changedFiles: ["apps/web/lib/example.ts"],
+  statusPorcelain: "",
+  upstream: "origin/feat/example",
+  ahead: 0,
+  behind: 0,
+  commits: [
+    {
+      sha: "1111111",
+      subject: "feat: add example",
+      body: "feat: add example\n\nSigned-off-by: Mark Bodman <markdbodman@gmail.com>",
+    },
+  ],
+};
+
+test("buildGatePlan mirrors pre-PR governance gates that CI owns", () => {
+  const plan = buildGatePlan({ prBody: "UX-Fit-Decision: no-ui-change", prLabelsJson: "[]" });
+  assert.deepEqual(
+    plan.map((gate) => gate.name),
+    [
+      "Spec/Plan/Doc Gate",
+      "Plan Backlog Coverage Gate",
+      "Seed Contribution Fit Gate",
+      "UX-Fit Gate",
+      "Design Grounding Gate",
+      "Data-Impact Gate",
+      "Docs Impact Gate",
+      "Doc Link Integrity",
+      "Doc Reference Integrity",
+      "Retired Superpowers Skill Guard",
+    ],
+  );
+  assert.equal(plan[0].env.BASE_SHA, "origin/main");
+  assert.equal(plan[2].env.GITHUB_EVENT_NAME, "pull_request");
+  assert.equal(plan[2].env.PR_LABELS_JSON, "[]");
+});
+
+test("parsePrBodyTrailers extracts supported trailers with line numbers", () => {
+  const trailers = parsePrBodyTrailers("Intro\n\nUX-Fit-Decision: compact-controls\nLocal-CI-Override: docs only");
+  assert.deepEqual(trailers.map((trailer) => [trailer.name, trailer.value, trailer.line]), [
+    ["UX-Fit-Decision", "compact-controls", 3],
+    ["Local-CI-Override", "docs only", 4],
+  ]);
+});
+
+test("validatePrBodyTrailers catches duplicate trailers and invalid seed-fit decisions", () => {
+  const result = validatePrBodyTrailers(
+    [
+      "Seed-Fit-Decision: install-local",
+      "Seed-Fit-Decision: global-default",
+      "Local-CI-Evidence: RV-1",
+      "Local-CI-Override: operator skipped",
+    ].join("\n"),
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.blockers.join("\n"), /Seed-Fit-Decision appears 2 times/);
+  assert.match(result.blockers.join("\n"), /Invalid Seed-Fit-Decision/);
+  assert.match(result.blockers.join("\n"), /Use either Local-CI-Evidence or Local-CI-Override/);
+});
+
+test("evaluateReadiness blocks unsafe or queue-hostile repository state", () => {
+  const result = evaluateReadiness({
+    repo: {
+      ...cleanRepo,
+      isShallow: true,
+      mergeBases: ["a", "b"],
+      statusPorcelain: " M scripts/x.mjs",
+      ahead: 2,
+      branch: "main",
+      commits: [{ sha: "2222222", subject: "fix: unsigned", body: "fix: unsigned" }],
+    },
+    gateResults: [],
+    prBody: "",
+  });
+  assert.equal(result.ready, false);
+  assert.match(result.blockers.join("\n"), /shallow Git repository/);
+  assert.match(result.blockers.join("\n"), /ambiguous merge-base/);
+  assert.match(result.blockers.join("\n"), /working tree has uncommitted changes/);
+  assert.match(result.blockers.join("\n"), /2 local commit\(s\) are not pushed/);
+  assert.match(result.blockers.join("\n"), /branch is main/);
+  assert.match(result.blockers.join("\n"), /missing DCO sign-off/);
+});
+
+test("evaluateReadiness folds failed local gates into one pre-PR verdict", () => {
+  const result = evaluateReadiness({
+    repo: cleanRepo,
+    gateResults: [
+      { name: "UX-Fit Gate", ok: false, exitCode: 1, output: "[ux-fit-gate] FAILED" },
+      { name: "Docs Impact Gate", ok: true, exitCode: 0, output: "[docs-impact-gate] OK" },
+    ],
+    prBody: "UX-Fit-Decision: compact-controls",
+  });
+  assert.equal(result.ready, false);
+  assert.match(result.blockers.join("\n"), /UX-Fit Gate failed locally/);
+  assert.match(result.warnings.join("\n"), /editing the PR body after a workflow run has started/);
+});
+
+test("formatReadinessReport uses plain-language headings and changed-file summary", () => {
+  const result = evaluateReadiness({
+    repo: { ...cleanRepo, changedFiles: ["a.ts", "b.ts"] },
+    gateResults: [],
+    prBody: "",
+  });
+  const report = formatReadinessReport(result);
+  assert.match(report, /PR readiness: READY/);
+  assert.match(report, /Changed files: 2/);
+  assert.match(report, /What passed/);
+  assert.match(report, /Safe to open or queue the PR/);
+});

--- a/scripts/pr-readiness/core.mjs
+++ b/scripts/pr-readiness/core.mjs
@@ -1,0 +1,203 @@
+import { SEED_FIT_DECISIONS } from "../lib/seed-fit-gate.mjs";
+
+const VALID_SEED_FIT_DECISIONS = new Set(SEED_FIT_DECISIONS);
+
+const SUPPORTED_TRAILERS = new Set([
+  "Process-Spine-Decision",
+  "UX-Fit-Decision",
+  "Seed-Fit-Decision",
+  "Design-Grounding-Decision",
+  "Docs-Impact-Decision",
+  "Local-CI-Evidence",
+  "Local-CI-Override",
+]);
+
+const REQUIRED_GATE_SCRIPTS = [
+  ["Spec/Plan/Doc Gate", "scripts/check-spec-plan-doc.mjs"],
+  ["Plan Backlog Coverage Gate", "scripts/check-plan-backlog-coverage.mjs"],
+  ["Seed Contribution Fit Gate", "scripts/check-seed-fit-decision.mjs"],
+  ["UX-Fit Gate", "scripts/check-ux-fit-decision.mjs"],
+  ["Design Grounding Gate", "scripts/check-design-grounding-decision.mjs"],
+  ["Data-Impact Gate", "scripts/check-data-impact.mjs"],
+  ["Docs Impact Gate", "scripts/check-docs-impact.mjs"],
+  ["Doc Link Integrity", "scripts/check-doc-links.mjs"],
+  ["Doc Reference Integrity", "scripts/check-doc-reference-integrity.mjs"],
+  ["Retired Superpowers Skill Guard", "scripts/check-no-retired-superpowers-skills.mjs"],
+];
+
+export function buildGatePlan({ prBody = "", prLabelsJson = "[]" } = {}) {
+  return REQUIRED_GATE_SCRIPTS.map(([name, script]) => ({
+    name,
+    command: [process.execPath, [script]],
+    env: {
+      BASE_SHA: "origin/main",
+      PR_BODY: prBody,
+      PR_LABELS_JSON: prLabelsJson,
+      GITHUB_EVENT_NAME: "pull_request",
+    },
+  }));
+}
+
+export function parsePrBodyTrailers(prBody = "") {
+  return String(prBody)
+    .split(/\r?\n/)
+    .flatMap((line, index) => {
+      const match = line.match(/^\s*([A-Za-z][A-Za-z-]*):\s*(\S.*)?$/);
+      if (!match || !SUPPORTED_TRAILERS.has(match[1])) return [];
+      return [{ name: match[1], value: (match[2] ?? "").trim(), line: index + 1 }];
+    });
+}
+
+export function validatePrBodyTrailers(prBody = "") {
+  const trailers = parsePrBodyTrailers(prBody);
+  const blockers = [];
+  const warnings = [];
+  const byName = new Map();
+
+  for (const trailer of trailers) {
+    if (!trailer.value) {
+      blockers.push(`${trailer.name} on line ${trailer.line} has no value.`);
+    }
+    byName.set(trailer.name, [...(byName.get(trailer.name) ?? []), trailer]);
+  }
+
+  for (const [name, entries] of byName) {
+    if (entries.length > 1) {
+      blockers.push(`${name} appears ${entries.length} times. Keep one reviewed trailer so CI reads one intent.`);
+    }
+  }
+
+  const seedFit = byName.get("Seed-Fit-Decision")?.[0]?.value;
+  if (seedFit && !VALID_SEED_FIT_DECISIONS.has(seedFit)) {
+    blockers.push(
+      `Invalid Seed-Fit-Decision "${seedFit}". Valid values: ${[...VALID_SEED_FIT_DECISIONS].join(", ")}.`,
+    );
+  }
+
+  if (byName.has("Local-CI-Evidence") && byName.has("Local-CI-Override")) {
+    blockers.push("Use either Local-CI-Evidence or Local-CI-Override, not both.");
+  }
+
+  if (trailers.length > 0) {
+    warnings.push(
+      "If a GitHub workflow run has already started, editing the PR body after a workflow run has started will not change that run's event payload. Push a new commit or re-run the workflow after body fixes.",
+    );
+  }
+
+  return { ok: blockers.length === 0, blockers, warnings, trailers };
+}
+
+export function evaluateReadiness({ repo, gateResults = [], prBody = "" } = {}) {
+  const blockers = [];
+  const warnings = [];
+  const notes = [];
+  const passed = [];
+  const changedFiles = repo?.changedFiles ?? [];
+
+  if (!repo) {
+    blockers.push("Repository state could not be read.");
+  } else {
+    if (repo.isShallow) {
+      blockers.push("Repository is a shallow Git repository; fetch full history before computing a PR diff.");
+    }
+    if (!Array.isArray(repo.mergeBases) || repo.mergeBases.length === 0) {
+      blockers.push("No merge-base with origin/main; fetch current main and rebase or recreate the branch.");
+    } else if (repo.mergeBases.length > 1) {
+      blockers.push(`Found an ambiguous merge-base with origin/main (${repo.mergeBases.length} candidates); repair history before opening a PR.`);
+    }
+    if (repo.isDetached) blockers.push("HEAD is detached; switch to a named topic branch before opening a PR.");
+    if (repo.branch === "main") blockers.push("Current branch is main; create a topic branch before opening a PR.");
+    if (String(repo.statusPorcelain ?? "").trim()) {
+      blockers.push("The working tree has uncommitted changes; commit or discard them before opening or queueing the PR.");
+    }
+    if (Number(repo.ahead ?? 0) > 0) {
+      blockers.push(`${repo.ahead} local commit(s) are not pushed to ${repo.upstream ?? "the branch upstream"}; do not enter the merge queue yet.`);
+    }
+    if (changedFiles.length === 0) {
+      blockers.push("No diff against current origin/main; there is no PR payload to validate.");
+    }
+
+    const unsigned = (repo.commits ?? []).filter((commit) => !/Signed-off-by:/i.test(commit.body ?? ""));
+    for (const commit of unsigned) {
+      blockers.push(`Commit ${commit.sha.slice(0, 12)} (${commit.subject}) is missing DCO sign-off.`);
+    }
+  }
+
+  const trailerVerdict = validatePrBodyTrailers(prBody);
+  blockers.push(...trailerVerdict.blockers);
+  warnings.push(...trailerVerdict.warnings);
+
+  for (const gate of gateResults) {
+    if (gate.ok) {
+      passed.push(gate.name);
+      continue;
+    }
+    const detail = summarizeGateOutput(gate.output);
+    blockers.push(`${gate.name} failed locally${detail ? `: ${detail}` : "."}`);
+  }
+
+  if (gateResults.length === 0) {
+    notes.push("No local gate scripts were run; repository and trailer checks only.");
+  }
+
+  if (repo && blockers.length === 0) {
+    passed.push("Git history, DCO, clean worktree, pushed branch, PR trailers, and local gate plan");
+  }
+
+  return {
+    ready: blockers.length === 0,
+    blockers,
+    warnings,
+    notes,
+    passed,
+    changedFiles,
+    branch: repo?.branch ?? "(unknown)",
+    base: "origin/main",
+    mergeBase: repo?.mergeBases?.[0] ?? null,
+  };
+}
+
+export function formatReadinessReport(result) {
+  const lines = [];
+  lines.push(`PR readiness: ${result.ready ? "READY" : "NOT READY"}`);
+  lines.push(`Branch: ${result.branch}`);
+  lines.push(`Base: ${result.base}${result.mergeBase ? ` (merge-base ${result.mergeBase.slice(0, 12)})` : ""}`);
+  lines.push(`Changed files: ${result.changedFiles.length}`);
+  lines.push("");
+
+  if (result.ready) {
+    lines.push("Safe to open or queue the PR.");
+  } else {
+    lines.push(`Fix these before opening or queueing the PR (${result.blockers.length}):`);
+    for (const blocker of result.blockers) lines.push(`- ${blocker}`);
+  }
+
+  if (result.warnings.length > 0) {
+    lines.push("");
+    lines.push("Warnings");
+    for (const warning of result.warnings) lines.push(`- ${warning}`);
+  }
+
+  if (result.passed.length > 0) {
+    lines.push("");
+    lines.push("What passed");
+    for (const item of result.passed) lines.push(`- ${item}`);
+  }
+
+  if (result.notes.length > 0) {
+    lines.push("");
+    lines.push("Notes");
+    for (const note of result.notes) lines.push(`- ${note}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function summarizeGateOutput(output = "") {
+  const lines = String(output)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const failed = lines.find((line) => /\bFAILED\b|^ERROR\b/i.test(line));
+  return failed ?? lines.at(-1) ?? "";
+}


### PR DESCRIPTION
## Summary
- Add `pnpm pr:ready` / `scripts/pr-readiness.mjs`, a pre-PR readiness orchestrator for external coding agents.
- Compose the existing local governance gates before GitHub Actions becomes the first reporter.
- Add pure readiness policy tests and a durable implementation plan for `BI-E0D662DD`.

## Verification
- `node --test scripts/pr-readiness.test.mjs scripts/check-seed-fit-decision.test.mjs scripts/check-ux-fit-decision.test.mjs scripts/check-design-grounding-decision.test.mjs scripts/check-data-impact.test.mjs scripts/check-docs-impact.test.mjs scripts/check-doc-reference-integrity.test.mjs scripts/check-plan-backlog-coverage.test.mjs` passed: 61 tests, 0 failures.
- `pnpm pr:ready` passed after push: 5 changed files, all composed local gates passed.
- `pnpm --filter web build` was attempted in the worktree but could not reach compilation because the worktree dependency install is incomplete: `next/dist/bin/next` is missing. This is recorded on `WC-6D2D82B8` as source-only worktree evidence.

Process-Spine-Decision: BI-E0D662DD carries a durable plan at docs/superpowers/plans/2026-07-20-external-pr-readiness-orchestrator.md.
Design-Grounding-Decision: reviewed the process-spine spec/plans, scripts/pr-health.mjs, .github/workflows/ci.yml, and the current local gate scripts; this adds a source-local pre-PR tool without changing UI or runtime behavior.
UX-Fit-Decision: no UI surface or operator form/control changed; CLI output is plain-language and lists concrete blockers.
Docs-Impact-Decision: no documented app route or user-guide behavior changed; operator-facing usage is covered by the script help and plan.
Local-CI-Override: source-local governance tool only; no app runtime, migration, or served UI surface changed. Targeted Node tests and pnpm pr:ready passed; web build was dependency-blocked in the source-only worktree before compilation.