### PR TITLE
fix(workspace): Simple mode condenses the twin hero, not just its state (BI-BF53A701)

### DIFF
--- a/apps/web/app/(shell)/workspace/page.tsx
+++ b/apps/web/app/(shell)/workspace/page.tsx
@@ -86,6 +86,7 @@ export default async function WorkspacePage() {
               ? workspaceHomeResolution.contribution
               : null
           }
+          density={simpleHome ? "simple" : "full"}
           platformBody={
             <PlatformWorkspaceHome
               data={platformHomeData}

--- a/apps/web/components/workspace-home/WorkspaceTwinHero.test.tsx
+++ b/apps/web/components/workspace-home/WorkspaceTwinHero.test.tsx
@@ -45,3 +45,47 @@ describe("WorkspaceTwinHero", () => {
     expect(html).toContain("Nothing needs you right now");
   });
 });
+
+describe("WorkspaceTwinHero density (BI-BF53A701)", () => {
+  const contribution = {
+    primaryOperatingQuestion: "are we ready for the next service period?",
+  } as never;
+
+  function renderDensity(density: "simple" | "full") {
+    return renderToStaticMarkup(
+      <WorkspaceTwinHero
+        cockpit={<div data-testid="cockpit-slot">What needs you now</div>}
+        presentation={presentation}
+        contribution={contribution}
+        platformBody={<div data-testid="platform-slot">All workspace areas</div>}
+        density={density}
+      />,
+    );
+  }
+
+  it("full mode shows builder chrome and the operational-twin body", () => {
+    const html = renderDensity("full");
+    expect(html).toContain("Living business");
+    expect(html).toContain("The worker arrives asking");
+    expect(html).toContain(presentation.snapshot.capacityChips[0].label);
+    expect(html).toContain("Demo data — live business projection pending");
+  });
+
+  it("simple mode condenses to the next-action surface and hides builder detail", () => {
+    const html = renderDensity("simple");
+    // Essential owner surfaces stay: next actions + area launcher + identity.
+    expect(html).toContain("cockpit-slot");
+    expect(html).toContain("platform-slot");
+    expect(html).toContain(presentation.archetypeName);
+    // Builder terminology and the full twin body are hidden — materially less
+    // content than Full mode.
+    expect(html).not.toContain("Living business");
+    expect(html).not.toContain("The worker arrives asking");
+    expect(html).not.toContain(presentation.snapshot.capacityChips[0].label);
+    expect(html).not.toContain("Demo data — live business projection pending");
+  });
+
+  it("Simple and Full render materially different content", () => {
+    expect(renderDensity("simple")).not.toEqual(renderDensity("full"));
+  });
+});

