### PR TITLE
feat(storefront): source-route help panel for Docs links (BI-2DD18122)

### DIFF
--- a/apps/web/app/(shell)/docs/[[...slug]]/page.tsx
+++ b/apps/web/app/(shell)/docs/[[...slug]]/page.tsx
@@ -1,17 +1,61 @@
 import { notFound } from "next/navigation";
+import { prisma } from "@dpf/db";
 import { loadDocPage, loadAllDocs, buildDocsIndex, extractHeadings, AREA_META, AREA_ORDER, type DocsIndex } from "@/lib/docs";
 import { DocsLayout } from "@/components/docs/DocsLayout";
 import { DocRenderer } from "@/components/docs/DocRenderer";
 import { ContextualQuickHelp } from "@/components/docs/ContextualQuickHelp";
+import { StorefrontHelpPanel } from "@/components/docs/StorefrontHelpPanel";
+import {
+  resolveStorefrontHelpPanel,
+  type StorefrontHelpPanel as StorefrontHelpPanelData,
+} from "@/lib/docs/storefront-help-panel";
+import { getVocabulary } from "@/lib/storefront/archetype-vocabulary";
+import { resolveVocabularyKey } from "@/lib/storefront/resolve-vocabulary";
 
 type Props = {
   params: Promise<{ slug?: string[] }>;
   searchParams: Promise<{ sourceRoute?: string }>;
 };
 
+/**
+ * When a storefront admin route opened this docs page, resolve the task-focused
+ * help panel rendered with the install's own archetype vocabulary (BI-2DD18122).
+ * Returns null for non-storefront routes or before any storefront is configured.
+ */
+async function loadStorefrontHelpPanel(
+  sourceRoute: string | undefined,
+): Promise<StorefrontHelpPanelData | null> {
+  if (!sourceRoute) return null;
+  const normalized = sourceRoute.split("?")[0] ?? "";
+  if (!normalized.startsWith("/storefront") && !normalized.startsWith("/admin/storefront")) {
+    return null;
+  }
+
+  const config = await prisma.storefrontConfig.findFirst({
+    select: { archetype: { select: { category: true, customVocabulary: true } } },
+  });
+  const businessContext = config
+    ? null
+    : await prisma.businessContext.findFirst({ select: { industry: true } });
+
+  const vocab = getVocabulary(
+    resolveVocabularyKey({
+      archetypeCategory: config?.archetype?.category ?? null,
+      industry: businessContext?.industry ?? null,
+    }),
+    (config?.archetype?.customVocabulary as Record<string, string> | null) ?? null,
+  );
+
+  return resolveStorefrontHelpPanel(sourceRoute, {
+    vocab,
+    archetypeCategory: config?.archetype?.category ?? null,
+  });
+}
+
 export default async function DocsPage({ params, searchParams }: Props) {
   const { slug } = await params;
   const { sourceRoute } = await searchParams;
+  const helpPanel = await loadStorefrontHelpPanel(sourceRoute);
   const allDocs = loadAllDocs();
   const index = buildDocsIndex(allDocs);
 
@@ -30,14 +74,17 @@ export default async function DocsPage({ params, searchParams }: Props) {
   }));
 
   // Arrived contextually from a specific page — demote the catalog so the
-  // immediate explanation is not competing with the full docs manual.
+  // immediate explanation is not competing with the full docs manual. When the
+  // storefront help panel resolves for the source route it leads, and the
+  // generic quick-help yields to it (helpPanel routes pass no sourceRoute down).
   const contextual = Boolean(sourceRoute);
 
   // No slug = docs home page
   if (!slug || slug.length === 0) {
     return (
       <DocsLayout index={sidebarIndex} currentSlug="" searchItems={searchItems} collapseCatalog={contextual}>
-        <DocsHome index={index} sourceRoute={sourceRoute} />
+        {helpPanel ? <StorefrontHelpPanel panel={helpPanel} sourceRoute={sourceRoute!} /> : null}
+        <DocsHome index={index} sourceRoute={helpPanel ? undefined : sourceRoute} />
       </DocsLayout>
     );
   }
@@ -57,7 +104,8 @@ export default async function DocsPage({ params, searchParams }: Props) {
       headings={tocHeadings}
       collapseCatalog={contextual}
     >
-      <DocContent doc={doc} sourceRoute={sourceRoute} />
+      {helpPanel ? <StorefrontHelpPanel panel={helpPanel} sourceRoute={sourceRoute!} /> : null}
+      <DocContent doc={doc} sourceRoute={helpPanel ? undefined : sourceRoute} />
     </DocsLayout>
   );
 }

