### PR TITLE
feat(decision): derive warrant BlastRadius from the real ChangeImpactReport (BI-22250BA2)

### DIFF
--- a/apps/web/lib/decision/blast-radius-from-change-impact.test.ts
+++ b/apps/web/lib/decision/blast-radius-from-change-impact.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { blastRadiusFromChangeImpact } from "./blast-radius-from-change-impact";
+import type { ChangeImpactReport } from "@/lib/integrate/change-impact";
+
+function report(overrides: Omit<Partial<ChangeImpactReport>, "blastRadius"> & {
+  blastRadius?: Partial<ChangeImpactReport["blastRadius"]>;
+} = {}): ChangeImpactReport {
+  return {
+    routes: { new: [], modified: [], deleted: [] },
+    schemaChanges: [],
+    impactedRoles: [],
+    blastRadius: {
+      newRoutes: 0,
+      modifiedRoutes: 0,
+      deletedRoutes: 0,
+      schemaChanges: 0,
+      totalFilesChanged: 0,
+      ...(overrides.blastRadius ?? {}),
+    },
+    riskLevel: "low",
+    rollbackComplexity: "simple",
+    summary: "",
+    ...overrides,
+  } as ChangeImpactReport;
+}
+
+describe("blastRadiusFromChangeImpact", () => {
+  it("a trivial diff yields a low, leaf-shaped blast radius", () => {
+    const br = blastRadiusFromChangeImpact(report({ blastRadius: { totalFilesChanged: 2 } }));
+    expect(br).toEqual({ downstreamCount: 2, touchesCoreContract: false, riskLevel: "low" });
+  });
+
+  it("counts impacted roles as downstream reach alongside files", () => {
+    const br = blastRadiusFromChangeImpact(
+      report({
+        blastRadius: { totalFilesChanged: 5 },
+        impactedRoles: [{ role: "operator" }, { role: "customer" }] as ChangeImpactReport["impactedRoles"],
+      }),
+    );
+    expect(br.downstreamCount).toBe(7);
+  });
+
+  it("a schema change is a core-contract touch", () => {
+    const br = blastRadiusFromChangeImpact(report({ blastRadius: { schemaChanges: 1, totalFilesChanged: 3 } }));
+    expect(br.touchesCoreContract).toBe(true);
+  });
+
+  it("a DELETED route is a core-contract touch (breaks existing consumers)", () => {
+    const br = blastRadiusFromChangeImpact(report({ blastRadius: { deletedRoutes: 1, totalFilesChanged: 1 } }));
+    expect(br.touchesCoreContract).toBe(true);
+  });
+
+  it("new/modified routes alone are additive — NOT a core-contract touch", () => {
+    const br = blastRadiusFromChangeImpact(
+      report({ blastRadius: { newRoutes: 3, modifiedRoutes: 2, totalFilesChanged: 5 } }),
+    );
+    expect(br.touchesCoreContract).toBe(false);
+  });
+
+  it("passes riskLevel through unchanged (shared union)", () => {
+    for (const riskLevel of ["low", "medium", "high", "critical"] as const) {
+      expect(blastRadiusFromChangeImpact(report({ riskLevel })).riskLevel).toBe(riskLevel);
+    }
+  });
+});

--- a/apps/web/lib/decision/blast-radius-from-change-impact.ts
+++ b/apps/web/lib/decision/blast-radius-from-change-impact.ts
@@ -1,0 +1,38 @@
+// apps/web/lib/decision/blast-radius-from-change-impact.ts
+//
+// A-POSTERIORI blast radius for the decision-altitude control plane
+// (EP-7B169558 / BI-22250BA2, which is the planned BI-CFEB2B22 P3).
+//
+// The warrant's promote-time blast radius is an INTERIM keyword heuristic
+// (deriveDeliverableSensitivity). Once a build has produced a diff, we have a
+// real, code-derived measure: analyzeChangeImpact() already parses the diff into
+// routes/schema/impacted-roles/riskLevel plus a code-graph coverage summary.
+// This maps that report onto the warrant's BlastRadius so the verify-time signal
+// can CONFIRM or CORRECT the promote-time altitude — one blast-radius core, not
+// two parallel ones.
+//
+// Pure: no DB, no graph traversal here. The caller supplies the report.
+
+import type { ChangeImpactReport } from "@/lib/integrate/change-impact";
+import type { BlastRadius } from "./work-warrant";
+
+/**
+ * Map a ChangeImpactReport onto the warrant's BlastRadius.
+ *
+ * - `downstreamCount` — graded reach: files the diff touches plus the distinct
+ *   platform roles it reaches. (The code-graph summary reports index COVERAGE,
+ *   not a dependents count, so it can't supply a reach number today.)
+ * - `touchesCoreContract` — a schema change or a DELETED route breaks existing
+ *   consumers by definition. New/modified routes are additive and don't qualify
+ *   on their own.
+ * - `riskLevel` — passed through; ChangeImpactReport and the warrant share the
+ *   same low|medium|high|critical union.
+ */
+export function blastRadiusFromChangeImpact(report: ChangeImpactReport): BlastRadius {
+  const b = report.blastRadius;
+  return {
+    downstreamCount: b.totalFilesChanged + report.impactedRoles.length,
+    touchesCoreContract: b.schemaChanges > 0 || b.deletedRoutes > 0,
+    riskLevel: report.riskLevel,
+  };
+}

