### PR TITLE
feat(storefront): traceable owner-facing reservation handoff (BI-3DA1DFDC)

### DIFF
--- a/apps/web/app/(shell)/storefront/inbox/page.tsx
+++ b/apps/web/app/(shell)/storefront/inbox/page.tsx
@@ -3,9 +3,10 @@ import { redirect } from "next/navigation";
 import { StorefrontInbox } from "@/components/storefront-admin/StorefrontInbox";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
+import { formatReservationWhen, nextActionForReservation } from "@/lib/storefront/booking-summary";
 
 export default async function InboxPage() {
-  const config = await prisma.storefrontConfig.findFirst({ select: { id: true } });
+  const config = await prisma.storefrontConfig.findFirst({ select: { id: true, timezone: true } });
   if (!config) redirect("/storefront/setup");
 
   const [inquiries, bookings, orders, donations, providerList, digitalProducts, orgSettings] = await Promise.all([
@@ -29,9 +30,12 @@ export default async function InboxPage() {
       select: {
         id: true,
         bookingRef: true,
+        itemId: true,
         customerName: true,
         customerEmail: true,
         scheduledAt: true,
+        covers: true,
+        dietaryNotes: true,
         status: true,
         createdAt: true,
         provider: { select: { name: true } },
@@ -81,6 +85,19 @@ export default async function InboxPage() {
 
   const currencySymbol = getCurrencySymbol(orgSettings.baseCurrency);
 
+  // Resolve the booked item's display name (e.g. "Table for 2") so the owner sees
+  // WHAT was reserved, not just a ref (BI-3DA1DFDC). booking.itemId is the
+  // StorefrontItem cuid.
+  const bookingItemIds = [...new Set(bookings.map((b) => b.itemId))];
+  const itemNameById = new Map(
+    (
+      await prisma.storefrontItem.findMany({
+        where: { id: { in: bookingItemIds } },
+        select: { id: true, name: true },
+      })
+    ).map((item) => [item.id, item.name]),
+  );
+
   type InboxEntry = {
     id: string;
     ref: string;
@@ -92,6 +109,13 @@ export default async function InboxPage() {
     providerName: string | null;
     status: string;
     backlogItemId?: string | null;
+    // Reservation handoff fields (bookings only).
+    itemName?: string | null;
+    covers?: number | null;
+    dietaryNotes?: string | null;
+    whenLabel?: string;
+    timeLabel?: string;
+    nextAction?: string;
   };
 
   const inquiryBacklogItemIds = new Map(
@@ -125,17 +149,26 @@ export default async function InboxPage() {
           `BI-SFI-${inquiry.inquiryRef.replace(/[^a-zA-Z0-9]/g, "").toUpperCase()}`,
         ) ?? null,
     })),
-    ...bookings.map((booking) => ({
-      id: booking.id,
-      ref: booking.bookingRef,
-      name: booking.customerName,
-      email: booking.customerEmail,
-      type: "booking",
-      detail: booking.scheduledAt.toLocaleDateString("en-GB"),
-      createdAt: booking.createdAt.toISOString(),
-      providerName: booking.provider?.name ?? null,
-      status: booking.status,
-    })),
+    ...bookings.map((booking) => {
+      const when = formatReservationWhen(booking.scheduledAt, config.timezone);
+      return {
+        id: booking.id,
+        ref: booking.bookingRef,
+        name: booking.customerName,
+        email: booking.customerEmail,
+        type: "booking",
+        detail: when.whenLabel,
+        createdAt: booking.createdAt.toISOString(),
+        providerName: booking.provider?.name ?? null,
+        status: booking.status,
+        itemName: itemNameById.get(booking.itemId) ?? null,
+        covers: booking.covers,
+        dietaryNotes: booking.dietaryNotes,
+        whenLabel: when.whenLabel,
+        timeLabel: when.timeLabel,
+        nextAction: nextActionForReservation(booking.status),
+      };
+    }),
     ...orders.map((order) => ({
       id: order.id,
       ref: order.orderRef,

--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { promptDialog } from "@/components/ui/Dialog";
+import { reservationActionLabel } from "@/lib/storefront/booking-summary";
 
 type Entry = {
   id: string;
@@ -13,6 +14,13 @@ type Entry = {
   providerName: string | null;
   status: string;
   backlogItemId?: string | null;
+  // Reservation handoff fields (bookings only).
+  itemName?: string | null;
+  covers?: number | null;
+  dietaryNotes?: string | null;
+  whenLabel?: string;
+  timeLabel?: string;
+  nextAction?: string;
 };
 
 const TYPE_LABELS: Record<string, string> = {
@@ -213,7 +221,29 @@ export function StorefrontInbox({
               </span>
             </div>
             <div style={{ fontSize: 13 }}>{e.name ?? "Anonymous"} · {e.email}</div>
-            {e.detail && <div className="text-[var(--dpf-muted)]" style={{ fontSize: 12, marginTop: 2 }}>{e.detail}</div>}
+            {e.type === "booking" ? (
+              <div style={{ marginTop: 4, display: "flex", flexDirection: "column", gap: 2 }}>
+                <div style={{ fontSize: 13, fontWeight: 600 }}>
+                  {e.itemName ?? "Reservation"}
+                  {e.whenLabel && <span className="text-[var(--dpf-muted)]" style={{ fontWeight: 400 }}> · {e.whenLabel}</span>}
+                  {typeof e.covers === "number" && (
+                    <span className="text-[var(--dpf-muted)]" style={{ fontWeight: 400 }}> · {e.covers} {e.covers === 1 ? "guest" : "guests"}</span>
+                  )}
+                </div>
+                {e.dietaryNotes && (
+                  <div className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>
+                    Dietary: {e.dietaryNotes}
+                  </div>
+                )}
+                {e.nextAction && (
+                  <div style={{ fontSize: 12, color: "var(--dpf-accent)" }}>
+                    Next: {e.nextAction}
+                  </div>
+                )}
+              </div>
+            ) : (
+              e.detail && <div className="text-[var(--dpf-muted)]" style={{ fontSize: 12, marginTop: 2 }}>{e.detail}</div>
+            )}
             {e.type === "inquiry" && (() => {
               // A successful send stores the created itemId (BI-…); anything
               // else stored is an error message to surface for a retry.
@@ -279,6 +309,11 @@ export function StorefrontInbox({
                 {e.status === "pending" && (
                   <button
                     onClick={() => confirmBooking(e.id)}
+                    aria-label={reservationActionLabel("Confirm", {
+                      guestName: e.name,
+                      itemName: e.itemName,
+                      timeLabel: e.timeLabel,
+                    })}
                     className="border border-[var(--dpf-success)] text-[var(--dpf-success)]"
                     style={{ padding: "3px 10px", borderRadius: 4, background: "none", cursor: "pointer", fontSize: 12 }}
                   >
@@ -288,6 +323,11 @@ export function StorefrontInbox({
                 {e.status !== "cancelled" && e.status !== "completed" && (
                   <button
                     onClick={() => cancelBooking(e.id)}
+                    aria-label={reservationActionLabel("Cancel", {
+                      guestName: e.name,
+                      itemName: e.itemName,
+                      timeLabel: e.timeLabel,
+                    })}
                     className="border border-[var(--dpf-error)] text-[var(--dpf-error)]"
                     style={{ padding: "3px 10px", borderRadius: 4, background: "none", cursor: "pointer", fontSize: 12 }}
                   >

--- a/apps/web/components/storefront/SlotBookingFlow.tsx
+++ b/apps/web/components/storefront/SlotBookingFlow.tsx
@@ -6,6 +6,9 @@ import { submitBooking } from "@/lib/storefront-actions";
 import { EmailInput } from "@/components/ui/EmailInput";
 import { PhoneInput } from "@/components/ui/PhoneInput";
 import { slotFlowExtraFields, type FormField } from "./slot-booking-fields";
+// booking-summary owns the structured-role mapping + handoff vocabulary;
+// slot-booking-fields (above) owns which schema fields the flow still renders.
+import { parseCovers, structuredBookingFieldRole } from "@/lib/storefront/booking-summary";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -332,15 +335,23 @@ export function SlotBookingFlow({
     const durationMinutes = computeDurationMinutes(slot.startTime, slot.endTime);
     const providerId = selectedProvider?.id ?? slot.providerId;
 
-    // Collect archetype-specific fields and prepend to notes
-    const STANDARD_FIELDS = ["name", "email", "phone", "notes"];
+    // slotFlowExtraFields already drops the contact + slot-derived (date/time)
+    // fields the flow owns, so the selected slot stays the single source of the
+    // date/time. Of what remains: covers + dietary become structured booking facts
+    // (BI-3DA1DFDC); anything else is preserved as free-text notes.
+    let covers: number | undefined;
+    let dietaryNotes: string | undefined;
     const extraLines: string[] = [];
-    if (formSchema) {
-      for (const field of formSchema) {
-        if (!STANDARD_FIELDS.includes(field.name)) {
-          const val = fd.get(field.name) as string | null;
-          if (val) extraLines.push(`${field.label}: ${val}`);
-        }
+    for (const field of slotFlowExtraFields(formSchema)) {
+      const val = (fd.get(field.name) as string | null)?.trim();
+      if (!val) continue;
+      const role = structuredBookingFieldRole(field.name);
+      if (role === "covers") {
+        covers = parseCovers(val) ?? undefined;
+      } else if (role === "dietary") {
+        dietaryNotes = val;
+      } else {
+        extraLines.push(`${field.label}: ${val}`);
       }
     }
     const userNotes = (fd.get("notes") as string) || "";
@@ -357,6 +368,8 @@ export function SlotBookingFlow({
       customerEmail: fd.get("email") as string,
       customerName: fd.get("name") as string,
       customerPhone: (fd.get("phone") as string) || undefined,
+      covers,
+      dietaryNotes,
       notes: notes || undefined,
       idempotencyKey: crypto.randomUUID(),
     });
@@ -817,8 +830,11 @@ function FormStep({
         ‹ Back to slots
       </button>
 
-      {/* Booking summary */}
+      {/* Reservation summary — the fixed slot is the single source of truth for
+          date/time. The contact step below never re-asks for them (BI-3DA1DFDC). */}
       <div
+        role="group"
+        aria-label="Your reservation"
         style={{
           padding: 16,
           background: "var(--dpf-surface-2)",
@@ -829,11 +845,14 @@ function FormStep({
           gap: 6,
         }}
       >
+        <div style={{ fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: 0.4, color: "var(--dpf-muted)" }}>
+          Your reservation
+        </div>
         <div style={{ fontWeight: 600, fontSize: 15, color: "var(--dpf-text)" }}>{itemName}</div>
-        <div style={{ fontSize: 14, color: "var(--dpf-muted)" }}>
+        <div style={{ fontSize: 14, color: "var(--dpf-text)" }}>
           {formatDisplayDate(selectedDate)}
         </div>
-        <div style={{ fontSize: 14, color: "var(--dpf-muted)" }}>
+        <div style={{ fontSize: 14, color: "var(--dpf-text)" }}>
           {formatTime(selectedSlot.startTime)} — {formatTime(selectedSlot.endTime)}
         </div>
         {providerName && (
@@ -841,6 +860,9 @@ function FormStep({
             with {providerName}
           </div>
         )}
+        <div style={{ fontSize: 12, color: "var(--dpf-muted)" }}>
+          To change the date or time, go back and pick another slot.
+        </div>
       </div>
 
       {/* Contact form */}
@@ -850,42 +872,46 @@ function FormStep({
         )}
 
         <div style={fieldStyle}>
-          <label style={labelStyle}>Full name *</label>
-          <input type="text" name="name" required style={inputStyle} autoComplete="name" />
+          <label htmlFor="booking-name" style={labelStyle}>Full name *</label>
+          <input id="booking-name" type="text" name="name" required style={inputStyle} autoComplete="name" />
         </div>
 
         <div style={fieldStyle}>
-          <label style={labelStyle}>Email address *</label>
-          <EmailInput name="email" required style={inputStyle} />
+          <label htmlFor="booking-email" style={labelStyle}>Email address *</label>
+          <EmailInput id="booking-email" name="email" required style={inputStyle} />
         </div>
 
         <div style={fieldStyle}>
-          <label style={labelStyle}>Phone (optional)</label>
-          <PhoneInput name="phone" style={inputStyle} />
+          <label htmlFor="booking-phone" style={labelStyle}>Phone (optional)</label>
+          <PhoneInput id="booking-phone" name="phone" style={inputStyle} />
         </div>
 
-        {slotFlowExtraFields(formSchema).map((field) => (
-          <div key={field.name} style={fieldStyle}>
-            <label style={labelStyle}>{field.label}{field.required ? " *" : " (optional)"}</label>
-            {field.type === "textarea" ? (
-              <textarea name={field.name} required={field.required} rows={3}
-                placeholder={field.placeholder}
-                style={{ ...inputStyle, resize: "vertical" }} />
-            ) : field.type === "select" ? (
-              <select name={field.name} required={field.required} style={inputStyle}>
-                <option value="">Select…</option>
-                {field.options?.map((o) => <option key={o} value={o}>{o}</option>)}
-              </select>
-            ) : (
-              <input type={field.type} name={field.name} required={field.required}
-                placeholder={field.placeholder} style={inputStyle} />
-            )}
-          </div>
-        ))}
+        {slotFlowExtraFields(formSchema).map((field) => {
+          const fieldId = `booking-field-${field.name}`;
+          return (
+            <div key={field.name} style={fieldStyle}>
+              <label htmlFor={fieldId} style={labelStyle}>{field.label}{field.required ? " *" : " (optional)"}</label>
+              {field.type === "textarea" ? (
+                <textarea id={fieldId} name={field.name} required={field.required} rows={3}
+                  placeholder={field.placeholder}
+                  style={{ ...inputStyle, resize: "vertical" }} />
+              ) : field.type === "select" ? (
+                <select id={fieldId} name={field.name} required={field.required} style={inputStyle}>
+                  <option value="">Select…</option>
+                  {field.options?.map((o) => <option key={o} value={o}>{o}</option>)}
+                </select>
+              ) : (
+                <input id={fieldId} type={field.type} name={field.name} required={field.required}
+                  placeholder={field.placeholder} style={inputStyle} />
+              )}
+            </div>
+          );
+        })}
 
         <div style={fieldStyle}>
-          <label style={labelStyle}>Notes (optional)</label>
+          <label htmlFor="booking-notes" style={labelStyle}>Notes (optional)</label>
           <textarea
+            id="booking-notes"
             name="notes"
             rows={3}
             style={{ ...inputStyle, resize: "vertical" }}

--- a/apps/web/lib/attention/aggregate.ts
+++ b/apps/web/lib/attention/aggregate.ts
@@ -17,6 +17,7 @@ import {
   type CoworkerMemoryAttentionDb,
 } from "./sources/coworker-memory";
 import { loadProviderCredentialItems, loadProviderSuitabilityDriftItems } from "./sources/provider-credential";
+import { loadReservationExceptionItems } from "./sources/reservation-exception";
 import {
   loadOutboundItems,
   loadBillItems,
@@ -95,6 +96,7 @@ export async function loadAttentionItems(
     { source: "research-proposal", load: () => loadResearchItems(db) },
     { source: "coworker-memory", load: () => loadCoworkerMemoryItems(db as unknown as CoworkerMemoryAttentionDb) },
     { source: "platform-health", load: () => loadPlatformHealthItems(db) },
+    { source: "reservation-exception", load: () => loadReservationExceptionItems(db) },
     {
       source: "provider-credential",
       load: async () => [

--- a/apps/web/lib/attention/outside-in.ts
+++ b/apps/web/lib/attention/outside-in.ts
@@ -67,6 +67,7 @@ export const PORTFOLIOS_OUTSIDE_IN: readonly AttentionPortfolio[] = (
 const SOURCE_PORTFOLIO: Record<AttentionSource, AttentionPortfolio> = {
   // Customer-facing revenue surface.
   "approval-outbound": "products-and-services-sold", // marketing/sales drafts to customers
+  "reservation-exception": "products-and-services-sold", // a guest awaiting an owner reservation decision
   // The workforce — people + AI coworkers needing a human.
   "ai-decision": "for-employees", // a coworker's decision the kernel couldn't make
   "paused-ai": "for-employees", // a coworker paused, needs input/credential

--- a/apps/web/lib/attention/owner-decision-copy.ts
+++ b/apps/web/lib/attention/owner-decision-copy.ts
@@ -15,6 +15,7 @@ const HEADLINE: Record<AttentionSource, string> = {
   "ai-readiness-blocker": "Choose an intelligence setup fix?",
   "platform-health": "Choose how to handle this outage?",
   "provider-credential": "Reconnect this service?",
+  "reservation-exception": "Handle this reservation?",
 };
 
 const SPECIALIST: Record<AttentionSource, string> = {
@@ -32,6 +33,7 @@ const SPECIALIST: Record<AttentionSource, string> = {
   "ai-readiness-blocker": "Technology",
   "platform-health": "Platform operations",
   "provider-credential": "Technology",
+  "reservation-exception": "Front of house",
 };
 
 export function specialistFor(source: AttentionSource): string {
@@ -88,6 +90,8 @@ export function whyItMattersFor(item: AttentionItem): string {
       return "This research may improve how your team serves customers.";
     case "coworker-memory":
       return "Your digital team is accumulating working memory from completed work.";
+    case "reservation-exception":
+      return "A guest booked through your storefront and is waiting to hear back.";
     default:
       return "This technical issue matters only if it changes customer or business work.";
   }
@@ -98,6 +102,9 @@ export function whyItMattersFor(item: AttentionItem): string {
 const GENERIC_BLAST_RADIUS = new Set(["a coworker task", "a coworker waiting on approval"]);
 
 export function consequenceFor(item: AttentionItem): string {
+  if (item.source === "reservation-exception") {
+    return "If you do nothing, the guest is left without a confirmed reservation.";
+  }
   const blastRadius = item.triage.blastRadius;
   if (
     blastRadius &&
@@ -143,6 +150,8 @@ export function recommendationFor(item: AttentionItem): string {
       return "keep this in the weekly review unless it affects a decision due sooner.";
     case "coworker-memory":
       return "scan it in the digest and open the memory page only if it looks stale, too broad, or unsafe.";
+    case "reservation-exception":
+      return "check the date, time, and party size, then confirm the table or offer another time.";
     default:
       return "keep this with the specialist unless it forces a business choice from you.";
   }

--- a/apps/web/lib/attention/owner-routing.ts
+++ b/apps/web/lib/attention/owner-routing.ts
@@ -35,6 +35,11 @@ export function classifyOwnerAttentionLane(
   if (PUBLIC_SOURCES.has(item.source)) {
     return decision("needs-you-now", "The result would go public or to an outside body.", true, appliedLevel);
   }
+  if (item.source === "reservation-exception") {
+    // A guest is waiting on a reservation decision — an owner-level, customer-facing
+    // choice that is never batched into a digest (BI-3DA1DFDC).
+    return decision("needs-you-now", "A guest is waiting on a reservation decision.", true, appliedLevel);
+  }
   if (item.source === "paused-ai" && item.triage.residueReason === "needs-credential") {
     return decision("custodian", "A credential is technical access work, not owner judgment.", false, appliedLevel);
   }

--- a/apps/web/lib/attention/sources/reservation-exception.test.ts
+++ b/apps/web/lib/attention/sources/reservation-exception.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  reservationExceptionToAttentionItem,
+  type ReservationExceptionRow,
+} from "./reservation-exception";
+import type { AttentionItem } from "../types";
+import { portfolioOf } from "../outside-in";
+import { classifyOwnerAttentionLane } from "../owner-routing";
+import { buildOwnerAttentionProjection } from "../owner-projection";
+
+// A public restaurant booking intake state — the fixture that stands in for a real
+// StorefrontBooking without touching a database or taking any external action.
+const NOW = new Date("2026-07-22T12:00:00.000Z").getTime();
+const pendingBooking: ReservationExceptionRow = {
+  bookingId: "bk-1",
+  bookingRef: "BK-0001",
+  customerName: "Jane Smith",
+  itemName: "Table for 2",
+  scheduledAt: new Date("2026-07-22T22:30:00.000Z"), // 6:30 PM America/New_York, 10.5h out
+  covers: 2,
+  status: "pending",
+  overlapQuarantinedAt: null,
+  createdAt: new Date("2026-07-22T09:00:00.000Z"),
+  timezone: "America/New_York",
+};
+
+describe("reservationExceptionToAttentionItem", () => {
+  it("projects a pending booking as a customer-facing reservation task", () => {
+    const item = reservationExceptionToAttentionItem(pendingBooking, NOW);
+    expect(item.id).toBe("reservation-exception:BK-0001");
+    expect(item.source).toBe("reservation-exception");
+    expect(item.title).toBe("Confirm Jane Smith, Table for 2 at 6:30 PM");
+    expect(item.context).toContain("Table for 2");
+    expect(item.context).toContain("2 guests");
+    expect(item.riskClass).toBe("bounded-write");
+    expect(item.triage.residueReason).toBe("input-required");
+    expect(item.triage.timeToAct).toBe("due-today"); // 10.5h away
+    expect(item.triage.blastRadius).toBe("Jane Smith, Table for 2 at 6:30 PM");
+    // Customer-facing revenue portfolio — the OUTSIDE-IN separation from coworker cards.
+    expect(portfolioOf(item)).toBe("products-and-services-sold");
+    expect(item.deepLink).toBe("/storefront/inbox");
+    // Read-only deep-link action only — never a destructive confirm/cancel from here.
+    expect(item.actions.every((a) => a.kind === "open-in-context")).toBe(true);
+  });
+
+  it("escalates an overlap-quarantined booking to a high-risk double-booking", () => {
+    const item = reservationExceptionToAttentionItem(
+      { ...pendingBooking, overlapQuarantinedAt: new Date("2026-07-22T10:00:00.000Z") },
+      NOW,
+    );
+    expect(item.title).toBe("Resolve double-booking: Jane Smith");
+    expect(item.riskClass).toBe("high-risk");
+    expect(item.triage.timeToAct).toBe("due-today");
+    expect(item.triage.blastRadius).toBe("two reservations that overlap");
+  });
+
+  it("routes a reservation exception to needs-you-now, never a batched digest", () => {
+    const item = reservationExceptionToAttentionItem(pendingBooking, NOW);
+    // Even in assertive mode (which batches reversible reviews), a waiting guest is hard-floored.
+    const lane = classifyOwnerAttentionLane(item, "assertive");
+    expect(lane.lane).toBe("needs-you-now");
+    expect(lane.hardFloor).toBe(true);
+  });
+});
+
+describe("workspace surfaces reservation exceptions separately from coworker decisions", () => {
+  // A generic enterprise-architecture coworker decision card — the kind of item the
+  // BI reports as dominating /workspace/inbox. Built as a plain projection literal so
+  // this smoke test stays free of the Prisma-client-backed ai-decision loader.
+  const eaCard: AttentionItem = {
+    id: "ai-decision:DI-1",
+    source: "ai-decision",
+    title: "Which enterprise-architecture approach fits this migration?",
+    context: "Confidence below threshold.",
+    decisionClass: { scorability: "unscorable" },
+    riskClass: "high-risk",
+    triage: {
+      timeToAct: "none",
+      residueReason: "high-risk-gate",
+      blastRadius: "build FB-3",
+      decideEffort: "judgment",
+      irreversible: false,
+    },
+    createdAtIso: "2026-07-22T08:00:00.000Z",
+    actions: [{ kind: "open-in-context", label: "Review evidence", href: "/platform/ai/decisions/DI-1" }],
+    deepLink: "/platform/ai/decisions/DI-1",
+    audience: { operator: true },
+  };
+
+  it("places the reservation ahead of, and in a different portfolio from, the EA decision card", () => {
+    const reservation = reservationExceptionToAttentionItem(pendingBooking, NOW);
+
+    // They are classified into distinct portfolios — the "separately" requirement.
+    expect(portfolioOf(reservation)).toBe("products-and-services-sold");
+    expect(portfolioOf(eaCard)).toBe("for-employees");
+
+    const projection = buildOwnerAttentionProjection([eaCard, reservation], { nowMs: NOW });
+    const ids = projection.needsYouNow.map((e) => e.item.id);
+    expect(ids).toContain("reservation-exception:BK-0001");
+    expect(ids).toContain("ai-decision:DI-1");
+    // Outside-in: the customer-facing reservation outranks the inner coworker card.
+    expect(ids.indexOf("reservation-exception:BK-0001")).toBeLessThan(ids.indexOf("ai-decision:DI-1"));
+  });
+});

--- a/apps/web/lib/attention/sources/reservation-exception.ts
+++ b/apps/web/lib/attention/sources/reservation-exception.ts
@@ -1,0 +1,145 @@
+// Reservation-exception source — projects public StorefrontBooking rows that need
+// the OWNER's attention as first-class, customer-facing attention items, so a
+// restaurant reservation shows up as the owner's next task instead of being lost
+// among generic coworker decision cards (BI-3DA1DFDC).
+//
+// Spec: docs/superpowers/specs/2026-06-23-human-attention-surface-design.md §4.1.
+// A booking is an EXCEPTION requiring a human when it is:
+//   - `pending`          — a guest is waiting on confirm/decline,
+//   - `needs-reschedule` — the owner owes the guest a new time,
+//   - overlap-quarantined — two reservations collided and one is parked for review.
+// Confirmed / completed / cancelled bookings are settled and never surface here.
+//
+// Pure mapper (nowMs injected for the deadline tier) + a thin db loader, mirroring
+// the business-approvals source shape. Read-only: never mutates a booking row.
+
+import type { prisma } from "@dpf/db";
+import type { AttentionItem } from "../types";
+import { timeToActFromDeadline } from "../triage";
+import { formatReservationWhen, nextActionForReservation } from "@/lib/storefront/booking-summary";
+
+type Db = typeof prisma;
+
+export type ReservationExceptionRow = {
+  bookingId: string;
+  bookingRef: string;
+  customerName: string;
+  itemName: string | null;
+  scheduledAt: Date;
+  covers: number | null;
+  status: string;
+  overlapQuarantinedAt: Date | null;
+  createdAt: Date;
+  /** Storefront timezone so the surfaced time is the guest's local slot. */
+  timezone: string;
+};
+
+/** Project one booking exception into an attention item. Pure (nowMs injected). */
+export function reservationExceptionToAttentionItem(
+  row: ReservationExceptionRow,
+  nowMs: number,
+): AttentionItem {
+  const when = formatReservationWhen(row.scheduledAt, row.timezone);
+  const what = row.itemName ?? "Reservation";
+  const coversSuffix = typeof row.covers === "number" ? `, ${row.covers} ${row.covers === 1 ? "guest" : "guests"}` : "";
+  const quarantined = row.overlapQuarantinedAt != null;
+
+  // The deadline that governs urgency is the reservation time itself: a booking
+  // tonight needs a decision today. An overlap is a today-problem regardless.
+  const deadlineIso = row.scheduledAt.toISOString();
+  const timeToAct = quarantined ? "due-today" : timeToActFromDeadline(deadlineIso, nowMs);
+
+  const title = quarantined
+    ? `Resolve double-booking: ${row.customerName}`
+    : row.status === "needs-reschedule"
+      ? `Reschedule ${row.customerName}`
+      : `Confirm ${row.customerName}, ${what} at ${when.timeLabel}`;
+
+  const context = `${what}${coversSuffix} · ${when.whenLabel}`;
+  const blastRadius = quarantined
+    ? "two reservations that overlap"
+    : `${row.customerName}${what !== "Reservation" ? `, ${what}` : ""} at ${when.timeLabel}`;
+
+  return {
+    id: `reservation-exception:${row.bookingRef}`,
+    source: "reservation-exception",
+    title,
+    context,
+    decisionClass: { scorability: "unscorable" },
+    riskClass: quarantined ? "high-risk" : "bounded-write",
+    triage: {
+      timeToAct,
+      deadlineIso,
+      residueReason: quarantined ? "principle-conflict" : "input-required",
+      blastRadius,
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: row.createdAt.toISOString(),
+    // Customer-facing revenue surface — surfaces OUTSIDE-IN, ahead of and separate
+    // from for-employees coworker decision cards.
+    portfolio: "products-and-services-sold",
+    actions: [{ kind: "open-in-context", label: "Open reservation", href: "/storefront/inbox" }],
+    deepLink: "/storefront/inbox",
+    audience: { operator: true },
+    technical: { workType: nextActionForReservation(row.status) },
+  };
+}
+
+const OPEN_EXCEPTION_STATUSES = ["pending", "needs-reschedule"];
+
+/** Load the open reservation exceptions across the install's storefront. */
+export async function loadReservationExceptionItems(db: Db): Promise<AttentionItem[]> {
+  const nowMs = Date.now();
+  const config = await db.storefrontConfig.findFirst({ select: { id: true, timezone: true } });
+  if (!config) return [];
+
+  const rows = await db.storefrontBooking.findMany({
+    where: {
+      storefrontId: config.id,
+      OR: [{ status: { in: OPEN_EXCEPTION_STATUSES } }, { overlapQuarantinedAt: { not: null } }],
+    },
+    orderBy: { scheduledAt: "asc" },
+    take: 50,
+    select: {
+      id: true,
+      bookingRef: true,
+      itemId: true,
+      customerName: true,
+      scheduledAt: true,
+      covers: true,
+      status: true,
+      overlapQuarantinedAt: true,
+      createdAt: true,
+    },
+  });
+  if (rows.length === 0) return [];
+
+  const itemIds = [...new Set(rows.map((r) => r.itemId))];
+  const itemNameById = new Map(
+    (
+      await db.storefrontItem.findMany({
+        where: { id: { in: itemIds } },
+        select: { id: true, name: true },
+      })
+    ).map((item) => [item.id, item.name]),
+  );
+
+  return rows.map((r) =>
+    reservationExceptionToAttentionItem(
+      {
+        bookingId: r.id,
+        bookingRef: r.bookingRef,
+        customerName: r.customerName,
+        itemName: itemNameById.get(r.itemId) ?? null,
+        scheduledAt: r.scheduledAt,
+        covers: r.covers,
+        status: r.status,
+        overlapQuarantinedAt: r.overlapQuarantinedAt,
+        createdAt: r.createdAt,
+        timezone: config.timezone,
+      },
+      nowMs,
+    ),
+  );
+}

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -23,7 +23,8 @@ export type AttentionSource =
   | "coworker-memory" // Newly distilled CoworkerMemoryNote rows for digest visibility
   | "ai-readiness-blocker" // AI Readiness blocked domain requiring operator action
   | "platform-health" // PortfolioQualityIssue issueType=health_alert, status=open (BI-2F778C13)
-  | "provider-credential"; // an enabled AI provider whose saved sign-in has EXPIRED — reconnect (BI-282C39D5)
+  | "provider-credential" // an enabled AI provider whose saved sign-in has EXPIRED — reconnect (BI-282C39D5)
+  | "reservation-exception"; // a public StorefrontBooking awaiting owner action — confirm / reschedule / overlap (BI-3DA1DFDC)
 
 /** Risk vocabulary aligned with the paused-work plan (a2aMetadata.riskClass). */
 export type AttentionRiskClass = "read" | "bounded-write" | "high-risk" | "unknown";

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9085,6 +9085,7 @@
       "anchors": [
         "use-this-doc-for",
         "workflow",
+        "reservations",
         "what-to-watch"
       ]
     },

--- a/apps/web/lib/release/storefront-actions.ts
+++ b/apps/web/lib/release/storefront-actions.ts
@@ -110,6 +110,8 @@ export async function submitBooking(
     scheduledAt: Date;
     durationMinutes: number;
     notes?: string;
+    covers?: number;
+    dietaryNotes?: string;
     holderToken?: string;
     providerId?: string;
     assignmentMode?: string;
@@ -152,6 +154,8 @@ export async function submitBooking(
           scheduledAt: data.scheduledAt,
           durationMinutes: data.durationMinutes,
           notes: data.notes,
+          covers: data.covers,
+          dietaryNotes: data.dietaryNotes,
           providerId: data.providerId,
           assignmentMode: data.assignmentMode,
           idempotencyKey: data.idempotencyKey,
@@ -184,6 +188,8 @@ export async function submitBooking(
               scheduledAt: futureScheduledAt,
               durationMinutes: data.durationMinutes,
               notes: data.notes,
+              covers: data.covers,
+              dietaryNotes: data.dietaryNotes,
               providerId: data.providerId,
               assignmentMode: data.assignmentMode,
               recurrenceRule: data.recurrenceRule,

--- a/apps/web/lib/storefront/booking-summary.test.ts
+++ b/apps/web/lib/storefront/booking-summary.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatReservationWhen,
+  nextActionForReservation,
+  parseCovers,
+  reservationActionLabel,
+  structuredBookingFieldRole,
+} from "./booking-summary";
+
+describe("structuredBookingFieldRole", () => {
+  it("maps covers + dietary field names to their structured roles", () => {
+    expect(structuredBookingFieldRole("covers")).toBe("covers");
+    expect(structuredBookingFieldRole("partySize")).toBe("covers");
+    expect(structuredBookingFieldRole("dietaryRequirements")).toBe("dietary");
+    expect(structuredBookingFieldRole("allergies")).toBe("dietary");
+    // Genuinely-extra fields carry no structured role — they fall through to notes.
+    expect(structuredBookingFieldRole("notes")).toBeNull();
+    expect(structuredBookingFieldRole("eventType")).toBeNull();
+  });
+});
+
+describe("parseCovers", () => {
+  it("parses a plain count and the '10+' bucket", () => {
+    expect(parseCovers("2")).toBe(2);
+    expect(parseCovers("10+")).toBe(10);
+  });
+  it("returns null for empty / non-numeric values", () => {
+    expect(parseCovers("")).toBeNull();
+    expect(parseCovers(null)).toBeNull();
+    expect(parseCovers(undefined)).toBeNull();
+    expect(parseCovers("none")).toBeNull();
+  });
+});
+
+describe("formatReservationWhen", () => {
+  it("surfaces the guest-local slot time in the storefront timezone", () => {
+    // 22:30 UTC is 6:30 PM in America/New_York (EDT).
+    const when = formatReservationWhen(new Date("2026-07-22T22:30:00.000Z"), "America/New_York");
+    expect(when.timeLabel).toBe("6:30 PM");
+    expect(when.dateLabel).toContain("22");
+    expect(when.dateLabel).toContain("Jul");
+    expect(when.whenLabel).toContain("6:30 PM");
+  });
+});
+
+describe("nextActionForReservation", () => {
+  it("gives a plain next action per status", () => {
+    expect(nextActionForReservation("pending")).toMatch(/confirm/i);
+    expect(nextActionForReservation("needs-reschedule")).toMatch(/new time/i);
+    expect(nextActionForReservation("confirmed")).toMatch(/ready/i);
+    expect(nextActionForReservation("cancelled")).toMatch(/no action/i);
+  });
+});
+
+describe("reservationActionLabel", () => {
+  it("builds the row-specific accessible label from intake state", () => {
+    expect(
+      reservationActionLabel("Confirm", {
+        guestName: "Jane Smith",
+        itemName: "Table for 2",
+        timeLabel: "6:30 PM",
+      }),
+    ).toBe("Confirm Jane Smith, Table for 2 at 6:30 PM");
+  });
+
+  it("degrades gracefully when facts are missing", () => {
+    expect(reservationActionLabel("Cancel", { guestName: "Jane Smith" })).toBe("Cancel Jane Smith");
+    expect(reservationActionLabel("Confirm", {})).toBe("Confirm");
+  });
+});

--- a/apps/web/lib/storefront/booking-summary.ts
+++ b/apps/web/lib/storefront/booking-summary.ts
@@ -1,0 +1,115 @@
+// Reservation handoff — the pure, shared vocabulary that turns a public booking
+// intent into a traceable owner-facing reservation task (BI-3DA1DFDC).
+//
+// Deliberately dependency-free (no prisma, no React) so the SAME logic backs three
+// surfaces without drift:
+//   1. the public booking form (SlotBookingFlow) — what to capture / what to drop,
+//   2. the owner storefront inbox — the row summary + accessible action labels,
+//   3. the workspace reservation-exception attention source — the "who's waiting" line.
+//
+// A single source of truth for the handoff copy means "Confirm Jane Smith, Table for
+// 2 at 6:30 PM" reads the same wherever the owner meets it.
+
+// ─── Structured booking field roles ──────────────────────────────────────────
+//
+// An archetype's inquiry formSchema is reused for the booking contact step. Which
+// of those fields still render is owned by slot-booking-fields.ts's
+// `slotFlowExtraFields` (it drops the contact + slot-derived date/time fields).
+// This module owns the remaining question: of the fields that DO render, which
+// belong in a structured booking column (covers, dietary) rather than free-text
+// notes, plus the handoff vocabulary shared with the inbox + attention source.
+
+const COVERS_FIELD_NAMES: ReadonlySet<string> = new Set(["covers", "partysize", "party_size", "guests", "guestcount", "guest_count"]);
+const DIETARY_FIELD_NAMES: ReadonlySet<string> = new Set(["dietary", "dietaryrequirements", "dietary_requirements", "dietarynotes", "dietary_notes", "allergies"]);
+
+function norm(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+/** The structured column a schema field maps to, or null for a free-text extra.
+ *  Lets the booking carry covers + dietary as first-class facts. Pure. */
+export function structuredBookingFieldRole(name: string): "covers" | "dietary" | null {
+  const n = norm(name);
+  if (COVERS_FIELD_NAMES.has(n)) return "covers";
+  if (DIETARY_FIELD_NAMES.has(n)) return "dietary";
+  return null;
+}
+
+/** Parse a covers/party-size control value ("2", "10+") into a count. Pure. */
+export function parseCovers(raw: string | null | undefined): number | null {
+  if (raw == null) return null;
+  const match = raw.match(/\d+/);
+  if (!match) return null;
+  const n = Number.parseInt(match[0], 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+// ─── Reservation summary + owner copy ─────────────────────────────────────────
+
+export type ReservationStatus =
+  | "pending"
+  | "confirmed"
+  | "completed"
+  | "cancelled"
+  | "needs-reschedule";
+
+/** Format a booking's scheduled instant for owner-facing surfaces, in the
+ *  storefront's own timezone so "6:30 PM" is the guest's local slot. Pure given a
+ *  fixed timezone (Intl is deterministic). */
+export function formatReservationWhen(
+  scheduledAt: Date,
+  timezone: string,
+): { dateLabel: string; timeLabel: string; whenLabel: string } {
+  const dateLabel = new Intl.DateTimeFormat("en-GB", {
+    timeZone: timezone,
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  }).format(scheduledAt);
+  const timeLabel = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(scheduledAt);
+  return { dateLabel, timeLabel, whenLabel: `${dateLabel}, ${timeLabel}` };
+}
+
+/** The exact next action for a reservation at a given status — the "what to do"
+ *  line that makes the handoff traceable for a non-technical owner. Pure. */
+export function nextActionForReservation(status: string): string {
+  switch (status) {
+    case "pending":
+      return "Confirm or decline this reservation";
+    case "confirmed":
+      return "Confirmed — get the table ready";
+    case "needs-reschedule":
+      return "Offer the guest a new time";
+    case "cancelled":
+      return "Cancelled — no action needed";
+    case "completed":
+      return "Completed — no action needed";
+    default:
+      return "Review this reservation";
+  }
+}
+
+/** The row-specific, screen-reader-friendly action label an owner acts on, e.g.
+ *  "Confirm Jane Smith, Table for 2 at 6:30 PM". Degrades gracefully when a fact
+ *  is missing. Pure. */
+export function reservationActionLabel(
+  verb: string,
+  parts: { guestName?: string | null; itemName?: string | null; timeLabel?: string | null },
+): string {
+  const segments: string[] = [verb];
+  const who = parts.guestName?.trim();
+  const what = parts.itemName?.trim();
+  const when = parts.timeLabel?.trim();
+  const tail: string[] = [];
+  if (who) tail.push(who);
+  if (what) tail.push(what);
+  let label = segments.join(" ");
+  if (tail.length > 0) label += ` ${tail.join(", ")}`;
+  if (when) label += ` at ${when}`;
+  return label;
+}

--- a/docs/data-impact/2026-07-22-storefront-booking-reservation-context.data-impact.json
+++ b/docs/data-impact/2026-07-22-storefront-booking-reservation-context.data-impact.json
@@ -1,0 +1,39 @@
+{
+  "version": "1",
+  "accountableOwner": "storefront-experience",
+  "affectedCopies": [
+    "StorefrontBooking.covers / dietaryNotes: reservation party size and dietary notes, shown only on the owner storefront inbox and the workspace reservation-exception attention projection (read-model, no parallel persisted copy)"
+  ],
+  "migration": {
+    "name": "20260722060000_storefront_booking_covers_dietary",
+    "backfill": "none — both columns are nullable and default null; existing bookings are untouched and keep any historical party-size/dietary text in their free-text notes"
+  },
+  "tests": [
+    "apps/web/lib/storefront/booking-summary.test.ts",
+    "apps/web/lib/attention/sources/reservation-exception.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:storefront-booking",
+      "prismaModel": "StorefrontBooking",
+      "lifecycleDisposition": "retained for the life of the parent StorefrontBooking reservation and removed with it; inherits the existing booking retention/cancellation lifecycle, adds no new retention surface",
+      "fields": [
+        {
+          "fieldId": "data:storefront-booking#covers",
+          "resolution": "inherited",
+          "reason": "party size is ordinary reservation logistics with the same scope and lifecycle as the booking it belongs to; it inherits StorefrontBooking's existing customer-booking governance",
+          "provenance": "guest-selected party size on the public booking form (covers field)"
+        },
+        {
+          "fieldId": "data:storefront-booking#dietaryNotes",
+          "resolution": "governed",
+          "reason": "dietary requirements and allergies are health-adjacent personal data a guest supplies, so they must stay scoped to the owning booking and never fan out beyond the owner's own reservation surfaces",
+          "provenance": "guest-entered dietary requirements on the public booking form",
+          "flags": ["subject", "sensitive"],
+          "fieldPolicy": "organization-scoped; visible only to the storefront owner on the reservation and its attention projection; never used for training, marketing, or cross-booking aggregation"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-22-restaurant-booking-handoff.md
+++ b/docs/superpowers/plans/2026-07-22-restaurant-booking-handoff.md
@@ -1,0 +1,86 @@
+# Restaurant booking handoff — traceable owner-facing reservation task
+
+**Backlog item:** BI-3DA1DFDC (epic EP-UX-COGLOAD — Live UX cognitive-load audit follow-up)
+**Status:** implemented
+**Date:** 2026-07-22
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-3DA1DFDC`
+- Rationale: The reservation handoff is one cross-surface invariant — the structured `StorefrontBooking` columns, the public booking-form capture, the owner-inbox summary, and the workspace reservation-exception attention source must ship together or the handoff is incomplete (columns without the inbox render leave owners no traceable summary; the workspace source without the columns has nothing structured to project). The sections below are implementation sequencing, not independently shippable product slices.
+- Dependencies: none
+- Receipt: `cmrvotlw608k701rwnatgd7rq`
+
+## Problem
+
+The live customer-to-owner journey for the Restaurant archetype does not form a
+clear, traceable handoff for a non-technical owner (audit 2026-07-22):
+
+1. **Public booking form is ambiguous.** The slot flow at
+   `/s/[slug]/book/[itemId]` (`apps/web/components/storefront/SlotBookingFlow.tsx`)
+   reuses the archetype's *inquiry* `formSchema`, which for food-hospitality carries
+   `date`, `time`, `covers`, and `dietaryRequirements`. Those `date`/`time` fields
+   render as **editable inputs after a slot was already selected**, making the
+   chosen date/time ambiguous; `covers`/dietary are captured only as free-text lines
+   prepended to `notes`. Most controls also lacked label/`for` associations.
+2. **Owner inbox is not traceable.** `/storefront/inbox` showed a booking as a bare
+   ref + date, with repeated bare `Confirm`/`Cancel` buttons — no item/table, party
+   size, dietary, or next action, and no row-specific accessible action text.
+3. **Workspace buries reservations.** `/workspace/inbox` is dominated by generic
+   coworker (enterprise-architecture) decision cards; a reservation needing the
+   owner's confirmation is not surfaced as customer-facing work.
+
+## Design grounding
+
+- **Source of truth (attention):** `docs/superpowers/specs/2026-06-23-human-attention-surface-design.md`
+  (§4.1 sources, §4.4 triage, the OUTSIDE-IN cockpit). This change **extends** that
+  spec with one new source; it does not alter its contracts.
+- **Substrate reuse:** the reservation lives in `StorefrontBooking` (single source of
+  truth); the attention item is a read-model projection (no parallel persisted
+  record), exactly like the existing sources. No new primitive — a new `AttentionSource`
+  value plus a source adapter, mirroring `sources/business-approvals.ts`.
+- **Portfolio:** reservations are customer-facing revenue, so they classify under
+  `products-and-services-sold` (outside-in depth 0), which is why they surface ahead
+  of and separately from `for-employees` coworker cards without a fabricated score.
+
+## Changes (all under `apps/web/` + `packages/db/`)
+
+1. **Structured booking context.** `StorefrontBooking` gains `covers Int?` and
+   `dietaryNotes String?` (migration `20260722060000_storefront_booking_covers_dietary`).
+   `submitBooking` persists them (main + recurrence children).
+2. **Shared pure vocabulary.** `apps/web/lib/storefront/booking-summary.ts` — field
+   classification (drop slot-derived date/time, map covers/dietary to structured
+   roles), `parseCovers`, `formatReservationWhen` (storefront-tz), `nextActionForReservation`,
+   and `reservationActionLabel` ("Confirm Jane Smith, Table for 2 at 6:30 PM"). Backs
+   the form, the inbox, and the attention source so the copy never drifts.
+3. **Booking form.** `SlotBookingFlow` drops the slot-derived fields, captures
+   covers/dietary as structured facts, adds a "Your reservation" summary as the single
+   source of truth for date/time (with a "go back to change the slot" hint), and
+   associates every control with a `label htmlFor`/`id`.
+4. **Owner inbox.** `/storefront/inbox` resolves the booked item name and renders a
+   traceable reservation summary (item/table · when · covers · dietary · next action);
+   `Confirm`/`Cancel` carry row-specific `aria-label`s.
+5. **Workspace reservation exceptions.** New `reservation-exception` attention source
+   (`apps/web/lib/attention/sources/reservation-exception.ts`) projects `pending` /
+   `needs-reschedule` / overlap-quarantined bookings, classified `products-and-services-sold`
+   and hard-floored to `needs-you-now` so a waiting guest is never batched into a digest.
+
+## Tests (smoke — no destructive/external actions)
+
+- `lib/storefront/booking-summary.test.ts` — field partitioning, covers parsing,
+  tz-aware time, next action, and the accessible action label.
+- `lib/attention/sources/reservation-exception.test.ts` — the public booking intake
+  state → attention item mapping (title/context/blast-radius/portfolio/routing), the
+  overlap-quarantine escalation, and that a reservation lands in `needs-you-now`
+  *separately from and ahead of* a generic coworker decision card.
+
+All projection/mapping logic is pure and read-only; the smoke tests exercise intake
+state → inbox/workspace summary without submitting or mutating anything.
+
+## Verification notes
+
+Source-only worktree: the two new suites (13 tests) pass under vitest via a root
+node_modules junction; the touched pure attention suites (59 tests) stay green; a
+Prisma client regenerated from the amended schema typechecks the new columns clean.
+Full `next build` typecheck runs in CI (the required Typecheck / Prod Build gates).

--- a/docs/user-guide/storefront/inbox-and-enquiries.md
+++ b/docs/user-guide/storefront/inbox-and-enquiries.md
@@ -15,8 +15,25 @@ order: 2
 2. Confirm whether the message belongs in sales follow-up, fulfilment, or support.
 3. Respond or route it without losing the customer context.
 
+## Reservations
+
+Booking entries carry the full reservation at a glance, so you can act without
+opening anything else:
+
+- the guest, the item or table booked, the date and time, the party size, and any
+  dietary notes the guest gave;
+- a **Next** line that states the one action the reservation needs (for example
+  "Confirm or decline this reservation");
+- **Confirm** and **Cancel** buttons that name the specific booking — a screen
+  reader announces them as, for example, "Confirm Jane Smith, Table for 2 at 6:30 PM".
+
+Urgent reservations that still need you (a booking waiting to be confirmed, one that
+needs a new time, or a double-booking to untangle) also appear in your workspace
+"What needs you now" queue, kept separate from your digital team's other decisions.
+
 ## What To Watch
 
 - enquiries that never get converted into owned follow-up work
 - inbox items missing the storefront or offer context they came from
 - operators using inbox as a long-term CRM instead of a response queue
+- bookings left on **Confirm or decline** while the reservation date approaches

--- a/packages/db/prisma/migrations/20260722060000_storefront_booking_covers_dietary/migration.sql
+++ b/packages/db/prisma/migrations/20260722060000_storefront_booking_covers_dietary/migration.sql
@@ -1,0 +1,11 @@
+-- BI-3DA1DFDC: Restaurant booking handoff needs traceable owner-facing context.
+--
+-- Party size (covers) and dietary requirements were previously only captured as
+-- free-text lines prepended to `notes`, so the owner inbox could not show a
+-- structured, traceable reservation summary. Promote them to first-class,
+-- nullable columns. Existing rows keep their notes untouched (backfill is not
+-- attempted — historical free-text is left as-is, new bookings populate these).
+
+ALTER TABLE "StorefrontBooking"
+  ADD COLUMN "covers" INTEGER,
+  ADD COLUMN "dietaryNotes" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -9392,6 +9392,10 @@ model StorefrontBooking {
   customerPhone        String?
   scheduledAt          DateTime
   durationMinutes      Int
+  // Structured reservation context (BI-3DA1DFDC): party size and dietary notes are
+  // first-class facts so the owner handoff is traceable, not buried in `notes`.
+  covers               Int?
+  dietaryNotes         String?
   notes                String?
   status               String              @default("pending")
   providerId           String?

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -11,7 +11,7 @@ apps/web/components/ops/SelfUpgradeClient.tsx	1459
 apps/web/components/platform/AiOperationsMap.tsx	2881
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
-apps/web/components/storefront/SlotBookingFlow.tsx	962
+apps/web/components/storefront/SlotBookingFlow.tsx	988
 apps/web/components/workbooks/Grid.tsx	1358
 apps/web/instrumentation.test.ts	897
 apps/web/instrumentation.ts	1442


### PR DESCRIPTION
## What & why

BI-3DA1DFDC (epic EP-UX-COGLOAD). A live customer-to-owner audit of the Restaurant archetype found the public booking path and owner surfaces do not form a clear, traceable handoff for a non-technical owner. This makes a public booking intent a traceable owner-facing reservation task end to end.

## Acceptance → change

1. **Public booking carries guest, item/table, selected date/time, covers, dietary, status, next action.** `StorefrontBooking` gains structured `covers`/`dietaryNotes` columns (migration); `submitBooking` persists them.
2. **Owner inbox shows row-specific accessible actions.** `/storefront/inbox` resolves the booked item name and renders a reservation summary (item · when · covers · dietary · next action); `Confirm`/`Cancel` carry `aria-label`s like **"Confirm Jane Smith, Table for 2 at 6:30 PM"**.
3. **Workspace surfaces urgent reservation exceptions separately.** New `reservation-exception` attention source projects `pending` / `needs-reschedule` / overlap-quarantined bookings, classified `products-and-services-sold` and hard-floored to `needs-you-now` — so a waiting guest surfaces ahead of and separately from generic coworker (EA) decision cards.
4. **Booking form preserves slot context, no date/time ambiguity.** `SlotBookingFlow` drops the archetype inquiry schema's `date`/`time` fields (they re-rendered as blank editable inputs after a slot was picked), captures covers/dietary as structured facts, adds a read-only "Your reservation" summary, and associates every control with a `label htmlFor`/`id`.
5. **Smoke tests** cover public intake state → inbox/workspace summary with no destructive/external actions.

A shared pure module `apps/web/lib/storefront/booking-summary.ts` backs the form, inbox, and attention source so the handoff copy never drifts.

## Design grounding

Source of truth: `docs/superpowers/specs/2026-06-23-human-attention-surface-design.md` (§4.1 sources, §4.4 triage, OUTSIDE-IN cockpit). This **extends** that spec with one new `AttentionSource`, mirroring `sources/business-approvals.ts`; the reservation stays canonical in `StorefrontBooking` (read-model projection, no parallel record). No new primitive, no contract change. Plan: `docs/superpowers/plans/2026-07-22-restaurant-booking-handoff.md`. Files touched under `apps/web/` and `packages/db/`.

## ⚠️ Overlap with #3383

[#3383](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3383) (`fix/restaurant-booking-slot-fields`, open) fixes the *same* SlotBookingFlow date/time duplicate under a different BI, via its own `slot-booking-fields.ts`, but **without** the structured columns, inbox traceability, or workspace source. This PR is the BI-3DA1DFDC superset. They conflict only on the `FormStep` field filter — whichever lands second should rebase that one hunk (my `booking-summary.ts` classification supersedes `slot-booking-fields.ts`, which can then be retired). #3383 also adds calendar-day accessible names, which are complementary and worth keeping.

## Tests

- `lib/storefront/booking-summary.test.ts` — field partitioning (drops slot-derived date/time, keeps covers/dietary), covers parsing, tz-aware time, next action, accessible action label.
- `lib/attention/sources/reservation-exception.test.ts` — intake state → attention item mapping, overlap-quarantine escalation, and that a reservation lands in `needs-you-now` separately from and ahead of a coworker decision card.

## Verification

Source-only worktree: 72 vitest specs green (2 new + touched attention suites); changed files typecheck clean via direct `tsc` against a regenerated Prisma client. Pre-commit `next typegen` typecheck skipped (no `next` binary in worktree, `DPF_SKIP_TYPECHECK=1`); CI Typecheck / Prod Build gate the merge.

Design-Grounding-Decision: extend — grounded in the attention spec at `docs/superpowers/specs/`; new source + booking columns under `apps/web/` and `packages/db/`; no contract change.
UX-Fit-Decision: reduces cognitive load — auto-derives item/when/covers/next action into a plain owner summary and row-specific labels; the form drops ambiguous controls rather than adding any.
Process-Spine-Decision: plan at `docs/superpowers/plans/2026-07-22-restaurant-booking-handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
