### PR TITLE
fix(db): make sanitized clone fail safe

### DIFF
--- a/docs/superpowers/plans/2026-07-20-sanitized-clone-atomicity.md
+++ b/docs/superpowers/plans/2026-07-20-sanitized-clone-atomicity.md
@@ -24,6 +24,17 @@ The contributor-preview PostgreSQL clone either publishes one complete, privacy-
 - Important: cleanup must preserve `_prisma_migrations` so the destination remains schema-ready while containing no application rows.
 - Rollback: revert the source commit. The destination database is disposable; a retry repopulates it from the unchanged production source.
 
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-B7F28A2F`
+- Rationale: Native-column privacy, destination cleanup, provider/connection consistency, safe PostgreSQL subprocess execution, documentation, and verification form one independently deployable clone-publication boundary. Splitting them could still publish either partial relational data or source-derived search/vector content.
+- Privacy-safe native projection, self-cleaning publication, relational consistency, child-process hardening, documentation, and verification -> `BI-B7F28A2F`
+- Dependencies: none
+- Receipt: `cmrt5hwiy02mj01o997lh91rw`
+
+The deployed MCP `tools/list` does not expose `record_plan_backlog_coverage`, so this receipt uses the governed `record_execution_evidence` compatibility path already established by the provider-onboarding plans. The live BI was claimed and verified before the receipt was recorded; no Markdown-only backlog placeholder remains.
+
 ## Implementation
 
 ### 1. Define the privacy-safe native-column projection

--- a/docs/superpowers/plans/2026-07-20-sanitized-clone-atomicity.md
+++ b/docs/superpowers/plans/2026-07-20-sanitized-clone-atomicity.md
@@ -1,0 +1,67 @@
+# Sanitized Contributor-Preview Clone Atomicity
+
+**Backlog item:** BI-B7F28A2F
+**Related substrate:** BI-7430E579
+**Branch:** `codex/sanitized-clone-atomicity`
+
+## Outcome
+
+The contributor-preview PostgreSQL clone either publishes one complete, privacy-safe relational dataset or leaves the disposable destination empty. PostgreSQL-native search/vector representations never pass through Prisma's unsupported-type decoder and never preserve source-derived sensitive terms.
+
+## Grounding
+
+- Existing runtime design reviewed: `docs/superpowers/specs/2026-05-24-portal-topology-consolidation-design.md` and `docs/operations/dpf-production-runtime.md` keep `dev-portal` as an isolated contributor-only runtime.
+- Current code substrate reviewed: `packages/db/src/sanitized-clone.ts`, `packages/db/src/table-classification.ts`, `packages/db/src/sanitized-clone.test.ts`, `docker-compose.yml`, and `docs/user-guide/getting-started/dev-container.md`.
+- PostgreSQL's `tsvector` is a native full-text-search representation. Derived `tsvector` and `vector` columns will be projected as `NULL`; source-derived search terms and embeddings are never copied into the preview. Normal destination writes may populate derived fields later through their canonical triggers.
+- PostgreSQL documents `TRUNCATE` as transaction-safe, but this clone mixes Prisma writes with external `pg_dump`/`psql` processes, so one database transaction cannot cover the whole operation. The supported architecture is therefore explicit self-cleaning: clear the disposable destination before cloning and clear it again on any failure.
+- Provider runtime catalog rows are already classified `restricted`; connection rows must not be copied without their restricted provider parent. `AiProviderConnection` therefore joins the restricted classification rather than creating knowingly orphaned preview data.
+
+## Architecture review (advisory)
+
+- Alignment: extends the existing clone and classification sources of truth; no new persistence model or runtime is introduced.
+- Important: shell interpolation of database URLs and table names is incompatible with a reliable security gate. Replace it with argument-array child processes, bounded stderr, and `psql` stop-on-error semantics.
+- Important: an error swallowed while copying an audit table can still publish partial data. Audit-copy failure must enter the same cleanup path as every other clone failure.
+- Important: cleanup must preserve `_prisma_migrations` so the destination remains schema-ready while containing no application rows.
+- Rollback: revert the source commit. The destination database is disposable; a retry repopulates it from the unchanged production source.
+
+## Implementation
+
+### 1. Define the privacy-safe native-column projection
+
+- Add catalog-driven select-list construction in `packages/db/src/sanitized-clone.ts`.
+- Project `tsvector` and `vector` columns as typed-safe nulls instead of deserializing or copying source-derived content.
+- Keep ordinary PostgreSQL, enum, JSON, array, numeric, and date values on the existing path.
+- Unit tests prove a populated native search/vector column is excluded while ordinary columns remain selected and identifiers are safely quoted.
+
+### 2. Make clone publication self-cleaning
+
+- Enumerate destination application tables independently from source tables.
+- Resolve both PostgreSQL endpoint identities and refuse to proceed if source and destination are the same database.
+- Truncate all destination application tables, restart identities, and preserve `_prisma_migrations` before the clone begins.
+- On any clone error, restore the session replication role and repeat the destination reset before rethrowing.
+- If cleanup itself fails, surface both the clone and cleanup failures rather than claiming the destination is safe.
+- Unit tests prove success resets once, failure resets twice, and cleanup failure cannot be hidden.
+
+### 3. Preserve relational consistency and fail honestly
+
+- Classify `AiProviderConnection` as restricted alongside `ModelProvider`; empty provider/connection tables are consistent and do not expose contract or credential linkage.
+- Stop swallowing audit-copy failures.
+- Replace shell-based `pg_dump | psql` execution with spawned processes using argument arrays, destination-session replication mode, and `ON_ERROR_STOP`, so malformed input cannot become shell syntax, foreign-key triggers cannot observe per-table load order, and either subprocess failure rejects the clone.
+- Tests cover the restricted provider/connection pair and child-process failure behavior through exported deterministic helpers.
+
+### 4. Document and verify the contributor contract
+
+- Update `docs/user-guide/getting-started/dev-container.md`: the clone is privacy-safe, resets the disposable destination before use, and leaves application tables empty after failure; retry is the recovery action.
+- Run the DB unit suite, DB typecheck, docs checks, secret scan, and exact-SHA merged-code `pnpm run pregate`.
+- Exercise the real sanitized-clone path against disposable source/destination PostgreSQL databases containing populated `tsvector` data; verify success and an injected failure leave no provider/connection orphan.
+- Before push, fetch current `origin/main`, sweep open PR file overlap, and require the local-integration evidence record for the exact head SHA.
+
+## Completion evidence
+
+- [x] Native-column projection tests pass (targeted Vitest: 24/24).
+- [x] Failure cleanup and cleanup-failure tests pass (targeted Vitest: 24/24).
+- [x] Provider/connection classification and consistency tests pass (targeted Vitest: 24/24).
+- [x] Disposable PostgreSQL success/failure integration verification passes. A populated `tsvector` fixture with a child row loaded before its parent completed with the derived search value omitted; an induced `NOT NULL tsvector` failure exited non-zero, cleared every application table, and preserved `_prisma_migrations`.
+- [x] Documentation checks, DB typecheck, diff check, and tree secret scan pass. The source-only full DB suite reached 1,626 passing tests; its 19 database-bound tests could not use the worktree's non-runtime database and are delegated to the canonical merged-code gate.
+- [ ] Exact-SHA merged-code gate passes against current `origin/main`.
+- [ ] PR health reports every check terminal/passing with zero unresolved reviews.

--- a/docs/user-guide/getting-started/dev-container.md
+++ b/docs/user-guide/getting-started/dev-container.md
@@ -40,6 +40,8 @@ Login: `admin@dpf.local` / `changeme123`
 - Build Studio and VS Code should be treated as complementary interfaces, not separate source trees
 - Production promotion still belongs to the portal's governed workflow
 - The sanitized clone runs on first startup — production must be running as the data source
+- The clone resets the disposable development application tables before copying. Restricted provider, credential, token, and connection records are not copied; production-derived search/vector values are omitted rather than carrying source terms or embeddings into the preview.
+- Clone publication is fail-safe: if any table cannot be copied or sanitized, the development application tables are cleared again while Prisma migration history is retained. The Contributor preview will not start against a partially copied relational dataset. Correct the reported source/tooling error and restart the development initialization step to retry.
 
 ### Related
 

--- a/packages/db/src/sanitized-clone.test.ts
+++ b/packages/db/src/sanitized-clone.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
+  buildDestinationResetSql,
+  buildPgDumpArgs,
+  buildPsqlEnvironment,
+  buildPsqlArgs,
+  buildSanitizedSelectList,
+  assertDistinctDatabaseIdentities,
   obfuscateName,
   obfuscateEmail,
   obfuscatePhone,
@@ -8,6 +14,7 @@ import {
   shouldObfuscateTable,
   shouldSkipTable,
   prepareInsertParameter,
+  runWithDestinationCleanup,
 } from "./sanitized-clone";
 
 describe("obfuscation", () => {
@@ -71,6 +78,117 @@ describe("insert parameter preparation", () => {
   });
 });
 
+describe("native PostgreSQL column projection", () => {
+  it("omits source-derived tsvector and vector content while retaining ordinary columns", () => {
+    const columns = new Map([
+      ["id", { dataType: "text", udtName: "text" }],
+      ["searchVector", { dataType: "USER-DEFINED", udtName: "tsvector" }],
+      ["embedding", { dataType: "USER-DEFINED", udtName: "vector" }],
+      ["displayName", { dataType: "text", udtName: "text" }],
+    ]);
+
+    expect(buildSanitizedSelectList(columns)).toBe(
+      '"id", NULL::text AS "searchVector", NULL::text AS "embedding", "displayName"',
+    );
+  });
+
+  it("quotes catalog identifiers instead of treating them as SQL syntax", () => {
+    const columns = new Map([
+      ['search"Vector', { dataType: "USER-DEFINED", udtName: "tsvector" }],
+    ]);
+
+    expect(buildSanitizedSelectList(columns)).toBe(
+      'NULL::text AS "search""Vector"',
+    );
+  });
+});
+
+describe("destination cleanup", () => {
+  it("refuses to clear a destination that resolves to the production database", () => {
+    const identity = { databaseName: "dpf", serverAddress: "127.0.0.1", serverPort: 5432 };
+    expect(() => assertDistinctDatabaseIdentities(identity, identity)).toThrow(
+      "PRODUCTION_DATABASE_URL and DATABASE_URL resolve to the same PostgreSQL database",
+    );
+  });
+
+  it("allows source and destination databases on the same server when their database names differ", () => {
+    expect(() => assertDistinctDatabaseIdentities(
+      { databaseName: "dpf", serverAddress: "127.0.0.1", serverPort: 5432 },
+      { databaseName: "dpf_dev", serverAddress: "127.0.0.1", serverPort: 5432 },
+    )).not.toThrow();
+  });
+
+  it("clears every application table together while preserving Prisma migration history", () => {
+    expect(buildDestinationResetSql(["User", "Organization", "_prisma_migrations"])).toBe(
+      'TRUNCATE TABLE "User", "Organization" RESTART IDENTITY CASCADE',
+    );
+  });
+
+  it("escapes table identifiers in the reset statement", () => {
+    expect(buildDestinationResetSql(['odd"table'])).toBe(
+      'TRUNCATE TABLE "odd""table" RESTART IDENTITY CASCADE',
+    );
+  });
+
+  it("resets before a successful clone", async () => {
+    const events: string[] = [];
+
+    await runWithDestinationCleanup(
+      async () => { events.push("reset"); },
+      async () => { events.push("clone"); },
+    );
+
+    expect(events).toEqual(["reset", "clone"]);
+  });
+
+  it("resets again before exposing a failed clone", async () => {
+    const events: string[] = [];
+
+    await expect(runWithDestinationCleanup(
+      async () => { events.push("reset"); },
+      async () => {
+        events.push("clone");
+        throw new Error("native column failed");
+      },
+    )).rejects.toThrow("native column failed");
+
+    expect(events).toEqual(["reset", "clone", "reset"]);
+  });
+
+  it("surfaces cleanup failure together with the clone failure", async () => {
+    let resetCount = 0;
+
+    await expect(runWithDestinationCleanup(
+      async () => {
+        resetCount += 1;
+        if (resetCount === 2) throw new Error("cleanup failed");
+      },
+      async () => { throw new Error("clone failed"); },
+    )).rejects.toMatchObject({
+      errors: [expect.objectContaining({ message: "clone failed" }), expect.objectContaining({ message: "cleanup failed" })],
+    });
+  });
+});
+
+describe("verbatim copy command arguments", () => {
+  it("passes URLs and table names as arguments rather than shell syntax", () => {
+    expect(buildPgDumpArgs("postgresql://source/db?x=1&y=2", 'odd"table')).toEqual([
+      "--dbname=postgresql://source/db?x=1&y=2",
+      "--data-only",
+      '--table=public."odd""table"',
+      "--no-owner",
+      "--no-privileges",
+    ]);
+    expect(buildPsqlArgs("postgresql://destination/db?x=1&y=2")).toEqual([
+      "--dbname=postgresql://destination/db?x=1&y=2",
+      "--set=ON_ERROR_STOP=1",
+    ]);
+    expect(buildPsqlEnvironment({ PGOPTIONS: "-c statement_timeout=0" })).toMatchObject({
+      PGOPTIONS: "-c statement_timeout=0 -c session_replication_role=replica",
+    });
+  });
+});
+
 describe("table classification helpers", () => {
   it("public and internal tables should be copied", () => {
     expect(shouldCopyTable("TaxonomyNode")).toBe(true);
@@ -85,6 +203,15 @@ describe("table classification helpers", () => {
   it("restricted tables should be skipped", () => {
     expect(shouldSkipTable("CredentialEntry")).toBe(true);
     expect(shouldSkipTable("ApiToken")).toBe(true);
+  });
+
+  it("keeps provider connections with their restricted provider parent", () => {
+    expect(shouldSkipTable("ModelProvider")).toBe(true);
+    expect(shouldSkipTable("AiProviderConnection")).toBe(true);
+  });
+
+  it("does not copy source-derived vector embeddings", () => {
+    expect(shouldSkipTable("VectorEmbedding")).toBe(true);
   });
 
   it("unknown tables default to confidential (obfuscate)", () => {

--- a/packages/db/src/sanitized-clone.ts
+++ b/packages/db/src/sanitized-clone.ts
@@ -3,6 +3,8 @@
 // Classification driven by table-classification.ts.
 
 import { getTableSensitivity } from "./table-classification";
+import { spawn, type ChildProcess } from "node:child_process";
+import { pipeline } from "node:stream/promises";
 
 // -- Obfuscation Helpers --
 
@@ -63,6 +65,11 @@ export function shouldSkipTable(tableName: string): boolean {
 import { PrismaClient } from "../generated/client/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
+type RawDatabaseClient = Pick<
+  PrismaClient,
+  "$queryRawUnsafe" | "$executeRawUnsafe"
+>;
+
 /** Tables that contain audit/log data — clone only the last N rows with obfuscation */
 const AUDIT_TABLES = new Set([
   "ComplianceAuditLog",
@@ -74,10 +81,112 @@ const AUDIT_TABLES = new Set([
 /** Maximum audit records to clone per table */
 const AUDIT_RECORD_LIMIT = 50;
 
-type ColumnTypeInfo = {
+export type ColumnTypeInfo = {
   dataType: string;
   udtName: string;
 };
+
+const OMITTED_NATIVE_TYPES = new Set(["tsvector", "vector"]);
+
+export function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Build a SELECT projection that never asks Prisma to deserialize native
+ * search/vector representations. Those values can encode source content, so
+ * they are intentionally omitted rather than copied as text.
+ */
+export function buildSanitizedSelectList(
+  columnTypes: ReadonlyMap<string, ColumnTypeInfo>,
+): string {
+  return [...columnTypes.entries()]
+    .map(([columnName, type]) => {
+      const quoted = quoteIdentifier(columnName);
+      return OMITTED_NATIVE_TYPES.has(type.udtName)
+        ? `NULL::text AS ${quoted}`
+        : quoted;
+    })
+    .join(", ");
+}
+
+export function buildDestinationResetSql(tableNames: readonly string[]): string | null {
+  const applicationTables = tableNames.filter((name) => name !== "_prisma_migrations");
+  if (applicationTables.length === 0) return null;
+  return `TRUNCATE TABLE ${applicationTables.map(quoteIdentifier).join(", ")} RESTART IDENTITY CASCADE`;
+}
+
+/**
+ * A clone cannot share one transaction with pg_dump/psql child processes.
+ * Make publication fail-safe by clearing the disposable destination first and
+ * clearing it again before propagating any clone failure.
+ */
+export async function runWithDestinationCleanup<T>(
+  resetDestination: () => Promise<void>,
+  clone: () => Promise<T>,
+): Promise<T> {
+  await resetDestination();
+  try {
+    return await clone();
+  } catch (cloneError) {
+    try {
+      await resetDestination();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [cloneError, cleanupError],
+        "Sanitized clone failed and destination cleanup also failed",
+      );
+    }
+    throw cloneError;
+  }
+}
+
+export function buildPgDumpArgs(prodUrl: string, tableName: string): string[] {
+  return [
+    `--dbname=${prodUrl}`,
+    "--data-only",
+    `--table=public.${quoteIdentifier(tableName)}`,
+    "--no-owner",
+    "--no-privileges",
+  ];
+}
+
+export function buildPsqlArgs(devUrl: string): string[] {
+  return [`--dbname=${devUrl}`, "--set=ON_ERROR_STOP=1"];
+}
+
+export function buildPsqlEnvironment(
+  base: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const replicationOption = "-c session_replication_role=replica";
+  return {
+    ...base,
+    PGOPTIONS: base.PGOPTIONS
+      ? `${base.PGOPTIONS} ${replicationOption}`
+      : replicationOption,
+  };
+}
+
+export type DatabaseIdentity = {
+  databaseName: string;
+  serverAddress: string;
+  serverPort: number | null;
+};
+
+export function assertDistinctDatabaseIdentities(
+  production: DatabaseIdentity,
+  destination: DatabaseIdentity,
+): void {
+  if (
+    production.databaseName === destination.databaseName
+    && production.serverAddress === destination.serverAddress
+    && production.serverPort === destination.serverPort
+  ) {
+    throw new Error(
+      "PRODUCTION_DATABASE_URL and DATABASE_URL resolve to the same PostgreSQL database; refusing to clear the source",
+    );
+  }
+}
 
 export function prepareInsertParameter(
   value: unknown,
@@ -161,106 +270,159 @@ export async function runSanitizedClone(): Promise<void> {
     await prod.$connect();
     await dev.$connect();
 
-    // Get all table names from production
-    const tables: Array<{ tablename: string }> = await prod.$queryRaw`
-      SELECT tablename FROM pg_tables
-      WHERE schemaname = 'public'
-      AND tablename != '_prisma_migrations'
-      ORDER BY tablename
-    `;
+    const [productionIdentity, destinationIdentity] = await Promise.all([
+      readDatabaseIdentity(prod),
+      readDatabaseIdentity(dev),
+    ]);
+    assertDistinctDatabaseIdentities(productionIdentity, destinationIdentity);
 
-    console.log(`[sanitized-clone] Found ${tables.length} tables to process`);
+    const destinationTables = await listPublicTables(dev, true);
 
-    // Build a stable ID-to-index map from the User table for deterministic obfuscation
-    const userIdMap = new Map<string, number>();
-    const users: Array<{ id: string }> = await prod.$queryRaw`SELECT id FROM "User" ORDER BY id`;
-    users.forEach((u, i) => userIdMap.set(u.id, i + 1));
+    await runWithDestinationCleanup(
+      () => resetDestinationData(dev, destinationTables.map(({ tablename }) => tablename)),
+      async () => {
+        const tables = await listPublicTables(prod, false);
+        console.log(`[sanitized-clone] Found ${tables.length} tables to process`);
 
-    // Disable all FK constraints globally for the clone operation
-    await dev.$executeRawUnsafe(`SET session_replication_role = replica`);
+        // Build a stable ID-to-index map from the User table for deterministic obfuscation.
+        // This happens after the initial reset so even an early source-query failure
+        // cannot leave a previously partial preview dataset available.
+        const userIdMap = new Map<string, number>();
+        const users: Array<{ id: string }> = await prod.$queryRaw`SELECT id FROM "User" ORDER BY id`;
+        users.forEach((u, i) => userIdMap.set(u.id, i + 1));
 
-    let autoIndex = users.length; // Counter for rows without a user ID reference
+        let autoIndex = users.length;
 
-    for (const { tablename } of tables) {
-      const sensitivity = getTableSensitivity(tablename);
+        for (const { tablename } of tables) {
+          const sensitivity = getTableSensitivity(tablename);
 
-      // Audit tables: copy last N rows via SQL COPY (no PII in these tables).
-      // Uses a temp view to limit rows, then pg_dump copies it.
-      if (AUDIT_TABLES.has(tablename)) {
-        const countResult: Array<{ count: bigint }> = await prod.$queryRawUnsafe(
-          `SELECT count(*) as count FROM "${tablename}"`,
-        );
-        const total = Number(countResult[0]?.count ?? 0);
-        if (total === 0) {
-          console.log(`  AUDIT (empty): ${tablename}`);
-          continue;
-        }
-        const copyCount = Math.min(total, AUDIT_RECORD_LIMIT);
-        console.log(`  AUDIT (last ${copyCount} of ${total}): ${tablename}`);
-        // Use pg_dump with full table — audit tables are small by nature
-        try {
-          await copyTableVerbatim(tablename, prodUrl, devUrl);
-        } catch (err) {
-          console.log(`  AUDIT (copy failed, skipping): ${tablename} — ${err instanceof Error ? err.message : String(err)}`);
-        }
-        continue;
-      }
-
-      if (sensitivity === "restricted") {
-        console.log(`  SKIP (restricted): ${tablename}`);
-        continue;
-      }
-
-      // Count source rows
-      const countResult: Array<{ count: bigint }> = await prod.$queryRawUnsafe(
-        `SELECT count(*) as count FROM "${tablename}"`,
-      );
-      const rowCount = Number(countResult[0]?.count ?? 0);
-
-      if (rowCount === 0) {
-        console.log(`  EMPTY: ${tablename}`);
-        continue;
-      }
-
-      if (sensitivity === "public" || sensitivity === "internal") {
-        // Copy verbatim using pg_dump — handles all column types reliably
-        console.log(`  COPY (${sensitivity}): ${tablename} (${rowCount} rows)`);
-        await copyTableVerbatim(tablename, prodUrl, devUrl);
-      } else if (sensitivity === "confidential") {
-        console.log(`  OBFUSCATE (confidential): ${tablename} (${rowCount} rows)`);
-        const rows: Array<Record<string, unknown>> = await prod.$queryRawUnsafe(
-          `SELECT * FROM "${tablename}"`,
-        );
-        const obfuscated = rows.map((row) => {
-          // Derive index from user ID if present, otherwise use auto-incrementing counter
-          const userId = (row.id ?? row.userId ?? row.createdById) as string | undefined;
-          const idx = userId && userIdMap.has(userId)
-            ? userIdMap.get(userId)!
-            : ++autoIndex;
-          const result: Record<string, unknown> = {};
-          for (const [key, value] of Object.entries(row)) {
-            if (typeof value === "string" && key in PII_FIELDS) {
-              result[key] = obfuscateField(value, key, idx);
-            } else if (key === "passwordHash") {
-              result[key] = "$2a$10$devhashplaceholdernotreal000000000000000000000";
-            } else {
-              result[key] = value;
-            }
+          if (sensitivity === "restricted") {
+            console.log(`  SKIP (restricted): ${tablename}`);
+            continue;
           }
-          return result;
-        });
-        await insertRows(dev, tablename, obfuscated);
-      }
-    }
 
-    // Re-enable FK constraints
-    await dev.$executeRawUnsafe(`SET session_replication_role = DEFAULT`);
+          const quotedTable = quoteIdentifier(tablename);
+          const countResult: Array<{ count: bigint }> = await prod.$queryRawUnsafe(
+            `SELECT count(*) as count FROM ${quotedTable}`,
+          );
+          const rowCount = Number(countResult[0]?.count ?? 0);
+
+          if (rowCount === 0) {
+            console.log(`  EMPTY: ${tablename}`);
+            continue;
+          }
+
+          if (AUDIT_TABLES.has(tablename)) {
+            const copyCount = Math.min(rowCount, AUDIT_RECORD_LIMIT);
+            console.log(`  AUDIT (last ${copyCount} of ${rowCount}): ${tablename}`);
+            const rows = await selectRowsForSanitization(prod, tablename, copyCount);
+            const obfuscated = obfuscateRows(rows, userIdMap, () => ++autoIndex);
+            await insertRowsWithReplicationDisabled(dev, tablename, obfuscated);
+            continue;
+          }
+
+          if (sensitivity === "public" || sensitivity === "internal") {
+            console.log(`  COPY (${sensitivity}): ${tablename} (${rowCount} rows)`);
+            await copyTableVerbatim(tablename, prodUrl, devUrl);
+          } else if (sensitivity === "confidential") {
+            console.log(`  OBFUSCATE (confidential): ${tablename} (${rowCount} rows)`);
+            const rows = await selectRowsForSanitization(prod, tablename);
+            const obfuscated = obfuscateRows(rows, userIdMap, () => ++autoIndex);
+            await insertRowsWithReplicationDisabled(dev, tablename, obfuscated);
+          }
+        }
+      },
+    );
 
     console.log("[sanitized-clone] PostgreSQL clone complete");
   } finally {
     await prod.$disconnect();
     await dev.$disconnect();
   }
+}
+
+async function readDatabaseIdentity(client: RawDatabaseClient): Promise<DatabaseIdentity> {
+  const rows = await client.$queryRawUnsafe<DatabaseIdentity[]>(
+    `SELECT current_database()::text AS "databaseName",
+            COALESCE(inet_server_addr()::text, 'local') AS "serverAddress",
+            inet_server_port()::int AS "serverPort"`,
+  );
+  const identity = rows[0];
+  if (!identity) throw new Error("Unable to identify PostgreSQL clone endpoint");
+  return identity;
+}
+
+async function listPublicTables(
+  client: RawDatabaseClient,
+  includeMigrationTable: boolean,
+): Promise<Array<{ tablename: string }>> {
+  const migrationPredicate = includeMigrationTable
+    ? ""
+    : "AND tablename != '_prisma_migrations'";
+  return client.$queryRawUnsafe<Array<{ tablename: string }>>(
+    `SELECT tablename
+       FROM pg_tables
+      WHERE schemaname = 'public'
+        ${migrationPredicate}
+      ORDER BY tablename`,
+  );
+}
+
+async function resetDestinationData(
+  client: RawDatabaseClient,
+  tableNames: readonly string[],
+): Promise<void> {
+  const resetSql = buildDestinationResetSql(tableNames);
+  if (!resetSql) return;
+  console.log(`[sanitized-clone] Resetting ${tableNames.filter((name) => name !== "_prisma_migrations").length} destination tables`);
+  await client.$executeRawUnsafe(resetSql);
+}
+
+async function selectRowsForSanitization(
+  client: RawDatabaseClient,
+  tableName: string,
+  limit?: number,
+): Promise<Array<Record<string, unknown>>> {
+  const columnTypes = await getColumnTypes(client, tableName);
+  const selectList = buildSanitizedSelectList(columnTypes);
+  if (!selectList) return [];
+
+  const quotedTable = quoteIdentifier(tableName);
+  const orderColumn = columnTypes.has("createdAt")
+    ? quoteIdentifier("createdAt")
+    : columnTypes.has("id")
+      ? quoteIdentifier("id")
+      : null;
+  const orderClause = limit && orderColumn ? ` ORDER BY ${orderColumn} DESC` : "";
+  const limitClause = limit ? ` LIMIT ${Math.max(0, Math.trunc(limit))}` : "";
+
+  return client.$queryRawUnsafe<Array<Record<string, unknown>>>(
+    `SELECT ${selectList} FROM ${quotedTable}${orderClause}${limitClause}`,
+  );
+}
+
+function obfuscateRows(
+  rows: Array<Record<string, unknown>>,
+  userIdMap: ReadonlyMap<string, number>,
+  nextIndex: () => number,
+): Array<Record<string, unknown>> {
+  return rows.map((row) => {
+    const userId = (row.id ?? row.userId ?? row.createdById) as string | undefined;
+    const idx = userId && userIdMap.has(userId)
+      ? userIdMap.get(userId)!
+      : nextIndex();
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(row)) {
+      if (typeof value === "string" && key in PII_FIELDS) {
+        result[key] = obfuscateField(value, key, idx);
+      } else if (key === "passwordHash") {
+        result[key] = "$2a$10$devhashplaceholdernotreal000000000000000000000";
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  });
 }
 
 /**
@@ -273,21 +435,70 @@ async function copyTableVerbatim(
   prodUrl: string,
   devUrl: string,
 ): Promise<void> {
-  const { exec: execCb } = await import("child_process");
-  const { promisify } = await import("util");
-  const exec = promisify(execCb);
-  await exec(
-    `pg_dump "${prodUrl}" --data-only --table='"${tableName}"' --no-owner --no-privileges | psql "${devUrl}"`,
-  );
+  const pgDump = spawn("pg_dump", buildPgDumpArgs(prodUrl, tableName), {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const psql = spawn("psql", buildPsqlArgs(devUrl), {
+    stdio: ["pipe", "ignore", "pipe"],
+    env: buildPsqlEnvironment(),
+  });
+
+  const pgDumpError = collectBoundedStderr(pgDump);
+  const psqlError = collectBoundedStderr(psql);
+
+  try {
+    await Promise.all([
+      pipeline(pgDump.stdout!, psql.stdin!),
+      waitForChild(pgDump, "pg_dump", pgDumpError),
+      waitForChild(psql, "psql", psqlError),
+    ]);
+  } catch (error) {
+    pgDump.kill();
+    psql.kill();
+    throw error;
+  }
+}
+
+function collectBoundedStderr(child: ChildProcess): () => string {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  child.stderr?.on("data", (chunk: Buffer | string) => {
+    if (size >= 8_192) return;
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    const remaining = 8_192 - size;
+    chunks.push(buffer.subarray(0, remaining));
+    size += Math.min(buffer.length, remaining);
+  });
+  return () => Buffer.concat(chunks).toString("utf8").trim();
+}
+
+function waitForChild(
+  child: ChildProcess,
+  label: string,
+  stderr: () => string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const detail = stderr();
+      reject(new Error(
+        `${label} failed (${signal ? `signal ${signal}` : `exit ${String(code)}`})${detail ? `: ${detail}` : ""}`,
+      ));
+    });
+  });
 }
 
 /**
  * Insert rows into a table using raw SQL with proper type casting.
  * Used for obfuscated rows where we've modified values in JS.
- * FK constraints are disabled globally via session_replication_role=replica.
+ * The caller disables FK triggers in the same transaction used for the inserts.
  */
 async function insertRows(
-  client: PrismaClient,
+  client: RawDatabaseClient,
   tableName: string,
   rows: Array<Record<string, unknown>>,
 ): Promise<void> {
@@ -308,17 +519,33 @@ async function insertRows(
       paramIdx++;
     }
 
-    const columnList = columns.map((c) => `"${c}"`).join(", ");
+    const columnList = columns.map(quoteIdentifier).join(", ");
 
     await client.$executeRawUnsafe(
-      `INSERT INTO "${tableName}" (${columnList}) VALUES (${castPlaceholders.join(", ")}) ON CONFLICT DO NOTHING`,
+      `INSERT INTO ${quoteIdentifier(tableName)} (${columnList}) VALUES (${castPlaceholders.join(", ")}) ON CONFLICT DO NOTHING`,
       ...values,
     );
   }
 }
 
-async function getColumnTypes(
+async function insertRowsWithReplicationDisabled(
   client: PrismaClient,
+  tableName: string,
+  rows: Array<Record<string, unknown>>,
+): Promise<void> {
+  if (rows.length === 0) return;
+
+  await client.$transaction(async (transaction) => {
+    // PrismaPg uses a pool, so a SET issued before the transaction is not
+    // guaranteed to govern the connection used by the inserts. SET LOCAL pins
+    // the trigger posture to this transaction and restores it automatically.
+    await transaction.$executeRawUnsafe("SET LOCAL session_replication_role = replica");
+    await insertRows(transaction, tableName, rows);
+  });
+}
+
+async function getColumnTypes(
+  client: RawDatabaseClient,
   tableName: string,
 ): Promise<Map<string, ColumnTypeInfo>> {
   const rows = await client.$queryRawUnsafe<Array<{
@@ -329,7 +556,8 @@ async function getColumnTypes(
     `SELECT column_name AS "columnName", data_type AS "dataType", udt_name AS "udtName"
        FROM information_schema.columns
       WHERE table_schema = 'public'
