### PR TITLE
feat(ux): L2 UX budget module + route→intended-shell registry (BI-B9BE9A29)

### DIFF
--- a/.github/workflows/audit-route-manifest.yml
+++ b/.github/workflows/audit-route-manifest.yml
@@ -22,6 +22,11 @@ on:
       - "apps/web/lib/navigation/route-audience.generated.json"
       - "apps/web/lib/navigation/route-audience.ts"
       - "apps/web/scripts/build-route-audience.ts"
+      # The intended-shell registry (BI-B9BE9A29) derives from both of the above.
+      - "apps/web/lib/ux-budget/route-shells.generated.json"
+      - "apps/web/lib/ux-budget/route-shells.ts"
+      - "apps/web/lib/ux-budget/budgets.ts"
+      - "apps/web/scripts/build-route-shells.ts"
       - ".github/workflows/audit-route-manifest.yml"
   push:
     branches: [main]
@@ -74,3 +79,12 @@ jobs:
       # override in apps/web/lib/navigation/route-audience.ts.
       - name: Check route audience registry is up to date
         run: pnpm --filter web check:route-audience
+
+      # BI-B9BE9A29 (EP-UX-SYSTEM L2): intended-shell classification is DERIVED from
+      # the manifest above plus the audience registry — it is not a second hand-kept
+      # list of routes. A new page route makes it stale (fix: pnpm --filter web
+      # build:route-shells && commit). The registry is the classification source for
+      # per-shell UX budgets, the §7.1 migration league table, and the route budget
+      # sweep (BI-BD81682A).
+      - name: Check route→shell registry is up to date
+        run: pnpm --filter web check:route-shells

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -4229,6 +4229,7 @@
         "platform-usability-standards",
         "color-system",
         "design-token-scales-l0",
+        "ux-budgets-l2",
         "contrast-requirements",
         "form-elements",
         "user-facing-form-contract-mandatory",

--- a/apps/web/lib/ux-budget/budgets.ts
+++ b/apps/web/lib/ux-budget/budgets.ts
@@ -1,0 +1,169 @@
+// apps/web/lib/ux-budget/budgets.ts
+//
+// Per-shell UX budgets — EP-UX-SYSTEM spec §6 L2 / §8 (BI-B9BE9A29).
+//
+// HONESTY ABOUT THESE NUMBERS. The research pass behind the spec found NO evidence
+// validating hard numeric cognitive-load thresholds. So these are explicitly
+// PLATFORM-OWNED CALIBRATION, not science, and they are versioned in code where a
+// founder can adjust them from lived review (spec §6 L6, "budget calibration" is
+// named human residue).
+//
+// Enforcement therefore splits by ROUTE AGE, not by axis (spec rev 2 decision D1,
+// PR #3434). On PRE-EXISTING routes these absolutes are advisory, and the gate that
+// actually holds is the REGRESSION RATCHET in the route sweep (BI-BD81682A): a changed
+// route may not exceed its own frozen baseline. Retrofitting the absolutes onto those
+// routes keeps the §8 flip contract. On NET-NEW routes the absolutes BLOCK from day
+// one — a pure ratchet would let a brand-new route become its own baseline and be born
+// as a wall of text without ever failing. Legacy debt earns a ratchet; new code has no
+// legacy excuse.
+//
+// PROVISIONAL NUMBERS. Rev 2 sets the day-one absolute at the measured median of
+// compliant routes, which needs the §7.1 baseline sweep (not built yet). These values
+// are a defensible starting point, not that median; they are expected to move once the
+// sweep reports the real distribution, and they only ever move downward.
+//
+// One source, three consumers: these values feed the prompts agents read (L3), the
+// CI checkers (L4/L5), and the migration league table (§7.1).
+
+import type { ReadingLevel } from "@dpf/validators";
+
+/**
+ * The page shells a surface can intend to be. Deliberately NOT called "archetype" —
+ * that word already means industry vertical on this platform (spec §6 L1).
+ */
+export const UX_SHELLS = [
+  "cockpit",
+  "list",
+  "detail",
+  "settings",
+  "form",
+  "public",
+  "unclassified",
+] as const;
+export type UxShell = (typeof UX_SHELLS)[number];
+
+export type UxBudget = {
+  /** Words visible on arrival, collapsed disclosure already excised. */
+  maxDefaultVisibleWords: number;
+  /** Words in the lead band — the first thing read. */
+  maxLeadBandWords: number;
+  /** Whether a lead band is expected at all. */
+  requireLeadBand: boolean;
+  maxPrimaryActions: number;
+  maxVisibleFields: number;
+  maxChoicesPerControl: number;
+  /** Sub-legible / sub-tappable controls tolerated. Always 0: WCAG 2.2 AA 2.5.8. */
+  maxSubLegibleControls: number;
+  readingLevel: ReadingLevel;
+  requireNextActionMarker: boolean;
+  /**
+   * Above this many default-visible words the surface must defer detail into at
+   * least one disclosure region. This is the anti-wall-of-text rule with teeth:
+   * "long" is allowed, "long AND undifferentiated" is not.
+   */
+  deferredDetailRequiredAboveWords: number;
+};
+
+/**
+ * Calibration table. Derived from the EP-UX-COGLOAD live audit (a domain landing page
+ * measured 818 words / 56 controls / 34 sub-legible controls) and the owner-first
+ * summary thresholds already in production (160 words for a summary band).
+ */
+export const UX_BUDGETS: Record<UxShell, UxBudget> = {
+  // The owner's home base: status at a glance, one obvious next move.
+  cockpit: {
+    maxDefaultVisibleWords: 350,
+    maxLeadBandWords: 60,
+    requireLeadBand: true,
+    maxPrimaryActions: 3,
+    maxVisibleFields: 4,
+    maxChoicesPerControl: 12,
+    maxSubLegibleControls: 0,
+    readingLevel: "high-school",
+    requireNextActionMarker: true,
+    deferredDetailRequiredAboveWords: 250,
+  },
+  // Scanning many rows: the rows carry the words, so the chrome must stay thin.
+  list: {
+    maxDefaultVisibleWords: 500,
+    maxLeadBandWords: 50,
+    requireLeadBand: true,
+    maxPrimaryActions: 3,
+    maxVisibleFields: 6,
+    maxChoicesPerControl: 20,
+    maxSubLegibleControls: 0,
+    readingLevel: "high-school",
+    requireNextActionMarker: true,
+    deferredDetailRequiredAboveWords: 400,
+  },
+  // One thing in depth — the shell where disclosure earns its keep.
+  detail: {
+    maxDefaultVisibleWords: 450,
+    maxLeadBandWords: 70,
+    requireLeadBand: true,
+    maxPrimaryActions: 4,
+    maxVisibleFields: 8,
+    maxChoicesPerControl: 20,
+    maxSubLegibleControls: 0,
+    readingLevel: "high-school",
+    requireNextActionMarker: true,
+    deferredDetailRequiredAboveWords: 300,
+  },
+  // Config surfaces were the worst offenders in the audit: everything, all at once.
+  settings: {
+    maxDefaultVisibleWords: 400,
+    maxLeadBandWords: 60,
+    requireLeadBand: true,
+    maxPrimaryActions: 2,
+    maxVisibleFields: 10,
+    maxChoicesPerControl: 15,
+    maxSubLegibleControls: 0,
+    readingLevel: "high-school",
+    requireNextActionMarker: false,
+    deferredDetailRequiredAboveWords: 250,
+  },
+  // Filling something in: fields are the point, prose is not.
+  form: {
+    maxDefaultVisibleWords: 300,
+    maxLeadBandWords: 50,
+    requireLeadBand: true,
+    maxPrimaryActions: 2,
+    maxVisibleFields: 12,
+    maxChoicesPerControl: 15,
+    maxSubLegibleControls: 0,
+    readingLevel: "high-school",
+    requireNextActionMarker: false,
+    deferredDetailRequiredAboveWords: 250,
+  },
+  // Customer-facing. Strictest prose budget; the reader owes us no patience.
+  public: {
+    maxDefaultVisibleWords: 400,
+    maxLeadBandWords: 40,
+    requireLeadBand: true,
+    maxPrimaryActions: 2,
+    maxVisibleFields: 12,
+    maxChoicesPerControl: 15,
+    maxSubLegibleControls: 0,
+    readingLevel: "high-school",
+    requireNextActionMarker: false,
+    deferredDetailRequiredAboveWords: 250,
+  },
+  // Not yet migrated. Generous on purpose — the RATCHET is what holds these routes,
+  // not the absolute number. Recorded baseline debt, never hidden (spec §7.1).
+  unclassified: {
+    maxDefaultVisibleWords: 900,
+    maxLeadBandWords: 120,
+    requireLeadBand: false,
+    maxPrimaryActions: 8,
+    maxVisibleFields: 20,
+    maxChoicesPerControl: 40,
+    maxSubLegibleControls: 0,
+    readingLevel: "college",
+    requireNextActionMarker: false,
+    deferredDetailRequiredAboveWords: 700,
+  },
+};
+
+export function budgetFor(shell: UxShell): UxBudget {
+  return UX_BUDGETS[shell];
+}

