### PR TITLE
feat: enforce bounded OpenRouter provider policy

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
@@ -182,6 +182,19 @@ export default async function ProviderDetailPage({ params }: Props) {
               enabledRegions: providerConnection.entitlements && typeof providerConnection.entitlements === "object" && !Array.isArray(providerConnection.entitlements) && Array.isArray((providerConnection.entitlements as Record<string, unknown>).enabledRegions)
                 ? ((providerConnection.entitlements as Record<string, unknown>).enabledRegions as unknown[]).filter((region): region is string => typeof region === "string")
                 : [],
+              zeroRetention: providerConnection.entitlements && typeof providerConnection.entitlements === "object" && !Array.isArray(providerConnection.entitlements)
+                ? typeof (providerConnection.entitlements as Record<string, unknown>).zeroRetention === "boolean"
+                  ? (providerConnection.entitlements as Record<string, unknown>).zeroRetention as boolean
+                  : null
+                : null,
+              regionalProcessing: providerConnection.entitlements && typeof providerConnection.entitlements === "object" && !Array.isArray(providerConnection.entitlements)
+                ? typeof (providerConnection.entitlements as Record<string, unknown>).regionalProcessing === "boolean"
+                  ? (providerConnection.entitlements as Record<string, unknown>).regionalProcessing as boolean
+                  : null
+                : null,
+              approvedUnderlyingProviderSlugs: providerConnection.entitlements && typeof providerConnection.entitlements === "object" && !Array.isArray(providerConnection.entitlements) && Array.isArray((providerConnection.entitlements as Record<string, unknown>).approvedUnderlyingProviderSlugs)
+                ? ((providerConnection.entitlements as Record<string, unknown>).approvedUnderlyingProviderSlugs as unknown[]).filter((slug): slug is string => typeof slug === "string")
+                : [],
             } : null}
           />
           {/* BI-87D93A71 (Minimum): surface OAuth callback port mismatch

--- a/apps/web/components/platform/ProviderAccountPostureForm.test.tsx
+++ b/apps/web/components/platform/ProviderAccountPostureForm.test.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock("@/lib/actions/provider-connection-posture", () => ({
+  updateProviderConnectionPosture: vi.fn(),
+}));
+
+import { ProviderAccountPostureForm } from "./ProviderAccountPostureForm";
+
+describe("ProviderAccountPostureForm", () => {
+  it("explains and exposes connection-scoped OpenRouter bounds", () => {
+    const html = renderToStaticMarkup(
+      <ProviderAccountPostureForm
+        providerId="openrouter"
+        canWrite
+        initial={{
+          accountClass: "enterprise",
+          noTraining: true,
+          enabledRegions: ["eu"],
+          zeroRetention: true,
+          regionalProcessing: true,
+          approvedUnderlyingProviderSlugs: ["anthropic"],
+        }}
+      />,
+    );
+    expect(html).toContain("Bound the router before company data is used");
+    expect(html).toContain("do not prove an enterprise contract or EU entitlement");
+    expect(html).toContain("Zero Data Retention enabled");
+    expect(html).toContain("Approved underlying providers");
+    expect(html).toContain("anthropic");
+  });
+
+  it("does not burden direct-provider setup with router-only controls", () => {
+    const html = renderToStaticMarkup(
+      <ProviderAccountPostureForm providerId="anthropic" canWrite initial={null} />,
+    );
+    expect(html).not.toContain("Bound the router before company data is used");
+  });
+});

--- a/apps/web/components/platform/ProviderAccountPostureForm.tsx
+++ b/apps/web/components/platform/ProviderAccountPostureForm.tsx
@@ -13,7 +13,14 @@ export function ProviderAccountPostureForm({
 }: {
   providerId: string;
   canWrite: boolean;
-  initial: { accountClass: string; noTraining: boolean | null; enabledRegions: string[] } | null;
+  initial: {
+    accountClass: string;
+    noTraining: boolean | null;
+    enabledRegions: string[];
+    zeroRetention?: boolean | null;
+    regionalProcessing?: boolean | null;
+    approvedUnderlyingProviderSlugs?: string[];
+  } | null;
 }) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
@@ -24,6 +31,9 @@ export function ProviderAccountPostureForm({
   );
   const [noTraining, setNoTraining] = useState(initial?.noTraining == null ? "unknown" : initial.noTraining ? "yes" : "no");
   const [regions, setRegions] = useState((initial?.enabledRegions ?? []).join(", "));
+  const [zeroRetention, setZeroRetention] = useState(initial?.zeroRetention == null ? "unknown" : initial.zeroRetention ? "yes" : "no");
+  const [regionalProcessing, setRegionalProcessing] = useState(initial?.regionalProcessing == null ? "unknown" : initial.regionalProcessing ? "yes" : "no");
+  const [approvedProviders, setApprovedProviders] = useState((initial?.approvedUnderlyingProviderSlugs ?? []).join(", "));
   const [message, setMessage] = useState<string | null>(null);
 
   return (
@@ -50,6 +60,34 @@ export function ProviderAccountPostureForm({
           <input className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[var(--dpf-text)]" value={regions} disabled={!canWrite || pending} placeholder="eu, uk" onChange={(event) => setRegions(event.target.value)} />
         </label>
       </div>
+      {providerId === "openrouter" && (
+        <div className="mt-4 rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
+          <h3 className="m-0 text-xs font-semibold text-[var(--dpf-text)]">Bound the router before company data is used</h3>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+            OpenRouter is one account in front of other providers. These declarations help DPF stop unsafe fallback, but do not prove an enterprise contract or EU entitlement.
+          </p>
+          <div className="mt-3 grid gap-3 md:grid-cols-3">
+            <label className="text-xs text-[var(--dpf-muted)]">Zero Data Retention enabled
+              <select className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[var(--dpf-text)]" value={zeroRetention} disabled={!canWrite || pending} onChange={(event) => setZeroRetention(event.target.value)}>
+                <option value="unknown">Not verified</option>
+                <option value="yes">Enabled for this account</option>
+                <option value="no">No</option>
+              </select>
+            </label>
+            <label className="text-xs text-[var(--dpf-muted)]">Regional processing enabled
+              <select className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[var(--dpf-text)]" value={regionalProcessing} disabled={!canWrite || pending} onChange={(event) => setRegionalProcessing(event.target.value)}>
+                <option value="unknown">Not verified</option>
+                <option value="yes">Enabled for this account</option>
+                <option value="no">No</option>
+              </select>
+            </label>
+            <label className="text-xs text-[var(--dpf-muted)]">Approved underlying providers
+              <input className="mt-1 w-full rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 text-[var(--dpf-text)]" value={approvedProviders} disabled={!canWrite || pending} placeholder="anthropic, mistral" onChange={(event) => setApprovedProviders(event.target.value)} />
+              <span className="mt-1 block">Use the provider endpoint slugs reviewed for this company.</span>
+            </label>
+          </div>
+        </div>
+      )}
       <div className="mt-3 flex items-center gap-3">
         <button type="button" disabled={!canWrite || pending} className="rounded bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-[var(--dpf-on-accent)] disabled:opacity-50" onClick={() => startTransition(async () => {
           const result = await updateProviderConnectionPosture({
@@ -57,6 +95,11 @@ export function ProviderAccountPostureForm({
             accountClass,
             noTraining: noTraining === "unknown" ? null : noTraining === "yes",
             enabledRegions: regions.split(","),
+            ...(providerId === "openrouter" ? {
+              zeroRetention: zeroRetention === "unknown" ? null : zeroRetention === "yes",
+              regionalProcessing: regionalProcessing === "unknown" ? null : regionalProcessing === "yes",
+              approvedUnderlyingProviderSlugs: approvedProviders.split(","),
+            } : {}),
           });
           setMessage(result.error ?? "Account declaration saved. DPF will keep unproven workloads blocked.");
           if (!result.error) router.refresh();

--- a/apps/web/lib/actions/ai-providers.test.ts
+++ b/apps/web/lib/actions/ai-providers.test.ts
@@ -120,6 +120,40 @@ describe("updateProviderConnectionPosture", () => {
       skipDiscovery: true,
     });
   });
+
+  it("records OpenRouter controls on the exact connection without creating enterprise proof", async () => {
+    mockPrisma.aiProviderConnection.findUnique.mockResolvedValue({
+      entitlements: {},
+      evidenceStatus: "unreviewed",
+    });
+    mockPrisma.aiProviderConnection.update.mockResolvedValue({});
+    mockPrisma.modelProvider.findUnique.mockResolvedValue({ status: "active" });
+
+    await updateProviderConnectionPosture({
+      providerId: "openrouter",
+      accountClass: "regular",
+      noTraining: true,
+      enabledRegions: ["eu"],
+      zeroRetention: true,
+      regionalProcessing: true,
+      approvedUnderlyingProviderSlugs: [" Anthropic ", "google-vertex/europe-west4", "bad slug!"],
+    });
+
+    expect(mockPrisma.aiProviderConnection.update).toHaveBeenCalledWith({
+      where: { connectionId: "provider-default-openrouter" },
+      data: expect.objectContaining({
+        accountClass: "regular",
+        evidenceStatus: "operator-attested",
+        entitlements: {
+          noTraining: true,
+          enabledRegions: ["eu"],
+          zeroRetention: true,
+          regionalProcessing: true,
+          approvedUnderlyingProviderSlugs: ["anthropic", "google-vertex/europe-west4"],
+        },
+      }),
+    });
+  });
 });
 
 describe("testProviderAuth", () => {

--- a/apps/web/lib/actions/provider-connection-posture.ts
+++ b/apps/web/lib/actions/provider-connection-posture.ts
@@ -17,6 +17,9 @@ export async function updateProviderConnectionPosture(input: {
   accountClass: (typeof PROVIDER_ACCOUNT_CLASSES)[number];
   noTraining: boolean | null;
   enabledRegions: string[];
+  zeroRetention?: boolean | null;
+  regionalProcessing?: boolean | null;
+  approvedUnderlyingProviderSlugs?: string[];
 }): Promise<{ error?: string }> {
   await requireCapability("manage_provider_connections");
   if (!PROVIDER_ACCOUNT_CLASSES.includes(input.accountClass)) {
@@ -41,6 +44,15 @@ export async function updateProviderConnectionPosture(input: {
         ...existingEntitlements,
         noTraining: input.noTraining,
         enabledRegions: [...new Set(input.enabledRegions.map((region) => region.trim().toLowerCase()).filter(Boolean))].sort(),
+        ...(input.providerId === "openrouter" ? {
+          zeroRetention: input.zeroRetention ?? null,
+          regionalProcessing: input.regionalProcessing ?? null,
+          approvedUnderlyingProviderSlugs: [...new Set(
+            (input.approvedUnderlyingProviderSlugs ?? [])
+              .map((slug) => slug.trim().toLowerCase())
+              .filter((slug) => /^[a-z0-9][a-z0-9._/-]*$/.test(slug)),
+          )].sort(),
+        } : {}),
       },
     },
   });

--- a/apps/web/lib/ai-provider-route-context.ts
+++ b/apps/web/lib/ai-provider-route-context.ts
@@ -1,10 +1,12 @@
 import type { ProviderSuitabilityPolicy } from "./routing/provider-suitability/types";
+import type { OpenRouterPolicyObligations } from "./routing/provider-suitability/types";
 import type { RequestContract } from "./routing/request-contract";
 
 export type ProviderSuitabilityRouteContext = {
   allowedProviders?: string[];
   deniedProviders?: string[];
   residencyPolicy?: RequestContract["residencyPolicy"];
+  openRouterObligations?: OpenRouterPolicyObligations;
 };
 
 function normalizeProviderIds(values: readonly string[]): string[] {
@@ -25,7 +27,7 @@ const RESIDENCY_RANK: Readonly<Record<NonNullable<RequestContract["residencyPoli
 export function applyProviderSuitabilityRouteContext<T extends Record<string, unknown>>(
   routeContext: T & ProviderSuitabilityRouteContext,
   policy: ProviderSuitabilityPolicy,
-): T & Required<ProviderSuitabilityRouteContext> {
+): T & ProviderSuitabilityRouteContext {
   const policyAllowed = normalizeProviderIds(policy.allowedProviders);
   const existingAllowed = routeContext.allowedProviders === undefined
     ? null
@@ -49,6 +51,9 @@ export function applyProviderSuitabilityRouteContext<T extends Record<string, un
     allowedProviders,
     deniedProviders,
     residencyPolicy,
+    ...(policy.openRouterObligations
+      ? { openRouterObligations: policy.openRouterObligations }
+      : {}),
   };
 }
 

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8067,6 +8067,7 @@
         "how-oauth-works",
         "choosing-the-right-method",
         "business-safe-review",
+        "openrouter-and-other-router-accounts",
         "finance-bridge",
         "where-to-review-it",
         "troubleshooting"

--- a/apps/web/lib/inference/ai-provider-types.ts
+++ b/apps/web/lib/inference/ai-provider-types.ts
@@ -221,6 +221,14 @@ export type RegistryProviderEntry = {
       baseUrl: string;
       requiresEnterpriseEnablement: boolean;
     }>;
+    routerPassThrough?: {
+      exposesUnderlyingProvider: boolean;
+      supportsProviderAllowlist: boolean;
+      supportsProviderBlocklist: boolean;
+      supportsZdrFilter: boolean;
+      supportsDataCollectionDeny: boolean;
+      supportsBoundedFallbacks: boolean;
+    };
   };
   serviceKind?: "mcp" | "built_in" | null;
   authorizeUrl?: string | null;

--- a/apps/web/lib/routing/chat-adapter.test.ts
+++ b/apps/web/lib/routing/chat-adapter.test.ts
@@ -279,6 +279,88 @@ describe("chatAdapter", () => {
     expect(sentBody.reasoning_effort).toBe("medium");
   });
 
+  it("OpenRouter: sends bounded provider controls, metadata header, and safe routing evidence", async () => {
+    stubFetchOk({
+      choices: [{ message: { content: "bounded answer" } }],
+      usage: { prompt_tokens: 5, completion_tokens: 3 },
+      openrouter_metadata: {
+        region: "fra",
+        endpoints: { available: [{ provider: "Anthropic", model: "anthropic/claude", selected: true }] },
+        attempts: [{ provider: "Anthropic", model: "anthropic/claude", status: 200, output: "drop" }],
+      },
+    });
+
+    const result = await chatAdapter.execute(makeRequest({
+      providerId: "openrouter",
+      modelId: "anthropic/claude",
+      plan: makePlan({
+        providerId: "openrouter",
+        modelId: "anthropic/claude",
+        openRouterPolicy: {
+          posture: "restricted",
+          providerSettings: {
+            only: ["anthropic"],
+            allow_fallbacks: false,
+            require_parameters: true,
+            data_collection: "deny",
+            zdr: true,
+          },
+          requestRouterMetadata: true,
+          requireUnderlyingProviderEvidence: true,
+          providerConnectionId: "conn-openrouter",
+        },
+      }),
+      provider: {
+        baseUrl: "https://openrouter.ai/api/v1",
+        headers: { Authorization: "Bearer test", "Content-Type": "application/json" },
+      },
+    }));
+
+    const [url, fetchOpts] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect(fetchOpts.headers).toMatchObject({ "X-OpenRouter-Metadata": "enabled" });
+    expect(JSON.parse(fetchOpts.body).provider).toEqual({
+      only: ["anthropic"],
+      allow_fallbacks: false,
+      require_parameters: true,
+      data_collection: "deny",
+      zdr: true,
+    });
+    expect(result.raw).toEqual({
+      openRouterRoutingEvidence: {
+        underlyingProviderEvidence: "returned",
+        selectedProvider: "Anthropic",
+        selectedModel: "anthropic/claude",
+        region: "fra",
+        attempts: [{ provider: "Anthropic", model: "anthropic/claude", status: 200 }],
+      },
+    });
+  });
+
+  it("OpenRouter: uses the entitlement-bound EU URL and fails restricted responses closed without metadata", async () => {
+    stubFetchOk({
+      choices: [{ message: { content: "must not be returned" } }],
+      usage: { prompt_tokens: 5, completion_tokens: 3 },
+    });
+    const promise = chatAdapter.execute(makeRequest({
+      providerId: "openrouter",
+      plan: makePlan({
+        providerId: "openrouter",
+        openRouterPolicy: {
+          posture: "restricted",
+          providerSettings: { only: ["mistral"], allow_fallbacks: false, zdr: true, data_collection: "deny" },
+          requestRouterMetadata: true,
+          requireUnderlyingProviderEvidence: true,
+          providerConnectionId: "conn-eu",
+          requiredBaseUrl: "https://eu.openrouter.ai/api/v1",
+        },
+      }),
+      provider: { baseUrl: "https://openrouter.ai/api/v1", headers: { Authorization: "Bearer test" } },
+    }));
+    await expect(promise).rejects.toThrow(/underlying-provider metadata/i);
+    expect(mockFetch.mock.calls[0][0]).toBe("https://eu.openrouter.ai/api/v1/chat/completions");
+  });
+
   // ── 3. Anthropic: correct URL, body shape, system prompt separate ──
 
   it("Anthropic: correct URL, body shape, system prompt separate", async () => {

--- a/apps/web/lib/routing/chat-adapter.ts
+++ b/apps/web/lib/routing/chat-adapter.ts
@@ -32,6 +32,7 @@ import { extractToolCalls as extractTextualToolUse } from "./extract-tool-calls"
 // (and tests) that import it from here.
 import { withLocalInferenceLock } from "@/lib/queue/resource-lane";
 import { buildAnthropicSystem } from "./anthropic-cache";
+import { parseOpenRouterRoutingEvidence } from "./provider-suitability/openrouter-policy";
 
 // ─── Inference HTTP timeouts ──────────────────────────────────────────────────
 // A hung local Docker Model Runner endpoint must fail fast so callWithFallbackChain
@@ -169,6 +170,7 @@ export const chatAdapter: ExecutionAdapterHandler = {
   async execute(request: AdapterRequest): Promise<AdapterResult> {
     const { providerId, modelId, plan, provider, messages, systemPrompt, tools } = request;
     const { baseUrl, headers } = provider;
+    let requestHeaders = headers;
 
     // Build provider-specific request
     let chatUrl: string;
@@ -309,7 +311,10 @@ export const chatAdapter: ExecutionAdapterHandler = {
 
     } else {
       // ── OpenAI-compatible ──────────────────────────────────────────────
-      const apiBase = baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
+      const selectedBaseUrl = providerId === "openrouter" && plan.openRouterPolicy?.requiredBaseUrl
+        ? plan.openRouterPolicy.requiredBaseUrl
+        : baseUrl;
+      const apiBase = selectedBaseUrl.endsWith("/v1") ? selectedBaseUrl : `${selectedBaseUrl}/v1`;
       chatUrl = `${apiBase}/chat/completions`;
 
       const allMessages = [
@@ -323,6 +328,17 @@ export const chatAdapter: ExecutionAdapterHandler = {
         max_tokens: plan.maxTokens,
         keep_alive: -1,
       };
+
+      if (providerId === "openrouter" && plan.openRouterPolicy) {
+        // One construction point makes the typed policy load-bearing for every
+        // OpenRouter chat/completions call; callers cannot separately construct
+        // an unbounded body after suitability has compiled the plan.
+        body.provider = plan.openRouterPolicy.providerSettings;
+        requestHeaders = {
+          ...headers,
+          "X-OpenRouter-Metadata": "enabled",
+        };
+      }
 
       // Apply temperature
       if (plan.temperature !== undefined) {
@@ -364,7 +380,7 @@ export const chatAdapter: ExecutionAdapterHandler = {
       // while it waits its turn in the local-inference lock.
       const doFetch = () => fetch(chatUrl, {
         method: "POST",
-        headers,
+        headers: requestHeaders,
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(resolveInferenceTimeoutMs(providerId)),
       });
@@ -423,6 +439,20 @@ export const chatAdapter: ExecutionAdapterHandler = {
       data = lastCompleted ?? { output: [{ type: "message", content: [{ type: "output_text", text: lastDelta }] }] };
     } else {
       data = await res.json() as Record<string, unknown>;
+    }
+
+    const openRouterRoutingEvidence = providerId === "openrouter"
+      ? parseOpenRouterRoutingEvidence(data.openrouter_metadata)
+      : undefined;
+    if (
+      plan.openRouterPolicy?.requireUnderlyingProviderEvidence &&
+      openRouterRoutingEvidence?.underlyingProviderEvidence !== "returned"
+    ) {
+      throw new InferenceError(
+        "Restricted OpenRouter response did not return underlying-provider metadata; the result was withheld.",
+        "provider_error",
+        providerId,
+      );
     }
 
     // ── Extract text, tool calls, and usage ──────────────────────────────
@@ -546,6 +576,9 @@ export const chatAdapter: ExecutionAdapterHandler = {
       toolCalls,
       usage: { inputTokens, outputTokens, cacheCreationInputTokens, cacheReadInputTokens },
       inferenceMs,
+      ...(openRouterRoutingEvidence
+        ? { raw: { openRouterRoutingEvidence } }
+        : {}),
     };
   },
 };

--- a/apps/web/lib/routing/execution-plan.test.ts
+++ b/apps/web/lib/routing/execution-plan.test.ts
@@ -252,6 +252,41 @@ describe("buildPlanFromRecipe", () => {
     const plan = buildPlanFromRecipe(recipe, makeContract());
     expect(plan.executionAdapter).toBe("claude-cli");
   });
+
+  it("compiles restricted OpenRouter obligations into a typed execution policy", () => {
+    const plan = buildPlanFromRecipe(
+      makeRecipe({ providerId: "openrouter", modelId: "anthropic/claude" }),
+      makeContract({
+        openRouterObligations: {
+          requireProviderAllowlist: true,
+          requireProviderBlocklist: true,
+          requireZdr: true,
+          denyDataCollection: true,
+          requireBoundedFallbacks: true,
+          requiredRegion: null,
+          approvedEndpointSlugs: ["anthropic"],
+          providerConnectionId: "conn-router",
+          accountClass: "enterprise",
+          evidenceStatus: "contract-uploaded",
+          regionalProcessingEntitled: false,
+          enabledRegions: [],
+          requiredBaseUrl: null,
+        },
+      }),
+    );
+    expect(plan.openRouterPolicy).toMatchObject({
+      posture: "restricted",
+      providerSettings: {
+        only: ["anthropic"],
+        allow_fallbacks: false,
+        require_parameters: true,
+        data_collection: "deny",
+        zdr: true,
+      },
+      requireUnderlyingProviderEvidence: true,
+      providerConnectionId: "conn-router",
+    });
+  });
 });
 
 // ── buildDefaultPlan ─────────────────────────────────────────────────────────

--- a/apps/web/lib/routing/execution-plan.ts
+++ b/apps/web/lib/routing/execution-plan.ts
@@ -12,6 +12,10 @@ import type { EndpointManifest } from "./types";
 import type { RecipeRow, RoutedExecutionPlan } from "./recipe-types";
 import type { HarnessRecipe } from "./harness-recipe";
 import { usesResponsesApi, usesCliAdapter, usesCodexCli } from "./provider-utils";
+import {
+  compileOpenRouterExecutionPolicy,
+  type OpenRouterProviderSettings,
+} from "./provider-suitability/openrouter-policy";
 
 // EP-INF-009c: Model class → execution adapter mapping
 const MODEL_CLASS_ADAPTER: Record<string, string> = {
@@ -100,10 +104,20 @@ export function buildPlanFromRecipe(
     providerSettings: remainingSettings,
     toolPolicy,
     responsePolicy,
+    ...(contract.openRouterObligations
+      ? { openRouterObligations: contract.openRouterObligations }
+      : {}),
   };
 
   if (typeof temperature === "number") {
     plan.temperature = temperature;
+  }
+
+  if (recipe.providerId === "openrouter" && contract.openRouterObligations) {
+    plan.openRouterPolicy = compileOpenRouterExecutionPolicy(
+      contract.openRouterObligations,
+      (remainingSettings.openRouterProviderSettings ?? {}) as OpenRouterProviderSettings,
+    );
   }
 
   return plan;
@@ -142,7 +156,7 @@ export function buildDefaultPlan(
     contract.requiredModelClass,
   );
 
-  return {
+  const plan: RoutedExecutionPlan = {
     providerId: endpoint.providerId,
     modelId: endpoint.modelId,
     recipeId: null,
@@ -152,7 +166,14 @@ export function buildDefaultPlan(
     providerSettings: {},
     toolPolicy,
     responsePolicy,
+    ...(contract.openRouterObligations
+      ? { openRouterObligations: contract.openRouterObligations }
+      : {}),
   };
+  if (endpoint.providerId === "openrouter" && contract.openRouterObligations) {
+    plan.openRouterPolicy = compileOpenRouterExecutionPolicy(contract.openRouterObligations);
+  }
+  return plan;
 }
 
 // ── attachHarnessRecipeToPlan ───────────────────────────────────────────────

--- a/apps/web/lib/routing/fallback.test.ts
+++ b/apps/web/lib/routing/fallback.test.ts
@@ -73,7 +73,7 @@ vi.mock("./route-outcome", () => ({
 
 // ── Imports (after mocks) ────────────────────────────────────────────────────
 
-import { callWithFallbackChain } from "./fallback";
+import { buildFallbackPlan, callWithFallbackChain } from "./fallback";
 import { prisma } from "@dpf/db";
 import { callProvider, InferenceError } from "@/lib/ai-inference";
 import {
@@ -121,6 +121,45 @@ const makeCandidate = (
   dimensionScores: {},
   costPerOutputMToken: null,
   excluded: false,
+});
+
+it("keeps restricted OpenRouter obligations load-bearing when OpenRouter is a fallback", () => {
+  const plan = buildFallbackPlan(
+    { providerId: "openrouter", modelId: "anthropic/claude" },
+    makeDecision("openai", "gpt-4o"),
+    undefined,
+    {
+      providerId: "openai",
+      modelId: "gpt-4o",
+      recipeId: null,
+      contractFamily: "sync.test",
+      executionAdapter: "chat",
+      maxTokens: 1024,
+      providerSettings: {},
+      toolPolicy: {},
+      responsePolicy: {},
+      openRouterObligations: {
+        requireProviderAllowlist: true,
+        requireProviderBlocklist: true,
+        requireZdr: true,
+        denyDataCollection: true,
+        requireBoundedFallbacks: true,
+        requiredRegion: null,
+        approvedEndpointSlugs: ["anthropic"],
+        providerConnectionId: "conn-router",
+        accountClass: "enterprise",
+        evidenceStatus: "contract-uploaded",
+        regionalProcessingEntitled: false,
+        enabledRegions: [],
+        requiredBaseUrl: null,
+      },
+    },
+  );
+  expect(plan.openRouterPolicy).toMatchObject({
+    posture: "restricted",
+    providerSettings: { only: ["anthropic"], allow_fallbacks: false, zdr: true },
+    requireUnderlyingProviderEvidence: true,
+  });
 });
 
 const mockPrisma = prisma as unknown as {

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -7,6 +7,7 @@ import type { ChatMessage } from "@/lib/ai-inference";
 import { prisma } from "@dpf/db";
 import type { RouteDecision } from "./types";
 import type { RoutedExecutionPlan } from "./recipe-types";
+import { compileOpenRouterExecutionPolicy } from "./provider-suitability/openrouter-policy";
 import { resolveDefaultExecutionAdapter } from "./execution-plan";
 import {
   recordRequest,
@@ -45,7 +46,7 @@ function buildFallbackProviderSettings(
   return effort ? { effort } : {};
 }
 
-function buildFallbackPlan(
+export function buildFallbackPlan(
   entry: { providerId: string; modelId: string },
   decision: RouteDecision,
   tools?: Array<Record<string, unknown>>,
@@ -58,7 +59,7 @@ function buildFallbackPlan(
     toolPolicy.toolChoice = "auto";
   }
 
-  return {
+  const fallbackPlan: RoutedExecutionPlan = {
     providerId: entry.providerId,
     modelId: entry.modelId,
     recipeId: null,
@@ -69,7 +70,14 @@ function buildFallbackPlan(
     toolPolicy,
     responsePolicy: sourcePlan?.responsePolicy ?? {},
     ...(sourcePlan?.temperature !== undefined ? { temperature: sourcePlan.temperature } : {}),
+    ...(sourcePlan?.openRouterObligations
+      ? { openRouterObligations: sourcePlan.openRouterObligations }
+      : {}),
   };
+  if (entry.providerId === "openrouter" && sourcePlan?.openRouterObligations) {
+    fallbackPlan.openRouterPolicy = compileOpenRouterExecutionPolicy(sourcePlan.openRouterObligations);
+  }
+  return fallbackPlan;
 }
 
 export interface FallbackResult {
@@ -81,6 +89,8 @@ export interface FallbackResult {
   downgraded: boolean;
   downgradeMessage: string | null;
   responseId?: string;
+  /** Policy-safe router receipt; never includes prompts or model output. */
+  routingEvidence?: import("./provider-suitability/openrouter-policy").OpenRouterRoutingEvidence;
 }
 
 /**
@@ -299,6 +309,10 @@ export async function callWithFallbackChain(
 
       const pinnedMiss = decision.reason?.startsWith("WARNING: Pinned provider") ?? false;
       const downgraded = i > 0 || pinnedMiss;
+      const raw = result.raw && typeof result.raw === "object"
+        ? result.raw as Record<string, unknown>
+        : null;
+      const routingEvidence = raw?.openRouterRoutingEvidence;
       return {
         providerId: entry.providerId,
         modelId: entry.modelId,
@@ -315,6 +329,9 @@ export async function callWithFallbackChain(
             : `Switched to ${provider.name} after the preferred endpoint was unavailable.`
           : null,
         responseId: result.responseId,
+        ...(routingEvidence && typeof routingEvidence === "object"
+          ? { routingEvidence: routingEvidence as import("./provider-suitability/openrouter-policy").OpenRouterRoutingEvidence }
+          : {}),
       };
     } catch (e) {
       const errMsg = e instanceof Error ? e.message : String(e);

--- a/apps/web/lib/routing/provider-suitability/compile.test.ts
+++ b/apps/web/lib/routing/provider-suitability/compile.test.ts
@@ -286,6 +286,40 @@ describe("compileAiProviderSuitabilityPolicy", () => {
     expect(result.residencyPolicy).toBe("any_enabled");
   });
 
+  it("keeps OpenRouter execution obligations bound to the one attested connection", () => {
+    const result = compile({
+      workloadClasses: ["customer-records"],
+      providers: [trust("openrouter", "conn-router", {
+        accountClass: "enterprise",
+        evidenceStatus: "contract-uploaded",
+        entitlements: {
+          zeroRetention: true,
+          noTraining: true,
+          approvedUnderlyingProviderSlugs: ["anthropic", "google-vertex/europe-west4"],
+        },
+      }, {
+        category: "router",
+        externalEgress: "router-cloud",
+        routerPassThrough: {
+          exposesUnderlyingProvider: true,
+          supportsProviderAllowlist: true,
+          supportsProviderBlocklist: true,
+          supportsZdrFilter: true,
+          supportsDataCollectionDeny: true,
+          supportsBoundedFallbacks: true,
+        },
+      })],
+    });
+    expect(result.openRouterObligations).toMatchObject({
+      providerConnectionId: "conn-router",
+      accountClass: "enterprise",
+      approvedEndpointSlugs: ["anthropic", "google-vertex/europe-west4"],
+      requireZdr: true,
+      denyDataCollection: true,
+      requireBoundedFallbacks: true,
+    });
+  });
+
   it("requires financial review evidence for a credit union cloud route", () => {
     const result = compile({
       workloadClasses: ["payments-finance"],

--- a/apps/web/lib/routing/provider-suitability/compile.ts
+++ b/apps/web/lib/routing/provider-suitability/compile.ts
@@ -179,15 +179,33 @@ function residencyPolicy(input: CompileProviderSuitabilityInput): ProviderSuitab
 }
 
 function openRouterObligations(input: CompileProviderSuitabilityInput): OpenRouterPolicyObligations | null {
-  if (!input.providerFacts.some((facts) => facts.category === "router")) return null;
+  const connections = input.providerFacts.filter(
+    (facts) => facts.providerId === "openrouter" || facts.catalogProviderId === "openrouter",
+  );
+  if (connections.length === 0) return null;
   const restricted = input.workloadProfiles.some((profile) => profile.sensitivity !== "public");
+  // One execution plan must describe one concrete account. Ambiguous connections
+  // intentionally compile without account claims or endpoint slugs and therefore
+  // fail closed if a restricted OpenRouter route somehow reaches dispatch.
+  const connection = connections.length === 1 ? connections[0]! : null;
+  const requiredRegion = input.businessProfile.dataResidency[0]?.toLowerCase() ?? null;
+  const regionalEndpoint = connection?.regionalEndpoints.find(
+    (endpoint) => endpoint.region === requiredRegion,
+  );
   return {
     requireProviderAllowlist: restricted,
     requireProviderBlocklist: restricted,
     requireZdr: restricted,
     denyDataCollection: restricted,
     requireBoundedFallbacks: restricted,
-    requiredRegion: input.businessProfile.dataResidency[0]?.toLowerCase() ?? null,
+    requiredRegion,
+    approvedEndpointSlugs: sortedUnique(connection?.entitlements.approvedUnderlyingProviderSlugs ?? []),
+    providerConnectionId: connection?.providerConnectionId ?? null,
+    accountClass: connection?.accountClass ?? "unknown",
+    evidenceStatus: connection?.evidenceStatus ?? "unreviewed",
+    regionalProcessingEntitled: connection?.entitlements.regionalProcessing === true,
+    enabledRegions: sortedUnique(connection?.entitlements.enabledRegions ?? []),
+    requiredBaseUrl: regionalEndpoint?.baseUrl ?? null,
   };
 }
 

--- a/apps/web/lib/routing/provider-suitability/openrouter-policy.test.ts
+++ b/apps/web/lib/routing/provider-suitability/openrouter-policy.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  OpenRouterPolicyError,
+  compileOpenRouterExecutionPolicy,
+  parseOpenRouterRoutingEvidence,
+} from "./openrouter-policy";
+
+const restrictedObligations = {
+  requireProviderAllowlist: true,
+  requireProviderBlocklist: true,
+  requireZdr: true,
+  denyDataCollection: true,
+  requireBoundedFallbacks: true,
+  requiredRegion: null,
+  approvedEndpointSlugs: ["anthropic", "google-vertex/europe-west4"],
+  providerConnectionId: "conn-openrouter-enterprise",
+  accountClass: "enterprise" as const,
+  evidenceStatus: "contract-uploaded" as const,
+  regionalProcessingEntitled: true,
+  enabledRegions: ["eu"],
+  requiredBaseUrl: null,
+};
+
+describe("OpenRouter execution policy", () => {
+  it("compiles restricted work to explicit ZDR, no-collection, parameter-safe bounded routing", () => {
+    expect(compileOpenRouterExecutionPolicy(restrictedObligations)).toEqual({
+      posture: "restricted",
+      providerSettings: {
+        only: ["anthropic", "google-vertex/europe-west4"],
+        allow_fallbacks: false,
+        require_parameters: true,
+        data_collection: "deny",
+        zdr: true,
+      },
+      requestRouterMetadata: true,
+      requireUnderlyingProviderEvidence: true,
+      providerConnectionId: "conn-openrouter-enterprise",
+    });
+  });
+
+  it("fails restricted work closed without a bounded underlying-provider allowlist", () => {
+    expect(() => compileOpenRouterExecutionPolicy({
+      ...restrictedObligations,
+      approvedEndpointSlugs: [],
+    })).toThrowError(OpenRouterPolicyError);
+  });
+
+  it("uses the EU endpoint only for the connection with proven enterprise entitlement", () => {
+    expect(compileOpenRouterExecutionPolicy({
+      ...restrictedObligations,
+      requiredRegion: "eu",
+      requiredBaseUrl: "https://eu.openrouter.ai/api/v1",
+    }).requiredBaseUrl).toBe("https://eu.openrouter.ai/api/v1");
+  });
+
+  it.each(["regular", "business-team", "unknown"] as const)(
+    "does not let a %s account inherit enterprise EU routing",
+    (accountClass) => {
+      expect(() => compileOpenRouterExecutionPolicy({
+        ...restrictedObligations,
+        requiredRegion: "eu",
+        requiredBaseUrl: "https://eu.openrouter.ai/api/v1",
+        accountClass,
+      })).toThrow(/enterprise entitlement/i);
+    },
+  );
+
+  it("keeps public cost-first routing available without manufacturing privacy claims", () => {
+    expect(compileOpenRouterExecutionPolicy({
+      requireProviderAllowlist: false,
+      requireProviderBlocklist: false,
+      requireZdr: false,
+      denyDataCollection: false,
+      requireBoundedFallbacks: false,
+      requiredRegion: null,
+      approvedEndpointSlugs: [],
+      providerConnectionId: "conn-openrouter-regular",
+      accountClass: "regular",
+      evidenceStatus: "unreviewed",
+      regionalProcessingEntitled: false,
+      enabledRegions: [],
+      requiredBaseUrl: null,
+    }, {
+      only: ["anthropic", "mistral"],
+      ignore: ["deepinfra"],
+      order: ["mistral", "anthropic"],
+      sort: "price",
+      allow_fallbacks: true,
+    })).toEqual({
+      posture: "public",
+      providerSettings: {
+        only: ["anthropic", "mistral"],
+        ignore: ["deepinfra"],
+        order: ["mistral", "anthropic"],
+        sort: "price",
+        allow_fallbacks: true,
+      },
+      requestRouterMetadata: true,
+      requireUnderlyingProviderEvidence: false,
+      providerConnectionId: "conn-openrouter-regular",
+    });
+  });
+});
+
+describe("OpenRouter routing evidence", () => {
+  it("extracts only policy-safe provider attempts and ignores unknown metadata", () => {
+    expect(parseOpenRouterRoutingEvidence({
+      requested: "anthropic/claude-sonnet",
+      region: "fra",
+      secret_future_field: { prompt: "must not persist" },
+      endpoints: {
+        available: [
+          { provider: "Anthropic", model: "anthropic/claude-sonnet", selected: true, prompt: "drop" },
+        ],
+      },
+      attempts: [
+        { provider: "Google Vertex", model: "google/gemini", status: 503, output: "drop" },
+        { provider: "Anthropic", model: "anthropic/claude-sonnet", status: 200 },
+      ],
+    })).toEqual({
+      underlyingProviderEvidence: "returned",
+      selectedProvider: "Anthropic",
+      selectedModel: "anthropic/claude-sonnet",
+      region: "fra",
+      attempts: [
+        { provider: "Google Vertex", model: "google/gemini", status: 503 },
+        { provider: "Anthropic", model: "anthropic/claude-sonnet", status: 200 },
+      ],
+    });
+  });
+
+  it("records an explicit not-returned state when metadata is absent", () => {
+    expect(parseOpenRouterRoutingEvidence(undefined)).toEqual({
+      underlyingProviderEvidence: "not-returned",
+      attempts: [],
+    });
+  });
+});

--- a/apps/web/lib/routing/provider-suitability/openrouter-policy.ts
+++ b/apps/web/lib/routing/provider-suitability/openrouter-policy.ts
@@ -1,0 +1,161 @@
+import type { OpenRouterPolicyObligations } from "./types";
+
+export type OpenRouterProviderSettings = {
+  only?: string[];
+  ignore?: string[];
+  order?: string[];
+  allow_fallbacks?: boolean;
+  require_parameters?: boolean;
+  data_collection?: "allow" | "deny";
+  zdr?: boolean;
+  sort?: "price" | "throughput" | "latency";
+};
+
+export type OpenRouterExecutionPolicy = {
+  posture: "public" | "restricted";
+  providerSettings: OpenRouterProviderSettings;
+  requestRouterMetadata: true;
+  requireUnderlyingProviderEvidence: boolean;
+  providerConnectionId: string | null;
+  requiredBaseUrl?: string;
+};
+
+export type OpenRouterRoutingEvidence = {
+  underlyingProviderEvidence: "returned" | "not-returned";
+  selectedProvider?: string;
+  selectedModel?: string;
+  region?: string;
+  attempts: Array<{ provider: string; model?: string; status?: number }>;
+};
+
+export class OpenRouterPolicyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OpenRouterPolicyError";
+  }
+}
+
+function cleanSlugs(values: readonly string[] | undefined): string[] {
+  return [...new Set((values ?? [])
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => /^[a-z0-9][a-z0-9._/-]*$/.test(value)))];
+}
+
+function restricted(obligations: OpenRouterPolicyObligations): boolean {
+  return obligations.requireProviderAllowlist ||
+    obligations.requireProviderBlocklist ||
+    obligations.requireZdr ||
+    obligations.denyDataCollection ||
+    obligations.requireBoundedFallbacks;
+}
+
+function requiresEu(region: string | null): boolean {
+  return region === "eu" || region === "europe" || region?.startsWith("eu-") === true;
+}
+
+/** Compile account-scoped suitability obligations into the exact OpenRouter wire policy. */
+export function compileOpenRouterExecutionPolicy(
+  obligations: OpenRouterPolicyObligations,
+  configured: OpenRouterProviderSettings = {},
+): OpenRouterExecutionPolicy {
+  const isRestricted = restricted(obligations);
+  const only = cleanSlugs(obligations.approvedEndpointSlugs);
+
+  if (isRestricted && only.length === 0) {
+    throw new OpenRouterPolicyError(
+      "Restricted OpenRouter routing requires at least one approved underlying-provider endpoint slug.",
+    );
+  }
+
+  let requiredBaseUrl: string | undefined;
+  if (requiresEu(obligations.requiredRegion)) {
+    const entitled = obligations.accountClass === "enterprise" &&
+      (obligations.evidenceStatus === "operator-attested" || obligations.evidenceStatus === "contract-uploaded") &&
+      obligations.regionalProcessingEntitled === true &&
+      obligations.enabledRegions.some((region) => requiresEu(region.toLowerCase()));
+    if (!entitled) {
+      throw new OpenRouterPolicyError(
+        "EU OpenRouter routing requires enterprise entitlement proven for this specific provider connection.",
+      );
+    }
+    if (obligations.requiredBaseUrl !== "https://eu.openrouter.ai/api/v1") {
+      throw new OpenRouterPolicyError(
+        "EU OpenRouter routing requires the approved https://eu.openrouter.ai/api/v1 endpoint.",
+      );
+    }
+    requiredBaseUrl = obligations.requiredBaseUrl;
+  }
+
+  const providerSettings: OpenRouterProviderSettings = isRestricted
+    ? {
+        only,
+        allow_fallbacks: false,
+        require_parameters: true,
+        data_collection: "deny",
+        zdr: true,
+      }
+    : {
+        ...(cleanSlugs(configured.only).length > 0 ? { only: cleanSlugs(configured.only) } : {}),
+        ...(cleanSlugs(configured.ignore).length > 0 ? { ignore: cleanSlugs(configured.ignore) } : {}),
+        ...(cleanSlugs(configured.order).length > 0 ? { order: cleanSlugs(configured.order) } : {}),
+        ...(configured.allow_fallbacks !== undefined ? { allow_fallbacks: configured.allow_fallbacks } : {}),
+        ...(configured.require_parameters !== undefined ? { require_parameters: configured.require_parameters } : {}),
+        ...(configured.data_collection !== undefined ? { data_collection: configured.data_collection } : {}),
+        ...(configured.zdr !== undefined ? { zdr: configured.zdr } : {}),
+        ...(configured.sort !== undefined ? { sort: configured.sort } : {}),
+      };
+
+  return {
+    posture: isRestricted ? "restricted" : "public",
+    providerSettings,
+    requestRouterMetadata: true,
+    requireUnderlyingProviderEvidence: isRestricted,
+    providerConnectionId: obligations.providerConnectionId,
+    ...(requiredBaseUrl ? { requiredBaseUrl } : {}),
+  };
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function boundedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 && value.length <= 200 ? value : undefined;
+}
+
+/** Whitelist routing fields so prompts, outputs, plugin data, and future fields never enter receipts. */
+export function parseOpenRouterRoutingEvidence(metadata: unknown): OpenRouterRoutingEvidence {
+  const root = record(metadata);
+  if (!root) return { underlyingProviderEvidence: "not-returned", attempts: [] };
+
+  const endpoints = record(root.endpoints);
+  const available = Array.isArray(endpoints?.available) ? endpoints.available : [];
+  const selected = available.map(record).find((item) => item?.selected === true);
+  const selectedProvider = boundedString(selected?.provider);
+  const selectedModel = boundedString(selected?.model);
+  const attempts = (Array.isArray(root.attempts) ? root.attempts : [])
+    .map(record)
+    .filter((item): item is Record<string, unknown> => item !== null)
+    .slice(0, 20)
+    .flatMap((item) => {
+      const provider = boundedString(item.provider);
+      if (!provider) return [];
+      const model = boundedString(item.model);
+      const status = typeof item.status === "number" && Number.isInteger(item.status) ? item.status : undefined;
+      return [{ provider, ...(model ? { model } : {}), ...(status !== undefined ? { status } : {}) }];
+    });
+  const region = boundedString(root.region);
+
+  if (!selectedProvider && attempts.length === 0) {
+    return { underlyingProviderEvidence: "not-returned", attempts: [] };
+  }
+  return {
+    underlyingProviderEvidence: "returned",
+    ...(selectedProvider ? { selectedProvider } : {}),
+    ...(selectedModel ? { selectedModel } : {}),
+    ...(region ? { region } : {}),
+    attempts,
+  };
+}

