### PR TITLE
feat(deps): standing stale-override audit — flag redundant pnpm floors on a schedule (BI-CDB2E8AB)

### DIFF
--- a/.github/workflows/audit-stale-overrides.yml
+++ b/.github/workflows/audit-stale-overrides.yml
@@ -1,0 +1,115 @@
+name: Stale Override Audit
+
+# Standing prune discipline for the pnpm `overrides:` block (BI-CDB2E8AB, spec
+# §7.4). Cross-checks each TAGGED security floor against the GitHub Dependabot
+# alerts API — "is the advisory that justified this floor still open?" — and
+# reports the floors whose alert is resolved as prune CANDIDATES. It PROPOSES;
+# a human/agent verifies each prune via the §7.1 prune screen (pnpm regen:lockfile)
+# before removing anything. Never edits overrides.
+#
+# Relies on the Override Provenance Guard tag convention
+# (scripts/check-override-comments.mjs). Floors with no machine-readable tag are
+# reported as un-auditable so the tag gets backfilled.
+#
+# See docs/superpowers/specs/2026-07-21-dependency-sovereignty-and-supply-chain-intake-hardening-design.md §7.
+
+on:
+  schedule:
+    - cron: "23 7 1 * *" # monthly, 1st — floors go redundant slowly
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "pnpm-workspace.yaml"
+      - "scripts/audit-stale-overrides.mjs"
+      - "scripts/audit-stale-overrides.test.mjs"
+      - "scripts/check-override-comments.mjs"
+      - ".github/workflows/audit-stale-overrides.yml"
+
+permissions:
+  contents: read
+  security-events: read # read Dependabot alerts
+  issues: write # open/update the prune tracking issue
+
+concurrency:
+  group: stale-override-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Stale override audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24
+
+      # Unit-test the pure classifier + the parser it shares with the guard.
+      - name: Unit tests
+        run: node --test scripts/audit-stale-overrides.test.mjs scripts/check-override-comments.test.mjs
+
+      - name: Audit stale overrides
+        # On scheduled/manual runs require the API (a silent skip would hide that
+        # the audit didn't run). On PRs, tolerate an outage so a transient blip
+        # can't block unrelated merges — it degrades to tag-coverage only.
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_ALERTS_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          FLAGS=""
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            FLAGS="--require-online"
+          fi
+          node scripts/audit-stale-overrides.mjs $FLAGS
+
+      - name: Publish report to the run summary
+        if: always()
+        run: |
+          { test -f sbom/stale-override-audit.md && cat sbom/stale-override-audit.md; } >> "$GITHUB_STEP_SUMMARY" || echo "No stale-override report produced." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: stale-override-audit-${{ github.run_id }}
+          path: |
+            sbom/stale-override-audit.json
+            sbom/stale-override-audit.md
+          if-no-files-found: warn
+          retention-days: 90
+
+      # File the finding: on scheduled runs, if there are prune candidates, open
+      # (or comment on) a single tracking issue. This is the CI-native "file a BI"
+      # — a human/agent triages it into the DPF backlog and runs the prune screen.
+      - name: File prune-candidate tracking issue
+        if: github.event_name == 'schedule'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('sbom/stale-override-audit.json','utf8')).candidates.length)")
+          if [ "$COUNT" = "0" ]; then
+            echo "No prune candidates — nothing to file."
+            exit 0
+          fi
+          TITLE="chore(deps): stale override floor(s) ready to prune"
+          BODY_FILE="$(mktemp)"
+          {
+            echo "The monthly stale-override audit found **$COUNT** override floor(s) whose justifying Dependabot advisory is no longer open — prune candidates."
+            echo ""
+            echo "Verify each via the §7.1 prune screen (\`pnpm regen:lockfile\` against a fresh store) before removing. Do NOT bulk-remove."
+            echo ""
+            cat sbom/stale-override-audit.md
+            echo ""
+            echo "_Filed by .github/workflows/audit-stale-overrides.yml — run ${{ github.run_id }}._"
+          } > "$BODY_FILE"
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file "$BODY_FILE"
+            echo "Commented on existing issue #$EXISTING."
+          else
+            gh issue create --title "$TITLE" --body-file "$BODY_FILE"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,8 @@ services/adp/pnpm-lock.yaml
 /sbom/provenance-audit.md
 /sbom/internalization-candidates.json
 /sbom/internalization-candidates.md