--- a/apps/web/lib/ux-budget/evaluate.ts
+++ b/apps/web/lib/ux-budget/evaluate.ts
@@ -1,0 +1,182 @@
+// apps/web/lib/ux-budget/evaluate.ts
+//
+// Budget evaluation — EP-UX-SYSTEM spec §6 L2 / §8 (BI-B9BE9A29).
+//
+// Produces one finding per axis. Severity depends on BOTH the axis and the age of the
+// route, per spec rev 2 (§6 L4 decision D1, PR #3434):
+//
+//   "blocking" always — checks with no calibration ambiguity: sub-legible controls
+//                 violate WCAG 2.2 AA 2.5.8, and a long AND undifferentiated surface is
+//                 a regression wherever the exact line sits.
+//   "blocking" on NET-NEW routes — the absolute text budgets. A pure ratchet freezes
+//                 whatever ships first, so a route created after Phase 1 would become
+//                 its own baseline and could be born as a wall of text without ever
+//                 failing. Legacy debt earns a ratchet; new code has no legacy excuse.
+//   "advisory" on PRE-EXISTING routes — the same absolute budgets, reported on the PR.
+//                 Text-mass thresholds remain platform-owned calibration (no surviving
+//                 evidence validates words-per-screen against user outcomes), so
+//                 RETROFITTING them onto existing routes keeps the §8 flip contract.
+//
+// The route sweep (BI-BD81682A) adds the axis this module cannot see on its own: the
+// REGRESSION RATCHET, comparing a changed route against its own frozen baseline.
+//
+// CALIBRATION STATUS: spec rev 2 sets the day-one absolute at the measured median of
+// compliant routes, which requires the §7.1 baseline sweep that does not exist yet.
+// The numbers in budgets.ts are therefore provisional; what lands here is the
+// MECHANISM that lets them bite the moment the sweep supplies real medians.
+
+import type { UxBudget, UxShell } from "./budgets";
+import { budgetFor } from "./budgets";
+import { meetsReadingLevel, type UxBudgetMetrics } from "./measure";
+import type { ExemptCheck } from "./route-shells";
+
+export type BudgetSeverity = "advisory" | "blocking";
+
+/**
+ * Whether the route existed before the budget regime. Net-new routes get the
+ * absolute budgets as blocking gates (spec rev 2 D1); pre-existing routes get them
+ * as advisory reports plus the sweep's ratchet.
+ */
+export type RouteStatus = "net-new" | "pre-existing";
+
+export type BudgetFinding = {
+  check: string;
+  ok: boolean;
+  severity: BudgetSeverity;
+  detail: string;
+  /** True when the check was waived because the route is pre-migration. */
+  exempt?: boolean;
+};
+
+export type BudgetReport = {
+  shell: UxShell;
+  routeStatus: RouteStatus;
+  metrics: UxBudgetMetrics;
+  findings: BudgetFinding[];
+  /** True when no BLOCKING finding failed. Advisory failures never set this false. */
+  ok: boolean;
+  advisoryFailures: number;
+};
+
+/** Absolute text-mass budgets: advisory when retrofitted, blocking when born new. */
+const ABSOLUTE_TEXT_CHECKS = new Set([
+  "default-visible-words",
+  "lead-band",
+  "lead-band-words",
+  "primary-actions",
+  "visible-fields",
+  "choices-per-control",
+  "reading-level",
+  "next-action-marker",
+]);
+
+function within(actual: number, max: number): boolean {
+  return actual <= max;
+}
+
+export function evaluateUxBudget(
+  metrics: UxBudgetMetrics,
+  shell: UxShell,
+  options: { exemptChecks?: readonly ExemptCheck[]; routeStatus?: RouteStatus } = {},
+): BudgetReport {
+  const budget: UxBudget = budgetFor(shell);
+  const routeStatus: RouteStatus = options.routeStatus ?? "pre-existing";
+  // A net-new route cannot claim pre-migration debt it never accrued.
+  const exempt = new Set<string>(routeStatus === "net-new" ? [] : (options.exemptChecks ?? []));
+
+  const raw: BudgetFinding[] = [
+    {
+      check: "default-visible-words",
+      ok: within(metrics.defaultVisibleWords, budget.maxDefaultVisibleWords),
+      severity: "advisory",
+      detail: `${metrics.defaultVisibleWords} words visible on arrival (budget ${budget.maxDefaultVisibleWords}; collapsed disclosure excised)`,
+    },
+    {
+      check: "lead-band",
+      ok: budget.requireLeadBand ? metrics.hasLeadBand : true,
+      severity: "advisory",
+      detail: metrics.hasLeadBand
+        ? "lead band present"
+        : "no data-dpf-lead band — the owner has no marked place to start",
+    },
+    {
+      check: "lead-band-words",
+      ok: !metrics.hasLeadBand || within(metrics.leadBandWords, budget.maxLeadBandWords),
+      severity: "advisory",
+      detail: `${metrics.leadBandWords} words in the lead band (budget ${budget.maxLeadBandWords})`,
+    },
+    {
+      check: "primary-actions",
+      ok: within(metrics.primaryActions, budget.maxPrimaryActions),
+      severity: "advisory",
+      detail: `${metrics.primaryActions} primary actions (budget ${budget.maxPrimaryActions})`,
+    },
+    {
+      check: "visible-fields",
+      ok: within(metrics.visibleFields, budget.maxVisibleFields),
+      severity: "advisory",
+      detail: `${metrics.visibleFields} fields visible at once (budget ${budget.maxVisibleFields})`,
+    },
+    {
+      check: "choices-per-control",
+      ok: within(metrics.maxChoicesPerControl, budget.maxChoicesPerControl),
+      severity: "advisory",
+      detail: `largest control offers ${metrics.maxChoicesPerControl} choices (budget ${budget.maxChoicesPerControl})`,
+    },
+    {
+      // WCAG 2.2 AA 2.5.8 — not calibration, a standard.
+      check: "sub-legible-controls",
+      ok: within(metrics.subLegibleControls, budget.maxSubLegibleControls),
+      severity: "blocking",
+      detail: `${metrics.subLegibleControls} sub-legible/sub-tappable controls (max ${budget.maxSubLegibleControls})`,
+    },
+    {
+      // The anti-wall-of-text rule: long is allowed, long AND undifferentiated is not.
+      check: "deferred-detail",
+      ok:
+        metrics.defaultVisibleWords <= budget.deferredDetailRequiredAboveWords ||
+        metrics.disclosureRegions > 0,
+      severity: "blocking",
+      detail:
+        metrics.defaultVisibleWords <= budget.deferredDetailRequiredAboveWords
+          ? `${metrics.defaultVisibleWords} words — below the ${budget.deferredDetailRequiredAboveWords}-word deferral threshold`
+          : `${metrics.defaultVisibleWords} words with ${metrics.disclosureRegions} disclosure regions — above ${budget.deferredDetailRequiredAboveWords} words the surface must defer detail`,
+    },
+    {
+      check: "reading-level",
+      ok: meetsReadingLevel(metrics, budget.readingLevel),
+      severity: "advisory",
+      detail: `grade ${metrics.readingGradeLevel} prose (tier: ${budget.readingLevel})`,
+    },
+    {
+      check: "next-action-marker",
+      ok: budget.requireNextActionMarker ? metrics.hasNextActionMarker : true,
+      severity: "advisory",
+      detail: metrics.hasNextActionMarker
+        ? "owner-first next action present"
+        : "no owner-first next action marker",
+    },
+  ];
+
+  const findings = raw
+    .map((f) =>
+      // D1: on a net-new route the absolute text budgets stop being suggestions.
+      routeStatus === "net-new" && ABSOLUTE_TEXT_CHECKS.has(f.check)
+        ? { ...f, severity: "blocking" as BudgetSeverity }
+        : f,
+    )
+    .map((f) =>
+      exempt.has(f.check) && !f.ok
+        ? { ...f, ok: true, exempt: true, detail: `${f.detail} — exempt (pre-migration baseline debt)` }
+        : f,
+    );
+
+  return {
+    shell,
+    routeStatus,
+    metrics,
+    findings,
+    ok: findings.every((f) => f.ok || f.severity !== "blocking"),
+    advisoryFailures: findings.filter((f) => !f.ok && f.severity === "advisory").length,
+  };
+}

