### PR TITLE
fix(auth): repair login redirect to a non-routable 0.0.0.0 host (BI-86165533)

### DIFF
--- a/apps/web/lib/govern/auth-redirect.test.ts
+++ b/apps/web/lib/govern/auth-redirect.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  isNonRoutableHost,
+  normalizeAuthRedirect,
+  resolveVisibleBase,
+} from "./auth-redirect";
+
+describe("isNonRoutableHost", () => {
+  it("flags bind-only / unspecified addresses", () => {
+    expect(isNonRoutableHost("0.0.0.0")).toBe(true);
+    expect(isNonRoutableHost("::")).toBe(true);
+    expect(isNonRoutableHost("[::]")).toBe(true);
+    expect(isNonRoutableHost("0000:0000:0000:0000:0000:0000:0000:0000")).toBe(true);
+  });
+
+  it("treats routable hosts as fine", () => {
+    expect(isNonRoutableHost("localhost")).toBe(false);
+    expect(isNonRoutableHost("127.0.0.1")).toBe(false);
+    expect(isNonRoutableHost("192.168.1.10")).toBe(false);
+    expect(isNonRoutableHost("portal.example.com")).toBe(false);
+  });
+});
+
+describe("resolveVisibleBase", () => {
+  it("prefers a routable PUBLIC_URL", () => {
+    const base = resolveVisibleBase("http://0.0.0.0:3000", "https://portal.example.com");
+    expect(base.origin).toBe("https://portal.example.com");
+  });
+
+  it("ignores a non-routable PUBLIC_URL and repairs the request base", () => {
+    const base = resolveVisibleBase("http://0.0.0.0:3000", "http://0.0.0.0:3000");
+    expect(base.hostname).toBe("localhost");
+    expect(base.port).toBe("3000");
+    expect(base.protocol).toBe("http:");
+  });
+
+  it("rewrites a non-routable request base to localhost, keeping the port", () => {
+    const base = resolveVisibleBase("http://0.0.0.0:3000");
+    expect(base.origin).toBe("http://localhost:3000");
+  });
+
+  it("passes a routable request base through unchanged", () => {
+    const base = resolveVisibleBase("http://localhost:3000");
+    expect(base.origin).toBe("http://localhost:3000");
+  });
+});
+
+describe("normalizeAuthRedirect", () => {
+  it("resolves a relative redirectTo against a repaired localhost base (the login bug)", () => {
+    // The exact failing case: Auth.js base derived as 0.0.0.0, relative /workspace.
+    const out = normalizeAuthRedirect({
+      url: "/workspace",
+      baseUrl: "http://0.0.0.0:3000",
+    });
+    expect(out).toBe("http://localhost:3000/workspace");
+  });
+
+  it("rewrites an absolute 0.0.0.0 target to the visible host", () => {
+    const out = normalizeAuthRedirect({
+      url: "http://0.0.0.0:3000/workspace",
+      baseUrl: "http://0.0.0.0:3000",
+    });
+    expect(out).toBe("http://localhost:3000/workspace");
+  });
+
+  it("preserves query strings on relative OAuth-flow redirects", () => {
+    const out = normalizeAuthRedirect({
+      url: "/customer-link-account?token=abc123",
+      baseUrl: "http://0.0.0.0:3000",
+    });
+    expect(out).toBe("http://localhost:3000/customer-link-account?token=abc123");
+  });
+
+  it("routes through PUBLIC_URL when configured", () => {
+    const out = normalizeAuthRedirect({
+      url: "/workspace",
+      baseUrl: "http://0.0.0.0:3000",
+      publicUrl: "https://portal.example.com",
+    });
+    expect(out).toBe("https://portal.example.com/workspace");
+  });
+
+  it("leaves a healthy localhost flow untouched", () => {
+    const out = normalizeAuthRedirect({
+      url: "/workspace",
+      baseUrl: "http://localhost:3000",
+    });
+    expect(out).toBe("http://localhost:3000/workspace");
+  });
+
+  it("collapses a foreign absolute origin to the safe base (open-redirect guard)", () => {
+    const out = normalizeAuthRedirect({
+      url: "https://evil.example.com/steal",
+      baseUrl: "http://localhost:3000",
+    });
+    expect(out).toBe("http://localhost:3000/");
+  });
+
+  it("keeps a same-origin absolute target", () => {
+    const out = normalizeAuthRedirect({
+      url: "http://localhost:3000/build",
+      baseUrl: "http://localhost:3000",
+    });
+    expect(out).toBe("http://localhost:3000/build");
+  });
+});