--- a/apps/web/lib/routing/provider-suitability/provider-onboarding-data.ts
+++ b/apps/web/lib/routing/provider-suitability/provider-onboarding-data.ts
@@ -42,6 +42,17 @@ function catalogFacts(provider: {
           : [];
       })
     : [];
+  const routerPassThroughRaw = record(trust.routerPassThrough);
+  const routerPassThrough = category === "router" && Object.keys(routerPassThroughRaw).length > 0
+    ? {
+        exposesUnderlyingProvider: routerPassThroughRaw.exposesUnderlyingProvider === true,
+        supportsProviderAllowlist: routerPassThroughRaw.supportsProviderAllowlist === true,
+        supportsProviderBlocklist: routerPassThroughRaw.supportsProviderBlocklist === true,
+        supportsZdrFilter: routerPassThroughRaw.supportsZdrFilter === true,
+        supportsDataCollectionDeny: routerPassThroughRaw.supportsDataCollectionDeny === true,
+        supportsBoundedFallbacks: routerPassThroughRaw.supportsBoundedFallbacks === true,
+      }
+    : undefined;
   return {
     providerId: provider.providerId,
     catalogProviderId: typeof entry.catalogProviderId === "string" ? entry.catalogProviderId : provider.providerId,
@@ -53,6 +64,7 @@ function catalogFacts(provider: {
     supportsRegionalRouting: typeof trust.supportsRegionalRouting === "boolean" ? trust.supportsRegionalRouting : null,
     supportedRegions: strings(trust.supportedRegions),
     regionalEndpoints,
+    ...(routerPassThrough ? { routerPassThrough } : {}),
   };
 }
 

--- a/apps/web/lib/routing/provider-suitability/types.ts
+++ b/apps/web/lib/routing/provider-suitability/types.ts
@@ -108,6 +108,8 @@ export type ProviderEntitlements = {
   adminAuditControls?: boolean | null;
   enterpriseSupportOrSla?: boolean | null;
   enabledRegions?: string[];
+  /** Account-approved OpenRouter endpoint slugs; never inferred from provider marketing. */
+  approvedUnderlyingProviderSlugs?: string[];
 };
 
 export type ProviderConnectionPosture = {
@@ -174,6 +176,13 @@ export type OpenRouterPolicyObligations = {
   denyDataCollection: boolean;
   requireBoundedFallbacks: boolean;
   requiredRegion: string | null;
+  approvedEndpointSlugs: string[];
+  providerConnectionId: string | null;
+  accountClass: ProviderAccountClass;
+  evidenceStatus: ProviderConnectionPosture["evidenceStatus"];
+  regionalProcessingEntitled: boolean;
+  enabledRegions: string[];
+  requiredBaseUrl: string | null;
 };
 
 export type ProviderSuitabilityPolicy = {

--- a/apps/web/lib/routing/recipe-types.ts
+++ b/apps/web/lib/routing/recipe-types.ts
@@ -59,6 +59,10 @@ export interface RoutedExecutionPlan {
   maxTokens: number;
   temperature?: number;
   providerSettings: Record<string, unknown>;
+  /** Typed, fail-closed OpenRouter wire policy. Present only for OpenRouter plans. */
+  openRouterPolicy?: import("./provider-suitability/openrouter-policy").OpenRouterExecutionPolicy;
+  /** Retained across fallback construction so OpenRouter cannot become an unbounded fallback. */
+  openRouterObligations?: import("./provider-suitability/types").OpenRouterPolicyObligations;
   toolPolicy: {
     toolChoice?: "auto" | "required" | "none";
     allowParallelToolCalls?: boolean;

--- a/apps/web/lib/routing/request-contract.ts
+++ b/apps/web/lib/routing/request-contract.ts
@@ -54,6 +54,8 @@ export interface RequestContract {
   allowedProviders?: string[];
   deniedProviders?: string[];
   residencyPolicy?: "local_only" | "approved_cloud" | "any_enabled";
+  /** Account-scoped router obligations compiled by provider suitability. */
+  openRouterObligations?: import("./provider-suitability/types").OpenRouterPolicyObligations;
 
   // ── EP-INF-009c: Model class constraint ───────────────────────
   /** When set, only endpoints with this modelClass are eligible.
@@ -131,6 +133,7 @@ export async function inferContract(
     residencyPolicy?: string;
     allowedProviders?: string[];
     deniedProviders?: string[];
+    openRouterObligations?: import("./provider-suitability/types").OpenRouterPolicyObligations;
     requiresCodeExecution?: boolean;
     requiresWebSearch?: boolean;
     requiresComputerUse?: boolean;
@@ -295,6 +298,9 @@ export async function inferContract(
   }
   if (routeContext?.deniedProviders !== undefined) {
     contract.deniedProviders = normalizeProviderIds(routeContext.deniedProviders);
+  }
+  if (routeContext?.openRouterObligations !== undefined) {
+    contract.openRouterObligations = routeContext.openRouterObligations;
   }
   // residencyPolicy: caller override wins, else the task requirement's policy
   // (e.g. email triage hardened to "local_only" by an operator). Unset when

--- a/docs/architecture/platform-overview.md
+++ b/docs/architecture/platform-overview.md
@@ -355,6 +355,8 @@ When an AI provider fails (credential expiry, rate limit exhaustion, network out
 
 Key design: degradation is **feature-specific, not platform-wide**. A missing deep-thinker provider degrades Build Studio (code generation) but has no impact on portfolio management or backlog tracking. The platform surfaces contextual warnings on the affected feature, not a global error banner.
 
+Router providers are also policy boundaries. The suitability compiler carries account-scoped OpenRouter obligations through the request contract and every execution/fallback plan. The chat adapter is the single request-construction point for the `provider` controls and router-metadata header. Restricted routes require bounded endpoint slugs, ZDR, data-collection denial, disabled unbounded fallback, parameter support, and returned underlying-provider evidence. EU base-URL selection additionally requires current enterprise regional entitlement on that specific connection. This prevents a router fallback or a second account for the same provider ID from bypassing the original route policy.
+
 ### Neo4j Sync Integrity
 
 Because Neo4j is a projection, it can fall out of sync with PostgreSQL. The current sync is fire-and-forget — failures are logged but not retried. This is a known operational risk that the monitoring system should track:

--- a/docs/user-guide/ai-workforce/connecting-providers.md
+++ b/docs/user-guide/ai-workforce/connecting-providers.md
@@ -78,6 +78,14 @@ DPF checks those references before returning the specialist's answer. A material
 
 Local processing reduces external egress but is not automatically compliant. Security, retention, lawful basis, access control, capability, and sector obligations still apply.
 
+### OpenRouter and other router accounts
+
+A router connection is two trust decisions: the OpenRouter account and the underlying provider that actually handles the request. For public work, DPF may use normal price or latency routing. For private or regulated work, DPF requires an explicit underlying-provider allowlist, disables unbounded fallback, requests parameter-compatible endpoints, enables Zero Data Retention, denies provider data collection, and requires returned router metadata before releasing the answer.
+
+EU in-region OpenRouter processing is an enterprise feature. DPF uses `eu.openrouter.ai` only when the exact connected account has current enterprise and regional-processing evidence; a regular API key cannot inherit that entitlement. If the account, approved endpoint list, regional entitlement, policy pass-through, or returned underlying-provider evidence is missing, the restricted request stops safely instead of silently using a broader route.
+
+Routing receipts retain only the selected provider/model, region, and bounded attempt statuses. They do not copy prompts, answers, or arbitrary router/plugin metadata into the receipt.
+
 ## Finance Bridge
 
 When a provider is configured successfully, the platform now seeds a Finance bridge for it automatically:

--- a/packages/db/data/providers-registry.json
+++ b/packages/db/data/providers-registry.json
@@ -842,20 +842,36 @@
       "costExplained": "Charges vary by underlying model used. Pricing is transparent and shown per model. A small routing fee may apply.",
       "capabilitySummary": "Simplifies AI setup by consolidating many providers behind one key. Useful for testing models or switching between them without reconfiguring credentials.",
       "limitations": "Adds a routing layer between your data and the underlying provider. Not suitable where direct provider contracts are required.",
-      "dataResidency": "Depends on the underlying provider selected. OpenRouter routes requests but does not store content.",
+      "dataResidency": "Depends on the OpenRouter account settings, regional endpoint, and underlying provider selected. Do not assume a regular account provides EU in-region processing or disables optional logging.",
       "setupDifficulty": "easy",
-      "regulatoryNotes": "Review the terms of the specific underlying provider used. OpenRouter itself is a pass-through; compliance obligations rest with the provider."
+      "regulatoryNotes": "Review both the OpenRouter account and the specific underlying provider. Restricted work needs bounded provider routing, privacy controls, and account-scoped regional/contract evidence."
     },
     "catalogProviderId": "openrouter",
     "trustCatalog": {
       "category": "router",
       "jurisdictions": [],
       "externalEgress": "router-cloud",
-      "supportsZdr": null,
-      "supportsNoTraining": null,
-      "supportsRegionalRouting": null,
-      "supportedRegions": [],
-      "regionalEndpoints": []
+      "supportsZdr": true,
+      "supportsNoTraining": true,
+      "supportsRegionalRouting": true,
+      "supportedRegions": [
+        "eu"
+      ],
+      "regionalEndpoints": [
+        {
+          "region": "eu",
+          "baseUrl": "https://eu.openrouter.ai/api/v1",
+          "requiresEnterpriseEnablement": true
+        }
+      ],
+      "routerPassThrough": {
+        "exposesUnderlyingProvider": true,
+        "supportsProviderAllowlist": true,
+        "supportsProviderBlocklist": true,
+        "supportsZdrFilter": true,
+        "supportsDataCollectionDeny": true,
+        "supportsBoundedFallbacks": true
+      }
     }
   },
   {

--- a/packages/db/src/provider-trust-registry.test.ts
+++ b/packages/db/src/provider-trust-registry.test.ts
@@ -83,6 +83,22 @@ describe("provider trust registry", () => {
     expect(byId.get("openrouter")?.trustCatalog).toMatchObject({
       category: "router",
       externalEgress: "router-cloud",
+      supportsZdr: true,
+      supportsNoTraining: true,
+      supportsRegionalRouting: true,
+      regionalEndpoints: [{
+        region: "eu",
+        baseUrl: "https://eu.openrouter.ai/api/v1",
+        requiresEnterpriseEnablement: true,
+      }],
+      routerPassThrough: {
+        exposesUnderlyingProvider: true,
+        supportsProviderAllowlist: true,
+        supportsProviderBlocklist: true,
+        supportsZdrFilter: true,
+        supportsDataCollectionDeny: true,
+        supportsBoundedFallbacks: true,
+      },
     });
   });
 });

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -48,8 +48,8 @@ apps/web/lib/mcp/packs/sandbox-pack.ts	920
 apps/web/lib/navigation/portal-navigation-model.ts	937
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1383
-apps/web/lib/routing/chat-adapter.test.ts	820
-apps/web/lib/routing/fallback.test.ts	1038
+apps/web/lib/routing/chat-adapter.test.ts	902
+apps/web/lib/routing/fallback.test.ts	1077
 apps/web/lib/self-upgrade/quiescence.test.ts	865
 apps/web/lib/self-upgrade/quiescence.ts	1469
 apps/web/lib/skills/evidence-search.ts	803


### PR DESCRIPTION
## Summary

- compile connection-scoped OpenRouter suitability obligations into a bounded wire policy
- fail closed for restricted work when approved underlying endpoints, regional entitlement, or returned routing evidence are missing
- retain obligations through fallback construction so a router cannot become an unbounded fallback
- add router-specific setup guidance without burdening direct-provider setup
- update provider trust data and operator/architecture documentation

## Design grounding

Design source: `docs/superpowers/specs/2026-07-19-ai-provider-suitability-routing-design.md` (BI-AIPS-005).

Code anchors inspected: provider-suitability compiler/types, request contract and route context, execution-plan and fallback builders, chat adapter, provider trust registry, provider posture action, and provider detail form. The implementation extends the existing suitability policy and routed execution-plan substrate; it does not introduce a parallel routing path.

The user journey remains under Platform → AI Operations → Providers & Routing → OpenRouter. The added form section explains that a router creates two trust decisions, collects ZDR/regional declarations and approved underlying-provider endpoint slugs, and explicitly states that these declarations do not prove an enterprise contract or EU entitlement. Router-only controls are absent on direct-provider pages.

Research grounding: official OpenRouter provider-routing controls, metadata, sovereign-AI endpoint, and logging/ZDR documentation:
- https://openrouter.ai/docs/guides/routing/provider-selection
- https://openrouter.ai/docs/guides/features/router-metadata
- https://openrouter.ai/docs/guides/features/sovereign-ai
- https://openrouter.ai/docs/guides/privacy/provider-logging

## Verification

- governed local-CI pregate passed for `a5fbad1c5e2ef56b2a0f4d9212ce5117f387c52b`
- full web Vitest suite passed in merged-code sandbox
- Prisma migration deploy passed (no migration added)
- production web build and TypeScript checks passed
- focused provider-policy tests passed
- contributor preview UX verified at 1440×900 and 390×844; no horizontal overflow; router controls absent for Anthropic

## Documentation impact

Updated the provider-connection user guide and platform architecture overview because the change affects operator setup, routing enforcement, and safe fallback behavior.

## Backlog

BI-AIPS-005

Seed-Fit-Decision: global-default
UX-Fit-Decision: conditional-inline (principle_decide DI-D253B3D30C82, margin 3.039)
Local-CI-Override: Prior merged-code gate passed runtime commit a5fbad1c5; head-only follow-up a6645c23 refreshes generated docs index and intentional test-size ratchet while governed sandbox lease NPEL-5007320193 is occupied.