### PR TITLE
fix(storefront): visible validation + named inquiry result route for public Restaurant forms (BI-F20763F5)

### DIFF
--- a/apps/web/app/(storefront)/s/[slug]/checkout/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/checkout/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { prisma } from "@dpf/db";
 
 const TYPE_LABELS: Record<string, { title: string; icon: string }> = {
@@ -19,6 +19,13 @@ export default async function CheckoutPage({
   const { ref, type } = await searchParams;
 
   if (!ref || !type) notFound();
+
+  // An inquiry is not a checkout action, so it gets its own named result route
+  // rather than the payment/booking confirmation page (BI-F20763F5). Redirecting
+  // here also catches any old bookmarked /checkout?type=inquiry links.
+  if (type === "inquiry") {
+    redirect(`/s/${slug}/inquiry/received?ref=${encodeURIComponent(ref)}`);
+  }
 
   const storefrontConfig = await prisma.storefrontConfig.findFirst({
     where: { organization: { slug } },

--- a/apps/web/app/(storefront)/s/[slug]/inquiry/received/page.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/inquiry/received/page.tsx
@@ -1,0 +1,95 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
+import { resolveInquiryFormSchema } from "@/lib/storefront-data";
+import { InquiryReceived, type SubmittedDetail } from "@/components/storefront/InquiryReceived";
+
+// Fields shown in dedicated rows / used as the message body — excluded from the
+// generic archetype-field list so they are not duplicated in "What you sent us".
+const RESERVED_FIELDS = new Set(["name", "email", "phone", "notes", "message"]);
+
+export default async function InquiryReceivedPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ ref?: string }>;
+}) {
+  const { slug } = await params;
+  const { ref } = await searchParams;
+  if (!ref) notFound();
+
+  const config = await prisma.storefrontConfig.findFirst({
+    where: { organization: { slug } },
+    select: {
+      id: true,
+      contactEmail: true,
+      contactPhone: true,
+      archetype: { select: { archetypeId: true } },
+      organization: { select: { name: true } },
+    },
+  });
+  if (!config) notFound();
+
+  const inquiry = await prisma.storefrontInquiry.findFirst({
+    where: { inquiryRef: ref, storefrontId: config.id },
+    select: {
+      inquiryRef: true,
+      customerName: true,
+      customerEmail: true,
+      customerPhone: true,
+      message: true,
+      itemId: true,
+      formData: true,
+    },
+  });
+  if (!inquiry) notFound();
+
+  const details: SubmittedDetail[] = [];
+
+  // What the enquiry was about, when tied to a specific offer/item.
+  if (inquiry.itemId) {
+    const item = await prisma.storefrontItem.findFirst({
+      where: { itemId: inquiry.itemId, storefrontId: config.id },
+      select: { name: true },
+    });
+    if (item?.name) details.push({ label: "About", value: item.name });
+  }
+
+  if (inquiry.customerPhone?.trim()) {
+    details.push({ label: "Phone", value: inquiry.customerPhone.trim() });
+  }
+
+  // Archetype-specific fields (party size, preferred date, etc.) mapped through
+  // the schema so a customer sees the label they filled in, not the raw key.
+  const formData = (inquiry.formData ?? {}) as Record<string, unknown>;
+  const schemaKeys = Object.keys(formData).filter(
+    (k) => !RESERVED_FIELDS.has(k) && k !== "calculatorSnapshot",
+  );
+  if (schemaKeys.length > 0) {
+    const schema = await resolveInquiryFormSchema(config.archetype?.archetypeId ?? "");
+    const labelFor = new Map(schema.map((f) => [f.name, f.label]));
+    for (const key of schemaKeys) {
+      const raw = formData[key];
+      if (raw == null || raw === "") continue;
+      const value = Array.isArray(raw) ? raw.join(", ") : String(raw);
+      details.push({ label: labelFor.get(key) ?? key, value });
+    }
+  }
+
+  if (inquiry.message?.trim()) {
+    details.push({ label: "Message", value: inquiry.message.trim() });
+  }
+
+  return (
+    <InquiryReceived
+      orgName={config.organization.name}
+      orgSlug={slug}
+      reference={inquiry.inquiryRef}
+      customerName={inquiry.customerName}
+      customerEmail={inquiry.customerEmail}
+      details={details}
+      contactEmail={config.contactEmail}
+      contactPhone={config.contactPhone}
+    />
+  );
+}

--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -124,7 +124,7 @@ export function StorefrontInbox({
             Requests from your storefront
           </div>
           <div className="text-[var(--dpf-muted)]" style={{ marginTop: 4, fontSize: 12 }}>
-            Use <strong>Send to backlog</strong> to track a customer request as work you can follow up on.
+            Use <strong>Send to backlog</strong> to track a customer request as internal follow-up work. It doesn&apos;t notify the customer.
           </div>
         </div>
       ) : (

--- a/apps/web/components/storefront/InquiryForm.test.tsx
+++ b/apps/web/components/storefront/InquiryForm.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const submitInquiry = vi.fn();
+const push = vi.fn();
+
+vi.mock("@/lib/storefront-actions", () => ({
+  submitInquiry: (...args: unknown[]) => submitInquiry(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+import { InquiryForm } from "./InquiryForm";
+
+const SCHEMA = [
+  { name: "name", label: "Your name", type: "text", required: true },
+  { name: "email", label: "Email address", type: "email", required: true },
+  { name: "message", label: "Message", type: "textarea", required: false },
+];
+
+beforeEach(() => {
+  cleanup();
+  submitInquiry.mockReset();
+  push.mockReset();
+});
+
+describe("InquiryForm empty/invalid submit", () => {
+  it("shows a visible error summary and does not submit or navigate", async () => {
+    render(<InquiryForm orgSlug="acme" formSchema={SCHEMA} />);
+    fireEvent.submit(screen.getByRole("button", { name: /send enquiry/i }).closest("form")!);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/before sending/i);
+    // Inline errors reference the two required fields.
+    expect(alert.textContent).toMatch(/Your name is required/);
+    expect(alert.textContent).toMatch(/Email address is required/);
+    // No side effects on an invalid submit.
+    expect(submitInquiry).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("marks the invalid fields with aria-invalid", async () => {
+    render(<InquiryForm orgSlug="acme" formSchema={SCHEMA} />);
+    fireEvent.submit(screen.getByRole("button", { name: /send enquiry/i }).closest("form")!);
+    await screen.findByRole("alert");
+    expect(screen.getByLabelText(/Your name/).getAttribute("aria-invalid")).toBe("true");
+  });
+});
+
+describe("InquiryForm valid submit", () => {
+  it("calls the action once and routes to the named inquiry result page", async () => {
+    submitInquiry.mockResolvedValue({ success: true, ref: "INQ-ABC123", type: "inquiry" });
+    render(<InquiryForm orgSlug="acme" formSchema={SCHEMA} />);
+
+    fireEvent.change(screen.getByLabelText(/Your name/), { target: { value: "Ada Lovelace" } });
+    fireEvent.change(screen.getByLabelText(/Email address/), { target: { value: "ada@example.com" } });
+    fireEvent.submit(screen.getByRole("button", { name: /send enquiry/i }).closest("form")!);
+
+    await waitFor(() => expect(submitInquiry).toHaveBeenCalledTimes(1));
+    expect(submitInquiry).toHaveBeenCalledWith(
+      "acme",
+      expect.objectContaining({ customerName: "Ada Lovelace", customerEmail: "ada@example.com" }),
+    );
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith("/s/acme/inquiry/received?ref=INQ-ABC123"),
+    );
+  });
+
+  it("surfaces a server error without navigating", async () => {
+    submitInquiry.mockResolvedValue({ success: false, error: "Storefront not found or not published" });
+    render(<InquiryForm orgSlug="acme" formSchema={SCHEMA} />);
+
+    fireEvent.change(screen.getByLabelText(/Your name/), { target: { value: "Ada" } });
+    fireEvent.change(screen.getByLabelText(/Email address/), { target: { value: "ada@example.com" } });
+    fireEvent.submit(screen.getByRole("button", { name: /send enquiry/i }).closest("form")!);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/not found or not published/i);
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/storefront/InquiryForm.tsx
+++ b/apps/web/components/storefront/InquiryForm.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useId } from "react";
 import { submitInquiry } from "@/lib/storefront-actions";
 import { useRouter } from "next/navigation";
+import {
+  validateRequiredFields,
+  orderedErrors,
+  type FieldErrors,
+  type FieldValues,
+} from "@/lib/storefront/inquiry-validation";
 
 type FormField = {
   name: string;
@@ -23,9 +29,12 @@ export function InquiryForm({
   formSchema: FormField[];
 }) {
   const router = useRouter();
+  const fieldIdPrefix = useId();
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [calcSnapshot, setCalcSnapshot] = useState<Record<string, unknown> | null>(null);
+  const summaryRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const raw = sessionStorage.getItem("dpf_calc_snapshot");
@@ -34,19 +43,39 @@ export function InquiryForm({
     }
   }, []);
 
+  const fieldDomId = (name: string) => `${fieldIdPrefix}-${name}`;
+  const errorDomId = (name: string) => `${fieldIdPrefix}-${name}-error`;
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setLoading(true);
-    setError(null);
+    setSubmitError(null);
 
     const fd = new FormData(e.currentTarget);
-    const email = fd.get("email") as string;
-    const name = fd.get("name") as string;
-    const phone = (fd.get("phone") as string | null) ?? undefined;
+    const values: FieldValues = {};
+    for (const field of formSchema) {
+      values[field.name] = fd.get(field.name) as string | null;
+    }
+
+    // Visible, accessible validation runs BEFORE any server call so an empty or
+    // invalid submit produces inline + summary feedback and no side effect —
+    // never a silent browser-native popup.
+    const errors = validateRequiredFields(formSchema, values);
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      // Move focus to the summary so screen-reader and keyboard users are taken
+      // straight to the list of problems.
+      requestAnimationFrame(() => summaryRef.current?.focus());
+      return;
+    }
+    setFieldErrors({});
+    setLoading(true);
+
+    const email = values.email ?? "";
+    const name = values.name ?? "";
+    const phone = (values.phone as string | null) ?? undefined;
     // Archetype schemas use a "notes" textarea for free-text; the generic schema
     // uses "message". Treat either as the inquiry message.
-    const message =
-      ((fd.get("message") ?? fd.get("notes")) as string | null) ?? undefined;
+    const message = (values.message ?? values.notes ?? undefined) as string | undefined;
 
     const formData: Record<string, unknown> = {};
     for (const field of formSchema) {
@@ -68,38 +97,126 @@ export function InquiryForm({
     });
 
     if (!result.success) {
-      setError(result.error);
+      setSubmitError(result.error);
       setLoading(false);
+      requestAnimationFrame(() => summaryRef.current?.focus());
       return;
     }
 
-    router.push(`/s/${orgSlug}/checkout?ref=${result.ref}&type=inquiry`);
+    router.push(`/s/${orgSlug}/inquiry/received?ref=${encodeURIComponent(result.ref)}`);
   }
 
+  const summaryErrors = orderedErrors(formSchema, fieldErrors);
+  const hasSummary = summaryErrors.length > 0 || submitError !== null;
+
   return (
-    <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 480 }}>
-      {error && <div style={{ color: "var(--dpf-error)", fontSize: 13 }}>{error}</div>}
-      {formSchema.map((field) => (
-        <div key={field.name} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <label style={{ fontSize: 13, fontWeight: 500, color: "var(--dpf-text)" }}>
-            {field.label}{field.required && " *"}
-          </label>
-          {field.type === "textarea" ? (
-            <textarea name={field.name} required={field.required} rows={4}
-              style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14, resize: "vertical" }} />
-          ) : field.type === "select" ? (
-            <select name={field.name} required={field.required}
-              style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }}>
-              <option value="">Select…</option>
-              {field.options?.map((o) => <option key={o} value={o}>{o}</option>)}
-            </select>
+    <form
+      onSubmit={handleSubmit}
+      noValidate
+      style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 480 }}
+    >
+      {hasSummary && (
+        <div
+          ref={summaryRef}
+          role="alert"
+          tabIndex={-1}
+          style={{
+            border: "1px solid var(--dpf-error)",
+            background: "color-mix(in srgb, var(--dpf-error) 8%, transparent)",
+            borderRadius: 8,
+            padding: "12px 14px",
+            fontSize: 13,
+            color: "var(--dpf-error)",
+            outline: "none",
+          }}
+        >
+          {submitError ? (
+            <span>{submitError}</span>
           ) : (
-            <input type={field.type} name={field.name} required={field.required}
-              placeholder={field.placeholder}
-              style={{ padding: "8px 12px", border: "1px solid var(--dpf-border)", borderRadius: 6, fontSize: 14 }} />
+            <>
+              <strong style={{ display: "block", marginBottom: 6 }}>
+                {`Please fix ${summaryErrors.length} ${summaryErrors.length === 1 ? "field" : "fields"} before sending:`}
+              </strong>
+              <ul style={{ margin: 0, paddingLeft: 18 }}>
+                {summaryErrors.map((err) => (
+                  <li key={err.name}>
+                    <a
+                      href={`#${fieldDomId(err.name)}`}
+                      style={{ color: "var(--dpf-error)", textDecoration: "underline" }}
+                    >
+                      {err.message}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </>
           )}
         </div>
-      ))}
+      )}
+      {formSchema.map((field) => {
+        const id = fieldDomId(field.name);
+        const error = fieldErrors[field.name];
+        const describedBy = error ? errorDomId(field.name) : undefined;
+        const commonStyle = {
+          padding: "8px 12px",
+          border: `1px solid ${error ? "var(--dpf-error)" : "var(--dpf-border)"}`,
+          borderRadius: 6,
+          fontSize: 14,
+        } as const;
+        return (
+          <div key={field.name} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <label htmlFor={id} style={{ fontSize: 13, fontWeight: 500, color: "var(--dpf-text)" }}>
+              {field.label}
+              {field.required && (
+                <span style={{ color: "var(--dpf-error)" }} aria-hidden="true"> *</span>
+              )}
+              {field.required && <span className="sr-only"> (required)</span>}
+            </label>
+            {field.type === "textarea" ? (
+              <textarea
+                id={id}
+                name={field.name}
+                required={field.required}
+                aria-required={field.required}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={describedBy}
+                rows={4}
+                style={{ ...commonStyle, resize: "vertical" }}
+              />
+            ) : field.type === "select" ? (
+              <select
+                id={id}
+                name={field.name}
+                required={field.required}
+                aria-required={field.required}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={describedBy}
+                style={commonStyle}
+              >
+                <option value="">Select…</option>
+                {field.options?.map((o) => <option key={o} value={o}>{o}</option>)}
+              </select>
+            ) : (
+              <input
+                id={id}
+                type={field.type}
+                name={field.name}
+                required={field.required}
+                aria-required={field.required}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={describedBy}
+                placeholder={field.placeholder}
+                style={commonStyle}
+              />
+            )}
+            {error && (
+              <span id={errorDomId(field.name)} style={{ fontSize: 12, color: "var(--dpf-error)" }}>
+                {error}
+              </span>
+            )}
+          </div>
+        );
+      })}
       <button type="submit" disabled={loading}
         style={{
           padding: "10px 20px", background: "var(--dpf-accent, #4f46e5)", color: "#fff",

--- a/apps/web/components/storefront/InquiryReceived.test.tsx
+++ b/apps/web/components/storefront/InquiryReceived.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import { InquiryReceived } from "./InquiryReceived";
+
+function markup(overrides: Partial<Parameters<typeof InquiryReceived>[0]> = {}) {
+  return renderToStaticMarkup(
+    <InquiryReceived
+      orgName="The Copper Table"
+      orgSlug="copper-table"
+      reference="INQ-FGQXCF4X"
+      customerName="UX Study Guest"
+      customerEmail="ux-study@example.invalid"
+      details={[
+        { label: "About", value: "Table for 2" },
+        { label: "Party size", value: "2" },
+        { label: "Message", value: "Anniversary dinner" },
+      ]}
+      contactEmail="hello@copper-table.example"
+      contactPhone="+44 20 7946 0000"
+      {...overrides}
+    />,
+  );
+}
+
+describe("InquiryReceived — submit-result contract", () => {
+  it("shows the reference prominently", () => {
+    expect(markup()).toContain("INQ-FGQXCF4X");
+  });
+
+  it("echoes the submitted context back to the customer", () => {
+    const html = markup();
+    expect(html).toContain("UX Study Guest");
+    expect(html).toContain("ux-study@example.invalid");
+    expect(html).toContain("Table for 2");
+    expect(html).toContain("Party size");
+    expect(html).toContain("Anniversary dinner");
+  });
+
+  it("names the response channel and expected time", () => {
+    const html = markup();
+    expect(html).toMatch(/What happens next/i);
+    expect(html).toMatch(/reply to you by email/i);
+    expect(html).toMatch(/one business day/i);
+  });
+
+  it("gives a correction/cancel path via the business contact channels", () => {
+    const html = markup();
+    expect(html).toMatch(/change or cancel/i);
+    expect(html).toContain("mailto:hello@copper-table.example");
+    expect(html).toContain("tel:+442079460000");
+  });
+
+  it("does not overpromise a confirmation email that is never sent", () => {
+    expect(markup()).not.toMatch(/check your (inbox|email) for/i);
+  });
+
+  it("falls back to a reply-when-contacted message when no contact channels exist", () => {
+    const html = markup({ contactEmail: null, contactPhone: null });
+    // renderToStaticMarkup escapes the apostrophe to &#x27;, so match either form.
+    expect(html).toMatch(/reply to the team(&#x27;|')s email/i);
+    expect(html).toMatch(/email when they get in touch/i);
+    expect(html).not.toContain("mailto:");
+  });
+
+  it("offers a route back to the storefront", () => {
+    expect(markup()).toContain('href="/s/copper-table"');
+  });
+});

--- a/apps/web/components/storefront/InquiryReceived.tsx
+++ b/apps/web/components/storefront/InquiryReceived.tsx
@@ -1,0 +1,165 @@
+import { Fragment } from "react";
+import Link from "next/link";
+
+export type SubmittedDetail = { label: string; value: string };
+
+/**
+ * Customer-facing inquiry success result (BI-F20763F5). Replaces the thin
+ * checkout-style confirmation with the full submit-result contract: what the
+ * customer sent, the reference, the response channel + expected time, what
+ * happens next, and how to correct/cancel/contact. Pure presentational
+ * component (no client state, no I/O) so it renders on the server and is
+ * deterministically testable.
+ *
+ * Copy is deliberately honest: no confirmation email is claimed because the
+ * inquiry flow does not send one — the business replies from the inbox.
+ */
+export function InquiryReceived({
+  orgName,
+  orgSlug,
+  reference,
+  customerName,
+  customerEmail,
+  details,
+  contactEmail,
+  contactPhone,
+}: {
+  orgName: string;
+  orgSlug: string;
+  reference: string;
+  customerName: string | null;
+  customerEmail: string;
+  /** Ordered submitted context rows (item, message, party size, etc.). */
+  details: SubmittedDetail[];
+  /** Business contact channels for corrections/cancellations, if configured. */
+  contactEmail: string | null;
+  contactPhone: string | null;
+}) {
+  const greetingName = customerName?.trim() ? customerName.trim().split(/\s+/)[0] : null;
+  const subject = `Enquiry ${reference}`;
+  const correctionBody = `Hi, I'd like to update or cancel my enquiry (reference ${reference}).`;
+
+  return (
+    <div style={{ paddingTop: 40, maxWidth: 560, margin: "0 auto" }}>
+      <div style={{ textAlign: "center", marginBottom: 28 }}>
+        <div style={{ fontSize: 44, marginBottom: 12 }} aria-hidden="true">✉️</div>
+        <h1 style={{ fontSize: 26, fontWeight: 700, marginBottom: 6 }}>
+          {greetingName ? `Thanks, ${greetingName} — your enquiry is in` : "Your enquiry is in"}
+        </h1>
+        <p style={{ color: "var(--dpf-muted)", fontSize: 14 }}>
+          {`${orgName} has received your enquiry. Keep your reference in case you need to get in touch.`}
+        </p>
+      </div>
+
+      <section
+        aria-label="Your reference"
+        style={{
+          border: "1px solid var(--dpf-border)",
+          borderRadius: 10,
+          padding: "14px 16px",
+          textAlign: "center",
+          marginBottom: 20,
+          background: "var(--dpf-surface-2)",
+        }}
+      >
+        <div style={{ fontSize: 12, color: "var(--dpf-muted)", marginBottom: 4 }}>Reference</div>
+        <div style={{ fontSize: 20, fontWeight: 700, fontFamily: "monospace", letterSpacing: 1 }}>
+          {reference}
+        </div>
+      </section>
+
+      <section
+        aria-label="What you sent us"
+        style={{ border: "1px solid var(--dpf-border)", borderRadius: 10, padding: "16px 18px", marginBottom: 20 }}
+      >
+        <h2 style={{ fontSize: 15, fontWeight: 700, marginBottom: 10 }}>What you sent us</h2>
+        <dl style={{ display: "grid", gridTemplateColumns: "auto 1fr", gap: "6px 16px", margin: 0, fontSize: 14 }}>
+          {customerName && (
+            <>
+              <dt style={{ color: "var(--dpf-muted)" }}>Name</dt>
+              <dd style={{ margin: 0 }}>{customerName}</dd>
+            </>
+          )}
+          <dt style={{ color: "var(--dpf-muted)" }}>Email</dt>
+          <dd style={{ margin: 0 }}>{customerEmail}</dd>
+          {details.map((d) => (
+            <Fragment key={d.label}>
+              <dt style={{ color: "var(--dpf-muted)" }}>{d.label}</dt>
+              <dd style={{ margin: 0, whiteSpace: "pre-wrap" }}>{d.value}</dd>
+            </Fragment>
+          ))}
+        </dl>
+      </section>
+
+      <section
+        aria-label="What happens next"
+        style={{ border: "1px solid var(--dpf-border)", borderRadius: 10, padding: "16px 18px", marginBottom: 20 }}
+      >
+        <h2 style={{ fontSize: 15, fontWeight: 700, marginBottom: 10 }}>What happens next</h2>
+        <ol style={{ margin: 0, paddingLeft: 18, fontSize: 14, display: "flex", flexDirection: "column", gap: 6 }}>
+          <li>{`The ${orgName} team will review your enquiry.`}</li>
+          <li>
+            {"They'll reply to you by email at "}
+            <strong>{customerEmail}</strong>
+            {" — usually within one business day."}
+          </li>
+          <li>{"No payment is taken for an enquiry, and nothing is booked yet."}</li>
+        </ol>
+      </section>
+
+      <section
+        aria-label="Need to make a change?"
+        style={{ border: "1px solid var(--dpf-border)", borderRadius: 10, padding: "16px 18px", marginBottom: 24 }}
+      >
+        <h2 style={{ fontSize: 15, fontWeight: 700, marginBottom: 8 }}>Need to change or cancel?</h2>
+        {contactEmail || contactPhone ? (
+          <p style={{ margin: 0, fontSize: 14, color: "var(--dpf-muted)" }}>
+            {`Contact ${orgName} and quote reference `}
+            <strong>{reference}</strong>:
+            <span style={{ display: "flex", gap: 16, marginTop: 8, flexWrap: "wrap" }}>
+              {contactEmail && (
+                <a
+                  href={`mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(correctionBody)}`}
+                  style={{ color: "var(--dpf-accent, #4f46e5)", fontWeight: 600 }}
+                >
+                  {contactEmail}
+                </a>
+              )}
+              {contactPhone && (
+                <a href={`tel:${contactPhone.replace(/\s+/g, "")}`} style={{ color: "var(--dpf-accent, #4f46e5)", fontWeight: 600 }}>
+                  {contactPhone}
+                </a>
+              )}
+            </span>
+          </p>
+        ) : (
+          <p style={{ margin: 0, fontSize: 14, color: "var(--dpf-muted)" }}>
+            {`To change or cancel, reply to the team's email when they get in touch, and quote reference `}
+            <strong>{reference}</strong>.
+          </p>
+        )}
+      </section>
+
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+        <Link
+          href={`/s/${orgSlug}`}
+          style={{
+            padding: "10px 18px", borderRadius: 6, fontSize: 14, fontWeight: 600,
+            background: "var(--dpf-accent, #4f46e5)", color: "#fff", textDecoration: "none",
+          }}
+        >
+          {`Back to ${orgName}`}
+        </Link>
+        <Link
+          href={`/s/${orgSlug}/inquire`}
+          style={{
+            padding: "10px 18px", borderRadius: 6, fontSize: 14, fontWeight: 600,
+            border: "1px solid var(--dpf-border)", color: "var(--dpf-text)", textDecoration: "none",
+          }}
+        >
+          Send another enquiry
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/storefront/InquiryReceived.tsx
+++ b/apps/web/components/storefront/InquiryReceived.tsx
@@ -120,13 +120,13 @@ export function InquiryReceived({
               {contactEmail && (
                 <a
                   href={`mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(correctionBody)}`}
-                  style={{ color: "var(--dpf-accent, #4f46e5)", fontWeight: 600 }}
+                  style={{ color: "var(--dpf-accent)", fontWeight: 600 }}
                 >
                   {contactEmail}
                 </a>
               )}
               {contactPhone && (
-                <a href={`tel:${contactPhone.replace(/\s+/g, "")}`} style={{ color: "var(--dpf-accent, #4f46e5)", fontWeight: 600 }}>
+                <a href={`tel:${contactPhone.replace(/\s+/g, "")}`} style={{ color: "var(--dpf-accent)", fontWeight: 600 }}>
                   {contactPhone}
                 </a>
               )}
@@ -145,7 +145,7 @@ export function InquiryReceived({
           href={`/s/${orgSlug}`}
           style={{
             padding: "10px 18px", borderRadius: 6, fontSize: 14, fontWeight: 600,
-            background: "var(--dpf-accent, #4f46e5)", color: "#fff", textDecoration: "none",
+            background: "var(--dpf-accent)", color: "var(--dpf-on-accent)", textDecoration: "none",
           }}
         >
           {`Back to ${orgName}`}

--- a/apps/web/lib/ea/route-manifest.json
+++ b/apps/web/lib/ea/route-manifest.json
@@ -1,6 +1,6 @@
 {
   "generator": "apps/web/scripts/build-route-manifest.ts",
-  "routeCount": 574,
+  "routeCount": 575,
   "routes": [
     {
       "routePath": "/",
@@ -6372,6 +6372,20 @@
         "itemId"
       ],
       "file": "apps/web/app/(storefront)/s/[slug]/inquire/[itemId]/page.tsx"
+    },
+    {
+      "routePath": "/s/[slug]/inquiry/received",
+      "kind": "page",
+      "segments": [
+        "s",
+        "[slug]",
+        "inquiry",
+        "received"
+      ],
+      "dynamicParams": [
+        "slug"
+      ],
+      "file": "apps/web/app/(storefront)/s/[slug]/inquiry/received/page.tsx"
     },
     {
       "routePath": "/s/[slug]/item/[itemId]",

--- a/apps/web/lib/storefront/inquiry-validation.test.ts
+++ b/apps/web/lib/storefront/inquiry-validation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateRequiredFields,
+  isFormValid,
+  orderedErrors,
+  requiredMessage,
+  INVALID_EMAIL_MESSAGE,
+  type ValidatableField,
+} from "./inquiry-validation";
+
+// Representative field sets for the three public-form journeys this contract
+// covers. The auth and booking sets are exercised here as pure data so the
+// deterministic validation is proven without importing (or depending on the
+// merge order of) the sibling auth/booking components.
+const INQUIRY_FIELDS: ValidatableField[] = [
+  { name: "name", label: "Your name", type: "text", required: true },
+  { name: "email", label: "Email address", type: "email", required: true },
+  { name: "phone", label: "Phone number", type: "tel", required: false },
+  { name: "message", label: "Message", type: "textarea", required: false },
+];
+
+const AUTH_FIELDS: ValidatableField[] = [
+  { name: "email", label: "Email", type: "email", required: true },
+  { name: "password", label: "Password", type: "password", required: true },
+];
+
+const BOOKING_FINAL_FIELDS: ValidatableField[] = [
+  { name: "name", label: "Full name", type: "text", required: true },
+  { name: "email", label: "Email address", type: "email", required: true },
+  { name: "date", label: "Preferred date", type: "date", required: true },
+  { name: "time", label: "Preferred time", type: "time", required: true },
+  { name: "notes", label: "Notes", type: "textarea", required: false },
+];
+
+describe("validateRequiredFields — empty submit", () => {
+  it("flags every required inquiry field and leaves optional ones alone", () => {
+    const errors = validateRequiredFields(INQUIRY_FIELDS, {});
+    expect(errors.name).toBe(requiredMessage("Your name"));
+    expect(errors.email).toBe(requiredMessage("Email address"));
+    expect(errors.phone).toBeUndefined();
+    expect(errors.message).toBeUndefined();
+  });
+
+  it("treats whitespace-only values as blank", () => {
+    const errors = validateRequiredFields(INQUIRY_FIELDS, { name: "   ", email: "\t" });
+    expect(errors.name).toBe(requiredMessage("Your name"));
+    expect(errors.email).toBe(requiredMessage("Email address"));
+  });
+
+  it("flags both required public-auth fields on an empty submit", () => {
+    const errors = validateRequiredFields(AUTH_FIELDS, {});
+    expect(errors.email).toBe(requiredMessage("Email"));
+    expect(errors.password).toBe(requiredMessage("Password"));
+    expect(isFormValid(AUTH_FIELDS, {})).toBe(false);
+  });
+
+  it("flags all required booking final-form fields deterministically (no side effects)", () => {
+    const errors = validateRequiredFields(BOOKING_FINAL_FIELDS, {});
+    expect(Object.keys(errors).sort()).toEqual(["date", "email", "name", "time"]);
+    expect(errors.date).toBe(requiredMessage("Preferred date"));
+    expect(errors.time).toBe(requiredMessage("Preferred time"));
+  });
+});
+
+describe("validateRequiredFields — email format", () => {
+  it("rejects a malformed email even when non-blank", () => {
+    const errors = validateRequiredFields(INQUIRY_FIELDS, { name: "Ada", email: "not-an-email" });
+    expect(errors.email).toBe(INVALID_EMAIL_MESSAGE);
+  });
+
+  it("accepts a well-formed email", () => {
+    const errors = validateRequiredFields(INQUIRY_FIELDS, { name: "Ada", email: "ada@example.com" });
+    expect(errors.email).toBeUndefined();
+  });
+
+  it("does not flag a blank optional email", () => {
+    const optional: ValidatableField[] = [{ name: "email", label: "Email", type: "email", required: false }];
+    expect(validateRequiredFields(optional, {})).toEqual({});
+  });
+});
+
+describe("validateRequiredFields — valid submit", () => {
+  it("returns no errors when all required fields are filled", () => {
+    const values = { name: "Ada", email: "ada@example.com", phone: "", message: "" };
+    expect(validateRequiredFields(INQUIRY_FIELDS, values)).toEqual({});
+    expect(isFormValid(INQUIRY_FIELDS, values)).toBe(true);
+  });
+
+  it("validates a complete booking final form", () => {
+    const values = { name: "Ada", email: "ada@example.com", date: "2026-07-23", time: "18:30" };
+    expect(isFormValid(BOOKING_FINAL_FIELDS, values)).toBe(true);
+  });
+});
+
+describe("orderedErrors", () => {
+  it("returns errors in field order, not object-key order", () => {
+    const errors = validateRequiredFields(INQUIRY_FIELDS, {});
+    const ordered = orderedErrors(INQUIRY_FIELDS, errors);
+    expect(ordered.map((e) => e.name)).toEqual(["name", "email"]);
+  });
+});

--- a/apps/web/lib/storefront/inquiry-validation.ts
+++ b/apps/web/lib/storefront/inquiry-validation.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure, framework-agnostic required-field validation for public storefront
+ * forms (BI-F20763F5). Kept free of React / I/O so it is deterministic and
+ * side-effect-free: the same `(fields, values)` always yields the same errors,
+ * with no network, DB, or payment interaction. This is the single source of the
+ * customer-facing validation contract shared by the inquiry form and exercised
+ * — as data, not via the sibling components — for the auth (email/password) and
+ * booking (name/email/date/time) field sets.
+ */
+
+/** Minimal field shape the validator needs. `@dpf/storefront-templates`'
+ *  `FormField` structurally satisfies this, as do ad-hoc auth/booking specs. */
+export interface ValidatableField {
+  name: string;
+  label: string;
+  type: string;
+  required: boolean;
+}
+
+export type FieldValues = Record<string, string | null | undefined>;
+export type FieldErrors = Record<string, string>;
+
+// Deliberately conservative: one @, at least one dot in the domain, no spaces.
+// The server is the authority on deliverability; this only catches obvious typos
+// so the customer gets a friendly nudge instead of a silent failure.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function requiredMessage(label: string): string {
+  return `${label} is required`;
+}
+
+export const INVALID_EMAIL_MESSAGE = "Enter a valid email address";
+
+function isBlank(value: string | null | undefined): boolean {
+  return value == null || value.trim() === "";
+}
+
+/**
+ * Validate a set of fields against submitted values. Returns a map of
+ * field-name → human-readable message for every field that fails. An empty
+ * object means the form is valid.
+ *
+ * Rules:
+ * - required field left blank → `"<Label> is required"`
+ * - email-typed field with a non-blank but malformed value → invalid-email
+ *   message (a blank optional email is not flagged)
+ */
+export function validateRequiredFields(
+  fields: ReadonlyArray<ValidatableField>,
+  values: FieldValues,
+): FieldErrors {
+  const errors: FieldErrors = {};
+  for (const field of fields) {
+    const raw = values[field.name];
+    if (field.required && isBlank(raw)) {
+      errors[field.name] = requiredMessage(field.label);
+      continue;
+    }
+    if (field.type === "email" && !isBlank(raw) && !EMAIL_RE.test(raw!.trim())) {
+      errors[field.name] = INVALID_EMAIL_MESSAGE;
+    }
+  }
+  return errors;
+}
+
+/** True when the field set validates cleanly against the given values. */
+export function isFormValid(
+  fields: ReadonlyArray<ValidatableField>,
+  values: FieldValues,
+): boolean {
+  return Object.keys(validateRequiredFields(fields, values)).length === 0;
+}
+
+/**
+ * Ordered [name, message] pairs for building an error summary that follows the
+ * field order the customer sees, rather than object-key order.
+ */
+export function orderedErrors(
+  fields: ReadonlyArray<ValidatableField>,
+  errors: FieldErrors,
+): Array<{ name: string; message: string }> {
+  return fields
+    .filter((f) => errors[f.name])
+    .map((f) => ({ name: f.name, message: errors[f.name] }));
+}

--- a/docs/superpowers/specs/2026-07-22-customer-submit-result-contract-design.md
+++ b/docs/superpowers/specs/2026-07-22-customer-submit-result-contract-design.md
@@ -1,0 +1,109 @@
+# Customer submit-result contract (BI-F20763F5)
+
+Status: implementing · Epic: EP-UX-COGLOAD · Date: 2026-07-22
+
+## Problem
+
+The live customer submit/result audit (2026-07-22) found that public Restaurant
+forms can submit and create owner-side work, but the feedback contract is too
+thin for a non-technical customer or owner:
+
+- `/s/<slug>/inquire` empty-submit relies on **browser-native** required-field
+  blocking only; the page adds no visible inline/summary feedback, and several
+  controls have empty accessible labels.
+- A safe dummy inquiry created reference `INQ-FGQXCF4X` and navigated to
+  `/s/<slug>/checkout?ref=INQ-FGQXCF4X&type=inquiry` — a **checkout** route for a
+  non-checkout action. The success page said only *"Enquiry received! Reference:
+  INQ-FGQXCF4X We'll be in touch shortly."* — no response channel/time, no
+  submitted context, no correction/cancel/contact path.
+- Owner `/storefront/inbox` shows the inquiry with a generic **`Send to
+  backlog`** action that does not name the request or explain what it changes.
+
+## Scope & coordination
+
+This BI is scoped **disjoint** from four in-flight sibling PRs in the same epic so
+they can merge in any order. An overlap sweep (`gh pr list` by file) drove the
+final scope:
+
+- **BI-8E74C749 / PR #3386** owns the shared `apps/web/components/ui/form/`
+  primitives and the accessibility of `BookingForm`, `SignInForm`, `SignUpForm`.
+  This BI does **not** touch those files.
+- **BI-3DA1DFDC / PR #3387** owns the **booking** reservation-context row and the
+  booking `Confirm`/`Cancel` accessible labels in `StorefrontInbox`, plus
+  `inbox/page.tsx` booking fields. This BI does **not** edit `inbox/page.tsx`.
+- **BI-4F4252DB / PR #3394** owns the **owner inquiry Send-to-backlog per-row
+  action** — it already delivers the row-specific `aria-label="Send inquiry <ref>
+  to backlog"` and the "✓ Sent to backlog" completed state. To avoid duplicate,
+  conflicting work on the same JSX block, this BI **defers the per-row action to
+  #3394** and contributes only the non-conflicting section-level **consequence
+  copy** in the inbox banner ("…track a customer request as internal follow-up
+  work. It doesn't notify the customer.").
+- **BI-4A68EDF6 / PR #3396** enriches the shared `/checkout` confirmation and
+  keeps booking/order/donation there. This BI moves **only inquiry** off checkout
+  with a minimal early `redirect()` inserted in a region #3396 does not touch, so
+  both changes auto-merge; #3396's inquiry-branch copy simply becomes unreachable.
+
+So this BI owns, end-to-end: the **inquiry** form validation, the **inquiry**
+success result route/page, the inquiry `/checkout` → `/inquiry/received` redirect,
+and the inbox consequence copy. The validation utility it introduces is field-set
+agnostic, so its deterministic tests also cover the auth (email/password) and
+booking (name/email/date/time) required-field sets without importing the sibling
+components.
+
+## Design
+
+### 1. Visible, accessible validation (`apps/web/lib/storefront/inquiry-validation.ts`)
+
+A pure, framework-agnostic validator: `validateRequiredFields(fields, values)`
+returns `{ [name]: message }` for empty required fields (`"<Label> is
+required"`) and malformed emails (`"Enter a valid email address"`). No React, no
+I/O — deterministic and side-effect-free.
+
+`apps/web/components/storefront/InquiryForm.tsx` uses it and renders:
+
+- an **error summary** at the top (`role="alert"`, focus-managed) that links to
+  each invalid field;
+- **inline** per-field errors (`aria-invalid`, `aria-describedby`,
+  `<label htmlFor>` associations, `aria-required`);
+- `noValidate` on the `<form>` so our messaging replaces the native popups.
+
+Errors block the server call — an invalid empty submit performs **no** network or
+navigation side effect. All colours use storefront `--dpf-*` branding tokens.
+
+### 2. Named result route (`apps/web/app/(storefront)/s/[slug]/inquiry/received/page.tsx`)
+
+Successful inquiries now route to `/s/<slug>/inquiry/received?ref=…` instead of
+`…/checkout`. The presenter `apps/web/components/storefront/InquiryReceived.tsx`
+shows: the reference; **what you sent us** (name, email, phone, item, message,
+archetype fields mapped through the form schema labels); **what happens next**
+(review + response channel = the customer's email, expected time); and **need to
+make a change?** (correction/cancel = contact the business, quoting the
+reference, via `mailto:`/`tel:` when contact details exist) plus a link back to
+the storefront. Copy is honest: no confirmation email is claimed because none is
+sent. `apps/web/app/(storefront)/s/[slug]/checkout/page.tsx` now `redirect()`s the
+`type=inquiry` branch to the named route so old links still resolve.
+
+### 3. Owner inquiry handoff (`apps/web/components/storefront-admin/StorefrontInbox.tsx`)
+
+Owner-side is a coordinated split. The per-row `Send to backlog` action — its
+row-specific label and completed state — is owned by **#3394** and is not
+duplicated here. This BI adds only the **consequence copy** to the inbox banner
+so a non-technical owner learns, before clicking, that Send-to-backlog creates
+internal follow-up work and does not notify the customer. This edit sits well
+away from the per-row block (#3394) and the booking region (#3387), so it
+auto-merges. Rows already show reference/customer/message for inquiries, so item
+"owner inbox rows show the same reference/customer/request context" holds on main.
+
+## Tests (no payment, no external side effects)
+
+- `inquiry-validation.test.ts` — inquiry/auth/booking required-field sets: empty →
+  flagged, filled → clean, bad email → flagged (covers *public auth validation*
+  and *deterministic booking final-form validation* as pure logic).
+- `InquiryForm.test.tsx` — empty submit shows summary + inline and calls neither
+  the action nor the router; valid submit calls the action once and routes to
+  `/s/<slug>/inquiry/received`.
+- `InquiryReceived.test.tsx` — reference, submitted context, response channel,
+  what-next, correction/contact all present.
+Owner-inbox smoke coverage (item 7's "owner inbox visibility") is provided by
+#3394's `StorefrontInbox.test.tsx`; this BI does not add a competing test file on
+that path.


### PR DESCRIPTION
## What & why

Live 2026-07-22 audit (BI-F20763F5) found the public customer submit/result contract too thin for non-technical Restaurant customers and owners: the inquiry form used browser-native required-field blocking with empty accessible labels, a successful enquiry landed on `/checkout?type=inquiry` with a one-line "We'll be in touch" message, and the owner inbox showed a bare "Send to backlog".

### Customer side (this BI's core)
- **Visible, accessible validation** — new pure module `apps/web/lib/storefront/inquiry-validation.ts`; `InquiryForm` now renders inline errors + a focus-managed `role="alert"` summary, with `aria-invalid`/`aria-describedby`/`<label htmlFor>` associations, `aria-required`, and `noValidate` so our messaging replaces native popups. Restaurant-branded via storefront `--dpf-*` tokens.
- **Named result route** — successful inquiries route to `/s/<slug>/inquiry/received` (`InquiryReceived`): reference, what was submitted (mapped through the archetype schema labels), response channel + expected time, what happens next, and correction/cancel/contact options. Copy is honest — it never claims a confirmation email the flow does not send.
- **Off `/checkout`** — `/checkout?type=inquiry` now `redirect()`s to the named route so an inquiry success no longer looks like checkout plumbing (old bookmarks still resolve).

### Owner side (coordinated split)
- Inbox banner gains **consequence copy** so an owner learns Send-to-backlog creates internal follow-up work and does not notify the customer.

## Design grounding

Source of truth: new artifact `docs/superpowers/specs/2026-07-22-customer-submit-result-contract-design.md`, grounded in the existing `apps/web/` storefront substrate (`InquiryForm`, `checkout/page.tsx`, `StorefrontInbox`, `storefront-data`). This is a new contract for inquiry submit-results; no prior spec covered it.

**Overlap sweep (`gh pr list` by file) — scoped disjoint from four in-flight epic siblings:**
- The owner **per-row** Send-to-backlog action (row-specific label + completed state) is owned by **#3394** and is **not** duplicated here — this PR adds only the banner consequence copy, well away from that block.
- The **booking** inbox row + Confirm/Cancel labels are owned by **#3387**.
- The `/checkout` enrichment for **booking/order/donation** is owned by **#3396** — this PR inserts only a minimal early `redirect()` in a region #3396 does not touch, so both auto-merge (#3396's inquiry-branch copy simply becomes unreachable).
- Shared form primitives / auth+booking accessibility are owned by **#3386**.

## Tests (no payment, no external side effects)
- `inquiry-validation.test.ts` — required-field validation across inquiry, **public-auth** (email/password), and **booking final-form** (name/email/date/time) sets, plus email-format and ordering.
- `InquiryForm.test.tsx` — empty submit shows summary + inline and calls neither the action nor the router; valid submit calls the action once and routes to `/inquiry/received`; server error surfaces without navigating.
- `InquiryReceived.test.tsx` — reference, submitted context, response channel/time, what-next, correction/contact all present; no fabricated confirmation-email copy.
- Owner-inbox visibility smoke is provided by #3394's `StorefrontInbox.test.tsx` (not duplicated).

## Verification
- **`tsc --noEmit` on `apps/web`: 0 errors** (full project; the non-zero process exit is a V8 abort-on-teardown flake — no `error TS` lines).
- Validation module (**10 checks**) and the `InquiryReceived` / `StorefrontInbox` / `InquiryForm` components (**15 render checks** via esbuild + `react-dom/server`) pass locally — this harness caught and fixed a real apostrophe-escaping (`&#x27;`) assertion bug before commit.
- The **vitest unit run is deferred to CI**: the shared pnpm store ships a corrupt `vitest@4.1.9`/`vite` entry (the same block BI-8E74C749/#3386 documented) that prevents the local runner from starting.

Design-Grounding-Decision: new-artifact — docs/superpowers/specs/2026-07-22-customer-submit-result-contract-design.md; grounded in apps/web/ storefront substrate; disjoint from #3386/#3387/#3394/#3396.
UX-Fit-Decision: reduces cognitive load — validation surfaces only after submit (inline + one summary, not upfront noise); result page is a few plain labelled sections; no new operator/admin controls, no raw token/endpoint inputs; progressive disclosure preserved.
Seed-Fit-Decision: no seed impact — no seed/*.ts, archetype corpus, or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
