### PR TITLE
feat: persist organization join through install lifecycle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN NODE_OPTIONS="--max-old-space-size=8192" NEXT_TELEMETRY_DISABLED=1 pnpm --fi
 # ─── Stage 4: init (build source for migrations, seed, Prisma client) ─────────
 FROM deps AS init
 COPY pnpm-workspace.yaml tsconfig.base.json .gitignore ./
-COPY docker-compose.yml docker-compose.release.yml ./
+COPY docker-compose.yml docker-compose.release.yml docker-compose.pki.yml docker-compose.organization-trust.yml docker-compose.tls.yml ./
 COPY scripts/set-hooks-path.mjs ./scripts/
 COPY scripts/lib/resolve-capability-compose-profiles.mjs ./scripts/lib/
 COPY scripts/lib/govern-capability-compose-args.mjs ./scripts/lib/
@@ -91,6 +91,7 @@ COPY scripts/installer/install-state.schema.json ./scripts/installer/
 COPY scripts/installer/install-state.v1.schema.json ./scripts/installer/
 COPY scripts/installer/install-state.v2.schema.json ./scripts/installer/
 COPY scripts/installer/native-edge-host.ps1 ./scripts/installer/
+COPY scripts/bootstrap-organization-pki.ps1 ./scripts/
 COPY scripts/installer/lib/state.ps1 ./scripts/installer/lib/
 COPY monitoring/ ./monitoring/
 COPY scripts/backup-postgres.sh ./scripts/
@@ -136,7 +137,8 @@ RUN pnpm --filter @dpf/db exec prisma generate
 RUN node packages/db/scripts/generate-tools-snapshot.js
 RUN mkdir -p /dpf-release-assets/scripts/lib /dpf-release-assets/scripts/installer/lib \
       /dpf-release-assets/monitoring && \
-    cp docker-compose.yml docker-compose.release.yml /dpf-release-assets/ && \
+    cp docker-compose.yml docker-compose.release.yml docker-compose.pki.yml docker-compose.organization-trust.yml docker-compose.tls.yml /dpf-release-assets/ && \
+    cp scripts/bootstrap-organization-pki.ps1 /dpf-release-assets/scripts/ && \
     cp scripts/lib/resolve-capability-compose-profiles.mjs scripts/lib/govern-capability-compose-args.mjs scripts/lib/capability-state-hash.mjs /dpf-release-assets/scripts/lib/ && \
     cp scripts/capability-service-catalog.generated.json /dpf-release-assets/scripts/ && \
     cp scripts/installer/validate-install-state.mjs /dpf-release-assets/scripts/installer/ && \

--- a/docker-compose.organization-trust.yml
+++ b/docker-compose.organization-trust.yml
@@ -1,0 +1,11 @@
+# Organization member trust overlay. This is deliberately separate from the
+# Step CA authority service so a joining installation never starts a second CA.
+
+services:
+  portal:
+    environment:
+      # Node reads this only at process start. Public Web PKI roots remain in
+      # the default trust store; this adds the pinned organization root.
+      NODE_EXTRA_CA_CERTS: /etc/dpf/pki/root_ca.crt
+    volumes:
+      - ${DPF_PKI_TRUST_BUNDLE:?Set DPF_PKI_TRUST_BUNDLE to the organization root_ca.crt path}:/etc/dpf/pki/root_ca.crt:ro

--- a/docker-compose.pki.yml
+++ b/docker-compose.pki.yml
@@ -45,14 +45,6 @@ services:
       retries: 10
       start_period: 20s
 
-  portal:
-    environment:
-      # Node reads this only at process start. It adds the organization root;
-      # public Web PKI roots remain available through the default trust store.
-      NODE_EXTRA_CA_CERTS: /etc/dpf/pki/root_ca.crt
-    volumes:
-      - ${DPF_PKI_TRUST_BUNDLE:?Set DPF_PKI_TRUST_BUNDLE to the organization root_ca.crt path}:/etc/dpf/pki/root_ca.crt:ro
-
 secrets:
   step-ca-password:
     file: ${DPF_PKI_PASSWORD_FILE:?Set DPF_PKI_PASSWORD_FILE to a mode-0600 file}

