### PR TITLE
fix(attention): demote generic decisions + reconcile twin reservations (BI-348766E5)

### DIFF
--- a/apps/web/lib/attention/owner-routing.test.ts
+++ b/apps/web/lib/attention/owner-routing.test.ts
@@ -112,6 +112,31 @@ describe("classifyOwnerAttentionLane", () => {
     expect(classifyOwnerAttentionLane(paused, "balanced").lane).toBe("custodian");
   });
 
+  it("demotes generic corpus-fallback decisions (coverage-gap, nothing blocked) to the digest", () => {
+    const generic = item("ai-decision", {
+      triage: {
+        timeToAct: "none",
+        residueReason: "coverage-gap",
+        decideEffort: "judgment",
+        irreversible: false,
+      },
+    });
+    expect(classifyOwnerAttentionLane(generic, "balanced").lane).toBe("weekly-digest");
+  });
+
+  it("keeps a coverage-gap decision that blocks a concrete outcome in needs-you", () => {
+    const blocking = item("ai-decision", {
+      triage: {
+        timeToAct: "none",
+        residueReason: "coverage-gap",
+        blastRadius: "build FB-123",
+        decideEffort: "judgment",
+        irreversible: false,
+      },
+    });
+    expect(classifyOwnerAttentionLane(blocking, "balanced").lane).toBe("needs-you-now");
+  });
+
   it("uses source-carried per-coworker proactivity before the fallback", () => {
     const research = item("research-proposal", {
       proactivity: { level: "quiet", actorId: "research-coworker" },

--- a/apps/web/lib/attention/owner-routing.ts
+++ b/apps/web/lib/attention/owner-routing.ts
@@ -49,7 +49,25 @@ export function classifyOwnerAttentionLane(
   if (item.source === "coworker-memory") {
     return decision("weekly-digest", "New coworker learning is visible in the digest.", false, appliedLevel);
   }
-  if (item.source === "ai-decision" || item.triage.decideEffort === "judgment") {
+  if (item.source === "ai-decision") {
+    // Generic corpus-fallback residue — the kernel simply had no applicable
+    // principle (coverage-gap) and nothing concrete is blocked (no blastRadius).
+    // These flood the primary count with near-identical cards, so group them into
+    // the advanced/weekly review BEHIND concrete operational work rather than let
+    // them outrank a guest reservation (BI-348766E5 fix 4).
+    const isGenericCorpusFallback =
+      item.triage.residueReason === "coverage-gap" && !item.triage.blastRadius;
+    if (isGenericCorpusFallback) {
+      return decision(
+        "weekly-digest",
+        "Grouped for advanced review — no customer or build outcome is blocked.",
+        false,
+        appliedLevel,
+      );
+    }
+    return decision("needs-you-now", "A real human judgment is still required.", false, appliedLevel);
+  }
+  if (item.triage.decideEffort === "judgment") {
     return decision("needs-you-now", "A real human judgment is still required.", false, appliedLevel);
   }
   if (item.source === "agent-proposal" || item.source === "paused-ai") {

--- a/apps/web/lib/twin/living-business-snapshot.test.ts
+++ b/apps/web/lib/twin/living-business-snapshot.test.ts
@@ -6,10 +6,13 @@ import {
   buildQuests,
   financeToUtility,
   humanizeWait,
+  isReservationQueueKey,
+  isUpcomingReservation,
   liveCapacityChips,
   loadLivingBusinessSnapshot,
   longestWaitMs,
   proposeCogAllocation,
+  reservationsToQueueItems,
   resourceUnits,
   rosterToPresence,
   statusIntent,
@@ -145,6 +148,33 @@ describe("living-business-snapshot — pure helpers", () => {
     const queue = bookingsToQueueItems(bookings, NOW);
     expect(queue[0].meta).toBe("awaiting schedule");
     expect(queue[0].waiting).toBe("3h");
+  });
+
+  it("reservationsToQueueItems surfaces upcoming reservations soonest-first (BI-348766E5)", () => {
+    const bookings = [
+      { id: "later", scheduledAt: new Date("2026-07-20T19:00:00Z"), createdAt: new Date("2026-07-15T09:00:00Z"), status: "confirmed", provider: { name: "Table 5" } },
+      { id: "soon", scheduledAt: new Date("2026-07-16T19:00:00Z"), createdAt: new Date("2026-07-15T09:00:00Z"), status: "pending", provider: null },
+      { id: "past", scheduledAt: new Date("2026-07-14T19:00:00Z"), createdAt: new Date("2026-07-13T09:00:00Z"), status: "pending", provider: null },
+      { id: "gone", scheduledAt: new Date("2026-07-18T19:00:00Z"), createdAt: new Date("2026-07-15T09:00:00Z"), status: "cancelled", provider: null },
+    ];
+    const queue = reservationsToQueueItems(bookings, NOW);
+    // Only future, non-cancelled bookings; soonest first; a cancelled one is excluded.
+    expect(queue.map((q) => q.key)).toEqual(["soon", "later"]);
+    expect(queue[0]).toMatchObject({ label: "Reservation", meta: "booked for 07-16" });
+    expect(queue[1].label).toBe("With Table 5");
+  });
+
+  it("isUpcomingReservation excludes past, cancelled and completed bookings", () => {
+    expect(isUpcomingReservation({ id: "a", scheduledAt: new Date("2026-07-20T09:00:00Z"), createdAt: null, status: "pending", provider: null }, NOW)).toBe(true);
+    expect(isUpcomingReservation({ id: "b", scheduledAt: new Date("2026-07-10T09:00:00Z"), createdAt: null, status: "pending", provider: null }, NOW)).toBe(false);
+    expect(isUpcomingReservation({ id: "c", scheduledAt: new Date("2026-07-20T09:00:00Z"), createdAt: null, status: "cancelled", provider: null }, NOW)).toBe(false);
+    expect(isUpcomingReservation({ id: "d", scheduledAt: null, createdAt: null, status: "pending", provider: null }, NOW)).toBe(false);
+  });
+
+  it("isReservationQueueKey matches the FLOOR/YARD reservations queue keys", () => {
+    expect(isReservationQueueKey("reservations")).toBe(true);
+    expect(isReservationQueueKey("waitlist")).toBe(false);
+    expect(isReservationQueueKey("dispatch")).toBe(false);
   });
 
   it("longestWaitMs ignores scheduled reservations — only walk-ins wait", () => {
@@ -300,8 +330,11 @@ describe("loadLivingBusinessSnapshot — loader", () => {
     expect(snap!.presence.some((p) => p.kind === "human")).toBe(true);
     // finance renders the ORG currency (USD), not the legacy GBP bill row
     expect(snap!.utility.find((m) => m.key === "bills")!.value).toContain("$500");
-    // a pending booking becomes queue demand + a cog proposal
-    expect(snap!.queues[0].items.length).toBeGreaterThan(0);
+    // an upcoming pending booking becomes RESERVATIONS-queue demand (BI-348766E5:
+    // the restaurant Reservations queue is populated, not hardcoded-empty) + a cog proposal
+    const reservationsQueue = snap!.queues.find((q) => isReservationQueueKey(q.key));
+    expect(reservationsQueue).toBeTruthy();
+    expect(reservationsQueue!.items.length).toBeGreaterThan(0);
     expect(snap!.cog).toBeTruthy();
     // A restaurant (FLOOR) headlines capacity in its own words — tables/seats/
     // waitlist — not the archetype-agnostic Workforce/AI counters (BI-7C95A586).

--- a/apps/web/lib/twin/living-business-snapshot.ts
+++ b/apps/web/lib/twin/living-business-snapshot.ts
@@ -285,6 +285,35 @@ export function readinessQuest(snap: RestaurantCapacitySnapshot): QuestData | nu
   };
 }
 
+/** A queue key that means "reservations" (restaurant FLOOR, rental YARD). */
+export function isReservationQueueKey(key: string): boolean {
+  return /reserv/i.test(key);
+}
+
+/** An upcoming, still-active reservation — a future scheduled slot that is neither
+ *  cancelled nor completed. This is the "reservations on the books" set. */
+export function isUpcomingReservation(b: BookingRow, now: Date): boolean {
+  const status = b.status.toLowerCase();
+  if (status === "cancelled" || status === "completed") return false;
+  return b.scheduledAt != null && b.scheduledAt.getTime() > now.getTime();
+}
+
+/** Upcoming reservations → queue items, soonest slot first. The meaningful metric
+ *  is time-until-service, not age-in-queue. Reconciles the twin Reservations queue
+ *  with the Storefront booking history (BI-348766E5). */
+export function reservationsToQueueItems(bookings: BookingRow[], now: Date, limit = 6): QueueItemData[] {
+  return bookings
+    .filter((b) => isUpcomingReservation(b, now))
+    .sort((a, b) => (a.scheduledAt?.getTime() ?? Infinity) - (b.scheduledAt?.getTime() ?? Infinity))
+    .slice(0, limit)
+    .map((b) => ({
+      key: b.id,
+      label: b.provider?.name ? `With ${b.provider.name}` : "Reservation",
+      meta: b.scheduledAt ? `booked for ${monthDay(b.scheduledAt)}` : "awaiting schedule",
+      waiting: b.scheduledAt ? `in ${humanizeWait(b.scheduledAt.getTime() - now.getTime())}` : undefined,
+    }));
+}
+
 /** The longest a pending item has waited — the queue's headline flow metric. */
 export function longestWaitMs(bookings: BookingRow[], now: Date): number {
   // Only genuine walk-in waits count — scheduled reservations (upcoming or
@@ -632,16 +661,33 @@ export async function loadLivingBusinessSnapshot(opts?: {
         })
       : null;
 
-  // NB: the Reservations-queue reconciliation (fixing "RESERVATIONS 0" while
-  // booking history exists) is owned by BI-348766E5 (PR #3403), which edits this
-  // same queue construction. This PR (BI-7C95A586) deliberately leaves it alone
-  // to avoid duplicating that work — it owns the capacity chips + readiness only.
-  const queueItems = bookingsToQueueItems(bookings, now);
-  const queues: TwinQueueSnapshot[] = profile.queues.map((qs, i) => ({
-    key: qs.key,
-    items: i === 0 ? queueItems : [],
-    emptyLabel: i === 0 ? "No demand waiting" : "Clear",
-  }));
+  // Distribute booking-derived demand across the profile's queues by MEANING, not
+  // just into queue 0. A profile with a dedicated reservations queue (e.g. the
+  // restaurant FLOOR: [waitlist, reservations]) must show its upcoming reservations
+  // there instead of a hardcoded-empty "Reservations 0 / Clear" that contradicts the
+  // Storefront booking history (BI-348766E5 fix 3). Guarded so profiles whose FIRST
+  // queue is the reservations queue (YARD) — and every non-reservation profile —
+  // keep their existing behaviour exactly.
+  const reservationQueuePresent = profile.queues.some((qs, i) => i > 0 && isReservationQueueKey(qs.key));
+  const upcomingReservationItems = reservationQueuePresent
+    ? reservationsToQueueItems(bookings, now)
+    : [];
+  // Keep the general (index 0) queue from double-counting the upcoming reservations
+  // now shown in their own queue.
+  const generalBookings = reservationQueuePresent
+    ? bookings.filter((b) => !isUpcomingReservation(b, now))
+    : bookings;
+  const generalQueueItems = bookingsToQueueItems(generalBookings, now);
+  const queues: TwinQueueSnapshot[] = profile.queues.map((qs, i) => {
+    if (i > 0 && isReservationQueueKey(qs.key)) {
+      return { key: qs.key, items: upcomingReservationItems, emptyLabel: "No upcoming reservations" };
+    }
+    return {
+      key: qs.key,
+      items: i === 0 ? generalQueueItems : [],
+      emptyLabel: i === 0 ? "No demand waiting" : "Clear",
+    };
+  });
 
   const cog = proposeCogAllocation(
     bookings,

--- a/docs/superpowers/plans/2026-07-22-restaurant-owner-attention-reconciliation.md
+++ b/docs/superpowers/plans/2026-07-22-restaurant-owner-attention-reconciliation.md
@@ -1,0 +1,52 @@
+# Plan — Restaurant owner attention reconciliation (BI-348766E5)
+
+Spec: `docs/superpowers/specs/2026-07-22-restaurant-owner-attention-reconciliation-design.md`
+BI: BI-348766E5 · coordinates BI-3DA1DFDC (PR #3387), BI-075F731F, BI-36807E68, BI-7D7EE150, BI-8EA88797
+
+## Coordination
+
+The reservation attention source, `covers`/dietary schema, and the row-specific Storefront Inbox
+Confirm/Cancel labels are delivered by the sibling BI-3DA1DFDC PR (#3387). This PR is scoped to the
+**complementary workspace-side reconciliation** so the two land cleanly without a duplicate source
+or a Storefront Inbox merge collision.
+
+## Phase 1 — Row-specific decision labels (fix 5): NOT via card copy
+
+Investigated; the plain-language owner-copy contract (`owner-decision.test.ts` bans raw-title /
+technical-acronym leakage; `AttentionInbox.test` hides the raw title) means a per-row *label* built
+from the only per-row datum (the raw technical question) is impossible without breaking the
+contract. Delivered instead by Phase 2 (demotion removes the repetition) + the pre-existing
+`?attentionId=` exact deep link. No card-copy changes.
+
+## Phase 2 — Demote the generic-decision flood (the substantive fix)
+
+4. `apps/web/lib/attention/owner-routing.ts`: an unlinked corpus `ai-decision`
+   (`coverage-gap`, no `blastRadius`) routes to `weekly-digest` (grouped advanced review) instead
+   of `needs-you-now`; genuine/blocking decisions stay in `needs-you-now`.
+
+## Phase 3 — Twin reservations queue
+
+5. `apps/web/lib/twin/living-business-snapshot.ts`: distribute booking items — a reservations-keyed
+   queue (index > 0) gets upcoming reservations soonest-first; the general queue (index 0) excludes
+   them; honest `No upcoming reservations` empty label. Non-restaurant profiles unchanged.
+
+## Phase 4 — Tests
+
+6. Vitest: extend `owner-routing.test.ts` (demotion) and `living-business-snapshot.test.ts`
+   (queue distribution + `isUpcomingReservation` / `isReservationQueueKey`).
+7. Playwright: `e2e/restaurant-vertical-signal-consistency.spec.ts` compares the public booking
+   context, `/storefront/inbox`, `/workspace`, and `/workspace/inbox`.
+
+## Verification
+
+- Merged-code typecheck via the shared local-integration sandbox (`tsc --noEmit`, green).
+- Unit gates run in CI (worktree is source-only; the shared sandbox's vitest was drift-blocked by
+  an unrelated infra defect — a known `fix/windows-local-integration-vitest` issue).
+- e2e requires the live portal + seeded restaurant demo (`loadDemoBusiness("restaurant")`); its
+  reservation-signal assertions light up once #3387's source is present.
+
+## Backlog coverage
+
+Closes the workspace-side half of BI-348766E5 (fixes 3/4/5 + smoke 7); fixes 1/2/6 are completed
+jointly with BI-3DA1DFDC (#3387). Advances BI-8EA88797 (exact-target focusing), BI-36807E68
+(vertical-signal-consistency fixture), BI-075F731F (owner cockpit surfaces reservation next-action).

--- a/docs/superpowers/specs/2026-07-22-restaurant-owner-attention-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-07-22-restaurant-owner-attention-reconciliation-design.md
@@ -1,0 +1,112 @@
+# Restaurant owner attention reconciliation — design
+
+- Date: 2026-07-22
+- Primary backlog item: BI-348766E5 (Workspace attention must reconcile vertical inbox signals before generic decisions)
+- Coordinates with: BI-3DA1DFDC, BI-075F731F, BI-36807E68, BI-7D7EE150, BI-8EA88797
+- Epics: EP-UX-COGLOAD, EP-ATTENTION-SURFACE, EP-VERTICAL-FOOD-HOSPITALITY
+- Surfaces touched: `apps/web/lib/attention/*`, `apps/web/components/storefront-admin/StorefrontInbox.tsx`, `apps/web/app/(shell)/storefront/inbox/page.tsx`, `apps/web/lib/twin/living-business-snapshot.ts`, `apps/web/components/attention/OwnerDecisionCards.tsx`
+
+## Problem
+
+A non-technical Restaurant owner's most concrete operational work — reservations that need
+confirming — is invisible on the primary attention surface, while generic
+enterprise-architecture "decisions" flood it. Live audit (2026-07-22) found:
+
+1. `/storefront/inbox` has real booking rows (guest, table, date/time, status, Confirm/Cancel).
+2. `/workspace` shows `RESERVATIONS 0 Clear` and `NEEDS YOU Nothing needs you right now`, while
+   separately claiming `30 things need you today`.
+3. `/workspace/inbox` shows ~28 repeated `Make this business decision?` / `Review this decision`
+   cards with no Restaurant vocabulary.
+4. Storefront Inbox `Confirm`/`Cancel` buttons are terse and repeated, with no row context or
+   consequence framing.
+
+### Root causes (verified in code)
+
+- **No reservation source in the attention aggregate.** `apps/web/lib/attention/aggregate.ts`
+  wires 13 loaders (agent/decision/approval/platform); none read `StorefrontBooking`. The
+  attention surface is structurally blind to customer demand.
+- **The twin "Reservations" queue is hardcoded empty.** `living-business-snapshot.ts:552`
+  assigns booking items only to queue index 0 (`items: i === 0 ? queueItems : []`). For the
+  restaurant `FLOOR` profile the queues are `[waitlist(0), reservations(1)]`, so Reservations is
+  always `0 / Clear` regardless of booking data.
+- **Generic residue floods the count.** Every unresolved `DecisionInteraction`
+  (`sources/ai-decision.ts`) hard-routes to `needs-you-now` (`owner-routing.ts:49`) with a static
+  `Make this business decision?` headline (`owner-decision-copy.ts:6`) and a fallback
+  `Review this decision` button (`owner-decision.ts:80`) — the linked `/platform/ai/decisions/...`
+  href is rejected by `isOwnerSafeHref`. N unlinked corpus-fallback rows become N identical cards.
+
+## Coordination with BI-3DA1DFDC (PR #3387)
+
+The **reservation attention source itself** — projecting owner-actionable `StorefrontBooking`
+rows (pending / needs-reschedule / overlap-quarantined) as customer-facing
+(`products-and-services-sold`) attention items, plus the `covers`/dietary schema columns and the
+row-specific Storefront Inbox Confirm/Cancel labels — is delivered by the sibling BI-3DA1DFDC PR
+(`apps/web/lib/attention/sources/reservation-exception.ts`). To avoid two competing reservation
+sources and merge collisions, **this PR does not add its own source or edit the Storefront Inbox
+surface.** It delivers the complementary WORKSPACE-side reconciliation that #3387 does not:
+demoting the generic-decision noise, fixing the repeated decision labels, fixing the twin
+"RESERVATIONS 0" counter, and the cross-surface smoke test. Together the two PRs land the
+BI-348766E5 acceptance.
+
+## Design
+
+### 1. Row-specific decision labels (fix 5) — constrained by the plain-language contract
+
+Investigated and **deliberately not changed via card copy.** The owner-facing copy has an
+intentional, tested contract (`owner-decision.test.ts`): headlines and choice labels must be plain
+language and must never leak the raw technical title (banned `\b(AI|API|DB|GPU|CI|CD)\b`, raw title
+hidden behind progressive disclosure — `AttentionInbox.test`). The only per-row datum on an
+`ai-decision` item is that raw technical question, so a genuinely per-row *label* cannot be produced
+without violating the contract. Instead:
+
+- The **demotion in §2** is the real fix for the "28 identical cards" flood — the generic residue
+  leaves `needs-you-now` entirely, so the primary surface no longer repeats.
+- The remaining cards are already distinguished by their **per-row `situation`/context body**, and
+  the fallback action already carries an exact `?attentionId=` deep link (pre-existing) — the
+  BI-8EA88797 exact-target requirement is met without changing the label.
+
+### 2. Demote generic corpus-fallback decisions behind concrete operations
+
+`classifyOwnerAttentionLane` routes an `ai-decision` item that is **unlinked corpus residue**
+(`residueReason = coverage-gap` and no `blastRadius`) to `weekly-digest` (grouped advanced
+review) instead of `needs-you-now`. Genuine escalations (principle-conflict, high-risk-gate, or
+build/task-linked) stay in `needs-you-now`. Result: the primary count reflects concrete,
+customer-facing work (reservations lead), and the generic backlog is grouped behind it rather
+than flooding "things need you today."
+
+### 3. Twin Reservations queue reconciliation (fix the hardcoded-empty counter)
+
+`living-business-snapshot.ts` distributes booking-derived items across queues by meaning, but
+only when a reservations queue exists at index > 0 (so `YARD`/`BAYS`/`TERRITORY`, whose first
+queue is the general one, are unchanged):
+
+- A reservations-keyed queue is filled with **upcoming reservations** (`scheduledAt > now`, not
+  cancelled/completed), ordered soonest-first.
+- The general queue (index 0) excludes those upcoming reservations to avoid double-counting.
+- Honest empty label: `No upcoming reservations` (explains a genuine `0` despite past booking
+  history — the BI's "explain why" branch), instead of a bare `Clear`.
+
+### Storefront Inbox actions (delivered by BI-3DA1DFDC / #3387)
+
+Row-specific, consequence-framed Storefront Inbox Confirm/Cancel labels are delivered by #3387
+(`reservationActionLabel` + aria-labels). This PR does not edit that surface.
+
+## Non-goals
+
+- No reservation attention source, `covers`/dietary schema, or Storefront Inbox edits — those are
+  owned by the sibling BI-3DA1DFDC PR (#3387); this PR is the complementary workspace-side half.
+- No new Prisma model or enum; no change to the booking write path, availability engine, or the
+  paused-work risk model.
+- No POS/KDS behavior; no change to the `YARD`/`BAYS`/`TERRITORY` twin queue semantics.
+
+## Test strategy
+
+- Vitest units: routing demotion (corpus fallback → weekly-digest; a coverage-gap decision that
+  blocks a concrete outcome stays in needs-you-now), and twin queue distribution (reservations
+  queue populated soonest-first, general queue de-duplicated, `isUpcomingReservation` /
+  `isReservationQueueKey` edge cases, non-restaurant profiles unchanged).
+- Playwright e2e smoke (`e2e/restaurant-vertical-signal-consistency.spec.ts`): asserts the same
+  reservation signal is coherent across the public booking context, `/storefront/inbox`,
+  `/workspace`, and `/workspace/inbox` (fails if the inbox has actionable bookings while Workspace
+  shows only generic corpus decisions). The reservation-signal half depends on #3387's source; the
+  action-label contract and the negative-space checks stand alone.

--- a/e2e/restaurant-vertical-signal-consistency.spec.ts
+++ b/e2e/restaurant-vertical-signal-consistency.spec.ts
@@ -1,0 +1,88 @@
+// Vertical signal consistency across the four Restaurant owner surfaces
+// (BI-348766E5, BI-36807E68). The reconciliation invariant: if `/storefront/inbox`
+// has actionable (pending) bookings, the SAME reservation signal must be visible on
+// `/workspace` and `/workspace/inbox` — it must fail when Workspace surfaces only
+// generic corpus decisions while real bookings need the owner.
+//
+// Precondition: the Restaurant demo business must be loaded (loadDemoBusiness
+// "restaurant") so there are pending StorefrontBooking rows to reconcile. When no
+// pending bookings exist the reconciliation assertions skip (nothing to reconcile),
+// but the row-specific action-label contract is always checked.
+import { test, expect, type Page } from "@playwright/test";
+import { ensureLoggedIn } from "./helpers/auth";
+
+/** Accessible names of every booking Confirm/Cancel control on /storefront/inbox. */
+async function bookingActionLabels(page: Page): Promise<string[]> {
+  await page.goto("/storefront/inbox");
+  await page.waitForLoadState("networkidle", { timeout: 12_000 }).catch(() => {});
+  const bookingFilter = page.getByRole("button", { name: "Booking", exact: true });
+  if (await bookingFilter.count()) {
+    await bookingFilter.first().click();
+    await page.waitForTimeout(200);
+  }
+  const buttons = page.getByRole("button", { name: /^(Confirm|Cancel)\b/ });
+  const labels: string[] = [];
+  const n = await buttons.count();
+  for (let i = 0; i < n; i++) {
+    labels.push((await buttons.nth(i).getAttribute("aria-label")) ?? (await buttons.nth(i).innerText()));
+  }
+  return labels;
+}
+
+function guestsFromLabels(labels: string[]): string[] {
+  return labels
+    .map((l) => l.match(/for (.+?) on /)?.[1] ?? l.match(/^Confirm (.+)$/)?.[1] ?? null)
+    .filter((g): g is string => Boolean(g) && g !== "booking" && g !== "guest");
+}
+
+test.describe("Restaurant vertical signal consistency", () => {
+  test("storefront inbox Confirm/Cancel actions are row-specific, never bare", async ({ page }) => {
+    await ensureLoggedIn(page);
+    const labels = await bookingActionLabels(page);
+    for (const label of labels) {
+      // The exact terse labels the audit flagged (BI-7D7EE150) must not survive.
+      expect(label.trim()).not.toBe("Confirm");
+      expect(label.trim()).not.toBe("Cancel");
+    }
+  });
+
+  test("pending reservations reconcile into Workspace and Workspace Inbox", async ({ page }) => {
+    await ensureLoggedIn(page);
+    const labels = await bookingActionLabels(page);
+    const guests = guestsFromLabels(labels);
+
+    test.skip(guests.length === 0, "No pending bookings loaded — nothing to reconcile.");
+
+    // The Workspace Inbox must reflect the reservation work, not only generic
+    // enterprise-architecture decisions. Accept either the guest by name or clear
+    // reservation vocabulary.
+    await page.goto("/workspace/inbox");
+    await page.waitForLoadState("networkidle", { timeout: 12_000 }).catch(() => {});
+    const inboxText = (await page.locator("main").innerText()).toLowerCase();
+    const reservationSignal =
+      guests.some((g) => inboxText.includes(g.toLowerCase())) ||
+      /reservation|table for|confirm .*(?:at|booking)/i.test(inboxText);
+    expect(
+      reservationSignal,
+      "Workspace Inbox shows only generic decisions while pending reservations need the owner",
+    ).toBe(true);
+
+    // The pathological state: every action reads the identical generic label.
+    const reviewButtons = page.getByRole("link", { name: /^Review this decision$/ });
+    const genericCount = await reviewButtons.count();
+    const anyActionable = await page.getByRole("link", { name: /Confirm|Reschedule|Review:/ }).count();
+    expect(
+      genericCount === 0 || anyActionable > 0,
+      "Every Workspace Inbox action is the identical 'Review this decision' label",
+    ).toBe(true);
+
+    // The Workspace home must not present a reservation signal that contradicts the
+    // Storefront booking history (the "RESERVATIONS 0 Clear" mismatch).
+    await page.goto("/workspace");
+    await page.waitForLoadState("networkidle", { timeout: 12_000 }).catch(() => {});
+    const homeText = (await page.locator("body").innerText()).toLowerCase();
+    const homeSignal =
+      guests.some((g) => homeText.includes(g.toLowerCase())) || /reservation/i.test(homeText);
+    expect(homeSignal, "Workspace home does not surface any reservation signal").toBe(true);
+  });
+});


### PR DESCRIPTION
## What

The workspace-side half of making **Restaurant owner attention consistent** across public booking, Storefront Inbox, Workspace, and Workspace Inbox (BI-348766E5). Live audit found `/storefront/inbox` full of actionable bookings while `/workspace` said `RESERVATIONS 0 Clear` / `Nothing needs you right now` **and** `30 things need you today`, and `/workspace/inbox` was ~28 near-identical generic decision cards.

## Coordination

- **#3387 (BI-3DA1DFDC, open)** owns the reservation attention source, `covers`/dietary schema, and row-specific Storefront Inbox Confirm/Cancel labels. This PR does not duplicate them.
- **#3402 (BI-7C95A586, merged)** added the restaurant capacity chips + readiness and explicitly **left the twin queue construction to this PR**. Rebased on top; the twin merge keeps its `floorSnapshot`/chips and adds the reservations-queue fix.

## Changes (7 files)

- **Demote the generic-decision flood** (`apps/web/lib/attention/owner-routing.ts`): an unlinked corpus `ai-decision` (`coverage-gap`, nothing blocked) now routes to the grouped weekly digest instead of `needs-you-now`; genuine/blocking decisions stay. Generic enterprise-architecture residue sits behind concrete operational work. *(fix 4)*
- **Fix the twin `RESERVATIONS 0` counter** (`apps/web/lib/twin/living-business-snapshot.ts`): the reservations-keyed queue is populated with upcoming reservations (archetype-safe — `YARD`/`BAYS`/`TERRITORY` unchanged) instead of a hardcoded-empty `Clear`; honest `No upcoming reservations` empty label. *(fixes 1 & 3)*
- **Smoke test** (`e2e/restaurant-vertical-signal-consistency.spec.ts`) comparing the public booking context, `/storefront/inbox`, `/workspace`, and `/workspace/inbox`. *(fix 7)*

## Fix 5 (row-specific decision labels) — deliberately not via card copy

Investigated and **not** changed. The owner-copy layer has an intentional, tested contract (`owner-decision.test.ts` bans raw-title / technical-acronym leakage; `AttentionInbox.test` hides the raw title behind progressive disclosure). The only per-row datum on an `ai-decision` item is that raw technical question, so a genuinely per-row *label* can't be produced without breaking the contract. The demotion above is the real fix for the "28 identical cards" flood; remaining cards are distinguished by their per-row `situation` body, and the fallback action already carries an exact `?attentionId=` deep link. Fixes 2 & 6 are delivered by #3387.

## Design grounding

Spec: `docs/superpowers/specs/2026-07-22-restaurant-owner-attention-reconciliation-design.md`; plan: `docs/superpowers/plans/2026-07-22-restaurant-owner-attention-reconciliation.md`. Substrate: `apps/web/lib/attention/*` + the twin snapshot.

## Verification

Typecheck green on the merged code earlier this session; unit fixes here directly target the previously-red suites (reverted the contract-violating fix-5 copy + `useSearchParams`; updated the twin loader test to assert the reservation lands in the reservations queue). CI is authoritative.

Coordinates BI-3DA1DFDC (#3387), BI-075F731F, BI-36807E68, BI-7D7EE150, BI-8EA88797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)