### PR TITLE
fix(storefront): confirm + preview + honest undo for service-line mutations (BI-7D7EE150)

### DIFF
--- a/apps/web/app/(shell)/storefront/page.tsx
+++ b/apps/web/app/(shell)/storefront/page.tsx
@@ -45,23 +45,45 @@ export default async function StorefrontPage() {
       tagline: true,
       organization: { select: { slug: true, name: true } },
       archetype: { select: { archetypeId: true, ctaType: true } },
-      _count: { select: { sections: true, items: true } },
     },
   });
 
   if (config) {
-    const [inquiryCount, bookingCount, orderCount, donationCount, compositionData, allArchetypes] =
-      await Promise.all([
-        prisma.storefrontInquiry.count({ where: { storefrontId: config.id } }),
-        prisma.storefrontBooking.count({ where: { storefrontId: config.id } }),
-        prisma.storefrontOrder.count({ where: { storefrontId: config.id } }),
-        prisma.storefrontDonation.count({ where: { storefrontId: config.id } }),
-        loadCompositionViewData(config.id),
-        prisma.storefrontArchetype.findMany({
-          select: { archetypeId: true, name: true, category: true },
-          orderBy: { name: "asc" },
-        }),
-      ]);
+    const [
+      inquiryCount,
+      bookingCount,
+      orderCount,
+      donationCount,
+      compositionData,
+      allArchetypes,
+      visibleSectionCount,
+      activeItemCount,
+    ] = await Promise.all([
+      prisma.storefrontInquiry.count({ where: { storefrontId: config.id } }),
+      prisma.storefrontBooking.count({ where: { storefrontId: config.id } }),
+      prisma.storefrontOrder.count({ where: { storefrontId: config.id } }),
+      prisma.storefrontDonation.count({ where: { storefrontId: config.id } }),
+      loadCompositionViewData(config.id),
+      prisma.storefrontArchetype.findMany({
+        select: {
+          archetypeId: true,
+          name: true,
+          category: true,
+          itemTemplates: true,
+          sectionTemplates: true,
+        },
+        orderBy: { name: "asc" },
+      }),
+      // Count only live artifacts so add/remove of a service line is honestly
+      // reflected on the dashboard — removing a line hides its items/sections and
+      // the counts drop back (BI-7D7EE150: undo must restore the visible state).
+      prisma.storefrontSection.count({
+        where: { storefrontId: config.id, isVisible: true },
+      }),
+      prisma.storefrontItem.count({
+        where: { storefrontId: config.id, isActive: true },
+      }),
+    ]);
 
     const compositionView = compositionData
       ? deriveStorefrontCompositionView(compositionData)
@@ -74,7 +96,15 @@ export default async function StorefrontPage() {
     ]);
     const availableArchetypes = allArchetypes
       .filter((a) => !activeSlugSet.has(a.archetypeId))
-      .map((a) => ({ archetypeSlug: a.archetypeId, name: a.name, category: a.category }));
+      .map((a) => ({
+        archetypeSlug: a.archetypeId,
+        name: a.name,
+        category: a.category,
+        // Preview counts so the add-confirmation can name exactly what the
+        // mutation will do (BI-7D7EE150).
+        itemCount: Array.isArray(a.itemTemplates) ? a.itemTemplates.length : 0,
+        sectionCount: Array.isArray(a.sectionTemplates) ? a.sectionTemplates.length : 0,
+      }));
 
     return (
       <>
@@ -87,8 +117,8 @@ export default async function StorefrontPage() {
             orgName: config.organization.name,
             archetypeId: config.archetype?.archetypeId ?? "",
             ctaType: config.archetype?.ctaType ?? "inquiry",
-            sectionCount: config._count.sections,
-            itemCount: config._count.items,
+            sectionCount: visibleSectionCount,
+            itemCount: activeItemCount,
           }}
           counts={{ inquiries: inquiryCount, bookings: bookingCount, orders: orderCount, donations: donationCount }}
         />

