### PR TITLE
feat(inference): tell "try again" from "cannot ever work" (BI-8C44DB49)

### DIFF
--- a/apps/web/lib/inference/dispatch-failure-class.test.ts
+++ b/apps/web/lib/inference/dispatch-failure-class.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { classifyDispatchFailure } from "./dispatch-failure-class";
+
+// BI-8C44DB49. A dispatch that cannot succeed must not be retried. On the live
+// install ~8 builds each re-dispatched a deliberation ~100 times against a
+// routing contract no endpoint could satisfy, producing 5,026 stalled TaskRuns
+// in four days and holding the self-upgrade quiescence gate open permanently.
+// The retry was never the bug — failing to tell "try again" from "cannot ever
+// work" was.
+
+function err(name: string, message: string, extra: Record<string, unknown> = {}) {
+  return Object.assign(new Error(message), { name }, extra);
+}
+
+describe("structural failures — retrying cannot help", () => {
+  it("classifies an unmet agent capability floor, and names the capability", () => {
+    const verdict = classifyDispatchFailure(
+      err(
+        "NoEligibleEndpointsError",
+        "No eligible endpoints for task 'conversation': No endpoint satisfies agent capability floor (EP-AGENT-CAP-002). Missing: toolUse. (3 endpoint(s) excluded)",
+        { missingCapability: "toolUse", excludedCount: 3 },
+      ),
+    );
+    expect(verdict.retryable).toBe(false);
+    expect(verdict.code).toBe("capability-floor-unmet");
+    // The operator-facing reason must name the real constraint. Reporting this
+    // as "no providers are configured" is what sent this investigation down the
+    // wrong path for hours — the install had 3 endpoints, all excluded.
+    expect(verdict.missingCapability).toBe("toolUse");
+    expect(verdict.summary).toMatch(/toolUse/);
+    expect(verdict.summary).not.toMatch(/no providers are configured/i);
+  });
+
+  it("classifies a served-context overflow from the local endpoint", () => {
+    const verdict = classifyDispatchFailure(
+      err(
+        "Error",
+        'All endpoints failed for conversation. Attempts: [{"endpointId":"local","error":"HTTP 400 from local: {\\"error\\":{\\"code\\":400,\\"message\\":\\"request (29362 tokens) exceeds the available context size (24576 tokens), try increasing it\\",\\"type\\":\\"exceed_context_size_error\\"}}"}]',
+      ),
+    );
+    expect(verdict.retryable).toBe(false);
+    expect(verdict.code).toBe("context-overflow");
+  });
+
+  it("classifies no eligible endpoints without a capability floor", () => {
+    const verdict = classifyDispatchFailure(
+      err("NoEligibleEndpointsError", "No eligible endpoints for task 'conversation': all endpoints disabled"),
+    );
+    expect(verdict.retryable).toBe(false);
+    expect(verdict.code).toBe("no-eligible-endpoint");
+  });
+
+  it("classifies a residency/sensitivity refusal", () => {
+    const verdict = classifyDispatchFailure(
+      err("NoAllowedProvidersForSensitivityError", "No allowed providers for sensitivity 'restricted'"),
+    );
+    expect(verdict.retryable).toBe(false);
+    expect(verdict.code).toBe("sensitivity-unsatisfiable");
+  });
+});
+
+describe("transient failures — retrying is legitimate", () => {
+  it.each([
+    ["rate limit", "HTTP 429 from openai: rate_limit_exceeded"],
+    ["upstream 5xx", "HTTP 503 from anthropic: overloaded_error"],
+    ["timeout", "ETIMEDOUT connecting to endpoint"],
+    ["socket reset", "read ECONNRESET"],
+  ])("keeps %s retryable", (_label, message) => {
+    const verdict = classifyDispatchFailure(err("Error", message));
+    expect(verdict.retryable).toBe(true);
+    expect(verdict.code).toBe("transient");
+  });
+
+  it("defaults an unrecognised failure to retryable rather than settling work as impossible", () => {
+    // Fail SAFE for the build, not for the fleet: a wrong "structural" verdict
+    // silently abandons recoverable work, which is worse than one extra retry.
+    // The attempt ceiling is what bounds the unknown case.
+    const verdict = classifyDispatchFailure(err("Error", "something nobody has seen before"));
+    expect(verdict.retryable).toBe(true);
+    expect(verdict.code).toBe("transient");
+  });
+
+  it("survives a non-Error throw without claiming structural knowledge", () => {
+    expect(classifyDispatchFailure("just a string").retryable).toBe(true);
+    expect(classifyDispatchFailure(null).retryable).toBe(true);
+    expect(classifyDispatchFailure(undefined).retryable).toBe(true);
+  });
+});
+
+describe("attempt ceiling — bounds what the classifier cannot", () => {
+  it("stops re-dispatching once the ceiling is reached even when transient", () => {
+    expect(classifyDispatchFailure(err("Error", "HTTP 429"), { attempt: 1 }).shouldRedispatch).toBe(true);
+    expect(classifyDispatchFailure(err("Error", "HTTP 429"), { attempt: 5 }).shouldRedispatch).toBe(true);
+    // ~100 attempts per build is what produced the flood; the ceiling makes an
+    // unrecognised-but-permanent failure cost a bounded number of runs.
+    expect(classifyDispatchFailure(err("Error", "HTTP 429"), { attempt: 6 }).shouldRedispatch).toBe(false);
+  });
+
+  it("never re-dispatches a structural failure, even on the first attempt", () => {
+    const verdict = classifyDispatchFailure(
+      err("NoEligibleEndpointsError", "Missing: toolUse", { missingCapability: "toolUse" }),
+      { attempt: 1 },
+    );
+    expect(verdict.shouldRedispatch).toBe(false);
+  });
+});

