### PR TITLE
docs(plan): canonical Backlog coverage heading for the merged BI-05208DE5 plan

### DIFF
--- a/docs/superpowers/plans/2026-07-22-bi-05208de5-plan-to-build-reconciler.md
+++ b/docs/superpowers/plans/2026-07-22-bi-05208de5-plan-to-build-reconciler.md
@@ -81,6 +81,10 @@ Single source of truth: extract the transition side-effect from `reviewBuildPlan
 - Regression test reproduces the stranded-with-complete-plan state and asserts it advances (and bounded-escalates).
 - After deploy via governed self-upgrade: re-promote the 8 builds whose `abandonReason` starts "Ops-abandoned to stop perpetual plan-phase resume flood" and confirm they advance out of `plan` — the BI's gating acceptance.
 
-## 7. Backlog coverage
+## Backlog coverage
 
-Single atomic BI (BI-05208DE5). Phases are sequencing, not independently shippable products: Phase 2 (reconciler) has no value without Phase 1 (the shared executor it calls), and both ship in one PR as one behavioral fix. Coverage recorded via `record_plan_backlog_coverage` (`decision: "atomic"`).
+- Decision: atomic
+- Parent: BI-05208DE5
+- Receipt: cmrvgaj4403w101p8dljox040
+- Rationale: Phase 2 (the resume reconciler) has no value without Phase 1 (the shared performPlanToBuildTransition executor it calls); both ship in one PR as one behavioral fix, so no phase is independently shippable.
+- Dependencies: none


### PR DESCRIPTION
## What & why

PR #3365 (BI-05208DE5) landed its implementation plan with a numbered `## 7. Backlog coverage` heading. The Plan Backlog Coverage gate (`scripts/check-plan-backlog-coverage.mjs`) parses a **literal** `## Backlog coverage` section with structured `Decision/Parent/Receipt/Rationale/Dependencies` bullets, so the merged plan reads as non-conformant — the advisory gate then shows red on in-flight PRs whose CI-merge diff picks the plan up (e.g. #3367).

This converts the section to the canonical shape, reusing the atomic coverage receipt already recorded via `record_plan_backlog_coverage` (`cmrvgaj4403w101p8dljox040`). Doc-only; no code surface.

Process-Spine-Decision: plan doc correction only, no code surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
