### PR TITLE
fix(db): repair EA artifact index integrity

### DIFF
--- a/docs/data-impact/2026-07-20-ea-reference-artifact-index-integrity.data-impact.json
+++ b/docs/data-impact/2026-07-20-ea-reference-artifact-index-integrity.data-impact.json
@@ -1,0 +1,35 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "EA reference-model artifact registry",
+    "EaReferenceProposal source-artifact relationships",
+    "Prisma-to-EA current-state data-model mirror",
+    "Contributor sanitized-clone source and destination"
+  ],
+  "migration": {
+    "name": "20260720143000_repair_ea_reference_artifact_index_integrity",
+    "backfill": "forced-heap exact-key convergence: oldest deterministic (modelId, path) survivor, collision-checked quarantine paths for losers, preservation of artifact ids and proposal relationships, then complete compound unique-index rebuild; no row is deleted"
+  },
+  "tests": [
+    "packages/db/src/ea-reference-artifact-index-integrity-migration.test.ts",
+    "packages/db/scripts/migration-safety-guard.test.ts",
+    "scripts/check-data-impact.test.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:ea-reference-model-artifact#model-path-integrity-repair",
+      "prismaModel": "EaReferenceModelArtifact",
+      "lifecycleDisposition": "the oldest exact-key row remains canonical; every loser remains durable under a reserved quarantine path with its original id, attributes, and proposal relationships",
+      "fields": [
+        {
+          "fieldId": "data:ea-reference-model-artifact#modelId-path",
+          "resolution": "governed",
+          "reason": "restore trustworthy compound-key uniqueness without deleting source-artifact history or weakening sanitized-clone enforcement",
+          "provenance": "BI-FB6381E6 forced heap/index evidence, canonical artifact upsert contract, and migration fixture"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-20-ea-reference-artifact-index-integrity.md
+++ b/docs/superpowers/plans/2026-07-20-ea-reference-artifact-index-integrity.md
@@ -1,0 +1,41 @@
+# EA reference artifact unique-index integrity repair
+
+**Backlog item:** `BI-FB6381E6`  
+**Epic:** `EP-4A12A7CB`  
+**Work capsule:** `WC-381DB582`  
+**Branch:** `codex/ea-reference-artifact-integrity`
+
+## Outcome
+
+Every install has one canonical `EaReferenceModelArtifact` row per `(modelId, path)`, and the physical contents of `EaReferenceModelArtifact_modelId_path_key` agree with a forced heap scan. Duplicate artifact rows and any proposal history attached by artifact id are preserved as explicitly quarantined paths rather than deleted. The governed Contributor preview can copy the table without weakening destination constraints.
+
+## Evidence and substrate
+
+- The governed Contributor preview copied the 167,475-row `ContributorInventorySnapshot`, then failed closed at `EaReferenceModelArtifact` and reset all 521 destination tables.
+- A forced sequential scan of the canonical install found three duplicate `(modelId, path)` groups while the canonical index reported unique, valid, ready, and live.
+- `EaReferenceProposal.sourceArtifactId` references artifact ids. Renaming duplicate paths preserves those ids and their proposal history; no natural-key foreign key needs detaching.
+- The seed already upserts artifacts by the canonical compound key. Rebuilding the index restores that existing write-time contract; no new model or seed path is required.
+- The fleet-safe quarantine and trustworthy-index-rebuild pattern is established by `20260720133000_repair_digital_product_index_integrity`.
+
+## Implementation phases
+
+1. **Migration fixture first.** Add a database test that creates a model, duplicate artifact keys, proposal history on a loser, and an untrustworthy canonical-named index. It must require deterministic oldest-row survivorship, non-destructive quarantine, proposal preservation, a rebuilt valid unique index, and idempotence.
+2. **Fleet-safe migration.** Disable every index scan class for heap-grounded ranking/assertion; rename each loser to a collision-checked `__dpf_quarantined__<id>__<original-path>` path; assert zero duplicate groups; drop and recreate the canonical unique index in the same transaction.
+3. **Structural gates.** Run the migration fixture, DB tests/typecheck, migration-safety and data-impact guards, and exact-SHA merged-code pregate.
+4. **Functional acceptance.** Apply through governed self-upgrade, prove zero heap duplicate groups plus one valid/ready/live unique index, then rerun the leased Contributor preview through sanitized-clone completion and `:3001/api/health`.
+
+The migration, fixture, and live proof are one atomic correction under `BI-FB6381E6`; splitting them would leave either existing data or enforcement untrusted.
+
+## Risks and rollback
+
+- The index rebuild takes DDL locks, owned by the self-upgrade maintenance window.
+- Quarantine changes only duplicate loser paths. IDs, model ownership, checksums, authority, timestamps, and proposal references are preserved.
+- A clean install changes no rows. Reapplying the SQL is idempotent because only duplicate ranks are renamed and the canonical index is rebuilt from the verified heap.
+- Rollback is forward-only: restore a quarantined path only after confirming the canonical survivor is no longer needed, then rebuild the unique index. The migration itself is immutable after commit.
+
+## Completion evidence
+
+- [ ] Fixture proves deterministic quarantine, proposal preservation, index integrity, and idempotence.
+- [ ] Migration safety/data-impact guards, DB typecheck, and exact-SHA pregate pass.
+- [ ] Governed self-upgrade applies the migration; forced heap/catalog checks pass.
+- [ ] Governed Contributor preview completes the full clone and serves `:3001/api/health`.

--- a/docs/superpowers/plans/2026-07-20-ea-reference-artifact-index-integrity.md
+++ b/docs/superpowers/plans/2026-07-20-ea-reference-artifact-index-integrity.md
@@ -26,6 +26,17 @@ Every install has one canonical `EaReferenceModelArtifact` row per `(modelId, pa
 
 The migration, fixture, and live proof are one atomic correction under `BI-FB6381E6`; splitting them would leave either existing data or enforcement untrusted.
 
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-FB6381E6`
+- Fleet-safe quarantine migration, canonical unique-index rebuild, migration fixture, exact gate, governed live heap/index proof, and full Contributor preview acceptance -> `BI-FB6381E6`
+- Dependencies: blocks `BI-7430E579`; builds on completed `BI-CD96EDD2` and `BI-BCF8A8D5`
+- Receipt: `cmrtbt0vm00xe01nshop21gxh`
+- Rationale: the migration, enforcement rebuild, and functional proof are one indivisible data-integrity correction; shipping any phase alone would leave either existing data or enforcement untrusted.
+
+The live MCP surface does not expose `record_plan_backlog_coverage`, so the receipt was recorded through the governed `record_execution_evidence` path with the same atomic decision, mapping, dependency graph, and rationale.
+
 ## Risks and rollback
 
 - The index rebuild takes DDL locks, owned by the self-upgrade maintenance window.

--- a/packages/db/prisma/migrations/20260720143000_repair_ea_reference_artifact_index_integrity/migration.sql
+++ b/packages/db/prisma/migrations/20260720143000_repair_ea_reference_artifact_index_integrity/migration.sql
@@ -1,0 +1,75 @@
+-- BI-FB6381E6 — restore agreement between the EaReferenceModelArtifact heap
+-- and its canonical unique (modelId, path) index. Affected installs can hold
+-- duplicate heap rows even while pg_index reports the btree healthy.
+--
+-- Fleet safety: duplicate rows are quarantined by path, never deleted. The
+-- artifact id and every ID-based proposal relationship remain unchanged.
+-- Clean installs change no data; the migration is idempotent and fails closed
+-- if duplicate natural keys remain.
+
+BEGIN;
+
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+-- Pick the oldest row as the stable canonical artifact. Quarantine paths
+-- include the loser id and original path; the collision loop is scoped to the
+-- model because the canonical key is the (modelId, path) pair.
+DO $$
+DECLARE
+  duplicate_row RECORD;
+  quarantine_path TEXT;
+BEGIN
+  FOR duplicate_row IN
+    WITH ranked AS MATERIALIZED (
+      SELECT
+        id,
+        "modelId",
+        path,
+        row_number() OVER (
+          PARTITION BY "modelId", path
+          ORDER BY "createdAt", id
+        ) AS duplicate_rank
+      FROM "EaReferenceModelArtifact"
+    )
+    SELECT id, "modelId", path
+    FROM ranked
+    WHERE duplicate_rank > 1
+    ORDER BY "modelId", path, id
+  LOOP
+    quarantine_path := '__dpf_quarantined__' || duplicate_row.id || '__' || duplicate_row.path;
+    WHILE EXISTS (
+      SELECT 1
+      FROM "EaReferenceModelArtifact"
+      WHERE "modelId" = duplicate_row."modelId"
+        AND path = quarantine_path
+        AND id <> duplicate_row.id
+    ) LOOP
+      quarantine_path := quarantine_path || '_';
+    END LOOP;
+
+    UPDATE "EaReferenceModelArtifact"
+    SET path = quarantine_path
+    WHERE id = duplicate_row.id;
+  END LOOP;
+END $$;
+
+-- This assertion is heap-grounded because every index scan class is disabled.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "EaReferenceModelArtifact"
+    GROUP BY "modelId", path
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'EaReferenceModelArtifact integrity repair left duplicate (modelId, path) keys';
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS "EaReferenceModelArtifact_modelId_path_key";
+CREATE UNIQUE INDEX "EaReferenceModelArtifact_modelId_path_key"
+  ON "EaReferenceModelArtifact" ("modelId", path);
+
+COMMIT;

--- a/packages/db/src/ea-reference-artifact-index-integrity-migration.test.ts
+++ b/packages/db/src/ea-reference-artifact-index-integrity-migration.test.ts
@@ -1,0 +1,114 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const schema = `ea_artifact_repair_${randomUUID().replaceAll("-", "")}`;
+let client: Client;
+
+async function scalar(sql: string): Promise<number> {
+  const result = await client.query<{ value: string }>(sql);
+  return Number(result.rows[0]?.value ?? 0);
+}
+
+describeDatabase("EaReferenceModelArtifact unique-index integrity migration", () => {
+  beforeAll(async () => {
+    client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    await client.query(`CREATE SCHEMA "${schema}"`);
+    await client.query(`SET search_path TO "${schema}"`);
+    await client.query(`
+      CREATE TABLE "EaReferenceModel" (id TEXT PRIMARY KEY);
+      CREATE TABLE "EaReferenceModelArtifact" (
+        id TEXT PRIMARY KEY,
+        "modelId" TEXT NOT NULL REFERENCES "EaReferenceModel"(id) ON DELETE CASCADE,
+        kind TEXT NOT NULL,
+        path TEXT NOT NULL,
+        checksum TEXT,
+        authority TEXT NOT NULL,
+        "importedAt" TIMESTAMPTZ,
+        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+      CREATE TABLE "EaReferenceProposal" (
+        id TEXT PRIMARY KEY,
+        "sourceArtifactId" TEXT REFERENCES "EaReferenceModelArtifact"(id)
+      );
+      CREATE INDEX "EaReferenceModelArtifact_modelId_path_key"
+        ON "EaReferenceModelArtifact" ("modelId", path);
+
+      INSERT INTO "EaReferenceModel" VALUES ('model-1');
+      INSERT INTO "EaReferenceModelArtifact"
+        (id, "modelId", kind, path, checksum, authority, "createdAt") VALUES
+        ('artifact-old', 'model-1', 'xlsx', 'docs/reference.xlsx', 'old-sum', 'authoritative', '2026-01-01'),
+        ('artifact-new', 'model-1', 'xlsx', 'docs/reference.xlsx', 'new-sum', 'authoritative', '2026-02-01'),
+        ('collision', 'model-1', 'txt', '__dpf_quarantined__artifact-new__docs/reference.xlsx', null, 'supporting', '2026-01-01');
+      INSERT INTO "EaReferenceProposal" VALUES ('proposal-1', 'artifact-new');
+    `);
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await client.end();
+  });
+
+  it("quarantines losers without losing proposal history and rebuilds a trustworthy unique index", async () => {
+    const migration = await readFile(
+      new URL(
+        "../prisma/migrations/20260720143000_repair_ea_reference_artifact_index_integrity/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    await client.query(migration);
+
+    expect(await scalar(`SELECT count(*)::text AS value FROM "EaReferenceModelArtifact"`)).toBe(3);
+    expect(
+      await scalar(`
+        SELECT count(*)::text AS value
+        FROM (
+          SELECT "modelId", path
+          FROM "EaReferenceModelArtifact"
+          GROUP BY 1, 2
+          HAVING count(*) > 1
+        ) duplicate_groups
+      `),
+    ).toBe(0);
+    expect(
+      (await client.query(`SELECT path, checksum FROM "EaReferenceModelArtifact" WHERE id='artifact-old'`)).rows[0],
+    ).toEqual({ path: "docs/reference.xlsx", checksum: "old-sum" });
+    expect(
+      (await client.query(`SELECT path, checksum FROM "EaReferenceModelArtifact" WHERE id='artifact-new'`)).rows[0],
+    ).toEqual({
+      path: "__dpf_quarantined__artifact-new__docs/reference.xlsx_",
+      checksum: "new-sum",
+    });
+    expect(
+      (await client.query(`SELECT "sourceArtifactId" FROM "EaReferenceProposal" WHERE id='proposal-1'`)).rows[0]
+        ?.sourceArtifactId,
+    ).toBe("artifact-new");
+    expect(
+      await scalar(`
+        SELECT count(*)::text AS value
+        FROM pg_index i
+        JOIN pg_class c ON c.oid=i.indexrelid
+        JOIN pg_namespace n ON n.oid=c.relnamespace
+        WHERE n.nspname=current_schema()
+          AND c.relname='EaReferenceModelArtifact_modelId_path_key'
+          AND i.indisunique AND i.indisvalid AND i.indisready AND i.indislive
+      `),
+    ).toBe(1);
+
+    const beforeSecondPass = JSON.stringify(
+      (await client.query(`SELECT * FROM "EaReferenceModelArtifact" ORDER BY id`)).rows,
+    );
+    await client.query(migration);
+    const afterSecondPass = JSON.stringify(
+      (await client.query(`SELECT * FROM "EaReferenceModelArtifact" ORDER BY id`)).rows,
+    );
+    expect(afterSecondPass).toBe(beforeSecondPass);
+  });
+});


### PR DESCRIPTION
## Summary
- repair three confirmed physical duplicate `EaReferenceModelArtifact(modelId, path)` groups with deterministic, non-destructive quarantine
- rebuild the untrustworthy canonical compound unique index from a forced-heap-verified table
- preserve artifact IDs and `EaReferenceProposal.sourceArtifactId` history, with an idempotent migration fixture
- resolves BI-FB6381E6 and unblocks BI-7430E579 Contributor preview acceptance

## Test plan
- [x] red-first migration fixture, then green: `ea-reference-artifact-index-integrity-migration.test.ts`
- [x] DB typecheck
- [x] migration-safety guard
- [x] data-impact manifest check
- [x] exact-SHA merged-code pregate at `fde230ec33dbfd9ef9cf4ee090970cceb218fc98`
- [x] full web test suite and production build through local-integration-ci lease `NPEL-CA100E02C4`
- [x] migration deploy against the merged-code gate database

Local-CI-Evidence: `cmrtbwvbt00z201nsy4cm836i`

## Functional follow-through
After merge, apply through governed self-upgrade, verify the canonical live heap/index state, then rerun the leased full sanitized clone and Contributor preview health check. This is acceptance evidence for the already-tested migration, not additional PR implementation scope.

## Overlap
No existing BI, active capsule, or open PR covers this table; the branch contains one DCO-signed concern.