--- a/apps/web/lib/ux-budget/index.ts
+++ b/apps/web/lib/ux-budget/index.ts
@@ -1,0 +1,69 @@
+// apps/web/lib/ux-budget/index.ts
+//
+// L2 UX budget module — EP-UX-SYSTEM spec §6 L2 (BI-B9BE9A29).
+//
+// One source, three consumers: the numbers agents are told (L3), the CI checkers
+// (L4/L4.5/L5), and the migration league table (§7.1). Import from here.
+
+export {
+  DISCLOSURE_ATTR,
+  LEAD_ATTR,
+  countDisclosureRegions,
+  defaultVisibleHtml,
+  extractSubtrees,
+  isDisclosureRegion,
+  isStructurallyHidden,
+  leadBandHtml,
+  removeSubtrees,
+  type TagToken,
+} from "./scope";
+
+export {
+  PRIMARY_ACTION_ATTR,
+  countPrimaryActions,
+  countVisibleFields,
+  maxChoicesPerControl,
+  measureUxBudget,
+  meetsReadingLevel,
+  type UxBudgetMetrics,
+} from "./measure";
+
+export {
+  UX_BUDGETS,
+  UX_SHELLS,
+  budgetFor,
+  type UxBudget,
+  type UxShell,
+} from "./budgets";
+
+export {
+  MIGRATED_ROUTES,
+  PRE_MIGRATION_EXEMPT_CHECKS,
+  shellForRoute,
+  shellPolicyFor,
+  type ExemptCheck,
+  type RouteShellPolicy,
+  type ShellClassifiable,
+} from "./route-shells";
+
+export {
+  evaluateUxBudget,
+  type BudgetFinding,
+  type BudgetReport,
+  type BudgetSeverity,
+  type RouteStatus,
+} from "./evaluate";
+
+import { measureUxBudget } from "./measure";
+import { evaluateUxBudget, type BudgetReport, type RouteStatus } from "./evaluate";
+import type { UxShell } from "./budgets";
+import type { ExemptCheck } from "./route-shells";
+
+/** Convenience: measure and evaluate a served-DOM HTML string in one call. */
+export function auditUxBudget(
+  html: string,
+  shell: UxShell,
+  options: { exemptChecks?: readonly ExemptCheck[]; routeStatus?: RouteStatus } = {},
+): BudgetReport {
+  return evaluateUxBudget(measureUxBudget(html), shell, options);
+}

