### PR TITLE
feat: add federated reseller demand channels

### DIFF
--- a/apps/web/app/(shell)/ops/demand/page.tsx
+++ b/apps/web/app/(shell)/ops/demand/page.tsx
@@ -4,14 +4,15 @@ import { resolveDemandPolicy } from "@/lib/demand/policy";
 import { DemandBoard } from "@/components/ops/DemandBoard";
 import { OpsTabNav } from "@/components/ops/OpsTabNav";
 import { NetworkDemandPanel } from "@/components/ops/NetworkDemandPanel";
-import { getNetworkDemandItems } from "@/lib/federation/demand-read-model";
+import { getDemandShareContext, getNetworkDemandItems } from "@/lib/federation/demand-read-model";
 
 export const dynamic = "force-dynamic";
 
 export default async function DemandPage() {
-  const [items, networkItems, policyConfig] = await Promise.all([
+  const [items, networkItems, shareContext, policyConfig] = await Promise.all([
     getDemandItems(),
     getNetworkDemandItems(),
+    getDemandShareContext(),
     prisma.platformDevConfig.findUnique({
       where: { id: "singleton" },
       select: { demandFramework: true, demandBucketTargets: true },
@@ -29,7 +30,10 @@ export default async function DemandPage() {
         </p>
       </div>
       <OpsTabNav />
-      <NetworkDemandPanel items={JSON.parse(JSON.stringify(networkItems))} />
+      <NetworkDemandPanel
+        items={JSON.parse(JSON.stringify(networkItems))}
+        shareContext={JSON.parse(JSON.stringify(shareContext))}
+      />
       <DemandBoard
         items={JSON.parse(JSON.stringify(items))}
         bucketTargets={policy.bucketTargets}

--- a/apps/web/app/(shell)/platform/federation-links/page.tsx
+++ b/apps/web/app/(shell)/platform/federation-links/page.tsx
@@ -11,6 +11,10 @@ import {
   type FederationLinkRow,
   type NearbyDiscoveryHealth,
 } from "@/components/platform/federation-links/FederationLinksAdminClient";
+import {
+  PartnerBusinessPanel,
+  type PartnerBusinessRow,
+} from "@/components/platform/federation-links/PartnerBusinessPanel";
 
 export const dynamic = "force-dynamic";
 
@@ -29,7 +33,7 @@ export default async function FederationLinksPage() {
     redirect("/403");
   }
 
-  const [links, discoveryCapabilities] = await Promise.all([
+  const [links, discoveryCapabilities, partnerAccounts] = await Promise.all([
     prisma.federationLink.findMany({
       include: { principal: { select: { displayName: true } } },
       orderBy: { createdAt: "desc" },
@@ -44,6 +48,15 @@ export default async function FederationLinksPage() {
         node: { select: { trustState: true, status: true } },
       },
       orderBy: { reportedAt: "desc" },
+    }),
+    prisma.partnerAccount.findMany({
+      include: {
+        federationLink: { include: { principal: { select: { displayName: true } } } },
+        agreements: { orderBy: { createdAt: "desc" }, take: 1 },
+        _count: { select: { agreements: true, entitlements: true, supportRoutes: true, contributionRecognitions: true } },
+      },
+      orderBy: { createdAt: "asc" },
+      take: 200,
     }),
   ]);
 
@@ -107,6 +120,23 @@ export default async function FederationLinksPage() {
     };
   });
 
+  const partners: PartnerBusinessRow[] = partnerAccounts.map((partner) => ({
+    partnerId: partner.partnerId,
+    displayName: partner.displayName,
+    standing: partner.standing,
+    tier: partner.tier,
+    linkName: partner.federationLink?.principal.displayName ?? null,
+    agreementReference: partner.agreements[0]?.externalReference ?? null,
+    agreementCount: partner._count.agreements,
+    entitlementCount: partner._count.entitlements,
+    supportRouteCount: partner._count.supportRoutes,
+    recognitionCount: partner._count.contributionRecognitions,
+  }));
+  const enrolledLinkIds = new Set(partnerAccounts.flatMap((partner) => partner.federationLinkId ? [partner.federationLinkId] : []));
+  const eligiblePartnerLinks = links
+    .filter((link) => link.role === "channel-upstream" && link.linkState === "trusted" && !enrolledLinkIds.has(link.linkId))
+    .map((link) => ({ linkId: link.linkId, displayName: link.principal.displayName }));
+
   return (
     <div className="space-y-6">
       <div>
@@ -121,6 +151,7 @@ export default async function FederationLinksPage() {
         nearbyCandidates={listNearbyFederationCandidates()}
         nearbyDiscoveryHealth={nearbyDiscoveryHealth}
       />
+      <PartnerBusinessPanel partners={partners} eligibleLinks={eligiblePartnerLinks} />
     </div>
   );
 }

--- a/apps/web/app/api/v1/federation/demand/reconcile/route.test.ts
+++ b/apps/web/app/api/v1/federation/demand/reconcile/route.test.ts
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NextRequest } from "next/server";
 
-const { mockResolveAuth, mockCompare } = vi.hoisted(() => ({
+const { mockResolveAuth, mockCompare, mockBindPeerIdentity } = vi.hoisted(() => ({
   mockResolveAuth: vi.fn(),
   mockCompare: vi.fn(),
+  mockBindPeerIdentity: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/federation-link-token", () => ({ resolveFederationLinkAuth: mockResolveAuth }));
 vi.mock("@/lib/federation/demand-digest", () => ({ compareIncomingDemandDigest: mockCompare }));
+vi.mock("@/lib/federation/channel-demand", () => ({ bindPeerInstallationIdentity: mockBindPeerIdentity }));
 
 import { POST } from "./route";
 
@@ -34,6 +36,7 @@ beforeEach(() => {
   process.env.DPF_FEDERATION_EXCHANGE_ENABLED = "1";
   mockResolveAuth.mockResolvedValue({ ok: true, linkId: "link_1" });
   mockCompare.mockResolvedValue({ checked: 1, needs: [{ originRecordRef: "ref_1", reason: "missing" }] });
+  mockBindPeerIdentity.mockResolvedValue({ action: "bound", peerInstallationId: "inst_origin" });
 });
 
 describe("POST /api/v1/federation/demand/reconcile", () => {
@@ -54,6 +57,7 @@ describe("POST /api/v1/federation/demand/reconcile", () => {
       ok: true, checked: 1, needs: [{ originRecordRef: "ref_1", reason: "missing" }],
     });
     expect(mockCompare).toHaveBeenCalledWith(expect.anything(), "link_1", digest);
+    expect(mockBindPeerIdentity).toHaveBeenCalledWith(expect.anything(), "link_1", "inst_origin");
   });
 
   it("rejects a malformed or oversized inventory before querying mirrors", async () => {

--- a/apps/web/app/api/v1/federation/demand/reconcile/route.ts
+++ b/apps/web/app/api/v1/federation/demand/reconcile/route.ts
@@ -6,6 +6,7 @@ import { validateDemandDigestV1, type DemandDigestV1 } from "@dpf/db/federated-d
 import { resolveFederationLinkAuth } from "@/lib/auth/federation-link-token";
 import { validateFederationCloudEvent } from "@/lib/federation/cloud-event-guard";
 import { compareIncomingDemandDigest, type DemandDigestDb } from "@/lib/federation/demand-digest";
+import { bindPeerInstallationIdentity } from "@/lib/federation/channel-demand";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 
 const ERROR_STATUS: Record<string, number> = {
@@ -54,6 +55,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       { ok: false, error: "invalid_demand_digest", violations },
       { status: 422 },
     );
+  }
+
+  try {
+    await bindPeerInstallationIdentity(
+      prisma,
+      authz.linkId,
+      (event.data as DemandDigestV1).originInstallationId,
+    );
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: "peer_identity_mismatch",
+      message: error instanceof Error ? error.message : "Peer identity mismatch",
+    }, { status: 409 });
   }
 
   const result = await compareIncomingDemandDigest(

--- a/apps/web/app/api/v1/federation/demand/route.test.ts
+++ b/apps/web/app/api/v1/federation/demand/route.test.ts
@@ -1,14 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NextRequest } from "next/server";
 
-const { mockResolveAuth, mockHandleIncomingDemand, mockResolveIdentity } = vi.hoisted(() => ({
+const { mockResolveAuth, mockHandleIncomingDemand, mockHandleIncomingDemandResponse, mockResolveIdentity } = vi.hoisted(() => ({
   mockResolveAuth: vi.fn(),
   mockHandleIncomingDemand: vi.fn(),
+  mockHandleIncomingDemandResponse: vi.fn(),
   mockResolveIdentity: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/federation-link-token", () => ({ resolveFederationLinkAuth: mockResolveAuth }));
 vi.mock("@/lib/federation/demand-exchange", () => ({ handleIncomingDemand: mockHandleIncomingDemand }));
+vi.mock("@/lib/federation/demand-response", () => ({ handleIncomingDemandResponse: mockHandleIncomingDemandResponse }));
 vi.mock("@/lib/federation/demand-identity", () => ({ resolveFederationIdentity: mockResolveIdentity }));
 
 import { POST } from "./route";
@@ -52,6 +54,7 @@ beforeEach(() => {
     originVersion: 1,
     disposition: "observed",
   });
+  mockHandleIncomingDemandResponse.mockResolvedValue({ action: "created", responseId: "rsp_opaque" });
 });
 
 describe("POST /api/v1/federation/demand", () => {
@@ -83,6 +86,15 @@ describe("POST /api/v1/federation/demand", () => {
       envelope,
       { receivingInstallationId: "inst_receiver" },
     );
+  });
+
+  it("routes collaboration responses to the durable response handler", async () => {
+    const demandResponse = { specVersion: "dpf.demand-response/1", responseId: "rsp_opaque" };
+    const response = await POST(request("dpf.demand.help-offered", demandResponse));
+
+    expect(response.status).toBe(202);
+    expect(mockHandleIncomingDemandResponse).toHaveBeenCalledWith(expect.anything(), "link_1", demandResponse);
+    expect(mockHandleIncomingDemand).not.toHaveBeenCalled();
   });
 
   it("returns validation violations without acknowledging receipt", async () => {

--- a/apps/web/app/api/v1/federation/demand/route.ts
+++ b/apps/web/app/api/v1/federation/demand/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 import { prisma } from "@dpf/db";
-import type { DemandEnvelopeV1 } from "@dpf/db/federated-demand-contract";
+import type { DemandEnvelopeV1, DemandResponseV1 } from "@dpf/db/federated-demand-contract";
 
 import { resolveFederationLinkAuth } from "@/lib/auth/federation-link-token";
 import { validateFederationCloudEvent } from "@/lib/federation/cloud-event-guard";
@@ -11,6 +11,10 @@ import {
   type DemandExchangeDb,
   type InboundDemandActivity,
 } from "@/lib/federation/demand-exchange";
+import {
+  handleIncomingDemandResponse,
+  type DemandResponseDb,
+} from "@/lib/federation/demand-response";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 
 const ERROR_STATUS: Record<string, number> = {
@@ -25,6 +29,10 @@ const INBOUND_ACTIVITIES = new Set<InboundDemandActivity>([
   "dpf.demand.proposed",
   "dpf.demand.updated",
   "dpf.demand.withdrawn",
+]);
+const RESPONSE_ACTIVITIES = new Set([
+  "dpf.demand.interest-recorded",
+  "dpf.demand.help-offered",
 ]);
 
 function isInboundActivity(value: unknown): value is InboundDemandActivity {
@@ -63,7 +71,23 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   const event = body as { type?: unknown; data?: unknown };
-  if (!isInboundActivity(event.type) || !event.data || typeof event.data !== "object" || Array.isArray(event.data)) {
+  if (!event.data || typeof event.data !== "object" || Array.isArray(event.data)) {
+    return NextResponse.json({ ok: false, error: "invalid_body" }, { status: 422 });
+  }
+
+  if (typeof event.type === "string" && RESPONSE_ACTIVITIES.has(event.type)) {
+    const response = await handleIncomingDemandResponse(
+      prisma as unknown as DemandResponseDb,
+      authz.linkId,
+      event.data as DemandResponseV1,
+    );
+    if (response.action === "rejected") {
+      return NextResponse.json({ ok: false, error: "invalid_demand_response", violations: response.violations }, { status: 422 });
+    }
+    return NextResponse.json({ ok: true, ...response }, { status: response.action === "noop" ? 200 : 202 });
+  }
+
+  if (!isInboundActivity(event.type)) {
     return NextResponse.json({ ok: false, error: "invalid_body" }, { status: 422 });
   }
 

--- a/apps/web/components/ops/NetworkDemandPanel.test.tsx
+++ b/apps/web/components/ops/NetworkDemandPanel.test.tsx
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/actions/federated-demand", () => ({
   adoptFederatedDemandAction: vi.fn(),
+  forwardFederatedDemandAction: vi.fn(),
+  respondToFederatedDemandAction: vi.fn(),
+  shareLocalDemandWithLinkAction: vi.fn(),
   setFederatedDemandFollowAction: vi.fn(),
+  stopSharingLocalDemandWithLinkAction: vi.fn(),
 }));
 vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
 
@@ -31,12 +35,58 @@ describe("NetworkDemandPanel", () => {
       originVersion: 1,
       updatedAt: "2026-07-20T05:10:00.000Z",
       localItemId: null,
+      forwardingToFounderPermitted: false,
+      forwardingExpiresAt: null,
     }]} />);
 
     expect(html).toContain("Shared by connected installations");
     expect(html).toContain("Follow");
+    expect(html).toContain("I&#x27;m interested");
+    expect(html).toContain("Offer help");
     expect(html).toContain("Adopt into our backlog");
     expect(html).toContain("Your local backlog stays authoritative");
     expect(html).not.toContain("fdm_private");
+  });
+
+  it("shows explicit per-connection sharing and consented founder forwarding", () => {
+    const html = renderToStaticMarkup(<NetworkDemandPanel
+      items={[{
+        mirrorId: "fdm_private",
+        title: "Customer-approved improvement",
+        summary: "A minimized customer need.",
+        workType: "feature",
+        attribution: "pseudonymous",
+        occurrenceCount: 2,
+        affectedOrganizations: 1,
+        disposition: "observed",
+        syncStatus: "synced",
+        originVersion: 1,
+        updatedAt: "2026-07-20T05:10:00.000Z",
+        localItemId: null,
+        forwardingToFounderPermitted: true,
+        forwardingExpiresAt: "2026-08-01T00:00:00.000Z",
+      }]}
+      shareContext={{
+        localItems: [{ itemId: "BI-LOCAL", title: "Local improvement", status: "open" }],
+        targets: [{ linkId: "FL-CUSTOMER", displayName: "Customer One", role: "manages", sharedItemIds: [] }],
+        founderTargets: [{ linkId: "FL-FOUNDER", displayName: "Arcamanus" }],
+        responses: [{
+          responseId: "rsp_opaque",
+          sourceName: "Reseller One",
+          responseKind: "help-offer",
+          message: "We can validate this.",
+          receivedAt: "2026-07-20T06:00:00.000Z",
+        }],
+      }}
+    />);
+
+    expect(html).toContain("Share local demand");
+    expect(html).toContain("Share selected demand");
+    expect(html).toContain("Only the minimized title, summary, applicability, signal count");
+    expect(html).toContain("90 days");
+    expect(html).toContain("Forward to Founder Hub");
+    expect(html).toContain("Reseller One");
+    expect(html).toContain("offered help");
+    expect(html).not.toContain("inst_customer");
   });
 });

--- a/apps/web/components/ops/NetworkDemandPanel.test.tsx
+++ b/apps/web/components/ops/NetworkDemandPanel.test.tsx
@@ -69,7 +69,7 @@ describe("NetworkDemandPanel", () => {
       shareContext={{
         localItems: [{ itemId: "BI-LOCAL", title: "Local improvement", status: "open" }],
         targets: [{ linkId: "FL-CUSTOMER", displayName: "Customer One", role: "manages", sharedItemIds: [] }],
-        founderTargets: [{ linkId: "FL-FOUNDER", displayName: "Arcamanus" }],
+        founderTargets: [{ linkId: "FL-FOUNDER", displayName: "Founder Hub" }],
         responses: [{
           responseId: "rsp_opaque",
           sourceName: "Reseller One",

--- a/apps/web/components/ops/NetworkDemandPanel.tsx
+++ b/apps/web/components/ops/NetworkDemandPanel.tsx
@@ -6,18 +6,34 @@ import { useState, useTransition } from "react";
 
 import {
   adoptFederatedDemandAction,
+  forwardFederatedDemandAction,
+  respondToFederatedDemandAction,
+  shareLocalDemandWithLinkAction,
   setFederatedDemandFollowAction,
+  stopSharingLocalDemandWithLinkAction,
 } from "@/lib/actions/federated-demand";
-import type { NetworkDemandView } from "@/lib/federation/demand-read-model";
+import type { DemandShareContext, NetworkDemandView } from "@/lib/federation/demand-read-model";
 import { InlineBusy } from "@/components/ui/InlineBusy";
 import { LocalTime } from "@/components/ui/LocalTime";
 import { CollapsibleList, EmptyState, StatusBadge } from "@/components/ui/report-kit";
 
-export function NetworkDemandPanel({ items }: { items: NetworkDemandView[] }) {
+const EMPTY_SHARE_CONTEXT: DemandShareContext = { targets: [], founderTargets: [], localItems: [], responses: [] };
+
+export function NetworkDemandPanel({
+  items,
+  shareContext = EMPTY_SHARE_CONTEXT,
+}: {
+  items: NetworkDemandView[];
+  shareContext?: DemandShareContext;
+}) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [activeMirror, setActiveMirror] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+  const [selectedItemId, setSelectedItemId] = useState(shareContext.localItems[0]?.itemId ?? "");
+  const [selectedLinkId, setSelectedLinkId] = useState(shareContext.targets[0]?.linkId ?? "");
+  const [founderTargetId, setFounderTargetId] = useState(shareContext.founderTargets[0]?.linkId ?? "");
+  const [allowFounderForwarding, setAllowFounderForwarding] = useState(false);
 
   const run = (mirrorId: string, action: "follow" | "unfollow" | "adopt") => {
     setActiveMirror(mirrorId);
@@ -30,6 +46,52 @@ export function NetworkDemandPanel({ items }: { items: NetworkDemandView[] }) {
       else if (result.disposition === "adopted") {
         setMessage(`Added ${result.itemId ?? "the item"} to your local backlog.`);
       }
+      setActiveMirror(null);
+      router.refresh();
+    });
+  };
+
+  const shareLocal = () => {
+    if (!selectedItemId || !selectedLinkId) return;
+    setMessage(null);
+    startTransition(async () => {
+      const result = await shareLocalDemandWithLinkAction({
+        itemId: selectedItemId,
+        linkId: selectedLinkId,
+        allowForwardToFounder: allowFounderForwarding,
+      });
+      setMessage(result.ok ? result.message : result.error);
+      router.refresh();
+    });
+  };
+
+  const stopSharing = (itemId: string, linkId: string) => {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await stopSharingLocalDemandWithLinkAction({ itemId, linkId });
+      setMessage(result.ok ? result.message : result.error);
+      router.refresh();
+    });
+  };
+
+  const forwardToFounder = (mirrorId: string) => {
+    if (!founderTargetId) return;
+    setActiveMirror(mirrorId);
+    setMessage(null);
+    startTransition(async () => {
+      const result = await forwardFederatedDemandAction({ mirrorId, targetLinkId: founderTargetId });
+      setMessage(result.ok ? result.message : result.error);
+      setActiveMirror(null);
+      router.refresh();
+    });
+  };
+
+  const respond = (mirrorId: string, kind: "interest" | "help-offer") => {
+    setActiveMirror(mirrorId);
+    setMessage(null);
+    startTransition(async () => {
+      const result = await respondToFederatedDemandAction({ mirrorId, kind });
+      setMessage(result.ok ? result.message : result.error);
       setActiveMirror(null);
       router.refresh();
     });
@@ -52,6 +114,109 @@ export function NetworkDemandPanel({ items }: { items: NetworkDemandView[] }) {
       </div>
 
       {message ? <p role="status" className="mb-3 text-xs text-[var(--dpf-muted)]">{message}</p> : null}
+
+      {shareContext.responses.length > 0 ? (
+        <div className="mb-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+          <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Collaboration responses</h3>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">Interest and help offers received for demand this installation shared.</p>
+          <ul className="mt-2 space-y-2">
+            {shareContext.responses.map((response) => (
+              <li key={response.responseId} className="text-xs text-[var(--dpf-text)]">
+                <span className="font-medium">{response.sourceName}</span>{" "}
+                {response.responseKind === "help-offer" ? "offered help" : "recorded interest"}
+                {response.message ? `: ${response.message}` : "."}{" "}
+                <span className="text-[var(--dpf-muted)]"><LocalTime value={response.receivedAt} mode="datetime" /></span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="mb-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+        <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Share local demand</h3>
+        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+          Choose one local item and one connection. Only the minimized title, summary, applicability, signal count, and chosen attribution leave this installation.
+        </p>
+        {shareContext.targets.length === 0 ? (
+          <p className="mt-3 text-xs text-[var(--dpf-muted)]">
+            No trusted reseller or channel connection is ready. <Link href="/platform/federation-links" className="font-medium text-[var(--dpf-accent)] hover:underline">Review connections</Link>
+          </p>
+        ) : (
+          <div className="mt-3 flex flex-wrap items-end gap-3">
+            <label className="text-xs text-[var(--dpf-muted)]">
+              Local demand
+              <select
+                aria-label="Local demand"
+                value={selectedItemId}
+                onChange={(event) => setSelectedItemId(event.target.value)}
+                className="mt-1 block max-w-72 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1.5 text-sm text-[var(--dpf-text)]"
+              >
+                {shareContext.localItems.map((item) => <option key={item.itemId} value={item.itemId}>{item.title}</option>)}
+              </select>
+            </label>
+            <label className="text-xs text-[var(--dpf-muted)]">
+              Connection
+              <select
+                aria-label="Connection"
+                value={selectedLinkId}
+                onChange={(event) => setSelectedLinkId(event.target.value)}
+                className="mt-1 block rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1.5 text-sm text-[var(--dpf-text)]"
+              >
+                {shareContext.targets.map((target) => <option key={target.linkId} value={target.linkId}>{target.displayName}</option>)}
+              </select>
+            </label>
+            <label className="flex max-w-sm items-start gap-2 text-xs text-[var(--dpf-muted)]">
+              <input
+                type="checkbox"
+                checked={allowFounderForwarding}
+                onChange={(event) => setAllowFounderForwarding(event.target.checked)}
+                className="mt-0.5"
+              />
+              Allow this reseller to forward the minimized envelope to Founder Hub for 90 days. Customer identity remains pseudonymous.
+            </label>
+            <button
+              type="button"
+              disabled={pending || !selectedItemId || !selectedLinkId}
+              onClick={shareLocal}
+              className="rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-semibold text-[var(--dpf-bg)] disabled:opacity-50"
+            >
+              {pending ? <InlineBusy label="Queuing…" tone="current" /> : "Share selected demand"}
+            </button>
+          </div>
+        )}
+        {shareContext.targets.some((target) => target.sharedItemIds.length > 0) ? (
+          <div className="mt-3 border-t border-[var(--dpf-border)] pt-3">
+            <p className="text-xs font-medium text-[var(--dpf-text)]">Currently shared</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {shareContext.targets.flatMap((target) => target.sharedItemIds.map((itemId) => (
+                <button
+                  key={`${target.linkId}:${itemId}`}
+                  type="button"
+                  disabled={pending}
+                  onClick={() => stopSharing(itemId, target.linkId)}
+                  className="rounded border border-[var(--dpf-border)] px-2 py-1 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-error)] disabled:opacity-50"
+                >
+                  Stop {itemId} → {target.displayName}
+                </button>
+              )))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      {shareContext.founderTargets.length > 1 ? (
+        <label className="mb-3 block text-xs text-[var(--dpf-muted)]">
+          Founder Hub destination
+          <select
+            aria-label="Founder Hub destination"
+            value={founderTargetId}
+            onChange={(event) => setFounderTargetId(event.target.value)}
+            className="ml-2 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1 text-[var(--dpf-text)]"
+          >
+            {shareContext.founderTargets.map((target) => <option key={target.linkId} value={target.linkId}>{target.displayName}</option>)}
+          </select>
+        </label>
+      ) : null}
 
       {items.length === 0 ? (
         <EmptyState
@@ -98,11 +263,40 @@ export function NetworkDemandPanel({ items }: { items: NetworkDemandView[] }) {
                         type="button"
                         disabled={pending}
                         aria-busy={isBusy}
+                        onClick={() => respond(item.mirrorId, "interest")}
+                        className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+                      >
+                        {isBusy ? <InlineBusy label="Queuing…" tone="current" /> : "I'm interested"}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={pending}
+                        aria-busy={isBusy}
+                        onClick={() => respond(item.mirrorId, "help-offer")}
+                        className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+                      >
+                        {isBusy ? <InlineBusy label="Queuing…" tone="current" /> : "Offer help"}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={pending}
+                        aria-busy={isBusy}
                         onClick={() => run(item.mirrorId, item.disposition === "followed" ? "unfollow" : "follow")}
                         className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
                       >
                         {isBusy ? <InlineBusy label="Saving…" tone="current" /> : item.disposition === "followed" ? "Stop following" : "Follow"}
                       </button>
+                      {item.forwardingToFounderPermitted && founderTargetId ? (
+                        <button
+                          type="button"
+                          disabled={pending}
+                          aria-busy={isBusy}
+                          onClick={() => forwardToFounder(item.mirrorId)}
+                          className="rounded-md border border-[var(--dpf-border)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50"
+                        >
+                          {isBusy ? <InlineBusy label="Queuing…" tone="current" /> : "Forward to Founder Hub"}
+                        </button>
+                      ) : null}
                       <button
                         type="button"
                         disabled={pending}

--- a/apps/web/components/platform/federation-links/FederationLinksAdminClient.test.tsx
+++ b/apps/web/components/platform/federation-links/FederationLinksAdminClient.test.tsx
@@ -3,12 +3,15 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { mockSetDiscovery } = vi.hoisted(() => ({ mockSetDiscovery: vi.fn() }));
+const { mockSetDiscovery, mockIssueInvitation } = vi.hoisted(() => ({
+  mockSetDiscovery: vi.fn(),
+  mockIssueInvitation: vi.fn(),
+}));
 
 vi.mock("@/lib/actions/federation-links", () => ({
   approveFederationLinkAction: vi.fn(),
   enrollWithPeerAction: vi.fn(),
-  issueFederationBootstrapAction: vi.fn(),
+  issueFederationBootstrapAction: mockIssueInvitation,
   quarantineFederationLinkAction: vi.fn(),
   revokeFederationLinkAction: vi.fn(),
   setFederationDiscoveryEnabledAction: mockSetDiscovery,
@@ -85,5 +88,21 @@ describe("FederationLinksAdminClient nearby setup", () => {
     fireEvent.click(screen.getByRole("button", { name: "Enable nearby discovery" }));
 
     await waitFor(() => expect(mockSetDiscovery).toHaveBeenCalledWith(true));
+  });
+});
+
+describe("FederationLinksAdminClient channel setup", () => {
+  it("offers a reseller/founder channel without implying exclusivity", () => {
+    render(<FederationLinksAdminClient rows={[]} />);
+
+    fireEvent.change(screen.getByLabelText("Relationship preset"), {
+      target: { value: "channel" },
+    });
+
+    expect((screen.getByLabelText("Relationship preset") as HTMLSelectElement).value).toBe("channel");
+    expect(screen.getByRole("option", { name: "channel-upstream (we receive curated demand)" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "channel-downstream (we share curated demand)" })).toBeTruthy();
+    expect(screen.getByText(/Each installation independently chooses what demand crosses this link/)).toBeTruthy();
+    expect(screen.getByText(/does not make this partner exclusive/i)).toBeTruthy();
   });
 });

--- a/apps/web/components/platform/federation-links/FederationLinksAdminClient.tsx
+++ b/apps/web/components/platform/federation-links/FederationLinksAdminClient.tsx
@@ -54,9 +54,11 @@ export function FederationLinksAdminClient({
 }) {
   const [flash, setFlash] = useState<Flash>(null);
   const [relationshipPreset, setRelationshipPreset] = useState<
-    "same-organization" | "service-provider"
+    "same-organization" | "service-provider" | "channel"
   >("service-provider");
-  const [role, setRole] = useState<"manages" | "managed-by" | "same-org-peer">("manages");
+  const [role, setRole] = useState<
+    "manages" | "managed-by" | "same-org-peer" | "channel-upstream" | "channel-downstream"
+  >("manages");
   const [ttlMinutes, setTtlMinutes] = useState(15);
   const [issued, setIssued] = useState<{ plaintext: string; expiresAt: string } | null>(null);
   const [peerUrl, setPeerUrl] = useState("");
@@ -314,15 +316,22 @@ export function FederationLinksAdminClient({
             <select
               value={relationshipPreset}
               onChange={(e) => {
-                const preset = e.target.value as "same-organization" | "service-provider";
+                const preset = e.target.value as "same-organization" | "service-provider" | "channel";
                 setRelationshipPreset(preset);
-                setRole(preset === "same-organization" ? "same-org-peer" : "manages");
+                setRole(
+                  preset === "same-organization"
+                    ? "same-org-peer"
+                    : preset === "channel"
+                      ? "channel-upstream"
+                      : "manages",
+                );
               }}
               className="mt-1 block rounded border px-2 py-1 text-sm text-[var(--dpf-text)]"
               style={{ borderColor: "var(--dpf-border)", backgroundColor: "var(--dpf-surface-2)" }}
             >
               <option value="same-organization">same organization</option>
               <option value="service-provider">service provider / customer</option>
+              <option value="channel">reseller / founder channel</option>
             </select>
           </label>
           <label className="text-xs text-[var(--dpf-muted)]">
@@ -330,15 +339,25 @@ export function FederationLinksAdminClient({
             <select
               value={role}
               disabled={relationshipPreset === "same-organization"}
-              onChange={(e) => setRole(e.target.value as "manages" | "managed-by")}
+              onChange={(e) => setRole(e.target.value as typeof role)}
               className="mt-1 block rounded border px-2 py-1 text-sm text-[var(--dpf-text)]"
               style={{ borderColor: "var(--dpf-border)", backgroundColor: "var(--dpf-surface-2)" }}
             >
               {relationshipPreset === "same-organization" && (
                 <option value="same-org-peer">same-organization peer</option>
               )}
-              <option value="manages">manages (we are the MSP)</option>
-              <option value="managed-by">managed-by (we are the customer)</option>
+              {relationshipPreset === "service-provider" && (
+                <>
+                  <option value="manages">manages (we are the service provider)</option>
+                  <option value="managed-by">managed-by (we are the customer)</option>
+                </>
+              )}
+              {relationshipPreset === "channel" && (
+                <>
+                  <option value="channel-upstream">channel-upstream (we receive curated demand)</option>
+                  <option value="channel-downstream">channel-downstream (we share curated demand)</option>
+                </>
+              )}
             </select>
           </label>
           <label className="text-xs text-[var(--dpf-muted)]">
@@ -366,6 +385,11 @@ export function FederationLinksAdminClient({
           <p className="mt-3 rounded border p-2 text-xs text-[var(--dpf-muted)]" style={{ borderColor: "var(--dpf-border)" }}>
             Shared platform demand and dispositions are offered after both installations approve.
             Local backlog details, work capsules, private planning, attachments, and customer context stay local.
+          </p>
+        )}
+        {relationshipPreset === "channel" && (
+          <p className="mt-3 rounded border p-2 text-xs text-[var(--dpf-muted)]" style={{ borderColor: "var(--dpf-border)" }}>
+            Each installation independently chooses what demand crosses this link and whether a reseller may forward it. This connection does not make this partner exclusive; other partners can have separate, non-overlapping scopes.
           </p>
         )}
         {issued && (

--- a/apps/web/components/platform/federation-links/PartnerBusinessPanel.test.tsx
+++ b/apps/web/components/platform/federation-links/PartnerBusinessPanel.test.tsx
@@ -28,7 +28,7 @@ describe("PartnerBusinessPanel", () => {
     />);
 
     expect(html).toContain("Founder Hub reseller network");
-    expect(html).toContain("Arcamanus owns reseller enrollment");
+    expect(html).toContain("Founder Hub owns reseller enrollment");
     expect(html).toContain("separate from demand sharing and Hive result intake");
     expect(html).toContain("Enroll reseller");
     expect(html).toContain("2 entitlements");

--- a/apps/web/components/platform/federation-links/PartnerBusinessPanel.test.tsx
+++ b/apps/web/components/platform/federation-links/PartnerBusinessPanel.test.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/actions/federation-links", () => ({
+  enrollChannelPartnerAction: vi.fn(),
+  updateChannelPartnerStandingAction: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+import { PartnerBusinessPanel } from "./PartnerBusinessPanel";
+
+describe("PartnerBusinessPanel", () => {
+  it("keeps business, demand, and Hive authority visibly independent", () => {
+    const html = renderToStaticMarkup(<PartnerBusinessPanel
+      eligibleLinks={[{ linkId: "FL-1", displayName: "Reseller One" }]}
+      partners={[{
+        partnerId: "PARTNER-1",
+        displayName: "Reseller One",
+        standing: "active",
+        tier: "authorized",
+        linkName: "Reseller One",
+        agreementReference: "AGR-2026-01",
+        agreementCount: 1,
+        entitlementCount: 2,
+        supportRouteCount: 1,
+        recognitionCount: 3,
+      }]}
+    />);
+
+    expect(html).toContain("Founder Hub reseller network");
+    expect(html).toContain("Arcamanus owns reseller enrollment");
+    expect(html).toContain("separate from demand sharing and Hive result intake");
+    expect(html).toContain("Enroll reseller");
+    expect(html).toContain("2 entitlements");
+    expect(html).toContain("3 recognitions");
+  });
+});

--- a/apps/web/components/platform/federation-links/PartnerBusinessPanel.tsx
+++ b/apps/web/components/platform/federation-links/PartnerBusinessPanel.tsx
@@ -118,7 +118,7 @@ export function PartnerBusinessPanel({
       <div>
         <h2 id="partner-business-heading" className="text-sm font-semibold text-[var(--dpf-text)]">Founder Hub reseller network</h2>
         <p className="mt-1 max-w-3xl text-xs text-[var(--dpf-muted)]">
-          Arcamanus owns reseller enrollment, standing, agreements, offering entitlements, support routing, and contribution recognition. These business records are separate from demand sharing and Hive result intake.
+          Founder Hub owns reseller enrollment, standing, agreements, offering entitlements, support routing, and contribution recognition. These business records are separate from demand sharing and Hive result intake.
         </p>
       </div>
 

--- a/apps/web/components/platform/federation-links/PartnerBusinessPanel.tsx
+++ b/apps/web/components/platform/federation-links/PartnerBusinessPanel.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  enrollChannelPartnerAction,
+  updateChannelPartnerStandingAction,
+} from "@/lib/actions/federation-links";
+import { InlineBusy } from "@/components/ui/InlineBusy";
+import { EmptyState, StatusBadge } from "@/components/ui/report-kit";
+
+export interface PartnerBusinessRow {
+  partnerId: string;
+  displayName: string;
+  standing: string;
+  tier: string;
+  linkName: string | null;
+  agreementReference: string | null;
+  agreementCount: number;
+  entitlementCount: number;
+  supportRouteCount: number;
+  recognitionCount: number;
+}
+
+export interface PartnerEnrollmentLink {
+  linkId: string;
+  displayName: string;
+}
+
+export function PartnerBusinessPanel({
+  partners,
+  eligibleLinks,
+}: {
+  partners: PartnerBusinessRow[];
+  eligibleLinks: PartnerEnrollmentLink[];
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [linkId, setLinkId] = useState(eligibleLinks[0]?.linkId ?? "");
+  const [agreementReference, setAgreementReference] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+
+  const enroll = () => {
+    if (!linkId) return;
+    setMessage(null);
+    startTransition(async () => {
+      const result = await enrollChannelPartnerAction({
+        linkId,
+        ...(agreementReference.trim() ? { agreementReference: agreementReference.trim() } : {}),
+      });
+      setMessage(result.ok
+        ? `Reseller ${result.partnerId} enrolled. Review standing before activating it.`
+        : result.message);
+      if (result.ok) router.refresh();
+    });
+  };
+
+  const setStanding = (partnerId: string, standing: string) => {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await updateChannelPartnerStandingAction(partnerId, standing);
+      setMessage(result.ok ? `${partnerId} is now ${result.standing}.` : result.message);
+      if (result.ok) router.refresh();
+    });
+  };
+
+  return (
+    <section className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4" aria-labelledby="partner-business-heading">
+      <div>
+        <h2 id="partner-business-heading" className="text-sm font-semibold text-[var(--dpf-text)]">Founder Hub reseller network</h2>
+        <p className="mt-1 max-w-3xl text-xs text-[var(--dpf-muted)]">
+          Arcamanus owns reseller enrollment, standing, agreements, offering entitlements, support routing, and contribution recognition. These business records are separate from demand sharing and Hive result intake.
+        </p>
+      </div>
+
+      {message ? <p className="mt-3 text-xs text-[var(--dpf-muted)]" role="status">{message}</p> : null}
+
+      {eligibleLinks.length > 0 ? (
+        <div className="mt-3 flex flex-wrap items-end gap-3 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+          <label className="text-xs text-[var(--dpf-muted)]">
+            Approved channel connection
+            <select
+              aria-label="Approved channel connection"
+              value={linkId}
+              onChange={(event) => setLinkId(event.target.value)}
+              className="mt-1 block rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1.5 text-sm text-[var(--dpf-text)]"
+            >
+              {eligibleLinks.map((link) => <option key={link.linkId} value={link.linkId}>{link.displayName}</option>)}
+            </select>
+          </label>
+          <label className="text-xs text-[var(--dpf-muted)]">
+            Agreement reference (optional)
+            <input
+              aria-label="Agreement reference (optional)"
+              value={agreementReference}
+              onChange={(event) => setAgreementReference(event.target.value)}
+              placeholder="Signed agreement or CRM reference"
+              className="mt-1 block w-64 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-1.5 text-sm text-[var(--dpf-text)]"
+            />
+          </label>
+          <button
+            type="button"
+            disabled={pending || !linkId}
+            onClick={enroll}
+            className="rounded bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-semibold text-[var(--dpf-bg)] disabled:opacity-50"
+          >
+            {pending ? <InlineBusy label="Enrolling…" tone="current" /> : "Enroll reseller"}
+          </button>
+        </div>
+      ) : null}
+
+      {partners.length === 0 ? (
+        <div className="mt-3">
+          <EmptyState
+            size="sm"
+            title="No resellers enrolled"
+            description="Create and approve an upstream channel connection first, then enroll that peer here. Demand and code sharing remain independently controlled."
+          />
+        </div>
+      ) : (
+        <div className="mt-3 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--dpf-border)] text-left text-xs text-[var(--dpf-muted)]">
+                <th className="p-2">Reseller</th>
+                <th className="p-2">Standing</th>
+                <th className="p-2">Agreement</th>
+                <th className="p-2">Business coverage</th>
+              </tr>
+            </thead>
+            <tbody>
+              {partners.map((partner) => (
+                <tr key={partner.partnerId} className="border-b border-[var(--dpf-border)] align-top">
+                  <td className="p-2">
+                    <p className="font-medium text-[var(--dpf-text)]">{partner.displayName}</p>
+                    <p className="text-xs text-[var(--dpf-muted)]">{partner.tier} · {partner.linkName ?? "No active link"}</p>
+                  </td>
+                  <td className="p-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <StatusBadge label={partner.standing} intent={partner.standing === "active" ? "success" : partner.standing === "suspended" || partner.standing === "at-risk" ? "warning" : "neutral"} variant="soft" />
+                      <select
+                        aria-label={`Standing for ${partner.displayName}`}
+                        value={partner.standing}
+                        disabled={pending}
+                        onChange={(event) => setStanding(partner.partnerId, event.target.value)}
+                        className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-text)]"
+                      >
+                        {['pending', 'active', 'at-risk', 'suspended', 'terminated'].map((standing) => <option key={standing} value={standing}>{standing}</option>)}
+                      </select>
+                    </div>
+                  </td>
+                  <td className="p-2 text-xs text-[var(--dpf-muted)]">
+                    {partner.agreementReference ?? "No reference"}
+                  </td>
+                  <td className="p-2 text-xs text-[var(--dpf-muted)]">
+                    {partner.agreementCount} agreement{partner.agreementCount === 1 ? "" : "s"} · {partner.entitlementCount} entitlement{partner.entitlementCount === 1 ? "" : "s"} · {partner.supportRouteCount} support route{partner.supportRouteCount === 1 ? "" : "s"} · {partner.recognitionCount} recognition{partner.recognitionCount === 1 ? "" : "s"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/platform/federation-links/PartnerBusinessPanel.tsx
+++ b/apps/web/components/platform/federation-links/PartnerBusinessPanel.tsx
@@ -8,7 +8,7 @@ import {
   updateChannelPartnerStandingAction,
 } from "@/lib/actions/federation-links";
 import { InlineBusy } from "@/components/ui/InlineBusy";
-import { EmptyState, StatusBadge } from "@/components/ui/report-kit";
+import { DataTable, EmptyState, StatusBadge, type Column } from "@/components/ui/report-kit";
 
 export interface PartnerBusinessRow {
   partnerId: string;
@@ -65,6 +65,54 @@ export function PartnerBusinessPanel({
     });
   };
 
+  const columns: Column<PartnerBusinessRow>[] = [
+    {
+      key: "reseller",
+      header: "Reseller",
+      sortAccessor: (partner) => partner.displayName,
+      cell: (partner) => (
+        <div>
+          <p className="font-medium text-[var(--dpf-text)]">{partner.displayName}</p>
+          <p className="text-xs text-[var(--dpf-muted)]">{partner.tier} · {partner.linkName ?? "No active link"}</p>
+        </div>
+      ),
+    },
+    {
+      key: "standing",
+      header: "Standing",
+      sortAccessor: (partner) => partner.standing,
+      cell: (partner) => (
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusBadge label={partner.standing} intent={partner.standing === "active" ? "success" : partner.standing === "suspended" || partner.standing === "at-risk" ? "warning" : "neutral"} variant="soft" />
+          <select
+            aria-label={`Standing for ${partner.displayName}`}
+            value={partner.standing}
+            disabled={pending}
+            onChange={(event) => setStanding(partner.partnerId, event.target.value)}
+            className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-text)]"
+          >
+            {['pending', 'active', 'at-risk', 'suspended', 'terminated'].map((standing) => <option key={standing} value={standing}>{standing}</option>)}
+          </select>
+        </div>
+      ),
+    },
+    {
+      key: "agreement",
+      header: "Agreement",
+      cell: (partner) => <span className="text-xs text-[var(--dpf-muted)]">{partner.agreementReference ?? "No reference"}</span>,
+      sortAccessor: (partner) => partner.agreementReference ?? "",
+    },
+    {
+      key: "coverage",
+      header: "Business coverage",
+      cell: (partner) => (
+        <span className="text-xs text-[var(--dpf-muted)]">
+          {partner.agreementCount} agreement{partner.agreementCount === 1 ? "" : "s"} · {partner.entitlementCount} entitlement{partner.entitlementCount === 1 ? "" : "s"} · {partner.supportRouteCount} support route{partner.supportRouteCount === 1 ? "" : "s"} · {partner.recognitionCount} recognition{partner.recognitionCount === 1 ? "" : "s"}
+        </span>
+      ),
+    },
+  ];
+
   return (
     <section className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4" aria-labelledby="partner-business-heading">
       <div>
@@ -119,47 +167,15 @@ export function PartnerBusinessPanel({
           />
         </div>
       ) : (
-        <div className="mt-3 overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-[var(--dpf-border)] text-left text-xs text-[var(--dpf-muted)]">
-                <th className="p-2">Reseller</th>
-                <th className="p-2">Standing</th>
-                <th className="p-2">Agreement</th>
-                <th className="p-2">Business coverage</th>
-              </tr>
-            </thead>
-            <tbody>
-              {partners.map((partner) => (
-                <tr key={partner.partnerId} className="border-b border-[var(--dpf-border)] align-top">
-                  <td className="p-2">
-                    <p className="font-medium text-[var(--dpf-text)]">{partner.displayName}</p>
-                    <p className="text-xs text-[var(--dpf-muted)]">{partner.tier} · {partner.linkName ?? "No active link"}</p>
-                  </td>
-                  <td className="p-2">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <StatusBadge label={partner.standing} intent={partner.standing === "active" ? "success" : partner.standing === "suspended" || partner.standing === "at-risk" ? "warning" : "neutral"} variant="soft" />
-                      <select
-                        aria-label={`Standing for ${partner.displayName}`}
-                        value={partner.standing}
-                        disabled={pending}
-                        onChange={(event) => setStanding(partner.partnerId, event.target.value)}
-                        className="rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2 py-1 text-xs text-[var(--dpf-text)]"
-                      >
-                        {['pending', 'active', 'at-risk', 'suspended', 'terminated'].map((standing) => <option key={standing} value={standing}>{standing}</option>)}
-                      </select>
-                    </div>
-                  </td>
-                  <td className="p-2 text-xs text-[var(--dpf-muted)]">
-                    {partner.agreementReference ?? "No reference"}
-                  </td>
-                  <td className="p-2 text-xs text-[var(--dpf-muted)]">
-                    {partner.agreementCount} agreement{partner.agreementCount === 1 ? "" : "s"} · {partner.entitlementCount} entitlement{partner.entitlementCount === 1 ? "" : "s"} · {partner.supportRouteCount} support route{partner.supportRouteCount === 1 ? "" : "s"} · {partner.recognitionCount} recognition{partner.recognitionCount === 1 ? "" : "s"}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="mt-3 overflow-x-auto rounded border border-[var(--dpf-border)]">
+          <DataTable
+            columns={columns}
+            rows={partners}
+            getRowKey={(partner) => partner.partnerId}
+            initialSort={{ key: "reseller", dir: "asc" }}
+            pageSize={20}
+            dense
+          />
         </div>
       )}
     </section>

--- a/apps/web/lib/actions/federated-demand.ts
+++ b/apps/web/lib/actions/federated-demand.ts
@@ -9,6 +9,14 @@ import {
   setIncomingDemandDisposition,
   type DemandExchangeDb,
 } from "@/lib/federation/demand-exchange";
+import {
+  forwardIncomingDemandToLink,
+  selectLocalDemandForLink,
+  unselectLocalDemandForLink,
+  type ChannelDemandDb,
+} from "@/lib/federation/channel-demand";
+import { queueDemandResponse, type DemandResponseDb } from "@/lib/federation/demand-response";
+import { resolveFederationIdentity, type FederationIdentityDb } from "@/lib/federation/demand-identity";
 import { ingestBacklogItem } from "@/lib/operate/backlog-ingest";
 import { requireCapability } from "@/lib/actions/shared/guards";
 
@@ -49,5 +57,120 @@ export async function adoptFederatedDemandAction(mirrorId: string): Promise<Fede
     return { ok: true, disposition: "adopted", itemId: result.itemId };
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : "Unable to adopt shared demand." };
+  }
+}
+
+export type FederatedDemandShareResult =
+  | { ok: true; action: "queued" | "noop"; message: string }
+  | { ok: false; error: string };
+
+export async function shareLocalDemandWithLinkAction(input: {
+  linkId: string;
+  itemId: string;
+  allowForwardToFounder?: boolean;
+}): Promise<FederatedDemandShareResult> {
+  await requireCapability("manage_backlog");
+  if (!input.linkId?.trim() || !input.itemId?.trim()) {
+    return { ok: false, error: "Choose a demand item and connection." };
+  }
+  try {
+    const now = new Date();
+    const result = await selectLocalDemandForLink(
+      prisma as unknown as ChannelDemandDb,
+      {
+        linkId: input.linkId.trim(),
+        itemId: input.itemId.trim(),
+        attribution: "pseudonymous",
+        allowForwardToFounder: input.allowForwardToFounder === true,
+        ...(input.allowForwardToFounder
+          ? { forwardingExpiresAt: new Date(now.getTime() + 90 * 24 * 60 * 60_000).toISOString() }
+          : {}),
+        now,
+      },
+    );
+    revalidatePath(DEMAND_PATH);
+    return {
+      ok: true,
+      action: result.action,
+      message: input.allowForwardToFounder
+        ? "Queued with pseudonymous attribution and a 90-day founder-forwarding grant."
+        : "Queued for this connection only; transitive forwarding is not permitted.",
+    };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : "Unable to share demand." };
+  }
+}
+
+export async function stopSharingLocalDemandWithLinkAction(input: {
+  linkId: string;
+  itemId: string;
+}): Promise<FederatedDemandShareResult> {
+  await requireCapability("manage_backlog");
+  try {
+    const result = await unselectLocalDemandForLink(
+      prisma as unknown as ChannelDemandDb,
+      { linkId: input.linkId.trim(), itemId: input.itemId.trim(), now: new Date() },
+    );
+    revalidatePath(DEMAND_PATH);
+    return {
+      ok: true,
+      action: result.action,
+      message: result.action === "noop" ? "This item was not shared on that connection." : "Withdrawal queued.",
+    };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : "Unable to stop sharing demand." };
+  }
+}
+
+export async function forwardFederatedDemandAction(input: {
+  mirrorId: string;
+  targetLinkId: string;
+}): Promise<FederatedDemandShareResult> {
+  await requireCapability("manage_backlog");
+  try {
+    const result = await forwardIncomingDemandToLink(
+      prisma as unknown as ChannelDemandDb,
+      { mirrorId: input.mirrorId.trim(), targetLinkId: input.targetLinkId.trim(), now: new Date() },
+    );
+    revalidatePath(DEMAND_PATH);
+    return {
+      ok: true,
+      action: result.action,
+      message: result.action === "noop"
+        ? "Founder already has this version queued."
+        : "Curated demand queued for Founder Hub with original provenance preserved.",
+    };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : "Unable to forward demand." };
+  }
+}
+
+export async function respondToFederatedDemandAction(input: {
+  mirrorId: string;
+  kind: "interest" | "help-offer";
+}): Promise<FederatedDemandShareResult> {
+  await requireCapability("manage_backlog");
+  try {
+    const identity = await resolveFederationIdentity(prisma as unknown as FederationIdentityDb);
+    const result = await queueDemandResponse(
+      prisma as unknown as DemandResponseDb,
+      {
+        mirrorId: input.mirrorId.trim(),
+        kind: input.kind,
+        identity,
+        ...(input.kind === "help-offer"
+          ? { message: "Our organization can help investigate, reproduce, or validate this demand." }
+          : {}),
+        now: new Date(),
+      },
+    );
+    revalidatePath(DEMAND_PATH);
+    return {
+      ok: true,
+      action: result.action,
+      message: input.kind === "help-offer" ? "Help offer queued for the source installation." : "Interest queued for the source installation.",
+    };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : "Unable to respond to demand." };
   }
 }

--- a/apps/web/lib/actions/federation-links.ts
+++ b/apps/web/lib/actions/federation-links.ts
@@ -6,6 +6,8 @@
 // the federation enrollment lib (lib/federation/enrollment). All mutations
 // revalidate the admin path so the UI sees fresh state.
 
+import { createHash } from "node:crypto";
+
 import { revalidatePath } from "next/cache";
 
 import { prisma } from "@dpf/db";
@@ -17,6 +19,7 @@ import {
   type FederationRelationshipPreset,
   type FederationRole,
 } from "@dpf/db/federation-link-types";
+import { isPartnerStanding, type PartnerStanding } from "@dpf/db/federated-channel";
 
 import { resolveAppBaseUrl } from "@/lib/app-url";
 import { auth } from "@/lib/auth";
@@ -202,6 +205,122 @@ export async function revokeFederationLinkAction(
     return { ok: true, linkId, linkState };
   } catch (err) {
     return { ok: false, error: "internal_error", message: err instanceof Error ? err.message : "revoke failed" };
+  }
+}
+
+// ── Founder Hub partner-business ownership ──────────────────────────────────
+
+export type PartnerBusinessActionResult =
+  | { ok: true; partnerId: string; standing: string }
+  | ActionFailure;
+
+function semanticId(prefix: string, value: string): string {
+  return `${prefix}-${createHash("sha256").update(value).digest("hex").slice(0, 16).toUpperCase()}`;
+}
+
+export async function enrollChannelPartnerAction(input: {
+  linkId: string;
+  displayName?: string;
+  agreementReference?: string;
+}): Promise<PartnerBusinessActionResult> {
+  const gate = await assertManagePlatform();
+  if (!gate.ok) return gate;
+  if (!input.linkId?.trim()) {
+    return { ok: false, error: "invalid_input", message: "Choose a channel connection." };
+  }
+  try {
+    const [link, organization] = await Promise.all([
+      prisma.federationLink.findUnique({
+        where: { linkId: input.linkId.trim() },
+        select: {
+          linkId: true,
+          role: true,
+          linkState: true,
+          peerOrganizationRef: true,
+          principal: { select: { displayName: true } },
+        },
+      }),
+      prisma.organization.findFirst({ orderBy: { createdAt: "asc" }, select: { id: true } }),
+    ]);
+    if (!link || !organization) {
+      return { ok: false, error: "not_found", message: "Connection or local organization was not found." };
+    }
+    if (link.role !== "channel-upstream") {
+      return { ok: false, error: "invalid_input", message: "Only an upstream channel connection can be enrolled as a Founder Hub reseller." };
+    }
+    if (link.linkState !== "trusted") {
+      return { ok: false, error: "invalid_transition", message: "Both installations must approve the connection before enrollment." };
+    }
+    const externalOrganizationRef = link.peerOrganizationRef ?? `peer:${link.linkId}`;
+    const partnerId = semanticId("PARTNER", `${organization.id}:${externalOrganizationRef}`);
+    const partner = await prisma.partnerAccount.upsert({
+      where: {
+        organizationId_externalOrganizationRef: {
+          organizationId: organization.id,
+          externalOrganizationRef,
+        },
+      },
+      create: {
+        partnerId,
+        organizationId: organization.id,
+        federationLinkId: link.linkId,
+        externalOrganizationRef,
+        displayName: input.displayName?.trim() || link.principal.displayName,
+        partnerKind: "reseller",
+        standing: "pending",
+        tier: "registered",
+        enrolledAt: new Date(),
+      },
+      update: {
+        federationLinkId: link.linkId,
+        displayName: input.displayName?.trim() || link.principal.displayName,
+      },
+      select: { id: true, partnerId: true, standing: true },
+    });
+    if (input.agreementReference?.trim()) {
+      const agreementReference = input.agreementReference.trim();
+      await prisma.partnerAgreement.upsert({
+        where: { agreementId: semanticId("PAGR", `${partner.partnerId}:${agreementReference}`) },
+        create: {
+          agreementId: semanticId("PAGR", `${partner.partnerId}:${agreementReference}`),
+          partnerAccountId: partner.id,
+          agreementType: "reseller",
+          status: "active",
+          externalReference: agreementReference,
+          effectiveFrom: new Date(),
+        },
+        update: { status: "active", externalReference: agreementReference },
+      });
+    }
+    revalidatePath(ADMIN_PATH);
+    return { ok: true, partnerId: partner.partnerId, standing: partner.standing };
+  } catch (error) {
+    return { ok: false, error: "internal_error", message: error instanceof Error ? error.message : "Partner enrollment failed" };
+  }
+}
+
+export async function updateChannelPartnerStandingAction(
+  partnerId: string,
+  standing: string,
+): Promise<PartnerBusinessActionResult> {
+  const gate = await assertManagePlatform();
+  if (!gate.ok) return gate;
+  if (!partnerId?.trim() || !isPartnerStanding(standing)) {
+    return { ok: false, error: "invalid_input", message: "Choose a valid partner and standing." };
+  }
+  try {
+    const partner = await prisma.partnerAccount.update({
+      where: { partnerId: partnerId.trim() },
+      data: {
+        standing: standing as PartnerStanding,
+        reviewedAt: new Date(),
+      },
+      select: { partnerId: true, standing: true },
+    });
+    revalidatePath(ADMIN_PATH);
+    return { ok: true, partnerId: partner.partnerId, standing: partner.standing };
+  } catch (error) {
+    return { ok: false, error: "internal_error", message: error instanceof Error ? error.message : "Partner update failed" };
   }
 }
 

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8751,6 +8751,7 @@
         "overview",
         "key-concepts",
         "what-you-can-do",
+        "shared-demand",
         "promotions",
         "promoter-timeout"
       ]

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 526,
+  "pageCount": 527,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -3944,6 +3944,18 @@
         "rules",
         "why-this-matters",
         "terminology-mapping"
+      ]
+    },
+    "docs/operations/federated-demand-channels.md": {
+      "publicHref": "/operations/federated-demand-channels/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "federated-demand-channels",
+        "customer-and-reseller-operation",
+        "founder-hub-business-management",
+        "privacy-and-recovery-behavior"
       ]
     },
     "docs/operations/install.md": {

--- a/apps/web/lib/federation/channel-demand.test.ts
+++ b/apps/web/lib/federation/channel-demand.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  bindPeerInstallationIdentity,
+  decodeChannelDemandPolicy,
+} from "./channel-demand";
+
+describe("decodeChannelDemandPolicy", () => {
+  it("defaults partner exchange to explicit selection and pseudonymous attribution", () => {
+    expect(decodeChannelDemandPolicy(null)).toEqual({
+      mode: "explicit",
+      selectedRecordRefs: [],
+      attribution: "pseudonymous",
+      allowTransitiveForwarding: false,
+      forwardingAudiences: [],
+    });
+  });
+
+  it("bounds, deduplicates, and narrows persisted policy values", () => {
+    expect(decodeChannelDemandPolicy({ demandChannelPolicy: {
+      mode: "automatic",
+      selectedRecordRefs: ["BI-A", "BI-A", 42],
+      attribution: "organization",
+      allowTransitiveForwarding: true,
+      forwardingAudiences: ["founder", "community"],
+    } })).toEqual({
+      mode: "explicit",
+      selectedRecordRefs: ["BI-A"],
+      attribution: "organization",
+      allowTransitiveForwarding: true,
+      forwardingAudiences: ["founder"],
+    });
+  });
+});
+
+describe("bindPeerInstallationIdentity", () => {
+  it("learns an authenticated digest sender once", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    await expect(bindPeerInstallationIdentity(
+      { federationLink: { updateMany } },
+      "FL-1",
+      "inst_peer_opaque",
+    )).resolves.toEqual({ peerInstallationId: "inst_peer_opaque" });
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        linkId: "FL-1",
+        OR: [{ peerInstallationId: null }, { peerInstallationId: "inst_peer_opaque" }],
+      },
+      data: { peerInstallationId: "inst_peer_opaque" },
+    });
+  });
+
+  it("rejects an authenticated link that changes installation identity", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    await expect(bindPeerInstallationIdentity(
+      { federationLink: { updateMany } },
+      "FL-1",
+      "inst_different",
+    )).rejects.toThrow("Peer installation identity does not match this connection.");
+  });
+});

--- a/apps/web/lib/federation/channel-demand.ts
+++ b/apps/web/lib/federation/channel-demand.ts
@@ -1,0 +1,340 @@
+import { createHash } from "node:crypto";
+
+import {
+  audienceForOutboundRole,
+  channelPolicySelectsRecord,
+  forwardDemandEnvelope,
+  forwardingGrantFromPolicy,
+  type ChannelDemandPolicy,
+} from "@dpf/db/federated-channel";
+import { DEMAND_PROJECTION_TEMPLATES } from "@dpf/db/federated-demand-contract";
+import {
+  isFederationRole,
+  type FederationRole,
+} from "@dpf/db/federation-link-types";
+
+import {
+  queueDemandProjection,
+  queueDemandWithdrawal,
+  queueForwardedDemand,
+  type DemandDeliveryDb,
+} from "./demand-delivery";
+import { decodeDemandMirrorPayload } from "./demand-exchange";
+import { resolveFederationIdentity, type FederationIdentityDb } from "./demand-identity";
+import { relationshipPresetForRole } from "./demand-reconciliation";
+
+interface ChannelLink {
+  linkId: string;
+  role: string;
+  linkState: string;
+  peerAuthorityUrl: string;
+  peerTokenEnc: string | null;
+  peerInstallationId: string | null;
+  projectionContractId: string | null;
+  revokedAt: Date | null;
+  quarantinedAt: Date | null;
+}
+
+interface ChannelBacklogItem {
+  itemId: string;
+  title: string;
+  body: string | null;
+  workType: string | null;
+  occurrenceCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+  digitalProduct: { productId: string } | null;
+}
+
+interface ChannelMirror {
+  mirrorId: string;
+  federationLinkId: string;
+  canonicalSide: string;
+  syncStatus: string;
+  payload: unknown;
+}
+
+export interface ChannelDemandDb extends FederationIdentityDb, DemandDeliveryDb {
+  federationLink: DemandDeliveryDb["federationLink"] & {
+    findUnique(args: unknown): Promise<ChannelLink | null>;
+    update(args: unknown): Promise<unknown>;
+  };
+  backlogItem: {
+    findUnique(args: unknown): Promise<ChannelBacklogItem | null>;
+  };
+  projectionContract: {
+    findFirst(args: unknown): Promise<{ cadaPosture: unknown } | null>;
+    upsert(args: unknown): Promise<unknown>;
+  };
+  federatedRecordMirror: DemandDeliveryDb["federatedRecordMirror"] & {
+    findUnique(args: unknown): Promise<(ChannelMirror & { version: number }) | null>;
+  };
+}
+
+const PARTNER_ROLES = new Set<FederationRole>([
+  "manages",
+  "managed-by",
+  "channel-upstream",
+  "channel-downstream",
+]);
+
+export async function bindPeerInstallationIdentity(
+  db: { federationLink: { updateMany(args: unknown): Promise<{ count: number }> } },
+  linkId: string,
+  peerInstallationId: string,
+): Promise<{ peerInstallationId: string }> {
+  const updated = await db.federationLink.updateMany({
+    where: {
+      linkId,
+      OR: [{ peerInstallationId: null }, { peerInstallationId }],
+    },
+    data: { peerInstallationId },
+  });
+  if (updated.count !== 1) {
+    throw new Error("Peer installation identity does not match this connection.");
+  }
+  return { peerInstallationId };
+}
+
+function assertTrustedPartnerLink(link: ChannelLink | null): asserts link is ChannelLink & { role: FederationRole } {
+  if (!link) throw new Error("Federation link was not found.");
+  if (!isFederationRole(link.role) || !PARTNER_ROLES.has(link.role)) {
+    throw new Error("This connection is not a service-provider or channel relationship.");
+  }
+  if (link.linkState !== "trusted" || link.revokedAt || link.quarantinedAt) {
+    throw new Error("Only a trusted, active connection can share demand.");
+  }
+}
+
+function safeSummary(body: string | null, title: string): string {
+  const value = (body ?? "")
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("[origin:"))
+    .join("\n")
+    .trim();
+  return value || title;
+}
+
+export function decodeChannelDemandPolicy(value: unknown): ChannelDemandPolicy {
+  const root = value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+  const candidate = root.demandChannelPolicy && typeof root.demandChannelPolicy === "object"
+    && !Array.isArray(root.demandChannelPolicy)
+    ? root.demandChannelPolicy as Record<string, unknown>
+    : {};
+  const refs = Array.isArray(candidate.selectedRecordRefs)
+    ? candidate.selectedRecordRefs.filter((ref): ref is string => typeof ref === "string" && ref.length > 0).slice(0, 5_000)
+    : [];
+  const forwardingAudiences = Array.isArray(candidate.forwardingAudiences)
+    ? candidate.forwardingAudiences.filter(
+        (audience): audience is "founder" => audience === "founder",
+      )
+    : [];
+  return {
+    mode: "explicit",
+    selectedRecordRefs: [...new Set(refs)],
+    attribution: candidate.attribution === "named" || candidate.attribution === "organization"
+      || candidate.attribution === "anonymous"
+      ? candidate.attribution
+      : "pseudonymous",
+    allowTransitiveForwarding: candidate.allowTransitiveForwarding === true,
+    forwardingAudiences: [...new Set(forwardingAudiences)],
+    ...(typeof candidate.forwardingExpiresAt === "string"
+      ? { forwardingExpiresAt: candidate.forwardingExpiresAt }
+      : {}),
+  };
+}
+
+function contractId(linkId: string): string {
+  return `PC-CHANNEL-${createHash("sha256").update(linkId).digest("hex").slice(0, 16).toUpperCase()}`;
+}
+
+async function storePolicy(
+  db: ChannelDemandDb,
+  link: ChannelLink,
+  policy: ChannelDemandPolicy,
+): Promise<void> {
+  const preset = relationshipPresetForRole(link.role);
+  if (preset !== "channel" && preset !== "service-provider") {
+    throw new Error("Partner demand policy requires a channel or service-provider link.");
+  }
+  const template = DEMAND_PROJECTION_TEMPLATES[preset];
+  const id = contractId(link.linkId);
+  await db.projectionContract.upsert({
+    where: { contractId: id },
+    create: {
+      contractId: id,
+      federationLinkId: link.linkId,
+      includeSlices: template.includeSlices,
+      excludeSlices: template.excludeSlices,
+      fieldAllowList: template.fieldAllowList,
+      retentionClass: template.retentionClass,
+      cadaPosture: { demandChannelPolicy: policy },
+    },
+    update: {
+      includeSlices: template.includeSlices,
+      excludeSlices: template.excludeSlices,
+      fieldAllowList: template.fieldAllowList,
+      retentionClass: template.retentionClass,
+      cadaPosture: { demandChannelPolicy: policy },
+    },
+  });
+  if (link.projectionContractId !== id) {
+    await db.federationLink.update({
+      where: { linkId: link.linkId },
+      data: { projectionContractId: id },
+    });
+  }
+}
+
+export async function selectLocalDemandForLink(
+  db: ChannelDemandDb,
+  input: {
+    linkId: string;
+    itemId: string;
+    attribution?: ChannelDemandPolicy["attribution"];
+    allowForwardToFounder?: boolean;
+    forwardingExpiresAt?: string;
+    now?: Date;
+  },
+  deps: {
+    resolveIdentity?: typeof resolveFederationIdentity;
+    queueProjection?: typeof queueDemandProjection;
+  } = {},
+) {
+  const [link, item, stored] = await Promise.all([
+    db.federationLink.findUnique({ where: { linkId: input.linkId } }),
+    db.backlogItem.findUnique({
+      where: { itemId: input.itemId },
+      select: {
+        itemId: true,
+        title: true,
+        body: true,
+        workType: true,
+        occurrenceCount: true,
+        createdAt: true,
+        updatedAt: true,
+        digitalProduct: { select: { productId: true } },
+      },
+    }),
+    db.projectionContract.findFirst({
+      where: { federationLinkId: input.linkId },
+      select: { cadaPosture: true },
+    }),
+  ]);
+  assertTrustedPartnerLink(link);
+  if (!item) throw new Error("Local demand item was not found.");
+  if ((item.body ?? "").includes("[origin:federatedDemand:")) {
+    throw new Error("Adopted demand must use governed forwarding so original provenance is preserved.");
+  }
+  const preset = relationshipPresetForRole(link.role);
+  if (preset !== "channel" && preset !== "service-provider") {
+    throw new Error("This relationship cannot receive explicitly shared demand.");
+  }
+  const current = decodeChannelDemandPolicy(stored?.cadaPosture);
+  const policy: ChannelDemandPolicy = {
+    ...current,
+    selectedRecordRefs: [...new Set([...current.selectedRecordRefs, item.itemId])],
+    attribution: input.attribution ?? current.attribution,
+    allowTransitiveForwarding: input.allowForwardToFounder === true,
+    forwardingAudiences: input.allowForwardToFounder ? ["founder"] : [],
+    ...(input.forwardingExpiresAt ? { forwardingExpiresAt: input.forwardingExpiresAt } : {}),
+  };
+  await storePolicy(db, link, policy);
+  const identity = await (deps.resolveIdentity ?? resolveFederationIdentity)(db);
+  const result = await (deps.queueProjection ?? queueDemandProjection)(db, {
+    link,
+    source: {
+      localRecordRef: item.itemId,
+      title: item.title,
+      summary: safeSummary(item.body, item.title),
+      workType: item.workType,
+      occurrenceCount: item.occurrenceCount,
+      product: item.digitalProduct?.productId ?? null,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    },
+    identity,
+    contract: DEMAND_PROJECTION_TEMPLATES[preset],
+    audience: audienceForOutboundRole(link.role),
+    attribution: policy.attribution,
+    forwarding: forwardingGrantFromPolicy(policy),
+    now: input.now,
+  });
+  return { ...result, policy };
+}
+
+export async function unselectLocalDemandForLink(
+  db: ChannelDemandDb,
+  input: { linkId: string; itemId: string; now?: Date },
+  deps: { queueWithdrawal?: typeof queueDemandWithdrawal } = {},
+) {
+  const [link, stored] = await Promise.all([
+    db.federationLink.findUnique({ where: { linkId: input.linkId } }),
+    db.projectionContract.findFirst({
+      where: { federationLinkId: input.linkId },
+      select: { cadaPosture: true },
+    }),
+  ]);
+  assertTrustedPartnerLink(link);
+  const current = decodeChannelDemandPolicy(stored?.cadaPosture);
+  if (!channelPolicySelectsRecord(current, input.itemId)) {
+    return { action: "noop" as const, policy: current };
+  }
+  const policy = {
+    ...current,
+    selectedRecordRefs: current.selectedRecordRefs.filter((ref) => ref !== input.itemId),
+  };
+  await storePolicy(db, link, policy);
+  const result = await (deps.queueWithdrawal ?? queueDemandWithdrawal)(
+    db,
+    link.linkId,
+    input.itemId,
+    input.now,
+  );
+  return { ...result, policy };
+}
+
+export async function forwardIncomingDemandToLink(
+  db: ChannelDemandDb,
+  input: { mirrorId: string; targetLinkId: string; now?: Date },
+  deps: {
+    resolveIdentity?: typeof resolveFederationIdentity;
+    queueForward?: typeof queueForwardedDemand;
+  } = {},
+) {
+  const [mirror, target] = await Promise.all([
+    db.federatedRecordMirror.findUnique({ where: { mirrorId: input.mirrorId } }),
+    db.federationLink.findUnique({ where: { linkId: input.targetLinkId } }),
+  ]);
+  if (!mirror || mirror.canonicalSide !== "peer") throw new Error("Incoming shared demand was not found.");
+  if (mirror.federationLinkId === input.targetLinkId) throw new Error("Demand cannot be forwarded back over its incoming link.");
+  assertTrustedPartnerLink(target);
+  if (target.role !== "channel-downstream") {
+    throw new Error("Selective upstream forwarding requires a founder/channel-upstream peer.");
+  }
+  if (!target.peerInstallationId) {
+    throw new Error("The target peer identity has not been reconciled yet.");
+  }
+  const current = decodeDemandMirrorPayload(mirror.payload);
+  if (!current || current.disposition === "withdrawn" || mirror.syncStatus === "withdrawn") {
+    throw new Error("Withdrawn or invalid demand cannot be forwarded.");
+  }
+  const identity = await (deps.resolveIdentity ?? resolveFederationIdentity)(db);
+  const envelope = forwardDemandEnvelope({
+    envelope: current.envelope,
+    targetAudience: "founder",
+    forwardingInstallationId: identity.installationId,
+    receivingInstallationId: target.peerInstallationId,
+    relationshipKind: "channel",
+    linkId: target.linkId,
+    now: input.now,
+  });
+  return (deps.queueForward ?? queueForwardedDemand)(db, {
+    link: target,
+    localMirrorRef: mirror.mirrorId,
+    envelope,
+    now: input.now,
+  });
+}

--- a/apps/web/lib/federation/client.ts
+++ b/apps/web/lib/federation/client.ts
@@ -6,7 +6,7 @@
 // storage is a separate slice). Injected `fetchImpl` keeps it unit-testable.
 
 import { toCloudEvent } from "@dpf/db/projection-serialization";
-import type { InboundDemandActivity } from "./demand-exchange";
+import type { DemandActivity } from "@dpf/db/federated-demand-contract";
 
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
 import { assertSafeOutboundUrl } from "@/lib/security/safe-fetch";
@@ -114,7 +114,7 @@ export async function sendProposalToPeer(target: PeerLinkTarget, proposal: unkno
 /** Deliver one versioned, already-minimized demand envelope to a trusted peer. */
 export async function sendDemandToPeer(
   target: PeerLinkTarget,
-  activity: InboundDemandActivity,
+  activity: DemandActivity,
   demandEnvelope: unknown,
   options: { eventId?: string; now?: Date } = {},
 ): Promise<PeerPostResult> {

--- a/apps/web/lib/federation/demand-delivery.test.ts
+++ b/apps/web/lib/federation/demand-delivery.test.ts
@@ -4,6 +4,7 @@ import { DEMAND_PROJECTION_TEMPLATES } from "@dpf/db/federated-demand-contract";
 
 import {
   dispatchDueDemand,
+  queueForwardedDemand,
   queueDemandProjection,
   queueDemandWithdrawal,
   retryDelayMs,
@@ -148,6 +149,56 @@ describe("queueDemandProjection", () => {
       syncStatus: "pending", deliveryAttempts: 0,
     }) }));
     expect(update.mock.calls[0][0].data.payload.envelope.originVersion).toBeGreaterThan(10);
+  });
+});
+
+describe("queueForwardedDemand", () => {
+  it("retains original provenance and uses only a local mirror as its outbox key", async () => {
+    const create = vi.fn().mockResolvedValue({});
+    const db = {
+      federationLink: { findMany: vi.fn() },
+      federatedRecordMirror: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create,
+        update: vi.fn(),
+        findMany: vi.fn(),
+      },
+    } as unknown as DemandDeliveryDb;
+    const forwarded = {
+      specVersion: "dpf.demand/1" as const,
+      envelopeId: "dem_origin",
+      originInstallationId: "inst_customer",
+      originRecordRef: "ref_customer",
+      originVersion: 9,
+      route: [{
+        installationId: "inst_reseller",
+        relationshipKind: "channel",
+        receivedAt: "2026-07-20T06:00:00.000Z",
+        attestationDigest: `sha256:${"a".repeat(64)}`,
+      }],
+      audience: "founder" as const,
+      title: "Curated request",
+      summary: "Still source-owned",
+      signal: { occurrenceCount: 4 },
+      attribution: "pseudonymous" as const,
+      forwarding: { permitted: true, audiences: ["founder" as const] },
+      createdAt: "2026-07-20T05:00:00.000Z",
+      updatedAt: "2026-07-20T06:00:00.000Z",
+      payloadDigest: `sha256:${"b".repeat(64)}`,
+    };
+
+    await queueForwardedDemand(db, {
+      link,
+      localMirrorRef: "fdm_incoming_1",
+      envelope: forwarded,
+      now: new Date("2026-07-20T06:01:00.000Z"),
+    });
+
+    const data = create.mock.calls[0][0].data;
+    expect(data.localRecordRef).toBe("forward:fdm_incoming_1");
+    expect(data.payload.envelope.originInstallationId).toBe("inst_customer");
+    expect(data.payload.envelope.originRecordRef).toBe("ref_customer");
+    expect(data.payload.envelope.attribution).toBe("pseudonymous");
   });
 });
 

--- a/apps/web/lib/federation/demand-delivery.ts
+++ b/apps/web/lib/federation/demand-delivery.ts
@@ -5,6 +5,7 @@ import type {
   DemandAttribution,
   DemandAudience,
   DemandEnvelopeV1,
+  DemandResponseV1,
 } from "@dpf/db/federated-demand-contract";
 import { computeDemandPayloadDigest } from "@dpf/db/federated-demand-contract";
 import type { ProjectionContractSpec } from "@dpf/db/projection-serialization";
@@ -15,10 +16,11 @@ import type { FederationIdentity } from "./demand-identity";
 import { decryptPeerToken } from "./outbound";
 
 type OutboundDemandActivity = Extract<DemandActivity, "dpf.demand.proposed" | "dpf.demand.updated" | "dpf.demand.withdrawn">;
+type OutboundResponseActivity = Extract<DemandActivity, "dpf.demand.interest-recorded" | "dpf.demand.help-offered">;
 
 export interface DemandOutboxPayload {
-  envelope: DemandEnvelopeV1;
-  activity: OutboundDemandActivity;
+  envelope: DemandEnvelopeV1 | DemandResponseV1;
+  activity: OutboundDemandActivity | OutboundResponseActivity;
   eventId: string;
   queuedAt: string;
 }
@@ -26,6 +28,7 @@ export interface DemandOutboxPayload {
 interface DemandOutboxRow {
   mirrorId: string;
   federationLinkId: string;
+  canonicalSide?: string;
   version: number;
   syncStatus: string;
   deliveryAttempts: number;
@@ -72,7 +75,7 @@ export function decodeDemandOutboxPayload(value: unknown): DemandOutboxPayload |
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const payload = value as Partial<DemandOutboxPayload>;
   if (!payload.envelope || typeof payload.envelope !== "object" || typeof payload.eventId !== "string") return null;
-  if (!["dpf.demand.proposed", "dpf.demand.updated", "dpf.demand.withdrawn"].includes(payload.activity ?? "")) return null;
+  if (!["dpf.demand.proposed", "dpf.demand.updated", "dpf.demand.withdrawn", "dpf.demand.interest-recorded", "dpf.demand.help-offered"].includes(payload.activity ?? "")) return null;
   return payload as DemandOutboxPayload;
 }
 
@@ -83,6 +86,7 @@ export async function queueDemandProjection(db: DemandDeliveryDb, input: {
   contract: ProjectionContractSpec;
   audience: DemandAudience;
   attribution: DemandAttribution;
+  forwarding?: DemandEnvelopeV1["forwarding"];
   now?: Date;
 }): Promise<{ action: "queued" | "noop"; mirrorId: string; originVersion: number }> {
   const built = buildDemandEnvelope(input);
@@ -127,6 +131,54 @@ export async function queueDemandProjection(db: DemandDeliveryDb, input: {
   return { action: "queued", mirrorId, originVersion: built.envelope.originVersion };
 }
 
+/** Queue an already-minimized, consent-validated forwarded envelope without
+ * rewriting its origin. The local mirror ref is an internal routing key only. */
+export async function queueForwardedDemand(db: DemandDeliveryDb, input: {
+  link: DemandLinkTarget;
+  localMirrorRef: string;
+  envelope: DemandEnvelopeV1;
+  now?: Date;
+}): Promise<{ action: "queued" | "noop"; mirrorId: string; originVersion: number }> {
+  const localRecordRef = `forward:${input.localMirrorRef}`;
+  const where = localWhere(input.link.linkId, localRecordRef);
+  const existing = await db.federatedRecordMirror.findUnique({ where });
+  const prior = decodeDemandOutboxPayload(existing?.payload);
+  if (existing && prior?.envelope.payloadDigest === input.envelope.payloadDigest) {
+    return { action: "noop", mirrorId: existing.mirrorId, originVersion: existing.version };
+  }
+  const activity: OutboundDemandActivity = existing ? "dpf.demand.updated" : "dpf.demand.proposed";
+  const payload: DemandOutboxPayload = {
+    envelope: input.envelope,
+    activity,
+    eventId: eventId(input.link.linkId, input.envelope, activity),
+    queuedAt: (input.now ?? new Date()).toISOString(),
+  };
+  const data = {
+    syncStatus: "pending",
+    version: input.envelope.originVersion,
+    payload,
+    deliveryAttempts: 0,
+    nextDeliveryAt: input.now ?? new Date(),
+    lastDeliveryError: null,
+    deadLetteredAt: null,
+  };
+  if (existing) {
+    await db.federatedRecordMirror.update({ where: { mirrorId: existing.mirrorId }, data });
+    return { action: "queued", mirrorId: existing.mirrorId, originVersion: input.envelope.originVersion };
+  }
+  const mirrorId = outboxId(input.link.linkId, localRecordRef);
+  await db.federatedRecordMirror.create({ data: {
+    mirrorId,
+    federationLinkId: input.link.linkId,
+    recordType: "demand-envelope",
+    canonicalSide: "local",
+    localRecordRef,
+    peerRecordRef: null,
+    ...data,
+  } });
+  return { action: "queued", mirrorId, originVersion: input.envelope.originVersion };
+}
+
 export async function queueDemandWithdrawal(
   db: DemandDeliveryDb,
   linkId: string,
@@ -136,7 +188,7 @@ export async function queueDemandWithdrawal(
   const existing = await db.federatedRecordMirror.findUnique({ where: localWhere(linkId, localRecordRef) });
   if (!existing) return { action: "noop", activity: "dpf.demand.withdrawn", mirrorId: "" };
   const prior = decodeDemandOutboxPayload(existing.payload);
-  if (!prior) throw new Error("Stored demand outbox payload is invalid.");
+  if (!prior || prior.envelope.specVersion !== "dpf.demand/1") throw new Error("Stored demand outbox payload is invalid.");
   if (prior.activity === "dpf.demand.withdrawn" && existing.syncStatus === "synced") {
     return { action: "noop", activity: "dpf.demand.withdrawn", mirrorId: existing.mirrorId };
   }
@@ -180,7 +232,7 @@ export async function dispatchDueDemand(db: DemandDeliveryDb, options: {
   const now = options.now ?? new Date();
   const rows = await db.federatedRecordMirror.findMany({
     where: {
-      recordType: "demand-envelope", canonicalSide: "local", syncStatus: "pending",
+      recordType: { in: ["demand-envelope", "demand-response"] }, canonicalSide: "local", syncStatus: "pending",
       OR: [{ nextDeliveryAt: null }, { nextDeliveryAt: { lte: now } }],
     },
     orderBy: [{ nextDeliveryAt: "asc" }, { updatedAt: "asc" }],
@@ -212,9 +264,14 @@ export async function dispatchDueDemand(db: DemandDeliveryDb, options: {
       { eventId: payload.eventId, now },
     );
 
+    const responseId = payload?.envelope.specVersion === "dpf.demand-response/1"
+      ? payload.envelope.responseId
+      : null;
     const acknowledged = result.ok
       && typeof result.body === "object" && result.body !== null
-      && Number((result.body as { originVersion?: unknown }).originVersion) === row.version;
+      && (responseId
+        ? (result.body as { responseId?: unknown }).responseId === responseId
+        : Number((result.body as { originVersion?: unknown }).originVersion) === row.version);
     if (acknowledged) {
       delivered++;
       await db.federatedRecordMirror.update({ where: { mirrorId: row.mirrorId }, data: {

--- a/apps/web/lib/federation/demand-digest.ts
+++ b/apps/web/lib/federation/demand-digest.ts
@@ -98,7 +98,9 @@ export async function reconcileDemandDigests(
     if (rows.length === 0) continue;
     const usable = rows.flatMap((row) => {
       const payload = decodeDemandOutboxPayload(row.payload);
-      return payload && row.mirrorId ? [{ row, payload }] : [];
+      return payload && payload.envelope.specVersion === "dpf.demand/1" && row.mirrorId
+        ? [{ row, payload: { ...payload, envelope: payload.envelope } }]
+        : [];
     });
     const records = usable.map(({ payload }) => ({
       originRecordRef: payload.envelope.originRecordRef,

--- a/apps/web/lib/federation/demand-projection.ts
+++ b/apps/web/lib/federation/demand-projection.ts
@@ -31,6 +31,7 @@ export function buildDemandEnvelope(input: {
   contract: ProjectionContractSpec;
   audience: DemandAudience;
   attribution: DemandAttribution;
+  forwarding?: DemandEnvelopeV1["forwarding"];
 }): { envelope: DemandEnvelopeV1; violations: string[] } {
   const refs = deriveDemandNetworkRefs(input.identity, input.source.localRecordRef);
   const candidate: DemandEnvelopeV1 = {
@@ -46,6 +47,7 @@ export function buildDemandEnvelope(input: {
     ...(input.source.product ? { applicability: { product: input.source.product } } : {}),
     signal: { occurrenceCount: Math.max(0, input.source.occurrenceCount) },
     attribution: input.attribution,
+    ...(input.forwarding ? { forwarding: input.forwarding } : {}),
     createdAt: input.source.createdAt.toISOString(),
     updatedAt: input.source.updatedAt.toISOString(),
     payloadDigest: "sha256:pending",

--- a/apps/web/lib/federation/demand-read-model.test.ts
+++ b/apps/web/lib/federation/demand-read-model.test.ts
@@ -47,6 +47,8 @@ describe("mapNetworkDemandRows", () => {
       originVersion: 2,
       updatedAt: "2026-07-20T05:10:00.000Z",
       localItemId: null,
+      forwardingToFounderPermitted: false,
+      forwardingExpiresAt: null,
     }]);
     expect(JSON.stringify(rows)).not.toContain("private-install-id");
     expect(JSON.stringify(rows)).not.toContain("private-record-ref");

--- a/apps/web/lib/federation/demand-read-model.ts
+++ b/apps/web/lib/federation/demand-read-model.ts
@@ -3,6 +3,7 @@ import { cache } from "react";
 import { prisma } from "@dpf/db";
 
 import { decodeDemandMirrorPayload, type DemandDisposition } from "./demand-exchange";
+import { decodeDemandResponseMirrorPayload } from "./demand-response";
 
 export interface NetworkDemandView {
   mirrorId: string;
@@ -17,6 +18,34 @@ export interface NetworkDemandView {
   originVersion: number;
   updatedAt: string;
   localItemId: string | null;
+  forwardingToFounderPermitted: boolean;
+  forwardingExpiresAt: string | null;
+}
+
+export interface DemandShareTarget {
+  linkId: string;
+  displayName: string;
+  role: string;
+  sharedItemIds: string[];
+}
+
+export interface LocalDemandShareCandidate {
+  itemId: string;
+  title: string;
+  status: string;
+}
+
+export interface DemandShareContext {
+  targets: DemandShareTarget[];
+  founderTargets: Array<{ linkId: string; displayName: string }>;
+  localItems: LocalDemandShareCandidate[];
+  responses: Array<{
+    responseId: string;
+    sourceName: string;
+    responseKind: "interest" | "help-offer";
+    message: string | null;
+    receivedAt: string;
+  }>;
 }
 
 interface DemandReadRow {
@@ -46,6 +75,10 @@ export function mapNetworkDemandRows(rows: DemandReadRow[]): NetworkDemandView[]
       originVersion: row.version,
       updatedAt: (row.lastSyncedAt ?? new Date(payload.receivedAt)).toISOString(),
       localItemId: row.localRecordRef,
+      forwardingToFounderPermitted:
+        envelope.forwarding?.permitted === true
+        && envelope.forwarding.audiences.includes("founder"),
+      forwardingExpiresAt: envelope.forwarding?.expiresAt ?? null,
     }];
   });
 }
@@ -64,4 +97,82 @@ export const getNetworkDemandItems = cache(async (): Promise<NetworkDemandView[]
     },
   });
   return mapNetworkDemandRows(rows);
+});
+
+export const getDemandShareContext = cache(async (): Promise<DemandShareContext> => {
+  const [links, localItems, mirrors, responseMirrors] = await Promise.all([
+    prisma.federationLink.findMany({
+      where: {
+        role: { in: ["manages", "managed-by", "channel-upstream", "channel-downstream"] },
+        linkState: "trusted",
+        revokedAt: null,
+        quarantinedAt: null,
+      },
+      select: {
+        linkId: true,
+        role: true,
+        peerInstallationId: true,
+        principal: { select: { displayName: true } },
+      },
+      orderBy: { createdAt: "asc" },
+    }),
+    prisma.backlogItem.findMany({
+      where: {
+        status: { in: ["open", "in-progress"] },
+        NOT: { body: { contains: "[origin:federatedDemand:" } },
+      },
+      select: { itemId: true, title: true, status: true },
+      orderBy: [{ priority: "desc" }, { updatedAt: "desc" }],
+      take: 200,
+    }),
+    prisma.federatedRecordMirror.findMany({
+      where: {
+        recordType: "demand-envelope",
+        canonicalSide: "local",
+        localRecordRef: { not: null },
+        syncStatus: { notIn: ["withdrawn", "revoked"] },
+      },
+      select: { federationLinkId: true, localRecordRef: true },
+    }),
+    prisma.federatedRecordMirror.findMany({
+      where: { recordType: "demand-response", canonicalSide: "peer", syncStatus: "synced" },
+      select: {
+        federationLinkId: true,
+        payload: true,
+      },
+      orderBy: { lastSyncedAt: "desc" },
+      take: 200,
+    }),
+  ]);
+  const sharedByLink = new Map<string, string[]>();
+  for (const mirror of mirrors) {
+    if (!mirror.localRecordRef || mirror.localRecordRef.startsWith("forward:")) continue;
+    const refs = sharedByLink.get(mirror.federationLinkId) ?? [];
+    refs.push(mirror.localRecordRef);
+    sharedByLink.set(mirror.federationLinkId, refs);
+  }
+  return {
+    targets: links.map((link) => ({
+      linkId: link.linkId,
+      displayName: link.principal.displayName,
+      role: link.role,
+      sharedItemIds: sharedByLink.get(link.linkId) ?? [],
+    })),
+    founderTargets: links
+      .filter((link) => link.role === "channel-downstream" && link.peerInstallationId)
+      .map((link) => ({ linkId: link.linkId, displayName: link.principal.displayName })),
+    localItems,
+    responses: responseMirrors.flatMap((mirror) => {
+      const payload = decodeDemandResponseMirrorPayload(mirror.payload);
+      if (!payload) return [];
+      const source = links.find((link) => link.linkId === mirror.federationLinkId);
+      return [{
+        responseId: payload.response.responseId,
+        sourceName: source?.principal.displayName ?? "Connected installation",
+        responseKind: payload.response.responseKind,
+        message: payload.response.message ?? null,
+        receivedAt: payload.receivedAt,
+      }];
+    }),
+  };
 });

--- a/apps/web/lib/federation/demand-response.test.ts
+++ b/apps/web/lib/federation/demand-response.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  computeDemandPayloadDigest,
+  computeDemandResponseDigest,
+  type DemandEnvelopeV1,
+  type DemandResponseV1,
+} from "@dpf/db/federated-demand-contract";
+
+import { handleIncomingDemandResponse, queueDemandResponse, type DemandResponseDb } from "./demand-response";
+
+const identity = { installationId: `inst_${"a".repeat(32)}`, projectionSecret: "b".repeat(64) };
+const envelope = (): DemandEnvelopeV1 => {
+  const value: DemandEnvelopeV1 = {
+    specVersion: "dpf.demand/1",
+    envelopeId: "dem_opaque",
+    originInstallationId: identity.installationId,
+    originRecordRef: "ref_opaque",
+    originVersion: 1,
+    route: [],
+    audience: "partner",
+    title: "Shared need",
+    summary: "Minimized collaboration context.",
+    signal: { occurrenceCount: 2 },
+    attribution: "pseudonymous",
+    createdAt: "2026-07-20T06:00:00.000Z",
+    updatedAt: "2026-07-20T06:00:00.000Z",
+    payloadDigest: "sha256:pending",
+  };
+  value.payloadDigest = computeDemandPayloadDigest(value);
+  return value;
+};
+
+function response(): DemandResponseV1 {
+  const value: DemandResponseV1 = {
+    specVersion: "dpf.demand-response/1",
+    responseId: "rsp_opaque",
+    envelopeId: "dem_opaque",
+    originInstallationId: identity.installationId,
+    originRecordRef: "ref_opaque",
+    responseKind: "help-offer",
+    message: "We can validate this need.",
+    responderAttribution: "organization",
+    createdAt: "2026-07-20T06:10:00.000Z",
+    payloadDigest: "sha256:pending",
+  };
+  value.payloadDigest = computeDemandResponseDigest(value);
+  return value;
+}
+
+function db(overrides: {
+  incoming?: unknown;
+  existingResponse?: unknown;
+  shared?: unknown[];
+} = {}) {
+  const create = vi.fn().mockResolvedValue({});
+  const findUnique = vi.fn().mockImplementation((args: { where?: Record<string, unknown> }) => {
+    if ("mirrorId" in (args.where ?? {})) return Promise.resolve(overrides.incoming ?? null);
+    return Promise.resolve(overrides.existingResponse ?? null);
+  });
+  return {
+    value: {
+      federationLink: {
+        findUnique: vi.fn().mockResolvedValue({
+          linkId: "link_1", peerAuthorityUrl: "https://peer.example", peerTokenEnc: "enc",
+          linkState: "trusted", revokedAt: null, quarantinedAt: null,
+        }),
+        findMany: vi.fn(),
+      },
+      federatedRecordMirror: {
+        findUnique,
+        findMany: vi.fn().mockResolvedValue(overrides.shared ?? []),
+        create,
+        update: vi.fn().mockResolvedValue({}),
+      },
+    } as unknown as DemandResponseDb,
+    create,
+  };
+}
+
+describe("queueDemandResponse", () => {
+  it("queues an opaque durable help offer back to the source link", async () => {
+    const incomingEnvelope = envelope();
+    const { value, create } = db({ incoming: {
+      mirrorId: "fdm_incoming", federationLinkId: "link_1", canonicalSide: "peer",
+      localRecordRef: null, peerRecordRef: "peer", syncStatus: "synced", version: 1,
+      payload: { envelope: incomingEnvelope, activity: "dpf.demand.proposed", disposition: "observed", receivedAt: incomingEnvelope.createdAt },
+    } });
+
+    const result = await queueDemandResponse(value, {
+      mirrorId: "fdm_incoming", kind: "help-offer", identity,
+      message: "We can validate this need.", now: new Date("2026-07-20T06:10:00.000Z"),
+    });
+
+    expect(result.action).toBe("queued");
+    const data = create.mock.calls[0][0].data;
+    expect(data).toMatchObject({ recordType: "demand-response", canonicalSide: "local", federationLinkId: "link_1" });
+    expect(data.payload.activity).toBe("dpf.demand.help-offered");
+    expect(JSON.stringify(data.payload)).not.toContain("fdm_incoming");
+  });
+
+  it("rejects responses to withdrawn demand", async () => {
+    const incomingEnvelope = envelope();
+    const { value } = db({ incoming: {
+      mirrorId: "fdm_incoming", federationLinkId: "link_1", canonicalSide: "peer",
+      localRecordRef: null, peerRecordRef: "peer", syncStatus: "withdrawn", version: 2,
+      payload: { envelope: incomingEnvelope, activity: "dpf.demand.withdrawn", disposition: "withdrawn", receivedAt: incomingEnvelope.createdAt },
+    } });
+
+    await expect(queueDemandResponse(value, { mirrorId: "fdm_incoming", kind: "interest", identity }))
+      .rejects.toThrow("Withdrawn or invalid demand");
+  });
+});
+
+describe("handleIncomingDemandResponse", () => {
+  it("persists an idempotent response only for an envelope shared on the same link", async () => {
+    const demand = envelope();
+    const shared = [{ payload: {
+      envelope: demand, activity: "dpf.demand.proposed", eventId: "evt", queuedAt: demand.createdAt,
+    } }];
+    const first = db({ shared });
+    await expect(handleIncomingDemandResponse(first.value, "link_1", response()))
+      .resolves.toMatchObject({ action: "created", responseId: "rsp_opaque" });
+    expect(first.create).toHaveBeenCalledTimes(1);
+
+    const second = db({ shared, existingResponse: { mirrorId: "fdri_existing" } });
+    await expect(handleIncomingDemandResponse(second.value, "link_1", response()))
+      .resolves.toMatchObject({ action: "noop", responseId: "rsp_opaque" });
+    expect(second.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a response for an envelope that was never shared on the link", async () => {
+    const { value, create } = db({ shared: [] });
+    await expect(handleIncomingDemandResponse(value, "link_1", response()))
+      .resolves.toEqual({ action: "rejected", violations: ["response:unknown-envelope"] });
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/federation/demand-response.ts
+++ b/apps/web/lib/federation/demand-response.ts
@@ -1,0 +1,179 @@
+import { createHmac } from "node:crypto";
+
+import {
+  computeDemandResponseDigest,
+  validateDemandResponseV1,
+  type DemandResponseKind,
+  type DemandResponseV1,
+} from "@dpf/db/federated-demand-contract";
+
+import {
+  decodeDemandOutboxPayload,
+  type DemandDeliveryDb,
+  type DemandLinkTarget,
+} from "./demand-delivery";
+import { decodeDemandMirrorPayload } from "./demand-exchange";
+import type { FederationIdentity } from "./demand-identity";
+
+interface ResponseMirrorRow {
+  mirrorId: string;
+  federationLinkId: string;
+  canonicalSide: string;
+  localRecordRef: string | null;
+  peerRecordRef: string | null;
+  syncStatus: string;
+  version: number;
+  payload: unknown;
+}
+
+export interface DemandResponseDb extends DemandDeliveryDb {
+  federationLink: DemandDeliveryDb["federationLink"] & {
+    findUnique(args: unknown): Promise<(DemandLinkTarget & { linkState: string; revokedAt: Date | null; quarantinedAt: Date | null }) | null>;
+  };
+  federatedRecordMirror: DemandDeliveryDb["federatedRecordMirror"] & {
+    findUnique(args: unknown): Promise<ResponseMirrorRow | null>;
+    findMany(args: unknown): Promise<ResponseMirrorRow[]>;
+  };
+}
+
+export interface DemandResponseMirrorPayload {
+  response: DemandResponseV1;
+  receivedAt: string;
+}
+
+export function decodeDemandResponseMirrorPayload(value: unknown): DemandResponseMirrorPayload | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const payload = value as Partial<DemandResponseMirrorPayload>;
+  if (!payload.response || validateDemandResponseV1(payload.response).length > 0) return null;
+  return payload as DemandResponseMirrorPayload;
+}
+
+function responseId(
+  identity: FederationIdentity,
+  linkId: string,
+  originRecordRef: string,
+  kind: DemandResponseKind,
+): string {
+  return `rsp_${createHmac("sha256", identity.projectionSecret)
+    .update(`${linkId}\u0000${originRecordRef}\u0000${kind}`)
+    .digest("hex")}`;
+}
+
+export async function queueDemandResponse(
+  db: DemandResponseDb,
+  input: {
+    mirrorId: string;
+    kind: DemandResponseKind;
+    message?: string;
+    identity: FederationIdentity;
+    now?: Date;
+  },
+): Promise<{ action: "queued" | "noop"; responseId: string }> {
+  const incoming = await db.federatedRecordMirror.findUnique({ where: { mirrorId: input.mirrorId } });
+  if (!incoming || incoming.canonicalSide !== "peer") throw new Error("Incoming shared demand was not found.");
+  const demand = decodeDemandMirrorPayload(incoming.payload);
+  if (!demand || demand.disposition === "withdrawn" || incoming.syncStatus === "withdrawn") {
+    throw new Error("Withdrawn or invalid demand cannot receive a response.");
+  }
+  const link = await db.federationLink.findUnique({ where: { linkId: incoming.federationLinkId } });
+  if (!link || link.linkState !== "trusted" || link.revokedAt || link.quarantinedAt) {
+    throw new Error("The source connection is not trusted and active.");
+  }
+  const id = responseId(input.identity, link.linkId, demand.envelope.originRecordRef, input.kind);
+  const localRecordRef = `response:${input.mirrorId}:${input.kind}`;
+  const existing = await db.federatedRecordMirror.findUnique({
+    where: {
+      federationLinkId_recordType_localRecordRef: {
+        federationLinkId: link.linkId,
+        recordType: "demand-response",
+        localRecordRef,
+      },
+    },
+  });
+  if (existing?.syncStatus === "synced") return { action: "noop", responseId: id };
+  const createdAt = (input.now ?? new Date()).toISOString();
+  const response: DemandResponseV1 = {
+    specVersion: "dpf.demand-response/1",
+    responseId: id,
+    envelopeId: demand.envelope.envelopeId,
+    originInstallationId: demand.envelope.originInstallationId,
+    originRecordRef: demand.envelope.originRecordRef,
+    responseKind: input.kind,
+    ...(input.message?.trim() ? { message: input.message.trim().slice(0, 1_000) } : {}),
+    responderAttribution: "organization",
+    createdAt,
+    payloadDigest: "sha256:pending",
+  };
+  response.payloadDigest = computeDemandResponseDigest(response);
+  const activity = input.kind === "help-offer"
+    ? "dpf.demand.help-offered" as const
+    : "dpf.demand.interest-recorded" as const;
+  const data = {
+    syncStatus: "pending",
+    version: (input.now ?? new Date()).getTime(),
+    payload: { envelope: response, activity, eventId: id, queuedAt: createdAt },
+    deliveryAttempts: 0,
+    nextDeliveryAt: input.now ?? new Date(),
+    lastDeliveryError: null,
+    deadLetteredAt: null,
+  };
+  if (existing) {
+    await db.federatedRecordMirror.update({ where: { mirrorId: existing.mirrorId }, data });
+  } else {
+    await db.federatedRecordMirror.create({ data: {
+      mirrorId: `fdr_${id.slice(4, 28)}`,
+      federationLinkId: link.linkId,
+      recordType: "demand-response",
+      canonicalSide: "local",
+      localRecordRef,
+      peerRecordRef: null,
+      ...data,
+    } });
+  }
+  return { action: "queued", responseId: id };
+}
+
+export async function handleIncomingDemandResponse(
+  db: DemandResponseDb,
+  linkId: string,
+  response: DemandResponseV1,
+  now = new Date(),
+): Promise<{ action: "created" | "noop" | "rejected"; responseId?: string; violations?: string[] }> {
+  const violations = validateDemandResponseV1(response);
+  if (violations.length > 0) return { action: "rejected", violations };
+  const shared = await db.federatedRecordMirror.findMany({
+    where: { federationLinkId: linkId, recordType: "demand-envelope", canonicalSide: "local" },
+    select: { payload: true },
+    take: 1_000,
+  });
+  const matchesSharedEnvelope = shared.some((row) => {
+    const payload = decodeDemandOutboxPayload(row.payload);
+    return payload?.envelope.specVersion === "dpf.demand/1"
+      && payload.envelope.envelopeId === response.envelopeId
+      && payload.envelope.originInstallationId === response.originInstallationId
+      && payload.envelope.originRecordRef === response.originRecordRef;
+  });
+  if (!matchesSharedEnvelope) return { action: "rejected", violations: ["response:unknown-envelope"] };
+  const where = {
+    federationLinkId_recordType_peerRecordRef: {
+      federationLinkId: linkId,
+      recordType: "demand-response",
+      peerRecordRef: response.responseId,
+    },
+  };
+  const existing = await db.federatedRecordMirror.findUnique({ where });
+  if (existing) return { action: "noop", responseId: response.responseId };
+  await db.federatedRecordMirror.create({ data: {
+    mirrorId: `fdri_${response.responseId.slice(4, 28)}`,
+    federationLinkId: linkId,
+    recordType: "demand-response",
+    canonicalSide: "peer",
+    localRecordRef: null,
+    peerRecordRef: response.responseId,
+    syncStatus: "synced",
+    version: 1,
+    payload: { response, receivedAt: now.toISOString() },
+    lastSyncedAt: now,
+  } });
+  return { action: "created", responseId: response.responseId };
+}

--- a/apps/web/lib/govern/data/assets.ts
+++ b/apps/web/lib/govern/data/assets.ts
@@ -168,6 +168,29 @@ export function resolveField(
 // baseline (legacy-coverage-baseline.ts), never as a blanket "internal" default.
 
 const SEED_ASSETS: readonly DataAssetDefinition[] = [
+  ...[
+    ["data:partner-account", "PartnerAccount"],
+    ["data:partner-agreement", "PartnerAgreement"],
+    ["data:partner-entitlement", "PartnerEntitlement"],
+    ["data:partner-support-route", "PartnerSupportRoute"],
+    ["data:partner-contribution-recognition", "PartnerContributionRecognition"],
+  ].map(([id, prismaModel]) => ({
+    id: id as DataAssetId,
+    physical: { prismaModel },
+    domain: "partner-channel",
+    ownerRole: "founder-business-owner",
+    stewardRole: "data-steward",
+    categories: ["configuration"] as DataCategory[],
+    sensitivity: "confidential" as DataSensitivity,
+    criticality: "standard" as DataCriticality,
+    subjectLocators: [],
+    lifecycleClass: "operational" as LifecycleClassKey,
+    purposeCapabilities: ["service-delivery", "platform-operations"] as ProcessingPurposeKey[],
+    residencyClass: "local-only" as ResidencyClassKey,
+    projectionClass: "metadata" as ProjectionClass,
+    classification: { state: "confirmed" as const, source: "manual" as const, effectiveFrom: "2026-07-20" },
+    fields: [],
+  })),
   {
     id: "data:ai-provider-connection",
     physical: { prismaModel: "AiProviderConnection" },

--- a/docs/data-impact/2026-07-20-federated-channel.data-impact.json
+++ b/docs/data-impact/2026-07-20-federated-channel.data-impact.json
@@ -1,0 +1,115 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [
+    "Prisma-to-EA current-state data-model mirror",
+    "federated demand inbox/outbox mirrors",
+    "Founder Hub partner business read model"
+  ],
+  "migration": {
+    "name": "20260720064000_federated_channel",
+    "backfill": "none — partner business records are enrolled explicitly and peer installation identity is learned through an authenticated digest"
+  },
+  "tests": [
+    "packages/db/src/federated-channel-schema.test.ts",
+    "packages/db/src/federated-channel.test.ts",
+    "apps/web/lib/federation/channel-demand.test.ts",
+    "apps/web/lib/federation/demand-response.test.ts",
+    "apps/web/lib/federation/demand-delivery.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:federation-link#peer-installation-id",
+      "prismaModel": "FederationLink",
+      "lifecycleDisposition": "cleared with the owning federation link; no hostname-derived or globally identifying value is stored",
+      "fields": [
+        {
+          "fieldId": "data:federation-link#peerInstallationId",
+          "resolution": "governed",
+          "reason": "authenticated pseudonymous peer identity is required for forwarding loop prevention and reconciliation",
+          "provenance": "federated demand network design section 6.2",
+          "flags": ["sensitive"],
+          "fieldPolicy": "learn only from an authenticated digest on a trusted link; reject identity changes; never derive from hostname"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:partner-account",
+      "prismaModel": "PartnerAccount",
+      "lifecycleDisposition": "Founder Hub owns the commercial record; terminating or deleting the account cascades its agreements, entitlements, support routes, and recognition links",
+      "fields": [
+        {
+          "fieldId": "data:partner-account#all",
+          "resolution": "governed",
+          "reason": "Founder Hub requires a business-only reseller account distinct from customer and human identity records",
+          "provenance": "federated demand network design sections 4.1 and 11 Slice 3"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:partner-agreement",
+      "prismaModel": "PartnerAgreement",
+      "lifecycleDisposition": "cascades with PartnerAccount; expired safe references remain only under the partner retention policy",
+      "fields": [
+        {
+          "fieldId": "data:partner-agreement#all",
+          "resolution": "governed",
+          "reason": "records governed agreement state and references without copying signed documents",
+          "provenance": "federated demand network design Slice 3"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:partner-entitlement",
+      "prismaModel": "PartnerEntitlement",
+      "lifecycleDisposition": "cascades with PartnerAccount and retains nullable references when an agreement or offering is retired",
+      "fields": [
+        {
+          "fieldId": "data:partner-entitlement#all",
+          "resolution": "governed",
+          "reason": "links a partner-specific grant to the existing offering catalog",
+          "provenance": "federated demand network design Slice 3"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:partner-support-route",
+      "prismaModel": "PartnerSupportRoute",
+      "lifecycleDisposition": "cascades with PartnerAccount; disabling a route preserves its operational history without granting authority",
+      "fields": [
+        {
+          "fieldId": "data:partner-support-route#all",
+          "resolution": "governed",
+          "reason": "stores local support routing separately from federation authorization",
+          "provenance": "federated demand network design Slice 3"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:partner-contribution-recognition",
+      "prismaModel": "PartnerContributionRecognition",
+      "lifecycleDisposition": "cascades with PartnerAccount while the nullable ledger reference preserves Hive contribution authority",
+      "fields": [
+        {
+          "fieldId": "data:partner-contribution-recognition#all",
+          "resolution": "governed",
+          "reason": "recognizes a result without duplicating the immutable Hive contribution or contributor planning context",
+          "provenance": "federated demand network design sections 7.4 and Slice 3"
+        }
+      ]
+    },
+    {
+      "kind": "projection",
+      "assetId": "projection:federated-channel-demand",
+      "derivedContractId": "dpf.demand/1+dpf.demand-response/1",
+      "cleanupTest": "apps/web/lib/federation/demand-delivery.test.ts withdrawal and dead-letter cases",
+      "reconciliationTest": "apps/web/lib/federation/demand-response.test.ts same-link envelope validation and idempotency cases"
+    }
+  ]
+}

--- a/docs/operations/federated-demand-channels.md
+++ b/docs/operations/federated-demand-channels.md
@@ -1,0 +1,52 @@
+# Federated demand channels
+
+DPF installations keep their own PostgreSQL backlog. A federated demand channel
+shares a deliberately minimized demand envelope; it never exposes or co-writes
+the source backlog. The source installation decides which item can travel over
+which connection and may withdraw that projection independently.
+
+## Customer and reseller operation
+
+1. In **Platform → Connections**, create or accept a service-provider or channel
+   invitation. Both installations must approve the link before exchange begins.
+2. The customer opens **Operate → Delivery Flow**, selects one local demand item
+   and one trusted connection, and chooses **Share selected demand**.
+3. Founder forwarding is off by default. The customer may grant a reseller a
+   time-bounded right to forward that minimized envelope to Founder Hub. The
+   grant does not authorize any other audience or remote action.
+4. The reseller can follow or adopt received demand locally, record interest,
+   offer help, or forward it to an eligible Founder Hub connection when the
+   source grant permits it. Adoption creates a new reseller-owned backlog item;
+   it does not turn the remote record into shared mutable work.
+5. The source sees received interest and help receipts in Delivery Flow. It may
+   stop sharing at any time; a withdrawal is queued over that connection.
+
+Multiple customer, reseller, and specialist relationships can coexist. Each
+link has an independent projection contract and selection set. Creating one
+partner never grants exclusivity or silently selects demand for another.
+
+## Founder Hub business management
+
+The Arcamanus Founder Hub installation manages resellers from the Connections
+page. Enrolling a trusted channel connection creates a business-only partner
+account. Operators can maintain standing and safe agreement references while
+the following authorities stay separate:
+
+- `FederationLink` owns trust, revocation, and routing.
+- `PartnerAccount` and its agreement/entitlement/support records own the
+  Founder-reseller commercial relationship.
+- `ServiceOffering` owns the reusable offering catalog.
+- `HiveContributionLedger` owns submitted contribution results and evidence.
+- `BacklogItem` remains the only local work authority.
+
+A Hive contribution never carries the contributor's backlog or work capsule.
+If a reseller wants Founder Hub to understand demand behind a result, it shares
+a separate minimized demand envelope under the demand-channel consent.
+
+## Privacy and recovery behavior
+
+Pseudonymous sources remain pseudonymous through reseller forwarding. Opaque
+origin references support deduplication but cannot be dereferenced into a local
+backlog identifier. Responses are bounded to interest/help intent and reject
+source-local planning fields. Delivery is durable and retried; local backlog
+work continues when a peer or Founder Hub is offline.

--- a/docs/operations/federated-demand-channels.md
+++ b/docs/operations/federated-demand-channels.md
@@ -27,7 +27,7 @@ partner never grants exclusivity or silently selects demand for another.
 
 ## Founder Hub business management
 
-The Arcamanus Founder Hub installation manages resellers from the Connections
+The central Founder Hub installation manages resellers from the Connections
 page. Enrolling a trusted channel connection creates a business-only partner
 account. Operators can maintain standing and safe agreement references while
 the following authorities stay separate:

--- a/docs/superpowers/plans/2026-07-19-federated-demand-network.md
+++ b/docs/superpowers/plans/2026-07-19-federated-demand-network.md
@@ -214,11 +214,41 @@ before the backlog item closes.
 - Extend existing organization/agreement/entitlement substrates after architecture parity review
 - Add reseller portfolio projections and help/response actions without a second backlog
 
-- [ ] Add `service-provider` and `channel` invitation presets with customer-controlled outbound projections and independent revocation.
-- [ ] Model Founder Hub reseller enrollment, standing, agreements/entitlements, offerings, support routing, and contribution recognition in their existing business owners.
-- [ ] Add reseller aggregation, pseudonymous attribution, help offers, and selective forwarding with transitive consent.
-- [ ] Prove multiple partners can coexist with non-overlapping projection scopes and no implied exclusivity.
-- [ ] Add EA/SysML parity for every schema/API surface in the same slice.
+- [x] Add `service-provider` and `channel` invitation presets with customer-controlled outbound projections and independent revocation.
+- [x] Model Founder Hub reseller enrollment, standing, agreements/entitlements, offerings, support routing, and contribution recognition in their existing business owners.
+- [x] Add reseller aggregation, pseudonymous attribution, help offers, and selective forwarding with transitive consent.
+- [x] Prove multiple partners can coexist with non-overlapping projection scopes and no implied exclusivity.
+- [x] Add EA/SysML parity for every schema/API surface in the same slice.
+
+**Slice 3 implementation receipt (2026-07-20, BI-D964E2DA):**
+
+- **Architecture:** `PartnerAccount` is a thin Founder-owned commercial account,
+  not a login identity, customer account, or remote backlog. Agreements,
+  entitlements, support routes, and contribution recognition reference their
+  existing owners (`ServiceOffering`, `HiveContributionLedger`, and
+  `FederationLink`) rather than copying catalog, contribution, or trust state.
+- **Federation:** customer/reseller selection is explicit per link; `channel`
+  links are directional and non-exclusive. Forwarding is denied unless the
+  source envelope grants the `founder` audience, and the reseller preserves the
+  original opaque origin and pseudonymous attribution while appending a signed
+  route attestation.
+- **Collaboration:** interest and help offers use bounded
+  `dpf.demand-response/1` envelopes. Responses can refer only to an envelope
+  previously shared over the same link and cannot contain backlog, capsule, or
+  planning identifiers.
+- **UX:** Connections exposes customer/reseller/channel roles and a Founder Hub
+  reseller panel. Delivery Flow exposes explicit per-link sharing, withdrawal,
+  forwarding, interest/help actions, and received response receipts.
+- **Data authority:** the local installation remains authoritative for its
+  backlog and outbound consent; the receiver owns only its mirror and response.
+  Founder Hub owns partner-business records. Hive remains the contribution-result
+  authority. The accompanying DataImpactManifest records model lifecycle and
+  projection cleanup/reconciliation coverage.
+- **EA/current-state parity:** Prisma-to-EA data mirror derives the new partner
+  models and relationship edges; the route-family extractor derives the demand
+  response port. No hand-maintained duplicate model was introduced. Publication
+  is gated by `check:architecture-parity`, route-manifest, migration, build, and
+  browser verification.
 
 **Verification:** customer negative-egress fixtures; multi-partner authorization tests; revoked-link behavior; reseller/customer/founder happy paths; role-appropriate UX; migration deploy and production build.
 

--- a/docs/superpowers/plans/2026-07-19-federated-demand-network.md
+++ b/docs/superpowers/plans/2026-07-19-federated-demand-network.md
@@ -12,6 +12,20 @@
 
 **First independently shippable slice:** Task 1. It adds closed relationship/activity/schema registries, safe demand projection templates, runtime conformance helpers, and a Hive result-only negative-egress guard. It changes no schema, route, discovery behavior, or live data flow.
 
+## Backlog coverage
+
+- Decision: decomposed
+- Parent: `BI-E3A084ED`
+- Receipt: `cmrsw3hdn0000lbpg591ouv5s`
+- Rationale: The protocol, same-network fleet, delivery, reseller channel, founder portfolio, and future routed-reach layers are independently deployable business capabilities with explicit sequencing dependencies.
+- Dependencies: internal fleet and delivery depend on protocol; channel depends on delivery; founder portfolio depends on channel; routed reach depends on founder portfolio.
+- Federated demand protocol -> `BI-E3A084ED`
+- Automatic same-network internal fleet sync -> `BI-52D34506`
+- Reliable federated delivery -> `BI-44AA45BF`
+- Reseller and service-provider demand channels -> `BI-D964E2DA`
+- Founder Hub shared portfolio -> `BI-D25A0C31`
+- Future routed federation reach -> `BI-D43D3D76`
+
 ---
 
 ## Task 1: Establish protocol, relationship, projection, and Hive-boundary contracts
@@ -251,6 +265,39 @@ before the backlog item closes.
   browser verification.
 
 **Verification:** customer negative-egress fixtures; multi-partner authorization tests; revoked-link behavior; reseller/customer/founder happy paths; role-appropriate UX; migration deploy and production build.
+
+### Design grounding — Task 4 reseller channels
+
+- **Existing specs/plans reviewed:** the federated-demand network design and
+  this implementation plan, including the local-authority, projection,
+  reseller-channel, and Hive result-only boundaries.
+- **Current code substrate reviewed:** `packages/db/src/federated-demand-contract.ts`,
+  `apps/web/lib/federation/`, the existing Connections route under
+  `apps/web/app/platform/federation-links/`, and Delivery Flow under
+  `apps/web/app/ops/demand/`.
+- **Source of truth:** `FederationLink` owns trust and directional relationship;
+  projection contracts own shareable fields; local `BacklogItem` rows remain
+  authoritative; Founder Hub partner records own commercial standing.
+- **Decision:** extend those owners with explicit, independently revocable
+  channel permissions and bounded response envelopes. Do not create a global
+  backlog, a second partner identity, or a parallel navigation surface.
+
+### Task 4 UX fit review — reseller channels
+
+- **Decision:** progressive disclosure in the existing Connections and Delivery
+  Flow routes. Relationship setup stays in Connections; item-level share,
+  withdraw, forwarding, interest, and help actions appear only in the relevant
+  demand card or partner panel.
+- **Cognitive load:** use business-language role labels and contextual actions;
+  keep protocol versions, pseudonymous origin keys, route attestations, and
+  projection internals out of the operator workflow.
+- **Navigation:** no new global navigation, dashboard, or duplicate backlog.
+- **Authority cues:** sharing and forwarding are explicit; the customer controls
+  outbound scope; withdrawal and revocation remain visible; received demand is
+  never presented as locally owned work until adoption.
+- **Failure/empty states:** no eligible link, revoked consent, withdrawn demand,
+  and response-delivery failures explain the unavailable action without hiding
+  the local backlog or other partners.
 
 ## Task 5: Add Founder Hub shared portfolio and independent Hive result intake
 

--- a/docs/user-guide/operations/index.md
+++ b/docs/user-guide/operations/index.md
@@ -29,6 +29,26 @@ Operations is the delivery backlog for the platform. It tracks the work items, e
 - Review deployment logs and backup references for completed promotions
 - Track change requests and their lifecycle (draft, approved, in-progress, completed)
 
+## Shared Demand
+
+Open **Operations > Delivery Flow** (`/ops/demand`) to review demand shared by
+approved DPF connections. A shared item is an observation from another
+installation, not a local backlog item. You can follow it, offer help, or adopt
+it; adoption creates a new locally owned backlog item and never transfers
+control of the sender's work.
+
+For demand your installation owns, use the item-level connection controls to
+share only with eligible approved links. Service-provider and channel links are
+selected explicitly. Forwarding is available only when the original sender
+allowed the Founder Hub audience, and it preserves pseudonymous origin
+provenance. Withdrawal stops the shared copy from being actionable without
+deleting your local item.
+
+If a share or response action is unavailable, check the displayed connection
+state and consent explanation. Manage the relationship itself under **Platform
+> Connections**. See the [federated demand channel runbook](../../operations/federated-demand-channels.md)
+for enrollment, revocation, and recovery procedures.
+
 ## Promotions
 
 The Promotions tab in Operations shows all features that have been through the Build Studio ship phase. Each promotion has a status:

--- a/docs/user-guide/platform/index.md
+++ b/docs/user-guide/platform/index.md
@@ -44,3 +44,16 @@ Choose the relationship preset that matches the connection:
 - **Service provider / customer** for a reseller or managed-service relationship, then select which side manages the other.
 
 Only the minimum shared projection crosses an approved link. Local backlog detail, work capsules, private plans, attachments, and customer context remain on their originating installation. Either side can pause or revoke the connection.
+
+For service-provider and channel relationships, the customer controls which
+outbound demand may be shared. A connection does not imply exclusivity, and
+multiple partners can coexist with different scopes. Founder Hub operators can
+use the reseller panel on this page to review partner standing, agreements,
+entitlements, support routing, and contribution recognition without creating a
+second customer identity or remote backlog.
+
+Connection revocation stops new demand and response exchange. Item-level
+withdrawal and forwarding controls live in **Operations > Delivery Flow** so
+relationship administration and delivery decisions remain separate. See the
+[federated demand channel runbook](../../operations/federated-demand-channels.md)
+for setup, consent, troubleshooting, and recovery procedures.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,6 +19,7 @@
     "./trust-link-lifecycle": "./src/trust-link-lifecycle.ts",
     "./federation-link-types": "./src/federation-link-types.ts",
     "./federated-demand-contract": "./src/federated-demand-contract.ts",
+    "./federated-channel": "./src/federated-channel.ts",
     "./projection-serialization": "./src/projection-serialization.ts",
     "./projection-egress": "./src/projection-egress.ts",
     "./remote-action-dispatch": "./src/remote-action-dispatch.ts",

--- a/packages/db/prisma/migrations/20260720064000_federated_channel/migration.sql
+++ b/packages/db/prisma/migrations/20260720064000_federated_channel/migration.sql
@@ -1,0 +1,111 @@
+-- Founder Hub partner-business records. External partner companies remain
+-- separate from CustomerAccount and human identity remains Principal-based.
+ALTER TABLE "FederationLink" ADD COLUMN "peerInstallationId" TEXT;
+CREATE INDEX "FederationLink_peerInstallationId_idx" ON "FederationLink"("peerInstallationId");
+
+CREATE TABLE "PartnerAccount" (
+    "id" TEXT NOT NULL,
+    "partnerId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "federationLinkId" TEXT,
+    "externalOrganizationRef" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "partnerKind" TEXT NOT NULL DEFAULT 'reseller',
+    "standing" TEXT NOT NULL DEFAULT 'pending',
+    "tier" TEXT NOT NULL DEFAULT 'registered',
+    "enrolledAt" TIMESTAMP(3),
+    "reviewedAt" TIMESTAMP(3),
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "PartnerAccount_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "PartnerAgreement" (
+    "id" TEXT NOT NULL,
+    "agreementId" TEXT NOT NULL,
+    "partnerAccountId" TEXT NOT NULL,
+    "agreementType" TEXT NOT NULL DEFAULT 'reseller',
+    "status" TEXT NOT NULL DEFAULT 'draft',
+    "externalReference" TEXT,
+    "effectiveFrom" TIMESTAMP(3),
+    "effectiveTo" TIMESTAMP(3),
+    "terms" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "PartnerAgreement_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "PartnerEntitlement" (
+    "id" TEXT NOT NULL,
+    "entitlementId" TEXT NOT NULL,
+    "partnerAccountId" TEXT NOT NULL,
+    "agreementId" TEXT,
+    "serviceOfferingId" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "scope" JSONB,
+    "effectiveFrom" TIMESTAMP(3),
+    "effectiveTo" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "PartnerEntitlement_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "PartnerSupportRoute" (
+    "id" TEXT NOT NULL,
+    "routeId" TEXT NOT NULL,
+    "partnerAccountId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "channel" TEXT NOT NULL,
+    "destination" TEXT NOT NULL,
+    "priority" INTEGER NOT NULL DEFAULT 100,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "scope" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "PartnerSupportRoute_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "PartnerContributionRecognition" (
+    "id" TEXT NOT NULL,
+    "recognitionId" TEXT NOT NULL,
+    "partnerAccountId" TEXT NOT NULL,
+    "contributionLedgerId" TEXT,
+    "recognitionType" TEXT NOT NULL DEFAULT 'contribution',
+    "status" TEXT NOT NULL DEFAULT 'recorded',
+    "note" TEXT,
+    "awardedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "PartnerContributionRecognition_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PartnerAccount_partnerId_key" ON "PartnerAccount"("partnerId");
+CREATE UNIQUE INDEX "PartnerAccount_federationLinkId_key" ON "PartnerAccount"("federationLinkId");
+CREATE UNIQUE INDEX "PartnerAccount_organizationId_externalOrganizationRef_key" ON "PartnerAccount"("organizationId", "externalOrganizationRef");
+CREATE INDEX "PartnerAccount_organizationId_standing_idx" ON "PartnerAccount"("organizationId", "standing");
+CREATE INDEX "PartnerAccount_partnerKind_standing_idx" ON "PartnerAccount"("partnerKind", "standing");
+CREATE UNIQUE INDEX "PartnerAgreement_agreementId_key" ON "PartnerAgreement"("agreementId");
+CREATE INDEX "PartnerAgreement_partnerAccountId_status_idx" ON "PartnerAgreement"("partnerAccountId", "status");
+CREATE INDEX "PartnerAgreement_effectiveTo_idx" ON "PartnerAgreement"("effectiveTo");
+CREATE UNIQUE INDEX "PartnerEntitlement_entitlementId_key" ON "PartnerEntitlement"("entitlementId");
+CREATE INDEX "PartnerEntitlement_partnerAccountId_status_idx" ON "PartnerEntitlement"("partnerAccountId", "status");
+CREATE INDEX "PartnerEntitlement_agreementId_idx" ON "PartnerEntitlement"("agreementId");
+CREATE INDEX "PartnerEntitlement_serviceOfferingId_idx" ON "PartnerEntitlement"("serviceOfferingId");
+CREATE INDEX "PartnerEntitlement_effectiveTo_idx" ON "PartnerEntitlement"("effectiveTo");
+CREATE UNIQUE INDEX "PartnerSupportRoute_routeId_key" ON "PartnerSupportRoute"("routeId");
+CREATE INDEX "PartnerSupportRoute_partnerAccountId_active_priority_idx" ON "PartnerSupportRoute"("partnerAccountId", "active", "priority");
+CREATE UNIQUE INDEX "PartnerContributionRecognition_recognitionId_key" ON "PartnerContributionRecognition"("recognitionId");
+CREATE UNIQUE INDEX "PartnerContributionRecognition_partnerAccountId_contributionLedgerId_key" ON "PartnerContributionRecognition"("partnerAccountId", "contributionLedgerId");
+CREATE INDEX "PartnerContributionRecognition_partnerAccountId_status_idx" ON "PartnerContributionRecognition"("partnerAccountId", "status");
+CREATE INDEX "PartnerContributionRecognition_contributionLedgerId_idx" ON "PartnerContributionRecognition"("contributionLedgerId");
+
+ALTER TABLE "PartnerAccount" ADD CONSTRAINT "PartnerAccount_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PartnerAccount" ADD CONSTRAINT "PartnerAccount_federationLinkId_fkey" FOREIGN KEY ("federationLinkId") REFERENCES "FederationLink"("linkId") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "PartnerAgreement" ADD CONSTRAINT "PartnerAgreement_partnerAccountId_fkey" FOREIGN KEY ("partnerAccountId") REFERENCES "PartnerAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PartnerEntitlement" ADD CONSTRAINT "PartnerEntitlement_partnerAccountId_fkey" FOREIGN KEY ("partnerAccountId") REFERENCES "PartnerAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PartnerEntitlement" ADD CONSTRAINT "PartnerEntitlement_agreementId_fkey" FOREIGN KEY ("agreementId") REFERENCES "PartnerAgreement"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "PartnerEntitlement" ADD CONSTRAINT "PartnerEntitlement_serviceOfferingId_fkey" FOREIGN KEY ("serviceOfferingId") REFERENCES "ServiceOffering"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "PartnerSupportRoute" ADD CONSTRAINT "PartnerSupportRoute_partnerAccountId_fkey" FOREIGN KEY ("partnerAccountId") REFERENCES "PartnerAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PartnerContributionRecognition" ADD CONSTRAINT "PartnerContributionRecognition_partnerAccountId_fkey" FOREIGN KEY ("partnerAccountId") REFERENCES "PartnerAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PartnerContributionRecognition" ADD CONSTRAINT "PartnerContributionRecognition_contributionLedgerId_fkey" FOREIGN KEY ("contributionLedgerId") REFERENCES "HiveContributionLedger"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -500,20 +500,20 @@ model Department {
 }
 
 model Position {
-  id         String            @id @default(cuid())
-  positionId String            @unique
-  title      String
-  jobFamily  String?
-  jobLevel   String?
+  id            String            @id @default(cuid())
+  positionId    String            @unique
+  title         String
+  jobFamily     String?
+  jobLevel      String?
   // Occupation dimension (EP-EMPLOYEE-OCCUPATION): a slug reference into the
   // OccupationProfile registry (validated in app code, not an FK — mirrors the
   // StorefrontConfig.archetypeId semantic-slug pattern). Nullable: an unmapped
   // position resolves to the archetype/platform fallback, an honest degrade.
   occupationKey String?
-  status     String            @default("active")
-  createdAt  DateTime          @default(now())
-  updatedAt  DateTime          @updatedAt
-  employees  EmployeeProfile[]
+  status        String            @default("active")
+  createdAt     DateTime          @default(now())
+  updatedAt     DateTime          @updatedAt
+  employees     EmployeeProfile[]
 
   @@index([status])
   @@index([occupationKey])
@@ -1086,27 +1086,28 @@ model CodebaseManifest {
 }
 
 model ServiceOffering {
-  id                 String            @id @default(cuid())
-  offeringId         String            @unique
-  digitalProductId   String
-  name               String
-  description        String?
-  consumers          Json
-  availabilityTarget Float?
-  mttrHours          Float?
-  mtbfHours          Float?
-  rtoHours           Float?
-  rpoHours           Float?
-  supportHours       String?
-  claRef             String?
-  olaRef             String?
-  status             String            @default("draft")
-  createdAt          DateTime          @default(now())
-  updatedAt          DateTime          @updatedAt
-  effectiveFrom      DateTime?
-  effectiveTo        DateTime?
-  digitalProduct     DigitalProduct    @relation(fields: [digitalProductId], references: [id])
-  coworkerServices   CoworkerService[]
+  id                  String               @id @default(cuid())
+  offeringId          String               @unique
+  digitalProductId    String
+  name                String
+  description         String?
+  consumers           Json
+  availabilityTarget  Float?
+  mttrHours           Float?
+  mtbfHours           Float?
+  rtoHours            Float?
+  rpoHours            Float?
+  supportHours        String?
+  claRef              String?
+  olaRef              String?
+  status              String               @default("draft")
+  createdAt           DateTime             @default(now())
+  updatedAt           DateTime             @updatedAt
+  effectiveFrom       DateTime?
+  effectiveTo         DateTime?
+  digitalProduct      DigitalProduct       @relation(fields: [digitalProductId], references: [id])
+  coworkerServices    CoworkerService[]
+  partnerEntitlements PartnerEntitlement[]
 
   @@index([digitalProductId])
   @@index([status])
@@ -1763,8 +1764,8 @@ model PlatformCapability {
 /// Durable receipt for the portal-to-host runtime capability transition saga.
 /// The partial unique index limiting active transitions is defined in SQL.
 model RuntimeCapabilityTransition {
-  id                String   @id @default(cuid())
-  transitionId      String   @unique
+  id                String                             @id @default(cuid())
+  transitionId      String                             @unique
   previousKeys      String[]
   desiredKeys       String[]
   previousProfiles  String[]
@@ -1780,14 +1781,14 @@ model RuntimeCapabilityTransition {
   expiresAt         DateTime?
   envelope          Json?
   envelopeSignature String?
-  status            String   @default("pending")
+  status            String                             @default("pending")
   hostReceipt       Json?
   failure           Json?
   requestedById     String?
-  createdAt         DateTime @default(now())
+  createdAt         DateTime                           @default(now())
   hostAppliedAt     DateTime?
   completedAt       DateTime?
-  updatedAt         DateTime @updatedAt
+  updatedAt         DateTime                           @updatedAt
   events            RuntimeCapabilityTransitionEvent[]
 
   @@index([status, createdAt])
@@ -1795,11 +1796,11 @@ model RuntimeCapabilityTransition {
 
 /// Append-only governance audit for every terminal runtime transition outcome.
 model RuntimeCapabilityTransitionEvent {
-  id           String   @id @default(cuid())
+  id           String                      @id @default(cuid())
   transitionId String
   outcome      String
   detail       Json
-  createdAt    DateTime @default(now())
+  createdAt    DateTime                    @default(now())
   transition   RuntimeCapabilityTransition @relation(fields: [transitionId], references: [transitionId], onDelete: Restrict)
 
   @@index([transitionId, createdAt])
@@ -1850,18 +1851,18 @@ model McpServerTool {
 }
 
 model CredentialEntry {
-  id             String    @id @default(cuid())
-  providerId     String    @unique
-  secretRef      String?
-  status         String    @default("unconfigured")
-  updatedAt      DateTime  @updatedAt
-  clientId       String?
-  clientSecret   String?
-  tokenEndpoint  String?
-  scope          String?
-  cachedToken    String?
-  tokenExpiresAt DateTime?
-  refreshToken   String?
+  id                 String                @id @default(cuid())
+  providerId         String                @unique
+  secretRef          String?
+  status             String                @default("unconfigured")
+  updatedAt          DateTime              @updatedAt
+  clientId           String?
+  clientSecret       String?
+  tokenEndpoint      String?
+  scope              String?
+  cachedToken        String?
+  tokenExpiresAt     DateTime?
+  refreshToken       String?
   providerConnection AiProviderConnection?
 }
 
@@ -1946,22 +1947,22 @@ model IntegrationToolCallLog {
 // requestHash and acknowledgment are safe, adapter-redacted projections; raw
 // callback payloads, signatures, and credentials must never be stored here.
 model IntegrationCallbackReceipt {
-  id               String    @id @default(cuid())
-  connectorId      String
-  deliveryKey      String
-  requestHash      String
-  status           String    @default("processing")
-  responseCode     Int?
-  domainEntityId   String?
-  acknowledgment   Json?
-  dispatchPending  Boolean   @default(false)
-  dispatchLeaseToken String?
+  id                     String    @id @default(cuid())
+  connectorId            String
+  deliveryKey            String
+  requestHash            String
+  status                 String    @default("processing")
+  responseCode           Int?
+  domainEntityId         String?
+  acknowledgment         Json?
+  dispatchPending        Boolean   @default(false)
+  dispatchLeaseToken     String?
   dispatchLeaseExpiresAt DateTime?
-  auditPending     Boolean   @default(false)
-  auditData        Json?
-  createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
-  completedAt      DateTime?
+  auditPending           Boolean   @default(false)
+  auditData              Json?
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
+  completedAt            DateTime?
 
   @@unique([connectorId, deliveryKey])
   @@index([status, dispatchPending, auditPending, updatedAt], map: "IntegrationCallbackReceipt_pending_idx")
@@ -2109,33 +2110,33 @@ model ModelProvider {
 // inherit each other's evidence. ModelProvider remains the catalog/runtime
 // provider owner; this row is the organization-scoped access posture.
 model AiProviderConnection {
-  id                     String    @id @default(cuid())
-  connectionId           String    @unique
-  organizationId         String?
-  providerId             String
-  credentialEntryId      String?   @unique
-  financeProfileId       String?
-  supplierContractId     String?
-  capacityStatusId       String?   @unique
-  label                  String?
-  status                 String    @default("unconfigured")
-  executionChannel       String
-  accountClass           String    @default("unknown")
-  commercialBasis        String    @default("unknown")
-  authMethod             String    @default("unknown")
-  contractEvidence       Json      @default("{}")
-  entitlements           Json      @default("{}")
-  evidenceStatus         String    @default("unreviewed")
-  lastReviewedAt         DateTime?
-  createdAt              DateTime  @default(now())
-  updatedAt              DateTime  @updatedAt
+  id                 String    @id @default(cuid())
+  connectionId       String    @unique
+  organizationId     String?
+  providerId         String
+  credentialEntryId  String?   @unique
+  financeProfileId   String?
+  supplierContractId String?
+  capacityStatusId   String?   @unique
+  label              String?
+  status             String    @default("unconfigured")
+  executionChannel   String
+  accountClass       String    @default("unknown")
+  commercialBasis    String    @default("unknown")
+  authMethod         String    @default("unknown")
+  contractEvidence   Json      @default("{}")
+  entitlements       Json      @default("{}")
+  evidenceStatus     String    @default("unreviewed")
+  lastReviewedAt     DateTime?
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
 
-  organization           Organization?             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  provider               ModelProvider             @relation(fields: [providerId], references: [providerId], onDelete: Cascade)
-  credentialEntry        CredentialEntry?           @relation(fields: [credentialEntryId], references: [id], onDelete: SetNull)
-  financeProfile         AiProviderFinanceProfile? @relation(fields: [financeProfileId], references: [id], onDelete: SetNull)
-  supplierContract       SupplierContract?         @relation(fields: [supplierContractId], references: [id], onDelete: SetNull)
-  capacityStatus         ProviderCapacityStatus?   @relation(fields: [capacityStatusId], references: [id], onDelete: SetNull)
+  organization     Organization?             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  provider         ModelProvider             @relation(fields: [providerId], references: [providerId], onDelete: Cascade)
+  credentialEntry  CredentialEntry?          @relation(fields: [credentialEntryId], references: [id], onDelete: SetNull)
+  financeProfile   AiProviderFinanceProfile? @relation(fields: [financeProfileId], references: [id], onDelete: SetNull)
+  supplierContract SupplierContract?         @relation(fields: [supplierContractId], references: [id], onDelete: SetNull)
+  capacityStatus   ProviderCapacityStatus?   @relation(fields: [capacityStatusId], references: [id], onDelete: SetNull)
 
   @@index([organizationId, status])
   @@index([providerId, status])
@@ -3838,6 +3839,7 @@ model Organization {
   careAppointments              CareAppointment[]
   careIntakePackets             CareIntakePacket[]
   aiProviderConnections         AiProviderConnection[]
+  partnerAccounts               PartnerAccount[]
 }
 
 // EP-PARTNER-CHANNEL Phase 1b. Generic per-organization opt-in overlay on top of
@@ -3864,6 +3866,130 @@ model OrganizationCapabilityActivation {
 
   @@unique([organizationId, capabilityKey])
   @@index([organizationId])
+}
+
+// EP-DELIVERY-FLOW federated demand Slice 3. Founder Hub owns the commercial
+// relationship with each reseller without reclassifying that external company
+// as a customer or creating a credential-bearing identity record. Human access
+// remains Principal-based; this is business account data only.
+model PartnerAccount {
+  id                      String    @id @default(cuid())
+  partnerId               String    @unique
+  organizationId          String
+  federationLinkId        String?   @unique
+  externalOrganizationRef String
+  displayName             String
+  // reseller | distributor | service-provider | technology-partner
+  partnerKind             String    @default("reseller")
+  // pending | active | at-risk | suspended | terminated
+  standing                String    @default("pending")
+  // registered | authorized | silver | gold | platinum
+  tier                    String    @default("registered")
+  enrolledAt              DateTime?
+  reviewedAt              DateTime?
+  notes                   String?
+  createdAt               DateTime  @default(now())
+  updatedAt               DateTime  @updatedAt
+
+  organization             Organization                     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  federationLink           FederationLink?                  @relation(fields: [federationLinkId], references: [linkId], onDelete: SetNull)
+  agreements               PartnerAgreement[]
+  entitlements             PartnerEntitlement[]
+  supportRoutes            PartnerSupportRoute[]
+  contributionRecognitions PartnerContributionRecognition[]
+
+  @@unique([organizationId, externalOrganizationRef])
+  @@index([organizationId, standing])
+  @@index([partnerKind, standing])
+}
+
+// Founder-owned agreement facts. The signed agreement may live in a document
+// system; DPF stores only its governed status, dates, reference, and safe terms.
+model PartnerAgreement {
+  id                String    @id @default(cuid())
+  agreementId       String    @unique
+  partnerAccountId  String
+  agreementType     String    @default("reseller")
+  status            String    @default("draft")
+  externalReference String?
+  effectiveFrom     DateTime?
+  effectiveTo       DateTime?
+  terms             Json?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  partnerAccount PartnerAccount       @relation(fields: [partnerAccountId], references: [id], onDelete: Cascade)
+  entitlements   PartnerEntitlement[]
+
+  @@index([partnerAccountId, status])
+  @@index([effectiveTo])
+}
+
+// A partner's right to offer/support an existing ServiceOffering. Catalog data
+// remains owned by ServiceOffering; this row owns only the partner-specific grant.
+model PartnerEntitlement {
+  id                String    @id @default(cuid())
+  entitlementId     String    @unique
+  partnerAccountId  String
+  agreementId       String?
+  serviceOfferingId String?
+  status            String    @default("pending")
+  scope             Json?
+  effectiveFrom     DateTime?
+  effectiveTo       DateTime?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  partnerAccount  PartnerAccount    @relation(fields: [partnerAccountId], references: [id], onDelete: Cascade)
+  agreement       PartnerAgreement? @relation(fields: [agreementId], references: [id], onDelete: SetNull)
+  serviceOffering ServiceOffering?  @relation(fields: [serviceOfferingId], references: [id], onDelete: SetNull)
+
+  @@index([partnerAccountId, status])
+  @@index([agreementId])
+  @@index([serviceOfferingId])
+  @@index([effectiveTo])
+}
+
+// Local operational routing for founder/reseller coordination. It never grants
+// remote execution or expands a FederationLink projection contract.
+model PartnerSupportRoute {
+  id               String   @id @default(cuid())
+  routeId          String   @unique
+  partnerAccountId String
+  name             String
+  channel          String
+  destination      String
+  priority         Int      @default(100)
+  active           Boolean  @default(true)
+  scope            Json?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  partnerAccount PartnerAccount @relation(fields: [partnerAccountId], references: [id], onDelete: Cascade)
+
+  @@index([partnerAccountId, active, priority])
+}
+
+// Recognition points to the existing immutable HiveContributionLedger; it does
+// not duplicate a submitted result or leak the contributor's local backlog.
+model PartnerContributionRecognition {
+  id                   String    @id @default(cuid())
+  recognitionId        String    @unique
+  partnerAccountId     String
+  contributionLedgerId String?
+  recognitionType      String    @default("contribution")
+  status               String    @default("recorded")
+  note                 String?
+  awardedAt            DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  partnerAccount PartnerAccount          @relation(fields: [partnerAccountId], references: [id], onDelete: Cascade)
+  contribution   HiveContributionLedger? @relation(fields: [contributionLedgerId], references: [id], onDelete: SetNull)
+
+  @@unique([partnerAccountId, contributionLedgerId])
+  @@index([partnerAccountId, status])
+  @@index([contributionLedgerId])
 }
 
 model BusinessContext {
@@ -4516,8 +4642,8 @@ model DiscoveredItem {
 }
 
 model DiscoveredSoftwareEvidence {
-  id                      String          @id @default(cuid())
-  evidenceKey             String          @unique
+  id                      String           @id @default(cuid())
+  evidenceKey             String           @unique
   inventoryEntityId       String
   evidenceSource          String
   packageManager          String?
@@ -4527,7 +4653,7 @@ model DiscoveredSoftwareEvidence {
   rawVersion              String?
   installLocation         String?
   rawMetadata             Json?
-  normalizationStatus     String          @default("pending")
+  normalizationStatus     String           @default("pending")
   normalizationConfidence Float?
   // `softwareIdentityId` is a pre-existing DANGLING FK — its target `SoftwareIdentity` was dropped
   // in migration 20260320222431. Left untouched here (additive change); its resolution
@@ -4536,9 +4662,9 @@ model DiscoveredSoftwareEvidence {
   softwareIdentityId      String?
   // New canonical linkage into the CatalogIdentity spine (additive).
   catalogIdentityId       String?
-  firstSeenAt             DateTime        @default(now())
-  lastSeenAt              DateTime        @default(now())
-  inventoryEntity         InventoryEntity @relation(fields: [inventoryEntityId], references: [id], onDelete: Cascade)
+  firstSeenAt             DateTime         @default(now())
+  lastSeenAt              DateTime         @default(now())
+  inventoryEntity         InventoryEntity  @relation(fields: [inventoryEntityId], references: [id], onDelete: Cascade)
   catalogIdentity         CatalogIdentity? @relation(fields: [catalogIdentityId], references: [id], onDelete: SetNull)
 
   @@index([inventoryEntityId])
@@ -4608,7 +4734,7 @@ model CatalogLifecycleMilestone {
 /// CatalogIdentity, with confidence + evidence. Human-confirmed rows are never overwritten by a
 /// rule (§6.3.1). BI-74579817.
 model IdentityResolutionLog {
-  id                String           @id @default(cuid())
+  id                String                    @id @default(cuid())
   inventoryEntityId String?
   catalogIdentityId String?
   fingerprintRuleId String?
@@ -4617,7 +4743,7 @@ model IdentityResolutionLog {
   confidence        Float?
   evidence          Json?
   discoveryRunId    String?
-  createdAt         DateTime         @default(now())
+  createdAt         DateTime                  @default(now())
   inventoryEntity   InventoryEntity?          @relation(fields: [inventoryEntityId], references: [id], onDelete: SetNull)
   catalogIdentity   CatalogIdentity?          @relation(fields: [catalogIdentityId], references: [id], onDelete: SetNull)
   fingerprintRule   DiscoveryFingerprintRule? @relation(fields: [fingerprintRuleId], references: [id], onDelete: SetNull)
@@ -7011,21 +7137,22 @@ model PlatformDevConfig {
 // One ledger for everything that flows to the hive — what was shared, when,
 // its type, and its curation status (spec §6.1: "one contribution ledger").
 model HiveContributionLedger {
-  id               String   @id @default(cuid())
+  id                  String                           @id @default(cuid())
   // "device_fingerprint" | "source" | "improvement" (extensible).
-  contributionType String
+  contributionType    String
   // The stable obfuscated contributor pseudonym used across all types.
-  contributor      String
+  contributor         String
   // For device-fingerprint contributions: the rule key shared.
-  ruleKey          String?
-  summary          String
+  ruleKey             String?
+  summary             String
   // Hash of the contributed payload for dedup/audit without storing PII.
-  payloadHash      String?
+  payloadHash         String?
   // submitted | curating | accepted | rejected | withdrawn
-  status           String   @default("submitted")
-  redactionStatus  String?
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  status              String                           @default("submitted")
+  redactionStatus     String?
+  createdAt           DateTime                         @default(now())
+  updatedAt           DateTime                         @updatedAt
+  partnerRecognitions PartnerContributionRecognition[]
 
   @@index([contributionType])
   @@index([status])
@@ -10293,10 +10420,10 @@ model AiProviderFinanceProfile {
   createdAt              DateTime  @default(now())
   updatedAt              DateTime  @updatedAt
 
-  provider          ModelProvider      @relation(fields: [providerId], references: [providerId], onDelete: Cascade)
-  supplier          Supplier?          @relation(fields: [supplierId], references: [id], onDelete: SetNull)
-  supplierContracts SupplierContract[]
-  financeWorkItems  FinanceWorkItem[]
+  provider            ModelProvider          @relation(fields: [providerId], references: [providerId], onDelete: Cascade)
+  supplier            Supplier?              @relation(fields: [supplierId], references: [id], onDelete: SetNull)
+  supplierContracts   SupplierContract[]
+  financeWorkItems    FinanceWorkItem[]
   providerConnections AiProviderConnection[]
 
   @@index([supplierId])
@@ -12586,6 +12713,9 @@ model FederationLink {
   peerAuthorityUrl      String
   // The peer's org identifier + our own org, for the B5 CustomerAccount↔Org crosswalk.
   peerOrganizationRef   String?
+  // Stable pseudonymous installation identity learned from an authenticated
+  // digest exchange. Used for route-loop checks; never derived from hostname.
+  peerInstallationId    String?
   localOrganizationId   String?
   // Trust state — derived from the approval/revoke/quarantine timestamps below.
   linkState             String    @default("pending")
@@ -12617,11 +12747,13 @@ model FederationLink {
 
   principal       Principal                  @relation("FederationLinkIdentity", fields: [principalId], references: [id], onDelete: Cascade)
   bootstrapTokens FederationBootstrapToken[] @relation("FederationBootstrapConsumer")
+  partnerAccount  PartnerAccount?
 
   @@index([linkState])
   @@index([role])
   @@index([tokenHash])
   @@index([peerOrganizationRef])
+  @@index([peerInstallationId])
 }
 
 // Single-use invitation, mirrors BootstrapToken. The inviting peer issues a
@@ -12679,20 +12811,20 @@ model ProjectionContract {
 // (B5). Canonical record stays SOURCE-SIDE; the peer holds a governed mirror.
 // recordType discriminates rather than spawning per-kind tables (spec §7.4).
 model FederatedRecordMirror {
-  id               String    @id @default(cuid())
-  mirrorId         String    @unique
-  federationLinkId String
+  id                  String    @id @default(cuid())
+  mirrorId            String    @unique
+  federationLinkId    String
   // "incident" | "service-ticket" | "organization-crosswalk" | "demand-envelope"
-  recordType       String
+  recordType          String
   // Which side holds the canonical record: "local" | "peer".
-  canonicalSide    String
-  localRecordRef   String?
-  peerRecordRef    String?
+  canonicalSide       String
+  localRecordRef      String?
+  peerRecordRef       String?
   // pending | synced | conflict | withdrawn | dead-letter | revoked
-  syncStatus       String    @default("pending")
-  version          Int       @default(1)
-  conflictReason   String?
-  lastSyncedAt     DateTime?
+  syncStatus          String    @default("pending")
+  version             Int       @default(1)
+  conflictReason      String?
+  lastSyncedAt        DateTime?
   // Durable delivery state for local-canonical outbox records. Peer-canonical
   // inbox mirrors leave these null/zero.
   deliveryAttempts    Int       @default(0)
@@ -12702,9 +12834,9 @@ model FederatedRecordMirror {
   acknowledgedVersion Int?
   deadLetteredAt      DateTime?
   // Last projected (already minimized) payload that crossed — never raw data.
-  payload          Json?
-  createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
+  payload             Json?
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
   @@unique([federationLinkId, recordType, localRecordRef], map: "FederatedRecordMirror_link_type_local_key")
   // Peer-canonical records (including demand envelopes) need the inverse key so
@@ -13088,8 +13220,8 @@ model CliPoolStatus {
 // (quota, throttles, credits, plan limits) from ModelProvider.status, which is
 // the configured/admin lifecycle state.
 model ProviderCapacityStatus {
-  id                    String        @id @default(cuid())
-  providerId            String        @unique
+  id                    String                @id @default(cuid())
+  providerId            String                @unique
   state                 String
   action                String
   retryAt               DateTime?
@@ -13097,14 +13229,14 @@ model ProviderCapacityStatus {
   providerCode          String?
   safeSummary           String
   confidence            String
-  isHumanActionRequired Boolean       @default(false)
-  lastObservedAt        DateTime      @default(now())
+  isHumanActionRequired Boolean               @default(false)
+  lastObservedAt        DateTime              @default(now())
   lastSuccessAt         DateTime?
   source                String
   rawSnippet            String?
-  createdAt             DateTime      @default(now())
-  updatedAt             DateTime      @updatedAt
-  provider              ModelProvider @relation(fields: [providerId], references: [providerId], onDelete: Cascade)
+  createdAt             DateTime              @default(now())
+  updatedAt             DateTime              @updatedAt
+  provider              ModelProvider         @relation(fields: [providerId], references: [providerId], onDelete: Cascade)
   providerConnection    AiProviderConnection?
 
   @@index([state, retryAt])
@@ -13734,34 +13866,34 @@ model GraphEdge {
 /// `demandShape` is the first-class discriminator so the solver posture is
 /// explicit rather than assumed.
 model StaffingDemand {
-  id                   String   @id @default(cuid())
-  demandId             String   @unique
-  organizationId       String
+  id                  String   @id @default(cuid())
+  demandId            String   @unique
+  organizationId      String
   // coverage_floor | forecast_curve | fixed_slot | task_pipeline | census_load
-  demandShape          String
-  sourceType           String? // forecast | manual | booking | work | census
-  sourceId             String?
-  startAt              DateTime
-  endAt                DateTime
-  timezone             String
-  localDateContext     String?
-  workLocationId       String?
-  occupationProfileId  String?
-  roleKey              String?
-  requiredSkills       String[] @default([])
-  requiredCredentials  String[] @default([])
-  minQuantity          Int      @default(1)
-  targetQuantity       Int?
+  demandShape         String
+  sourceType          String? // forecast | manual | booking | work | census
+  sourceId            String?
+  startAt             DateTime
+  endAt               DateTime
+  timezone            String
+  localDateContext    String?
+  workLocationId      String?
+  occupationProfileId String?
+  roleKey             String?
+  requiredSkills      String[] @default([])
+  requiredCredentials String[] @default([])
+  minQuantity         Int      @default(1)
+  targetQuantity      Int?
   // headcount-by-formula (spec §9.3): when set, quantity is derived at eval time
-  quantityFormula      Json?
-  priority             Int      @default(0)
-  status               String   @default("open") // open | partially_covered | covered | cancelled
-  provenance           Json?
-  effectiveVersion     Int      @default(1)
-  createdAt            DateTime @default(now())
-  updatedAt            DateTime @updatedAt
+  quantityFormula     Json?
+  priority            Int      @default(0)
+  status              String   @default("open") // open | partially_covered | covered | cancelled
+  provenance          Json?
+  effectiveVersion    Int      @default(1)
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 
-  shifts               StaffingShift[]
+  shifts StaffingShift[]
 
   @@index([organizationId, status])
   @@index([demandShape])
@@ -13787,9 +13919,9 @@ model StaffingShift {
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
-  demand             StaffingDemand?        @relation(fields: [staffingDemandId], references: [id])
-  assignments        StaffingAssignment[]
-  resourceLinks      StaffingResourceLink[]
+  demand        StaffingDemand?        @relation(fields: [staffingDemandId], references: [id])
+  assignments   StaffingAssignment[]
+  resourceLinks StaffingResourceLink[]
 
   @@index([organizationId, lifecycle])
   @@index([staffingDemandId])
@@ -13819,9 +13951,9 @@ model StaffingAssignment {
   createdAt             DateTime @default(now())
   updatedAt             DateTime @updatedAt
 
-  shift                 StaffingShift             @relation(fields: [staffingShiftId], references: [id], onDelete: Cascade)
-  crew                  StaffingCrew?             @relation(fields: [staffingCrewId], references: [id])
-  events                StaffingAssignmentEvent[]
+  shift  StaffingShift             @relation(fields: [staffingShiftId], references: [id], onDelete: Cascade)
+  crew   StaffingCrew?             @relation(fields: [staffingCrewId], references: [id])
+  events StaffingAssignmentEvent[]
 
   @@index([organizationId, lifecycle])
   @@index([staffingShiftId])
@@ -13840,7 +13972,7 @@ model StaffingAssignmentEvent {
   detail               Json?
   createdAt            DateTime @default(now())
 
-  assignment           StaffingAssignment @relation(fields: [staffingAssignmentId], references: [id], onDelete: Cascade)
+  assignment StaffingAssignment @relation(fields: [staffingAssignmentId], references: [id], onDelete: Cascade)
 
   @@index([staffingAssignmentId, createdAt])
 }
@@ -13857,8 +13989,8 @@ model StaffingCrew {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  members        StaffingCrewMember[]
-  assignments    StaffingAssignment[]
+  members     StaffingCrewMember[]
+  assignments StaffingAssignment[]
 
   @@index([organizationId])
 }
@@ -13871,7 +14003,7 @@ model StaffingCrewMember {
   isLead            Boolean  @default(false)
   createdAt         DateTime @default(now())
 
-  crew              StaffingCrew @relation(fields: [staffingCrewId], references: [id], onDelete: Cascade)
+  crew StaffingCrew @relation(fields: [staffingCrewId], references: [id], onDelete: Cascade)
 
   @@unique([staffingCrewId, employeeProfileId])
   @@index([employeeProfileId])
@@ -13889,7 +14021,7 @@ model StaffingResourceLink {
   resourceRef     String
   createdAt       DateTime @default(now())
 
-  shift           StaffingShift @relation(fields: [staffingShiftId], references: [id], onDelete: Cascade)
+  shift StaffingShift @relation(fields: [staffingShiftId], references: [id], onDelete: Cascade)
 
   @@index([staffingShiftId])
   @@index([resourceType, resourceRef])
@@ -13897,8 +14029,8 @@ model StaffingResourceLink {
 
 /// Employee-declared or authorized availability window. Spec §5.1.4.
 model EmployeeAvailabilityWindow {
-  id                String   @id @default(cuid())
-  windowId          String   @unique
+  id                String    @id @default(cuid())
+  windowId          String    @unique
   organizationId    String
   employeeProfileId String
   kind              String // available | unavailable
@@ -13911,11 +14043,11 @@ model EmployeeAvailabilityWindow {
   effectiveFrom     DateTime?
   effectiveTo       DateTime?
   ownerRef          String?
-  confirmationState String   @default("confirmed") // confirmed | pending
+  confirmationState String    @default("confirmed") // confirmed | pending
   supersededById    String?
-  version           Int      @default(1)
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  version           Int       @default(1)
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   @@index([employeeProfileId])
   @@index([organizationId, kind])
@@ -13926,23 +14058,23 @@ model EmployeeAvailabilityWindow {
 /// employee-confirmed preferences (origin=explicit or promoted) are binding;
 /// inferred origin stays soft and expiring.
 model EmployeeSchedulingPreference {
-  id                String   @id @default(cuid())
-  preferenceId      String   @unique
+  id                String    @id @default(cuid())
+  preferenceId      String    @unique
   organizationId    String
   employeeProfileId String
   preferenceType    String
   scope             String?
-  weight            Float    @default(0)
-  origin            String   @default("explicit") // explicit | inferred
-  consentState      String   @default("pending") // pending | consented | revoked
+  weight            Float     @default(0)
+  origin            String    @default("explicit") // explicit | inferred
+  consentState      String    @default("pending") // pending | consented | revoked
   confidence        Float?
   evidenceRefs      Json?
   effectiveFrom     DateTime?
   expiresAt         DateTime?
   supersededById    String?
-  version           Int      @default(1)
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  version           Int       @default(1)
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   @@index([employeeProfileId])
   @@index([organizationId, preferenceType])
@@ -13953,23 +14085,23 @@ model EmployeeSchedulingPreference {
 /// `predicateType` names the §9.8 variable family; hard rules cannot be relaxed
 /// by the solver, and non-waivable hard rules reject exception creation (§6).
 model StaffingConstraintRule {
-  id              String   @id @default(cuid())
-  ruleId          String   @unique
+  id              String    @id @default(cuid())
+  ruleId          String    @unique
   organizationId  String?
   predicateType   String
   family          String?
-  parameters      Json     @default("{}")
-  severity        String   @default("hard") // hard | soft
-  applicability   Json     @default("{}") // jurisdiction | archetype | org | unit | location | employmentType
+  parameters      Json      @default("{}")
+  severity        String    @default("hard") // hard | soft
+  applicability   Json      @default("{}") // jurisdiction | archetype | org | unit | location | employmentType
   sourcePolicyUrl String?
-  legallyWaivable Boolean  @default(false)
+  legallyWaivable Boolean   @default(false)
   effectiveFrom   DateTime?
   effectiveTo     DateTime?
-  validationState String   @default("draft") // draft | reviewed | active
+  validationState String    @default("draft") // draft | reviewed | active
   reviewOwnerRef  String?
-  version         Int      @default(1)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  version         Int       @default(1)
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
   @@index([organizationId])
   @@index([predicateType])
@@ -13996,7 +14128,7 @@ model StaffingProposalRun {
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 
-  options           StaffingProposalOption[]
+  options StaffingProposalOption[]
 
   @@index([organizationId, status])
 }
@@ -14015,7 +14147,7 @@ model StaffingProposalOption {
   terminalStatus        String?
   createdAt             DateTime @default(now())
 
-  run                   StaffingProposalRun @relation(fields: [staffingProposalRunId], references: [id], onDelete: Cascade)
+  run StaffingProposalRun @relation(fields: [staffingProposalRunId], references: [id], onDelete: Cascade)
 
   @@index([staffingProposalRunId, rank])
 }
@@ -14024,21 +14156,21 @@ model StaffingProposalOption {
 /// non-waivable legal/credential rules must reject exception creation at the
 /// application layer.
 model StaffingExceptionRequest {
-  id                     String   @id @default(cuid())
-  exceptionId            String   @unique
-  organizationId         String
+  id                       String    @id @default(cuid())
+  exceptionId              String    @unique
+  organizationId           String
   staffingConstraintRuleId String?
-  staffingShiftId        String?
-  staffingAssignmentId   String?
-  reason                 String
-  requestedScope         String?
-  expiresAt              DateTime?
-  approvingAuthorityRef  String?
-  decision               String   @default("pending") // pending | approved | denied
-  decisionInteractionId  String?
-  evidence               Json?
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
+  staffingShiftId          String?
+  staffingAssignmentId     String?
+  reason                   String
+  requestedScope           String?
+  expiresAt                DateTime?
+  approvingAuthorityRef    String?
+  decision                 String    @default("pending") // pending | approved | denied
+  decisionInteractionId    String?
+  evidence                 Json?
+  createdAt                DateTime  @default(now())
+  updatedAt                DateTime  @updatedAt
 
   @@index([organizationId, decision])
   @@index([staffingConstraintRuleId])
@@ -14048,24 +14180,24 @@ model StaffingExceptionRequest {
 /// (spec §5.1.9 + §10-§11). Never directly solver-authoritative: it must be
 /// employee-confirmed and promoted (to a preference or a LeaveRequest) first.
 model WorkforceCandidateFact {
-  id                     String   @id @default(cuid())
-  candidateFactId        String   @unique
-  organizationId         String
+  id                       String    @id @default(cuid())
+  candidateFactId          String    @unique
+  organizationId           String
   subjectEmployeeProfileId String?
-  kind                   String // time_off_intent | availability_hint | preference_hint
-  extractedValue         Json?
-  confidence             Float?
-  sourceEnvelope         Json? // provider | tenant | external id | sender/subject | received | integrity | excerpt/digest
-  identityResolution     String   @default("unresolved") // unresolved | resolved | ambiguous
-  reviewState            String   @default("pending") // pending | confirmed | edited | rejected
-  extractionModelVersion String?
-  inferenceAt            DateTime?
-  expiresAt              DateTime?
-  correctionOf           String?
-  promotionTargetType    String? // preference | leave_request
-  promotionTargetId      String?
-  createdAt              DateTime @default(now())
-  updatedAt              DateTime @updatedAt
+  kind                     String // time_off_intent | availability_hint | preference_hint
+  extractedValue           Json?
+  confidence               Float?
+  sourceEnvelope           Json? // provider | tenant | external id | sender/subject | received | integrity | excerpt/digest
+  identityResolution       String    @default("unresolved") // unresolved | resolved | ambiguous
+  reviewState              String    @default("pending") // pending | confirmed | edited | rejected
+  extractionModelVersion   String?
+  inferenceAt              DateTime?
+  expiresAt                DateTime?
+  correctionOf             String?
+  promotionTargetType      String? // preference | leave_request
+  promotionTargetId        String?
+  createdAt                DateTime  @default(now())
+  updatedAt                DateTime  @updatedAt
 
   @@index([organizationId, reviewState])
   @@index([subjectEmployeeProfileId])

--- a/packages/db/src/federated-channel-schema.test.ts
+++ b/packages/db/src/federated-channel-schema.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const schema = readFileSync(resolve(import.meta.dirname, "../prisma/schema.prisma"), "utf8");
+
+describe("Founder Hub partner business ownership", () => {
+  it("keeps the reseller company distinct from customer and human identity", () => {
+    expect(schema).toContain("model PartnerAccount {");
+    expect(schema).toMatch(/model PartnerAccount \{[\s\S]*organizationId\s+String[\s\S]*federationLinkId\s+String\?/);
+    expect(schema).not.toMatch(/model PartnerAccount \{[\s\S]*passwordHash/);
+  });
+
+  it("owns agreements locally while referencing offering and contribution owners", () => {
+    expect(schema).toContain("model PartnerAgreement {");
+    expect(schema).toContain("model PartnerEntitlement {");
+    expect(schema).toContain("model PartnerSupportRoute {");
+    expect(schema).toContain("model PartnerContributionRecognition {");
+    expect(schema).toMatch(/model PartnerEntitlement \{[\s\S]*serviceOffering\s+ServiceOffering\?/);
+    expect(schema).toMatch(/model PartnerContributionRecognition \{[\s\S]*contribution\s+HiveContributionLedger\?/);
+  });
+
+  it("supports more than one active partner without an exclusivity field", () => {
+    const account = schema.match(/model PartnerAccount \{[\s\S]*?\n\}/)?.[0] ?? "";
+    expect(account).toContain("@@unique([organizationId, externalOrganizationRef])");
+    expect(account).not.toMatch(/exclusive/i);
+  });
+});

--- a/packages/db/src/federated-channel.test.ts
+++ b/packages/db/src/federated-channel.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import type { DemandEnvelopeV1 } from "./federated-demand-contract";
+import {
+  audienceForOutboundRole,
+  channelPolicySelectsRecord,
+  forwardDemandEnvelope,
+  forwardingGrantFromPolicy,
+  validateChannelForwarding,
+  type ChannelDemandPolicy,
+} from "./federated-channel";
+
+const envelope: DemandEnvelopeV1 = {
+  specVersion: "dpf.demand/1",
+  envelopeId: "dem_origin",
+  originInstallationId: "inst_customer",
+  originRecordRef: "ref_opaque_customer",
+  originVersion: 7,
+  route: [],
+  audience: "partner",
+  title: "Customer-approved demand",
+  summary: "A minimized need the customer elected to share.",
+  signal: { occurrenceCount: 3, affectedOrganizations: 1 },
+  attribution: "pseudonymous",
+  forwarding: {
+    permitted: true,
+    audiences: ["founder"],
+    expiresAt: "2026-08-01T00:00:00.000Z",
+  },
+  createdAt: "2026-07-20T00:00:00.000Z",
+  updatedAt: "2026-07-20T00:00:00.000Z",
+  payloadDigest: "sha256:pending",
+};
+
+describe("channel demand selection", () => {
+  const policy: ChannelDemandPolicy = {
+    mode: "explicit",
+    selectedRecordRefs: ["local-a"],
+    attribution: "pseudonymous",
+    allowTransitiveForwarding: false,
+    forwardingAudiences: [],
+  };
+
+  it("keeps each partner link independently scoped", () => {
+    expect(channelPolicySelectsRecord(policy, "local-a")).toBe(true);
+    expect(channelPolicySelectsRecord(policy, "local-b")).toBe(false);
+    expect(channelPolicySelectsRecord({ ...policy, selectedRecordRefs: ["local-b"] }, "local-a"))
+      .toBe(false);
+  });
+
+  it("never treats an automatic policy as valid for a partner link", () => {
+    expect(channelPolicySelectsRecord({ ...policy, mode: "automatic" } as unknown as ChannelDemandPolicy, "local-a"))
+      .toBe(false);
+  });
+
+  it("maps directional roles to the least-privilege audience", () => {
+    expect(audienceForOutboundRole("managed-by")).toBe("partner");
+    expect(audienceForOutboundRole("manages")).toBe("partner");
+    expect(audienceForOutboundRole("channel-downstream")).toBe("founder");
+    expect(audienceForOutboundRole("channel-upstream")).toBe("partner");
+  });
+
+  it("omits transitive permission unless the source explicitly grants it", () => {
+    expect(forwardingGrantFromPolicy(policy)).toBeUndefined();
+    expect(forwardingGrantFromPolicy({
+      ...policy,
+      allowTransitiveForwarding: true,
+      forwardingAudiences: ["founder", "founder"],
+      forwardingExpiresAt: "2026-08-01T00:00:00.000Z",
+    })).toEqual({
+      permitted: true,
+      audiences: ["founder"],
+      expiresAt: "2026-08-01T00:00:00.000Z",
+    });
+  });
+});
+
+describe("transitive channel forwarding", () => {
+  it("requires explicit, current consent for the target audience", () => {
+    expect(validateChannelForwarding({
+      envelope,
+      targetAudience: "founder",
+      forwardingInstallationId: "inst_reseller",
+      receivingInstallationId: "inst_founder",
+      now: new Date("2026-07-20T01:00:00.000Z"),
+    })).toEqual([]);
+
+    expect(validateChannelForwarding({
+      envelope: { ...envelope, forwarding: { ...envelope.forwarding!, permitted: false } },
+      targetAudience: "founder",
+      forwardingInstallationId: "inst_reseller",
+      receivingInstallationId: "inst_founder",
+    })).toContain("forwarding:not-permitted");
+
+    expect(validateChannelForwarding({
+      envelope,
+      targetAudience: "community",
+      forwardingInstallationId: "inst_reseller",
+      receivingInstallationId: "inst_founder",
+    })).toContain("forwarding:audience-not-consented");
+
+    expect(validateChannelForwarding({
+      envelope,
+      targetAudience: "founder",
+      forwardingInstallationId: "inst_reseller",
+      receivingInstallationId: "inst_founder",
+      now: new Date("2026-08-02T00:00:00.000Z"),
+    })).toContain("forwarding:consent-expired");
+  });
+
+  it("preserves origin and pseudonymity while adding an intermediary attestation", () => {
+    const forwarded = forwardDemandEnvelope({
+      envelope,
+      targetAudience: "founder",
+      forwardingInstallationId: "inst_reseller",
+      receivingInstallationId: "inst_founder",
+      relationshipKind: "channel",
+      linkId: "FL-RESELLER-FOUNDER",
+      now: new Date("2026-07-20T01:00:00.000Z"),
+    });
+
+    expect(forwarded.originInstallationId).toBe("inst_customer");
+    expect(forwarded.originRecordRef).toBe("ref_opaque_customer");
+    expect(forwarded.attribution).toBe("pseudonymous");
+    expect(forwarded.audience).toBe("founder");
+    expect(forwarded.route).toHaveLength(1);
+    expect(forwarded.route[0]).toMatchObject({
+      installationId: "inst_reseller",
+      relationshipKind: "channel",
+      receivedAt: "2026-07-20T01:00:00.000Z",
+    });
+    expect(forwarded.route[0]?.attestationDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(forwarded.payloadDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it("rejects cycles and self-forwarding", () => {
+    expect(validateChannelForwarding({
+      envelope: {
+        ...envelope,
+        route: [{
+          installationId: "inst_founder",
+          relationshipKind: "channel",
+          receivedAt: "2026-07-20T00:30:00.000Z",
+          attestationDigest: `sha256:${"a".repeat(64)}`,
+        }],
+      },
+      targetAudience: "founder",
+      forwardingInstallationId: "inst_reseller",
+      receivingInstallationId: "inst_founder",
+    })).toContain("forwarding:receiver-already-in-route");
+  });
+});

--- a/packages/db/src/federated-channel.ts
+++ b/packages/db/src/federated-channel.ts
@@ -1,0 +1,148 @@
+import { createHash } from "node:crypto";
+
+import {
+  computeDemandPayloadDigest,
+  type DemandAttribution,
+  type DemandAudience,
+  type DemandEnvelopeV1,
+} from "./federated-demand-contract";
+import type { FederationRole } from "./federation-link-types";
+
+export const CHANNEL_POLICY_MODES = ["explicit"] as const;
+export type ChannelPolicyMode = (typeof CHANNEL_POLICY_MODES)[number];
+
+export const PARTNER_ACCOUNT_KINDS = [
+  "reseller",
+  "distributor",
+  "service-provider",
+  "technology-partner",
+] as const;
+export type PartnerAccountKind = (typeof PARTNER_ACCOUNT_KINDS)[number];
+
+export const PARTNER_STANDINGS = ["pending", "active", "at-risk", "suspended", "terminated"] as const;
+export type PartnerStanding = (typeof PARTNER_STANDINGS)[number];
+
+export const PARTNER_TIERS = ["registered", "authorized", "silver", "gold", "platinum"] as const;
+export type PartnerTier = (typeof PARTNER_TIERS)[number];
+
+export const PARTNER_AGREEMENT_STATUSES = ["draft", "active", "expired", "terminated"] as const;
+export type PartnerAgreementStatus = (typeof PARTNER_AGREEMENT_STATUSES)[number];
+
+export const PARTNER_ENTITLEMENT_STATUSES = ["pending", "active", "suspended", "expired", "revoked"] as const;
+export type PartnerEntitlementStatus = (typeof PARTNER_ENTITLEMENT_STATUSES)[number];
+
+export function isPartnerStanding(value: string): value is PartnerStanding {
+  return (PARTNER_STANDINGS as readonly string[]).includes(value);
+}
+
+/** Local-only, per-link selection policy. The record refs never leave the
+ * source installation; the demand envelope carries only opaque network refs. */
+export interface ChannelDemandPolicy {
+  mode: ChannelPolicyMode;
+  selectedRecordRefs: string[];
+  attribution: DemandAttribution;
+  allowTransitiveForwarding: boolean;
+  forwardingAudiences: DemandAudience[];
+  forwardingExpiresAt?: string;
+}
+
+export function channelPolicySelectsRecord(
+  policy: ChannelDemandPolicy,
+  localRecordRef: string,
+): boolean {
+  return policy.mode === "explicit" && policy.selectedRecordRefs.includes(localRecordRef);
+}
+
+export function audienceForOutboundRole(role: FederationRole): DemandAudience {
+  if (role === "same-org-peer") return "internal";
+  if (role === "channel-downstream") return "founder";
+  if (role === "community-peer") return "community";
+  return "partner";
+}
+
+export function forwardingGrantFromPolicy(
+  policy: ChannelDemandPolicy,
+): DemandEnvelopeV1["forwarding"] | undefined {
+  if (!policy.allowTransitiveForwarding) return undefined;
+  return {
+    permitted: true,
+    audiences: [...new Set(policy.forwardingAudiences)],
+    ...(policy.forwardingExpiresAt ? { expiresAt: policy.forwardingExpiresAt } : {}),
+  };
+}
+
+export interface ChannelForwardingInput {
+  envelope: DemandEnvelopeV1;
+  targetAudience: DemandAudience;
+  forwardingInstallationId: string;
+  receivingInstallationId: string;
+  now?: Date;
+}
+
+/** Enforce the source's transitive-consent boundary before an intermediary
+ * constructs any new route attestation. */
+export function validateChannelForwarding(input: ChannelForwardingInput): string[] {
+  const violations: string[] = [];
+  const grant = input.envelope.forwarding;
+  if (!grant?.permitted) violations.push("forwarding:not-permitted");
+  if (!grant?.audiences.includes(input.targetAudience)) {
+    violations.push("forwarding:audience-not-consented");
+  }
+  if (grant?.expiresAt && Date.parse(grant.expiresAt) < (input.now ?? new Date()).getTime()) {
+    violations.push("forwarding:consent-expired");
+  }
+  if (input.forwardingInstallationId === input.receivingInstallationId) {
+    violations.push("forwarding:self-target");
+  }
+  if (input.envelope.originInstallationId === input.forwardingInstallationId) {
+    violations.push("forwarding:origin-cannot-intermediate");
+  }
+  if (input.envelope.route.some((hop) => hop.installationId === input.forwardingInstallationId)) {
+    violations.push("forwarding:intermediary-already-in-route");
+  }
+  if (
+    input.envelope.originInstallationId === input.receivingInstallationId
+    || input.envelope.route.some((hop) => hop.installationId === input.receivingInstallationId)
+  ) {
+    violations.push("forwarding:receiver-already-in-route");
+  }
+  if (input.envelope.route.length >= 8) violations.push("forwarding:hop-limit");
+  return violations;
+}
+
+export function forwardDemandEnvelope(input: ChannelForwardingInput & {
+  relationshipKind: string;
+  linkId: string;
+}): DemandEnvelopeV1 {
+  const violations = validateChannelForwarding(input);
+  if (violations.length > 0) {
+    throw new Error(`Demand forwarding refused: ${violations.join(", ")}`);
+  }
+  const receivedAt = (input.now ?? new Date()).toISOString();
+  const attestationDigest = `sha256:${createHash("sha256")
+    .update([
+      input.linkId,
+      input.envelope.originInstallationId,
+      input.envelope.originRecordRef,
+      String(input.envelope.originVersion),
+      input.forwardingInstallationId,
+      input.receivingInstallationId,
+      input.targetAudience,
+      receivedAt,
+    ].join("\u0000"))
+    .digest("hex")}`;
+  const forwarded: DemandEnvelopeV1 = {
+    ...input.envelope,
+    audience: input.targetAudience,
+    route: [...input.envelope.route, {
+      installationId: input.forwardingInstallationId,
+      relationshipKind: input.relationshipKind,
+      receivedAt,
+      attestationDigest,
+    }],
+    updatedAt: receivedAt,
+    payloadDigest: "sha256:pending",
+  };
+  forwarded.payloadDigest = computeDemandPayloadDigest(forwarded);
+  return forwarded;
+}

--- a/packages/db/src/federated-demand-contract.test.ts
+++ b/packages/db/src/federated-demand-contract.test.ts
@@ -7,10 +7,13 @@ import {
   DEMAND_PROJECTION_TEMPLATES,
   DEMAND_SCHEMA_VERSIONS,
   computeDemandPayloadDigest,
+  computeDemandResponseDigest,
   validateDemandEnvelopeV1,
+  validateDemandResponseV1,
   validateDemandDigestV1,
   type DemandDigestV1,
   type DemandEnvelopeV1,
+  type DemandResponseV1,
 } from "./federated-demand-contract";
 import { FEDERATION_RELATIONSHIP_PRESETS } from "./federation-link-types";
 
@@ -163,5 +166,42 @@ describe("validateDemandDigestV1", () => {
         originRecordRef: "", originVersion: 0, payloadDigest: "", withdrawn: "no",
       })),
     })).toEqual(expect.arrayContaining(["records:too-many"]));
+  });
+});
+
+describe("validateDemandResponseV1", () => {
+  const response = (overrides: Partial<DemandResponseV1> = {}): DemandResponseV1 => {
+    const value: DemandResponseV1 = {
+      specVersion: "dpf.demand-response/1",
+      responseId: "rsp_opaque_1",
+      envelopeId: "dem_01",
+      originInstallationId: "inst_opaque_a",
+      originRecordRef: "ref_opaque_1",
+      responseKind: "help-offer",
+      message: "We can help reproduce and validate this need.",
+      responderAttribution: "organization",
+      createdAt: "2026-07-20T06:00:00.000Z",
+      payloadDigest: "sha256:pending",
+      ...overrides,
+    };
+    if (overrides.payloadDigest === undefined) value.payloadDigest = computeDemandResponseDigest(value);
+    return value;
+  };
+
+  it("accepts an opaque, bounded collaboration response", () => {
+    expect(validateDemandResponseV1(response())).toEqual([]);
+  });
+
+  it("rejects source-local planning context and oversized messages", () => {
+    expect(validateDemandResponseV1({
+      ...response(),
+      backlogItemId: "BI-PRIVATE",
+      workCapsuleId: "WC-PRIVATE",
+      message: "x".repeat(1_001),
+    })).toEqual(expect.arrayContaining([
+      "field:not-allowed:backlogItemId",
+      "field:not-allowed:workCapsuleId",
+      "message:invalid",
+    ]));
   });
 });

--- a/packages/db/src/federated-demand-contract.ts
+++ b/packages/db/src/federated-demand-contract.ts
@@ -51,6 +51,13 @@ export interface DemandEnvelopeV1 {
   evidence?: Array<{ kind: string; digest: string; safeRef?: string }>;
   signal: { occurrenceCount: number; affectedOrganizations?: number };
   attribution: DemandAttribution;
+  /** Source-owned consent for a downstream intermediary to forward this
+   * minimized envelope. Absence means forwarding is forbidden. */
+  forwarding?: {
+    permitted: boolean;
+    audiences: DemandAudience[];
+    expiresAt?: string;
+  };
   createdAt: string;
   updatedAt: string;
   payloadDigest: string;
@@ -68,6 +75,22 @@ export interface DemandDigestV1 {
   originInstallationId: string;
   generatedAt: string;
   records: DemandDigestRecordV1[];
+}
+
+export const DEMAND_RESPONSE_KINDS = ["interest", "help-offer"] as const;
+export type DemandResponseKind = (typeof DEMAND_RESPONSE_KINDS)[number];
+
+export interface DemandResponseV1 {
+  specVersion: "dpf.demand-response/1";
+  responseId: string;
+  envelopeId: string;
+  originInstallationId: string;
+  originRecordRef: string;
+  responseKind: DemandResponseKind;
+  message?: string;
+  responderAttribution: DemandAttribution;
+  createdAt: string;
+  payloadDigest: string;
 }
 
 const REQUIRED_FIELDS = [
@@ -92,12 +115,14 @@ const COLLABORATIVE_FIELDS = [
   "workType",
   "applicability",
   "evidence",
+  "forwarding",
 ];
 
 const PARTNER_FIELDS = [
   ...REQUIRED_FIELDS,
   "workType",
   "applicability",
+  "forwarding",
 ];
 
 const COMMUNITY_FIELDS = [
@@ -157,6 +182,48 @@ export function computeDemandPayloadDigest(value: Omit<DemandEnvelopeV1, "payloa
   return `sha256:${createHash("sha256").update(stableJson(content)).digest("hex")}`;
 }
 
+export function computeDemandResponseDigest(
+  value: Omit<DemandResponseV1, "payloadDigest"> | DemandResponseV1,
+): string {
+  const content = { ...(value as DemandResponseV1) } as Record<string, unknown>;
+  delete content.payloadDigest;
+  return `sha256:${createHash("sha256").update(stableJson(content)).digest("hex")}`;
+}
+
+export function validateDemandResponseV1(value: unknown): string[] {
+  if (!isRecord(value)) return ["response:invalid"];
+  const allowed = new Set([
+    "specVersion", "responseId", "envelopeId", "originInstallationId",
+    "originRecordRef", "responseKind", "message", "responderAttribution",
+    "createdAt", "payloadDigest",
+  ]);
+  const violations: string[] = [];
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) violations.push(`field:not-allowed:${key}`);
+  }
+  if (value.specVersion !== "dpf.demand-response/1") violations.push("specVersion:unsupported");
+  if (!isNonEmptyString(value.responseId, 160)) violations.push("responseId:invalid");
+  if (!isNonEmptyString(value.envelopeId, 160)) violations.push("envelopeId:invalid");
+  if (!isNonEmptyString(value.originInstallationId, 160)) violations.push("originInstallationId:invalid");
+  if (!isNonEmptyString(value.originRecordRef, 240)) violations.push("originRecordRef:invalid");
+  if (!(DEMAND_RESPONSE_KINDS as readonly unknown[]).includes(value.responseKind)) {
+    violations.push("responseKind:unsupported");
+  }
+  if (value.message !== undefined && (typeof value.message !== "string" || value.message.length > 1_000)) {
+    violations.push("message:invalid");
+  }
+  if (!(DEMAND_ATTRIBUTIONS as readonly unknown[]).includes(value.responderAttribution)) {
+    violations.push("responderAttribution:unsupported");
+  }
+  if (!isIsoTimestamp(value.createdAt)) violations.push("createdAt:invalid");
+  if (typeof value.payloadDigest !== "string" || !/^sha256:[a-f0-9]{64}$/.test(value.payloadDigest)) {
+    violations.push("payloadDigest:invalid");
+  } else if (computeDemandResponseDigest(value as unknown as DemandResponseV1) !== value.payloadDigest) {
+    violations.push("payloadDigest:mismatch");
+  }
+  return violations;
+}
+
 /** Pure protocol conformance check used before persistence or semantic processing. */
 export function validateDemandEnvelopeV1(
   value: unknown,
@@ -188,6 +255,23 @@ export function validateDemandEnvelopeV1(
     violations.push(typeof value.summary === "string" && value.summary.length > 4_000 ? "summary:too-long" : "summary:invalid");
   }
   if (!(DEMAND_ATTRIBUTIONS as readonly unknown[]).includes(value.attribution)) violations.push("attribution:unsupported");
+  if (value.forwarding !== undefined) {
+    if (!isRecord(value.forwarding)) {
+      violations.push("forwarding:invalid");
+    } else {
+      if (typeof value.forwarding.permitted !== "boolean") violations.push("forwarding.permitted:invalid");
+      if (!Array.isArray(value.forwarding.audiences) || value.forwarding.audiences.length > 4) {
+        violations.push("forwarding.audiences:invalid");
+      } else if (value.forwarding.audiences.some(
+        (audience) => !(DEMAND_AUDIENCES as readonly unknown[]).includes(audience),
+      )) {
+        violations.push("forwarding.audiences:unsupported");
+      }
+      if (value.forwarding.expiresAt !== undefined && !isIsoTimestamp(value.forwarding.expiresAt)) {
+        violations.push("forwarding.expiresAt:invalid");
+      }
+    }
+  }
   if (!isIsoTimestamp(value.createdAt)) violations.push("createdAt:invalid");
   if (!isIsoTimestamp(value.updatedAt)) violations.push("updatedAt:invalid");
   if (typeof value.payloadDigest !== "string" || !/^sha256:[a-f0-9]{64}$/.test(value.payloadDigest)) {

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -1,11 +1,11 @@
 {
   "changeRationale": {
     "defaultRequiredServiceCount": "Capability-owned services moved behind deterministic Compose profiles; only PostgreSQL, portal initialization, and portal remain universal core.",
-    "prismaModelCount": "AiProviderConnection separates provider catalog identity from organization-scoped account, credential, contract, entitlement, finance, and capacity evidence so suitability policy cannot infer business-safe use from a provider slug.",
+    "prismaModelCount": "Five Founder Hub partner-business models separate reseller account standing, agreements, offering entitlements, support routing, and contribution recognition while referencing the existing federation, catalog, and Hive authorities instead of duplicating them.",
     "serviceCount": "Linux Ollama is now explicitly catalogued as a host-specific runtime:external-ai service instead of remaining an ungoverned overlay-only container."
   },
-  "generatedAt": "2026-07-20T00:12:00.000Z",
-  "gitSha": "c16edb843adf7d58b97e10ecbd60df8a1dfd67e1",
+  "generatedAt": "2026-07-20T07:25:00.000Z",
+  "gitSha": "b3bebf2cbdf44829da703f3217637c3c44ff1107",
   "manifestVersion": 2,
   "metrics": {
     "defaultRequiredServiceCount": {
@@ -22,7 +22,7 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 513
+      "value": 518
     },
     "prismaSchemaLines": {
       "direction": "informational",


### PR DESCRIPTION
## Summary
- add explicit customer/reseller and reseller/Founder Hub demand selection, withdrawal, pseudonymous forwarding, and transitive-consent enforcement
- add durable interest/help responses tied only to envelopes previously shared on the same link
- add Founder Hub reseller business records and Connections/Delivery Flow controls while keeping backlog, Hive result, catalog, and commercial authorities separate
- document the operating model, implementation receipt, governed data impact, and live backlog coverage

## Verification
- canonical local-integration evidence `cmrswhny60cea01pgktsnpbqf` for exact head `61b91f7dcfdc59a7f8c5b90c5a500670208b93c7`
- merged-code base `origin/main@eea68c5e441b5c3f3541867370029bc5b425188d`
- Prisma migration deploy passed against ephemeral Postgres; rerun reported no pending migrations
- full web Vitest suite passed
- web typecheck passed with the canonical 8 GiB setting
- production Next.js build passed; `/platform/federation-links`, `/ops/demand`, `/api/v1/federation/demand`, and `/api/v1/federation/demand/reconcile` are present
- focused database protocol/schema tests: 25 passed
- affected UI component tests: 4 passed
- architecture parity: 0 errors, 0 warnings; route manifest current at 572 routes
- private-identity guard and substrate-complexity guard self-test pass
- authenticated contributor preview reached both changed routes; rendering correctly stopped at the unapplied branch migration, which was not applied to the live Arcamanus database. Component render/interaction contracts are covered by focused tests; post-merge live verification remains governed by self-upgrade.

## Design grounding
- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-07-19-federated-demand-network-design.md`
  - `docs/superpowers/plans/2026-07-19-federated-demand-network.md`
- Current code substrate reviewed:
  - `packages/db/src/federated-demand-contract.ts`
  - `apps/web/lib/federation/`
  - existing Connections and Delivery Flow routes
- Source of truth:
  - `FederationLink` owns trust and directional relationship; projection contracts own shareable fields; local `BacklogItem` remains authoritative; Founder Hub partner records own commercial standing.
- Decision:
  - extend existing owners with explicit, independently revocable channel permissions and bounded response envelopes; do not create a global backlog, second partner identity, or parallel navigation surface.

UX-Fit-Decision: progressive disclosure in existing Connections and Delivery Flow routes; relationship setup and contextual item actions remain separated, with protocol internals hidden.

## Governance boundaries
- live backlog-coverage receipt `cmrsw3hdn0000lbpg591ouv5s` maps all six independently shippable deliverables to their governed backlog items
- OSS UI/docs use the generic Founder Hub role; the private Arcamanus installation name appears only here as runtime verification context
- the substrate baseline records the intentional five-model increase: partner standing, agreements, offering entitlements, support routing, and contribution recognition remain separate authorities while referencing existing federation, catalog, and Hive records
- local `BacklogItem` remains authoritative; federation stores minimized mirrors only
- Founder Hub partner records are business-only and do not create credentials or a second backlog
- Hive contributions remain result/evidence records and reject source backlog/work-capsule context
- source-owned forwarding consent is explicit, audience-bounded, expiring, and independently revocable

Closes BI-D964E2DA
