### PR TITLE
feat(storefront): mobile-safe preview-first menu/section editing + residue recovery (BI-CBE9B9B3)

### DIFF
--- a/apps/web/app/(shell)/storefront/items/page.tsx
+++ b/apps/web/app/(shell)/storefront/items/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@dpf/db";
 import { redirect } from "next/navigation";
 import { ItemsManager } from "@/components/storefront-admin/ItemsManager";
 import { getVocabulary, getCategorySuggestions } from "@/lib/storefront/archetype-vocabulary";
+import { loadStorefrontContentFit } from "@/lib/storefront/content-fit.server";
 
 export default async function ItemsPage() {
   const [config, orgSettings] = await Promise.all([
@@ -25,6 +26,18 @@ export default async function ItemsPage() {
   );
   const categorySuggestions = getCategorySuggestions(config.archetype.archetypeId);
 
+  const fit = await loadStorefrontContentFit({
+    storefrontId: config.id,
+    currentCategory: config.archetype.category,
+    vocabulary,
+    items: items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      category: item.category,
+      isActive: item.isActive,
+    })),
+  });
+
   return (
     <ItemsManager
       storefrontId={config.id}
@@ -37,6 +50,8 @@ export default async function ItemsPage() {
       categorySuggestions={categorySuggestions}
       defaultCtaType={config.archetype.ctaType}
       defaultCurrency={orgSettings?.baseCurrency ?? "USD"}
+      isPublished={config.isPublished}
+      residueGroups={fit.groups.filter((g) => g.itemIds.length > 0)}
     />
   );
 }

--- a/apps/web/app/(shell)/storefront/sections/page.tsx
+++ b/apps/web/app/(shell)/storefront/sections/page.tsx
@@ -1,9 +1,17 @@
 import { prisma } from "@dpf/db";
 import { redirect } from "next/navigation";
 import { SectionsManager } from "@/components/storefront-admin/SectionsManager";