--- a/apps/web/components/docs/StorefrontHelpPanel.tsx
+++ b/apps/web/components/docs/StorefrontHelpPanel.tsx
@@ -1,0 +1,83 @@
+import type { StorefrontHelpPanel as HelpPanelData } from "@/lib/docs/storefront-help-panel";
+
+type Props = {
+  panel: HelpPanelData;
+  sourceRoute: string;
+};
+
+// A task-focused help panel that leads the docs page when an owner opens the
+// contextual "Docs" link from a storefront admin route (BI-2DD18122). It answers
+// the four questions a non-technical owner has BEFORE the full docs catalog:
+// what is this, what to do next, what changes if I save, how do I recover.
+export function StorefrontHelpPanel({ panel, sourceRoute }: Props) {
+  return (
+    <section
+      aria-label="Contextual help for this page"
+      className="mb-6 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-5"
+    >
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--dpf-accent)]">
+            Help for this page
+          </p>
+          <h2 className="mt-1 text-lg font-bold text-[var(--dpf-text)]">{panel.title}</h2>
+          <p className="mt-0.5 text-xs text-[var(--dpf-muted)]">
+            Opened from <span className="font-mono">{sourceRoute}</span>
+          </p>
+        </div>
+        <a
+          href={sourceRoute}
+          className="shrink-0 inline-flex items-center rounded-full border border-[var(--dpf-border)] px-3 py-1.5 text-xs font-medium text-[var(--dpf-muted)] transition-colors hover:border-[var(--dpf-accent)] hover:text-[var(--dpf-accent)]"
+        >
+          Back to page
+        </a>
+      </div>
+
+      <HelpBlock label="What is this?">
+        <p className="text-sm leading-relaxed text-[var(--dpf-text)]">{panel.whatIsThis}</p>
+      </HelpBlock>
+
+      <HelpBlock label="What should I do next?">
+        <HelpList items={panel.whatToDoNext} ordered />
+      </HelpBlock>
+
+      <HelpBlock label="What changes if I save or confirm?">
+        <HelpList items={panel.whatChangesIfYouSave} />
+      </HelpBlock>
+
+      <HelpBlock label="How do I recover or undo?">
+        <HelpList items={panel.howToRecover} />
+      </HelpBlock>
+    </section>
+  );
+}
+
+function HelpBlock({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="mt-4 first:mt-0">
+      <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--dpf-muted)]">
+        {label}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+function HelpList({ items, ordered = false }: { items: string[]; ordered?: boolean }) {
+  const ListTag = ordered ? "ol" : "ul";
+  return (
+    <ListTag
+      className={[
+        "space-y-1.5 text-sm leading-relaxed text-[var(--dpf-text)]",
+        ordered ? "list-decimal" : "list-disc",
+        "pl-5",
+      ].join(" ")}
+    >
+      {items.map((item, i) => (
+        <li key={i} className="marker:text-[var(--dpf-muted)]">
+          {item}
+        </li>
+      ))}
+    </ListTag>
+  );
+}

