### PR TITLE
fix: harden Claude build engine readiness parsing

### DIFF
--- a/apps/web/lib/routing/capability-probes/engine-version-parser.ts
+++ b/apps/web/lib/routing/capability-probes/engine-version-parser.ts
@@ -1,0 +1,29 @@
+export type EngineVersionParseConfig = {
+  engineId: string;
+  binary: string;
+  versionRegex: string | RegExp;
+};
+
+function toRegExp(versionRegex: string | RegExp): RegExp {
+  return typeof versionRegex === "string" ? new RegExp(versionRegex) : versionRegex;
+}
+
+export function extractEngineVersion(
+  engine: EngineVersionParseConfig,
+  stdout: string,
+): string | null {
+  const regex = toRegExp(engine.versionRegex);
+  regex.lastIndex = 0;
+  const match = regex.exec(stdout);
+  if (match) return match[1] ?? match[0];
+
+  if (engine.binary === "claude" || engine.engineId === "claude") {
+    return (
+      /\b(\d+\.\d+\.\d+)\s+\(Claude Code\)(?:\s|$)/i.exec(stdout)?.[1] ??
+      /\bclaude-code\/(\d+\.\d+\.\d+)\b/i.exec(stdout)?.[1] ??
+      null
+    );
+  }
+
+  return null;
+}

--- a/apps/web/lib/routing/capability-probes/probe-engine-readiness.test.ts
+++ b/apps/web/lib/routing/capability-probes/probe-engine-readiness.test.ts
@@ -37,12 +37,20 @@ vi.mock("@/lib/shared/lazy-node", () => ({
 }));
 
 import { probeEngineReadiness, type EngineProbeConfig } from "./probe-engine-readiness";
+import { extractEngineVersion } from "./engine-version-parser";
 
 const GROK: EngineProbeConfig = {
   engineId: "grok",
   binary: "grok",
   verifyCommand: "grok --version",
   versionRegex: /(\d+\.\d+\.\d+)/,
+};
+
+const CLAUDE_WITH_STALE_REGISTRY_REGEX: EngineProbeConfig = {
+  engineId: "claude",
+  binary: "claude",
+  verifyCommand: "claude --version",
+  versionRegex: "claude[- ]cli[/ ]([0-9.]+)",
 };
 
 describe("probeEngineReadiness", () => {
@@ -99,5 +107,21 @@ describe("probeEngineReadiness", () => {
 
     expect(result.present).toBe(true);
     expect(result.version).toBe("0.4.1");
+  });
+
+  it("recognizes current Claude Code stdout even when the persisted registry regex is stale", async () => {
+    mockExec.mockResolvedValueOnce({ stdout: "2.1.215 (Claude Code)\n", stderr: "" });
+
+    const result = await probeEngineReadiness(CLAUDE_WITH_STALE_REGISTRY_REGEX);
+
+    expect(result.present).toBe(true);
+    expect(result.version).toBe("2.1.215");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("keeps malformed Claude stdout unparseable", () => {
+    expect(
+      extractEngineVersion(CLAUDE_WITH_STALE_REGISTRY_REGEX, "Claude Code\n"),
+    ).toBeNull();
   });
 });

--- a/apps/web/lib/routing/capability-probes/probe-engine-readiness.ts
+++ b/apps/web/lib/routing/capability-probes/probe-engine-readiness.ts
@@ -19,6 +19,8 @@
 
 import { lazyChildProcess, lazyUtil } from "@/lib/shared/lazy-node";
 
+import { extractEngineVersion } from "./engine-version-parser";
+
 const SANDBOX_CONTAINER = process.env.SANDBOX_CONTAINER_ID ?? "dpf-sandbox-1";
 const PROBE_TIMEOUT_MS = 10_000;
 
@@ -78,8 +80,8 @@ export async function probeEngineReadiness(engine: EngineProbeConfig): Promise<E
     };
   }
 
-  const match = regex.exec(stdout);
-  if (!match) {
+  const version = extractEngineVersion({ ...engine, versionRegex: regex }, stdout);
+  if (!version) {
     return {
       engineId: engine.engineId,
       present: false,
@@ -92,7 +94,7 @@ export async function probeEngineReadiness(engine: EngineProbeConfig): Promise<E
   return {
     engineId: engine.engineId,
     present: true,
-    version: match[1] ?? match[0],
+    version,
     probedAt,
   };
 }


### PR DESCRIPTION
## Summary
- add a pure build-engine version parser with Claude Code fallback formats
- route the shared sandbox readiness probe through that parser
- add regression coverage for stale Claude registry regex plus current Claude Code stdout

## Root cause
The live issue came from a stale BuildEngine.versionRegex that accepted older claude-cli output but rejected current stdout like 2.1.215 (Claude Code), making an installed Claude binary look absent.

## Validation
- node --experimental-strip-types parser check: passed
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web typecheck: passed
- live get_build_engine_readiness(refresh:true): Claude present=true, version=2.1.217 after self-upgrade

## Notes
Targeted local Vitest was blocked in this worktree by a corrupted hoisted Vitest package missing node_modules/vitest/dist/chunks/cac.D3xHeqeL.js before test discovery. The regression test is included for CI and a clean dependency graph to execute.

Docs impact: no user-facing docs needed; this is internal readiness parser hardening for an already documented Build Engine provisioning surface.