### PR TITLE
feat(storefront): graphical restaurant floor plan on Tables & Capacity (BI-287AA5F7)

### DIFF
--- a/apps/web/app/(shell)/storefront/tables/page.tsx
+++ b/apps/web/app/(shell)/storefront/tables/page.tsx
@@ -2,8 +2,9 @@ import Link from "next/link";
 import { prisma } from "@dpf/db";
 import { redirect } from "next/navigation";
 
-import { StatCard, StatusBadge } from "@/components/ui/report-kit";
+import { StatCard } from "@/components/ui/report-kit";
 import { intentStyle } from "@/components/ui/report-kit/statusColors";
+import { TablesNowView } from "@/components/storefront-admin/TablesNowView";
 import { TeamManager } from "@/components/storefront-admin/TeamManager";
 import { getVocabulary } from "@/lib/storefront/archetype-vocabulary";
 import { resolveResourceVocabulary } from "@/lib/storefront/resource-vocabulary";
@@ -126,32 +127,9 @@ export default async function TablesCapacityPage() {
         </div>
       )}
 
-      {/* Live table state — reconciles with Workspace and public booking. */}
-      {snapshot && snapshot.tables.length > 0 && (
-        <div className="border border-[var(--dpf-border)]" style={{ borderRadius: 10, overflow: "hidden" }}>
-          <div className="bg-[var(--dpf-surface-1)] border-b border-[var(--dpf-border)]" style={{ padding: "10px 14px", fontSize: 13, fontWeight: 600 }}>
-            Tables right now
-          </div>
-          <div>
-            {snapshot.tables.map((t) => (
-              <div
-                key={t.key}
-                className="border-b border-[var(--dpf-border)]"
-                style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 14px" }}
-              >
-                <div style={{ flex: 1, fontSize: 14 }}>
-                  {t.label}
-                  {t.seats != null && <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}> · {t.seats} seats</span>}
-                </div>
-                {t.state === "turning-soon" && t.freeInMinutes != null && (
-                  <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>free in {t.freeInMinutes}m</span>
-                )}
-                <StatusBadge intent={capacityStateIntent(t.state)} label={capacityStateLabel(t.state)} variant="soft" />
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+      {/* Live table state — graphical floor plan or list, one shared projection
+          so both reconcile with Workspace and public booking. */}
+      {snapshot && snapshot.tables.length > 0 && <TablesNowView tables={snapshot.tables} />}
 
       {/* Manage the physical tables (add / edit / block). */}
       <div style={{ marginTop: 4 }}>

--- a/apps/web/components/storefront-admin/TablesNowView.tsx
+++ b/apps/web/components/storefront-admin/TablesNowView.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+// "Tables right now" — the owner's live capacity, as either a graphical floor
+// plan (the facsimile: which tables are open / turning soon, at a glance) or the
+// legible list. Both render the SAME `RestaurantTable[]` projection, so they
+// reconcile by construction. Floor plan is the default; the list stays for
+// scan-and-act. EP-SPATIAL-OPERATIONAL-VIEWS (BI-287AA5F7) increment 1.
+
+import { useMemo, useState, type ReactNode } from "react";
+
+import { StatusBadge } from "@/components/ui/report-kit";
+import { FloorPlanCanvas } from "@/components/twin/floor/FloorPlanCanvas";
+import { layoutRestaurantFloor } from "@/lib/storefront/floor-layout";
+import {
+  capacityStateIntent,
+  capacityStateLabel,
+  type RestaurantTable,
+} from "@/lib/storefront/restaurant-capacity";
+
+type View = "floor" | "list";
+
+export interface TablesNowViewProps {
+  tables: RestaurantTable[];
+}
+
+export function TablesNowView({ tables }: TablesNowViewProps) {
+  const [view, setView] = useState<View>("floor");
+  const scene = useMemo(() => layoutRestaurantFloor(tables), [tables]);
+
+  return (
+    <div className="border border-[var(--dpf-border)]" style={{ borderRadius: 10, overflow: "hidden" }}>
+      <div
+        className="bg-[var(--dpf-surface-1)] border-b border-[var(--dpf-border)]"
+        style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px" }}
+      >
+        <div style={{ flex: 1, fontSize: 13, fontWeight: 600 }}>Tables right now</div>
+        <div role="tablist" aria-label="Table view" style={{ display: "flex", gap: 4 }}>
+          <ViewTab current={view} value="floor" onSelect={setView}>
+            Floor plan
+          </ViewTab>
+          <ViewTab current={view} value="list" onSelect={setView}>
+            List
+          </ViewTab>
+        </div>
+      </div>
+
+      {view === "floor" ? (
+        <FloorPlanCanvas scene={scene} />
+      ) : (
+        <div>
+          {tables.map((t) => (
+            <div
+              key={t.key}
+              className="border-b border-[var(--dpf-border)]"
+              style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 14px" }}
+            >
+              <div style={{ flex: 1, fontSize: 14 }}>
+                {t.label}
+                {t.seats != null && (
+                  <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>
+                    {" "}
+                    · {t.seats} seats
+                  </span>
+                )}
+              </div>
+              {t.state === "turning-soon" && t.freeInMinutes != null && (
+                <span className="text-[var(--dpf-muted)]" style={{ fontSize: 12 }}>
+                  free in {t.freeInMinutes}m
+                </span>
+              )}
+              <StatusBadge
+                intent={capacityStateIntent(t.state)}
+                label={capacityStateLabel(t.state)}
+                variant="soft"
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ViewTab({
+  current,
+  value,
+  onSelect,
+  children,
+}: {
+  current: View;
+  value: View;
+  onSelect: (v: View) => void;
+  children: ReactNode;
+}) {
+  const active = current === value;
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={() => onSelect(value)}
+      className={
+        active
+          ? "bg-[var(--dpf-accent)] text-white"
+          : "bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] border border-[var(--dpf-border)]"
+      }
+      style={{ padding: "4px 10px", borderRadius: 6, fontSize: 12, fontWeight: 600, cursor: "pointer" }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/components/twin/floor/FloorPlanCanvas.tsx
+++ b/apps/web/components/twin/floor/FloorPlanCanvas.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+// Cartesian floor-plan renderer (EP-SPATIAL-OPERATIONAL-VIEWS §4.1).
+// The reusable "operate mode" surface: given a positioned `FloorScene`, draw the
+// zones as backdrops and the resource units (tables) as status-coloured nodes on
+// the platform's one canvas engine — React Flow (`@xyflow/react`), the same
+// substrate as the EA canvas. Read-only here; the authoring editor (drag/resize
+// + persisted geometry via OperationalSceneLayout) is the next increment.
+
+import { useMemo } from "react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  type Node,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+import type { FloorScene } from "@/lib/storefront/floor-layout";
+
+import { FloorZoneNode } from "./FloorZoneNode";
+import { TableFloorNode } from "./TableFloorNode";
+
+const NODE_TYPES = { table: TableFloorNode, zone: FloorZoneNode };
+
+function sceneToNodes(scene: FloorScene): Node[] {
+  // Zones first so they paint behind the tables.
+  const zoneNodes: Node[] = scene.zones.map((z) => ({
+    id: `zone-${z.section}`,
+    type: "zone",
+    position: { x: z.x, y: z.y },
+    data: { label: z.label, w: z.w, h: z.h },
+    draggable: false,
+    selectable: false,
+    connectable: false,
+    zIndex: 0,
+  }));
+  const tableNodes: Node[] = scene.placements.map((p) => ({
+    id: p.key,
+    type: "table",
+    position: { x: p.x, y: p.y },
+    data: {
+      label: p.label,
+      seats: p.seats,
+      shape: p.shape,
+      w: p.w,
+      h: p.h,
+      state: p.state,
+      stateLabel: p.stateLabel,
+      intent: p.intent,
+      freeInMinutes: p.freeInMinutes,
+    },
+    draggable: false,
+    selectable: false,
+    connectable: false,
+    zIndex: 1,
+  }));
+  return [...zoneNodes, ...tableNodes];
+}
+
+export interface FloorPlanCanvasProps {
+  scene: FloorScene;
+  /** Canvas height in px (the width fills its container). */
+  height?: number;
+}
+
+export function FloorPlanCanvas({ scene, height = 520 }: FloorPlanCanvasProps) {
+  const nodes = useMemo(() => sceneToNodes(scene), [scene]);
+
+  return (
+    <div
+      className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]"
+      style={{ height, borderRadius: 10, overflow: "hidden" }}
+    >
+      <ReactFlow
+        nodes={nodes}
+        edges={[]}
+        nodeTypes={NODE_TYPES}
+        fitView
+        fitViewOptions={{ padding: 0.15 }}
+        minZoom={0.2}
+        maxZoom={2}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        panOnScroll
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background gap={24} color="var(--dpf-border)" />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/apps/web/components/twin/floor/FloorZoneNode.tsx
+++ b/apps/web/components/twin/floor/FloorZoneNode.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+// A named floor region (dining room, window, bar…) rendered as a soft labelled
+// backdrop behind the tables. Non-interactive; purely orientational.
+
+import { memo } from "react";
+import type { NodeProps } from "@xyflow/react";
+
+import type { FloorZone } from "@/lib/storefront/floor-layout";
+
+export type FloorZoneNodeData = Pick<FloorZone, "label" | "w" | "h">;
+
+function FloorZoneNodeImpl({ data }: NodeProps) {
+  const d = data as unknown as FloorZoneNodeData;
+  return (
+    <div
+      style={{
+        width: d.w,
+        height: d.h,
+        borderRadius: 14,
+        border: "1px dashed var(--dpf-border)",
+        background: "var(--dpf-surface-1)",
+        boxSizing: "border-box",
+        position: "relative",
+      }}
+    >
+      <span
+        className="text-[var(--dpf-muted)]"
+        style={{
+          position: "absolute",
+          top: 8,
+          left: 12,
+          fontSize: 10,
+          fontWeight: 600,
+          textTransform: "uppercase",
+          letterSpacing: "0.12em",
+        }}
+      >
+        {d.label}
+      </span>
+    </div>
+  );
+}
+
+export const FloorZoneNode = memo(FloorZoneNodeImpl);

--- a/apps/web/components/twin/floor/TableFloorNode.tsx
+++ b/apps/web/components/twin/floor/TableFloorNode.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+// One table on the cartesian floor plan (EP-SPATIAL-OPERATIONAL-VIEWS, FLOOR).
+// A React Flow custom node whose footprint, shape, and colour come entirely from
+// the positioned `FloorPlacement` — live status via the shared `intentStyle`
+// tokens, never a local colour map (AGENTS.md §12).
+
+import { memo } from "react";
+import type { NodeProps } from "@xyflow/react";
+
+import { intentStyle } from "@/components/ui/report-kit/statusColors";
+
+import type { FloorPlacement } from "@/lib/storefront/floor-layout";
+
+export type TableFloorNodeData = Pick<
+  FloorPlacement,
+  "label" | "seats" | "shape" | "w" | "h" | "state" | "stateLabel" | "intent" | "freeInMinutes"
+>;
+
+function shapeRadius(shape: FloorPlacement["shape"], w: number, h: number): string {
+  if (shape === "round") return "50%";
+  if (shape === "bar") return `${Math.min(w, h) / 2}px`; // pill
+  if (shape === "booth") return "12px";
+  return "8px"; // square
+}
+
+function TableFloorNodeImpl({ data }: NodeProps) {
+  const d = data as unknown as TableFloorNodeData;
+  const style = intentStyle(d.intent);
+  const isTurning = d.state === "turning-soon" && d.freeInMinutes != null;
+
+  return (
+    <div
+      title={`${d.label}${d.seats != null ? ` · ${d.seats} seats` : ""} — ${d.stateLabel}`}
+      style={{
+        width: d.w,
+        height: d.h,
+        borderRadius: shapeRadius(d.shape, d.w, d.h),
+        border: `2px solid ${style.border}`,
+        background: style.softBg,
+        color: "var(--dpf-text)",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 1,
+        padding: 4,
+        textAlign: "center",
+        overflow: "hidden",
+        boxSizing: "border-box",
+      }}
+    >
+      <span style={{ fontSize: 11, fontWeight: 700, lineHeight: 1.1 }}>{d.label}</span>
+      {d.seats != null && (
+        <span style={{ fontSize: 9, color: "var(--dpf-muted)" }}>{d.seats} seats</span>
+      )}
+      {isTurning ? (
+        <span style={{ fontSize: 9, fontWeight: 600, color: style.fg }}>{d.freeInMinutes}m</span>
+      ) : (
+        <span style={{ fontSize: 9, color: style.fg }}>{d.stateLabel}</span>
+      )}
+    </div>
+  );
+}
+
+export const TableFloorNode = memo(TableFloorNodeImpl);

--- a/apps/web/lib/storefront/floor-layout.test.ts
+++ b/apps/web/lib/storefront/floor-layout.test.ts
@@ -1,0 +1,101 @@
+// apps/web/lib/storefront/floor-layout.test.ts
+import { describe, expect, it } from "vitest";
+
+import {
+  inferSectionShape,
+  layoutRestaurantFloor,
+  tableSize,
+  type FloorSection,
+} from "./floor-layout";
+import type { RestaurantTable, TableCapacityState } from "./restaurant-capacity";
+
+function table(
+  label: string,
+  state: TableCapacityState = "available",
+  seats: number | null = 2,
+  freeInMinutes: number | null = null,
+): RestaurantTable {
+  return { key: label.toLowerCase().replace(/\s+/g, "-"), label, seats, state, freeInMinutes };
+}
+
+describe("inferSectionShape", () => {
+  it("routes seating vocabulary to sections without any new data", () => {
+    expect(inferSectionShape("Window 2").section).toBe<FloorSection>("window");
+    expect(inferSectionShape("Patio 5").section).toBe<FloorSection>("patio");
+    expect(inferSectionShape("Bar seat 3").section).toBe<FloorSection>("bar");
+    expect(inferSectionShape("Booth 1").section).toBe<FloorSection>("booth");
+    expect(inferSectionShape("Table 4").section).toBe<FloorSection>("main");
+  });
+
+  it("gives the bar and booth their own shapes", () => {
+    expect(inferSectionShape("Bar seat 3").shape).toBe("bar");
+    expect(inferSectionShape("Booth 1").shape).toBe("booth");
+    expect(inferSectionShape("Table 4").shape).toBe("round");
+  });
+});
+
+describe("tableSize", () => {
+  it("scales with seats and is null-safe", () => {
+    const two = tableSize(2, "round");
+    const eight = tableSize(8, "round");
+    expect(eight.w).toBeGreaterThan(two.w);
+    expect(tableSize(null, "round")).toEqual(tableSize(2, "round"));
+  });
+
+  it("clamps within shape bounds", () => {
+    expect(tableSize(999, "round").w).toBeLessThanOrEqual(132);
+    expect(tableSize(0, "round").w).toBeGreaterThanOrEqual(64);
+    expect(tableSize(6, "booth").h).toBe(84);
+  });
+});
+
+describe("layoutRestaurantFloor", () => {
+  it("is total on an empty install", () => {
+    const scene = layoutRestaurantFloor([]);
+    expect(scene.placements).toHaveLength(0);
+    expect(scene.zones).toHaveLength(0);
+    expect(scene.width).toBeGreaterThan(0);
+    expect(scene.height).toBeGreaterThan(0);
+  });
+
+  it("places every table exactly once and carries its live state through", () => {
+    const tables = [
+      table("Table 1", "available"),
+      table("Table 2", "occupied"),
+      table("Window 1", "turning-soon", 2, 8),
+      table("Booth 3", "blocked", 6),
+    ];
+    const scene = layoutRestaurantFloor(tables);
+    expect(scene.placements).toHaveLength(4);
+    expect(new Set(scene.placements.map((p) => p.key)).size).toBe(4);
+    const turning = scene.placements.find((p) => p.key === "window-1")!;
+    expect(turning.state).toBe("turning-soon");
+    expect(turning.freeInMinutes).toBe(8);
+    expect(turning.stateLabel).toBe("Turning soon");
+  });
+
+  it("clusters tables into stable, non-overlapping section bands", () => {
+    const tables = [table("Table 1"), table("Window 1"), table("Bar seat 1"), table("Booth 1")];
+    const scene = layoutRestaurantFloor(tables);
+    const sections = scene.zones.map((z) => z.section);
+    // Window before main before booth before bar — the fixed SECTION_ORDER.
+    expect(sections).toEqual(["window", "main", "booth", "bar"]);
+    // Bands do not vertically overlap.
+    for (let i = 1; i < scene.zones.length; i++) {
+      expect(scene.zones[i].y).toBeGreaterThanOrEqual(scene.zones[i - 1].y + scene.zones[i - 1].h);
+    }
+  });
+
+  it("wraps a section to multiple rows past the column count", () => {
+    const many = Array.from({ length: 15 }, (_, i) => table(`Table ${i + 1}`));
+    const scene = layoutRestaurantFloor(many, { cols: 6 });
+    expect(scene.placements).toHaveLength(15);
+    const rowYs = new Set(scene.placements.map((p) => Math.round(p.y / 10)));
+    expect(rowYs.size).toBeGreaterThanOrEqual(3); // 15 / 6 -> 3 rows
+  });
+
+  it("is deterministic", () => {
+    const tables = [table("Table 1"), table("Window 1"), table("Booth 2", "occupied", 6)];
+    expect(layoutRestaurantFloor(tables)).toEqual(layoutRestaurantFloor(tables));
+  });
+});

--- a/apps/web/lib/storefront/floor-layout.ts
+++ b/apps/web/lib/storefront/floor-layout.ts
@@ -1,0 +1,181 @@
+// apps/web/lib/storefront/floor-layout.ts
+//
+// Pure, deterministic auto-layout that turns the live `RestaurantTable[]`
+// capacity projection (restaurant-capacity.ts) into a positioned floor-plan
+// scene. This is the FLOOR renderer's geometry seam (EP-SPATIAL-OPERATIONAL-VIEWS,
+// BI-287AA5F7): live *state* stays a projection; *geometry* is derived here for
+// the read-only "operate" facsimile. When persisted operator geometry lands
+// (OperationalSceneLayout, increment 2), `layoutRestaurantFloor` becomes the
+// fallback for tables the operator has not yet placed by hand.
+//
+// No new data: section + shape are inferred from the operator's own table label
+// (the same naming the capacity classifier already relies on), so the plan is
+// legible on day one with zero configuration.
+//
+// Spec: docs/superpowers/specs/2026-07-21-spatial-operational-views-design.md §3–4
+
+import type { Intent } from "@/components/ui/report-kit/statusColors";
+
+import {
+  capacityStateIntent,
+  capacityStateLabel,
+  type RestaurantTable,
+  type TableCapacityState,
+} from "./restaurant-capacity";
+
+export type FloorShape = "round" | "square" | "booth" | "bar";
+export type FloorSection = "window" | "main" | "booth" | "bar" | "patio";
+
+/** One positioned table on the floor, ready for the cartesian renderer. */
+export interface FloorPlacement {
+  key: string;
+  label: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  shape: FloorShape;
+  section: FloorSection;
+  seats: number | null;
+  state: TableCapacityState;
+  stateLabel: string;
+  intent: Intent;
+  /** Minutes until a `turning-soon` table frees; null otherwise. */
+  freeInMinutes: number | null;
+}
+
+/** A named region the tables cluster into (rendered as a soft backdrop). */
+export interface FloorZone {
+  section: FloorSection;
+  label: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface FloorScene {
+  placements: FloorPlacement[];
+  zones: FloorZone[];
+  width: number;
+  height: number;
+}
+
+const SECTION_ORDER: readonly FloorSection[] = ["window", "main", "booth", "bar", "patio"];
+
+const SECTION_LABEL: Record<FloorSection, string> = {
+  window: "Window & terrace",
+  main: "Dining room",
+  booth: "Booths",
+  bar: "Bar & counter",
+  patio: "Patio",
+};
+
+// Section/shape inferred from the operator's own label — deterministic, no new
+// field. Mirrors the seating vocabulary the capacity classifier already knows.
+const SECTION_RULES: { rx: RegExp; section: FloorSection; shape: FloorShape }[] = [
+  { rx: /\b(window|terrace)\b/i, section: "window", shape: "square" },
+  { rx: /\b(patio|garden|outdoor)\b/i, section: "patio", shape: "round" },
+  { rx: /\b(bar|counter)\b/i, section: "bar", shape: "bar" },
+  { rx: /\b(booth|banquette|nook)\b/i, section: "booth", shape: "booth" },
+];
+
+export function inferSectionShape(label: string): { section: FloorSection; shape: FloorShape } {
+  for (const rule of SECTION_RULES) {
+    if (rule.rx.test(label)) return { section: rule.section, shape: rule.shape };
+  }
+  return { section: "main", shape: "round" };
+}
+
+const COLS = 6;
+const CELL_W = 172;
+const CELL_H = 150;
+const SECTION_GAP = 72;
+const PAD = 48;
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/** Table footprint scales with seat count and shape. Total, seat-null-safe. */
+export function tableSize(seats: number | null, shape: FloorShape): { w: number; h: number } {
+  const s = seats && seats > 0 ? seats : 2;
+  if (shape === "booth") return { w: clamp(112 + s * 8, 112, 208), h: 84 };
+  if (shape === "bar") return { w: clamp(96 + s * 10, 96, 224), h: 58 };
+  const side = clamp(64 + s * 7, 64, 132); // round / square
+  return { w: side, h: side };
+}
+
+/**
+ * Lay the configured tables into a legible floor plan. Deterministic and total:
+ * the same tables always yield the same scene; an empty list yields an empty
+ * scene with the outer padding preserved. Sections appear only when populated,
+ * in a stable order, each as a clustered band of tables.
+ */
+export function layoutRestaurantFloor(
+  tables: RestaurantTable[],
+  opts?: { cols?: number },
+): FloorScene {
+  const cols = Math.max(1, opts?.cols ?? COLS);
+
+  const bySection = new Map<FloorSection, { table: RestaurantTable; shape: FloorShape }[]>();
+  for (const table of tables) {
+    const { section, shape } = inferSectionShape(table.label);
+    const bucket = bySection.get(section);
+    if (bucket) bucket.push({ table, shape });
+    else bySection.set(section, [{ table, shape }]);
+  }
+
+  const placements: FloorPlacement[] = [];
+  const zones: FloorZone[] = [];
+  let y = PAD;
+
+  for (const section of SECTION_ORDER) {
+    const group = bySection.get(section);
+    if (!group || group.length === 0) continue;
+
+    const rows = Math.ceil(group.length / cols);
+    const zoneTop = y - 12;
+
+    group.forEach(({ table, shape }, i) => {
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      const size = tableSize(table.seats, shape);
+      const x = PAD + col * CELL_W + (CELL_W - size.w) / 2;
+      const ty = y + row * CELL_H + (CELL_H - size.h) / 2;
+      placements.push({
+        key: table.key,
+        label: table.label,
+        x,
+        y: ty,
+        w: size.w,
+        h: size.h,
+        shape,
+        section,
+        seats: table.seats,
+        state: table.state,
+        stateLabel: capacityStateLabel(table.state),
+        intent: capacityStateIntent(table.state),
+        freeInMinutes: table.freeInMinutes,
+      });
+    });
+
+    const zoneH = rows * CELL_H;
+    zones.push({
+      section,
+      label: SECTION_LABEL[section],
+      x: PAD - 20,
+      y: zoneTop,
+      w: cols * CELL_W,
+      h: zoneH + 20,
+    });
+    y += zoneH + SECTION_GAP;
+  }
+
+  return {
+    placements,
+    zones,
+    width: PAD * 2 + cols * CELL_W,
+    height: placements.length === 0 ? PAD * 2 : y - SECTION_GAP + PAD,
+  };
+}

--- a/docs/user-guide/storefront/team-and-fulfilment.md
+++ b/docs/user-guide/storefront/team-and-fulfilment.md
@@ -27,6 +27,16 @@ their own **Tables & Capacity** page (`/storefront/tables`):
   turning soon, blocked), how many parties are waiting, and one clear next
   action for the next service period. Add or block tables here, not under Team.
 
+Under "Tables right now" you can switch between two views of the same live
+capacity:
+
+- **Floor plan** (the default) — a graphical layout of your tables, each shaped
+  by its seats and coloured by its state, so you can see at a glance which tables
+  are open and which are turning soon (with the minutes until they free up).
+  Tables cluster into sections (window, bar, booths, patio) inferred from their
+  names, so the plan is legible without any extra setup. Pan and zoom to explore.
+- **List** — the same tables as a scannable list.
+
 Tables are never shown as "providers" and never mixed into the Staff list.
 
 ## What To Watch


### PR DESCRIPTION
## Summary
First increment of **Spatial Operational Views** (EP-SPATIAL-OPERATIONAL-VIEWS, BI-287AA5F7): render the restaurant's **currently-configured tables** as a graphical floor-plan facsimile on `/storefront/tables`, not just a list. Owners see at a glance which tables are open and which are turning soon (with minutes-to-free).

Scoped to what the restaurant archetype already has configured — **zero new data, zero migration**. It consumes the capacity contract just landed in #3402 (`RestaurantTable` with `state` + `freeInMinutes`).

## What's here
- **`floor-layout.ts`** — pure, deterministic auto-layout: `RestaurantTable[]` → positioned `FloorScene`. Sections (window / bar / booth / patio) are inferred from the operator's own table names, so the plan is legible with no extra setup. Live *state* stays a projection; *geometry* is derived here.
- **`FloorPlanCanvas` + `TableFloorNode` + `FloorZoneNode`** — the reusable cartesian renderer on **React Flow (`@xyflow/react`)**, the platform's existing canvas engine (same as the EA canvas) — no second engine. Read-only *operate* mode; status colour via the shared `intentStyle` tokens (no local colour map).
- **`TablesNowView`** — a **List ⇄ Floor plan** toggle, both driven by the one shared projection so they reconcile by construction.

Next increment: drag-to-arrange + persisted geometry (`OperationalSceneLayout`), and the customer-facing read-only variant.

## Design grounding
Extends `docs/superpowers/specs/2026-07-21-spatial-operational-views-design.md` (FLOOR, cartesian-interior renderer, §3–4). Consumes `apps/web/lib/storefront/restaurant-capacity.ts` (BI-7C95A586) — no new contract invented. Source of truth for the twin/nouns: `packages/storefront-templates/src/twin-profile.ts` (FLOOR). Substrate reviewed: `apps/web/components/ea/EaCanvas.tsx` (React Flow v12 idioms), `apps/web/app/(shell)/storefront/tables/page.tsx`.

Docs-Impact-Decision: updated `docs/user-guide/storefront/team-and-fulfilment.md` (the `/storefront/tables` page doc) with the new floor-plan view.

## Verification
- **Pure layout algorithm — PASS.** All `floor-layout` assertions (section routing, seat-scaled sizing + clamps, empty-safety, one-placement-per-table, live-state passthrough, stable non-overlapping section bands, row wrapping, determinism) verified against the real source via a standalone strip-types harness. The committed vitest (`floor-layout.test.ts`) runs the same in CI.
- **Typecheck + Production Build — deferred to CI.** This is a source-only worktree (no local toolchain; the shared local-CI store was unstable today), so the runtime-bound gates run on the required CI jobs (Typecheck, Production Build, Unit Tests) rather than locally. React Flow usage mirrors the EA canvas (bare `NodeProps` + `data as` cast, `Node` object shape) verified against `EaCanvas.tsx`.
- **UX verification** on the live install follows after merge + self-upgrade (owner `/storefront/tables` → Floor plan).

Local-CI-Override: source-only worktree could not lease the shared sandbox (toolchain absent; shared pnpm store unstable this session). Pure logic verified via strip-types harness; required CI jobs (Typecheck / Production Build / Unit Tests) are the authoritative gate for the TSX build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)