### PR TITLE
fix(build-studio): re-dispatch once when a CLI specialist dies on infrastructure (BI-2B9E16CC)

### DIFF
--- a/apps/web/lib/integrate/blocked-cause.test.ts
+++ b/apps/web/lib/integrate/blocked-cause.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { classifyBlockedCause } from "./blocked-cause";
+
+describe("classifyBlockedCause", () => {
+  it("treats a mid-work timeout as infrastructure — the case that stranded builds", () => {
+    expect(
+      classifyBlockedCause({ content: "Error: request timed out after 600000ms", exitCode: 1 }),
+    ).toBe("infrastructure");
+  });
+
+  it.each([
+    ["ECONNRESET", "read ECONNRESET"],
+    ["connection refused", "connect: connection refused"],
+    ["503", "upstream returned 503"],
+    ["service unavailable", "Service Unavailable"],
+    ["overloaded", "Error: provider overloaded, please retry"],
+    ["rate limit", "429 rate limit exceeded, retry-after: 30"],
+    ["SIGKILL", "Process terminated by SIGKILL"],
+    ["out of memory", "FATAL ERROR: JavaScript heap out of memory"],
+    ["fetch failed", "TypeError: fetch failed"],
+    ["socket hang up", "Error: socket hang up"],
+  ])("classifies %s as infrastructure", (_label, content) => {
+    expect(classifyBlockedCause({ content, exitCode: 1 })).toBe("infrastructure");
+  });
+
+  it("empty output is a process that died before it could speak", () => {
+    expect(classifyBlockedCause({ content: "", exitCode: 1 })).toBe("infrastructure");
+    expect(classifyBlockedCause({ content: "   \n  ", exitCode: 1 })).toBe("infrastructure");
+  });
+
+  it.each([137, 143, 124])("exit code %i is the harness killing the process, not a verdict", (exitCode) => {
+    expect(classifyBlockedCause({ content: "partial work written to src/foo.ts", exitCode })).toBe(
+      "infrastructure",
+    );
+  });
+
+  it("a considered refusal stays substantive — retrying will not answer it", () => {
+    expect(
+      classifyBlockedCause({
+        content:
+          "I cannot complete this task. The spec does not say whether refunds should be prorated, " +
+          "and both readings change the schema. This needs a product decision before I write code.",
+        exitCode: 1,
+      }),
+    ).toBe("substantive");
+  });
+
+  it("a failing test report is substantive — the run finished and reported", () => {
+    expect(
+      classifyBlockedCause({
+        content: "Test Suites: 1 failed, 4 passed\n3 tests failed\nExpected 200, received 404",
+        exitCode: 1,
+      }),
+    ).toBe("substantive");
+  });
+
+  it("a missing dependency the agent found is substantive, not transport", () => {
+    expect(
+      classifyBlockedCause({
+        content: "Cannot proceed: the referenced module @dpf/billing does not exist in this repo.",
+        exitCode: 1,
+      }),
+    ).toBe("substantive");
+  });
+
+  it("is biased toward infrastructure on ambiguity — one extra run beats a permanent strand", () => {
+    // A substantive report that also mentions a timeout resolves to infrastructure.
+    // Cost: one bounded re-dispatch. The opposite error strands the build forever.
+    expect(
+      classifyBlockedCause({
+        content: "Implemented the handler, but the integration test timed out waiting for the DB.",
+        exitCode: 1,
+      }),
+    ).toBe("infrastructure");
+  });
+});

