### PR TITLE
feat(ux): close the EP-UX-COGLOAD residual acceptance gaps (BI-348766E5, BI-A36CF68D, BI-3DA1DFDC, BI-2B2FCB2B, BI-CC580161, BI-F0B389C9)

### DIFF
--- a/apps/web/components/customer-marketing/ApprovalQueuePanel.tsx
+++ b/apps/web/components/customer-marketing/ApprovalQueuePanel.tsx
@@ -201,6 +201,7 @@ export function ApprovalQueuePanel({
                       channelConnected={linkedInConnected}
                       channelId="linkedin-personal-social"
                       fitBlocked={assessArchetypeFit({ text: draft.body, category }).blocked}
+                      artifactTitle={draft.assetTaskTitle}
                     />
                   ) : isEmailChannel(draft.channelId) ? (
                     <PublishEmailButton
@@ -208,6 +209,7 @@ export function ApprovalQueuePanel({
                       channelConnected={emailConnected}
                       channelId="email-postmark"
                       fitBlocked={assessArchetypeFit({ text: draft.body, category }).blocked}
+                      artifactTitle={draft.assetTaskTitle}
                     />
                   ) : (
                     <p className="text-xs text-[var(--dpf-muted)]">

--- a/apps/web/components/customer-marketing/PublishEmailButton.tsx
+++ b/apps/web/components/customer-marketing/PublishEmailButton.tsx
@@ -9,10 +9,21 @@ type Props = {
   channelId: string;
   /** True when archetype-fit flags the body as off-archetype/software-platform content. */
   fitBlocked?: boolean;
+  /** Owner-readable artifact title shown in the pre-send confirmation. */
+  artifactTitle?: string | null;
+  /** Owner-readable audience description shown in the pre-send confirmation. */
+  audience?: string | null;
 };
 
-export function PublishEmailButton({ draftId, channelConnected, channelId, fitBlocked }: Props) {
-  const [status, setStatus] = useState<"idle" | "sending" | "done" | "error">("idle");
+export function PublishEmailButton({
+  draftId,
+  channelConnected,
+  channelId,
+  fitBlocked,
+  artifactTitle,
+  audience,
+}: Props) {
+  const [status, setStatus] = useState<"idle" | "confirming" | "sending" | "done" | "error">("idle");
   const [message, setMessage] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
@@ -60,11 +71,49 @@ export function PublishEmailButton({ draftId, channelConnected, channelId, fitBl
     );
   }
 
+  // Explicit owner confirmation before the send: channel, artifact, audience,
+  // and the external consequence (BI-CC580161 publish-confirmation acceptance).
+  if (status === "confirming") {
+    return (
+      <div
+        data-testid="send-confirm-panel"
+        className="flex flex-col gap-2 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-xs text-[var(--dpf-text)]"
+      >
+        <p className="font-semibold">Send this email?</p>
+        <ul className="flex flex-col gap-1">
+          <li><span className="text-[var(--dpf-muted)]">Channel:</span> Email</li>
+          {artifactTitle && <li><span className="text-[var(--dpf-muted)]">Message:</span> {artifactTitle}</li>}
+          <li>
+            <span className="text-[var(--dpf-muted)]">Audience:</span>{" "}
+            {audience ?? "the recipients configured for this email channel"}
+          </li>
+          <li>This sends outside DPF and cannot be unsent.</li>
+        </ul>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={onSend}
+            className="rounded-full bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-white"
+          >
+            Yes, send email
+          </button>
+          <button
+            type="button"
+            onClick={() => setStatus("idle")}
+            className="rounded-full border border-[var(--dpf-border)] px-4 py-1.5 text-sm text-[var(--dpf-text)]"
+          >
+            Keep as draft
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-wrap items-center gap-2">
       <button
         type="button"
-        onClick={onSend}
+        onClick={() => setStatus("confirming")}
         disabled={pending || status === "done"}
         className="rounded-full bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50"
       >

--- a/apps/web/components/customer-marketing/PublishLinkedInButton.test.tsx
+++ b/apps/web/components/customer-marketing/PublishLinkedInButton.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+// Publish-confirmation contract (BI-CC580161): before anything posts outside
+// DPF, the owner reviews channel, artifact title, audience, and the external
+// consequence in one explicit confirmation step.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const actionMocks = vi.hoisted(() => ({
+  publishOutboundDraftAction: vi.fn(),
+}));
+vi.mock("@/app/(shell)/customer/marketing/actions", () => actionMocks);
+
+import { PublishLinkedInButton } from "./PublishLinkedInButton";
+
+afterEach(() => {
+  cleanup();
+  actionMocks.publishOutboundDraftAction.mockReset();
+});
+
+describe("PublishLinkedInButton confirmation step", () => {
+  it("shows channel, artifact title, audience, and external consequence before publishing", () => {
+    render(
+      <PublishLinkedInButton
+        draftId="draft-1"
+        channelConnected
+        channelId="linkedin-personal-social"
+        artifactTitle="Seasonal menu launch"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /publish to linkedin/i }));
+
+    const panel = screen.getByTestId("publish-confirm-panel");
+    expect(panel.textContent).toContain("LinkedIn");
+    expect(panel.textContent).toContain("Seasonal menu launch");
+    expect(panel.textContent).toMatch(/audience/i);
+    expect(panel.textContent).toMatch(/posts outside DPF/i);
+    // Nothing has been published yet — the first click only opens the review.
+    expect(actionMocks.publishOutboundDraftAction).not.toHaveBeenCalled();
+  });
+
+  it("publishes only after the explicit confirmation", async () => {
+    actionMocks.publishOutboundDraftAction.mockResolvedValue({
+      ok: true,
+      externalUrl: "https://linkedin.example/post/1",
+    });
+    render(
+      <PublishLinkedInButton draftId="draft-1" channelConnected channelId="linkedin-personal-social" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /publish to linkedin/i }));
+    fireEvent.click(screen.getByRole("button", { name: /yes, publish to linkedin/i }));
+
+    await waitFor(() => expect(actionMocks.publishOutboundDraftAction).toHaveBeenCalledWith("draft-1"));
+    expect(await screen.findByTestId("publish-success-link")).toBeTruthy();
+  });
+
+  it("keeps the draft when the owner backs out of the review", () => {
+    render(
+      <PublishLinkedInButton draftId="draft-1" channelConnected channelId="linkedin-personal-social" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /publish to linkedin/i }));
+    fireEvent.click(screen.getByRole("button", { name: /keep as draft/i }));
+
+    expect(screen.queryByTestId("publish-confirm-panel")).toBeNull();
+    expect(screen.getByRole("button", { name: /publish to linkedin/i })).toBeTruthy();
+    expect(actionMocks.publishOutboundDraftAction).not.toHaveBeenCalled();
+  });
+
+  it("still hard-blocks off-archetype content ahead of any confirmation", () => {
+    render(
+      <PublishLinkedInButton
+        draftId="draft-1"
+        channelConnected
+        channelId="linkedin-personal-social"
+        fitBlocked
+      />,
+    );
+    expect(screen.getByTestId("publish-blocked-fit")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /publish to linkedin/i })).toBeNull();
+  });
+});

--- a/apps/web/components/customer-marketing/PublishLinkedInButton.tsx
+++ b/apps/web/components/customer-marketing/PublishLinkedInButton.tsx
@@ -9,10 +9,21 @@ type Props = {
   channelId: string;
   /** True when archetype-fit flags the body as off-archetype/software-platform content. */
   fitBlocked?: boolean;
+  /** Owner-readable artifact title shown in the pre-publish confirmation. */
+  artifactTitle?: string | null;
+  /** Owner-readable audience description shown in the pre-publish confirmation. */
+  audience?: string | null;
 };
 
