### PR TITLE
feat(storefront-admin): tap-safe owner controls + owner-outcome field labels (BI-F0B389C9)

### DIFF
--- a/apps/web/components/admin/OperatingHoursEditor.test.tsx
+++ b/apps/web/components/admin/OperatingHoursEditor.test.tsx
@@ -28,7 +28,7 @@ describe("OperatingHoursEditor save feedback", () => {
 describe("OperatingHoursEditor timezone options", () => {
   it("labels zones with a UTC-offset prefix and a de-underscored name", () => {
     render(<OperatingHoursEditor defaultSchedule={schedule} timezone="America/New_York" onSave={vi.fn()} />);
-    const select = screen.getByLabelText("Operating hours timezone") as HTMLSelectElement;
+    const select = screen.getByLabelText(/Business timezone/i) as HTMLSelectElement;
     const selected = Array.from(select.options).find((o) => o.value === "America/New_York");
     // Orthodox: "(UTC−05:00) America/New York" — offset prefix, no underscore.
     expect(selected?.textContent).toMatch(/^\(UTC[+−±]\d{2}:\d{2}\) America\/New York$/);
@@ -37,7 +37,7 @@ describe("OperatingHoursEditor timezone options", () => {
 
   it("orders options by UTC offset, not raw alphabetical", () => {
     render(<OperatingHoursEditor defaultSchedule={schedule} timezone="America/Chicago" onSave={vi.fn()} />);
-    const select = screen.getByLabelText("Operating hours timezone") as HTMLSelectElement;
+    const select = screen.getByLabelText(/Business timezone/i) as HTMLSelectElement;
     const offsets = Array.from(select.options).map((o) => {
       const m = o.textContent?.match(/^\(UTC([+−±])(\d{2}):(\d{2})\)/);
       if (!m) return 0;

--- a/apps/web/components/admin/OperatingHoursEditor.tsx
+++ b/apps/web/components/admin/OperatingHoursEditor.tsx
@@ -180,13 +180,14 @@ export function OperatingHoursEditor({ defaultSchedule, timezone, onSave, saving
           </label>
           <select
             id="op-hours-tz"
+            name="operatingHoursTimezone"
             value={tz}
             onChange={(e) => {
               setTz(e.target.value);
               setSaved(false);
             }}
-            aria-label="Operating hours timezone"
-            className="px-2 py-1 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] text-sm"
+            aria-label="Business timezone — bookings and the maintenance window use this zone"
+            className="min-h-[44px] max-w-full px-2 py-1 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] text-sm"
           >
             {zones.map((z) => (
               <option key={z.value} value={z.value} className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">
@@ -219,49 +220,60 @@ export function OperatingHoursEditor({ defaultSchedule, timezone, onSave, saving
           return (
             <div
               key={day}
-              className="flex items-center gap-3 p-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)]"
+              className="flex flex-wrap items-center gap-x-3 gap-y-2 p-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)]"
             >
-              {/* Toggle */}
+              {/* Open/closed toggle — 44px hit area wraps the small visual switch. */}
               <button
                 type="button"
+                role="switch"
+                aria-checked={d.enabled}
+                aria-label={`Open on ${DAY_LABELS[day]}`}
                 onClick={() => updateDay(day, { enabled: !d.enabled })}
-                className={`w-10 h-5 rounded-full transition-colors relative shrink-0 ${
-                  d.enabled
-                    ? "bg-[var(--dpf-accent)]"
-                    : "bg-[var(--dpf-muted-foreground)]/30"
-                }`}
+                className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] shrink-0 rounded-md"
               >
                 <span
-                  className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
-                    d.enabled ? "left-5" : "left-0.5"
+                  className={`relative block h-5 w-10 rounded-full transition-colors ${
+                    d.enabled ? "bg-[var(--dpf-accent)]" : "bg-[var(--dpf-border-strong)]"
                   }`}
-                />
+                >
+                  <span
+                    className={`absolute top-0.5 h-4 w-4 rounded-full bg-[var(--dpf-surface-1)] transition-transform ${
+                      d.enabled ? "left-5" : "left-0.5"
+                    }`}
+                  />
+                </span>
               </button>
 
               {/* Day label */}
               <span
-                className={`w-24 text-sm font-medium ${
+                className={`w-20 shrink-0 text-sm font-medium sm:w-24 ${
                   d.enabled ? "text-[var(--dpf-text)]" : "text-[var(--dpf-muted)]"
                 }`}
               >
                 {DAY_LABELS[day]}
               </span>
 
-              {/* Time pickers */}
+              {/* Time pickers — each labelled by owner outcome so assistive tech and
+                  the mobile audit read "Monday opens" / "Monday closes", not two
+                  anonymous 09:00 fields. Wraps to its own line on narrow phones. */}
               {d.enabled ? (
-                <div className="flex items-center gap-2 text-sm">
+                <div className="flex flex-wrap items-center gap-2 text-sm">
                   <input
                     type="time"
+                    name={`${day}-opens`}
                     value={d.open}
                     onChange={(e) => updateDay(day, { open: e.target.value })}
-                    className="px-2 py-1 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] text-sm"
+                    aria-label={`${DAY_LABELS[day]} opens`}
+                    className="min-h-[44px] px-2 py-1 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] text-sm"
                   />
                   <span className="text-[var(--dpf-muted)]">to</span>
                   <input
                     type="time"
+                    name={`${day}-closes`}
                     value={d.close}
                     onChange={(e) => updateDay(day, { close: e.target.value })}
-                    className="px-2 py-1 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] text-sm"
+                    aria-label={`${DAY_LABELS[day]} closes`}
+                    className="min-h-[44px] px-2 py-1 rounded bg-[var(--dpf-surface-2)] border border-[var(--dpf-border)] text-[var(--dpf-text)] text-sm"
                   />
                 </div>
               ) : (

--- a/apps/web/components/storefront-admin/ItemsManager.tsx
+++ b/apps/web/components/storefront-admin/ItemsManager.tsx
@@ -186,7 +186,7 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
         </h2>
         <button
           onClick={openCreate}
-          className="px-3 py-1.5 text-xs font-medium rounded-md transition-colors bg-[var(--dpf-accent)] text-white"
+          className="inline-flex min-h-[44px] items-center px-4 py-1.5 text-xs font-medium rounded-md transition-colors bg-[var(--dpf-accent)] text-white"
         >
           {vocabulary.addButtonLabel}
         </button>
@@ -197,7 +197,8 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
         <div className="flex gap-1 mb-4 flex-wrap">
           <button
             onClick={() => setActiveCategory(null)}
-            className={`px-2.5 py-1 text-[10px] font-medium rounded-full transition-colors ${
+            aria-label="Show all"
+            className={`inline-flex min-h-[44px] items-center px-3 py-1 text-[10px] font-medium rounded-full transition-colors ${
               activeCategory === null
                 ? "bg-[var(--dpf-accent)] text-white"
                 : "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
@@ -209,7 +210,8 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
             <button
               key={cat}
               onClick={() => setActiveCategory(cat === activeCategory ? null : cat)}
-              className={`px-2.5 py-1 text-[10px] font-medium rounded-full transition-colors ${
+              aria-label={`Filter to ${cat}`}
+              className={`inline-flex min-h-[44px] items-center px-3 py-1 text-[10px] font-medium rounded-full transition-colors ${
                 activeCategory === cat
                   ? "bg-[var(--dpf-accent)] text-white"
                   : "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
@@ -232,7 +234,7 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
               onDragStart={() => handleDragStart(idx)}
               onDragOver={(e) => handleDragOver(e, idx)}
               onDragEnd={handleDragEnd}
-              className="flex items-center gap-3 p-3 rounded-lg transition-colors cursor-grab active:cursor-grabbing"
+              className="flex flex-wrap items-center gap-3 p-3 rounded-lg transition-colors cursor-grab active:cursor-grabbing"
               style={{
                 background: dragIdx === idx ? "var(--dpf-surface-2)" : "var(--dpf-surface-1)",
                 opacity: item.isActive ? 1 : 0.5,
@@ -270,26 +272,35 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
                 </span>
               </div>
 
-              {/* Actions */}
+              {/* Actions — visually compact but each carries a row-specific
+                  accessible label ("Show Table for 2 …", "Edit …", "Delete …")
+                  and a 44px hit area so they are safe to tap on a phone. */}
               <div className="flex items-center gap-1 shrink-0">
                 <button
                   onClick={() => toggleActive(item.id, !item.isActive)}
-                  className={`text-[10px] px-2 py-0.5 rounded border border-[var(--dpf-border)] hover:bg-[var(--dpf-surface-2)] transition-colors ${item.isActive ? "text-[var(--dpf-success)]" : "text-[var(--dpf-muted)]"}`}
-                  title={item.isActive ? "Deactivate" : "Activate"}
+                  className={`inline-flex items-center justify-center min-h-[44px] min-w-[44px] text-[10px] px-2 rounded border border-[var(--dpf-border)] hover:bg-[var(--dpf-surface-2)] transition-colors ${item.isActive ? "text-[var(--dpf-success)]" : "text-[var(--dpf-muted)]"}`}
+                  aria-label={
+                    item.isActive
+                      ? `Hide ${item.name} from your public page`
+                      : `Show ${item.name} on your public page`
+                  }
+                  title={item.isActive ? `Hide ${item.name}` : `Show ${item.name}`}
                 >
                   {item.isActive ? "On" : "Off"}
                 </button>
                 <button
                   onClick={() => openEdit(item)}
-                  className="text-[10px] px-2 py-0.5 rounded border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] transition-colors"
-                  title="Edit"
+                  className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] text-[10px] px-2 rounded border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] transition-colors"
+                  aria-label={`Edit ${item.name}`}
+                  title={`Edit ${item.name}`}
                 >
                   Edit
                 </button>
                 <button
                   onClick={() => handleDelete(item)}
-                  className="text-[10px] px-2 py-0.5 rounded border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-error)] hover:border-[var(--dpf-error)]/30 transition-colors"
-                  title="Delete"
+                  className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] text-[10px] px-2 rounded border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-error)] hover:border-[var(--dpf-error)]/30 transition-colors"
+                  aria-label={`Delete ${item.name}`}
+                  title={`Delete ${item.name}`}
                 >
                   Del
                 </button>

--- a/apps/web/components/storefront-admin/SectionsManager.tsx
+++ b/apps/web/components/storefront-admin/SectionsManager.tsx
@@ -37,20 +37,39 @@ export function SectionsManager({ storefrontId, sections: initial }: { storefron
     <div>
       <h2 style={{ fontSize: 15, fontWeight: 600, marginBottom: 16 }}>Sections</h2>
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        {sections.map((s, idx) => (
-          <div key={s.id} className="border border-[var(--dpf-border)]" style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 12px", borderRadius: 6 }}>
-            <div style={{ flex: 1 }}>
-              <span style={{ fontWeight: 600, fontSize: 13 }}>{s.title ?? s.type}</span>
+        {sections.map((s, idx) => {
+          const name = s.title ?? s.type;
+          return (
+          <div key={s.id} className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--dpf-border)] px-3 py-2.5">
+            <div className="min-w-0 flex-1">
+              <span style={{ fontWeight: 600, fontSize: 13 }}>{name}</span>
               <span className="text-[var(--dpf-muted)]" style={{ fontSize: 11, marginLeft: 6 }}>{s.type}</span>
             </div>
-            <button onClick={() => moveSection(s.id, "up")} disabled={idx === 0} className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)]" style={{ fontSize: 12, padding: "2px 8px", borderRadius: 4, cursor: "pointer" }}>↑</button>
-            <button onClick={() => moveSection(s.id, "down")} disabled={idx === sections.length - 1} className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)]" style={{ fontSize: 12, padding: "2px 8px", borderRadius: 4, cursor: "pointer" }}>↓</button>
-            <button onClick={() => toggleVisibility(s.id, !s.isVisible)}
-              className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)]" style={{ fontSize: 12, padding: "2px 8px", borderRadius: 4, cursor: "pointer" }}>
+            {/* Reorder / visibility — row-specific accessible labels and 44px hit
+                areas so the arrows and Hide/Show are safe to tap and screen-reader
+                legible ("Move Hero up", "Hide Hero section") rather than anonymous. */}
+            <button
+              onClick={() => moveSection(s.id, "up")}
+              disabled={idx === 0}
+              aria-label={`Move ${name} up`}
+              className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] text-sm disabled:opacity-40"
+            >↑</button>
+            <button
+              onClick={() => moveSection(s.id, "down")}
+              disabled={idx === sections.length - 1}
+              aria-label={`Move ${name} down`}
+              className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] text-sm disabled:opacity-40"
+            >↓</button>
+            <button
+              onClick={() => toggleVisibility(s.id, !s.isVisible)}
+              aria-label={s.isVisible ? `Hide ${name} section from your public page` : `Show ${name} section on your public page`}
+              className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] px-3 text-xs"
+            >
               {s.isVisible ? "Hide" : "Show"}
             </button>
           </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/docs/superpowers/plans/2026-07-22-owner-surfaces-cognitive-load.md
+++ b/docs/superpowers/plans/2026-07-22-owner-surfaces-cognitive-load.md
@@ -1,0 +1,53 @@
+# Owner-admin storefront: mobile tap-safety + outcome labels (EP-UX-COGLOAD)
+
+- **Epic:** EP-UX-COGLOAD — Live UX cognitive-load audit follow-up
+- **Primary item:** BI-F0B389C9 (Storefront owner mobile setup — tap-safe responsive controls)
+- **Cross-checked acceptance:** BI-7D7EE150, BI-C39DC90C (row-specific mutation labels), BI-8E74C749 (owner-outcome field labels)
+- **Source of truth:** EP-UX-COGLOAD backlog acceptance criteria.
+- **Date:** 2026-07-22
+
+## Scope (deliberately narrow — coordinated with sibling PRs)
+
+The 390px owner-mobile audit spans many surfaces; this epic is being landed as
+several non-overlapping PRs. This PR covers **only** the owner-**admin** storefront
+controls that no sibling PR touches:
+
+- `components/storefront-admin/ItemsManager.tsx`
+- `components/storefront-admin/SectionsManager.tsx`
+- `components/admin/OperatingHoursEditor.tsx`
+
+Explicitly **out of scope here** (owned by concurrent PRs, to avoid conflicts):
+
+- Mobile shell / primary-nav collapse + `globals.css` + usability-standards →
+  **#3392** (shell owner-chrome action-result contract).
+- `/ops/self-upgrade` owner-readable release card (BI-8D87084D) → **#3391**.
+- `StorefrontInbox` booking confirm/cancel handoff (BI-3DA1DFDC) → **#3387**.
+- Service-line add/remove recovery + `/storefront` setup model (BI-C39DC90C) → **#3389**.
+- Public restaurant storefront 390px (BI-2B2FCB2B) → **#3390**.
+
+## Changes
+
+1. **Tap-safe controls (WCAG 2.5.8, 44px).** Every mutation/reorder/toggle control in
+   the items and sections managers, and the operating-hours day toggle, presents a
+   44×44 hit area (inline `min-h-[44px] min-w-[44px] inline-flex …`); the item Add
+   button and category filter chips get a 44px min height. Rows wrap (`flex-wrap`)
+   instead of overflowing at 390px.
+2. **Row-specific accessible labels.** Terse repeated controls carry a row-specific
+   `aria-label` naming their target: `Show/Hide <item> on your public page`,
+   `Edit <item>`, `Delete <item>`, `Move <section> up/down`,
+   `Hide/Show <section> section …`. Visible glyphs stay compact.
+3. **Owner-outcome field labels (operations).** Each time input is labelled
+   `Monday opens` / `Monday closes` with a stable `name`; the timezone select is
+   labelled by outcome (`Business timezone — bookings and the maintenance window use
+   this zone`); the day rows wrap so `/storefront/settings/operations` no longer
+   overflows horizontally at 390px.
+
+No new shared CSS/util files, no route-ownership change — the tap-target utilities
+are applied inline so this PR shares no file with the shell/standards PR (#3392).
+
+## Verification
+
+- `components/admin/OperatingHoursEditor.test.tsx` — updated for the outcome label.
+- `e2e/ux-owner-mobile-cognitive-load.spec.ts` — 390px assertions for operations
+  field labels + no-overflow, and sections/items 44px hit areas + row labels.
+- vitest green for the touched components; project typecheck via CI.

--- a/e2e/ux-owner-mobile-cognitive-load.spec.ts
+++ b/e2e/ux-owner-mobile-cognitive-load.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Owner-admin storefront cognitive-load UX smoke checks (EP-UX-COGLOAD / BI-F0B389C9).
+ *
+ * Scoped to the owner-admin controls this PR owns — items, sections, and operating
+ * hours. Sibling PRs cover the mobile shell (#3392), self-upgrade (#3391), inbox
+ * (#3387), and setup recovery (#3389), so this spec deliberately does not assert on
+ * those surfaces.
+ *
+ * At a 390px phone width: owner setup fields carry outcome labels, mutation controls
+ * meet a 44px hit area with row-specific accessible labels, and the operations
+ * editor does not overflow horizontally.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { loginToDPF } from "./helpers";
+
+const PHONE = { width: 390, height: 844 };
+
+async function gotoSettled(page: Page, path: string): Promise<string> {
+  await page.goto(path);
+  await page.waitForLoadState("networkidle", { timeout: 15_000 }).catch(() => {});
+  return new URL(page.url()).pathname;
+}
+
+async function expectNoHorizontalOverflow(page: Page, path: string): Promise<void> {
+  const { scrollW, clientW } = await page.evaluate(() => ({
+    scrollW: document.documentElement.scrollWidth,
+    clientW: document.documentElement.clientWidth,
+  }));
+  expect(
+    scrollW,
+    `${path}: horizontal overflow — scrollWidth ${scrollW} > clientWidth ${clientW} at ${PHONE.width}px`,
+  ).toBeLessThanOrEqual(clientW + 1);
+}
+
+test.describe("Owner-admin storefront — mobile cognitive load", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(PHONE);
+    await loginToDPF(page);
+  });
+
+  test("operations time inputs are labelled by owner outcome and don't overflow", async ({ page }) => {
+    const landed = await gotoSettled(page, "/storefront/settings/operations");
+    test.skip(landed.includes("/login") || landed.includes("/setup"), `redirected to ${landed}`);
+
+    // Accessible names tie each control to a business outcome, not an anonymous 09:00.
+    await expect(page.getByLabel("Monday opens")).toBeVisible();
+    await expect(page.getByLabel("Monday closes")).toBeVisible();
+    await expect(page.getByLabel(/Business timezone/i)).toBeVisible();
+
+    // The day rows wrap instead of forcing page-level horizontal scroll.
+    await expectNoHorizontalOverflow(page, "/storefront/settings/operations");
+  });
+
+  test("sections controls meet a 44px hit area with row-specific labels", async ({ page }) => {
+    const landed = await gotoSettled(page, "/storefront/sections");
+    test.skip(landed.includes("/login") || landed.includes("/setup"), `redirected to ${landed}`);
+
+    // Row controls carry row-specific accessible labels (not bare arrows / Hide).
+    const controls = page.getByRole("button", { name: /^(Move|Hide|Show) .+/ });
+    const count = await controls.count();
+    test.skip(count === 0, "no sections rendered in this environment");
+
+    for (let i = 0; i < Math.min(count, 6); i++) {
+      const box = await controls.nth(i).boundingBox();
+      expect(box, `control ${i} has no box`).not.toBeNull();
+      if (!box) continue;
+      expect(
+        box.width >= 44 && box.height >= 44,
+        `sections control ${i} hit area ${Math.round(box.width)}x${Math.round(box.height)} < 44x44`,
+      ).toBeTruthy();
+    }
+  });
+
+  test("items controls carry row-specific accessible labels", async ({ page }) => {
+    const landed = await gotoSettled(page, "/storefront/items");
+    test.skip(landed.includes("/login") || landed.includes("/setup"), `redirected to ${landed}`);
+
+    const editControls = page.getByRole("button", { name: /^Edit .+/ });
+    const count = await editControls.count();
+    test.skip(count === 0, "no items rendered in this environment");
+
+    // Every Edit/Delete carries the item name, and meets the 44px hit area.
+    const box = await editControls.first().boundingBox();
+    expect(box).not.toBeNull();
+    if (box) {
+      expect(
+        box.width >= 44 && box.height >= 44,
+        `items Edit hit area ${Math.round(box.width)}x${Math.round(box.height)} < 44x44`,
+      ).toBeTruthy();
+    }
+    await expect(page.getByRole("button", { name: /^Delete .+/ }).first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

EP-UX-COGLOAD owner-admin slice. Fixes the owner-admin storefront controls from the 390px owner-mobile audit (BI-F0B389C9), scoped to files **no sibling EP-UX-COGLOAD PR touches**.

- **ItemsManager / SectionsManager** — 44px hit areas on every mutation/reorder/toggle control (inline `min-h-[44px] min-w-[44px]` utilities), plus row-specific accessible labels: `Show/Hide <item> on your public page`, `Edit <item>`, `Delete <item>`, `Move <section> up/down`, `Hide/Show <section> section …`. Rows wrap (`flex-wrap`) instead of overflowing at 390px.
- **OperatingHoursEditor** — each time input labelled by owner outcome (`Monday opens` / `Monday closes`) with a stable `name`; timezone select labelled by outcome; day rows wrap so `/storefront/settings/operations` no longer overflows horizontally at 390px.

## Scope & overlap

This is deliberately narrow to avoid conflicts with concurrent EP-UX-COGLOAD PRs. Intentionally **not** touched here:
- Mobile shell / nav collapse + `globals.css` + usability-standards → **#3392**
- `/ops/self-upgrade` owner card (BI-8D87084D) → **#3391**
- `StorefrontInbox` booking handoff (BI-3DA1DFDC) → **#3387**
- Service-line recovery + `/storefront` setup (BI-C39DC90C) → **#3389**
- Public restaurant storefront 390px (BI-2B2FCB2B) → **#3390**

Tap-target utilities are applied inline (no shared `globals.css`/standards edit) so this PR shares no file with any open PR.

## Tests
- `OperatingHoursEditor.test.tsx` updated for the outcome label.
- `e2e/ux-owner-mobile-cognitive-load.spec.ts` — 390px operations field labels + no-overflow; sections/items 44px hit areas + row-specific labels.
- Local: vitest green for OperatingHoursEditor + storefront-admin (9 files / 21 tests). Pre-commit typecheck skipped (source-only worktree); CI gates typecheck + Playwright.

## Backlog
- Primary: BI-F0B389C9. Cross-checks: BI-7D7EE150, BI-C39DC90C (row-specific labels), BI-8E74C749 (owner-outcome field labels).

Design-Grounding-Decision: New artifact docs/superpowers/plans/2026-07-22-owner-surfaces-cognitive-load.md. SSOT = EP-UX-COGLOAD backlog acceptance. apps/web storefront-admin + admin components only; no contract/route-ownership change; shell/globals/usability-standards left to #3392.
UX-Fit-Decision: Reduces human_cognitive_load — labels and tap-sizes existing controls; adds no operator-configurable control and asks the layman to type nothing.
Seed-Fit-Decision: none — no seed or reference-data change.
Docs-Impact: plan added under docs/superpowers/plans; no user-facing doc route change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)