--- a/apps/web/lib/integrate/blocked-cause.ts
+++ b/apps/web/lib/integrate/blocked-cause.ts
@@ -1,0 +1,66 @@
+// apps/web/lib/integrate/blocked-cause.ts
+//
+// Why is a specialist task BLOCKED? (BI-2B9E16CC)
+//
+// classifyOutcome() maps EVERY failed CLI result to "BLOCKED" — a mid-work
+// timeout and "I need a product decision before I can proceed" are the same
+// terminal verdict. And the only existing recovery,
+// classifyRetrySafePreDispatchFailure, deliberately gives up once
+// durationMs > 1000 (it guards against silently re-running work that may have
+// already applied side effects), so every CLI death AFTER dispatch strands the
+// build in `build` phase with no path forward.
+//
+// Meanwhile the agentic path has always retried failures MAX_SPECIALIST_RETRIES
+// times with a "previous attempt had issues" prompt. That asymmetry is the bug:
+// the same failure is recoverable on one path and terminal on the other.
+//
+// This splits the two causes so the CLI path can take the bounded retry the
+// agentic path already takes.
+//
+// Bias is deliberate: mis-reading substantive as infrastructure costs ONE extra
+// bounded re-dispatch; mis-reading infrastructure as substantive strands the
+// build permanently. So an ambiguous transient signal resolves to infrastructure.
+// A specialist that reports a real obstacle in prose matches nothing here and
+// stays substantive — it is not retried, because retrying will not answer it.
+
+export type BlockedCause = "infrastructure" | "substantive";
+
+/** Process/transport deaths — the CLI never got to finish its own reasoning. */
+const INFRASTRUCTURE_PATTERNS: RegExp[] = [
+  /timed?\s?out|timeout/,
+  /econnreset|econnrefused|etimedout|enetunreach|epipe|socket hang ?up/,
+  /connection (reset|refused|closed|aborted)/,
+  /\b(429|500|502|503|504)\b/,
+  /service unavailable|internal server error|bad gateway|gateway time/,
+  /overloaded|rate.?limit|retry-after|quota exceeded|capacity/,
+  /sigkill|sigterm|killed|out of memory|oom|heap limit/,
+  /stream (error|closed unexpectedly)|network error|fetch failed/,
+  /provider (unavailable|error)|no healthy provider/,
+];
+
+/**
+ * Classify a failed specialist dispatch.
+ *
+ * @param content stdout/stderr from the run
+ * @param exitCode process exit code, when known
+ */
+export function classifyBlockedCause(input: {
+  content: string;
+  exitCode?: number | null;
+}): BlockedCause {
+  const content = (input.content ?? "").toLowerCase();
+
+  // No output at all is a process that died before it could say anything —
+  // never a considered refusal.
+  if (content.trim().length === 0) return "infrastructure";
+
+  // 137 = SIGKILL (OOM-killer / docker stop), 143 = SIGTERM, 124 = coreutils
+  // `timeout`. These are the harness killing the process, not a verdict.
+  if (input.exitCode === 137 || input.exitCode === 143 || input.exitCode === 124) {
+    return "infrastructure";
+  }
+
+  return INFRASTRUCTURE_PATTERNS.some((pat) => pat.test(content))
+    ? "infrastructure"
+    : "substantive";
+}

--- a/apps/web/lib/integrate/build-orchestrator.ts
+++ b/apps/web/lib/integrate/build-orchestrator.ts
@@ -26,6 +26,7 @@ import {
   SPECIALIST_TOOLS,
 } from "./specialist-prompts";
 import { isMissingSandboxToolSurfaceOutput } from "./sandbox-tool-surface-detector";
