### PR TITLE
fix(db): repair PortfolioQualityIssue index integrity

### DIFF
--- a/docs/data-impact/2026-07-20-portfolio-quality-issue-index-integrity.data-impact.json
+++ b/docs/data-impact/2026-07-20-portfolio-quality-issue-index-integrity.data-impact.json
@@ -1,0 +1,35 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "Portfolio quality issue registry",
+    "Discovery triage decision quality-issue references",
+    "Prisma-to-EA current-state data-model mirror",
+    "Contributor sanitized-clone source and destination"
+  ],
+  "migration": {
+    "name": "20260720170000_repair_portfolio_quality_issue_index_integrity",
+    "backfill": "forced-heap exact-key convergence: newest lastDetectedAt/firstDetectedAt/id survivor remains active, collision-checked quarantine keys preserve older observations and ids, then complete unique-index rebuild; no row is deleted"
+  },
+  "tests": [
+    "packages/db/src/portfolio-quality-issue-index-integrity-migration.test.ts",
+    "packages/db/scripts/migration-safety-guard.test.ts",
+    "scripts/check-data-impact.test.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:portfolio-quality-issue#issue-key-integrity-repair",
+      "prismaModel": "PortfolioQualityIssue",
+      "lifecycleDisposition": "the newest observation remains canonical; each older duplicate remains durable under a reserved quarantine key with its original id, issue content, timestamps, and inbound references",
+      "fields": [
+        {
+          "fieldId": "data:portfolio-quality-issue#issueKey",
+          "resolution": "governed",
+          "reason": "restore trustworthy issue-key uniqueness without deleting quality history, breaking triage references, or weakening sanitized-clone enforcement",
+          "provenance": "BI-2296E46C forced heap/index evidence and migration fixture"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-20-portfolio-quality-issue-index-integrity.md
+++ b/docs/superpowers/plans/2026-07-20-portfolio-quality-issue-index-integrity.md
@@ -1,0 +1,44 @@
+# PortfolioQualityIssue unique-index integrity repair
+
+**Backlog item:** `BI-2296E46C`  
+**Epic:** `EP-4A12A7CB`  
+**Work capsule:** `WC-215CE8E3`  
+**Branch:** `codex/portfolio-quality-integrity`
+
+## Outcome
+
+Every install has one active `PortfolioQualityIssue` row per issue key, with the physical heap agreeing with `PortfolioQualityIssue_issueKey_key`. The most recently observed issue remains active; older duplicates remain durable under reserved quarantine keys. Contributor preview can copy the table without weakening its destination constraint.
+
+## Evidence and substrate
+
+- A clean, governed preview clone passed all prior repaired tables and failed closed at `PortfolioQualityIssue`.
+- A forced heap scan found 243 duplicate groups and 243 loser rows while the canonical index reported unique, valid, ready, and live.
+- `DiscoveryTriageDecision` references issue ids with `ON DELETE SET NULL`; preserving every id keeps those references intact.
+- The existing unique key and migration-based repair pattern are sufficient; no new model or runtime bypass is needed.
+
+## Implementation
+
+1. Add a database fixture with old/new observations and a quarantine-key collision. Require newest-observation survivorship, non-destructive quarantine, healthy unique-index metadata, and idempotence.
+2. Disable every index scan class; rank by `lastDetectedAt DESC, firstDetectedAt DESC, id DESC`; collision-check quarantine keys; assert a duplicate-free heap; rebuild the canonical unique index atomically.
+3. Run the fixture, DB typecheck, migration-safety guard, exact-SHA merged-code pregate, governed self-upgrade, forced heap/catalog proof, and the complete Contributor preview clone.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-2296E46C`
+- Fleet-safe migration, index rebuild, fixture, exact gate, live proof, and preview acceptance -> `BI-2296E46C`
+- Dependencies: blocks `BI-7430E579`; builds on `BI-E07FEB3A`
+- Rationale: source remediation and full preview acceptance are one indivisible integrity correction.
+
+## Risks and rollback
+
+- Index rebuild DDL runs in the governed maintenance window.
+- Only older duplicate issue keys change. IDs, issue content, timestamps, and references remain intact.
+- Clean installs change no data; reapplication is idempotent.
+- Forward rollback restores a quarantined key only after deliberately resolving its active conflict and rebuilding the index.
+
+## Completion evidence
+
+- [ ] Fixture, DB typecheck, migration safety, and exact-SHA pregate pass.
+- [ ] Governed self-upgrade and forced heap/catalog proof pass.
+- [ ] Complete Contributor preview clone and `:3001/api/health` pass.

--- a/docs/superpowers/plans/2026-07-20-portfolio-quality-issue-index-integrity.md
+++ b/docs/superpowers/plans/2026-07-20-portfolio-quality-issue-index-integrity.md
@@ -28,6 +28,7 @@ Every install has one active `PortfolioQualityIssue` row per issue key, with the
 - Parent: `BI-2296E46C`
 - Fleet-safe migration, index rebuild, fixture, exact gate, live proof, and preview acceptance -> `BI-2296E46C`
 - Dependencies: blocks `BI-7430E579`; builds on `BI-E07FEB3A`
+- Receipt: `cmrtfvojb00fx01ljoh4vnpfs`
 - Rationale: source remediation and full preview acceptance are one indivisible integrity correction.
 
 ## Risks and rollback
@@ -39,6 +40,6 @@ Every install has one active `PortfolioQualityIssue` row per issue key, with the
 
 ## Completion evidence
 
-- [ ] Fixture, DB typecheck, migration safety, and exact-SHA pregate pass.
+- [x] Fixture, DB typecheck, migration safety, and exact-SHA pregate pass at `05cb0a72f8f2fd432149c7a677ddb60fce4658ed`.
 - [ ] Governed self-upgrade and forced heap/catalog proof pass.
 - [ ] Complete Contributor preview clone and `:3001/api/health` pass.

--- a/packages/db/prisma/migrations/20260720170000_repair_portfolio_quality_issue_index_integrity/migration.sql
+++ b/packages/db/prisma/migrations/20260720170000_repair_portfolio_quality_issue_index_integrity/migration.sql
@@ -1,0 +1,68 @@
+-- BI-2296E46C — restore agreement between the PortfolioQualityIssue heap and
+-- its canonical issue-key index. Affected installs can hold duplicate heap
+-- rows even while pg_index reports the btree healthy.
+--
+-- Fleet safety: the latest observation remains active; older rows are
+-- quarantined by issueKey, never deleted. IDs, issue contents, timestamps,
+-- and inbound references are preserved. Clean installs change no data; the
+-- migration is idempotent and fails closed.
+
+BEGIN;
+
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+DO $$
+DECLARE
+  duplicate_row RECORD;
+  quarantine_key TEXT;
+BEGIN
+  FOR duplicate_row IN
+    WITH ranked AS MATERIALIZED (
+      SELECT
+        id,
+        "issueKey",
+        row_number() OVER (
+          PARTITION BY "issueKey"
+          ORDER BY "lastDetectedAt" DESC, "firstDetectedAt" DESC, id DESC
+        ) AS duplicate_rank
+      FROM "PortfolioQualityIssue"
+    )
+    SELECT id, "issueKey"
+    FROM ranked
+    WHERE duplicate_rank > 1
+    ORDER BY "issueKey", id
+  LOOP
+    quarantine_key := '__dpf_quarantined__' || duplicate_row.id || '__' || duplicate_row."issueKey";
+    WHILE EXISTS (
+      SELECT 1
+      FROM "PortfolioQualityIssue"
+      WHERE "issueKey" = quarantine_key AND id <> duplicate_row.id
+    ) LOOP
+      quarantine_key := quarantine_key || '_';
+    END LOOP;
+
+    UPDATE "PortfolioQualityIssue"
+    SET "issueKey" = quarantine_key
+    WHERE id = duplicate_row.id;
+  END LOOP;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "PortfolioQualityIssue"
+    GROUP BY "issueKey"
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'PortfolioQualityIssue integrity repair left duplicate issue keys';
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS "PortfolioQualityIssue_issueKey_key";
+CREATE UNIQUE INDEX "PortfolioQualityIssue_issueKey_key"
+  ON "PortfolioQualityIssue" ("issueKey");
+
+COMMIT;

--- a/packages/db/src/portfolio-quality-issue-index-integrity-migration.test.ts
+++ b/packages/db/src/portfolio-quality-issue-index-integrity-migration.test.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const schema = `portfolio_quality_issue_repair_${randomUUID().replaceAll("-", "")}`;
+let client: Client;
+
+async function scalar(sql: string): Promise<number> {
+  const result = await client.query<{ value: string }>(sql);
+  return Number(result.rows[0]?.value ?? 0);
+}
+
+describeDatabase("PortfolioQualityIssue unique-index integrity migration", () => {
+  beforeAll(async () => {
+    client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    await client.query(`CREATE SCHEMA "${schema}"`);
+    await client.query(`SET search_path TO "${schema}"`);
+    await client.query(`
+      CREATE TABLE "PortfolioQualityIssue" (
+        id TEXT PRIMARY KEY,
+        "issueKey" TEXT NOT NULL,
+        status TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        "firstDetectedAt" TIMESTAMP(3) NOT NULL,
+        "lastDetectedAt" TIMESTAMP(3) NOT NULL
+      );
+      CREATE INDEX "PortfolioQualityIssue_issueKey_key" ON "PortfolioQualityIssue" ("issueKey");
+      INSERT INTO "PortfolioQualityIssue"
+        (id, "issueKey", status, summary, "firstDetectedAt", "lastDetectedAt") VALUES
+        ('issue-old', 'stale-runtime', 'open', 'old observation', '2026-07-01', '2026-07-01'),
+        ('issue-new', 'stale-runtime', 'open', 'new observation', '2026-07-20', '2026-07-20'),
+        ('collision', '__dpf_quarantined__issue-old__stale-runtime', 'resolved', 'reserved collision', '2026-07-01', '2026-07-01');
+    `);
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await client.end();
+  });
+
+  it("keeps the latest observation active, preserves losers, and rebuilds the unique index", async () => {
+    const migration = await readFile(
+      new URL(
+        "../prisma/migrations/20260720170000_repair_portfolio_quality_issue_index_integrity/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    await client.query(migration);
+
+    expect(await scalar(`SELECT count(*)::text AS value FROM "PortfolioQualityIssue"`)).toBe(3);
+    expect(
+      await scalar(`
+        SELECT count(*)::text AS value
+        FROM (SELECT "issueKey" FROM "PortfolioQualityIssue" GROUP BY "issueKey" HAVING count(*) > 1) duplicate_groups
+      `),
+    ).toBe(0);
+    expect(
+      (await client.query(`SELECT "issueKey", summary FROM "PortfolioQualityIssue" WHERE id='issue-new'`)).rows[0],
+    ).toEqual({ issueKey: "stale-runtime", summary: "new observation" });
+    expect(
+      (await client.query(`SELECT "issueKey", summary FROM "PortfolioQualityIssue" WHERE id='issue-old'`)).rows[0],
+    ).toEqual({
+      issueKey: "__dpf_quarantined__issue-old__stale-runtime_",
+      summary: "old observation",
+    });
+    expect(
+      await scalar(`
+        SELECT count(*)::text AS value
+        FROM pg_index i
+        JOIN pg_class c ON c.oid=i.indexrelid
+        JOIN pg_namespace n ON n.oid=c.relnamespace
+        WHERE n.nspname=current_schema()
+          AND c.relname='PortfolioQualityIssue_issueKey_key'
+          AND i.indisunique AND i.indisvalid AND i.indisready AND i.indislive
+      `),
+    ).toBe(1);
+
+    const beforeSecondPass = JSON.stringify(
+      (await client.query(`SELECT * FROM "PortfolioQualityIssue" ORDER BY id`)).rows,
+    );
+    await client.query(migration);
+    const afterSecondPass = JSON.stringify(
+      (await client.query(`SELECT * FROM "PortfolioQualityIssue" ORDER BY id`)).rows,
+    );
+    expect(afterSecondPass).toBe(beforeSecondPass);
+  });
+});


### PR DESCRIPTION
## Summary
- repair physical duplicate `PortfolioQualityIssue.issueKey` rows without deleting issue or reference data
- keep the latest observed issue active and quarantine older conflicting keys deterministically
- rebuild and verify the canonical unique index with an idempotent database fixture
- declare the governed data impact for the quality registry, triage references, clone copies, lifecycle, and field policy

## Why
A clean Contributor-preview sanitized clone passed all prior integrity repairs, then failed closed because the live heap contained 243 duplicate issue-key groups even though PostgreSQL reported the unique index valid and live.

## Verification
- test-first DB fixture: pass
- `pnpm --filter @dpf/db typecheck`: pass
- migration safety guard: pass
- Data-Impact Gate: pass
- exact-SHA `pnpm run pregate` at `bac19696829242e62bc5cee6e2517e333896a7ab`: pass
  - sandbox freshness: green
  - migration deploy: pass
  - full web tests/typecheck/production build: pass
- overlap sweep against open PR files: no overlap

Local-CI-Evidence: exact-SHA pregate passed under lease NPEL-4961379723.

## Documentation
The implementation plan records the source evidence, survivor rule, fleet-safe rollback, backlog mapping, completion boundary, and data-impact contract.

Backlog: BI-2296E46C
