### PR TITLE
fix(browser-use): degraded-run contract — an aborted agent is NOT-RUN, never empty success (BI-1BAA177C)

### DIFF
--- a/apps/web/lib/mcp/build-lifecycle-handlers.ts
+++ b/apps/web/lib/mcp/build-lifecycle-handlers.ts
@@ -308,6 +308,20 @@ export async function runUxTest(params: Record<string, unknown>, userId: string,
     const testResult = await testRes.json();
     const testContent = JSON.parse(testResult?.result?.content?.[0]?.text ?? "{}");
 
+    // BI-1BAA177C: a degraded run means the agent could not drive the browser
+    // at all — it is NOT-RUN evidence, never pass/fail. Do not persist steps
+    // (uxVerificationStatus stays unset, so the ship gate keeps blocking) and
+    // say so plainly instead of surfacing 0/N "failures".
+    if (testContent.degraded === true) {
+      const reason = typeof testContent.reason === "string" ? testContent.reason : "browser agent could not run";
+      logBuildActivity(buildId, "run_ux_test", `UX tests DEGRADED (not run): ${reason}`);
+      return {
+        success: false,
+        error: `UX verification DEGRADED — tests did not run: ${reason}`,
+        message: `UX verification did not run: the browser-use agent could not drive its browser (${reason}). This is a NOT-RUN, not a failure of the UI. Check 'docker logs dpf-browser-use-1' and GET /health/capability on the sidecar; re-run once the probe reports capable.`,
+      };
+    }
+
     // Convert to UxTestStep format for storage. screenshot_path (when
     // present) is a filename inside the evidence_dir — turn it into a
     // portal-served URL the ReviewPanel can render.

--- a/apps/web/lib/mcp/packs/public-web-design-pack.ts
+++ b/apps/web/lib/mcp/packs/public-web-design-pack.ts
@@ -369,6 +369,18 @@ async function evaluatePageHandler(
     const sessionId = openContent.session_id;
     if (!sessionId) throw new Error("Failed to open browser session");
 
+    // BI-1BAA177C: a degraded/errored navigation means nothing after this
+    // point is evidence — report NOT-RUN instead of success-shaped emptiness.
+    if (openContent.degraded === true || openContent.status === "error") {
+      const reason = openContent.reason ?? openContent.error ?? "browser agent could not drive the browser";
+      return {
+        success: false,
+        error: `Page evaluation DEGRADED — did not run: ${reason}`,
+        message: `Page evaluation did not run: ${reason}. This is a NOT-RUN (browser-use could not drive its browser), not a clean page. Check GET /health/capability on the sidecar.`,
+        data: { url: targetUrl, degraded: true, reason },
+      };
+    }
+
     // Extract accessibility and UX findings using AI analysis
     const evalRes = await fetch(BROWSER_USE_URL, {
       method: "POST",
@@ -389,6 +401,15 @@ async function evaluatePageHandler(
     });
     const evalResult = await evalRes.json();
     const evalContent = JSON.parse(evalResult?.result?.content?.[0]?.text ?? "{}");
+    if (evalContent.degraded === true) {
+      const reason = evalContent.reason ?? "browser agent could not analyze the page";
+      return {
+        success: false,
+        error: `Page evaluation DEGRADED — did not run: ${reason}`,
+        message: `Page evaluation did not run: ${reason}. This is a NOT-RUN, not a zero-findings result.`,
+        data: { url: targetUrl, degraded: true, reason },
+      };
+    }
 
     // Get screenshot
     const ssRes = await fetch(BROWSER_USE_URL, {

--- a/apps/web/lib/operate/browser-use-client.test.ts
+++ b/apps/web/lib/operate/browser-use-client.test.ts
@@ -1,0 +1,116 @@
+// BI-1BAA177C — the degraded-run contract. A browser-use agent that cannot
+// drive its browser must surface as BrowserUseDegradedError (NOT-RUN), never
+// as empty findings or 0/N test results.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/self-upgrade/quiescence", () => ({
+  getQuiescenceLevel: vi.fn().mockResolvedValue("normal"),
+  QuiescingError: class QuiescingError extends Error {},
+}));
+
+import {
+  BrowserUseDegradedError,
+  evaluatePage,
+  runBrowserUseTests,
+} from "./browser-use-client";
+
+function mcpResponse(payload: Record<string, unknown>) {
+  return {
+    ok: true,
+    json: async () => ({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { content: [{ type: "text", text: JSON.stringify(payload) }] },
+    }),
+  } as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("runBrowserUseTests degraded contract", () => {
+  it("throws BrowserUseDegradedError when the whole run is degraded", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mcpResponse({
+        url: "http://sandbox:3000",
+        degraded: true,
+        reason: "navigation agent could not drive the browser",
+        total: 3,
+        passed: 0,
+        failed: 0,
+        results: [],
+      }),
+    );
+
+    await expect(runBrowserUseTests("http://sandbox:3000", ["a", "b", "c"])).rejects.toThrow(
+      BrowserUseDegradedError,
+    );
+  });
+
+  it("maps a degraded step to not-passed with its reason", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mcpResponse({
+        url: "http://sandbox:3000",
+        total: 2,
+        passed: 1,
+        failed: 0,
+        degraded_steps: 1,
+        results: [
+          { test: "t1", status: "pass", detail: "ok" },
+          { test: "t2", status: "degraded", detail: "agent could not drive the browser: aborted" },
+        ],
+      }),
+    );
+
+    const steps = await runBrowserUseTests("http://sandbox:3000", ["t1", "t2"]);
+    expect(steps[0]!.passed).toBe(true);
+    expect(steps[1]!.passed).toBe(false);
+    expect(steps[1]!.error).toContain("could not drive the browser");
+  });
+});
+
+describe("evaluatePage degraded contract", () => {
+  it("throws when navigation is degraded (the live-incident shape)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mcpResponse({ session_id: "abc", status: "degraded", degraded: true, reason: "browser state unavailable" }),
+      )
+      // browse_close in the finally block
+      .mockResolvedValue(mcpResponse({ status: "closed" }));
+
+    await expect(evaluatePage("http://localhost:3000/login")).rejects.toThrow(BrowserUseDegradedError);
+  });
+
+  it("throws when extraction is degraded instead of returning empty findings", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mcpResponse({ session_id: "abc", status: "navigated", url: "http://x" }))
+      .mockResolvedValueOnce(
+        mcpResponse({ session_id: "abc", status: "degraded", degraded: true, reason: "agent stopped before completing" }),
+      )
+      .mockResolvedValue(mcpResponse({ status: "closed" }));
+
+    await expect(evaluatePage("http://x")).rejects.toThrow(BrowserUseDegradedError);
+  });
+
+  it("still returns findings on a healthy run", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mcpResponse({ session_id: "abc", status: "navigated", url: "http://x" }))
+      .mockResolvedValueOnce(
+        mcpResponse({ session_id: "abc", status: "completed", data: JSON.stringify([{ issue: "low contrast" }]) }),
+      )
+      .mockResolvedValueOnce(mcpResponse({ session_id: "abc", screenshot_base64: "iVBOR" }))
+      .mockResolvedValue(mcpResponse({ status: "closed" }));
+
+    const result = await evaluatePage("http://x");
+    expect(result.findings).toHaveLength(1);
+    expect(result.screenshot).toBe("iVBOR");
+  });
+});

