### PR TITLE
feat(marketing): owner-first progressive disclosure + funnel de-dup for Restaurant marketing (BI-8AB9C904, BI-CC580161)

### DIFF
--- a/apps/web/app/(shell)/customer/marketing/page.test.tsx
+++ b/apps/web/app/(shell)/customer/marketing/page.test.tsx
@@ -5,6 +5,22 @@ const { getMarketingWorkspaceSnapshot } = vi.hoisted(() => ({
   getMarketingWorkspaceSnapshot: vi.fn(),
 }));
 
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
 vi.mock("@/lib/marketing", () => ({
   formatMarketingDate: (value: Date | string | null | undefined) =>
     value ? new Date(value).toISOString().slice(0, 10) : "No date",
@@ -136,5 +152,127 @@ describe("CustomerMarketingPage", () => {
     expect(html).not.toContain('data-topic-id="strategy-review"');
     expect(html).not.toContain('data-topic-id="campaign-directions"');
     expect(html).not.toContain('data-topic-id="proof-plan"');
+  });
+});
+
+const LEAK_BRIEF = {
+  briefId: "brief-leak",
+  title: "Reach technical founders with our AI workflow",
+  objective: "Show how Build Studio ships software",
+  audience: "technical founders",
+  channels: ["linkedin"],
+  cta: "Book a demo",
+  proofAssets: [],
+  kpis: [],
+  notes: "Position the SaaS platform.",
+  status: "draft",
+  createdAt: now,
+};
+
+const CLEAN_BRIEF = {
+  briefId: "brief-clean",
+  title: "Fill quiet midweek covers with a seasonal tasting menu",
+  objective: "Lift midweek bookings",
+  audience: "local diners",
+  channels: ["email"],
+  cta: "Reserve a table",
+  proofAssets: [],
+  kpis: ["Booking fill rate"],
+  notes: "Feature our reviews.",
+  status: "draft",
+  createdAt: now,
+};
+
+function restaurantSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    ...snapshot(),
+    storefront: {
+      id: "sf-r",
+      archetypeId: "restaurant",
+      archetypeName: "Restaurant",
+      category: "food-hospitality",
+      tagline: "Seasonal neighbourhood dining",
+      description: null,
+      ctaType: "booking",
+    },
+    strategy: {
+      ...snapshot().strategy,
+      primaryGoal: "Fill covers during quiet periods",
+      proofAssets: [{ type: "testimonial", label: "Five-star reviews" }],
+    },
+    ...overrides,
+  };
+}
+
+describe("CustomerMarketingPage — progressive disclosure (BI-8AB9C904 + BI-CC580161)", () => {
+  it("opens with one restaurant owner-first question and defers strategy behind disclosure", async () => {
+    getMarketingWorkspaceSnapshot.mockResolvedValue(restaurantSnapshot());
+    const html = renderToStaticMarkup(await CustomerMarketingPage());
+
+    // Exactly one owner-first question, phrased in booking language.
+    expect(html).toContain('data-testid="marketing-owner-question"');
+    expect(html.toLowerCase()).toContain("booking demand");
+
+    // The strategy machinery is deferred inside a <details>, not on the first screen.
+    const detailsIdx = html.indexOf('data-testid="marketing-advanced-strategy"');
+    const overviewIdx = html.indexOf('data-testid="strategy-overview"');
+    expect(detailsIdx).toBeGreaterThan(-1);
+    expect(overviewIdx).toBeGreaterThan(detailsIdx);
+  });
+
+  it("quarantines off-archetype artifacts and defers publish/review until a fit campaign exists", async () => {
+    getMarketingWorkspaceSnapshot.mockResolvedValue(
+      restaurantSnapshot({
+        workProducts: {
+          campaignBriefs: [LEAK_BRIEF],
+          assetTasks: [],
+          kpiCheckpoints: [],
+          automationCandidates: [],
+        },
+      }),
+    );
+    const html = renderToStaticMarkup(await CustomerMarketingPage());
+
+    expect(html).toContain('data-testid="marketing-quarantine-banner"');
+    expect(html).toContain('data-testid="marketing-publish-deferred"');
+    expect(html).not.toContain('data-testid="approval-queue"');
+
+    // No software-founder campaign copy leaks into the always-visible page shell.
+    expect(html).not.toContain("Build Studio");
+    expect(html).not.toContain("technical founders");
+    expect(html).not.toContain("AI workflow");
+  });
+
+  it("reveals the review & publish queue once there is archetype-fit work", async () => {
+    getMarketingWorkspaceSnapshot.mockResolvedValue(
+      restaurantSnapshot({
+        workProducts: {
+          campaignBriefs: [CLEAN_BRIEF],
+          assetTasks: [],
+          kpiCheckpoints: [],
+          automationCandidates: [],
+        },
+        pendingDrafts: [
+          {
+            draftId: "d1",
+            sourceType: "marketing-asset-task",
+            sourceId: "t1",
+            assetTaskTitle: "Email",
+            channelId: "email",
+            assetType: "email",
+            status: "pending-review",
+            body: "Reserve a table for our seasonal tasting menu.",
+            bodyFormat: "markdown",
+            createdByAgentId: "AGT",
+            createdAt: now,
+          },
+        ],
+      }),
+    );
+    const html = renderToStaticMarkup(await CustomerMarketingPage());
+
+    expect(html).toContain('data-testid="marketing-publish-review"');
+    expect(html).toContain('data-testid="approval-queue"');
+    expect(html).not.toContain('data-testid="marketing-publish-deferred"');
   });
 });

--- a/apps/web/app/(shell)/customer/marketing/page.tsx
+++ b/apps/web/app/(shell)/customer/marketing/page.tsx
@@ -13,6 +13,10 @@ import {
 } from "@/lib/marketing/agentic-operations";
 import { getPlaybook } from "@/lib/tak/marketing-playbooks";
 import { buildMarketingOwnerDecision } from "@/lib/marketing/next-decision";
