### PR TITLE
fix(db): repair PlatformConfig index integrity

### DIFF
--- a/docs/data-impact/2026-07-20-platform-config-index-integrity.data-impact.json
+++ b/docs/data-impact/2026-07-20-platform-config-index-integrity.data-impact.json
@@ -1,0 +1,35 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "Platform configuration registry",
+    "Build Studio dispatch configuration",
+    "Prisma-to-EA current-state data-model mirror",
+    "Contributor sanitized-clone source and destination"
+  ],
+  "migration": {
+    "name": "20260720160000_repair_platform_config_index_integrity",
+    "backfill": "forced-heap exact-key convergence: newest updatedAt/id survivor remains active, collision-checked quarantine keys preserve older rows and JSON values, then complete unique-index rebuild; no row is deleted"
+  },
+  "tests": [
+    "packages/db/src/platform-config-index-integrity-migration.test.ts",
+    "packages/db/scripts/migration-safety-guard.test.ts",
+    "scripts/check-data-impact.test.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:platform-config#key-integrity-repair",
+      "prismaModel": "PlatformConfig",
+      "lifecycleDisposition": "the newest exact-key row remains active; older rows remain durable under reserved quarantine keys with original ids, JSON values, and timestamps",
+      "fields": [
+        {
+          "fieldId": "data:platform-config#key",
+          "resolution": "governed",
+          "reason": "restore trustworthy singleton configuration without reverting the current operator choice or deleting configuration history",
+          "provenance": "BI-E07FEB3A forced heap/index evidence and migration fixture"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-20-platform-config-index-integrity.md
+++ b/docs/superpowers/plans/2026-07-20-platform-config-index-integrity.md
@@ -1,0 +1,47 @@
+# PlatformConfig unique-index integrity repair
+
+**Backlog item:** `BI-E07FEB3A`  
+**Epic:** `EP-4A12A7CB`  
+**Work capsule:** `WC-F28B58F1`  
+**Branch:** `codex/platform-config-integrity`
+
+## Outcome
+
+Every install has one active `PlatformConfig` row per key, with the physical heap agreeing with `PlatformConfig_key_key`. The newest configuration remains active; older conflicting values remain durable under reserved quarantine keys. The Contributor preview can copy the table without weakening its destination constraint.
+
+## Evidence and substrate
+
+- The governed clone passed the pgvector, EA integrity, and array-typing repairs, then failed closed on duplicate `build-studio-dispatch` keys and reset all 521 destination tables.
+- A forced heap scan found two rows while the canonical index reported unique, valid, ready, and live.
+- The older row selects Claude; the newer row selects Codex/ChatGPT. Keeping the newest `updatedAt` value prevents silently reverting the operator's current dispatch choice.
+- No foreign keys reference PlatformConfig ids. Quarantining the key preserves ids, full JSON values, and timestamps without introducing new substrate.
+
+## Implementation
+
+1. Add a database fixture with old/new conflicting values and a quarantine-key collision. Require newest-row survivorship, non-destructive quarantine, index integrity, and idempotence.
+2. Disable all index scan classes; rank by `updatedAt DESC, id DESC`; collision-check quarantine keys; assert a duplicate-free heap; rebuild the canonical unique index in one transaction.
+3. Run the fixture, DB typecheck, migration safety guard, exact-SHA merged-code pregate, governed self-upgrade, live heap/index proof, and the full Contributor preview clone.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-E07FEB3A`
+- Fleet-safe migration, index rebuild, fixture, exact gate, live proof, and full preview acceptance -> `BI-E07FEB3A`
+- Dependencies: blocks `BI-7430E579`; builds on `BI-A170C1EB`
+- Receipt: `cmrtesb9f005301mlp7hv41sg`
+- Rationale: the active-value selection, preservation, enforcement rebuild, and end-to-end proof are one indivisible configuration-integrity correction.
+
+The live MCP surface does not expose `record_plan_backlog_coverage`, so the receipt was recorded through governed `record_execution_evidence` with the same decision, mapping, dependencies, and rationale.
+
+## Risks and rollback
+
+- Index rebuild DDL runs in the governed maintenance window.
+- Only older duplicate keys change. Values, ids, and timestamps remain available for audit/recovery.
+- Clean installs change no rows; reapplication is idempotent.
+- Forward rollback restores a quarantined key only after deliberately removing/rekeying the active conflict, then rebuilding the index.
+
+## Completion evidence
+
+- [ ] Fixture, DB typecheck, migration safety, and exact-SHA pregate pass.
+- [ ] Governed self-upgrade and forced heap/catalog proof pass.
+- [ ] Full Contributor preview clone completes and `:3001/api/health` is healthy.

--- a/packages/db/prisma/migrations/20260720160000_repair_platform_config_index_integrity/migration.sql
+++ b/packages/db/prisma/migrations/20260720160000_repair_platform_config_index_integrity/migration.sql
@@ -1,0 +1,60 @@
+-- BI-E07FEB3A — restore agreement between the PlatformConfig heap and its
+-- canonical unique key index. Affected installs can hold duplicate heap rows
+-- even while pg_index reports the btree healthy.
+--
+-- Fleet safety: the most recently updated value remains active; older rows are
+-- quarantined by key, never deleted. IDs, values, and timestamps are preserved.
+-- Clean installs change no data; the migration is idempotent and fails closed.
+
+BEGIN;
+
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+DO $$
+DECLARE
+  duplicate_row RECORD;
+  quarantine_key TEXT;
+BEGIN
+  FOR duplicate_row IN
+    WITH ranked AS MATERIALIZED (
+      SELECT
+        id,
+        key,
+        row_number() OVER (
+          PARTITION BY key
+          ORDER BY "updatedAt" DESC, id DESC
+        ) AS duplicate_rank
+      FROM "PlatformConfig"
+    )
+    SELECT id, key
+    FROM ranked
+    WHERE duplicate_rank > 1
+    ORDER BY key, id
+  LOOP
+    quarantine_key := '__dpf_quarantined__' || duplicate_row.id || '__' || duplicate_row.key;
+    WHILE EXISTS (
+      SELECT 1 FROM "PlatformConfig"
+      WHERE key = quarantine_key AND id <> duplicate_row.id
+    ) LOOP
+      quarantine_key := quarantine_key || '_';
+    END LOOP;
+
+    UPDATE "PlatformConfig" SET key = quarantine_key WHERE id = duplicate_row.id;
+  END LOOP;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM "PlatformConfig" GROUP BY key HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'PlatformConfig integrity repair left duplicate keys';
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS "PlatformConfig_key_key";
+CREATE UNIQUE INDEX "PlatformConfig_key_key" ON "PlatformConfig" (key);
+
+COMMIT;

--- a/packages/db/src/platform-config-index-integrity-migration.test.ts
+++ b/packages/db/src/platform-config-index-integrity-migration.test.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const schema = `platform_config_repair_${randomUUID().replaceAll("-", "")}`;
+let client: Client;
+
+async function scalar(sql: string): Promise<number> {
+  const result = await client.query<{ value: string }>(sql);
+  return Number(result.rows[0]?.value ?? 0);
+}
+
+describeDatabase("PlatformConfig unique-index integrity migration", () => {
+  beforeAll(async () => {
+    client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    await client.query(`CREATE SCHEMA "${schema}"`);
+    await client.query(`SET search_path TO "${schema}"`);
+    await client.query(`
+      CREATE TABLE "PlatformConfig" (
+        id TEXT PRIMARY KEY,
+        key TEXT NOT NULL,
+        value JSONB NOT NULL,
+        "updatedAt" TIMESTAMP(3) NOT NULL
+      );
+      CREATE INDEX "PlatformConfig_key_key" ON "PlatformConfig" (key);
+      INSERT INTO "PlatformConfig" (id, key, value, "updatedAt") VALUES
+        ('config-old', 'build-studio-dispatch', '{"provider":"claude"}', '2026-07-01'),
+        ('config-new', 'build-studio-dispatch', '{"provider":"codex"}', '2026-07-20'),
+        ('collision', '__dpf_quarantined__config-old__build-studio-dispatch', '{"provider":"local"}', '2026-07-01');
+    `);
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await client.end();
+  });
+
+  it("keeps the newest configuration active, preserves losers, and rebuilds the unique index", async () => {
+    const migration = await readFile(
+      new URL(
+        "../prisma/migrations/20260720160000_repair_platform_config_index_integrity/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    await client.query(migration);
+
+    expect(await scalar(`SELECT count(*)::text AS value FROM "PlatformConfig"`)).toBe(3);
+    expect(
+      await scalar(`
+        SELECT count(*)::text AS value
+        FROM (SELECT key FROM "PlatformConfig" GROUP BY key HAVING count(*) > 1) duplicate_groups
+      `),
+    ).toBe(0);
+    expect(
+      (await client.query(`SELECT key, value FROM "PlatformConfig" WHERE id='config-new'`)).rows[0],
+    ).toEqual({ key: "build-studio-dispatch", value: { provider: "codex" } });
+    expect(
+      (await client.query(`SELECT key, value FROM "PlatformConfig" WHERE id='config-old'`)).rows[0],
+    ).toEqual({
+      key: "__dpf_quarantined__config-old__build-studio-dispatch_",
+      value: { provider: "claude" },
+    });
+    expect(
+      await scalar(`
+        SELECT count(*)::text AS value
+        FROM pg_index i
+        JOIN pg_class c ON c.oid=i.indexrelid
+        JOIN pg_namespace n ON n.oid=c.relnamespace
+        WHERE n.nspname=current_schema()
+          AND c.relname='PlatformConfig_key_key'
+          AND i.indisunique AND i.indisvalid AND i.indisready AND i.indislive
+      `),
+    ).toBe(1);
+
+    const beforeSecondPass = JSON.stringify((await client.query(`SELECT * FROM "PlatformConfig" ORDER BY id`)).rows);
+    await client.query(migration);
+    const afterSecondPass = JSON.stringify((await client.query(`SELECT * FROM "PlatformConfig" ORDER BY id`)).rows);
+    expect(afterSecondPass).toBe(beforeSecondPass);
+  });
+});


### PR DESCRIPTION
## Summary
- keep the newest PlatformConfig value active for each duplicate key
- quarantine older conflicting rows without deleting ids, JSON values, or timestamps
- rebuild and verify the canonical unique key index from a forced heap scan
- add an idempotent database fixture with a quarantine-key collision

## Backlog
- BI-E07FEB3A
- EP-4A12A7CB
- WC-F28B58F1

## Verification
- migration fixture: pass
- migration safety suite: pass
- DB typecheck: pass
- exact merged-code pregate: pass
- Local-CI-Evidence: cmrtexlhs00e901mlfbogyida
- Local-CI-Lease: NPEL-931FE7A511
- Exact-SHA: 4b7b659014eb4a3c2cae53d230679cbb39be7059

## Runtime evidence
The governed Contributor preview passed the pgvector, EA integrity, and array-typing repairs, then failed closed copying duplicate PlatformConfig key build-studio-dispatch and reset all 521 destination tables. The newer row selects the current Codex/ChatGPT dispatch configuration; newest-updated survivorship prevents an unintended rollback to the older Claude selection.

## Documentation impact
The implementation plan and data-impact manifest are included. No user-guide change is needed because this is an internal fleet-safe integrity repair; the operator-visible configuration workflow remains unchanged.