### PR TITLE
fix(routing): eliminate ALL suitability object-shorthand + guard it (BI-573A8EB3)

### DIFF
--- a/apps/web/lib/routing/provider-suitability/onboarding-recommendation.ts
+++ b/apps/web/lib/routing/provider-suitability/onboarding-recommendation.ts
@@ -77,8 +77,13 @@ function compileFor(input: {
 }) {
   return compileAiProviderSuitabilityPolicy({
     businessProfile: input.businessProfile,
-    workloadProfiles: input.workloadClasses.map((workloadClass) =>
-      deriveAiWorkloadDataProfile({ workloadClass }),
+    // Explicit `workloadClass: onboardingWorkloadClass`, never shorthand — same
+    // Turbopack inline-minifier bug as work-context.ts profileFromHint
+    // (BI-573A8EB3). A shorthand `{ workloadClass }` whose value is this renamed
+    // map parameter is emitted as a dangling free reference in the production
+    // bundle. Guarded by scripts/check-no-suitability-object-shorthand.mjs.
+    workloadProfiles: input.workloadClasses.map((onboardingWorkloadClass) =>
+      deriveAiWorkloadDataProfile({ workloadClass: onboardingWorkloadClass }),
     ),
     dataPolicyDecisions: [],
     regulationResults: [],

--- a/apps/web/lib/routing/provider-suitability/work-context.ts
+++ b/apps/web/lib/routing/provider-suitability/work-context.ts
@@ -82,29 +82,33 @@ function cloneProfile(profile: AiWorkloadDataProfile): AiWorkloadDataProfile {
   };
 }
 
-// BI-4C8F9E2A — the parameter is deliberately NOT named `workloadClass`, and the
-// property below is deliberately written `workloadClass: hintWorkloadClass`
-// rather than shorthand. Turbopack's minifier inlines this function into its sole
-// caller — `classes.map((workloadClass) => profileFromHint(workloadClass, …))` —
-// renames that map parameter to a single letter, but then FAILS to rewrite an
-// object-shorthand `{ workloadClass }` whose value was that renamed parameter,
-// emitting a bare `{ workloadClass }` that references nothing. The result is a
-// runtime `ReferenceError: workloadClass is not defined` that fires on EVERY
-// routed-phase route (plan / design-review / plan-review), which
-// resolve_model_selection then mislabels "No AI providers are configured". The
-// bug exists ONLY in the minified production bundle — source, typecheck, and unit
-// tests are all clean — so nothing but a built-bundle check catches it. Giving the
-// parameter a distinct name and writing the property explicitly denies the
-// minifier the shorthand it mishandles. Do not "simplify" this back to shorthand.
+// BI-573A8EB3 / BI-4C8F9E2A — EVERY parameter here is deliberately given a
+// distinct name and EVERY property below is written explicit `key: value`, never
+// shorthand. Turbopack's minifier inlines this function into its sole caller —
+// `classes.map((workloadClass) => profileFromHint(workloadClass, …))` — renames
+// the parameters to single letters, but then FAILS to rewrite an object-shorthand
+// `{ x }` whose value was one of those renamed parameters, emitting a bare `{ x }`
+// that references nothing. At runtime that is `ReferenceError: <name> is not
+// defined` on EVERY routed-phase route (plan / design-review / plan-review),
+// which resolve_model_selection mislabels "No AI providers are configured".
+//
+// It bites one property at a time: the error throws on the FIRST dangling
+// reference, so fixing only `workloadClass` (the first shorthand) merely exposed
+// `classificationKnown` (the second) on the live install after deploy — a partial
+// fix that passed a narrow bundle grep but failed reality. Hence: no shorthand at
+// all in this object, and a matching guard (scripts/check-no-suitability-object-
+// shorthand.mjs) now fails CI if any returns. The bug exists ONLY in the minified
+// production bundle — source, typecheck, and unit tests are all clean — so nothing
+// but a built-bundle check or that guard catches it. Do not reintroduce shorthand.
 function profileFromHint(
   hintWorkloadClass: AiWorkloadClassKey,
   activity: ActivityContract,
-  classificationKnown: boolean,
+  hintClassificationKnown: boolean,
 ): AiWorkloadDataProfile {
   const governed = activity.governedData;
   const base = deriveAiWorkloadDataProfile({
     workloadClass: hintWorkloadClass,
-    classificationKnown,
+    classificationKnown: hintClassificationKnown,
     applicableRegulationIds: governed?.applicableRegulationIds,
     processingActivityId: governed?.processingActivityId,
   });

--- a/scripts/check-no-suitability-object-shorthand.mjs
+++ b/scripts/check-no-suitability-object-shorthand.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * check-no-suitability-object-shorthand — CI ratchet for BI-573A8EB3.
+ *
+ * Turbopack's production minifier inlines the small helpers in
+ * apps/web/lib/routing/provider-suitability/ into their `.map(param => …)`
+ * callers, renames the parameters, but then FAILS to rewrite an object-property
+ * SHORTHAND `{ x }` whose value was one of those renamed parameters — emitting a
+ * bare `{ x }` that binds to nothing. At runtime that is
+ * `ReferenceError: <name> is not defined` on EVERY routed Build Studio phase
+ * (plan / design-review / plan-review), which strands builds in `plan` and feeds
+ * the deliberation flood (BI-8C44DB49).
+ *
+ * It bites one property at a time — the error throws on the FIRST dangling
+ * reference — so a partial fix (rename only the property that happens to throw)
+ * passes a narrow bundle grep but re-breaks on the NEXT shorthand after deploy.
+ * That is exactly what happened: `workloadClass` was fixed, then
+ * `classificationKnown` surfaced live. The only safe rule is: NO shorthand in the
+ * object literals passed to `deriveAiWorkloadDataProfile(...)` in this directory.
+ *
+ * WHY A GUARD AND NOT A UNIT TEST: the bug exists ONLY in the minified production
+ * bundle — source, tsc, and vitest are all clean, because they run the correct TS
+ * source. Nothing but a built-bundle check or this source-level ban catches it.
+ * This runs in the Repo Guard Loop (a required check), the surface-agnostic
+ * chokepoint that actually blocks a merge.
+ *
+ *   node scripts/check-no-suitability-object-shorthand.mjs
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SCAN_DIR = join(ROOT, "apps", "web", "lib", "routing", "provider-suitability");
+const CALL = "deriveAiWorkloadDataProfile(";
+
+/**
+ * Extract the balanced `{ … }` that is the first argument of each
+ * `deriveAiWorkloadDataProfile(` call, and return the shorthand property names in
+ * it. A shorthand property is a top-level (brace-depth 1) bare identifier that is
+ * NOT followed by `:` and is not a spread. Pure + string-based (the guards here
+ * do not carry an AST parser), scoped tightly enough that heavier syntax does not
+ * reach it.
+ */
+export function findShorthandProps(source) {
+  const findings = [];
+  let from = 0;
+  for (;;) {
+    const call = source.indexOf(CALL, from);
+    if (call === -1) break;
+    from = call + CALL.length;
+    const open = source.indexOf("{", call);
+    if (open === -1 || open > source.indexOf(")", call) + 1) continue;
+    // Walk the object literal with brace matching (good enough: the suitability
+    // objects contain no braces inside strings/regex today, and the guard only
+    // needs to see the TOP level).
+    let depth = 0;
+    let end = -1;
+    for (let i = open; i < source.length; i += 1) {
+      if (source[i] === "{") depth += 1;
+      else if (source[i] === "}") {
+        depth -= 1;
+        if (depth === 0) { end = i; break; }
+      }
+    }
+    if (end === -1) continue;
+    const body = source.slice(open + 1, end);
+    // Split top-level (depth-0) properties on commas.
+    let d = 0;
+    let cur = "";
+    const props = [];
+    for (const ch of body) {
+      if (ch === "{" || ch === "[" || ch === "(") d += 1;
+      else if (ch === "}" || ch === "]" || ch === ")") d -= 1;
+      if (ch === "," && d === 0) { props.push(cur); cur = ""; continue; }
+      cur += ch;
+    }
+    props.push(cur);
+    for (const raw of props) {
+      const p = raw.trim();
+      if (!p || p.startsWith("...")) continue;
+      // Explicit `key: value` or a method/computed key → fine. Shorthand is a
+      // bare identifier that stands alone.
+      if (/^[A-Za-z_$][\w$]*$/.test(p)) findings.push(p);
+    }
+  }
+  return findings;
+}
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (/\.tsx?$/.test(name) && !/\.test\.tsx?$/.test(name)) out.push(full);
+  }
+  return out;
+}
+
+function main() {
+  const offenders = [];
+  for (const file of walk(SCAN_DIR)) {
+    const shorthand = findShorthandProps(readFileSync(file, "utf8"));
+    for (const name of shorthand) {
+      offenders.push(`${relative(ROOT, file).replace(/\\/g, "/")} → deriveAiWorkloadDataProfile({ ${name} })`);
+    }
+  }
+  if (offenders.length > 0) {
+    console.error("check-no-suitability-object-shorthand: object SHORTHAND passed to deriveAiWorkloadDataProfile.");
+    console.error("Turbopack's minifier drops inlined shorthand, producing a runtime ReferenceError that");
+    console.error("breaks every routed Build Studio phase (BI-573A8EB3). Write it explicit: { workloadClass: x }.");
+    console.error("");
+    for (const o of offenders) console.error(`  ${o}`);
+    console.error("");
+    process.exit(1);
+  }
+  console.log("check-no-suitability-object-shorthand: OK — no inlined shorthand in the suitability path.");
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, "/")}`).href) {
+  main();
+}

--- a/scripts/check-no-suitability-object-shorthand.test.mjs
+++ b/scripts/check-no-suitability-object-shorthand.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findShorthandProps } from "./check-no-suitability-object-shorthand.mjs";
+
+// BI-573A8EB3. The two forms that actually appeared on the live install, one
+// after the other, as each was fixed in turn.
+test("flags the shorthand that broke plan routing", () => {
+  const src = `deriveAiWorkloadDataProfile({ workloadClass, classificationKnown, applicableRegulationIds: g?.a })`;
+  assert.deepEqual(findShorthandProps(src).sort(), ["classificationKnown", "workloadClass"]);
+});
+
+test("flags a lone shorthand (the onboarding call site)", () => {
+  assert.deepEqual(findShorthandProps("deriveAiWorkloadDataProfile({ workloadClass })"), ["workloadClass"]);
+});
+
+test("accepts the explicit form the fix uses", () => {
+  const src = `deriveAiWorkloadDataProfile({
+    workloadClass: hintWorkloadClass,
+    classificationKnown: hintClassificationKnown,
+    applicableRegulationIds: governed?.applicableRegulationIds,
+    processingActivityId: governed?.processingActivityId,
+  })`;
+  assert.deepEqual(findShorthandProps(src), []);
+});
+
+test("does not confuse a spread or a nested object for shorthand", () => {
+  const src = `deriveAiWorkloadDataProfile({ workloadClass: x, ...rest, nested: { a } })`;
+  assert.deepEqual(findShorthandProps(src), []);
+});
+
+test("scans every call in a file, not just the first", () => {
+  const src = `
+    deriveAiWorkloadDataProfile({ workloadClass: ok })
+    deriveAiWorkloadDataProfile({ workloadClass })
+  `;
+  assert.deepEqual(findShorthandProps(src), ["workloadClass"]);
+});
+
+test("clean when there are no calls", () => {
+  assert.deepEqual(findShorthandProps("const x = { workloadClass };"), []);
+});


### PR DESCRIPTION
Completes the partial fix in #3354 and guards the class so it cannot recur.

## What #3354 got wrong

#3354 renamed only `workloadClass` to explicit form, on my mistaken reasoning that the sibling `classificationKnown` was a closure variable that would survive. **It isn't** — it's `profileFromHint`'s third parameter. The Turbopack inline-minifier bug drops object-shorthand **one property at a time**, and the `ReferenceError` throws on the *first* dangling reference:

```
before #3354:  ReferenceError: workloadClass is not defined
after  #3354:  ReferenceError: classificationKnown is not defined   ← caught live
```

The build-grep I used to verify #3354 searched only for `workloadClass`, so it passed a partial fix. **The live `resolve_model_selection` check is what caught the regression** — which is exactly why an end-to-end live check, not a narrow grep, is the real verification for a minifier-only bug.

## The complete fix

Every parameter of `profileFromHint` now has a distinct name and **every** property in the `deriveAiWorkloadDataProfile` object is explicit `key: value` — no shorthand remains. Same treatment for the `onboarding-recommendation.ts` call site (a latent instance on the onboarding path).

## The guard I should have shipped the first time

A unit test **cannot** catch this class — the bug lives only in the minified bundle; source, `tsc`, and vitest are all clean. `scripts/check-no-suitability-object-shorthand.mjs` is a **Repo Guard Loop ratchet** (a required check) that fails CI if any object-shorthand is passed to `deriveAiWorkloadDataProfile` in the suitability directory. 6 unit tests cover both live-observed forms and the explicit fix; auto-discovered by `check-guards.mjs`, no wiring.

## Verification

- guard **6/6**, and passes against the fixed source
- build-grep of the production bundle for **any** remaining dangling shorthand (result appended below)
- final proof will be the live `resolve_model_selection` after deploy — no `is not defined` on any routed phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
