### PR TITLE
fix(storefront): tap-safe team/schedule setup + labelled file inputs at 390px (BI-F0B389C9)

### DIFF
--- a/apps/web/components/admin/BusinessDocumentUpload.tsx
+++ b/apps/web/components/admin/BusinessDocumentUpload.tsx
@@ -41,14 +41,16 @@ export function BusinessDocumentUpload() {
 
   return (
     <div style={{ fontSize: 13 }}>
-      <div style={{ fontWeight: 600, marginBottom: 4 }}>
+      <label htmlFor="business-document-file" style={{ display: "block", fontWeight: 600, marginBottom: 4 }}>
         Have a business plan or key document?{" "}
         <span style={{ fontWeight: 400, color: "var(--dpf-muted)" }}>(optional)</span>
-      </div>
+      </label>
       <input
+        id="business-document-file"
         ref={inputRef}
         type="file"
         accept=".pdf,.doc,.docx,.txt,.md,.rtf"
+        aria-label="Upload a business plan or key document"
         disabled={uploading}
         onChange={(e) => {
           const f = e.target.files?.[0];

--- a/apps/web/components/admin/RosterImport.tsx
+++ b/apps/web/components/admin/RosterImport.tsx
@@ -32,14 +32,16 @@ export function RosterImport() {
 
   return (
     <div style={{ fontSize: 13 }}>
-      <div style={{ fontWeight: 600, marginBottom: 4 }}>
+      <label htmlFor="roster-import-file" style={{ display: "block", fontWeight: 600, marginBottom: 4 }}>
         Add your team from a spreadsheet{" "}
         <span style={{ fontWeight: 400, color: "var(--dpf-muted)" }}>(optional)</span>
-      </div>
+      </label>
       <input
+        id="roster-import-file"
         ref={inputRef}
         type="file"
         accept=".csv,.tsv,.xlsx"
+        aria-label="Upload a team spreadsheet"
         disabled={pending}
         onChange={(e) => {
           const f = e.target.files?.[0];

--- a/apps/web/components/storefront-admin/ScheduleEditor.tsx
+++ b/apps/web/components/storefront-admin/ScheduleEditor.tsx
@@ -147,28 +147,33 @@ export function ScheduleEditor({
           const d = dayStates[i];
           if (!d) return null;
           return (
-            <div key={name} style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 13 }}>
-              <input
-                type="checkbox"
-                checked={d.enabled}
-                onChange={(e) => setDay(i, { enabled: e.target.checked })}
-                className="accent-[var(--dpf-accent)]"
-              />
-              <span className={d.enabled ? undefined : "text-[var(--dpf-muted)]"} style={{ width: 80 }}>{name}</span>
+            <div key={name} style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 10, fontSize: 13 }}>
+              <label style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <input
+                  type="checkbox"
+                  checked={d.enabled}
+                  onChange={(e) => setDay(i, { enabled: e.target.checked })}
+                  aria-label={`${name} open`}
+                  className="accent-[var(--dpf-accent)]"
+                />
+                <span className={d.enabled ? undefined : "text-[var(--dpf-muted)]"} style={{ width: 80 }}>{name}</span>
+              </label>
               {d.enabled ? (
                 <>
                   <input
                     type="time"
                     value={d.startTime}
                     onChange={(e) => setDay(i, { startTime: e.target.value })}
-                    className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "2px 6px", borderRadius: 4, color: "inherit", fontSize: 12 }}
+                    aria-label={`${name} opening time`}
+                    className="min-h-[44px] min-w-[44px] border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "2px 6px", borderRadius: 4, color: "inherit", fontSize: 12 }}
                   />
                   <span className="text-[var(--dpf-muted)]">–</span>
                   <input
                     type="time"
                     value={d.endTime}
                     onChange={(e) => setDay(i, { endTime: e.target.value })}
-                    className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "2px 6px", borderRadius: 4, color: "inherit", fontSize: 12 }}
+                    aria-label={`${name} closing time`}
+                    className="min-h-[44px] min-w-[44px] border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "2px 6px", borderRadius: 4, color: "inherit", fontSize: 12 }}
                   />
                 </>
               ) : (
@@ -195,7 +200,8 @@ export function ScheduleEditor({
                 {ex.reason && <span className="text-[var(--dpf-muted)]">{ex.reason}</span>}
                 <button
                   onClick={() => removeException(ex.id)}
-                  className="text-[var(--dpf-muted)]"
+                  aria-label={`Remove schedule exception on ${ex.date}`}
+                  className="min-h-[44px] min-w-[44px] text-[var(--dpf-muted)]"
                   style={{ marginLeft: "auto", background: "none", border: "none", cursor: "pointer", fontSize: 12 }}
                 >
                   Remove
@@ -210,15 +216,17 @@ export function ScheduleEditor({
             type="date"
             value={exceptionDraft.date}
             onChange={(e) => setExceptionDraft((p) => ({ ...p, date: e.target.value }))}
-            className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "4px 8px", borderRadius: 4, color: "inherit", fontSize: 12 }}
+            aria-label="Exception date"
+            className="min-h-[44px] min-w-[44px] border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "4px 8px", borderRadius: 4, color: "inherit", fontSize: 12 }}
           />
           <select
             value={exceptionDraft.isBlocked ? "blocked" : "custom"}
             onChange={(e) => setExceptionDraft((p) => ({ ...p, isBlocked: e.target.value === "blocked" }))}
-            className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "4px 8px", borderRadius: 4, color: "inherit", fontSize: 12 }}
+            aria-label="Exception type"
+            className="min-h-[44px] min-w-[44px] border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "4px 8px", borderRadius: 4, color: "inherit", fontSize: 12 }}
           >
-            <option value="blocked">Block day</option>
-            <option value="custom">Custom hours</option>
+            <option value="blocked" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Block day</option>
+            <option value="custom" className="bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]">Custom hours</option>
           </select>
           {!exceptionDraft.isBlocked && (
             <>
@@ -226,14 +234,16 @@ export function ScheduleEditor({
                 type="time"
                 value={exceptionDraft.startTime}
                 onChange={(e) => setExceptionDraft((p) => ({ ...p, startTime: e.target.value }))}
-                className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "2px 6px", borderRadius: 4, color: "inherit", fontSize: 12 }}
+                aria-label="Exception opening time"
+                className="min-h-[44px] min-w-[44px] border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "2px 6px", borderRadius: 4, color: "inherit", fontSize: 12 }}
               />
               <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>–</span>
               <input
                 type="time"
                 value={exceptionDraft.endTime}
                 onChange={(e) => setExceptionDraft((p) => ({ ...p, endTime: e.target.value }))}
-                className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "2px 6px", borderRadius: 4, color: "inherit", fontSize: 12 }}
+                aria-label="Exception closing time"
+                className="min-h-[44px] min-w-[44px] border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "2px 6px", borderRadius: 4, color: "inherit", fontSize: 12 }}
               />
             </>
           )}
@@ -242,12 +252,14 @@ export function ScheduleEditor({
             placeholder="Reason (optional)"
             value={exceptionDraft.reason}
             onChange={(e) => setExceptionDraft((p) => ({ ...p, reason: e.target.value }))}
-            className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "4px 8px", borderRadius: 4, color: "inherit", fontSize: 12, width: 160 }}
+            aria-label="Exception reason (optional)"
+            className="min-h-[44px] min-w-[44px] border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "4px 8px", borderRadius: 4, color: "inherit", fontSize: 12, width: 160 }}
           />
           <button
             onClick={addException}
             disabled={!exceptionDraft.date}
-            className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "4px 10px", borderRadius: 4, color: "inherit", cursor: "pointer", fontSize: 12 }}
+            aria-label="Add schedule exception"
+            className="min-h-[44px] min-w-[44px] border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]" style={{ padding: "4px 10px", borderRadius: 4, color: "inherit", cursor: "pointer", fontSize: 12 }}
           >
             Add
           </button>
@@ -258,7 +270,7 @@ export function ScheduleEditor({
         <button
           onClick={save}
           disabled={saving}
-          className="bg-[var(--dpf-accent)] text-white" style={{ padding: "6px 14px", borderRadius: 5, border: "none", cursor: "pointer", fontSize: 13, fontWeight: 600 }}
+          className="min-h-[44px] min-w-[44px] bg-[var(--dpf-accent)] text-white" style={{ padding: "6px 14px", borderRadius: 5, border: "none", cursor: "pointer", fontSize: 13, fontWeight: 600 }}
         >
           {saving ? "Saving…" : "Save Schedule"}
         </button>

--- a/apps/web/components/storefront-admin/TeamManager.tsx
+++ b/apps/web/components/storefront-admin/TeamManager.tsx
@@ -216,7 +216,8 @@ export function TeamManager({
         <div style={{ fontSize: 15, fontWeight: 600 }}>{teamLabel} ({providers.length})</div>
         <button
           onClick={() => setShowAddForm((v) => !v)}
-          className={`border border-[var(--dpf-border)] ${showAddForm ? "text-white" : ""}`}
+          aria-label={showAddForm ? "Cancel adding a provider" : `Add a new ${teamLabel.toLowerCase().replace(/s$/, "")}`}
+          className={`min-h-[44px] min-w-[44px] border border-[var(--dpf-border)] ${showAddForm ? "text-white" : ""}`}
           style={{ padding: "6px 14px", borderRadius: 5, background: showAddForm ? "var(--dpf-accent)" : "none", cursor: "pointer", fontSize: 13 }}
         >
           {showAddForm ? "Cancel" : "+ Add Provider"}
@@ -253,7 +254,7 @@ export function TeamManager({
               <button
                 onClick={addProvider}
                 disabled={adding || !newName.trim()}
-                className="bg-[var(--dpf-accent)] text-white"
+                className="min-h-[44px] min-w-[44px] bg-[var(--dpf-accent)] text-white"
                 style={{ padding: "7px 16px", borderRadius: 5, border: "none", cursor: "pointer", fontSize: 13, fontWeight: 600 }}
               >
                 {adding ? "Adding…" : "Add Provider"}
@@ -351,7 +352,8 @@ export function TeamManager({
                       <button
                         onClick={() => saveProvider(p)}
                         disabled={edit.saving}
-                        className="bg-[var(--dpf-accent)] text-white"
+                        aria-label={`Save details for ${p.name}`}
+                        className="min-h-[44px] min-w-[44px] bg-[var(--dpf-accent)] text-white"
                         style={{ padding: "6px 14px", borderRadius: 5, border: "none", cursor: "pointer", fontSize: 13, fontWeight: 600 }}
                       >
                         {edit.saving ? "Saving…" : "Save Details"}
@@ -392,7 +394,8 @@ export function TeamManager({
                   <div className="border-t border-[var(--dpf-border)]" style={{ marginTop: 16, paddingTop: 12 }}>
                     <button
                       onClick={() => deleteProvider(p)}
-                      className="border border-[var(--dpf-error)] text-[var(--dpf-error)]"
+                      aria-label={`Delete provider ${p.name}`}
+                      className="min-h-[44px] min-w-[44px] border border-[var(--dpf-error)] text-[var(--dpf-error)]"
                       style={{ padding: "6px 14px", borderRadius: 5, background: "none", cursor: "pointer", fontSize: 13 }}
                     >
                       Delete Provider

--- a/docs/superpowers/specs/2026-07-22-storefront-owner-mobile-setup-design.md
+++ b/docs/superpowers/specs/2026-07-22-storefront-owner-mobile-setup-design.md
@@ -1,0 +1,73 @@
+# Storefront owner mobile setup — team/schedule + setup file inputs (390px)
+
+- **Backlog item:** BI-F0B389C9 — "Storefront owner mobile setup needs tap-safe responsive controls"
+- **Epic:** EP-UX-COGLOAD — Live UX cognitive-load audit follow-up
+- **Status:** implemented
+- **Date:** 2026-07-22
+
+## Problem
+
+The 390x844 owner-mobile audit found Storefront setup unusable for a
+non-technical owner: sub-44px controls, terse/anonymous mutation buttons, and
+unlabeled inputs. BI-F0B389C9 is broad; several concurrent EP-UX-COGLOAD PRs
+carve it into non-overlapping slices. This PR owns the **team/provider +
+schedule** controls and the **setup file inputs** — the part no sibling PR
+touches.
+
+## Scope & overlap (concurrent EP-UX-COGLOAD PRs)
+
+Deliberately file-disjoint from the siblings so nothing collides at merge:
+
+- Operating hours / items / sections tap-targets + labels → **#3395**
+  (`OperatingHoursEditor`, `ItemsManager`, `SectionsManager`).
+- Common shell / nav collapse + `apps/web/app/globals.css` + usability
+  standards → **#3392**.
+- `/ops/self-upgrade` owner card (BI-8D87084D) → **#3391**.
+- `StorefrontInbox` booking handoff (BI-3DA1DFDC) → **#3387**; service-line
+  recovery + `/storefront` setup (BI-C39DC90C) → **#3389**; public restaurant
+  390px (BI-2B2FCB2B) → **#3390**; form-field contract (BI-8E74C749) → **#3386**.
+
+Because the shared `.dpf-tap-target` utility would collide with #3392's
+`globals.css` ownership, this PR applies the 44px minimum with **inline**
+`min-h-[44px] min-w-[44px]` utilities (the same pattern #3395 uses), so it shares
+no file with any open PR.
+
+## Design grounding
+
+- **Specs/plans reviewed:** `docs/superpowers/specs/` EP-UX-COGLOAD, and the live
+  open-PR set (swept via `gh pr list --json files`) to carve a disjoint slice.
+- **Code substrate reviewed (`apps/web/`):**
+  `apps/web/components/storefront-admin/{TeamManager,ScheduleEditor}.tsx`,
+  `apps/web/components/admin/{BusinessDocumentUpload,RosterImport}.tsx`,
+  `apps/web/tailwind.config.ts` (colors only). Colors stay on `--dpf-*` tokens
+  (AGENTS.md §12); the `confirmDialog` primitive is unchanged.
+- **Decision:** extend the components in place with inline tap utilities.
+
+## Approach
+
+1. **TeamManager** — `+ Add Provider` / `Save Details` / `Delete Provider` get
+   row-specific accessible names (`Delete provider ${p.name}`, `Save details for
+   ${p.name}`, `Add a new ${teamLabel}`) and the 44px minimum.
+2. **ScheduleEditor** — weekly and exception time inputs get outcome/context
+   `aria-label`s (`${day} opening time` / `closing time`, `Exception opening
+   time`), the exception type select + date + reason inputs get labels, the
+   Remove/Add/Save controls get labels + 44px, and the weekly row `flex-wrap`s so
+   it never clips at 390px. The day checkbox is wrapped in its `<label>`.
+3. **BusinessDocumentUpload / RosterImport** — the file inputs are associated via
+   `<label htmlFor>` + `id` and carry an outcome `aria-label` (`Upload a business
+   plan or key document`, `Upload a team spreadsheet`).
+4. **Playwright** — a `mobile-390` project (390x844, seeded-admin auth) runs
+   `e2e/storefront-owner-mobile.spec.ts`: no horizontal overflow on
+   `/storefront/team`, the add-provider control labelled + ≥44px, and every
+   setup file input labelled. Assertions stay scoped to controls this PR sizes so
+   the smoke does not depend on a sibling PR merging first.
+
+## Acceptance mapping (BI-F0B389C9 — this slice)
+
+- 44px tap targets on team/schedule controls — inline `min-h/min-w-[44px]`;
+  Playwright asserts the add-provider control ≥44px.
+- Row-specific labels replacing terse team/schedule buttons — `aria-label`s.
+- Time inputs labelled by owner outcome (schedule) — `aria-label`s.
+- File/select inputs labelled by owner outcome — file-input `<label>` + labels
+  on the exception select.
+- No overflow on the team route — weekly-row `flex-wrap`; Playwright asserts it.

--- a/e2e/storefront-owner-mobile.spec.ts
+++ b/e2e/storefront-owner-mobile.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, type Page } from "./fixtures/dpf-test";
+
+// BI-F0B389C9 — this PR's slice of the 390px owner-setup fix: the team/provider
+// + schedule controls and the setup file inputs (the operating-hours, items and
+// sections controls are handled by the sibling PR #3395; the shell/globals by
+// #3392). Runs only under the `mobile-390` project (390x844, seeded-admin auth);
+// see playwright.config.ts. Assertions stay scoped to controls THIS PR sizes/
+// labels so the smoke doesn't depend on a sibling PR having merged first.
+
+async function gotoOwnerRoute(page: Page, route: string): Promise<void> {
+  await page.goto(route);
+  await expect(page, `${route} should not bounce to welcome/login`).not.toHaveURL(
+    /\/welcome|\/login/,
+  );
+  await page.waitForLoadState("networkidle").catch(() => {});
+}
+
+test.describe("Owner team/setup mobile usability @390px (BI-F0B389C9)", () => {
+  test("no horizontal overflow on the team route at 390px", async ({ page }) => {
+    await gotoOwnerRoute(page, "/storefront/team");
+    const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(scrollWidth, "/storefront/team overflows horizontally at 390px").toBeLessThanOrEqual(
+      clientWidth + 1,
+    );
+  });
+
+  test("the add-provider control is labelled and meets the 44px tap target", async ({ page }) => {
+    await gotoOwnerRoute(page, "/storefront/team");
+    const btn = page.getByRole("button", { name: /add a new|cancel adding/i }).first();
+    await expect(btn).toBeVisible();
+    const box = await btn.boundingBox();
+    expect(box?.height ?? 0, "add-provider control height").toBeGreaterThanOrEqual(43.5);
+  });
+
+  test("setup file inputs are labelled by owner outcome", async ({ page }) => {
+    await gotoOwnerRoute(page, "/storefront/settings/business");
+    const files = page.locator('input[type="file"]');
+    const count = await files.count();
+    // The business-context setup renders the business-document upload; assert
+    // every file input exposes an accessible name (not a bare unlabeled control).
+    for (let i = 0; i < count; i++) {
+      const name = await files.nth(i).getAttribute("aria-label");
+      expect(name?.trim(), `file input #${i} needs an accessible name`).toBeTruthy();
+    }
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,8 +19,21 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      testIgnore: /.*ai-routing-.*\.spec\.ts/,
+      // ai-routing specs run under their own projects; the storefront owner
+      // mobile smoke runs only under the 390px project below (BI-F0B389C9).
+      testIgnore: [/.*ai-routing-.*\.spec\.ts/, /.*storefront-owner-mobile\.spec\.ts/],
       use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      // BI-F0B389C9: owner setup usability at phone width. Same seeded-admin
+      // auth as the desktop project, viewport pinned to 390x844.
+      name: "mobile-390",
+      testMatch: /.*storefront-owner-mobile\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 390, height: 844 },
+        storageState: "e2e/.auth/state.json",
+      },
     },
     {
       name: "build-studio",


### PR DESCRIPTION
Fixes the **team/schedule + setup-file-input** slice of **BI-F0B389C9** (EP-UX-COGLOAD) at 390px.

> **Re-scoped to de-duplicate.** A concurrent auto-dispatched session opened **#3395** for the same BI covering `OperatingHoursEditor` / `ItemsManager` / `SectionsManager`, and **#3392** owns the shell + `globals.css`. This PR was originally broader and collided on those files; it is now scoped to the slice **no sibling PR touches** and applies the 44px minimum with **inline `min-h/min-w-[44px]`** utilities (same pattern as #3395) instead of a shared `globals.css` class — so it shares **zero files** with any open PR. Together #3395 + #3392 + this PR cover BI-F0B389C9.

## What changed
- **`TeamManager`** — `+ Add Provider` / `Save Details` / `Delete Provider` get row-specific accessible names (`Delete provider ${p.name}`, `Save details for ${p.name}`, `Add a new ${teamLabel}`) and the 44px minimum.
- **`ScheduleEditor`** — weekly + exception time inputs labelled by day/context (`${day} opening time`); exception type select / date / reason labelled; Remove/Add/Save labelled + 44px; weekly row `flex-wrap`s so it never clips at 390px; day checkbox wrapped in its `<label>`.
- **`BusinessDocumentUpload` / `RosterImport`** — file inputs associated via `<label htmlFor>` + `id` with an outcome `aria-label`.
- **Playwright** — `mobile-390` project (390×844, seeded-admin auth) runs `e2e/storefront-owner-mobile.spec.ts`: no overflow on `/storefront/team`, add-provider control labelled + ≥44px, every setup file input labelled. Assertions stay scoped to controls this PR sizes, so the smoke doesn't depend on a sibling merging first.

## Design grounding
Disjoint slice of BI-F0B389C9. **Specs/plans reviewed:** `docs/superpowers/specs/` EP-UX-COGLOAD + a live open-PR sweep (`gh pr list --json files`). New spec `docs/superpowers/specs/2026-07-22-storefront-owner-mobile-setup-design.md`. **Code substrate reviewed:** `apps/web/components/storefront-admin/{TeamManager,ScheduleEditor}.tsx`, `apps/web/components/admin/{BusinessDocumentUpload,RosterImport}.tsx`, `apps/web/tailwind.config.ts`.

UX-Fit-Decision: human_cognitive_load — no net-new control/configurable input; tap-sizes + labels existing controls, removes overflow. Colors stay on `--dpf-*` tokens.

Docs-Impact-Decision: accessibility/responsive-only on `/storefront/team` and the business-setup file inputs; no documented-workflow change, so the linked `docs/storefront` pages don't change.

Local-CI-Override: source-only worktree (no local vitest/tsc); required CI **Unit Tests** + **Prod Build** are the substrate. The `mobile-390` Playwright smoke runs against a live portal (canonical install / leased sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
