### PR TITLE
fix(storefront): owner-visible result feedback for menu & section edits (BI-CBE9B9B3)

### DIFF
--- a/apps/web/components/storefront-admin/ItemsManager.test.tsx
+++ b/apps/web/components/storefront-admin/ItemsManager.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ItemsManager } from "./ItemsManager";
+import { getVocabulary } from "@/lib/storefront/archetype-vocabulary";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const vocabulary = getVocabulary("food-hospitality");
+
+function item(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "itm_1",
+    itemId: "ITM-1",
+    name: "Table for 2",
+    description: null,
+    category: null,
+    priceAmount: null,
+    priceCurrency: "USD",
+    priceType: null,
+    ctaType: "booking",
+    ctaLabel: null,
+    imageUrl: null,
+    isActive: true,
+    sortOrder: 0,
+    bookingConfig: null,
+  };
+}
+
+function renderManager() {
+  return render(
+    <ItemsManager
+      storefrontId="sf_1"
+      items={[item()]}
+      vocabulary={vocabulary}
+      categorySuggestions={[]}
+      defaultCtaType="booking"
+    />,
+  );
+}
+
+describe("ItemsManager owner action feedback", () => {
+  it("confirms success in plain language after hiding an item", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) }));
+    renderManager();
+
+    fireEvent.click(screen.getByRole("button", { name: /hide table for 2 from your public page/i }));
+
+    await waitFor(() => expect(screen.getByRole("status").textContent).toMatch(/hidden from your public page/i));
+  });
+
+  it("keeps the item visible and offers Retry when the change fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, json: async () => ({ error: "nope" }) }));
+    renderManager();
+
+    fireEvent.click(screen.getByRole("button", { name: /hide table for 2 from your public page/i }));
+
+    await waitFor(() => expect(screen.getByRole("status").textContent).toMatch(/nope|couldn't update/i));
+    // Still labelled "hide" — the item did not actually get hidden.
+    expect(screen.getByRole("button", { name: /hide table for 2 from your public page/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeTruthy();
+  });
+});

--- a/apps/web/components/storefront-admin/ItemsManager.tsx
+++ b/apps/web/components/storefront-admin/ItemsManager.tsx
@@ -4,6 +4,9 @@ import { confirmDialog } from "@/components/ui/Dialog";
 import { ItemFormDialog, type ItemFormData } from "./ItemFormDialog";
 import { getCurrencySymbol } from "@/lib/finance/currency-symbol";
 import type { ArchetypeVocabulary } from "@/lib/storefront/archetype-vocabulary";
+import { useRowActions, assertOk, RowStatus } from "./use-row-action";
+
+const REORDER_KEY = "__reorder__";
 
 type Item = {
   id: string;
@@ -45,6 +48,8 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
   const [editingItem, setEditingItem] = useState<Item | null>(null);
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [dragIdx, setDragIdx] = useState<number | null>(null);
+  const [orderBeforeDrag, setOrderBeforeDrag] = useState<Item[] | null>(null);
+  const { statuses, runRowAction } = useRowActions();
 
   // Derive unique categories from items
   const categories = [...new Set(items.map((i) => i.category).filter(Boolean))] as string[];
@@ -110,19 +115,29 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
     }
   }
 
-  async function toggleActive(id: string, isActive: boolean) {
-    await fetch(`/api/storefront/admin/items/${id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ isActive }),
+  function toggleActive(id: string, isActive: boolean, name: string) {
+    void runRowAction(id, {
+      savingMessage: "Saving…",
+      successMessage: isActive ? "Shown on your public page" : "Hidden from your public page",
+      run: async () => {
+        const res = await fetch(`/api/storefront/admin/items/${id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ isActive }),
+        });
+        await assertOk(res, `Couldn't update ${name}. Try again.`);
+        // Apply only after the server confirms — never leave the UI showing an unsaved change.
+        setItems((prev) => prev.map((i) => (i.id === id ? { ...i, isActive } : i)));
+      },
     });
-    setItems((prev) => prev.map((i) => i.id === id ? { ...i, isActive } : i));
   }
 
   // ─── Drag-to-Reorder ─────────────────────────────────────────────────
 
   function handleDragStart(idx: number) {
     setDragIdx(idx);
+    // Snapshot so a failed save can restore the owner's original order.
+    setOrderBeforeDrag(items);
   }
 
   function handleDragOver(e: React.DragEvent, idx: number) {
@@ -138,14 +153,30 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
     setDragIdx(idx);
   }
 