--- a/apps/web/lib/docs/storefront-help-panel.test.ts
+++ b/apps/web/lib/docs/storefront-help-panel.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveStorefrontHelpPanel,
+  STOREFRONT_HELP_ROUTE_KEYS,
+  type StorefrontHelpPanel,
+} from "./storefront-help-panel";
+import { getVocabulary } from "@/lib/storefront/archetype-vocabulary";
+import { buildContextualDocsHref } from "@/lib/docs-route-map";
+
+// A Restaurant install → food-hospitality vocabulary (Menu / Guests /
+// Reservations / Staff), which is what the owner audit sampled.
+const RESTAURANT = getVocabulary("food-hospitality");
+const opts = { vocab: RESTAURANT, archetypeCategory: "food-hospitality" };
+
+/** All four help questions must be answered (non-empty) for every panel. */
+function expectAnswersAllFourQuestions(panel: StorefrontHelpPanel | null): asserts panel is StorefrontHelpPanel {
+  expect(panel).not.toBeNull();
+  const p = panel!;
+  expect(p.whatIsThis.trim().length).toBeGreaterThan(0);
+  expect(p.whatToDoNext.length).toBeGreaterThan(0);
+  expect(p.whatChangesIfYouSave.length).toBeGreaterThan(0);
+  expect(p.howToRecover.length).toBeGreaterThan(0);
+  expect(p.title.trim().length).toBeGreaterThan(0);
+}
+
+/** Flatten every string in a panel to one lowercase blob for term assertions. */
+function panelText(panel: StorefrontHelpPanel): string {
+  return [panel.title, panel.whatIsThis, ...panel.whatToDoNext, ...panel.whatChangesIfYouSave, ...panel.howToRecover]
+    .join(" ")
+    .toLowerCase();
+}
+
+describe("resolveStorefrontHelpPanel — route coverage", () => {
+  // The six Docs links the acceptance requires route-level coverage for.
+  const ROUTES: Array<{ label: string; route: string; docsPath: string }> = [
+    { label: "dashboard", route: "/storefront", docsPath: "/docs/storefront/index" },
+    { label: "operations", route: "/storefront/settings/operations", docsPath: "/docs/storefront/settings-business-and-operations" },
+    { label: "team", route: "/storefront/team", docsPath: "/docs/storefront/team-and-fulfilment" },
+    { label: "catalog/items", route: "/storefront/items", docsPath: "/docs/storefront/catalog-and-page-content" },
+    { label: "sections", route: "/storefront/sections", docsPath: "/docs/storefront/catalog-and-page-content" },
+    { label: "inbox", route: "/storefront/inbox", docsPath: "/docs/storefront/inbox-and-enquiries" },
+  ];
+
+  for (const { label, route, docsPath } of ROUTES) {
+    it(`resolves a four-question help panel for the ${label} Docs link`, () => {
+      const panel = resolveStorefrontHelpPanel(route, opts);
+      expectAnswersAllFourQuestions(panel);
+      expect(panel.docsPath).toBe(docsPath);
+      expect(panel.routeKey).toBe(route);
+    });
+  }
+
+  it("resolves the same panel for /admin/storefront mirror routes", () => {
+    const publicPanel = resolveStorefrontHelpPanel("/storefront/team", opts);
+    const adminPanel = resolveStorefrontHelpPanel("/admin/storefront/team", opts);
+    expect(adminPanel).not.toBeNull();
+    expect(adminPanel!.title).toBe(publicPanel!.title);
+    expect(adminPanel!.routeKey).toBe("/storefront/team");
+  });
+
+  it("matches leaf routes to their parent panel by longest prefix", () => {
+    const leaf = resolveStorefrontHelpPanel("/storefront/team/prov-123", opts);
+    expect(leaf).not.toBeNull();
+    expect(leaf!.routeKey).toBe("/storefront/team");
+  });
+
+  it("resolves /storefront (dashboard) without swallowing more specific routes", () => {
+    expect(resolveStorefrontHelpPanel("/storefront", opts)!.routeKey).toBe("/storefront");
+    expect(resolveStorefrontHelpPanel("/storefront/settings/operations", opts)!.routeKey).toBe(
+      "/storefront/settings/operations",
+    );
+  });
+
+  it("returns null for non-storefront and malformed routes", () => {
+    expect(resolveStorefrontHelpPanel("/finance/reports", opts)).toBeNull();
+    expect(resolveStorefrontHelpPanel("/platform/ai", opts)).toBeNull();
+    expect(resolveStorefrontHelpPanel("", opts)).toBeNull();
+    expect(resolveStorefrontHelpPanel(undefined, opts)).toBeNull();
+    expect(resolveStorefrontHelpPanel("storefront/team", opts)).toBeNull();
+  });
+});
+
+describe("resolveStorefrontHelpPanel — Restaurant vocabulary preservation", () => {
+  it("uses Restaurant vocabulary across setup routes: tables, reservations, menu, hours, guests, availability", () => {
+    // Aggregate the setup-route panels — the vocabulary must be preserved
+    // somewhere across the owner's setup journey, not generic item/customer copy.
+    const setupRoutes = [
+      "/storefront",
+      "/storefront/setup",
+      "/storefront/settings/operations",
+      "/storefront/team",
+      "/storefront/items",
+      "/storefront/sections",
+      "/storefront/inbox",
+    ];
+    const blob = setupRoutes
+      .map((r) => resolveStorefrontHelpPanel(r, opts))
+      .map((p) => {
+        expect(p).not.toBeNull();
+        return panelText(p!);
+      })
+      .join(" ");
+
+    for (const term of ["tables", "reservations", "menu", "hours", "guests", "availability"]) {
+      expect(blob, `Restaurant vocabulary should include "${term}"`).toContain(term);
+    }
+    // Generic fallbacks should not leak through when a real archetype is set.
+    expect(blob).not.toContain("bookable slot");
+  });
+
+  it("operations panel explains what changing hours/timezone affects and how to recover", () => {
+    const panel = resolveStorefrontHelpPanel("/storefront/settings/operations", opts)!;
+    const changes = panel.whatChangesIfYouSave.join(" ").toLowerCase();
+    const recover = panel.howToRecover.join(" ").toLowerCase();
+    expect(changes).toContain("hours");
+    expect(changes).toContain("time zone");
+    expect(recover).toContain("time zone");
+    expect(panelText(panel)).toContain("availability");
+  });
+
+  it("team panel resolves the table-as-provider / staff confusion", () => {
+    const panel = resolveStorefrontHelpPanel("/storefront/team", opts)!;
+    const text = panelText(panel);
+    expect(text).toContain("tables");
+    expect(text).toContain("staff");
+    expect(text).toContain("provider");
+  });
+
+  it("catalog/items and sections panels give recovery for generated content", () => {
+    const items = resolveStorefrontHelpPanel("/storefront/items", opts)!;
+    const sections = resolveStorefrontHelpPanel("/storefront/sections", opts)!;
+    expect(items.howToRecover.join(" ").toLowerCase()).toContain("delete");
+    expect(panelText(items)).toContain("menu");
+    expect(sections.howToRecover.join(" ").toLowerCase()).toMatch(/hide|delete/);
+    expect(panelText(sections).toLowerCase()).toMatch(/generated|left over|residue/);
+  });
+
+  it("inbox panel keeps Reservations/Guests vocabulary", () => {
+    const panel = resolveStorefrontHelpPanel("/storefront/inbox", opts)!;
+    const text = panelText(panel);
+    expect(text).toContain("reservations");
+    expect(text).toContain("guests");
+  });
+});
+
+describe("resolveStorefrontHelpPanel — archetype independence", () => {
+  it("adapts vocabulary and resource noun to a non-food archetype", () => {
+    const salon = getVocabulary("beauty-personal-care");
+    const panel = resolveStorefrontHelpPanel("/storefront/team", {
+      vocab: salon,
+      archetypeCategory: "beauty-personal-care",
+    })!;
+    const text = panelText(panel);
+    // Salon vocabulary — not Restaurant tables.
+    expect(text).toContain("appointment slot");
+    expect(text).not.toContain("tables");
+  });
+
+  it("falls back to a generic resource noun for an unknown archetype", () => {
+    const generic = getVocabulary(null);
+    const panel = resolveStorefrontHelpPanel("/storefront/team", { vocab: generic, archetypeCategory: null })!;
+    expect(panelText(panel)).toContain("bookable slot");
+  });
+});
+
+describe("contextual Docs links wire to a help panel", () => {
+  it("every storefront help route builds a contextual href whose sourceRoute resolves a panel", () => {
+    for (const routeKey of STOREFRONT_HELP_ROUTE_KEYS) {
+      const href = buildContextualDocsHref(routeKey);
+      expect(href, `${routeKey} should expose a contextual docs link`).not.toBeNull();
+      const sourceRoute = new URLSearchParams(href!.split("?")[1]).get("sourceRoute");
+      expect(sourceRoute).toBe(routeKey);
+      expect(resolveStorefrontHelpPanel(sourceRoute, opts)).not.toBeNull();
+    }
+  });
+});