+/sbom/stale-override-audit.json
+/sbom/stale-override-audit.md
 
 # Python bytecode caches
 __pycache__/

--- a/docs/superpowers/specs/2026-07-21-dependency-sovereignty-and-supply-chain-intake-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-21-dependency-sovereignty-and-supply-chain-intake-hardening-design.md
@@ -160,6 +160,8 @@ Editing the `overrides:` block makes pnpm re-resolve the **whole** tree. On a de
 
 Pruning once is not enough — floors re-accumulate. Add a periodic (e.g. monthly, or Dependabot-triggered) **stale-override audit** that runs §7.1 across the whole block and files a BI listing newly-redundant floors. This keeps the control surface legible by construction. Each floor comment should already name its `Dependabot #NN` / GHSA id (PR #3357 established this convention) so the audit can machine-check "is this alert still open?".
 
+**Shipped (`BI-CDB2E8AB`):** `scripts/audit-stale-overrides.mjs` (alias `pnpm audit:stale-overrides`) reuses the Override Provenance Guard's parser to read every floor's advisory tag, cross-checks each against the GitHub Dependabot alerts API, and classifies floors as *prune candidate* (advisory no longer open — verify via §7.1), *load-bearing* (advisory still open), *indeterminate*, or *un-auditable* (security floor with no machine-readable tag → backfill it). It runs monthly via `.github/workflows/audit-stale-overrides.yml`, which files a tracking issue when candidates exist. Report-only and graceful-offline (no token → tag-coverage half only), so fully-local installs still get useful output. It **proposes**; a human/agent runs the per-floor prune screen before removing anything — never auto-edits overrides.
+
 ---
 
 ## 8. Roadmap

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:bundle-boundaries": "node scripts/check-bundle-boundaries.mjs",
     "check:diagram-dependency-pins": "node scripts/check-diagram-dependency-pins.mjs",
     "check:override-comments": "node scripts/check-override-comments.mjs && node --test scripts/check-override-comments.test.mjs",
+    "audit:stale-overrides": "node scripts/audit-stale-overrides.mjs",
     "regen:lockfile": "node scripts/regen-lockfile.mjs",
     "check:reporting-composition": "node scripts/check-reporting-composition.mjs",
     "check:n1-caller-honesty": "node scripts/check-n-minus-one-caller-honesty.mjs",

--- a/scripts/audit-stale-overrides.mjs
+++ b/scripts/audit-stale-overrides.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+// scripts/audit-stale-overrides.mjs
+//
+// Standing stale-override audit (BI-CDB2E8AB) — the periodic guard that keeps the
+// `overrides:` control surface legible by construction. A CVE security floor is
+// dead weight the moment the direct/parent dependency naturally resolves to a
+// patched version on its own; nobody removes floors, so the block only grows
+// (spec §7.4). This audit cross-checks each TAGGED floor against the GitHub
+// Dependabot alerts API — "is the advisory that justified this floor still open?"
+// — and reports the floors whose alert is no longer open as prune CANDIDATES.
+//
+// It PROPOSES; a human/agent VERIFIES each prune via the §7.1 per-floor prune
+// screen (regen against a fresh store) before removing anything — exactly the
+// BI-316CCCD7 discipline. It never edits overrides.
+//
+// Relies on the Override Provenance Guard's tag convention
+// (scripts/check-override-comments.mjs): every security floor carries a
+// `Dependabot #NN` / `GHSA-…` / `CVE-…` id. Floors without a machine-readable tag
+// (grandfathered debt) are reported as UN-AUDITABLE so the tag gets backfilled.
+//
+// Report-only by default (exit 0). Graceful offline: with no token or an
+// unreachable API it emits the parse-only half (tag coverage) and skips the
+// cross-check, so a fully-local run still produces useful output.
+//
+// Usage:
+//   node scripts/audit-stale-overrides.mjs                 # report (CI / manual)
+//   node scripts/audit-stale-overrides.mjs --require-online # fail if API unreachable (scheduled)
+//   node scripts/audit-stale-overrides.mjs --fail-on-candidates # exit 1 if any candidate found
+//
+// Auth: GITHUB_TOKEN (or GH_TOKEN) with `security_events: read` on the repo.
+// Repo: GITHUB_REPOSITORY (owner/name), else parsed from the origin remote is the
+// workflow's job — pass --repo owner/name to override.
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseOverrides } from "./check-override-comments.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const OUT = join(ROOT, "sbom");
+const API = (process.env.GITHUB_API_URL ?? "https://api.github.com").replace(/\/$/, "");
+
+// A Dependabot alert is "no longer justifying a floor" when it is not open.
+const RESOLVED_STATES = new Set(["fixed", "dismissed", "auto_dismissed"]);
+
+/**
+ * Normalize a raw advisory tag string into a lookup key.
+ * @param {string} raw e.g. "Dependabot #105", "GHSA-frvp-7c67-39w9", "CVE-2026-33327"
+ * @returns {{ type: "dependabot"|"ghsa"|"cve", key: string, label: string } | null}
+ */
+export function normalizeTag(raw) {
+  const dependabot = raw.match(/Dependabot #(\d+)/i);
+  if (dependabot) return { type: "dependabot", key: `#${dependabot[1]}`, label: raw.trim() };
+  const ghsa = raw.match(/GHSA-[0-9a-z]{4,}-[0-9a-z]{4,}-[0-9a-z]{4,}/i);
+  if (ghsa) return { type: "ghsa", key: ghsa[0].toLowerCase(), label: ghsa[0] };
+  const cve = raw.match(/CVE-\d{4}-\d{4,}/i);
+  if (cve) return { type: "cve", key: cve[0].toLowerCase(), label: cve[0] };
+  return null;
+}
+
+/**
+ * Build a lookup from advisory id → alert state out of the raw Dependabot alerts.
+ * Each alert is indexed by its number (#NN), GHSA id, and CVE id so any tag form
+ * resolves.
+ * @param {Array<{number:number,state:string,security_advisory?:{ghsa_id?:string,cve_id?:string}}>} alerts
+ * @returns {Map<string,string>} lookup key → state
+ */
+export function buildAlertLookup(alerts) {
+  const lookup = new Map();
+  for (const a of alerts) {
+    if (typeof a.number === "number") lookup.set(`#${a.number}`, a.state);
+    const ghsa = a.security_advisory?.ghsa_id;
+    if (ghsa) lookup.set(ghsa.toLowerCase(), a.state);
+    const cve = a.security_advisory?.cve_id;
+    if (cve) lookup.set(cve.toLowerCase(), a.state);
+  }
+  return lookup;
+}
+
+/**
+ * Classify every override floor against the alert lookup. Pure.
+ * @param {Array<{key:string,tags:string[],classification:string}>} entries from parseOverrides
+ * @param {Map<string,string>|null} lookup null = cross-check unavailable (offline)
+ * @returns {{ loadBearing: object[], candidates: object[], unauditable: object[], unknown: object[] }}
+ */
+export function classifyFloors(entries, lookup) {
+  const loadBearing = [];
+  const candidates = [];
+  const unauditable = [];
+  const unknown = [];
+
+  for (const e of entries) {
+    // Only security floors are auditable. Dedup/compat/pattern pins are not CVE
+    // floors — they never go "redundant" on advisory grounds, so skip them.
+    if (e.classification === "dedup-exempt" || e.classification === "pattern-exempt") continue;
+
+    // A security floor with no machine-readable tag can't be cross-checked.
+    if (e.tags.length === 0) {
+      unauditable.push({ key: e.key, reason: e.classification });
+      continue;
+    }
+
+    if (!lookup) continue; // offline: reported separately as "cross-check skipped"
+
+    const resolutions = e.tags
+      .map((t) => normalizeTag(t))
+      .filter(Boolean)
+      .map((n) => ({ ...n, state: lookup.get(n.key) ?? "not-found" }));
+
+    const anyOpen = resolutions.some((r) => r.state === "open");
+    const anyFound = resolutions.some((r) => r.state !== "not-found");
+    const allResolved = anyFound && resolutions.every((r) => RESOLVED_STATES.has(r.state));
+
+    const row = { key: e.key, tags: resolutions };
+    if (anyOpen) loadBearing.push(row);
+    else if (allResolved) candidates.push(row);
+    else unknown.push(row); // some tags not found & none open — can't confirm either way
+  }
+
+  return { loadBearing, candidates, unauditable, unknown };
+}
+
+// ---- I/O layer (network; not exercised by unit tests) --------------------
+
+async function fetchAllDependabotAlerts({ repo, token }) {
+  const alerts = [];
+  for (let page = 1; page <= 20; page++) {
+    const url = `${API}/repos/${repo}/dependabot/alerts?per_page=100&state=all&page=${page}`;
+    const res = await fetch(url, {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+      },
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status} ${res.statusText}`);
+    const batch = await res.json();
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    alerts.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return alerts;
+}
+
+function renderReport({ result, lookup, repo, scanned }) {
+  const L = [];
+  L.push("# DPF Stale-Override Audit");
+  L.push("");
+  L.push(
+    `_Generated ${new Date().toISOString().slice(0, 10)} · ${scanned} overrides scanned` +
+      `${repo ? ` · repo ${repo}` : ""} · ${lookup ? "cross-checked against Dependabot alerts" : "cross-check SKIPPED (offline / no token)"}._`,
+  );
+  L.push("");
+  L.push("> Reports override floors whose justifying advisory is no longer open —");
+  L.push("> prune CANDIDATES. Proposes only; verify each via the §7.1 prune screen");
+  L.push("> (`pnpm regen:lockfile`) before removing. Never auto-edits overrides.");
+  L.push("");
+  L.push("## Summary");
+  L.push("");
+  L.push(`- **${result.candidates.length}** prune candidate(s) — advisory resolved; re-run the prune screen.`);
+  L.push(`- **${result.loadBearing.length}** load-bearing — advisory still open; keep.`);
+  L.push(`- **${result.unknown.length}** indeterminate — advisory not found in alerts; needs review.`);
+  L.push(`- **${result.unauditable.length}** un-auditable — security floor with no machine-readable tag; backfill the tag.`);
+  L.push("");
+
+  if (result.candidates.length) {
+    L.push("## Prune candidates (advisory resolved)");
+    L.push("");
+    L.push("| Override | Advisory state |");
+    L.push("| --- | --- |");
+    for (const r of result.candidates) {
+      L.push(`| \`${r.key}\` | ${r.tags.map((t) => `${t.label}: ${t.state}`).join("; ")} |`);
+    }
+    L.push("");
+  }
+  if (result.unauditable.length) {
+    L.push("## Un-auditable (backfill the advisory tag)");
+    L.push("");
+    L.push("| Override | Kind |");
+    L.push("| --- | --- |");
+    for (const r of result.unauditable) L.push(`| \`${r.key}\` | ${r.reason} |`);
+    L.push("");
+  }
+  if (result.unknown.length) {
+    L.push("## Indeterminate (advisory id not found among alerts)");
+    L.push("");
+    L.push("| Override | Tags |");
+    L.push("| --- | --- |");
+    for (const r of result.unknown) {
+      L.push(`| \`${r.key}\` | ${r.tags.map((t) => `${t.label}: ${t.state}`).join("; ")} |`);
+    }
+    L.push("");
+  }
+  return L.join("\n");
+}
+
+async function run() {
+  const argv = process.argv.slice(2);
+  const requireOnline = argv.includes("--require-online");
+  const failOnCandidates = argv.includes("--fail-on-candidates");
+  const repoArg = argv.find((a) => a.startsWith("--repo="));
+  const repo = repoArg ? repoArg.slice("--repo=".length) : process.env.GITHUB_REPOSITORY || "";
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "";
+
+  const text = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8");
+  const { entries, scanned } = parseOverrides(text);
+
+  let lookup = null;
+  if (repo && token) {
+    try {
+      const alerts = await fetchAllDependabotAlerts({ repo, token });
+      lookup = buildAlertLookup(alerts);
+    } catch (err) {
+      const msg = `stale-override audit: Dependabot alerts unreachable (${err?.message || err}).`;
+      if (requireOnline) {
+        process.stderr.write(`::error::${msg}\n`);
+        process.exit(2);
+      }
+      process.stdout.write(`SKIPPED cross-check: ${msg} Set GITHUB_REPOSITORY + GITHUB_TOKEN (security_events: read).\n`);
+    }
+  } else if (requireOnline) {
+    process.stderr.write("::error::stale-override audit: --require-online set but GITHUB_REPOSITORY / GITHUB_TOKEN missing.\n");
+    process.exit(2);
+  } else {
+    process.stdout.write("Cross-check skipped: no GITHUB_REPOSITORY + GITHUB_TOKEN. Reporting tag coverage only.\n");
+  }
+
+  const result = classifyFloors(entries, lookup);
+  const report = renderReport({ result, lookup, repo, scanned });
+
+  mkdirSync(OUT, { recursive: true });
+  writeFileSync(join(OUT, "stale-override-audit.json"), JSON.stringify({ generatedAt: new Date().toISOString(), repo, crossChecked: Boolean(lookup), scanned, ...result }, null, 2));
+  writeFileSync(join(OUT, "stale-override-audit.md"), report);
+
+  process.stdout.write(
+    [
+      `Stale-override audit: ${scanned} overrides scanned.`,
+      `  prune candidates: ${result.candidates.length}`,
+      `  load-bearing:     ${result.loadBearing.length}`,
+      `  indeterminate:    ${result.unknown.length}`,
+      `  un-auditable:     ${result.unauditable.length}`,
+      `Report: ${join(OUT, "stale-override-audit.md")}`,
+      "",
+    ].join("\n"),
+  );
+
+  if (failOnCandidates && result.candidates.length > 0) {
+    process.stderr.write(`::error::${result.candidates.length} stale override floor(s) — advisory resolved, prune-screen them.\n`);
+    process.exit(1);
+  }
+}
+
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (invokedDirectly) {
+  run().catch((err) => {
+    process.stderr.write(`::error::audit-stale-overrides failed: ${err?.stack || err}\n`);
+    process.exit(2);
+  });
+}

