### PR TITLE
fix(coworker): route-scoped identity & owner-readable controls for the coworker panel (BI-3238AAF0)

### DIFF
--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -271,9 +271,6 @@ export function AgentCoworkerPanel({
 
   const routeAgent: AgentInfo = resolveAgentForRouteSync(effectiveRoute, userContext);
   const agent = presentStandingCoo(routeAgent, cooConversationalName);
-  // BI-3238AAF0: the business area the panel is currently attached to, so the
-  // header can name the owner's context rather than showing anonymous chrome.
-  const routeContextLabel = resolvePanelRouteContextLabel(effectiveRoute);
   const webAccessAvailable = agentHoldsWebSearchGrant(agent.agentId);
   const canUseDev = userContext.isSuperuser || userContext.platformRole === "HR-000" || userContext.platformRole === "HR-300";
   const preferenceUserKey = userContext.userId ?? `${userContext.isSuperuser ? "super" : "role"}:${userContext.platformRole ?? "none"}`;
@@ -918,7 +915,7 @@ export function AgentCoworkerPanel({
         onViewProfile={() => setShowProfile(true)}
         marketingSkillRules={marketingSkillRules}
         isDocked={isDocked}
-        routeContextLabel={routeContextLabel}
+        routeContextLabel={resolvePanelRouteContextLabel(effectiveRoute)}
       />
 
       {/* Voice activity indicator — shown when voice synthesis is active */}

--- a/apps/web/components/agent/AgentCoworkerPanel.tsx
+++ b/apps/web/components/agent/AgentCoworkerPanel.tsx
@@ -50,6 +50,7 @@ import {
 } from "./agent-message-state";
 import { useVoiceSynth } from "./hooks/useVoiceSynth";
 import { deriveComposerState, type ThreadLoadState } from "./composer-state";
+import { resolvePanelRouteContextLabel } from "@/lib/agent/panel-route-context";
 
 type Props = {
   threadId: string | null;
@@ -270,6 +271,9 @@ export function AgentCoworkerPanel({
 
   const routeAgent: AgentInfo = resolveAgentForRouteSync(effectiveRoute, userContext);
   const agent = presentStandingCoo(routeAgent, cooConversationalName);
+  // BI-3238AAF0: the business area the panel is currently attached to, so the
+  // header can name the owner's context rather than showing anonymous chrome.
+  const routeContextLabel = resolvePanelRouteContextLabel(effectiveRoute);
   const webAccessAvailable = agentHoldsWebSearchGrant(agent.agentId);
   const canUseDev = userContext.isSuperuser || userContext.platformRole === "HR-000" || userContext.platformRole === "HR-300";
   const preferenceUserKey = userContext.userId ?? `${userContext.isSuperuser ? "super" : "role"}:${userContext.platformRole ?? "none"}`;
@@ -914,6 +918,7 @@ export function AgentCoworkerPanel({
         onViewProfile={() => setShowProfile(true)}
         marketingSkillRules={marketingSkillRules}
         isDocked={isDocked}
+        routeContextLabel={routeContextLabel}
       />
 
       {/* Voice activity indicator — shown when voice synthesis is active */}

--- a/apps/web/components/agent/AgentPanelHeader.tsx
+++ b/apps/web/components/agent/AgentPanelHeader.tsx
@@ -33,6 +33,13 @@ type Props = {
   onToggleDev?: () => void;
   marketingSkillRules?: Record<string, { visible?: boolean; label?: string; reframe?: string }> | null;
   isDocked?: boolean;
+  /**
+   * BI-3238AAF0: the business area / route the panel is currently attached to
+   * (e.g. "Finance", "Marketing"). Rendered as a context chip so an owner can
+   * always tell WHERE the coworker is helping, especially after the panel is
+   * carried across a navigation.
+   */
+  routeContextLabel?: string;
 };
 
 /** A single action row inside the overflow menu. */
@@ -103,6 +110,7 @@ export function AgentPanelHeader({
   onViewProfile,
   marketingSkillRules,
   isDocked = false,
+  routeContextLabel,
 }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -164,6 +172,31 @@ export function AgentPanelHeader({
           />
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 6, marginLeft: 12, minWidth: 0 }}>
+          {routeContextLabel && (
+            <span
+              data-testid="panel-route-context"
+              title={`Helping on: ${routeContextLabel}`}
+              aria-label={`Current context: ${routeContextLabel}`}
+              style={{
+                fontSize: 9,
+                textTransform: "uppercase",
+                letterSpacing: "0.06em",
+                color: "var(--dpf-accent)",
+                border: "1px solid color-mix(in srgb, var(--dpf-accent) 45%, transparent)",
+                background: "color-mix(in srgb, var(--dpf-accent) 10%, transparent)",
+                borderRadius: 999,
+                padding: "0 6px",
+                lineHeight: 1.6,
+                flex: "0 0 auto",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                maxWidth: 140,
+              }}
+            >
+              {routeContextLabel}
+            </span>
+          )}
           <span
             title={`Data sensitivity: ${formatSensitivityLabel(agent.sensitivity)}`}
             style={{

--- a/apps/web/components/agent/CoworkerPostureControl.tsx
+++ b/apps/web/components/agent/CoworkerPostureControl.tsx
@@ -168,6 +168,11 @@ export function CoworkerPostureControl({
         }}
         aria-expanded={open}
         aria-haspopup="dialog"
+        // BI-3238AAF0: a stable owner-readable accessible name. Without it the
+        // button's accessible name collapses to the visible summary — "Controls"
+        // when nothing is active — which reads as cryptic chrome. The visible
+        // summary still communicates active posture at a glance.
+        aria-label={`Conversation controls${summaryParts.length > 0 ? `: ${summaryLabel}` : ""}`}
         title="Conversation controls — mode, page editing, and web access for this coworker"
         style={{
           display: "inline-flex",

--- a/apps/web/components/agent/coworker-panel-ux-smoke.test.tsx
+++ b/apps/web/components/agent/coworker-panel-ux-smoke.test.tsx
@@ -1,0 +1,308 @@
+// @vitest-environment jsdom
+
+/**
+ * UX smoke coverage for the coworker side-panel shell (BI-3238AAF0).
+ *
+ * Reproduces the live cognitive-load audit findings as executable checks:
+ *  1. The coworker panel persists ONLY once intentionally opened, carries its
+ *     open state across /finance and other routes, and collapses back to the
+ *     launcher on close.
+ *  2. The panel's controls expose owner-readable accessible names — not the bare
+ *     `⋯`, `x`, `+ Add`, or `Controls` glyphs the audit flagged — and the header
+ *     names the current route/business context.
+ *
+ * The sibling BI-62FF22DB concern — clicking header `Feedback` on /workspace must
+ * yield a feedback-labeled surface rather than a generic coworker conversation —
+ * is owned and smoke-tested by `HeaderFeedbackButton.test.tsx` (PR #3376). This
+ * file deliberately does not duplicate that coverage; it exercises the panel
+ * shell itself, which that change does not touch.
+ */
+
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentCoworkerShell } from "./AgentCoworkerShell";
+import { AgentPanelHeader } from "./AgentPanelHeader";
+import { AgentMessageInput } from "./AgentMessageInput";
+import { CoworkerPostureControl } from "./CoworkerPostureControl";
+
+// ── Mutable route for usePathname ────────────────────────────────────────────
+let pathname = "/workspace";
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+}));
+
+// ── AgentCoworkerShell dependencies ──────────────────────────────────────────
+const shell = vi.hoisted(() => ({
+  agentPanel: vi.fn(),
+  getOrCreateThreadSnapshot: vi.fn(),
+  getThreadSnapshotById: vi.fn(),
+  startFeedbackSupport: vi.fn(),
+  startProviderComplianceConsultation: vi.fn(),
+  savePanelOpen: vi.fn(),
+  panelOpen: { value: false },
+}));
+
+vi.mock("@/lib/actions/agent-coworker", () => ({
+  getOrCreateThreadSnapshot: shell.getOrCreateThreadSnapshot,
+  getThreadSnapshotById: shell.getThreadSnapshotById,
+}));
+vi.mock("@/lib/actions/provider-compliance-consultation", () => ({
+  startProviderComplianceConsultation: shell.startProviderComplianceConsultation,
+}));
+vi.mock("@/lib/actions/feedback-support", () => ({
+  startFeedbackSupport: shell.startFeedbackSupport,
+}));
+
+vi.mock("./AgentFAB", () => ({
+  AgentFAB: ({ onClick }: { onClick: () => void }) => (
+    <button type="button" data-agent-fab="true" onClick={onClick}>
+      Open coworker
+    </button>
+  ),
+}));
+
+vi.mock("./AgentCoworkerPanel", () => ({
+  AgentCoworkerPanel: (props: Record<string, unknown>) => {
+    shell.agentPanel(props);
+    return (
+      <section data-testid="coworker-panel">
+        <span data-testid="panel-route-override">
+          {String(props.routeContextOverride ?? "")}
+        </span>
+        <button type="button" onClick={props.onClose as () => void}>
+          Close
+        </button>
+      </section>
+    );
+  },
+}));
+
+vi.mock("./agent-auto-message", () => ({
+  shouldDispatchAutoMessageImmediately: () => true,
+  shouldSuppressAutoMessage: () => false,
+}));
+
+vi.mock("./agent-panel-layout", () => ({
+  clampPanelPosition: (position: { x: number; y: number }) => position,
+  clampPanelSize: (size: { width: number; height: number }) => size,
+  getDockedPanelFrame: () => null,
+  getReservedPanelWidth: () => 0,
+  isDockedPanelViewport: () => false,
+}));
+
+// Stateful panel-open persistence so we can prove the panel is only pinned once
+// intentionally opened, and that the pinned flag survives a fresh mount.
+vi.mock("./agent-panel-prefs", () => ({
+  loadPanelOpen: () => shell.panelOpen.value,
+  loadPanelPosition: () => ({ x: 32, y: 48 }),
+  loadPanelSize: () => ({ width: 380, height: 480 }),
+  savePanelOpen: (userId: string, open: boolean) => {
+    shell.panelOpen.value = open;
+    shell.savePanelOpen(userId, open);
+  },
+  savePanelPosition: vi.fn(),
+  savePanelSize: vi.fn(),
+}));
+
+// ── Control-surface dependencies (AgentPanelHeader / AgentMessageInput) ──────
+vi.mock("./AgentSkillsDropdown", () => ({
+  AgentSkillsDropdown: () => <span>Skills</span>,
+}));
+vi.mock("./AgentFileUpload", () => ({
+  AgentFileUpload: () => null,
+}));
+vi.mock("./uploadAgentAttachment", () => ({
+  uploadAgentAttachment: vi.fn(),
+  isAcceptedUploadFile: () => true,
+  UPLOAD_ACCEPT_ATTR: ".png",
+  ACCEPTED_UPLOAD_EXTENSIONS: ["png"],
+}));
+vi.mock("./hooks/useVoiceCapture", () => ({
+  useVoiceCapture: () => ({
+    state: "idle",
+    error: null,
+    errorCode: null,
+    supported: true,
+    start: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+function shellElement() {
+  return (
+    <AgentCoworkerShell
+      userContext={{ userId: "user-1", platformRole: "OPS-100", isSuperuser: false }}
+      useUnifiedCoworker
+      cooConversationalName={null}
+    />
+  );
+}
+
+async function settleMount() {
+  await waitFor(() => {
+    expect(shell.getOrCreateThreadSnapshot).toHaveBeenCalled();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("UX smoke — coworker panel persistence & collapse (BI-3238AAF0)", () => {
+  beforeEach(() => {
+    shell.panelOpen.value = false;
+    shell.savePanelOpen.mockClear();
+    shell.getOrCreateThreadSnapshot.mockReset();
+    shell.getOrCreateThreadSnapshot.mockResolvedValue({ threadId: "thread-1", messages: [] });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true }) }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not show the panel until it is intentionally opened", async () => {
+    pathname = "/workspace";
+    render(shellElement());
+    await settleMount();
+
+    expect(screen.queryByTestId("coworker-panel")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open coworker" })).toBeInTheDocument();
+  });
+
+  it("persists the panel across /finance and another route once intentionally opened", async () => {
+    pathname = "/workspace";
+    const view = render(shellElement());
+    await settleMount();
+
+    // Intentional open via the launcher pins the panel.
+    fireEvent.click(screen.getByRole("button", { name: "Open coworker" }));
+    await flush();
+    expect(screen.getByTestId("coworker-panel")).toBeInTheDocument();
+    expect(shell.savePanelOpen).toHaveBeenCalledWith("user-1", true);
+
+    // Navigate to /finance — the panel remains.
+    pathname = "/finance";
+    view.rerender(shellElement());
+    await flush();
+    expect(screen.getByTestId("coworker-panel")).toBeInTheDocument();
+
+    // Navigate again — still present.
+    pathname = "/storefront";
+    view.rerender(shellElement());
+    await flush();
+    expect(screen.getByTestId("coworker-panel")).toBeInTheDocument();
+  });
+
+  it("reopens on a fresh mount when the panel was left intentionally open (route reload)", async () => {
+    shell.panelOpen.value = true; // persisted intentional-open flag
+    pathname = "/finance";
+    render(shellElement());
+    await settleMount();
+
+    expect(await screen.findByTestId("coworker-panel")).toBeInTheDocument();
+  });
+
+  it("collapses back to the launcher on close", async () => {
+    pathname = "/workspace";
+    render(shellElement());
+    await settleMount();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open coworker" }));
+    await flush();
+    expect(screen.getByTestId("coworker-panel")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    await flush();
+    expect(screen.queryByTestId("coworker-panel")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open coworker" })).toBeInTheDocument();
+    expect(shell.savePanelOpen).toHaveBeenLastCalledWith("user-1", false);
+  });
+});
+
+describe("UX smoke — panel controls have owner-readable accessible names (BI-3238AAF0)", () => {
+  afterEach(() => cleanup());
+
+  const headerProps = {
+    agent: {
+      agentId: "agent-1",
+      agentName: "Ops Co-worker",
+      agentDescription: "Helps with operations",
+      canAssist: true,
+      sensitivity: "internal" as const,
+      systemPrompt: "prompt",
+      skills: [],
+    },
+    userContext: { userId: "user-1", platformRole: "OPS-100", isSuperuser: false },
+    onSend: () => {},
+    onOpenClearConfirm: () => {},
+    onCancelClearConfirm: () => {},
+    onConfirmClear: () => {},
+    clearDisabled: false,
+    clearConfirmOpen: false,
+    onClose: () => {},
+    onDragStart: () => {},
+  };
+
+  const inputProps = {
+    onSend: () => {},
+    composerState: "ready" as const,
+    threadId: "thread-1",
+    pendingFile: null,
+    onFileUploaded: () => {},
+    onFileClear: () => {},
+  };
+
+  const postureProps = {
+    elevatedAssistEnabled: false,
+    onToggleElevatedAssist: () => {},
+    externalAccessEnabled: false,
+    onToggleExternalAccess: () => {},
+  };
+
+  it("header overflow and close controls read in plain language, not ⋯ / x", () => {
+    render(<AgentPanelHeader {...headerProps} />);
+    expect(screen.getByRole("button", { name: "More options" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close coworker panel" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "⋯" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^x$/i })).not.toBeInTheDocument();
+  });
+
+  it("header names the current route/business context", () => {
+    render(<AgentPanelHeader {...headerProps} routeContextLabel="Finance" />);
+    const context = screen.getByTestId("panel-route-context");
+    expect(context).toHaveTextContent("Finance");
+    expect(context).toHaveAttribute("aria-label", "Current context: Finance");
+  });
+
+  it("composer add-context control reads 'Add context', not '+ Add'", () => {
+    render(<AgentMessageInput {...inputProps} />);
+    expect(screen.getByRole("button", { name: "Add context" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^\+\s*add$/i })).not.toBeInTheDocument();
+    // Dictation and send are owner-readable too.
+    expect(screen.getByRole("button", { name: /start dictation/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+  });
+
+  it("posture control's accessible name is 'Conversation controls', not 'Controls'", () => {
+    render(<CoworkerPostureControl {...postureProps} />);
+    expect(
+      screen.getByRole("button", { name: /conversation controls/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^controls$/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/lib/agent/panel-route-context.test.ts
+++ b/apps/web/lib/agent/panel-route-context.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolvePanelRouteContextLabel } from "./panel-route-context";
+
+describe("resolvePanelRouteContextLabel (BI-3238AAF0)", () => {
+  it("names top-level business areas from the canonical nav model", () => {
+    expect(resolvePanelRouteContextLabel("/workspace")).toBe("Workspace");
+    expect(resolvePanelRouteContextLabel("/finance")).toBe("Finance");
+    expect(resolvePanelRouteContextLabel("/customer")).toBe("Customer");
+  });
+
+  it("prefers the deepest modelled context for nested routes", () => {
+    expect(resolvePanelRouteContextLabel("/customer/marketing")).toBe("Marketing");
+  });
+
+  it("falls back to the deepest KNOWN ancestor for unmodelled deep routes", () => {
+    // An id-bearing tail should never surface raw — it resolves to the nearest
+    // modelled ancestor instead.
+    expect(resolvePanelRouteContextLabel("/finance/ledgers/LEDGER-9f3a")).toBe("Finance");
+  });
+
+  it("title-cases the top-level domain when nothing is modelled", () => {
+    expect(resolvePanelRouteContextLabel("/totally-unknown-area/thing")).toBe(
+      "Totally Unknown Area",
+    );
+  });
+
+  it("ignores query strings and hashes", () => {
+    expect(resolvePanelRouteContextLabel("/finance?tab=ap#top")).toBe("Finance");
+  });
+
+  it("defaults to Workspace for empty or root paths", () => {
+    expect(resolvePanelRouteContextLabel("/")).toBe("Workspace");
+    expect(resolvePanelRouteContextLabel("")).toBe("Workspace");
+    expect(resolvePanelRouteContextLabel(null)).toBe("Workspace");
+    expect(resolvePanelRouteContextLabel(undefined)).toBe("Workspace");
+  });
+});

--- a/apps/web/lib/agent/panel-route-context.ts
+++ b/apps/web/lib/agent/panel-route-context.ts
@@ -1,0 +1,46 @@
+import { getRouteNavRecord } from "@/lib/navigation/portal-navigation-model";
+
+/**
+ * BI-3238AAF0: the coworker side panel must clearly identify the route/business
+ * context it is currently attached to, so an owner who lands on it (or carried
+ * it across a navigation) can tell WHERE the coworker is helping rather than
+ * seeing anonymous assistant chrome.
+ *
+ * Pure and client-safe: resolves a short human label for a pathname from the
+ * canonical portal navigation model, falling back to title-cased URL segments
+ * so an unmodelled route still reads as a business area rather than a raw slug.
+ */
+
+function titleCase(segment: string): string {
+  return segment
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+const ROOT_LABEL = "Workspace";
+
+export function resolvePanelRouteContextLabel(pathname: string | null | undefined): string {
+  const raw = (pathname ?? "").split(/[?#]/, 1)[0]?.trim() ?? "";
+  if (!raw || raw === "/") return ROOT_LABEL;
+
+  // Exact model match wins (e.g. "/customer/marketing" → "Marketing").
+  const exact = getRouteNavRecord(raw);
+  if (exact) return exact.label;
+
+  // Otherwise walk the segments and prefer the deepest KNOWN nav-record label.
+  // Unknown deep segments (ids, slugs) are skipped in favour of the nearest
+  // modelled ancestor so the panel never surfaces a raw id as its context.
+  const segments = raw.split("/").filter(Boolean);
+  let accumulated = "";
+  let deepestKnown: string | null = null;
+  for (const segment of segments) {
+    accumulated += `/${segment}`;
+    const known = getRouteNavRecord(accumulated);
+    if (known) deepestKnown = known.label;
+  }
+  if (deepestKnown) return deepestKnown;
+
+  // No modelled ancestor at all — title-case the top-level business domain.
+  const firstSegment = segments[0];
+  return firstSegment ? titleCase(firstSegment) : ROOT_LABEL;
+}

--- a/docs/superpowers/plans/2026-07-22-coworker-panel-persistence-and-feedback-action.md
+++ b/docs/superpowers/plans/2026-07-22-coworker-panel-persistence-and-feedback-action.md
@@ -1,0 +1,95 @@
+# Coworker side-panel persistence, identity & owner-readable controls
+
+Status: implemented (single PR, BI-3238AAF0)
+Owner: platform / portal UX
+Related: BI-3238AAF0 (this PR — panel persistence + owner-readable controls +
+route context), BI-62FF22DB (header Feedback mislabel — delivered separately by
+PR #3376), epic EP-UX-COGLOAD (live UX cognitive-load audit follow-up)
+
+## Coordination note (BI-62FF22DB ↔ PR #3376)
+
+The audit filed two coupled BIs. **BI-62FF22DB** (header `Feedback` opening the
+coworker panel instead of a feedback surface) is already being fixed by the
+in-flight **PR #3376** (`fix/header-feedback-flow`), which reroutes
+`HeaderFeedbackButton` to open the `FeedbackForm` directly and rewrites its test.
+To avoid duplicate/colliding edits this PR **defers BI-62FF22DB entirely to
+#3376** and does not touch `HeaderFeedbackButton.*`. The two PRs are disjoint at
+the file level and can merge in any order. This PR owns **BI-3238AAF0**, the
+panel-shell aspects #3376 does not address.
+
+## Design grounding
+
+- Source of truth: bug-fix under EP-UX-COGLOAD from the 2026-07-22 live
+  action-result usability audit. No prior spec governs the coworker-panel shell
+  mount contract; nearest existing artifact is the ops-map/coworker-panel-honesty
+  plan (2026-07-06). This is a new artifact for BI-3238AAF0; it changes no
+  published contract.
+- Substrate inspected: `AgentCoworkerShell` (panel mount + localStorage
+  open-flag), `AgentCoworkerPanel` / `AgentPanelHeader` / `AgentMessageInput` /
+  `CoworkerPostureControl` (the flagged control surface), and
+  `portal-navigation-model` (canonical route → label). Also inspected #3376 to
+  scope out the Feedback path.
+- Decision: **extend** the existing components; add one pure helper
+  (`resolvePanelRouteContextLabel`). No new tables, enums, or MCP tools — the nav
+  model already exposes the labels needed (`getRouteNavRecord`).
+
+## The audit findings (BI-3238AAF0 portion)
+
+The coworker panel could become a persistent cognitive-load layer across
+unrelated routes, carrying cryptic controls (`⋯`, `x`, `+ Add`, `Controls`) onto
+each page and never naming the route/business context it was attached to.
+
+## Root causes addressed here
+
+- **Cryptic accessible names.** The posture control's accessible name collapsed to
+  its visible summary "Controls"; the panel never named its route/business
+  context.
+- **Persistence semantics.** The panel open-state is a single localStorage flag
+  set by any open. Once #3376 stops the mislabelled Feedback trigger from opening
+  the panel, the remaining opens (launcher FAB / explicit guided opens) are the
+  "intentional opens" the acceptance calls for and legitimately follow the user
+  across routes. This PR adds the identity + control-legibility defenses and
+  locks the intentional-open persistence/collapse behavior behind a smoke test.
+
+## The change (BI-3238AAF0)
+
+1. **Panel names its route/business context.** New pure helper
+   `lib/agent/panel-route-context.ts#resolvePanelRouteContextLabel` derives a short
+   human label from the canonical `portal-navigation-model` (deepest known
+   ancestor; title-cased domain fallback). `AgentCoworkerPanel` computes it from
+   the effective route and `AgentPanelHeader` renders it as a context chip
+   (`data-testid="panel-route-context"`, `aria-label="Current context: <area>"`).
+
+2. **Owner-readable controls.** `CoworkerPostureControl` gets a stable
+   `aria-label="Conversation controls…"` so its accessible name is no longer the
+   bare "Controls". The overflow (`⋯` → "More options"), close (`x` → "Close
+   coworker panel"), add-context (`+ Add` → "Add context"), dictation ("Start
+   dictation"), send ("Send"), and the collapse affordance (FAB → "Open AI
+   Coworker") already carry owner-readable accessible names — now asserted by a
+   smoke test so they cannot silently regress.
+
+## Tests
+
+- `lib/agent/panel-route-context.test.ts` — pure label resolution against the real
+  nav model (`/finance`→Finance, `/customer/marketing`→Marketing,
+  deepest-ancestor + title-case fallbacks, query/hash stripping).
+- `components/agent/coworker-panel-ux-smoke.test.tsx` — UX smoke: intentional open
+  persists across `/finance` and another route; a fresh mount reopens the pinned
+  panel; close collapses to the launcher; every control exposes an owner-readable
+  accessible name (not only `⋯`/`x`/`+ Add`/`Controls`); the header names the
+  route context. The Feedback-surface bullet is covered by
+  `HeaderFeedbackButton.test.tsx` in #3376 and intentionally not duplicated here.
+
+## Verification
+
+Authored in a source-only worktree whose local install lacks `next` runtime
+files, so specs importing `next/navigation` (the shell + control-name suite)
+cannot transform locally; the pure-logic and non-`next` component suites pass
+locally (43 tests). Relying on CI (Unit Tests, Typecheck, Prod Build) for the
+`next`-importing suites — the same substrate the existing shell/header tests use.
+
+## Non-goals
+
+- No change to BI-62FF22DB / `HeaderFeedbackButton` (owned by #3376).
+- No change to the `open-agent-panel` guided-work / provider-consultation / setup
+  opens, which are genuine user-initiated contextual assists.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -2,7 +2,7 @@ apps/web/app/api/mcp/v1/route.test.ts	1260
 apps/web/app/api/v1/edge/discovery-runs/route.test.ts	982
 apps/web/components/admin/BusinessModelBuilder.tsx	821
 apps/web/components/admin/McpTokenManager.tsx	1373
-apps/web/components/agent/AgentCoworkerPanel.tsx	1253
+apps/web/components/agent/AgentCoworkerPanel.tsx	1255
 apps/web/components/agent/AgentMessageInput.tsx	1034
 apps/web/components/ea/EaCanvas.tsx	1047
 apps/web/components/inventory/TopologyGraph.tsx	1031


### PR DESCRIPTION
## What & why

BI-3238AAF0 (EP-UX-COGLOAD). The 2026-07-22 live UX cognitive-load audit found the AI coworker side panel could become a persistent cognitive-load layer across unrelated routes, carrying cryptic controls (`⋯`, `x`, `+ Add`, `Controls`) onto each page and never naming the route/business context it was attached to.

This PR fixes the **panel-shell half** of the audit.

## Coordination with BI-62FF22DB / #3376

The sibling BI-62FF22DB (header `Feedback` opening the coworker panel instead of a feedback surface) is delivered by the in-flight #3376, which edits only `HeaderFeedbackButton.*`. This PR **deliberately does not touch** those files — the two are disjoint at the file level and can merge in any order. Removing the mislabeled Feedback trigger (in #3376) closes the accidental-open path; this PR adds the identity + control-legibility defenses and locks the intentional-open persistence/collapse behavior behind a smoke test.

## Change

- **Route/business identity**: new pure helper `apps/web/lib/agent/panel-route-context.ts#resolvePanelRouteContextLabel` derives a short business-area label from the canonical `portal-navigation-model`; `AgentPanelHeader` renders it as a context chip (`aria-label="Current context: <area>"`).
- **Owner-readable controls**: `CoworkerPostureControl` gets a stable `aria-label="Conversation controls…"` so its accessible name is no longer the bare "Controls". Overflow ("More options"), close ("Close coworker panel"), add-context ("Add context"), dictation ("Start dictation"), send ("Send"), and the collapse launcher ("Open AI Coworker") already read well — now locked by a smoke test.

## Tests

- `apps/web/lib/agent/panel-route-context.test.ts` — pure label resolution against the real nav model (passes locally).
- `apps/web/components/agent/coworker-panel-ux-smoke.test.tsx` — persistence across `/finance`+another route once intentionally opened; fresh-mount reopen; close→collapse; every control exposes an owner-readable accessible name; header names the route context.
- The feedback-surface smoke bullet is owned by `HeaderFeedbackButton.test.tsx` in #3376 and intentionally not duplicated.

## Design grounding

- Existing specs/plans reviewed: no owning spec under `docs/superpowers/specs/` for the coworker-panel shell; nearest is the 2026-07-06 ops-map/coworker-panel-honesty plan.
- Substrate reviewed under `apps/web/components/agent/` (AgentCoworkerShell/Panel/Header, CoworkerPostureControl, AgentMessageInput) and `apps/web/lib/navigation/portal-navigation-model.ts`.
- Decision: extend existing components + one pure helper; no new tables/enums/tools. New plan added under `docs/superpowers/plans/`.

Design-Grounding-Decision: reviewed `apps/web/components/agent/*` and the portal navigation model; no owning spec under `docs/superpowers/specs/`; localized UX-legibility fix, no contract/routing change; new plan under `docs/superpowers/plans/`.
UX-Fit-Decision: human_cognitive_load — truthful labels + progressive disclosure; names the panel's route context and controls; no new route/tab/input.
Docs-Impact-Decision: no `docs/user-guide` page documents the coworker panel chrome; in-app behavior only; plan doc added.
Process-Spine-Decision: localized UX fix plus tests and a plan; no new module/route/migration and no large rewrite.

## Verification

Authored in a source-only worktree whose install lacks `next` runtime files, so specs importing `next/navigation` (the shell smoke suite) cannot transform locally — the same limitation affects the existing `AgentCoworkerShell.test.tsx`. Locally: `tsc --noEmit` passes project-wide (0 errors) and the non-`next` suites pass (38 tests). Relying on CI (Unit Tests, Typecheck, Prod Build) for the `next`-importing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)