### PR TITLE
feat(marketing): scope restaurant/food-hospitality marketing to org archetype (BI-CC580161)

### DIFF
--- a/apps/web/app/(shell)/customer/marketing/actions.ts
+++ b/apps/web/app/(shell)/customer/marketing/actions.ts
@@ -14,6 +14,7 @@ import {
   type OutboundDraftStatus,
 } from "@/lib/marketing/execution";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { guardDraftArchetypeFit } from "@/lib/marketing/fit-guard";
 
 type ActionResult =
   | { ok: true; draftId: string; status: OutboundDraftStatus }
@@ -76,6 +77,13 @@ export async function approveOutboundDraftAction(
 ): Promise<ActionResult> {
   const auth = await requireOperator();
   if ("error" in auth) return { ok: false, error: auth.error };
+
+  // Archetype-fit guard: never approve software-platform / off-archetype-block
+  // copy for a real audience. Checks the operator's edited body when provided,
+  // since they may have fixed the leak before approving.
+  const fit = await guardDraftArchetypeFit({ draftId, contentOverride: editedBody ?? null });
+  if (fit && !fit.ok) return { ok: false, error: fit.error };
+
   return decideOnDraft(draftId, "approved", editedBody ?? null, notes ?? null, auth.userId);
 }
 

--- a/apps/web/app/(shell)/customer/marketing/campaigns/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/campaigns/page.tsx
@@ -9,6 +9,10 @@ import {
 } from "@/components/customer-marketing/MarketingRoutePrimitives";
 import { formatMarketingLabel, getMarketingWorkspaceSnapshot } from "@/lib/marketing";
 import { buildMarketingCampaignsView } from "@/lib/marketing/subroutes";
