### PR TITLE
refactor(ops): owner-readable release status card for Self-Upgrade (BI-8D87084D)

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -75,7 +75,8 @@ vi.mock("@/components/ops/LocalChangesLedger", () => ({
 }));
 
 // The page reads the Simple/Full nav-mode cookie to decide the Advanced default.
-const mockCookieGet = vi.fn().mockReturnValue(undefined);
+// vi.hoisted so the (hoisted) vi.mock factory can reference the fn without a TDZ.
+const { mockCookieGet } = vi.hoisted(() => ({ mockCookieGet: vi.fn() }));
 vi.mock("next/headers", () => ({
   cookies: vi.fn().mockResolvedValue({ get: mockCookieGet }),
 }));

--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -57,6 +57,29 @@ vi.mock("@/components/ops/SelfUpgradeClient", () => ({
   ),
 }));
 
+// BI-8D87084D: owner-readable release card fronts the technical ledger. Stub it
+// to surface the derived state; the summary derivation itself is unit-tested in
+// lib/self-upgrade/owner-summary.test.ts.
+vi.mock("@/components/ops/OwnerReleaseCard", () => ({
+  OwnerReleaseCard: (props: { summary: { state: string } }) => (
+    <div data-testid="owner-release-card" data-release-state={props.summary.state} />
+  ),
+}));
+
+vi.mock("@/lib/self-upgrade/local-changes-ledger", () => ({
+  getLocalChangesLedger: vi.fn().mockResolvedValue({ available: true, changes: [] }),
+}));
+
+vi.mock("@/components/ops/LocalChangesLedger", () => ({
+  LocalChangesLedger: () => <div data-testid="local-changes-ledger" />,
+}));
+
+// The page reads the Simple/Full nav-mode cookie to decide the Advanced default.
+const mockCookieGet = vi.fn().mockReturnValue(undefined);
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({ get: mockCookieGet }),
+}));
+
 import { getSelfUpgradeStatus, listSelfUpgradeRuns } from "@/lib/actions/promotions";
 import { getPlatformDevConfig } from "@/lib/actions/platform-dev-config";
 import { loadPersistedImpactSummary, summarizeUpgradeImpact } from "@/lib/self-upgrade/impact";
@@ -66,6 +89,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   // Default: install does not customise source — panel stays dormant.
   vi.mocked(getPlatformDevConfig).mockResolvedValue(null as never);
+  // Default nav-mode: no cookie → Full (operator) → Advanced expanded.
+  mockCookieGet.mockReturnValue(undefined);
 });
 
 const baseStatus = {
@@ -264,5 +289,44 @@ describe("SelfUpgradePage", () => {
 
     expect(summarizeUpgradeImpact).not.toHaveBeenCalled();
     expect(loadPersistedImpactSummary).toHaveBeenCalled();
+  });
+
+  it("renders the owner release card ahead of the advanced controls (BI-8D87084D)", async () => {
+    vi.mocked(getSelfUpgradeStatus).mockResolvedValue({
+      ...baseStatus,
+      enabled: true,
+      isFresh: false,
+      targetSha: "b".repeat(40),
+    });
+    vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
+
+    const html = renderToStaticMarkup(await SelfUpgradePage());
+
+    // Owner card first, derived state exposed.
+    expect(html).toContain('data-testid="owner-release-card"');
+    expect(html).toContain('data-release-state="update-available"');
+    // Technical controls preserved, now under an Advanced disclosure.
+    expect(html).toContain('data-component="self-upgrade-advanced-toggle"');
+    expect(html).toContain('data-testid="self-upgrade-client"');
+    // Owner card is positioned before the advanced disclosure toggle.
+    expect(html.indexOf('data-testid="owner-release-card"')).toBeLessThan(
+      html.indexOf('data-component="self-upgrade-advanced-toggle"'),
+    );
+  });
+
+  it("expands the advanced controls in Full mode and collapses them in Simple mode", async () => {
+    vi.mocked(getSelfUpgradeStatus).mockResolvedValue(baseStatus);
+    vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
+
+    // Full (operator) — default cookie unset → details open.
+    const fullHtml = renderToStaticMarkup(await SelfUpgradePage());
+    expect(fullHtml).toMatch(/<details[^>]*\sopen/);
+
+    // Simple (worker) — details collapsed by default.
+    mockCookieGet.mockReturnValue({ value: "worker" });
+    const simpleHtml = renderToStaticMarkup(await SelfUpgradePage());
+    expect(simpleHtml).not.toMatch(/<details[^>]*\sopen/);
+    // The disclosure toggle is still present so it can be opened.
+    expect(simpleHtml).toContain('data-component="self-upgrade-advanced-toggle"');
   });
 });

--- a/apps/web/app/(shell)/ops/self-upgrade/page.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.tsx
@@ -1,11 +1,16 @@
+import { cookies } from "next/headers";
 import { getSelfUpgradeStatus, listSelfUpgradeRuns } from "@/lib/actions/promotions";
 import { getPlatformDevConfig } from "@/lib/actions/platform-dev-config";
 import { loadPersistedImpactSummary } from "@/lib/self-upgrade/impact";
+import { buildOwnerReleaseSummary } from "@/lib/self-upgrade/owner-summary";
 import SelfUpgradeClient from "@/components/ops/SelfUpgradeClient";
