### PR TITLE
feat(owner-first): open business domains with owner daily work before subsystems (BI-3BCAF95F)

### DIFF
--- a/apps/web/app/(shell)/customer/(crm)/funnel/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/funnel/page.tsx
@@ -1,4 +1,5 @@
 // apps/web/app/(shell)/customer/funnel/page.tsx
+import { cookies } from "next/headers";
 import { prisma } from "@dpf/db";
 import {
   CRM_TONE_CLASSES,
@@ -7,6 +8,10 @@ import {
   type CrmTone,
 } from "@/lib/crm/presentation";
 import { formatRevenueAmount } from "@/lib/crm/revenue-cockpit";
+import { OwnerFirstSummaryBand } from "@/components/owner-first/OwnerFirstSummary";
+import { loadOwnerFirstContext } from "@/lib/owner-first/context";
+import { buildWorkspaceStorefrontSummary } from "@/lib/owner-first/domain-summary";
+import { isSimpleNavMode, NAV_MODE_COOKIE, resolveNavModeFromCookie } from "@/lib/navigation/nav-mode";
 
 function getFunnelWidthClass(width: number) {
   if (width >= 90) return "w-full";
@@ -117,6 +122,23 @@ export default async function FunnelPage() {
     ? convRates.reduce((min, c) => (Number(c.rate) < Number(min.rate) ? c : min))
     : null;
 
+  // Owner-first: turn the top-of-funnel storefront counts into concrete guest
+  // follow-up work before the conversion-analysis view (BI-3BCAF95F). The funnel
+  // 30-day counts stay below; these are the items still awaiting a response.
+  const simple = isSimpleNavMode(
+    resolveNavModeFromCookie((await cookies()).get(NAV_MODE_COOKIE)?.value),
+  );
+  const [{ vocab }, pendingReservations, newInquiriesPending, pendingOrders] = await Promise.all([
+    loadOwnerFirstContext(),
+    prisma.storefrontBooking.count({ where: { status: "pending" } }),
+    prisma.storefrontInquiry.count({ where: { status: "new" } }),
+    prisma.storefrontOrder.count({ where: { status: "pending" } }),
+  ]);
+  const ownerSummary = buildWorkspaceStorefrontSummary(
+    { pendingReservations, newInquiries: newInquiriesPending, pendingOrders },
+    vocab,
+  );
+
   return (
     <div>
       <div className="mb-6">
@@ -125,6 +147,9 @@ export default async function FunnelPage() {
           {config?.archetype?.name ?? "Unknown business"} — last 30 days
         </p>
       </div>
+
+      {/* Owner-first: guest work waiting on a response, before the analysis. */}
+      <OwnerFirstSummaryBand summary={ownerSummary} density={simple ? "simple" : "full"} />
 
       {/* Funnel visualisation */}
       <div className="space-y-3 mb-6">
@@ -168,7 +193,10 @@ export default async function FunnelPage() {
         </div>
       )}
 
-      {/* Pipeline breakdown by stage */}
+      {/* Pipeline + inbox breakdown — the analyst detail. Simple mode drops it to
+          reduce body content (BI-3BCAF95F). */}
+      {!simple && (
+        <>
       <div className="mb-6">
         <h2 className="text-sm font-semibold text-[var(--dpf-text)] mb-3">Pipeline by Stage</h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
@@ -227,6 +255,8 @@ export default async function FunnelPage() {
           })}
         </div>
       </div>
+        </>
+      )}
 
       {totalInteractions === 0 && (
         <p className="text-sm text-[var(--dpf-muted)] mt-4">

--- a/apps/web/app/(shell)/customer/(crm)/page.tsx
+++ b/apps/web/app/(shell)/customer/(crm)/page.tsx
@@ -1,7 +1,13 @@
 // apps/web/app/(shell)/customer/page.tsx
 import Link from "next/link";
+import { cookies } from "next/headers";
 import { prisma } from "@dpf/db";
 import { EXCLUDE_TOMBSTONED } from "@dpf/db/customer-lifecycle";
+import { OwnerFirstSummaryBand } from "@/components/owner-first/OwnerFirstSummary";
+import { OwnerFirstDisclosure } from "@/components/owner-first/OwnerFirstDisclosure";
+import { loadOwnerFirstContext } from "@/lib/owner-first/context";
+import { buildCustomerOwnerSummary } from "@/lib/owner-first/domain-summary";
+import { isSimpleNavMode, NAV_MODE_COOKIE, resolveNavModeFromCookie } from "@/lib/navigation/nav-mode";
 import { NewCustomerButton } from "@/components/customer/NewCustomerButton";
 import { DuplicateAccountsPanel } from "@/components/customer/DuplicateAccountsPanel";
 import { RevenueCockpit } from "@/components/customer/RevenueCockpit";
@@ -169,6 +175,33 @@ export default async function CustomerPage({
   );
   const attentionCount = accountsWithAttention.filter((a) => a.attention.signal).length;
 
+  // Owner-first summary: guest follow-up leads, CRM structure moves behind
+  // progressive disclosure (BI-3BCAF95F). Reuse the storefront queues so
+  // reservations/orders/inquiries become concrete follow-up work.
+  const simple = isSimpleNavMode(
+    resolveNavModeFromCookie((await cookies()).get(NAV_MODE_COOKIE)?.value),
+  );
+  const [{ vocab }, pendingReservations, newInquiries, pendingOrders] = await Promise.all([
+    loadOwnerFirstContext(),
+    prisma.storefrontBooking.count({ where: { status: "pending" } }),
+    prisma.storefrontInquiry.count({ where: { status: "new" } }),
+    prisma.storefrontOrder.count({ where: { status: "pending" } }),
+  ]);
+  const unworkedEngagements = engagementCounts
+    .filter((e) => e.status === "new" || e.status === "contacted")
+    .reduce((sum, e) => sum + e._count, 0);
+  const ownerSummary = buildCustomerOwnerSummary(
+    {
+      pendingReservations,
+      pendingOrders,
+      newInquiries,
+      unworkedEngagements,
+      overdueInvoices: overdueInvoiceCount,
+      renewalsDueSoon: renewalsDueSoonCount,
+    },
+    vocab,
+  );
+
   return (
     <div>
       <div className="mb-6 flex items-start justify-between">
@@ -189,14 +222,28 @@ export default async function CustomerPage({
         <NewCustomerButton />
       </div>
 
-      <RevenueCockpit summary={revenueSummary} />
+      {/* Owner-first: what guest work needs you today, before the CRM. */}
+      <OwnerFirstSummaryBand summary={ownerSummary} density={simple ? "simple" : "full"} />
 
-      <DuplicateAccountsPanel />
+      {/* CRM structure — revenue, duplicates, pipeline grid, and the account list —
+          is the professional detail behind the daily work. Full mode keeps it one
+          click away; Simple mode drops it to reduce body content (BI-3BCAF95F). A
+          grid/surface deep-link (`?view=`) still renders, opened, so the demotion
+          never strands that navigation. */}
+      {(!simple || view) && (
+        <OwnerFirstDisclosure
+          summary="All CRM detail"
+          hint="Revenue, accounts, and pipeline"
+          defaultOpen={Boolean(view)}
+        >
+          <RevenueCockpit summary={revenueSummary} />
 
-      <PlatformGridSection entityType="customer_account" view={view} />
+          <DuplicateAccountsPanel />
 
-      {!view && (
-        <>
+          <PlatformGridSection entityType="customer_account" view={view} />
+
+          {!view && (
+            <>
       {/* Account list — accounts needing the operator lead the list. */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {accountsWithAttention.map((a) => {
@@ -246,7 +293,9 @@ export default async function CustomerPage({
       {accounts.length === 0 && (
         <p className="text-sm text-[var(--dpf-muted)]">No accounts registered yet.</p>
       )}
-        </>
+            </>
+          )}
+        </OwnerFirstDisclosure>
       )}
     </div>
   );

--- a/apps/web/app/(shell)/employee/page.test.tsx
+++ b/apps/web/app/(shell)/employee/page.test.tsx
@@ -14,6 +14,10 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(),
 }));
 
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({ get: () => undefined }),
+}));
+
 vi.mock("@/lib/auth", () => ({
   auth: vi.fn().mockResolvedValue({ user: { id: "user-1", platformRole: "HR-000", isSuperuser: false } }),
 }));
@@ -38,6 +42,13 @@ vi.mock("@dpf/db", () => ({
     },
     orgSettings: {
       findFirst: vi.fn().mockResolvedValue(null),
+    },
+    // Owner-first summary (BI-3BCAF95F): archetype context + timesheet approvals.
+    storefrontConfig: {
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
+    timesheetPeriod: {
+      count: vi.fn().mockResolvedValue(0),
     },
   },
 }));

--- a/apps/web/app/(shell)/employee/page.tsx
+++ b/apps/web/app/(shell)/employee/page.tsx
@@ -1,5 +1,11 @@
 // apps/web/app/(shell)/employee/page.tsx
+import { cookies } from "next/headers";
 import { prisma } from "@dpf/db";
+import { OwnerFirstSummaryBand } from "@/components/owner-first/OwnerFirstSummary";
+import { OwnerFirstDisclosure } from "@/components/owner-first/OwnerFirstDisclosure";
+import { loadOwnerFirstContext } from "@/lib/owner-first/context";
+import { buildEmployeeOwnerSummary } from "@/lib/owner-first/domain-summary";
+import { isSimpleNavMode, NAV_MODE_COOKIE, resolveNavModeFromCookie } from "@/lib/navigation/nav-mode";
 import { EmployeeDirectoryPanel } from "@/components/employee/EmployeeDirectoryPanel";
 import { EmployeeProfilePanel } from "@/components/employee/EmployeeProfilePanel";
 import { EmployeeTabNav } from "@/components/employee/EmployeeTabNav";
@@ -137,12 +143,30 @@ export default async function EmployeePage({ searchParams }: Props) {
   }
   const compensationRows = view === "directory" ? await getEmployeeCompensationRows() : [];
 
+  // Owner-first: lead with service-staffing readiness, then demote role
+  // governance behind progressive disclosure (BI-3BCAF95F). For a Restaurant
+  // owner, "who is on for the next service" comes before HITL tiers and SLAs.
+  const simple = isSimpleNavMode(
+    resolveNavModeFromCookie((await cookies()).get(NAV_MODE_COOKIE)?.value),
+  );
+  const [{ vocab }, submittedTimesheets] = await Promise.all([
+    loadOwnerFirstContext(),
+    prisma.timesheetPeriod.count({ where: { status: "submitted" } }),
+  ]);
+  const unassignedRoles = roles.filter((r) => r._count.users === 0).length;
+  const ownerSummary = buildEmployeeOwnerSummary(
+    { submittedTimesheets, teamSize: employees.length, unassignedRoles },
+    vocab,
+  );
+
   return (
     <div>
       <div className="mb-6 flex items-start justify-between">
         <div>
-          <h1 className="text-xl font-bold text-[var(--dpf-text)]">Employee</h1>
+          <h1 className="text-xl font-bold text-[var(--dpf-text)]">People</h1>
           <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
+            {employees.length} {employees.length === 1 ? "person" : "people"}
+            {" · "}
             {roles.length} role{roles.length !== 1 ? "s" : ""}
           </p>
         </div>
@@ -170,48 +194,8 @@ export default async function EmployeePage({ searchParams }: Props) {
         />
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        {roles.map((r) => {
-          const userCount = r._count.users;
-          const sla =
-            r.slaDurationH != null && r.slaDurationH > 0
-              ? `${r.slaDurationH}h SLA`
-              : "No SLA";
-
-          return (
-            <div
-              key={r.id}
-              className="p-4 rounded-lg bg-[var(--dpf-surface-1)] border-l-4"
-              style={{ borderLeftColor: "#7c8cf8" }}
-            >
-              <p className="text-[9px] font-mono text-[var(--dpf-muted)] mb-1">
-                {r.roleId}
-              </p>
-              <p className="text-sm font-semibold text-[var(--dpf-text)] leading-tight mb-1">
-                {r.name}
-              </p>
-              {r.description != null && (
-                <p className="text-[10px] text-[var(--dpf-muted)] line-clamp-2 mb-2">
-                  {r.description}
-                </p>
-              )}
-              <div className="flex flex-wrap gap-2">
-                <span className="text-[9px] text-[var(--dpf-muted)]">
-                  HITL T{r.hitlTierMin}
-                </span>
-                <span className="text-[9px] text-[var(--dpf-muted)]">{sla}</span>
-                <span className="text-[9px] text-[var(--dpf-muted)]">
-                  {userCount === 0 ? "Unassigned" : `${userCount} ${userCount === 1 ? "person" : "people"}`}
-                </span>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-
-      {roles.length === 0 && (
-        <p className="text-sm text-[var(--dpf-muted)]">No roles registered yet.</p>
-      )}
+      {/* Owner-first: service-staffing readiness leads. */}
+      <OwnerFirstSummaryBand summary={ownerSummary} density={simple ? "simple" : "full"} />
 
       <div className="mt-8">
         <EmployeeTabNav />
@@ -276,18 +260,73 @@ export default async function EmployeePage({ searchParams }: Props) {
         )}
       </div>
 
-      {users.length > 0 && (
+      {/* Role governance — HITL tiers, SLAs, and user access. Demoted behind
+          progressive disclosure so staffing readiness leads (BI-3BCAF95F). Simple
+          mode drops it entirely to reduce body content. */}
+      {!simple && (
         <div className="mt-8">
-          <HrUserLifecyclePanel
-            roles={roles.map((role) => ({ roleId: role.roleId, name: role.name }))}
-            users={users.map((user) => ({
-              id: user.id,
-              email: user.email,
-              isActive: user.isActive,
-              isSuperuser: user.isSuperuser,
-              roleId: user.groups[0]?.platformRole.roleId ?? null,
-            }))}
-          />
+          <OwnerFirstDisclosure
+            summary="Role governance & access"
+            hint="HITL tiers, SLAs, and who can do what"
+          >
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {roles.map((r) => {
+                const userCount = r._count.users;
+                const sla =
+                  r.slaDurationH != null && r.slaDurationH > 0
+                    ? `${r.slaDurationH}h SLA`
+                    : "No SLA";
+
+                return (
+                  <div
+                    key={r.id}
+                    className="p-4 rounded-lg bg-[var(--dpf-surface-2)] border-l-4"
+                    style={{ borderLeftColor: "#7c8cf8" }}
+                  >
+                    <p className="text-[9px] font-mono text-[var(--dpf-muted)] mb-1">
+                      {r.roleId}
+                    </p>
+                    <p className="text-sm font-semibold text-[var(--dpf-text)] leading-tight mb-1">
+                      {r.name}
+                    </p>
+                    {r.description != null && (
+                      <p className="text-[10px] text-[var(--dpf-muted)] line-clamp-2 mb-2">
+                        {r.description}
+                      </p>
+                    )}
+                    <div className="flex flex-wrap gap-2">
+                      <span className="text-[9px] text-[var(--dpf-muted)]">
+                        HITL T{r.hitlTierMin}
+                      </span>
+                      <span className="text-[9px] text-[var(--dpf-muted)]">{sla}</span>
+                      <span className="text-[9px] text-[var(--dpf-muted)]">
+                        {userCount === 0 ? "Unassigned" : `${userCount} ${userCount === 1 ? "person" : "people"}`}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {roles.length === 0 && (
+              <p className="text-sm text-[var(--dpf-muted)]">No roles registered yet.</p>
+            )}
+
+            {users.length > 0 && (
+              <div className="mt-8">
+                <HrUserLifecyclePanel
+                  roles={roles.map((role) => ({ roleId: role.roleId, name: role.name }))}
+                  users={users.map((user) => ({
+                    id: user.id,
+                    email: user.email,
+                    isActive: user.isActive,
+                    isSuperuser: user.isSuperuser,
+                    roleId: user.groups[0]?.platformRole.roleId ?? null,
+                  }))}
+                />
+              </div>
+            )}
+          </OwnerFirstDisclosure>
         </div>
       )}
     </div>

--- a/apps/web/app/(shell)/finance/page.tsx
+++ b/apps/web/app/(shell)/finance/page.tsx
@@ -1,6 +1,12 @@
 // apps/web/app/(shell)/finance/page.tsx
 import { prisma } from "@dpf/db";
 import Link from "next/link";
+import { cookies } from "next/headers";
+import { OwnerFirstSummaryBand } from "@/components/owner-first/OwnerFirstSummary";
+import { OwnerFirstDisclosure } from "@/components/owner-first/OwnerFirstDisclosure";
+import { loadOwnerFirstContext } from "@/lib/owner-first/context";
+import { buildFinanceOwnerSummary } from "@/lib/owner-first/domain-summary";
+import { isSimpleNavMode, NAV_MODE_COOKIE, resolveNavModeFromCookie } from "@/lib/navigation/nav-mode";
 import { getFinancialSetupStatus } from "@/lib/actions/financial-setup";
 import { getOrgSettings } from "@/lib/actions/currency";
 import { getCurrencySymbol } from "@/lib/currency-symbol";
@@ -186,6 +192,25 @@ export default async function FinancePage() {
     amount: Number(inv.totalAmount),
   }));
 
+  // Owner-first: open with what must be paid, collected, or approved today, then
+  // demote the accountant lanes and AR/AP/reporting taxonomy behind progressive
+  // disclosure (BI-3BCAF95F).
+  const simple = isSimpleNavMode(
+    resolveNavModeFromCookie((await cookies()).get(NAV_MODE_COOKIE)?.value),
+  );
+  const { vocab } = await loadOwnerFirstContext();
+  const ownerSummary = buildFinanceOwnerSummary(
+    {
+      billsDue: moneyOweCount,
+      overdueInvoices: overdueCount,
+      pendingExpenses: pendingExpenseCount,
+      oldestOverdueName: oldestOverdue?.account.name ?? null,
+      currencySymbol: sym,
+      moneyOwedToYou: owedAmount,
+    },
+    vocab,
+  );
+
   return (
     <div>
       {/* Setup prompt banner */}
@@ -226,6 +251,15 @@ export default async function FinancePage() {
 
       <FinanceTabNav />
 
+      {/* Owner-first: money that needs paying, collecting, or approving today. */}
+      <OwnerFirstSummaryBand summary={ownerSummary} density={simple ? "simple" : "full"} />
+
+      {/* The finance workspace — lanes, at-a-glance money, the full taxonomy, and
+          recent invoices — is the professional detail behind the daily money
+          decisions. Simple mode drops it to reduce body content (BI-3BCAF95F). */}
+      {!simple && (
+        <>
+      <OwnerFirstDisclosure summary="Finance lanes" hint="Revenue, Spend, Close, Configuration">
       <div className="grid gap-4 lg:grid-cols-2 mb-8">
         <FinanceSummaryCard
           title="Revenue"
@@ -270,6 +304,7 @@ export default async function FinancePage() {
       </div>
 
       <AccountantWorkLanePanel lane={accountantLane} />
+      </OwnerFirstDisclosure>
 
       {/* Row 1: Cash Position + 30-day Forecast + Outstanding + Overdue */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
@@ -380,7 +415,11 @@ export default async function FinancePage() {
         />
       </div>
 
-      {/* Navigation links */}
+      {/* Navigation links — the AR/AP/procurement/reporting taxonomy. */}
+      <OwnerFirstDisclosure
+        summary="All finance areas"
+        hint="AR, AP, procurement, banking, reports, and settings"
+      >
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         {/* AR links */}
         <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
@@ -526,6 +565,7 @@ export default async function FinancePage() {
           </div>
         </div>
       </div>
+      </OwnerFirstDisclosure>
 
       {/* Recent Invoices */}
       <section>
@@ -541,6 +581,8 @@ export default async function FinancePage() {
           <RecentInvoicesTable rows={recentInvoiceRows} currencySymbol={sym} />
         )}
       </section>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/app/(shell)/workspace/page.tsx
+++ b/apps/web/app/(shell)/workspace/page.tsx
@@ -6,6 +6,7 @@ import { prisma } from "@dpf/db";
 import { PlatformWorkspaceHome } from "@/components/workspace-home/PlatformWorkspaceHome";
 import { VerticalWorkspaceHome } from "@/components/workspace-home/VerticalWorkspaceHome";
 import { OperatorCockpit } from "@/components/workspace-home/OperatorCockpit";
+import { WorkspaceStorefrontAttention } from "@/components/owner-first/WorkspaceStorefrontAttention";
 import { WorkspaceTwinHero } from "@/components/workspace-home/WorkspaceTwinHero";
 import { LocalOnlyProviderNotice } from "@/components/workspace-home/LocalOnlyProviderNotice";
 import { UnconfiguredWorkspaceHomeNotice } from "@/components/workspace-home/UnconfiguredWorkspaceHomeNotice";
@@ -66,7 +67,16 @@ export default async function WorkspacePage() {
   // Supersedes the old "Needs you" band; it always states its state, so no other
   // panel can contradict its count. On the twin hero it folds in as the HUD rail so
   // there is still exactly ONE attention surface.
-  const cockpit = <OperatorCockpit userId={session.user.id} />;
+  // Storefront/Funnel signals are reconciled into the attention surface FIRST,
+  // then the cockpit renders the generic coworker-decision residue below it
+  // (BI-3BCAF95F). The storefront band self-hides when there is no guest work, so
+  // it never adds an empty panel to the surface we are decluttering.
+  const cockpit = (
+    <>
+      <WorkspaceStorefrontAttention density={simpleHome ? "simple" : "full"} />
+      <OperatorCockpit userId={session.user.id} />
+    </>
+  );
 
   return (
     <div data-nav-mode={navMode}>

--- a/apps/web/components/owner-first/OwnerFirstDisclosure.tsx
+++ b/apps/web/components/owner-first/OwnerFirstDisclosure.tsx
@@ -1,0 +1,46 @@
+// apps/web/components/owner-first/OwnerFirstDisclosure.tsx
+//
+// Progressive-disclosure wrapper for the professional/internal structure that
+// used to OPEN the domain pages — CRM stages, HR role governance, accountant
+// lanes, AR/AP/reporting taxonomy, platform posture (BI-3BCAF95F). It stays one
+// click away for the owner who wants it, but no longer competes with today's
+// action for the first viewport.
+//
+// A native <details>/<summary> so it works as a server component with zero client
+// JS. `data-owner-first-detail` marks it as demoted structure for the UX checks.
+
+import type { ReactNode } from "react";
+
+export function OwnerFirstDisclosure({
+  summary,
+  hint,
+  children,
+  defaultOpen = false,
+}: {
+  /** The affordance label, e.g. "All CRM detail" or "Role governance & directory". */
+  summary: string;
+  /** Optional one-line context shown next to the label. */
+  hint?: string;
+  children: ReactNode;
+  defaultOpen?: boolean;
+}) {
+  return (
+    <details
+      data-owner-first-detail=""
+      open={defaultOpen}
+      className="group mb-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+    >
+      <summary className="flex min-h-11 cursor-pointer list-none items-center gap-2 px-4 py-3 text-sm font-medium text-[var(--dpf-text)] marker:hidden [&::-webkit-details-marker]:hidden">
+        <span
+          aria-hidden
+          className="text-[var(--dpf-muted)] transition-transform group-open:rotate-90"
+        >
+          ▸
+        </span>
+        <span>{summary}</span>
+        {hint && <span className="text-xs font-normal text-[var(--dpf-muted)]">{hint}</span>}
+      </summary>
+      <div className="border-t border-[var(--dpf-border)] p-4">{children}</div>
+    </details>
+  );
+}

--- a/apps/web/components/owner-first/OwnerFirstSummary.test.tsx
+++ b/apps/web/components/owner-first/OwnerFirstSummary.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// The next/link mock MUST forward ...rest so the data-owner-first-next-action
+// attribute survives to the rendered markup — the UX audit keys off it.
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  } & Record<string, unknown>) => (
+    <a href={typeof href === "string" ? href : "#"} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { OwnerFirstSummaryBand } from "./OwnerFirstSummary";
+import {
+  buildCustomerOwnerSummary,
+  buildEmployeeOwnerSummary,
+  buildFinanceOwnerSummary,
+} from "@/lib/owner-first/domain-summary";
+import { resolveOwnerVocabulary } from "@/lib/owner-first/vocabulary";
+import { auditOwnerFirst, countWords } from "@/lib/owner-first/ux-audit";
+
+const restaurant = resolveOwnerVocabulary("food-hospitality");
+
+const customer = buildCustomerOwnerSummary(
+  {
+    pendingReservations: 3,
+    pendingOrders: 1,
+    newInquiries: 2,
+    unworkedEngagements: 2,
+    overdueInvoices: 1,
+    renewalsDueSoon: 0,
+  },
+  restaurant,
+);
+const finance = buildFinanceOwnerSummary(
+  {
+    billsDue: 2,
+    overdueInvoices: 1,
+    pendingExpenses: 1,
+    oldestOverdueName: "Ada Bistro",
+    currencySymbol: "£",
+    moneyOwedToYou: 4200,
+  },
+  restaurant,
+);
+const employee = buildEmployeeOwnerSummary(
+  { submittedTimesheets: 2, teamSize: 8, unassignedRoles: 1 },
+  restaurant,
+);
+
+describe("OwnerFirstSummaryBand — rendered UX checks", () => {
+  for (const [name, summary] of [
+    ["customer", customer],
+    ["finance", finance],
+    ["employee", employee],
+  ] as const) {
+    it(`renders an owner-first ${name} band that passes every UX check`, () => {
+      const html = renderToStaticMarkup(
+        <OwnerFirstSummaryBand summary={summary} density="full" />,
+      );
+      const { ok, findings } = auditOwnerFirst(html);
+      const failed = findings.filter((f) => !f.ok);
+      expect(failed, JSON.stringify(failed)).toHaveLength(0);
+      expect(ok).toBe(true);
+    });
+  }
+
+  it("stamps an owner-first next action and uses no generic decision labels", () => {
+    const html = renderToStaticMarkup(
+      <OwnerFirstSummaryBand summary={customer} density="full" />,
+    );
+    expect(html).toContain("data-owner-first-next-action");
+    expect(html).not.toContain("Make this business decision?");
+    expect(html).not.toContain("Technical detail");
+  });
+
+  it("Simple mode reduces the body content of the band", () => {
+    const full = renderToStaticMarkup(
+      <OwnerFirstSummaryBand summary={customer} density="full" />,
+    );
+    const simple = renderToStaticMarkup(
+      <OwnerFirstSummaryBand summary={customer} density="simple" />,
+    );
+    // Simple mode drops the subhead and each per-action "why" line.
+    expect(countWords(simple)).toBeLessThan(countWords(full));
+    // But the actionable controls remain.
+    expect(simple).toContain("data-owner-first-next-action");
+  });
+});

--- a/apps/web/components/owner-first/OwnerFirstSummary.tsx
+++ b/apps/web/components/owner-first/OwnerFirstSummary.tsx
@@ -1,0 +1,75 @@
+// apps/web/components/owner-first/OwnerFirstSummary.tsx
+//
+// The owner-first summary band that OPENS each major business-domain page
+// (BI-3BCAF95F). It renders, in the owner's own words: what needs action today,
+// why it matters, and the single safest next action — before any CRM / HR /
+// accountant / platform structure. Server component; the shape it renders comes
+// from the pure builders in lib/owner-first/domain-summary.ts.
+//
+// Density-aware: in Simple mode the band drops the subhead and the per-action
+// "why" line, so Simple mode reduces the BODY content of these pages, not only
+// the rail (BI-3BCAF95F + BI-655418A7).
+
+import Link from "next/link";
+
+import type { OwnerFirstSummary, OwnerFirstTone } from "@/lib/owner-first/domain-summary";
+import { OWNER_FIRST_NEXT_ACTION_ATTR } from "@/lib/owner-first/ux-audit";
+
+const TONE_BORDER: Record<OwnerFirstTone, string> = {
+  urgent: "border-[var(--dpf-danger)]",
+  attention: "border-[var(--dpf-warning)]",
+  info: "border-[var(--dpf-accent)]",
+  calm: "border-[var(--dpf-border)]",
+};
+
+export function OwnerFirstSummaryBand({
+  summary,
+  density = "full",
+}: {
+  summary: OwnerFirstSummary;
+  density?: "full" | "simple";
+}) {
+  const simple = density === "simple";
+  const hasWork = summary.actions.length > 0;
+
+  return (
+    <section
+      aria-label={`${summary.headline} — what needs you today`}
+      className="mb-6 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4"
+    >
+      <header className="mb-3">
+        <h2 className="text-sm font-semibold text-[var(--dpf-text)]">{summary.headline}</h2>
+        {!simple && (
+          <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">{summary.subhead}</p>
+        )}
+      </header>
+
+      {hasWork ? (
+        <ul className="space-y-3">
+          {summary.actions.map((action) => (
+            <li
+              key={action.id}
+              className={`rounded-md border-l-4 ${TONE_BORDER[action.tone]} bg-[var(--dpf-surface-1)] p-3`}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-sm font-semibold text-[var(--dpf-text)]">{action.title}</p>
+                <Link
+                  href={action.nextAction.href}
+                  {...{ [OWNER_FIRST_NEXT_ACTION_ATTR]: action.id }}
+                  className="inline-flex min-h-9 items-center rounded-md bg-[var(--dpf-accent)] px-3 py-2 text-xs font-semibold text-[var(--dpf-on-accent,var(--dpf-surface-1))] hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--dpf-accent)]"
+                >
+                  {action.nextAction.label}
+                </Link>
+              </div>
+              {!simple && (
+                <p className="mt-1 text-xs leading-relaxed text-[var(--dpf-muted)]">{action.why}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-[var(--dpf-muted)]">{summary.clearMessage}</p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/owner-first/WorkspaceStorefrontAttention.tsx
+++ b/apps/web/components/owner-first/WorkspaceStorefrontAttention.tsx
@@ -1,0 +1,41 @@
+// apps/web/components/owner-first/WorkspaceStorefrontAttention.tsx
+//
+// Reconciles Storefront/Funnel signals into the Workspace attention surface
+// BEFORE the generic coworker decisions (BI-3BCAF95F). The live audit found the
+// workspace home led with generic `Make this business decision?` cards while the
+// `RESERVATIONS 0` rail chip and the funnel's `BOOKINGS 12 / INQUIRIES 1` never
+// became a concrete owner action. This band renders the pending storefront work
+// first, in owner language, then the OperatorCockpit renders the residue below.
+//
+// Read-only projection over the storefront queues — their rows stay canonical.
+
+import { prisma } from "@dpf/db";
+
+import { OwnerFirstSummaryBand } from "./OwnerFirstSummary";
+import { loadOwnerFirstContext } from "@/lib/owner-first/context";
+import { buildWorkspaceStorefrontSummary, hasOwnerFirstAction } from "@/lib/owner-first/domain-summary";
+
+export async function WorkspaceStorefrontAttention({
+  density = "full",
+}: {
+  density?: "full" | "simple";
+}) {
+  const [{ vocab }, pendingReservations, newInquiries, pendingOrders] = await Promise.all([
+    loadOwnerFirstContext(),
+    prisma.storefrontBooking.count({ where: { status: "pending" } }),
+    prisma.storefrontInquiry.count({ where: { status: "new" } }),
+    prisma.storefrontOrder.count({ where: { status: "pending" } }),
+  ]);
+
+  const summary = buildWorkspaceStorefrontSummary(
+    { pendingReservations, newInquiries, pendingOrders },
+    vocab,
+  );
+
+  // Only take the top of the workspace when there is real guest work. When it is
+  // clear, the OperatorCockpit's own "nothing needs you" state is enough — a second
+  // empty band would just add noise to the very surface we are decluttering.
+  if (!hasOwnerFirstAction(summary)) return null;
+
+  return <OwnerFirstSummaryBand summary={summary} density={density} />;
+}

--- a/apps/web/lib/owner-first/context.ts
+++ b/apps/web/lib/owner-first/context.ts
@@ -1,0 +1,27 @@
+// apps/web/lib/owner-first/context.ts
+//
+// Shared loader for the archetype context the owner-first summaries need. The
+// domain pages (customer, employee, finance) did not previously read the
+// storefront archetype, so each would otherwise hand-roll the same query. One
+// cached read keeps the summaries archetype-aware without four divergent copies.
+
+import { prisma } from "@dpf/db";
+import { resolveOwnerVocabulary, type OwnerDomainVocabulary } from "./vocabulary";
+
+export type OwnerFirstContext = {
+  archetypeCategory: string | null;
+  archetypeName: string | null;
+  vocab: OwnerDomainVocabulary;
+};
+
+export async function loadOwnerFirstContext(): Promise<OwnerFirstContext> {
+  const config = await prisma.storefrontConfig.findFirst({
+    include: { archetype: { select: { category: true, name: true } } },
+  });
+  const category = config?.archetype?.category ?? null;
+  return {
+    archetypeCategory: category,
+    archetypeName: config?.archetype?.name ?? null,
+    vocab: resolveOwnerVocabulary(category),
+  };
+}

--- a/apps/web/lib/owner-first/domain-summary.test.ts
+++ b/apps/web/lib/owner-first/domain-summary.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCustomerOwnerSummary,
+  buildEmployeeOwnerSummary,
+  buildFinanceOwnerSummary,
+  buildWorkspaceStorefrontSummary,
+  hasOwnerFirstAction,
+} from "./domain-summary";
+import { resolveOwnerVocabulary } from "./vocabulary";
+
+const restaurant = resolveOwnerVocabulary("food-hospitality");
+const neutral = resolveOwnerVocabulary("retail-goods");
+
+describe("buildCustomerOwnerSummary", () => {
+  it("leads with guest follow-up in restaurant language and orders by urgency", () => {
+    const summary = buildCustomerOwnerSummary(
+      {
+        pendingReservations: 3,
+        pendingOrders: 1,
+        newInquiries: 2,
+        unworkedEngagements: 4,
+        overdueInvoices: 1,
+        renewalsDueSoon: 0,
+      },
+      restaurant,
+    );
+    expect(summary.headline).toBe("Guest follow-up");
+    // Reservations are the most urgent → first.
+    expect(summary.actions[0].id).toBe("reservations");
+    expect(summary.actions[0].tone).toBe("urgent");
+    // Every action carries a safest next action.
+    for (const action of summary.actions) {
+      expect(action.nextAction.href).toMatch(/^\//);
+      expect(action.nextAction.label.length).toBeGreaterThan(0);
+      expect(action.why.length).toBeGreaterThan(0);
+    }
+    expect(hasOwnerFirstAction(summary)).toBe(true);
+  });
+
+  it("explains why the surface is clear when nothing is waiting", () => {
+    const summary = buildCustomerOwnerSummary(
+      {
+        pendingReservations: 0,
+        pendingOrders: 0,
+        newInquiries: 0,
+        unworkedEngagements: 0,
+        overdueInvoices: 0,
+        renewalsDueSoon: 0,
+      },
+      restaurant,
+    );
+    expect(summary.actions).toHaveLength(0);
+    expect(hasOwnerFirstAction(summary)).toBe(false);
+    expect(summary.clearMessage).toMatch(/guests/i);
+  });
+
+  it("uses neutral customer language off-archetype", () => {
+    const summary = buildCustomerOwnerSummary(
+      {
+        pendingReservations: 1,
+        pendingOrders: 0,
+        newInquiries: 0,
+        unworkedEngagements: 0,
+        overdueInvoices: 0,
+        renewalsDueSoon: 0,
+      },
+      neutral,
+    );
+    expect(summary.headline).toBe("Customer follow-up");
+    expect(summary.subhead).toMatch(/customers/i);
+  });
+});
+
+describe("buildFinanceOwnerSummary", () => {
+  it("leads with bills to pay and names the money owed to you", () => {
+    const summary = buildFinanceOwnerSummary(
+      {
+        billsDue: 2,
+        overdueInvoices: 3,
+        pendingExpenses: 1,
+        oldestOverdueName: "Ada Bistro",
+        currencySymbol: "£",
+        moneyOwedToYou: 4200,
+      },
+      restaurant,
+    );
+    expect(summary.actions[0].id).toBe("bills");
+    expect(summary.actions[0].tone).toBe("urgent");
+    const collect = summary.actions.find((a) => a.id === "collect");
+    expect(collect?.why).toContain("£4,200");
+    expect(collect?.why).toContain("Ada Bistro");
+  });
+
+  it("is clear when there is no money work today", () => {
+    const summary = buildFinanceOwnerSummary(
+      {
+        billsDue: 0,
+        overdueInvoices: 0,
+        pendingExpenses: 0,
+        oldestOverdueName: null,
+        currencySymbol: "£",
+        moneyOwedToYou: 0,
+      },
+      restaurant,
+    );
+    expect(summary.actions).toHaveLength(0);
+    expect(summary.clearMessage).toMatch(/nothing needs/i);
+  });
+});
+
+describe("buildEmployeeOwnerSummary", () => {
+  it("leads with service readiness and surfaces timesheets to approve", () => {
+    const summary = buildEmployeeOwnerSummary(
+      { submittedTimesheets: 2, teamSize: 8, unassignedRoles: 1 },
+      restaurant,
+    );
+    expect(summary.headline).toBe("Next service readiness");
+    expect(summary.actions[0].id).toBe("timesheets");
+    expect(summary.subhead).toMatch(/service staff of 8/);
+  });
+
+  it("is clear (team set) with an explanation when nothing needs sign-off", () => {
+    const summary = buildEmployeeOwnerSummary(
+      { submittedTimesheets: 0, teamSize: 5, unassignedRoles: 0 },
+      restaurant,
+    );
+    expect(summary.actions).toHaveLength(0);
+    expect(summary.clearMessage).toMatch(/set for the next service/i);
+  });
+});
+
+describe("buildWorkspaceStorefrontSummary", () => {
+  it("reframes storefront signals as owner-first guest work", () => {
+    const summary = buildWorkspaceStorefrontSummary(
+      { pendingReservations: 12, newInquiries: 1, pendingOrders: 0 },
+      restaurant,
+    );
+    expect(summary.domain).toBe("workspace");
+    expect(summary.headline).toBe("From your guests");
+    expect(summary.actions[0].id).toBe("reservations");
+    expect(hasOwnerFirstAction(summary)).toBe(true);
+  });
+
+  it("has no actions when the storefront is quiet", () => {
+    const summary = buildWorkspaceStorefrontSummary(
+      { pendingReservations: 0, newInquiries: 0, pendingOrders: 0 },
+      neutral,
+    );
+    expect(hasOwnerFirstAction(summary)).toBe(false);
+  });
+});

--- a/apps/web/lib/owner-first/domain-summary.ts
+++ b/apps/web/lib/owner-first/domain-summary.ts
@@ -1,0 +1,300 @@
+// apps/web/lib/owner-first/domain-summary.ts
+//
+// Pure owner-first summary builders (BI-3BCAF95F, EP-UX-COGLOAD). Each major
+// business-domain page must OPEN with the owner's daily job: what needs action
+// today, why it matters, and the safest next action — before any CRM / HR /
+// accountant / platform structure. These builders take the counts a page already
+// fetches and project them into an ordered, owner-language action list. No DB and
+// no React here, so the shape is unit-testable and the UX checks can run against
+// the rendered output deterministically.
+
+import type { OwnerDomainVocabulary } from "./vocabulary";
+
+export type OwnerFirstDomain = "workspace" | "customer" | "employee" | "finance";
+
+/** Urgency tone — drives colour, and orders the list (urgent first). */
+export type OwnerFirstTone = "urgent" | "attention" | "info" | "calm";
+
+const TONE_RANK: Record<OwnerFirstTone, number> = {
+  urgent: 0,
+  attention: 1,
+  info: 2,
+  calm: 3,
+};
+
+export type OwnerFirstAction = {
+  id: string;
+  /** What needs action today, in owner language (carries the count). */
+  title: string;
+  /** Why it matters — the one-line consequence, owner language. */
+  why: string;
+  /** The single safest next action. */
+  nextAction: { label: string; href: string };
+  tone: OwnerFirstTone;
+};
+
+export type OwnerFirstSummary = {
+  domain: OwnerFirstDomain;
+  /** The owner-language heading for the whole surface. */
+  headline: string;
+  /** One line of context under the heading. */
+  subhead: string;
+  /** Ordered most-urgent first; empty when nothing needs the owner today. */
+  actions: OwnerFirstAction[];
+  /** Shown when `actions` is empty — always explains WHY it is clear. */
+  clearMessage: string;
+};
+
+/** Order most-urgent first, stable within a tone. */
+function orderActions(actions: OwnerFirstAction[]): OwnerFirstAction[] {
+  return actions
+    .map((a, i) => ({ a, i }))
+    .sort((x, y) => TONE_RANK[x.a.tone] - TONE_RANK[y.a.tone] || x.i - y.i)
+    .map(({ a }) => a);
+}
+
+function plural(n: number, one: string, many: string): string {
+  return n === 1 ? one : many;
+}
+
+// ─── Customer / guest follow-up ──────────────────────────────────────────────
+
+export type CustomerSummaryInput = {
+  pendingReservations: number;
+  pendingOrders: number;
+  newInquiries: number;
+  unworkedEngagements: number;
+  overdueInvoices: number;
+  renewalsDueSoon: number;
+};
+
+export function buildCustomerOwnerSummary(
+  input: CustomerSummaryInput,
+  vocab: OwnerDomainVocabulary,
+): OwnerFirstSummary {
+  const actions: OwnerFirstAction[] = [];
+
+  if (input.pendingReservations > 0) {
+    const n = input.pendingReservations;
+    actions.push({
+      id: "reservations",
+      title: `${n} ${plural(n, vocab.reservationsLabel.replace(/s$/, ""), vocab.reservationsLabel)} to confirm`,
+      why: `${plural(n, "A guest is", "Guests are")} waiting to hear their ${plural(n, "table", "tables")} ${plural(n, "is", "are")} held.`,
+      nextAction: { label: "Review reservations", href: "/customer/funnel" },
+      tone: "urgent",
+    });
+  }
+
+  if (input.pendingOrders > 0) {
+    const n = input.pendingOrders;
+    actions.push({
+      id: "orders",
+      title: `${n} ${plural(n, vocab.ordersLabel.replace(/s$/, ""), vocab.ordersLabel)} to fulfil`,
+      why: `${plural(n, "An order is", "Orders are")} placed and waiting to be actioned.`,
+      nextAction: { label: "Review orders", href: "/customer/funnel" },
+      tone: "attention",
+    });
+  }
+
+  if (input.newInquiries > 0) {
+    const n = input.newInquiries;
+    actions.push({
+      id: "inquiries",
+      title: `${n} new ${plural(n, vocab.inquiriesLabel.replace(/ies$/, "y"), vocab.inquiriesLabel)} to answer`,
+      why: `${plural(n, "Someone reached", "People reached")} out and ${plural(n, "has", "have")} not had a reply.`,
+      nextAction: { label: "Open inquiries", href: "/customer/funnel" },
+      tone: "attention",
+    });
+  }
+
+  if (input.unworkedEngagements > 0) {
+    const n = input.unworkedEngagements;
+    actions.push({
+      id: "engagements",
+      title: `${n} ${vocab.guestsLabel} to follow up`,
+      why: `${plural(n, "A guest has", "Guests have")} an open conversation with no next step logged.`,
+      nextAction: { label: "Open follow-ups", href: "/customer" },
+      tone: "info",
+    });
+  }
+
+  if (input.overdueInvoices > 0) {
+    const n = input.overdueInvoices;
+    actions.push({
+      id: "overdue",
+      title: `${n} overdue ${plural(n, vocab.invoicesLabel.replace(/s$/, ""), vocab.invoicesLabel)} to chase`,
+      why: "Money you have earned has not arrived yet.",
+      nextAction: { label: "See who owes you", href: "/finance/reports/aged-debtors" },
+      tone: "info",
+    });
+  }
+
+  return {
+    domain: "customer",
+    headline: vocab.guestFollowUpLabel,
+    subhead: vocab.isRestaurant
+      ? "Guests waiting on you — reservations, orders, and inquiries first."
+      : "Customers waiting on you first — the rest of your CRM is below.",
+    actions: orderActions(actions),
+    clearMessage: `No ${vocab.guestsLabel} are waiting on a reply right now. New ${vocab.reservationsLabel} and ${vocab.inquiriesLabel} will appear here first.`,
+  };
+}
+
+// ─── Employee / service staffing ─────────────────────────────────────────────
+
+export type EmployeeSummaryInput = {
+  submittedTimesheets: number;
+  teamSize: number;
+  unassignedRoles: number;
+};
+
+export function buildEmployeeOwnerSummary(
+  input: EmployeeSummaryInput,
+  vocab: OwnerDomainVocabulary,
+): OwnerFirstSummary {
+  const actions: OwnerFirstAction[] = [];
+
+  if (input.submittedTimesheets > 0) {
+    const n = input.submittedTimesheets;
+    actions.push({
+      id: "timesheets",
+      title: `${n} ${vocab.timesheetLabel} ${plural(n, "sheet", "sheets")} to approve`,
+      why: `Your ${vocab.staffLabel} cannot be paid until ${plural(n, "this is", "these are")} approved.`,
+      nextAction: { label: "Approve hours", href: "/employee?view=timesheets" },
+      tone: "attention",
+    });
+  }
+
+  if (input.unassignedRoles > 0) {
+    const n = input.unassignedRoles;
+    actions.push({
+      id: "coverage",
+      title: `${n} ${plural(n, "role has", "roles have")} nobody assigned`,
+      why: "A gap in coverage means work has no owner for the next service.",
+      nextAction: { label: "Check coverage", href: "/employee?view=workforce" },
+      tone: "info",
+    });
+  }
+
+  return {
+    domain: "employee",
+    headline: vocab.serviceReadinessLabel,
+    subhead: vocab.isRestaurant
+      ? `Who is on and what needs sign-off before the next service — ${vocab.staffLabel} of ${input.teamSize}.`
+      : `Who is on and what needs sign-off — ${vocab.staffLabel} of ${input.teamSize}.`,
+    actions: orderActions(actions),
+    clearMessage: `Your ${vocab.staffLabel} are set for the next service. Role governance and the directory are below.`,
+  };
+}
+
+// ─── Finance / bills, deposits, invoices ─────────────────────────────────────
+
+export type FinanceSummaryInput = {
+  billsDue: number;
+  overdueInvoices: number;
+  pendingExpenses: number;
+  oldestOverdueName: string | null;
+  currencySymbol: string;
+  moneyOwedToYou: number;
+};
+
+function formatMoney(amount: number, symbol: string): string {
+  return `${symbol}${amount.toLocaleString("en-GB", { maximumFractionDigits: 0 })}`;
+}
+
+export function buildFinanceOwnerSummary(
+  input: FinanceSummaryInput,
+  vocab: OwnerDomainVocabulary,
+): OwnerFirstSummary {
+  const actions: OwnerFirstAction[] = [];
+
+  if (input.billsDue > 0) {
+    const n = input.billsDue;
+    actions.push({
+      id: "bills",
+      title: `${n} ${plural(n, vocab.billsLabel.replace(/s$/, ""), vocab.billsLabel)} to pay`,
+      why: "Suppliers are waiting to be paid for what you have already received.",
+      nextAction: { label: "Review bills", href: "/finance/bills" },
+      tone: "urgent",
+    });
+  }
+
+  if (input.overdueInvoices > 0) {
+    const n = input.overdueInvoices;
+    const who = input.oldestOverdueName ? ` Oldest: ${input.oldestOverdueName}.` : "";
+    actions.push({
+      id: "collect",
+      title: `${n} overdue ${plural(n, vocab.invoicesLabel.replace(/s$/, ""), vocab.invoicesLabel)} to collect`,
+      why: `${formatMoney(input.moneyOwedToYou, input.currencySymbol)} is owed to you.${who}`,
+      nextAction: { label: "See who owes you", href: "/finance/reports/aged-debtors" },
+      tone: "attention",
+    });
+  }
+
+  if (input.pendingExpenses > 0) {
+    const n = input.pendingExpenses;
+    actions.push({
+      id: "expenses",
+      title: `${n} expense ${plural(n, "claim", "claims")} to approve`,
+      why: `Your ${vocab.staffLabel} are waiting to be reimbursed.`,
+      nextAction: { label: "Approve claims", href: "/finance/expense-claims?status=submitted" },
+      tone: "info",
+    });
+  }
+
+  return {
+    domain: "finance",
+    headline: vocab.isRestaurant ? "Money today" : "Money today",
+    subhead: vocab.isRestaurant
+      ? `What must be paid, collected, or approved — ${vocab.billsLabel}, ${vocab.depositsLabel}, and ${vocab.invoicesLabel}.`
+      : "What must be paid, collected, or approved today.",
+    actions: orderActions(actions),
+    clearMessage:
+      "Nothing needs paying, collecting, or approving today. The full finance workspace is below.",
+  };
+}
+
+// ─── Workspace / storefront reconciliation ───────────────────────────────────
+//
+// Storefront bookings and inquiries are real owner work, but the workspace home
+// only surfaced them indirectly (a `RESERVATIONS 0` rail chip) while generic
+// coworker decisions took the top cards. This projects the pending storefront
+// signals into the SAME owner-first shape so they render BEFORE the generic
+// cockpit decisions (BI-3BCAF95F acceptance: reconcile storefront/funnel signals
+// before generic coworker decisions).
+
+export type WorkspaceStorefrontInput = {
+  pendingReservations: number;
+  pendingOrders: number;
+  newInquiries: number;
+};
+
+export function buildWorkspaceStorefrontSummary(
+  input: WorkspaceStorefrontInput,
+  vocab: OwnerDomainVocabulary,
+): OwnerFirstSummary {
+  const summary = buildCustomerOwnerSummary(
+    {
+      pendingReservations: input.pendingReservations,
+      pendingOrders: input.pendingOrders,
+      newInquiries: input.newInquiries,
+      unworkedEngagements: 0,
+      overdueInvoices: 0,
+      renewalsDueSoon: 0,
+    },
+    vocab,
+  );
+  return {
+    ...summary,
+    domain: "workspace",
+    headline: vocab.isRestaurant ? "From your guests" : "From your storefront",
+    subhead: vocab.isRestaurant
+      ? "Reservations, orders, and inquiries waiting on you — before anything else."
+      : "Storefront bookings and inquiries waiting on you — before anything else.",
+  };
+}
+
+/** True when the summary has at least one owner-first next action. */
+export function hasOwnerFirstAction(summary: OwnerFirstSummary): boolean {
+  return summary.actions.length > 0;
+}

--- a/apps/web/lib/owner-first/ux-audit.test.ts
+++ b/apps/web/lib/owner-first/ux-audit.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  auditOwnerFirst,
+  countControls,
+  countGenericDecisionLabels,
+  countSmallControls,
+  countTechnicalDetail,
+  countWords,
+  hasOwnerFirstNextAction,
+  measureOwnerFirst,
+  OWNER_FIRST_NEXT_ACTION_ATTR,
+  OWNER_FIRST_SUMMARY_THRESHOLDS,
+} from "./ux-audit";
+
+describe("owner-first UX metrics", () => {
+  it("counts visible words, decoding entities and ignoring tags", () => {
+    // renderToStaticMarkup escapes apostrophes to &#x27; — the count must not
+    // split a word on the entity.
+    expect(countWords("<p>You&#x27;re all set for today</p>")).toBe(5);
+    expect(countWords("<div></div>")).toBe(0);
+  });
+
+  it("counts links and buttons as controls", () => {
+    const html = `<a href="/a">A</a><button>B</button><A href="/c">C</A>`;
+    expect(countControls(html)).toBe(3);
+  });
+
+  it("flags sub-legible controls by their type scale", () => {
+    const html = `<a class="text-[9px]">tiny</a><a class="text-sm min-h-9">ok</a>`;
+    expect(countSmallControls(html)).toBe(1);
+  });
+
+  it("counts generic decision labels and repeated Technical detail", () => {
+    const html = `<p>Make this business decision?</p><p>Make this business decision?</p><p>Technical detail</p><p>Technical detail</p>`;
+    expect(countGenericDecisionLabels(html)).toBe(2);
+    expect(countTechnicalDetail(html)).toBe(2);
+  });
+
+  it("detects a stamped owner-first next action", () => {
+    expect(hasOwnerFirstNextAction(`<a ${OWNER_FIRST_NEXT_ACTION_ATTR}="x">go</a>`)).toBe(true);
+    expect(hasOwnerFirstNextAction(`<a href="/x">go</a>`)).toBe(false);
+  });
+});
+
+describe("auditOwnerFirst", () => {
+  it("passes a clean owner-first band and fails a subsystem-dashboard band", () => {
+    const clean = `
+      <section>
+        <h2>Guest follow-up</h2>
+        <p>Guests waiting on you first.</p>
+        <a ${OWNER_FIRST_NEXT_ACTION_ATTR}="reservations" class="text-xs min-h-9" href="/customer/funnel">Review reservations</a>
+      </section>`;
+    const cleanResult = auditOwnerFirst(clean);
+    expect(cleanResult.ok).toBe(true);
+
+    // Mirror the live audit's overloaded finding: repeated generic labels,
+    // repeated Technical detail, tiny controls, and no owner-first next action.
+    const overloaded = `
+      <section>
+        <p>Make this business decision?</p>
+        <p>Make this business decision?</p>
+        <p>Technical detail</p>
+        <p>Technical detail</p>
+        <a class="text-[9px]" href="/x">deep link</a>
+      </section>`;
+    const overloadedResult = auditOwnerFirst(overloaded);
+    expect(overloadedResult.ok).toBe(false);
+    const failed = overloadedResult.findings.filter((f) => !f.ok).map((f) => f.check);
+    expect(failed).toContain("generic-decision-labels");
+    expect(failed).toContain("repeated-technical-detail");
+    expect(failed).toContain("small-controls");
+    expect(failed).toContain("owner-first-next-action");
+  });
+
+  it("measureOwnerFirst reports every signal at once", () => {
+    const metrics = measureOwnerFirst(
+      `<a ${OWNER_FIRST_NEXT_ACTION_ATTR}="x" href="/x">go</a>`,
+    );
+    expect(metrics).toMatchObject({
+      controlCount: 1,
+      genericDecisionLabelCount: 0,
+      technicalDetailCount: 0,
+      hasOwnerFirstNextAction: true,
+    });
+  });
+
+  it("exposes usable default thresholds for a summary band", () => {
+    expect(OWNER_FIRST_SUMMARY_THRESHOLDS.maxGenericDecisionLabels).toBe(0);
+    expect(OWNER_FIRST_SUMMARY_THRESHOLDS.requireOwnerFirstNextAction).toBe(true);
+  });
+});

--- a/apps/web/lib/owner-first/ux-audit.ts
+++ b/apps/web/lib/owner-first/ux-audit.ts
@@ -1,0 +1,198 @@
+// apps/web/lib/owner-first/ux-audit.ts
+//
+// Owner-first UX checks (BI-3BCAF95F acceptance: "Add UX checks for word count,
+// link/button count, small controls, repeated generic decision labels, repeated
+// Technical detail, and owner-first next-action presence").
+//
+// The live UX audit measured the domain pages with exactly these signals — 818
+// words, 56 links/buttons, 34 small controls, "Make this business decision?" ×29,
+// "Technical detail" ×32. This module turns those signals into pure functions that
+// run against rendered HTML, so a test (or a future route sweep) can assert a
+// surface stays owner-first instead of drifting back into a subsystem dashboard.
+//
+// The functions operate on an HTML string (e.g. renderToStaticMarkup output). They
+// are deliberately markup-shaped, not DOM-dependent, so they run anywhere.
+
+/** The generic, non-owner decision labels the audit flagged as overload. */
+export const GENERIC_DECISION_LABELS = [
+  "Make this business decision?",
+  "Review this decision",
+  "Approve this bill?",
+  "Send this message?",
+] as const;
+
+/** Phrase that, when repeated, signals builder detail leaking onto an owner surface. */
+export const TECHNICAL_DETAIL_PHRASE = "Technical detail";
+
+/** Structural marker a compliant owner-first summary stamps on its next-action control. */
+export const OWNER_FIRST_NEXT_ACTION_ATTR = "data-owner-first-next-action";
+
+const ENTITY_MAP: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#x27;": "'",
+  "&#39;": "'",
+  "&nbsp;": " ",
+};
+
+function decodeEntities(text: string): string {
+  return text.replace(/&(?:amp|lt|gt|quot|nbsp|#x27|#39);/g, (m) => ENTITY_MAP[m] ?? m);
+}
+
+/** Strip tags and collapse whitespace to the visible text of a markup string. */
+export function visibleText(html: string): string {
+  const withoutTags = html.replace(/<[^>]*>/g, " ");
+  return decodeEntities(withoutTags).replace(/\s+/g, " ").trim();
+}
+
+/** Visible word count. */
+export function countWords(html: string): number {
+  const text = visibleText(html);
+  if (text.length === 0) return 0;
+  return text.split(/\s+/).length;
+}
+
+/** Every interactive control — anchors and buttons. */
+export function countControls(html: string): number {
+  return (html.match(/<a\b/gi)?.length ?? 0) + (html.match(/<button\b/gi)?.length ?? 0);
+}
+
+// A "small control" is a link/button whose type scale is below a comfortable tap
+// label. The audit flagged text-[9px]/text-[10px] controls; those are hard to read
+// and hard to hit. We match a control open-tag whose class list carries a tiny
+// text token.
+const SMALL_TEXT_TOKENS = ["text-[9px]", "text-[10px]", "text-[11px]"];
+
+/** Controls rendered at a sub-legible type scale. */
+export function countSmallControls(html: string): number {
+  const controlTags = html.match(/<(?:a|button)\b[^>]*>/gi) ?? [];
+  return controlTags.filter((tag) => SMALL_TEXT_TOKENS.some((tok) => tag.includes(tok))).length;
+}
+
+/** How many times a phrase appears in the visible text (case-sensitive). */
+export function countPhrase(html: string, phrase: string): number {
+  if (phrase.length === 0) return 0;
+  const text = visibleText(html);
+  let count = 0;
+  let idx = text.indexOf(phrase);
+  while (idx !== -1) {
+    count += 1;
+    idx = text.indexOf(phrase, idx + phrase.length);
+  }
+  return count;
+}
+
+/** Total occurrences of any generic (non-owner) decision label. */
+export function countGenericDecisionLabels(html: string): number {
+  return GENERIC_DECISION_LABELS.reduce((sum, label) => sum + countPhrase(html, label), 0);
+}
+
+/** Occurrences of the "Technical detail" phrase. */
+export function countTechnicalDetail(html: string): number {
+  return countPhrase(html, TECHNICAL_DETAIL_PHRASE);
+}
+
+/** True when the markup carries at least one stamped owner-first next action. */
+export function hasOwnerFirstNextAction(html: string): boolean {
+  return html.includes(OWNER_FIRST_NEXT_ACTION_ATTR);
+}
+
+export type OwnerFirstMetrics = {
+  wordCount: number;
+  controlCount: number;
+  smallControlCount: number;
+  genericDecisionLabelCount: number;
+  technicalDetailCount: number;
+  hasOwnerFirstNextAction: boolean;
+};
+
+/** Measure a markup string against every owner-first signal at once. */
+export function measureOwnerFirst(html: string): OwnerFirstMetrics {
+  return {
+    wordCount: countWords(html),
+    controlCount: countControls(html),
+    smallControlCount: countSmallControls(html),
+    genericDecisionLabelCount: countGenericDecisionLabels(html),
+    technicalDetailCount: countTechnicalDetail(html),
+    hasOwnerFirstNextAction: hasOwnerFirstNextAction(html),
+  };
+}
+
+export type OwnerFirstThresholds = {
+  maxWords: number;
+  maxControls: number;
+  maxSmallControls: number;
+  maxGenericDecisionLabels: number;
+  maxTechnicalDetail: number;
+  requireOwnerFirstNextAction: boolean;
+};
+
+/** Sensible defaults for an owner-first SUMMARY band (not a whole page). The band
+ *  leads the page; the professional detail behind it is not measured here. */
+export const OWNER_FIRST_SUMMARY_THRESHOLDS: OwnerFirstThresholds = {
+  maxWords: 160,
+  maxControls: 12,
+  maxSmallControls: 0,
+  maxGenericDecisionLabels: 0,
+  maxTechnicalDetail: 0,
+  requireOwnerFirstNextAction: true,
+};
+
+export type OwnerFirstFinding = {
+  check: string;
+  ok: boolean;
+  detail: string;
+};
+
+/** Evaluate metrics against thresholds; returns one finding per check. */
+export function evaluateOwnerFirst(
+  metrics: OwnerFirstMetrics,
+  thresholds: OwnerFirstThresholds,
+): OwnerFirstFinding[] {
+  return [
+    {
+      check: "word-count",
+      ok: metrics.wordCount <= thresholds.maxWords,
+      detail: `${metrics.wordCount} words (max ${thresholds.maxWords})`,
+    },
+    {
+      check: "control-count",
+      ok: metrics.controlCount <= thresholds.maxControls,
+      detail: `${metrics.controlCount} links/buttons (max ${thresholds.maxControls})`,
+    },
+    {
+      check: "small-controls",
+      ok: metrics.smallControlCount <= thresholds.maxSmallControls,
+      detail: `${metrics.smallControlCount} sub-legible controls (max ${thresholds.maxSmallControls})`,
+    },
+    {
+      check: "generic-decision-labels",
+      ok: metrics.genericDecisionLabelCount <= thresholds.maxGenericDecisionLabels,
+      detail: `${metrics.genericDecisionLabelCount} generic decision labels (max ${thresholds.maxGenericDecisionLabels})`,
+    },
+    {
+      check: "repeated-technical-detail",
+      ok: metrics.technicalDetailCount <= thresholds.maxTechnicalDetail,
+      detail: `"${TECHNICAL_DETAIL_PHRASE}" ×${metrics.technicalDetailCount} (max ${thresholds.maxTechnicalDetail})`,
+    },
+    {
+      check: "owner-first-next-action",
+      ok: thresholds.requireOwnerFirstNextAction ? metrics.hasOwnerFirstNextAction : true,
+      detail: metrics.hasOwnerFirstNextAction
+        ? "owner-first next action present"
+        : "no owner-first next action found",
+    },
+  ];
+}
+
+/** Convenience: audit a markup string end-to-end. `ok` is true iff every check passes. */
+export function auditOwnerFirst(
+  html: string,
+  thresholds: OwnerFirstThresholds = OWNER_FIRST_SUMMARY_THRESHOLDS,
+): { ok: boolean; metrics: OwnerFirstMetrics; findings: OwnerFirstFinding[] } {
+  const metrics = measureOwnerFirst(html);
+  const findings = evaluateOwnerFirst(metrics, thresholds);
+  return { ok: findings.every((f) => f.ok), metrics, findings };
+}

--- a/apps/web/lib/owner-first/vocabulary.test.ts
+++ b/apps/web/lib/owner-first/vocabulary.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { resolveOwnerVocabulary, RESTAURANT_ARCHETYPE_CATEGORY } from "./vocabulary";
+
+describe("resolveOwnerVocabulary", () => {
+  it("uses restaurant vocabulary for the food-hospitality archetype", () => {
+    const v = resolveOwnerVocabulary(RESTAURANT_ARCHETYPE_CATEGORY);
+    expect(v.isRestaurant).toBe(true);
+    expect(v.guestsLabel).toBe("guests");
+    expect(v.guestFollowUpLabel).toBe("Guest follow-up");
+    expect(v.reservationsLabel).toBe("reservations");
+    expect(v.staffLabel).toBe("service staff");
+    expect(v.serviceReadinessLabel).toBe("Next service readiness");
+    expect(v.depositsLabel).toBe("deposits");
+  });
+
+  it("is case- and whitespace-insensitive on the category", () => {
+    expect(resolveOwnerVocabulary("  Food-Hospitality  ").isRestaurant).toBe(true);
+  });
+
+  it("falls back to a neutral small-business default for other archetypes", () => {
+    const v = resolveOwnerVocabulary("retail-goods");
+    expect(v.isRestaurant).toBe(false);
+    expect(v.guestsLabel).toBe("customers");
+    expect(v.guestFollowUpLabel).toBe("Customer follow-up");
+    expect(v.category).toBe("retail-goods");
+  });
+
+  it("handles a missing archetype category", () => {
+    const v = resolveOwnerVocabulary(null);
+    expect(v.isRestaurant).toBe(false);
+    expect(v.category).toBeNull();
+  });
+});

--- a/apps/web/lib/owner-first/vocabulary.ts
+++ b/apps/web/lib/owner-first/vocabulary.ts
@@ -1,0 +1,81 @@
+// apps/web/lib/owner-first/vocabulary.ts
+//
+// Owner-first vocabulary for the major business-domain pages (BI-3BCAF95F,
+// EP-UX-COGLOAD). The domain pages (/workspace, /customer, /employee, /finance)
+// still open in professional subsystem language — CRM, HR, accountant lanes. A
+// non-technical owner has to translate that into "what do I do today". This
+// module resolves the archetype into the owner's own words for each domain so
+// the owner-first summaries can lead with them.
+//
+// Restaurant/Venue Portal (`food-hospitality`) is the calibration archetype the
+// live audit was run against, so it gets first-class vocabulary here. Every other
+// archetype falls back to a neutral small-business default — the summaries stay
+// owner-first everywhere, they just don't borrow restaurant nouns.
+
+/** The archetype category the live UX audit calibrated against. */
+export const RESTAURANT_ARCHETYPE_CATEGORY = "food-hospitality";
+
+export type OwnerDomainVocabulary = {
+  /** True when the install is the Restaurant/Venue Portal archetype. */
+  isRestaurant: boolean;
+  category: string | null;
+  /** The people the business serves. */
+  guestsLabel: string;
+  /** Customer-domain daily work. */
+  guestFollowUpLabel: string;
+  reservationsLabel: string;
+  ordersLabel: string;
+  inquiriesLabel: string;
+  /** People-domain daily work. */
+  staffLabel: string;
+  serviceReadinessLabel: string;
+  timesheetLabel: string;
+  /** Finance-domain daily work. */
+  billsLabel: string;
+  depositsLabel: string;
+  invoicesLabel: string;
+};
+
+const RESTAURANT_VOCABULARY: OwnerDomainVocabulary = {
+  isRestaurant: true,
+  category: RESTAURANT_ARCHETYPE_CATEGORY,
+  guestsLabel: "guests",
+  guestFollowUpLabel: "Guest follow-up",
+  reservationsLabel: "reservations",
+  ordersLabel: "orders",
+  inquiriesLabel: "inquiries",
+  staffLabel: "service staff",
+  serviceReadinessLabel: "Next service readiness",
+  timesheetLabel: "shift hours",
+  billsLabel: "bills",
+  depositsLabel: "deposits",
+  invoicesLabel: "invoices",
+};
+
+const DEFAULT_VOCABULARY: OwnerDomainVocabulary = {
+  isRestaurant: false,
+  category: null,
+  guestsLabel: "customers",
+  guestFollowUpLabel: "Customer follow-up",
+  reservationsLabel: "bookings",
+  ordersLabel: "orders",
+  inquiriesLabel: "inquiries",
+  staffLabel: "team",
+  serviceReadinessLabel: "Team readiness",
+  timesheetLabel: "timesheets",
+  billsLabel: "bills",
+  depositsLabel: "deposits",
+  invoicesLabel: "invoices",
+};
+
+/**
+ * Resolve the owner-first vocabulary for an archetype category. Restaurant/Venue
+ * Portal installs (`food-hospitality`) get restaurant nouns; everything else
+ * gets a neutral small-business default (still owner-first, just archetype-neutral).
+ */
+export function resolveOwnerVocabulary(category: string | null | undefined): OwnerDomainVocabulary {
+  if ((category ?? "").trim().toLowerCase() === RESTAURANT_ARCHETYPE_CATEGORY) {
+    return RESTAURANT_VOCABULARY;
+  }
+  return { ...DEFAULT_VOCABULARY, category: category ?? null };
+}

--- a/docs/superpowers/plans/2026-07-22-owner-first-domain-summaries-BI-3BCAF95F.md
+++ b/docs/superpowers/plans/2026-07-22-owner-first-domain-summaries-BI-3BCAF95F.md
@@ -1,0 +1,80 @@
+# BI-3BCAF95F — Owner-first daily work before CRM/HR/finance internals (plan)
+
+**Epic:** EP-UX-COGLOAD — Live UX cognitive-load audit follow-up
+**BI:** BI-3BCAF95F — Business domain pages need owner-first daily work before CRM, HR, and finance internals
+**Date:** 2026-07-22
+**Guiding outcome:** each major business-domain page opens with the owner's daily
+job — what needs action today, why it matters, and the safest next action — in the
+owner's own words, before any professional subsystem structure.
+
+## Problem (live audit, 2026-07-22)
+
+The domain pages still open as professional subsystem dashboards:
+
+- `/workspace` leads with generic `Make this business decision?` cards while the
+  `RESERVATIONS 0` rail chip and the funnel's `BOOKINGS 12 / INQUIRIES 1` never
+  become a concrete owner action.
+- `/customer` is framed as Accounts / Engagements / Pipeline / Quotes / Orders.
+- `/customer/funnel` shows bookings/inquiries as analytics, not follow-up work.
+- `/employee` opens with HR role cards (`HR-000`, HITL, SLA) before the directory.
+- `/finance` opens with accountant lanes and the full AR/AP/reporting taxonomy.
+
+## Design grounding
+
+Extends the existing attention/workspace-home substrate; **creates one new
+capability**: an owner-first summary layer that sits *in front of* the existing
+domain surfaces. Source of truth for the projections is the same canonical data the
+pages already load (storefront queues, CRM counts, timesheet periods, finance
+aggregates) — no parallel record is persisted. Reuses `lib/navigation/nav-mode`
+for Simple/Full density and the `food-hospitality` archetype category (the live
+calibration archetype) for restaurant vocabulary.
+
+Not touched: the global attention aggregator (`lib/attention/aggregate.ts`) — the
+storefront reconciliation is rendered as an owner-first band *above* the
+`OperatorCockpit` so it leads without re-plumbing the shared projector (which a
+sibling BI, BI-348766E5, is already editing).
+
+## What ships
+
+**New shared module `lib/owner-first/`:**
+- `vocabulary.ts` — `resolveOwnerVocabulary(category)` → restaurant vs neutral
+  owner language (guest follow-up, reservations/orders/inquiries, service staff,
+  bills/deposits/invoices, next service readiness).
+- `domain-summary.ts` — pure builders (`buildCustomerOwnerSummary`,
+  `buildEmployeeOwnerSummary`, `buildFinanceOwnerSummary`,
+  `buildWorkspaceStorefrontSummary`) that project counts into an ordered
+  `OwnerFirstSummary` (what / why / safest next action), urgent-first.
+- `ux-audit.ts` — the owner-first UX checks (word count, link/button count, small
+  controls, repeated generic decision labels, repeated `Technical detail`, and
+  owner-first next-action presence) plus threshold evaluation.
+- `context.ts` — one cached archetype read shared by the domain pages.
+
+**New components `components/owner-first/`:**
+- `OwnerFirstSummaryBand` — the band each page opens with; Simple mode drops the
+  subhead and per-action "why" lines (reduces body content, not only the rail).
+- `OwnerFirstDisclosure` — native `<details>` wrapper demoting professional
+  structure behind progressive disclosure.
+- `WorkspaceStorefrontAttention` — reconciles pending storefront
+  reservations/orders/inquiries into the workspace before the cockpit residue.
+
+**Page wiring:**
+- `/workspace` — storefront band renders before `OperatorCockpit`.
+- `/customer` — guest-follow-up band leads; RevenueCockpit / duplicates / grid /
+  account list move behind an "All CRM detail" disclosure (hidden in Simple mode).
+- `/customer/funnel` — guest-work band leads; pipeline + inbox breakdown hidden in
+  Simple mode.
+- `/employee` — heading corrected to "People"; service-readiness band leads; role
+  governance (cards + HR lifecycle) moves to the bottom behind a "Role governance
+  & access" disclosure (hidden in Simple mode).
+- `/finance` — money-today band leads; finance lanes + accountant lane and the
+  AR/AP/reporting taxonomy move behind disclosures (hidden in Simple mode).
+
+## Verification
+
+- `lib/owner-first/*.test.ts` — vocabulary, per-domain summary shape/ordering,
+  restaurant vs neutral language, and the UX-check functions (including the live
+  audit's overloaded-markup case).
+- `components/owner-first/OwnerFirstSummary.test.tsx` — renders each domain band
+  and asserts it passes every UX check, stamps an owner-first next action, uses no
+  generic decision labels or repeated `Technical detail`, and that Simple mode
+  reduces the rendered word count.


### PR DESCRIPTION
## What

Business-domain pages (`/workspace`, `/customer`, `/customer/funnel`, `/employee`, `/finance`) opened as professional subsystem dashboards — CRM stages, HR role governance, accountant lanes, AR/AP taxonomy — instead of the owner's daily job. This adds an **owner-first summary layer** that leads each page with *what needs action today, why it matters, and the safest next action*, in the owner's own words, then demotes the professional structure behind progressive disclosure.

Implements **BI-3BCAF95F** (EP-UX-COGLOAD).

## How

**New shared module `apps/web/lib/owner-first/`**
- `vocabulary.ts` — restaurant (`food-hospitality`) vs neutral owner language.
- `domain-summary.ts` — pure, urgent-first builders per domain (what / why / safest next action).
- `ux-audit.ts` — owner-first UX checks: word count, link/button count, small controls, repeated generic decision labels, repeated `Technical detail`, and owner-first next-action presence.
- `context.ts` — one cached archetype read shared by the pages.

**New components `apps/web/components/owner-first/`**
- `OwnerFirstSummaryBand` — the band each page opens with; **Simple mode drops the subhead + per-action "why"** to reduce body content.
- `OwnerFirstDisclosure` — native `<details>` demotion of professional structure.
- `WorkspaceStorefrontAttention` — reconciles pending storefront reservations/orders/inquiries into `/workspace` **before** the generic `OperatorCockpit` decisions.

**Page wiring**
- `/workspace` — storefront band before the cockpit.
- `/customer` — guest-follow-up band leads; RevenueCockpit / duplicates / grid / account list behind an "All CRM detail" disclosure (a `?view=` grid deep-link still renders, opened).
- `/customer/funnel` — guest-work band leads; pipeline + inbox breakdown hidden in Simple mode.
- `/employee` — heading corrected to **People**; service-readiness band leads; role governance moved to the bottom behind a disclosure.
- `/finance` — money-today band leads; finance lanes + AR/AP/reporting taxonomy behind disclosures.

## Acceptance

- [x] `/workspace`, `/customer`, `/employee`, `/finance` begin with an owner-first summary (what / why / safest next action).
- [x] Storefront/Funnel bookings & inquiries reconciled into workspace attention before generic coworker decisions.
- [x] CRM stages, HR role governance, accountant lanes, AR/AP/reporting taxonomy moved behind progressive disclosure.
- [x] Restaurant language: guest follow-up, reservations/orders/inquiries, service staffing, bills/deposits/invoices, next service readiness.
- [x] Simple mode reduces body content on these pages.
- [x] UX checks added (word count, link/button count, small controls, repeated generic labels, repeated Technical detail, owner-first next-action).

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/plans/2026-07-22-owner-first-domain-summaries-BI-3BCAF95F.md` (EP-UX-COGLOAD follow-up).
- Current code substrate reviewed: `apps/web/lib/attention`, `apps/web/lib/navigation/nav-mode`, `apps/web/lib/storefront/archetype-vocabulary`.
- Source of truth: the canonical domain queries each page already runs; no parallel record persisted. The global attention aggregator (`apps/web/lib/attention/aggregate.ts`) is intentionally untouched — a sibling BI owns it; the storefront band leads without re-plumbing it.
- Decision: add a new owner-first layer in front of the existing surfaces rather than rewriting them.

## Verification

Source-only worktree (vitest bin not installed here — CI runs the suite):
- Pure builders + UX-check functions validated via a node harness (all pass, incl. the live audit's overloaded-markup case).
- All changed files pass esbuild parse; **full-project `tsc --noEmit` passes** (pre-commit typecheck ok with a raised heap).
- Rendered word-count budgets confirmed under thresholds; Simple mode < Full mode.

New tests: `lib/owner-first/{vocabulary,domain-summary,ux-audit}.test.ts` and `components/owner-first/OwnerFirstSummary.test.tsx`.