--- a/scripts/audit-stale-overrides.test.mjs
+++ b/scripts/audit-stale-overrides.test.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseOverrides } from "./check-override-comments.mjs";
+import { normalizeTag, buildAlertLookup, classifyFloors } from "./audit-stale-overrides.mjs";
+
+const wrap = (body) => `packages:\n  - "apps/*"\noverrides:\n${body}\nallowBuilds:\n  sharp: true\n`;
+
+test("normalizeTag parses the three advisory forms and rejects junk", () => {
+  assert.deepEqual(normalizeTag("Dependabot #105"), { type: "dependabot", key: "#105", label: "Dependabot #105" });
+  assert.equal(normalizeTag("GHSA-abcd-abcd-abcd").type, "ghsa");
+  assert.equal(normalizeTag("GHSA-ABCD-ABCD-ABCD").key, "ghsa-abcd-abcd-abcd"); // lowercased
+  assert.equal(normalizeTag("CVE-2026-33327").key, "cve-2026-33327");
+  assert.equal(normalizeTag("just some prose"), null);
+});
+
+test("buildAlertLookup indexes an alert by number, GHSA, and CVE", () => {
+  const lookup = buildAlertLookup([
+    { number: 105, state: "fixed", security_advisory: { ghsa_id: "GHSA-abcd-abcd-abcd", cve_id: "CVE-2026-1" } },
+  ]);
+  assert.equal(lookup.get("#105"), "fixed");
+  assert.equal(lookup.get("ghsa-abcd-abcd-abcd"), "fixed");
+  assert.equal(lookup.get("cve-2026-1"), "fixed");
+});
+
+test("a floor whose advisory is fixed is a prune candidate", () => {
+  const { entries } = parseOverrides(
+    wrap(["  # foo: GHSA-abcd-abcd-abcd rce (high).", "  foo: '^1.2.3'"].join("\n")),
+  );
+  const lookup = buildAlertLookup([{ number: 1, state: "fixed", security_advisory: { ghsa_id: "GHSA-abcd-abcd-abcd" } }]);
+  const res = classifyFloors(entries, lookup);
+  assert.deepEqual(res.candidates.map((c) => c.key), ["foo"]);
+  assert.equal(res.loadBearing.length, 0);
+});
+
+test("a floor whose advisory is still open is load-bearing", () => {
+  const { entries } = parseOverrides(
+    wrap(["  # bar: GHSA-abcd-abcd-abcd rce (high).", "  bar: '^2.0.0'"].join("\n")),
+  );
+  const lookup = buildAlertLookup([{ number: 1, state: "open", security_advisory: { ghsa_id: "GHSA-abcd-abcd-abcd" } }]);
+  const res = classifyFloors(entries, lookup);
+  assert.deepEqual(res.loadBearing.map((c) => c.key), ["bar"]);
+  assert.equal(res.candidates.length, 0);
+});
+
+test("multiple tags with any one open keeps the floor load-bearing", () => {
+  const { entries } = parseOverrides(
+    wrap(["  # baz: GHSA-aaaa-aaaa-aaaa and GHSA-bbbb-bbbb-bbbb.", "  baz: '^3.0.0'"].join("\n")),
+  );
+  const lookup = buildAlertLookup([
+    { number: 1, state: "fixed", security_advisory: { ghsa_id: "GHSA-aaaa-aaaa-aaaa" } },
+    { number: 2, state: "open", security_advisory: { ghsa_id: "GHSA-bbbb-bbbb-bbbb" } },
+  ]);
+  const res = classifyFloors(entries, lookup);
+  assert.deepEqual(res.loadBearing.map((c) => c.key), ["baz"]);
+});
+
+test("a tagged floor whose advisory is absent from alerts is indeterminate, not a candidate", () => {
+  const { entries } = parseOverrides(
+    wrap(["  # qux: GHSA-zzzz-zzzz-zzzz.", "  qux: '^1.0.0'"].join("\n")),
+  );
+  const res = classifyFloors(entries, buildAlertLookup([]));
+  assert.deepEqual(res.unknown.map((c) => c.key), ["qux"]);
+  assert.equal(res.candidates.length, 0, "must not propose pruning when we can't confirm resolution");
+});
+
+test("a security floor with no machine-readable tag is un-auditable", () => {
+  // node-forge is grandfathered debt with no tag → cannot be cross-checked.
+  const { entries } = parseOverrides(wrap("  node-forge: '1.4.0'"));
+  const res = classifyFloors(entries, buildAlertLookup([]));
+  assert.deepEqual(res.unauditable.map((c) => c.key), ["node-forge"]);
+});
+
+test("dedup / pattern pins are skipped entirely (never advisory-redundant)", () => {
+  const { entries } = parseOverrides(wrap(["  lodash: '4.18.0'", "  jest: '^30.0.0'"].join("\n")));
+  const res = classifyFloors(entries, buildAlertLookup([{ number: 1, state: "fixed" }]));
+  assert.equal(res.candidates.length, 0);
+  assert.equal(res.loadBearing.length, 0);
+  assert.equal(res.unauditable.length, 0);
+  assert.equal(res.unknown.length, 0);
+});
+
+test("offline (null lookup): tagged floors are neither candidate nor load-bearing; untagged still surfaces", () => {
+  const { entries } = parseOverrides(
+    wrap(["  # foo: GHSA-abcd-abcd-abcd.", "  foo: '^1.2.3'", "  node-forge: '1.4.0'"].join("\n")),
+  );
+  const res = classifyFloors(entries, null);
+  assert.equal(res.candidates.length, 0);
+  assert.equal(res.loadBearing.length, 0);
+  assert.equal(res.unknown.length, 0);
+  assert.deepEqual(res.unauditable.map((c) => c.key), ["node-forge"]);
+});
+
+test("the live pnpm-workspace.yaml parses and classifies without throwing", () => {
+  // Offline classification over the real file — proves the parser + classifier
+  // agree on the live overrides block (the guard already asserts tag coverage).
+  const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const text = readFileSync(join(root, "pnpm-workspace.yaml"), "utf8");
+  const { entries, scanned } = parseOverrides(text);
+  assert.ok(scanned > 0);
+  const res = classifyFloors(entries, null);
+  // node-forge is grandfathered debt (no tag) → must surface as un-auditable.
+  assert.ok(res.unauditable.some((r) => r.key === "node-forge"), "node-forge should be un-auditable until its tag is backfilled");
+});

