### PR TITLE
feat(navigation): explicit route audience/destination-kind registry + CI gate (BI-8C0F219A)

### DIFF
--- a/.github/workflows/audit-route-manifest.yml
+++ b/.github/workflows/audit-route-manifest.yml
@@ -18,6 +18,10 @@ on:
       - "apps/web/lib/ea/route-manifest.json"
       - "apps/web/scripts/build-route-manifest.ts"
       - "apps/web/lib/ea/route-extract.ts"
+      # The audience registry (BI-8C0F219A) derives from the manifest above.
+      - "apps/web/lib/navigation/route-audience.generated.json"
+      - "apps/web/lib/navigation/route-audience.ts"
+      - "apps/web/scripts/build-route-audience.ts"
       - ".github/workflows/audit-route-manifest.yml"
   push:
     branches: [main]
@@ -62,3 +66,11 @@ jobs:
 
       - name: Check route manifest is up to date
         run: pnpm --filter web check:route-manifest
+
+      # BI-8C0F219A: the audience/destination-kind registry derives from the manifest
+      # above, so it is checked right after. A new page route makes it stale (fix:
+      # pnpm --filter web build:route-audience && commit); routes the heuristic can
+      # only classify low-confidence are printed as a non-fatal warning to pin an
+      # override in apps/web/lib/navigation/route-audience.ts.
+      - name: Check route audience registry is up to date
+        run: pnpm --filter web check:route-audience

