### PR TITLE
fix(routing): defeat Turbopack minifier bug breaking every routed phase (BI-573A8EB3)

### DIFF
--- a/apps/web/lib/inference/phase-model-resolution.ts
+++ b/apps/web/lib/inference/phase-model-resolution.ts
@@ -246,6 +246,16 @@ async function resolveRoutedPhase(args: {
     // what actually happened; only claim "no providers" when that is the case.
     const verdict = classifyDispatchFailure(err);
     const structural = verdict.code !== "transient";
+    // BI-573A8EB3: keeping only err.message here is how a `ReferenceError:
+    // workloadClass is not defined` (a Turbopack-minifier bug in the suitability
+    // path) stayed invisible for days — the message names the symptom, the STACK
+    // names the file. Log the stack once per failure so the next opaque routing
+    // throw is diagnosable from the logs instead of by bundle archaeology. The
+    // returned rationale stays the human-readable message.
+    console.error(
+      `[phase-model-resolution] ${args.label} route failed (${verdict.code}):`,
+      err instanceof Error ? (err.stack ?? err.message) : err,
+    );
     return {
       ...base,
       providerId: null,

--- a/apps/web/lib/routing/provider-suitability/work-context.ts
+++ b/apps/web/lib/routing/provider-suitability/work-context.ts
@@ -82,14 +82,28 @@ function cloneProfile(profile: AiWorkloadDataProfile): AiWorkloadDataProfile {
   };
 }
 
+// BI-4C8F9E2A — the parameter is deliberately NOT named `workloadClass`, and the
+// property below is deliberately written `workloadClass: hintWorkloadClass`
+// rather than shorthand. Turbopack's minifier inlines this function into its sole
+// caller — `classes.map((workloadClass) => profileFromHint(workloadClass, …))` —
+// renames that map parameter to a single letter, but then FAILS to rewrite an
+// object-shorthand `{ workloadClass }` whose value was that renamed parameter,
+// emitting a bare `{ workloadClass }` that references nothing. The result is a
+// runtime `ReferenceError: workloadClass is not defined` that fires on EVERY
+// routed-phase route (plan / design-review / plan-review), which
+// resolve_model_selection then mislabels "No AI providers are configured". The
+// bug exists ONLY in the minified production bundle — source, typecheck, and unit
+// tests are all clean — so nothing but a built-bundle check catches it. Giving the
+// parameter a distinct name and writing the property explicitly denies the
+// minifier the shorthand it mishandles. Do not "simplify" this back to shorthand.
 function profileFromHint(
-  workloadClass: AiWorkloadClassKey,
+  hintWorkloadClass: AiWorkloadClassKey,
   activity: ActivityContract,
   classificationKnown: boolean,
 ): AiWorkloadDataProfile {
   const governed = activity.governedData;
   const base = deriveAiWorkloadDataProfile({
-    workloadClass,
+    workloadClass: hintWorkloadClass,
     classificationKnown,
     applicableRegulationIds: governed?.applicableRegulationIds,
     processingActivityId: governed?.processingActivityId,

--- a/docs/superpowers/plans/2026-07-21-dispatch-failure-fail-fast.md
+++ b/docs/superpowers/plans/2026-07-21-dispatch-failure-fail-fast.md
@@ -2,7 +2,20 @@
 
 Status: slice 1 landed, slices 2–4 open
 Owner: platform / inference
-Related: BI-8C44DB49, BI-A009313E (stranded-ideate flood, same unbounded-retry class)
+Related: BI-8C44DB49, BI-A009313E (stranded-ideate flood, same unbounded-retry class),
+BI-573A8EB3 (the UPSTREAM cause — see below)
+
+## Update — the upstream trigger is BI-573A8EB3, a Turbopack minifier bug
+
+This fail-fast work bounds the *damage* (don't retry what can't succeed). The
+thing that can't succeed was finally root-caused: routed phases (plan /
+design-review / plan-review) throw `ReferenceError: workloadClass is not defined`
+from a Turbopack inlining bug in `provider-suitability/work-context.ts` — the
+source is correct, only the minified bundle is broken, so no unit test sees it.
+Fixed under BI-573A8EB3. With that fixed AND an eligible provider, the 8 stranded
+`plan`-phase builds can actually advance instead of feeding the flood. The
+fail-fast slices remain worth landing: they are the general guarantee that any
+*future* structural dispatch failure is bounded rather than infinite.
 
 ## The incident this exists to prevent
 

--- a/docs/superpowers/plans/2026-07-21-routed-phase-minifier-referenceerror.md
+++ b/docs/superpowers/plans/2026-07-21-routed-phase-minifier-referenceerror.md
@@ -1,0 +1,100 @@
+# Routed-phase `ReferenceError: workloadClass is not defined` — BI-573A8EB3
+
+Status: source fix applied, build-verification in progress
+Related: BI-8C44DB49 (the flood this causes), BI-9257CF19 (auto-resume),
+BI-A009313E (7-day stranded age-out safety net)
+
+## The actual root cause behind the flood
+
+Every routed Build Studio phase — `plan`, `design-review`, `plan-review` — fails
+model resolution with:
+
+```
+rationale: "workloadClass is not defined"
+```
+
+That is a JavaScript `ReferenceError`, not a routing verdict. It is why 8 builds
+have been stranded in `plan` since 2026-07-18: the plan/review phases can't
+resolve a model, the build never advances, the 30-minute auto-resume
+(BI-9257CF19) re-dispatches it, and each attempt mints the `Deliberation`
+TaskRuns counted in BI-8C44DB49. The "No AI providers configured" banner was a
+mislabel — `local`, `chatgpt`, `codex`, `zai-coding` are all active with
+`supportsToolUse=true`.
+
+## It's a Turbopack minifier bug, not a source defect
+
+Call path (confirmed): `previewRoute` → `prepareRoute` →
+`prepareProviderSuitabilityRuntime` (`routed-inference.ts:214`) →
+`deriveProviderSuitabilityWorkContext` (`provider-suitability/work-context.ts`) →
+`profileFromHint`.
+
+Source, correct:
+
+```ts
+profiles = classes.map((workloadClass) =>
+  profileFromHint(workloadClass, input.activity, classificationKnown));
+
+function profileFromHint(workloadClass, activity, classificationKnown) {
+  const base = deriveAiWorkloadDataProfile({ workloadClass, classificationKnown, … }); // shorthand
+}
+```
+
+Deployed minified chunk (`/app/apps/web/.next/server/chunks/_1ks12ad._.js`),
+verbatim:
+
+```js
+n=s.map(i=>{var o,r;let n,a;return o=e.activity,n=o.governedData,
+  {...(a=t[(r={workloadClass,classificationKnown, …
+```
+
+Turbopack **inlined** `profileFromHint` into the `.map` callback, renamed that
+callback's `workloadClass` parameter to `i`, but then **failed to rewrite the
+object-shorthand `{ workloadClass }`** whose value was that renamed parameter —
+emitting a bare `workloadClass` bound to nothing. The sibling shorthand
+`classificationKnown` survives because it is a closure variable, not the inlined
+parameter, which is exactly why only `workloadClass` throws.
+
+## Why it hid for days
+
+- Source is correct, `tsc` is clean, unit tests are clean. **The bug exists only
+  in the minified production bundle** — nothing that runs TS source can reproduce
+  it.
+- The `phase-model-resolution` catch kept only `err.message` and discarded the
+  stack, and (pre-slice-1) relabelled it "No AI providers configured", aiming
+  every investigator at a configuration problem that did not exist.
+
+## The fix
+
+`work-context.ts` `profileFromHint`: rename the parameter to `hintWorkloadClass`
+and write the property explicitly as `workloadClass: hintWorkloadClass` instead
+of shorthand. That gives the minifier a distinct value identifier to rename, so
+the inliner can no longer collapse it into a dangling shorthand. Semantically
+identical; typecheck-clean. A comment marks it load-bearing so it is not
+"simplified" back.
+
+## Hardening gap — a unit test cannot guard this
+
+This class of bug only appears after minification, so a source-level test never
+sees it. Real regression protection needs a **post-build** check: after
+`next build`, load the built suitability module (or scan the emitted chunks) and
+assert `deriveProviderSuitabilityWorkContext` resolves without a `ReferenceError`
+/ emits no dangling free-variable shorthand. Recommended as a prod-build gate
+step (follow-up).
+
+## Verification
+
+The only valid proof is the built bundle, not a unit test:
+
+1. Rebuild the web bundle from this branch.
+2. `grep` the emitted `.next/server/chunks` for a bare `workloadClass` shorthand
+   in the suitability code — it must be gone (only `.workloadClass` /
+   `workloadClass:` property forms remain).
+3. On the live install, `resolve_model_selection` must stop returning
+   `workloadClass is not defined` for the routed phases.
+
+## Interaction with the flood
+
+Even unfixed, the 8 stranded builds age out to `abandoned` at 7 days
+(BI-A009313E, keyed on `createdAt`), i.e. ~2026-07-25, which stops the flood on
+its own. This fix lets the routed phases actually resolve, so a build with an
+eligible provider can complete `plan` instead of being abandoned.


### PR DESCRIPTION
The true upstream cause of the Build Studio flood in `BI-8C44DB49`. Every routed phase (`plan` / `design-review` / `plan-review`) fails model resolution with `ReferenceError: workloadClass is not defined`, which strands builds in `plan` forever and feeds the Deliberation TaskRun flood.

## It's a Turbopack minifier bug — the source is correct

Call path: `previewRoute → prepareRoute → prepareProviderSuitabilityRuntime → deriveProviderSuitabilityWorkContext → profileFromHint`.

**Source (correct):**
```ts
classes.map((workloadClass) => profileFromHint(workloadClass, activity, known))
function profileFromHint(workloadClass, …) {
  deriveAiWorkloadDataProfile({ workloadClass, classificationKnown, … })  // shorthand
}
```

**Minified bundle (`_1ks12ad._.js`), verbatim:**
```js
n=s.map(i=>{ … r={workloadClass,classificationKnown, …
```

Turbopack **inlined** `profileFromHint` into the `.map` callback, renamed that callback's `workloadClass` parameter to `i`, but **failed to rewrite the object-shorthand `{ workloadClass }`** whose value was that renamed parameter — leaving a bare `workloadClass` bound to nothing. `classificationKnown` survives because it's a closure variable, not the inlined parameter, which is exactly why only `workloadClass` throws.

## Why it hid for days

- The bug exists **only in the minified production bundle**. Source, `tsc`, and every unit test are clean — nothing that runs TS source can reproduce it.
- The `phase-model-resolution` catch kept only `err.message` and discarded the stack, and (pre-slice-1) relabelled it "No AI providers configured" — aiming every investigator at a config problem that didn't exist. Providers were fine (`local`/`chatgpt`/`codex`/`zai-coding`, all `supportsToolUse=true`).

## Fix + hardening

1. `work-context.ts`: rename the param to `hintWorkloadClass`, write the property explicitly (`workloadClass: hintWorkloadClass`). A distinct value identifier denies the minifier the shorthand it collapses wrong. Marked load-bearing.
2. `phase-model-resolution.ts`: the catch now logs the full stack once per failure, so the next opaque routing throw names its file instead of requiring bundle archaeology.

## Verified against a production-identical build (no unit test can catch this)

Built the portal image from this branch and grepped the emitted chunks:

```
before:  {workloadClass,classificationKnown     ← dangling free reference → ReferenceError
after:   workloadClass:i,classificationKnown     ← explicit key, renamed var as value ✓
```

The exact bug signature `{workloadClass,classificationKnown` → **0 matches**; the corrected `workloadClass:<renamed-var>` appears in every suitability chunk.

## Follow-up (filed on BI-573A8EB3)

A unit test structurally cannot guard this class — it needs a **post-build** assertion (load the built suitability module / scan chunks after `next build`). Recommended as a prod-build gate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
