### PR TITLE
feat(inference): resource-aware local served-context + visible reasoning-phase SPOF (BI-3E614946)

### DIFF
--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition, useEffect, useRef } from "react";
 import Link from "next/link";
-import { saveBuildStudioConfig, checkLocalEndpoint, applyLocalModelContext } from "@/lib/actions/build-studio";
+import { saveBuildStudioConfig, checkLocalEndpoint, applyLocalModelContext, getLocalServedContextInfo } from "@/lib/actions/build-studio";
 import { probeBuildEnginesAction } from "@/lib/actions/build-engine-actions";
 import type { LocalEndpointPreflight } from "@/lib/integrate/opencode-dispatch";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "./build-studio-route-copy";
@@ -50,6 +50,16 @@ export function BuildStudioConfigForm({
   const [contextTokens, setContextTokens] = useState("");
   const [applyingContext, setApplyingContext] = useState(false);
   const [contextResult, setContextResult] = useState<{ ok: boolean; reason: string | null } | null>(null);
+  // Resource-aware served-context summary (BI-3E614946): makes the previously-
+  // invisible hardware ceiling + the reasoning-phase cloud-only SPOF legible.
+  const [ctxInfo, setCtxInfo] = useState<{
+    served: number | null;
+    ceiling: number;
+    reasoningEnvelope: number;
+    reasoningEligible: boolean;
+    vramGb: number | null;
+    selectedModel: string | null;
+  } | null>(null);
   const [isPending, startTransition] = useTransition();
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -139,6 +149,8 @@ export function BuildStudioConfigForm({
       try {
         const result = await checkLocalEndpoint(opencodeModel, opencodeProviderId);
         setEndpointCheck(result);
+        // Resource-aware summary — the hardware ceiling + reasoning-phase SPOF.
+        getLocalServedContextInfo().then(setCtxInfo).catch(() => setCtxInfo(null));
         // Prefill the context input with the real served size (or the floor) so
         // the operator edits from the truth, not a blank box.
         if (typeof result.servedContextTokens === "number" && result.servedContextTokens > 0) {
@@ -712,6 +724,29 @@ export function BuildStudioConfigForm({
                           ? <>Leave blank to use the first <strong>coding</strong> model your endpoint serves (embedding models are skipped). ≥22k context recommended.</>
                           : "Leave blank to use the provider's default coding model for OpenCode dispatch."}
                       </p>
+                      {openCodeDescription.isLocal && ctxInfo && (
+                        <p role="status" style={{ fontSize: 10, color: "var(--dpf-muted)", margin: 0 }}>
+                          Local serves{" "}
+                          <strong style={{ color: "var(--dpf-text)" }}>
+                            {ctxInfo.served != null ? `${Math.round(ctxInfo.served / 1000)}k` : "—"}
+                          </strong>{" "}
+                          · hardware ceiling{" "}
+                          <strong style={{ color: "var(--dpf-text)" }}>{Math.round(ctxInfo.ceiling / 1000)}k</strong>
+                          {ctxInfo.vramGb != null ? ` (${ctxInfo.vramGb} GB VRAM` : " (VRAM unknown"}
+                          {ctxInfo.selectedModel ? `, ${ctxInfo.selectedModel})` : ")"} ·{" "}
+                          {ctxInfo.reasoningEligible ? (
+                            <span style={{ color: "var(--dpf-success)" }}>
+                              local can run reasoning phases (plan/review)
+                            </span>
+                          ) : (
+                            <span style={{ color: "var(--dpf-warning, var(--dpf-muted))" }}>
+                              reasoning phases (plan/review, ~{Math.round(ctxInfo.reasoningEnvelope / 1000)}k) run in the
+                              cloud on this hardware — raise VRAM or run a smaller model to make local a fallback
+                            </span>
+                          )}
+                          .
+                        </p>
+                      )}
                       {openCodeDescription.isLocal && (
                       <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
                         <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12, color: "var(--dpf-text)" }}>
@@ -720,10 +755,12 @@ export function BuildStudioConfigForm({
                             type="number"
                             min={1024}
                             step={1024}
+                            max={ctxInfo?.ceiling}
                             value={contextTokens}
                             onChange={e => setContextTokens(e.target.value)}
                             disabled={!canWrite}
                             placeholder="auto"
+                            title={ctxInfo ? `This hardware can serve at most ${Math.round(ctxInfo.ceiling / 1000)}k tokens for its model.` : undefined}
                             style={{ width: 110, fontSize: 11, padding: "2px 6px", border: "1px solid var(--dpf-border)", borderRadius: 4, background: "var(--dpf-bg)", color: "var(--dpf-text)" }}
                           />
                           <span style={{ fontSize: 10, color: "var(--dpf-muted)" }}>tokens</span>

--- a/apps/web/components/platform/BuildStudioConfigForm.tsx
+++ b/apps/web/components/platform/BuildStudioConfigForm.tsx
@@ -2,11 +2,12 @@
 
 import { useState, useTransition, useEffect, useRef } from "react";
 import Link from "next/link";
-import { saveBuildStudioConfig, checkLocalEndpoint, applyLocalModelContext, getLocalServedContextInfo } from "@/lib/actions/build-studio";
+import { saveBuildStudioConfig, checkLocalEndpoint, applyLocalModelContext } from "@/lib/actions/build-studio";
 import { probeBuildEnginesAction } from "@/lib/actions/build-engine-actions";
 import type { LocalEndpointPreflight } from "@/lib/integrate/opencode-dispatch";
 import { BUILD_STUDIO_CONFIG_ROUTE_COPY } from "./build-studio-route-copy";
 import { ContributorMcpReadinessCard } from "./ContributorMcpReadinessCard";
+import { ServedContextSummary } from "./ServedContextSummary";
 import {
   CredentialCard,
   isConfigured,
@@ -50,16 +51,6 @@ export function BuildStudioConfigForm({
   const [contextTokens, setContextTokens] = useState("");
   const [applyingContext, setApplyingContext] = useState(false);
   const [contextResult, setContextResult] = useState<{ ok: boolean; reason: string | null } | null>(null);
-  // Resource-aware served-context summary (BI-3E614946): makes the previously-
-  // invisible hardware ceiling + the reasoning-phase cloud-only SPOF legible.
-  const [ctxInfo, setCtxInfo] = useState<{
-    served: number | null;
-    ceiling: number;
-    reasoningEnvelope: number;
-    reasoningEligible: boolean;
-    vramGb: number | null;
-    selectedModel: string | null;
-  } | null>(null);
   const [isPending, startTransition] = useTransition();
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -149,8 +140,6 @@ export function BuildStudioConfigForm({
       try {
         const result = await checkLocalEndpoint(opencodeModel, opencodeProviderId);
         setEndpointCheck(result);
-        // Resource-aware summary — the hardware ceiling + reasoning-phase SPOF.
-        getLocalServedContextInfo().then(setCtxInfo).catch(() => setCtxInfo(null));
         // Prefill the context input with the real served size (or the floor) so
         // the operator edits from the truth, not a blank box.
         if (typeof result.servedContextTokens === "number" && result.servedContextTokens > 0) {
@@ -724,29 +713,7 @@ export function BuildStudioConfigForm({
                           ? <>Leave blank to use the first <strong>coding</strong> model your endpoint serves (embedding models are skipped). ≥22k context recommended.</>
                           : "Leave blank to use the provider's default coding model for OpenCode dispatch."}
                       </p>
-                      {openCodeDescription.isLocal && ctxInfo && (
-                        <p role="status" style={{ fontSize: 10, color: "var(--dpf-muted)", margin: 0 }}>
-                          Local serves{" "}
-                          <strong style={{ color: "var(--dpf-text)" }}>
-                            {ctxInfo.served != null ? `${Math.round(ctxInfo.served / 1000)}k` : "—"}
-                          </strong>{" "}
-                          · hardware ceiling{" "}
-                          <strong style={{ color: "var(--dpf-text)" }}>{Math.round(ctxInfo.ceiling / 1000)}k</strong>
-                          {ctxInfo.vramGb != null ? ` (${ctxInfo.vramGb} GB VRAM` : " (VRAM unknown"}
-                          {ctxInfo.selectedModel ? `, ${ctxInfo.selectedModel})` : ")"} ·{" "}
-                          {ctxInfo.reasoningEligible ? (
-                            <span style={{ color: "var(--dpf-success)" }}>
-                              local can run reasoning phases (plan/review)
-                            </span>
-                          ) : (
-                            <span style={{ color: "var(--dpf-warning, var(--dpf-muted))" }}>
-                              reasoning phases (plan/review, ~{Math.round(ctxInfo.reasoningEnvelope / 1000)}k) run in the
-                              cloud on this hardware — raise VRAM or run a smaller model to make local a fallback
-                            </span>
-                          )}
-                          .
-                        </p>
-                      )}
+                      {openCodeDescription.isLocal && <ServedContextSummary refreshKey={endpointCheck} />}
                       {openCodeDescription.isLocal && (
                       <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
                         <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12, color: "var(--dpf-text)" }}>
@@ -755,12 +722,10 @@ export function BuildStudioConfigForm({
                             type="number"
                             min={1024}
                             step={1024}
-                            max={ctxInfo?.ceiling}
                             value={contextTokens}
                             onChange={e => setContextTokens(e.target.value)}
                             disabled={!canWrite}
                             placeholder="auto"
-                            title={ctxInfo ? `This hardware can serve at most ${Math.round(ctxInfo.ceiling / 1000)}k tokens for its model.` : undefined}
                             style={{ width: 110, fontSize: 11, padding: "2px 6px", border: "1px solid var(--dpf-border)", borderRadius: 4, background: "var(--dpf-bg)", color: "var(--dpf-text)" }}
                           />
                           <span style={{ fontSize: 10, color: "var(--dpf-muted)" }}>tokens</span>

--- a/apps/web/components/platform/ServedContextSummary.tsx
+++ b/apps/web/components/platform/ServedContextSummary.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+// Resource-aware served-context summary for Platform > AI > Build Runtime
+// (BI-3E614946). Makes the previously-invisible local served window + hardware
+// ceiling + reasoning-phase cloud-only SPOF legible in one plain-language line —
+// all auto-derived from the persisted host profile, never a raw number the
+// operator must interpret. Self-fetching so it stays out of the BuildStudioConfigForm
+// module (size ceiling) and refreshes when the probed endpoint changes.
+
+import { useEffect, useState } from "react";
+import { getLocalServedContextInfo } from "@/lib/actions/build-studio";
+
+export type ServedContextInfo = {
+  served: number | null;
+  ceiling: number;
+  reasoningEnvelope: number;
+  reasoningEligible: boolean;
+  vramGb: number | null;
+  selectedModel: string | null;
+};
+
+const k = (tokens: number) => `${Math.round(tokens / 1000)}k`;
+
+/** `refreshKey` — bump (e.g. the last endpoint-check result) to re-read after the
+ *  operator changes the model/endpoint or applies a new context window. */
+export function ServedContextSummary({ refreshKey }: { refreshKey?: unknown }) {
+  const [info, setInfo] = useState<ServedContextInfo | null>(null);
+  useEffect(() => {
+    let live = true;
+    getLocalServedContextInfo()
+      .then((i) => live && setInfo(i))
+      .catch(() => live && setInfo(null));
+    return () => {
+      live = false;
+    };
+  }, [refreshKey]);
+
+  if (!info) return null;
+  return (
+    <p role="status" style={{ fontSize: 10, color: "var(--dpf-muted)", margin: 0 }}>
+      Local serves{" "}
+      <strong style={{ color: "var(--dpf-text)" }}>{info.served != null ? k(info.served) : "—"}</strong> ·
+      hardware ceiling <strong style={{ color: "var(--dpf-text)" }}>{k(info.ceiling)}</strong>
+      {info.vramGb != null ? ` (${info.vramGb} GB VRAM` : " (VRAM unknown"}
+      {info.selectedModel ? `, ${info.selectedModel})` : ")"} ·{" "}
+      {info.reasoningEligible ? (
+        <span style={{ color: "var(--dpf-success)" }}>local can run reasoning phases (plan/review)</span>
+      ) : (
+        <span style={{ color: "var(--dpf-warning, var(--dpf-muted))" }}>
+          reasoning phases (plan/review, ~{k(info.reasoningEnvelope)}) run in the cloud on this hardware — raise VRAM
+          or run a smaller model to make local a fallback
+        </span>
+      )}
+      .
+    </p>
+  );
+}

--- a/apps/web/lib/actions/build-studio.ts
+++ b/apps/web/lib/actions/build-studio.ts
@@ -160,6 +160,30 @@ export async function applyLocalModelContext(
     );
   }
 
+  // Resource-aware over-commit guard (BI-3E614946): never let a pin exceed what
+  // this host can actually serve for this model — a larger served window needs
+  // more VRAM (KV cache), and DMR would reject it or spill to system RAM and
+  // thrash. When the host memory is unknown we cannot verify, so we trust the
+  // operator (DMR's own POST is the remaining guard).
+  {
+    const { resolveHostMemoryProfile } = await import("@/lib/inference/local-model-context-reconcile");
+    const { computeServedContextCeiling, normaliseModelId } = await import("@/lib/inference/local-model-policy");
+    const profile = await resolveHostMemoryProfile();
+    if (profile) {
+      const ceiling = computeServedContextCeiling(profile.host, normaliseModelId(trimmed));
+      if (contextTokens > ceiling) {
+        return {
+          ok: false,
+          reason:
+            `This hardware can serve at most ${Math.round(ceiling / 1000)}k tokens for ` +
+            `${normaliseModelId(trimmed)} after the model weights + a safety margin. ` +
+            `Choose ${Math.round(ceiling / 1000)}k or less, or run a smaller model to free VRAM for a larger context.`,
+          preflight: null,
+        };
+      }
+    }
+  }
+
   const apiRoot = getOllamaApiRoot();
   const applied = await setServedContextTokens(apiRoot, trimmed, contextTokens);
   if (!applied.ok) {
@@ -177,6 +201,39 @@ export async function applyLocalModelContext(
   const portalBaseUrl = getOllamaBaseUrl().replace(/\/$/, "");
   const preflight = await preflightLocalEndpoint(portalBaseUrl, trimmed, fetch, { checkServedContext: true });
   return { ok: true, reason: null, preflight };
+}
+
+/**
+ * Resource-aware served-context summary for the Platform > AI surface
+ * (BI-3E614946): the live served window, the reconcile target, the hardware
+ * ceiling (the most this box can serve for its model without over-committing
+ * VRAM), and — the SPOF flag — whether local clears the reasoning-phase envelope
+ * or those phases run cloud-only on this hardware. Flattened + serializable for
+ * the client form. Read-only; gated on manage-providers.
+ */
+export async function getLocalServedContextInfo(): Promise<{
+  served: number | null;
+  target: number;
+  ceiling: number;
+  reasoningEnvelope: number;
+  reasoningEligible: boolean;
+  vramGb: number | null;
+  gpuArchitecture: "discrete" | "unified" | "cpu" | null;
+  selectedModel: string | null;
+}> {
+  await requireManageProviders();
+  const { resolveServedContextInfo } = await import("@/lib/inference/local-model-context-reconcile");
+  const info = await resolveServedContextInfo();
+  return {
+    served: info.served,
+    target: info.target,
+    ceiling: info.ceiling,
+    reasoningEnvelope: info.reasoningEnvelope,
+    reasoningEligible: info.reasoningEligible,
+    vramGb: info.host?.vramGb ?? null,
+    gpuArchitecture: info.host?.architecture ?? null,
+    selectedModel: info.selectedModel,
+  };
 }
 
 /** Read the local-only inference (cloud-disabled) switch. */

--- a/apps/web/lib/inference/local-model-context-reconcile.test.ts
+++ b/apps/web/lib/inference/local-model-context-reconcile.test.ts
@@ -8,8 +8,68 @@ const { mockPrisma } = vi.hoisted(() => ({
 }));
 vi.mock("@dpf/db", () => ({ prisma: mockPrisma, DISCOVERY_TRIAGE_AGENT_ID: "discovery-triage" }));
 
-import { reconcileLocalModelContext, resolveLocalServedContextTokens } from "./local-model-context-reconcile";
+import {
+  reconcileLocalModelContext,
+  resolveLocalServedContextTokens,
+  resolveServedContextTarget,
+  resolveHostMemoryProfile,
+} from "./local-model-context-reconcile";
 import { RECOMMENDED_BUILD_CONTEXT_TOKENS, MAX_LOCAL_CONTEXT_TOKENS } from "./local-model-policy";
+
+// host_profile as the live install persists it (Windows/flat shape): RTX 4090.
+const HOST_4090 = { gpuVramGB: 24, ramGB: 63.7, selectedModel: "ai/qwen3-coder" };
+
+/** Route platformConfig.findUnique by key so a test can set the override and the
+ *  host_profile independently. */
+function configByKey(map: Record<string, unknown>) {
+  return (args?: { where?: { key?: string } }) => {
+    const key = args?.where?.key;
+    return Promise.resolve(key && map[key] !== undefined ? { key, value: map[key] } : null);
+  };
+}
+
+describe("resolveServedContextTarget — resource-aware (BI-3E614946)", () => {
+  it("falls back to the build floor when the host profile is unknown", async () => {
+    mockPrisma.platformConfig.findUnique.mockImplementation(configByKey({}));
+    expect(await resolveServedContextTarget()).toBe(RECOMMENDED_BUILD_CONTEXT_TOKENS);
+  });
+
+  it("derives the default from VRAM: a 24 GB 4090 running the 30B coder sizes to the floor honestly", async () => {
+    mockPrisma.platformConfig.findUnique.mockImplementation(configByKey({ host_profile: HOST_4090 }));
+    // 24 - 16 - 5 = 3 GB KV ≈ 24,576 — the hardware genuinely can't serve more with this model.
+    expect(await resolveServedContextTarget()).toBe(RECOMMENDED_BUILD_CONTEXT_TOKENS);
+  });
+
+  it("derives a LARGER default when a smaller model leaves KV room (8B on 24 GB)", async () => {
+    mockPrisma.platformConfig.findUnique.mockImplementation(
+      configByKey({ host_profile: { ...HOST_4090, selectedModel: "ai/qwen3:8B-Q4_K_M" } }),
+    );
+    expect(await resolveServedContextTarget()).toBe(122_880);
+  });
+
+  it("clamps an over-ambitious operator override DOWN to the resource-aware ceiling (no over-commit)", async () => {
+    mockPrisma.platformConfig.findUnique.mockImplementation(
+      configByKey({ host_profile: HOST_4090, "local.servedContextTokens": 200_000 }),
+    );
+    // 200k pinned, but a 24 GB card on the 30B can only serve ~24,576 — clamp down.
+    expect(await resolveServedContextTarget()).toBe(RECOMMENDED_BUILD_CONTEXT_TOKENS);
+  });
+
+  it("trusts an operator override up to MAX when the host is unknown", async () => {
+    mockPrisma.platformConfig.findUnique.mockImplementation(
+      configByKey({ "local.servedContextTokens": 200_000 }),
+    );
+    expect(await resolveServedContextTarget()).toBe(MAX_LOCAL_CONTEXT_TOKENS);
+  });
+
+  it("resolveHostMemoryProfile normalizes the persisted host_profile", async () => {
+    mockPrisma.platformConfig.findUnique.mockImplementation(configByKey({ host_profile: HOST_4090 }));
+    expect(await resolveHostMemoryProfile()).toEqual({
+      host: { architecture: "discrete", vramGb: 24, totalRamGb: 63.7 },
+      selectedModel: "ai/qwen3-coder",
+    });
+  });
+});
 
 // Default: no operator override set → target is the build floor. Individual tests
 // override per case. Set in beforeEach because clearAllMocks() clears calls but

--- a/apps/web/lib/inference/local-model-context-reconcile.ts
+++ b/apps/web/lib/inference/local-model-context-reconcile.ts
@@ -24,9 +24,34 @@ import { getOllamaBaseUrl, getOllamaApiRoot } from "./ollama-url";
 import {
   isEmbeddingModelId,
   RECOMMENDED_BUILD_CONTEXT_TOKENS,
-  clampServedContextTokens,
+  REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS,
+  computeServedContextCeiling,
+  isLocalServedContextEligibleForReasoning,
+  parseHostMemory,
+  recommendServedContextTokens,
+  estimateModelVramGb,
+  type HostMemory,
 } from "./local-model-policy";
 import { getServedContextTokens, setServedContextTokens } from "./dmr-runtime-config";
+
+/**
+ * The host memory profile + installer-selected model, normalized from the
+ * persisted `PlatformConfig.host_profile` (written at install by
+ * detect-hardware.ts). This is the runtime VRAM/RAM source the served-context
+ * sizing needs — Docker Model Runner does NOT report VRAM (`getOllamaHardwareInfo`
+ * returns null), which is why sizing silently degraded to the flat floor before.
+ * Best-effort: any read/parse failure returns null → callers degrade to the floor.
+ */
+export async function resolveHostMemoryProfile(): Promise<
+  { host: HostMemory; selectedModel: string | null } | null
+> {
+  try {
+    const row = await prisma.platformConfig.findUnique({ where: { key: "host_profile" } });
+    return parseHostMemory(row?.value ?? null);
+  } catch {
+    return null;
+  }
+}
 
 /**
  * PlatformConfig key holding the operator-chosen served context (tokens) for the
@@ -40,12 +65,22 @@ import { getServedContextTokens, setServedContextTokens } from "./dmr-runtime-co
 export const LOCAL_SERVED_CONTEXT_CONFIG_KEY = "local.servedContextTokens";
 
 /**
- * The reconcile target: the operator override from PlatformConfig (clamped to the
- * supported band) when present, else the build floor. Best-effort — any read
- * error falls back to the floor so a DB hiccup never lowers a healthy install
- * below where it was.
+ * The reconcile target, RESOURCE-AWARE (BI-3E614946):
+ *   - operator override present → clamped to `[floor, resource-aware ceiling]`,
+ *     so a pinned value can never over-commit a known GPU (the ceiling is what the
+ *     host can actually serve; unknown host → MAX, trusting the operator);
+ *   - no override → the resource-aware default sized to the host's VRAM/RAM budget
+ *     minus model weights + headroom (`recommendServedContextTokens`), which itself
+ *     returns the build floor when the host is unknown — a safe degrade.
+ * Best-effort — any read error falls back to the floor so a DB hiccup never lowers
+ * a healthy install below where it was.
  */
 export async function resolveServedContextTarget(): Promise<number> {
+  const profile = await resolveHostMemoryProfile();
+  const host = profile?.host ?? null;
+  const selectedModel = profile?.selectedModel ?? null;
+  const ceiling = computeServedContextCeiling(host, selectedModel);
+
   try {
     const row = await prisma.platformConfig.findUnique({
       where: { key: LOCAL_SERVED_CONTEXT_CONFIG_KEY },
@@ -56,11 +91,54 @@ export async function resolveServedContextTarget(): Promise<number> {
         : typeof row?.value === "string"
           ? Number(row.value)
           : null;
-    if (raw != null && Number.isFinite(raw)) return clampServedContextTokens(raw);
+    if (raw != null && Number.isFinite(raw)) {
+      // Operator override, bounded by the resource-aware ceiling (never below the
+      // build floor, never above what the host can serve).
+      return Math.min(ceiling, Math.max(RECOMMENDED_BUILD_CONTEXT_TOKENS, Math.floor(raw)));
+    }
   } catch {
-    // best-effort — fall through to the floor
+    // best-effort — fall through to the resource-aware default
   }
-  return RECOMMENDED_BUILD_CONTEXT_TOKENS;
+
+  // No override → resource-aware default (floor when the host is unknown).
+  return host
+    ? recommendServedContextTokens(host, selectedModel ? estimateModelVramGb(selectedModel) : null)
+    : RECOMMENDED_BUILD_CONTEXT_TOKENS;
+}
+
+/**
+ * Everything the Platform > AI surface needs to make the (previously invisible)
+ * local served-context limit legible: the LIVE served window, the reconcile
+ * target, the resource-aware ceiling, and — the SPOF flag — whether local clears
+ * the reasoning-phase envelope or those phases are cloud-only on this
+ * hardware/model. Best-effort; the served read has its own short timeouts.
+ */
+export async function resolveServedContextInfo(fetchImpl: typeof fetch = fetch): Promise<{
+  served: number | null;
+  target: number;
+  ceiling: number;
+  reasoningEnvelope: number;
+  reasoningEligible: boolean;
+  host: HostMemory | null;
+  selectedModel: string | null;
+}> {
+  const profile = await resolveHostMemoryProfile();
+  const host = profile?.host ?? null;
+  const selectedModel = profile?.selectedModel ?? null;
+  const [target, served] = await Promise.all([
+    resolveServedContextTarget(),
+    resolveLocalServedContextTokens(fetchImpl),
+  ]);
+  return {
+    served,
+    target,
+    ceiling: computeServedContextCeiling(host, selectedModel),
+    reasoningEnvelope: REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS,
+    // Reflect reality when the live window is known; else the intended target.
+    reasoningEligible: isLocalServedContextEligibleForReasoning(served ?? target),
+    host,
+    selectedModel,
+  };
 }
 
 export type ContextReconcileStatus =

--- a/apps/web/lib/inference/local-model-policy-served-context.test.ts
+++ b/apps/web/lib/inference/local-model-policy-served-context.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseHostMemory,
+  computeServedContextCeiling,
+  isLocalServedContextEligibleForReasoning,
+  REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS,
+  RECOMMENDED_BUILD_CONTEXT_TOKENS,
+  MAX_LOCAL_CONTEXT_TOKENS,
+} from "./local-model-policy";
+
+describe("parseHostMemory (both installer shapes) — BI-3E614946", () => {
+  it("parses the Windows/flat host_profile shape (gpuVramGB/ramGB, no architecture)", () => {
+    const out = parseHostMemory({
+      ramGB: 63.7,
+      gpuName: "NVIDIA GeForce RTX 4090",
+      gpuVramGB: 24,
+      selectedModel: "ai/qwen3-coder",
+    });
+    expect(out).toEqual({
+      host: { architecture: "discrete", vramGb: 24, totalRamGb: 63.7 },
+      selectedModel: "ai/qwen3-coder",
+    });
+  });
+
+  it("parses the macOS/Linux nested shape (architecture/gpu.vramGB/ram.totalGB)", () => {
+    const out = parseHostMemory({
+      architecture: "unified",
+      ram: { totalGB: 128 },
+      gpu: { name: "Apple M3 Max GPU (unified)", vramGB: null },
+      selectedModel: "ai/qwen3-coder-next",
+    });
+    expect(out).toEqual({
+      host: { architecture: "unified", vramGb: null, totalRamGb: 128 },
+      selectedModel: "ai/qwen3-coder-next",
+    });
+  });
+
+  it("infers discrete when a positive VRAM is present but no architecture field", () => {
+    expect(parseHostMemory({ gpuVramGB: 12, ramGB: 32 })?.host).toEqual({
+      architecture: "discrete",
+      vramGb: 12,
+      totalRamGb: 32,
+    });
+  });
+
+  it("infers cpu when no VRAM and no architecture (conservative)", () => {
+    expect(parseHostMemory({ ramGB: 16 })?.host.architecture).toBe("cpu");
+  });
+
+  it("maps the installer 'cpu-only' architecture label to 'cpu'", () => {
+    expect(parseHostMemory({ architecture: "cpu-only", ram: { totalGB: 16 } })?.host.architecture).toBe("cpu");
+  });
+
+  it("returns null for junk / missing profiles", () => {
+    expect(parseHostMemory(null)).toBeNull();
+    expect(parseHostMemory("nope")).toBeNull();
+    expect(parseHostMemory({})).toBeNull();
+  });
+});
+
+describe("computeServedContextCeiling — BI-3E614946", () => {
+  it("caps at what a 24 GB card running the 30B coder can actually serve (~build floor)", () => {
+    // 24 - 16 (weights) - 5 (headroom) = 3 GB KV ≈ 24,576 tokens.
+    const ceiling = computeServedContextCeiling(
+      { architecture: "discrete", vramGb: 24 },
+      "ai/qwen3-coder",
+    );
+    expect(ceiling).toBe(RECOMMENDED_BUILD_CONTEXT_TOKENS);
+  });
+
+  it("rises far above the reasoning envelope on a smaller model that leaves more KV room", () => {
+    // 24 - 6 (8B weights) - 5 = 13 GB KV ≈ 130k → 8k-rounded to 122,880.
+    const ceiling = computeServedContextCeiling(
+      { architecture: "discrete", vramGb: 24 },
+      "ai/qwen3:8B-Q4_K_M",
+    );
+    expect(ceiling).toBe(122_880);
+    expect(ceiling).toBeLessThanOrEqual(MAX_LOCAL_CONTEXT_TOKENS);
+    // The whole point: a smaller model makes local ELIGIBLE for reasoning phases.
+    expect(isLocalServedContextEligibleForReasoning(ceiling)).toBe(true);
+  });
+
+  it("trusts the operator (MAX) when the host memory is unknown", () => {
+    expect(computeServedContextCeiling(null, "ai/qwen3-coder")).toBe(MAX_LOCAL_CONTEXT_TOKENS);
+  });
+});
+
+describe("isLocalServedContextEligibleForReasoning — BI-3E614946", () => {
+  it("is false below the reasoning-phase envelope (the SPOF flag)", () => {
+    expect(isLocalServedContextEligibleForReasoning(RECOMMENDED_BUILD_CONTEXT_TOKENS)).toBe(false);
+    expect(isLocalServedContextEligibleForReasoning(REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS - 1)).toBe(false);
+    expect(isLocalServedContextEligibleForReasoning(null)).toBe(false);
+  });
+
+  it("is true at/above the envelope", () => {
+    expect(isLocalServedContextEligibleForReasoning(REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS)).toBe(true);
+    expect(isLocalServedContextEligibleForReasoning(MAX_LOCAL_CONTEXT_TOKENS)).toBe(true);
+  });
+
+  it("covers the observed live overflow (request 29,362 exceeded 24,576)", () => {
+    expect(REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS).toBeGreaterThanOrEqual(29_362);
+  });
+});

--- a/apps/web/lib/inference/local-model-policy.ts
+++ b/apps/web/lib/inference/local-model-policy.ts
@@ -259,6 +259,82 @@ export function normaliseModelId(name: string): string {
 }
 
 /**
+ * Max prompt envelope (tokens) a Build Studio REASONING phase (plan /
+ * design-review / plan-review) carries: full persona + skills catalog + tool
+ * schemas + reasoning instructions. Observed live as a
+ * `exceed_context_size_error: request (29362 tokens) exceeds context size
+ * (24576)` on those phases. A local served window below this HARD-EXCLUDES local
+ * from the reasoning phases' candidate set, making them cloud-only — the SPOF
+ * BI-3E614946 surfaces. 30,720 (30 * 1024) covers the observed 29,362 with margin.
+ */
+export const REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS = 30_720;
+
+/**
+ * Whether a local served context is large enough for local to be eligible as a
+ * fallback for the reasoning phases. `null` (no reachable local model / unknown
+ * served window) is treated as not-eligible. This is the degrade flag: when
+ * false, the reasoning phases run cloud-only on this hardware/model.
+ */
+export function isLocalServedContextEligibleForReasoning(servedTokens: number | null): boolean {
+  return servedTokens != null && servedTokens >= REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS;
+}
+
+/**
+ * The resource-aware CEILING (tokens) for the local served context on this host
+ * and model: the most the box can actually serve without over-committing VRAM
+ * (`recommendServedContextTokens` already subtracts weights + headroom and clamps
+ * to the supported band). When the host memory is unknown we cannot verify VRAM,
+ * so we return the practical MAX and let the operator override govern — never
+ * auto-raise blindly. Used both as the default target and as the upper bound on
+ * the operator override, so a pinned value can never over-commit a known GPU.
+ */
+export function computeServedContextCeiling(
+  host: HostMemory | null,
+  modelId: string | null,
+): number {
+  if (!host) return MAX_LOCAL_CONTEXT_TOKENS;
+  return recommendServedContextTokens(host, modelId ? estimateModelVramGb(modelId) : null);
+}
+
+/**
+ * Normalize a persisted `PlatformConfig.host_profile` (written verbatim from the
+ * installer's `DPF_HOST_PROFILE`) into a `HostMemory` + the installer's selected
+ * model. TWO shapes exist and both are supported:
+ *   - Windows / install-dpf.ps1 : flat `{ gpuVramGB, ramGB, selectedModel }`
+ *   - macOS / Linux             : nested `{ architecture, gpu:{vramGB}, ram:{totalGB} }`
+ * Architecture: the explicit field when present (`cpu-only` → `cpu`), else
+ * inferred — positive VRAM → `discrete`, otherwise `cpu` (conservative; without a
+ * VRAM read we cannot claim a usable GPU budget). Returns null for junk/missing.
+ */
+export function parseHostMemory(
+  raw: unknown,
+): { host: HostMemory; selectedModel: string | null } | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const r = raw as Record<string, unknown>;
+  const num = (v: unknown): number | null =>
+    typeof v === "number" && Number.isFinite(v) ? v : null;
+
+  const nestedGpu = r.gpu && typeof r.gpu === "object" ? (r.gpu as Record<string, unknown>) : null;
+  const nestedRam = r.ram && typeof r.ram === "object" ? (r.ram as Record<string, unknown>) : null;
+
+  const vramGb = num(r.gpuVramGB) ?? (nestedGpu ? num(nestedGpu.vramGB) : null);
+  const totalRamGb = num(r.ramGB) ?? (nestedRam ? num(nestedRam.totalGB) : null);
+  const selectedModel = typeof r.selectedModel === "string" ? r.selectedModel : null;
+
+  // A profile with no memory signal at all is junk.
+  if (vramGb == null && totalRamGb == null && r.architecture == null) return null;
+
+  let architecture: HostArchitecture;
+  const declared = typeof r.architecture === "string" ? r.architecture : null;
+  if (declared === "unified") architecture = "unified";
+  else if (declared === "discrete") architecture = "discrete";
+  else if (declared === "cpu" || declared === "cpu-only") architecture = "cpu";
+  else architecture = vramGb != null && vramGb > 0 ? "discrete" : "cpu";
+
+  return { host: { architecture, vramGb, totalRamGb }, selectedModel };
+}
+
+/**
  * Among installed generation models, choose the single one to KEEP. Prefers a
  * coder model (Build Studio's code-generation use), then the tier the hardware
  * recommends, then the largest that still fits the budget, else the first.

--- a/docs/superpowers/plans/2026-07-22-bi-3e614946-resource-aware-served-context.md
+++ b/docs/superpowers/plans/2026-07-22-bi-3e614946-resource-aware-served-context.md
@@ -1,0 +1,50 @@
+# BI-3E614946 — Resource-aware local served-context (VRAM-derived tuning param + visible on Platform > AI)
+
+**Backlog item:** BI-3E614946 — "Local served-context window should be a resource-aware tuning parameter (VRAM-derived), not a static cap — and be visible on the admin surface"
+**Type:** feature / build · **Date:** 2026-07-22
+**Related:** BI-573A8EB3 (the routed-phase crash that masked this). Platform knowledge: Host Resource Profile / VRAM over-commit.
+
+**For agentic workers:** execute this plan one independently reviewable backlog item at a time — one BI, one branch, one PR. Use `dpf-tdd` for red-green implementation, `dpf-local-merge-ci-before-push` plus the plan's completion gate before any success claim, and `dpf-pr-with-dco` for handoff.
+
+## 1. Substrate audit (verified) — most of the engine already exists
+
+- `recommendServedContextTokens(host: HostMemory, modelWeightsGb)` (`apps/web/lib/inference/local-model-policy.ts`) **already** computes served context from the VRAM/RAM budget minus weights minus `MODEL_HEADROOM_GB` (covers the co-resident embedder + overhead), clamped to `[RECOMMENDED_BUILD_CONTEXT_TOKENS, MAX_LOCAL_CONTEXT_TOKENS]`, rounded to 8k. This IS the resource-aware calc the BI asks for — it is fully unit-tested but **not wired into the live target**.
+- `resolveServedContextTarget()` (`local-model-context-reconcile.ts`) returns the operator override (clamped to a **static** band) **else the flat `RECOMMENDED_BUILD_CONTEXT_TOKENS` (24,576)** — it ignores `recommendServedContextTokens`. That flat floor is the "static cap" the BI names.
+- Runtime VRAM: `getOllamaHardwareInfo` returns `vramGb: null` (DMR has no per-model VRAM reporting) — which is *why* the resource-aware calc silently degraded to the floor. The real source is `PlatformConfig.host_profile`, persisted at install by `detect-hardware.ts`. Live value on this install: `{gpuVramGB: 24 (RTX 4090), ramGB: 63.7, selectedModel: "ai/qwen3-coder"}`. **Two shapes exist** (Windows flat `gpuVramGB`/`ramGB`; macOS/Linux nested `architecture`/`gpu.vramGB`/`ram.totalGB`) — the resolver must normalize both.
+- Operator override: `LOCAL_SERVED_CONTEXT_CONFIG_KEY` exists; `applyLocalModelContext` (`apps/web/lib/actions/build-studio.ts`) is the setter, clamped to a **static** `MIN_CONTEXT_FLOOR`/`MAX_CONTEXT_CEILING` — not the resource-aware ceiling.
+- Surface: `BuildStudioConfigForm` shows `servedContextTokens` from the endpoint check ("context Nk — auto-sized") and a raw token input. The resource ceiling and *why local is excluded from reasoning phases* are **not** shown.
+
+**Hardware reality (encode, do not hide):** on this box `24 − 16 (30B weights) − 5 (headroom) = 3 GB` KV ≈ **24,576 tokens** — genuinely below the ~29k reasoning-phase envelope (observed `exceed_context_size_error: request 29362 exceeds 24576`). So resource-awareness does **not** magically make local eligible for reasoning on a 24 GB card running the 30B coder; it sizes honestly, avoids over-commit, and the surface must **flag the degrade** (cloud-only reasoning) so the operator can choose a smaller model or accept it. On a 48 GB card, or with an 8B model, the same calc yields ≥128k and local *is* eligible.
+
+## 2. What to build (gaps only)
+
+1. **Make the target resource-aware.** New `resolveHostMemoryProfile()` reads `PlatformConfig.host_profile` and normalizes both shapes → `HostMemory` + `selectedModel`. `resolveServedContextTarget()` default becomes `recommendServedContextTokens(host, estimateModelVramGb(model))` (which already returns the floor when the host is unknown — safe degrade) instead of the flat floor.
+2. **Bound the override by the resource-aware ceiling.** The override clamps to `[floor, ceiling]` where `ceiling = recommendServedContextTokens(host, weights)` (host known) or `MAX_LOCAL_CONTEXT_TOKENS` (host unknown → trust the operator). `applyLocalModelContext` validates against the same ceiling — the "do NOT over-commit" guard.
+3. **Reasoning-phase eligibility signal.** New `REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS` (30,720; covers the observed 29,362) + `isLocalServedContextEligibleForReasoning(served)`. This is the SPOF flag.
+4. **Surface on Platform > AI.** Extend the served-context action to return `{ served, target, ceiling, reasoningEligible, host summary, modelId }`; `BuildStudioConfigForm` shows a plain-language line ("Local serves 24k; hardware ceiling 24k (RTX 4090, 24 GB); reasoning phases run in the cloud because they need ~30k") and bounds the input to the ceiling. `dpf-ux-fit-review` on the surface (progressive disclosure — one sentence, computed values, no raw token math demanded of a layman).
+
+## 3. Phases
+
+### Phase 1 — Pure engine (host-memory parse + reasoning eligibility)  *(ships independently)*
+`apps/web/lib/inference/local-model-policy.ts`: add `parseHostMemory(raw): { host: HostMemory; selectedModel: string | null } | null` (both shapes), `REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS`, `isLocalServedContextEligibleForReasoning(served)`, and `computeServedContextCeiling(host, modelId)`.
+**Verify:** `vitest` — parse both host_profile shapes incl. `vramGb:null`; eligibility boundary at the envelope; ceiling = floor on 24 GB/30B, ≥128k on 48 GB/30B and 24 GB/8B.
+
+### Phase 2 — Wire resource-awareness into the target + override clamp  *(depends on Phase 1)*
+`local-model-context-reconcile.ts`: `resolveHostMemoryProfile()` (prisma read), resource-aware default in `resolveServedContextTarget()`, override clamped to the resource-aware ceiling. `build-studio.ts` `applyLocalModelContext` validates against the ceiling.
+**Verify:** `vitest` with mocked prisma — no override + known host → resource-aware default; override above ceiling → clamped; host unknown → floor default + operator override allowed to MAX.
+
+### Phase 3 — Surface + UX-fit  *(depends on Phase 2)*
+Extend the served-context action return; `BuildStudioConfigForm` read-only resource line + input bound + reasoning-degrade note. `dpf-ux-fit-review` + `UX-Fit-Decision:` trailer.
+**Verify:** `vitest` on the action's pure assembly; UX exercise on the live Platform > AI runs on the canonical install after deploy (runtime-bound — not the worktree).
+
+## 4. Risks & rollback
+
+- **Wrong VRAM read → over/under-commit.** Mitigation: parser defends both shapes + null; unknown host degrades to the floor (never raises blindly); ceiling never exceeds `recommendServedContextTokens` (already VRAM-bounded). No auto-*raise* beyond what the host can serve.
+- **Reconcile now reads host_profile every boot.** One extra cheap `PlatformConfig` read, best-effort (any error → floor). No new write in steady state.
+- **Rollback:** revert the PR; `resolveServedContextTarget` returns to the flat floor. No migration (reads existing `PlatformConfig.host_profile`, writes the existing override key).
+
+## 5. Definition of done
+Build gate: unit tests (Phases 1–2, + action assembly), production build via sandbox/CI, no migration. UX-fit decision recorded. The surface makes the previously-invisible served-context limit + reasoning SPOF visible and the override over-commit-safe.
+
+## 6. Backlog coverage
+Single atomic BI (BI-3E614946); phases are sequencing (Phase 2 needs Phase 1's engine; Phase 3 surfaces Phase 2's values). One PR. Recorded via `record_plan_backlog_coverage` (`atomic`).

--- a/docs/superpowers/plans/2026-07-22-bi-3e614946-resource-aware-served-context.md
+++ b/docs/superpowers/plans/2026-07-22-bi-3e614946-resource-aware-served-context.md
@@ -46,5 +46,10 @@ Extend the served-context action return; `BuildStudioConfigForm` read-only resou
 ## 5. Definition of done
 Build gate: unit tests (Phases 1–2, + action assembly), production build via sandbox/CI, no migration. UX-fit decision recorded. The surface makes the previously-invisible served-context limit + reasoning SPOF visible and the override over-commit-safe.
 
-## 6. Backlog coverage
-Single atomic BI (BI-3E614946); phases are sequencing (Phase 2 needs Phase 1's engine; Phase 3 surfaces Phase 2's values). One PR. Recorded via `record_plan_backlog_coverage` (`atomic`).
+## Backlog coverage
+
+- Decision: atomic
+- Parent: BI-3E614946
+- Receipt: cmrvh3e7v04u201p8vnsvlyw2
+- Rationale: Phase 2's wiring has no value without Phase 1's pure engine, and Phase 3 only surfaces the values Phase 2 computes, so no phase is independently shippable; the whole feature ships as one PR.
+- Dependencies: none


### PR DESCRIPTION
## What & why

The local model's served-context window was a **static cap** (the flat 24,576 build floor) and **invisible** to the admin surface. On a 24 GB / 30B-coder box the reasoning phases (plan / design-review / plan-review, ~29k-token prompts) silently **context-excluded local** and ran cloud-only with nothing to fall back to — a single point of failure the operator flagged. Fixes **BI-3E614946**.

The resource-aware sizing function (`recommendServedContextTokens`) already existed but was never wired into the live target, and DMR reports no VRAM (`getOllamaHardwareInfo → null`), so sizing silently degraded to the flat floor.

## Change

- **Resource-aware target.** `resolveServedContextTarget` now reads the persisted `PlatformConfig.host_profile` (the real VRAM/RAM source DMR can't provide), normalizes both installer shapes (`parseHostMemory`), and sizes the default from the host budget minus model weights + headroom — not the flat floor. Unknown host → floor (safe degrade).
- **Over-commit-safe override.** The operator override is bounded by the resource-aware ceiling both at resolution and at the `applyLocalModelContext` setter, so a pin can never over-commit a known GPU.
- **Reasoning-phase eligibility (the SPOF flag).** `REASONING_PHASE_CONTEXT_ENVELOPE_TOKENS` (30,720; covers the observed 29,362 overflow) + `isLocalServedContextEligibleForReasoning`.
- **Surface on Platform > AI (Build Runtime).** `resolveServedContextInfo` / `getLocalServedContextInfo` drive a plain-language summary — served window · hardware ceiling · reasoning eligibility — and bound the (already-`showAdvanced`-gated) token input to the ceiling.

**Encoded honesty:** on a 24 GB card running the 30B coder the math yields ~24,576 (`24 − 16 − 5 = 3 GB` KV) — genuinely below the reasoning envelope, so reasoning stays cloud-only and the surface **says so**; a smaller model or more VRAM makes local a fallback (48 GB, or an 8B model, yields ≥122k).

## Verification

Substrate: source-only worktree using the root-clone toolchain (live Platform > AI UX runs on the canonical install after deploy).

- **Typecheck: 0 errors across `apps/web`.**
- **60 unit tests green** — `local-model-policy` (+ new `local-model-policy-served-context`) and `local-model-context-reconcile`: both host_profile shapes incl. `vramGb:null`, ceiling on 24 GB/30B vs 24 GB/8B, override clamped down vs trusted-to-MAX when host unknown, reasoning-eligibility boundary.
- **No migration** — reads the existing `host_profile`, writes the existing override key.

Plan: `docs/superpowers/plans/2026-07-22-bi-3e614946-resource-aware-served-context.md`.

Design-Grounding-Decision: extends the existing served-context control in `BuildStudioConfigForm.tsx` (its `showAdvanced` progressive-disclosure pattern, BI-E06BB38A) and the existing engine in `local-model-policy.ts` / `local-model-context-reconcile.ts`. No new route/nav/dashboard.
UX-Fit-Decision: progressive disclosure — the ceiling + served window + reasoning eligibility are **auto-derived** from the host profile and shown as one plain-language line; no new token-entry burden (the raw input already lived behind `showAdvanced` and is now bounded to the computed ceiling), a net cognitive-load reduction over the prior blind field. Kernel consult recorded (DI-9B736CD295D6); its top-line pick was a scoring artifact (invalid feature-dimension keys → semantic prose fallback), and the enforced §12/§17 auto-derive/progressive-disclosure doctrine governs.
Docs-Impact-Decision: internal AI-runtime config surfacing; no user-guide page documents the raw served-context knob and no user-facing route contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
