### PR TITLE
feat(onboarding): add optional AI COO conversational name

### DIFF
--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -64,7 +64,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
       },
     }),
     prisma.organization.findFirst({
-      select: { name: true, logoUrl: true },
+      select: { name: true, logoUrl: true, cooConversationalName: true },
     }),
     isUnifiedCoworkerEnabled(),
     resolveHomePhoneCountry(),
@@ -247,6 +247,7 @@ export default async function ShellLayout({ children }: { children: React.ReactN
         <AgentCoworkerShell
           userContext={{ userId: user.id, platformRole: user.platformRole, isSuperuser: user.isSuperuser }}
           useUnifiedCoworker={useUnifiedCoworker}
+          cooConversationalName={organization?.cooConversationalName ?? null}
         />
         {/* FeedbackButton moved to Header — see HeaderFeedbackButton */}
         <QueueFlusher />

--- a/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
+++ b/apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx
@@ -40,6 +40,8 @@ import {
   DecisionsPanel,
 } from "@/components/platform/coworker-record/panels";
 import { NeedsAndPlaybooksPanel } from "@/components/platform/coworker-record/NeedsAndPlaybooksPanel";
+import { CooConversationalNameCard } from "@/components/platform/coworker-record/CooConversationalNameCard";
+import { isStandingCooAgentId } from "@/lib/coworker-presentation/coo-name";
 
 const BUDGET_CLASS_LABELS: Record<string, string> = {
   quality_first: "Quality first",
@@ -173,6 +175,9 @@ export default async function AgentDetailPage({
     { platformRole: session.user.platformRole, isSuperuser: session.user.isSuperuser },
     "manage_platform",
   );
+  const cooNamePreference = isStandingCooAgentId(agent.agentId)
+    ? await prisma.organization.findFirst({ select: { cooConversationalName: true } }).catch(() => null)
+    : null;
 
   const providerNames: Record<string, string> = {};
   for (const p of activeProviders) providerNames[p.providerId] = p.name;
@@ -312,6 +317,13 @@ export default async function AgentDetailPage({
         {gaid && <span style={{ marginLeft: 12 }}>GAID: <code style={{ fontSize: 10 }}>{gaid}</code></span>}
         {agent.slugId && <span style={{ marginLeft: 12 }}>Slug: <code style={{ fontSize: 10 }}>{agent.slugId}</code></span>}
       </div>
+
+      {isStandingCooAgentId(agent.agentId) && (
+        <CooConversationalNameCard
+          initialName={cooNamePreference?.cooConversationalName ?? null}
+          canWrite={canWrite}
+        />
+      )}
 
       <CoworkerRecordTabs tabs={tabs}>
         <OverviewPanel record={record} summary={summary} />

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -22,30 +22,10 @@ import { getConversationParticipants } from "@/lib/actions/conversation-particip
 import type { ConversationParticipant } from "@/lib/tak/conversation-participants-core";
 import { isTaskInFlight } from "@/lib/tak/task-state-intent";
 import { CoworkerHealthStatus } from "@/components/monitoring/CoworkerHealthStatus";
-import { SetupActionButtons } from "@/components/setup/SetupActionButtons";
+import { SetupActionButtonsWrapper } from "@/components/setup/SetupActionButtonsWrapper";
 import { resolveCoworkerRuntimeMode } from "./coworker-runtime-mode";
 import type { QuestionPacket } from "@/lib/tak/question-packet";
-
-/** Renders setup action buttons only when the setup overlay is active (data attribute on <html>) */
-function SetupActionButtonsWrapper({ isPending }: { isPending: boolean }) {
-  const [active, setActive] = useState(false);
-  const [isLast, setIsLast] = useState(false);
-
-  useEffect(() => {
-    function check() {
-      setActive(document.documentElement.hasAttribute("data-setup-active"));
-      setIsLast(document.documentElement.getAttribute("data-setup-last-step") === "true");
-    }
-    check();
-    // Re-check on navigation (MutationObserver on the html element's attributes)
-    const observer = new MutationObserver(check);
-    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-setup-active", "data-setup-last-step"] });
-    return () => observer.disconnect();
-  }, []);
-
-  if (!active || isPending) return null;
-  return <SetupActionButtons isLastStep={isLast} />;
-}
+import { presentStandingCoo, resolveCooPresentationName } from "@/lib/coworker-presentation/coo-name";
 import {
   loadElevatedAssistPreference,
   saveElevatedAssistPreference,
@@ -89,6 +69,8 @@ type Props = {
   threadLoadState?: ThreadLoadState;
   /** Recovery for a failed load: hard reload to fetch a fresh bundle (see shell handler). */
   onReloadToReconnect?: () => void;
+  /** Organization-scoped presentation preference for the standing COO only. */
+  cooConversationalName?: string | null;
 };
 
 type MessageSendOptions = {
@@ -148,6 +130,7 @@ export function AgentCoworkerPanel({
   isDocked = false,
   threadLoadState,
   onReloadToReconnect,
+  cooConversationalName = null,
 }: Props) {
   const pathname = usePathname();
   // During setup, use the override so the onboarding-coo agent handles all steps
@@ -286,7 +269,7 @@ export function AgentCoworkerPanel({
   voicePlaybackEnabledRef.current = voicePlaybackEnabled;
 
   const routeAgent: AgentInfo = resolveAgentForRouteSync(effectiveRoute, userContext);
-  const agent = routeAgent;
+  const agent = presentStandingCoo(routeAgent, cooConversationalName);
   const webAccessAvailable = agentHoldsWebSearchGrant(agent.agentId);
   const canUseDev = userContext.isSuperuser || userContext.platformRole === "HR-000" || userContext.platformRole === "HR-300";
   const preferenceUserKey = userContext.userId ?? `${userContext.isSuperuser ? "super" : "role"}:${userContext.platformRole ?? "none"}`;
@@ -1003,7 +986,11 @@ export function AgentCoworkerPanel({
               key={msg.id}
               message={msg}
               showAgentLabel={showAgentLabel}
-              agentName={showAgentLabel && msg.agentId ? (AGENT_NAME_MAP[msg.agentId] ?? msg.agentId) : null}
+              agentName={showAgentLabel && msg.agentId ? resolveCooPresentationName({
+                agentId: msg.agentId,
+                canonicalName: AGENT_NAME_MAP[msg.agentId] ?? msg.agentId,
+                conversationalName: cooConversationalName,
+              }) : null}
               onApprove={handleApprove}
               onReject={handleReject}
               {...(decisionActive ? { onDecision: (value: string) => handleSend(value) } : {})}

--- a/apps/web/components/agent/AgentCoworkerShell.test.tsx
+++ b/apps/web/components/agent/AgentCoworkerShell.test.tsx
@@ -105,7 +105,7 @@ vi.mock("./agent-panel-prefs", () => ({
   savePanelSize: vi.fn(),
 }));
 
-function renderShell() {
+function renderShell(cooConversationalName: string | null = null) {
   return render(
     <AgentCoworkerShell
       userContext={{
@@ -114,6 +114,7 @@ function renderShell() {
         isSuperuser: false,
       }}
       useUnifiedCoworker={true}
+      cooConversationalName={cooConversationalName}
     />,
   );
 }
@@ -181,6 +182,15 @@ describe("AgentCoworkerShell support entry", () => {
     cleanup();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+  });
+
+  it("passes the organization COO presentation preference to the panel", async () => {
+    renderShell("Number Two");
+    fireEvent.click(screen.getByRole("button", { name: "Open coworker" }));
+    await settleShellThread();
+    expect(agentCoworkerPanelMock).toHaveBeenLastCalledWith(expect.objectContaining({
+      cooConversationalName: "Number Two",
+    }));
   });
 
   it("handles a valid open-agent-feedback event in the existing panel", async () => {

--- a/apps/web/components/agent/AgentCoworkerShell.tsx
+++ b/apps/web/components/agent/AgentCoworkerShell.tsx
@@ -45,6 +45,7 @@ import {
 type Props = {
   userContext: UserContext;
   useUnifiedCoworker: boolean;
+  cooConversationalName?: string | null;
 };
 
 type PendingSupportSession = {
@@ -147,7 +148,7 @@ function supportStartFailureMessage(error: unknown): AgentMessageRow {
   };
 }
 
-export function AgentCoworkerShell({ userContext, useUnifiedCoworker }: Props) {
+export function AgentCoworkerShell({ userContext, useUnifiedCoworker, cooConversationalName = null }: Props) {
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
   const [position, setPosition] = useState<PanelPosition>({ x: 0, y: 0 });
@@ -708,6 +709,7 @@ export function AgentCoworkerShell({ userContext, useUnifiedCoworker }: Props) {
             initialMessages={initialMessages}
             userContext={userContext}
             useUnifiedCoworker={useUnifiedCoworker}
+            cooConversationalName={cooConversationalName}
             onClose={handleClose}
             onDragStart={handleDragStart}
             pendingAutoMessage={pendingAutoMessage}

--- a/apps/web/components/platform/coworker-record/CooConversationalNameCard.test.tsx
+++ b/apps/web/components/platform/coworker-record/CooConversationalNameCard.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { saveCooConversationalName } = vi.hoisted(() => ({ saveCooConversationalName: vi.fn() }));
+vi.mock("@/lib/actions/coo-conversational-name", () => ({ saveCooConversationalName }));
+
+import { CooConversationalNameCard } from "./CooConversationalNameCard";
+
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+describe("CooConversationalNameCard", () => {
+  it("shows a read-only role-preserving presentation to users without write authority", () => {
+    render(<CooConversationalNameCard initialName="Navigator" canWrite={false} />);
+    expect(screen.getByText(/Presented as Navigator · AI COO/)).toBeVisible();
+    expect(screen.getByText(/does not change the canonical COO identity, permissions, authority/)).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+  });
+
+  it("lets an authorized operator change and clear the preference", async () => {
+    saveCooConversationalName
+      .mockResolvedValueOnce({ ok: true, value: "General" })
+      .mockResolvedValueOnce({ ok: true, value: null });
+    render(<CooConversationalNameCard initialName={null} canWrite />);
+
+    fireEvent.click(screen.getByRole("button", { name: "General" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(saveCooConversationalName).toHaveBeenCalledWith({ name: "General" }));
+    expect(await screen.findByText(/Presented as General · AI COO/)).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use COO" }));
+    await waitFor(() => expect(saveCooConversationalName).toHaveBeenLastCalledWith({ name: null }));
+    expect(await screen.findByText(/Presented as COO\./)).toBeVisible();
+  });
+});

--- a/apps/web/components/platform/coworker-record/CooConversationalNameCard.tsx
+++ b/apps/web/components/platform/coworker-record/CooConversationalNameCard.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { saveCooConversationalName } from "@/lib/actions/coo-conversational-name";
+import { COO_NAME_MAX_LENGTH, COO_NAME_SUGGESTION_GROUPS } from "@/lib/coworker-presentation/coo-name";
+
+export function CooConversationalNameCard({ initialName, canWrite }: { initialName: string | null; canWrite: boolean }) {
+  const [name, setName] = useState(initialName ?? "");
+  const [savedName, setSavedName] = useState(initialName);
+  const [message, setMessage] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function save(value: string | null) {
+    startTransition(async () => {
+      setMessage(null);
+      const result = await saveCooConversationalName({ name: value });
+      if (!result.ok) {
+        setMessage(result.error);
+        return;
+      }
+      setName(result.value ?? "");
+      setSavedName(result.value);
+      setMessage(result.value ? "Conversational name saved." : "The standing coworker will be shown as COO.");
+    });
+  }
+
+  return (
+    <section aria-labelledby="coo-conversational-name-heading" style={{ marginBottom: 20, padding: 14, border: "1px solid var(--dpf-border)", borderRadius: 10, background: "var(--dpf-surface-1)" }}>
+      <h2 id="coo-conversational-name-heading" style={{ margin: 0, fontSize: 13, color: "var(--dpf-text)" }}>Conversational name</h2>
+      <p style={{ margin: "5px 0 10px", fontSize: 11, lineHeight: 1.5, color: "var(--dpf-muted)", maxWidth: 760 }}>
+        {savedName ? `Presented as ${savedName} · AI COO.` : "Presented as COO."} This organization-visible preference does not change the canonical COO identity, permissions, authority, audit history, or owner accountability.
+      </p>
+      {canWrite && (
+        <>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }} aria-label="Suggested COO names">
+            {COO_NAME_SUGGESTION_GROUPS.flatMap((group) => group.names.map((suggestion) => (
+              <button key={suggestion} type="button" disabled={pending} onClick={() => setName(suggestion)} style={{ border: "1px solid var(--dpf-border)", borderRadius: 999, padding: "4px 9px", fontSize: 10, color: "var(--dpf-text)", background: "transparent" }}>{suggestion}</button>
+            )))}
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            <label htmlFor="coo-name-settings" className="sr-only">Conversational name</label>
+            <input id="coo-name-settings" value={name} maxLength={COO_NAME_MAX_LENGTH} disabled={pending} onChange={(event) => setName(event.target.value)} style={{ minWidth: 240, flex: "1 1 280px", border: "1px solid var(--dpf-border)", borderRadius: 6, padding: "7px 9px", fontSize: 12, color: "var(--dpf-text)", background: "var(--dpf-bg)" }} />
+            <button type="button" disabled={pending} onClick={() => save(name)} style={{ border: "1px solid var(--dpf-accent)", borderRadius: 6, padding: "7px 12px", fontSize: 11, color: "var(--dpf-accent)", background: "color-mix(in srgb, var(--dpf-accent) 12%, transparent)" }}>{pending ? "Saving…" : "Save"}</button>
+            <button type="button" disabled={pending} onClick={() => save(null)} style={{ border: "1px solid var(--dpf-border)", borderRadius: 6, padding: "7px 12px", fontSize: 11, color: "var(--dpf-muted)", background: "transparent" }}>Use COO</button>
+          </div>
+        </>
+      )}
+      {message && <p role="status" style={{ margin: "8px 0 0", fontSize: 11, color: message.includes("saved") || message.includes("shown") ? "var(--dpf-success)" : "var(--dpf-error)" }}>{message}</p>}
+    </section>
+  );
+}

--- a/apps/web/components/setup/CooNameSetupCard.test.tsx
+++ b/apps/web/components/setup/CooNameSetupCard.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { saveCooConversationalName } = vi.hoisted(() => ({ saveCooConversationalName: vi.fn() }));
+vi.mock("@/lib/actions/coo-conversational-name", () => ({ saveCooConversationalName }));
+
+import { CooNameSetupCard } from "./CooNameSetupCard";
+
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+describe("CooNameSetupCard", () => {
+  it("explains the boundary and saves a suggested conversational name", async () => {
+    saveCooConversationalName.mockResolvedValue({ ok: true, value: "Number Two" });
+    const details: unknown[] = [];
+    const handler = (event: Event) => details.push((event as CustomEvent).detail);
+    document.addEventListener("setup-action", handler);
+    render(<CooNameSetupCard progressId="progress-1" initialName={null} />);
+
+    expect(screen.getByText(/does not change the coworker's role, permissions, authority/)).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Number Two" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save and continue" }));
+
+    await waitFor(() => expect(saveCooConversationalName).toHaveBeenCalledWith({ name: "Number Two", setupProgressId: "progress-1" }));
+    expect(details).toEqual([{ action: "continue", contextUpdate: { cooConversationalName: "Number Two" } }]);
+    document.removeEventListener("setup-action", handler);
+  });
+
+  it("can keep the canonical COO title", async () => {
+    saveCooConversationalName.mockResolvedValue({ ok: true, value: null });
+    render(<CooNameSetupCard progressId="progress-1" initialName="General" />);
+    fireEvent.click(screen.getByRole("button", { name: "Keep COO" }));
+    await waitFor(() => expect(saveCooConversationalName).toHaveBeenCalledWith({ name: null, setupProgressId: "progress-1" }));
+  });
+
+  it("shows validation errors without advancing", async () => {
+    saveCooConversationalName.mockResolvedValue({ ok: false, error: "That name is reserved." });
+    render(<CooNameSetupCard progressId="progress-1" initialName={null} />);
+    fireEvent.change(screen.getByLabelText("Conversational name"), { target: { value: "Owner" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save and continue" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("That name is reserved.");
+  });
+});

--- a/apps/web/components/setup/CooNameSetupCard.tsx
+++ b/apps/web/components/setup/CooNameSetupCard.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { saveCooConversationalName } from "@/lib/actions/coo-conversational-name";
+import { COO_NAME_MAX_LENGTH, COO_NAME_SUGGESTION_GROUPS } from "@/lib/coworker-presentation/coo-name";
+
+type Props = { progressId: string; initialName: string | null; disabled?: boolean };
+
+export function CooNameSetupCard({ progressId, initialName, disabled = false }: Props) {
+  const [name, setName] = useState(initialName ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function saveAndContinue(value: string | null) {
+    startTransition(async () => {
+      setError(null);
+      const result = await saveCooConversationalName({ name: value, setupProgressId: progressId });
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      document.dispatchEvent(new CustomEvent("setup-action", {
+        detail: {
+          action: "continue",
+          contextUpdate: { cooConversationalName: result.value ?? "COO" },
+        },
+      }));
+    });
+  }
+
+  const isDisabled = disabled || pending;
+  return (
+    <section
+      aria-labelledby="coo-name-heading"
+      className="fixed left-1/2 top-16 z-[59] max-h-[calc(100dvh-5rem)] w-[min(92vw,680px)] -translate-x-1/2 overflow-y-auto rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 shadow-xl"
+    >
+      <h2 id="coo-name-heading" className="m-0 text-sm font-semibold text-[var(--dpf-text)]">What would you like to call your AI COO?</h2>
+      <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">
+        This optional, organization-visible name changes presentation only. It does not change the coworker&apos;s role, permissions, authority, audit identity, or your accountability as owner.
+      </p>
+      <div className="mt-3 grid gap-2 sm:grid-cols-3" aria-label="Suggested COO names">
+        {COO_NAME_SUGGESTION_GROUPS.map((group) => (
+          <fieldset key={group.label} className="min-w-0 border-0 p-0">
+            <legend className="mb-1 text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-muted)]">{group.label}</legend>
+            <div className="flex flex-wrap gap-1.5">
+              {group.names.map((suggestion) => (
+                <button key={suggestion} type="button" disabled={isDisabled} onClick={() => setName(suggestion)}
+                  className="rounded-full border border-[var(--dpf-border)] px-3 py-1 text-xs text-[var(--dpf-text)] hover:border-[var(--dpf-accent)] disabled:opacity-50">
+                  {suggestion}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+        ))}
+      </div>
+      <label htmlFor="coo-conversational-name" className="mt-3 block text-xs font-medium text-[var(--dpf-text)]">Conversational name</label>
+      <input id="coo-conversational-name" value={name} maxLength={COO_NAME_MAX_LENGTH} disabled={isDisabled}
+        onChange={(event) => setName(event.target.value)} placeholder="For example, Number Two or Alex"
+        className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-bg)] px-3 py-2 text-sm text-[var(--dpf-text)]" />
+      {error && <p role="alert" className="mt-2 text-xs text-[var(--dpf-error)]">{error}</p>}
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button type="button" disabled={isDisabled} onClick={() => saveAndContinue(name)}
+          className="rounded-md border border-[var(--dpf-accent)] bg-[var(--dpf-accent)]/20 px-4 py-2 text-xs font-medium text-[var(--dpf-accent)] disabled:opacity-50">
+          {pending ? "Saving…" : "Save and continue"}
+        </button>
+        <button type="button" disabled={isDisabled} onClick={() => saveAndContinue(null)}
+          className="rounded-md border border-[var(--dpf-border)] px-4 py-2 text-xs text-[var(--dpf-muted)] disabled:opacity-50">
+          Keep COO
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/setup/SetupActionButtonsWrapper.tsx
+++ b/apps/web/components/setup/SetupActionButtonsWrapper.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { SetupActionButtons } from "./SetupActionButtons";
+
+/** Renders setup actions only while the setup overlay owns the page. */
+export function SetupActionButtonsWrapper({ isPending }: { isPending: boolean }) {
+  const [active, setActive] = useState(false);
+  const [isLast, setIsLast] = useState(false);
+
+  useEffect(() => {
+    function check() {
+      setActive(document.documentElement.hasAttribute("data-setup-active"));
+      setIsLast(document.documentElement.getAttribute("data-setup-last-step") === "true");
+    }
+    check();
+    const observer = new MutationObserver(check);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-setup-active", "data-setup-last-step"] });
+    return () => observer.disconnect();
+  }, []);
+
+  if (!active || isPending) return null;
+  return <SetupActionButtons isLastStep={isLast} />;
+}

--- a/apps/web/components/setup/SetupOverlay.test.tsx
+++ b/apps/web/components/setup/SetupOverlay.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { markStepTriggered } = vi.hoisted(() => ({ markStepTriggered: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/workspace",
+  useRouter: () => ({ push: vi.fn() }),
+}));
+vi.mock("@/lib/actions/setup-progress", () => ({
+  advanceStep: vi.fn(),
+  skipStep: vi.fn(),
+  pauseSetup: vi.fn(),
+  completeSetup: vi.fn(),
+  markStepTriggered,
+}));
+
+import { buildStepTrigger, SetupOverlay } from "./SetupOverlay";
+
+afterEach(() => { cleanup(); vi.useRealTimers(); vi.clearAllMocks(); });
+
+describe("SetupOverlay COO handoff", () => {
+  it("keeps the naming explanation honest and includes the selected presentation in the final handoff", () => {
+    expect(buildStepTrigger("meet-your-coo", {})).toContain("Onboarding COO guiding setup is distinct from the standing AI COO");
+    const final = buildStepTrigger("workspace", { cooConversationalName: "Number Two" });
+    expect(final).toContain("Number Two · AI COO");
+    expect(final).toContain("does not change the coworker's AI identity, permissions, authority, or the owner's accountability");
+  });
+
+  it("routes real-page setup guidance to the distinct Onboarding COO thread", () => {
+    vi.useFakeTimers();
+    const details: unknown[] = [];
+    const handler = (event: Event) => details.push((event as CustomEvent).detail);
+    document.addEventListener("open-agent-panel", handler);
+
+    render(<SetupOverlay
+      progressId="progress-1"
+      currentStep="meet-your-coo"
+      steps={{ "meet-your-coo": "pending", workspace: "pending" }}
+      setupContext={{}}
+      triggeredSteps={[]}
+    />);
+    act(() => vi.advanceTimersByTime(300));
+
+    expect(details).toHaveLength(1);
+    expect(details[0]).toEqual(expect.objectContaining({ routeContext: "/setup" }));
+    expect(markStepTriggered).toHaveBeenCalledWith("progress-1", "meet-your-coo");
+    document.removeEventListener("open-agent-panel", handler);
+  });
+});

--- a/apps/web/components/setup/SetupOverlay.tsx
+++ b/apps/web/components/setup/SetupOverlay.tsx
@@ -10,6 +10,7 @@ import {
   type StepStatus,
 } from "@/lib/actions/setup-constants";
 import { advanceStep, skipStep, pauseSetup, completeSetup, markStepTriggered } from "@/lib/actions/setup-progress";
+import { CooNameSetupCard } from "./CooNameSetupCard";
 
 /** Build a context-aware trigger prompt for the current setup step.
  * Sent as an autoMessage — triggers a real LLM call so the COO responds
@@ -22,7 +23,7 @@ import { advanceStep, skipStep, pauseSetup, completeSetup, markStepTriggered } f
  * Prompts under "Route Personas"). Customizing the COO's guidance during setup
  * is done by editing the onboarding-coo prompt, not these trigger strings.
  */
-function buildStepTrigger(step: string, ctx: Record<string, string>): string {
+export function buildStepTrigger(step: string, ctx: Record<string, string>): string {
   const org = ctx.orgName ? `Organisation: ${ctx.orgName}` : "Organisation: not yet entered";
   const archetype = ctx.suggestedArchetypeName ? `Business type: ${ctx.suggestedArchetypeName}` : "";
   const industry = ctx.industry || ctx.suggestedIndustry ? `Industry: ${ctx.industry || ctx.suggestedIndustry}` : "";
@@ -39,6 +40,7 @@ function buildStepTrigger(step: string, ctx: Record<string, string>): string {
     "storefront": "Storefront — customer-facing portal",
     "platform-development": "Platform Development — contribution and governance mode",
     "build-studio": "Build Studio — custom feature development",
+    "meet-your-coo": "Meet your AI COO — optionally choose how they are addressed",
     "workspace": "Workspace — day-to-day operations and guardrails",
   };
 
@@ -53,7 +55,14 @@ function buildStepTrigger(step: string, ctx: Record<string, string>): string {
   // Workspace is the final step — welcome the user and orient them, but do NOT
   // create epics, backlog items, or start building anything.
   if (step === "workspace") {
-    return `[Setup step: ${label}]\n${contextLine}\n\nThis is the final setup step. Welcome the user to their workspace. Briefly explain that this is where they will manage day-to-day operations — viewing their backlog, talking to coworkers, and monitoring work. Congratulate them on completing setup. Do NOT create any epics, backlog items, or guardrails. Do NOT start building or decomposing anything. Keep it to 2-3 sentences.`;
+    const cooName = ctx.cooConversationalName && ctx.cooConversationalName !== "COO"
+      ? `${ctx.cooConversationalName} · AI COO`
+      : "COO";
+    return `[Setup step: ${label}]\n${contextLine}\n\nThis is the final setup step. Welcome the user to their workspace and introduce their standing coworker as ${cooName}. Make clear that the conversational name does not change the coworker's AI identity, permissions, authority, or the owner's accountability. Briefly explain that this is where they will manage day-to-day operations — viewing their backlog, talking to coworkers, and monitoring work. Congratulate them on completing setup. Do NOT create any epics, backlog items, or guardrails. Do NOT start building or decomposing anything. Keep it to 2-3 sentences.`;
+  }
+
+  if (step === "meet-your-coo") {
+    return `[Setup step: ${label}]\n${contextLine}\n\nExplain in plain language that the Onboarding COO guiding setup is distinct from the standing AI COO that will have the owner's back after setup. The owner may keep the title COO or choose an optional conversational name. The name is organization-visible presentation only and cannot change identity, permissions, authority, accountability, or audit records. Invite them to use the naming card; keep it to 2-3 sentences.`;
   }
 
   if (step === "ai-providers") {
@@ -105,7 +114,9 @@ export function SetupOverlay({ progressId, currentStep, steps, setupContext, tri
     const timer = setTimeout(() => {
       document.dispatchEvent(
         new CustomEvent("open-agent-panel", {
-          detail: { autoMessage: trigger },
+          // Setup guidance always belongs to the distinct Onboarding COO and
+          // its own thread, even though the tour renders on real portal routes.
+          detail: { autoMessage: trigger, routeContext: "/setup" },
         }),
       );
       void markStepTriggered(progressId, currentStep);
@@ -125,9 +136,9 @@ export function SetupOverlay({ progressId, currentStep, steps, setupContext, tri
     window.location.href = nextRoute;
   };
 
-  const handleContinue = () => {
+  const handleContinue = (contextUpdate?: Record<string, string>) => {
     startTransition(async () => {
-      const updated = await advanceStep(progressId);
+      const updated = await advanceStep(progressId, contextUpdate);
       if ("blocked" in updated && updated.blocked === "storefront-required") {
         // The storefront hasn't been created yet — keep the operator on the
         // storefront setup so they finish the wizard before moving on.
@@ -185,8 +196,9 @@ export function SetupOverlay({ progressId, currentStep, steps, setupContext, tri
   // Listen for setup action clicks from the coworker panel
   useEffect(() => {
     function handleSetupAction(e: Event) {
-      const action = (e as CustomEvent<string>).detail;
-      if (action === "continue") handleContinue();
+      const detail = (e as CustomEvent<string | { action: string; contextUpdate?: Record<string, string> }>).detail;
+      const action = typeof detail === "string" ? detail : detail.action;
+      if (action === "continue") handleContinue(typeof detail === "string" ? undefined : detail.contextUpdate);
       else if (action === "skip") handleSkip();
       else if (action === "pause") handlePause();
     }
@@ -202,6 +214,13 @@ export function SetupOverlay({ progressId, currentStep, steps, setupContext, tri
         steps={steps}
         onStepClick={handleStepClick}
       />
+      {currentStep === "meet-your-coo" && (
+        <CooNameSetupCard
+          progressId={progressId}
+          initialName={setupContext.cooConversationalName ?? null}
+          disabled={isPending}
+        />
+      )}
       {blockedMsg && (
         <div
           role="alert"

--- a/apps/web/lib/actions/coo-conversational-name.test.ts
+++ b/apps/web/lib/actions/coo-conversational-name.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { requireCapability, revalidatePath } = vi.hoisted(() => ({
+  requireCapability: vi.fn(),
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/shared/guards", () => ({ requireCapability }));
+vi.mock("next/cache", () => ({ revalidatePath }));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    organization: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    platformSetupProgress: {
+      findUnique: vi.fn(),
+    },
+    employeeProfile: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { saveCooConversationalName } from "./coo-conversational-name";
+
+describe("saveCooConversationalName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireCapability.mockResolvedValue({ userId: "user-1" });
+    vi.mocked(prisma.organization.findFirst).mockResolvedValue({
+      id: "org-1",
+      cooConversationalName: null,
+    } as never);
+    vi.mocked(prisma.employeeProfile.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.organization.update).mockResolvedValue({
+      id: "org-1",
+      cooConversationalName: null,
+    } as never);
+  });
+
+  it("requires manage_platform before reading or writing organization state", async () => {
+    requireCapability.mockRejectedValue(new Error("Unauthorized"));
+    await expect(saveCooConversationalName({ name: "Navigator" })).rejects.toThrow("Unauthorized");
+    expect(requireCapability).toHaveBeenCalledWith("manage_platform");
+    expect(prisma.organization.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("normalizes and saves an organization-scoped name", async () => {
+    await expect(saveCooConversationalName({ name: "  Number   Two " })).resolves.toEqual({
+      ok: true,
+      value: "Number Two",
+    });
+    expect(prisma.organization.update).toHaveBeenCalledWith({
+      where: { id: "org-1" },
+      data: { cooConversationalName: "Number Two" },
+      select: { cooConversationalName: true },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith("/workspace");
+    expect(revalidatePath).toHaveBeenCalledWith("/platform/ai/agent/AGT-ORCH-000");
+  });
+
+  it("resolves the setup organization from the supplied progress record", async () => {
+    vi.mocked(prisma.platformSetupProgress.findUnique).mockResolvedValue({ organizationId: "org-setup" } as never);
+    await saveCooConversationalName({ name: "General", setupProgressId: "progress-1" });
+    expect(prisma.organization.findFirst).not.toHaveBeenCalled();
+    expect(prisma.organization.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: "org-setup" },
+    }));
+  });
+
+  it("rejects a real employee name without writing", async () => {
+    vi.mocked(prisma.employeeProfile.findFirst).mockResolvedValue({ id: "employee-1" } as never);
+    await expect(saveCooConversationalName({ name: "mark" })).resolves.toEqual({
+      ok: false,
+      error: "Choose a name that is not already used by a person in your organization.",
+    });
+    expect(prisma.employeeProfile.findFirst).toHaveBeenCalledWith({
+      where: { displayName: { equals: "mark", mode: "insensitive" } },
+      select: { id: true },
+    });
+    expect(prisma.organization.update).not.toHaveBeenCalled();
+  });
+
+  it("clears back to the canonical COO default", async () => {
+    await expect(saveCooConversationalName({ name: null })).resolves.toEqual({ ok: true, value: null });
+    expect(prisma.organization.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: { cooConversationalName: null },
+    }));
+  });
+});

--- a/apps/web/lib/actions/coo-conversational-name.ts
+++ b/apps/web/lib/actions/coo-conversational-name.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@dpf/db";
+import { requireCapability } from "@/lib/actions/shared/guards";
+import { validateCooConversationalName } from "@/lib/coworker-presentation/coo-name";
+
+export async function saveCooConversationalName({
+  name,
+  setupProgressId,
+}: {
+  name: string | null;
+  setupProgressId?: string;
+}): Promise<{ ok: true; value: string | null } | { ok: false; error: string }> {
+  await requireCapability("manage_platform");
+
+  let organizationId: string | null = null;
+  if (setupProgressId) {
+    const progress = await prisma.platformSetupProgress.findUnique({
+      where: { id: setupProgressId },
+      select: { organizationId: true },
+    });
+    organizationId = progress?.organizationId ?? null;
+  } else {
+    organizationId = (await prisma.organization.findFirst({ select: { id: true } }))?.id ?? null;
+  }
+  if (!organizationId) return { ok: false, error: "No organization is linked to this setup." };
+
+  const validation = validateCooConversationalName(name);
+  if (!validation.ok) return validation;
+  if (validation.value) {
+    const employeeCollision = await prisma.employeeProfile.findFirst({
+      where: { displayName: { equals: validation.value, mode: "insensitive" } },
+      select: { id: true },
+    });
+    if (employeeCollision) {
+      return {
+        ok: false,
+        error: "Choose a name that is not already used by a person in your organization.",
+      };
+    }
+  }
+
+  await prisma.organization.update({
+    where: { id: organizationId },
+    data: { cooConversationalName: validation.value },
+    select: { cooConversationalName: true },
+  });
+
+  revalidatePath("/workspace");
+  revalidatePath("/platform/ai/agent/AGT-ORCH-000");
+  revalidatePath("/platform/ai/agent/coo");
+  return validation;
+}

--- a/apps/web/lib/actions/setup-constants.ts
+++ b/apps/web/lib/actions/setup-constants.ts
@@ -13,6 +13,7 @@ export const SETUP_STEPS = [
   "storefront",          // /storefront — customer-facing portal setup
   "platform-development",// /admin/platform-development — contribution mode
   "build-studio",        // /build — show the self-development capability
+  "meet-your-coo",       // /workspace — optionally choose a conversational name for the standing COO
   "workspace",           // /workspace — see the workspace, meet the COO
 ] as const;
 
@@ -26,6 +27,7 @@ export const STEP_ROUTES: Record<string, string> = {
   "storefront": "/storefront",
   "platform-development": "/admin/platform-development",
   "build-studio": "/build",
+  "meet-your-coo": "/workspace",
   "workspace": "/workspace",
 };
 
@@ -39,6 +41,7 @@ export const STEP_LABELS: Record<string, string> = {
   "storefront": "Storefront",
   "platform-development": "Platform Dev",
   "build-studio": "Build",
+  "meet-your-coo": "Meet Your COO",
   "workspace": "Workspace",
 };
 
@@ -49,6 +52,7 @@ export type SetupContext = {
   orgName?: string;
   industry?: string;
   hasCloudProvider?: boolean;
+  cooConversationalName?: string;
   skippedSteps?: string[];
   // Populated by importBrandFromUrl during the branding step
   suggestedCompanyName?: string;

--- a/apps/web/lib/actions/setup-integration.test.ts
+++ b/apps/web/lib/actions/setup-integration.test.ts
@@ -47,7 +47,7 @@ import {
 } from "./setup-progress";
 import { SETUP_STEPS } from "./setup-constants";
 
-// SETUP_STEPS has 10 entries:
+// SETUP_STEPS has 11 entries:
 //   0: account-bootstrap
 //   1: business-context
 //   2: ai-providers
@@ -57,7 +57,8 @@ import { SETUP_STEPS } from "./setup-constants";
 //   6: storefront
 //   7: platform-development
 //   8: build-studio
-//   9: workspace
+//   9: meet-your-coo
+//   10: workspace
 
 describe("setup flow integration", () => {
   it("walks through the full step sequence", async () => {
@@ -96,9 +97,13 @@ describe("setup flow integration", () => {
     const step7 = await advanceStep(progress.id);
     expect(step7.currentStep).toBe("build-studio");
 
-    // Advance into the final workspace step
+    // Advance into the optional standing-COO naming step
     const step8 = await advanceStep(progress.id);
-    expect(step8.currentStep).toBe("workspace");
+    expect(step8.currentStep).toBe("meet-your-coo");
+
+    // Advance into the final workspace step
+    const step9 = await advanceStep(progress.id, { cooConversationalName: "Number Two" });
+    expect(step9.currentStep).toBe("workspace");
 
     // Advance workspace — final, sets completedAt
     const final = await advanceStep(progress.id);

--- a/apps/web/lib/coworker-presentation/coo-name.test.ts
+++ b/apps/web/lib/coworker-presentation/coo-name.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  COO_NAME_SUGGESTION_GROUPS,
+  resolveCooPresentationName,
+  validateCooConversationalName,
+} from "./coo-name";
+
+describe("COO conversational-name policy", () => {
+  it("treats blank, skip, and the canonical role as the role-only default", () => {
+    expect(validateCooConversationalName("")).toEqual({ ok: true, value: null });
+    expect(validateCooConversationalName("   ")).toEqual({ ok: true, value: null });
+    expect(validateCooConversationalName("coo")).toEqual({ ok: true, value: null });
+  });
+
+  it("normalizes a custom name without changing its human-facing casing", () => {
+    expect(validateCooConversationalName("  First   Officer  ")).toEqual({
+      ok: true,
+      value: "First Officer",
+    });
+  });
+
+  it("offers optional role, mission, and relaxed suggestions", () => {
+    expect(COO_NAME_SUGGESTION_GROUPS.map((group) => group.label)).toEqual([
+      "Role-like",
+      "Mission-inspired",
+      "Relaxed",
+    ]);
+    expect(COO_NAME_SUGGESTION_GROUPS.flatMap((group) => group.names)).toEqual(
+      expect.arrayContaining(["First Officer", "Number Two", "General", "Navigator", "Alex", "Sam"]),
+    );
+  });
+
+  it.each([
+    ["AGT-ORCH-000", "internal coworker identifier"],
+    ["system", "internal system identity"],
+    ["Onboarding COO", "distinct setup coworker"],
+    ["CEO", "accountable human role"],
+    ["Owner", "accountable human role"],
+  ])("rejects deceptive or internal name %s", (name, errorFragment) => {
+    const result = validateCooConversationalName(name);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain(errorFragment);
+  });
+
+  it("rejects control characters, overlong values, and values without a letter or number", () => {
+    expect(validateCooConversationalName("Good\u0000Name").ok).toBe(false);
+    expect(validateCooConversationalName("a".repeat(41)).ok).toBe(false);
+    expect(validateCooConversationalName("---").ok).toBe(false);
+  });
+
+  it("rejects a real employee display-name collision case-insensitively", () => {
+    const result = validateCooConversationalName("  mArK ", { employeeDisplayNames: ["Mark"] });
+    expect(result).toEqual({
+      ok: false,
+      error: "Choose a name that is not already used by a person in your organization.",
+    });
+  });
+
+  it("layers the friendly label only over the standing COO presentation", () => {
+    expect(resolveCooPresentationName({
+      agentId: "AGT-ORCH-000",
+      canonicalName: "COO",
+      conversationalName: "Number Two",
+    })).toBe("Number Two · AI COO");
+    expect(resolveCooPresentationName({
+      agentId: "coo",
+      canonicalName: "COO",
+      conversationalName: "General",
+    })).toBe("General · AI COO");
+    expect(resolveCooPresentationName({
+      agentId: "AGT-902",
+      canonicalName: "Data Protection Officer",
+      conversationalName: "General",
+    })).toBe("Data Protection Officer");
+    expect(resolveCooPresentationName({
+      agentId: "AGT-ORCH-000",
+      canonicalName: "COO",
+      conversationalName: null,
+    })).toBe("COO");
+  });
+});

--- a/apps/web/lib/coworker-presentation/coo-name.ts
+++ b/apps/web/lib/coworker-presentation/coo-name.ts
@@ -1,0 +1,100 @@
+export const COO_NAME_MAX_LENGTH = 40;
+
+export const COO_NAME_SUGGESTION_GROUPS = [
+  { label: "Role-like", names: ["First Officer", "Number Two"] },
+  { label: "Mission-inspired", names: ["General", "Navigator"] },
+  { label: "Relaxed", names: ["Alex", "Sam"] },
+] as const;
+
+type ValidationOptions = {
+  employeeDisplayNames?: readonly string[];
+};
+
+export type CooNameValidation =
+  | { ok: true; value: string | null }
+  | { ok: false; error: string };
+
+const RESERVED_NAMES = new Map<string, string>([
+  ["system", "That name is reserved for an internal system identity."],
+  ["onboarding coo", "That name belongs to the distinct setup coworker."],
+  ["ceo", "That name implies an accountable human role. Choose a conversational name instead."],
+  ["chief executive officer", "That name implies an accountable human role. Choose a conversational name instead."],
+  ["owner", "That name implies an accountable human role. Choose a conversational name instead."],
+  ["founder", "That name implies an accountable human role. Choose a conversational name instead."],
+  ["accountable officer", "That name implies an accountable human role. Choose a conversational name instead."],
+]);
+
+function normalizeForComparison(value: string): string {
+  return value.normalize("NFKC").toLocaleLowerCase();
+}
+
+export function normalizeCooConversationalName(value: string | null | undefined): string | null {
+  const normalized = value?.normalize("NFKC").trim().replace(/\s+/gu, " ") ?? "";
+  if (!normalized || normalizeForComparison(normalized) === "coo") return null;
+  return normalized;
+}
+
+export function validateCooConversationalName(
+  value: string | null | undefined,
+  options: ValidationOptions = {},
+): CooNameValidation {
+  const normalized = normalizeCooConversationalName(value);
+  if (normalized === null) return { ok: true, value: null };
+
+  if (/[\u0000-\u001f\u007f-\u009f]/u.test(normalized)) {
+    return { ok: false, error: "The conversational name cannot contain control characters." };
+  }
+  if (Array.from(normalized).length > COO_NAME_MAX_LENGTH) {
+    return { ok: false, error: `Keep the conversational name to ${COO_NAME_MAX_LENGTH} characters or fewer.` };
+  }
+  if (!/[\p{L}\p{N}]/u.test(normalized)) {
+    return { ok: false, error: "Enter a name containing at least one letter or number." };
+  }
+
+  const comparison = normalizeForComparison(normalized);
+  if (/^agt(?:-|_)/u.test(comparison)) {
+    return { ok: false, error: "That looks like an internal coworker identifier." };
+  }
+  const reservedError = RESERVED_NAMES.get(comparison);
+  if (reservedError) return { ok: false, error: reservedError };
+
+  const employeeNames = options.employeeDisplayNames ?? [];
+  if (employeeNames.some((employeeName) => normalizeForComparison(employeeName.trim()) === comparison)) {
+    return {
+      ok: false,
+      error: "Choose a name that is not already used by a person in your organization.",
+    };
+  }
+
+  return { ok: true, value: normalized };
+}
+
+export function isStandingCooAgentId(agentId: string | null | undefined): boolean {
+  return agentId === "AGT-ORCH-000" || agentId === "coo";
+}
+
+export function resolveCooPresentationName({
+  agentId,
+  canonicalName,
+  conversationalName,
+}: {
+  agentId: string | null | undefined;
+  canonicalName: string;
+  conversationalName: string | null | undefined;
+}): string {
+  if (!isStandingCooAgentId(agentId)) return canonicalName;
+  const normalized = normalizeCooConversationalName(conversationalName);
+  return normalized ? `${normalized} · AI COO` : canonicalName;
+}
+
+export function presentStandingCoo<T extends { agentId: string; agentName: string }>(
+  agent: T,
+  conversationalName: string | null | undefined,
+): T {
+  const agentName = resolveCooPresentationName({
+    agentId: agent.agentId,
+    canonicalName: agent.agentName,
+    conversationalName,
+  });
+  return agentName === agent.agentName ? agent : { ...agent, agentName };
+}

--- a/docs/data-impact/2026-07-20-coo-conversational-name.data-impact.json
+++ b/docs/data-impact/2026-07-20-coo-conversational-name.data-impact.json
@@ -1,0 +1,37 @@
+{
+  "version": "1",
+  "accountableOwner": "platform-architecture",
+  "affectedCopies": [
+    "Organization.cooConversationalName: organization-visible presentation preference for the standing AI COO"
+  ],
+  "migration": {
+    "name": "20260720140000_add_coo_conversational_name",
+    "backfill": "none; null preserves the canonical role-only COO presentation for every existing organization"
+  },
+  "tests": [
+    "apps/web/lib/coworker-presentation/coo-name.test.ts",
+    "apps/web/lib/actions/coo-conversational-name.test.ts",
+    "apps/web/components/setup/CooNameSetupCard.test.tsx",
+    "apps/web/components/setup/SetupOverlay.test.tsx",
+    "apps/web/components/platform/coworker-record/CooConversationalNameCard.test.tsx",
+    "apps/web/lib/actions/setup-integration.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:organization",
+      "prismaModel": "Organization",
+      "lifecycleDisposition": "organization configuration; clearable by an authorized platform manager",
+      "fields": [
+        {
+          "fieldId": "data:organization#cooConversationalName",
+          "resolution": "governed",
+          "reason": "gives the owner an optional relationship-friendly address without changing the coworker's canonical identity or authority",
+          "provenance": "explicit owner choice during setup or later coworker-record editing",
+          "flags": ["subject"],
+          "fieldPolicy": "organization-visible presentation only; never a routing key, principal, author, permission subject, prompt identity, or accountable actor"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-20-coo-conversational-name.md
+++ b/docs/superpowers/plans/2026-07-20-coo-conversational-name.md
@@ -1,0 +1,78 @@
+# Organization-scoped conversational name for the AI COO
+
+**Backlog item:** BI-ADEF2982
+**Epic:** EP-AI-PROVIDER-SUITABILITY
+**Work capsule:** WC-7DC40C78
+**Branch:** `codex/coo-conversational-name`
+
+## Outcome
+
+During setup, an owner may keep “COO,” choose an optional suggestion, or enter a short organization-visible conversational name for the standing coworker. Approved conversational surfaces render `<name> · AI COO`; canonical workforce identity, routing, authority, model/provider attribution, A2A references, and authenticated action attribution remain `AGT-ORCH-000` / `COO`.
+
+## Grounded substrate
+
+- `Agent.displayName` is the canonical workforce label and `resolveAgentIdentity` forces `AGT-ORCH-000` to `COO`.
+- The setup tour is a real-route sequence in `setup-constants.ts`; `SetupOverlay` and the distinct Onboarding COO own guidance and handoff.
+- The standing chat header and message bylines currently resolve from canonical route/agent labels in `AgentCoworkerPanel`.
+- The existing coworker record at `/platform/ai/agent/[agentId]` is the correct later-management surface.
+- `PlatformSetupProgress.context` is workflow state, not durable presentation configuration. Registry aliases are technical routing identity, not organization preference.
+
+## Architecture and amended persona decision
+
+Decision `DI-B0D8FBA2C56C` recommends a nullable `Organization.cooConversationalName` field with high confidence (composite 12.365, margin 0.478, no commandment conflict). It outranks a generalized presentation table because this BI deliberately proves the contract only for the standing COO, and it decisively outranks reading completed setup context forever.
+
+This narrowly amends the ratified role-only contract: `COO` remains the primary canonical identity and all byline/accountability rules remain binding. The organization may add a conversational address only when the UI simultaneously and persistently discloses `AI COO`. The preference is never an alias, author, principal, accountable officer, permission subject, prompt identity, or routing key.
+
+## TDD implementation plan
+
+1. Add pure validation and presentation-resolution tests first: default/clear, whitespace normalization, length/control-character rejection, system identifiers, reserved accountable titles, and collision with a real employee display name.
+2. Add the nullable Organization field and fleet-safe migration, plus a data-impact manifest. No existing row changes and null means the role-only default.
+3. Add authenticated server actions to read/save/clear the preference for the current install organization. Require `manage_platform`; validate again server-side and never write Agent or historical message/audit rows.
+4. Insert a non-blocking `meet-your-coo` step before the final Workspace step. Render an accessible choice card with plain-language AI/authority disclosure, small inclusive suggestion groups, free text, Keep COO, and Skip/Later behavior. Persist the choice before advancing.
+5. Include the saved presentation in the Onboarding COO’s final handoff trigger while keeping the two agents distinct.
+6. Pass the preference from the server shell into the coworker panel. Override only standing-COO chat header, busy label, avatar, and standing-COO message byline with the role-preserving presentation string; all other coworkers and stored messages remain canonical.
+7. Add the same editor to the existing standing-COO record page for authorized later change/clear. The record header, IDs, governance, and audit panels stay canonical.
+8. Amend the persona/attribution decision, setup and AI Workforce user guides, and data-impact documentation. Run targeted unit/component/action tests, migration apply, typecheck/build, and authenticated desktop/mobile setup plus post-setup chat/settings walkthrough.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-ADEF2982`
+- Organization preference, validation, setup choice/handoff, approved chat presentation, later editor, canonical identity invariants, and UX proof -> `BI-ADEF2982`
+- Dependencies: none
+- Receipt: `cmrt9hb47021401muieltufl2`
+- Rationale: The organization preference, validation policy, setup choice/handoff, approved chat presentation, later settings editor, canonical identity invariants, and UX proof are one end-to-end personalization contract; no slice is safe or useful to ship independently.
+
+The live MCP surface does not yet expose `record_plan_backlog_coverage`, so this receipt was written through governed `record_execution_evidence` with the equivalent atomic decision and mapping after live verification of the BI.
+
+## Risks and rollback
+
+- Anthropomorphism or implied accountability is the primary product risk. Every friendly presentation keeps `AI COO` visible, while audit/byline truth remains canonical.
+- A deceptive name could impersonate a real worker or internal system. Server validation rejects employee collisions, control characters, internal identifiers, and a narrow reserved-title set; client validation is only assistance.
+- Setup must never block on personalization. Keep COO, Skip, Later, and clearing all restore the null/default contract.
+- The migration is additive and nullable. Code rollback ignores the field; data rollback is clearing the preference, not editing a committed migration.
+
+## UX fit review — optional AI COO conversational name
+
+- Decision: `fits-with-guardrails`.
+- Owning area: Platform; setup is the contextual introduction, while `/platform/ai/agent/coo` is the canonical later-management home.
+- Route family: the existing `/workspace` setup overlay and `/platform/ai/agent/coo`; no global or section navigation changes and no new route.
+- Primary persona: a non-technical founder/operator choosing how to address the coworker who has their back, without needing to understand agent identifiers, provider routing, or permission models.
+- Navigation layer touched: contextual setup action plus a local editor on the existing COO record.
+- Reuse/convergence: reuses `SetupOverlay`, its established setup-action contract, the existing coworker record, theme tokens, and standard form controls. The report-kit is intentionally not used because this is a preference form, not reporting or data-display UI. The setup action observer was extracted from the oversized coworker panel into the setup component family rather than increasing that module's budget.
+- Source truth: nullable `Organization.cooConversationalName`; `Agent.displayName`, `AGT-ORCH-000`, grants, routing, prompts, messages, and audit attribution remain canonical.
+- Empty/failure behavior: null, Keep COO, Skip, Later, or clear all retain `COO`; invalid names stay in place with a plain-language error; unauthorized users see the value but no editor; save failures do not advance setup.
+- AI boundary: choosing or saving a name sends no coworker prompt and grants no authority. The existing Onboarding COO narration remains informational, and advancing setup remains an explicit user action.
+- Design-research result: the design-intelligence and existing-spec searches returned no closer pattern. The platform UX spine favors a contextual setup decision and a single canonical settings home. Advisory decision `DI-32A5A9AE792F` favored onboarding exposure over settings-only with high confidence; the dedicated late setup step preserves that exposure without crowding initial account fields.
+- Guardrails folded into the implementation: optional language; persistent `AI COO` disclosure; no new navigation; server-side validation; role/accountability disclosure in setup and settings; desktop and narrow-viewport verification.
+- Evidence before merge: focused route/component/action tests, module-size guard, token/theme scan through the normal build gate, additive migration apply, authenticated `/workspace` setup at desktop and 390×844, standing chat presentation, `/platform/ai/agent/coo` edit/clear, and exact-SHA merged-code pregate.
+- Captured in: this plan and PR #3343.
+
+## Completion evidence
+
+- [x] Default, suggestion, custom, clear, invalid, employee-collision, authorization, and canonical identity tests pass (7 focused files, 41 tests).
+- [x] Setup resume and Onboarding-COO-to-standing-COO handoff tests pass.
+- [x] Chat header/message/busy presentation tests prove `<name> · AI COO`; routing and stored attribution remain canonical.
+- [x] Migration, data-impact, typecheck, production build, and exact-SHA pregate pass (first acceptance gate: candidate `3f9a521dd98e026fb90e2acf04b7f38584e71000` merged with `origin/main` `65354b9a71cd5d5592e177a57014042915bff4e0` under lease `NPEL-4E2D460A13`; the final evidence-only amendment is re-gated before publication).
+- [x] Authenticated desktop/mobile setup, chat, later-edit, clear, and comprehension walkthrough passes under governed Contributor preview lease `NPEL-E7220B211F`: suggestions and custom field were operable, save advanced the setup record, the 390×844 card fit within the viewport without overflow, standing chat rendered `Number Two · AI COO`, settings retained the canonical-identity disclosure, and `Use COO` cleared the organization preference.
+- [ ] PR health is terminal/passing, merge queue lands it, and governed live verification confirms the deployed behavior.

--- a/docs/superpowers/specs/2026-07-18-coo-persona-attribution-contract-design.md
+++ b/docs/superpowers/specs/2026-07-18-coo-persona-attribution-contract-design.md
@@ -98,3 +98,9 @@ Synthesis confidence ≈ 0.7 (branches converge A > C > B; the reframe strengthe
 - Current code substrate reviewed: `apps/web/lib/tak/agent-routing.ts`, `packages/db/src/agent-identity.ts`, `packages/db/data/agent_registry.json`, `prompts/route-persona/coo.prompt.md`, `apps/web/lib/attention/types.ts`, `apps/web/lib/governance/action-proposal-presentation.ts`.
 - Source of truth: founder principles `never-fabricate` + `schema-honesty-over-aspirational-naming`, plus the persona-voice and attention-surface specs.
 - Decision: escalated to a formal deliberation (this artifact); no code/schema change yet.
+
+## Narrow addendum — owner-chosen conversational address (2026-07-20)
+
+BI-ADEF2982 and governed decision `DI-B0D8FBA2C56C` add one narrow, organization-scoped option without reopening the ratified identity or attribution contract. `COO` remains the canonical workforce identity, role label, routing target, permission subject, prompt identity, author, and audit identity. During setup, an owner may optionally choose a short conversational address for the standing COO; approved conversational surfaces render it only as `<name> · AI COO`. Null means the role-only default.
+
+The preference lives on `Organization`, not `Agent`, completed setup context, or a routing alias. It cannot change grants, authority, accountability, A2A references, stored message attribution, or the authenticated `(human × client × session)` spine. The distinct Onboarding COO may explain and hand off to the standing COO but never adopts the chosen name. Server-side validation rejects internal identifiers, accountable human titles, control characters, and exact collisions with employee display names. Authorized operators may later clear the preference from the canonical COO record.

--- a/docs/user-guide/ai-workforce/index.md
+++ b/docs/user-guide/ai-workforce/index.md
@@ -28,6 +28,7 @@ The AI Workforce area is where platform administrators configure the AI infrastr
 - Monitor token spend and usage patterns across all active providers
 - Hand off configured providers into Finance so supplier ownership and committed spend stay visible
 - Manage agent-to-provider assignments for specific platform capabilities
+- Optionally give the standing COO a conversational name from its coworker record; DPF always keeps the `AI COO` role visible and does not change the coworker's identity, authority, or audit attribution
 - View the **Authority** tab to understand agent tool grants, HITL tiers, and escalation paths
 - Review the **Action History** to see all agent proposals and their approval status
 - Inspect the **Tool Execution Log** to audit every tool call made by any agent (who, what, when, result)
@@ -38,6 +39,7 @@ The AI Workforce area is where platform administrators configure the AI infrastr
 ## Related Routes
 
 - `/platform/ai/providers/[providerId]` — provider setup and the Finance Bridge panel
+- `/platform/ai/agent/AGT-ORCH-000` — standing COO record, including its optional organization-visible conversational name
 - `/platform/ai/runtime-health` — capability-aware local service and external-provider health
 - `/finance/spend/ai` — finance-owned view of AI supplier commitments and work items
 

--- a/docs/user-guide/getting-started/ai-coworker.md
+++ b/docs/user-guide/getting-started/ai-coworker.md
@@ -8,6 +8,8 @@ order: 3
 
 DPF coworkers are purposed helpers, not a generic chatbot. The coworker on a page understands the page, the selected business archetype, the user's role, and the tools that coworker is allowed to propose.
 
+The standing COO may have an owner-chosen conversational name, shown as **Name · AI COO**. This is presentation only: the canonical coworker remains COO, and identity, permissions, authority, audit attribution, and the owner's accountability do not change. Authorized users can change or clear the name from the COO record in **AI Workforce**.
+
 For the broader product framing, see [Market Archetypes And Coworkers](../market-archetypes.md).
 
 ## How It Works

--- a/docs/user-guide/getting-started/setup-and-first-login.md
+++ b/docs/user-guide/getting-started/setup-and-first-login.md
@@ -14,8 +14,9 @@ order: 5
 2. Review AI providers only after that context is captured. Personal, consumer, and unknown hosted connections remain limited to public or synthetic material until their business terms are reviewed.
 3. Use the COO's provider guidance when the decision is unclear. The COO consults the Data Governance Agent and returns validated source links, explicit unknowns, and one safest next action without sending customer data or secrets to obtain advice. If the available evidence is stale, mismatched, or incomplete, DPF says it cannot confirm the claim and keeps the safer provider posture.
 4. If you are not ready to choose, select **Skip safely** or **Review later**. Skipping does not approve a hosted provider: company and customer data remain restricted until the missing review is complete.
-5. Confirm the first internal user can authenticate and reach the internal shell.
-6. Move into the relevant operational area only after setup and first-login checks succeed.
+5. At **Meet Your COO**, optionally choose how your standing AI COO is addressed. Suggestions such as **Number Two**, **General**, or **Alex** are starting points; **Keep COO** leaves the role-only default. DPF always displays a chosen name with **AI COO** and the choice never changes permissions, authority, audit identity, or owner accountability. You can change or clear it later from the COO's AI Workforce record.
+6. Confirm the first internal user can authenticate and reach the internal shell.
+7. Move into the relevant operational area only after setup and first-login checks succeed.
 
 ## Help Visibility Policy
 

--- a/packages/db/prisma/migrations/20260720140000_add_coo_conversational_name/migration.sql
+++ b/packages/db/prisma/migrations/20260720140000_add_coo_conversational_name/migration.sql
@@ -1,0 +1,7 @@
+-- BI-ADEF2982 — optional organization-facing presentation preference for the
+-- standing COO. Null preserves the ratified role-only default. This field is
+-- never used for Agent identity, routing, authority, or attribution.
+-- @migration-safety: data-safe: additive nullable column; every existing organization remains NULL.
+
+ALTER TABLE "Organization"
+  ADD COLUMN "cooConversationalName" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3788,6 +3788,9 @@ model Organization {
   address                       Json?
   logoUrl                       String?
   designSystem                  Json?
+  // Optional organization-facing address for the standing AGT-ORCH-000 coworker.
+  // Canonical identity, routing, authority, and attribution remain Agent.displayName="COO".
+  cooConversationalName         String?
   // EP-WIKI-004: per-org retrieval mode for wiki search.
   // "vector" = the EP-WIKI-001 default (Qdrant cosine similarity only).
   // "ppr"    = vector seeds → Personalized PageRank over the per-org


### PR DESCRIPTION
## Summary

- add an optional organization-scoped conversational name for the standing AI COO, with role-like, mission-inspired, and relaxed suggestions during onboarding
- keep `COO` / `AGT-ORCH-000` canonical for routing, authority, attribution, audit, permissions, and A2A identity while approved chat presentation uses `<name> · AI COO`
- provide an authorized later editor on the standing COO record, including a one-click return to `COO`
- document the distinction between the Onboarding COO and the standing COO, and the owner-accountability guardrail

## Backlog

- BI-ADEF2982
- EP-AI-PROVIDER-SUITABILITY
- WC-7DC40C78
- Decision: DI-B0D8FBA2C56C

## UX fit

UX-Fit-Decision: fits-with-guardrails — keep naming optional and presentation-only in the existing late setup step, retain the canonical COO record as the only later editor, add no navigation, and never send a coworker prompt from the naming controls.

- Owning area: Platform, with the existing `/workspace` setup overlay as contextual introduction and `/platform/ai/agent/coo` as canonical management home.
- Primary persona: non-technical founder/operator.
- Source truth: nullable `Organization.cooConversationalName`; all identity, authority, audit, routing, and accountability remain canonical.
- Full review and evidence are captured in `docs/superpowers/plans/2026-07-20-coo-conversational-name.md`.

## Verification

- 7 focused files / 41 tests passed across validation, authorization, setup, handoff, settings, and chat presentation
- `pnpm --filter web typecheck`
- module-size guard passes after extracting setup-only observer logic from the coworker panel; the panel is smaller than its baseline
- `pnpm docs:links`
- `pnpm security:secrets`
- migration applied successfully in the governed Contributor preview; data-impact manifest included
- authenticated desktop and 390×844 mobile walkthrough under lease `NPEL-E7220B211F`: optional suggestions/custom entry, save-and-advance, mobile no-overflow fit, `Number Two · AI COO` standing chat header/bylines, later settings disclosure, and `Use COO` clear behavior
- exact-SHA merged-code pregate passed for `875b2bf74a07b3041bb7ef2691c9d764a9d5c24f` against `origin/main` `65354b9a71cd5d5592e177a57014042915bff4e0` under lease `NPEL-AC5F4D836A`

## Documentation and data impact

The setup guide, AI Workforce guide, coworker guide, persona/attribution design, implementation plan, and additive nullable-field data-impact record are updated. Existing organizations remain unchanged (`NULL` means the canonical `COO` presentation), and rollback is clearing the preference rather than rewriting migration history.