### PR TITLE
feat(identity): partner principal + partner-program enrolment side table (BI-DE47EC0B)

### DIFF
--- a/apps/web/lib/govern/data/assets.ts
+++ b/apps/web/lib/govern/data/assets.ts
@@ -169,6 +169,98 @@ export function resolveField(
 
 const SEED_ASSETS: readonly DataAssetDefinition[] = [
   {
+    // BI-DE47EC0B: partner-program commercial terms for an account that resells
+    // / delivers DPF (the local-MSP channel). No data subject — this describes a
+    // BUSINESS relationship, not a person; the partner's people are contacts on
+    // the account and are governed there. Margin and tier are confidential
+    // commercial terms: disclosure across partners damages the relationship.
+    id: "data:partner-program-enrollment",
+    physical: { prismaModel: "PartnerProgramEnrollment" },
+    domain: "partner-channel",
+    ownerRole: "platform-owner",
+    stewardRole: "data-steward",
+    categories: ["operational", "financial", "configuration"],
+    sensitivity: "confidential",
+    criticality: "standard",
+    subjectLocators: [],
+    lifecycleClass: "business-record",
+    purposeCapabilities: ["service-delivery", "billing-and-payments", "platform-operations"],
+    residencyClass: "local-only",
+    projectionClass: "metadata",
+    classification: { state: "confirmed", source: "manual", effectiveFrom: "2026-07-23" },
+    fields: [
+      {
+        id: "data:partner-program-enrollment#marginPercent",
+        physicalName: "marginPercent",
+        resolution: "governed",
+        resolutionReason:
+          "Confidential partner margin from the signed agreement. Never rendered on partner-visible or customer-visible surfaces without an explicit disclosure decision.",
+        categories: ["financial"],
+        sensitivity: "confidential",
+        collectionRule: "minimize",
+        protection: "mask-on-read",
+        projectionOverride: "structure",
+        provenance: {
+          source: "manual",
+          state: "confirmed",
+          assertedBy: "data-steward",
+          effectiveFrom: "2026-07-23",
+        },
+      },
+      ...["tier", "agreementRef"].map((physicalName) => ({
+        id: `data:partner-program-enrollment#${physicalName}` as DataFieldId,
+        physicalName,
+        resolution: "governed" as const,
+        resolutionReason:
+          "Commercial standing of a business partner — organization-scoped terms visible to the operator and the partner they describe, never to other partners or customer-facing surfaces.",
+        categories: ["operational"] as DataCategory[],
+        sensitivity: "confidential" as DataSensitivity,
+        collectionRule: "minimize" as const,
+        protection: "mask-on-read" as ProtectionProfileKey,
+        projectionOverride: "metadata" as ProjectionClass,
+        provenance: {
+          source: "manual" as const,
+          state: "confirmed" as const,
+          assertedBy: "data-steward",
+          effectiveFrom: "2026-07-23",
+        },
+      })),
+      ...["status", "territory", "dealRegistrationEnabled", "enrolledAt", "endedAt"].map(
+        (physicalName) => ({
+          id: `data:partner-program-enrollment#${physicalName}` as DataFieldId,
+          physicalName,
+          resolution: "inherited" as const,
+          resolutionReason:
+            "Enrolment lifecycle and channel-configuration facts with the same scope and lifecycle as the enrolment itself; no personal data, and territory is a soft designation rather than an exclusivity grant.",
+          provenance: {
+            source: "manual" as const,
+            state: "confirmed" as const,
+            assertedBy: "data-steward",
+            effectiveFrom: "2026-07-23",
+          },
+        }),
+      ),
+      {
+        id: "data:partner-program-enrollment#notes",
+        physicalName: "notes",
+        resolution: "governed",
+        resolutionReason:
+          "Free-text operator notes on the partner relationship — unbounded content that must stay operator-scoped and out of any partner- or customer-visible projection.",
+        categories: ["content"],
+        sensitivity: "confidential",
+        collectionRule: "minimize",
+        protection: "mask-on-read",
+        projectionOverride: "structure",
+        provenance: {
+          source: "manual",
+          state: "confirmed",
+          assertedBy: "data-steward",
+          effectiveFrom: "2026-07-23",
+        },
+      },
+    ],
+  },
+  {
     id: "data:federation-pairing-session",
     physical: { prismaModel: "FederationPairingSession" },
     domain: "federated-demand",

--- a/apps/web/lib/identity/partner-principal.test.ts
+++ b/apps/web/lib/identity/partner-principal.test.ts
@@ -1,0 +1,212 @@
+// Partner identity — EP-PARTNER-CHANNEL Phase 2 (BI-DE47EC0B).
+//
+// Contract under test: a partner contact converges onto the SAME Principal
+// spine as every other party (no parallel partner identity table), and the
+// `partner` kind is DERIVED from the account's live PartnerProgramEnrollment
+// rather than asserted by the caller.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    employeeProfile: { findUnique: vi.fn() },
+    agent: { findUnique: vi.fn() },
+    customerContact: { findUnique: vi.fn() },
+    principal: { create: vi.fn(), update: vi.fn() },
+    principalAlias: { findFirst: vi.fn(), createMany: vi.fn(), findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "@dpf/db";
+import { syncPartnerPrincipal, principalKindForContact } from "./principal-linking";
+
+const NOW = new Date("2026-07-23T00:00:00Z");
+
+function partnerContact(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "contact-1",
+    email: "Tech@LocalMSP.example",
+    isActive: true,
+    account: {
+      accountId: "ACC-MSP-1",
+      partnerEnrollment: { status: "active", endedAt: null },
+    },
+    ...overrides,
+  };
+}
+
+function mockCreatedPrincipal(kind: string) {
+  vi.mocked(prisma.principalAlias.findFirst).mockResolvedValue(null);
+  vi.mocked(prisma.principal.create).mockResolvedValue({
+    id: "principal-db-partner",
+    principalId: "PRN-000900",
+    kind,
+    status: "active",
+    displayName: "Tech@LocalMSP.example",
+    sponsorPrincipalId: null,
+    authorityMode: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+  } as never);
+  vi.mocked(prisma.principalAlias.createMany).mockResolvedValue({ count: 2 });
+  vi.mocked(prisma.principalAlias.findMany).mockResolvedValue([
+    {
+      id: "alias-partner-contact",
+      principalId: "principal-db-partner",
+      aliasType: "partner_contact",
+      aliasValue: "contact-1",
+      issuer: "",
+      createdAt: NOW,
+    },
+    {
+      id: "alias-email",
+      principalId: "principal-db-partner",
+      aliasType: "email",
+      aliasValue: "tech@localmsp.example",
+      issuer: "",
+      createdAt: NOW,
+    },
+  ] as never);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("syncPartnerPrincipal", () => {
+  it("creates a partner principal anchored by partner_contact and email aliases", async () => {
+    vi.mocked(prisma.customerContact.findUnique).mockResolvedValue(partnerContact() as never);
+    mockCreatedPrincipal("partner");
+
+    const result = await syncPartnerPrincipal("contact-1");
+
+    expect(result.kind).toBe("partner");
+    expect(prisma.principal.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ kind: "partner" }) }),
+    );
+    // Email alias is lowercased so a partner contact converges with the SAME
+    // person already known as a customer contact — one principal, not two.
+    const aliasTypes = result.aliases.map((a) => a.aliasType).sort();
+    expect(aliasTypes).toEqual(["email", "partner_contact"]);
+    expect(result.aliases.find((a) => a.aliasType === "email")?.aliasValue).toBe(
+      "tech@localmsp.example",
+    );
+  });
+
+  it("re-kinds an EXISTING principal instead of creating a parallel partner identity", async () => {
+    vi.mocked(prisma.customerContact.findUnique).mockResolvedValue(partnerContact() as never);
+    // The same person already exists as a customer-kind principal (found by alias).
+    vi.mocked(prisma.principalAlias.findFirst).mockResolvedValue({
+      id: "alias-email",
+      principalId: "principal-db-partner",
+      aliasType: "email",
+      aliasValue: "tech@localmsp.example",
+      issuer: "",
+      createdAt: NOW,
+      principal: {
+        id: "principal-db-partner",
+        principalId: "PRN-000900",
+        kind: "customer",
+        status: "active",
+        displayName: "Tech@LocalMSP.example",
+        sponsorPrincipalId: null,
+        authorityMode: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    } as never);
+    vi.mocked(prisma.principal.update).mockResolvedValue({
+      id: "principal-db-partner",
+      principalId: "PRN-000900",
+      kind: "partner",
+      status: "active",
+      displayName: "Tech@LocalMSP.example",
+      sponsorPrincipalId: null,
+      authorityMode: null,
+      createdAt: NOW,
+      updatedAt: NOW,
+    } as never);
+    vi.mocked(prisma.principalAlias.createMany).mockResolvedValue({ count: 1 });
+    vi.mocked(prisma.principalAlias.findMany).mockResolvedValue([] as never);
+
+    const result = await syncPartnerPrincipal("contact-1");
+
+    expect(prisma.principal.create).not.toHaveBeenCalled();
+    expect(prisma.principal.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "principal-db-partner" },
+        data: expect.objectContaining({ kind: "partner" }),
+      }),
+    );
+    expect(result.principalId).toBe("PRN-000900");
+  });
+
+  it("refuses to promote a contact whose account has no live enrolment", async () => {
+    vi.mocked(prisma.customerContact.findUnique).mockResolvedValue(
+      partnerContact({ account: { accountId: "ACC-PLAIN", partnerEnrollment: null } }) as never,
+    );
+
+    await expect(syncPartnerPrincipal("contact-1")).rejects.toThrow(/not a partner contact/i);
+    expect(prisma.principal.create).not.toHaveBeenCalled();
+    expect(prisma.principal.update).not.toHaveBeenCalled();
+  });
+
+  it("treats an ended enrolment as not a partner", async () => {
+    vi.mocked(prisma.customerContact.findUnique).mockResolvedValue(
+      partnerContact({
+        account: {
+          accountId: "ACC-EX",
+          partnerEnrollment: { status: "ended", endedAt: new Date("2026-06-01T00:00:00Z") },
+        },
+      }) as never,
+    );
+
+    await expect(syncPartnerPrincipal("contact-1")).rejects.toThrow(/no live PartnerProgramEnrollment/i);
+  });
+
+  it("throws a clear error when the contact does not exist", async () => {
+    vi.mocked(prisma.customerContact.findUnique).mockResolvedValue(null as never);
+    await expect(syncPartnerPrincipal("missing")).rejects.toThrow(/not found/i);
+  });
+
+  it("carries inactive contact status onto the principal", async () => {
+    vi.mocked(prisma.customerContact.findUnique).mockResolvedValue(
+      partnerContact({ isActive: false }) as never,
+    );
+    mockCreatedPrincipal("partner");
+
+    await syncPartnerPrincipal("contact-1");
+
+    expect(prisma.principal.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: "inactive" }) }),
+    );
+  });
+});
+
+describe("principalKindForContact", () => {
+  it("derives partner from a live enrolment", () => {
+    expect(principalKindForContact({ partnerEnrollment: { status: "active", endedAt: null } })).toBe(
+      "partner",
+    );
+    expect(
+      principalKindForContact({ partnerEnrollment: { status: "prospect", endedAt: null } }),
+    ).toBe("partner");
+  });
+
+  it("derives customer with no enrolment, or an ended one", () => {
+    expect(principalKindForContact({ partnerEnrollment: null })).toBe("customer");
+    expect(principalKindForContact({})).toBe("customer");
+    expect(
+      principalKindForContact({ partnerEnrollment: { status: "ended", endedAt: NOW } }),
+    ).toBe("customer");
+  });
+
+  it("is the single derivation rule — an account is never both kinds at once", () => {
+    // The enrolment is additive (an MSP can be customer AND partner as a
+    // business), but the PRINCIPAL kind is single-valued and deterministic.
+    const kinds = new Set([
+      principalKindForContact({ partnerEnrollment: { status: "active", endedAt: null } }),
+      principalKindForContact({ partnerEnrollment: { status: "active", endedAt: null } }),
+    ]);
+    expect(kinds.size).toBe(1);
+  });
+});

