### PR TITLE
feat(storefront): task-first setup status + generated-content recovery (BI-C39DC90C)

### DIFF
--- a/apps/web/app/(shell)/storefront/page.tsx
+++ b/apps/web/app/(shell)/storefront/page.tsx
@@ -1,11 +1,20 @@
 import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { StorefrontDashboard } from "@/components/storefront-admin/StorefrontDashboard";
+import { StorefrontSetupPanel } from "@/components/storefront-admin/StorefrontSetupPanel";
 import { ServiceLinesPanel } from "@/components/storefront-admin/ServiceLinesPanel";
 import { getVocabulary } from "@/lib/storefront/archetype-vocabulary";
 import { resolveVocabularyKey } from "@/lib/storefront/resolve-vocabulary";
-import { loadCompositionViewData } from "@/lib/storefront/service-line-actions";
+import {
+  loadCompositionViewData,
+  loadRemovedServiceLines,
+} from "@/lib/storefront/service-line-actions";
 import { deriveStorefrontCompositionView } from "@/lib/storefront/composition-view";
+import {
+  deriveStorefrontSetupModel,
+  resolveSetupCapabilities,
+  type GeneratedContentGroupInput,
+} from "@/lib/storefront/setup-model";
 
 function getSetupSteps(portalLabel: string, stakeholderLabel: string) {
   return [
@@ -43,8 +52,13 @@ export default async function StorefrontPage() {
       id: true,
       isPublished: true,
       tagline: true,
+      heroImageUrl: true,
+      contactEmail: true,
+      contactPhone: true,
       organization: { select: { slug: true, name: true } },
-      archetype: { select: { archetypeId: true, ctaType: true } },
+      archetype: {
+        select: { archetypeId: true, category: true, ctaType: true, customVocabulary: true },
+      },
     },
   });
 