-  async function handleDragEnd() {
+  function handleDragEnd() {
     setDragIdx(null);
-    // Persist new order
+    const snapshot = orderBeforeDrag;
+    setOrderBeforeDrag(null);
+    // No net movement — nothing to persist.
+    if (!snapshot || snapshot.map((i) => i.id).join() === items.map((i) => i.id).join()) return;
     const reorderData = items.map((item, idx) => ({ id: item.id, sortOrder: idx }));
-    await fetch("/api/storefront/admin/items/reorder", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ items: reorderData }),
+    void runRowAction(REORDER_KEY, {
+      savingMessage: "Saving new order…",
+      successMessage: "Order saved",
+      run: async () => {
+        const res = await fetch("/api/storefront/admin/items/reorder", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ items: reorderData }),
+        });
+        try {
+          await assertOk(res, "Couldn't save the new order. Try again.");
+        } catch (err) {
+          // Reorder is applied live during drag, so restore the owner's original order on failure.
+          setItems(snapshot);
+          throw err;
+        }
+      },
     });
   }
 
@@ -277,8 +308,9 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
                   and a 44px hit area so they are safe to tap on a phone. */}
               <div className="flex items-center gap-1 shrink-0">
                 <button
-                  onClick={() => toggleActive(item.id, !item.isActive)}
-                  className={`inline-flex items-center justify-center min-h-[44px] min-w-[44px] text-[10px] px-2 rounded border border-[var(--dpf-border)] hover:bg-[var(--dpf-surface-2)] transition-colors ${item.isActive ? "text-[var(--dpf-success)]" : "text-[var(--dpf-muted)]"}`}
+                  onClick={() => toggleActive(item.id, !item.isActive, item.name)}
+                  disabled={statuses[item.id]?.kind === "saving"}
+                  className={`inline-flex items-center justify-center min-h-[44px] min-w-[44px] text-[10px] px-2 rounded border border-[var(--dpf-border)] hover:bg-[var(--dpf-surface-2)] transition-colors disabled:opacity-60 ${item.isActive ? "text-[var(--dpf-success)]" : "text-[var(--dpf-muted)]"}`}
                   aria-label={
                     item.isActive
                       ? `Hide ${item.name} from your public page`
@@ -305,10 +337,24 @@ export function ItemsManager({ storefrontId, items: initial, vocabulary, categor
                   Del
                 </button>
               </div>
+
+              {/* Row-specific result of the last publish-affecting change. */}
+              {statuses[item.id] && (
+                <div className="basis-full">
+                  <RowStatus status={statuses[item.id]} />
+                </div>
+              )}
             </div>
           );
         })}
       </div>