--- a/apps/web/lib/inference/dispatch-failure-class.ts
+++ b/apps/web/lib/inference/dispatch-failure-class.ts
@@ -1,0 +1,137 @@
+// BI-8C44DB49 — tell "try again" from "cannot ever work".
+//
+// The self-upgrade wedge of 2026-07-18..21 was not caused by a retry bug. Every
+// component behaved correctly on its own terms: the deliberation dispatched, the
+// route threw, the watchdog settled the TaskRun stalled and deliberately did NOT
+// fail the build (a leaked deliberation must not corrupt a healthy build), so
+// the build still needed a deliberation and the sweep re-dispatched it. Forever.
+// ~8 builds x ~100 attempts produced 5,026 stalled TaskRuns in four days, and
+// because `coworker.reasoning-loop` is a HARD blocker in the quiescence gate,
+// the operator's self-upgrade skipped with "activity-in-flight" while the AI
+// workforce screen correctly showed nobody working — they were failed
+// dispatches, not running coworkers.
+//
+// The missing concept is this one: some failures are STRUCTURAL. No endpoint
+// offers `toolUse`; the prompt is larger than the served context. A thousand
+// retries cannot change either. Those must settle once, with the real reason,
+// and never re-dispatch.
+//
+// Deliberately a PURE function over `name` + `message`, importing nothing. Two
+// reasons: it is called from the dispatch path AND from operator-facing
+// diagnostics, and a shared module that reaches into routing internals is how
+// promoter-only code got dragged into the web bundle (BI-76651B7B). It also
+// means a non-Error throw, a serialized error crossing a queue boundary, or a
+// future error class all classify without a type dependency.
+
+/** Why a dispatch failed, in terms an operator can act on. */
+export type DispatchFailureCode =
+  | "capability-floor-unmet"
+  | "context-overflow"
+  | "no-eligible-endpoint"
+  | "sensitivity-unsatisfiable"
+  | "transient";
+
+export interface DispatchFailureVerdict {
+  code: DispatchFailureCode;
+  /** False only when retrying is provably pointless. */
+  retryable: boolean;
+  /** Whether the caller should re-dispatch: retryable AND under the ceiling. */
+  shouldRedispatch: boolean;
+  /** Operator-facing one-liner naming the real constraint. */
+  summary: string;
+  /** EP-AGENT-CAP-002 capability the contract required and nothing offered. */
+  missingCapability?: string;
+}
+
+/**
+ * Attempts allowed for a failure we could not prove structural. The flood ran to
+ * ~100 attempts per build; a ceiling means an unrecognised-but-permanent failure
+ * costs a bounded number of runs instead of an unbounded one. Low enough to stay
+ * quiet, high enough to ride out a provider outage across sweep cycles.
+ */
+export const MAX_DISPATCH_ATTEMPTS = 5;
+
+const CONTEXT_OVERFLOW = /exceed_context_size_error|exceeds the available context size|context length exceeded|maximum context length/i;
+const CAPABILITY_FLOOR = /capability floor|EP-AGENT-CAP-002/i;
+const MISSING_CAPABILITY = /Missing:\s*([A-Za-z][A-Za-z0-9_]*)/;
+
+function readError(error: unknown): { name: string; message: string; missingCapability?: string } {
+  if (typeof error === "object" && error !== null) {
+    const candidate = error as { name?: unknown; message?: unknown; missingCapability?: unknown };
+    return {
+      name: typeof candidate.name === "string" ? candidate.name : "",
+      message: typeof candidate.message === "string" ? candidate.message : "",
+      missingCapability:
+        typeof candidate.missingCapability === "string" ? candidate.missingCapability : undefined,
+    };
+  }
+  return { name: "", message: typeof error === "string" ? error : "" };
+}
+
+/**
+ * Classify a dispatch failure.
+ *
+ * Fails SAFE toward retryable: an unrecognised failure stays retryable, because
+ * wrongly calling something structural silently abandons recoverable work, which
+ * is worse than one extra attempt. The ceiling bounds that unknown case instead.
+ */
+export function classifyDispatchFailure(
+  error: unknown,
+  opts: { attempt?: number } = {},
+): DispatchFailureVerdict {
+  const { name, message, missingCapability } = readError(error);
+  const attempt = opts.attempt ?? 1;
+  const structural = (
+    code: DispatchFailureCode,
+    summary: string,
+    capability?: string,
+  ): DispatchFailureVerdict => ({
+    code,
+    retryable: false,
+    shouldRedispatch: false,
+    summary,
+    ...(capability ? { missingCapability: capability } : {}),
+  });
+
+  if (CONTEXT_OVERFLOW.test(message)) {
+    return structural(
+      "context-overflow",
+      "The request is larger than the endpoint's served context window. Retrying sends the same oversized request. Raise the served context, or reduce the prompt/tool budget.",
+    );
+  }
+
+  if (CAPABILITY_FLOOR.test(message) || (name === "NoEligibleEndpointsError" && missingCapability)) {
+    const capability = missingCapability ?? MISSING_CAPABILITY.exec(message)?.[1];
+    return structural(
+      "capability-floor-unmet",
+      capability
+        ? `No configured endpoint offers the required '${capability}' capability. Endpoints exist but were excluded — this is a capability gap, not a missing provider.`
+        : "No configured endpoint satisfies this request's capability floor. Endpoints exist but were excluded.",
+      capability,
+    );
+  }
+
+  if (name === "NoEligibleEndpointsError") {
+    return structural(
+      "no-eligible-endpoint",
+      "No endpoint satisfies this request's routing contract. Retrying re-evaluates the same contract against the same endpoints.",
+    );
+  }
+
+  if (name === "NoAllowedProvidersForSensitivityError" || name === "NoProvidersAvailableError") {
+    return structural(
+      "sensitivity-unsatisfiable",
+      "No provider is permitted for this request's sensitivity or residency policy.",
+    );
+  }
+
+  return {
+    code: "transient",
+    retryable: true,
+    shouldRedispatch: attempt <= MAX_DISPATCH_ATTEMPTS,
+    summary:
+      attempt <= MAX_DISPATCH_ATTEMPTS
+        ? "Dispatch failed for a reason that may clear on its own."
+        : `Dispatch failed ${attempt} times without a recognised structural cause; stopping at the ${MAX_DISPATCH_ATTEMPTS}-attempt ceiling rather than retrying indefinitely.`,
+  };
+}

