### PR TITLE
feat(attention): honest AI attribution — resolver, byline, retire "your COO recommends" (BI-AB12B3D3, BI-90CC785C)

### DIFF
--- a/apps/web/components/attention/OwnerDecisionCards.test.tsx
+++ b/apps/web/components/attention/OwnerDecisionCards.test.tsx
@@ -35,7 +35,7 @@ const entry: OwnerAttentionEntry = {
     whyItMatters: "Paying the right bills on time keeps your business supplied.",
     ifYouDoNothing: "If you do nothing, the bill may become late.",
     recommendation: {
-      lead: "Your COO recommends",
+      lead: "AI recommendation",
       text: "review the amount and recipient, then approve it if both are right.",
       specialistByline: "Finance",
     },
@@ -71,7 +71,7 @@ describe("OwnerDecisionCards", () => {
     expect(screen.getByText(/Paying the right bills/)).toBeTruthy();
     expect(screen.getByText(/If you do nothing/)).toBeTruthy();
     expect(screen.getByText(/the bill may become late/)).toBeTruthy();
-    expect(screen.getByText("Your COO recommends")).toBeTruthy();
+    expect(screen.getByText("AI recommendation")).toBeTruthy();
     expect(screen.getByText("Finance")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Review bill" }).getAttribute("href")).toBe(
       "/finance/bills",

--- a/apps/web/components/attention/OwnerDecisionCards.tsx
+++ b/apps/web/components/attention/OwnerDecisionCards.tsx
@@ -95,6 +95,11 @@ function DecisionSummary({ entry }: { entry: OwnerAttentionEntry }) {
             {capitalize(card.recommendation.text)}
           </span>
         </span>
+        {card.byline ? (
+          <span className="block text-[10px] text-[var(--dpf-muted)]" title="Who produced this — AI-labeled; a role is a presentation label, not an accountable person.">
+            {card.byline}
+          </span>
+        ) : null}
       </span>
 
       <span className="mt-2 block text-[11px] font-medium text-[var(--dpf-muted)]">

--- a/apps/web/components/attention/WeeklyDigestPanel.test.tsx
+++ b/apps/web/components/attention/WeeklyDigestPanel.test.tsx
@@ -48,7 +48,7 @@ const entry = {
     whyItMatters: "This may improve customer work.",
     ifYouDoNothing: "If you do nothing, it waits.",
     recommendation: {
-      lead: "Your COO recommends",
+      lead: "AI recommendation",
       text: "review this with the weekly batch.",
       specialistByline: "Research",
     },

--- a/apps/web/components/customer-marketing/ApprovalQueuePanel.tsx
+++ b/apps/web/components/customer-marketing/ApprovalQueuePanel.tsx
@@ -1,3 +1,4 @@
+import { resolveAgentRoleLabel } from "@dpf/db/agent-identity";
 import type { InboundMessageRow, OutboundDraftRow } from "@/lib/marketing";
 import { formatMarketingLabel } from "@/lib/marketing";
 import { assessArchetypeFit } from "@/lib/marketing/archetype-fit";
@@ -86,7 +87,7 @@ function DraftRow({
               {statusLabel(draft.status)}
             </span>
             <span>
-              Drafted by {draft.createdByAgentId ?? "unknown"} · {timeAgo(draft.createdAt)}
+              AI-drafted by your {resolveAgentRoleLabel(draft.createdByAgentId)} · {timeAgo(draft.createdAt)}
             </span>
             <ArchetypeFitBadge assessment={fit} />
           </div>

--- a/apps/web/components/platform/SkillProposalsPanel.tsx
+++ b/apps/web/components/platform/SkillProposalsPanel.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useState, useTransition } from "react";
 import type { CSSProperties } from "react";
+import { resolveAgentRoleLabel } from "@dpf/db/agent-identity";
 
 import type { SkillProposalRow } from "@/lib/skills/proposals";
 import {
@@ -142,8 +143,7 @@ function ProposalRow({
             </p>
           )}
           <p style={{ fontSize: 11, color: "var(--dpf-muted)", margin: "0 0 12px 0" }}>
-            Submitted by <code>{proposal.submittedById}</code> via <code>{proposal.agentId}</code>
-            {proposal.threadId ? <> · thread <code>{proposal.threadId}</code></> : null}
+            AI-proposed by your {resolveAgentRoleLabel(proposal.agentId)}
           </p>
 
           <SimpleDiff current={currentContent} proposed={proposal.proposedContent} />

--- a/apps/web/components/workspace-home/OperatorCockpit.test.tsx
+++ b/apps/web/components/workspace-home/OperatorCockpit.test.tsx
@@ -46,7 +46,7 @@ describe("OperatorCockpitView", () => {
     expect(html).toContain("2 things need you today");
     expect(html).toContain("Approve this bill?");
     expect(html).toContain("Send this message?");
-    expect(html).toContain("Your COO recommends");
+    expect(html).toContain("AI recommendation");
     expect(html).not.toContain("3040");
     expect(html).not.toContain("high-risk");
   });

--- a/apps/web/lib/attention/attribution.test.ts
+++ b/apps/web/lib/attention/attribution.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { attentionAuthorForAgent, formatAttentionByline } from "./attribution";
+
+describe("attentionAuthorForAgent (BI-AB12B3D3)", () => {
+  it("resolves a role label for a known agent, never a persona name", () => {
+    const author = attentionAuthorForAgent("coo");
+    expect(author.roleLabel).toBe("COO");
+    expect(author.roleLabel.toLowerCase()).not.toContain("jiminy");
+  });
+
+  it("derives a role label for an unknown agent", () => {
+    expect(attentionAuthorForAgent("marketing-specialist").roleLabel).toBe("Marketing");
+  });
+
+  it("falls back to a generic AI label when the agent is missing", () => {
+    expect(attentionAuthorForAgent(null).roleLabel).toBe("an AI coworker");
+    expect(attentionAuthorForAgent(undefined).roleLabel).toBe("an AI coworker");
+  });
+
+  it("carries the AI client and trust level when provided", () => {
+    const author = attentionAuthorForAgent("coo", { aiClient: "Claude", trustLevel: "L1" });
+    expect(author.aiClient).toBe("Claude");
+    expect(author.trustLevel).toBe("L1");
+  });
+});
+
+describe("formatAttentionByline (BI-AB12B3D3)", () => {
+  it("is always AI-labeled and never implies a human decided", () => {
+    const line = formatAttentionByline({ roleLabel: "COO" });
+    expect(line.startsWith("AI ·")).toBe(true);
+    expect(line).toBe("AI · your COO");
+    expect(line).not.toContain("decided");
+  });
+
+  it("appends the AI client when known", () => {
+    expect(formatAttentionByline({ roleLabel: "COO", aiClient: "Claude" })).toBe(
+      "AI · your COO · Claude",
+    );
+  });
+
+  it("degrades to a generic AI label when there is no author", () => {
+    expect(formatAttentionByline(undefined)).toBe("AI coworker");
+    expect(formatAttentionByline(null)).toBe("AI coworker");
+  });
+});

--- a/apps/web/lib/attention/attribution.ts
+++ b/apps/web/lib/attention/attribution.ts
@@ -1,0 +1,35 @@
+// Honest attribution for attention items (BI-AB12B3D3; ratified contract BI-7D29937E,
+// spec docs/superpowers/specs/2026-07-18-coo-persona-attribution-contract-design.md).
+//
+// The byline attributes to the accountable (human × client × session) identity,
+// presented via a thin ROLE label resolved through the ONE resolver
+// (resolveAgentRoleLabel). It is ALWAYS AI-labeled, never a persona name, and never
+// implies a human accountable party the attribution spine cannot produce on demand.
+// Composes with the honest-attention-surface anti-fabrication rule
+// (2026-06-23-human-attention-surface-design.md).
+
+import { resolveAgentRoleLabel } from "@dpf/db/agent-identity";
+import type { AttentionAuthor } from "./types";
+
+/** Build an AttentionAuthor from a coworker agentId. Role is a thin label over the
+ *  accountable identity, resolved through the single source of truth. */
+export function attentionAuthorForAgent(
+  agentId: string | null | undefined,
+  extra?: { aiClient?: string; trustLevel?: string },
+): AttentionAuthor {
+  return {
+    roleLabel: resolveAgentRoleLabel(agentId),
+    ...(extra?.aiClient ? { aiClient: extra.aiClient } : {}),
+    ...(extra?.trustLevel ? { trustLevel: extra.trustLevel } : {}),
+  };
+}
+
+/** The honest byline for an agent-authored item. AI-labeled first, role as a thin
+ *  presentation label, AI client appended when known. Never implies a human
+ *  decided — e.g. "AI · your COO · Claude", never "your COO decided". */
+export function formatAttentionByline(author: AttentionAuthor | undefined | null): string {
+  if (!author) return "AI coworker";
+  const parts = [`AI · your ${author.roleLabel}`];
+  if (author.aiClient) parts.push(author.aiClient);
+  return parts.join(" · ");
+}

--- a/apps/web/lib/attention/owner-decision.test.ts
+++ b/apps/web/lib/attention/owner-decision.test.ts
@@ -37,7 +37,7 @@ describe("translateAttentionToOwnerDecision", () => {
     expect(card.headline).not.toMatch(/\b(AI|API|DB|GPU|CI|CD)\b/);
     expect(card.whyItMatters).toMatch(/business|customer|team|work/i);
     expect(card.ifYouDoNothing.length).toBeGreaterThan(10);
-    expect(card.recommendation.lead).toBe("Your COO recommends");
+    expect(card.recommendation.lead).toBe("AI recommendation");
     expect(card.recommendation.specialistByline).toBe("Platform operations");
   });
 

--- a/apps/web/lib/attention/owner-decision.ts
+++ b/apps/web/lib/attention/owner-decision.ts
@@ -8,6 +8,7 @@ import {
   whyItMattersFor,
 } from "./owner-decision-copy";
 import { builderActions, technicalFields } from "./owner-technical-detail";
+import { formatAttentionByline } from "./attribution";
 
 export type OwnerDecisionTag = {
   label: string;
@@ -30,10 +31,17 @@ export type OwnerDecisionCard = {
   whyItMatters: string;
   ifYouDoNothing: string;
   recommendation: {
-    lead: "Your COO recommends";
+    /** Honest, AI-labeled lead (BI-AB12B3D3 / ratified BI-7D29937E): the platform
+     *  recommends, presented as AI — NOT "your COO decided". A role is a thin
+     *  presentation label (specialistByline), never the accountable actor. */
+    lead: "AI recommendation";
     text: string;
     specialistByline: string;
   };
+  /** Honest attribution byline for an AI-authored item — AI-labeled, role as a
+   *  thin label over the accountable identity (BI-AB12B3D3). Absent when the item
+   *  has no single AI author. */
+  byline?: string;
   choices: OwnerDecisionChoice[];
   tags: OwnerDecisionTag[];
   technical: {
@@ -54,10 +62,11 @@ export function translateAttentionToOwnerDecision(
     whyItMatters: whyItMattersFor(item),
     ifYouDoNothing: consequenceFor(item),
     recommendation: {
-      lead: "Your COO recommends",
+      lead: "AI recommendation",
       text: recommendationFor(item),
       specialistByline: specialistFor(item.source),
     },
+    ...(item.author ? { byline: formatAttentionByline(item.author) } : {}),
     choices: ownerChoices(item),
     tags: tagsFor(item, nowMs),
     technical: {

--- a/apps/web/lib/attention/sources/agent-proposal.ts
+++ b/apps/web/lib/attention/sources/agent-proposal.ts
@@ -9,6 +9,7 @@ import {
   parseProactivityChangeProposalParameters,
 } from "@/lib/proactivity/proactivity-change-proposal";
 import { getProactivityLevelCopy } from "@/lib/proactivity/proactivity-copy";
+import { attentionAuthorForAgent } from "../attribution";
 import type { AttentionItem } from "../types";
 
 type Db = typeof prisma;
@@ -18,6 +19,8 @@ export type AgentActionProposalRow = {
   actionType: string;
   parameters: unknown;
   proposedAt: Date;
+  /** The coworker that proposed this — drives the honest byline (BI-AB12B3D3). */
+  agentId: string;
 };
 
 /** Pure projection of one proposed agent action into an attention item. */
@@ -70,6 +73,7 @@ export function agentProposalToAttentionItem(row: AgentActionProposalRow): Atten
         }:${proactivityChange.currentLevel}`,
       },
       technical: { detectedBy: proactivityChange.agentId ?? "AI workforce" },
+      author: attentionAuthorForAgent(proactivityChange.agentId ?? row.agentId),
     };
   }
 
@@ -97,6 +101,7 @@ export function agentProposalToAttentionItem(row: AgentActionProposalRow): Atten
     }],
     deepLink: isActivityRoutingAction ? "/platform/ai/operations-map" : "/platform/ai",
     audience: { operator: true },
+    author: attentionAuthorForAgent(row.agentId),
   };
 }
 
@@ -105,7 +110,7 @@ export async function loadAgentProposalItems(db: Db): Promise<AttentionItem[]> {
     where: { status: "proposed" },
     orderBy: { proposedAt: "desc" },
     take: 50,
-    select: { proposalId: true, actionType: true, parameters: true, proposedAt: true },
+    select: { proposalId: true, actionType: true, parameters: true, proposedAt: true, agentId: true },
   });
   return rows.map(agentProposalToAttentionItem);
 }

--- a/apps/web/lib/attention/sources/paused-ai.ts
+++ b/apps/web/lib/attention/sources/paused-ai.ts
@@ -6,6 +6,7 @@
 
 import type { prisma } from "@dpf/db";
 import { isProactivityLevel } from "@/lib/proactivity/proactivity-types";
+import { attentionAuthorForAgent } from "../attribution";
 import type { AttentionItem, AttentionRiskClass } from "../types";
 
 type Db = typeof prisma;
@@ -65,6 +66,7 @@ function readProactivity(meta: unknown): AttentionItem["proactivity"] {
 export function pausedAiToAttentionItem(row: TaskRunRow): AttentionItem {
   const authRequired = row.status === "auth-required";
   const risk = readRisk(row.a2aMetadata);
+  const proactivity = readProactivity(row.a2aMetadata);
   return {
     id: `paused-ai:${row.taskRunId}`,
     source: "paused-ai",
@@ -91,7 +93,8 @@ export function pausedAiToAttentionItem(row: TaskRunRow): AttentionItem {
     ],
     deepLink: "/platform/ai/operations-map",
     audience: { operator: true, assigneePrincipalId: row.userId },
-    proactivity: readProactivity(row.a2aMetadata),
+    proactivity: proactivity,
+    ...(proactivity?.actorId ? { author: attentionAuthorForAgent(proactivity.actorId) } : {}),
   };
 }
 

--- a/apps/web/lib/attention/sources/sources.test.ts
+++ b/apps/web/lib/attention/sources/sources.test.ts
@@ -167,18 +167,22 @@ describe("agentProposalToAttentionItem", () => {
       actionType: "create_invoice",
       parameters: {},
       proposedAt: new Date("2026-06-23T07:00:00.000Z"),
+      agentId: "coo",
     };
     const item = agentProposalToAttentionItem(row);
     expect(item.id).toBe("agent-proposal:AP-1");
     expect(item.title).toBe("Approve: Create invoice");
     expect(item.triage.residueReason).toBe("policy-approval");
     expect(item.decisionClass.scorability).toBe("unscorable");
+    // BI-AB12B3D3: attributed by ROLE, never a persona name.
+    expect(item.author?.roleLabel).toBe("COO");
   });
 
   it("projects an activity-harness proposal with routing-specific context", () => {
     const item = agentProposalToAttentionItem({
       proposalId: "AP-ROUTE",
       actionType: "activity_harness_confidence_override",
+      agentId: "platform-engineer",
       parameters: {
         kind: "activity-harness-confidence-override",
         activityClass: "code-edit",
@@ -201,6 +205,7 @@ describe("agentProposalToAttentionItem", () => {
     const item = agentProposalToAttentionItem({
       proposalId: "AP-PROACTIVE",
       actionType: "propose_proactivity_change",
+      agentId: "coo",
       parameters: {
         kind: "proactivity-change",
         agentId: "dispatcher",

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -123,6 +123,20 @@ export type AttentionProactivity = {
   policyId?: string;
 };
 
+/** Honest attribution for an agent-authored item (BI-AB12B3D3, ratified contract
+ * BI-7D29937E). The byline attributes to the accountable (human × client × session)
+ * identity, presented via a thin ROLE label — NEVER a persona name, and never
+ * implying a human accountable party the attribution spine can't produce. Always
+ * AI-labeled at render (see formatAttentionByline in ./attribution). */
+export type AttentionAuthor = {
+  /** Role-based presentation label (via resolveAgentRoleLabel), never a persona name. */
+  roleLabel: string;
+  /** The AI client that produced the work (Claude / Codex / Grok), when known. */
+  aiClient?: string;
+  /** Trust level (L0–L3) at which it was produced, when known. */
+  trustLevel?: string;
+};
+
 export type AttentionItem = {
   /** Stable per source row, e.g. "escalation:PIR-…", "ai-decision:DI-…". */
   id: string;
@@ -152,4 +166,7 @@ export type AttentionItem = {
   proactivity?: AttentionProactivity;
   /** Builder-grade facts preserved for progressive disclosure. */
   technical?: AttentionTechnicalMetadata;
+  /** Honest attribution when an AI coworker produced this item (BI-AB12B3D3).
+   * Absent for items with no single AI author (e.g. a bill awaiting approval). */
+  author?: AttentionAuthor;
 };

--- a/packages/db/src/agent-identity.ts
+++ b/packages/db/src/agent-identity.ts
@@ -125,6 +125,23 @@ export function deriveAgentDisplayName(source: string): string {
   return tokens.map(titleCaseToken).join(" ");
 }
 
+/**
+ * The ONE user-facing agent-attribution resolver (BI-90CC785C). Given any agentId
+ * or slug, return the role-based display LABEL — override first, else Title-Case
+ * derivation. No raw agentId should ever reach the UI: every surface that shows
+ * "who" an AI coworker is routes through here, so there is a single source of truth
+ * for the role label. Pure + client-safe. Never returns a human persona name
+ * (the ratified role-only contract, BI-7D29937E).
+ */
+export function resolveAgentRoleLabel(agentIdOrSlug: string | null | undefined): string {
+  if (!agentIdOrSlug || !agentIdOrSlug.trim()) return "an AI coworker";
+  const raw = agentIdOrSlug.trim();
+  const canonical = resolveCanonicalAgentId(raw);
+  const override =
+    AGENT_IDENTITY_OVERRIDES[raw]?.displayName ?? AGENT_IDENTITY_OVERRIDES[canonical]?.displayName;
+  return override ?? deriveAgentDisplayName(raw);
+}
+
 /** Derive the role-kind from the name / id / tier. */
 export function deriveAgentKind(source: string, agentId: string, tier?: string): AgentKind {
   const s = source.toLowerCase();


### PR DESCRIPTION
Implements the two follow-on BIs of the ratified persona/attribution contract ([#3252](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3252), `BI-7D29937E`): recommendations attribute to the accountable identity via a **thin role label**, always **AI-labeled**, never a persona and never implying a human decided.

## `BI-90CC785C` — one resolver + kill raw-agentId leaks
- **`resolveAgentRoleLabel(agentIdOrSlug)`** in `agent-identity.ts` — the single user-facing resolver (override → derive), never a persona name, pure/client-safe.
- **ApprovalQueuePanel**: `Drafted by {raw agentId}` → `AI-drafted by your {roleLabel}`.
- **SkillProposalsPanel**: `Submitted by {submittedById} via {agentId}` → `AI-proposed by your {roleLabel}`. Raw ids no longer reach the UI.

## `BI-AB12B3D3` — author + honest byline
- `AttentionItem` gains an optional **`author`** (role label + AI client + trust level); new **`attribution.ts`** builds it and formats the byline (`AI · your COO · Claude`, never *"your COO decided"*). Unit-tested.
- Projectors populate `author`: **agent-proposal**, **paused-ai**.
- **OwnerDecisionCard**: recommendation lead `"Your COO recommends"` → **`"AI recommendation"`** — the role-as-accountable-actor phrasing was precisely what the contract rejects — and renders the byline.

## Verification
- **vitest green: 75/75**, including the new `attribution` suite and the updated owner-decision tests.
- ⚠️ Local `tsc` reports `resolveAgentRoleLabel` "not exported" **only** because this worktree's `node_modules/@dpf/db` symlinks to a *sibling* worktree lacking this commit (known @dpf-resolves-to-sibling gotcha). CI typechecks the repo's own `packages/db`, so **CI Typecheck / Prod Build / Unit gate the merge.** The `next/*` tsc noise is the typegen-not-run worktree artifact.

Completes the ratified contract implementation under EP-COWORKER-INTERACTIVITY (keystone `BI-9EC69381` merged in #3264).