### PR TITLE
fix(marketing): scope Restaurant marketing artifacts to org + archetype (BI-CC580161)

### DIFF
--- a/apps/web/app/(shell)/customer/marketing/actions.ts
+++ b/apps/web/app/(shell)/customer/marketing/actions.ts
@@ -14,6 +14,7 @@ import {
   type OutboundDraftStatus,
 } from "@/lib/marketing/execution";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { guardDraftArchetypeFit } from "@/lib/marketing/fit-guard";
 
 type ActionResult =
   | { ok: true; draftId: string; status: OutboundDraftStatus }
@@ -76,6 +77,13 @@ export async function approveOutboundDraftAction(
 ): Promise<ActionResult> {
   const auth = await requireOperator();
   if ("error" in auth) return { ok: false, error: auth.error };
+
+  // Archetype-fit guard: never approve software-platform / off-archetype-block
+  // copy for a real audience. Checks the operator's edited body when provided,
+  // since they may have fixed the leak before approving.
+  const fit = await guardDraftArchetypeFit({ draftId, contentOverride: editedBody ?? null });
+  if (fit && !fit.ok) return { ok: false, error: fit.error };
+
   return decideOnDraft(draftId, "approved", editedBody ?? null, notes ?? null, auth.userId);
 }
 

--- a/apps/web/app/(shell)/customer/marketing/campaigns/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/campaigns/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/customer-marketing/MarketingRoutePrimitives";
 import { formatMarketingLabel, getMarketingWorkspaceSnapshot } from "@/lib/marketing";
 import { buildMarketingCampaignsView } from "@/lib/marketing/subroutes";
