### PR TITLE
feat: add expiring organization join packages

### DIFF
--- a/docs/superpowers/plans/2026-07-19-federated-demand-network.md
+++ b/docs/superpowers/plans/2026-07-19-federated-demand-network.md
@@ -115,10 +115,12 @@ guided organization join code is added.
 - [ ] Add source-contract tests, isolated CA initialize/issue/renew tests,
   compose rendering on macOS/Windows/Linux, recovery/rollback evidence, and
   documentation for root/intermediate/password custody.
-- [ ] Add a guided, expiring organization join package containing CA URL,
+- [x] Add an expiring organization join package containing CA URL,
   public root fingerprint, one-time enrollment authority, intended peer, and
   expiry. Import must verify the fingerprint and still require federation
   matching-code dual approval; no root private key crosses installations.
+- [ ] Expose package issue/import as a guided contextual Connections action
+  after the governed mutating host-action prerequisites are implemented.
 - [ ] Wire install/repair flows to the join package so a normal operator never
   copies certificates, edits environment variables, opens a shell, or manages
   Caddy/Step CA directly.
@@ -126,6 +128,59 @@ guided organization join code is added.
   add/remove expiry, validate HTTPS from each portal, exchange a nearby
   invitation, approve both sides, and record evidence before closing
   `BI-52D34506`.
+
+#### Organization-join package increment
+
+**Implemented contract:** the existing cross-platform PKI bootstrap owner now
+issues and consumes `DPF_ORGANIZATION_JOIN_V1` `.dpfjoin` packages. Each file is
+permission-restricted, bound to one intended hostname and SAN set, carries an
+origin-only HTTPS CA URL plus the public-root fingerprint, and expires together
+with its 15-minute Step CA enrollment authority. Import rejects unknown or
+duplicate fields, insecure file permissions, wrong-peer use, invalid roots, and
+expired authority before contacting Docker. Successful import removes the
+package and its temporary token file. The root or intermediate private key is
+never packaged.
+
+**Functional evidence:** an isolated authority issued a real package to a
+separate installation directory; the joining container fingerprint-pinned the
+root, obtained a `joiner.local` leaf with the intended loopback SAN, produced a
+valid leaf to intermediate to root chain, and consumed the package. That
+exercise also found and fixed a bootstrap defect: operator-supplied SANs now
+enter the CA server certificate on Bash and PowerShell, so the joining host can
+validate the CA's host-accessible private name.
+
+**Remaining guided-experience gate:** the package is installer-owned and ready
+for a host executor, but the portal must not receive the CA password, root key,
+or Docker socket. The existing `RemoteAction` host channel is deliberately
+read-only. Governed decision `DI-E461878DCB73` therefore rejected a one-off
+privileged localhost broker and selected the general threat-modeled mutating
+Edge-action path (high confidence, margin 1.379). The Connections action stays
+gated until machine-bound Edge trust, signed single-use dispatch, per-node
+action allow-lists, a `ChangeRequest`, rollback declaration, and post-action
+health evidence exist. This preserves the checkbox above as incomplete: the
+secure package works, while the no-shell portal invocation is still pending.
+
+#### Task 2 UX fit review — organization join
+
+- **Decision:** fits-with-guardrails
+- **Owning area:** Platform
+- **Route family:** existing `/platform/federation-links` Connections page
+- **Primary persona:** founder/operator adding another company installation
+  without handling certificates, environment variables, or shell commands
+- **Navigation layer:** contextual action; no new dashboard, tab, or global item
+- **Reuse/convergence:** existing Connections setup and approval workflow; the
+  host executor will reuse governed `RemoteAction`, not a new privileged broker
+- **Source truth:** Step CA owns certificate issuance; the expiring package owns
+  only bootstrap transfer; `FederationPairingSession` and `FederationLink` keep
+  their existing approval and trust authority
+- **Empty/failure behavior:** unavailable host execution explains the security
+  prerequisite and leaves manual invitation visible; expired/wrong-peer files
+  fail before host mutation
+- **AI boundary:** no coworker prompt and no autonomous trust creation
+- **Evidence before the portal action merges:** machine-bound Edge channel
+  verification, action approval and rollback evidence, light/dark and narrow
+  viewport exercise, keyboard/file-picker behavior, expired/wrong-peer package
+  fixtures, and installed macOS-to-Windows success
 
 **Risks and rollback:** CA key loss invalidates renewal and CA replacement
 invalidates peer trust. Back up the PKI volume and password secret as one

--- a/docs/superpowers/specs/2026-07-19-federated-demand-network-design.md
+++ b/docs/superpowers/specs/2026-07-19-federated-demand-network-design.md
@@ -549,3 +549,21 @@ plumbing, not federation authorization: nearby candidate validation, expiring
 invitation authority, matching-code dual approval, `FederationLink`, and
 projection review remain mandatory. Public or operator-provided corporate PKI
 remains valid for cross-organization reseller/customer/founder relationships.
+
+Resolved for the organization bootstrap transfer: the versioned
+`DPF_ORGANIZATION_JOIN_V1` package is a private, expiring installer artifact,
+not a federation record and not a second trust model. It contains only a random
+package id, origin-only private HTTPS CA URL, public-root fingerprint, intended
+hostname/SAN set, epoch expiry, and short-lived Step CA enrollment authority.
+It contains no CA private key and creates no `FederationLink`; matching-code
+dual approval remains a separate mandatory step. The package is accepted only
+by the intended installation, through strict closed-field parsing and private
+file permissions, and is removed after successful consumption.
+
+Resolved for portal automation: governed decision `DI-E461878DCB73` selected
+the general mutating Edge-action control plane over a dedicated privileged
+localhost broker. The portal will not mount the Docker socket, CA password, or
+CA configuration. Organization package issue/import action types cannot be
+enabled until the existing remote-action threat model's machine-bound trust,
+signed single-use dispatch, scope/allow-list, explicit approval/change,
+rollback, and independent health-evidence gates are implemented.

