### PR TITLE
fix(portfolio): reconcile-on-recovery for stale issues + stale_entity Docker parity

### DIFF
--- a/docs/data-impact/2026-07-22-docker-origin-stale-entity-resolve.data-impact.json
+++ b/docs/data-impact/2026-07-22-docker-origin-stale-entity-resolve.data-impact.json
@@ -1,0 +1,37 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "PortfolioQualityIssue rows (open Docker-origin stale_entity issues)",
+    "Prisma-to-EA current-state data-model mirror"
+  ],
+  "migration": {
+    "name": "20260722130000_resolve_docker_origin_stale_entity_issues",
+    "backfill": "status flip only — no row is created or deleted, no id, scope FK, summary, or detection timestamp is changed. Open Docker-origin stale_entity PortfolioQualityIssue rows (issueKey carrying container:/subnet:docker-/gateway:docker-gw:/runtime:docker/docker_host:/host:hostname:<12hex> shapes or a Docker 172.16/12 bridge address, e.g. the leaked network_interface:iface:eth0:172.18.0.14 NIC rows) are set status open->resolved with resolvedAt=NOW(). Real-estate and genuine stale entities (192.168 LAN, named hosts, application/service targets) carry none of these and are left open for the reconcile-on-recovery pass. Non-destructive and idempotent: already-resolved rows are not re-selected."
+  },
+  "tests": [
+    "packages/db/src/docker-origin.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:portfolio-quality-issue#docker-origin-stale-entity-resolve",
+      "prismaModel": "PortfolioQualityIssue",
+      "lifecycleDisposition": "no lifecycle change to the underlying InventoryEntity or any operator-facing record: only the derived quality-issue status transitions open->resolved for issues describing platform-internal Docker bridge/self-scan entity churn. firstDetectedAt, lastDetectedAt, scope FKs, and summary are preserved; rows remain for audit.",
+      "fields": [
+        {
+          "fieldId": "data:portfolio-quality-issue#status",
+          "resolution": "governed",
+          "reason": "resolve permanently-open, never-actionable stale_entity issues emitted for the platform's own Docker self-scan bridge NICs that leaked past the isDockerOriginEntityKey guard; each container recreation orphans the bridge address, so the issue can never resolve on its own and the queue accumulated indefinitely",
+          "provenance": "live-DB analysis (follow-up to BI-527290AA): 159 open stale_entity rows, all null entity FK; 51 are Docker 172.16/12 bridge shape (network_interface:...172.18 + __dpf_quarantined__ wrappers) resolved here; the remaining 108 (platform prom-targets + genuine) are left for the reconcile-on-recovery pass; gated by the same Docker-origin entity-key predicate as the extended isDockerOriginEntityKey guard"
+        },
+        {
+          "fieldId": "data:portfolio-quality-issue#resolvedAt",
+          "resolution": "governed",
+          "reason": "stamp the resolution time for the audit trail on the same open->resolved transition",
+          "provenance": "set to NOW() only on rows matching the Docker-origin entity-key predicate; real-estate/genuine rows are untouched"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/db/prisma/migrations/20260722130000_resolve_docker_origin_stale_entity_issues/migration.sql
+++ b/packages/db/prisma/migrations/20260722130000_resolve_docker_origin_stale_entity_issues/migration.sql
@@ -1,0 +1,32 @@
+-- Follow-up to BI-527290AA (#3418) — Resolve historical Docker-origin stale_entity
+-- quality issues (the entity twin of the stale_relationship cleanup).
+--
+-- The discovery pipeline emitted an OPEN stale_entity PortfolioQualityIssue for
+-- every InventoryEntity marked status='stale'. The entity loop already guards
+-- Docker-origin entities via isDockerOriginEntityKey, but that guard missed the
+-- self-scan's bridge-NIC shape (network_interface:iface:eth0:172.18.0.14 and its
+-- __dpf_quarantined__… wrappers), so those leaked past it and opened a permanent
+-- stale_entity issue per orphaned Docker 172.16/12 bridge address — churn that
+-- never resolves. isDockerOriginEntityKey is now extended to catch the 172.16/12
+-- bridge range in any key shape (packages/db/src/docker-origin.ts).
+--
+-- This one-shot backfill resolves the rows already persisted under the old
+-- behaviour. Non-destructive: it only flips status open -> resolved (rows remain
+-- for audit). The predicate mirrors the Docker-origin entity-key detection; the
+-- operator's real LAN is 192.168/10, so it matches none of the real-estate or
+-- genuine stale entities (which are left open for the reconcile-on-recovery pass).
+UPDATE "PortfolioQualityIssue"
+SET "status" = 'resolved',
+    "resolvedAt" = NOW()
+WHERE "issueType" = 'stale_entity'
+  AND "status" = 'open'
+  AND (
+    "issueKey" LIKE 'inventory_entity:container:%'
+    OR "issueKey" LIKE 'inventory_entity:subnet:docker-%'
+    OR "issueKey" LIKE 'inventory_entity:gateway:docker-gw:%'
+    OR "issueKey" LIKE 'inventory_entity:runtime:docker%'
+    OR "issueKey" LIKE 'inventory_entity:docker_host:%'
+    OR "issueKey" ~ 'host:hostname:[0-9a-f]{12}'
+    -- Docker 172.16.0.0/12 bridge address in any key shape (bridge NICs, etc.)
+    OR "issueKey" ~ '(^|[^0-9.])172\.(1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3}'
+  );

--- a/packages/db/src/discovery-sync.test.ts
+++ b/packages/db/src/discovery-sync.test.ts
@@ -77,6 +77,7 @@ describe("persistBootstrapDiscoveryRun", () => {
             qualityIssues.push(create);
             return {};
           },
+          updateMany: async () => ({ count: 0 }),
         },
       }),
     };
