### PR TITLE
fix(db): preserve sanitized clone array types

### DIFF
--- a/docs/superpowers/plans/2026-07-20-sanitized-clone-array-types.md
+++ b/docs/superpowers/plans/2026-07-20-sanitized-clone-array-types.md
@@ -26,7 +26,7 @@ Confidential-table rows copied through the sanitized clone retain each PostgreSQ
 - Decision: atomic
 - Parent: `BI-A170C1EB`
 - Catalog-derived casts, regression tests, exact gate, and full preview proof -> `BI-A170C1EB`
-- Dependency: blocks `BI-7430E579`
+- Dependencies: blocks `BI-7430E579`
 - Receipt: `cmrtdowat006q01o20ae0d1ek`
 - Rationale: the code and end-to-end driver/catalog proof are one correctness repair; unit-only completion would leave the real clone path unproven.
 

--- a/docs/superpowers/plans/2026-07-20-sanitized-clone-array-types.md
+++ b/docs/superpowers/plans/2026-07-20-sanitized-clone-array-types.md
@@ -1,0 +1,44 @@
+# Sanitized clone PostgreSQL array typing
+
+**Backlog item:** `BI-A170C1EB`  
+**Epic:** `EP-5410E8EA`  
+**Work capsule:** `WC-54D95CC3`  
+**Branch:** `codex/sanitized-clone-array-types`
+
+## Outcome
+
+Confidential-table rows copied through the sanitized clone retain each PostgreSQL array column's catalog element type. `integer[]`, `text[]`, and custom-enum arrays no longer collapse to `text[]`, while JSON/JSONB arrays keep their existing JSON serialization.
+
+## Evidence and substrate
+
+- The governed Contributor preview passed both repaired EA tables, then failed closed on `NonProductionEnvironmentLease.ports` with SQLSTATE `42804`: the destination expects `integer[]`, but the generic inserter emitted `text[]`.
+- `getColumnTypes` already retrieves each column's `data_type` and `udt_name`; no new schema or metadata path is needed.
+- PostgreSQL exposes array UDT names as `_<element-type>`. A quoted catalog-derived element identifier supports built-ins and case-sensitive custom types without interpreting the identifier as SQL syntax.
+
+## Implementation
+
+1. Add failing tests for text, integer, and custom-enum arrays while retaining the JSON-array regression.
+2. Derive the cast from the catalog UDT, reject malformed array UDT names, quote the element identifier, and preserve the existing array-literal escaping.
+3. Run the focused suite, DB typecheck, exact-SHA merged-code pregate, then rerun the full governed Contributor preview clone.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-A170C1EB`
+- Catalog-derived casts, regression tests, exact gate, and full preview proof -> `BI-A170C1EB`
+- Dependency: blocks `BI-7430E579`
+- Receipt: `cmrtdowat006q01o20ae0d1ek`
+- Rationale: the code and end-to-end driver/catalog proof are one correctness repair; unit-only completion would leave the real clone path unproven.
+
+The live MCP surface does not expose `record_plan_backlog_coverage`, so the receipt was recorded through governed `record_execution_evidence` with the same decision, mapping, dependency, and rationale.
+
+## Documentation impact
+
+No user-guide, setup, public-site, architecture, or operations text changes. This is an internal type-preservation defect in an existing governed clone workflow; the operator-visible contract remains unchanged.
+
+## Completion evidence
+
+- [x] Red tests reproduce the text-array cast for integer and custom element types.
+- [x] Focused tests and DB typecheck pass after the catalog-derived cast.
+- [ ] Exact-SHA merged-code pregate passes.
+- [ ] Full Contributor preview clone completes and `:3001/api/health` is healthy.

--- a/packages/db/src/sanitized-clone.test.ts
+++ b/packages/db/src/sanitized-clone.test.ts
@@ -60,8 +60,26 @@ describe("insert parameter preparation", () => {
     const result = prepareInsertParameter(["a", "b"], { dataType: "ARRAY", udtName: "_text" }, 2);
 
     expect(result).toEqual({
-      placeholder: "$2::text[]",
+      placeholder: "$2::\"text\"[]",
       value: "{\"a\",\"b\"}",
+    });
+  });
+
+  it("casts integer arrays to their catalog element type instead of text[]", () => {
+    const result = prepareInsertParameter([3001, 5433], { dataType: "ARRAY", udtName: "_int4" }, 3);
+
+    expect(result).toEqual({
+      placeholder: "$3::\"int4\"[]",
+      value: "{\"3001\",\"5433\"}",
+    });
+  });
+
+  it("quotes custom array element type names from the catalog", () => {
+    const result = prepareInsertParameter(["open"], { dataType: "ARRAY", udtName: "_LifecycleStatus" }, 4);
+
+    expect(result).toEqual({
+      placeholder: "$4::\"LifecycleStatus\"[]",
+      value: "{\"open\"}",
     });
   });
 

--- a/packages/db/src/sanitized-clone.ts
+++ b/packages/db/src/sanitized-clone.ts
@@ -208,7 +208,7 @@ export function prepareInsertParameter(
 
   if (columnType?.dataType === "ARRAY" && Array.isArray(value)) {
     return {
-      placeholder: `${placeholder}::text[]`,
+      placeholder: `${placeholder}::${arrayElementTypeCast(columnType.udtName)}`,
       value: toPostgresTextArrayLiteral(value),
     };
   }
@@ -247,6 +247,18 @@ export function prepareInsertParameter(
 
 function toPostgresTextArrayLiteral(value: unknown[]): string {
   return `{${value.map((item: unknown) => `"${String(item).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`).join(",")}}`;
+}
+
+function arrayElementTypeCast(arrayUdtName: string): string {
+  if (!arrayUdtName.startsWith("_") || arrayUdtName.length === 1) {
+    throw new Error(`Unexpected PostgreSQL array UDT name: ${arrayUdtName}`);
+  }
+
+  // PostgreSQL exposes array UDTs as _<element-type>. Quote the catalog-owned
+  // identifier so built-ins (int4/text) and case-sensitive custom enums both
+  // resolve without treating any part of the name as SQL syntax.
+  const elementType = arrayUdtName.slice(1).replaceAll('"', '""');
+  return `"${elementType}"[]`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- derive PostgreSQL array casts from destination catalog UDT metadata
- safely quote built-in and case-sensitive custom element type identifiers
- preserve existing JSON/JSONB array serialization
- add red/green regressions for text[], integer[], and custom-enum arrays

## Backlog
- BI-A170C1EB
- EP-5410E8EA
- WC-54D95CC3

## Verification
- focused sanitized-clone tests: 27 pass
- DB typecheck: pass
- exact merged-code pregate: pass
- Local-CI-Evidence: cmrte0kcr00mk01o2u55ulqlx
- Local-CI-Lease: NPEL-3C879F5950
- Exact-SHA: 682a4fcbdf8ec6644b9bebbdbf6070a5e3e26e6c

## Runtime evidence
The governed Contributor preview passed both repaired EA tables, then failed closed on NonProductionEnvironmentLease.ports because the generic inserter emitted text[] for an integer[] destination. It reset all 521 destination tables.

## Documentation impact
An implementation plan records the governed clone contract and acceptance path. No user-guide, public-site, setup, architecture, or operations wording changes because the operator-visible workflow is unchanged.