### PR TITLE
feat(docs): route-specific quick-help panel for contextual Docs (BI-2DD18122)

### DIFF
--- a/apps/web/app/(shell)/docs/[[...slug]]/page.tsx
+++ b/apps/web/app/(shell)/docs/[[...slug]]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { loadDocPage, loadAllDocs, buildDocsIndex, extractHeadings, AREA_META, AREA_ORDER, type DocsIndex } from "@/lib/docs";
 import { DocsLayout } from "@/components/docs/DocsLayout";
 import { DocRenderer } from "@/components/docs/DocRenderer";
+import { ContextualQuickHelp } from "@/components/docs/ContextualQuickHelp";
 
 type Props = {
   params: Promise<{ slug?: string[] }>;
@@ -28,10 +29,14 @@ export default async function DocsPage({ params, searchParams }: Props) {
     content: d.content.slice(0, 500),
   }));
 
+  // Arrived contextually from a specific page — demote the catalog so the
+  // immediate explanation is not competing with the full docs manual.
+  const contextual = Boolean(sourceRoute);
+
   // No slug = docs home page
   if (!slug || slug.length === 0) {
     return (
-      <DocsLayout index={sidebarIndex} currentSlug="" searchItems={searchItems}>
+      <DocsLayout index={sidebarIndex} currentSlug="" searchItems={searchItems} collapseCatalog={contextual}>
         <DocsHome index={index} sourceRoute={sourceRoute} />
       </DocsLayout>
     );
@@ -45,43 +50,69 @@ export default async function DocsPage({ params, searchParams }: Props) {
   const tocHeadings = extractHeadings(doc.content);
 
   return (
-    <DocsLayout index={sidebarIndex} currentSlug={docSlug} searchItems={searchItems} headings={tocHeadings}>
+    <DocsLayout
+      index={sidebarIndex}
+      currentSlug={docSlug}
+      searchItems={searchItems}
+      headings={tocHeadings}
+      collapseCatalog={contextual}
+    >
       <DocContent doc={doc} sourceRoute={sourceRoute} />
     </DocsLayout>
   );
 }
 
 function DocsHome({ index, sourceRoute }: { index: Record<string, unknown[]>; sourceRoute?: string }) {
+  const contextual = Boolean(sourceRoute);
+  const catalog = (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {AREA_ORDER.map((areaKey) => {
+        const meta = AREA_META[areaKey];
+        if (!meta) return null;
+        const pages = index[areaKey] as unknown[] | undefined;
+        const pageCount = pages?.length ?? 0;
+        return (
+          <a
+            key={areaKey}
+            href={`/docs/${areaKey}/index`}
+            className="block p-4 rounded-lg border border-[var(--dpf-border)] hover:border-[var(--dpf-accent)] transition-colors"
+          >
+            <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-1">{meta.label}</h2>
+            <p className="text-xs text-[var(--dpf-muted)]">{meta.description}</p>
+            {pageCount > 0 && (
+              <p className="text-[10px] text-[var(--dpf-muted)] mt-2">
+                {pageCount} page{pageCount !== 1 ? "s" : ""}
+              </p>
+            )}
+          </a>
+        );
+      })}
+    </div>
+  );
+
+  // Contextual arrival: quick help leads, and the full catalog is demoted into
+  // a collapsed disclosure so it does not compete with the immediate answer.
+  if (contextual && sourceRoute) {
+    return (
+      <div>
+        <ContextualQuickHelp sourceRoute={sourceRoute} />
+        <details className="rounded-lg border border-[var(--dpf-border)]">
+          <summary className="cursor-pointer px-4 py-3 text-sm font-medium text-[var(--dpf-text)]">
+            Browse the full documentation catalog
+          </summary>
+          <div className="px-4 pb-4">{catalog}</div>
+        </details>
+      </div>
+    );
+  }
+
   return (
     <div>
-      {sourceRoute ? <ContextualSourceBanner sourceRoute={sourceRoute} /> : null}
       <h1 className="text-xl font-bold text-[var(--dpf-text)] mb-2">Documentation</h1>
       <p className="text-sm text-[var(--dpf-muted)] mb-6">
         Learn how to use every area of the platform.
       </p>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {AREA_ORDER.map((areaKey) => {
-          const meta = AREA_META[areaKey];
-          if (!meta) return null;
-          const pages = index[areaKey] as unknown[] | undefined;
-          const pageCount = pages?.length ?? 0;
-          return (
-            <a
-              key={areaKey}
-              href={`/docs/${areaKey}/index`}
-              className="block p-4 rounded-lg border border-[var(--dpf-border)] hover:border-[var(--dpf-accent)] transition-colors"
-            >
-              <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-1">{meta.label}</h2>
-              <p className="text-xs text-[var(--dpf-muted)]">{meta.description}</p>
-              {pageCount > 0 && (
-                <p className="text-[10px] text-[var(--dpf-muted)] mt-2">
-                  {pageCount} page{pageCount !== 1 ? "s" : ""}
-                </p>
-              )}
-            </a>
-          );
-        })}
-      </div>
+      {catalog}
     </div>
   );
 }
@@ -96,7 +127,7 @@ function DocContent({
   const areaLabel = AREA_META[doc.area]?.label ?? doc.area;
   return (
     <div>
-      {sourceRoute ? <ContextualSourceBanner sourceRoute={sourceRoute} /> : null}
+      {sourceRoute ? <ContextualQuickHelp sourceRoute={sourceRoute} /> : null}
       <div className="mb-2">
         <a href="/docs" className="text-xs text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]">Docs</a>
         <span className="text-xs text-[var(--dpf-muted)]"> / </span>
@@ -106,29 +137,6 @@ function DocContent({
       </div>
       <h1 className="text-xl font-bold text-[var(--dpf-text)] mb-6">{doc.title}</h1>
       <DocRenderer content={doc.content} sourcePath={`docs/user-guide/${doc.slug}.md`} />
-    </div>
-  );
-}
-
-function ContextualSourceBanner({ sourceRoute }: { sourceRoute: string }) {
-  if (!sourceRoute.startsWith("/")) return null;
-
-  return (
-    <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
-          Contextual Docs
-        </p>
-        <p className="text-sm text-[var(--dpf-text)]">
-          Opened from <span className="font-mono text-xs">{sourceRoute}</span>
-        </p>
-      </div>
-      <a
-        href={sourceRoute}
-        className="inline-flex items-center rounded-full border border-[var(--dpf-border)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-muted)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)]"
-      >
-        Back to page
-      </a>
     </div>
   );
 }

--- a/apps/web/components/docs/ContextualQuickHelp.test.tsx
+++ b/apps/web/components/docs/ContextualQuickHelp.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ContextualQuickHelp } from "./ContextualQuickHelp";
+import { resolveQuickHelp } from "@/lib/docs-quick-help";
+
+describe("ContextualQuickHelp — source banner", () => {
+  it("keeps the sourceRoute provenance and a Back to page link", () => {
+    const html = renderToStaticMarkup(<ContextualQuickHelp sourceRoute="/storefront/inbox" />);
+    expect(html).toContain("Opened from");
+    expect(html).toContain("/storefront/inbox");
+    expect(html).toContain("Back to page");
+    // Back to page links to the exact source route.
+    expect(html).toContain('href="/storefront/inbox"');
+  });
+
+  it("renders nothing for a non-internal source route", () => {
+    const html = renderToStaticMarkup(<ContextualQuickHelp sourceRoute="https://evil.example" />);
+    expect(html).toBe("");
+  });
+});
+
+describe("ContextualQuickHelp — quick help panel", () => {
+  it("leads with the five quick-help questions when the route has help", () => {
+    const html = renderToStaticMarkup(<ContextualQuickHelp sourceRoute="/ops/self-upgrade" />);
+    for (const label of [
+      "What this page is",
+      "What to do now",
+      "If you do nothing",
+      "What&#x27;s reversible",
+      "Where to get help",
+    ]) {
+      expect(html, `panel should show "${label}"`).toContain(label);
+    }
+    // And the actual route-specific copy is present, not a generic manual.
+    const help = resolveQuickHelp("/ops/self-upgrade")!;
+    expect(html).toContain("Quick help");
+    expect(html).toContain(help.whatThisPageIs);
+    expect(html).toContain(help.reversible);
+  });
+
+  it("shows the banner without a panel for a route that has no quick help", () => {
+    const html = renderToStaticMarkup(<ContextualQuickHelp sourceRoute="/finance/reports/cash-flow" />);
+    expect(html).toContain("Back to page");
+    expect(html).toContain("/finance/reports/cash-flow");
+    expect(html).not.toContain("Quick help");
+  });
+
+  it("renders route-specific business-settings copy distinct from the settings default", () => {
+    const html = renderToStaticMarkup(<ContextualQuickHelp sourceRoute="/storefront/settings/business" />);
+    const business = resolveQuickHelp("/storefront/settings/business")!;
+    expect(html).toContain(business.whatThisPageIs);
+  });
+});

--- a/apps/web/components/docs/ContextualQuickHelp.tsx
+++ b/apps/web/components/docs/ContextualQuickHelp.tsx
@@ -1,0 +1,77 @@
+import { resolveQuickHelp, type QuickHelp } from "@/lib/docs-quick-help";
+
+type Props = {
+  sourceRoute: string;
+};
+
+/**
+ * The contextual header shown when docs are opened from a specific page.
+ *
+ * It keeps the "Back to page" affordance and the `sourceRoute` provenance, and
+ * — when the route has route-specific quick help — leads with a short panel
+ * that answers the five questions someone actually has when they open help
+ * while stuck: what this page is, what to do now, what happens if they do
+ * nothing, what is reversible, and where recovery lives. The full doc body
+ * follows underneath.
+ */
+export function ContextualQuickHelp({ sourceRoute }: Props) {
+  if (!sourceRoute.startsWith("/")) return null;
+
+  const help = resolveQuickHelp(sourceRoute);
+
+  return (
+    <section aria-label="Contextual help" className="mb-6">
+      <ContextualSourceBanner sourceRoute={sourceRoute} />
+      {help ? <QuickHelpPanel help={help} /> : null}
+    </section>
+  );
+}
+
+function ContextualSourceBanner({ sourceRoute }: { sourceRoute: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-3">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--dpf-muted)]">
+          Contextual Docs
+        </p>
+        <p className="text-sm text-[var(--dpf-text)]">
+          Opened from <span className="font-mono text-xs">{sourceRoute}</span>
+        </p>
+      </div>
+      <a
+        href={sourceRoute}
+        className="inline-flex shrink-0 items-center rounded-full border border-[var(--dpf-border)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-muted)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)]"
+      >
+        Back to page
+      </a>
+    </div>
+  );
+}
+
+const QUICK_HELP_ROWS: Array<{ key: keyof QuickHelp; label: string }> = [
+  { key: "whatThisPageIs", label: "What this page is" },
+  { key: "actionNow", label: "What to do now" },
+  { key: "ifNothingDone", label: "If you do nothing" },
+  { key: "reversible", label: "What's reversible" },
+  { key: "recovery", label: "Where to get help" },
+];
+
+function QuickHelpPanel({ help }: { help: QuickHelp }) {
+  return (
+    <div className="mt-3 rounded-lg border border-[var(--dpf-accent)]/40 bg-[var(--dpf-surface-1)] p-4">
+      <p className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--dpf-accent)]">
+        Quick help
+      </p>
+      <dl className="space-y-3">
+        {QUICK_HELP_ROWS.map((row) => (
+          <div key={row.key}>
+            <dt className="text-[11px] font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+              {row.label}
+            </dt>
+            <dd className="mt-0.5 text-sm text-[var(--dpf-text)]">{help[row.key]}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/apps/web/components/docs/DocsLayout.tsx
+++ b/apps/web/components/docs/DocsLayout.tsx
@@ -9,10 +9,12 @@ type Props = {
   currentSlug: string;
   searchItems: Array<{ slug: string; title: string; area: string; content: string }>;
   headings?: DocHeading[];
+  /** Demote the full area catalog into a collapsed disclosure (contextual arrival). */
+  collapseCatalog?: boolean;
   children: React.ReactNode;
 };
 
-export function DocsLayout({ index, currentSlug, searchItems, headings, children }: Props) {
+export function DocsLayout({ index, currentSlug, searchItems, headings, collapseCatalog = false, children }: Props) {
   const tocHeadings = headings ?? [];
 
   return (
@@ -20,7 +22,7 @@ export function DocsLayout({ index, currentSlug, searchItems, headings, children
       {/* Left sidebar — search + area nav */}
       <div className="w-52 shrink-0 hidden lg:block">
         <DocsSearch items={searchItems} />
-        <DocsSidebar index={index} currentSlug={currentSlug} />
+        <DocsSidebar index={index} currentSlug={currentSlug} collapsible={collapseCatalog} />
       </div>
 
       {/* Main content */}

--- a/apps/web/components/docs/DocsSidebar.tsx
+++ b/apps/web/components/docs/DocsSidebar.tsx
@@ -6,60 +6,81 @@ import { AREA_META, AREA_ORDER, type DocsIndex } from "@/lib/docs-types";
 type Props = {
   index: DocsIndex;
   currentSlug: string;
+  /** Demote the full area list into a collapsed disclosure (contextual arrival). */
+  collapsible?: boolean;
 };
 
-export function DocsSidebar({ index, currentSlug }: Props) {
+export function DocsSidebar({ index, currentSlug, collapsible = false }: Props) {
   const currentArea = currentSlug.split("/")[0] ?? "";
+
+  const areaList = AREA_ORDER.map((areaKey) => {
+    const meta = AREA_META[areaKey];
+    if (!meta) return null;
+    const pages = index[areaKey];
+    if (!pages || pages.length === 0) return null;
+    const isCurrentArea = currentArea === areaKey;
+
+    return (
+      <div key={areaKey}>
+        <p
+          className={[
+            "text-[10px] uppercase tracking-widest mb-1",
+            isCurrentArea ? "text-[var(--dpf-accent)]" : "text-[var(--dpf-muted)]",
+          ].join(" ")}
+        >
+          {meta.label}
+        </p>
+        <ul className="space-y-0.5">
+          {pages.map((page) => {
+            const isActive = currentSlug === page.slug;
+            return (
+              <li key={page.slug}>
+                <Link
+                  href={`/docs/${page.slug}`}
+                  className={[
+                    "block text-xs py-0.5 px-2 rounded transition-colors",
+                    isActive
+                      ? "text-[var(--dpf-text)] bg-[var(--dpf-surface-2)]"
+                      : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
+                  ].join(" ")}
+                >
+                  {page.title}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    );
+  });
+
+  const allDocsLink = (
+    <Link
+      href="/docs"
+      className="block text-xs font-semibold text-[var(--dpf-accent)] hover:underline"
+    >
+      All Docs
+    </Link>
+  );
+
+  if (collapsible) {
+    return (
+      <nav className="sticky top-6 space-y-3">
+        {allDocsLink}
+        <details className="rounded border border-[var(--dpf-border)]">
+          <summary className="cursor-pointer px-2 py-1.5 text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+            Browse all areas
+          </summary>
+          <div className="space-y-4 px-2 py-2">{areaList}</div>
+        </details>
+      </nav>
+    );
+  }
 
   return (
     <nav className="sticky top-6 space-y-4">
-      <Link
-        href="/docs"
-        className="block text-xs font-semibold text-[var(--dpf-accent)] hover:underline mb-3"
-      >
-        All Docs
-      </Link>
-
-      {AREA_ORDER.map((areaKey) => {
-        const meta = AREA_META[areaKey];
-        if (!meta) return null;
-        const pages = index[areaKey];
-        if (!pages || pages.length === 0) return null;
-        const isCurrentArea = currentArea === areaKey;
-
-        return (
-          <div key={areaKey}>
-            <p
-              className={[
-                "text-[10px] uppercase tracking-widest mb-1",
-                isCurrentArea ? "text-[var(--dpf-accent)]" : "text-[var(--dpf-muted)]",
-              ].join(" ")}
-            >
-              {meta.label}
-            </p>
-            <ul className="space-y-0.5">
-              {pages.map((page) => {
-                const isActive = currentSlug === page.slug;
-                return (
-                  <li key={page.slug}>
-                    <Link
-                      href={`/docs/${page.slug}`}
-                      className={[
-                        "block text-xs py-0.5 px-2 rounded transition-colors",
-                        isActive
-                          ? "text-[var(--dpf-text)] bg-[var(--dpf-surface-2)]"
-                          : "text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]",
-                      ].join(" ")}
-                    >
-                      {page.title}
-                    </Link>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        );
-      })}
+      <div className="mb-3">{allDocsLink}</div>
+      {areaList}
     </nav>
   );
 }

--- a/apps/web/lib/docs-quick-help.test.ts
+++ b/apps/web/lib/docs-quick-help.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { getQuickHelpRoutes, resolveQuickHelp, type QuickHelp } from "./docs-quick-help";
+import { buildContextualDocsHref, resolveDocsPath } from "./docs-route-map";
+
+/** Every quick-help panel must answer all five questions with real copy. */
+function expectAnswersAllFive(help: QuickHelp | null): asserts help is QuickHelp {
+  expect(help).not.toBeNull();
+  const h = help!;
+  for (const key of ["whatThisPageIs", "actionNow", "ifNothingDone", "reversible", "recovery"] as const) {
+    expect(h[key].trim().length, `${key} should be non-empty`).toBeGreaterThan(0);
+  }
+}
+
+describe("resolveQuickHelp — required routes", () => {
+  const REQUIRED: Array<{ label: string; route: string }> = [
+    { label: "storefront inbox", route: "/storefront/inbox" },
+    { label: "storefront business settings", route: "/storefront/settings/business" },
+    { label: "self-upgrade", route: "/ops/self-upgrade" },
+    { label: "customer marketing", route: "/customer/marketing" },
+  ];
+
+  for (const { label, route } of REQUIRED) {
+    it(`answers all five questions for ${label} (${route})`, () => {
+      expectAnswersAllFive(resolveQuickHelp(route));
+    });
+
+    it(`still resolves for a leaf under ${route}`, () => {
+      expectAnswersAllFive(resolveQuickHelp(`${route}/EX-001`));
+    });
+  }
+});
+
+describe("resolveQuickHelp — longest-prefix specificity", () => {
+  it("self-upgrade gets its own help, not the generic /ops backlog help", () => {
+    const selfUpgrade = resolveQuickHelp("/ops/self-upgrade");
+    const opsBacklog = resolveQuickHelp("/ops/demand");
+    expect(selfUpgrade).not.toBeNull();
+    expect(opsBacklog).not.toBeNull();
+    expect(selfUpgrade!.whatThisPageIs).not.toBe(opsBacklog!.whatThisPageIs);
+    expect(selfUpgrade!.whatThisPageIs.toLowerCase()).toContain("upgrad");
+  });
+
+  it("business settings override the generic settings help", () => {
+    const business = resolveQuickHelp("/storefront/settings/business");
+    const settings = resolveQuickHelp("/storefront/settings");
+    expect(business).not.toBeNull();
+    expect(settings).not.toBeNull();
+    expect(business!.whatThisPageIs).not.toBe(settings!.whatThisPageIs);
+  });
+});
+
+describe("resolveQuickHelp — misses", () => {
+  it("returns null for routes without dedicated help", () => {
+    expect(resolveQuickHelp("/finance/reports")).toBeNull();
+  });
+
+  it("returns null for empty or external inputs", () => {
+    expect(resolveQuickHelp(undefined)).toBeNull();
+    expect(resolveQuickHelp(null)).toBeNull();
+    expect(resolveQuickHelp("")).toBeNull();
+    expect(resolveQuickHelp("https://example.com")).toBeNull();
+  });
+});
+
+describe("self-upgrade is not generic operations", () => {
+  it("resolves the source route to a dedicated self-upgrade doc", () => {
+    expect(resolveDocsPath("/ops/self-upgrade")).toBe("/docs/operations/self-upgrade");
+    // The generic operations backlog still maps to its own index.
+    expect(resolveDocsPath("/ops/demand")).toBe("/docs/operations/index");
+  });
+
+  it("builds a contextual href that carries the source route back", () => {
+    expect(buildContextualDocsHref("/ops/self-upgrade")).toBe(
+      "/docs/operations/self-upgrade?sourceRoute=%2Fops%2Fself-upgrade",
+    );
+  });
+});
+
+describe("buildContextualDocsHref — required routes preserve sourceRoute", () => {
+  const CASES: Array<[route: string, href: string]> = [
+    ["/storefront/inbox", "/docs/storefront/inbox-and-enquiries?sourceRoute=%2Fstorefront%2Finbox"],
+    [
+      "/storefront/settings/business",
+      "/docs/storefront/settings-business-and-operations?sourceRoute=%2Fstorefront%2Fsettings%2Fbusiness",
+    ],
+    ["/customer/marketing", "/docs/customers/marketing?sourceRoute=%2Fcustomer%2Fmarketing"],
+  ];
+
+  for (const [route, href] of CASES) {
+    it(`${route} → ${href}`, () => {
+      expect(buildContextualDocsHref(route)).toBe(href);
+    });
+  }
+});
+
+describe("getQuickHelpRoutes", () => {
+  it("exposes the registered route prefixes for auditing", () => {
+    const routes = getQuickHelpRoutes();
+    expect(routes).toContain("/ops/self-upgrade");
+    expect(routes).toContain("/storefront/inbox");
+    expect(routes).toContain("/storefront/settings/business");
+    expect(routes).toContain("/customer/marketing");
+  });
+});

--- a/apps/web/lib/docs-quick-help.ts
+++ b/apps/web/lib/docs-quick-help.ts
@@ -1,0 +1,197 @@
+// apps/web/lib/docs-quick-help.ts
+// Route-specific "quick help" answers for the contextual docs panel.
+//
+// The goal is to reduce overload: instead of dropping the operator into a
+// generic docs manual, the contextual docs surface leads with a short panel
+// that answers the five questions a person actually has when they open help
+// from a page they are stuck on.
+//
+// Quick help is keyed by the ROUTE they came from (`sourceRoute`), not by the
+// docs page. Several routes legitimately share one long-form doc, so the doc
+// alone cannot say "what to do now" for the specific screen. Resolution is by
+// longest matching route prefix, so a leaf route (e.g. /storefront/settings/business)
+// can override the family default (/storefront/settings).
+//
+// Data-only module — no Node imports — so it is safe to import from client and
+// server components and trivial to unit test.
+
+export type QuickHelp = {
+  /** What this page is — one plain-language line. */
+  whatThisPageIs: string;
+  /** The single most useful action to take right now. */
+  actionNow: string;
+  /** What happens if nothing is done. */
+  ifNothingDone: string;
+  /** What is reversible / how safe changes are. */
+  reversible: string;
+  /** Where recovery or further help lives. */
+  recovery: string;
+};
+
+type QuickHelpEntry = {
+  routePrefix: string;
+  help: QuickHelp;
+};
+
+const QUICK_HELP_MAP: QuickHelpEntry[] = [
+  {
+    routePrefix: "/storefront/inbox",
+    help: {
+      whatThisPageIs:
+        "The response queue for inbound customer messages and enquiries from your storefront.",
+      actionNow:
+        "Triage each new message: decide whether it belongs in sales follow-up, fulfilment, or support, then respond or route it without losing the customer's context.",
+      ifNothingDone:
+        "Enquiries pile up unanswered and customers who reached out are never converted into owned follow-up work.",
+      reversible:
+        "Routing and re-assigning an enquiry can be redone at any time. A reply you send to a customer cannot be unsent — review it before sending.",
+      recovery:
+        "Lost the context a message came from? Open the originating storefront or offer from the enquiry. Full guidance is in Storefront → Inbox and Enquiries below.",
+    },
+  },
+  {
+    routePrefix: "/storefront/items",
+    help: {
+      whatThisPageIs:
+        "The catalog and page-content editor for the offers and sections shown on your public storefront.",
+      actionNow:
+        "Decide whether you are editing an offer or the page structure around it, and keep item details, sections, and published messaging aligned.",
+      ifNothingDone:
+        "The public storefront keeps showing stale or inconsistent content, and sections may promise flows the underlying item cannot support.",
+      reversible:
+        "Content edits can be changed back, but they affect the live storefront — re-check the public page after a meaningful change.",
+      recovery:
+        "Preview the public storefront to confirm the customer-facing result. Full guidance is in Storefront → Catalog and Page Content below.",
+    },
+  },
+  {
+    routePrefix: "/storefront/settings/business",
+    help: {
+      whatThisPageIs:
+        "The business-context settings behind your storefront — identity, promise, and customer-facing framing.",
+      actionNow:
+        "Correct the business identity or promise only where it no longer matches what customers actually experience.",
+      ifNothingDone:
+        "Your storefront keeps presenting a business context that has drifted from reality, confusing both customers and staff.",
+      reversible:
+        "Settings can be edited back at any time, but changes affect the public storefront immediately — verify the public page after saving.",
+      recovery:
+        "Preview the live storefront URL to confirm impact. Full guidance is in Storefront → Settings, Business and Operations below.",
+    },
+  },
+  {
+    routePrefix: "/storefront/settings",
+    help: {
+      whatThisPageIs:
+        "The storefront settings for presentation, live URL, business context, and operating rules.",
+      actionNow:
+        "Start with core presentation and the live URL; move to business context or operations settings only when identity, hours, or availability are wrong.",
+      ifNothingDone:
+        "Operating rules and customer promises stay out of sync with how the business actually runs.",
+      reversible:
+        "Every setting can be changed back, but hours and availability rules affect real customer interactions the moment they are saved.",
+      recovery:
+        "Check the public storefront after changing operating rules. Full guidance is in Storefront → Settings, Business and Operations below.",
+    },
+  },
+  {
+    routePrefix: "/storefront/setup",
+    help: {
+      whatThisPageIs: "The guided setup flow that prepares a storefront for launch.",
+      actionNow:
+        "Complete the guided steps in order and verify business context, catalog, and operational settings before you launch.",
+      ifNothingDone:
+        "A partially configured storefront can be mistaken for launch-ready and go live with gaps.",
+      reversible:
+        "Setup choices can be revisited before and after launch; check the public route after any launch-related change.",
+      recovery:
+        "Re-open the guided setup to resume where you left off. Full guidance is in Storefront → Setup and Launch below.",
+    },
+  },
+  {
+    routePrefix: "/storefront/team",
+    help: {
+      whatThisPageIs: "Who delivers, supports, or owns the storefront work.",
+      actionNow:
+        "Review staffing and assignments with the customer journey in mind before changing owners.",
+      ifNothingDone:
+        "Visible storefront promises can be left with no matching fulfilment owner.",
+      reversible:
+        "Staffing and assignment changes can be reassigned again at any time.",
+      recovery:
+        "Re-check booking, enquiry, and fulfilment flows after team updates. Full guidance is in Storefront → Team and Fulfilment below.",
+    },
+  },
+  {
+    routePrefix: "/ops/self-upgrade",
+    help: {
+      whatThisPageIs:
+        "The controls for upgrading the platform itself — building a fresh application image and swapping the running install.",
+      actionNow:
+        "Review the pending upgrade and trigger it only inside an approved deployment window; a normal upgrade completes in a few minutes.",
+      ifNothingDone:
+        "The install stays on its current version — queued fixes and improvements are not applied until an operator approves the upgrade.",
+      reversible:
+        "A failed upgrade is automatically rolled back and its container force-removed. A bounded timeout (default 25 minutes) stops a stalled build from hanging or swapping later.",
+      recovery:
+        "If an upgrade fails, read the deployment log for the retryable diagnosis and re-run. Full guidance is in Operations → Self-Upgrade below.",
+    },
+  },
+  {
+    routePrefix: "/ops",
+    help: {
+      whatThisPageIs:
+        "The delivery backlog — the work items, epics, priorities, promotions, and deployments behind your team's commitments.",
+      actionNow:
+        "Find and clear blockers before they stall delivery, and review promotions that are ready to deploy.",
+      ifNothingDone:
+        "Blocked or unprioritised work stays invisible in the flow and delivery quietly stalls.",
+      reversible:
+        "Backlog edits, status moves, and priorities can all be changed back. A deployment is governed and, if it fails, is rolled back automatically.",
+      recovery:
+        "Check deployment logs and backup references for any failed promotion. Full guidance is in Operations below.",
+    },
+  },
+  {
+    routePrefix: "/customer/marketing",
+    help: {
+      whatThisPageIs:
+        "The marketing view for customer acquisition — positioning, audience, funnel health, and proof assets.",
+      actionNow:
+        "Compare campaign ideas against funnel bottlenecks before acting, and turn repeatable gaps into backlog work.",
+      ifNothingDone:
+        "Acquisition analysis stays as analysis — gaps never become owned work and campaigns get generated without fixing the real bottleneck.",
+      reversible:
+        "Reviewing and drafting here changes nothing customer-facing on its own; only promoted backlog items or published campaigns take effect.",
+      recovery:
+        "Route offer, proof, or follow-up gaps to the right operations area. Full guidance is in Customers → Marketing below.",
+    },
+  },
+];
+
+function routeMatches(pathname: string, routePrefix: string): boolean {
+  return pathname === routePrefix || pathname.startsWith(`${routePrefix}/`);
+}
+
+/**
+ * Resolve the route-specific quick help for a source route by longest matching
+ * prefix. Returns null when the route is unknown or not an internal path.
+ */
+export function resolveQuickHelp(sourceRoute: string | undefined | null): QuickHelp | null {
+  if (!sourceRoute || !sourceRoute.startsWith("/")) return null;
+
+  let best: QuickHelpEntry | null = null;
+  for (const entry of QUICK_HELP_MAP) {
+    if (routeMatches(sourceRoute, entry.routePrefix)) {
+      if (!best || entry.routePrefix.length > best.routePrefix.length) {
+        best = entry;
+      }
+    }
+  }
+
+  return best?.help ?? null;
+}
+
+export function getQuickHelpRoutes(): string[] {
+  return QUICK_HELP_MAP.map((entry) => entry.routePrefix);
+}

--- a/apps/web/lib/docs-route-map.ts
+++ b/apps/web/lib/docs-route-map.ts
@@ -84,6 +84,9 @@ const DOCS_ROUTE_MAP: DocsRouteEntry[] = [
   { routePrefix: "/customer", docsPath: "/docs/customers/index" },
   { routePrefix: "/coworker-decisions", docsPath: "/docs/wiki/index" },
   { routePrefix: "/build", docsPath: "/docs/build-studio/index" },
+  // Self-upgrade is high-consequence — give it a dedicated doc rather than
+  // letting it fall through to the generic operations backlog page.
+  { routePrefix: "/ops/self-upgrade", docsPath: "/docs/operations/self-upgrade" },
   { routePrefix: "/ops", docsPath: "/docs/operations/index" },
   { routePrefix: "/portfolio/product", docsPath: "/docs/products/index" },
   { routePrefix: "/portfolio", docsPath: "/docs/portfolios/index" },

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 534,
+  "pageCount": 535,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -8875,6 +8875,21 @@
         "grafana-dashboards",
         "edge-node-fleet-metrics-push-not-scrape",
         "osi-layer-model"
+      ]
+    },
+    "docs/user-guide/operations/self-upgrade.md": {
+      "publicHref": "/user-guide/operations/self-upgrade/",
+      "portalHref": "/docs/operations/self-upgrade",
+      "publishedPublic": true,
+      "publishedPortal": true,
+      "anchors": [
+        "use-this-doc-for",
+        "overview",
+        "workflow",
+        "what-happens-if-you-do-nothing",
+        "what-is-reversible",
+        "recovery-and-help",
+        "what-to-watch"
       ]
     },
     "docs/user-guide/platform/ai-operations.md": {

--- a/docs/superpowers/plans/2026-07-22-contextual-docs-quick-help.md
+++ b/docs/superpowers/plans/2026-07-22-contextual-docs-quick-help.md
@@ -1,0 +1,71 @@
+# Contextual Docs quick-help panel (BI-2DD18122)
+
+## Problem
+
+Opening the contextual **Docs** link from a working screen currently lands the
+operator on a generic docs page (or the ~80-link catalog) with a small "Opened
+from `<route>`" banner. That reduces overload only marginally: the reader still
+has to find, in a manual, the answer to the immediate question they had on the
+page they left. On high-consequence routes (`/ops/self-upgrade`) it is actively
+misleading, because the route falls through to the generic operations backlog
+doc.
+
+## Approach
+
+Lead the contextual docs surface with a short, route-specific **quick-help
+panel** that answers the five questions a stuck operator actually has, then keep
+the full doc body underneath and demote the catalog.
+
+### Source of truth
+
+- `apps/web/lib/docs-route-map.ts` — the existing `sourceRoute` → `docsPath`
+  registry (longest-prefix match). Extended with an explicit
+  `/ops/self-upgrade` → `/docs/operations/self-upgrade` entry so self-upgrade no
+  longer falls through to `/docs/operations/index`.
+- `apps/web/lib/docs-quick-help.ts` — **new** data-only registry keyed by the
+  `sourceRoute`, resolved by longest matching prefix. Keyed by route (not doc)
+  so routes that legitimately share one long-form doc (e.g.
+  `/storefront/settings/business` and `/storefront/settings/operations`) can
+  each show route-specific guidance.
+
+### The five questions each panel answers
+
+1. What this page is
+2. What action to take now
+3. What happens if nothing is done
+4. What is reversible
+5. Where recovery / help lives
+
+### Rendering
+
+- `apps/web/components/docs/ContextualQuickHelp.tsx` — **new** server component.
+  Keeps the `sourceRoute` provenance and the **Back to page** affordance, and
+  renders the quick-help panel above the doc body when the route has help.
+- `apps/web/app/(shell)/docs/[[...slug]]/page.tsx` — renders `ContextualQuickHelp`
+  in place of the old inline banner; when arriving contextually, collapses the
+  home catalog into a `<details>` disclosure.
+- `apps/web/components/docs/DocsLayout.tsx` + `DocsSidebar.tsx` — accept a
+  `collapseCatalog` / `collapsible` flag that demotes the full area list into a
+  collapsed disclosure so it does not compete with the immediate explanation.
+
+### Docs
+
+- `docs/user-guide/operations/self-upgrade.md` — **new** dedicated user-guide
+  page for `/ops/self-upgrade`, so the mapped `docsPath` is backed by a real
+  page and the full doc body is self-upgrade-specific.
+
+## Tests
+
+- `apps/web/lib/docs-quick-help.test.ts` — `resolveQuickHelp` for the required
+  routes (`/storefront/inbox`, `/storefront/settings/business`,
+  `/ops/self-upgrade`, `/customer/marketing`), longest-prefix specificity,
+  misses, and `buildContextualDocsHref` preserving `sourceRoute`.
+- `apps/web/components/docs/ContextualQuickHelp.test.tsx` — contextual banner
+  rendering (Back to page + sourceRoute) and the five-question panel.
+
+## Non-goals / coordination
+
+- The archetype-vocabulary storefront panel explored on
+  `claude/storefront-docs-help-panel-2d417c` is a separate, storefront-only take;
+  this slice is the general route-keyed quick-help system that also covers
+  `/ops/self-upgrade` and `/customer/marketing`.

--- a/docs/user-guide/operations/self-upgrade.md
+++ b/docs/user-guide/operations/self-upgrade.md
@@ -1,0 +1,59 @@
+---
+title: "Self-Upgrade"
+area: operations
+order: 2
+---
+
+## Use This Doc For
+
+- `/ops/self-upgrade`
+
+## Overview
+
+Self-upgrade upgrades the platform itself. It builds a fresh application image
+from the approved source and swaps the running install over to it. This is a
+higher-consequence operation than editing backlog work, so it is operator-gated
+and governed by deployment windows.
+
+## Workflow
+
+1. Review the pending upgrade and what it will change before triggering anything.
+2. Trigger the upgrade only inside an approved deployment window. Normal changes
+   respect the window; only an emergency change may override it.
+3. Watch the deployment status — the page updates automatically while the build
+   and swap are in progress. A normal upgrade completes in a few minutes.
+4. Confirm the health check passed after the swap, and read the deployment log if
+   it did not.
+
+## What Happens If You Do Nothing
+
+The install stays on its current version. Queued fixes and improvements are not
+applied until an operator approves and runs the upgrade. Nothing is lost by
+waiting, but the platform does not move forward on its own.
+
+## What Is Reversible
+
+- A failed upgrade is **automatically rolled back** and its promoter container is
+  force-removed, so a broken build cannot leave the install in a half-swapped
+  state.
+- The build is bounded by a hard wall-clock budget (default **25 minutes**). If a
+  build step stalls, the promoter is killed and the deployment is marked failed
+  with a retryable `promoter-timeout` diagnosis instead of hanging.
+- A periodic watchdog force-removes any promoter container orphaned by a
+  mid-deployment restart, so a stalled build can never linger and cause an
+  unexpected later swap.
+
+## Recovery And Help
+
+- If an upgrade fails, open the deployment log for the retryable diagnosis, then
+  re-run the upgrade.
+- Operators on unusually slow hosts can raise the build budget by setting
+  `DPF_PROMOTER_TIMEOUT_MS` (milliseconds) in the environment.
+- Deployment windows and change-request lifecycle are managed from the wider
+  Operations area.
+
+## What To Watch
+
+- triggering an upgrade outside an approved deployment window
+- treating a failed, rolled-back deployment as if the swap had succeeded
+- re-running an upgrade without first reading the failure diagnosis in the log


### PR DESCRIPTION
## What

Makes the contextual **Docs** link reduce overload instead of opening a generic docs manual. When a `sourceRoute` is present, the docs surface now leads with a short, route-specific **quick-help panel** — the full doc body stays underneath and the ~80-link catalog is demoted into a collapsed disclosure so it no longer competes with the immediate explanation.

Each panel answers the five questions a stuck operator actually has:

1. **What this page is**
2. **What to do now**
3. **If you do nothing**
4. **What's reversible**
5. **Where to get help / recovery**

## Acceptance

- ✅ Keeps `sourceRoute` and **Back to page**.
- ✅ Route-specific quick-help panel renders **before** the full doc body.
- ✅ Panel answers all five required questions.
- ✅ Full docs catalog demoted — collapsed disclosure on the docs home + a collapsible sidebar (`collapseCatalog`).
- ✅ Explicit help for `/ops/self-upgrade`: new `docs/user-guide/operations/self-upgrade.md` + dedicated route-map entry (`/docs/operations/self-upgrade`) + its own quick-help entry — no longer falls through to `/docs/operations/index`.
- ✅ Shared docs get route-specific guidance via `sourceRoute` (quick help is keyed by route, not doc — e.g. `/storefront/settings/business` vs `/storefront/settings/operations`).
- ✅ Tests for `buildContextualDocsHref`, contextual banner rendering, and `/storefront/inbox`, `/storefront/settings/business`, `/ops/self-upgrade`, `/customer/marketing`.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/plans/2026-07-22-contextual-docs-quick-help.md` (authored for this slice).
- Current code substrate reviewed: `apps/web/lib/docs-route-map.ts` (the `sourceRoute` → `docsPath` registry) and `apps/web/app/(shell)/docs/[[...slug]]/page.tsx`.
- Source of truth: the route map + the new `apps/web/lib/docs-quick-help.ts` registry.
- Decision: new artifact grounded in existing substrate; no routing contract broken.

## Verification

Run in the worktree via junctioned `node_modules`:

- **vitest**: 35 passed (`docs-quick-help`, `ContextualQuickHelp` render, `docs-route-map`).
- **tsc --noEmit**: 0 errors (direct invocation).
- **doc-links**: pass (73 user-guide pages).
- **doc-index**: regenerated + `--check` fresh (535 pages).
- **module-size**: OK.
- Clean auto-merge against latest `origin/main` (only `doc-index.generated.json` overlaps concurrent PRs; it uses the `merge=union` driver).

Pre-commit typecheck hook skipped only because a source-only worktree can't resolve the `next` binary through pnpm's recursive runner; CI re-runs the full gate.

## Coordination

The archetype-vocabulary storefront panel explored on the local `claude/storefront-docs-help-panel-2d417c` branch is a separate, storefront-only take. This slice is the general route-keyed quick-help system that also covers `/ops/self-upgrade` and `/customer/marketing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)