### PR TITLE
fix(feedback): header Feedback opens a feedback flow, not the coworker panel (BI-62FF22DB)

### DIFF
--- a/apps/web/components/feedback/HeaderFeedbackButton.test.tsx
+++ b/apps/web/components/feedback/HeaderFeedbackButton.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import "@testing-library/jest-dom/vitest";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HeaderFeedbackButton } from "./HeaderFeedbackButton";
 
@@ -19,105 +19,55 @@ vi.mock("./FeedbackForm", () => ({
   FeedbackForm: (props: Record<string, unknown>) => {
     feedbackFormMock.props.push(props);
 
-    return <div data-testid="feedback-form">Feedback fallback</div>;
+    return <div data-testid="feedback-form">Feedback form</div>;
   },
 }));
 
 describe("HeaderFeedbackButton", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     pathname = "/build";
     feedbackFormMock.props = [];
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
-    vi.useRealTimers();
     cleanup();
   });
 
-  it("dispatches a cancelable manual support event for the build route", () => {
-    const received: CustomEvent[] = [];
+  it("opens a feedback-labeled surface, not the AI coworker conversation", () => {
+    // BI-62FF22DB: a control labeled "Feedback" must not open the coworker
+    // panel. Guard against any coworker-panel event being dispatched.
+    const coworkerEvents: Event[] = [];
     const handler = ((event: Event) => {
-      received.push(event as CustomEvent);
+      coworkerEvents.push(event);
     }) as EventListener;
     document.addEventListener("open-agent-feedback", handler);
+    document.addEventListener("open-agent-panel", handler);
 
     try {
       render(<HeaderFeedbackButton userId="user-1" />);
-      const trigger = screen.getByRole("button", {
-        name: /^feedback$/i,
-      });
-
+      const trigger = screen.getByRole("button", { name: /^feedback$/i });
       expect(trigger).toHaveAccessibleName("Feedback");
 
       fireEvent.click(trigger);
 
-      expect(received).toHaveLength(1);
-      expect(received[0].cancelable).toBe(true);
-      expect(received[0].detail).toEqual(
-        expect.objectContaining({
-          routeContext: "/build",
-          triggerKind: "manual",
-          autoFilePolicy: "ask",
-        }),
-      );
-      expect(received[0].detail.supportSessionId).toMatch(
-        /^dpf_support_[a-f0-9]{32}$/,
-      );
+      // A feedback-specific surface appears, with a clear title and the form.
+      const dialog = screen.getByRole("dialog", { name: /send feedback/i });
+      expect(dialog).toBeInTheDocument();
+      expect(screen.getByText("Send Feedback")).toBeVisible();
+      expect(screen.getByTestId("feedback-form")).toBeInTheDocument();
+
+      // ...and no AI coworker panel is opened.
+      expect(coworkerEvents).toHaveLength(0);
     } finally {
       document.removeEventListener("open-agent-feedback", handler);
+      document.removeEventListener("open-agent-panel", handler);
     }
   });
 
-  it("keeps the fallback form closed when the support event is handled", () => {
-    const handler = ((event: Event) => {
-      event.preventDefault();
-    }) as EventListener;
-    document.addEventListener("open-agent-feedback", handler);
-
-    try {
-      render(<HeaderFeedbackButton userId="user-1" />);
-      fireEvent.click(screen.getByRole("button", { name: "Feedback" }));
-
-      act(() => {
-        vi.advanceTimersByTime(500);
-      });
-
-      expect(screen.queryByTestId("feedback-form")).not.toBeInTheDocument();
-      expect(feedbackFormMock.props).toHaveLength(0);
-    } finally {
-      document.removeEventListener("open-agent-feedback", handler);
-    }
-  });
-
-  it("keeps the fallback form closed when the coworker panel opens", () => {
-    render(<HeaderFeedbackButton userId="user-1" />);
-    fireEvent.click(screen.getByRole("button", { name: "Feedback" }));
-
-    const panel = document.createElement("div");
-    panel.setAttribute("data-agent-panel", "true");
-    document.body.appendChild(panel);
-
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
-
-    expect(screen.queryByTestId("feedback-form")).not.toBeInTheDocument();
-    expect(feedbackFormMock.props).toHaveLength(0);
-    panel.remove();
-  });
-
-  it("opens the fallback form with the same support context when the event is unhandled", () => {
+  it("passes the current route and manual support context to the feedback form", () => {
     render(<HeaderFeedbackButton userId="user-1" />);
     fireEvent.click(screen.getByRole("button", { name: /^feedback$/i }));
 
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
-
-    expect(screen.getByTestId("feedback-form")).toBeInTheDocument();
-    expect(screen.getByText("Feedback fallback")).toBeVisible();
     expect(feedbackFormMock.props).toHaveLength(1);
     expect(feedbackFormMock.props[0]).toEqual(
       expect.objectContaining({
@@ -131,5 +81,18 @@ describe("HeaderFeedbackButton", () => {
     expect(feedbackFormMock.props[0].supportSessionId).toMatch(
       /^dpf_support_[a-f0-9]{32}$/,
     );
+  });
+
+  it("toggles the feedback surface closed on a second click", () => {
+    render(<HeaderFeedbackButton userId="user-1" />);
+    const trigger = screen.getByRole("button", { name: /^feedback$/i });
+
+    fireEvent.click(trigger);
+    expect(screen.getByTestId("feedback-form")).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(trigger);
+    expect(screen.queryByTestId("feedback-form")).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/apps/web/components/feedback/HeaderFeedbackButton.tsx
+++ b/apps/web/components/feedback/HeaderFeedbackButton.tsx
@@ -15,7 +15,7 @@ type Props = {
 export function HeaderFeedbackButton({ userId }: Props) {
   const pathname = usePathname();
   const [showForm, setShowForm] = useState(false);
-  const [fallbackDetail, setFallbackDetail] = useState<FeedbackEventDetail | null>(null);
+  const [detail, setDetail] = useState<FeedbackEventDetail | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -30,26 +30,15 @@ export function HeaderFeedbackButton({ userId }: Props) {
   }, [showForm]);
 
   function handleClick() {
-    const detail = createManualFeedbackEventDetail(pathname);
-    const handled = !document.dispatchEvent(
-      new CustomEvent("open-agent-feedback", {
-        cancelable: true,
-        detail,
-      }),
-    );
-
-    if (handled) {
+    // A control labeled "Feedback" must open a feedback surface, not the AI
+    // coworker conversation (BI-62FF22DB). Open the feedback form directly and
+    // capture the current route as context.
+    if (showForm) {
+      setShowForm(false);
       return;
     }
-
-    // Fallback: if panel doesn't open, show the simple form
-    setTimeout(() => {
-      const panel = document.querySelector("[data-agent-panel]");
-      if (!panel) {
-        setFallbackDetail(detail);
-        setShowForm(true);
-      }
-    }, 500);
+    setDetail(createManualFeedbackEventDetail(pathname));
+    setShowForm(true);
   }
 
   return (
@@ -57,24 +46,30 @@ export function HeaderFeedbackButton({ userId }: Props) {
       <button
         type="button"
         onClick={handleClick}
+        aria-haspopup="dialog"
+        aria-expanded={showForm}
         className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] transition-colors"
       >
         Feedback
       </button>
 
       {showForm && (
-        <div className="absolute right-0 top-full mt-2 w-[300px] bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-lg shadow-lg z-50 overflow-hidden">
+        <div
+          role="dialog"
+          aria-label="Send feedback"
+          className="absolute right-0 top-full mt-2 w-[300px] bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-lg shadow-lg z-50 overflow-hidden"
+        >
           <div className="px-3 pt-2.5 text-xs font-semibold text-[var(--dpf-text)]">
             Send Feedback
           </div>
           <FeedbackForm
-            routeContext={fallbackDetail?.routeContext ?? pathname}
+            routeContext={detail?.routeContext ?? pathname}
             {...(userId != null && { userId })}
             source="manual"
-            {...(fallbackDetail && {
-              triggerKind: fallbackDetail.triggerKind,
-              supportSessionId: fallbackDetail.supportSessionId,
-              autoFilePolicy: fallbackDetail.autoFilePolicy,
+            {...(detail && {
+              triggerKind: detail.triggerKind,
+              supportSessionId: detail.supportSessionId,
+              autoFilePolicy: detail.autoFilePolicy,
             })}
             onClose={() => setShowForm(false)}
           />


### PR DESCRIPTION
## What & why

BI-62FF22DB (EP-UX-COGLOAD). Live usability study: clicking the header **Feedback** button opened the AI coworker side panel (a COO conversation with Skills / Priority / Proactivity / dictation / Send) instead of a feedback surface. For a non-technical owner the visible result does not match the command, so the control reads as mislabeled or non-functional.

## Change

- `HeaderFeedbackButton` now opens the existing `FeedbackForm` directly (type + message + submit/cancel, current route captured), which already posts to `/api/quality/report`.
- The surface renders as `role="dialog" aria-label="Send feedback"` with a clear **Send Feedback** title; the button toggles it and exposes `aria-expanded`.
- The `open-agent-feedback` event contract and the `AgentCoworkerShell` listener are **untouched** — non-manual triggers (runtime errors, etc.) still route to coworker support.

## Tests

Rewrote `HeaderFeedbackButton.test.tsx`: clicking Feedback produces a feedback-labeled surface and dispatches **no** coworker-panel event; the route + manual support context reach the form; a second click toggles it closed.

## Design grounding

- Existing specs/plans reviewed: `search_specs_and_plans("feedback quality report submission")` → no owning spec/plan for the header feedback control.
- Current code substrate reviewed (code graph + rg): `apps/web/components/feedback/*` (FeedbackForm, HeaderFeedbackButton), `apps/web/lib/operate/quality-queue.ts`, `apps/web/app/api/quality/report/route.ts`, `apps/web/lib/feedback/feedback-event.ts`, and `apps/web/components/agent/AgentCoworkerShell.tsx` (the `open-agent-feedback` listener).
- Source of truth: the existing feedback form + `/api/quality/report`.
- Decision: trivial no-contract-change edit — promote the existing `FeedbackForm` from a 500ms race fallback to the primary manual path; coworker event contract preserved for non-manual triggers.

Design-Grounding-Decision: reviewed `apps/web/components/feedback/*` + `search_specs_and_plans` (no owning spec); localized behavior fix, no contract or routing change.
UX-Fit-Decision: human_cognitive_load — truthful-label + progressive disclosure; the control yields exactly the 3-field feedback surface its label promises; no new route/tab/input.
Docs-Impact-Decision: no `docs/user-guide` page documents the header Feedback control; in-app behavior only.
Process-Spine-Decision: small localized bug fix (one client component + its test); no new module/route/migration and no large rewrite.

## Verification

Authored in a source-only worktree (no local test runner); relying on CI (Unit Tests, Typecheck, Prod Build) as the verification substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)