### PR TITLE
feat(docs): quick-help coverage for Workspace, People, Finance & Compliance + overload ceilings (BI-2DD18122)

### DIFF
--- a/apps/web/components/docs/ContextualQuickHelp.test.tsx
+++ b/apps/web/components/docs/ContextualQuickHelp.test.tsx
@@ -45,9 +45,9 @@ describe("ContextualQuickHelp", () => {
   });
 
   it("still shows the banner but omits the quick-help panel for routes without curated help", () => {
-    render(<ContextualQuickHelp sourceRoute="/finance/banking" />);
+    render(<ContextualQuickHelp sourceRoute="/no-such-area/banking" />);
 
-    expect(screen.getByRole("link", { name: "Back to page" })).toHaveAttribute("href", "/finance/banking");
+    expect(screen.getByRole("link", { name: "Back to page" })).toHaveAttribute("href", "/no-such-area/banking");
     expect(screen.queryByText("Quick help")).not.toBeInTheDocument();
   });
 

--- a/apps/web/lib/docs-quick-help.test.ts
+++ b/apps/web/lib/docs-quick-help.test.ts
@@ -47,12 +47,57 @@ describe("resolveQuickHelp", () => {
     expect(resolveQuickHelp(null)).toBeNull();
     expect(resolveQuickHelp("")).toBeNull();
     expect(resolveQuickHelp("https://example.com")).toBeNull();
-    expect(resolveQuickHelp("/finance/banking")).toBeNull();
+    expect(resolveQuickHelp("/no-such-area/banking")).toBeNull();
   });
 
   it("exposes its registered routes for coverage checks", () => {
     const routes = getQuickHelpRoutes();
     expect(routes).toContain("/ops/self-upgrade");
     expect(routes).toContain("/customer/marketing");
+  });
+
+  // ── BI-2DD18122 acceptance: representative sourceRoute coverage + ceilings ──
+  it("covers every contextual entry the acceptance names, across all main owner areas", () => {
+    const acceptanceRoutes = [
+      "/storefront/inbox",
+      "/storefront/items",
+      "/storefront/settings/operations",
+      "/compliance/licensing",
+      "/employee",
+      "/workspace",
+      "/customer/marketing",
+      "/finance",
+      "/ops/self-upgrade",
+    ];
+    for (const route of acceptanceRoutes) {
+      const help = resolveQuickHelp(route);
+      expect(help, `expected quick help for ${route}`).not.toBeNull();
+      for (const field of REQUIRED_FIELDS) {
+        expect(help![field], `${route} is missing ${field}`).toBeTruthy();
+      }
+    }
+  });
+
+  it("keeps every panel inside the overload ceiling — quick help must stay quick", () => {
+    // The whole point of the panel is LESS to read than the docs catalog: each
+    // answer stays a sentence or two, and a full panel stays well under the
+    // ~300-word wall-of-text threshold the live UX audit flagged.
+    for (const route of getQuickHelpRoutes()) {
+      const help = resolveQuickHelp(route)!;
+      let panelWords = 0;
+      for (const field of REQUIRED_FIELDS) {
+        const words = help[field].split(/\s+/).length;
+        expect(words, `${route} ${field} exceeds the 60-word answer ceiling`).toBeLessThanOrEqual(60);
+        panelWords += words;
+      }
+      expect(panelWords, `${route} panel exceeds the 220-word ceiling`).toBeLessThanOrEqual(220);
+    }
+  });
+
+  it("leaf routes override their family default (licensing vs compliance)", () => {
+    const licensing = resolveQuickHelp("/compliance/licensing");
+    const family = resolveQuickHelp("/compliance/policies");
+    expect(licensing!.whatThisPageIs).toContain("Licensing");
+    expect(family!.whatThisPageIs).not.toBe(licensing!.whatThisPageIs);
   });
 });

--- a/apps/web/lib/docs-quick-help.ts
+++ b/apps/web/lib/docs-quick-help.ts
@@ -167,6 +167,83 @@ const QUICK_HELP_MAP: QuickHelpEntry[] = [
         "Route offer, proof, or follow-up gaps to the right operations area. Full guidance is in Customers → Marketing below.",
     },
   },