+
+      {/* Reorder save state — the whole list moved, so this belongs to the list, not one row. */}
+      {statuses[REORDER_KEY] && (
+        <div className="mt-2">
+          <RowStatus status={statuses[REORDER_KEY]} />
+        </div>
+      )}
 
       {filtered.length === 0 && (
         <p className="text-sm text-[var(--dpf-muted)] py-8 text-center">

--- a/apps/web/components/storefront-admin/SectionsManager.test.tsx
+++ b/apps/web/components/storefront-admin/SectionsManager.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { SectionsManager } from "./SectionsManager";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const sections = [
+  { id: "sec_1", type: "opening_hours", title: null, sortOrder: 0, isVisible: true },
+  { id: "sec_2", type: "menu", title: "Dinner Menu", sortOrder: 1, isVisible: true },
+];
+
+function mockFetch(ok: boolean) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    json: async () => (ok ? { success: true } : { error: "Server said no" }),
+  });
+}
+
+describe("SectionsManager owner action feedback", () => {
+  it("shows an owner-readable name instead of the internal type slug", () => {
+    render(<SectionsManager storefrontId="sf_1" sections={sections} />);
+    // Humanized fallback for a null title, never the raw "opening_hours" slug.
+    expect(screen.getByText("Opening Hours")).toBeTruthy();
+    expect(screen.queryByText("opening_hours")).toBeNull();
+  });
+
+  it("labels the visibility control per-row and confirms success after saving", async () => {
+    vi.stubGlobal("fetch", mockFetch(true));
+    render(<SectionsManager storefrontId="sf_1" sections={sections} />);
+
+    const hide = screen.getByRole("button", { name: /hide dinner menu section from your public page/i });
+    fireEvent.click(hide);
+
+    // Result is announced to assistive tech and the owner in plain language.
+    await waitFor(() => expect(screen.getByRole("status").textContent).toMatch(/hidden from your public page/i));
+    // Control flipped to "Show" only after the server confirmed.
+    expect(screen.getByRole("button", { name: /show dinner menu section on your public page/i })).toBeTruthy();
+  });
+
+  it("keeps the old state and offers Retry when a visibility change fails", async () => {
+    vi.stubGlobal("fetch", mockFetch(false));
+    render(<SectionsManager storefrontId="sf_1" sections={sections} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /hide dinner menu section from your public page/i }));
+
+    await waitFor(() => expect(screen.getByRole("status").textContent).toMatch(/server said no|couldn't update/i));
+    // Failed save must not leave the UI claiming the change stuck.
+    expect(screen.getByRole("button", { name: /hide dinner menu section from your public page/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeTruthy();
+  });
+});

--- a/apps/web/components/storefront-admin/SectionsManager.tsx
+++ b/apps/web/components/storefront-admin/SectionsManager.tsx
@@ -1,21 +1,39 @@
 "use client";
 import { useState } from "react";
+import { useRowActions, assertOk, RowStatus } from "./use-row-action";
 
 type Section = { id: string; type: string; title: string | null; sortOrder: number; isVisible: boolean };
 
+/** Turns an internal section-type slug (e.g. "opening_hours") into owner-readable text. */
+function humanizeSectionType(type: string): string {
+  return type
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}
+
 export function SectionsManager({ storefrontId, sections: initial }: { storefrontId: string; sections: Section[] }) {
   const [sections, setSections] = useState(initial);
+  const { statuses, runRowAction } = useRowActions();
 
-  async function toggleVisibility(id: string, isVisible: boolean) {
-    await fetch(`/api/storefront/admin/sections/${id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ isVisible }),
+  function toggleVisibility(id: string, isVisible: boolean, name: string) {
+    void runRowAction(id, {
+      savingMessage: "Saving…",
+      successMessage: isVisible ? "Shown on your public page" : "Hidden from your public page",
+      run: async () => {
+        const res = await fetch(`/api/storefront/admin/sections/${id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ isVisible }),
+        });
+        await assertOk(res, `Couldn't update ${name}. Try again.`);
+        // Apply only after the server confirms — never leave the UI showing an unsaved change.
+        setSections((prev) => prev.map((s) => (s.id === id ? { ...s, isVisible } : s)));
+      },
     });
-    setSections((prev) => prev.map((s) => s.id === id ? { ...s, isVisible } : s));
   }
 
-  async function moveSection(id: string, direction: "up" | "down") {
+  function moveSection(id: string, direction: "up" | "down", name: string) {
     const idx = sections.findIndex((s) => s.id === id);
     if (direction === "up" && idx === 0) return;
     if (direction === "down" && idx === sections.length - 1) return;
@@ -25,11 +43,19 @@ export function SectionsManager({ storefrontId, sections: initial }: { storefron
     updated[idx] = updated[swapIdx]!;
     updated[swapIdx] = tmp;
     const reordered = updated.map((s, i) => ({ ...s, sortOrder: i }));
-    setSections(reordered);
-    await fetch(`/api/storefront/admin/sections/reorder`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ storefrontId, order: reordered.map((s) => s.id) }),
+
+    void runRowAction(id, {
+      savingMessage: "Saving order…",
+      successMessage: direction === "up" ? "Moved up" : "Moved down",
+      run: async () => {
+        const res = await fetch(`/api/storefront/admin/sections/reorder`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ storefrontId, order: reordered.map((s) => s.id) }),
+        });
+        await assertOk(res, `Couldn't move ${name}. Try again.`);
+        setSections(reordered);
+      },
     });
   }
 
