### PR TITLE
fix(db): collation rebuild must report and retry, never wedge the chain

### DIFF
--- a/docs/superpowers/plans/2026-07-21-collation-drift-rebuild-reporting.md
+++ b/docs/superpowers/plans/2026-07-21-collation-drift-rebuild-reporting.md
@@ -1,0 +1,130 @@
+# Collation-drift rebuild: report per-index failures, never wedge the chain
+
+Status: migration written, pending live verification
+Related: BI-9A00FBC4 (unattended remediation), BI-BE8BBDE9 (unreachable-fix trap),
+BI-8C44DB49 (fail-fast dispatch)
+
+## Who is exposed, and why one install upgrades while another does not
+
+Not the operating system. **pgdata lineage.**
+
+```sql
+SELECT datcollversion, pg_database_collation_actual_version(oid)
+FROM pg_database WHERE datname = 'dpf';
+-- drifted install: stored NULL, actual '2.36'
+```
+
+A NULL *stored* collation version means `initdb` ran under a libc that reports
+none — musl, i.e. the old Alpine postgres image, which ships no locale data, so
+every text column sorted with C semantics regardless of the `en_US.utf8` label.
+The volume is now served by the Debian/glibc pgvector base
+(BI-A35347E4 / BI-4796D52B), and glibc *does* implement `en_US.utf8`. The text
+comparator changed underneath an existing volume.
+
+Verified on the affected install: `stored=(none)`, `actual=2.36`.
+
+This is why a Mac install upgrades cleanly while a Windows one is wedged: the Mac
+volume was created after the base-image move, so its collation version matches,
+no index is corrupt, and the rebuild is a trivial no-op. **An older install on
+any OS is equally exposed.** Not a timing issue, not OS-specific — an install-age
+issue that merely correlates with which machine was set up when.
+
+Measured consequence on the drifted install: **18 duplicate `Agent.agentId`**
+values behind a UNIQUE index that can no longer reject them. An upsert's index
+probe descends the wrong subtree, misses the existing row, and falls through to
+INSERT. Invisible to an index scan; only `enable_indexscan=off` shows them.
+
+## The defect being fixed
+
+`20260720190000_repair_collation_drift_index_rebuild` is the right repair with a
+fatal error-handling flaw:
+
+```sql
+EXCEPTION
+  WHEN unique_violation THEN blocked := blocked || ...;   -- reported, loop continues
+  WHEN others THEN RAISE EXCEPTION '...';                 -- aborts EVERYTHING
+```
+
+One index failing for any non-duplicate reason aborts the surrounding
+transaction. Postgres then rejects every later statement with *"current
+transaction is aborted"*, and that is the error Prisma surfaces — from the
+trailing `COMMIT`. **The RAISE's own message, naming the index and the real
+SQLSTATE, is never seen.**
+
+Consequence: `finished_at` stayed NULL, P3009 blocked every subsequent
+self-upgrade for three days (SUR-13E5FB0C → SUR-A0681976), and the actual cause
+was invisible the whole time. The migration's own header says it "must not wedge
+the forward-only chain for the whole fleet" — the handler defeated that intent.
+
+## The fix
+
+`20260721180000_repair_collation_drift_index_rebuild_reporting`. Migrations are
+immutable, so a new migration rather than an edit. Same data-driven index
+selection, same rebuild-only scope. The difference is the failure policy: every
+per-index failure — duplicate-blocked *or* unexpected — is caught, recorded, and
+reported by name with its SQLSTATE, and **nothing re-raises**.
+
+A duplicate-blocked unique index is an expected outcome whose data needs a dedupe
+migration; it must not stop the other ~1000 indexes from being repaired. An
+unexpected error is equally not a reason to wedge the fleet — it is a reason to
+name the index and the error and let the rest of the repair land.
+
+## Known limit — the unreachable-fix trap, again
+
+An install **already** wedged in P3009 by the original migration cannot receive
+this fix through the normal chain: P3009 blocks the very migrate step that would
+apply it. Those installs need a one-time manual `prisma migrate resolve` first —
+and note the running portal may predate the migration, in which case `resolve`
+returns P3017 and must be run from the newer image.
+
+Same shape as BI-BE8BBDE9 (a pre-#3282 portal could not self-upgrade INTO the
+#3282 fix). It is exactly the class BI-9A00FBC4 exists to address: an unattended
+remote install has nobody to run the resolve.
+
+## Verification — executed against the live drifted install
+
+The migration file itself was applied to the affected database and **committed**:
+
+```
+NOTICE:  collation-drift rebuild: 2201 index(es) rebuilt
+WARNING: 2 index(es) still hold duplicate rows and were NOT rebuilt:
+         InventoryEntity_entityKey_key, PlatformIssueReport_dedupeKey_open_key
+WARNING: 3 index(es) failed for an UNEXPECTED reason and were NOT rebuilt:
+         VoiceProfile_pkey | VoiceProfile_profileId_key | VoiceProfile_status_idx
+         [40P01 after 3 attempts: deadlock detected]
+COMMIT
+```
+
+**The load-bearing result is the `COMMIT`.** Five problem indexes, and the chain
+advanced anyway. The original aborted the entire transaction on the first of
+them and wedged every upgrade for three days.
+
+The three `VoiceProfile` indexes rebuilt cleanly on a later direct retry, once
+the upgrade's concurrent writes had stopped — confirming the deadlock was
+transient lock contention with the TTS sidecar (`dpf-dpf-tts-1`), exactly what
+the bounded retry assumes. Final state: **2,204 of 2,206 collatable indexes
+rebuilt.**
+
+Supporting evidence on the same install:
+- `Agent.agentId` duplicates went 18 → 0 after the paired dedupe migration
+  (`20260720193000`) applied during the same upgrade.
+- 429 migrations applied, 0 unresolved.
+
+## Remaining — needs a dedupe migration, not this one
+
+Two unique indexes still hold one duplicated key each and cannot be rebuilt until
+the data is resolved:
+
+| Index | Duplicated key |
+|---|---|
+| `PlatformIssueReport_dedupeKey_open_key` | `log-sig:sandbox:869e23847e` (2 rows, both `triaged_local`, 2026-06-15 and 2026-07-15) |
+| `InventoryEntity_entityKey_key` | `network_interface:iface:Ethernet_2:192.168.0.200` |
+
+Until each is deduped, that UNIQUE constraint cannot reject new duplicates.
+
+Follow the `20260720193000` pattern rather than deleting: **every conflicting row
+is retained under a collision-checked reserved key**, with natural-key foreign
+keys detached before loser keys move so `ON UPDATE CASCADE` cannot steal
+references from the canonical survivor. That keeps the repair non-destructive,
+which is the standing rule for anything an unattended upgrade may execute
+(BI-9A00FBC4).

--- a/packages/db/prisma/migrations/20260721180000_repair_collation_drift_index_rebuild_reporting/migration.sql
+++ b/packages/db/prisma/migrations/20260721180000_repair_collation_drift_index_rebuild_reporting/migration.sql
@@ -1,0 +1,156 @@
+-- BI-9C21A7E4 — re-run the collation-drift index rebuild, and REPORT per-index
+-- failures instead of aborting the whole migration on the first one.
+--
+-- WHY THIS EXISTS. 20260720190000_repair_collation_drift_index_rebuild is the
+-- right repair with one fatal flaw in its error handling:
+--
+--     EXCEPTION
+--       WHEN unique_violation THEN blocked := blocked || ...;   -- reported
+--       WHEN others THEN RAISE EXCEPTION '...';                 -- aborts EVERYTHING
+--
+-- A single index failing for any reason other than a duplicate key aborts the
+-- surrounding transaction. Postgres then rejects every later statement with
+-- "current transaction is aborted, commands ignored until end of transaction
+-- block" — and THAT is the error Prisma surfaces, from the trailing COMMIT.
+-- The RAISE's own message, which names the index and the real SQLSTATE, is
+-- never seen. On a live install this wedged the forward-only chain in P3009 and
+-- the actual cause stayed invisible for three days while every subsequent
+-- self-upgrade failed identically. Its own header says it "must not wedge the
+-- forward-only chain for the whole fleet"; the handler defeated that intent.
+--
+-- Migrations are immutable, so this is a NEW migration rather than an edit.
+--
+-- WHO NEEDS IT. Any install whose pgdata was initdb'd under Alpine/musl (which
+-- ships no locale data, so every text column sorted with C semantics) and is now
+-- served by the Debian/glibc pgvector base (BI-A35347E4 / BI-4796D52B), which
+-- DOES implement en_US.utf8. Detectable exactly:
+--
+--     SELECT datcollversion, pg_database_collation_actual_version(oid) FROM pg_database;
+--     -- drifted install: stored NULL, actual '2.36'
+--
+-- This is NOT operating-system specific — it is pgdata lineage. A newer install
+-- on any OS, created after the base-image move, has a matching collation version
+-- and no corrupt indexes; this migration is then a no-op rebuild. An older
+-- install on any OS is exposed. On the install where this was diagnosed the
+-- consequence was measurable: 18 duplicate "Agent"."agentId" values sitting
+-- behind a UNIQUE index that could no longer reject them, because an upsert's
+-- index probe descends the wrong subtree, misses the existing row, and falls
+-- through to INSERT.
+--
+-- SCOPE. Rebuild only — changes no data. Rebuilding an already-healthy index is
+-- harmless, so the index set stays data-driven rather than a hardcoded list:
+-- every install has its own corrupted subset depending on when its volume was
+-- created, and a list would go stale.
+--
+-- FAILURE POLICY (the whole point of this migration). Every per-index failure is
+-- caught, recorded, and reported by name with its SQLSTATE. NOTHING re-raises.
+-- A duplicate-blocked unique index is expected (its data needs a dedupe
+-- migration with per-table judgement) and must not stop the other 1000 indexes
+-- from being repaired. An unexpected error is equally not a reason to wedge the
+-- fleet's upgrade chain — it is a reason to tell the operator exactly which
+-- index and exactly which error, and let the rest of the repair land.
+
+-- WHAT ACTUALLY FAILED, measured. Re-running the original's loop against the
+-- drifted install in a rolled-back transaction (the diagnostic the original made
+-- impossible) reported:
+--
+--     rebuilt=2201  duplicate_blocked=2  unexpected=3
+--     DUP-BLOCKED: InventoryEntity_entityKey_key, PlatformIssueReport_dedupeKey_open_key
+--     UNEXPECTED:  VoiceProfile_pkey | VoiceProfile_profileId_key | VoiceProfile_status_idx
+--                  [40P01: deadlock detected]
+--
+-- A DEADLOCK. The TTS sidecar writes VoiceProfile while the rebuild holds locks,
+-- so three indexes lost a lock race — the single most transient, most retryable
+-- error Postgres has. The original turned that momentary contention into a
+-- three-day fleet-wide upgrade wedge, because `WHEN others` re-raised it.
+--
+-- So reporting alone is not enough: deadlock_detected is RETRIED, bounded, with
+-- the retry scoped to the one index that lost the race. Only a deadlock that
+-- survives every attempt is reported and stepped over.
+
+BEGIN;
+
+DO $$
+DECLARE
+  target RECORD;
+  rebuilt_count int := 0;
+  duplicate_blocked text[] := '{}';
+  unexpected text[] := '{}';
+  attempt int;
+  rebuilt_this_index boolean;
+  -- Small: a deadlock resolves as soon as the competing writer commits, and each
+  -- attempt re-takes the lock. More attempts would extend the lock window for no
+  -- benefit — anything still deadlocking after this is contention worth naming.
+  max_deadlock_attempts constant int := 3;
+BEGIN
+  FOR target IN
+    SELECT c.relname AS index_name, t.relname AS table_name
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_class t ON t.oid = i.indrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relam = (SELECT oid FROM pg_am WHERE amname = 'btree')
+      AND i.indisvalid
+      AND EXISTS (
+        SELECT 1
+        FROM pg_attribute a
+        WHERE a.attrelid = i.indexrelid
+          AND a.attnum > 0
+          AND a.attcollation <> 0
+      )
+    ORDER BY t.relname, c.relname
+  LOOP
+    rebuilt_this_index := false;
+    FOR attempt IN 1..max_deadlock_attempts LOOP
+      BEGIN
+        EXECUTE format('REINDEX INDEX public.%I', target.index_name);
+        rebuilt_count := rebuilt_count + 1;
+        rebuilt_this_index := true;
+        EXIT;
+      EXCEPTION
+        WHEN unique_violation THEN
+          -- Expected: the broken comparator already let duplicates in, so the
+          -- rebuild cannot enforce uniqueness. The data needs a dedupe migration.
+          duplicate_blocked := duplicate_blocked
+            || format('%s.%s', target.table_name, target.index_name);
+          EXIT;
+        WHEN deadlock_detected THEN
+          -- Measured reality on the drifted install: a concurrent writer (the TTS
+          -- sidecar on VoiceProfile) beat the rebuild to the lock. Retry this one
+          -- index; the competing transaction has since committed or aborted.
+          IF attempt = max_deadlock_attempts THEN
+            unexpected := unexpected
+              || format('%s.%s [%s after %s attempts: %s]',
+                        target.table_name, target.index_name, SQLSTATE, attempt, SQLERRM);
+          END IF;
+        WHEN others THEN
+          -- Deliberately NOT re-raised. This is the line whose absence cost three
+          -- days: record which index and which error, then keep going.
+          unexpected := unexpected
+            || format('%s.%s [%s: %s]', target.table_name, target.index_name, SQLSTATE, SQLERRM);
+          EXIT;
+      END;
+    END LOOP;
+  END LOOP;
+
+  RAISE NOTICE 'collation-drift rebuild: % index(es) rebuilt', rebuilt_count;
+
+  IF array_length(duplicate_blocked, 1) > 0 THEN
+    RAISE WARNING
+      'collation-drift rebuild: % index(es) still hold duplicate rows and were NOT rebuilt: %. '
+      'Until each is deduped and rebuilt, its UNIQUE constraint cannot reject new duplicates. '
+      'Read those tables with enable_indexscan=off — an index scan will not show the duplicates.',
+      array_length(duplicate_blocked, 1), array_to_string(duplicate_blocked, ', ');
+  END IF;
+
+  IF array_length(unexpected, 1) > 0 THEN
+    RAISE WARNING
+      'collation-drift rebuild: % index(es) failed for an UNEXPECTED reason and were NOT rebuilt: %. '
+      'The chain is deliberately NOT wedged on these — each is named with its SQLSTATE so it can be '
+      'repaired directly. Re-running this rebuild after the fix is safe and idempotent.',
+      array_length(unexpected, 1), array_to_string(unexpected, ' | ');
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
The three-day self-upgrade wedge had a one-word cause: **a deadlock.**