+  // ── BI-2DD18122 coverage: every contextual Docs entry from the main owner
+  // areas lands with a route-specific panel, not the generic catalog. ─────────
+  {
+    routePrefix: "/workspace",
+    help: {
+      whatThisPageIs:
+        "Your daily home — what needs you now across bookings, customers, money, and your digital team, before any subsystem detail.",
+      actionNow:
+        "Work the \"needs you\" queue top-down: each card names one decision and the safest next action; anything below it can wait.",
+      ifNothingDone:
+        "Waiting customers, approvals, and exceptions sit unanswered — the queue is ordered so ignoring it delays the most time-sensitive item first.",
+      reversible:
+        "Opening and reviewing changes nothing. Each card states its own consequence before you act; most decisions can be revisited, and irreversible ones say so.",
+      recovery:
+        "A dismissed or completed card's underlying record stays in its own area (inbox, finance, approvals). Full guidance is in Workspace below.",
+    },
+  },
+  {
+    routePrefix: "/employee",
+    help: {
+      whatThisPageIs:
+        "The People area — your staff and digital coworkers, their roles, and who is covering the work.",
+      actionNow:
+        "Check today's staffing and coverage first; role governance and HR configuration can wait until the day is covered.",
+      ifNothingDone:
+        "Nothing changes by itself, but staffing gaps and unassigned responsibilities stay invisible until they bite during service or delivery.",
+      reversible:
+        "Viewing is free; assignments and role changes can be changed back. Removing a person's access takes effect immediately — re-adding restores it.",
+      recovery:
+        "A wrong assignment or role change is corrected by editing it again — the history stays. Full guidance is in People below.",
+    },
+  },
+  {
+    routePrefix: "/finance",
+    help: {
+      whatThisPageIs:
+        "The money area — what needs attention today (owed to you, owed by you, approvals), ahead of the accountant's lanes.",
+      actionNow:
+        "Answer the money jobs first: what must be collected, paid, or approved today. The Revenue/Spend/Close lanes underneath are for deeper accounting work.",
+      ifNothingDone:
+        "Unpaid invoices age, supplier bills slip past due dates, and approvals block the people waiting on them.",
+      reversible:
+        "Drafting invoices and reviewing is safe. Recording a payment or approving a bill changes your books — each action says whether it moves real money (most only record it).",
+      recovery:
+        "A wrongly recorded payment or invoice can be corrected or voided from its own record. Full guidance is in Finance below.",
+    },
+  },
+  {
+    routePrefix: "/compliance",
+    help: {
+      whatThisPageIs:
+        "The compliance area — the permits, filings, policies, and evidence your business must keep current.",
+      actionNow:
+        "Deal with anything due or expiring first; the rest of the register is reference until a deadline approaches.",
+      ifNothingDone:
+        "Deadlines pass silently — an expired permit or missed filing becomes a real-world business problem, not just a red row here.",
+      reversible:
+        "Tracking and editing the register is safe and reversible. Submitting a filing to an outside body is external — check it before sending.",
+      recovery:
+        "A mis-entered requirement can be edited or removed; submitted filings are corrected with the receiving body. Full guidance is in Compliance below.",
+    },
+  },
+  {
+    routePrefix: "/compliance/licensing",
+    help: {
+      whatThisPageIs:
+        "Licensing readiness — the permits and licences your business needs, with their status and renewal dates.",
+      actionNow:
+        "Confirm every licence the business actually operates under is listed, and act on anything expiring soon — renewals take lead time.",
+      ifNothingDone:
+        "A licence lapses and the business may be operating outside its permissions before anyone notices.",
+      reversible:
+        "Editing the register is reversible and changes nothing externally — renewals themselves happen with the issuing authority.",
+      recovery:
+        "If a licence has already lapsed, contact the issuing authority about reinstatement and record the outcome here. Full guidance is in Compliance below.",
+    },
+  },
 ];
 
 function routeMatches(pathname: string, routePrefix: string): boolean {

--- a/docs/superpowers/plans/2026-07-22-docs-quick-help-owner-area-coverage.md
+++ b/docs/superpowers/plans/2026-07-22-docs-quick-help-owner-area-coverage.md
@@ -1,0 +1,29 @@
+# Docs quick-help — owner-area coverage + overload ceilings (BI-2DD18122 final slice)
+
+Date: 2026-07-22
+Backlog: BI-2DD18122 (EP-UX-COGLOAD)
+
+## Context
+
+BI-2DD18122's acceptance requires every contextual Docs entry from the main
+owner areas to land on a route-specific quick-help panel, with representative
+sourceRoute tests and density ceilings. #3398 shipped the panel + resolver and
+covered Storefront/Ops/Marketing; #3417 adds the archetype-aware storefront
+help panel. This slice closes the remaining coverage: Workspace, People
+(/employee), Finance, and Compliance (+ the /compliance/licensing leaf), plus
+the acceptance-route test and a word-budget ceiling over every panel.
+
+## Design grounding
+
+Extends the existing SSOT — `apps/web/lib/docs-quick-help.ts` (data-only
+route→five-question map from #3398) and its test. No new components, routes, or
+contracts; the duplicate-Docs-label clause is already satisfied by
+`CONTEXTUAL_DOCS_LABEL` ("Help for this page") in the shell action contract.
+
+## Verification
+
+- `docs-quick-help.test.ts`: acceptance-route coverage (all 9 named routes,
+  five questions each), 60-word per-answer / 220-word per-panel ceilings across
+  every registered route, leaf-over-family resolution for licensing.
+- `ContextualQuickHelp.test.tsx` no-curated-help case re-pointed at a genuinely
+  unmapped route (the /finance family is now covered).


### PR DESCRIPTION
## Summary

Final slice of **BI-2DD18122** (EP-UX-COGLOAD). #3398 shipped the route-keyed five-question quick-help panel and covered Storefront/Ops/Marketing; #3417 (in flight) adds the archetype-aware storefront help panel. This PR closes the remaining acceptance:

- Coverage for the missing owner areas: **/workspace**, **/employee** (People), **/finance**, **/compliance** + a **/compliance/licensing** leaf override.
- The acceptance-route test: all nine named sourceRoutes (`/storefront/inbox`, `/storefront/items`, `/storefront/settings/operations`, `/compliance/licensing`, `/employee`, `/workspace`, `/customer/marketing`, `/finance`, `/ops/self-upgrade`) resolve a full five-question panel.
- Density ceilings enforced by test over EVERY registered route: ≤60 words per answer, ≤220 words per panel — quick help stays quick, by construction.
- `ContextualQuickHelp.test.tsx` no-curated-help case re-pointed at a genuinely unmapped route (`/finance` is now covered).

Duplicate-Docs-label clause was already satisfied on main (`CONTEXTUAL_DOCS_LABEL` = "Help for this page"); catalog demotion on contextual arrival shipped in #3398.

## Design grounding

Searched docs/superpowers/specs/ — no owning spec; this extends the existing `apps/web/lib/docs-quick-help.ts` SSOT (data-only map + resolver from #3398). No new components, routes, or contracts. Plan: `docs/superpowers/plans/2026-07-22-docs-quick-help-owner-area-coverage.md`.

## Test plan

- `docs-quick-help.test.ts` + `ContextualQuickHelp.test.tsx` + `lib/docs` suites: 27 tests green locally.
- File-disjoint from open #3417 and #3427 (overlap-swept).

Design-Grounding-Decision: extends the docs-quick-help SSOT under apps/web/; specs swept in docs/superpowers/specs/; plan authored
UX-Fit-Decision: enforced word ceilings reduce cognitive load; no new controls
Seed-Fit-Decision: no seed or reference-data changes; not applicable
Process-Spine-Decision: plan artifact added in the same PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)