### PR TITLE
fix(db): tolerate additive clone schema skew

### DIFF
--- a/docs/superpowers/plans/2026-07-20-sanitized-clone-schema-skew.md
+++ b/docs/superpowers/plans/2026-07-20-sanitized-clone-schema-skew.md
@@ -1,0 +1,52 @@
+# Sanitized clone additive schema-skew tolerance
+
+**Backlog item:** `BI-080670E4`  
+**Epic:** `EP-5410E8EA`  
+**Work capsule:** `WC-970F331F`  
+**Branch:** `codex/sanitized-clone-schema-skew`
+
+## Outcome
+
+Contributor preview can clone a live installation whose source schema contains additive columns that have not yet reached the destination branch. Public and internal tables stream only the compatible, non-generated columns shared by source and destination; incompatible shared column types fail closed with a precise error. The destination-wide reset, restricted/confidential classifications, trigger suppression, and bounded-memory behavior remain intact.
+
+## Evidence and substrate
+
+- A governed preview run against current `main` reproduced the defect on `DecisionInteraction.gateKey`: the live source had two additive columns from an in-flight branch, while the migrated destination did not.
+- `copyTableVerbatim` currently pipes a source `pg_dump --data-only` into destination `psql`. The dump owns its source column list, so the destination rejects source-ahead columns before the fail-safe cleanup resets all 521 application tables.
+- Both databases already expose authoritative column names, types, ordinal position, and generated-column posture through `information_schema.columns`.
+- The existing child-process pipeline is the correct bounded-memory boundary. Replacing `pg_dump` with paired `psql COPY ... FORMAT binary` processes preserves streaming while allowing an explicit, catalog-derived shared column list.
+- The full rerun also proved that the restricted `VectorEmbedding` model's `@@map("vector_embedding")` physical name bypassed the model-keyed classification and reached the confidential fallback. Physical-name resolution must preserve the restricted no-copy decision; inserting a redacted null vector is both meaningless and rejected by the non-null column.
+
+## TDD implementation
+
+1. Add failing pure-contract tests for source-ahead and destination-ahead additive columns, generated-column exclusion, catalog identifier quoting, type-drift rejection, and source/destination COPY command arguments.
+2. Read both catalogs, resolve shared insertable columns in source order for both verbatim and obfuscated paths, and reject an empty or type-incompatible projection.
+3. Stream binary COPY from the source query into destination COPY using argument arrays only; retain destination `session_replication_role=replica` and bounded child stderr.
+4. Keep confidential/audit rows on their existing typed obfuscation path and restricted tables skipped, including Prisma models with mapped physical table names.
+5. Run focused tests, DB typecheck, documentation/data-impact gates, exact-SHA merged-code pregate, and a governed full clone where the source contains the two extra `DecisionInteraction` columns.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-080670E4`
+- Shared-column resolution, streaming COPY, fail-closed type checks, regression tests, exact gate, and full source-ahead preview proof -> `BI-080670E4`
+- Dependencies: none
+- Downstream: blocks final acceptance of `BI-7430E579` and authenticated UX proof for `BI-ADEF2982`
+- Receipt: `cmrtl4tcg01a701lpmor4diz8`
+- Rationale: resolving columns without changing the streaming transport would still fail on additive skew; changing transport without catalog/type guards could silently corrupt data. They form one clone-compatibility invariant.
+
+The deployed MCP surface does not expose `record_plan_backlog_coverage`, so the receipt uses the governed `record_execution_evidence` compatibility path with the same atomic decision, mapping, dependencies, and rationale.
+
+## Architecture and documentation impact
+
+- No Prisma schema, migration, route, user workflow, provider behavior, or production data changes.
+- Update the Contributor preview architecture spec and setup guide because the supported source/destination skew contract is operator-relevant.
+- The source database remains read-only. The destination is disposable and retains the existing reset-before-copy and reset-on-failure guarantees.
+
+## Completion evidence
+
+- [x] Red unit tests reproduced the missing compatibility contract; the first real rerun additionally proved the confidential `DecisionInteraction` path needed the same projection before destination cleanup ran.
+- [x] Focused clone tests pass (31/31) and DB typecheck passes.
+- [x] Exact-SHA merged-code pregate passes against current `origin/main` with sandbox freshness, migrations, full web tests, and production build green.
+- [x] Under lease `NPEL-ECC53AEB66`, all 521 source tables completed and `:3001/api/health` returned HTTP 200 while the source had two additional `DecisionInteraction` columns, the destination had zero, and all 182 decision rows cloned. Restricted `vector_embedding` correctly remained empty.
+- [ ] PR health is terminal/passing and the merge queue lands the repair.

--- a/docs/superpowers/specs/2026-03-22-dev-container-platform-development-design.md
+++ b/docs/superpowers/specs/2026-03-22-dev-container-platform-development-design.md
@@ -173,10 +173,12 @@ Sanitization rules per sensitivity level:
 
 | Sensitivity | Example Tables | Clone Strategy |
 |-------------|---------------|----------------|
-| **public** | TaxonomyNode, EaElementType, EaRelationshipType, StorefrontArchetype | Copy verbatim |
-| **internal** | Portfolio, DigitalProduct, EaElement, EaView, FeatureBuild, Epic, BacklogItem | Copy verbatim -- operator's own work, valuable for realistic testing |
+| **public** | TaxonomyNode, EaElementType, EaRelationshipType, StorefrontArchetype | Stream compatible columns verbatim with PostgreSQL binary COPY |
+| **internal** | Portfolio, DigitalProduct, EaElement, EaView, FeatureBuild, Epic, BacklogItem | Stream compatible columns verbatim with PostgreSQL binary COPY -- operator's own work, valuable for realistic testing |
 | **confidential** | User, EmployeeProfile, Team, Customer, Agent governance profiles | Obfuscate PII: names -> "Dev User NNN", emails -> `devNNN@dpf.test`, phone -> `555-0NNN`. Preserve relationships and role assignments. |
 | **restricted** | ModelProvider credentials, CREDENTIAL_ENCRYPTION_KEY, API keys, AuthorizationDecisionLog | Never copy. Generate fresh dev-only credentials. Provider registry structure copied but secrets replaced with empty/placeholder values. |
+
+For public and internal tables, the source and migrated destination catalogs define the transfer projection. The clone copies non-generated columns present on both sides in source order, ignores additive source-only or destination-only columns/tables, and fails closed if a shared column's PostgreSQL type differs. This lets a contributor preview run safely while another in-flight branch has already applied an additive migration to the local source install, without loading large tables into JavaScript memory or weakening the destination reset-on-failure guarantee.
 
 ### Audit Trail Handling
 

--- a/docs/user-guide/getting-started/dev-container.md
+++ b/docs/user-guide/getting-started/dev-container.md
@@ -41,6 +41,7 @@ Login: `admin@dpf.local` / `changeme123`
 - Production promotion still belongs to the portal's governed workflow
 - The sanitized clone runs on first startup — production must be running as the data source
 - The clone resets the disposable development application tables before copying. Restricted provider, credential, token, and connection records are not copied; production-derived search/vector values are omitted rather than carrying source terms or embeddings into the preview.
+- Additive source-schema differences are expected during concurrent development. Source-only columns or tables are left out of the preview, destination-only columns use their migrated defaults, and a shared column with an incompatible type stops the clone with a precise error instead of risking a corrupt preview.
 - Clone publication is fail-safe: if any table cannot be copied or sanitized, the development application tables are cleared again while Prisma migration history is retained. The Contributor preview will not start against a partially copied relational dataset. Correct the reported source/tooling error and restart the development initialization step to retry.
 
 ### Related

--- a/packages/db/src/sanitized-clone.test.ts
+++ b/packages/db/src/sanitized-clone.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   buildDestinationResetSql,
-  buildPgDumpArgs,
+  buildSourceCopyArgs,
+  buildDestinationCopyArgs,
+  buildCompatibleSanitizedSelectList,
   buildPsqlEnvironment,
   buildPsqlArgs,
   buildSanitizedSelectList,
@@ -16,6 +18,7 @@ import {
   prepareInsertParameter,
   runWithDestinationCleanup,
   insertRowsWithReplicationDisabled,
+  resolveCompatibleCopyColumns,
 } from "./sanitized-clone";
 
 describe("obfuscation", () => {
@@ -228,14 +231,48 @@ describe("bounded confidential inserts", () => {
   });
 });
 
-describe("verbatim copy command arguments", () => {
-  it("passes URLs and table names as arguments rather than shell syntax", () => {
-    expect(buildPgDumpArgs("postgresql://source/db?x=1&y=2", 'odd"table')).toEqual([
+describe("schema-compatible streaming copy", () => {
+  const ordinary = (columnName: string, udtName = "text") => ({
+    columnName,
+    dataType: udtName === "text" ? "text" : "USER-DEFINED",
+    udtName,
+    isGenerated: false,
+  });
+
+  it("copies only shared non-generated columns in source order", () => {
+    expect(resolveCompatibleCopyColumns(
+      [ordinary("id"), ordinary("sourceAhead"), ordinary("displayName"), { ...ordinary("searchVector", "tsvector"), isGenerated: true }],
+      [ordinary("displayName"), ordinary("destinationAhead"), ordinary("id"), ordinary("searchVector", "tsvector")],
+      "DecisionInteraction",
+    )).toEqual(["id", "displayName"]);
+  });
+
+  it("fails closed when a shared column changed type", () => {
+    expect(() => resolveCompatibleCopyColumns(
+      [ordinary("id", "text")],
+      [ordinary("id", "uuid")],
+      "Example",
+    )).toThrow(/Example\.id.*text.*uuid/);
+  });
+
+  it("uses the same compatible projection before confidential rows are obfuscated", () => {
+    expect(buildCompatibleSanitizedSelectList(
+      [ordinary("id"), ordinary("sourceAhead"), ordinary("displayName"), ordinary("embedding", "vector")],
+      [ordinary("id"), ordinary("displayName"), ordinary("embedding", "vector"), ordinary("destinationAhead")],
+      "DecisionInteraction",
+    )).toBe('"id", "displayName", NULL::text AS "embedding"');
+  });
+
+  it("passes URLs and catalog-derived identifiers as process arguments", () => {
+    expect(buildSourceCopyArgs("postgresql://source/db?x=1&y=2", 'odd"table', ["id", 'display"Name'])).toEqual([
       "--dbname=postgresql://source/db?x=1&y=2",
-      "--data-only",
-      '--table=public."odd""table"',
-      "--no-owner",
-      "--no-privileges",
+      "--set=ON_ERROR_STOP=1",
+      '--command=COPY (SELECT "id", "display""Name" FROM "odd""table") TO STDOUT WITH (FORMAT binary)',
+    ]);
+    expect(buildDestinationCopyArgs("postgresql://destination/db?x=1&y=2", 'odd"table', ["id", 'display"Name'])).toEqual([
+      "--dbname=postgresql://destination/db?x=1&y=2",
+      "--set=ON_ERROR_STOP=1",
+      '--command=COPY "odd""table" ("id", "display""Name") FROM STDIN WITH (FORMAT binary)',
     ]);
     expect(buildPsqlArgs("postgresql://destination/db?x=1&y=2")).toEqual([
       "--dbname=postgresql://destination/db?x=1&y=2",
@@ -266,6 +303,11 @@ describe("table classification helpers", () => {
   it("keeps provider connections with their restricted provider parent", () => {
     expect(shouldSkipTable("ModelProvider")).toBe(true);
     expect(shouldSkipTable("AiProviderConnection")).toBe(true);
+  });
+
+  it("applies restricted model classifications to mapped physical table names", () => {
+    expect(shouldSkipTable("VectorEmbedding")).toBe(true);
+    expect(shouldSkipTable("vector_embedding")).toBe(true);
   });
 
   it("does not copy source-derived vector embeddings", () => {

--- a/packages/db/src/sanitized-clone.ts
+++ b/packages/db/src/sanitized-clone.ts
@@ -86,6 +86,11 @@ export type ColumnTypeInfo = {
   udtName: string;
 };
 
+export type CloneColumnInfo = ColumnTypeInfo & {
+  columnName: string;
+  isGenerated: boolean;
+};
+
 const OMITTED_NATIVE_TYPES = new Set(["tsvector", "vector"]);
 
 export function quoteIdentifier(identifier: string): string {
@@ -141,13 +146,76 @@ export async function runWithDestinationCleanup<T>(
   }
 }
 
-export function buildPgDumpArgs(prodUrl: string, tableName: string): string[] {
+export function resolveCompatibleCopyColumns(
+  sourceColumns: readonly CloneColumnInfo[],
+  destinationColumns: readonly CloneColumnInfo[],
+  tableName: string,
+): string[] {
+  const destinationByName = new Map(
+    destinationColumns.map((column) => [column.columnName, column]),
+  );
+  const compatible: string[] = [];
+
+  for (const source of sourceColumns) {
+    const destination = destinationByName.get(source.columnName);
+    if (!destination || source.isGenerated || destination.isGenerated) continue;
+
+    if (source.dataType !== destination.dataType || source.udtName !== destination.udtName) {
+      throw new Error(
+        `Sanitized clone type mismatch for ${tableName}.${source.columnName}: source ${source.dataType}/${source.udtName}, destination ${destination.dataType}/${destination.udtName}`,
+      );
+    }
+    compatible.push(source.columnName);
+  }
+
+  if (compatible.length === 0) {
+    throw new Error(`Sanitized clone found no compatible insertable columns for ${tableName}`);
+  }
+  return compatible;
+}
+
+export function buildCompatibleSanitizedSelectList(
+  sourceColumns: readonly CloneColumnInfo[],
+  destinationColumns: readonly CloneColumnInfo[],
+  tableName: string,
+): string {
+  const compatibleColumns = new Set(
+    resolveCompatibleCopyColumns(sourceColumns, destinationColumns, tableName),
+  );
+  const columnTypes = new Map(
+    sourceColumns
+      .filter((column) => compatibleColumns.has(column.columnName))
+      .map((column) => [
+        column.columnName,
+        { dataType: column.dataType, udtName: column.udtName },
+      ]),
+  );
+  return buildSanitizedSelectList(columnTypes);
+}
+
+export function buildSourceCopyArgs(
+  prodUrl: string,
+  tableName: string,
+  columns: readonly string[],
+): string[] {
+  const projection = columns.map(quoteIdentifier).join(", ");
   return [
     `--dbname=${prodUrl}`,
-    "--data-only",
-    `--table=public.${quoteIdentifier(tableName)}`,
-    "--no-owner",
-    "--no-privileges",
+    "--set=ON_ERROR_STOP=1",
+    `--command=COPY (SELECT ${projection} FROM ${quoteIdentifier(tableName)}) TO STDOUT WITH (FORMAT binary)`,
+  ];
+}
+
+export function buildDestinationCopyArgs(
+  devUrl: string,
+  tableName: string,
+  columns: readonly string[],
+): string[] {
+  const columnList = columns.map(quoteIdentifier).join(", ");
+  return [
+    `--dbname=${devUrl}`,
+    "--set=ON_ERROR_STOP=1",
+    `--command=COPY ${quoteIdentifier(tableName)} (${columnList}) FROM STDIN WITH (FORMAT binary)`,
   ];
 }
 
@@ -289,6 +357,7 @@ export async function runSanitizedClone(): Promise<void> {
     assertDistinctDatabaseIdentities(productionIdentity, destinationIdentity);
 
     const destinationTables = await listPublicTables(dev, true);
+    const destinationTableNames = new Set(destinationTables.map(({ tablename }) => tablename));
 
     await runWithDestinationCleanup(
       () => resetDestinationData(dev, destinationTables.map(({ tablename }) => tablename)),
@@ -306,6 +375,10 @@ export async function runSanitizedClone(): Promise<void> {
         let autoIndex = users.length;
 
         for (const { tablename } of tables) {
+          if (!destinationTableNames.has(tablename)) {
+            console.log(`  SKIP (source schema ahead): ${tablename}`);
+            continue;
+          }
           const sensitivity = getTableSensitivity(tablename);
 
           if (sensitivity === "restricted") {
@@ -327,7 +400,7 @@ export async function runSanitizedClone(): Promise<void> {
           if (AUDIT_TABLES.has(tablename)) {
             const copyCount = Math.min(rowCount, AUDIT_RECORD_LIMIT);
             console.log(`  AUDIT (last ${copyCount} of ${rowCount}): ${tablename}`);
-            const rows = await selectRowsForSanitization(prod, tablename, copyCount);
+            const rows = await selectRowsForSanitization(prod, dev, tablename, copyCount);
             const obfuscated = obfuscateRows(rows, userIdMap, () => ++autoIndex);
             await insertRowsWithReplicationDisabled(dev, tablename, obfuscated);
             continue;
@@ -335,10 +408,10 @@ export async function runSanitizedClone(): Promise<void> {
 
           if (sensitivity === "public" || sensitivity === "internal") {
             console.log(`  COPY (${sensitivity}): ${tablename} (${rowCount} rows)`);
-            await copyTableVerbatim(tablename, prodUrl, devUrl);
+            await copyTableCompatible(tablename, prodUrl, devUrl, prod, dev);
           } else if (sensitivity === "confidential") {
             console.log(`  OBFUSCATE (confidential): ${tablename} (${rowCount} rows)`);
-            const rows = await selectRowsForSanitization(prod, tablename);
+            const rows = await selectRowsForSanitization(prod, dev, tablename);
             const obfuscated = obfuscateRows(rows, userIdMap, () => ++autoIndex);
             await insertRowsWithReplicationDisabled(dev, tablename, obfuscated);
           }
@@ -391,24 +464,34 @@ async function resetDestinationData(
 }
 
 async function selectRowsForSanitization(
-  client: RawDatabaseClient,
+  sourceClient: RawDatabaseClient,
+  destinationClient: RawDatabaseClient,
   tableName: string,
   limit?: number,
 ): Promise<Array<Record<string, unknown>>> {
-  const columnTypes = await getColumnTypes(client, tableName);
-  const selectList = buildSanitizedSelectList(columnTypes);
-  if (!selectList) return [];
+  const [sourceColumns, destinationColumns] = await Promise.all([
+    getCloneColumns(sourceClient, tableName),
+    getCloneColumns(destinationClient, tableName),
+  ]);
+  const selectList = buildCompatibleSanitizedSelectList(
+    sourceColumns,
+    destinationColumns,
+    tableName,
+  );
+  const compatibleColumns = new Set(
+    resolveCompatibleCopyColumns(sourceColumns, destinationColumns, tableName),
+  );
 
   const quotedTable = quoteIdentifier(tableName);
-  const orderColumn = columnTypes.has("createdAt")
+  const orderColumn = compatibleColumns.has("createdAt")
     ? quoteIdentifier("createdAt")
-    : columnTypes.has("id")
+    : compatibleColumns.has("id")
       ? quoteIdentifier("id")
       : null;
   const orderClause = limit && orderColumn ? ` ORDER BY ${orderColumn} DESC` : "";
   const limitClause = limit ? ` LIMIT ${Math.max(0, Math.trunc(limit))}` : "";
 
-  return client.$queryRawUnsafe<Array<Record<string, unknown>>>(
+  return sourceClient.$queryRawUnsafe<Array<Record<string, unknown>>>(
     `SELECT ${selectList} FROM ${quotedTable}${orderClause}${limitClause}`,
   );
 }
@@ -438,35 +521,43 @@ function obfuscateRows(
 }
 
 /**
- * Copy all rows from a table in production to dev using pg_dump piped to psql.
- * This is the most reliable approach — handles JSON, arrays, and all column types
- * without needing to serialize/deserialize through Prisma.
+ * Stream all compatible rows from production to dev using PostgreSQL binary
+ * COPY. The explicit catalog-derived projection tolerates additive schema skew
+ * without serializing values through JavaScript.
  */
-async function copyTableVerbatim(
+async function copyTableCompatible(
   tableName: string,
   prodUrl: string,
   devUrl: string,
+  prod: RawDatabaseClient,
+  dev: RawDatabaseClient,
 ): Promise<void> {
-  const pgDump = spawn("pg_dump", buildPgDumpArgs(prodUrl, tableName), {
+  const [sourceColumns, destinationColumns] = await Promise.all([
+    getCloneColumns(prod, tableName),
+    getCloneColumns(dev, tableName),
+  ]);
+  const columns = resolveCompatibleCopyColumns(sourceColumns, destinationColumns, tableName);
+
+  const sourcePsql = spawn("psql", buildSourceCopyArgs(prodUrl, tableName, columns), {
     stdio: ["ignore", "pipe", "pipe"],
   });
-  const psql = spawn("psql", buildPsqlArgs(devUrl), {
+  const destinationPsql = spawn("psql", buildDestinationCopyArgs(devUrl, tableName, columns), {
     stdio: ["pipe", "ignore", "pipe"],
     env: buildPsqlEnvironment(),
   });
 
-  const pgDumpError = collectBoundedStderr(pgDump);
-  const psqlError = collectBoundedStderr(psql);
+  const sourceError = collectBoundedStderr(sourcePsql);
+  const destinationError = collectBoundedStderr(destinationPsql);
 
   try {
     await Promise.all([
-      pipeline(pgDump.stdout!, psql.stdin!),
-      waitForChild(pgDump, "pg_dump", pgDumpError),
-      waitForChild(psql, "psql", psqlError),
+      pipeline(sourcePsql.stdout!, destinationPsql.stdin!),
+      waitForChild(sourcePsql, "source psql", sourceError),
+      waitForChild(destinationPsql, "destination psql", destinationError),
     ]);
   } catch (error) {
-    pgDump.kill();
-    psql.kill();
+    sourcePsql.kill();
+    destinationPsql.kill();
     throw error;
   }
 }
@@ -600,6 +691,35 @@ async function getColumnTypes(
       { dataType: row.dataType, udtName: row.udtName },
     ]),
   );
+}
+
+async function getCloneColumns(
+  client: RawDatabaseClient,
+  tableName: string,
+): Promise<CloneColumnInfo[]> {
+  const rows = await client.$queryRawUnsafe<Array<{
+    columnName: string;
+    dataType: string;
+    udtName: string;
+    isGenerated: "ALWAYS" | "NEVER";
+  }>>(
+    `SELECT column_name AS "columnName",
+            data_type AS "dataType",
+            udt_name AS "udtName",
+            is_generated AS "isGenerated"
+       FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = $1
+      ORDER BY ordinal_position`,
+    tableName,
+  );
+
+  return rows.map((row) => ({
+    columnName: row.columnName,
+    dataType: row.dataType,
+    udtName: row.udtName,
+    isGenerated: row.isGenerated === "ALWAYS",
+  }));
 }
 
 // ── Neo4j Clone Pipeline ─────────────────────────────────────────────────────

--- a/packages/db/src/table-classification.ts
+++ b/packages/db/src/table-classification.ts
@@ -245,7 +245,15 @@ export const TABLE_CLASSIFICATION: Record<string, TableSensitivity> = {
 /** Fallback for tables not yet classified — defaults to confidential (obfuscate). */
 export const DEFAULT_SENSITIVITY: TableSensitivity = "confidential";
 
+// The clone enumerates physical PostgreSQL names, while this registry is keyed
+// by canonical Prisma model names. Keep explicit aliases for mapped models whose
+// classification differs from the confidential fallback.
+const PHYSICAL_TABLE_MODEL_ALIASES: Readonly<Record<string, string>> = Object.freeze({
+  vector_embedding: "VectorEmbedding",
+});
+
 /** Look up the sensitivity level for a table, falling back to DEFAULT_SENSITIVITY. */
 export function getTableSensitivity(tableName: string): TableSensitivity {
-  return TABLE_CLASSIFICATION[tableName] ?? DEFAULT_SENSITIVITY;
+  const canonicalName = PHYSICAL_TABLE_MODEL_ALIASES[tableName] ?? tableName;
+  return TABLE_CLASSIFICATION[canonicalName] ?? DEFAULT_SENSITIVITY;
 }


### PR DESCRIPTION
## Summary\n\nMakes Contributor preview cloning tolerant of additive source-schema skew. The clone now derives a compatible source/destination column projection, streams public/internal data with PostgreSQL binary COPY, applies the same projection before confidential obfuscation, and preserves restricted classification for mapped physical table names.\n\n## Changes\n\n- Replace whole-table pg_dump replay with bounded binary COPY over compatible non-generated columns.\n- Ignore additive source-only tables/columns and allow destination-only columns to use migrated defaults.\n- Fail closed with a precise error when a shared column changes PostgreSQL type.\n- Apply the compatible projection to confidential/audit rows before obfuscation.\n- Resolve vector_embedding to the restricted VectorEmbedding classification.\n- Document the concurrency-safe clone contract and fail-safe behavior.\n\n## Test plan\n\n- [x] DB typecheck\n- [x] Focused sanitized-clone suite (31/31)\n- [x] Docs links, docs impact, data impact, and secret scan\n- [x] Full 521-table clone under governed lease NPEL-ECC53AEB66\n- [x] Contributor preview GET /api/health returned HTTP 200\n- [x] Final exact-SHA merged-code pregate NPEL-F9E16D4759\n\n### Verification evidence\n\nThe live source had DecisionInteraction.gateKey and gateFallbackUsed while the current-main destination had neither. All 182 DecisionInteraction rows cloned successfully; vector_embedding was skipped and remained empty. The preview reported database=ok and eventLoop=ok. MCP evidence: cmrtkvd4d00z901lp8vgncit0 and cmrtl2xw6019n01lpvirstoih.\n\n## Related issues / Epic\n\nParent: EP-5410E8EA\nThis PR covers: BI-080670E4\nBlocks final acceptance of BI-7430E579 and authenticated UX proof for BI-ADEF2982.\n\n## Backlog coverage\n\nDecision: atomic\nParent: BI-080670E4\nCompatible projection, streaming transport, restricted physical-name resolution, regression tests, and full source-ahead preview proof are one clone-safety invariant.\n\n## Design grounding\n\nExtends the existing sanitized-clone and Contributor preview contracts. information_schema.columns remains authoritative; no new schema, service, persistence model, or classification axis is introduced.\n\n## Overlap sweep\n\nNo open PR touches any file in this branch. The unpublished decision-tier branch owns the additive source columns used to reproduce the skew; this PR does not modify that work.\n\n## Documentation impact\n\nUpdated the Contributor preview architecture spec and Dev Container guide with the supported additive-skew and fail-closed type-drift behavior.\n\n## Notes for the reviewer\n\nThere is no migration. The source remains read-only and destination reset-before-copy/reset-on-failure is unchanged. A host Node 26 V8 abort interrupted one pre-commit web typecheck attempt; the affected DB typecheck passed, and both exact-SHA merged-code pregates passed full web tests and production build.\n\nLocal-CI-Evidence: NPEL-F9E16D4759 @ 3367ea93f2f94f2ed83701e572794ae7207167b3\n\n