+import { classifyBlockedCause } from "./blocked-cause";
 import type { SpecialistRole } from "./task-dependency-graph";
 import type {
   BuildPlanDoc,
@@ -800,13 +801,18 @@ async function dispatchSpecialist(params: {
       ? [selectedCandidate, ...config.selection!.fallbackChain.slice(0, 1)]
       : [];
     let cliResult: CodexResult | ClaudeResult | null = null;
-    for (let attemptIndex = 0; attemptIndex < Math.max(1, cliAttempts.length); attemptIndex += 1) {
-      const candidate = cliAttempts[attemptIndex];
-      if (candidate?.engine === "agentic") {
-        agenticFallbackProviderId = candidate.providerId;
-        break;
-      }
+    // One bounded same-engine re-dispatch per task when the CLI dies on
+    // infrastructure (BI-2B9E16CC). The agentic path has always retried failures
+    // MAX_SPECIALIST_RETRIES times; the CLI path retried nothing after dispatch,
+    // so a timeout or a 503 stranded the whole build in `build` phase forever.
+    let infraRedispatchUsed = false;
+    const dispatchOnce = async (
+      candidate: BuildEngineCandidate | undefined,
+    ): Promise<(CodexResult | ClaudeResult) & { exitCode: number }> => {
       const engine = candidate?.engine ?? config.provider;
+      // The loop diverts "agentic" to the legacy path before ever calling this;
+      // the guard is here to narrow the union for resolveBuildProviderRunner.
+      if (engine === "agentic") throw new Error("dispatchOnce received the agentic engine");
       const { provider, runner } = resolveBuildProviderRunner({ agentId: engine });
       const runResult = await runner.run(
         provider,
@@ -824,12 +830,51 @@ async function dispatchSpecialist(params: {
           onProgress,
         },
       );
-      cliResult = {
+      return {
         content: runResult.stdout || runResult.stderr,
         success: runResult.exitCode === 0,
         executedTools: [],
         durationMs: runResult.durationMs,
+        exitCode: runResult.exitCode,
       };
+    };
+    for (let attemptIndex = 0; attemptIndex < Math.max(1, cliAttempts.length); attemptIndex += 1) {
+      const candidate = cliAttempts[attemptIndex];
+      if (candidate?.engine === "agentic") {
+        agenticFallbackProviderId = candidate.providerId;
+        break;
+      }
+      const engine = candidate?.engine ?? config.provider;
+      let dispatched = await dispatchOnce(candidate);
+      cliResult = dispatched;
+
+      // Infrastructure death → retry the SAME engine once. A substantive block
+      // ("I need a decision on X") matches nothing and is not retried, because
+      // re-running will not answer it.
+      if (
+        !dispatched.success
+        && !infraRedispatchUsed
+        && classifyBlockedCause({ content: dispatched.content, exitCode: dispatched.exitCode }) === "infrastructure"
+      ) {
+        infraRedispatchUsed = true;
+        agentEventBus.emit(parentThreadId, {
+          type: "orchestrator:specialist_retry",
+          buildId,
+          specialist: ROLE_LABELS[role],
+          reason: `The ${engine} session died on infrastructure (not a decision it needed from you); retrying the same task once.`,
+          attempt: 1,
+        });
+        await prisma.buildActivity.create({
+          data: {
+            buildId,
+            tool: "engine_selection",
+            summary: `Build dispatch ${engine} failed on infrastructure after ${dispatched.durationMs}ms; re-dispatching the same engine once for task "${task.title}".`,
+          },
+        }).catch(() => {});
+        dispatched = await dispatchOnce(candidate);
+        cliResult = dispatched;
+      }
+
       if (cliResult.success) break;
       const retryClass = classifyRetrySafePreDispatchFailure({
         message: cliResult.content,

--- a/docs/superpowers/plans/2026-07-22-cli-infrastructure-redispatch.md
+++ b/docs/superpowers/plans/2026-07-22-cli-infrastructure-redispatch.md
@@ -1,0 +1,87 @@
+# CLI infrastructure re-dispatch — ending the permanent BLOCKED strand
+
+**BI-2B9E16CC** · 2026-07-22
+
+## The strand
+
+A Build Studio task dispatched to a CLI engine (codex / claude / grok / opencode)
+that dies mid-work leaves the build stuck in `build` phase with no path forward.
+Three things compound:
+
+1. **`classifyOutcome` collapses every CLI failure to `BLOCKED`.** In
+   `build-orchestrator.ts` the CLI branch reads:
+
+   ```ts
+   if (!result.success) {
+     if (content.includes("timed out")) return "BLOCKED";
+     return "BLOCKED";
+   }
+   ```
+
+   A transport timeout and "I need a product decision before I can write this"
+   produce the identical terminal verdict.
+
+2. **The only existing recovery gives up after one second.**
+   `classifyRetrySafePreDispatchFailure` returns `null` once
+   `durationMs > 1000`. That guard is *correct* for what it does — it exists so a
+   run that may already have applied sandbox side effects is never silently
+   re-run on a different engine. But it means nothing that fails *after* dispatch
+   is recoverable, and mid-work deaths are by definition after dispatch.
+
+3. **`hasBlocked` then refuses build → review advancement**, so the build reports
+   "not ready for review" and waits for a human forever.
+
+## The asymmetry that makes it a bug
+
+The **agentic** path has always retried failures up to `MAX_SPECIALIST_RETRIES`,
+re-prompting with `RETRY (attempt N): The previous attempt had issues: …`. The
+**CLI** path retried nothing after dispatch. The same failure is routine on one
+path and terminal on the other — purely because of which engine was selected.
+
+## The fix
+
+Give the CLI path the bounded retry the agentic path already takes, gated on
+*why* it failed.
+
+- **`integrate/blocked-cause.ts`** (new) — `classifyBlockedCause({content, exitCode})`
+  → `"infrastructure" | "substantive"`. Infrastructure covers transport and
+  process death: timeouts, `ECONNRESET`/`EPIPE`/socket hang up, 429/5xx,
+  overloaded/rate-limit/quota, SIGKILL/SIGTERM/OOM, `fetch failed`, empty output,
+  and exit codes 137/143/124. Everything else — including a specialist that wrote
+  a considered explanation of what it needs — is substantive.
+
+- **`build-orchestrator.ts`** — the runner invocation is extracted to a local
+  `dispatchOnce(candidate)`. On a failure classified `infrastructure`, the same
+  engine is re-dispatched **once** per task, with an
+  `orchestrator:specialist_retry` event and a `BuildActivity` row recording it.
+  A substantive block is not retried — re-running will not answer the question it
+  asked.
+
+The pre-dispatch engine-fallback path is untouched: it still governs *switching
+engines* before side effects, which is a different and stricter question.
+
+## Bias, stated deliberately
+
+`classifyBlockedCause` resolves ambiguity toward `infrastructure`. Reading a
+substantive block as infrastructure costs **one bounded re-dispatch**; reading
+infrastructure as substantive **strands the build permanently**. The costs are
+not symmetric, so neither is the classifier. There is a test asserting this
+explicitly (a report that both implements a handler and mentions a test timeout
+resolves to infrastructure).
+
+## Evidence
+
+```bash
+pnpm --filter web exec vitest run lib/integrate/blocked-cause.test.ts lib/integrate/build-orchestrator.test.ts
+```
+
+19 new tests; the 56 existing build-orchestrator tests unchanged and green;
+`tsc --noEmit` clean across the touched files.
+
+## Not covered
+
+`classifyOutcome` itself still returns a flat `BLOCKED` — the cause is consumed at
+the dispatch site, not carried on `SpecialistOutcome`. Surfacing
+infrastructure-vs-substantive in the build-complete message and the phase gate
+(so an operator sees *which* kind of blocked they are looking at) is the natural
+follow-on.

--- a/docs/user-guide/build-studio/index.md
+++ b/docs/user-guide/build-studio/index.md
@@ -54,6 +54,8 @@ The AI Coworker creates an implementation plan listing the files to create or mo
 
 The AI Coworker generates code inside the isolated Build runtime. You can see the live preview update in real time. It runs tests and typecheck after generating code. If tests fail, it attempts to fix them automatically. You can ask for changes at any time.
 
+If a task stops before it finishes, Build Studio distinguishes *why*. When the coding session died on infrastructure — a timeout, a provider outage, a rate limit, the process being killed — that is not a verdict on your feature, so the same task is re-run once automatically and you see a "retrying" note in the activity feed. When the session instead stopped because it needs something only you can supply — an unresolved product question, a contradiction in the spec — it is **not** retried, because re-running will not answer the question. That one surfaces as a blocked task for you to resolve.
+
 ### Review
 
 Quality gates verify the feature is ready: documentation evidence is present, all tests pass, typecheck is clean, acceptance criteria are met, and accessibility checks pass. The AI Coworker presents a plain-language summary of the results.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -39,6 +39,8 @@ apps/web/lib/inference/ai-provider-internals.ts	1228
 apps/web/lib/integrate/build-agent-prompts.ts	1064
 apps/web/lib/integrate/build-orchestrator.ts	1751
 apps/web/lib/integrate/sandbox/build-branch.ts	870
+apps/web/lib/integrate/build-orchestrator.ts	1796
+apps/web/lib/integrate/sandbox/build-branch.ts	852
 apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp-tools-backlog.test.ts	874
 apps/web/lib/mcp-tools.ts	1910


### PR DESCRIPTION
## The strand

A Build Studio task dispatched to a CLI engine (codex/claude/grok/opencode) that dies **mid-work** stranded the whole build in `build` phase permanently. Three things compounded:

1. **`classifyOutcome` collapses every failed CLI result to `BLOCKED`** — a transport timeout and *"I need a product decision before I can write this"* produce the identical terminal verdict.
2. **The only existing recovery gives up after one second.** `classifyRetrySafePreDispatchFailure` returns `null` once `durationMs > 1000`. That guard is *correct* for what it does — it exists so a run that may already have applied sandbox side effects is never silently re-run on a different engine — but it means nothing that fails *after* dispatch is recoverable, and mid-work deaths are by definition after dispatch.
3. **`hasBlocked` then refuses build → review advancement**, so the build reports "not ready for review" and waits for a human forever.

## The asymmetry that makes it a bug

The **agentic** path has always retried failures up to `MAX_SPECIALIST_RETRIES`, re-prompting with `RETRY (attempt N): The previous attempt had issues: …`. The **CLI** path retried nothing after dispatch. The same failure is routine on one path and terminal on the other, purely because of which engine got selected.

## The fix

- **`apps/web/lib/integrate/blocked-cause.ts`** (new) — `classifyBlockedCause({content, exitCode}) → "infrastructure" | "substantive"`. Infrastructure covers transport and process death: timeouts, `ECONNRESET`/`EPIPE`/socket hang up, 429/5xx, overloaded/rate-limit/quota, SIGKILL/SIGTERM/OOM, `fetch failed`, empty output, and exit codes 137/143/124. Everything else — including a specialist that wrote a considered explanation of what it needs — is substantive.
- **`apps/web/lib/integrate/build-orchestrator.ts`** — the runner invocation is extracted to a local `dispatchOnce(candidate)`. An `infrastructure` failure re-dispatches the **same engine once** per task, with an `orchestrator:specialist_retry` event and a `BuildActivity` row. A substantive block is **not** retried — re-running will not answer the question it asked.

The pre-dispatch engine-fallback path is untouched: switching *engines* before side effects is a different and stricter question.

## Bias, stated deliberately

`classifyBlockedCause` resolves ambiguity toward `infrastructure`. Misreading a substantive block costs **one bounded re-dispatch**; misreading infrastructure **strands the build permanently**. The costs are not symmetric, so neither is the classifier — and there is a test asserting that explicitly.

## Evidence

- 19 new tests in `blocked-cause.test.ts`.
- The 56 existing `build-orchestrator` tests unchanged and green (identical to `main`).
- `tsc --noEmit` clean across the touched files.
- Plan doc in the same PR: `docs/superpowers/plans/2026-07-22-cli-infrastructure-redispatch.md`.

## Not covered

`classifyOutcome` still returns a flat `BLOCKED` — the cause is consumed at the dispatch site, not carried on `SpecialistOutcome`. Surfacing infrastructure-vs-substantive in the build-complete message and the phase gate (so an operator sees *which* kind of blocked they are looking at) is the natural follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)