--- a/docs/user-guide/platform/index.md
+++ b/docs/user-guide/platform/index.md
@@ -48,6 +48,16 @@ until an authorized operator independently approves the connection on both
 installations. The matching code is only a visual check; it is never a password
 or bearer credential.
 
+When the second installation does not yet trust the organization's private
+HTTPS authority, DPF support can create a private `.dpfjoin` file for that one
+installation. Move the file to the joining computer within 15 minutes and let
+the DPF installer apply it. The file carries the public-root fingerprint and a
+one-time enrollment authority; it never carries the organization's CA private
+key. It works only for the named installation and is removed after successful
+use. This establishes certificate trust only—the two Connections screens still
+show the matching code and still require independent approval before any demand
+is shared.
+
 If the candidate uses HTTP, its certificate cannot be verified, or discovery is
 unavailable, use the invitation controls on the same page. Never bypass the TLS
 warning: issue the one-time invitation on one installation and enter it with the

--- a/scripts/bootstrap-organization-pki.ps1
+++ b/scripts/bootstrap-organization-pki.ps1
@@ -1,14 +1,16 @@
 # PowerShell 5.1-compatible organization PKI bootstrap for Windows.
 [CmdletBinding()]
 param(
-    [ValidateSet("authority", "join")][string]$Mode = "authority",
-    [Parameter(Mandatory)][string]$Hostname,
+    [ValidateSet("authority", "issue-join", "join")][string]$Mode = "authority",
+    [string]$Hostname,
     [string[]]$San = @(),
     [string]$OutDir = (Join-Path $env:USERPROFILE ".dpf\pki"),
     [string]$BindAddress = "127.0.0.1",
     [string]$CaUrl,
     [string]$Fingerprint,
     [string]$TokenFile,
+    [string]$JoinPackage,
+    [string]$PackageOutput,
     [string]$OrganizationName = "DPF Organization CA",
     [switch]$NoStartTls
 )
@@ -23,7 +25,49 @@ $script:PasswordFileEffective = $PasswordFile
 $AuthorityCert = Join-Path $OutDir "authority.crt"
 $AuthorityKey = Join-Path $OutDir "authority.key"
 $Caddyfile = Join-Path $OutDir "Caddyfile"
+$PackageId = $null
+$PackageToken = $null
 