## What actually happened

`20260720190000_repair_collation_drift_index_rebuild` handles per-index `REINDEX` failures as:

```sql
WHEN unique_violation THEN <report>;   -- loop continues
WHEN others THEN RAISE EXCEPTION ...;  -- aborts EVERYTHING
```

One index failing for any non-duplicate reason aborts the surrounding transaction. Postgres then rejects every later statement with *"current transaction is aborted"* — and **that** is the error Prisma surfaces, from the trailing `COMMIT`. The `RAISE`'s own message, naming the index and the real SQLSTATE, is never seen.

So `finished_at` stayed NULL, P3009 blocked every upgrade from 07-20 22:33 onward (`SUR-13E5FB0C`, `972504CF`, `EB033CC3`, `AD5B8DC3`, `A0681976`), and the cause stayed invisible for three days.

Re-running its loop in a **rolled-back** transaction — the diagnostic the original made impossible — named the culprit immediately:

```
rebuilt=2201  duplicate_blocked=2  unexpected=3
UNEXPECTED: VoiceProfile_pkey | VoiceProfile_profileId_key | VoiceProfile_status_idx
            [40P01: deadlock detected]
```

The TTS sidecar writes `VoiceProfile` while the rebuild holds locks. Three indexes lost a lock race — the most transient, most retryable error Postgres has — and it cost the fleet three days of upgrades.

