### PR TITLE
fix(db): repair EA element index integrity

### DIFF
--- a/docs/data-impact/2026-07-20-ea-reference-element-index-integrity.data-impact.json
+++ b/docs/data-impact/2026-07-20-ea-reference-element-index-integrity.data-impact.json
@@ -1,0 +1,36 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "EA reference-model element registry",
+    "EA reference-model element parent relationships",
+    "EA reference assessment element relationships",
+    "Prisma-to-EA current-state data-model mirror",
+    "Contributor sanitized-clone source and destination"
+  ],
+  "migration": {
+    "name": "20260720150000_repair_ea_reference_element_index_integrity",
+    "backfill": "forced-heap exact-key convergence: lexical-id deterministic (modelId, slug) survivor, collision-checked quarantine slugs for losers, preservation of element ids and all ID-based relationships, then complete compound unique-index rebuild; no row is deleted"
+  },
+  "tests": [
+    "packages/db/src/ea-reference-element-index-integrity-migration.test.ts",
+    "packages/db/scripts/migration-safety-guard.test.ts",
+    "scripts/check-data-impact.test.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:ea-reference-model-element#model-slug-integrity-repair",
+      "prismaModel": "EaReferenceModelElement",
+      "lifecycleDisposition": "the lexical-first exact-key row remains canonical; each loser remains durable under a reserved quarantine slug with its original id, attributes, parent/child links, and assessment relationships",
+      "fields": [
+        {
+          "fieldId": "data:ea-reference-model-element#modelId-slug",
+          "resolution": "governed",
+          "reason": "restore trustworthy compound-key uniqueness without deleting reference-model history or weakening sanitized-clone enforcement",
+          "provenance": "BI-A794805F forced heap/index evidence, canonical element import contract, and migration fixture"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-20-ea-reference-element-index-integrity.md
+++ b/docs/superpowers/plans/2026-07-20-ea-reference-element-index-integrity.md
@@ -1,0 +1,50 @@
+# EA reference element unique-index integrity repair
+
+**Backlog item:** `BI-A794805F`  
+**Epic:** `EP-4A12A7CB`  
+**Work capsule:** `WC-B67C9451`  
+**Branch:** `codex/ea-reference-element-integrity`
+
+## Outcome
+
+Every install has one canonical `EaReferenceModelElement` row per `(modelId, slug)`, and the physical heap agrees with the canonical unique index. Duplicate rows remain available under reserved quarantine slugs, preserving their ids, parent/child links, assessments, attributes, and provenance. The governed Contributor preview can enforce and copy the table without weakening destination constraints.
+
+## Evidence and substrate
+
+- The governed Contributor preview passed the artifact repair, copied the large inventory/discovery tables, then failed closed at `EaReferenceModelElement` and reset all 521 destination tables.
+- A forced sequential scan found 22 duplicate groups (23 loser rows) while `EaReferenceModelElement_modelId_slug_key` reported unique, valid, ready, and live.
+- `parentId` and `EaReferenceAssessment.modelElementId` reference element ids. Renaming loser slugs preserves every ID-based relationship.
+- The seed/import contract already identifies elements by the canonical `(modelId, slug)` key. Rebuilding the index restores that contract without inventing new substrate.
+- The fleet-safe quarantine and trustworthy-index-rebuild pattern is established by the adjacent DigitalProduct and EA artifact integrity repairs.
+
+## Implementation phases
+
+1. **Migration fixture first.** Reproduce duplicate natural keys, a quarantine-name collision, a child linked to a loser, and an assessment linked to a loser. Require deterministic lexical-id survivorship, non-destructive quarantine, relationship preservation, a rebuilt valid unique index, and idempotence.
+2. **Fleet-safe migration.** Disable all index scan classes; quarantine every lexical loser with a collision-checked reserved slug; assert zero heap duplicates; drop and recreate the canonical index in one transaction.
+3. **Structural gates.** Run the migration fixture, DB tests/typecheck, migration-safety and data-impact guards, and exact-SHA merged-code pregate.
+4. **Functional acceptance.** Apply through governed self-upgrade, prove heap/index integrity, then rerun the leased Contributor preview through sanitized-clone completion and `:3001/api/health`.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-A794805F`
+- Fleet-safe quarantine migration, canonical unique-index rebuild, fixture, exact gate, governed live proof, and full Contributor preview acceptance -> `BI-A794805F`
+- Dependencies: blocks `BI-7430E579`; builds on completed EA artifact and DigitalProduct integrity repairs
+- Receipt: `cmrtcqw9u00ch01o92x5oizc8`
+- Rationale: migration, enforcement rebuild, and functional proof are one indivisible correction; splitting them leaves either source data or destination enforcement untrusted.
+
+The live MCP surface does not expose `record_plan_backlog_coverage`, so this receipt was recorded through the governed `record_execution_evidence` path with the same atomic decision, mapping, dependency graph, and rationale.
+
+## Risks and rollback
+
+- The index rebuild takes DDL locks during the self-upgrade maintenance window.
+- Quarantine changes only duplicate loser slugs. IDs, relationships, attributes, and provenance remain intact.
+- A clean install changes no rows. Reapplication is idempotent because only duplicate ranks are renamed and the index is rebuilt from the verified heap.
+- Rollback is forward-only: a quarantined slug may be restored only after its canonical conflict is deliberately resolved, followed by another unique-index rebuild.
+
+## Completion evidence
+
+- [ ] Fixture proves deterministic quarantine, relationship preservation, index integrity, and idempotence.
+- [ ] Migration safety/data-impact guards, DB typecheck, and exact-SHA pregate pass.
+- [ ] Governed self-upgrade applies the migration; forced heap/catalog checks pass.
+- [ ] Governed Contributor preview completes the full clone and serves `:3001/api/health`.

--- a/packages/db/prisma/migrations/20260720150000_repair_ea_reference_element_index_integrity/migration.sql
+++ b/packages/db/prisma/migrations/20260720150000_repair_ea_reference_element_index_integrity/migration.sql
@@ -1,0 +1,75 @@
+-- BI-A794805F — restore agreement between the EaReferenceModelElement heap
+-- and its canonical unique (modelId, slug) index. Affected installs can hold
+-- duplicate heap rows even while pg_index reports the btree healthy.
+--
+-- Fleet safety: duplicate rows are quarantined by slug, never deleted. Element
+-- ids and every ID-based parent/assessment relationship remain unchanged.
+-- Clean installs change no data; the migration is idempotent and fails closed
+-- if duplicate natural keys remain.
+
+BEGIN;
+
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+-- The table has no creation timestamp, so lexical id order is the stable,
+-- repeatable survivor rule. The collision loop is scoped to the model because
+-- the canonical key is the (modelId, slug) pair.
+DO $$
+DECLARE
+  duplicate_row RECORD;
+  quarantine_slug TEXT;
+BEGIN
+  FOR duplicate_row IN
+    WITH ranked AS MATERIALIZED (
+      SELECT
+        id,
+        "modelId",
+        slug,
+        row_number() OVER (
+          PARTITION BY "modelId", slug
+          ORDER BY id
+        ) AS duplicate_rank
+      FROM "EaReferenceModelElement"
+    )
+    SELECT id, "modelId", slug
+    FROM ranked
+    WHERE duplicate_rank > 1
+    ORDER BY "modelId", slug, id
+  LOOP
+    quarantine_slug := '__dpf_quarantined__' || duplicate_row.id || '__' || duplicate_row.slug;
+    WHILE EXISTS (
+      SELECT 1
+      FROM "EaReferenceModelElement"
+      WHERE "modelId" = duplicate_row."modelId"
+        AND slug = quarantine_slug
+        AND id <> duplicate_row.id
+    ) LOOP
+      quarantine_slug := quarantine_slug || '_';
+    END LOOP;
+
+    UPDATE "EaReferenceModelElement"
+    SET slug = quarantine_slug
+    WHERE id = duplicate_row.id;
+  END LOOP;
+END $$;
+
+-- This assertion is heap-grounded because every index scan class is disabled.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "EaReferenceModelElement"
+    GROUP BY "modelId", slug
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'EaReferenceModelElement integrity repair left duplicate (modelId, slug) keys';
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS "EaReferenceModelElement_modelId_slug_key";
+CREATE UNIQUE INDEX "EaReferenceModelElement_modelId_slug_key"
+  ON "EaReferenceModelElement" ("modelId", slug);
+
+COMMIT;

--- a/packages/db/src/ea-reference-element-index-integrity-migration.test.ts
+++ b/packages/db/src/ea-reference-element-index-integrity-migration.test.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const schema = `ea_element_repair_${randomUUID().replaceAll("-", "")}`;
+let client: Client;
+
+async function scalar(sql: string): Promise<number> {
+  const result = await client.query<{ value: string }>(sql);
+  return Number(result.rows[0]?.value ?? 0);
+}
+
+describeDatabase("EaReferenceModelElement unique-index integrity migration", () => {
+  beforeAll(async () => {
+    client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    await client.query(`CREATE SCHEMA "${schema}"`);
+    await client.query(`SET search_path TO "${schema}"`);
+    await client.query(`
+      CREATE TABLE "EaReferenceModel" (id TEXT PRIMARY KEY);
+      CREATE TABLE "EaReferenceModelElement" (
+        id TEXT PRIMARY KEY,
+        "modelId" TEXT NOT NULL REFERENCES "EaReferenceModel"(id) ON DELETE CASCADE,
+        "parentId" TEXT REFERENCES "EaReferenceModelElement"(id) ON DELETE SET NULL,
+        kind TEXT NOT NULL,
+        slug TEXT NOT NULL,
+        name TEXT NOT NULL,
+        properties JSONB NOT NULL DEFAULT '{}'::jsonb
+      );
+      CREATE TABLE "EaReferenceAssessment" (
+        id TEXT PRIMARY KEY,
+        "modelElementId" TEXT NOT NULL REFERENCES "EaReferenceModelElement"(id) ON DELETE CASCADE
+      );
+      CREATE INDEX "EaReferenceModelElement_modelId_slug_key"
+        ON "EaReferenceModelElement" ("modelId", slug);
+
+      INSERT INTO "EaReferenceModel" VALUES ('model-1');
+      INSERT INTO "EaReferenceModelElement"
+        (id, "modelId", kind, slug, name, properties) VALUES
+        ('element-a', 'model-1', 'criterion', 'duplicate-slug', 'Canonical', '{"source":"a"}'),
+        ('element-b', 'model-1', 'criterion', 'duplicate-slug', 'Duplicate', '{"source":"b"}'),
+        ('collision', 'model-1', 'criterion', '__dpf_quarantined__element-b__duplicate-slug', 'Collision', '{}');
+      INSERT INTO "EaReferenceModelElement"
+        (id, "modelId", "parentId", kind, slug, name) VALUES
+        ('child', 'model-1', 'element-b', 'criterion', 'child-slug', 'Child');
+      INSERT INTO "EaReferenceAssessment" VALUES ('assessment-1', 'element-b');
+    `);
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await client.end();
+  });
+
+  it("quarantines losers without breaking ID relationships and rebuilds a trustworthy unique index", async () => {
+    const migration = await readFile(
+      new URL(
+        "../prisma/migrations/20260720150000_repair_ea_reference_element_index_integrity/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    await client.query(migration);
+
+    expect(await scalar(`SELECT count(*)::text AS value FROM "EaReferenceModelElement"`)).toBe(4);
+    expect(
+      await scalar(`
+        SELECT count(*)::text AS value
+        FROM (
+          SELECT "modelId", slug
+          FROM "EaReferenceModelElement"
+          GROUP BY 1, 2
+          HAVING count(*) > 1
+        ) duplicate_groups
+      `),
+    ).toBe(0);
+    expect(
+      (await client.query(`SELECT slug, name, properties FROM "EaReferenceModelElement" WHERE id='element-a'`))
+        .rows[0],
+    ).toEqual({ slug: "duplicate-slug", name: "Canonical", properties: { source: "a" } });
+    expect(
+      (await client.query(`SELECT slug, name, properties FROM "EaReferenceModelElement" WHERE id='element-b'`))
+        .rows[0],
+    ).toEqual({
+      slug: "__dpf_quarantined__element-b__duplicate-slug_",
+      name: "Duplicate",
+      properties: { source: "b" },
+    });
+    expect(
+      (await client.query(`SELECT "parentId" FROM "EaReferenceModelElement" WHERE id='child'`)).rows[0]
+        ?.parentId,
+    ).toBe("element-b");
+    expect(
+      (await client.query(`SELECT "modelElementId" FROM "EaReferenceAssessment" WHERE id='assessment-1'`))
+        .rows[0]?.modelElementId,
+    ).toBe("element-b");
+    expect(
+      await scalar(`
+        SELECT count(*)::text AS value
+        FROM pg_index i
+        JOIN pg_class c ON c.oid=i.indexrelid
+        JOIN pg_namespace n ON n.oid=c.relnamespace
+        WHERE n.nspname=current_schema()
+          AND c.relname='EaReferenceModelElement_modelId_slug_key'
+          AND i.indisunique AND i.indisvalid AND i.indisready AND i.indislive
+      `),
+    ).toBe(1);
+
+    const beforeSecondPass = JSON.stringify(
+      (await client.query(`SELECT * FROM "EaReferenceModelElement" ORDER BY id`)).rows,
+    );
+    await client.query(migration);
+    const afterSecondPass = JSON.stringify(
+      (await client.query(`SELECT * FROM "EaReferenceModelElement" ORDER BY id`)).rows,
+    );
+    expect(afterSecondPass).toBe(beforeSecondPass);
+  });
+});


### PR DESCRIPTION
## Summary
- quarantine physical duplicate EaReferenceModelElement natural keys without deleting rows
- preserve element ids, parent/child links, assessments, attributes, and provenance
- rebuild and verify the canonical unique (modelId, slug) index
- add a database fixture covering collisions, relationship preservation, and idempotence

## Backlog
- BI-A794805F
- EP-4A12A7CB
- WC-B67C9451

## Verification
- migration fixture: pass
- DB typecheck: pass
- migration safety guard: pass
- exact merged-code pregate: pass
- Local-CI-Evidence: cmrtcwoi200hd01o9d8aqxrgm
- Local-CI-Lease: NPEL-5C34F9DC2A
- Exact-SHA: 36331fd165c9afc6a6f2a4669247f14d2382fef5

## Data and migration safety
- 22 physical duplicate groups were proven by a forced heap scan on the canonical install while the canonical index reported healthy
- losers receive collision-checked reserved slugs; no rows or ID-based relationships are deleted
- all index scan classes are disabled during ranking and the post-repair assertion
- the canonical unique index is rebuilt in the same transaction

## Documentation impact
The implementation plan and governed data-impact manifest are included. No user-guide change is needed because this is an internal fleet-safe integrity repair; the operator-visible outcome is a contributor preview that initializes reliably.