### PR TITLE
fix(db): bound sanitized clone transactions (BI-CD96EDD2)

### DIFF
--- a/docs/superpowers/plans/2026-07-20-sanitized-clone-transaction-scaling.md
+++ b/docs/superpowers/plans/2026-07-20-sanitized-clone-transaction-scaling.md
@@ -1,0 +1,51 @@
+# Sanitized-clone transaction scaling
+
+**Backlog item:** BI-CD96EDD2  
+**Epic:** EP-5410E8EA  
+**Work capsule:** WC-CC21ABCD  
+**Branch:** `codex/sanitized-clone-timeout`
+
+## Outcome
+
+Contributor sanitized clones must copy arbitrarily large confidential tables without depending on Prisma's five-second default interactive-transaction timeout. Inserts remain trigger-suppressed, bounded, and fail-safe: any failed chunk still causes the existing destination-wide reset before the preview can start.
+
+## Evidence and substrate
+
+- The governed BI-7430E579 preview run reached `insertRowsWithReplicationDisabled` after the geographic repair and failed with Prisma `P2028` at 5,001 ms.
+- The same run reported `ContributorInventorySnapshot` at 165,323 confidential rows. The current implementation issues one insert per row inside one interactive transaction, so a table's transaction duration grows without bound with row count.
+- `runWithDestinationCleanup` already owns publication safety and resets all 521 destination application tables after any clone failure. This change must preserve that behavior.
+- The required session-local `session_replication_role=replica` posture is already correct; each new chunk transaction must set it before inserting.
+
+## TDD plan
+
+1. Add a failing unit test that requires confidential inserts to be split into deterministic chunks.
+2. Require every chunk to open an interactive transaction with explicit bounded `maxWait` and `timeout` options and to set `session_replication_role` before row inserts.
+3. Implement the smallest reusable transaction policy around the existing insert path; do not change sensitivity classification, obfuscation, native-column omission, or destination cleanup.
+4. Run the targeted sanitized-clone suite, the full DB suite/typecheck, and an exact-SHA merged-code pregate.
+5. Re-run the governed isolated Contributor preview and prove pgvector readiness, all migrations, sanitized clone completion, and `:3001/api/health`.
+
+## Documentation impact
+
+- This is an internal clone scalability correction. The implementation plan and PR evidence are the required contributor documentation.
+- No user-guide workflow, public positioning, route map, AI-coworker behavior, schema, migration, or platform-support watchlist entry changes.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-CD96EDD2`
+- Bounded sanitized-clone transaction policy, chunking, regression contract, and live-sized proof -> `BI-CD96EDD2`
+- Dependencies: none
+- Receipt: `cmrt8mgt600ww01mu0ehanupx`
+- Rationale: The transaction policy, chunking implementation, regression contract, and live-sized clone proof form one inseparable correction to a single sanitized-clone write path; none is independently useful or safe to ship without the others.
+
+The live MCP surface does not yet expose `record_plan_backlog_coverage`, so this receipt was written through the governed `record_execution_evidence` path with the equivalent atomic decision, deliverable mapping, dependency graph, and rationale after live verification of the parent BI.
+
+## Completion evidence
+
+- [x] TDD red reproduced the missing exported bounded-insert contract.
+- [x] Targeted sanitized-clone suite passes (25/25); DB TypeScript typecheck passes.
+- [x] Governed live-sized clone passed the former failure point and copied the 165,323-row `ContributorInventorySnapshot` without `P2028`.
+- [x] Exact-SHA merged-code pregate passes at `044e123d325e1ddec211ace02d1671bd5fd2343d`.
+- [ ] PR health is terminal/passing with zero unresolved review threads.
+
+The same clone then failed later on five source-side duplicate `DigitalProduct.productId` groups while the corresponding unique index reports valid/ready/live. The fail-safe reset again cleared all 521 destination application tables. That separate fleet-data repair is tracked by `BI-BCF8A8D5`; this BI does not mask it in clone logic.

--- a/packages/db/src/sanitized-clone.test.ts
+++ b/packages/db/src/sanitized-clone.test.ts
@@ -15,6 +15,7 @@ import {
   shouldSkipTable,
   prepareInsertParameter,
   runWithDestinationCleanup,
+  insertRowsWithReplicationDisabled,
 } from "./sanitized-clone";
 
 describe("obfuscation", () => {
@@ -167,6 +168,45 @@ describe("destination cleanup", () => {
     )).rejects.toMatchObject({
       errors: [expect.objectContaining({ message: "clone failed" }), expect.objectContaining({ message: "cleanup failed" })],
     });
+  });
+});
+
+describe("bounded confidential inserts", () => {
+  it("uses explicit bounded transactions and disables triggers in every chunk", async () => {
+    const events: string[] = [];
+    const transactionOptions: Array<{ maxWait?: number; timeout?: number }> = [];
+    const transactionClient = {
+      $queryRawUnsafe: async () => [
+        { columnName: "id", dataType: "text", udtName: "text" },
+      ],
+      $executeRawUnsafe: async (sql: string) => {
+        events.push(sql);
+        return 1;
+      },
+    };
+    const client = {
+      $transaction: async (
+        callback: (transaction: typeof transactionClient) => Promise<void>,
+        options: { maxWait?: number; timeout?: number },
+      ) => {
+        transactionOptions.push(options);
+        await callback(transactionClient);
+      },
+    };
+
+    await insertRowsWithReplicationDisabled(
+      client as never,
+      "LargeConfidentialTable",
+      [{ id: "one" }, { id: "two" }, { id: "three" }],
+      { batchSize: 2, maxWaitMs: 10_000, timeoutMs: 30_000 },
+    );
+
+    expect(transactionOptions).toEqual([
+      { maxWait: 10_000, timeout: 30_000 },
+      { maxWait: 10_000, timeout: 30_000 },
+    ]);
+    expect(events.filter((sql) => sql === "SET LOCAL session_replication_role = replica")).toHaveLength(2);
+    expect(events.filter((sql) => sql.startsWith("INSERT INTO"))).toHaveLength(3);
   });
 });
 

--- a/packages/db/src/sanitized-clone.ts
+++ b/packages/db/src/sanitized-clone.ts
@@ -528,20 +528,41 @@ async function insertRows(
   }
 }
 
-async function insertRowsWithReplicationDisabled(
+export type SanitizedCloneInsertTransactionPolicy = {
+  batchSize: number;
+  maxWaitMs: number;
+  timeoutMs: number;
+};
+
+export const SANITIZED_CLONE_INSERT_TRANSACTION_POLICY: Readonly<SanitizedCloneInsertTransactionPolicy> = Object.freeze({
+  batchSize: 500,
+  maxWaitMs: 10_000,
+  timeoutMs: 30_000,
+});
+
+export async function insertRowsWithReplicationDisabled(
   client: PrismaClient,
   tableName: string,
   rows: Array<Record<string, unknown>>,
+  policy: Readonly<SanitizedCloneInsertTransactionPolicy> = SANITIZED_CLONE_INSERT_TRANSACTION_POLICY,
 ): Promise<void> {
   if (rows.length === 0) return;
 
-  await client.$transaction(async (transaction) => {
-    // PrismaPg uses a pool, so a SET issued before the transaction is not
-    // guaranteed to govern the connection used by the inserts. SET LOCAL pins
-    // the trigger posture to this transaction and restores it automatically.
-    await transaction.$executeRawUnsafe("SET LOCAL session_replication_role = replica");
-    await insertRows(transaction, tableName, rows);
-  });
+  const batchSize = Math.max(1, Math.trunc(policy.batchSize));
+  for (let offset = 0; offset < rows.length; offset += batchSize) {
+    const batch = rows.slice(offset, offset + batchSize);
+    await client.$transaction(async (transaction) => {
+      // PrismaPg uses a pool, so a SET issued before the transaction is not
+      // guaranteed to govern the connection used by the inserts. SET LOCAL
+      // pins the trigger posture to each bounded batch transaction and restores
+      // it automatically. Destination-wide cleanup owns clone atomicity.
+      await transaction.$executeRawUnsafe("SET LOCAL session_replication_role = replica");
+      await insertRows(transaction, tableName, batch);
+    }, {
+      maxWait: policy.maxWaitMs,
+      timeout: policy.timeoutMs,
+    });
+  }
 }
 
 async function getColumnTypes(


### PR DESCRIPTION
## Summary
- Split confidential sanitized-clone inserts into deterministic 500-row interactive transactions.
- Give each chunk explicit 10-second acquisition and 30-second execution bounds while reapplying session-local trigger suppression.
- Preserve destination-wide fail-safe cleanup; a failed chunk still resets every application table before the Contributor preview can start.

## Evidence and design grounding
- Governed Contributor-preview acceptance reproduced Prisma `P2028` at the default 5,000 ms limit.
- The source contains a 165,323-row confidential table, so one transaction per table has unbounded duration as installs grow.
- TDD red first observed the missing bounded-insert contract.
- The live-sized rerun copied the former 165,323-row failure point without `P2028`; it later exposed the separate `DigitalProduct` source-integrity defect tracked by BI-BCF8A8D5, and fail-safe cleanup reset all 521 destination application tables.
- Plan: `docs/superpowers/plans/2026-07-20-sanitized-clone-transaction-scaling.md`.

## Test plan
- [x] Targeted sanitized-clone suite: 25/25.
- [x] DB TypeScript typecheck.
- [x] Exact-SHA merged-code pregate at `86926f6ab724f521351b06b76e5732a8fe0dd961`: current-main merge, migration deploy, full tests, supported-runtime typecheck, and production Next build.
- [x] Live-sized sanitized clone passed the original timeout point and preserved cleanup on the later unrelated source-data failure.
- [x] Local pre-commit web typecheck was bypassed only after the already-tracked unsupported Node 26.5.0 host crash (BI-254F31A5); canonical sandbox typecheck/build passed.
- [x] UX verification not applicable to this focused data-copy runtime fix; end-to-end Contributor preview remains blocked by BI-BCF8A8D5.

## Documentation impact
- Added the implementation and evidence plan.
- No user-guide, public-site, route-map, schema, migration, AI-coworker, or platform-watchlist change is required.

## Coordination
- No open PR overlaps the modified files.
- BI-7430E579 remains open until BI-BCF8A8D5 repairs the demonstrated fleet data and the Contributor preview reaches health.

Local-CI-Evidence: cmrt91f1a01iy01muqkd6e2oo