+import {
+  buildMarketingDisclosure,
+  buildMarketingOwnerQuestion,
+} from "@/lib/marketing/disclosure";
 
 export default async function CustomerMarketingPage() {
   const snapshot = await getMarketingWorkspaceSnapshot();
@@ -75,61 +79,74 @@ export default async function CustomerMarketingPage() {
   });
   const playbook = getPlaybook(snapshot.storefront.category, snapshot.storefront.ctaType);
   const ownerDecision = buildMarketingOwnerDecision(snapshot, playbook);
+  const ownerQuestion = buildMarketingOwnerQuestion(snapshot.storefront.category, playbook);
+  const disclosure = buildMarketingDisclosure(snapshot);
+  const archetypeName = snapshot.storefront.archetypeName ?? "your business";
 
   return (
     <div className="space-y-6">
+      {/* First viewport: ONE owner-first question, then the single recommended
+          next step. Strategy / campaign / publish machinery is deferred below. */}
       <section
         data-testid="marketing-owner-decision"
         data-decision-id={ownerDecision.id}
         className="rounded-lg border border-[var(--dpf-accent)] bg-[var(--dpf-surface-1)] p-6"
       >
-        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--dpf-accent)]">
-              Your next decision
-            </p>
-            <h2 className="mt-2 text-xl font-bold text-[var(--dpf-text)]">
-              {ownerDecision.headline}
-            </h2>
-            <p className="mt-2 max-w-2xl text-sm text-[var(--dpf-muted)]">
-              {ownerDecision.detail}
-            </p>
-            <p className="mt-3 text-xs text-[var(--dpf-muted)]">
-              Moves: <span className="font-medium text-[var(--dpf-text)]">{ownerDecision.metricFocus}</span>
-            </p>
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--dpf-accent)]">
+          Start here
+        </p>
+        <h1
+          data-testid="marketing-owner-question"
+          className="mt-2 text-xl font-bold text-[var(--dpf-text)]"
+        >
+          {ownerQuestion}
+        </h1>
+        <div className="mt-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
+              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                Recommended next step
+              </p>
+              <p className="mt-1 text-base font-semibold text-[var(--dpf-text)]">
+                {ownerDecision.headline}
+              </p>
+              <p className="mt-1 max-w-2xl text-sm text-[var(--dpf-muted)]">
+                {ownerDecision.detail}
+              </p>
+              <p className="mt-2 text-xs text-[var(--dpf-muted)]">
+                Moves:{" "}
+                <span className="font-medium text-[var(--dpf-text)]">
+                  {ownerDecision.metricFocus}
+                </span>
+              </p>
+            </div>
+            <Link
+              href={ownerDecision.ctaHref}
+              className="shrink-0 rounded-full bg-[var(--dpf-accent)] px-5 py-2 text-sm font-medium text-white hover:opacity-90"
+            >
+              {ownerDecision.ctaLabel}
+            </Link>
           </div>
-          <Link
-            href={ownerDecision.ctaHref}
-            className="shrink-0 rounded-full bg-[var(--dpf-accent)] px-5 py-2 text-sm font-medium text-white hover:opacity-90"
-          >
-            {ownerDecision.ctaLabel}
-          </Link>
         </div>
       </section>
 
-      <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <p className="text-xs uppercase tracking-[0.18em] text-[var(--dpf-muted)]">
-              Customer Marketing
-            </p>
-            <h1 className="mt-2 text-2xl font-bold text-[var(--dpf-text)]">
-              Work with your Marketing Strategist
-            </h1>
-            <p className="mt-2 max-w-3xl text-sm text-[var(--dpf-muted)]">
-              Use the AI Coworker to shape the market, choose campaigns, and turn
-              rough business context into work that can acquire customers.
-            </p>
-          </div>
-          <Link
-            href="/customer/marketing/strategy"
-            className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-2 text-sm font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
-          >
-            View current assumptions
-          </Link>
-        </div>
-
-      </div>
+      {disclosure.quarantinedCount > 0 ? (
+        <section
+          data-testid="marketing-quarantine-banner"
+          className="rounded-lg border border-[var(--dpf-warning)] bg-[var(--dpf-surface-1)] p-4"
+        >
+          <p className="text-sm font-semibold text-[var(--dpf-text)]">
+            {disclosure.quarantinedCount}{" "}
+            {disclosure.quarantinedCount === 1 ? "saved item does not" : "saved items do not"} fit{" "}
+            {archetypeName}
+          </p>
+          <p className="mt-1 max-w-2xl text-sm text-[var(--dpf-muted)]">
+            This looks like imported or test marketing data (for example software-platform copy). It
+            is blocked from publishing and does not count as real campaign work. Reset or replace it
+            with {archetypeName}-fit campaigns before you launch.
+          </p>
+        </section>
+      ) : null}
 
       <div id="marketing-launcher" className="scroll-mt-24">
         <AgentWorkLauncher