--- a/apps/web/lib/inference/phase-model-resolution.ts
+++ b/apps/web/lib/inference/phase-model-resolution.ts
@@ -32,6 +32,10 @@
 
 import { prisma } from "@dpf/db";
 import { previewRoute, type RouteAndCallOptions } from "@/lib/inference/routed-inference";
+import {
+  classifyDispatchFailure,
+  type DispatchFailureVerdict,
+} from "@/lib/inference/dispatch-failure-class";
 import type { RequestContract } from "@/lib/routing/request-contract";
 import {
   loadPhaseEnableCandidateProviders,
@@ -234,7 +238,14 @@ async function resolveRoutedPhase(args: {
       flags: [],
     };
   } catch (err) {
-    // prepareRoute throws NoEligibleEndpointsError when zero providers exist.
+    // BI-8C44DB49: this catch used to relabel EVERY prepareRoute throw as
+    // "no providers are configured". On an install with three endpoints — all
+    // excluded because none offered `toolUse` — that reading sent both the
+    // operator and a debugging session after a configuration problem that did
+    // not exist, while the real capability gap stayed invisible for days. Report
+    // what actually happened; only claim "no providers" when that is the case.
+    const verdict = classifyDispatchFailure(err);
+    const structural = verdict.code !== "transient";
     return {
       ...base,
       providerId: null,
@@ -246,13 +257,36 @@ async function resolveRoutedPhase(args: {
       flags: [
         {
           severity: "error",
-          code: "no-providers",
-          message: `No AI providers are configured — the ${args.label} phase cannot run.`,
-          remediation:
-            "Connect a provider in Providers & Routing, or configure a local model endpoint.",
+          code: structural ? verdict.code : "no-providers",
+          message: structural
+            ? `The ${args.label} phase cannot run: ${verdict.summary}`
+            : `No AI providers are configured — the ${args.label} phase cannot run.`,
+          remediation: remediationFor(verdict),
         },
       ],
     };
+  }
+}
+
+/**
+ * Remediation that matches the actual constraint (BI-8C44DB49). "Connect a
+ * provider" is useless advice when providers exist and were excluded — it tells
+ * the operator to fix something that is not broken.
+ */
+function remediationFor(verdict: DispatchFailureVerdict): string {
+  switch (verdict.code) {
+    case "capability-floor-unmet":
+      return verdict.missingCapability
+        ? `Activate a model that supports '${verdict.missingCapability}' in Platform > AI > Model Assignment. Existing endpoints were excluded for lacking it, so adding another provider without that capability will not help.`
+        : "Activate a model whose capabilities satisfy this phase in Platform > AI > Model Assignment.";
+    case "context-overflow":
+      return "Raise the served context window on the local endpoint (DMR serving config), or reduce the prompt/tool budget for this phase.";
+    case "no-eligible-endpoint":
+      return "Relax this phase's routing contract, or activate an endpoint that satisfies it, in Providers & Routing.";
+    case "sensitivity-unsatisfiable":
+      return "Permit a provider for this sensitivity/residency policy, or lower the request's sensitivity.";
+    default:
+      return "Connect a provider in Providers & Routing, or configure a local model endpoint.";
   }
 }
 

--- a/docs/superpowers/plans/2026-07-21-dispatch-failure-fail-fast.md
+++ b/docs/superpowers/plans/2026-07-21-dispatch-failure-fail-fast.md
@@ -66,11 +66,23 @@ Everything else is `transient` and retryable up to the ceiling.
       relabelling structural failures as `no-providers` and emits remediation
       that matches the real constraint ("activate a model supporting `toolUse`",
       not "connect a provider" when providers exist).
-- [ ] **2 — fail-fast in the dispatch path.** `lib/deliberation/orchestrator.ts`
-      creates a fresh `active` TaskRun per attempt with no cap. On a structural
-      verdict it must settle the run terminally with `verdict.summary` and record
-      the code, so the sweep has something to read. Seam: the `try` around the
-      DeliberationRun creation/dispatch.
+- [ ] **2 — PREFLIGHT the route before creating the TaskRun.** Not post-hoc
+      settling — that was the obvious design and it does not work. Evidence:
+      `orchestrator.ts:731` already catches and calls
+      `settleBootstrapTaskRun(taskRunId, "failed")`, yet all 5,026 rows are
+      `stalled`, which is the *watchdog's* state, not the orchestrator's. The
+      reason is `settleBootstrapTaskRun` scopes its update to rows still in
+      `active|working|queued|running`, so once the watchdog reaps a slow failure
+      to `stalled` the orchestrator's own handler is a silent no-op. Any fix that
+      settles *after* the attempt loses the same race.
+
+      So: call the side-effect-free `previewRoute` for the deliberation's
+      contract BEFORE `prisma.taskRun.create`, classify with
+      `classifyDispatchFailure`, and on a structural verdict return a blocked
+      outcome carrying `verdict.summary` — creating no TaskRun at all. The row
+      that never exists cannot stall, cannot be reaped, cannot be retried, and
+      cannot hold the quiescence gate open. This is also the literal reading of
+      the operator's ask: "raise an error vs. trying what won't work."
 - [ ] **3 — attempt ceiling on the sweep.** The re-dispatch sweep must count
       prior attempts per build and consult `shouldRedispatch`. Same unbounded
       retry class as BI-A009313E; the ceiling is what makes an unrecognised

--- a/docs/superpowers/plans/2026-07-21-dispatch-failure-fail-fast.md
+++ b/docs/superpowers/plans/2026-07-21-dispatch-failure-fail-fast.md
@@ -1,0 +1,94 @@
+# Fail-fast dispatch classification — BI-8C44DB49
+
+Status: slice 1 landed, slices 2–4 open
+Owner: platform / inference
+Related: BI-8C44DB49, BI-A009313E (stranded-ideate flood, same unbounded-retry class)
+
+## The incident this exists to prevent
+
+Between 2026-07-18 and 07-21 a live Windows install produced **5,026 stalled
+TaskRuns in four days** (baseline ~5/day) from two titles — `Deliberation: review`
+(3,908 stalled / 60 completed) and `Deliberation: debate` (1,110 / 22). Roughly 8
+builds each re-dispatched ~100 times.
+
+Every component was individually correct:
+
+1. A deliberation dispatches.
+2. `routeAndCall` throws — **structurally**: `No endpoint satisfies agent
+   capability floor (EP-AGENT-CAP-002). Missing: toolUse. (3 endpoint(s) excluded)`
+   and, where local was reachable, `request (29362 tokens) exceeds the available
+   context size (24576 tokens)`.
+3. The watchdog settles the TaskRun `stalled` and deliberately does **not** fail
+   the build — `shouldSurfaceBuildFailure()` correctly refuses to let a leaked
+   deliberation corrupt a healthy build.
+4. The build therefore still needs a deliberation, so the sweep re-dispatches it
+   ~30 minutes later. Forever.
+
+Two consequences, both of which cost the operator days:
+
+- `coworker.reasoning-loop` is a **hard** blocker in the self-upgrade quiescence
+  gate, which skips even a *manual* trigger. With a fresh batch every 30 minutes
+  there was almost never a clear window, so self-upgrade reported
+  `activity-in-flight` while the AI workforce screen correctly showed nobody
+  working — these were failed dispatches, not running coworkers.
+- `resolve_model_selection` reported `no-providers` ("No AI providers are
+  configured") because `phase-model-resolution.ts` relabelled *every* routing
+  throw. The install had three endpoints; they were excluded for lacking
+  `toolUse`. Both the operator and a debugging session chased a configuration
+  problem that did not exist.
+
+**The missing concept:** some failures are structural. No endpoint offers
+`toolUse`; the prompt exceeds the served context. No number of retries changes
+either. Nothing in the system could express that, so everything was retryable.
+
+## Design
+
+`lib/inference/dispatch-failure-class.ts` — a pure function over `name` +
+`message`, importing nothing.
+
+- Pure because it is called from the dispatch path *and* from operator-facing
+  diagnostics; a shared module reaching into routing internals is how
+  promoter-only code got dragged into the web bundle (BI-76651B7B).
+- Over `name`/`message` rather than `instanceof` so a serialized error crossing
+  a queue boundary, a non-Error throw, or a future error class all classify.
+- **Fails safe toward retryable.** Wrongly calling something structural silently
+  abandons recoverable work — worse than one extra attempt. `MAX_DISPATCH_ATTEMPTS`
+  bounds the unknown case instead.
+
+Structural codes: `capability-floor-unmet` (carries the missing capability),
+`context-overflow`, `no-eligible-endpoint`, `sensitivity-unsatisfiable`.
+Everything else is `transient` and retryable up to the ceiling.
+
+## Slices
+
+- [x] **1 — classifier + honest diagnostics.** The pure classifier with 12 tests
+      including the exact live log strings; `phase-model-resolution.ts` stops
+      relabelling structural failures as `no-providers` and emits remediation
+      that matches the real constraint ("activate a model supporting `toolUse`",
+      not "connect a provider" when providers exist).
+- [ ] **2 — fail-fast in the dispatch path.** `lib/deliberation/orchestrator.ts`
+      creates a fresh `active` TaskRun per attempt with no cap. On a structural
+      verdict it must settle the run terminally with `verdict.summary` and record
+      the code, so the sweep has something to read. Seam: the `try` around the
+      DeliberationRun creation/dispatch.
+- [ ] **3 — attempt ceiling on the sweep.** The re-dispatch sweep must count
+      prior attempts per build and consult `shouldRedispatch`. Same unbounded
+      retry class as BI-A009313E; the ceiling is what makes an unrecognised
+      permanent failure cost a bounded number of runs.
+- [ ] **4 — quiescence gate honesty.** A TaskRun whose dispatch structurally
+      cannot succeed must not hold the self-upgrade drain open as
+      `coworker.reasoning-loop`. Today the reaper only handles corpses by
+      liveness; a structurally-blocked run is neither live work nor a corpse.
+
+## Verification
+
+Slice 1: `vitest run lib/inference/dispatch-failure-class.test.ts
+lib/inference/phase-model-resolution.test.ts` — 20 passing. Test cases use the
+verbatim error strings captured from `docker logs dpf-portal-1` during the
+incident, so the classifier is proven against the real failure text rather than
+an invented approximation.
+
+Slices 2–4 need a live-install check: after landing, `SELECT count(*) FROM
+"TaskRun" WHERE status='stalled' AND "startedAt" > now() - interval '1 day'`
+should return to single digits, and self-upgrade should stop reporting
+`activity-in-flight` with an idle workforce.


### PR DESCRIPTION
Slice 1 of the fail-fast hardening for the self-upgrade wedge. Full evidence in `BI-8C44DB49`; design and remaining slices in [the plan](docs/superpowers/plans/2026-07-21-dispatch-failure-fail-fast.md).

## What happened on the live install

5,026 stalled TaskRuns in four days (baseline ~5/day) from two titles — `Deliberation: review` (3,908 stalled / 60 completed) and `Deliberation: debate` (1,110 / 22). ~8 builds re-dispatched ~100 times each. Self-upgrade skipped with `activity-in-flight` while the AI workforce screen correctly showed nobody working.

**Every component was individually correct**, which is why it survived days of looking:

```
deliberation dispatches
  → routeAndCall throws STRUCTURALLY
       "Missing: toolUse. (3 endpoint(s) excluded)"
       "request (29362 tokens) exceeds the available context size (24576 tokens)"
  → watchdog settles it stalled, correctly refusing to fail a healthy build
  → build still needs a deliberation
  → sweep re-dispatches ~30 min later → forever
```

The missing concept was **structural failure**. No endpoint offers `toolUse`; the prompt is bigger than the context. No number of retries changes either — but nothing could express that, so everything was retryable.

## The classifier

`classifyDispatchFailure()` — pure function over `name` + `message`, importing nothing.

- **Pure** because the dispatch path *and* operator diagnostics both call it, and a shared module reaching into routing internals is exactly how promoter-only code got dragged into the web bundle (`BI-76651B7B`).
- **Over `name`/`message`, not `instanceof`**, so a serialized error crossing a queue boundary or a future error class still classifies.
- **Fails safe toward retryable.** Wrongly calling something structural silently abandons recoverable work — worse than one extra attempt. `MAX_DISPATCH_ATTEMPTS` bounds the unknown case instead of a wrong verdict doing it.

## Also fixes the diagnostic that cost days

`phase-model-resolution.ts` caught **every** `prepareRoute` throw and reported *"No AI providers are configured"*. The install had three endpoints, all excluded for lacking `toolUse` — so both the operator and a debugging session chased a configuration problem that did not exist.

Structural failures now report the real constraint, and remediation names it: *"activate a model supporting `toolUse`"* rather than *"connect a provider"* when providers are present.

## Scope — this slice does not stop the flood

By design it classifies and reports; nothing on the dispatch path consumes the verdict yet. Slices 2–4 are sequenced in the plan.

Slice 2's seam is already corrected there based on evidence found while writing it: the obvious design (settle the run terminally on failure) **cannot work**, because `orchestrator.ts:731` already does that and all 5,026 rows are `stalled` — the watchdog's state. `settleBootstrapTaskRun` only updates rows still `active|working|queued|running`, so once the watchdog reaps, the orchestrator's handler is a no-op. Slice 2 is therefore a **preflight** that creates no TaskRun at all.

## Verification

- 20 tests passing (new suite + existing `phase-model-resolution`)
- classifier cases use the **verbatim** error strings from `docker logs dpf-portal-1` during the incident, so it's proven against the real failure text rather than an approximation
- `check-bundle-boundaries` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
