### PR TITLE
fix(storefront): customer trust, brand & archetype-gated journeys for public Restaurant storefront (BI-4A68EDF6)

### DIFF
--- a/apps/web/app/(storefront)/s/[slug]/book/[itemId]/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/book/[itemId]/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import { getPublicStorefront, getPublicItem, resolveInquiryFormSchema } from "@/lib/storefront-data";
+import { resolveTrustProfile } from "@/lib/storefront/public-trust";
 import { SlotBookingFlow } from "@/components/storefront/SlotBookingFlow";
 import { resolveResourceVocabulary } from "@/lib/storefront/resource-vocabulary";
 
@@ -16,6 +18,8 @@ export default async function BookItemPage({
   if (!storefront || !item) notFound();
 
   const formSchema = await resolveInquiryFormSchema(storefront.archetypeId);
+  const trust = resolveTrustProfile(storefront.archetypeCategory);
+  const capitalizedNoun = trust.bookingNoun.charAt(0).toUpperCase() + trust.bookingNoun.slice(1);
 
   // For a capacity archetype (Restaurant FLOOR), availability reads in table
   // terms; other archetypes keep generic booking copy (BI-7C95A586).
@@ -24,7 +28,30 @@ export default async function BookItemPage({
 
   return (
     <div style={{ paddingTop: 40, maxWidth: 520 }}>
-      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>Book: {item.name}</h1>
+      <p style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.05em", textTransform: "uppercase", color: "var(--dpf-muted)", margin: "0 0 4px" }}>
+        {capitalizedNoun} request
+      </p>
+      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8, color: "var(--dpf-text)" }}>Book: {item.name}</h1>
+
+      <div
+        style={{
+          marginBottom: 20,
+          padding: "14px 16px",
+          borderRadius: 10,
+          border: "1px solid var(--dpf-border)",
+          background: "var(--dpf-surface-1)",
+        }}
+      >
+        <p style={{ fontSize: 14, lineHeight: 1.6, color: "var(--dpf-text)", margin: "0 0 6px" }}>
+          {trust.bookingPolicy}
+        </p>
+        {trust.dietaryNote && (
+          <p style={{ fontSize: 13, lineHeight: 1.6, color: "var(--dpf-muted)", margin: 0 }}>
+            {trust.dietaryNote}
+          </p>
+        )}
+      </div>
+
       <SlotBookingFlow
         orgSlug={slug}
         itemId={item.itemId}
@@ -35,6 +62,13 @@ export default async function BookItemPage({
         formSchema={formSchema}
         resourceNoun={resourceNoun}
       />
+
+      <p style={{ marginTop: 16, fontSize: 13, color: "var(--dpf-muted)" }}>
+        {trust.cancellationPolicy}{" "}
+        <Link href={`/s/${slug}/inquire`} style={{ color: "var(--dpf-accent)" }}>Contact {storefront.orgName}</Link>
+        {" · "}
+        <Link href={`/s/${slug}/policies`} style={{ color: "var(--dpf-accent)" }}>Full policy</Link>
+      </p>
     </div>
   );
 }

--- a/apps/web/app/(storefront)/s/[slug]/checkout/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/checkout/page.tsx
@@ -1,11 +1,28 @@
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import { prisma } from "@dpf/db";
 
-const TYPE_LABELS: Record<string, { title: string; icon: string }> = {
-  booking: { title: "Booking confirmed!", icon: "📅" },
-  inquiry: { title: "Enquiry received!", icon: "✉️" },
-  order: { title: "Order placed!", icon: "📦" },
-  donation: { title: "Thank you for your donation!", icon: "❤️" },
+const TYPE_LABELS: Record<string, { title: string; icon: string; next: string }> = {
+  booking: {
+    title: "Booking request received",
+    icon: "📅",
+    next: "We'll review your request and confirm your booking by email or phone. Keep your reference in case you need to change it.",
+  },
+  inquiry: {
+    title: "Enquiry received",
+    icon: "✉️",
+    next: "Thanks for getting in touch — we've received your message and will reply as soon as we can, usually within one business day.",
+  },
+  order: {
+    title: "Order placed",
+    icon: "📦",
+    next: "We've received your order and will be in touch with confirmation and next steps.",
+  },
+  donation: {
+    title: "Thank you for your donation",
+    icon: "❤️",
+    next: "Your support means a great deal. A receipt will be sent to your email.",
+  },
 };
 
 export default async function CheckoutPage({
@@ -59,17 +76,33 @@ export default async function CheckoutPage({
 
   if (!refValid) notFound();
 
-  const meta = TYPE_LABELS[type] ?? { title: "Confirmed!", icon: "✓" };
+  const meta = TYPE_LABELS[type] ?? {
+    title: "Received",
+    icon: "✓",
+    next: "We've received your request and will be in touch shortly.",
+  };
 
   return (
-    <div style={{ textAlign: "center", padding: "80px 0" }}>
-      <div style={{ fontSize: 48, marginBottom: 16 }}>{meta.icon}</div>
-      <h1 style={{ fontSize: 28, fontWeight: 700, marginBottom: 8 }}>{meta.title}</h1>
-      <p style={{ color: "var(--dpf-muted)", fontSize: 15, marginBottom: 4 }}>
-        Reference: <strong>{ref}</strong>
-      </p>
+    <div style={{ maxWidth: 520, margin: "0 auto", padding: "72px 0", textAlign: "center" }}>
+      <div style={{ fontSize: 48, marginBottom: 16 }} aria-hidden="true">{meta.icon}</div>
+      <h1 style={{ fontSize: 28, fontWeight: 700, marginBottom: 12, color: "var(--dpf-text)" }}>{meta.title}</h1>
+      <div
+        style={{
+          display: "inline-block",
+          padding: "6px 14px",
+          borderRadius: 999,
+          border: "1px solid var(--dpf-border)",
+          background: "var(--dpf-surface-1)",
+          fontSize: 14,
+          color: "var(--dpf-text)",
+          marginBottom: 16,
+        }}
+      >
+        Reference <strong>{ref}</strong>
+      </div>
       {bookingDetail && (
-        <p style={{ color: "var(--dpf-muted)", fontSize: 14, marginBottom: 4 }}>
+        <p style={{ color: "var(--dpf-text)", fontSize: 15, marginBottom: 12 }}>
+          {bookingDetail.customerName ? `${bookingDetail.customerName} · ` : ""}
           {new Date(bookingDetail.scheduledAt).toLocaleString(undefined, {
             weekday: "long",
             year: "numeric",
@@ -81,12 +114,42 @@ export default async function CheckoutPage({
           {` · ${bookingDetail.durationMinutes} min`}
         </p>
       )}
-      <p style={{ color: "var(--dpf-muted)", fontSize: 14 }}>
-        {"We'll be in touch shortly. You can return to "}
-        <a href={`/s/${slug}`} style={{ color: "var(--dpf-accent, #4f46e5)" }}>
-          the storefront
-        </a>.
+      <p style={{ color: "var(--dpf-muted)", fontSize: 15, lineHeight: 1.6, marginBottom: 24 }}>
+        {meta.next}
       </p>
+      <div style={{ display: "flex", gap: 10, justifyContent: "center", flexWrap: "wrap" }}>
+        <Link
+          href={`/s/${slug}`}
+          style={{
+            display: "inline-block",
+            padding: "10px 18px",
+            borderRadius: 8,
+            fontSize: 14,
+            fontWeight: 600,
+            textDecoration: "none",
+            background: "var(--dpf-accent)",
+            color: "var(--dpf-surface-1)",
+          }}
+        >
+          Back to home
+        </Link>
+        <Link
+          href={`/s/${slug}/inquire`}
+          style={{
+            display: "inline-block",
+            padding: "10px 18px",
+            borderRadius: 8,
+            fontSize: 14,
+            fontWeight: 600,
+            textDecoration: "none",
+            border: "1px solid var(--dpf-border)",
+            color: "var(--dpf-text)",
+            background: "var(--dpf-surface-1)",
+          }}
+        >
+          Need to change something?
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/(storefront)/s/[slug]/donate/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/donate/page.tsx
@@ -2,7 +2,9 @@ import { notFound } from "next/navigation";
 import { prisma } from "@dpf/db";
 import { getPublicStorefront } from "@/lib/storefront-data";
 import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
+import { isJourneySupported } from "@/lib/storefront/public-trust";
 import { DonationForm } from "@/components/storefront/DonationForm";
+import { StorefrontUnavailable } from "@/components/storefront/StorefrontUnavailable";
 
 export default async function DonatePage({
   params,
@@ -15,6 +17,21 @@ export default async function DonatePage({
     prisma.orgSettings.findFirst({ select: { baseCurrency: true } }),
   ]);
   if (!storefront) notFound();
+
+  // Donations are only offered when the business has configured a donation appeal.
+  // A restaurant (or any venue without one) must not present a live donation form
+  // with generic "your support makes a difference" copy — recover the customer
+  // back into the storefront instead.
+  if (!isJourneySupported(storefront, "donation")) {
+    return (
+      <StorefrontUnavailable
+        orgSlug={slug}
+        orgName={storefront.orgName}
+        title="Donations aren't set up here"
+        message={`${storefront.orgName} isn't accepting online donations right now. If you'd like to support or get in touch, send us a message.`}
+      />
+    );
+  }
 
   const currencySymbol = getCurrencySymbol(orgSettings?.baseCurrency ?? "USD");
 

--- a/apps/web/app/(storefront)/s/[slug]/inquire/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/inquire/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import { getPublicStorefront, resolveInquiryFormSchema } from "@/lib/storefront-data";
 import { InquiryForm } from "@/components/storefront/InquiryForm";
 
@@ -25,6 +26,10 @@ export default async function InquirePage({
           : "Share what you need and we will route your inquiry to the right team."}
       </p>
       <InquiryForm orgSlug={slug} formSchema={formSchema} />
+      <p style={{ marginTop: 16, fontSize: 12, color: "var(--dpf-muted)" }}>
+        We use your details only to respond to your message. See our{" "}
+        <Link href={`/s/${slug}/policies#privacy`} style={{ color: "var(--dpf-accent)" }}>privacy notice</Link>.
+      </p>
     </div>
   );
 }

--- a/apps/web/app/(storefront)/s/[slug]/item/[itemId]/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/item/[itemId]/page.tsx
@@ -1,6 +1,22 @@
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import { getPublicStorefront, getPublicItem } from "@/lib/storefront-data";
+import { resolveTrustProfile } from "@/lib/storefront/public-trust";
 import { CtaButton } from "@/components/storefront/CtaButton";
+
+/** One line explaining what taking this action commits the customer to. */
+function whatHappensNext(ctaType: string, bookingNoun: string): string {
+  switch (ctaType) {
+    case "booking":
+      return `Choose a time and share your details — we'll confirm your ${bookingNoun} before it's held. You won't be charged to request a time.`;
+    case "purchase":
+      return "You'll see the price and can review your order before you pay. Card details are entered on a secure step.";
+    case "donation":
+      return "You'll be able to choose an amount before confirming. Thank you for your support.";
+    default:
+      return "Send us a few details and we'll get back to you — there's no commitment.";
+  }
+}
 
 export default async function ItemDetailPage({
   params,
@@ -15,19 +31,45 @@ export default async function ItemDetailPage({
 
   if (!storefront || !item) notFound();
 
+  const trust = resolveTrustProfile(storefront.archetypeCategory);
+  const nextLine = whatHappensNext(item.ctaType, trust.bookingNoun);
+
   return (
     <div style={{ maxWidth: 600, paddingTop: 40 }}>
       {item.imageUrl && (
         <img src={item.imageUrl} alt={item.name}
           style={{ width: "100%", borderRadius: 8, marginBottom: 24 }} />
       )}
-      <h1 style={{ fontSize: 28, fontWeight: 700 }}>{item.name}</h1>
+      <h1 style={{ fontSize: 28, fontWeight: 700, color: "var(--dpf-text)" }}>{item.name}</h1>
       {item.description && (
-        <p style={{ color: "#374151", lineHeight: 1.75, marginTop: 12 }}>{item.description}</p>
+        <p style={{ color: "var(--dpf-muted)", lineHeight: 1.75, marginTop: 12 }}>{item.description}</p>
       )}
-      <div style={{ marginTop: 24 }}>
-        <CtaButton ctaType={item.ctaType} ctaLabel={item.ctaLabel} orgSlug={slug} itemId={item.itemId} priceAmount={item.priceAmount} />
+
+      <div
+        style={{
+          marginTop: 20,
+          padding: "14px 16px",
+          borderRadius: 10,
+          border: "1px solid var(--dpf-border)",
+          background: "var(--dpf-surface-1)",
+        }}
+      >
+        <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.05em", textTransform: "uppercase", color: "var(--dpf-muted)", marginBottom: 6 }}>
+          What happens next
+        </div>
+        <p style={{ fontSize: 14, lineHeight: 1.6, color: "var(--dpf-text)", margin: 0 }}>{nextLine}</p>
       </div>
+
+      <div style={{ marginTop: 20 }}>
+        <CtaButton ctaType={item.ctaType} ctaLabel={item.ctaLabel} orgSlug={slug} itemId={item.itemId} priceAmount={item.priceAmount} itemName={item.name} />
+      </div>
+
+      <p style={{ marginTop: 16, fontSize: 13, color: "var(--dpf-muted)" }}>
+        Questions before you book?{" "}
+        <Link href={`/s/${slug}/inquire`} style={{ color: "var(--dpf-accent)" }}>Contact {storefront.orgName}</Link>
+        {" · "}
+        <Link href={`/s/${slug}/policies`} style={{ color: "var(--dpf-accent)" }}>Booking &amp; cancellation policy</Link>
+      </p>
     </div>
   );
 }

--- a/apps/web/app/(storefront)/s/[slug]/layout.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/layout.tsx
@@ -1,7 +1,33 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPublicStorefront } from "@/lib/storefront-data";
+import { getPublicOperatingHours } from "@/lib/storefront/public-trust";
 import { buildBrandingStyleTag } from "@/lib/branding";
 import { StorefrontNav } from "@/components/storefront/StorefrontNav";
+import { StorefrontTrustFooter } from "@/components/storefront/StorefrontTrustFooter";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  // Public pages must carry the STOREFRONT's identity, not the platform's. Without
+  // this the browser tab (and share previews) fall back to the root "Digital
+  // Product Factory" title, so a customer never sees the business they're on.
+  const storefront = await getPublicStorefront(slug, { includeUnpublished: true });
+  if (!storefront) return { title: "Not found" };
+  const description = storefront.tagline ?? storefront.description ?? undefined;
+  return {
+    title: { default: storefront.orgName, template: `%s · ${storefront.orgName}` },
+    ...(description ? { description } : {}),
+    openGraph: {
+      title: storefront.orgName,
+      ...(description ? { description } : {}),
+      ...(storefront.orgLogoUrl ? { images: [{ url: storefront.orgLogoUrl }] } : {}),
+    },
+  };
+}
 
 export default async function StorefrontLayout({
   children,
@@ -13,22 +39,35 @@ export default async function StorefrontLayout({
   const { slug } = await params;
   // includeUnpublished: auth pages (sign-in, sign-up) must work even before
   // the storefront is published. Content pages enforce isPublished themselves.
-  const storefront = await getPublicStorefront(slug, { includeUnpublished: true });
+  const [storefront, hours] = await Promise.all([
+    getPublicStorefront(slug, { includeUnpublished: true }),
+    getPublicOperatingHours(),
+  ]);
   if (!storefront) notFound();
 
   const brandingCss = buildBrandingStyleTag(storefront.brandingTokens ?? null);
 
   return (
-    <div style={{ minHeight: "100vh", background: "var(--dpf-bg)", color: "var(--dpf-text)", overflowX: "hidden" }}>
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        background: "var(--dpf-bg)",
+        color: "var(--dpf-text)",
+        overflowX: "hidden",
+      }}
+    >
       {brandingCss && <style dangerouslySetInnerHTML={{ __html: brandingCss }} />}
       <StorefrontNav
         orgName={storefront.orgName}
         orgLogoUrl={storefront.orgLogoUrl}
         orgSlug={slug}
       />
-      <main style={{ width: "100%", maxWidth: 1200, margin: "0 auto", padding: "0 clamp(16px, 4vw, 24px) 48px", boxSizing: "border-box" }}>
+      <main style={{ flex: 1, width: "100%", maxWidth: 1200, margin: "0 auto", padding: "0 clamp(16px, 4vw, 24px) 48px", boxSizing: "border-box" }}>
         {children}
       </main>
+      <StorefrontTrustFooter storefront={storefront} hours={hours} />
     </div>
   );
 }

--- a/apps/web/app/(storefront)/s/[slug]/not-found.test.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/not-found.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const pathname = vi.fn<() => string>();
+vi.mock("next/navigation", () => ({ usePathname: () => pathname() }));
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+import StorefrontNotFound from "./not-found";
+
+describe("storefront not-found recovery", () => {
+  it("recovers a customer URL to the storefront's own surfaces, not workspace/docs", () => {
+    pathname.mockReturnValue("/s/copper-kettle/order/itm-123");
+    const html = renderToStaticMarkup(<StorefrontNotFound />);
+    expect(html).toContain('href="/s/copper-kettle"');
+    expect(html).toContain('href="/s/copper-kettle/inquire"');
+    expect(html).toContain('href="/s/copper-kettle/sign-in"');
+    expect(html).not.toContain("/workspace");
+    expect(html).not.toContain("Browse docs");
+  });
+
+  it("still offers a safe home link when the slug can't be recovered", () => {
+    pathname.mockReturnValue("/s");
+    const html = renderToStaticMarkup(<StorefrontNotFound />);
+    expect(html).toContain('href="/"');
+    // No slug-specific customer links are fabricated.
+    expect(html).not.toContain("/inquire");
+  });
+});

--- a/apps/web/app/(storefront)/s/[slug]/not-found.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/not-found.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+/**
+ * Customer-facing not-found boundary for the public storefront. A visitor who
+ * hits a stale or unsupported `/s/<slug>/…` URL must recover back into the SHOP,
+ * not the internal workspace/docs the global 404 points at. The slug isn't a
+ * prop on a Next not-found, so we recover it from the pathname and route every
+ * link back to that storefront's own customer surfaces.
+ */
+export default function StorefrontNotFound() {
+  const pathname = usePathname() ?? "";
+  const match = pathname.match(/^\/s\/([^/]+)/);
+  const slug = match?.[1] ?? "";
+  const base = slug ? `/s/${slug}` : "/";
+
+  return (
+    <div style={{ maxWidth: 520, margin: "0 auto", padding: "64px 0", textAlign: "center" }}>
+      <div
+        aria-hidden="true"
+        style={{
+          margin: "0 auto 16px",
+          width: 44,
+          height: 44,
+          borderRadius: "50%",
+          border: "1px solid var(--dpf-border)",
+          background: "var(--dpf-surface-2)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontWeight: 700,
+          color: "var(--dpf-accent)",
+        }}
+      >
+        404
+      </div>
+      <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 8, color: "var(--dpf-text)" }}>
+        We couldn&apos;t find that page
+      </h1>
+      <p style={{ color: "var(--dpf-muted)", fontSize: 15, lineHeight: 1.6, marginBottom: 24 }}>
+        The link may be out of date. Let&apos;s get you back to somewhere useful.
+      </p>
+      <div style={{ display: "flex", gap: 10, justifyContent: "center", flexWrap: "wrap" }}>
+        <Link
+          href={base}
+          style={{
+            display: "inline-block",
+            padding: "10px 18px",
+            borderRadius: 8,
+            fontSize: 14,
+            fontWeight: 600,
+            textDecoration: "none",
+            background: "var(--dpf-accent)",
+            color: "var(--dpf-surface-1)",
+          }}
+        >
+          Back to home
+        </Link>
+        {slug && (
+          <>
+            <Link
+              href={`${base}/inquire`}
+              style={{
+                display: "inline-block",
+                padding: "10px 18px",
+                borderRadius: 8,
+                fontSize: 14,
+                fontWeight: 600,
+                textDecoration: "none",
+                border: "1px solid var(--dpf-border)",
+                color: "var(--dpf-text)",
+                background: "var(--dpf-surface-1)",
+              }}
+            >
+              Contact us
+            </Link>
+            <Link
+              href={`${base}/sign-in`}
+              style={{
+                display: "inline-block",
+                padding: "10px 18px",
+                borderRadius: 8,
+                fontSize: 14,
+                fontWeight: 600,
+                textDecoration: "none",
+                border: "1px solid var(--dpf-border)",
+                color: "var(--dpf-text)",
+                background: "var(--dpf-surface-1)",
+              }}
+            >
+              Sign in
+            </Link>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(storefront)/s/[slug]/order/[itemId]/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/order/[itemId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { getPublicStorefront, getPublicItem } from "@/lib/storefront-data";
 import { OrderForm } from "@/components/storefront/OrderForm";
+import { StorefrontUnavailable } from "@/components/storefront/StorefrontUnavailable";
 
 export default async function OrderItemPage({
   params,
@@ -13,9 +14,21 @@ export default async function OrderItemPage({
     getPublicItem(slug, itemId),
   ]);
 
-  // A purchasable item must exist and carry a real price. Without a price there
-  // is nothing to charge, so we 404 rather than render a checkout for £0.
-  if (!storefront || !item || item.priceAmount === null) notFound();
+  if (!storefront) notFound();
+
+  // A purchasable item must exist and carry a real price — there is nothing to
+  // charge for a £0 "order". Rather than dead-end a customer on the internal 404,
+  // recover them into the storefront with a clear, business-safe message.
+  if (!item || item.priceAmount === null) {
+    return (
+      <StorefrontUnavailable
+        orgSlug={slug}
+        orgName={storefront.orgName}
+        title="Online ordering isn't available"
+        message={`This item can't be ordered online right now at ${storefront.orgName}. Browse what's available, or send us a message and we'll help.`}
+      />
+    );
+  }
 
   return (
     <div style={{ paddingTop: 40, maxWidth: 520 }}>

--- a/apps/web/app/(storefront)/s/[slug]/policies/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/policies/page.tsx
@@ -1,0 +1,85 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getPublicStorefront } from "@/lib/storefront-data";
+import { resolveTrustProfile, isJourneySupported } from "@/lib/storefront/public-trust";
+
+export default async function StorefrontPoliciesPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const storefront = await getPublicStorefront(slug);
+  if (!storefront) notFound();
+
+  const trust = resolveTrustProfile(storefront.archetypeCategory);
+  const takesPayment = isJourneySupported(storefront, "order");
+  const contactBits = [storefront.contactEmail, storefront.contactPhone].filter(Boolean).join(" · ");
+
+  const sectionStyle = { marginBottom: 32 } as const;
+  const h2Style = { fontSize: 18, fontWeight: 700, marginBottom: 8, color: "var(--dpf-text)" } as const;
+  const pStyle = { fontSize: 15, lineHeight: 1.7, color: "var(--dpf-muted)", margin: "0 0 8px" } as const;
+
+  return (
+    <div style={{ maxWidth: 720, paddingTop: 40 }}>
+      <h1 style={{ fontSize: 28, fontWeight: 700, marginBottom: 8, color: "var(--dpf-text)" }}>
+        Policies &amp; customer information
+      </h1>
+      <p style={{ ...pStyle, marginBottom: 32 }}>
+        How {storefront.orgName} handles bookings, your information, and getting in touch.
+      </p>
+
+      <section id="booking" style={sectionStyle}>
+        <h2 style={h2Style}>Booking &amp; cancellation</h2>
+        <p style={pStyle}>{trust.bookingPolicy}</p>
+        <p style={pStyle}>{trust.cancellationPolicy}</p>
+      </section>
+
+      {trust.dietaryNote && (
+        <section id="dietary" style={sectionStyle}>
+          <h2 style={h2Style}>Dietary &amp; allergens</h2>
+          <p style={pStyle}>{trust.dietaryNote}</p>
+        </section>
+      )}
+
+      <section id="payment" style={sectionStyle}>
+        <h2 style={h2Style}>Payment &amp; security</h2>
+        <p style={pStyle}>{trust.paymentNote}</p>
+        {takesPayment && (
+          <p style={pStyle}>
+            When a payment is required, you&apos;ll see the amount before you confirm, and card
+            details are entered on a secure payment step — never shared with us in a form or email.
+          </p>
+        )}
+      </section>
+
+      <section id="privacy" style={sectionStyle}>
+        <h2 style={h2Style}>Privacy</h2>
+        <p style={pStyle}>
+          The details you enter (such as your name, contact details, and any notes) are used only to
+          handle your booking, order, or enquiry with {storefront.orgName}. They are not sold, and
+          are shared only as needed to fulfil your request.
+        </p>
+        <p style={pStyle}>
+          To ask what information is held about you, or to have it corrected or removed, contact us
+          {contactBits ? ` at ${contactBits}` : " using the details on this site"}.
+        </p>
+      </section>
+
+      <section id="terms" style={sectionStyle}>
+        <h2 style={h2Style}>Terms</h2>
+        <p style={pStyle}>
+          Submitting a booking or enquiry is a request, not a guaranteed reservation, until {storefront.orgName}{" "}
+          confirms it. Prices, availability, and menus may change. These are the business&apos;s standard
+          terms; contact us with any questions before you book.
+        </p>
+      </section>
+
+      <p style={{ ...pStyle, marginTop: 24 }}>
+        <Link href={`/s/${slug}`} style={{ color: "var(--dpf-accent)" }}>
+          ← Back to {storefront.orgName}
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/(storefront)/s/[slug]/sign-in/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/sign-in/page.tsx
@@ -1,5 +1,7 @@
-import { SignInForm } from "@/components/storefront/SignInForm";
+import Link from "next/link";
 import { getPublicStorefront } from "@/lib/storefront-data";
+import { resolveTrustProfile } from "@/lib/storefront/public-trust";
+import { SignInForm } from "@/components/storefront/SignInForm";
 
 export default async function StorefrontSignInPage({
   params,
@@ -10,12 +12,25 @@ export default async function StorefrontSignInPage({
   // getPublicStorefront is React-cached, so this reuses the layout's fetch.
   const storefront = await getPublicStorefront(slug, { includeUnpublished: true });
   const orgName = storefront?.orgName;
+  const trust = storefront ? resolveTrustProfile(storefront.archetypeCategory) : null;
+
   return (
     <div style={{ paddingTop: 60, width: "100%", maxWidth: 400, margin: "0 auto" }}>
-      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 24, overflowWrap: "break-word" }}>
+      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8, overflowWrap: "break-word", color: "var(--dpf-text)" }}>
         {orgName ? `Sign in to ${orgName}` : "Sign in"}
       </h1>
+      {trust && (
+        <p style={{ fontSize: 14, color: "var(--dpf-muted)", marginBottom: 24 }}>
+          Access your account to {trust.accountPurpose}.
+        </p>
+      )}
       <SignInForm orgSlug={slug} />
+      <p style={{ marginTop: 20, fontSize: 12, color: "var(--dpf-muted)" }}>
+        By signing in you agree to our{" "}
+        <Link href={`/s/${slug}/policies#terms`} style={{ color: "var(--dpf-accent)" }}>terms</Link>
+        {" and "}
+        <Link href={`/s/${slug}/policies#privacy`} style={{ color: "var(--dpf-accent)" }}>privacy notice</Link>.
+      </p>
     </div>
   );
 }

--- a/apps/web/app/(storefront)/s/[slug]/sign-up/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/sign-up/page.tsx
@@ -1,5 +1,7 @@
-import { SignUpForm } from "@/components/storefront/SignUpForm";
+import Link from "next/link";
 import { getPublicStorefront } from "@/lib/storefront-data";
+import { resolveTrustProfile } from "@/lib/storefront/public-trust";
+import { SignUpForm } from "@/components/storefront/SignUpForm";
 
 export default async function StorefrontSignUpPage({
   params,
@@ -13,12 +15,25 @@ export default async function StorefrontSignUpPage({
   // getPublicStorefront is React-cached, so this reuses the layout's fetch.
   const storefront = await getPublicStorefront(slug, { includeUnpublished: true });
   const orgName = storefront?.orgName;
+  const trust = storefront ? resolveTrustProfile(storefront.archetypeCategory) : null;
+
   return (
     <div style={{ paddingTop: 60, width: "100%", maxWidth: 400, margin: "0 auto" }}>
-      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 24, overflowWrap: "break-word" }}>
+      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8, overflowWrap: "break-word", color: "var(--dpf-text)" }}>
         {orgName ? `Create your ${orgName} account` : "Create an account"}
       </h1>
+      {trust && (
+        <p style={{ fontSize: 14, color: "var(--dpf-muted)", marginBottom: 24 }}>
+          Set up an account to {trust.accountPurpose}.
+        </p>
+      )}
       <SignUpForm orgSlug={slug} {...(prefillEmail ? { prefillEmail } : {})} />
+      <p style={{ marginTop: 20, fontSize: 12, color: "var(--dpf-muted)" }}>
+        By creating an account you agree to our{" "}
+        <Link href={`/s/${slug}/policies#terms`} style={{ color: "var(--dpf-accent)" }}>terms</Link>
+        {" and "}
+        <Link href={`/s/${slug}/policies#privacy`} style={{ color: "var(--dpf-accent)" }}>privacy notice</Link>.
+      </p>
     </div>
   );
 }

--- a/apps/web/app/(storefront)/s/[slug]/storefront-trust.smoke.test.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/storefront-trust.smoke.test.tsx
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+//
+// Route-level smoke coverage for the public Restaurant storefront trust work
+// (BI-4A68EDF6): brand-inheriting metadata, item/booking trust context, gated
+// donation/order journeys, customer-safe confirmation, and auth vocabulary.
+// Child form/flow components and the data layer are mocked so each test asserts
+// the trust content this BI added, not the forms owned by sibling PRs.
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// ── shared mocks ────────────────────────────────────────────────────────────
+class NotFoundError extends Error {
+  constructor() {
+    super("NEXT_NOT_FOUND");
+  }
+}
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new NotFoundError();
+  },
+}));
+vi.mock("next/link", () => ({
+  // Forward ALL props (href, aria-label, …) like the real Link.
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}));
+
+const getPublicStorefront = vi.fn();
+const getPublicItem = vi.fn();
+const resolveInquiryFormSchema = vi.fn().mockResolvedValue([]);
+vi.mock("@/lib/storefront-data", () => ({
+  getPublicStorefront: (...a: unknown[]) => getPublicStorefront(...a),
+  getPublicItem: (...a: unknown[]) => getPublicItem(...a),
+  resolveInquiryFormSchema: (...a: unknown[]) => resolveInquiryFormSchema(...a),
+}));
+
+// Prisma is only touched by donate (orgSettings) and checkout; give it a
+// per-model mock surface the tests configure.
+const prismaMock = {
+  orgSettings: { findFirst: vi.fn() },
+  storefrontConfig: { findFirst: vi.fn() },
+  storefrontBooking: { findFirst: vi.fn() },
+  storefrontInquiry: { findFirst: vi.fn() },
+  storefrontDonation: { findFirst: vi.fn() },
+  storefrontOrder: { findFirst: vi.fn() },
+  businessProfile: { findFirst: vi.fn() },
+};
+vi.mock("@dpf/db", () => ({ prisma: prismaMock }));
+
+// Stub the child forms/flows — owned by sibling PRs, not under test here.
+vi.mock("@/components/storefront/SlotBookingFlow", () => ({ SlotBookingFlow: () => <div data-test="slot-flow" /> }));
+vi.mock("@/components/storefront/SignInForm", () => ({ SignInForm: () => <form data-test="signin" /> }));
+vi.mock("@/components/storefront/SignUpForm", () => ({ SignUpForm: () => <form data-test="signup" /> }));
+vi.mock("@/components/storefront/InquiryForm", () => ({ InquiryForm: () => <form data-test="inquiry" /> }));
+vi.mock("@/components/storefront/OrderForm", () => ({ OrderForm: () => <form data-test="order" /> }));
+vi.mock("@/components/storefront/DonationForm", () => ({ DonationForm: () => <form data-test="donation" /> }));
+vi.mock("@/lib/finance/currency-symbol", () => ({ getCurrencySymbol: () => "$" }));
+
+const RESTAURANT = {
+  orgName: "The Copper Kettle",
+  orgSlug: "copper-kettle",
+  tagline: "Seasonal British dining",
+  description: null,
+  archetypeId: "restaurant",
+  archetypeCategory: "food-hospitality",
+  contactEmail: "hello@copper.example",
+  contactPhone: null,
+  orgLogoUrl: null,
+  timezone: "Europe/London",
+  items: [{ ctaType: "booking", priceAmount: null }],
+  sections: [],
+};
+
+const params = <T,>(o: T): Promise<T> => Promise.resolve(o);
+
+async function renderPage(el: Promise<React.ReactElement> | React.ReactElement) {
+  return renderToStaticMarkup(await el);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resolveInquiryFormSchema.mockResolvedValue([]);
+});
+
+// ── layout metadata (brand inheritance) ─────────────────────────────────────
+describe("storefront metadata inherits business brand", () => {
+  it("titles pages with the storefront name + tagline, not the platform default", async () => {
+    getPublicStorefront.mockResolvedValue(RESTAURANT);
+    const { generateMetadata } = await import("./layout");
+    const meta = await generateMetadata({ params: params({ slug: "copper-kettle" }) });
+    expect(meta.title).toEqual({ default: "The Copper Kettle", template: "%s · The Copper Kettle" });
+    expect(meta.description).toBe("Seasonal British dining");
+  });
+});
+
+// ── item page trust context ─────────────────────────────────────────────────
+describe("item page", () => {
+  it("explains what happens next and links to the booking policy", async () => {
+    getPublicStorefront.mockResolvedValue(RESTAURANT);
+    getPublicItem.mockResolvedValue({
+      id: "x", itemId: "itm-1", name: "Table for 2", description: "Reserve a table for two guests",
+      ctaType: "booking", ctaLabel: null, priceAmount: null, imageUrl: null,
+    });
+    const Page = (await import("./item/[itemId]/page")).default;
+    const html = await renderPage(Page({ params: params({ slug: "copper-kettle", itemId: "itm-1" }) }));
+    expect(html).toContain("What happens next");
+    expect(html).toContain("confirm your reservation");
+    expect(html).toContain('aria-label="Book Now: Table for 2"');
+    expect(html).toContain("/s/copper-kettle/policies");
+  });
+});
+
+// ── booking page trust context ──────────────────────────────────────────────
+describe("booking page", () => {
+  it("shows reservation policy, dietary note, cancellation + contact fallback", async () => {
+    getPublicStorefront.mockResolvedValue(RESTAURANT);
+    getPublicItem.mockResolvedValue({ id: "x", itemId: "itm-1", name: "Table for 2", ctaType: "booking", bookingConfig: null });
+    const Page = (await import("./book/[itemId]/page")).default;
+    const html = await renderPage(Page({ params: params({ slug: "copper-kettle", itemId: "itm-1" }) }));
+    expect(html).toContain("Reservation request");
+    expect(html).toContain("confirmation of your reservation");
+    expect(html).toMatch(/allerg/i);
+    expect(html).toContain('data-test="slot-flow"');
+    expect(html).toContain("/s/copper-kettle/inquire");
+  });
+});
+
+// ── donation gating ─────────────────────────────────────────────────────────
+describe("donation journey gating", () => {
+  it("shows a customer-safe unavailable page for a venue with no donation appeal", async () => {
+    getPublicStorefront.mockResolvedValue(RESTAURANT); // booking-only
+    prismaMock.orgSettings.findFirst.mockResolvedValue({ baseCurrency: "USD" });
+    const Page = (await import("./donate/page")).default;
+    const html = await renderPage(Page({ params: params({ slug: "copper-kettle" }) }));
+    expect(html).toContain("Donations aren&#x27;t set up here");
+    expect(html).not.toContain('data-test="donation"');
+    expect(html).toContain("/s/copper-kettle");
+  });
+
+  it("renders the donation form when a donation appeal is configured", async () => {
+    getPublicStorefront.mockResolvedValue({ ...RESTAURANT, items: [{ ctaType: "donation", priceAmount: null }] });
+    prismaMock.orgSettings.findFirst.mockResolvedValue({ baseCurrency: "USD" });
+    const Page = (await import("./donate/page")).default;
+    const html = await renderPage(Page({ params: params({ slug: "copper-kettle" }) }));
+    expect(html).toContain('data-test="donation"');
+  });
+});
+
+// ── order gating ────────────────────────────────────────────────────────────
+describe("order journey gating", () => {
+  it("shows a customer-safe unavailable page for a priceless item", async () => {
+    getPublicStorefront.mockResolvedValue(RESTAURANT);
+    getPublicItem.mockResolvedValue({ id: "x", itemId: "itm-1", name: "Table for 2", ctaType: "booking", priceAmount: null });
+    const Page = (await import("./order/[itemId]/page")).default;
+    const html = await renderPage(Page({ params: params({ slug: "copper-kettle", itemId: "itm-1" }) }));
+    expect(html).toContain("Online ordering isn&#x27;t available");
+    expect(html).not.toContain('data-test="order"');
+  });
+
+  it("renders the order form for a priced item", async () => {
+    getPublicStorefront.mockResolvedValue(RESTAURANT);
+    getPublicItem.mockResolvedValue({ id: "x", itemId: "itm-1", name: "Sourdough", ctaType: "purchase", priceAmount: "4.50", priceCurrency: "USD" });
+    const Page = (await import("./order/[itemId]/page")).default;
+    const html = await renderPage(Page({ params: params({ slug: "copper-kettle", itemId: "itm-1" }) }));
+    expect(html).toContain('data-test="order"');
+    expect(html).toContain("Order: Sourdough");
+  });
+});
+
+// ── checkout confirmation (inquiry does not look like plumbing) ──────────────
+describe("confirmation page", () => {
+  it("explains what happens next after an inquiry and offers customer recovery", async () => {
+    prismaMock.storefrontConfig.findFirst.mockResolvedValue({ id: "sf1" });
+    prismaMock.storefrontInquiry.findFirst.mockResolvedValue({ id: "inq1" });
+    const Page = (await import("./checkout/page")).default;
+    const html = await renderPage(
+      Page({ params: params({ slug: "copper-kettle" }), searchParams: params({ ref: "INQ-1", type: "inquiry" }) }),
+    );
+    expect(html).toContain("Enquiry received");
+    expect(html).toContain("INQ-1");
+    expect(html).toContain("reply as soon as we can");
+    expect(html).toContain("/s/copper-kettle/inquire");
+    expect(html).not.toContain("/workspace");
+  });
+});
+
+// ── auth vocabulary + policy links ──────────────────────────────────────────
+describe("customer auth pages", () => {
+  it("sign-in inherits brand + reservation vocabulary and links terms/privacy", async () => {
+    getPublicStorefront.mockResolvedValue(RESTAURANT);
+    const Page = (await import("./sign-in/page")).default;
+    const html = await renderPage(Page({ params: params({ slug: "copper-kettle" }) }));
+    expect(html).toContain("The Copper Kettle");
+    expect(html).toMatch(/reservation/i);
+    expect(html).toContain("/s/copper-kettle/policies#terms");
+    expect(html).toContain("/s/copper-kettle/policies#privacy");
+    expect(html).toContain('data-test="signin"');
+  });
+
+  it("sign-up inherits brand + vocabulary", async () => {
+    getPublicStorefront.mockResolvedValue(RESTAURANT);
+    const Page = (await import("./sign-up/page")).default;
+    const html = await renderPage(Page({ params: params({ slug: "copper-kettle" }), searchParams: params({}) }));
+    expect(html).toContain("Create your The Copper Kettle account");
+    expect(html).toMatch(/reservation/i);
+    expect(html).toContain('data-test="signup"');
+  });
+});
+
+// ── inquiry + policies pages ────────────────────────────────────────────────
+describe("inquiry + policies pages", () => {
+  it("inquiry page carries a privacy note", async () => {
+    getPublicStorefront.mockResolvedValue(RESTAURANT);
+    const Page = (await import("./inquire/page")).default;
+    const html = await renderPage(Page({ params: params({ slug: "copper-kettle" }) }));
+    expect(html).toContain("/s/copper-kettle/policies#privacy");
+    expect(html).toContain('data-test="inquiry"');
+  });
+
+  it("policies page renders booking, dietary, privacy and terms for a restaurant", async () => {
+    getPublicStorefront.mockResolvedValue(RESTAURANT);
+    const Page = (await import("./policies/page")).default;
+    const html = await renderPage(Page({ params: params({ slug: "copper-kettle" }) }));
+    expect(html).toContain('id="booking"');
+    expect(html).toContain('id="dietary"');
+    expect(html).toContain('id="privacy"');
+    expect(html).toContain('id="terms"');
+    expect(html).toContain("The Copper Kettle");
+  });
+});

--- a/apps/web/components/storefront/CtaButton.test.tsx
+++ b/apps/web/components/storefront/CtaButton.test.tsx
@@ -5,8 +5,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { cleanup, render as renderDom, screen } from "@testing-library/react";
 
 vi.mock("next/link", () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
-    <a href={href}>{children}</a>
+  // Forward ALL props (href, aria-label, style, …) like the real Link, so tests
+  // can assert on attributes the component sets beyond href/children.
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>{children}</a>
   ),
 }));
 
@@ -87,6 +89,22 @@ describe("CtaButton price-less purchase guard (AUDIT-R3/R4)", () => {
     expect(hrefFor("booking", null)).toBe("/s/acme/book/item-1");
     expect(hrefFor("donation", null)).toBe("/s/acme/donate");
     expect(hrefFor("inquiry", null)).toBe("/s/acme/inquire/item-1");
+  });
+});
+
+describe("CtaButton item-specific accessible name (BI-4A68EDF6)", () => {
+  it("gives a repeated CTA an item-specific aria-label", () => {
+    const html = renderToStaticMarkup(
+      <CtaButton ctaType="booking" ctaLabel={null} orgSlug="acme" itemId="i1" itemName="Table for 2" />,
+    );
+    expect(html).toContain('aria-label="Book Now: Table for 2"');
+  });
+
+  it("omits aria-label when no item name is provided (unchanged behaviour)", () => {
+    const html = renderToStaticMarkup(
+      <CtaButton ctaType="booking" ctaLabel={null} orgSlug="acme" itemId="i1" />,
+    );
+    expect(html).not.toContain("aria-label");
   });
 });
 

--- a/apps/web/components/storefront/CtaButton.tsx
+++ b/apps/web/components/storefront/CtaButton.tsx
@@ -7,6 +7,7 @@ export function CtaButton({
   orgSlug,
   itemId,
   priceAmount,
+  itemName,
 }: {
   ctaType: string;
   ctaLabel: string | null;
@@ -14,6 +15,8 @@ export function CtaButton({
   itemId: string;
   /** Decimal amount as a string (Prisma Decimal serializes to string), or null. */
   priceAmount?: string | null;
+  /** Item name — used to give repeated CTAs an item-specific accessible name. */
+  itemName?: string;
 }) {
   // A "purchase" item with no price has nothing to charge — the order route
   // (/s/[slug]/order/[itemId]) 404s when priceAmount is null. Rather than render
@@ -35,9 +38,15 @@ export function CtaButton({
     : effectiveCtaType === "donation" ? `/s/${orgSlug}/donate`
     : `/s/${orgSlug}/inquire/${itemId}`;
 
+  // A storefront home lists the same "Book Now" label on every card; give each
+  // link an item-specific accessible name (e.g. "Book Now: Table for 2") so
+  // screen-reader users can tell the repeated actions apart.
+  const accessibleName = itemName ? `${label}: ${itemName}` : undefined;
+
   return (
     <Link
       href={href}
+      {...(accessibleName ? { "aria-label": accessibleName } : {})}
       style={{
         display: "inline-flex",
         alignItems: "center",

--- a/apps/web/components/storefront/ItemCard.tsx
+++ b/apps/web/components/storefront/ItemCard.tsx
@@ -50,7 +50,7 @@ export function ItemCard({ item, orgSlug }: { item: PublicItem; orgSlug: string 
         <div style={{ fontSize: 15, fontWeight: 700, color: "var(--dpf-text)" }}>{priceDisplay}</div>
       )}
       <div style={{ marginTop: "auto", paddingTop: 8 }}>
-        <CtaButton ctaType={item.ctaType} ctaLabel={item.ctaLabel} orgSlug={orgSlug} itemId={item.itemId} priceAmount={item.priceAmount} />
+        <CtaButton ctaType={item.ctaType} ctaLabel={item.ctaLabel} orgSlug={orgSlug} itemId={item.itemId} priceAmount={item.priceAmount} itemName={item.name} />
       </div>
     </div>
   );

--- a/apps/web/components/storefront/StorefrontTrustFooter.test.tsx
+++ b/apps/web/components/storefront/StorefrontTrustFooter.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+import { StorefrontTrustFooter } from "./StorefrontTrustFooter";
+
+const base = {
+  orgName: "The Copper Kettle",
+  orgSlug: "copper-kettle",
+  orgAddress: { street: "1 High St", city: "Bristol", postcode: "BS1 1AA", country: "UK" },
+  contactEmail: "hello@copper.example",
+  contactPhone: "+44 117 000 0000",
+  socialLinks: { instagram: "https://instagram.com/copper" },
+  timezone: "Europe/London",
+} as const;
+
+const hours = {
+  monday: { enabled: true, open: "11:00", close: "22:00" },
+  tuesday: { enabled: false, open: "09:00", close: "17:00" },
+  wednesday: { enabled: true, open: "11:00", close: "22:00" },
+  thursday: { enabled: true, open: "11:00", close: "22:00" },
+  friday: { enabled: true, open: "11:00", close: "23:00" },
+  saturday: { enabled: true, open: "10:00", close: "23:00" },
+  sunday: { enabled: false, open: "09:00", close: "17:00" },
+};
+
+describe("StorefrontTrustFooter", () => {
+  it("shows location, contact, hours and policy links", () => {
+    const html = renderToStaticMarkup(<StorefrontTrustFooter storefront={base} hours={hours} />);
+    expect(html).toContain("1 High St, Bristol, BS1 1AA, UK");
+    expect(html).toContain("mailto:hello@copper.example");
+    expect(html).toContain("tel:+44 117 000 0000");
+    expect(html).toContain("11:00–22:00");
+    expect(html).toContain("Closed");
+    expect(html).toContain("/s/copper-kettle/policies");
+    expect(html).toContain("/s/copper-kettle/policies#privacy");
+    expect(html).toContain("/s/copper-kettle/policies#terms");
+  });
+
+  it("degrades gracefully when hours/contact/address are missing", () => {
+    const html = renderToStaticMarkup(
+      <StorefrontTrustFooter
+        storefront={{ ...base, orgAddress: null, contactEmail: null, contactPhone: null, socialLinks: null }}
+        hours={null}
+      />,
+    );
+    expect(html).toContain("Contact us for current opening hours.");
+    expect(html).toContain("Contact us for location details.");
+    // With no email/phone, still offer a way to reach the business.
+    expect(html).toContain("/s/copper-kettle/inquire");
+  });
+});

--- a/apps/web/components/storefront/StorefrontTrustFooter.tsx
+++ b/apps/web/components/storefront/StorefrontTrustFooter.tsx
@@ -1,0 +1,182 @@
+import Link from "next/link";
+import type { PublicStorefrontConfig } from "@/lib/storefront-types";
+import type { WeeklySchedule } from "@/lib/operating-hours-types";
+
+const DAYS: { key: keyof WeeklySchedule; label: string }[] = [
+  { key: "monday", label: "Mon" },
+  { key: "tuesday", label: "Tue" },
+  { key: "wednesday", label: "Wed" },
+  { key: "thursday", label: "Thu" },
+  { key: "friday", label: "Fri" },
+  { key: "saturday", label: "Sat" },
+  { key: "sunday", label: "Sun" },
+];
+
+/**
+ * Site-wide trust footer for every public storefront page. Surfaces the
+ * customer-safety cues an anonymous visitor needs to trust the business:
+ * who they're dealing with, where it is, how to reach it, when it's open,
+ * and where the booking/cancellation, privacy and terms policies live.
+ *
+ * Presentational only — the layout resolves the storefront + hours and passes
+ * them in, so this renders in any environment (and is trivially testable).
+ */
+export function StorefrontTrustFooter({
+  storefront,
+  hours,
+}: {
+  storefront: Pick<
+    PublicStorefrontConfig,
+    "orgName" | "orgSlug" | "orgAddress" | "contactEmail" | "contactPhone" | "socialLinks" | "timezone"
+  >;
+  hours: WeeklySchedule | null;
+}) {
+  const { orgSlug, orgAddress } = storefront;
+  const addressLine = orgAddress
+    ? [orgAddress.street, orgAddress.city, orgAddress.postcode, orgAddress.country]
+        .filter(Boolean)
+        .join(", ")
+    : null;
+  const socials = Object.entries(storefront.socialLinks ?? {}).filter(
+    ([, url]) => typeof url === "string" && url.length > 0,
+  ) as [string, string][];
+
+  const labelStyle = {
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: "0.06em",
+    textTransform: "uppercase" as const,
+    color: "var(--dpf-muted)",
+    marginBottom: 6,
+  };
+  const linkStyle = { color: "var(--dpf-text)", textDecoration: "none" };
+
+  return (
+    <footer
+      style={{
+        borderTop: "1px solid var(--dpf-border)",
+        background: "var(--dpf-surface-1)",
+        color: "var(--dpf-text)",
+        marginTop: 48,
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 1200,
+          margin: "0 auto",
+          padding: "32px 24px",
+          display: "grid",
+          gap: 28,
+          gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+        }}
+      >
+        {/* Identity + location */}
+        <div>
+          <div style={labelStyle}>{storefront.orgName}</div>
+          {addressLine ? (
+            <address style={{ fontStyle: "normal", fontSize: 14, lineHeight: 1.6, color: "var(--dpf-text)" }}>
+              {addressLine}
+            </address>
+          ) : (
+            <p style={{ fontSize: 13, color: "var(--dpf-muted)", margin: 0 }}>
+              Contact us for location details.
+            </p>
+          )}
+        </div>
+
+        {/* Contact */}
+        <div>
+          <div style={labelStyle}>Contact</div>
+          <div style={{ fontSize: 14, lineHeight: 1.8 }}>
+            {storefront.contactEmail && (
+              <div>
+                <a href={`mailto:${storefront.contactEmail}`} style={linkStyle}>
+                  {storefront.contactEmail}
+                </a>
+              </div>
+            )}
+            {storefront.contactPhone && (
+              <div>
+                <a href={`tel:${storefront.contactPhone}`} style={linkStyle}>
+                  {storefront.contactPhone}
+                </a>
+              </div>
+            )}
+            {!storefront.contactEmail && !storefront.contactPhone && (
+              <Link href={`/s/${orgSlug}/inquire`} style={linkStyle}>
+                Send us a message
+              </Link>
+            )}
+          </div>
+        </div>
+
+        {/* Opening hours */}
+        <div>
+          <div style={labelStyle}>Opening hours</div>
+          {hours ? (
+            <ul style={{ listStyle: "none", margin: 0, padding: 0, fontSize: 13, lineHeight: 1.7 }}>
+              {DAYS.map(({ key, label }) => {
+                const day = hours[key];
+                return (
+                  <li key={key} style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
+                    <span style={{ color: "var(--dpf-muted)" }}>{label}</span>
+                    <span>{day.enabled ? `${day.open}–${day.close}` : "Closed"}</span>
+                  </li>
+                );
+              })}
+              <li style={{ marginTop: 6, color: "var(--dpf-muted)", fontSize: 12 }}>
+                Times shown in {storefront.timezone}
+              </li>
+            </ul>
+          ) : (
+            <p style={{ fontSize: 13, color: "var(--dpf-muted)", margin: 0 }}>
+              Contact us for current opening hours.
+            </p>
+          )}
+        </div>
+
+        {/* Policies + follow */}
+        <div>
+          <div style={labelStyle}>Policies &amp; help</div>
+          <ul style={{ listStyle: "none", margin: 0, padding: 0, fontSize: 14, lineHeight: 1.9 }}>
+            <li>
+              <Link href={`/s/${orgSlug}/policies`} style={linkStyle}>
+                Booking &amp; cancellation
+              </Link>
+            </li>
+            <li>
+              <Link href={`/s/${orgSlug}/policies#privacy`} style={linkStyle}>
+                Privacy
+              </Link>
+            </li>
+            <li>
+              <Link href={`/s/${orgSlug}/policies#terms`} style={linkStyle}>
+                Terms
+              </Link>
+            </li>
+            <li>
+              <Link href={`/s/${orgSlug}/inquire`} style={linkStyle}>
+                Contact us
+              </Link>
+            </li>
+          </ul>
+          {socials.length > 0 && (
+            <div style={{ marginTop: 10, display: "flex", gap: 12, flexWrap: "wrap", fontSize: 13 }}>
+              {socials.map(([name, url]) => (
+                <a
+                  key={name}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer nofollow"
+                  style={{ color: "var(--dpf-muted)", textTransform: "capitalize" }}
+                >
+                  {name}
+                </a>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/components/storefront/StorefrontUnavailable.test.tsx
+++ b/apps/web/components/storefront/StorefrontUnavailable.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+import { StorefrontUnavailable } from "./StorefrontUnavailable";
+
+describe("StorefrontUnavailable", () => {
+  it("recovers the customer back into their storefront, never the workspace/docs", () => {
+    const html = renderToStaticMarkup(
+      <StorefrontUnavailable orgSlug="copper-kettle" orgName="The Copper Kettle" message="Not set up." />,
+    );
+    expect(html).toContain("/s/copper-kettle");
+    expect(html).toContain("/s/copper-kettle/inquire");
+    expect(html).toContain("Back to The Copper Kettle");
+    expect(html).not.toContain("/workspace");
+    expect(html).not.toContain("/docs");
+  });
+
+  it("renders the supplied title and message", () => {
+    const html = renderToStaticMarkup(
+      <StorefrontUnavailable orgSlug="s" title="Donations aren't set up here" message="Send us a message instead." />,
+    );
+    expect(html).toContain("Donations aren&#x27;t set up here");
+    expect(html).toContain("Send us a message instead.");
+  });
+});

--- a/apps/web/components/storefront/StorefrontUnavailable.tsx
+++ b/apps/web/components/storefront/StorefrontUnavailable.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+
+/**
+ * Customer-safe "this isn't available here" panel for public storefront journeys
+ * that the business hasn't configured (e.g. a donation or order path on a venue
+ * that only takes reservations). Unlike the internal 404, every recovery link
+ * points back into the customer's own storefront — never the workspace or docs.
+ */
+export function StorefrontUnavailable({
+  orgSlug,
+  orgName,
+  title = "This isn't available here",
+  message,
+}: {
+  orgSlug: string;
+  orgName?: string;
+  title?: string;
+  message: string;
+}) {
+  const linkBase = {
+    display: "inline-block",
+    padding: "10px 18px",
+    borderRadius: 8,
+    fontSize: 14,
+    fontWeight: 600,
+    textDecoration: "none",
+  } as const;
+
+  return (
+    <div style={{ maxWidth: 520, margin: "0 auto", padding: "64px 0", textAlign: "center" }}>
+      <div
+        aria-hidden="true"
+        style={{
+          margin: "0 auto 16px",
+          width: 44,
+          height: 44,
+          borderRadius: "50%",
+          border: "1px solid var(--dpf-border)",
+          background: "var(--dpf-surface-2)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 20,
+        }}
+      >
+        🔎
+      </div>
+      <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 8, color: "var(--dpf-text)" }}>{title}</h1>
+      <p style={{ color: "var(--dpf-muted)", fontSize: 15, lineHeight: 1.6, marginBottom: 24 }}>{message}</p>
+      <div style={{ display: "flex", gap: 10, justifyContent: "center", flexWrap: "wrap" }}>
+        <Link
+          href={`/s/${orgSlug}`}
+          style={{ ...linkBase, background: "var(--dpf-accent)", color: "var(--dpf-surface-1)" }}
+        >
+          {orgName ? `Back to ${orgName}` : "Back to home"}
+        </Link>
+        <Link
+          href={`/s/${orgSlug}/inquire`}
+          style={{
+            ...linkBase,
+            border: "1px solid var(--dpf-border)",
+            color: "var(--dpf-text)",
+            background: "var(--dpf-surface-1)",
+          }}
+        >
+          Contact us
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 575,
+  "routeCount": 576,
   "routes": [
     {
       "routePath": "/",
@@ -6402,6 +6402,19 @@
         "itemId"
       ],
       "file": "apps/web/app/(storefront)/s/[slug]/order/[itemId]/page.tsx"
+    },
+    {
+      "routePath": "/s/[slug]/policies",
+      "kind": "page",
+      "segments": [
+        "s",
+        "[slug]",
+        "policies"
+      ],
+      "dynamicParams": [
+        "slug"
+      ],
+      "file": "apps/web/app/(storefront)/s/[slug]/policies/page.tsx"
     },
     {
       "routePath": "/s/[slug]/sign-in",

--- a/apps/web/lib/navigation/route-audience.generated.json
+++ b/apps/web/lib/navigation/route-audience.generated.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-audience.ts",
-  "pageRouteCount": 331,
+  "pageRouteCount": 332,
   "summary": {
     "byAudience": {
       "admin": 140,
@@ -8,12 +8,12 @@
       "builder": 3,
       "customer": 10,
       "owner": 149,
-      "public": 16,
+      "public": 17,
       "worker": 2
     },
     "byDestinationKind": {
       "advanced-diagnostic": 94,
-      "detail": 155,
+      "detail": 156,
       "legacy-internal": 29,
       "section-home": 32,
       "settings-config": 12,
@@ -2077,6 +2077,13 @@
     },
     {
       "routePath": "/s/[slug]/order/[itemId]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/policies",
       "audience": "public",
       "destinationKind": "detail",
       "confidence": "high",

--- a/apps/web/lib/navigation/route-manifest.generated.json
+++ b/apps/web/lib/navigation/route-manifest.generated.json
@@ -1,11 +1,11 @@
 {
   "source": "apps/web/app x apps/web/lib/navigation/portal-navigation-model.ts",
-  "totalPageRoutes": 330,
-  "distinctUnclassifiedRoutes": 154,
+  "totalPageRoutes": 332,
+  "distinctUnclassifiedRoutes": 155,
   "counts": {
-    "unclassified": 154,
+    "unclassified": 155,
     "legacy-redirect": 44,
-    "detail": 75,
+    "detail": 76,
     "nav-model": 57
   },
   "routes": [
@@ -2103,6 +2103,13 @@
       "classification": "legacy-redirect"
     },
     {
+      "route": "/storefront/tables",
+      "group": "(shell)",
+      "dynamic": false,
+      "inNavModel": false,
+      "classification": "unclassified"
+    },
+    {
       "route": "/storefront/team",
       "group": "(shell)",
       "dynamic": false,
@@ -2251,6 +2258,13 @@
     },
     {
       "route": "/s/[slug]",
+      "group": "(storefront)",
+      "dynamic": true,
+      "inNavModel": false,
+      "classification": "detail"
+    },
+    {
+      "route": "/s/[slug]/policies",
       "group": "(storefront)",
       "dynamic": true,
       "inNavModel": false,

--- a/apps/web/lib/release/storefront-data.ts
+++ b/apps/web/lib/release/storefront-data.ts
@@ -148,7 +148,7 @@ export const getPublicStorefront = cache(async function getPublicStorefront(
       contactPhone: true,
       socialLinks: true,
       archetype: {
-        select: { archetypeId: true },
+        select: { archetypeId: true, category: true },
       },
       organization: {
         select: {
@@ -276,6 +276,7 @@ export const getPublicStorefront = cache(async function getPublicStorefront(
     contactPhone: config.contactPhone,
     socialLinks: config.socialLinks as PublicStorefrontConfig["socialLinks"],
     archetypeId: config.archetype?.archetypeId ?? "",
+    archetypeCategory: config.archetype?.category ?? "",
     orgName: org.name,
     orgSlug: org.slug,
     orgLogoUrl: org.logoUrl,

--- a/apps/web/lib/release/storefront-types.ts
+++ b/apps/web/lib/release/storefront-types.ts
@@ -96,6 +96,8 @@ export interface PublicStorefrontConfig {
   contactPhone: string | null;
   socialLinks: SocialLinks | null;
   archetypeId: string; // human-readable slug from StorefrontArchetype.archetypeId
+  /** Archetype category (e.g. "food-hospitality") — drives vocabulary + trust copy. */
+  archetypeCategory: string;
   orgName: string;
   orgSlug: string;
   orgLogoUrl: string | null;

--- a/apps/web/lib/storefront/public-trust.test.ts
+++ b/apps/web/lib/storefront/public-trust.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const findFirst = vi.fn();
+vi.mock("@dpf/db", () => ({ prisma: { businessProfile: { findFirst: (...a: unknown[]) => findFirst(...a) } } }));
+
+import {
+  isJourneySupported,
+  resolveTrustProfile,
+  getPublicOperatingHours,
+  type PublicJourney,
+} from "./public-trust";
+
+type Store = Parameters<typeof isJourneySupported>[0];
+type Item = Store["items"][number];
+type Section = Store["sections"][number];
+
+function storefront(over: Partial<Store> = {}): Store {
+  return { items: [], sections: [], ...over };
+}
+
+const item = (o: Record<string, unknown>): Item =>
+  ({ ctaType: "inquiry", priceAmount: null, ...o }) as unknown as Item;
+const section = (type: string): Section => ({ type }) as unknown as Section;
+
+describe("isJourneySupported", () => {
+  it("treats inquiry as always available (universal fallback)", () => {
+    expect(isJourneySupported(storefront(), "inquiry")).toBe(true);
+  });
+
+  it("only supports donation when an appeal item or donate section exists", () => {
+    expect(isJourneySupported(storefront(), "donation")).toBe(false);
+    expect(isJourneySupported(storefront({ items: [item({ ctaType: "donation" })] }), "donation")).toBe(true);
+    expect(
+      isJourneySupported(storefront({ sections: [section("donate")] }), "donation"),
+    ).toBe(true);
+  });
+
+  it("only supports order when a purchasable item carries a real price", () => {
+    expect(isJourneySupported(storefront({ items: [item({ ctaType: "purchase", priceAmount: null })] }), "order")).toBe(false);
+    expect(isJourneySupported(storefront({ items: [item({ ctaType: "purchase", priceAmount: "9.50" })] }), "order")).toBe(true);
+  });
+
+  it("supports booking when a booking item exists", () => {
+    expect(isJourneySupported(storefront(), "booking")).toBe(false);
+    expect(isJourneySupported(storefront({ items: [item({ ctaType: "booking" })] }), "booking")).toBe(true);
+  });
+
+  it("does not offer a restaurant (booking-only) donation/order path", () => {
+    const restaurant = storefront({ items: [item({ ctaType: "booking" }), item({ ctaType: "booking" })] });
+    const gated: PublicJourney[] = ["donation", "order"];
+    for (const j of gated) expect(isJourneySupported(restaurant, j)).toBe(false);
+    expect(isJourneySupported(restaurant, "booking")).toBe(true);
+  });
+});
+
+describe("resolveTrustProfile", () => {
+  it("gives food-hospitality a reservation noun, dietary + deposit copy", () => {
+    const p = resolveTrustProfile("food-hospitality");
+    expect(p.bookingNoun).toBe("reservation");
+    expect(p.dietaryNote).toMatch(/allerg/i);
+    expect(p.paymentNote).toMatch(/deposit/i);
+    expect(p.accountPurpose).toMatch(/reservation/i);
+  });
+
+  it("falls back to a safe generic profile with no invented dietary claim", () => {
+    const p = resolveTrustProfile("something-unknown");
+    expect(p.bookingNoun).toBe("booking");
+    expect(p.dietaryNote).toBeNull();
+    expect(p.bookingPolicy).toBeTruthy();
+    expect(p.cancellationPolicy).toBeTruthy();
+  });
+});
+
+describe("getPublicOperatingHours", () => {
+  beforeEach(() => findFirst.mockReset());
+
+  it("returns null when hours are not confirmed (never shows invented hours)", async () => {
+    findFirst.mockResolvedValue({ hoursConfirmedAt: null, businessHours: { monday: { open: "11:00", close: "22:00" } } });
+    expect(await getPublicOperatingHours()).toBeNull();
+  });
+
+  it("maps confirmed business hours to a weekly schedule", async () => {
+    findFirst.mockResolvedValue({
+      hoursConfirmedAt: new Date("2026-01-01"),
+      businessHours: { monday: { open: "11:00", close: "22:00" }, tuesday: null },
+    });
+    const schedule = await getPublicOperatingHours();
+    expect(schedule?.monday).toEqual({ enabled: true, open: "11:00", close: "22:00" });
+    expect(schedule?.tuesday.enabled).toBe(false);
+  });
+});

--- a/apps/web/lib/storefront/public-trust.ts
+++ b/apps/web/lib/storefront/public-trust.ts
@@ -1,0 +1,134 @@
+// apps/web/lib/storefront/public-trust.ts
+//
+// Single source of truth for the customer-facing TRUST layer of the public
+// storefront (`/s/[slug]/*`): archetype-appropriate policy/dietary/payment copy,
+// customer-account vocabulary, and the journey-support predicate that decides
+// whether an archetype-specific path (donation / order / booking) is actually
+// offered by this storefront.
+//
+// Kept archetype-CATEGORY keyed (never fabricated per-org) so every food venue,
+// clinic, salon, etc. inherits honest, non-overclaiming trust copy. Categories
+// without a bespoke profile fall back to a safe generic profile — we never
+// invent a specific legal/payment claim the business has not configured.
+
+import type { PublicStorefrontConfig } from "@/lib/release/storefront-types";
+import { prisma } from "@dpf/db";
+import { profileHoursToSchedule } from "@/lib/operating-hours-read";
+import type { WeeklySchedule } from "@/lib/operating-hours-types";
+
+export type PublicJourney = "booking" | "order" | "donation" | "inquiry";
+
+/**
+ * Does this storefront actually OFFER the given customer journey? Derived from
+ * the configured items + sections, never assumed from the archetype label. A
+ * Restaurant that has never configured a donation appeal must not expose a live
+ * `/donate` page; an order path needs a purchasable item with a real price.
+ */
+export function isJourneySupported(
+  storefront: Pick<PublicStorefrontConfig, "items" | "sections">,
+  journey: PublicJourney,
+): boolean {
+  const items = storefront.items ?? [];
+  const sections = storefront.sections ?? [];
+  switch (journey) {
+    case "donation":
+      return (
+        items.some((i) => i.ctaType === "donation") ||
+        sections.some((s) => s.type === "donate")
+      );
+    case "order":
+      // A purchasable item needs a real price — there is nothing to charge for a
+      // £0 "order", so the journey is not genuinely supported.
+      return items.some((i) => i.ctaType === "purchase" && i.priceAmount !== null);
+    case "booking":
+      return items.some((i) => i.ctaType === "booking");
+    case "inquiry":
+      // Inquiry is the universal, always-safe fallback contact journey.
+      return true;
+  }
+}
+
+export type TrustProfile = {
+  /** Noun for a single committed request, e.g. "reservation" / "appointment". */
+  bookingNoun: string;
+  /** One line: what booking commits the customer to + how confirmation works. */
+  bookingPolicy: string;
+  /** One line: how to change or cancel. */
+  cancellationPolicy: string;
+  /** Dietary / allergen note (food only); null when not applicable. */
+  dietaryNote: string | null;
+  /** Reassurance shown where money is taken (deposit / card security). */
+  paymentNote: string;
+  /** What the customer account is for, in archetype terms. */
+  accountPurpose: string;
+};
+
+const GENERIC_TRUST: TrustProfile = {
+  bookingNoun: "booking",
+  bookingPolicy:
+    "Requesting a time sends your details to the team; you'll receive confirmation before it's final.",
+  cancellationPolicy:
+    "Need to change or cancel? Contact us using the details below and we'll help.",
+  dietaryNote: null,
+  paymentNote:
+    "You won't be asked for payment to make this request. Any payment is handled directly with the business.",
+  accountPurpose: "manage your bookings and requests",
+};
+
+const TRUST_BY_CATEGORY: Record<string, TrustProfile> = {
+  "food-hospitality": {
+    bookingNoun: "reservation",
+    bookingPolicy:
+      "Reserving a table sends your request to the venue; you'll receive confirmation of your reservation before it's held.",
+    cancellationPolicy:
+      "Plans changed? Contact the venue using the details below to amend or cancel your reservation — please give as much notice as you can.",
+    dietaryNote:
+      "Have allergies or dietary requirements? Note them when you book and the kitchen will do its best to accommodate you.",
+    paymentNote:
+      "No card details are taken to reserve a table. Any deposit for large parties or private dining is arranged directly with the venue.",
+    accountPurpose: "manage your reservations and view your booking history",
+  },
+  "healthcare-wellness": {
+    bookingNoun: "appointment",
+    bookingPolicy:
+      "Requesting a time sends your details to the practice; you'll receive confirmation before your appointment is booked.",
+    cancellationPolicy:
+      "Need to reschedule or cancel? Contact the practice using the details below as early as you can.",
+    dietaryNote: null,
+    paymentNote:
+      "No payment is taken to request an appointment. Fees are arranged directly with the practice.",
+    accountPurpose: "manage your appointments and requests",
+  },
+  "beauty-personal-care": {
+    bookingNoun: "appointment",
+    bookingPolicy:
+      "Requesting a time sends your details to the team; you'll receive confirmation before your appointment is held.",
+    cancellationPolicy:
+      "To change or cancel, contact us using the details below — please give as much notice as you can.",
+    dietaryNote: null,
+    paymentNote:
+      "No card details are taken to book. Any deposit is arranged directly with the business.",
+    accountPurpose: "manage your appointments and bookings",
+  },
+};
+
+/** Resolve the trust profile for an archetype category (falls back to generic). */
+export function resolveTrustProfile(category: string | null | undefined): TrustProfile {
+  return TRUST_BY_CATEGORY[category ?? ""] ?? GENERIC_TRUST;
+}
+
+/**
+ * Load the storefront's confirmed weekly opening hours for public display, or
+ * null when the operator has not confirmed hours. We never render the generic
+ * 9–5 default publicly — showing invented hours would be a trust regression.
+ */
+export async function getPublicOperatingHours(): Promise<WeeklySchedule | null> {
+  const profile = await prisma.businessProfile.findFirst({
+    where: { isActive: true },
+    select: { businessHours: true, hoursConfirmedAt: true },
+  });
+  if (!profile?.hoursConfirmedAt || !profile.businessHours) return null;
+  return profileHoursToSchedule(
+    profile.businessHours as Record<string, { open: string; close: string } | null>,
+  );
+}

--- a/docs/superpowers/plans/2026-07-22-restaurant-storefront-trust.md
+++ b/docs/superpowers/plans/2026-07-22-restaurant-storefront-trust.md
@@ -1,0 +1,103 @@
+# Restaurant public storefront: customer trust, brand & archetype-gated journeys
+
+- **Backlog item:** BI-4A68EDF6 (`Restaurant public storefront needs customer trust, brand, and archetype-gated journeys`), epic EP-UX-COGLOAD.
+- **Date:** 2026-07-22
+- **Surface:** external Claude Code build, worktree `restaurant-storefront-trust-30cc39`.
+
+## Backlog coverage
+
+- Decision: atomic
+- Parent: BI-4A68EDF6
+- Receipt: cmrvoh31n07dx01rwlcjc6kkj
+- Rationale: One cohesive UX fix to a single surface (the public `/s/[slug]` storefront). The eight change areas share the same new `public-trust` SSOT and route registries and are sequencing-only, not independently shippable — shipping any subset (gating without recovery, footer without the policies page) would leave broken links or half-states. The coordinating BIs are separate PRs, deliberately kept disjoint.
+- Dependencies: none blocking. Coordinates with (disjoint from) BI-2B2FCB2B (#3390 mobile), BI-8E74C749 (#3386 forms), BI-3DA1DFDC/BI-0E4A1228 (booking lifecycle/handoff), BI-C764BE03 (`/portal` auth).
+
+## Problem
+
+A live public/customer trust audit (2026-07-22) found the Restaurant storefront at
+`/s/<slug>` is navigable but does not read as a trustworthy restaurant. Concretely:
+the browser title/brand fell back to the platform default, there was no site-wide
+trust content (location/contact/hours, booking/cancellation, dietary/allergen,
+privacy/terms, payment/deposit), repeated `Book Now` links had no item-specific
+accessible name, item/booking pages did not explain what the customer was committing
+to or what happens next, unsupported archetype journeys (`/donate`, `/order`,
+`/checkout`) dead-ended on the internal 404 whose recovery links point at
+`/workspace` and `/docs`, and the inquiry confirmation read like checkout plumbing.
+
+## Design grounding
+
+- **Specs/plans reviewed:** `search_specs_and_plans` + `rg docs/superpowers` for
+  storefront/trust — no existing public-storefront-trust spec owns this; the
+  archetype substrate is `docs/superpowers/specs/2026-07-21-archetype-provisioning-playbook-design.md`
+  and the value-stream doc `docs/architecture/archetype-business-value-streams.md`
+  (`attract · capture · qualify · deliver · settle · retain`). This BI hardens the
+  **attract/capture** stages for `food-hospitality`.
+- **Code substrate reviewed (`rg` + reads):** `apps/web/app/(storefront)/s/[slug]/*`
+  (layout + all page routes), `apps/web/lib/release/storefront-data.ts`
+  (`getPublicStorefront`), `apps/web/lib/release/storefront-types.ts`,
+  `apps/web/lib/storefront/archetype-vocabulary.ts`, `cta-labels.ts`,
+  `apps/web/components/storefront/*` (ContactSection, CtaButton, ItemCard,
+  StorefrontNav, SectionRenderer), `apps/web/lib/operating-hours-read.ts`
+  (`profileHoursToSchedule`), and `packages/storefront-templates/src/archetypes/food-hospitality.ts`.
+- **Decision:** *extend* existing substrate — no new tables, enums, epics, or
+  primitives. `getPublicStorefront` already returns brand/contact/address/timezone;
+  we surface it. New leaf modules only (a trust SSOT lib + presentational
+  components + one policies route).
+- **Source of truth for trust copy:** new `apps/web/lib/storefront/public-trust.ts`,
+  archetype-**category** keyed (never fabricated per-org), falling back to a safe
+  generic profile so no legal/payment/dietary claim is invented.
+
+## Coordination (disjoint from in-flight PRs)
+
+- **#3386** (BI-8E74C749) owns the per-field accessible **form contract** inside
+  `SignInForm` / `SignUpForm` / `BookingForm`. This BI does **not** touch those
+  components — it adds site-wide + page-level trust context around them.
+- **#3383 / #3387** (BI-0E4A1228 / BI-3DA1DFDC) own `SlotBookingFlow`,
+  `slot-booking-fields`, `booking-summary`, and the owner-side handoff. This BI does
+  **not** touch those — it adds trust copy in the booking *page wrapper* above the flow.
+- **BI-C764BE03** owns the `/portal/*` customer-auth 404. This BI scopes recovery to
+  the `/s/<slug>` storefront segment only (a new segment `not-found`), leaving the
+  global `not-found.tsx` and `/portal` untouched.
+
+## Changes
+
+1. **Brand inheritance** — `generateMetadata` in the storefront layout titles every
+   public page with the storefront name + tagline (+ OpenGraph), replacing the
+   platform default.
+2. **Site-wide trust footer** — `StorefrontTrustFooter` rendered in the layout:
+   location, contact, confirmed opening hours (only when confirmed — never invented),
+   and links to the policies page. Data from `getPublicStorefront` + a new
+   `getPublicOperatingHours` (reuses `profileHoursToSchedule`).
+3. **Public trust SSOT** — `public-trust.ts`: `resolveTrustProfile(category)`
+   (booking/cancellation/dietary/payment/account copy) and
+   `isJourneySupported(storefront, journey)` (derives donation/order/booking support
+   from configured items/sections).
+4. **Archetype journey gating** — `/donate` and `/order` render a customer-safe
+   `StorefrontUnavailable` (recovery into the storefront) when the journey isn't
+   configured, instead of the internal 404.
+5. **Customer-safe 404 recovery** — new `s/[slug]/not-found.tsx` recovers the slug
+   from the pathname and links back to storefront home / contact / sign-in.
+6. **Item & booking context** — "what happens next", booking/cancellation policy,
+   dietary note, and a contact fallback; item-specific `aria-label` on repeated CTAs
+   (`CtaButton` gains an optional `itemName`).
+7. **Confirmation copy** — checkout confirmation explains what happens next per
+   request type and offers customer recovery, so inquiry success no longer reads as
+   checkout plumbing.
+8. **Auth vocabulary + policies page** — sign-in/sign-up inherit brand + reservation
+   vocabulary and link terms/privacy; a new `/s/[slug]/policies` page is the honest
+   home for booking/cancellation, dietary/allergen, payment/security, privacy, terms.
+
+## Tests (smoke + unit)
+
+- `public-trust.test.ts` — journey gating, trust profiles, confirmed-hours loader.
+- `StorefrontTrustFooter.test.tsx`, `StorefrontUnavailable.test.tsx`, `not-found.test.tsx`.
+- `CtaButton.test.tsx` — item-specific accessible name.
+- `storefront-trust.smoke.test.tsx` — brand metadata, item/booking trust context,
+  donation/order gating (+ supported), confirmation copy, auth vocabulary, inquiry +
+  policies pages.
+
+## Verification substrate
+
+Source-only worktree (unpopulated `node_modules`) — local vitest/tsc/build cannot
+run here (AGENTS §5 "where each gate runs"). The required CI **Typecheck**, **Unit
+Tests**, and **Prod Build** jobs are the authoritative gate for this PR.


### PR DESCRIPTION
## What & why

BI-4A68EDF6 (epic EP-UX-COGLOAD). A live public/customer trust audit found the Restaurant storefront at `/s/<slug>` navigable but not trustworthy: platform-default page title, no site-wide trust content, repeated unlabeled `Book Now` CTAs, item/booking pages that don't explain what the customer is committing to, unsupported journeys (`/donate`, `/order`, `/checkout`) dead-ending on the internal workspace/docs 404, and an inquiry confirmation that reads like checkout plumbing.

This makes the public storefront **business-branded, trustworthy, and customer-safe** — driven by an archetype-**category**-keyed trust SSOT so every archetype benefits, with honest fallbacks (no invented legal/payment/dietary/hours claims).

## Changes

1. **Brand inheritance** — `generateMetadata` titles public pages with the storefront name + tagline (+ OpenGraph), replacing the `Digital Product Factory` platform default.
2. **Site-wide trust footer** (`StorefrontTrustFooter` in the layout) — location, contact, **confirmed** opening hours (never invented), and links to the policies page.
3. **Public trust SSOT** (`lib/storefront/public-trust.ts`) — `resolveTrustProfile(category)` (booking/cancellation/dietary/payment/account copy) + `isJourneySupported(storefront, journey)` deriving donation/order/booking support from configured items/sections.
4. **Archetype journey gating** — `/donate` and `/order` render a customer-safe `StorefrontUnavailable` recovery panel when the journey isn't configured, instead of the internal 404.
5. **Customer-safe 404 recovery** — new `s/[slug]/not-found.tsx` recovers the slug from the pathname and links back to storefront home / contact / sign-in (never `/workspace` or `/docs`).
6. **Item & booking context** — "what happens next", booking/cancellation policy, dietary note, contact fallback; item-specific `aria-label` on repeated CTAs (`CtaButton` gains optional `itemName`).
7. **Confirmation copy** — per-request-type "what happens next" + reference + customer recovery, so inquiry success no longer reads as checkout plumbing.
8. **Auth vocabulary + policies page** — sign-in/sign-up inherit brand + reservation vocabulary and link terms/privacy; new `/s/[slug]/policies` route (booking/cancellation, dietary/allergen, payment/security, privacy, terms).

## Coordination (overlap-swept before push)

- **#3390** (BI-2B2FCB2B, mobile 390px) overlaps on `layout.tsx`, `sign-in`/`sign-up`, `CtaButton.tsx`. Converged as a **superset** (2nd commit): this PR folds in #3390's mobile overflow guard, `clamp()` padding, brand H1, and touch-target-adjacent structure so whichever lands second rebases trivially and both BIs stay complete.
- **#3386** (BI-8E74C749, form contract): untouched `SignInForm`/`SignUpForm`/`BookingForm` — this PR adds trust context *around* the forms, not their fields.
- **#3383 / #3387** (BI-0E4A1228 / BI-3DA1DFDC): untouched `SlotBookingFlow`/`booking-summary`/handoff — booking trust copy is in the *page wrapper* above the flow.
- **BI-C764BE03** (`/portal` auth 404): out of scope — recovery here is scoped to the `/s/<slug>` segment; the global `not-found.tsx` and `/portal` are untouched.

## Design grounding

- **Specs/plans reviewed:** archetype-provisioning-playbook, archetype-business-value-streams (hardens `attract`/`capture` for `food-hospitality`). No existing spec owns public-storefront trust.
- **Code substrate reviewed:** `(storefront)/s/[slug]/*`, `lib/release/storefront-data.ts`, `lib/storefront/archetype-vocabulary.ts`, `cta-labels.ts`, `components/storefront/*`, `lib/operating-hours-read.ts`, `storefront-templates/food-hospitality`.
- **Decision:** *extend* — no new table/enum/epic/primitive; new leaf modules + one policies route. SSOT: `lib/storefront/public-trust.ts`. Plan: `docs/superpowers/plans/2026-07-22-restaurant-storefront-trust.md`.

Design-Grounding-Decision: extends existing storefront substrate (specs + code named above); new leaf modules + one route only; SSOT `apps/web/lib/storefront/public-trust.ts`; plan `docs/superpowers/plans/2026-07-22-restaurant-storefront-trust.md`.

UX-Fit-Decision: human_cognitive_load — progressive disclosure. Trust surfaced as a passive site-wide footer + short per-page context lines + one linked policies page; no new operator controls, numeric inputs, dashboards, or nav layers. Unsupported journeys collapse to a single clear recovery action, not a dead-end 404.

Docs-Impact-Decision: public `/s/<slug>` customer routes are not in `DOCS_ROUTE_MAP` (only internal `/storefront` + `/admin/storefront` are documented); no user-guide page documents the public customer storefront, so no mapped doc changes. Implementation history in `docs/superpowers/plans/`.

## Tests

Unit: `public-trust.test.ts` (journey gating, trust profiles, confirmed-hours loader). Component: `StorefrontTrustFooter`, `StorefrontUnavailable`, `not-found`, `CtaButton` (item-specific accessible name). Route-level smoke: `storefront-trust.smoke.test.tsx` (brand metadata, item/booking context, donation/order gating + supported, confirmation, auth vocabulary, inquiry + policies).

## Verification substrate

Local-CI-Override: source-only worktree (unpopulated `node_modules`) — local vitest/tsc/build cannot run here (AGENTS §5 "where each gate runs"). The required CI **Typecheck**, **Unit Tests**, and **Prod Build** jobs are the authoritative gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)