@@ -38,35 +64,39 @@ export function SectionsManager({ storefrontId, sections: initial }: { storefron
       <h2 style={{ fontSize: 15, fontWeight: 600, marginBottom: 16 }}>Sections</h2>
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {sections.map((s, idx) => {
-          const name = s.title ?? s.type;
+          const name = s.title ?? humanizeSectionType(s.type);
+          const status = statuses[s.id];
           return (
-          <div key={s.id} className="flex flex-wrap items-center gap-2 rounded-md border border-[var(--dpf-border)] px-3 py-2.5">
-            <div className="min-w-0 flex-1">
-              <span style={{ fontWeight: 600, fontSize: 13 }}>{name}</span>
-              <span className="text-[var(--dpf-muted)]" style={{ fontSize: 11, marginLeft: 6 }}>{s.type}</span>
+          <div key={s.id} className="rounded-md border border-[var(--dpf-border)] px-3 py-2.5">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="min-w-0 flex-1">
+                <span style={{ fontWeight: 600, fontSize: 13 }}>{name}</span>
+              </div>
+              {/* Reorder / visibility — row-specific accessible labels and 44px hit
+                  areas so the arrows and Hide/Show are safe to tap and screen-reader
+                  legible ("Move Hero up", "Hide Hero section") rather than anonymous. */}
+              <button
+                onClick={() => moveSection(s.id, "up", name)}
+                disabled={idx === 0 || status?.kind === "saving"}
+                aria-label={`Move ${name} up`}
+                className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] text-sm disabled:opacity-40"
+              >↑</button>
+              <button
+                onClick={() => moveSection(s.id, "down", name)}
+                disabled={idx === sections.length - 1 || status?.kind === "saving"}
+                aria-label={`Move ${name} down`}
+                className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] text-sm disabled:opacity-40"
+              >↓</button>
+              <button
+                onClick={() => toggleVisibility(s.id, !s.isVisible, name)}
+                disabled={status?.kind === "saving"}
+                aria-label={s.isVisible ? `Hide ${name} section from your public page` : `Show ${name} section on your public page`}
+                className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] px-3 text-xs disabled:opacity-60"
+              >
+                {s.isVisible ? "Hide" : "Show"}
+              </button>
             </div>
-            {/* Reorder / visibility — row-specific accessible labels and 44px hit
-                areas so the arrows and Hide/Show are safe to tap and screen-reader
-                legible ("Move Hero up", "Hide Hero section") rather than anonymous. */}
-            <button
-              onClick={() => moveSection(s.id, "up")}
-              disabled={idx === 0}
-              aria-label={`Move ${name} up`}
-              className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] text-sm disabled:opacity-40"
-            >↑</button>
-            <button
-              onClick={() => moveSection(s.id, "down")}
-              disabled={idx === sections.length - 1}
-              aria-label={`Move ${name} down`}
-              className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] text-sm disabled:opacity-40"
-            >↓</button>
-            <button
-              onClick={() => toggleVisibility(s.id, !s.isVisible)}
-              aria-label={s.isVisible ? `Hide ${name} section from your public page` : `Show ${name} section on your public page`}
-              className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-text)] px-3 text-xs"
-            >
-              {s.isVisible ? "Hide" : "Show"}
-            </button>
+            <RowStatus status={status} />
           </div>
           );
         })}