@@ -269,6 +270,7 @@ describe("persistBootstrapDiscoveryRun", () => {
         portfolioQualityIssue: {
           findMany: async () => [],
           upsert: async () => ({}),
+          updateMany: async () => ({ count: 0 }),
         },
       }),
     };
@@ -378,7 +380,7 @@ describe("persistBootstrapDiscoveryRun", () => {
             return {};
           },
         },
-        portfolioQualityIssue: { findMany: async () => [], upsert: async () => ({}) },
+        portfolioQualityIssue: { findMany: async () => [], upsert: async () => ({}), updateMany: async () => ({ count: 0 }) },
       }),
     };
 
@@ -514,7 +516,7 @@ describe("persistBootstrapDiscoveryRun", () => {
             return {};
           },
         },
-        portfolioQualityIssue: { findMany: async () => [], upsert: async () => ({}) },
+        portfolioQualityIssue: { findMany: async () => [], upsert: async () => ({}), updateMany: async () => ({ count: 0 }) },
       }),
     };
 
@@ -655,7 +657,7 @@ describe("persistBootstrapDiscoveryRun", () => {
             updateMany: async () => ({ count: 0 }),
           },
           discoveredRelationship: { create: async () => ({}) },
-          portfolioQualityIssue: { findMany: async () => [], upsert: async () => ({}) },
+          portfolioQualityIssue: { findMany: async () => [], upsert: async () => ({}), updateMany: async () => ({ count: 0 }) },
           identityResolutionLog: {
             findFirst,
             create: async ({ data }: { data: Record<string, unknown> }) => {

--- a/packages/db/src/discovery-sync.ts
+++ b/packages/db/src/discovery-sync.ts
@@ -157,6 +157,10 @@ type DiscoverySyncTx = {
       create: Record<string, unknown>;
       update: Record<string, unknown>;
     }): Promise<unknown>;
+    updateMany(args: {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    }): Promise<{ count: number }>;
   };
 };
 
