### PR TITLE
feat(deliberation): route preflight primitive — the run that is never created (BI-8C44DB49)

### DIFF
--- a/apps/web/lib/deliberation/route-preflight.test.ts
+++ b/apps/web/lib/deliberation/route-preflight.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { preflightDeliberationRoute } from "./route-preflight";
+
+// BI-8C44DB49 slice 2. On the live install ~8 builds re-dispatched a
+// deliberation ~100 times each against a capability floor no endpoint could
+// satisfy, producing 5,026 stalled TaskRuns and holding the self-upgrade
+// quiescence gate open. The run that is never created is the one that cannot do
+// that.
+
+const capabilityFloorError = () =>
+  Object.assign(
+    new Error(
+      "No eligible endpoints for task 'conversation': No endpoint satisfies agent capability floor (EP-AGENT-CAP-002). Missing: toolUse. (3 endpoint(s) excluded)",
+    ),
+    { name: "NoEligibleEndpointsError", missingCapability: "toolUse" },
+  );
+
+const probes = [
+  { roleId: "critic", minimumCapabilities: { toolUse: true } },
+  { roleId: "advocate", minimumCapabilities: { toolUse: true } },
+];
+
+describe("blocks only what provably cannot run", () => {
+  it("blocks when every role fails the capability floor", async () => {
+    const preview = vi.fn().mockRejectedValue(capabilityFloorError());
+    const result = await preflightDeliberationRoute(probes, { previewRouteImpl: preview as never });
+
+    expect(result.blocked).toBe(true);
+    expect(result.verdict?.code).toBe("capability-floor-unmet");
+    expect(result.verdict?.missingCapability).toBe("toolUse");
+    expect(preview).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes the role's real capability floor to the router", async () => {
+    const preview = vi.fn().mockResolvedValue({ decision: {}, selectedManifest: {}, contract: {} });
+    await preflightDeliberationRoute(probes, { previewRouteImpl: preview as never });
+
+    // The live failure only throws when minimumCapabilities is set. A probe
+    // without it evaluates no floor at all and is meaningless. Tools are NOT the
+    // gate here — buildBranchRequestContract sets requiresTools:false, and
+    // routing relaxes an unsatisfiable tools requirement anyway.
+    const [, , options] = preview.mock.calls[0];
+    expect(options.minimumCapabilities).toEqual({ toolUse: true });
+    expect(options.tools).toBeUndefined();
+  });
+
+  it("proceeds as soon as ONE role can route — a deliberation may run fewer branches", async () => {
+    const preview = vi
+      .fn()
+      .mockRejectedValueOnce(capabilityFloorError())
+      .mockResolvedValueOnce({ decision: {}, selectedManifest: {}, contract: {} });
+    const result = await preflightDeliberationRoute(probes, { previewRouteImpl: preview as never });
+
+    expect(result.blocked).toBe(false);
+  });
+});
+
+describe("fails safe — a false block is worse than the flood", () => {
+  it("proceeds on a transient routing failure", async () => {
+    const preview = vi.fn().mockRejectedValue(new Error("HTTP 429 rate_limit_exceeded"));
+    const result = await preflightDeliberationRoute(probes, { previewRouteImpl: preview as never });
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it("proceeds on an unrecognised failure rather than abandoning recoverable work", async () => {
+    const preview = vi.fn().mockRejectedValue(new Error("something nobody has seen"));
+    const result = await preflightDeliberationRoute(probes, { previewRouteImpl: preview as never });
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it("proceeds when there is nothing to probe", async () => {
+    const preview = vi.fn();
+    const result = await preflightDeliberationRoute([], { previewRouteImpl: preview as never });
+
+    expect(result.blocked).toBe(false);
+    expect(preview).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/deliberation/route-preflight.ts
+++ b/apps/web/lib/deliberation/route-preflight.ts
@@ -39,7 +39,7 @@ import {
   classifyDispatchFailure,
   type DispatchFailureVerdict,
 } from "@/lib/inference/dispatch-failure-class";
-import type { AgentMinimumCapabilities } from "@/lib/routing/request-contract";
+import type { AgentMinimumCapabilities } from "@/lib/routing/agent-capability-types";
 
 export interface DeliberationRoutePreflight {
   /** True when NO role could dispatch — do not create a TaskRun. */

--- a/apps/web/lib/deliberation/route-preflight.ts
+++ b/apps/web/lib/deliberation/route-preflight.ts
@@ -1,0 +1,99 @@
+// BI-8C44DB49 slice 2 — refuse a deliberation whose branches cannot route,
+// BEFORE any TaskRun exists.
+//
+// WHY NOT SETTLE THE RUN AFTER IT FAILS. orchestrator.ts already catches and
+// calls settleBootstrapTaskRun(taskRunId, "failed"), and yet all 5,026 stalled
+// rows on the live install carry `stalled` — the WATCHDOG's state, not the
+// orchestrator's. settleBootstrapTaskRun scopes its update to rows still in
+// active|working|queued|running, so once the watchdog reaps a slow failure the
+// orchestrator's own handler is a silent no-op. Every post-hoc settle loses that
+// same race.
+//
+// A row that is never created cannot stall, cannot be reaped, cannot be
+// re-dispatched by the sweep, and cannot hold the self-upgrade quiescence gate
+// open as `coworker.reasoning-loop`. That is the whole fix.
+//
+// PROBING THE RIGHT GATE. The live failure was
+//   `No endpoint satisfies agent capability floor (EP-AGENT-CAP-002). Missing: toolUse`
+// which routed-inference throws ONLY when `options.minimumCapabilities` is set.
+// For a deliberation that floor is per-role: buildBranchRequestContract sets
+// `minimumCapabilities = ROLE_DEFAULT_CAPABILITIES[roleId]`, and notably sets
+// `requiresTools: false`.
+//
+// So a probe that passes `tools` would test the wrong thing twice over: tools are
+// not the deliberation gate, and routing RELAXES an unsatisfiable tools
+// requirement anyway (routed-inference.ts:375 retries with requiresTools=false
+// and strips tools). Such a probe would pass on an install where every real
+// branch fails — the exact blindness this slice exists to remove. We pass the
+// role's real capability floor instead.
+//
+// FAIL-SAFE. previewRoute is a side-effect-free dry run of the same routing the
+// branches use. We block only when EVERY role's floor throws structurally. If
+// any role can route, the deliberation proceeds — it can run with fewer
+// branches. A transient throw, an unexpected shape, or a bug here all proceed
+// exactly as before: a false block silently stops legitimate deliberation, which
+// is worse than the flood this prevents.
+
+import { previewRoute, type RouteAndCallOptions } from "@/lib/inference/routed-inference";
+import {
+  classifyDispatchFailure,
+  type DispatchFailureVerdict,
+} from "@/lib/inference/dispatch-failure-class";
+import type { AgentMinimumCapabilities } from "@/lib/routing/request-contract";
+
+export interface DeliberationRoutePreflight {
+  /** True when NO role could dispatch — do not create a TaskRun. */
+  blocked: boolean;
+  /** Set when blocked: why, in operator-actionable terms. */
+  verdict?: DispatchFailureVerdict;
+}
+
+const PROCEED: DeliberationRoutePreflight = { blocked: false };
+
+export interface DeliberationRouteProbe {
+  roleId: string;
+  minimumCapabilities: AgentMinimumCapabilities;
+}
+
+/**
+ * Probe whether any deliberation branch could route.
+ *
+ * Blocks only when every supplied role fails structurally — i.e. no branch of
+ * this deliberation could ever dispatch, so creating a TaskRun would produce a
+ * guaranteed corpse for the sweep to retry forever.
+ */
+export async function preflightDeliberationRoute(
+  probes: readonly DeliberationRouteProbe[],
+  opts: {
+    taskType?: string;
+    sensitivity?: "public" | "internal" | "confidential" | "restricted";
+    previewRouteImpl?: typeof previewRoute;
+  } = {},
+): Promise<DeliberationRoutePreflight> {
+  if (probes.length === 0) return PROCEED;
+  const preview = opts.previewRouteImpl ?? previewRoute;
+  const sensitivity = opts.sensitivity ?? "internal";
+  const taskType = opts.taskType ?? "conversation";
+
+  let lastStructural: DispatchFailureVerdict | undefined;
+
+  for (const probe of probes) {
+    try {
+      await preview([{ role: "user", content: "deliberation route preflight" }], sensitivity, {
+        taskType,
+        // The gate that actually failed on the live install. Without this the
+        // floor is never evaluated and the probe is meaningless.
+        minimumCapabilities: probe.minimumCapabilities,
+      } as RouteAndCallOptions);
+      // One routable role is enough — the deliberation can run.
+      return PROCEED;
+    } catch (error) {
+      const verdict = classifyDispatchFailure(error);
+      // Anything not provably structural: fail safe and let it run.
+      if (verdict.retryable) return PROCEED;
+      lastStructural = verdict;
+    }
+  }
+
+  return lastStructural ? { blocked: true, verdict: lastStructural } : PROCEED;
+}

--- a/docs/superpowers/plans/2026-07-21-dispatch-failure-fail-fast.md
+++ b/docs/superpowers/plans/2026-07-21-dispatch-failure-fail-fast.md
@@ -96,6 +96,28 @@ Everything else is `transient` and retryable up to the ceiling.
       that never exists cannot stall, cannot be reaped, cannot be retried, and
       cannot hold the quiescence gate open. This is also the literal reading of
       the operator's ask: "raise an error vs. trying what won't work."
+      **Primitive landed** (`lib/deliberation/route-preflight.ts`, 6 tests). Wiring
+      is NOT done, and the last mile has a trap worth naming — it nearly caught
+      two separate probe designs:
+
+      1. A probe passing `tools` is meaningless twice over: `buildBranchRequestContract`
+         sets `requiresTools: false`, and routing RELAXES an unsatisfiable tools
+         requirement anyway (`routed-inference.ts:375` retries with
+         `requiresTools=false` and strips tools). It would pass on an install
+         where every real branch fails.
+      2. A probe passing `ROLE_DEFAULT_CAPABILITIES[roleId]` is ALSO inert for the
+         observed failure. That map is deliberately empty for deliberation —
+         *"Deliberation branches default read-only … toolUse is NOT a floor"*
+         (request-contract.ts:88). So the probe would find no floor, previewRoute
+         would succeed, and the preflight would never block.
+
+      The `Missing: toolUse` floor came from `[agentic-loop] routeAndCall`, i.e.
+      the floor of the AGENT the injected `BranchDispatcher` runs — not the
+      branch role. **Before wiring, trace what `input.dispatcher` passes as
+      `minimumCapabilities`** and feed the probe from that same source. A probe
+      built from anything else is inert, and inert is worse than absent because
+      it reads as covered.
+
 - [ ] **3 — attempt ceiling on the sweep.** The re-dispatch sweep must count
       prior attempts per build and consult `shouldRedispatch`. Same unbounded
       retry class as BI-A009313E; the ceiling is what makes an unrecognised


### PR DESCRIPTION
Slice 2 **primitive**, following [#3345](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3345). A deliberation whose branches cannot route must not create a TaskRun at all.

## Why not settle after failure

`orchestrator.ts:731` **already** catches and calls `settleBootstrapTaskRun(taskRunId, "failed")` — yet all 5,026 stalled rows on the live install carry `stalled`, the *watchdog's* state. `settleBootstrapTaskRun` scopes its update to rows still `active|working|queued|running`, so once the watchdog reaps a slow failure the orchestrator's handler is a silent no-op.

Every post-hoc settle loses that race. A row that never exists cannot stall, be reaped, be re-dispatched by the sweep, or hold the quiescence gate open as `coworker.reasoning-loop`.

## Two inert probe designs, caught before shipping

Both would have read as covered while doing nothing:

1. **Probing with `tools`** is meaningless twice over — `buildBranchRequestContract` sets `requiresTools: false`, *and* `routed-inference.ts:375` relaxes an unsatisfiable tools requirement (retries with `requiresTools=false`, strips tools). It would pass on an install where every real branch fails.
2. **Probing with `ROLE_DEFAULT_CAPABILITIES[roleId]`** is also inert — that map is deliberately empty for deliberation: *"Deliberation branches default read-only … toolUse is NOT a floor"* (`request-contract.ts:88`).

`routed-inference` throws the floor error **only** when `options.minimumCapabilities` is set, so the probe takes the floor as an explicit argument rather than guessing its source.

The live `Missing: toolUse` came from `[agentic-loop] routeAndCall` — the floor of the agent the injected `BranchDispatcher` runs. **Wiring must feed the probe from that source**; the plan says so explicitly, because an inert probe is worse than no probe.

## Fail-safe throughout

Blocks only when **every** probed role fails structurally; one routable role proceeds, since a deliberation can run with fewer branches. Transient throws, unexpected shapes, and bugs in the probe itself all proceed exactly as before — a false block silently stops legitimate deliberation, which is worse than the flood it prevents.

## Scope

Primitive + tests only. **Wiring is deliberately excluded** — it is gated on tracing what `input.dispatcher` passes as `minimumCapabilities`, which is the difference between a working preflight and an inert one.

## Verification

18 tests (6 new preflight + 12 classifier), `previewRoute` injected so behaviour is proven without a live router. `check-bundle-boundaries` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