+import { OwnerReleaseCard } from "@/components/ops/OwnerReleaseCard";
 import { OpsTabNav } from "@/components/ops/OpsTabNav";
 import { PlatformUpdateApplyPanel } from "@/components/admin/PlatformUpdateApplyPanel";
 import { LocalChangesLedger } from "@/components/ops/LocalChangesLedger";
 import { getLocalChangesLedger } from "@/lib/self-upgrade/local-changes-ledger";
+import { hasGovernedRecoveryPoint } from "@/lib/self-upgrade/rollback";
+import { NAV_MODE_COOKIE, resolveNavModeFromCookie, isSimpleNavMode } from "@/lib/navigation/nav-mode";
 
 export default async function SelfUpgradePage() {
   // BI-D43EB266: Self-Upgrade is the single operator entry point for "update
@@ -39,27 +44,80 @@ export default async function SelfUpgradePage() {
     }),
   );
 
+  // BI-8D87084D: front the runtime ledger with a plain-language release status
+  // card that answers is-there-an-update / is-it-safe / can-I-keep-working /
+  // can-I-undo / what-if-I-do-nothing. The technical controls, SUR run history,
+  // runtime/security ledgers, and logs move behind an Advanced disclosure that
+  // Simple (worker) nav-mode keeps collapsed by default.
+  const ownerSummary = buildOwnerReleaseSummary(
+    {
+      enabled: status.enabled,
+      isFresh: status.isFresh,
+      targetSha: status.targetSha,
+      deployedSha: status.deployedSha,
+      nextWindowStart: status.nextWindowStart,
+      blackoutUntil: status.blackoutUntil,
+      blackoutName: status.blackoutName,
+      platformVersion: {
+        version: status.platformVersion.version,
+        gitSha: status.platformVersion.gitSha,
+      },
+      rollbackAvailable: hasGovernedRecoveryPoint(status.latestRun?.completionEvidence ?? null),
+      latestRun: status.latestRun
+        ? {
+            status: status.latestRun.status,
+            reason: status.latestRun.reason,
+            targetSha: status.latestRun.targetSha,
+          }
+        : null,
+      latestRunImpact: status.latestRunImpact,
+    },
+    localChanges,
+  );
+  const navMode = resolveNavModeFromCookie((await cookies()).get(NAV_MODE_COOKIE)?.value);
+  const simple = isSimpleNavMode(navMode);
+
   return (
     <div>
       <div className="mb-6">
         <h1 className="text-xl font-bold text-[var(--dpf-text)]">Self-Upgrade</h1>
         <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
-          Automated portal self-upgrade status and controls.
+          Keep your platform up to date. Here&apos;s the plain-language status; technical
+          controls and history are under Advanced.
         </p>
       </div>
 
       <OpsTabNav />
 
-      <SelfUpgradeClient {...clientProps} />
-
-      <PlatformUpdateApplyPanel
-        updatePending={devConfig?.updatePending ?? false}
-        pendingVersion={devConfig?.pendingVersion ?? null}
-      />
-
-      <div className="mt-6">
-        <LocalChangesLedger result={localChanges} />
+      <div className="mt-4">
+        <OwnerReleaseCard summary={ownerSummary} />
       </div>
+
+      {/* Advanced: the technical deploy controls, run history, runtime/security
+          ledgers and logs. Collapsed by default in Simple mode so a non-technical
+          owner sees the release status first, expanded in Full mode for operators. */}
+      <details className="mt-6 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]" open={!simple}>
+        <summary
+          data-component="self-upgrade-advanced-toggle"
+          className="cursor-pointer select-none rounded-xl px-4 py-3 text-sm font-medium text-[var(--dpf-text)] marker:text-[var(--dpf-muted)]"
+        >
+          Advanced controls &amp; history
+          <span className="ml-2 text-xs font-normal text-[var(--dpf-muted)]">
+            Deploy controls, run logs, runtime and security checks
+          </span>
+        </summary>
+
+        <div className="space-y-6 border-t border-[var(--dpf-border)] p-4">
+          <SelfUpgradeClient {...clientProps} />
+
+          <PlatformUpdateApplyPanel
+            updatePending={devConfig?.updatePending ?? false}
+            pendingVersion={devConfig?.pendingVersion ?? null}
+          />
+
+          <LocalChangesLedger result={localChanges} />
+        </div>
+      </details>
     </div>
   );
 }

