### PR TITLE
fix(build): reconcile stranded plan→build transition instead of flooding (BI-05208DE5)

### DIFF
--- a/apps/web/lib/integrate/plan-to-build-transition.test.ts
+++ b/apps/web/lib/integrate/plan-to-build-transition.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Collaborator mocks ───────────────────────────────────────────────────────
+const findUniqueMock = vi.fn();
+const updateMock = vi.fn();
+const activityCreateMock = vi.fn();
+const checkPhaseGateMock = vi.fn();
+const canTransitionPhaseMock = vi.fn();
+const normalizeHappyPathStateMock = vi.fn();
+const deriveDependencyGateMock = vi.fn();
+const logBuildActivityMock = vi.fn();
+const evaluateWwmdGateMock = vi.fn();
+const isSandboxAvailableMock = vi.fn();
+const startBuildBranchMock = vi.fn();
+const startBuildPhaseRunMock = vi.fn();
+const completeBuildPhaseRunMock = vi.fn();
+const dispatchBuildMock = vi.fn();
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    featureBuild: {
+      findUnique: (...a: unknown[]) => findUniqueMock(...a),
+      update: (...a: unknown[]) => updateMock(...a),
+    },
+    buildActivity: { create: (...a: unknown[]) => activityCreateMock(...a) },
+  },
+}));
+vi.mock("@/lib/feature-build-types", () => ({
+  checkPhaseGate: (...a: unknown[]) => checkPhaseGateMock(...a),
+  canTransitionPhase: (...a: unknown[]) => canTransitionPhaseMock(...a),
+  normalizeHappyPathState: (...a: unknown[]) => normalizeHappyPathStateMock(...a),
+}));
+vi.mock("@/lib/build/feature-build-dependencies", () => ({
+  deriveFeatureBuildDependencyGate: (...a: unknown[]) => deriveDependencyGateMock(...a),
+  FEATURE_BUILD_DEPENDENCY_GATE_SELECT: { dependenciesOut: true },
+}));
+vi.mock("@/lib/mcp/build-tool-helpers", () => ({
+  logBuildActivity: (...a: unknown[]) => logBuildActivityMock(...a),
+}));
+vi.mock("@/lib/decision-perspective/build-studio-gate", () => ({
+  evaluateBuildStudioPlanAdvancementGate: (...a: unknown[]) => evaluateWwmdGateMock(...a),
+}));
+vi.mock("@/lib/integrate/sandbox/build-branch", () => ({
+  isSandboxAvailable: (...a: unknown[]) => isSandboxAvailableMock(...a),
+  startBuildBranch: (...a: unknown[]) => startBuildBranchMock(...a),
+}));
+vi.mock("@/lib/integrate/build-phase-run", () => ({
+  startBuildPhaseRun: (...a: unknown[]) => startBuildPhaseRunMock(...a),
+  completeBuildPhaseRun: (...a: unknown[]) => completeBuildPhaseRunMock(...a),
+}));
+vi.mock("@/lib/integrate/build-on-plan-approval", () => ({
+  dispatchBuildForApprovedPlan: (...a: unknown[]) => dispatchBuildMock(...a),
+}));
+
+import {
+  performPlanToBuildTransition,
+  recordPlanAdvanceFailure,
+  shouldEscalatePlanAdvance,
+  readPlanAdvanceTracker,
+  PLAN_ADVANCE_ESCALATE_AFTER,
+} from "./plan-to-build-transition";
+
+function planBuild(overrides: Record<string, unknown> = {}) {
+  return {
+    phase: "plan",
+    plan: { processSize: "medium" },
+    buildPlan: { tasks: [{ title: "t" }] },
+    planReview: { decision: "pass" },
+    id: "row-1",
+    buildId: "FB-X",
+    title: "A feature",
+    kind: "feature",
+    parentEpicId: null,
+    deliberationSummary: null,
+    buildExecState: null,
+    dependenciesOut: [],
+    ...overrides,
+  };
+}
+
+describe("plan-advance pure helpers (BI-05208DE5)", () => {
+  it("recordPlanAdvanceFailure increments the counter and stamps the latest error", () => {
+    const now = new Date("2026-07-22T00:00:00Z");
+    const first = recordPlanAdvanceFailure(null, "boom", now);
+    expect(first.failures).toBe(1);
+    expect(first.lastError).toBe("boom");
+    expect(first.lastAt).toBe(now.toISOString());
+    const second = recordPlanAdvanceFailure(first, "boom again", now);
+    expect(second.failures).toBe(2);
+    expect(second.lastError).toBe("boom again");
+  });
+
+  it("recordPlanAdvanceFailure preserves a prior escalatedAt stamp", () => {
+    const now = new Date("2026-07-22T00:00:00Z");
+    const prev = { failures: 3, escalatedAt: "2026-07-21T00:00:00Z" };
+    expect(recordPlanAdvanceFailure(prev, "x", now).escalatedAt).toBe("2026-07-21T00:00:00Z");
+  });
+
+  it("shouldEscalatePlanAdvance fires only at/above the threshold", () => {
+    expect(shouldEscalatePlanAdvance({ failures: PLAN_ADVANCE_ESCALATE_AFTER - 1 })).toBe(false);
+    expect(shouldEscalatePlanAdvance({ failures: PLAN_ADVANCE_ESCALATE_AFTER })).toBe(true);
+    expect(shouldEscalatePlanAdvance({ failures: 1, threshold: 1 })).toBe(true);
+  });
+
+  it("readPlanAdvanceTracker parses a persisted tracker and defends against junk", () => {
+    expect(readPlanAdvanceTracker(null)).toBeNull();
+    expect(readPlanAdvanceTracker({ planAdvance: "nope" })).toBeNull();
+    expect(readPlanAdvanceTracker({ planAdvance: { failures: 2, lastError: "e" } })).toMatchObject({
+      failures: 2,
+      lastError: "e",
+    });
+  });
+});
+
+describe("performPlanToBuildTransition (BI-05208DE5)", () => {
+  beforeEach(() => {
+    findUniqueMock.mockReset().mockResolvedValue(planBuild());
+    updateMock.mockReset().mockResolvedValue({});
+    activityCreateMock.mockReset().mockResolvedValue({});
+    checkPhaseGateMock.mockReset().mockReturnValue({ allowed: true });
+    canTransitionPhaseMock.mockReset().mockReturnValue(true);
+    normalizeHappyPathStateMock.mockReset().mockReturnValue({});
+    deriveDependencyGateMock.mockReset().mockReturnValue({ allowed: true });
+    logBuildActivityMock.mockReset();
+    evaluateWwmdGateMock.mockReset().mockResolvedValue({ allowed: true, operatorMessage: "ok" });
+    isSandboxAvailableMock.mockReset().mockResolvedValue(true);
+    startBuildBranchMock.mockReset().mockResolvedValue(null);
+    startBuildPhaseRunMock.mockReset().mockResolvedValue(undefined);
+    completeBuildPhaseRunMock.mockReset().mockResolvedValue(undefined);
+    dispatchBuildMock.mockReset().mockResolvedValue({ kind: "dispatched" });
+  });
+
+  it("advances a complete, reviewed, WWMD-recommended plan to build (initializes branch, flips phase, dispatches)", async () => {
+    const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
+    expect(out).toEqual({ kind: "advanced" });
+    expect(startBuildBranchMock).toHaveBeenCalledWith("FB-X");
+    // phase flipped to build
+    expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({ data: { phase: "build" } }));
+    // build orchestrator auto-dispatched (fire-and-forget dynamic import — flush)
+    await vi.waitFor(() => expect(dispatchBuildMock).toHaveBeenCalledWith({ buildId: "FB-X", userId: "u1" }));
+    expect(logBuildActivityMock).toHaveBeenCalledWith("FB-X", "phase:advance", expect.stringContaining("plan → build"));
+  });
+
+  it("does NOT flip when the WWMD gate withholds advancement", async () => {
+    evaluateWwmdGateMock.mockResolvedValue({ allowed: false, operatorMessage: "principle conflict" });
+    const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
+    expect(out.kind).toBe("wwmd-withheld");
+    expect(startBuildBranchMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalledWith(expect.objectContaining({ data: { phase: "build" } }));
+  });
+
+  it("counts a startBuildBranch failure and returns transition-failed below the threshold (does not flip)", async () => {
+    startBuildBranchMock.mockRejectedValue(new Error("Command failed: docker exec ..."));
+    const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
+    expect(out).toMatchObject({ kind: "transition-failed", failures: 1 });
+    // never flips to build
+    expect(updateMock).not.toHaveBeenCalledWith(expect.objectContaining({ data: { phase: "build" } }));
+    // persists the tracker
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          buildExecState: expect.objectContaining({ planAdvance: expect.objectContaining({ failures: 1 }) }),
+        }),
+      }),
+    );
+  });
+
+  it("escalates to the operator after the threshold and pauses the loop", async () => {
+    // Prior tracker already at threshold-1 failures.
+    findUniqueMock.mockResolvedValue(
+      planBuild({ parentEpicId: "cmr-epic", buildExecState: { planAdvance: { failures: PLAN_ADVANCE_ESCALATE_AFTER - 1 } } }),
+    );
+    startBuildBranchMock.mockRejectedValue(new Error("Command failed: docker exec ..."));
+    const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
+    expect(out.kind).toBe("escalated");
+    expect((out as { failures: number }).failures).toBe(PLAN_ADVANCE_ESCALATE_AFTER);
+    expect(logBuildActivityMock).toHaveBeenCalledWith("FB-X", "phase:needs-operator", expect.stringContaining("epic-child"));
+  });
+
+  it("short-circuits to escalated (skips the failing transition) once already escalated", async () => {
+    findUniqueMock.mockResolvedValue(
+      planBuild({ buildExecState: { planAdvance: { failures: 5, escalatedAt: "2026-07-22T00:00:00Z" } } }),
+    );
+    const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
+    expect(out.kind).toBe("escalated");
+    // No transition work at all — the whole point of pausing the flood.
+    expect(startBuildBranchMock).not.toHaveBeenCalled();
+    expect(evaluateWwmdGateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns not-ready when the build is no longer in the plan phase", async () => {
+    findUniqueMock.mockResolvedValue(planBuild({ phase: "build" }));
+    const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
+    expect(out.kind).toBe("not-ready");
+    expect(startBuildBranchMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks on the structural phase gate without attempting the branch", async () => {
+    checkPhaseGateMock.mockReturnValue({ allowed: false, reason: "buildPlan-present required" });
+    const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
+    expect(out).toMatchObject({ kind: "gate-blocked" });
+    expect(startBuildBranchMock).not.toHaveBeenCalled();
+  });
+
+  it("treats sandbox-not-running as a counted transition failure", async () => {
+    isSandboxAvailableMock.mockResolvedValue(false);
+    const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
+    expect(out).toMatchObject({ kind: "transition-failed", failures: 1 });
+    expect(startBuildBranchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/integrate/plan-to-build-transition.ts
+++ b/apps/web/lib/integrate/plan-to-build-transition.ts
@@ -1,0 +1,341 @@
+// apps/web/lib/integrate/plan-to-build-transition.ts
+//
+// Single source of truth for the Build Studio plan→build phase transition
+// (BI-05208DE5).
+//
+// Both the fresh-review path (reviewBuildPlan in mcp-tools.ts) and the
+// auto-resume reconciler (resume-pre-build-phase.ts) need to take a build whose
+// plan is complete and reviewed and actually flip it into `build` — initializing
+// the isolated build branch FIRST so `buildBranch` is set before `phase=build`
+// (else deploy_feature runs on whatever leftover HEAD the sandbox is on). That
+// logic was duplicated inline in reviewBuildPlan, and it had a load-bearing flaw:
+// when the branch-init step threw (the sandbox was down or churning during a
+// self-upgrade), the exception was caught and logged as `phase:gate-blocked`, the
+// phase never flipped, and the 30-minute auto-resume re-ran the ENTIRE plan
+// review (two reviewer model calls + a deliberation trail that stalls) and
+// re-attempted the same transition — forever, with no failure counter and no
+// age-out for epic-decomposed children (isStrandedPreBuildAbandonable returns
+// false when parentEpicId is set). That perpetual loop wedged routine
+// self-upgrade (the activity-in-flight skip kept seeing live deliberation
+// TaskRuns).
+//
+// This module extracts the transition into one executor and adds a bounded
+// failure tracker on FeatureBuild.buildExecState.planAdvance: repeated transition
+// failures are counted and, past a threshold, escalate to the operator instead of
+// looping — the only thing that stops an age-out-exempt epic child from flooding.
+// The WWMD decision itself is NOT the blocker (the stuck builds carried a cached
+// `recommend`, confidence 0.9); the transition SIDE-EFFECT was.
+
+import { prisma, type Prisma } from "@dpf/db";
+import {
+  canTransitionPhase,
+  checkPhaseGate,
+  normalizeHappyPathState,
+} from "@/lib/feature-build-types";
+import {
+  deriveFeatureBuildDependencyGate,
+  FEATURE_BUILD_DEPENDENCY_GATE_SELECT,
+} from "@/lib/build/feature-build-dependencies";
+import { logBuildActivity } from "@/lib/mcp/build-tool-helpers";
+
+/**
+ * How many consecutive failed plan→build transition attempts before a build
+ * escalates to the operator and auto-resume stops re-attempting. Default 3
+ * (≈90 min at the 30-min resume cadence): a transient sandbox blip recovers
+ * within a cycle (the counter resets on any success), so only a PERSISTENT
+ * failure — a real bug or a long sandbox outage — escalates. Override with
+ * BUILD_PLAN_ADVANCE_ESCALATE_AFTER.
+ */
+export const PLAN_ADVANCE_ESCALATE_AFTER =
+  Number(process.env.BUILD_PLAN_ADVANCE_ESCALATE_AFTER) || 3;
+
+/** Per-build advance tracker, persisted under `buildExecState.planAdvance`. */
+export type PlanAdvanceTracker = {
+  failures: number;
+  lastError?: string;
+  lastAt?: string;
+  escalatedAt?: string;
+};
+
+export type PlanToBuildTransitionOutcome =
+  | { kind: "advanced" }
+  | { kind: "not-ready"; reason: string }
+  | { kind: "gate-blocked"; reason: string }
+  | { kind: "wwmd-withheld"; reason: string }
+  | { kind: "transition-failed"; reason: string; failures: number }
+  | { kind: "escalated"; reason: string; failures: number };
+
+// ── Pure helpers (DB-free, unit-tested) ──────────────────────────────────────
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function readPlanAdvanceTracker(buildExecState: unknown): PlanAdvanceTracker | null {
+  const state = asRecord(buildExecState);
+  const raw = state ? asRecord(state.planAdvance) : null;
+  if (!raw) return null;
+  return {
+    failures: typeof raw.failures === "number" ? raw.failures : 0,
+    lastError: typeof raw.lastError === "string" ? raw.lastError : undefined,
+    lastAt: typeof raw.lastAt === "string" ? raw.lastAt : undefined,
+    escalatedAt: typeof raw.escalatedAt === "string" ? raw.escalatedAt : undefined,
+  };
+}
+
+/** Increment the failure counter, recording the latest error + timestamp. */
+export function recordPlanAdvanceFailure(
+  prev: PlanAdvanceTracker | null | undefined,
+  error: string,
+  now: Date,
+): PlanAdvanceTracker {
+  return {
+    failures: (prev?.failures ?? 0) + 1,
+    lastError: error.slice(0, 300),
+    lastAt: now.toISOString(),
+    ...(prev?.escalatedAt ? { escalatedAt: prev.escalatedAt } : {}),
+  };
+}
+
+export function shouldEscalatePlanAdvance(args: { failures: number; threshold?: number }): boolean {
+  return args.failures >= (args.threshold ?? PLAN_ADVANCE_ESCALATE_AFTER);
+}
+
+// ── Tracker persistence ──────────────────────────────────────────────────────
+
+async function persistPlanAdvanceTracker(buildId: string, tracker: PlanAdvanceTracker): Promise<void> {
+  try {
+    const row = await prisma.featureBuild.findUnique({
+      where: { buildId },
+      select: { buildExecState: true },
+    });
+    const existing = asRecord(row?.buildExecState) ?? {};
+    await prisma.featureBuild.update({
+      where: { buildId },
+      data: {
+        buildExecState: { ...existing, planAdvance: tracker } as unknown as Prisma.InputJsonValue,
+      },
+    });
+  } catch (err) {
+    console.warn("[plan-to-build-transition] failed to persist planAdvance tracker:", { buildId }, err);
+  }
+}
+
+/** On success, drop the tracker so a later unrelated strand starts clean. */
+async function clearPlanAdvanceTracker(buildId: string, existingState: unknown): Promise<void> {
+  const rec = asRecord(existingState);
+  if (!rec || rec.planAdvance == null) return;
+  try {
+    const { planAdvance: _drop, ...rest } = rec;
+    await prisma.featureBuild.update({
+      where: { buildId },
+      data: { buildExecState: rest as unknown as Prisma.InputJsonValue },
+    });
+  } catch {
+    /* best-effort */
+  }
+}
+
+async function failTransition(args: {
+  buildId: string;
+  parentEpicId: string | null;
+  reason: string;
+  prevTracker: PlanAdvanceTracker | null;
+}): Promise<PlanToBuildTransitionOutcome> {
+  const { buildId, parentEpicId, reason, prevTracker } = args;
+  const now = new Date();
+  let tracker = recordPlanAdvanceFailure(prevTracker, reason, now);
+
+  if (shouldEscalatePlanAdvance({ failures: tracker.failures })) {
+    tracker = { ...tracker, escalatedAt: tracker.escalatedAt ?? now.toISOString() };
+    await persistPlanAdvanceTracker(buildId, tracker);
+    logBuildActivity(
+      buildId,
+      "phase:needs-operator",
+      `plan → build blocked ${tracker.failures}x (${reason}). Auto-resume paused for this build; ` +
+        `restart the sandbox and manually advance, or re-promote the backlog item.` +
+        (parentEpicId
+          ? " (epic-child build — exempt from the 7-day age-out, so this escalation is what stops it looping.)"
+          : ""),
+    );
+    return { kind: "escalated", reason, failures: tracker.failures };
+  }
+
+  await persistPlanAdvanceTracker(buildId, tracker);
+  logBuildActivity(
+    buildId,
+    "phase:gate-blocked",
+    `plan → build transition failed (attempt ${tracker.failures}): ${reason}`,
+  );
+  return { kind: "transition-failed", reason, failures: tracker.failures };
+}
+
+// ── The single transition executor ───────────────────────────────────────────
+
+/**
+ * Take a plan-phase build whose plan is complete + reviewed and flip it into
+ * `build` — the ONE place the plan→build side-effect lives. Runs the structural
+ * phase gate, the dependency gate, and the WWMD kernel gate (fail-OPEN on
+ * evaluator error, block on a genuine principle conflict), then initializes the
+ * build branch BEFORE flipping the phase and auto-dispatches the build
+ * orchestrator. A branch-init / sandbox failure is counted and escalated past the
+ * threshold rather than looped forever. Never throws.
+ */
+export async function performPlanToBuildTransition(params: {
+  buildId: string;
+  userId: string;
+  context?: { threadId?: string } | null;
+}): Promise<PlanToBuildTransitionOutcome> {
+  const { buildId, userId, context } = params;
+
+  const build = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: {
+      phase: true,
+      plan: true,
+      buildPlan: true,
+      planReview: true,
+      id: true,
+      buildId: true,
+      title: true,
+      kind: true,
+      parentEpicId: true,
+      deliberationSummary: true,
+      buildExecState: true,
+      dependenciesOut: FEATURE_BUILD_DEPENDENCY_GATE_SELECT.dependenciesOut,
+    },
+  });
+  if (!build) return { kind: "not-ready", reason: "build not found" };
+  if (build.phase !== "plan" || !canTransitionPhase("plan", "build")) {
+    return { kind: "not-ready", reason: `build is in phase ${build.phase}, not plan` };
+  }
+
+  // Already escalated → do not re-attempt the failing transition; keep the
+  // resume loop cheap (a single DB read). Operator recovery: re-promote, or
+  // restart the sandbox and manually advance.
+  const tracker = readPlanAdvanceTracker(build.buildExecState);
+  if (tracker?.escalatedAt) {
+    return {
+      kind: "escalated",
+      reason: tracker.lastError ?? "prior plan→build transition failures",
+      failures: tracker.failures,
+    };
+  }
+
+  // Structural phase gate.
+  const planRec = (build.plan as Record<string, unknown> | null) ?? {};
+  const gate = checkPhaseGate("plan", "build", {
+    kind: build.kind,
+    processSize: (planRec.processSize as string | undefined) ?? "medium",
+    deliverableSensitivity: planRec.deliverableSensitivity,
+    qualityFirst: planRec.qualityFirst === true,
+    buildPlan: build.buildPlan,
+    planReview: build.planReview,
+    happyPathState: normalizeHappyPathState(planRec.happyPathState),
+  });
+  if (!gate.allowed) {
+    logBuildActivity(buildId, "phase:gate-blocked", gate.reason ?? "plan→build gate not satisfied");
+    return { kind: "gate-blocked", reason: gate.reason ?? "plan→build gate not satisfied" };
+  }
+
+  // Dependency gate (blocking upstream builds).
+  const dependencyGate = deriveFeatureBuildDependencyGate(build);
+  if (!dependencyGate.allowed) {
+    logBuildActivity(buildId, "phase:gate-blocked", dependencyGate.message);
+    return { kind: "gate-blocked", reason: dependencyGate.message };
+  }
+
+  // WWMD kernel gate. Structural gates above are necessary but not sufficient:
+  // principle_decide is the authority on whether plan→build honors platform
+  // principles. Fail OPEN on evaluator error (a kernel hiccup must not wedge the
+  // flow); a genuine principle conflict blocks and surfaces a DecisionInteraction.
+  try {
+    const { evaluateBuildStudioPlanAdvancementGate } = await import(
+      "@/lib/decision-perspective/build-studio-gate"
+    );
+    const decisionGate = await evaluateBuildStudioPlanAdvancementGate({
+      db: prisma,
+      build: {
+        buildId: build.buildId,
+        title: build.title ?? build.buildId,
+        phase: "plan",
+        planReview: build.planReview as Parameters<
+          typeof evaluateBuildStudioPlanAdvancementGate
+        >[0]["build"]["planReview"],
+        deliberationSummary: build.deliberationSummary as Parameters<
+          typeof evaluateBuildStudioPlanAdvancementGate
+        >[0]["build"]["deliberationSummary"],
+      },
+      triggeredByUserId: userId,
+    });
+    if (!decisionGate.allowed) {
+      logBuildActivity(
+        buildId,
+        "wwmd:gate-blocked",
+        decisionGate.operatorMessage ?? "Decision kernel withheld plan→build advancement.",
+      );
+      return {
+        kind: "wwmd-withheld",
+        reason: decisionGate.operatorMessage ?? "decision kernel withheld advancement",
+      };
+    }
+  } catch (wwmdErr) {
+    console.error("[plan-to-build-transition] WWMD gate errored (failing open):", wwmdErr);
+  }
+
+  // Initialize the build branch BEFORE flipping the phase so `buildBranch` is
+  // always paired with `phase=build`. This is the step that was failing (sandbox
+  // down / churning) and looping the whole fleet — count + escalate instead.
+  try {
+    const { isSandboxAvailable, startBuildBranch } = await import(
+      "@/lib/integrate/sandbox/build-branch"
+    );
+    if (!(await isSandboxAvailable())) {
+      return await failTransition({
+        buildId,
+        parentEpicId: build.parentEpicId ?? null,
+        reason: "sandbox not running",
+        prevTracker: tracker,
+      });
+    }
+    await startBuildBranch(buildId);
+  } catch (branchErr) {
+    return await failTransition({
+      buildId,
+      parentEpicId: build.parentEpicId ?? null,
+      reason: `startBuildBranch failed: ${(branchErr as Error).message?.slice(0, 200)}`,
+      prevTracker: tracker,
+    });
+  }
+
+  // Branch ready → phase-run bookkeeping, flip, dispatch.
+  const { completeBuildPhaseRun, startBuildPhaseRun } = await import(
+    "@/lib/integrate/build-phase-run"
+  );
+  void completeBuildPhaseRun(buildId, "plan");
+  // swallow QuiescingError thrown during a self-upgrade drain (BI-QUIESCE-005)
+  void startBuildPhaseRun(buildId, "build").catch(() => {});
+  if (context?.threadId) {
+    const { persistPhaseHandoffSummary } = await import("@/lib/integrate/phase-compaction-wire");
+    void persistPhaseHandoffSummary(context.threadId, "plan");
+  }
+  await prisma.featureBuild.update({ where: { buildId }, data: { phase: "build" } });
+  if (context?.threadId) {
+    const { agentEventBus } = await import("@/lib/agent-event-bus");
+    agentEventBus.emit(context.threadId, { type: "phase:change", buildId, phase: "build" });
+  }
+  logBuildActivity(buildId, "phase:advance", "Phase advanced: plan → build (buildBranch initialized)");
+  await clearPlanAdvanceTracker(buildId, build.buildExecState);
+
+  // Auto-dispatch the build orchestrator (fire-and-forget) so specialist code
+  // generation runs immediately without waiting for an operator prompt.
+  void import("@/lib/integrate/build-on-plan-approval").then((m) =>
+    m
+      .dispatchBuildForApprovedPlan({ buildId, userId })
+      .catch((err) => console.error("[build-on-plan-approval] auto-dispatch failed:", err)),
+  );
+
+  return { kind: "advanced" };
+}

--- a/apps/web/lib/integrate/resume-pre-build-phase.test.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.test.ts
@@ -44,6 +44,10 @@ vi.mock("@/lib/integrate/plan-on-approval", () => ({
 vi.mock("@/lib/mcp-tools", () => ({
   executeTool: (...args: unknown[]) => executeToolMock(...args),
 }));
+const performPlanToBuildTransitionMock = vi.fn();
+vi.mock("@/lib/integrate/plan-to-build-transition", () => ({
+  performPlanToBuildTransition: (...args: unknown[]) => performPlanToBuildTransitionMock(...args),
+}));
 
 import {
   resumePreBuildPhase,
@@ -64,6 +68,7 @@ describe("resumePreBuildPhase (BI-9257CF19)", () => {
     // the operator-driven behavior; governed autopilot tests override this.
     platformDevConfigFindUniqueMock.mockReset().mockResolvedValue({ governedBacklogEnabled: false });
     autoResolveDecomposeMock.mockReset().mockResolvedValue({ action: "park" });
+    performPlanToBuildTransitionMock.mockReset().mockResolvedValue({ kind: "advanced" });
   });
 
   it("re-queues review verification for a stranded review-phase build", async () => {
@@ -99,6 +104,48 @@ describe("resumePreBuildPhase (BI-9257CF19)", () => {
     expect(dispatchPlanMock).toHaveBeenCalledWith({ buildId: "FB-3F", userId: "u3", forceRegenerate: true });
     expect(executeToolMock).not.toHaveBeenCalled();
     expect(out).toMatchObject({ kind: "resumed", via: "dispatchPlanForApprovedBuild:repair" });
+  });
+
+  // ── Plan→build reconciler (BI-05208DE5) ──────────────────────────────────
+  // A build with a COMPLETE plan whose review already PASSED is stranded only
+  // because the transition side-effect (startBuildBranch) failed — the WWMD
+  // decision already recommends. Resume must perform the transition DIRECTLY,
+  // NOT re-run the expensive reviewBuildPlan (which re-mints a deliberation that
+  // stalls and floods).
+  it("reconciles a complete + passed plan straight to build without re-running reviewBuildPlan", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { x: 1 },
+      buildPlan: { tasks: [{ title: "t" }] },
+      planReview: { decision: "pass" },
+    });
+    const out = await resumePreBuildPhase({ buildId: "FB-RC", phase: "plan", userId: "uRC" });
+    expect(performPlanToBuildTransitionMock).toHaveBeenCalledWith({ buildId: "FB-RC", userId: "uRC" });
+    expect(executeToolMock).not.toHaveBeenCalled();
+    expect(dispatchPlanMock).not.toHaveBeenCalled();
+    expect(out).toMatchObject({ kind: "resumed", via: "performPlanToBuildTransition" });
+  });
+
+  it("returns skipped (auto-resume paused) once the plan→build transition has escalated", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { x: 1 },
+      buildPlan: { tasks: [{ title: "t" }] },
+      planReview: { decision: "pass" },
+      parentEpicId: "cmr-epic",
+    });
+    performPlanToBuildTransitionMock.mockResolvedValue({ kind: "escalated", failures: 3, reason: "startBuildBranch failed" });
+    const out = await resumePreBuildPhase({ buildId: "FB-ESC", phase: "plan", userId: "uESC" });
+    expect(performPlanToBuildTransitionMock).toHaveBeenCalledOnce();
+    expect(executeToolMock).not.toHaveBeenCalled();
+    expect(out.kind).toBe("skipped");
+    expect((out as { reason: string }).reason).toContain("escalated");
+  });
+
+  it("still runs the canonical plan review (not the reconciler) when no review verdict exists yet", async () => {
+    findUniqueMock.mockResolvedValue({ designDoc: { x: 1 }, buildPlan: { tasks: [{ title: "t" }] } });
+    const out = await resumePreBuildPhase({ buildId: "FB-NOREV", phase: "plan", userId: "uNR" });
+    expect(performPlanToBuildTransitionMock).not.toHaveBeenCalled();
+    expect(executeToolMock).toHaveBeenCalledWith("reviewBuildPlan", { buildId: "FB-NOREV" }, "uNR", { featureBuildId: "FB-NOREV" });
+    expect(out).toMatchObject({ kind: "resumed", via: "executeTool:reviewBuildPlan" });
   });
 
   it("re-dispatches ideate research when no design doc exists yet", async () => {

--- a/apps/web/lib/integrate/resume-pre-build-phase.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.ts
@@ -462,8 +462,48 @@ export async function resumePreBuildPhase(params: {
         const outcome = await dispatchPlanForApprovedBuild({ buildId, userId, forceRegenerate: true });
         return { kind: "resumed", phase, via: "dispatchPlanForApprovedBuild:repair", detail: outcome.kind };
       }
-      // No failed verdict — re-run the review (current reviewer logic may now pass
-      // an older verdict); it auto-advances plan->build on pass.
+      // Reconciler (BI-05208DE5): a complete plan whose review already PASSED is
+      // stranded only because the plan→build transition SIDE-EFFECT failed — the
+      // WWMD decision already recommends (the stuck builds carried a cached
+      // `recommend`, confidence 0.9). Perform the transition DIRECTLY via the
+      // shared executor instead of re-running the expensive reviewBuildPlan, which
+      // re-mints a plan-review deliberation that stalls (heartbeats once, watchdog
+      // reaps it) and floods every 30 min — the loop that wedged self-upgrade.
+      // Epic-decomposed children are exempt from the 7-day age-out, so this direct
+      // path (with the executor's bounded-retry + escalation) is the only thing
+      // that stops them looping forever. See target #2 / BI-8C44DB49 for the
+      // orchestrator stall itself.
+      const planReviewPassed =
+        (build.planReview as { decision?: string } | null)?.decision === "pass";
+      if (planReviewPassed) {
+        const { performPlanToBuildTransition } = await import("@/lib/integrate/plan-to-build-transition");
+        const outcome = await performPlanToBuildTransition({ buildId, userId });
+        switch (outcome.kind) {
+          case "advanced":
+            return { kind: "resumed", phase, via: "performPlanToBuildTransition", detail: "advanced plan → build" };
+          case "escalated":
+            return {
+              kind: "skipped",
+              phase,
+              reason: `plan → build transition failed ${outcome.failures}x — escalated to operator; auto-resume paused for this build (${outcome.reason}).`,
+            };
+          case "transition-failed":
+            return {
+              kind: "skipped",
+              phase,
+              reason: `plan → build transition failed (attempt ${outcome.failures}); will retry next cycle (${outcome.reason}).`,
+            };
+          case "gate-blocked":
+          case "wwmd-withheld":
+            return { kind: "skipped", phase, reason: `plan → build ${outcome.kind}: ${outcome.reason}` };
+          case "not-ready":
+            // Build advanced out of plan (or vanished) between scan and now.
+            return { kind: "skipped", phase, reason: `plan → build not-ready: ${outcome.reason}` };
+        }
+      }
+
+      // No usable verdict yet — re-run the review (current reviewer logic may now
+      // pass an older verdict); it auto-advances plan->build on pass.
       const { executeTool } = await import("@/lib/mcp-tools");
       const result = await executeTool("reviewBuildPlan", { buildId }, userId, { featureBuildId: buildId });
       return {

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1792,118 +1792,20 @@ export async function executeTool(
         logBuildActivity(buildId, "reviewBuildPlan", `Plan review failed but is ADVISORY for this kind/size (phase gate does not require planReview-passed) — advancing on the gate; issues recorded for visibility.`);
       }
 
-      // Passed review → auto-advance if gate is satisfied.
+      // Passed review (or advisory-non-gating) → advance to build via the SINGLE
+      // transition executor, shared with the auto-resume reconciler so the plan→
+      // build side-effect lives in exactly one place (BI-05208DE5). The executor
+      // runs the structural + dependency + WWMD kernel gates (fail-open on kernel
+      // error, block on a genuine principle conflict), initializes the build
+      // branch BEFORE flipping the phase (so `buildBranch` is paired with
+      // `phase=build`), auto-dispatches the build orchestrator, and — critically —
+      // COUNTS a branch-init/sandbox failure and escalates past a threshold
+      // instead of silently looping forever (the flood that wedged self-upgrade).
       try {
-        const { checkPhaseGate, canTransitionPhase, normalizeHappyPathState } = await import("@/lib/feature-build-types");
-        const { deriveFeatureBuildDependencyGate, FEATURE_BUILD_DEPENDENCY_GATE_SELECT } = await import("@/lib/build/feature-build-dependencies");
-        const updatedBuild = await prisma.featureBuild.findUnique({
-          where: { buildId },
-          select: {
-            phase: true,
-            plan: true,
-            buildPlan: true,
-            planReview: true,
-            id: true,
-            buildId: true,
-            title: true,
-            kind: true,
-            parentEpicId: true,
-            deliberationSummary: true,
-            dependenciesOut: FEATURE_BUILD_DEPENDENCY_GATE_SELECT.dependenciesOut,
-          },
-        });
-        if (updatedBuild && updatedBuild.phase === "plan" && canTransitionPhase("plan", "build")) {
-          const plan = (updatedBuild.plan as Record<string, unknown> | null) ?? {};
-          const happyPathState = normalizeHappyPathState(plan.happyPathState);
-          const gate = checkPhaseGate("plan", "build", {
-            kind: updatedBuild.kind,
-            // Right-sizing matrix: persisted on the plan at promote time. The
-            // warrant supplies deliverableSensitivity/qualityFirst so rigor
-            // scales by altitude + blast-radius, not effort size alone.
-            processSize: (plan.processSize as string | undefined) ?? "medium",
-            deliverableSensitivity: plan.deliverableSensitivity,
-            qualityFirst: plan.qualityFirst === true,
-            buildPlan: updatedBuild.buildPlan,
-            planReview: updatedBuild.planReview,
-            happyPathState,
-          });
-          if (gate.allowed) {
-            const dependencyGate = deriveFeatureBuildDependencyGate(updatedBuild);
-            if (!dependencyGate.allowed) {
-              logBuildActivity(buildId, "phase:gate-blocked", dependencyGate.message);
-            } else {
-              // WWMD kernel gate. The structural checkPhaseGate + dependency gate
-              // above are necessary but not sufficient: the decision kernel
-              // (principle_decide) is the authority on whether plan→build honors
-              // platform principles. The advance-phase HTTP route runs this gate;
-              // this agentic-loop auto-advance MUST too, or local-model builds
-              // silently bypass WWMD. Fail OPEN on evaluator error so a kernel
-              // hiccup can't wedge the streamlined flow — but a genuine principle
-              // conflict (gate not allowed) blocks the auto-advance and surfaces a
-              // DecisionInteraction for operator review.
-              let decisionAllowed = true;
-              try {
-                const { evaluateBuildStudioPlanAdvancementGate } = await import("@/lib/decision-perspective/build-studio-gate");
-                const decisionGate = await evaluateBuildStudioPlanAdvancementGate({
-                  db: prisma,
-                  build: {
-                    buildId: updatedBuild.buildId,
-                    title: updatedBuild.title ?? updatedBuild.buildId,
-                    phase: "plan",
-                    planReview: updatedBuild.planReview as Parameters<typeof evaluateBuildStudioPlanAdvancementGate>[0]["build"]["planReview"],
-                    deliberationSummary: updatedBuild.deliberationSummary as Parameters<typeof evaluateBuildStudioPlanAdvancementGate>[0]["build"]["deliberationSummary"],
-                  },
-                  triggeredByUserId: userId,
-                });
-                if (!decisionGate.allowed) {
-                  decisionAllowed = false;
-                  logBuildActivity(buildId, "wwmd:gate-blocked", decisionGate.operatorMessage ?? "Decision kernel withheld plan→build advancement.");
-                }
-              } catch (wwmdErr) {
-                console.error("[reviewBuildPlan] WWMD gate errored (failing open):", wwmdErr);
-              }
-              if (decisionAllowed) {
-              // Initialize the build branch BEFORE flipping the phase. If the
-              // phase flip lands without buildBranch set, deploy_feature runs
-              // on whatever the current sandbox HEAD is — picking up leftover
-              // work from earlier builds. Gate the transition on the branch
-              // actually being ready so the "phase: build" record is always
-              // paired with a valid buildBranch on the FeatureBuild row.
-              try {
-                const { isSandboxAvailable, startBuildBranch } = await import("@/lib/integrate/sandbox/build-branch");
-                const sandboxUp = await isSandboxAvailable();
-                if (!sandboxUp) {
-                  logBuildActivity(buildId, "phase:gate-blocked", "Auto-advance to build blocked: sandbox not running. Start the sandbox, then call start_build.");
-                } else {
-                  await startBuildBranch(buildId);
-                  // EP-COST Phase 3: record plan-phase cost rollup, start build tracking, and compact thread
-                  const { completeBuildPhaseRun, startBuildPhaseRun } = await import("@/lib/integrate/build-phase-run");
-                  void completeBuildPhaseRun(buildId, "plan");
-                  void startBuildPhaseRun(buildId, "build").catch(() => {}); // swallow QuiescingError thrown during a self-upgrade drain (BI-QUIESCE-005)
-                  if (context?.threadId) {
-                    const { persistPhaseHandoffSummary } = await import("@/lib/integrate/phase-compaction-wire");
-                    void persistPhaseHandoffSummary(context.threadId, "plan");
-                  }
-                  await prisma.featureBuild.update({ where: { buildId }, data: { phase: "build" } });
-                  if (context?.threadId) agentEventBus.emit(context.threadId, { type: "phase:change", buildId, phase: "build" });
-                  logBuildActivity(buildId, "phase:advance", "Phase advanced: plan → build (buildBranch initialized)");
-                  // Auto-dispatch the build orchestrator so specialist code generation
-                  // runs immediately without waiting for an operator to prompt the
-                  // coworker. The orchestrator handles the full build phase including
-                  // task dispatch, progress tracking, and auto-advance to review.
-                  void import("@/lib/integrate/build-on-plan-approval").then(m =>
-                    m.dispatchBuildForApprovedPlan({ buildId, userId })
-                      .catch(err => console.error("[build-on-plan-approval] auto-dispatch failed:", err))
-                  );
-                }
-              } catch (branchErr) {
-                logBuildActivity(buildId, "phase:gate-blocked", `startBuildBranch failed: ${(branchErr as Error).message?.slice(0, 200)}`);
-              }
-              }
-            }
-          } else {
-            logBuildActivity(buildId, "phase:gate-blocked", gate.reason ?? "unknown");
-          }
+        const { performPlanToBuildTransition } = await import("@/lib/integrate/plan-to-build-transition");
+        const outcome = await performPlanToBuildTransition({ buildId, userId, context });
+        if (outcome.kind === "escalated") {
+          logBuildActivity(buildId, "reviewBuildPlan", `plan → build escalated to operator after ${outcome.failures} failed transition attempts (${outcome.reason}).`);
         }
       } catch (err) {
         console.error("[reviewBuildPlan] auto-advance failed:", err);

--- a/docs/superpowers/plans/2026-07-22-bi-05208de5-plan-to-build-reconciler.md
+++ b/docs/superpowers/plans/2026-07-22-bi-05208de5-plan-to-build-reconciler.md
@@ -1,0 +1,86 @@
+# BI-05208DE5 — Plan→Build transition reconciler (stop the perpetual plan-phase resume flood)
+
+**Backlog item:** BI-05208DE5 — "Build Studio builds strand in plan with a complete plan + cached WWMD 'advance' decision that never executes the plan→build transition"
+**Type:** bug / build · **Date:** 2026-07-22
+**Related:** BI-573A8EB3 (routed-phase ReferenceError that preceded + masked this), BI-9257CF19 (auto-resume), BI-A009313E (7-day stranded age-out), BI-8C44DB49 (deliberation flood / fail-fast — owns target #2, the orchestrator stall; **not built here**), BI-98B723C0 (per-build worktree isolation / `startBuildBranch`).
+
+**For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+---
+
+## 1. Root cause (evidence-grounded, live DB + sandbox verified)
+
+The BI framed this as "a cached/idempotent WWMD 'advance' decision that never executes the transition." Live investigation refined it:
+
+1. **The WWMD decision is NOT the blocker.** The cached `DecisionInteraction` rows for the stuck builds (`DI-5E60C0B9F97B` etc.) are `outcomeType = "recommend"`, `confidenceAfter = 0.9`, `gateKey = "build-studio"`, `phaseFrom=plan phaseTo=build`. The idempotent-hit branch (`apps/web/lib/decision-perspective/evaluator.ts:582`) therefore returns `allowed = true`. The transition **is** authorized. (`phaseTo:build` in the trace is the *transition being gated*, not the verdict — the verdict is `recommend`.)
+
+2. **The transition is coupled to `startBuildBranch`, which failed.** In `reviewBuildPlan` (`apps/web/lib/mcp-tools.ts:1795–1910`) the plan→build advance runs: `checkPhaseGate` → `deriveFeatureBuildDependencyGate` → `evaluateBuildStudioPlanAdvancementGate` (WWMD, idempotent recommend → allowed) → **`isSandboxAvailable()` + `startBuildBranch(buildId)`** → only then flip `phase="build"`. The branch-init is deliberately done *before* the flip (so `buildBranch` is set before `phase=build`, preventing `deploy_feature` from running on leftover HEAD). `startBuildBranch` threw for these builds:
+   `phase:gate-blocked — startBuildBranch failed: Command failed: docker exec 'dpf-sandbox-1' sh -c '…'` (the stored summary truncates at 200 chars, before the failing git subcommand). Earlier cycles show the precursor `Auto-advance to build blocked: sandbox not running` — i.e. the sandbox was down/churning during the self-upgrade wedge. **Live re-check (2026-07-22): the sandbox git tree is healthy, `git fetch origin main` succeeds, and the stuck builds' `build/FB-*` branches + worktrees do not exist — so the original failure was transient.**
+
+3. **A failed transition loops forever with no escalation.** The `catch (branchErr)` at `mcp-tools.ts:1899` logs `phase:gate-blocked` and returns; the build stays in `plan`. The 30-minute auto-resume (`resumeStrandedBuildsOnBoot` → `resumePreBuildPhase`, phase `plan`) then re-runs the **entire expensive plan review** (two reviewer model calls + `runBuildReviewDeliberation`) and re-attempts the same transition — every 30 minutes, indefinitely. There is **no failure counter, no backoff, no escalation**.
+
+4. **Epic children never self-clear.** `isStrandedPreBuildAbandonable` (`resume-pre-build-phase.ts:96`) returns `false` when `parentEpicId` is set, so the 7-day age-out (BI-A009313E) never fires for the 8 stuck builds (all epic-decomposed children). The flood is therefore **perpetual**, and it wedged routine self-upgrade (the `activity-in-flight` skip kept seeing live deliberation TaskRuns).
+
+**Net root cause:** the routine plan→build transition is a fragile, un-bounded retry — coupled to a multi-step sandbox git op, re-minting an expensive (and separately-stalling) plan-review deliberation on every attempt, with no cap and no age-out for epic children.
+
+**Out of scope (owned by BI-8C44DB49):** *why* the plan-review deliberation TaskRuns bootstrap, heartbeat once, then stall (`apps/web/lib/deliberation/orchestrator.ts` branch dispatch). This plan **starves** that stall by not minting the deliberation when the plan is already complete + reviewed + recommended; it does not fix the orchestrator itself.
+
+## 2. Fix shape
+
+A **reconciler**: on resume of a plan-phase build that already has a complete plan **and** a cached advance-readiness decision, perform the transition **directly** — no fresh plan-review deliberation — and cap+escalate repeated transition failures so an age-out-exempt epic child stops flooding.
+
+Single source of truth: extract the transition side-effect from `reviewBuildPlan` into one shared executor used by both `reviewBuildPlan` and the reconciler.
+
+## 3. Substrate the plan touches (verified via code graph / reads)
+
+- `apps/web/lib/mcp-tools.ts:1795–1912` — `reviewBuildPlan` advance block (source of the extract).
+- `apps/web/lib/integrate/resume-pre-build-phase.ts:409–475` — `resumePreBuildPhase` phase `plan` (reconciler wiring).
+- `apps/web/lib/decision-perspective/persistence.ts:159` — `findExistingDecisionInteraction` (cached-decision lookup).
+- `apps/web/lib/decision-perspective/build-studio-gate.ts` — `evaluateBuildStudioPlanAdvancementGate`.
+- `apps/web/lib/integrate/sandbox/build-branch.ts` — `startBuildBranch`, `isSandboxAvailable`.
+- `apps/web/lib/feature-build-types` — `checkPhaseGate`, `canTransitionPhase`, `normalizeHappyPathState`.
+- `apps/web/lib/build/feature-build-dependencies` — `deriveFeatureBuildDependencyGate`, `FEATURE_BUILD_DEPENDENCY_GATE_SELECT`.
+- `apps/web/lib/integrate/build-on-plan-approval.ts` — `dispatchBuildForApprovedPlan`.
+- `FeatureBuild.buildExecState` (Json, additive — **no migration**) — stores the advance-attempt tracker.
+
+## 4. Phases
+
+### Phase 1 — Extract `performPlanToBuildTransition` (single source of truth)  *(ships independently)*
+**Deliverable:** new `apps/web/lib/integrate/plan-to-build-transition.ts`:
+- `performPlanToBuildTransition({ buildId, userId, context? }): Promise<PlanAdvanceOutcome>` — loads the build, guards `phase==="plan"` + `canTransitionPhase`, runs `checkPhaseGate` → dependency gate → WWMD gate (fail-**open** on evaluator error, as today), then `isSandboxAvailable` + `startBuildBranch` + phase-run bookkeeping + flip to `build` + `dispatchBuildForApprovedPlan`. Returns a typed outcome: `advanced | gate-blocked | wwmd-withheld | transition-failed | escalated | not-ready`.
+- On `startBuildBranch` throw or sandbox-down: record an attempt on `buildExecState.planAdvance` (`{ failures, lastError, lastAt, escalatedAt? }`) and return `transition-failed` (or `escalated` once `failures >= threshold`).
+- **Pure, DB-free helpers** (the unit-test core): `recordPlanAdvanceAttempt(prev, error, now)` and `shouldEscalatePlanAdvance({ failures, threshold })`. Threshold default `3`, env-override `BUILD_PLAN_ADVANCE_ESCALATE_AFTER`.
+- Refactor `reviewBuildPlan`'s advance block to call `performPlanToBuildTransition` after a passing/advisory review — deleting the duplicated inline transition logic.
+
+**Verification (functional):** `vitest` on the new pure helpers; a test proving `performPlanToBuildTransition` flips `phase→build` on success (mocked `startBuildBranch`) and records/escalates on repeated failure without flipping; existing `mcp-tools` review-advance tests stay green (behavior-preserving extraction).
+
+### Phase 2 — Reconciler on resume (skip the stalling re-review)  *(depends on Phase 1)*
+**Deliverable:** in `resume-pre-build-phase.ts` phase `plan`, after the child-intake heal and before the `executeTool("reviewBuildPlan")` fallback:
+- If `hasPlanTasks(buildPlan)` **and** a cached WWMD plan→build advance decision exists (`recommend`/`arbitrate`, via `findExistingDecisionInteraction`) **and** the plan review is not a hard `fail` → call `performPlanToBuildTransition` **directly** and return its outcome. No `reviewBuildPlan`, no fresh deliberation.
+- Once the outcome is `escalated`, the resume returns `{ kind: "skipped", reason: "plan-advance escalated to operator after N failed transitions" }` so the caller stops re-attempting — **this is what stops the epic-child flood** that the age-out cannot.
+- All other states (no plan / review failed / no cached decision) keep today's behavior exactly.
+- Helper `hasCachedPlanAdvanceDecision(buildId)`.
+
+**Verification (functional):** `vitest` regression test reproducing the BI's stranded state — build `phase="plan"`, `buildPlan` with tasks, `designDoc` present, `planReview="pass"`, and a cached `recommend` `DecisionInteraction` — asserts the resume performs the transition (`performPlanToBuildTransition` invoked / phase flips) and does **not** invoke `reviewBuildPlan`; a second test asserts that after `threshold` transition failures the resume returns `skipped` (escalated) rather than looping.
+
+### Phase 3 — Durable knowledge + evidence
+**Deliverable:** this plan (process-spine artifact); PR body carries `Process-Spine-Decision:` / `Docs-Impact-Decision:` (internal build-pipeline fix, no documented user route changes) and the root-cause evidence. Update the incident memory note. No AGENTS.md change required (no new durable contract for contributors).
+
+**Verification:** Spec/Plan/Doc gate satisfied by this plan file; UX-Fit gate N/A (no UI surface).
+
+## 5. Risks & rollback
+
+- **Hot-path risk (reviewBuildPlan advance).** Extraction must be behavior-identical on the happy path (sandbox up → advances exactly as before). Mitigation: the shared function mirrors the current block 1:1; existing review-advance tests are the safety net; run `mcp-tools.test.ts` + `resume-pre-build-phase.test.ts`.
+- **Premature escalation.** Too low a threshold could park healthy builds. Mitigation: default `3` (~90 min of retries), env-overridable; escalation only on repeated *hard* transition failures, never first attempt; escalated builds stay in `plan`, fully re-promotable and manually advanceable.
+- **Reconciler over-firing.** It only short-circuits when a cached `recommend`/`arbitrate` decision already exists — the precise BI state — so no behavior change for builds still needing a real review.
+- **Rollback:** revert the PR. `buildExecState.planAdvance` is additive Json (no migration), so rollback is clean; the resume path returns to re-running `reviewBuildPlan`.
+
+## 6. Definition of done
+
+- Build gate (§5 AGENTS.md): unit tests (Phase 1 + 2), production build (via shared local-CI sandbox lease), **no migration**.
+- Regression test reproduces the stranded-with-complete-plan state and asserts it advances (and bounded-escalates).
+- After deploy via governed self-upgrade: re-promote the 8 builds whose `abandonReason` starts "Ops-abandoned to stop perpetual plan-phase resume flood" and confirm they advance out of `plan` — the BI's gating acceptance.
+
+## 7. Backlog coverage
+
+Single atomic BI (BI-05208DE5). Phases are sequencing, not independently shippable products: Phase 2 (reconciler) has no value without Phase 1 (the shared executor it calls), and both ship in one PR as one behavioral fix. Coverage recorded via `record_plan_backlog_coverage` (`decision: "atomic"`).


### PR DESCRIPTION
## What & why

Build Studio builds stranded in `plan` — with a **complete plan + designDoc + a cached WWMD `recommend` decision** — never advanced to `build`, and the 30-minute auto-resume re-ran the entire expensive plan review every cycle **forever**. Because epic-decomposed children are exempt from the 7-day stranded age-out, the flood was **perpetual and never self-clearing**, and it wedged routine self-upgrade. Fixes **BI-05208DE5**.

## Root cause (live DB + sandbox verified)

- The cached `DecisionInteraction` rows are `outcomeType = "recommend"`, confidence `0.9` → the WWMD gate **authorizes** the transition. `phaseTo:build` in the `wwmd.idempotent.hit` trace is the *transition being gated*, not the verdict.
- The transition is coupled to `startBuildBranch` (in `reviewBuildPlan`'s advance block). It **threw** — the sandbox was down/churning during the self-upgrade wedge (`phase:gate-blocked — startBuildBranch failed: Command failed: docker exec 'dpf-sandbox-1' …`). The exception was caught, logged, and the phase never flipped.
- The 30-min auto-resume then re-ran the **entire** plan review (two reviewer model calls + a deliberation trail that stalls) and re-attempted the same transition — with **no failure counter, no backoff, no escalation**, and no age-out for epic children.
- Asymmetry that hid it: the manual `/api/agent/build/advance-phase` route flips the phase **directly** (no `startBuildBranch`), which is why a *forced* advance succeeded while the *routine* path stayed wedged.

On re-check the sandbox is healthy and the stuck builds' `build/FB-*` branches don't exist → the original `startBuildBranch` failure was **transient**.

## Change

- **Single source of truth:** extract the plan→build side-effect into `performPlanToBuildTransition` (`apps/web/lib/integrate/plan-to-build-transition.ts`), used by both `reviewBuildPlan` and the resume path. It runs the structural + dependency + WWMD gates, initializes the build branch before flipping the phase, and dispatches the build orchestrator.
- **Reconciler:** on resume, a build with a complete plan whose review already **passed** advances **directly** via the executor instead of re-minting a plan-review deliberation that stalls and floods.
- **Bounded escalation:** repeated transition failures are counted on `buildExecState.planAdvance`; past a threshold (default 3, `BUILD_PLAN_ADVANCE_ESCALATE_AFTER`) the build escalates (`phase:needs-operator`) and auto-resume stops re-attempting — the only thing that stops an age-out-exempt epic child from looping.

**Out of scope:** *why* the plan-review deliberation TaskRuns themselves bootstrap-then-stall (the orchestrator branch dispatch) is **BI-8C44DB49**; this reconciler starves that stall by not minting the deliberation.

## Verification

Substrate: source-only worktree using the root-clone toolchain (runtime-bound gates run in CI / the shared sandbox).

- **Typecheck: 0 errors across `apps/web`** (not skipped).
- **Unit tests green:** `plan-to-build-transition` (12) + `resume-pre-build-phase` (28); adjacent `build-branch` + `build-studio-gate` (33). New regression tests reproduce the stranded-with-complete-plan state and assert it advances, and that it bounded-escalates instead of looping.
- **No migration** — `buildExecState` is an existing `Json` field.

After this deploys via governed self-upgrade, the 8 builds ops-abandoned to stop the flood (`abandonReason` starting "Ops-abandoned to stop perpetual plan-phase resume flood") will be re-promoted to confirm they now advance.

Plan: `docs/superpowers/plans/2026-07-22-bi-05208de5-plan-to-build-reconciler.md`.

Design-Grounding-Decision: extends the existing plan→build advance in `apps/web/lib/mcp-tools.ts` and the auto-resume in `apps/web/lib/integrate/resume-pre-build-phase.ts`; specs/plans + code substrate named in the plan. No new UX/queue/nav/attention surface.
Docs-Impact-Decision: internal build-pipeline transition fix; no user-facing documented route changes.
Process-Spine-Decision: implementation plan authored at `docs/superpowers/plans/2026-07-22-bi-05208de5-plan-to-build-reconciler.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