@@ -54,16 +68,30 @@ export default async function StorefrontPage() {
       bookingCount,
       orderCount,
       donationCount,
-      compositionData,
-      allArchetypes,
-      visibleSectionCount,
       activeItemCount,
+      visibleSectionCount,
+      resourceCount,
+      businessProfile,
+      compositionData,
+      removedLines,
+      allArchetypes,
     ] = await Promise.all([
       prisma.storefrontInquiry.count({ where: { storefrontId: config.id } }),
       prisma.storefrontBooking.count({ where: { storefrontId: config.id } }),
       prisma.storefrontOrder.count({ where: { storefrontId: config.id } }),
       prisma.storefrontDonation.count({ where: { storefrontId: config.id } }),
+      // Count only live artifacts so add/remove of a service line is honestly
+      // reflected on the dashboard — removing a line hides its items/sections and
+      // the counts drop back (BI-7D7EE150).
+      prisma.storefrontItem.count({ where: { storefrontId: config.id, isActive: true } }),
+      prisma.storefrontSection.count({ where: { storefrontId: config.id, isVisible: true } }),
+      prisma.serviceProvider.count({ where: { storefrontId: config.id } }),
+      prisma.businessProfile.findFirst({
+        where: { isActive: true },
+        select: { hoursConfirmedAt: true },
+      }),
       loadCompositionViewData(config.id),
+      loadRemovedServiceLines(config.id),
       prisma.storefrontArchetype.findMany({
         select: {
           archetypeId: true,
@@ -74,22 +102,79 @@ export default async function StorefrontPage() {
         },
         orderBy: { name: "asc" },
       }),
-      // Count only live artifacts so add/remove of a service line is honestly
-      // reflected on the dashboard — removing a line hides its items/sections and
-      // the counts drop back (BI-7D7EE150: undo must restore the visible state).
-      prisma.storefrontSection.count({
-        where: { storefrontId: config.id, isVisible: true },
-      }),
-      prisma.storefrontItem.count({
-        where: { storefrontId: config.id, isActive: true },
-      }),
     ]);
 
+    const primaryCategory = config.archetype?.category ?? null;
+    const vocabulary = getVocabulary(
+      primaryCategory,
+      config.archetype?.customVocabulary as Record<string, string> | null,
+    );
+    const capabilities = resolveSetupCapabilities(
+      primaryCategory,
+      compositionData?.primary.activationProfile?.modules ?? [],
+    );
+
+    // Generated-content groups, keyed by the composition that produced them.
+    const primaryGroup: GeneratedContentGroupInput = {
+      compositionId: compositionData?.primary.compositionId ?? "primary",
+      name: compositionData?.primary.name ?? config.organization.name,
+      category: primaryCategory ?? "",
+      role: "primary",
+      itemsGenerated: activeItemCount,
+      sectionsGenerated: visibleSectionCount,
+    };
+    const secondaryGroups: GeneratedContentGroupInput[] = (compositionData?.secondaries ?? []).map(
+      (s) => {
+        const counts = compositionData?.seededCountsByCompositionId[s.compositionId] ?? { items: 0, sections: 0 };
+        return {
+          compositionId: s.compositionId,
+          name: s.name,
+          category: s.category,
+          role: "secondary" as const,
+          itemsGenerated: counts.items,
+          sectionsGenerated: counts.sections,
+          crossCategory: s.category !== primaryCategory,
+        };
+      },
+    );
+    const retainedGroups: GeneratedContentGroupInput[] = removedLines.map((r) => ({
+      compositionId: r.compositionId,
+      name: r.name,
+      category: r.category,
+      role: "secondary" as const,
+      itemsGenerated: r.retainedItems,
+      sectionsGenerated: r.retainedSections,
+      crossCategory: r.category !== primaryCategory,
+      retained: true,
+    }));
+
+    const model = deriveStorefrontSetupModel({
+      vocabulary,
+      capabilities,
+      config: {
+        isPublished: config.isPublished,
+        hasTagline: Boolean(config.tagline),
+        hasHeroImage: Boolean(config.heroImageUrl),
+        hasContact: Boolean(config.contactEmail || config.contactPhone),
+      },
+      content: { activeItemCount, visibleSectionCount },
+      resources: { count: resourceCount },
+      availability: { operatingHoursConfigured: Boolean(businessProfile?.hoursConfirmedAt) },
+      serviceLines: {
+        primary: primaryGroup,
+        secondaries: secondaryGroups,
+        retainedSecondaries: retainedGroups,
+      },
+    });
+
+    const activeLines = model.inventory.filter((g) => g.role === "secondary" && g.state === "active");
+    const retainedLines = model.inventory.filter((g) => g.state === "retained");
+
+    // Active service lines (add/remove) are owned by ServiceLinesPanel, kept
+    // as-is so BI-7D7EE150's confirm/preview/undo flow is not duplicated here.
     const compositionView = compositionData
       ? deriveStorefrontCompositionView(compositionData)
       : null;
-
-    // Archetypes not already active in the composition
     const activeSlugSet = new Set([
       compositionData?.primary.archetypeSlug,
       ...(compositionData?.secondaries.map((s) => s.archetypeSlug) ?? []),
@@ -121,6 +206,16 @@ export default async function StorefrontPage() {
             itemCount: activeItemCount,
           }}
           counts={{ inquiries: inquiryCount, bookings: bookingCount, orders: orderCount, donations: donationCount }}
+        />
+        {/* Task-first setup status + generated-content inventory + recovery of
+            removed lines (BI-C39DC90C). Add/remove of active lines stays in
+            ServiceLinesPanel below. */}
+        <StorefrontSetupPanel
+          storefrontId={config.id}
+          steps={model.steps}
+          summary={{ completeCount: model.summary.completeCount, totalCount: model.summary.totalCount }}
+          activeLines={activeLines}
+          retainedLines={retainedLines}
         />
         {compositionView && (
           <ServiceLinesPanel

--- a/apps/web/components/storefront-admin/StorefrontSetupPanel.tsx
+++ b/apps/web/components/storefront-admin/StorefrontSetupPanel.tsx
@@ -1,0 +1,463 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  removeStorefrontServiceLine,
+  restoreStorefrontServiceLine,
+  purgeRemovedServiceLine,
+} from "@/lib/storefront/service-line-actions";
+import { intentStyle } from "@/components/ui/report-kit/statusColors";
+import type { SetupTask, GeneratedContentGroup } from "@/lib/storefront/setup-model";
+
+interface Props {
+  storefrontId: string;
+  steps: SetupTask[];
+  summary: { completeCount: number; totalCount: number };
+  /** Active secondary lines — shown read-only; add/remove lives in ServiceLinesPanel. */
+  activeLines: GeneratedContentGroup[];
+  /** Removed-but-retained lines — the recovery surface (restore / purge). */
+  retainedLines: GeneratedContentGroup[];
+}
+
+const STATUS_INTENT = {
+  complete: "success",
+  attention: "warning",
+  "not-started": "neutral",
+} as const;
+
+const STATUS_LABEL = {
+  complete: "Done",
+  attention: "Needs attention",
+  "not-started": "Not started",
+} as const;
+
+type Feedback = { tone: "success" | "error"; message: string; undo?: () => void } | null;
+
+export function StorefrontSetupPanel({ storefrontId, steps, summary, activeLines, retainedLines }: Props) {
+  const router = useRouter();
+  const [recoveryOpen, setRecoveryOpen] = useState(false);
+
+  const advancedCount = activeLines.length + retainedLines.length;
+  const generatedTotals = [...activeLines, ...retainedLines].reduce(
+    (acc, g) => ({ items: acc.items + g.itemsGenerated, sections: acc.sections + g.sectionsGenerated }),
+    { items: 0, sections: 0 },
+  );
+
+  return (
+    <div style={{ marginTop: 24, display: "flex", flexDirection: "column", gap: 24 }}>
+      {/* ── Task-first setup steps ─────────────────────────────────────────── */}
+      <section className="border border-[var(--dpf-border)]" style={{ borderRadius: 10, overflow: "hidden" }}>
+        <header
+          className="border-b border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+          style={{ padding: "14px 20px", display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12 }}
+        >
+          <div className="text-[var(--dpf-text)]" style={{ fontSize: 14, fontWeight: 700 }}>
+            Set up your storefront
+          </div>
+          <div className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>
+            {summary.completeCount} of {summary.totalCount} steps done
+          </div>
+        </header>
+        <ol style={{ listStyle: "none", margin: 0, padding: 0 }}>
+          {steps.map((step) => (
+            <StepRow key={step.key} step={step} />
+          ))}
+        </ol>
+      </section>
+
+      {/* ── Generated content inventory + recovery — hidden until opened ────── */}
+      {advancedCount > 0 && (
+        <section className="border border-[var(--dpf-border)]" style={{ borderRadius: 10, overflow: "hidden" }}>
+          <button
+            onClick={() => setRecoveryOpen((v) => !v)}
+            aria-expanded={recoveryOpen}
+            className="bg-[var(--dpf-surface-1)] text-[var(--dpf-text)]"
+            style={{
+              width: "100%",
+              border: "none",
+              padding: "14px 20px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 12,
+              cursor: "pointer",
+              font: "inherit",
+              textAlign: "left",
+            }}
+          >
+            <span>
+              <span style={{ fontSize: 14, fontWeight: 700 }}>Generated content &amp; recovery</span>
+              <span className="text-[var(--dpf-muted)]" style={{ display: "block", fontSize: 12, marginTop: 2 }}>
+                {activeLines.length} active service line{activeLines.length !== 1 ? "s" : ""}
+                {retainedLines.length > 0 ? ` · ${retainedLines.length} removed (retained)` : ""} ·{" "}
+                {generatedTotals.items} items · {generatedTotals.sections} sections auto-created.
+              </span>
+            </span>
+            <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12, whiteSpace: "nowrap" }}>
+              {recoveryOpen ? "Hide ▲" : "Open ▼"}
+            </span>
+          </button>
+
+          {recoveryOpen && (
+            <GeneratedContentRecovery
+              storefrontId={storefrontId}
+              activeLines={activeLines}
+              retainedLines={retainedLines}
+              onChanged={() => router.refresh()}
+            />
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+function StepRow({ step }: { step: SetupTask }) {
+  const style = intentStyle(STATUS_INTENT[step.status]);
+  return (
+    <li
+      className="border-b border-[var(--dpf-border)]"
+      style={{ display: "flex", gap: 14, alignItems: "flex-start", padding: "14px 20px" }}
+    >
+      <span
+        aria-hidden
+        style={{ marginTop: 4, width: 10, height: 10, borderRadius: "50%", background: style.fg, flexShrink: 0 }}
+      />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <a href={step.href} className="text-[var(--dpf-text)]" style={{ fontSize: 14, fontWeight: 600, textDecoration: "none" }}>
+            {step.title}
+          </a>
+          <span
+            style={{
+              fontSize: 10,
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.04em",
+              padding: "2px 6px",
+              borderRadius: 4,
+              background: style.softBg,
+              color: style.fg,
+              border: `1px solid ${style.border}`,
+            }}
+          >
+            {STATUS_LABEL[step.status]}
+          </span>
+        </div>
+        <div className="text-[var(--dpf-muted)]" style={{ fontSize: 12, marginTop: 3, lineHeight: 1.5 }}>
+          {step.description}
+        </div>
+        {step.hint && (
+          <a href={step.href} className="text-[var(--dpf-accent)]" style={{ fontSize: 12, marginTop: 4, display: "inline-block", textDecoration: "none" }}>
+            {step.hint} →
+          </a>
+        )}
+      </div>
+    </li>
+  );
+}
+
+// ── Recovery: restore / purge removed lines, each with preview + feedback ─────
+
+interface ConfirmState {
+  kind: "restore" | "purge";
+  title: string;
+  affected: { items: number; sections: number };
+  note: string;
+  destructive: boolean;
+  run: () => Promise<void>;
+}
+
+function useUndoableRemove(storefrontId: string, onChanged: () => void, setFeedback: (f: Feedback) => void) {
+  const [, startTransition] = useTransition();
+  return (compositionId: string, name: string) =>
+    startTransition(async () => {
+      const r = await removeStorefrontServiceLine(storefrontId, compositionId);
+      if ("error" in r) setFeedback({ tone: "error", message: r.error });
+      else setFeedback({ tone: "success", message: `Removed “${name}” again — its content is retained.` });
+      onChanged();
+    });
+}
+
+function GeneratedContentRecovery({
+  storefrontId,
+  activeLines,
+  retainedLines,
+  onChanged,
+}: {
+  storefrontId: string;
+  activeLines: GeneratedContentGroup[];
+  retainedLines: GeneratedContentGroup[];
+  onChanged: () => void;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [confirm, setConfirm] = useState<ConfirmState | null>(null);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const reRemove = useUndoableRemove(storefrontId, onChanged, setFeedback);
+
+  function execute() {
+    if (!confirm) return;
+    const c = confirm;
+    startTransition(async () => {
+      try {
+        await c.run();
+      } finally {
+        setConfirm(null);
+        onChanged();
+      }
+    });
+  }
+
+  function prepareRestore(line: GeneratedContentGroup) {
+    setFeedback(null);
+    setConfirm({
+      kind: "restore",
+      title: `Restore “${line.name}”`,
+      affected: { items: line.itemsGenerated, sections: line.sectionsGenerated },
+      note: "Reactivates the retained items. Sections stay hidden until you reveal them. You can remove it again afterwards.",
+      destructive: false,
+      run: async () => {
+        const res = await restoreStorefrontServiceLine(storefrontId, line.compositionId);
+        if ("error" in res) setFeedback({ tone: "error", message: res.error });
+        else
+          setFeedback({
+            tone: "success",
+            message: `Restored “${line.name}” — ${res.affected.items} items reactivated.`,
+            undo: () => reRemove(line.compositionId, line.name),
+          });
+      },
+    });
+  }
+
+  function preparePurge(line: GeneratedContentGroup) {
+    setFeedback(null);
+    setConfirm({
+      kind: "purge",
+      title: `Permanently remove “${line.name}”`,
+      affected: { items: line.itemsGenerated, sections: line.sectionsGenerated },
+      note: "Deletes the retained items and sections for good. This cannot be undone.",
+      destructive: true,
+      run: async () => {
+        const res = await purgeRemovedServiceLine(storefrontId, line.compositionId);
+        if ("error" in res) setFeedback({ tone: "error", message: res.error });
+        else
+          setFeedback({
+            tone: "success",
+            message: `Permanently removed “${line.name}” (${res.affected.items} items, ${res.affected.sections} sections deleted).`,
+          });
+      },
+    });
+  }
+
+  return (
+    <div className="border-t border-[var(--dpf-border)]" style={{ padding: "16px 20px", display: "flex", flexDirection: "column", gap: 16 }}>
+      {feedback && (
+        <div
+          role="status"
+          style={{
+            fontSize: 12,
+            padding: "8px 12px",
+            borderRadius: 6,
+            border: `1px solid ${feedback.tone === "success" ? "var(--dpf-success)" : "var(--dpf-error)"}`,
+            background: `color-mix(in srgb, ${feedback.tone === "success" ? "var(--dpf-success)" : "var(--dpf-error)"} 10%, transparent)`,
+            color: "var(--dpf-text)",
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            flexWrap: "wrap",
+          }}
+        >
+          <span>{feedback.message}</span>
+          {feedback.undo && (
+            <button
+              onClick={feedback.undo}
+              disabled={isPending}
+              className="text-[var(--dpf-accent)]"
+              style={{ background: "none", border: "none", cursor: "pointer", fontSize: 12, fontWeight: 700, textDecoration: "underline" }}
+            >
+              Undo
+            </button>
+          )}
+        </div>
+      )}
+
+      {activeLines.length > 0 && (
+        <div>
+          <div className="text-[var(--dpf-muted)]" style={{ fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 8 }}>
+            Active
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {activeLines.map((line) => (
+              <LineRow
+                key={line.compositionId}
+                line={line}
+                badge={line.crossCategory ? { label: "Other industry", intent: "warning" } : null}
+                actions={[]}
+              />
+            ))}
+          </div>
+          <div className="text-[var(--dpf-muted)]" style={{ fontSize: 11, marginTop: 6 }}>
+            Add or remove active lines in the Service lines panel below.
+          </div>
+        </div>
+      )}
+
+      {retainedLines.length > 0 && (
+        <div>
+          <div className="text-[var(--dpf-muted)]" style={{ fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 8 }}>
+            Removed — content retained
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {retainedLines.map((line) => (
+              <LineRow
+                key={line.compositionId}
+                line={line}
+                badge={{ label: "Retained", intent: "neutral" }}
+                actions={[
+                  { label: "Restore", accessibleLabel: `Restore ${line.name} line`, intent: "accent", onClick: () => prepareRestore(line), disabled: isPending },
+                  { label: "Remove permanently", accessibleLabel: `Permanently remove ${line.name} line`, intent: "danger", onClick: () => preparePurge(line), disabled: isPending },
+                ]}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {confirm && <ConfirmPanel confirm={confirm} isPending={isPending} onCancel={() => setConfirm(null)} onConfirm={execute} />}
+    </div>
+  );
+}
+
+function ConfirmPanel({
+  confirm,
+  isPending,
+  onCancel,
+  onConfirm,
+}: {
+  confirm: ConfirmState;
+  isPending: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const accent = confirm.destructive ? "var(--dpf-error)" : "var(--dpf-accent)";
+  return (
+    <div
+      role="dialog"
+      aria-label={confirm.title}
+      className="border"
+      style={{
+        borderColor: accent,
+        borderRadius: 8,
+        padding: "14px 16px",
+        background: `color-mix(in srgb, ${accent} 8%, transparent)`,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      <div className="text-[var(--dpf-text)]" style={{ fontSize: 14, fontWeight: 700 }}>{confirm.title}</div>
+      <div className="text-[var(--dpf-text)]" style={{ fontSize: 12 }}>
+        Affects <strong>{confirm.affected.items}</strong> item{confirm.affected.items !== 1 ? "s" : ""} and{" "}
+        <strong>{confirm.affected.sections}</strong> section{confirm.affected.sections !== 1 ? "s" : ""}.
+      </div>
+      <div className="text-[var(--dpf-muted)]" style={{ fontSize: 12, lineHeight: 1.5 }}>{confirm.note}</div>
+      <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+        <button
+          onClick={onConfirm}
+          disabled={isPending}
+          className="text-white"
+          style={{ background: accent, padding: "7px 16px", borderRadius: 6, border: "none", fontSize: 13, fontWeight: 600, cursor: isPending ? "wait" : "pointer" }}
+        >
+          {isPending ? "Working…" : confirm.destructive ? "Delete permanently" : "Confirm"}
+        </button>
+        <button
+          onClick={onCancel}
+          disabled={isPending}
+          className="border border-[var(--dpf-border)] text-[var(--dpf-text)]"
+          style={{ background: "transparent", padding: "7px 16px", borderRadius: 6, fontSize: 13, fontWeight: 600, cursor: "pointer" }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function LineRow({
+  line,
+  badge,
+  actions,
+}: {
+  line: GeneratedContentGroup;
+  badge: { label: string; intent: "warning" | "neutral" | "accent" } | null;
+  actions: { label: string; accessibleLabel: string; intent: "danger" | "accent"; onClick: () => void; disabled: boolean }[];
+}) {
+  return (
+    <div
+      className="border border-[var(--dpf-border)]"
+      style={{ borderRadius: 8, padding: "10px 14px", display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}
+    >
+      <div style={{ flex: 1, minWidth: 160 }}>
+        <div className="text-[var(--dpf-text)]" style={{ fontSize: 13, fontWeight: 600, display: "flex", alignItems: "center", gap: 8 }}>
+          {line.name}
+          {badge && <Badge label={badge.label} intent={badge.intent} />}
+        </div>
+        <div className="text-[var(--dpf-muted)]" style={{ fontSize: 12, marginTop: 2 }}>
+          {line.itemsGenerated} items · {line.sectionsGenerated} sections
+        </div>
+      </div>
+      {actions.length > 0 && (
+        <div style={{ display: "flex", gap: 6, flexShrink: 0 }}>
+          {actions.map((a) => {
+            const style = intentStyle(a.intent);
+            return (
+              <button
+                key={a.label}
+                onClick={a.onClick}
+                disabled={a.disabled}
+                aria-label={a.accessibleLabel}
+                className="border"
+                style={{
+                  borderColor: style.border,
+                  color: style.fg,
+                  background: "transparent",
+                  padding: "5px 12px",
+                  borderRadius: 5,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: a.disabled ? "not-allowed" : "pointer",
+                  opacity: a.disabled ? 0.5 : 1,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {a.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Badge({ label, intent }: { label: string; intent: "warning" | "neutral" | "accent" }) {
+  const style = intentStyle(intent);
+  return (
+    <span
+      style={{
+        fontSize: 10,
+        fontWeight: 700,
+        textTransform: "uppercase",
+        letterSpacing: "0.04em",
+        padding: "1px 6px",
+        borderRadius: 4,
+        background: style.softBg,
+        color: style.fg,
+        border: `1px solid ${style.border}`,
+      }}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/web/lib/storefront/service-line-actions.ts
+++ b/apps/web/lib/storefront/service-line-actions.ts
@@ -10,6 +10,22 @@ const MAX_SECONDARY_LINES = 2;
 
 type ActionResult = { success: true } | { error: string };
 
+/** Result of a mutating service-line action that retains or removes artifacts. */
+type ArtifactActionResult =
+  | { success: true; affected: { items: number; sections: number } }
+  | { error: string };
+
+/** A removed-but-retained service line whose generated content still exists. */
+export interface RetainedServiceLine {
+  compositionId: string;
+  archetypeSlug: string;
+  name: string;
+  category: string;
+  removedAt: Date;
+  retainedItems: number;
+  retainedSections: number;
+}
+
 async function requireAdmin(): Promise<{ organizationId: string } | { error: string }> {
   const session = await auth();
   if (!session?.user || (session.user as { type?: string }).type !== "admin") {
@@ -213,6 +229,132 @@ export async function removeStorefrontServiceLine(
 
   revalidatePath("/storefront");
   return { success: true };
+}
+
+/**
+ * Undo a service-line removal: reactivate the retained composition and its
+ * seeded items. Sections stay hidden (as when first seeded) so the operator
+ * chooses what to reveal. The inverse of removeStorefrontServiceLine.
+ */
+export async function restoreStorefrontServiceLine(
+  storefrontId: string,
+  compositionId: string,
+): Promise<ArtifactActionResult> {
+  const auth = await requireAdmin();
+  if ("error" in auth) return auth;
+
+  const composition = await prisma.storefrontArchetypeComposition.findFirst({
+    where: {
+      id: compositionId,
+      storefrontId,
+      storefront: { organizationId: auth.organizationId },
+      removedAt: { not: null },
+    },
+    select: { id: true, role: true },
+  });
+  if (!composition) return { error: "Removed service line not found" };
+  if (composition.role === "primary") return { error: "Primary service line cannot be restored" };
+
+  // Guard the max-active limit: a restore re-activates a line, so it must not
+  // exceed the same ceiling the add path enforces.
+  const activeSecondaries = await prisma.storefrontArchetypeComposition.count({
+    where: { storefrontId, role: "secondary", removedAt: null },
+  });
+  if (activeSecondaries >= MAX_SECONDARY_LINES) {
+    return { error: `Maximum ${MAX_SECONDARY_LINES} active service lines — remove one before restoring.` };
+  }
+
+  const [itemUpdate, sectionCount] = await Promise.all([
+    prisma.storefrontItem.updateMany({
+      where: { sourceCompositionId: compositionId },
+      data: { isActive: true },
+    }),
+    prisma.storefrontSection.count({ where: { sourceCompositionId: compositionId } }),
+    prisma.storefrontArchetypeComposition.update({
+      where: { id: compositionId },
+      data: { removedAt: null, updatedAt: new Date() },
+    }),
+  ]);
+
+  revalidatePath("/storefront");
+  return { success: true, affected: { items: itemUpdate.count, sections: sectionCount } };
+}
+
+/**
+ * Permanently remove a retained (already-removed) service line's generated
+ * content — the "explain retained artifacts, then let me purge them" recovery.
+ * Only operates on soft-removed lines so an active line's content is never
+ * deleted out from under the storefront.
+ */
+export async function purgeRemovedServiceLine(
+  storefrontId: string,
+  compositionId: string,
+): Promise<ArtifactActionResult> {
+  const auth = await requireAdmin();
+  if ("error" in auth) return auth;
+
+  const composition = await prisma.storefrontArchetypeComposition.findFirst({
+    where: {
+      id: compositionId,
+      storefrontId,
+      storefront: { organizationId: auth.organizationId },
+      removedAt: { not: null },
+    },
+    select: { id: true, role: true },
+  });
+  if (!composition) return { error: "Removed service line not found" };
+  if (composition.role === "primary") return { error: "Primary service line cannot be purged" };
+
+  const seededItems = await prisma.storefrontItem.findMany({
+    where: { sourceCompositionId: compositionId },
+    select: { id: true },
+  });
+  const seededItemIds = seededItems.map((i) => i.id);
+
+  const sectionCount = await prisma.storefrontSection.count({
+    where: { sourceCompositionId: compositionId },
+  });
+
+  await prisma.$transaction(async (tx) => {
+    if (seededItemIds.length > 0) {
+      // Clear dependents that FK to the items before deleting them.
+      await tx.providerService.deleteMany({ where: { itemId: { in: seededItemIds } } });
+      await tx.bookingHold.deleteMany({ where: { itemId: { in: seededItemIds } } });
+      await tx.storefrontItem.deleteMany({ where: { id: { in: seededItemIds } } });
+    }
+    await tx.storefrontSection.deleteMany({ where: { sourceCompositionId: compositionId } });
+    await tx.storefrontArchetypeComposition.delete({ where: { id: compositionId } });
+  });
+
+  revalidatePath("/storefront");
+  return { success: true, affected: { items: seededItemIds.length, sections: sectionCount } };
+}
+
+/**
+ * List removed-but-retained service lines with the generated content still on
+ * disk, so the recovery UI can offer restore-or-purge for each.
+ */
+export async function loadRemovedServiceLines(
+  storefrontId: string,
+): Promise<RetainedServiceLine[]> {
+  const rows = await prisma.storefrontArchetypeComposition.findMany({
+    where: { storefrontId, role: "secondary", removedAt: { not: null } },
+    orderBy: [{ removedAt: "desc" }],
+    include: {
+      archetype: { select: { archetypeId: true, name: true, category: true } },
+      _count: { select: { seededItems: true, seededSections: true } },
+    },
+  });
+
+  return rows.map((row) => ({
+    compositionId: row.id,
+    archetypeSlug: row.archetype.archetypeId,
+    name: row.archetype.name,
+    category: row.archetype.category,
+    removedAt: row.removedAt as Date,
+    retainedItems: row._count.seededItems,
+    retainedSections: row._count.seededSections,
+  }));
 }
 
 /**

--- a/apps/web/lib/storefront/setup-model.test.ts
+++ b/apps/web/lib/storefront/setup-model.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveStorefrontSetupModel,
+  resolveSetupCapabilities,
+  auditSetupSurface,
+  type SetupModelInput,
+} from "./setup-model";
+
+const RESTAURANT_VOCAB = {
+  itemsLabel: "Menu",
+  singleItemLabel: "Item",
+  portalLabel: "Venue Portal",
+  stakeholderLabel: "Guests",
+  teamLabel: "Staff",
+  inboxLabel: "Reservations",
+};
+
+function restaurantInput(over: Partial<SetupModelInput> = {}): SetupModelInput {
+  return {
+    vocabulary: RESTAURANT_VOCAB,
+    capabilities: resolveSetupCapabilities("food-hospitality"),
+    config: { isPublished: false, hasTagline: true, hasHeroImage: true, hasContact: true },
+    content: { activeItemCount: 12, visibleSectionCount: 4 },
+    resources: { count: 6 },
+    availability: { operatingHoursConfigured: true },
+    serviceLines: {
+      primary: {
+        compositionId: "c-primary",
+        name: "Restaurant",
+        category: "food-hospitality",
+        role: "primary",
+        itemsGenerated: 12,
+        sectionsGenerated: 4,
+      },
+      secondaries: [],
+      retainedSecondaries: [],
+    },
+    ...over,
+  };
+}
+
+describe("resolveSetupCapabilities", () => {
+  it("gives a restaurant Tables + hours + inbox", () => {
+    const cap = resolveSetupCapabilities("food-hospitality");
+    expect(cap.supportsResources).toBe(true);
+    expect(cap.resourceLabel).toBe("Tables");
+    expect(cap.supportsHours).toBe(true);
+    expect(cap.supportsInbox).toBe(true);
+  });
+
+  it("omits resources/hours for a non-booking retailer", () => {
+    const cap = resolveSetupCapabilities("retail-goods");
+    expect(cap.supportsResources).toBe(false);
+    expect(cap.supportsHours).toBe(false);
+    expect(cap.supportsInbox).toBe(true);
+  });
+});
+
+describe("deriveStorefrontSetupModel", () => {
+  it("produces restaurant-labeled task-first steps", () => {
+    const model = deriveStorefrontSetupModel(restaurantInput());
+    const keys = model.steps.map((s) => s.key);
+    expect(keys).toEqual(["brand", "items", "resources", "hours", "inbox"]);
+    const titles = model.steps.map((s) => s.title);
+    expect(titles.some((t) => t.includes("Menu"))).toBe(true);
+    expect(titles.some((t) => t.includes("Tables"))).toBe(true);
+    expect(model.steps.find((s) => s.key === "inbox")?.title).toBe("Reservations");
+  });
+
+  it("marks steps complete/attention/not-started from real data", () => {
+    const model = deriveStorefrontSetupModel(
+      restaurantInput({
+        config: { isPublished: false, hasTagline: false, hasHeroImage: false, hasContact: false },
+        content: { activeItemCount: 0, visibleSectionCount: 0 },
+        resources: { count: 0 },
+        availability: { operatingHoursConfigured: false },
+      }),
+    );
+    expect(model.steps.find((s) => s.key === "brand")?.status).toBe("attention");
+    expect(model.steps.find((s) => s.key === "items")?.status).toBe("not-started");
+    expect(model.steps.find((s) => s.key === "hours")?.status).toBe("attention");
+    expect(model.summary.completeCount).toBe(0);
+  });
+
+  it("drops resources/hours steps for a non-booking archetype", () => {
+    const model = deriveStorefrontSetupModel(
+      restaurantInput({ capabilities: resolveSetupCapabilities("retail-goods") }),
+    );
+    const keys = model.steps.map((s) => s.key);
+    expect(keys).not.toContain("resources");
+    expect(keys).not.toContain("hours");
+  });
+
+  it("keeps advanced service lines hidden and counts them", () => {
+    const model = deriveStorefrontSetupModel(
+      restaurantInput({
+        serviceLines: {
+          primary: {
+            compositionId: "c-primary",
+            name: "Restaurant",
+            category: "food-hospitality",
+            role: "primary",
+            itemsGenerated: 12,
+            sectionsGenerated: 4,
+          },
+          secondaries: [
+            {
+              compositionId: "c-1",
+              name: "Coffee Shop",
+              category: "food-hospitality",
+              role: "secondary",
+              itemsGenerated: 5,
+              sectionsGenerated: 2,
+            },
+          ],
+          retainedSecondaries: [
+            {
+              compositionId: "c-2",
+              name: "Auto Repair",
+              category: "automotive-services",
+              role: "secondary",
+              itemsGenerated: 8,
+              sectionsGenerated: 3,
+              crossCategory: true,
+            },
+          ],
+        },
+      }),
+    );
+    expect(model.advanced.hidden).toBe(true);
+    expect(model.advanced.activeServiceLineCount).toBe(1);
+    expect(model.advanced.retainedServiceLineCount).toBe(1);
+    expect(model.advanced.hasCrossCategory).toBe(true);
+  });
+
+  it("inventories generated content with recovery per group", () => {
+    const model = deriveStorefrontSetupModel(
+      restaurantInput({
+        serviceLines: {
+          primary: {
+            compositionId: "c-primary",
+            name: "Restaurant",
+            category: "food-hospitality",
+            role: "primary",
+            itemsGenerated: 12,
+            sectionsGenerated: 4,
+          },
+          secondaries: [
+            {
+              compositionId: "c-1",
+              name: "Coffee Shop",
+              category: "food-hospitality",
+              role: "secondary",
+              itemsGenerated: 5,
+              sectionsGenerated: 2,
+            },
+          ],
+          retainedSecondaries: [
+            {
+              compositionId: "c-2",
+              name: "Auto Repair",
+              category: "automotive-services",
+              role: "secondary",
+              itemsGenerated: 8,
+              sectionsGenerated: 3,
+              crossCategory: true,
+            },
+          ],
+        },
+      }),
+    );
+    const primary = model.inventory.find((g) => g.role === "primary")!;
+    expect(primary.state).toBe("core");
+    expect(primary.recoverable).toBe(false);
+    expect(primary.recoveryLabel).toBeNull();
+
+    const active = model.inventory.find((g) => g.compositionId === "c-1")!;
+    expect(active.state).toBe("active");
+    expect(active.recoverable).toBe(true);
+
+    const retained = model.inventory.find((g) => g.compositionId === "c-2")!;
+    expect(retained.state).toBe("retained");
+    expect(retained.recoverable).toBe(true);
+    expect(retained.crossCategory).toBe(true);
+  });
+});
+
+describe("auditSetupSurface — the surface passes its own UX ceilings", () => {
+  it("passes with a lean prose block and a collapsed 100-option add list", () => {
+    const model = deriveStorefrontSetupModel(
+      restaurantInput({
+        serviceLines: {
+          primary: {
+            compositionId: "c-primary",
+            name: "Restaurant",
+            category: "food-hospitality",
+            role: "primary",
+            itemsGenerated: 12,
+            sectionsGenerated: 4,
+          },
+          secondaries: [
+            {
+              compositionId: "c-1",
+              name: "Coffee Shop",
+              category: "food-hospitality",
+              role: "secondary",
+              itemsGenerated: 5,
+              sectionsGenerated: 2,
+            },
+          ],
+          retainedSecondaries: [],
+        },
+      }),
+    );
+    const report = auditSetupSurface(model, {
+      route: "/storefront",
+      prose:
+        "Set up your venue portal. Work through each step, then publish when you are ready. " +
+        "Advanced service lines stay hidden until you open them.",
+      extraActions: [{ label: "Publish" }, { label: "Show advanced service lines" }],
+      availableServiceLineCount: 100,
+    });
+    expect(report.ok).toBe(true);
+    expect(report.violations).toEqual([]);
+  });
+});

--- a/apps/web/lib/storefront/setup-model.ts
+++ b/apps/web/lib/storefront/setup-model.ts
@@ -1,0 +1,333 @@
+// Pure, task-first setup + recovery model for a storefront owner (BI-C39DC90C).
+//
+// The live audit found /storefront dumped 17 competing actions, a 101-option
+// service-line select, and generated "residue" a non-technical owner could not
+// see or undo. This module turns the raw storefront data into:
+//   • a small ordered set of setup TASKS with a plain status each,
+//   • a generated-content INVENTORY grouped by what produced it, and
+//   • an ADVANCED bucket that stays hidden until explicitly opened.
+//
+// No Prisma / React imports — callers load data and pass it in, and both the
+// page and the UX-ceiling tests derive from one shape. The step VOCABULARY is
+// archetype-driven (Menu / Tables / Reservations for a restaurant), so this is
+// not restaurant-hardcoded — it just reads correctly for one.
+
+import {
+  analyzeSetupSurface,
+  type SetupSurfaceDescriptor,
+  type SetupUxReport,
+} from "@dpf/validators";
+
+export type SetupTaskStatus = "complete" | "attention" | "not-started";
+
+export interface SetupTask {
+  key: string;
+  title: string;
+  /** One plain sentence: what this step is for. */
+  description: string;
+  status: SetupTaskStatus;
+  /** Short "what to do next" nudge when not complete. */
+  hint?: string;
+  /** Where the owner goes to work on it. */
+  href: string;
+}
+
+export type GeneratedGroupState = "core" | "active" | "retained";
+
+export interface GeneratedContentGroupInput {
+  compositionId: string;
+  name: string;
+  category: string;
+  role: "primary" | "secondary";
+  itemsGenerated: number;
+  sectionsGenerated: number;
+  /** Retained = removed (soft-deleted) but its items/sections still exist. */
+  retained?: boolean;
+  /** Different category from the primary line — cross-industry expansion. */
+  crossCategory?: boolean;
+}
+
+export interface GeneratedContentGroup {
+  compositionId: string;
+  name: string;
+  role: "primary" | "secondary";
+  state: GeneratedGroupState;
+  itemsGenerated: number;
+  sectionsGenerated: number;
+  crossCategory: boolean;
+  /** The core (primary) line is not removable; secondaries always are. */
+  recoverable: boolean;
+  /** Plain-language recovery action for this group. */
+  recoveryLabel: string | null;
+}
+
+export interface SetupCapabilities {
+  supportsResources: boolean;
+  resourceLabel: string;
+  resourceLabelSingular: string;
+  supportsHours: boolean;
+  supportsInbox: boolean;
+}
+
+export interface SetupModelInput {
+  vocabulary: {
+    itemsLabel: string;
+    singleItemLabel: string;
+    portalLabel: string;
+    stakeholderLabel: string;
+    teamLabel: string;
+    inboxLabel: string;
+  };
+  capabilities: SetupCapabilities;
+  config: {
+    isPublished: boolean;
+    hasTagline: boolean;
+    hasHeroImage: boolean;
+    hasContact: boolean;
+  };
+  content: {
+    activeItemCount: number;
+    visibleSectionCount: number;
+  };
+  resources: { count: number };
+  availability: { operatingHoursConfigured: boolean };
+  serviceLines: {
+    primary: GeneratedContentGroupInput;
+    secondaries: GeneratedContentGroupInput[];
+    /** Removed lines whose generated content is retained (recoverable/purgeable). */
+    retainedSecondaries: GeneratedContentGroupInput[];
+  };
+}
+
+export interface StorefrontSetupModel {
+  steps: SetupTask[];
+  inventory: GeneratedContentGroup[];
+  advanced: {
+    /** Advanced / cross-industry expansion is collapsed until explicitly opened. */
+    hidden: true;
+    activeServiceLineCount: number;
+    retainedServiceLineCount: number;
+    hasCrossCategory: boolean;
+  };
+  summary: {
+    completeCount: number;
+    totalCount: number;
+    published: boolean;
+  };
+}
+
+// ─── Capability resolution (archetype-aware, not restaurant-hardcoded) ────────
+
+const RESOURCE_LABELS: Record<string, { plural: string; singular: string }> = {
+  "food-hospitality": { plural: "Tables", singular: "Table" },
+  "beauty-personal-care": { plural: "Chairs & rooms", singular: "Station" },
+  "healthcare-wellness": { plural: "Rooms", singular: "Room" },
+  "fitness-recreation": { plural: "Spaces", singular: "Space" },
+};
+
+/** Categories where the storefront is booking/availability-shaped. */
+const BOOKING_CATEGORIES = new Set([
+  "food-hospitality",
+  "beauty-personal-care",
+  "healthcare-wellness",
+  "fitness-recreation",
+  "pet-services",
+  "professional-services",
+]);
+
+export function resolveSetupCapabilities(
+  category: string | null | undefined,
+  modules: readonly string[] = [],
+): SetupCapabilities {
+  const cat = category ?? "";
+  const isBooking = BOOKING_CATEGORIES.has(cat) || modules.includes("service-operations");
+  const labels = RESOURCE_LABELS[cat] ?? { plural: "Resources", singular: "Resource" };
+  return {
+    supportsResources: isBooking,
+    resourceLabel: labels.plural,
+    resourceLabelSingular: labels.singular,
+    supportsHours: isBooking,
+    supportsInbox: true,
+  };
+}
+
+// ─── Recovery labels ──────────────────────────────────────────────────────────
+
+function recoveryLabelFor(state: GeneratedGroupState): string | null {
+  switch (state) {
+    case "core":
+      return null; // the primary line is the storefront itself — not removable
+    case "active":
+      return "Remove line (undoable)";
+    case "retained":
+      return "Restore or remove permanently";
+  }
+}
+
+function toGroup(input: GeneratedContentGroupInput): GeneratedContentGroup {
+  const state: GeneratedGroupState =
+    input.role === "primary" ? "core" : input.retained ? "retained" : "active";
+  return {
+    compositionId: input.compositionId,
+    name: input.name,
+    role: input.role,
+    state,
+    itemsGenerated: input.itemsGenerated,
+    sectionsGenerated: input.sectionsGenerated,
+    crossCategory: input.crossCategory ?? false,
+    recoverable: input.role === "secondary",
+    recoveryLabel: recoveryLabelFor(state),
+  };
+}
+
+// ─── Model derivation ─────────────────────────────────────────────────────────
+
+export function deriveStorefrontSetupModel(input: SetupModelInput): StorefrontSetupModel {
+  const { vocabulary: v, capabilities: cap, config, content, resources, availability } = input;
+
+  const steps: SetupTask[] = [];
+
+  // 1 — Brand / public profile
+  steps.push({
+    key: "brand",
+    title: "Brand & public profile",
+    description: `Your name, tagline, hero image, and contact details — what ${v.stakeholderLabel.toLowerCase()} see first.`,
+    status: config.hasTagline && config.hasContact ? "complete" : "attention",
+    hint: config.hasTagline ? undefined : "Add a tagline and contact details.",
+    href: "/storefront/settings/business",
+  });
+
+  // 2 — Menu / items
+  steps.push({
+    key: "items",
+    title: `${v.itemsLabel} & ${v.singleItemLabel.toLowerCase()}s`,
+    description: `The ${v.itemsLabel.toLowerCase()} ${v.stakeholderLabel.toLowerCase()} browse and act on.`,
+    status: content.activeItemCount > 0 ? "complete" : "not-started",
+    hint: content.activeItemCount > 0 ? undefined : `Add your first ${v.singleItemLabel.toLowerCase()}.`,
+    href: "/storefront/items",
+  });
+
+  // 3 — Tables / resources (booking-shaped archetypes only)
+  if (cap.supportsResources) {
+    steps.push({
+      key: "resources",
+      title: `${cap.resourceLabel} & ${v.teamLabel.toLowerCase()}`,
+      description: `The ${cap.resourceLabel.toLowerCase()} and ${v.teamLabel.toLowerCase()} that ${v.inboxLabel.toLowerCase()} are assigned to.`,
+      status: resources.count > 0 ? "complete" : "not-started",
+      hint: resources.count > 0 ? undefined : `Add a ${cap.resourceLabelSingular.toLowerCase()}.`,
+      href: "/storefront/team",
+    });
+  }
+
+  // 4 — Hours / availability (booking-shaped archetypes only)
+  if (cap.supportsHours) {
+    steps.push({
+      key: "hours",
+      title: "Hours & availability",
+      description: `When you are open, so ${v.inboxLabel.toLowerCase()} land on real slots.`,
+      status: availability.operatingHoursConfigured ? "complete" : "attention",
+      hint: availability.operatingHoursConfigured ? undefined : "Set your operating hours.",
+      href: "/storefront/settings/operations",
+    });
+  }
+
+  // 5 — Reservations / inbox
+  if (cap.supportsInbox) {
+    steps.push({
+      key: "inbox",
+      title: v.inboxLabel,
+      description: `Where ${v.stakeholderLabel.toLowerCase()} requests arrive and you respond.`,
+      // The inbox exists as soon as the storefront does; it is "ready", not a
+      // blocking setup gate — surface it as complete once items exist to act on.
+      status: content.activeItemCount > 0 ? "complete" : "not-started",
+      hint: content.activeItemCount > 0 ? undefined : `Add ${v.itemsLabel.toLowerCase()} so ${v.stakeholderLabel.toLowerCase()} can reach you.`,
+      href: "/storefront/inbox",
+    });
+  }
+
+  const completeCount = steps.filter((s) => s.status === "complete").length;
+
+  // ── Generated-content inventory ────────────────────────────────────────────
+  const inventory: GeneratedContentGroup[] = [
+    toGroup(input.serviceLines.primary),
+    ...input.serviceLines.secondaries.map(toGroup),
+    ...input.serviceLines.retainedSecondaries.map((g) => toGroup({ ...g, retained: true })),
+  ];
+
+  const hasCrossCategory = [
+    ...input.serviceLines.secondaries,
+    ...input.serviceLines.retainedSecondaries,
+  ].some((g) => g.crossCategory);
+
+  return {
+    steps,
+    inventory,
+    advanced: {
+      hidden: true,
+      activeServiceLineCount: input.serviceLines.secondaries.length,
+      retainedServiceLineCount: input.serviceLines.retainedSecondaries.length,
+      hasCrossCategory,
+    },
+    summary: {
+      completeCount,
+      totalCount: steps.length,
+      published: config.isPublished,
+    },
+  };
+}
+
+// ─── UX-ceiling surface descriptor ────────────────────────────────────────────
+
+/**
+ * Assemble the descriptor the setup surface presents so a test (or a runtime
+ * audit) can hold it to the SETUP_UX_CEILINGS. `prose` is the visible copy the
+ * component renders; `extraActions` are controls beyond the per-step links and
+ * per-group recovery actions (e.g. Publish, the advanced disclosure toggle).
+ *
+ * Row-level recovery actions get a distinguishing accessible name ("Remove
+ * Coffee Shop line") so they never trip the repeated-terse-label check, and the
+ * advanced service-line option list is declared collapsed-until-opened.
+ */
+export function buildSetupSurfaceDescriptor(
+  model: StorefrontSetupModel,
+  opts: {
+    route: string;
+    prose: string;
+    extraActions?: { label: string; accessibleLabel?: string }[];
+    availableServiceLineCount?: number;
+  },
+): SetupSurfaceDescriptor {
+  const stepActions = model.steps.map((s) => ({ label: s.title }));
+  const recoveryActions = model.inventory
+    .filter((g) => g.recoverable && g.recoveryLabel)
+    .map((g) => ({ label: g.recoveryLabel as string, accessibleLabel: `${g.recoveryLabel} — ${g.name}` }));
+
+  const recoverableGroups = model.inventory.filter((g) => g.role === "secondary");
+
+  return {
+    route: opts.route,
+    text: opts.prose,
+    actions: [...(opts.extraActions ?? []), ...stepActions, ...recoveryActions],
+    optionGroups: opts.availableServiceLineCount
+      ? [
+          {
+            label: "Add advanced service line",
+            optionCount: opts.availableServiceLineCount,
+            collapsedUntilOpened: true,
+          },
+        ]
+      : [],
+    recovery: {
+      generatedGroups: recoverableGroups.length,
+      recoverableGroups: recoverableGroups.filter((g) => g.recoverable).length,
+    },
+  };
+}
+
+/** Convenience: derive the model and immediately check its surface. */
+export function auditSetupSurface(
+  model: StorefrontSetupModel,
+  opts: Parameters<typeof buildSetupSurfaceDescriptor>[1],
+): SetupUxReport {
+  return analyzeSetupSurface(buildSetupSurfaceDescriptor(model, opts));
+}

--- a/docs/superpowers/plans/2026-07-22-storefront-owner-setup-recovery-BI-C39DC90C.md
+++ b/docs/superpowers/plans/2026-07-22-storefront-owner-setup-recovery-BI-C39DC90C.md
@@ -1,0 +1,114 @@
+# Storefront owner: task-first setup + recovery model
+
+- **Backlog item:** BI-C39DC90C — "Storefront owner setup needs task-first status and recovery for generated content"
+- **Epic:** EP-UX-COGLOAD (Live UX cognitive-load audit follow-up)
+- **Surface:** `apps/web/app/(shell)/storefront/` admin routes
+- **Date:** 2026-07-22
+
+## Problem (from the live audit)
+
+A Restaurant owner's `/storefront` admin exposed many setup surfaces with no
+coherent, task-first status, no map of what generated content exists, and no
+safe recovery path:
+
+- `/storefront` ~505 words / 17 actions, cross-industry/generated residue,
+  `Add service line` / `Unpublish` with no preview or recovery language, and a
+  **101-option** service-line `<select>` sitting in the page + accessibility
+  stream.
+- Removing a service line retained items/sections (deactivated/hidden) with no
+  explanation and no undo — the owner could not tell what was kept or get it
+  back.
+
+## Design grounding
+
+- **Source of truth:** the multi-archetype composition model
+  (`2026-06-13-multi-archetype-composition-design.md`,
+  `StorefrontArchetypeComposition` + `sourceCompositionId` provenance on items
+  and sections). This change **extends** that model's UI; it introduces no new
+  table, enum, or provenance concept.
+- **Substrate reused:** `service-line-actions.ts` (add/remove), `composition-view.ts`,
+  `archetype-vocabulary.ts` (restaurant → Menu / Tables / Reservations),
+  `@dpf/validators/readability.ts` (sibling policy pattern for the new UX check),
+  `report-kit/statusColors.ts` (intent tokens).
+- **Decision:** keep all mutating logic in server actions + a pure model so the
+  behaviour is testable without rendering; the client component is a thin shell.
+  Advanced/cross-industry expansion is **collapsed until opened** (progressive
+  disclosure) so the default surface stays inside the cognitive-load ceilings.
+
+## What shipped
+
+1. **`packages/validators/src/setup-ux.ts`** — a pure, shared route-level UX
+   validator (`analyzeSetupSurface`) with ceilings for **word count**, **action
+   count**, **repeated terse labels** (Edit/Del/On/Off/↑/↓ with no
+   distinguishing accessible name), **long inline option exposure** (a long list
+   must be collapsed-until-opened), and **generated-content recovery state**
+   (every generated group must be recoverable). Mirrors `readability.ts`.
+2. **`apps/web/lib/storefront/setup-model.ts`** — pure, archetype-aware
+   derivation of task-first **steps** (brand · menu/items · tables/resources ·
+   hours/availability · reservations/inbox) each with a plain status, a
+   **generated-content inventory** grouped by the composition that produced it,
+   and an **advanced** bucket kept hidden. `auditSetupSurface` holds the model to
+   the ceilings.
+3. **`service-line-actions.ts`** — added (additive only) `restoreStorefrontServiceLine`
+   (undo of a removal), `purgeRemovedServiceLine` (permanent delete of retained
+   artifacts), and `loadRemovedServiceLines`. `removeStorefrontServiceLine` /
+   `addStorefrontServiceLine` are left untouched so PR #3379 (BI-7D7EE150) owns
+   the add/remove confirm/preview/undo flow without collision.
+4. **`StorefrontSetupPanel.tsx`** + `/storefront/page.tsx` wiring — an **additive**
+   panel rendered above the existing `ServiceLinesPanel`: task-first steps with
+   status, plus a **collapsed** "Generated content & recovery" disclosure that
+   lists the generated inventory and offers **restore** / **remove permanently**
+   for removed-but-retained lines — each with a **preview** (affected artifacts),
+   **confirm**, **success/failure feedback**, and **undo** (restore) or an explicit
+   "cannot be undone" warning (purge). `ServiceLinesPanel` keeps ownership of
+   add/remove of active lines (BI-7D7EE150).
+
+### Reconciliation with PR #3379 (BI-7D7EE150)
+
+BI-7D7EE150 is an in-flight PR adding confirm/preview/undo to service-line
+**add/remove**. To avoid a hard collision this PR is deliberately **additive**:
+it does not delete or modify `ServiceLinesPanel`, does not change the
+`add`/`remove` action signatures, and layers the task-first status + the
+recovery-of-removed-lines (restore/purge) that #3379 does not cover. The
+add-line preview + the "hide the cross-industry add control" acceptance points
+are delivered by #3379's flow; the two PRs compose.
+
+## Acceptance mapping
+
+| Acceptance | Where |
+| --- | --- |
+| Group setup into clear steps | `setup-model.ts` `deriveStorefrontSetupModel` |
+| Setup status + generated-content inventory | steps `status`, `inventory` + panel |
+| Hide advanced/cross-industry until opened | collapsed "Generated content & recovery" disclosure (add control preview owned by #3379) |
+| Recovery/undo for sections/items/service lines | `restoreStorefrontServiceLine` / `purgeRemovedServiceLine` / `loadRemovedServiceLines` + recovery UI |
+| Preview, affected artifacts, feedback, complete undo / explain retained | `ConfirmPanel` + restore/purge return shapes (add/remove owned by #3379) |
+| Route-level UX checks | `setup-ux.ts` + tests (word/action ceiling, terse labels, long-option, recovery state) |
+
+## Follow-up (not in this PR)
+
+- **Docs pages** mirroring the task-first steps + recovery guidance
+  (operations timezone/hours effects, table-as-resource, recovering generated
+  menu/items/sections). Filed separately to avoid product `doc-index` churn in
+  this behaviour-focused PR; the in-product route-local recovery this BI's
+  primary ask is delivered here.
+- Applying the same task-first grouping to `/storefront/items` and
+  `/storefront/sections` (repeated `Edit`/`Del`/`↑`/`↓` labels) — the shared
+  `setup-ux` validator now gives those routes a check to build against.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: `BI-C39DC90C`
+- Receipt: `cmrvod66y079a01rwucd9xtr5`
+- Rationale: The route-level UX-ceiling validator, the pure setup model, the recovery server actions, and the StorefrontSetupPanel are one interdependent vertical slice — the panel cannot ship without the model, the model without the validator, or the recovery UI without the actions — so they ship together under BI-C39DC90C and no phase is independently shippable. The Docs-page mirror and applying the same grouping to /storefront/items and /storefront/sections are out of this plan's scope and will be filed as separate BIs (see Follow-up).
+- Dependencies: none
+- Task-first setup status + generated-content inventory + recovery of generated service lines -> `BI-C39DC90C`
+
+## Verification note
+
+This was implemented in a source-only worktree (no `node_modules`). The pure
+modules were verified with vitest against the worktree source
+(`setup-ux.test.ts` 13/13, `setup-model.test.ts` 8/8) and `tsc --noEmit` on the
+validators package is clean. A full web `tsc` in the worktree is unreliable here
+(the `@dpf/*` and `next/*` module resolution points at the main clone / sibling
+worktrees), so the authoritative typecheck is CI's fresh install.

--- a/docs/user-guide/storefront/index.md
+++ b/docs/user-guide/storefront/index.md
@@ -17,6 +17,8 @@ The storefront is also the most visible expression of the selected market archet
 - **Items** — The products or services listed for sale or booking. Each item has a price, description, and availability settings.
 - **Domain Routing** — The storefront serves your organization's public experience under its configured path or domain with its selected branding.
 - **Inbox** — Messages and enquiries submitted by visitors through the storefront. Managed by staff from inside the platform.
+- **Setup status** — The storefront home groups getting-ready work into a few plain steps (brand & public profile, menu/items, tables/resources, hours & availability, reservations/inbox) and shows a simple status for each — *Done*, *Needs attention*, or *Not started* — so a non-technical owner can see what is left without reading every settings screen. The exact steps and their labels follow your archetype (a restaurant sees Menu, Tables, and Reservations).
+- **Generated content & recovery** — When you add a service line, the platform auto-creates items and sections for it. The storefront home lists this generated content grouped by what produced it. Removing a service line **retains** its items and sections (items are deactivated, sections hidden) rather than deleting them, so the removal is recoverable. From the collapsed **Generated content & recovery** panel you can **Restore** a removed line (reactivates its items) or **Remove permanently** (deletes the retained items and sections — this cannot be undone). Every recovery action first shows exactly how many items and sections it affects and asks you to confirm.
 - **Healthcare intake** — Medical and dental archetypes add an internal **Intake** workspace for receptionists and care-practice staff. It summarizes visit readiness, missing steps, and open exceptions without displaying clinical answers. Patient references are pseudonymous in this workspace; detailed clinical records remain on their governed care surfaces.
 
 ## What You Can Do
@@ -26,6 +28,8 @@ The storefront is also the most visible expression of the selected market archet
 - Add, edit, or remove items available for purchase or booking
 - Manage the booking calendar — set availability, block dates, assign service providers
 - Review and respond to enquiries arriving in the storefront inbox
+- Track setup progress from the storefront home and see what generated content exists
+- Recover generated content after removing a service line — restore it, or remove the retained items and sections permanently
 - For medical and dental practices, review active patient-intake readiness from **Portal → Intake** and identify packets that need attention before a visit
 
 ## Related

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -10,4 +10,5 @@ export * from "./field-dispatch-warranty";
 export * from "./field-dispatch-assignment";
 export * from "./field-dispatch-policy";
 export * from "./readability";
+export * from "./setup-ux";
 export * from "./storefront";

--- a/packages/validators/src/setup-ux.test.ts
+++ b/packages/validators/src/setup-ux.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import {
+  analyzeSetupSurface,
+  isTerseLabel,
+  SETUP_UX_CEILINGS,
+  setupSurfaceDescriptorSchema,
+  type SetupSurfaceDescriptor,
+} from "./setup-ux";
+
+function baseDescriptor(over: Partial<SetupSurfaceDescriptor> = {}): SetupSurfaceDescriptor {
+  return {
+    route: "/storefront",
+    text: "Set up your restaurant. Add your menu, tables, and hours.",
+    actions: [{ label: "Publish" }, { label: "Edit settings" }],
+    ...over,
+  };
+}
+
+describe("isTerseLabel", () => {
+  it("flags stock verbs, glyphs, and 1–2 char controls", () => {
+    for (const l of ["Edit", "Del", "On", "Off", "Hide", "Show", "↑", "↓", "×", "x", "Up"]) {
+      expect(isTerseLabel(l)).toBe(true);
+    }
+    expect(isTerseLabel("")).toBe(true);
+  });
+
+  it("does not flag a descriptive label", () => {
+    expect(isTerseLabel("Remove Coffee Shop line")).toBe(false);
+    expect(isTerseLabel("Add menu item")).toBe(false);
+  });
+});
+
+describe("analyzeSetupSurface", () => {
+  it("passes a lean task-first surface", () => {
+    const report = analyzeSetupSurface(baseDescriptor());
+    expect(report.ok).toBe(true);
+    expect(report.violations).toEqual([]);
+  });
+
+  it("flags a word wall over the ceiling", () => {
+    const text = Array.from({ length: SETUP_UX_CEILINGS.maxWords + 50 }, () => "word").join(" ");
+    const report = analyzeSetupSurface(baseDescriptor({ text }));
+    expect(report.violations.map((v) => v.code)).toContain("word-ceiling");
+  });
+
+  it("flags too many actions", () => {
+    const actions = Array.from({ length: SETUP_UX_CEILINGS.maxActions + 3 }, (_, i) => ({
+      label: `Action ${i}`,
+    }));
+    const report = analyzeSetupSurface(baseDescriptor({ actions }));
+    expect(report.violations.map((v) => v.code)).toContain("action-ceiling");
+  });
+
+  it("flags repeated terse labels with no distinguishing accessible name", () => {
+    const actions = [
+      { label: "Edit" },
+      { label: "Edit" },
+      { label: "Edit" },
+      { label: "Del" },
+      { label: "Del" },
+      { label: "Del" },
+    ];
+    const report = analyzeSetupSurface(baseDescriptor({ actions }));
+    const codes = report.violations.map((v) => v.code);
+    expect(codes).toContain("repeated-terse-label");
+    // Both Edit and Del breach → two violations.
+    expect(report.violations.filter((v) => v.code === "repeated-terse-label")).toHaveLength(2);
+  });
+
+  it("does NOT flag terse visible labels that carry unique accessible names", () => {
+    const actions = [
+      { label: "Remove", accessibleLabel: "Remove Coffee Shop line" },
+      { label: "Remove", accessibleLabel: "Remove Food Truck line" },
+      { label: "Remove", accessibleLabel: "Remove Catering line" },
+    ];
+    const report = analyzeSetupSurface(baseDescriptor({ actions }));
+    expect(report.violations.map((v) => v.code)).not.toContain("repeated-terse-label");
+  });
+
+  it("flags a long inline option list (101-option service-line select)", () => {
+    const report = analyzeSetupSurface(
+      baseDescriptor({
+        optionGroups: [{ label: "Add service line", optionCount: 101 }],
+      }),
+    );
+    expect(report.violations.map((v) => v.code)).toContain("long-option-exposure");
+  });
+
+  it("exempts a long option list that is collapsed until opened", () => {
+    const report = analyzeSetupSurface(
+      baseDescriptor({
+        optionGroups: [
+          { label: "Add service line", optionCount: 101, collapsedUntilOpened: true },
+        ],
+      }),
+    );
+    expect(report.violations.map((v) => v.code)).not.toContain("long-option-exposure");
+  });
+
+  it("flags generated content with no recovery path", () => {
+    const report = analyzeSetupSurface(
+      baseDescriptor({ recovery: { generatedGroups: 2, recoverableGroups: 1 } }),
+    );
+    expect(report.violations.map((v) => v.code)).toContain("generated-content-recovery");
+  });
+
+  it("passes when every generated group is recoverable", () => {
+    const report = analyzeSetupSurface(
+      baseDescriptor({ recovery: { generatedGroups: 2, recoverableGroups: 2 } }),
+    );
+    expect(report.violations.map((v) => v.code)).not.toContain("generated-content-recovery");
+  });
+
+  it("reproduces the audited /storefront failure profile", () => {
+    // 2026-07-22 audit: ~505 words, 17 actions, 101-option service-line select,
+    // generated residue with no recovery.
+    const report = analyzeSetupSurface({
+      route: "/storefront",
+      text: Array.from({ length: 505 }, () => "word").join(" "),
+      actions: Array.from({ length: 17 }, (_, i) => ({ label: `Action ${i}` })),
+      optionGroups: [{ label: "Add service line", optionCount: 101 }],
+      recovery: { generatedGroups: 3, recoverableGroups: 0 },
+    });
+    expect(report.ok).toBe(false);
+    expect(new Set(report.violations.map((v) => v.code))).toEqual(
+      new Set(["word-ceiling", "action-ceiling", "long-option-exposure", "generated-content-recovery"]),
+    );
+  });
+});
+
+describe("setupSurfaceDescriptorSchema", () => {
+  it("parses a well-formed descriptor", () => {
+    const parsed = setupSurfaceDescriptorSchema.safeParse(baseDescriptor());
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/validators/src/setup-ux.ts
+++ b/packages/validators/src/setup-ux.ts
@@ -1,0 +1,248 @@
+import { z } from "zod";
+import { analyzeReadability } from "./readability";
+
+// ============================================================================
+// Setup-surface UX ceilings — the route-level checks BI-C39DC90C asks for.
+//
+// A non-technical owner's setup surface fails when it dumps too much prose,
+// exposes too many competing actions, repeats undistinguishable terse labels
+// (Edit / Del / On / Off / ↑ / ↓), buries a long option list in the page and
+// accessibility stream (a 101-option service-line select, a 418-option
+// timezone select), or generates content the owner cannot see or recover.
+//
+// This module is pure + shared (no React, no DB) so a page's own descriptor
+// — or a rendered-route audit — can be checked against one contract, and the
+// thresholds live in one place. Mirrors readability.ts as a sibling policy.
+//
+// Related: docs/platform-usability-standards.md → Cognitive Load & Setup
+// ============================================================================
+
+/** A single interactive control counted on a setup surface. */
+export interface SetupSurfaceAction {
+  /** Visible label (button text, link text, icon glyph). */
+  label: string;
+  /**
+   * Accessible name if it differs from the visible label — e.g. an icon button
+   * whose aria-label is "Remove Coffee Shop line". A terse visible label that
+   * carries a distinguishing accessible name does NOT count as a repeated
+   * terse label, because assistive tech and the audit both read the aria name.
+   */
+  accessibleLabel?: string;
+}
+
+/** A `<select>` / option group whose length is what matters for exposure. */
+export interface SetupSurfaceOptionGroup {
+  /** What the control is for, used in the violation message. */
+  label: string;
+  /** Number of options exposed inline (in the DOM / a11y stream). */
+  optionCount: number;
+  /**
+   * True when the long list is only mounted after an explicit open (a
+   * disclosure, a search-then-pick, a dedicated route) so it never sits in the
+   * default page/accessibility stream. Collapsed long lists are exempt.
+   */
+  collapsedUntilOpened?: boolean;
+}
+
+/** Generated (auto-seeded) content the owner should be able to see + recover. */
+export interface SetupSurfaceRecoveryState {
+  /** Distinct generated groups present (e.g. a seeded service line). */
+  generatedGroups: number;
+  /** Of those, how many expose a recover / undo / remove path. */
+  recoverableGroups: number;
+}
+
+export interface SetupSurfaceDescriptor {
+  /** Route or surface id, only used to label violations. */
+  route: string;
+  /** All rendered prose on the surface, concatenated. */
+  text: string;
+  /** Every interactive control the surface renders by default. */
+  actions: SetupSurfaceAction[];
+  /** Option groups (selects, long pick lists). */
+  optionGroups?: SetupSurfaceOptionGroup[];
+  /** Generated-content recovery posture, when the surface owns generated content. */
+  recovery?: SetupSurfaceRecoveryState;
+}
+
+// ── Ceilings ────────────────────────────────────────────────────────────────
+
+export const SETUP_UX_CEILINGS = {
+  /** Max words of prose before a setup surface reads as a wall of text. */
+  maxWords: 350,
+  /** Max interactive controls competing for a non-technical owner's attention. */
+  maxActions: 14,
+  /**
+   * Max options a single control may expose inline. Above this a control must
+   * collapse behind an explicit open (search/disclosure/route) instead of
+   * dumping every option into the page + accessibility stream.
+   */
+  maxInlineOptions: 12,
+  /**
+   * How many times one terse label may repeat (without a distinguishing
+   * accessible name) before the row actions are indistinguishable. One pair is
+   * tolerated; three identical "Edit" names in the a11y tree is the smell.
+   */
+  maxRepeatedTerseLabel: 2,
+} as const;
+
+/**
+ * A label is "terse" when it is too short, or a bare icon glyph / stock verb,
+ * to identify WHICH artifact it acts on. These are exactly the labels the audit
+ * flagged: Edit / Del / On / Off / Hide / Show / ↑ / ↓ / Remove.
+ */
+const TERSE_LABELS = new Set(
+  [
+    "edit",
+    "del",
+    "delete",
+    "on",
+    "off",
+    "hide",
+    "show",
+    "remove",
+    "add",
+    "up",
+    "down",
+    "↑",
+    "↓",
+    "×",
+    "x",
+  ].map((s) => s.toLowerCase()),
+);
+
+export function isTerseLabel(label: string): boolean {
+  const trimmed = label.trim();
+  if (!trimmed) return true;
+  const lower = trimmed.toLowerCase();
+  if (TERSE_LABELS.has(lower)) return true;
+  // A single glyph or a 1–2 char control is terse regardless of set membership.
+  return trimmed.length <= 2;
+}
+
+export type SetupUxViolationCode =
+  | "word-ceiling"
+  | "action-ceiling"
+  | "repeated-terse-label"
+  | "long-option-exposure"
+  | "generated-content-recovery";
+
+export interface SetupUxViolation {
+  code: SetupUxViolationCode;
+  message: string;
+}
+
+export interface SetupUxReport {
+  route: string;
+  ok: boolean;
+  words: number;
+  actionCount: number;
+  violations: SetupUxViolation[];
+}
+
+/**
+ * The accessible name an action presents to the audit + assistive tech: its
+ * explicit accessibleLabel when set, otherwise its visible label.
+ */
+function resolvedName(action: SetupSurfaceAction): string {
+  return (action.accessibleLabel ?? action.label).trim();
+}
+
+/**
+ * Evaluate a setup surface against the ceilings. Pure — returns every
+ * violation so a test can assert the full set, and `ok` for a quick gate.
+ */
+export function analyzeSetupSurface(descriptor: SetupSurfaceDescriptor): SetupUxReport {
+  const violations: SetupUxViolation[] = [];
+
+  const words = analyzeReadability(descriptor.text).words;
+  if (words > SETUP_UX_CEILINGS.maxWords) {
+    violations.push({
+      code: "word-ceiling",
+      message: `${descriptor.route} renders ~${words} words (ceiling ${SETUP_UX_CEILINGS.maxWords}). Split into task-first steps or move detail behind disclosures.`,
+    });
+  }
+
+  const actionCount = descriptor.actions.length;
+  if (actionCount > SETUP_UX_CEILINGS.maxActions) {
+    violations.push({
+      code: "action-ceiling",
+      message: `${descriptor.route} exposes ${actionCount} actions (ceiling ${SETUP_UX_CEILINGS.maxActions}). Group secondary actions or hide advanced expansion until opened.`,
+    });
+  }
+
+  // Repeated terse labels — count only labels that are terse AND have no
+  // distinguishing accessible name. A terse visible label with a unique aria
+  // name (icon button → "Remove Coffee Shop line") is fine.
+  const terseCounts = new Map<string, number>();
+  for (const action of descriptor.actions) {
+    const name = resolvedName(action);
+    if (isTerseLabel(name)) {
+      const key = name.toLowerCase();
+      terseCounts.set(key, (terseCounts.get(key) ?? 0) + 1);
+    }
+  }
+  for (const [label, count] of terseCounts) {
+    if (count > SETUP_UX_CEILINGS.maxRepeatedTerseLabel) {
+      violations.push({
+        code: "repeated-terse-label",
+        message: `${descriptor.route} repeats the terse label "${label}" ${count} times with no distinguishing accessible name. Give each row action a name that says which item it acts on.`,
+      });
+    }
+  }
+
+  for (const group of descriptor.optionGroups ?? []) {
+    if (group.optionCount > SETUP_UX_CEILINGS.maxInlineOptions && !group.collapsedUntilOpened) {
+      violations.push({
+        code: "long-option-exposure",
+        message: `${descriptor.route} exposes ${group.optionCount} inline options in "${group.label}" (ceiling ${SETUP_UX_CEILINGS.maxInlineOptions}). Collapse it behind an explicit open (search/disclosure) so it stays out of the default page and accessibility stream.`,
+      });
+    }
+  }
+
+  if (descriptor.recovery && descriptor.recovery.generatedGroups > 0) {
+    const { generatedGroups, recoverableGroups } = descriptor.recovery;
+    if (recoverableGroups < generatedGroups) {
+      violations.push({
+        code: "generated-content-recovery",
+        message: `${descriptor.route} has ${generatedGroups} generated content group(s) but only ${recoverableGroups} expose a recovery path. Every generated section, item, or service line must be recoverable (undo) or explain what is retained.`,
+      });
+    }
+  }
+
+  return {
+    route: descriptor.route,
+    ok: violations.length === 0,
+    words,
+    actionCount,
+    violations,
+  };
+}
+
+// ── Runtime-parseable descriptor (for future audit ingestion) ───────────────
+
+export const setupSurfaceActionSchema = z.object({
+  label: z.string(),
+  accessibleLabel: z.string().optional(),
+});
+
+export const setupSurfaceDescriptorSchema = z.object({
+  route: z.string(),
+  text: z.string(),
+  actions: z.array(setupSurfaceActionSchema),
+  optionGroups: z
+    .array(
+      z.object({
+        label: z.string(),
+        optionCount: z.number().int().nonnegative(),
+        collapsedUntilOpened: z.boolean().optional(),
+      }),
+    )
+    .optional(),
+  recovery: z
+    .object({
+      generatedGroups: z.number().int().nonnegative(),
+      recoverableGroups: z.number().int().nonnegative(),
+    })
+    .optional(),
+});


### PR DESCRIPTION
## What & why

BI-C39DC90C (epic EP-UX-COGLOAD). A Restaurant owner's `/storefront` admin had no coherent task-first setup status, no map of generated content, and no safe recovery path for auto-seeded service-line content. This adds that as an **additive** layer.

## Scope reconciliation with #3379 (BI-7D7EE150)

PR #3379 is in flight adding confirm/preview/undo to service-line **add/remove**. To avoid a hard collision this PR is deliberately additive and **composes** with it:
- Does **not** delete or modify `ServiceLinesPanel` (which #3379 edits + tests).
- Does **not** change the `add`/`remove` action signatures.
- Adds the parts #3379 does not cover: task-first setup status, generated-content inventory, and **recovery (restore / permanent-remove) of removed-but-retained lines**.

The add-line preview and hiding the cross-industry add control are delivered by #3379's flow; together the two PRs satisfy the epic.

## Changes

- `packages/validators/src/setup-ux.ts` (+tests) — pure route-level UX-ceiling validator: word/action ceilings, repeated terse labels (Edit/Del/↑/↓ with no distinguishing accessible name), long inline-option exposure (must be collapsed-until-opened), generated-content recovery state. Sibling to `readability.ts`.
- `apps/web/lib/storefront/setup-model.ts` (+tests) — archetype-aware task-first steps (brand · menu/items · tables/resources · hours/availability · reservations/inbox), each with a plain status; generated-content inventory grouped by source composition; hidden advanced bucket. `auditSetupSurface` holds the model to the ceilings.
- `apps/web/lib/storefront/service-line-actions.ts` — additive `restoreStorefrontServiceLine`, `purgeRemovedServiceLine`, `loadRemovedServiceLines`.
- `apps/web/components/storefront-admin/StorefrontSetupPanel.tsx` + `page.tsx` — steps + a **collapsed** "Generated content & recovery" disclosure; each recovery mutation shows preview (affected artifacts) + confirm + success/failure feedback + undo (restore) or explicit no-undo (purge).

## Design grounding

Extends the multi-archetype composition model in `docs/superpowers/specs/2026-06-13-multi-archetype-composition-design.md` and the `apps/web/` storefront admin. No new table, enum, or provenance concept — reuses `StorefrontArchetypeComposition` + `sourceCompositionId`. Plan: `docs/superpowers/plans/2026-07-22-storefront-owner-setup-recovery-BI-C39DC90C.md`.

## Verification

Source-only worktree (no node_modules): `setup-ux` 13/13, `setup-model` 8/8 (vitest against worktree source), `@dpf/validators` `tsc --noEmit` clean. The pre-commit web typecheck was overridden (`DPF_SKIP_TYPECHECK=1`) because in-worktree `@dpf/*` + `next/*` resolve to the main clone / sibling worktrees; **CI's fresh install is the authoritative typecheck**.

## Follow-up (in the plan, not this PR)

- Product Docs pages mirroring the task-first steps + recovery guidance (operations timezone/hours effects, recovering generated menu/items/sections).
- Applying the same task-first grouping + the shared `setup-ux` checks to `/storefront/items` and `/storefront/sections`.

Design-Grounding-Decision: extend — grounded in docs/superpowers/specs/2026-06-13-multi-archetype-composition-design.md and apps/web/ storefront substrate; additive plan authored, no schema change.
UX-Fit-Decision: progressive disclosure — task-first steps default (<=5 plain steps); generated-content + recovery collapsed until opened; every recovery mutation gated behind preview + confirm + feedback + undo; no raw token/endpoint/count inputs.
Docs-Impact: added docs/superpowers/plans/2026-07-22-storefront-owner-setup-recovery-BI-C39DC90C.md; product Docs pages filed as follow-up.
Process-Spine-Decision: plan authored at docs/superpowers/plans/2026-07-22-storefront-owner-setup-recovery-BI-C39DC90C.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)