--- a/apps/web/lib/operate/browser-use-client.ts
+++ b/apps/web/lib/operate/browser-use-client.ts
@@ -13,6 +13,29 @@ export type UxTestStep = {
   error: string | null;
 };
 
+/**
+ * The browser-use sidecar answered, but its agent could not actually drive
+ * the browser (BI-1BAA177C: aborted runs used to come back as success-shaped
+ * empty results). Callers MUST treat this as NOT-RUN — never as "no findings"
+ * and never as a pass/fail verdict.
+ */
+export class BrowserUseDegradedError extends Error {
+  constructor(public readonly reason: string) {
+    super(`browser-use degraded: ${reason}`);
+    this.name = "BrowserUseDegradedError";
+  }
+}
+
+function throwIfDegraded(result: Record<string, unknown>, context: string): void {
+  if (result.degraded === true || result.status === "degraded") {
+    throw new BrowserUseDegradedError(
+      typeof result.reason === "string" && result.reason
+        ? `${context}: ${result.reason}`
+        : context,
+    );
+  }
+}
+
 type BrowserUseMcpResponse = {
   jsonrpc: string;
   id: number;
@@ -69,10 +92,13 @@ export async function runBrowserUseTests(
   if (options?.buildId) args.evidence_dir = `build_${options.buildId}`;
 
   const result = await callBrowserUse("tools/call", "browse_run_tests", args, 300000);
+  throwIfDegraded(result, "UX test run");
 
   const results = (result.results ?? []) as Array<Record<string, unknown>>;
   return results.map((r, i) => ({
     step: (r.test as string) ?? `Test ${i + 1}`,
+    // A "degraded" step never counts as pass — and its error names the cause
+    // so a reviewer sees "browser could not run", not "UI failed".
     passed: r.status === "pass",
     screenshotUrl: options?.buildId && typeof r.screenshot_path === "string"
       ? `/api/build/${encodeURIComponent(options.buildId)}/evidence/${encodeURIComponent(r.screenshot_path)}`
@@ -95,10 +121,18 @@ export async function evaluatePage(
   if (!sessionId) throw new Error("Failed to open browser session");
 
   try {
+    throwIfDegraded(open, "page navigation");
+    if (open.status === "error") {
+      throw new BrowserUseDegradedError(
+        `page navigation errored: ${typeof open.error === "string" ? open.error : "unknown"}`,
+      );
+    }
+
     const extract = await callBrowserUse("tools/call", "browse_extract", {
       session_id: sessionId,
       query: "Analyze this page for UX and accessibility issues. Return a JSON array of findings.",
     }, 120000);
+    throwIfDegraded(extract, "page evaluation");
 
     const ss = await callBrowserUse("tools/call", "browse_screenshot", {
       session_id: sessionId,

--- a/services/browser-use/agent_outcome.py
+++ b/services/browser-use/agent_outcome.py
@@ -1,0 +1,47 @@
+"""Agent-run outcome inspection (BI-1BAA177C).
+
+browser-use's Agent.run() does NOT raise when the agent aborts (e.g. after
+consecutive BrowserStateRequestEvent failures when the internal browser
+session cannot produce state) — it returns an AgentHistoryList that simply
+never reached a terminal success. Upstream code that stringifies that history
+turns a dead browser into success-shaped empty results, which the portal then
+cannot distinguish from "page has no issues".
+
+Kept stdlib-only (duck-typed against the history object) so it is unit
+testable without the browser_use dependency — same pattern as url_policy.py.
+"""
+
+from typing import Any, Tuple
+
+
+def agent_outcome(agent_result: Any) -> Tuple[bool, str]:
+    """Classify an Agent.run() return value.
+
+    Returns (ok, reason). ok=False means the agent did not complete its task
+    — the run is DEGRADED and its content must not be treated as an empty
+    success. Inspection is defensive: if the history object does not expose
+    the expected browser-use API, we do NOT degrade (never false-alarm on an
+    API drift; the capability probe owns deep detection).
+    """
+    if agent_result is None:
+        return False, "agent returned no history"
+
+    try:
+        is_done = getattr(agent_result, "is_done", None)
+        done = is_done() if callable(is_done) else None
+
+        is_successful = getattr(agent_result, "is_successful", None)
+        successful = is_successful() if callable(is_successful) else None
+
+        if done is False:
+            return False, (
+                "agent stopped before completing its task "
+                "(browser state unavailable or consecutive step failures)"
+            )
+        if successful is False:
+            return False, "agent completed but reported failure"
+
+        # done True/unknown and successful True/None/unknown → treat as ok.
+        return True, ""
+    except Exception as exc:  # noqa: BLE001 — inspection must never crash a handler
+        return True, f"outcome inspection unavailable: {exc}"

--- a/services/browser-use/agent_outcome_test.py
+++ b/services/browser-use/agent_outcome_test.py
@@ -1,0 +1,64 @@
+"""Unit tests for agent_outcome (BI-1BAA177C). Stdlib-only, like url_policy_test.py."""
+
+import unittest
+
+from agent_outcome import agent_outcome
+
+
+class FakeHistory:
+    def __init__(self, done=None, successful=None, raise_on=None):
+        self._done = done
+        self._successful = successful
+        self._raise_on = raise_on or set()
+
+    def is_done(self):
+        if "is_done" in self._raise_on:
+            raise RuntimeError("boom")
+        return self._done
+
+    def is_successful(self):
+        if "is_successful" in self._raise_on:
+            raise RuntimeError("boom")
+        return self._successful
+
+
+class AgentOutcomeTest(unittest.TestCase):
+    def test_none_history_is_degraded(self):
+        ok, reason = agent_outcome(None)
+        self.assertFalse(ok)
+        self.assertIn("no history", reason)
+
+    def test_aborted_run_is_degraded(self):
+        # The live failure mode: consecutive BrowserStateRequestEvent
+        # failures abort the run; history is not done.
+        ok, reason = agent_outcome(FakeHistory(done=False, successful=None))
+        self.assertFalse(ok)
+        self.assertIn("stopped before completing", reason)
+
+    def test_explicit_failure_is_degraded(self):
+        ok, reason = agent_outcome(FakeHistory(done=True, successful=False))
+        self.assertFalse(ok)
+        self.assertIn("reported failure", reason)
+
+    def test_successful_run_is_ok(self):
+        ok, _ = agent_outcome(FakeHistory(done=True, successful=True))
+        self.assertTrue(ok)
+
+    def test_done_with_unknown_success_is_ok(self):
+        # is_successful() returns None on some paths — never false-alarm.
+        ok, _ = agent_outcome(FakeHistory(done=True, successful=None))
+        self.assertTrue(ok)
+
+    def test_api_drift_does_not_degrade(self):
+        # Object without the expected methods (library API drift): stay ok.
+        ok, _ = agent_outcome(object())
+        self.assertTrue(ok)
+
+    def test_inspection_exception_does_not_degrade(self):
+        ok, reason = agent_outcome(FakeHistory(raise_on={"is_done"}))
+        self.assertTrue(ok)
+        self.assertIn("inspection unavailable", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/browser-use/server.py
+++ b/services/browser-use/server.py
@@ -860,7 +860,9 @@ async def health_capability():
             try:
                 await probe.stop()
             except Exception:
-                pass
+                # Cleanup must not mask the probe verdict — the capability
+                # result is already decided; a stop failure is only logged.
+                logger.warning("capability probe browser stop failed", exc_info=True)
 
     result["service"] = "browser-use-mcp"
     _capability_cache["checked_at"] = now

--- a/services/browser-use/server.py
+++ b/services/browser-use/server.py
@@ -27,6 +27,11 @@ from browser_use import Agent, BrowserSession, ChatOpenAI, ChatAnthropic
 # without the browser_use deps.
 from url_policy import check_navigation
 
+# Agent-run outcome inspection (BI-1BAA177C) — stdlib-only, unit-tested.
+# Agent.run() does not raise on an aborted run; without this check a dead
+# browser session becomes success-shaped empty results.
+from agent_outcome import agent_outcome
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("browser-use-mcp")
 
@@ -440,15 +445,25 @@ async def handle_browse_open(params: dict[str, Any]) -> dict[str, Any]:
                 llm=llm,
                 browser=session.browser,
             )
-            await agent.run()
+            nav_history = await agent.run()
+            nav_ok, nav_reason = agent_outcome(nav_history)
             session.actions.append(ActionRecord(
                 timestamp=time.time(),
                 action="navigate",
                 detail=f"Opened {url}",
-                success=True,
+                success=nav_ok,
             ))
-            result["status"] = "navigated"
-            result["url"] = url
+            if nav_ok:
+                result["status"] = "navigated"
+                result["url"] = url
+            else:
+                # BI-1BAA177C: an aborted navigation agent must never look
+                # like a navigated session — callers treat degraded as NOT-RUN.
+                result["status"] = "degraded"
+                result["degraded"] = True
+                result["reason"] = nav_reason
+                result["url"] = url
+                logger.error("browse_open DEGRADED for %s: %s", url, nav_reason)
         except Exception as e:
             result["status"] = "error"
             result["error"] = str(e)
@@ -478,6 +493,19 @@ async def handle_browse_act(params: dict[str, Any]) -> dict[str, Any]:
             browser=session.browser,
         )
         agent_result = await agent.run()
+        act_ok, act_reason = agent_outcome(agent_result)
+        if not act_ok:
+            session.actions.append(ActionRecord(
+                timestamp=time.time(), action="act", detail=task, success=False,
+            ))
+            logger.error("browse_act DEGRADED (session %s): %s", session_id, act_reason)
+            return {
+                "session_id": session_id,
+                "status": "degraded",
+                "degraded": True,
+                "reason": act_reason,
+                "task": task,
+            }
 
         # Enforce the target-domain allowlist on the page the action landed on.
         # The act loop drives adaptively, so this is the deterministic checkpoint:
@@ -551,6 +579,19 @@ async def handle_browse_extract(params: dict[str, Any]) -> dict[str, Any]:
             browser=session.browser,
         )
         agent_result = await agent.run()
+        extract_ok, extract_reason = agent_outcome(agent_result)
+        if not extract_ok:
+            session.actions.append(ActionRecord(
+                timestamp=time.time(), action="extract", detail=query, success=False,
+            ))
+            logger.error("browse_extract DEGRADED (session %s): %s", session_id, extract_reason)
+            return {
+                "session_id": session_id,
+                "status": "degraded",
+                "degraded": True,
+                "reason": extract_reason,
+                "query": query,
+            }
 
         session.actions.append(ActionRecord(
             timestamp=time.time(),
@@ -615,7 +656,24 @@ async def handle_browse_run_tests(params: dict[str, Any]) -> dict[str, Any]:
             llm=llm,
             browser=session.browser,
         )
-        await nav_agent.run()
+        nav_history = await nav_agent.run()
+        nav_ok, nav_reason = agent_outcome(nav_history)
+        if not nav_ok:
+            # BI-1BAA177C: if the browser cannot even navigate, every per-test
+            # verdict would be noise — and the old word-heuristic could score
+            # an aborted agent as PASS. Report the whole run as degraded;
+            # callers must treat it as NOT-RUN, never as pass/fail evidence.
+            logger.error("browse_run_tests DEGRADED for %s: %s", url, nav_reason)
+            await sessions.close(session.session_id)
+            return {
+                "url": url,
+                "degraded": True,
+                "reason": f"navigation agent could not drive the browser: {nav_reason}",
+                "total": len(tests),
+                "passed": 0,
+                "failed": 0,
+                "results": [],
+            }
 
         for i, test_case in enumerate(tests):
             try:
@@ -631,6 +689,14 @@ async def handle_browse_run_tests(params: dict[str, Any]) -> dict[str, Any]:
                     browser=session.browser,
                 )
                 agent_result = await agent.run()
+                step_ok, step_reason = agent_outcome(agent_result)
+                if not step_ok:
+                    results.append({
+                        "test": test_case,
+                        "status": "degraded",
+                        "detail": f"agent could not drive the browser: {step_reason}",
+                    })
+                    continue
                 result_str = str(agent_result).lower()
 
                 # Heuristic: check if the agent reported failure
@@ -674,15 +740,23 @@ async def handle_browse_run_tests(params: dict[str, Any]) -> dict[str, Any]:
         await sessions.close(session.session_id)
 
     passed_count = sum(1 for r in results if r["status"] == "pass")
-    failed_count = sum(1 for r in results if r["status"] != "pass")
+    degraded_count = sum(1 for r in results if r["status"] == "degraded")
+    failed_count = sum(1 for r in results if r["status"] not in ("pass", "degraded"))
 
-    return {
+    response: dict[str, Any] = {
         "url": url,
         "total": len(tests),
         "passed": passed_count,
         "failed": failed_count,
         "results": results,
     }
+    if degraded_count:
+        response["degraded_steps"] = degraded_count
+        # Whole run is only evidence when at least one assertion actually ran.
+        if degraded_count == len(results):
+            response["degraded"] = True
+            response["reason"] = "every test agent failed to drive the browser"
+    return response
 
 
 async def handle_browse_close(params: dict[str, Any]) -> dict[str, Any]:
@@ -741,6 +815,58 @@ async def shutdown():
 @app.get("/health")
 async def health():
     return {"status": "healthy", "service": "browser-use-mcp", "model": LLM_MODEL}
+
+
+# BI-1BAA177C: /health only proves HTTP liveness — the live incident had a
+# healthy healthcheck over a browser that could not produce state. This probe
+# exercises the actual capability (launch Chromium, load a page, read state).
+# Cached because a real browser launch is expensive; consumers (portal
+# capability reporting, EP-UX-SYSTEM capability probes) poll infrequently.
+_capability_cache: dict[str, Any] = {"checked_at": 0.0, "result": None}
+_CAPABILITY_TTL_SECONDS = int(os.environ.get("CAPABILITY_PROBE_TTL_SECONDS", "300"))
+
+
+@app.get("/health/capability")
+async def health_capability():
+    now = time.time()
+    cached = _capability_cache["result"]
+    if cached is not None and (now - _capability_cache["checked_at"]) < _CAPABILITY_TTL_SECONDS:
+        return {**cached, "cached": True}
+
+    result: dict[str, Any]
+    probe = None
+    try:
+        probe = BrowserSession(
+            headless=True,
+            executable_path=CHROME_BIN,
+            chromium_sandbox=False,
+            args=["--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+        )
+        await probe.start()
+        page = await probe.get_current_page()
+        if page is None:
+            result = {"capable": False, "reason": "browser started but produced no page"}
+        else:
+            b64 = await page.screenshot()
+            if b64:
+                result = {"capable": True, "reason": ""}
+            else:
+                result = {"capable": False, "reason": "page produced no screenshot (browser state unavailable)"}
+    except Exception as e:
+        logger.exception("capability probe failed")
+        result = {"capable": False, "reason": f"probe error: {e.__class__.__name__}"}
+    finally:
+        if probe is not None:
+            try:
+                await probe.stop()
+            except Exception:
+                pass
+
+    result["service"] = "browser-use-mcp"
+    _capability_cache["checked_at"] = now
+    _capability_cache["result"] = result
+    status_code = 200 if result.get("capable") else 503
+    return JSONResponse(content={**result, "cached": False}, status_code=status_code)
 
 
 @app.post("/mcp")


### PR DESCRIPTION
## What

EP-UX-SYSTEM Phase 0, third repair (BI-1BAA177C, linked — this PR ships the contract half; the version-upgrade half stays open on the BI). Live incident: `dpf-browser-use-1` (healthy healthcheck) logged its agent aborting — `BrowserStateRequestEvent` → None ×6, 'Stopping due to 5 consecutive failures' — and still returned 200; the portal's `evaluate_page` surfaced `{findings: [], screenshot: null}`, indistinguishable from a clean page. Worse, `browse_run_tests`' word-heuristic could score an aborted agent as **pass**.

**Sidecar** (`services/browser-use/`):
- `agent_outcome.py` — stdlib-only outcome classifier over `Agent.run()` history (`is_done()`/`is_successful()`), defensive against library API drift (never false-degrades). 7 unit tests, `url_policy.py` pattern.
- `browse_open` / `browse_act` / `browse_extract` return `status: "degraded"` + reason when the agent could not drive the browser.
- `browse_run_tests`: navigation failure ⇒ whole run degraded (no bogus per-test verdicts); degraded steps excluded from pass/fail counts; all-degraded ⇒ run degraded.
- `GET /health/capability` — a real capability probe (launch Chromium, read page, screenshot; 300s cache; 503 when not capable). `/health` proved only HTTP liveness during the incident.

**Portal**:
- `BrowserUseDegradedError`; `evaluatePage`/`runBrowserUseTests` throw instead of returning empty results.
- `runUxTest` (the ship-gating check): degraded ⇒ explicit NOT-RUN result, no `uxTestResults` persisted, so `uxVerificationStatus` stays unset and the phase gate keeps blocking — an unrun gate, never a pass.
- `evaluate_page` tool handler: degraded nav/extract ⇒ structured NOT-RUN result.

This closes the third instance of the silent-empty pattern the EP-UX-SYSTEM spec §2 outlaws (design-intelligence: #3421; prompts: #3422; runtime eval: this PR).

## Deliberately out of scope

The `browser-use>=0.12,<0.13` pin is unchanged. The underlying browser breakage likely needs the 0.13.x upgrade, but that requires a sidecar image rebuild + live capability verification through the governed path — kept on BI-1BAA177C. This PR makes the failure visible and un-gameable at any version; post-merge, `GET /health/capability` on the live sidecar is the acceptance probe (expected: 503 + reason until the upgrade lands, instead of today's false healthy).

## Verification

- Python: `agent_outcome_test.py` 7/7, `url_policy_test.py` 4/4 (unchanged, still green), `py_compile` clean on `server.py`.
- vitest: `browser-use-client.test.ts` 5/5 (degraded throw paths + healthy path; quiescence seam mocked).
- tsc scan of the three changed TS files: zero errors (worktree full run carries the documented pre-existing source-only env errors).
- Pre-commit typecheck + pregate skipped with recorded reasons (source-only worktree); CI Typecheck / Prod Build / Unit Tests authoritative.

## Design grounding

- Specs reviewed: docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md (§2 item 2, §6 L5 capability probes, §8 Phase 0); docs/superpowers/specs/2026-05-11-ai-routing-ux-verification-test-architecture-design.md (run_ux_test gate role).
- Code substrate reviewed: services/browser-use/server.py (+url_policy.py test pattern), apps/web/lib/operate/browser-use-client.ts, apps/web/lib/mcp/build-lifecycle-handlers.ts (runUxTest, uxVerificationStatus gate), apps/web/lib/mcp/packs/public-web-design-pack.ts (evaluatePageHandler), apps/web/lib/decision/visual-cognitive-load.ts (downstream consumer).
- Disposition: extends existing modules in place per the merged EP-UX-SYSTEM spec; new stdlib module follows the established url_policy.py pattern; no new tool names, no contract renames — the degraded field is additive.

Local-CI-Override: source-only worktree cannot host pregate; evidence = python 11/11 + vitest 5/5 + targeted tsc clean (commit body); CI required checks authoritative.
Design-Grounding-Decision: implements merged EP-UX-SYSTEM spec §8 Phase 0 / §2 item 2; substrate reviewed as listed; additive degraded-run contract, no existing behavior contract renamed.
Docs-Impact-Decision: no user-facing route changed; agent/ops-facing evaluation contract only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)