### PR TITLE
feat(storefront): clear customer submit-result + validation contract (BI-F20763F5)

### DIFF
--- a/apps/web/app/(storefront)/s/[slug]/booking/confirmed/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/booking/confirmed/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from "next/navigation";
+import { loadSubmissionResult } from "@/lib/storefront/submission-result";
+import { SubmissionResultView } from "@/components/storefront/SubmissionResultView";
+
+// Named result route for a confirmed reservation (BI-F20763F5). Carries the
+// selected slot, guest, and item context into a branded confirmation.
+export default async function BookingConfirmedPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ ref?: string }>;
+}) {
+  const { slug } = await params;
+  const { ref } = await searchParams;
+  if (!ref) notFound();
+
+  const result = await loadSubmissionResult(slug, "booking", ref);
+  if (!result) notFound();
+
+  return <SubmissionResultView result={result} />;
+}

--- a/apps/web/app/(storefront)/s/[slug]/checkout/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/checkout/page.tsx
@@ -1,31 +1,18 @@
-import { notFound } from "next/navigation";
-import Link from "next/link";
-import { prisma } from "@dpf/db";
+import { notFound, redirect } from "next/navigation";
+import { isSubmissionType, resultRouteFor } from "@/lib/storefront/submission-result";
 
-const TYPE_LABELS: Record<string, { title: string; icon: string; next: string }> = {
-  booking: {
-    title: "Booking request received",
-    icon: "📅",
-    next: "We'll review your request and confirm your booking by email or phone. Keep your reference in case you need to change it.",
-  },
-  inquiry: {
-    title: "Enquiry received",
-    icon: "✉️",
-    next: "Thanks for getting in touch — we've received your message and will reply as soon as we can, usually within one business day.",
-  },
-  order: {
-    title: "Order placed",
-    icon: "📦",
-    next: "We've received your order and will be in touch with confirmation and next steps.",
-  },
-  donation: {
-    title: "Thank you for your donation",
-    icon: "❤️",
-    next: "Your support means a great deal. A receipt will be sent to your email.",
-  },
-};
-
-export default async function CheckoutPage({
+/**
+ * Back-compat shim (BI-F20763F5). `/checkout` was previously the generic
+ * success page for every submission type, which is misleading for a Restaurant
+ * customer who never checks out — an inquiry or reservation is not a purchase.
+ *
+ * Success now lives at result-named routes (`/inquiry/received`,
+ * `/booking/confirmed`, …). This route stays only to forward any submit path
+ * that still targets `/checkout?ref=&type=` (e.g. the booking/order/donation
+ * flows owned by sibling work) to the matching named result route, preserving
+ * the reference. The named route validates the reference and 404s if invalid.
+ */
+export default async function CheckoutRedirectPage({
   params,
   searchParams,
 }: {
@@ -35,121 +22,7 @@ export default async function CheckoutPage({
   const { slug } = await params;
   const { ref, type } = await searchParams;
 
-  if (!ref || !type) notFound();
+  if (!ref || !type || !isSubmissionType(type)) notFound();
 
-  const storefrontConfig = await prisma.storefrontConfig.findFirst({
-    where: { organization: { slug } },
-    select: { id: true },
-  });
-  if (!storefrontConfig) notFound();
-
-  const storefrontId = storefrontConfig.id;
-  let refValid = false;
-  let bookingDetail: { scheduledAt: Date; durationMinutes: number; customerName: string } | null = null;
-
-  if (type === "booking") {
-    const tx = await prisma.storefrontBooking.findFirst({
-      where: { bookingRef: ref, storefrontId },
-      select: { id: true, scheduledAt: true, durationMinutes: true, customerName: true },
-    });
-    refValid = !!tx;
-    if (tx) bookingDetail = { scheduledAt: tx.scheduledAt, durationMinutes: tx.durationMinutes, customerName: tx.customerName };
-  } else if (type === "inquiry") {
-    const tx = await prisma.storefrontInquiry.findFirst({
-      where: { inquiryRef: ref, storefrontId },
-      select: { id: true },
-    });
-    refValid = !!tx;
-  } else if (type === "donation") {
-    const tx = await prisma.storefrontDonation.findFirst({
-      where: { donationRef: ref, storefrontId },
-      select: { id: true },
-    });
-    refValid = !!tx;
-  } else if (type === "order") {
-    const tx = await prisma.storefrontOrder.findFirst({
-      where: { orderRef: ref, storefrontId },
-      select: { id: true },
-    });
-    refValid = !!tx;
-  }
-
-  if (!refValid) notFound();
-
-  const meta = TYPE_LABELS[type] ?? {
-    title: "Received",
-    icon: "✓",
-    next: "We've received your request and will be in touch shortly.",
-  };
-
-  return (
-    <div style={{ maxWidth: 520, margin: "0 auto", padding: "72px 0", textAlign: "center" }}>
-      <div style={{ fontSize: 48, marginBottom: 16 }} aria-hidden="true">{meta.icon}</div>
-      <h1 style={{ fontSize: 28, fontWeight: 700, marginBottom: 12, color: "var(--dpf-text)" }}>{meta.title}</h1>
-      <div
-        style={{
-          display: "inline-block",
-          padding: "6px 14px",
-          borderRadius: 999,
-          border: "1px solid var(--dpf-border)",
-          background: "var(--dpf-surface-1)",
-          fontSize: 14,
-          color: "var(--dpf-text)",
-          marginBottom: 16,
-        }}
-      >
-        Reference <strong>{ref}</strong>
-      </div>
-      {bookingDetail && (
-        <p style={{ color: "var(--dpf-text)", fontSize: 15, marginBottom: 12 }}>
-          {bookingDetail.customerName ? `${bookingDetail.customerName} · ` : ""}
-          {new Date(bookingDetail.scheduledAt).toLocaleString(undefined, {
-            weekday: "long",
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-          })}
-          {` · ${bookingDetail.durationMinutes} min`}
-        </p>
-      )}
-      <p style={{ color: "var(--dpf-muted)", fontSize: 15, lineHeight: 1.6, marginBottom: 24 }}>
-        {meta.next}
-      </p>
-      <div style={{ display: "flex", gap: 10, justifyContent: "center", flexWrap: "wrap" }}>
-        <Link
-          href={`/s/${slug}`}
-          style={{
-            display: "inline-block",
-            padding: "10px 18px",
-            borderRadius: 8,
-            fontSize: 14,
-            fontWeight: 600,
-            textDecoration: "none",
-            background: "var(--dpf-accent)",
-            color: "var(--dpf-surface-1)",
-          }}
-        >
-          Back to home
-        </Link>
-        <Link
-          href={`/s/${slug}/inquire`}
-          style={{
-            display: "inline-block",
-            padding: "10px 18px",
-            borderRadius: 8,
-            fontSize: 14,
-            fontWeight: 600,
-            textDecoration: "none",
-            border: "1px solid var(--dpf-border)",
-            color: "var(--dpf-text)",
-            background: "var(--dpf-surface-1)",
-          }}
-        >
-          Need to change something?
-        </Link>
-      </div>
-    </div>
-  );
+  redirect(`/s/${slug}/${resultRouteFor(type)}?ref=${encodeURIComponent(ref)}`);
 }

--- a/apps/web/app/(storefront)/s/[slug]/donation/received/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/donation/received/page.tsx
@@ -1,0 +1,21 @@
+import { notFound } from "next/navigation";
+import { loadSubmissionResult } from "@/lib/storefront/submission-result";
+import { SubmissionResultView } from "@/components/storefront/SubmissionResultView";
+
+// Named result route for a completed donation (BI-F20763F5).
+export default async function DonationReceivedPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ ref?: string }>;
+}) {
+  const { slug } = await params;
+  const { ref } = await searchParams;
+  if (!ref) notFound();
+
+  const result = await loadSubmissionResult(slug, "donation", ref);
+  if (!result) notFound();
+
+  return <SubmissionResultView result={result} />;
+}

--- a/apps/web/app/(storefront)/s/[slug]/inquiry/received/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/inquiry/received/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from "next/navigation";
+import { loadSubmissionResult } from "@/lib/storefront/submission-result";
+import { SubmissionResultView } from "@/components/storefront/SubmissionResultView";
+
+// Named result route for a submitted inquiry (BI-F20763F5). Replaces the
+// generic `/checkout?type=inquiry` plumbing so the URL matches the action.
+export default async function InquiryReceivedPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ ref?: string }>;
+}) {
+  const { slug } = await params;
+  const { ref } = await searchParams;
+  if (!ref) notFound();
+
+  const result = await loadSubmissionResult(slug, "inquiry", ref);
+  if (!result) notFound();
+
+  return <SubmissionResultView result={result} />;
+}

--- a/apps/web/app/(storefront)/s/[slug]/order/received/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/order/received/page.tsx
@@ -1,0 +1,21 @@
+import { notFound } from "next/navigation";
+import { loadSubmissionResult } from "@/lib/storefront/submission-result";
+import { SubmissionResultView } from "@/components/storefront/SubmissionResultView";
+
+// Named result route for a submitted order (BI-F20763F5).
+export default async function OrderReceivedPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ ref?: string }>;
+}) {
+  const { slug } = await params;
+  const { ref } = await searchParams;
+  if (!ref) notFound();
+
+  const result = await loadSubmissionResult(slug, "order", ref);
+  if (!result) notFound();
+
+  return <SubmissionResultView result={result} />;
+}

--- a/apps/web/app/(storefront)/s/[slug]/storefront-trust.smoke.test.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/storefront-trust.smoke.test.tsx
@@ -15,9 +15,19 @@ class NotFoundError extends Error {
     super("NEXT_NOT_FOUND");
   }
 }