--- a/apps/web/lib/docs/storefront-help-panel.ts
+++ b/apps/web/lib/docs/storefront-help-panel.ts
@@ -1,0 +1,315 @@
+// apps/web/lib/docs/storefront-help-panel.ts
+//
+// Source-route-specific help panels for Storefront Docs links (BI-2DD18122).
+//
+// When an owner opens the contextual "Docs" link from a storefront admin route
+// (e.g. /storefront/settings/operations), the docs shell should lead with a
+// task-focused help panel — NOT the ~82-link docs catalog. Each panel answers
+// the four questions a non-technical owner actually has:
+//
+//   1. What is this?
+//   2. What should I do next?
+//   3. What changes if I save/confirm?
+//   4. How do I recover / undo?
+//
+// The copy is archetype-aware: it interpolates the storefront's own vocabulary
+// (Menu / Guests / Reservations / Staff for a Restaurant), so a food-hospitality
+// install preserves Restaurant vocabulary — tables, reservations, menu, hours,
+// guests, availability — instead of generic "items / customers / inbox" wording.
+//
+// Pure and client-safe (no fs / prisma). The docs page resolves the archetype
+// vocabulary server-side and passes it in.
+
+import type { ArchetypeVocabulary } from "@/lib/storefront/archetype-vocabulary";
+
+// ── Public shape ─────────────────────────────────────────────────────────────
+
+export type StorefrontHelpPanel = {
+  /** The storefront route the reader came from (normalized, no /admin prefix). */
+  routeKey: string;
+  /** Docs page this route maps to — kept so the panel can deep-link the catalog. */
+  docsPath: string;
+  /** Short, plain-language heading. */
+  title: string;
+  /** "What is this" — one or two sentences. */
+  whatIsThis: string;
+  /** "What should I do next" — ordered, concrete steps. */
+  whatToDoNext: string[];
+  /** "What changes if I save/confirm" — the visible/public effect of mutations. */
+  whatChangesIfYouSave: string[];
+  /** "How do I recover / undo" — the safe way back. */
+  howToRecover: string[];
+};
+
+// ── Archetype-aware lexicon ──────────────────────────────────────────────────
+
+/**
+ * The bookable resource a booking is assigned to, per archetype category.
+ * For a Restaurant this is a *table* — which is exactly the "table-as-provider"
+ * confusion the owner audit surfaced on the team route.
+ */
+const RESOURCE_NOUN: Record<string, { resource: string; resourcePlural: string }> = {
+  "food-hospitality": { resource: "table", resourcePlural: "tables" },
+  "healthcare-wellness": { resource: "appointment slot", resourcePlural: "appointment slots" },
+  "beauty-personal-care": { resource: "appointment slot", resourcePlural: "appointment slots" },
+  "pet-services": { resource: "appointment slot", resourcePlural: "appointment slots" },
+  "professional-services": { resource: "appointment slot", resourcePlural: "appointment slots" },
+  "fitness-recreation": { resource: "class", resourcePlural: "classes" },
+  "education-training": { resource: "class", resourcePlural: "classes" },
+  "asset-rental": { resource: "unit", resourcePlural: "units" },
+  "live-events-venues": { resource: "seat", resourcePlural: "seats" },
+  "real-estate-construction": { resource: "appointment slot", resourcePlural: "appointment slots" },
+  "warehousing-fulfilment": { resource: "handling slot", resourcePlural: "handling slots" },
+};
+
+const DEFAULT_RESOURCE = { resource: "bookable slot", resourcePlural: "bookable slots" };
+
+type HelpLexicon = {
+  portal: string; // "Venue Portal"
+  menu: string; // "Menu"
+  item: string; // "Item"
+  guests: string; // "Guests"
+  reservations: string; // "Reservations"
+  staff: string; // "Staff"
+  category: string; // "Course"
+  price: string; // "Price"
+  resource: string; // "table"
+  resourcePlural: string; // "tables"
+};
+
+function buildLexicon(vocab: ArchetypeVocabulary, archetypeCategory?: string | null): HelpLexicon {
+  const res = RESOURCE_NOUN[archetypeCategory ?? ""] ?? DEFAULT_RESOURCE;
+  return {
+    portal: vocab.portalLabel,
+    menu: vocab.itemsLabel,
+    item: vocab.singleItemLabel,
+    guests: vocab.stakeholderLabel,
+    reservations: vocab.inboxLabel,
+    staff: vocab.teamLabel,
+    category: vocab.categoryLabel,
+    price: vocab.priceLabel,
+    resource: res.resource,
+    resourcePlural: res.resourcePlural,
+  };
+}
+
+// Lowercase helpers keep interpolated labels reading naturally mid-sentence.
+const lc = (s: string) => s.toLowerCase();
+
+// ── Panel builders (one per storefront route family) ─────────────────────────
+
+type PanelBuilder = (lex: HelpLexicon) => Omit<StorefrontHelpPanel, "routeKey" | "docsPath">;
+
+const DASHBOARD: PanelBuilder = (lex) => ({
+  title: `Your ${lex.portal} at a glance`,
+  whatIsThis: `This is the control centre for your public ${lex.portal}. It shows whether you are published, how much of your ${lc(lex.menu)} and how many page sections are live, and it links into every setup step — brand, ${lc(lex.menu)}, ${lex.resourcePlural}, hours, and ${lc(lex.reservations)}.`,
+  whatToDoNext: [
+    `Work through setup in order: brand & public profile → ${lc(lex.menu)} → ${lex.resourcePlural} & ${lc(lex.staff)} → hours & availability → ${lc(lex.reservations)}.`,
+    `Set one thing up at a time instead of editing every surface at once.`,
+    `Leave advanced service lines and cross-industry options closed until your core ${lex.portal} is live.`,
+  ],
+  whatChangesIfYouSave: [
+    `Publishing makes your ${lex.portal} visible to ${lc(lex.guests)} at your public link.`,
+    `Adding a service line can generate extra sections and ${lc(lex.menu)} items you will then need to review or remove.`,
+  ],
+  howToRecover: [
+    `Nothing on this page changes anything just by loading it — you can leave without saving.`,
+    `If a wrong service line added content, remove the generated sections and ${lc(lex.menu)} items, or unpublish while you clean up, then publish again.`,
+  ],
+});
+
+const OPERATIONS: PanelBuilder = (lex) => ({
+  title: `Opening hours & availability`,
+  whatIsThis: `This is where you set your ${lex.portal}'s opening hours, time zone, and the availability windows that decide when ${lc(lex.guests)} can request ${lc(lex.reservations)} against your ${lex.resourcePlural}.`,
+  whatToDoNext: [
+    `Set your time zone first — every hour and availability window is read in it.`,
+    `Enter opening hours for each day; leave a day closed to block ${lc(lex.reservations)} then.`,
+    `Adjust availability windows only after your ${lex.resourcePlural} and ${lc(lex.staff)} are in place.`,
+  ],
+  whatChangesIfYouSave: [
+    `Saving hours immediately changes when ${lc(lex.guests)} can book ${lc(lex.reservations)} on your live ${lex.portal}.`,
+    `Changing the time zone shifts every existing hour and availability window — a 7pm slot can move to a different clock time for ${lc(lex.guests)}.`,
+  ],
+  howToRecover: [
+    `Hours and time zone stay editable — reopen this page and set them back at any time.`,
+    `If ${lc(lex.reservations)} start landing at the wrong time after a change, re-check the time zone first, then the per-day hours, then save again.`,
+  ],
+});
+
+const BUSINESS: PanelBuilder = (lex) => ({
+  title: `Business profile & public identity`,
+  whatIsThis: `This holds your business identity — description, mission, contact, address, and payment or compliance details — that shapes how your ${lex.portal} presents itself to ${lc(lex.guests)}.`,
+  whatToDoNext: [
+    `Fill the core identity first: name, description, and contact details.`,
+    `Leave advanced fields (source-system / migration, market scope, AI autonomy) until the basics are correct.`,
+    `Review the public-facing wording before you consider the profile done.`,
+  ],
+  whatChangesIfYouSave: [
+    `Saving updates the identity and framing ${lc(lex.guests)} see on your ${lex.portal}.`,
+    `Payment, compliance, and region fields can change what checkout or ${lc(lex.reservations)} flows are offered.`,
+  ],
+  howToRecover: [
+    `Every field here is editable — reopen this page and correct it; nothing is public until you publish.`,
+    `If you are unsure a value is right, change the one field back rather than resetting the whole form.`,
+  ],
+});
+
+const TEAM: PanelBuilder = (lex) => ({
+  title: `${lex.staff} & who fulfils ${lc(lex.reservations)}`,
+  whatIsThis: `This lists the ${lc(lex.staff)} and providers who deliver your work. A "provider" is whoever — or whatever ${lex.resource} — a ${lex.resource ? lex.resource : "booking"} is assigned to: for a restaurant that is often your ${lex.resourcePlural} and the ${lc(lex.staff)} who serve them, not a single named person.`,
+  whatToDoNext: [
+    `Add your ${lc(lex.staff)}, and if you take ${lc(lex.reservations)} against specific ${lex.resourcePlural}, add those ${lex.resourcePlural} as providers too.`,
+    `Give each provider availability so bookings only land when that ${lex.resource} or person is free.`,
+    `Keep ${lex.resourcePlural} and ${lc(lex.staff)} distinct so the roster stays readable.`,
+  ],
+  whatChangesIfYouSave: [
+    `Adding or removing a provider changes which ${lex.resourcePlural} or ${lc(lex.staff)} can receive ${lc(lex.reservations)}.`,
+    `Editing availability changes the slots ${lc(lex.guests)} see on your live ${lex.portal}.`,
+  ],
+  howToRecover: [
+    `Removing a provider does not delete past ${lc(lex.reservations)}; re-add the provider to restore future availability.`,
+    `If ${lex.resourcePlural} and ${lc(lex.staff)} got mixed up, rename or remove the wrong providers here — nothing is published until you save.`,
+  ],
+});
+
+const ITEMS: PanelBuilder = (lex) => ({
+  title: `Your ${lex.menu}`,
+  whatIsThis: `This is your ${lex.menu} — the ${lc(lex.menu)} entries ${lc(lex.guests)} can view, order, or book. Each ${lc(lex.item)} has a name, ${lc(lex.price)}, ${lc(lex.category)}, and availability.`,
+  whatToDoNext: [
+    `Edit the pre-loaded ${lc(lex.menu)} items to match what you actually offer, then add your own by ${lc(lex.category)}.`,
+    `Remove any generated or cross-industry items that do not belong on your ${lex.menu}.`,
+    `Check the public ${lex.portal} after a meaningful ${lc(lex.menu)} change.`,
+  ],
+  whatChangesIfYouSave: [
+    `Saving an ${lc(lex.item)} updates your public ${lex.menu} as soon as the ${lex.portal} is published.`,
+    `Turning an ${lc(lex.item)} Off hides it from ${lc(lex.guests)} without deleting it.`,
+  ],
+  howToRecover: [
+    `Toggle a hidden ${lc(lex.item)} back On to restore it — Off is fully reversible.`,
+    `To clear generated ${lc(lex.menu)} residue, delete the unwanted items here; deleting an ${lc(lex.item)} does not remove past orders or ${lc(lex.reservations)}.`,
+  ],
+});
+
+const SECTIONS: PanelBuilder = (lex) => ({
+  title: `Page sections`,
+  whatIsThis: `Sections are the building blocks of your public ${lex.portal} page — hero, featured ${lc(lex.menu)}, ${lc(lex.reservations)} calendar, and so on. Reordering or hiding a section changes what ${lc(lex.guests)} see, not your underlying ${lc(lex.menu)}.`,
+  whatToDoNext: [
+    `Arrange sections in the order ${lc(lex.guests)} should read them; hide any you do not need yet.`,
+    `Remove generated or cross-industry sections left over from setup or a wrong service line.`,
+    `Preview the public page after reordering.`,
+  ],
+  whatChangesIfYouSave: [
+    `Show / Hide and the ↑ / ↓ order controls change your public page layout as soon as it is published.`,
+    `Hiding a section keeps its content — it just stops showing to ${lc(lex.guests)}.`,
+  ],
+  howToRecover: [
+    `Hiding is reversible: Show the section again to bring it back exactly as it was.`,
+    `If setup generated unwanted sections, Hide or delete them here; your ${lc(lex.menu)} items are stored separately and stay intact.`,
+  ],
+});
+
+const INBOX: PanelBuilder = (lex) => ({
+  title: `${lex.reservations} & enquiries`,
+  whatIsThis: `This is your ${lex.reservations} inbox — the ${lc(lex.reservations)}, orders, and enquiries ${lc(lex.guests)} send through your ${lex.portal}. Treat it as a response queue, not a long-term customer record.`,
+  whatToDoNext: [
+    `Work newest first: confirm, respond to, or route each ${lc(lex.guests)} message.`,
+    `Move anything that needs ongoing follow-up into your customer records.`,
+    `Keep the queue clear so no ${lc(lex.guests)} request is missed.`,
+  ],
+  whatChangesIfYouSave: [
+    `Confirming or replying notifies the ${lc(lex.guests)} and updates the request's status.`,
+    `Nothing you do here changes your public ${lex.portal} or your ${lc(lex.menu)}.`,
+  ],
+  howToRecover: [
+    `Responding does not delete the original message — the thread stays for context.`,
+    `If you route a message to the wrong place, it remains in the inbox history to pick back up.`,
+  ],
+});
+
+const SETUP: PanelBuilder = (lex) => ({
+  title: `Guided ${lex.portal} setup`,
+  whatIsThis: `This is the guided setup that stands up your ${lex.portal}: choose an archetype, set your public URL and branding, then load starter ${lc(lex.menu)} and sections that match your business.`,
+  whatToDoNext: [
+    `Complete the steps in order and stop to check each one rather than rushing to publish.`,
+    `Pick the archetype that matches your real business so the starter ${lc(lex.menu)} and vocabulary fit.`,
+    `Verify business context, ${lc(lex.menu)}, and hours before you launch.`,
+  ],
+  whatChangesIfYouSave: [
+    `Finishing setup can generate starter sections and ${lc(lex.menu)} items for your archetype.`,
+    `Launching makes the ${lex.portal} reachable at your public link for ${lc(lex.guests)}.`,
+  ],
+  howToRecover: [
+    `Partial setup is not live until you publish — you can leave and resume later.`,
+    `If the starter content does not fit, edit or remove the generated ${lc(lex.menu)} items and sections afterwards; re-running setup does not wipe your edits automatically.`,
+  ],
+});
+
+// ── Route registry (longest prefix wins) ─────────────────────────────────────
+
+type RouteEntry = { routeKey: string; docsPath: string; build: PanelBuilder };
+
+// Ordered most-specific first so the longest matching prefix is chosen. The
+// docsPath mirrors DOCS_ROUTE_MAP in lib/docs-route-map.ts.
+const STOREFRONT_HELP_ROUTES: RouteEntry[] = [
+  { routeKey: "/storefront/settings/operations", docsPath: "/docs/storefront/settings-business-and-operations", build: OPERATIONS },
+  { routeKey: "/storefront/settings/business", docsPath: "/docs/storefront/settings-business-and-operations", build: BUSINESS },
+  { routeKey: "/storefront/settings", docsPath: "/docs/storefront/settings-business-and-operations", build: BUSINESS },
+  { routeKey: "/storefront/setup", docsPath: "/docs/storefront/setup-and-launch", build: SETUP },
+  { routeKey: "/storefront/team", docsPath: "/docs/storefront/team-and-fulfilment", build: TEAM },
+  { routeKey: "/storefront/items", docsPath: "/docs/storefront/catalog-and-page-content", build: ITEMS },
+  { routeKey: "/storefront/sections", docsPath: "/docs/storefront/catalog-and-page-content", build: SECTIONS },
+  { routeKey: "/storefront/inbox", docsPath: "/docs/storefront/inbox-and-enquiries", build: INBOX },
+  { routeKey: "/storefront", docsPath: "/docs/storefront/index", build: DASHBOARD },
+];
+
+/** Route keys that have a dedicated help panel — exported for tests/tooling. */
+export const STOREFRONT_HELP_ROUTE_KEYS = STOREFRONT_HELP_ROUTES.map((r) => r.routeKey);
+
+// ── Resolution ───────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a source route so admin and public storefront variants share panels
+ * and trailing slashes / leaf ids don't defeat prefix matching.
+ * `/admin/storefront/team` and `/storefront/team/prov-1` both → `/storefront/team`.
+ */
+function normalizeSourceRoute(sourceRoute: string): string {
+  let route = sourceRoute.split("?")[0]!.split("#")[0]!;
+  if (route.length > 1 && route.endsWith("/")) route = route.replace(/\/+$/, "");
+  if (route === "/admin/storefront" || route.startsWith("/admin/storefront/")) {
+    route = route.slice("/admin".length);
+  }
+  return route;
+}
+
+function routeMatches(pathname: string, routeKey: string): boolean {
+  return pathname === routeKey || pathname.startsWith(`${routeKey}/`);
+}
+
+/**
+ * Resolve the task-focused help panel for a storefront source route, rendered
+ * with the install's own archetype vocabulary. Returns null for any route that
+ * is not a storefront admin surface.
+ */
+export function resolveStorefrontHelpPanel(
+  sourceRoute: string | null | undefined,
+  opts: { vocab: ArchetypeVocabulary; archetypeCategory?: string | null },
+): StorefrontHelpPanel | null {
+  if (!sourceRoute || !sourceRoute.startsWith("/")) return null;
+
+  const route = normalizeSourceRoute(sourceRoute);
+
+  let best: RouteEntry | null = null;
+  for (const entry of STOREFRONT_HELP_ROUTES) {
+    if (routeMatches(route, entry.routeKey)) {
+      if (!best || entry.routeKey.length > best.routeKey.length) best = entry;
+    }
+  }
+  if (!best) return null;
+
+  const lex = buildLexicon(opts.vocab, opts.archetypeCategory);
+  return {
+    routeKey: best.routeKey,
+    docsPath: best.docsPath,
+    ...best.build(lex),
+  };
+}

