### PR TITLE
fix(metering): thread buildId into adapter telemetry so per-phase token/cost metering works (BI-0A6B8B38)

### DIFF
--- a/apps/web/lib/inference/ai-inference.ts
+++ b/apps/web/lib/inference/ai-inference.ts
@@ -443,7 +443,7 @@ export async function callProvider(
   plan?: RoutedExecutionPlan,
   previousResponseId?: string,
   mcpSession?: import("@/lib/routing/adapter-types").AdapterMcpSession,
-  attribution?: { agentId?: string | null; threadId?: string | null; skillId?: string | null; agentMessageId?: string | null },
+  attribution?: { agentId?: string | null; threadId?: string | null; skillId?: string | null; agentMessageId?: string | null; buildId?: string | null },
 ): Promise<InferenceResult> {
   // 0. EP-COST-001 Phase 2 — pre-call budget gate.
   // Check the agent's daily token budget before dispatching. If the agent has
@@ -621,6 +621,7 @@ export async function callProvider(
         : (err instanceof Error ? err.message : undefined),
       agentId: attribution?.agentId ?? undefined,
       threadId: attribution?.threadId ?? undefined,
+      buildId: attribution?.buildId ?? undefined,
       skillId: attribution?.skillId ?? undefined,
       agentMessageId: attribution?.agentMessageId ?? undefined,
     });
@@ -672,6 +673,7 @@ export async function callProvider(
     toolCallsTotal: result.toolCalls.length,
     agentId: attribution?.agentId ?? undefined,
     threadId: attribution?.threadId ?? undefined,
+    buildId: attribution?.buildId ?? undefined,
     skillId: attribution?.skillId ?? undefined,
     agentMessageId: attribution?.agentMessageId ?? undefined,
   });