+import { ArchetypeFitNotice } from "@/components/customer-marketing/ArchetypeFitNotice";
 
 export default async function CustomerMarketingCampaignsPage() {
   const snapshot = await getMarketingWorkspaceSnapshot();
@@ -36,6 +37,24 @@ export default async function CustomerMarketingCampaignsPage() {
 
       <MarketingMetricGrid metrics={view.metrics} />
 
+      {view.importedTestCount > 0 ? (
+        <div
+          data-testid="marketing-imported-test-banner"
+          className="rounded-lg border border-red-500/50 bg-red-500/10 p-4 text-sm text-red-500"
+        >
+          <p className="font-semibold">
+            {view.importedTestCount} saved{" "}
+            {view.importedTestCount === 1 ? "artifact reads" : "artifacts read"} like imported / test
+            data
+          </p>
+          <p className="mt-1 leading-snug">
+            These carry software-platform language that doesn&rsquo;t belong in this business&rsquo;s
+            marketing. They&rsquo;re flagged below and blocked from publishing — reject or rewrite them
+            before they go to a real audience.
+          </p>
+        </div>
+      ) : null}
+
       <MarketingSection
         title="Campaign briefs"
         description="Briefs define the audience, channel mix, proof, and measurable outcome before individual assets are drafted."
@@ -62,6 +81,10 @@ export default async function CustomerMarketingCampaignsPage() {
                   </div>
                   <MarketingLifecycleBadge status={campaign.status} />
                 </div>
+
+                {campaign.archetypeFit.severity !== "ok" ? (
+                  <ArchetypeFitNotice assessment={campaign.archetypeFit} className="mt-3" />
+                ) : null}
 
                 <dl className="mt-4 grid gap-3 text-sm md:grid-cols-2">
                   <div>
@@ -138,6 +161,9 @@ export default async function CustomerMarketingCampaignsPage() {
                   </div>
                   <MarketingLifecycleBadge status={task.status} />
                 </div>
+                {task.archetypeFit.severity !== "ok" ? (
+                  <ArchetypeFitNotice assessment={task.archetypeFit} className="mt-3" />
+                ) : null}
                 <p className="mt-3 text-sm text-[var(--dpf-text)]">{task.brief}</p>
                 <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
                   <span className="text-[var(--dpf-muted)]">{task.dueWindow}</span>

--- a/apps/web/app/(shell)/customer/marketing/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/page.tsx
@@ -11,6 +11,8 @@ import {
   MARKETING_AGENTIC_OPERATIONS_ROUTE,
   buildMarketingAgenticOperationTopics,
 } from "@/lib/marketing/agentic-operations";
+import { getPlaybook } from "@/lib/tak/marketing-playbooks";
+import { buildMarketingOwnerDecision } from "@/lib/marketing/next-decision";
 
 export default async function CustomerMarketingPage() {
   const snapshot = await getMarketingWorkspaceSnapshot();
@@ -71,9 +73,40 @@ export default async function CustomerMarketingPage() {
     kpiStack,
     suggestions,
   });
+  const playbook = getPlaybook(snapshot.storefront.category, snapshot.storefront.ctaType);
+  const ownerDecision = buildMarketingOwnerDecision(snapshot, playbook);
 
   return (
     <div className="space-y-6">
+      <section
+        data-testid="marketing-owner-decision"
+        data-decision-id={ownerDecision.id}
+        className="rounded-lg border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-6"
+      >
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="min-w-0">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--dpf-accent)]">
+              Your next decision
+            </p>
+            <h2 className="mt-2 text-xl font-bold text-[var(--dpf-text)]">
+              {ownerDecision.headline}
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm text-[var(--dpf-muted)]">
+              {ownerDecision.detail}
+            </p>
+            <p className="mt-3 text-xs text-[var(--dpf-muted)]">
+              Moves: <span className="font-medium text-[var(--dpf-text)]">{ownerDecision.metricFocus}</span>
+            </p>
+          </div>
+          <Link
+            href={ownerDecision.ctaHref}
+            className="shrink-0 rounded-full bg-[var(--dpf-accent)] px-5 py-2 text-sm font-medium text-white hover:opacity-90"
+          >
+            {ownerDecision.ctaLabel}
+          </Link>
+        </div>
+      </section>
+
       <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
@@ -98,12 +131,14 @@ export default async function CustomerMarketingPage() {
 
       </div>
 
-      <AgentWorkLauncher
-        agentName="Marketing Strategist"
-        primaryActionLabel="Start marketing review"
-        topics={launcherTopics}
-        routeContext={MARKETING_AGENTIC_OPERATIONS_ROUTE}
-      />
+      <div id="marketing-launcher" className="scroll-mt-24">
+        <AgentWorkLauncher
+          agentName="Marketing Strategist"
+          primaryActionLabel="Start marketing review"
+          topics={launcherTopics}
+          routeContext={MARKETING_AGENTIC_OPERATIONS_ROUTE}
+        />
+      </div>
 
       <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
         <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
@@ -234,6 +269,7 @@ export default async function CustomerMarketingPage() {
         approvedDrafts={snapshot.approvedDrafts}
         connectedChannels={snapshot.connectedChannels}
         inboundMessages={snapshot.inboundMessages}
+        category={snapshot.storefront.category}
       />
     </div>
   );

--- a/apps/web/components/customer-marketing/ApprovalQueuePanel.tsx
+++ b/apps/web/components/customer-marketing/ApprovalQueuePanel.tsx
@@ -1,6 +1,8 @@
 import type { InboundMessageRow, OutboundDraftRow } from "@/lib/marketing";
 import { formatMarketingLabel } from "@/lib/marketing";
+import { assessArchetypeFit } from "@/lib/marketing/archetype-fit";
 import { ApprovalQueueReview } from "./ApprovalQueueReview";
+import { ArchetypeFitBadge } from "./ArchetypeFitNotice";
 import { PublishLinkedInButton } from "./PublishLinkedInButton";
 import { PublishEmailButton } from "./PublishEmailButton";
 
@@ -9,6 +11,8 @@ type Props = {
   approvedDrafts: OutboundDraftRow[];
   connectedChannels: string[];
   inboundMessages: InboundMessageRow[];
+  /** Active storefront archetype category, for archetype-fit checks. */
+  category: string | null;
 };
 
 function timeAgo(date: Date | string): string {
@@ -56,13 +60,17 @@ function relativeTime(date: Date | string): string {
 function DraftRow({
   draft,
   trailing,
+  category,
 }: {
   draft: OutboundDraftRow;
   trailing: React.ReactNode;
+  category: string | null;
 }) {
+  const fit = assessArchetypeFit({ text: draft.body, category });
   return (
     <li
       data-draft-id={draft.draftId}
+      data-fit-severity={fit.severity}
       className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4"
     >
       <div className="flex flex-wrap items-start justify-between gap-2">
@@ -80,6 +88,7 @@ function DraftRow({
             <span>
               Drafted by {draft.createdByAgentId ?? "unknown"} · {timeAgo(draft.createdAt)}
             </span>
+            <ArchetypeFitBadge assessment={fit} />
           </div>
           {draft.assetTaskTitle ? (
             <p className="mt-2 truncate text-sm font-medium text-[var(--dpf-text)]">
@@ -99,6 +108,7 @@ export function ApprovalQueuePanel({
   approvedDrafts,
   connectedChannels,
   inboundMessages,
+  category,
 }: Props) {
   const linkedInConnected =
     connectedChannels.includes("linkedin-personal-social") ||
@@ -138,6 +148,7 @@ export function ApprovalQueuePanel({
               <DraftRow
                 key={draft.draftId}
                 draft={draft}
+                category={category}
                 trailing={
                   <ApprovalQueueReview
                     draftId={draft.draftId}
@@ -145,6 +156,7 @@ export function ApprovalQueuePanel({
                     assetTaskTitle={draft.assetTaskTitle}
                     channelId={draft.channelId}
                     assetType={draft.assetType}
+                    category={category}
                   />
                 }
               />
@@ -181,18 +193,21 @@ export function ApprovalQueuePanel({
               <DraftRow
                 key={draft.draftId}
                 draft={draft}
+                category={category}
                 trailing={
                   isLinkedInChannel(draft.channelId) ? (
                     <PublishLinkedInButton
                       draftId={draft.draftId}
                       channelConnected={linkedInConnected}
                       channelId="linkedin-personal-social"
+                      fitBlocked={assessArchetypeFit({ text: draft.body, category }).blocked}
                     />
                   ) : isEmailChannel(draft.channelId) ? (
                     <PublishEmailButton
                       draftId={draft.draftId}
                       channelConnected={emailConnected}
                       channelId="email-postmark"
+                      fitBlocked={assessArchetypeFit({ text: draft.body, category }).blocked}
                     />
                   ) : (
                     <p className="text-xs text-[var(--dpf-muted)]">

--- a/apps/web/components/customer-marketing/ApprovalQueueReview.tsx
+++ b/apps/web/components/customer-marketing/ApprovalQueueReview.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import {
   approveOutboundDraftAction,
   requestChangesOnDraftAction,
   rejectOutboundDraftAction,
 } from "@/app/(shell)/customer/marketing/actions";
+import { assessArchetypeFit } from "@/lib/marketing/archetype-fit";
+import { ArchetypeFitNotice } from "./ArchetypeFitNotice";
 
 type Props = {
   draftId: string;
@@ -13,16 +15,23 @@ type Props = {
   assetTaskTitle: string | null;
   channelId: string;
   assetType: string;
+  category: string | null;
 };
 
 type FlashState = { kind: "ok" | "err"; message: string } | null;
 
-export function ApprovalQueueReview({ draftId, initialBody, assetTaskTitle, channelId, assetType }: Props) {
+export function ApprovalQueueReview({ draftId, initialBody, assetTaskTitle, channelId, assetType, category }: Props) {
   const [open, setOpen] = useState(false);
   const [body, setBody] = useState(initialBody);
   const [notes, setNotes] = useState("");
   const [flash, setFlash] = useState<FlashState>(null);
   const [pending, startTransition] = useTransition();
+
+  // Live archetype-fit assessment of the (possibly edited) body. A hard block
+  // (software-platform / off-archetype content) disables Approve until the
+  // operator edits the leak out. The server action enforces the same rule.
+  const fit = useMemo(() => assessArchetypeFit({ text: body, category }), [body, category]);
+  const approveBlocked = fit.blocked;
 
   function showError(err: string) {
     setFlash({ kind: "err", message: err });
@@ -134,19 +143,25 @@ export function ApprovalQueueReview({ draftId, initialBody, assetTaskTitle, chan
                 className="mt-1 w-full rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-2 text-sm text-[var(--dpf-text)] focus:border-[var(--dpf-accent)] focus:outline-none"
               />
 
+              {fit.severity !== "ok" ? (
+                <ArchetypeFitNotice assessment={fit} className="mt-3" />
+              ) : null}
+
               <div className="mt-3 flex flex-wrap gap-2">
                 <button
                   type="button"
-                  disabled={pending}
+                  disabled={pending || approveBlocked}
                   onClick={() => approve(false)}
+                  title={approveBlocked ? fit.summary : undefined}
                   className="rounded-full bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50"
                 >
                   Approve
                 </button>
                 <button
                   type="button"
-                  disabled={pending || body === initialBody}
+                  disabled={pending || body === initialBody || approveBlocked}
                   onClick={() => approve(true)}
+                  title={approveBlocked ? fit.summary : undefined}
                   className="rounded-full border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] px-4 py-1.5 text-sm font-medium text-[var(--dpf-accent)] disabled:opacity-50"
                 >
                   Approve with edits

--- a/apps/web/components/customer-marketing/ArchetypeFitNotice.tsx
+++ b/apps/web/components/customer-marketing/ArchetypeFitNotice.tsx
@@ -1,0 +1,55 @@
+import type { ArchetypeFitAssessment } from "@/lib/marketing/archetype-fit";
+import { IMPORTED_TEST_BADGE_LABEL } from "@/lib/marketing/archetype-fit";
+
+/**
+ * Small, theme-aware badge + note for an archetype-fit assessment.
+ * - block → red "Imported / test data — blocked from publish" badge + reason.
+ * - warn  → amber "Check archetype fit" badge + reason.
+ * - ok    → renders nothing.
+ */
+export function ArchetypeFitNotice({
+  assessment,
+  className = "",
+}: {
+  assessment: ArchetypeFitAssessment;
+  className?: string;
+}) {
+  if (assessment.severity === "ok") return null;
+
+  const blocked = assessment.blocked;
+  const tone = blocked
+    ? "border-red-500/50 bg-red-500/10 text-red-500"
+    : "border-amber-500/50 bg-amber-500/10 text-amber-600";
+
+  return (
+    <div
+      data-testid="archetype-fit-notice"
+      data-fit-severity={assessment.severity}
+      className={`rounded-lg border px-3 py-2 text-xs ${tone} ${className}`.trim()}
+    >
+      <p className="font-semibold">
+        {blocked ? IMPORTED_TEST_BADGE_LABEL : "Check archetype fit before sending"}
+      </p>
+      <p className="mt-1 leading-snug">{assessment.summary}</p>
+    </div>
+  );
+}
+
+/** Inline pill variant for compact placements (e.g. artifact card headers). */
+export function ArchetypeFitBadge({ assessment }: { assessment: ArchetypeFitAssessment }) {
+  if (assessment.severity === "ok") return null;
+  const blocked = assessment.blocked;
+  return (
+    <span
+      data-testid="archetype-fit-badge"
+      data-fit-severity={assessment.severity}
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${
+        blocked
+          ? "border-red-500/50 bg-red-500/10 text-red-500"
+          : "border-amber-500/50 bg-amber-500/10 text-amber-600"
+      }`}
+    >
+      {blocked ? IMPORTED_TEST_BADGE_LABEL : "Check archetype fit"}
+    </span>
+  );
+}

--- a/apps/web/components/customer-marketing/PublishEmailButton.tsx
+++ b/apps/web/components/customer-marketing/PublishEmailButton.tsx
@@ -7,9 +7,11 @@ type Props = {
   draftId: string;
   channelConnected: boolean;
   channelId: string;
+  /** True when archetype-fit flags the body as off-archetype/software-platform content. */
+  fitBlocked?: boolean;
 };
 
-export function PublishEmailButton({ draftId, channelConnected, channelId }: Props) {
+export function PublishEmailButton({ draftId, channelConnected, channelId, fitBlocked }: Props) {
   const [status, setStatus] = useState<"idle" | "sending" | "done" | "error">("idle");
   const [message, setMessage] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
@@ -27,6 +29,19 @@ export function PublishEmailButton({ draftId, channelConnected, channelId }: Pro
         setMessage(result.error);
       }
     });
+  }
+
+  if (fitBlocked) {
+    return (
+      <p
+        data-testid="send-blocked-fit"
+        className="rounded-lg border border-red-500/50 bg-red-500/10 px-3 py-1.5 text-xs text-red-500"
+        role="status"
+      >
+        Blocked: this reads as imported/test or off-archetype content. It can’t be emailed to this
+        business’s audience — reject it or fix the copy first.
+      </p>
+    );
   }
 
   if (!channelConnected) {

--- a/apps/web/components/customer-marketing/PublishLinkedInButton.tsx
+++ b/apps/web/components/customer-marketing/PublishLinkedInButton.tsx
@@ -7,9 +7,11 @@ type Props = {
   draftId: string;
   channelConnected: boolean;
   channelId: string;
+  /** True when archetype-fit flags the body as off-archetype/software-platform content. */
+  fitBlocked?: boolean;
 };
 
-export function PublishLinkedInButton({ draftId, channelConnected, channelId }: Props) {
+export function PublishLinkedInButton({ draftId, channelConnected, channelId, fitBlocked }: Props) {
   const [status, setStatus] = useState<"idle" | "publishing" | "done" | "error">("idle");
   const [message, setMessage] = useState<string | null>(null);
   const [externalUrl, setExternalUrl] = useState<string | null>(null);
@@ -30,6 +32,19 @@ export function PublishLinkedInButton({ draftId, channelConnected, channelId }: 
         setMessage(result.error);
       }
     });
+  }
+
+  if (fitBlocked) {
+    return (
+      <p
+        data-testid="publish-blocked-fit"
+        className="rounded-lg border border-red-500/50 bg-red-500/10 px-3 py-1.5 text-xs text-red-500"
+        role="status"
+      >
+        Blocked: this reads as imported/test or off-archetype content. It can’t be published to this
+        business’s audience — reject it or fix the copy first.
+      </p>
+    );
   }
 
   if (!channelConnected) {

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -4240,6 +4240,10 @@
         "enforcement-points",
         "coworker-rule",
         "common-shell-action-result-contract",
+        "archetype-scoped-marketing-content-bi-cc580161",
+        "fit-engine-source-of-truth",
+        "enforcement-points-1",
+        "first-viewport-decision",
         "standards-referenced",
         "operator-identity-and-personalization",
         "operator-queue-deep-links"

--- a/apps/web/lib/marketing.ts
+++ b/apps/web/lib/marketing.ts
@@ -212,6 +212,7 @@ export type MarketingWorkspaceSnapshot = {
     id: string | null;
     archetypeId: string | null;
     archetypeName: string | null;
+    category: string | null;
     tagline: string | null;
     description: string | null;
     ctaType: string | null;
@@ -1259,6 +1260,7 @@ export async function getMarketingWorkspaceSnapshot(): Promise<MarketingWorkspac
       id: organization.storefrontConfig?.id ?? null,
       archetypeId: organization.storefrontConfig?.archetypeId ?? null,
       archetypeName: cleanText(organization.storefrontConfig?.archetype?.name),
+      category: cleanText(organization.storefrontConfig?.archetype?.category),
       tagline: cleanText(organization.storefrontConfig?.tagline),
       description: cleanText(organization.storefrontConfig?.description),
       ctaType: cleanText(organization.storefrontConfig?.archetype?.ctaType),

--- a/apps/web/lib/marketing/archetype-fit.test.ts
+++ b/apps/web/lib/marketing/archetype-fit.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assessArchetypeFit,
+  isImportedTestArtifact,
+  isPublishBlockedByFit,
+  worstFitSeverity,
+} from "./archetype-fit";
+
+describe("assessArchetypeFit", () => {
+  it("blocks software-platform / DPF artifacts for a restaurant", () => {
+    const result = assessArchetypeFit({
+      text: "Our Build Studio helps technical founders ship software with an AI workflow.",
+      category: "food-hospitality",
+    });
+    expect(result.severity).toBe("block");
+    expect(result.blocked).toBe(true);
+    expect(isPublishBlockedByFit(result)).toBe(true);
+    expect(isImportedTestArtifact(result)).toBe(true);
+    expect(result.findings.some((f) => f.kind === "platform-leak" && /Build Studio/i.test(f.term))).toBe(
+      true,
+    );
+  });
+
+  it("passes clean food-hospitality copy for a restaurant", () => {
+    const result = assessArchetypeFit({
+      text: "Reserve a table for our seasonal tasting menu and fill quiet midweek covers. Read our reviews.",
+      category: "food-hospitality",
+    });
+    expect(result.severity).toBe("ok");
+    expect(result.blocked).toBe(false);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("warns when a restaurant draft uses another archetype's vocabulary", () => {
+    const result = assessArchetypeFit({
+      text: "Open an account today and check our APY — plus book your annual health screening.",
+      category: "food-hospitality",
+    });
+    expect(result.severity).toBe("warn");
+    expect(result.blocked).toBe(false);
+    expect(result.findings.every((f) => f.kind === "off-archetype")).toBe(true);
+    expect(result.findings.map((f) => f.looksLikeCategory)).toContain("banking-financial-services");
+  });
+
+  it("does not warn on the active archetype's own vocabulary", () => {
+    // "reservation" and "menu" are food-hospitality signatures, so a restaurant
+    // must not be warned about its own words.
+    const result = assessArchetypeFit({
+      text: "Confirm your reservation and view the new menu.",
+      category: "food-hospitality",
+    });
+    expect(result.severity).toBe("ok");
+  });
+
+  it("still blocks platform leaks regardless of active category", () => {
+    const result = assessArchetypeFit({
+      text: "Our SaaS software platform is built on Prisma.",
+      category: "trades-maintenance",
+    });
+    expect(result.blocked).toBe(true);
+  });
+
+  it("block outranks warn when both are present", () => {
+    const result = assessArchetypeFit({
+      text: "Build Studio for technical founders — also, book your annual screening.",
+      category: "food-hospitality",
+    });
+    expect(result.severity).toBe("block");
+  });
+
+  it("treats empty content as ok", () => {
+    expect(assessArchetypeFit({ text: "", category: "food-hospitality" }).severity).toBe("ok");
+    expect(assessArchetypeFit({ text: null, category: null }).severity).toBe("ok");
+  });
+
+  it("computes the worst severity across assessments", () => {
+    const ok = assessArchetypeFit({ text: "Reserve a table.", category: "food-hospitality" });
+    const warn = assessArchetypeFit({ text: "Check our APY.", category: "food-hospitality" });
+    const block = assessArchetypeFit({ text: "Build Studio.", category: "food-hospitality" });
+    expect(worstFitSeverity([ok, warn])).toBe("warn");
+    expect(worstFitSeverity([ok, warn, block])).toBe("block");
+    expect(worstFitSeverity([ok])).toBe("ok");
+  });
+});

--- a/apps/web/lib/marketing/archetype-fit.ts
+++ b/apps/web/lib/marketing/archetype-fit.ts
@@ -1,0 +1,238 @@
+// Marketing archetype-fit engine.
+//
+// Customer marketing artifacts (campaign briefs, proof prompts, drafts) must
+// speak in the language of the organization's OWN business archetype — a
+// restaurant markets covers, bookings, menus and seasonal offers, never
+// "Build Studio", "technical founders", or "AI workflow". Early bootstrap and
+// imported/test data can leak software-platform (DPF) vocabulary into a
+// customer's marketing surfaces; this module detects that leak deterministically
+// so the UI can warn, badge it as imported/test data, and the server can block
+// it from ever publishing to a real audience.
+//
+// Two finding kinds:
+//   - platform-leak  → software-platform / DPF-internal artifacts that are
+//                       foreign to EVERY customer archetype. Always a hard
+//                       BLOCK (must not publish, badge as imported/test data).
+//   - off-archetype  → vocabulary that clearly belongs to a DIFFERENT customer
+//                       archetype than the active one. A WARN — confirm before
+//                       sending — because cross-sell copy can be legitimate.
+//
+// Reference: docs/platform-usability-standards.md (archetype-scoped surfaces).
+
+export type ArchetypeFitSeverity = "ok" | "warn" | "block";
+
+export type ArchetypeFitFindingKind = "platform-leak" | "off-archetype";
+
+export type ArchetypeFitFinding = {
+  kind: ArchetypeFitFindingKind;
+  severity: "warn" | "block";
+  term: string;
+  message: string;
+  /** For off-archetype findings, the category the term looks like it belongs to. */
+  looksLikeCategory?: string | null;
+};
+
+export type ArchetypeFitAssessment = {
+  severity: ArchetypeFitSeverity;
+  /** True when severity === "block": content must not publish to a real audience. */
+  blocked: boolean;
+  findings: ArchetypeFitFinding[];
+  summary: string;
+};
+
+export const IMPORTED_TEST_BADGE_LABEL = "Imported / test data — blocked from publish";
+
+const MAX_FINDINGS = 6;
+
+type TermSpec = {
+  term: string;
+  pattern: RegExp;
+  message: string;
+};
+
+// Escape a literal and allow flexible internal whitespace, matched on word-ish
+// boundaries so "menus" does not trip a "menu" foreign match but "SaaS-first"
+// still trips "saas".
+function termPattern(literal: string): RegExp {
+  const escaped = literal
+    .trim()
+    .split(/\s+/)
+    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("\\s+");
+  return new RegExp(`(?<![\\w-])${escaped}(?![\\w-])`, "i");
+}
+
+function spec(term: string, message: string): TermSpec {
+  return { term, pattern: termPattern(term), message };
+}
+
+// ─── Platform-leak terms (universal hard block) ────────────────────────────
+// Software-platform / DPF-internal artifacts. These do not belong in ANY
+// customer's marketing, regardless of archetype, so they always block.
+const PLATFORM_LEAK_TERMS: TermSpec[] = [
+  spec("Build Studio", "“Build Studio” is a software-platform build tool, not a customer marketing concept."),
+  spec("Digital Product Factory", "“Digital Product Factory” is the internal platform name and must not reach a customer audience."),
+  spec("technical founder", "“technical founder” is software-startup language, foreign to this business's audience."),
+  spec("technical co-founder", "“technical co-founder” is software-startup language, foreign to this business's audience."),
+  spec("technical founders", "“technical founders” is software-startup language, foreign to this business's audience."),
+  spec("AI workflow", "“AI workflow” exposes internal platform mechanics rather than a customer benefit."),
+  spec("agentic", "“agentic” is internal platform jargon, not customer marketing language."),
+  spec("AI coworker", "“AI coworker” is internal platform tooling, not something to market to customers."),
+  spec("software platform", "“software platform” is not what this business sells to its customers."),
+  spec("SaaS", "“SaaS” is software-industry positioning, foreign to this business's audience."),
+  spec("self-upgrade", "“self-upgrade” is internal platform machinery, not a customer message."),
+  spec("MCP server", "“MCP server” is internal platform plumbing and must not appear in marketing."),
+  spec("MCP tool", "“MCP tool” is internal platform plumbing and must not appear in marketing."),
+  spec("backlog item", "“backlog item” is internal delivery jargon, not a customer marketing concept."),
+  spec("work capsule", "“work capsule” is internal platform jargon, not a customer marketing concept."),
+  spec("Prisma", "“Prisma” is an internal database detail that must never appear in marketing copy."),
+  spec("codebase", "“codebase” is software-engineering language, foreign to this business's marketing."),
+];
+
+// ─── Off-archetype signatures (warn) ────────────────────────────────────────
+// Distinctive vocabulary per customer archetype category. When content carries
+// signatures from a category OTHER than the active one, warn the operator to
+// confirm the copy fits before it is approved or sent. Kept deliberately
+// high-precision (domain-specific, multi-word where possible) to avoid noise.
+const CATEGORY_SIGNATURES: Record<string, string[]> = {
+  // Distinctive food-hospitality terms only. Generic words ("menu", "covers",
+  // "dining") are omitted so they don't falsely warn OTHER archetypes' copy —
+  // each term here only matters when a different archetype's draft uses it.
+  "food-hospitality": [
+    "reserve a table", "tasting menu", "prix fixe", "no-show", "private dining",
+    "diners", "covers per service", "reservation",
+  ],
+  "banking-financial-services": ["apy", "apr", "fdic", "ncua", "open an account", "mortgage", "member fdic"],
+  "healthcare-wellness": ["recall reminder", "vaccination", "screening", "preventive care", "patient recall"],
+  "education-training": ["enrolment", "enrollment", "taster session", "term launch", "open day", "course completion"],
+  "real-estate-construction": ["display home", "floor plan", "handover", "purchase agreement", "stage release"],
+  "trades-maintenance": ["gas safety", "eicr", "boiler", "call-out", "pat testing"],
+  "pet-services": ["grooming", "boarding", "puppy programme", "kennel"],
+  "automotive-services": ["adas calibration", "windscreen", "windshield", "fleet account"],
+  "fitness-recreation": ["class schedule", "membership churn", "trial pass", "personal training"],
+  "nonprofit-community": ["donor", "fundraising", "recurring giving", "volunteer recruitment"],
+  "warehousing-fulfilment": ["pallet", "3pl", "despatch", "rate card", "committed capacity"],
+  "beauty-personal-care": ["rebooking", "stylist", "gift voucher", "colour service"],
+  "asset-rental": ["off-peak", "rentable pool", "return-due", "deposit policy"],
+  "live-events-venues": ["on-sale", "presale", "line-up reveal", "season-pass"],
+  "hoa-property-management": ["bylaw", "special assessment", "amenity reservation", "board meeting"],
+  "public-sector": ["public hearing", "council meeting", "permit deadline", "levy"],
+  "professional-services": ["retainer renewal", "thought leadership", "engagement value"],
+  "media-production": ["showreel", "reel", "commission", "behind-the-scenes"],
+  "security-services": ["monitoring plan", "rfp response", "response-time sla"],
+  "moving-and-logistics": ["packing service", "moving quote", "b2b route"],
+  "retail-goods": ["average order value", "flash sale", "pre-order", "gift guide"],
+};
+
+type CompiledSignature = { category: string; term: string; pattern: RegExp };
+
+const COMPILED_SIGNATURES: CompiledSignature[] = Object.entries(CATEGORY_SIGNATURES).flatMap(
+  ([category, terms]) => terms.map((term) => ({ category, term, pattern: termPattern(term) })),
+);
+
+function humanCategory(category: string): string {
+  return category
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function severityRank(severity: ArchetypeFitSeverity): number {
+  return severity === "block" ? 2 : severity === "warn" ? 1 : 0;
+}
+
+/**
+ * Assess whether marketing content fits the active archetype.
+ *
+ * @param text     the content to check (title + body + notes, joined)
+ * @param category the active storefront archetype category (e.g. "food-hospitality")
+ */
+export function assessArchetypeFit(input: {
+  text: string | null | undefined;
+  category: string | null | undefined;
+}): ArchetypeFitAssessment {
+  const text = (input.text ?? "").toString();
+  const category = (input.category ?? "").trim().toLowerCase();
+  const findings: ArchetypeFitFinding[] = [];
+
+  if (text.trim().length === 0) {
+    return { severity: "ok", blocked: false, findings: [], summary: "No content to check." };
+  }
+
+  const seen = new Set<string>();
+
+  // 1) Platform leaks — always block.
+  for (const leak of PLATFORM_LEAK_TERMS) {
+    if (leak.pattern.test(text)) {
+      const key = `leak:${leak.term.toLowerCase()}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      findings.push({ kind: "platform-leak", severity: "block", term: leak.term, message: leak.message });
+    }
+  }
+
+  // 2) Off-archetype signatures — warn. Skip the active category's own terms.
+  for (const sig of COMPILED_SIGNATURES) {
+    if (sig.category === category) continue;
+    if (!sig.pattern.test(text)) continue;
+    const key = `sig:${sig.term.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    findings.push({
+      kind: "off-archetype",
+      severity: "warn",
+      term: sig.term,
+      looksLikeCategory: sig.category,
+      message: `“${sig.term}” reads like ${humanCategory(sig.category)} marketing, not this business's.`,
+    });
+  }
+
+  const trimmed = findings.slice(0, MAX_FINDINGS);
+  const severity: ArchetypeFitSeverity = trimmed.some((f) => f.severity === "block")
+    ? "block"
+    : trimmed.some((f) => f.severity === "warn")
+      ? "warn"
+      : "ok";
+
+  return {
+    severity,
+    blocked: severity === "block",
+    findings: trimmed,
+    summary: summarize(severity, trimmed),
+  };
+}
+
+function summarize(severity: ArchetypeFitSeverity, findings: ArchetypeFitFinding[]): string {
+  if (severity === "block") {
+    const terms = findings.filter((f) => f.kind === "platform-leak").map((f) => `“${f.term}”`);
+    return `Blocked: software-platform content (${terms.join(", ")}) does not belong in this business's marketing. Treat as imported/test data — it cannot be published.`;
+  }
+  if (severity === "warn") {
+    const cats = [
+      ...new Set(
+        findings
+          .filter((f) => f.kind === "off-archetype" && f.looksLikeCategory)
+          .map((f) => humanCategory(f.looksLikeCategory as string)),
+      ),
+    ];
+    return `Heads up: this copy uses ${cats.join(" / ")} language. Confirm it fits this business before you approve or send it.`;
+  }
+  return "Content fits this business's archetype.";
+}
+
+/** True when a fit assessment should hard-block Approve / Send / Publish. */
+export function isPublishBlockedByFit(assessment: ArchetypeFitAssessment): boolean {
+  return assessment.blocked;
+}
+
+/** True when a saved artifact should be badged as imported/test data. */
+export function isImportedTestArtifact(assessment: ArchetypeFitAssessment): boolean {
+  return assessment.blocked;
+}
+
+/** Worst severity across several assessments (for aggregate badges). */
+export function worstFitSeverity(assessments: ArchetypeFitAssessment[]): ArchetypeFitSeverity {
+  return assessments.reduce<ArchetypeFitSeverity>((worst, a) => {
+    return severityRank(a.severity) > severityRank(worst) ? a.severity : worst;
+  }, "ok");
+}

--- a/apps/web/lib/marketing/archetype-scoping.test.ts
+++ b/apps/web/lib/marketing/archetype-scoping.test.ts
@@ -1,0 +1,170 @@
+// Regression coverage for archetype-scoping of the Restaurant marketing cockpit
+// across its three routes:
+//   - /customer/marketing  → buildMarketingOwnerDecision (first-viewport decision)
+//                             + per-draft archetype-fit (approval queue)
+//   - /customer/marketing/strategy → getPlaybook + fit over strategy artifacts
+//   - /customer/marketing/campaigns → buildMarketingCampaignsView (imported/test flag)
+//
+// BI-CC580161: saved campaign artifacts, proof prompts, draft review, and
+// publish readiness must be scoped to the current organization and archetype.
+
+import { describe, expect, it } from "vitest";
+
+import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+import { getPlaybook } from "@/lib/tak/marketing-playbooks";
+import { assessArchetypeFit } from "./archetype-fit";
+import { buildMarketingOwnerDecision } from "./next-decision";
+import { buildMarketingCampaignsView } from "./subroutes";
+
+const now = new Date("2026-07-22T12:00:00.000Z");
+
+const LEAK_BODY =
+  "Build Studio helps technical founders ship software with an AI workflow — powered by our SaaS platform.";
+const CLEAN_BODY =
+  "Reserve a table for our autumn tasting menu and fill quiet midweek covers. Our five-star reviews speak for themselves.";
+
+function restaurantSnapshot(): MarketingWorkspaceSnapshot {
+  return {
+    organization: { id: "org-r", name: "The Copper Table", website: null, addressSummary: "Leeds" },
+    storefront: {
+      id: "sf-r",
+      archetypeId: "restaurant",
+      archetypeName: "Restaurant",
+      category: "food-hospitality",
+      tagline: "Seasonal neighbourhood dining",
+      description: null,
+      ctaType: "booking",
+    },
+    strategy: {
+      strategyId: "st-r",
+      status: "active",
+      primaryGoal: "Fill covers during quiet periods",
+      routeToMarket: "inbound",
+      localityModel: "hyperlocal",
+      geographicScope: "Leeds",
+      primaryChannels: ["email", "instagram"],
+      secondaryChannels: [],
+      differentiators: ["Seasonal menu", "Local sourcing"],
+      reviewCadence: "monthly",
+      lastReviewedAt: now,
+      nextReviewAt: new Date("2026-08-22T12:00:00.000Z"),
+      sourceSummary: null,
+      specialistNotes: null,
+      seasonalityNotes: null,
+      targetSegments: [{ name: "Local diners", description: null }],
+      idealCustomerProfiles: [],
+      entryOffers: [],
+      proofAssets: [{ type: "testimonial", label: "Five-star reviews" }],
+      serviceTerritories: [],
+      constraints: null,
+    },
+    latestReview: {
+      reviewType: "ai-proactive",
+      summary: "Focus on midweek covers",
+      createdAt: now,
+      suggestedActions: [],
+      recommendation: null,
+    },
+    workProducts: {
+      campaignBriefs: [
+        {
+          briefId: "brief-leak",
+          title: "Reach technical founders with our AI workflow",
+          objective: "Show how Build Studio ships software",
+          audience: "technical founders",
+          channels: ["linkedin"],
+          cta: "Book a demo",
+          proofAssets: [],
+          kpis: [],
+          notes: "Position the SaaS platform.",
+          status: "draft",
+          createdAt: now,
+        },
+        {
+          briefId: "brief-clean",
+          title: "Fill quiet midweek covers with a seasonal tasting menu",
+          objective: "Lift midweek bookings",
+          audience: "local diners",
+          channels: ["email"],
+          cta: "Reserve a table",
+          proofAssets: [],
+          kpis: ["Booking fill rate"],
+          notes: "Feature our reviews.",
+          status: "draft",
+          createdAt: now,
+        },
+      ],
+      assetTasks: [],
+      kpiCheckpoints: [],
+      automationCandidates: [],
+    },
+    pendingDrafts: [
+      {
+        draftId: "draft-leak",
+        sourceType: "marketing-asset-task",
+        sourceId: "t-leak",
+        assetTaskTitle: "LinkedIn post",
+        channelId: "linkedin",
+        assetType: "linkedin-post",
+        status: "pending-review",
+        body: LEAK_BODY,
+        bodyFormat: "markdown",
+        createdByAgentId: "AGT",
+        createdAt: now,
+      },
+    ],
+    approvedDrafts: [],
+    connectedChannels: [],
+    inboundMessages: [],
+    staleAreas: [],
+  };
+}
+
+describe("Restaurant marketing archetype scoping (BI-CC580161)", () => {
+  it("/customer/marketing: first-viewport decision is restaurant-scoped, not DPF/software", () => {
+    const snapshot = restaurantSnapshot();
+    const playbook = getPlaybook(snapshot.storefront.category, snapshot.storefront.ctaType);
+    const decision = buildMarketingOwnerDecision(snapshot, playbook);
+
+    // Pending drafts exist → the one next decision is to review them.
+    expect(decision.id).toBe("review-drafts");
+    expect(decision.metricFocus.toLowerCase()).toMatch(/covers|booking/);
+    const decisionText = `${decision.headline} ${decision.detail} ${decision.metricFocus}`.toLowerCase();
+    expect(decisionText).not.toMatch(/build studio|technical founder|ai workflow|saas/);
+  });
+
+  it("/customer/marketing: approval queue blocks a platform-leak draft, passes clean copy", () => {
+    const category = restaurantSnapshot().storefront.category;
+    expect(assessArchetypeFit({ text: LEAK_BODY, category }).blocked).toBe(true);
+    expect(assessArchetypeFit({ text: CLEAN_BODY, category }).severity).toBe("ok");
+  });
+
+  it("/strategy: playbook + strategy artifacts use food-hospitality concepts", () => {
+    const snapshot = restaurantSnapshot();
+    const playbook = getPlaybook(snapshot.storefront.category, snapshot.storefront.ctaType);
+
+    // Playbook is the restaurant one — covers, bookings, no-show, reviews.
+    expect(playbook.keyMetrics.join(" ").toLowerCase()).toMatch(/covers|booking fill|no-show/);
+    expect(playbook.ctaLanguage.join(" ").toLowerCase()).toMatch(/reserve a table|menu/);
+
+    // Clean strategy content passes; a platform-leak differentiator is caught.
+    const cleanStrategyText = [snapshot.strategy.primaryGoal, ...snapshot.strategy.differentiators].join(" ");
+    expect(assessArchetypeFit({ text: cleanStrategyText, category: snapshot.storefront.category }).severity).toBe(
+      "ok",
+    );
+    expect(
+      assessArchetypeFit({ text: "Differentiator: our AI workflow", category: snapshot.storefront.category })
+        .blocked,
+    ).toBe(true);
+  });
+
+  it("/campaigns: saved briefs are flagged imported/test when off-archetype, clean ones pass", () => {
+    const view = buildMarketingCampaignsView(restaurantSnapshot());
+    const leak = view.campaigns.find((c) => c.id === "brief-leak");
+    const clean = view.campaigns.find((c) => c.id === "brief-clean");
+
+    expect(leak?.archetypeFit.blocked).toBe(true);
+    expect(clean?.archetypeFit.severity).toBe("ok");
+    expect(view.importedTestCount).toBe(1);
+  });
+});

--- a/apps/web/lib/marketing/draft-builder.ts
+++ b/apps/web/lib/marketing/draft-builder.ts
@@ -16,6 +16,7 @@ import {
   type OutboundDraftStatus,
 } from "./execution";
 import { getMarketingWorkspaceSnapshot } from "../marketing";
+import { getPlaybook } from "@/lib/tak/marketing-playbooks";
 
 export type DraftMarketingAssetResult =
   | {
@@ -34,9 +35,9 @@ const LINKEDIN_POST_GUIDE = `LinkedIn post shape:
 - Hook in line 1 — pain-led, specific, no generic openers like "I've been thinking…".
 - Target 180–280 words. Concrete examples beat abstractions.
 - Use short paragraphs (1–3 lines). Whitespace makes mobile readable.
-- 0–3 hashtags max, only ones a technical-founder audience would actually search.
-- Exactly one call to action at the end. Comment-trigger CTAs ("comment 'X' for the checklist") perform well for inquiry.
-- No emoji-flood, no "🚀". Confident founder voice, not corporate marketing voice.`;
+- 0–3 hashtags max, only ones this business's actual audience would search.
+- Exactly one call to action at the end, matching the business's booking/inquiry/purchase motion.
+- No emoji-flood, no "🚀". Use the business's own voice, not generic corporate marketing voice.`;
 
 const EMAIL_GUIDE = `Email shape:
 - First line: subject (prefix with "Subject: "). Concise, curiosity-led, no clickbait.
@@ -108,15 +109,31 @@ export async function draftMarketingAsset(input: {
   const proof =
     snapshot.strategy.proofAssets[0]?.label ?? null;
 
+  // Archetype voice: the drafter must speak in THIS business's language, not
+  // generic software-startup voice. The playbook supplies the stakeholders,
+  // tone, and CTA vocabulary for the active archetype (e.g. a restaurant markets
+  // covers, bookings, menus and seasonal offers — never "technical founders").
+  const playbook = getPlaybook(snapshot.storefront.category, snapshot.storefront.ctaType);
+  const archetypeVoice = `This business is a ${
+    snapshot.storefront.archetypeName ?? snapshot.storefront.category ?? "local business"
+  }.
+- Audience: ${playbook.stakeholders}.
+- Voice: ${playbook.contentTone}.
+- Speak in this business's own concepts. Preferred calls to action: ${playbook.ctaLanguage.join(", ")}.
+- NEVER use software-platform language (Build Studio, technical founders, AI workflow, SaaS, software platform). This is a real business marketing to real customers.`;
+
   const systemPrompt = `You are a senior marketing copywriter producing channel-shaped, ready-to-publish copy from a marketing brief.
 
 You produce the body the human will review next. Do NOT produce meta-commentary, options, or "here are three variants" — produce ONE draft, the one you'd publish if you had the authority. The human reviews and edits before any external publish.
 
 ${shapingGuide(task.assetType)}
 
+Business voice (stay inside this — it defines who you are writing as):
+${archetypeVoice}
+
 Constraints:
 - Stay grounded in the brief and the positioning. Do not invent product features that aren't in the brief.
-- Use the strategist's stakeholder language. If the audience term is "technical founders", do not say "SMB owners".
+- Use the strategist's stakeholder language and the business voice above.
 - No placeholders like [Insert X] except the explicit signer placeholder in email sign-offs.`;
 
   const userPrompt = `Brief title: ${task.title}

--- a/apps/web/lib/marketing/fit-guard.ts
+++ b/apps/web/lib/marketing/fit-guard.ts
@@ -1,0 +1,58 @@
+// Server-side archetype-fit guard.
+//
+// Client warnings can be bypassed, so the hard block on publishing off-archetype
+// / software-platform content must be enforced where the state actually
+// changes: at Approve and at Publish/Send. This module resolves the active
+// archetype category for a draft's organization and runs the pure
+// assessArchetypeFit engine against the content the operator is about to
+// release.
+
+import { prisma } from "@dpf/db";
+import { assessArchetypeFit, type ArchetypeFitAssessment } from "./archetype-fit";
+
+/** Resolve the active storefront archetype category for an organization. */
+export async function resolveOrgArchetypeCategory(
+  organizationId: string,
+): Promise<string | null> {
+  const organization = await prisma.organization.findUnique({
+    where: { id: organizationId },
+    select: {
+      storefrontConfig: {
+        select: { archetype: { select: { category: true } } },
+      },
+    },
+  });
+  return organization?.storefrontConfig?.archetype?.category ?? null;
+}
+
+export type DraftFitGuardResult =
+  | { ok: true; assessment: ArchetypeFitAssessment }
+  | { ok: false; error: string; assessment: ArchetypeFitAssessment };
+
+/**
+ * Assess the fit of the content that is about to be released for a draft.
+ * `contentOverride` lets Approve check the operator's edited body (they may
+ * have fixed the leak) rather than the stored body.
+ */
+export async function guardDraftArchetypeFit(input: {
+  draftId: string;
+  contentOverride?: string | null;
+}): Promise<DraftFitGuardResult | null> {
+  const draft = await prisma.outboundDraft.findUnique({
+    where: { draftId: input.draftId },
+    select: { body: true, organizationId: true },
+  });
+  if (!draft) return null;
+
+  const category = await resolveOrgArchetypeCategory(draft.organizationId);
+  const text =
+    input.contentOverride && input.contentOverride.trim().length > 0
+      ? input.contentOverride
+      : draft.body;
+  const assessment = assessArchetypeFit({ text, category });
+
+  if (assessment.blocked) {
+    return { ok: false, error: assessment.summary, assessment };
+  }
+  return { ok: true, assessment };
+}

--- a/apps/web/lib/marketing/next-decision.test.ts
+++ b/apps/web/lib/marketing/next-decision.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+import { getPlaybook } from "@/lib/tak/marketing-playbooks";
+import { buildMarketingOwnerDecision } from "./next-decision";
+
+const now = new Date("2026-07-22T12:00:00.000Z");
+const playbook = getPlaybook("food-hospitality", "booking");
+
+function restaurantSnapshot(
+  overrides: Partial<MarketingWorkspaceSnapshot> = {},
+): MarketingWorkspaceSnapshot {
+  const base: MarketingWorkspaceSnapshot = {
+    organization: { id: "org-r", name: "The Copper Table", website: null, addressSummary: "Leeds" },
+    storefront: {
+      id: "sf-r",
+      archetypeId: "restaurant",
+      archetypeName: "Restaurant",
+      category: "food-hospitality",
+      tagline: "Seasonal neighbourhood dining",
+      description: null,
+      ctaType: "booking",
+    },
+    strategy: {
+      strategyId: "st-r",
+      status: "active",
+      primaryGoal: "Fill covers during quiet periods",
+      routeToMarket: "inbound",
+      localityModel: "hyperlocal",
+      geographicScope: "Leeds",
+      primaryChannels: ["email", "instagram"],
+      secondaryChannels: [],
+      differentiators: [],
+      reviewCadence: "monthly",
+      lastReviewedAt: now,
+      nextReviewAt: new Date("2026-08-22T12:00:00.000Z"),
+      sourceSummary: null,
+      specialistNotes: null,
+      seasonalityNotes: null,
+      targetSegments: [{ name: "Local diners", description: null }],
+      idealCustomerProfiles: [],
+      entryOffers: [],
+      proofAssets: [{ type: "testimonial", label: "Five-star reviews" }],
+      serviceTerritories: [],
+      constraints: null,
+    },
+    latestReview: {
+      reviewType: "ai-proactive",
+      summary: "Focus on midweek covers",
+      createdAt: now,
+      suggestedActions: [],
+      recommendation: null,
+    },
+    workProducts: {
+      campaignBriefs: [
+        {
+          briefId: "b1",
+          title: "Midweek covers",
+          objective: "Lift quiet nights",
+          audience: "Local diners",
+          channels: ["email"],
+          cta: "Reserve a table",
+          proofAssets: [],
+          kpis: [],
+          notes: null,
+          status: "draft",
+          createdAt: now,
+        },
+      ],
+      assetTasks: [],
+      kpiCheckpoints: [],
+      automationCandidates: [],
+    },
+    pendingDrafts: [],
+    approvedDrafts: [],
+    connectedChannels: [],
+    inboundMessages: [],
+    staleAreas: [],
+  };
+  return { ...base, ...overrides };
+}
+
+describe("buildMarketingOwnerDecision", () => {
+  it("prioritises reviewing pending drafts, phrased for diners", () => {
+    const decision = buildMarketingOwnerDecision(
+      restaurantSnapshot({
+        pendingDrafts: [
+          {
+            draftId: "d1",
+            sourceType: "marketing-asset-task",
+            sourceId: "t1",
+            assetTaskTitle: "Post",
+            channelId: "email",
+            assetType: "email",
+            status: "pending-review",
+            body: "Reserve a table",
+            bodyFormat: "markdown",
+            createdByAgentId: "AGT",
+            createdAt: now,
+          },
+        ],
+      }),
+      playbook,
+    );
+    expect(decision.id).toBe("review-drafts");
+    expect(decision.headline).toContain("diners");
+    expect(decision.metricFocus).toBe(playbook.keyMetrics[0]);
+  });
+
+  it("surfaces publishing when approved drafts wait", () => {
+    const decision = buildMarketingOwnerDecision(
+      restaurantSnapshot({
+        approvedDrafts: [
+          {
+            draftId: "d2",
+            sourceType: "marketing-asset-task",
+            sourceId: "t2",
+            assetTaskTitle: "Post",
+            channelId: "email",
+            assetType: "email",
+            status: "approved",
+            body: "Reserve a table",
+            bodyFormat: "markdown",
+            createdByAgentId: "AGT",
+            createdAt: now,
+          },
+        ],
+      }),
+      playbook,
+    );
+    expect(decision.id).toBe("publish-approved");
+  });
+
+  it("asks for a first strategy review when none exists", () => {
+    const decision = buildMarketingOwnerDecision(
+      restaurantSnapshot({ latestReview: null }),
+      playbook,
+    );
+    expect(decision.id).toBe("run-first-review");
+    expect(decision.detail.toLowerCase()).toContain("covers");
+  });
+
+  it("asks to create the first campaign when strategy exists but no briefs", () => {
+    const decision = buildMarketingOwnerDecision(
+      restaurantSnapshot({
+        workProducts: {
+          campaignBriefs: [],
+          assetTasks: [],
+          kpiCheckpoints: [],
+          automationCandidates: [],
+        },
+      }),
+      playbook,
+    );
+    expect(decision.id).toBe("create-first-campaign");
+    expect(decision.headline).toContain(playbook.campaignTypes[0]!);
+  });
+
+  it("asks to choose proof when none is saved", () => {
+    const snap = restaurantSnapshot();
+    snap.strategy.proofAssets = [];
+    const decision = buildMarketingOwnerDecision(snap, playbook);
+    expect(decision.id).toBe("choose-proof");
+    expect(decision.headline.toLowerCase()).toContain("review");
+  });
+
+  it("falls back to planning the next seasonal push when steady-state", () => {
+    const decision = buildMarketingOwnerDecision(restaurantSnapshot(), playbook);
+    expect(decision.id).toBe("plan-seasonal");
+  });
+});

--- a/apps/web/lib/marketing/next-decision.ts
+++ b/apps/web/lib/marketing/next-decision.ts
@@ -1,0 +1,143 @@
+// Marketing "one next decision" for the owner's first viewport.
+//
+// The /customer/marketing page must open with a single, archetype-scoped next
+// decision — the one thing this business owner should do next, phrased in their
+// own vocabulary (a restaurant owner sees covers, bookings, quiet services and
+// reviews, not "campaign brief #2"). The decision is derived from the saved
+// marketing state plus the active archetype playbook, so it stays correct as
+// the workspace advances (drafts to review → publish → strategy gaps → first
+// campaign → seasonal push).
+
+import type { MarketingPlaybook } from "@/lib/tak/marketing-playbooks";
+import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+
+export type MarketingOwnerDecision = {
+  id:
+    | "review-drafts"
+    | "publish-approved"
+    | "run-first-review"
+    | "create-first-campaign"
+    | "choose-proof"
+    | "plan-seasonal";
+  /** Short, archetype-flavoured decision headline. */
+  headline: string;
+  /** One line of supporting context. */
+  detail: string;
+  ctaLabel: string;
+  ctaHref: string;
+  /** The metric this decision moves, drawn from the archetype playbook. */
+  metricFocus: string;
+};
+
+function count(n: number, singular: string, plural = `${singular}s`): string {
+  return `${n} ${n === 1 ? singular : plural}`;
+}
+
+function proofNoun(playbook: MarketingPlaybook): string {
+  // Restaurants feature reviews; most local businesses lean on the same idea.
+  const joined = playbook.campaignTypes.join(" ").toLowerCase();
+  if (joined.includes("review")) return "reviews and testimonials";
+  if (joined.includes("case stud")) return "case studies";
+  return "proof (reviews, testimonials, or outcomes)";
+}
+
+/**
+ * Compute the single next decision to surface in the first viewport.
+ * Priority runs from the most time-sensitive owner action (drafts waiting on
+ * them) down to steady-state planning.
+ */
+export function buildMarketingOwnerDecision(
+  snapshot: MarketingWorkspaceSnapshot,
+  playbook: MarketingPlaybook,
+): MarketingOwnerDecision {
+  const metricFocus = playbook.keyMetrics[0] ?? "Customer acquisition";
+  const firstCampaign = playbook.campaignTypes[0] ?? "your first campaign";
+  const pending = snapshot.pendingDrafts.length;
+  const approved = snapshot.approvedDrafts.length;
+  const hasReview = Boolean(snapshot.latestReview);
+  const reviewOverdue = snapshot.staleAreas.some((area) =>
+    area.toLowerCase().includes("review"),
+  );
+  const briefCount = snapshot.workProducts.campaignBriefs.length;
+  const proofCount = snapshot.strategy.proofAssets.length;
+
+  if (pending > 0) {
+    return {
+      id: "review-drafts",
+      headline: `Review ${count(pending, "draft")} before ${audienceWord(playbook)} see them`,
+      detail:
+        "The Marketing Strategist has copy waiting for your approval. Nothing goes out until you approve it.",
+      ctaLabel: "Review drafts",
+      ctaHref: "/customer/marketing#marketing-approval-queue",
+      metricFocus,
+    };
+  }
+
+  if (approved > 0) {
+    return {
+      id: "publish-approved",
+      headline: `Publish ${count(approved, "approved post")}`,
+      detail:
+        "Approved copy is ready. Each publish is one explicit action — you stay in control of what goes live.",
+      ctaLabel: "Go to publish queue",
+      ctaHref: "/customer/marketing#marketing-publish-queue",
+      metricFocus,
+    };
+  }
+
+  if (!hasReview || reviewOverdue) {
+    return {
+      id: "run-first-review",
+      headline: "Decide which quiet service to fill first",
+      detail: `Run a strategy review so the plan targets ${playbook.primaryGoal.toLowerCase()}.`,
+      ctaLabel: "Start marketing review",
+      ctaHref: "/customer/marketing#marketing-launcher",
+      metricFocus,
+    };
+  }
+
+  if (briefCount === 0) {
+    return {
+      id: "create-first-campaign",
+      headline: `Turn the plan into your first campaign: ${firstCampaign}`,
+      detail:
+        "You have a strategy but no campaign yet. Ask the strategist to shape the first campaign brief and asset.",
+      ctaLabel: "Plan a campaign",
+      ctaHref: "/customer/marketing/campaigns",
+      metricFocus,
+    };
+  }
+
+  if (proofCount === 0) {
+    return {
+      id: "choose-proof",
+      headline: `Choose the ${proofNoun(playbook)} to feature`,
+      detail:
+        "Campaigns land harder with proof. Pick what makes the offer credible before the next push.",
+      ctaLabel: "Review strategy",
+      ctaHref: "/customer/marketing/strategy",
+      metricFocus,
+    };
+  }
+
+  return {
+    id: "plan-seasonal",
+    headline: `Plan the next push: ${firstCampaign}`,
+    detail:
+      "Strategy and proof are in place. Line up the next seasonal or quiet-period campaign with the strategist.",
+    ctaLabel: "Plan a campaign",
+    ctaHref: "/customer/marketing/campaigns",
+    metricFocus,
+  };
+}
+
+function audienceWord(playbook: MarketingPlaybook): string {
+  const stakeholders = playbook.stakeholders.toLowerCase();
+  if (stakeholders.includes("diner")) return "diners";
+  if (stakeholders.includes("patient")) return "patients";
+  if (stakeholders.includes("member")) return "members";
+  if (stakeholders.includes("donor")) return "donors";
+  if (stakeholders.includes("student")) return "students";
+  if (stakeholders.includes("buyer")) return "buyers";
+  return "customers";
+}

--- a/apps/web/lib/marketing/publish.ts
+++ b/apps/web/lib/marketing/publish.ts
@@ -17,6 +17,8 @@ import {
 } from "./execution";
 import { getAdapter } from "./channels/registry";
 import type { ChannelCredentialBundle } from "./channels/contracts";
+import { assessArchetypeFit } from "./archetype-fit";
+import { resolveOrgArchetypeCategory } from "./fit-guard";
 
 export type PublishApprovedDraftResult =
   | {
@@ -51,6 +53,19 @@ export async function publishApprovedDraft(input: {
       error: "draft_not_approved",
       retryable: false,
       message: `Draft is in status ${JSON.stringify(draft.status)}; only "approved" drafts can be published.`,
+    };
+  }
+
+  // Archetype-fit block: software-platform / off-archetype-block content must
+  // never reach a real audience, even if it somehow reached "approved".
+  const fitCategory = await resolveOrgArchetypeCategory(draft.organizationId);
+  const fit = assessArchetypeFit({ text: draft.body, category: fitCategory });
+  if (fit.blocked) {
+    return {
+      ok: false,
+      error: "archetype_fit_blocked",
+      retryable: false,
+      message: fit.summary,
     };
   }
 

--- a/apps/web/lib/marketing/subroutes.test.ts
+++ b/apps/web/lib/marketing/subroutes.test.ts
@@ -23,6 +23,7 @@ function snapshot(
       id: "storefront-1",
       archetypeId: "expert-services",
       archetypeName: "Expert Services",
+      category: "professional-services",
       tagline: "Proof-led growth",
       description: "Operational advice",
       ctaType: "inquiry",
@@ -157,6 +158,62 @@ describe("marketing subroute view models", () => {
       title: "Draft LinkedIn proof post",
       draftStatusLabel: "Pending review",
     });
+  });
+
+  it("flags saved artifacts that leak software-platform language as imported/test data", () => {
+    const leaky = snapshot({
+      storefront: {
+        id: "storefront-r",
+        archetypeId: "restaurant",
+        archetypeName: "Restaurant",
+        category: "food-hospitality",
+        tagline: "Seasonal dining",
+        description: "Neighbourhood restaurant",
+        ctaType: "booking",
+      },
+      workProducts: {
+        campaignBriefs: [
+          {
+            briefId: "brief-leak",
+            title: "Reach technical founders with our AI workflow",
+            objective: "Explain how Build Studio ships software",
+            audience: "technical founders",
+            channels: ["linkedin"],
+            cta: "Book a demo",
+            proofAssets: [],
+            kpis: [],
+            notes: "Mention the SaaS platform.",
+            status: "draft",
+            createdAt: now,
+          },
+          {
+            briefId: "brief-clean",
+            title: "Fill quiet midweek covers with a seasonal tasting menu",
+            objective: "Lift midweek bookings",
+            audience: "local diners",
+            channels: ["email"],
+            cta: "Reserve a table",
+            proofAssets: [],
+            kpis: [],
+            notes: "Feature our five-star reviews.",
+            status: "draft",
+            createdAt: now,
+          },
+        ],
+        assetTasks: [],
+        kpiCheckpoints: [],
+        automationCandidates: [],
+      },
+      pendingDrafts: [],
+    });
+
+    const view = buildMarketingCampaignsView(leaky);
+    const leak = view.campaigns.find((c) => c.id === "brief-leak");
+    const clean = view.campaigns.find((c) => c.id === "brief-clean");
+
+    expect(leak?.archetypeFit.blocked).toBe(true);
+    expect(clean?.archetypeFit.severity).toBe("ok");
+    expect(view.importedTestCount).toBe(1);
   });
 
   it("aggregates funnel evidence without overstating attribution", () => {

--- a/apps/web/lib/marketing/subroutes.ts
+++ b/apps/web/lib/marketing/subroutes.ts
@@ -9,6 +9,7 @@ import {
   isOpenOpportunityStage,
   OPEN_OPPORTUNITY_STAGES,
 } from "@/lib/crm/presentation";
+import { assessArchetypeFit, type ArchetypeFitAssessment } from "@/lib/marketing/archetype-fit";
 
 export type MarketingMetric = {
   label: string;
@@ -31,6 +32,7 @@ export type MarketingCampaignRow = {
   approvedDraftCount: number;
   nextWorkLabel: string;
   kpis: string[];
+  archetypeFit: ArchetypeFitAssessment;
 };
 
 export type MarketingAssetTaskRow = {
@@ -42,6 +44,7 @@ export type MarketingAssetTaskRow = {
   status: string;
   draftStatusLabel: string;
   brief: string;
+  archetypeFit: ArchetypeFitAssessment;
 };
 
 export type MarketingCampaignsView = {
@@ -49,6 +52,8 @@ export type MarketingCampaignsView = {
   campaigns: MarketingCampaignRow[];
   assetTasks: MarketingAssetTaskRow[];
   hasWork: boolean;
+  /** Count of saved artifacts flagged as imported/test data (blocked from publish). */
+  importedTestCount: number;
 };
 
 export type MarketingFunnelEngagementInput = {
@@ -197,6 +202,7 @@ export function buildMarketingCampaignsView(
   const tasks = snapshot.workProducts.assetTasks;
   const pendingReviewCount = snapshot.pendingDrafts.length;
   const approvedCount = snapshot.approvedDrafts.length;
+  const category = snapshot.storefront.category;
 
   const campaigns = briefs.map((brief) => {
     const matchedTasks = tasks.filter((task) => taskMatchesBrief(task, brief));
@@ -230,6 +236,12 @@ export function buildMarketingCampaignsView(
       approvedDraftCount,
       nextWorkLabel,
       kpis: brief.kpis,
+      archetypeFit: assessArchetypeFit({
+        text: [brief.title, brief.objective, brief.audience, brief.notes, brief.kpis.join(" ")]
+          .filter(Boolean)
+          .join("\n"),
+        category,
+      }),
     };
   });
 
@@ -242,7 +254,15 @@ export function buildMarketingCampaignsView(
     status: task.status,
     draftStatusLabel: draftStatusLabel(task.taskId, snapshot),
     brief: nonEmpty(task.brief, "No saved brief"),
+    archetypeFit: assessArchetypeFit({
+      text: [task.title, task.brief].filter(Boolean).join("\n"),
+      category,
+    }),
   }));
+
+  const importedTestCount =
+    campaigns.filter((c) => c.archetypeFit.blocked).length +
+    assetTasks.filter((t) => t.archetypeFit.blocked).length;
 
   return {
     metrics: [
@@ -271,6 +291,7 @@ export function buildMarketingCampaignsView(
     campaigns,
     assetTasks,
     hasWork: briefs.length > 0 || tasks.length > 0,
+    importedTestCount,
   };
 }
 

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -202,6 +202,28 @@ The common shell chrome that wraps every owner route (`apps/web/app/(shell)/layo
 
 New shell controls, and edits to the existing ones, must be covered by the action-result smoke (`apps/web/components/shell/shell-action-result-contract.test.tsx`), which parameterises the contract across the owner routes.
 
+## Archetype-scoped marketing content (BI-CC580161)
+
+Customer marketing surfaces (`/customer/marketing`, `/customer/marketing/strategy`, `/customer/marketing/campaigns`) must speak in the language of the **organization's own business archetype**. A restaurant markets covers, bookings, menus, seasonal/quiet-period offers and reviews — never software-platform artifacts (Build Studio, technical founders, AI workflow, SaaS, the Digital Product Factory). Bootstrap and imported/test data can leak that vocabulary in; the platform detects and contains it.
+
+### Fit engine (source of truth)
+
+`apps/web/lib/marketing/archetype-fit.ts` — `assessArchetypeFit({ text, category })` returns a deterministic `{ severity: "ok" | "warn" | "block", blocked, findings, summary }`:
+
+- **platform-leak → `block`.** Software-platform / DPF-internal terms are foreign to *every* customer archetype and can never be published. Blocked artifacts are badged **"Imported / test data — blocked from publish"** and cannot pass Approve, Send email, or Publish to LinkedIn.
+- **off-archetype → `warn`.** Vocabulary distinctive to a *different* archetype (e.g. banking "APY", education "enrolment") surfaces a warning to confirm fit before sending; it does not hard-block, because cross-sell copy can be legitimate.
+- The active archetype's own vocabulary never warns.
+
+### Enforcement points
+
+- **Server (authoritative):** `guardDraftArchetypeFit` blocks Approve (`actions.ts`) and `publishApprovedDraft` (`publish.ts`) blocks Publish/Send — client warnings alone are never trusted.
+- **UI:** the approval queue, publish buttons, and saved campaign/asset artifacts (`/campaigns`) render the fit badge/notice and disable release on a hard block.
+- **Drafter:** `draft-builder.ts` derives audience, tone, and CTA vocabulary from the archetype playbook (`lib/tak/marketing-playbooks.ts`) instead of a hardcoded software-founder voice, so generated copy is on-archetype by construction.
+
+### First-viewport decision
+
+`/customer/marketing` opens with **one** archetype-scoped next decision (`lib/marketing/next-decision.ts`, `buildMarketingOwnerDecision`) phrased in the owner's own terms and tied to the archetype's headline metric (e.g. booking fill rate, covers).
+
 ## Standards Referenced
 
 - WCAG 2.2 (W3C Recommendation) — Level AA compliance

--- a/docs/superpowers/plans/2026-07-22-archetype-scoped-marketing-cockpit.md
+++ b/docs/superpowers/plans/2026-07-22-archetype-scoped-marketing-cockpit.md
@@ -1,0 +1,28 @@
+# Plan — Archetype-scoped Restaurant marketing cockpit (BI-CC580161)
+
+## Problem
+
+The customer marketing cockpit (`/customer/marketing`, `/strategy`, `/campaigns`) rendered saved campaign artifacts, proof prompts, draft review, and publish readiness **without scoping to the current organization/archetype**. For a Restaurant / Food & Hospitality business this leaked software-platform (DPF) vocabulary — "Build Studio", "technical founders", "AI workflow", "SaaS" — into artifacts, drafts, and the drafter's own voice. The drafter (`draft-builder.ts`) hardcoded a "technical-founder" audience, so generated copy was off-archetype by construction.
+
+## Source of truth
+
+`docs/platform-usability-standards.md` → new section **"Archetype-scoped marketing content (BI-CC580161)"**. This plan is grounded there; the marketing playbooks (`apps/web/lib/tak/marketing-playbooks.ts`, already carrying a `food-hospitality` playbook) supply the per-archetype vocabulary.
+
+## Design grounding
+
+- **Extends** existing marketing substrate: `lib/marketing.ts` snapshot, `lib/marketing/subroutes.ts` view models, the approval-queue components, and the marketing playbooks. No new tables, routes, or DB migration.
+- New contract module `lib/marketing/archetype-fit.ts` (pure, deterministic) is the single fit authority; a thin server guard (`fit-guard.ts`) enforces it where state changes.
+
+## Phases (implemented)
+
+1. **Fit engine** — `lib/marketing/archetype-fit.ts`: `assessArchetypeFit({text, category})` → `ok | warn | block`. Platform-leak terms block universally; off-archetype signatures (per-category, high-precision) warn; the active archetype's own terms never warn.
+2. **Snapshot** — expose `storefront.category` on `MarketingWorkspaceSnapshot`.
+3. **Owner next decision** — `lib/marketing/next-decision.ts`: one archetype-scoped decision for the first viewport, tied to the playbook's headline metric.
+4. **Server enforcement** — `guardDraftArchetypeFit` blocks Approve (`actions.ts`); `publishApprovedDraft` blocks Publish/Send (`publish.ts`). Client warnings are advisory only.
+5. **UI** — approval queue + publish buttons + `/campaigns` artifacts show the fit badge/notice, badge blocks as "Imported / test data — blocked from publish", and disable release; `/customer/marketing` renders the one next decision first.
+6. **Drafter** — `draft-builder.ts` derives audience/tone/CTA from the archetype playbook instead of a hardcoded founder voice.
+7. **Regression tests** — `archetype-fit.test.ts`, `next-decision.test.ts`, extended `subroutes.test.ts`, and `archetype-scoping.test.ts` covering all three routes.
+
+## Verification
+
+- Pure engine + decision logic verified locally via Node type-stripping harness (11/11 and 10/10 assertions). Full vitest + typecheck run in CI (source-only worktree: `vite`/`vitest` and `@dpf` junctions are partial locally).

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -39,7 +39,7 @@ apps/web/lib/inference/ai-provider-internals.ts	1228
 apps/web/lib/integrate/build-agent-prompts.ts	1064
 apps/web/lib/integrate/build-orchestrator.ts	1751
 apps/web/lib/integrate/sandbox/build-branch.ts	852
-apps/web/lib/marketing.ts	1367
+apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp-tools-backlog.test.ts	874
 apps/web/lib/mcp-tools.ts	2008
 apps/web/lib/mcp/packs/backlog-pack.ts	1318


### PR DESCRIPTION
## What & why

Customer marketing surfaces (`/customer/marketing`, `/customer/marketing/strategy`, `/customer/marketing/campaigns`) rendered saved campaign artifacts, proof prompts, draft review, and publish readiness **without scoping to the current organization/archetype**. For a Restaurant / Food & Hospitality business this leaked software-platform (DPF) vocabulary — Build Studio, technical founders, AI workflow, SaaS — into artifacts and drafts, and the drafter hardcoded a "technical-founder" voice.

BI-CC580161 scopes the whole cockpit to the active archetype.

## Changes

- **Fit engine** — `apps/web/lib/marketing/archetype-fit.ts` (pure, deterministic). `assessArchetypeFit({text, category})` → `ok | warn | block`. Platform-leak terms hard-**block** (badged **"Imported / test data — blocked from publish"**); off-archetype vocabulary **warns**; the active archetype's own terms never warn.
- **Server enforcement** — `guardDraftArchetypeFit` blocks Approve (`actions.ts`); `publishApprovedDraft` blocks Publish to LinkedIn and Send email (`publish.ts`). Client warnings are advisory only.
- **UI** — approval queue, publish buttons, and `/campaigns` artifacts show the fit badge/notice and disable release on a hard block; an imported/test banner summarises flagged artifacts.
- **First viewport** — `/customer/marketing` opens with **one** archetype-scoped owner next decision (`next-decision.ts`), phrased for the restaurant and tied to the playbook's headline metric (covers, booking fill rate).
- **Drafter** — `draft-builder.ts` derives audience/tone/CTA from the archetype playbook (`lib/tak/marketing-playbooks.ts`) instead of a hardcoded software-founder voice.
- **Snapshot** — expose `storefront.category`.

## Acceptance mapping

- Restaurant pages no longer show DPF/software artifacts unless flagged imported/test **and blocked from publish** ✔ (fit engine + server block + badges).
- Food-hospitality concepts (menu, booking/reservation, dining, catering/event package, seasonal/quiet-period offers, reviews, covers, booking fill rate, no-show rate) drive copy via the playbook ✔.
- Archetype-fit warning/block before Approve, Send email, Publish to LinkedIn ✔.
- First viewport shows one Restaurant-owner next decision ✔.
- Regression coverage for `/customer/marketing`, `/strategy`, `/campaigns` ✔ (`archetype-fit.test.ts`, `next-decision.test.ts`, extended `subroutes.test.ts`, `archetype-scoping.test.ts`).

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/plans/2026-07-22-archetype-scoped-marketing-cockpit.md`; `docs/platform-usability-standards.md` (source of truth, updated with an "Archetype-scoped marketing content" section).
- Current code substrate reviewed: `apps/web/lib/marketing.ts`, `apps/web/lib/marketing/subroutes.ts`, `apps/web/lib/marketing/draft-builder.ts`, `apps/web/lib/tak/marketing-playbooks.ts`, `apps/web/components/customer-marketing/`.
- Decision: extend existing marketing substrate; no new tables/routes/migration; one pure fit contract module + a thin server guard.

## Verification

- Full `tsc --noEmit` for `apps/web`: **clean, 0 errors** (pre-commit typecheck passed).
- Fit engine + owner-decision logic verified locally (11/11 and 10/10 assertions). Full vitest runs in CI (source-only worktree can't run vite/vitest locally).

Docs-Impact-Decision: internal marketing-cockpit guardrail; standards doc + plan updated, no user-guide surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)