--- a/apps/web/components/ops/OwnerReleaseCard.tsx
+++ b/apps/web/components/ops/OwnerReleaseCard.tsx
@@ -1,0 +1,110 @@
+// apps/web/components/ops/OwnerReleaseCard.tsx
+//
+// Owner-readable release status card for /ops/self-upgrade (BI-8D87084D). Renders
+// the plain-language summary FIRST, above the technical controls/logs (which move
+// behind an Advanced disclosure on the page). Pure/server — no hooks, token-only
+// colors, report-kit primitives (no hand-rolled badge/KPI div, AGENTS.md §12).
+
+import { Notice, StatCard, type NoticeVariant } from "@/components/ui/report-kit";
+import type { OwnerReleaseSummary, OwnerReleaseTone } from "@/lib/self-upgrade/owner-summary";
+
+const TONE_VARIANT: Record<OwnerReleaseTone, NoticeVariant> = {
+  success: "success",
+  info: "info",
+  warning: "warn",
+  danger: "error",
+};
+
+const TONE_INTENT = {
+  success: "success",
+  info: "info",
+  warning: "warning",
+  danger: "danger",
+} as const;
+
+function QuestionRow({ q, a }: { q: string; a: string }) {
+  return (
+    <div className="flex flex-col gap-0.5 border-t border-[var(--dpf-border)] py-2 first:border-t-0 sm:flex-row sm:gap-4">
+      <dt className="shrink-0 text-xs font-medium text-[var(--dpf-muted)] sm:w-48">{q}</dt>
+      <dd className="min-w-0 text-sm text-[var(--dpf-text)]">{a}</dd>
+    </div>
+  );
+}
+
+export function OwnerReleaseCard({ summary }: { summary: OwnerReleaseSummary }) {
+  return (
+    <section
+      aria-label="Release status"
+      data-component="owner-release-card"
+      data-release-state={summary.state}
+      className="space-y-4 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+    >
+      {/* The single-sentence answer + the one action, at the top. */}
+      <Notice variant={TONE_VARIANT[summary.tone]} title={summary.headline}>
+        <p className="font-medium text-[var(--dpf-text)]">{summary.recommendedAction.label}</p>
+        <p className="text-[var(--dpf-muted)]">{summary.recommendedAction.detail}</p>
+      </Notice>
+
+      {/* Version at-a-glance. */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <StatCard
+          label="Running now"
+          value={<span className="text-base font-semibold">{summary.currentVersion}</span>}
+          intent="neutral"
+        />
+        <StatCard
+          label="Update ready"
+          value={
+            <span className="text-base font-semibold">{summary.availableVersion ?? "You're current"}</span>
+          }
+          intent={summary.state === "update-available" ? TONE_INTENT.info : "success"}
+        />
+      </div>
+
+      {/* The questions an owner actually has, answered in plain words. */}
+      <dl className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3">
+        <QuestionRow q="Can the business keep working?" a={summary.canKeepWorking.detail} />
+        <QuestionRow q="What's kept on your system?" a={summary.keptLocally.detail} />
+        <QuestionRow q="Can this be undone?" a={summary.rollback.detail} />
+        <QuestionRow q="If you do nothing" a={summary.ifYouDoNothing} />
+      </dl>
+
+      {/* Honest, short risk list. */}
+      {summary.whatCouldGoWrong.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-xs font-medium uppercase tracking-[0.14em] text-[var(--dpf-muted)]">
+            What could go wrong
+          </p>
+          <ul className="list-disc space-y-1 pl-5 text-sm text-[var(--dpf-text)]">
+            {summary.whatCouldGoWrong.map((risk, i) => (
+              <li key={i}>{risk}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Consequence / reversibility / duration / recovery BEFORE the install action. */}
+      {summary.riskNotice && (
+        <Notice variant="warn" title="Before you install">
+          <ul className="space-y-0.5">
+            <li>
+              <span className="font-medium">What happens:</span> {summary.riskNotice.consequence}
+            </li>
+            <li>
+              <span className="font-medium">Can it be undone:</span> {summary.riskNotice.reversibility}
+            </li>
+            <li>
+              <span className="font-medium">How long:</span> {summary.riskNotice.duration}
+            </li>
+            <li>
+              <span className="font-medium">If it fails:</span> {summary.riskNotice.recovery}
+            </li>
+          </ul>
+          <p className="mt-1 text-xs text-[var(--dpf-muted)]">
+            The install control is under “Advanced controls &amp; history” below.
+          </p>
+        </Notice>
+      )}
+    </section>
+  );
+}

--- a/apps/web/lib/self-upgrade/owner-summary.test.ts
+++ b/apps/web/lib/self-upgrade/owner-summary.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import { buildOwnerReleaseSummary, type OwnerReleaseInput } from "./owner-summary";
+import type { LocalChangesResult } from "./local-changes-ledger";
+
+const NO_LOCAL_CHANGES: LocalChangesResult = { available: true, changes: [] };
+
+function baseInput(overrides: Partial<OwnerReleaseInput> = {}): OwnerReleaseInput {
+  return {
+    enabled: true,
+    isFresh: true,
+    targetSha: null,
+    deployedSha: "abc1234def",
+    nextWindowStart: null,
+    blackoutUntil: null,
+    blackoutName: null,
+    platformVersion: { version: "1.2.0", gitSha: "abc1234" },
+    rollbackAvailable: false,
+    latestRun: null,
+    latestRunImpact: null,
+    ...overrides,
+  };
+}
+
+// Terms an owner should never have to decode on the summary card. The technical
+// ledger keeps them behind the Advanced disclosure; this asserts the OWNER card
+// stays plain-language (the cognitive-load acceptance for BI-8D87084D).
+const JARGON = ["SUR-", "quiescence", "quiesce", "promoter", "targetSha", "deployedSha", "SHA", "Inngest", "admission lane"];
+
+function allCopy(s: ReturnType<typeof buildOwnerReleaseSummary>): string {
+  return [
+    s.headline,
+    s.currentVersion,
+    s.availableVersion ?? "",
+    s.recommendedAction.label,
+    s.recommendedAction.detail,
+    s.canKeepWorking.detail,
+    s.keptLocally.detail,
+    ...s.whatCouldGoWrong,
+    s.rollback.detail,
+    s.ifYouDoNothing,
+    ...(s.riskNotice ? Object.values(s.riskNotice) : []),
+  ].join(" \n ");
+}
+
+describe("buildOwnerReleaseSummary", () => {
+  it("reports up-to-date when the build is fresh with no target", () => {
+    const s = buildOwnerReleaseSummary(baseInput({ isFresh: true, targetSha: null }), NO_LOCAL_CHANGES);
+    expect(s.state).toBe("up-to-date");
+    expect(s.tone).toBe("success");
+    expect(s.availableVersion).toBeNull();
+    expect(s.riskNotice).toBeNull();
+    expect(s.recommendedAction.label).toBe("No action needed");
+  });
+
+  it("reports update-available with a consequence/reversibility risk notice", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({ isFresh: false, targetSha: "f".repeat(40) }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.state).toBe("update-available");
+    expect(s.availableVersion).toContain("fffffff");
+    // Risk copy must state all four contract fields before the action is offered.
+    expect(s.riskNotice).not.toBeNull();
+    expect(s.riskNotice?.consequence.length).toBeGreaterThan(0);
+    expect(s.riskNotice?.reversibility.length).toBeGreaterThan(0);
+    expect(s.riskNotice?.duration.length).toBeGreaterThan(0);
+    expect(s.riskNotice?.recovery.length).toBeGreaterThan(0);
+  });
+
+  it("uses the impact headline as the available version when present", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        isFresh: false,
+        targetSha: "f".repeat(40),
+        latestRunImpact: {
+          counts: { breaking: 0, feature: 3, fix: 2, performance: 0, other: 1, total: 6 },
+          headline: "6 changes · 3 new · 2 fixes",
+        },
+      }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.availableVersion).toBe("6 changes · 3 new · 2 fixes");
+  });
+
+  it("flags higher-impact (breaking) changes in what-could-go-wrong", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        isFresh: false,
+        targetSha: "f".repeat(40),
+        latestRunImpact: {
+          counts: { breaking: 2, feature: 0, fix: 0, performance: 0, other: 0, total: 2 },
+          headline: null,
+        },
+      }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.whatCouldGoWrong.some((w) => w.includes("higher-impact"))).toBe(true);
+  });
+
+  it("always includes the automatic-restore safety net", () => {
+    const s = buildOwnerReleaseSummary(baseInput(), NO_LOCAL_CHANGES);
+    expect(s.whatCouldGoWrong.at(-1)).toContain("restores the previous version");
+  });
+
+  it("reports in-progress while a run is queued/running/completing", () => {
+    for (const status of ["queued", "pending", "running", "completing"]) {
+      const s = buildOwnerReleaseSummary(
+        baseInput({
+          latestRun: { status, reason: null, targetSha: null },
+        }),
+        NO_LOCAL_CHANGES,
+      );
+      expect(s.state).toBe("in-progress");
+      expect(s.riskNotice).toBeNull();
+      expect(s.canKeepWorking.ok).toBe(true);
+    }
+  });
+
+  it("reports failed and points at recovery when a run failed with a recovery point", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        isFresh: false,
+        targetSha: "f".repeat(40),
+        rollbackAvailable: true,
+        latestRun: { status: "failed", reason: null, targetSha: null },
+      }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.state).toBe("failed");
+    expect(s.tone).toBe("danger");
+    expect(s.rollback.available).toBe(true);
+    expect(s.recommendedAction.detail).toContain("Restore the previous version");
+  });
+
+  it("marks rollback unavailable (with a reassuring detail) when no governed recovery point exists", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({ rollbackAvailable: false, latestRun: { status: "succeeded", reason: null, targetSha: null } }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.rollback.available).toBe(false);
+    expect(s.rollback.detail).toContain("saved automatically");
+  });
+
+  it("counts kept local changes and explains they are preserved", () => {
+    const local: LocalChangesResult = {
+      available: true,
+      changes: [
+        { path: "apps/web/a.ts", added: 1, deleted: 0 },
+        { path: "apps/web/b.ts", added: 2, deleted: 1 },
+      ],
+    };
+    const s = buildOwnerReleaseSummary(baseInput(), local);
+    expect(s.keptLocally.count).toBe(2);
+    expect(s.keptLocally.detail).toContain("kept");
+  });
+
+  it("degrades gracefully when local changes could not be measured", () => {
+    const s = buildOwnerReleaseSummary(baseInput(), {
+      available: false,
+      changes: [],
+      note: "Ledger unavailable right now.",
+    });
+    expect(s.keptLocally.count).toBe(0);
+    expect(s.keptLocally.detail).toBe("Ledger unavailable right now.");
+  });
+
+  it("explains do-nothing behaviour for a paused (blackout) schedule", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({
+        isFresh: false,
+        targetSha: "f".repeat(40),
+        blackoutUntil: "2026-08-01T00:00:00.000Z",
+        blackoutName: "Holiday freeze",
+      }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.ifYouDoNothing).toContain("paused");
+    expect(s.ifYouDoNothing).toContain("Holiday freeze");
+  });
+
+  it("explains do-nothing behaviour when automatic updates are off", () => {
+    const s = buildOwnerReleaseSummary(
+      baseInput({ enabled: false, isFresh: false, targetSha: "f".repeat(40) }),
+      NO_LOCAL_CHANGES,
+    );
+    expect(s.ifYouDoNothing).toContain("automatic updates are off");
+  });
+
+  it("keeps every owner-facing string free of runtime jargon", () => {
+    const inputs: OwnerReleaseInput[] = [
+      baseInput({ isFresh: true, targetSha: null }),
+      baseInput({ isFresh: false, targetSha: "f".repeat(40) }),
+      baseInput({ latestRun: { status: "running", reason: null, targetSha: null } }),
+      baseInput({
+        isFresh: false,
+        targetSha: "f".repeat(40),
+        latestRun: { status: "failed", reason: null, targetSha: null },
+      }),
+    ];
+    for (const input of inputs) {
+      const copy = allCopy(buildOwnerReleaseSummary(input, NO_LOCAL_CHANGES));
+      for (const term of JARGON) {
+        expect(copy).not.toContain(term);
+      }
+    }
+  });
+});

