### PR TITLE
fix(coworker): grant registry_read so ux-design-critic can reach the WSID decision path

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -6227,6 +6227,7 @@
         "stage-3-gate-blocking",
         "what-the-criterion-may-not-be",
         "what-may-skip-the-ladder",
+        "when-wsid-decisions-carry-dimension-vectors",
         "scope-boundary",
         "see-also"
       ]

--- a/docs/professions/ux-design/wiki/critique-calibration-gate.md
+++ b/docs/professions/ux-design/wiki/critique-calibration-gate.md
@@ -55,6 +55,22 @@ Deterministic measurement does not need this gate, and conflating the two would 
 
 The ladder governs **judgment**, not measurement. A useful test when in doubt: *would two runs on identical input give the same answer?* If yes, ratchet it now. If no, it climbs the stages.
 
+## When WSID decisions carry dimension vectors
+
+WSID craft decisions are weighed through `evaluate_profession_decision`, which grounds a technique call in the profession's recorded corpus rather than in unaided judgment. As that path gains **dimension vectors** — the same machinery that lets kernel principles be scored rather than merely quoted — two things change here, and one must not.
+
+**What improves.** The per-critique call ("is this finding worth raising, and which lens dominates when hierarchy and density disagree?") stops being a prose judgment and becomes a scored one with a recorded contribution ledger. That is a real gain: it makes the *reasoning* auditable, not just the verdict, and it lets disagreement between lenses be resolved by weighting rather than by whoever writes the most confident sentence.
+
+**What also improves.** The stage promotions above become recordable as scored decisions with their evidence attached, instead of a founder's call remembered in a commit message.
+
+**What must not change.** A scorable decision path is not a substitute for the corpus authority contract. Specifically:
+
+- **The critic may not score its own promotion.** Running the promotion decision through the scored path with the critic as the caller is self-certification wearing a ledger. The promotion decision is the founder's, recorded; the machinery makes it auditable, not automatic.
+- **Vectors weigh options; they do not establish thresholds.** The agreement threshold that governs promotion is a founder-set number stated in advance. A scoring system can tell you which option wins given weights — it cannot tell you that 0.7 agreement is good enough, because that is a risk-appetite question, not a trade-off.
+- **Corpus entries still need an attached human verdict.** A vector-scored proposal is still a proposal. Nothing about better decision machinery makes an agent-authored verdict calibration-eligible.
+
+The short version: vectors make this gate's *reasoning* legible and its *promotions* auditable. They do not move where the authority sits.
+
 ## Scope boundary
 
 This gate governs **compositional** critique: is this screen well designed, judged before anyone uses it. It does not govern **behavioural** findings — where real users actually struggled, drawn from usage telemetry. That is a different question with a different evidence base, a different coworker, and its own governance. When a finding is behavioural, hand it over rather than speculating about users that were never observed.

--- a/packages/db/data/agent_registry.json
+++ b/packages/db/data/agent_registry.json
@@ -2375,7 +2375,8 @@
           "code_graph_read",
           "deliberation_create",
           "deliberation_read",
-          "decision_record_create"
+          "decision_record_create",
+          "registry_read"
         ],
         "memory": {
           "type": "session",

--- a/packages/db/src/workforce-seed.ts
+++ b/packages/db/src/workforce-seed.ts
@@ -371,6 +371,13 @@ export const HARDCODED_COWORKER_GRANTS: Record<string, readonly string[]> = {
     "deliberation_create",
     "deliberation_read",
     "decision_record_create",
+    // registry_read is what makes evaluate_profession_decision reachable — the
+    // WSID craft-decision path. Without it this coworker could read its own
+    // profession corpus but never weigh a craft call THROUGH it, which is the
+    // whole point of grounding design critique in WSID rather than in taste.
+    // Load-bearing once WSID decisions carry dimension vectors: that scored
+    // path runs through this tool.
+    "registry_read",
   ],
 };
 


### PR DESCRIPTION
Follow-up to [#3436](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3436), found while checking how AGT-906 composes with the **WSID dimension-vector work landing in a parallel thread**.

## The gap

`evaluate_profession_decision` — the tool that weighs a craft call against the profession's recorded corpus — requires `registry_read`. AGT-906 did not have it.

So the coworker could **read** its own `ux-design` profession corpus but never **decide through** it. That is the entire point of grounding design critique in WSID rather than in taste, and it becomes load-bearing the moment WSID decisions carry dimension vectors, because that scored path runs through this tool.

The conformance gate does not catch this class: LIFE-002 checks that every granted key is honored by some tool. It does not check that every tool the role needs is reachable. Worth knowing about — the same blind spot applies to any coworker.

Added to both grant sources, which must stay byte-identical or the grant-source divergence ratchet fires. Still a read grant; the no-gating-authority contract is unchanged.

## The governance seam, recorded before it becomes a hole

Once WSID decisions carry dimension vectors, two things genuinely improve: the per-critique call ("which lens dominates when hierarchy and density disagree?") becomes scored with an auditable contribution ledger instead of a prose judgment, and the stage promotions become recordable decisions with evidence attached rather than a call remembered in a commit message.

But **scorable is not self-certifying**, and the calibration-gate page now says so explicitly:

- **The critic may not score its own promotion.** Running that decision through the scored path with the critic as caller is self-certification wearing a ledger.
- **Vectors weigh options; they do not set thresholds.** The agreement threshold is a founder risk-appetite call stated in advance — a scoring system can say which option wins given weights, not that 0.7 agreement is good enough.
- **A vector-scored proposal is still a proposal.** Nothing about better decision machinery makes an agent-authored verdict calibration-eligible.

## Verification

- grant-consistency **2/2**, zero divergence (both sources identical)
- seed + seed-skills **20/20**; conformance + agent-grants **139/139** pre-rebase
- module-size OK, doc index fresh (539), Docs Link Integrity **PASS**

Design-Grounding-Decision: extends docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md section 6 L6; substrate inspected in apps/web/lib/mcp/packs/profession-decision-pack.ts and apps/web/lib/tak/ before implementing.
Docs-Impact-Decision: amends one existing WSID profession page under docs/professions/ux-design/wiki/; doc index regenerated.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)