--- a/docs/superpowers/plans/2026-07-22-storefront-docs-help-panel.md
+++ b/docs/superpowers/plans/2026-07-22-storefront-docs-help-panel.md
@@ -1,0 +1,70 @@
+# Storefront Docs help panel (BI-2DD18122, coordinating BI-C39DC90C)
+
+**Epic:** EP-UX-COGLOAD — Live UX cognitive-load audit follow-up
+**Status:** implemented
+**Scope:** the Storefront portion of BI-2DD18122 only. In-product setup/recovery UX
+is BI-C39DC90C (separate worktree `restaurant-storefront-setup-recovery`).
+
+## Problem
+
+The owner usability audit found that contextual **Docs** links from storefront
+admin routes open the full docs shell — an ~82-link area catalog and product/docs
+chrome — *before* any explanation. Route pages are short (~370–630 words) yet the
+catalog dominates. The `?sourceRoute=` banner only said "Opened from /storefront";
+it never answered what the page is, what to do next, what a save changes, or how
+to recover. Restaurant vocabulary (tables, reservations, menu, hours, guests,
+availability) was absent from the sampled docs.
+
+## Design grounding
+
+- **Source of truth reused, not reinvented:**
+  - `apps/web/lib/docs-route-map.ts` already maps storefront routes → docs pages
+    and builds the `?sourceRoute=` contextual href. We key the help panel off the
+    same `sourceRoute` and mirror its `docsPath` values.
+  - `apps/web/lib/storefront/archetype-vocabulary.ts` (`getVocabulary`) is the
+    canonical archetype vocabulary. The panel is rendered *through* it so a
+    food-hospitality install reads Menu / Guests / Reservations / Staff — no new
+    vocabulary source, no hardcoded "Restaurant".
+- **New artifact:** a small, pure `storefront-help-panel` resolver + a
+  presentational panel component. No schema, no new contract beyond the panel shape.
+
+## What was built
+
+1. `apps/web/lib/docs/storefront-help-panel.ts` — pure, client-safe resolver.
+   `resolveStorefrontHelpPanel(sourceRoute, { vocab, archetypeCategory })` maps a
+   storefront source route (dashboard, operations, business, settings, setup,
+   team, items, sections, inbox; `/admin/storefront/*` mirrors normalized) to a
+   panel answering the four owner questions: **what is this / what to do next /
+   what changes if I save or confirm / how do I recover or undo.** Copy
+   interpolates archetype vocabulary + an archetype resource noun
+   (food-hospitality → *tables*), so Restaurant vocabulary is preserved without
+   breaking other archetypes. Longest-prefix match; returns null off-storefront.
+2. `apps/web/components/docs/StorefrontHelpPanel.tsx` — renders the panel with a
+   "Back to page" affordance, above the doc content.
+3. `apps/web/app/(shell)/docs/[[...slug]]/page.tsx` — for storefront source
+   routes, loads the install's archetype vocabulary server-side and leads with the
+   panel; collapses the catalog when a panel is present.
+4. `apps/web/components/docs/DocsSidebar.tsx` + `DocsLayout.tsx` — the full area
+   catalog is now collapsible and defaults to collapsed when a help panel leads
+   (search stays visible). Cuts the initial ~82 nav links to a search box + one
+   "Browse all areas" toggle.
+
+## Verification
+
+- `apps/web/lib/docs/storefront-help-panel.test.ts` — route-level coverage for the
+  six required Docs links (dashboard, operations, team, catalog/items, sections,
+  inbox): each resolves a four-question panel; operations explains hours/timezone
+  change + recovery; team resolves the table-as-provider/staff confusion; items &
+  sections give generated-content recovery; Restaurant vocabulary (tables,
+  reservations, menu, hours, guests, availability) is preserved across the setup
+  journey; admin mirrors + leaf routes resolve; non-food archetype adapts; every
+  contextual href wires back to a panel.
+- `tsc --noEmit` clean; vitest green (30 tests across the panel + route-map suites).
+
+## Deliberately out of scope
+
+- In-product setup status / generated-content recovery UI → **BI-C39DC90C**.
+- Platform-wide docs density ceilings and the AI-workforce Advanced/Builder split
+  (the non-storefront half of BI-2DD18122).
+- Static user-guide markdown stays archetype-generic; the archetype-aware panel is
+  the vehicle for Restaurant vocabulary and recovery guidance on storefront routes.