--- a/apps/web/components/storefront-admin/use-row-action.tsx
+++ b/apps/web/components/storefront-admin/use-row-action.tsx
@@ -1,0 +1,108 @@
+"use client";
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Per-row action feedback for owner content managers.
+ *
+ * A non-technical owner needs to see that a publish-affecting change (hide an
+ * item, reorder a section) is in progress, succeeded, or failed — and be able to
+ * retry a failure — rather than a bare fetch that silently no-ops. The `run`
+ * callback owns the request AND applies the state change only on confirmed
+ * success, so a failed save never leaves the UI showing a change that did not
+ * persist. Mirrors the pending/succeeded/failed shape already used by
+ * StorefrontInbox's send-to-backlog action.
+ */
+export type RowActionStatus =
+  | { kind: "saving"; message: string }
+  | { kind: "saved"; message: string }
+  | { kind: "error"; message: string; retry: () => void };
+
+const SAVED_LINGER_MS = 2500;
+
+export function useRowActions() {
+  const [statuses, setStatuses] = useState<Record<string, RowActionStatus | undefined>>({});
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  const scheduleSavedClear = useCallback((key: string) => {
+    if (timers.current[key]) clearTimeout(timers.current[key]);
+    timers.current[key] = setTimeout(() => {
+      setStatuses((current) => {
+        if (current[key]?.kind !== "saved") return current;
+        const next = { ...current };
+        delete next[key];
+        return next;
+      });
+    }, SAVED_LINGER_MS);
+  }, []);
+
+  const runRowAction = useCallback(
+    (
+      key: string,
+      opts: {
+        savingMessage: string;
+        successMessage: string;
+        /** Performs the request and applies state on success. Must throw on failure. */
+        run: () => Promise<void>;
+      },
+    ): Promise<boolean> => {
+      const attempt = async (): Promise<boolean> => {
+        if (timers.current[key]) clearTimeout(timers.current[key]);
+        setStatuses((current) => ({ ...current, [key]: { kind: "saving", message: opts.savingMessage } }));
+        try {
+          await opts.run();
+          setStatuses((current) => ({ ...current, [key]: { kind: "saved", message: opts.successMessage } }));
+          scheduleSavedClear(key);
+          return true;
+        } catch (err) {
+          const message = err instanceof Error && err.message ? err.message : "Couldn't save. Try again.";
+          setStatuses((current) => ({
+            ...current,
+            [key]: { kind: "error", message, retry: () => void attempt() },
+          }));
+          return false;
+        }
+      };
+      return attempt();
+    },
+    [scheduleSavedClear],
+  );
+
+  return { statuses, runRowAction };
+}
+
+/** Throws a friendly error when a storefront admin mutation response is not ok. */
+export async function assertOk(res: Response, fallback: string): Promise<void> {
+  if (res.ok) return;
+  let message = fallback;
+  try {
+    const body = (await res.json()) as { error?: string };
+    if (body?.error) message = body.error;
+  } catch {
+    /* non-JSON error body — keep the fallback */
+  }
+  throw new Error(message);
+}
+
+/** Inline, screen-reader-announced result of the most recent row action. */
+export function RowStatus({ status }: { status: RowActionStatus | undefined }) {
+  if (!status) return null;
+  const color =
+    status.kind === "error" ? "var(--dpf-error)" : status.kind === "saved" ? "var(--dpf-success)" : "var(--dpf-muted)";
+  return (
+    <div role="status" aria-live="polite" className="mt-1.5 flex items-center gap-2" style={{ fontSize: 11, color }}>
+      <span>
+        {status.kind === "saved" ? "✓ " : status.kind === "error" ? "⚠ " : ""}
+        {status.message}
+      </span>
+      {status.kind === "error" && (
+        <button
+          onClick={status.retry}
+          className="underline underline-offset-2 text-[var(--dpf-accent)]"
+          style={{ fontSize: 11 }}
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What & why

Under **EP-UX-COGLOAD**, BI-CBE9B9B3 requires that a non-technical Restaurant owner sees every publish-affecting menu/section edit **succeed or fail visibly**. The current `ItemsManager` and `SectionsManager` mutated the public site with **bare fetches**: no `res.ok` check, no pending/saved/failed state, and optimistic updates that never rolled back. So hiding a menu item or reordering a section *looked* like it worked even when the save silently failed.

The 44px hit-areas + row-specific `aria-label`s from the BI already landed via an earlier merge; this PR delivers the **action-result contract** and the **vocabulary/slug** cleanup — the remaining unmet acceptance criteria.

## Changes

- **Shared `useRowActions` hook + `RowStatus`** (`aria-live`), mirroring the existing `StorefrontInbox` send-to-backlog pending/succeeded/failed pattern — no new contract.
- **Confirm-then-apply**: item/section visibility toggles and section reorder apply local state **only after the server confirms**. Failures show an inline `⚠ Couldn't save… / Retry` and never leave a false state. Controls disable while saving.
- **Drag-reorder** in `ItemsManager` snapshots the pre-drag order and **restores it on a failed save**, with a list-level `✓ Order saved` / failure result.
- **Vocabulary**: the raw internal section-`type` slug beside titles (e.g. `opening_hours`) is replaced with a humanized, owner-readable name.
- **Tests** (5, passing): success confirmation, failure → `Retry` + state unchanged, and slug suppression, for both managers.

## Scope / deferral

Delivers the action-result + vocabulary slice. The **generated/cross-archetype grouped-recovery** slice of the BI is deferred to the setup-recovery work — **BI-C39DC90C owns service-line recovery** — and is tracked on BI-CBE9B9B3. This PR does not mark the BI done.

## Design grounding

**Design-Grounding-Decision: extend** — reuses the established `StorefrontInbox` per-row pending/saved/failed pattern. Source of truth: BI-CBE9B9B3 acceptance criteria. No new spec artifact (no contract change). Touches `apps/web/` storefront-admin components only.

## Verification

- `vitest` on both new test files: **5/5 pass**.
- Direct `node node_modules/typescript/bin/tsc -p apps/web`: **zero errors in the changed files** (worktree pre-commit `next typegen` is env-blocked by the missing `next` bin; CI runs the authoritative typecheck).
- **Live desktop/mobile preview pass is still pending** — the `:3001` Contributor preview lease was refused (`portal_quiescing`, platform upgrade draining). To be completed once the platform upgrade clears; the BI stays open until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
