### PR TITLE
feat(marketing): badge off-archetype artifacts on /strategy overview (BI-CC580161 follow-up)

### DIFF
--- a/apps/web/components/customer-marketing/MarketingStrategyOverview.test.tsx
+++ b/apps/web/components/customer-marketing/MarketingStrategyOverview.test.tsx
@@ -1,0 +1,108 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+
+// DraftAssetButton is a client component that imports server actions; stub it so
+// the overview renders as a pure tree in the source-only test environment.
+vi.mock("./DraftAssetButton", () => ({
+  DraftAssetButton: () => null,
+}));
+
+import { MarketingStrategyOverview } from "./MarketingStrategyOverview";
+
+const now = new Date("2026-07-01T12:00:00.000Z");
+
+function snapshot(
+  overrides: Partial<MarketingWorkspaceSnapshot> = {},
+): MarketingWorkspaceSnapshot {
+  const base: MarketingWorkspaceSnapshot = {
+    organization: { id: "org-1", name: "Trattoria", website: null, addressSummary: "Austin, TX" },
+    storefront: {
+      id: "sf-1",
+      archetypeId: "restaurant",
+      archetypeName: "Restaurant",
+      category: "food-hospitality",
+      tagline: null,
+      description: null,
+      ctaType: "booking",
+    },
+    strategy: {
+      strategyId: "strategy-1",
+      status: "active",
+      primaryGoal: "Fill covers",
+      routeToMarket: "inbound",
+      localityModel: "hyperlocal",
+      geographicScope: "Austin, TX",
+      primaryChannels: ["email"],
+      secondaryChannels: [],
+      differentiators: [],
+      reviewCadence: "monthly",
+      lastReviewedAt: now,
+      nextReviewAt: now,
+      sourceSummary: null,
+      specialistNotes: null,
+      seasonalityNotes: null,
+      targetSegments: [],
+      idealCustomerProfiles: [],
+      entryOffers: [],
+      proofAssets: [
+        { type: "testimonial", label: "Five-star review of our tasting menu" },
+        { type: "outcome", label: "Built with Build Studio by our technical founders" },
+      ],
+      serviceTerritories: [],
+      constraints: null,
+    },
+    latestReview: null,
+    workProducts: {
+      campaignBriefs: [
+        {
+          briefId: "brief-clean",
+          title: "Seasonal tasting menu launch",
+          objective: "Fill quiet midweek covers",
+          audience: "Local diners",
+          channels: ["email"],
+          cta: "Reserve a table",
+          proofAssets: [],
+          kpis: [],
+          notes: null,
+          status: "draft",
+          createdAt: now,
+        },
+      ],
+      assetTasks: [],
+      kpiCheckpoints: [],
+      automationCandidates: [],
+    },
+    pendingDrafts: [],
+    approvedDrafts: [],
+    connectedChannels: [],
+    inboundMessages: [],
+    staleAreas: [],
+  };
+  return { ...base, ...overrides };
+}
+
+describe("MarketingStrategyOverview — archetype-fit badges on /strategy", () => {
+  it("badges a proof asset that leaks software-platform language, not the clean one", () => {
+    const html = renderToStaticMarkup(<MarketingStrategyOverview snapshot={snapshot()} />);
+    // Exactly one blocked badge — the "Build Studio / technical founders" proof asset.
+    const blocked = html.match(/data-fit-severity="block"/g) ?? [];
+    expect(blocked).toHaveLength(1);
+    expect(html).toContain('data-testid="archetype-fit-badge"');
+    // The clean, in-archetype tasting-menu review must not be badged.
+    expect(html).toContain("Five-star review of our tasting menu");
+  });
+
+  it("does not badge a fully in-archetype restaurant strategy", () => {
+    const clean = snapshot({
+      strategy: {
+        ...snapshot().strategy,
+        proofAssets: [{ type: "testimonial", label: "Guests love our seasonal menu" }],
+      },
+    });
+    const html = renderToStaticMarkup(<MarketingStrategyOverview snapshot={clean} />);
+    expect(html).not.toContain('data-fit-severity="block"');
+    expect(html).not.toContain('data-fit-severity="warn"');
+  });
+});

--- a/apps/web/components/customer-marketing/MarketingStrategyOverview.tsx
+++ b/apps/web/components/customer-marketing/MarketingStrategyOverview.tsx
@@ -3,7 +3,9 @@ import {
   formatMarketingLabel,
   type MarketingWorkspaceSnapshot,
 } from "@/lib/marketing";
+import { assessArchetypeFit } from "@/lib/marketing/archetype-fit";
 import { DraftAssetButton } from "./DraftAssetButton";