+if ($Mode -eq "join" -and $JoinPackage) {
+    if (-not (Test-Path -LiteralPath $JoinPackage -PathType Leaf)) { throw "Join package was not found" }
+    $tokenAcl = & icacls $JoinPackage
+    if ($tokenAcl -match "Everyone|BUILTIN\\Users") { throw "Join package must be private" }
+    $lines = [IO.File]::ReadAllLines($JoinPackage)
+    if ($lines.Count -lt 2 -or $lines[0].TrimEnd("`r") -ne "DPF_ORGANIZATION_JOIN_V1") { throw "Join package version is not supported" }
+    $fields = @{}
+    foreach ($line in $lines[1..($lines.Count - 1)]) {
+        $clean = $line.TrimEnd("`r")
+        if (-not $clean) { continue }
+        $separator = $clean.IndexOf('=')
+        if ($separator -lt 1) { throw "Join package contains a malformed field" }
+        $key = $clean.Substring(0, $separator)
+        $value = $clean.Substring($separator + 1)
+        if ($fields.ContainsKey($key)) { throw "Join package contains duplicate fields" }
+        if ($key -notin @("package_id", "ca_url", "root_fingerprint", "intended_hostname", "intended_sans", "expires_at", "enrollment_token")) {
+            throw "Join package contains an unknown field"
+        }
+        $fields[$key] = $value
+    }
+    foreach ($required in @("package_id", "ca_url", "root_fingerprint", "intended_hostname", "expires_at", "enrollment_token")) {
+        if (-not $fields.ContainsKey($required) -or -not $fields[$required]) { throw "Join package is incomplete" }
+    }
+    if ($fields.package_id -notmatch '^[a-f0-9]{32}$') { throw "Join package id is invalid" }
+    if ($fields.root_fingerprint -notmatch '^[A-Fa-f0-9]{64}$') { throw "Join package root fingerprint is invalid" }
+    if ($fields.intended_hostname -notmatch '^[A-Za-z0-9._:-]+$') { throw "Join package intended peer is invalid" }
+    if ($fields.expires_at -notmatch '^[0-9]{1,12}$') { throw "Join package expiry is invalid" }
+    if ($fields.enrollment_token -notmatch '^[A-Za-z0-9._-]+$') { throw "Join package enrollment authority is invalid" }
+    $nowEpoch = [int64]([DateTime]::UtcNow - [DateTime]'1970-01-01').TotalSeconds
+    if ([int64]$fields.expires_at -le $nowEpoch) { throw "Join package has expired" }
+    if ($Hostname -and $Hostname -ne $fields.intended_hostname) { throw "Join package is intended for another installation" }
+    $Hostname = $fields.intended_hostname
+    $San = if ($fields.intended_sans) { @($fields.intended_sans.Split(',') | Where-Object { $_ }) } else { @() }
+    $CaUrl = $fields.ca_url
+    $Fingerprint = $fields.root_fingerprint
+    $PackageId = $fields.package_id
+    $PackageToken = $fields.enrollment_token
+}
+
+if (-not $Hostname) { throw "Hostname is required" }
 if ($Hostname -notmatch '^[A-Za-z0-9._:-]+$') { throw "Hostname contains unsupported characters" }
 foreach ($name in $San) {
     if ($name -notmatch '^[A-Za-z0-9._:-]+$') { throw "SAN contains unsupported characters" }
@@ -35,6 +79,34 @@ if (-not [Net.IPAddress]::TryParse($BindAddress, [ref]$parsedBind) -or $parsedBi
 $octets = $BindAddress.Split('.') | ForEach-Object { [int]$_ }
 $isPrivate = $octets[0] -eq 127 -or $octets[0] -eq 10 -or ($octets[0] -eq 192 -and $octets[1] -eq 168) -or ($octets[0] -eq 172 -and $octets[1] -ge 16 -and $octets[1] -le 31)
 if (-not $isPrivate) { throw "BindAddress must be a private IPv4 address or loopback" }
+
+$parsedCaUrl = $null
+if ($CaUrl) {
+    if (-not [Uri]::TryCreate($CaUrl, [UriKind]::Absolute, [ref]$parsedCaUrl) -or
+        $parsedCaUrl.Scheme -ne "https" -or $parsedCaUrl.UserInfo -or
+        $parsedCaUrl.AbsolutePath -ne "/" -or $parsedCaUrl.Query -or $parsedCaUrl.Fragment) {
+        throw "CaUrl must be an origin-only HTTPS URL"
+    }
+    $privateCaHost = $false
+    $caAddress = $null
+    if ([Net.IPAddress]::TryParse($parsedCaUrl.Host, [ref]$caAddress) -and $caAddress.AddressFamily -eq [Net.Sockets.AddressFamily]::InterNetwork) {
+        $caOctets = $caAddress.GetAddressBytes()
+        $privateCaHost = $caOctets[0] -eq 127 -or $caOctets[0] -eq 10 -or
+            ($caOctets[0] -eq 192 -and $caOctets[1] -eq 168) -or
+            ($caOctets[0] -eq 172 -and $caOctets[1] -ge 16 -and $caOctets[1] -le 31)
+    } else {
+        $caHost = $parsedCaUrl.Host.ToLowerInvariant()
+        $privateCaHost = $caHost -eq "localhost" -or $caHost -eq "host.docker.internal" -or
+            $caHost.EndsWith(".local") -or $caHost.EndsWith(".internal")
+    }
+    if (-not $privateCaHost) { throw "CaUrl must name a private or local HTTPS authority" }
+}
+if ($Mode -eq "issue-join" -and (-not $CaUrl -or -not $PackageOutput)) {
+    throw "issue-join mode requires CaUrl and PackageOutput"
+}
+if ($Mode -eq "issue-join" -and (Test-Path -LiteralPath $PackageOutput)) {
+    throw "Refusing to overwrite an existing join package"
+}
 
 function Invoke-DpfPkiCompose {
     param([Parameter(Mandatory)][string[]]$Arguments)
@@ -50,7 +122,7 @@ function Invoke-DpfPkiCompose {
         $env:DPF_PKI_PASSWORD_FILE = $script:PasswordFileEffective
         $env:DPF_PKI_TRUST_BUNDLE = $RootCert
         $env:DPF_PKI_BIND_ADDRESS = $BindAddress
-        $env:DPF_PKI_DNS_NAMES = "$Hostname,$BindAddress,localhost,127.0.0.1"
+        $env:DPF_PKI_DNS_NAMES = ((@($Hostname) + $San + @($BindAddress, "localhost", "127.0.0.1")) | Where-Object { $_ }) -join ","
         $env:DPF_PKI_NAME = $OrganizationName
         $env:DPF_TLS_DIR = $OutDir
         & docker compose --project-directory $RepoRoot -f (Join-Path $RepoRoot "docker-compose.yml") -f (Join-Path $RepoRoot "docker-compose.pki.yml") @Arguments
@@ -69,6 +141,15 @@ function Invoke-DpfPkiCompose {
 if (-not (Get-Command docker.exe -ErrorAction SilentlyContinue)) { throw "Docker is required" }
 New-Item -ItemType Directory -Force -Path $OutDir, (Join-Path $OutDir "secrets") | Out-Null
 
+if ($Mode -eq "join" -and $JoinPackage) {
+    $TokenFile = Join-Path $OutDir "secrets\.join-token-$PackageId"
+    [IO.File]::WriteAllText($TokenFile, "$PackageToken`n", (New-Object Text.UTF8Encoding($false)))
+    $PackageToken = $null
+    & icacls $TokenFile /inheritance:r /grant:r "$env:USERNAME`:F" 2>&1 | Out-Null
+}
+
+$JoinSucceeded = $false
+try {
 if ($Mode -eq "authority") {
     if (-not (Test-Path -LiteralPath $PasswordFile)) {
         $bytes = New-Object byte[] 32
@@ -115,6 +196,36 @@ if ($Mode -eq "authority") {
     if ($LASTEXITCODE -ne 0) { throw "organization_pki_leaf_issue_failed" }
     Invoke-DpfPkiCompose -Arguments @("cp", "step-ca:/home/step/certs/dpf-portal.crt", $AuthorityCert)
     Invoke-DpfPkiCompose -Arguments @("cp", "step-ca:/home/step/secrets/dpf-portal.key", $AuthorityKey)
+} elseif ($Mode -eq "issue-join") {
+    if (-not (Test-Path -LiteralPath $PasswordFile)) { throw "Organization CA is not initialized on this installation" }
+    Invoke-DpfPkiCompose -Arguments @("up", "-d", "step-ca")
+    Invoke-DpfPkiCompose -Arguments @("exec", "-T", "step-ca", "step", "ca", "health", "--ca-url", "https://127.0.0.1:9000", "--root", "/home/step/certs/root_ca.crt") | Out-Null
+    $Fingerprint = (Invoke-DpfPkiCompose -Arguments @("exec", "-T", "step-ca", "step", "certificate", "fingerprint", "/home/step/certs/root_ca.crt")).Trim()
+    $sanArguments = @("--san", $Hostname)
+    foreach ($name in $San) { $sanArguments += @("--san", $name) }
+    $tokenArguments = @("exec", "-T", "step-ca", "step", "ca", "token", $Hostname) + $sanArguments + @("--not-after", "15m", "--provisioner", "dpf-installer", "--password-file", "/run/secrets/step-ca-password")
+    $enrollmentToken = (Invoke-DpfPkiCompose -Arguments $tokenArguments).Trim()
+    $bytes = New-Object byte[] 16
+    [Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes)
+    $package_id = -join ($bytes | ForEach-Object { $_.ToString("x2") })
+    $expires_at = [int64]([DateTime]::UtcNow - [DateTime]'1970-01-01').TotalSeconds + 900
+    $intendedSans = $San -join ','
+    $package = @(
+        "DPF_ORGANIZATION_JOIN_V1",
+        "package_id=$package_id",
+        "ca_url=$CaUrl",
+        "root_fingerprint=$Fingerprint",
+        "intended_hostname=$Hostname",
+        "intended_sans=$intendedSans",
+        "expires_at=$expires_at",
+        "enrollment_token=$enrollmentToken"
+    ) -join "`n"
+    [IO.File]::WriteAllText($PackageOutput, "$package`n", (New-Object Text.UTF8Encoding($false)))
+    & icacls $PackageOutput /inheritance:r /grant:r "$env:USERNAME`:F" 2>&1 | Out-Null
+    $enrollmentToken = $null
+    Write-Host "Organization join package created at $PackageOutput."
+    Write-Host "It expires in 15 minutes and is intended only for $Hostname."
+    exit 0
 } else {
     if (-not $CaUrl -or -not $Fingerprint) { throw "join mode requires CaUrl and Fingerprint" }
     if (-not $CaUrl.StartsWith("https://", [StringComparison]::OrdinalIgnoreCase)) { throw "join mode requires an HTTPS CaUrl" }
@@ -155,7 +266,16 @@ if (-not $NoStartTls) {
     Invoke-DpfPkiCompose -Arguments @("-f", (Join-Path $RepoRoot "docker-compose.tls.yml"), "up", "-d", "portal", "portal-tls")
     Invoke-DpfPkiCompose -Arguments @("-f", (Join-Path $RepoRoot "docker-compose.tls.yml"), "restart", "portal-tls") | Out-Null
 }
+$JoinSucceeded = $Mode -eq "join"
 
 Write-Host "Organization HTTPS is configured for $Hostname."
 Write-Host "Public root fingerprint: $Fingerprint"
 Write-Host "PKI recovery directory: $OutDir (protect and back up with host secrets)."
+} finally {
+    if ($TokenFile -and $JoinPackage -and (Test-Path -LiteralPath $TokenFile)) {
+        Remove-Item -LiteralPath $TokenFile -Force -ErrorAction SilentlyContinue
+    }
+    if ($JoinSucceeded -and $JoinPackage -and (Test-Path -LiteralPath $JoinPackage)) {
+        Remove-Item -LiteralPath $JoinPackage -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/bootstrap-organization-pki.sh
+++ b/scripts/bootstrap-organization-pki.sh
@@ -12,6 +12,8 @@ BIND_ADDRESS="${DPF_PKI_BIND_ADDRESS:-127.0.0.1}"
 CA_URL=""
 FINGERPRINT=""
 TOKEN_FILE=""
+JOIN_PACKAGE=""
+PACKAGE_OUTPUT=""
 ORG_NAME="${DPF_PKI_NAME:-DPF Organization CA}"
 START_TLS=1
 SANS=""
@@ -25,15 +27,20 @@ Authority (first installation):
     --hostname <private-name-or-IP> [--san <name-or-IP>] \
     [--bind-address <private-IP>] [--out-dir <directory>]
 
-Join (another installation; public root fingerprint + one-time token only):
+Issue a 15-minute package for one intended installation:
+  bash scripts/bootstrap-organization-pki.sh --mode issue-join \
+    --hostname <joining-private-name-or-IP> [--san <name-or-IP>] \
+    --ca-url <https://private-ca:9000> --package-output <file.dpfjoin>
+
+Join (another installation; one private package file only):
   bash scripts/bootstrap-organization-pki.sh --mode join \
-    --hostname <private-name-or-IP> --ca-url <https://private-ca:9000> \
-    --fingerprint <sha256> --token-file <mode-0600-file>
+    --join-package <mode-0600-file.dpfjoin> [--out-dir <directory>]
 
 The root private key never leaves the Authority installation. Join mode accepts
 only a fingerprint-pinned public root and a short-lived enrollment token. Both
 modes write root_ca.crt, authority.crt, authority.key, and Caddyfile. Existing
-CA state is reused; the script refuses silent CA replacement.
+CA state is reused; the script refuses silent CA replacement. A join package
+uses the DPF_ORGANIZATION_JOIN_V1 contract and carries no CA private key.
 EOF
 }
 
@@ -43,6 +50,83 @@ append_san() {
 
 valid_name_or_ip() {
   printf '%s' "$1" | grep -Eq '^[A-Za-z0-9._:-]+$'
+}
+
+valid_ca_url() {
+  printf '%s' "$1" | grep -Eq '^https://[A-Za-z0-9._:-]+$'
+}
+
+valid_private_ca_url() {
+  valid_ca_url "$1" || return 1
+  ca_origin="${1#https://}"
+  ca_host="${ca_origin%%:*}"
+  case "$ca_host" in
+    localhost|*.local|*.internal|host.docker.internal) return 0 ;;
+  esac
+  private_ipv4_or_loopback "$ca_host"
+}
+
+read_join_package() {
+  package_path="$1"
+  [ -f "$package_path" ] || { echo "Join package was not found" >&2; exit 64; }
+  package_mode="$(stat -f '%Lp' "$package_path" 2>/dev/null || stat -c '%a' "$package_path" 2>/dev/null || echo unknown)"
+  [ "$package_mode" = "600" ] || { echo "Join package must have mode 0600" >&2; exit 77; }
+
+  package_header=""
+  package_id=""
+  package_ca_url=""
+  package_fingerprint=""
+  package_hostname=""
+  package_sans=""
+  package_expires_at=""
+  package_token=""
+  seen_package_id=0
+  seen_ca_url=0
+  seen_fingerprint=0
+  seen_hostname=0
+  seen_sans=0
+  seen_expiry=0
+  seen_token=0
+  line_number=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+    line_number=$((line_number + 1))
+    if [ "$line_number" -eq 1 ]; then package_header="$line"; continue; fi
+    [ -n "$line" ] || continue
+    key="${line%%=*}"
+    value="${line#*=}"
+    [ "$key" != "$line" ] || { echo "Join package contains a malformed field" >&2; exit 77; }
+    case "$key" in
+      package_id) [ "$seen_package_id" = 0 ] || { echo "Join package contains duplicate fields" >&2; exit 77; }; seen_package_id=1; package_id="$value" ;;
+      ca_url) [ "$seen_ca_url" = 0 ] || { echo "Join package contains duplicate fields" >&2; exit 77; }; seen_ca_url=1; package_ca_url="$value" ;;
+      root_fingerprint) [ "$seen_fingerprint" = 0 ] || { echo "Join package contains duplicate fields" >&2; exit 77; }; seen_fingerprint=1; package_fingerprint="$value" ;;
+      intended_hostname) [ "$seen_hostname" = 0 ] || { echo "Join package contains duplicate fields" >&2; exit 77; }; seen_hostname=1; package_hostname="$value" ;;
+      intended_sans) [ "$seen_sans" = 0 ] || { echo "Join package contains duplicate fields" >&2; exit 77; }; seen_sans=1; package_sans="$value" ;;
+      expires_at) [ "$seen_expiry" = 0 ] || { echo "Join package contains duplicate fields" >&2; exit 77; }; seen_expiry=1; package_expires_at="$value" ;;
+      enrollment_token) [ "$seen_token" = 0 ] || { echo "Join package contains duplicate fields" >&2; exit 77; }; seen_token=1; package_token="$value" ;;
+      *) echo "Join package contains an unknown field" >&2; exit 77 ;;
+    esac
+  done < "$package_path"
+
+  [ "$package_header" = "DPF_ORGANIZATION_JOIN_V1" ] || { echo "Join package version is not supported" >&2; exit 77; }
+  printf '%s' "$package_id" | grep -Eq '^[a-f0-9]{32}$' || { echo "Join package id is invalid" >&2; exit 77; }
+  valid_private_ca_url "$package_ca_url" || { echo "Join package CA URL must be private or local HTTPS" >&2; exit 77; }
+  printf '%s' "$package_fingerprint" | grep -Eq '^[A-Fa-f0-9]{64}$' || { echo "Join package root fingerprint is invalid" >&2; exit 77; }
+  valid_name_or_ip "$package_hostname" || { echo "Join package intended peer is invalid" >&2; exit 77; }
+  printf '%s' "$package_expires_at" | grep -Eq '^[0-9]{1,12}$' || { echo "Join package expiry is invalid" >&2; exit 77; }
+  printf '%s' "$package_token" | grep -Eq '^[A-Za-z0-9._-]+$' || { echo "Join package enrollment authority is invalid" >&2; exit 77; }
+  now_epoch="$(date +%s)"
+  [ "$package_expires_at" -gt "$now_epoch" ] || { echo "Join package has expired" >&2; exit 77; }
+  if [ -n "$HOSTNAME_VALUE" ] && [ "$HOSTNAME_VALUE" != "$package_hostname" ]; then
+    echo "Join package is intended for another installation" >&2
+    exit 77
+  fi
+  HOSTNAME_VALUE="$package_hostname"
+  SANS="$package_sans"
+  CA_URL="$package_ca_url"
+  FINGERPRINT="$package_fingerprint"
+  PACKAGE_ID="$package_id"
+  PACKAGE_TOKEN="$package_token"
 }
 
 private_ipv4_or_loopback() {
@@ -59,7 +143,7 @@ private_ipv4_or_loopback() {
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --mode) shift; MODE="${1:?--mode requires authority or join}" ;;
+    --mode) shift; MODE="${1:?--mode requires authority, issue-join, or join}" ;;
     --hostname) shift; HOSTNAME_VALUE="${1:?--hostname requires a value}" ;;
     --san) shift; append_san "${1:?--san requires a value}" ;;
     --out-dir) shift; OUT_DIR="${1:?--out-dir requires a value}" ;;
