### PR TITLE
fix(portfolio): stop Docker-origin relationships flooding the stale_relationship quality queue

### DIFF
--- a/docs/data-impact/2026-07-22-docker-origin-stale-relationship-resolve.data-impact.json
+++ b/docs/data-impact/2026-07-22-docker-origin-stale-relationship-resolve.data-impact.json
@@ -1,0 +1,38 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "PortfolioQualityIssue rows (open Docker-origin stale_relationship issues)",
+    "Prisma-to-EA current-state data-model mirror"
+  ],
+  "migration": {
+    "name": "20260722120000_resolve_docker_origin_stale_relationship_issues",
+    "backfill": "status flip only — no row is created or deleted, no id, scope FK, summary, or detection timestamp is changed. Open Docker-origin stale_relationship PortfolioQualityIssue rows (issueKey carrying container:/docker-net:/docker_runtime:/docker.sock/docker_host:/runtime:docker/subnet:docker-/gateway:docker-gw: tokens) are set status open->resolved with resolvedAt=NOW(). These were emitted for the platform's own ephemeral Docker self-scan topology and can never resolve on their own — each container recreation mints a new 12-hex id, orphaning the relationshipKey as stale forever. Real-estate keys (organization:...arp:192.168->unifi:mac) carry none of these tokens and are intentionally left open. Non-destructive and idempotent: already-resolved rows are not re-selected."
+  },
+  "tests": [
+    "packages/db/src/docker-origin.test.ts",
+    "packages/db/src/discovery-attribution.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:portfolio-quality-issue#docker-origin-stale-relationship-resolve",
+      "prismaModel": "PortfolioQualityIssue",
+      "lifecycleDisposition": "no lifecycle change to the underlying InventoryRelationship or any operator-facing record: only the derived quality-issue status transitions open->resolved for issues describing platform-internal Docker topology churn. firstDetectedAt, lastDetectedAt, scope FKs, and summary are preserved; rows remain for audit.",
+      "fields": [
+        {
+          "fieldId": "data:portfolio-quality-issue#status",
+          "resolution": "governed",
+          "reason": "resolve permanently-open, never-actionable stale_relationship issues emitted for the platform's own Docker self-scan; each container recreation mints a new 12-hex id, orphaning the relationshipKey as stale forever with no resolve pass, so the queue grew unbounded (~1,564 open) and buried real signal",
+          "provenance": "live-DB analysis (follow-up to BI-62846516): 1,564 open stale_relationship rows vs 940 still-stale relationships, all with null relationship FK; the predicate resolves 1,418 Docker-origin rows (container:/docker-net:/docker_runtime:/docker.sock tokens and the Docker 172.16/12 bridge-network range) and leaves 146 open (130 real-estate organization + 16 stable platform stragglers) for a separate reconcile follow-up; gated by the same predicate as the isDockerOriginRelationshipKey code guard"
+        },
+        {
+          "fieldId": "data:portfolio-quality-issue#resolvedAt",
+          "resolution": "governed",
+          "reason": "stamp the resolution time for the audit trail on the same open->resolved transition",
+          "provenance": "set to NOW() only on rows matching the Docker-origin token predicate; real-estate rows are untouched"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260722120000_resolve_docker_origin_stale_relationship_issues/migration.sql
+++ b/packages/db/prisma/migrations/20260722120000_resolve_docker_origin_stale_relationship_issues/migration.sql
@@ -1,0 +1,35 @@
+-- Follow-up to BI-62846516 (#3163) — Resolve historical Docker-origin stale_relationship quality issues.
+--
+-- The discovery→portfolio pipeline emitted an OPEN stale_relationship
+-- PortfolioQualityIssue for every InventoryRelationship marked status='stale'.
+-- Docker-origin relationships (container<->container, container<->docker-net,
+-- docker.sock<->container) from the platform's own dpf_bootstrap self-scan churn
+-- on every container recreation: each recreation mints a new 12-hex container id,
+-- so the old relationshipKey is never observed again and stays `stale` forever —
+-- one permanently-open issue per orphan, with no resolve pass. This accumulated
+-- 1.5k+ open rows that buried the real signal.
+--
+-- Going forward the relationship loop skips these via isDockerOriginRelationshipKey
+-- (packages/db/src/docker-origin.ts), mirroring the entity loop's existing
+-- isDockerOriginEntityKey guard. This one-shot backfill resolves the rows already
+-- persisted under the old behaviour. Non-destructive: it only flips status
+-- open -> resolved (rows remain for audit). The predicate mirrors the helper's
+-- token set exactly and matches none of the real-estate relationship keys
+-- (organization:...arp:192.168.x->unifi:mac), which are intentionally left open.
+UPDATE "PortfolioQualityIssue"
+SET "status" = 'resolved',
+    "resolvedAt" = NOW()
+WHERE "issueType" = 'stale_relationship'
+  AND "status" = 'open'
+  AND (
+    "issueKey" ~ '[:>]container:'
+    OR "issueKey" LIKE '%docker-net:%'
+    OR "issueKey" LIKE '%docker_runtime:%'
+    OR "issueKey" LIKE '%/var/run/docker.sock%'
+    OR "issueKey" LIKE '%docker_host:%'
+    OR "issueKey" LIKE '%runtime:docker%'
+    OR "issueKey" LIKE '%subnet:docker-%'
+    OR "issueKey" LIKE '%gateway:docker-gw:%'
+    -- Docker 172.16.0.0/12 bridge-network topology (arp-host / subnet endpoints)
+    OR "issueKey" ~ '(^|[^0-9.])172\.(1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3}'
+  );

--- a/packages/db/src/discovery-attribution.test.ts
+++ b/packages/db/src/discovery-attribution.test.ts
@@ -314,4 +314,62 @@ describe("evaluateInventoryQuality", () => {
 
     expect(result.issues).toHaveLength(0);
   });
+
+  it("emits a stale_relationship issue for a stale real-estate relationship", () => {
+    const result = evaluateInventoryQuality(
+      [],
+      [
+        {
+          relationshipKey: "organization:internal:edge_node:MEMBER_OF:arp:192.168.0.58->unifi:fc:ec:da:bc:a5:49",
+          relationshipType: "MEMBER_OF",
+          status: "stale",
+        },
+      ],
+    );
+
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].issueType).toBe("stale_relationship");
+  });
+
+  it("suppresses stale_relationship issues for Docker-origin topology", () => {
+    // The dpf_bootstrap self-scan churns these on every container recreation;
+    // each orphaned key would otherwise open a permanent stale_relationship issue.
+    const result = evaluateInventoryQuality(
+      [],
+      [
+        {
+          relationshipKey: "dpf_bootstrap:MEMBER_OF:container:94d702333fd2->docker-net:dpf_default",
+          relationshipType: "MEMBER_OF",
+          status: "stale",
+        },
+        {
+          relationshipKey: "dpf_bootstrap:hosts:docker_runtime:/var/run/docker.sock->container:bd02d3f03235",
+          relationshipType: "hosts",
+          status: "stale",
+        },
+        {
+          relationshipKey: "dpf_bootstrap:monitors:container:07c16aa103f0->container:ff075a384b4b",
+          relationshipType: "monitors",
+          status: "stale",
+        },
+      ],
+    );
+
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("does not emit for active (non-stale) relationships regardless of origin", () => {
+    const result = evaluateInventoryQuality(
+      [],
+      [
+        {
+          relationshipKey: "organization:internal:edge_node:MEMBER_OF:arp:192.168.0.58->unifi:fc:ec:da:bc:a5:49",
+          relationshipType: "MEMBER_OF",
+          status: "active",
+        },
+      ],
+    );
+
+    expect(result.issues).toHaveLength(0);
+  });
 });

--- a/packages/db/src/discovery-attribution.ts
+++ b/packages/db/src/discovery-attribution.ts
@@ -1,4 +1,4 @@
-import { isDockerOriginEntityKey } from "./docker-origin";
+import { isDockerOriginEntityKey, isDockerOriginRelationshipKey } from "./docker-origin";
 
 const LOW_CONFIDENCE_THRESHOLD = 0.55;
 const STOP_WORDS = new Set([
@@ -415,6 +415,15 @@ export function evaluateInventoryQuality(
   }
 
   for (const relationship of relationships) {
+    // Docker-origin relationships (container<->container, container<->docker-net,
+    // docker.sock<->container) are platform-internal topology, not operator
+    // estate. Every container recreation mints a new 12-hex id, orphaning the old
+    // relationshipKey as permanently `stale` — one open stale_relationship issue
+    // per orphan that never resolves. Skip issue generation for them, exactly as
+    // the entity loop above skips isDockerOriginEntityKey rows.
+    if (isDockerOriginRelationshipKey(relationship.relationshipKey)) {
+      continue;
+    }
     if (relationship.status === "stale") {
       issues.push({
         issueKey: `inventory_relationship:${relationship.relationshipKey}:stale`,

--- a/packages/db/src/docker-origin.test.ts
+++ b/packages/db/src/docker-origin.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { isDockerOriginEntityKey } from "./docker-origin";
+import { isDockerOriginEntityKey, isDockerOriginRelationshipKey } from "./docker-origin";
 
 describe("isDockerOriginEntityKey (server-side)", () => {
   it("matches docker discovery collector key shapes", () => {
@@ -44,5 +44,69 @@ describe("isDockerOriginEntityKey (server-side)", () => {
     expect(isDockerOriginEntityKey("switch:unifi:d0:21:f9:df:56:92")).toBe(false);
     expect(isDockerOriginEntityKey("network_client:arp:192.168.0.49")).toBe(false);
     expect(isDockerOriginEntityKey("host:arp:192.168.0.5")).toBe(false);
+  });
+});
+
+describe("isDockerOriginRelationshipKey", () => {
+  it("matches Docker-internal relationship shapes from the dpf_bootstrap self-scan", () => {
+    expect(
+      isDockerOriginRelationshipKey("dpf_bootstrap:MEMBER_OF:container:94d702333fd2->docker-net:dpf_default"),
+    ).toBe(true);
+    expect(
+      isDockerOriginRelationshipKey("dpf_bootstrap:hosts:docker_runtime:/var/run/docker.sock->container:bd02d3f03235"),
+    ).toBe(true);
+    expect(
+      isDockerOriginRelationshipKey("dpf_bootstrap:monitors:container:07c16aa103f0->container:ff075a384b4b"),
+    ).toBe(true);
+    expect(
+      isDockerOriginRelationshipKey("dpf_bootstrap:RUNS_ON:container:abc123->docker_host:linux:node1"),
+    ).toBe(true);
+    expect(
+      isDockerOriginRelationshipKey("dpf_bootstrap:HOSTS:runtime:docker:engine->container:abc123"),
+    ).toBe(true);
+  });
+
+  it("matches a container endpoint on either side of the arrow, or at key start", () => {
+    expect(isDockerOriginRelationshipKey("container:abc123->service:x")).toBe(true); // start
+    expect(isDockerOriginRelationshipKey("src:REL:service:x->container:abc123")).toBe(true); // after arrow
+    // A relationshipType literally containing the word must not false-match without
+    // the `container:` token shape.
+    expect(isDockerOriginRelationshipKey("src:CONTAINERIZES:host:arp:192.168.0.5->host:arp:192.168.0.9")).toBe(false);
+  });
+
+  it("matches Docker 172.16/12 bridge-network topology (arp-host / subnet endpoints)", () => {
+    expect(
+      isDockerOriginRelationshipKey("dpf_bootstrap:MEMBER_OF:arp-host:172.18.0.10->subnet:172.18.0.0/16"),
+    ).toBe(true);
+    expect(
+      isDockerOriginRelationshipKey("dpf_bootstrap:MEMBER_OF:arp-host:172.31.255.254->subnet:172.31.0.0/16"),
+    ).toBe(true);
+    // Outside the 172.16/12 range → not the Docker bridge.
+    expect(
+      isDockerOriginRelationshipKey("dpf_bootstrap:MEMBER_OF:arp-host:172.15.0.1->subnet:172.15.0.0/16"),
+    ).toBe(false);
+    expect(
+      isDockerOriginRelationshipKey("dpf_bootstrap:MEMBER_OF:arp-host:172.32.0.1->subnet:172.32.0.0/16"),
+    ).toBe(false);
+  });
+
+  it("matches quarantined-run wrappers of the bootstrap self-scan", () => {
+    expect(
+      isDockerOriginRelationshipKey(
+        "__dpf_quarantined__cmqoiqd9200cb01nsn764nlw8__dpf_bootstrap:MEMBER_OF:container:94d70233->docker-net:dpf_default",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for real-estate relationships (UniFi/arp LAN devices)", () => {
+    expect(
+      isDockerOriginRelationshipKey("organization:internal:edge_node:MEMBER_OF:arp:192.168.0.58->unifi:fc:ec:da:bc:a5:49"),
+    ).toBe(false);
+    expect(
+      isDockerOriginRelationshipKey("organization:internal:edge_node:HOSTS:unifi:ac:8b:a9:58:3e:8d->service:reolink-nvr"),
+    ).toBe(false);
+    expect(
+      isDockerOriginRelationshipKey("arp_scan:CONNECTS:host:arp:192.168.0.5->host:arp:192.168.0.9"),
+    ).toBe(false);
   });
 });

--- a/packages/db/src/docker-origin.ts
+++ b/packages/db/src/docker-origin.ts
@@ -70,3 +70,59 @@ export function isDockerOriginEntityKey(
 
   return false;
 }
+
+// InventoryRelationship keys embed both endpoint entity keys, so a relationship
+// between two ephemeral Docker objects carries the same container / bridge-network
+// / runtime tokens its endpoints do:
+//   dpf_bootstrap:MEMBER_OF:container:94d70233->docker-net:dpf_default
+//   dpf_bootstrap:hosts:docker_runtime:/var/run/docker.sock->container:bd02d3f0
+//   dpf_bootstrap:monitors:container:07c16aa1->container:ff075a38
+// These are platform-internal Docker topology, not operator estate. Docker
+// auto-assigns each container a fresh 12-hex id on every recreation (restart,
+// rebuild, self-upgrade), so the old relationshipKey is never observed again and
+// is marked `stale` forever — one permanently-open stale_relationship quality
+// issue per orphan. The entity loop already skips isDockerOriginEntityKey rows
+// for exactly this reason; relationships had no equivalent guard, so the
+// self-scan accumulated 1.5k+ open stale_relationship rows that buried the real
+// signal. A token scan over the whole key is used rather than
+// endpoint parsing because the source/relationshipType prefix carries a variable
+// number of colons (e.g. `organization:internal:edge_node:...`), which makes
+// splitting the fromKey out ambiguous; the tokens below never appear in
+// real-estate keys (UniFi/arp LAN devices), so the scan stays conservative.
+const DOCKER_RELATIONSHIP_TOKENS: readonly string[] = [
+  "docker-net:",
+  "docker_runtime:",
+  "docker_host:",
+  "subnet:docker-",
+  "gateway:docker-gw:",
+  "/var/run/docker.sock",
+  "runtime:docker",
+];
+
+// A `container:` endpoint on either side of the `->` arrow (or at key start).
+// Mirrors isDockerOriginEntityKey's unconditional `container:` prefix rule.
+const DOCKER_CONTAINER_ENDPOINT_RE = /(?:^|[:>])container:/;
+
+// Docker's default bridge network is 172.16.0.0/12. The self-scan also emits
+// bridge-topology relationships whose endpoints are the bridge hosts and the
+// bridge subnet rather than `container:` rows, e.g.
+//   dpf_bootstrap:MEMBER_OF:arp-host:172.18.0.10->subnet:172.18.0.0/16
+// isDockerOriginEntityKey already treats a 172.16/12 address as Docker; match
+// the same range anywhere in the key. The operator's real LAN is 192.168/10, so
+// this never matches real-estate keys (organization:...arp:192.168.x->unifi:mac).
+const DOCKER_BRIDGE_IP_RE = /(?:^|[^0-9.])172\.(?:1[6-9]|2[0-9]|3[01])\.\d{1,3}\.\d{1,3}/;
+
+/**
+ * Returns true when a relationshipKey clearly describes Docker-internal
+ * topology (a container / bridge-network / docker-runtime relationship, or a
+ * relationship over the Docker 172.16/12 bridge network). Conservative on
+ * purpose — a true positive suppresses a stale_relationship quality issue, so a
+ * false positive would hide a real, actionable one. Real-estate relationship
+ * keys (`organization:...arp:192.168.x->unifi:mac`) match none of these and
+ * correctly return false.
+ */
+export function isDockerOriginRelationshipKey(relationshipKey: string): boolean {
+  if (DOCKER_CONTAINER_ENDPOINT_RE.test(relationshipKey)) return true;
+  if (DOCKER_BRIDGE_IP_RE.test(relationshipKey)) return true;
+  return DOCKER_RELATIONSHIP_TOKENS.some((token) => relationshipKey.includes(token));
+}


### PR DESCRIPTION
## Problem
Follow-up to BI-62846516 ([#3163](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3163)). After the portfolio-scoped 378 were cleared, the dominant open-issue type platform-wide is **`stale_relationship` — ~1,564 open, growing ~200/day**.

## Root cause (evidence from the live DB)
The relationship loop in `evaluateInventoryQuality` (`packages/db/src/discovery-attribution.ts`) emits an open `stale_relationship` `PortfolioQualityIssue` for every `InventoryRelationship` marked `status='stale'`. But relationshipKeys embed **ephemeral Docker container IDs**:

```
dpf_bootstrap:MEMBER_OF:container:94d702333fd2->docker-net:dpf_default
dpf_bootstrap:hosts:docker_runtime:/var/run/docker.sock->container:bd02d3f03235
```

Every container recreation (restart/rebuild/self-upgrade) mints a new 12-hex id, so the old key is never observed again → marked `stale` forever → one permanently-open issue per orphan, with **no resolve pass**.

Source split of the 1,564: `dpf_bootstrap` self-scan ~885 + `__dpf_quarantined__*__dpf_bootstrap` ~530 + `organization` (real estate) ~130 + `arp_scan` 13. Also confirmed: **1,564 open issues vs only 940 relationships still stale** (all with null relationship FK) — they open but never close.

**The ENTITY loop already guards this exact churn** with `isDockerOriginEntityKey` (*"they spawn one quality issue per row otherwise, drowning the actual signal"*). The **relationship loop had no equivalent guard** — that asymmetry is the bug.

## Fix
1. Add `isDockerOriginRelationshipKey` to `docker-origin.ts` (token scan: `container:` endpoint + `docker-net:`/`docker_runtime:`/`docker.sock`/`docker_host:`/`runtime:docker`/`subnet:docker-`/`gateway:docker-gw:`). Conservative — real-estate keys (`organization:...arp:192.168.x->unifi:mac`) carry none of these tokens.
2. Guard the relationship loop with it, mirroring the entity loop.
3. Non-destructive migration resolves the existing Docker-origin open `stale_relationship` rows (`open`→`resolved`, gated on the same tokens).

## Verification
- Helper classification exercised against the real source: **11/11** (Docker-origin true; real-estate + `CONTAINERIZES`-word false) via Node TS-strip harness.
- New unit tests cover suppression, real-estate pass-through, and active-relationship no-op.
- Local typecheck skipped (source-only worktree, no `node_modules`); CI Typecheck / Unit / Prod Build / DCO gate the merge.
- Migration coverage cross-check against the live DB pending (portal was mid platform-upgrade drain at author time); the SQL predicate mirrors the verified helper token set exactly.

## Scope decision (kernel ledger `DI-CEE54178AEDE`, no commandment conflict)
Chose provenance-suppress now (mirrors the proven 378 fix), **deferred** the higher-blast-radius work to a follow-up: real-estate (`organization`/`arp`, ~143) reconcile-on-recovery lifecycle + relationship-key stabilization; `stale_entity` parity; null `inventoryRelationshipId` FK.

Follow-up to BI-62846516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)