--- a/apps/web/lib/inference/routed-inference-options.ts
+++ b/apps/web/lib/inference/routed-inference-options.ts
@@ -32,6 +32,9 @@ export interface RouteAndCallOptions {
   agentMinimumContextTokens?: number;
   agentId?: string;
   agentMessageId?: string;
+  /** FeatureBuild this call belongs to. Threaded into AdapterRunTelemetry so
+   *  completeBuildPhaseRun can aggregate per-phase tokens/cost (BI-0A6B8B38). */
+  buildId?: string;
   routingActor?: RouteDecisionActor;
   effort?: "low" | "medium" | "high" | "max";
   previousResponseId?: string;

--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -552,7 +552,7 @@ export async function routeAndCall(
       decision.executionPlan,
       options?.previousResponseId,
       options?.mcpSession,
-      { agentId: options?.agentId ?? null, agentMessageId: options?.agentMessageId ?? null },
+      { agentId: options?.agentId ?? null, agentMessageId: options?.agentMessageId ?? null, buildId: options?.buildId ?? null },
     );
     applyObservedRouterEvidence(decision, result.routingEvidence, routeDecisionLogId);
 
@@ -620,7 +620,7 @@ export async function routeAndCall(
     decision.executionPlan,
     options?.previousResponseId,
     options?.mcpSession,
-    { agentId: options?.agentId ?? null },
+    { agentId: options?.agentId ?? null, buildId: options?.buildId ?? null },
   );
   applyObservedRouterEvidence(decision, result.routingEvidence, routeDecisionLogId);
 

--- a/apps/web/lib/integrate/ideate-dispatch.ts
+++ b/apps/web/lib/integrate/ideate-dispatch.ts
@@ -450,6 +450,9 @@ export async function dispatchIdeateResearch(params: {
    *  "local"/undefined keeps it on the on-box model. */
   modelTier?: "local" | "robust";
   sensitivity?: "public" | "internal" | "confidential" | "restricted";
+  /** FeatureBuild this research belongs to — threaded into AdapterRunTelemetry
+   *  so completeBuildPhaseRun can meter the ideate phase (BI-0A6B8B38). */
+  buildId?: string;
   onProgress?: (message: string) => void;
 }): Promise<IdeateResult> {
   const dispatchEngine = params.dispatchEngine ?? "codex";
@@ -488,6 +491,7 @@ export async function dispatchIdeateResearch(params: {
             budgetClass: "quality_first",
             ...(providerId ? { allowedProviders: [providerId] } : {}),
             ...(params.modelTier ? { modelTier: params.modelTier } : {}),
+            ...(params.buildId ? { buildId: params.buildId } : {}),
           });
           return response.content ?? "";
         },

--- a/apps/web/lib/integrate/ideate-on-approval.ts
+++ b/apps/web/lib/integrate/ideate-on-approval.ts
@@ -197,6 +197,7 @@ export async function dispatchIdeateForApprovedBuild(params: {
         + `(provider=${attempt.providerId}, model=${attempt.modelId || "default"})`,
       );
       ideateResult = await dispatchIdeateResearch({
+        buildId,
         featureTitle,
         featureDescription,
         reusabilityScope: requestedReusabilityScope || "parameterizable",

--- a/apps/web/lib/integrate/plan-on-approval.ts
+++ b/apps/web/lib/integrate/plan-on-approval.ts
@@ -188,6 +188,9 @@ async function generateNormalizedPlan(args: {
   priorReviewIssues?: ReadonlyArray<PlanReviewIssue>;
   /** EP-MODEL-TIER-ROUTING: capability tier for plan generation. */
   modelTier?: "local" | "robust";
+  /** FeatureBuild this generation belongs to — threaded into AdapterRunTelemetry
+   *  so completeBuildPhaseRun can meter the plan phase (BI-0A6B8B38). */
+  buildId?: string;
   log: (summary: string) => Promise<void>;
 }): Promise<{ plan: { fileStructure?: unknown[]; tasks?: unknown[] } } | { error: string }> {
   const { routeAndCall } = await import("@/lib/inference/routed-inference");
@@ -211,7 +214,7 @@ async function generateNormalizedPlan(args: {
       [{ role: "user" as const, content: prompt }],
       systemPrompt,
       "internal",
-      { budgetClass: "quality_first", ...(args.modelTier ? { modelTier: args.modelTier } : {}) },
+      { budgetClass: "quality_first", ...(args.modelTier ? { modelTier: args.modelTier } : {}), ...(args.buildId ? { buildId: args.buildId } : {}) },
     );
     planObj = parsePlanJson(response.content);
     if (!planObj) {
@@ -376,6 +379,7 @@ export async function dispatchPlanForApprovedBuild(params: {
 
     // 3-7. Generate the initial plan (helper handles parse-retry + validate + normalize).
     const gen = await generateNormalizedPlan({
+      buildId,
       title: build.title,
       designDoc: build.designDoc as Record<string, unknown>,
       biTitle,
@@ -410,6 +414,7 @@ export async function dispatchPlanForApprovedBuild(params: {
       round++;
       await log(`Plan review failed — revising (round ${round}/${PLAN_FIX_MAX_ROUNDS}) against ${review.issues.length} blocking issue(s)`);
       const revised = await generateNormalizedPlan({
+        buildId,
         title: build.title,
         designDoc: build.designDoc as Record<string, unknown>,
         biTitle,

--- a/apps/web/lib/routing/adapter-telemetry-writer.test.ts
+++ b/apps/web/lib/routing/adapter-telemetry-writer.test.ts
@@ -174,3 +174,34 @@ describe("writeAdapterTelemetry", () => {
     warn.mockRestore();
   });
 });
+
+// BI-0A6B8B38 — per-phase token/cost metering. completeBuildPhaseRun aggregates
+// AdapterRunTelemetry by buildId; before this every row had buildId NULL, so the
+// aggregate matched nothing and BuildPhaseRun tokens/cost were always 0/null.
+describe("writeAdapterTelemetry — buildId attribution (BI-0A6B8B38)", () => {
+  const base = {
+    adapterKind: "claude-code-cli" as const,
+    adapterVersion: "claude-code/1.2.3",
+    providerId: "anthropic-sub",
+    modelId: "claude-opus-4-7",
+    executionMode: "single" as const,
+    startedAt: new Date("2026-07-17T10:00:00.000Z"),
+    status: "success" as const,
+  };
+
+  it("persists buildId so completeBuildPhaseRun can aggregate the phase", async () => {
+    await writeAdapterTelemetry({ ...base, buildId: "FB-ABCD1234", inputTokens: 120, outputTokens: 45 });
+    expect(writeOverride).toHaveBeenCalledTimes(1);
+    const row = writeOverride.mock.calls[0]![0] as Record<string, unknown>;
+    expect(row.buildId).toBe("FB-ABCD1234");
+    expect(row.inputTokens).toBe(120);
+    expect(row.outputTokens).toBe(45);
+  });
+
+  it("omits buildId when the call is not build-scoped (unchanged behaviour)", async () => {
+    await writeAdapterTelemetry({ ...base });
+    const row = writeOverride.mock.calls[0]![0] as Record<string, unknown>;
+    expect(row.buildId).toBeUndefined();
+  });
+});
+

--- a/apps/web/lib/routing/fallback.ts
+++ b/apps/web/lib/routing/fallback.ts
@@ -36,6 +36,8 @@ type RouteOutcomeAttribution = {
    * adapter rows are written inside each iteration).
    */
   agentMessageId?: string | null;
+  /** FeatureBuild this call belongs to (BI-0A6B8B38 per-phase metering). */
+  buildId?: string | null;
 };
 
 function buildFallbackProviderSettings(
@@ -217,6 +219,7 @@ export async function callWithFallbackChain(
   let authRefreshRetried = false;
   const agentId = outcomeAttribution?.agentId?.trim() || mcpSession?.agentId?.trim() || null;
   const agentMessageId = outcomeAttribution?.agentMessageId?.trim() || null;
+  const buildId = outcomeAttribution?.buildId?.trim() || null;
 
   // Small local fallback models (Docker Model Runner / 7-13B class) reliably
   // handle ~10-15 tools before tool-selection accuracy collapses. When the
@@ -279,7 +282,7 @@ export async function callWithFallbackChain(
         entryPlan,
         i === 0 ? previousResponseId : undefined,
         mcpSession,
-        { agentId, agentMessageId },
+        { agentId, agentMessageId, buildId },
       );
 
       // EP-INF-004: Record successful request for rate tracking

--- a/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
+++ b/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
@@ -180,3 +180,25 @@ when effort size is "small"; a small doc/chore stays light. Monotonic — can on
 raise rigor above the matrix baseline. When the code-graph + EA provider
 (BI-22250BA2) lands it swaps the interim keyword blast radius for the graph-derived
 one behind the same `warrantForBacklogItem` seam; no gate-site changes.
+
+## Token/cost metering (BI-0A6B8B38) — feat/build-token-metering
+
+Root cause found by inspection: `completeBuildPhaseRun` already aggregates
+`AdapterRunTelemetry` by `buildId`, and routed inference already returns
+`tokenUsage` — but **`buildId` was NULL on all 27,043 telemetry rows** (and
+`threadId` too), so the aggregate matched nothing and every `BuildPhaseRun` showed
+`inputTokens=0, outputTokens=0, costUsd=null, inferenceCount=0`. The writer already
+accepted `buildId`; no caller ever passed it.
+
+Fix threads build attribution end-to-end:
+`RouteAndCallOptions.buildId` → `routeAndCall` → `callWithFallbackChain`
+(`RouteOutcomeAttribution.buildId`) → `callProvider` attribution → `ai-inference`
+→ `writeAdapterTelemetry({ buildId })`. Phase call sites now pass it:
+`dispatchIdeateResearch` (ideate) and `generateNormalizedPlan` (plan).
+
+Effect: per-phase tokens/cost/inferenceCount populate, which is what makes the
+warrant's `budget.tokenCeiling` enforceable rather than advisory.
+
+Follow-on: the build phase's coding-agent path (`coding-agent.ts` routeAndCall) has
+no buildId in scope — threading it needs a param through its callers; tracked as
+the remainder of BI-0A6B8B38.


### PR DESCRIPTION
Second piece of "deliver the rest" on EP-7B169558, after the warrant wiring (#3143).

## Root cause (found by inspection, not guesswork)
`completeBuildPhaseRun` **already** aggregates `AdapterRunTelemetry` by `buildId`, and routed inference **already** returns `tokenUsage`. But:

```
AdapterRunTelemetry: 27,043 rows | 21,599 with tokens | 0 with buildId
```

Every row had `buildId` NULL (and `threadId` too), so the aggregate matched nothing → every `BuildPhaseRun` reported `inputTokens=0, outputTokens=0, costUsd=null, inferenceCount=0`. The writer already *accepted* `buildId`; **no caller ever passed it.**

## Fix
Threads build attribution end-to-end:
`RouteAndCallOptions.buildId` → `routeAndCall` → `callWithFallbackChain` (`RouteOutcomeAttribution.buildId`) → `callProvider` attribution → `ai-inference` → `writeAdapterTelemetry({ buildId })`.

Phase call sites now pass it: **ideate** (`dispatchIdeateResearch`) and **plan** (`generateNormalizedPlan`).

## Why it matters
This is what makes the warrant's `budget.tokenCeiling` **enforceable** rather than advisory — the feedback loop for the whole control plane.

## Follow-on (tracked)
The build phase's `coding-agent.ts` `routeAndCall` has no `buildId` in scope; threading it needs a param through its callers — the remainder of BI-0A6B8B38.

## Verification
`tsc --noEmit` clean; `adapter-telemetry-writer` **9/9** including 2 new tests (persists buildId when build-scoped; omits it otherwise, so non-build calls are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)