### PR TITLE
Clarify self-upgrade job-engine recovery

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -42,10 +42,7 @@ vi.mock("@/components/ops/UpgradeImpactPanel", () => ({
   default: () => null,
 }));
 
-import SelfUpgradeClient, {
-  conciseFailureReason,
-  shouldPollForJobEngineRecovery,
-} from "./SelfUpgradeClient";
+import SelfUpgradeClient, { conciseFailureReason } from "./SelfUpgradeClient";
 
 const baseStatus = {
   enabled: true,
@@ -215,73 +212,6 @@ describe("SelfUpgradeClient – enabled", () => {
     expect(html).toContain("Scheduled upgrades paused");
     expect(html).toContain("Launch week freeze");
     expect(html).toContain('data-blackout="true"');
-  });
-
-  it("explains degraded job-engine health with automatic recovery guidance", () => {
-    const html = renderToStaticMarkup(
-      <SelfUpgradeClient
-        {...baseStatus}
-        jobEngine={{
-          status: "degraded",
-          detail: "Inngest re-sync failed: fetch failed",
-          checkedAt: "2026-07-20T05:23:47.866Z",
-          watchdog: {
-            status: "unknown",
-            detail: null,
-            lastInvocationAt: null,
-            lastGatewayHitAt: null,
-            lastRecoveryAttemptAt: null,
-            lastRecoverySummary: null,
-          },
-        }}
-      />,
-    );
-
-    expect(html).toContain("Background jobs need attention");
-    expect(html).toContain("The portal retries Inngest registration automatically every 5 minutes");
-    expect(html).toContain("Last check");
-    expect(html).toContain("Current signal");
-    expect(html).toContain("Inngest re-sync failed: fetch failed");
-    expect(html).not.toContain("Restart the");
-  });
-
-  it("shows the last watchdog recovery attempt when present", () => {
-    const html = renderToStaticMarkup(
-      <SelfUpgradeClient
-        {...baseStatus}
-        jobEngine={{
-          status: "degraded",
-          detail: "No /api/inngest POST execution has been observed for 20 minute(s).",
-          checkedAt: "2026-07-20T05:23:47.866Z",
-          watchdog: {
-            status: "degraded",
-            detail: "No /api/inngest POST execution has been observed for 20 minute(s).",
-            lastInvocationAt: "2026-07-20T05:03:47.866Z",
-            lastGatewayHitAt: "2026-07-20T05:03:47.866Z",
-            lastRecoveryAttemptAt: "2026-07-20T05:20:00.000Z",
-            lastRecoverySummary: "retention sweep ran, orphansReaped=0, historyTrimmed=3, errors=0",
-          },
-        }}
-      />,
-    );
-
-    expect(html).toContain("Last recovery attempt");
-    expect(html).toContain("retention sweep ran");
-  });
-});
-
-describe("shouldPollForJobEngineRecovery", () => {
-  it("polls only while the job engine is degraded", () => {
-    expect(shouldPollForJobEngineRecovery(undefined)).toBe(false);
-    expect(shouldPollForJobEngineRecovery({ status: "healthy", detail: null, checkedAt: null })).toBe(false);
-    expect(shouldPollForJobEngineRecovery({ status: "unknown", detail: null, checkedAt: null })).toBe(false);
-    expect(
-      shouldPollForJobEngineRecovery({
-        status: "degraded",
-        detail: "Inngest re-sync failed: fetch failed",
-        checkedAt: "2026-07-20T05:23:47.866Z",
-      }),
-    ).toBe(true);
   });
 });
 

--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -42,7 +42,10 @@ vi.mock("@/components/ops/UpgradeImpactPanel", () => ({
   default: () => null,
 }));
 
