### PR TITLE
fix(attention): deep-link approval cards to the exact record (BI-1336126B)

### DIFF
--- a/apps/web/lib/attention/sources/business-approvals.test.ts
+++ b/apps/web/lib/attention/sources/business-approvals.test.ts
@@ -12,6 +12,7 @@ const NOW = new Date("2026-06-23T12:00:00.000Z").getTime();
 
 describe("billToAttentionItem", () => {
   const base = {
+    id: "bill_ckabc123",
     billRef: "BILL-2026-0001",
     currency: "GBP",
     amountDue: "500.00",
@@ -28,6 +29,16 @@ describe("billToAttentionItem", () => {
     expect(item.triage.residueReason).toBe("policy-approval");
   });
 
+  it("deep-links Review bill to the exact bill detail, not the list (BI-1336126B)", () => {
+    const item = billToAttentionItem({ ...base, dueDate: new Date("2026-06-22T10:00:00.000Z") }, NOW);
+    expect(item.actions).toHaveLength(1);
+    expect(item.actions[0].label).toBe("Review bill");
+    expect(item.actions[0].href).toBe("/finance/bills/bill_ckabc123");
+    expect(item.deepLink).toBe("/finance/bills/bill_ckabc123");
+    // Never the generic list route the owner had to re-search.
+    expect(item.actions[0].href).not.toBe("/finance/bills");
+  });
+
   it("leaves a far-off bill in the normal tier", () => {
     const item = billToAttentionItem({ ...base, dueDate: new Date("2026-08-01T10:00:00.000Z") }, NOW);
     expect(item.triage.timeToAct).toBe("none");
@@ -37,6 +48,7 @@ describe("billToAttentionItem", () => {
 
 describe("regulatoryToAttentionItem", () => {
   const base = {
+    id: "rs_ck0001",
     submissionId: "RS-1",
     title: "Quarterly VAT return",
     recipientBody: "HMRC",
@@ -50,6 +62,8 @@ describe("regulatoryToAttentionItem", () => {
     expect(item.riskClass).toBe("high-risk");
     expect(item.triage.timeToAct).toBe("due-today");
     expect(isOverrideTier(item)).toBe(true);
+    expect(item.actions[0].href).toBe("/compliance/submissions/rs_ck0001");
+    expect(item.deepLink).toBe("/compliance/submissions/rs_ck0001");
   });
 
   it("handles a submission with no deadline", () => {
@@ -75,6 +89,7 @@ describe("the no-deadline business approvals", () => {
 
   it("maps an expense claim, preferring submittedAt for age", () => {
     const item = expenseToAttentionItem({
+      id: "ec_ck77",
       claimId: "EC-1",
       title: "Client dinner",
       currency: "USD",
@@ -85,6 +100,8 @@ describe("the no-deadline business approvals", () => {
     expect(item.id).toBe("approval-expense:EC-1");
     expect(item.createdAtIso).toBe("2026-06-22T18:00:00.000Z");
     expect(item.context).toBe("USD 82.50");
+    expect(item.actions[0].href).toBe("/finance/expense-claims/ec_ck77");
+    expect(item.deepLink).toBe("/finance/expense-claims/ec_ck77");
   });
 
   it("maps a research proposal as low-risk", () => {

--- a/apps/web/lib/attention/sources/business-approvals.ts
+++ b/apps/web/lib/attention/sources/business-approvals.ts
@@ -59,6 +59,7 @@ export async function loadOutboundItems(db: Db): Promise<AttentionItem[]> {
 // ─── Bills (AP) — hard dueDate ───────────────────────────────────────────────
 
 export type BillRow = {
+  id: string;
   billRef: string;
   currency: string;
   amountDue: string;
@@ -68,6 +69,10 @@ export type BillRow = {
 
 export function billToAttentionItem(row: BillRow, nowMs: number): AttentionItem {
   const deadlineIso = row.dueDate.toISOString();
+  // Deep-link to the exact bill, not the bills list, so the owner lands on the
+  // specific decision instead of re-finding it (BI-1336126B). The detail route
+  // resolves by internal `id` (see getBill / the bills list row links).
+  const href = `/finance/bills/${encodeURIComponent(row.id)}`;
   return {
     id: `approval-bill:${row.billRef}`,
     source: "approval-bill",
@@ -83,8 +88,8 @@ export function billToAttentionItem(row: BillRow, nowMs: number): AttentionItem 
       irreversible: false,
     },
     createdAtIso: row.createdAt.toISOString(),
-    actions: [{ kind: "open-in-context", label: "Review bill", href: "/finance/bills" }],
-    deepLink: "/finance/bills",
+    actions: [{ kind: "open-in-context", label: "Review bill", href }],
+    deepLink: href,
     audience: { operator: true },
   };
 }
@@ -95,7 +100,7 @@ export async function loadBillItems(db: Db): Promise<AttentionItem[]> {
     where: { status: "awaiting_approval" },
     orderBy: { dueDate: "asc" },
     take: 50,
-    select: { billRef: true, currency: true, amountDue: true, dueDate: true, createdAt: true },
+    select: { id: true, billRef: true, currency: true, amountDue: true, dueDate: true, createdAt: true },
   });
   return rows.map((r) =>
     billToAttentionItem({ ...r, amountDue: r.amountDue.toString() }, nowMs),
@@ -105,6 +110,7 @@ export async function loadBillItems(db: Db): Promise<AttentionItem[]> {
 // ─── Expense claims — no hard deadline ───────────────────────────────────────
 
 export type ExpenseClaimRow = {
+  id: string;
   claimId: string;
   title: string;
   currency: string;
@@ -114,6 +120,8 @@ export type ExpenseClaimRow = {
 };
 
 export function expenseToAttentionItem(row: ExpenseClaimRow): AttentionItem {
+  // Deep-link to the exact claim (resolved by internal `id`, per getExpenseClaim).
+  const href = `/finance/expense-claims/${encodeURIComponent(row.id)}`;
   return {
     id: `approval-expense:${row.claimId}`,
     source: "approval-expense",
@@ -128,8 +136,8 @@ export function expenseToAttentionItem(row: ExpenseClaimRow): AttentionItem {
       irreversible: false,
     },
     createdAtIso: (row.submittedAt ?? row.createdAt).toISOString(),
-    actions: [{ kind: "open-in-context", label: "Review claim", href: "/finance/expense-claims" }],
-    deepLink: "/finance/expense-claims",
+    actions: [{ kind: "open-in-context", label: "Review claim", href }],
+    deepLink: href,
     audience: { operator: true },
   };
 }
@@ -139,7 +147,7 @@ export async function loadExpenseItems(db: Db): Promise<AttentionItem[]> {
     where: { status: "submitted" },
     orderBy: { submittedAt: "desc" },
     take: 50,
-    select: { claimId: true, title: true, currency: true, totalAmount: true, submittedAt: true, createdAt: true },
+    select: { id: true, claimId: true, title: true, currency: true, totalAmount: true, submittedAt: true, createdAt: true },
   });
   return rows.map((r) => expenseToAttentionItem({ ...r, totalAmount: r.totalAmount.toString() }));
 }
@@ -147,6 +155,7 @@ export async function loadExpenseItems(db: Db): Promise<AttentionItem[]> {
 // ─── Regulatory submissions — hard dueDate, high stakes ──────────────────────
 
 export type RegulatorySubmissionRow = {
+  id: string;
   submissionId: string;
   title: string;
   recipientBody: string;
@@ -157,6 +166,8 @@ export type RegulatorySubmissionRow = {
 
 export function regulatoryToAttentionItem(row: RegulatorySubmissionRow, nowMs: number): AttentionItem {
   const deadlineIso = row.dueDate ? row.dueDate.toISOString() : undefined;
+  // Deep-link to the exact submission (resolved by internal `id`, per getSubmission).
+  const href = `/compliance/submissions/${encodeURIComponent(row.id)}`;
   return {
     id: `compliance-submission:${row.submissionId}`,
     source: "compliance-submission",
@@ -172,8 +183,8 @@ export function regulatoryToAttentionItem(row: RegulatorySubmissionRow, nowMs: n
       irreversible: false,
     },
     createdAtIso: row.createdAt.toISOString(),
-    actions: [{ kind: "open-in-context", label: "Open submission", href: "/compliance/submissions" }],
-    deepLink: "/compliance/submissions",
+    actions: [{ kind: "open-in-context", label: "Open submission", href }],
+    deepLink: href,
     audience: { operator: true },
   };
 }
@@ -185,6 +196,7 @@ export async function loadRegulatoryItems(db: Db): Promise<AttentionItem[]> {
     orderBy: { dueDate: "asc" },
     take: 50,
     select: {
+      id: true,
       submissionId: true,
       title: true,
       recipientBody: true,

--- a/docs/superpowers/plans/2026-07-22-attention-deeplink-exact-record.md
+++ b/docs/superpowers/plans/2026-07-22-attention-deeplink-exact-record.md
@@ -1,0 +1,56 @@
+# BI-1336126B — Attention approval cards deep-link to the exact record
+
+Part of **EP-UX-COGLOAD** (live cognitive-load audit follow-up). Focused,
+one-concern change; the epic's other first-slice items ship separately
+(#3377 mobile overflow, #3378 Simple mode, #3380 login redirect).
+
+## Design grounding
+
+- **Source of truth reviewed** — `apps/web/lib/attention/sources/business-approvals.ts`
+  (the approval AttentionItem producers), `apps/web/lib/attention/owner-decision.ts`
+  (`ownerChoices` / `isOwnerSafeHref` — the card action projector), and the
+  id-keyed detail routes `app/(shell)/finance/bills/[id]`,
+  `finance/expense-claims/[id]`, `compliance/submissions/[id]` (each resolves by
+  internal `id` via `getBill` / `getExpenseClaim` / `getSubmission`, matching the
+  list-row links).
+- **Decision** — extend the existing attention producers; no new contract.
+
+## Problem (live evidence)
+
+On the running install the `/workspace` cockpit card action **Review bill**
+linked to `/finance/bills` — the generic list — with a real `BILL-2026-0001`
+awaiting approval. The owner, asked to review that specific bill, had to re-find
+it in the list. The expense and regulatory approval cards had the same list-level
+links.
+
+## Change
+
+Deep-link the three approval sources that have an id-keyed detail route to the
+exact record:
+
+- bill → `/finance/bills/{id}`
+- expense claim → `/finance/expense-claims/{id}`
+- regulatory submission → `/compliance/submissions/{id}`
+
+The producers now select the internal `id` and build the href from it (both the
+card `action.href` and `deepLink`). All three routes start with `/finance` or
+`/compliance`, so `isOwnerSafeHref` still admits them. Sources without an
+owner-safe detail route (outbound draft → `/customer/marketing`, research
+proposal → `/admin/research`) keep their section route.
+
+## Follow-up noted
+
+The bill **detail** page has no approve/reject control for `awaiting_approval`
+status; the working approval surface is the external `/s/approve/[token]` page,
+and the in-portal `/finance/ap/approvals/[token]` link built by
+`submitBillForApproval` is a dead route. Deep-linking to the detail preserves the
+decision context now; an in-portal approve action for `awaiting_approval` bills is
+a separate finance-UX gap (candidate BI).
+
+## Verification
+
+Unit: `apps/web/lib/attention/sources/business-approvals.test.ts` asserts each
+card deep-links to `/{route}/{id}` and never the bare list. Typecheck of the
+changed producer confirmed clean via a direct `tsc --noEmit` against the root
+install (the shared local-CI sandbox is drift-blocked — BI-7FEEBA8E — so the full
+prod-build/unit gate runs on CI).


### PR DESCRIPTION
## What & why

**BI-1336126B** (EP-UX-COGLOAD). Live usability study on `/workspace`: the cockpit action **Review bill** navigated to `/finance/bills` — a list — forcing the owner to re-find the specific bill they were asked to review (`BILL-2026-0001`, confirmed awaiting approval on the running install). The expense and regulatory approval cards had the same list-level links.

This is the one first-slice item of EP-UX-COGLOAD **not** already covered by a sibling PR (#3377 mobile overflow, #3378 Simple mode, #3380 login redirect).

## Change

Deep-link the three approval sources that have an id-keyed detail route to the exact record:

- bill → `/finance/bills/{id}`
- expense claim → `/finance/expense-claims/{id}`
- regulatory submission → `/compliance/submissions/{id}`

The producers now select the internal `id` and build the href from it (both the card `action.href` and `deepLink`). Routes resolve by internal `id` — matching the list-row links and `getBill` / `getExpenseClaim` / `getSubmission`. All three stay `isOwnerSafeHref` (start with `/finance` or `/compliance`). Sources without an owner-safe detail route (outbound draft, research proposal) keep their section route.

## Design grounding

Grounds in `apps/web/lib/attention/sources/business-approvals.ts` and `apps/web/lib/attention/owner-decision.ts` — extends existing attention producers, no new contract. Plan: `docs/superpowers/plans/2026-07-22-attention-deeplink-exact-record.md`.

## Follow-up noted (not this PR)

The bill **detail** page has no approve/reject control for `awaiting_approval` status; the working approval surface is the external `/s/approve/[token]` page, and the in-portal `/finance/ap/approvals/[token]` link built by `submitBillForApproval` is a dead route. Deep-linking to the detail preserves the decision context now; an in-portal approve action for `awaiting_approval` bills is a separate finance-UX gap (candidate BI).

## Verification

- Unit: `business-approvals.test.ts` asserts each card deep-links to `/{route}/{id}` and never the bare list (8 tests green via the root toolchain).
- Typecheck of the changed producer confirmed clean via a direct `tsc --noEmit` against the root install.
- **Local-CI-Override**: the shared local-CI sandbox is drift-blocked (**BI-7FEEBA8E**: `vitest@4.1.9` vs locked `4.1.10`), so the full prod-build/unit gate could not run in the sandbox lane; CI runs the authoritative typecheck / build / unit checks here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)