### PR TITLE
feat: add secure nearby federation pairing

### DIFF
--- a/apps/web/app/(shell)/platform/federation-links/page.tsx
+++ b/apps/web/app/(shell)/platform/federation-links/page.tsx
@@ -1,16 +1,19 @@
 import { redirect } from "next/navigation";
 
 import { prisma } from "@dpf/db";
+import { isFederationPairingDirection } from "@dpf/db/federation-pairing-types";
 import { resolveIncidentProjectionSpec } from "@dpf/db/projection-egress";
 
 import { auth } from "@/lib/auth";
 import { can } from "@/lib/permissions";
 import { listNearbyFederationCandidates } from "@/lib/federation/nearby-candidates";
+import { summarizeNearbyPairingProjection } from "@/lib/federation/nearby-pairing";
 import { resolveFounderDemandEnvironment } from "@dpf/db/founder-shared-portfolio";
 import {
   FederationLinksAdminClient,
   type FederationLinkRow,
   type NearbyDiscoveryHealth,
+  type NearbyPairingRow,
 } from "@/components/platform/federation-links/FederationLinksAdminClient";
 import {
   PartnerBusinessPanel,
@@ -34,7 +37,7 @@ export default async function FederationLinksPage() {
     redirect("/403");
   }
 
-  const [links, discoveryCapabilities, partnerAccounts] = await Promise.all([
+  const [links, discoveryCapabilities, partnerAccounts, nearbyPairingSessions] = await Promise.all([
     prisma.federationLink.findMany({
       include: { principal: { select: { displayName: true } } },
       orderBy: { createdAt: "desc" },
@@ -58,6 +61,14 @@ export default async function FederationLinksPage() {
       },
       orderBy: { createdAt: "asc" },
       take: 200,
+    }),
+    prisma.federationPairingSession.findMany({
+      where: {
+        status: { in: ["pending", "approved"] },
+        expiresAt: { gt: new Date() },
+      },
+      orderBy: { requestedAt: "desc" },
+      take: 20,
     }),
   ]);
 
@@ -134,6 +145,23 @@ export default async function FederationLinksPage() {
     supportRouteCount: partner._count.supportRoutes,
     recognitionCount: partner._count.contributionRecognitions,
   }));
+  const nearbyProjection = summarizeNearbyPairingProjection();
+  const nearbyPairings: NearbyPairingRow[] = nearbyPairingSessions.flatMap((pairing) =>
+    isFederationPairingDirection(pairing.direction)
+      ? [{
+          pairingId: pairing.pairingId,
+          direction: pairing.direction,
+          status: pairing.status,
+          matchingCode: pairing.matchingCode,
+          peerDisplayName: pairing.peerDisplayName,
+          peerAuthorityUrl: pairing.peerAuthorityUrl,
+          expiresAt: pairing.expiresAt.toISOString(),
+          sharedSlices: nearbyProjection.sharedSlices,
+          retentionClass: nearbyProjection.retentionClass,
+          staysLocal: nearbyProjection.staysLocal,
+        }]
+      : [],
+  );
   const enrolledLinkIds = new Set(partnerAccounts.flatMap((partner) => partner.federationLinkId ? [partner.federationLinkId] : []));
   const eligiblePartnerLinks = links
     .filter((link) => link.role === "channel-upstream" && link.linkState === "trusted" && !enrolledLinkIds.has(link.linkId))
@@ -151,6 +179,7 @@ export default async function FederationLinksPage() {
       <FederationLinksAdminClient
         rows={rows}
         nearbyCandidates={listNearbyFederationCandidates()}
+        nearbyPairings={nearbyPairings}
         nearbyDiscoveryHealth={nearbyDiscoveryHealth}
       />
       <PartnerBusinessPanel partners={partners} eligibleLinks={eligiblePartnerLinks} />

--- a/apps/web/app/connect/pair/route.test.ts
+++ b/apps/web/app/connect/pair/route.test.ts
@@ -1,0 +1,112 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  poll: vi.fn(),
+  identity: vi.fn(),
+  organization: vi.fn(),
+}));
+
+vi.mock("@dpf/db", () => ({
+  prisma: { organization: { findFirst: mocks.organization } },
+}));
+vi.mock("@/lib/federation/demand-identity", () => ({
+  resolveFederationIdentity: mocks.identity,
+}));
+vi.mock("@/lib/federation/nearby-pairing-service", () => ({
+  createIncomingNearbyPairing: mocks.create,
+  pollIncomingNearbyPairing: mocks.poll,
+}));
+
+import { _resetNearbyPairingRateLimits } from "@/lib/federation/nearby-pairing-rate-limit";
+
+import { POST } from "./route";
+
+function request(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest("https://dpf-b.local/connect/pair", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": "192.168.1.40", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /connect/pair", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetNearbyPairingRateLimits();
+    mocks.identity.mockResolvedValue({ installationId: `inst_${"b".repeat(32)}`, projectionSecret: "c".repeat(64) });
+    mocks.organization.mockResolvedValue({ name: "Arcamanus Windows" });
+    mocks.create.mockResolvedValue({ ok: true, pairingId: "pair_123" });
+    mocks.poll.mockResolvedValue({ ok: true, status: "pending" });
+  });
+
+  it("creates a bounded incoming session without requiring an existing federation credential", async () => {
+    const response = await POST(request({
+      operation: "request",
+      requesterAuthorityUrl: "https://dpf-a.local:3443",
+      displayName: "Arcamanus Mac",
+      requesterInstallationId: `inst_${"a".repeat(32)}`,
+      candidateDiscoveryId: "rotating-b-123456",
+      relationshipPreset: "same-organization",
+    }));
+
+    expect(response.status).toBe(201);
+    expect(mocks.create).toHaveBeenCalledWith(
+      {
+        requesterAuthorityUrl: "https://dpf-a.local:3443",
+        displayName: "Arcamanus Mac",
+        requesterInstallationId: `inst_${"a".repeat(32)}`,
+        candidateDiscoveryId: "rotating-b-123456",
+        relationshipPreset: "same-organization",
+      },
+      expect.objectContaining({
+        localDisplayName: "Arcamanus Windows",
+        localInstallationId: `inst_${"b".repeat(32)}`,
+      }),
+    );
+  });
+
+  it("polls only with the pairing id and high-entropy bearer secret", async () => {
+    const response = await POST(request({
+      operation: "poll",
+      pairingId: "pair_123",
+      pairingSecret: `dpffpair_${"a".repeat(43)}`,
+    }));
+    expect(response.status).toBe(200);
+    expect(mocks.poll).toHaveBeenCalledWith({
+      pairingId: "pair_123",
+      pairingSecret: `dpffpair_${"a".repeat(43)}`,
+    });
+
+    const codeResponse = await POST(request({
+      operation: "poll",
+      pairingId: "pair_123",
+      pairingSecret: "ABCD-EFGH",
+    }));
+    expect(codeResponse.status).toBe(400);
+  });
+
+  it("rejects oversized and repeated unauthenticated requests", async () => {
+    const oversized = await POST(request({ operation: "request" }, { "content-length": "9000" }));
+    expect(oversized.status).toBe(413);
+
+    let last = await POST(request({ operation: "unknown" }));
+    for (let index = 0; index < 10; index += 1) {
+      last = await POST(request({ operation: "unknown" }));
+    }
+    expect(last.status).toBe(429);
+  });
+
+  it("allows the three-second approval polling cadence without opening request intake", async () => {
+    let response: Response | undefined;
+    for (let index = 0; index < 20; index += 1) {
+      response = await POST(request({
+        operation: "poll",
+        pairingId: "pair_123",
+        pairingSecret: `dpffpair_${"a".repeat(43)}`,
+      }));
+    }
+    expect(response?.status).toBe(200);
+  });
+});

--- a/apps/web/app/connect/pair/route.test.ts
+++ b/apps/web/app/connect/pair/route.test.ts
@@ -36,7 +36,7 @@ describe("POST /connect/pair", () => {
     vi.clearAllMocks();
     _resetNearbyPairingRateLimits();
     mocks.identity.mockResolvedValue({ installationId: `inst_${"b".repeat(32)}`, projectionSecret: "c".repeat(64) });
-    mocks.organization.mockResolvedValue({ name: "Arcamanus Windows" });
+    mocks.organization.mockResolvedValue({ name: "Windows development installation" });
     mocks.create.mockResolvedValue({ ok: true, pairingId: "pair_123" });
     mocks.poll.mockResolvedValue({ ok: true, status: "pending" });
   });