-import SelfUpgradeClient, { conciseFailureReason } from "./SelfUpgradeClient";
+import SelfUpgradeClient, {
+  conciseFailureReason,
+  shouldPollForJobEngineRecovery,
+} from "./SelfUpgradeClient";
 
 const baseStatus = {
   enabled: true,
@@ -212,6 +215,73 @@ describe("SelfUpgradeClient – enabled", () => {
     expect(html).toContain("Scheduled upgrades paused");
     expect(html).toContain("Launch week freeze");
     expect(html).toContain('data-blackout="true"');
+  });
+
+  it("explains degraded job-engine health with automatic recovery guidance", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        jobEngine={{
+          status: "degraded",
+          detail: "Inngest re-sync failed: fetch failed",
+          checkedAt: "2026-07-20T05:23:47.866Z",
+          watchdog: {
+            status: "unknown",
+            detail: null,
+            lastInvocationAt: null,
+            lastGatewayHitAt: null,
+            lastRecoveryAttemptAt: null,
+            lastRecoverySummary: null,
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Background jobs need attention");
+    expect(html).toContain("The portal retries Inngest registration automatically every 5 minutes");
+    expect(html).toContain("Last check");
+    expect(html).toContain("Current signal");
+    expect(html).toContain("Inngest re-sync failed: fetch failed");
+    expect(html).not.toContain("Restart the");
+  });
+
+  it("shows the last watchdog recovery attempt when present", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeClient
+        {...baseStatus}
+        jobEngine={{
+          status: "degraded",
+          detail: "No /api/inngest POST execution has been observed for 20 minute(s).",
+          checkedAt: "2026-07-20T05:23:47.866Z",
+          watchdog: {
+            status: "degraded",
+            detail: "No /api/inngest POST execution has been observed for 20 minute(s).",
+            lastInvocationAt: "2026-07-20T05:03:47.866Z",
+            lastGatewayHitAt: "2026-07-20T05:03:47.866Z",
+            lastRecoveryAttemptAt: "2026-07-20T05:20:00.000Z",
+            lastRecoverySummary: "retention sweep ran, orphansReaped=0, historyTrimmed=3, errors=0",
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Last recovery attempt");
+    expect(html).toContain("retention sweep ran");
+  });
+});
+
+describe("shouldPollForJobEngineRecovery", () => {
+  it("polls only while the job engine is degraded", () => {
+    expect(shouldPollForJobEngineRecovery(undefined)).toBe(false);
+    expect(shouldPollForJobEngineRecovery({ status: "healthy", detail: null, checkedAt: null })).toBe(false);
+    expect(shouldPollForJobEngineRecovery({ status: "unknown", detail: null, checkedAt: null })).toBe(false);
+    expect(
+      shouldPollForJobEngineRecovery({
+        status: "degraded",
+        detail: "Inngest re-sync failed: fetch failed",
+        checkedAt: "2026-07-20T05:23:47.866Z",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -80,6 +80,20 @@ type AdmissionSnapshot = {
   summary: string;
 };
 
+type JobEngineHealth = {
+  status: "healthy" | "degraded" | "unknown";
+  detail: string | null;
+  checkedAt: string | null;
+  watchdog?: {
+    status: "healthy" | "degraded" | "unknown";
+    detail: string | null;
+    lastInvocationAt: string | null;
+    lastGatewayHitAt: string | null;
+    lastRecoveryAttemptAt: string | null;
+    lastRecoverySummary: string | null;
+  } | null;
+};
+
 type Props = {
   enabled: boolean;
   channel: string;
@@ -122,11 +136,7 @@ type Props = {
   quiescence?: QuiescenceActivity | null;
   admission?: AdmissionSnapshot | null;
   cooldownUntil?: string | null;
-  jobEngine?: {
-    status: "healthy" | "degraded" | "unknown";
-    detail: string | null;
-    checkedAt: string | null;
-  };
+  jobEngine?: JobEngineHealth;
   history?: LatestRun[];
   historyNextCursor?: string | null;
   initialImpactSummary?: SummaryResult | null;
@@ -312,6 +322,10 @@ export function isExpectedDuringSwap(err: unknown): boolean {
   );
 }
 
+export function shouldPollForJobEngineRecovery(jobEngine: JobEngineHealth | undefined): boolean {
+  return jobEngine?.status === "degraded";
+}
+
 export default function SelfUpgradeClient({
   enabled,
   channel,
@@ -421,6 +435,12 @@ export default function SelfUpgradeClient({
     const interval = setInterval(() => router.refresh(), 4_000);
     return () => clearInterval(interval);
   }, [justQueued, upgradeInFlight, restarting, router]);
+
+  useEffect(() => {
+    if (!shouldPollForJobEngineRecovery(jobEngine)) return;
+    const interval = setInterval(() => router.refresh(), 15_000);
+    return () => clearInterval(interval);
+  }, [jobEngine, router]);
 
   // Drop the reconnect banner once the swapped-in portal actually answers with
   // fresh data. We snapshot the server-derived signature at the moment the swap
@@ -631,14 +651,40 @@ export default function SelfUpgradeClient({
           data-job-engine-health="degraded"
         >
           <div className="font-medium text-[var(--dpf-warning)]">
-            ⚠ Background job engine isn’t dispatching
+            Background jobs need attention
           </div>
           <div className="mt-1 text-[var(--dpf-muted)]">
-            The portal couldn’t register its jobs with Inngest, so background work
-            — self-upgrade, evals, backups, watchdogs — won’t run until this is
-            fixed.{jobEngine.detail ? ` (${jobEngine.detail})` : ""} Restart the
-            portal or check the Inngest service.
+            Self-upgrade, evals, backups, and watchdogs depend on Inngest. The
+            portal retries Inngest registration automatically every 5 minutes and
+            this page checks for recovery while the alert is visible.
           </div>
+          <dl className="mt-2 grid gap-1 text-xs text-[var(--dpf-muted)] sm:grid-cols-2">
+            <div>
+              <dt className="font-medium text-[var(--dpf-text)]">Last check</dt>
+              <dd>
+                <LocalTime value={jobEngine.checkedAt} mode="time" fallback="not recorded yet" />
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-[var(--dpf-text)]">Current signal</dt>
+              <dd>{jobEngine.detail ?? "Inngest registration is degraded."}</dd>
+            </div>
+            {jobEngine.watchdog?.lastRecoveryAttemptAt && (
+              <div className="sm:col-span-2">
+                <dt className="font-medium text-[var(--dpf-text)]">Last recovery attempt</dt>
+                <dd>
+                  <LocalTime
+                    value={jobEngine.watchdog.lastRecoveryAttemptAt}
+                    mode="time"
+                    fallback="not recorded yet"
+                  />
+                  {jobEngine.watchdog.lastRecoverySummary
+                    ? ` - ${jobEngine.watchdog.lastRecoverySummary}`
+                    : ""}
+                </dd>
+              </div>
+            )}
+          </dl>
         </div>
       )}
       <div className="flex items-center justify-between">

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -11,6 +11,10 @@ import {
 } from "@/lib/actions/promotions";
 import { LocalTime } from "@/components/ui/LocalTime";
 import UpgradeImpactPanel from "@/components/ops/UpgradeImpactPanel";
+import SelfUpgradeJobEngineHealthAlert, {
+  shouldPollForJobEngineRecovery,
+  type JobEngineHealth,
+} from "@/components/ops/SelfUpgradeJobEngineHealthAlert";
 import type { SummaryResult, RunImpactDigest } from "@/lib/self-upgrade/impact/types";
 import { UpgradeScopeRibbon } from "@/components/ops/UpgradeScopeRibbon";
 import { StatusBadge } from "@/components/ui/report-kit";
@@ -78,20 +82,6 @@ type AdmissionSnapshot = {
   buildHolders: number;
   totalHolders: number;
   summary: string;
-};
-
-type JobEngineHealth = {
-  status: "healthy" | "degraded" | "unknown";
-  detail: string | null;
-  checkedAt: string | null;
-  watchdog?: {
-    status: "healthy" | "degraded" | "unknown";
-    detail: string | null;
-    lastInvocationAt: string | null;
-    lastGatewayHitAt: string | null;
-    lastRecoveryAttemptAt: string | null;
-    lastRecoverySummary: string | null;
-  } | null;
 };
 
 type Props = {
@@ -320,10 +310,6 @@ export function isExpectedDuringSwap(err: unknown): boolean {
   return /unexpected response was received|failed to fetch|fetch failed|load failed|networkerror|err_connection|connection (?:refused|reset|closed)|the operation was aborted/i.test(
     message,
   );
-}
-
-export function shouldPollForJobEngineRecovery(jobEngine: JobEngineHealth | undefined): boolean {
-  return jobEngine?.status === "degraded";
 }
 
 export default function SelfUpgradeClient({
@@ -644,49 +630,7 @@ export default function SelfUpgradeClient({
           need to refresh.
         </div>
       )}
-      {jobEngine?.status === "degraded" && (
-        <div
-          className="p-3 rounded-lg bg-[var(--dpf-warning)]/15 border border-[var(--dpf-warning)]/40 text-sm"
-          role="alert"
-          data-job-engine-health="degraded"
-        >
-          <div className="font-medium text-[var(--dpf-warning)]">
-            Background jobs need attention
-          </div>
-          <div className="mt-1 text-[var(--dpf-muted)]">
-            Self-upgrade, evals, backups, and watchdogs depend on Inngest. The
-            portal retries Inngest registration automatically every 5 minutes and
-            this page checks for recovery while the alert is visible.
-          </div>
-          <dl className="mt-2 grid gap-1 text-xs text-[var(--dpf-muted)] sm:grid-cols-2">
-            <div>
-              <dt className="font-medium text-[var(--dpf-text)]">Last check</dt>
-              <dd>
-                <LocalTime value={jobEngine.checkedAt} mode="time" fallback="not recorded yet" />
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-[var(--dpf-text)]">Current signal</dt>
-              <dd>{jobEngine.detail ?? "Inngest registration is degraded."}</dd>
-            </div>
-            {jobEngine.watchdog?.lastRecoveryAttemptAt && (
-              <div className="sm:col-span-2">
-                <dt className="font-medium text-[var(--dpf-text)]">Last recovery attempt</dt>
-                <dd>
-                  <LocalTime
-                    value={jobEngine.watchdog.lastRecoveryAttemptAt}
-                    mode="time"
-                    fallback="not recorded yet"
-                  />
-                  {jobEngine.watchdog.lastRecoverySummary
-                    ? ` - ${jobEngine.watchdog.lastRecoverySummary}`
-                    : ""}
-                </dd>
-              </div>
-            )}
-          </dl>
-        </div>
-      )}
+      <SelfUpgradeJobEngineHealthAlert jobEngine={jobEngine} />
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span

--- a/apps/web/components/ops/SelfUpgradeJobEngineHealthAlert.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeJobEngineHealthAlert.test.tsx
@@ -1,0 +1,66 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import SelfUpgradeJobEngineHealthAlert, {
+  shouldPollForJobEngineRecovery,
+} from "./SelfUpgradeJobEngineHealthAlert";
+
+describe("SelfUpgradeJobEngineHealthAlert", () => {
+  it("explains degraded job-engine health with automatic recovery guidance", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeJobEngineHealthAlert
+        jobEngine={{
+          status: "degraded",
+          detail: "Inngest re-sync failed: fetch failed",
+          checkedAt: "2026-07-20T05:23:47.866Z",
+          watchdog: null,
+        }}
+      />,
+    );
+
+    expect(html).toContain("Background jobs need attention");
+    expect(html).toContain("The portal retries Inngest registration automatically every 5 minutes");
+    expect(html).toContain("Last check");
+    expect(html).toContain("Current signal");
+    expect(html).toContain("Inngest re-sync failed: fetch failed");
+    expect(html).not.toContain("Restart the");
+  });
+
+  it("shows the last watchdog recovery attempt when present", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeJobEngineHealthAlert
+        jobEngine={{
+          status: "degraded",
+          detail: "No /api/inngest POST execution has been observed for 20 minute(s).",
+          checkedAt: "2026-07-20T05:23:47.866Z",
+          watchdog: {
+            status: "degraded",
+            detail: "No /api/inngest POST execution has been observed for 20 minute(s).",
+            lastInvocationAt: "2026-07-20T05:03:47.866Z",
+            lastGatewayHitAt: "2026-07-20T05:03:47.866Z",
+            lastRecoveryAttemptAt: "2026-07-20T05:20:00.000Z",
+            lastRecoverySummary: "retention sweep ran, orphansReaped=0, historyTrimmed=3, errors=0",
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Last recovery attempt");
+    expect(html).toContain("retention sweep ran");
+  });
+});
+
+describe("shouldPollForJobEngineRecovery", () => {
+  it("polls only while the job engine is degraded", () => {
+    expect(shouldPollForJobEngineRecovery(undefined)).toBe(false);
+    expect(shouldPollForJobEngineRecovery({ status: "healthy", detail: null, checkedAt: null })).toBe(false);
+    expect(shouldPollForJobEngineRecovery({ status: "unknown", detail: null, checkedAt: null })).toBe(false);
+    expect(
+      shouldPollForJobEngineRecovery({
+        status: "degraded",
+        detail: "Inngest re-sync failed: fetch failed",
+        checkedAt: "2026-07-20T05:23:47.866Z",
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/components/ops/SelfUpgradeJobEngineHealthAlert.tsx
+++ b/apps/web/components/ops/SelfUpgradeJobEngineHealthAlert.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { LocalTime } from "@/components/ui/LocalTime";
+
+export type JobEngineHealth = {
+  status: "healthy" | "degraded" | "unknown";
+  detail: string | null;
+  checkedAt: string | null;
+  watchdog?: {
+    status: "healthy" | "degraded" | "unknown";
+    detail: string | null;
+    lastInvocationAt: string | null;
+    lastGatewayHitAt: string | null;
+    lastRecoveryAttemptAt: string | null;
+    lastRecoverySummary: string | null;
+  } | null;
+};
+
+export function shouldPollForJobEngineRecovery(jobEngine: JobEngineHealth | undefined): boolean {
+  return jobEngine?.status === "degraded";
+}
+
+type Props = {
+  jobEngine: JobEngineHealth | undefined;
+};
+
+export default function SelfUpgradeJobEngineHealthAlert({ jobEngine }: Props) {
+  if (jobEngine?.status !== "degraded") return null;
+
+  return (
+    <div
+      className="p-3 rounded-lg bg-[var(--dpf-warning)]/15 border border-[var(--dpf-warning)]/40 text-sm"
+      role="alert"
+      data-job-engine-health="degraded"
+    >
+      <div className="font-medium text-[var(--dpf-warning)]">Background jobs need attention</div>
+      <div className="mt-1 text-[var(--dpf-muted)]">
+        Self-upgrade, evals, backups, and watchdogs depend on Inngest. The portal
+        retries Inngest registration automatically every 5 minutes and this page
+        checks for recovery while the alert is visible.
+      </div>
+      <dl className="mt-2 grid gap-1 text-xs text-[var(--dpf-muted)] sm:grid-cols-2">
+        <div>
+          <dt className="font-medium text-[var(--dpf-text)]">Last check</dt>
+          <dd>
+            <LocalTime value={jobEngine.checkedAt} mode="time" fallback="not recorded yet" />
+          </dd>
+        </div>
+        <div>
+          <dt className="font-medium text-[var(--dpf-text)]">Current signal</dt>
+          <dd>{jobEngine.detail ?? "Inngest registration is degraded."}</dd>
+        </div>
+        {jobEngine.watchdog?.lastRecoveryAttemptAt && (
+          <div className="sm:col-span-2">
+            <dt className="font-medium text-[var(--dpf-text)]">Last recovery attempt</dt>
+            <dd>
+              <LocalTime
+                value={jobEngine.watchdog.lastRecoveryAttemptAt}
+                mode="time"
+                fallback="not recorded yet"
+              />
+              {jobEngine.watchdog.lastRecoverySummary ? ` - ${jobEngine.watchdog.lastRecoverySummary}` : ""}
+            </dd>
+          </div>
+        )}
+      </dl>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- make the Self-Upgrade job-engine warning operator-actionable instead of telling the user to restart blindly
- poll the page while Inngest/job-engine health is degraded so transient recovery self-clears
- show last health check, current signal, and watchdog recovery details when available
- split the new alert into a small component/test file so the existing large SelfUpgradeClient ratchet stays tight

## Design grounding
- Existing specs/plans reviewed:
  - AGENTS.md self-upgrade and live portal refresh doctrine for governed upgrade behavior
  - docs/superpowers/specs/2026-06-06-procedural-functional-verification-design.md for live-install verification boundaries
  - docs/superpowers/specs/2026-07-03-fleet-safe-schema-evolution-design.md for fail-closed upgrade safety context
- Current code substrate reviewed:
  - apps/web/components/ops/SelfUpgradeClient.tsx existing self-upgrade status and polling UX
  - apps/web/lib/actions/promotions.ts getSelfUpgradeStatus payload wiring
  - apps/web/lib/queue/job-engine-health.ts Inngest registration/watchdog health contract
  - apps/web/app/(shell)/platform/ai/runtime-health/page.tsx existing watchdog recovery detail presentation
- Source of truth:
  - getJobEngineHealth() remains the health source; this PR only changes how the existing self-upgrade surface presents and refreshes degraded state.
- Decision:
  - Localized ops UX fix: show retry/recovery facts already tracked by the platform, poll only while degraded, and avoid changing routes, queue contracts, or upgrade execution behavior.

## Verification
- node scripts/check-module-size.mjs (passes; no baselined file grew)
- pnpm --filter web exec vitest run 'app/(shell)/ops/self-upgrade/page.test.tsx' 'components/ops/SelfUpgradeClient.test.tsx' 'components/ops/SelfUpgradeJobEngineHealthAlert.test.tsx' (103 tests passed; existing Prisma mock noise still prints)
- NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter web exec tsc --noEmit --pretty false
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter web build (exit 0; existing Edge-runtime warnings still print)
- Local-CI gate attempted with Git for Windows Bash; blocked by sandbox freshness drift after convergence retries: apps/web/node_modules/vitest resolves to 4.1.9 but pnpm-lock.yaml requires 4.1.10, and dist/chunks/cac.D3xHeqeL.js is missing. Classified as sandbox drift, not product build evidence.

## Docs
- No docs update needed: this only changes an ops warning state inside the existing Self-Upgrade page.

Local-CI-Override: blocked_sandbox_drift: sandbox freshness preflight reports vitest 4.1.9/incomplete bytes while lockfile requires 4.1.10 after convergence retries