@@ -817,6 +821,43 @@ export async function persistBootstrapDiscoveryRun(
       if (!existingIssueKeys.has(issue.issueKey)) {
         createdIssues += 1;
       }
+    }
+
+    // Reconcile-on-recovery: an entity or relationship observed active in THIS
+    // sweep is no longer stale, so any open stale_entity / stale_relationship
+    // issue for it must resolve. The stale-issue writer only ever opened rows and
+    // never resolved recovered ones, so a row that went stale for one sweep and
+    // came back stayed open forever (the churn that accumulated 1.5k+ open rows).
+    // Keyed by issueKey — the entity/relationship key is embedded — so this is
+    // source-bounded by construction: a key this sweep confirmed active belongs to
+    // this source, and another source's stale issue has a different key and is
+    // never matched. Docker-origin churn is handled by suppression at emission (it
+    // never recovers under the same key); this closes the loop for real estate.
+    const recoveredEntityIssueKeys = [...currentEntityKeys].map(
+      (entityKey) => `inventory_entity:${entityKey}:stale`,
+    );
+    if (recoveredEntityIssueKeys.length > 0) {
+      await tx.portfolioQualityIssue.updateMany({
+        where: {
+          issueType: "stale_entity",
+          status: "open",
+          issueKey: { in: recoveredEntityIssueKeys },
+        },
+        data: { status: "resolved", resolvedAt: now },
+      });
+    }
+    const recoveredRelationshipIssueKeys = normalized.inventoryRelationships.map(
+      (relationship) => `inventory_relationship:${relationship.relationshipKey}:stale`,
+    );
+    if (recoveredRelationshipIssueKeys.length > 0) {
+      await tx.portfolioQualityIssue.updateMany({
+        where: {
+          issueType: "stale_relationship",
+          status: "open",
+          issueKey: { in: recoveredRelationshipIssueKeys },
+        },
+        data: { status: "resolved", resolvedAt: now },
+      });
     }
 
     return {

--- a/packages/db/src/docker-origin.test.ts
+++ b/packages/db/src/docker-origin.test.ts
@@ -45,6 +45,20 @@ describe("isDockerOriginEntityKey (server-side)", () => {
     expect(isDockerOriginEntityKey("network_client:arp:192.168.0.49")).toBe(false);
     expect(isDockerOriginEntityKey("host:arp:192.168.0.5")).toBe(false);
   });
+
+  it("matches Docker 172.16/12 bridge NIC shapes the specific matches miss", () => {
+    // The self-scan's bridge NIC rows and their quarantined wrappers leaked past
+    // the host:arp:/host:hostname: matches and opened permanent stale_entity issues.
+    expect(isDockerOriginEntityKey("network_interface:iface:eth0:172.18.0.14")).toBe(true);
+    expect(
+      isDockerOriginEntityKey("__dpf_quarantined__cmpjsbvh8006c01lmp4levblx__network_interface:iface:eth0:172.18.0.14"),
+    ).toBe(true);
+    expect(isDockerOriginEntityKey("network_interface:iface:eth0:172.31.255.254")).toBe(true);
+    // Real LAN NIC (192.168) and outside-/12 stay false.
+    expect(isDockerOriginEntityKey("network_interface:iface:Ethernet_2:192.168.0.200")).toBe(false);
+    expect(isDockerOriginEntityKey("network_interface:iface:eth0:172.15.0.1")).toBe(false);
+    expect(isDockerOriginEntityKey("network_interface:iface:eth0:172.32.0.1")).toBe(false);
+  });
 });
 
 describe("isDockerOriginRelationshipKey", () => {

--- a/packages/db/src/docker-origin.ts
+++ b/packages/db/src/docker-origin.ts
@@ -66,6 +66,16 @@ export function isDockerOriginEntityKey(
     if (DOCKER_DESKTOP_VPNKIT_IPS.has(arpMatch[1])) return true;
   }
 
+  // Docker's 172.16/12 bridge address also appears in key shapes the specific
+  // matches above don't cover — e.g. the self-scan's bridge NIC rows
+  // `network_interface:iface:eth0:172.18.0.14` (and their `__dpf_quarantined__…`
+  // wrappers), which otherwise leak past this guard and open a permanent
+  // stale_entity issue per orphan. The operator's real LAN is 192.168/10, so a
+  // 172.16/12 address anywhere in the key is a reliable Docker-bridge signal.
+  // (DOCKER_BRIDGE_IP_RE is declared below for isDockerOriginRelationshipKey;
+  // the reference resolves at call time.)
+  if (DOCKER_BRIDGE_IP_RE.test(entityKey)) return true;
+
   if (name && nameLooksDockerOrigin(name)) return true;
 
   return false;

--- a/packages/db/test/discovery-sync-scope.test.ts
+++ b/packages/db/test/discovery-sync-scope.test.ts
@@ -50,6 +50,7 @@ function buildStubDb() {
         portfolioQualityIssue: {
           findMany: async () => [],
           upsert: async () => ({}),
+          updateMany: async () => ({ count: 0 }),
         },
       }),
   };

