### PR TITLE
docs: govern no-shell organization joining

### DIFF
--- a/docs/superpowers/plans/2026-07-19-federated-demand-network.md
+++ b/docs/superpowers/plans/2026-07-19-federated-demand-network.md
@@ -26,6 +26,16 @@
 - Founder Hub shared portfolio -> `BI-D25A0C31`
 - Future routed federation reach -> `BI-D43D3D76`
 
+Task 2's remaining no-shell and installed two-host closure was decomposed after
+the organization PKI and installer slices merged:
+
+- Machine-bound signed Edge action channel -> `BI-F12A8D0D`
+- Governed organization join issue/import host actions -> `BI-A8399604`
+- Connections no-shell workflow -> `BI-87B0DBD7`
+- Physical Founder Hub Mac/Windows acceptance -> `BI-05EB708F`
+- Coverage receipt -> `cmrvft9zf0mj301qkdb9e44w2`
+- Detailed plan -> `docs/superpowers/plans/2026-07-21-federation-no-shell-organization-join.md`
+
 ---
 
 ## Task 1: Establish protocol, relationship, projection, and Hive-boundary contracts

--- a/docs/superpowers/plans/2026-07-21-federation-no-shell-organization-join.md
+++ b/docs/superpowers/plans/2026-07-21-federation-no-shell-organization-join.md
@@ -1,0 +1,210 @@
+# Federation no-shell organization join implementation plan
+
+> **For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+**Umbrella backlog item:** `BI-52D34506`
+
+**Parent outcome:** `BI-E3A084ED`
+
+**Design authorities:**
+
+- `docs/superpowers/specs/2026-07-19-federated-demand-network-design.md`
+- `docs/superpowers/specs/2026-06-26-remote-action-edge-auth-and-dispatch-design.md`
+- `docs/superpowers/specs/2026-06-25-remote-action-edge-dispatch-threat-model.md`
+
+## Outcome
+
+A non-technical operator can use Connections to create an expiring organization
+join file on the Founder Hub authority installation and import it on the second
+Mac or Windows installation. No terminal commands, installer arguments,
+certificate copying, CA passwords, or hand-edited environment files are part
+of the normal workflow. Privileged host work runs only through the
+machine-bound, signed, allow-listed native Edge action channel.
+
+This closes the trust prerequisite for certificate-valid nearby pairing and
+automatic reconciliation of policy-eligible same-organization demand. It does
+not weaken local backlog authority or make discovery itself trusted.
+
+## Backlog coverage
+
+- Decision: decomposed
+- Umbrella: `BI-52D34506`
+- Receipt: `cmrvft9zf0mj301qkdb9e44w2`
+- `p2a-machine-dispatch` -> `BI-F12A8D0D`; dependencies: none
+- `p2b-organization-join-actions` -> `BI-A8399604`; depends on `p2a-machine-dispatch`
+- `connections-no-shell-ux` -> `BI-87B0DBD7`; depends on `p2b-organization-join-actions`
+- `physical-two-host-acceptance` -> `BI-05EB708F`; depends on `connections-no-shell-ux`
+
+The four deliverables are independently shippable: the read-only channel is a
+general security foundation; the two host actions are independently testable
+without UI; the Connections workflow is a user capability; installed-host
+acceptance is governed release evidence rather than source implementation.
+
+## Architecture decisions
+
+- `DI-F822CC2C9F40` — high-confidence selection of an organization-rooted,
+  dedicated Edge client-auth intermediate/profile. One organization trust
+  anchor, separate issuer key and EKU policy.
+- `DI-4D4877ED738F` — high-confidence selection of a dedicated Caddy mTLS
+  listener with application-level certificate lifecycle and scope checks on
+  every action request.
+- The native Go Edge Node remains outbound-only and polls. No privileged
+  localhost broker, inbound Edge port, Docker socket in the portal, or generic
+  `script.run` action is introduced.
+- `RemoteAction`, `ChangeRequest`, `EdgeNode`, `EdgeNodeCapability`,
+  `EdgeNode.scopePolicy`, credential encryption, Step CA, and the existing
+  cross-platform bootstrap scripts remain the canonical owners.
+
+## Deliverable 1 — BI-F12A8D0D: machine-bound read-only dispatch
+
+**Independently shippable:** yes. No host mutation.
+
+### Source changes
+
+1. Add a fleet-safe `EdgeNodeCertificate` side table and relations on
+   `EdgeNode`; persist only CSR/certificate metadata, never a device private
+   key. Add active fingerprint, node, status, and expiry indexes.
+2. Extend Step CA bootstrap with a dedicated Edge client-auth
+   intermediate/profile and CSR signing contract. Generate the device key in
+   the native Edge OS keystore and enroll/renew from the host.
+3. Generate a second Caddy site/listener for Edge actions (default `:8443`)
+   using `client_auth require_and_verify`. Route only
+   `/api/v1/edge/actions/*`, strip all incoming certificate-identity headers,
+   and inject Caddy-derived fingerprint, serial, and subject values.
+4. Add a transport-auth resolver that requires both the verified certificate
+   metadata and the existing split bearer scope. Re-check active certificate,
+   node trust, tenant/site scope, capability mode, and
+   `scopePolicy.allowedActionTypes` on every request.
+5. Sign a canonical dispatch envelope over action key/type, parameters digest,
+   node ID, nonce, creation, and expiry. Persist consumption before execution.
+6. Extend `services/edge-node-go` with an mTLS client, poll loop, authority
+   signature verification, replay journal, and only an `inventory.collect`
+   handler. Report fixed-schema evidence and support certificate renewal.
+
+### TDD and verification
+
+- Red tests first for bearer-only rejection, spoofed header stripping,
+  unknown/revoked/expired/wrong-node certificate rejection, scope/allow-list
+  enforcement, signature tamper/expiry/replay rejection, and claim races.
+- Migration deploys against populated fixtures and a clean database.
+- Caddy configuration adapts successfully and a TLS harness proves no-cert,
+  wrong-cert, revoked-cert, and valid-cert behavior.
+- Go tests exercise the poller and replay journal on darwin/windows/linux
+  builds; an installed read-only pilot executes `inventory.collect` once.
+- Full DB/web tests, typechecks, production build, security scan, and governed
+  exact-SHA merged-code gate pass.
+
+### Risk and rollback
+
+- Default-off feature flag and disabled `action.execute` capability prevent
+  activation during rollout.
+- Removing the mTLS overlay and disabling the capability returns to the current
+  read-up-channel behavior; additive certificate rows remain as audit metadata.
+- Certificate revocation plus node quarantine stops the channel immediately.
+
+## Deliverable 2 — BI-A8399604: organization join host actions
+
+**Independently shippable:** yes. Exposes governed API/action behavior without
+the operator-facing file workflow.
+
+### Source changes
+
+1. Add a closed RemoteAction type/parameter registry. Enable exactly
+   `organization.join.issue` and `organization.join.import` after P2a proof;
+   reject unknown fields and never interpolate a shell command.
+2. Add action creation services that require the correct host role, explicit
+   per-node allow-list, current local approval, and an approved `ChangeRequest`
+   carrying impact, recovery, and post-change verification requirements.
+3. Reuse the credential-encryption boundary for package material in
+   `RemoteAction.parameters/result`. Decrypt only at dispatch/download, redact
+   all evidence, and clear on first download, terminal import, failure cleanup,
+   cancellation, or expiry.
+4. Implement native Go parameterized handlers that invoke the existing Bash or
+   PowerShell bootstrap owner through argument arrays, fixed executable paths,
+   bounded temporary files, permissions checks, timeouts, and captured exit
+   codes. No arbitrary executable/path/value is accepted.
+5. After import, restart the persisted member overlays and record host-local
+   evidence. Independently verify portal health, certificate trust, overlay
+   persistence, and Edge heartbeat before terminal success.
+
+### TDD and verification
+
+- Red tests cover wrong role, missing approval/ChangeRequest, missing allowlist,
+  schema/path/metacharacter abuse, expiry/replay, secret redaction/clearing,
+  partial failure, rollback, and independent-health disagreement.
+- Execute real issue/import against disposable authority/member directories on
+  macOS and a Windows PowerShell contract harness.
+- Run full package/web/Go tests, typechecks, production build, migration if
+  required, security scan, and exact-SHA merged-code gate.
+
+### Risk and rollback
+
+- The actions remain disabled until explicitly allow-listed on a named node.
+- Import snapshots the prior overlay/install state and restores it if the new
+  trust path fails health verification.
+- Package expiry and first-use clearing bound credential exposure.
+
+## Deliverable 3 — BI-87B0DBD7: Connections no-shell workflow
+
+**Independently shippable:** yes, after the host actions exist.
+
+### Source changes
+
+1. Add contextual **Create join file** and **Join an organization** actions to
+   the existing Connections page. Do not add a global route or technical admin
+   form.
+2. Authority flow: intended installation, short expiry, plain-language scope
+   preview, confirmation, truthful action progress, one-time download.
+3. Member flow: file picker/drag-and-drop, local schema/fingerprint/peer/expiry
+   preview, confirmation, upload, truthful import/restart/health progress.
+4. Persist action identity so page refresh resumes status. Explain expired,
+   wrong-peer, consumed, signature, permission, and health failures with one
+   recommended recovery action.
+5. Keep certificates, tokens, package content, CA passwords, and private keys
+   out of HTML, logs, analytics, and error copy.
+
+### UX verification
+
+- Use existing report-kit primitives and platform theme tokens.
+- Verify keyboard and screen-reader operation, error focus, desktop/narrow
+  widths, light/dark themes, progress refresh, and empty/disabled states.
+- A non-technical walkthrough must complete without terminal or installer
+  instructions.
+
+### Risk and rollback
+
+- Hide/disable the controls when the secure action capability is absent; the
+  already shipped installer argument remains a recovery path for one release.
+- UI cancellation cancels only a not-yet-dispatched action; it never claims a
+  running host mutation was undone.
+
+## Deliverable 4 — BI-05EB708F: physical Founder Hub acceptance
+
+**Independently shippable:** yes. Evidence-only closure after merged code is
+deployed through the governed install/update path.
+
+1. Advance both Founder Hub development/test installations to the merged release.
+2. Use only Connections to issue/import organization trust.
+3. Verify certificate-valid HTTPS from Mac to Windows and Windows to Mac.
+4. Verify discovery add/expiry, automatic invitation exchange, matching code,
+   dual approval, and service restart persistence.
+5. Approve one minimized same-organization projection. Verify selected demand
+   reconciles automatically, unselected/excluded fields do not egress, local
+   authority is preserved, offline reconnect deduplicates, and revocation stops
+   exchange.
+6. Capture V-01/V-03 evidence without secrets and attach it to `BI-52D34506`.
+
+## Completion gate
+
+The no-shell outcome is complete only when all four mapped BIs are done, their
+PRs/verification evidence are attached, both real installed hosts pass V-01 and
+V-03, and a final parent audit proves:
+
+- no normal setup step requires a shell or installer argument;
+- discovery never creates trust;
+- the action channel rejects bearer-only, spoofed, expired, replayed, and
+  unauthorized requests;
+- only the two founder-approved organization-join mutation types are enabled;
+- certificate-valid pairing and approved automatic demand reconciliation work
+  across the actual Founder Hub Mac/Windows topology;
+- local backlog state remains sovereign and unselected data never egresses.