+import { getVocabulary } from "@/lib/storefront/archetype-vocabulary";
+import { loadStorefrontContentFit } from "@/lib/storefront/content-fit.server";
 
 export default async function SectionsPage() {
-  const config = await prisma.storefrontConfig.findFirst({ select: { id: true } });
+  const config = await prisma.storefrontConfig.findFirst({
+    select: {
+      id: true,
+      isPublished: true,
+      archetype: { select: { category: true, customVocabulary: true } },
+    },
+  });
   if (!config) redirect("/storefront/setup");
 
   const sections = await prisma.storefrontSection.findMany({
@@ -12,5 +20,25 @@ export default async function SectionsPage() {
     select: { id: true, type: true, title: true, sortOrder: true, isVisible: true },
   });
 
-  return <SectionsManager storefrontId={config.id} sections={sections} />;
+  const vocabulary = getVocabulary(
+    config.archetype.category,
+    config.archetype.customVocabulary as Record<string, string> | null,
+  );
+
+  const fit = await loadStorefrontContentFit({
+    storefrontId: config.id,
+    currentCategory: config.archetype.category,
+    vocabulary,
+    sections,
+  });
+
+  return (
+    <SectionsManager
+      storefrontId={config.id}
+      sections={sections}
+      vocabulary={vocabulary}
+      isPublished={config.isPublished}
+      residueGroups={fit.groups.filter((g) => g.sectionIds.length > 0)}
+    />
+  );
 }

--- a/apps/web/components/storefront-admin/ItemsManager.tsx
+++ b/apps/web/components/storefront-admin/ItemsManager.tsx
@@ -1,9 +1,17 @@
 "use client";
 import { useState, useCallback } from "react";
-import { confirmDialog } from "@/components/ui/Dialog";
 import { ItemFormDialog, type ItemFormData } from "./ItemFormDialog";
 import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
 import type { ArchetypeVocabulary } from "@/lib/storefront/archetype-vocabulary";
+import type { ResidueGroup } from "@/lib/storefront/content-fit";
+import {
+  RowActionSheet,
+  MutationStatus,
+  useRowMutations,
+  confirmPublicChange,
+  GeneratedResidueBanner,
+  type RowAction,
+} from "./content-editing-ui";
 
 type Item = {
   id: string;
@@ -29,6 +37,8 @@ type Props = {
   categorySuggestions: string[];
   defaultCtaType: string;
   defaultCurrency?: string;
+  isPublished: boolean;
+  residueGroups: ResidueGroup[];
 };
 
 const CTA_BADGES: Record<string, { color: string; label: string }> = {
@@ -39,20 +49,28 @@ const CTA_BADGES: Record<string, { color: string; label: string }> = {
   rental: { color: "#a78bfa", label: "Rental" },
 };
 
-export function ItemsManager({ storefrontId, items: initial, vocabulary, categorySuggestions, defaultCtaType, defaultCurrency }: Props) {
+export function ItemsManager({
+  storefrontId,
+  items: initial,
+  vocabulary,
+  categorySuggestions,
+  defaultCtaType,
+  defaultCurrency,
+  isPublished,
+  residueGroups,
+}: Props) {
   const [items, setItems] = useState(initial);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<Item | null>(null);
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
-  const [dragIdx, setDragIdx] = useState<number | null>(null);
+  const mutations = useRowMutations();
+
+  const singular = vocabulary.singleItemLabel.toLowerCase();
+  const publicWhere = `your public ${vocabulary.itemsLabel.toLowerCase()}`;
 
   // Derive unique categories from items
   const categories = [...new Set(items.map((i) => i.category).filter(Boolean))] as string[];
-
-  // Filter items by active category
-  const filtered = activeCategory
-    ? items.filter((i) => i.category === activeCategory)
-    : items;
+  const filtered = activeCategory ? items.filter((i) => i.category === activeCategory) : items;
 
   // ─── CRUD Handlers ──────────────────────────────────────────────────
 
@@ -70,16 +88,14 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
     const body = buildRequestBody(formData);
 
     if (editingItem) {
-      // Update
       const res = await fetch(`/api/storefront/admin/items/${editingItem.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
       const updated = await res.json();
-      setItems((prev) => prev.map((i) => i.id === editingItem.id ? { ...i, ...updated } : i));
+      setItems((prev) => prev.map((i) => (i.id === editingItem.id ? { ...i, ...updated } : i)));
     } else {
-      // Create
       const res = await fetch("/api/storefront/admin/items", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -91,65 +107,83 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
   }, [editingItem]);
 
   async function handleDelete(item: Item) {
-    const confirmed = await confirmDialog({
-      title: "Delete item",
-      message: `Delete "${item.name}"? This cannot be undone.`,
-      tone: "danger",
-      confirmLabel: "Delete",
+    const confirmed = await confirmPublicChange({
+      verb: "Remove",
+      target: item.name,
+      where: publicWhere,
+      isPublished,
+      danger: true,
+      confirmLabel: "Remove",
     });
     if (!confirmed) return;
 
-    const res = await fetch(`/api/storefront/admin/items/${item.id}`, { method: "DELETE" });
-    const result = await res.json();
-
-    if (result.softDeleted) {
-      // Item was deactivated instead of deleted
-      setItems((prev) => prev.map((i) => i.id === item.id ? { ...i, isActive: false } : i));
-    } else {
-      setItems((prev) => prev.filter((i) => i.id !== item.id));
+    const snapshot = items;
+    setItems((prev) => prev.filter((i) => i.id !== item.id));
+    try {
+      await mutations.run(`${item.id}:delete`, async () => {
+        const res = await fetch(`/api/storefront/admin/items/${item.id}`, { method: "DELETE" });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const result = await res.json();
+        // Soft-deleted (had bookings/inquiries) → keep it, deactivated.
+        if (result.softDeleted) {
+          setItems(snapshot.map((i) => (i.id === item.id ? { ...i, isActive: false } : i)));
+        }
+      });
+    } catch {
+      setItems(snapshot); // revert on failure
     }
   }
 
-  async function toggleActive(id: string, isActive: boolean) {
-    await fetch(`/api/storefront/admin/items/${id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ isActive }),
+  async function toggleActive(item: Item) {
+    const next = !item.isActive;
+    const confirmed = await confirmPublicChange({
+      verb: next ? "Show" : "Hide",
+      target: item.name,
+      where: publicWhere,
+      isPublished,
     });
-    setItems((prev) => prev.map((i) => i.id === id ? { ...i, isActive } : i));
+    if (!confirmed) return;
+
+    setItems((prev) => prev.map((i) => (i.id === item.id ? { ...i, isActive: next } : i)));
+    try {
+      await mutations.run(`${item.id}:active`, async () => {
+        const res = await fetch(`/api/storefront/admin/items/${item.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ isActive: next }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      });
+    } catch {
+      setItems((prev) => prev.map((i) => (i.id === item.id ? { ...i, isActive: item.isActive } : i)));
+    }
   }
 
-  // ─── Drag-to-Reorder ─────────────────────────────────────────────────
+  async function moveItem(item: Item, direction: "up" | "down") {
+    const idx = items.findIndex((i) => i.id === item.id);
+    const swapIdx = direction === "up" ? idx - 1 : idx + 1;
+    if (swapIdx < 0 || swapIdx >= items.length) return;
 
-  function handleDragStart(idx: number) {
-    setDragIdx(idx);
+    const snapshot = items;
+    const next = [...items];
+    const tmp = next[idx]!;
+    next[idx] = next[swapIdx]!;
+    next[swapIdx] = tmp;
+    setItems(next);
+
+    try {
+      await mutations.run(`${item.id}:order`, async () => {
+        const res = await fetch("/api/storefront/admin/items/reorder", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ items: next.map((it, i) => ({ id: it.id, sortOrder: i })) }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      });
+    } catch {
+      setItems(snapshot);
+    }
   }
-
-  function handleDragOver(e: React.DragEvent, idx: number) {
-    e.preventDefault();
-    if (dragIdx === null || dragIdx === idx) return;
-
-    setItems((prev) => {
-      const next = [...prev];
-      const [moved] = next.splice(dragIdx, 1);
-      next.splice(idx, 0, moved);
-      return next;
-    });
-    setDragIdx(idx);
-  }
-
-  async function handleDragEnd() {
-    setDragIdx(null);
-    // Persist new order
-    const reorderData = items.map((item, idx) => ({ id: item.id, sortOrder: idx }));
-    await fetch("/api/storefront/admin/items/reorder", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ items: reorderData }),
-    });
-  }
-
-  // ─── Form Data Conversion ─────────────────────────────────────────────
 
   function itemToFormData(item: Item): Partial<ItemFormData> {
     const bc = item.bookingConfig as Record<string, unknown> | null;
@@ -179,11 +213,11 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
 
   return (
     <div>
+      <GeneratedResidueBanner storefrontId={storefrontId} groups={residueGroups} isPublished={isPublished} />
+
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-semibold text-[var(--dpf-text)]">
-          {vocabulary.itemsLabel}
-        </h2>
+        <h2 className="text-base font-semibold text-[var(--dpf-text)]">{vocabulary.itemsLabel}</h2>
         <button
           onClick={openCreate}
           className="inline-flex min-h-[44px] items-center px-4 py-1.5 text-xs font-medium rounded-md transition-colors bg-[var(--dpf-accent)] text-white"
@@ -197,7 +231,7 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
         <div className="flex gap-1 mb-4 flex-wrap">
           <button
             onClick={() => setActiveCategory(null)}
-            aria-label="Show all"
+            aria-label={`Show all ${vocabulary.itemsLabel.toLowerCase()}`}
             className={`inline-flex min-h-[44px] items-center px-3 py-1 text-[10px] font-medium rounded-full transition-colors ${
               activeCategory === null
                 ? "bg-[var(--dpf-accent)] text-white"
@@ -225,25 +259,49 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
 
       {/* Item cards */}
       <div className="space-y-2">
-        {filtered.map((item, idx) => {
+        {filtered.map((item) => {
           const badge = CTA_BADGES[item.ctaType] ?? { color: "var(--dpf-muted)", label: item.ctaType };
+          const globalIdx = items.findIndex((i) => i.id === item.id);
+          const activeState = mutations.get(`${item.id}:active`);
+          const orderState = mutations.get(`${item.id}:order`);
+          const deleteState = mutations.get(`${item.id}:delete`);
+          const rowState = deleteState.phase !== "idle"
+            ? deleteState
+            : activeState.phase !== "idle"
+              ? activeState
+              : orderState;
+
+          const actions: RowAction[] = [
+            { label: `Edit ${item.name}`, onSelect: () => openEdit(item) },
+            {
+              label: item.isActive
+                ? `Hide ${item.name} from ${publicWhere}`
+                : `Show ${item.name} on ${publicWhere}`,
+              onSelect: () => void toggleActive(item),
+            },
+            {
+              label: `Move ${item.name} up`,
+              onSelect: () => void moveItem(item, "up"),
+              disabled: globalIdx <= 0,
+            },
+            {
+              label: `Move ${item.name} down`,
+              onSelect: () => void moveItem(item, "down"),
+              disabled: globalIdx >= items.length - 1,
+            },
+            { label: `Remove ${item.name}`, onSelect: () => void handleDelete(item), tone: "danger" },
+          ];
+
           return (
             <div
               key={item.id}
-              draggable
-              onDragStart={() => handleDragStart(idx)}
-              onDragOver={(e) => handleDragOver(e, idx)}
-              onDragEnd={handleDragEnd}
-              className="flex flex-wrap items-center gap-3 p-3 rounded-lg transition-colors cursor-grab active:cursor-grabbing"
+              className="flex flex-wrap items-center gap-3 p-3 rounded-lg"
               style={{
-                background: dragIdx === idx ? "var(--dpf-surface-2)" : "var(--dpf-surface-1)",
+                background: "var(--dpf-surface-1)",
                 opacity: item.isActive ? 1 : 0.5,
                 borderLeft: `3px solid ${badge.color}`,
               }}
             >
-              {/* Drag handle */}
-              <span className="text-[var(--dpf-muted)] text-xs select-none" title="Drag to reorder">::</span>
-
               {/* Main content */}
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-0.5">
@@ -259,6 +317,11 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
                       {item.category}
                     </span>
                   )}
+                  {!item.isActive && (
+                    <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-[var(--dpf-surface-2)] text-[var(--dpf-muted)] shrink-0">
+                      Hidden
+                    </span>
+                  )}
                 </div>
                 {item.description && (
                   <p className="text-[11px] text-[var(--dpf-muted)] truncate">{item.description}</p>
@@ -272,38 +335,20 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
                 </span>
               </div>
 
-              {/* Actions — visually compact but each carries a row-specific
-                  accessible label ("Show Table for 2 …", "Edit …", "Delete …")
-                  and a 44px hit area so they are safe to tap on a phone. */}
-              <div className="flex items-center gap-1 shrink-0">
-                <button
-                  onClick={() => toggleActive(item.id, !item.isActive)}
-                  className={`inline-flex items-center justify-center min-h-[44px] min-w-[44px] text-[10px] px-2 rounded border border-[var(--dpf-border)] hover:bg-[var(--dpf-surface-2)] transition-colors ${item.isActive ? "text-[var(--dpf-success)]" : "text-[var(--dpf-muted)]"}`}
-                  aria-label={
-                    item.isActive
-                      ? `Hide ${item.name} from your public page`
-                      : `Show ${item.name} on your public page`
-                  }
-                  title={item.isActive ? `Hide ${item.name}` : `Show ${item.name}`}
-                >
-                  {item.isActive ? "On" : "Off"}
-                </button>
-                <button
-                  onClick={() => openEdit(item)}
-                  className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] text-[10px] px-2 rounded border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] transition-colors"
-                  aria-label={`Edit ${item.name}`}
-                  title={`Edit ${item.name}`}
-                >
-                  Edit
-                </button>
-                <button
-                  onClick={() => handleDelete(item)}
-                  className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] text-[10px] px-2 rounded border border-[var(--dpf-border)] text-[var(--dpf-muted)] hover:text-[var(--dpf-error)] hover:border-[var(--dpf-error)]/30 transition-colors"
-                  aria-label={`Delete ${item.name}`}
-                  title={`Delete ${item.name}`}
-                >
-                  Del
-                </button>
+              {/* Status + single labelled action trigger */}
+              <div className="flex items-center gap-2 shrink-0">
+                <MutationStatus
+                  state={rowState}
+                  onRetry={() => mutations.retry(
+                    deleteState.phase === "failed"
+                      ? `${item.id}:delete`
+                      : activeState.phase === "failed"
+                        ? `${item.id}:active`
+                        : `${item.id}:order`,
+                  )}
+                  label={singular}
+                />
+                <RowActionSheet rowLabel={item.name} actions={actions} />
               </div>
             </div>
           );
@@ -322,7 +367,10 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
       <ItemFormDialog
         key={editingItem?.id ?? "new"}
         open={dialogOpen}
-        onClose={() => { setDialogOpen(false); setEditingItem(null); }}
+        onClose={() => {
+          setDialogOpen(false);
+          setEditingItem(null);
+        }}
         onSave={handleSave}
         initial={editingItem ? itemToFormData(editingItem) : undefined}
         vocabulary={vocabulary}
@@ -341,11 +389,11 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
 function formatPrice(amount: string | null, currency: string, priceType: string | null): string {
   const symbol = getCurrencySymbol(currency);
 
-  if (!priceType) return "\u2014";
+  if (!priceType) return "—";
 
   switch (priceType) {
     case "fixed":
-      return amount ? `${symbol}${Number(amount).toFixed(2)}` : "\u2014";
+      return amount ? `${symbol}${Number(amount).toFixed(2)}` : "—";
     case "from":
       return amount ? `From ${symbol}${Number(amount).toFixed(2)}` : "From...";
     case "per-hour":

--- a/apps/web/components/storefront-admin/SectionsManager.tsx
+++ b/apps/web/components/storefront-admin/SectionsManager.tsx
@@ -1,76 +1,140 @@
 "use client";
 import { useState } from "react";
+import type { ArchetypeVocabulary } from "@/lib/storefront/archetype-vocabulary";
+import { sectionDisplayName } from "@/lib/storefront/content-fit";
+import type { ResidueGroup } from "@/lib/storefront/content-fit";
+import {
+  RowActionSheet,
+  MutationStatus,
+  useRowMutations,
+  confirmPublicChange,
+  GeneratedResidueBanner,
+  type RowAction,
+} from "./content-editing-ui";
 
 type Section = { id: string; type: string; title: string | null; sortOrder: number; isVisible: boolean };
 
-export function SectionsManager({ storefrontId, sections: initial }: { storefrontId: string; sections: Section[] }) {
-  const [sections, setSections] = useState(initial);
+type Props = {
+  storefrontId: string;
+  sections: Section[];
+  vocabulary: ArchetypeVocabulary;
+  isPublished: boolean;
+  residueGroups: ResidueGroup[];
+};
 
-  async function toggleVisibility(id: string, isVisible: boolean) {
-    await fetch(`/api/storefront/admin/sections/${id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ isVisible }),
+export function SectionsManager({ storefrontId, sections: initial, vocabulary, isPublished, residueGroups }: Props) {
+  const [sections, setSections] = useState(initial);
+  const mutations = useRowMutations();
+  const publicWhere = "your public page";
+
+  async function toggleVisibility(section: Section) {
+    const name = sectionDisplayName(section, vocabulary);
+    const next = !section.isVisible;
+    const confirmed = await confirmPublicChange({
+      verb: next ? "Show" : "Hide",
+      target: `${name} section`,
+      where: publicWhere,
+      isPublished,
     });
-    setSections((prev) => prev.map((s) => s.id === id ? { ...s, isVisible } : s));
+    if (!confirmed) return;
+
+    setSections((prev) => prev.map((s) => (s.id === section.id ? { ...s, isVisible: next } : s)));
+    try {
+      await mutations.run(`${section.id}:visible`, async () => {
+        const res = await fetch(`/api/storefront/admin/sections/${section.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ isVisible: next }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      });
+    } catch {
+      setSections((prev) => prev.map((s) => (s.id === section.id ? { ...s, isVisible: section.isVisible } : s)));
+    }
   }
 
-  async function moveSection(id: string, direction: "up" | "down") {
-    const idx = sections.findIndex((s) => s.id === id);
-    if (direction === "up" && idx === 0) return;
-    if (direction === "down" && idx === sections.length - 1) return;
+  async function moveSection(section: Section, direction: "up" | "down") {
+    const idx = sections.findIndex((s) => s.id === section.id);
     const swapIdx = direction === "up" ? idx - 1 : idx + 1;
+    if (swapIdx < 0 || swapIdx >= sections.length) return;
+
+    const snapshot = sections;
     const updated = [...sections];
     const tmp = updated[idx]!;
     updated[idx] = updated[swapIdx]!;
     updated[swapIdx] = tmp;
     const reordered = updated.map((s, i) => ({ ...s, sortOrder: i }));
     setSections(reordered);
-    await fetch(`/api/storefront/admin/sections/reorder`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ storefrontId, order: reordered.map((s) => s.id) }),
-    });
+
+    try {
+      await mutations.run(`${section.id}:order`, async () => {
+        const res = await fetch(`/api/storefront/admin/sections/reorder`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ storefrontId, order: reordered.map((s) => s.id) }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      });
+    } catch {
+      setSections(snapshot);
+    }
   }
 
   return (
     <div>
-      <h2 style={{ fontSize: 15, fontWeight: 600, marginBottom: 16 }}>Sections</h2>
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <GeneratedResidueBanner storefrontId={storefrontId} groups={residueGroups} isPublished={isPublished} />
+
+      <h2 className="mb-4 text-base font-semibold text-[var(--dpf-text)]">Your public page sections</h2>
+      <div className="flex flex-col gap-2">
         {sections.map((s, idx) => {
-          const name = s.title ?? s.type;
+          const name = sectionDisplayName(s, vocabulary);
+          const visibleState = mutations.get(`${s.id}:visible`);
+          const orderState = mutations.get(`${s.id}:order`);
+          const rowState = visibleState.phase !== "idle" ? visibleState : orderState;
+
+          const actions: RowAction[] = [
+            {
+              label: s.isVisible ? `Hide ${name} section from ${publicWhere}` : `Show ${name} section on ${publicWhere}`,
+              onSelect: () => void toggleVisibility(s),
+            },
+            { label: `Move ${name} up`, onSelect: () => void moveSection(s, "up"), disabled: idx === 0 },
+            {
+              label: `Move ${name} down`,
+              onSelect: () => void moveSection(s, "down"),
+              disabled: idx === sections.length - 1,
+            },
+          ];
+
           return (
-          <div key={s.id} className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--dpf-border)] px-3 py-2.5">
-            <div className="min-w-0 flex-1">
-              <span style={{ fontWeight: 600, fontSize: 13 }}>{name}</span>
-              <span className="text-[var(--dpf-muted)]" style={{ fontSize: 11, marginLeft: 6 }}>{s.type}</span>
-            </div>
-            {/* Reorder / visibility — row-specific accessible labels and 44px hit
-                areas so the arrows and Hide/Show are safe to tap and screen-reader
-                legible ("Move Hero up", "Hide Hero section") rather than anonymous. */}
-            <button
-              onClick={() => moveSection(s.id, "up")}
-              disabled={idx === 0}
-              aria-label={`Move ${name} up`}
-              className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] text-sm disabled:opacity-40"
-            >↑</button>
-            <button
-              onClick={() => moveSection(s.id, "down")}
-              disabled={idx === sections.length - 1}
-              aria-label={`Move ${name} down`}
-              className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] text-sm disabled:opacity-40"
-            >↓</button>
-            <button
-              onClick={() => toggleVisibility(s.id, !s.isVisible)}
-              aria-label={s.isVisible ? `Hide ${name} section from your public page` : `Show ${name} section on your public page`}
-              className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] px-3 text-xs"
+            <div
+              key={s.id}
+              className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--dpf-border)] px-3 py-2.5"
+              style={{ opacity: s.isVisible ? 1 : 0.55 }}
             >
-              {s.isVisible ? "Hide" : "Show"}
-            </button>
-          </div>
+              <div className="min-w-0 flex-1">
+                <span className="text-sm font-medium text-[var(--dpf-text)]">{name}</span>
+                {!s.isVisible && (
+                  <span className="ml-2 rounded-full bg-[var(--dpf-surface-2)] px-1.5 py-0.5 text-[10px] text-[var(--dpf-muted)]">
+                    Hidden
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <MutationStatus
+                  state={rowState}
+                  onRetry={() => mutations.retry(visibleState.phase === "failed" ? `${s.id}:visible` : `${s.id}:order`)}
+                  label="section"
+                />
+                <RowActionSheet rowLabel={`${name} section`} actions={actions} />
+              </div>
+            </div>
           );
         })}
       </div>
+
+      {sections.length === 0 && (
+        <p className="py-8 text-center text-sm text-[var(--dpf-muted)]">No sections on your page yet.</p>
+      )}
     </div>
   );
 }

--- a/apps/web/components/storefront-admin/content-editing-ui.tsx
+++ b/apps/web/components/storefront-admin/content-editing-ui.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+// apps/web/components/storefront-admin/content-editing-ui.tsx
+//
+// BI-CBE9B9B3 — shared, mobile-safe editing primitives for the menu and section
+// editors. Three problems the terse per-row controls had, solved once here:
+//
+//   • Action overload / tiny targets — RowActionSheet collapses a row's many
+//     terse controls into ONE 44px trigger that opens a labelled action sheet;
+//     every action inside is a full, row-specific sentence.
+//   • Silent mutations — useRowMutations tracks pending / saved / failed per row
+//     with a Retry path, and MutationStatus renders it inline.
+//   • Blind public changes — confirmPublicChange previews what changes, where it
+//     shows, and whether the live site is affected before anything runs.
+//
+// GeneratedResidueBanner is the grouped cross-archetype recovery surface.
+
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { confirmDialog, alertDialog } from "@/components/ui/Dialog";
+import {
+  recoverGeneratedResidue,
+  type RecoverResidueResult,
+} from "@/lib/storefront/content-recovery-actions";
+import type { ResidueGroup } from "@/lib/storefront/content-fit";
+
+// ─── Per-row mutation state ─────────────────────────────────────────────────
+
+export type MutationPhase = "idle" | "pending" | "saved" | "failed";
+export interface MutationState {
+  phase: MutationPhase;
+  error?: string;
+}
+
+export interface RowMutations {
+  status: Record<string, MutationState>;
+  /** Run a mutation under `key`, tracking pending/saved/failed and storing a retry. */
+  run: (key: string, action: () => Promise<void>) => Promise<void>;
+  retry: (key: string) => void;
+  get: (key: string) => MutationState;
+}
+
+/**
+ * Tracks the state of keyed row mutations. Optimistic UI stays the caller's
+ * responsibility (it owns the list state); this hook owns the *feedback* — what
+ * the owner sees while a change is saving, once it saved, or when it failed, and
+ * the retry that re-runs the exact same action.
+ */
+export function useRowMutations(): RowMutations {
+  const [status, setStatus] = useState<Record<string, MutationState>>({});
+  const retries = useRef<Record<string, () => Promise<void>>>({});
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  useEffect(() => {
+    const t = timers.current;
+    return () => {
+      for (const id of Object.values(t)) clearTimeout(id);
+    };
+  }, []);
+
+  const run = useCallback(async (key: string, action: () => Promise<void>) => {
+    retries.current[key] = action;
+    if (timers.current[key]) clearTimeout(timers.current[key]);
+    setStatus((s) => ({ ...s, [key]: { phase: "pending" } }));
+    try {
+      await action();
+      setStatus((s) => ({ ...s, [key]: { phase: "saved" } }));
+      timers.current[key] = setTimeout(() => {
+        setStatus((s) => {
+          if (s[key]?.phase !== "saved") return s;
+          const next = { ...s };
+          delete next[key];
+          return next;
+        });
+      }, 2500);
+    } catch (err) {
+      setStatus((s) => ({
+        ...s,
+        [key]: { phase: "failed", error: err instanceof Error ? err.message : "Something went wrong" },
+      }));
+      throw err;
+    }
+  }, []);
+
+  const retry = useCallback(
+    (key: string) => {
+      const action = retries.current[key];
+      if (action) void run(key, action);
+    },
+    [run],
+  );
+
+  const get = useCallback((key: string): MutationState => status[key] ?? { phase: "idle" }, [status]);
+
+  return { status, run, retry, get };
+}
+
+/** Inline pending/saved/failed pill with a Retry affordance on failure. */
+export function MutationStatus({
+  state,
+  onRetry,
+  label = "change",
+}: {
+  state: MutationState;
+  onRetry?: () => void;
+  label?: string;
+}) {
+  if (state.phase === "idle") return null;
+  if (state.phase === "pending") {
+    return (
+      <span role="status" className="text-[11px] text-[var(--dpf-muted)]">
+        Saving…
+      </span>
+    );
+  }
+  if (state.phase === "saved") {
+    return (
+      <span role="status" className="text-[11px] text-[var(--dpf-success)]">
+        Saved
+      </span>
+    );
+  }
+  return (
+    <span role="alert" className="inline-flex items-center gap-1.5 text-[11px] text-[var(--dpf-error)]">
+      Couldn’t save {label}
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="inline-flex min-h-[44px] items-center rounded border border-[var(--dpf-error)]/40 px-2 font-medium text-[var(--dpf-error)] hover:bg-[var(--dpf-error)]/10"
+        >
+          Retry
+        </button>
+      )}
+    </span>
+  );
+}
+
+// ─── Row action sheet ───────────────────────────────────────────────────────
+
+export interface RowAction {
+  label: string;
+  onSelect: () => void;
+  tone?: "default" | "danger";
+  disabled?: boolean;
+}
+
+/**
+ * One 44px trigger per row that opens a bottom action sheet. Collapsing a row's
+ * controls to a single trigger is what takes the pages from ~70 tap targets to
+ * one-per-row; the sheet then affords full, row-specific labels with generous
+ * hit areas that a phone can actually tap.
+ */
+export function RowActionSheet({
+  rowLabel,
+  actions,
+}: {
+  /** The row's own name, e.g. "Table for 2" — used for the trigger's accessible name. */
+  rowLabel: string;
+  actions: RowAction[];
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-haspopup="dialog"
+        aria-label={`Manage ${rowLabel}`}
+        className="inline-flex min-h-[44px] items-center gap-1 rounded-md border border-[var(--dpf-border)] px-3 text-xs font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+      >
+        Manage
+        <span aria-hidden="true">▾</span>
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-[1000] flex items-end justify-center bg-black/50 sm:items-center"
+          onMouseDown={(e) => {
+            if (e.target === e.currentTarget) setOpen(false);
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Actions for ${rowLabel}`}
+            className="w-full max-w-md rounded-t-2xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-2 shadow-xl sm:rounded-2xl"
+          >
+            <p className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+              {rowLabel}
+            </p>
+            <div className="flex flex-col">
+              {actions.map((action) => (
+                <button
+                  key={action.label}
+                  type="button"
+                  disabled={action.disabled}
+                  onClick={() => {
+                    setOpen(false);
+                    action.onSelect();
+                  }}
+                  className={`flex min-h-[44px] items-center rounded-lg px-3 text-left text-sm hover:bg-[var(--dpf-surface-2)] disabled:opacity-40 ${
+                    action.tone === "danger" ? "text-[var(--dpf-error)]" : "text-[var(--dpf-text)]"
+                  }`}
+                >
+                  {action.label}
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="mt-1 flex min-h-[44px] items-center justify-center rounded-lg border border-[var(--dpf-border)] px-3 text-sm font-medium text-[var(--dpf-muted)] hover:bg-[var(--dpf-surface-2)]"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ─── Preview-before-execute confirm ─────────────────────────────────────────
+
+/**
+ * Preview a public-site-affecting change before it runs: what changes, where it
+ * appears on the public page, and whether the live site is affected right now.
+ */
+export function confirmPublicChange(opts: {
+  verb: string;
+  target: string;
+  /** Where on the public page this shows, e.g. "your public menu". */
+  where: string;
+  isPublished: boolean;
+  danger?: boolean;
+  confirmLabel?: string;
+}): Promise<boolean> {
+  const liveLine = opts.isPublished
+    ? "Your public page is live, so visitors will see this change straight away."
+    : "Your public page isn’t published yet, so visitors won’t see this until you publish.";
+  return confirmDialog({
+    title: `${opts.verb} ${opts.target}?`,
+    message: `This will ${opts.verb.toLowerCase()} “${opts.target}”.\n\nWhere it shows: ${opts.where}.\n${liveLine}`,
+    tone: opts.danger ? "danger" : "default",
+    confirmLabel: opts.confirmLabel ?? opts.verb,
+  });
+}
+
+// ─── Generated / cross-archetype residue recovery ───────────────────────────
+
+/**
+ * Grouped recovery banner. Surfaces cross-archetype and duplicate residue the
+ * owner never chose, and removes each group in one previewed action with an
+ * affected-artifact list. Renders nothing when there is no residue.
+ */
+export function GeneratedResidueBanner({
+  storefrontId,
+  groups,
+  isPublished,
+}: {
+  storefrontId: string;
+  groups: ResidueGroup[];
+  isPublished: boolean;
+}) {
+  const router = useRouter();
+  const [expanded, setExpanded] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  if (groups.length === 0) return null;
+
+  const totalItems = groups.reduce((n, g) => n + g.itemIds.length, 0);
+  const totalSections = groups.reduce((n, g) => n + g.sectionIds.length, 0);
+
+  async function removeGroups(target: ResidueGroup[], key: string) {
+    const itemIds = target.flatMap((g) => g.itemIds);
+    const sectionIds = target.flatMap((g) => g.sectionIds);
+    const names = target.flatMap((g) => [...g.itemNames, ...g.sectionNames]);
+    const preview =
+      names.length <= 8 ? names.map((n) => `• ${n}`).join("\n") : `${names.length} items and sections`;
+    const liveLine = isPublished
+      ? "Your public page is live, so this is removed from what visitors see."
+      : "Your public page isn’t published yet, so visitors aren’t affected.";
+    const confirmed = await confirmDialog({
+      title: "Remove generated content?",
+      message: `This removes:\n${preview}\n\n${liveLine}\nContent with real bookings or enquiries is turned off instead of deleted.`,
+      tone: "danger",
+      confirmLabel: `Remove ${itemIds.length + sectionIds.length}`,
+    });
+    if (!confirmed) return;
+
+    setBusyKey(key);
+    startTransition(async () => {
+      let result: RecoverResidueResult;
+      try {
+        result = await recoverGeneratedResidue(storefrontId, { itemIds, sectionIds });
+      } catch {
+        result = { error: "Recovery failed. Please try again." };
+      }
+      setBusyKey(null);
+      if ("error" in result) {
+        await alertDialog({ title: "Couldn’t remove content", message: result.error, tone: "danger" });
+        return;
+      }
+      const parts: string[] = [];
+      if (result.removedItems) parts.push(`${result.removedItems} removed`);
+      if (result.removedSections) parts.push(`${result.removedSections} section${result.removedSections === 1 ? "" : "s"} removed`);
+      if (result.deactivatedItems) parts.push(`${result.deactivatedItems} turned off (had bookings/enquiries)`);
+      await alertDialog({
+        title: "Recovered",
+        message: parts.length ? parts.join(", ") + "." : "Done.",
+      });
+      router.refresh();
+    });
+  }
+
+  return (
+    <section
+      aria-label="Generated content needing review"
+      data-testid="residue-recovery"
+      className="mb-4 rounded-lg border p-3"
+      style={{ borderColor: "var(--dpf-warning)", background: "var(--dpf-state-warning)" }}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-[var(--dpf-text)]">
+            Found content that doesn’t fit your storefront
+          </h3>
+          <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">
+            {totalItems > 0 && `${totalItems} item${totalItems === 1 ? "" : "s"}`}
+            {totalItems > 0 && totalSections > 0 && " and "}
+            {totalSections > 0 && `${totalSections} section${totalSections === 1 ? "" : "s"}`}
+            {" "}look generated from a different business type. Review before removing.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          className="inline-flex min-h-[44px] shrink-0 items-center rounded-md border border-[var(--dpf-border)] px-3 text-xs font-medium text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]"
+        >
+          {expanded ? "Hide" : "Review"}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="mt-3 flex flex-col gap-3">
+          {groups.map((group) => (
+            <div key={group.key} className="rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+              <p className="text-xs font-semibold text-[var(--dpf-text)]">
+                {group.title} ({group.count})
+              </p>
+              <p className="mt-0.5 text-[11px] text-[var(--dpf-muted)]">{group.description}</p>
+              <ul className="mt-2 flex flex-wrap gap-1.5">
+                {[...group.itemNames, ...group.sectionNames].map((name, i) => (
+                  <li
+                    key={`${group.key}-${i}`}
+                    className="rounded-full bg-[var(--dpf-surface-2)] px-2 py-0.5 text-[11px] text-[var(--dpf-text)]"
+                  >
+                    {name}
+                  </li>
+                ))}
+              </ul>
+              <button
+                type="button"
+                disabled={pending}
+                onClick={() => removeGroups([group], group.key)}
+                className="mt-2 inline-flex min-h-[44px] items-center rounded-md border border-[var(--dpf-error)]/40 px-3 text-xs font-medium text-[var(--dpf-error)] hover:bg-[var(--dpf-error)]/10 disabled:opacity-50"
+              >
+                {busyKey === group.key ? "Removing…" : `Remove ${group.title.toLowerCase()}`}
+              </button>
+            </div>
+          ))}
+
+          {groups.length > 1 && (
+            <button
+              type="button"
+              disabled={pending}
+              onClick={() => removeGroups(groups, "__all__")}
+              className="inline-flex min-h-[44px] items-center justify-center rounded-md bg-[var(--dpf-error)] px-3 text-xs font-semibold text-white hover:opacity-90 disabled:opacity-50"
+            >
+              {busyKey === "__all__" ? "Removing…" : `Remove all (${totalItems + totalSections})`}
+            </button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/storefront-admin/content-editing-ui.tsx
+++ b/apps/web/components/storefront-admin/content-editing-ui.tsx
@@ -15,7 +15,7 @@
 //
 // GeneratedResidueBanner is the grouped cross-archetype recovery surface.
 
-import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { confirmDialog, alertDialog } from "@/components/ui/Dialog";
 import {
@@ -265,8 +265,8 @@ export function GeneratedResidueBanner({
 }) {
   const router = useRouter();
   const [expanded, setExpanded] = useState(false);
-  const [pending, startTransition] = useTransition();
   const [busyKey, setBusyKey] = useState<string | null>(null);
+  const busy = busyKey !== null;
 
   if (groups.length === 0) return null;
 
@@ -290,29 +290,31 @@ export function GeneratedResidueBanner({
     });
     if (!confirmed) return;
 
+    // The recovery runs OUTSIDE any React transition: alertDialog dispatches a
+    // DialogHost state update that never renders interactively inside a deferred
+    // transition, silently wedging the button (BI-FE7C543C). A plain busy flag
+    // keeps the result dialogs reachable.
     setBusyKey(key);
-    startTransition(async () => {
-      let result: RecoverResidueResult;
-      try {
-        result = await recoverGeneratedResidue(storefrontId, { itemIds, sectionIds });
-      } catch {
-        result = { error: "Recovery failed. Please try again." };
-      }
-      setBusyKey(null);
-      if ("error" in result) {
-        await alertDialog({ title: "Couldn’t remove content", message: result.error, tone: "danger" });
-        return;
-      }
-      const parts: string[] = [];
-      if (result.removedItems) parts.push(`${result.removedItems} removed`);
-      if (result.removedSections) parts.push(`${result.removedSections} section${result.removedSections === 1 ? "" : "s"} removed`);
-      if (result.deactivatedItems) parts.push(`${result.deactivatedItems} turned off (had bookings/enquiries)`);
-      await alertDialog({
-        title: "Recovered",
-        message: parts.length ? parts.join(", ") + "." : "Done.",
-      });
-      router.refresh();
+    let result: RecoverResidueResult;
+    try {
+      result = await recoverGeneratedResidue(storefrontId, { itemIds, sectionIds });
+    } catch {
+      result = { error: "Recovery failed. Please try again." };
+    }
+    setBusyKey(null);
+    if ("error" in result) {
+      await alertDialog({ title: "Couldn’t remove content", message: result.error, tone: "danger" });
+      return;
+    }
+    const parts: string[] = [];
+    if (result.removedItems) parts.push(`${result.removedItems} removed`);
+    if (result.removedSections) parts.push(`${result.removedSections} section${result.removedSections === 1 ? "" : "s"} removed`);
+    if (result.deactivatedItems) parts.push(`${result.deactivatedItems} turned off (had bookings/enquiries)`);
+    await alertDialog({
+      title: "Recovered",
+      message: parts.length ? parts.join(", ") + "." : "Done.",
     });
+    router.refresh();
   }
 
   return (
@@ -364,7 +366,7 @@ export function GeneratedResidueBanner({
               </ul>
               <button
                 type="button"
-                disabled={pending}
+                disabled={busy}
                 onClick={() => removeGroups([group], group.key)}
                 className="mt-2 inline-flex min-h-[44px] items-center rounded-md border border-[var(--dpf-error)]/40 px-3 text-xs font-medium text-[var(--dpf-error)] hover:bg-[var(--dpf-error)]/10 disabled:opacity-50"
               >
@@ -376,7 +378,7 @@ export function GeneratedResidueBanner({
           {groups.length > 1 && (
             <button
               type="button"
-              disabled={pending}
+              disabled={busy}
               onClick={() => removeGroups(groups, "__all__")}
               className="inline-flex min-h-[44px] items-center justify-center rounded-md bg-[var(--dpf-error)] px-3 text-xs font-semibold text-white hover:opacity-90 disabled:opacity-50"
             >

--- a/apps/web/components/storefront-admin/mobile-content-ux.test.tsx
+++ b/apps/web/components/storefront-admin/mobile-content-ux.test.tsx
@@ -1,0 +1,124 @@
+// BI-CBE9B9B3 — mobile UX checks for the menu and section editors.
+//
+// These assert the acceptance invariants against the *default* (390px) rendered
+// surface — the state an owner lands on: single labelled action per row, 44px hit
+// areas, row-specific (non-repeated) accessible names, no internal slug leakage,
+// and a visible recovery surface when residue is present.
+
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ItemsManager } from "./ItemsManager";
+import { SectionsManager } from "./SectionsManager";
+import { getVocabulary } from "@/lib/storefront/archetype-vocabulary";
+import type { ResidueGroup } from "@/lib/storefront/content-fit";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: () => {} }) }));
+vi.mock("@/lib/storefront/content-recovery-actions", () => ({
+  recoverGeneratedResidue: vi.fn(async () => ({
+    success: true, removedItems: 0, removedSections: 0, deactivatedItems: 0, skipped: [],
+  })),
+}));
+
+const vocab = getVocabulary("food-hospitality");
+
+function openTags(html: string, tag: string): string[] {
+  return html.match(new RegExp(`<${tag}[^>]*>`, "g")) ?? [];
+}
+function ariaLabels(html: string): string[] {
+  return [...html.matchAll(/aria-label="([^"]*)"/g)].map((m) => m[1]!);
+}
+
+const items = [
+  { id: "i1", itemId: "itm-1", name: "Set Dinner Menu", description: "Three courses", category: "Set Menus", priceAmount: "45", priceCurrency: "USD", priceType: "fixed", ctaType: "purchase", ctaLabel: null, imageUrl: null, isActive: true, sortOrder: 0, bookingConfig: null },
+  { id: "i2", itemId: "itm-2", name: "Table for 2", description: null, category: null, priceAmount: null, priceCurrency: "USD", priceType: null, ctaType: "booking", ctaLabel: null, imageUrl: null, isActive: true, sortOrder: 1, bookingConfig: null },
+  { id: "i3", itemId: "itm-3", name: "Sunday Roast", description: null, category: null, priceAmount: "20", priceCurrency: "USD", priceType: "fixed", ctaType: "purchase", ctaLabel: null, imageUrl: null, isActive: false, sortOrder: 2, bookingConfig: null },
+];
+
+function renderItems(residueGroups: ResidueGroup[] = []) {
+  return renderToStaticMarkup(
+    <ItemsManager
+      storefrontId="sf1"
+      items={items}
+      vocabulary={vocab}
+      categorySuggestions={[]}
+      defaultCtaType="purchase"
+      defaultCurrency="USD"
+      isPublished
+      residueGroups={residueGroups}
+    />,
+  );
+}
+
+const sections = [
+  { id: "s1", type: "hero", title: null, sortOrder: 0, isVisible: true },
+  { id: "s2", type: "items", title: null, sortOrder: 1, isVisible: true },
+  { id: "s3", type: "animals-available", title: null, sortOrder: 2, isVisible: true },
+];
+
+function renderSections(residueGroups: ResidueGroup[] = []) {
+  return renderToStaticMarkup(
+    <SectionsManager
+      storefrontId="sf1"
+      sections={sections}
+      vocabulary={vocab}
+      isPublished
+      residueGroups={residueGroups}
+    />,
+  );
+}
+
+describe("menu editor mobile UX", () => {
+  it("gives each row exactly one labelled action trigger (low action count)", () => {
+    const html = renderItems();
+    const managers = ariaLabels(html).filter((l) => l.startsWith("Manage "));
+    expect(managers).toHaveLength(items.length);
+  });
+
+  it("has no sub-44px interactive controls", () => {
+    const html = renderItems();
+    for (const button of openTags(html, "button")) {
+      expect(button).toContain("min-h-[44px]");
+    }
+  });
+
+  it("uses row-specific accessible names with no repeated labels", () => {
+    const html = renderItems();
+    const managers = ariaLabels(html).filter((l) => l.startsWith("Manage "));
+    expect(new Set(managers).size).toBe(managers.length);
+    expect(managers).toContain("Manage Set Dinner Menu");
+  });
+
+  it("drops the old terse repeated controls", () => {
+    const html = renderItems();
+    expect(html).not.toMatch(/>On<|>Off<|>Del<|>Edit<\s*<\/button>/);
+  });
+
+  it("shows the grouped recovery surface only when residue exists", () => {
+    expect(renderItems()).not.toContain('data-testid="residue-recovery"');
+    const withResidue = renderItems([
+      { key: "category:warehousing-fulfilment", title: "Warehousing Fulfilment content", description: "…", itemIds: ["i2"], sectionIds: [], itemNames: ["Pallet Storage"], sectionNames: [], count: 1 },
+    ]);
+    expect(withResidue).toContain('data-testid="residue-recovery"');
+    expect(withResidue).toContain("doesn’t fit your storefront");
+  });
+});
+
+describe("section editor mobile UX", () => {
+  it("never leaks internal type slugs — shows friendly names", () => {
+    const html = renderSections();
+    expect(html).not.toMatch(/>hero</);
+    expect(html).not.toContain("animals-available");
+    expect(html).toContain("Welcome banner");
+    expect(html).toContain("Menu"); // items → Restaurant vocab
+  });
+
+  it("labels each section action per-row with 44px targets", () => {
+    const html = renderSections();
+    for (const button of openTags(html, "button")) {
+      expect(button).toContain("min-h-[44px]");
+    }
+    const managers = ariaLabels(html).filter((l) => l.startsWith("Manage "));
+    expect(managers).toContain("Manage Welcome banner section");
+    expect(new Set(managers).size).toBe(managers.length);
+  });
+});

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -9074,6 +9074,8 @@
       "anchors": [
         "use-this-doc-for",
         "workflow",
+        "managing-a-row",
+        "fixing-generated-content-that-doesnt-fit",
         "what-to-watch"
       ]
     },

--- a/apps/web/lib/storefront/content-fit.server.ts
+++ b/apps/web/lib/storefront/content-fit.server.ts
@@ -1,0 +1,98 @@
+// apps/web/lib/storefront/content-fit.server.ts
+//
+// BI-CBE9B9B3 — server helpers that feed the pure content-fit classifier.
+// Builds the cross-archetype fingerprint from the seeded archetype library and
+// runs the classifier for a storefront. Kept out of content-fit.ts so that
+// module stays database-free and unit-testable.
+
+import { prisma } from "@dpf/db";
+import {
+  classifyStorefrontContentFit,
+  type ContentFitFingerprint,
+  type ContentFitResult,
+  type FitItem,
+  type FitSection,
+} from "./content-fit";
+import type { ArchetypeVocabulary } from "./archetype-vocabulary";
+
+/**
+ * Build the fingerprint from every archetype's seed item templates, keyed by
+ * item-template name → the categories that seed it. This is what lets the
+ * classifier tell "Pallet Storage" (a warehousing template) apart from an
+ * owner-typed "Set Dinner Menu" (matches no foreign template).
+ */
+export async function buildContentFitFingerprint(): Promise<ContentFitFingerprint> {
+  const archetypes = await prisma.storefrontArchetype.findMany({
+    select: { name: true, category: true, itemTemplates: true },
+  });
+
+  const itemNameCategories: Record<string, Set<string>> = {};
+  const categoryLabels: Record<string, string> = {};
+
+  for (const archetype of archetypes) {
+    if (!categoryLabels[archetype.category]) {
+      // Prefer a clean category label derived from the slug; archetype.name is a
+      // leaf brand ("3PL Contract Warehousing"), too specific for a group label.
+      categoryLabels[archetype.category] = archetype.category
+        .split(/[-_]/)
+        .filter(Boolean)
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(" ");
+    }
+    const templates = Array.isArray(archetype.itemTemplates)
+      ? (archetype.itemTemplates as Array<{ name?: unknown }>)
+      : [];
+    for (const template of templates) {
+      if (typeof template?.name !== "string") continue;
+      const key = template.name.trim().toLowerCase();
+      if (!key) continue;
+      (itemNameCategories[key] ??= new Set()).add(archetype.category);
+    }
+  }
+
+  return {
+    itemNameCategories: Object.fromEntries(
+      Object.entries(itemNameCategories).map(([k, v]) => [k, [...v]]),
+    ),
+    categoryLabels,
+  };
+}
+
+/**
+ * Classify a storefront's live items and sections for cross-archetype /
+ * duplicate residue. Loads the storefront's own content plus the fingerprint,
+ * then runs the pure classifier.
+ */
+export async function loadStorefrontContentFit(input: {
+  storefrontId: string;
+  currentCategory: string;
+  vocabulary?: ArchetypeVocabulary;
+  items?: FitItem[];
+  sections?: FitSection[];
+}): Promise<ContentFitResult> {
+  const [fingerprint, items, sections] = await Promise.all([
+    buildContentFitFingerprint(),
+    input.items ??
+      prisma.storefrontItem
+        .findMany({
+          where: { storefrontId: input.storefrontId },
+          select: { id: true, name: true, category: true, isActive: true },
+        })
+        .then((rows) => rows as FitItem[]),
+    input.sections ??
+      prisma.storefrontSection
+        .findMany({
+          where: { storefrontId: input.storefrontId },
+          select: { id: true, type: true, title: true, isVisible: true, sortOrder: true },
+        })
+        .then((rows) => rows as FitSection[]),
+  ]);
+
+  return classifyStorefrontContentFit({
+    currentCategory: input.currentCategory,
+    items,
+    sections,
+    fingerprint,
+    ...(input.vocabulary ? { vocabulary: input.vocabulary } : {}),
+  });
+}

--- a/apps/web/lib/storefront/content-fit.test.ts
+++ b/apps/web/lib/storefront/content-fit.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyStorefrontContentFit,
+  sectionDisplayName,
+  friendlySectionTypeLabel,
+  type ContentFitFingerprint,
+  type FitItem,
+  type FitSection,
+} from "./content-fit";
+import { getVocabulary } from "./archetype-vocabulary";
+
+const FINGERPRINT: ContentFitFingerprint = {
+  itemNameCategories: {
+    "pallet storage": ["warehousing-fulfilment"],
+    "goods-in & receiving": ["warehousing-fulfilment"],
+    "set dinner menu": ["food-hospitality"],
+    // A name legitimately shared by both restaurant and warehousing seeds.
+    "gift cards": ["food-hospitality", "retail-goods"],
+  },
+  categoryLabels: {
+    "warehousing-fulfilment": "Warehousing Fulfilment",
+    "food-hospitality": "Food Hospitality",
+  },
+};
+
+const restaurantVocab = getVocabulary("food-hospitality");
+
+function section(partial: Partial<FitSection> & { id: string; type: string }): FitSection {
+  return { title: null, isVisible: true, sortOrder: 0, ...partial };
+}
+
+describe("classifyStorefrontContentFit", () => {
+  it("flags foreign item-template names but never owner-typed or shared names", () => {
+    const items: FitItem[] = [
+      { id: "i1", name: "Set Dinner Menu", category: "Set Menus", isActive: true }, // native
+      { id: "i2", name: "Pallet Storage", category: null, isActive: true }, // foreign
+      { id: "i3", name: "Goods-In & Receiving", category: null, isActive: false }, // foreign, hidden
+      { id: "i4", name: "Table for 2", category: null, isActive: true }, // owner-authored, unknown
+      { id: "i5", name: "Gift Cards", category: null, isActive: true }, // shared with current → keep
+    ];
+    const result = classifyStorefrontContentFit({
+      currentCategory: "food-hospitality",
+      items,
+      sections: [],
+      fingerprint: FINGERPRINT,
+      vocabulary: restaurantVocab,
+    });
+
+    const ids = result.residueItems.map((r) => r.id).sort();
+    expect(ids).toEqual(["i2", "i3"]);
+    expect(result.residueItems[0]?.foreignLabel).toBe("Warehousing Fulfilment");
+    expect(result.hasResidue).toBe(true);
+  });
+
+  it("flags archetype-specific foreign sections and duplicate singletons, not universal ones", () => {
+    const sections: FitSection[] = [
+      section({ id: "s1", type: "hero", sortOrder: 0 }),
+      section({ id: "s2", type: "items", sortOrder: 1 }),
+      section({ id: "s3", type: "about", sortOrder: 2 }),
+      section({ id: "s4", type: "calculator", sortOrder: 3 }), // foreign (banking)
+      section({ id: "s5", type: "hero", sortOrder: 4 }), // duplicate singleton
+      section({ id: "s6", type: "custom", title: "Our story", sortOrder: 5 }), // universal, keep
+    ];
+    const result = classifyStorefrontContentFit({
+      currentCategory: "food-hospitality",
+      items: [],
+      sections,
+      fingerprint: FINGERPRINT,
+      vocabulary: restaurantVocab,
+    });
+
+    const foreign = result.residueSections.find((s) => s.reason === "foreign-archetype");
+    const duplicate = result.residueSections.find((s) => s.reason === "duplicate-section");
+    expect(foreign?.id).toBe("s4");
+    expect(duplicate?.id).toBe("s5"); // the SECOND hero, first is kept
+    expect(result.residueSections).toHaveLength(2);
+  });
+
+  it("does not flag an archetype-specific section that is native to the current category", () => {
+    const sections: FitSection[] = [section({ id: "s1", type: "donate", sortOrder: 0 })];
+    const result = classifyStorefrontContentFit({
+      currentCategory: "nonprofit-community",
+      items: [],
+      sections,
+      fingerprint: FINGERPRINT,
+      vocabulary: getVocabulary("nonprofit-community"),
+    });
+    expect(result.hasResidue).toBe(false);
+  });
+
+  it("groups residue by foreign source and by duplicates for one-action recovery", () => {
+    const result = classifyStorefrontContentFit({
+      currentCategory: "food-hospitality",
+      items: [{ id: "i2", name: "Pallet Storage", category: null, isActive: true }],
+      sections: [
+        section({ id: "s1", type: "hero", sortOrder: 0 }),
+        section({ id: "s5", type: "hero", sortOrder: 1 }),
+      ],
+      fingerprint: FINGERPRINT,
+      vocabulary: restaurantVocab,
+    });
+
+    const dup = result.groups.find((g) => g.key === "duplicate-sections");
+    const foreign = result.groups.find((g) => g.key.startsWith("category:"));
+    expect(dup?.sectionIds).toEqual(["s5"]);
+    expect(foreign?.itemIds).toEqual(["i2"]);
+    expect(foreign?.count).toBe(1);
+  });
+
+  it("returns no residue and no groups for a clean restaurant storefront", () => {
+    const result = classifyStorefrontContentFit({
+      currentCategory: "food-hospitality",
+      items: [{ id: "i1", name: "Set Dinner Menu", category: "Set Menus", isActive: true }],
+      sections: [
+        section({ id: "s1", type: "hero", sortOrder: 0 }),
+        section({ id: "s2", type: "items", sortOrder: 1 }),
+      ],
+      fingerprint: FINGERPRINT,
+      vocabulary: restaurantVocab,
+    });
+    expect(result.hasResidue).toBe(false);
+    expect(result.groups).toHaveLength(0);
+  });
+});
+
+describe("section display naming (no internal slug leakage)", () => {
+  it("prefers the owner's title, else a friendly label — never a raw slug", () => {
+    expect(sectionDisplayName({ type: "hero", title: null }, restaurantVocab)).toBe("Welcome banner");
+    expect(sectionDisplayName({ type: "items", title: null }, restaurantVocab)).toBe("Menu");
+    expect(sectionDisplayName({ type: "animals-available", title: null })).toBe("Adoptable animals");
+    expect(sectionDisplayName({ type: "hero", title: "  Welcome to Bella  " }, restaurantVocab)).toBe(
+      "Welcome to Bella",
+    );
+  });
+
+  it("humanises even unknown types rather than exposing the token", () => {
+    expect(friendlySectionTypeLabel("weird-new-type")).toBe("Weird New Type");
+  });
+
+  it("uses Restaurant vocabulary for menu and staff", () => {
+    expect(friendlySectionTypeLabel("items", restaurantVocab)).toBe("Menu");
+    expect(friendlySectionTypeLabel("team", restaurantVocab)).toBe("Staff");
+  });
+});

--- a/apps/web/lib/storefront/content-fit.ts
+++ b/apps/web/lib/storefront/content-fit.ts
@@ -1,0 +1,337 @@
+// apps/web/lib/storefront/content-fit.ts
+//
+// BI-CBE9B9B3 — owner-facing content-management recovery for the Restaurant
+// (and every other archetype) storefront editors.
+//
+// The menu/section editors are exactly where a non-technical owner goes to fix
+// bad *generated* content — including cross-archetype residue left behind when a
+// storefront was seeded from, or migrated between, archetypes (e.g. warehousing
+// "Pallet Storage" / "Goods-In & Receiving" items or a banking loan-calculator
+// section surfacing inside a Restaurant portal). Nothing marks that residue in
+// the schema, so this module classifies it from evidence:
+//
+//   1. Foreign item — an item whose name exactly matches a *different*
+//      archetype-category's seed item template (and is NOT also a template of the
+//      current category). Exact-match keeps false-positives near zero: a real
+//      "Set Dinner Menu" an owner typed is never a warehousing template name.
+//   2. Foreign section — a section whose type is archetype-specific (donate,
+//      animals-available, disclosures, calculator) and belongs to a category
+//      other than the current one. Universal section types (hero/about/items/
+//      contact/team/gallery/testimonials/custom) are NEVER flagged.
+//   3. Duplicate section — a second-or-later occurrence of a singleton section
+//      type (hero/about/contact/items), the classic generated-duplicate residue.
+//
+// Everything unknown or owner-authored is left strictly alone. The engine is a
+// pure function so it unit-tests without a database.
+
+import type { ArchetypeVocabulary } from "./archetype-vocabulary";
+
+// ─── Section-type vocabulary ────────────────────────────────────────────────
+
+/**
+ * Section types that must never appear more than once on a page. A second
+ * occurrence is generated duplicate residue.
+ */
+export const SINGLETON_SECTION_TYPES = ["hero", "about", "contact", "items"] as const;
+
+/**
+ * Archetype-specific section types → the archetype category they belong to.
+ * A section of one of these types is cross-archetype residue when the storefront
+ * is any *other* category. Types absent from this map are universal and are
+ * never treated as residue on fit grounds.
+ */
+export const ARCHETYPE_SPECIFIC_SECTION_TYPES: Record<string, { category: string; label: string }> = {
+  donate: { category: "nonprofit-community", label: "Donations" },
+  "animals-available": { category: "nonprofit-community", label: "Adoptable animals" },
+  disclosures: { category: "banking-financial-services", label: "Regulatory disclosures" },
+  calculator: { category: "banking-financial-services", label: "Loan calculator" },
+};
+
+/**
+ * Human-readable, non-technical names for the built-in section types. The
+ * editors show these (or the owner's own section title) instead of the raw slug,
+ * so an owner never has to read `hero` / `animals-available`. Archetype
+ * vocabulary is applied where it reads better (`items` → "Menu" for a
+ * restaurant, `team` → "Staff").
+ */
+export function friendlySectionTypeLabel(type: string, vocab?: ArchetypeVocabulary): string {
+  switch (type) {
+    case "hero":
+      return "Welcome banner";
+    case "about":
+      return "About";
+    case "items":
+      return vocab?.itemsLabel ?? "Items";
+    case "contact":
+      return "Contact";
+    case "team":
+      return vocab?.teamLabel ?? "Team";
+    case "gallery":
+      return "Photos";
+    case "testimonials":
+      return "Reviews";
+    case "donate":
+      return "Donations";
+    case "animals-available":
+      return "Adoptable animals";
+    case "disclosures":
+      return "Disclosures";
+    case "calculator":
+      return "Calculator";
+    case "custom":
+      return "Custom section";
+    default:
+      // Unknown type — humanise the slug so we still never leak a raw token.
+      return type
+        .split(/[-_]/)
+        .filter(Boolean)
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(" ");
+  }
+}
+
+/**
+ * Display name for a section row: prefer the owner's own title, otherwise the
+ * friendly type label. Never returns a bare slug.
+ */
+export function sectionDisplayName(
+  section: { type: string; title: string | null },
+  vocab?: ArchetypeVocabulary,
+): string {
+  const title = section.title?.trim();
+  if (title) return title;
+  return friendlySectionTypeLabel(section.type, vocab);
+}
+
+// ─── Fit fingerprint ────────────────────────────────────────────────────────
+
+/**
+ * The cross-archetype fingerprint the classifier matches against — derived once
+ * (server-side) from every archetype's seed templates. Kept separate from the
+ * pure classifier so the classifier stays database-free and testable.
+ */
+export interface ContentFitFingerprint {
+  /**
+   * Lower-cased seed item-template name → the set of categories that seed an
+   * item with that exact name. Used to decide whether an item name is a foreign
+   * template (belongs only to other categories) or shared with the current one.
+   */
+  itemNameCategories: Record<string, string[]>;
+  /** Category slug → human label, for describing where residue came from. */
+  categoryLabels: Record<string, string>;
+}
+
+// ─── Classification ─────────────────────────────────────────────────────────
+
+export interface FitItem {
+  id: string;
+  name: string;
+  category: string | null;
+  isActive: boolean;
+}
+
+export interface FitSection {
+  id: string;
+  type: string;
+  title: string | null;
+  isVisible: boolean;
+  sortOrder: number;
+}
+
+export type ResidueReason = "foreign-archetype" | "duplicate-section";
+
+export interface ResidueItem {
+  id: string;
+  name: string;
+  reason: "foreign-archetype";
+  foreignCategory: string;
+  foreignLabel: string;
+}
+
+export interface ResidueSection {
+  id: string;
+  name: string;
+  type: string;
+  reason: ResidueReason;
+  /** For foreign sections, the category the type belongs to. */
+  foreignCategory?: string;
+  foreignLabel?: string;
+}
+
+/**
+ * A grouped, previewable recovery unit. Each group gathers residue attributable
+ * to one foreign source (a cross-archetype category, or "duplicate sections")
+ * so the owner removes it in one deliberate action rather than one row at a time.
+ */
+export interface ResidueGroup {
+  key: string;
+  title: string;
+  description: string;
+  itemIds: string[];
+  sectionIds: string[];
+  itemNames: string[];
+  sectionNames: string[];
+  count: number;
+}
+
+export interface ContentFitResult {
+  residueItems: ResidueItem[];
+  residueSections: ResidueSection[];
+  groups: ResidueGroup[];
+  /** True when any residue was detected — the editors key their banner on this. */
+  hasResidue: boolean;
+}
+
+function humaniseCategory(category: string, labels: Record<string, string>): string {
+  return (
+    labels[category] ??
+    category
+      .split(/[-_]/)
+      .filter(Boolean)
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(" ")
+  );
+}
+
+/**
+ * Classify a storefront's items and sections against the current archetype,
+ * flagging cross-archetype and duplicate residue. Pure — no I/O.
+ */
+export function classifyStorefrontContentFit(input: {
+  currentCategory: string;
+  items: FitItem[];
+  sections: FitSection[];
+  fingerprint: ContentFitFingerprint;
+  vocabulary?: ArchetypeVocabulary;
+}): ContentFitResult {
+  const { currentCategory, items, sections, fingerprint, vocabulary } = input;
+  const residueItems: ResidueItem[] = [];
+  const residueSections: ResidueSection[] = [];
+
+  // ── Foreign items: exact name match to another category's seed template ──
+  for (const item of items) {
+    const key = item.name.trim().toLowerCase();
+    const categories = fingerprint.itemNameCategories[key];
+    if (!categories || categories.length === 0) continue;
+    // Shared with the current category → legitimate, never flag.
+    if (categories.includes(currentCategory)) continue;
+    const foreignCategory = categories[0]!;
+    residueItems.push({
+      id: item.id,
+      name: item.name,
+      reason: "foreign-archetype",
+      foreignCategory,
+      foreignLabel: humaniseCategory(foreignCategory, fingerprint.categoryLabels),
+    });
+  }
+
+  // ── Foreign sections: archetype-specific type from another category ──
+  const seenSingletonTypes = new Set<string>();
+  const sortedSections = [...sections].sort((a, b) => a.sortOrder - b.sortOrder);
+  for (const section of sortedSections) {
+    const name = sectionDisplayName(section, vocabulary);
+    const specific = ARCHETYPE_SPECIFIC_SECTION_TYPES[section.type];
+    if (specific && specific.category !== currentCategory) {
+      residueSections.push({
+        id: section.id,
+        name,
+        type: section.type,
+        reason: "foreign-archetype",
+        foreignCategory: specific.category,
+        foreignLabel: humaniseCategory(specific.category, fingerprint.categoryLabels),
+      });
+      continue;
+    }
+    // ── Duplicate singleton sections ──
+    if ((SINGLETON_SECTION_TYPES as readonly string[]).includes(section.type)) {
+      if (seenSingletonTypes.has(section.type)) {
+        residueSections.push({
+          id: section.id,
+          name,
+          type: section.type,
+          reason: "duplicate-section",
+        });
+      } else {
+        seenSingletonTypes.add(section.type);
+      }
+    }
+  }
+
+  const groups = buildGroups(residueItems, residueSections, vocabulary);
+
+  return {
+    residueItems,
+    residueSections,
+    groups,
+    hasResidue: residueItems.length > 0 || residueSections.length > 0,
+  };
+}
+
+function buildGroups(
+  residueItems: ResidueItem[],
+  residueSections: ResidueSection[],
+  vocabulary?: ArchetypeVocabulary,
+): ResidueGroup[] {
+  const byCategory = new Map<
+    string,
+    { label: string; itemIds: string[]; sectionIds: string[]; itemNames: string[]; sectionNames: string[] }
+  >();
+
+  const ensure = (category: string, label: string) => {
+    let g = byCategory.get(category);
+    if (!g) {
+      g = { label, itemIds: [], sectionIds: [], itemNames: [], sectionNames: [] };
+      byCategory.set(category, g);
+    }
+    return g;
+  };
+
+  for (const item of residueItems) {
+    const g = ensure(item.foreignCategory, item.foreignLabel);
+    g.itemIds.push(item.id);
+    g.itemNames.push(item.name);
+  }
+  for (const section of residueSections) {
+    if (section.reason !== "foreign-archetype") continue;
+    const g = ensure(section.foreignCategory!, section.foreignLabel!);
+    g.sectionIds.push(section.id);
+    g.sectionNames.push(section.name);
+  }
+
+  const groups: ResidueGroup[] = [];
+  const itemsWord = (vocabulary?.itemsLabel ?? "items").toLowerCase();
+  for (const [category, g] of byCategory) {
+    const count = g.itemIds.length + g.sectionIds.length;
+    groups.push({
+      key: `category:${category}`,
+      title: `${g.label} content`,
+      description:
+        `This ${itemsWord} content looks like it came from a different business type (${g.label}) ` +
+        `and doesn't fit your storefront.`,
+      itemIds: g.itemIds,
+      sectionIds: g.sectionIds,
+      itemNames: g.itemNames,
+      sectionNames: g.sectionNames,
+      count,
+    });
+  }
+
+  // Duplicate sections form their own group.
+  const duplicates = residueSections.filter((s) => s.reason === "duplicate-section");
+  if (duplicates.length > 0) {
+    groups.push({
+      key: "duplicate-sections",
+      title: "Duplicate sections",
+      description:
+        "These sections repeat one that already appears on your page. Removing the duplicates " +
+        "leaves the first of each kind in place.",
+      itemIds: [],
+      sectionIds: duplicates.map((s) => s.id),
+      itemNames: [],
+      sectionNames: duplicates.map((s) => s.name),
+      count: duplicates.length,
+    });
+  }
+
+  return groups;
+}

--- a/apps/web/lib/storefront/content-recovery-actions.ts
+++ b/apps/web/lib/storefront/content-recovery-actions.ts
@@ -1,0 +1,168 @@
+"use server";
+
+// apps/web/lib/storefront/content-recovery-actions.ts
+//
+// BI-CBE9B9B3 — grouped recovery of generated / cross-archetype residue from the
+// menu and section editors. The owner reviews an affected-artifact preview, then
+// removes a whole group in one action instead of deleting rows one at a time.
+//
+// Trust boundary: the client sends the ids it wants removed, but this action
+// re-derives the residue set server-side and removes ONLY ids that are both
+// requested AND independently classified as residue for this storefront. A stale
+// or tampered client can never use it to delete legitimate owner content.
+
+import { prisma } from "@dpf/db";
+import { auth } from "@/lib/auth";
+import { revalidatePath } from "next/cache";
+import { loadStorefrontContentFit } from "./content-fit.server";
+import { getVocabulary } from "./archetype-vocabulary";
+
+export interface RecoverResidueRequest {
+  itemIds: string[];
+  sectionIds: string[];
+}
+
+export interface SkippedItem {
+  id: string;
+  name: string;
+  reason: string;
+}
+
+export type RecoverResidueResult =
+  | {
+      success: true;
+      removedItems: number;
+      removedSections: number;
+      deactivatedItems: number;
+      skipped: SkippedItem[];
+    }
+  | { error: string };
+
+async function requireAdminOrg(): Promise<{ organizationId: string } | { error: string }> {
+  const session = await auth();
+  if (!session?.user || (session.user as { type?: string }).type !== "admin") {
+    return { error: "Unauthorized" };
+  }
+  const org = await prisma.organization.findFirst({ select: { id: true } });
+  if (!org) return { error: "Organization not found" };
+  return { organizationId: org.id };
+}
+
+export async function recoverGeneratedResidue(
+  storefrontId: string,
+  request: RecoverResidueRequest,
+): Promise<RecoverResidueResult> {
+  const authed = await requireAdminOrg();
+  if ("error" in authed) return authed;
+
+  const storefront = await prisma.storefrontConfig.findFirst({
+    where: { id: storefrontId, organizationId: authed.organizationId },
+    include: {
+      archetype: { select: { category: true, archetypeId: true, customVocabulary: true } },
+    },
+  });
+  if (!storefront) return { error: "Storefront not found" };
+
+  const vocabulary = getVocabulary(
+    storefront.archetype.category,
+    storefront.archetype.customVocabulary as Record<string, string> | null,
+  );
+
+  // Re-derive residue server-side; act only on the intersection with the request.
+  const fit = await loadStorefrontContentFit({
+    storefrontId,
+    currentCategory: storefront.archetype.category,
+    vocabulary,
+  });
+
+  const residueItemIds = new Set(fit.residueItems.map((i) => i.id));
+  const residueSectionIds = new Set(fit.residueSections.map((s) => s.id));
+
+  const targetItemIds = request.itemIds.filter((id) => residueItemIds.has(id));
+  const targetSectionIds = request.sectionIds.filter((id) => residueSectionIds.has(id));
+
+  if (targetItemIds.length === 0 && targetSectionIds.length === 0) {
+    return {
+      error: "Nothing to recover — this content no longer looks like generated residue.",
+    };
+  }
+
+  const skipped: SkippedItem[] = [];
+  let deactivatedItems = 0;
+  let removedItems = 0;
+  let removedSections = 0;
+
+  // Items that carry real customer footprint (bookings/inquiries) are deactivated
+  // rather than hard-deleted, mirroring the single-item DELETE route contract so
+  // recovery never destroys booking history.
+  const deletableItemIds: string[] = [];
+  if (targetItemIds.length > 0) {
+    const items = await prisma.storefrontItem.findMany({
+      where: { id: { in: targetItemIds }, storefrontId },
+      select: { id: true, name: true },
+    });
+    const validIds = new Set(items.map((i) => i.id));
+    const nameById = new Map(items.map((i) => [i.id, i.name] as const));
+
+    const [bookings, inquiries] = await Promise.all([
+      prisma.storefrontBooking.groupBy({
+        by: ["itemId"],
+        where: { itemId: { in: [...validIds] } },
+        _count: { itemId: true },
+      }),
+      prisma.storefrontInquiry.groupBy({
+        by: ["itemId"],
+        where: { itemId: { in: [...validIds] } },
+        _count: { itemId: true },
+      }),
+    ]);
+    const hasFootprint = new Set<string>([
+      ...bookings.map((b) => b.itemId),
+      ...inquiries.map((i) => i.itemId).filter((id): id is string => id !== null),
+    ]);
+
+    for (const id of validIds) {
+      if (hasFootprint.has(id)) {
+        skipped.push({
+          id,
+          name: nameById.get(id) ?? id,
+          reason: "Has bookings or enquiries — deactivated instead of deleted.",
+        });
+      } else {
+        deletableItemIds.push(id);
+      }
+    }
+
+    const footprintIds = [...hasFootprint].filter((id) => validIds.has(id));
+    if (footprintIds.length > 0) {
+      const res = await prisma.storefrontItem.updateMany({
+        where: { id: { in: footprintIds } },
+        data: { isActive: false },
+      });
+      deactivatedItems = res.count;
+    }
+  }
+
+  await prisma.$transaction(async (tx) => {
+    if (deletableItemIds.length > 0) {
+      await tx.providerService.deleteMany({ where: { itemId: { in: deletableItemIds } } });
+      await tx.bookingHold.deleteMany({ where: { itemId: { in: deletableItemIds } } });
+      const res = await tx.storefrontItem.deleteMany({
+        where: { id: { in: deletableItemIds }, storefrontId },
+      });
+      removedItems = res.count;
+    }
+    if (targetSectionIds.length > 0) {
+      const res = await tx.storefrontSection.deleteMany({
+        where: { id: { in: targetSectionIds }, storefrontId },
+      });
+      removedSections = res.count;
+    }
+  });
+
+  revalidatePath("/storefront/items");
+  revalidatePath("/storefront/sections");
+  revalidatePath("/storefront");
+
+  return { success: true, removedItems, removedSections, deactivatedItems, skipped };
+}

--- a/docs/superpowers/specs/2026-07-22-storefront-content-editing-mobile-recovery.md
+++ b/docs/superpowers/specs/2026-07-22-storefront-content-editing-mobile-recovery.md
@@ -1,0 +1,116 @@
+# Storefront menu & section editors — mobile-safe, preview-first, recoverable
+
+- **Backlog item:** BI-CBE9B9B3 — "Storefront menu and section editors need mobile-safe preview-first recovery flows"
+- **Epic:** EP-UX-COGLOAD — Live UX cognitive-load audit follow-up
+- **Status:** implemented
+- **Date:** 2026-07-22
+
+## Problem
+
+The 390×844 owner-mobile audit found `/storefront/items` (~70 actions, 69 sub-44px
+controls, `Edit`×11 / `Del`×11 / `Off`×6 / `On`×5) and `/storefront/sections`
+(~69 actions, `↑`/`↓`×11, `Show`×7 / `Hide`×4, raw type slugs) mobile-hostile.
+These are exactly the pages a non-technical owner opens to fix bad *generated*
+content — including cross-archetype residue (warehousing "Pallet Storage",
+"Goods-In & Receiving", "Pick & Despatch", or a banking loan-calculator section
+surfacing inside a Restaurant portal) — yet the controls were small, terse,
+repeated, and their public/durable mutations fired with no preview and no
+recoverable result state.
+
+A sibling PR (#3395) already applied the 44px minimum + per-row `aria-label`s to
+these managers. This item owns the deeper content-management slice the tap-target
+work explicitly left out: **preview-first public mutations, per-row result state,
+Restaurant vocabulary, action-count reduction, and grouped residue recovery.**
+
+## Scope & overlap
+
+Swept `gh pr list` (open #3387–#3407): no open PR touches `ItemsManager`,
+`SectionsManager`, the `/storefront/{items,sections}` pages, or the storefront
+content-fit surface. Sibling BI-C39DC90C (#3389) owns setup-page service-line
+recovery; this PR is disjoint — it operates on the item/section editors and adds
+a distinct *cross-archetype* residue detector (primary-seed residue that
+`sourceCompositionId`-based service-line recovery does not cover).
+
+## Design grounding
+
+- **Specs/plans reviewed:** `docs/superpowers/specs/` EP-UX-COGLOAD set, notably
+  `2026-07-22-storefront-owner-mobile-setup-design.md` (sibling setup slice).
+- **Code substrate reviewed (`apps/web/`):**
+  `components/storefront-admin/{ItemsManager,SectionsManager}.tsx`,
+  `lib/storefront/{archetype-vocabulary,service-line-actions,archetype-reset}.ts`,
+  `components/storefront/SectionRenderer.tsx`, the
+  `api/storefront/admin/{items,sections}/*` routes, and the
+  `StorefrontItem`/`StorefrontSection`/`StorefrontArchetype` models.
+- **Source of truth:** archetype seed templates (`StorefrontArchetype.itemTemplates`
+  / `sectionTemplates`) are authoritative for "what belongs"; the renderer's
+  `switch (section.type)` is the closed section-type universe.
+- **Decision:** new artifact (this doc) + new modules; no existing contract
+  changed. No new API route (recovery is a server action), so route-manifest and
+  audience baselines are untouched.
+
+## Design
+
+### 1. Row action sheet (action-count + hit-area)
+`RowActionSheet` collapses every row's controls into **one** 44px "Manage"
+trigger whose accessible name is row-specific (`Manage Table for 2`). It opens a
+bottom sheet of full-sentence, row-specific actions (`Hide Table for 2 from your
+public menu`, `Move Set Dinner Menu up`, `Remove Sunday Roast`). This takes the
+pages from ~70 tap targets to one-per-row and removes every repeated terse label.
+Reorder moves from mobile-hostile drag/drop to explicit labelled Move up/down.
+
+### 2. Preview-first public mutations
+`confirmPublicChange` previews **what** changes, **where** it shows (`your public
+menu` / `your public page`), and **whether the live site is affected right now**
+(keyed on `StorefrontConfig.isPublished`) before any visibility/active/remove
+mutation runs. Reorder is low-stakes and gets result state without a blocking
+preview.
+
+### 3. Per-row result state + retry/revert
+`useRowMutations` tracks pending → saved → failed per row; `MutationStatus`
+renders it inline with a Retry that re-runs the exact action. Every mutation
+applies optimistically and **reverts on failure**, replacing the previous bare
+`fetch` with no feedback.
+
+### 4. Grouped generated-residue recovery
+`lib/storefront/content-fit.ts` (pure, unit-tested) classifies residue from
+evidence — no schema flag exists:
+- **Foreign item** — name exactly matches a *different* category's seed item
+  template (and not the current category's). Exact-match keeps false-positives
+  near zero; owner-typed names match no foreign template.
+- **Foreign section** — an archetype-specific section type (`donate`,
+  `animals-available`, `disclosures`, `calculator`) belonging to another
+  category. Universal types (hero/about/items/contact/team/gallery/testimonials/
+  custom) are never flagged.
+- **Duplicate section** — a second-or-later singleton section (hero/about/
+  contact/items).
+
+`content-fit.server.ts` builds the fingerprint from every archetype's seed
+templates. `GeneratedResidueBanner` shows the grouped, previewable recovery with
+an affected-artifact list; `recoverGeneratedResidue` (server action) **re-derives
+the residue set server-side** and removes only ids that are both requested and
+independently classified — a stale/tampered client can never delete legitimate
+content. Items with real bookings/enquiries are deactivated, not deleted,
+mirroring the single-item DELETE contract.
+
+### 5. Restaurant vocabulary, no slug leakage
+Section rows show the owner's title or a friendly label (`hero` → "Welcome
+banner", `items` → "Menu", `team` → "Staff") via `sectionDisplayName`; the raw
+`type` slug is never rendered. Menu labels use `ArchetypeVocabulary`.
+
+## Testing
+
+- `lib/storefront/content-fit.test.ts` — detection: foreign items, foreign/
+  duplicate sections, no false-positives on owner or shared content, grouping,
+  friendly naming.
+- `components/storefront-admin/mobile-content-ux.test.tsx` — the required mobile
+  UX checks against the default 390px render: one labelled action per row, no
+  sub-44px controls, unique (non-repeated) accessible names, no internal slug
+  leakage, and recovery-surface presence only when residue exists.
+
+## Files
+
+- New: `lib/storefront/content-fit.ts`, `content-fit.server.ts`,
+  `content-recovery-actions.ts`; `components/storefront-admin/content-editing-ui.tsx`;
+  two test files; this doc.
+- Changed: `components/storefront-admin/{ItemsManager,SectionsManager}.tsx`,
+  `app/(shell)/storefront/{items,sections}/page.tsx`.

--- a/docs/user-guide/storefront/catalog-and-page-content.md
+++ b/docs/user-guide/storefront/catalog-and-page-content.md
@@ -17,8 +17,37 @@ order: 3
 2. Keep item details, sections, and published messaging aligned.
 3. Re-check the public storefront after a meaningful content change.
 
+## Managing a row
+
+Each menu item and page section has one **Manage** button. Tap it to open a list
+of clearly named actions for that specific row — for example *Hide Table for 2
+from your public menu*, *Move Set Dinner Menu up*, *Edit Sunday Roast*, or
+*Remove* — instead of a wall of tiny repeated buttons. Section rows are shown by
+their friendly name (a "Welcome banner", your "Menu", your "Staff" section), not
+an internal type code.
+
+Anything that changes your public site — hiding or showing an item or section,
+or removing one — first shows a short preview of **what** will change, **where**
+it appears, and whether your live page is affected right now. Nothing is applied
+until you confirm.
+
+After you confirm, the row shows its progress: **Saving…**, then **Saved**, or
+**Couldn't save** with a **Retry** button. If a change fails it is rolled back,
+so the list always matches what customers actually see.
+
+## Fixing generated content that doesn't fit
+
+If setup or an earlier business type left behind content that doesn't belong —
+items or sections that read like a different kind of business, or duplicate
+sections — a banner appears at the top of the page. Open **Review** to see
+exactly which items and sections are affected, then remove a group in one action.
+Items that already have real bookings or enquiries are turned off rather than
+deleted, so you never lose customer history.
+
 ## What To Watch
 
 - sections promising flows that the underlying item cannot support
 - item changes that break the storefront story or page order
 - editing internal management data without verifying customer-facing output
+- removing generated content: check the affected-artifact list in the review
+  banner before confirming, since removal affects your public page


### PR DESCRIPTION
## What & why

`BI-CBE9B9B3` (EP-UX-COGLOAD). The 390×844 owner-mobile audit found `/storefront/items` (~70 actions, 69 sub-44px controls, `Edit`×11/`Del`×11/`On`+`Off`) and `/storefront/sections` (raw type slugs, `↑`/`↓`×11, `Show`/`Hide`) mobile-hostile — exactly the pages a non-technical owner opens to fix bad *generated* content, including cross-archetype residue (warehousing "Pallet Storage" / a banking loan-calculator section inside a Restaurant portal). Mutations fired to the public site with no preview and no recoverable result state.

A sibling (#3395) already added 44px + aria-labels here; this PR owns the deeper content-management slice that work left out.

## Acceptance → implementation

- **Row-specific labels replace terse repeated controls** — `RowActionSheet`: one 44px `Manage {name}` trigger per row opens a sheet of full, row-specific actions (`Hide Table for 2 from your public menu`, `Move Set Dinner Menu up`, `Remove Sunday Roast`). ~70 tap targets → one per row; drag reorder → explicit labelled Move up/down.
- **Public changes preview before execution** — `confirmPublicChange` shows what changes, where it appears, and whether the live site is affected (`isPublished`) before any visibility/active/remove mutation.
- **Pending/saved/failed + retry/revert** — `useRowMutations` + `MutationStatus`; every mutation is optimistic and reverts on failure with a Retry.
- **Generated content marked + grouped recovery** — pure `content-fit.ts` engine flags foreign seed-template items, foreign archetype-specific sections, and duplicate singletons; `GeneratedResidueBanner` previews affected artifacts and removes a group in one action. `recoverGeneratedResidue` (server action) **re-derives residue server-side** before deleting; items with bookings/enquiries are deactivated, not deleted.
- **Restaurant vocabulary before internal terms** — `sectionDisplayName` shows friendly names (`hero`→"Welcome banner", `items`→"Menu", `team`→"Staff"); the raw `type` slug is never rendered.
- **Mobile UX checks** — `content-fit.test.ts` (detection: foreign/duplicate/no-false-positive/grouping) and `mobile-content-ux.test.tsx` (sub-44px, repeated labels, action count, slug leakage, recovery state).

## Design grounding

Spec: `docs/superpowers/specs/2026-07-22-storefront-content-editing-mobile-recovery.md`. No new API route — recovery is a server action, so route-manifest/audience baselines are untouched. No schema change (residue is classified from archetype seed templates, not a stored flag).

## Testing

- `content-fit.test.ts` (8) + `mobile-content-ux.test.tsx` (7) green locally.
- Scoped `tsc` clean apart from environmental `next/*`+prisma-client resolution in this worktree (present even in unchanged files); CI Typecheck gates the merge.

## Overlap

Swept open PRs (#3387–#3407): none touch these managers, pages, or the content-fit surface. Rebased onto current `origin/main`; `git diff --name-only origin/main HEAD` is exactly the 11 files in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)