--- a/packages/db/test/discovery-sync-source-attribution.test.ts
+++ b/packages/db/test/discovery-sync-source-attribution.test.ts
@@ -93,6 +93,7 @@ function buildStubDb(opts: {
         portfolioQualityIssue: {
           findMany: async () => [],
           upsert: async () => ({}),
+          updateMany: async () => ({ count: 0 }),
         },
       }),
   };

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -66,5 +66,5 @@ apps/web/lib/work-capsules/work-capsule-store.ts	1056
 apps/web/lib/workbooks/platform-tables.ts	938
 apps/web/lib/workforce/calendar-data.ts	1134
 apps/web/lib/workspace/command-center.ts	1118
-packages/db/src/discovery-sync.ts	883
+packages/db/src/discovery-sync.ts	924
 packages/db/src/wiki-store.test.ts	824


### PR DESCRIPTION
## Context
Follow-up to BI-527290AA ([#3418](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3418), merged). Closes the two remaining lifecycle gaps behind the stale-issue accumulation — the reconcile pass the system never had, plus the entity twin of the Docker-origin suppression.

## Fixes
**1. Reconcile-on-recovery** (`packages/db/src/discovery-sync.ts`) — the root lifecycle defect. The stale-issue writer only ever *opened* rows and never resolved recovered ones, so an entity/relationship that went stale for one sweep and came back stayed open forever (this is *why* the queue only ever grew). After the issue-upsert loop, resolve any open `stale_entity`/`stale_relationship` issue whose key matches an entity/relationship observed **active** this sweep. Keyed by `issueKey` (the entity/relationship key is embedded) → **source-bounded by construction**: a key this sweep confirmed active belongs to this source; another source's stale issue has a different key and is never matched. Docker-origin churn (never recovers under the same key) stays handled by suppression at emission.

**2. `stale_entity` Docker parity** — `isDockerOriginEntityKey` already guards Docker entities but missed the self-scan's bridge-NIC shape (`network_interface:iface:eth0:172.18.0.14` + `__dpf_quarantined__` wrappers), which leaked past it and opened a permanent `stale_entity` issue per orphaned 172.16/12 bridge address. Extended the guard to match the Docker 172.16/12 bridge range in any key shape (reusing `DOCKER_BRIDGE_IP_RE`). Non-destructive migration resolves the 51 existing rows; the remaining 108 (platform prom-targets + genuine) are left for the reconcile path.

## Verification
- `isDockerOriginEntityKey` **11/11** vs real source (bridge NICs true; real LAN 192.168, out-of-/12, and prom-targets false).
- Migration coverage previewed on the live DB: **51 resolved / 108 left**.
- Reconcile key format matches the emission format exactly (`inventory_entity:${key}:stale` / `inventory_relationship:${key}:stale`) and is exercised by the existing persist tests.
- Local typecheck skipped (source-only worktree); CI Typecheck/Unit/Prod Build/DCO + Data-Impact + Migration Safety gate the merge.

## Remaining (smaller follow-ups, noted in BI-3715F309)
null relationship/entity FK on emitted rows (navigational only); aging/retention for genuinely-gone real-estate; and the ~330 genuinely-actionable issues (`lifecycle_unverified`, `catalog_match_ambiguous`) which are real operator work to surface via the portal, not code fixes.

Follow-up to BI-527290AA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)