### PR TITLE
fix(ci): preserve jsdom storage on Node 26

### DIFF
--- a/docs/testing/pre-pr-gate.md
+++ b/docs/testing/pre-pr-gate.md
@@ -168,7 +168,10 @@ The command plan carries required process environment as `env NAME=value ...`
 prefixes, and the Node runner interprets those prefixes directly instead of
 depending on a host `env` executable. This keeps the 8 GiB `NODE_OPTIONS`
 headroom on both POSIX and Windows typecheck paths; the production build may
-still use the host-specific strategy selected by the plan.
+still use the host-specific strategy selected by the plan. Vitest runs with
+Node's experimental host web-storage disabled so Node 26 cannot shadow the
+`localStorage` and `sessionStorage` implementations owned by jsdom. This is a
+test-runner compatibility setting, not a change to application runtime policy.
 
 The sandbox-freshness step checks the load-bearing runtime and gate packages,
 including the Vitest runner used by the next step. Vitest is checked for both

--- a/scripts/lib/local-integration-ci.mjs
+++ b/scripts/lib/local-integration-ci.mjs
@@ -27,6 +27,12 @@ export function dockerBuildTag(candidateBranch) {
 // it). Verified 2026-07-05: default heap SIGABRT; 8 GiB completes cleanly.
 export const HOST_BUILD_NODE_OPTIONS = "NODE_OPTIONS=--max-old-space-size=8192";
 
+// Node 26 exposes experimental host localStorage/sessionStorage accessors even
+// when no backing file is configured. Those undefined host values shadow the
+// web storage that jsdom installs in Vitest fork workers. Disable only Node's
+// host implementation at process start so jsdom remains the environment owner.
+export const HOST_TEST_NODE_OPTIONS = "NODE_OPTIONS=--no-experimental-webstorage";
+
 export function resolveCommandInvocation(command, baseEnv = process.env) {
   if (command[0] !== "env") {
     return { command: command[0], args: command.slice(1), env: baseEnv };
@@ -84,6 +90,7 @@ export function createToolchainFingerprint(input) {
     arch: input.arch ?? "unknown",
     lockfileSha256: input.lockfileSha256 ?? "unknown",
     nodeOptions: input.nodeOptions ?? "",
+    testNodeOptions: input.testNodeOptions ?? "",
   };
   return {
     toolchain,
@@ -118,6 +125,7 @@ export function collectToolchainFingerprint({ buildStrategy, cwd = process.cwd()
     arch: process.arch,
     lockfileSha256: fileSha256(`${cwd}/pnpm-lock.yaml`),
     nodeOptions: HOST_BUILD_NODE_OPTIONS,
+    testNodeOptions: HOST_TEST_NODE_OPTIONS,
   });
 }
 
@@ -153,7 +161,7 @@ export function createLocalIntegrationPlan(input) {
     ...(input.includeMigrateDeploy
       ? [["pnpm", "--filter", "@dpf/db", "exec", "prisma", "migrate", "deploy"]]
       : []),
-    ["pnpm", "--filter", "web", "exec", "vitest", "run"],
+    ["env", HOST_TEST_NODE_OPTIONS, "pnpm", "--filter", "web", "exec", "vitest", "run"],
     // typecheck needs the same heap headroom as the host-next build: with the
     // node 24 default heap, `tsc --noEmit` over apps/web SIGABRTs (exit 134)
     // exactly like the build worker did (BI-B5011ACE) — observed live on the

--- a/scripts/lib/local-integration-ci.test.mjs
+++ b/scripts/lib/local-integration-ci.test.mjs
@@ -21,6 +21,7 @@ describe("createLocalIntegrationPlan", () => {
       arch: "arm64",
       lockfileSha256: "lock-sha",
       nodeOptions: "NODE_OPTIONS=--max-old-space-size=8192",
+      testNodeOptions: "NODE_OPTIONS=--no-experimental-webstorage",
     });
 
     assert.equal(evidence.toolchainFingerprint.length, 64);
@@ -33,6 +34,7 @@ describe("createLocalIntegrationPlan", () => {
       arch: "arm64",
       lockfileSha256: "lock-sha",
       nodeOptions: "NODE_OPTIONS=--max-old-space-size=8192",
+      testNodeOptions: "NODE_OPTIONS=--no-experimental-webstorage",
     });
     assert.equal(evidence.toolchainFingerprint, createToolchainFingerprint({
       arch: "arm64",
@@ -40,6 +42,7 @@ describe("createLocalIntegrationPlan", () => {
       gitVersion: "git version 2.50.1",
       lockfileSha256: "lock-sha",
       nodeOptions: "NODE_OPTIONS=--max-old-space-size=8192",
+      testNodeOptions: "NODE_OPTIONS=--no-experimental-webstorage",
       nodeVersion: "v24.0.0",
       platform: "linux",
       pnpmVersion: "10.14.0",
@@ -59,10 +62,23 @@ describe("createLocalIntegrationPlan", () => {
       "git merge --no-ff --no-edit doc/build-studio-decision-skill-packs",
       "node scripts/sandbox-freshness-preflight.mjs --converge --branch local-integration/doc-build-studio-decision-skill-packs",
       "pnpm --filter @dpf/db exec prisma generate",
-      "pnpm --filter web exec vitest run",
+      "env NODE_OPTIONS=--no-experimental-webstorage pnpm --filter web exec vitest run",
       "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck",
       "env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web exec next build",
     ]);
+  });
+
+  it("disables Node host web-storage before Vitest starts jsdom workers (BI-3E989BEA)", () => {
+    const plan = createLocalIntegrationPlan({
+      candidateBranch: "fix/node-26-webstorage",
+      mode: "single-branch",
+      siblingBranches: [],
+      hostPlatform: "linux",
+    });
+
+    assert.ok(plan.commands.map((command) => command.join(" ")).includes(
+      "env NODE_OPTIONS=--no-experimental-webstorage pnpm --filter web exec vitest run",
+    ));
   });
 
   it("uses a locally available accepted-base ref without fetching by default (BI-76551B2D)", () => {


### PR DESCRIPTION
## Summary

Restores reliable web UI tests on Node 26 by disabling Node's experimental host web-storage for the canonical local-integration Vitest process. Without this process-start flag, undefined host localStorage/sessionStorage accessors shadow jsdom and cause 54 false failures on unchanged main.

## Changes

- Run canonical web Vitest with NODE_OPTIONS=--no-experimental-webstorage.
- Include the test-runner option in content-addressed toolchain evidence.
- Add a regression test for the command-plan contract and document why the setting exists.

## Test plan

- [x] Source-only change
  - [x] node --test scripts/lib/local-integration-ci.test.mjs (16 passed)
  - [x] Six representative jsdom suites (62 passed)
- [x] Runtime-bound change
  - [x] Full governed local-integration gate passed under lease NPEL-8B2370C2C9
  - [x] Full web Vitest, web typecheck, and production Next.js build passed
- [ ] Verification-harness limitation acknowledged

### Verification evidence

pnpm run pregate completed with gate passed for 03edfa07e6ba86a7307aff7bb86292a22581e8a8. Sandbox freshness was green with Node v26.5.0, Vitest 4.1.10, Next 16.2.10, React 19.2.7, TypeScript 6.0.3, and Prisma 7.8.0.

## Related issues / Epic

Backlog: BI-3E989BEA
Blocks reliable publication verification for BI-EDAAD429 in the onboarding epic.

## Epic / Backlog linkage (for multi-BI work)

Standalone CI remediation for BI-3E989BEA.

## Overlap sweep

No open PR modifies docs/testing/pre-pr-gate.md, scripts/lib/local-integration-ci.mjs, or scripts/lib/local-integration-ci.test.mjs.

## Notes for the reviewer

This changes only the test runner process. Application runtime web-storage behavior is unchanged.