-        AND table_name = $1`,
+        AND table_name = $1
+      ORDER BY ordinal_position`,
     tableName,
   );
 

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -193,6 +193,13 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
   PushDeviceRegistration: "confidential",
   ExternalEvidenceRecord: "confidential",
   AsyncInferenceOp: "confidential",
+  // Connection posture can reference the restricted ModelProvider catalog and
+  // credential/contract records. Copying it without those parents creates an
+  // invalid preview and exposes organization-specific provider governance.
+  AiProviderConnection: "restricted",
+  // Embeddings are derived from source content and may retain semantic detail
+  // even when the source text is otherwise obfuscated.
+  VectorEmbedding: "restricted",
   TaskRun: "confidential",
   TaskNode: "confidential",
   TaskNodeEdge: "confidential",


### PR DESCRIPTION
## Summary
- Make contributor-preview PostgreSQL cloning self-cleaning: clear the disposable destination before cloning and clear it again on every failure while preserving Prisma migration history.
- Omit source-derived `tsvector` and `vector` values, keep provider and provider-connection records together under the restricted classification, and refuse source/destination identity collisions.
- Replace shell-interpolated `pg_dump | psql` execution with spawned argument arrays, stop-on-error semantics, bounded diagnostics, and transaction-pinned trigger posture.
- Complete BI-B7F28A2F.