+import { ArchetypeFitBadge } from "./ArchetypeFitNotice";
 
 type Props = {
   snapshot: MarketingWorkspaceSnapshot;
@@ -43,6 +45,7 @@ export function MarketingStrategyOverview({
 }: Props) {
   const isDetail = mode === "detail";
   const strategy = snapshot.strategy;
+  const category = snapshot.storefront.category;
   const territory =
     strategy.geographicScope ?? snapshot.organization.addressSummary ?? "Market territory still needs a decision";
   const constraintNotes = strategy.constraints
@@ -119,11 +122,14 @@ export function MarketingStrategyOverview({
           {strategy.proofAssets.length > 0 ? (
             <ul className="space-y-2 text-sm text-[var(--dpf-text)]">
               {strategy.proofAssets.map((asset) => (
-                <li key={`${asset.type}-${asset.label}`}>
-                  {asset.label}
-                  <span className="ml-2 text-[var(--dpf-muted)]">
+                <li key={`${asset.type}-${asset.label}`} className="flex flex-wrap items-center gap-2">
+                  <span>{asset.label}</span>
+                  <span className="text-[var(--dpf-muted)]">
                     {formatMarketingLabel(asset.type)}
                   </span>
+                  <ArchetypeFitBadge
+                    assessment={assessArchetypeFit({ text: asset.label, category })}
+                  />
                 </li>
               ))}
             </ul>
@@ -249,7 +255,17 @@ export function MarketingStrategyOverview({
               <ul className="space-y-3 text-sm">
                 {snapshot.workProducts.campaignBriefs.map((brief) => (
                   <li key={brief.briefId} className="border-l border-[var(--dpf-border)] pl-3">
-                    <p className="font-medium text-[var(--dpf-text)]">{brief.title}</p>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium text-[var(--dpf-text)]">{brief.title}</p>
+                      <ArchetypeFitBadge
+                        assessment={assessArchetypeFit({
+                          text: [brief.title, brief.objective, brief.audience, brief.notes]
+                            .filter(Boolean)
+                            .join("\n"),
+                          category,
+                        })}
+                      />
+                    </div>
                     <p className="text-[var(--dpf-muted)]">{brief.objective}</p>
                     <div className="mt-2 flex flex-wrap gap-2">
                       {brief.channels.map((channel) => (
@@ -273,7 +289,15 @@ export function MarketingStrategyOverview({
               <ul className="space-y-3 text-sm">
                 {snapshot.workProducts.assetTasks.map((task) => (
                   <li key={task.taskId} className="border-l border-[var(--dpf-border)] pl-3">
-                    <p className="font-medium text-[var(--dpf-text)]">{task.title}</p>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium text-[var(--dpf-text)]">{task.title}</p>
+                      <ArchetypeFitBadge
+                        assessment={assessArchetypeFit({
+                          text: [task.title, task.brief].filter(Boolean).join("\n"),
+                          category,
+                        })}
+                      />
+                    </div>
                     <p className="text-[var(--dpf-muted)]">
                       {formatMarketingLabel(task.assetType)}
                       {task.dueWindow ? ` - ${task.dueWindow}` : ""}


### PR DESCRIPTION
## What & why

Follow-up to #3406 (which landed archetype-scoped restaurant marketing for BI-CC580161). #3406 badges imported/test-data artifacts on `/campaigns` and blocks Approve/Publish server-side, but the **`/strategy` overview** still listed proof assets and work-product briefs/tasks un-scoped — a leaked "Build Studio / technical founders" proof asset showed on `/strategy` with no imported-test badge, even though `/strategy` is named in the BI.

## Change

- `MarketingStrategyOverview` runs `assessArchetypeFit` over each proof asset, campaign brief, and asset task and renders `ArchetypeFitBadge`, so `/strategy` is archetype-scoped consistently with `/campaigns`.
- New `MarketingStrategyOverview.test.tsx`: a leaked proof asset is badged (`data-fit-severity="block"`); clean in-archetype restaurant copy is not.

## Testing

- New component test green (2 assertions); `tsc --noEmit` clean (0 errors app-wide).
- Ran locally against merged main: Module Size Guard OK, doc-impact `--check` fresh, doc-index `--check` fresh.

Design-Grounding-Decision: Extends the "Archetype-scoped marketing content" standard in `docs/platform-usability-standards.md` and the plan `docs/superpowers/plans/2026-07-22-archetype-scoped-marketing-cockpit.md` (both landed in #3406) to the `/strategy` surface; verified `apps/web/` substrate.
UX-Fit-Decision: Progressive disclosure — badge renders only on warn/block; no new control to configure.
Docs-Impact-Decision: No user-guide change — scopes an existing component to the already-documented archetype-fit contract; no route added/removed.
Seed-Fit-Decision: No seed/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