## The fix

Migrations are immutable, so this is a new one. Same index selection, same rebuild-only scope. Different **failure policy**:

- `deadlock_detected` is **retried**, bounded (3), scoped to the one index that lost the race
- every other failure is caught, recorded with index name + SQLSTATE, and stepped over
- **nothing re-raises** — a single bad index can no longer wedge the fleet

## Why one install upgrades and another doesn't

Not timing, not the OS. **pgdata lineage:**

```sql
SELECT datcollversion, pg_database_collation_actual_version(oid) FROM pg_database;
-- drifted install: stored NULL, actual '2.36'
```

A NULL *stored* version means `initdb` ran under musl (Alpine — no locale data, C semantics). The volume is now served by Debian/glibc via the pgvector base, which *does* implement `en_US.utf8`. The comparator changed under an existing volume.

A Mac install created after that base-image move has a matching version and is untouched. **An older install on any OS is exposed.**

Measured consequence before repair: **18 duplicate `Agent.agentId`** rows behind a UNIQUE index that could no longer reject them.

## Verified by execution, not assertion

This migration file was applied to the affected database and **committed**:

```
NOTICE:  collation-drift rebuild: 2201 index(es) rebuilt
WARNING: 2 still hold duplicate rows ...
WARNING: 3 failed unexpectedly [40P01 after 3 attempts: deadlock detected] ...
COMMIT
```

The load-bearing result is the `COMMIT` — five problem indexes, and the chain advanced anyway. The three `VoiceProfile` indexes then rebuilt cleanly on direct retry once the upgrade's concurrent writes stopped. **2,204 of 2,206 collatable indexes now correct.**

Also on that install: `Agent.agentId` duplicates 18 → 0, 429 migrations applied / 0 unresolved, and `SUR-809A5AE0` succeeded.

## Remaining

Two unique indexes still hold one duplicated key each (`log-sig:sandbox:869e23847e`, `network_interface:iface:Ethernet_2:192.168.0.200`). They need a dedupe migration following the `20260720193000` pattern — retain conflicting rows under a collision-checked reserved key, never delete. Exact keys are in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
