### PR TITLE
fix(storefront): unmistakable Send-to-backlog completed state + valid metadata (BI-4F4252DB)

### DIFF
--- a/apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.test.ts
+++ b/apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.test.ts
@@ -102,8 +102,11 @@ describe("POST /api/storefront/admin/inquiries/[id]/product-backlog", () => {
     expect(mockBacklogItem.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          status: "triaging",
+          workType: "feature",
+          type: "product",
           source: "user-request",
+          status: "triaging",
+          priority: 2,
           digitalProductId: "dp_1",
         }),
       }),

--- a/apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.ts
+++ b/apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.ts
@@ -85,6 +85,10 @@ export async function POST(
       itemId: draft.itemId,
       title: draft.title,
       type: draft.type,
+      // Storefront inquiries are engaged product feature work, not a bug or
+      // chore. workType is nullable with no schema default, so it must be set
+      // explicitly or the item lands without an allocation basis (BI-4F4252DB).
+      workType: draft.workType,
       status: draft.status,
       source: draft.source,
       priority: draft.priority,

--- a/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { StorefrontInbox } from "./StorefrontInbox";
+
+afterEach(() => cleanup());
+
+const defaultDigitalProduct = { id: "dp_1", name: "Open Digital Product Factory" };
+
+function inquiry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "inq_1",
+    ref: "INQ-0001",
+    name: "Jane Prospect",
+    email: "jane@example.com",
+    type: "inquiry",
+    detail: "I want to run product ops on DPF.",
+    createdAt: "2026-07-20T10:00:00.000Z",
+    providerName: null,
+    status: "",
+    backlogItemId: null,
+    ...overrides,
+  };
+}
+
+describe("StorefrontInbox send-to-backlog state", () => {
+  it("offers an enabled Send to backlog action when the inquiry is untracked", () => {
+    render(
+      <StorefrontInbox entries={[inquiry()]} defaultDigitalProduct={defaultDigitalProduct} />,
+    );
+    const button = screen.getByRole("button", { name: /send inquiry INQ-0001 to backlog/i });
+    expect(button).toBeTruthy();
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("replaces the action with a completed marker and a direct link once tracked", () => {
+    render(
+      <StorefrontInbox
+        entries={[inquiry({ backlogItemId: "BI-SFI-INQ0001" })]}
+        defaultDigitalProduct={defaultDigitalProduct}
+      />,
+    );
+
+    // No lingering enabled action beside a tracked inquiry.
+    expect(screen.queryByRole("button", { name: /send inquiry INQ-0001 to backlog/i })).toBeNull();
+
+    // Unmistakable completed state plus an owner-readable link to the item.
+    expect(screen.getByText(/sent to backlog/i)).toBeTruthy();
+    const link = screen.getByRole("link", { name: /open backlog item BI-SFI-INQ0001 for inquiry INQ-0001/i });
+    expect(link.getAttribute("href")).toBe("/ops?itemId=BI-SFI-INQ0001");
+    expect(link.textContent).toContain("BI-SFI-INQ0001");
+  });
+
+  it("disables the action when backlog sending is unavailable", () => {
+    render(<StorefrontInbox entries={[inquiry()]} defaultDigitalProduct={null} />);
+    const button = screen.getByRole("button", { name: /send inquiry INQ-0001 to backlog/i });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -214,44 +214,66 @@ export function StorefrontInbox({
             </div>
             <div style={{ fontSize: 13 }}>{e.name ?? "Anonymous"} · {e.email}</div>
             {e.detail && <div className="text-[var(--dpf-muted)]" style={{ fontSize: 12, marginTop: 2 }}>{e.detail}</div>}
-            {e.type === "inquiry" && (
-              <div style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap", alignItems: "center" }}>
-                <button
-                  onClick={() => sendInquiryToProductBacklog(e.id)}
-                  disabled={!defaultDigitalProduct || pendingInquiryId === e.id}
-                  className="border border-[var(--dpf-accent)] text-[var(--dpf-accent)]"
-                  style={{
-                    padding: "3px 10px",
-                    borderRadius: 4,
-                    background: "none",
-                    cursor: !defaultDigitalProduct || pendingInquiryId === e.id ? "not-allowed" : "pointer",
-                    fontSize: 12,
-                    opacity: !defaultDigitalProduct || pendingInquiryId === e.id ? 0.6 : 1,
-                  }}
-                >
-                  {pendingInquiryId === e.id ? "Sending..." : "Send to backlog"}
-                </button>
-                {e.backlogItemId && (
-                  <span className="text-[var(--dpf-success)]" style={{ fontSize: 12 }}>
-                    Backlog item {e.backlogItemId}
-                  </span>
-                )}
-                {!e.backlogItemId && productBacklogState[e.id] && (
-                  <span
-                    className={productBacklogState[e.id].startsWith("BI-")
-                      ? "text-[var(--dpf-success)]"
-                      : "text-[var(--dpf-error)]"}
-                    style={{
-                      fontSize: 12,
-                    }}
-                  >
-                    {productBacklogState[e.id].startsWith("BI-")
-                      ? `Backlog item ${productBacklogState[e.id]}`
-                      : productBacklogState[e.id]}
-                  </span>
-                )}
-              </div>
-            )}
+            {e.type === "inquiry" && (() => {
+              // A successful send stores the created itemId (BI-…); anything
+              // else stored is an error message to surface for a retry.
+              const clientState = productBacklogState[e.id];
+              const clientItemId = clientState?.startsWith("BI-") ? clientState : null;
+              const errorMessage = clientState && !clientState.startsWith("BI-") ? clientState : null;
+              // Server-rendered link (existing item) OR the item we just made.
+              const backlogItemId = e.backlogItemId ?? clientItemId;
+              const isSending = pendingInquiryId === e.id;
+
+              return (
+                <div style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap", alignItems: "center" }}>
+                  {backlogItemId ? (
+                    // Terminal state: the inquiry is already tracked, so there is
+                    // no enabled "Send to backlog" action — only a completed
+                    // marker and a direct link to the created item.
+                    <>
+                      <span
+                        className="text-[var(--dpf-success)]"
+                        style={{ fontSize: 12, fontWeight: 600, display: "inline-flex", alignItems: "center", gap: 5 }}
+                      >
+                        <span aria-hidden="true">✓</span> Sent to backlog
+                      </span>
+                      <a
+                        href={`/ops?itemId=${encodeURIComponent(backlogItemId)}`}
+                        className="text-[var(--dpf-accent)]"
+                        style={{ fontSize: 12, textDecoration: "underline" }}
+                        aria-label={`Open backlog item ${backlogItemId} for inquiry ${e.ref}`}
+                      >
+                        {backlogItemId}
+                      </a>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        onClick={() => sendInquiryToProductBacklog(e.id)}
+                        disabled={!defaultDigitalProduct || isSending}
+                        aria-label={`Send inquiry ${e.ref} to backlog`}
+                        className="border border-[var(--dpf-accent)] text-[var(--dpf-accent)]"
+                        style={{
+                          padding: "3px 10px",
+                          borderRadius: 4,
+                          background: "none",
+                          cursor: !defaultDigitalProduct || isSending ? "not-allowed" : "pointer",
+                          fontSize: 12,
+                          opacity: !defaultDigitalProduct || isSending ? 0.6 : 1,
+                        }}
+                      >
+                        {isSending ? "Sending..." : "Send to backlog"}
+                      </button>
+                      {errorMessage && (
+                        <span className="text-[var(--dpf-error)]" role="alert" style={{ fontSize: 12 }}>
+                          {errorMessage}
+                        </span>
+                      )}
+                    </>
+                  )}
+                </div>
+              );
+            })()}
             {e.type === "booking" && (
               <div style={{ display: "flex", gap: 6, marginTop: 8 }}>
                 {e.status === "pending" && (

--- a/apps/web/lib/governed-backlog-workflow.test.ts
+++ b/apps/web/lib/governed-backlog-workflow.test.ts
@@ -100,10 +100,40 @@ describe("deriveLifecycleLabel", () => {
       itemId: "BI-SFI-INQ1001",
       title: "Emergency Call-Out inquiry from Jane Prospect (INQ-1001)",
       type: "product",
+      workType: "feature",
       status: "triaging",
       source: "user-request",
+      priority: 2,
       signalLabel: "customer-zero",
       recommendedTriageOutcome: "build",
     });
+  });
+
+  it("leads the title with the owner-readable label, not an opaque ref code", () => {
+    const draft = createStorefrontInquiryBacklogDraft({
+      inquiryId: "inquiry_2",
+      inquiryRef: "INQ-2002",
+      customerName: "Sam Buyer",
+      customerEmail: "sam@example.com",
+      message: "Interested in a bespoke build.",
+      itemLabel: "Emergency Call-Out",
+    });
+    // The readable product/request label must be the first visible words so an
+    // owner scanning the backlog sees what the inquiry is about, not a code.
+    expect(draft.title.startsWith("Emergency Call-Out")).toBe(true);
+    expect(draft.title).not.toMatch(/^(BI-|INQ-)/);
+  });
+
+  it("falls back to a readable subject word when no item label is available", () => {
+    const draft = createStorefrontInquiryBacklogDraft({
+      inquiryId: "inquiry_3",
+      inquiryRef: "INQ-3003",
+      customerName: "Pat Lead",
+      customerEmail: "pat@example.com",
+      message: "General question.",
+    });
+    // No opaque code as the first visible word even without an item label.
+    expect(draft.title).toBe("Inquiry from Pat Lead (INQ-3003)");
+    expect(draft.title).not.toMatch(/^(BI-|INQ-)/);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the Storefront Inbox **Send to backlog** owner action so a successful conversion has an unmistakable completed state and creates valid backlog metadata (BI-4F4252DB).

Before: the action stayed enabled beside inquiries that were already tracked, there was no direct owner-readable link to the created item, and the API omitted `workType` so intake items landed without an allocation basis.

## Changes

- **`apps/web/components/storefront-admin/StorefrontInbox.tsx`** — once an inquiry has a backlog item (server-rendered `e.backlogItemId` **or** a fresh create), the enabled *Send to backlog* button is replaced with a **✓ Sent to backlog** marker plus a direct **`/ops?itemId=…`** link to the created item. A failed attempt keeps a retryable action and surfaces the error (`role="alert"`).
- **`apps/web/app/api/storefront/admin/inquiries/[id]/product-backlog/route.ts`** — persist `workType: "feature"` (nullable column, no schema default) so the item carries an allocation basis.
- **Tests** — the route test now asserts `workType`, `type`, `source`, `status`, `priority`, and `digitalProductId` on the created item. `governed-backlog-workflow.test.ts` locks the readable-title contract (leads with the owner-readable product/request label, never an opaque `INQ-`/`BI-` code, including the no-label fallback). New `StorefrontInbox.test.tsx` covers the completed-state + link and the disabled/unavailable case.

## Overlap reconciliation

PR #3387 (BI-3DA1DFDC) already delivers the booking **Confirm/Cancel** row-specific accessible labels via the shared `reservationActionLabel` helper. The BI made booking labels optional ("if it fits cleanly; otherwise file/leave linked to BI-7D7EE150"). To stay additive, this change **does not touch** the booking-button region — it is fully disjoint from #3387. Booking-label a11y is covered by #3387 / BI-7D7EE150.

## Design grounding

- **Design-Grounding-Decision:** trivial no-contract-change edit — completes an existing owner action on `apps/web/components/storefront-admin/StorefrontInbox.tsx`; no spec under `docs/superpowers/specs/` governs this micro-interaction. Source of truth: `apps/web/lib/governed-backlog-workflow.ts` (storefront intake metadata contract).
- **Docs-Impact:** none — self-evident inbox UX.
- **Module-Size:** `StorefrontInbox.tsx` grows ~40 net lines for the completed-state branch; not a shrink.

## Testing

- `apps/web` vitest — `governed-backlog-workflow.test.ts` + `StorefrontInbox.test.tsx`: **14 passed**.
- The route test (`product-backlog/route.test.ts`) cannot run in this source-only worktree (the `next` binary/files are absent, so `next/server` specs can't transform); CI runs it. Local typecheck was skipped for the same reason (`DPF_SKIP_TYPECHECK=1`); CI's Typecheck gate still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)