### PR TITLE
feat(finance): subtype money jobs for Restaurant, Catering & Bakery (BI-3326DA86)

### DIFF
--- a/apps/web/app/(shell)/finance/invoices/new/page.tsx
+++ b/apps/web/app/(shell)/finance/invoices/new/page.tsx
@@ -43,8 +43,9 @@ export default async function NewInvoicePage({ searchParams }: Props) {
   );
 
   const category = storefront?.archetype?.category ?? null;
-  const surface = resolveFinanceSurface(category);
-  const copy = resolveFinanceInvoiceCopy(category);
+  const archetypeId = storefront?.archetype?.archetypeId ?? null;
+  const surface = resolveFinanceSurface(category, archetypeId);
+  const copy = resolveFinanceInvoiceCopy(category, archetypeId);
 
   // When the form is opened from a Restaurant billing context (?from=booking …),
   // lead with that context's framing instead of the generic customer-first copy.
@@ -52,12 +53,14 @@ export default async function NewInvoicePage({ searchParams }: Props) {
   const contextCopy = context ? copy.contexts[context] : null;
   const heading = contextCopy?.title ?? "New Invoice";
   const subhead = contextCopy?.description ?? copy.newInvoiceSubhead;
-  const contextLabel =
-    context && context !== "no-show"
-      ? surface.invoiceEntryPoints.find((entry) => entry.id === context)?.label ?? null
-      : context === "no-show"
-        ? "No-show fee"
-        : null;
+  // Prefer the subtype's own entry-point label; fall back to the context copy
+  // title for contexts that are money-job actions rather than entry points
+  // (e.g. no-show), and to no badge at all for an unmapped context.
+  const contextLabel = context
+    ? surface.invoiceEntryPoints.find((entry) => entry.id === context)?.label ??
+      contextCopy?.title ??
+      null
+    : null;
 
   return (
     <div>

--- a/apps/web/app/(shell)/finance/page.tsx
+++ b/apps/web/app/(shell)/finance/page.tsx
@@ -155,13 +155,17 @@ export default async function FinancePage() {
     // Org settings — for base currency
     getOrgSettings(),
 
-    // Storefront archetype — drives the owner-first (food-hospitality) surface
+    // Storefront archetype — category drives the owner-first (food-hospitality)
+    // surface; archetypeId narrows it to the subtype (restaurant/catering/bakery).
     prisma.storefrontConfig.findFirst({
-      select: { archetype: { select: { category: true } } },
+      select: { archetype: { select: { category: true, archetypeId: true } } },
     }),
   ]);
 
-  const financeSurface = resolveFinanceSurface(storefrontConfig?.archetype.category);
+  const financeSurface = resolveFinanceSurface(
+    storefrontConfig?.archetype.category,
+    storefrontConfig?.archetype.archetypeId,
+  );
 
   const sym = getCurrencySymbol(orgSettings.baseCurrency);
 

--- a/apps/web/components/finance/OwnerFirstFinanceView.test.tsx
+++ b/apps/web/components/finance/OwnerFirstFinanceView.test.tsx
@@ -20,7 +20,7 @@ vi.mock("next/link", () => ({
 import { OwnerFirstFinanceView, type MoneyJobMetric } from "./OwnerFirstFinanceView";
 import { resolveFinanceSurface, type FinanceMetricKey } from "@/lib/finance/finance-surface";
 
-const surface = resolveFinanceSurface("food-hospitality");
+const surface = resolveFinanceSurface("food-hospitality", "restaurant");
 
 const metrics: Partial<Record<FinanceMetricKey, MoneyJobMetric>> = {
   "outstanding-receivables": { value: "£1,250.00", hint: "3 invoices outstanding" },
@@ -82,6 +82,33 @@ describe("OwnerFirstFinanceView", () => {
     // The internals live under a collapsed <details> summary, not at the top.
     expect(html).toContain("<details");
     expect(html).toContain("<summary");
+  });
+
+  it("renders Catering money jobs for a catering install, not Restaurant ones", () => {
+    const html = renderToStaticMarkup(
+      <OwnerFirstFinanceView
+        surface={resolveFinanceSurface("food-hospitality", "catering")}
+        metrics={metrics}
+      />,
+    );
+    expect(html).toContain("Event deposits &amp; balances");
+    expect(html).toContain("Quote a catering job");
+    expect(html).toContain("Ingredient &amp; staffing bills");
+    expect(html).not.toContain("No-show &amp; cancellation fees");
+    expect(html).toContain('href="/finance/invoices/new?from=quote"');
+  });
+
+  it("renders Bakery money jobs for a bakery install", () => {
+    const html = renderToStaticMarkup(
+      <OwnerFirstFinanceView
+        surface={resolveFinanceSurface("food-hospitality", "bakery")}
+        metrics={metrics}
+      />,
+    );
+    expect(html).toContain("Custom order deposits &amp; balances");
+    expect(html).toContain("Counter &amp; order takings");
+    expect(html).toContain("Bill a custom order");
+    expect(html).toContain('href="/finance/invoices/new?from=custom-order"');
   });
 
   it("keeps VAT, dunning, payment runs, GL, bank rules, and AI spend links available (deferred, not dropped)", () => {

--- a/apps/web/lib/finance/finance-surface.test.ts
+++ b/apps/web/lib/finance/finance-surface.test.ts
@@ -4,10 +4,14 @@ import {
   isOwnerFirstFinanceCategory,
   resolveFinanceInvoiceCopy,
   resolveFinanceSurface,
+  resolveFoodHospitalitySubtype,
+  type FoodHospitalitySubtype,
 } from "./finance-surface";
 
-// Accounting internals that must NOT lead the surface for a restaurant owner.
-// They are allowed only inside the deferred advanced sections.
+const FOOD = "food-hospitality";
+
+// Accounting internals that must NOT lead the surface for a food-hospitality
+// owner. They are allowed only inside the deferred advanced sections.
 const INTERNAL_ROUTES = [
   "/finance/reports/vat-summary",
   "/finance/settings/tax",
@@ -18,77 +22,188 @@ const INTERNAL_ROUTES = [
   "/finance/spend/ai",
 ];
 
-describe("resolveFinanceSurface — food-hospitality (owner-first)", () => {
-  const surface = resolveFinanceSurface("food-hospitality");
+const SUBTYPES: FoodHospitalitySubtype[] = ["restaurant", "catering", "bakery", "generic"];
 
-  it("runs in owner-first mode and leads with the money question", () => {
+describe("resolveFoodHospitalitySubtype", () => {
+  it("recognises the three known subtypes", () => {
+    expect(resolveFoodHospitalitySubtype("restaurant")).toBe("restaurant");
+    expect(resolveFoodHospitalitySubtype("catering")).toBe("catering");
+    expect(resolveFoodHospitalitySubtype("bakery")).toBe("bakery");
+  });
+
+  it("falls back to generic for unknown/absent archetype ids", () => {
+    expect(resolveFoodHospitalitySubtype("cafe")).toBe("generic");
+    expect(resolveFoodHospitalitySubtype(null)).toBe("generic");
+    expect(resolveFoodHospitalitySubtype(undefined)).toBe("generic");
+  });
+});
+
+describe("food-hospitality surface — invariants shared by every subtype", () => {
+  it.each(SUBTYPES)("%s runs owner-first and leads with the money question", (subtype) => {
+    const surface = resolveFinanceSurface(FOOD, subtype);
     expect(surface.mode).toBe("owner-first");
+    expect(surface.subtype).toBe(subtype);
     expect(surface.headline.toLowerCase()).toContain("attention today");
   });
 
-  it("foregrounds the Restaurant money jobs", () => {
-    const ids = surface.moneyJobs.map((job) => job.id);
-    expect(ids).toEqual(
-      expect.arrayContaining([
-        "deposits-balances", // booking deposits + event/catering balances
-        "order-ticket-payments", // ticket/order payments
-        "supplier-bills", // supplier bills
-        "payouts-reconciliation", // payouts/reconciliation
-        "no-show-cancellation-fees", // no-show/cancellation fees
-      ]),
-    );
-  });
-
-  it("names booking deposits, catering/event balances, and no-show fees in owner-first language", () => {
-    const text = surface.moneyJobs
-      .map((job) => `${job.label} ${job.question}`)
-      .join(" ")
-      .toLowerCase();
-    expect(text).toContain("deposit");
-    expect(text).toContain("catering");
-    expect(text).toContain("supplier");
-    expect(text).toContain("no-show");
-    expect(text).toContain("reconcil");
-  });
-
-  it("does NOT lead with accountant/internal routes as money jobs", () => {
-    const jobRoutes = surface.moneyJobs.map((job) => job.href);
+  it.each(SUBTYPES)("%s does NOT lead with accountant/internal routes", (subtype) => {
+    const jobRoutes = resolveFinanceSurface(FOOD, subtype).moneyJobs.map((j) => j.href);
     for (const route of INTERNAL_ROUTES) {
       expect(jobRoutes).not.toContain(route);
     }
   });
 
-  it("defers VAT, dunning, payment runs, GL, bank rules, and AI spend into advanced sections", () => {
-    const advancedRoutes = surface.advancedSections.flatMap((section) =>
-      section.links.map((link) => link.href),
+  it.each(SUBTYPES)("%s defers VAT/dunning/payment-runs/GL/bank-rules/AI-spend", (subtype) => {
+    const advancedRoutes = resolveFinanceSurface(FOOD, subtype).advancedSections.flatMap((s) =>
+      s.links.map((l) => l.href),
     );
     for (const route of INTERNAL_ROUTES) {
       expect(advancedRoutes).toContain(route);
     }
   });
 
-  it("offers booking/order/catering/private-event invoice entry points", () => {
-    const ids = surface.invoiceEntryPoints.map((entry) => entry.id);
-    expect(ids).toEqual(
-      expect.arrayContaining(["booking", "order", "catering", "private-event"]),
-    );
-    // Each Restaurant context entry point carries its context, not just a blank form.
-    const bookingEntry = surface.invoiceEntryPoints.find((e) => e.id === "booking");
-    expect(bookingEntry?.href).toContain("from=booking");
+  // Honesty invariant: the surface re-frames a fixed set of real figures. If two
+  // jobs claimed the same metric the owner would see one number under two names.
+  it.each(SUBTYPES)("%s never shows the same live figure under two jobs", (subtype) => {
+    const metrics = resolveFinanceSurface(FOOD, subtype)
+      .moneyJobs.map((j) => j.metricKey)
+      .filter((m): m is NonNullable<typeof m> => m != null);
+    expect(new Set(metrics).size).toBe(metrics.length);
+  });
+
+  it.each(SUBTYPES)("%s offers a blank invoice escape hatch", (subtype) => {
+    const ids = resolveFinanceSurface(FOOD, subtype).invoiceEntryPoints.map((e) => e.id);
+    expect(ids).toContain("blank");
   });
 });
 
-describe("resolveFinanceSurface — non-food-hospitality (standard)", () => {
+describe("Restaurant subtype money jobs", () => {
+  const surface = resolveFinanceSurface(FOOD, "restaurant");
+
+  it("foregrounds booking deposits, order/ticket payments, supplier bills, payouts, no-show fees", () => {
+    expect(surface.moneyJobs.map((j) => j.id)).toEqual(
+      expect.arrayContaining([
+        "deposits-balances",
+        "order-ticket-payments",
+        "supplier-bills",
+        "payouts-reconciliation",
+        "no-show-cancellation-fees",
+      ]),
+    );
+  });
+
+  it("uses Restaurant money language", () => {
+    const text = surface.moneyJobs.map((j) => `${j.label} ${j.question}`).join(" ").toLowerCase();
+    expect(text).toContain("deposit");
+    expect(text).toContain("cover");
+    expect(text).toContain("no-show");
+    expect(text).toContain("supplier");
+  });
+
+  it("starts invoices from booking/order/catering/private-event context", () => {
+    expect(surface.invoiceEntryPoints.map((e) => e.id)).toEqual(
+      expect.arrayContaining(["booking", "order", "catering", "private-event"]),
+    );
+  });
+});
+
+describe("Catering subtype money jobs", () => {
+  const surface = resolveFinanceSurface(FOOD, "catering");
+
+  it("foregrounds quote, event deposits/balances, ingredient & staffing costs", () => {
+    expect(surface.moneyJobs.map((j) => j.id)).toEqual(
+      expect.arrayContaining([
+        "event-deposits-balances",
+        "event-payments",
+        "ingredient-staffing-bills",
+        "quote-catering-job",
+      ]),
+    );
+  });
+
+  it("uses Catering money language, not Restaurant covers/no-show language", () => {
+    const text = surface.moneyJobs.map((j) => `${j.label} ${j.question}`).join(" ").toLowerCase();
+    expect(text).toContain("quote");
+    expect(text).toContain("deposit");
+    expect(text).toContain("balance");
+    expect(text).toContain("staffing");
+    expect(text).not.toContain("no-show");
+    expect(text).not.toContain("table order");
+  });
+
+  it("offers quote / event-deposit / event-balance entry points", () => {
+    expect(surface.invoiceEntryPoints.map((e) => e.id)).toEqual(
+      expect.arrayContaining(["quote", "event-deposit", "event-balance"]),
+    );
+  });
+
+  it("makes clear a quote owes nothing yet", () => {
+    const quote = surface.invoiceEntryPoints.find((e) => e.id === "quote");
+    expect(quote?.description.toLowerCase()).toContain("nothing is owed");
+  });
+});
+
+describe("Bakery subtype money jobs", () => {
+  const surface = resolveFinanceSurface(FOOD, "bakery");
+
+  it("foregrounds custom-order deposits/balances, counter takings, ingredient bills", () => {
+    expect(surface.moneyJobs.map((j) => j.id)).toEqual(
+      expect.arrayContaining([
+        "custom-order-deposits-balances",
+        "counter-order-takings",
+        "ingredient-supplier-bills",
+        "bill-custom-order",
+      ]),
+    );
+  });
+
+  it("distinguishes standard counter sales from custom cake deposit/balance", () => {
+    const text = surface.moneyJobs.map((j) => `${j.label} ${j.question}`).join(" ").toLowerCase();
+    expect(text).toContain("counter");
+    expect(text).toContain("wedding");
+    expect(text).toContain("deposit");
+    expect(text).toContain("balance");
+  });
+
+  it("offers custom-order / counter-sale / pickup-delivery entry points", () => {
+    expect(surface.invoiceEntryPoints.map((e) => e.id)).toEqual(
+      expect.arrayContaining(["custom-order", "counter-sale", "delivery"]),
+    );
+  });
+});
+
+describe("subtypes are actually differentiated", () => {
+  it("gives restaurant, catering, and bakery distinct money-job sets", () => {
+    const ids = (s: FoodHospitalitySubtype) =>
+      resolveFinanceSurface(FOOD, s).moneyJobs.map((j) => j.id).join("|");
+    expect(ids("restaurant")).not.toBe(ids("catering"));
+    expect(ids("catering")).not.toBe(ids("bakery"));
+    expect(ids("restaurant")).not.toBe(ids("bakery"));
+  });
+
+  it("gives each subtype its own opening subhead", () => {
+    const sub = (s: FoodHospitalitySubtype) => resolveFinanceSurface(FOOD, s).subhead;
+    expect(sub("catering")).not.toBe(sub("restaurant"));
+    expect(sub("bakery")).not.toBe(sub("restaurant"));
+  });
+});
+
+describe("non-food-hospitality (standard)", () => {
   it.each(["professional-services", "retail-goods", "healthcare-wellness"])(
     "keeps %s in standard mode with no owner-first money jobs",
     (category) => {
       const surface = resolveFinanceSurface(category);
       expect(surface.mode).toBe("standard");
+      expect(surface.subtype).toBeNull();
       expect(surface.moneyJobs).toHaveLength(0);
       expect(surface.invoiceEntryPoints).toHaveLength(0);
       expect(surface.advancedSections).toHaveLength(0);
     },
   );
+
+  it("stays standard even when an archetype id is supplied", () => {
+    expect(resolveFinanceSurface("professional-services", "restaurant").mode).toBe("standard");
+  });
 
   it("falls back to standard mode for unknown/null categories", () => {
     expect(resolveFinanceSurface(null).mode).toBe("standard");
@@ -99,23 +214,36 @@ describe("resolveFinanceSurface — non-food-hospitality (standard)", () => {
 
 describe("isOwnerFirstFinanceCategory", () => {
   it("is true only for food-hospitality", () => {
-    expect(isOwnerFirstFinanceCategory("food-hospitality")).toBe(true);
+    expect(isOwnerFirstFinanceCategory(FOOD)).toBe(true);
     expect(isOwnerFirstFinanceCategory("professional-services")).toBe(false);
     expect(isOwnerFirstFinanceCategory(null)).toBe(false);
   });
 });
 
 describe("resolveFinanceInvoiceCopy", () => {
-  it("uses Restaurant-appropriate language for food-hospitality", () => {
-    const copy = resolveFinanceInvoiceCopy("food-hospitality");
-    expect(copy.newInvoiceSubhead.toLowerCase()).toContain("booking");
+  it("uses Restaurant guest language", () => {
+    const copy = resolveFinanceInvoiceCopy(FOOD, "restaurant");
     expect(copy.customerLabel.toLowerCase()).toContain("guest");
-    // Replaces the professional-services engagement-letter framing.
+    expect(copy.newInvoiceSubhead.toLowerCase()).toContain("booking");
     expect(copy.signatureHint.toLowerCase()).not.toContain("engagement letter");
-    expect(copy.contexts.catering.description.toLowerCase()).toContain("catering");
   });
 
-  it("keeps professional-services copy as the default", () => {
+  it("uses Catering client + quote/deposit/balance language", () => {
+    const copy = resolveFinanceInvoiceCopy(FOOD, "catering");
+    expect(copy.customerLabel).toBe("Client");
+    expect(copy.newInvoiceSubhead.toLowerCase()).toContain("quote");
+    expect(copy.contexts.quote?.description.toLowerCase()).toContain("nothing is owed");
+    expect(copy.contexts["event-balance"]?.description.toLowerCase()).toContain("delivered");
+  });
+
+  it("uses Bakery custom-order language", () => {
+    const copy = resolveFinanceInvoiceCopy(FOOD, "bakery");
+    expect(copy.newInvoiceSubhead.toLowerCase()).toContain("custom order");
+    expect(copy.contexts["custom-order"]?.description.toLowerCase()).toContain("deposit");
+    expect(copy.contexts["counter-sale"]?.title.toLowerCase()).toContain("counter");
+  });
+
+  it("keeps professional-services copy as the default for other archetypes", () => {
     const copy = resolveFinanceInvoiceCopy("professional-services");
     expect(copy.customerLabel).toBe("Customer");
     expect(copy.signatureHint.toLowerCase()).toContain("engagement letter");
@@ -123,10 +251,20 @@ describe("resolveFinanceInvoiceCopy", () => {
 });
 
 describe("isFinanceInvoiceContext", () => {
-  it("accepts the known Restaurant contexts", () => {
-    for (const ctx of ["booking", "order", "catering", "private-event", "no-show"]) {
-      expect(isFinanceInvoiceContext(ctx)).toBe(true);
-    }
+  it.each([
+    "booking",
+    "order",
+    "catering",
+    "private-event",
+    "no-show",
+    "quote",
+    "event-deposit",
+    "event-balance",
+    "custom-order",
+    "counter-sale",
+    "delivery",
+  ])("accepts %s", (ctx) => {
+    expect(isFinanceInvoiceContext(ctx)).toBe(true);
   });
 
   it("rejects anything else", () => {

--- a/apps/web/lib/finance/finance-surface.ts
+++ b/apps/web/lib/finance/finance-surface.ts
@@ -9,18 +9,29 @@
 // works from.
 //
 // This module maps an archetype CATEGORY (StorefrontArchetype.category, e.g.
-// "food-hospitality") to an owner-first finance surface that foregrounds the
-// restaurant's real money jobs and defers the accounting internals behind clear
-// advanced sections. Every job/link points at a REAL finance route — there are
-// no Restaurant-specific money tables today, so the surface is an honest
-// re-framing of the existing Invoice/Payment/Bill/BankTransaction data, not a
-// promise of new records.
+// "food-hospitality") to an owner-first finance surface, and further narrows it
+// by the archetype SUBTYPE (StorefrontArchetype.archetypeId — restaurant,
+// catering, bakery) so a caterer sees quotes/event balances and a bakery sees
+// custom-order deposits rather than one generic food set.
+//
+// Every job/link points at a REAL finance route. There are no Restaurant money
+// tables today, so the surface is an honest re-framing of the existing
+// Invoice/Payment/Bill/BankTransaction data, not a promise of new records. Each
+// live metric is used by AT MOST ONE money job per subtype — the same figure is
+// never shown twice under two different names.
 //
 // Dependency-free on purpose (no prisma/@dpf/db, no react) so it unit-tests in
 // isolation and never pulls a server-only module into a client bundle. The
-// server resolves the org's archetype category and calls resolveFinanceSurface.
+// server resolves the org's archetype and calls resolveFinanceSurface.
 
 export type FinanceSurfaceMode = "owner-first" | "standard";
+
+/**
+ * Food-hospitality archetype subtypes (StorefrontArchetype.archetypeId).
+ * `generic` is the fallback for a food-hospitality install whose archetypeId is
+ * not one of the three known subtypes.
+ */
+export type FoodHospitalitySubtype = "restaurant" | "catering" | "bakery" | "generic";
 
 /**
  * A live figure the finance overview page computes and slots into a money job.
@@ -36,7 +47,7 @@ export type FinanceMetricKey =
 
 export type FinanceMoneyJob = {
   id: string;
-  /** Restaurant-facing name for this money job. */
+  /** Subtype-facing name for this money job. */
   label: string;
   /** Owner-first phrasing of the money question this job answers. */
   question: string;
@@ -44,7 +55,7 @@ export type FinanceMoneyJob = {
   href: string;
   /**
    * "monitor" jobs show a running figure the owner watches; "action" jobs are a
-   * thing the owner starts (e.g. charge a no-show fee).
+   * thing the owner starts (e.g. quote a catering job).
    */
   kind: "monitor" | "action";
   /** Live figure to display, for monitor jobs backed by a running number. */
@@ -56,6 +67,12 @@ export type FinanceInvoiceEntryPointId =
   | "order"
   | "catering"
   | "private-event"
+  | "quote"
+  | "event-deposit"
+  | "event-balance"
+  | "custom-order"
+  | "counter-sale"
+  | "delivery"
   | "blank";
 
 export type FinanceInvoiceEntryPoint = {
@@ -76,28 +93,54 @@ export type FinanceAdvancedSection = {
 
 export type FinanceSurfaceModel = {
   archetypeCategory: string | null;
+  /** Null in standard mode. */
+  subtype: FoodHospitalitySubtype | null;
   mode: FinanceSurfaceMode;
   headline: string;
   subhead: string;
-  /** Foregrounded Restaurant money jobs (empty in standard mode). */
+  /** Foregrounded subtype money jobs (empty in standard mode). */
   moneyJobs: FinanceMoneyJob[];
-  /** Restaurant-context invoice entry points (empty in standard mode). */
+  /** Subtype invoice entry points (empty in standard mode). */
   invoiceEntryPoints: FinanceInvoiceEntryPoint[];
   /** Deferred accounting/back-office internals (empty in standard mode). */
   advancedSections: FinanceAdvancedSection[];
 };
 
 // Archetype categories that get the owner-first money-jobs surface. Keyed on
-// StorefrontArchetype.category so every food-hospitality archetype (restaurant,
-// café, bakery, catering) inherits it — not just one archetypeId.
+// StorefrontArchetype.category so every food-hospitality archetype inherits it.
 const OWNER_FIRST_CATEGORIES: ReadonlySet<string> = new Set(["food-hospitality"]);
 
-function foodHospitalityMoneyJobs(): FinanceMoneyJob[] {
-  return [
+const KNOWN_SUBTYPES: ReadonlySet<string> = new Set(["restaurant", "catering", "bakery"]);
+
+/** Narrow a StorefrontArchetype.archetypeId to a known food-hospitality subtype. */
+export function resolveFoodHospitalitySubtype(
+  archetypeId: string | null | undefined,
+): FoodHospitalitySubtype {
+  return archetypeId != null && KNOWN_SUBTYPES.has(archetypeId)
+    ? (archetypeId as FoodHospitalitySubtype)
+    : "generic";
+}
+
+// ─── Money jobs per subtype ───────────────────────────────────────────────────
+// Shared shape across subtypes: receivables, money-in, overdue, supplier bills,
+// payouts, plus one subtype-specific action. The METRICS are the same real
+// figures; the LABEL and QUESTION carry the subtype's actual money job.
+
+const PAYOUTS_RECONCILIATION: FinanceMoneyJob = {
+  id: "payouts-reconciliation",
+  label: "Payouts & reconciliation",
+  question: "Card payouts landing in the bank, matched back to sales.",
+  href: "/finance/banking",
+  kind: "monitor",
+  metricKey: "cash-position",
+};
+
+const MONEY_JOBS_BY_SUBTYPE: Record<FoodHospitalitySubtype, FinanceMoneyJob[]> = {
+  restaurant: [
     {
       id: "deposits-balances",
       label: "Deposits & event balances",
-      question: "Booking deposits and catering or event balances still to collect.",
+      question: "Booking deposits and private-dining balances still to collect.",
       href: "/finance/invoices",
       kind: "monitor",
       metricKey: "outstanding-receivables",
@@ -113,7 +156,7 @@ function foodHospitalityMoneyJobs(): FinanceMoneyJob[] {
     {
       id: "overdue-collections",
       label: "Overdue payments",
-      question: "Guest, catering, and event payments now past their due date.",
+      question: "Guest and private-dining payments now past their due date.",
       href: "/finance/reports/aged-debtors",
       kind: "monitor",
       metricKey: "overdue-count",
@@ -126,14 +169,7 @@ function foodHospitalityMoneyJobs(): FinanceMoneyJob[] {
       kind: "monitor",
       metricKey: "supplier-bills-due",
     },
-    {
-      id: "payouts-reconciliation",
-      label: "Payouts & reconciliation",
-      question: "Card payouts landing in the bank, matched back to sales.",
-      href: "/finance/banking",
-      kind: "monitor",
-      metricKey: "cash-position",
-    },
+    PAYOUTS_RECONCILIATION,
     {
       id: "no-show-cancellation-fees",
       label: "No-show & cancellation fees",
@@ -141,11 +177,151 @@ function foodHospitalityMoneyJobs(): FinanceMoneyJob[] {
       href: "/finance/invoices/new?from=no-show",
       kind: "action",
     },
-  ];
-}
+  ],
 
-function foodHospitalityInvoiceEntryPoints(): FinanceInvoiceEntryPoint[] {
-  return [
+  catering: [
+    {
+      id: "event-deposits-balances",
+      label: "Event deposits & balances",
+      question: "Deposits securing dates, and balances due after events are delivered.",
+      href: "/finance/invoices",
+      kind: "monitor",
+      metricKey: "outstanding-receivables",
+    },
+    {
+      id: "event-payments",
+      label: "Event payments received",
+      question: "Money in from catering jobs and events this month.",
+      href: "/finance/payments",
+      kind: "monitor",
+      metricKey: "money-in-month",
+    },
+    {
+      id: "overdue-event-payments",
+      label: "Overdue event payments",
+      question: "Corporate and event invoices now past their due date.",
+      href: "/finance/reports/aged-debtors",
+      kind: "monitor",
+      metricKey: "overdue-count",
+    },
+    {
+      id: "ingredient-staffing-bills",
+      label: "Ingredient & staffing bills",
+      question: "Food, drink, and staffing costs for upcoming events.",
+      href: "/finance/bills",
+      kind: "monitor",
+      metricKey: "supplier-bills-due",
+    },
+    PAYOUTS_RECONCILIATION,
+    {
+      id: "quote-catering-job",
+      label: "Quote a catering job",
+      question: "Price a corporate, wedding, or private event before you commit.",
+      href: "/finance/invoices/new?from=quote",
+      kind: "action",
+    },
+  ],
+
+  bakery: [
+    {
+      id: "custom-order-deposits-balances",
+      label: "Custom order deposits & balances",
+      question: "Deposits and balances on celebration and wedding cakes.",
+      href: "/finance/invoices",
+      kind: "monitor",
+      metricKey: "outstanding-receivables",
+    },
+    {
+      id: "counter-order-takings",
+      label: "Counter & order takings",
+      question: "Money in from counter sales and collected orders this month.",
+      href: "/finance/payments",
+      kind: "monitor",
+      metricKey: "money-in-month",
+    },
+    {
+      id: "overdue-order-payments",
+      label: "Overdue order payments",
+      question: "Custom and wholesale orders now past their due date.",
+      href: "/finance/reports/aged-debtors",
+      kind: "monitor",
+      metricKey: "overdue-count",
+    },
+    {
+      id: "ingredient-supplier-bills",
+      label: "Ingredient & supplier bills",
+      question: "Flour, dairy, packaging, and supplier bills waiting to be paid.",
+      href: "/finance/bills",
+      kind: "monitor",
+      metricKey: "supplier-bills-due",
+    },
+    PAYOUTS_RECONCILIATION,
+    {
+      id: "bill-custom-order",
+      label: "Bill a custom order",
+      question: "Take a deposit on a celebration or wedding cake.",
+      href: "/finance/invoices/new?from=custom-order",
+      kind: "action",
+    },
+  ],
+
+  // Food-hospitality install whose archetypeId is not one of the three known
+  // subtypes — neutral food/drink language, no subtype-specific claims.
+  generic: [
+    {
+      id: "deposits-balances",
+      label: "Deposits & balances",
+      question: "Deposits and outstanding balances still to collect from customers.",
+      href: "/finance/invoices",
+      kind: "monitor",
+      metricKey: "outstanding-receivables",
+    },
+    {
+      id: "order-payments",
+      label: "Order payments",
+      question: "Money in from orders and sales this month.",
+      href: "/finance/payments",
+      kind: "monitor",
+      metricKey: "money-in-month",
+    },
+    {
+      id: "overdue-collections",
+      label: "Overdue payments",
+      question: "Customer payments now past their due date.",
+      href: "/finance/reports/aged-debtors",
+      kind: "monitor",
+      metricKey: "overdue-count",
+    },
+    {
+      id: "supplier-bills",
+      label: "Supplier bills",
+      question: "Food, drink, and supplier bills waiting to be paid.",
+      href: "/finance/bills",
+      kind: "monitor",
+      metricKey: "supplier-bills-due",
+    },
+    PAYOUTS_RECONCILIATION,
+    {
+      id: "bill-a-job",
+      label: "Bill a job",
+      question: "Raise an invoice for an order, booking, or event.",
+      href: "/finance/invoices/new?from=order",
+      kind: "action",
+    },
+  ],
+};
+
+// ─── Invoice entry points per subtype ─────────────────────────────────────────
+
+const BLANK_ENTRY_POINT: FinanceInvoiceEntryPoint = {
+  id: "blank",
+  label: "Blank invoice",
+  description: "Start from a blank invoice with no context.",
+  href: "/finance/invoices/new",
+};
+
+const ENTRY_POINTS_BY_SUBTYPE: Record<FoodHospitalitySubtype, FinanceInvoiceEntryPoint[]> = {
+  restaurant: [
     {
       id: "booking",
       label: "From a booking",
@@ -170,19 +346,81 @@ function foodHospitalityInvoiceEntryPoints(): FinanceInvoiceEntryPoint[] {
       description: "Invoice a private hire or event, deposit first.",
       href: "/finance/invoices/new?from=private-event",
     },
-    {
-      id: "blank",
-      label: "Blank invoice",
-      description: "Start from a blank invoice with no context.",
-      href: "/finance/invoices/new",
-    },
-  ];
-}
+    BLANK_ENTRY_POINT,
+  ],
 
-// Accounting internals a restaurant owner should not have to lead with. Kept as
-// clearly-labelled advanced sections so a bookkeeper/accountant can still reach
-// VAT, dunning, payment runs, the general ledger, bank rules, and AI spend —
-// they are one disclosure away, not on the first screen.
+  catering: [
+    {
+      id: "quote",
+      label: "Quote",
+      description: "Price a job before it is confirmed — nothing is owed yet.",
+      href: "/finance/invoices/new?from=quote",
+    },
+    {
+      id: "event-deposit",
+      label: "Event deposit",
+      description: "Take the deposit that secures the date.",
+      href: "/finance/invoices/new?from=event-deposit",
+    },
+    {
+      id: "event-balance",
+      label: "Event balance",
+      description: "Bill the remaining balance after the event is delivered.",
+      href: "/finance/invoices/new?from=event-balance",
+    },
+    {
+      id: "private-event",
+      label: "Private event",
+      description: "Invoice a wedding, party, or private celebration.",
+      href: "/finance/invoices/new?from=private-event",
+    },
+    BLANK_ENTRY_POINT,
+  ],
+
+  bakery: [
+    {
+      id: "custom-order",
+      label: "Custom order",
+      description: "Bill a celebration or wedding cake — deposit up front.",
+      href: "/finance/invoices/new?from=custom-order",
+    },
+    {
+      id: "counter-sale",
+      label: "Counter sale",
+      description: "Record a standard over-the-counter sale.",
+      href: "/finance/invoices/new?from=counter-sale",
+    },
+    {
+      id: "delivery",
+      label: "Pickup or delivery",
+      description: "Add a pickup or delivery fee to an order.",
+      href: "/finance/invoices/new?from=delivery",
+    },
+    BLANK_ENTRY_POINT,
+  ],
+
+  generic: [
+    {
+      id: "order",
+      label: "From an order",
+      description: "Bill an order or sale.",
+      href: "/finance/invoices/new?from=order",
+    },
+    {
+      id: "booking",
+      label: "From a booking",
+      description: "Turn a booking into a deposit or balance invoice.",
+      href: "/finance/invoices/new?from=booking",
+    },
+    BLANK_ENTRY_POINT,
+  ],
+};
+
+// ─── Deferred accounting internals ────────────────────────────────────────────
+// Kept as clearly-labelled advanced sections so a bookkeeper/accountant can
+// still reach VAT, dunning, payment runs, the general ledger, bank rules, and AI
+// spend — they are one disclosure away, not on the first screen.
+
 function foodHospitalityAdvancedSections(): FinanceAdvancedSection[] {
   return [
     {
@@ -213,34 +451,53 @@ function foodHospitalityAdvancedSections(): FinanceAdvancedSection[] {
   ];
 }
 
+const SUBHEAD_BY_SUBTYPE: Record<FoodHospitalitySubtype, string> = {
+  restaurant:
+    "Deposits to collect, payments coming in, supplier bills to pay, and payouts to reconcile — the accounting detail is one tap away below.",
+  catering:
+    "Quotes to send, deposits securing dates, balances due after events, and ingredient and staffing bills — the accounting detail is one tap away below.",
+  bakery:
+    "Custom-order deposits and balances, counter takings, and ingredient bills — the accounting detail is one tap away below.",
+  generic:
+    "Deposits to collect, payments coming in, supplier bills to pay, and payouts to reconcile — the accounting detail is one tap away below.",
+};
+
 /**
- * Resolve the finance overview surface for an archetype category.
+ * Resolve the finance overview surface for an archetype.
  *
- * Owner-first (food-hospitality) returns foregrounded money jobs, Restaurant
- * invoice entry points, and deferred advanced sections. Every other archetype
- * (and an unknown/null category) returns the "standard" mode with empty
- * collections — the page keeps its existing generic layout for those.
+ * Owner-first (food-hospitality) returns foregrounded money jobs narrowed to the
+ * archetype subtype, subtype invoice entry points, and deferred advanced
+ * sections. Every other archetype (and an unknown/null category) returns the
+ * "standard" mode with empty collections — the page keeps its existing generic
+ * layout for those.
+ *
+ * @param category    StorefrontArchetype.category (e.g. "food-hospitality")
+ * @param archetypeId StorefrontArchetype.archetypeId (e.g. "catering"); when
+ *                    omitted or unknown the neutral food-hospitality set is used.
  */
 export function resolveFinanceSurface(
   category: string | null | undefined,
+  archetypeId?: string | null,
 ): FinanceSurfaceModel {
   const normalized = category ?? null;
 
   if (normalized != null && OWNER_FIRST_CATEGORIES.has(normalized)) {
+    const subtype = resolveFoodHospitalitySubtype(archetypeId);
     return {
       archetypeCategory: normalized,
+      subtype,
       mode: "owner-first",
       headline: "What money needs attention today?",
-      subhead:
-        "Deposits to collect, payments coming in, supplier bills to pay, and payouts to reconcile — the accounting detail is one tap away below.",
-      moneyJobs: foodHospitalityMoneyJobs(),
-      invoiceEntryPoints: foodHospitalityInvoiceEntryPoints(),
+      subhead: SUBHEAD_BY_SUBTYPE[subtype],
+      moneyJobs: MONEY_JOBS_BY_SUBTYPE[subtype],
+      invoiceEntryPoints: ENTRY_POINTS_BY_SUBTYPE[subtype],
       advancedSections: foodHospitalityAdvancedSections(),
     };
   }
 
   return {
     archetypeCategory: normalized,
+    subtype: null,
     mode: "standard",
     headline: "Finance",
     subhead: "Run cash, receivables, payables, and close work from one place.",
@@ -259,9 +516,20 @@ export function isOwnerFirstFinanceCategory(
 // ─── Archetype-appropriate invoice copy ───────────────────────────────────────
 // The generic invoice form leads with professional-services language
 // ("engagement letters and service agreements"). Resolve the copy from the
-// archetype so a restaurant sees booking/order/catering wording instead.
+// archetype so a restaurant, caterer, or bakery sees its own wording instead.
 
-export type FinanceInvoiceContext = "booking" | "order" | "catering" | "private-event" | "no-show";
+export type FinanceInvoiceContext =
+  | "booking"
+  | "order"
+  | "catering"
+  | "private-event"
+  | "no-show"
+  | "quote"
+  | "event-deposit"
+  | "event-balance"
+  | "custom-order"
+  | "counter-sale"
+  | "delivery";
 
 export type FinanceInvoiceCopy = {
   /** Subhead under the "New Invoice" heading. */
@@ -270,8 +538,11 @@ export type FinanceInvoiceCopy = {
   signatureHint: string;
   /** Label for the account/customer picker. */
   customerLabel: string;
-  /** Per-entry-point framing shown when the form is opened with ?from=<context>. */
-  contexts: Record<FinanceInvoiceContext, { title: string; description: string }>;
+  /**
+   * Per-entry-point framing shown when the form is opened with ?from=<context>.
+   * Partial: an unmapped context falls back to the generic heading + subhead.
+   */
+  contexts: Partial<Record<FinanceInvoiceContext, { title: string; description: string }>>;
 };
 
 const PROFESSIONAL_INVOICE_COPY: FinanceInvoiceCopy = {
@@ -279,58 +550,118 @@ const PROFESSIONAL_INVOICE_COPY: FinanceInvoiceCopy = {
   signatureHint:
     "The customer signs on the payment page before they can pay. Recommended for engagement letters and service agreements.",
   customerLabel: "Customer",
-  contexts: {
-    booking: { title: "New invoice", description: "Create a draft invoice to send to a customer." },
-    order: { title: "New invoice", description: "Create a draft invoice to send to a customer." },
-    catering: { title: "New invoice", description: "Create a draft invoice to send to a customer." },
-    "private-event": { title: "New invoice", description: "Create a draft invoice to send to a customer." },
-    "no-show": { title: "New invoice", description: "Create a draft invoice to send to a customer." },
+  contexts: {},
+};
+
+const SHARED_FOOD_CONTEXTS: FinanceInvoiceCopy["contexts"] = {
+  booking: {
+    title: "Invoice from a booking",
+    description: "Bill a reservation for its deposit now, or the balance after service.",
+  },
+  order: {
+    title: "Invoice from an order",
+    description: "Bill a table, takeaway, or delivery order.",
+  },
+  catering: {
+    title: "Catering invoice",
+    description: "Bill a catering job — take the deposit up front and the balance on delivery.",
+  },
+  "private-event": {
+    title: "Private-event invoice",
+    description: "Bill a private hire or event, with the deposit secured first.",
+  },
+  "no-show": {
+    title: "No-show or cancellation fee",
+    description: "Charge a guest for a no-show or a late cancellation.",
   },
 };
 
-const FOOD_HOSPITALITY_INVOICE_COPY: FinanceInvoiceCopy = {
-  newInvoiceSubhead: "Bill a booking, order, catering job, or private event.",
-  signatureHint:
-    "The guest signs on the payment page before they can pay. Useful for catering and private-event agreements where you want sign-off before the deposit.",
-  customerLabel: "Guest or customer",
-  contexts: {
-    booking: {
-      title: "Invoice from a booking",
-      description: "Bill a reservation for its deposit now, or the balance after service.",
+const INVOICE_COPY_BY_SUBTYPE: Record<FoodHospitalitySubtype, FinanceInvoiceCopy> = {
+  restaurant: {
+    newInvoiceSubhead: "Bill a booking, order, catering job, or private event.",
+    signatureHint:
+      "The guest signs on the payment page before they can pay. Useful for catering and private-event agreements where you want sign-off before the deposit.",
+    customerLabel: "Guest or customer",
+    contexts: SHARED_FOOD_CONTEXTS,
+  },
+
+  catering: {
+    newInvoiceSubhead: "Quote a job, take the deposit that secures the date, or bill the balance.",
+    signatureHint:
+      "The client signs on the payment page before they can pay. Useful for wedding and corporate event agreements where you want sign-off before the deposit.",
+    customerLabel: "Client",
+    contexts: {
+      ...SHARED_FOOD_CONTEXTS,
+      quote: {
+        title: "Catering quote",
+        description: "Price the job before it is confirmed — nothing is owed until the client accepts.",
+      },
+      "event-deposit": {
+        title: "Event deposit",
+        description: "Take the deposit that secures the date in your diary.",
+      },
+      "event-balance": {
+        title: "Event balance",
+        description: "Bill the remaining balance now the event has been delivered.",
+      },
     },
-    order: {
-      title: "Invoice from an order",
-      description: "Bill a table, takeaway, or delivery order.",
+  },
+
+  bakery: {
+    newInvoiceSubhead: "Bill a custom order, a counter sale, or a pickup and delivery fee.",
+    signatureHint:
+      "The customer signs on the payment page before they can pay. Useful for wedding-cake orders where you want sign-off before the deposit.",
+    customerLabel: "Customer",
+    contexts: {
+      ...SHARED_FOOD_CONTEXTS,
+      "custom-order": {
+        title: "Custom order invoice",
+        description: "Bill a celebration or wedding cake — deposit up front, balance on collection.",
+      },
+      "counter-sale": {
+        title: "Counter sale",
+        description: "Record a standard over-the-counter sale.",
+      },
+      delivery: {
+        title: "Pickup or delivery fee",
+        description: "Add a pickup or delivery charge to an order.",
+      },
     },
-    catering: {
-      title: "Catering invoice",
-      description: "Bill a catering job — take the deposit up front and the balance on delivery.",
-    },
-    "private-event": {
-      title: "Private-event invoice",
-      description: "Bill a private hire or event, with the deposit secured first.",
-    },
-    "no-show": {
-      title: "No-show or cancellation fee",
-      description: "Charge a guest for a no-show or a late cancellation.",
-    },
+  },
+
+  generic: {
+    newInvoiceSubhead: "Bill an order, booking, or event.",
+    signatureHint:
+      "The customer signs on the payment page before they can pay. Useful for event and catering agreements where you want sign-off before the deposit.",
+    customerLabel: "Customer",
+    contexts: SHARED_FOOD_CONTEXTS,
   },
 };
 
 export function resolveFinanceInvoiceCopy(
   category: string | null | undefined,
+  archetypeId?: string | null,
 ): FinanceInvoiceCopy {
-  return isOwnerFirstFinanceCategory(category)
-    ? FOOD_HOSPITALITY_INVOICE_COPY
-    : PROFESSIONAL_INVOICE_COPY;
+  if (!isOwnerFirstFinanceCategory(category)) return PROFESSIONAL_INVOICE_COPY;
+  return INVOICE_COPY_BY_SUBTYPE[resolveFoodHospitalitySubtype(archetypeId)];
 }
 
-export function isFinanceInvoiceContext(value: string | null | undefined): value is FinanceInvoiceContext {
-  return (
-    value === "booking" ||
-    value === "order" ||
-    value === "catering" ||
-    value === "private-event" ||
-    value === "no-show"
-  );
+const FINANCE_INVOICE_CONTEXTS: ReadonlySet<string> = new Set<FinanceInvoiceContext>([
+  "booking",
+  "order",
+  "catering",
+  "private-event",
+  "no-show",
+  "quote",
+  "event-deposit",
+  "event-balance",
+  "custom-order",
+  "counter-sale",
+  "delivery",
+]);
+
+export function isFinanceInvoiceContext(
+  value: string | null | undefined,
+): value is FinanceInvoiceContext {
+  return value != null && FINANCE_INVOICE_CONTEXTS.has(value);
 }

--- a/docs/superpowers/plans/2026-07-22-food-hospitality-subtype-money-jobs-BI-3326DA86.md
+++ b/docs/superpowers/plans/2026-07-22-food-hospitality-subtype-money-jobs-BI-3326DA86.md
@@ -1,0 +1,76 @@
+# Food & hospitality subtype money jobs — Restaurant / Catering / Bakery (plan)
+
+**BI:** BI-3326DA86 (next slice, after PR #3416)
+**Date:** 2026-07-22
+**Guiding outcome:** a caterer and a bakery should not be shown a restaurant's
+money jobs. Narrow the owner-first finance surface from the food-hospitality
+*category* down to the archetype *subtype*.
+
+## Problem
+
+PR #3416 shipped the owner-first finance surface keyed on
+`StorefrontArchetype.category === "food-hospitality"`, so Restaurant, Catering,
+and Bakery installs all received the same six money jobs and the same invoice
+entry points. The backlog evidence on BI-3326DA86 (Twin Gallery pass, 2026-07-22)
+called this out directly: Catering needs quote → deposit → event invoice →
+balance due and staffing/menu cost; Bakery needs standard counter sale vs custom
+cake deposit/balance and pickup/delivery fees. Showing a bakery "no-show &
+cancellation fees" and "table orders" is the same category error the BI was
+raised to fix, one level down.
+
+## Design grounding
+
+- **Source of truth:** `apps/web/lib/finance/finance-surface.ts` (shipped in
+  #3416) — this slice extends that resolver rather than forking a second one.
+- **Subtype ids** come from `packages/storefront-templates/src/archetypes/food-hospitality.ts`,
+  which defines exactly three: `restaurant`, `catering`, `bakery`. These are
+  `StorefrontArchetype.archetypeId`; the category stays `food-hospitality`.
+- **No new data models.** Still no Restaurant/Catering/Bakery money tables — the
+  same five real figures (`Invoice`/`Payment`/`Bill`/`BankTransaction` derived)
+  are re-framed in each subtype's language. Subtype differentiation is in the
+  label, question, and action, not in invented metrics.
+
+## Changes
+
+1. **`resolveFinanceSurface(category, archetypeId?)`** — optional second
+   argument, so existing single-argument callers keep working. Resolves a
+   `FoodHospitalitySubtype` (`restaurant` | `catering` | `bakery` | `generic`)
+   and returns that subtype's money jobs, entry points, and subhead. `generic`
+   is the fallback for a food-hospitality install whose `archetypeId` is not one
+   of the three, so no install regresses to the standard accountant surface.
+2. **Money jobs per subtype** — Catering leads with event deposits/balances,
+   event payments, ingredient & staffing bills, and "Quote a catering job";
+   Bakery leads with custom-order deposits/balances, counter takings, ingredient
+   bills, and "Bill a custom order". Restaurant is unchanged from #3416.
+3. **Invoice entry points + copy per subtype** — Catering gains
+   `quote` / `event-deposit` / `event-balance`; Bakery gains
+   `custom-order` / `counter-sale` / `delivery`. `FinanceInvoiceContext` and the
+   copy map expand accordingly; `contexts` becomes `Partial` with a fallback to
+   the generic heading so an unmapped context degrades gracefully.
+4. **Callers** — `/finance` now selects `archetypeId` alongside `category`;
+   `/finance/invoices/new` passes both to the resolver and the copy resolver, and
+   the context badge falls back to the context copy title.
+
+## Honesty invariant (tested)
+
+Each live metric is used by **at most one money job per subtype**. If two jobs
+claimed the same metric the owner would see one number presented under two
+different names. `finance-surface.test.ts` asserts this for every subtype, and
+also re-asserts per subtype that accounting internals never lead the surface and
+are never dropped (only deferred).
+
+## Tests
+
+- `finance-surface.test.ts` — subtype resolution + fallback; per-subtype
+  invariants (owner-first, no internal routes leading, internals deferred, no
+  duplicated metric, blank-invoice escape hatch); Restaurant/Catering/Bakery
+  money-job and entry-point sets; explicit "subtypes are actually differentiated"
+  checks; per-subtype copy; expanded context guard.
+- `OwnerFirstFinanceView.test.tsx` — renders Catering jobs (and *not* Restaurant
+  no-show) for a catering install, and Bakery jobs for a bakery install.
+
+## Out of scope
+
+- Prefilling invoices from a real booking/order — **BI-5CC7392C**.
+- A first-class no-show/cancellation fee policy with a waive path — **BI-1AF3CE43**.
+- The remaining BI-3326DA86 clause "coworker can draft readiness notes".

--- a/docs/user-guide/finance/accounts-receivable.md
+++ b/docs/user-guide/finance/accounts-receivable.md
@@ -20,7 +20,15 @@ order: 3
 
 ## Starting an invoice from context (food & hospitality)
 
-For the **food-hospitality** archetype, `/finance/invoices/new` can start from a specific billing context instead of only a generic customer dropdown. Opening the page with a `from` parameter — `?from=booking`, `?from=order`, `?from=catering`, `?from=private-event`, or `?from=no-show` — sets a contextual heading, an entry-point chooser, a context badge, and Restaurant-appropriate helper copy (guest/catering language). The same entry points are surfaced as cards on the owner-first `/finance` overview. Other business types keep the standard customer-first invoice form and copy.
+For the **food-hospitality** archetype, `/finance/invoices/new` can start from a specific billing context instead of only a generic customer dropdown. Opening the page with a `from` parameter sets a contextual heading, an entry-point chooser, a context badge, and helper copy matched to your business. The same entry points appear as cards on the owner-first `/finance` overview.
+
+The available contexts depend on the business:
+
+- **Restaurant** — `?from=booking`, `?from=order`, `?from=catering`, `?from=private-event`, and `?from=no-show`. Copy uses guest and booking language.
+- **Catering** — `?from=quote` (price a job before it is confirmed; nothing is owed until the client accepts), `?from=event-deposit` (the deposit that secures the date), `?from=event-balance` (the remainder once the event is delivered), and `?from=private-event`. The account picker is labelled **Client**.
+- **Bakery** — `?from=custom-order` (celebration or wedding cake, deposit up front and balance on collection), `?from=counter-sale` (a standard over-the-counter sale), and `?from=delivery` (a pickup or delivery fee).
+
+A blank invoice is always available. Other business types keep the standard customer-first invoice form and professional-services copy.
 
 ## What To Watch
 

--- a/docs/user-guide/finance/index.md
+++ b/docs/user-guide/finance/index.md
@@ -27,14 +27,36 @@ The Finance area handles your organization's core financial operations: billing 
 
 ## Owner-first overview (food & hospitality)
 
-For restaurants, cafés, bakeries, and caterers (the **food-hospitality** archetype), the `/finance` overview opens with **"what money needs attention today?"** instead of an accountant-shaped dashboard. It foregrounds the money jobs an owner runs day to day:
+For restaurants, bakeries, and caterers (the **food-hospitality** archetype), the `/finance` overview opens with **"what money needs attention today?"** instead of an accountant-shaped dashboard, and the money jobs it shows are matched to your specific business.
 
-- **Deposits & event balances** — booking deposits and catering/event balances still to collect
-- **Order & ticket payments** — money coming in from orders, tickets, and covers
-- **Overdue payments** — guest, catering, and event payments past their due date
+**Restaurant**
+
+- **Deposits & event balances** — booking deposits and private-dining balances still to collect
+- **Order & ticket payments** — money coming in from table orders, tickets, and covers
+- **Overdue payments** — guest and private-dining payments past their due date
 - **Supplier bills** — food, drink, and supplier bills waiting to be paid
 - **Payouts & reconciliation** — card payouts landing in the bank, matched back to sales
 - **No-show & cancellation fees** — charge a fee when a guest no-shows or cancels late
+
+**Catering**
+
+- **Event deposits & balances** — deposits securing dates, and balances due after events are delivered
+- **Event payments received** — money in from catering jobs and events
+- **Overdue event payments** — corporate and event invoices past their due date
+- **Ingredient & staffing bills** — food, drink, and staffing costs for upcoming events
+- **Payouts & reconciliation**
+- **Quote a catering job** — price a corporate, wedding, or private event before you commit
+
+**Bakery**
+
+- **Custom order deposits & balances** — deposits and balances on celebration and wedding cakes
+- **Counter & order takings** — money in from counter sales and collected orders
+- **Overdue order payments** — custom and wholesale orders past their due date
+- **Ingredient & supplier bills** — flour, dairy, packaging, and supplier bills
+- **Payouts & reconciliation**
+- **Bill a custom order** — take a deposit on a celebration or wedding cake
+
+A food-hospitality business that isn't one of those three sees a neutral food/drink set of the same jobs.
 
 Accounting internals — VAT/tax remittance, dunning reminders, payment runs, ledger and P&L reports, bank rules, and AI spend — are kept one tap away under a collapsed **"Accounting & admin"** section. Every other business type keeps the standard finance overview.
 


### PR DESCRIPTION
## What

PR #3416 made the finance surface owner-first for the **food-hospitality category** — so a caterer and a bakery both got a *restaurant's* money jobs. A bakery was shown "table orders" and "no-show & cancellation fees"; a caterer had nowhere to send a quote. This narrows the surface to the archetype **subtype**.

Continues **BI-3326DA86** (the "subtype money jobs" half of the recorded next slice).

### Catering now leads with
Event deposits & balances · event payments received · overdue event payments · **ingredient & staffing bills** · payouts & reconciliation · **Quote a catering job**

### Bakery now leads with
**Custom order deposits & balances** · **counter & order takings** · overdue order payments · ingredient & supplier bills · payouts & reconciliation · **Bill a custom order**

Restaurant is unchanged from #3416.

### Invoice entry points + copy per subtype
- **Catering** gains `?from=quote` (states plainly that *nothing is owed until the client accepts*), `?from=event-deposit` (secures the date), `?from=event-balance` (after delivery). The account picker is labelled **Client**.
- **Bakery** gains `?from=custom-order` (deposit up front, balance on collection), `?from=counter-sale`, `?from=delivery`.
- A blank invoice remains available everywhere.

## How
- `resolveFinanceSurface(category, archetypeId?)` — the second argument is **optional**, so existing single-argument callers keep working. Resolves `restaurant | catering | bakery | generic`.
- **`generic` fallback**: a food-hospitality install whose `archetypeId` isn't one of the three keeps a neutral food/drink set — it never regresses to the accountant surface.
- Subtype ids come from `packages/storefront-templates/src/archetypes/food-hospitality.ts`, which defines exactly those three.
- `/finance` now selects `archetypeId` alongside `category`; `/finance/invoices/new` passes both to the surface and copy resolvers, and the context badge falls back to the context-copy title.

**No new data models.** Still no Restaurant/Catering/Bakery money tables — the same five real `Invoice`/`Payment`/`Bill`/`BankTransaction` figures are re-framed in each subtype's language. Differentiation is in the label, question, and action, not in invented metrics.

## Honesty invariant (tested per subtype)
Each live figure backs **at most one** money job. If two jobs claimed the same metric, the owner would see one number presented under two different names. Asserted for every subtype, alongside per-subtype re-assertions that accounting internals never lead the surface and are never dropped (only deferred).

## Tests — 66 green (up from 23)
- `finance-surface.test.ts` — subtype resolution + fallback; per-subtype invariants (owner-first, no internal routes leading, internals deferred, no duplicated metric, blank-invoice escape hatch); Restaurant/Catering/Bakery job + entry-point sets; explicit "subtypes are actually differentiated" checks; per-subtype copy; expanded context guard.
- `OwnerFirstFinanceView.test.tsx` — renders Catering jobs (and asserts Restaurant's no-show job is **absent**) for a catering install, and Bakery jobs for a bakery install.

Locally: 66 tests pass; direct `tsc --noEmit` clean for all touched files apart from the worktree-wide missing-`next`-package noise (CI gates typecheck); docs-impact gate green.

## Design grounding
- **Existing specs/plans reviewed:** `docs/superpowers/plans/2026-07-22-food-hospitality-subtype-money-jobs-BI-3326DA86.md` plus the prior slice's plan `docs/superpowers/plans/2026-07-22-restaurant-finance-owner-first-BI-3326DA86.md`.
- **Current code substrate reviewed:** `apps/web/lib/finance/finance-surface.ts` (source of truth, shipped in #3416) and `packages/storefront-templates/src/archetypes/food-hospitality.ts`.
- **Decision:** extend the existing resolver; do not fork a second one.

Docs-Impact: docs/user-guide/finance/index.md, docs/user-guide/finance/accounts-receivable.md
Design-Grounding-Decision: extends apps/web/lib/finance/finance-surface.ts; grounded in docs/superpowers/plans/2026-07-22-food-hospitality-subtype-money-jobs-BI-3326DA86.md

## Related
Follow-ups filed while scoping this, deliberately **not** in here: **BI-5CC7392C** (prefill invoices from a real booking/order) and **BI-1AF3CE43** (first-class no-show/cancellation fee policy + waive path). The remaining BI-3326DA86 clause — "coworker can draft readiness notes" — is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)