+import {
+  ArchetypeFitBadge,
+  ArchetypeFitNotice,
+} from "@/components/customer-marketing/ArchetypeFitNotice";
 
 export default async function CustomerMarketingCampaignsPage() {
   const snapshot = await getMarketingWorkspaceSnapshot();
@@ -36,6 +40,23 @@ export default async function CustomerMarketingCampaignsPage() {
 
       <MarketingMetricGrid metrics={view.metrics} />
 
+      {view.importedTestCount > 0 ? (
+        <div
+          data-testid="imported-test-banner"
+          className="rounded-lg border border-red-500/50 bg-red-500/10 px-4 py-3 text-sm text-red-500"
+        >
+          <p className="font-semibold">
+            {view.importedTestCount} saved artifact
+            {view.importedTestCount === 1 ? "" : "s"} flagged as imported / test data — blocked
+            from publish
+          </p>
+          <p className="mt-1 text-xs text-red-500/90">
+            These carry software-platform language that does not belong in this business's
+            marketing. They stay visible for cleanup but can never be approved or published.
+          </p>
+        </div>
+      ) : null}
+
       <MarketingSection
         title="Campaign briefs"
         description="Briefs define the audience, channel mix, proof, and measurable outcome before individual assets are drafted."
@@ -53,15 +74,22 @@ export default async function CustomerMarketingCampaignsPage() {
               <MarketingRecordCard key={campaign.id}>
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <h2 className="text-base font-semibold text-[var(--dpf-text)]">
-                      {campaign.title}
-                    </h2>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+                        {campaign.title}
+                      </h2>
+                      <ArchetypeFitBadge assessment={campaign.archetypeFit} />
+                    </div>
                     <p className="mt-1 text-sm text-[var(--dpf-muted)]">
                       {campaign.objective}
                     </p>
                   </div>
                   <MarketingLifecycleBadge status={campaign.status} />
                 </div>
+
+                {campaign.archetypeFit.severity !== "ok" ? (
+                  <ArchetypeFitNotice assessment={campaign.archetypeFit} className="mt-3" />
+                ) : null}
 
                 <dl className="mt-4 grid gap-3 text-sm md:grid-cols-2">
                   <div>
@@ -129,15 +157,21 @@ export default async function CustomerMarketingCampaignsPage() {
               <MarketingRecordCard key={task.id}>
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
-                    <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
-                      {task.title}
-                    </h2>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="text-sm font-semibold text-[var(--dpf-text)]">
+                        {task.title}
+                      </h2>
+                      <ArchetypeFitBadge assessment={task.archetypeFit} />
+                    </div>
                     <p className="mt-1 text-xs text-[var(--dpf-muted)]">
                       {formatMarketingLabel(task.assetType)} on {task.channelLabel}
                     </p>
                   </div>
                   <MarketingLifecycleBadge status={task.status} />
                 </div>
+                {task.archetypeFit.severity !== "ok" ? (
+                  <ArchetypeFitNotice assessment={task.archetypeFit} className="mt-3" />
+                ) : null}
                 <p className="mt-3 text-sm text-[var(--dpf-text)]">{task.brief}</p>
                 <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
                   <span className="text-[var(--dpf-muted)]">{task.dueWindow}</span>

--- a/apps/web/app/(shell)/customer/marketing/page.test.tsx
+++ b/apps/web/app/(shell)/customer/marketing/page.test.tsx
@@ -63,6 +63,7 @@ function snapshot() {
       id: "storefront-1",
       archetypeId: "expert-services",
       archetypeName: "Expert Services",
+      category: "professional-services",
       tagline: "Proof-led growth",
       description: "Operational advice",
       ctaType: "inquiry",
@@ -136,5 +137,17 @@ describe("CustomerMarketingPage", () => {
     expect(html).not.toContain('data-topic-id="strategy-review"');
     expect(html).not.toContain('data-topic-id="campaign-directions"');
     expect(html).not.toContain('data-topic-id="proof-plan"');
+  });
+
+  it("opens with a single archetype-scoped next decision in the first viewport", async () => {
+    const html = renderToStaticMarkup(await CustomerMarketingPage());
+
+    expect(html).toContain('data-testid="marketing-next-decision"');
+    // Snapshot has a review + proof but no campaign brief → create the first campaign.
+    expect(html).toContain('data-decision-id="create-first-campaign"');
+    expect(html).toContain("Your next decision");
+    // Must not leak software-platform vocabulary onto a customer marketing surface.
+    expect(html).not.toContain("Build Studio");
+    expect(html).not.toContain("backlog item");
   });
 });

--- a/apps/web/app/(shell)/customer/marketing/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/page.tsx
@@ -11,6 +11,8 @@ import {
   MARKETING_AGENTIC_OPERATIONS_ROUTE,
   buildMarketingAgenticOperationTopics,
 } from "@/lib/marketing/agentic-operations";
+import { buildMarketingOwnerDecision } from "@/lib/marketing/next-decision";
+import { getPlaybook } from "@/lib/tak/marketing-playbooks";
 
 export default async function CustomerMarketingPage() {
   const snapshot = await getMarketingWorkspaceSnapshot();
@@ -72,8 +74,38 @@ export default async function CustomerMarketingPage() {
     suggestions,
   });
 
+  // Single archetype-scoped next decision for the first viewport — phrased in the
+  // owner's own vocabulary (a restaurant owner sees covers/bookings, not "brief #2").
+  const playbook = getPlaybook(snapshot.storefront.category, snapshot.storefront.ctaType);
+  const nextDecision = buildMarketingOwnerDecision(snapshot, playbook);
+
   return (
     <div className="space-y-6">
+      <section
+        data-testid="marketing-next-decision"
+        data-decision-id={nextDecision.id}
+        className="rounded-lg border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-6"
+      >
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--dpf-accent)]">
+          Your next decision
+        </p>
+        <h2 className="mt-2 text-xl font-bold text-[var(--dpf-text)]">
+          {nextDecision.headline}
+        </h2>
+        <p className="mt-2 max-w-2xl text-sm text-[var(--dpf-muted)]">{nextDecision.detail}</p>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <Link
+            href={nextDecision.ctaHref}
+            className="rounded-full bg-[var(--dpf-accent)] px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+          >
+            {nextDecision.ctaLabel}
+          </Link>
+          <span className="text-xs text-[var(--dpf-muted)]">
+            Moves: {nextDecision.metricFocus}
+          </span>
+        </div>
+      </section>
+
       <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
@@ -234,6 +266,7 @@ export default async function CustomerMarketingPage() {
         approvedDrafts={snapshot.approvedDrafts}
         connectedChannels={snapshot.connectedChannels}
         inboundMessages={snapshot.inboundMessages}
+        category={snapshot.storefront.category}
       />
     </div>
   );

--- a/apps/web/components/customer-marketing/ApprovalQueuePanel.tsx
+++ b/apps/web/components/customer-marketing/ApprovalQueuePanel.tsx
@@ -1,6 +1,8 @@
 import type { InboundMessageRow, OutboundDraftRow } from "@/lib/marketing";
 import { formatMarketingLabel } from "@/lib/marketing";
+import { assessArchetypeFit } from "@/lib/marketing/archetype-fit";
 import { ApprovalQueueReview } from "./ApprovalQueueReview";
+import { ArchetypeFitNotice } from "./ArchetypeFitNotice";
 import { PublishLinkedInButton } from "./PublishLinkedInButton";
 import { PublishEmailButton } from "./PublishEmailButton";
 
@@ -9,6 +11,8 @@ type Props = {
   approvedDrafts: OutboundDraftRow[];
   connectedChannels: string[];
   inboundMessages: InboundMessageRow[];
+  /** Active storefront archetype category, scopes fit checks to this business. */
+  category: string | null;
 };
 
 function timeAgo(date: Date | string): string {
@@ -99,6 +103,7 @@ export function ApprovalQueuePanel({
   approvedDrafts,
   connectedChannels,
   inboundMessages,
+  category,
 }: Props) {
   const linkedInConnected =
     connectedChannels.includes("linkedin-personal-social") ||
@@ -145,6 +150,7 @@ export function ApprovalQueuePanel({
                     assetTaskTitle={draft.assetTaskTitle}
                     channelId={draft.channelId}
                     assetType={draft.assetType}
+                    category={category}
                   />
                 }
               />
@@ -177,33 +183,43 @@ export function ApprovalQueuePanel({
           </p>
         ) : (
           <ul className="mt-4 space-y-3">
-            {approvedDrafts.map((draft) => (
-              <DraftRow
-                key={draft.draftId}
-                draft={draft}
-                trailing={
-                  isLinkedInChannel(draft.channelId) ? (
-                    <PublishLinkedInButton
-                      draftId={draft.draftId}
-                      channelConnected={linkedInConnected}
-                      channelId="linkedin-personal-social"
-                    />
-                  ) : isEmailChannel(draft.channelId) ? (
-                    <PublishEmailButton
-                      draftId={draft.draftId}
-                      channelConnected={emailConnected}
-                      channelId="email-postmark"
-                    />
-                  ) : (
-                    <p className="text-xs text-[var(--dpf-muted)]">
-                      Publishing for{" "}
-                      <span className="text-[var(--dpf-text)]">{draft.channelId}</span> lands in
-                      a later phase.
-                    </p>
-                  )
-                }
-              />
-            ))}
+            {approvedDrafts.map((draft) => {
+              const fit = assessArchetypeFit({ text: draft.body, category });
+              return (
+                <DraftRow
+                  key={draft.draftId}
+                  draft={draft}
+                  trailing={
+                    <div className="space-y-2">
+                      <ArchetypeFitNotice assessment={fit} />
+                      {isLinkedInChannel(draft.channelId) ? (
+                        <PublishLinkedInButton
+                          draftId={draft.draftId}
+                          channelConnected={linkedInConnected}
+                          channelId="linkedin-personal-social"
+                          fitBlocked={fit.blocked}
+                          fitReason={fit.summary}
+                        />
+                      ) : isEmailChannel(draft.channelId) ? (
+                        <PublishEmailButton
+                          draftId={draft.draftId}
+                          channelConnected={emailConnected}
+                          channelId="email-postmark"
+                          fitBlocked={fit.blocked}
+                          fitReason={fit.summary}
+                        />
+                      ) : (
+                        <p className="text-xs text-[var(--dpf-muted)]">
+                          Publishing for{" "}
+                          <span className="text-[var(--dpf-text)]">{draft.channelId}</span> lands in
+                          a later phase.
+                        </p>
+                      )}
+                    </div>
+                  }
+                />
+              );
+            })}
           </ul>
         )}
       </section>

--- a/apps/web/components/customer-marketing/ApprovalQueueReview.tsx
+++ b/apps/web/components/customer-marketing/ApprovalQueueReview.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import {
   approveOutboundDraftAction,
   requestChangesOnDraftAction,
   rejectOutboundDraftAction,
 } from "@/app/(shell)/customer/marketing/actions";
+import { assessArchetypeFit } from "@/lib/marketing/archetype-fit";
+import { ArchetypeFitNotice } from "./ArchetypeFitNotice";
 
 type Props = {
   draftId: string;
@@ -13,22 +15,38 @@ type Props = {
   assetTaskTitle: string | null;
   channelId: string;
   assetType: string;
+  category: string | null;
 };
 
 type FlashState = { kind: "ok" | "err"; message: string } | null;
 
-export function ApprovalQueueReview({ draftId, initialBody, assetTaskTitle, channelId, assetType }: Props) {
+export function ApprovalQueueReview({ draftId, initialBody, assetTaskTitle, channelId, assetType, category }: Props) {
   const [open, setOpen] = useState(false);
   const [body, setBody] = useState(initialBody);
   const [notes, setNotes] = useState("");
   const [flash, setFlash] = useState<FlashState>(null);
   const [pending, startTransition] = useTransition();
 
+  // Live archetype-fit check on the body the operator is about to approve.
+  // Recomputes as they edit, so removing a platform-leak term re-enables Approve.
+  const fit = useMemo(
+    () =>
+      assessArchetypeFit({
+        text: [assetTaskTitle, body].filter(Boolean).join("\n"),
+        category,
+      }),
+    [assetTaskTitle, body, category],
+  );
+
   function showError(err: string) {
     setFlash({ kind: "err", message: err });
   }
 
   function approve(withEdits: boolean) {
+    if (fit.blocked) {
+      showError(fit.summary);
+      return;
+    }
     startTransition(async () => {
       const editedBody = withEdits && body !== initialBody ? body : undefined;
       const result = await approveOutboundDraftAction(draftId, editedBody, notes || undefined);
@@ -134,10 +152,12 @@ export function ApprovalQueueReview({ draftId, initialBody, assetTaskTitle, chan
                 className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)] focus:border-[var(--dpf-accent)] focus:outline-none"
               />
 
+              <ArchetypeFitNotice assessment={fit} className="mt-3" />
+
               <div className="mt-3 flex flex-wrap gap-2">
                 <button
                   type="button"
-                  disabled={pending}
+                  disabled={pending || fit.blocked}
                   onClick={() => approve(false)}
                   className="rounded-full bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50"
                 >
@@ -145,7 +165,7 @@ export function ApprovalQueueReview({ draftId, initialBody, assetTaskTitle, chan
                 </button>
                 <button
                   type="button"
-                  disabled={pending || body === initialBody}
+                  disabled={pending || fit.blocked || body === initialBody}
                   onClick={() => approve(true)}
                   className="rounded-full border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] px-4 py-1.5 text-sm font-medium text-[var(--dpf-accent)] disabled:opacity-50"
                 >

--- a/apps/web/components/customer-marketing/ArchetypeFitNotice.tsx
+++ b/apps/web/components/customer-marketing/ArchetypeFitNotice.tsx
@@ -1,0 +1,55 @@
+import type { ArchetypeFitAssessment } from "@/lib/marketing/archetype-fit";
+import { IMPORTED_TEST_BADGE_LABEL } from "@/lib/marketing/archetype-fit";
+
+/**
+ * Small, theme-aware badge + note for an archetype-fit assessment.
+ * - block → red "Imported / test data — blocked from publish" badge + reason.
+ * - warn  → amber "Check archetype fit" badge + reason.
+ * - ok    → renders nothing.
+ */
+export function ArchetypeFitNotice({
+  assessment,
+  className = "",
+}: {
+  assessment: ArchetypeFitAssessment;
+  className?: string;
+}) {
+  if (assessment.severity === "ok") return null;
+
+  const blocked = assessment.blocked;
+  const tone = blocked
+    ? "border-red-500/50 bg-red-500/10 text-red-500"
+    : "border-amber-500/50 bg-amber-500/10 text-amber-600";
+
+  return (
+    <div
+      data-testid="archetype-fit-notice"
+      data-fit-severity={assessment.severity}
+      className={`rounded-lg border px-3 py-2 text-xs ${tone} ${className}`.trim()}
+    >
+      <p className="font-semibold">
+        {blocked ? IMPORTED_TEST_BADGE_LABEL : "Check archetype fit before sending"}
+      </p>
+      <p className="mt-1 leading-snug">{assessment.summary}</p>
+    </div>
+  );
+}
+
+/** Inline pill variant for compact placements (e.g. artifact card headers). */
+export function ArchetypeFitBadge({ assessment }: { assessment: ArchetypeFitAssessment }) {
+  if (assessment.severity === "ok") return null;
+  const blocked = assessment.blocked;
+  return (
+    <span
+      data-testid="archetype-fit-badge"
+      data-fit-severity={assessment.severity}
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${
+        blocked
+          ? "border-red-500/50 bg-red-500/10 text-red-500"
+          : "border-amber-500/50 bg-amber-500/10 text-amber-600"
+      }`}
+    >
+      {blocked ? IMPORTED_TEST_BADGE_LABEL : "Check archetype fit"}
+    </span>
+  );
+}

--- a/apps/web/components/customer-marketing/MarketingStrategyOverview.tsx
+++ b/apps/web/components/customer-marketing/MarketingStrategyOverview.tsx
@@ -3,7 +3,9 @@ import {
   formatMarketingLabel,
   type MarketingWorkspaceSnapshot,
 } from "@/lib/marketing";
+import { assessArchetypeFit } from "@/lib/marketing/archetype-fit";
 import { DraftAssetButton } from "./DraftAssetButton";
+import { ArchetypeFitBadge } from "./ArchetypeFitNotice";
 
 type Props = {
   snapshot: MarketingWorkspaceSnapshot;
@@ -43,6 +45,7 @@ export function MarketingStrategyOverview({
 }: Props) {
   const isDetail = mode === "detail";
   const strategy = snapshot.strategy;
+  const category = snapshot.storefront.category;
   const territory =
     strategy.geographicScope ?? snapshot.organization.addressSummary ?? "Market territory still needs a decision";
   const constraintNotes = strategy.constraints
@@ -119,11 +122,14 @@ export function MarketingStrategyOverview({
           {strategy.proofAssets.length > 0 ? (
             <ul className="space-y-2 text-sm text-[var(--dpf-text)]">
               {strategy.proofAssets.map((asset) => (
-                <li key={`${asset.type}-${asset.label}`}>
-                  {asset.label}
-                  <span className="ml-2 text-[var(--dpf-muted)]">
+                <li key={`${asset.type}-${asset.label}`} className="flex flex-wrap items-center gap-2">
+                  <span>{asset.label}</span>
+                  <span className="text-[var(--dpf-muted)]">
                     {formatMarketingLabel(asset.type)}
                   </span>
+                  <ArchetypeFitBadge
+                    assessment={assessArchetypeFit({ text: asset.label, category })}
+                  />
                 </li>
               ))}
             </ul>
@@ -249,7 +255,17 @@ export function MarketingStrategyOverview({
               <ul className="space-y-3 text-sm">
                 {snapshot.workProducts.campaignBriefs.map((brief) => (
                   <li key={brief.briefId} className="border-l border-[var(--dpf-border)] pl-3">
-                    <p className="font-medium text-[var(--dpf-text)]">{brief.title}</p>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium text-[var(--dpf-text)]">{brief.title}</p>
+                      <ArchetypeFitBadge
+                        assessment={assessArchetypeFit({
+                          text: [brief.title, brief.objective, brief.audience, brief.notes]
+                            .filter(Boolean)
+                            .join("\n"),
+                          category,
+                        })}
+                      />
+                    </div>
                     <p className="text-[var(--dpf-muted)]">{brief.objective}</p>
                     <div className="mt-2 flex flex-wrap gap-2">
                       {brief.channels.map((channel) => (
@@ -273,7 +289,15 @@ export function MarketingStrategyOverview({
               <ul className="space-y-3 text-sm">
                 {snapshot.workProducts.assetTasks.map((task) => (
                   <li key={task.taskId} className="border-l border-[var(--dpf-border)] pl-3">
-                    <p className="font-medium text-[var(--dpf-text)]">{task.title}</p>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium text-[var(--dpf-text)]">{task.title}</p>
+                      <ArchetypeFitBadge
+                        assessment={assessArchetypeFit({
+                          text: [task.title, task.brief].filter(Boolean).join("\n"),
+                          category,
+                        })}
+                      />
+                    </div>
                     <p className="text-[var(--dpf-muted)]">
                       {formatMarketingLabel(task.assetType)}
                       {task.dueWindow ? ` - ${task.dueWindow}` : ""}

--- a/apps/web/components/customer-marketing/PublishEmailButton.tsx
+++ b/apps/web/components/customer-marketing/PublishEmailButton.tsx
@@ -7,14 +7,28 @@ type Props = {
   draftId: string;
   channelConnected: boolean;
   channelId: string;
+  /** When true, content conflicts with the active archetype and must not send. */
+  fitBlocked?: boolean;
+  fitReason?: string;
 };
 
-export function PublishEmailButton({ draftId, channelConnected, channelId }: Props) {
+export function PublishEmailButton({
+  draftId,
+  channelConnected,
+  channelId,
+  fitBlocked = false,
+  fitReason,
+}: Props) {
   const [status, setStatus] = useState<"idle" | "sending" | "done" | "error">("idle");
   const [message, setMessage] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
   function onSend() {
+    if (fitBlocked) {
+      setStatus("error");
+      setMessage(fitReason ?? "Blocked: content does not fit this business's archetype.");
+      return;
+    }
     setStatus("sending");
     setMessage(null);
     startTransition(async () => {
@@ -50,7 +64,8 @@ export function PublishEmailButton({ draftId, channelConnected, channelId }: Pro
       <button
         type="button"
         onClick={onSend}
-        disabled={pending || status === "done"}
+        disabled={pending || status === "done" || fitBlocked}
+        title={fitBlocked ? fitReason : undefined}
         className="rounded-full bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50"
       >
         {status === "done" ? "Sent" : pending || status === "sending" ? "Sending…" : "Send email"}

--- a/apps/web/components/customer-marketing/PublishLinkedInButton.tsx
+++ b/apps/web/components/customer-marketing/PublishLinkedInButton.tsx
@@ -7,15 +7,29 @@ type Props = {
   draftId: string;
   channelConnected: boolean;
   channelId: string;
+  /** When true, content conflicts with the active archetype and must not publish. */
+  fitBlocked?: boolean;
+  fitReason?: string;
 };
 
-export function PublishLinkedInButton({ draftId, channelConnected, channelId }: Props) {
+export function PublishLinkedInButton({
+  draftId,
+  channelConnected,
+  channelId,
+  fitBlocked = false,
+  fitReason,
+}: Props) {
   const [status, setStatus] = useState<"idle" | "publishing" | "done" | "error">("idle");
   const [message, setMessage] = useState<string | null>(null);
   const [externalUrl, setExternalUrl] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
   function onPublish() {
+    if (fitBlocked) {
+      setStatus("error");
+      setMessage(fitReason ?? "Blocked: content does not fit this business's archetype.");
+      return;
+    }
     setStatus("publishing");
     setMessage(null);
     setExternalUrl(null);
@@ -67,7 +81,8 @@ export function PublishLinkedInButton({ draftId, channelConnected, channelId }: 
       <button
         type="button"
         onClick={onPublish}
-        disabled={pending}
+        disabled={pending || fitBlocked}
+        title={fitBlocked ? fitReason : undefined}
         className="rounded-full bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50"
       >
         {pending ? "Publishing…" : "Publish to LinkedIn"}

--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -212,6 +212,7 @@ export type MarketingWorkspaceSnapshot = {
     id: string | null;
     archetypeId: string | null;
     archetypeName: string | null;
+    category: string | null;
     tagline: string | null;
     description: string | null;
     ctaType: string | null;
@@ -1259,6 +1260,7 @@ export async function getMarketingWorkspaceSnapshot(): Promise<MarketingWorkspac
       id: organization.storefrontConfig?.id ?? null,
       archetypeId: organization.storefrontConfig?.archetypeId ?? null,
       archetypeName: cleanText(organization.storefrontConfig?.archetype?.name),
+      category: cleanText(organization.storefrontConfig?.archetype?.category),
       tagline: cleanText(organization.storefrontConfig?.tagline),
       description: cleanText(organization.storefrontConfig?.description),
       ctaType: cleanText(organization.storefrontConfig?.archetype?.ctaType),

--- a/apps/web/lib/marketing/archetype-fit.test.ts
+++ b/apps/web/lib/marketing/archetype-fit.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assessArchetypeFit,
+  isImportedTestArtifact,
+  isPublishBlockedByFit,
+  worstFitSeverity,
+} from "./archetype-fit";
+
+describe("assessArchetypeFit — platform leaks (universal hard block)", () => {
+  it.each([
+    "Build Studio",
+    "Digital Product Factory",
+    "technical founders",
+    "technical co-founder",
+    "AI workflow",
+    "agentic",
+    "AI coworker",
+    "SaaS",
+    "self-upgrade",
+    "MCP server",
+    "backlog item",
+    "Prisma",
+    "codebase",
+  ])("blocks software-platform term %s regardless of archetype", (term) => {
+    const result = assessArchetypeFit({
+      text: `Join our ${term} launch this weekend!`,
+      category: "food-hospitality",
+    });
+    expect(result.severity).toBe("block");
+    expect(result.blocked).toBe(true);
+    expect(isPublishBlockedByFit(result)).toBe(true);
+    expect(isImportedTestArtifact(result)).toBe(true);
+    expect(result.summary.toLowerCase()).toContain("imported/test data");
+  });
+
+  it("flags a restaurant campaign that leaked DPF founder/AI-workflow language", () => {
+    const result = assessArchetypeFit({
+      text: "Meet our technical founders and see the AI workflow behind Build Studio.",
+      category: "food-hospitality",
+    });
+    expect(result.blocked).toBe(true);
+    const terms = result.findings.map((f) => f.term);
+    expect(terms).toContain("technical founders");
+    expect(terms).toContain("AI workflow");
+    expect(terms).toContain("Build Studio");
+  });
+});
+
+describe("assessArchetypeFit — restaurant vocabulary is in-archetype", () => {
+  it("passes food-hospitality copy in its own vocabulary", () => {
+    const result = assessArchetypeFit({
+      text: "Reserve a table for our seasonal tasting menu — fill your quiet midweek covers.",
+      category: "food-hospitality",
+    });
+    expect(result.severity).toBe("ok");
+    expect(result.blocked).toBe(false);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("does not trip the active category's own signature terms", () => {
+    const result = assessArchetypeFit({
+      text: "New dinner menu, private dining, and no-show policy update.",
+      category: "food-hospitality",
+    });
+    expect(result.severity).toBe("ok");
+  });
+});
+
+describe("assessArchetypeFit — off-archetype (warn, not block)", () => {
+  it("warns when banking language appears on a restaurant surface", () => {
+    const result = assessArchetypeFit({
+      text: "Open an account today and lock in a 5% APY before rates change.",
+      category: "food-hospitality",
+    });
+    expect(result.severity).toBe("warn");
+    expect(result.blocked).toBe(false);
+    expect(result.findings.every((f) => f.kind === "off-archetype")).toBe(true);
+    expect(result.summary.toLowerCase()).toContain("confirm");
+  });
+
+  it("blocks (not just warns) when a platform leak co-occurs with off-archetype copy", () => {
+    const result = assessArchetypeFit({
+      text: "Open an account — powered by our SaaS platform.",
+      category: "food-hospitality",
+    });
+    expect(result.severity).toBe("block");
+  });
+});
+
+describe("assessArchetypeFit — edge cases and helpers", () => {
+  it("returns ok for empty content", () => {
+    expect(assessArchetypeFit({ text: "", category: "food-hospitality" }).severity).toBe("ok");
+    expect(assessArchetypeFit({ text: null, category: null }).severity).toBe("ok");
+  });
+
+  it("worstFitSeverity picks the most severe across assessments", () => {
+    const ok = assessArchetypeFit({ text: "Reserve a table.", category: "food-hospitality" });
+    const warn = assessArchetypeFit({ text: "Open an account.", category: "food-hospitality" });
+    const block = assessArchetypeFit({ text: "Build Studio launch.", category: "food-hospitality" });
+    expect(worstFitSeverity([ok, warn])).toBe("warn");
+    expect(worstFitSeverity([ok, warn, block])).toBe("block");
+    expect(worstFitSeverity([ok])).toBe("ok");
+  });
+});

--- a/apps/web/lib/marketing/archetype-fit.ts
+++ b/apps/web/lib/marketing/archetype-fit.ts
@@ -1,0 +1,235 @@
+// Marketing archetype-fit engine.
+//
+// Customer marketing artifacts (campaign briefs, proof prompts, drafts) must
+// speak in the language of the organization's OWN business archetype — a
+// restaurant markets covers, bookings, menus and seasonal offers, never
+// "Build Studio", "technical founders", or "AI workflow". Early bootstrap and
+// imported/test data can leak software-platform (DPF) vocabulary into a
+// customer's marketing surfaces; this module detects that leak deterministically
+// so the UI can warn, badge it as imported/test data, and the server can block
+// it from ever publishing to a real audience.
+//
+// Two finding kinds:
+//   - platform-leak  → software-platform / DPF-internal artifacts that are
+//                       foreign to EVERY customer archetype. Always a hard
+//                       BLOCK (must not publish, badge as imported/test data).
+//   - off-archetype  → vocabulary that clearly belongs to a DIFFERENT customer
+//                       archetype than the active one. A WARN — confirm before
+//                       sending — because cross-sell copy can be legitimate.
+//
+// Reference: docs/platform-usability-standards.md (archetype-scoped surfaces).
+
+export type ArchetypeFitSeverity = "ok" | "warn" | "block";
+
+export type ArchetypeFitFindingKind = "platform-leak" | "off-archetype";
+
+export type ArchetypeFitFinding = {
+  kind: ArchetypeFitFindingKind;
+  severity: "warn" | "block";
+  term: string;
+  message: string;
+  /** For off-archetype findings, the category the term looks like it belongs to. */
+  looksLikeCategory?: string | null;
+};
+
+export type ArchetypeFitAssessment = {
+  severity: ArchetypeFitSeverity;
+  /** True when severity === "block": content must not publish to a real audience. */
+  blocked: boolean;
+  findings: ArchetypeFitFinding[];
+  summary: string;
+};
+
+export const IMPORTED_TEST_BADGE_LABEL = "Imported / test data — blocked from publish";
+
+const MAX_FINDINGS = 6;
+
+type TermSpec = {
+  term: string;
+  pattern: RegExp;
+  message: string;
+};
+
+// Escape a literal and allow flexible internal whitespace, matched on word-ish
+// boundaries so "menus" does not trip a "menu" foreign match but "SaaS-first"
+// still trips "saas".
+function termPattern(literal: string): RegExp {
+  const escaped = literal
+    .trim()
+    .split(/\s+/)
+    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("\\s+");
+  return new RegExp(`(?<![\\w-])${escaped}(?![\\w-])`, "i");
+}
+
+function spec(term: string, message: string): TermSpec {
+  return { term, pattern: termPattern(term), message };
+}
+
+// ─── Platform-leak terms (universal hard block) ────────────────────────────
+// Software-platform / DPF-internal artifacts. These do not belong in ANY
+// customer's marketing, regardless of archetype, so they always block.
+const PLATFORM_LEAK_TERMS: TermSpec[] = [
+  spec("Build Studio", "“Build Studio” is a software-platform build tool, not a customer marketing concept."),
+  spec("Digital Product Factory", "“Digital Product Factory” is the internal platform name and must not reach a customer audience."),
+  spec("technical founder", "“technical founder” is software-startup language, foreign to this business's audience."),
+  spec("technical co-founder", "“technical co-founder” is software-startup language, foreign to this business's audience."),
+  spec("technical founders", "“technical founders” is software-startup language, foreign to this business's audience."),
+  spec("AI workflow", "“AI workflow” exposes internal platform mechanics rather than a customer benefit."),
+  spec("agentic", "“agentic” is internal platform jargon, not customer marketing language."),
+  spec("AI coworker", "“AI coworker” is internal platform tooling, not something to market to customers."),
+  spec("software platform", "“software platform” is not what this business sells to its customers."),
+  spec("SaaS", "“SaaS” is software-industry positioning, foreign to this business's audience."),
+  spec("self-upgrade", "“self-upgrade” is internal platform machinery, not a customer message."),
+  spec("MCP server", "“MCP server” is internal platform plumbing and must not appear in marketing."),
+  spec("MCP tool", "“MCP tool” is internal platform plumbing and must not appear in marketing."),
+  spec("backlog item", "“backlog item” is internal delivery jargon, not a customer marketing concept."),
+  spec("work capsule", "“work capsule” is internal platform jargon, not a customer marketing concept."),
+  spec("Prisma", "“Prisma” is an internal database detail that must never appear in marketing copy."),
+  spec("codebase", "“codebase” is software-engineering language, foreign to this business's marketing."),
+];
+
+// ─── Off-archetype signatures (warn) ────────────────────────────────────────
+// Distinctive vocabulary per customer archetype category. When content carries
+// signatures from a category OTHER than the active one, warn the operator to
+// confirm the copy fits before it is approved or sent. Kept deliberately
+// high-precision (domain-specific, multi-word where possible) to avoid noise.
+const CATEGORY_SIGNATURES: Record<string, string[]> = {
+  "food-hospitality": [
+    "covers", "reservation", "reserve a table", "dining", "menu", "tasting menu",
+    "prix fixe", "no-show", "private dining", "seating", "brunch", "diners",
+  ],
+  "banking-financial-services": ["apy", "apr", "fdic", "ncua", "open an account", "mortgage", "member fdic"],
+  "healthcare-wellness": ["recall reminder", "vaccination", "screening", "preventive care", "patient recall"],
+  "education-training": ["enrolment", "enrollment", "taster session", "term launch", "open day", "course completion"],
+  "real-estate-construction": ["display home", "floor plan", "handover", "purchase agreement", "stage release"],
+  "trades-maintenance": ["gas safety", "eicr", "boiler", "call-out", "pat testing"],
+  "pet-services": ["grooming", "boarding", "puppy programme", "kennel"],
+  "automotive-services": ["adas calibration", "windscreen", "windshield", "fleet account"],
+  "fitness-recreation": ["class schedule", "membership churn", "trial pass", "personal training"],
+  "nonprofit-community": ["donor", "fundraising", "recurring giving", "volunteer recruitment"],
+  "warehousing-fulfilment": ["pallet", "3pl", "despatch", "rate card", "committed capacity"],
+  "beauty-personal-care": ["rebooking", "stylist", "gift voucher", "colour service"],
+  "asset-rental": ["off-peak", "rentable pool", "return-due", "deposit policy"],
+  "live-events-venues": ["on-sale", "presale", "line-up reveal", "season-pass"],
+  "hoa-property-management": ["bylaw", "special assessment", "amenity reservation", "board meeting"],
+  "public-sector": ["public hearing", "council meeting", "permit deadline", "levy"],
+  "professional-services": ["retainer renewal", "thought leadership", "engagement value"],
+  "media-production": ["showreel", "reel", "commission", "behind-the-scenes"],
+  "security-services": ["monitoring plan", "rfp response", "response-time sla"],
+  "moving-and-logistics": ["packing service", "moving quote", "b2b route"],
+  "retail-goods": ["average order value", "flash sale", "pre-order", "gift guide"],
+};
+
+type CompiledSignature = { category: string; term: string; pattern: RegExp };
+
+const COMPILED_SIGNATURES: CompiledSignature[] = Object.entries(CATEGORY_SIGNATURES).flatMap(
+  ([category, terms]) => terms.map((term) => ({ category, term, pattern: termPattern(term) })),
+);
+
+function humanCategory(category: string): string {
+  return category
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function severityRank(severity: ArchetypeFitSeverity): number {
+  return severity === "block" ? 2 : severity === "warn" ? 1 : 0;
+}
+
+/**
+ * Assess whether marketing content fits the active archetype.
+ *
+ * @param text     the content to check (title + body + notes, joined)
+ * @param category the active storefront archetype category (e.g. "food-hospitality")
+ */
+export function assessArchetypeFit(input: {
+  text: string | null | undefined;
+  category: string | null | undefined;
+}): ArchetypeFitAssessment {
+  const text = (input.text ?? "").toString();
+  const category = (input.category ?? "").trim().toLowerCase();
+  const findings: ArchetypeFitFinding[] = [];
+
+  if (text.trim().length === 0) {
+    return { severity: "ok", blocked: false, findings: [], summary: "No content to check." };
+  }
+
+  const seen = new Set<string>();
+
+  // 1) Platform leaks — always block.
+  for (const leak of PLATFORM_LEAK_TERMS) {
+    if (leak.pattern.test(text)) {
+      const key = `leak:${leak.term.toLowerCase()}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      findings.push({ kind: "platform-leak", severity: "block", term: leak.term, message: leak.message });
+    }
+  }
+
+  // 2) Off-archetype signatures — warn. Skip the active category's own terms.
+  for (const sig of COMPILED_SIGNATURES) {
+    if (sig.category === category) continue;
+    if (!sig.pattern.test(text)) continue;
+    const key = `sig:${sig.term.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    findings.push({
+      kind: "off-archetype",
+      severity: "warn",
+      term: sig.term,
+      looksLikeCategory: sig.category,
+      message: `“${sig.term}” reads like ${humanCategory(sig.category)} marketing, not this business's.`,
+    });
+  }
+
+  const trimmed = findings.slice(0, MAX_FINDINGS);
+  const severity: ArchetypeFitSeverity = trimmed.some((f) => f.severity === "block")
+    ? "block"
+    : trimmed.some((f) => f.severity === "warn")
+      ? "warn"
+      : "ok";
+
+  return {
+    severity,
+    blocked: severity === "block",
+    findings: trimmed,
+    summary: summarize(severity, trimmed),
+  };
+}
+
+function summarize(severity: ArchetypeFitSeverity, findings: ArchetypeFitFinding[]): string {
+  if (severity === "block") {
+    const terms = findings.filter((f) => f.kind === "platform-leak").map((f) => `“${f.term}”`);
+    return `Blocked: software-platform content (${terms.join(", ")}) does not belong in this business's marketing. Treat as imported/test data — it cannot be published.`;
+  }
+  if (severity === "warn") {
+    const cats = [
+      ...new Set(
+        findings
+          .filter((f) => f.kind === "off-archetype" && f.looksLikeCategory)
+          .map((f) => humanCategory(f.looksLikeCategory as string)),
+      ),
+    ];
+    return `Heads up: this copy uses ${cats.join(" / ")} language. Confirm it fits this business before you approve or send it.`;
+  }
+  return "Content fits this business's archetype.";
+}
+
+/** True when a fit assessment should hard-block Approve / Send / Publish. */
+export function isPublishBlockedByFit(assessment: ArchetypeFitAssessment): boolean {
+  return assessment.blocked;
+}
+
+/** True when a saved artifact should be badged as imported/test data. */
+export function isImportedTestArtifact(assessment: ArchetypeFitAssessment): boolean {
+  return assessment.blocked;
+}
+
+/** Worst severity across several assessments (for aggregate badges). */
+export function worstFitSeverity(assessments: ArchetypeFitAssessment[]): ArchetypeFitSeverity {
+  return assessments.reduce<ArchetypeFitSeverity>((worst, a) => {
+    return severityRank(a.severity) > severityRank(worst) ? a.severity : worst;
+  }, "ok");
+}

--- a/apps/web/lib/marketing/fit-guard.test.ts
+++ b/apps/web/lib/marketing/fit-guard.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    organization: {
+      findUnique: vi.fn(),
+    },
+    outboundDraft: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { guardDraftArchetypeFit, resolveOrgArchetypeCategory } from "./fit-guard";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function mockCategory(category: string | null) {
+  vi.mocked(prisma.organization.findUnique).mockResolvedValue(
+    (category === null
+      ? { storefrontConfig: { archetype: { category: null } } }
+      : { storefrontConfig: { archetype: { category } } }) as never,
+  );
+}
+
+describe("resolveOrgArchetypeCategory", () => {
+  it("returns the storefront archetype category", async () => {
+    mockCategory("food-hospitality");
+    expect(await resolveOrgArchetypeCategory("org-1")).toBe("food-hospitality");
+  });
+
+  it("returns null when no storefront/archetype is configured", async () => {
+    vi.mocked(prisma.organization.findUnique).mockResolvedValue(null as never);
+    expect(await resolveOrgArchetypeCategory("org-1")).toBeNull();
+  });
+});
+
+describe("guardDraftArchetypeFit", () => {
+  it("returns null when the draft does not exist", async () => {
+    vi.mocked(prisma.outboundDraft.findUnique).mockResolvedValue(null as never);
+    expect(await guardDraftArchetypeFit({ draftId: "missing" })).toBeNull();
+  });
+
+  it("blocks a restaurant draft that leaks software-platform language", async () => {
+    vi.mocked(prisma.outboundDraft.findUnique).mockResolvedValue({
+      body: "Come meet our technical founders behind Build Studio!",
+      organizationId: "org-1",
+    } as never);
+    mockCategory("food-hospitality");
+
+    const result = await guardDraftArchetypeFit({ draftId: "d-1" });
+    expect(result).not.toBeNull();
+    expect(result!.ok).toBe(false);
+    if (!result!.ok) {
+      expect(result!.assessment.blocked).toBe(true);
+      expect(result!.error.toLowerCase()).toContain("imported/test data");
+    }
+  });
+
+  it("passes clean, in-archetype restaurant copy", async () => {
+    vi.mocked(prisma.outboundDraft.findUnique).mockResolvedValue({
+      body: "Reserve a table for our seasonal tasting menu this weekend.",
+      organizationId: "org-1",
+    } as never);
+    mockCategory("food-hospitality");
+
+    const result = await guardDraftArchetypeFit({ draftId: "d-2" });
+    expect(result!.ok).toBe(true);
+  });
+
+  it("honors the edited-body override when the operator fixes the leak", async () => {
+    vi.mocked(prisma.outboundDraft.findUnique).mockResolvedValue({
+      body: "Meet the technical founders behind our AI workflow.",
+      organizationId: "org-1",
+    } as never);
+    mockCategory("food-hospitality");
+
+    const result = await guardDraftArchetypeFit({
+      draftId: "d-3",
+      contentOverride: "Reserve a table for our seasonal menu tonight.",
+    });
+    expect(result!.ok).toBe(true);
+  });
+});

--- a/apps/web/lib/marketing/fit-guard.ts
+++ b/apps/web/lib/marketing/fit-guard.ts
@@ -1,0 +1,58 @@
+// Server-side archetype-fit guard.
+//
+// Client warnings can be bypassed, so the hard block on publishing off-archetype
+// / software-platform content must be enforced where the state actually
+// changes: at Approve and at Publish/Send. This module resolves the active
+// archetype category for a draft's organization and runs the pure
+// assessArchetypeFit engine against the content the operator is about to
+// release.
+
+import { prisma } from "@dpf/db";
+import { assessArchetypeFit, type ArchetypeFitAssessment } from "./archetype-fit";
+
+/** Resolve the active storefront archetype category for an organization. */
+export async function resolveOrgArchetypeCategory(
+  organizationId: string,
+): Promise<string | null> {
+  const organization = await prisma.organization.findUnique({
+    where: { id: organizationId },
+    select: {
+      storefrontConfig: {
+        select: { archetype: { select: { category: true } } },
+      },
+    },
+  });
+  return organization?.storefrontConfig?.archetype?.category ?? null;
+}
+
+export type DraftFitGuardResult =
+  | { ok: true; assessment: ArchetypeFitAssessment }
+  | { ok: false; error: string; assessment: ArchetypeFitAssessment };
+
+/**
+ * Assess the fit of the content that is about to be released for a draft.
+ * `contentOverride` lets Approve check the operator's edited body (they may
+ * have fixed the leak) rather than the stored body.
+ */
+export async function guardDraftArchetypeFit(input: {
+  draftId: string;
+  contentOverride?: string | null;
+}): Promise<DraftFitGuardResult | null> {
+  const draft = await prisma.outboundDraft.findUnique({
+    where: { draftId: input.draftId },
+    select: { body: true, organizationId: true },
+  });
+  if (!draft) return null;
+
+  const category = await resolveOrgArchetypeCategory(draft.organizationId);
+  const text =
+    input.contentOverride && input.contentOverride.trim().length > 0
+      ? input.contentOverride
+      : draft.body;
+  const assessment = assessArchetypeFit({ text, category });
+
+  if (assessment.blocked) {
+    return { ok: false, error: assessment.summary, assessment };
+  }
+  return { ok: true, assessment };
+}

--- a/apps/web/lib/marketing/next-decision.test.ts
+++ b/apps/web/lib/marketing/next-decision.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+import { getPlaybook } from "@/lib/tak/marketing-playbooks";
+import { buildMarketingOwnerDecision } from "./next-decision";
+
+const restaurantPlaybook = getPlaybook("food-hospitality", "booking");
+
+const now = new Date("2026-07-01T12:00:00.000Z");
+
+function snapshot(overrides: {
+  pending?: number;
+  approved?: number;
+  hasReview?: boolean;
+  reviewStale?: boolean;
+  briefs?: number;
+  proofs?: number;
+}): MarketingWorkspaceSnapshot {
+  const {
+    pending = 0,
+    approved = 0,
+    hasReview = true,
+    reviewStale = false,
+    briefs = 1,
+    proofs = 1,
+  } = overrides;
+
+  const draft = (id: string): MarketingWorkspaceSnapshot["pendingDrafts"][number] => ({
+    draftId: id,
+    sourceType: "marketing-asset-task",
+    sourceId: "task-1",
+    assetTaskTitle: "Seasonal menu post",
+    channelId: "email",
+    assetType: "email",
+    status: "pending-review",
+    body: "Body",
+    bodyFormat: "markdown",
+    createdByAgentId: "AGT-WS-MARKETING",
+    createdAt: now,
+  });
+
+  return {
+    organization: { id: "org-1", name: "Trattoria", website: null, addressSummary: "Austin, TX" },
+    storefront: {
+      id: "sf-1",
+      archetypeId: "restaurant",
+      archetypeName: "Restaurant",
+      category: "food-hospitality",
+      tagline: null,
+      description: null,
+      ctaType: "booking",
+    },
+    strategy: {
+      strategyId: "strategy-1",
+      status: "active",
+      primaryGoal: null,
+      routeToMarket: "inbound",
+      localityModel: "hyperlocal",
+      geographicScope: "Austin, TX",
+      primaryChannels: ["email"],
+      secondaryChannels: [],
+      differentiators: [],
+      reviewCadence: "monthly",
+      lastReviewedAt: hasReview ? now : null,
+      nextReviewAt: now,
+      sourceSummary: null,
+      specialistNotes: null,
+      seasonalityNotes: null,
+      targetSegments: [],
+      idealCustomerProfiles: [],
+      entryOffers: [],
+      proofAssets: Array.from({ length: proofs }, (_, i) => ({
+        type: "testimonial" as const,
+        label: `Review ${i + 1}`,
+      })),
+      serviceTerritories: [],
+      constraints: null,
+    },
+    latestReview: hasReview
+      ? {
+          reviewType: "ai-proactive",
+          summary: "Fill midweek covers.",
+          createdAt: now,
+          suggestedActions: [],
+          recommendation: null,
+        }
+      : null,
+    workProducts: {
+      campaignBriefs: Array.from({ length: briefs }, (_, i) => ({
+        briefId: `brief-${i}`,
+        title: "Seasonal menu",
+        objective: "Fill covers",
+        audience: "Diners",
+        channels: ["email"] as never,
+        cta: null,
+        proofAssets: [],
+        kpis: [],
+        notes: null,
+        status: "draft",
+        createdAt: now,
+      })),
+      assetTasks: [],
+      kpiCheckpoints: [],
+      automationCandidates: [],
+    },
+    pendingDrafts: Array.from({ length: pending }, (_, i) => draft(`d-${i}`)),
+    approvedDrafts: Array.from({ length: approved }, (_, i) => ({
+      ...draft(`a-${i}`),
+      status: "approved" as const,
+    })),
+    connectedChannels: [],
+    inboundMessages: [],
+    staleAreas: reviewStale ? ["Strategy review cadence is overdue"] : [],
+  };
+}
+
+describe("buildMarketingOwnerDecision — single restaurant-owner next decision", () => {
+  it("prioritizes reviewing pending drafts, phrased for diners", () => {
+    const decision = buildMarketingOwnerDecision(snapshot({ pending: 2 }), restaurantPlaybook);
+    expect(decision.id).toBe("review-drafts");
+    expect(decision.headline).toContain("diners");
+    expect(decision.metricFocus).toBe("Covers per service (lunch vs dinner)");
+  });
+
+  it("falls through to publishing approved copy when nothing is pending", () => {
+    const decision = buildMarketingOwnerDecision(snapshot({ approved: 1 }), restaurantPlaybook);
+    expect(decision.id).toBe("publish-approved");
+    expect(decision.ctaHref).toContain("marketing-publish-queue");
+  });
+
+  it("asks to run the first review when none exists", () => {
+    const decision = buildMarketingOwnerDecision(
+      snapshot({ hasReview: false }),
+      restaurantPlaybook,
+    );
+    expect(decision.id).toBe("run-first-review");
+    expect(decision.detail.toLowerCase()).toContain("fill covers");
+  });
+
+  it("routes to the first campaign using a food-hospitality campaign type", () => {
+    const decision = buildMarketingOwnerDecision(snapshot({ briefs: 0 }), restaurantPlaybook);
+    expect(decision.id).toBe("create-first-campaign");
+    expect(decision.headline).toContain("Seasonal menu launches");
+  });
+
+  it("asks to choose restaurant proof (reviews) when none is featured", () => {
+    const decision = buildMarketingOwnerDecision(snapshot({ proofs: 0 }), restaurantPlaybook);
+    expect(decision.id).toBe("choose-proof");
+    expect(decision.headline.toLowerCase()).toContain("reviews");
+  });
+
+  it("plans the next seasonal push in steady state", () => {
+    const decision = buildMarketingOwnerDecision(snapshot({}), restaurantPlaybook);
+    expect(decision.id).toBe("plan-seasonal");
+    expect(decision.headline).toContain("Seasonal menu launches");
+  });
+
+  it("never leaks software-platform vocabulary into the headline", () => {
+    for (const scenario of [
+      snapshot({ pending: 1 }),
+      snapshot({ approved: 1 }),
+      snapshot({ hasReview: false }),
+      snapshot({ briefs: 0 }),
+      snapshot({ proofs: 0 }),
+      snapshot({}),
+    ]) {
+      const decision = buildMarketingOwnerDecision(scenario, restaurantPlaybook);
+      const text = `${decision.headline} ${decision.detail}`.toLowerCase();
+      expect(text).not.toContain("build studio");
+      expect(text).not.toContain("agentic");
+      expect(text).not.toContain("backlog");
+    }
+  });
+});

--- a/apps/web/lib/marketing/next-decision.ts
+++ b/apps/web/lib/marketing/next-decision.ts
@@ -1,0 +1,143 @@
+// Marketing "one next decision" for the owner's first viewport.
+//
+// The /customer/marketing page must open with a single, archetype-scoped next
+// decision — the one thing this business owner should do next, phrased in their
+// own vocabulary (a restaurant owner sees covers, bookings, quiet services and
+// reviews, not "campaign brief #2"). The decision is derived from the saved
+// marketing state plus the active archetype playbook, so it stays correct as
+// the workspace advances (drafts to review → publish → strategy gaps → first
+// campaign → seasonal push).
+
+import type { MarketingPlaybook } from "@/lib/tak/marketing-playbooks";
+import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+
+export type MarketingOwnerDecision = {
+  id:
+    | "review-drafts"
+    | "publish-approved"
+    | "run-first-review"
+    | "create-first-campaign"
+    | "choose-proof"
+    | "plan-seasonal";
+  /** Short, archetype-flavoured decision headline. */
+  headline: string;
+  /** One line of supporting context. */
+  detail: string;
+  ctaLabel: string;
+  ctaHref: string;
+  /** The metric this decision moves, drawn from the archetype playbook. */
+  metricFocus: string;
+};
+
+function count(n: number, singular: string, plural = `${singular}s`): string {
+  return `${n} ${n === 1 ? singular : plural}`;
+}
+
+function proofNoun(playbook: MarketingPlaybook): string {
+  // Restaurants feature reviews; most local businesses lean on the same idea.
+  const joined = playbook.campaignTypes.join(" ").toLowerCase();
+  if (joined.includes("review")) return "reviews and testimonials";
+  if (joined.includes("case stud")) return "case studies";
+  return "proof (reviews, testimonials, or outcomes)";
+}
+
+/**
+ * Compute the single next decision to surface in the first viewport.
+ * Priority runs from the most time-sensitive owner action (drafts waiting on
+ * them) down to steady-state planning.
+ */
+export function buildMarketingOwnerDecision(
+  snapshot: MarketingWorkspaceSnapshot,
+  playbook: MarketingPlaybook,
+): MarketingOwnerDecision {
+  const metricFocus = playbook.keyMetrics[0] ?? "Customer acquisition";
+  const firstCampaign = playbook.campaignTypes[0] ?? "your first campaign";
+  const pending = snapshot.pendingDrafts.length;
+  const approved = snapshot.approvedDrafts.length;
+  const hasReview = Boolean(snapshot.latestReview);
+  const reviewOverdue = snapshot.staleAreas.some((area) =>
+    area.toLowerCase().includes("review"),
+  );
+  const briefCount = snapshot.workProducts.campaignBriefs.length;
+  const proofCount = snapshot.strategy.proofAssets.length;
+
+  if (pending > 0) {
+    return {
+      id: "review-drafts",
+      headline: `Review ${count(pending, "draft")} before ${audienceWord(playbook)} see them`,
+      detail:
+        "The Marketing Strategist has copy waiting for your approval. Nothing goes out until you approve it.",
+      ctaLabel: "Review drafts",
+      ctaHref: "/customer/marketing#marketing-approval-queue",
+      metricFocus,
+    };
+  }
+
+  if (approved > 0) {
+    return {
+      id: "publish-approved",
+      headline: `Publish ${count(approved, "approved post")}`,
+      detail:
+        "Approved copy is ready. Each publish is one explicit action — you stay in control of what goes live.",
+      ctaLabel: "Go to publish queue",
+      ctaHref: "/customer/marketing#marketing-publish-queue",
+      metricFocus,
+    };
+  }
+
+  if (!hasReview || reviewOverdue) {
+    return {
+      id: "run-first-review",
+      headline: "Decide which quiet service to fill first",
+      detail: `Run a strategy review so the plan targets ${playbook.primaryGoal.toLowerCase()}.`,
+      ctaLabel: "Start marketing review",
+      ctaHref: "/customer/marketing#marketing-launcher",
+      metricFocus,
+    };
+  }
+
+  if (briefCount === 0) {
+    return {
+      id: "create-first-campaign",
+      headline: `Turn the plan into your first campaign: ${firstCampaign}`,
+      detail:
+        "You have a strategy but no campaign yet. Ask the strategist to shape the first campaign brief and asset.",
+      ctaLabel: "Plan a campaign",
+      ctaHref: "/customer/marketing/campaigns",
+      metricFocus,
+    };
+  }
+
+  if (proofCount === 0) {
+    return {
+      id: "choose-proof",
+      headline: `Choose the ${proofNoun(playbook)} to feature`,
+      detail:
+        "Campaigns land harder with proof. Pick what makes the offer credible before the next push.",
+      ctaLabel: "Review strategy",
+      ctaHref: "/customer/marketing/strategy",
+      metricFocus,
+    };
+  }
+
+  return {
+    id: "plan-seasonal",
+    headline: `Plan the next push: ${firstCampaign}`,
+    detail:
+      "Strategy and proof are in place. Line up the next seasonal or quiet-period campaign with the strategist.",
+    ctaLabel: "Plan a campaign",
+    ctaHref: "/customer/marketing/campaigns",
+    metricFocus,
+  };
+}
+
+function audienceWord(playbook: MarketingPlaybook): string {
+  const stakeholders = playbook.stakeholders.toLowerCase();
+  if (stakeholders.includes("diner")) return "diners";
+  if (stakeholders.includes("patient")) return "patients";
+  if (stakeholders.includes("member")) return "members";
+  if (stakeholders.includes("donor")) return "donors";
+  if (stakeholders.includes("student")) return "students";
+  if (stakeholders.includes("buyer")) return "buyers";
+  return "customers";
+}

--- a/apps/web/lib/marketing/publish.ts
+++ b/apps/web/lib/marketing/publish.ts
@@ -17,6 +17,8 @@ import {
 } from "./execution";
 import { getAdapter } from "./channels/registry";
 import type { ChannelCredentialBundle } from "./channels/contracts";
+import { assessArchetypeFit } from "./archetype-fit";
+import { resolveOrgArchetypeCategory } from "./fit-guard";
 
 export type PublishApprovedDraftResult =
   | {
@@ -51,6 +53,19 @@ export async function publishApprovedDraft(input: {
       error: "draft_not_approved",
       retryable: false,
       message: `Draft is in status ${JSON.stringify(draft.status)}; only "approved" drafts can be published.`,
+    };
+  }
+
+  // Archetype-fit block: software-platform / off-archetype-block content must
+  // never reach a real audience, even if it somehow reached "approved".
+  const fitCategory = await resolveOrgArchetypeCategory(draft.organizationId);
+  const fit = assessArchetypeFit({ text: draft.body, category: fitCategory });
+  if (fit.blocked) {
+    return {
+      ok: false,
+      error: "archetype_fit_blocked",
+      retryable: false,
+      message: fit.summary,
     };
   }
 

--- a/apps/web/lib/marketing/subroutes.test.ts
+++ b/apps/web/lib/marketing/subroutes.test.ts
@@ -23,6 +23,7 @@ function snapshot(
       id: "storefront-1",
       archetypeId: "expert-services",
       archetypeName: "Expert Services",
+      category: "professional-services",
       tagline: "Proof-led growth",
       description: "Operational advice",
       ctaType: "inquiry",
@@ -185,6 +186,58 @@ describe("marketing subroute view models", () => {
       "Proposal",
       "Won",
     ]);
+  });
+
+  it("flags campaign artifacts that leak software-platform language as imported/test data", () => {
+    const leaked = snapshot({
+      storefront: {
+        id: "storefront-1",
+        archetypeId: "restaurant",
+        archetypeName: "Restaurant",
+        category: "food-hospitality",
+        tagline: null,
+        description: null,
+        ctaType: "booking",
+      },
+      workProducts: {
+        campaignBriefs: [
+          {
+            briefId: "brief-leak",
+            title: "Meet our technical founders",
+            objective: "Show off the Build Studio AI workflow",
+            audience: "SaaS buyers",
+            channels: ["linkedin"],
+            cta: "Book a demo",
+            proofAssets: [],
+            kpis: [],
+            notes: null,
+            status: "draft",
+            createdAt: now,
+          },
+        ],
+        assetTasks: [
+          {
+            taskId: "task-clean",
+            title: "Draft seasonal tasting menu post",
+            assetType: "email",
+            channel: "email",
+            dueWindow: "this week",
+            brief: "Promote the autumn tasting menu and reserve-a-table CTA.",
+            status: "draft",
+            createdAt: now,
+          },
+        ],
+        kpiCheckpoints: [],
+        automationCandidates: [],
+      },
+    });
+
+    const view = buildMarketingCampaignsView(leaked);
+    expect(view.importedTestCount).toBe(1);
+    expect(view.campaigns[0]!.archetypeFit.blocked).toBe(true);
+    // Clean, in-archetype restaurant task must not be flagged.
+    expect(view.assetTasks[0]!.archetypeFit.blocked).toBe(false);
+    expect(view.assetTasks[0]!.archetypeFit.severity).toBe("ok");
   });
 
   it("summarizes automation approval posture", () => {

--- a/apps/web/lib/marketing/subroutes.ts
+++ b/apps/web/lib/marketing/subroutes.ts
@@ -9,6 +9,7 @@ import {
   isOpenOpportunityStage,
   OPEN_OPPORTUNITY_STAGES,
 } from "@/lib/crm/presentation";
+import { assessArchetypeFit, type ArchetypeFitAssessment } from "@/lib/marketing/archetype-fit";
 
 export type MarketingMetric = {
   label: string;
@@ -31,6 +32,7 @@ export type MarketingCampaignRow = {
   approvedDraftCount: number;
   nextWorkLabel: string;
   kpis: string[];
+  archetypeFit: ArchetypeFitAssessment;
 };
 
 export type MarketingAssetTaskRow = {
@@ -42,6 +44,7 @@ export type MarketingAssetTaskRow = {
   status: string;
   draftStatusLabel: string;
   brief: string;
+  archetypeFit: ArchetypeFitAssessment;
 };
 
 export type MarketingCampaignsView = {
@@ -49,6 +52,8 @@ export type MarketingCampaignsView = {
   campaigns: MarketingCampaignRow[];
   assetTasks: MarketingAssetTaskRow[];
   hasWork: boolean;
+  /** Count of saved artifacts flagged as imported/test data (blocked from publish). */
+  importedTestCount: number;
 };
 
 export type MarketingFunnelEngagementInput = {
@@ -197,6 +202,7 @@ export function buildMarketingCampaignsView(
   const tasks = snapshot.workProducts.assetTasks;
   const pendingReviewCount = snapshot.pendingDrafts.length;
   const approvedCount = snapshot.approvedDrafts.length;
+  const category = snapshot.storefront.category;
 
   const campaigns = briefs.map((brief) => {
     const matchedTasks = tasks.filter((task) => taskMatchesBrief(task, brief));
@@ -230,6 +236,12 @@ export function buildMarketingCampaignsView(
       approvedDraftCount,
       nextWorkLabel,
       kpis: brief.kpis,
+      archetypeFit: assessArchetypeFit({
+        text: [brief.title, brief.objective, brief.audience, brief.notes, brief.kpis.join(" ")]
+          .filter(Boolean)
+          .join("\n"),
+        category,
+      }),
     };
   });
 
@@ -242,7 +254,15 @@ export function buildMarketingCampaignsView(
     status: task.status,
     draftStatusLabel: draftStatusLabel(task.taskId, snapshot),
     brief: nonEmpty(task.brief, "No saved brief"),
+    archetypeFit: assessArchetypeFit({
+      text: [task.title, task.brief].filter(Boolean).join("\n"),
+      category,
+    }),
   }));
+
+  const importedTestCount =
+    campaigns.filter((c) => c.archetypeFit.blocked).length +
+    assetTasks.filter((t) => t.archetypeFit.blocked).length;
 
   return {
     metrics: [
@@ -271,6 +291,7 @@ export function buildMarketingCampaignsView(
     campaigns,
     assetTasks,
     hasWork: briefs.length > 0 || tasks.length > 0,
+    importedTestCount,
   };
 }
 

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -217,3 +217,16 @@ Cockpit tiles, attention cards, and coworker handoffs that open an operator work
 5. **No coordinate deep links** — never deep-link via x/y click targets or ephemeral row indexes; use semantic ids (`BI-*`, `FB-*`, `WC-*`).
 
 When adding a new operator queue, document its query keys next to the route (or in the page's report-kit `FilterBar`) so cockpit cards and `record_execution_evidence` links can reuse them.
+
+## Archetype-scoped customer marketing surfaces
+
+Customer marketing artifacts (campaign briefs, proof prompts, asset tasks, drafts) **must** speak in the vocabulary of the organization's own business archetype. A restaurant markets covers, bookings, menus, seasonal/quiet-period offers, and reviews — never software-platform artifacts such as "Build Studio", "technical founders", or "AI workflow". Early bootstrap and imported/test data can leak DPF-internal vocabulary into a customer surface; the platform detects and contains that leak deterministically (BI-CC580161).
+
+Contract (implemented in `apps/web/lib/marketing/archetype-fit.ts` + `apps/web/lib/marketing/fit-guard.ts`):
+
+1. **Two finding kinds.** `platform-leak` (software-platform / DPF-internal terms foreign to every customer archetype) is a hard **block**; `off-archetype` (vocabulary distinctive to a *different* customer archetype than the active one) is a **warn** — cross-sell copy can be legitimate, so confirm before sending.
+2. **First viewport = one next decision.** `/customer/marketing` opens with a single archetype-scoped owner decision (`buildMarketingOwnerDecision`), phrased in the owner's own metrics (covers, booking fill rate, no-show rate for food-hospitality), not internal delivery jargon.
+3. **Guard at every release point.** Approve, Send email, and Publish to LinkedIn show a fit warning/block and are disabled on a `block`. The block is also enforced server-side (`guardDraftArchetypeFit`, `publishApprovedDraft`) so a client bypass cannot reach a real audience.
+4. **Saved leaks stay visible but inert.** Blocked artifacts render an "Imported / test data — blocked from publish" badge on the strategy and campaigns pages and count toward `importedTestCount`; they are never silently hidden and never publishable.
+
+Archetype vocabulary is sourced from the archetype-category marketing playbooks in `apps/web/lib/tak/marketing-playbooks.ts`; the active category comes from `StorefrontConfig.archetype.category`.


### PR DESCRIPTION
## What & why

Restaurant / Food & Hospitality marketing now scopes saved campaign artifacts, proof prompts, draft review, and publish readiness to the current organization **and its archetype**. A restaurant markets covers, bookings, menus, catering/event packages, seasonal & quiet-period offers, and reviews — never software-platform artifacts (Build Studio, technical founders, AI workflow, agentic, SaaS). Imported/test data that leaks DPF-internal vocabulary is detected, badged, and permanently blocked from publish.

Fixes **BI-CC580161**.

## Acceptance criteria

- ✅ Restaurant pages don't show DPF/software-platform artifacts unless marked **imported/test data** and blocked from publish (badge + `importedTestCount` on `/campaigns` and `/strategy`).
- ✅ Food-hospitality concepts drive the surface (menu, booking/reservation, dining, catering/event package, seasonal/quiet-period offers, reviews, covers, booking fill rate, no-show rate) — via `marketing-playbooks.ts` + `next-decision.ts`.
- ✅ Archetype-fit **warning/block before Approve, Send email, and Publish to LinkedIn** — client disables + notice, and server-side guards (`guardDraftArchetypeFit`, `publishApprovedDraft`) enforce it so a client bypass can't reach a real audience.
- ✅ First viewport shows **one Restaurant-owner next decision** phrased in owner metrics.
- ✅ Regression coverage for `/customer/marketing`, `/strategy`, and `/campaigns` (plus the archetype-fit engine, server guard, and next-decision).

## How it works

- `lib/marketing/archetype-fit.ts` — deterministic engine. `platform-leak` → hard **block** (imported/test data); `off-archetype` → **warn** (cross-sell copy can be legitimate, confirm first).
- `lib/marketing/fit-guard.ts` + `publish.ts` + `actions.ts` — server enforcement at Approve and Publish/Send.
- `lib/marketing/next-decision.ts` — single archetype-scoped owner decision for the first viewport.
- `ArchetypeFitNotice.tsx` — theme-aware badge/notice reused across review, publish, campaigns, and strategy.

## Design grounding

Source of truth: `docs/platform-usability-standards.md` (already referenced by the engine), updated here with a new **"Archetype-scoped customer marketing surfaces"** section. Substrate verified across `apps/web/lib/marketing` and `apps/web/components/customer-marketing`. This extends an existing usability standard, so no new `docs/superpowers/specs/` artifact is warranted.

## Testing

- 240 marketing vitest assertions green (37 new): `archetype-fit`, `next-decision`, `fit-guard`, extended `subroutes` + `page`.
- `tsc --noEmit` clean (0 errors app-wide) run directly. The packaged `next typegen` typecheck can't run in a source-only worktree (empty `.bin`), so the local pre-commit typecheck was overridden with `DPF_SKIP_TYPECHECK=1`; CI gates the merge.

Design-Grounding-Decision: Extends `docs/platform-usability-standards.md`; verified `apps/web/` substrate; no new `docs/superpowers/specs/` artifact needed.
UX-Fit-Decision: Progressive disclosure — notices render only on warn/block; first viewport reduces to one plain next decision; no layman-configured token/endpoint inputs.
Docs-Impact: Updated `docs/platform-usability-standards.md`.
Seed-Fit-Decision: No seed/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