--- a/docs/superpowers/specs/2026-06-26-remote-action-edge-auth-and-dispatch-design.md
+++ b/docs/superpowers/specs/2026-06-26-remote-action-edge-auth-and-dispatch-design.md
@@ -1,7 +1,7 @@
 # RemoteAction Edge dispatch — authentication & channel design (EP-REMOTE-ACTION P2)
 
 - **Date:** 2026-06-26
-- **Status:** Design for review — resolves the auth-mechanism decision left open by the convergent design (§10-Q1) and the threat model (R1).
+- **Status:** Accepted architecture; P2a/P2b implementation increments are governed by `BI-F12A8D0D` and `BI-A8399604`.
 - **Extends (does NOT fork):** `docs/superpowers/specs/2026-06-25-convergent-remote-action-execution-design.md` §7 + `docs/superpowers/specs/2026-06-25-remote-action-edge-dispatch-threat-model.md` (R1–R11).
 - **Epic:** `EP-REMOTE-ACTION` · founder-directed ("follow the commercial pattern" for authn/authz).
 
@@ -14,7 +14,7 @@ This is the commercial-RMM standard, and what the founder asked us to match:
 - Tanium, ManageEngine, and Microsoft Intune (via SCEP) authenticate the host agent with a **client certificate**; the agent generates a keypair at install, submits a CSR, and the platform CA signs it. ([Tanium clientAuth EKU](https://www.stigviewer.com/stig/tanium_7.x_application_on_tanos/2022-10-31/finding/V-254914), [ManageEngine client-cert auth](https://www.manageengine.com/products/desktop-central/client-certificate-authentication.html), [SCEP auto-enrollment](https://www.appviewx.com/blogs/what-are-certificate-auto-enrollment-protocols-and-why-are-they-important/))
 - **Why mTLS over a bearer token:** mTLS binds identity to a private key that **never leaves the device** — there is no credential to steal or replay ([mTLS for agent auth](https://securew2.com/blog/mutual-tls-mtls-authentication)). That *is* threat-model **R1** ("machine-bound Edge trust… bearer-only nodes may collect but never mutate") and closes **T3** (token theft) and **T11** (spoofed dispatch — the channel is mutually authenticated).
 
-**Decision:** the Edge dispatch channel uses **mutual TLS**; the Edge Node holds a per-device client certificate issued by a platform **Edge-CA**. DPoP and TPM/Secure-Enclave **attestation** are noted as future hardening *layered on the same cert* (attested key → non-exportable proof), not a different mechanism.
+**Decision:** the Edge dispatch channel uses **mutual TLS**; the Edge Node holds a per-device client certificate issued by a dedicated **Edge client-auth intermediate/profile rooted in the installation's existing organization Step CA**. The Edge issuer has its own restricted signing key and client-auth EKU policy; it does not reuse the portal server issuer key and does not introduce a second organization root. Governed consultation `DI-F822CC2C9F40` selected this shape with high confidence (composite 7.453, margin 2.844, no commandment conflict). DPoP and TPM/Secure-Enclave attestation remain future hardening layered on the same device key.
 
 ## 2. Channel shape: agent-dials-out, long-poll
 
@@ -26,25 +26,36 @@ The Edge is **outbound/pull-only** today (no inbound port; enroll/heartbeat/disc
 
 Today: bootstrap token → `POST /api/v1/edge/enroll` → bearer node token (`dpfedge_`). Add a certificate leg:
 
-1. After the node is `trustState=trusted`, it **generates a keypair** (private key stored in the OS keystore / secure element, non-exportable where supported) and submits a **CSR** (`subject CN = nodeId`).
-2. The platform **Edge-CA signs** the CSR → a per-device client cert (validity ≤ 90d).
+1. After the node is `trustState=trusted`, it **generates a keypair** (private key stored in the OS keystore / secure element, non-exportable where supported) and submits a **CSR** (`subject CN = nodeId`). The private key never crosses the host boundary.
+2. The organization Step CA's restricted Edge client-auth intermediate/profile signs the CSR and returns a per-device client certificate (validity ≤ 90d, `clientAuth` EKU only).
 3. New model **`EdgeNodeCertificate`**: `edgeNodeId`, `serial @unique`, `fingerprintSha256 @unique`, `subjectCn`, `notBefore`, `notAfter`, `status` (active|revoked|expired), `issuedAt`, `revokedAt?`, `csrPem`/`certPem`. (Cert metadata is a side table on `EdgeNode`, not a new identity — `EdgeNode` is already a `PrincipalAlias`, AGENTS.md §11.)
-4. **Edge-CA**: a platform CA keypair (self-managed intermediate, kept as a managed secret; reuse the `packages/integration-shared/credential-crypto.ts` storage pattern). Signing is server-side only.
+4. The Edge intermediate key remains in Step CA custody. The portal receives neither the organization root/intermediate private key nor the CA password. The portal stores certificate lifecycle metadata and invokes the already isolated CA contract; it does not become a CA implementation.
 
 **The bearer token is retained for the read-only up-channel** (heartbeat/discovery/collect). The **mTLS client cert is *required* for the action dispatch channel** — a bearer-only node can never reach `…/actions/*` (R1, R3).
 
+### 3.1 TLS termination boundary
+
+The canonical deployment already assigns HTTPS termination to the Caddy sidecar. Client authentication is a TLS-handshake policy, not an HTTP-path policy, so Edge actions use a **dedicated mTLS site/listener** rather than making the normal browser portal require a client certificate.
+
+- Caddy listens on the normal browser HTTPS endpoint without client authentication and on a separate Edge-action endpoint (default `:8443`) with `client_auth` mode `require_and_verify` and the organization Edge trust bundle.
+- The action listener serves only `/api/v1/edge/actions/*`; all other paths return 404.
+- Before proxying, Caddy removes every caller-provided `X-DPF-Edge-Cert-*` header and injects the verified fingerprint, serial, and subject from Caddy TLS placeholders.
+- The application treats the injected values as transport evidence, not final authorization: every request still resolves an active `EdgeNodeCertificate`, confirms node trust and scope, and checks `action.execute` plus the per-node action-type allow-list.
+
+Governed consultation `DI-4D4877ED738F` selected this boundary with high confidence (composite 7.235, margin 2.390, no commandment conflict). This follows Caddy's documented `client_auth` `require_and_verify` trust-pool contract and its TLS client-certificate placeholders.
+
 ## 4. Dispatch protocol (read-only pilot)
 
-- **`GET /api/v1/edge/actions/pending`** — authenticated by the **client cert** (mTLS), scope **`action:dispatch`**. Returns `RemoteAction`s where: status=`queued` ∧ the action's `customerAccountId`/`customerSiteId` **matches the node's enrolled scope** (R5) ∧ `actionType` is in the node's **capability allow-list** (R3). In the pilot, only `inventory.collect` / `diagnostics.collect` are allow-listed (read-only; R-pilot).
-- Each returned dispatch is **signed by the platform authority** over `{actionKey, nonce, expiresAt}` (R4 anti-replay, R11 anti-spoof — the agent verifies the platform signature; the server records consumed `actionKey`s).
-- The agent executes the read-only action and **`POST /api/v1/edge/actions/{actionKey}/result`** — scope **`action:report`**, **idempotent on `actionKey`**, result + evidence per a fixed schema (R7).
+- **`POST /api/v1/edge/actions/claim`** — authenticated by both the enrolled client certificate and the existing short-lived/rotatable Edge credential carrying `edge:actions:claim`. It returns `RemoteAction`s where status=`queued`, approval is valid, customer/site scope matches the enrolled node, and `actionType` is in `EdgeNode.scopePolicy.allowedActionTypes`. The pilot permits only `inventory.collect`.
+- Each returned dispatch is **signed by the platform authority** over a canonical envelope containing `{actionKey, actionType, parametersDigest, nodeId, nonce, createdAt, expiresAt}`. Signing only the action key/expiry is insufficient because an intermediary could otherwise substitute parameters. The Edge verifies the signature, node binding, digest, expiry, and nonce before execution and persists the consumed action/nonce before side effects.
+- The agent executes the read-only action and **`POST /api/v1/edge/actions/result`** with `edge:actions:report`, idempotent on `actionKey`, result, and evidence under a fixed schema (R7).
 - The server validates cert-valid-and-not-revoked ∧ scope-match ∧ signature ∧ idempotency, then transitions `status` (`dispatched`→`running`→`succeeded|failed|timed-out`).
 - **Independent corroboration (R7):** a node's self-reported success is cross-checked against the next discovery sweep (a node claiming a result whose inventory disagrees is flagged).
 
 ## 5. Scopes & capability (R2, R3)
 
-- Add **`action:dispatch`** + **`action:report`** to the closed Edge token-scope vocabulary (`edge-node-types.ts`).
-- **`capability.action.execute`** on `EdgeNodeCapability`, mode `disabled` by default, with a per-`actionType` **allow-list**. The pilot enables only the read-only types.
+- Retain the existing `edge:actions:claim` + `edge:actions:report` bearer scopes as a second factor; they never authorize an action request without mTLS.
+- **`action.execute`** on `EdgeNodeCapability` remains `disabled` by default. `EdgeNode.scopePolicy.allowedActionTypes` is the canonical per-node action allow-list. Capability mode and action-type scope must both allow a claim.
 
 ## 6. Certificate lifecycle (the operational reality)
 
@@ -56,9 +67,9 @@ Today: bootstrap token → `POST /api/v1/edge/enroll` → bearer node token (`dp
 | Requirement | Satisfied by |
 | --- | --- |
 | R1 machine-bound trust | §1 mTLS client cert (non-exportable key) |
-| R2 split scopes | §5 `action:dispatch` / `action:report` |
+| R2 split scopes | §5 `edge:actions:claim` / `edge:actions:report` plus mTLS |
 | R3 per-node allow-list, default-off | §5 `capability.action.execute` + allow-list |
-| R4 signed single-use expiring dispatch | §4 signed `{actionKey,nonce,expiresAt}` + consumed-key tracking |
+| R4 signed single-use expiring dispatch | §4 signed full action/digest/node/nonce/time envelope + consumed-key tracking |
 | R5 scope enforcement | §4 customer/site match at dispatch **and** node |
 | R7 result schema + independent re-collection | §4 result schema + sweep corroboration |
 | R11 spoofed dispatch | §1 mutual auth + §4 platform signature |
@@ -66,15 +77,31 @@ Today: bootstrap token → `POST /api/v1/edge/enroll` → bearer node token (`dp
 
 ## 8. Build slices
 
-- **P2a — machine-bound identity + read-only channel (buildable now; mutates nothing):** Edge-CA + `EdgeNodeCertificate` model + CSR-at-enrollment; `action:dispatch`/`action:report` scopes + `capability.action.execute` (read-only allow-list); the mTLS-authed `GET pending` / `POST result` routes (scope-filtered, signed, idempotent); the `services/edge-node` agent's mTLS client + poll loop running `inventory.collect` only; sweep corroboration. **This is the threat model's recommended read-only pilot.**
-- **P2b — mutating (GATED on P2a proven + founder per-`actionType` sign-off):** enable `patch.apply` / `service.restart` / `reboot` behind the full R6/R8/R9/R10/R12 gates (parameterized handlers, `ChangeRequest`, window/blackout, no-downgrade via `@dpf/db/patch` `compareVersions`, recovery/health/rollback, federation sovereignty egress).
+- **P2a — `BI-F12A8D0D`, machine-bound identity + read-only channel:** organization-rooted Edge intermediate/profile + `EdgeNodeCertificate` metadata; dedicated Caddy mTLS listener; existing split bearer scopes as a second factor; signed/idempotent claim/result; native Go Edge poll loop running `inventory.collect` only; sweep corroboration. **No mutating action is enabled in this slice.**
+- **P2b organization join — `BI-A8399604`:** after P2a is functionally proven, enable only `organization.join.issue` and `organization.join.import`. The founder explicitly authorized these two types for the no-shell Connections outcome. Both require fixed parameter schemas, per-node allow-listing, a locally approved `ChangeRequest`, encrypted/cleared package material, host-role checks, a declared recovery path, and independent post-action TLS/portal/Edge health evidence. This authorization does not extend to another action type.
+- **P2b general remediation:** `patch.apply`, `service.restart`, `reboot`, or any other mutating type remains gated on separate founder sign-off and the full R6/R8/R9/R10/R12 controls. `script.run` is not an acceptable implementation shortcut.
 - **P3 — backends:** native package managers (patch) etc., per `actionType`.
 
-## 9. Substrate to verify before P2a code
-- The **mTLS termination point**: does the portal sit behind a proxy (Caddy/nginx/Traefik in compose) that can verify client certs and pass the subject to the app, or must verification be app-layer? (Drives whether `…/actions/*` reads a verified-client-cert header or does the TLS itself.)
-- CA-key storage: confirm the `credential-crypto` / managed-secret path for the Edge-CA private key.
-- The `services/edge-node` runtime (Go native vs TS container per the 2026-05-16 runtime decision) for the mTLS client + keystore integration.
+## 9. Verified substrate
 
-## 10. Decisions — resolved & remaining
-- **Resolved:** auth mechanism = **mTLS per-device client cert** (commercial standard); channel = agent long-poll; read-only pilot first.
-- **For the founder:** (a) Edge-CA as a self-managed intermediate vs. rooted under an existing internal CA; (b) mTLS termination at the proxy vs. app layer (§9); (c) confirm `inventory.collect`-only for the pilot before any mutating `actionType` is enabled.
+- `docker-compose.tls.yml` and `scripts/issue-authority-tls-cert.sh` establish Caddy as the TLS boundary; the generated configuration must gain the separate mTLS action listener.
+- Organization Step CA bootstrap and custody are already shipped. Edge issuance extends that owner with a restricted intermediate/profile; the portal does not store CA keys.
+- The installed host runtime is the native Go service in `services/edge-node-go`; the older TypeScript collector is not the host-action executor.
+- `RemoteAction`, `EdgeNode`, `EdgeNodeCapability`, `ChangeRequest`, split Edge bearer scopes, claim/result routes, and credential encryption already exist. Extend them rather than create a second queue, identity, approval, or secret store.
+- `EdgeNodeCertificate` metadata is absent and justified as a side table; the private key remains host-local.
+
+## 10. Decisions — resolved
+
+- Auth mechanism: mTLS per-device client certificate, with the existing bearer credential retained only as a second factor.
+- Trust topology: dedicated Edge client-auth intermediate/profile under the organization root (`DI-F822CC2C9F40`).
+- Termination: dedicated Caddy mTLS listener plus application re-authorization (`DI-4D4877ED738F`).
+- Channel: agent-initiated pull; no inbound Edge port.
+- Pilot: `inventory.collect` only.
+- First privileged types: `organization.join.issue` and `organization.join.import`, explicitly founder-authorized for the no-shell organization-join workflow after P2a proof.
+
+## 11. Standards adopted
+
+- [NIST SP 800-207](https://csrc.nist.gov/pubs/sp/800/207/final) and [SP 800-207A](https://csrc.nist.gov/pubs/sp/800/207/a/final): network location is not trust; authorize the device/service identity and policy on each request.
+- [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421): bind signatures to all security-relevant message components and use nonce/creation/expiry fields for replay control.
+- [Caddy `tls` client authentication](https://caddyserver.com/docs/caddyfile/directives/tls) and [TLS placeholders](https://caddyserver.com/docs/caddyfile/concepts): require and verify client certificates at the TLS boundary, then forward only derived certificate identity.
+- [OWASP Transaction Authorization](https://cheatsheetseries.owasp.org/cheatsheets/Transaction_Authorization_Cheat_Sheet.html): operator approval is specific to the exact action and parameters and is enforced server-side.

--- a/docs/superpowers/specs/2026-07-19-federated-demand-network-design.md
+++ b/docs/superpowers/specs/2026-07-19-federated-demand-network-design.md
@@ -200,6 +200,43 @@ For `same-organization`, the default contract offers continuous sync of share-sa
 
 Discovery alone never starts data exchange. This preserves zero-trust behavior while making normal operation effectively hands-off.
 
+### 5.4 No-shell organization trust join
+
+Nearby discovery cannot bootstrap certificate-valid HTTPS by itself. A normal
+operator joins another installation to the organization trust from the existing
+Connections page without copying certificates, editing environment variables,
+supplying installer flags, or opening a shell:
+
+1. On the organization-authority installation, **Create join file** asks for
+   the intended installation identity and a short expiry, shows exactly what
+   the file authorizes, and requires local confirmation.
+2. The portal records an approved `ChangeRequest` and queues the explicit
+   `organization.join.issue` action to the authority host's native Edge Node.
+   The host invokes the existing PKI bootstrap owner and returns one expiring,
+   intended-peer-bound `.dpfjoin` package. It never returns a CA private key or
+   password.
+3. The operator downloads the package once and moves it to the other
+   installation using the organization's normal secure file-transfer practice.
+4. On the joining installation, **Join an organization** uses a file picker.
+   The portal validates and previews issuer, intended peer, fingerprint, and
+   expiry before a second local confirmation. It then queues only
+   `organization.join.import` to that host's native Edge Node.
+5. The host consumes the package through the existing cross-platform bootstrap
+   script, restarts the persisted member TLS overlays, and reports redacted
+   evidence. The portal independently verifies certificate-valid HTTPS,
+   portal health, and Edge heartbeat before showing the join as complete.
+
+These are privileged host actions, not browser or server shell calls. They use
+the convergent `RemoteAction` control plane and are unavailable until the
+machine-bound P2a channel in `BI-F12A8D0D` is proven. Each action additionally
+requires an active per-device certificate, the node's explicit action-type
+allow-list, a parameter-specific local approval, single-use signed dispatch,
+and rollback/recovery declaration. `script.run` is never enabled. Detailed
+authority is in
+`docs/superpowers/specs/2026-06-26-remote-action-edge-auth-and-dispatch-design.md`;
+delivery is decomposed by
+`docs/superpowers/plans/2026-07-21-federation-no-shell-organization-join.md`.
+
 ## 6. Demand exchange contract
 
 DPF exchanges a versioned **Demand Envelope**, not a `BacklogItem` serialization.


### PR DESCRIPTION
## Summary
- Resolve the remaining machine-trust decisions for no-shell organization joining: organization-rooted Edge client certificates and a dedicated Caddy mTLS action boundary.
- Decompose BI-52D34506 into four governed deliverables: BI-F12A8D0D, BI-A8399604, BI-87B0DBD7, and BI-05EB708F.
- Define the Connections issue/download/import workflow and the physical Founder Hub Mac/Windows completion gate without introducing a generic shell action, parallel CA root, or duplicate artifact store.

## Architecture review
- Advisory result: aligned with concerns; the spec edits address trust custody, replay protection, per-node authorization, action-specific approval, rollback, and deployment-boundary ownership.
- Kernel decisions: DI-F822CC2C9F40 and DI-4D4877ED738F, both high confidence with no commandment conflict.
- Plan coverage: cmrvft9zf0mj301qkdb9e44w2, revalidated live.

## Test plan
- [x] `node scripts/check-plan-backlog-coverage.mjs`: 2 changed plans valid
- [x] `node scripts/gen-doc-index.mjs --check`: index fresh
- [x] `node scripts/check-doc-links.mjs`: no error-level findings
- [x] `git diff --check`: clean
- [x] staged Gitleaks scan: no leaks
- [x] DCO sign-off: present
- [x] Production build / UX / migration: not applicable to this documentation-only architecture and plan concern

Local-CI-Override: Documentation-only architecture and governed implementation plan; no runtime code or schema changes.