--- a/apps/web/components/workspace-home/WorkspaceTwinHero.tsx
+++ b/apps/web/components/workspace-home/WorkspaceTwinHero.tsx
@@ -28,6 +28,13 @@ export interface WorkspaceTwinHeroProps {
   /** Platform tiles / area launcher, demoted below the hero (navigation, not a
    *  rival dashboard). */
   platformBody: ReactNode;
+  /** Rail nav-mode density (BI-BF53A701). In "simple" the hero condenses to the
+   *  essential "what needs you now" surface: builder chrome (the "Living business"
+   *  eyebrow, the operator "worker arrives asking" line) and the full
+   *  operational-twin body are hidden by default. The full view is one click away
+   *  via the Full toggle in the rail, so nothing is lost — it is disclosed on
+   *  demand. Defaults to "full". */
+  density?: "simple" | "full";
 }
 
 export function WorkspaceTwinHero({
@@ -35,7 +42,9 @@ export function WorkspaceTwinHero({
   presentation,
   contribution,
   platformBody,
+  density = "full",
 }: WorkspaceTwinHeroProps) {
+  const simple = density === "simple";
   const operatingQuestion = contribution?.primaryOperatingQuestion ?? null;
 
   return (
@@ -46,17 +55,19 @@ export function WorkspaceTwinHero({
       >
         {/* HUD rail — identity + the single attention surface. */}
         <header className="border-b border-[var(--dpf-border)] px-4 pb-3 pt-4">
-          <div className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-[var(--dpf-muted)]">
-            <Activity size={15} aria-hidden="true" />
-            Living business
-          </div>
+          {!simple && (
+            <div className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-[var(--dpf-muted)]">
+              <Activity size={15} aria-hidden="true" />
+              Living business
+            </div>
+          )}
           <h1
             id="workspace-twin-hero-title"
             className="text-xl font-bold text-[var(--dpf-text)]"
           >
             {presentation.archetypeName}
           </h1>
-          {operatingQuestion ? (
+          {!simple && operatingQuestion ? (
             <p className="mt-1 max-w-3xl text-sm text-[var(--dpf-muted)]">
               The worker arrives asking: {operatingQuestion}
             </p>
@@ -64,12 +75,15 @@ export function WorkspaceTwinHero({
         </header>
 
         {/* The one "what needs you now" surface, folded in as the hero HUD. */}
-        <div className="px-4 pt-4">{cockpit}</div>
+        <div className={simple ? "px-4 py-4" : "px-4 pt-4"}>{cockpit}</div>
 
-        {/* The operational twin — the main workspace view. */}
-        <div className="px-4 pb-4">
-          <WorkspaceTwinPanel presentation={presentation} />
-        </div>
+        {/* The operational twin — the main workspace view in Full mode; hidden in
+            Simple mode as technical detail (reachable via the Full rail toggle). */}
+        {!simple && (
+          <div className="px-4 pb-4">
+            <WorkspaceTwinPanel presentation={presentation} />
+          </div>
+        )}
       </section>
 
       {/* Demoted: platform areas / navigation, below the hero. */}


### PR DESCRIPTION
## What & why

BI-BF53A701 (EP-UX-COGLOAD). Live usability study on `/workspace`: clicking **Simple** flipped `aria-pressed` from Full to Simple, but the visible content did not change — word count stayed ~740, and builder terminology / technical-detail affordances stayed visible.

## Root cause

`workspace/page.tsx` computes `simpleHome` from the nav-mode cookie but only consumed it in the **non-twin fallback** branch. The primary **twin-hero** branch (what a configured owner actually sees) never received it and hardcoded `density="simple"` on only the demoted platform launcher — so the hero rendered identical content in both modes.

## Change

- `WorkspaceTwinHero` gains a `density` prop (default `"full"`). In `"simple"` it keeps the essential **what needs you now** cockpit + area launcher + business-identity heading, and hides the builder chrome (the "Living business" eyebrow, the "worker arrives asking" operator line) and the full operational-twin body. The full view is one click away via the **Full** toggle in the rail — disclosed on demand, not lost.
- `workspace/page.tsx` threads `simpleHome` into the twin-hero branch.

## Tests

Existing `WorkspaceTwinHero` tests keep the Full-mode default. New tests assert Simple hides builder terminology + the twin body, and that Simple vs Full render **materially different** content.

## Design grounding

- Existing specs/plans reviewed: `search_specs_and_plans` + `docs/superpowers/plans/2026-07-15-twin-workspace-home-placement-execution.md` (twin-hero placement), and the BI-655418A7 nav-mode density concept.
- Current code substrate reviewed (code graph + rg): `apps/web/app/(shell)/workspace/page.tsx`, `apps/web/components/workspace-home/WorkspaceTwinHero.tsx`, `apps/web/lib/navigation/nav-mode.ts`.
- Source of truth: the twin-hero placement plan + nav-mode density.
- Decision: extend the existing density concept into the twin-hero branch it missed; no new contract.

Design-Grounding-Decision: reviewed `docs/superpowers/plans/2026-07-15-twin-workspace-home-placement-execution.md` + `apps/web/components/workspace-home/WorkspaceTwinHero.tsx`; extends existing density concept, no new contract.
UX-Fit-Decision: human_cognitive_load — progressive disclosure is the fix; Simple keeps the essential surfaces and moves operational-twin detail behind the existing Full toggle; no new route/tab/input.
Docs-Impact-Decision: Simple/Full is in-app behavior; no user-guide page documents the twin-hero density.
Process-Spine-Decision: localized bug fix (one component prop + page wiring + tests); no new module/route/migration and no large rewrite.

## Verification

Authored in a source-only worktree (no local test runner); relying on CI (Unit Tests, Typecheck, Prod Build) as the verification substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)