### PR TITLE
feat: govern provider trust evidence and route receipts

### DIFF
--- a/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx
@@ -20,6 +20,9 @@ import { AiProviderFinancePanel } from "@/components/finance/AiProviderFinancePa
 import { getAiProviderFinanceDetail } from "@/lib/finance/ai-provider-finance";
 import { buildProviderCostView } from "@/lib/inference/ai-provider-cost-view";
 import { ProviderAccountPostureForm } from "@/components/platform/ProviderAccountPostureForm";
+import { ProviderTrustEvidencePanel } from "@/components/platform/ProviderTrustEvidencePanel";
+import { resolveProviderTrustEvidence, type ProviderTrustClaimKey } from "@/lib/routing/provider-suitability/evidence";
+import { connectionPosture } from "@/lib/routing/provider-suitability/provider-onboarding-data";
 
 type Props = { params: Promise<{ providerId: string }> };
 
@@ -66,7 +69,13 @@ export default async function ProviderDetailPage({ params }: Props) {
     getModelClassCounts(providerId),
     getAiProviderFinanceDetail(providerId),
     getTokenSpendByProvider(currentMonth),
-    prisma.aiProviderConnection.findUnique({ where: { connectionId: `provider-default-${providerId}` } }),
+    prisma.aiProviderConnection.findUnique({
+      where: { connectionId: `provider-default-${providerId}` },
+      include: {
+        trustEvidence: true,
+        supplierContract: { select: { contractId: true, status: true, startDate: true, endDate: true } },
+      },
+    }),
   ]);
   if (!pw) notFound();
   const costView = buildProviderCostView({
@@ -74,6 +83,19 @@ export default async function ProviderDetailPage({ params }: Props) {
     financeProfile: financeDetail,
     internalUsage: tokenSpend.find((row) => row.providerId === providerId) ?? null,
   });
+  const requiredEvidenceClaims: ProviderTrustClaimKey[] = providerId === "openrouter"
+    ? ["no-training", "enabled-regions", "zero-retention", "regional-processing", "approved-underlying-providers", "dpa-on-file"]
+    : ["no-training", "enabled-regions", "dpa-on-file"];
+  const trustEvidenceResolution = providerConnection
+    ? resolveProviderTrustEvidence({
+      connection: connectionPosture(providerConnection),
+      evidenceConnectionId: providerConnection.id,
+      records: providerConnection.trustEvidence,
+      requiredClaims: requiredEvidenceClaims,
+      supplierContract: providerConnection.supplierContract ?? undefined,
+      now,
+    })
+    : null;
 
   const hasActiveProvider = allProviders.some((p) => p.provider.status === "active");
 
@@ -197,6 +219,13 @@ export default async function ProviderDetailPage({ params }: Props) {
                 : [],
             } : null}
           />