--- a/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
+++ b/docs/superpowers/plans/2026-07-16-work-warrant-decision-altitude-control-plane.md
@@ -202,3 +202,24 @@ warrant's `budget.tokenCeiling` enforceable rather than advisory.
 Follow-on: the build phase's coding-agent path (`coding-agent.ts` routeAndCall) has
 no buildId in scope — threading it needs a param through its callers; tracked as
 the remainder of BI-0A6B8B38.
+
+## Blast-radius provider, a-posteriori half (BI-22250BA2 / BI-CFEB2B22 P3)
+
+`blastRadiusFromChangeImpact(report)` maps the EXISTING `ChangeImpactReport`
+(`analyzeChangeImpact`, which already parses a diff into routes / schemaChanges /
+impactedRoles / riskLevel + a code-graph coverage summary) onto the warrant's
+`BlastRadius` — so the verify-time signal can CONFIRM or CORRECT the promote-time
+altitude. One blast-radius core, not two.
+
+- `downstreamCount` = files touched + distinct impacted roles. (The code-graph
+  summary reports index COVERAGE, not a dependents count, so it cannot supply a
+  reach number today — a real dependents traversal is the remaining a-priori half.)
+- `touchesCoreContract` = schema change OR a DELETED route (both break existing
+  consumers). New/modified routes are additive and do not qualify alone.
+- `riskLevel` passes through — `ChangeImpactReport` and the warrant share the same
+  low|medium|high|critical union.
+
+Remaining for BI-22250BA2: the A-PRIORI half — predict blast radius at promote from
+the design's declared surfaces via a code-graph dependents traversal + the EA model
+(EaElement/EaFrameworkMapping), replacing the interim keyword heuristic in
+`warrantForBacklogItem`. It lands behind that same seam with no gate-site changes.


### PR DESCRIPTION
Third piece of "deliver the rest" on EP-7B169558, after the warrant wiring (#3143) and token metering (#3438).

## What
The warrant's promote-time blast radius is an **interim keyword heuristic**. But once a build has a diff, `analyzeChangeImpact()` **already** produces a real, code-derived measure — routes, schemaChanges, impactedRoles, riskLevel, plus a code-graph coverage summary.

`blastRadiusFromChangeImpact(report)` maps that onto the warrant's `BlastRadius`, so the **verify-time** signal can confirm or correct the **promote-time** altitude. That's the convergence `changeImpactToSensitivity` already hinted at — **one blast-radius core, not two parallel ones.**

| Field | Derivation |
|---|---|
| `downstreamCount` | files touched + distinct impacted roles |
| `touchesCoreContract` | schema change **or** a DELETED route (both break existing consumers); new/modified routes are additive and don't qualify alone |
| `riskLevel` | passes through — shared `low\|medium\|high\|critical` union |

Pure: no DB, no graph traversal; the caller supplies the report.

## Remaining for BI-22250BA2
The **a-priori half** — predict blast radius at promote from the design's declared surfaces via a code-graph *dependents* traversal + the EA model (`EaElement`/`EaFrameworkMapping`), replacing the keyword heuristic in `warrantForBacklogItem`. (The code-graph summary today reports index *coverage*, not a dependents count, so it can't supply reach yet.) It lands behind that same seam with **no gate-site changes**.

## Verification
`tsc --noEmit` clean; **6/6** tests including "a DELETED route is a core-contract touch" and "new/modified routes alone are NOT".

🤖 Generated with [Claude Code](https://claude.com/claude-code)