@@ -67,6 +151,8 @@ while [ "$#" -gt 0 ]; do
     --ca-url) shift; CA_URL="${1:?--ca-url requires a value}" ;;
     --fingerprint) shift; FINGERPRINT="${1:?--fingerprint requires a value}" ;;
     --token-file) shift; TOKEN_FILE="${1:?--token-file requires a value}" ;;
+    --join-package) shift; JOIN_PACKAGE="${1:?--join-package requires a value}" ;;
+    --package-output) shift; PACKAGE_OUTPUT="${1:?--package-output requires a value}" ;;
     --org-name) shift; ORG_NAME="${1:?--org-name requires a value}" ;;
     --no-start-tls) START_TLS=0 ;;
     -h|--help) usage; exit 0 ;;
@@ -75,7 +161,8 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
-case "$MODE" in authority|join) ;; *) echo "--mode must be authority or join" >&2; exit 64 ;; esac
+case "$MODE" in authority|issue-join|join) ;; *) echo "--mode must be authority, issue-join, or join" >&2; exit 64 ;; esac
+if [ "$MODE" = "join" ] && [ -n "$JOIN_PACKAGE" ]; then read_join_package "$JOIN_PACKAGE"; fi
 [ -n "$HOSTNAME_VALUE" ] || { echo "--hostname is required" >&2; exit 64; }
 valid_name_or_ip "$HOSTNAME_VALUE" || { echo "--hostname contains unsupported characters" >&2; exit 64; }
 old_ifs="$IFS"
