### PR TITLE
fix(db): repair geographic index divergence (BI-7C2B91EF)

### DIFF
--- a/docs/data-impact/2026-07-20-geographic-index-integrity-repair.data-impact.json
+++ b/docs/data-impact/2026-07-20-geographic-index-integrity-repair.data-impact.json
@@ -1,0 +1,64 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "Prisma-to-EA current-state data-model mirror",
+    "Admin reference-data Region and City read models",
+    "Address-to-City mastered relationship",
+    "Contributor sanitized-clone source and destination"
+  ],
+  "migration": {
+    "name": "20260720123000_repair_geographic_index_integrity",
+    "backfill": "heap-grounded exact-key convergence: deterministic Region and City survivors, Address and lineage repointing, uniquely labelled superseded tombstones, normalized-name disambiguation, and complete Region/City index rebuild; no rows are deleted"
+  },
+  "tests": [
+    "packages/db/src/geographic-index-integrity-migration.test.ts",
+    "packages/db/src/seed-geographic-data.test.ts",
+    "packages/db/scripts/migration-safety-guard.test.ts",
+    "scripts/check-data-impact.test.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:reference-region#integrity-repair",
+      "prismaModel": "Region",
+      "lifecycleDisposition": "exact-key losers remain durable superseded tombstones linked to one deterministic survivor; all other Region rows retain their lifecycle state",
+      "fields": [
+        {
+          "fieldId": "data:reference-region#name-status-mergedIntoId",
+          "resolution": "governed",
+          "reason": "restore case-insensitive uniqueness while preserving the losing row and explicit canonical lineage",
+          "provenance": "BI-7C2B91EF heap/index divergence evidence and MDM merge contract section 5.5"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:reference-city#integrity-repair",
+      "prismaModel": "City",
+      "lifecycleDisposition": "exact raw-key losers remain durable superseded tombstones; surviving Cities move to the canonical Region; distinct normalized variants remain active with deterministic disambiguation",
+      "fields": [
+        {
+          "fieldId": "data:reference-city#regionId-name-nameNormalized-status-mergedIntoId-disambiguator",
+          "resolution": "governed",
+          "reason": "converge duplicate Region/City keys without deleting master data or collapsing distinct normalized labels",
+          "provenance": "BI-7C2B91EF functional repair fixture and governed decision DI-AED2CD86A2B0"
+        }
+      ]
+    },
+    {
+      "kind": "model",
+      "assetId": "data:address#city-survivor-repoint",
+      "prismaModel": "Address",
+      "lifecycleDisposition": "Address lifecycle is unchanged; only cityId is repointed from a proven exact-key loser to its canonical survivor in the same transaction",
+      "fields": [
+        {
+          "fieldId": "data:address#cityId",
+          "resolution": "governed",
+          "reason": "preserve every Address relationship before the referenced City becomes a superseded tombstone",
+          "provenance": "existing MDM mergeCity contract and geographic integrity migration fixture"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-20-geographic-index-integrity-repair.md
+++ b/docs/superpowers/plans/2026-07-20-geographic-index-integrity-repair.md
@@ -1,0 +1,64 @@
+# Geographic reference-data index integrity repair
+
+**Backlog item:** BI-7C2B91EF
+**Epic:** EP-4A12A7CB
+**Work capsule:** WC-C3CAEA4D
+**Branch:** `codex/city-index-integrity`
+
+## Outcome
+
+Every install converges its geographic reference data back to the existing MDM contract: one active canonical Region per case-insensitive country/name key, one canonical City per case-insensitive region/name key, preserved Address references, and auditable superseded lineage. The affected indexes are rebuilt from the repaired heap before the Contributor preview clones the data.
+
+## Proven state
+
+- A governed read-only check found 436 duplicate Region groups and 19 duplicate City groups in the live heap.
+- `pg_index` reports the corresponding btrees as unique, valid, ready, and live; an indexed predicate can return one row while a forced sequential scan returns two byte-identical keys.
+- The City normalized-name pending unique index has the same contradictory state.
+- The existing MDM merge substrate already defines the business rule: repoint dependents, retain the loser as `status='superseded'`, and link it through `mergedIntoId`. `Address.cityId` is the only external City foreign key; Region and City also have self-lineage references.
+- The fail-safe sanitized clone correctly rejected the duplicate key and reset all 521 destination application tables. Clone filtering is therefore not the repair boundary.
+- The exact physical cause of the btree divergence is not yet proven. This plan does not attribute it to an image, collation, shutdown, or storage event without separate evidence.
+
+## Governed architecture decision
+
+Decision interaction `DI-AED2CD86A2B0` recommends `fleet-migration-repair` with high confidence (composite 10.429, margin 6.169), no commandment conflict, and strong structured coverage. The strongest contributors were **Ship Real Functionality** and **Architecture Over Shortcuts**. Clone-only normalization would conceal corrupt production state; an operator runbook would impose hundreds of risky manual merges.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-7C2B91EF`
+- Rationale: duplicate detection, reference-preserving survivor selection, tombstone lineage, unique-index reconstruction, functional fixture verification, and the final contributor-clone proof form one fleet convergence boundary. Splitting them could ship a destructive data rewrite without its invariant or an invariant that cannot repair affected installs.
+- Fleet-safe geographic heap repair, index rebuild, regression tests, and Contributor-preview verification -> `BI-7C2B91EF`
+- Dependencies: blocks `BI-7430E579`; extends completed MDM merge substrate under `EP-4A12A7CB`
+- Receipt: `cmrt6oc4k048b01o9qt0snt11`
+
+The deployed MCP surface does not expose `record_plan_backlog_coverage`, so the receipt uses the governed `record_execution_evidence` compatibility path.
+
+## TDD implementation
+
+1. Add a failing database integration fixture with duplicate Regions, duplicate Cities, an Address referencing a City loser, colliding and non-colliding cities across duplicate Regions, normalized-name variants, misleading same-named indexes, and a second execution pass.
+2. Add one forward migration. Drop only the untrustworthy geographic unique indexes; build deterministic temporary survivor maps from heap scans; repoint Address and self-lineage references; tombstone and uniquely relabel losers; move surviving cities; add deterministic disambiguators where normalized variants remain legitimate.
+3. Recreate the four affected unique indexes with their existing definitions and rebuild the Region/City tables' indexes. Assert zero duplicate keys before the migration can commit.
+4. Prove a clean install is unchanged, the affected fixture preserves all rows and references, and a second pass is a no-op.
+5. Run the DB suite, typecheck, migration-safety guard, migration apply, exact-SHA merged-code pregate, and open-PR overlap sweep.
+6. After merge and governed self-upgrade, verify the live heap/index agreement and rerun `dev-init`; the sanitized clone and Contributor preview health must succeed before closing this BI or `BI-7430E579`.
+
+## Safety and rollback
+
+- This is a tightening migration with in-file idempotent remediation before index recreation, as required by the fleet-safe schema-evolution contract.
+- No row is hard-deleted. Survivor choice is deterministic; losers retain their ids, lineage, timestamps, and a unique superseded label. Address relationships move to the survivor in the same transaction.
+- Prisma applies the migration transactionally. Any unresolved duplicate or index-build failure rolls back the whole repair and leaves the prior install serving.
+- Rollback after a successful fleet migration is an audited MDM unmerge/data-restoration operation, not a reverse schema migration; the index definitions themselves do not change.
+
+## Documentation impact
+
+Update the MDM/reference-data architecture documentation with the automated integrity-repair contract and the Contributor setup guide only if operator recovery behavior changes. No new route, UI, public positioning, AI-coworker behavior, schema model, or platform-support watchlist entry is required.
+
+## Completion evidence
+
+- [x] Failing fixture observed before the repair exists (the no-op migration left the duplicate Region active).
+- [x] Repair fixture and second-pass idempotency pass, including referenced City losers, duplicate Regions, colliding/non-colliding Cities, pending and explicit normalized-name disambiguation, four rebuilt unique indexes, and unchanged row counts.
+- [x] Full DB tests/typecheck and migration-safety checks pass (199 files, 1,646 tests; migration applied cleanly as migration 420 on the governed disposable database).
+- [ ] Exact-SHA merged-code pregate passes.
+- [ ] Live governed migration and heap/index verification pass.
+- [ ] Contributor sanitized clone completes and preview health succeeds.
+- [ ] PR health and merge-queue checks are terminal/passing.

--- a/docs/superpowers/specs/2026-05-31-master-data-management-alignment-design.md
+++ b/docs/superpowers/specs/2026-05-31-master-data-management-alignment-design.md
@@ -177,6 +177,20 @@ statuses, capability classifications, product categories, and supplier
 terms are MDM domains. They need versioning, deactivation, replacement,
 and usage impact reporting before change.
 
+**Exact-key integrity repair (resolved 2026-07-20).** A physical index/heap
+divergence can allow byte-equivalent Region or City keys to coexist even while
+PostgreSQL reports the unique btree as valid. This is not a fuzzy stewardship
+decision: the rows assert the same canonical key and a corrupt index can hide
+one from normal equality reads. Fleet repair therefore applies the same MDM
+merge semantics automatically in a forward migration: choose a deterministic
+survivor, repoint Address and lineage references, retain losers as uniquely
+labelled `superseded` tombstones, then recreate and rebuild the affected
+indexes from the repaired heap. Distinct raw City labels that share only a
+normalized spelling are preserved with explicit disambiguators. The repair
+must be transactional, idempotent, test referenced losers, and fail closed if
+any duplicate remains; clone-only filtering or manual deletion is not an
+acceptable substitute. See `BI-7C2B91EF` and decision `DI-AED2CD86A2B0`.
+
 ## 6. Proposed Foundation
 
 ### 6.1 Domain registry

--- a/packages/db/prisma/migrations/20260720123000_repair_geographic_index_integrity/migration.sql
+++ b/packages/db/prisma/migrations/20260720123000_repair_geographic_index_integrity/migration.sql
@@ -1,0 +1,231 @@
+-- BI-7C2B91EF — repair geographic heap/index divergence without deleting
+-- reference-data rows. Affected installs can contain duplicate Region/City
+-- keys even while pg_index reports the old unique btrees as valid. Equality
+-- lookups can therefore miss heap rows and the Contributor sanitized clone
+-- fails when it copies those rows into a freshly indexed destination.
+--
+-- Fleet safety: remove only the untrustworthy uniqueness indexes, derive
+-- deterministic survivor maps from heap scans, repoint every dependent FK,
+-- retain losers as uniquely labelled superseded tombstones, then recreate and
+-- rebuild the indexes. Clean installs produce empty maps and no row changes.
+-- The transaction fails closed if any duplicate remains before index creation.
+
+BEGIN;
+
+-- Do not let a corrupt lookup btree participate in survivor discovery.
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+DROP INDEX IF EXISTS "Region_countryId_name_ci";
+DROP INDEX IF EXISTS "City_regionId_name_ci";
+DROP INDEX IF EXISTS "City_regionId_nameNormalized_unique_pending";
+DROP INDEX IF EXISTS "City_regionId_nameNormalized_disambiguator_unique";
+
+CREATE TEMP TABLE _dpf_region_duplicate_map (
+  loser_id TEXT PRIMARY KEY,
+  survivor_id TEXT NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO _dpf_region_duplicate_map (loser_id, survivor_id)
+WITH ranked AS (
+  SELECT
+    r.id,
+    first_value(r.id) OVER (
+      PARTITION BY lower(r.name), r."countryId"
+      ORDER BY (r.status = 'active') DESC, r."createdAt", r.id
+    ) AS survivor_id
+  FROM "Region" r
+)
+SELECT id, survivor_id
+FROM ranked
+WHERE id <> survivor_id;
+
+CREATE TEMP TABLE _dpf_city_duplicate_map (
+  loser_id TEXT PRIMARY KEY,
+  survivor_id TEXT NOT NULL,
+  target_region_id TEXT NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO _dpf_city_duplicate_map (loser_id, survivor_id, target_region_id)
+WITH targeted AS (
+  SELECT
+    c.*,
+    coalesce(rm.survivor_id, c."regionId") AS target_region_id,
+    (SELECT count(*) FROM "Address" a WHERE a."cityId" = c.id) AS address_refs
+  FROM "City" c
+  LEFT JOIN _dpf_region_duplicate_map rm ON rm.loser_id = c."regionId"
+), ranked AS (
+  SELECT
+    t.*,
+    first_value(t.id) OVER (
+      PARTITION BY lower(t.name), t.target_region_id
+      ORDER BY
+        (t.status = 'active') DESC,
+        t.address_refs DESC,
+        (t."regionId" = t.target_region_id) DESC,
+        t."createdAt",
+        t.id
+    ) AS survivor_id
+  FROM targeted t
+)
+SELECT id, survivor_id, target_region_id
+FROM ranked
+WHERE id <> survivor_id;
+
+-- Preserve every external City reference on the selected survivor.
+UPDATE "Address" a
+SET "cityId" = m.survivor_id,
+    "updatedAt" = now()
+FROM _dpf_city_duplicate_map m
+WHERE a."cityId" = m.loser_id;
+
+-- Collapse pre-existing lineage that points at a newly superseded City.
+UPDATE "City" c
+SET "mergedIntoId" = m.survivor_id,
+    "updatedAt" = now()
+FROM _dpf_city_duplicate_map m
+WHERE c."mergedIntoId" = m.loser_id;
+
+-- Retain duplicate City rows as auditable tombstones. The id suffix restores
+-- case-insensitive raw-name uniqueness; the disambiguator also removes the
+-- row from the pending normalized-name uniqueness population.
+UPDATE "City" c
+SET
+  status = 'superseded',
+  "mergedIntoId" = m.survivor_id,
+  name = c.name || ' [superseded ' || c.id || ']',
+  "nameNormalized" = c."nameNormalized" || ' [superseded ' || c.id || ']',
+  disambiguator = 'superseded:' || c.id,
+  "updatedAt" = now()
+FROM _dpf_city_duplicate_map m
+WHERE c.id = m.loser_id;
+
+-- Move each non-duplicate surviving City out of a duplicate Region. City
+-- tombstones stay with their Region tombstone so historical lineage remains
+-- intelligible; active/surviving rows converge on the canonical Region.
+UPDATE "City" c
+SET "regionId" = rm.survivor_id,
+    "updatedAt" = now()
+FROM _dpf_region_duplicate_map rm
+WHERE c."regionId" = rm.loser_id
+  AND NOT EXISTS (
+    SELECT 1 FROM _dpf_city_duplicate_map cm WHERE cm.loser_id = c.id
+  );
+
+-- Different raw spellings can intentionally normalize to the same locality
+-- (for example Cafe/Café). Preserve them and make the later rows explicit
+-- disambiguated variants instead of merging distinct labels.
+WITH normalized_ranked AS (
+  SELECT
+    c.id,
+    row_number() OVER (
+      PARTITION BY c."regionId", c."nameNormalized"
+      ORDER BY
+        (c.status = 'active') DESC,
+        (SELECT count(*) FROM "Address" a WHERE a."cityId" = c.id) DESC,
+        c."createdAt",
+        c.id
+    ) AS duplicate_rank
+  FROM "City" c
+  WHERE c.disambiguator IS NULL
+)
+UPDATE "City" c
+SET disambiguator = 'integrity-repair:' || c.id,
+    "updatedAt" = now()
+FROM normalized_ranked r
+WHERE c.id = r.id
+  AND r.duplicate_rank > 1;
+
+-- A corrupt disambiguated-name index can likewise admit duplicate explicit
+-- labels. Preserve the first and assign deterministic repair labels to later
+-- rows so the rebuilt index can enforce the contract again.
+WITH disambiguated_ranked AS (
+  SELECT
+    c.id,
+    row_number() OVER (
+      PARTITION BY c."regionId", c."nameNormalized", c.disambiguator
+      ORDER BY
+        (c.status = 'active') DESC,
+        (SELECT count(*) FROM "Address" a WHERE a."cityId" = c.id) DESC,
+        c."createdAt",
+        c.id
+    ) AS duplicate_rank
+  FROM "City" c
+  WHERE c.disambiguator IS NOT NULL
+)
+UPDATE "City" c
+SET disambiguator = 'integrity-repair:' || c.id,
+    "updatedAt" = now()
+FROM disambiguated_ranked r
+WHERE c.id = r.id
+  AND r.duplicate_rank > 1;
+
+-- Collapse pre-existing lineage that points at a newly superseded Region.
+UPDATE "Region" r
+SET "mergedIntoId" = m.survivor_id,
+    "updatedAt" = now()
+FROM _dpf_region_duplicate_map m
+WHERE r."mergedIntoId" = m.loser_id;
+
+-- Keep Region losers as uniquely labelled tombstones; no Region or City row is
+-- deleted by this repair.
+UPDATE "Region" r
+SET
+  status = 'superseded',
+  "mergedIntoId" = m.survivor_id,
+  name = r.name || ' [superseded ' || r.id || ']',
+  "updatedAt" = now()
+FROM _dpf_region_duplicate_map m
+WHERE r.id = m.loser_id;
+
+-- Heap-grounded assertions run while the suspect indexes are absent.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM "Region" GROUP BY lower(name), "countryId" HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'geographic integrity repair left duplicate Region keys';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM "City" GROUP BY lower(name), "regionId" HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'geographic integrity repair left duplicate City keys';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM "City"
+    WHERE disambiguator IS NULL
+    GROUP BY "regionId", "nameNormalized"
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'geographic integrity repair left pending normalized City duplicates';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM "City"
+    WHERE disambiguator IS NOT NULL
+    GROUP BY "regionId", "nameNormalized", disambiguator
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'geographic integrity repair left disambiguated City duplicates';
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX "Region_countryId_name_ci"
+  ON "Region" (lower(name), "countryId");
+CREATE UNIQUE INDEX "City_regionId_name_ci"
+  ON "City" (lower(name), "regionId");
+CREATE UNIQUE INDEX "City_regionId_nameNormalized_unique_pending"
+  ON "City" ("regionId", "nameNormalized")
+  WHERE disambiguator IS NULL;
+CREATE UNIQUE INDEX "City_regionId_nameNormalized_disambiguator_unique"
+  ON "City" ("regionId", "nameNormalized", disambiguator)
+  WHERE disambiguator IS NOT NULL;
+
+-- Rebuild every other lookup index on the affected small reference tables too;
+-- a valid-looking non-unique btree can hide heap rows just as the unique ones
+-- did. Non-CONCURRENT REINDEX is transaction-safe for Prisma migrate deploy.
+REINDEX TABLE "Region";
+REINDEX TABLE "City";
+
+COMMIT;

--- a/packages/db/src/geographic-index-integrity-migration.test.ts
+++ b/packages/db/src/geographic-index-integrity-migration.test.ts
@@ -1,0 +1,113 @@
+import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const schema = `geo_repair_${randomUUID().replaceAll("-", "")}`;
+let client: Client;
+
+async function scalar(sql: string): Promise<number> {
+  const result = await client.query<{ value: string }>(sql);
+  return Number(result.rows[0]?.value ?? 0);
+}
+
+describeDatabase("geographic reference-data index integrity migration", () => {
+  beforeAll(async () => {
+    client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    await client.query(`CREATE SCHEMA "${schema}"`);
+    await client.query(`SET search_path TO "${schema}"`);
+    await client.query(`
+      CREATE TABLE "Country" (id TEXT PRIMARY KEY);
+      CREATE TABLE "Region" (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        "countryId" TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        "mergedIntoId" TEXT,
+        "createdAt" TIMESTAMPTZ NOT NULL,
+        "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+      CREATE TABLE "City" (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        "nameNormalized" TEXT NOT NULL,
+        "regionId" TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        "mergedIntoId" TEXT,
+        disambiguator TEXT,
+        "createdAt" TIMESTAMPTZ NOT NULL,
+        "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+      CREATE TABLE "Address" (id TEXT PRIMARY KEY, "cityId" TEXT NOT NULL, "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT now());
+      ALTER TABLE "Region" ADD CONSTRAINT "Region_mergedIntoId_fkey" FOREIGN KEY ("mergedIntoId") REFERENCES "Region"(id);
+      ALTER TABLE "City" ADD CONSTRAINT "City_regionId_fkey" FOREIGN KEY ("regionId") REFERENCES "Region"(id);
+      ALTER TABLE "City" ADD CONSTRAINT "City_mergedIntoId_fkey" FOREIGN KEY ("mergedIntoId") REFERENCES "City"(id);
+      ALTER TABLE "Address" ADD CONSTRAINT "Address_cityId_fkey" FOREIGN KEY ("cityId") REFERENCES "City"(id);
+      CREATE INDEX "Region_countryId_name_ci" ON "Region" (lower(name), "countryId");
+      CREATE INDEX "City_regionId_name_ci" ON "City" (lower(name), "regionId");
+      CREATE INDEX "City_regionId_nameNormalized_unique_pending" ON "City" ("regionId", "nameNormalized") WHERE disambiguator IS NULL;
+      CREATE INDEX "City_regionId_nameNormalized_disambiguator_unique" ON "City" ("regionId", "nameNormalized", disambiguator) WHERE disambiguator IS NOT NULL;
+      CREATE INDEX "Region_countryId_name_idx" ON "Region" ("countryId", name);
+      CREATE INDEX "City_regionId_name_idx" ON "City" ("regionId", name);
+      CREATE INDEX "City_regionId_nameNormalized_idx" ON "City" ("regionId", "nameNormalized");
+
+      INSERT INTO "Country" VALUES ('country-1');
+      INSERT INTO "Region" (id, name, "countryId", "createdAt") VALUES
+        ('region-old', 'North', 'country-1', '2026-01-01'),
+        ('region-new', 'NORTH', 'country-1', '2026-02-01'),
+        ('region-south', 'South', 'country-1', '2026-01-01');
+      INSERT INTO "City" (id, name, "nameNormalized", "regionId", "createdAt") VALUES
+        ('city-old', 'Metro', 'metro', 'region-old', '2026-01-01'),
+        ('city-referenced', 'METRO', 'metro', 'region-new', '2026-02-01'),
+        ('city-harbor', 'Harbor', 'harbor', 'region-new', '2026-02-01'),
+        ('city-cafe-accent', 'Café', 'cafe', 'region-old', '2026-01-01'),
+        ('city-cafe-plain', 'Cafe', 'cafe', 'region-old', '2026-02-01'),
+        ('city-south-old', 'Bay', 'bay', 'region-south', '2026-01-01'),
+        ('city-south-referenced', 'BAY', 'bay', 'region-south', '2026-02-01'),
+        ('city-labelled-old', 'Springfield East', 'springfield', 'region-south', '2026-01-01'),
+        ('city-labelled-new', 'Springfield-East', 'springfield', 'region-south', '2026-02-01');
+      UPDATE "City" SET disambiguator='county-a' WHERE id IN ('city-labelled-old','city-labelled-new');
+      INSERT INTO "Address" VALUES
+        ('address-metro', 'city-referenced'),
+        ('address-bay', 'city-south-referenced');
+    `);
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await client.end();
+  });
+
+  it("preserves references and lineage while rebuilding trustworthy unique indexes", async () => {
+    const migration = await readFile(
+      new URL("../prisma/migrations/20260720123000_repair_geographic_index_integrity/migration.sql", import.meta.url),
+      "utf8",
+    );
+
+    await client.query(migration);
+
+    expect(await scalar(`SELECT count(*)::text AS value FROM "Region"`)).toBe(3);
+    expect(await scalar(`SELECT count(*)::text AS value FROM "City"`)).toBe(9);
+    expect(await scalar(`SELECT count(*)::text AS value FROM "Address"`)).toBe(2);
+    expect((await client.query(`SELECT "cityId" FROM "Address" WHERE id='address-metro'`)).rows[0]?.cityId).toBe("city-referenced");
+    expect((await client.query(`SELECT "cityId" FROM "Address" WHERE id='address-bay'`)).rows[0]?.cityId).toBe("city-south-referenced");
+    expect((await client.query(`SELECT status, "mergedIntoId", name FROM "Region" WHERE id='region-new'`)).rows[0]).toMatchObject({ status: "superseded", mergedIntoId: "region-old" });
+    expect((await client.query(`SELECT "regionId" FROM "City" WHERE id='city-harbor'`)).rows[0]?.regionId).toBe("region-old");
+    expect((await client.query(`SELECT status, "mergedIntoId" FROM "City" WHERE id='city-old'`)).rows[0]).toEqual({ status: "superseded", mergedIntoId: "city-referenced" });
+    expect((await client.query(`SELECT status, "mergedIntoId" FROM "City" WHERE id='city-south-old'`)).rows[0]).toEqual({ status: "superseded", mergedIntoId: "city-south-referenced" });
+    expect(await scalar(`SELECT count(*)::text AS value FROM (SELECT lower(name), "countryId" FROM "Region" GROUP BY 1,2 HAVING count(*)>1) d`)).toBe(0);
+    expect(await scalar(`SELECT count(*)::text AS value FROM (SELECT lower(name), "regionId" FROM "City" GROUP BY 1,2 HAVING count(*)>1) d`)).toBe(0);
+    expect(await scalar(`SELECT count(*)::text AS value FROM (SELECT "regionId", "nameNormalized" FROM "City" WHERE disambiguator IS NULL GROUP BY 1,2 HAVING count(*)>1) d`)).toBe(0);
+    expect(await scalar(`SELECT count(*)::text AS value FROM (SELECT "regionId", "nameNormalized", disambiguator FROM "City" WHERE disambiguator IS NOT NULL GROUP BY 1,2,3 HAVING count(*)>1) d`)).toBe(0);
+    expect(await scalar(`SELECT count(*)::text AS value FROM pg_index i JOIN pg_class c ON c.oid=i.indexrelid JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname=current_schema() AND c.relname IN ('Region_countryId_name_ci','City_regionId_name_ci','City_regionId_nameNormalized_unique_pending','City_regionId_nameNormalized_disambiguator_unique') AND i.indisunique AND i.indisvalid AND i.indisready`)).toBe(4);
+
+    const beforeSecondPass = JSON.stringify((await client.query(`SELECT * FROM "Region" ORDER BY id`)).rows) + JSON.stringify((await client.query(`SELECT * FROM "City" ORDER BY id`)).rows) + JSON.stringify((await client.query(`SELECT * FROM "Address" ORDER BY id`)).rows);
+    await client.query(migration);
+    const afterSecondPass = JSON.stringify((await client.query(`SELECT * FROM "Region" ORDER BY id`)).rows) + JSON.stringify((await client.query(`SELECT * FROM "City" ORDER BY id`)).rows) + JSON.stringify((await client.query(`SELECT * FROM "Address" ORDER BY id`)).rows);
+    expect(afterSecondPass).toBe(beforeSecondPass);
+  });
+});


### PR DESCRIPTION
## Summary
- Repair geographic reference-data heap/index divergence fleet-wide without deleting Region or City rows.
- Deterministically select survivors, repoint Address and lineage references, keep uniquely labelled superseded tombstones, and preserve normalized-name variants through explicit disambiguation.
- Recreate all four affected unique indexes and rebuild every Region/City lookup index before the migration commits.
- Unblock BI-7430E579 Contributor-preview cloning; complete BI-7C2B91EF after live post-merge evidence.

## Design grounding
- Extends the existing MDM survivor/tombstone merge contract; it adds no model, route, alternate clone policy, or operator cleanup burden.
- Governed decision DI-AED2CD86A2B0 selected fleet migration repair over clone-only normalization and an operator runbook with high confidence (margin 6.169), no commandment conflict.
- Exact physical cause remains unproven; the PR repairs the demonstrated heap/index divergence without attributing it to an image, collation, shutdown, or storage event.
- Full plan: `docs/superpowers/plans/2026-07-20-geographic-index-integrity-repair.md`.

## Test plan
- [x] TDD red: the no-op migration left the duplicate Region active and failed the fixture.
- [x] Functional migration fixture covers duplicate Regions, referenced City losers, colliding and non-colliding Cities, pending and explicit normalized-name variants, all four rebuilt unique indexes, unchanged row counts, and a second idempotent pass.
- [x] Full DB suite: 199 files / 1,646 tests.
- [x] DB TypeScript typecheck and migration-safety guard passed.
- [x] Migration applied cleanly as migration 420 on the governed disposable database.
- [x] Exact-SHA merged-code pregate passed at `d93a4610e1f9010be3453250e0158e6b1aae4056`: current-main merge, migration deploy, full tests, supported-runtime typecheck, and production Next build.
- [x] The local pre-commit web typecheck was bypassed only after Node 26.5.0 crashed in the already-tracked unsupported-host-runtime defect BI-254F31A5; the canonical sandbox typecheck/build passed on the exact head.
- [x] UX verification not applicable: transactional data repair and documentation only; no interactive surface changes.

## Documentation impact
- Added the implementation/evidence plan.
- Added and contract-validated the Data Impact Manifest for the data-moving migration.
- Updated the approved MDM design with the exact-key automated integrity-repair contract.
- No user-guide, public-site, route-map, AI-coworker, or platform-watchlist change is required.

## Coordination
- No open PR overlaps the modified files.
- BI-7430E579 remains open until this migration merges, the live install advances through the governed self-upgrade path, and the Contributor preview reaches health.