+          {trustEvidenceResolution && (
+            <ProviderTrustEvidencePanel
+              evidenceStatus={trustEvidenceResolution.posture.evidenceStatus}
+              lastReviewedAt={trustEvidenceResolution.posture.lastReviewedAt}
+              claims={trustEvidenceResolution.claims}
+            />
+          )}
           {/* BI-87D93A71 (Minimum): surface OAuth callback port mismatch
               BEFORE the user clicks Connect — eliminates the silent
               :3000 → :1455 origin divergence that the shared OpenAI

--- a/apps/web/components/platform/ProviderTrustEvidencePanel.test.tsx
+++ b/apps/web/components/platform/ProviderTrustEvidencePanel.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ProviderTrustEvidencePanel } from "./ProviderTrustEvidencePanel";
+
+afterEach(cleanup);
+
+describe("ProviderTrustEvidencePanel", () => {
+  it("shows evidence state, age, expiry, and the safest next action in plain language", () => {
+    render(<ProviderTrustEvidencePanel
+      evidenceStatus="expired"
+      lastReviewedAt="2026-06-20T09:00:00.000Z"
+      claims={[
+        {
+          claimKey: "no-training",
+          status: "expired",
+          evidenceIds: ["evidence-1"],
+          evidenceAgeDays: 30,
+          expiresAt: "2026-07-19T09:00:00.000Z",
+          nextAction: "Renew or replace the expired evidence.",
+        },
+      ]}
+    />);
+
+    expect(screen.getByRole("region", { name: "Provider trust evidence" })).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toContain("Action needed");
+    expect(screen.getByText("No training on company data")).toBeTruthy();
+    expect(screen.getByText(/30 days old/)).toBeTruthy();
+    expect(screen.getByText(/Renew or replace/)).toBeTruthy();
+  });
+
+  it("does not expose internal evidence ids and explains an empty state", () => {
+    const { rerender } = render(<ProviderTrustEvidencePanel
+      evidenceStatus="contract-uploaded"
+      lastReviewedAt="2026-07-20T09:00:00.000Z"
+      claims={[{
+        claimKey: "dpa-on-file",
+        status: "valid",
+        evidenceIds: ["sensitive-internal-evidence-id"],
+        evidenceAgeDays: 0,
+        expiresAt: "2027-07-20T09:00:00.000Z",
+        nextAction: "No action required.",
+      }]}
+    />);
+
+    expect(document.body.textContent).not.toContain("sensitive-internal-evidence-id");
+    expect(screen.getByRole("status").textContent).toContain("Current");
+
+    rerender(<ProviderTrustEvidencePanel evidenceStatus="unreviewed" lastReviewedAt={null} claims={[]} />);
+    expect(screen.getByText(/No account-specific trust evidence is linked yet/)).toBeTruthy();
+  });
+});

--- a/apps/web/components/platform/ProviderTrustEvidencePanel.tsx
+++ b/apps/web/components/platform/ProviderTrustEvidencePanel.tsx
@@ -1,0 +1,101 @@
+import type {
+  ProviderTrustClaimKey,
+  ResolvedProviderTrustClaim,
+} from "@/lib/routing/provider-suitability/evidence";
+import type { ProviderConnectionPosture } from "@/lib/routing/provider-suitability/types";
+
+const CLAIM_LABELS: Record<ProviderTrustClaimKey, string> = {
+  "no-training": "No training on company data",
+  "zero-retention": "Zero data retention",
+  "regional-processing": "Regional processing",
+  "enabled-regions": "Enabled processing regions",
+  "approved-underlying-providers": "Approved router providers",
+  "admin-audit-controls": "Administrative and audit controls",
+  "enterprise-support-sla": "Enterprise support or SLA",
+  "baa-on-file": "Business Associate Agreement (BAA)",
+  "dpa-on-file": "Data Processing Agreement (DPA)",
+  soc2: "SOC 2 assurance",
+  iso27001: "ISO 27001 assurance",
+  "fedramp-eligible": "FedRAMP eligibility",
+  "service-provider-oversight-reviewed-at": "Service-provider oversight review",
+  "student-data-terms-reviewed-at": "Student-data terms review",
+  "financial-customer-info-reviewed-at": "Financial customer-information review",
+};
+
+function statusLabel(status: ResolvedProviderTrustClaim["status"]): string {
+  if (status === "valid") return "Current";
+  if (status === "missing") return "Not provided";
+  if (status === "expired") return "Expired";
+  if (status === "rejected") return "Rejected";
+  if (status === "conflicting") return "Conflicting";
+  return "Replaced";
+}
+
+function dateLabel(value: string): string {
+  return new Intl.DateTimeFormat("en", { dateStyle: "medium", timeZone: "UTC" }).format(new Date(value));
+}
+
+export function ProviderTrustEvidencePanel({
+  evidenceStatus,
+  lastReviewedAt,
+  claims,
+}: {
+  evidenceStatus: ProviderConnectionPosture["evidenceStatus"];
+  lastReviewedAt: string | null;
+  claims: ResolvedProviderTrustClaim[];
+}) {
+  const actionNeeded = claims.length === 0 || claims.some((claim) => claim.status !== "valid");
+
+  return (
+    <section
+      aria-labelledby="provider-trust-evidence-heading"
+      className="mb-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 id="provider-trust-evidence-heading" className="m-0 text-sm font-semibold text-[var(--dpf-text)]">
+            Provider trust evidence
+          </h2>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+            Evidence applies only to this connected account. It never carries over to another key, subscription, or tenant.
+          </p>
+        </div>
+        <span
+          role="status"
+          className={`rounded-full px-2 py-1 text-xs font-semibold ${actionNeeded ? "bg-[var(--dpf-warning-soft)] text-[var(--dpf-warning)]" : "bg-[var(--dpf-success-soft)] text-[var(--dpf-success)]"}`}
+        >
+          {actionNeeded ? "Action needed" : "Current"}
+        </span>
+      </div>
+
+      {claims.length === 0 ? (
+        <div className="mt-3 rounded border border-dashed border-[var(--dpf-border)] p-3 text-xs text-[var(--dpf-muted)]">
+          No account-specific trust evidence is linked yet. General or public work remains governed separately; restricted work stays blocked until the required evidence is current.
+        </div>
+      ) : (
+        <ul className="mt-3 grid list-none gap-2 p-0">
+          {claims.map((claim) => (
+            <li key={claim.claimKey} className="rounded border border-[var(--dpf-border)] p-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="text-xs font-semibold text-[var(--dpf-text)]">{CLAIM_LABELS[claim.claimKey]}</span>
+                <span className="text-xs text-[var(--dpf-muted)]">{statusLabel(claim.status)}</span>
+              </div>
+              <p className="mb-0 mt-1 text-xs text-[var(--dpf-muted)]">
+                {claim.evidenceAgeDays == null ? "No dated evidence" : `${claim.evidenceAgeDays} days old`}
+                {claim.expiresAt ? ` · valid until ${dateLabel(claim.expiresAt)}` : ""}
+              </p>
+              {claim.status !== "valid" && (
+                <p className="mb-0 mt-1 text-xs font-medium text-[var(--dpf-text)]">Next: {claim.nextAction}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="mb-0 mt-3 text-xs text-[var(--dpf-muted)]">
+        Evidence state: {evidenceStatus.replaceAll("-", " ")}
+        {lastReviewedAt ? ` · last reviewed ${dateLabel(lastReviewedAt)}` : " · not yet reviewed"}
+      </p>
+    </section>
+  );
+}

--- a/apps/web/lib/actions/ai-providers.test.ts
+++ b/apps/web/lib/actions/ai-providers.test.ts
@@ -9,6 +9,8 @@ const {
   mockAuth,
   mockActivateProvider,
   mockSeedAiProviderFinanceBridge,
+  mockRecordProviderTrustEvidence,
+  mockSupersedeProviderTrustEvidenceClaim,
 } = vi.hoisted(() => ({
   mockPrisma: {
     modelProvider: {
@@ -40,6 +42,8 @@ const {
   mockAuth: vi.fn(),
   mockActivateProvider: vi.fn(),
   mockSeedAiProviderFinanceBridge: vi.fn(),
+  mockRecordProviderTrustEvidence: vi.fn().mockResolvedValue({ evidenceId: "evidence-1" }),
+  mockSupersedeProviderTrustEvidenceClaim: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@dpf/db", () => ({
@@ -62,6 +66,11 @@ vi.mock("@/lib/govern/activate-provider", () => ({
 
 vi.mock("@/lib/finance/ai-provider-finance", () => ({
   seedAiProviderFinanceBridge: mockSeedAiProviderFinanceBridge,
+}));
+
+vi.mock("@/lib/routing/provider-suitability/evidence", () => ({
+  recordProviderTrustEvidence: mockRecordProviderTrustEvidence,
+  supersedeProviderTrustEvidenceClaim: mockSupersedeProviderTrustEvidenceClaim,
 }));
 
 vi.mock("@/lib/ai-provider-internals", () => ({
@@ -94,6 +103,7 @@ describe("updateProviderConnectionPosture", () => {
 
   it("records an operator attestation without promoting it to contract proof", async () => {
     mockPrisma.aiProviderConnection.findUnique.mockResolvedValue({
+      id: "connection-db-1",
       entitlements: { adminAuditControls: true },
       evidenceStatus: "unreviewed",
     });
@@ -118,6 +128,43 @@ describe("updateProviderConnectionPosture", () => {
     expect(mockActivateProvider).toHaveBeenCalledWith("anthropic", {
       trigger: "test_auth",
       skipDiscovery: true,
+    });
+    expect(mockRecordProviderTrustEvidence).toHaveBeenCalledWith(expect.objectContaining({
+      providerConnectionDbId: "connection-db-1",
+      claimKey: "no-training",
+      assertedValue: true,
+      evidenceType: "provider-operator-attestation",
+    }));
+    expect(mockRecordProviderTrustEvidence).toHaveBeenCalledWith(expect.objectContaining({
+      providerConnectionDbId: "connection-db-1",
+      claimKey: "enabled-regions",
+      assertedValue: ["eu", "uk"],
+    }));
+  });
+
+  it("supersedes prior operator evidence when the declaration returns to unknown", async () => {
+    mockPrisma.aiProviderConnection.findUnique.mockResolvedValue({
+      id: "connection-db-1",
+      entitlements: {},
+      evidenceStatus: "operator-attested",
+    });
+    mockPrisma.aiProviderConnection.update.mockResolvedValue({});
+    mockPrisma.modelProvider.findUnique.mockResolvedValue({ status: "inactive" });
+
+    await updateProviderConnectionPosture({
+      providerId: "anthropic",
+      accountClass: "unknown",
+      noTraining: null,
+      enabledRegions: [],
+    });
+
+    expect(mockSupersedeProviderTrustEvidenceClaim).toHaveBeenCalledWith({
+      providerConnectionDbId: "connection-db-1",
+      claimKey: "no-training",
+    });
+    expect(mockSupersedeProviderTrustEvidenceClaim).toHaveBeenCalledWith({
+      providerConnectionDbId: "connection-db-1",
+      claimKey: "enabled-regions",
     });
   });
 

--- a/apps/web/lib/actions/provider-connection-posture.ts
+++ b/apps/web/lib/actions/provider-connection-posture.ts
@@ -4,6 +4,11 @@ import { prisma } from "@dpf/db";
 
 import { requireCapability } from "@/lib/actions/shared/guards";
 import { activateProvider } from "@/lib/govern/activate-provider";
+import {
+  recordProviderTrustEvidence,
+  supersedeProviderTrustEvidenceClaim,
+  type ProviderTrustClaimKey,
+} from "@/lib/routing/provider-suitability/evidence";
 
 const PROVIDER_ACCOUNT_CLASSES = ["regular", "business-team", "enterprise", "unknown"] as const;
 
@@ -28,34 +33,66 @@ export async function updateProviderConnectionPosture(input: {
   const connectionId = `provider-default-${input.providerId}`;
   const connection = await prisma.aiProviderConnection.findUnique({
     where: { connectionId },
-    select: { entitlements: true, evidenceStatus: true },
+    select: { id: true, entitlements: true, evidenceStatus: true },
   });
   if (!connection) return { error: "Provider connection not found" };
   const existingEntitlements = connection.entitlements && typeof connection.entitlements === "object" && !Array.isArray(connection.entitlements)
     ? connection.entitlements as Record<string, unknown>
     : {};
+  const reviewedAt = new Date();
+  const expiresAt = new Date(reviewedAt.getTime() + 90 * 86_400_000);
+  const enabledRegions = [...new Set(input.enabledRegions.map((region) => region.trim().toLowerCase()).filter(Boolean))].sort();
+  const approvedUnderlyingProviderSlugs = [...new Set(
+    (input.approvedUnderlyingProviderSlugs ?? [])
+      .map((slug) => slug.trim().toLowerCase())
+      .filter((slug) => /^[a-z0-9][a-z0-9._/-]*$/.test(slug)),
+  )].sort();
   await prisma.aiProviderConnection.update({
     where: { connectionId },
     data: {
       accountClass: input.accountClass,
       evidenceStatus: connection.evidenceStatus === "contract-uploaded" ? "contract-uploaded" : "operator-attested",
-      lastReviewedAt: new Date(),
+      lastReviewedAt: reviewedAt,
       entitlements: {
         ...existingEntitlements,
         noTraining: input.noTraining,
-        enabledRegions: [...new Set(input.enabledRegions.map((region) => region.trim().toLowerCase()).filter(Boolean))].sort(),
+        enabledRegions,
         ...(input.providerId === "openrouter" ? {
           zeroRetention: input.zeroRetention ?? null,
           regionalProcessing: input.regionalProcessing ?? null,
-          approvedUnderlyingProviderSlugs: [...new Set(
-            (input.approvedUnderlyingProviderSlugs ?? [])
-              .map((slug) => slug.trim().toLowerCase())
-              .filter((slug) => /^[a-z0-9][a-z0-9._/-]*$/.test(slug)),
-          )].sort(),
+          approvedUnderlyingProviderSlugs,
         } : {}),
       },
     },
   });
+  const recordDeclaration = (
+    claimKey: ProviderTrustClaimKey,
+    assertedValue: boolean | string[] | null | undefined,
+    title: string,
+  ) => assertedValue == null || (Array.isArray(assertedValue) && assertedValue.length === 0)
+    ? supersedeProviderTrustEvidenceClaim({ providerConnectionDbId: connection.id, claimKey })
+    : recordProviderTrustEvidence({
+      providerConnectionDbId: connection.id,
+      claimKey,
+      assertedValue,
+      evidenceType: "provider-operator-attestation",
+      title,
+      description: "Operator declaration captured during provider setup; contract evidence is still required where policy demands it.",
+      collectedAt: reviewedAt,
+      expiresAt,
+    });
+  const evidenceWrites = [
+    recordDeclaration("no-training", input.noTraining, "Connected-account no-training declaration"),
+    recordDeclaration("enabled-regions", enabledRegions, "Connected-account enabled-region declaration"),
+  ];
+  if (input.providerId === "openrouter") {
+    evidenceWrites.push(
+      recordDeclaration("zero-retention", input.zeroRetention, "Connected-account zero-retention declaration"),
+      recordDeclaration("regional-processing", input.regionalProcessing, "Connected-account regional-processing declaration"),
+      recordDeclaration("approved-underlying-providers", approvedUnderlyingProviderSlugs, "Connected-account router-provider declaration"),
+    );
+  }
+  await Promise.all(evidenceWrites);
   const provider = await prisma.modelProvider.findUnique({
     where: { providerId: input.providerId },
     select: { status: true },

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 527,
+  "pageCount": 528,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -4075,6 +4075,19 @@
         "when-the-guard-fails-on-your-pr",
         "protecting-a-new-entity",
         "known-limits-defense-in-depth-not-a-wall"
+      ]
+    },
+    "docs/operations/provider-trust-evidence.md": {
+      "publicHref": "/operations/provider-trust-evidence/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "provider-trust-evidence-and-route-receipts",
+        "authority-boundaries",
+        "review-and-remediation",
+        "receipt-privacy-check",
+        "existing-installs"
       ]
     },
     "docs/operations/runtime-glossary.md": {
@@ -8164,6 +8177,7 @@
         "default-agent-tiers",
         "how-routing-selects-a-model",
         "the-work-changes-which-providers-are-eligible",
+        "evidence-belongs-to-the-connected-account",
         "how-routing-adapts-over-time",
         "provider-specific-notes",
         "anthropic-oauth-subscription",

--- a/apps/web/lib/routing/loader.test.ts
+++ b/apps/web/lib/routing/loader.test.ts
@@ -87,6 +87,17 @@ describe("persistRouteDecision", () => {
       }),
     ]);
   });
+
+  it("persists the privacy-safe provider suitability receipt when supplied", async () => {
+    const decision = makeDecision();
+    decision.providerSuitabilityReceipt = makeSuitabilityReceipt();
+
+    await persistRouteDecision(decision, { actor: { kind: "agent", id: "build-specialist" } });
+
+    expect(mockPrisma.routeDecisionLog.create.mock.calls[0]?.[0].data.suitabilityReceipt).toEqual(
+      makeSuitabilityReceipt(),
+    );
+  });
 });
 
 describe("loadEndpointManifests", () => {
@@ -346,5 +357,23 @@ function makeDecisionWithHarness(): RouteDecision {
         providerFamily: "frontier",
       },
     },
+  };
+}
+
+function makeSuitabilityReceipt() {
+  return {
+    schemaVersion: "provider-suitability-route-receipt/v1" as const,
+    policyId: "policy-sha256",
+    compilerVersion: "provider-suitability/v1",
+    inputVersion: "work-context/v1",
+    connectionRef: "connection-sha256:1234567890abcdef12345678",
+    executionChannel: "direct-api" as const,
+    accountClass: "business-team" as const,
+    selectedProviderId: "anthropic",
+    selectedUnderlyingProviderId: null,
+    excludedProviderIds: ["personal-provider"],
+    obligations: null,
+    explanationCodes: ["provider-evidence-required"],
+    createdAt: "2026-07-20T09:00:00.000Z",
   };
 }

--- a/apps/web/lib/routing/loader.ts
+++ b/apps/web/lib/routing/loader.ts
@@ -427,6 +427,7 @@ export async function persistRouteDecision(
       policyRulesApplied: decision.policyRulesApplied,
       fallbackChain: decision.fallbackChain,
       shadowMode,
+      suitabilityReceipt: decision.providerSuitabilityReceipt ?? undefined,
     },
   });
   return record.id;

--- a/apps/web/lib/routing/provider-suitability/evidence.test.ts
+++ b/apps/web/lib/routing/provider-suitability/evidence.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createEvidence, updateEvidence } = vi.hoisted(() => ({
+  createEvidence: vi.fn().mockResolvedValue({ id: "evidence-db-new" }),
+  updateEvidence: vi.fn().mockResolvedValue({ count: 1 }),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    complianceEvidence: {
+      create: createEvidence,
+      updateMany: updateEvidence,
+    },
+  },
+}));
+
+import type { ProviderConnectionPosture, ProviderSuitabilityPolicy } from "./types";
+import {
+  buildProviderSuitabilityRouteReceipt,
+  recordProviderTrustEvidence,
+  resolveProviderTrustEvidence,
+  supersedeProviderTrustEvidenceClaim,
+  type ProviderTrustEvidenceRecord,
+} from "./evidence";
+
+const NOW = new Date("2026-07-20T09:00:00.000Z");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createEvidence.mockResolvedValue({ id: "evidence-db-new" });
+  updateEvidence.mockResolvedValue({ count: 1 });
+});
+
+function connection(overrides: Partial<ProviderConnectionPosture> = {}): ProviderConnectionPosture {
+  return {
+    providerConnectionId: "connection-enterprise",
+    providerId: "anthropic",
+    executionChannel: "direct-api",
+    accountClass: "enterprise",
+    commercialBasis: "enterprise-contract",
+    authMethod: "api-key",
+    contractEvidence: {
+      supplierContractId: "contract-enterprise",
+      baaOnFile: true,
+      dpaOnFile: true,
+    },
+    entitlements: {
+      noTraining: true,
+      zeroRetention: true,
+      enabledRegions: ["eu"],
+    },
+    evidenceStatus: "contract-uploaded",
+    lastReviewedAt: "2026-06-20T09:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function evidence(overrides: Partial<ProviderTrustEvidenceRecord> = {}): ProviderTrustEvidenceRecord {
+  return {
+    evidenceId: "evidence-no-training",
+    providerConnectionId: "connection-enterprise",
+    evidenceType: "provider-contract",
+    claimKey: "no-training",
+    assertedValue: true,
+    status: "active",
+    collectedAt: new Date("2026-06-20T09:00:00.000Z"),
+    validFrom: null,
+    expiresAt: new Date("2027-06-20T09:00:00.000Z"),
+    supersededById: null,
+    ...overrides,
+  };
+}
+
+describe("resolveProviderTrustEvidence", () => {
+  it("accepts current connection-bound evidence and reports its age", () => {
+    const result = resolveProviderTrustEvidence({
+      connection: connection(),
+      records: [evidence()],
+      now: NOW,
+    });
+
+    expect(result.claims).toEqual([
+      expect.objectContaining({ claimKey: "no-training", status: "valid", evidenceAgeDays: 30 }),
+    ]);
+    expect(result.posture.entitlements.noTraining).toBe(true);
+    expect(result.posture.evidenceStatus).toBe("contract-uploaded");
+  });
+
+  it.each([
+    ["missing", [], "Add evidence for this connected account."],
+    ["expired", [evidence({ expiresAt: new Date("2026-07-19T09:00:00.000Z") })], "Renew or replace the expired evidence."],
+    ["rejected", [evidence({ status: "rejected" })], "Resolve the rejected evidence before restricted routing."],
+    ["superseded", [evidence({ status: "superseded", supersededById: "new-evidence" })], "Link the current replacement evidence."],
+  ] as const)("reports %s evidence without preserving the asserted entitlement", (status, records, nextAction) => {
+    const result = resolveProviderTrustEvidence({
+      connection: connection(),
+      records: [...records],
+      now: NOW,
+      requiredClaims: ["no-training"],
+    });
+
+    expect(result.claims[0]).toEqual(expect.objectContaining({ status, nextAction }));
+    expect(result.posture.entitlements.noTraining).toBeUndefined();
+  });
+
+  it("treats simultaneously current contradictory assertions as conflicting", () => {
+    const result = resolveProviderTrustEvidence({
+      connection: connection(),
+      records: [evidence(), evidence({ evidenceId: "evidence-training-allowed", assertedValue: false })],
+      now: NOW,
+    });
+
+    expect(result.claims[0]).toEqual(expect.objectContaining({ status: "conflicting" }));
+    expect(result.posture.entitlements.noTraining).toBeUndefined();
+    expect(result.posture.evidenceStatus).toBe("rejected");
+  });
+
+  it("never transfers evidence from another account or tenant for the same provider", () => {
+    const regular = resolveProviderTrustEvidence({
+      connection: connection({
+        providerConnectionId: "connection-regular",
+        accountClass: "regular",
+        commercialBasis: "usage-metered",
+        contractEvidence: {},
+        entitlements: {},
+        evidenceStatus: "unreviewed",
+      }),
+      records: [evidence()],
+      now: NOW,
+      requiredClaims: ["no-training"],
+    });
+
+    expect(regular.claims[0]?.status).toBe("missing");
+    expect(regular.posture.entitlements.noTraining).toBeUndefined();
+    expect(regular.posture.contractEvidence.supplierContractId).toBeUndefined();
+  });
+
+  it("drops a future-dated assertion until its validity window begins", () => {
+    const result = resolveProviderTrustEvidence({
+      connection: connection(),
+      records: [evidence({ validFrom: new Date("2026-08-01T00:00:00.000Z") })],
+      now: NOW,
+    });
+
+    expect(result.claims[0]?.status).toBe("missing");
+    expect(result.posture.entitlements.noTraining).toBeUndefined();
+  });
+});
+
+describe("buildProviderSuitabilityRouteReceipt", () => {
+  const policy: ProviderSuitabilityPolicy = {
+    policyId: "policy-sha256",
+    organizationId: "organization-sensitive-id",
+    source: "admin",
+    effect: "review",
+    allowedProviders: ["anthropic"],
+    deniedProviders: ["personal-provider"],
+    allowedProviderConnectionIds: ["connection-enterprise"],
+    deniedProviderConnectionIds: ["connection-personal"],
+    residencyPolicy: "approved_cloud",
+    openRouterObligations: {
+      requireProviderAllowlist: true,
+      requireProviderBlocklist: false,
+      requireZdr: true,
+      denyDataCollection: true,
+      requireBoundedFallbacks: true,
+      requiredRegion: "eu",
+      approvedEndpointSlugs: ["anthropic/eu"],
+      providerConnectionId: "connection-enterprise",
+      accountClass: "enterprise",
+      evidenceStatus: "contract-uploaded",
+      regionalProcessingEntitled: true,
+      enabledRegions: ["eu"],
+      requiredBaseUrl: "https://eu.openrouter.ai/api/v1",
+    },
+    explanations: [
+      { code: "provider-evidence-required", message: "Sensitive explanation", providerConnectionId: "connection-personal" },
+    ],
+    compilerVersion: "provider-suitability/v1",
+  };
+
+  it("captures policy versions, channel posture, provider identity, exclusions, obligations, and codes", () => {
+    const receipt = buildProviderSuitabilityRouteReceipt({
+      policy,
+      inputVersion: "work-context/v1",
+      connection: connection(),
+      selectedProviderId: "openrouter",
+      selectedUnderlyingProviderId: "anthropic",
+      excludedProviderIds: ["personal-provider"],
+      createdAt: NOW,
+    });
+
+    expect(receipt).toEqual(expect.objectContaining({
+      schemaVersion: "provider-suitability-route-receipt/v1",
+      policyId: "policy-sha256",
+      compilerVersion: "provider-suitability/v1",
+      inputVersion: "work-context/v1",
+      selectedProviderId: "openrouter",
+      selectedUnderlyingProviderId: "anthropic",
+      executionChannel: "direct-api",
+      accountClass: "enterprise",
+      excludedProviderIds: ["personal-provider"],
+      explanationCodes: ["provider-evidence-required"],
+    }));
+    expect(receipt.connectionRef).toMatch(/^connection-sha256:/);
+  });
+
+  it("never serializes raw account identifiers, credentials, explanation text, or payload content", () => {
+    const receipt = buildProviderSuitabilityRouteReceipt({
+      policy,
+      inputVersion: "work-context/v1",
+      connection: connection(),
+      selectedProviderId: "anthropic",
+      excludedProviderIds: [],
+      createdAt: NOW,
+    });
+    const serialized = JSON.stringify(receipt);
+
+    expect(serialized).not.toContain("organization-sensitive-id");
+    expect(serialized).not.toContain("connection-enterprise");
+    expect(serialized).not.toContain("connection-personal");
+    expect(serialized).not.toContain("Sensitive explanation");
+    expect(serialized).not.toMatch(/api[-_]?key|credential|messages|prompt|payload/i);
+  });
+});
+
+describe("provider trust evidence revisions", () => {
+  it("appends a connection-scoped revision and supersedes older active assertions", async () => {
+    const result = await recordProviderTrustEvidence({
+      providerConnectionDbId: "connection-db-1",
+      claimKey: "dpa-on-file",
+      assertedValue: true,
+      evidenceType: "provider-contract",
+      title: "Reviewed DPA",
+      description: "Reviewed for this tenant.",
+      collectedAt: NOW,
+      expiresAt: new Date("2027-07-20T09:00:00.000Z"),
+    });
+
+    expect(result.evidenceId).toMatch(/^provider-trust:connection-db-1:dpa-on-file:/);
+    expect(createEvidence).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        providerConnectionId: "connection-db-1",
+        claimKey: "dpa-on-file",
+        assertedValue: true,
+        status: "active",
+      }),
+    }));
+    expect(updateEvidence).toHaveBeenCalledWith({
+      where: {
+        providerConnectionId: "connection-db-1",
+        claimKey: "dpa-on-file",
+        status: "active",
+        id: { not: "evidence-db-new" },
+      },
+      data: { status: "superseded", supersededById: "evidence-db-new" },
+    });
+  });
+
+  it("withdraws an operator claim without deleting its audit history", async () => {
+    await supersedeProviderTrustEvidenceClaim({
+      providerConnectionDbId: "connection-db-1",
+      claimKey: "no-training",
+    });
+
+    expect(updateEvidence).toHaveBeenCalledWith({
+      where: {
+        providerConnectionId: "connection-db-1",
+        claimKey: "no-training",
+        status: "active",
+      },
+      data: { status: "superseded" },
+    });
+  });
+});

--- a/apps/web/lib/routing/provider-suitability/evidence.ts
+++ b/apps/web/lib/routing/provider-suitability/evidence.ts
@@ -1,0 +1,381 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { Prisma } from "@dpf/db";
+
+import type {
+  ProviderConnectionPosture,
+  ProviderContractEvidence,
+  ProviderEntitlements,
+  ProviderSuitabilityPolicy,
+} from "./types";
+
+export const PROVIDER_TRUST_CLAIM_KEYS = [
+  "no-training",
+  "zero-retention",
+  "regional-processing",
+  "enabled-regions",
+  "approved-underlying-providers",
+  "admin-audit-controls",
+  "enterprise-support-sla",
+  "baa-on-file",
+  "dpa-on-file",
+  "soc2",
+  "iso27001",
+  "fedramp-eligible",
+  "service-provider-oversight-reviewed-at",
+  "student-data-terms-reviewed-at",
+  "financial-customer-info-reviewed-at",
+] as const;
+
+export type ProviderTrustClaimKey = (typeof PROVIDER_TRUST_CLAIM_KEYS)[number];
+export type ProviderTrustEvidenceStatus =
+  | "valid"
+  | "missing"
+  | "expired"
+  | "rejected"
+  | "conflicting"
+  | "superseded";
+
+export type ProviderTrustEvidenceRecord = {
+  evidenceId: string;
+  providerConnectionId: string | null;
+  evidenceType: string;
+  claimKey: string | null;
+  assertedValue: unknown;
+  status: string;
+  collectedAt: Date;
+  validFrom: Date | null;
+  expiresAt: Date | null;
+  supersededById: string | null;
+};
+
+export type ResolvedProviderTrustClaim = {
+  claimKey: ProviderTrustClaimKey;
+  status: ProviderTrustEvidenceStatus;
+  evidenceIds: string[];
+  evidenceAgeDays: number | null;
+  expiresAt: string | null;
+  nextAction: string;
+};
+
+export type ProviderTrustEvidenceResolution = {
+  posture: ProviderConnectionPosture;
+  claims: ResolvedProviderTrustClaim[];
+  hasActionRequired: boolean;
+};
+
+type CurrentSupplierContract = {
+  contractId: string;
+  status: string;
+  startDate: Date | null;
+  endDate: Date | null;
+};
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort();
+}
+
+function stableValue(value: unknown): string {
+  if (Array.isArray(value)) return JSON.stringify(sortedUnique(value.filter((item): item is string => typeof item === "string")));
+  return JSON.stringify(value);
+}
+
+function isClaimKey(value: string | null): value is ProviderTrustClaimKey {
+  return PROVIDER_TRUST_CLAIM_KEYS.includes(value as ProviderTrustClaimKey);
+}
+
+function isCurrent(record: ProviderTrustEvidenceRecord, now: Date): boolean {
+  return record.status === "active"
+    && !record.supersededById
+    && (!record.validFrom || record.validFrom.getTime() <= now.getTime())
+    && (!record.expiresAt || record.expiresAt.getTime() > now.getTime());
+}
+
+function contractIsCurrent(contract: CurrentSupplierContract | undefined, now: Date): boolean {
+  return Boolean(
+    contract
+      && contract.status === "active"
+      && (!contract.startDate || contract.startDate.getTime() <= now.getTime())
+      && (!contract.endDate || contract.endDate.getTime() > now.getTime()),
+  );
+}
+
+function ageDays(collectedAt: Date, now: Date): number {
+  return Math.max(0, Math.floor((now.getTime() - collectedAt.getTime()) / 86_400_000));
+}
+
+function nextAction(status: ProviderTrustEvidenceStatus): string {
+  switch (status) {
+    case "valid": return "No action required.";
+    case "expired": return "Renew or replace the expired evidence.";
+    case "rejected": return "Resolve the rejected evidence before restricted routing.";
+    case "conflicting": return "Resolve the conflicting assertions before restricted routing.";
+    case "superseded": return "Link the current replacement evidence.";
+    case "missing": return "Add evidence for this connected account.";
+  }
+}
+
+function classifyClaim(
+  claimKey: ProviderTrustClaimKey,
+  records: ProviderTrustEvidenceRecord[],
+  now: Date,
+): { summary: ResolvedProviderTrustClaim; accepted: ProviderTrustEvidenceRecord | null } {
+  const current = records.filter((record) => isCurrent(record, now));
+  const distinctValues = new Set(current.map((record) => stableValue(record.assertedValue)));
+  let status: ProviderTrustEvidenceStatus;
+  let accepted: ProviderTrustEvidenceRecord | null = null;
+
+  if (distinctValues.size > 1) status = "conflicting";
+  else if (current.length > 0) {
+    status = "valid";
+    accepted = [...current].sort((a, b) => b.collectedAt.getTime() - a.collectedAt.getTime())[0] ?? null;
+  } else if (records.some((record) => record.status === "rejected")) status = "rejected";
+  else if (records.some((record) => record.status === "active" && record.expiresAt && record.expiresAt.getTime() <= now.getTime())) status = "expired";
+  else if (records.some((record) => record.status === "superseded" || record.supersededById)) status = "superseded";
+  else status = "missing";
+
+  const newest = [...records].sort((a, b) => b.collectedAt.getTime() - a.collectedAt.getTime())[0];
+  return {
+    accepted,
+    summary: {
+      claimKey,
+      status,
+      evidenceIds: records.map((record) => record.evidenceId).sort(),
+      evidenceAgeDays: newest ? ageDays(newest.collectedAt, now) : null,
+      expiresAt: newest?.expiresAt?.toISOString() ?? null,
+      nextAction: nextAction(status),
+    },
+  };
+}
+
+function applyClaim(
+  claimKey: ProviderTrustClaimKey,
+  value: unknown,
+  contractEvidence: ProviderContractEvidence,
+  entitlements: ProviderEntitlements,
+): void {
+  const booleanValue = typeof value === "boolean" ? value : undefined;
+  const stringValue = typeof value === "string" ? value : undefined;
+  switch (claimKey) {
+    case "no-training": entitlements.noTraining = booleanValue; break;
+    case "zero-retention": entitlements.zeroRetention = booleanValue; break;
+    case "regional-processing": entitlements.regionalProcessing = booleanValue; break;
+    case "enabled-regions":
+      entitlements.enabledRegions = Array.isArray(value)
+        ? sortedUnique(value.filter((item): item is string => typeof item === "string").map((region) => region.toLowerCase()))
+        : [];
+      break;
+    case "approved-underlying-providers":
+      entitlements.approvedUnderlyingProviderSlugs = Array.isArray(value)
+        ? sortedUnique(value.filter((item): item is string => typeof item === "string").map((slug) => slug.toLowerCase()))
+        : [];
+      break;
+    case "admin-audit-controls": entitlements.adminAuditControls = booleanValue; break;
+    case "enterprise-support-sla": entitlements.enterpriseSupportOrSla = booleanValue; break;
+    case "baa-on-file": contractEvidence.baaOnFile = booleanValue; break;
+    case "dpa-on-file": contractEvidence.dpaOnFile = booleanValue; break;
+    case "soc2": contractEvidence.soc2 = booleanValue; break;
+    case "iso27001": contractEvidence.iso27001 = booleanValue; break;
+    case "fedramp-eligible": contractEvidence.fedrampEligible = booleanValue; break;
+    case "service-provider-oversight-reviewed-at": contractEvidence.serviceProviderOversightReviewedAt = stringValue; break;
+    case "student-data-terms-reviewed-at": contractEvidence.studentDataTermsReviewedAt = stringValue; break;
+    case "financial-customer-info-reviewed-at": contractEvidence.financialCustomerInfoReviewedAt = stringValue; break;
+  }
+}
+
+/**
+ * Resolve evidence only inside one configured connection boundary. Values on
+ * the connection row are treated as declarations until a current evidence row
+ * for that exact connection and claim validates them.
+ */
+export function resolveProviderTrustEvidence(input: {
+  connection: ProviderConnectionPosture;
+  /** DB identity used by evidence rows; defaults to the semantic connection id for pure callers. */
+  evidenceConnectionId?: string;
+  records: ProviderTrustEvidenceRecord[];
+  now?: Date;
+  requiredClaims?: ProviderTrustClaimKey[];
+  supplierContract?: CurrentSupplierContract;
+}): ProviderTrustEvidenceResolution {
+  const now = input.now ?? new Date();
+  const scoped = input.records.filter(
+    (record) => record.providerConnectionId === (input.evidenceConnectionId ?? input.connection.providerConnectionId) && isClaimKey(record.claimKey),
+  );
+  const claimKeys: ProviderTrustClaimKey[] = input.requiredClaims
+    ?? [...new Set(scoped.map((record) => record.claimKey as ProviderTrustClaimKey))].sort();
+  const contractEvidence: ProviderContractEvidence = {};
+  const entitlements: ProviderEntitlements = {};
+  const resolved = claimKeys.map((claimKey) => classifyClaim(
+    claimKey,
+    scoped.filter((record) => record.claimKey === claimKey),
+    now,
+  ));
+
+  for (const result of resolved) {
+    if (result.accepted) applyClaim(result.summary.claimKey, result.accepted.assertedValue, contractEvidence, entitlements);
+  }
+
+  const validContractEvidence = resolved.some(
+    (result) => result.accepted?.evidenceType === "provider-contract",
+  );
+  if (validContractEvidence && contractIsCurrent(input.supplierContract, now)) {
+    contractEvidence.supplierContractId = input.supplierContract?.contractId;
+  }
+
+  const statuses = resolved.map((result) => result.summary.status);
+  const evidenceStatus: ProviderConnectionPosture["evidenceStatus"] =
+    statuses.some((status) => status === "conflicting" || status === "rejected")
+      ? "rejected"
+      : statuses.some((status) => status === "valid")
+        ? validContractEvidence ? "contract-uploaded" : "operator-attested"
+        : statuses.some((status) => status === "expired")
+          ? "expired"
+          : "unreviewed";
+  const acceptedDates = resolved
+    .map((result) => result.accepted?.collectedAt)
+    .filter((date): date is Date => Boolean(date));
+
+  return {
+    posture: {
+      ...input.connection,
+      contractEvidence,
+      entitlements,
+      evidenceStatus,
+      lastReviewedAt: acceptedDates.length > 0
+        ? new Date(Math.max(...acceptedDates.map((date) => date.getTime()))).toISOString()
+        : null,
+    },
+    claims: resolved.map((result) => result.summary),
+    hasActionRequired: statuses.some((status) => status !== "valid"),
+  };
+}
+
+export type ProviderSuitabilityRouteReceipt = {
+  schemaVersion: "provider-suitability-route-receipt/v1";
+  policyId: string;
+  compilerVersion: string;
+  inputVersion: string;
+  connectionRef: string;
+  executionChannel: ProviderConnectionPosture["executionChannel"];
+  accountClass: ProviderConnectionPosture["accountClass"];
+  selectedProviderId: string;
+  selectedUnderlyingProviderId: string | null;
+  excludedProviderIds: string[];
+  obligations: null | {
+    requireProviderAllowlist: boolean;
+    requireProviderBlocklist: boolean;
+    requireZdr: boolean;
+    denyDataCollection: boolean;
+    requireBoundedFallbacks: boolean;
+    requiredRegion: string | null;
+    approvedEndpointSlugs: string[];
+    regionalProcessingEntitled: boolean;
+    enabledRegions: string[];
+    requiredBaseUrl: string | null;
+  };
+  explanationCodes: string[];
+  createdAt: string;
+};
+
+function connectionRef(connectionId: string): string {
+  return `connection-sha256:${createHash("sha256").update(connectionId).digest("hex").slice(0, 24)}`;
+}
+
+/** Build a deliberately allowlisted receipt; arbitrary request or evidence data cannot enter it. */
+export function buildProviderSuitabilityRouteReceipt(input: {
+  policy: ProviderSuitabilityPolicy;
+  inputVersion: string;
+  connection: ProviderConnectionPosture;
+  selectedProviderId: string;
+  selectedUnderlyingProviderId?: string | null;
+  excludedProviderIds: string[];
+  createdAt?: Date;
+}): ProviderSuitabilityRouteReceipt {
+  return {
+    schemaVersion: "provider-suitability-route-receipt/v1",
+    policyId: input.policy.policyId,
+    compilerVersion: input.policy.compilerVersion,
+    inputVersion: input.inputVersion,
+    connectionRef: connectionRef(input.connection.providerConnectionId),
+    executionChannel: input.connection.executionChannel,
+    accountClass: input.connection.accountClass,
+    selectedProviderId: input.selectedProviderId,
+    selectedUnderlyingProviderId: input.selectedUnderlyingProviderId ?? null,
+    excludedProviderIds: sortedUnique([...input.excludedProviderIds, ...input.policy.deniedProviders]),
+    obligations: input.policy.openRouterObligations ? {
+      requireProviderAllowlist: input.policy.openRouterObligations.requireProviderAllowlist,
+      requireProviderBlocklist: input.policy.openRouterObligations.requireProviderBlocklist,
+      requireZdr: input.policy.openRouterObligations.requireZdr,
+      denyDataCollection: input.policy.openRouterObligations.denyDataCollection,
+      requireBoundedFallbacks: input.policy.openRouterObligations.requireBoundedFallbacks,
+      requiredRegion: input.policy.openRouterObligations.requiredRegion,
+      approvedEndpointSlugs: [...input.policy.openRouterObligations.approvedEndpointSlugs],
+      regionalProcessingEntitled: input.policy.openRouterObligations.regionalProcessingEntitled,
+      enabledRegions: [...input.policy.openRouterObligations.enabledRegions],
+      requiredBaseUrl: input.policy.openRouterObligations.requiredBaseUrl,
+    } : null,
+    explanationCodes: sortedUnique(input.policy.explanations.map((explanation) => explanation.code)),
+    createdAt: (input.createdAt ?? new Date()).toISOString(),
+  };
+}
+
+/**
+ * Append a new account-scoped evidence revision and supersede older active
+ * revisions for the same claim. A partial failure leaves contradictory active
+ * revisions, which the resolver deliberately classifies as conflicting.
+ */
+export async function recordProviderTrustEvidence(input: {
+  providerConnectionDbId: string;
+  claimKey: ProviderTrustClaimKey;
+  assertedValue: Prisma.InputJsonValue;
+  evidenceType: "provider-operator-attestation" | "provider-contract" | "provider-assurance";
+  title: string;
+  description: string;
+  collectedAt?: Date;
+  validFrom?: Date | null;
+  expiresAt: Date;
+}): Promise<{ evidenceId: string }> {
+  const { prisma } = await import("@dpf/db");
+  const collectedAt = input.collectedAt ?? new Date();
+  const evidenceId = `provider-trust:${input.providerConnectionDbId}:${input.claimKey}:${randomUUID()}`;
+  const created = await prisma.complianceEvidence.create({
+    data: {
+      evidenceId,
+      title: input.title,
+      evidenceType: input.evidenceType,
+      description: input.description,
+      providerConnectionId: input.providerConnectionDbId,
+      claimKey: input.claimKey,
+      assertedValue: input.assertedValue,
+      status: "active",
+      collectedAt,
+      validFrom: input.validFrom ?? collectedAt,
+      expiresAt: input.expiresAt,
+    },
+    select: { id: true },
+  });
+  await prisma.complianceEvidence.updateMany({
+    where: {
+      providerConnectionId: input.providerConnectionDbId,
+      claimKey: input.claimKey,
+      status: "active",
+      id: { not: created.id },
+    },
+    data: { status: "superseded", supersededById: created.id },
+  });
+  return { evidenceId };
+}
+
+export async function supersedeProviderTrustEvidenceClaim(input: {
+  providerConnectionDbId: string;
+  claimKey: ProviderTrustClaimKey;
+}): Promise<void> {
+  const { prisma } = await import("@dpf/db");
+  await prisma.complianceEvidence.updateMany({
+    where: {
+      providerConnectionId: input.providerConnectionDbId,
+      claimKey: input.claimKey,
+      status: "active",
+    },
+    data: { status: "superseded" },
+  });
+}

--- a/apps/web/lib/routing/provider-suitability/provider-onboarding-data.ts
+++ b/apps/web/lib/routing/provider-suitability/provider-onboarding-data.ts
@@ -8,6 +8,7 @@ import type {
 } from "./types";
 import { isEeaState } from "@dpf/db/eu-jurisdictions";
 import { parseOrgAddress } from "@/lib/shared/org-address";
+import { resolveProviderTrustEvidence } from "./evidence";
 
 function record(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -68,7 +69,7 @@ function catalogFacts(provider: {
   };
 }
 
-function connectionPosture(connection: {
+export function connectionPosture(connection: {
   connectionId: string;
   providerId: string;
   executionChannel: string;
@@ -101,7 +102,11 @@ export async function loadProviderOnboardingRecommendation() {
     prisma.storefrontConfig.findFirst({ select: { archetypeId: true, archetype: { select: { category: true } } } }),
     prisma.aiProviderConnection.findMany({
       where: organization ? { OR: [{ organizationId: organization.id }, { organizationId: null }] } : undefined,
-      include: { provider: { select: { providerId: true, name: true, category: true, endpointType: true, catalogEntry: true, status: true } } },
+      include: {
+        provider: { select: { providerId: true, name: true, category: true, endpointType: true, catalogEntry: true, status: true } },
+        trustEvidence: true,
+        supplierContract: { select: { contractId: true, status: true, startDate: true, endDate: true } },
+      },
       orderBy: [{ status: "asc" }, { label: "asc" }],
     }),
   ]);
@@ -126,16 +131,24 @@ export async function loadProviderOnboardingRecommendation() {
   return buildProviderOnboardingRecommendation({
     businessProfile: profile,
     handlesCardPayments: businessContext?.handlesCardPayments ?? false,
-    connections: connections.map((connection) => ({
-      label: connection.label || connection.provider.name,
-      // ModelProvider owns runtime activation. AiProviderConnection may retain its
-      // setup-state value after activation, so do not let that stale projection
-      // downgrade (or accidentally upgrade) the onboarding recommendation.
-      status: resolveRuntimeConnectionStatus(connection.provider.status, connection.status),
-      facts: resolveProviderTrustFacts({
-        catalog: catalogFacts(connection.provider),
+    connections: connections.map((connection) => {
+      const evidence = resolveProviderTrustEvidence({
         connection: connectionPosture(connection),
-      }),
-    })),
+        evidenceConnectionId: connection.id,
+        records: connection.trustEvidence,
+        supplierContract: connection.supplierContract ?? undefined,
+      });
+      return {
+        label: connection.label || connection.provider.name,
+        // ModelProvider owns runtime activation. AiProviderConnection may retain its
+        // setup-state value after activation, so do not let that stale projection
+        // downgrade (or accidentally upgrade) the onboarding recommendation.
+        status: resolveRuntimeConnectionStatus(connection.provider.status, connection.status),
+        facts: resolveProviderTrustFacts({
+          catalog: catalogFacts(connection.provider),
+          connection: evidence.posture,
+        }),
+      };
+    }),
   });
 }

--- a/apps/web/lib/routing/task-dispatcher.test.ts
+++ b/apps/web/lib/routing/task-dispatcher.test.ts
@@ -116,6 +116,36 @@ describe("callWithFallbackChain", () => {
     expect(mockObserve).not.toHaveBeenCalled();
   });
 
+  it("persists a supplied provider suitability receipt without request content", async () => {
+    mockCallProvider.mockResolvedValueOnce({
+      content: "success",
+      inputTokens: 10,
+      outputTokens: 20,
+      inferenceMs: 500,
+    });
+    const suitabilityReceipt = {
+      schemaVersion: "provider-suitability-route-receipt/v1" as const,
+      policyId: "policy-sha256",
+      compilerVersion: "provider-suitability/v1",
+      inputVersion: "work-context/v1",
+      connectionRef: "connection-sha256:1234567890abcdef12345678",
+      executionChannel: "direct-api" as const,
+      accountClass: "enterprise" as const,
+      selectedProviderId: "provider-1",
+      selectedUnderlyingProviderId: null,
+      excludedProviderIds: ["provider-unsafe"],
+      obligations: null,
+      explanationCodes: ["provider-evidence-required"],
+      createdAt: "2026-07-20T09:00:00.000Z",
+    };
+
+    await callWithFallbackChain({ ...mockDecision, providerSuitabilityReceipt: suitabilityReceipt }, mockPayload, mockContext);
+
+    const persisted = mockPrisma.routeDecisionLog.create.mock.calls[0][0].data;
+    expect(persisted.suitabilityReceipt).toEqual(suitabilityReceipt);
+    expect(JSON.stringify(persisted.suitabilityReceipt)).not.toContain("Hello");
+  });
+
   it("logs token usage with correct shape after success", async () => {
     mockCallProvider.mockResolvedValueOnce({
       content: "ok",

--- a/apps/web/lib/routing/task-dispatcher.ts
+++ b/apps/web/lib/routing/task-dispatcher.ts
@@ -173,6 +173,7 @@ async function persistDecision(
       fallbacksUsed: JSON.stringify(fallbacksUsed),
       shadowMode: context.shadowMode ?? false,
       selectedModelId: selectedCandidate?.modelId ?? null,
+      suitabilityReceipt: decision.providerSuitabilityReceipt ?? undefined,
     },
   });
 }

--- a/apps/web/lib/routing/task-router-types.ts
+++ b/apps/web/lib/routing/task-router-types.ts
@@ -130,4 +130,6 @@ export interface TaskRouteDecision {
   taskType: string;
   sensitivity: SensitivityLevel;
   timestamp: Date;
+  /** Policy-safe provider suitability audit receipt; never contains request content or raw account ids. */
+  providerSuitabilityReceipt?: import("./provider-suitability/evidence").ProviderSuitabilityRouteReceipt;
 }

--- a/apps/web/lib/routing/types.ts
+++ b/apps/web/lib/routing/types.ts
@@ -143,6 +143,8 @@ export interface RouteDecision {
   taskType: string;
   sensitivity: SensitivityLevel;
   timestamp: Date;
+  /** Policy-safe provider suitability audit receipt; never contains request content or raw account ids. */
+  providerSuitabilityReceipt?: import("./provider-suitability/evidence").ProviderSuitabilityRouteReceipt;
 
   // EP-INF-005b: Execution recipe fields
   selectedRecipeId?: string;

--- a/docs/data-impact/2026-07-20-provider-suitability-evidence.data-impact.json
+++ b/docs/data-impact/2026-07-20-provider-suitability-evidence.data-impact.json
@@ -1,0 +1,85 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [
+    "Prisma-to-EA current-state data-model mirror",
+    "provider onboarding suitability projection",
+    "RouteDecisionLog operator explanation surfaces"
+  ],
+  "migration": {
+    "name": "20260720100000_provider_suitability_evidence",
+    "backfill": "none — all evidence bindings and suitability receipts are nullable; existing declarations remain unknown until reviewed"
+  },
+  "tests": [
+    "packages/db/src/provider-suitability-evidence-schema.test.ts",
+    "apps/web/lib/routing/provider-suitability/evidence.test.ts",
+    "apps/web/lib/routing/loader.test.ts",
+    "apps/web/lib/routing/task-dispatcher.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:compliance-evidence#provider-connection-claim",
+      "prismaModel": "ComplianceEvidence",
+      "lifecycleDisposition": "retained as supersedable legal and operational evidence; replacement appends a revision rather than deleting history",
+      "fields": [
+        {
+          "fieldId": "data:compliance-evidence#providerConnectionId",
+          "resolution": "governed",
+          "reason": "binds each claim to the exact provider key, subscription, or tenant so evidence cannot become vendor-wide authority",
+          "provenance": "operator attestation or reviewed supplier evidence",
+          "flags": ["sensitive", "subject"],
+          "fieldPolicy": "organization-scoped authorization; fail closed on missing, conflicting, expired, or mismatched connection evidence"
+        },
+        {
+          "fieldId": "data:compliance-evidence#claimKey",
+          "resolution": "governed",
+          "reason": "typed claim identity permits deterministic current-revision and conflict resolution",
+          "provenance": "provider suitability claim registry"
+        },
+        {
+          "fieldId": "data:compliance-evidence#assertedValue",
+          "resolution": "governed",
+          "reason": "records the reviewed assertion without copying credentials or provider evidence documents into routing receipts",
+          "provenance": "operator attestation or reviewed supplier evidence",
+          "flags": ["sensitive"],
+          "fieldPolicy": "read only within provider-governance scope; never emit in privacy-safe route receipts"
+        },
+        {
+          "fieldId": "data:compliance-evidence#validFrom-expiresAt",
+          "resolution": "governed",
+          "reason": "dated validity prevents stale enterprise, regional, and data-handling rights from persisting indefinitely",
+          "provenance": "evidence review lifecycle"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:route-decision-log#suitability-receipt",
+      "prismaModel": "RouteDecisionLog",
+      "lifecycleDisposition": "retained with the existing route decision audit lifecycle and never used as a source of authorization",
+      "fields": [
+        {
+          "fieldId": "data:route-decision-log#suitabilityReceipt",
+          "resolution": "governed",
+          "reason": "explains provider suitability using versioned, allowlisted facts without storing request content or external account identifiers",
+          "provenance": "provider suitability compiler",
+          "flags": ["sensitive"],
+          "fieldPolicy": "allowlist only; exclude prompts, messages, payloads, credentials, evidence documents, organization IDs, raw connection IDs, and free text"
+        }
+      ]
+    },
+    {
+      "kind": "policy",
+      "policyId": "provider-trust-evidence-resolution-v1",
+      "testVectors": {
+        "allow": true,
+        "deny": true,
+        "obligation": true,
+        "unknownContext": true,
+        "precedence": true,
+        "exceptionExpiry": true
+      }
+    }
+  ]
+}

--- a/docs/operations/provider-trust-evidence.md
+++ b/docs/operations/provider-trust-evidence.md
@@ -1,0 +1,43 @@
+# Provider trust evidence and route receipts
+
+Use this runbook when a provider is configured but DPF reports that regulated or otherwise restricted work cannot use it.
+
+## Authority boundaries
+
+- `ModelProvider` owns the provider catalog and runtime lifecycle.
+- `AiProviderConnection` owns the configured account/channel posture. A vendor may have several connections with different rights.
+- `SupplierContract` owns the commercial agreement and its active dates.
+- `ComplianceEvidence` owns reviewed claim evidence, validity, expiry, rejection, and supersession. Provider evidence is linked to exactly one connection.
+- `RouteDecisionLog.suitabilityReceipt` owns the policy-safe routing receipt. It is not an evidence-document store.
+
+Never infer a BAA, DPA, zero-retention term, regional entitlement, administrative control, SLA, or router endpoint approval from provider marketing or from another account for the same vendor.
+
+## Review and remediation
+
+1. Open **Platform → AI Operations → Providers & Routing** and select the configured provider.
+2. Confirm the connected account type and execution channel are correct.
+3. Review **Provider trust evidence**. It shows every evaluated claim's status, age, expiry, and next action.
+4. For missing evidence, obtain and review evidence for this exact account or tenant.
+5. For expired evidence, renew or replace it. Do not extend the date without a current source.
+6. For rejected evidence, resolve the review finding before enabling restricted work.
+7. For conflicting evidence, determine which assertion is authoritative and supersede the obsolete revision.
+8. For replaced evidence, link the current revision. The old revision remains in the audit trail and cannot authorize work.
+9. Reassess the intended workload. Public marketing work and regulated records are separate decisions; a failed restricted-work claim should not be turned into a provider-wide guess.
+
+Operator declarations made on the provider page are evidence-backed for 90 days, remain weaker than reviewed contract evidence, and never become a BAA, DPA, or enterprise entitlement by themselves.
+
+## Receipt privacy check
+
+A provider suitability route receipt may contain:
+
+- receipt schema, compiler, policy, and work-context input versions;
+- a one-way internal connection reference and bounded channel/account-class posture;
+- selected provider and router-selected underlying provider identifiers;
+- excluded provider identifiers, enforced obligations, and explanation codes;
+- receipt creation time.
+
+It must not contain prompts, messages, tool payloads, credentials, secrets, vendor account identifiers, raw organization or connection identifiers, uploaded evidence content, file references, or free-text explanations. Treat any such field as an audit defect and stop the affected rollout until corrected.
+
+## Existing installs
+
+The schema migration adds only nullable evidence and receipt fields. Existing connections remain unknown/unreviewed; the migration does not manufacture rights from old declarations. Continuous remediation and staged enforcement for existing installs is owned by BI-AIPS-008.

--- a/docs/superpowers/plans/2026-07-19-ai-provider-suitability-routing.md
+++ b/docs/superpowers/plans/2026-07-19-ai-provider-suitability-routing.md
@@ -224,15 +224,15 @@ unreviewed connections; no account tier, contract, or entitlement is inferred.
 - Modify: existing route-decision/telemetry writer selected during Task 1 audit
 - Modify: `apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx`
 
-- [ ] Decide whether `SupplierContract` + `ComplianceEvidence` + existing provider, credential, and finance metadata can express connection identity, account class, BAA/DPA, ZDR/no-training, regional entitlement, admin/audit controls, SLA/support, review status, and expiry. Add a new model only for facts those owners cannot represent.
-- [ ] If a migration is required, write forward-safe migration tests and an inline backfill/attestation per AGENTS.md migration rules.
-- [ ] Write failing evidence resolution tests for valid, missing, expired, rejected, conflicting, and superseded evidence.
-- [ ] Write failing isolation tests proving an enterprise contract or entitlement linked to one account/connection never authorizes a regular API key, subscription session, or second tenant for the same vendor.
-- [ ] Write failing receipt tests that capture policy/input versions, provider/underlying-provider identity, exclusions, obligations, and explanation codes without sensitive content.
-- [ ] Make expired evidence downgrade restricted eligibility immediately while leaving general/public routing governed by its own policy.
-- [ ] Render contract/evidence status and next action on the existing provider detail page; do not create another admin workspace.
+- [x] Decide whether `SupplierContract` + `ComplianceEvidence` + existing provider, credential, and finance metadata can express connection identity, account class, BAA/DPA, ZDR/no-training, regional entitlement, admin/audit controls, SLA/support, review status, and expiry. Add a new model only for facts those owners cannot represent.
+- [x] If a migration is required, write forward-safe migration tests and an inline backfill/attestation per AGENTS.md migration rules.
+- [x] Write failing evidence resolution tests for valid, missing, expired, rejected, conflicting, and superseded evidence.
+- [x] Write failing isolation tests proving an enterprise contract or entitlement linked to one account/connection never authorizes a regular API key, subscription session, or second tenant for the same vendor.
+- [x] Write failing receipt tests that capture policy/input versions, provider/underlying-provider identity, exclusions, obligations, and explanation codes without sensitive content.
+- [x] Make expired evidence downgrade restricted eligibility immediately while leaving general/public routing governed by its own policy.
+- [x] Render contract/evidence status and next action on the existing provider detail page; do not create another admin workspace.
 - [ ] Run migration, unit, typecheck, build, UX, and route-receipt evidence gates.
-- [ ] Update operations and AI provider docs.
+- [x] Update operations and AI provider docs.
 - [ ] Commit with DCO: `feat(ai-providers): govern trust evidence and route receipts`.
 
 ### Task 8: BI-AIPS-008 - Continuous Suitability, Rollout, And Completion Gate

--- a/docs/user-guide/ai-workforce/model-routing-lifecycle.md
+++ b/docs/user-guide/ai-workforce/model-routing-lifecycle.md
@@ -116,6 +116,14 @@ That means one connected provider can be available for public marketing copy and
 
 An employee's occupation focuses the explanations and recommendations they see. It does not grant data access, expand coworker or tool authority, or make a blocked provider eligible.
 
+### Evidence belongs to the connected account
+
+Provider claims are not vendor-wide. A business agreement, BAA, DPA, no-training term, regional entitlement, or router allowlist applies only to the connected account it was reviewed for. It does not make a personal API key, an individual subscription, or a second tenant for the same vendor suitable.
+
+Open **Platform → AI Operations → Providers & Routing**, choose a provider, and review **Provider trust evidence**. Each claim shows whether its evidence is current, missing, expired, rejected, conflicting, or replaced, along with its age, expiry, and safest next action. Operator declarations expire after 90 days unless stronger reviewed evidence replaces them. Expiry removes the claim from restricted-work eligibility immediately; it does not unnecessarily block separately governed public work.
+
+Every governed route may carry a privacy-safe suitability receipt. The receipt records policy and input versions, the selected provider and any router-selected underlying provider, the connection's channel/account posture, exclusions, obligations, and explanation codes. It deliberately excludes prompts, messages, credentials, vendor account identifiers, organization identifiers, evidence documents, and free-text explanations.
+
 ## How Routing Adapts Over Time
 
 | Event | What Happens |
@@ -128,6 +136,8 @@ An employee's occupation focuses the explanations and recommendations they see. 
 | Model disappears from provider API | After 2+ discovery cycles without seeing it, model is retired. |
 | Pre-evaluated profile re-profiled | Metadata is updated but dimension scores are NOT overwritten (`profileSource: "evaluated"` is protected). |
 | Admin overrides AgentModelConfig | Takes effect immediately. Seed will not overwrite admin-configured rows on next restart. |
+| Provider evidence expires or is rejected | The affected claim stops authorizing restricted work; the provider detail page shows the repair action. |
+| Provider evidence is replaced | The prior revision remains an audit record but no longer authorizes work. |
 
 ## Provider-Specific Notes
 
@@ -167,6 +177,12 @@ Local models are automatically discovered and profiled. They are assigned the `b
 - Discovery is manual for cloud providers. Go to AI Workforce > Providers > select the provider > click "Discover Models"
 - After discovery, click "Profile Models" to assign quality tiers and dimension scores
 - Models outside the provider's `modelRestrictions` allowlist will be automatically retired
+
+**A provider is active but restricted work is blocked:**
+- Open the provider detail page and review **Provider trust evidence**.
+- Confirm the evidence is attached to the same connected account that will execute the work.
+- Follow the displayed next action for missing, expired, rejected, conflicting, or replaced evidence.
+- Do not copy evidence from another key, subscription, tenant, or provider account; DPF will not transfer those rights.
 
 **Local model not appearing:**
 - Visit the AI Workforce providers page to trigger automatic discovery

--- a/packages/db/prisma/migrations/20260720100000_provider_suitability_evidence/migration.sql
+++ b/packages/db/prisma/migrations/20260720100000_provider_suitability_evidence/migration.sql
@@ -1,0 +1,24 @@
+-- Provider suitability evidence remains connection-scoped. Every new column is
+-- nullable so existing installs upgrade as unknown/unreviewed; this migration
+-- does not infer contract rights, entitlements, or evidence validity.
+-- @migration-safety: data-safe: providerConnectionId is added nullable here, so every existing row is NULL before the foreign key is created.
+ALTER TABLE "ComplianceEvidence"
+  ADD COLUMN "providerConnectionId" TEXT,
+  ADD COLUMN "claimKey" TEXT,
+  ADD COLUMN "assertedValue" JSONB,
+  ADD COLUMN "validFrom" TIMESTAMP(3),
+  ADD COLUMN "expiresAt" TIMESTAMP(3);
+
+ALTER TABLE "RouteDecisionLog"
+  ADD COLUMN "suitabilityReceipt" JSONB;
+
+CREATE INDEX "ComplianceEvidence_providerConnectionId_claimKey_status_idx"
+  ON "ComplianceEvidence"("providerConnectionId", "claimKey", "status");
+
+CREATE INDEX "ComplianceEvidence_expiresAt_status_idx"
+  ON "ComplianceEvidence"("expiresAt", "status");
+
+ALTER TABLE "ComplianceEvidence"
+  ADD CONSTRAINT "ComplianceEvidence_providerConnectionId_fkey"
+  FOREIGN KEY ("providerConnectionId") REFERENCES "AiProviderConnection"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2138,6 +2138,7 @@ model AiProviderConnection {
   financeProfile   AiProviderFinanceProfile? @relation(fields: [financeProfileId], references: [id], onDelete: SetNull)
   supplierContract SupplierContract?         @relation(fields: [supplierContractId], references: [id], onDelete: SetNull)
   capacityStatus   ProviderCapacityStatus?   @relation(fields: [capacityStatusId], references: [id], onDelete: SetNull)
+  trustEvidence    ComplianceEvidence[]
 
   @@index([organizationId, status])
   @@index([providerId, status])
@@ -8211,6 +8212,11 @@ model ComplianceEvidence {
   fileRef                   String?
   retentionUntil            DateTime?
   supersededById            String?
+  providerConnectionId      String?
+  claimKey                  String?
+  assertedValue             Json?
+  validFrom                 DateTime?
+  expiresAt                 DateTime?
   agentId                   String?
   status                    String                     @default("active")
   createdAt                 DateTime                   @default(now())
@@ -8220,6 +8226,7 @@ model ComplianceEvidence {
   obligation                Obligation?                @relation(fields: [obligationId], references: [id])
   supersededBy              ComplianceEvidence?        @relation("EvidenceSupersession", fields: [supersededById], references: [id])
   supersedes                ComplianceEvidence[]       @relation("EvidenceSupersession")
+  providerConnection        AiProviderConnection?      @relation(fields: [providerConnectionId], references: [id], onDelete: SetNull)
   licenseDisplayObligations LicenseDisplayObligation[]
 
   @@index([obligationId])
@@ -8227,6 +8234,8 @@ model ComplianceEvidence {
   @@index([collectedByEmployeeId])
   @@index([status])
   @@index([evidenceType])
+  @@index([providerConnectionId, claimKey, status])
+  @@index([expiresAt, status])
 }
 
 model RiskAssessment {
@@ -8735,6 +8744,7 @@ model RouteDecisionLog {
   shadowMode         Boolean  @default(false)
   createdAt          DateTime @default(now())
   selectedModelId    String?
+  suitabilityReceipt Json?
 
   @@index([taskType])
   @@index([actorKind, actorId, createdAt])

--- a/packages/db/src/provider-suitability-evidence-schema.test.ts
+++ b/packages/db/src/provider-suitability-evidence-schema.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const schema = readFileSync(resolve(import.meta.dirname, "../prisma/schema.prisma"), "utf8");
+const migration = readFileSync(resolve(
+  import.meta.dirname,
+  "../prisma/migrations/20260720100000_provider_suitability_evidence/migration.sql",
+), "utf8");
+
+describe("provider suitability evidence schema", () => {
+  it("binds claim evidence to one provider connection through the existing ComplianceEvidence owner", () => {
+    expect(schema).toMatch(/model ComplianceEvidence \{[\s\S]*providerConnectionId\s+String\?/);
+    expect(schema).toMatch(/model ComplianceEvidence \{[\s\S]*claimKey\s+String\?/);
+    expect(schema).toMatch(/model ComplianceEvidence \{[\s\S]*assertedValue\s+Json\?/);
+    expect(schema).toMatch(/model ComplianceEvidence \{[\s\S]*providerConnection\s+AiProviderConnection\?/);
+    expect(schema).not.toContain("model ProviderTrustEvidence {");
+  });
+
+  it("adds only nullable unknown-by-default fields and preserves existing-install safety", () => {
+    expect(migration).toContain('ADD COLUMN "providerConnectionId" TEXT');
+    expect(migration).toContain('ADD COLUMN "claimKey" TEXT');
+    expect(migration).toContain('ADD COLUMN "assertedValue" JSONB');
+    expect(migration).toContain('ADD COLUMN "validFrom" TIMESTAMP(3)');
+    expect(migration).toContain('ADD COLUMN "expiresAt" TIMESTAMP(3)');
+    expect(migration).not.toMatch(/providerConnectionId" TEXT NOT NULL|claimKey" TEXT NOT NULL|DEFAULT '\{.*entitl/i);
+    expect(migration).toContain("ON DELETE SET NULL");
+  });
+
+  it("adds a nullable policy-safe receipt to the existing route audit log", () => {
+    expect(schema).toMatch(/model RouteDecisionLog \{[\s\S]*suitabilityReceipt\s+Json\?/);
+    expect(migration).toContain('ALTER TABLE "RouteDecisionLog"');
+    expect(migration).toContain('ADD COLUMN "suitabilityReceipt" JSONB');
+  });
+});


### PR DESCRIPTION
## Summary
- bind dated, revisable trust claims to the exact AI provider connection and resolve missing, expired, conflicting, or superseded evidence fail-closed
- persist privacy-safe provider-suitability receipts through both route-decision writers
- add an operator evidence panel to the existing provider detail page, plus operations and user guidance

## Design grounding
Implements BI-AIPS-007 and Task 7 of `docs/superpowers/plans/2026-07-19-ai-provider-suitability-routing.md`, grounded in `docs/superpowers/specs/2026-07-19-ai-provider-suitability-routing-design.md`.

This extends the existing owners rather than creating parallel substrate: `ComplianceEvidence` owns dated evidence revisions, `AiProviderConnection` owns account identity, `SupplierContract` remains contract authority, and `RouteDecisionLog` owns the compact receipt. Existing declarations without governed proof resolve unknown; the migration is additive and nullable.

## Verification
- Exact head: `bf1717ebb6440dba921f004a6c41808f4c2b727f`
- Local-CI lease `NPEL-BFBD476477`, merged over `origin/main@adefc0f27aec9999e6888cc9d12eced5d32a543d`
- 92 focused tests passed: 89 web + 3 database schema
- Full web test suite, web/db typecheck, production build, Prisma validate/generate, migration apply, docs links/index, and module-size guard passed
- Contributor preview verified `/platform/ai/providers/openrouter` at 1280x720 and 390x844 with no horizontal overflow; the panel showed connection-scoped evidence, Action needed, evidence freshness, and one next action per claim

## Privacy and migration safety
The receipt uses an explicit allowlist and excludes prompts, messages, payloads, credentials, evidence documents, free text, organization IDs, and raw provider-connection IDs. The migration adds nullable fields and indexes only; no existing install receives fabricated rights.

## Documentation impact
Updated the AI routing lifecycle guide and added an operator runbook for provider trust evidence.

UX-Fit-Decision: conditional-inline in the existing provider detail page; no new route or workspace
Data-Impact: additive nullable evidence and receipt fields; existing rows remain unknown until reviewed
Local-CI-Evidence: NPEL-BFBD476477 passed for bf1717ebb6440dba921f004a6c41808f4c2b727f
Docs-Impact-Decision: Updated the linked AI routing lifecycle guide and added the provider trust evidence operator runbook.
Local-CI-Evidence: NPEL-BF51851B5A passed for 3dca82f9298ea94c19fb571f0fb66abe3dc436c8