--- a/apps/web/lib/ux-budget/measure.ts
+++ b/apps/web/lib/ux-budget/measure.ts
@@ -1,0 +1,111 @@
+// apps/web/lib/ux-budget/measure.ts
+//
+// L2 budget metrics — EP-UX-SYSTEM spec §6 L2 (BI-B9BE9A29).
+//
+// Extends the owner-first audit signals (lib/owner-first/ux-audit.ts, BI-3BCAF95F)
+// from "one summary band" to "a whole surface, scoped to what is visible on
+// arrival". The primitives it already got right — visible text extraction, word and
+// control counting, sub-legible control detection, the next-action marker — are
+// REUSED here rather than reimplemented, so there is one definition of "a word" on
+// this platform.
+//
+// Every function is pure and DOM-free so the same module runs in a unit test, in the
+// CI route sweep (BI-BD81682A), and as the source of the numbers quoted to agents in
+// prompts (L3). Readability uses the PURE analyzer from @dpf/validators, NOT
+// lib/readability/policy.ts — that module reads PlatformConfig through Prisma, and a
+// CI checker must never need a database. The policy vocabulary (ReadingLevel, the
+// grade caps) is shared; only the DB-backed override resolution stays at runtime.
+
+import { analyzeReadability, withinReadingLevel, type ReadingLevel } from "@dpf/validators";
+import {
+  countSmallControls,
+  countWords,
+  visibleText,
+  OWNER_FIRST_NEXT_ACTION_ATTR,
+} from "../owner-first/ux-audit";
+import { countDisclosureRegions, defaultVisibleHtml, leadBandHtml } from "./scope";
+
+/** Marks the one control a surface most wants the owner to press. */
+export const PRIMARY_ACTION_ATTR = "data-dpf-primary-action";
+
+const FIELD_RE = /<(input|select|textarea)\b([^>]*)>/gi;
+const NON_FIELD_INPUT_TYPES = new Set(["hidden", "submit", "button", "reset", "image"]);
+
+/** Form fields the owner must actually fill in (excludes hidden/submit inputs). */
+export function countVisibleFields(html: string): number {
+  let count = 0;
+  FIELD_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = FIELD_RE.exec(html)) !== null) {
+    if (m[1].toLowerCase() !== "input") {
+      count += 1;
+      continue;
+    }
+    const type = /\btype\s*=\s*["']?([a-zA-Z-]+)/.exec(m[2])?.[1]?.toLowerCase() ?? "text";
+    if (!NON_FIELD_INPUT_TYPES.has(type)) count += 1;
+  }
+  return count;
+}
+
+/** Controls the surface presents as the owner's next move. */
+export function countPrimaryActions(html: string): number {
+  const marked = html.match(new RegExp(PRIMARY_ACTION_ATTR, "g"))?.length ?? 0;
+  if (marked > 0) return marked;
+  // Un-migrated surfaces carry no marker; a submit button is the honest proxy.
+  return (html.match(/<button\b[^>]*type\s*=\s*["']?submit/gi) ?? []).length;
+}
+
+/**
+ * The largest number of options any single control offers. Hick's law: a 40-option
+ * select is a decision the surface pushed onto the owner instead of resolving.
+ */
+export function maxChoicesPerControl(html: string): number {
+  const selects = html.match(/<select\b[\s\S]*?<\/select>/gi) ?? [];
+  let max = 0;
+  for (const select of selects) {
+    max = Math.max(max, (select.match(/<option\b/gi) ?? []).length);
+  }
+  return max;
+}
+
+export type UxBudgetMetrics = {
+  /** Words visible on arrival — collapsed disclosure already excised. */
+  defaultVisibleWords: number;
+  /** Words in the lead band; 0 when the surface has no marked lead. */
+  leadBandWords: number;
+  hasLeadBand: boolean;
+  primaryActions: number;
+  visibleFields: number;
+  maxChoicesPerControl: number;
+  /** Controls rendered below a legible/tappable size. */
+  subLegibleControls: number;
+  disclosureRegions: number;
+  hasNextActionMarker: boolean;
+  /** Flesch–Kincaid grade of the default-visible prose. */
+  readingGradeLevel: number;
+};
+
+/** Measure a served-DOM HTML string against every budget axis at once. */
+export function measureUxBudget(html: string): UxBudgetMetrics {
+  const visible = defaultVisibleHtml(html);
+  const lead = leadBandHtml(html);
+  const prose = visibleText(visible);
+  return {
+    defaultVisibleWords: countWords(visible),
+    leadBandWords: countWords(lead),
+    hasLeadBand: lead.trim().length > 0,
+    primaryActions: countPrimaryActions(visible),
+    visibleFields: countVisibleFields(visible),
+    maxChoicesPerControl: maxChoicesPerControl(visible),
+    subLegibleControls: countSmallControls(visible),
+    disclosureRegions: countDisclosureRegions(html),
+    hasNextActionMarker: visible.includes(OWNER_FIRST_NEXT_ACTION_ATTR),
+    // An empty surface has no prose to grade; report 0 rather than a fabricated score.
+    readingGradeLevel: prose.length === 0 ? 0 : analyzeReadability(prose).gradeLevel,
+  };
+}
+
+/** Does this surface's prose sit within the shell's reading tier? */
+export function meetsReadingLevel(metrics: UxBudgetMetrics, level: ReadingLevel): boolean {
+  return withinReadingLevel(metrics.readingGradeLevel, level);
+}

--- a/apps/web/lib/ux-budget/route-shells.generated.json
+++ b/apps/web/lib/ux-budget/route-shells.generated.json
@@ -1,0 +1,3086 @@
+{
+  "generator": "apps/web/scripts/build-route-shells.ts",
+  "pageRouteCount": 307,
+  "migratedCount": 0,
+  "summary": {
+    "cockpit": 15,
+    "list": 6,
+    "detail": 234,
+    "settings": 12,
+    "form": 19,
+    "public": 21,
+    "unclassified": 0
+  },
+  "routes": [
+    {
+      "routePath": "/admin",
+      "shell": "list",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/archetypes",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/backups",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/branding",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/build-studio/stall-thresholds",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/business-models",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/cockpit",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/data-stewardship",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/diagnostics",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/hive",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/issue-reports",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/platform-development",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/reference-data",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/research",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/scheduled-jobs",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/settings",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/twin-gallery",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/twin-gallery/[archetypeId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/twin-kit",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/admin/wiki/lint",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/build",
+      "shell": "list",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/build/work",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/build/work/[capsuleId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/complaints",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/actions",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/actions/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/audits",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/audits/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/controls",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/controls/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/evidence",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/evidence/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/gaps",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/incidents",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/incidents/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/licensing",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/obligations",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/obligations/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/onboard",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/policies",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/policies/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/posture",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/regulations",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/regulations/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/risks",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/risks/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/submissions",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/compliance/submissions/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/[...slug]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/craft",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/craft/[professionKey]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/decisions",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/decisions/[interactionId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/edit/[...slug]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/matrix",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/perspectives",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/perspectives/[profileId]/voice",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/proactivity",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/review",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/coworker-decisions/stance",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer-complete-profile",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer-link-account",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer-login",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer-signup",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/engagements",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/funnel",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/marketing",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/marketing/automation",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/marketing/campaigns",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/marketing/funnel",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/marketing/strategy",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/opportunities",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/opportunities/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/quotes",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/quotes/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/customer/sales-orders",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/delivery",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/docs/[[...slug]]",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ea",
+      "shell": "list",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ea/capabilities",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ea/data-model",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ea/models",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ea/models/[slug]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ea/value-streams",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ea/views",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ea/views/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/employee",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/assets",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/assets/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/assets/new",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/banking",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/banking/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/banking/[id]/import",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/banking/[id]/reconcile",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/banking/new",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/banking/rules",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/bills",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/bills/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/bills/new",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/close",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/configuration",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/expense-claims",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/expense-claims/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/funds",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/invoices",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/invoices/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/invoices/new",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/my-expenses",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/my-expenses/new",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/payment-runs",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/payments",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/purchase-orders",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/purchase-orders/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/purchase-orders/new",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/recurring",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/recurring/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/recurring/new",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/reports",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/reports/aged-creditors",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/reports/aged-debtors",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/reports/cash-flow",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/reports/general-ledger",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/reports/outstanding",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/reports/profit-loss",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/reports/revenue-by-customer",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/reports/vat-summary",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/revenue",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/settings",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/settings/currency",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/settings/dunning",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/settings/rate-card",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/settings/setup",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/settings/tax",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/spend",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/spend/ai",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/suppliers",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/suppliers/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/finance/suppliers/new",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/forgot-password",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/governance",
+      "shell": "list",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/governance/records-requests",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/inventory",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/inventory/entity/[entityId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/knowledge",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/knowledge/[articleId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/knowledge/new",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/login",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/member-equity",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ops",
+      "shell": "list",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ops/changes",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ops/demand",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ops/dev-loop",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ops/health",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ops/patches",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ops/promotions",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ops/security",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/ops/self-upgrade",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform",
+      "shell": "list",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/agent/[agentId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/assignments",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/assignments/bindings/[bindingId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/browser-sessions",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/browser-sessions/setup",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/build-studio",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/capacity-continuity",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/catalog",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/decisions/[interactionId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/founder-review",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/memory",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/operations-map",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/overview",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/priority/outcomes",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/prompts",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/providers",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/providers/[providerId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/readiness",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/runtime-health",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/ai/skills",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/audit",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/audit/authority",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/audit/journal",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/audit/ledger",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/audit/metrics",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/audit/operations",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/audit/routes",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/development/change-lanes",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/device-catalog",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/edge-nodes",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/federation-links",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/federation-proposals",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/identity",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/identity/agents",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/identity/applications",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/identity/authorization",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/identity/authorization/bindings/[bindingId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/identity/directory",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/identity/federation",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/identity/groups",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/identity/principals",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/schedule",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/service-desk",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/services/[serverId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/built-ins",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/catalog",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/catalog/sync",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/discovery",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/discovery/promotion-audit",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/adp",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/communications",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/email-postmark",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/facebook-lead-ads",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/facebook-pages",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/google-business-profile",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/google-marketing-intelligence",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/hubspot",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/instagram-business",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/linkedin-personal-social",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/mailchimp",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/microsoft365-communications",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/quickbooks",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/stripe",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/integrations/whatsapp-business",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/inventory",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/services",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/services/[serverId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/platform/tools/services/activate",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portal",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portal/account",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portal/cases",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portal/cases/[caseKey]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portal/health",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portal/health/intake/[packetId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portal/orders",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portal/services",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portal/sign-in",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portal/support",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/[[...slug]]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/product/[id]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/architecture",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/backlog",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/changes",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/health",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/inventory",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/knowledge",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/offerings",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/supply-chain",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/team",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/product/[id]/versions",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/portfolio/products/[productId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/rental",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/reset-password",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/book/[itemId]",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/booking/confirmed",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/checkout",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/donate",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/donation/received",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/inquire",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/inquire/[itemId]",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/inquiry/received",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/item/[itemId]",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/order/[itemId]",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/order/received",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/policies",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/sign-in",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/[slug]/sign-up",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/approve/[token]",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/expense-approve/[token]",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/pay/[token]",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/s/quote/[token]",
+      "shell": "public",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/sandbox-restricted",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/service-requests",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/setup",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/animals",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/dispatch",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/inbox",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/intake",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/items",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/sections",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/settings",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/settings/business",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/settings/capabilities",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/settings/operations",
+      "shell": "settings",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/setup",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/tables",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/team",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/storefront/units",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/welcome",
+      "shell": "form",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/wiki/[...slug]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/workbooks",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/workbooks/[workbookId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/workbooks/system/[entityType]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/workspace",
+      "shell": "cockpit",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/workspace/calendar",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/workspace/cases/[caseKey]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/workspace/documents",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/workspace/documents/[documentId]",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/workspace/inbox",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    },
+    {
+      "routePath": "/workspace/my-queue",
+      "shell": "detail",
+      "migrated": false,
+      "exemptChecks": [
+        "next-action-marker",
+        "lead-band"
+      ],
+      "confidence": "high"
+    }
+  ]
+}

--- a/apps/web/lib/ux-budget/route-shells.ts
+++ b/apps/web/lib/ux-budget/route-shells.ts
@@ -1,0 +1,82 @@
+// apps/web/lib/ux-budget/route-shells.ts
+//
+// Route → intended page shell — EP-UX-SYSTEM spec §6 L2 / §7.1 (BI-B9BE9A29).
+//
+// SUBSTRATE DECISION: this does NOT hand-author 307 route classifications, and it does
+// NOT fork the route inventory. The platform already classifies every page route by
+// AUDIENCE and DESTINATION KIND (lib/navigation/route-audience.ts, BI-8C0F219A), which
+// is itself layered on the single route-inventory source of truth
+// (lib/ea/route-manifest.json). Intended shell is DERIVED from those two axes. A second
+// hand-maintained registry of the same routes would drift from the first within weeks —
+// the spec's own §6 L1 rule about not creating a second manifest home, applied here.
+//
+// What this adds that the audience registry does not: the shell a surface should be
+// built as, and whether that surface has actually been MIGRATED to its shell yet.
+
+import type { RouteAudience, RouteDestinationKind } from "../navigation/route-audience";
+import type { UxShell } from "./budgets";
+
+export type ShellClassifiable = {
+  audience: RouteAudience;
+  destinationKind: RouteDestinationKind;
+};
+
+/**
+ * Derive the intended shell. Ordered rules: the shape of the destination decides
+ * first (a settings page is a settings page whoever it is for), then the audience.
+ */
+export function shellForRoute(c: ShellClassifiable): UxShell {
+  // Redirect shims and deprecated surfaces are not worth a shell.
+  if (c.destinationKind === "legacy-internal") return "unclassified";
+  if (c.destinationKind === "settings-config") return "settings";
+  if (c.destinationKind === "workflow-step") return "form";
+  if (c.audience === "public") return "public";
+  // Login / signup / credential recovery are forms first, public second.
+  if (c.audience === "auth-setup") return "form";
+  if (c.destinationKind === "detail") return "detail";
+  // Deep technical surfaces are detail pages with a higher tolerance.
+  if (c.destinationKind === "advanced-diagnostic") return "detail";
+  if (c.destinationKind === "section-home") {
+    // An owner's section home is their cockpit; a builder/admin console is a
+    // dense working list and is budgeted as one.
+    return c.audience === "admin" || c.audience === "builder" ? "list" : "cockpit";
+  }
+  return "unclassified";
+}
+
+/**
+ * Routes that have actually adopted their L1 page shell.
+ *
+ * INTENTIONALLY EMPTY. The shells themselves are BI-36CE8BAB (Phase 2) — nothing has
+ * migrated yet, and saying so in code is the point: spec §7.1 requires pre-migration
+ * debt to be RECORDED, not hidden behind a check that quietly passes. Until a route
+ * appears here it is exempt from the shell-structure expectations below, and the
+ * regression ratchet is what actually holds it.
+ *
+ * Each migration PR (spec §7.2) adds its route here in the same change that adopts
+ * the shell, so the exemption list shrinks visibly as the redesign lands.
+ */
+export const MIGRATED_ROUTES: ReadonlySet<string> = new Set<string>([]);
+
+/** Checks a pre-migration route is not yet expected to satisfy. */
+export const PRE_MIGRATION_EXEMPT_CHECKS = ["next-action-marker", "lead-band"] as const;
+export type ExemptCheck = (typeof PRE_MIGRATION_EXEMPT_CHECKS)[number];
+
+export type RouteShellPolicy = {
+  routePath: string;
+  shell: UxShell;
+  /** True once the route has adopted its L1 shell. */
+  migrated: boolean;
+  /** Checks waived while the route is pre-migration — recorded baseline debt. */
+  exemptChecks: readonly ExemptCheck[];
+};
+
+export function shellPolicyFor(routePath: string, c: ShellClassifiable): RouteShellPolicy {
+  const migrated = MIGRATED_ROUTES.has(routePath);
+  return {
+    routePath,
+    shell: shellForRoute(c),
+    migrated,
+    exemptChecks: migrated ? [] : PRE_MIGRATION_EXEMPT_CHECKS,
+  };
+}

--- a/apps/web/lib/ux-budget/scope.ts
+++ b/apps/web/lib/ux-budget/scope.ts
@@ -45,8 +45,24 @@ export type TagToken = {
 };
 
 // Matches a tag while tolerating `>` inside quoted attribute values.
-const TAG_RE = /<(\/?)([a-zA-Z][a-zA-Z0-9-]*)((?:"[^"]*"|'[^']*'|[^>])*?)(\/?)>/g;
+//
+// The alternation branches are mutually exclusive BY CONSTRUCTION: the catch-all
+// excludes both quote characters, so a `"` can only ever be consumed by the quoted
+// branch. An earlier version used `[^>]` there, which let `""` be matched two
+// different ways and made the pattern exponentially backtrack on input like
+// `<a""""""…` (CodeQL js/redos). Unambiguous branches also mean the quantifier can be
+// greedy rather than lazy, which is what removes the backtracking entirely.
+//
+// Self-closing syntax is detected from the captured attribute text rather than a
+// trailing `(\/?)` group, because with a greedy catch-all the `/` of `<br/>` is
+// consumed as attribute text before such a group could see it.
+const TAG_RE = /<(\/?)([a-zA-Z][a-zA-Z0-9-]*)((?:"[^"]*"|'[^']*'|[^>"'])*)>/g;
 const ATTR_RE = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+)))?/g;
+
+/** `<br/>` and `<img … />`: the trailing slash lands in the captured attribute text. */
+function hasSelfClosingSlash(rawAttrs: string): boolean {
+  return /\/\s*$/.test(rawAttrs);
+}
 
 function parseAttrs(raw: string): Record<string, string> {
   const attrs: Record<string, string> = {};
@@ -74,10 +90,10 @@ export function removeSubtrees(
   TAG_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
   while ((m = TAG_RE.exec(html)) !== null) {
-    const [full, closeSlash, rawName, rawAttrs, endSlash] = m;
+    const [full, closeSlash, rawName, rawAttrs] = m;
     const name = rawName.toLowerCase();
     const isClose = closeSlash === "/";
-    const isVoid = VOID_ELEMENTS.has(name) || endSlash === "/";
+    const isVoid = VOID_ELEMENTS.has(name) || hasSelfClosingSlash(rawAttrs);
 
     if (skipping) {
       // Only same-name tags move the depth counter; everything else is swallowed.
@@ -128,10 +144,10 @@ export function extractSubtrees(
   TAG_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
   while ((m = TAG_RE.exec(html)) !== null) {
-    const [full, closeSlash, rawName, rawAttrs, endSlash] = m;
+    const [full, closeSlash, rawName, rawAttrs] = m;
     const name = rawName.toLowerCase();
     const isClose = closeSlash === "/";
-    const isVoid = VOID_ELEMENTS.has(name) || endSlash === "/";
+    const isVoid = VOID_ELEMENTS.has(name) || hasSelfClosingSlash(rawAttrs);
 
     if (capture) {
       if (name === capture.name && !isVoid) {

--- a/apps/web/lib/ux-budget/scope.ts
+++ b/apps/web/lib/ux-budget/scope.ts
@@ -1,0 +1,204 @@
+// apps/web/lib/ux-budget/scope.ts
+//
+// L2 measurement scoping — EP-UX-SYSTEM spec §6 L2 (BI-B9BE9A29).
+//
+// THE RULE THIS FILE ENCODES: progressive disclosure is REWARDED, never taxed.
+// A budget that counted every word in the markup would punish the exact fix it is
+// supposed to encourage — moving professional detail behind a <details> or a
+// disclosure region. So before anything is measured, collapsed subtrees are
+// EXCISED. Content the owner cannot see on arrival does not count against them.
+//
+// Why a tag scanner rather than a regex: a regex cannot match a closing tag to its
+// opening tag, so `<details><div>…</div></details>` would be truncated at the first
+// `</div>` and leak the tail of a collapsed subtree into the measured scope — the
+// budget would then silently measure the wrong thing, which is worse than not
+// measuring at all. This walks the tag stream and tracks depth.
+//
+// Input is an HTML string. The route sweep (BI-BD81682A) serialises the SERVED DOM
+// after hydration, so client components and their real state are present; this
+// module then applies the structural disclosure semantics. Computed-style
+// invisibility (e.g. a `hidden md:block` utility) is the browser's job to prune
+// before serialising — see `isStructurallyHidden` for what is handled here.
+
+/** Elements that never have a closing tag. */
+const VOID_ELEMENTS = new Set([
+  "area", "base", "br", "col", "embed", "hr", "img", "input",
+  "link", "meta", "param", "source", "track", "wbr",
+]);
+
+/** Elements whose text is never rendered to the reader. */
+const NON_RENDERED = new Set(["script", "style", "template", "noscript"]);
+
+/** Marks a region as progressive disclosure; excised unless explicitly open. */
+export const DISCLOSURE_ATTR = "data-dpf-disclosure";
+
+/** Marks the lead band — the first thing the owner reads. Budgeted separately. */
+export const LEAD_ATTR = "data-dpf-lead";
+
+export type TagToken = {
+  /** Lowercased tag name. */
+  name: string;
+  /** Lowercased attribute name -> value ("" for valueless attributes). */
+  attrs: Record<string, string>;
+  /** True for `<br/>`-style self-closing syntax. */
+  selfClosing: boolean;
+};
+
+// Matches a tag while tolerating `>` inside quoted attribute values.
+const TAG_RE = /<(\/?)([a-zA-Z][a-zA-Z0-9-]*)((?:"[^"]*"|'[^']*'|[^>])*?)(\/?)>/g;
+const ATTR_RE = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+)))?/g;
+
+function parseAttrs(raw: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  ATTR_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = ATTR_RE.exec(raw)) !== null) {
+    attrs[m[1].toLowerCase()] = m[2] ?? m[3] ?? m[4] ?? "";
+  }
+  return attrs;
+}
+
+/**
+ * Remove every subtree whose opening tag satisfies `shouldRemove`, matching close
+ * tags by depth so nested markup cannot truncate the removal early.
+ */
+export function removeSubtrees(
+  html: string,
+  shouldRemove: (tag: TagToken) => boolean,
+): string {
+  let out = "";
+  let cursor = 0;
+  // Non-null while skipping: the tag name being skipped and how deep we are in it.
+  let skipping: { name: string; depth: number } | null = null;
+
+  TAG_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = TAG_RE.exec(html)) !== null) {
+    const [full, closeSlash, rawName, rawAttrs, endSlash] = m;
+    const name = rawName.toLowerCase();
+    const isClose = closeSlash === "/";
+    const isVoid = VOID_ELEMENTS.has(name) || endSlash === "/";
+
+    if (skipping) {
+      // Only same-name tags move the depth counter; everything else is swallowed.
+      if (name === skipping.name && !isVoid) {
+        if (isClose) {
+          skipping.depth -= 1;
+          if (skipping.depth === 0) {
+            skipping = null;
+            cursor = m.index + full.length;
+          }
+        } else {
+          skipping.depth += 1;
+        }
+      }
+      continue;
+    }
+
+    if (isClose) continue;
+
+    const tag: TagToken = { name, attrs: parseAttrs(rawAttrs), selfClosing: isVoid };
+    if (!shouldRemove(tag)) continue;
+
+    out += html.slice(cursor, m.index);
+    if (isVoid) {
+      // No subtree to skip — drop the single tag.
+      cursor = m.index + full.length;
+    } else {
+      skipping = { name, depth: 1 };
+    }
+  }
+
+  // An unclosed skipped element swallows the remainder, which is the safe
+  // direction: unparseable markup must not silently inflate the measured scope.
+  return skipping ? out : out + html.slice(cursor);
+}
+
+/**
+ * Extract the outerHTML of every subtree whose opening tag satisfies `predicate`.
+ * Nested matches are not descended into — the outermost match wins.
+ */
+export function extractSubtrees(
+  html: string,
+  predicate: (tag: TagToken) => boolean,
+): string[] {
+  const found: string[] = [];
+  let capture: { name: string; depth: number; start: number } | null = null;
+
+  TAG_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = TAG_RE.exec(html)) !== null) {
+    const [full, closeSlash, rawName, rawAttrs, endSlash] = m;
+    const name = rawName.toLowerCase();
+    const isClose = closeSlash === "/";
+    const isVoid = VOID_ELEMENTS.has(name) || endSlash === "/";
+
+    if (capture) {
+      if (name === capture.name && !isVoid) {
+        if (isClose) {
+          capture.depth -= 1;
+          if (capture.depth === 0) {
+            found.push(html.slice(capture.start, m.index + full.length));
+            capture = null;
+          }
+        } else {
+          capture.depth += 1;
+        }
+      }
+      continue;
+    }
+
+    if (isClose) continue;
+    const tag: TagToken = { name, attrs: parseAttrs(rawAttrs), selfClosing: isVoid };
+    if (!predicate(tag)) continue;
+
+    if (isVoid) found.push(full);
+    else capture = { name, depth: 1, start: m.index };
+  }
+  return found;
+}
+
+/** True when an attribute is present and not explicitly negated. */
+function flagOn(attrs: Record<string, string>, name: string): boolean {
+  if (!(name in attrs)) return false;
+  const v = attrs[name].toLowerCase();
+  return v !== "false" && v !== "closed";
+}
+
+/**
+ * Structurally hidden on arrival: `hidden`, `aria-hidden="true"`, a collapsed
+ * `<details>`, or a disclosure region that is not explicitly open.
+ */
+export function isStructurallyHidden(tag: TagToken): boolean {
+  if (flagOn(tag.attrs, "hidden")) return true;
+  if (tag.attrs["aria-hidden"]?.toLowerCase() === "true") return true;
+  if (tag.name === "details" && !("open" in tag.attrs)) return true;
+  if (DISCLOSURE_ATTR in tag.attrs && !("open" in tag.attrs)) return true;
+  return false;
+}
+
+/** True when the element carries progressive-disclosure semantics at all. */
+export function isDisclosureRegion(tag: TagToken): boolean {
+  return tag.name === "details" || DISCLOSURE_ATTR in tag.attrs;
+}
+
+/**
+ * The scope a budget is measured against: what the owner actually sees on arrival.
+ * Non-rendered tags go first so a `<script>` containing markup-shaped strings
+ * cannot confuse the disclosure pass.
+ */
+export function defaultVisibleHtml(html: string): string {
+  const rendered = removeSubtrees(html, (tag) => NON_RENDERED.has(tag.name));
+  return removeSubtrees(rendered, isStructurallyHidden);
+}
+
+/** The lead band(s) — concatenated, already scoped to what is visible. */
+export function leadBandHtml(html: string): string {
+  return extractSubtrees(defaultVisibleHtml(html), (tag) => LEAD_ATTR in tag.attrs).join("\n");
+}
+
+/** How many disclosure regions the surface defers detail into. */
+export function countDisclosureRegions(html: string): number {
+  const rendered = removeSubtrees(html, (tag) => NON_RENDERED.has(tag.name));
+  return extractSubtrees(rendered, isDisclosureRegion).length;
+}

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -1,0 +1,230 @@
+// BI-B9BE9A29 (EP-UX-SYSTEM L2) — budget module contract.
+//
+// The two assertions that earn this module: collapsed disclosure is NOT counted
+// (progressive disclosure rewarded, never taxed), and a net-new route cannot be born
+// as a wall of text (spec rev 2 D1 — a pure ratchet would let it).
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  auditUxBudget,
+  countDisclosureRegions,
+  countPrimaryActions,
+  countVisibleFields,
+  defaultVisibleHtml,
+  leadBandHtml,
+  maxChoicesPerControl,
+  measureUxBudget,
+  removeSubtrees,
+  shellForRoute,
+  UX_SHELLS,
+} from "./index";
+import { countWords } from "../owner-first/ux-audit";
+
+describe("disclosure scoping — collapsed detail is excised, never taxed", () => {
+  it("does not count words inside a collapsed <details>", () => {
+    const html = `<div><p>visible words here</p><details><summary>More</summary><p>${"hidden ".repeat(50)}</p></details></div>`;
+    expect(countWords(defaultVisibleHtml(html))).toBeLessThan(10);
+  });
+
+  it("DOES count words inside an open <details> — disclosure must be honest both ways", () => {
+    const html = `<div><p>visible</p><details open><summary>More</summary><p>one two three four five</p></details></div>`;
+    expect(countWords(defaultVisibleHtml(html))).toBeGreaterThan(5);
+  });
+
+  it("matches close tags by depth so nested markup cannot truncate the excision", () => {
+    // The regression a naive regex causes: it stops at the first </div> and leaks
+    // the tail of the collapsed subtree back into the measured scope.
+    const html = `<details><div><div>LEAK</div></div></details><p>kept</p>`;
+    const visible = defaultVisibleHtml(html);
+    expect(visible).not.toContain("LEAK");
+    expect(visible).toContain("kept");
+  });
+
+  it("excises data-dpf-disclosure regions unless explicitly open", () => {
+    const collapsed = `<section data-dpf-disclosure><p>deferred detail</p></section><p>lead</p>`;
+    const open = `<section data-dpf-disclosure open><p>deferred detail</p></section><p>lead</p>`;
+    expect(defaultVisibleHtml(collapsed)).not.toContain("deferred detail");
+    expect(defaultVisibleHtml(open)).toContain("deferred detail");
+  });
+
+  it("excises hidden and aria-hidden subtrees", () => {
+    expect(defaultVisibleHtml(`<div hidden><p>no</p></div><p>yes</p>`)).not.toContain("no");
+    expect(defaultVisibleHtml(`<div aria-hidden="true"><p>no</p></div><p>yes</p>`)).not.toContain("no");
+  });
+
+  it("drops script/style content so markup-shaped strings cannot inflate the count", () => {
+    const html = `<script>const s = "<p>ghost words ghost words</p>";</script><p>real</p>`;
+    expect(countWords(defaultVisibleHtml(html))).toBe(1);
+  });
+
+  it("counts disclosure regions whether collapsed or open", () => {
+    expect(countDisclosureRegions(`<details><p>a</p></details><div data-dpf-disclosure><p>b</p></div>`)).toBe(2);
+  });
+
+  it("removeSubtrees leaves void elements alone rather than swallowing the rest", () => {
+    const out = removeSubtrees(`<p>a</p><img src="x"><p>b</p>`, (t) => t.name === "img");
+    expect(out).toContain("<p>a</p>");
+    expect(out).toContain("<p>b</p>");
+    expect(out).not.toContain("<img");
+  });
+});
+
+describe("lead band", () => {
+  it("extracts only the marked lead band", () => {
+    const html = `<header data-dpf-lead><h1>Your day</h1></header><section><p>everything else</p></section>`;
+    const lead = leadBandHtml(html);
+    expect(lead).toContain("Your day");
+    expect(lead).not.toContain("everything else");
+  });
+
+  it("reports no lead band when none is marked", () => {
+    expect(measureUxBudget(`<p>nothing marked</p>`).hasLeadBand).toBe(false);
+  });
+});
+
+describe("budget axes", () => {
+  it("counts fields the owner must fill, not hidden or submit inputs", () => {
+    const html = `<input type="hidden" name="csrf"><input type="text"><select></select><textarea></textarea><input type="submit">`;
+    expect(countVisibleFields(html)).toBe(3);
+  });
+
+  it("prefers the explicit primary-action marker, falling back to submit buttons", () => {
+    expect(countPrimaryActions(`<button data-dpf-primary-action>Go</button><button type="submit">x</button>`)).toBe(1);
+    expect(countPrimaryActions(`<button type="submit">a</button><button type="submit">b</button>`)).toBe(2);
+  });
+
+  it("reports the largest single control's choice count (Hick's law)", () => {
+    const html = `<select><option>1</option><option>2</option></select><select>${"<option>x</option>".repeat(9)}</select>`;
+    expect(maxChoicesPerControl(html)).toBe(9);
+  });
+
+  it("does not fabricate a reading grade for an empty surface", () => {
+    expect(measureUxBudget("<div></div>").readingGradeLevel).toBe(0);
+  });
+});
+
+describe("enforcement splits by route age (spec rev 2 D1)", () => {
+  // A surface well over the cockpit budget, with no disclosure and no lead band.
+  const wallOfText = `<main><p>${"word ".repeat(600)}</p></main>`;
+
+  it("a NET-NEW route cannot be born as a wall of text — absolutes block", () => {
+    const report = auditUxBudget(wallOfText, "cockpit", { routeStatus: "net-new" });
+    expect(report.ok).toBe(false);
+    const wordFinding = report.findings.find((f) => f.check === "default-visible-words");
+    expect(wordFinding?.ok).toBe(false);
+    expect(wordFinding?.severity).toBe("blocking");
+  });
+
+  it("the SAME surface on a pre-existing route reports advisory, not blocking", () => {
+    const report = auditUxBudget(wallOfText, "cockpit", { routeStatus: "pre-existing" });
+    const wordFinding = report.findings.find((f) => f.check === "default-visible-words");
+    expect(wordFinding?.ok).toBe(false);
+    expect(wordFinding?.severity).toBe("advisory");
+    expect(report.advisoryFailures).toBeGreaterThan(0);
+  });
+
+  it("defers detail to satisfy the blocking anti-wall-of-text rule", () => {
+    // Same word mass, but the bulk is deferred — this is the fix the budget rewards.
+    const disclosed = `<main data-dpf-lead><p>short lead</p></main><details><p>${"word ".repeat(600)}</p></details>`;
+    const report = auditUxBudget(disclosed, "cockpit", { routeStatus: "net-new" });
+    expect(report.findings.find((f) => f.check === "deferred-detail")?.ok).toBe(true);
+    expect(report.findings.find((f) => f.check === "default-visible-words")?.ok).toBe(true);
+  });
+
+  it("sub-legible controls block regardless of route age — WCAG, not calibration", () => {
+    const tiny = `<p>short</p><button class="text-[9px]">x</button>`;
+    for (const routeStatus of ["net-new", "pre-existing"] as const) {
+      const report = auditUxBudget(tiny, "cockpit", { routeStatus });
+      const f = report.findings.find((c) => c.check === "sub-legible-controls");
+      expect(f?.ok, routeStatus).toBe(false);
+      expect(f?.severity, routeStatus).toBe("blocking");
+      expect(report.ok, routeStatus).toBe(false);
+    }
+  });
+
+  it("a net-new route cannot claim pre-migration exemptions it never accrued", () => {
+    const noMarker = `<main><p>short surface</p></main>`;
+    const exempted = auditUxBudget(noMarker, "cockpit", {
+      routeStatus: "net-new",
+      exemptChecks: ["next-action-marker", "lead-band"],
+    });
+    expect(exempted.findings.find((f) => f.check === "next-action-marker")?.ok).toBe(false);
+
+    const legacy = auditUxBudget(noMarker, "cockpit", {
+      routeStatus: "pre-existing",
+      exemptChecks: ["next-action-marker", "lead-band"],
+    });
+    const legacyFinding = legacy.findings.find((f) => f.check === "next-action-marker");
+    expect(legacyFinding?.ok).toBe(true);
+    expect(legacyFinding?.exempt).toBe(true);
+  });
+});
+
+describe("route → intended shell derivation", () => {
+  it("derives shells from the existing audience/destination-kind registry", () => {
+    expect(shellForRoute({ audience: "owner", destinationKind: "section-home" })).toBe("cockpit");
+    expect(shellForRoute({ audience: "admin", destinationKind: "section-home" })).toBe("list");
+    expect(shellForRoute({ audience: "owner", destinationKind: "detail" })).toBe("detail");
+    expect(shellForRoute({ audience: "owner", destinationKind: "settings-config" })).toBe("settings");
+    expect(shellForRoute({ audience: "owner", destinationKind: "workflow-step" })).toBe("form");
+    expect(shellForRoute({ audience: "public", destinationKind: "detail" })).toBe("public");
+    expect(shellForRoute({ audience: "auth-setup", destinationKind: "detail" })).toBe("form");
+    expect(shellForRoute({ audience: "admin", destinationKind: "legacy-internal" })).toBe("unclassified");
+  });
+
+  it("settings/workflow shape wins over audience — a settings page is a settings page", () => {
+    expect(shellForRoute({ audience: "public", destinationKind: "settings-config" })).toBe("settings");
+  });
+});
+
+describe("generated route-shell registry", () => {
+  const registry = JSON.parse(
+    readFileSync(resolve(__dirname, "route-shells.generated.json"), "utf8"),
+  ) as {
+    pageRouteCount: number;
+    migratedCount: number;
+    summary: Record<string, number>;
+    routes: { routePath: string; shell: string; migrated: boolean; exemptChecks: string[] }[];
+  };
+
+  const manifest = JSON.parse(
+    readFileSync(resolve(__dirname, "../ea/route-manifest.json"), "utf8"),
+  ) as { routes: { routePath: string; kind: string; redirectTo?: string }[] };
+
+  it("covers exactly the non-redirect page routes in the route manifest", () => {
+    const expected = manifest.routes
+      .filter((r) => r.kind === "page" && !r.redirectTo)
+      .map((r) => r.routePath)
+      .sort();
+    expect(registry.routes.map((r) => r.routePath).sort()).toEqual(expected);
+  });
+
+  it("assigns every route a known shell", () => {
+    const known = new Set<string>(UX_SHELLS);
+    expect(registry.routes.filter((r) => !known.has(r.shell))).toEqual([]);
+  });
+
+  it("records pre-migration debt rather than hiding it", () => {
+    // Nothing has adopted an L1 shell yet (shells are Phase 2, BI-36CE8BAB), so every
+    // route must carry its exemptions explicitly. When this starts failing, the
+    // migration has begun — update MIGRATED_ROUTES, do not weaken the check.
+    expect(registry.migratedCount).toBe(0);
+    expect(registry.routes.every((r) => r.exemptChecks.length > 0)).toBe(true);
+  });
+
+  it("summary totals reconcile with the route list", () => {
+    const sum = Object.values(registry.summary).reduce((a, b) => a + b, 0);
+    expect(sum).toBe(registry.pageRouteCount);
+    expect(registry.pageRouteCount).toBe(registry.routes.length);
+  });
+
+  it("the committed registry is in sync with its generator", async () => {
+    // The assertion `pnpm --filter web check:route-shells` makes in CI, repeated here
+    // so staleness fails the REQUIRED Unit check too — not only the advisory workflow.
+    const { build } = await import("../../scripts/build-route-shells");
+    const regenerated = `${JSON.stringify(build(), null, 2)}\n`;
+    expect(readFileSync(resolve(__dirname, "route-shells.generated.json"), "utf8")).toBe(regenerated);
+  });
+});

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -13,6 +13,7 @@ import {
   countPrimaryActions,
   countVisibleFields,
   defaultVisibleHtml,
+  extractSubtrees,
   leadBandHtml,
   maxChoicesPerControl,
   measureUxBudget,
@@ -68,6 +69,32 @@ describe("disclosure scoping — collapsed detail is excised, never taxed", () =
     expect(out).toContain("<p>a</p>");
     expect(out).toContain("<p>b</p>");
     expect(out).not.toContain("<img");
+  });
+
+  it("treats XHTML-style self-closing tags as void", () => {
+    // The trailing slash lands in the captured attribute text now that the tag
+    // pattern is greedy, so it must be detected there.
+    const out = removeSubtrees(`<p>a</p><br/><p>b</p>`, (t) => t.name === "br");
+    expect(out).toContain("<p>a</p>");
+    expect(out).toContain("<p>b</p>");
+    const found = extractSubtrees(`<img src="x" />`, (t) => t.name === "img");
+    expect(found).toHaveLength(1);
+  });
+
+  it("does not backtrack exponentially on adjacent empty attribute values", () => {
+    // CodeQL js/redos: an earlier `[^>]` catch-all let `""` match two ways, so this
+    // input took exponential time. The branches are now mutually exclusive.
+    const pathological = `<a${'""'.repeat(60)}>text</a>`;
+    const started = performance.now();
+    defaultVisibleHtml(pathological);
+    expect(performance.now() - started).toBeLessThan(1000);
+  });
+
+  it("still tolerates > inside a quoted attribute value", () => {
+    const html = `<div title="a > b"><p>kept</p></div><details><p>gone</p></details>`;
+    const visible = defaultVisibleHtml(html);
+    expect(visible).toContain("kept");
+    expect(visible).not.toContain("gone");
   });
 });
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,8 @@
     "check:route-manifest": "tsx scripts/build-route-manifest.ts --check",
     "build:route-audience": "tsx scripts/build-route-audience.ts",
     "check:route-audience": "tsx scripts/build-route-audience.ts --check",
+    "build:route-shells": "tsx scripts/build-route-shells.ts",
+    "check:route-shells": "tsx scripts/build-route-shells.ts --check",
     "build:design-tokens": "tsx scripts/build-design-tokens.ts",
     "check:design-tokens": "tsx scripts/build-design-tokens.ts --check"
   },

--- a/apps/web/scripts/build-route-shells.ts
+++ b/apps/web/scripts/build-route-shells.ts
@@ -1,0 +1,108 @@
+/**
+ * Route → intended page shell registry — EP-UX-SYSTEM spec §6 L2 / §7.1 (BI-B9BE9A29).
+ *
+ * Emits the committed classification source the route budget sweep (BI-BD81682A), the
+ * migration league table (§7.1) and the Phase-4 cohort plan all read.
+ *
+ * Layers on the existing inventory rather than forking it: routes come from
+ * lib/ea/route-manifest.json, audience/destination-kind from lib/navigation/route-audience.ts,
+ * and shell is DERIVED from those (lib/ux-budget/route-shells.ts). Nothing here
+ * re-walks the filesystem or re-classifies a route.
+ *
+ * Deterministic by construction: manifest order is already byte-stable and no
+ * timestamps are emitted, so a regeneration with no route change is identical.
+ *
+ * Usage (local):
+ *   pnpm --filter web build:route-shells
+ *   pnpm --filter web check:route-shells   # fail if stale
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { classifyRoute, type ClassifiableRoute } from "../lib/navigation/route-audience";
+import { shellPolicyFor, type RouteShellPolicy } from "../lib/ux-budget/route-shells";
+import { UX_SHELLS, type UxShell } from "../lib/ux-budget/budgets";
+
+function repoRoot(): string {
+  let dir = process.cwd();
+  while (dir !== "/" && dir !== resolve(dir, "..")) {
+    if (existsSync(join(dir, "pnpm-workspace.yaml"))) return dir;
+    dir = resolve(dir, "..");
+  }
+  return process.cwd();
+}
+
+const ROOT = repoRoot();
+const MANIFEST_REL = "apps/web/lib/ea/route-manifest.json";
+const OUT_REL = "apps/web/lib/ux-budget/route-shells.generated.json";
+
+type ManifestRow = ClassifiableRoute & { kind: "page" | "route" };
+
+type Registry = {
+  generator: string;
+  pageRouteCount: number;
+  migratedCount: number;
+  summary: Record<UxShell, number>;
+  routes: (RouteShellPolicy & { confidence: "high" | "low" })[];
+};
+
+function build(): Registry {
+  const manifest = JSON.parse(readFileSync(join(ROOT, MANIFEST_REL), "utf8")) as {
+    routes: ManifestRow[];
+  };
+
+  // Page routes only, and never redirect shims — a shim renders no surface to budget.
+  const pages = manifest.routes.filter((r) => r.kind === "page" && !r.redirectTo);
+
+  const routes = pages.map((route) => {
+    const classification = classifyRoute(route);
+    return {
+      ...shellPolicyFor(route.routePath, classification),
+      confidence: classification.confidence,
+    };
+  });
+
+  const summary = Object.fromEntries(UX_SHELLS.map((s) => [s, 0])) as Record<UxShell, number>;
+  for (const r of routes) summary[r.shell] += 1;
+
+  return {
+    generator: "apps/web/scripts/build-route-shells.ts",
+    pageRouteCount: routes.length,
+    migratedCount: routes.filter((r) => r.migrated).length,
+    summary,
+    routes,
+  };
+}
+
+function main(): void {
+  const check = process.argv.includes("--check");
+  const outPath = join(ROOT, OUT_REL);
+  const registry = build();
+  const serialized = `${JSON.stringify(registry, null, 2)}\n`;
+
+  if (check) {
+    const current = existsSync(outPath) ? readFileSync(outPath, "utf8") : "";
+    if (current !== serialized) {
+      console.error(
+        `[route-shells] STALE — ${OUT_REL} is out of date. Run: pnpm --filter web build:route-shells`,
+      );
+      process.exit(1);
+    }
+    console.error(`[route-shells] up to date (${registry.pageRouteCount} page routes)`);
+    return;
+  }
+
+  writeFileSync(outPath, serialized, "utf8");
+  console.error(
+    `[route-shells] wrote ${OUT_REL} (${registry.pageRouteCount} page routes, ${registry.migratedCount} migrated)`,
+  );
+  const unclassified = registry.summary.unclassified;
+  if (unclassified > 0) {
+    // Not a failure: pre-migration debt is recorded, not hidden (spec §7.1).
+    console.error(`[route-shells] note: ${unclassified} route(s) have no intended shell yet`);
+  }
+}
+
+if (process.argv[1] && /build-route-shells\.[cm]?ts$/.test(process.argv[1])) main();
+
+export { build };

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -47,6 +47,53 @@ generated utilities are canonical for new code.
 > to nothing. `apps/web/design/tokens-utilities.test.ts` runs the real compiler and asserts each
 > promised utility emits a rule, so a token under a namespace v4 does not expose fails loudly.
 
+## UX Budgets (L2)
+
+Every owner-facing surface has a measurable budget. `apps/web/lib/ux-budget/` is the one
+module that defines them, and the same numbers feed three consumers: the guidance agents
+read, the CI checkers, and the migration league table. Intended shell per route is
+**derived** from the existing audience/destination-kind registry
+(`lib/navigation/route-audience.ts`) — there is no second hand-kept route list.
+
+| Axis | Budgeted as |
+|------|-------------|
+| Default-visible words | Words on arrival, **collapsed disclosure excised** |
+| Lead band | Presence + word count of `data-dpf-lead` |
+| Primary actions | `data-dpf-primary-action` (falls back to submit buttons) |
+| Visible fields | Fields the owner must fill (not hidden/submit inputs) |
+| Choices per control | Largest single control's option count (Hick's law) |
+| Sub-legible controls | Always 0 — WCAG 2.2 AA 2.5.8 |
+| Reading level | Flesch–Kincaid tier per shell |
+| Deferred detail | Above a per-shell word threshold the surface **must** use disclosure |
+
+**Progressive disclosure is rewarded, never taxed.** Measurement excises
+`<details>` without `open`, `[data-dpf-disclosure]` without `open`, `[hidden]` and
+`[aria-hidden="true"]` — matching close tags by depth, so nested markup cannot leak a
+collapsed subtree back into the measured scope. Moving professional detail behind
+disclosure is the sanctioned fix for a surface over budget, and the budget measures it
+that way.
+
+**Enforcement splits by route age, not by axis.**
+
+- **Net-new routes — absolute budgets block from day one.** A pure ratchet freezes
+  whatever ships first, so a brand-new route would become its own baseline and could be
+  born as a wall of text without ever failing. Legacy debt earns a ratchet; new code has
+  no legacy excuse.
+- **Pre-existing routes — the same budgets are advisory**, reported on the PR, plus the
+  regression ratchet. Retrofitting absolutes onto them keeps the flip contract.
+- **WCAG and the deferred-detail rule block regardless of age** — those are standards
+  and structure, not calibration.
+
+Text-mass numbers are **platform-owned calibration, not science** — no evidence
+validates words-per-screen against user outcomes. They are versioned in
+`lib/ux-budget/budgets.ts` for a founder to adjust from lived review, and they only move
+downward. (Visual/perceptual metrics are a different case — those *are* validated and
+ratchet independently.)
+
+Pre-migration routes carry recorded exemptions (`next-action-marker`, `lead-band`) until
+they adopt their shell. The exemption list is checked in and shrinks visibly as the
+redesign lands — debt recorded, never hidden.
+
 ## Contrast Requirements
 
 All color pairs must meet WCAG 2.2 Level AA minimum contrast ratios:


### PR DESCRIPTION
Phase 1 of **EP-UX-SYSTEM**, backlog item **BI-B9BE9A29**. This is the measurement substrate the token lint (BI-CBC7430F) and the route budget sweep (BI-BD81682A) consume, and the classification source for the §7.1 migration league table. Builds on the merged L0 token foundation (#3433).

## What lands

`apps/web/lib/ux-budget/` — scope · measure · budgets · route-shells · evaluate. It extends `lib/owner-first/ux-audit.ts` from "one summary band" to "a whole surface, scoped to what is visible on arrival", **reusing** its word/control primitives so there is one definition of "a word" on this platform.

Axes: default-visible words · lead band (presence + words) · primary actions · visible fields · choices per control (Hick's law) · sub-legible controls · reading level · deferred detail.

Readability uses the **pure** analyzer from `@dpf/validators`, deliberately **not** `lib/readability/policy.ts` — that module reads `PlatformConfig` through Prisma, and a CI checker must never need a database. The policy vocabulary is shared; only the DB-backed override resolution stays at runtime.

## Progressive disclosure is rewarded, never taxed

Measurement **excises** collapsed subtrees before counting — `<details>` without `open`, `[data-dpf-disclosure]` without `open`, `[hidden]`, `[aria-hidden="true"]` — matching close tags **by depth**.

That last part is load-bearing. A regex cannot pair a closing tag with its opener, so `<details><div>…</div></details>` would truncate at the first `</div>` and leak the tail of a collapsed subtree back into the measured scope. A budget that silently measures the wrong thing is worse than no budget. There is a test for exactly this.

Moving professional detail behind disclosure is the sanctioned fix for an over-budget surface, and the budget measures it that way.

## No second route registry

Intended shell is **derived** from the existing audience/destination-kind classification (`lib/navigation/route-audience.ts`, itself layered on `lib/ea/route-manifest.json`) — not hand-authored for 307 routes. A parallel hand-kept list of the same routes would drift from the first within weeks; this is the spec's own no-second-manifest rule applied to itself. The generated registry has a `--check` freshness gate wired into the existing Route Manifest Freshness workflow.

## Enforcement splits by route age (incorporates rev 2 D1)

Spec **rev 2** ([#3434](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3434)) landed while this was in progress and corrected a real hole in my first cut, which had made *every* absolute budget advisory:

- **Net-new routes — absolutes BLOCK from day one.** A pure ratchet freezes whatever ships first, so a brand-new route becomes its own baseline and could be born as a wall of text without ever failing. Legacy debt earns a ratchet; new code has no legacy excuse.
- **Pre-existing routes — the same budgets are advisory** plus the sweep's ratchet, so retrofitting keeps the §8 flip contract.
- **WCAG sub-legible controls and the deferred-detail rule block regardless of age** — standards and structure, not calibration.

**The numbers are provisional and labelled as such.** Rev 2 sets the day-one absolute at the *measured median of compliant routes*, which requires the §7.1 baseline sweep that does not exist yet. What lands here is the **mechanism** that lets them bite the moment the sweep supplies real medians. Text-mass thresholds remain platform-owned calibration, never presented as science.

## Verification

- 25 module tests, 74 across all touched libs — all passing.
- Freshness gate proven in both directions (clean → exit 0; drift → `STALE`, exit 1), and **also asserted by a unit test** so staleness fails the required Unit check, not only the advisory workflow.
- `check-style-drift`, `check-module-size`, `check-doc-links` green; doc index regenerated for the new heading.
- Local typecheck clean in every new file. The worktree's 2,211 pre-existing errors are the documented missing-`next`/Prisma-client pattern; the 2 that appeared since my last run are in `lib/identity/principal-linking.ts`, untouched here and arriving with main.

## Design grounding

Implements `docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md` §6 L2 and §7.1, incorporating rev 2 decision D1. Implementation in `apps/web/lib/ux-budget/` and `apps/web/scripts/build-route-shells.ts`.

Design-Grounding-Decision: implements the merged spec docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md section 6 L2 and section 7.1, incorporating rev 2 decision D1 from PR #3434. Implementation lands in apps/web/lib/ux-budget/ and apps/web/scripts/build-route-shells.ts.
Docs-Impact-Decision: updated docs/platform-usability-standards.md with a UX Budgets (L2) section covering every axis, the disclosure-excision rule, and the route-age enforcement split.
Module-Size-Decision: no file exceeds the 800 LOC threshold; check-module-size reports no new oversized files and no baselined file grew.
Process-Spine-Decision: doc updated in this PR (docs/platform-usability-standards.md); the governing spec already exists and is extended, not forked.
