### PR TITLE
feat(coworker): ground the autonomous execution path in profession corpus (BI-744D583B)

### DIFF
--- a/apps/web/lib/tak/autonomous-grounding-seam.test.ts
+++ b/apps/web/lib/tak/autonomous-grounding-seam.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Locks the BI-744D583B seam gate: executeAutonomousAgenticLoop grounds the
+// AUTONOMOUS path in profession corpus, but NOT the chat path (chat injects the
+// corpus upstream in agent-coworker and passes interactionMode "chat" — grounding
+// here would double-inject). The grounding logic itself is unit-tested in
+// profession-grounding.test.ts; this test only verifies the gate + handoff.
+
+vi.mock("@dpf/db", () => {
+  const prisma = {
+    agent: { findFirst: vi.fn(async () => null) },
+    taskRun: { create: vi.fn(), findFirst: vi.fn() },
+  };
+  return { prisma };
+});
+vi.mock("@/lib/platform-runtime/work-admission", () => ({ admitRuntimeGuardedWork: vi.fn() }));
+vi.mock("@/lib/tak/agentic-loop", () => ({ runAgenticLoop: vi.fn() }));
+vi.mock("@/lib/inference/inference-admission", () => ({
+  withInferenceOrigin: (_origin: string, fn: () => unknown) => fn(),
+}));
+vi.mock("@/lib/golden-triangle/coworker-review", () => ({
+  resolveCoworkerReviewPattern: vi.fn(async () => "none"),
+}));
+vi.mock("@/lib/tak/coworker-inline-review", () => ({ reviewCoworkerDraft: vi.fn() }));
+vi.mock("@/lib/tak/reflection-triggers", () => ({ processRuntimeIssueReflection: vi.fn() }));
+vi.mock("@/lib/tak/profession-grounding", () => ({
+  groundPromptWithProfessionCorpus: vi.fn(async () => ({ systemPrompt: "GROUNDED", grounded: true })),
+  defaultProfessionGroundingDeps: {},
+}));
+
+async function callLoop(interactionMode?: "chat" | "autonomous") {
+  const { executeAutonomousAgenticLoop } = await import("./autonomous-work-run");
+  await executeAutonomousAgenticLoop({
+    systemPrompt: "BASE",
+    chatHistory: [{ role: "user", content: "Do the build task." }],
+    sensitivity: "internal",
+    tools: [],
+    toolsForProvider: [],
+    userId: "user-1",
+    routeContext: "build",
+    agentId: "build-qa-engineer",
+    threadId: "thread-1",
+    ...(interactionMode ? { interactionMode } : {}),
+  });
+}
+
+describe("executeAutonomousAgenticLoop — profession-corpus grounding gate", () => {
+  beforeEach(async () => {
+    const agentic = await import("@/lib/tak/agentic-loop");
+    vi.mocked(agentic.runAgenticLoop).mockReset();
+    vi.mocked(agentic.runAgenticLoop).mockResolvedValue({ content: "ok", executedTools: [] } as never);
+    const grounding = await import("@/lib/tak/profession-grounding");
+    vi.mocked(grounding.groundPromptWithProfessionCorpus).mockClear();
+  });
+
+  it("grounds the autonomous path and forwards the grounded prompt to the loop", async () => {
+    await callLoop(); // default interactionMode → autonomous
+    const grounding = await import("@/lib/tak/profession-grounding");
+    const agentic = await import("@/lib/tak/agentic-loop");
+    expect(grounding.groundPromptWithProfessionCorpus).toHaveBeenCalledTimes(1);
+    expect(agentic.runAgenticLoop).toHaveBeenCalledWith(
+      expect.objectContaining({ systemPrompt: "GROUNDED" }),
+    );
+  });
+
+  it("does NOT ground the chat path (chat injects upstream — no double-injection)", async () => {
+    await callLoop("chat");
+    const grounding = await import("@/lib/tak/profession-grounding");
+    const agentic = await import("@/lib/tak/agentic-loop");
+    expect(grounding.groundPromptWithProfessionCorpus).not.toHaveBeenCalled();
+    expect(agentic.runAgenticLoop).toHaveBeenCalledWith(
+      expect.objectContaining({ systemPrompt: "BASE" }),
+    );
+  });
+});