--- a/docs/superpowers/plans/2026-07-19-federated-demand-network.md
+++ b/docs/superpowers/plans/2026-07-19-federated-demand-network.md
@@ -124,6 +124,15 @@ guided organization join code is added.
 - [ ] Wire install/repair flows to the join package so a normal operator never
   copies certificates, edits environment variables, opens a shell, or manages
   Caddy/Step CA directly.
+  - [x] Add the cross-platform installer input and persistent restart wiring:
+    `--organization-join-package` on macOS/Linux and
+    `-OrganizationJoinPackage` on Windows validate and consume the package,
+    configure member trust/TLS, and restore those overlays on later starts.
+    The member overlay is physically separate from the Step CA authority
+    overlay, so a joined installation cannot accidentally start a second CA.
+  - [ ] Replace the installer argument with the contextual Connections action
+    once the governed mutating Edge-action prerequisite is available; that is
+    the remaining no-shell/file-picker experience required by this checkbox.
 - [ ] Run installed macOS + Windows V-01/V-03: restart both services, observe
   add/remove expiry, validate HTTPS from each portal, exchange a nearby
   invitation, approve both sides, and record evidence before closing
@@ -159,6 +168,16 @@ gated until machine-bound Edge trust, signed single-use dispatch, per-node
 action allow-lists, a `ChangeRequest`, rollback declaration, and post-action
 health evidence exist. This preserves the checkbox above as incomplete: the
 secure package works, while the no-shell portal invocation is still pending.
+
+**Installer lifecycle increment:** both platform installers now accept the
+private package as a first-class input, call the same strict bootstrap with TLS
+startup deferred, and let the normal install compose step start the trusted
+HTTPS endpoint. A successful bootstrap atomically persists only the public-root
+path, TLS directory, and enabled marker into `.env`; subsequent macOS/Linux and
+Windows start paths restore the member-trust and TLS overlays automatically.
+The release asset manifest carries the Windows bootstrap and overlays. Member
+trust is split from `docker-compose.pki.yml`, keeping `step-ca` exclusive to the
+authority installation.
 
 #### Task 2 UX fit review — organization join
 

--- a/docs/user-guide/platform/index.md
+++ b/docs/user-guide/platform/index.md
@@ -58,6 +58,15 @@ use. This establishes certificate trust only—the two Connections screens still
 show the matching code and still require independent approval before any demand
 is shared.
 
+The installer owns the technical work. On macOS/Linux it accepts the file as
+the **organization join package** input; the Windows installer accepts the same
+`.dpfjoin` file. After validation, DPF obtains the local HTTPS certificate,
+stores the public organization root, configures the HTTPS endpoint, and remembers
+that trust on later starts. A joining installation does not run or receive the
+organization CA. Until the Connections file picker is enabled, support may need
+to supply this installer input during setup; operators should never extract the
+file or copy certificates and environment settings by hand.
+
 If the candidate uses HTTP, its certificate cannot be verified, or discovery is
 unavailable, use the invitation controls on the same page. Never bypass the TLS
 warning: issue the one-time invitation on one installation and enter it with the

--- a/dpf-start.sh
+++ b/dpf-start.sh
@@ -81,6 +81,7 @@ done
 # that already has a bundled node > default OFF. Export so dpf_compose_files
 # includes the edge overlay only when this install enabled it.
 export DPF_INCLUDE_EDGE="$(dpf_resolve_edge_enabled "$REPO_ROOT")"
+# dpf_compose_files also restores persisted organization-trust and TLS overlays.
 
 cd "$REPO_ROOT"
 dpf_platform

--- a/install-dpf.ps1
+++ b/install-dpf.ps1
@@ -4,9 +4,14 @@ param(
     [string]$Version = "latest",
     [switch]$LibraryOnly,
     [switch]$WithEdge,
-    [switch]$NoEdge
+    [switch]$NoEdge,
+    [ValidateNotNullOrEmpty()][string]$OrganizationJoinPackage
 )
 $ErrorActionPreference = "Stop"
