### PR TITLE
fix(booking): drop duplicate blank Preferred date/time after slot selection (BI-0E4A1228, BI-36807E68)

### DIFF
--- a/apps/web/components/storefront/SlotBookingFlow.tsx
+++ b/apps/web/components/storefront/SlotBookingFlow.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { submitBooking } from "@/lib/storefront-actions";
 import { EmailInput } from "@/components/ui/EmailInput";
 import { PhoneInput } from "@/components/ui/PhoneInput";
+import { slotFlowExtraFields, type FormField } from "./slot-booking-fields";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -27,15 +28,6 @@ type SlotsResult =
   | { mode: "class"; slots: AvailableSlot[] };
 
 type Step = "date" | "slot" | "form" | "confirmation";
-
-type FormField = {
-  name: string;
-  label: string;
-  type: string;
-  required: boolean;
-  options?: string[];
-  placeholder?: string;
-};
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -473,11 +465,19 @@ function DateStep({
           const isPast = dateStr < todayStr;
           const isClickable = isAvailable && !isPast && !loading;
 
+          // The visible label is just the day number, so give the button an
+          // accessible name tied to the full date + availability, e.g.
+          // "Wednesday, July 22, 2026 — available" (BI-36807E68).
+          const dayAccessibleName = `${formatDisplayDate(dateStr)}${
+            isClickable ? " — available" : isPast ? " — past" : " — no availability"
+          }`;
+
           return (
             <button
               key={day}
               disabled={!isClickable}
               onClick={() => isClickable && onSelectDate(dateStr)}
+              aria-label={dayAccessibleName}
               style={{
                 textAlign: "center",
                 padding: "8px 4px",
@@ -821,7 +821,7 @@ function FormStep({
           <PhoneInput name="phone" style={inputStyle} />
         </div>
 
-        {formSchema?.filter(f => !["name", "email", "phone", "notes", "message"].includes(f.name)).map((field) => (
+        {slotFlowExtraFields(formSchema).map((field) => (
           <div key={field.name} style={fieldStyle}>
             <label style={labelStyle}>{field.label}{field.required ? " *" : " (optional)"}</label>
             {field.type === "textarea" ? (

--- a/apps/web/components/storefront/slot-booking-fields.test.ts
+++ b/apps/web/components/storefront/slot-booking-fields.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { slotFlowExtraFields, type FormField } from "./slot-booking-fields";
+
+// Mirrors the Restaurant archetype inquiry schema in
+// packages/storefront-templates/src/archetypes/food-hospitality.ts — the schema
+// the /s/<org>/book/<itemId> slot flow reuses. The calendar step already owns
+// `date` and the slot step already owns `time`, so they must NOT reappear as
+// blank controls in the confirmation form (BI-0E4A1228 / BI-36807E68).
+const RESTAURANT_INQUIRY_SCHEMA: FormField[] = [
+  { name: "covers", label: "Number of guests", type: "number", required: true },
+  { name: "date", label: "Preferred date", type: "text", required: true, placeholder: "DD/MM/YYYY" },
+  { name: "time", label: "Preferred time", type: "select", required: true, options: ["6:00 PM", "6:30 PM"] },
+  { name: "dietaryRequirements", label: "Dietary requirements", type: "textarea", required: false },
+];
+
+describe("slotFlowExtraFields (BI-0E4A1228 / BI-36807E68)", () => {
+  it("drops the scheduling fields the slot flow already captured", () => {
+    const names = slotFlowExtraFields(RESTAURANT_INQUIRY_SCHEMA).map((f) => f.name);
+
+    // No blank duplicate Preferred date/time after slot selection.
+    expect(names).not.toContain("date");
+    expect(names).not.toContain("time");
+    // Genuinely-extra fields the customer still needs to fill are kept.
+    expect(names).toContain("covers");
+    expect(names).toContain("dietaryRequirements");
+  });
+
+  it("matches scheduling field names regardless of case and separators", () => {
+    const schema: FormField[] = [
+      { name: "Preferred Date", label: "Preferred date", type: "text", required: true },
+      { name: "preferred_time", label: "Preferred time", type: "text", required: true },
+      { name: "preferredDate", label: "Preferred date", type: "text", required: true },
+      { name: "partySize", label: "Party size", type: "number", required: true },
+    ];
+
+    const names = slotFlowExtraFields(schema).map((f) => f.name);
+    expect(names).toEqual(["partySize"]);
+  });
+
+  it("still drops the explicit contact fields FormStep renders itself", () => {
+    const schema: FormField[] = [
+      { name: "name", label: "Full name", type: "text", required: true },
+      { name: "email", label: "Email", type: "email", required: true },
+      { name: "phone", label: "Phone", type: "tel", required: false },
+      { name: "allergens", label: "Allergens", type: "textarea", required: false },
+    ];
+
+    expect(slotFlowExtraFields(schema).map((f) => f.name)).toEqual(["allergens"]);
+  });
+
+  it("returns an empty array for an undefined schema", () => {
+    expect(slotFlowExtraFields(undefined)).toEqual([]);
+  });
+});

--- a/apps/web/components/storefront/slot-booking-fields.ts
+++ b/apps/web/components/storefront/slot-booking-fields.ts
@@ -1,0 +1,49 @@
+// Field-schema helpers for the public slot-booking flow (BI-0E4A1228 /
+// BI-36807E68). Kept in a standalone, dependency-free module so they are
+// unit-testable without importing the heavy `SlotBookingFlow` client component.
+
+export type FormField = {
+  name: string;
+  label: string;
+  type: string;
+  required: boolean;
+  options?: string[];
+  placeholder?: string;
+};
+
+// Fields the slot-booking flow already captures itself — the calendar step owns
+// the date and the slot step owns the time — plus the contact fields FormStep
+// renders explicitly. These are dropped from the archetype's inquiry schema so
+// the confirmation step never shows a blank duplicate "Preferred date/time"
+// after a slot has already been chosen.
+export const SLOT_FLOW_HANDLED_FIELD_NAMES = new Set<string>([
+  // contact fields rendered explicitly above the schema fields
+  "name",
+  "email",
+  "phone",
+  "notes",
+  "message",
+  // scheduling fields the calendar + slot steps already captured
+  "date",
+  "time",
+  "datetime",
+  "slot",
+  "scheduledat",
+  "preferreddate",
+  "preferredtime",
+]);
+
+function canonicalFieldName(name: string): string {
+  return name.toLowerCase().replace(/[-_\s]/g, "");
+}
+
+/** The archetype schema fields the confirmation form should still render — i.e.
+ *  everything the slot-booking flow does not already own (contact fields and the
+ *  scheduled date/time). Names are matched case-, separator-, and
+ *  whitespace-insensitively, so `preferred-date`, `Preferred Date`, and
+ *  `preferredDate` all resolve to the same handled field. */
+export function slotFlowExtraFields(formSchema?: FormField[]): FormField[] {
+  return (formSchema ?? []).filter(
+    (f) => !SLOT_FLOW_HANDLED_FIELD_NAMES.has(canonicalFieldName(f.name)),
+  );
+}


### PR DESCRIPTION
## What & why

Food & hospitality vertical (EP-VERTICAL-FOOD-HOSPITALITY; BI-0E4A1228, BI-36807E68). Live usability study on the Restaurant booking flow (`/s/<org>/book/<itemId>`): after choosing day 22 and time 6:30 PM, the final confirmation form **still** showed blank **Preferred date \*** and **Preferred time \*** controls — so it was unclear whether the selected slot was locked or could be accidentally changed.

## Root cause

The confirmation `FormStep` renders the archetype inquiry schema minus only the contact fields (name/email/phone/notes/message). The Restaurant schema's `date` and `time` fields — already captured by the calendar step and the slot step — were not excluded, so they re-rendered as fresh empty controls (and were dead weight on submit; `scheduledAt` is derived from the slot).

## Change

- New `slot-booking-fields.ts`: `slotFlowExtraFields` drops the fields the flow already owns (contact + scheduling), matching names case/separator-insensitively so `date`, `Preferred Date`, `preferred_time`, `preferredDate` all resolve. `FormStep` uses it, so **slot selection is the single source of the date/time**.
- Calendar day buttons get an **accessible name** tied to the full date + availability ("Wednesday, July 22, 2026 — available") instead of a bare day number.

## Tests

`slot-booking-fields.test.ts` mirrors the real Restaurant inquiry schema and asserts the confirmation form drops `date`/`time` (no blank duplicates) while keeping genuinely-extra fields (covers, dietary/allergens), plus name-variant and undefined-schema cases.

## Design grounding

- Existing specs/plans reviewed: `search_specs_and_plans("restaurant booking slot lifecycle")` → no owning spec/plan.
- Current code substrate reviewed (code graph + rg): `apps/web/components/storefront/SlotBookingFlow.tsx`, `packages/storefront-templates/src/archetypes/food-hospitality.ts`.
- Source of truth: the slot-booking flow + the archetype inquiry schema.
- Decision: extend the existing slot-flow substrate; no new contract.

Design-Grounding-Decision: reviewed `apps/web/components/storefront/SlotBookingFlow.tsx` + the food-hospitality archetype schema; `search_specs_and_plans` found no owning spec; extends existing substrate, no new contract.
UX-Fit-Decision: human_cognitive_load — removes a confusing duplicate-input trap; slot selection is the one source of the scheduled date/time; adds accessible day names; no new route/tab/input.
Docs-Impact-Decision: public booking flow behavior fix; no user-guide page documents the archetype booking form fields.
Process-Spine-Decision: localized fix (one small pure module + one component + tests); no new route/migration and no large rewrite.

## Verification

Authored in a source-only worktree (no local test runner); relying on CI (Unit Tests, Typecheck, Prod Build) as the verification substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)