### PR TITLE
feat(discovery): anchor estate identity on MAC + separate managed from merely-observed

### DIFF
--- a/docs/data-impact/2026-07-23-observed-estate-stale-resolve.data-impact.json
+++ b/docs/data-impact/2026-07-23-observed-estate-stale-resolve.data-impact.json
@@ -1,0 +1,39 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "PortfolioQualityIssue rows (open stale_entity / stale_relationship for merely-observed estate)",
+    "Prisma-to-EA current-state data-model mirror"
+  ],
+  "migration": {
+    "name": "20260723020000_resolve_observed_estate_stale_issues",
+    "backfill": "status flip only — no row is created or deleted, no id, scope FK, summary, or detection timestamp is changed. Open stale_entity / stale_relationship rows whose issueKey carries a positional observed token (arp:, arp-host:, unifi-client:, prom:, prom-target:) or a positional container: segment are set status open->resolved with resolvedAt=NOW(). These describe things discovery merely observed (ARP neighbours, UniFi clients, platform Prometheus targets) or Docker containers that bypassed the prefix-only guard — none is resolvable by operator action. Managed infrastructure that genuinely vanished (UniFi devices, servers, services) is deliberately left OPEN because it is real signal. Tokens match positionally so managed names containing the letters (promotions-engine, sharp-imaging) are never matched. Non-destructive and idempotent: already-resolved rows are not re-selected."
+  },
+  "tests": [
+    "packages/db/src/estate-observation-class.test.ts",
+    "packages/db/src/docker-origin.test.ts",
+    "packages/db/src/discovery-attribution.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:portfolio-quality-issue#observed-estate-stale-resolve",
+      "prismaModel": "PortfolioQualityIssue",
+      "lifecycleDisposition": "no lifecycle change to the underlying InventoryEntity / InventoryRelationship or any operator-facing record: only the derived quality-issue status transitions open->resolved for issues describing merely-observed (non-managed) estate. firstDetectedAt, lastDetectedAt, scope FKs, and summary are preserved; rows remain for audit.",
+      "fields": [
+        {
+          "fieldId": "data:portfolio-quality-issue#status",
+          "resolution": "governed",
+          "reason": "resolve permanently-open stale issues raised for transient observations (ARP neighbours, UniFi clients) and platform-internal Prometheus targets, which vanish as a matter of course and can never be resolved by operator action; going forward evaluateInventoryQuality only emits stale issues for the managed estate",
+          "provenance": "live-DB analysis after the #3418/#3424 migrations applied: stale_relationship 146 open (137 observed / 9 managed) and stale_entity 108 open (86 observed + 11 positional-container / 11 managed); this migration resolves 234 and leaves the 20 genuinely-managed rows open, which resolve to a single coherent signal (the operator's UniFi gateway, switch and 4 APs plus their topology links stopped reporting)"
+        },
+        {
+          "fieldId": "data:portfolio-quality-issue#resolvedAt",
+          "resolution": "governed",
+          "reason": "stamp the resolution time for the audit trail on the same open->resolved transition",
+          "provenance": "set to NOW() only on rows matching the positional observed/container token predicate; managed-estate rows are untouched"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/specs/2026-07-22-estate-identity-and-managed-classification-design.md
+++ b/docs/superpowers/specs/2026-07-22-estate-identity-and-managed-classification-design.md
@@ -1,0 +1,111 @@
+# Estate identity anchoring + managed-vs-observed classification
+
+Status: implemented
+Date: 2026-07-22
+Backlog: follow-up to BI-527290AA / BI-3715F309 (open-issues cleanup arc)
+
+## Problem
+
+Discovery treats **every observation as inventory**. That produced two distinct
+defects behind the `stale_entity` / `stale_relationship` quality-issue flood that
+the preceding PRs (#3163, #3418, #3424) only partly drained.
+
+### 1. Identity is anchored to the observation, not the thing
+
+Two identity regimes coexisted in the collectors:
+
+| Collector | Key | Stability |
+| --- | --- | --- |
+| UniFi devices | `unifi:${mac}` | stable |
+| UniFi clients | `unifi-client:${mac}` | stable |
+| ARP neighbours (`network.ts`, `snmp.ts`, `arp-scan.ts`) | `arp:${ip}` / `arp-host:${ip}` | **volatile** |
+
+An ARP-discovered host is keyed by its **IP**, even though ARP inherently yields
+the IP↔**MAC** pair and the MAC was already being captured as an attribute. Every
+DHCP lease change therefore mints a *new* entity and strands the old one as
+permanently `stale` — one orphan per re-lease — plus a duplicate row for what is
+physically one device.
+
+### 2. Transient observations are treated as managed estate
+
+A UniFi access point disappearing is real, actionable signal. A phone that left
+the wifi, an ARP neighbour seen once, or the platform's own Prometheus scrape
+target disappearing is **normal** — but all of them raised a `stale_*` quality
+issue that no operator can ever resolve.
+
+## Design
+
+### Axis 1 — identity anchoring (stability)
+
+Anchor ARP-discovered hosts on the **MAC** when the collector reported one,
+falling back to the IP only when it did not:
+
+```ts
+const identity = normalizeMac(host.mac) ?? host.ip;   // canonical, e.g. 00A0C9123456
+externalRef = `arp-host:${identity}`;
+naturalKey  = `arp:${identity}`;
+```
+
+Reuses the existing `normalizeMac` (`discovery-mac-classification.ts`), so
+separator/case variation between `arp -a`, `ip neigh`, nmap and SNMP collapses to
+one canonical form. Applied in all three ARP-emitting collectors
+(`network.ts`, `snmp.ts`, `arp-scan.ts`). This matches the UniFi convention and
+makes the entity a durable record of *the device* rather than of *a sighting*.
+
+### Axis 2 — managed vs merely observed (durability)
+
+A second, orthogonal classification in `estate-observation-class.ts`:
+
+- **`managed`** — infrastructure the operator owns and administers (UniFi
+  devices, SNMP-managed gear, servers, services, databases). Disappearance is
+  actionable signal.
+- **`observed`** — transient things merely seen (ARP neighbours, UniFi clients)
+  or platform-internal monitoring targets (`prom:` / `prom-target:`).
+  Disappearance is normal and must not raise a quality issue.
+
+Classification is by positional token match on the key (never substring, so
+`promotions-engine` and `sharp-imaging` stay managed). **Default is `managed`**:
+a false `observed` would *hide* real operator signal, whereas a false `managed`
+only leaves a resolvable row on the queue.
+
+Relationships take the **least-durable endpoint**: a relationship touching any
+observed endpoint is observed (a transient client on a managed AP vanishes when
+the client leaves), while managed↔managed topology (AP uplink → switch) stays
+managed.
+
+Wired into `evaluateInventoryQuality`: only `managed` entities/relationships emit
+`stale_entity` / `stale_relationship`.
+
+### Relationship to existing classification
+
+This is the **second axis**. The first, `classifyEstateProvenance`
+(`discovery-promotion-policy.ts`), separates the operator's real estate from the
+platform's own black-box runtime. This one separates, *within what discovery can
+see*, the managed set from the merely observed set. `isDockerOriginEntityKey` /
+`isDockerOriginRelationshipKey` remain the structural Docker-churn guard; this
+change also makes the entity guard's `container:` match **positional**, closing a
+leak where `monitoring_service:container:<12hex>` bypassed it.
+
+## Why not the alternatives
+
+- **Retention/aging only** (age out stale rows after N days) — treats the symptom.
+  A guest phone would still open an issue for N days, and duplicate identities
+  would keep accumulating.
+- **Re-key existing rows in a migration** — the volatile `arp:<ip>` rows are
+  classified `observed` by axis 2, so they raise nothing while they age out. A
+  full re-key of entity + relationship keys carries far more blast radius than
+  the churn it would avoid.
+- **Suppress all issue types for observed entities** — deliberately out of scope.
+  This change is scoped to *disappearance* (`stale_*`). Whether an observed host
+  should also skip `lifecycle_unverified` / `catalog_match_ambiguous` needs its
+  own evidence pass.
+
+## Out of scope / follow-ups
+
+- **Retention & aging** for genuinely-decommissioned *managed* assets: after N
+  days unseen, surface a **decision** ("retire this device?") rather than a
+  standing quality issue. This is a policy call for the operator.
+- **Cross-collector identity resolution**: the same physical device discovered by
+  both UniFi and ARP still yields two rows (`unifi:<mac>` and `arp:<MAC>`).
+  Anchoring both on MAC is the prerequisite; merging them is the next step.
+- Broader suppression of non-stale issue types for observed entities (above).

--- a/packages/db/prisma/migrations/20260723020000_resolve_observed_estate_stale_issues/migration.sql
+++ b/packages/db/prisma/migrations/20260723020000_resolve_observed_estate_stale_issues/migration.sql
@@ -1,0 +1,35 @@
+-- Estate identity + managed-vs-observed classification
+-- (docs/superpowers/specs/2026-07-22-estate-identity-and-managed-classification-design.md)
+--
+-- Resolve open stale_entity / stale_relationship issues for things discovery
+-- merely OBSERVED rather than things the operator MANAGES:
+--
+--   arp: / arp-host:   ARP neighbours — a host that answered on the wire once.
+--   unifi-client:      UniFi *clients* (phones, laptops, guests), as opposed to
+--                      `unifi:` UniFi *devices* (AP/switch/router), which ARE
+--                      managed infrastructure and are deliberately left open.
+--   prom: / prom-target:  the platform's own Prometheus scrape topology.
+--
+-- These vanish as a matter of course, so a "stale" issue for them can never be
+-- resolved by any operator action — it is noise by construction. Going forward
+-- `evaluateInventoryQuality` no longer emits them (estate-observation-class.ts).
+--
+-- Also resolves Docker container rows that bypassed isDockerOriginEntityKey
+-- because `container:` appeared as a LATER segment (e.g.
+-- `monitoring_service:container:06cc859f0e76`) rather than a prefix; that guard
+-- is now positional.
+--
+-- Tokens are matched POSITIONALLY (after `:` or the `->` arrow) so a managed
+-- product whose name merely contains the letters — `promotions-engine`,
+-- `sharp-imaging` — is never matched. Non-destructive: status open -> resolved
+-- only; rows remain for audit. Managed infrastructure that genuinely vanished is
+-- intentionally left OPEN, because that is real operator signal.
+UPDATE "PortfolioQualityIssue"
+SET "status" = 'resolved',
+    "resolvedAt" = NOW()
+WHERE "status" = 'open'
+  AND "issueType" IN ('stale_entity', 'stale_relationship')
+  AND (
+    "issueKey" ~ '[:>](arp|arp-host|unifi-client|prom|prom-target):'
+    OR "issueKey" ~ '[:>]container:'
+  );

--- a/packages/db/src/discovery-attribution.test.ts
+++ b/packages/db/src/discovery-attribution.test.ts
@@ -316,12 +316,17 @@ describe("evaluateInventoryQuality", () => {
   });
 
   it("emits a stale_relationship issue for a stale real-estate relationship", () => {
+    // Real-estate topology still raises, unlike Docker-origin churn. The
+    // exemplar is managed<->managed (gateway uplink to switch): an
+    // `arp:<host>-> unifi:<ap>` link is a TRANSIENT client attachment and is
+    // now classified observed — see the managed-vs-observed test below.
     const result = evaluateInventoryQuality(
       [],
       [
         {
-          relationshipKey: "organization:internal:edge_node:MEMBER_OF:arp:192.168.0.58->unifi:fc:ec:da:bc:a5:49",
-          relationshipType: "MEMBER_OF",
+          relationshipKey:
+            "organization:internal:edge_node:HOSTS:unifi:9c:05:d6:de:8d:3f->unifi:d0:21:f9:df:56:92",
+          relationshipType: "HOSTS",
           status: "stale",
         },
       ],
@@ -356,6 +361,66 @@ describe("evaluateInventoryQuality", () => {
     );
 
     expect(result.issues).toHaveLength(0);
+  });
+
+  it("emits stale_entity for MANAGED infrastructure but not for merely-observed things", () => {
+    const result = evaluateInventoryQuality([
+      // Managed: a UniFi access point vanishing is real, actionable signal.
+      {
+        entityKey: "organization:internal:access_point:unifi:ac:8b:a9:3f:1b:29",
+        entityType: "access_point",
+        attributionStatus: "stale",
+      },
+      // Observed: an ARP neighbour and a UniFi client leaving is normal churn.
+      {
+        entityKey: "organization:internal:host:arp:00A0C9123456",
+        entityType: "host",
+        attributionStatus: "stale",
+      },
+      {
+        entityKey: "organization:internal:host:unifi-client:aa:bb:cc:dd:ee:ff",
+        entityType: "host",
+        attributionStatus: "stale",
+      },
+      // Observed: the platform's own Prometheus scrape target.
+      {
+        entityKey: "application:prom:portal:portal:3000",
+        entityType: "application",
+        attributionStatus: "stale",
+      },
+    ]);
+
+    const stale = result.issues.filter((issue) => issue.issueType === "stale_entity");
+    expect(stale).toHaveLength(1);
+    expect(stale[0].inventoryEntityKey).toBe(
+      "organization:internal:access_point:unifi:ac:8b:a9:3f:1b:29",
+    );
+  });
+
+  it("suppresses stale_relationship when either endpoint is merely observed", () => {
+    const result = evaluateInventoryQuality(
+      [],
+      [
+        // Managed<->managed topology (gateway uplink to switch) — real signal.
+        {
+          relationshipKey:
+            "organization:internal:edge_node:HOSTS:unifi:9c:05:d6:de:8d:3f->unifi:d0:21:f9:df:56:92",
+          relationshipType: "HOSTS",
+          status: "stale",
+        },
+        // Transient client attached to a managed AP — vanishes when it leaves.
+        {
+          relationshipKey:
+            "organization:internal:edge_node:MEMBER_OF:arp:00A0C9123456->unifi:fc:ec:da:bc:a5:49",
+          relationshipType: "MEMBER_OF",
+          status: "stale",
+        },
+      ],
+    );
+
+    const stale = result.issues.filter((issue) => issue.issueType === "stale_relationship");
+    expect(stale).toHaveLength(1);
+    expect(stale[0].inventoryRelationshipKey).toContain("unifi:9c:05:d6:de:8d:3f");
   });
 
   it("does not emit for active (non-stale) relationships regardless of origin", () => {

--- a/packages/db/src/discovery-attribution.ts
+++ b/packages/db/src/discovery-attribution.ts
@@ -1,4 +1,8 @@
 import { isDockerOriginEntityKey, isDockerOriginRelationshipKey } from "./docker-origin";
+import {
+  classifyEntityObservation,
+  classifyRelationshipObservation,
+} from "./estate-observation-class";
 
 const LOW_CONFIDENCE_THRESHOLD = 0.55;
 const STOP_WORDS = new Set([
@@ -366,7 +370,14 @@ export function evaluateInventoryQuality(
       });
     }
 
-    if (entity.attributionStatus === "stale") {
+    // Only the MANAGED estate raises an issue when it vanishes. An ARP
+    // neighbour, a UniFi client (phone/laptop), or a platform Prometheus target
+    // disappearing is normal churn, not an operator-actionable gap — surfacing
+    // it produces a permanently-open row nobody can resolve.
+    if (
+      entity.attributionStatus === "stale"
+      && classifyEntityObservation(entity.entityKey) === "managed"
+    ) {
       issues.push({
         issueKey: `inventory_entity:${entity.entityKey}:stale`,
         issueType: "stale_entity",
@@ -422,6 +433,12 @@ export function evaluateInventoryQuality(
     // per orphan that never resolves. Skip issue generation for them, exactly as
     // the entity loop above skips isDockerOriginEntityKey rows.
     if (isDockerOriginRelationshipKey(relationship.relationshipKey)) {
+      continue;
+    }
+    // A relationship is only as durable as its least-durable endpoint: a
+    // transient client attached to a managed AP vanishes the moment that client
+    // leaves. Managed<->managed topology (AP uplink to switch) still raises.
+    if (classifyRelationshipObservation(relationship.relationshipKey) === "observed") {
       continue;
     }
     if (relationship.status === "stale") {

--- a/packages/db/src/discovery-collectors/arp-scan.ts
+++ b/packages/db/src/discovery-collectors/arp-scan.ts
@@ -14,6 +14,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { CollectorContext, CollectorOutput } from "../discovery-types";
+import { normalizeMac } from "../discovery-mac-classification";
 
 const execFileAsync = promisify(execFile);
 
@@ -131,15 +132,19 @@ export async function collectArpScanDiscovery(
       },
     });
 
-    // Create host entities for each discovered IP
+    // Create host entities for each discovered host
     for (const host of hosts) {
-      const hostRef = `arp-host:${host.ip}`;
+      // Identity anchor: MAC is stable across DHCP lease changes, IP is not —
+      // see discovery-collectors/network.ts. nmap/arp give the MAC when the host
+      // answers on the local segment; fall back to the IP only when it did not.
+      const hostIdentity = normalizeMac(host.mac) ?? host.ip;
+      const hostRef = `arp-host:${hostIdentity}`;
       items.push({
         sourceKind: source,
         itemType: "host",
         name: host.hostname ?? `LAN Host ${host.ip}`,
         externalRef: hostRef,
-        naturalKey: `arp:${host.ip}`,
+        naturalKey: `arp:${hostIdentity}`,
         confidence: 0.70,
         attributes: {
           address: host.ip,

--- a/packages/db/src/discovery-collectors/network.ts
+++ b/packages/db/src/discovery-collectors/network.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import { spawnSync } from "node:child_process";
 
 import type { CollectorContext, CollectorOutput } from "../discovery-types";
+import { normalizeMac } from "../discovery-mac-classification";
 
 // ─── Dependency Injection Types ────────────────────────────────────────────
 
@@ -419,13 +420,20 @@ export async function collectNetworkDiscovery(
   // ── ARP Neighbors (L3) ────────────────────────────────────────
   const neighbors = discoverArpNeighbors(deps);
   for (const neighbor of neighbors) {
-    const neighborRef = `arp-host:${neighbor.ip}`;
+    // Identity anchor: a host's MAC is stable across DHCP lease changes; its IP
+    // is not. Keying on the IP mints a NEW entity every time the lease moves and
+    // strands the old one as permanently `stale` — one orphan per re-lease. ARP
+    // inherently yields the IP<->MAC pair, so anchor on the MAC when the
+    // neighbour reported one and fall back to the IP only when it did not. This
+    // matches the UniFi collector's `unifi:${mac}` convention.
+    const neighborIdentity = normalizeMac(neighbor.mac) ?? neighbor.ip;
+    const neighborRef = `arp-host:${neighborIdentity}`;
     items.push({
       sourceKind: source,
       itemType: "host",
       name: `LAN Host ${neighbor.ip}`,
       externalRef: neighborRef,
-      naturalKey: `arp:${neighbor.ip}`,
+      naturalKey: `arp:${neighborIdentity}`,
       confidence: 0.6,
       attributes: {
         address: neighbor.ip,

--- a/packages/db/src/discovery-collectors/snmp.ts
+++ b/packages/db/src/discovery-collectors/snmp.ts
@@ -13,6 +13,7 @@
 // This file runs inside Docker containers, not in the browser.
 import snmp from "net-snmp";
 import type { CollectorContext, CollectorOutput, DiscoverySourceKind } from "../discovery-types";
+import { normalizeMac } from "../discovery-mac-classification";
 
 // ─── SNMP OIDs ──────────────────────────────────────────────────────────────
 
@@ -289,13 +290,17 @@ async function discoverSnmpDevice(
         : "";
       if (!ip || ip === "0.0.0.0" || ip === target.address) continue;
 
-      const hostRef = `arp-host:${ip}`;
+      // Identity anchor: MAC is stable across DHCP lease changes, IP is not —
+      // see the same reasoning in discovery-collectors/network.ts. The SNMP ARP
+      // table gives both, so anchor on the MAC when present.
+      const hostIdentity = normalizeMac(mac) ?? ip;
+      const hostRef = `arp-host:${hostIdentity}`;
       items.push({
         sourceKind: source,
         itemType: "host",
         name: `LAN Host ${ip}`,
         externalRef: hostRef,
-        naturalKey: `arp:${ip}`,
+        naturalKey: `arp:${hostIdentity}`,
         confidence: 0.60,
         attributes: {
           address: ip,

--- a/packages/db/src/docker-origin.test.ts
+++ b/packages/db/src/docker-origin.test.ts
@@ -46,6 +46,15 @@ describe("isDockerOriginEntityKey (server-side)", () => {
     expect(isDockerOriginEntityKey("host:arp:192.168.0.5")).toBe(false);
   });
 
+  it("matches a container: segment anywhere in the key, not just as a prefix", () => {
+    // Collectors emit `container:` as a later segment too; a startsWith check
+    // missed these and they opened a permanent stale_entity per recreation.
+    expect(isDockerOriginEntityKey("monitoring_service:container:06cc859f0e76")).toBe(true);
+    expect(isDockerOriginEntityKey("container:dpf-portal-1")).toBe(true);
+    // Must not false-match a non-container token that merely starts with it.
+    expect(isDockerOriginEntityKey("service:container-registry")).toBe(false);
+  });
+
   it("matches Docker 172.16/12 bridge NIC shapes the specific matches miss", () => {
     // The self-scan's bridge NIC rows and their quarantined wrappers leaked past
     // the host:arp:/host:hostname: matches and opened permanent stale_entity issues.

--- a/packages/db/src/docker-origin.ts
+++ b/packages/db/src/docker-origin.ts
@@ -51,7 +51,12 @@ export function isDockerOriginEntityKey(
 ): boolean {
   if (entityKey.startsWith("subnet:docker-")) return true;
   if (entityKey.startsWith("gateway:docker-gw:")) return true;
-  if (entityKey.startsWith("container:")) return true;
+  // `container:` is matched POSITIONALLY, not just as a prefix: collectors also
+  // emit it as a later segment (e.g. `monitoring_service:container:06cc859f0e76`),
+  // which a startsWith check missed — those leaked past this guard and opened a
+  // permanent stale_entity issue per recreated container. Mirrors the same
+  // positional rule already used by isDockerOriginRelationshipKey.
+  if (DOCKER_CONTAINER_ENDPOINT_RE.test(entityKey)) return true;
   if (entityKey.startsWith("runtime:docker")) return true;
   if (entityKey.startsWith("docker_host:")) return true;
 

--- a/packages/db/src/estate-observation-class.test.ts
+++ b/packages/db/src/estate-observation-class.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyEntityObservation,
+  classifyRelationshipObservation,
+} from "./estate-observation-class";
+
+describe("classifyEntityObservation", () => {
+  it("classifies UniFi infrastructure devices as managed", () => {
+    // These are the operator's owned/administered network gear — an AP or
+    // switch going missing is real, actionable signal.
+    expect(classifyEntityObservation("organization:internal:access_point:unifi:ac:8b:a9:3f:1b:29")).toBe("managed");
+    expect(classifyEntityObservation("organization:internal:switch:unifi:d0:21:f9:df:56:92")).toBe("managed");
+    expect(classifyEntityObservation("organization:internal:router:unifi:fc:ec:da:bc:a5:49")).toBe("managed");
+  });
+
+  it("classifies servers, services and databases as managed", () => {
+    expect(classifyEntityObservation("host:hostname:dpf-dev")).toBe("managed");
+    expect(classifyEntityObservation("service:mystery-engine")).toBe("managed");
+    expect(classifyEntityObservation("database:postgres-primary")).toBe("managed");
+  });
+
+  it("classifies ARP neighbours as observed (transient, IP-seen hosts)", () => {
+    expect(classifyEntityObservation("organization:internal:host:arp:192.168.0.58")).toBe("observed");
+    expect(classifyEntityObservation("host:arp-host:192.168.0.58")).toBe("observed");
+    expect(classifyEntityObservation("arp:00A0C9123456")).toBe("observed");
+  });
+
+  it("classifies UniFi clients as observed but UniFi devices as managed", () => {
+    // The distinction that matters: `unifi-client:` is a phone/laptop passing
+    // through; `unifi:` is the AP it connected to.
+    expect(classifyEntityObservation("organization:internal:host:unifi-client:aa:bb:cc:dd:ee:ff")).toBe("observed");
+    expect(classifyEntityObservation("organization:internal:access_point:unifi:aa:bb:cc:dd:ee:ff")).toBe("managed");
+  });
+
+  it("classifies platform Prometheus scrape targets as observed", () => {
+    expect(classifyEntityObservation("application:prom:portal:portal:3000")).toBe("observed");
+    expect(classifyEntityObservation("service:prom:adp:adp:8600")).toBe("observed");
+    expect(classifyEntityObservation("database:prom:postgres:postgres-exporter:9187")).toBe("observed");
+  });
+
+  it("only matches observed tokens positionally — never as a substring", () => {
+    // A managed product legitimately containing these letters must not be
+    // misclassified; a false "observed" would hide real signal.
+    expect(classifyEntityObservation("service:sharp-imaging")).toBe("managed");
+    expect(classifyEntityObservation("application:promotions-engine")).toBe("managed");
+    expect(classifyEntityObservation("service:warp:gateway")).toBe("managed");
+  });
+});
+
+describe("classifyRelationshipObservation", () => {
+  it("keeps managed<->managed topology managed", () => {
+    // AP uplink to switch — if that link disappears, the operator wants to know.
+    expect(
+      classifyRelationshipObservation(
+        "organization:internal:edge_node:HOSTS:unifi:9c:05:d6:de:8d:3f->unifi:d0:21:f9:df:56:92",
+      ),
+    ).toBe("managed");
+  });
+
+  it("classifies a relationship touching ANY observed endpoint as observed", () => {
+    // Transient client attached to a managed AP — vanishes when the client leaves.
+    expect(
+      classifyRelationshipObservation(
+        "organization:internal:edge_node:MEMBER_OF:arp:192.168.0.58->unifi:fc:ec:da:bc:a5:49",
+      ),
+    ).toBe("observed");
+    expect(
+      classifyRelationshipObservation(
+        "dpf_bootstrap:monitors:prom-target:prometheus:localhost:9090->prom-target:adp:adp:8600",
+      ),
+    ).toBe("observed");
+  });
+
+  it("does not false-match an observed token inside another segment", () => {
+    expect(
+      classifyRelationshipObservation("org:internal:HOSTS:service:promotions->service:sharp-imaging"),
+    ).toBe("managed");
+  });
+});

--- a/packages/db/src/estate-observation-class.ts
+++ b/packages/db/src/estate-observation-class.ts
@@ -1,0 +1,89 @@
+// estate-observation-class.ts
+//
+// Separates the estate the operator MANAGES from the things discovery merely
+// OBSERVED passing through the network.
+//
+// Why this exists: discovery treats every observation as inventory. A UniFi
+// access point, a switch, and a router are infrastructure the operator owns and
+// administers — if one stops answering, that is real signal worth surfacing. A
+// phone that joined the wifi, an ARP neighbour seen once at 192.168.0.58, or a
+// Prometheus scrape target inside the platform are NOT the operator's managed
+// estate; they appear and vanish as a matter of course. Raising a
+// stale_entity / stale_relationship quality issue when one of those disappears
+// is noise by construction — it can never be "fixed", only ignored.
+//
+// This is the second axis of estate classification. The first,
+// classifyEstateProvenance (discovery-promotion-policy.ts), separates the
+// operator's real estate from the platform's own black-box runtime. This one
+// separates, WITHIN what discovery can see, the managed set from the merely
+// observed set.
+//
+// Bias: default to "managed". A false "observed" SUPPRESSES a quality issue and
+// would hide real operator signal; a false "managed" only leaves a resolvable
+// issue on the queue. So only clearly-transient shapes are classified observed.
+
+export type EstateObservationClass = "managed" | "observed";
+
+// Natural-key prefixes emitted by the collectors for things that are seen
+// rather than administered. Matched positionally (start of key, or after a `:`
+// or the `->` arrow in a relationship key) so a substring inside another token
+// never false-matches.
+//
+//   arp: / arp-host:  — discoverArpNeighbors (network.ts, snmp.ts). Confidence
+//                       0.6, named "LAN Host <ip>". An ARP neighbour is any host
+//                       that answered on the wire once.
+//   unifi-client:     — UniFi *clients* (laptops, phones, guest devices), as
+//                       opposed to `unifi:` UniFi *devices* (AP/switch/router),
+//                       which ARE managed infrastructure.
+//   prom: / prom-target: — the platform's own Prometheus scrape topology.
+const OBSERVED_KEY_TOKENS: readonly string[] = [
+  "arp:",
+  "arp-host:",
+  "unifi-client:",
+  "prom:",
+  "prom-target:",
+];
+
+function hasObservedToken(key: string): boolean {
+  return OBSERVED_KEY_TOKENS.some((token) => {
+    let from = 0;
+    for (;;) {
+      const at = key.indexOf(token, from);
+      if (at === -1) return false;
+      // Positional: key start, or immediately after `:` or `>` (the `->` arrow).
+      const prev = at === 0 ? "" : key[at - 1];
+      if (at === 0 || prev === ":" || prev === ">") return true;
+      from = at + 1;
+    }
+  });
+}
+
+/**
+ * Classify a discovered InventoryEntity by its entityKey.
+ *
+ * `managed`  — infrastructure the operator owns/administers (UniFi devices,
+ *              SNMP-managed gear, servers, services, databases). Its
+ *              disappearance is real, actionable signal.
+ * `observed` — transient things merely seen on the network (ARP neighbours,
+ *              UniFi clients) or platform-internal monitoring targets. Its
+ *              disappearance is normal and must not raise a quality issue.
+ */
+export function classifyEntityObservation(entityKey: string): EstateObservationClass {
+  return hasObservedToken(entityKey) ? "observed" : "managed";
+}
+
+/**
+ * Classify a discovered InventoryRelationship by its relationshipKey.
+ *
+ * A relationship is only as durable as its least-durable endpoint: an
+ * `arp:192.168.0.58 -> unifi:<ap-mac>` attachment describes a transient client
+ * sitting on a managed AP, and vanishes the moment that client leaves. So a
+ * relationship touching ANY observed endpoint is itself observed. A
+ * managed↔managed link (`unifi:<mac> -> unifi:<mac>`, e.g. AP uplink to switch)
+ * stays managed — that topology going away IS worth surfacing.
+ */
+export function classifyRelationshipObservation(
+  relationshipKey: string,
+): EstateObservationClass {
+  return hasObservedToken(relationshipKey) ? "observed" : "managed";
+}


### PR DESCRIPTION
Delivers the two layers behind the residual stale-issue churn. Design: `docs/superpowers/specs/2026-07-22-estate-identity-and-managed-classification-design.md`. Follow-up to BI-527290AA / BI-3715F309.

## 1. Identity anchoring — the entity should be the *device*, not the *sighting*

ARP-discovered hosts were keyed by **IP** (`arp:${ip}`, `arp-host:${ip}`) even though ARP inherently yields the IP↔**MAC** pair and the MAC was *already* captured as an attribute. Every DHCP lease change minted a **new** entity and stranded the old one as permanently `stale` — one orphan per re-lease, plus a duplicate row for one physical device.

All three ARP-emitting collectors (`network.ts`, `snmp.ts`, `arp-scan.ts`) now anchor on `normalizeMac(mac) ?? ip`, reusing the existing canonical normalizer so separator/case variation across `arp -a`, `ip neigh`, nmap and SNMP collapses to one form. Matches the UniFi `unifi:${mac}` convention.

## 2. Managed vs merely-observed

New `estate-observation-class.ts`:

| Class | What | Disappearance |
|---|---|---|
| `managed` | UniFi **devices** (AP/switch/router), SNMP gear, servers, services, databases | Real, actionable signal |
| `observed` | ARP neighbours, UniFi **clients** (phones/laptops), platform `prom:`/`prom-target:` targets | Normal churn — must not raise |

`evaluateInventoryQuality` now emits `stale_entity`/`stale_relationship` only for the **managed** set. Relationships take the **least-durable endpoint**: any observed endpoint makes the relationship observed, while managed↔managed topology (AP uplink → switch) still raises.

Tokens match **positionally**, so `promotions-engine` and `sharp-imaging` stay managed. **Default is `managed`** — a false `observed` would *hide* real signal, a false `managed` only leaves a resolvable row.

Also makes `isDockerOriginEntityKey`'s `container:` match positional, closing a leak where `monitoring_service:container:<12hex>` bypassed the prefix-only check.

## Result — the noise finally resolves to one real signal

Live-DB verified after #3418/#3424 applied. The migration resolves **234 of the 254** remaining rows and leaves **20** open. Those 20 are not random — they are:

- the UniFi **gateway**, the **switch**, and all **4 access points**
- the **5 topology links** between them (gateway→switch, switch→each AP)
- the platform host's own NICs / subnet

i.e. **the operator's entire UniFi network stopped reporting.** That is exactly the signal the 2,247 rows of noise were burying, and it is now the only thing left on the queue.

## Verification
- Classifier **17/17** against real source (incl. positional non-match guards).
- Docker guard **7/7** (incl. the new positional `container:` fix and its `container-registry` non-match).
- New unit tests for the `evaluateInventoryQuality` wiring (managed raises, observed suppressed, either-endpoint rule).
- Data-impact manifest + module-size guard verified green locally. Local typecheck skipped (source-only worktree); CI gates.

## Deferred (documented in the spec)
Retention/aging for genuinely-decommissioned managed assets (an operator policy call), cross-collector identity merge (`unifi:<mac>` vs `arp:<MAC>` for one device), and broader suppression of non-stale issue types for observed entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)