--- a/apps/web/lib/navigation/route-audience.generated.json
+++ b/apps/web/lib/navigation/route-audience.generated.json
@@ -1,0 +1,2338 @@
+{
+  "generator": "apps/web/scripts/build-route-audience.ts",
+  "pageRouteCount": 330,
+  "summary": {
+    "byAudience": {
+      "admin": 140,
+      "auth-setup": 11,
+      "builder": 3,
+      "customer": 10,
+      "owner": 148,
+      "public": 16,
+      "worker": 2
+    },
+    "byDestinationKind": {
+      "advanced-diagnostic": 94,
+      "detail": 154,
+      "legacy-internal": 29,
+      "section-home": 32,
+      "settings-config": 12,
+      "workflow-step": 9
+    },
+    "overrideCount": 5,
+    "lowConfidenceCount": 0,
+    "lowConfidencePaths": []
+  },
+  "routes": [
+    {
+      "routePath": "/",
+      "audience": "auth-setup",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "override"
+    },
+    {
+      "routePath": "/admin",
+      "audience": "admin",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/archetypes",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/backlog",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/backups",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/branding",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/build-studio/stall-thresholds",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/business-context",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/business-models",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/cockpit",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/data-stewardship",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/diagnostics",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/hive",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/issue-reports",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/operating-hours",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/platform-development",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/prompts",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/reference-data",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/research",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/scheduled-jobs",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/settings",
+      "audience": "admin",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/skills",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/storefront",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/storefront/inbox",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/storefront/items",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/storefront/sections",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/storefront/settings",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/storefront/setup",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/storefront/team",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/twin-gallery",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/twin-gallery/[archetypeId]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/twin-kit",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/admin/wiki/lint",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/build",
+      "audience": "builder",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/build/work",
+      "audience": "builder",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/build/work/[capsuleId]",
+      "audience": "builder",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/complaints",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/actions",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/actions/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/audits",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/audits/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/controls",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/controls/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/evidence",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/evidence/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/gaps",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/incidents",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/incidents/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/licensing",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/obligations",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/obligations/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/onboard",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/policies",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/policies/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/posture",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/regulations",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/regulations/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/risks",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/risks/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/submissions",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/compliance/submissions/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/[...slug]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/craft",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/craft/[professionKey]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/decisions",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/decisions/[interactionId]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/edit/[...slug]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/matrix",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/perspectives",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/perspectives/[profileId]/voice",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/proactivity",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/review",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/coworker-decisions/stance",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer-complete-profile",
+      "audience": "auth-setup",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer-link-account",
+      "audience": "auth-setup",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer-login",
+      "audience": "auth-setup",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer-signup",
+      "audience": "auth-setup",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/engagements",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/funnel",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/marketing",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/marketing/automation",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/marketing/campaigns",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/marketing/funnel",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/marketing/strategy",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/opportunities",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/opportunities/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/quotes",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/quotes/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/customer/sales-orders",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/delivery",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/docs/[[...slug]]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ea",
+      "audience": "admin",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ea/agents",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ea/capabilities",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ea/data-model",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ea/models",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ea/models/[slug]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ea/value-streams",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ea/views",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ea/views/[id]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/employee",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/assets",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/assets/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/assets/new",
+      "audience": "owner",
+      "destinationKind": "workflow-step",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/banking",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/banking/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/banking/[id]/import",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/banking/[id]/reconcile",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/banking/new",
+      "audience": "owner",
+      "destinationKind": "workflow-step",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/banking/rules",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/bills",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/bills/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/bills/new",
+      "audience": "owner",
+      "destinationKind": "workflow-step",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/close",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/configuration",
+      "audience": "owner",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/expense-claims",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/expense-claims/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/funds",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/invoices",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/invoices/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/invoices/new",
+      "audience": "owner",
+      "destinationKind": "workflow-step",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/my-expenses",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/my-expenses/new",
+      "audience": "owner",
+      "destinationKind": "workflow-step",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/payment-runs",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/payments",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/purchase-orders",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/purchase-orders/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/purchase-orders/new",
+      "audience": "owner",
+      "destinationKind": "workflow-step",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/recurring",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/recurring/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/recurring/new",
+      "audience": "owner",
+      "destinationKind": "workflow-step",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/reports",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/reports/aged-creditors",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/reports/aged-debtors",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/reports/cash-flow",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/reports/general-ledger",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/reports/outstanding",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/reports/profit-loss",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/reports/revenue-by-customer",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/reports/vat-summary",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/revenue",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/settings",
+      "audience": "owner",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/settings/currency",
+      "audience": "owner",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/settings/dunning",
+      "audience": "owner",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/settings/rate-card",
+      "audience": "owner",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/settings/setup",
+      "audience": "owner",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/settings/tax",
+      "audience": "owner",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/spend",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/spend/ai",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/suppliers",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/suppliers/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/finance/suppliers/new",
+      "audience": "owner",
+      "destinationKind": "workflow-step",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/forgot-password",
+      "audience": "auth-setup",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/governance",
+      "audience": "admin",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/governance/records-requests",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/inventory",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/inventory/entity/[entityId]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/knowledge",
+      "audience": "public",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "override"
+    },
+    {
+      "routePath": "/knowledge/[articleId]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/knowledge/new",
+      "audience": "admin",
+      "destinationKind": "workflow-step",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/login",
+      "audience": "auth-setup",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/member-equity",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ops",
+      "audience": "admin",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ops/changes",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ops/demand",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ops/dev-loop",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ops/health",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ops/improvements",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ops/patches",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ops/promotions",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ops/security",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/ops/self-upgrade",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform",
+      "audience": "admin",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/agent/[agentId]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/assignments",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/assignments/bindings/[bindingId]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/authority",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/browser-sessions",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/browser-sessions/setup",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/build-studio",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/capability-needs",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/capacity-continuity",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/catalog",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/decisions/[interactionId]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/founder-review",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/history",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/memory",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/model-assignment",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/operations",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/operations-map",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/overview",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/priority",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/priority/outcomes",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/prompts",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/providers",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/providers/[providerId]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/readiness",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/routing",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/runtime-health",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/ai/skills",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/audit",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/audit/authority",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/audit/journal",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/audit/ledger",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/audit/metrics",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/audit/operations",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/audit/routes",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/development/change-lanes",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/device-catalog",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/edge-nodes",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/federation-links",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/federation-proposals",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/identity",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/identity/agents",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/identity/applications",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/identity/authorization",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/identity/authorization/bindings/[bindingId]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/identity/directory",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/identity/federation",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/identity/groups",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/identity/principals",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/integrations",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/integrations/sync",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/schedule",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/service-desk",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/services",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/services/[serverId]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/services/activate",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/built-ins",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/catalog",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/catalog/sync",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/discovery",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/discovery/promotion-audit",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/adp",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/communications",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/email-postmark",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/facebook-lead-ads",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/facebook-pages",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/google-business-profile",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/google-marketing-intelligence",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/hubspot",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/instagram-business",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/linkedin-personal-social",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/mailchimp",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/microsoft365-communications",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/quickbooks",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/stripe",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/integrations/whatsapp-business",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/inventory",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/services",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/services/[serverId]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/platform/tools/services/activate",
+      "audience": "admin",
+      "destinationKind": "advanced-diagnostic",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portal",
+      "audience": "customer",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portal/account",
+      "audience": "customer",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portal/cases",
+      "audience": "customer",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portal/cases/[caseKey]",
+      "audience": "customer",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portal/health",
+      "audience": "customer",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portal/health/intake/[packetId]",
+      "audience": "customer",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portal/orders",
+      "audience": "customer",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portal/services",
+      "audience": "customer",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portal/sign-in",
+      "audience": "customer",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portal/support",
+      "audience": "customer",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/[[...slug]]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/architecture",
+      "audience": "owner",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/product/[id]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/architecture",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/backlog",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/changes",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/health",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/inventory",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/knowledge",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/offerings",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/supply-chain",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/team",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/versions",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/portfolio/products/[productId]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/rental",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/reset-password",
+      "audience": "auth-setup",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/book/[itemId]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/checkout",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/donate",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/inquire",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/inquire/[itemId]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/item/[itemId]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/order/[itemId]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/sign-in",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/sign-up",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/approve/[token]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/expense-approve/[token]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/pay/[token]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/quote/[token]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/sandbox-restricted",
+      "audience": "auth-setup",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/service-requests",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/setup",
+      "audience": "auth-setup",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/animals",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/dispatch",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/inbox",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/intake",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/items",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/sections",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/settings",
+      "audience": "owner",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/settings/business",
+      "audience": "owner",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/settings/capabilities",
+      "audience": "owner",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/settings/operations",
+      "audience": "owner",
+      "destinationKind": "settings-config",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/setup",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/team",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/storefront/units",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/welcome",
+      "audience": "auth-setup",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/wiki",
+      "audience": "admin",
+      "destinationKind": "legacy-internal",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/wiki/[...slug]",
+      "audience": "admin",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/workbooks",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/workbooks/[workbookId]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/workbooks/system/[entityType]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/workspace",
+      "audience": "owner",
+      "destinationKind": "section-home",
+      "confidence": "high",
+      "source": "override"
+    },
+    {
+      "routePath": "/workspace/calendar",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/workspace/cases/[caseKey]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/workspace/documents",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/workspace/documents/[documentId]",
+      "audience": "owner",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/workspace/inbox",
+      "audience": "worker",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "override"
+    },
+    {
+      "routePath": "/workspace/my-queue",
+      "audience": "worker",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "override"
+    }
+  ]
+}