### PR DESCRIPTION
## Summary

Storefront portion of **BI-2DD18122** (epic EP-UX-COGLOAD). Contextual **Docs** links from storefront routes now lead with a task-focused help panel instead of the ~82-link docs catalog. Each panel answers the four questions a non-technical owner has — **what is this / what to do next / what changes if I save or confirm / how do I recover or undo** — rendered through the install's own archetype vocabulary so a Restaurant install preserves *tables, reservations, menu, hours, guests, availability*. The full docs area catalog is collapsed/searchable by default when the panel leads.

Coordinates with **BI-C39DC90C** (in-product setup/recovery UX) — this PR is the Docs/help half only.

## Design grounding

Searched `docs/superpowers/specs/` and `docs/superpowers/plans/` — no existing spec owns this surface, so a new plan artifact was authored: `docs/superpowers/plans/2026-07-22-storefront-docs-help-panel.md`. The change is grounded in existing `apps/web/` substrate rather than inventing a new source of truth:
- `apps/web/lib/docs-route-map.ts` — existing `sourceRoute` + `docsPath` mapping; the panel keys off the same `sourceRoute` and mirrors its `docsPath`.
- `apps/web/lib/storefront/archetype-vocabulary.ts` (`getVocabulary`) — canonical archetype vocabulary; the panel renders through it, no new vocabulary source and no hardcoded "Restaurant".