--- a/apps/web/components/storefront-admin/ServiceLinesPanel.test.tsx
+++ b/apps/web/components/storefront-admin/ServiceLinesPanel.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ServiceLinesPanel } from "./ServiceLinesPanel";
+import type {
+  StorefrontCompositionView,
+  StorefrontServiceLineView,
+} from "@/lib/storefront/composition-view";
+
+const { addMock, removeMock, confirmMock } = vi.hoisted(() => ({
+  addMock: vi.fn(),
+  removeMock: vi.fn(),
+  confirmMock: vi.fn(),
+}));
+
+vi.mock("@/lib/storefront/service-line-actions", () => ({
+  addStorefrontServiceLine: addMock,
+  removeStorefrontServiceLine: removeMock,
+}));
+
+vi.mock("@/components/ui/Dialog", () => ({
+  confirmDialog: confirmMock,
+}));
+
+function line(overrides: Partial<StorefrontServiceLineView> = {}): StorefrontServiceLineView {
+  return {
+    compositionId: "comp-primary",
+    role: "primary",
+    archetypeSlug: "restaurant",
+    name: "Restaurant",
+    category: "food-hospitality",
+    operatorLabel: "Restaurant",
+    visualPattern: "service-readiness-board",
+    status: "good",
+    statusLabel: "Compatible",
+    statusIntent: "success",
+    statusIconName: "check",
+    contributedModules: [],
+    contributedServiceCategories: [],
+    contributedItemCount: 0,
+    contributedSectionCount: 0,
+    warnings: [],
+    ...overrides,
+  } as unknown as StorefrontServiceLineView;
+}
+
+const secondary = line({
+  compositionId: "comp-3pl",
+  role: "secondary",
+  archetypeSlug: "third-party-logistics",
+  name: "3PL Contract Warehousing",
+  category: "warehousing-fulfilment",
+  operatorLabel: "3PL Contract Warehousing",
+  contributedModules: [{ key: "warehouse" }] as never,
+});
+
+const view = {
+  storefrontId: "sf-1",
+  primary: line(),
+  secondaries: [secondary],
+  compatibilitySummary: { status: "good", label: "All compatible", reasons: [] },
+} as StorefrontCompositionView;
+
+const availableArchetypes = [
+  {
+    archetypeSlug: "third-party-logistics",
+    name: "3PL Contract Warehousing",
+    category: "warehousing-fulfilment",
+    itemCount: 4,
+    sectionCount: 3,
+  },
+];
+
+describe("ServiceLinesPanel action safety (BI-7D7EE150)", () => {
+  beforeEach(() => {
+    addMock.mockResolvedValue({ success: true });
+    removeMock.mockResolvedValue({ success: true });
+    confirmMock.mockReset();
+  });
+
+  afterEach(cleanup);
+
+  it("never adds a cross-archetype service line on a single unconfirmed click", async () => {
+    confirmMock.mockResolvedValueOnce(false);
+    render(
+      <ServiceLinesPanel
+        storefrontId="sf-1"
+        view={view}
+        availableArchetypes={availableArchetypes}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add service line" }));
+
+    await waitFor(() => expect(confirmMock).toHaveBeenCalledTimes(1));
+    // The confirmation names the exact mutation and its scope.
+    expect(confirmMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        title: expect.stringContaining("3PL Contract Warehousing"),
+        message: expect.stringContaining("4 items"),
+      }),
+    );
+    // Cancelled → the durable mutation never runs.
+    expect(addMock).not.toHaveBeenCalled();
+  });
+
+  it("adds the service line only after the owner confirms", async () => {
+    confirmMock.mockResolvedValueOnce(true);
+    render(
+      <ServiceLinesPanel
+        storefrontId="sf-1"
+        view={view}
+        availableArchetypes={availableArchetypes}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add service line" }));
+
+    await waitFor(() =>
+      expect(addMock).toHaveBeenCalledWith("sf-1", "third-party-logistics"),
+    );
+  });
+
+  it("requires a danger-toned confirmation before removing a service line", async () => {
+    confirmMock.mockResolvedValueOnce(false);
+    render(
+      <ServiceLinesPanel
+        storefrontId="sf-1"
+        view={view}
+        availableArchetypes={availableArchetypes}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove 3PL Contract Warehousing" }),
+    );
+
+    await waitFor(() => expect(confirmMock).toHaveBeenCalledTimes(1));
+    expect(confirmMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ tone: "danger" }),
+    );
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/storefront-admin/ServiceLinesPanel.tsx
+++ b/apps/web/components/storefront-admin/ServiceLinesPanel.tsx
@@ -7,11 +7,18 @@ import {
 } from "@/lib/storefront/service-line-actions";
 import type { StorefrontCompositionView, StorefrontServiceLineView } from "@/lib/storefront/composition-view";
 import { intentStyle } from "@/components/ui/report-kit/statusColors";
+import { confirmDialog } from "@/components/ui/Dialog";
 
 interface AvailableArchetype {
   archetypeSlug: string;
   name: string;
   category: string;
+  itemCount: number;
+  sectionCount: number;
+}
+
+function plural(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? "" : "s"}`;
 }
 
 interface Props {
@@ -25,8 +32,26 @@ export function ServiceLinesPanel({ storefrontId, view, availableArchetypes }: P
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  function handleAdd() {
+  // BI-7D7EE150: adding a service line is a durable business mutation (it seeds
+  // items + sections), so it must never happen on a single unconfirmed click.
+  // Preview exactly what will change and confirm BEFORE the transition (dialog
+  // helpers must not run inside startTransition).
+  async function handleAdd() {
     if (!selectedSlug) return;
+    const selected = availableArchetypes.find((a) => a.archetypeSlug === selectedSlug);
+    if (!selected) return;
+
+    const confirmed = await confirmDialog({
+      title: `Add ${selected.name} as a service line?`,
+      message:
+        `This adds ${selected.name} to your portal, including ${plural(selected.itemCount, "item")} and ` +
+        `${plural(selected.sectionCount, "section")} (sections stay hidden until you show them). ` +
+        `You can remove it again afterwards.`,
+      confirmLabel: "Add service line",
+      cancelLabel: "Cancel",
+    });
+    if (!confirmed) return;
+
     setError(null);
     startTransition(async () => {
       const result = await addStorefrontServiceLine(storefrontId, selectedSlug);
@@ -34,10 +59,23 @@ export function ServiceLinesPanel({ storefrontId, view, availableArchetypes }: P
     });
   }
 
-  function handleRemove(compositionId: string) {
+  async function handleRemove(line: StorefrontServiceLineView) {
+    const moduleCount = line.contributedModules.length;
+    const confirmed = await confirmDialog({
+      title: `Remove ${line.operatorLabel}?`,
+      message:
+        `This hides the ${line.operatorLabel} service line` +
+        (moduleCount > 0 ? ` and the ${plural(moduleCount, "module")} it added to your portal` : "") +
+        `. You can add it back later.`,
+      tone: "danger",
+      confirmLabel: "Remove service line",
+      cancelLabel: "Keep it",
+    });
+    if (!confirmed) return;
+
     setError(null);
     startTransition(async () => {
-      const result = await removeStorefrontServiceLine(storefrontId, compositionId);
+      const result = await removeStorefrontServiceLine(storefrontId, line.compositionId);
       if ("error" in result) setError(result.error);
     });
   }
@@ -88,7 +126,7 @@ export function ServiceLinesPanel({ storefrontId, view, availableArchetypes }: P
           <ServiceLineRow
             key={line.compositionId}
             line={line}
-            onRemove={() => handleRemove(line.compositionId)}
+            onRemove={() => handleRemove(line)}
             isPending={isPending}
           />
         ))}

--- a/apps/web/lib/storefront/service-line-actions.ts
+++ b/apps/web/lib/storefront/service-line-actions.ts
@@ -72,12 +72,33 @@ export async function addStorefrontServiceLine(
   });
   const nextSortOrder = (lastComposition?.sortOrder ?? 0) + 1;
 
-  // Write (or reactivate) the composition row
+  // Add/remove must be inverse (BI-7D7EE150). If this line was added before and
+  // then removed, reactivate the exact artifacts it seeded rather than creating a
+  // second, duplicate set — so re-adding restores the prior state cleanly.
+  if (existing) {
+    await prisma.storefrontArchetypeComposition.update({
+      where: { id: existing.id },
+      data: { removedAt: null, sortOrder: nextSortOrder, updatedAt: new Date() },
+    });
+    const seededItemCount = await prisma.storefrontItem.count({
+      where: { sourceCompositionId: existing.id },
+    });
+    if (seededItemCount > 0) {
+      await prisma.storefrontItem.updateMany({
+        where: { sourceCompositionId: existing.id },
+        data: { isActive: true },
+      });
+      // Sections were seeded hidden and stay hidden until the operator reveals
+      // them, matching the original add behavior.
+      revalidatePath("/storefront");
+      return { success: true };
+    }
+    // Legacy row with no provenance-tagged artifacts: fall through and seed.
+  }
+
+  // Write (or reuse the reactivated) composition row.
   const composition = existing
-    ? await prisma.storefrontArchetypeComposition.update({
-        where: { id: existing.id },
-        data: { removedAt: null, sortOrder: nextSortOrder, updatedAt: new Date() },
-      })
+    ? { id: existing.id }
     : await prisma.storefrontArchetypeComposition.create({
         data: {
           storefrontId,


### PR DESCRIPTION
## What & why

BI-7D7EE150 (EP-UX-COGLOAD). Live usability study on `/storefront`: clicking **Add service line** IMMEDIATELY added a cross-industry line (3PL Contract Warehousing) to a Restaurant portal and jumped the dashboard from 6 sections/5 items to 11/11 — no chooser, no confirmation. Clicking **Remove** then left the counts at 11/11, so undo did not visibly restore the previous state.

## Change — three fixes so a durable business mutation is never a surprise one-click

1. **Confirm + preview before mutating** (`ServiceLinesPanel`). Add awaits a `confirmDialog` that names the line and previews exactly what it seeds ("adds N items and M sections; sections stay hidden until you show them"); Remove awaits a **danger**-toned confirm that names what it hides. Dialogs are awaited **outside** the transition per the no-dialog-in-transition rule.
2. **Honest counts** (`storefront/page.tsx`). The dashboard now counts **visible** sections and **active** items, not raw rows — so removing a line drops the counts back and undo is visible. Preview counts come from the archetype item/section templates.
3. **Add/remove are inverse** (`service-line-actions.ts`). Re-adding a previously removed line reactivates the exact artifacts it seeded instead of creating a duplicate second set.

## Tests

New `ServiceLinesPanel.test.tsx` proves there is **no one-click cross-archetype mutation**: Add/Remove call `confirmDialog` first and the server action never runs on cancel; Add runs only after confirm; Remove uses `danger` tone and names the archetype.

## Design grounding

- Existing specs/plans reviewed: `search_specs_and_plans("storefront service line composition secondary archetype")` → no owning spec/plan.
- Current code substrate reviewed (code graph + rg): `apps/web/lib/storefront/service-line-actions.ts`, `apps/web/components/storefront-admin/ServiceLinesPanel.tsx`, `apps/web/app/(shell)/storefront/page.tsx`, `apps/web/components/ui/Dialog.tsx`, `apps/web/lib/storefront/composition-view.ts`.
- Source of truth: the storefront composition substrate + the canonical in-app `Dialog` primitive (no native dialogs).
- Decision: extend existing substrate; reuse `confirmDialog`; no new contract.

Design-Grounding-Decision: reviewed `apps/web/lib/storefront/*` + `apps/web/components/ui/Dialog.tsx`; `search_specs_and_plans` found no owning spec; extends existing composition substrate, no new contract.
UX-Fit-Decision: human_cognitive_load — confirmation + preview is progressive disclosure of consequences; truthful button labels; no new route/tab/input; reuses the shared themed Dialog.
Docs-Impact-Decision: `/storefront` service-line management is operator UI; behavior hardening (confirm/undo), no route or documented-workflow change requiring a user-guide edit.
Process-Spine-Decision: localized safety fix across one action + one page + one panel + its test; no new module/route/migration and no large rewrite.

## Verification

Authored in a source-only worktree (no local test runner); relying on CI (Unit Tests, Typecheck, Prod Build) as the verification substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)