+class RedirectError extends Error {
+  url: string;
+  constructor(url: string) {
+    super("NEXT_REDIRECT");
+    this.url = url;
+  }
+}
 vi.mock("next/navigation", () => ({
   notFound: () => {
     throw new NotFoundError();
+  },
+  redirect: (url: string) => {
+    throw new RedirectError(url);
   },
 }));
 vi.mock("next/link", () => ({
@@ -170,19 +180,34 @@ describe("order journey gating", () => {
 });
 
 // ── checkout confirmation (inquiry does not look like plumbing) ──────────────
+// Success now lives at result-named routes (BI-F20763F5). `/checkout` is a
+// back-compat shim that redirects an inquiry to `/inquiry/received`, so the
+// customer never lands on a "checkout" URL for a non-purchase action. The rich
+// what-happens-next / recovery content is asserted in
+// components/storefront/SubmissionResultView.test.tsx.
 describe("confirmation page", () => {
-  it("explains what happens next after an inquiry and offers customer recovery", async () => {
-    prismaMock.storefrontConfig.findFirst.mockResolvedValue({ id: "sf1" });
-    prismaMock.storefrontInquiry.findFirst.mockResolvedValue({ id: "inq1" });
+  it("redirects an inquiry checkout to its named result route (not checkout plumbing)", async () => {
     const Page = (await import("./checkout/page")).default;
-    const html = await renderPage(
-      Page({ params: params({ slug: "copper-kettle" }), searchParams: params({ ref: "INQ-1", type: "inquiry" }) }),
-    );
-    expect(html).toContain("Enquiry received");
-    expect(html).toContain("INQ-1");
-    expect(html).toContain("reply as soon as we can");
-    expect(html).toContain("/s/copper-kettle/inquire");
-    expect(html).not.toContain("/workspace");
+    let redirectUrl: string | null = null;
+    try {
+      await Page({
+        params: params({ slug: "copper-kettle" }),
+        searchParams: params({ ref: "INQ-1", type: "inquiry" }),
+      });
+    } catch (err) {
+      if (err instanceof RedirectError) redirectUrl = err.url;
+      else throw err;
+    }
+    expect(redirectUrl).toBe("/s/copper-kettle/inquiry/received?ref=INQ-1");
+    expect(redirectUrl).not.toContain("checkout");
+    expect(redirectUrl).not.toContain("/workspace");
+  });
+
+  it("404s a checkout hit with a missing or unknown type", async () => {
+    const Page = (await import("./checkout/page")).default;
+    await expect(
+      Page({ params: params({ slug: "copper-kettle" }), searchParams: params({ ref: "INQ-1" }) }),
+    ).rejects.toBeInstanceOf(NotFoundError);
   });
 });
 

--- a/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
@@ -1,10 +1,13 @@
 // @vitest-environment jsdom
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import { StorefrontInbox } from "./StorefrontInbox";
 
-afterEach(() => cleanup());
+vi.mock("@/components/ui/Dialog", () => ({
+  promptDialog: vi.fn(),
+}));
+
+import { StorefrontInbox } from "./StorefrontInbox";
 
 const defaultDigitalProduct = { id: "dp_1", name: "Open Digital Product Factory" };
 
@@ -24,6 +27,9 @@ function inquiry(overrides: Record<string, unknown> = {}) {
   };
 }
 
+afterEach(() => cleanup());
+
+// ── Send-to-backlog action state (BI-4F4252DB) ──────────────────────────────
 describe("StorefrontInbox send-to-backlog state", () => {
   it("offers an enabled Send to backlog action when the inquiry is untracked", () => {
     render(
@@ -56,5 +62,53 @@ describe("StorefrontInbox send-to-backlog state", () => {
     render(<StorefrontInbox entries={[inquiry()]} defaultDigitalProduct={null} />);
     const button = screen.getByRole("button", { name: /send inquiry INQ-0001 to backlog/i });
     expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+// ── Owner inbox visibility + row-specific action (BI-F20763F5) ───────────────
+describe("StorefrontInbox — owner inbox visibility (inquiry)", () => {
+  it("shows reference, customer, and request context on the row", () => {
+    render(
+      <StorefrontInbox entries={[inquiry()]} defaultDigitalProduct={defaultDigitalProduct} />,
+    );
+    expect(screen.getByText("INQ-0001")).toBeTruthy();
+    expect(screen.getByText(/Jane Prospect/)).toBeTruthy();
+    expect(screen.getByText(/jane@example\.com/)).toBeTruthy();
+    // The request itself (the customer's message) is visible to the owner.
+    expect(screen.getByText("I want to run product ops on DPF.")).toBeTruthy();
+  });
+
+  it("uses a row-specific action label instead of a generic 'Send to backlog'", () => {
+    render(
+      <StorefrontInbox entries={[inquiry()]} defaultDigitalProduct={defaultDigitalProduct} />,
+    );
+    // Visible label carries the reference; accessible name is row-specific.
+    const button = screen.getByRole("button", { name: /send inquiry INQ-0001 to backlog/i });
+    expect(button.textContent).toContain("INQ-0001");
+    // No bare generic label survives on the action.
+    expect(screen.queryByText(/^Send to backlog$/)).toBeNull();
+  });
+
+  it("explains the consequence of the action to a non-technical owner", () => {
+    render(
+      <StorefrontInbox entries={[inquiry()]} defaultDigitalProduct={defaultDigitalProduct} />,
+    );
+    expect(
+      screen.getByText(/Creates an internal work item for your team to follow up\. The customer isn't notified\./),
+    ).toBeTruthy();
+  });
+
+  it("keeps each row uniquely targetable when multiple inquiries exist", () => {
+    render(
+      <StorefrontInbox
+        entries={[
+          inquiry(),
+          inquiry({ id: "inq_2", ref: "INQ-SECOND22", name: "Second Guest" }),
+        ]}
+        defaultDigitalProduct={defaultDigitalProduct}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /send inquiry INQ-0001 to backlog/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /send inquiry INQ-SECOND22 to backlog/i })).toBeTruthy();
   });
 });

--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -124,7 +124,7 @@ export function StorefrontInbox({
             Requests from your storefront
           </div>
           <div className="text-[var(--dpf-muted)]" style={{ marginTop: 4, fontSize: 12 }}>
-            Use <strong>Send to backlog</strong> to track a customer request as work you can follow up on.
+            Use <strong>Send inquiry to backlog</strong> on a request to track it as internal work you can follow up on. The customer isn&apos;t notified.
           </div>
         </div>
       ) : (
@@ -225,51 +225,62 @@ export function StorefrontInbox({
               const isSending = pendingInquiryId === e.id;
 
               return (
-                <div style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap", alignItems: "center" }}>
-                  {backlogItemId ? (
-                    // Terminal state: the inquiry is already tracked, so there is
-                    // no enabled "Send to backlog" action — only a completed
-                    // marker and a direct link to the created item.
-                    <>
-                      <span
-                        className="text-[var(--dpf-success)]"
-                        style={{ fontSize: 12, fontWeight: 600, display: "inline-flex", alignItems: "center", gap: 5 }}
-                      >
-                        <span aria-hidden="true">✓</span> Sent to backlog
-                      </span>
-                      <a
-                        href={`/ops?itemId=${encodeURIComponent(backlogItemId)}`}
-                        className="text-[var(--dpf-accent)]"
-                        style={{ fontSize: 12, textDecoration: "underline" }}
-                        aria-label={`Open backlog item ${backlogItemId} for inquiry ${e.ref}`}
-                      >
-                        {backlogItemId}
-                      </a>
-                    </>
-                  ) : (
-                    <>
-                      <button
-                        onClick={() => sendInquiryToProductBacklog(e.id)}
-                        disabled={!defaultDigitalProduct || isSending}
-                        aria-label={`Send inquiry ${e.ref} to backlog`}
-                        className="border border-[var(--dpf-accent)] text-[var(--dpf-accent)]"
-                        style={{
-                          padding: "3px 10px",
-                          borderRadius: 4,
-                          background: "none",
-                          cursor: !defaultDigitalProduct || isSending ? "not-allowed" : "pointer",
-                          fontSize: 12,
-                          opacity: !defaultDigitalProduct || isSending ? 0.6 : 1,
-                        }}
-                      >
-                        {isSending ? "Sending..." : "Send to backlog"}
-                      </button>
-                      {errorMessage && (
-                        <span className="text-[var(--dpf-error)]" role="alert" style={{ fontSize: 12 }}>
-                          {errorMessage}
+                <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 8 }}>
+                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+                    {backlogItemId ? (
+                      // Terminal state: the inquiry is already tracked, so there is
+                      // no enabled "Send to backlog" action — only a completed
+                      // marker and a direct link to the created item.
+                      <>
+                        <span
+                          className="text-[var(--dpf-success)]"
+                          style={{ fontSize: 12, fontWeight: 600, display: "inline-flex", alignItems: "center", gap: 5 }}
+                        >
+                          <span aria-hidden="true">✓</span> Sent to backlog
                         </span>
-                      )}
-                    </>
+                        <a
+                          href={`/ops?itemId=${encodeURIComponent(backlogItemId)}`}
+                          className="text-[var(--dpf-accent)]"
+                          style={{ fontSize: 12, textDecoration: "underline" }}
+                          aria-label={`Open backlog item ${backlogItemId} for inquiry ${e.ref}`}
+                        >
+                          {backlogItemId}
+                        </a>
+                      </>
+                    ) : (
+                      <>
+                        {/* Row-specific label + consequence copy so a non-technical
+                            owner knows exactly which request this acts on and what
+                            sending it changes (BI-F20763F5). */}
+                        <button
+                          onClick={() => sendInquiryToProductBacklog(e.id)}
+                          disabled={!defaultDigitalProduct || isSending}
+                          aria-label={`Send inquiry ${e.ref} to backlog`}
+                          title={`Creates an internal work item from ${e.name ?? "this customer"}'s inquiry ${e.ref}. The customer is not notified.`}
+                          className="border border-[var(--dpf-accent)] text-[var(--dpf-accent)]"
+                          style={{
+                            padding: "3px 10px",
+                            borderRadius: 4,
+                            background: "none",
+                            cursor: !defaultDigitalProduct || isSending ? "not-allowed" : "pointer",
+                            fontSize: 12,
+                            opacity: !defaultDigitalProduct || isSending ? 0.6 : 1,
+                          }}
+                        >
+                          {isSending ? "Sending…" : `Send inquiry ${e.ref} to backlog`}
+                        </button>
+                        {errorMessage && (
+                          <span className="text-[var(--dpf-error)]" role="alert" style={{ fontSize: 12 }}>
+                            {errorMessage}
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </div>
+                  {!backlogItemId && (
+                    <p className="text-[var(--dpf-muted)]" style={{ fontSize: 11, margin: 0 }}>
+                      Creates an internal work item for your team to follow up. The customer isn&apos;t notified.
+                    </p>
                   )}
                 </div>
               );

--- a/apps/web/components/storefront/InquiryForm.test.tsx
+++ b/apps/web/components/storefront/InquiryForm.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+const submitInquiry = vi.fn();
+vi.mock("@/lib/storefront-actions", () => ({
+  submitInquiry: (...args: unknown[]) => submitInquiry(...args),
+}));
+
+import { InquiryForm } from "./InquiryForm";
+
+const SCHEMA = [
+  { name: "name", label: "Your name", type: "text", required: true },
+  { name: "email", label: "Email address", type: "email", required: true },
+  { name: "phone", label: "Phone number", type: "tel", required: false },
+  { name: "message", label: "Message", type: "textarea", required: false },
+];
+
+function setup() {
+  return render(<InquiryForm orgSlug="bella-trattoria" formSchema={SCHEMA} />);
+}
+
+beforeEach(() => {
+  push.mockReset();
+  submitInquiry.mockReset();
+});
+afterEach(() => cleanup());
+
+describe("InquiryForm — empty validation", () => {
+  it("shows a visible accessible summary and blocks submit on empty required fields", async () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: /send enquiry/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toBeTruthy();
+    expect(alert.textContent).toContain("Your name is required");
+    expect(alert.textContent).toContain("Email address is required");
+
+    // No network action, no navigation — browser-native blocking is not relied on.
+    expect(submitInquiry).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("marks invalid fields with aria-invalid and links the inline error", async () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: /send enquiry/i }));
+    await screen.findByRole("alert");
+
+    const nameInput = screen.getByLabelText(/your name/i);
+    expect(nameInput.getAttribute("aria-invalid")).toBe("true");
+    expect(nameInput.getAttribute("aria-describedby")).toBe("inquiry-name-error");
+  });
+
+  it("rejects a malformed email without submitting", async () => {
+    setup();
+    fireEvent.change(screen.getByLabelText(/your name/i), { target: { value: "Guest" } });
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: "not-an-email" } });
+    fireEvent.click(screen.getByRole("button", { name: /send enquiry/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Enter a valid email address");
+    expect(submitInquiry).not.toHaveBeenCalled();
+  });
+});
+
+describe("InquiryForm — safe successful submit", () => {
+  it("submits valid data and navigates to the named result route", async () => {
+    submitInquiry.mockResolvedValue({ success: true, ref: "INQ-XYZ789", type: "inquiry" });
+    setup();
+
+    fireEvent.change(screen.getByLabelText(/your name/i), { target: { value: "UX Study Guest" } });
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: "guest@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /send enquiry/i }));
+
+    await waitFor(() => expect(submitInquiry).toHaveBeenCalledTimes(1));
+    expect(submitInquiry).toHaveBeenCalledWith(
+      "bella-trattoria",
+      expect.objectContaining({ customerName: "UX Study Guest", customerEmail: "guest@example.com" }),
+    );
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith("/s/bella-trattoria/inquiry/received?ref=INQ-XYZ789"),
+    );
+    // Never routes through /checkout for an inquiry.
+    expect(push).not.toHaveBeenCalledWith(expect.stringContaining("/checkout"));
+  });
+
+  it("surfaces a server error without navigating", async () => {
+    submitInquiry.mockResolvedValue({ success: false, error: "Storefront not published" });
+    setup();
+
+    fireEvent.change(screen.getByLabelText(/your name/i), { target: { value: "Guest" } });
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: "guest@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /send enquiry/i }));
+
+    expect(await screen.findByText("Storefront not published")).toBeTruthy();
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/storefront/InquiryForm.tsx
+++ b/apps/web/components/storefront/InquiryForm.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useRef, useState, useEffect } from "react";
 import { submitInquiry } from "@/lib/storefront-actions";
 import { useRouter } from "next/navigation";
+import {
+  validateRequiredFields,
+  errorId,
+  type FieldErrors,
+  type ValidatableField,
+} from "@/lib/storefront/form-validation";
 
 type FormField = {
   name: string;
@@ -12,6 +18,8 @@ type FormField = {
   options?: string[];
   placeholder?: string;
 };
+
+const FORM_ID = "inquiry";
 
 export function InquiryForm({
   orgSlug,
@@ -25,7 +33,10 @@ export function InquiryForm({
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>(() => ({}));
+  const [errorOrder, setErrorOrder] = useState<string[]>([]);
   const [calcSnapshot, setCalcSnapshot] = useState<Record<string, unknown> | null>(null);
+  const summaryRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const raw = sessionStorage.getItem("dpf_calc_snapshot");
@@ -34,25 +45,48 @@ export function InquiryForm({
     }
   }, []);
 
+  function readValues(form: HTMLFormElement): Record<string, string> {
+    const fd = new FormData(form);
+    const values: Record<string, string> = {};
+    for (const field of formSchema) {
+      const v = fd.get(field.name);
+      values[field.name] = typeof v === "string" ? v : "";
+    }
+    return values;
+  }
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    const form = e.currentTarget;
+
+    // Visible, accessible validation — not browser-native blocking only.
+    const values = readValues(form);
+    const validation = validateRequiredFields(formSchema as ValidatableField[], values);
+    if (!validation.valid) {
+      setFieldErrors(validation.errors);
+      setErrorOrder(validation.order);
+      // Move focus to the summary so screen readers and keyboard users land on it.
+      requestAnimationFrame(() => summaryRef.current?.focus());
+      return;
+    }
+    setFieldErrors({});
+    setErrorOrder([]);
+
     setLoading(true);
     setError(null);
 
-    const fd = new FormData(e.currentTarget);
-    const email = fd.get("email") as string;
-    const name = fd.get("name") as string;
-    const phone = (fd.get("phone") as string | null) ?? undefined;
+    const email = values.email;
+    const name = values.name;
+    const phone = values.phone || undefined;
     // Archetype schemas use a "notes" textarea for free-text; the generic schema
     // uses "message". Treat either as the inquiry message.
-    const message =
-      ((fd.get("message") ?? fd.get("notes")) as string | null) ?? undefined;
+    const message = values.message || values.notes || undefined;
 
     const formData: Record<string, unknown> = {};
     for (const field of formSchema) {
       if (!["name", "email", "phone", "notes", "message"].includes(field.name)) {
-        const val = fd.get(field.name);
-        if (val !== null) formData[field.name] = val;
+        const val = values[field.name];
+        if (val) formData[field.name] = val;
       }
     }
 
@@ -61,8 +95,8 @@ export function InquiryForm({
     const result = await submitInquiry(orgSlug, {
       customerEmail: email,
       customerName: name,
-      customerPhone: phone || undefined,
-      message: message || undefined,
+      customerPhone: phone,
+      message,
       itemId,
       formData: Object.keys(formData).length > 0 ? formData : undefined,
     });
@@ -73,39 +107,113 @@ export function InquiryForm({
       return;
     }
 
-    router.push(`/s/${orgSlug}/checkout?ref=${result.ref}&type=inquiry`);
+    // Result-named route — an enquiry is not a checkout (BI-F20763F5).
+    router.push(`/s/${orgSlug}/inquiry/received?ref=${encodeURIComponent(result.ref)}`);
   }
 
+  const labelByName = new Map(formSchema.map((f) => [f.name, f.label] as const));
+
   return (
-    <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 480 }}>
-      {error && <div style={{ color: "var(--dpf-error)", fontSize: 13 }}>{error}</div>}
-      {formSchema.map((field) => (
-        <div key={field.name} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <label style={{ fontSize: 13, fontWeight: 500, color: "var(--dpf-text)" }}>
-            {field.label}{field.required && " *"}
-          </label>
-          {field.type === "textarea" ? (
-            <textarea name={field.name} required={field.required} rows={4}
-              style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14, resize: "vertical" }} />
-          ) : field.type === "select" ? (
-            <select name={field.name} required={field.required}
-              style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }}>
-              <option value="">Select…</option>
-              {field.options?.map((o) => <option key={o} value={o}>{o}</option>)}
-            </select>
-          ) : (
-            <input type={field.type} name={field.name} required={field.required}
-              placeholder={field.placeholder}
-              style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }} />
-          )}
+    <form onSubmit={handleSubmit} noValidate style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 480 }}>
+      {errorOrder.length > 0 && (
+        <div
+          ref={summaryRef}
+          role="alert"
+          tabIndex={-1}
+          className="border border-[var(--dpf-error)]"
+          style={{
+            borderRadius: 8,
+            padding: "12px 14px",
+            background: "color-mix(in srgb, var(--dpf-error) 8%, transparent)",
+            outline: "none",
+          }}
+        >
+          <p style={{ fontSize: 13, fontWeight: 600, color: "var(--dpf-error)", marginBottom: errorOrder.length ? 6 : 0 }}>
+            Please check the following {errorOrder.length === 1 ? "field" : `${errorOrder.length} fields`}:
+          </p>
+          <ul style={{ margin: 0, paddingLeft: 18 }}>
+            {errorOrder.map((name) => (
+              <li key={name} style={{ fontSize: 13 }}>
+                <a href={`#${FORM_ID}-${name}`} style={{ color: "var(--dpf-error)" }}>
+                  {fieldErrors[name] ?? `${labelByName.get(name) ?? name} is required`}
+                </a>
+              </li>
+            ))}
+          </ul>
         </div>
-      ))}
-      <button type="submit" disabled={loading}
+      )}
+
+      {error && <div role="alert" style={{ color: "var(--dpf-error)", fontSize: 13 }}>{error}</div>}
+
+      {formSchema.map((field) => {
+        const fieldError = fieldErrors[field.name];
+        const describedBy = fieldError ? errorId(FORM_ID, field.name) : undefined;
+        const inputId = `${FORM_ID}-${field.name}`;
+        const commonStyle = {
+          padding: "8px 12px",
+          border: `1px solid ${fieldError ? "var(--dpf-error)" : "var(--dpf-border)"}`,
+          borderRadius: 6,
+          fontSize: 14,
+        };
+        return (
+          <div key={field.name} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <label htmlFor={inputId} style={{ fontSize: 13, fontWeight: 500, color: "var(--dpf-text)" }}>
+              {field.label}
+              {field.required && <span style={{ color: "var(--dpf-error)" }} aria-hidden="true"> *</span>}
+              {field.required && <span className="sr-only"> (required)</span>}
+            </label>
+            {field.type === "textarea" ? (
+              <textarea
+                id={inputId}
+                name={field.name}
+                required={field.required}
+                rows={4}
+                aria-invalid={fieldError ? true : undefined}
+                aria-describedby={describedBy}
+                style={{ ...commonStyle, resize: "vertical" }}
+              />
+            ) : field.type === "select" ? (
+              <select
+                id={inputId}
+                name={field.name}
+                required={field.required}
+                aria-invalid={fieldError ? true : undefined}
+                aria-describedby={describedBy}
+                style={commonStyle}
+              >
+                <option value="">Select…</option>
+                {field.options?.map((o) => <option key={o} value={o}>{o}</option>)}
+              </select>
+            ) : (
+              <input
+                id={inputId}
+                type={field.type}
+                name={field.name}
+                required={field.required}
+                placeholder={field.placeholder}
+                aria-invalid={fieldError ? true : undefined}
+                aria-describedby={describedBy}
+                style={commonStyle}
+              />
+            )}
+            {fieldError && (
+              <span id={errorId(FORM_ID, field.name)} style={{ fontSize: 12, color: "var(--dpf-error)" }}>
+                {fieldError}
+              </span>
+            )}
+          </div>
+        );
+      })}
+
+      <button
+        type="submit"
+        disabled={loading}
         style={{
           padding: "10px 20px", background: "var(--dpf-accent, #4f46e5)", color: "#fff",
           border: "none", borderRadius: 6, fontSize: 14, fontWeight: 600,
           cursor: loading ? "not-allowed" : "pointer",
-        }}>
+        }}
+      >
         {loading ? "Sending…" : "Send Enquiry"}
       </button>
     </form>

--- a/apps/web/components/storefront/SubmissionResultView.test.tsx
+++ b/apps/web/components/storefront/SubmissionResultView.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SubmissionResultView } from "./SubmissionResultView";
+import type { SubmissionResultModel } from "@/lib/storefront/submission-result";
+
+const INQUIRY: SubmissionResultModel = {
+  type: "inquiry",
+  ref: "INQ-ABC123",
+  orgName: "Bella Trattoria",
+  orgSlug: "bella-trattoria",
+  heading: "Thanks — we've received your enquiry",
+  icon: "✉️",
+  context: [
+    { label: "Name", value: "UX Study Guest" },
+    { label: "Email", value: "guest@example.com" },
+    { label: "Your message", value: "Do you cater for gluten-free?" },
+  ],
+  responseChannel: "We'll reply by email to guest@example.com.",
+  responseTime: "We aim to respond within one business day.",
+  nextSteps: [
+    "A member of the Bella Trattoria team reads your enquiry.",
+    "We reply using the contact details you gave us.",
+    "We'll confirm anything we need before going ahead.",
+  ],
+  contact: { email: "hello@bella.example", phone: "+44 20 1234 5678" },
+};
+
+function html(model: SubmissionResultModel): string {
+  return renderToStaticMarkup(<SubmissionResultView result={model} />);
+}
+
+describe("SubmissionResultView", () => {
+  it("shows the reference prominently", () => {
+    expect(html(INQUIRY)).toContain("INQ-ABC123");
+  });
+
+  it("shows the submitted context (name, email, message)", () => {
+    const out = html(INQUIRY);
+    expect(out).toContain("UX Study Guest");
+    expect(out).toContain("guest@example.com");
+    expect(out).toContain("Do you cater for gluten-free?");
+  });
+
+  it("explains response channel and expected time", () => {
+    const out = html(INQUIRY);
+    expect(out).toContain("We&#x27;ll reply by email to guest@example.com.");
+    expect(out).toContain("aim to respond within one business day");
+  });
+
+  it("lists what happens next", () => {
+    const out = html(INQUIRY);
+    expect(out).toContain("What happens next");
+    expect(out).toContain("reads your enquiry");
+  });
+
+  it("offers correction/cancel/contact affordances", () => {
+    const out = html(INQUIRY);
+    expect(out).toContain("Need to change or cancel?");
+    expect(out).toContain("mailto:hello@bella.example");
+    expect(out).toContain("tel:+44 20 1234 5678");
+  });
+
+  it("provides a branded return link to the storefront", () => {
+    const out = html(INQUIRY);
+    expect(out).toContain('href="/s/bella-trattoria"');
+    expect(out).toContain("Back to Bella Trattoria");
+  });
+
+  it("gracefully omits the contact block when no channels are configured", () => {
+    const out = html({ ...INQUIRY, contact: { email: null, phone: null } });
+    expect(out).not.toContain("mailto:");
+    expect(out).not.toContain("tel:");
+    // Still tells the customer how to change/cancel via their reference.
+    expect(out).toContain("Need to change or cancel?");
+  });
+});

--- a/apps/web/components/storefront/SubmissionResultView.tsx
+++ b/apps/web/components/storefront/SubmissionResultView.tsx
@@ -1,0 +1,111 @@
+import type { SubmissionResultModel } from "@/lib/storefront/submission-result";
+
+/**
+ * Branded, accessible result surface for a completed customer submission
+ * (BI-F20763F5). Pure presentational component — all data is resolved by
+ * `loadSubmissionResult`, so this renders identically under test and in the
+ * storefront layout, inheriting the storefront brand/nav from that layout.
+ */
+export function SubmissionResultView({ result }: { result: SubmissionResultModel }) {
+  const { icon, heading, ref, orgName, context, responseChannel, responseTime, nextSteps, contact } =
+    result;
+
+  return (
+    <div style={{ maxWidth: 560, margin: "0 auto", padding: "48px 0" }}>
+      <div style={{ textAlign: "center", marginBottom: 24 }}>
+        <div style={{ fontSize: 44, marginBottom: 8 }} aria-hidden="true">
+          {icon}
+        </div>
+        <h1 style={{ fontSize: 26, fontWeight: 700, marginBottom: 6 }}>{heading}</h1>
+        <p style={{ color: "var(--dpf-muted)", fontSize: 14 }}>
+          Your reference is{" "}
+          <strong style={{ fontFamily: "monospace", color: "var(--dpf-text)" }}>{ref}</strong>. Please
+          keep it handy.
+        </p>
+      </div>
+
+      {/* What you submitted */}
+      {context.length > 0 && (
+        <section
+          aria-label="What you submitted"
+          className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]"
+          style={{ borderRadius: 10, padding: "16px 18px", marginBottom: 16 }}
+        >
+          <h2 style={{ fontSize: 13, fontWeight: 700, marginBottom: 10 }}>What you submitted</h2>
+          <dl style={{ display: "grid", gridTemplateColumns: "auto 1fr", gap: "6px 14px", margin: 0 }}>
+            {context.map((line) => (
+              <div key={line.label} style={{ display: "contents" }}>
+                <dt className="text-[var(--dpf-muted)]" style={{ fontSize: 13 }}>
+                  {line.label}
+                </dt>
+                <dd style={{ fontSize: 13, margin: 0, whiteSpace: "pre-wrap" }}>{line.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      )}
+
+      {/* Response channel + time */}
+      <section
+        aria-label="When you'll hear from us"
+        style={{ borderRadius: 10, padding: "4px 2px 16px", marginBottom: 8 }}
+      >
+        <p style={{ fontSize: 14, marginBottom: 4 }}>{responseChannel}</p>
+        <p className="text-[var(--dpf-muted)]" style={{ fontSize: 13 }}>
+          {responseTime}
+        </p>
+      </section>
+
+      {/* What happens next */}
+      <section aria-label="What happens next" style={{ marginBottom: 16 }}>
+        <h2 style={{ fontSize: 13, fontWeight: 700, marginBottom: 8 }}>What happens next</h2>
+        <ol style={{ paddingLeft: 20, margin: 0, display: "flex", flexDirection: "column", gap: 6 }}>
+          {nextSteps.map((step, i) => (
+            <li key={i} style={{ fontSize: 13, lineHeight: 1.5 }}>
+              {step}
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* Correction / cancel / contact */}
+      <section
+        aria-label="Need to change or cancel"
+        className="border border-[var(--dpf-border)]"
+        style={{ borderRadius: 10, padding: "14px 18px", marginBottom: 24 }}
+      >
+        <h2 style={{ fontSize: 13, fontWeight: 700, marginBottom: 6 }}>
+          Need to change or cancel?
+        </h2>
+        <p className="text-[var(--dpf-muted)]" style={{ fontSize: 13, marginBottom: contact.email || contact.phone ? 8 : 0 }}>
+          Reply to our confirmation email, or contact the {orgName} team with your reference{" "}
+          <strong style={{ fontFamily: "monospace", color: "var(--dpf-text)" }}>{ref}</strong>.
+        </p>
+        {(contact.email || contact.phone) && (
+          <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+            {contact.email && (
+              <a href={`mailto:${contact.email}`} style={{ fontSize: 13, color: "var(--dpf-accent, #4f46e5)" }}>
+                ✉️ {contact.email}
+              </a>
+            )}
+            {contact.phone && (
+              <a href={`tel:${contact.phone}`} style={{ fontSize: 13, color: "var(--dpf-accent, #4f46e5)" }}>
+                📞 {contact.phone}
+              </a>
+            )}
+          </div>
+        )}
+      </section>
+
+      <div style={{ textAlign: "center" }}>
+        <a
+          href={`/s/${result.orgSlug}`}
+          className="border border-[var(--dpf-border)]"
+          style={{ display: "inline-block", padding: "8px 18px", borderRadius: 8, fontSize: 14, color: "var(--dpf-text)" }}
+        >
+          Back to {orgName}
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/storefront/SubmissionResultView.tsx
+++ b/apps/web/components/storefront/SubmissionResultView.tsx
@@ -84,12 +84,12 @@ export function SubmissionResultView({ result }: { result: SubmissionResultModel
         {(contact.email || contact.phone) && (
           <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
             {contact.email && (
-              <a href={`mailto:${contact.email}`} style={{ fontSize: 13, color: "var(--dpf-accent, #4f46e5)" }}>
+              <a href={`mailto:${contact.email}`} style={{ fontSize: 13, color: "var(--dpf-accent)" }}>
                 ✉️ {contact.email}
               </a>
             )}
             {contact.phone && (
-              <a href={`tel:${contact.phone}`} style={{ fontSize: 13, color: "var(--dpf-accent, #4f46e5)" }}>
+              <a href={`tel:${contact.phone}`} style={{ fontSize: 13, color: "var(--dpf-accent)" }}>
                 📞 {contact.phone}
               </a>
             )}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 576,
+  "routeCount": 580,
   "routes": [
     {
       "routePath": "/",
@@ -6320,6 +6320,20 @@
       "file": "apps/web/app/(storefront)/s/[slug]/book/[itemId]/page.tsx"
     },
     {
+      "routePath": "/s/[slug]/booking/confirmed",
+      "kind": "page",
+      "segments": [
+        "s",
+        "[slug]",
+        "booking",
+        "confirmed"
+      ],
+      "dynamicParams": [
+        "slug"
+      ],
+      "file": "apps/web/app/(storefront)/s/[slug]/booking/confirmed/page.tsx"
+    },
+    {
       "routePath": "/s/[slug]/checkout",
       "kind": "page",
       "segments": [
@@ -6344,6 +6358,20 @@
         "slug"
       ],
       "file": "apps/web/app/(storefront)/s/[slug]/donate/page.tsx"
+    },
+    {
+      "routePath": "/s/[slug]/donation/received",
+      "kind": "page",
+      "segments": [
+        "s",
+        "[slug]",
+        "donation",
+        "received"
+      ],
+      "dynamicParams": [
+        "slug"
+      ],
+      "file": "apps/web/app/(storefront)/s/[slug]/donation/received/page.tsx"
     },
     {
       "routePath": "/s/[slug]/inquire",
@@ -6374,6 +6402,20 @@
       "file": "apps/web/app/(storefront)/s/[slug]/inquire/[itemId]/page.tsx"
     },
     {
+      "routePath": "/s/[slug]/inquiry/received",
+      "kind": "page",
+      "segments": [
+        "s",
+        "[slug]",
+        "inquiry",
+        "received"
+      ],
+      "dynamicParams": [
+        "slug"
+      ],
+      "file": "apps/web/app/(storefront)/s/[slug]/inquiry/received/page.tsx"
+    },
+    {
       "routePath": "/s/[slug]/item/[itemId]",
       "kind": "page",
       "segments": [
@@ -6402,6 +6444,20 @@
         "itemId"
       ],
       "file": "apps/web/app/(storefront)/s/[slug]/order/[itemId]/page.tsx"
+    },
+    {
+      "routePath": "/s/[slug]/order/received",
+      "kind": "page",
+      "segments": [
+        "s",
+        "[slug]",
+        "order",
+        "received"
+      ],
+      "dynamicParams": [
+        "slug"
+      ],
+      "file": "apps/web/app/(storefront)/s/[slug]/order/received/page.tsx"
     },
     {
       "routePath": "/s/[slug]/policies",

--- a/apps/web/lib/navigation/route-audience.generated.json
+++ b/apps/web/lib/navigation/route-audience.generated.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-audience.ts",
-  "pageRouteCount": 332,
+  "pageRouteCount": 336,
   "summary": {
     "byAudience": {
       "admin": 140,
@@ -8,12 +8,12 @@
       "builder": 3,
       "customer": 10,
       "owner": 149,
-      "public": 17,
+      "public": 21,
       "worker": 2
     },
     "byDestinationKind": {
       "advanced-diagnostic": 94,
-      "detail": 156,
+      "detail": 160,
       "legacy-internal": 29,
       "section-home": 32,
       "settings-config": 12,
@@ -2041,6 +2041,13 @@
       "source": "heuristic"
     },
     {
+      "routePath": "/s/[slug]/booking/confirmed",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
       "routePath": "/s/[slug]/checkout",
       "audience": "public",
       "destinationKind": "detail",
@@ -2049,6 +2056,13 @@
     },
     {
       "routePath": "/s/[slug]/donate",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/donation/received",
       "audience": "public",
       "destinationKind": "detail",
       "confidence": "high",
@@ -2069,6 +2083,13 @@
       "source": "heuristic"
     },
     {
+      "routePath": "/s/[slug]/inquiry/received",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
       "routePath": "/s/[slug]/item/[itemId]",
       "audience": "public",
       "destinationKind": "detail",
@@ -2077,6 +2098,13 @@
     },
     {
       "routePath": "/s/[slug]/order/[itemId]",
+      "audience": "public",
+      "destinationKind": "detail",
+      "confidence": "high",
+      "source": "heuristic"
+    },
+    {
+      "routePath": "/s/[slug]/order/received",
       "audience": "public",
       "destinationKind": "detail",
       "confidence": "high",

--- a/apps/web/lib/storefront/form-validation.test.ts
+++ b/apps/web/lib/storefront/form-validation.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLikelyEmail,
+  validateRequiredFields,
+  errorId,
+  type ValidatableField,
+} from "./form-validation";
+
+// The generic inquiry schema (name/email required, phone/message optional).
+const INQUIRY_FIELDS: ValidatableField[] = [
+  { name: "name", label: "Your name", type: "text", required: true },
+  { name: "email", label: "Email address", type: "email", required: true },
+  { name: "phone", label: "Phone number", type: "tel", required: false },
+  { name: "message", label: "Message", type: "textarea", required: false },
+];
+
+// Public auth field contract (BI-F20763F5 item: public auth validation).
+const AUTH_FIELDS: ValidatableField[] = [
+  { name: "email", label: "Email", type: "email", required: true },
+  { name: "password", label: "Password", type: "text", required: true },
+];
+
+// Booking final-form contract — deterministic, no payment/network.
+const BOOKING_FIELDS: ValidatableField[] = [
+  { name: "name", label: "Your name", type: "text", required: true },
+  { name: "email", label: "Email", type: "email", required: true },
+  { name: "phone", label: "Phone", type: "tel", required: false },
+];
+
+describe("isLikelyEmail", () => {
+  it("accepts ordinary addresses", () => {
+    expect(isLikelyEmail("guest@example.com")).toBe(true);
+    expect(isLikelyEmail("  guest@example.co.uk  ")).toBe(true);
+  });
+  it("rejects obvious mistakes", () => {
+    expect(isLikelyEmail("guest")).toBe(false);
+    expect(isLikelyEmail("guest@")).toBe(false);
+    expect(isLikelyEmail("guest@example")).toBe(false);
+    expect(isLikelyEmail("")).toBe(false);
+  });
+});
+
+describe("validateRequiredFields — empty validation", () => {
+  it("flags every empty required field, keeps optional fields clean", () => {
+    const result = validateRequiredFields(INQUIRY_FIELDS, {});
+    expect(result.valid).toBe(false);
+    expect(result.order).toEqual(["name", "email"]);
+    expect(result.errors.name).toBe("Your name is required");
+    expect(result.errors.email).toBe("Email address is required");
+    expect(result.errors.phone).toBeUndefined();
+    expect(result.errors.message).toBeUndefined();
+  });
+
+  it("treats whitespace-only values as empty", () => {
+    const result = validateRequiredFields(INQUIRY_FIELDS, { name: "   ", email: "   " });
+    expect(result.valid).toBe(false);
+    expect(result.order).toEqual(["name", "email"]);
+  });
+});
+
+describe("validateRequiredFields — email format", () => {
+  it("rejects a malformed required email even when non-empty", () => {
+    const result = validateRequiredFields(INQUIRY_FIELDS, { name: "Guest", email: "nope" });
+    expect(result.valid).toBe(false);
+    expect(result.order).toEqual(["email"]);
+    expect(result.errors.email).toBe("Enter a valid email address");
+  });
+
+  it("passes a fully valid submission", () => {
+    const result = validateRequiredFields(INQUIRY_FIELDS, {
+      name: "Guest",
+      email: "guest@example.com",
+    });
+    expect(result.valid).toBe(true);
+    expect(result.order).toEqual([]);
+    expect(result.errors).toEqual({});
+  });
+});
+
+describe("validateRequiredFields — public auth contract", () => {
+  it("requires email and password on empty submit", () => {
+    const result = validateRequiredFields(AUTH_FIELDS, {});
+    expect(result.valid).toBe(false);
+    expect(result.order).toEqual(["email", "password"]);
+  });
+
+  it("accepts a valid credential pair", () => {
+    const result = validateRequiredFields(AUTH_FIELDS, {
+      email: "guest@example.com",
+      password: "hunter2",
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("validateRequiredFields — deterministic booking final form", () => {
+  it("blocks an empty booking form with no side effects (pure)", () => {
+    const result = validateRequiredFields(BOOKING_FIELDS, { phone: "" });
+    expect(result.valid).toBe(false);
+    expect(result.order).toEqual(["name", "email"]);
+  });
+
+  it("passes when name + email are present (phone optional)", () => {
+    const result = validateRequiredFields(BOOKING_FIELDS, {
+      name: "Jane Guest",
+      email: "jane@example.com",
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("errorId", () => {
+  it("builds a stable, unique id per form + field", () => {
+    expect(errorId("inquiry", "email")).toBe("inquiry-email-error");
+  });
+});

--- a/apps/web/lib/storefront/form-validation.ts
+++ b/apps/web/lib/storefront/form-validation.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared, framework-free validation for public storefront customer forms
+ * (BI-F20763F5). Public forms previously relied on browser-native
+ * `required` blocking only, which is invisible to a summary region and
+ * inconsistent for assistive technology. This helper is the single, pure
+ * contract used to produce *visible* inline + summary validation so the
+ * feedback is deterministic and testable without a DOM.
+ *
+ * It is intentionally decoupled from the shared `ui/form` primitives
+ * (BI-8E74C749) so a public form can adopt visible validation without a
+ * compile-time dependency on that in-flight work; the two share the same
+ * accessible pattern (aria-invalid + aria-describedby + a role="alert"
+ * summary) rather than sharing code.
+ */
+
+export type ValidatableField = {
+  name: string;
+  label: string;
+  type: string;
+  required: boolean;
+};
+
+export type FieldErrors = Record<string, string>;
+
+export type ValidationResult = {
+  valid: boolean;
+  /** Per-field message, keyed by field name — drives inline errors. */
+  errors: FieldErrors;
+  /** Ordered field names with errors — drives the summary region ordering. */
+  order: string[];
+};
+
+// Deliberately permissive: catches the "obviously not an email" mistakes a
+// customer makes (missing @, missing domain, trailing dot) without rejecting
+// valid-but-unusual addresses. Server-side validation remains authoritative.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isLikelyEmail(value: string): boolean {
+  return EMAIL_RE.test(value.trim());
+}
+
+/**
+ * Validate a set of field values against their schema. Returns per-field
+ * messages plus a stable order so the summary lists errors in field order.
+ *
+ * @param fields the form schema (required flag + type drive the rules)
+ * @param values raw string values keyed by field name (missing = empty)
+ */
+export function validateRequiredFields(
+  fields: ReadonlyArray<ValidatableField>,
+  values: Record<string, string | undefined | null>,
+): ValidationResult {
+  const errors: FieldErrors = {};
+  const order: string[] = [];
+
+  for (const field of fields) {
+    const raw = values[field.name];
+    const value = typeof raw === "string" ? raw.trim() : "";
+
+    if (field.required && value === "") {
+      errors[field.name] = `${field.label} is required`;
+      order.push(field.name);
+      continue;
+    }
+
+    // Only format-check when a value is present; an empty optional email is fine.
+    if (value !== "" && field.type === "email" && !isLikelyEmail(value)) {
+      errors[field.name] = `Enter a valid email address`;
+      order.push(field.name);
+    }
+  }
+
+  return { valid: order.length === 0, errors, order };
+}
+
+/** Stable id for a field's inline error node, used by aria-describedby. */
+export function errorId(formId: string, fieldName: string): string {
+  return `${formId}-${fieldName}-error`;
+}

--- a/apps/web/lib/storefront/submission-result-content.ts
+++ b/apps/web/lib/storefront/submission-result-content.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure copy + type contract for the customer submit-result surface
+ * (BI-F20763F5). No database or framework imports — this is the part that
+ * decides *what the customer reads* on a result page, so it stays unit-testable
+ * in isolation. The DB loader lives in `submission-result.ts` and re-exports
+ * everything here for callers.
+ */
+
+export type SubmissionType = "inquiry" | "booking" | "order" | "donation";
+
+export const SUBMISSION_TYPES: readonly SubmissionType[] = [
+  "inquiry",
+  "booking",
+  "order",
+  "donation",
+] as const;
+
+export function isSubmissionType(value: string): value is SubmissionType {
+  return (SUBMISSION_TYPES as readonly string[]).includes(value);
+}
+
+/** The named result route for a submission type (relative to `/s/[slug]`). */
+export function resultRouteFor(type: SubmissionType): string {
+  switch (type) {
+    case "inquiry":
+      return "inquiry/received";
+    case "booking":
+      return "booking/confirmed";
+    case "order":
+      return "order/received";
+    case "donation":
+      return "donation/received";
+  }
+}
+
+export type ContextLine = { label: string; value: string };
+
+export type SubmissionResultModel = {
+  type: SubmissionType;
+  ref: string;
+  orgName: string;
+  orgSlug: string;
+  heading: string;
+  icon: string;
+  /** Human summary of exactly what the customer submitted. */
+  context: ContextLine[];
+  /** Where and how the business will reply. */
+  responseChannel: string;
+  /** Expected timeframe copy. */
+  responseTime: string;
+  /** Ordered "what happens next" steps. */
+  nextSteps: string[];
+  /** Correction / cancel / contact affordances. */
+  contact: { email: string | null; phone: string | null };
+};
+
+export function resultHeading(type: SubmissionType): { heading: string; icon: string } {
+  switch (type) {
+    case "booking":
+      return { heading: "Your table is reserved", icon: "📅" };
+    case "inquiry":
+      return { heading: "Thanks — we've received your enquiry", icon: "✉️" };
+    case "order":
+      return { heading: "Your order is in", icon: "🧾" };
+    case "donation":
+      return { heading: "Thank you for your support", icon: "❤️" };
+  }
+}
+
+export function whatHappensNextSteps(type: SubmissionType, orgName: string): string[] {
+  switch (type) {
+    case "booking":
+      return [
+        `${orgName} holds your table for the date and time above.`,
+        "You'll receive an email confirming your reservation.",
+        "Just turn up — no payment is taken online.",
+      ];
+    case "inquiry":
+      return [
+        `A member of the ${orgName} team reads your enquiry.`,
+        "We reply using the contact details you gave us.",
+        "We'll confirm anything we need before going ahead.",
+      ];
+    case "order":
+      return [
+        `${orgName} reviews your order.`,
+        "We'll be in touch to confirm details and timing.",
+        "Keep your reference handy for any questions.",
+      ];
+    case "donation":
+      return [
+        `Your gift goes straight to ${orgName}.`,
+        "We'll email you a confirmation and receipt.",
+        "Thank you for making a difference.",
+      ];
+  }
+}
+
+/** Where we'll reply. Email is the primary channel for every submission type. */
+export function responseChannelCopy(email: string | null): string {
+  return email
+    ? `We'll reply by email to ${email}.`
+    : "We'll reply using the contact details you provided.";
+}
+
+/**
+ * Expected timeframe. Intentionally a soft, honest default rather than a
+ * fabricated per-business SLA — the owner has not configured a promised
+ * response time, so we state an aim, not a guarantee.
+ */
+export function responseTimeCopy(type: SubmissionType): string {
+  return type === "booking"
+    ? "We aim to confirm your reservation within one business day."
+    : "We aim to respond within one business day.";
+}

--- a/apps/web/lib/storefront/submission-result.test.ts
+++ b/apps/web/lib/storefront/submission-result.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSubmissionType,
+  resultRouteFor,
+  resultHeading,
+  whatHappensNextSteps,
+  responseChannelCopy,
+  responseTimeCopy,
+  SUBMISSION_TYPES,
+  type SubmissionType,
+} from "./submission-result-content";
+
+describe("isSubmissionType", () => {
+  it("accepts the four supported types", () => {
+    for (const t of ["inquiry", "booking", "order", "donation"]) {
+      expect(isSubmissionType(t)).toBe(true);
+    }
+  });
+  it("rejects unknown types (e.g. checkout plumbing)", () => {
+    expect(isSubmissionType("checkout")).toBe(false);
+    expect(isSubmissionType("")).toBe(false);
+  });
+});
+
+describe("resultRouteFor — named result routes, never /checkout", () => {
+  it("maps each type to a result-named route", () => {
+    expect(resultRouteFor("inquiry")).toBe("inquiry/received");
+    expect(resultRouteFor("booking")).toBe("booking/confirmed");
+    expect(resultRouteFor("order")).toBe("order/received");
+    expect(resultRouteFor("donation")).toBe("donation/received");
+  });
+  it("no route reuses the checkout segment", () => {
+    for (const t of SUBMISSION_TYPES) {
+      expect(resultRouteFor(t)).not.toContain("checkout");
+    }
+  });
+});
+
+describe("resultHeading", () => {
+  it("gives a customer-facing heading per type", () => {
+    expect(resultHeading("booking").heading).toMatch(/reserved/i);
+    expect(resultHeading("inquiry").heading).toMatch(/enquiry/i);
+    expect(resultHeading("order").heading.length).toBeGreaterThan(0);
+    expect(resultHeading("donation").heading).toMatch(/thank/i);
+  });
+});
+
+describe("whatHappensNextSteps", () => {
+  it("returns ordered, brand-personalised steps", () => {
+    const steps = whatHappensNextSteps("inquiry", "Bella Trattoria");
+    expect(steps.length).toBeGreaterThanOrEqual(3);
+    expect(steps[0]).toContain("Bella Trattoria");
+  });
+  it("booking steps reassure that no online payment is taken", () => {
+    const steps = whatHappensNextSteps("booking", "Bella Trattoria");
+    expect(steps.join(" ")).toMatch(/no payment/i);
+  });
+});
+
+describe("responseChannelCopy", () => {
+  it("names the customer email when known", () => {
+    expect(responseChannelCopy("guest@example.com")).toContain("guest@example.com");
+  });
+  it("falls back gracefully when no email is known", () => {
+    expect(responseChannelCopy(null)).toMatch(/contact details/i);
+  });
+});
+
+describe("responseTimeCopy", () => {
+  it("states an aim, not a fabricated guarantee", () => {
+    const copy = responseTimeCopy("inquiry");
+    expect(copy).toMatch(/aim/i);
+    expect(copy).toMatch(/business day/i);
+  });
+  it("uses reservation wording for bookings", () => {
+    expect(responseTimeCopy("booking")).toMatch(/reservation/i);
+  });
+});
+
+describe("SUBMISSION_TYPES coverage", () => {
+  it("every type resolves through the full copy contract without throwing", () => {
+    for (const t of SUBMISSION_TYPES as readonly SubmissionType[]) {
+      expect(() => {
+        resultHeading(t);
+        whatHappensNextSteps(t, "Org");
+        responseTimeCopy(t);
+        resultRouteFor(t);
+      }).not.toThrow();
+    }
+  });
+});

--- a/apps/web/lib/storefront/submission-result.ts
+++ b/apps/web/lib/storefront/submission-result.ts
@@ -1,0 +1,173 @@
+/**
+ * Customer submit-result contract — server loader (BI-F20763F5).
+ *
+ * A successful inquiry/booking/order/donation must land the customer on a
+ * result surface that is NAMED for the result (`/inquiry/received`,
+ * `/booking/confirmed`, …) — not the generic `/checkout` plumbing — and must
+ * explain: what they submitted, their reference, the response channel and
+ * expected time, what happens next, and how to correct / cancel / contact.
+ *
+ * The pure copy + type contract lives in `submission-result-content.ts` (no DB
+ * import, unit-tested there). This module adds `loadSubmissionResult`, which
+ * validates the reference against the storefront and assembles the branded,
+ * Restaurant-appropriate context.
+ */
+
+import { prisma } from "@dpf/db";
+import {
+  isSubmissionType,
+  resultHeading,
+  responseChannelCopy,
+  responseTimeCopy,
+  whatHappensNextSteps,
+  type ContextLine,
+  type SubmissionResultModel,
+  type SubmissionType,
+} from "./submission-result-content";
+
+export {
+  isSubmissionType,
+  resultRouteFor,
+  resultHeading,
+  whatHappensNextSteps,
+  responseChannelCopy,
+  responseTimeCopy,
+  SUBMISSION_TYPES,
+} from "./submission-result-content";
+export type { ContextLine, SubmissionResultModel, SubmissionType } from "./submission-result-content";
+
+function formatWhen(scheduledAt: Date, timezone: string): string {
+  const opts: Intl.DateTimeFormatOptions = {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  };
+  try {
+    return new Intl.DateTimeFormat("en-GB", { ...opts, timeZone: timezone || "UTC" }).format(scheduledAt);
+  } catch {
+    // Guard against an invalid stored timezone string.
+    return new Intl.DateTimeFormat("en-GB", { ...opts, timeZone: "UTC" }).format(scheduledAt);
+  }
+}
+
+/**
+ * Validate `ref` against the storefront and assemble the branded result model.
+ * Returns `null` when the storefront or the referenced record does not exist —
+ * the route renders `notFound()` in that case, so a guessed/stale ref never
+ * shows a fabricated confirmation.
+ */
+export async function loadSubmissionResult(
+  slug: string,
+  type: SubmissionType,
+  ref: string,
+): Promise<SubmissionResultModel | null> {
+  if (!isSubmissionType(type)) return null;
+
+  const config = await prisma.storefrontConfig.findFirst({
+    where: { organization: { slug } },
+    select: {
+      id: true,
+      timezone: true,
+      contactEmail: true,
+      contactPhone: true,
+      organization: { select: { name: true, slug: true } },
+    },
+  });
+  if (!config) return null;
+
+  const storefrontId = config.id;
+  const orgName = config.organization.name;
+  const orgSlug = config.organization.slug;
+  const { heading, icon } = resultHeading(type);
+
+  const context: ContextLine[] = [];
+  let customerEmail: string | null = null;
+
+  async function itemName(itemId: string | null | undefined): Promise<string | null> {
+    if (!itemId) return null;
+    const item = await prisma.storefrontItem.findFirst({
+      where: { id: itemId, storefrontId },
+      select: { name: true },
+    });
+    return item?.name ?? null;
+  }
+
+  if (type === "inquiry") {
+    const row = await prisma.storefrontInquiry.findFirst({
+      where: { inquiryRef: ref, storefrontId },
+      select: {
+        customerName: true,
+        customerEmail: true,
+        customerPhone: true,
+        message: true,
+        itemId: true,
+      },
+    });
+    if (!row) return null;
+    customerEmail = row.customerEmail;
+    const name = await itemName(row.itemId);
+    if (name) context.push({ label: "About", value: name });
+    context.push({ label: "Name", value: row.customerName });
+    context.push({ label: "Email", value: row.customerEmail });
+    if (row.customerPhone) context.push({ label: "Phone", value: row.customerPhone });
+    if (row.message) context.push({ label: "Your message", value: row.message });
+  } else if (type === "booking") {
+    const row = await prisma.storefrontBooking.findFirst({
+      where: { bookingRef: ref, storefrontId },
+      select: {
+        customerName: true,
+        customerEmail: true,
+        customerPhone: true,
+        scheduledAt: true,
+        durationMinutes: true,
+        notes: true,
+        itemId: true,
+      },
+    });
+    if (!row) return null;
+    customerEmail = row.customerEmail;
+    const name = await itemName(row.itemId);
+    if (name) context.push({ label: "Reservation", value: name });
+    context.push({ label: "When", value: formatWhen(row.scheduledAt, config.timezone) });
+    context.push({ label: "For", value: `${row.durationMinutes} minutes` });
+    context.push({ label: "Name", value: row.customerName });
+    context.push({ label: "Email", value: row.customerEmail });
+    if (row.customerPhone) context.push({ label: "Phone", value: row.customerPhone });
+    if (row.notes) context.push({ label: "Notes", value: row.notes });
+  } else if (type === "order") {
+    const row = await prisma.storefrontOrder.findFirst({
+      where: { orderRef: ref, storefrontId },
+      select: { customerName: true, customerEmail: true },
+    });
+    if (!row) return null;
+    customerEmail = row.customerEmail;
+    if (row.customerName) context.push({ label: "Name", value: row.customerName });
+    context.push({ label: "Email", value: row.customerEmail });
+  } else {
+    const row = await prisma.storefrontDonation.findFirst({
+      where: { donationRef: ref, storefrontId },
+      select: { donorName: true, donorEmail: true, isAnonymous: true },
+    });
+    if (!row) return null;
+    customerEmail = row.donorEmail;
+    if (row.donorName && !row.isAnonymous) context.push({ label: "Name", value: row.donorName });
+    context.push({ label: "Email", value: row.donorEmail });
+  }
+
+  return {
+    type,
+    ref,
+    orgName,
+    orgSlug,
+    heading,
+    icon,
+    context,
+    responseChannel: responseChannelCopy(customerEmail),
+    responseTime: responseTimeCopy(type),
+    nextSteps: whatHappensNextSteps(type, orgName),
+    contact: { email: config.contactEmail, phone: config.contactPhone },
+  };
+}

--- a/docs/superpowers/specs/2026-07-22-customer-submit-result-contract.md
+++ b/docs/superpowers/specs/2026-07-22-customer-submit-result-contract.md
@@ -1,0 +1,120 @@
+# Customer submit-result contract (BI-F20763F5)
+
+**Status:** implemented
+**Date:** 2026-07-22
+**Backlog item:** BI-F20763F5 — "Customer submissions need clear success, validation, and owner handoff feedback"
+**Epic:** EP-UX-COGLOAD (Live UX cognitive-load audit follow-up)
+
+## Problem
+
+A live customer submit/result audit (2026-07-22) found the public storefront can
+submit and create owner-side work, but the feedback contract is too thin for a
+non-technical Restaurant customer or owner:
+
+- Public forms relied on **browser-native `required` blocking only** — no visible
+  inline or summary validation, several controls with empty accessible labels.
+- A safe inquiry submit landed on `/s/<slug>/checkout?ref=INQ-…&type=inquiry`
+  ("Enquiry received! … We'll be in touch shortly.") — success plumbing that
+  reads like a checkout and omits **what was requested, response channel/time,
+  what happens next, and how to correct/cancel/contact**.
+- The owner `/storefront/inbox` inquiry row exposed a generic **`Send to backlog`**
+  action with no row context or consequence copy.
+
+## Design grounding
+
+- **Source of truth:** `docs/platform-usability-standards.md` (accessible form
+  contract, owned/extended by BI-8E74C749) and the public storefront route
+  substrate under `apps/web/app/(storefront)/s/[slug]/`.
+- **Substrate check (grep + open PRs):** the shared `apps/web/components/ui/form/`
+  primitives, `SlotBookingFlow`, `BookingForm`, auth forms, and the owner inbox
+  **booking** rows are already claimed by in-flight sibling PRs (#3386, #3387,
+  #3383). This work is scoped to the **uncontended delta**: the public
+  **inquiry** form, the **result page/route**, and the owner **inquiry** row.
+- **Decision:** create a new, self-contained contract (this spec) that *composes*
+  with the form-primitive work rather than depending on it at compile time — a
+  public form can adopt visible validation without waiting for #3386 to merge.
+  The two share the same accessible pattern (`aria-invalid` +
+  `aria-describedby` + a `role="alert"` summary), not shared code.
+
+## Contract
+
+### 1. Visible, accessible, branded validation
+
+`apps/web/lib/storefront/form-validation.ts` is the single pure validation
+contract (`validateRequiredFields`): required-empty + email-format rules, a
+stable error order for the summary, and `errorId` for `aria-describedby`. The
+public inquiry form (`InquiryForm`) renders:
+
+- a `role="alert"`, focus-managed **error summary** listing each failing field
+  (anchored to the field), and
+- **inline** per-field messages with `aria-invalid`/`aria-describedby` and an
+  accessible "(required)" marker.
+
+`noValidate` disables browser-native bubbles so our visible contract is the
+single source of feedback.
+
+### 2. Named result routes (never `/checkout` for non-checkout actions)
+
+`apps/web/lib/storefront/submission-result-content.ts` (pure) maps each
+submission type to a **result-named** route:
+
+| Type      | Route (under `/s/[slug]`) |
+|-----------|---------------------------|
+| inquiry   | `inquiry/received`        |
+| booking   | `booking/confirmed`       |
+| order     | `order/received`          |
+| donation  | `donation/received`       |
+
+`submission-result.ts` adds `loadSubmissionResult`, which validates the
+reference against the storefront and assembles a branded model. Each route is a
+thin server page rendering `SubmissionResultView`, which inherits the storefront
+brand/nav from `s/[slug]/layout.tsx` and shows:
+
+- reference, **what you submitted** (name/email/item/date-time/message/notes),
+- **response channel** (email) + an honest **expected time** (an *aim*, not a
+  fabricated SLA),
+- **what happens next** (ordered, brand-personalised steps),
+- **correction/cancel/contact** (reply-to-email framing + `mailto:`/`tel:` when
+  the storefront has configured contact channels), and a branded return link.
+
+`InquiryForm` now navigates to `inquiry/received`. The old `/checkout` page is
+retained only as a **back-compat redirect** that forwards any submit path still
+targeting `/checkout?ref=&type=` to the matching named route — so the
+booking/order/donation flows owned by sibling PRs land correctly without this
+change touching their files.
+
+### 3. Owner inquiry handoff
+
+`StorefrontInbox` inquiry rows keep the reference + customer + message (request
+context) and replace the generic `Send to backlog` with a **row-specific** label
+(`Send inquiry INQ-… to backlog`), a full-context `aria-label`, and
+**consequence copy** ("Creates an internal work item … The customer isn't
+notified."). Booking rows are untouched (owned by BI-3DA1DFDC / #3387).
+
+## Coordination
+
+| BI / PR | Overlap | How this work stays additive |
+|---------|---------|------------------------------|
+| BI-8E74C749 / #3386 | shared `ui/form` primitives; auth + `BookingForm` | Inquiry form uses the *same accessible pattern* without importing the primitives (no merge-order dependency). Does not touch auth/BookingForm. |
+| BI-3DA1DFDC / #3387 | owner inbox **booking** rows + `booking-summary.ts` | Only the **inquiry** branch of `StorefrontInbox` is edited; booking branch and inbox page booking mapping untouched. |
+| BI-0E4A1228, BI-36807E68 / #3383 | booking final-form fields | `SlotBookingFlow` is not modified; booking success reaches `booking/confirmed` via the `/checkout` redirect. |
+| BI-4A68EDF6 | public trust/brand + gating unsupported paths | Result pages inherit storefront brand; `/checkout` now redirects (no bare checkout surface). Path gating remains that BI's scope. |
+| BI-348766E5, BI-7D7EE150 | workspace attention; owner action safety | Consequence copy on the inquiry action aligns; workspace reconciliation and destructive-action confirmation remain those BIs' scope. |
+
+## Tests
+
+- `form-validation.test.ts` — empty validation, email format, public-auth field
+  contract, deterministic booking final-form validation (pure, no side effects).
+- `submission-result.test.ts` — route naming (never `/checkout`), headings,
+  next-steps, response channel/time copy.
+- `SubmissionResultView.test.tsx` — reference, submitted context, response
+  channel/time, what-next, correction/cancel/contact, graceful no-contact case.
+- `InquiryForm.test.tsx` — empty submit shows summary + blocks network/nav;
+  invalid email blocked; safe valid submit calls the action and routes to
+  `inquiry/received` (never `/checkout`); server error surfaced without nav.
+- `StorefrontInbox.test.tsx` — inquiry row shows ref/customer/request context,
+  row-specific label, consequence copy, uniquely targetable per row.
+
+> Note: `InquiryForm.test.tsx` imports `next/navigation` (mocked, as ~dozens of
+> existing specs do) and therefore transforms only where `next` is installed
+> (CI), not in a source-only worktree. All other specs run locally green.


### PR DESCRIPTION
## Summary

Public Restaurant customer submissions had a too-thin feedback contract (live audit 2026-07-22, BI-F20763F5): forms relied on **browser-native `required` blocking only**, a successful inquiry landed on generic `/checkout?type=inquiry` plumbing with no context, and the owner inbox exposed a generic **`Send to backlog`** action. This PR adds a visible, accessible, Restaurant-branded **customer submit-result contract**.

### What changed
1. **Visible, accessible validation** — `apps/web/lib/storefront/form-validation.ts` (pure required + email rules) wired into `InquiryForm`: a `role="alert"` focus-managed **error summary** + **inline** `aria-invalid`/`aria-describedby` messages; `noValidate` replaces browser-native bubbles.
2. **Named result routes** — `inquiry/received`, `booking/confirmed`, `order/received`, `donation/received` under `apps/web/app/(storefront)/s/[slug]`, rendered by a branded **`SubmissionResultView`**: reference, *what you submitted*, response channel + honest expected time, *what happens next*, and correction/cancel/contact. Inquiry submit routes to `inquiry/received`; **`/checkout` is now a back-compat redirect** so sibling-owned booking/order/donation flows land correctly without this PR touching their files.
3. **Owner inquiry handoff** — `StorefrontInbox` inquiry rows keep ref/customer/message context and replace `Send to backlog` with a **row-specific label** (`Send inquiry INQ-… to backlog`), full-context `aria-label`, and **consequence copy** ("Creates an internal work item … The customer isn't notified.").

## Design grounding
- **Source of truth:** `docs/platform-usability-standards.md` + the `apps/web/app/(storefront)/s/[slug]` route substrate.
- **New artifact:** `docs/superpowers/specs/2026-07-22-customer-submit-result-contract.md`.
- Scoped to the **uncontended delta** (public inquiry form, result page/route, owner inquiry row) after an open-PR substrate sweep.

## Coordination (additive)
| BI / PR | Overlap | Kept additive by |
|---|---|---|
| BI-8E74C749 / #3386 | `ui/form` primitives; auth + `BookingForm` | Inquiry form uses the same accessible pattern **without importing** the primitives (no merge-order dependency); auth/BookingForm untouched. |
| BI-3DA1DFDC / #3387 | owner inbox **booking** rows | Only the **inquiry** branch of `StorefrontInbox` is edited; booking branch + inbox booking mapping untouched. Minor same-file diff, cleanly resolvable. |
| BI-0E4A1228, BI-36807E68 / #3383 | booking final-form fields | `SlotBookingFlow` not modified; booking success reaches `booking/confirmed` via the `/checkout` redirect. |
| BI-4A68EDF6 | public trust/brand; gating | Result pages inherit storefront brand; `/checkout` no longer a bare surface. Path gating stays that BI's scope. |
| BI-348766E5, BI-7D7EE150 | attention; action safety | Consequence copy aligns; workspace reconciliation + destructive-action confirmation remain those BIs' scope. |

## Tests
`form-validation`, `submission-result` content, `SubmissionResultView`, `InquiryForm`, and `StorefrontInbox` specs cover: **empty validation**, **safe inquiry submit** → named result route, **owner inbox visibility**, **public-auth field contract**, and **deterministic booking final-form validation** (no payment/external side effects).

## Verification
- **vitest: 34 passing** locally across `form-validation` (11), `submission-result` (11), `SubmissionResultView` (8), `StorefrontInbox` (4). `InquiryForm.test` imports `next/navigation` (mocked, as ~dozens of existing specs do) so it transforms in CI, not this source-only worktree.
- **Typecheck:** standalone `tsc` showed only `next`-not-installed cascades (app-wide baseline in this worktree); my pure modules + view + loader are error-free. Local pre-commit typecheck skipped (`next` binary absent in source-only worktree) — **CI Typecheck gate is authoritative.**

Design-Grounding-Decision: New spec `docs/superpowers/specs/2026-07-22-customer-submit-result-contract.md` grounded in `docs/platform-usability-standards.md` and the `apps/web/app/(storefront)` route substrate; scoped to the uncontended inquiry/result delta.
Process-Spine-Decision: Spec added under docs/superpowers/specs/ for this new customer submit-result contract.
UX-Fit-Decision: Progressive disclosure — validation surfaces only on submit as a plain-language summary + inline messages; no new dashboards/tabs; no raw tokens/endpoints exposed; result page states an honest response aim, not a fabricated SLA.
Docs-Impact: Added spec; no customer /docs help pages changed (doc-index unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
