### PR TITLE
fix(ui): shared accessible submit contract for user-facing forms (BI-8E74C749)

### DIFF
--- a/apps/web/components/admin/AdminUserAccessPanel.test.tsx
+++ b/apps/web/components/admin/AdminUserAccessPanel.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+//
+// Route-level accessible-submit-contract coverage for /admin "Create user"
+// (renders <AdminUserAccessPanel />). BI-8E74C749.
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock("@/lib/actions/users", () => ({
+  createUserAccount: vi.fn(),
+  adminIssuePasswordReset: vi.fn(),
+}));
+
+import { AdminUserAccessPanel } from "./AdminUserAccessPanel";
+
+const roles = [
+  { roleId: "HR-100", name: "HR Manager" },
+  { roleId: "OPS-200", name: "Operations" },
+];
+const users = [{ id: "u1", email: "person@company.com" }];
+
+afterEach(() => cleanup());
+
+describe("AdminUserAccessPanel accessible contract", () => {
+  it("labels every create-user control and wires names + password autocomplete", () => {
+    render(<AdminUserAccessPanel roles={roles} users={users} />);
+
+    const email = screen.getByLabelText(/email/i);
+    expect(email).toHaveAttribute("name", "new-user-email");
+    expect(email).toHaveAttribute("type", "email");
+    // An admin creating another account should not autofill their own address.
+    expect(email).toHaveAttribute("autocomplete", "off");
+
+    const password = screen.getByLabelText(/temporary password/i);
+    expect(password).toHaveAttribute("type", "password");
+    expect(password).toHaveAttribute("autocomplete", "new-password");
+    expect(password).toBeRequired();
+
+    expect(screen.getByLabelText(/primary role/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/superuser/i)).toHaveAttribute("type", "checkbox");
+  });
+
+  it("explains the consequence of creating a user (what/who/reversible/recovery)", () => {
+    render(<AdminUserAccessPanel roles={roles} users={users} />);
+    // Summary is always visible; the four details expand via progressive disclosure.
+    // The four term labels appear on every ConsequenceNotice, so assert presence
+    // (>= 1) rather than uniqueness here — the create-specific copy is the summary.
+    expect(screen.getByText(/creates a new sign-in and grants portal access/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/what changes/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/who's affected/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/can it be undone/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/if it was a mistake/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("explains the consequence of a password reset", () => {
+    render(<AdminUserAccessPanel roles={roles} users={users} />);
+    expect(
+      screen.getByText(/ends the user's current password and issues a recovery link/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders both submit actions", () => {
+    render(<AdminUserAccessPanel roles={roles} users={users} />);
+    expect(screen.getByRole("button", { name: /create user/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /issue recovery/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/admin/AdminUserAccessPanel.tsx
+++ b/apps/web/components/admin/AdminUserAccessPanel.tsx
@@ -8,7 +8,15 @@ import {
   type PasswordResetIssueResult,
   type UserActionResult,
 } from "@/lib/actions/users";
-import { EmailInput } from "@/components/ui/EmailInput";
+import {
+  EmailField,
+  TextField,
+  SelectField,
+  CheckboxField,
+  SubmitButton,
+  FormStatus,
+  ConsequenceNotice,
+} from "@/components/ui/form";
 
 type RoleOption = {
   roleId: string;
@@ -24,11 +32,6 @@ type Props = {
   roles: RoleOption[];
   users: UserOption[];
 };
-
-function resultClasses(result: UserActionResult | null): string {
-  if (!result) return "text-[var(--dpf-muted)]";
-  return result.ok ? "text-green-400" : "text-red-400";
-}
 
 export function AdminUserAccessPanel({ roles, users }: Props) {
   const router = useRouter();
@@ -67,9 +70,7 @@ export function AdminUserAccessPanel({ roles, users }: Props) {
         setResetResult({ ok: false, message: "Select a user to reset password." });
         return;
       }
-      const result = await adminIssuePasswordReset({
-        userId: resetUserId,
-      });
+      const result = await adminIssuePasswordReset({ userId: resetUserId });
       setResetResult(result);
       if (result.ok) {
         router.refresh();
@@ -78,104 +79,129 @@ export function AdminUserAccessPanel({ roles, users }: Props) {
   }
 
   return (
-    <div className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] p-4 space-y-6">
+    <div className="space-y-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4">
       <div>
         <h3 className="text-sm font-semibold text-[var(--dpf-text)]">Access setup (Admin)</h3>
-        <p className="text-xs text-[var(--dpf-muted)] mt-1">Create user credentials and perform password resets.</p>
+        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+          Create user credentials and perform password resets.
+        </p>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
-        <div className="space-y-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-          <h4 className="text-xs font-semibold text-[var(--dpf-text)] uppercase tracking-wider">Create user</h4>
-          <label className="block">
-            <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">Email</span>
-            <EmailInput
-              value={createEmail}
-              onValueChange={(v) => setCreateEmail(v)}
-              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-2 text-sm text-[var(--dpf-text)]"
-              placeholder="person@company.com"
-            />
-          </label>
-          <label className="block">
-            <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">Temporary password</span>
-            <input
-              value={createPassword}
-              onChange={(e) => setCreatePassword(e.target.value)}
-              type="password"
-              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-2 text-sm text-[var(--dpf-text)]"
-              placeholder="12+ chars, upper/lower/number/symbol"
-            />
-          </label>
-          <label className="block">
-            <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">Primary role</span>
-            <select
-              value={createRoleId}
-              onChange={(e) => setCreateRoleId(e.target.value)}
-              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-2 text-sm text-[var(--dpf-text)]"
-            >
-              {roles.map((role) => (
-                <option key={role.roleId} value={role.roleId}>
-                  {role.roleId} - {role.name}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="inline-flex items-center gap-2 text-xs text-[var(--dpf-muted)]">
-            <input
-              type="checkbox"
-              checked={createSuperuser}
-              onChange={(e) => setCreateSuperuser(e.target.checked)}
-              className="h-3.5 w-3.5 rounded border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
-            />
-            Superuser
-          </label>
-          <button
-            type="button"
-            disabled={isPending}
-            onClick={onCreate}
-            className="rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-white disabled:opacity-60"
-          >
-            {isPending ? "Saving..." : "Create user"}
-          </button>
-          <p className={`text-xs ${resultClasses(createResult)}`}>
-            {createResult?.message ?? "Password policy: min 12 chars with upper/lower/number/symbol."}
-          </p>
-        </div>
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
+        {/* Create user */}
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            onCreate();
+          }}
+          noValidate
+          className="space-y-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3"
+        >
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-[var(--dpf-text)]">
+            Create user
+          </h4>
 
-        <div className="space-y-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3">
-          <h4 className="text-xs font-semibold text-[var(--dpf-text)] uppercase tracking-wider">Password reset</h4>
-          <label className="block">
-            <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">User</span>
-            <select
-              value={resetUserId}
-              onChange={(e) => setResetUserId(e.target.value)}
-              className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2.5 py-2 text-sm text-[var(--dpf-text)]"
-            >
-              {users.map((user) => (
-                <option key={user.id} value={user.id}>
-                  {user.email}
-                </option>
-              ))}
-            </select>
-          </label>
-          <button
-            type="button"
-            disabled={isPending}
-            onClick={onReset}
-            className="rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-white disabled:opacity-60"
-          >
-            {isPending ? "Saving..." : "Issue recovery"}
-          </button>
+          <ConsequenceNotice
+            tone={createSuperuser ? "danger" : "info"}
+            summary="This creates a new sign-in and grants portal access."
+            what={
+              createSuperuser
+                ? "Adds an account with the temporary password and role you set. Superuser is ticked — this person will be able to control everything, including other admins."
+                : "Adds an account with the temporary password and role you set. They can sign in right away and are prompted to change the password."
+            }
+            who="The person at the email address you enter. No one else is notified automatically."
+            reversibility="Reversible — deactivate the account or change its role anytime from Employee → HR."
+            recovery="Wrong details? Deactivate the user under Employee → HR, or issue a password reset on the right."
+          />
+
+          <EmailField
+            name="new-user-email"
+            label="Email"
+            value={createEmail}
+            onValueChange={setCreateEmail}
+            required
+            autoComplete="off"
+            placeholder="person@company.com"
+          />
+          <TextField
+            name="temporary-password"
+            label="Temporary password"
+            type="password"
+            value={createPassword}
+            onValueChange={setCreatePassword}
+            required
+            autoComplete="new-password"
+            hint="Min 12 characters with upper/lower/number/symbol. The user changes it on first sign-in."
+          />
+          <SelectField
+            name="primary-role"
+            label="Primary role"
+            value={createRoleId}
+            onValueChange={setCreateRoleId}
+            required
+            options={roles.map((role) => ({ value: role.roleId, label: `${role.roleId} - ${role.name}` }))}
+          />
+          <CheckboxField
+            name="superuser"
+            label="Superuser"
+            checked={createSuperuser}
+            onCheckedChange={setCreateSuperuser}
+            hint="Full control of the platform, including other admin accounts. Grant only when necessary."
+          />
+          <SubmitButton pending={isPending} pendingLabel="Creating…">
+            Create user
+          </SubmitButton>
+          <FormStatus
+            error={createResult && !createResult.ok ? createResult.message : null}
+            success={createResult?.ok ? createResult.message : null}
+          />
+        </form>
+
+        {/* Password reset */}
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            onReset();
+          }}
+          noValidate
+          className="space-y-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3"
+        >
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-[var(--dpf-text)]">
+            Password reset
+          </h4>
+
+          <ConsequenceNotice
+            tone="warning"
+            summary="This ends the user's current password and issues a recovery link."
+            what="Their existing password stops working immediately. A one-time recovery link (or email, when configured) lets them set a new one."
+            who="The user you select below. They'll need the link to get back in."
+            reversibility="Partly — the old password can't be restored, but you can re-issue a new recovery link anytime."
+            recovery="If the email doesn't arrive, use the manual recovery link shown here after you issue it."
+          />
+
+          <SelectField
+            name="reset-user"
+            label="User"
+            value={resetUserId}
+            onValueChange={setResetUserId}
+            options={users.map((user) => ({ value: user.id, label: user.email }))}
+          />
+          <SubmitButton pending={isPending} pendingLabel="Issuing…">
+            Issue recovery
+          </SubmitButton>
           {resetResult?.recoveryLink ? (
             <div className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-3 py-2">
-              <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">Manual recovery link</span>
+              <span className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+                Manual recovery link
+              </span>
               <p className="mt-1 break-all text-xs text-[var(--dpf-text)]">{resetResult.recoveryLink}</p>
             </div>
           ) : null}
-          <p className={`text-xs ${resultClasses(resetResult)}`}>
-            {resetResult?.message ?? "Issue a recovery email when configured, or reveal a one-time manual link during bootstrap."}
-          </p>
-        </div>
+          <FormStatus
+            error={resetResult && !resetResult.ok ? resetResult.message : null}
+            success={resetResult?.ok ? resetResult.message : null}
+          />
+        </form>
       </div>
     </div>
   );

--- a/apps/web/components/admin/BusinessContextForm.test.tsx
+++ b/apps/web/components/admin/BusinessContextForm.test.tsx
@@ -48,4 +48,37 @@ describe("BusinessContextForm", () => {
     expect(html).toContain("Legacy spreadsheets");
     expect(html).toContain("sourceSystem");
   });
+
+  // BI-8E74C749: the /storefront/settings/business form must carry stable field
+  // names and correct autocomplete tokens (the compact audit flagged missing
+  // names on this dense setup form), plus an accessible submit action.
+  it("wires stable names on the free-text business fields", () => {
+    const html = renderToStaticMarkup(
+      <BusinessContextForm initial={baseInitial} archetypeSummary={null} />,
+    );
+    expect(html).toContain('name="description"');
+    expect(html).toContain('name="mission"');
+    expect(html).toContain('name="targetMarket"');
+  });
+
+  it("gives contact + address inputs autocomplete tokens", () => {
+    const html = renderToStaticMarkup(
+      <BusinessContextForm initial={baseInitial} archetypeSummary={null} />,
+    );
+    expect(html).toContain('name="contactEmail"');
+    expect(html).toContain('autocomplete="email"');
+    expect(html).toContain('name="contactPhone"');
+    expect(html).toContain('autocomplete="tel"');
+    expect(html).toContain('autocomplete="address-line1"');
+    expect(html).toContain('autocomplete="postal-code"');
+    expect(html).toContain('autocomplete="country"');
+  });
+
+  it("renders an accessible primary submit action", () => {
+    const html = renderToStaticMarkup(
+      <BusinessContextForm initial={baseInitial} archetypeSummary={null} isEdit={false} />,
+    );
+    expect(html).toContain("<button");
+    expect(html).toContain("Continue");
+  });
 });

--- a/apps/web/components/admin/BusinessContextForm.test.tsx
+++ b/apps/web/components/admin/BusinessContextForm.test.tsx
@@ -65,13 +65,16 @@ describe("BusinessContextForm", () => {
     const html = renderToStaticMarkup(
       <BusinessContextForm initial={baseInitial} archetypeSummary={null} />,
     );
+    // React 19 renderToStaticMarkup preserves the camelCase `autoComplete` prop
+    // name in the emitted markup (the browser + jsdom treat it case-insensitively),
+    // so match the token case-insensitively rather than assuming lowercase.
     expect(html).toContain('name="contactEmail"');
-    expect(html).toContain('autocomplete="email"');
+    expect(html).toMatch(/autocomplete="email"/i);
     expect(html).toContain('name="contactPhone"');
-    expect(html).toContain('autocomplete="tel"');
-    expect(html).toContain('autocomplete="address-line1"');
-    expect(html).toContain('autocomplete="postal-code"');
-    expect(html).toContain('autocomplete="country"');
+    expect(html).toMatch(/autocomplete="tel"/i);
+    expect(html).toMatch(/autocomplete="address-line1"/i);
+    expect(html).toMatch(/autocomplete="postal-code"/i);
+    expect(html).toMatch(/autocomplete="country"/i);
   });
 
   it("renders an accessible primary submit action", () => {

--- a/apps/web/components/admin/BusinessContextForm.tsx
+++ b/apps/web/components/admin/BusinessContextForm.tsx
@@ -8,6 +8,7 @@ import {
 } from "./business-context-form-state";
 import { EmailInput } from "@/components/ui/EmailInput";
 import { PhoneInput } from "@/components/ui/PhoneInput";
+import { SubmitButton, FormStatus } from "@/components/ui/form";
 import { BusinessDocumentUpload } from "@/components/admin/BusinessDocumentUpload";
 import { RosterImport } from "@/components/admin/RosterImport";
 import { MarketContextFields } from "@/components/admin/MarketContextFields";
@@ -340,6 +341,7 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
         <label style={labelStyle}>
           <div style={fieldLabelStyle}>What does your business do?</div>
           <textarea
+            name="description"
             value={data.description}
             onChange={(e) => update("description", e.target.value)}
             placeholder="Describe what your business does in 1-2 sentences"
@@ -375,6 +377,7 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
             )}
           </div>
           <textarea
+            name="mission"
             value={data.mission}
             onChange={(e) => update("mission", e.target.value)}
             placeholder={missionSuggestion ?? "Your mission in a sentence — the difference you set out to make"}
@@ -398,6 +401,7 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
           <div style={fieldLabelStyle}>Who do you serve?</div>
           <input
             type="text"
+            name="targetMarket"
             value={data.targetMarket}
             onChange={(e) => update("targetMarket", e.target.value)}
             placeholder="e.g. Homeowners in the community, Local pet owners, Small business clients"
@@ -496,7 +500,7 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
             {/* Country (drives the state picker + timezone) */}
             <label style={labelStyle}>
               <div style={fieldLabelStyle}>Country</div>
-              <select value={countrySel} onChange={(e) => onCountryChange(e.target.value)} style={inputStyle}>
+              <select name="country" autoComplete="country" value={countrySel} onChange={(e) => onCountryChange(e.target.value)} style={inputStyle}>
                 <option value="" style={optionStyle}>Select country…</option>
                 {COUNTRY_OPTIONS.map((c) => (
                   <option key={c.code} value={c.code} style={optionStyle}>{c.name}</option>
@@ -510,6 +514,8 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
                 <div style={fieldLabelStyle}>Country name</div>
                 <input
                   type="text"
+                  name="country"
+                  autoComplete="country-name"
                   value={data.address.country ?? ""}
                   onChange={(e) => updateAddressField("country", e.target.value)}
                   placeholder="Country"
@@ -523,6 +529,8 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
               <div style={fieldLabelStyle}>Street address</div>
               <input
                 type="text"
+                name="line1"
+                autoComplete="address-line1"
                 value={data.address.line1 ?? ""}
                 onChange={(e) => updateAddressField("line1", e.target.value)}
                 placeholder="123 Main St"
@@ -533,6 +541,8 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
               <div style={fieldLabelStyle}>Address line 2 {optionalHint}</div>
               <input
                 type="text"
+                name="line2"
+                autoComplete="address-line2"
                 value={data.address.line2 ?? ""}
                 onChange={(e) => updateAddressField("line2", e.target.value)}
                 placeholder="Suite, unit, floor"
@@ -546,6 +556,8 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
                 <div style={fieldLabelStyle}>City / Town</div>
                 <input
                   type="text"
+                  name="city"
+                  autoComplete="address-level2"
                   value={data.address.city ?? ""}
                   onChange={(e) => updateAddressField("city", e.target.value)}
                   placeholder="City"
@@ -557,6 +569,8 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
                 <label style={labelStyle}>
                   <div style={fieldLabelStyle}>State</div>
                   <select
+                    name="stateCode"
+                    autoComplete="address-level1"
                     value={data.address.stateCode ?? ""}
                     onChange={(e) => onStateChange(e.target.value)}
                     style={inputStyle}
@@ -572,6 +586,8 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
                   <div style={fieldLabelStyle}>State / Province / Region {optionalHint}</div>
                   <input
                     type="text"
+                    name="region"
+                    autoComplete="address-level1"
                     value={data.address.region ?? ""}
                     onChange={(e) => updateAddressField("region", e.target.value)}
                     placeholder="Region"
@@ -586,6 +602,8 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
               <div style={fieldLabelStyle}>Postal / ZIP code</div>
               <input
                 type="text"
+                name="postalCode"
+                autoComplete="postal-code"
                 value={data.address.postalCode ?? ""}
                 onChange={(e) => updateAddressField("postalCode", e.target.value)}
                 placeholder="ZIP / postcode"
@@ -718,8 +736,10 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
           <label style={labelStyle}>
             <div style={fieldLabelStyle}>Contact email</div>
             <EmailInput
+              name="contactEmail"
               value={data.contactEmail}
               onValueChange={(v) => update("contactEmail", v)}
+              autoComplete="email"
               placeholder="info@example.com"
               style={inputStyle}
             />
@@ -728,8 +748,10 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
           <label style={labelStyle}>
             <div style={fieldLabelStyle}>Contact phone</div>
             <PhoneInput
+              name="contactPhone"
               value={data.contactPhone}
               onValueChange={(v) => update("contactPhone", v)}
+              autoComplete="tel"
               placeholder="(415) 555-1234"
               style={inputStyle}
             />
@@ -737,30 +759,19 @@ export function BusinessContextForm({ initial, archetypeSummary, isEdit, autoFil
           </label>
         </div>
 
-        {/* Error / success */}
-        {error && <p style={{ color: "var(--dpf-error)", fontSize: 13, margin: 0 }}>{error}</p>}
-        {saved && <p style={{ color: "var(--dpf-success)", fontSize: 13, margin: 0 }}>Saved successfully.</p>}
+        {/* Error / success — announced live regions */}
+        <FormStatus error={error} success={saved ? "Saved successfully." : null} />
 
         {/* Actions */}
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <button
+          <SubmitButton
             type="button"
             onClick={handleSubmit}
-            disabled={submitting}
-            style={{
-              padding: "8px 20px",
-              borderRadius: 6,
-              border: "none",
-              background: "var(--dpf-accent)",
-              color: "#fff",
-              cursor: submitting ? "wait" : "pointer",
-              fontSize: 13,
-              fontWeight: 600,
-              opacity: submitting ? 0.7 : 1,
-            }}
+            pending={submitting}
+            pendingLabel="Saving…"
           >
-            {submitting ? "Saving..." : isEdit ? "Save" : "Continue"}
-          </button>
+            {isEdit ? "Save" : "Continue"}
+          </SubmitButton>
         </div>
       </div>
     </div>

--- a/apps/web/components/employee/CompensationPanel.test.tsx
+++ b/apps/web/components/employee/CompensationPanel.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+//
+// Route-level accessible-submit-contract coverage for /employee HR/pay
+// (renders <CompensationPanel />). BI-8E74C749.
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { EmployeeCompensationRow } from "@/lib/hr/compensation-data";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock("@/lib/actions/workforce", () => ({ setEmployeeCompensation: vi.fn() }));
+
+import { CompensationPanel } from "./CompensationPanel";
+
+const employees: EmployeeCompensationRow[] = [
+  {
+    employeeProfileId: "ep-1",
+    displayName: "Dana Rivera",
+    employeeId: "E-1",
+    payType: "hourly",
+    hourlyRate: 25,
+    annualSalary: null,
+    standardAnnualHours: null,
+  },
+];
+
+afterEach(() => cleanup());
+
+describe("CompensationPanel accessible contract", () => {
+  it("labels the employee picker and the pay-type choice", () => {
+    render(<CompensationPanel employees={employees} currency="GBP" />);
+    expect(screen.getByLabelText(/employee/i)).toBeInTheDocument();
+    // Pay-type radios live in a labelled fieldset.
+    expect(screen.getByRole("group", { name: /how is this person paid/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/paid hourly/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/salaried/i)).toBeInTheDocument();
+  });
+
+  it("labels the hourly rate field and marks it required", () => {
+    render(<CompensationPanel employees={employees} currency="GBP" />);
+    const rate = screen.getByLabelText(/hourly pay rate/i);
+    expect(rate).toHaveAttribute("name", "hourly-rate");
+    expect(rate).toHaveAttribute("type", "number");
+    expect(rate).toBeRequired();
+  });
+
+  it("swaps to the salary field with an optional advanced hours control", () => {
+    render(<CompensationPanel employees={employees} currency="GBP" />);
+    fireEvent.click(screen.getByLabelText(/salaried/i));
+    const salary = screen.getByLabelText(/annual salary/i);
+    expect(salary).toBeRequired();
+    // Standard hours is an optional field disclosed under "Advanced".
+    expect(screen.getByLabelText(/standard hours per year/i)).not.toBeRequired();
+  });
+
+  it("renders the save action", () => {
+    render(<CompensationPanel employees={employees} currency="GBP" />);
+    expect(screen.getByRole("button", { name: /save pay/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/employee/CompensationPanel.tsx
+++ b/apps/web/components/employee/CompensationPanel.tsx
@@ -9,6 +9,12 @@ import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { setEmployeeCompensation } from "@/lib/actions/workforce";
 import type { EmployeeCompensationRow } from "@/lib/hr/compensation-data";
+import {
+  SelectField,
+  TextField,
+  SubmitButton,
+  FormStatus,
+} from "@/components/ui/form";
 
 type Props = {
   employees: EmployeeCompensationRow[];
@@ -16,8 +22,7 @@ type Props = {
   currency: string;
 };
 
-const inputCls =
-  "w-32 px-2 py-1 text-xs rounded border border-[var(--dpf-border)] bg-[var(--dpf-bg)] text-[var(--dpf-text)]";
+type SaveResult = { ok: boolean; message: string };
 
 function describePay(e: EmployeeCompensationRow, currency: string): string {
   if (e.payType === "hourly" && e.hourlyRate != null) {
@@ -44,7 +49,7 @@ export function CompensationPanel({ employees, currency }: Props) {
   const [standardHours, setStandardHours] = useState<string>(
     selected?.standardAnnualHours?.toString() ?? "",
   );
-  const [message, setMessage] = useState<string | null>(null);
+  const [result, setResult] = useState<SaveResult | null>(null);
 
   function selectEmployee(id: string) {
     setSelectedId(id);
@@ -53,13 +58,13 @@ export function CompensationPanel({ employees, currency }: Props) {
     setHourlyRate(e?.hourlyRate?.toString() ?? "");
     setAnnualSalary(e?.annualSalary?.toString() ?? "");
     setStandardHours(e?.standardAnnualHours?.toString() ?? "");
-    setMessage(null);
+    setResult(null);
   }
 
   function handleSave() {
     if (!selected) return;
     startTransition(async () => {
-      const result = await setEmployeeCompensation({
+      const saved = await setEmployeeCompensation({
         employeeProfileId: selected.employeeProfileId,
         payType,
         ...(payType === "hourly"
@@ -69,8 +74,8 @@ export function CompensationPanel({ employees, currency }: Props) {
               standardAnnualHours: standardHours ? parseInt(standardHours, 10) || null : null,
             }),
       });
-      setMessage(result.message);
-      if (result.ok) router.refresh();
+      setResult(saved);
+      if (saved.ok) router.refresh();
     });
   }
 
@@ -86,105 +91,107 @@ export function CompensationPanel({ employees, currency }: Props) {
       {employees.length === 0 ? (
         <p className="text-xs text-[var(--dpf-muted)]">Add an employee first, then set their pay here.</p>
       ) : (
-        <div className="space-y-3">
-          <div className="flex flex-wrap items-center gap-2">
-            <select
-              value={selectedId}
-              onChange={(e) => selectEmployee(e.target.value)}
-              className="px-2 py-1 text-xs rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] max-w-56"
-              aria-label="Employee"
-            >
-              {employees.map((e) => (
-                <option key={e.employeeProfileId} value={e.employeeProfileId} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
-                  {e.displayName}
-                </option>
-              ))}
-            </select>
-            {selected && (
-              <span className="text-[10px] text-[var(--dpf-muted)]">{describePay(selected, currency)}</span>
-            )}
-          </div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSave();
+          }}
+          noValidate
+          className="space-y-3"
+        >
+          <SelectField
+            name="pay-employee"
+            label="Employee"
+            value={selectedId}
+            onValueChange={selectEmployee}
+            options={employees.map((e) => ({ value: e.employeeProfileId, label: e.displayName }))}
+          />
+          {selected && (
+            <p className="text-[11px] text-[var(--dpf-muted)]">{describePay(selected, currency)}</p>
+          )}
 
-          <div className="flex items-center gap-3 text-xs text-[var(--dpf-text)]">
-            <label className="flex items-center gap-1.5 cursor-pointer">
+          <fieldset className="flex items-center gap-3 text-sm text-[var(--dpf-text)]">
+            <legend className="text-sm font-medium text-[var(--dpf-text)]">How is this person paid?</legend>
+            <label className="flex cursor-pointer items-center gap-1.5">
               <input
                 type="radio"
-                name="payType"
+                name="pay-type"
                 checked={payType === "hourly"}
                 onChange={() => setPayType("hourly")}
               />
               Paid hourly
             </label>
-            <label className="flex items-center gap-1.5 cursor-pointer">
+            <label className="flex cursor-pointer items-center gap-1.5">
               <input
                 type="radio"
-                name="payType"
+                name="pay-type"
                 checked={payType === "salary"}
                 onChange={() => setPayType("salary")}
               />
               Salaried
             </label>
-          </div>
+          </fieldset>
 
           {payType === "hourly" ? (
-            <label className="flex items-center gap-2 text-xs text-[var(--dpf-text)]">
-              Hourly pay rate ({currency})
-              <input
-                type="number"
-                min={0}
-                step={0.5}
-                value={hourlyRate}
-                onChange={(e) => setHourlyRate(e.target.value)}
-                className={inputCls}
-              />
-            </label>
+            <TextField
+              name="hourly-rate"
+              label={`Hourly pay rate (${currency})`}
+              type="number"
+              value={hourlyRate}
+              onValueChange={setHourlyRate}
+              required
+              autoComplete="off"
+              min={0}
+              step={0.5}
+              inputClassName="max-w-40"
+            />
           ) : (
             <div className="space-y-2">
-              <label className="flex items-center gap-2 text-xs text-[var(--dpf-text)]">
-                Annual salary ({currency})
-                <input
-                  type="number"
-                  min={0}
-                  step={500}
-                  value={annualSalary}
-                  onChange={(e) => setAnnualSalary(e.target.value)}
-                  className={inputCls}
-                />
-              </label>
+              <TextField
+                name="annual-salary"
+                label={`Annual salary (${currency})`}
+                type="number"
+                value={annualSalary}
+                onValueChange={setAnnualSalary}
+                required
+                autoComplete="off"
+                min={0}
+                step={500}
+                inputClassName="max-w-40"
+              />
               <details className="text-xs">
                 <summary className="cursor-pointer text-[var(--dpf-muted)]">Advanced</summary>
-                <label className="mt-2 flex items-center gap-2 text-xs text-[var(--dpf-text)]">
-                  Standard hours per year
-                  <input
+                <div className="mt-2">
+                  <TextField
+                    name="standard-annual-hours"
+                    label="Standard hours per year"
                     type="number"
+                    value={standardHours}
+                    onValueChange={setStandardHours}
+                    optional
+                    autoComplete="off"
                     min={1}
                     max={8760}
                     step={1}
                     placeholder="2080"
-                    value={standardHours}
-                    onChange={(e) => setStandardHours(e.target.value)}
-                    className={inputCls}
+                    hint="Used to work out an hourly cost for job pricing. Leave blank for 2,080 (40 hours × 52 weeks)."
+                    inputClassName="max-w-40"
                   />
-                </label>
-                <p className="mt-1 text-[10px] text-[var(--dpf-muted)]">
-                  Used to work out an hourly cost for job pricing. Leave blank for 2,080 (40 hours × 52 weeks).
-                </p>
+                </div>
               </details>
             </div>
           )}
 
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              disabled={isPending || !selected}
-              onClick={handleSave}
-              className="text-[11px] px-3 py-1.5 rounded border border-[var(--dpf-accent)]/40 text-[var(--dpf-accent)] hover:bg-[var(--dpf-accent)]/10 disabled:opacity-50"
-            >
+          <div className="flex items-center gap-3">
+            <SubmitButton pending={isPending} pendingLabel="Saving…" disabled={!selected}>
               Save pay
-            </button>
-            {message && <span className="text-[11px] text-[var(--dpf-muted)]">{message}</span>}
+            </SubmitButton>
+            <FormStatus
+              error={result && !result.ok ? result.message : null}
+              success={result?.ok ? result.message : null}
+            />
           </div>
-        </div>
+        </form>
       )}
     </section>
   );

--- a/apps/web/components/employee/HrUserLifecyclePanel.tsx
+++ b/apps/web/components/employee/HrUserLifecyclePanel.tsx
@@ -3,6 +3,13 @@
 import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { updateUserLifecycle, type UserActionResult } from "@/lib/actions/users";
+import {
+  SelectField,
+  CheckboxField,
+  SubmitButton,
+  FormStatus,
+  ConsequenceNotice,
+} from "@/components/ui/form";
 
 type RoleOption = {
   roleId: string;
@@ -37,11 +44,16 @@ export function HrUserLifecyclePanel({ users, roles }: Props) {
   const [roleId, setRoleId] = useState(selectedUser?.roleId ?? roles[0]?.roleId ?? "HR-100");
   const [isActive, setIsActive] = useState(selectedUser?.isActive ?? true);
 
+  // A deactivation (was active, now unticked) is the offboarding path — surface
+  // it as a danger-toned consequence so it is never a silent side effect.
+  const deactivating = (selectedUser?.isActive ?? true) && !isActive;
+
   function syncFromSelected(nextUserId: string) {
     setSelectedUserId(nextUserId);
     const next = sortedUsers.find((user) => user.id === nextUserId);
     setRoleId(next?.roleId ?? roles[0]?.roleId ?? "HR-100");
     setIsActive(next?.isActive ?? true);
+    setResult(null);
   }
 
   function save() {
@@ -50,82 +62,86 @@ export function HrUserLifecyclePanel({ users, roles }: Props) {
         setResult({ ok: false, message: "Select a user first." });
         return;
       }
-      const response = await updateUserLifecycle({
-        userId: selectedUserId,
-        roleId,
-        isActive,
-      });
+      const response = await updateUserLifecycle({ userId: selectedUserId, roleId, isActive });
       setResult(response);
       if (response.ok) router.refresh();
     });
   }
 
   return (
-    <div className="rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] p-4 space-y-4">
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        save();
+      }}
+      noValidate
+      className="space-y-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+    >
       <div>
         <h2 className="text-sm font-semibold text-[var(--dpf-text)]">HR user lifecycle</h2>
-        <p className="text-xs text-[var(--dpf-muted)] mt-1">Manage role assignment and active/inactive state. Password setup/reset stays in Admin.</p>
+        <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+          Manage role assignment and active/inactive state. Password setup/reset stays in Admin.
+        </p>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        <label className="block">
-          <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">User</span>
-          <select
-            value={selectedUserId}
-            onChange={(e) => syncFromSelected(e.target.value)}
-            className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-2 text-sm text-[var(--dpf-text)]"
-          >
-            {sortedUsers.map((user) => (
-              <option key={user.id} value={user.id}>
-                {user.email}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label className="block">
-          <span className="text-[10px] text-[var(--dpf-muted)] uppercase tracking-widest">Role</span>
-          <select
-            value={roleId}
-            onChange={(e) => setRoleId(e.target.value)}
-            className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-2 text-sm text-[var(--dpf-text)]"
-          >
-            {roles.map((role) => (
-              <option key={role.roleId} value={role.roleId}>
-                {role.roleId} - {role.name}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label className="inline-flex items-center gap-2 text-xs text-[var(--dpf-muted)] self-end md:pb-2">
-          <input
-            type="checkbox"
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <SelectField
+          name="lifecycle-user"
+          label="User"
+          value={selectedUserId}
+          onValueChange={syncFromSelected}
+          options={sortedUsers.map((user) => ({ value: user.id, label: user.email }))}
+        />
+        <SelectField
+          name="lifecycle-role"
+          label="Role"
+          value={roleId}
+          onValueChange={setRoleId}
+          options={roles.map((role) => ({ value: role.roleId, label: `${role.roleId} - ${role.name}` }))}
+        />
+        <div className="self-end md:pb-1">
+          <CheckboxField
+            name="lifecycle-active"
+            label="Active user"
             checked={isActive}
-            onChange={(e) => setIsActive(e.target.checked)}
-            className="h-3.5 w-3.5 rounded border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]"
+            onCheckedChange={setIsActive}
           />
-          Active user
-        </label>
+        </div>
       </div>
 
       {selectedUser?.isSuperuser && (
-        <p className="text-xs text-amber-400">Selected user is a superuser. Only superusers can change superuser accounts.</p>
+        <p className="text-xs text-[var(--dpf-warning)]">
+          Selected user is a superuser. Only superusers can change superuser accounts.
+        </p>
       )}
 
+      <ConsequenceNotice
+        tone={deactivating ? "danger" : "info"}
+        defaultOpen={deactivating}
+        summary={
+          deactivating
+            ? "Deactivating this user removes their access."
+            : "This updates the user's role and active state."
+        }
+        what={
+          deactivating
+            ? "The account is marked inactive — they can no longer sign in — and their role is set to the value above."
+            : "Sets the selected role and keeps the account active. No password or email changes happen here."
+        }
+        who={selectedUser ? selectedUser.email : "The selected user."}
+        reversibility="Reversible — re-tick Active user (and reselect a role) and save again to restore access."
+        recovery="Locked someone out by mistake? Reactivate them here; password issues are handled under Admin → Access setup."
+      />
+
       <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={save}
-          disabled={isPending}
-          className="rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-white disabled:opacity-60"
-        >
-          {isPending ? "Saving..." : "Save HR changes"}
-        </button>
-        <p className={`text-xs ${result ? (result.ok ? "text-green-400" : "text-red-400") : "text-[var(--dpf-muted)]"}`}>
-          {result?.message ?? "Typical HR functions: role movement, onboarding activation, offboarding deactivation."}
-        </p>
+        <SubmitButton pending={isPending} pendingLabel="Saving…">
+          Save HR changes
+        </SubmitButton>
+        <FormStatus
+          error={result && !result.ok ? result.message : null}
+          success={result?.ok ? result.message : null}
+        />
       </div>
-    </div>
+    </form>
   );
 }

--- a/apps/web/components/storefront/BookingForm.test.tsx
+++ b/apps/web/components/storefront/BookingForm.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+//
+// Route-level accessible-submit-contract coverage for the Restaurant (and other
+// archetype) booking/intake form rendered on /s/[slug]/book/*. BI-8E74C749.
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("@/lib/storefront-actions", () => ({ submitBooking: vi.fn() }));
+
+import { BookingForm } from "./BookingForm";
+
+const props = {
+  orgSlug: "trattoria",
+  itemId: "item-1",
+  itemName: "Table for two",
+  durationMinutes: 90,
+};
+
+afterEach(() => cleanup());
+
+describe("BookingForm accessible contract", () => {
+  it("labels the contact fields with correct autocomplete + required state", () => {
+    render(<BookingForm {...props} />);
+
+    const name = screen.getByLabelText(/full name/i);
+    expect(name).toHaveAttribute("name", "name");
+    expect(name).toHaveAttribute("autocomplete", "name");
+    expect(name).toBeRequired();
+
+    const email = screen.getByLabelText(/email address/i);
+    expect(email).toHaveAttribute("type", "email");
+    expect(email).toHaveAttribute("autocomplete", "email");
+    expect(email).toBeRequired();
+  });
+
+  it("marks phone optional and not required", () => {
+    render(<BookingForm {...props} />);
+    const phone = screen.getByLabelText(/phone/i);
+    expect(phone).toHaveAttribute("name", "phone");
+    expect(phone).toHaveAttribute("autocomplete", "tel");
+    expect(phone).not.toBeRequired();
+  });
+
+  it("requires date and time and exposes an optional notes field", () => {
+    render(<BookingForm {...props} />);
+    expect(screen.getByLabelText(/date/i)).toBeRequired();
+    expect(screen.getByLabelText(/time/i)).toBeRequired();
+    expect(screen.getByLabelText(/notes/i)).not.toBeRequired();
+  });
+
+  it("renders the submit action for the item", () => {
+    render(<BookingForm {...props} />);
+    expect(screen.getByRole("button", { name: /book table for two/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/storefront/BookingForm.tsx
+++ b/apps/web/components/storefront/BookingForm.tsx
@@ -3,6 +3,13 @@
 import { useState } from "react";
 import { submitBooking } from "@/lib/storefront-actions";
 import { useRouter } from "next/navigation";
+import {
+  TextField,
+  EmailField,
+  TextareaField,
+  SubmitButton,
+  FormStatus,
+} from "@/components/ui/form";
 
 export function BookingForm({
   orgSlug,
@@ -19,24 +26,30 @@ export function BookingForm({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [date, setDate] = useState("");
+  const [time, setTime] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const today = new Date().toISOString().split("T")[0];
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setLoading(true);
     setError(null);
 
-    const fd = new FormData(e.currentTarget);
-    const date = fd.get("date") as string;
-    const time = fd.get("time") as string;
     const scheduledAt = new Date(`${date}T${time}:00`);
 
     const result = await submitBooking(orgSlug, {
       itemId,
-      customerEmail: fd.get("email") as string,
-      customerName: fd.get("name") as string,
-      customerPhone: (fd.get("phone") as string | null) ?? undefined,
+      customerEmail: email,
+      customerName: name,
+      customerPhone: phone || undefined,
       scheduledAt,
       durationMinutes,
-      notes: (fd.get("notes") as string | null) ?? undefined,
+      notes: notes || undefined,
     });
 
     if (!result.success) {
@@ -49,42 +62,69 @@ export function BookingForm({
   }
 
   return (
-    <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 480 }}>
-      {error && <div style={{ color: "var(--dpf-error)", fontSize: 13 }}>{error}</div>}
-      {[
-        { name: "name", label: "Full name", type: "text" },
-        { name: "email", label: "Email address", type: "email" },
-        { name: "phone", label: "Phone (optional)", type: "tel", required: false },
-      ].map((f) => (
-        <div key={f.name} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <label style={{ fontSize: 13, fontWeight: 500 }}>{f.label}</label>
-          <input type={f.type} name={f.name} required={f.required !== false}
-            style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }} />
-        </div>
-      ))}
-      <div style={{ display: "flex", gap: 12 }}>
-        <div style={{ display: "flex", flexDirection: "column", gap: 4, flex: 1 }}>
-          <label style={{ fontSize: 13, fontWeight: 500 }}>Date *</label>
-          <input type="date" name="date" required
-            min={new Date().toISOString().split("T")[0]}
-            style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }} />
-        </div>
-        <div style={{ display: "flex", flexDirection: "column", gap: 4, flex: 1 }}>
-          <label style={{ fontSize: 13, fontWeight: 500 }}>Time *</label>
-          <input type="time" name="time" required
-            style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }} />
-        </div>
+    <form onSubmit={handleSubmit} className="flex max-w-[480px] flex-col gap-4" noValidate>
+      <FormStatus error={error} />
+      <TextField
+        name="name"
+        label="Full name"
+        value={name}
+        onValueChange={setName}
+        required
+        autoComplete="name"
+      />
+      <EmailField
+        name="email"
+        label="Email address"
+        value={email}
+        onValueChange={setEmail}
+        required
+        autoComplete="email"
+      />
+      <TextField
+        name="phone"
+        label="Phone"
+        type="tel"
+        value={phone}
+        onValueChange={setPhone}
+        optional
+        autoComplete="tel"
+      />
+      <div className="flex gap-3">
+        <TextField
+          name="date"
+          label="Date"
+          type="date"
+          value={date}
+          onValueChange={setDate}
+          required
+          autoComplete="off"
+          min={today}
+          className="flex-1"
+        />
+        <TextField
+          name="time"
+          label="Time"
+          type="time"
+          value={time}
+          onValueChange={setTime}
+          required
+          autoComplete="off"
+          className="flex-1"
+        />
       </div>
-      <div style={{ fontSize: 13, color: "var(--dpf-muted)" }}>Duration: {durationMinutes} minutes</div>
-      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-        <label style={{ fontSize: 13, fontWeight: 500 }}>Notes (optional)</label>
-        <textarea name="notes" rows={3}
-          style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14, resize: "vertical" }} />
-      </div>
-      <button type="submit" disabled={loading}
-        style={{ padding: "10px 20px", background: "var(--dpf-accent, #4f46e5)", color: "var(--dpf-text)", border: "none", borderRadius: 6, fontSize: 14, fontWeight: 600, cursor: "pointer" }}>
-        {loading ? "Booking…" : `Book ${itemName}`}
-      </button>
+      <div className="text-sm text-[var(--dpf-muted)]">Duration: {durationMinutes} minutes</div>
+      <TextareaField
+        name="notes"
+        label="Notes"
+        value={notes}
+        onValueChange={setNotes}
+        optional
+        rows={3}
+        hint="Anything we should know — dietary needs, party size, accessibility."
+      />
+      <SubmitButton pending={loading} pendingLabel="Booking…">
+        {`Book ${itemName}`}
+      </SubmitButton>
     </form>
   );
 }

--- a/apps/web/components/storefront/SignInForm.test.tsx
+++ b/apps/web/components/storefront/SignInForm.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+//
+// Route-level accessible-submit-contract coverage for /portal/sign-in and
+// /s/[slug]/sign-in (both render <SignInForm />). BI-8E74C749.
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("next-auth/react", () => ({ signIn: vi.fn() }));
+
+import { SignInForm } from "./SignInForm";
+
+afterEach(() => cleanup());
+
+describe("SignInForm accessible contract", () => {
+  it("labels the email field and wires name + username autocomplete", () => {
+    render(<SignInForm />);
+    const email = screen.getByLabelText(/email address/i);
+    expect(email).toHaveAttribute("name", "email");
+    expect(email).toHaveAttribute("type", "email");
+    expect(email).toHaveAttribute("autocomplete", "username");
+    expect(email).toBeRequired();
+  });
+
+  it("labels the password field with the current-password autocomplete hint", () => {
+    render(<SignInForm />);
+    const password = screen.getByLabelText(/password/i);
+    expect(password).toHaveAttribute("name", "password");
+    expect(password).toHaveAttribute("type", "password");
+    expect(password).toHaveAttribute("autocomplete", "current-password");
+    expect(password).toBeRequired();
+  });
+
+  it("renders an accessible submit button", () => {
+    render(<SignInForm />);
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/storefront/SignInForm.tsx
+++ b/apps/web/components/storefront/SignInForm.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
-import { EmailInput } from "@/components/ui/EmailInput";
+import { EmailField, TextField, SubmitButton, FormStatus } from "@/components/ui/form";
 
 export function SignInForm({ orgSlug }: { orgSlug?: string }) {
   const router = useRouter();
@@ -26,89 +26,61 @@ export function SignInForm({ orgSlug }: { orgSlug?: string }) {
   }
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 20, maxWidth: 360 }}>
-      <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-        {error && <div style={{ color: "var(--dpf-error)", fontSize: 13 }}>{error}</div>}
-        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <label style={{ fontSize: 13, fontWeight: 500 }}>Email address</label>
-          <EmailInput
-            value={email}
-            onValueChange={(v) => setEmail(v)}
-            required
-            style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }}
-          />
-        </div>
-        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <label style={{ fontSize: 13, fontWeight: 500 }}>Password</label>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }}
-          />
-        </div>
-        <button
-          type="submit"
-          disabled={loading}
-          style={{
-            padding: "10px 20px",
-            background: "var(--dpf-accent, #4f46e5)",
-            color: "var(--dpf-text)",
-            border: "none",
-            borderRadius: 6,
-            fontSize: 14,
-            fontWeight: 600,
-            cursor: "pointer",
-          }}
-        >
-          {loading ? "…" : "Sign in"}
-        </button>
+    <div className="flex max-w-[360px] flex-col gap-5">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
+        <FormStatus error={error} />
+        <EmailField
+          name="email"
+          label="Email address"
+          value={email}
+          onValueChange={setEmail}
+          required
+          autoComplete="username"
+        />
+        <TextField
+          name="password"
+          label="Password"
+          type="password"
+          value={password}
+          onValueChange={setPassword}
+          required
+          autoComplete="current-password"
+        />
+        <SubmitButton pending={loading} pendingLabel="Signing in…">
+          Sign in
+        </SubmitButton>
       </form>
 
       {/* Social auth — shown only when configured */}
       {process.env.NEXT_PUBLIC_ENABLE_SOCIAL_AUTH === "true" && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          <div style={{ textAlign: "center", fontSize: 12, color: "var(--dpf-muted)" }}>or continue with</div>
+        <div className="flex flex-col gap-2">
+          <div className="text-center text-xs text-[var(--dpf-muted)]">or continue with</div>
           <button
             type="button"
             onClick={() => signIn("google", { callbackUrl: "/portal" })}
-            style={{
-              padding: "10px 20px",
-              border: "1px solid var(--dpf-border)",
-              borderRadius: 6,
-              fontSize: 14,
-              cursor: "pointer",
-              background: "#fff",
-              color: "var(--dpf-text)",
-            }}
+            className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-5 py-2.5 text-sm text-[var(--dpf-text)]"
           >
             Continue with Google
           </button>
           <button
             type="button"
             onClick={() => signIn("apple", { callbackUrl: "/portal" })}
-            style={{
-              padding: "10px 20px",
-              border: "1px solid var(--dpf-border)",
-              borderRadius: 6,
-              fontSize: 14,
-              cursor: "pointer",
-              background: "#000",
-              color: "var(--dpf-text)",
-            }}
+            className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-5 py-2.5 text-sm text-[var(--dpf-text)]"
           >
             Continue with Apple
           </button>
         </div>
       )}
 
-      <div style={{ textAlign: "center", fontSize: 12, color: "var(--dpf-muted)" }}>
-        <a href={orgSlug ? `/s/${orgSlug}/sign-up` : "/portal/sign-up"} style={{ color: "var(--dpf-accent, #4f46e5)", fontWeight: 500 }}>
+      <div className="text-center text-xs text-[var(--dpf-muted)]">
+        <a
+          href={orgSlug ? `/s/${orgSlug}/sign-up` : "/portal/sign-up"}
+          className="font-medium text-[var(--dpf-accent)]"
+        >
           Create an account
         </a>
         {" · "}
-        <a href="/login" style={{ color: "var(--dpf-muted)" }}>
+        <a href="/login" className="text-[var(--dpf-muted)]">
           Staff login
         </a>
       </div>

--- a/apps/web/components/storefront/SignUpForm.test.tsx
+++ b/apps/web/components/storefront/SignUpForm.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+//
+// Route-level accessible-submit-contract coverage for /s/[slug]/sign-up
+// (renders <SignUpForm />). BI-8E74C749.
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("next-auth/react", () => ({ signIn: vi.fn() }));
+
+import { SignUpForm } from "./SignUpForm";
+
+afterEach(() => cleanup());
+
+describe("SignUpForm accessible contract", () => {
+  it("marks the name field required (regression: it used to be unmarked)", () => {
+    render(<SignUpForm orgSlug="acme" />);
+    const name = screen.getByLabelText(/full name/i);
+    expect(name).toHaveAttribute("name", "name");
+    expect(name).toHaveAttribute("autocomplete", "name");
+    expect(name).toBeRequired();
+  });
+
+  it("uses the new-password autocomplete hint on both password fields", () => {
+    render(<SignUpForm orgSlug="acme" />);
+    const password = screen.getByLabelText(/^password/i);
+    const confirm = screen.getByLabelText(/confirm password/i);
+    expect(password).toHaveAttribute("autocomplete", "new-password");
+    expect(confirm).toHaveAttribute("autocomplete", "new-password");
+  });
+
+  it("shows inline validation when the confirmation does not match", () => {
+    render(<SignUpForm orgSlug="acme" />);
+    fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: "abcdefghijkl" } });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: "different" } });
+    const confirm = screen.getByLabelText(/confirm password/i);
+    expect(confirm).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByRole("alert")).toHaveTextContent(/passwords do not match/i);
+    expect(screen.getByRole("button", { name: /create account/i })).toBeDisabled();
+  });
+});

--- a/apps/web/components/storefront/SignUpForm.tsx
+++ b/apps/web/components/storefront/SignUpForm.tsx
@@ -2,7 +2,12 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
-import { EmailInput } from "@/components/ui/EmailInput";
+import {
+  TextField,
+  EmailField,
+  SubmitButton,
+  FormStatus,
+} from "@/components/ui/form";
 
 export function SignUpForm({
   orgSlug,
@@ -18,6 +23,13 @@ export function SignUpForm({
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  // Inline field-level validation: surface the mismatch on the confirm field
+  // itself (aria-invalid + described error) rather than only a form-level banner.
+  const mismatch =
+    confirmPassword.length > 0 && password !== confirmPassword
+      ? "Passwords do not match."
+      : undefined;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -37,7 +49,7 @@ export function SignUpForm({
     });
 
     if (!res.ok) {
-      const data = await res.json() as { error?: string };
+      const data = (await res.json()) as { error?: string };
       setError(data.error ?? "Sign-up failed. Please try again.");
       setLoading(false);
       return;
@@ -55,57 +67,51 @@ export function SignUpForm({
   }
 
   return (
-    <form onSubmit={handleSubmit}
-      style={{ display: "flex", flexDirection: "column", gap: 14, maxWidth: 360 }}>
-      {error && <div style={{ color: "var(--dpf-error)", fontSize: 13 }}>{error}</div>}
-      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-        <label style={{ fontSize: 13, fontWeight: 500 }}>Full name</label>
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Your name"
-          style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }}
-        />
-      </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-        <label style={{ fontSize: 13, fontWeight: 500 }}>Email address</label>
-        <EmailInput
-          value={email}
-          onValueChange={(v) => setEmail(v)}
-          required
-          style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }}
-        />
-      </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-        <label style={{ fontSize: 13, fontWeight: 500 }}>Password</label>
-        <input
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-          style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }}
-        />
-      </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-        <label style={{ fontSize: 13, fontWeight: 500 }}>Confirm password</label>
-        <input
-          type="password"
-          value={confirmPassword}
-          onChange={(e) => setConfirmPassword(e.target.value)}
-          required
-          style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }}
-        />
-      </div>
-      <button
-        type="submit"
-        disabled={loading}
-        style={{ padding: "10px 20px", background: "var(--dpf-accent, #4f46e5)", color: "var(--dpf-text)", border: "none", borderRadius: 6, fontSize: 14, fontWeight: 600, cursor: "pointer" }}>
-        {loading ? "…" : "Create account"}
-      </button>
-      <p style={{ fontSize: 13, color: "var(--dpf-muted)", textAlign: "center" }}>
+    <form onSubmit={handleSubmit} className="flex max-w-[360px] flex-col gap-4" noValidate>
+      <FormStatus error={error} />
+      <TextField
+        name="name"
+        label="Full name"
+        value={name}
+        onValueChange={setName}
+        required
+        autoComplete="name"
+        placeholder="Your name"
+      />
+      <EmailField
+        name="email"
+        label="Email address"
+        value={email}
+        onValueChange={setEmail}
+        required
+        autoComplete="email"
+      />
+      <TextField
+        name="password"
+        label="Password"
+        type="password"
+        value={password}
+        onValueChange={setPassword}
+        required
+        autoComplete="new-password"
+        hint="At least 12 characters."
+      />
+      <TextField
+        name="confirm-password"
+        label="Confirm password"
+        type="password"
+        value={confirmPassword}
+        onValueChange={setConfirmPassword}
+        required
+        autoComplete="new-password"
+        error={mismatch}
+      />
+      <SubmitButton pending={loading} pendingLabel="Creating account…" disabled={!!mismatch}>
+        Create account
+      </SubmitButton>
+      <p className="text-center text-sm text-[var(--dpf-muted)]">
         Already have an account?{" "}
-        <a href={`/s/${orgSlug}/sign-in`} style={{ color: "var(--dpf-accent, #4f46e5)", fontWeight: 500 }}>
+        <a href={`/s/${orgSlug}/sign-in`} className="font-medium text-[var(--dpf-accent)]">
           Sign in
         </a>
       </p>

--- a/apps/web/components/ui/form/CheckboxField.tsx
+++ b/apps/web/components/ui/form/CheckboxField.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+// CheckboxField — a labeled checkbox whose caption sits to the right of the box
+// (the conventional layout), with an optional hint and consequence-aware error.
+// Wiring mirrors FormField: htmlFor/id, aria-describedby, role="alert" error.
+
+import { useId, type ReactNode } from "react";
+import { cx, fieldErrorClass, fieldHintClass } from "./styles";
+
+export type CheckboxFieldProps = {
+  name: string;
+  label: ReactNode;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  hint?: ReactNode;
+  error?: ReactNode;
+  disabled?: boolean;
+  className?: string;
+};
+
+export function CheckboxField({
+  name,
+  label,
+  checked,
+  onCheckedChange,
+  hint,
+  error,
+  disabled,
+  className,
+}: CheckboxFieldProps) {
+  const uid = useId();
+  const id = `${uid}-${name}`;
+  const hintId = hint ? `${id}-hint` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy = [hintId, errorId].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <div className={cx("flex flex-col gap-1", className)}>
+      <div className="flex items-start gap-2">
+        <input
+          id={id}
+          name={name}
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          onChange={(e) => onCheckedChange(e.target.checked)}
+          className="mt-0.5 h-4 w-4 rounded border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+        />
+        <label htmlFor={id} className="text-sm text-[var(--dpf-text)]">
+          {label}
+        </label>
+      </div>
+      {hint ? (
+        <p id={hintId} className={cx(fieldHintClass, "ml-6")}>
+          {hint}
+        </p>
+      ) : null}
+      {error ? (
+        <p id={errorId} role="alert" className={cx(fieldErrorClass, "ml-6")}>
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/ui/form/ConsequenceNotice.tsx
+++ b/apps/web/components/ui/form/ConsequenceNotice.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+// ConsequenceNotice — risk-proportional consequence copy for a mutating or
+// sensitive form action, kept behind progressive disclosure so a non-technical
+// owner sees one plain summary line, not a wall of text (AGENTS.md §12/§17).
+//
+// It answers the four questions the form-contract requires for sensitive
+// actions: what will change, who/what is affected, whether it can be reversed,
+// and the recovery path. The summary is always visible; the four details expand
+// on demand via a native <details> (the canonical construct for "one short,
+// secondary piece of prose", per platform-usability-standards.md).
+
+import type { ReactNode } from "react";
+import { cx } from "./styles";
+
+export type ConsequenceNoticeProps = {
+  /** The always-visible one-line plain-language summary of what this does. */
+  summary: ReactNode;
+  /** What data/state changes. */
+  what: ReactNode;
+  /** Who or what is affected (the person, account, records). */
+  who: ReactNode;
+  /** Whether and how the action can be undone. */
+  reversibility: ReactNode;
+  /** How to recover / where to go if it was a mistake. */
+  recovery: ReactNode;
+  /** Visual weight. `danger` for destructive/irreversible actions. */
+  tone?: "info" | "warning" | "danger";
+  /** Expand the details by default (use for the most dangerous actions). */
+  defaultOpen?: boolean;
+  /** Text for the disclosure toggle. */
+  detailsLabel?: string;
+  className?: string;
+};
+
+const TONE_ACCENT: Record<NonNullable<ConsequenceNoticeProps["tone"]>, string> = {
+  info: "var(--dpf-accent)",
+  warning: "var(--dpf-warning)",
+  danger: "var(--dpf-error)",
+};
+
+const TONE_BG: Record<NonNullable<ConsequenceNoticeProps["tone"]>, string> = {
+  info: "var(--dpf-accent-soft)",
+  warning: "var(--dpf-state-warning)",
+  danger: "var(--dpf-state-error)",
+};
+
+export function ConsequenceNotice({
+  summary,
+  what,
+  who,
+  reversibility,
+  recovery,
+  tone = "info",
+  defaultOpen = false,
+  detailsLabel = "What happens when I do this?",
+  className,
+}: ConsequenceNoticeProps) {
+  const rows: Array<{ term: string; detail: ReactNode }> = [
+    { term: "What changes", detail: what },
+    { term: "Who's affected", detail: who },
+    { term: "Can it be undone", detail: reversibility },
+    { term: "If it was a mistake", detail: recovery },
+  ];
+
+  return (
+    <details
+      open={defaultOpen}
+      className={cx("rounded-md border px-3 py-2 text-sm", className)}
+      style={{
+        borderColor: TONE_ACCENT[tone],
+        background: TONE_BG[tone],
+        color: "var(--dpf-text)",
+      }}
+    >
+      <summary className="cursor-pointer list-none font-medium marker:content-none">
+        <span className="mr-1" aria-hidden="true" style={{ color: TONE_ACCENT[tone] }}>
+          ⓘ
+        </span>
+        {summary}
+        <span className="ml-1 text-xs text-[var(--dpf-muted)]">— {detailsLabel}</span>
+      </summary>
+      <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+        {rows.map((row) => (
+          <div key={row.term} className="contents">
+            <dt className="text-xs font-semibold text-[var(--dpf-muted)]">{row.term}</dt>
+            <dd className="text-xs text-[var(--dpf-text)]">{row.detail}</dd>
+          </div>
+        ))}
+      </dl>
+    </details>
+  );
+}

--- a/apps/web/components/ui/form/EmailField.tsx
+++ b/apps/web/components/ui/form/EmailField.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+// EmailField — FormField + the EmailInput primitive, so the address is
+// normalized on blur AND the label/required/error wiring is consistent with
+// every other field. Defaults autoComplete to "email"; pass "username" on a
+// sign-in form where the email is the account identifier if you prefer.
+
+import type { ReactNode } from "react";
+import { EmailInput } from "@/components/ui/EmailInput";
+import { FormField } from "./FormField";
+import { cx, fieldControlClass } from "./styles";
+
+export type EmailFieldProps = {
+  name: string;
+  label: ReactNode;
+  value: string;
+  onValueChange: (value: string) => void;
+  required?: boolean;
+  optional?: boolean;
+  hint?: ReactNode;
+  error?: ReactNode;
+  autoComplete?: string;
+  placeholder?: string;
+  className?: string;
+  inputClassName?: string;
+  autoFocus?: boolean;
+};
+
+export function EmailField({
+  name,
+  label,
+  value,
+  onValueChange,
+  required = false,
+  optional = false,
+  hint,
+  error,
+  autoComplete = "email",
+  placeholder,
+  className,
+  inputClassName,
+  autoFocus,
+}: EmailFieldProps) {
+  return (
+    <FormField
+      name={name}
+      label={label}
+      required={required}
+      optional={optional}
+      hint={hint}
+      error={error}
+      className={className}
+    >
+      {(control) => (
+        <EmailInput
+          {...control}
+          value={value}
+          onValueChange={onValueChange}
+          autoComplete={autoComplete}
+          placeholder={placeholder}
+          autoFocus={autoFocus}
+          className={cx(fieldControlClass, inputClassName)}
+        />
+      )}
+    </FormField>
+  );
+}

--- a/apps/web/components/ui/form/FormField.test.tsx
+++ b/apps/web/components/ui/form/FormField.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { FormField } from "./FormField";
+import { TextField } from "./TextField";
+
+afterEach(() => cleanup());
+
+describe("FormField", () => {
+  it("binds label to control via htmlFor/id and wires the name", () => {
+    render(
+      <FormField name="email" label="Email address">
+        {(control) => <input {...control} type="email" />}
+      </FormField>,
+    );
+    const input = screen.getByLabelText(/email address/i);
+    expect(input).toHaveAttribute("name", "email");
+    expect(input.getAttribute("id")).toBeTruthy();
+  });
+
+  it("exposes required state visibly and to assistive tech", () => {
+    render(
+      <FormField name="email" label="Email" required>
+        {(control) => <input {...control} type="email" />}
+      </FormField>,
+    );
+    const input = screen.getByLabelText(/email/i);
+    expect(input).toBeRequired();
+    expect(input).toHaveAttribute("aria-required", "true");
+    // Visible marker + screen-reader "(required)" text.
+    expect(screen.getByText("*")).toBeInTheDocument();
+    expect(screen.getByText(/\(required\)/i)).toBeInTheDocument();
+  });
+
+  it("marks a field optional when requested", () => {
+    render(
+      <FormField name="phone" label="Phone" optional>
+        {(control) => <input {...control} type="tel" />}
+      </FormField>,
+    );
+    expect(screen.getByText(/\(optional\)/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/phone/i)).not.toBeRequired();
+  });
+
+  it("associates a hint through aria-describedby", () => {
+    render(
+      <FormField name="password" label="Password" hint="At least 12 characters.">
+        {(control) => <input {...control} type="password" />}
+      </FormField>,
+    );
+    const input = screen.getByLabelText(/password/i);
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const hint = screen.getByText(/at least 12 characters/i);
+    expect(describedBy).toContain(hint.id);
+  });
+
+  it("flags invalid state and announces the error via role=alert", () => {
+    render(
+      <FormField name="confirm" label="Confirm" error="Passwords do not match.">
+        {(control) => <input {...control} type="password" />}
+      </FormField>,
+    );
+    const input = screen.getByLabelText(/confirm/i);
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/passwords do not match/i);
+    expect(input.getAttribute("aria-describedby")).toContain(alert.id);
+  });
+
+  it("does not collide ids across two fields with the same name", () => {
+    render(
+      <>
+        <TextField name="email" label="Primary email" value="" onValueChange={() => {}} />
+        <TextField name="email" label="Backup email" value="" onValueChange={() => {}} />
+      </>,
+    );
+    const a = screen.getByLabelText(/primary email/i);
+    const b = screen.getByLabelText(/backup email/i);
+    expect(a.id).not.toEqual(b.id);
+  });
+});

--- a/apps/web/components/ui/form/FormField.tsx
+++ b/apps/web/components/ui/form/FormField.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+// FormField — the accessible labeled-control wrapper for the portal form
+// contract (BI-8E74C749). It owns the four things every user-facing field must
+// get right and which hand-rolled forms kept dropping:
+//   1. a real <label htmlFor> bound to the control's id (click-to-focus + AT),
+//   2. a visible + screen-reader required/optional state,
+//   3. a hint region wired via aria-describedby,
+//   4. inline validation: aria-invalid + an error region wired via
+//      aria-describedby and announced with role="alert".
+//
+// The control itself is supplied through a render prop so any input — a plain
+// <input>, a themed <select>, EmailInput, PhoneInput — receives the exact same
+// id/name/aria wiring. Ids are derived from React's useId(), so two forms with a
+// "email" field on one page never collide.
+
+import { useId, type ReactNode } from "react";
+import { cx, fieldErrorClass, fieldHintClass, fieldLabelClass } from "./styles";
+
+/** The wiring a control must spread onto itself to satisfy the contract. */
+export type FieldControlProps = {
+  id: string;
+  name: string;
+  required: boolean;
+  "aria-required": true | undefined;
+  "aria-invalid": true | undefined;
+  "aria-describedby": string | undefined;
+};
+
+export type FormFieldProps = {
+  /** Form field name — becomes the control's `name` and seeds its id. */
+  name: string;
+  /** Visible label text. */
+  label: ReactNode;
+  required?: boolean;
+  /** Show an "(optional)" marker. Ignored when `required`. */
+  optional?: boolean;
+  /** Persistent helper text beneath the control. */
+  hint?: ReactNode;
+  /** Inline validation message. Presence flips the control to the invalid state. */
+  error?: ReactNode;
+  /** Renders the control with the required id/name/aria props spread in. */
+  children: (control: FieldControlProps) => ReactNode;
+  className?: string;
+};
+
+export function FormField({
+  name,
+  label,
+  required = false,
+  optional = false,
+  hint,
+  error,
+  children,
+  className,
+}: FormFieldProps) {
+  const uid = useId();
+  const id = `${uid}-${name}`;
+  const hintId = hint ? `${id}-hint` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy = [hintId, errorId].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <div className={cx("flex flex-col gap-1", className)}>
+      <label htmlFor={id} className={fieldLabelClass}>
+        <span>{label}</span>
+        {required ? (
+          <>
+            <span aria-hidden="true" className="ml-0.5 text-[var(--dpf-error)]">
+              *
+            </span>
+            <span className="sr-only"> (required)</span>
+          </>
+        ) : optional ? (
+          <span className="ml-1 font-normal text-[var(--dpf-muted)]">(optional)</span>
+        ) : null}
+      </label>
+
+      {children({
+        id,
+        name,
+        required,
+        "aria-required": required || undefined,
+        "aria-invalid": error ? true : undefined,
+        "aria-describedby": describedBy,
+      })}
+
+      {hint ? (
+        <p id={hintId} className={fieldHintClass}>
+          {hint}
+        </p>
+      ) : null}
+      {error ? (
+        <p id={errorId} role="alert" className={fieldErrorClass}>
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/ui/form/FormStatus.tsx
+++ b/apps/web/components/ui/form/FormStatus.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+// FormStatus — the mutating-submit feedback region. A form's outcome must be
+// announced, not just recolored: errors render assertively (role="alert"),
+// success politely (role="status" + aria-live). Pending feedback lives on the
+// SubmitButton (aria-busy + InlineBusy); this component owns the settled result.
+//
+// Render one <FormStatus> per form near the submit button. Pass at most one of
+// `error` / `success`; error wins if both are set.
+
+import type { ReactNode } from "react";
+import { cx } from "./styles";
+
+export type FormStatusProps = {
+  error?: ReactNode | null;
+  success?: ReactNode | null;
+  className?: string;
+};
+
+export function FormStatus({ error, success, className }: FormStatusProps) {
+  if (error) {
+    return (
+      <p role="alert" className={cx("text-sm text-[var(--dpf-error)]", className)}>
+        {error}
+      </p>
+    );
+  }
+  if (success) {
+    return (
+      <p role="status" aria-live="polite" className={cx("text-sm text-[var(--dpf-success)]", className)}>
+        {success}
+      </p>
+    );
+  }
+  // Keep a stable polite live region mounted so an async success/error that
+  // replaces empty state is still announced by screen readers.
+  return <div role="status" aria-live="polite" className="sr-only" />;
+}

--- a/apps/web/components/ui/form/SelectField.tsx
+++ b/apps/web/components/ui/form/SelectField.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+// SelectField — a themed labeled <select> wired through FormField. Options are
+// rendered with the required themed <option> classes (AGENTS.md §12). Pass a
+// placeholder to render a disabled leading "Select…" option.
+
+import type { ReactNode } from "react";
+import { FormField } from "./FormField";
+import { cx, fieldControlClass, fieldOptionClass } from "./styles";
+
+export type SelectOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+export type SelectFieldProps = {
+  name: string;
+  label: ReactNode;
+  value: string;
+  onValueChange: (value: string) => void;
+  options: SelectOption[];
+  required?: boolean;
+  optional?: boolean;
+  hint?: ReactNode;
+  error?: ReactNode;
+  /** Leading placeholder option text (value ""). */
+  placeholder?: string;
+  autoComplete?: string;
+  className?: string;
+  selectClassName?: string;
+};
+
+export function SelectField({
+  name,
+  label,
+  value,
+  onValueChange,
+  options,
+  required = false,
+  optional = false,
+  hint,
+  error,
+  placeholder,
+  autoComplete,
+  className,
+  selectClassName,
+}: SelectFieldProps) {
+  return (
+    <FormField
+      name={name}
+      label={label}
+      required={required}
+      optional={optional}
+      hint={hint}
+      error={error}
+      className={className}
+    >
+      {(control) => (
+        <select
+          {...control}
+          value={value}
+          onChange={(e) => onValueChange(e.target.value)}
+          autoComplete={autoComplete}
+          className={cx(fieldControlClass, selectClassName)}
+        >
+          {placeholder !== undefined ? (
+            <option value="" disabled className={fieldOptionClass}>
+              {placeholder}
+            </option>
+          ) : null}
+          {options.map((opt) => (
+            <option key={opt.value} value={opt.value} disabled={opt.disabled} className={fieldOptionClass}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      )}
+    </FormField>
+  );
+}

--- a/apps/web/components/ui/form/SubmitButton.tsx
+++ b/apps/web/components/ui/form/SubmitButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+// SubmitButton — the primary form action with a first-class pending state. It
+// composes the shared InlineBusy affordance (spinner + announced label) instead
+// of the hand-rolled "swap the button text" idiom, marks itself aria-busy while
+// pending, and disables to prevent double-submit.
+
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { InlineBusy } from "@/components/ui/InlineBusy";
+import { cx, primaryButtonClass } from "./styles";
+
+export type SubmitButtonProps = {
+  children: ReactNode;
+  /** True while the mutating action is in flight. */
+  pending?: boolean;
+  /** Visible + announced label during the pending state. */
+  pendingLabel?: string;
+  disabled?: boolean;
+  type?: "submit" | "button";
+  onClick?: () => void;
+  className?: string;
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "type" | "onClick" | "className" | "disabled">;
+
+export function SubmitButton({
+  children,
+  pending = false,
+  pendingLabel = "Working…",
+  disabled = false,
+  type = "submit",
+  onClick,
+  className,
+  ...rest
+}: SubmitButtonProps) {
+  return (
+    <button
+      {...rest}
+      type={type}
+      onClick={onClick}
+      disabled={disabled || pending}
+      aria-busy={pending || undefined}
+      className={cx(primaryButtonClass, className)}
+    >
+      {pending ? <InlineBusy label={pendingLabel} tone="current" /> : children}
+    </button>
+  );
+}

--- a/apps/web/components/ui/form/TextField.tsx
+++ b/apps/web/components/ui/form/TextField.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+// TextField — a single-line labeled input wired through FormField. Covers the
+// everyday text-ish types (text/tel/password/number/date/time/url/search). For
+// email prefer EmailField (it also normalizes on blur); for a themed dropdown
+// use SelectField.
+
+import type { InputHTMLAttributes, ReactNode } from "react";
+import { FormField } from "./FormField";
+import { cx, fieldControlClass } from "./styles";
+
+type NativeInputProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "id" | "name" | "value" | "onChange" | "required" | "type"
+>;
+
+export type TextFieldProps = {
+  name: string;
+  label: ReactNode;
+  value: string;
+  onValueChange: (value: string) => void;
+  type?: "text" | "tel" | "password" | "number" | "date" | "time" | "url" | "search";
+  required?: boolean;
+  optional?: boolean;
+  hint?: ReactNode;
+  error?: ReactNode;
+  /**
+   * The autocomplete token. Required by lint intent for auth fields — pass
+   * "current-password" / "new-password" for passwords, "username"/"email" for
+   * identifiers, "name", "tel", etc. Pass "off" only with a reason.
+   */
+  autoComplete?: string;
+  className?: string;
+  inputClassName?: string;
+} & NativeInputProps;
+
+export function TextField({
+  name,
+  label,
+  value,
+  onValueChange,
+  type = "text",
+  required = false,
+  optional = false,
+  hint,
+  error,
+  autoComplete,
+  className,
+  inputClassName,
+  ...inputProps
+}: TextFieldProps) {
+  return (
+    <FormField
+      name={name}
+      label={label}
+      required={required}
+      optional={optional}
+      hint={hint}
+      error={error}
+      className={className}
+    >
+      {(control) => (
+        <input
+          {...inputProps}
+          {...control}
+          type={type}
+          value={value}
+          onChange={(e) => onValueChange(e.target.value)}
+          autoComplete={autoComplete}
+          className={cx(fieldControlClass, inputClassName)}
+        />
+      )}
+    </FormField>
+  );
+}

--- a/apps/web/components/ui/form/TextareaField.tsx
+++ b/apps/web/components/ui/form/TextareaField.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+// TextareaField — a multi-line labeled control wired through FormField.
+
+import type { ReactNode, TextareaHTMLAttributes } from "react";
+import { FormField } from "./FormField";
+import { cx, fieldControlClass } from "./styles";
+
+type NativeTextareaProps = Omit<
+  TextareaHTMLAttributes<HTMLTextAreaElement>,
+  "id" | "name" | "value" | "onChange" | "required"
+>;
+
+export type TextareaFieldProps = {
+  name: string;
+  label: ReactNode;
+  value: string;
+  onValueChange: (value: string) => void;
+  required?: boolean;
+  optional?: boolean;
+  hint?: ReactNode;
+  error?: ReactNode;
+  rows?: number;
+  placeholder?: string;
+  className?: string;
+  textareaClassName?: string;
+} & NativeTextareaProps;
+
+export function TextareaField({
+  name,
+  label,
+  value,
+  onValueChange,
+  required = false,
+  optional = false,
+  hint,
+  error,
+  rows = 3,
+  placeholder,
+  className,
+  textareaClassName,
+  ...textareaProps
+}: TextareaFieldProps) {
+  return (
+    <FormField
+      name={name}
+      label={label}
+      required={required}
+      optional={optional}
+      hint={hint}
+      error={error}
+      className={className}
+    >
+      {(control) => (
+        <textarea
+          {...textareaProps}
+          {...control}
+          value={value}
+          onChange={(e) => onValueChange(e.target.value)}
+          rows={rows}
+          placeholder={placeholder}
+          className={cx(fieldControlClass, "resize-y", textareaClassName)}
+        />
+      )}
+    </FormField>
+  );
+}

--- a/apps/web/components/ui/form/index.ts
+++ b/apps/web/components/ui/form/index.ts
@@ -1,0 +1,25 @@
+// Portal form contract (BI-8E74C749). The shared, accessible primitives every
+// user-facing form composes so field wiring, required/optional state, inline
+// validation, submit feedback, and consequence copy are consistent for
+// non-technical owners and assistive technology.
+//
+// See docs/platform-usability-standards.md → "User-facing form contract".
+
+export { FormField, type FormFieldProps, type FieldControlProps } from "./FormField";
+export { TextField, type TextFieldProps } from "./TextField";
+export { EmailField, type EmailFieldProps } from "./EmailField";
+export { SelectField, type SelectFieldProps, type SelectOption } from "./SelectField";
+export { TextareaField, type TextareaFieldProps } from "./TextareaField";
+export { CheckboxField, type CheckboxFieldProps } from "./CheckboxField";
+export { FormStatus, type FormStatusProps } from "./FormStatus";
+export { SubmitButton, type SubmitButtonProps } from "./SubmitButton";
+export { ConsequenceNotice, type ConsequenceNoticeProps } from "./ConsequenceNotice";
+export {
+  fieldControlClass,
+  fieldOptionClass,
+  fieldLabelClass,
+  fieldHintClass,
+  fieldErrorClass,
+  primaryButtonClass,
+  cx,
+} from "./styles";

--- a/apps/web/components/ui/form/styles.ts
+++ b/apps/web/components/ui/form/styles.ts
@@ -1,0 +1,34 @@
+// Shared, theme-aware class strings for the portal form contract (BI-8E74C749).
+// All colors resolve through the --dpf-* custom properties (AGENTS.md §12) so
+// light mode, dark mode, and branding all work automatically. Keep control
+// styling in one place so every user-facing form looks and focuses identically.
+
+/** The standard text/select/textarea control surface. */
+export const fieldControlClass =
+  "w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] " +
+  "px-3 py-2 text-sm text-[var(--dpf-text)] placeholder:text-[var(--dpf-muted)] " +
+  "focus:outline-none focus:ring-2 focus:ring-[var(--dpf-accent)] " +
+  "aria-[invalid=true]:border-[var(--dpf-error)]";
+
+/** <option> elements need explicit themed colors (AGENTS.md §12). */
+export const fieldOptionClass = "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]";
+
+/** Field label text. */
+export const fieldLabelClass = "text-sm font-medium text-[var(--dpf-text)]";
+
+/** Small helper/hint text beneath a control. */
+export const fieldHintClass = "text-xs text-[var(--dpf-muted)]";
+
+/** Inline validation / error text. */
+export const fieldErrorClass = "text-xs text-[var(--dpf-error)]";
+
+/** Primary submit button. */
+export const primaryButtonClass =
+  "inline-flex items-center justify-center gap-2 rounded-md bg-[var(--dpf-accent)] " +
+  "px-4 py-2 text-sm font-semibold text-white transition-opacity " +
+  "hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60";
+
+/** Join class strings, dropping falsy values. */
+export function cx(...parts: Array<string | false | null | undefined>): string {
+  return parts.filter(Boolean).join(" ");
+}

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -4229,6 +4229,7 @@
         "color-system",
         "contrast-requirements",
         "form-elements",
+        "user-facing-form-contract-mandatory",
         "prohibited-patterns",
         "allowed-hex-usage",
         "component-checklist",

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -42,6 +42,36 @@ All `<input>`, `<select>`, `<textarea>` elements receive a baseline via `@layer 
 - **Disabled:** `opacity: 0.5; cursor: not-allowed`
 - **Active/focused:** Border color changes to `--dpf-accent`
 
+## User-facing form contract (mandatory)
+
+Every user-facing form — public/customer auth, storefront setup, employee HR/pay,
+admin, and archetype booking/intake — composes the shared primitives in
+[`apps/web/components/ui/form/`](../apps/web/components/ui/form/) so field wiring
+and action feedback are consistent for non-technical owners and assistive
+technology. Do **not** hand-roll a label/input pair, a submit spinner, or a bespoke
+consequence banner; a form that re-implements these is a defect (BI-8E74C749).
+
+**Primitives** (import from `@/components/ui/form`):
+
+| Primitive | Responsibility |
+|---|---|
+| `FormField` | Labeled-control wrapper (render-prop). Owns `<label htmlFor>`↔`id`, required/optional marker, `aria-required`, `aria-invalid`, hint + error wired via `aria-describedby`, and `role="alert"` on the error. |
+| `TextField` / `EmailField` / `SelectField` / `TextareaField` / `CheckboxField` | Typed controls built on `FormField`. `EmailField` also normalizes on blur via `EmailInput`. |
+| `SubmitButton` | Primary action with a first-class pending state (`aria-busy` + `InlineBusy`); disables to prevent double-submit. |
+| `FormStatus` | Settled outcome region — error is assertive (`role="alert"`), success is polite (`role="status"` + `aria-live`). |
+| `ConsequenceNotice` | Risk-proportional consequence copy behind progressive disclosure (native `<details>`): what changes, who's affected, reversibility, recovery. |
+
+**The contract each field must satisfy:**
+1. **Stable name + id-label wiring** — every control has a `name` and an `id` bound to a real `<label htmlFor>` (so `getByLabelText`, click-to-focus, and AT all work).
+2. **Accessible label** — visible label text, never placeholder-as-label.
+3. **Required/optional state** — exposed visibly (`*` / `(optional)`) **and** to AT (`aria-required`, the native `required` attribute, and an SR-only "(required)").
+4. **Correct `autocomplete`** — `username`/`email` for identifiers, `current-password` for sign-in, `new-password` for set/confirm/temporary passwords, `name`/`tel`, and the `address-line1`/`address-level1`/`address-level2`/`postal-code`/`country` tokens for addresses. Use `off` only for admin-entered credentials for *another* user, and one-off date/time pickers.
+5. **Inline validation** — field-level errors set `aria-invalid` and render through `FormField`'s described `role="alert"` region, not only a form-level banner.
+
+**Mutating submits** show pending → success/failure through `SubmitButton` + `FormStatus` (never a silent recolor or a bare text swap).
+
+**Sensitive actions** (create/deactivate a user, reset a password, change pay) carry a `ConsequenceNotice` that answers what changes, who/what is affected, whether it can be undone, and the recovery path — kept behind progressive disclosure so a non-technical owner sees one plain summary line, not a wall of text.
+
 ## Prohibited Patterns
 
 These patterns are NOT allowed in component code:

--- a/docs/superpowers/specs/2026-07-22-accessible-form-submit-contract-design.md
+++ b/docs/superpowers/specs/2026-07-22-accessible-form-submit-contract-design.md
@@ -1,0 +1,86 @@
+# Accessible form submit contract (BI-8E74C749)
+
+**Epic:** EP-UX-COGLOAD (Live UX cognitive-load audit follow-up)
+**Status:** implemented
+**Surface:** `apps/web` — user-facing forms (public/customer auth, storefront setup, employee HR/pay, admin, archetype booking/intake)
+
+## Problem
+
+A 2026-07-22 compact browser audit found a repeated pattern across customer,
+owner, and admin pages: forms render visually, but the field structure and the
+action-consequence contract are inconsistent for non-technical owners and
+assistive technology. Concretely: `/portal/sign-in` and
+`/s/digital-product-factory/sign-in` fields lacked `name`, accessible labels, and
+password `autocomplete`; `/s/.../sign-up` did not mark the name field required and
+passwords lacked `autocomplete`; `/storefront/settings/business` (dense 15-field
+setup) had many missing names and no required-state contract; `/employee` HR/pay
+and `/admin` Create-user exposed no required-state and no consequence/undo
+language for sensitive controls.
+
+Root cause: **no shared form primitive existed.** Every form hand-rolled its own
+label wiring and `inputClasses`/`labelClasses` constants, so the accessible-name,
+required-state, `autocomplete`, validation, submit-feedback, and consequence-copy
+decisions were re-made (and dropped) per form.
+
+## Design grounding
+
+- **Source of truth:** `docs/platform-usability-standards.md` (Form Elements +
+  the new "User-facing form contract" section) and AGENTS.md §12 (theme-aware
+  styling, no native dialogs, progressive disclosure) / §17 (hide complexity from
+  layman users).
+- **Substrate check:** no `FormField`/`LabeledInput` primitive existed
+  (grep + code-graph). Existing input-only primitives (`EmailInput`, `PhoneInput`,
+  `InlineBusy`, `Dialog`) are composed, not replaced. This **extends** the
+  usability standard and **creates** one shared primitive family under
+  `apps/web/components/ui/form/`, mirroring the existing report-kit pattern
+  ("compose a shared palette, never hand-roll").
+- **Decision:** extend the standard + add primitives; no new data model, route, or
+  migration. Progressive disclosure keeps consequence detail out of the default
+  view, so this **lowers** cognitive load rather than adding controls.
+
+## Research & benchmarking
+
+- **WCAG 2.2 AA / WAI-ARIA APG** — label association, `aria-required`,
+  `aria-invalid`, `aria-describedby` error wiring, live-region announcements.
+- **HTML `autocomplete` token spec (WHATWG)** — `username`, `current-password`,
+  `new-password`, `tel`, and the `address-*` token family.
+- **GOV.UK Design System** (error summary + per-field error, one question per
+  thing) and **Shopify Polaris** (progressive disclosure of consequential
+  settings) — adopted the field-level `role="alert"` error and the disclosure of
+  consequence detail; rejected a modal-per-action confirm for low/medium-risk
+  saves as too heavy for a non-technical owner.
+
+## Primitives (`apps/web/components/ui/form/`)
+
+`FormField` (render-prop wrapper owning label↔id, required/optional, aria-*,
+described hint + `role="alert"` error), `TextField`, `EmailField`, `SelectField`,
+`TextareaField`, `CheckboxField`, `SubmitButton` (pending via `InlineBusy` +
+`aria-busy`), `FormStatus` (assertive error / polite success), and
+`ConsequenceNotice` (what / who / reversibility / recovery behind a native
+`<details>`). Ids come from `useId()` so same-named fields never collide. All
+colors resolve through `--dpf-*` tokens.
+
+## Applied surfaces
+
+| Route | Component |
+|---|---|
+| `/portal/sign-in`, `/s/[slug]/sign-in` | `SignInForm` |
+| `/s/[slug]/sign-up` | `SignUpForm` |
+| `/storefront/settings/business` | `BusinessContextForm` (surgical: names + autocomplete + announced submit) |
+| `/employee` (HR/pay) | `CompensationPanel`, `HrUserLifecyclePanel` (+ ConsequenceNotice on deactivate) |
+| `/admin` (Create user) | `AdminUserAccessPanel` (+ ConsequenceNotice on create + reset) |
+| Restaurant / archetype booking | `BookingForm` |
+
+## Tests
+
+Route-level `*.test.tsx` co-located with each form assert the contract via
+`getByLabelText` / `getByRole` (jsdom) — name/id-label wiring, `autocomplete`,
+required/optional, inline validation, and consequence copy — plus a `FormField`
+unit test (including same-name id-collision). `BusinessContextForm` reuses its
+existing `renderToStaticMarkup` test, extended with name/autocomplete assertions.
+
+## Non-goals
+
+Not a full rewrite of every form in the portal; the remaining hand-rolled forms
+(compliance, wiki, finance, edge-node admin) migrate opportunistically to the same
+primitives when next touched.


### PR DESCRIPTION
## Summary

Implements **BI-8E74C749** (EP-UX-COGLOAD): a consistent accessible submit contract for user-facing portal forms. A 2026-07-22 compact browser audit found forms rendering visually but with inconsistent field structure and action-consequence contracts for non-technical owners and assistive technology — because **no shared form primitive existed** and every form hand-rolled its own label wiring.

Adds `apps/web/components/ui/form/` — the shared primitives every user-facing form composes:

- `FormField` (render-prop) — label↔id via `useId`, required/optional marker, `aria-required`/`aria-invalid`, hint + error wired through `aria-describedby`, `role="alert"` on errors.
- `TextField` / `EmailField` / `SelectField` / `TextareaField` / `CheckboxField`.
- `SubmitButton` — pending state via `InlineBusy` + `aria-busy`, disables to prevent double-submit.
- `FormStatus` — assertive error (`role="alert"`) / polite success (`role="status"`).
- `ConsequenceNotice` — what/who/reversibility/recovery behind a native `<details>` (progressive disclosure).

### Applied surfaces

| Route | Component | Change |
|---|---|---|
| `/portal/sign-in`, `/s/[slug]/sign-in` | `SignInForm` | name/id-label wiring, `username` + `current-password` autocomplete, required |
| `/s/[slug]/sign-up` | `SignUpForm` | name now **required** (was unmarked), `new-password` hints, inline confirm-mismatch validation |
| `/storefront/settings/business` | `BusinessContextForm` | stable names + address/contact autocomplete + announced submit (surgical) |
| `/employee` (HR/pay) | `CompensationPanel`, `HrUserLifecyclePanel` | required state; deactivate carries a `ConsequenceNotice` |
| `/admin` (Create user) | `AdminUserAccessPanel` | consequence disclosure on create + password reset |
| Restaurant/archetype booking | `BookingForm` | full contract; no overlap with #3383 (that touches `SlotBookingFlow.tsx`) |

Route-level `*.test.tsx` cover each surface + a `FormField` unit test. Standard documented in `docs/platform-usability-standards.md`; design in `docs/superpowers/specs/2026-07-22-accessible-form-submit-contract-design.md`.

## Design grounding

Reviewed specs/plans under `docs/superpowers/specs/` (no prior form-contract spec) and the code substrate under `apps/web/` (no shared `FormField` existed; report-kit is the compose-a-shared-palette precedent). Source of truth: `docs/platform-usability-standards.md` + AGENTS.md §12/§17. Extends the usability standard and adds one primitive family — no new route/model/migration.

## Verification substrate

- **Typecheck: PASSED** — real `next typegen && tsc --noEmit` against converged dependencies, **0 errors**.
- **Unit tests + production build:** run authoritatively in **CI** (see below).

The shared local-CI convergence sandbox is currently **blocked by a pre-existing store defect** — `vitest@4.1.9` is corrupt (missing `dist/chunks/cac.*.js`) while the lockfile requires `4.1.10` after a recent main bump; the freshness preflight exits 3 (`blocked_sandbox_drift`), which per AGENTS.md §5 is a **sandbox defect, not a product build failure**, affecting every branch. A governed `--converge` did not repair it (store-level corruption needs a shared-store prune, out of scope for this feature per the BLOCKED stop-rule). The pre-push gate was overridden for that reason; CI runs Unit Tests + Prod Build in a clean environment.

UX-Fit-Decision: Progressive disclosure lowers cognitive load — no new required inputs; consequence detail for sensitive actions (create/deactivate user, password reset, pay) sits behind a collapsed `<details>` so the default view stays 3-5 plain fields. On the human_cognitive_load axis, standardizing label/required/feedback wiring reduces load vs the inconsistent hand-rolled forms.
Design-Grounding-Decision: Reviewed specs/plans under docs/superpowers/specs/ (no prior form-contract spec) and the code substrate under apps/web/ (no shared FormField existed). Source of truth: docs/platform-usability-standards.md + AGENTS.md §12/§17. Extends the usability standard; adds one primitive family; no new route/model/migration.
Docs-Impact-Decision: Auth/booking/admin/employee routes changed only field wiring and feedback (no user-visible workflow change); the durable standard is captured in docs/platform-usability-standards.md and the design spec.
Local-CI-Override: local-CI sandbox blocked by pre-existing corrupt vitest@4.1.9 store entry (locked 4.1.10); freshness preflight exit 3 = sandbox defect not product evidence (AGENTS.md §5). Verified real tsc --noEmit = 0 errors against converged deps; unit tests + prod build run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)