### PR TITLE
fix(db): repair ScheduledJob index integrity

### DIFF
--- a/docs/data-impact/2026-07-20-scheduled-job-index-integrity.data-impact.json
+++ b/docs/data-impact/2026-07-20-scheduled-job-index-integrity.data-impact.json
@@ -1,0 +1,35 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "Scheduled job registry",
+    "Scheduler runtime job lookup",
+    "Prisma-to-EA current-state data-model mirror",
+    "Contributor sanitized-clone source and destination"
+  ],
+  "migration": {
+    "name": "20260720180000_repair_scheduled_job_index_integrity",
+    "backfill": "forced-heap exact-key convergence: newest updatedAt/lastRunAt/createdAt/id survivor remains active, collision-checked quarantine job ids preserve older job state and ids, then complete unique-index rebuild; no row is deleted"
+  },
+  "tests": [
+    "packages/db/src/scheduled-job-index-integrity-migration.test.ts",
+    "packages/db/scripts/migration-safety-guard.test.ts",
+    "scripts/check-data-impact.test.mjs"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:scheduled-job#job-id-integrity-repair",
+      "prismaModel": "ScheduledJob",
+      "lifecycleDisposition": "the newest persisted job state remains canonical; each older duplicate remains durable under a reserved quarantine job id with its original row id, configuration, execution state, and timestamps",
+      "fields": [
+        {
+          "fieldId": "data:scheduled-job#jobId",
+          "resolution": "governed",
+          "reason": "restore trustworthy scheduler identity without deleting job history or weakening sanitized-clone enforcement",
+          "provenance": "BI-69306ED7 forced heap/index evidence and migration fixture"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-20-scheduled-job-index-integrity.md
+++ b/docs/superpowers/plans/2026-07-20-scheduled-job-index-integrity.md
@@ -27,6 +27,7 @@ Every install has one active `ScheduledJob` row per job id, with the physical he
 - Parent: `BI-69306ED7`
 - Fleet-safe migration, index rebuild, fixture, exact gate, live proof, and preview acceptance -> `BI-69306ED7`
 - Dependencies: blocks `BI-7430E579`; builds on `BI-2296E46C`
+- Receipt: `cmrth7zdb00j301p0u7lq9fbs`
 - Rationale: source remediation and full preview acceptance are one indivisible integrity correction.
 
 ## Risks and rollback

--- a/docs/superpowers/plans/2026-07-20-scheduled-job-index-integrity.md
+++ b/docs/superpowers/plans/2026-07-20-scheduled-job-index-integrity.md
@@ -1,0 +1,43 @@
+# ScheduledJob unique-index integrity repair
+
+**Backlog item:** `BI-69306ED7`  
+**Epic:** `EP-4A12A7CB`  
+**Work capsule:** `WC-F04F2FFF`  
+**Branch:** `codex/scheduled-job-integrity`
+
+## Outcome
+
+Every install has one active `ScheduledJob` row per job id, with the physical heap agreeing with `ScheduledJob_jobId_key`. The newest persisted job state remains active; older duplicates remain durable under reserved quarantine ids. Contributor preview can copy the table without weakening its destination constraint.
+
+## Evidence and substrate
+
+- A clean governed preview clone passed all preceding repaired tables, including `PortfolioQualityIssue`, then failed closed at `ScheduledJob`.
+- A forced heap scan found four duplicate groups and four loser rows while the canonical index reported unique, valid, ready, and live.
+- No foreign keys reference ScheduledJob ids. Existing job ids and the migration repair pattern are sufficient; no new scheduler substrate or runtime bypass is needed.
+
+## Implementation
+
+1. Add a database fixture with old/new job state and a quarantine-id collision. Require newest-state survivorship, non-destructive quarantine, healthy unique-index metadata, and idempotence.
+2. Disable every index scan class; rank by `updatedAt DESC, lastRunAt DESC NULLS LAST, createdAt DESC, id DESC`; collision-check quarantine job ids; assert a duplicate-free heap; rebuild the canonical unique index atomically.
+3. Run the fixture, DB typecheck, migration-safety and data-impact guards, exact-SHA merged-code pregate, governed self-upgrade, forced heap/catalog proof, and the complete Contributor preview clone.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-69306ED7`
+- Fleet-safe migration, index rebuild, fixture, exact gate, live proof, and preview acceptance -> `BI-69306ED7`
+- Dependencies: blocks `BI-7430E579`; builds on `BI-2296E46C`
+- Rationale: source remediation and full preview acceptance are one indivisible integrity correction.
+
+## Risks and rollback
+
+- Index rebuild DDL runs in the governed maintenance window.
+- Only older duplicate job ids change. IDs, job configuration, execution state, and timestamps remain intact.
+- Clean installs change no data; reapplication is idempotent.
+- Forward rollback restores a quarantined job id only after deliberately resolving its active conflict and rebuilding the index.
+
+## Completion evidence
+
+- [ ] Fixture, DB typecheck, migration safety, data impact, and exact-SHA pregate pass.
+- [ ] Governed self-upgrade and forced heap/catalog proof pass.
+- [ ] Complete Contributor preview clone and `:3001/api/health` pass.

--- a/packages/db/prisma/migrations/20260720180000_repair_scheduled_job_index_integrity/migration.sql
+++ b/packages/db/prisma/migrations/20260720180000_repair_scheduled_job_index_integrity/migration.sql
@@ -1,0 +1,67 @@
+-- BI-69306ED7 — restore agreement between the ScheduledJob heap and its
+-- canonical job-id index. Affected installs can hold duplicate heap rows even
+-- while pg_index reports the btree healthy.
+--
+-- Fleet safety: the newest persisted job state remains active; older rows are
+-- quarantined by jobId, never deleted. IDs, configuration, run state, and
+-- timestamps are preserved. Clean installs change no data; the migration is
+-- idempotent and fails closed.
+
+BEGIN;
+
+SET LOCAL enable_indexscan = off;
+SET LOCAL enable_indexonlyscan = off;
+SET LOCAL enable_bitmapscan = off;
+
+DO $$
+DECLARE
+  duplicate_row RECORD;
+  quarantine_job_id TEXT;
+BEGIN
+  FOR duplicate_row IN
+    WITH ranked AS MATERIALIZED (
+      SELECT
+        id,
+        "jobId",
+        row_number() OVER (
+          PARTITION BY "jobId"
+          ORDER BY "updatedAt" DESC, "lastRunAt" DESC NULLS LAST, "createdAt" DESC, id DESC
+        ) AS duplicate_rank
+      FROM "ScheduledJob"
+    )
+    SELECT id, "jobId"
+    FROM ranked
+    WHERE duplicate_rank > 1
+    ORDER BY "jobId", id
+  LOOP
+    quarantine_job_id := '__dpf_quarantined__' || duplicate_row.id || '__' || duplicate_row."jobId";
+    WHILE EXISTS (
+      SELECT 1
+      FROM "ScheduledJob"
+      WHERE "jobId" = quarantine_job_id AND id <> duplicate_row.id
+    ) LOOP
+      quarantine_job_id := quarantine_job_id || '_';
+    END LOOP;
+
+    UPDATE "ScheduledJob"
+    SET "jobId" = quarantine_job_id
+    WHERE id = duplicate_row.id;
+  END LOOP;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "ScheduledJob"
+    GROUP BY "jobId"
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'ScheduledJob integrity repair left duplicate job ids';
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS "ScheduledJob_jobId_key";
+CREATE UNIQUE INDEX "ScheduledJob_jobId_key" ON "ScheduledJob" ("jobId");
+
+COMMIT;

--- a/packages/db/src/scheduled-job-index-integrity-migration.test.ts
+++ b/packages/db/src/scheduled-job-index-integrity-migration.test.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+const schema = `scheduled_job_repair_${randomUUID().replaceAll("-", "")}`;
+let client: Client;
+
+async function scalar(sql: string): Promise<number> {
+  const result = await client.query<{ value: string }>(sql);
+  return Number(result.rows[0]?.value ?? 0);
+}
+
+describeDatabase("ScheduledJob unique-index integrity migration", () => {
+  beforeAll(async () => {
+    client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    await client.query(`CREATE SCHEMA "${schema}"`);
+    await client.query(`SET search_path TO "${schema}"`);
+    await client.query(`
+      CREATE TABLE "ScheduledJob" (
+        id TEXT PRIMARY KEY,
+        "jobId" TEXT NOT NULL,
+        name TEXT NOT NULL,
+        "lastStatus" TEXT,
+        "lastRunAt" TIMESTAMP(3),
+        "createdAt" TIMESTAMP(3) NOT NULL,
+        "updatedAt" TIMESTAMP(3) NOT NULL
+      );
+      CREATE INDEX "ScheduledJob_jobId_key" ON "ScheduledJob" ("jobId");
+      INSERT INTO "ScheduledJob"
+        (id, "jobId", name, "lastStatus", "lastRunAt", "createdAt", "updatedAt") VALUES
+        ('job-old', 'eval-model', 'Old eval', 'failed', '2026-07-01', '2026-06-01', '2026-07-01'),
+        ('job-new', 'eval-model', 'Current eval', 'completed', '2026-07-20', '2026-07-01', '2026-07-20'),
+        ('collision', '__dpf_quarantined__job-old__eval-model', 'Reserved collision', 'completed', NULL, '2026-07-01', '2026-07-01');
+    `);
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+    await client.end();
+  });
+
+  it("keeps the newest job state active, preserves losers, and rebuilds the unique index", async () => {
+    const migration = await readFile(
+      new URL(
+        "../prisma/migrations/20260720180000_repair_scheduled_job_index_integrity/migration.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    await client.query(migration);
+
+    expect(await scalar(`SELECT count(*)::text AS value FROM "ScheduledJob"`)).toBe(3);
+    expect(
+      await scalar(`
+        SELECT count(*)::text AS value
+        FROM (SELECT "jobId" FROM "ScheduledJob" GROUP BY "jobId" HAVING count(*) > 1) duplicate_groups
+      `),
+    ).toBe(0);
+    expect(
+      (await client.query(`SELECT "jobId", name, "lastStatus" FROM "ScheduledJob" WHERE id='job-new'`)).rows[0],
+    ).toEqual({ jobId: "eval-model", name: "Current eval", lastStatus: "completed" });
+    expect(
+      (await client.query(`SELECT "jobId", name, "lastStatus" FROM "ScheduledJob" WHERE id='job-old'`)).rows[0],
+    ).toEqual({
+      jobId: "__dpf_quarantined__job-old__eval-model_",
+      name: "Old eval",
+      lastStatus: "failed",
+    });
+    expect(
+      await scalar(`
+        SELECT count(*)::text AS value
+        FROM pg_index i
+        JOIN pg_class c ON c.oid=i.indexrelid
+        JOIN pg_namespace n ON n.oid=c.relnamespace
+        WHERE n.nspname=current_schema()
+          AND c.relname='ScheduledJob_jobId_key'
+          AND i.indisunique AND i.indisvalid AND i.indisready AND i.indislive
+      `),
+    ).toBe(1);
+
+    const beforeSecondPass = JSON.stringify((await client.query(`SELECT * FROM "ScheduledJob" ORDER BY id`)).rows);
+    await client.query(migration);
+    const afterSecondPass = JSON.stringify((await client.query(`SELECT * FROM "ScheduledJob" ORDER BY id`)).rows);
+    expect(afterSecondPass).toBe(beforeSecondPass);
+  });
+});


### PR DESCRIPTION
## Summary
- repair physical duplicate `ScheduledJob.jobId` rows without deleting scheduler state
- keep the newest persisted job state active and quarantine older conflicts deterministically
- rebuild the canonical unique index with an idempotent database fixture
- declare the governed data impact and live backlog-coverage receipt

## Why
A clean Contributor-preview sanitized clone passed all previous integrity repairs, then failed closed because the live heap contained four duplicate job-id groups even though PostgreSQL reported the unique index valid and live.

## Verification
- test-first DB fixture: red then pass
- DB typecheck: pass
- migration safety guard: pass
- Data-Impact Gate: pass
- Spec/Plan/Doc + live coverage receipt: pass locally
- exact-SHA `pnpm run pregate` at `5b7acabe6c901b062ff2ed0d617e8c79d02c0548`: pass
  - sandbox freshness: green
  - 426-migration deploy: pass
  - full web tests/typecheck/production build: pass
- overlap sweep against open PR files: no overlap

Local-CI-Evidence: exact-SHA pregate passed under lease NPEL-11776C7F3F.

## Documentation
The implementation plan and data-impact manifest record source evidence, survivor order, non-destructive lifecycle, rollback, governed receipt, and the full preview acceptance boundary.

Backlog: BI-69306ED7