--- a/scripts/check-override-comments.mjs
+++ b/scripts/check-override-comments.mjs
@@ -61,13 +61,44 @@ const GRANDFATHERED_DEBT = new Set([
 // tags the whole contiguous run). Keyed explicitly so the sibling still counts.
 const COVERED_BY_SIBLING = new Set(["minimatch@9.0.9>brace-expansion"]);
 
+// Global variant of TAG_RE for extracting EVERY advisory id on a line/comment
+// (TAG_RE itself only tests presence). Kept in lock-step with TAG_RE.
+const TAG_RE_GLOBAL = new RegExp(TAG_RE.source, "gi");
+
+/** Extract every advisory id (Dependabot #NN / GHSA / CVE) from a set of strings. */
+function extractTags(strings) {
+  const out = [];
+  for (const s of strings) {
+    const found = s.match(TAG_RE_GLOBAL);
+    if (found) out.push(...found);
+  }
+  return out;
+}
+
 /**
- * Audit the overrides block. Pure — takes the file text, returns the list of
- * override keys that are security-shaped but carry no machine-readable provenance.
- * @param {string} text pnpm-workspace.yaml contents
- * @returns {{ untagged: string[], scanned: number }}
+ * Classify a single override key. Precedence matches the original guard exactly:
+ * a machine-readable advisory tag wins first, then the exempt/grandfathered/
+ * covered/pattern buckets, else it is an untagged security floor (the failure set).
+ * @returns {"tagged"|"dedup-exempt"|"grandfathered"|"covered-by-sibling"|"pattern-exempt"|"untagged"}
  */
-export function auditOverrides(text) {
+function classifyOverride(key, tags) {
+  if (tags.length > 0) return "tagged";
+  if (EXEMPT_DEDUP.has(key)) return "dedup-exempt";
+  if (GRANDFATHERED_DEBT.has(key)) return "grandfathered";
+  if (COVERED_BY_SIBLING.has(key)) return "covered-by-sibling";
+  if (EXEMPT_PATTERNS.some((re) => re.test(key))) return "pattern-exempt";
+  return "untagged";
+}
+
+/**
+ * Parse the `overrides:` block into structured entries. Shared substrate: the
+ * Override Provenance Guard (`auditOverrides`) and the stale-override audit
+ * (scripts/audit-stale-overrides.mjs) both consume this so the YAML walk lives
+ * in exactly one place (single-source-of-truth).
+ * @param {string} text pnpm-workspace.yaml contents
+ * @returns {{ entries: Array<{ key: string, tags: string[], classification: string }>, scanned: number }}
+ */
+export function parseOverrides(text) {
   const lines = text.split(/\r?\n/);
   const start = lines.findIndex((l) => /^overrides:\s*$/.test(l));
   if (start === -1) throw new Error("no `overrides:` block found");
@@ -79,8 +110,7 @@ export function auditOverrides(text) {
     }
   }
 
-  const untagged = [];
-  let scanned = 0;
+  const entries = [];
   let comments = [];
   for (let i = start + 1; i < end; i++) {
     const line = lines[i];
@@ -99,16 +129,25 @@ export function auditOverrides(text) {
       continue;
     }
     const key = m[2].trim();
-    scanned++;
-    const tagged = TAG_RE.test(line) || comments.some((c) => TAG_RE.test(c));
+    const tags = extractTags([line, ...comments]);
+    entries.push({ key, tags, classification: classifyOverride(key, tags) });
     comments = [];
-    if (tagged) continue;
-    if (EXEMPT_DEDUP.has(key)) continue;
-    if (GRANDFATHERED_DEBT.has(key)) continue;
-    if (COVERED_BY_SIBLING.has(key)) continue;
-    if (EXEMPT_PATTERNS.some((re) => re.test(key))) continue;
-    untagged.push(key);
   }
+  return { entries, scanned: entries.length };
+}
+
+/**
+ * Audit the overrides block. Pure — takes the file text, returns the list of
+ * override keys that are security-shaped but carry no machine-readable provenance.
+ * Thin wrapper over {@link parseOverrides} so behavior stays identical.
+ * @param {string} text pnpm-workspace.yaml contents
+ * @returns {{ untagged: string[], scanned: number }}
+ */
+export function auditOverrides(text) {
+  const { entries, scanned } = parseOverrides(text);
+  const untagged = entries
+    .filter((e) => e.classification === "untagged")
+    .map((e) => e.key);
   return { untagged, scanned };
 }
 


### PR DESCRIPTION
## What

Phase B of `EP-DEP-SOVEREIGNTY` — resolves **BI-CDB2E8AB**. Adds the standing prune discipline that keeps the pnpm `overrides:` control surface legible: a scheduled audit that flags floors whose justifying advisory is no longer open.

## How it works

`scripts/audit-stale-overrides.mjs` (alias `pnpm audit:stale-overrides`):
- **Reuses the guard's parser** — refactored a shared `parseOverrides()` into `scripts/check-override-comments.mjs` so the YAML walk lives in one place (`single-source-of-truth`). The Override Provenance Guard's behavior and its 10 tests are unchanged.
- **Cross-checks each tagged floor** (`Dependabot #NN` / GHSA / CVE) against the GitHub Dependabot alerts API and classifies it: **prune candidate** (advisory no longer open → verify via the §7.1 prune screen), **load-bearing** (still open), **indeterminate**, or **un-auditable** (security floor with no machine-readable tag → backfill it).
- **Report-only + graceful-offline**: no token → emits the tag-coverage half and skips the cross-check, so fully-local / air-gapped runs still produce useful output.
- **Proposes; never edits overrides.** A human/agent runs the per-floor prune screen (`pnpm regen:lockfile`) before removing anything — the BI-316CCCD7 discipline.

`.github/workflows/audit-stale-overrides.yml` runs it monthly (and on PRs touching the overrides/scripts), publishes the report to the run summary + an artifact, and files a single tracking issue when candidates exist.

## Verification

- `node --test` — 10 new cases over the pure classifier + parser (fixtures + a fake alert lookup, **no network**); the guard's 10 tests stay green → **20/20**.
- Offline run over the live tree correctly reports the **5 un-auditable** grandfathered-debt floors (`node-forge`, `postcss`, `protobufjs`, `ws`, `minimatch>brace-expansion` sibling).
- `sbom/stale-override-audit.{json,md}` artifacts gitignored, consistent with the sibling provenance/dependency-scan reports.

## Seam

This is the **prevention/intake** epic's hygiene tool. It reads the same Dependabot alert state the detection side (`EP-ASSURANCE-LEDGER`) tracks, but only to decide "can this floor be pruned?" — it does not duplicate SBOM/SCA. Spec §7.4 updated to record it as shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