@@ -83,9 +170,15 @@ IFS=','
 for san in $SANS; do valid_name_or_ip "$san" || { echo "--san contains unsupported characters" >&2; exit 64; }; done
 IFS="$old_ifs"
 private_ipv4_or_loopback "$BIND_ADDRESS" || { echo "--bind-address must be a private IPv4 address or loopback" >&2; exit 64; }
+if [ "$MODE" = "issue-join" ]; then
+  [ -n "$CA_URL" ] || { echo "issue-join mode requires --ca-url" >&2; exit 64; }
+  valid_private_ca_url "$CA_URL" || { echo "issue-join mode requires a private or local origin-only HTTPS --ca-url" >&2; exit 64; }
+  [ -n "$PACKAGE_OUTPUT" ] || { echo "issue-join mode requires --package-output" >&2; exit 64; }
+  [ ! -e "$PACKAGE_OUTPUT" ] || { echo "Refusing to overwrite an existing join package" >&2; exit 73; }
+fi
 command -v docker >/dev/null 2>&1 || { echo "Docker is required" >&2; exit 69; }
 docker compose version >/dev/null 2>&1 || { echo "Docker Compose v2 is required" >&2; exit 69; }
-if [ "$MODE" = "authority" ]; then
+if [ "$MODE" = "authority" ] || [ "$MODE" = "issue-join" ]; then
   command -v openssl >/dev/null 2>&1 || { echo "OpenSSL is required in authority mode" >&2; exit 69; }
 fi
 
