### PR TITLE
fix(shell): wrap Workspace mobile nav so it never overflows the page (BI-882B3680)

### DIFF
--- a/apps/web/app/(shell)/layout.tsx
+++ b/apps/web/app/(shell)/layout.tsx
@@ -189,8 +189,8 @@ export default async function ShellLayout({ children }: { children: React.ReactN
         />
         <div className="flex flex-1 flex-col lg:flex-row">
           {shellNavSections.length > 0 && (
-            <aside className="shrink-0 border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] lg:w-[248px] lg:border-b-0 lg:border-r">
-              <div className="mx-auto w-full max-w-[1600px] lg:max-w-none">
+            <aside className="min-w-0 shrink-0 border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] lg:w-[248px] lg:border-b-0 lg:border-r">
+              <div className="mx-auto w-full min-w-0 max-w-[1600px] lg:max-w-none">
                 <AppRail sections={shellNavSections} mode={navMode} />
               </div>
             </aside>

--- a/apps/web/components/shell/AppRail.test.tsx
+++ b/apps/web/components/shell/AppRail.test.tsx
@@ -95,11 +95,15 @@ describe("AppRail", () => {
     expect(html).not.toContain("Controls, risk, obligations, and posture.");
   });
 
-  it("uses a horizontal grouped rail on small screens and vertical rail on desktop", () => {
+  it("wraps the grouped rail on small screens and uses a vertical rail on desktop", () => {
+    // BI-882B3680: the mobile rail must wrap (not force a single wide
+    // horizontal-scroll row) so a 390px viewport never overflows the page.
     pathname = "/finance";
     const html = renderToStaticMarkup(<AppRail sections={sections} />);
 
-    expect(html).toContain("overflow-x-auto");
+    expect(html).toContain("flex-wrap");
+    expect(html).not.toContain("overflow-x-auto");
+    expect(html).not.toContain("min-w-max");
     expect(html).toContain("lg:grid");
     expect(html).toContain("whitespace-nowrap");
   });

--- a/apps/web/components/shell/AppRail.tsx
+++ b/apps/web/components/shell/AppRail.tsx
@@ -67,14 +67,17 @@ export function AppRail({ sections, mode = "operator" }: Props) {
         </button>
       </div>
 
-      <div className="flex gap-3 overflow-x-auto lg:grid lg:overflow-visible">
+      {/* BI-882B3680: on mobile the rail wraps instead of forcing a single wide
+          horizontal-scroll row, so a phone-width viewport (390px) never overflows
+          the page. Desktop keeps the vertical grid rail. */}
+      <div className="flex min-w-0 flex-wrap gap-3 lg:grid lg:overflow-visible">
         {sections.map((section) => (
-          <section key={section.key} className="min-w-max shrink-0 lg:min-w-0">
+          <section key={section.key} className="min-w-0">
             <p className="px-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--dpf-muted)]">
               {section.label}
             </p>
 
-            <div className="mt-1 flex gap-1 lg:block lg:space-y-1">
+            <div className="mt-1 flex flex-wrap gap-1 lg:block lg:space-y-1">
               {section.items.map((item) => {
                 const isActive = activeHref === item.href;
                 return (

--- a/e2e/workspace-mobile-overflow.spec.ts
+++ b/e2e/workspace-mobile-overflow.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+import { ensureLoggedIn } from "./helpers/auth";
+
+// BI-882B3680: owner approvals often happen on a phone, so the internal shell
+// navigation must not force horizontal page overflow at a common mobile width.
+test.describe("Workspace mobile shell navigation", () => {
+  test("has no horizontal page overflow at 390px", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await ensureLoggedIn(page);
+    await page.goto("/workspace");
+    await page.waitForLoadState("networkidle").catch(() => {});
+
+    const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+
+    // A 1px rounding tolerance; anything larger is a real horizontal overflow.
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 1);
+  });
+});


### PR DESCRIPTION
## What & why

BI-882B3680 (EP-UX-COGLOAD). Live usability study at 390x844: `/workspace` had horizontal page overflow in the internal shell navigation, worst on the Business links (Customer, People, Finance, Compliance, Portal). Owner approvals often happen on a phone, so a page that scrolls sideways blocks safe lightweight decision-making.

## Root cause

The mobile rail laid every section out in a single `overflow-x-auto` row with `min-w-max` sections and `whitespace-nowrap` links. The nav `<aside>` is a flex item with no `min-w-0`, so that wide min-content propagated up the shell column and forced the page wider than the viewport.

## Change

- **AppRail**: the grouped rail now **wraps** on mobile (`flex-wrap`, `min-w-0` sections, wrapping item rows) instead of a single wide scroll row. Desktop keeps the vertical `lg:grid` rail unchanged.
- **Shell layout**: `min-w-0` added to the nav `<aside>` and its inner wrapper so a wide child can never force horizontal page overflow again.

## Tests

- `AppRail.test.tsx`: asserts the wrap layout (`flex-wrap`, no `overflow-x-auto` / `min-w-max`, `lg:grid`, links still `whitespace-nowrap`).
- New `e2e/workspace-mobile-overflow.spec.ts`: at 390px, asserts `document.documentElement.scrollWidth <= clientWidth` on `/workspace`.

## Design grounding

- Existing specs/plans reviewed: `search_specs_and_plans("shell navigation rail mobile responsive")` → no owning spec/plan; the rail carries an EP-NAV-COHERENCE code comment only.
- Current code substrate reviewed (code graph + rg): `apps/web/components/shell/AppRail.tsx`, `apps/web/app/(shell)/layout.tsx`, `apps/web/lib/navigation/portal-navigation-model.ts`.
- Source of truth: `AppRail` + shell layout.
- Decision: trivial no-contract-change responsive edit — nav model, sections, audience filtering unchanged; only the mobile CSS layout changes.

Design-Grounding-Decision: reviewed `apps/web/components/shell/AppRail.tsx` + shell layout via code graph; `search_specs_and_plans` found no owning spec; responsive-only, no contract change.
UX-Fit-Decision: human_cognitive_load — removes a horizontal-overflow trap on mobile; no new route/tab/control/input; same links, wrapped instead of sideways-scrolled.
Docs-Impact-Decision: internal responsive layout of the shell nav; no user-visible content or route change.
Process-Spine-Decision: small localized CSS/responsive fix plus tests; no new module/route/migration and no large rewrite.

## Verification

Authored in a source-only worktree (no local test runner); relying on CI plus the new Playwright assertion as the verification substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)