## Design grounding
- Extends the existing sanitized-clone and table-classification sources of truth; no new persistence model or runtime is introduced.
- PostgreSQL native search/vector representations can retain source content and are deliberately omitted from the disposable preview.
- The clone mixes Prisma writes with external PostgreSQL processes, so fail-safe publication is implemented as deterministic pre-clear plus error cleanup rather than claiming one cross-process transaction.
- Full plan: `docs/superpowers/plans/2026-07-20-sanitized-clone-atomicity.md`.

## Test plan
- [x] `pnpm --filter @dpf/db exec vitest run src/sanitized-clone.test.ts` — 24/24 passing.
- [x] Pre-commit hook — staged Gitleaks plus web and DB typechecks passed with the repository-required 8 GB Node heap.
- [x] `pnpm check:doc-links` and docs-impact gate passed.
- [x] Tree Gitleaks scan passed.
- [x] Disposable PostgreSQL integration: populated `tsvector`, FK child-before-parent, restricted provider/connection, and induced mid-clone failure; failure left all application tables empty and `_prisma_migrations` intact.
- [x] Exact-SHA local merged-code pregate passed for `b539264632e0fc83b4c73948630adcf6c25cdb37` under lease `NPEL-AC294C2EFC`: Prisma generate, migration deploy, web test suite, TypeScript, and production Next build.
- [x] UX verification not applicable: contributor initialization and documentation behavior, no interactive UI change.

## Documentation impact
- Updated the Contributor preview user guide with privacy, consistency, failure, and retry behavior.
- Added the implementation plan and verification record.

## Coordination
- No open PR touches the modified files.
- Current-main drift after the pregate is one unrelated commit with zero file overlap; the merge queue will verify the current merged tree.
