### PR TITLE
feat(finance): coworker-drafted readiness notes for food-hospitality owners (BI-3326DA86)

### DIFF
--- a/apps/web/components/finance/OwnerFirstFinanceView.test.tsx
+++ b/apps/web/components/finance/OwnerFirstFinanceView.test.tsx
@@ -84,6 +84,12 @@ describe("OwnerFirstFinanceView", () => {
     expect(html).toContain("<summary");
   });
 
+  it("offers a coworker-drafted readiness note that promises no action", () => {
+    const html = render();
+    expect(html).toContain("Draft readiness note");
+    expect(html).toContain("nothing is sent and no money moves");
+  });
+
   it("renders Catering money jobs for a catering install, not Restaurant ones", () => {
     const html = renderToStaticMarkup(
       <OwnerFirstFinanceView

--- a/apps/web/components/finance/OwnerFirstFinanceView.tsx
+++ b/apps/web/components/finance/OwnerFirstFinanceView.tsx
@@ -4,6 +4,8 @@ import type {
   FinanceMoneyJob,
   FinanceSurfaceModel,
 } from "@/lib/finance/finance-surface";
+import { buildFinanceReadinessNotePrompt } from "@/lib/finance/readiness-note";
+import { AiFinanceCoworkerAskButton } from "@/components/finance/AiFinanceCoworkerAskButton";
 
 export type MoneyJobMetric = {
   /** Pre-formatted display value, e.g. "£1,250.00" or "3". */
@@ -69,7 +71,36 @@ export function OwnerFirstFinanceView({ surface, metrics, advancedChildren }: Pr
         </div>
       </section>
 
-      {/* Restaurant-context invoice entry points */}
+      {/* Coworker-drafted readiness note, grounded in the figures above */}
+      {surface.subtype && (
+        <section aria-label="Readiness note" className="mb-8">
+          <div className="flex flex-col gap-3 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-[var(--dpf-text)]">
+                Want this written up?
+              </p>
+              <p className="mt-1 text-xs leading-5 text-[var(--dpf-muted)]">
+                The Finance Specialist can draft a short readiness note from the figures above —
+                what needs attention, why it matters, and the safest next action. It is a draft for
+                you to review; nothing is sent and no money moves.
+              </p>
+            </div>
+            <div className="shrink-0">
+              <AiFinanceCoworkerAskButton
+                prompt={buildFinanceReadinessNotePrompt({
+                  subtype: surface.subtype,
+                  moneyJobs: surface.moneyJobs,
+                  metrics,
+                })}
+                routeContext="/finance"
+                label="Draft readiness note"
+              />
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Subtype invoice entry points */}
       {surface.invoiceEntryPoints.length > 0 && (
         <section aria-label="Start a bill" className="mb-8">
           <h2 className="mb-3 text-[10px] uppercase tracking-widest text-[var(--dpf-muted)]">

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -8672,6 +8672,7 @@
         "key-concepts",
         "what-you-can-do",
         "owner-first-overview-food-hospitality",
+        "readiness-notes",
         "recording-a-payment-run",
         "route-guide"
       ]

--- a/apps/web/lib/finance/readiness-note.test.ts
+++ b/apps/web/lib/finance/readiness-note.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { buildFinanceReadinessNotePrompt } from "./readiness-note";
+import { resolveFinanceSurface, type FinanceMetricKey } from "./finance-surface";
+import type { ReadinessMetricValue } from "./readiness-note";
+
+const METRICS: Partial<Record<FinanceMetricKey, ReadinessMetricValue>> = {
+  "outstanding-receivables": { value: "£1,250.00", hint: "3 invoices outstanding" },
+  "money-in-month": { value: "£8,400.00", hint: "42 invoices paid this month" },
+  "overdue-count": { value: "2", hint: "oldest: Bramley Wedding" },
+  "supplier-bills-due": { value: "£640.00", hint: "5 bills awaiting payment" },
+  "cash-position": { value: "£12,000.00", hint: "across 2 accounts" },
+};
+
+function promptFor(archetypeId: string, metrics = METRICS) {
+  const surface = resolveFinanceSurface("food-hospitality", archetypeId);
+  return buildFinanceReadinessNotePrompt({
+    subtype: surface.subtype!,
+    moneyJobs: surface.moneyJobs,
+    metrics,
+  });
+}
+
+describe("buildFinanceReadinessNotePrompt", () => {
+  it("names the business in the owner's own terms", () => {
+    expect(promptFor("restaurant")).toContain("my restaurant");
+    expect(promptFor("catering")).toContain("my catering business");
+    expect(promptFor("bakery")).toContain("my bakery");
+  });
+
+  it("grounds the note in the live figures on screen", () => {
+    const prompt = promptFor("restaurant");
+    expect(prompt).toContain("£1,250.00");
+    expect(prompt).toContain("3 invoices outstanding");
+    expect(prompt).toContain("£640.00");
+    expect(prompt).toContain("Today's position:");
+  });
+
+  it("uses the subtype's money-job language", () => {
+    expect(promptFor("catering")).toContain("Ingredient & staffing bills");
+    expect(promptFor("bakery")).toContain("Custom order deposits & balances");
+    expect(promptFor("restaurant")).toContain("Order & ticket payments");
+  });
+
+  it("forbids inventing numbers", () => {
+    expect(promptFor("restaurant").toLowerCase()).toContain("do not invent numbers");
+  });
+
+  // The same honesty boundary the payment-run disclosure enforces: DPF is not
+  // the payment rail, so a drafted note must not claim money moved.
+  it("constrains the coworker to a draft and forbids claiming money moved", () => {
+    const prompt = promptFor("catering").toLowerCase();
+    expect(prompt).toContain("draft");
+    expect(prompt).toContain("do not take any action");
+    expect(prompt).toContain("not a bank transfer");
+  });
+
+  it("omits money jobs that have no live figure rather than inventing a placeholder", () => {
+    // Only one metric supplied — the other monitor jobs must not appear.
+    const prompt = promptFor("restaurant", {
+      "supplier-bills-due": { value: "£640.00" },
+    });
+    expect(prompt).toContain("Supplier bills: £640.00");
+    expect(prompt).not.toContain("Order & ticket payments");
+    expect(prompt).not.toContain("undefined");
+  });
+
+  it("never quotes action jobs, which carry no figure", () => {
+    expect(promptFor("restaurant")).not.toContain("No-show & cancellation fees:");
+    expect(promptFor("catering")).not.toContain("Quote a catering job:");
+  });
+
+  it("falls back to a setup-oriented note when no figures exist yet", () => {
+    const prompt = promptFor("bakery", {});
+    expect(prompt).toContain("No live finance figures are available yet");
+    expect(prompt).toContain("set up first");
+    expect(prompt).not.toContain("Today's position:");
+    expect(prompt.toLowerCase()).toContain("do not take any action");
+  });
+});

--- a/apps/web/lib/finance/readiness-note.ts
+++ b/apps/web/lib/finance/readiness-note.ts
@@ -1,0 +1,79 @@
+// Finance readiness-note prompt builder.
+//
+// BI-3326DA86 asks that "the coworker can draft readiness notes" for a
+// food-hospitality owner. This builds the PROMPT the existing Finance
+// Specialist coworker is dispatched with (see AiFinanceCoworkerAskButton →
+// dispatchAgentPrompt) — it does not add agent infrastructure of its own.
+//
+// The prompt is grounded in the figures already on screen so the coworker
+// drafts against the owner's real position instead of inventing numbers, and it
+// explicitly constrains the coworker to a DRAFT FOR REVIEW: no action taken, no
+// claim that money moved. That constraint matters because DPF is not the
+// payment rail — the same honesty boundary the payment-run disclosure enforces.
+//
+// Dependency-free (no prisma, no react) so it unit-tests in isolation.
+
+import type {
+  FinanceMetricKey,
+  FinanceMoneyJob,
+  FoodHospitalitySubtype,
+} from "./finance-surface";
+
+export type ReadinessMetricValue = {
+  /** Pre-formatted display value, e.g. "£1,250.00" or "3". */
+  value: string;
+  hint?: string;
+};
+
+const BUSINESS_LABEL: Record<FoodHospitalitySubtype, string> = {
+  restaurant: "restaurant",
+  catering: "catering business",
+  bakery: "bakery",
+  generic: "food and drink business",
+};
+
+/**
+ * Build the readiness-note prompt for the Finance Specialist coworker.
+ *
+ * Only money jobs that actually have a live figure are quoted — a job with no
+ * metric is omitted rather than described with a placeholder, so the coworker is
+ * never handed a number that does not exist.
+ */
+export function buildFinanceReadinessNotePrompt(input: {
+  subtype: FoodHospitalitySubtype;
+  moneyJobs: FinanceMoneyJob[];
+  metrics: Partial<Record<FinanceMetricKey, ReadinessMetricValue>>;
+}): string {
+  const business = BUSINESS_LABEL[input.subtype];
+
+  const lines = input.moneyJobs
+    .filter((job) => job.kind === "monitor" && job.metricKey != null)
+    .map((job) => {
+      const metric = input.metrics[job.metricKey as FinanceMetricKey];
+      if (!metric) return null;
+      const hint = metric.hint ? ` (${metric.hint})` : "";
+      return `- ${job.label}: ${metric.value}${hint} — ${job.question}`;
+    })
+    .filter((line): line is string => line != null);
+
+  const header = `Draft a short finance readiness note for my ${business}.`;
+
+  const guardrails = [
+    "Write 3-5 short bullets in plain language. For each: what needs attention, why it matters, and the safest next action.",
+    "Ground every point in the figures above — do not invent numbers or estimate anything that is not listed.",
+    "This is a DRAFT for me to review. Do not take any action, do not send anything to anyone, and do not say that money has been paid or moved — recording a payment in DPF is not a bank transfer.",
+  ].join("\n");
+
+  if (lines.length === 0) {
+    return [
+      header,
+      "",
+      "No live finance figures are available yet for this business.",
+      "",
+      "Explain in 3-5 short bullets what I need to set up first before a readiness note is meaningful, and the safest next action for each.",
+      "This is a DRAFT for me to review. Do not take any action on my behalf.",
+    ].join("\n");
+  }
+
+  return [header, "", "Today's position:", ...lines, "", guardrails].join("\n");
+}

--- a/docs/superpowers/plans/2026-07-22-finance-readiness-notes-BI-3326DA86.md
+++ b/docs/superpowers/plans/2026-07-22-finance-readiness-notes-BI-3326DA86.md
@@ -1,0 +1,72 @@
+# Coworker-drafted finance readiness notes (plan)
+
+**BI:** BI-3326DA86 (final open acceptance clause)
+**Date:** 2026-07-22
+**Stacked on:** `claude/food-hospitality-subtype-money-jobs` (PR #3423)
+**Guiding outcome:** close the last unimplemented clause of BI-3326DA86 —
+*"coworker can draft readiness notes"*.
+
+## Problem
+
+The post-merge reconciliation of PR #3416 confirmed the owner-first finance
+surface, the differentiated billing entry points, and the honest payment-run
+copy, but recorded one clause with **no implementation at all**: the original
+acceptance asked that the coworker be able to draft finance readiness notes.
+Nothing on the finance surface offered that.
+
+## Design grounding
+
+- **Source of truth / existing substrate:** `apps/web/components/finance/AiFinanceCoworkerAskButton.tsx`
+  already dispatches a prompt to the Finance Specialist via
+  `dispatchAgentPrompt` (`apps/web/components/agent/AgentWorkLauncher.tsx`),
+  and is already used that way in `AiSpendWorkspace.tsx`. This slice **reuses**
+  that path — it adds no agent infrastructure, no new route, and no new model.
+- **What is actually new** is the *prompt*: a pure builder that grounds the
+  coworker in the figures already on screen.
+- Extends `apps/web/lib/finance/finance-surface.ts` (the money jobs and subtype
+  resolved there are what the note is written from).
+
+## Changes
+
+1. **`apps/web/lib/finance/readiness-note.ts`** (new, pure, dependency-free):
+   `buildFinanceReadinessNotePrompt({ subtype, moneyJobs, metrics })` composes a
+   prompt naming the business in the owner's terms ("my catering business"),
+   quoting today's position from the live figures, and asking for 3–5 bullets of
+   what needs attention / why it matters / safest next action.
+2. **`OwnerFirstFinanceView`** gains a "Want this written up?" affordance that
+   dispatches that prompt to the Finance Specialist with `routeContext="/finance"`.
+
+## Honesty constraints (tested)
+
+The prompt is deliberately constrained, because DPF is not the payment rail and
+a drafted note is not an action:
+
+- **Only real figures are quoted.** A money job with no live metric is *omitted*,
+  never described with a placeholder — the coworker is never handed a number
+  that does not exist. Action jobs (no-show fee, quote a job) carry no figure and
+  are never quoted as if they did.
+- **"Do not invent numbers or estimate anything that is not listed."**
+- **Draft for review only:** no action taken, nothing sent, and an explicit
+  instruction not to claim money has been paid or moved — *"recording a payment
+  in DPF is not a bank transfer"*, the same boundary the payment-run disclosure
+  enforces.
+- When there are no figures at all, the prompt degrades to a setup-oriented note
+  rather than fabricating a position.
+
+The on-screen copy makes the same promise: *"It is a draft for you to review;
+nothing is sent and no money moves."*
+
+## Tests
+
+`readiness-note.test.ts` — business naming per subtype; grounding in live
+figures; subtype money-job language; the no-invented-numbers and
+draft-only/no-money-moved constraints; omission of jobs without figures;
+exclusion of action jobs; and the empty-figures fallback.
+`OwnerFirstFinanceView.test.tsx` — the affordance renders with its no-action promise.
+
+## Out of scope
+
+- Persisting a drafted note as a record on the finance surface. Today the draft
+  lands in the coworker panel for the owner to read and use; storing/attaching it
+  would need a note model and an owner-acknowledgement path
+  (cf. Propose-Acknowledge-Reassign) and should be its own BI if wanted.

--- a/docs/user-guide/finance/index.md
+++ b/docs/user-guide/finance/index.md
@@ -60,6 +60,12 @@ A food-hospitality business that isn't one of those three sees a neutral food/dr
 
 Accounting internals — VAT/tax remittance, dunning reminders, payment runs, ledger and P&L reports, bank rules, and AI spend — are kept one tap away under a collapsed **"Accounting & admin"** section. Every other business type keeps the standard finance overview.
 
+### Readiness notes
+
+**Draft readiness note** asks the Finance Specialist coworker to write up the position shown on the overview: 3–5 bullets covering what needs attention, why it matters, and the safest next action. The note is drafted from the figures on screen — the coworker is instructed not to invent numbers, and to omit anything it has no figure for.
+
+It is a **draft for you to review**. Nothing is sent to anyone, no action is taken on your behalf, and the note will not claim money has been paid or moved — recording a payment in DPF is not a bank transfer. If your finances aren't set up yet, the note explains what to set up first instead.
+
 ## Recording a payment run
 
 A payment run (`/finance/payment-runs`) **records the selected approved bills as paid in DPF** and writes a matching outbound payment. It is **not a draft** and does **not** initiate a real bank transfer — pay your suppliers through your bank as usual, then use a payment run to keep your books settled. The action is labelled **"Record as Paid"** to make this explicit.


### PR DESCRIPTION
## What

Closes the **last unimplemented clause of BI-3326DA86** — *"coworker can draft readiness notes"* — which the post-merge reconciliation of #3416 recorded as having no implementation at all.

The `/finance` owner-first surface gains a **"Want this written up?"** affordance: the Finance Specialist drafts a short readiness note from the figures already on screen — 3–5 bullets of what needs attention, why it matters, and the safest next action.

Builds on the subtype money jobs merged in #3423.

## How

Reuses the **existing** coworker path — `AiFinanceCoworkerAskButton` → `dispatchAgentPrompt` (`AgentWorkLauncher`), already used this way by `AiSpendWorkspace`. **No new agent infrastructure, no new route, no new model.**

What is actually new is the prompt: `apps/web/lib/finance/readiness-note.ts`, a pure dependency-free builder that names the business in the owner's own terms ("my catering business", "my bakery") and quotes today's position from the live metrics the view already has.

## Honesty constraints (tested)

DPF is not the payment rail, and a drafted note is not an action — so the prompt is deliberately constrained:

- **Only real figures are quoted.** A money job with no live metric is *omitted*, never given a placeholder, so the coworker is never handed a number that doesn't exist. Action jobs (no-show fee, quote a job) carry no figure and are never quoted as if they did.
- **"Do not invent numbers or estimate anything that is not listed."**
- **Draft for review only** — no action taken, nothing sent, and an explicit instruction not to claim money has been paid or moved: *recording a payment in DPF is not a bank transfer*. Same boundary the payment-run disclosure enforces.
- With **no figures at all**, it degrades to a setup-oriented note rather than fabricating a position.

The on-screen copy makes the same promise: *"It is a draft for you to review; nothing is sent and no money moves."*

## Tests — 75 green

`readiness-note.test.ts` covers business naming per subtype, grounding in live figures, subtype money-job language, the no-invented-numbers and draft-only/no-money-moved constraints, omission of jobs without figures, exclusion of action jobs, and the empty-figures fallback. `OwnerFirstFinanceView.test.tsx` asserts the affordance renders with its no-action promise.

Locally: 75 tests pass against current `main`; docs-impact gate green; direct `tsc --noEmit` clean for touched files apart from the worktree-wide missing-`next` noise (CI gates typecheck).

## Design grounding
- **Existing specs/plans reviewed:** `docs/superpowers/plans/2026-07-22-finance-readiness-notes-BI-3326DA86.md` plus the prior slices' plans.
- **Current code substrate reviewed:** `apps/web/components/finance/AiFinanceCoworkerAskButton.tsx` and `apps/web/components/agent/AgentWorkLauncher.tsx` — the coworker path already exists and is reused; `apps/web/lib/finance/finance-surface.ts` supplies the subtype and money jobs.
- **Decision:** extend existing substrate; add only the pure prompt builder.

Docs-Impact: docs/user-guide/finance/index.md
Design-Grounding-Decision: reuses apps/web/components/finance/AiFinanceCoworkerAskButton.tsx; grounded in docs/superpowers/plans/2026-07-22-finance-readiness-notes-BI-3326DA86.md

## Out of scope
Persisting a drafted note as a record — that needs a note model plus an owner-acknowledgement path (Propose-Acknowledge-Reassign) and should be its own BI if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)