-export function PublishLinkedInButton({ draftId, channelConnected, channelId, fitBlocked }: Props) {
-  const [status, setStatus] = useState<"idle" | "publishing" | "done" | "error">("idle");
+export function PublishLinkedInButton({
+  draftId,
+  channelConnected,
+  channelId,
+  fitBlocked,
+  artifactTitle,
+  audience,
+}: Props) {
+  const [status, setStatus] = useState<"idle" | "confirming" | "publishing" | "done" | "error">("idle");
   const [message, setMessage] = useState<string | null>(null);
   const [externalUrl, setExternalUrl] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
@@ -77,11 +88,50 @@ export function PublishLinkedInButton({ draftId, channelConnected, channelId, fi
     );
   }
 
+  // Explicit owner confirmation before anything leaves the building: channel,
+  // artifact, audience, and the external consequence, reviewed in one place
+  // (BI-CC580161 publish-confirmation acceptance).
+  if (status === "confirming") {
+    return (
+      <div
+        data-testid="publish-confirm-panel"
+        className="flex flex-col gap-2 rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] p-3 text-xs text-[var(--dpf-text)]"
+      >
+        <p className="font-semibold">Publish this post publicly?</p>
+        <ul className="flex flex-col gap-1">
+          <li><span className="text-[var(--dpf-muted)]">Channel:</span> LinkedIn</li>
+          {artifactTitle && <li><span className="text-[var(--dpf-muted)]">Post:</span> {artifactTitle}</li>}
+          <li>
+            <span className="text-[var(--dpf-muted)]">Audience:</span>{" "}
+            {audience ?? "everyone who can see this business's LinkedIn presence"}
+          </li>
+          <li>This posts outside DPF. It can be deleted on LinkedIn later, but people may already have seen it.</li>
+        </ul>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={onPublish}
+            className="rounded-full bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-white"
+          >
+            Yes, publish to LinkedIn
+          </button>
+          <button
+            type="button"
+            onClick={() => setStatus("idle")}
+            className="rounded-full border border-[var(--dpf-border)] px-4 py-1.5 text-sm text-[var(--dpf-text)]"
+          >
+            Keep as draft
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-wrap items-center gap-2">
       <button
         type="button"
-        onClick={onPublish}
+        onClick={() => setStatus("confirming")}
         disabled={pending}
         className="rounded-full bg-[var(--dpf-accent)] px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50"
       >

--- a/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.test.tsx
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-vi.mock("@/components/ui/Dialog", () => ({
+const dialogMocks = vi.hoisted(() => ({
+  confirmDialog: vi.fn(),
   promptDialog: vi.fn(),
 }));
+vi.mock("@/components/ui/Dialog", () => dialogMocks);
 
 import { StorefrontInbox } from "./StorefrontInbox";
 
@@ -27,7 +29,42 @@ function inquiry(overrides: Record<string, unknown> = {}) {
   };
 }
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  dialogMocks.confirmDialog.mockReset();
+  dialogMocks.promptDialog.mockReset();
+});
+
+function booking(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "bk_1",
+    ref: "BK-0001",
+    name: "Jane Smith",
+    email: "jane.smith@example.com",
+    type: "booking",
+    detail: "Wednesday, July 22",
+    createdAt: "2026-07-20T10:00:00.000Z",
+    providerName: null,
+    status: "pending",
+    backlogItemId: null,
+    itemName: "Table for 2",
+    covers: 2,
+    whenLabel: "Wednesday, July 22 · 6:30 PM",
+    timeLabel: "6:30 PM",
+    nextAction: "Confirm or decline",
+    ...overrides,
+  };
+}
+
+function stubFetch(response: { ok: boolean; body?: Record<string, unknown> }) {
+  const fetchMock = vi.fn(async () => ({
+    ok: response.ok,
+    json: async () => response.body ?? {},
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
 
 // ── Send-to-backlog action state (BI-4F4252DB) ──────────────────────────────
 describe("StorefrontInbox send-to-backlog state", () => {
@@ -110,5 +147,110 @@ describe("StorefrontInbox — owner inbox visibility (inquiry)", () => {
     );
     expect(screen.getByRole("button", { name: /send inquiry INQ-0001 to backlog/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /send inquiry INQ-SECOND22 to backlog/i })).toBeTruthy();
+  });
+});
+
+// ── Booking action-result contract (BI-3DA1DFDC) ─────────────────────────────
+describe("StorefrontInbox — booking confirm/cancel result states", () => {
+  it("reviews the exact reservation before confirming, then shows a success state without reloading", async () => {
+    dialogMocks.confirmDialog.mockResolvedValue(true);
+    const fetchMock = stubFetch({ ok: true });
+    render(<StorefrontInbox entries={[booking()]} defaultDigitalProduct={defaultDigitalProduct} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /confirm jane smith, table for 2 at 6:30 pm/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/confirmed — the guest's booking is now confirmed\./i)).toBeTruthy(),
+    );
+    // Pre-action review named the exact reservation + consequence.
+    expect(dialogMocks.confirmDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringMatching(/confirm jane smith, table for 2 at 6:30 pm/i),
+        message: expect.stringMatching(/BK-0001.*becomes confirmed/i),
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith("/api/storefront/bookings/bk_1/confirm", { method: "POST" });
+    // The row's visible status updated in place — no window.location.reload().
+    expect(screen.getByText("confirmed")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /confirm jane smith/i })).toBeNull();
+  });
+
+  it("does nothing when the owner declines the confirm review", async () => {
+    dialogMocks.confirmDialog.mockResolvedValue(false);
+    const fetchMock = stubFetch({ ok: true });
+    render(<StorefrontInbox entries={[booking()]} defaultDigitalProduct={defaultDigitalProduct} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /confirm jane smith/i }));
+    await waitFor(() => expect(dialogMocks.confirmDialog).toHaveBeenCalled());
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a failed confirm as a row-specific retryable error, not a silent reload", async () => {
+    dialogMocks.confirmDialog.mockResolvedValue(true);
+    stubFetch({ ok: false, body: { error: "Booking already cancelled by the guest." } });
+    render(<StorefrontInbox entries={[booking()]} defaultDigitalProduct={defaultDigitalProduct} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /confirm jane smith/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Booking already cancelled by the guest.");
+    expect(alert.textContent).toMatch(/the booking is unchanged — try again/i);
+    // The action is still available for retry.
+    expect(screen.getByRole("button", { name: /confirm jane smith/i })).toBeTruthy();
+  });
+
+  it("names the reservation in the cancel dialog and shows the cancelled result", async () => {
+    dialogMocks.promptDialog.mockResolvedValue("Guest phoned to cancel");
+    const fetchMock = stubFetch({ ok: true });
+    render(<StorefrontInbox entries={[booking()]} defaultDigitalProduct={defaultDigitalProduct} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel jane smith, table for 2 at 6:30 pm/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/cancelled — the guest sees this booking as cancelled\./i)).toBeTruthy(),
+    );
+    expect(dialogMocks.promptDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringMatching(/cancel jane smith, table for 2 at 6:30 pm/i),
+        message: expect.stringMatching(/BK-0001.*guest will see this booking as cancelled/i),
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/storefront/bookings/bk_1/cancel",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(screen.getByText("cancelled")).toBeTruthy();
+  });
+});
+
+// ── Filter announcement + labelled provider select (BI-F0B389C9 residue) ─────
+describe("StorefrontInbox — filter chips and provider select", () => {
+  it("marks the active filter chip and announces the result count", () => {
+    render(
+      <StorefrontInbox
+        entries={[inquiry(), booking()]}
+        defaultDigitalProduct={defaultDigitalProduct}
+      />,
+    );
+    const all = screen.getByRole("button", { name: /filter requests: all/i });
+    expect(all.getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: /filter requests: booking/i }));
+    expect(
+      screen.getByRole("button", { name: /filter requests: booking/i }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(screen.getByRole("status").textContent).toMatch(/showing 1 of 2 requests — booking filter on/i);
+  });
+
+  it("gives the booking provider filter an accessible name", () => {
+    render(
+      <StorefrontInbox
+        entries={[booking({ providerName: "Table 1" })]}
+        providers={[{ id: "p1", name: "Table 1" }]}
+        defaultDigitalProduct={defaultDigitalProduct}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /filter requests: booking/i }));
+    expect(screen.getByRole("combobox", { name: /filter bookings by provider/i })).toBeTruthy();
   });
 });

--- a/apps/web/components/storefront-admin/StorefrontInbox.tsx
+++ b/apps/web/components/storefront-admin/StorefrontInbox.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState } from "react";
-import { promptDialog } from "@/components/ui/Dialog";
+import { confirmDialog, promptDialog } from "@/components/ui/Dialog";
 import { reservationActionLabel } from "@/lib/storefront/booking-summary";
 
 type Entry = {
@@ -60,6 +60,15 @@ export function StorefrontInbox({
   const [providerFilter, setProviderFilter] = useState<string>("all");
   const [productBacklogState, setProductBacklogState] = useState<Record<string, string>>({});
   const [pendingInquiryId, setPendingInquiryId] = useState<string | null>(null);
+  // Row-specific booking action result state: an owner must see whether a
+  // confirm/cancel is in flight, succeeded, or failed — never a silent reload
+  // that hides a failed POST (BI-3DA1DFDC).
+  const [bookingAction, setBookingAction] = useState<
+    Record<string, { phase: "pending" | "done" | "error"; message: string }>
+  >({});
+  // Successful actions update the row's visible status without a full reload,
+  // so the success note and the new status stay on screen together.
+  const [statusOverride, setStatusOverride] = useState<Record<string, string>>({});
 
   const filtered = entries.filter((e) => {
     if (typeFilter !== "all" && e.type !== typeFilter) return false;
@@ -67,27 +76,79 @@ export function StorefrontInbox({
     return true;
   });
 
-  async function cancelBooking(id: string) {
+  function bookingLabelParts(e: Entry) {
+    return { guestName: e.name, itemName: e.itemName, timeLabel: e.timeLabel };
+  }
+
+  async function runBookingAction(
+    e: Entry,
+    opts: {
+      pendingMessage: string;
+      successStatus: string;
+      successMessage: string;
+      failureMessage: string;
+      request: () => Promise<Response>;
+    },
+  ) {
+    setBookingAction((s) => ({ ...s, [e.id]: { phase: "pending", message: opts.pendingMessage } }));
+    try {
+      const res = await opts.request();
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(typeof body.error === "string" ? body.error : opts.failureMessage);
+      }
+      setStatusOverride((s) => ({ ...s, [e.id]: opts.successStatus }));
+      setBookingAction((s) => ({ ...s, [e.id]: { phase: "done", message: opts.successMessage } }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : opts.failureMessage;
+      setBookingAction((s) => ({
+        ...s,
+        [e.id]: { phase: "error", message: `${message} The booking is unchanged — try again.` },
+      }));
+    }
+  }
+
+  async function cancelBooking(e: Entry) {
+    // Name the exact reservation in the dialog so the owner reviews what they
+    // are cancelling — guest, table/service, time — plus the consequence.
     const reason = await promptDialog({
-      title: "Cancel booking",
-      message: "Cancellation reason:",
+      title: reservationActionLabel("Cancel", bookingLabelParts(e)),
+      message: `Booking ${e.ref}. The guest will see this booking as cancelled. Cancellation reason:`,
       confirmLabel: "Cancel booking",
       cancelLabel: "Keep booking",
     });
     if (reason === null) return; // user dismissed
-    await fetch(`/api/storefront/bookings/${id}/cancel`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ reason }),
+    await runBookingAction(e, {
+      pendingMessage: "Cancelling…",
+      successStatus: "cancelled",
+      successMessage: "Cancelled — the guest sees this booking as cancelled.",
+      failureMessage: "Couldn't cancel the booking.",
+      request: () =>
+        fetch(`/api/storefront/bookings/${e.id}/cancel`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reason }),
+        }),
     });
-    window.location.reload();
   }
 
-  async function confirmBooking(id: string) {
-    await fetch(`/api/storefront/bookings/${id}/confirm`, {
-      method: "POST",
+  async function confirmBooking(e: Entry) {
+    // Pre-action review with consequence copy: exactly which reservation, and
+    // what confirming changes for the guest (BI-3DA1DFDC).
+    const ok = await confirmDialog({
+      title: reservationActionLabel("Confirm", bookingLabelParts(e)),
+      message: `Booking ${e.ref}. The guest's booking becomes confirmed. You can still cancel later with a reason.`,
+      confirmLabel: "Confirm booking",
+      cancelLabel: "Not yet",
     });
-    window.location.reload();
+    if (!ok) return;
+    await runBookingAction(e, {
+      pendingMessage: "Confirming…",
+      successStatus: "confirmed",
+      successMessage: "Confirmed — the guest's booking is now confirmed.",
+      failureMessage: "Couldn't confirm the booking.",
+      request: () => fetch(`/api/storefront/bookings/${e.id}/confirm`, { method: "POST" }),
+    });
   }
 
   async function sendInquiryToProductBacklog(id: string) {
@@ -149,14 +210,16 @@ export function StorefrontInbox({
         </div>
       )}
 
-      <div style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap", alignItems: "center" }}>
+      <div style={{ display: "flex", gap: 8, marginBottom: 8, flexWrap: "wrap", alignItems: "center" }}>
         {["all", "inquiry", "booking", "order", "donation"].map((t) => (
           <button
             key={t}
             onClick={() => { setTypeFilter(t); setProviderFilter("all"); }}
-            className={`border border-[var(--dpf-border)] ${typeFilter === t ? "bg-[var(--dpf-accent)] text-white" : ""}`}
+            aria-pressed={typeFilter === t}
+            aria-label={`Filter requests: ${t === "all" ? "All" : TYPE_LABELS[t]}`}
+            className={`dpf-tap-target border border-[var(--dpf-border)] ${typeFilter === t ? "bg-[var(--dpf-accent)] text-white" : ""}`}
             style={{
-              padding: "4px 10px",
+              padding: "4px 12px",
               borderRadius: 4,
               background: typeFilter === t ? undefined : "none",
               color: typeFilter === t ? undefined : "inherit",
@@ -171,7 +234,8 @@ export function StorefrontInbox({
           <select
             value={providerFilter}
             onChange={(e) => setProviderFilter(e.target.value)}
-            className="border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]"
+            aria-label="Filter bookings by provider"
+            className="dpf-tap-target border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)]"
             style={{
               padding: "4px 10px",
               borderRadius: 4,
@@ -187,6 +251,12 @@ export function StorefrontInbox({
           </select>
         )}
       </div>
+      {/* Announce the active filter + result count so the chips aren't a silent
+          visual-only state (BI-4F4252DB follow-through). */}
+      <p role="status" className="text-[var(--dpf-muted)]" style={{ fontSize: 12, margin: "0 0 16px" }}>
+        Showing {filtered.length} of {entries.length} requests
+        {typeFilter !== "all" ? ` — ${TYPE_LABELS[typeFilter]} filter on` : ""}
+      </p>
 
       {filtered.length === 0 && <p className="text-[var(--dpf-muted)]" style={{ fontSize: 13 }}>No entries yet.</p>}
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
@@ -210,7 +280,9 @@ export function StorefrontInbox({
                 </span>
               )}
               <span style={{ fontSize: 12, fontFamily: "monospace" }}>{e.ref}</span>
-              {e.type === "booking" && e.status && <StatusBadge status={e.status} />}
+              {e.type === "booking" && (statusOverride[e.id] ?? e.status) && (
+                <StatusBadge status={statusOverride[e.id] ?? e.status} />
+              )}
               {e.type === "booking" && e.providerName && (
                 <span className="text-[var(--dpf-accent)]" style={{ fontSize: 11, padding: "1px 7px", borderRadius: 10, background: "rgba(79,70,229,0.12)" }}>
                   {e.providerName}
@@ -270,7 +342,7 @@ export function StorefrontInbox({
                         </span>
                         <a
                           href={`/ops?itemId=${encodeURIComponent(backlogItemId)}`}
-                          className="text-[var(--dpf-accent)]"
+                          className="dpf-tap-target text-[var(--dpf-accent)]"
                           style={{ fontSize: 12, textDecoration: "underline" }}
                           aria-label={`Open backlog item ${backlogItemId} for inquiry ${e.ref}`}
                         >
@@ -287,9 +359,9 @@ export function StorefrontInbox({
                           disabled={!defaultDigitalProduct || isSending}
                           aria-label={`Send inquiry ${e.ref} to backlog`}
                           title={`Creates an internal work item from ${e.name ?? "this customer"}'s inquiry ${e.ref}. The customer is not notified.`}
-                          className="border border-[var(--dpf-accent)] text-[var(--dpf-accent)]"
+                          className="dpf-tap-target border border-[var(--dpf-accent)] text-[var(--dpf-accent)]"
                           style={{
-                            padding: "3px 10px",
+                            padding: "3px 12px",
                             borderRadius: 4,
                             background: "none",
                             cursor: !defaultDigitalProduct || isSending ? "not-allowed" : "pointer",
@@ -315,38 +387,70 @@ export function StorefrontInbox({
                 </div>
               );
             })()}
-            {e.type === "booking" && (
-              <div style={{ display: "flex", gap: 6, marginTop: 8 }}>
-                {e.status === "pending" && (
-                  <button
-                    onClick={() => confirmBooking(e.id)}
-                    aria-label={reservationActionLabel("Confirm", {
-                      guestName: e.name,
-                      itemName: e.itemName,
-                      timeLabel: e.timeLabel,
-                    })}
-                    className="border border-[var(--dpf-success)] text-[var(--dpf-success)]"
-                    style={{ padding: "3px 10px", borderRadius: 4, background: "none", cursor: "pointer", fontSize: 12 }}
-                  >
-                    Confirm
-                  </button>
-                )}
-                {e.status !== "cancelled" && e.status !== "completed" && (
-                  <button
-                    onClick={() => cancelBooking(e.id)}
-                    aria-label={reservationActionLabel("Cancel", {
-                      guestName: e.name,
-                      itemName: e.itemName,
-                      timeLabel: e.timeLabel,
-                    })}
-                    className="border border-[var(--dpf-error)] text-[var(--dpf-error)]"
-                    style={{ padding: "3px 10px", borderRadius: 4, background: "none", cursor: "pointer", fontSize: 12 }}
-                  >
-                    Cancel
-                  </button>
-                )}
-              </div>
-            )}
+            {e.type === "booking" && (() => {
+              const status = statusOverride[e.id] ?? e.status;
+              const action = bookingAction[e.id];
+              const busy = action?.phase === "pending";
+              return (
+                <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 8 }}>
+                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                    {status === "pending" && (
+                      <button
+                        onClick={() => confirmBooking(e)}
+                        disabled={busy}
+                        aria-label={reservationActionLabel("Confirm", bookingLabelParts(e))}
+                        className="dpf-tap-target border border-[var(--dpf-success)] text-[var(--dpf-success)]"
+                        style={{
+                          padding: "3px 12px",
+                          borderRadius: 4,
+                          background: "none",
+                          cursor: busy ? "wait" : "pointer",
+                          fontSize: 12,
+                          opacity: busy ? 0.6 : 1,
+                        }}
+                      >
+                        {busy ? "Working…" : "Confirm"}
+                      </button>
+                    )}
+                    {status !== "cancelled" && status !== "completed" && (
+                      <button
+                        onClick={() => cancelBooking(e)}
+                        disabled={busy}
+                        aria-label={reservationActionLabel("Cancel", bookingLabelParts(e))}
+                        className="dpf-tap-target border border-[var(--dpf-error)] text-[var(--dpf-error)]"
+                        style={{
+                          padding: "3px 12px",
+                          borderRadius: 4,
+                          background: "none",
+                          cursor: busy ? "wait" : "pointer",
+                          fontSize: 12,
+                          opacity: busy ? 0.6 : 1,
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    )}
+                  </div>
+                  {/* Row-specific action result: pending, success, or a failure the
+                      owner can retry — never a silent reload (BI-3DA1DFDC). */}
+                  {action && (
+                    <span
+                      role={action.phase === "error" ? "alert" : "status"}
+                      className={
+                        action.phase === "error"
+                          ? "text-[var(--dpf-error)]"
+                          : action.phase === "done"
+                            ? "text-[var(--dpf-success)]"
+                            : "text-[var(--dpf-muted)]"
+                      }
+                      style={{ fontSize: 12 }}
+                    >
+                      {action.message}
+                    </span>
+                  )}
+                </div>
+              );
+            })()}
           </div>
         ))}
       </div>

--- a/apps/web/components/storefront/SlotBookingFlow.mobile.test.tsx
+++ b/apps/web/components/storefront/SlotBookingFlow.mobile.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+// Mobile smoke for the public booking flow at phone width (BI-2B2FCB2B):
+// calendar day buttons and time-slot buttons carry a 44px touch-target floor and
+// full-context accessible names, and the final form keeps the selected slot as
+// the single source of truth (no duplicate editable preferred date/time).
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock("@/lib/storefront-actions", () => ({
+  submitBooking: vi.fn(),
+}));
+
+import { SlotBookingFlow } from "./SlotBookingFlow";
+
+// Tomorrow in local time — a clickable (non-past) calendar day. If tomorrow
+// rolls into the next month the test clicks "Next month" first.
+const now = new Date();
+const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+const tomorrowStr = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, "0")}-${String(
+  tomorrow.getDate(),
+).padStart(2, "0")}`;
+const tomorrowLabel = tomorrow.toLocaleDateString("default", {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+});
+
+function stubBookingFetch() {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/dates")) {
+      return { ok: true, json: async () => ({ dates: [tomorrowStr] }) };
+    }
+    if (url.includes("/slots")) {
+      return {
+        ok: true,
+        json: async () => ({
+          mode: "next-available",
+          slots: [{ startTime: "18:30", endTime: "20:00" }],
+        }),
+      };
+    }
+    if (url.includes("/hold")) {
+      return { ok: true, json: async () => ({ holderToken: "tok_1" }) };
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+async function renderFlowAtSlotStep() {
+  stubBookingFetch();
+  render(
+    <SlotBookingFlow
+      orgSlug="demo-restaurant"
+      itemId="itm-1"
+      itemInternalId="cuid-1"
+      itemName="Table for 2"
+      timezone="Europe/London"
+      bookingConfig={null}
+      resourceNoun="table"
+    />,
+  );
+  if (tomorrow.getMonth() !== now.getMonth()) {
+    fireEvent.click(screen.getByRole("button", { name: "Next month" }));
+  }
+  const dayButton = await screen.findByRole("button", {
+    name: `${tomorrowLabel} — available`,
+  });
+  return dayButton;
+}
+
+describe("public booking mobile contract (390px floor)", () => {
+  it("gives calendar day buttons a 44px floor and a full-date accessible name", async () => {
+    const dayButton = await renderFlowAtSlotStep();
+    expect((dayButton as HTMLButtonElement).style.minHeight).toBe("44px");
+  });
+
+  it("labels time-slot buttons with the full slot context and a 44px floor", async () => {
+    const dayButton = await renderFlowAtSlotStep();
+    fireEvent.click(dayButton);
+
+    const slotButton = await screen.findByRole("button", {
+      name: `6:30 PM to 8:00 PM on ${tomorrowLabel}`,
+    });
+    expect((slotButton as HTMLButtonElement).style.minHeight).toBe("44px");
+    expect((slotButton as HTMLButtonElement).style.minWidth).toBe("44px");
+  });
+
+  it("keeps the selected slot authoritative on the final form — no duplicate date/time fields", async () => {
+    const dayButton = await renderFlowAtSlotStep();
+    fireEvent.click(dayButton);
+    fireEvent.click(await screen.findByRole("button", { name: `6:30 PM to 8:00 PM on ${tomorrowLabel}` }));
+
+    // Final form: the reservation summary states the fixed slot…
+    const summary = await screen.findByRole("group", { name: "Your reservation" });
+    await waitFor(() => expect(summary.textContent).toContain("6:30 PM — 8:00 PM"));
+    expect(summary.textContent).toContain(tomorrowLabel);
+    expect(summary.textContent).toContain("To change the date or time, go back and pick another slot.");
+
+    // …and no editable preferred-date/preferred-time controls re-ask for it.
+    expect(screen.queryByLabelText(/preferred date/i)).toBeNull();
+    expect(screen.queryByLabelText(/preferred time/i)).toBeNull();
+    expect(document.querySelector('input[type="date"]')).toBeNull();
+    expect(document.querySelector('input[type="time"]')).toBeNull();
+  });
+});

--- a/apps/web/components/storefront/SlotBookingFlow.tsx
+++ b/apps/web/components/storefront/SlotBookingFlow.tsx
@@ -97,6 +97,7 @@ const fieldStyle: React.CSSProperties = {
 function primaryBtnStyle(disabled?: boolean): React.CSSProperties {
   return {
     padding: "10px 20px",
+    minHeight: 44,
     background: disabled ? "var(--dpf-muted)" : "var(--dpf-accent, #4f46e5)",
     color: "var(--dpf-surface-1, #fff)",
     border: "none",
@@ -117,8 +118,25 @@ function ghostBtnStyle(): React.CSSProperties {
     fontSize: 13,
     padding: 0,
     textDecoration: "underline",
+    // 44px touch-target floor on phone viewports (BI-2B2FCB2B).
+    minHeight: 44,
+    display: "inline-flex",
+    alignItems: "center",
   };
 }
+
+/** Shared 44px-floor style for tappable slot/time buttons (BI-2B2FCB2B). */
+const slotBtnBase: React.CSSProperties = {
+  border: "1px solid var(--dpf-border)",
+  borderRadius: 6,
+  background: "var(--dpf-surface-2)",
+  color: "var(--dpf-text)",
+  fontSize: 14,
+  cursor: "pointer",
+  fontWeight: 500,
+  minHeight: 44,
+  minWidth: 44,
+};
 
 // ── Calendar helpers ──────────────────────────────────────────────────────────
 
@@ -528,6 +546,7 @@ function DateStep({
               style={{
                 textAlign: "center",
                 padding: "8px 4px",
+                minHeight: 44,
                 borderRadius: 6,
                 border: "1px solid transparent",
                 fontSize: 14,
@@ -605,6 +624,7 @@ function SlotStep({
           {slotsResult.mode === "next-available" && (
             <NextAvailableSlots
               slots={slotsResult.slots}
+              dateLabel={formatDisplayDate(selectedDate)}
               selectLabel={copy.selectTime}
               onSelect={(slot) => onSelectSlot(slot)}
             />
@@ -612,12 +632,14 @@ function SlotStep({
           {slotsResult.mode === "customer-choice" && (
             <CustomerChoiceSlots
               providers={slotsResult.providers}
+              dateLabel={formatDisplayDate(selectedDate)}
               onSelect={onSelectSlot}
             />
           )}
           {slotsResult.mode === "class" && (
             <ClassSlots
               slots={slotsResult.slots}
+              dateLabel={formatDisplayDate(selectedDate)}
               onSelect={(slot) => onSelectSlot(slot)}
             />
           )}
@@ -638,12 +660,22 @@ function isEmpty(result: SlotsResult): boolean {
   return result.slots.length === 0;
 }
 
+/** The visible label is just the start time, so tie the accessible name to the
+ *  full slot context — time range + day (+ provider) — mirroring the calendar's
+ *  day buttons (BI-2B2FCB2B). */
+function slotAccessibleName(slot: AvailableSlot, dateLabel: string, providerName?: string): string {
+  const range = `${formatTime(slot.startTime)} to ${formatTime(slot.endTime)}`;
+  return `${range} on ${dateLabel}${providerName ? ` with ${providerName}` : ""}`;
+}
+
 function NextAvailableSlots({
   slots,
+  dateLabel,
   selectLabel = "Select a time:",
   onSelect,
 }: {
   slots: AvailableSlot[];
+  dateLabel: string;
   selectLabel?: string;
   onSelect: (slot: AvailableSlot) => void;
 }) {
@@ -655,16 +687,8 @@ function NextAvailableSlots({
           <button
             key={`${slot.startTime}-${slot.providerId ?? "any"}`}
             onClick={() => onSelect(slot)}
-            style={{
-              padding: "8px 14px",
-              border: "1px solid var(--dpf-border)",
-              borderRadius: 6,
-              background: "var(--dpf-surface-2)",
-              color: "var(--dpf-text)",
-              fontSize: 14,
-              cursor: "pointer",
-              fontWeight: 500,
-            }}
+            aria-label={slotAccessibleName(slot, dateLabel)}
+            style={{ ...slotBtnBase, padding: "8px 14px" }}
           >
             {formatTime(slot.startTime)}
           </button>
@@ -676,9 +700,11 @@ function NextAvailableSlots({
 
 function CustomerChoiceSlots({
   providers,
+  dateLabel,
   onSelect,
 }: {
   providers: SlotsByProvider[];
+  dateLabel: string;
   onSelect: (slot: AvailableSlot, provider: { id: string; name: string; avatarUrl?: string | null }) => void;
 }) {
   return (
@@ -731,16 +757,8 @@ function CustomerChoiceSlots({
               <button
                 key={slot.startTime}
                 onClick={() => onSelect(slot, provider)}
-                style={{
-                  padding: "8px 14px",
-                  border: "1px solid var(--dpf-border)",
-                  borderRadius: 6,
-                  background: "var(--dpf-surface-2)",
-                  color: "var(--dpf-text)",
-                  fontSize: 14,
-                  cursor: "pointer",
-                  fontWeight: 500,
-                }}
+                aria-label={slotAccessibleName(slot, dateLabel, provider.name)}
+                style={{ ...slotBtnBase, padding: "8px 14px" }}
               >
                 {formatTime(slot.startTime)}
               </button>
@@ -754,9 +772,11 @@ function CustomerChoiceSlots({
 
 function ClassSlots({
   slots,
+  dateLabel,
   onSelect,
 }: {
   slots: AvailableSlot[];
+  dateLabel: string;
   onSelect: (slot: AvailableSlot) => void;
 }) {
   return (
@@ -766,11 +786,13 @@ function ClassSlots({
         <button
           key={slot.startTime}
           onClick={() => onSelect(slot)}
+          aria-label={slotAccessibleName(slot, dateLabel)}
           style={{
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
             padding: "12px 16px",
+            minHeight: 44,
             border: "1px solid var(--dpf-border)",
             borderRadius: 8,
             background: "var(--dpf-surface-2)",

--- a/apps/web/lib/attention/aggregate.ts
+++ b/apps/web/lib/attention/aggregate.ts
@@ -18,6 +18,7 @@ import {
 } from "./sources/coworker-memory";
 import { loadProviderCredentialItems, loadProviderSuitabilityDriftItems } from "./sources/provider-credential";
 import { loadReservationExceptionItems } from "./sources/reservation-exception";
+import { loadStorefrontInquiryItems } from "./sources/storefront-inquiry";
 import {
   loadOutboundItems,
   loadBillItems,
@@ -97,6 +98,7 @@ export async function loadAttentionItems(
     { source: "coworker-memory", load: () => loadCoworkerMemoryItems(db as unknown as CoworkerMemoryAttentionDb) },
     { source: "platform-health", load: () => loadPlatformHealthItems(db) },
     { source: "reservation-exception", load: () => loadReservationExceptionItems(db) },
+    { source: "storefront-inquiry", load: () => loadStorefrontInquiryItems(db) },
     {
       source: "provider-credential",
       load: async () => [

--- a/apps/web/lib/attention/outside-in.ts
+++ b/apps/web/lib/attention/outside-in.ts
@@ -68,6 +68,7 @@ const SOURCE_PORTFOLIO: Record<AttentionSource, AttentionPortfolio> = {
   // Customer-facing revenue surface.
   "approval-outbound": "products-and-services-sold", // marketing/sales drafts to customers
   "reservation-exception": "products-and-services-sold", // a guest awaiting an owner reservation decision
+  "storefront-inquiry": "products-and-services-sold", // a customer enquiry awaiting the owner's first reply
   // The workforce — people + AI coworkers needing a human.
   "ai-decision": "for-employees", // a coworker's decision the kernel couldn't make
   "paused-ai": "for-employees", // a coworker paused, needs input/credential

--- a/apps/web/lib/attention/owner-decision-copy.ts
+++ b/apps/web/lib/attention/owner-decision-copy.ts
@@ -16,6 +16,7 @@ const HEADLINE: Record<AttentionSource, string> = {
   "platform-health": "Choose how to handle this outage?",
   "provider-credential": "Reconnect this service?",
   "reservation-exception": "Handle this reservation?",
+  "storefront-inquiry": "Reply to this enquiry?",
 };
 
 const SPECIALIST: Record<AttentionSource, string> = {
@@ -34,6 +35,7 @@ const SPECIALIST: Record<AttentionSource, string> = {
   "platform-health": "Platform operations",
   "provider-credential": "Technology",
   "reservation-exception": "Front of house",
+  "storefront-inquiry": "Front of house",
 };
 
 export function specialistFor(source: AttentionSource): string {

--- a/apps/web/lib/attention/owner-routing.ts
+++ b/apps/web/lib/attention/owner-routing.ts
@@ -40,6 +40,11 @@ export function classifyOwnerAttentionLane(
     // choice that is never batched into a digest (BI-3DA1DFDC).
     return decision("needs-you-now", "A guest is waiting on a reservation decision.", true, appliedLevel);
   }
+  if (item.source === "storefront-inquiry") {
+    // A customer is waiting on the owner's first reply — hard-floored like a
+    // reservation so a waiting lead is never batched into a digest (BI-A36CF68D).
+    return decision("needs-you-now", "A customer is waiting on a reply.", true, appliedLevel);
+  }
   if (item.source === "paused-ai" && item.triage.residueReason === "needs-credential") {
     return decision("custodian", "A credential is technical access work, not owner judgment.", false, appliedLevel);
   }

--- a/apps/web/lib/attention/sources/storefront-inquiry.test.ts
+++ b/apps/web/lib/attention/sources/storefront-inquiry.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  storefrontInquiryToAttentionItem,
+  inquiryBacklogItemId,
+  type StorefrontInquiryRow,
+} from "./storefront-inquiry";
+import { portfolioOf } from "../outside-in";
+import { classifyOwnerAttentionLane } from "../owner-routing";
+import { specialistFor } from "../owner-decision-copy";
+
+// A public restaurant enquiry intake state — stands in for a real StorefrontInquiry
+// without touching a database or taking any external action (BI-A36CF68D).
+const newInquiry: StorefrontInquiryRow = {
+  inquiryId: "inq-1",
+  inquiryRef: "INQ-FGQXCF4X",
+  customerName: "UX Study Guest",
+  customerEmail: "ux-study@example.invalid",
+  message: "Do you take private-dining bookings for twelve people?",
+  itemName: null,
+  createdAt: new Date("2026-07-22T09:00:00.000Z"),
+};
+
+describe("storefrontInquiryToAttentionItem", () => {
+  it("projects a new enquiry as a customer-facing reply task", () => {
+    const item = storefrontInquiryToAttentionItem(newInquiry);
+    expect(item.id).toBe("storefront-inquiry:INQ-FGQXCF4X");
+    expect(item.source).toBe("storefront-inquiry");
+    expect(item.title).toBe("Reply to UX Study Guest");
+    expect(item.context).toContain("private-dining");
+    expect(item.triage.residueReason).toBe("input-required");
+    expect(item.triage.blastRadius).toContain("INQ-FGQXCF4X");
+    // Customer-facing revenue portfolio — the OUTSIDE-IN separation from coworker cards,
+    // same lane as reservation exceptions.
+    expect(portfolioOf(item)).toBe("products-and-services-sold");
+    expect(item.deepLink).toBe("/storefront/inbox");
+    // Read-only deep-link action only — replying happens in the inbox, not from here.
+    expect(item.actions.every((a) => a.kind === "open-in-context")).toBe(true);
+  });
+
+  it("names the linked item when the enquiry is about a specific offer", () => {
+    const item = storefrontInquiryToAttentionItem({ ...newInquiry, itemName: "Private Dining" });
+    expect(item.title).toBe("Reply to UX Study Guest about Private Dining");
+  });
+
+  it("falls back to ref + email context when the enquiry has no message", () => {
+    const item = storefrontInquiryToAttentionItem({ ...newInquiry, message: null });
+    expect(item.context).toContain("INQ-FGQXCF4X");
+    expect(item.context).toContain("ux-study@example.invalid");
+  });
+
+  it("routes a waiting customer to needs-you-now, never a batched digest", () => {
+    const item = storefrontInquiryToAttentionItem(newInquiry);
+    // Even in assertive mode (which batches reversible reviews), a waiting lead is hard-floored.
+    const lane = classifyOwnerAttentionLane(item, "assertive");
+    expect(lane.lane).toBe("needs-you-now");
+    expect(lane.hardFloor).toBe(true);
+  });
+
+  it("belongs to the front-of-house specialist like reservations", () => {
+    expect(specialistFor("storefront-inquiry")).toBe("Front of house");
+  });
+});
+
+describe("inquiryBacklogItemId", () => {
+  it("derives the same settled-marker id that Send-to-backlog creates", () => {
+    // Mirrors the inbox page + product-backlog route derivation: an inquiry with
+    // this backlog item present has been routed and must NOT surface as attention.
+    expect(inquiryBacklogItemId("INQ-FGQXCF4X")).toBe("BI-SFI-INQFGQXCF4X");
+  });
+});

--- a/apps/web/lib/attention/sources/storefront-inquiry.ts
+++ b/apps/web/lib/attention/sources/storefront-inquiry.ts
@@ -1,0 +1,133 @@
+// Storefront-inquiry source — projects new public StorefrontInquiry rows that
+// still need the OWNER's first response into the attention surface, so a customer
+// lead surfaces as the owner's next task instead of living only in the Storefront
+// inbox while Workspace says "nothing needs you" (BI-348766E5).
+//
+// Spec: docs/superpowers/specs/2026-06-23-human-attention-surface-design.md §4.1.
+// An inquiry needs a human while it is status `new` and has NOT been routed to
+// the backlog: routing it (Send to backlog) is the owner's handling decision, so
+// routed inquiries are settled from the attention surface's point of view even
+// though the inbox still shows their history.
+//
+// Pure mapper + a thin db loader, mirroring the reservation-exception source.
+// Read-only: never mutates an inquiry row.
+
+import type { prisma } from "@dpf/db";
+import type { AttentionItem } from "../types";
+
+type Db = typeof prisma;
+
+export type StorefrontInquiryRow = {
+  inquiryId: string;
+  inquiryRef: string;
+  customerName: string;
+  customerEmail: string;
+  message: string | null;
+  itemName: string | null;
+  createdAt: Date;
+};
+
+function clip(text: string, max = 90): string {
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+/** Project one unanswered inquiry into an attention item. Pure. */
+export function storefrontInquiryToAttentionItem(row: StorefrontInquiryRow): AttentionItem {
+  const about = row.itemName ? ` about ${row.itemName}` : "";
+  const context = row.message
+    ? clip(row.message)
+    : `${row.inquiryRef} · ${row.customerEmail}`;
+
+  return {
+    id: `storefront-inquiry:${row.inquiryRef}`,
+    source: "storefront-inquiry",
+    title: `Reply to ${row.customerName}${about}`,
+    context,
+    decisionClass: { scorability: "unscorable" },
+    // Replying is a customer-visible action, but surfacing the lead is read-only.
+    riskClass: "read",
+    triage: {
+      timeToAct: "none",
+      residueReason: "input-required",
+      blastRadius: `${row.customerName}'s inquiry ${row.inquiryRef}`,
+      decideEffort: "review",
+      irreversible: false,
+    },
+    createdAtIso: row.createdAt.toISOString(),
+    // Customer-facing revenue surface — surfaces OUTSIDE-IN, ahead of and separate
+    // from for-employees coworker decision cards (same lane as reservations).
+    portfolio: "products-and-services-sold",
+    actions: [{ kind: "open-in-context", label: "Open inquiry", href: "/storefront/inbox" }],
+    deepLink: "/storefront/inbox",
+    audience: { operator: true },
+  };
+}
+
+/** The derived backlog id Send-to-backlog creates for an inquiry ref — an
+ *  inquiry with this item present has been routed and is settled. Mirrors the
+ *  id derivation in the inbox page + product-backlog route. */
+export function inquiryBacklogItemId(inquiryRef: string): string {
+  return `BI-SFI-${inquiryRef.replace(/[^a-zA-Z0-9]/g, "").toUpperCase()}`;
+}
+
+/** Load the unanswered (new, not-yet-routed) inquiries for the install's storefront. */
+export async function loadStorefrontInquiryItems(db: Db): Promise<AttentionItem[]> {
+  const config = await db.storefrontConfig.findFirst({ select: { id: true } });
+  if (!config) return [];
+
+  // Settled = explicitly closed or already being worked; every other status
+  // (including unknown future ones) stays actionable so no waiting customer is
+  // silently dropped (BI-A36CF68D).
+  const rows = await db.storefrontInquiry.findMany({
+    where: { storefrontId: config.id, status: { notIn: ["closed", "in-progress"] } },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+    select: {
+      id: true,
+      inquiryRef: true,
+      customerName: true,
+      customerEmail: true,
+      message: true,
+      itemId: true,
+      createdAt: true,
+    },
+  });
+  if (rows.length === 0) return [];
+
+  // Routed inquiries (Send to backlog already clicked) are settled.
+  const routedIds = new Set(
+    (
+      await db.backlogItem.findMany({
+        where: { itemId: { in: rows.map((r) => inquiryBacklogItemId(r.inquiryRef)) } },
+        select: { itemId: true },
+      })
+    ).map((b) => b.itemId),
+  );
+
+  const open = rows.filter((r) => !routedIds.has(inquiryBacklogItemId(r.inquiryRef)));
+  if (open.length === 0) return [];
+
+  const itemIds = [...new Set(open.map((r) => r.itemId).filter((id): id is string => id != null))];
+  const itemNameById = new Map(
+    itemIds.length === 0
+      ? []
+      : (
+          await db.storefrontItem.findMany({
+            where: { id: { in: itemIds } },
+            select: { id: true, name: true },
+          })
+        ).map((item) => [item.id, item.name] as const),
+  );
+
+  return open.map((r) =>
+    storefrontInquiryToAttentionItem({
+      inquiryId: r.id,
+      inquiryRef: r.inquiryRef,
+      customerName: r.customerName,
+      customerEmail: r.customerEmail,
+      message: r.message,
+      itemName: r.itemId ? (itemNameById.get(r.itemId) ?? null) : null,
+      createdAt: r.createdAt,
+    }),
+  );
+}

--- a/apps/web/lib/attention/types.ts
+++ b/apps/web/lib/attention/types.ts
@@ -24,7 +24,8 @@ export type AttentionSource =
   | "ai-readiness-blocker" // AI Readiness blocked domain requiring operator action
   | "platform-health" // PortfolioQualityIssue issueType=health_alert, status=open (BI-2F778C13)
   | "provider-credential" // an enabled AI provider whose saved sign-in has EXPIRED — reconnect (BI-282C39D5)
-  | "reservation-exception"; // a public StorefrontBooking awaiting owner action — confirm / reschedule / overlap (BI-3DA1DFDC)
+  | "reservation-exception" // a public StorefrontBooking awaiting owner action — confirm / reschedule / overlap (BI-3DA1DFDC)
+  | "storefront-inquiry"; // a new public StorefrontInquiry awaiting the owner's first response (BI-348766E5)
 
 /** Risk vocabulary aligned with the paused-work plan (a2aMetadata.riskClass). */
 export type AttentionRiskClass = "read" | "bounded-write" | "high-risk" | "unknown";

--- a/docs/superpowers/plans/2026-07-22-ux-cogload-residual-closure.md
+++ b/docs/superpowers/plans/2026-07-22-ux-cogload-residual-closure.md
@@ -1,0 +1,62 @@
+# EP-UX-COGLOAD residual closure — the gaps that kept five verified-merged BIs open
+
+Date: 2026-07-22
+Backlog: BI-348766E5 + BI-A36CF68D, BI-3DA1DFDC, BI-2B2FCB2B, BI-CC580161, BI-F0B389C9 (EP-UX-COGLOAD / EP-ATTENTION-SURFACE)
+
+## Context
+
+The 2026-07-22 backlog↔PR reconciliation verified the EP-UX-COGLOAD fan-out on
+origin/main and found five BIs whose merged PRs deliver the core but miss a
+named acceptance line each. This plan closes exactly those residuals in one PR —
+no re-implementation of the merged cores.
+
+## Backlog coverage
+
+One atomic PR: each phase is a small residual on a different, already-merged
+surface; none is independently shippable as a product slice, and together they
+flip five BIs (plus the follow-up BI-A36CF68D) to done.
+
+## Phases
+
+1. **Storefront-inquiry attention source (BI-348766E5 / BI-A36CF68D)** — sibling
+   of the merged `reservation-exception` source per the BI-A36CF68D proposed
+   approach: pure mapper + loader (`sources/storefront-inquiry.ts`), settled =
+   `closed`/`in-progress` or routed-to-backlog (derived `BI-SFI-<ref>` marker),
+   unknown open statuses stay actionable; wired into `aggregate.ts`,
+   `outside-in.ts` (products-and-services-sold), `owner-decision-copy.ts`
+   (Front of house), and hard-floored needs-you-now in `owner-routing.ts`.
+2. **Booking action-result states (BI-3DA1DFDC)** — StorefrontInbox confirm/cancel
+   get pre-action review dialogs naming guest/table/time + consequence, res.ok
+   checking, row-specific pending/succeeded/failed messages with retry copy, and
+   in-place status update instead of `window.location.reload()`.
+3. **Public booking mobile floor (BI-2B2FCB2B)** — 44px minimum on calendar day,
+   month-nav, time-slot, ghost and primary buttons in SlotBookingFlow;
+   full-context accessible names on time-slot buttons; component mobile smoke
+   proving the selected slot stays authoritative on the final form.
+4. **Publish confirmation (BI-CC580161)** — PublishLinkedInButton and
+   PublishEmailButton gain an explicit review step (channel, artifact title,
+   audience, external consequence) before the action fires; archetype-fit
+   hard-block unchanged and still ahead of any confirmation.
+5. **Inbox/dashboard 390px assertions (BI-F0B389C9)** — filter chips + row
+   actions + backlog link sized via `.dpf-tap-target`, chips announce pressed
+   state + result count, provider select labelled; e2e mobile-390 assertions
+   added for `/storefront` (overflow + first-viewport owner task) and
+   `/storefront/inbox` (overflow + chip/action tap targets).
+
+## Design grounding
+
+- SSOT for attention: `docs/superpowers/specs/2026-06-23-human-attention-surface-design.md`
+  §1/§4.1 — extended with one new projector source, no materialization.
+- SSOT for the booking handoff/action labels: `docs/superpowers/plans/2026-07-22-restaurant-booking-handoff.md`
+  (`reservationActionLabel`, booking-summary contract) — extended, not changed.
+- SSOT for archetype-fit publish gating: `apps/web/lib/marketing/archetype-fit.ts`
+  (#3406/#3414) — the confirmation step composes in front of it.
+- Tap-target utility: existing `.dpf-tap-target` (44px) from #3397 — reused, not
+  reinvented.
+
+## Verification
+
+- Unit: storefront-inquiry mapper/routing, StorefrontInbox action-result suite,
+  SlotBookingFlow mobile smoke, PublishLinkedInButton confirmation suite.
+- Canonical typecheck (`tsc --noEmit`) + CI (Typecheck / Prod Build / Unit / DCO).
+- Live-install UX verification pending governed self-upgrade deploy.

--- a/docs/user-guide/storefront/inbox-and-enquiries.md
+++ b/docs/user-guide/storefront/inbox-and-enquiries.md
@@ -27,9 +27,17 @@ opening anything else:
 - **Confirm** and **Cancel** buttons that name the specific booking — a screen
   reader announces them as, for example, "Confirm Jane Smith, Table for 2 at 6:30 PM".
 
+Confirming or cancelling always shows you the exact reservation first, then tells
+you what happened: a short "working" state while it runs, a green note when it
+succeeds ("Confirmed — the guest's booking is now confirmed"), or a red note if it
+fails — the booking is unchanged and you can simply try again. Cancelling asks for
+a reason and explains that the guest will see the booking as cancelled.
+
 Urgent reservations that still need you (a booking waiting to be confirmed, one that
 needs a new time, or a double-booking to untangle) also appear in your workspace
 "What needs you now" queue, kept separate from your digital team's other decisions.
+New customer enquiries that haven't been replied to or routed yet appear there too
+("Reply to …"), so a waiting lead is never visible only in this inbox.
 
 ## What To Watch
 

--- a/e2e/storefront-owner-mobile.spec.ts
+++ b/e2e/storefront-owner-mobile.spec.ts
@@ -47,3 +47,61 @@ test.describe("Owner team/setup mobile usability @390px (BI-F0B389C9)", () => {
     }
   });
 });
+
+// Residual-closure slice (BI-F0B389C9): the dashboard + inbox routes named in
+// the acceptance now get explicit 390px assertions too. Chips/action controls
+// were sized by the residual-closure PR; earlier routes stay covered above.
+test.describe("Owner dashboard + inbox mobile usability @390px (BI-F0B389C9)", () => {
+  test("no horizontal overflow and a first-viewport owner task on /storefront", async ({ page }) => {
+    await gotoOwnerRoute(page, "/storefront");
+    const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(scrollWidth, "/storefront overflows horizontally at 390px").toBeLessThanOrEqual(
+      clientWidth + 1,
+    );
+    // Chrome budget: the owner's task content (first main-content heading) must
+    // start inside the first phone viewport, not below a wall of shell chrome.
+    const heading = page.locator("main h1, main h2").first();
+    await expect(heading).toBeVisible();
+    const box = await heading.boundingBox();
+    expect(box?.y ?? Infinity, "owner task heading must be in the first 390x844 viewport").toBeLessThan(
+      844,
+    );
+  });
+
+  test("inbox filter chips meet the 44px tap target and expose pressed state", async ({ page }) => {
+    await gotoOwnerRoute(page, "/storefront/inbox");
+    const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(scrollWidth, "/storefront/inbox overflows horizontally at 390px").toBeLessThanOrEqual(
+      clientWidth + 1,
+    );
+
+    const chips = page.getByRole("button", { name: /^filter requests:/i });
+    const chipCount = await chips.count();
+    expect(chipCount, "expected the request filter chips").toBeGreaterThanOrEqual(3);
+    for (let i = 0; i < chipCount; i++) {
+      const chip = chips.nth(i);
+      const box = await chip.boundingBox();
+      expect(box?.height ?? 0, `filter chip #${i} height`).toBeGreaterThanOrEqual(43.5);
+      expect(await chip.getAttribute("aria-pressed"), `filter chip #${i} pressed state`).not.toBeNull();
+    }
+  });
+
+  test("inbox row actions are 44px and row-specific when requests exist", async ({ page }) => {
+    await gotoOwnerRoute(page, "/storefront/inbox");
+    const rowActions = page.getByRole("button", {
+      name: /^(confirm|cancel|send inquiry) /i,
+    });
+    const count = await rowActions.count();
+    test.skip(count === 0, "no actionable requests seeded on this install");
+    for (let i = 0; i < Math.min(count, 6); i++) {
+      const box = await rowActions.nth(i).boundingBox();
+      expect(box?.height ?? 0, `inbox row action #${i} height`).toBeGreaterThanOrEqual(43.5);
+    }
+  });
+});

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -11,7 +11,7 @@ apps/web/components/ops/SelfUpgradeClient.tsx	1459
 apps/web/components/platform/AiOperationsMap.tsx	2881
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
-apps/web/components/storefront/SlotBookingFlow.tsx	988
+apps/web/components/storefront/SlotBookingFlow.tsx	1010
 apps/web/components/workbooks/Grid.tsx	1358
 apps/web/instrumentation.test.ts	897
 apps/web/instrumentation.ts	1442


### PR DESCRIPTION
## Summary

The 2026-07-22 backlog↔PR reconciliation verified the EP-UX-COGLOAD fan-out on origin/main and found five BIs whose merged PRs deliver the core but each miss one named acceptance line. This PR closes exactly those residuals — no re-implementation of the merged cores.

- **BI-348766E5 / BI-A36CF68D** — new `storefront-inquiry` attention source (sibling of the merged `reservation-exception` projector): new/unrouted StorefrontInquiry rows surface as "Reply to <guest>" in Workspace/Needs You, hard-floored `needs-you-now` so a waiting lead is never batched; settled when `closed`/`in-progress` or routed to backlog (derived `BI-SFI-<ref>` marker); unknown open statuses stay actionable.
- **BI-3DA1DFDC** — StorefrontInbox booking **Confirm/Cancel** now review the exact reservation (guest, table/service, time, ref) with consequence copy before acting, check `res.ok`, and show row-specific pending/succeeded/failed states with retry copy — replacing the silent bare-fetch + `window.location.reload()`.
- **BI-2B2FCB2B** — SlotBookingFlow calendar/month-nav/time-slot/ghost/primary buttons get the 44px touch floor; time-slot buttons get full-context accessible names ("6:30 PM to 8:00 PM on Wednesday, July 22, 2026"); mobile smoke proves the selected slot stays authoritative on the final form (no duplicate preferred date/time).
- **BI-CC580161** — Publish to LinkedIn / Send email now require an explicit owner confirmation naming channel, artifact title, audience, and the external consequence before anything leaves DPF; the archetype-fit hard block stays ahead of any confirmation.
- **BI-F0B389C9** — inbox filter chips/actions/select/link raised to the 44px floor via the shared `.dpf-tap-target`; chips announce pressed state + result count; provider select labelled; mobile-390 e2e assertions added for `/storefront` (overflow + first-viewport owner task) and `/storefront/inbox` (overflow + chip/action tap targets).

## Design grounding

Searched docs/superpowers/specs/ and docs/superpowers/plans/ — this extends existing artifacts rather than inventing new sources of truth in apps/web/:
- `docs/superpowers/specs/2026-06-23-human-attention-surface-design.md` §1/§4.1 — one new projector source, no materialization; wired through the existing per-source maps (outside-in, owner-decision-copy, owner-routing hard floor).
- `docs/superpowers/plans/2026-07-22-restaurant-booking-handoff.md` — reuses `reservationActionLabel` + booking-summary contract for the action-review dialogs.
- `apps/web/lib/marketing/archetype-fit.ts` (#3406/#3414) — the publish confirmation composes in front of the existing fit gate.
- Plan for this PR: `docs/superpowers/plans/2026-07-22-ux-cogload-residual-closure.md`.

## Test plan

- New: `storefront-inquiry.test.ts` (mapper, routing hard floor, settled-marker derivation), StorefrontInbox booking action-result suite + chips/select suite, `SlotBookingFlow.mobile.test.tsx`, `PublishLinkedInButton.test.tsx`.
- Local: vitest 20 files / 178 tests green (full attention + customer-marketing + StorefrontInbox); `tsc --noEmit` scoped to changed files clean. Full pregate typecheck is blocked in this worktree only by the missing `next` package (environmental — documented override used); CI Typecheck/Prod Build/Unit gate the merge.
- e2e additions run under the existing `mobile-390` Playwright project.

## Overlap sweep

Open PRs checked: #3419 (attention attribution) shares only `lib/attention/types.ts` (one-line union add — trivial rebase for whichever lands second); #3423/#3425 (BI-3326DA86 finance) and #3417 (docs) are file-disjoint.

Design-Grounding-Decision: extends docs/superpowers/specs/2026-06-23-human-attention-surface-design.md and the merged apps/web/ substrate; plan authored at docs/superpowers/plans/2026-07-22-ux-cogload-residual-closure.md
UX-Fit-Decision: progressive disclosure preserved — confirmation panels appear only on explicit owner intent; no new always-visible controls; touch targets raised to the 44px floor
Seed-Fit-Decision: no seed or reference-data changes; not applicable
Process-Spine-Decision: plan + user-guide doc updated in the same PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)