### PR TITLE
feat(finance): owner-first Restaurant finance surface + honest payment-run disclosure (BI-3326DA86)

### DIFF
--- a/apps/web/app/(shell)/finance/invoices/new/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/new/page.tsx
@@ -4,8 +4,17 @@ import Link from "next/link";
 import { CreateInvoiceForm } from "@/components/finance/CreateInvoiceForm";
 import { getInvoiceDefaultTaxRate } from "@/lib/actions/financial-setup";
 import { defaultSignatureRequiredForArchetype } from "@/lib/finance/invoice-signature-default";
+import {
+  isFinanceInvoiceContext,
+  resolveFinanceInvoiceCopy,
+  resolveFinanceSurface,
+} from "@/lib/finance/finance-surface";
 
-export default async function NewInvoicePage() {
+type Props = { searchParams: Promise<{ from?: string }> };
+
+export default async function NewInvoicePage({ searchParams }: Props) {
+  const { from } = await searchParams;
+
   // Default the TAX % field from the org's wizard VAT selection, not a 20% hardcode
   // (shared with the recurring-schedule form via getInvoiceDefaultTaxRate).
   const [customers, storefront, defaultTaxRate, orgSettings] = await Promise.all([
@@ -22,7 +31,7 @@ export default async function NewInvoicePage() {
       },
     }),
     prisma.storefrontConfig.findFirst({
-      select: { archetype: { select: { archetypeId: true } } },
+      select: { archetype: { select: { archetypeId: true, category: true } } },
     }),
     getInvoiceDefaultTaxRate(),
     prisma.orgSettings.findFirst({ select: { baseCurrency: true } }),
@@ -32,6 +41,23 @@ export default async function NewInvoicePage() {
   const defaultSignatureRequired = defaultSignatureRequiredForArchetype(
     storefront?.archetype?.archetypeId ?? null,
   );
+
+  const category = storefront?.archetype?.category ?? null;
+  const surface = resolveFinanceSurface(category);
+  const copy = resolveFinanceInvoiceCopy(category);
+
+  // When the form is opened from a Restaurant billing context (?from=booking …),
+  // lead with that context's framing instead of the generic customer-first copy.
+  const context = isFinanceInvoiceContext(from) ? from : null;
+  const contextCopy = context ? copy.contexts[context] : null;
+  const heading = contextCopy?.title ?? "New Invoice";
+  const subhead = contextCopy?.description ?? copy.newInvoiceSubhead;
+  const contextLabel =
+    context && context !== "no-show"
+      ? surface.invoiceEntryPoints.find((entry) => entry.id === context)?.label ?? null
+      : context === "no-show"
+        ? "No-show fee"
+        : null;
 
   return (
     <div>
@@ -56,17 +82,47 @@ export default async function NewInvoicePage() {
 
       {/* Header */}
       <div className="mb-6">
-        <h1 className="text-xl font-bold text-[var(--dpf-text)]">New Invoice</h1>
-        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">
-          Create a draft invoice to send to a customer
-        </p>
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">{heading}</h1>
+        <p className="text-sm text-[var(--dpf-muted)] mt-0.5">{subhead}</p>
       </div>
+
+      {/* Restaurant billing entry points — start from a booking, order, catering,
+          or private event rather than only a generic customer dropdown. */}
+      {surface.mode === "owner-first" && surface.invoiceEntryPoints.length > 0 && (
+        <div className="mb-6">
+          <p className="mb-2 text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+            Start from
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {surface.invoiceEntryPoints.map((entry) => {
+              const active = context === entry.id || (entry.id === "blank" && context === null);
+              return (
+                <Link
+                  key={entry.id}
+                  href={entry.href}
+                  className={[
+                    "rounded-lg border px-3 py-1.5 text-xs transition-colors",
+                    active
+                      ? "border-[var(--dpf-accent)] bg-[color-mix(in_srgb,var(--dpf-accent)_12%,transparent)] text-[var(--dpf-text)]"
+                      : "border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] text-[var(--dpf-muted)] hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-text)]",
+                  ].join(" ")}
+                >
+                  {entry.label}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       <CreateInvoiceForm
         customers={customers}
         defaultTaxRate={defaultTaxRate}
         defaultSignatureRequired={defaultSignatureRequired}
         defaultCurrency={orgSettings?.baseCurrency ?? "USD"}
+        customerLabel={copy.customerLabel}
+        signatureHint={copy.signatureHint}
+        contextLabel={contextLabel}
       />
     </div>
   );

--- a/apps/web/app/(shell)/finance/page.tsx
+++ b/apps/web/app/(shell)/finance/page.tsx
@@ -14,6 +14,8 @@ import { AccountantWorkLanePanel } from "@/components/finance/AccountantWorkLane
 import { getBookkeeperAccountantWorkLane } from "@/lib/finance/accountant-work-lane";
 import { FinanceSummaryCard } from "@/components/finance/FinanceSummaryCard";
 import { FinanceTabNav } from "@/components/finance/FinanceTabNav";
+import { OwnerFirstFinanceView, type MoneyJobMetric } from "@/components/finance/OwnerFirstFinanceView";
+import { resolveFinanceSurface, type FinanceMetricKey } from "@/lib/finance/finance-surface";
 import { StatCard } from "@/components/ui/report-kit";
 import { RecentInvoicesTable, type RecentInvoiceRow } from "./RecentInvoicesTable";
 
@@ -43,6 +45,7 @@ export default async function FinancePage() {
     activeAssets,
     setupStatus,
     orgSettings,
+    storefrontConfig,
   ] = await Promise.all([
     // Money owed to you — sum amountDue for active receivable statuses
     prisma.invoice.aggregate({
@@ -151,7 +154,14 @@ export default async function FinancePage() {
 
     // Org settings — for base currency
     getOrgSettings(),
+
+    // Storefront archetype — drives the owner-first (food-hospitality) surface
+    prisma.storefrontConfig.findFirst({
+      select: { archetype: { select: { category: true } } },
+    }),
   ]);
+
+  const financeSurface = resolveFinanceSurface(storefrontConfig?.archetype.category);
 
   const sym = getCurrencySymbol(orgSettings.baseCurrency);
 
@@ -192,9 +202,79 @@ export default async function FinancePage() {
     amount: Number(inv.totalAmount),
   }));
 
-  // Owner-first: open with what must be paid, collected, or approved today, then
-  // demote the accountant lanes and AR/AP/reporting taxonomy behind progressive
-  // disclosure (BI-3BCAF95F).
+  // ─── Owner-first surface (food-hospitality) ─────────────────────────────────
+  // Deeper, finance-specific owner-first view (BI-3326DA86): lead with the
+  // restaurant's real money jobs — the same live figures re-framed as "what
+  // needs attention today" — and push every accounting internal into the
+  // collapsed advanced region. Supersedes the generic owner-first summary band
+  // (BI-3BCAF95F) for food-hospitality, so it returns before that is built.
+  if (financeSurface.mode === "owner-first") {
+    const moneyJobMetrics: Partial<Record<FinanceMetricKey, MoneyJobMetric>> = {
+      "outstanding-receivables": {
+        value: `${sym}${formatMoney(owedAmount)}`,
+        hint: `${owedCount} invoice${owedCount !== 1 ? "s" : ""} outstanding`,
+        intent: owedAmount > 0 ? "warning" : "neutral",
+      },
+      "money-in-month": {
+        value: `${sym}${formatMoney(paidAmount)}`,
+        hint: `${paidCount} invoice${paidCount !== 1 ? "s" : ""} paid this month`,
+        intent: paidAmount > 0 ? "success" : "neutral",
+      },
+      "overdue-count": {
+        value: `${overdueCount}`,
+        hint:
+          overdueCount > 0 && oldestOverdue
+            ? `oldest: ${oldestOverdue.account.name}`
+            : "all up to date",
+        intent: overdueCount > 0 ? "danger" : "success",
+      },
+      "supplier-bills-due": {
+        value: `${sym}${formatMoney(moneyOweAmount)}`,
+        hint: `${moneyOweCount} bill${moneyOweCount !== 1 ? "s" : ""} awaiting payment`,
+        intent: moneyOweAmount > 0 ? "warning" : "success",
+      },
+      "cash-position": {
+        value: bankAccounts.length === 0 ? "No accounts" : `${sym}${formatMoney(totalCash)}`,
+        hint:
+          bankAccounts.length === 0
+            ? "add a bank account to reconcile payouts"
+            : `across ${bankAccounts.length} account${bankAccounts.length !== 1 ? "s" : ""}`,
+        intent: bankAccounts.length === 0 ? "neutral" : totalCash >= 0 ? "success" : "danger",
+      },
+    };
+
+    return (
+      <div>
+        {!setupStatus.isConfigured && <SetupBanner />}
+
+        <FinanceTabNav />
+
+        <OwnerFirstFinanceView
+          surface={financeSurface}
+          metrics={moneyJobMetrics}
+          advancedChildren={<AccountantWorkLanePanel lane={accountantLane} />}
+        />
+
+        {/* Recent invoices — owner-relevant, kept below the money jobs */}
+        <section>
+          <h2 className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-3">
+            Recent Invoices
+          </h2>
+          {recentInvoices.length === 0 ? (
+            <p className="text-sm text-[var(--dpf-muted)]">
+              No invoices yet. Bill a booking, order, or catering job to get started.
+            </p>
+          ) : (
+            <RecentInvoicesTable rows={recentInvoiceRows} currencySymbol={sym} />
+          )}
+        </section>
+      </div>
+    );
+  }
+
+  // Owner-first summary for every other archetype (BI-3BCAF95F): open with what
+  // must be paid, collected, or approved today, then demote the accountant lanes
+  // and AR/AP/reporting taxonomy behind progressive disclosure.
   const simple = isSimpleNavMode(
     resolveNavModeFromCookie((await cookies()).get(NAV_MODE_COOKIE)?.value),
   );
@@ -214,24 +294,7 @@ export default async function FinancePage() {
   return (
     <div>
       {/* Setup prompt banner */}
-      {!setupStatus.isConfigured && (
-        <div className="mb-6 rounded-lg border border-[color-mix(in_srgb,var(--dpf-warning)_35%,var(--dpf-border))] bg-[color-mix(in_srgb,var(--dpf-warning)_10%,transparent)] p-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-[var(--dpf-warning)]">Complete your financial setup</p>
-              <p className="text-xs text-[var(--dpf-muted)] mt-0.5">
-                Set up your finances based on your business type to get started with invoicing, expenses, and reporting.
-              </p>
-            </div>
-            <Link
-              href="/finance/settings/setup"
-              className="px-3 py-1.5 text-xs font-medium rounded bg-[var(--dpf-warning)] text-[var(--dpf-bg)] hover:opacity-90 transition-opacity shrink-0"
-            >
-              Set Up Now
-            </Link>
-          </div>
-        </div>
-      )}
+      {!setupStatus.isConfigured && <SetupBanner />}
 
       {/* Header */}
       <div className="mb-6 flex items-start justify-between">
@@ -583,6 +646,27 @@ export default async function FinancePage() {
       </section>
         </>
       )}
+    </div>
+  );
+}
+
+function SetupBanner() {
+  return (
+    <div className="mb-6 rounded-lg border border-[color-mix(in_srgb,var(--dpf-warning)_35%,var(--dpf-border))] bg-[color-mix(in_srgb,var(--dpf-warning)_10%,transparent)] p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-[var(--dpf-warning)]">Complete your financial setup</p>
+          <p className="text-xs text-[var(--dpf-muted)] mt-0.5">
+            Set up your finances based on your business type to get started with invoicing, expenses, and reporting.
+          </p>
+        </div>
+        <Link
+          href="/finance/settings/setup"
+          className="px-3 py-1.5 text-xs font-medium rounded bg-[var(--dpf-warning)] text-[var(--dpf-bg)] hover:opacity-90 transition-opacity shrink-0"
+        >
+          Set Up Now
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/finance/CreateInvoiceForm.tsx
+++ b/apps/web/components/finance/CreateInvoiceForm.tsx
@@ -30,6 +30,15 @@ interface Props {
   defaultSignatureRequired?: boolean;
   /** Workspace base currency; pre-fills the currency field before a customer is selected. */
   defaultCurrency?: string;
+  /** Archetype-appropriate label for the account picker (e.g. "Guest or customer"). */
+  customerLabel?: string;
+  /** Archetype-appropriate helper under "require signature before payment". */
+  signatureHint?: string;
+  /**
+   * When the form was opened from a Restaurant billing context (booking, order,
+   * catering, private event), a short badge to confirm what is being billed.
+   */
+  contextLabel?: string | null;
 }
 
 function round2(n: number): number {
@@ -47,6 +56,9 @@ export function CreateInvoiceForm({
   defaultTaxRate = 0,
   defaultSignatureRequired = false,
   defaultCurrency = "USD",
+  customerLabel = "Customer",
+  signatureHint = "The customer signs on the payment page before they can pay. Recommended for engagement letters and service agreements.",
+  contextLabel = null,
 }: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
@@ -164,12 +176,19 @@ export function CreateInvoiceForm({
 
       {/* Customer & invoice details */}
       <div className="p-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
-        <h2 className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)] mb-4">
-          Invoice Details
-        </h2>
+        <div className="mb-4 flex items-center justify-between gap-2">
+          <h2 className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+            Invoice Details
+          </h2>
+          {contextLabel && (
+            <span className="rounded-full border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--dpf-accent)]">
+              {contextLabel}
+            </span>
+          )}
+        </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
-            <label className={labelClasses}>Customer *</label>
+            <label className={labelClasses}>{customerLabel} *</label>
             <select
               value={selectedAccountId}
               onChange={(e) => handleCustomerChange(e.target.value)}
@@ -234,10 +253,7 @@ export function CreateInvoiceForm({
               />
               <span className="text-xs text-[var(--dpf-text)]">
                 Require signature before payment
-                <span className="block text-[var(--dpf-muted)]">
-                  The customer signs on the payment page before they can pay. Recommended for
-                  engagement letters and service agreements.
-                </span>
+                <span className="block text-[var(--dpf-muted)]">{signatureHint}</span>
               </span>
             </label>
           </div>

--- a/apps/web/components/finance/OwnerFirstFinanceView.test.tsx
+++ b/apps/web/components/finance/OwnerFirstFinanceView.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+import { OwnerFirstFinanceView, type MoneyJobMetric } from "./OwnerFirstFinanceView";
+import { resolveFinanceSurface, type FinanceMetricKey } from "@/lib/finance/finance-surface";
+
+const surface = resolveFinanceSurface("food-hospitality");
+
+const metrics: Partial<Record<FinanceMetricKey, MoneyJobMetric>> = {
+  "outstanding-receivables": { value: "£1,250.00", hint: "3 invoices outstanding" },
+  "money-in-month": { value: "£8,400.00", hint: "42 invoices paid this month" },
+  "overdue-count": { value: "2", hint: "oldest: Table 12" },
+  "supplier-bills-due": { value: "£640.00", hint: "5 bills awaiting payment" },
+  "cash-position": { value: "£12,000.00", hint: "across 2 accounts" },
+};
+
+function render() {
+  return renderToStaticMarkup(
+    <OwnerFirstFinanceView
+      surface={surface}
+      metrics={metrics}
+      advancedChildren={<div>ACCOUNTANT_WORK_LANE_MARKER</div>}
+    />,
+  );
+}
+
+describe("OwnerFirstFinanceView", () => {
+  it("leads with the money question and foregrounds Restaurant money jobs", () => {
+    const html = render();
+    expect(html).toContain("What money needs attention today?");
+    expect(html).toContain("Deposits &amp; event balances");
+    expect(html).toContain("Order &amp; ticket payments");
+    expect(html).toContain("Supplier bills");
+    expect(html).toContain("Payouts &amp; reconciliation");
+    expect(html).toContain("No-show &amp; cancellation fees");
+  });
+
+  it("renders the live figures for each money job", () => {
+    const html = render();
+    expect(html).toContain("£1,250.00");
+    expect(html).toContain("£8,400.00");
+    expect(html).toContain("£640.00");
+    expect(html).toContain("£12,000.00");
+  });
+
+  it("offers Restaurant invoice entry points instead of only a customer dropdown", () => {
+    const html = render();
+    expect(html).toContain("From a booking");
+    expect(html).toContain("Catering order");
+    expect(html).toContain("Private event");
+    expect(html).toContain('href="/finance/invoices/new?from=booking"');
+  });
+
+  it("does NOT lead with accountant/internal sections — they sit inside the advanced region", () => {
+    const html = render();
+
+    // The money jobs must appear before the deferred "Accounting & admin" block.
+    const firstMoneyJob = html.indexOf("Deposits &amp; event balances");
+    const advancedHeading = html.indexOf("Accounting &amp; admin");
+    const accountantLane = html.indexOf("ACCOUNTANT_WORK_LANE_MARKER");
+
+    expect(firstMoneyJob).toBeGreaterThan(-1);
+    expect(advancedHeading).toBeGreaterThan(firstMoneyJob);
+    expect(accountantLane).toBeGreaterThan(advancedHeading);
+
+    // The internals live under a collapsed <details> summary, not at the top.
+    expect(html).toContain("<details");
+    expect(html).toContain("<summary");
+  });
+
+  it("keeps VAT, dunning, payment runs, GL, bank rules, and AI spend links available (deferred, not dropped)", () => {
+    const html = render();
+    for (const href of [
+      "/finance/reports/vat-summary",
+      "/finance/settings/dunning",
+      "/finance/payment-runs",
+      "/finance/reports/general-ledger",
+      "/finance/banking/rules",
+      "/finance/spend/ai",
+    ]) {
+      expect(html).toContain(`href="${href}"`);
+    }
+  });
+});

--- a/apps/web/components/finance/OwnerFirstFinanceView.tsx
+++ b/apps/web/components/finance/OwnerFirstFinanceView.tsx
@@ -1,0 +1,180 @@
+import Link from "next/link";
+import type {
+  FinanceMetricKey,
+  FinanceMoneyJob,
+  FinanceSurfaceModel,
+} from "@/lib/finance/finance-surface";
+
+export type MoneyJobMetric = {
+  /** Pre-formatted display value, e.g. "£1,250.00" or "3". */
+  value: string;
+  /** Short supporting line, e.g. "4 invoices outstanding". */
+  hint?: string;
+  intent?: "neutral" | "success" | "warning" | "danger";
+};
+
+const INTENT_TEXT: Record<NonNullable<MoneyJobMetric["intent"]>, string> = {
+  neutral: "text-[var(--dpf-text)]",
+  success: "text-[var(--dpf-success)]",
+  warning: "text-[var(--dpf-warning)]",
+  danger: "text-[var(--dpf-error)]",
+};
+
+type Props = {
+  /** Must be an owner-first surface (mode === "owner-first"). */
+  surface: FinanceSurfaceModel;
+  /** Formatted live figures keyed by metric, filled in by the server page. */
+  metrics: Partial<Record<FinanceMetricKey, MoneyJobMetric>>;
+  /**
+   * Accounting internals rendered INSIDE the collapsed advanced region so the
+   * owner-first screen never leads with them (e.g. the bookkeeper/accountant
+   * work lane).
+   */
+  advancedChildren?: React.ReactNode;
+};
+
+/**
+ * Owner-first finance overview for food-hospitality. Leads with the money jobs
+ * a restaurant owner cares about today and pushes every accounting internal
+ * (VAT, dunning, payment runs, GL reports, bank rules, AI spend, the accountant
+ * work lane) into clearly-labelled, collapsed advanced sections.
+ */
+export function OwnerFirstFinanceView({ surface, metrics, advancedChildren }: Props) {
+  return (
+    <div data-component="owner-first-finance" data-finance-mode={surface.mode}>
+      {/* Header */}
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold text-[var(--dpf-text)]">{surface.headline}</h1>
+          <p className="mt-1 max-w-2xl text-sm text-[var(--dpf-muted)]">{surface.subhead}</p>
+        </div>
+        <Link
+          href="/finance/invoices/new"
+          className="shrink-0 rounded-md bg-[var(--dpf-accent)] px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+        >
+          New Invoice
+        </Link>
+      </div>
+
+      {/* Money jobs — the foregrounded "what needs attention today" grid */}
+      <section aria-label="Money that needs attention today" className="mb-8">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {surface.moneyJobs.map((job) => (
+            <MoneyJobCard
+              key={job.id}
+              job={job}
+              metric={job.metricKey ? metrics[job.metricKey] : undefined}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Restaurant-context invoice entry points */}
+      {surface.invoiceEntryPoints.length > 0 && (
+        <section aria-label="Start a bill" className="mb-8">
+          <h2 className="mb-3 text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+            Start a bill
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {surface.invoiceEntryPoints.map((entry) => (
+              <Link
+                key={entry.id}
+                href={entry.href}
+                className="block rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3 transition-colors hover:border-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)]"
+              >
+                <p className="text-sm font-medium text-[var(--dpf-text)]">{entry.label}</p>
+                <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">{entry.description}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Deferred accounting internals — collapsed by default */}
+      {surface.advancedSections.length > 0 && (
+        <section aria-label="Accounting and admin" className="mb-6">
+          <details className="group rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 p-4">
+              <div>
+                <p className="text-sm font-semibold text-[var(--dpf-text)]">
+                  Accounting &amp; admin
+                </p>
+                <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">
+                  VAT, dunning, payment runs, ledger reports, bank rules, and AI spend — the
+                  back-office detail, out of the way until you need it.
+                </p>
+              </div>
+              <span className="shrink-0 text-[11px] font-medium text-[var(--dpf-accent)]">
+                Show →
+              </span>
+            </summary>
+
+            <div className="space-y-6 border-t border-[var(--dpf-border)] p-4">
+              <div className="grid gap-6 sm:grid-cols-2">
+                {surface.advancedSections.map((advanced) => (
+                  <div key={advanced.id}>
+                    <p className="text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">
+                      {advanced.label}
+                    </p>
+                    <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">
+                      {advanced.description}
+                    </p>
+                    <div className="mt-3 flex flex-col gap-2">
+                      {advanced.links.map((link) => (
+                        <Link
+                          key={link.href}
+                          href={link.href}
+                          className="text-xs text-[var(--dpf-accent)] hover:underline"
+                        >
+                          {link.label} →
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {advancedChildren}
+            </div>
+          </details>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function MoneyJobCard({ job, metric }: { job: FinanceMoneyJob; metric?: MoneyJobMetric }) {
+  const intentClass = metric?.intent ? INTENT_TEXT[metric.intent] : "text-[var(--dpf-text)]";
+
+  return (
+    <Link
+      href={job.href}
+      className="flex h-full flex-col rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 transition-colors hover:border-[var(--dpf-accent)] hover:bg-[var(--dpf-surface-2)]"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-semibold text-[var(--dpf-text)]">{job.label}</p>
+        {job.kind === "action" && (
+          <span className="shrink-0 rounded-full border border-[var(--dpf-border)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[var(--dpf-muted)]">
+            Action
+          </span>
+        )}
+      </div>
+      <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">{job.question}</p>
+
+      <div className="mt-auto pt-3">
+        {job.kind === "monitor" && metric ? (
+          <>
+            <p className={`text-lg font-bold ${intentClass}`}>{metric.value}</p>
+            {metric.hint && (
+              <p className="mt-0.5 text-[11px] text-[var(--dpf-muted)]">{metric.hint}</p>
+            )}
+          </>
+        ) : (
+          <span className="text-[11px] font-medium text-[var(--dpf-accent)]">
+            {job.kind === "action" ? "Charge a fee →" : "Open →"}
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/components/finance/PaymentRunBuilder.test.tsx
+++ b/apps/web/components/finance/PaymentRunBuilder.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock("@/lib/actions/ap", () => ({ createPaymentRun: vi.fn(async () => undefined) }));
+
+import { PaymentRunBuilder } from "./PaymentRunBuilder";
+
+const BILLS = [
+  {
+    id: "bill-1",
+    billRef: "BILL-001",
+    supplierId: "sup-1",
+    supplierName: "Fresh Produce Co",
+    currency: "GBP",
+    amountDue: 320,
+  },
+];
+
+describe("PaymentRunBuilder — payment semantics disclosure", () => {
+  it("states it records bills as paid and does NOT initiate a real payment, before any bill is selected", () => {
+    const html = renderToStaticMarkup(<PaymentRunBuilder approvedBills={BILLS} />);
+
+    expect(html).toContain("This records bills as paid — it does not move money");
+    expect(html).toContain("not initiate a real bank transfer");
+    expect(html).toContain("not a draft");
+  });
+
+  it("labels the primary action honestly (Record as Paid, not Execute/Pay)", () => {
+    const html = renderToStaticMarkup(<PaymentRunBuilder approvedBills={BILLS} />);
+    expect(html).not.toContain("Execute Payment Run");
+  });
+
+  it("shows the disclosure even when there are no approved bills", () => {
+    const html = renderToStaticMarkup(<PaymentRunBuilder approvedBills={[]} />);
+    expect(html).toContain("does not move money");
+    expect(html).toContain("No approved bills ready to record as paid.");
+  });
+});

--- a/apps/web/components/finance/PaymentRunBuilder.tsx
+++ b/apps/web/components/finance/PaymentRunBuilder.tsx
@@ -77,14 +77,20 @@ export function PaymentRunBuilder({ approvedBills }: Props) {
 
   if (approvedBills.length === 0) {
     return (
-      <p className="text-sm text-[var(--dpf-muted)]">
-        No approved bills ready for payment.
-      </p>
+      <div>
+        <PaymentRunDisclosure />
+        <p className="text-sm text-[var(--dpf-muted)]">
+          No approved bills ready to record as paid.
+        </p>
+      </div>
     );
   }
 
   return (
     <div>
+      {/* What this action does — shown before any bill is selected. */}
+      <PaymentRunDisclosure />
+
       {/* Consolidate toggle */}
       <div className="flex items-center gap-3 mb-4">
         <label className="flex items-center gap-2 cursor-pointer">
@@ -181,7 +187,7 @@ export function PaymentRunBuilder({ approvedBills }: Props) {
               disabled={loading}
               className="px-4 py-2 rounded-md text-sm font-medium bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity disabled:opacity-50"
             >
-              Execute Payment Run
+              Record as Paid
             </button>
           </div>
         </div>
@@ -192,18 +198,19 @@ export function PaymentRunBuilder({ approvedBills }: Props) {
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
           <div className="bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] rounded-xl p-6 max-w-sm w-full mx-4">
             <h3 className="text-base font-semibold text-[var(--dpf-text)] mb-2">
-              Confirm Payment Run
+              Record payment run
             </h3>
             <p className="text-sm text-[var(--dpf-muted)] mb-4">
-              This will pay{" "}
+              This records{" "}
               <span className="text-[var(--dpf-text)] font-semibold">
                 {selectedIds.size} bill{selectedIds.size !== 1 ? "s" : ""}
               </span>{" "}
               totalling{" "}
               <span className="text-[var(--dpf-text)] font-semibold">
                 GBP {formatMoney(total)}
-              </span>
-              . This action cannot be undone.
+              </span>{" "}
+              as paid in DPF. It does not move money through your bank — pay your suppliers as
+              usual, then this keeps your books settled. This can&rsquo;t be undone here.
             </p>
             {error && <p className="text-xs text-[var(--dpf-error)] mb-4">{error}</p>}
             <div className="flex gap-3">
@@ -219,12 +226,35 @@ export function PaymentRunBuilder({ approvedBills }: Props) {
                 disabled={loading}
                 className="flex-1 px-4 py-2 rounded-md text-sm font-medium bg-[var(--dpf-accent)] text-white hover:opacity-90 transition-opacity disabled:opacity-50"
               >
-                {loading ? "Processing…" : "Confirm & Pay"}
+                {loading ? "Recording…" : "Record as Paid"}
               </button>
             </div>
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * States plainly what recording a payment run does BEFORE the owner selects any
+ * bills. `createPaymentRun` marks the selected approved bills as paid and writes
+ * a matching outbound payment record — it does not draft, and it does not
+ * initiate a real bank transfer. Say so, so the owner is not misled into
+ * thinking DPF moved money.
+ */
+function PaymentRunDisclosure() {
+  return (
+    <div className="mb-4 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-3">
+      <p className="text-xs font-semibold text-[var(--dpf-text)]">
+        This records bills as paid — it does not move money
+      </p>
+      <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">
+        Recording a payment run marks the selected approved bills as paid in DPF and writes a
+        matching outbound payment. It is <span className="text-[var(--dpf-text)]">not a draft</span>{" "}
+        and it does <span className="text-[var(--dpf-text)]">not initiate a real bank transfer</span>{" "}
+        — pay your suppliers through your bank as usual, then use this to keep your books settled.
+      </p>
     </div>
   );
 }

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8612,6 +8612,7 @@
       "anchors": [
         "use-this-doc-for",
         "workflow",
+        "starting-an-invoice-from-context-food-hospitality",
         "what-to-watch"
       ]
     },
@@ -8670,6 +8671,8 @@
         "overview",
         "key-concepts",
         "what-you-can-do",
+        "owner-first-overview-food-hospitality",
+        "recording-a-payment-run",
         "route-guide"
       ]
     },

--- a/apps/web/lib/finance/finance-surface.test.ts
+++ b/apps/web/lib/finance/finance-surface.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  isFinanceInvoiceContext,
+  isOwnerFirstFinanceCategory,
+  resolveFinanceInvoiceCopy,
+  resolveFinanceSurface,
+} from "./finance-surface";
+
+// Accounting internals that must NOT lead the surface for a restaurant owner.
+// They are allowed only inside the deferred advanced sections.
+const INTERNAL_ROUTES = [
+  "/finance/reports/vat-summary",
+  "/finance/settings/tax",
+  "/finance/reports/general-ledger",
+  "/finance/settings/dunning",
+  "/finance/payment-runs",
+  "/finance/banking/rules",
+  "/finance/spend/ai",
+];
+
+describe("resolveFinanceSurface — food-hospitality (owner-first)", () => {
+  const surface = resolveFinanceSurface("food-hospitality");
+
+  it("runs in owner-first mode and leads with the money question", () => {
+    expect(surface.mode).toBe("owner-first");
+    expect(surface.headline.toLowerCase()).toContain("attention today");
+  });
+
+  it("foregrounds the Restaurant money jobs", () => {
+    const ids = surface.moneyJobs.map((job) => job.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "deposits-balances", // booking deposits + event/catering balances
+        "order-ticket-payments", // ticket/order payments
+        "supplier-bills", // supplier bills
+        "payouts-reconciliation", // payouts/reconciliation
+        "no-show-cancellation-fees", // no-show/cancellation fees
+      ]),
+    );
+  });
+
+  it("names booking deposits, catering/event balances, and no-show fees in owner-first language", () => {
+    const text = surface.moneyJobs
+      .map((job) => `${job.label} ${job.question}`)
+      .join(" ")
+      .toLowerCase();
+    expect(text).toContain("deposit");
+    expect(text).toContain("catering");
+    expect(text).toContain("supplier");
+    expect(text).toContain("no-show");
+    expect(text).toContain("reconcil");
+  });
+
+  it("does NOT lead with accountant/internal routes as money jobs", () => {
+    const jobRoutes = surface.moneyJobs.map((job) => job.href);
+    for (const route of INTERNAL_ROUTES) {
+      expect(jobRoutes).not.toContain(route);
+    }
+  });
+
+  it("defers VAT, dunning, payment runs, GL, bank rules, and AI spend into advanced sections", () => {
+    const advancedRoutes = surface.advancedSections.flatMap((section) =>
+      section.links.map((link) => link.href),
+    );
+    for (const route of INTERNAL_ROUTES) {
+      expect(advancedRoutes).toContain(route);
+    }
+  });
+
+  it("offers booking/order/catering/private-event invoice entry points", () => {
+    const ids = surface.invoiceEntryPoints.map((entry) => entry.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(["booking", "order", "catering", "private-event"]),
+    );
+    // Each Restaurant context entry point carries its context, not just a blank form.
+    const bookingEntry = surface.invoiceEntryPoints.find((e) => e.id === "booking");
+    expect(bookingEntry?.href).toContain("from=booking");
+  });
+});
+
+describe("resolveFinanceSurface — non-food-hospitality (standard)", () => {
+  it.each(["professional-services", "retail-goods", "healthcare-wellness"])(
+    "keeps %s in standard mode with no owner-first money jobs",
+    (category) => {
+      const surface = resolveFinanceSurface(category);
+      expect(surface.mode).toBe("standard");
+      expect(surface.moneyJobs).toHaveLength(0);
+      expect(surface.invoiceEntryPoints).toHaveLength(0);
+      expect(surface.advancedSections).toHaveLength(0);
+    },
+  );
+
+  it("falls back to standard mode for unknown/null categories", () => {
+    expect(resolveFinanceSurface(null).mode).toBe("standard");
+    expect(resolveFinanceSurface(undefined).mode).toBe("standard");
+    expect(resolveFinanceSurface("").mode).toBe("standard");
+  });
+});
+
+describe("isOwnerFirstFinanceCategory", () => {
+  it("is true only for food-hospitality", () => {
+    expect(isOwnerFirstFinanceCategory("food-hospitality")).toBe(true);
+    expect(isOwnerFirstFinanceCategory("professional-services")).toBe(false);
+    expect(isOwnerFirstFinanceCategory(null)).toBe(false);
+  });
+});
+
+describe("resolveFinanceInvoiceCopy", () => {
+  it("uses Restaurant-appropriate language for food-hospitality", () => {
+    const copy = resolveFinanceInvoiceCopy("food-hospitality");
+    expect(copy.newInvoiceSubhead.toLowerCase()).toContain("booking");
+    expect(copy.customerLabel.toLowerCase()).toContain("guest");
+    // Replaces the professional-services engagement-letter framing.
+    expect(copy.signatureHint.toLowerCase()).not.toContain("engagement letter");
+    expect(copy.contexts.catering.description.toLowerCase()).toContain("catering");
+  });
+
+  it("keeps professional-services copy as the default", () => {
+    const copy = resolveFinanceInvoiceCopy("professional-services");
+    expect(copy.customerLabel).toBe("Customer");
+    expect(copy.signatureHint.toLowerCase()).toContain("engagement letter");
+  });
+});
+
+describe("isFinanceInvoiceContext", () => {
+  it("accepts the known Restaurant contexts", () => {
+    for (const ctx of ["booking", "order", "catering", "private-event", "no-show"]) {
+      expect(isFinanceInvoiceContext(ctx)).toBe(true);
+    }
+  });
+
+  it("rejects anything else", () => {
+    expect(isFinanceInvoiceContext("customer")).toBe(false);
+    expect(isFinanceInvoiceContext(null)).toBe(false);
+    expect(isFinanceInvoiceContext(undefined)).toBe(false);
+  });
+});

--- a/apps/web/lib/finance/finance-surface.ts
+++ b/apps/web/lib/finance/finance-surface.ts
@@ -1,0 +1,336 @@
+// Archetype-scoped finance surface model.
+//
+// The generic finance overview leads with accountant/back-office sections
+// (receivables/payables/close, VAT, dunning, payment runs, GL reports, bank
+// rules, AI spend). For an owner-operated food-hospitality business that is the
+// wrong first screen: the owner wants to know "what money needs attention
+// today?" — deposits to collect, order and ticket payments landing, supplier
+// bills to pay, payouts to reconcile — not the ledger internals a bookkeeper
+// works from.
+//
+// This module maps an archetype CATEGORY (StorefrontArchetype.category, e.g.
+// "food-hospitality") to an owner-first finance surface that foregrounds the
+// restaurant's real money jobs and defers the accounting internals behind clear
+// advanced sections. Every job/link points at a REAL finance route — there are
+// no Restaurant-specific money tables today, so the surface is an honest
+// re-framing of the existing Invoice/Payment/Bill/BankTransaction data, not a
+// promise of new records.
+//
+// Dependency-free on purpose (no prisma/@dpf/db, no react) so it unit-tests in
+// isolation and never pulls a server-only module into a client bundle. The
+// server resolves the org's archetype category and calls resolveFinanceSurface.
+
+export type FinanceSurfaceMode = "owner-first" | "standard";
+
+/**
+ * A live figure the finance overview page computes and slots into a money job.
+ * The surface model only names which figure a job wants; the page owns the
+ * prisma queries and the formatting.
+ */
+export type FinanceMetricKey =
+  | "outstanding-receivables"
+  | "money-in-month"
+  | "overdue-count"
+  | "supplier-bills-due"
+  | "cash-position";
+
+export type FinanceMoneyJob = {
+  id: string;
+  /** Restaurant-facing name for this money job. */
+  label: string;
+  /** Owner-first phrasing of the money question this job answers. */
+  question: string;
+  /** Real finance route this job opens. */
+  href: string;
+  /**
+   * "monitor" jobs show a running figure the owner watches; "action" jobs are a
+   * thing the owner starts (e.g. charge a no-show fee).
+   */
+  kind: "monitor" | "action";
+  /** Live figure to display, for monitor jobs backed by a running number. */
+  metricKey?: FinanceMetricKey;
+};
+
+export type FinanceInvoiceEntryPointId =
+  | "booking"
+  | "order"
+  | "catering"
+  | "private-event"
+  | "blank";
+
+export type FinanceInvoiceEntryPoint = {
+  id: FinanceInvoiceEntryPointId;
+  label: string;
+  description: string;
+  href: string;
+};
+
+export type FinanceAdvancedLink = { label: string; href: string };
+
+export type FinanceAdvancedSection = {
+  id: string;
+  label: string;
+  description: string;
+  links: FinanceAdvancedLink[];
+};
+
+export type FinanceSurfaceModel = {
+  archetypeCategory: string | null;
+  mode: FinanceSurfaceMode;
+  headline: string;
+  subhead: string;
+  /** Foregrounded Restaurant money jobs (empty in standard mode). */
+  moneyJobs: FinanceMoneyJob[];
+  /** Restaurant-context invoice entry points (empty in standard mode). */
+  invoiceEntryPoints: FinanceInvoiceEntryPoint[];
+  /** Deferred accounting/back-office internals (empty in standard mode). */
+  advancedSections: FinanceAdvancedSection[];
+};
+
+// Archetype categories that get the owner-first money-jobs surface. Keyed on
+// StorefrontArchetype.category so every food-hospitality archetype (restaurant,
+// café, bakery, catering) inherits it — not just one archetypeId.
+const OWNER_FIRST_CATEGORIES: ReadonlySet<string> = new Set(["food-hospitality"]);
+
+function foodHospitalityMoneyJobs(): FinanceMoneyJob[] {
+  return [
+    {
+      id: "deposits-balances",
+      label: "Deposits & event balances",
+      question: "Booking deposits and catering or event balances still to collect.",
+      href: "/finance/invoices",
+      kind: "monitor",
+      metricKey: "outstanding-receivables",
+    },
+    {
+      id: "order-ticket-payments",
+      label: "Order & ticket payments",
+      question: "Money in from table orders, tickets, and covers this month.",
+      href: "/finance/payments",
+      kind: "monitor",
+      metricKey: "money-in-month",
+    },
+    {
+      id: "overdue-collections",
+      label: "Overdue payments",
+      question: "Guest, catering, and event payments now past their due date.",
+      href: "/finance/reports/aged-debtors",
+      kind: "monitor",
+      metricKey: "overdue-count",
+    },
+    {
+      id: "supplier-bills",
+      label: "Supplier bills",
+      question: "Food, drink, and supplier bills waiting to be paid.",
+      href: "/finance/bills",
+      kind: "monitor",
+      metricKey: "supplier-bills-due",
+    },
+    {
+      id: "payouts-reconciliation",
+      label: "Payouts & reconciliation",
+      question: "Card payouts landing in the bank, matched back to sales.",
+      href: "/finance/banking",
+      kind: "monitor",
+      metricKey: "cash-position",
+    },
+    {
+      id: "no-show-cancellation-fees",
+      label: "No-show & cancellation fees",
+      question: "Charge a fee when a guest no-shows or cancels late.",
+      href: "/finance/invoices/new?from=no-show",
+      kind: "action",
+    },
+  ];
+}
+
+function foodHospitalityInvoiceEntryPoints(): FinanceInvoiceEntryPoint[] {
+  return [
+    {
+      id: "booking",
+      label: "From a booking",
+      description: "Turn a reservation into a deposit or balance invoice.",
+      href: "/finance/invoices/new?from=booking",
+    },
+    {
+      id: "order",
+      label: "From an order",
+      description: "Bill a table, takeaway, or delivery order.",
+      href: "/finance/invoices/new?from=order",
+    },
+    {
+      id: "catering",
+      label: "Catering order",
+      description: "Invoice a catering job — deposit up front, balance later.",
+      href: "/finance/invoices/new?from=catering",
+    },
+    {
+      id: "private-event",
+      label: "Private event",
+      description: "Invoice a private hire or event, deposit first.",
+      href: "/finance/invoices/new?from=private-event",
+    },
+    {
+      id: "blank",
+      label: "Blank invoice",
+      description: "Start from a blank invoice with no context.",
+      href: "/finance/invoices/new",
+    },
+  ];
+}
+
+// Accounting internals a restaurant owner should not have to lead with. Kept as
+// clearly-labelled advanced sections so a bookkeeper/accountant can still reach
+// VAT, dunning, payment runs, the general ledger, bank rules, and AI spend —
+// they are one disclosure away, not on the first screen.
+function foodHospitalityAdvancedSections(): FinanceAdvancedSection[] {
+  return [
+    {
+      id: "accounting-tax",
+      label: "Accounting & tax",
+      description: "Period-end, VAT, and ledger detail your bookkeeper or accountant works from.",
+      links: [
+        { label: "VAT summary", href: "/finance/reports/vat-summary" },
+        { label: "VAT / tax remittance", href: "/finance/settings/tax" },
+        { label: "General ledger", href: "/finance/reports/general-ledger" },
+        { label: "Profit & loss", href: "/finance/reports/profit-loss" },
+        { label: "All reports", href: "/finance/reports" },
+        { label: "Period close", href: "/finance/close" },
+      ],
+    },
+    {
+      id: "automation-controls",
+      label: "Automation & controls",
+      description: "Set-and-forget rules and back-office runs — configured once, revisited rarely.",
+      links: [
+        { label: "Payment runs", href: "/finance/payment-runs" },
+        { label: "Dunning reminders", href: "/finance/settings/dunning" },
+        { label: "Bank rules", href: "/finance/banking/rules" },
+        { label: "Recurring schedules", href: "/finance/recurring" },
+        { label: "AI spend", href: "/finance/spend/ai" },
+      ],
+    },
+  ];
+}
+
+/**
+ * Resolve the finance overview surface for an archetype category.
+ *
+ * Owner-first (food-hospitality) returns foregrounded money jobs, Restaurant
+ * invoice entry points, and deferred advanced sections. Every other archetype
+ * (and an unknown/null category) returns the "standard" mode with empty
+ * collections — the page keeps its existing generic layout for those.
+ */
+export function resolveFinanceSurface(
+  category: string | null | undefined,
+): FinanceSurfaceModel {
+  const normalized = category ?? null;
+
+  if (normalized != null && OWNER_FIRST_CATEGORIES.has(normalized)) {
+    return {
+      archetypeCategory: normalized,
+      mode: "owner-first",
+      headline: "What money needs attention today?",
+      subhead:
+        "Deposits to collect, payments coming in, supplier bills to pay, and payouts to reconcile — the accounting detail is one tap away below.",
+      moneyJobs: foodHospitalityMoneyJobs(),
+      invoiceEntryPoints: foodHospitalityInvoiceEntryPoints(),
+      advancedSections: foodHospitalityAdvancedSections(),
+    };
+  }
+
+  return {
+    archetypeCategory: normalized,
+    mode: "standard",
+    headline: "Finance",
+    subhead: "Run cash, receivables, payables, and close work from one place.",
+    moneyJobs: [],
+    invoiceEntryPoints: [],
+    advancedSections: [],
+  };
+}
+
+export function isOwnerFirstFinanceCategory(
+  category: string | null | undefined,
+): boolean {
+  return category != null && OWNER_FIRST_CATEGORIES.has(category);
+}
+
+// ─── Archetype-appropriate invoice copy ───────────────────────────────────────
+// The generic invoice form leads with professional-services language
+// ("engagement letters and service agreements"). Resolve the copy from the
+// archetype so a restaurant sees booking/order/catering wording instead.
+
+export type FinanceInvoiceContext = "booking" | "order" | "catering" | "private-event" | "no-show";
+
+export type FinanceInvoiceCopy = {
+  /** Subhead under the "New Invoice" heading. */
+  newInvoiceSubhead: string;
+  /** Helper line under "require signature before payment". */
+  signatureHint: string;
+  /** Label for the account/customer picker. */
+  customerLabel: string;
+  /** Per-entry-point framing shown when the form is opened with ?from=<context>. */
+  contexts: Record<FinanceInvoiceContext, { title: string; description: string }>;
+};
+
+const PROFESSIONAL_INVOICE_COPY: FinanceInvoiceCopy = {
+  newInvoiceSubhead: "Create a draft invoice to send to a customer.",
+  signatureHint:
+    "The customer signs on the payment page before they can pay. Recommended for engagement letters and service agreements.",
+  customerLabel: "Customer",
+  contexts: {
+    booking: { title: "New invoice", description: "Create a draft invoice to send to a customer." },
+    order: { title: "New invoice", description: "Create a draft invoice to send to a customer." },
+    catering: { title: "New invoice", description: "Create a draft invoice to send to a customer." },
+    "private-event": { title: "New invoice", description: "Create a draft invoice to send to a customer." },
+    "no-show": { title: "New invoice", description: "Create a draft invoice to send to a customer." },
+  },
+};
+
+const FOOD_HOSPITALITY_INVOICE_COPY: FinanceInvoiceCopy = {
+  newInvoiceSubhead: "Bill a booking, order, catering job, or private event.",
+  signatureHint:
+    "The guest signs on the payment page before they can pay. Useful for catering and private-event agreements where you want sign-off before the deposit.",
+  customerLabel: "Guest or customer",
+  contexts: {
+    booking: {
+      title: "Invoice from a booking",
+      description: "Bill a reservation for its deposit now, or the balance after service.",
+    },
+    order: {
+      title: "Invoice from an order",
+      description: "Bill a table, takeaway, or delivery order.",
+    },
+    catering: {
+      title: "Catering invoice",
+      description: "Bill a catering job — take the deposit up front and the balance on delivery.",
+    },
+    "private-event": {
+      title: "Private-event invoice",
+      description: "Bill a private hire or event, with the deposit secured first.",
+    },
+    "no-show": {
+      title: "No-show or cancellation fee",
+      description: "Charge a guest for a no-show or a late cancellation.",
+    },
+  },
+};
+
+export function resolveFinanceInvoiceCopy(
+  category: string | null | undefined,
+): FinanceInvoiceCopy {
+  return isOwnerFirstFinanceCategory(category)
+    ? FOOD_HOSPITALITY_INVOICE_COPY
+    : PROFESSIONAL_INVOICE_COPY;
+}
+
+export function isFinanceInvoiceContext(value: string | null | undefined): value is FinanceInvoiceContext {
+  return (
+    value === "booking" ||
+    value === "order" ||
+    value === "catering" ||
+    value === "private-event" ||
+    value === "no-show"
+  );
+}

--- a/docs/superpowers/plans/2026-07-22-restaurant-finance-owner-first-BI-3326DA86.md
+++ b/docs/superpowers/plans/2026-07-22-restaurant-finance-owner-first-BI-3326DA86.md
@@ -1,0 +1,101 @@
+# Restaurant finance owner-first + progressive disclosure (plan)
+
+**BI:** BI-3326DA86 (with supporting changes from BI-3BCAF95F)
+**Date:** 2026-07-22
+**Guiding outcome:** for a food-hospitality / Restaurant business, the finance
+first screen should answer **"what money needs attention today?"** in the owner's
+language, and defer the accountant/back-office internals behind clear advanced
+sections.
+
+## Problem
+
+The finance overview (`apps/web/app/(shell)/finance/page.tsx`) renders an
+identical, accountant-shaped surface for every org: Revenue / Spend / Close /
+Configuration cards, a Bookkeeper/Accountant work lane, and a wall of AR/AP/
+Procurement/Banking/Reports/People/Management/Settings link columns. For an
+owner-operated restaurant this is the wrong first screen — it leads with ledger
+internals (VAT remittance, dunning, payment runs, GL reports, bank rules, AI
+spend) instead of the money jobs a restaurateur actually watches: booking
+deposits, event/catering balances, order/ticket payments, supplier bills,
+payouts/reconciliation, and no-show/cancellation fees.
+
+The generic invoice flow compounds this: it starts only from a customer dropdown
+and uses professional-services helper copy ("engagement letters and service
+agreements"). And the payment-run builder said "Execute Payment Run" / "Confirm &
+Pay" / "This will pay … cannot be undone", implying a real, irreversible bank
+transfer — when `createPaymentRun` only records an internal completed payment and
+marks bills paid (no bank rail).
+
+## Design grounding
+
+- **Source of truth:** the archetype/finance mapping already lives in
+  `apps/web/lib/finance/setup-profile.ts` (`financeProfileSlugFromCategory`) and
+  `packages/finance-templates/src/profiles.ts` (`food_hospitality` profile,
+  point-of-sale billing pattern). This work **extends** that substrate; it does
+  not fork a new archetype system.
+- **No new data models.** The substrate sweep confirmed there are no
+  Restaurant-specific money tables (no booking-deposit / catering-balance /
+  no-show-fee / payout models). Restaurant money already flows through the
+  generic `Invoice` / `Payment` / `Bill` / `BankTransaction` tables, with
+  `Invoice.sourceType` / `sourceId` linking back to a booking or order. The
+  owner-first surface is therefore an **honest re-framing of existing finance
+  data**, not a promise of new records — every money job and link points at a
+  real finance route.
+- **Archetype-scoping pattern** mirrors the dependency-free pure-resolver style
+  of `apps/web/lib/finance/invoice-signature-default.ts` and the category-keyed
+  registry of `apps/web/lib/workspace-home/profiles.ts`.
+
+## Changes
+
+1. **`apps/web/lib/finance/finance-surface.ts`** (new, pure, dependency-free):
+   `resolveFinanceSurface(category)` returns an owner-first surface for
+   `food-hospitality` (money jobs + Restaurant invoice entry points + deferred
+   advanced sections) and a `standard` surface for every other/unknown category.
+   Also `resolveFinanceInvoiceCopy(category)` swaps professional-services invoice
+   copy for Restaurant language, and small guards (`isOwnerFirstFinanceCategory`,
+   `isFinanceInvoiceContext`).
+
+2. **`apps/web/components/finance/OwnerFirstFinanceView.tsx`** (new): presentational
+   view that leads with the money-jobs grid and pushes every accounting internal
+   (VAT, dunning, payment runs, GL reports, bank rules, AI spend, the accountant
+   work lane) into a collapsed, clearly-labelled `Accounting & admin` `<details>`.
+
+3. **`apps/web/app/(shell)/finance/page.tsx`**: reads the storefront archetype
+   category, resolves the surface, and branches — owner-first renders
+   `OwnerFirstFinanceView` (re-using the same live figures already queried);
+   every other archetype keeps the existing generic layout unchanged.
+
+4. **Restaurant invoice entry points + copy** (`invoices/new/page.tsx`,
+   `CreateInvoiceForm.tsx`): `?from=booking|order|catering|private-event|no-show`
+   gives a contextual heading, an entry-point chooser, a context badge, and
+   Restaurant helper copy (guest/catering language) instead of only a generic
+   customer dropdown. Defaults preserve professional-services copy for other
+   archetypes.
+
+5. **Payment-run disclosure** (`PaymentRunBuilder.tsx`): a disclosure shown
+   **before** any bill is selected states plainly that recording a payment run
+   marks the selected bills as paid in DPF and is **not a draft** and does **not
+   initiate a real bank transfer**. Action labels changed from
+   "Execute Payment Run" / "Confirm & Pay" to "Record as Paid".
+
+## Tests
+
+- `apps/web/lib/finance/finance-surface.test.ts` — food-hospitality resolves
+  owner-first with the Restaurant money jobs, does **not** lead with
+  accountant/internal routes, defers VAT/dunning/payment-runs/GL/bank-rules/
+  AI-spend into advanced sections; non-food-hospitality stays standard.
+- `apps/web/components/finance/OwnerFirstFinanceView.test.tsx` — Restaurant money
+  jobs + live figures render, internals sit inside the collapsed advanced region
+  (money jobs appear before the advanced heading), and the internal links are
+  deferred-not-dropped.
+- `apps/web/components/finance/PaymentRunBuilder.test.tsx` — disclosure semantics
+  render before bill selection and the misleading "Execute Payment Run" label is
+  gone.
+
+## Out of scope / follow-ups
+
+- Real booking→invoice prefill (reading `StorefrontBooking`/`StorefrontOrder`
+  into the invoice draft) is a data feature for a later BI; today the entry
+  points carry context via query param and framing only.
+- Charging a no-show/cancellation fee is surfaced as an entry point into the
+  generic invoice flow; a first-class fee model is a later BI.

--- a/docs/user-guide/finance/accounts-receivable.md
+++ b/docs/user-guide/finance/accounts-receivable.md
@@ -18,6 +18,10 @@ order: 3
 2. Send or record the receivable event.
 3. Apply payments and review what remains outstanding.
 
+## Starting an invoice from context (food & hospitality)
+
+For the **food-hospitality** archetype, `/finance/invoices/new` can start from a specific billing context instead of only a generic customer dropdown. Opening the page with a `from` parameter — `?from=booking`, `?from=order`, `?from=catering`, `?from=private-event`, or `?from=no-show` — sets a contextual heading, an entry-point chooser, a context badge, and Restaurant-appropriate helper copy (guest/catering language). The same entry points are surfaced as cards on the owner-first `/finance` overview. Other business types keep the standard customer-first invoice form and copy.
+
 ## What To Watch
 
 - invoices sent before the underlying customer or service data is ready

--- a/docs/user-guide/finance/index.md
+++ b/docs/user-guide/finance/index.md
@@ -25,6 +25,23 @@ The Finance area handles your organization's core financial operations: billing 
 - Monitor AI providers as finance-owned suppliers, including draft contracts, open setup work items, and linked billing/usage pages
 - Review committed AI spend and setup gaps from the dedicated `/finance/spend/ai` workspace
 
+## Owner-first overview (food & hospitality)
+
+For restaurants, cafés, bakeries, and caterers (the **food-hospitality** archetype), the `/finance` overview opens with **"what money needs attention today?"** instead of an accountant-shaped dashboard. It foregrounds the money jobs an owner runs day to day:
+
+- **Deposits & event balances** — booking deposits and catering/event balances still to collect
+- **Order & ticket payments** — money coming in from orders, tickets, and covers
+- **Overdue payments** — guest, catering, and event payments past their due date
+- **Supplier bills** — food, drink, and supplier bills waiting to be paid
+- **Payouts & reconciliation** — card payouts landing in the bank, matched back to sales
+- **No-show & cancellation fees** — charge a fee when a guest no-shows or cancels late
+
+Accounting internals — VAT/tax remittance, dunning reminders, payment runs, ledger and P&L reports, bank rules, and AI spend — are kept one tap away under a collapsed **"Accounting & admin"** section. Every other business type keeps the standard finance overview.
+
+## Recording a payment run
+
+A payment run (`/finance/payment-runs`) **records the selected approved bills as paid in DPF** and writes a matching outbound payment. It is **not a draft** and does **not** initiate a real bank transfer — pay your suppliers through your bank as usual, then use a payment run to keep your books settled. The action is labelled **"Record as Paid"** to make this explicit.
+
 ## Route Guide
 
 - `/finance` — Finance overview workspace


### PR DESCRIPTION
## What

For **food-hospitality / Restaurant** orgs, the finance overview now answers **"what money needs attention today?"** first — and defers the accountant/back-office internals behind clear progressive disclosure. Every other archetype keeps the existing generic layout unchanged.

Implements **BI-3326DA86** (with the supporting owner-first framing of **BI-3BCAF95F**).

### Foregrounded Restaurant money jobs
Booking deposits & event/catering balances · order/ticket payments · overdue collections · supplier bills · payouts & reconciliation · no-show/cancellation fees — each a live figure or a start-action, pointing at a real finance route.

### Deferred behind a collapsed "Accounting & admin" section
VAT remittance, dunning, payment runs, general-ledger/P&L reports, bank rules, AI spend, and the bookkeeper/accountant work lane — one tap away, not the first screen.

### Restaurant billing entry points + copy
`/finance/invoices/new?from=booking|order|catering|private-event|no-show` gives a contextual heading, an entry-point chooser, a context badge, and Restaurant helper copy (guest/catering language) — not only a generic customer dropdown. Professional-services copy is preserved as the default for other archetypes.

### Honest payment-run disclosure
`createPaymentRun` records the selected approved bills as **paid in DPF** (a completed internal payment) and does **not** initiate a real bank transfer. The builder now says so **before any bill is selected**, and the misleading "Execute Payment Run" / "Confirm & Pay" labels became **"Record as Paid"**.

## How
- `apps/web/lib/finance/finance-surface.ts` — new pure, dependency-free resolver (mirrors `invoice-signature-default.ts`) mapping archetype **category** → owner-first money-jobs surface + entry points + deferred sections, plus Restaurant invoice copy.
- `apps/web/components/finance/OwnerFirstFinanceView.tsx` — presentational owner-first view; `finance/page.tsx` branches on it, reusing the live figures it already queries.
- `CreateInvoiceForm.tsx` / `invoices/new/page.tsx` — archetype-aware copy + context entry points.
- `PaymentRunBuilder.tsx` — pre-selection disclosure + honest labels.

No Restaurant-specific money tables were added — the surface is an honest re-framing of existing `Invoice`/`Payment`/`Bill`/`BankTransaction` data (`Invoice.sourceType`/`sourceId` already link to bookings/orders).

## Tests (23 new, green locally)
- `lib/finance/finance-surface.test.ts` — food-hospitality resolves owner-first Restaurant money jobs, does **not** lead with accountant/internal routes, defers VAT/dunning/payment-runs/GL/bank-rules/AI-spend; non-food-hospitality stays standard.
- `components/finance/OwnerFirstFinanceView.test.tsx` — money jobs + live figures render; internals sit inside the collapsed advanced region (jobs appear before the advanced heading); links deferred-not-dropped.
- `components/finance/PaymentRunBuilder.test.tsx` — disclosure renders before bill selection; misleading label gone.

Local verification: 23 new tests pass. Direct `tsc --noEmit` is clean for all touched files apart from the worktree-wide missing-`next`-package module-resolution noise (`next typegen` is unavailable in the worktree; CI gates typecheck). Prisma-dependent finance test files fail only on the ungenerated worktree client — unrelated to this change.

## Design grounding
- **Existing specs/plans reviewed:** `docs/superpowers/plans/2026-07-22-restaurant-finance-owner-first-BI-3326DA86.md`; swept `docs/superpowers` for prior finance owner-first work.
- **Current code substrate reviewed:** `apps/web/lib/finance/setup-profile.ts`, `packages/finance-templates/src/profiles.ts`, `apps/web/app/(shell)/finance/page.tsx`, `apps/web/components/finance/PaymentRunBuilder.tsx` — confirmed no Restaurant money tables exist.
- **Source of truth:** `apps/web/lib/finance/setup-profile.ts` archetype→finance-profile mapping.
- **Decision:** new artifact extending the existing archetype substrate.

Docs-Impact: docs/superpowers/plans/2026-07-22-restaurant-finance-owner-first-BI-3326DA86.md
Design-Grounding-Decision: extends apps/web/lib/finance/setup-profile.ts; grounded in docs/superpowers/plans/2026-07-22-restaurant-finance-owner-first-BI-3326DA86.md

## Overlap note
Open PR **#3412** (BI-3BCAF95F) adds a shallower cross-domain owner-first band and edits the same `apps/web/app/(shell)/finance/page.tsx` (its `lib/owner-first/` substrate is not yet on main). This PR is the finance-deep take; the single-file overlap on `finance/page.tsx` is resolved at merge — for food-hospitality this owner-first view supersedes #3412's finance slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)