New/changed under `apps/web/`:
- `apps/web/lib/docs/storefront-help-panel.ts` — pure resolver (route → four-question panel, archetype-aware).
- `apps/web/components/docs/StorefrontHelpPanel.tsx` — presentational panel.
- `apps/web/app/(shell)/docs/[[...slug]]/page.tsx` — loads vocab server-side, leads with the panel, collapses the catalog.
- `apps/web/components/docs/DocsSidebar.tsx` + `DocsLayout.tsx` — catalog collapsible, default-collapsed when a panel leads.

**Docs-Impact:** Plan added under `docs/superpowers/plans/`; user-guide markdown stays archetype-generic — the archetype-aware panel is the vehicle for Restaurant vocabulary and recovery guidance on storefront routes.

**Process-Spine-Decision:** Plan authored before commit; scope is the Storefront half of BI-2DD18122 only (platform-wide docs density ceilings and the AI-workforce Advanced/Builder split are out of scope here).

**Seed-Fit-Decision:** No seed or reference-data changes in this PR; not applicable.

## Overlap sweep

Swept open PRs and the coordinating branch `claude/restaurant-storefront-setup-recovery-345a07` (BI-C39DC90C). It touches `docs/user-guide/storefront/index.md` and its own plan file — **disjoint from this PR's files**. No conflicts.

## Test plan

- `apps/web/lib/docs/storefront-help-panel.test.ts` — route-level coverage for the six required Docs links (dashboard, operations, team, catalog/items, sections, inbox): four-question panel resolves; operations explains hours/timezone change + recovery; team resolves the table-as-provider/staff confusion; items & sections give generated-content recovery; Restaurant vocabulary preserved across the setup journey; admin mirrors + leaf routes resolve; non-food archetype adapts; contextual hrefs wire back to a panel.
- Local: `tsc --noEmit` clean (0 errors); vitest green (34 tests across panel + route-map + docs suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Docs-Impact-Decision: docs shell composition only — the /docs route change renders the storefront help panel and collapsed catalog; no user-guide page content changed, so docs/user-guide/index.md needs no edit.