--- a/apps/web/lib/govern/auth-redirect.ts
+++ b/apps/web/lib/govern/auth-redirect.ts
@@ -1,0 +1,111 @@
+// Sign-in redirect normalization (BI-86165533).
+//
+// Auth.js (`trustHost: true`, no explicit AUTH_URL) derives its base URL from
+// the incoming request. In a self-hosted Docker deploy the portal process is
+// bound to 0.0.0.0, and there are request paths (direct /api/auth/callback
+// hits without a browser Host header, some proxy setups) where Auth.js ends up
+// resolving its base URL to the *bind* address — `http://0.0.0.0:3000`.
+//
+// A relative `redirectTo: "/workspace"` then resolves to
+// `http://0.0.0.0:3000/workspace`. 0.0.0.0 is a valid bind address but NOT a
+// routable destination a browser can navigate to on Windows/macOS, so the
+// post-login redirect silently fails: the browser stays on /login with no
+// error and no console message — exactly the "inert login" symptom.
+//
+// `normalizeAuthRedirect` runs inside the NextAuth `redirect` callback and
+// guarantees the final Location uses an operator-visible host: PUBLIC_URL when
+// the operator has configured one, otherwise `localhost` (preserving scheme +
+// port). It also preserves Auth.js's open-redirect guard — an absolute URL to
+// a foreign origin collapses to the safe base.
+
+/** Hostnames that are valid to *bind* to but are not routable *destinations*. */
+const NON_ROUTABLE_BIND_HOSTS = new Set<string>([
+  "0.0.0.0",
+  "::",
+  "[::]",
+  "::0",
+  "0000:0000:0000:0000:0000:0000:0000:0000",
+]);
+
+/** True when `host` (URL.hostname, no port) is a bind-only / unspecified address. */
+export function isNonRoutableHost(host: string): boolean {
+  const h = host.trim().toLowerCase();
+  if (NON_ROUTABLE_BIND_HOSTS.has(h)) return true;
+  // URL.hostname strips brackets from IPv6 literals; catch the unspecified
+  // address in both bracketed and bare forms.
+  if (h === "::" || h === "[::]") return true;
+  return false;
+}
+
+function tryParseUrl(value: string, base?: string): URL | null {
+  try {
+    return base ? new URL(value, base) : new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the operator-visible origin to redirect against.
+ *
+ * Precedence:
+ *   1. A valid PUBLIC_URL origin (operator-declared canonical URL).
+ *   2. The request-derived baseUrl, with a non-routable host rewritten to
+ *      `localhost` (scheme + port preserved).
+ */
+export function resolveVisibleBase(baseUrl: string, publicUrl?: string | null): URL {
+  const fromPublic = publicUrl && publicUrl.length > 0 ? tryParseUrl(publicUrl) : null;
+  if (fromPublic && !isNonRoutableHost(fromPublic.hostname)) {
+    return fromPublic;
+  }
+
+  const base = tryParseUrl(baseUrl);
+  if (!base) {
+    // Last-resort fallback — a syntactically valid, routable local origin.
+    return new URL("http://localhost:3000");
+  }
+  if (isNonRoutableHost(base.hostname)) {
+    base.hostname = "localhost";
+  }
+  return base;
+}
+
+/**
+ * Normalize an Auth.js redirect target so the browser always lands on a
+ * routable, operator-visible host.
+ *
+ * @param url      The redirect target Auth.js wants to send the user to. May be
+ *                 relative (`/workspace`) or absolute (`http://0.0.0.0:3000/…`).
+ * @param baseUrl  The Auth.js-derived base URL for this request.
+ * @param publicUrl Operator-declared canonical URL (`process.env.PUBLIC_URL`).
+ * @returns An absolute URL string safe to use as a redirect Location.
+ */
+export function normalizeAuthRedirect(args: {
+  url: string;
+  baseUrl: string;
+  publicUrl?: string | null;
+}): string {
+  const { url, baseUrl, publicUrl } = args;
+  const visibleBase = resolveVisibleBase(baseUrl, publicUrl);
+
+  // Relative path (or protocol-relative) — resolve against the visible base.
+  const resolved = tryParseUrl(url, visibleBase.href);
+  if (!resolved) {
+    return visibleBase.href;
+  }
+
+  // Rewrite a non-routable absolute host to the visible base host.
+  if (isNonRoutableHost(resolved.hostname)) {
+    resolved.protocol = visibleBase.protocol;
+    resolved.hostname = visibleBase.hostname;
+    resolved.port = visibleBase.port;
+    return resolved.href;
+  }
+
+  // Open-redirect guard (mirrors Auth.js default): only allow same-origin
+  // absolute targets; anything foreign collapses to the visible base.
+  if (resolved.origin === visibleBase.origin) {
+    return resolved.href;
+  }
+  return visibleBase.href;
+}

--- a/apps/web/lib/govern/auth.ts
+++ b/apps/web/lib/govern/auth.ts
@@ -6,6 +6,7 @@ import Apple from "next-auth/providers/apple";
 import { prisma } from "@dpf/db";
 import { verifyPassword, hashPassword } from "./password";
 import { determineSocialAuthFlow, createTempToken } from "./social-auth";
+import { normalizeAuthRedirect } from "./auth-redirect";
 
 /**
  * Load social auth credentials from PlatformConfig DB into process.env.
@@ -209,6 +210,17 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     }),
   ],
   callbacks: {
+    // BI-86165533: guarantee the post-login redirect targets an operator-visible
+    // host. With trustHost + no AUTH_URL, Auth.js can derive its base URL from the
+    // 0.0.0.0 bind address on some request paths; a relative redirectTo then
+    // resolves to http://0.0.0.0:3000/… which no browser can follow, leaving the
+    // user stranded on /login with no error. normalizeAuthRedirect repairs the
+    // host (PUBLIC_URL when set, else localhost) while preserving Auth.js's
+    // open-redirect guard.
+    redirect({ url, baseUrl }) {
+      return normalizeAuthRedirect({ url, baseUrl, publicUrl: process.env.PUBLIC_URL });
+    },
+
     async signIn({ user, account }) {
       await ensureSocialAuthCredentials();
       // Credential providers: pass through (existing behavior)

--- a/docs/superpowers/plans/2026-07-22-ux-cognitive-load-audit-followup.md
+++ b/docs/superpowers/plans/2026-07-22-ux-cognitive-load-audit-followup.md
@@ -1,0 +1,74 @@
+# EP-UX-COGLOAD — Login redirect fix + audit-slice coordination (plan)
+
+**Epic:** EP-UX-COGLOAD — Live UX cognitive-load audit follow-up
+**Date:** 2026-07-22
+**Guiding outcome:** non-technical owners should see fewer walls of text, one clear
+next action, working actions/deep links, mobile-safe navigation, and technical detail
+behind progressive disclosure.
+
+## Scope of this branch
+
+This branch ships the one epic BI with **no existing PR** — the P1 login blocker.
+
+### BI-86165533 — Login can appear inert with valid local admin credentials (P1, bug)
+
+Root cause: with `trustHost: true` and no `AUTH_URL`, Auth.js can derive its base URL
+from the container's `0.0.0.0` bind address on some request paths. A relative
+`redirectTo: "/workspace"` then resolves to `http://0.0.0.0:3000/workspace`, which is a
+valid bind address but **not** a routable browser destination — so a valid login
+silently leaves the browser on `/login` with no error and no console message. Same root
+cause as the observed `http://0.0.0.0:3000` callback redirect.
+
+Fix (`apps/web/lib/govern/auth-redirect.ts`): a pure
+`normalizeAuthRedirect({url, baseUrl, publicUrl})` that rewrites a non-routable bind host
+(`0.0.0.0`, `::`) to the operator-visible host — `PUBLIC_URL` when the operator has
+configured one, otherwise `localhost` (scheme + port preserved) — while preserving
+Auth.js's open-redirect guard. Wired into the Auth.js `redirect` callback in
+`apps/web/lib/govern/auth.ts`. Regression coverage: `auth-redirect.test.ts` (13 cases
+including the exact `/workspace` × `0.0.0.0` failing case).
+
+**Design grounding:** extends the existing auth/host substrate
+(`apps/web/lib/govern/auth.ts`, `apps/web/lib/canonical-host.ts`, `apps/web/proxy.ts`);
+adds a normalization step inside the existing `redirect` callback, does not fork host
+policy.
+
+## Rest of the epic slice — already in flight (do not duplicate)
+
+An overlap sweep at branch-finish time found the remaining audit BIs already have open,
+ready-to-merge PRs from a concurrent effort. This branch deliberately does **not** touch
+their files:
+
+| BI | Priority | Existing PR | Approach there |
+| --- | --- | --- | --- |
+| BI-BF53A701 (Simple mode density) | 2 | #3378 | adds `density` to `WorkspaceTwinHero`, condenses the hero in Simple mode |
+| BI-882B3680 (mobile nav overflow) | 4 | #3377 | makes the mobile rail `flex-wrap` (no horizontal scroll) + `min-w-0` |
+| BI-62FF22DB (header Feedback flow) | 8 | #3376 | — |
+| BI-7D7EE150 (owner-mutation confirm/undo) | 3 | #3379 | — |
+
+Observation for #3378 owners (not blocking): #3378 condenses the twin **hero** but leaves
+the demoted `platformBody` at hardcoded `density="simple"`, so the builder/operator
+`BusinessCommandCenter` (technical snapshot: coworker counts, open-work, improvement-proposal
+/ Build Studio counts) still renders there in both toggle states. If the audit's "88 AI
+coworkers / 3943 proposals" density is that snapshot, gating `BusinessCommandCenter` behind
+Full mode in `PlatformWorkspaceHome` would complete the Simple-mode reduction.
+
+## Deferred (next slice — own PRs)
+
+- **BI-8C0F219A** (P7, refactor) — route audience/destination-kind registry, **extending**
+  `apps/web/lib/ea/route-manifest.json` (`build-route-manifest.ts` + `audit-route-manifest.yml`)
+  with a pure `classifyRoute()` + explicit override registry + a CI warning on unclassified
+  new page routes. Enables the disclosure audit below.
+- **BI-1D718FCA** (P5, refactor) — progressive-disclosure audit of high-overload pages
+  (`/ops`, `/build`, `/workspace/inbox`, `/platform/tools/integrations`, `/platform/ai/overview`,
+  `/finance`, `/storefront`): owner-first summary + one next action + technical inventory behind
+  tabs/drawers, plus route-level word-count / disclosure-marker smoke checks keyed off the
+  BI-8C0F219A audience classification. Sequenced after the registry.
+
+## Verification
+
+- Unit: `apps/web/lib/govern/auth-redirect.test.ts` — 13 pass, run in the topic worktree.
+- The full runtime gates (typecheck, production build) are the CI required checks; the shared
+  local-CI convergence sandbox was `blocked_sandbox_drift` at attempt time (its
+  `pnpm install --frozen-lockfile` converge failed mid-install), which is a sandbox defect,
+  not product build evidence (AGENTS §5). The auth changes are a new pure module + one
+  callback wire; no dependency or schema change.


### PR DESCRIPTION
## What & why (BI-86165533, P1)

A valid local admin login could leave the browser on `/login` with **no error and no console message**. Root cause: with `trustHost: true` and no `AUTH_URL`, Auth.js can derive its base URL from the container's `0.0.0.0` bind address on some request paths, so `redirectTo: "/workspace"` resolved to `http://0.0.0.0:3000/workspace` — a valid bind address but **not** a routable browser destination — so the post-login navigation silently failed. This is the same root cause as the observed `http://0.0.0.0:3000` callback redirect in the usability study.

## Fix

- New pure `normalizeAuthRedirect()` (`apps/web/lib/govern/auth-redirect.ts`) rewrites a non-routable bind host (`0.0.0.0`, `::`) to the operator-visible host — `PUBLIC_URL` when configured, else `localhost` (scheme + port preserved) — while preserving Auth.js's open-redirect guard.
- Wired into the Auth.js `redirect` callback (`apps/web/lib/govern/auth.ts`).
- `auth-redirect.test.ts` — 13 unit tests incl. the exact `/workspace` × `0.0.0.0` failing case, query-string preservation on OAuth-flow redirects, `PUBLIC_URL` routing, healthy-localhost passthrough, and the open-redirect guard.

## Scope / overlap

This branch intentionally ships **only** BI-86165533 — the one EP-UX-COGLOAD audit BI with no open PR. An overlap sweep found the rest of the slice already in flight as ready PRs, so this branch does not touch their files:

- #3378 — BI-BF53A701 (Simple mode density)
- #3377 — BI-882B3680 (mobile nav overflow)
- #3376 — BI-62FF22DB (header Feedback flow)
- #3379 — BI-7D7EE150 (owner-mutation confirm/undo)

Coordination note + the two deferred refactors (BI-8C0F219A route registry, BI-1D718FCA progressive-disclosure audit) are captured in `docs/superpowers/plans/2026-07-22-ux-cognitive-load-audit-followup.md`.

## Verification

- `apps/web/lib/govern/auth-redirect.test.ts` — 13 pass, run in the topic worktree.
- Runtime gates (typecheck, production build) run as the CI required checks: the shared local-CI convergence sandbox was `blocked_sandbox_drift` at attempt time (its `pnpm install --frozen-lockfile` converge failed mid-install — a sandbox defect, not product evidence per AGENTS §5). No dependency or schema change; change is a new pure module + one callback wire.

UX-Fit-Decision: restores a broken user-facing flow; no new operator-configurable control or raw input.
Design-Grounding-Decision: extends existing auth/host substrate (`auth.ts`, `canonical-host.ts`, `proxy.ts`); normalization added inside the existing redirect callback.
Docs-Impact-Decision: `/login` is not in `DOCS_ROUTE_MAP`; no user-guide page maps to it.
Local-CI-Override: sandbox `blocked_sandbox_drift` (AGENTS §5); auth-redirect unit-verified in-worktree; CI required checks are the authoritative gate. Evidence: cmrvllqmu03ik01rwq6km07of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