+$OrganizationJoinPackagePath = if ($OrganizationJoinPackage) { [IO.Path]::GetFullPath($OrganizationJoinPackage) } else { $null }
+if ($OrganizationJoinPackagePath -and -not (Test-Path -LiteralPath $OrganizationJoinPackagePath -PathType Leaf)) {
+    throw "organization_join_package_not_found:$OrganizationJoinPackagePath"
+}
 
 function Resolve-DPFNativeEdgeModulePath {
     param([Parameter(Mandatory)][string]$InstallDir)
@@ -334,6 +339,15 @@ function Get-DPFComposeArgs {
         $composeArgs += @("-f", "docker-compose.edge.yml")
     }
 
+    $envPath = Join-Path $InstallDir ".env"
+    $organizationTrust = $env:DPF_ORGANIZATION_TRUST_ENABLED -eq "1"
+    if (-not $organizationTrust -and (Test-Path -LiteralPath $envPath)) {
+        $organizationTrust = [bool](Select-String -LiteralPath $envPath -Pattern '^DPF_ORGANIZATION_TRUST_ENABLED=1$' -Quiet)
+    }
+    if ($organizationTrust) {
+        $composeArgs += @("-f", "docker-compose.organization-trust.yml", "-f", "docker-compose.tls.yml")
+    }
+
     return $composeArgs
 }
 
@@ -538,6 +552,10 @@ if (Test-Path (Join-Path $DPF_DIR "docker-compose.release.yml")) {
 }
 if (Test-Path (Join-Path $DPF_DIR "docker-compose.override.yml")) {
     $composeArgs += @("-f", "docker-compose.override.yml")
+}
+$envPath = Join-Path $DPF_DIR ".env"
+if ((Test-Path -LiteralPath $envPath) -and (Select-String -LiteralPath $envPath -Pattern '^DPF_ORGANIZATION_TRUST_ENABLED=1$' -Quiet)) {
+    $composeArgs += @("-f", "docker-compose.organization-trust.yml", "-f", "docker-compose.tls.yml")
 }
 docker compose @composeArgs up -d
 
@@ -1483,6 +1501,17 @@ if ($env:Path -notlike "*$safetyBin*") {
 Write-Action "Open a new terminal for the PATH change to take effect in other windows."
 
 # --- Step 6: Start Platform ---------------------------------------------------
+
+if ($OrganizationJoinPackagePath) {
+    Write-Host ""
+    Write-Host "  Configuring organization trust..." -ForegroundColor Cyan
+    $bootstrap = Join-Path $DPF_DIR "scripts\bootstrap-organization-pki.ps1"
+    if (-not (Test-Path -LiteralPath $bootstrap)) { $bootstrap = Join-Path $PSScriptRoot "scripts\bootstrap-organization-pki.ps1" }
+    if (-not (Test-Path -LiteralPath $bootstrap)) { throw "organization_pki_bootstrap_missing" }
+    & $bootstrap -Mode join -JoinPackage $OrganizationJoinPackagePath -NoStartTls
+    $env:DPF_ORGANIZATION_TRUST_ENABLED = "1"
+    Write-OK "Organization HTTPS trust configured; the one-time package was consumed"
+}
 
 Write-Step 7 10 "Starting the platform..."
 if (-not (Test-StepDone "started")) {

--- a/install-dpf.sh
+++ b/install-dpf.sh
@@ -118,6 +118,10 @@ Flags:
                 (docker-compose.edge-standalone.yml).
   --no-edge     Force-skip the local Edge Node even if a prior install
                 enabled it (Edge is already off by default).
+  --organization-join-package <file.dpfjoin>
+                Join an existing organization trust domain during install.
+                The private package is validated, consumed, and deleted on
+                success; certificates and restart wiring are automatic.
   -h, --help    Show this help.
 
 Status: Phase 6+ vertical slice. Full end-user install (Docker
@@ -142,6 +146,8 @@ DPF_INCLUDE_EDGE="${DPF_INCLUDE_EDGE:-}"    # opt-in; resolved after state init 
 # the install path, becomes the worktree base. Empty = single-tree mode (current
 # behavior). Future phases will turn this into a hard install/dev separation.
 DPF_DEV_WORKSPACE_PATH_ARG=""
+DPF_ORGANIZATION_JOIN_PACKAGE=""
+DPF_INSTALL_CALLER_DIR="$PWD"
 SUBCOMMAND=""
 
 while [ $# -gt 0 ]; do
@@ -157,6 +163,10 @@ while [ $# -gt 0 ]; do
     --no-autostart)         DPF_AUTOSTART=0 ;;
     --with-edge)            DPF_INCLUDE_EDGE=1 ;;
     --no-edge)              DPF_INCLUDE_EDGE=0 ;;
+    --organization-join-package)
+                            shift
+                            [ -n "${1:-}" ] || { echo "--organization-join-package requires a file" >&2; exit 64; }
+                            DPF_ORGANIZATION_JOIN_PACKAGE="$1" ;;
     --force-unsupported-host)
                             DPF_FORCE_UNSUPPORTED_HOST=1
                             export DPF_FORCE_UNSUPPORTED_HOST ;;