@@ -99,11 +192,20 @@ AUTHORITY_CERT="$OUT_DIR/authority.crt"
 AUTHORITY_KEY="$OUT_DIR/authority.key"
 CADDYFILE="$OUT_DIR/Caddyfile"
 
+if [ "$MODE" = "join" ] && [ -n "$JOIN_PACKAGE" ]; then
+  TOKEN_FILE="$OUT_DIR/secrets/.join-token-$PACKAGE_ID"
+  umask 077
+  printf '%s\n' "$PACKAGE_TOKEN" > "$TOKEN_FILE"
+  chmod 0600 "$TOKEN_FILE"
+  unset PACKAGE_TOKEN
+  trap 'rm -f "$TOKEN_FILE"' EXIT HUP INT TERM
+fi
+
 compose() {
   DPF_PKI_PASSWORD_FILE="$PASSWORD_FILE_EFFECTIVE" \
   DPF_PKI_TRUST_BUNDLE="$ROOT_CERT" \
   DPF_PKI_BIND_ADDRESS="$BIND_ADDRESS" \
-  DPF_PKI_DNS_NAMES="$HOSTNAME_VALUE,$BIND_ADDRESS,localhost,127.0.0.1" \
+  DPF_PKI_DNS_NAMES="$HOSTNAME_VALUE,$SANS,$BIND_ADDRESS,localhost,127.0.0.1" \
   DPF_PKI_NAME="$ORG_NAME" \
   DPF_TLS_DIR="$OUT_DIR" \
   docker compose --project-directory "$REPO_ROOT" \
@@ -157,6 +259,38 @@ if [ "$MODE" = "authority" ]; then
   fi
   compose cp step-ca:/home/step/certs/dpf-portal.crt "$AUTHORITY_CERT" >/dev/null
   compose cp step-ca:/home/step/secrets/dpf-portal.key "$AUTHORITY_KEY" >/dev/null
+elif [ "$MODE" = "issue-join" ]; then
+  [ -f "$PASSWORD_FILE" ] || { echo "Organization CA is not initialized on this installation" >&2; exit 69; }
+  compose up -d step-ca
+  compose exec -T step-ca step ca health --ca-url https://127.0.0.1:9000 \
+    --root /home/step/certs/root_ca.crt >/dev/null
+  FINGERPRINT="$(compose exec -T step-ca step certificate fingerprint /home/step/certs/root_ca.crt | tr -d '\r\n')"
+  san_args="--san $HOSTNAME_VALUE"
+  old_ifs="$IFS"
+  IFS=','
+  for san in $SANS; do san_args="$san_args --san $san"; done
+  IFS="$old_ifs"
+  # shellcheck disable=SC2086 # Values passed by word splitting were validated above.
+  token="$(compose exec -T step-ca step ca token "$HOSTNAME_VALUE" $san_args \
+    --not-after 15m --provisioner dpf-installer --password-file /run/secrets/step-ca-password)"
+  package_id="$(openssl rand -hex 16)"
+  expires_at="$(( $(date +%s) + 900 ))"
+  umask 077
+  {
+    printf '%s\n' "DPF_ORGANIZATION_JOIN_V1"
+    printf 'package_id=%s\n' "$package_id"
+    printf 'ca_url=%s\n' "$CA_URL"
+    printf 'root_fingerprint=%s\n' "$FINGERPRINT"
+    printf 'intended_hostname=%s\n' "$HOSTNAME_VALUE"
+    printf 'intended_sans=%s\n' "$SANS"
+    printf 'expires_at=%s\n' "$expires_at"
+    printf 'enrollment_token=%s\n' "$token"
+  } > "$PACKAGE_OUTPUT"
+  chmod 0600 "$PACKAGE_OUTPUT"
+  unset token
+  echo "Organization join package created at $PACKAGE_OUTPUT."
+  echo "It expires in 15 minutes and is intended only for $HOSTNAME_VALUE."
+  exit 0
 else
   [ -n "$CA_URL" ] || { echo "join mode requires --ca-url" >&2; exit 64; }
   [ -n "$FINGERPRINT" ] || { echo "join mode requires --fingerprint" >&2; exit 64; }
@@ -208,6 +342,10 @@ chmod 0644 "$CADDYFILE"
 if [ "$START_TLS" = "1" ]; then
   compose -f "$REPO_ROOT/docker-compose.tls.yml" up -d portal portal-tls
   compose -f "$REPO_ROOT/docker-compose.tls.yml" restart portal-tls >/dev/null
+fi
+
+if [ "$MODE" = "join" ] && [ -n "$JOIN_PACKAGE" ]; then
+  rm -f "$JOIN_PACKAGE" 2>/dev/null || true
 fi
 
 echo "Organization HTTPS is configured for $HOSTNAME_VALUE."

--- a/scripts/installer/pki-contract.test.mjs
+++ b/scripts/installer/pki-contract.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 const read = (path) => readFile(new URL(`../../${path}`, import.meta.url), "utf8");
@@ -30,7 +32,11 @@ test("Bash and PowerShell PKI bootstraps expose the same safe lifecycle", async 
 
   for (const source of [shell, powershell]) {
     assert.match(source, /authority/i);
+    assert.match(source, /issue-join/i);
     assert.match(source, /join/i);
+    assert.match(source, /DPF_ORGANIZATION_JOIN_V1/);
+    assert.match(source, /expires/i);
+    assert.match(source, /intended/i);
     assert.match(source, /fingerprint/i);
     assert.match(source, /root_ca\.crt/);
     assert.match(source, /authority\.crt/);
@@ -47,6 +53,107 @@ test("Bash and PowerShell PKI bootstraps expose the same safe lifecycle", async 
   assert.doesNotMatch(powershell, /ConvertFrom-Json -AsHashtable|ForEach-Object -Parallel/);
 });
 
+test("join packages are short-lived, intended-peer-bound, and never require a CA private key", async () => {
+  const [shell, powershell] = await Promise.all([
+    read("scripts/bootstrap-organization-pki.sh"),
+    read("scripts/bootstrap-organization-pki.ps1"),
+  ]);
+
+  for (const source of [shell, powershell]) {
+    assert.match(source, /package_id/i);
+    assert.match(source, /ca_url/i);
+    assert.match(source, /root_fingerprint/i);
+    assert.match(source, /intended_hostname/i);
+    assert.match(source, /expires_at/i);
+    assert.match(source, /enrollment_token/i);
+    assert.match(source, /15m|900/);
+    assert.doesNotMatch(source, /root_ca\.key[^\n]*(?:package|join)/i);
+  }
+});
+
+test("Bash join rejects an expired package before Docker is invoked", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "dpf-join-expired-"));
+  const packagePath = join(directory, "expired.dpfjoin");
+  const script = new URL("../bootstrap-organization-pki.sh", import.meta.url).pathname;
+
+  try {
+    await writeFile(packagePath, [
+      "DPF_ORGANIZATION_JOIN_V1",
+      "package_id=0123456789abcdef0123456789abcdef",
+      "ca_url=https://192.168.0.10:9000",
+      `root_fingerprint=${"a".repeat(64)}`,
+      "intended_hostname=peer.local",
+      "intended_sans=192.168.0.20",
+      "expires_at=1",
+      "enrollment_token=fixture-enrollment-token-expired",
+      "",
+    ].join("\n"), { mode: 0o600 });
+    await chmod(packagePath, 0o600);
+
+    const result = spawnSync("bash", [script, "--mode", "join", "--hostname", "peer.local", "--join-package", packagePath], { encoding: "utf8" });
+    assert.equal(result.status, 77);
+    assert.match(result.stderr, /expired/i);
+    assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /Docker is required/i);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Bash join rejects a package intended for a different installation", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "dpf-join-peer-"));
+  const packagePath = join(directory, "wrong-peer.dpfjoin");
+  const script = new URL("../bootstrap-organization-pki.sh", import.meta.url).pathname;
+
+  try {
+    await writeFile(packagePath, [
+      "DPF_ORGANIZATION_JOIN_V1",
+      "package_id=0123456789abcdef0123456789abcdef",
+      "ca_url=https://192.168.0.10:9000",
+      `root_fingerprint=${"a".repeat(64)}`,
+      "intended_hostname=other.local",
+      "intended_sans=192.168.0.20",
+      `expires_at=${Math.floor(Date.now() / 1000) + 900}`,
+      "enrollment_token=fixture-enrollment-token-wrong-peer",
+      "",
+    ].join("\n"), { mode: 0o600 });
+    await chmod(packagePath, 0o600);
+
+    const result = spawnSync("bash", [script, "--mode", "join", "--hostname", "peer.local", "--join-package", packagePath], { encoding: "utf8" });
+    assert.equal(result.status, 77);
+    assert.match(result.stderr, /intended for another installation/i);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Bash join rejects a public CA origin before Docker is invoked", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "dpf-join-public-ca-"));
+  const packagePath = join(directory, "public-ca.dpfjoin");
+  const script = new URL("../bootstrap-organization-pki.sh", import.meta.url).pathname;
+
+  try {
+    await writeFile(packagePath, [
+      "DPF_ORGANIZATION_JOIN_V1",
+      "package_id=0123456789abcdef0123456789abcdef",
+      "ca_url=https://example.com:9000",
+      `root_fingerprint=${"a".repeat(64)}`,
+      "intended_hostname=peer.local",
+      "intended_sans=192.168.0.20",
+      `expires_at=${Math.floor(Date.now() / 1000) + 900}`,
+      "enrollment_token=fixture-enrollment-token-public-ca",
+      "",
+    ].join("\n"), { mode: 0o600 });
+    await chmod(packagePath, 0o600);
+
+    const result = spawnSync("bash", [script, "--mode", "join", "--join-package", packagePath], { encoding: "utf8" });
+    assert.equal(result.status, 77);
+    assert.match(result.stderr, /private or local/i);
+    assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /Docker is required/i);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("PKI bootstrap refuses silent CA replacement and never prints enrollment secrets", async () => {
   const [shell, powershell] = await Promise.all([
     read("scripts/bootstrap-organization-pki.sh"),
@@ -60,6 +167,16 @@ test("PKI bootstrap refuses silent CA replacement and never prints enrollment se
     powershell,
     /Write-(?:Host|Output)[^\n]*(?:\$enrollmentToken|\$PasswordFile)/i,
   );
+});
+
+test("the organization CA server certificate includes operator-supplied private SANs", async () => {
+  const [shell, powershell] = await Promise.all([
+    read("scripts/bootstrap-organization-pki.sh"),
+    read("scripts/bootstrap-organization-pki.ps1"),
+  ]);
+
+  assert.match(shell, /DPF_PKI_DNS_NAMES="\$HOSTNAME_VALUE,\$SANS,/);
+  assert.match(powershell, /DPF_PKI_DNS_NAMES[^\n]*\$San/);
 });
 
 test("Bash bootstrap rejects public binds and argument injection before Docker", () => {


### PR DESCRIPTION
## Summary
- add a versioned, expiring `.dpfjoin` package that lets a support operator enroll another private-network installation without transferring the organization CA private key
- bind every package to its intended hostname/SANs, a pinned organization root fingerprint, a private/local CA origin, and a 15-minute Step CA enrollment token
- enforce strict parsing, local file privacy, one-time consumption, cleanup on failure, and refusal of expired, wrong-peer, public-origin, duplicate-field, or malformed packages in both Bash 3.2 and PowerShell 5.1
- include operator-supplied private SANs in the Step CA server certificate and document the remaining guided portal and installer wiring
- linked backlog: BI-52D34506; work capsule: WC-DF69E53A

## Test plan
- [x] organization PKI contract tests: 9 passing
- [x] Bash syntax, PowerShell ASCII contract, diff checks, and staged Gitleaks scan
- [x] isolated real Step CA issue/import: pinned three-level chain verified; intended DNS/IP SANs present; package consumed after success
- [x] exact-SHA local merged-code gate: sandbox freshness, Prisma migrate deploy, full web Vitest, web typecheck, and production Next build passed
- [x] UX verification: n/a for this installer/runtime package slice; the contextual Connections action has a documented UX-fit plan and remains open

Local-CI-Evidence: cmrv4j4vw05xg01qkefdpjnh8 (feat/federation-pki-guided-join@ebc8394c5c2816b47871e07b6cfb67fb12fcac39)
Local-CI-Lease: NPEL-07DCC8DF2E
Decision: DI-E461878DCB73

## Scope boundary
This PR deliberately does not close BI-52D34506. The no-shell contextual portal action requires the governed mutating Edge action control plane; installer/repair wiring and installed macOS plus Windows V-01/V-03 acceptance remain checked open in the implementation plan.

Seed-Fit-Decision: global-default