--- a/apps/web/lib/self-upgrade/owner-summary.ts
+++ b/apps/web/lib/self-upgrade/owner-summary.ts
@@ -1,0 +1,310 @@
+// apps/web/lib/self-upgrade/owner-summary.ts
+//
+// Owner-readable release summary for /ops/self-upgrade (BI-8D87084D).
+//
+// The Self-Upgrade page reads like a runtime ledger: SUR ids, RUNTIME/RELEASES/
+// SECURITY tabs, SUCCEEDED/SKIPPED/FAILED status, quiescence blockers. A
+// non-technical owner cannot answer the only questions they actually have —
+// is an update available, is it safe, is the business still working, can it be
+// undone, and what happens if I do nothing.
+//
+// This is the PURE derivation from the existing status object (no I/O, no React)
+// into plain-language answers to exactly those questions, so the card is a thin
+// presenter and the wording is unit-testable. The technical controls, run logs,
+// and ledgers stay on the page behind an Advanced disclosure — this never
+// replaces them, it fronts them.
+
+import type { LocalChangesResult } from "@/lib/self-upgrade/local-changes-ledger";
+import { describeSkipReason } from "@/lib/self-upgrade/skip-reason";
+
+/** The release state an owner cares about — deliberately coarser than the run status machine. */
+export type OwnerReleaseState = "up-to-date" | "update-available" | "in-progress" | "failed";
+
+/** Notice/badge tone paired with each state, resolved through the report-kit intent model by the card. */
+export type OwnerReleaseTone = "success" | "info" | "warning" | "danger";
+
+/** Consequence copy shown BEFORE a risk-bearing action (Upgrade now) is offered. */
+export interface OwnerRiskNotice {
+  consequence: string;
+  reversibility: string;
+  duration: string;
+  recovery: string;
+}
+
+export interface OwnerReleaseSummary {
+  state: OwnerReleaseState;
+  tone: OwnerReleaseTone;
+  /** One plain-language sentence: the answer to "what's going on with updates?". */
+  headline: string;
+  /** Human version label for the running build. */
+  currentVersion: string;
+  /** Human label for the update that's ready, or null when there's nothing newer. */
+  availableVersion: string | null;
+  /** The single next thing (if any) the owner should do, in plain words. */
+  recommendedAction: { label: string; detail: string };
+  /** Can the business keep working through this? */
+  canKeepWorking: { ok: boolean; detail: string };
+  /** What of the owner's own customisations is preserved across the update. */
+  keptLocally: { count: number; detail: string };
+  /** Honest, short list of risks — empty when there's nothing to flag. */
+  whatCouldGoWrong: string[];
+  /** Whether the last/next update can be undone, and how. */
+  rollback: { available: boolean; detail: string };
+  /** What happens with zero owner intervention. */
+  ifYouDoNothing: string;
+  /** Present only when a risk-bearing install action is offered (state = update-available). */
+  riskNotice: OwnerRiskNotice | null;
+}
+
+/**
+ * The subset of `getSelfUpgradeStatus()` the summary reads. Declared structurally
+ * (not `Awaited<ReturnType<...>>`) so the builder stays decoupled from the server
+ * action module and its fixtures stay small. The real status object is a superset
+ * and assigns cleanly.
+ */
+export interface OwnerReleaseInput {
+  enabled: boolean;
+  isFresh: boolean;
+  targetSha: string | null;
+  deployedSha: string | null;
+  nextWindowStart: string | null;
+  blackoutUntil: string | null;
+  blackoutName: string | null;
+  platformVersion: { version: string; gitSha: string | null };
+  /**
+   * Whether a governed recovery point exists for the last run, so this update
+   * can be undone. Computed by the caller (via `hasGovernedRecoveryPoint`) and
+   * passed in as a plain boolean, keeping this builder free of the prisma-backed
+   * rollback module.
+   */
+  rollbackAvailable: boolean;
+  latestRun: {
+    status: string;
+    reason: string | null;
+    targetSha: string | null;
+  } | null;
+  latestRunImpact: {
+    counts: {
+      breaking: number;
+      feature: number;
+      fix: number;
+      performance: number;
+      other: number;
+      total: number;
+    };
+    headline: string | null;
+  } | null;
+}
+
+const IN_FLIGHT: ReadonlySet<string> = new Set(["queued", "pending", "running", "completing"]);
+
+function shortSha(sha: string | null | undefined): string | null {
+  if (!sha) return null;
+  return sha.length > 7 ? sha.slice(0, 7) : sha;
+}
+
+function plural(n: number): string {
+  return n === 1 ? "" : "s";
+}
+
+/** A friendly "on Tuesday at 2:00 AM" for the next quiet window, or "" when unknown. */
+function describeWhen(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  try {
+    return ` (${d.toLocaleString(undefined, {
+      weekday: "long",
+      hour: "numeric",
+      minute: "2-digit",
+    })})`;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Derive the owner-readable release summary from the self-upgrade status. Pure —
+ * safe to unit-test and to call during server render.
+ */
+export function buildOwnerReleaseSummary(
+  input: OwnerReleaseInput,
+  localChanges: LocalChangesResult,
+): OwnerReleaseSummary {
+  const runStatus = input.latestRun?.status ?? null;
+  const inFlight = runStatus != null && IN_FLIGHT.has(runStatus);
+  const failed = runStatus === "failed";
+
+  const state: OwnerReleaseState = inFlight
+    ? "in-progress"
+    : failed
+      ? "failed"
+      : input.isFresh || !input.targetSha
+        ? "up-to-date"
+        : "update-available";
+
+  const tone: OwnerReleaseTone =
+    state === "up-to-date"
+      ? "success"
+      : state === "failed"
+        ? "danger"
+        : state === "in-progress"
+          ? "info"
+          : "info";
+
+  const currentShort = shortSha(input.deployedSha) ?? shortSha(input.platformVersion.gitSha);
+  const currentVersion = currentShort
+    ? `${input.platformVersion.version} (${currentShort})`
+    : input.platformVersion.version;
+
+  const targetShort = shortSha(input.targetSha);
+  const availableVersion =
+    state === "update-available"
+      ? input.latestRunImpact?.headline
+        ? input.latestRunImpact.headline
+        : targetShort
+          ? `Latest build (${targetShort})`
+          : "Latest build"
+      : null;
+
+  // "Why nothing happened" copy for the routine no-op path (run skipped).
+  const skip = runStatus === "skipped" ? describeSkipReason(input.latestRun?.reason) : null;
+
+  // What's kept from the owner's own install.
+  const localCount = localChanges.available ? localChanges.changes.length : 0;
+  const keptLocally = localChanges.available
+    ? localCount > 0
+      ? {
+          count: localCount,
+          detail: `${localCount} change${plural(localCount)} you've made to this install are kept and re-applied on top of each update.`,
+        }
+      : {
+          count: 0,
+          detail: "You have no local changes — this install tracks the standard platform.",
+        }
+    : {
+        count: 0,
+        detail: localChanges.note ?? "We couldn't check your local changes just now.",
+      };
+
+  const rollbackAvailable = input.rollbackAvailable;
+  const rollback = {
+    available: rollbackAvailable,
+    detail: rollbackAvailable
+      ? "You can restore the version from before the last update — a recovery point was saved."
+      : "A recovery point is saved automatically before each update, so an update can be undone.",
+  };
+
+  const breaking = input.latestRunImpact?.counts.breaking ?? 0;
+  const whatCouldGoWrong: string[] = [];
+  if (breaking > 0) {
+    whatCouldGoWrong.push(
+      `This update includes ${breaking} higher-impact change${plural(breaking)} — open "What's in this update" below before installing.`,
+    );
+  }
+  if (keptLocally.count > 0) {
+    whatCouldGoWrong.push(
+      "Your local changes are merged in automatically; a rare conflict would pause the update for review rather than lose your work.",
+    );
+  }
+  if (failed) {
+    whatCouldGoWrong.push(
+      "The previous attempt didn't finish — check the details below before you retry.",
+    );
+  }
+  // Always reassure with the safety net, last.
+  whatCouldGoWrong.push(
+    "If an update fails, the platform restores the previous version on its own.",
+  );
+
+  let headline: string;
+  let recommendedAction: { label: string; detail: string };
+  let ifYouDoNothing: string;
+  let riskNotice: OwnerRiskNotice | null = null;
+
+  const canKeepWorking = inFlight
+    ? {
+        ok: true,
+        detail: "Mostly — the portal restarts for a moment as the update finishes, then reconnects on its own.",
+      }
+    : {
+        ok: true,
+        detail: "Yes. Updates install while your storefront is closed and only restart the portal briefly.",
+      };
+
+  switch (state) {
+    case "up-to-date":
+      headline = "Your platform is up to date";
+      recommendedAction = {
+        label: "No action needed",
+        detail: skip?.detail ?? "You're running the latest version. Nothing to install.",
+      };
+      ifYouDoNothing =
+        "Nothing changes — you stay on the latest version, and the platform keeps checking for updates for you.";
+      break;
+    case "update-available":
+      headline = "A platform update is ready to install";
+      recommendedAction = {
+        label: "Install the update",
+        detail: input.enabled
+          ? "Install it now below, or leave it — it installs on its own during your next quiet period."
+          : "Automatic updates are off. Install it below when you're ready.",
+      };
+      if (input.blackoutUntil) {
+        ifYouDoNothing = `Updates are paused${
+          input.blackoutName ? ` (${input.blackoutName})` : ""
+        } right now, so nothing installs until the pause ends.`;
+      } else if (input.enabled) {
+        ifYouDoNothing = `The update installs on its own during your next quiet period${describeWhen(
+          input.nextWindowStart,
+        )}.`;
+      } else {
+        ifYouDoNothing =
+          "Nothing installs — automatic updates are off. It waits here until you install it.";
+      }
+      riskNotice = {
+        consequence: "Installs the new version and briefly restarts the portal.",
+        reversibility: rollbackAvailable
+          ? "Reversible — restore the saved recovery point to undo it."
+          : "A recovery point is saved first, so it can be undone.",
+        duration: "Usually a few minutes.",
+        recovery: "If it fails, the previous version is restored automatically.",
+      };
+      break;
+    case "in-progress":
+      headline = "A platform update is installing now";
+      recommendedAction = {
+        label: "Let it finish",
+        detail: "The update is running. The portal may reconnect for a moment — no action is needed.",
+      };
+      ifYouDoNothing = "The update finishes on its own. You don't need to do anything.";
+      break;
+    case "failed":
+    default:
+      headline = "The last update didn't finish";
+      recommendedAction = {
+        label: "Review and recover",
+        detail: rollbackAvailable
+          ? "Restore the previous version below if the platform isn't behaving, then try the update again."
+          : "Check the details below, then try the update again.",
+      };
+      ifYouDoNothing =
+        "The platform stays on the previous version. Nothing else changes until you retry.";
+      break;
+  }
+
+  return {
+    state,
+    tone,
+    headline,
+    currentVersion,
+    availableVersion,
+    recommendedAction,
+    canKeepWorking,
+    keptLocally,
+    whatCouldGoWrong,
+    rollback,
+    ifYouDoNothing,
+    riskNotice,
+  };
+}

--- a/docs/superpowers/specs/2026-07-22-self-upgrade-owner-release-card-design.md
+++ b/docs/superpowers/specs/2026-07-22-self-upgrade-owner-release-card-design.md
@@ -1,0 +1,94 @@
+# Self-Upgrade owner-readable release status card
+
+- **Backlog item:** BI-8D87084D — "Self-upgrade page needs owner-readable release and rollback guidance"
+- **Epic:** EP-UX-COGLOAD — Live UX cognitive-load audit follow-up
+- **Status:** implemented
+- **Date:** 2026-07-22
+
+## Problem
+
+The live UX cognitive-load audit found `/ops/self-upgrade` reads like a runtime
+ledger, not an owner surface. Evidence: ~1,527 words, 46 visible actions, 52
+risk/action-word hits, and unexplained operational terms (`DELIVERY`, `RUNTIME`,
+`RELEASES`, `SECURITY`, `SOC`, `SUR-*`, `SUCCEEDED`, `SKIPPED`, `FAILED`). The
+first viewport is internal chrome and a runtime status row with a bare
+`Upgrade now` risk button — before a non-technical owner can answer the only
+questions they have:
+
+1. Is an update available?
+2. Is it safe — can the business keep working?
+3. Is one running / did the last one fail?
+4. Can it be undone?
+5. What is kept on my system?
+6. What happens if I do nothing?
+
+## Design grounding
+
+- **Specs/plans reviewed:** `docs/superpowers/specs/` self-upgrade surface —
+  BI-4A400DE4 (durable-cache-only impact summary on render), BI-D43EB266
+  (Self-Upgrade as the single operator update entry point, source-merge sub-step
+  folded in), BI-75C4A412 (content-based local-changes ledger). No existing spec
+  owns an owner-readable release summary — this creates a new, thin presenter
+  over the existing status contract, not a new substrate.
+- **Code substrate reviewed (`apps/web/`):** `getSelfUpgradeStatus()`
+  (`apps/web/lib/actions/promotions.ts`) already returns every field the summary
+  needs — `isFresh`, `targetSha`/`deployedSha`, `latestRun`, `latestRunImpact`,
+  `releaseBatch`, `blackoutUntil`, `nextWindowStart`, `platformVersion`. Plain-
+  language copy sources already exist: `describeSkipReason`
+  (`apps/web/lib/self-upgrade/skip-reason.ts`), `hasGovernedRecoveryPoint`
+  (`apps/web/lib/self-upgrade/rollback.ts`), `getLocalChangesLedger`
+  (`apps/web/lib/self-upgrade/local-changes-ledger.ts`). Card styling reuses the
+  report-kit palette (`apps/web/components/ui/report-kit/` — `Notice`,
+  `StatCard`), never a hand-rolled badge/KPI (AGENTS.md §12). Simple/Full is the
+  existing `dpf-nav-mode` cookie (`apps/web/lib/navigation/nav-mode.ts`).
+- **Decision:** extend the existing surface. The technical
+  `SelfUpgradeClient`, `PlatformUpdateApplyPanel`, and `LocalChangesLedger` are
+  preserved unchanged; only their placement changes.
+
+## Approach
+
+1. **Pure derivation** — `apps/web/lib/self-upgrade/owner-summary.ts`:
+   `buildOwnerReleaseSummary(input, localChanges)` maps the status object into an
+   `OwnerReleaseSummary` (state, tone, headline, current/available version,
+   recommended action, can-keep-working, kept-locally, what-could-go-wrong,
+   rollback, if-you-do-nothing, and a pre-action `riskNotice`). Pure and
+   prisma-free (the caller passes `rollbackAvailable` as a boolean), so the copy
+   and state machine are unit-tested (`owner-summary.test.ts`), including a
+   jargon guard asserting the owner strings never contain `SUR-`, `quiescence`,
+   `promoter`, `targetSha`, `SHA`, etc.
+2. **Presenter** — `apps/web/components/ops/OwnerReleaseCard.tsx`: a server
+   component composing report-kit `Notice`/`StatCard`, token-only colors.
+3. **Page** — `apps/web/app/(shell)/ops/self-upgrade/page.tsx` renders the owner
+   card first, then moves the technical controls/history/ledgers behind an
+   `<details>` "Advanced controls & history" disclosure. Simple (worker)
+   nav-mode collapses it by default; Full (operator) expands it.
+
+The risk-bearing `Upgrade now` / rollback controls keep their existing wiring
+inside `SelfUpgradeClient`; the owner card states consequence, reversibility,
+expected duration, and recovery path before the owner opens Advanced to act.
+
+## Research & benchmarking
+
+- **Windows Update / macOS Software Update** — lead with a one-line status
+  ("Your device is up to date" / "Update available"), a single primary action,
+  and "what's new" + "you can keep working" framing; advanced/technical detail is
+  a secondary disclosure. Adopted: status-first headline, one recommended action,
+  progressive disclosure of technical detail.
+- **Vercel / deployment dashboards** — surface build status + rollback
+  prominently. Adopted: explicit rollback/recovery answer. Rejected: exposing raw
+  build logs at the top level (that is the cognitive-load anti-pattern this item
+  fixes).
+
+## Acceptance mapping
+
+- Owner-readable release status card first — `OwnerReleaseCard` above the fold.
+- Current/available version, recommended action, keep-working, kept-locally,
+  what-could-go-wrong, rollback/recovery, do-nothing — fields on
+  `OwnerReleaseSummary`.
+- Technical run logs, SUR ids, runtime/security ledgers behind Advanced —
+  `<details>` disclosure.
+- Risk actions state consequence/reversibility/duration/recovery — `riskNotice`.
+- Simple mode hides technical ledger content — `<details open={!simple}>`.
+- UX smoke checks — `owner-summary.test.ts` (word/jargon/risk-copy/state) +
+  `page.test.tsx` (card-before-advanced ordering, disclosure marker, Simple/Full
+  default) + the mobile Playwright smoke covers the route.


### PR DESCRIPTION
Fixes the cognitive-load defect in **BI-8D87084D** (EP-UX-COGLOAD): `/ops/self-upgrade` read like a runtime ledger — SUR ids, RUNTIME/RELEASES/SECURITY tabs, SUCCEEDED/SKIPPED/FAILED, a bare `Upgrade now` button, ~1,527 words / 46 actions — before a non-technical owner could tell whether an update was available, safe, running, failed, reversible, or needed action.

## What changed
- **`apps/web/lib/self-upgrade/owner-summary.ts`** (new, pure) — `buildOwnerReleaseSummary()` derives a plain-language `OwnerReleaseSummary` from the existing `getSelfUpgradeStatus()` contract: state, headline, current/available version, recommended action, can-keep-working, what's-kept-locally, what-could-go-wrong, rollback/recovery, if-you-do-nothing, and a **consequence / reversibility / duration / recovery** `riskNotice` shown before the install action. Prisma-free (the caller passes `rollbackAvailable`) so it is unit-tested.
- **`apps/web/components/ops/OwnerReleaseCard.tsx`** (new, server) — composes report-kit `Notice`/`StatCard` (token-only, no hand-rolled badge, AGENTS.md §12).
- **`page.tsx`** — renders the card first, then wraps the unchanged `SelfUpgradeClient`, `PlatformUpdateApplyPanel`, and `LocalChangesLedger` behind a `<details>` **"Advanced controls & history"** disclosure that **Simple (worker) nav-mode collapses by default** and Full (operator) expands.

The risk-bearing `Upgrade now` / rollback controls keep their existing wiring inside `SelfUpgradeClient`; the card states the consequences up front.

## Acceptance mapping (BI-8D87084D)
- Owner-readable release status card first ✓ · current/available version, recommended action, keep-working, kept-locally, what-could-go-wrong, rollback/recovery, do-nothing ✓ · run logs / SUR ids / runtime+security ledgers behind Advanced ✓ · risk action states consequence/reversibility/duration/recovery ✓ · Simple mode hides technical ledger ✓
- UX smoke checks: `owner-summary.test.ts` (state machine, risk copy, **jargon-free** owner strings) + `page.test.tsx` (card-before-advanced ordering, disclosure marker, Simple/Full default).

## Design grounding
Extend the existing `/ops/self-upgrade` surface — not a new substrate. **Specs/plans reviewed:** `docs/superpowers/specs/` self-upgrade history (BI-4A400DE4, BI-D43EB266, BI-75C4A412) — none owned an owner-readable summary; new spec `docs/superpowers/specs/2026-07-22-self-upgrade-owner-release-card-design.md`. **Code substrate reviewed:** `apps/web/lib/actions/promotions.ts`, `apps/web/lib/self-upgrade/{skip-reason,rollback,local-changes-ledger}.ts`, `apps/web/components/ui/report-kit/`, `apps/web/lib/navigation/nav-mode.ts`.

UX-Fit-Decision: human_cognitive_load — progressive disclosure; owner card answers 5–6 plain questions with one recommended action, technical detail behind an Advanced `<details>` hidden in Simple mode. No net-new operator-configurable input.

Docs-Impact-Decision: `/ops/self-upgrade` is not in `DOCS_ROUTE_MAP` (no linked user-guide page); design captured in `docs/superpowers/specs/`.

Local-CI-Override: source-only worktree (no local vitest/tsc); the required CI **Unit Tests** + **Prod Build** jobs are the verification substrate for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