@@ -140,137 +157,201 @@ export default async function CustomerMarketingPage() {
         />
       </div>
 
-      <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
-        <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+      {/* Progressive disclosure: strategy, assumptions, and proof stay collapsed
+          until the owner asks for them, so the first screen is one decision. */}
+      <details
+        data-testid="marketing-advanced-strategy"
+        className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+      >
+        <summary className="cursor-pointer list-none rounded-lg px-6 py-4 text-sm font-semibold text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]">
+          Strategy, assumptions &amp; proof
+          <span className="ml-2 font-normal text-[var(--dpf-muted)]">
+            Market, buyer, channels, latest recommendation, and proof
+          </span>
+        </summary>
+
+        <div className="space-y-6 border-t border-[var(--dpf-border)] p-6">
           <div>
-            <h2 className="text-base font-semibold text-[var(--dpf-text)]">
-              Current working focus
+            <h2 className="text-lg font-bold text-[var(--dpf-text)]">
+              Work with your Marketing Strategist
             </h2>
-            <p className="mt-1 max-w-2xl text-sm text-[var(--dpf-muted)]">
-              These are starting assumptions for the strategist to challenge,
-              refine, and turn into campaigns.
+            <p className="mt-2 max-w-3xl text-sm text-[var(--dpf-muted)]">
+              Use the AI Coworker to shape the market, choose campaigns, and turn
+              rough business context into work that can acquire customers.
             </p>
+            <Link
+              href="/customer/marketing/strategy"
+              className="mt-3 inline-block rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-4 py-2 text-sm font-medium text-[var(--dpf-text)] hover:border-[var(--dpf-accent)]"
+            >
+              View current assumptions
+            </Link>
           </div>
-          <p className="text-sm font-medium text-[var(--dpf-accent)]">
-            {snapshot.latestReview
-              ? formatMarketingLabel(snapshot.latestReview.reviewType)
-              : "First review pending"}
-          </p>
-        </div>
 
-        <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
-              Market
-            </p>
-            <p className="mt-2 text-sm text-[var(--dpf-text)]">{marketFocus}</p>
-          </div>
-          <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
-              Buyer
-            </p>
-            <p className="mt-2 text-sm text-[var(--dpf-text)]">{audienceFocus}</p>
-          </div>
-          <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
-              Motion
-            </p>
-            <p className="mt-2 text-sm text-[var(--dpf-text)]">{routeFocus}</p>
-          </div>
-          <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
-              Channels
-            </p>
-            <p className="mt-2 text-sm text-[var(--dpf-text)]">{recommendedChannels}</p>
-          </div>
-        </div>
-      </section>
-
-      <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
-        <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
-          <div>
-            <h2 className="text-base font-semibold text-[var(--dpf-text)]">
-              Latest strategist recommendation
-            </h2>
-            <p className="mt-1 max-w-2xl text-sm text-[var(--dpf-muted)]">
-              Saved recommendations make the current plan visible outside the chat.
-            </p>
-          </div>
-          <p className="text-sm font-medium text-[var(--dpf-accent)]">
-            {snapshot.latestReview
-              ? formatMarketingLabel(snapshot.latestReview.reviewType)
-              : "Not saved yet"}
-          </p>
-        </div>
-        {snapshot.latestReview ? (
-          <div className="mt-4 grid gap-3 md:grid-cols-3">
-            <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
-                Do next
-              </p>
-              <p className="mt-2 text-sm text-[var(--dpf-text)]">
-                {snapshot.latestReview.summary}
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+            <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+                  Current working focus
+                </h2>
+                <p className="mt-1 max-w-2xl text-sm text-[var(--dpf-muted)]">
+                  These are starting assumptions for the strategist to challenge,
+                  refine, and turn into campaigns.
+                </p>
+              </div>
+              <p className="text-sm font-medium text-[var(--dpf-accent)]">
+                {snapshot.latestReview
+                  ? formatMarketingLabel(snapshot.latestReview.reviewType)
+                  : "First review pending"}
               </p>
             </div>
-            <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
-                Skip for now
-              </p>
-              <p className="mt-2 text-sm text-[var(--dpf-text)]">{skippedChannels}</p>
-            </div>
-            <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
-                KPI stack
-              </p>
-              <p className="mt-2 text-sm text-[var(--dpf-text)]">{kpiStack}</p>
-            </div>
-          </div>
-        ) : (
-          <p className="mt-4 text-sm text-[var(--dpf-muted)]">
-            No saved strategist recommendation yet. Ask the Marketing Strategist
-            for a plan and it should persist the recommendation here.
-          </p>
-        )}
-      </section>
 
-      <section className="grid gap-4 lg:grid-cols-[1fr_1.2fr]">
-        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+            <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                  Market
+                </p>
+                <p className="mt-2 text-sm text-[var(--dpf-text)]">{marketFocus}</p>
+              </div>
+              <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                  Buyer
+                </p>
+                <p className="mt-2 text-sm text-[var(--dpf-text)]">{audienceFocus}</p>
+              </div>
+              <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                  Motion
+                </p>
+                <p className="mt-2 text-sm text-[var(--dpf-text)]">{routeFocus}</p>
+              </div>
+              <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                  Channels
+                </p>
+                <p className="mt-2 text-sm text-[var(--dpf-text)]">{recommendedChannels}</p>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+            <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+                  Latest strategist recommendation
+                </h2>
+                <p className="mt-1 max-w-2xl text-sm text-[var(--dpf-muted)]">
+                  Saved recommendations make the current plan visible outside the chat.
+                </p>
+              </div>
+              <p className="text-sm font-medium text-[var(--dpf-accent)]">
+                {snapshot.latestReview
+                  ? formatMarketingLabel(snapshot.latestReview.reviewType)
+                  : "Not saved yet"}
+              </p>
+            </div>
+            {snapshot.latestReview ? (
+              <div className="mt-4 grid gap-3 md:grid-cols-3">
+                <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                    Do next
+                  </p>
+                  <p className="mt-2 text-sm text-[var(--dpf-text)]">
+                    {snapshot.latestReview.summary}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                    Skip for now
+                  </p>
+                  <p className="mt-2 text-sm text-[var(--dpf-text)]">{skippedChannels}</p>
+                </div>
+                <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-4">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-[var(--dpf-muted)]">
+                    KPI stack
+                  </p>
+                  <p className="mt-2 text-sm text-[var(--dpf-text)]">{kpiStack}</p>
+                </div>
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-[var(--dpf-muted)]">
+                No saved strategist recommendation yet. Ask the Marketing Strategist
+                for a plan and it should persist the recommendation here.
+              </p>
+            )}
+          </section>
+
+          <section className="grid gap-4 lg:grid-cols-[1fr_1.2fr]">
+            <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+              <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+                What to clarify with the strategist
+              </h2>
+              <ul className="mt-4 space-y-2 text-sm text-[var(--dpf-text)]">
+                {suggestions.map((suggestion) => (
+                  <li key={suggestion} className="rounded-lg bg-[var(--dpf-surface-2)] px-3 py-2">
+                    {suggestion}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
+              <h2 className="text-base font-semibold text-[var(--dpf-text)]">
+                Proof before promotion
+              </h2>
+              <p className="mt-2 text-sm text-[var(--dpf-muted)]">
+                Campaigns will perform better when the offer is backed by credible
+                evidence. The strategist should help decide what proof to collect,
+                write, or publish first.
+              </p>
+              <p className="mt-4 rounded-lg bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)]">
+                {proofFocus}
+              </p>
+            </div>
+          </section>
+
+          <MarketingStrategyOverview snapshot={snapshot} />
+        </div>
+      </details>
+
+      {/* Publish/review queues are deferred until there is an archetype-fit
+          campaign or real review work, so a fresh workspace is not overloaded
+          with empty publish surfaces (BI-8AB9C904). */}
+      {disclosure.showPublishReview ? (
+        <details
+          data-testid="marketing-publish-review"
+          open={disclosure.publishReviewOpenByDefault}
+          className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+        >
+          <summary className="cursor-pointer list-none rounded-lg px-6 py-4 text-sm font-semibold text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)]">
+            Review &amp; publish queue
+            <span className="ml-2 font-normal text-[var(--dpf-muted)]">
+              Drafts awaiting approval, ready-to-publish, and inbound replies
+            </span>
+          </summary>
+          <div className="border-t border-[var(--dpf-border)] p-6">
+            <ApprovalQueuePanel
+              pendingDrafts={snapshot.pendingDrafts}
+              approvedDrafts={snapshot.approvedDrafts}
+              connectedChannels={snapshot.connectedChannels}
+              inboundMessages={snapshot.inboundMessages}
+              category={snapshot.storefront.category}
+            />
+          </div>
+        </details>
+      ) : (
+        <section
+          data-testid="marketing-publish-deferred"
+          className="rounded-lg border border-dashed border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6"
+        >
           <h2 className="text-base font-semibold text-[var(--dpf-text)]">
-            What to clarify with the strategist
+            Review &amp; publish unlock with your first campaign
           </h2>
-          <ul className="mt-4 space-y-2 text-sm text-[var(--dpf-text)]">
-            {suggestions.map((suggestion) => (
-              <li key={suggestion} className="rounded-lg bg-[var(--dpf-surface-2)] px-3 py-2">
-                {suggestion}
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        <div className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5">
-          <h2 className="text-base font-semibold text-[var(--dpf-text)]">
-            Proof before promotion
-          </h2>
-          <p className="mt-2 text-sm text-[var(--dpf-muted)]">
-            Campaigns will perform better when the offer is backed by credible
-            evidence. The strategist should help decide what proof to collect,
-            write, or publish first.
+          <p className="mt-2 max-w-2xl text-sm text-[var(--dpf-muted)]">
+            Once you have a {archetypeName}-fit campaign with drafts to approve, the review and
+            publish queues appear here. Start a marketing review above to shape that first campaign.
           </p>
-          <p className="mt-4 rounded-lg bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-text)]">
-            {proofFocus}
-          </p>
-        </div>
-      </section>
-
-      <MarketingStrategyOverview snapshot={snapshot} />
-
-      <ApprovalQueuePanel
-        pendingDrafts={snapshot.pendingDrafts}
-        approvedDrafts={snapshot.approvedDrafts}
-        connectedChannels={snapshot.connectedChannels}
-        inboundMessages={snapshot.inboundMessages}
-        category={snapshot.storefront.category}
-      />
+        </section>
+      )}
     </div>
   );
 }

--- a/apps/web/components/customer-marketing/marketing-nav.ts
+++ b/apps/web/components/customer-marketing/marketing-nav.ts
@@ -8,6 +8,6 @@ export const MARKETING_TABS: ReadonlyArray<{ label: string; href: string }> = [
   { label: "Overview", href: "/customer/marketing" },
   { label: "Strategy", href: "/customer/marketing/strategy" },
   { label: "Campaigns", href: "/customer/marketing/campaigns" },
-  { label: "Funnel", href: "/customer/marketing/funnel" },
+  { label: "Marketing Funnel", href: "/customer/marketing/funnel" },
   { label: "Automation", href: "/customer/marketing/automation" },
 ];

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8564,6 +8564,8 @@
       "anchors": [
         "use-this-doc-for",
         "workflow",
+        "off-archetype-imported-test-artifacts",
+        "funnel-two-different-views",
         "what-to-watch"
       ]
     },

--- a/apps/web/lib/govern/permissions.test.ts
+++ b/apps/web/lib/govern/permissions.test.ts
@@ -184,7 +184,7 @@ describe("getAccessibleSectionNavEntries()", () => {
       "Pipeline",
       "Quotes",
       "Orders",
-      "Funnel",
+      "Sales Funnel",
       "Marketing",
     ]);
     expect(tabs.map((tab) => tab.href)).toContain("/customer/marketing");

--- a/apps/web/lib/marketing/disclosure.test.ts
+++ b/apps/web/lib/marketing/disclosure.test.ts
@@ -1,0 +1,199 @@
+// Coverage for the marketing overview's progressive-disclosure state and the
+// owner-first question (BI-8AB9C904 + BI-CC580161):
+//   - off-archetype / software-platform artifacts are quarantined, never counted
+//     as an archetype-fit campaign or as reason to expose publish/review queues;
+//   - publish/review queues are deferred until there is fit work to act on;
+//   - the first-viewport question speaks the archetype's own vocabulary.
+
+import { describe, expect, it } from "vitest";
+
+import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+import { getPlaybook } from "@/lib/tak/marketing-playbooks";
+import {
+  buildMarketingDisclosure,
+  buildMarketingOwnerQuestion,
+  marketingOwnerJobs,
+} from "./disclosure";
+
+const now = new Date("2026-07-22T12:00:00.000Z");
+
+type CampaignBriefRow = MarketingWorkspaceSnapshot["workProducts"]["campaignBriefs"][number];
+
+const LEAK_BRIEF: CampaignBriefRow = {
+  briefId: "brief-leak",
+  title: "Reach technical founders with our AI workflow",
+  objective: "Show how Build Studio ships software",
+  audience: "technical founders",
+  channels: ["linkedin"],
+  cta: "Book a demo",
+  proofAssets: [],
+  kpis: [],
+  notes: "Position the SaaS platform.",
+  status: "draft" as const,
+  createdAt: now,
+};
+
+const CLEAN_BRIEF: CampaignBriefRow = {
+  briefId: "brief-clean",
+  title: "Fill quiet midweek covers with a seasonal tasting menu",
+  objective: "Lift midweek bookings",
+  audience: "local diners",
+  channels: ["email"],
+  cta: "Reserve a table",
+  proofAssets: [],
+  kpis: ["Booking fill rate"],
+  notes: "Feature our reviews.",
+  status: "draft" as const,
+  createdAt: now,
+};
+
+function restaurantSnapshot(
+  overrides: Partial<MarketingWorkspaceSnapshot> = {},
+): MarketingWorkspaceSnapshot {
+  return {
+    organization: { id: "org-r", name: "The Copper Table", website: null, addressSummary: "Leeds" },
+    storefront: {
+      id: "sf-r",
+      archetypeId: "restaurant",
+      archetypeName: "Restaurant",
+      category: "food-hospitality",
+      tagline: "Seasonal neighbourhood dining",
+      description: null,
+      ctaType: "booking",
+    },
+    strategy: {
+      strategyId: "st-r",
+      status: "active",
+      primaryGoal: "Fill covers during quiet periods",
+      routeToMarket: "inbound",
+      localityModel: "hyperlocal",
+      geographicScope: "Leeds",
+      primaryChannels: ["email", "instagram"],
+      secondaryChannels: [],
+      differentiators: ["Seasonal menu"],
+      reviewCadence: "monthly",
+      lastReviewedAt: now,
+      nextReviewAt: new Date("2026-08-22T12:00:00.000Z"),
+      sourceSummary: null,
+      specialistNotes: null,
+      seasonalityNotes: null,
+      targetSegments: [{ name: "Local diners", description: null }],
+      idealCustomerProfiles: [],
+      entryOffers: [],
+      proofAssets: [{ type: "testimonial", label: "Five-star reviews" }],
+      serviceTerritories: [],
+      constraints: null,
+    },
+    latestReview: {
+      reviewType: "ai-proactive",
+      summary: "Focus on midweek covers",
+      createdAt: now,
+      suggestedActions: [],
+      recommendation: null,
+    },
+    workProducts: {
+      campaignBriefs: [],
+      assetTasks: [],
+      kpiCheckpoints: [],
+      automationCandidates: [],
+    },
+    pendingDrafts: [],
+    approvedDrafts: [],
+    connectedChannels: [],
+    inboundMessages: [],
+    staleAreas: [],
+    ...overrides,
+  } as MarketingWorkspaceSnapshot;
+}
+
+describe("buildMarketingDisclosure", () => {
+  it("defers publish/review and quarantines when only off-archetype artifacts exist", () => {
+    const snapshot = restaurantSnapshot({
+      workProducts: {
+        campaignBriefs: [LEAK_BRIEF],
+        assetTasks: [],
+        kpiCheckpoints: [],
+        automationCandidates: [],
+      },
+    });
+
+    const d = buildMarketingDisclosure(snapshot);
+    // A software-platform brief is NOT an archetype-fit campaign...
+    expect(d.hasArchetypeFitCampaign).toBe(false);
+    // ...it is quarantined...
+    expect(d.quarantinedCount).toBe(1);
+    // ...and it does not unlock the publish/review queues.
+    expect(d.showPublishReview).toBe(false);
+  });
+
+  it("treats a clean archetype-fit brief as a campaign and unlocks the queues", () => {
+    const snapshot = restaurantSnapshot({
+      workProducts: {
+        campaignBriefs: [LEAK_BRIEF, CLEAN_BRIEF],
+        assetTasks: [],
+        kpiCheckpoints: [],
+        automationCandidates: [],
+      },
+    });
+
+    const d = buildMarketingDisclosure(snapshot);
+    expect(d.hasArchetypeFitCampaign).toBe(true);
+    expect(d.quarantinedCount).toBe(1); // only the leak brief
+    expect(d.showPublishReview).toBe(true);
+  });
+
+  it("opens the publish/review disclosure when drafts are waiting", () => {
+    const snapshot = restaurantSnapshot({
+      pendingDrafts: [
+        {
+          draftId: "d1",
+          sourceType: "marketing-asset-task",
+          sourceId: "t1",
+          assetTaskTitle: "Email",
+          channelId: "email",
+          assetType: "email",
+          status: "pending-review",
+          body: "Reserve a table for our tasting menu.",
+          bodyFormat: "markdown",
+          createdByAgentId: "AGT",
+          createdAt: now,
+        },
+      ],
+    });
+
+    const d = buildMarketingDisclosure(snapshot);
+    expect(d.reviewableCount).toBe(1);
+    expect(d.showPublishReview).toBe(true);
+    expect(d.publishReviewOpenByDefault).toBe(true);
+  });
+
+  it("defers everything for a fresh workspace with no artifacts", () => {
+    const d = buildMarketingDisclosure(restaurantSnapshot());
+    expect(d.hasArchetypeFitCampaign).toBe(false);
+    expect(d.reviewableCount).toBe(0);
+    expect(d.showPublishReview).toBe(false);
+    expect(d.quarantinedCount).toBe(0);
+    expect(d.publishReviewOpenByDefault).toBe(false);
+  });
+});
+
+describe("buildMarketingOwnerQuestion", () => {
+  it("asks a restaurant owner about booking demand in food/hospitality language", () => {
+    const playbook = getPlaybook("food-hospitality", "booking");
+    const question = buildMarketingOwnerQuestion("food-hospitality", playbook);
+
+    expect(question.toLowerCase()).toContain("booking demand");
+    // Food/hospitality jobs, not software-founder language.
+    expect(question.toLowerCase()).toMatch(/slow nights|private dining|catering|repeat guests/);
+    expect(question.toLowerCase()).not.toMatch(/build studio|technical founder|ai workflow|saas/);
+  });
+
+  it("derives a sensible question for non-food archetypes from the playbook", () => {
+    const playbook = getPlaybook("trades-maintenance", "quote");
+    const question = buildMarketingOwnerQuestion("trades-maintenance", playbook);
+
+    expect(question.toLowerCase()).toContain("grow first");
+    expect(question).not.toContain("booking demand");
+    expect(marketingOwnerJobs("trades-maintenance", playbook).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/lib/marketing/disclosure.ts
+++ b/apps/web/lib/marketing/disclosure.ts
@@ -1,0 +1,140 @@
+// Progressive-disclosure state for the /customer/marketing overview.
+//
+// BI-8AB9C904: the marketing overview must open with ONE owner-first decision
+// (phrased as a question in the owner's own vocabulary) and defer the strategy,
+// campaign, and — especially — publish/review machinery behind disclosure until
+// there is real, archetype-fit work to act on. A brand-new restaurant owner must
+// not land on three empty publish queues plus a full strategy dossier.
+//
+// BI-CC580161: off-archetype / software-platform ("imported / test") artifacts
+// must be quarantined and clearly marked unusable, never presented as active
+// campaign / review / publish work. This module counts them so the page can show
+// a single quarantine banner instead of scattering wrong-archetype copy through
+// the live queues.
+//
+// Pure and framework-free so it can be unit-tested without rendering React.
+
+import type { MarketingWorkspaceSnapshot } from "@/lib/marketing";
+import type { MarketingPlaybook } from "@/lib/tak/marketing-playbooks";
+import { assessArchetypeFit } from "@/lib/marketing/archetype-fit";
+
+type CampaignBriefRow = MarketingWorkspaceSnapshot["workProducts"]["campaignBriefs"][number];
+
+function campaignBriefText(
+  brief: Pick<CampaignBriefRow, "title" | "objective" | "audience" | "notes" | "kpis">,
+): string {
+  return [brief.title, brief.objective, brief.audience, brief.notes, brief.kpis.join(" ")]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export type MarketingDisclosure = {
+  /** At least one saved campaign brief that actually fits the active archetype. */
+  hasArchetypeFitCampaign: boolean;
+  /** Drafts awaiting review + approved drafts + inbound replies. */
+  reviewableCount: number;
+  /**
+   * Whether the publish/review queues should render at all. Deferred until there
+   * is either an archetype-fit campaign or real review work — so a fresh install
+   * shows a single "unlocks with your first campaign" note, not empty queues.
+   */
+  showPublishReview: boolean;
+  /** Whether the publish/review disclosure should start expanded. */
+  publishReviewOpenByDefault: boolean;
+  /** Saved artifacts (briefs + drafts) blocked as imported/test / platform-leak. */
+  quarantinedCount: number;
+};
+
+/**
+ * Derive the progressive-disclosure state for the marketing overview from the
+ * saved workspace snapshot and the active archetype category.
+ */
+export function buildMarketingDisclosure(
+  snapshot: MarketingWorkspaceSnapshot,
+): MarketingDisclosure {
+  const category = snapshot.storefront.category;
+
+  const briefFits = snapshot.workProducts.campaignBriefs.map((brief) =>
+    assessArchetypeFit({ text: campaignBriefText(brief), category }),
+  );
+  const draftFits = [...snapshot.pendingDrafts, ...snapshot.approvedDrafts].map((draft) =>
+    assessArchetypeFit({ text: draft.body, category }),
+  );
+
+  const hasArchetypeFitCampaign = briefFits.some((fit) => fit.severity === "ok");
+  const reviewableCount =
+    snapshot.pendingDrafts.length +
+    snapshot.approvedDrafts.length +
+    snapshot.inboundMessages.length;
+
+  const quarantinedCount =
+    briefFits.filter((fit) => fit.blocked).length + draftFits.filter((fit) => fit.blocked).length;
+
+  return {
+    hasArchetypeFitCampaign,
+    reviewableCount,
+    showPublishReview: hasArchetypeFitCampaign || reviewableCount > 0,
+    publishReviewOpenByDefault:
+      snapshot.pendingDrafts.length > 0 || snapshot.approvedDrafts.length > 0,
+    quarantinedCount,
+  };
+}
+
+// ─── Owner-first question ──────────────────────────────────────────────────
+// The first screen poses one question in the owner's own language. For a
+// restaurant this is booking demand, not "campaign brief #2". Jobs are grounded
+// in the archetype so other categories inherit a sensible question too.
+
+const OWNER_JOB_HINTS: Record<string, string[]> = {
+  // BI-CC580161 acceptance vocabulary — food/hospitality jobs.
+  "food-hospitality": [
+    "fill slow nights",
+    "private dining",
+    "catering",
+    "seasonal menus",
+    "reviews",
+    "repeat guests",
+    "booking conversion",
+  ],
+};
+
+/** Short, owner-language "jobs" for the question, grounded in the archetype. */
+export function marketingOwnerJobs(
+  category: string | null | undefined,
+  playbook: MarketingPlaybook,
+): string[] {
+  const explicit = OWNER_JOB_HINTS[(category ?? "").trim().toLowerCase()];
+  if (explicit) return explicit;
+  // Fallback: derive concise jobs from the playbook's campaign types.
+  return playbook.campaignTypes
+    .slice(0, 4)
+    .map((type) =>
+      type
+        .toLowerCase()
+        .replace(/\s*\([^)]*\)\s*/g, " ")
+        .split(/ and | & |,|:|\//)[0]!
+        .trim(),
+    )
+    .filter(Boolean);
+}
+
+/**
+ * The single owner-first question for the marketing overview's first viewport.
+ * Restaurants are asked about booking demand explicitly (per BI-CC580161).
+ */
+export function buildMarketingOwnerQuestion(
+  category: string | null | undefined,
+  playbook: MarketingPlaybook,
+): string {
+  const jobs = marketingOwnerJobs(category, playbook).slice(0, 4);
+  const jobList = jobs.join(", ");
+  const cat = (category ?? "").trim().toLowerCase();
+  if (cat.includes("food") || cat.includes("hospitality")) {
+    return jobList
+      ? `What booking demand do you want to improve — ${jobList}?`
+      : "What booking demand do you want to improve?";
+  }
+  return jobList
+    ? `Where do you want to grow first — ${jobList}?`
+    : "Where do you want to grow first?";
+}

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -214,6 +214,9 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
   {
     key: "customer-funnel",
     label: "Funnel",
+    // Disambiguate from the Marketing subnav's "Marketing Funnel": this is the
+    // CRM deal-stage conversion funnel (BI-8AB9C904 duplicate-funnel confusion).
+    sectionNavLabel: "Sales Funnel",
     path: "/customer/funnel",
     parentPath: "/customer",
     domain: "customer",

--- a/docs/superpowers/plans/2026-07-22-restaurant-marketing-owner-first-disclosure.md
+++ b/docs/superpowers/plans/2026-07-22-restaurant-marketing-owner-first-disclosure.md
@@ -1,0 +1,78 @@
+# Restaurant marketing: owner-first progressive disclosure + funnel de-dup
+
+- **BIs:** BI-8AB9C904 (owner-first progressive disclosure before publish actions),
+  BI-CC580161 (Restaurant marketing shows software-platform campaign artifacts).
+- **Epic:** EP-UX-COGLOAD (Live UX cognitive-load audit follow-up).
+- **Date:** 2026-07-22.
+
+## Design grounding
+
+**Source of truth:** the merged archetype-scoping engine for `/customer/marketing`
+(PR #3406, `apps/web/lib/marketing/archetype-fit.ts`, `next-decision.ts`,
+`draft-builder.ts`, `subroutes.ts`, and `docs/platform-usability-standards.md`).
+BI-CC580161's core — no software-platform artifacts as active work, food/hospitality
+vocabulary, archetype-fit warning/block before Approve/Send/Publish, and the
+first-viewport owner decision — already landed on `main` via #3406. This change
+**extends** that substrate rather than creating a new contract; the older competing
+PR #3404 is redundant and should be closed.
+
+What #3406 did **not** deliver, and this change adds (BI-8AB9C904):
+
+1. **Progressive disclosure.** The overview still rendered the full dense stack
+   (strategy focus, latest recommendation, clarification prompts, proof,
+   `MarketingStrategyOverview`, `ApprovalQueuePanel`) immediately after the decision
+   card — ~1,200 words and 49 actions before the owner chooses a job.
+2. **Deferred publish/review.** Empty publish/review queues were shown to a
+   brand-new owner. They are now deferred until there is archetype-fit work.
+3. **One owner-first question.** The first viewport now leads with a single
+   archetype-flavoured question ("What booking demand do you want to improve —
+   fill slow nights, private dining, catering, seasonal menus?").
+4. **Funnel de-dup.** Two adjacent nav layers both read "Funnel".
+
+## Changes
+
+- **`apps/web/lib/marketing/disclosure.ts` (new, pure/testable):**
+  - `buildMarketingDisclosure(snapshot)` → `{ hasArchetypeFitCampaign,
+    reviewableCount, showPublishReview, publishReviewOpenByDefault, quarantinedCount }`.
+    A campaign counts as fit only when `assessArchetypeFit(...).severity === "ok"`;
+    platform-leak / off-archetype briefs and drafts are counted as quarantined and
+    never unlock the queues. Publish/review is deferred until there is a fit campaign
+    or real review work (drafts / inbound).
+  - `buildMarketingOwnerQuestion(category, playbook)` / `marketingOwnerJobs(...)` →
+    the owner-first question, grounded in the archetype playbook. Food/hospitality
+    gets the BI-CC580161 acceptance vocabulary; other archetypes derive jobs from
+    their playbook's campaign types.
+- **`apps/web/app/(shell)/customer/marketing/page.tsx`:** first viewport = owner
+  question + one recommended next step + primary launcher. Strategy/assumptions/proof
+  moved behind a collapsed `<details data-testid="marketing-advanced-strategy">`.
+  Publish/review rendered only when `showPublishReview`, inside a `<details>` that is
+  open when drafts are waiting; otherwise a `marketing-publish-deferred` placeholder.
+  A `marketing-quarantine-banner` surfaces when off-archetype/imported-test artifacts
+  are present, marking them unusable until reset/replaced.
+- **Funnel de-dup:** `portal-navigation-model.ts` customer-funnel gains
+  `sectionNavLabel: "Sales Funnel"` (CRM deal-stage funnel); the Marketing subnav's
+  `Funnel` becomes `Marketing Funnel` (`marketing-nav.ts`).
+
+## Tests
+
+- `apps/web/lib/marketing/disclosure.test.ts` — quarantine of off-archetype
+  artifacts, deferral of publish/review until fit work exists, open-by-default when
+  drafts wait, and the food/hospitality owner question.
+- `apps/web/app/(shell)/customer/marketing/page.test.tsx` — Restaurant snapshot opens
+  with one owner-first question, defers strategy behind disclosure, quarantines
+  off-archetype artifacts, shows no software-founder copy in the always-visible shell,
+  and reveals the review/publish queue only when archetype-fit work exists.
+- `apps/web/lib/govern/permissions.test.ts` — updated for the "Sales Funnel" label.
+
+## Verification
+
+- `disclosure.test.ts` 6/6, `page.test.tsx` 4/4, nav/permissions/nav-model 48/48 pass
+  via the junctioned worktree (`DPF_SKIP_TYPECHECK=1`). The DB-backed marketing tests
+  (`subroutes`, `campaigns`, `archetype-scoping`, …) are blocked in the worktree by the
+  ungenerated Prisma client (unchanged by this PR) and run in CI.
+
+## Out of scope / follow-ups
+
+- `next-decision.ts` counts all campaign briefs (fit or not) for the "has a campaign"
+  branch; the disclosure layer is fit-aware and compensates. A future pass could make
+  the decision itself fit-aware.

--- a/docs/user-guide/customers/marketing.md
+++ b/docs/user-guide/customers/marketing.md
@@ -10,12 +10,34 @@ order: 2
 
 ## Workflow
 
-1. Review positioning, audience, funnel health, and proof assets together.
-2. Separate immediate campaign ideas from longer-term offer or credibility gaps.
-3. Turn repeatable gaps into backlog work rather than leaving them in analysis only.
+1. Start with the one owner-first question at the top of the page (for a
+   restaurant: *"What booking demand do you want to improve — fill slow nights,
+   private dining, catering, seasonal menus?"*) and the single recommended next
+   step beside it. Everything else is deferred until you ask for it.
+2. Open **Strategy, assumptions & proof** (the collapsible panel) when you want to
+   review positioning, audience, channels, the latest strategist recommendation,
+   and proof assets together.
+3. Use the **Review & publish queue** to approve or publish drafts. It only appears
+   once you have a campaign that fits your business; a fresh workspace shows a short
+   "unlocks with your first campaign" note instead of empty queues.
+4. Turn repeatable gaps into backlog work rather than leaving them in analysis only.
+
+## Off-archetype (imported / test) artifacts
+
+If saved marketing content was imported or seeded from a different business type
+(for example software-platform copy in a restaurant workspace), a **quarantine
+banner** flags it as unusable and blocks it from publishing. Reset or replace those
+artifacts with archetype-fit campaigns before you launch.
+
+## Funnel: two different views
+
+- **Marketing Funnel** (`/customer/marketing/funnel`) — acquisition sources and how
+  they convert into pipeline.
+- **Sales Funnel** (`/customer/funnel`) — deal-stage conversion across the CRM.
 
 ## What To Watch
 
 - campaign ideas being generated without checking funnel bottlenecks
 - customer acquisition analysis drifting away from storefront reality
 - marketing changes that should really be solved in offer, proof, or follow-up operations
+- publishing content before confirming it fits the current business archetype

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -45,7 +45,7 @@ apps/web/lib/mcp-tools.ts	1910
 apps/web/lib/mcp/packs/backlog-pack.ts	1318
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	858
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
-apps/web/lib/navigation/portal-navigation-model.ts	937
+apps/web/lib/navigation/portal-navigation-model.ts	940
 apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1383
 apps/web/lib/routing/chat-adapter.test.ts	902


### PR DESCRIPTION
## What & why

Live audit found `/customer/marketing` overloaded a non-technical Restaurant owner: after the archetype decision card it still rendered the full strategy + campaign + publish/review stack at once (~1,200 words, 49 actions), showed empty publish queues to brand-new owners, and mixed off-archetype ("imported/test") software-platform artifacts into live work. Two adjacent nav layers both read "Funnel".

This delivers the two open pieces of that audit:
- **BI-8AB9C904** — owner-first progressive disclosure before publish actions.
- **BI-CC580161** — no software-platform artifacts as active work; off-archetype artifacts quarantined/marked unusable. (The archetype-fit **engine** already merged via #3406; this extends it at the page level and finishes the deferral + quarantine UX.)

## Changes

- **`apps/web/lib/marketing/disclosure.ts`** (new, pure/testable) — `buildMarketingDisclosure` decides what to show: a campaign counts as fit only when archetype-fit is `ok`; platform-leak / off-archetype briefs and drafts are quarantined and never unlock the queues. Publish/review is deferred until there is fit work. `buildMarketingOwnerQuestion` / `marketingOwnerJobs` produce the first-viewport question in the archetype's own words.
- **`page.tsx`** — first screen = one owner question ("What booking demand do you want to improve — fill slow nights, private dining, catering, seasonal menus?") + one recommended step + launcher. Strategy/assumptions/proof behind a collapsed `<details>`. Publish/review deferred, or in a `<details>` that opens when drafts wait. A quarantine banner marks off-archetype artifacts unusable until reset/replaced.
- **Funnel de-dup** — CRM `/customer/funnel` nav label → **"Sales Funnel"** (`sectionNavLabel`); Marketing subnav → **"Marketing Funnel"**.

## Acceptance mapping

- No software-platform artifacts as active campaign/review/publish work — engine (merged) + shell renders none; queues gated. ✅
- Off-archetype artifacts quarantined / clearly marked unusable — quarantine banner + per-draft badges. ✅
- First screen asks one Restaurant-owner question before strategy/campaign/automation machinery. ✅
- Restaurant prompts use food/hospitality jobs. ✅
- Hide/defer publish/review until there is an archetype-fit campaign. ✅
- Resolve duplicate Funnel confusion with clearer labels. ✅
- Tests prove no software-founder copy + progressive disclosure of advanced queues. ✅

## Design grounding

Extends the merged BI-CC580161 archetype-scoping substrate (`apps/web/lib/marketing/archetype-fit.ts`, `next-decision.ts`). Plan: `docs/superpowers/plans/2026-07-22-restaurant-marketing-owner-first-disclosure.md`. No new cross-surface contract.

## Verification

Worktree: `disclosure.test.ts` 6/6, `page.test.tsx` 4/4, nav/permissions/nav-model 48/48; direct `tsc --noEmit` clean except the worktree-only `next/link` resolution (next not installed here — resolves in CI). The DB-backed marketing tests are blocked in the worktree by the ungenerated Prisma client (unchanged here) and run in CI.

## Related PRs

- Builds on **#3406** (BI-CC580161 archetype-fit engine, merged).
- **Supersedes the stale competing #3404** (older BI-CC580161 impl that would regress main) — recommend closing it.
- Composes cleanly with **#3410** (strategy-overview off-archetype badging — disjoint files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)