@@ -45,7 +45,7 @@ describe("POST /connect/pair", () => {
     const response = await POST(request({
       operation: "request",
       requesterAuthorityUrl: "https://dpf-a.local:3443",
-      displayName: "Arcamanus Mac",
+      displayName: "Mac development installation",
       requesterInstallationId: `inst_${"a".repeat(32)}`,
       candidateDiscoveryId: "rotating-b-123456",
       relationshipPreset: "same-organization",
@@ -55,13 +55,13 @@ describe("POST /connect/pair", () => {
     expect(mocks.create).toHaveBeenCalledWith(
       {
         requesterAuthorityUrl: "https://dpf-a.local:3443",
-        displayName: "Arcamanus Mac",
+        displayName: "Mac development installation",
         requesterInstallationId: `inst_${"a".repeat(32)}`,
         candidateDiscoveryId: "rotating-b-123456",
         relationshipPreset: "same-organization",
       },
       expect.objectContaining({
-        localDisplayName: "Arcamanus Windows",
+        localDisplayName: "Windows development installation",
         localInstallationId: `inst_${"b".repeat(32)}`,
       }),
     );

--- a/apps/web/app/connect/pair/route.ts
+++ b/apps/web/app/connect/pair/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { prisma } from "@dpf/db";
+
+import { resolveFederationIdentity } from "@/lib/federation/demand-identity";
+import {
+  createIncomingNearbyPairing,
+  pollIncomingNearbyPairing,
+} from "@/lib/federation/nearby-pairing-service";
+import { checkNearbyPairingRateLimit } from "@/lib/federation/nearby-pairing-rate-limit";
+
+const MAX_BODY_BYTES = 8 * 1024;
+
+function requesterKey(request: NextRequest): string {
+  const forwarded = request.headers.get("x-forwarded-for")?.split(",", 1)[0]?.trim();
+  const real = request.headers.get("x-real-ip")?.trim();
+  const value = forwarded || real || "unknown";
+  return value.length <= 80 ? value : value.slice(0, 80);
+}
+
+function error(status: number, code: string, message: string): NextResponse {
+  return NextResponse.json({ ok: false, error: code, message }, { status });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const declaredLength = Number(request.headers.get("content-length") ?? 0);
+  if (declaredLength > MAX_BODY_BYTES) {
+    return error(413, "payload_too_large", "Pairing request is too large.");
+  }
+  let raw: string;
+  try {
+    raw = await request.text();
+  } catch {
+    return error(400, "invalid_body", "Pairing request could not be read.");
+  }
+  if (Buffer.byteLength(raw, "utf8") > MAX_BODY_BYTES) {
+    return error(413, "payload_too_large", "Pairing request is too large.");
+  }
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    return error(400, "invalid_json", "Pairing request must be valid JSON.");
+  }
+  if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
+    return error(400, "invalid_request", "Pairing request must be an object.");
+  }
+  const { operation, ...payload } = decoded as Record<string, unknown>;
+  const rateClass = operation === "poll" ? "poll" : "request";
+  const perRequesterLimit = rateClass === "poll" ? 60 : 10;
+  const globalLimit = rateClass === "poll" ? 600 : 100;
+  const globalRateLimit = checkNearbyPairingRateLimit(`global:${rateClass}`, {
+    maxRequests: globalLimit,
+  });
+  const requesterRateLimit = globalRateLimit.allowed
+    ? checkNearbyPairingRateLimit(`${rateClass}:${requesterKey(request)}`, {
+        maxRequests: perRequesterLimit,
+      })
+    : globalRateLimit;
+  if (!requesterRateLimit.allowed) {
+    return NextResponse.json(
+      { ok: false, error: "rate_limited", message: "Too many pairing requests. Try again shortly." },
+      { status: 429, headers: { "Retry-After": String(requesterRateLimit.retryAfterSeconds) } },
+    );
+  }
+
+  if (operation === "request") {
+    try {
+      const [identity, organization] = await Promise.all([
+        resolveFederationIdentity(prisma),
+        prisma.organization.findFirst({ orderBy: { createdAt: "asc" }, select: { name: true } }),
+      ]);
+      const result = await createIncomingNearbyPairing(payload, {
+        localDisplayName: organization?.name?.trim() || "Nearby DPF installation",
+        localInstallationId: identity.installationId,
+      });
+      return NextResponse.json(result, { status: 201 });
+    } catch (caught) {
+      return error(
+        400,
+        "invalid_request",
+        caught instanceof Error ? caught.message : "Pairing request is invalid.",
+      );
+    }
+  }
+
+  if (operation === "poll") {
+    const pairingId = payload.pairingId;
+    const pairingSecret = payload.pairingSecret;
+    if (
+      Object.keys(payload).some((key) => key !== "pairingId" && key !== "pairingSecret") ||
+      typeof pairingId !== "string" ||
+      !/^pair_[A-Za-z0-9_-]{3,160}$/.test(pairingId) ||
+      typeof pairingSecret !== "string" ||
+      !/^dpffpair_[A-Za-z0-9_-]{40,80}$/.test(pairingSecret)
+    ) {
+      return error(400, "invalid_request", "Pairing poll is invalid.");
+    }
+    const result = await pollIncomingNearbyPairing({ pairingId, pairingSecret });
+    if (!result.ok) {
+      return result.error === "not_found"
+        ? error(404, result.error, "Pairing session was not found.")
+        : error(503, result.error, "Pairing credential is temporarily unavailable.");
+    }
+    return NextResponse.json(result);
+  }
+
+  return error(400, "unsupported_operation", "Use request or poll.");
+}

--- a/apps/web/components/platform/federation-links/FederationLinksAdminClient.test.tsx
+++ b/apps/web/components/platform/federation-links/FederationLinksAdminClient.test.tsx
@@ -3,10 +3,14 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { mockSetDiscovery, mockIssueInvitation, mockSetEnvironment } = vi.hoisted(() => ({
+const { mockSetDiscovery, mockIssueInvitation, mockSetEnvironment, mockStartPairing, mockPollPairing, mockApprovePairing, mockDenyPairing } = vi.hoisted(() => ({
   mockSetDiscovery: vi.fn(),
   mockIssueInvitation: vi.fn(),
   mockSetEnvironment: vi.fn(),
+  mockStartPairing: vi.fn(),
+  mockPollPairing: vi.fn(),
+  mockApprovePairing: vi.fn(),
+  mockDenyPairing: vi.fn(),
 }));
 
 vi.mock("@/lib/actions/federation-links", () => ({
@@ -17,6 +21,14 @@ vi.mock("@/lib/actions/federation-links", () => ({
   revokeFederationLinkAction: vi.fn(),
   setFederationDiscoveryEnabledAction: mockSetDiscovery,
   setFederationLinkEnvironmentAction: mockSetEnvironment,
+  startNearbyPairingAction: mockStartPairing,
+  pollNearbyPairingAction: mockPollPairing,
+  approveNearbyPairingAction: mockApprovePairing,
+  denyNearbyPairingAction: mockDenyPairing,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
 }));
 
 import { FederationLinksAdminClient } from "./FederationLinksAdminClient";
@@ -46,14 +58,18 @@ describe("FederationLinksAdminClient nearby setup", () => {
     expect(screen.getByText(/TLS will be verified before any invitation is sent/)).toBeTruthy();
   });
 
-  it("prefills the peer endpoint and same-organization preset", () => {
-    render(<FederationLinksAdminClient rows={[]} nearbyCandidates={[secureCandidate]} />);
+  it("shows an incoming request with the matching code and canonical projection summary", () => {
+    render(<FederationLinksAdminClient rows={[]} nearbyPairings={[{
+      pairingId: "pair_123", direction: "incoming", status: "pending", matchingCode: "ABCD-EFGH",
+      peerDisplayName: "Arcamanus Mac", peerAuthorityUrl: "https://peer-one.local",
+      expiresAt: "2026-07-20T12:15:00.000Z", sharedSlices: ["demand"], retentionClass: "standard",
+      staysLocal: ["local backlog details", "work capsules"],
+    }]} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Set up this DPF" }));
-
-    expect((screen.getByLabelText("Peer URL") as HTMLInputElement).value).toBe("https://peer-one.local");
-    expect((screen.getByLabelText("Relationship preset") as HTMLSelectElement).value).toBe("same-organization");
-    expect(screen.getByText(/Shared platform demand and dispositions/)).toBeTruthy();
+    expect(screen.getByText("ABCD-EFGH")).toBeTruthy();
+    expect(screen.getByText(/Arcamanus Mac is asking to connect/)).toBeTruthy();
+    expect(screen.getByText((_, element) => element?.tagName === "P" && element.textContent?.includes("Shares: demand") === true)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Approve this installation" })).toBeTruthy();
   });
 
   it("blocks automatic setup for an HTTP candidate", () => {

--- a/apps/web/components/platform/federation-links/FederationLinksAdminClient.test.tsx
+++ b/apps/web/components/platform/federation-links/FederationLinksAdminClient.test.tsx
@@ -61,13 +61,13 @@ describe("FederationLinksAdminClient nearby setup", () => {
   it("shows an incoming request with the matching code and canonical projection summary", () => {
     render(<FederationLinksAdminClient rows={[]} nearbyPairings={[{
       pairingId: "pair_123", direction: "incoming", status: "pending", matchingCode: "ABCD-EFGH",
-      peerDisplayName: "Arcamanus Mac", peerAuthorityUrl: "https://peer-one.local",
+      peerDisplayName: "Mac development installation", peerAuthorityUrl: "https://peer-one.local",
       expiresAt: "2026-07-20T12:15:00.000Z", sharedSlices: ["demand"], retentionClass: "standard",
       staysLocal: ["local backlog details", "work capsules"],
     }]} />);
 
     expect(screen.getByText("ABCD-EFGH")).toBeTruthy();
-    expect(screen.getByText(/Arcamanus Mac is asking to connect/)).toBeTruthy();
+    expect(screen.getByText(/Mac development installation is asking to connect/)).toBeTruthy();
     expect(screen.getByText((_, element) => element?.tagName === "P" && element.textContent?.includes("Shares: demand") === true)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Approve this installation" })).toBeTruthy();
   });

--- a/apps/web/components/platform/federation-links/FederationLinksAdminClient.tsx
+++ b/apps/web/components/platform/federation-links/FederationLinksAdminClient.tsx
@@ -1,18 +1,24 @@
 "use client";
 
 import Link from "next/link";
-import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState, useTransition } from "react";
 
 import { confirmDialog, promptDialog } from "@/components/ui/Dialog";
+import { InlineBusy } from "@/components/ui/InlineBusy";
 import { StatusBadge } from "@/components/ui/report-kit";
 import {
   approveFederationLinkAction,
+  approveNearbyPairingAction,
+  denyNearbyPairingAction,
   enrollWithPeerAction,
   issueFederationBootstrapAction,
+  pollNearbyPairingAction,
   quarantineFederationLinkAction,
   revokeFederationLinkAction,
   setFederationDiscoveryEnabledAction,
   setFederationLinkEnvironmentAction,
+  startNearbyPairingAction,
 } from "@/lib/actions/federation-links";
 import type { NearbyFederationCandidate } from "@/lib/federation/nearby-candidates";
 
@@ -39,11 +45,25 @@ export interface NearbyDiscoveryHealth {
   detail: string;
 }
 
+export interface NearbyPairingRow {
+  pairingId: string;
+  direction: "incoming" | "outgoing";
+  status: string;
+  matchingCode: string;
+  peerDisplayName: string;
+  peerAuthorityUrl: string;
+  expiresAt: string;
+  sharedSlices: string[];
+  retentionClass: string;
+  staysLocal: string[];
+}
+
 type Flash = { kind: "success" | "error"; text: string } | null;
 
 export function FederationLinksAdminClient({
   rows,
   nearbyCandidates = [],
+  nearbyPairings = [],
   nearbyDiscoveryHealth = {
     status: "unavailable",
     label: "Not set up",
@@ -52,8 +72,10 @@ export function FederationLinksAdminClient({
 }: {
   rows: FederationLinkRow[];
   nearbyCandidates?: NearbyFederationCandidate[];
+  nearbyPairings?: NearbyPairingRow[];
   nearbyDiscoveryHealth?: NearbyDiscoveryHealth;
 }) {
+  const router = useRouter();
   const [flash, setFlash] = useState<Flash>(null);
   const [relationshipPreset, setRelationshipPreset] = useState<
     "same-organization" | "service-provider" | "channel"
@@ -66,14 +88,110 @@ export function FederationLinksAdminClient({
   const [peerUrl, setPeerUrl] = useState("");
   const [peerToken, setPeerToken] = useState("");
   const [peerName, setPeerName] = useState("");
+  const [activePairing, setActivePairing] = useState<NearbyPairingRow | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  function selectNearbyCandidate(candidate: NearbyFederationCandidate) {
+  const pairingRows = useMemo(() => {
+    if (!activePairing) return nearbyPairings;
+    return [activePairing, ...nearbyPairings.filter((row) => row.pairingId !== activePairing.pairingId)];
+  }, [activePairing, nearbyPairings]);
+
+  function actionPairingRow(
+    result: Extract<Awaited<ReturnType<typeof startNearbyPairingAction>>, { ok: true }>,
+  ): NearbyPairingRow {
+    return {
+      pairingId: result.pairingId,
+      direction: "outgoing",
+      status: result.status,
+      matchingCode: result.matchingCode,
+      peerDisplayName: result.peerDisplayName,
+      peerAuthorityUrl: result.peerAuthorityUrl,
+      expiresAt: result.expiresAt,
+      sharedSlices: result.projectionSummary.sharedSlices,
+      retentionClass: result.projectionSummary.retentionClass,
+      staysLocal: result.projectionSummary.staysLocal,
+    };
+  }
+
+  useEffect(() => {
+    const outgoing = pairingRows.find(
+      (row) => row.direction === "outgoing" && (row.status === "pending" || row.status === "approved"),
+    );
+    if (!outgoing || isPending) return;
+    const timer = window.setTimeout(() => {
+      startTransition(async () => {
+        const result = await pollNearbyPairingAction(outgoing.pairingId);
+        if (!result.ok) {
+          setFlash({ kind: "error", text: `Pairing check failed: ${result.message}` });
+          return;
+        }
+        setActivePairing(actionPairingRow(result));
+        if (result.status === "consumed") {
+          setFlash({
+            kind: "success",
+            text: `Secure setup completed${result.linkId ? ` — link ${result.linkId}` : ""}. Approve the new connection below; it becomes trusted after both installations approve.`,
+          });
+          router.refresh();
+        }
+      });
+    }, 3_000);
+    return () => window.clearTimeout(timer);
+  }, [isPending, pairingRows, router]);
+
+  async function selectNearbyCandidate(candidate: NearbyFederationCandidate) {
     if (candidate.automaticPairing === "blocked-insecure-transport") return;
-    setPeerUrl(candidate.endpoint);
-    setPeerName(`Nearby DPF ${candidate.discoveryId.slice(-4)}`);
-    setRelationshipPreset("same-organization");
-    setRole("same-org-peer");
+    const confirmed = await confirmDialog({
+      title: "Connect another installation",
+      message: "Is this another DPF owned by your organization? Both installations will show the same code and sharing summary before approval.",
+      confirmLabel: "Yes, start secure setup",
+    });
+    if (!confirmed) return;
+    setFlash(null);
+    startTransition(async () => {
+      const result = await startNearbyPairingAction({
+        discoveryId: candidate.discoveryId,
+        endpoint: candidate.endpoint,
+      });
+      if (!result.ok) {
+        setFlash({ kind: "error", text: `Secure setup failed: ${result.message} Manual invitation remains available below.` });
+        return;
+      }
+      setActivePairing(actionPairingRow(result));
+      setFlash({ kind: "success", text: "Secure setup started. Confirm the same code on both installations." });
+    });
+  }
+
+  async function onApprovePairing(row: NearbyPairingRow) {
+    const confirmed = await confirmDialog({
+      title: "Approve this installation",
+      message: `Approve ${row.peerDisplayName} only if it shows the same code ${row.matchingCode} and you accept the sharing summary. The connection still remains pending until both installations approve it.`,
+      confirmLabel: "Approve this installation",
+    });
+    if (!confirmed) return;
+    startTransition(async () => {
+      const result = await approveNearbyPairingAction(row.pairingId);
+      setFlash(result.ok
+        ? { kind: "success", text: "Pairing approved here. Waiting for the other installation to finish setup." }
+        : { kind: "error", text: `Pairing approval failed: ${result.message}` });
+      if (result.ok) router.refresh();
+    });
+  }
+
+  async function onDenyPairing(row: NearbyPairingRow) {
+    const reason = await promptDialog({
+      title: "Deny this installation",
+      message: `Why are you denying ${row.peerDisplayName}?`,
+      required: true,
+      confirmLabel: "Deny connection",
+    });
+    if (!reason?.trim()) return;
+    startTransition(async () => {
+      const result = await denyNearbyPairingAction(row.pairingId, reason.trim());
+      setFlash(result.ok
+        ? { kind: "success", text: "Pairing request denied. No invitation or connection was created." }
+        : { kind: "error", text: `Pairing denial failed: ${result.message}` });
+      if (result.ok) router.refresh();
+    });
   }
 
   function setNearbyDiscovery(enabled: boolean) {
@@ -299,16 +417,76 @@ export function FederationLinksAdminClient({
                   </div>
                   <button
                     type="button"
-                    disabled={!secure}
+                    disabled={!secure || isPending}
                     onClick={() => selectNearbyCandidate(candidate)}
                     className="rounded px-3 py-1.5 text-sm font-medium text-[var(--dpf-bg)] disabled:opacity-50"
                     style={{ backgroundColor: secure ? "var(--dpf-accent)" : "var(--dpf-muted)" }}
                   >
-                    {secure ? "Set up this DPF" : "Secure setup required"}
+                    {secure && isPending ? <InlineBusy label="Starting…" tone="current" /> : secure ? "Set up this DPF" : "Secure setup required"}
                   </button>
                 </div>
               );
             })}
+          </div>
+        )}
+        {pairingRows.length > 0 && (
+          <div className="mt-4 space-y-3" aria-live="polite">
+            {pairingRows.map((pairing) => (
+              <div
+                key={pairing.pairingId}
+                className="rounded border p-3"
+                style={{ borderColor: "var(--dpf-border)", backgroundColor: "var(--dpf-surface-2)" }}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-[var(--dpf-text)]">
+                      {pairing.direction === "incoming"
+                        ? `${pairing.peerDisplayName} is asking to connect`
+                        : `${pairing.peerDisplayName} is waiting for approval`}
+                    </p>
+                    <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                      Confirm this same code on both installations:
+                    </p>
+                    <code className="mt-1 block text-lg font-bold tracking-widest text-[var(--dpf-text)]">
+                      {pairing.matchingCode}
+                    </code>
+                    <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+                      Expires {new Date(pairing.expiresAt).toLocaleString()}.
+                    </p>
+                  </div>
+                  <StatusBadge label={pairing.status} intent={pairing.status === "approved" ? "success" : "neutral"} variant="soft" />
+                </div>
+                <div className="mt-3 rounded border p-2 text-xs text-[var(--dpf-muted)]" style={{ borderColor: "var(--dpf-border)" }}>
+                  <p><span className="font-medium text-[var(--dpf-text)]">Shares:</span> {pairing.sharedSlices.join(", ")} · retain: {pairing.retentionClass}</p>
+                  <p className="mt-1"><span className="font-medium text-[var(--dpf-text)]">Stays here:</span> {pairing.staysLocal.join(", ")}</p>
+                </div>
+                {pairing.direction === "incoming" && pairing.status === "pending" && (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      disabled={isPending}
+                      onClick={() => onApprovePairing(pairing)}
+                      className="rounded px-3 py-1.5 text-sm font-medium text-[var(--dpf-bg)] disabled:opacity-50"
+                      style={{ backgroundColor: "var(--dpf-accent)" }}
+                    >
+                      {isPending ? <InlineBusy label="Approving…" tone="current" /> : "Approve this installation"}
+                    </button>
+                    <button
+                      type="button"
+                      disabled={isPending}
+                      onClick={() => onDenyPairing(pairing)}
+                      className="rounded border px-3 py-1.5 text-sm font-medium text-[var(--dpf-text)] disabled:opacity-50"
+                      style={{ borderColor: "var(--dpf-border)", backgroundColor: "var(--dpf-surface-1)" }}
+                    >
+                      Deny
+                    </button>
+                  </div>
+                )}
+                {pairing.direction === "outgoing" && (pairing.status === "pending" || pairing.status === "approved") && (
+                  <div className="mt-3"><InlineBusy label="Checking for approval…" /></div>
+                )}
+              </div>
+            ))}
           </div>
         )}
       </section>

--- a/apps/web/lib/actions/federation-links-pairing.test.ts
+++ b/apps/web/lib/actions/federation-links-pairing.test.ts
@@ -98,7 +98,7 @@ describe("nearby federation pairing actions", () => {
     mocks.listCandidates.mockReturnValue([candidate]);
     mocks.assertEncryption.mockResolvedValue(undefined);
     mocks.resolveIdentity.mockResolvedValue({ installationId: `inst_${"a".repeat(32)}` });
-    mocks.findOrganization.mockResolvedValue({ id: "org_1", name: "Arcamanus Mac" });
+    mocks.findOrganization.mockResolvedValue({ id: "org_1", name: "Mac development installation" });
     mocks.findPairing.mockResolvedValue(null);
     mocks.encryptSecret.mockReturnValue("encrypted-pairing-secret");
     mocks.createPairing.mockResolvedValue({ id: "session_1" });
@@ -110,7 +110,7 @@ describe("nearby federation pairing actions", () => {
       pairingId: "pair_123",
       pairingSecret: `dpffpair_${"a".repeat(43)}`,
       matchingCode: "ABCD-EFGH",
-      peerDisplayName: "Arcamanus Windows",
+      peerDisplayName: "Windows development installation",
       peerInstallationId: `inst_${"b".repeat(32)}`,
       expiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),
       projectionSummary: {
@@ -150,7 +150,7 @@ describe("nearby federation pairing actions", () => {
       status: "pending",
       matchingCode: "ABCD-EFGH",
       pairingSecretEnc: "encrypted-pairing-secret",
-      peerDisplayName: "Arcamanus Windows",
+      peerDisplayName: "Windows development installation",
       peerAuthorityUrl: candidate.endpoint,
       peerInstallationId: `inst_${"b".repeat(32)}`,
       expiresAt,

--- a/apps/web/lib/actions/federation-links-pairing.test.ts
+++ b/apps/web/lib/actions/federation-links-pairing.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  revalidatePath: vi.fn(),
+  resolveAppBaseUrl: vi.fn(),
+  listCandidates: vi.fn(),
+  resolveIdentity: vi.fn(),
+  requestPairing: vi.fn(),
+  pollPairing: vi.fn(),
+  enrollWithPeer: vi.fn(),
+  assertEncryption: vi.fn(),
+  encryptSecret: vi.fn(),
+  decryptSecret: vi.fn(),
+  findPrincipalAlias: vi.fn(),
+  findOrganization: vi.fn(),
+  findPairing: vi.fn(),
+  findPairingById: vi.fn(),
+  createPairing: vi.fn(),
+  updatePairing: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    principalAlias: { findFirst: mocks.findPrincipalAlias },
+    organization: { findFirst: mocks.findOrganization },
+    federationPairingSession: {
+      findFirst: mocks.findPairing,
+      findUnique: mocks.findPairingById,
+      create: mocks.createPairing,
+      update: mocks.updatePairing,
+    },
+  },
+}));
+vi.mock("@/lib/auth", () => ({ auth: mocks.auth }));
+vi.mock("@/lib/permissions", () => ({ can: () => true }));
+vi.mock("@/lib/app-url", () => ({ resolveAppBaseUrl: mocks.resolveAppBaseUrl }));
+vi.mock("@/lib/identity/principal-linking", () => ({ syncUserPrincipal: vi.fn() }));
+vi.mock("@/lib/federation/demand-identity", () => ({
+  resolveFederationIdentity: mocks.resolveIdentity,
+}));
+vi.mock("@/lib/federation/nearby-candidates", () => ({
+  listNearbyFederationCandidates: mocks.listCandidates,
+}));
+vi.mock("@/lib/federation/nearby-pairing", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/federation/nearby-pairing")>();
+  return {
+    ...original,
+    requestNearbyPairing: mocks.requestPairing,
+    pollNearbyPairingPeer: mocks.pollPairing,
+  };
+});
+vi.mock("@/lib/federation/nearby-pairing-service", () => ({
+  approveIncomingNearbyPairing: vi.fn(),
+  denyIncomingNearbyPairing: vi.fn(),
+}));
+vi.mock("@/lib/federation/outbound", () => ({
+  enrollWithPeer: mocks.enrollWithPeer,
+  relayApprovalToPeer: vi.fn(),
+}));
+vi.mock("@/lib/federation/enrollment", () => ({
+  approveFederationLinkLocal: vi.fn(),
+  issueFederationBootstrap: vi.fn(),
+  quarantineFederationLink: vi.fn(),
+  revokeFederationLink: vi.fn(),
+}));
+vi.mock("@/lib/govern/credential-crypto", () => ({
+  assertEncryptionReadyForCredentialWrite: mocks.assertEncryption,
+  encryptSecret: mocks.encryptSecret,
+  decryptSecret: mocks.decryptSecret,
+}));
+
+import {
+  pollNearbyPairingAction,
+  startNearbyPairingAction,
+} from "./federation-links";
+
+const candidate = {
+  discoveryId: "rotating-peer-1234",
+  endpoint: "https://peer.local:3443",
+  protocol: "1" as const,
+  capabilityDigest: "8f31c9a2",
+  pairPath: "/connect/pair" as const,
+  observedAt: "2026-07-20T12:00:00.000Z",
+  expiresAt: "2026-07-20T12:02:00.000Z",
+  automaticPairing: "tls-validation-required" as const,
+};
+
+describe("nearby federation pairing actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auth.mockResolvedValue({
+      user: { id: "user_1", platformRole: "admin", isSuperuser: true },
+    });
+    mocks.findPrincipalAlias.mockResolvedValue({ principalId: "principal_1" });
+    mocks.resolveAppBaseUrl.mockReturnValue("https://local-dpf.local:3443");
+    mocks.listCandidates.mockReturnValue([candidate]);
+    mocks.assertEncryption.mockResolvedValue(undefined);
+    mocks.resolveIdentity.mockResolvedValue({ installationId: `inst_${"a".repeat(32)}` });
+    mocks.findOrganization.mockResolvedValue({ id: "org_1", name: "Arcamanus Mac" });
+    mocks.findPairing.mockResolvedValue(null);
+    mocks.encryptSecret.mockReturnValue("encrypted-pairing-secret");
+    mocks.createPairing.mockResolvedValue({ id: "session_1" });
+  });
+
+  it("persists an encrypted outgoing session only for a currently discovered HTTPS peer", async () => {
+    mocks.requestPairing.mockResolvedValue({
+      ok: true,
+      pairingId: "pair_123",
+      pairingSecret: `dpffpair_${"a".repeat(43)}`,
+      matchingCode: "ABCD-EFGH",
+      peerDisplayName: "Arcamanus Windows",
+      peerInstallationId: `inst_${"b".repeat(32)}`,
+      expiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),
+      projectionSummary: {
+        relationshipLabel: "Same organization",
+        retentionClass: "standard",
+        sharedSlices: ["demand"],
+        staysLocal: ["local backlog details"],
+      },
+    });
+
+    await expect(startNearbyPairingAction({
+      discoveryId: candidate.discoveryId,
+      endpoint: candidate.endpoint,
+    })).resolves.toMatchObject({ ok: true, pairingId: "pair_123", status: "pending" });
+
+    expect(mocks.requestPairing).toHaveBeenCalledWith(expect.objectContaining({
+      candidateEndpoint: candidate.endpoint,
+      requesterAuthorityUrl: "https://local-dpf.local:3443",
+      requesterInstallationId: `inst_${"a".repeat(32)}`,
+    }));
+    expect(mocks.createPairing).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        direction: "outgoing",
+        pairingSecretEnc: "encrypted-pairing-secret",
+        peerAuthorityUrl: candidate.endpoint,
+      }),
+    });
+    expect(mocks.createPairing.mock.calls[0]?.[0].data).not.toHaveProperty("pairingSecret");
+  });
+
+  it("redeems an approved peer invitation and clears the pairing credential", async () => {
+    const expiresAt = new Date(Date.now() + 10 * 60_000);
+    mocks.findPairingById.mockResolvedValue({
+      id: "session_1",
+      pairingId: "pair_123",
+      direction: "outgoing",
+      status: "pending",
+      matchingCode: "ABCD-EFGH",
+      pairingSecretEnc: "encrypted-pairing-secret",
+      peerDisplayName: "Arcamanus Windows",
+      peerAuthorityUrl: candidate.endpoint,
+      peerInstallationId: `inst_${"b".repeat(32)}`,
+      expiresAt,
+    });
+    mocks.decryptSecret.mockReturnValue(`dpffpair_${"a".repeat(43)}`);
+    mocks.pollPairing.mockResolvedValue({
+      ok: true,
+      status: "approved",
+      bootstrapToken: `dpffboot_${"A".repeat(39)}`,
+    });
+    mocks.enrollWithPeer.mockResolvedValue({
+      ok: true,
+      linkId: "FL-1",
+      linkState: "pending",
+      role: "same-org-peer",
+    });
+    mocks.updatePairing.mockResolvedValue({ id: "session_1" });
+
+    await expect(pollNearbyPairingAction("pair_123")).resolves.toMatchObject({
+      ok: true,
+      status: "consumed",
+      linkId: "FL-1",
+    });
+    expect(mocks.enrollWithPeer).toHaveBeenCalledWith(expect.objectContaining({
+      bootstrapToken: `dpffboot_${"A".repeat(39)}`,
+      peerAuthorityUrl: candidate.endpoint,
+      localOrganizationId: "org_1",
+    }));
+    expect(mocks.updatePairing).toHaveBeenLastCalledWith({
+      where: { id: "session_1" },
+      data: expect.objectContaining({ status: "consumed", pairingSecretEnc: null }),
+    });
+  });
+});

--- a/apps/web/lib/actions/federation-links.ts
+++ b/apps/web/lib/actions/federation-links.ts
@@ -23,6 +23,7 @@ import { isPartnerStanding, type PartnerStanding } from "@dpf/db/federated-chann
 
 import { resolveAppBaseUrl } from "@/lib/app-url";
 import { auth } from "@/lib/auth";
+import { resolveFederationIdentity } from "@/lib/federation/demand-identity";
 import {
   approveFederationLinkLocal,
   issueFederationBootstrap,
@@ -30,6 +31,21 @@ import {
   revokeFederationLink,
 } from "@/lib/federation/enrollment";
 import { enrollWithPeer, relayApprovalToPeer } from "@/lib/federation/outbound";
+import {
+  pollNearbyPairingPeer,
+  requestNearbyPairing,
+  summarizeNearbyPairingProjection,
+} from "@/lib/federation/nearby-pairing";
+import {
+  approveIncomingNearbyPairing,
+  denyIncomingNearbyPairing,
+} from "@/lib/federation/nearby-pairing-service";
+import { listNearbyFederationCandidates } from "@/lib/federation/nearby-candidates";
+import {
+  assertEncryptionReadyForCredentialWrite,
+  decryptSecret,
+  encryptSecret,
+} from "@/lib/govern/credential-crypto";
 import { syncUserPrincipal } from "@/lib/identity/principal-linking";
 import { can } from "@/lib/permissions";
 import { envFlagEnabled } from "@/lib/runtime/env-flags";
@@ -361,6 +377,238 @@ export async function enrollWithPeerAction(input: {
   } catch (err) {
     return { ok: false, error: "internal_error", message: err instanceof Error ? err.message : "enroll failed" };
   }
+}
+
+// ── Secure automatic nearby pairing ─────────────────────────────────────────
+
+export type NearbyPairingActionResult =
+  | {
+      ok: true;
+      pairingId: string;
+      status: string;
+      matchingCode: string;
+      peerDisplayName: string;
+      peerAuthorityUrl: string;
+      expiresAt: string;
+      projectionSummary: ReturnType<typeof summarizeNearbyPairingProjection>;
+      linkId?: string;
+    }
+  | ActionFailure;
+
+export async function startNearbyPairingAction(input: {
+  discoveryId: string;
+  endpoint: string;
+}): Promise<NearbyPairingActionResult> {
+  const gate = await assertManagePlatform();
+  if (!gate.ok) return gate;
+  const candidate = listNearbyFederationCandidates().find(
+    (row) => row.discoveryId === input.discoveryId && row.endpoint === input.endpoint,
+  );
+  if (!candidate) {
+    return { ok: false, error: "not_found", message: "That nearby DPF is no longer visible. Wait for discovery to refresh." };
+  }
+  if (candidate.automaticPairing === "blocked-insecure-transport") {
+    return { ok: false, error: "invalid_input", message: "Automatic pairing requires HTTPS. Use a manual invitation until this installation has a trusted certificate." };
+  }
+  const localAuthorityUrl = resolveAppBaseUrl();
+  if (!localAuthorityUrl) {
+    return { ok: false, error: "internal_error", message: "This installation's base URL is not configured." };
+  }
+  try {
+    await assertEncryptionReadyForCredentialWrite();
+    const now = new Date();
+    const existing = await prisma.federationPairingSession.findFirst({
+      where: {
+        direction: "outgoing",
+        candidateDiscoveryId: candidate.discoveryId,
+        peerAuthorityUrl: candidate.endpoint,
+        status: { in: ["pending", "approved"] },
+        expiresAt: { gt: now },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    if (existing) {
+      return {
+        ok: true,
+        pairingId: existing.pairingId,
+        status: existing.status,
+        matchingCode: existing.matchingCode,
+        peerDisplayName: existing.peerDisplayName,
+        peerAuthorityUrl: existing.peerAuthorityUrl,
+        expiresAt: existing.expiresAt.toISOString(),
+        projectionSummary: summarizeNearbyPairingProjection(),
+      };
+    }
+    const [identity, organization] = await Promise.all([
+      resolveFederationIdentity(prisma),
+      prisma.organization.findFirst({ orderBy: { createdAt: "asc" }, select: { id: true, name: true } }),
+    ]);
+    const displayName = organization?.name?.trim() || "Nearby DPF installation";
+    const requested = await requestNearbyPairing({
+      candidateEndpoint: candidate.endpoint,
+      requesterAuthorityUrl: localAuthorityUrl,
+      displayName,
+      requesterInstallationId: identity.installationId,
+      candidateDiscoveryId: candidate.discoveryId,
+    });
+    if (!requested.ok) {
+      return { ok: false, error: "internal_error", message: requested.message };
+    }
+    const remoteExpiry = new Date(requested.expiresAt);
+    const expiresAt = new Date(Math.min(remoteExpiry.getTime(), now.getTime() + 15 * 60_000));
+    await prisma.federationPairingSession.create({
+      data: {
+        pairingId: requested.pairingId,
+        direction: "outgoing",
+        status: "pending",
+        relationshipPreset: "same-organization",
+        projectionTemplateKey: "same-organization",
+        matchingCode: requested.matchingCode,
+        pairingSecretEnc: encryptSecret(requested.pairingSecret),
+        peerAuthorityUrl: candidate.endpoint,
+        peerDisplayName: requested.peerDisplayName,
+        peerInstallationId: requested.peerInstallationId,
+        candidateDiscoveryId: candidate.discoveryId,
+        requestedAt: now,
+        expiresAt,
+      },
+    });
+    revalidatePath(ADMIN_PATH);
+    return {
+      ok: true,
+      pairingId: requested.pairingId,
+      status: "pending",
+      matchingCode: requested.matchingCode,
+      peerDisplayName: requested.peerDisplayName,
+      peerAuthorityUrl: candidate.endpoint,
+      expiresAt: expiresAt.toISOString(),
+      projectionSummary: requested.projectionSummary,
+    };
+  } catch (error) {
+    return { ok: false, error: "internal_error", message: error instanceof Error ? error.message : "Nearby pairing failed." };
+  }
+}
+
+export async function pollNearbyPairingAction(pairingId: string): Promise<NearbyPairingActionResult> {
+  const gate = await assertManagePlatform();
+  if (!gate.ok) return gate;
+  const row = await prisma.federationPairingSession.findUnique({ where: { pairingId } });
+  if (!row || row.direction !== "outgoing") {
+    return { ok: false, error: "not_found", message: "Pairing session not found." };
+  }
+  const baseResult = {
+    pairingId: row.pairingId,
+    matchingCode: row.matchingCode,
+    peerDisplayName: row.peerDisplayName,
+    peerAuthorityUrl: row.peerAuthorityUrl,
+    expiresAt: row.expiresAt.toISOString(),
+    projectionSummary: summarizeNearbyPairingProjection(),
+  };
+  if (row.status === "consumed" || row.status === "denied" || row.status === "expired") {
+    return { ok: true, ...baseResult, status: row.status };
+  }
+  if (row.expiresAt.getTime() <= Date.now()) {
+    await prisma.federationPairingSession.update({
+      where: { id: row.id },
+      data: { status: "expired", pairingSecretEnc: null },
+    });
+    return { ok: true, ...baseResult, status: "expired" };
+  }
+  if (!row.pairingSecretEnc) {
+    return { ok: false, error: "internal_error", message: "Stored pairing credential is unavailable." };
+  }
+  const pairingSecret = decryptSecret(row.pairingSecretEnc);
+  if (!pairingSecret) {
+    return { ok: false, error: "internal_error", message: "Stored pairing credential could not be decrypted." };
+  }
+  const peer = await pollNearbyPairingPeer({
+    candidateEndpoint: row.peerAuthorityUrl,
+    pairingId: row.pairingId,
+    pairingSecret,
+  });
+  if (!peer.ok) return { ok: false, error: "internal_error", message: peer.message };
+  if (peer.status !== "approved") {
+    await prisma.federationPairingSession.update({
+      where: { id: row.id },
+      data: {
+        status: peer.status,
+        ...(peer.status === "pending" ? {} : { pairingSecretEnc: null }),
+        lastPolledAt: new Date(),
+        pollCount: { increment: 1 },
+      },
+    });
+    revalidatePath(ADMIN_PATH);
+    return { ok: true, ...baseResult, status: peer.status };
+  }
+  const [localAuthorityUrl, organization] = await Promise.all([
+    Promise.resolve(resolveAppBaseUrl()),
+    prisma.organization.findFirst({ orderBy: { createdAt: "asc" }, select: { id: true, name: true } }),
+  ]);
+  if (!localAuthorityUrl) {
+    return { ok: false, error: "internal_error", message: "This installation's base URL is not configured." };
+  }
+  const enrolled = await enrollWithPeer({
+    peerAuthorityUrl: row.peerAuthorityUrl,
+    bootstrapToken: peer.bootstrapToken,
+    localAuthorityUrl,
+    displayName: organization?.name?.trim() || "Nearby DPF installation",
+    localOrganizationId: organization?.id ?? null,
+    peerOrganizationRef: row.peerInstallationId,
+  });
+  if (!enrolled.ok) {
+    return { ok: false, error: "internal_error", message: enrolled.message };
+  }
+  const consumedAt = new Date();
+  await prisma.federationPairingSession.update({
+    where: { id: row.id },
+    data: {
+      status: "consumed",
+      consumedAt,
+      pairingSecretEnc: null,
+      lastPolledAt: consumedAt,
+      pollCount: { increment: 1 },
+    },
+  });
+  revalidatePath(ADMIN_PATH);
+  return { ok: true, ...baseResult, status: "consumed", linkId: enrolled.linkId };
+}
+
+export async function approveNearbyPairingAction(pairingId: string): Promise<
+  { ok: true; status: "approved" } | ActionFailure
+> {
+  const gate = await assertManagePlatform();
+  if (!gate.ok) return gate;
+  const result = await approveIncomingNearbyPairing({ pairingId, approverPrincipalId: gate.principalId });
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: result.error === "not_found" ? "not_found" : "invalid_transition",
+      message: result.error === "expired" ? "Pairing request expired." : "Pairing request cannot be approved.",
+    };
+  }
+  revalidatePath(ADMIN_PATH);
+  return result;
+}
+
+export async function denyNearbyPairingAction(pairingId: string, reason: string): Promise<
+  { ok: true; status: "denied" } | ActionFailure
+> {
+  const gate = await assertManagePlatform();
+  if (!gate.ok) return gate;
+  const result = await denyIncomingNearbyPairing({
+    pairingId,
+    deniedByPrincipalId: gate.principalId,
+    reason,
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: result.error === "invalid_input" ? "invalid_input" : "invalid_transition",
+      message: result.error === "invalid_input" ? "A denial reason is required." : "Pairing request cannot be denied.",
+    };
+  }
+  revalidatePath(ADMIN_PATH);
+  return result;
 }
 
 export type SetFederationDiscoveryActionResult =

--- a/apps/web/lib/ea/federated-demand-architecture-extract.test.ts
+++ b/apps/web/lib/ea/federated-demand-architecture-extract.test.ts
@@ -9,6 +9,7 @@ describe("federated demand SysML projection", () => {
   it("preserves the authority break from local backlog through forge delivery", () => {
     expect(byKey.get("fdn:part:local-backlog")?.properties).toMatchObject({ prismaModel: "BacklogItem" });
     expect(byKey.get("fdn:part:federated-mirror")?.properties).toMatchObject({ prismaModel: "FederatedRecordMirror" });
+    expect(byKey.get("fdn:part:pairing-session")?.properties).toMatchObject({ prismaModel: "FederationPairingSession" });
     expect(byKey.get("fdn:part:founder-cluster")?.properties).toMatchObject({ prismaModel: "FounderDemandCluster" });
     expect(byKey.get("fdn:part:hive-ledger")?.properties).toMatchObject({ prismaModel: "HiveContributionLedger" });
     expect(byKey.get("fdn:part:forge")?.description).toContain("not backlog or federation authority");
@@ -19,5 +20,7 @@ describe("federated demand SysML projection", () => {
     expect(model.elements.filter((element) => element.sysmlKey.startsWith("fdn:port:"))).toHaveLength(8);
     expect(model.elements.filter((element) => element.sysmlKey.startsWith("fdn:vc:"))).toHaveLength(15);
     expect(model.relationships).toContainEqual({ fromKey: "fdn:vc:15", toKey: "fdn:req:11", relSlug: "verifies" });
+    expect(model.relationships).toContainEqual({ fromKey: "fdn:part:pairing-session", toKey: "fdn:port:pairing", relSlug: "connects" });
+    expect(model.relationships).toContainEqual({ fromKey: "fdn:part:pairing-session", toKey: "fdn:req:02", relSlug: "satisfies" });
   });
 });

--- a/apps/web/lib/ea/federated-demand-architecture-extract.ts
+++ b/apps/web/lib/ea/federated-demand-architecture-extract.ts
@@ -18,6 +18,7 @@ const REQUIREMENTS = [
 
 const PARTS = [
   ["local-backlog", "Local Backlog Authority", "BacklogItem", "Each installation owns its work, priority, status, estimate, and build state."],
+  ["pairing-session", "Federation Pairing Session", "FederationPairingSession", "Owns expiring device-binding state and one-time bootstrap delivery; never creates relationship trust."],
   ["federated-mirror", "Federated Demand Mirror", "FederatedRecordMirror", "Stores minimized peer observations and durable protocol outbox state; never owns local work."],
   ["founder-cluster", "Founder Shared Portfolio", "FounderDemandCluster", "Founder Hub owns cluster membership, reach, disposition, and canonical local-item mapping."],
   ["founder-origin", "Founder Deduplicated Origin", "FounderDemandClusterMember", "Counts one immutable installation/envelope origin once while retaining every route attestation."],
@@ -74,6 +75,9 @@ export function buildFederatedDemandArchitectureModel(): SysmlDesiredModel {
     relationships.push({ fromKey: FEDERATED_DEMAND_PACKAGE_KEY, toKey: key, relSlug: "contains" });
   }
   relationships.push(
+    { fromKey: "fdn:part:pairing-session", toKey: "fdn:port:pairing", relSlug: "connects" },
+    { fromKey: "fdn:part:pairing-session", toKey: "fdn:req:02", relSlug: "satisfies" },
+    { fromKey: "fdn:part:pairing-session", toKey: "fdn:req:09", relSlug: "satisfies" },
     { fromKey: "fdn:part:local-backlog", toKey: "fdn:port:delivery-flow", relSlug: "connects" },
     { fromKey: "fdn:port:delivery-flow", toKey: "fdn:part:federated-mirror", relSlug: "connects" },
     { fromKey: "fdn:part:federated-mirror", toKey: "fdn:port:founder-portfolio", relSlug: "connects" },

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 573,
+  "routeCount": 574,
   "routes": [
     {
       "routePath": "/",
@@ -3785,6 +3785,16 @@
         "id"
       ],
       "file": "apps/web/app/(shell)/compliance/submissions/[id]/page.tsx"
+    },
+    {
+      "routePath": "/connect/pair",
+      "kind": "route",
+      "segments": [
+        "connect",
+        "pair"
+      ],
+      "dynamicParams": [],
+      "file": "apps/web/app/connect/pair/route.ts"
     },
     {
       "routePath": "/coworker-decisions",

--- a/apps/web/lib/federation/nearby-pairing-rate-limit.ts
+++ b/apps/web/lib/federation/nearby-pairing-rate-limit.ts
@@ -1,0 +1,38 @@
+const WINDOW_MS = 60_000;
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+const globalPairingRateLimits = globalThis as typeof globalThis & {
+  __dpfNearbyPairingRateLimits?: Map<string, Bucket>;
+};
+const buckets =
+  globalPairingRateLimits.__dpfNearbyPairingRateLimits ??
+  (globalPairingRateLimits.__dpfNearbyPairingRateLimits = new Map());
+
+export function checkNearbyPairingRateLimit(
+  key: string,
+  options: { maxRequests: number; now?: Date },
+): { allowed: true } | { allowed: false; retryAfterSeconds: number } {
+  const now = options.now ?? new Date();
+  const timestamp = now.getTime();
+  for (const [bucketKey, bucket] of buckets) {
+    if (bucket.resetAt <= timestamp) buckets.delete(bucketKey);
+  }
+  const current = buckets.get(key);
+  const bucket = !current || current.resetAt <= timestamp
+    ? { count: 0, resetAt: timestamp + WINDOW_MS }
+    : current;
+  bucket.count += 1;
+  buckets.set(key, bucket);
+  if (bucket.count <= options.maxRequests) return { allowed: true };
+  return {
+    allowed: false,
+    retryAfterSeconds: Math.max(1, Math.ceil((bucket.resetAt - timestamp) / 1_000)),
+  };
+}
+
+export function _resetNearbyPairingRateLimits(): void {
+  buckets.clear();
+}

--- a/apps/web/lib/federation/nearby-pairing-service.test.ts
+++ b/apps/web/lib/federation/nearby-pairing-service.test.ts
@@ -10,7 +10,7 @@ import {
 const now = new Date("2026-07-20T12:00:00.000Z");
 const request = {
   requesterAuthorityUrl: "https://dpf-a.local:3443",
-  displayName: "Arcamanus Mac",
+  displayName: "Mac development installation",
   requesterInstallationId: `inst_${"a".repeat(32)}`,
   candidateDiscoveryId: "rotating-b-123456",
 };
@@ -26,7 +26,7 @@ describe("nearby pairing persistence service", () => {
       now,
       pairingId: "pair_test123",
       randomBytes: () => Buffer.alloc(32, 7),
-      localDisplayName: "Arcamanus Windows",
+      localDisplayName: "Windows development installation",
       localInstallationId: `inst_${"b".repeat(32)}`,
     });
 
@@ -45,7 +45,7 @@ describe("nearby pairing persistence service", () => {
       ok: true,
       pairingId: "pair_test123",
       pairingSecret: expect.stringMatching(/^dpffpair_/),
-      peerDisplayName: "Arcamanus Windows",
+      peerDisplayName: "Windows development installation",
       peerInstallationId: `inst_${"b".repeat(32)}`,
     });
   });

--- a/apps/web/lib/federation/nearby-pairing-service.test.ts
+++ b/apps/web/lib/federation/nearby-pairing-service.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  approveIncomingNearbyPairing,
+  createIncomingNearbyPairing,
+  denyIncomingNearbyPairing,
+  pollIncomingNearbyPairing,
+} from "./nearby-pairing-service";
+
+const now = new Date("2026-07-20T12:00:00.000Z");
+const request = {
+  requesterAuthorityUrl: "https://dpf-a.local:3443",
+  displayName: "Arcamanus Mac",
+  requesterInstallationId: `inst_${"a".repeat(32)}`,
+  candidateDiscoveryId: "rotating-b-123456",
+};
+
+describe("nearby pairing persistence service", () => {
+  it("stores only the incoming secret hash and returns plaintext once", async () => {
+    const create = vi.fn(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: "row_1",
+      ...data,
+    }));
+    const result = await createIncomingNearbyPairing(request, {
+      db: { federationPairingSession: { create } },
+      now,
+      pairingId: "pair_test123",
+      randomBytes: () => Buffer.alloc(32, 7),
+      localDisplayName: "Arcamanus Windows",
+      localInstallationId: `inst_${"b".repeat(32)}`,
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        pairingId: "pair_test123",
+        direction: "incoming",
+        status: "pending",
+        pairingSecretHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        peerInstallationId: request.requesterInstallationId,
+        expiresAt: new Date("2026-07-20T12:15:00.000Z"),
+      }),
+    });
+    expect(create.mock.calls[0]?.[0].data).not.toHaveProperty("pairingSecretEnc");
+    expect(result).toMatchObject({
+      ok: true,
+      pairingId: "pair_test123",
+      pairingSecret: expect.stringMatching(/^dpffpair_/),
+      peerDisplayName: "Arcamanus Windows",
+      peerInstallationId: `inst_${"b".repeat(32)}`,
+    });
+  });
+
+  it("approves once by minting the existing bootstrap authority inside one transaction", async () => {
+    const row = {
+      id: "row_1",
+      pairingId: "pair_test123",
+      direction: "incoming",
+      status: "pending",
+      expiresAt: new Date("2026-07-20T12:15:00.000Z"),
+    };
+    const tx = {
+      federationPairingSession: {
+        findUnique: vi.fn(async () => row),
+        updateMany: vi.fn(async () => ({ count: 1 })),
+        update: vi.fn(async () => ({ ...row, status: "approved" })),
+      },
+      federationBootstrapToken: {
+        create: vi.fn(async () => ({ id: "boot_1" })),
+      },
+    };
+    const db = {
+      async $transaction<T>(fn: (client: typeof tx) => Promise<T>): Promise<T> {
+        return fn(tx);
+      },
+    };
+
+    await expect(
+      approveIncomingNearbyPairing(
+        { pairingId: "pair_test123", approverPrincipalId: "principal_1" },
+        {
+          db,
+          now,
+          encryptSecret: (value) => `enc:${value}`,
+          bootstrapMaterial: {
+            plaintext: `dpffboot_${"A".repeat(39)}`,
+            hash: "c".repeat(64),
+            prefix: "dpffboot_AAA",
+          },
+        },
+      ),
+    ).resolves.toMatchObject({ ok: true, status: "approved" });
+
+    expect(tx.federationBootstrapToken.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        tokenHash: "c".repeat(64),
+        offeredRole: "same-org-peer",
+        issuedByPrincipalId: "principal_1",
+      }),
+    });
+    expect(tx.federationPairingSession.update).toHaveBeenCalledWith({
+      where: { id: "row_1" },
+      data: expect.objectContaining({
+        status: "approved",
+        bootstrapTokenId: "boot_1",
+        bootstrapTokenEnc: expect.stringMatching(/^enc:dpffboot_/),
+      }),
+    });
+  });
+
+  it("polls with the high-entropy secret and never authorizes with the matching code", async () => {
+    const secret = `dpffpair_${"a".repeat(43)}`;
+    const { createHash } = await import("node:crypto");
+    const row = {
+      id: "row_1",
+      pairingId: "pair_test123",
+      direction: "incoming",
+      status: "approved",
+      pairingSecretHash: createHash("sha256").update(secret).digest("hex"),
+      bootstrapTokenEnc: "enc:bootstrap",
+      matchingCode: "ABCD-EFGH",
+      expiresAt: new Date("2026-07-20T12:15:00.000Z"),
+      bootstrapToken: { consumedAt: null, revokedAt: null, expiresAt: new Date("2026-07-20T12:15:00.000Z") },
+    };
+    const update = vi.fn(async () => row);
+    const db = {
+      federationPairingSession: {
+        findUnique: vi.fn(async () => row),
+        update,
+      },
+    };
+
+    await expect(
+      pollIncomingNearbyPairing(
+        { pairingId: row.pairingId, pairingSecret: row.matchingCode },
+        { db, now, decryptSecret: () => "dpffboot_wrong" },
+      ),
+    ).resolves.toMatchObject({ ok: false, error: "not_found" });
+    await expect(
+      pollIncomingNearbyPairing(
+        { pairingId: row.pairingId, pairingSecret: secret },
+        { db, now, decryptSecret: () => `dpffboot_${"B".repeat(39)}` },
+      ),
+    ).resolves.toMatchObject({ ok: true, status: "approved", bootstrapToken: expect.stringMatching(/^dpffboot_/) });
+    expect(update).toHaveBeenCalledWith({
+      where: { id: row.id },
+      data: expect.objectContaining({ deliveredAt: now, lastPolledAt: now, pollCount: { increment: 1 } }),
+    });
+  });
+
+  it("records an operator denial without minting invitation authority", async () => {
+    const updateMany = vi.fn(async () => ({ count: 1 }));
+    const db = { federationPairingSession: { updateMany } };
+    await expect(
+      denyIncomingNearbyPairing(
+        {
+          pairingId: "pair_test123",
+          deniedByPrincipalId: "principal_1",
+          reason: "Not one of our installations",
+        },
+        { db, now },
+      ),
+    ).resolves.toEqual({ ok: true, status: "denied" });
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        pairingId: "pair_test123",
+        direction: "incoming",
+        status: "pending",
+        expiresAt: { gt: now },
+      },
+      data: expect.objectContaining({
+        status: "denied",
+        deniedAt: now,
+        deniedByPrincipalId: "principal_1",
+        denialReason: "Not one of our installations",
+        bootstrapTokenEnc: null,
+      }),
+    });
+  });
+});

--- a/apps/web/lib/federation/nearby-pairing-service.ts
+++ b/apps/web/lib/federation/nearby-pairing-service.ts
@@ -1,0 +1,318 @@
+import { randomUUID } from "node:crypto";
+
+import { prisma } from "@dpf/db";
+import { DEMAND_PROJECTION_TEMPLATES } from "@dpf/db/federated-demand-contract";
+import {
+  isFederationPairingStatus,
+  resolveFederationPairingStatus,
+} from "@dpf/db/federation-pairing-types";
+
+import {
+  assertEncryptionReadyForCredentialWrite,
+  decryptSecret as decryptStoredSecret,
+  encryptSecret as encryptStoredSecret,
+} from "@/lib/govern/credential-crypto";
+
+import {
+  createNearbyPairingMaterial,
+  pairingSecretMatches,
+  parseNearbyPairingRequest,
+  summarizeNearbyPairingProjection,
+  type NearbyPairingRequest,
+} from "./nearby-pairing";
+import { generateFederationBootstrapToken } from "./tokens";
+
+const PAIRING_TTL_MS = 15 * 60_000;
+
+interface SessionCreateDb {
+  federationPairingSession: {
+    create(args: { data: Record<string, unknown> }): Promise<unknown>;
+  };
+}
+
+interface ApprovalSessionRow {
+  id: string;
+  pairingId: string;
+  direction: string;
+  status: string;
+  expiresAt: Date;
+}
+
+interface ApprovalTx {
+  federationPairingSession: {
+    findUnique(args: unknown): Promise<ApprovalSessionRow | null>;
+    updateMany(args: unknown): Promise<{ count: number }>;
+    update(args: unknown): Promise<unknown>;
+  };
+  federationBootstrapToken: {
+    create(args: unknown): Promise<{ id: string }>;
+  };
+}
+
+interface ApprovalDb {
+  $transaction<T>(callback: (tx: ApprovalTx) => Promise<T>): Promise<T>;
+}
+
+interface PollSessionRow {
+  id: string;
+  pairingId: string;
+  direction: string;
+  status: string;
+  pairingSecretHash: string | null;
+  bootstrapTokenEnc: string | null;
+  matchingCode: string;
+  expiresAt: Date;
+  deliveredAt?: Date | null;
+  bootstrapToken: {
+    consumedAt: Date | null;
+    revokedAt: Date | null;
+    expiresAt: Date;
+  } | null;
+}
+
+interface PollDb {
+  federationPairingSession: {
+    findUnique(args: unknown): Promise<PollSessionRow | null>;
+    update(args: unknown): Promise<unknown>;
+  };
+}
+
+interface DenyDb {
+  federationPairingSession: {
+    updateMany(args: unknown): Promise<{ count: number }>;
+  };
+}
+
+export async function createIncomingNearbyPairing(
+  input: unknown,
+  options: {
+    db?: SessionCreateDb;
+    now?: Date;
+    pairingId?: string;
+    randomBytes?: (size: number) => Buffer;
+    localDisplayName: string;
+    localInstallationId: string;
+  },
+) {
+  const request = parseNearbyPairingRequest(input);
+  const now = options.now ?? new Date();
+  const pairingId = options.pairingId ?? `pair_${randomUUID().replaceAll("-", "")}`;
+  const expiresAt = new Date(now.getTime() + PAIRING_TTL_MS);
+  const material = createNearbyPairingMaterial(
+    options.randomBytes ? { randomBytes: options.randomBytes } : {},
+  );
+  await (options.db ?? (prisma as unknown as SessionCreateDb)).federationPairingSession.create({
+    data: {
+      pairingId,
+      direction: "incoming",
+      status: "pending",
+      relationshipPreset: "same-organization",
+      projectionTemplateKey: "same-organization",
+      matchingCode: material.matchingCode,
+      pairingSecretHash: material.secretHash,
+      peerAuthorityUrl: request.requesterAuthorityUrl,
+      peerDisplayName: request.displayName,
+      peerInstallationId: request.requesterInstallationId,
+      candidateDiscoveryId: request.candidateDiscoveryId,
+      requestedAt: now,
+      expiresAt,
+    },
+  });
+  return {
+    ok: true as const,
+    pairingId,
+    pairingSecret: material.plaintextSecret,
+    matchingCode: material.matchingCode,
+    peerDisplayName: options.localDisplayName,
+    peerInstallationId: options.localInstallationId,
+    expiresAt: expiresAt.toISOString(),
+    projectionSummary: summarizeNearbyPairingProjection(),
+  };
+}
+
+export type ApproveIncomingPairingResult =
+  | { ok: true; status: "approved" }
+  | { ok: false; error: "not_found" | "expired" | "invalid_transition" };
+
+export async function approveIncomingNearbyPairing(
+  input: { pairingId: string; approverPrincipalId: string },
+  options: {
+    db?: ApprovalDb;
+    now?: Date;
+    encryptSecret?: (value: string) => string;
+    bootstrapMaterial?: { plaintext: string; hash: string; prefix: string };
+  } = {},
+): Promise<ApproveIncomingPairingResult> {
+  await assertEncryptionReadyForCredentialWrite();
+  const db = options.db ?? (prisma as unknown as ApprovalDb);
+  const now = options.now ?? new Date();
+  const encryptSecret = options.encryptSecret ?? encryptStoredSecret;
+  return db.$transaction(async (tx) => {
+    const row = await tx.federationPairingSession.findUnique({
+      where: { pairingId: input.pairingId },
+    });
+    if (!row || row.direction !== "incoming" || !isFederationPairingStatus(row.status)) {
+      return { ok: false, error: "not_found" };
+    }
+    const effectiveStatus = resolveFederationPairingStatus({
+      status: row.status,
+      expiresAt: row.expiresAt,
+      now,
+    });
+    if (effectiveStatus === "expired") {
+      await tx.federationPairingSession.update({
+        where: { id: row.id },
+        data: { status: "expired", pairingSecretEnc: null, bootstrapTokenEnc: null },
+      });
+      return { ok: false, error: "expired" };
+    }
+    if (effectiveStatus !== "pending") {
+      return { ok: false, error: "invalid_transition" };
+    }
+    const claimed = await tx.federationPairingSession.updateMany({
+      where: { id: row.id, status: "pending", expiresAt: { gt: now } },
+      data: { status: "approved", approvedAt: now, approvedByPrincipalId: input.approverPrincipalId },
+    });
+    if (claimed.count !== 1) return { ok: false, error: "invalid_transition" };
+
+    const bootstrap = options.bootstrapMaterial ?? generateFederationBootstrapToken();
+    const token = await tx.federationBootstrapToken.create({
+      data: {
+        tokenHash: bootstrap.hash,
+        prefix: bootstrap.prefix,
+        offeredRole: "same-org-peer",
+        proposedProjection: DEMAND_PROJECTION_TEMPLATES["same-organization"],
+        issuedByPrincipalId: input.approverPrincipalId,
+        expiresAt: row.expiresAt,
+      },
+    });
+    await tx.federationPairingSession.update({
+      where: { id: row.id },
+      data: {
+        status: "approved",
+        bootstrapTokenId: token.id,
+        bootstrapTokenEnc: encryptSecret(bootstrap.plaintext),
+      },
+    });
+    return { ok: true, status: "approved" };
+  });
+}
+
+export type PollIncomingPairingResult =
+  | { ok: true; status: "pending" | "denied" | "expired" | "consumed" }
+  | { ok: true; status: "approved"; bootstrapToken: string }
+  | { ok: false; error: "not_found" | "credential_unavailable" };
+
+export async function pollIncomingNearbyPairing(
+  input: { pairingId: string; pairingSecret: string },
+  options: {
+    db?: PollDb;
+    now?: Date;
+    decryptSecret?: (value: string) => string | null;
+  } = {},
+): Promise<PollIncomingPairingResult> {
+  const db = options.db ?? (prisma as unknown as PollDb);
+  const now = options.now ?? new Date();
+  const row = await db.federationPairingSession.findUnique({
+    where: { pairingId: input.pairingId },
+    include: { bootstrapToken: true },
+  });
+  if (
+    !row ||
+    row.direction !== "incoming" ||
+    !row.pairingSecretHash ||
+    !pairingSecretMatches(input.pairingSecret, row.pairingSecretHash) ||
+    !isFederationPairingStatus(row.status)
+  ) {
+    return { ok: false, error: "not_found" };
+  }
+  const status = resolveFederationPairingStatus({ status: row.status, expiresAt: row.expiresAt, now });
+  if (status === "expired") {
+    await db.federationPairingSession.update({
+      where: { id: row.id },
+      data: {
+        status: "expired",
+        pairingSecretEnc: null,
+        bootstrapTokenEnc: null,
+        lastPolledAt: now,
+        pollCount: { increment: 1 },
+      },
+    });
+    return { ok: true, status: "expired" };
+  }
+  if (status === "pending" || status === "denied" || status === "consumed") {
+    await db.federationPairingSession.update({
+      where: { id: row.id },
+      data: { lastPolledAt: now, pollCount: { increment: 1 } },
+    });
+    return { ok: true, status };
+  }
+  if (
+    !row.bootstrapToken ||
+    row.bootstrapToken.consumedAt ||
+    row.bootstrapToken.revokedAt ||
+    row.bootstrapToken.expiresAt.getTime() <= now.getTime()
+  ) {
+    await db.federationPairingSession.update({
+      where: { id: row.id },
+      data: {
+        status: "consumed",
+        consumedAt: now,
+        pairingSecretEnc: null,
+        bootstrapTokenEnc: null,
+        lastPolledAt: now,
+        pollCount: { increment: 1 },
+      },
+    });
+    return { ok: true, status: "consumed" };
+  }
+  if (!row.bootstrapTokenEnc) return { ok: false, error: "credential_unavailable" };
+  const bootstrapToken = (options.decryptSecret ?? decryptStoredSecret)(row.bootstrapTokenEnc);
+  if (!bootstrapToken) return { ok: false, error: "credential_unavailable" };
+  await db.federationPairingSession.update({
+    where: { id: row.id },
+    data: {
+      deliveredAt: row.deliveredAt ?? now,
+      lastPolledAt: now,
+      pollCount: { increment: 1 },
+    },
+  });
+  return { ok: true, status: "approved", bootstrapToken };
+}
+
+export async function denyIncomingNearbyPairing(
+  input: { pairingId: string; deniedByPrincipalId: string; reason: string },
+  options: { db?: DenyDb; now?: Date } = {},
+): Promise<
+  | { ok: true; status: "denied" }
+  | { ok: false; error: "invalid_input" | "invalid_transition" }
+> {
+  const reason = input.reason.trim();
+  if (!input.pairingId.trim() || !input.deniedByPrincipalId.trim() || !reason || reason.length > 500) {
+    return { ok: false, error: "invalid_input" };
+  }
+  const now = options.now ?? new Date();
+  const result = await (
+    options.db ?? (prisma as unknown as DenyDb)
+  ).federationPairingSession.updateMany({
+    where: {
+      pairingId: input.pairingId,
+      direction: "incoming",
+      status: "pending",
+      expiresAt: { gt: now },
+    },
+    data: {
+      status: "denied",
+      deniedAt: now,
+      deniedByPrincipalId: input.deniedByPrincipalId,
+      denialReason: reason,
+      pairingSecretEnc: null,
+      bootstrapTokenEnc: null,
+    },
+  });
+  return result.count === 1
+    ? { ok: true, status: "denied" }
+    : { ok: false, error: "invalid_transition" };
+}
+
+export type { NearbyPairingRequest };

--- a/apps/web/lib/federation/nearby-pairing.test.ts
+++ b/apps/web/lib/federation/nearby-pairing.test.ts
@@ -27,13 +27,13 @@ describe("nearby federation pairing contract", () => {
     expect(
       parseNearbyPairingRequest({
         requesterAuthorityUrl: "https://dpf-a.local",
-        displayName: "Arcamanus Mac",
+        displayName: "Mac development installation",
         requesterInstallationId: `inst_${"a".repeat(32)}`,
         candidateDiscoveryId: "rotating-b-123456",
       }),
     ).toEqual({
       requesterAuthorityUrl: "https://dpf-a.local",
-      displayName: "Arcamanus Mac",
+      displayName: "Mac development installation",
       requesterInstallationId: `inst_${"a".repeat(32)}`,
       candidateDiscoveryId: "rotating-b-123456",
       relationshipPreset: "same-organization",
@@ -42,7 +42,7 @@ describe("nearby federation pairing contract", () => {
     expect(() =>
       parseNearbyPairingRequest({
         requesterAuthorityUrl: "http://dpf-a.local",
-        displayName: "Arcamanus Mac",
+        displayName: "Mac development installation",
         requesterInstallationId: `inst_${"a".repeat(32)}`,
         candidateDiscoveryId: "rotating-b-123456",
       }),
@@ -50,7 +50,7 @@ describe("nearby federation pairing contract", () => {
     expect(() =>
       parseNearbyPairingRequest({
         requesterAuthorityUrl: "https://example.com",
-        displayName: "Arcamanus Mac",
+        displayName: "Mac development installation",
         requesterInstallationId: `inst_${"a".repeat(32)}`,
         candidateDiscoveryId: "rotating-b-123456",
       }),
@@ -66,7 +66,7 @@ describe("nearby federation pairing contract", () => {
     expect(() =>
       parseNearbyPairingRequest({
         requesterAuthorityUrl: "https://dpf-a.local",
-        displayName: "Arcamanus Mac",
+        displayName: "Mac development installation",
         requesterInstallationId: "inst_not-valid",
         candidateDiscoveryId: "rotating-b-123456",
       }),
@@ -74,7 +74,7 @@ describe("nearby federation pairing contract", () => {
     expect(() =>
       parseNearbyPairingRequest({
         requesterAuthorityUrl: "https://dpf-a.local",
-        displayName: "Arcamanus Mac",
+        displayName: "Mac development installation",
         requesterInstallationId: `inst_${"a".repeat(32)}`,
         candidateDiscoveryId: "rotating-b-123456",
         backlogItem: { title: "must never cross" },
@@ -105,7 +105,7 @@ describe("nearby federation pairing contract", () => {
           pairingId: "pair_123",
           pairingSecret: `dpffpair_${"a".repeat(43)}`,
           matchingCode: "ABCD-EFGH",
-          peerDisplayName: "Arcamanus Windows",
+          peerDisplayName: "Windows development installation",
           peerInstallationId: `inst_${"b".repeat(32)}`,
           expiresAt: "2026-07-20T12:15:00.000Z",
           projectionSummary: summarizeNearbyPairingProjection(),
@@ -118,7 +118,7 @@ describe("nearby federation pairing contract", () => {
       requestNearbyPairing({
         candidateEndpoint: "https://dpf-b.local:3443",
         requesterAuthorityUrl: "https://dpf-a.local:3443",
-        displayName: "Arcamanus Mac",
+        displayName: "Mac development installation",
         requesterInstallationId: `inst_${"a".repeat(32)}`,
         candidateDiscoveryId: "rotating-b-123456",
         fetchImpl,
@@ -137,7 +137,7 @@ describe("nearby federation pairing contract", () => {
           pairingId: "pair_123",
           pairingSecret: `dpffpair_${"a".repeat(43)}`,
           matchingCode: "ABCD-EFGH",
-          peerDisplayName: "Arcamanus Windows",
+          peerDisplayName: "Windows development installation",
           peerInstallationId: `inst_${"b".repeat(32)}`,
           expiresAt: "2026-07-20T12:15:00.000Z",
           projectionSummary: {
@@ -152,7 +152,7 @@ describe("nearby federation pairing contract", () => {
       requestNearbyPairing({
         candidateEndpoint: "https://dpf-b.local:3443",
         requesterAuthorityUrl: "https://dpf-a.local:3443",
-        displayName: "Arcamanus Mac",
+        displayName: "Mac development installation",
         requesterInstallationId: `inst_${"a".repeat(32)}`,
         candidateDiscoveryId: "rotating-b-123456",
         fetchImpl,
@@ -164,7 +164,7 @@ describe("nearby federation pairing contract", () => {
       requestNearbyPairing({
         candidateEndpoint: "http://dpf-b.local:3000",
         requesterAuthorityUrl: "https://dpf-a.local:3443",
-        displayName: "Arcamanus Mac",
+        displayName: "Mac development installation",
         requesterInstallationId: `inst_${"a".repeat(32)}`,
         candidateDiscoveryId: "rotating-b-123456",
         fetchImpl,

--- a/apps/web/lib/federation/nearby-pairing.test.ts
+++ b/apps/web/lib/federation/nearby-pairing.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createNearbyPairingMaterial,
+  parseNearbyPairingRequest,
+  pairingSecretMatches,
+  pollNearbyPairingPeer,
+  requestNearbyPairing,
+  summarizeNearbyPairingProjection,
+} from "./nearby-pairing";
+
+describe("nearby federation pairing contract", () => {
+  it("creates a high-entropy bearer secret and a separate readable matching code", () => {
+    const material = createNearbyPairingMaterial({
+      randomBytes: () => Buffer.from(Array.from({ length: 32 }, (_, index) => index)),
+    });
+
+    expect(material.plaintextSecret).toMatch(/^dpffpair_[A-Za-z0-9_-]{40,}$/);
+    expect(material.secretHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(material.matchingCode).toMatch(/^[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}$/);
+    expect(material.matchingCode).not.toContain(material.plaintextSecret.slice(-8));
+    expect(pairingSecretMatches(material.plaintextSecret, material.secretHash)).toBe(true);
+    expect(pairingSecretMatches(`${material.plaintextSecret}x`, material.secretHash)).toBe(false);
+  });
+
+  it("accepts only bounded same-organization requests with link-local HTTPS authorities", () => {
+    expect(
+      parseNearbyPairingRequest({
+        requesterAuthorityUrl: "https://dpf-a.local",
+        displayName: "Arcamanus Mac",
+        requesterInstallationId: `inst_${"a".repeat(32)}`,
+        candidateDiscoveryId: "rotating-b-123456",
+      }),
+    ).toEqual({
+      requesterAuthorityUrl: "https://dpf-a.local",
+      displayName: "Arcamanus Mac",
+      requesterInstallationId: `inst_${"a".repeat(32)}`,
+      candidateDiscoveryId: "rotating-b-123456",
+      relationshipPreset: "same-organization",
+    });
+
+    expect(() =>
+      parseNearbyPairingRequest({
+        requesterAuthorityUrl: "http://dpf-a.local",
+        displayName: "Arcamanus Mac",
+        requesterInstallationId: `inst_${"a".repeat(32)}`,
+        candidateDiscoveryId: "rotating-b-123456",
+      }),
+    ).toThrow(/certificate-valid HTTPS/i);
+    expect(() =>
+      parseNearbyPairingRequest({
+        requesterAuthorityUrl: "https://example.com",
+        displayName: "Arcamanus Mac",
+        requesterInstallationId: `inst_${"a".repeat(32)}`,
+        candidateDiscoveryId: "rotating-b-123456",
+      }),
+    ).toThrow(/nearby private or local endpoint/i);
+    expect(() =>
+      parseNearbyPairingRequest({
+        requesterAuthorityUrl: "https://dpf-a.local",
+        displayName: "x".repeat(121),
+        requesterInstallationId: `inst_${"a".repeat(32)}`,
+        candidateDiscoveryId: "rotating-b-123456",
+      }),
+    ).toThrow(/display name/i);
+    expect(() =>
+      parseNearbyPairingRequest({
+        requesterAuthorityUrl: "https://dpf-a.local",
+        displayName: "Arcamanus Mac",
+        requesterInstallationId: "inst_not-valid",
+        candidateDiscoveryId: "rotating-b-123456",
+      }),
+    ).toThrow(/installation ID/i);
+    expect(() =>
+      parseNearbyPairingRequest({
+        requesterAuthorityUrl: "https://dpf-a.local",
+        displayName: "Arcamanus Mac",
+        requesterInstallationId: `inst_${"a".repeat(32)}`,
+        candidateDiscoveryId: "rotating-b-123456",
+        backlogItem: { title: "must never cross" },
+      }),
+    ).toThrow(/unknown pairing field/i);
+  });
+
+  it("derives the operator summary from the canonical same-organization projection", () => {
+    expect(summarizeNearbyPairingProjection()).toEqual({
+      relationshipLabel: "Same organization",
+      retentionClass: "standard",
+      sharedSlices: ["demand"],
+      staysLocal: [
+        "local backlog details",
+        "work capsules",
+        "private planning",
+        "attachments",
+        "customer context",
+      ],
+    });
+  });
+
+  it("exchanges a pairing request only with a certificate-valid nearby HTTPS endpoint", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          pairingId: "pair_123",
+          pairingSecret: `dpffpair_${"a".repeat(43)}`,
+          matchingCode: "ABCD-EFGH",
+          peerDisplayName: "Arcamanus Windows",
+          peerInstallationId: `inst_${"b".repeat(32)}`,
+          expiresAt: "2026-07-20T12:15:00.000Z",
+          projectionSummary: summarizeNearbyPairingProjection(),
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await expect(
+      requestNearbyPairing({
+        candidateEndpoint: "https://dpf-b.local:3443",
+        requesterAuthorityUrl: "https://dpf-a.local:3443",
+        displayName: "Arcamanus Mac",
+        requesterInstallationId: `inst_${"a".repeat(32)}`,
+        candidateDiscoveryId: "rotating-b-123456",
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({ ok: true, pairingId: "pair_123", matchingCode: "ABCD-EFGH" });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://dpf-b.local:3443/connect/pair",
+      expect.objectContaining({ method: "POST", redirect: "error" }),
+    );
+
+    fetchImpl.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          pairingId: "pair_123",
+          pairingSecret: `dpffpair_${"a".repeat(43)}`,
+          matchingCode: "ABCD-EFGH",
+          peerDisplayName: "Arcamanus Windows",
+          peerInstallationId: `inst_${"b".repeat(32)}`,
+          expiresAt: "2026-07-20T12:15:00.000Z",
+          projectionSummary: {
+            ...summarizeNearbyPairingProjection(),
+            sharedSlices: ["backlog", "customer-context"],
+          },
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      ),
+    );
+    await expect(
+      requestNearbyPairing({
+        candidateEndpoint: "https://dpf-b.local:3443",
+        requesterAuthorityUrl: "https://dpf-a.local:3443",
+        displayName: "Arcamanus Mac",
+        requesterInstallationId: `inst_${"a".repeat(32)}`,
+        candidateDiscoveryId: "rotating-b-123456",
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({ ok: false, error: "invalid_peer_response" });
+
+    fetchImpl.mockClear();
+    await expect(
+      requestNearbyPairing({
+        candidateEndpoint: "http://dpf-b.local:3000",
+        requesterAuthorityUrl: "https://dpf-a.local:3443",
+        displayName: "Arcamanus Mac",
+        requesterInstallationId: `inst_${"a".repeat(32)}`,
+        candidateDiscoveryId: "rotating-b-123456",
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({ ok: false, error: "tls_required" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("polls the same HTTPS pairing endpoint with the high-entropy secret", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({ ok: true, status: "approved", bootstrapToken: `dpffboot_${"A".repeat(39)}` }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    await expect(
+      pollNearbyPairingPeer({
+        candidateEndpoint: "https://dpf-b.local:3443",
+        pairingId: "pair_123",
+        pairingSecret: `dpffpair_${"a".repeat(43)}`,
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({ ok: true, status: "approved", bootstrapToken: expect.stringMatching(/^dpffboot_/) });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://dpf-b.local:3443/connect/pair",
+      expect.objectContaining({ method: "POST", redirect: "error" }),
+    );
+  });
+});

--- a/apps/web/lib/federation/nearby-pairing.test.ts
+++ b/apps/web/lib/federation/nearby-pairing.test.ts
@@ -55,6 +55,21 @@ describe("nearby federation pairing contract", () => {
         candidateDiscoveryId: "rotating-b-123456",
       }),
     ).toThrow(/nearby private or local endpoint/i);
+    for (const requesterAuthorityUrl of [
+      "https://dpf-a.local/connect/pair",
+      "https://operator:secret@dpf-a.local",
+      "https://dpf-a.local?mode=pair",
+      "https://dpf-a.local#pair",
+    ]) {
+      expect(() =>
+        parseNearbyPairingRequest({
+          requesterAuthorityUrl,
+          displayName: "Mac development installation",
+          requesterInstallationId: `inst_${"a".repeat(32)}`,
+          candidateDiscoveryId: "rotating-b-123456",
+        }),
+      ).toThrow(/authority URL must be an origin/i);
+    }
     expect(() =>
       parseNearbyPairingRequest({
         requesterAuthorityUrl: "https://dpf-a.local",

--- a/apps/web/lib/federation/nearby-pairing.ts
+++ b/apps/web/lib/federation/nearby-pairing.ts
@@ -1,0 +1,384 @@
+import {
+  createHash,
+  randomBytes as nodeRandomBytes,
+  timingSafeEqual,
+} from "node:crypto";
+
+import { DEMAND_PROJECTION_TEMPLATES } from "@dpf/db/federated-demand-contract";
+
+import { isLinkLocalFederationEndpoint } from "./nearby-candidates";
+
+const PAIRING_SECRET_PREFIX = "dpffpair_";
+const PAIRING_SECRET_BYTES = 32;
+const MATCHING_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const MAX_DISPLAY_NAME_LENGTH = 120;
+const MAX_DISCOVERY_ID_LENGTH = 160;
+
+export interface NearbyPairingRequest {
+  requesterAuthorityUrl: string;
+  displayName: string;
+  requesterInstallationId: string;
+  candidateDiscoveryId: string;
+  relationshipPreset: "same-organization";
+}
+
+export interface NearbyPairingProjectionSummary {
+  relationshipLabel: "Same organization";
+  retentionClass: string;
+  sharedSlices: string[];
+  staysLocal: string[];
+}
+
+export type RequestNearbyPairingResult =
+  | {
+      ok: true;
+      pairingId: string;
+      pairingSecret: string;
+      matchingCode: string;
+      peerDisplayName: string;
+      peerInstallationId: string;
+      expiresAt: string;
+      projectionSummary: NearbyPairingProjectionSummary;
+    }
+  | {
+      ok: false;
+      error: "tls_required" | "not_nearby" | "peer_unreachable" | "peer_rejected" | "invalid_peer_response";
+      message: string;
+    };
+
+function pairingSecretHash(plaintext: string): string {
+  return createHash("sha256").update(plaintext).digest("hex");
+}
+
+function encodeMatchingCode(bytes: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let encoded = "";
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5 && encoded.length < 8) {
+      encoded += MATCHING_CODE_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+    if (encoded.length === 8) break;
+  }
+  return `${encoded.slice(0, 4)}-${encoded.slice(4, 8)}`;
+}
+
+export function createNearbyPairingMaterial(options: {
+  randomBytes?: (size: number) => Buffer;
+} = {}): {
+  plaintextSecret: string;
+  secretHash: string;
+  matchingCode: string;
+} {
+  const randomBytes = options.randomBytes ?? nodeRandomBytes;
+  const entropy = randomBytes(PAIRING_SECRET_BYTES);
+  if (entropy.length !== PAIRING_SECRET_BYTES) {
+    throw new Error(`pairing entropy must contain ${PAIRING_SECRET_BYTES} bytes`);
+  }
+  const plaintextSecret = `${PAIRING_SECRET_PREFIX}${entropy.toString("base64url")}`;
+  const digest = createHash("sha256").update(entropy).digest();
+  return {
+    plaintextSecret,
+    secretHash: pairingSecretHash(plaintextSecret),
+    matchingCode: encodeMatchingCode(digest.subarray(0, 5)),
+  };
+}
+
+export function pairingSecretMatches(plaintext: string, expectedHash: string): boolean {
+  if (!plaintext.startsWith(PAIRING_SECRET_PREFIX) || !/^[a-f0-9]{64}$/.test(expectedHash)) {
+    return false;
+  }
+  const actual = Buffer.from(pairingSecretHash(plaintext), "hex");
+  const expected = Buffer.from(expectedHash, "hex");
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+function boundedString(value: unknown, label: string, maxLength: number): string {
+  if (typeof value !== "string" || value.trim().length === 0 || value.trim().length > maxLength) {
+    throw new Error(`${label} must be between 1 and ${maxLength} characters`);
+  }
+  return value.trim();
+}
+
+export function parseNearbyPairingRequest(value: unknown): NearbyPairingRequest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("pairing request must be an object");
+  }
+  const input = value as Record<string, unknown>;
+  const allowedFields = new Set([
+    "requesterAuthorityUrl",
+    "displayName",
+    "requesterInstallationId",
+    "candidateDiscoveryId",
+    "relationshipPreset",
+  ]);
+  const unknownField = Object.keys(input).find((key) => !allowedFields.has(key));
+  if (unknownField) throw new Error(`unknown pairing field: ${unknownField}`);
+  if (
+    input.relationshipPreset !== undefined &&
+    input.relationshipPreset !== "same-organization"
+  ) {
+    throw new Error("automatic nearby pairing supports only same-organization relationships");
+  }
+  const requesterAuthorityUrl = boundedString(
+    input.requesterAuthorityUrl,
+    "requester authority URL",
+    500,
+  );
+  let url: URL;
+  try {
+    url = new URL(requesterAuthorityUrl);
+  } catch {
+    throw new Error("peer authority URL is invalid");
+  }
+  if (url.protocol !== "https:") {
+    throw new Error("automatic pairing requires certificate-valid HTTPS");
+  }
+  if (!isLinkLocalFederationEndpoint(requesterAuthorityUrl)) {
+    throw new Error("automatic pairing requires a nearby private or local endpoint");
+  }
+
+  const requesterInstallationId = boundedString(
+    input.requesterInstallationId,
+    "requester installation ID",
+    MAX_DISCOVERY_ID_LENGTH,
+  );
+  if (!/^inst_[a-f0-9]{32}$/.test(requesterInstallationId)) {
+    throw new Error("requester installation ID is invalid");
+  }
+  const candidateDiscoveryId = boundedString(
+    input.candidateDiscoveryId,
+    "candidate discovery ID",
+    MAX_DISCOVERY_ID_LENGTH,
+  );
+  if (!/^[A-Za-z0-9_-]{16,64}$/.test(candidateDiscoveryId)) {
+    throw new Error("candidate discovery ID is invalid");
+  }
+
+  return {
+    requesterAuthorityUrl: requesterAuthorityUrl.replace(/\/+$/, ""),
+    displayName: boundedString(input.displayName, "display name", MAX_DISPLAY_NAME_LENGTH),
+    requesterInstallationId,
+    candidateDiscoveryId,
+    relationshipPreset: "same-organization",
+  };
+}
+
+export function summarizeNearbyPairingProjection(): NearbyPairingProjectionSummary {
+  const projection = DEMAND_PROJECTION_TEMPLATES["same-organization"];
+  return {
+    relationshipLabel: "Same organization",
+    retentionClass: projection.retentionClass ?? "standard",
+    sharedSlices: [...projection.includeSlices],
+    staysLocal: [
+      "local backlog details",
+      "work capsules",
+      "private planning",
+      "attachments",
+      "customer context",
+    ],
+  };
+}
+
+
+function isPairingStartResponse(value: unknown): value is Extract<RequestNearbyPairingResult, { ok: true }> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const row = value as Record<string, unknown>;
+  const projection = row.projectionSummary as Record<string, unknown> | null;
+  const canonicalProjection = summarizeNearbyPairingProjection();
+  const matchesCanonicalList = (actual: unknown, expected: string[]) =>
+    Array.isArray(actual) &&
+    actual.length === expected.length &&
+    actual.every((item, index) => item === expected[index]);
+  return (
+    row.ok === true &&
+    typeof row.pairingId === "string" &&
+    /^pair_[A-Za-z0-9_-]{3,160}$/.test(row.pairingId) &&
+    typeof row.pairingSecret === "string" &&
+    row.pairingSecret.startsWith(PAIRING_SECRET_PREFIX) &&
+    typeof row.matchingCode === "string" &&
+    /^[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}$/.test(row.matchingCode) &&
+    typeof row.peerDisplayName === "string" &&
+    row.peerDisplayName.length > 0 && row.peerDisplayName.length <= MAX_DISPLAY_NAME_LENGTH &&
+    typeof row.peerInstallationId === "string" &&
+    /^inst_[a-f0-9]{32}$/.test(row.peerInstallationId) &&
+    typeof row.expiresAt === "string" &&
+    !Number.isNaN(Date.parse(row.expiresAt)) &&
+    !!projection &&
+    typeof projection === "object" &&
+    !Array.isArray(projection) &&
+    projection.relationshipLabel === canonicalProjection.relationshipLabel &&
+    projection.retentionClass === canonicalProjection.retentionClass &&
+    matchesCanonicalList(projection.sharedSlices, canonicalProjection.sharedSlices) &&
+    matchesCanonicalList(projection.staysLocal, canonicalProjection.staysLocal)
+  );
+}
+
+export async function requestNearbyPairing(input: {
+  candidateEndpoint: string;
+  requesterAuthorityUrl: string;
+  displayName: string;
+  requesterInstallationId: string;
+  candidateDiscoveryId: string;
+  fetchImpl?: typeof fetch;
+}): Promise<RequestNearbyPairingResult> {
+  let candidate: URL;
+  try {
+    candidate = new URL(input.candidateEndpoint);
+  } catch {
+    return { ok: false, error: "not_nearby", message: "Nearby DPF endpoint is invalid." };
+  }
+  if (candidate.protocol !== "https:") {
+    return {
+      ok: false,
+      error: "tls_required",
+      message: "Automatic pairing requires a certificate-valid HTTPS endpoint.",
+    };
+  }
+  if (!isLinkLocalFederationEndpoint(input.candidateEndpoint)) {
+    return {
+      ok: false,
+      error: "not_nearby",
+      message: "Automatic nearby pairing is limited to private or local-network endpoints.",
+    };
+  }
+
+  let request: NearbyPairingRequest;
+  try {
+    request = parseNearbyPairingRequest({
+      requesterAuthorityUrl: input.requesterAuthorityUrl,
+      displayName: input.displayName,
+      requesterInstallationId: input.requesterInstallationId,
+      candidateDiscoveryId: input.candidateDiscoveryId,
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      error: "not_nearby",
+      message: error instanceof Error ? error.message : "Pairing request is invalid.",
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await (input.fetchImpl ?? fetch)(
+      `${candidate.href.replace(/\/+$/, "")}/connect/pair`,
+      {
+        method: "POST",
+        redirect: "error",
+        headers: { "content-type": "application/json", accept: "application/json" },
+        body: JSON.stringify({ operation: "request", ...request }),
+      },
+    );
+  } catch {
+    return {
+      ok: false,
+      error: "peer_unreachable",
+      message: "The nearby DPF could not be reached with a valid HTTPS certificate.",
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  if (!response.ok) {
+    const peerMessage = body && typeof body === "object" && !Array.isArray(body)
+      ? (body as Record<string, unknown>).message
+      : null;
+    return {
+      ok: false,
+      error: "peer_rejected",
+      message: typeof peerMessage === "string" ? peerMessage : `Nearby DPF responded ${response.status}.`,
+    };
+  }
+  if (!isPairingStartResponse(body)) {
+    return {
+      ok: false,
+      error: "invalid_peer_response",
+      message: "The nearby DPF returned an invalid pairing response.",
+    };
+  }
+  return body;
+}
+
+export type PollNearbyPairingPeerResult =
+  | { ok: true; status: "pending" | "denied" | "expired" | "consumed" }
+  | { ok: true; status: "approved"; bootstrapToken: string }
+  | { ok: false; error: "tls_required" | "not_nearby" | "peer_unreachable" | "peer_rejected" | "invalid_peer_response"; message: string };
+
+export async function pollNearbyPairingPeer(input: {
+  candidateEndpoint: string;
+  pairingId: string;
+  pairingSecret: string;
+  fetchImpl?: typeof fetch;
+}): Promise<PollNearbyPairingPeerResult> {
+  let candidate: URL;
+  try {
+    candidate = new URL(input.candidateEndpoint);
+  } catch {
+    return { ok: false, error: "not_nearby", message: "Nearby DPF endpoint is invalid." };
+  }
+  if (candidate.protocol !== "https:") {
+    return { ok: false, error: "tls_required", message: "Automatic pairing requires certificate-valid HTTPS." };
+  }
+  if (!isLinkLocalFederationEndpoint(input.candidateEndpoint)) {
+    return { ok: false, error: "not_nearby", message: "Pairing endpoint is not on the nearby private network." };
+  }
+  if (
+    !/^pair_[A-Za-z0-9_-]{3,160}$/.test(input.pairingId) ||
+    !/^dpffpair_[A-Za-z0-9_-]{40,80}$/.test(input.pairingSecret)
+  ) {
+    return { ok: false, error: "invalid_peer_response", message: "Stored pairing session is invalid." };
+  }
+  let response: Response;
+  try {
+    response = await (input.fetchImpl ?? fetch)(
+      `${candidate.href.replace(/\/+$/, "")}/connect/pair`,
+      {
+        method: "POST",
+        redirect: "error",
+        headers: { "content-type": "application/json", accept: "application/json" },
+        body: JSON.stringify({
+          operation: "poll",
+          pairingId: input.pairingId,
+          pairingSecret: input.pairingSecret,
+        }),
+      },
+    );
+  } catch {
+    return {
+      ok: false,
+      error: "peer_unreachable",
+      message: "The nearby DPF could not be reached with a valid HTTPS certificate.",
+    };
+  }
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  if (!response.ok) {
+    return { ok: false, error: "peer_rejected", message: `Nearby DPF responded ${response.status}.` };
+  }
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "invalid_peer_response", message: "Nearby DPF returned an invalid poll response." };
+  }
+  const value = body as Record<string, unknown>;
+  if (value.ok !== true || !["pending", "approved", "denied", "expired", "consumed"].includes(String(value.status))) {
+    return { ok: false, error: "invalid_peer_response", message: "Nearby DPF returned an invalid poll state." };
+  }
+  if (value.status === "approved") {
+    if (typeof value.bootstrapToken !== "string" || !value.bootstrapToken.startsWith("dpffboot_")) {
+      return { ok: false, error: "invalid_peer_response", message: "Approved pairing did not return a bootstrap token." };
+    }
+    return { ok: true, status: "approved", bootstrapToken: value.bootstrapToken };
+  }
+  return { ok: true, status: value.status as "pending" | "denied" | "expired" | "consumed" };
+}

--- a/apps/web/lib/federation/nearby-pairing.ts
+++ b/apps/web/lib/federation/nearby-pairing.ts
@@ -137,7 +137,16 @@ export function parseNearbyPairingRequest(value: unknown): NearbyPairingRequest 
   if (url.protocol !== "https:") {
     throw new Error("automatic pairing requires certificate-valid HTTPS");
   }
-  if (!isLinkLocalFederationEndpoint(requesterAuthorityUrl)) {
+  if (
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("requester authority URL must be an origin");
+  }
+  if (!isLinkLocalFederationEndpoint(url.origin)) {
     throw new Error("automatic pairing requires a nearby private or local endpoint");
   }
 
@@ -159,7 +168,7 @@ export function parseNearbyPairingRequest(value: unknown): NearbyPairingRequest 
   }
 
   return {
-    requesterAuthorityUrl: requesterAuthorityUrl.replace(/\/+$/, ""),
+    requesterAuthorityUrl: url.origin,
     displayName: boundedString(input.displayName, "display name", MAX_DISPLAY_NAME_LENGTH),
     requesterInstallationId,
     candidateDiscoveryId,

--- a/apps/web/lib/govern/data/assets.test.ts
+++ b/apps/web/lib/govern/data/assets.test.ts
@@ -118,4 +118,29 @@ describe("seeded registry", () => {
     });
     expect(member?.physical.prismaModel).toBe("FounderDemandClusterMember");
   });
+
+  it("governs nearby pairing as restricted local-only setup authority", () => {
+    const pairing = lookupAsset(DATA_ASSET_REGISTRY, "data:federation-pairing-session");
+    expect(pairing).toMatchObject({
+      physical: { prismaModel: "FederationPairingSession" },
+      sensitivity: "restricted",
+      lifecycleClass: "security-audit",
+      residencyClass: "local-only",
+      projectionClass: "metadata",
+    });
+    expect(
+      resolveField(DATA_ASSET_REGISTRY, "data:federation-pairing-session#pairingSecretEnc"),
+    ).toMatchObject({
+      collectionRule: "minimize",
+      protection: "encrypt-and-mask",
+      projectionOverride: "structure",
+    });
+    expect(
+      resolveField(DATA_ASSET_REGISTRY, "data:federation-pairing-session#bootstrapTokenEnc"),
+    ).toMatchObject({
+      collectionRule: "minimize",
+      protection: "encrypt-and-mask",
+      projectionOverride: "structure",
+    });
+  });
 });

--- a/apps/web/lib/govern/data/assets.ts
+++ b/apps/web/lib/govern/data/assets.ts
@@ -168,6 +168,60 @@ export function resolveField(
 // baseline (legacy-coverage-baseline.ts), never as a blanket "internal" default.
 
 const SEED_ASSETS: readonly DataAssetDefinition[] = [
+  {
+    id: "data:federation-pairing-session",
+    physical: { prismaModel: "FederationPairingSession" },
+    domain: "federated-demand",
+    ownerRole: "platform-owner",
+    stewardRole: "data-steward",
+    categories: ["credential-secret", "authorization", "configuration", "security-audit"],
+    sensitivity: "restricted",
+    criticality: "high",
+    subjectLocators: [],
+    lifecycleClass: "security-audit",
+    purposeCapabilities: ["service-delivery", "security-and-fraud", "platform-operations"],
+    residencyClass: "local-only",
+    projectionClass: "metadata",
+    classification: { state: "confirmed", source: "manual", effectiveFrom: "2026-07-20" },
+    fields: [
+      {
+        id: "data:federation-pairing-session#pairingSecretHash",
+        physicalName: "pairingSecretHash",
+        resolution: "governed",
+        resolutionReason:
+          "One-time incoming poll authenticator retained only as a hash and never disclosed after creation.",
+        categories: ["credential-secret", "authorization"],
+        sensitivity: "restricted",
+        collectionRule: "minimize",
+        protection: "mask-on-read",
+        projectionOverride: "structure",
+        provenance: {
+          source: "manual",
+          state: "confirmed",
+          assertedBy: "data-steward",
+          effectiveFrom: "2026-07-20",
+        },
+      },
+      ...["pairingSecretEnc", "bootstrapTokenEnc"].map((physicalName) => ({
+        id: `data:federation-pairing-session#${physicalName}` as DataFieldId,
+        physicalName,
+        resolution: "governed" as const,
+        resolutionReason:
+          "Short-lived federation bearer material encrypted through the credential-crypto boundary and cleared at terminal disposition.",
+        categories: ["credential-secret", "authorization"] as DataCategory[],
+        sensitivity: "restricted" as DataSensitivity,
+        collectionRule: "minimize" as const,
+        protection: "encrypt-and-mask" as ProtectionProfileKey,
+        projectionOverride: "structure" as ProjectionClass,
+        provenance: {
+          source: "manual" as const,
+          state: "confirmed" as const,
+          assertedBy: "data-steward",
+          effectiveFrom: "2026-07-20",
+        },
+      })),
+    ],
+  },
   ...[
     ["data:founder-demand-cluster", "FounderDemandCluster"],
     ["data:founder-demand-cluster-member", "FounderDemandClusterMember"],

--- a/docs/data-impact/2026-07-20-federation-pairing-session.data-impact.json
+++ b/docs/data-impact/2026-07-20-federation-pairing-session.data-impact.json
@@ -1,0 +1,63 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [
+    "Prisma-to-EA current-state data-model mirror",
+    "Federated Demand Network SysML projection",
+    "Connections pairing read model"
+  ],
+  "migration": {
+    "name": "20260720120000_federation_pairing_session",
+    "backfill": "none — existing manual invitations and federation links remain valid; sessions are created only by new nearby-pairing requests"
+  },
+  "tests": [
+    "packages/db/src/federation-pairing-types.test.ts",
+    "packages/db/src/federation-pairing-schema.test.ts",
+    "apps/web/lib/federation/nearby-pairing.test.ts",
+    "apps/web/lib/ea/federated-demand-architecture-extract.test.ts",
+    "apps/web/lib/govern/data/assets.test.ts",
+    "apps/web/lib/govern/data/coverage.live.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:federation-pairing-session",
+      "prismaModel": "FederationPairingSession",
+      "lifecycleDisposition": "short-lived setup authority; terminal sessions retain bounded audit metadata under federation policy, while bearer material is cleared on consumption or expiry",
+      "fields": [
+        {
+          "fieldId": "data:federation-pairing-session#pairingSecretHash",
+          "resolution": "governed",
+          "reason": "authenticates a one-time incoming poll without retaining the plaintext request secret",
+          "provenance": "federated demand network design section 5.2 durable nearby pairing session",
+          "flags": ["sensitive"],
+          "fieldPolicy": "SHA-256 hash only; plaintext is returned once over certificate-valid HTTPS and is never persisted on the receiving installation"
+        },
+        {
+          "fieldId": "data:federation-pairing-session#pairingSecretEnc",
+          "resolution": "governed",
+          "reason": "allows the requesting installation to resume an approved session after a page or process restart",
+          "provenance": "federated demand network design V-03 and governed decision DI-CE359E1CA3FB",
+          "flags": ["sensitive"],
+          "fieldPolicy": "AES-256-GCM through the existing credential-crypto boundary; cleared when the session is consumed, denied, or expires"
+        },
+        {
+          "fieldId": "data:federation-pairing-session#bootstrapTokenEnc",
+          "resolution": "governed",
+          "reason": "delivers the approved single-use enrollment authority to the requesting installation exactly once",
+          "provenance": "federated demand network design section 5.2 durable nearby pairing session",
+          "flags": ["sensitive"],
+          "fieldPolicy": "AES-256-GCM through the existing credential-crypto boundary; returned only to the authenticated pairing poll and cleared immediately after delivery"
+        },
+        {
+          "fieldId": "data:federation-pairing-session#operatorMetadata",
+          "resolution": "governed",
+          "reason": "shows both authorized operators the same bounded identity, matching code, status, and canonical projection summary",
+          "provenance": "federated demand network design V-03",
+          "flags": ["sensitive"],
+          "fieldPolicy": "installation ID, local/private authority URL, display name, rotating discovery alias, matching code, status, timestamps, and canonical projection template reference only; no backlog, customer, attachment, discussion, priority, estimate, or private planning data"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-19-federated-demand-network.md
+++ b/docs/superpowers/plans/2026-07-19-federated-demand-network.md
@@ -85,7 +85,9 @@
   component family
 - **Source truth:** expiring in-process candidate cache populated only by the
   authenticated Edge route; `EdgeNodeCapability` owns enabled/health state;
-  `FederationLink` remains the only durable trust record
+  `FederationPairingSession` owns expiring setup state;
+  `FederationBootstrapToken` remains invitation authority and `FederationLink`
+  remains the only durable trust record
 - **Empty/failure behavior:** no candidates keeps the invitation path visible;
   missing capability links to Edge Nodes; HTTP, certificate, multicast, and
   firewall failures explain why automatic setup is unavailable
@@ -107,8 +109,12 @@ existing federation/Edge runtime rather than an invented external pattern.
 
 - **Alignment:** aligned with concerns. The implementation extends the existing
   native Edge capability, `FederationBootstrapToken`, `FederationLink`,
-  principal, and projection-template substrate; it adds no competing trust
-  model, table, or migration.
+  principal, credential-crypto, and projection-template substrate. Governed
+  decision `DI-CE359E1CA3FB` selected one additive
+  `FederationPairingSession` because restart-safe one-time delivery, expiry,
+  throttling, and auditable approve/deny state do not belong on the invitation
+  authority row or the GitHub-specific OAuth device session. It adds no
+  competing identity, approval, or trust model.
 - **Allocation:** DNS-SD stays in the native Go Edge Node because Docker Desktop
   does not expose the Windows/macOS host multicast interfaces faithfully. The
   portal receives only authenticated, bounded candidate snapshots.
@@ -131,6 +137,37 @@ existing federation/Edge runtime rather than an invented external pattern.
 - **Evidence boundary:** CGO-disabled cross-compilation is source portability
   evidence, not Windows/macOS two-node functional evidence. V-01 remains open
   until both installed native services are exercised on the real LAN.
+
+### Task 2 SysML architecture note — secure nearby pairing
+
+- **Scope:** pairing behavior inside the DPF Federated Demand Network;
+  discovery, demand exchange, and trusted-link authority remain unchanged.
+- **Changed requirements/constraints:** automatic exchange requires
+  certificate-valid private/link-local HTTPS, a 256-bit one-time bearer secret,
+  a non-secret matching code, bounded expiry, explicit approve/deny, one-time
+  bootstrap retrieval, and independent link approvals.
+- **Changed interfaces/ports:** `/connect/pair` adds request and authenticated
+  poll operations; the existing Connections server actions add local
+  approve/deny and initiation operations; existing federation enrollment remains
+  the only link-creation interface.
+- **Allocations:** protocol validation and TLS client behavior live in
+  `apps/web/lib/federation`; Postgres `FederationPairingSession` owns ephemeral
+  state; `FederationBootstrapToken` owns invitation authority;
+  `FederationLink` owns relationship trust; Connections owns operator review.
+- **Verification cases:** source-local secret/code/HTTPS tests, route validation
+  and replay tests, approval/denial/expiry transition tests, invitation replay
+  rejection, Connections desktop/narrow/failure-path exercise, migration apply,
+  production build, and installed macOS↔Windows V-01/V-03 evidence.
+- **Data authority impact:** one additive ephemeral Postgres authority; nearby
+  candidate cache and UI are derived, and no local backlog data enters the
+  session.
+- **EA/current-state catch-up:** add the session data element and pairing port
+  allocation to the existing federated-demand parity projection in the same PR.
+- **Parity/extractor impact:** extend the existing federation architecture
+  source registry/projection; do not hand-maintain a separate SysML file.
+- **Open architecture risks:** local certificate provisioning and actual
+  macOS/Windows interoperability remain canonical-runtime evidence gates; an
+  HTTPS candidate with an untrusted certificate must fail closed.
 
 ## Task 3: Implement reliable demand delivery and reconciliation
 

--- a/docs/superpowers/specs/2026-07-19-federated-demand-network-design.md
+++ b/docs/superpowers/specs/2026-07-19-federated-demand-network-design.md
@@ -154,6 +154,40 @@ separately reviewed PAKE such as SPAKE2+; DPF must not invent pairing
 cryptography. This allocation was selected by governed decision
 `DI-E72BC42D5FFB` with high confidence.
 
+#### Durable nearby pairing session
+
+Automatic nearby pairing uses a federation-specific, expiring device-style
+session rather than overloading `FederationBootstrapToken` or the GitHub OAuth
+`DeviceCodeSession`. Governed decision `DI-CE359E1CA3FB` selected this shape
+with high confidence. The session is not a second trust model: it is a
+restart-safe delivery envelope around the existing bootstrap-token lifecycle.
+
+1. The requesting installation posts bounded identity and same-organization
+   intent to the discovered `/connect/pair` endpoint. The client accepts only a
+   link-local/private HTTPS origin, follows no redirects, and relies on the host
+   trust store for certificate validation.
+2. The receiving Authority Core creates a short-lived pending session, stores
+   only a hash of the 256-bit `dpffpair_*` request secret, and returns the
+   plaintext secret once with an eight-character matching code. The code is a
+   visual device-binding check, never authorization material.
+3. Both Connections views derive the same projection summary from
+   `DEMAND_PROJECTION_TEMPLATES["same-organization"]`. The receiving operator
+   approves or denies locally. Approval mints the existing single-use
+   `FederationBootstrapToken`; it does not create a trusted link.
+4. A poll authenticated by the request secret retrieves the bootstrap token
+   once. The requesting installation immediately redeems it through the
+   existing enrollment service, creating pending `FederationLink` rows on both
+   sides. Each installation still records an independent local approval before
+   either link becomes trusted.
+5. Expiry, denial, consumption, TLS failure, certificate failure, or a page
+   restart leaves no implicit trust. Manual out-of-band invitation remains
+   visible as the recovery path.
+
+Postgres is authoritative for session state. Inbound request secrets are
+hashed; replayable outbound/session credentials are encrypted at rest using the
+existing credential-crypto boundary and cleared on consumption. The route is
+bounded, throttled, one-time, and exposes no backlog data.
+
 ### 5.3 Automatic after approval
 
 For `same-organization`, the default contract offers continuous sync of share-safe platform demand and dispositions. Automatic means:
@@ -274,6 +308,7 @@ The business/channel and Hive Mind contribution paths are parallel adapters on t
 | --- | --- |
 | `FederationLink` | Peer identity, dual approval, token rotation, quarantine, revocation, relationship role |
 | `FederationBootstrapToken` | Single-use invitation and enrollment |
+| `FederationPairingSession` | Expiring pairing request, matching code, one-time bootstrap delivery, and auditable approve/deny state |
 | `ProjectionContract` | Allow-listed slices/fields, exclusions, retention, negative-egress evidence |
 | `FederatedRecordMirror` | Store minimized `recordType="demand-envelope"` projections and version/sync status |
 | `HiveContributionLedger` | Immutable audit of founder/community contribution and curation state |
@@ -286,6 +321,9 @@ Phase 1 should add no second federation identity or approval stack. Before addin
 
 The likely minimum additions are:
 
+- a durable, expiring `FederationPairingSession` tied to the existing
+  bootstrap lifecycle, with hashed inbound request secrets and encrypted
+  replayable credentials;
 - relationship preset and protocol/capability negotiation metadata on `FederationLink`;
 - a durable federation outbox/inbox receipt with idempotency, retry schedule, payload digest, acknowledgment, and dead-letter state;
 - projection-policy templates keyed by relationship preset;
@@ -458,6 +496,10 @@ The system of interest is the **DPF Federated Demand Network**, containing disco
 ### Allocations
 
 - Authority and consent allocate to `FederationLink`, `Principal`, `AuthorityBinding`, and local authenticated users.
+- Pairing transport and device-binding state allocate to
+  `FederationPairingSession`; invitation authority remains allocated to
+  `FederationBootstrapToken`, and trusted relationship state remains allocated
+  to `FederationLink`.
 - Data minimization allocates to `ProjectionContract` and the egress serializer/guard.
 - Reliable delivery allocates to the federation inbox/outbox and reconciliation worker.
 - Projected state allocates to `FederatedRecordMirror`; local execution state remains on local domain models.

--- a/docs/user-guide/platform/index.md
+++ b/docs/user-guide/platform/index.md
@@ -38,6 +38,21 @@ Open **Platform > Connections** to find nearby DPF installations or connect by i
 
 The page reports whether the native Edge Node is listening for nearby installations. If discovery is not set up, paused, or unhealthy, use the Edge Nodes link to review its authority and network status. Invitation-based setup remains available when local-network discovery cannot be used.
 
+For another installation owned by the same organization, choose **Set up this
+DPF**. Automatic setup is available only when both installations advertise a
+private/local HTTPS address whose certificate is trusted by the other host.
+Confirm that both screens show the same matching code and the same **Shares / Stays
+here** summary, then approve on the receiving installation. DPF exchanges and
+redeems a short-lived invitation, but the resulting connection remains pending
+until an authorized operator independently approves the connection on both
+installations. The matching code is only a visual check; it is never a password
+or bearer credential.
+
+If the candidate uses HTTP, its certificate cannot be verified, or discovery is
+unavailable, use the invitation controls on the same page. Never bypass the TLS
+warning: issue the one-time invitation on one installation and enter it with the
+peer URL on the other.
+
 Choose the relationship preset that matches the connection:
 
 - **Same organization** for installations operated by the same company.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -18,6 +18,7 @@
     "./customer-lifecycle": "./src/customer-lifecycle.ts",
     "./trust-link-lifecycle": "./src/trust-link-lifecycle.ts",
     "./federation-link-types": "./src/federation-link-types.ts",
+    "./federation-pairing-types": "./src/federation-pairing-types.ts",
     "./federated-demand-contract": "./src/federated-demand-contract.ts",
     "./federated-channel": "./src/federated-channel.ts",
     "./founder-shared-portfolio": "./src/founder-shared-portfolio.ts",

--- a/packages/db/prisma/migrations/20260720120000_federation_pairing_session/migration.sql
+++ b/packages/db/prisma/migrations/20260720120000_federation_pairing_session/migration.sql
@@ -1,0 +1,58 @@
+-- Expiring device-style pairing transport. FederationBootstrapToken remains
+-- invitation authority; FederationLink remains relationship/trust authority.
+CREATE TABLE "FederationPairingSession" (
+    "id" TEXT NOT NULL,
+    "pairingId" TEXT NOT NULL,
+    "direction" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "relationshipPreset" TEXT NOT NULL DEFAULT 'same-organization',
+    "projectionTemplateKey" TEXT NOT NULL DEFAULT 'same-organization',
+    "matchingCode" TEXT NOT NULL,
+    "pairingSecretHash" TEXT,
+    "pairingSecretEnc" TEXT,
+    "peerAuthorityUrl" TEXT NOT NULL,
+    "peerDisplayName" TEXT NOT NULL,
+    "peerInstallationId" TEXT,
+    "candidateDiscoveryId" TEXT,
+    "bootstrapTokenId" TEXT,
+    "bootstrapTokenEnc" TEXT,
+    "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "approvedAt" TIMESTAMP(3),
+    "approvedByPrincipalId" TEXT,
+    "deniedAt" TIMESTAMP(3),
+    "deniedByPrincipalId" TEXT,
+    "denialReason" TEXT,
+    "deliveredAt" TIMESTAMP(3),
+    "consumedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "lastPolledAt" TIMESTAMP(3),
+    "pollCount" INTEGER NOT NULL DEFAULT 0,
+    "failureReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FederationPairingSession_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "FederationPairingSession_pairingId_key"
+ON "FederationPairingSession"("pairingId");
+
+CREATE UNIQUE INDEX "FederationPairingSession_pairingSecretHash_key"
+ON "FederationPairingSession"("pairingSecretHash");
+
+CREATE UNIQUE INDEX "FederationPairingSession_bootstrapTokenId_key"
+ON "FederationPairingSession"("bootstrapTokenId");
+
+CREATE INDEX "FederationPairingSession_status_expiresAt_idx"
+ON "FederationPairingSession"("status", "expiresAt");
+
+CREATE INDEX "FederationPairingSession_direction_status_idx"
+ON "FederationPairingSession"("direction", "status");
+
+CREATE INDEX "FederationPairingSession_peerInstallationId_idx"
+ON "FederationPairingSession"("peerInstallationId");
+
+ALTER TABLE "FederationPairingSession"
+ADD CONSTRAINT "FederationPairingSession_bootstrapTokenId_fkey"
+FOREIGN KEY ("bootstrapTokenId") REFERENCES "FederationBootstrapToken"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -12848,10 +12848,55 @@ model FederationBootstrapToken {
   consumedByLinkId      String?
   revokedAt             DateTime?
 
-  link FederationLink? @relation("FederationBootstrapConsumer", fields: [consumedByLinkId], references: [id])
+  link           FederationLink?           @relation("FederationBootstrapConsumer", fields: [consumedByLinkId], references: [id])
+  pairingSession FederationPairingSession?
 
   @@index([consumedByLinkId])
   @@index([expiresAt])
+}
+
+// Expiring device-style delivery envelope for nearby same-organization setup.
+// This row never creates trust: FederationBootstrapToken remains invitation
+// authority and FederationLink remains the only relationship/trust authority.
+// Incoming request secrets are hashed; replayable local credentials use the
+// existing AES-256-GCM credential-crypto boundary and are cleared at terminal
+// lifecycle points.
+model FederationPairingSession {
+  id                    String    @id @default(cuid())
+  pairingId             String    @unique
+  direction             String
+  status                String    @default("pending")
+  relationshipPreset    String    @default("same-organization")
+  projectionTemplateKey String    @default("same-organization")
+  matchingCode          String
+  pairingSecretHash     String?   @unique
+  pairingSecretEnc      String?
+  peerAuthorityUrl      String
+  peerDisplayName       String
+  peerInstallationId    String?
+  candidateDiscoveryId  String?
+  bootstrapTokenId      String?   @unique
+  bootstrapTokenEnc     String?
+  requestedAt           DateTime  @default(now())
+  approvedAt            DateTime?
+  approvedByPrincipalId String?
+  deniedAt              DateTime?
+  deniedByPrincipalId   String?
+  denialReason          String?
+  deliveredAt           DateTime?
+  consumedAt            DateTime?
+  expiresAt             DateTime
+  lastPolledAt          DateTime?
+  pollCount             Int       @default(0)
+  failureReason         String?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+
+  bootstrapToken FederationBootstrapToken? @relation(fields: [bootstrapTokenId], references: [id], onDelete: SetNull)
+
+  @@index([status, expiresAt])
+  @@index([direction, status])
+  @@index([peerInstallationId])
 }
 
 // ── EP-MSP-FEDERATION · B2 — scoped estate projection contract (BI-4F8F50FD) ──

--- a/packages/db/src/federation-pairing-schema.test.ts
+++ b/packages/db/src/federation-pairing-schema.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const schema = readFileSync(resolve(import.meta.dirname, "../prisma/schema.prisma"), "utf8");
+const migration = readFileSync(
+  resolve(
+    import.meta.dirname,
+    "../prisma/migrations/20260720120000_federation_pairing_session/migration.sql",
+  ),
+  "utf8",
+);
+
+describe("federation pairing session persistence", () => {
+  it("keeps ephemeral pairing separate from invitation and relationship authority", () => {
+    expect(schema).toContain("model FederationPairingSession {");
+    expect(schema).toMatch(
+      /model FederationPairingSession \{[\s\S]*bootstrapToken\s+FederationBootstrapToken\?\s+@relation/,
+    );
+    expect(schema).not.toContain("model FederationPairingLink {");
+  });
+
+  it("hashes incoming secrets and encrypts replayable credentials", () => {
+    expect(schema).toMatch(/model FederationPairingSession \{[\s\S]*pairingSecretHash\s+String\?\s+@unique/);
+    expect(schema).toMatch(/model FederationPairingSession \{[\s\S]*pairingSecretEnc\s+String\?/);
+    expect(schema).toMatch(/model FederationPairingSession \{[\s\S]*bootstrapTokenEnc\s+String\?/);
+    expect(schema).not.toMatch(/model FederationPairingSession \{[\s\S]*pairingSecret\s+String\s/);
+  });
+
+  it("migrates an additive table with lifecycle and expiry indexes", () => {
+    expect(migration).toContain('CREATE TABLE "FederationPairingSession"');
+    expect(migration).toContain('CREATE UNIQUE INDEX "FederationPairingSession_pairingId_key"');
+    expect(migration).toContain('CREATE INDEX "FederationPairingSession_status_expiresAt_idx"');
+    expect(migration).toContain('FOREIGN KEY ("bootstrapTokenId")');
+  });
+});

--- a/packages/db/src/federation-pairing-types.test.ts
+++ b/packages/db/src/federation-pairing-types.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FEDERATION_PAIRING_DIRECTIONS,
+  FEDERATION_PAIRING_STATUSES,
+  canTransitionFederationPairing,
+  resolveFederationPairingStatus,
+} from "./federation-pairing-types";
+
+describe("federation pairing lifecycle", () => {
+  it("keeps direction and status registries closed", () => {
+    expect(FEDERATION_PAIRING_DIRECTIONS).toEqual(["incoming", "outgoing"]);
+    expect(FEDERATION_PAIRING_STATUSES).toEqual([
+      "pending",
+      "approved",
+      "denied",
+      "consumed",
+      "expired",
+    ]);
+  });
+
+  it("permits only one-way, auditable lifecycle transitions", () => {
+    expect(canTransitionFederationPairing("pending", "approved")).toBe(true);
+    expect(canTransitionFederationPairing("pending", "denied")).toBe(true);
+    expect(canTransitionFederationPairing("approved", "consumed")).toBe(true);
+    expect(canTransitionFederationPairing("approved", "pending")).toBe(false);
+    expect(canTransitionFederationPairing("denied", "approved")).toBe(false);
+    expect(canTransitionFederationPairing("consumed", "approved")).toBe(false);
+  });
+
+  it("treats an elapsed session as expired without trusting a stale stored status", () => {
+    const now = new Date("2026-07-20T12:15:00.000Z");
+    expect(
+      resolveFederationPairingStatus({
+        status: "pending",
+        expiresAt: new Date("2026-07-20T12:14:59.999Z"),
+        now,
+      }),
+    ).toBe("expired");
+    expect(
+      resolveFederationPairingStatus({
+        status: "approved",
+        expiresAt: new Date("2026-07-20T12:15:00.001Z"),
+        now,
+      }),
+    ).toBe("approved");
+    expect(
+      resolveFederationPairingStatus({
+        status: "consumed",
+        expiresAt: new Date("2026-07-20T12:14:00.000Z"),
+        now,
+      }),
+    ).toBe("consumed");
+  });
+});

--- a/packages/db/src/federation-pairing-types.ts
+++ b/packages/db/src/federation-pairing-types.ts
@@ -1,0 +1,47 @@
+export const FEDERATION_PAIRING_DIRECTIONS = ["incoming", "outgoing"] as const;
+export type FederationPairingDirection = (typeof FEDERATION_PAIRING_DIRECTIONS)[number];
+
+export const FEDERATION_PAIRING_STATUSES = [
+  "pending",
+  "approved",
+  "denied",
+  "consumed",
+  "expired",
+] as const;
+export type FederationPairingStatus = (typeof FEDERATION_PAIRING_STATUSES)[number];
+
+const PAIRING_TRANSITIONS: Record<FederationPairingStatus, readonly FederationPairingStatus[]> = {
+  pending: ["pending", "approved", "denied", "expired"],
+  approved: ["approved", "consumed", "expired"],
+  denied: ["denied"],
+  consumed: ["consumed"],
+  expired: ["expired"],
+};
+
+export function isFederationPairingDirection(value: unknown): value is FederationPairingDirection {
+  return (FEDERATION_PAIRING_DIRECTIONS as readonly unknown[]).includes(value);
+}
+
+export function isFederationPairingStatus(value: unknown): value is FederationPairingStatus {
+  return (FEDERATION_PAIRING_STATUSES as readonly unknown[]).includes(value);
+}
+
+export function canTransitionFederationPairing(
+  from: FederationPairingStatus,
+  to: FederationPairingStatus,
+): boolean {
+  return PAIRING_TRANSITIONS[from].includes(to);
+}
+
+export function resolveFederationPairingStatus(input: {
+  status: FederationPairingStatus;
+  expiresAt: Date;
+  now?: Date;
+}): FederationPairingStatus {
+  if (input.status === "denied" || input.status === "consumed" || input.status === "expired") {
+    return input.status;
+  }
+  return input.expiresAt.getTime() <= (input.now ?? new Date()).getTime()
+    ? "expired"
+    : input.status;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -194,6 +194,16 @@ export {
   type FederationRole,
 } from "./federation-link-types";
 export {
+  FEDERATION_PAIRING_DIRECTIONS,
+  FEDERATION_PAIRING_STATUSES,
+  canTransitionFederationPairing,
+  isFederationPairingDirection,
+  isFederationPairingStatus,
+  resolveFederationPairingStatus,
+  type FederationPairingDirection,
+  type FederationPairingStatus,
+} from "./federation-pairing-types";
+export {
   DEMAND_ACTIVITIES,
   DEMAND_ATTRIBUTIONS,
   DEMAND_AUDIENCES,

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -1,11 +1,9 @@
 {
   "changeRationale": {
-    "defaultRequiredServiceCount": "Capability-owned services moved behind deterministic Compose profiles; only PostgreSQL, portal initialization, and portal remain universal core.",
-    "prismaModelCount": "Five Founder Hub partner-business models separate reseller account standing, agreements, offering entitlements, support routing, and contribution recognition; two shared-portfolio models preserve founder clustering and deduplicated origin membership while the existing mirror, backlog, and Hive records remain authoritative.",
-    "serviceCount": "Linux Ollama is now explicitly catalogued as a host-specific runtime:external-ai service instead of remaining an ungoverned overlay-only container."
+    "prismaModelCount": "One short-lived FederationPairingSession adds the durable, resumable same-LAN handshake selected by DI-CE359E1CA3FB while reusing FederationBootstrapToken, enrollment, projection, and FederationLink approval substrate."
   },
-  "generatedAt": "2026-07-20T07:25:00.000Z",
-  "gitSha": "b3bebf2cbdf44829da703f3217637c3c44ff1107",
+  "generatedAt": "2026-07-20T10:01:44.811Z",
+  "gitSha": "cbd3c56bf79902428b6dcfc83a93394feeff9185",
   "manifestVersion": 2,
   "metrics": {
     "defaultRequiredServiceCount": {
@@ -22,11 +20,11 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 520
+      "value": 521
     },
     "prismaSchemaLines": {
       "direction": "informational",
-      "value": 14269
+      "value": 14325
     },
     "productionModuleHotspotCount": {
       "direction": "non-increasing",
@@ -38,7 +36,7 @@
     },
     "seedCoordinatorLines": {
       "direction": "informational",
-      "value": 2716
+      "value": 2727
     },
     "serviceCount": {
       "direction": "non-increasing",


### PR DESCRIPTION
## Summary
- turn privacy-safe same-LAN discovery into an automatic pairing request without exposing invitation tokens to operators
- require certificate-valid private/link-local HTTPS, matching codes, canonical projection summaries, and explicit approval on both installations
- preserve manual invitations as the fallback and keep each installation's backlog, work capsules, private planning, attachments, and customer context local

## Design grounding
Implements the remaining automatic-exchange portion of BI-52D34506 under EP-DELIVERY-FLOW, grounded in `docs/superpowers/specs/2026-07-19-federated-demand-network-design.md` and its implementation plan.

The design reuses the existing `FederationBootstrapToken`, enrollment flow, discovery candidates, projection contract, and independent `FederationLink` approvals. A durable, short-lived `FederationPairingSession` adds only the resumable handshake seam selected by governed decision DI-CE359E1CA3FB; certificate-valid HTTPS was selected by DI-E72BC42D5FFB.

## Security and privacy
- stores incoming request secrets as SHA-256 hashes and outgoing resumable secrets with AES-256-GCM credential encryption
- delivers the single-use bootstrap authority only to the authenticated poller and clears bearer material at terminal disposition
- rejects public, non-HTTPS, redirected, expired, replayed, malformed, and broader-than-canonical projection exchanges
- rate-limits request and poll traffic independently
- registers the session as restricted, local-only security data with explicit minimized bearer-field policies

## Verification
- Exact head: `6f341203646dab888d07424ef77ce31b6bd4fedb`
- Local-CI lease `NPEL-4B12FF40A8`, merged over `origin/main@8a8a0db83db40d809834750c7a4b36b2db4446d0`
- Prisma generate and all 419 migrations passed, including `20260720120000_federation_pairing_session`
- Full web Vitest suite, web typecheck, and production Next build passed
- Repository guards pass with generic installation identities and an explicit 520→521 substrate-budget rationale
- CodeQL high-severity alert resolved by accepting only credential-free authority origins and replacing uncontrolled-input regex normalization with parsed `URL.origin`
- Focused pairing, route, action, component, database schema/type, EA projection, data registry, and live coverage tests passed
- Governed UX lease `NPEL-F64A656966` exercised `/platform/federation-links` on the production bundle: peer identity, matching code, expiry, shared demand scope, explicit local-only exclusions, confirmation dialog, successful approval, approving-principal attribution, and encrypted bootstrap authority were verified

## Related Epic / backlog
Parent: EP-DELIVERY-FLOW
This PR covers: BI-52D34506 automatic secure invitation exchange and operator approval portion

The final installed Mac-to-Windows acceptance run remains post-merge evidence; this PR does not claim that cross-host deployment result before the code is available to both installations.

## Overlap sweep
`gh pr list --state open --limit 50` returned no open PRs immediately before initial push.

## Documentation impact
Updated the federated-demand network design and plan, the Platform Connections user guide, the SysML/EA projection, and the data-impact manifest.

UX-Fit-Decision: extend the existing Platform > Connections workspace; no new operator route
Data-Impact: additive short-lived FederationPairingSession with restricted local-only governance and an immutable additive migration
Local-CI-Evidence: NPEL-4B12FF40A8 passed for 6f341203646dab888d07424ef77ce31b6bd4fedb
Docs-Impact-Decision: Updated the governing federation design, implementation plan, Platform Connections user guide, EA projection, and data-impact manifest.