--- a/apps/web/lib/identity/principal-linking.ts
+++ b/apps/web/lib/identity/principal-linking.ts
@@ -323,6 +323,94 @@ export async function syncCustomerPrincipal(
   });
 }
 
+/**
+ * Sync the Principal for a PARTNER contact — a person at a partner org (e.g. a
+ * local IT MSP that resells and operates installs for its local customers).
+ * EP-PARTNER-CHANNEL Phase 2 (BI-DE47EC0B).
+ *
+ * Convergence contract (AGENTS §11): there is NO parallel partner identity
+ * table. A partner contact is the same CustomerContact party row as any other
+ * contact; what makes them a partner is that their ACCOUNT carries a live
+ * PartnerProgramEnrollment. So:
+ *
+ *   - `kind` is DERIVED from the account's enrolment, never passed in. That
+ *     makes the value deterministic and prevents two callers flapping the same
+ *     principal between "customer" and "partner".
+ *   - A contact whose account has no live enrolment is rejected outright rather
+ *     than silently promoted to partner.
+ *   - The `partner_contact` alias sits ALONGSIDE the shared `email` alias, so a
+ *     person who was already synced as a customer contact converges onto the
+ *     SAME principal (found by email) and is re-kinded, rather than gaining a
+ *     second identity.
+ *
+ * An org that is both a customer and a partner is expected and supported — the
+ * enrolment is additive, not an exclusive discriminator.
+ */
+export async function syncPartnerPrincipal(
+  customerContactId: string,
+  db: PrincipalDb = prisma,
+): Promise<SyncedPrincipal> {
+  const contact = await db.customerContact.findUnique({
+    where: { id: customerContactId },
+    select: {
+      id: true,
+      email: true,
+      isActive: true,
+      account: {
+        select: {
+          accountId: true,
+          partnerEnrollment: { select: { status: true, endedAt: true } },
+        },
+      },
+    },
+  });
+
+  if (!contact) {
+    throw new Error(`CustomerContact ${customerContactId} not found.`);
+  }
+
+  const enrollment = contact.account?.partnerEnrollment;
+  const enrolled = Boolean(enrollment) && enrollment!.status !== "ended" && enrollment!.endedAt == null;
+  if (!enrolled) {
+    throw new Error(
+      `CustomerContact ${customerContactId} is not a partner contact: account ${contact.account?.accountId ?? "(none)"} has no live PartnerProgramEnrollment.`,
+    );
+  }
+
+  const lowercaseEmail = contact.email.toLowerCase();
+
+  return upsertPrincipalForAliases(db, {
+    kind: "partner",
+    status: contact.isActive ? "active" : "inactive",
+    displayName: contact.email,
+    aliases: [
+      {
+        aliasType: "partner_contact",
+        aliasValue: contact.id,
+        issuer: INTERNAL_ISSUER,
+      },
+      {
+        aliasType: "email",
+        aliasValue: lowercaseEmail,
+        issuer: INTERNAL_ISSUER,
+      },
+    ],
+  });
+}
+
+/**
+ * Resolve the principal kind a contact should carry, from its account's partner
+ * enrolment. Exported so callers that sync a contact generically (customer OR
+ * partner) apply the SAME derivation rule instead of guessing.
+ */
+export function principalKindForContact(input: {
+  partnerEnrollment?: { status: string; endedAt: Date | null } | null;
+}): "customer" | "partner" {
+  const e = input.partnerEnrollment;
+  if (e && e.status !== "ended" && e.endedAt == null) return "partner";
+  return "customer";
+}
+
 export async function ensureAgentPrincipalIdentity(
   agentId: string,
   db: PrincipalDb = prisma,

--- a/apps/web/lib/mdm/merge-adapters-completeness.test.ts
+++ b/apps/web/lib/mdm/merge-adapters-completeness.test.ts
@@ -18,6 +18,17 @@ const SCHEMA_PATH = join(__dirname, "..", "..", "..", "..", "packages", "db", "p
 
 /** Relations intentionally NOT repointed, with the reason. */
 const WAIVED: Record<string, string> = {
+  // BI-DE47EC0B. PartnerProgramEnrollment is a 1:1 side table (accountId is
+  // UNIQUE), so a blind repoint would violate that constraint whenever BOTH the
+  // survivor and the loser are enrolled partners. Deciding WHICH tier, margin
+  // and agreement survives is a commercial judgement, not something a generic
+  // dedup may make silently. Waiving is safe and non-destructive: the loser
+  // account row survives as a tombstone (mergedIntoId set), so the FK stays
+  // valid, the commercial terms remain auditable on the superseded row, and the
+  // enrolment is excluded from default reads along with its account. An explicit
+  // partner-merge path lands with the partner portal (BI-00E69FBA).
+  "PartnerProgramEnrollment.accountId":
+    "1:1 partner side table — merging enrolled partners is an explicit commercial decision, not a silent repoint; the loser's enrolment stays auditable on its tombstoned account",
   "CustomerAccount.mergedIntoId":
     "the tombstone pointer itself — merged-away rows keep pointing at their survivor",
   "CustomerSite.mergedIntoId":

--- a/docs/data-impact/2026-07-23-partner-program-enrollment.data-impact.json
+++ b/docs/data-impact/2026-07-23-partner-program-enrollment.data-impact.json
@@ -1,0 +1,64 @@
+{
+  "version": "1",
+  "accountableOwner": "partner-channel",
+  "affectedCopies": [
+    "PartnerProgramEnrollment: partner-program commercial terms for an account that resells/delivers DPF (tier, territory, agreement reference, margin, deal-registration flag). Single persisted copy; no read-model duplicates the commercial terms. The partner PRINCIPAL identity derived from it lives on the existing Principal/PrincipalAlias spine, which stores no commercial terms."
+  ],
+  "migration": {
+    "name": "20260723010000_partner_program_enrollment",
+    "backfill": "none — purely additive new table. No existing account is enrolled by this migration; accounts remain non-partners until an enrollment row is explicitly created."
+  },
+  "tests": [
+    "apps/web/lib/identity/partner-principal.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:partner-program-enrollment",
+      "prismaModel": "PartnerProgramEnrollment",
+      "lifecycleDisposition": "retained for the life of the partner relationship and cascade-deleted with its CustomerAccount; ended partnerships are retained with endedAt set so historical deal-registration and margin terms stay auditable rather than being erased",
+      "fields": [
+        {
+          "fieldId": "data:partner-program-enrollment#tier",
+          "resolution": "governed",
+          "reason": "commercial standing of a business partner — organization-scoped commercial term that must not leak to other partners or to customer-facing surfaces",
+          "provenance": "operator-set when enrolling or re-tiering a partner",
+          "fieldPolicy": "organization-scoped; visible to the operator and the partner it describes; never exposed on customer-facing or cross-partner surfaces"
+        },
+        {
+          "fieldId": "data:partner-program-enrollment#marginPercent",
+          "resolution": "governed",
+          "reason": "partner margin is confidential commercial terms; disclosure across partners or to customers would damage the commercial relationship",
+          "provenance": "operator-set from the signed partner agreement",
+          "flags": ["sensitive"],
+          "fieldPolicy": "organization-scoped and confidential; operator-only, never rendered on any partner-visible or customer-visible surface without an explicit disclosure decision"
+        },
+        {
+          "fieldId": "data:partner-program-enrollment#agreementRef",
+          "resolution": "governed",
+          "reason": "pointer to the executed partner agreement; scoped to the partner relationship it documents",
+          "provenance": "operator-entered reference to the signed agreement record",
+          "fieldPolicy": "organization-scoped; operator and the referenced partner only"
+        },
+        {
+          "fieldId": "data:partner-program-enrollment#territory",
+          "resolution": "inherited",
+          "reason": "soft local-area designation for the local-MSP channel with the same scope and lifecycle as the enrolment it belongs to; carries no personal data and is not an exclusivity grant",
+          "provenance": "operator-set when enrolling a local partner"
+        },
+        {
+          "fieldId": "data:partner-program-enrollment#status",
+          "resolution": "inherited",
+          "reason": "lifecycle state of the enrolment itself (prospect/active/suspended/ended); inherits the account's existing governance",
+          "provenance": "operator-set through the partner enrolment lifecycle"
+        },
+        {
+          "fieldId": "data:partner-program-enrollment#dealRegistrationEnabled",
+          "resolution": "inherited",
+          "reason": "feature flag for whether this partner may register deals; operational switch with no personal data, scoped to the enrolment",
+          "provenance": "operator-set per partner agreement"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/specs/2026-07-23-partner-identity-schema-audit.md
+++ b/docs/superpowers/specs/2026-07-23-partner-identity-schema-audit.md
@@ -1,0 +1,92 @@
+# Partner identity — schema audit and decision
+
+Date: 2026-07-23
+Backlog: BI-DE47EC0B (EP-PARTNER-CHANNEL Phase 2)
+Driver: BI-53D48861 — local-MSP sell-to/sell-through channel model
+Kernel decision: `DI-CD377B58CA99` (principle_decide, external_coding_agent)
+
+## 1. The question the BI posed
+
+> Schema-audit the partner-org account: reuse `CustomerAccount` with an
+> `accountKind` discriminator vs a thin `PartnerAccount` carrying
+> tier/agreement/margin/deal-registration. **NO parallel partner identity table.**
+
+## 2. What the substrate already says
+
+- `Principal` + `PrincipalAlias` is the convergence spine. `EdgeNode` and
+  `FederationLink` are **side tables keyed to a Principal**, not parallel
+  identity models (AGENTS §11, 2026-05-09 addendum). The pattern is settled.
+- `Principal.kind` and `PrincipalAlias.aliasType` are plain `String` columns —
+  adding a `partner` kind and a `partner_contact` alias needs **no migration**.
+- `CustomerAccount` already owns the entire commercial spine: invoices, quotes,
+  sales orders, subscriptions, opportunities, engagements, activities, sites,
+  configuration items, edge nodes, service tickets, MDM dedup fields and merge
+  tombstones. A partner needs *these same facts* — partners are invoiced, hold
+  subscriptions, and generate deals.
+- `PartnerProgramProfile` (Phase 0, BI-DE3FA72C) is a **derived archetype type**
+  in `packages/storefront-templates`, not persistence. Nothing was persisted yet.
+
+## 3. Decision
+
+**Reuse `CustomerAccount` as the canonical party row; mark partnership with a
+thin `PartnerProgramEnrollment` side table.**
+
+Kernel scoring (composite 9.24 vs 3.15, margin 6.09, confidence high, no
+commandment conflict) was led by *Ground New Work In Existing Platform* and
+*Architecture Over Shortcuts*. A parallel `PartnerAccount` would fork the
+commercial spine and force two rows to be kept in sync for the common case.
+
+### 3.1 Refinement: no exclusive `accountKind` discriminator
+
+The BI offered `accountKind` as the discriminator. The audit rejects that
+refinement for a concrete reason: **a local MSP is routinely BOTH a customer
+(it buys and runs its own install) and a partner (it resells and operates
+installs for local customers).** A single-valued discriminator forces a false
+choice and would misreport the flagship channel case.
+
+Instead, **the presence of a live `PartnerProgramEnrollment` IS the partnership
+flag** — additive, not exclusive, and exactly how `EdgeNode`/`FederationLink`
+mark a Principal's role today.
+
+### 3.2 Principal kind is derived, never asserted
+
+`Principal.kind` is single-valued, so it needs a deterministic rule:
+
+```
+kind = partner   if the contact's account has an enrolment that is
+                 not `ended` and has no `endedAt`
+     = customer  otherwise
+```
+
+Exposed as `principalKindForContact()` and enforced inside
+`syncPartnerPrincipal()`, which **rejects** a contact whose account has no live
+enrolment rather than silently promoting them. This removes the flapping risk of
+two callers disagreeing about the same principal's kind.
+
+The `partner_contact` alias sits alongside the shared lowercase `email` alias,
+so a person already known as a customer contact **converges onto the same
+Principal** and is re-kinded — one identity, never two.
+
+## 4. What shipped in this slice
+
+| Artifact | Purpose |
+|---|---|
+| `PartnerProgramEnrollment` model + migration `20260723010000_partner_program_enrollment` | partner-only commercial terms (tier, territory, agreement ref, margin, deal-registration flag); 1:1 side table, cascade-deleted with the account |
+| `CustomerAccount.partnerEnrollment` relation | the party row stays canonical |
+| `syncPartnerPrincipal()` | partner contact → `Principal(kind="partner")` + `partner_contact`/`email` aliases |
+| `principalKindForContact()` | the single derivation rule |
+| `partner-principal.test.ts` | 16 assertions incl. re-kinding an existing principal, refusing non-enrolled contacts, and ended-enrolment handling |
+| `2026-07-23-partner-program-enrollment.data-impact.json` | margin/tier/agreementRef governed as confidential commercial terms |
+
+Migration is **purely additive** — a new empty table plus one FK. No backfill; no
+existing account becomes a partner until explicitly enrolled.
+
+## 5. Deliberately deferred
+
+- **Tier semantics and margin policy** — fields exist, meaning stays
+  *prepared-not-prescribed* until real local-partner deals shape it (BI-C47A568C).
+- **Territory exclusivity** — `territory` is a soft designation, not a grant.
+- **Partner login / `/partners` shell** — BI-00E69FBA (next in sequence; it
+  consumes the `partner` principal kind this slice establishes).
+- **Enrolment admin UX** — no operator surface yet; enrolments are data-level
+  until the partner portal lands.

--- a/packages/db/prisma/migrations/20260723010000_partner_program_enrollment/migration.sql
+++ b/packages/db/prisma/migrations/20260723010000_partner_program_enrollment/migration.sql
@@ -1,0 +1,49 @@
+-- BI-DE47EC0B (EP-PARTNER-CHANNEL Phase 2) — partner-org account persistence.
+--
+-- Schema audit outcome (docs/superpowers/specs/2026-07-23-partner-identity-schema-audit.md,
+-- kernel decision DI-CD377B58CA99): reuse CustomerAccount as the canonical party
+-- row and mark partnership with this thin side table, rather than forking a
+-- parallel PartnerAccount. Every shared commercial fact (invoices, quotes,
+-- subscriptions, opportunities, sites, tickets) stays on CustomerAccount; only
+-- partner-specific attributes live here. The side-table presence IS the
+-- partnership flag — no exclusive accountKind discriminator — because a local
+-- MSP is routinely BOTH a customer (buys its own install) and a partner
+-- (resells and operates installs for local customers).
+--
+-- Purely additive: a new empty table plus one FK. No backfill, no column
+-- rewrite, no destructive change; existing accounts are untouched and remain
+-- non-partners until explicitly enrolled.
+
+CREATE TABLE "PartnerProgramEnrollment" (
+  "id" TEXT NOT NULL,
+  "enrollmentId" TEXT NOT NULL,
+  "accountId" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'prospect',
+  "tier" TEXT,
+  "territory" TEXT,
+  "agreementRef" TEXT,
+  "marginPercent" DECIMAL(65,30),
+  "dealRegistrationEnabled" BOOLEAN NOT NULL DEFAULT false,
+  "enrolledAt" TIMESTAMP(3),
+  "endedAt" TIMESTAMP(3),
+  "notes" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "PartnerProgramEnrollment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PartnerProgramEnrollment_enrollmentId_key"
+  ON "PartnerProgramEnrollment"("enrollmentId");
+
+-- 1:1 with the party row — one enrollment per account (the side-table pattern).
+CREATE UNIQUE INDEX "PartnerProgramEnrollment_accountId_key"
+  ON "PartnerProgramEnrollment"("accountId");
+
+CREATE INDEX "PartnerProgramEnrollment_status_idx"
+  ON "PartnerProgramEnrollment"("status");
+
+ALTER TABLE "PartnerProgramEnrollment"
+  ADD CONSTRAINT "PartnerProgramEnrollment_accountId_fkey"
+  FOREIGN KEY ("accountId") REFERENCES "CustomerAccount"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3191,12 +3191,52 @@ model CustomerAccount {
   qualityIssues          PortfolioQualityIssue[]     @relation("QualityIssueCustomerAccount")
   serviceTickets         ServiceTicket[]             @relation("ServiceTicketCustomerAccount")
   memberEquityEntries    MemberEquityEntry[]
+  // EP-PARTNER-CHANNEL · Phase 2 (BI-DE47EC0B) — a partner org (e.g. a local
+  // IT MSP that resells and operates installs) is the SAME party model as any
+  // other account; partnership is a thin side table, exactly as EdgeNode and
+  // FederationLink are side tables on Principal. Its presence marks the
+  // partnership — there is deliberately no exclusive accountKind discriminator,
+  // because an MSP is routinely BOTH a customer (buys its own install) and a
+  // partner (resells). Schema audit: docs/superpowers/specs/2026-07-23-partner-identity-schema-audit.md
+  partnerEnrollment      PartnerProgramEnrollment?
 
   @@index([status])
   @@index([parentAccountId])
   @@index([nameNormalized])
   @@index([domainNormalized])
   @@index([mergedIntoId])
+}
+
+/// Partner-program side table for a CustomerAccount that resells / delivers DPF
+/// (EP-PARTNER-CHANNEL Phase 2, BI-DE47EC0B). Carries ONLY partner-specific
+/// commercial attributes; every shared commercial fact (invoices, quotes,
+/// subscriptions, opportunities, sites, tickets) stays on CustomerAccount so the
+/// commercial spine is never forked. Tiering and territory are recorded as
+/// *prepared-not-prescribed*: the fields exist, the policy is deliberately not
+/// hardcoded until real local-partner deals shape it.
+model PartnerProgramEnrollment {
+  id                      String          @id @default(cuid())
+  enrollmentId            String          @unique
+  /// 1:1 with the party row — the side-table convergence pattern.
+  accountId               String          @unique
+  /// prospect | active | suspended | ended
+  status                  String          @default("prospect")
+  /// Free-form tier label; intentionally not an enum (prepared-not-prescribed).
+  tier                    String?
+  /// Soft local-area designation for the local-MSP channel. NOT an exclusivity
+  /// grant — exclusivity is a founder decision deferred until partner density.
+  territory               String?
+  agreementRef            String?
+  marginPercent           Decimal?
+  dealRegistrationEnabled Boolean         @default(false)
+  enrolledAt              DateTime?
+  endedAt                 DateTime?
+  notes                   String?
+  createdAt               DateTime        @default(now())
+  updatedAt               DateTime        @updatedAt
+  account                 CustomerAccount @relation(fields: [accountId], references: [id], onDelete: Cascade)
+
+  @@index([status])
 }
 
 model CustomerSite {

--- a/scripts/platform-substrate-baseline.json
+++ b/scripts/platform-substrate-baseline.json
@@ -1,9 +1,9 @@
 {
   "changeRationale": {
-    "prismaModelCount": "One AgentSurfaceReadiness heartbeat table (BI-D6DFC0E7) makes each build surface's already-computed toolchain readiness fleet-observable; it reuses the bootstrap's computeReadinessState rather than adding a parallel readiness concept."
+    "prismaModelCount": "One PartnerProgramEnrollment side table (BI-DE47EC0B) persists partner-only commercial terms (tier, territory, agreement ref, margin, deal-registration) for an account that resells/delivers DPF. The schema audit (docs/superpowers/specs/2026-07-23-partner-identity-schema-audit.md, kernel decision DI-CD377B58CA99) explicitly REJECTED the higher-substrate option — a parallel PartnerAccount duplicating the CustomerAccount commercial spine — in favour of reusing CustomerAccount as the canonical party row with this thin 1:1 side table, mirroring the existing Principal+EdgeNode / Principal+FederationLink pattern. Partner IDENTITY adds no model at all: it reuses Principal/PrincipalAlias string columns."
   },
-  "generatedAt": "2026-07-22T03:26:05.986Z",
-  "gitSha": "055fdc09b05430b79411abcbe6f9842c038163c8",
+  "generatedAt": "2026-07-23T01:22:22.336Z",
+  "gitSha": "cb5933b4051d90582ddd089755a8de7544676859",
   "manifestVersion": 2,
   "metrics": {
     "defaultRequiredServiceCount": {
@@ -20,11 +20,11 @@
     },
     "prismaModelCount": {
       "direction": "non-increasing",
-      "value": 522
+      "value": 523
     },
     "prismaSchemaLines": {
       "direction": "informational",
-      "value": 14367
+      "value": 14411
     },
     "productionModuleHotspotCount": {
       "direction": "non-increasing",


### PR DESCRIPTION
## Summary

EP-PARTNER-CHANNEL **Phase 2**, first build of the local-MSP channel sequence (driver: BI-53D48861, merged #3431).

**Schema audit resolved** — the question the BI posed ("reuse CustomerAccount vs a parallel PartnerAccount") is answered and recorded: **reuse CustomerAccount as the canonical party row, mark partnership with a thin `PartnerProgramEnrollment` side table**, mirroring the settled Principal+EdgeNode / Principal+FederationLink convergence pattern. Scored through the kernel (`principle_decide`, decision `DI-CD377B58CA99`): composite **9.24 vs 3.15**, margin 6.09, high confidence, no commandment conflict — led by *Ground New Work In Existing Platform* and *Architecture Over Shortcuts*. A parallel PartnerAccount would fork the commercial spine (invoices, quotes, subscriptions, opportunities all already live on CustomerAccount).

**One refinement on the BI's proposal:** no exclusive `accountKind` discriminator. A local MSP is routinely **both** a customer (runs its own install) and a partner (resells and operates installs for local customers) — a single-valued discriminator would misreport the flagship channel case. Partnership is marked *additively* by the enrolment's presence.

**Principal kind is derived, never asserted.** `principalKindForContact()` is the single rule (live enrolment → `partner`, else `customer`); `syncPartnerPrincipal()` **rejects** a contact whose account has no live enrolment rather than silently promoting them, removing the flapping risk of two callers disagreeing. The `partner_contact` alias sits beside the shared lowercase `email` alias, so a person already known as a customer contact converges onto the **same** Principal and is re-kinded — one identity, never two.

## Migration safety

Purely additive: one new empty table + FK + indexes. No backfill, no column rewrite, nothing destructive; no existing account becomes a partner until explicitly enrolled. Data-impact manifest added — `marginPercent`, `tier`, `agreementRef` governed as confidential commercial terms.

**Verification honesty:** `prisma validate` clean, data-impact gate satisfied, 16/16 identity tests green locally. The migration has **not** been applied against a live database from this worktree (no DATABASE_URL here; DB application is operator-gated) — CI's migration check is the gate.

## Test plan

- `apps/web/lib/identity/partner-principal.test.ts` (new): alias anchoring + lowercase email convergence, re-kinding an existing principal instead of creating a parallel identity, refusal for non-enrolled and ended-enrolment contacts, inactive status carry-through, and the derivation rule.
- `principal-linking.test.ts` regression: green (no change to existing sync paths).

## Scope / next

Deliberately deferred and recorded in the spec: tier semantics + margin policy (prepared-not-prescribed until real deals, BI-C47A568C), territory exclusivity, enrolment admin UX, and partner login //partners shell — **BI-00E69FBA is next in the sequence and consumes the `partner` kind this establishes.**

Data-Impact-Decision: manifest at docs/data-impact/2026-07-23-partner-program-enrollment.data-impact.json; additive table, no backfill; margin/tier/agreementRef governed confidential
Design-Grounding-Decision: grounded in the existing Principal/PrincipalAlias spine (AGENTS §11) + CustomerAccount commercial spine under packages/db and apps/web/; audit spec under docs/superpowers/specs/
Seed-Fit-Decision: no seed or reference-data changes; enrolments are operator-created
Process-Spine-Decision: schema audit recorded and kernel-scored before any migration was authored

🤖 Generated with [Claude Code](https://claude.com/claude-code)