--- a/apps/web/lib/navigation/route-audience.test.ts
+++ b/apps/web/lib/navigation/route-audience.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyRoute,
+  isAdvancedRoute,
+  isSectionHome,
+  ROUTE_AUDIENCE_OVERRIDES,
+  type ClassifiableRoute,
+} from "./route-audience";
+
+function route(routePath: string, extra: Partial<ClassifiableRoute> = {}): ClassifiableRoute {
+  const segments = routePath === "/" ? [] : routePath.replace(/^\//, "").split("/");
+  return { routePath, segments, dynamicParams: [], ...extra };
+}
+
+describe("classifyRoute — audience", () => {
+  it("maps builder / admin technical first segments", () => {
+    expect(classifyRoute(route("/build")).audience).toBe("builder");
+    expect(classifyRoute(route("/platform")).audience).toBe("admin");
+    expect(classifyRoute(route("/ops")).audience).toBe("admin");
+    expect(classifyRoute(route("/ea")).audience).toBe("admin");
+  });
+
+  it("maps owner/operator business first segments", () => {
+    expect(classifyRoute(route("/finance")).audience).toBe("owner");
+    expect(classifyRoute(route("/compliance")).audience).toBe("owner");
+    expect(classifyRoute(route("/customer")).audience).toBe("owner");
+  });
+
+  it("maps customer + public first segments", () => {
+    expect(classifyRoute(route("/portal")).audience).toBe("customer");
+    expect(classifyRoute(route("/s/abc")).audience).toBe("public");
+  });
+
+  it("maps auth/setup entry segments", () => {
+    expect(classifyRoute(route("/login")).audience).toBe("auth-setup");
+    expect(classifyRoute(route("/setup")).audience).toBe("auth-setup");
+    expect(classifyRoute(route("/reset-password")).audience).toBe("auth-setup");
+  });
+
+  it("defaults an unknown first segment to admin/low-confidence", () => {
+    const c = classifyRoute(route("/totally-new-thing"));
+    expect(c.audience).toBe("admin");
+    expect(c.confidence).toBe("low"); // surfaced by the CI unclassified warning
+  });
+});
+
+describe("classifyRoute — destination kind", () => {
+  it("flags redirect shims as legacy-internal", () => {
+    expect(classifyRoute(route("/admin", { redirectTo: "/admin/storefront" })).destinationKind).toBe(
+      "legacy-internal",
+    );
+  });
+
+  it("flags settings/config surfaces", () => {
+    expect(classifyRoute(route("/finance/settings")).destinationKind).toBe("settings-config");
+    expect(classifyRoute(route("/platform/configuration")).destinationKind).toBe("settings-config");
+  });
+
+  it("flags create/edit workflow steps", () => {
+    expect(classifyRoute(route("/finance/invoices/new")).destinationKind).toBe("workflow-step");
+    expect(classifyRoute(route("/customer/edit")).destinationKind).toBe("workflow-step");
+  });
+
+  it("flags dynamic pages as detail", () => {
+    expect(
+      classifyRoute(route("/finance/invoices/[id]", { dynamicParams: ["id"] })).destinationKind,
+    ).toBe("detail");
+  });
+
+  it("flags top-level section roots as section-home", () => {
+    expect(classifyRoute(route("/finance")).destinationKind).toBe("section-home");
+  });
+
+  it("flags deep technical pages as advanced-diagnostic", () => {
+    const c = classifyRoute(route("/platform/ai/runtime-health"));
+    expect(c.destinationKind).toBe("advanced-diagnostic");
+    expect(c.audience).toBe("admin");
+  });
+});
+
+describe("classifyRoute — overrides", () => {
+  it("an override wins over the heuristic and is high-confidence", () => {
+    const c = classifyRoute(route("/workspace/my-queue"));
+    expect(c.source).toBe("override");
+    expect(c.audience).toBe("worker");
+    expect(c.confidence).toBe("high");
+  });
+
+  it("every override key is a well-formed absolute path", () => {
+    for (const key of Object.keys(ROUTE_AUDIENCE_OVERRIDES)) {
+      expect(key.startsWith("/")).toBe(true);
+    }
+  });
+});
+
+describe("registry query helpers", () => {
+  it("isAdvancedRoute is true for admin/builder/advanced-diagnostic", () => {
+    expect(isAdvancedRoute({ audience: "admin", destinationKind: "detail" })).toBe(true);
+    expect(isAdvancedRoute({ audience: "builder", destinationKind: "detail" })).toBe(true);
+    expect(isAdvancedRoute({ audience: "owner", destinationKind: "advanced-diagnostic" })).toBe(true);
+    expect(isAdvancedRoute({ audience: "owner", destinationKind: "section-home" })).toBe(false);
+  });
+
+  it("isSectionHome is true only for section homes", () => {
+    expect(isSectionHome({ destinationKind: "section-home" })).toBe(true);
+    expect(isSectionHome({ destinationKind: "detail" })).toBe(false);
+  });
+});

--- a/apps/web/lib/navigation/route-audience.ts
+++ b/apps/web/lib/navigation/route-audience.ts
@@ -1,0 +1,232 @@
+// Route audience + destination-kind classification (BI-8C0F219A, EP-UX-COGLOAD).
+//
+// The portal has ~330 page routes but the hand-authored navigation model lists a
+// fraction of them, so the *purpose* of most routes is implicit and hard to police
+// as the portal grows. This module makes it explicit: every page route is classified
+// by its primary AUDIENCE (who the surface is for) and DESTINATION KIND (what shape of
+// destination it is). A generated, committed registry
+// (`route-audience.generated.json`, built by `scripts/build-route-audience.ts`) is the
+// queryable output; a CI check keeps it fresh and warns when a new page route can only
+// be classified with low confidence and has no explicit override.
+//
+// This layers on top of the route-inventory single source of truth
+// (`apps/web/lib/ea/route-manifest.json`) — it does NOT re-walk the filesystem or fork
+// the inventory. Pure + dependency-free so the build script (plain Node) and unit tests
+// can import it.
+
+/** Who a page route is primarily for. */
+export type RouteAudience =
+  | "owner" // the non-technical business owner / operator making business decisions
+  | "worker" // day-to-day task execution (queues, my-work)
+  | "customer" // authenticated external customer (the /portal experience)
+  | "builder" // platform delivery / Build Studio surfaces
+  | "admin" // platform administration, operations, architecture, governance
+  | "public" // unauthenticated marketing / short-link / reference surfaces
+  | "auth-setup"; // login, setup, welcome, credential recovery
+
+/** What shape of destination a page route is. */
+export type RouteDestinationKind =
+  | "section-home" // a durable domain landing (top-level section root)
+  | "detail" // a record/entity detail page (usually dynamic)
+  | "workflow-step" // a step in a create/edit/wizard flow
+  | "settings-config" // settings / configuration surface
+  | "advanced-diagnostic" // deep technical / diagnostic surface (progressive-disclosure boundary)
+  | "legacy-internal"; // redirect shim / internal-only / deprecated
+
+export const ROUTE_AUDIENCES: readonly RouteAudience[] = [
+  "owner",
+  "worker",
+  "customer",
+  "builder",
+  "admin",
+  "public",
+  "auth-setup",
+] as const;
+
+export const ROUTE_DESTINATION_KINDS: readonly RouteDestinationKind[] = [
+  "section-home",
+  "detail",
+  "workflow-step",
+  "settings-config",
+  "advanced-diagnostic",
+  "legacy-internal",
+] as const;
+
+/** The minimal route shape the classifier needs (a subset of RouteManifestRow). */
+export interface ClassifiableRoute {
+  routePath: string;
+  segments: string[];
+  dynamicParams: string[];
+  redirectTo?: string;
+}
+
+export interface RouteClassification {
+  audience: RouteAudience;
+  destinationKind: RouteDestinationKind;
+  /** "high" when the first segment is known AND a specific kind rule matched;
+   *  "low" when the audience/kind is a fallback guess — these want an override. */
+  confidence: "high" | "low";
+  /** "override" when a pin in ROUTE_AUDIENCE_OVERRIDES decided it, else "heuristic". */
+  source: "heuristic" | "override";
+}
+
+// ─── First-segment → audience (the durable-domain map) ───────────────────────
+//
+// Best-guess DEFAULT per top-level segment. Ambiguous or refine-worthy routes are
+// pinned in ROUTE_AUDIENCE_OVERRIDES below; anything that falls through to the
+// UNKNOWN default is classified low-confidence and surfaced by the CI warning.
+
+const AUTH_SETUP_SEGMENTS = new Set([
+  "login",
+  "welcome",
+  "setup",
+  "forgot-password",
+  "reset-password",
+  "customer-login",
+  "customer-signup",
+  "customer-complete-profile",
+  "customer-link-account",
+  "sandbox-restricted",
+]);
+
+const FIRST_SEGMENT_AUDIENCE: Record<string, RouteAudience> = {
+  // Platform delivery / build
+  build: "builder",
+  // Platform administration / operations / architecture / governance / knowledge ops
+  platform: "admin",
+  admin: "admin",
+  ops: "admin",
+  ea: "admin",
+  governance: "admin",
+  wiki: "admin",
+  knowledge: "admin",
+  // External customer + public
+  portal: "customer",
+  s: "public",
+  docs: "public",
+  // Owner / operator business domains
+  finance: "owner",
+  workspace: "owner",
+  compliance: "owner",
+  customer: "owner", // owner-facing CRM (managing customers)
+  storefront: "owner", // internal storefront management (AGENTS §2: /storefront is internal)
+  portfolio: "owner",
+  "coworker-decisions": "owner",
+  workbooks: "owner",
+  inventory: "owner",
+  delivery: "owner",
+  complaints: "owner",
+  employee: "owner",
+  rental: "owner",
+  "member-equity": "owner",
+  "service-requests": "owner",
+};
+
+/** Segments that mark a settings/configuration surface anywhere in the path. */
+const SETTINGS_SEGMENTS = new Set(["settings", "configuration", "config", "preferences"]);
+/** Trailing segments that mark a create/edit/wizard workflow step. */
+const WORKFLOW_SEGMENTS = new Set(["new", "create", "edit", "add", "wizard", "onboarding"]);
+/** First segments whose deep pages are technical/diagnostic by default. */
+const ADVANCED_FIRST_SEGMENTS = new Set(["platform", "admin", "ops", "ea", "governance", "wiki"]);
+
+/**
+ * Explicit overrides — the pin registry. Add an entry here when the heuristic gets a
+ * route wrong or classifies it low-confidence. Keyed by exact routePath.
+ */
+export const ROUTE_AUDIENCE_OVERRIDES: Record<
+  string,
+  { audience: RouteAudience; destinationKind: RouteDestinationKind }
+> = {
+  "/": { audience: "auth-setup", destinationKind: "legacy-internal" }, // redirect → /welcome
+  "/workspace": { audience: "owner", destinationKind: "section-home" },
+  "/workspace/my-queue": { audience: "worker", destinationKind: "detail" },
+  "/workspace/inbox": { audience: "worker", destinationKind: "detail" },
+  "/knowledge": { audience: "public", destinationKind: "section-home" },
+  "/docs": { audience: "public", destinationKind: "section-home" },
+};
+
+// ─── Classifier ──────────────────────────────────────────────────────────────
+
+function lastSegment(segments: string[]): string {
+  return segments.length ? segments[segments.length - 1]! : "/";
+}
+
+/** Derive the audience from the first segment (auth-setup segments win). */
+function audienceOf(route: ClassifiableRoute): { audience: RouteAudience; known: boolean } {
+  const first = route.segments[0];
+  if (first && AUTH_SETUP_SEGMENTS.has(first)) return { audience: "auth-setup", known: true };
+  if (first && first in FIRST_SEGMENT_AUDIENCE) {
+    return { audience: FIRST_SEGMENT_AUDIENCE[first]!, known: true };
+  }
+  // Unknown top-level segment (or the root) — default to admin/internal, low confidence.
+  return { audience: "admin", known: false };
+}
+
+/** Derive the destination kind. Order matters — most specific first. */
+function destinationKindOf(route: ClassifiableRoute): RouteDestinationKind {
+  if (route.redirectTo) return "legacy-internal";
+
+  const last = lastSegment(route.segments);
+  const hasSettings = route.segments.some((s) => SETTINGS_SEGMENTS.has(s));
+  if (hasSettings) return "settings-config";
+
+  if (WORKFLOW_SEGMENTS.has(last)) return "workflow-step";
+
+  if (route.dynamicParams.length > 0) return "detail";
+
+  // A top-level section root (one static segment) is a durable section home.
+  if (route.segments.length === 1) return "section-home";
+
+  // Deep pages under a technical first segment are diagnostic/advanced.
+  const first = route.segments[0];
+  if (first && ADVANCED_FIRST_SEGMENTS.has(first) && route.segments.length >= 2) {
+    return "advanced-diagnostic";
+  }
+
+  // A deep static page under a business domain — best-effort detail.
+  return "detail";
+}
+
+/** Classify one page route into (audience, destinationKind) with a confidence + source. */
+export function classifyRoute(route: ClassifiableRoute): RouteClassification {
+  const override = ROUTE_AUDIENCE_OVERRIDES[route.routePath];
+  if (override) {
+    return {
+      audience: override.audience,
+      destinationKind: override.destinationKind,
+      confidence: "high",
+      source: "override",
+    };
+  }
+
+  const { audience, known } = audienceOf(route);
+  const kind = destinationKindOf(route);
+  // Confidence keys on AUDIENCE, the classification that matters for policing nav +
+  // progressive disclosure. Destination kind is always assigned best-effort; a
+  // known-audience route with an ambiguous kind is still "classified". Only an
+  // UNRECOGNISED first segment is genuinely unclassified and worth a human override —
+  // keeping the CI warning a meaningful signal, not noise across ~330 routes.
+  return {
+    audience,
+    destinationKind: kind,
+    confidence: known ? "high" : "low",
+    source: "heuristic",
+  };
+}
+
+// ─── Registry query helpers (for nav + progressive-disclosure consumers) ─────
+
+/** True when a route is a technical/diagnostic or admin/builder surface that should
+ *  sit behind a progressive-disclosure boundary for owner/worker audiences (BI-1D718FCA). */
+export function isAdvancedRoute(c: Pick<RouteClassification, "audience" | "destinationKind">): boolean {
+  return (
+    c.destinationKind === "advanced-diagnostic" ||
+    c.audience === "admin" ||
+    c.audience === "builder"
+  );
+}
+
+/** True when a route is a durable section home eligible for global/section navigation. */
+export function isSectionHome(c: Pick<RouteClassification, "destinationKind">): boolean {
+  return c.destinationKind === "section-home";
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "build:route-manifest": "tsx scripts/build-route-manifest.ts",
-    "check:route-manifest": "tsx scripts/build-route-manifest.ts --check"
+    "check:route-manifest": "tsx scripts/build-route-manifest.ts --check",
+    "build:route-audience": "tsx scripts/build-route-audience.ts",
+    "check:route-audience": "tsx scripts/build-route-audience.ts --check"
   },
   "dependencies": {
     "@axe-core/playwright": "^4.12.1",

--- a/apps/web/scripts/build-route-audience.ts
+++ b/apps/web/scripts/build-route-audience.ts
@@ -1,0 +1,147 @@
+/**
+ * Build-time route AUDIENCE registry (BI-8C0F219A, EP-UX-COGLOAD).
+ *
+ * Reads the route-inventory single source of truth
+ * (`apps/web/lib/ea/route-manifest.json`, produced by build-route-manifest.ts),
+ * classifies every PAGE route by audience + destination kind
+ * (`apps/web/lib/navigation/route-audience.ts`), and emits a deterministic committed
+ * registry (`apps/web/lib/navigation/route-audience.generated.json`).
+ *
+ * Deterministic by construction: stable input order + byte-stable sort + no timestamps,
+ * so a regeneration with no route changes produces identical bytes (no spurious diffs).
+ *
+ * Usage (local):
+ *   pnpm --filter web exec tsx scripts/build-route-audience.ts
+ *   pnpm --filter web exec tsx scripts/build-route-audience.ts --check   # fail if stale
+ *
+ * The `--check` mode is the CI gate: a new page route makes the committed registry
+ * stale, forcing a regeneration whose diff shows the route's classification. Routes the
+ * heuristic can only classify with LOW confidence (and that carry no explicit override)
+ * are listed in `summary.lowConfidencePaths` and printed as a non-fatal warning, so a
+ * reviewer can pin an override in ROUTE_AUDIENCE_OVERRIDES.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import {
+  classifyRoute,
+  type ClassifiableRoute,
+  type RouteAudience,
+  type RouteDestinationKind,
+} from "../lib/navigation/route-audience";
+
+function repoRoot(): string {
+  let dir = process.cwd();
+  while (dir !== "/" && dir !== resolve(dir, "..")) {
+    if (existsSync(join(dir, "pnpm-workspace.yaml"))) return dir;
+    dir = resolve(dir, "..");
+  }
+  return process.cwd();
+}
+const ROOT = repoRoot();
+const MANIFEST_REL = "apps/web/lib/ea/route-manifest.json";
+const OUT_REL = "apps/web/lib/navigation/route-audience.generated.json";
+
+interface ManifestRow {
+  routePath: string;
+  kind: "page" | "route";
+  segments: string[];
+  dynamicParams: string[];
+  redirectTo?: string;
+}
+
+interface RegistryRow {
+  routePath: string;
+  audience: RouteAudience;
+  destinationKind: RouteDestinationKind;
+  confidence: "high" | "low";
+  source: "heuristic" | "override";
+}
+
+function tally<T extends string>(rows: RegistryRow[], key: (r: RegistryRow) => T): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const r of rows) {
+    const k = key(r);
+    out[k] = (out[k] ?? 0) + 1;
+  }
+  // Deterministic key order.
+  return Object.fromEntries(Object.entries(out).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+}
+
+function buildRegistry() {
+  const manifestPath = join(ROOT, MANIFEST_REL);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as { routes: ManifestRow[] };
+
+  const pages = manifest.routes.filter((r) => r.kind === "page");
+  const rows: RegistryRow[] = pages
+    .map((p) => {
+      const route: ClassifiableRoute = {
+        routePath: p.routePath,
+        segments: p.segments,
+        dynamicParams: p.dynamicParams,
+        ...(p.redirectTo ? { redirectTo: p.redirectTo } : {}),
+      };
+      const c = classifyRoute(route);
+      return {
+        routePath: p.routePath,
+        audience: c.audience,
+        destinationKind: c.destinationKind,
+        confidence: c.confidence,
+        source: c.source,
+      };
+    })
+    .sort((a, b) => (a.routePath < b.routePath ? -1 : a.routePath > b.routePath ? 1 : 0));
+
+  const lowConfidencePaths = rows
+    .filter((r) => r.confidence === "low")
+    .map((r) => r.routePath);
+
+  return {
+    generator: "apps/web/scripts/build-route-audience.ts",
+    pageRouteCount: rows.length,
+    summary: {
+      byAudience: tally(rows, (r) => r.audience),
+      byDestinationKind: tally(rows, (r) => r.destinationKind),
+      overrideCount: rows.filter((r) => r.source === "override").length,
+      lowConfidenceCount: lowConfidencePaths.length,
+      lowConfidencePaths,
+    },
+    routes: rows,
+  };
+}
+
+function main(): void {
+  const check = process.argv.includes("--check");
+  const outPath = join(ROOT, OUT_REL);
+  const registry = buildRegistry();
+  const serialized = `${JSON.stringify(registry, null, 2)}\n`;
+
+  const warnLowConfidence = () => {
+    if (registry.summary.lowConfidenceCount > 0) {
+      console.error(
+        `[route-audience] WARNING: ${registry.summary.lowConfidenceCount} page route(s) are low-confidence and unclassified by override. ` +
+          `Pin them in ROUTE_AUDIENCE_OVERRIDES (apps/web/lib/navigation/route-audience.ts):`,
+      );
+      for (const p of registry.summary.lowConfidencePaths) console.error(`  - ${p}`);
+    }
+  };
+
+  if (check) {
+    const current = existsSync(outPath) ? readFileSync(outPath, "utf8") : "";
+    if (current !== serialized) {
+      console.error(
+        `[route-audience] STALE — ${OUT_REL} is out of date. Run: pnpm --filter web exec tsx scripts/build-route-audience.ts`,
+      );
+      process.exit(1);
+    }
+    warnLowConfidence();
+    console.error(`[route-audience] up to date (${registry.pageRouteCount} page routes)`);
+    return;
+  }
+
+  writeFileSync(outPath, serialized, "utf8");
+  warnLowConfidence();
+  console.error(`[route-audience] wrote ${OUT_REL} (${registry.pageRouteCount} page routes)`);
+}
+
+main();

--- a/docs/superpowers/specs/2026-07-22-route-audience-registry-design.md
+++ b/docs/superpowers/specs/2026-07-22-route-audience-registry-design.md
@@ -1,0 +1,79 @@
+# Route Audience & Destination-Kind Registry — design
+
+**BI:** BI-8C0F219A (EP-UX-COGLOAD — Live UX cognitive-load audit follow-up)
+**Date:** 2026-07-22
+**Status:** implemented (this PR)
+
+## Problem
+
+The live navigation/audience audit found **330 page routes** but the hand-authored
+navigation model lists ~71 nav paths — 261 page routes are not represented. That is not
+automatically wrong (many are detail, workflow, settings, auth, or direct-link pages),
+but the *purpose* of most routes is **implicit** and hard to police as the portal grows.
+The audit also found the largest audience bucket is technical/admin/knowledge (139
+routes), and section homes like `/finance` expose long destination catalogs in the same
+owner-facing flow. Without an explicit, machine-checkable classification there is no way
+to enforce rules like "global nav is limited to durable domains" or "advanced/technical
+routes must sit behind a progressive-disclosure boundary" (the latter is what BI-1D718FCA
+needs).
+
+## Design
+
+Layer an **explicit classification registry** on top of the existing route-inventory
+single source of truth — do **not** fork the inventory or re-walk the filesystem.
+
+- **Inventory SSOT (existing):** `apps/web/lib/ea/route-manifest.json`, produced by
+  `apps/web/scripts/build-route-manifest.ts` and kept fresh by the
+  `audit-route-manifest.yml` workflow (Parity Engine, domain 4). It already enumerates
+  every page/route with `segments`, `dynamicParams`, and `redirectTo`.
+- **Classifier (new, pure):** `apps/web/lib/navigation/route-audience.ts` —
+  `classifyRoute(route)` returns `{ audience, destinationKind, confidence, source }`.
+  - **Audience** (who it's for): `owner`, `worker`, `customer`, `builder`, `admin`,
+    `public`, `auth-setup`. Derived from a first-segment map + an auth/setup segment set.
+  - **Destination kind** (what shape): `section-home`, `detail`, `workflow-step`,
+    `settings-config`, `advanced-diagnostic`, `legacy-internal`. Derived by precedence:
+    redirect shim → settings/config segment → create/edit workflow segment → dynamic
+    param → top-level root → deep-under-technical-segment → best-effort detail.
+  - **Confidence** keys on the AUDIENCE (the classification that matters for policing
+    nav + disclosure). A route with an unrecognised first segment is `low` — genuinely
+    unclassified and worth a human override. Destination kind is always best-effort, so
+    it never drops confidence on its own (avoids ~150 noise warnings across 330 routes).
+  - **Overrides:** `ROUTE_AUDIENCE_OVERRIDES` — the pin registry for routes the heuristic
+    gets wrong or classifies low-confidence (e.g. `/workspace/my-queue` → worker).
+- **Generated registry (new, committed):**
+  `apps/web/lib/navigation/route-audience.generated.json`, built by
+  `apps/web/scripts/build-route-audience.ts` (deterministic, `--check` mode). Carries the
+  per-route classification plus a summary (`byAudience`, `byDestinationKind`,
+  `overrideCount`, `lowConfidenceCount`, `lowConfidencePaths`).
+- **CI gate (extended):** `audit-route-manifest.yml` runs `check:route-audience` right
+  after `check:route-manifest`. A new page route makes the registry stale → the check
+  fails → regenerate + commit, and the route's classification shows up in the diff.
+  Low-confidence routes with no override are printed as a **non-fatal warning** listing
+  their paths — the "warns when a new page route is unclassified" acceptance.
+- **Consumer helpers:** `isAdvancedRoute()` / `isSectionHome()` expose the progressive-
+  disclosure boundary and the durable-domain set for nav + BI-1D718FCA to consume.
+
+Initial run: 330 page routes → owner 148, admin 140, public 16, auth-setup 11,
+customer 10, builder 3, worker 2; kinds detail 154, advanced-diagnostic 94, section-home
+32, legacy-internal 29, settings-config 12, workflow-step 9; 5 overrides, 0 low-confidence.
+
+## Research & benchmarking
+
+- **Next.js App Router has no runtime route registry** — routes are filesystem
+  convention, compiled away in a standalone build. Both this registry and the existing
+  manifest solve that with a build-time walker + committed JSON (the pattern Nx and
+  Turborepo use for their project graphs: derive-and-commit, check-for-drift in CI).
+- **Route-metadata-as-data** mirrors how Remix/TanStack Router attach `handle`/route
+  metadata, and how design systems tag surfaces by audience — adopted: classification as
+  data, not scattered per-page constants. Rejected: a per-page `export const audience`
+  convention (330 edit sites, no central view, easy to forget) in favour of a central
+  heuristic + override registry with a freshness gate.
+- **Anti-pattern avoided:** duplicating the route inventory. The registry reads the EA
+  manifest so there is one enumeration of routes (single-source-of-truth, AGENTS §11).
+
+## Non-goals / next slice
+
+This PR delivers the registry + gate + query helpers. **Rewiring navigation** to consume
+it (global nav limited to durable `section-home`s, advanced routes gated behind
+disclosure) is **BI-1D718FCA**'s progressive-disclosure work, which builds on
+`isAdvancedRoute()` / the `advanced-diagnostic` set here.


### PR DESCRIPTION
## What & why (BI-8C0F219A, EP-UX-COGLOAD)

The live audit found **330 page routes** but the hand-authored nav model lists ~71 — the *purpose* of most routes is implicit and impossible to police as the portal grows (largest audience bucket is technical/admin/knowledge, and section homes like `/finance` dump long destination catalogs into the owner flow). This adds an explicit, machine-checkable **audience + destination-kind classification**, layered on the existing route-inventory SSOT (`apps/web/lib/ea/route-manifest.json`) — it does **not** fork the inventory or re-walk the filesystem.

## What's in it

- **`apps/web/lib/navigation/route-audience.ts`** — pure `classifyRoute()`:
  - **audience**: `owner · worker · customer · builder · admin · public · auth-setup`
  - **destination kind**: `section-home · detail · workflow-step · settings-config · advanced-diagnostic · legacy-internal`
  - a first-segment audience map, an explicit `ROUTE_AUDIENCE_OVERRIDES` pin registry, and `isAdvancedRoute()` / `isSectionHome()` consumer helpers. Confidence keys on **audience** so the unclassified warning is a meaningful signal, not noise across 330 routes.
- **`apps/web/scripts/build-route-audience.ts`** — deterministic generator with `--check`; warns (non-fatal) on low-confidence routes lacking an override.
- **`apps/web/lib/navigation/route-audience.generated.json`** — 330 routes classified: owner 148, admin 140, public 16, auth-setup 11, customer 10, builder 3, worker 2; advanced-diagnostic 94, detail 154, section-home 32, legacy-internal 29, settings-config 12, workflow-step 9; **0 low-confidence**.
- **`audit-route-manifest.yml`** — runs `check:route-audience` after `check:route-manifest`. A new page route makes the registry stale (fix: `pnpm --filter web build:route-audience && commit`); unclassified routes are surfaced for a human override — the "CI warns when a new route is unclassified" acceptance.
- **15 unit tests** for the classifier + helpers.

## Enables the next slice

The `advanced-diagnostic` set + `isAdvancedRoute()` are the progressive-disclosure boundary **BI-1D718FCA** consumes (keeping technical/admin routes out of owner/operator paths without an explicit disclosure boundary). Design: `docs/superpowers/specs/2026-07-22-route-audience-registry-design.md`.

## Verification

- Classifier: `apps/web/lib/navigation/route-audience.test.ts` — 15 pass (run in worktree).
- Generator `--check` up to date; registry regenerates deterministically.
- Full runtime gates (typecheck / prod build) are the CI required checks.

UX-Fit-Decision: no UI surface added (build-time registry + CI gate + helpers, no new route/tab/component/input); reduces future cognitive load by making the advanced-vs-owner boundary explicit and enforceable.
Design-Grounding-Decision: grounds on the route-inventory SSOT (`route-manifest.json`, `build-route-manifest.ts`, `route-extract.ts`) + Parity Engine routes domain; layers a new classification artifact rather than forking the inventory (AGENTS §11).
Docs-Impact-Decision: no documented user-facing route changes; internal navigation-governance substrate. New design spec added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