--- a/apps/web/lib/tak/autonomous-work-run.ts
+++ b/apps/web/lib/tak/autonomous-work-run.ts
@@ -265,6 +265,31 @@ export async function executeAutonomousAgenticLoop(input: {
   // considers PlatformIssueReport rows this run produced.
   const startedAt = new Date();
 
+  // BI-744D583B (EP-COMPETENCE-FLYWHEEL): ground the AUTONOMOUS path in
+  // profession (WSID) corpus. The interactive chat path injects the corpus into
+  // its own prompt assembly upstream and passes interactionMode "chat"; every
+  // autonomous caller (dispatcher child threads, scheduled self-tasks, remote
+  // MCP task submission) reaches this single seam with a pre-assembled prompt
+  // that never carried the corpus — so a build-lane coworker worked without its
+  // craft knowledge. Gate on !== "chat" so chat is never double-injected. Total
+  // + fail-open: on any error the original prompt is used unchanged.
+  let systemPrompt = input.systemPrompt;
+  if (input.interactionMode !== "chat") {
+    const { groundPromptWithProfessionCorpus, defaultProfessionGroundingDeps } = await import(
+      "@/lib/tak/profession-grounding"
+    );
+    const grounding = await groundPromptWithProfessionCorpus(
+      {
+        systemPrompt,
+        agentId: input.agentId,
+        query: lastUserRequest(input.chatHistory),
+        routeContext: input.routeContext,
+      },
+      defaultProfessionGroundingDeps,
+    ).catch(() => ({ systemPrompt, grounded: false }));
+    systemPrompt = grounding.systemPrompt;
+  }
+
   // This is the single seam both interactive chat (interactionMode "chat") and
   // autonomous work (scheduled self-tasks, build phases, system tasks) flow
   // through. Tag the inference origin here so the admission gate in callProvider
@@ -274,7 +299,7 @@ export async function executeAutonomousAgenticLoop(input: {
 
   const result = await withInferenceOrigin(inferenceOrigin, () =>
     runAgenticLoop({
-      systemPrompt: input.systemPrompt,
+      systemPrompt,
       chatHistory: input.chatHistory,
       sensitivity: input.sensitivity,
       tools: input.tools,

--- a/apps/web/lib/tak/profession-grounding.test.ts
+++ b/apps/web/lib/tak/profession-grounding.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  groundPromptWithProfessionCorpus,
+  type ProfessionGroundingDeps,
+} from "./profession-grounding";
+import type { ProfessionCorpusContext } from "@/lib/decision-perspective/profession-corpus";
+
+const INJECTED: ProfessionCorpusContext = {
+  status: "injected",
+  professionKey: "operations",
+  familyLabel: "Operations",
+  profileId: "wsid-operations",
+  pages: [{ slug: "professions/operations/wiki/x", title: "X", abstract: "a", excerpt: "e", score: 3 }],
+  promptBlock: "## Profession corpus — Operations\n- X: e",
+  compactBlock: "Operations: X",
+  tokenCount: 12,
+  compactTokenCount: 4,
+  lowRelevance: false,
+  missingTopic: "warehouse receiving",
+  suggestedSource: null,
+};
+
+const MISS: ProfessionCorpusContext = {
+  status: "missed-empty-corpus",
+  professionKey: "operations",
+  familyLabel: "Operations",
+  profileId: "wsid-operations",
+  pages: [],
+  promptBlock: "",
+  compactBlock: "",
+  tokenCount: 0,
+  compactTokenCount: 0,
+  lowRelevance: false,
+  missingTopic: "warehouse receiving",
+  suggestedSource: "gs1/logistics",
+};
+
+function deps(over: Partial<ProfessionGroundingDeps> = {}): ProfessionGroundingDeps {
+  return {
+    loadIdentity: vi.fn(async (agentId) => ({ agentId, slugId: "ops", name: "Ops" })),
+    resolveInstallContext: vi.fn(async () => ({})),
+    resolveCorpus: vi.fn(async () => INJECTED),
+    recordEvidence: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+describe("groundPromptWithProfessionCorpus", () => {
+  it("appends the corpus promptBlock to the system prompt on a hit", async () => {
+    const d = deps();
+    const r = await groundPromptWithProfessionCorpus(
+      { systemPrompt: "BASE", agentId: "build-qa-engineer", query: "how do I verify a receipt?", routeContext: "build" },
+      d,
+    );
+    expect(r.grounded).toBe(true);
+    expect(r.systemPrompt).toBe(`BASE\n\n${INJECTED.promptBlock}`);
+  });
+
+  it("records evidence with promptInjected=true on a hit", async () => {
+    const d = deps();
+    await groundPromptWithProfessionCorpus(
+      { systemPrompt: "BASE", agentId: "a", query: "q q", routeContext: "build" },
+      d,
+    );
+    // fire-and-forget — allow the microtask to run
+    await Promise.resolve();
+    expect(d.recordEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "a", promptInjected: true, context: INJECTED }),
+    );
+  });
+
+  it("still records evidence on a MISS (feeds the growth loop) but does not change the prompt", async () => {
+    const d = deps({ resolveCorpus: vi.fn(async () => MISS) });
+    const r = await groundPromptWithProfessionCorpus(
+      { systemPrompt: "BASE", agentId: "a", query: "obscure thing", routeContext: "build" },
+      d,
+    );
+    expect(r.grounded).toBe(false);
+    expect(r.systemPrompt).toBe("BASE");
+    await Promise.resolve();
+    expect(d.recordEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({ promptInjected: false, context: MISS }),
+    );
+  });
+
+  it("is fail-open: a resolver throw returns the original prompt unchanged", async () => {
+    const d = deps({
+      resolveCorpus: vi.fn(async () => {
+        throw new Error("db down");
+      }),
+    });
+    const r = await groundPromptWithProfessionCorpus(
+      { systemPrompt: "BASE", agentId: "a", query: "q q", routeContext: "build" },
+      d,
+    );
+    expect(r.grounded).toBe(false);
+    expect(r.systemPrompt).toBe("BASE");
+  });
+
+  it("no-ops on an empty query without calling the resolver", async () => {
+    const d = deps();
+    const r = await groundPromptWithProfessionCorpus(
+      { systemPrompt: "BASE", agentId: "a", query: "   ", routeContext: "build" },
+      d,
+    );
+    expect(r.grounded).toBe(false);
+    expect(r.systemPrompt).toBe("BASE");
+    expect(d.resolveCorpus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/tak/profession-grounding.ts
+++ b/apps/web/lib/tak/profession-grounding.ts
@@ -1,0 +1,159 @@
+import "server-only";
+
+import type { ProfessionCorpusContext } from "@/lib/decision-perspective/profession-corpus";
+
+// BI-744D583B (EP-COMPETENCE-FLYWHEEL, knowledge pillar). Ground the AUTONOMOUS
+// coworker execution path in profession (WSID) corpus.
+//
+// The interactive chat path (agent-coworker.ts) already resolves the corpus and
+// injects it into its own prompt assembly. Every autonomous caller — spawned
+// child threads (agent-thread-dispatcher-runtime), scheduled self-tasks
+// (agent-task-scheduler), remote MCP task submission — flows through
+// executeAutonomousAgenticLoop with a PRE-ASSEMBLED systemPrompt that never
+// carried the corpus. So a build-lane coworker was bound to a profession family
+// but did its actual work WITHOUT its craft knowledge, exactly when it matters
+// most. This closes the read edge on that path.
+//
+// Mirrors the chat path (agent-coworker.ts:673-681, 1130-1131, 1187-1201):
+//   • resolve family-scoped, install-variant-filtered corpus, fail-open;
+//   • append the full promptBlock to the system prompt (the legacy-branch shape);
+//   • fire the SAME ProfessionCorpusGap / ProfessionCorpusUsageStat evidence so
+//     autonomous misses also feed the growth loop.
+//
+// The caller gates on interactionMode !== "chat" so chat is never double-injected.
+
+/** Minimal identity the corpus resolver needs to map a coworker to a family. */
+export interface ProfessionGroundingIdentity {
+  agentId: string;
+  slugId?: string | null;
+  name?: string | null;
+}
+
+/**
+ * Injectable dependency surface so the grounding logic is unit-testable without
+ * a live DB. `defaultProfessionGroundingDeps` wires the real implementations via
+ * dynamic import (avoiding a load-time cycle through the corpus + prisma stack).
+ */
+export interface ProfessionGroundingDeps {
+  loadIdentity: (agentId: string) => Promise<ProfessionGroundingIdentity | null>;
+  resolveInstallContext: () => Promise<Record<string, unknown>>;
+  resolveCorpus: (input: {
+    identity: ProfessionGroundingIdentity;
+    query: string;
+    installContext: Record<string, unknown>;
+  }) => Promise<ProfessionCorpusContext | null>;
+  recordEvidence: (input: {
+    context: ProfessionCorpusContext;
+    query: string;
+    agentId: string;
+    routeContext: string;
+    promptInjected: boolean;
+  }) => Promise<void>;
+}
+
+export interface ProfessionGroundingResult {
+  /** The system prompt with the corpus block appended when one was injected. */
+  systemPrompt: string;
+  /** True when a corpus promptBlock was actually appended. */
+  grounded: boolean;
+}
+
+/**
+ * Resolve the coworker's profession corpus for the current query and append it
+ * to the system prompt. Total and fail-open: any error returns the original
+ * prompt unchanged (professional grounding must never break the run). Records
+ * corpus evidence for BOTH hits and misses so the growth loop sees autonomous
+ * demand — matching the chat path's `if (professionCorpus)` guard.
+ */
+export async function groundPromptWithProfessionCorpus(
+  input: {
+    systemPrompt: string;
+    agentId: string;
+    query: string;
+    routeContext: string;
+  },
+  deps: ProfessionGroundingDeps,
+): Promise<ProfessionGroundingResult> {
+  const query = input.query?.trim() ?? "";
+  if (!query || !input.agentId) {
+    return { systemPrompt: input.systemPrompt, grounded: false };
+  }
+
+  try {
+    const identity =
+      (await deps.loadIdentity(input.agentId).catch(() => null)) ?? { agentId: input.agentId };
+    const installContext = await deps.resolveInstallContext().catch(() => ({}));
+
+    const context = await deps
+      .resolveCorpus({ identity, query, installContext })
+      .catch(() => null);
+    if (!context) return { systemPrompt: input.systemPrompt, grounded: false };
+
+    const grounded = Boolean(context.promptBlock);
+    const systemPrompt = grounded
+      ? `${input.systemPrompt}\n\n${context.promptBlock}`
+      : input.systemPrompt;
+
+    // Evidence for hits AND misses (the growth-loop signal). Fire-and-forget.
+    void deps
+      .recordEvidence({
+        context,
+        query,
+        agentId: input.agentId,
+        routeContext: input.routeContext,
+        promptInjected: grounded,
+      })
+      .catch((e) =>
+        console.warn("[profession-corpus] autonomous evidence record failed (fail-open):", e),
+      );
+
+    return { systemPrompt, grounded };
+  } catch (e) {
+    console.warn("[profession-corpus] autonomous grounding failed (fail-open):", e);
+    return { systemPrompt: input.systemPrompt, grounded: false };
+  }
+}
+
+/** Real dependency wiring (dynamic imports keep this off the module load path). */
+export const defaultProfessionGroundingDeps: ProfessionGroundingDeps = {
+  loadIdentity: async (agentId) => {
+    const { prisma } = await import("@dpf/db");
+    // Promise.resolve().then so a synchronous throw (partial prisma mock) becomes
+    // a rejection the caller's .catch absorbs — identity lookup never breaks a run.
+    return Promise.resolve()
+      .then(() =>
+        prisma.agent.findFirst({
+          where: { agentId },
+          select: { agentId: true, slugId: true, name: true },
+        }),
+      )
+      .catch(() => null);
+  },
+  resolveInstallContext: async () => {
+    const { prisma } = await import("@dpf/db");
+    const { resolveInstallVariantContext } = await import(
+      "@/lib/decision-perspective/install-variant-context"
+    );
+    return Promise.resolve()
+      .then(() => resolveInstallVariantContext(prisma) as Promise<Record<string, unknown>>)
+      .catch(() => ({}));
+  },
+  resolveCorpus: async ({ identity, query, installContext }) => {
+    const { prisma } = await import("@dpf/db");
+    const { resolveProfessionCorpusContext } = await import(
+      "@/lib/decision-perspective/profession-corpus"
+    );
+    return resolveProfessionCorpusContext({
+      db: prisma,
+      identity,
+      query,
+      installContext,
+    });
+  },
+  recordEvidence: async (args) => {
+    const { recordProfessionCorpusEvidence } = await import(
+      "@/lib/decision-perspective/profession-corpus-evidence"
+    );
+    await recordProfessionCorpusEvidence(args);
+  },
+};

--- a/docs/superpowers/specs/2026-07-21-coworker-competence-flywheel-design.md
+++ b/docs/superpowers/specs/2026-07-21-coworker-competence-flywheel-design.md
@@ -296,7 +296,7 @@ exercised.
 
 | BI | Pillar | Edge |
 |---|---|---|
-| BI-744D583B | Knowledge | ground the autonomous executor in profession corpus |
+| BI-744D583B | Knowledge | ground the autonomous executor in profession corpus — **shipped 2026-07-21** (`groundPromptWithProfessionCorpus` at the `executeAutonomousAgenticLoop` seam, gated `interactionMode !== "chat"`) |
 | BI-BE9C95D9 | Knowledge | close the gap→page growth edge + corpus freshness lifecycle |
 | BI-4B0A1C1F | Memory | adopt memory-trust P1–P6 + the experience→note acquisition edge |
 | BI-A834EE61 | Judgment | outcome-correctness signal + close the WWMD/WSID feedback loop |


### PR DESCRIPTION
## What

First build under **EP-COMPETENCE-FLYWHEEL** (knowledge pillar) — implements BI-744D583B from [`2026-07-21-coworker-competence-flywheel-design.md`](docs/superpowers/specs/2026-07-21-coworker-competence-flywheel-design.md) §4.1.

The interactive chat path already resolves a coworker's WSID profession corpus and injects it into its prompt. Every **autonomous** caller — spawned child threads, scheduled self-tasks, remote MCP task submission — reaches the shared `executeAutonomousAgenticLoop` seam with a pre-assembled prompt that never carried the corpus. So a build-lane coworker (`build-software-engineer`, `build-qa-engineer`, …) was *bound* to a profession family but did its actual build work **without its craft knowledge** — corpus-blind exactly when it matters most. This is the single highest-value, lowest-risk knowledge-pillar fix, and it pays off on the very next build (not just over accumulated exercise).

## How

A small, fail-open grounding helper (`apps/web/lib/tak/profession-grounding.ts`) resolves the family-scoped, install-variant-filtered corpus for the turn's query, appends the `promptBlock`, and fires the **same** `ProfessionCorpusGap` / `ProfessionCorpusUsageStat` evidence so autonomous misses also feed the growth loop. Wired at the **single** `executeAutonomousAgenticLoop` seam, gated `interactionMode !== "chat"` so the chat path (which injects upstream) is never double-injected. One seam covers all autonomous callers.

**Total + fail-open by construction:** no query, no agentId, or any resolver/DB error returns the original prompt unchanged — grounding never breaks a run.

## Tests (13 new, all green)

- `profession-grounding.test.ts` (5) — appends on a hit; records evidence on hit **and** miss (growth loop); fail-open on a resolver throw; no-op on empty query.
- `autonomous-grounding-seam.test.ts` (2) — the gate: autonomous grounds and forwards the grounded prompt to the loop; **chat does NOT ground** (no double-injection).
- Existing `autonomous-work-run.test.ts` (12) still green — proves the seam runs and fail-opens in an integration path. `profession-corpus` + `coworker-record` suites (69) green. module-size, route-error, doc-links pass.

**Honest gap:** `apps/web` tsc isn't runnable in this worktree (`next` absent — known harness limitation); CI Typecheck + Production Build gate it. The one external contract (`recordProfessionCorpusEvidence` signature) was verified by hand. The pre-commit typecheck hook was overridden for the missing-binary reason, not for type errors.

## Scope

Runtime read-path enhancement on the coworker execution seam. No schema change, no new contract beyond the spec, no chat-path behavior change.

Seed-Fit-Decision: global-default
Design-Grounding-Decision: implements BI-744D583B from docs/superpowers/specs/2026-07-21-coworker-competence-flywheel-design.md (§4.1); touches apps/web/lib/tak (new profession-grounding module + the executeAutonomousAgenticLoop seam) and apps/web/lib/actions (chat path unchanged, verified not double-injected).
Docs-Impact-Decision: marks BI-744D583B shipped in the flywheel spec; regenerates apps/web/lib/docs/doc-index.generated.json. No user-guide route affected.
Process-Spine-Decision: runtime read-path enhancement; no CI/gate/promotion-spine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Local-CI-Override: the shared local-integration-ci sandbox reports `sandbox_drift` (its node_modules has vitest 4.1.9 vs the locked 4.1.10, incomplete install) — a sandbox-infrastructure defect the gate itself labels "NOT product build evidence", unrelated to this PR's diff. The risk this gate covers (a build/runtime break unit tests miss) is directly covered on this PR: CI Production Build (6m18s) and Typecheck (3m23s) passed, alongside all four web unit-test shards and Unit Tests (packages). No lease left dangling.