@@ -170,6 +180,17 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+if [ -n "$DPF_ORGANIZATION_JOIN_PACKAGE" ]; then
+  case "$DPF_ORGANIZATION_JOIN_PACKAGE" in
+    /*) : ;;
+    *) DPF_ORGANIZATION_JOIN_PACKAGE="$DPF_INSTALL_CALLER_DIR/$DPF_ORGANIZATION_JOIN_PACKAGE" ;;
+  esac
+  [ -f "$DPF_ORGANIZATION_JOIN_PACKAGE" ] || {
+    echo "Organization join package was not found: $DPF_ORGANIZATION_JOIN_PACKAGE" >&2
+    exit 66
+  }
+fi
 
 cd "$REPO_ROOT"
 
@@ -847,6 +868,15 @@ fi
 #     happen inside portal-init using whatever DPF_LLM_PROVIDER
 #     resolves to (Docker Model Runner on Docker Desktop; Ollama on
 #     Linux native Docker via docker-compose.linux.yml).
+if [ -n "$DPF_ORGANIZATION_JOIN_PACKAGE" ]; then
+  step "Organization trust"
+  bash "$REPO_ROOT/scripts/bootstrap-organization-pki.sh" \
+    --mode join --join-package "$DPF_ORGANIZATION_JOIN_PACKAGE" --no-start-tls
+  export DPF_ORGANIZATION_TRUST_ENABLED=1
+  dpf_compose_files "$DPF_MODE"
+  ok "Organization HTTPS trust configured; the one-time package was consumed"
+fi
+
 step "Bringing up the platform"
 # Stamp the build with the current commit so /ops/self-upgrade can compare the
 # running image to the upgrade target. Contributor mode builds from local

--- a/scripts/bootstrap-organization-pki.ps1
+++ b/scripts/bootstrap-organization-pki.ps1
@@ -125,7 +125,11 @@ function Invoke-DpfPkiCompose {
         $env:DPF_PKI_DNS_NAMES = ((@($Hostname) + $San + @($BindAddress, "localhost", "127.0.0.1")) | Where-Object { $_ }) -join ","
         $env:DPF_PKI_NAME = $OrganizationName
         $env:DPF_TLS_DIR = $OutDir
-        & docker compose --project-directory $RepoRoot -f (Join-Path $RepoRoot "docker-compose.yml") -f (Join-Path $RepoRoot "docker-compose.pki.yml") @Arguments
+        $composeFiles = @("-f", (Join-Path $RepoRoot "docker-compose.yml"), "-f", (Join-Path $RepoRoot "docker-compose.organization-trust.yml"))
+        if ($Mode -in @("authority", "issue-join")) {
+            $composeFiles += @("-f", (Join-Path $RepoRoot "docker-compose.pki.yml"))
+        }
+        & docker compose --project-directory $RepoRoot @composeFiles @Arguments
         if ($LASTEXITCODE -ne 0) { throw "organization_pki_compose_failed" }
     } finally {
         foreach ($key in $old.Keys) {
@@ -135,6 +139,34 @@ function Invoke-DpfPkiCompose {
                 Set-Item -Path "env:$key" -Value $old[$key]
             }
         }
+    }
+}
+
+function Set-DpfOrganizationTrustEnvironment {
+    $envPath = Join-Path $RepoRoot ".env"
+    if (-not (Test-Path -LiteralPath $envPath -PathType Leaf)) { return }
+    foreach ($value in @($RootCert, $OutDir)) {
+        if ($value -match "[`r`n]") { throw "PKI paths must not contain newlines" }
+    }
+    $content = [IO.File]::ReadAllLines($envPath) | Where-Object {
+        $_ -notmatch '^DPF_ORGANIZATION_TRUST_ENABLED=' -and
+        $_ -notmatch '^DPF_PKI_TRUST_BUNDLE=' -and
+        $_ -notmatch '^DPF_TLS_DIR='
+    }
+    $content += @(
+        "DPF_ORGANIZATION_TRUST_ENABLED=1",
+        "DPF_PKI_TRUST_BUNDLE=$RootCert",
+        "DPF_TLS_DIR=$OutDir"
+    )
+    $suffix = [guid]::NewGuid().ToString('N')
+    $temporary = "$envPath.organization-trust.$suffix.tmp"
+    $backup = "$envPath.organization-trust.$suffix.bak"
+    try {
+        [IO.File]::WriteAllLines($temporary, $content, (New-Object Text.UTF8Encoding($false)))
+        [IO.File]::Replace($temporary, $envPath, $backup, $true)
+    } finally {
+        Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
     }
 }
 
@@ -261,6 +293,8 @@ $hosts {
 }
 "@
 [IO.File]::WriteAllText($Caddyfile, $caddy, (New-Object Text.UTF8Encoding($false)))
+
+Set-DpfOrganizationTrustEnvironment
 
 if (-not $NoStartTls) {
     Invoke-DpfPkiCompose -Arguments @("-f", (Join-Path $RepoRoot "docker-compose.tls.yml"), "up", "-d", "portal", "portal-tls")

--- a/scripts/bootstrap-organization-pki.sh
+++ b/scripts/bootstrap-organization-pki.sh
@@ -202,6 +202,10 @@ if [ "$MODE" = "join" ] && [ -n "$JOIN_PACKAGE" ]; then
 fi
 
 compose() {
+  local compose_files=(-f "$REPO_ROOT/docker-compose.yml" -f "$REPO_ROOT/docker-compose.organization-trust.yml")
+  if [ "$MODE" = "authority" ] || [ "$MODE" = "issue-join" ]; then
+    compose_files+=( -f "$REPO_ROOT/docker-compose.pki.yml" )
+  fi
   DPF_PKI_PASSWORD_FILE="$PASSWORD_FILE_EFFECTIVE" \
   DPF_PKI_TRUST_BUNDLE="$ROOT_CERT" \
   DPF_PKI_BIND_ADDRESS="$BIND_ADDRESS" \
@@ -209,8 +213,22 @@ compose() {
   DPF_PKI_NAME="$ORG_NAME" \
   DPF_TLS_DIR="$OUT_DIR" \
   docker compose --project-directory "$REPO_ROOT" \
-    -f "$REPO_ROOT/docker-compose.yml" \
-    -f "$REPO_ROOT/docker-compose.pki.yml" "$@"
+    "${compose_files[@]}" "$@"
+}
+
+persist_organization_trust() {
+  env_file="$REPO_ROOT/.env"
+  [ -f "$env_file" ] || return 0
+  case "$OUT_DIR$ROOT_CERT" in *$'\n'*|*$'\r'*) echo "PKI paths must not contain newlines" >&2; exit 64 ;; esac
+  env_tmp="$(mktemp "$env_file.organization-trust.XXXXXX")"
+  awk -F= '$1 != "DPF_ORGANIZATION_TRUST_ENABLED" && $1 != "DPF_PKI_TRUST_BUNDLE" && $1 != "DPF_TLS_DIR" { print }' "$env_file" > "$env_tmp"
+  {
+    printf 'DPF_ORGANIZATION_TRUST_ENABLED=1\n'
+    printf 'DPF_PKI_TRUST_BUNDLE=%s\n' "$ROOT_CERT"
+    printf 'DPF_TLS_DIR=%s\n' "$OUT_DIR"
+  } >> "$env_tmp"
+  chmod 0600 "$env_tmp"
+  mv "$env_tmp" "$env_file"
 }
 
 if [ "$MODE" = "authority" ]; then
@@ -338,6 +356,8 @@ $HOSTS {
 }
 EOF
 chmod 0644 "$CADDYFILE"
+
+persist_organization_trust
 
 if [ "$START_TLS" = "1" ]; then
   compose -f "$REPO_ROOT/docker-compose.tls.yml" up -d portal portal-tls

--- a/scripts/dpf-start.ps1
+++ b/scripts/dpf-start.ps1
@@ -36,6 +36,10 @@ $composeArgs = @("-f", "docker-compose.yml")
 if (Test-Path (Join-Path $DPF_DIR "docker-compose.override.yml")) {
     $composeArgs += @("-f", "docker-compose.override.yml")
 }
+$envPath = Join-Path $DPF_DIR ".env"
+if ((Test-Path -LiteralPath $envPath) -and (Select-String -LiteralPath $envPath -Pattern '^DPF_ORGANIZATION_TRUST_ENABLED=1$' -Quiet)) {
+    $composeArgs += @("-f", "docker-compose.organization-trust.yml", "-f", "docker-compose.tls.yml")
+}
 if ($includeEdge -and (Test-Path (Join-Path $DPF_DIR "docker-compose.edge.yml"))) {
     $composeArgs += @("-f", "docker-compose.edge.yml")
 }

--- a/scripts/installer/lib/compose.sh
+++ b/scripts/installer/lib/compose.sh
@@ -104,6 +104,17 @@ dpf_compose_files() {
     DPF_COMPOSE_FILES+=(-f docker-compose.edge.yml)
   fi
 
+  # Organization members persist this marker only after a fingerprint-pinned
+  # join succeeds. Trust/TLS is a member lifecycle concern; the Step CA
+  # authority overlay is deliberately not added here.
+  organization_trust="${DPF_ORGANIZATION_TRUST_ENABLED:-}"
+  if [ -z "$organization_trust" ] && [ -f .env ]; then
+    organization_trust="$(sed -n 's/^DPF_ORGANIZATION_TRUST_ENABLED=//p' .env | tail -1)"
+  fi
+  if [ "$organization_trust" = "1" ]; then
+    DPF_COMPOSE_FILES+=(-f docker-compose.organization-trust.yml -f docker-compose.tls.yml)
+  fi
+
   # Append any caller-provided extras (e.g. docker-compose.dev.yml for
   # the developer port-exposing overlay).
   while [ "$#" -gt 0 ]; do

--- a/scripts/installer/pki-contract.test.mjs
+++ b/scripts/installer/pki-contract.test.mjs
@@ -9,6 +9,7 @@ const read = (path) => readFile(new URL(`../../${path}`, import.meta.url), "utf8
 
 test("organization PKI compose pins the approved image and protects CA custody", async () => {
   const compose = await read("docker-compose.pki.yml");
+  const trust = await read("docker-compose.organization-trust.yml");
 
   assert.match(
     compose,
@@ -21,7 +22,59 @@ test("organization PKI compose pins the approved image and protects CA custody",
   assert.match(compose, /DPF_PKI_BIND_ADDRESS:-127\.0\.0\.1/);
   assert.match(compose, /no-new-privileges:true/);
   assert.match(compose, /step_ca_data/);
-  assert.match(compose, /NODE_EXTRA_CA_CERTS/);
+  assert.doesNotMatch(compose, /NODE_EXTRA_CA_CERTS/);
+  assert.doesNotMatch(compose, /\n\s{2}portal:/);
+  assert.match(trust, /NODE_EXTRA_CA_CERTS/);
+  assert.match(trust, /DPF_PKI_TRUST_BUNDLE/);
+  assert.doesNotMatch(trust, /step-ca:/);
+});
+
+test("installers consume an organization join package without asking operators to manage PKI", async () => {
+  const [shellInstaller, windowsInstaller] = await Promise.all([
+    read("install-dpf.sh"),
+    read("install-dpf.ps1"),
+  ]);
+
+  assert.match(shellInstaller, /--organization-join-package/);
+  assert.match(shellInstaller, /Organization join package was not found/);
+  assert.match(shellInstaller, /bootstrap-organization-pki\.sh[\s\S]*--mode[\s\S]*join[\s\S]*--no-start-tls/);
+  assert.match(windowsInstaller, /OrganizationJoinPackage/);
+  assert.match(windowsInstaller, /organization_join_package_not_found/);
+  assert.match(windowsInstaller, /bootstrap-organization-pki\.ps1[\s\S]*-Mode[\s\S]*join[\s\S]*-NoStartTls/);
+});
+
+test("successful PKI bootstrap persists member trust for normal restart lifecycle", async () => {
+  const [shellBootstrap, windowsBootstrap, shellStart, windowsStart, composeLib] = await Promise.all([
+    read("scripts/bootstrap-organization-pki.sh"),
+    read("scripts/bootstrap-organization-pki.ps1"),
+    read("dpf-start.sh"),
+    read("scripts/dpf-start.ps1"),
+    read("scripts/installer/lib/compose.sh"),
+  ]);
+
+  for (const source of [shellBootstrap, windowsBootstrap]) {
+    assert.match(source, /DPF_ORGANIZATION_TRUST_ENABLED/);
+    assert.match(source, /DPF_PKI_TRUST_BUNDLE/);
+    assert.match(source, /DPF_TLS_DIR/);
+  }
+  assert.match(composeLib, /docker-compose\.organization-trust\.yml/);
+  assert.match(composeLib, /docker-compose\.tls\.yml/);
+  assert.match(shellStart, /DPF_ORGANIZATION_TRUST_ENABLED|organization-trust/);
+  assert.match(windowsStart, /docker-compose\.organization-trust\.yml/);
+  assert.match(windowsStart, /docker-compose\.tls\.yml/);
+});
+
+test("Windows consumer release carries the verified organization-join lifecycle assets", async () => {
+  const dockerfile = await read("Dockerfile");
+
+  for (const asset of [
+    "docker-compose.pki.yml",
+    "docker-compose.organization-trust.yml",
+    "docker-compose.tls.yml",
+    "scripts/bootstrap-organization-pki.ps1",
+  ]) {
+    assert.match(dockerfile, new RegExp(asset.replaceAll(".", "\\.")));
+  }
 });
 
 test("Bash and PowerShell PKI bootstraps expose the same safe lifecycle", async () => {


### PR DESCRIPTION
## Summary\n\nPersists an organization join package through the macOS/Linux and Windows installer/start lifecycle so a member installation restores its organization trust bundle and TLS overlay automatically after install, restart, and repair. It also separates member trust from authority operation so joined members never start a second Step CA.\n\n## Changes\n\n- add a member-only organization trust Compose overlay and keep Step CA in the authority-only PKI overlay\n- accept an organization join package in both native installers, fail fast when it is missing, bootstrap before startup, and persist the resolved trust/TLS settings atomically\n- restore organization trust and TLS overlays from persisted installation state in Bash and PowerShell start paths\n- package the required overlays and bootstrap surfaces into release images/assets\n- extend cross-platform installer contracts and operator documentation\n\n## Test plan\n\n- [x] **Runtime-bound change** (installer and Compose lifecycle)\n  - [x] source checks passed in the worktree\n  - [x] functional verification ran in an isolated scratch installation\n  - [x] merged-code CI-equivalent verification ran in the governed shared nonprod environment (lease NPEL-79B4DBC2BF)\n  - [x] evidence captured below\n\n### Verification evidence\n\n- exact head: 80aa000569798485bf336712867bd6d1105eb6ea\n- current merged base: 560541f6d7b4f4815fefc78f979811de7a19da91\n- Local-CI-Evidence: cmrv5xuu608bd01qk8znbzsua\n- full web Vitest, TypeScript, Next production build, Prisma generate, and migrate deploy passed\n- focused installer suite: 35/35 passed\n- member Compose topology includes portal, portal-init, portal-tls, and postgres with no step-ca; authority topology adds step-ca\n- isolated scratch install health returned HTTP 200 and first-run setup, organization/owner bootstrap, provider setup, and authenticated Work Control passed\n- scratch evidence: /tmp/dpf-scratch-federation-installer-join-80aa0005/evidence\n- PowerShell runtime was unavailable on the macOS verification host; PowerShell behavior is covered by the static cross-platform contract and CRLF/ASCII checks, with physical Windows acceptance remaining in the parent BI\n\n## Related issues / Epic\n\n- Parent objective: federated demand network\n- This PR covers BI-52D34506 partially: installer/repair lifecycle wiring for organization join\n\n## Epic / Backlog linkage\n\n- BI-52D34506 remains open for the no-shell Connections action and physical Mac/Windows two-host acceptance.\n\n## Overlap sweep\n\n- Compared this PR's 13 files with open PRs before publication: no overlapping files.\n- Compared files changed on main since the first gate with this branch: no overlap.\n\n## Notes for the reviewer\n\n- Members consume the organization trust overlay but do not run Step CA. Authority/issuance mode explicitly adds the authority overlay.\n- No schema migration and no new UI route are included.\n- Documentation impact: operator guidance and the federated-demand implementation plan are updated.\n- Seed-Fit-Decision: global-default\n\nDPF-Capsule: WC-5F00A8E9\nLocal-CI-Evidence: cmrv5xuu608bd01qk8znbzsua\n