### PR TITLE
fix(mcp): stop the governed read tools returning silently wrong answers (BI-EC9471C7)

### DIFF
--- a/apps/web/lib/mcp/packs/admin-pack.test.ts
+++ b/apps/web/lib/mcp/packs/admin-pack.test.ts
@@ -123,6 +123,37 @@ describe("admin pack — handler behavior (delegation preserved)", () => {
     expect(db.queryRawUnsafe).not.toHaveBeenCalled();
   });
 
+  // REGRESSION: the row cap was applied as `sql + " LIMIT 1000"`, so any query
+  // that supplied its own LIMIT produced `... LIMIT 30 LIMIT 1000` — a
+  // Postgres syntax error rather than a capped result.
+  it("admin_query_db respects a caller-supplied LIMIT instead of appending a second one", async () => {
+    db.queryRawUnsafe.mockResolvedValue([]);
+    await adminPack.handlers.admin_query_db({ sql: 'SELECT * FROM "Epic" LIMIT 30' }, "u1");
+    expect(db.queryRawUnsafe).toHaveBeenCalledWith('SELECT * FROM "Epic" LIMIT 30');
+  });
+
+  it("admin_query_db strips a trailing semicolon before appending the row cap", async () => {
+    db.queryRawUnsafe.mockResolvedValue([]);
+    await adminPack.handlers.admin_query_db({ sql: 'SELECT * FROM "Epic";' }, "u1");
+    expect(db.queryRawUnsafe).toHaveBeenCalledWith('SELECT * FROM "Epic" LIMIT 1000');
+  });
+
+  // REGRESSION: Postgres returns COUNT() as BigInt and JSON.stringify throws on
+  // it, so every aggregate query failed with "Do not know how to serialize a
+  // BigInt" before it could be returned or audit-logged.
+  it("admin_query_db serializes BigInt aggregate results instead of throwing", async () => {
+    db.queryRawUnsafe.mockResolvedValue([{ epics: BigInt(137), items: BigInt(1799) }]);
+    const res = await adminPack.handlers.admin_query_db({ sql: 'SELECT COUNT(*) AS epics FROM "Epic"' }, "u1");
+    expect(res.success).toBe(true);
+    expect((res.data as { rows: unknown[] }).rows).toEqual([{ epics: 137, items: 1799 }]);
+  });
+
+  it("admin_query_db keeps BigInt values beyond Number.MAX_SAFE_INTEGER as strings", async () => {
+    db.queryRawUnsafe.mockResolvedValue([{ big: BigInt("9007199254740993") }]);
+    const res = await adminPack.handlers.admin_query_db({ sql: "SELECT 1" }, "u1");
+    expect((res.data as { rows: unknown[] }).rows).toEqual([{ big: "9007199254740993" }]);
+  });
+
   it("admin_run_command blocks a command outside the allowlist", async () => {
     const res = await adminPack.handlers.admin_run_command({ command: "rm -rf /" }, "u1");
     expect(res.success).toBe(false);

--- a/apps/web/lib/mcp/packs/admin-pack.ts
+++ b/apps/web/lib/mcp/packs/admin-pack.ts
@@ -42,7 +42,7 @@ const definitions: ToolDefinition[] = [
   },
   {
     name: "admin_query_db",
-    description: "Run a read-only SQL query against the portal database. Only SELECT statements are permitted. Max 1000 rows.",
+    description: "Run a read-only SQL query against the portal database. Only SELECT statements are permitted. Capped at 1000 rows; a LIMIT you supply yourself is respected. Aggregates (COUNT/SUM) are supported — BigInt results are returned as numbers.",
     inputSchema: {
       type: "object",
       properties: {
@@ -150,6 +150,35 @@ async function adminViewLogs(params: Record<string, unknown>, userId: string): P
   }
 }
 
+const ADMIN_QUERY_ROW_CAP = 1000;
+
+// The row cap used to be applied as `sql + " LIMIT 1000"`, which is a syntax
+// error for any query that already ends in its own LIMIT or a trailing
+// semicolon. Strip the terminator, and only append the cap when the caller
+// has not already bounded the result themselves.
+function applyRowCap(sql: string): string {
+  const stripped = sql.replace(/;\s*$/, "").trim();
+  return /\blimit\s+\d+\s*$/i.test(stripped) ? stripped : `${stripped} LIMIT ${ADMIN_QUERY_ROW_CAP}`;
+}
+
+// Postgres returns COUNT()/SUM() as BigInt and Prisma hands it straight
+// through; JSON.stringify throws on BigInt, so an unsanitized aggregate query
+// fails before it can be returned or audit-logged. Numbers beyond the safe
+// integer range degrade to a string rather than losing precision silently.
+function toJsonSafe(value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return value <= BigInt(Number.MAX_SAFE_INTEGER) && value >= BigInt(Number.MIN_SAFE_INTEGER)
+      ? Number(value)
+      : value.toString();
+  }
+  if (Array.isArray(value)) return value.map(toJsonSafe);
+  if (value instanceof Date) return value;
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, toJsonSafe(v)]));
+  }
+  return value;
+}
+
 async function adminQueryDb(params: Record<string, unknown>, userId: string): Promise<ToolResult> {
   const sql = String(params.sql ?? "").trim();
   if (!sql) return { success: false, error: "sql is required.", message: "Provide a SQL query." };
@@ -173,10 +202,14 @@ async function adminQueryDb(params: Record<string, unknown>, userId: string): Pr
     return { success: false, error: "Query contains forbidden keywords (INSERT, UPDATE, DELETE, DROP, etc).", message: "This tool is read-only." };
   }
   try {
-    const result = await prisma.$queryRawUnsafe(sql + " LIMIT 1000") as unknown[];
-    const preview = JSON.stringify(result).slice(0, 500);
-    await logAdminActivity(userId, "admin_query_db", { sql }, "success", 1, `${result.length} rows. ${preview}`);
-    return { success: true, message: `Query returned ${result.length} row(s).`, data: { sql, rows: result, rowCount: result.length } };
+    const result = await prisma.$queryRawUnsafe(applyRowCap(normalized)) as unknown[];
+    // Postgres COUNT()/SUM() come back as BigInt, which JSON.stringify throws
+    // on. Sanitize before both the preview and the returned payload, or every
+    // aggregate query fails with "Do not know how to serialize a BigInt".
+    const rows = toJsonSafe(result) as unknown[];
+    const preview = JSON.stringify(rows).slice(0, 500);
+    await logAdminActivity(userId, "admin_query_db", { sql }, "success", 1, `${rows.length} rows. ${preview}`);
+    return { success: true, message: `Query returned ${rows.length} row(s).`, data: { sql, rows, rowCount: rows.length } };
   } catch (err) {
     const msg = (err as Error).message?.slice(0, 500) ?? "Query failed";
     await logAdminActivity(userId, "admin_query_db", { sql }, "error", 1, msg);

--- a/apps/web/lib/mcp/packs/backlog-pack.test.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.test.ts
@@ -8,6 +8,7 @@ const db = vi.hoisted(() => ({
   backlogItemCount: vi.fn(),
   epicFindMany: vi.fn(),
   epicFindFirst: vi.fn(),
+  epicCount: vi.fn(),
   platformDevConfigFindUnique: vi.fn(),
   transaction: vi.fn(),
 }));
@@ -23,6 +24,7 @@ vi.mock("@dpf/db", () => ({
     epic: {
       findMany: (...a: unknown[]) => db.epicFindMany(...a),
       findFirst: (...a: unknown[]) => db.epicFindFirst(...a),
+      count: (...a: unknown[]) => db.epicCount(...a),
     },
     platformDevConfig: {
       findUnique: (...a: unknown[]) => db.platformDevConfigFindUnique(...a),
@@ -168,10 +170,66 @@ describe("backlog pack — handler behavior (delegation preserved)", () => {
     db.backlogItemFindMany.mockResolvedValue([]);
     db.epicFindMany.mockResolvedValue([]);
     db.backlogItemCount.mockResolvedValue(0);
+    db.epicCount.mockResolvedValue(0);
     const res = await backlogPack.handlers.query_backlog({}, "u1");
     expect(res.success).toBe(true);
     expect(res.message).toContain("Backlog:");
     expect(res.data).toMatchObject({ summary: { open: 0, inProgress: 0, done: 0 } });
+  });
+
+  // REGRESSION: `BacklogItem.epicId` is the internal cuid FK, so passing the
+  // semantic "EP-*" id straight into the where-clause matched nothing and
+  // returned an empty item list under success:true — a silent wrong answer
+  // that reads as "this epic has no items".
+  it("query_backlog resolves a semantic epic id to the row id before filtering", async () => {
+    db.epicFindFirst.mockResolvedValue({ id: "ckepicrow1" });
+    db.backlogItemFindMany.mockResolvedValue([]);
+    db.epicFindMany.mockResolvedValue([]);
+    db.backlogItemCount.mockResolvedValue(0);
+    db.epicCount.mockResolvedValue(0);
+
+    const res = await backlogPack.handlers.query_backlog({ epicId: "EP-0AF96937" }, "u1");
+
+    expect(res.success).toBe(true);
+    expect(db.backlogItemFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { epicId: "ckepicrow1" } }),
+    );
+  });
+
+  it("query_backlog reports epic_not_found instead of an empty list for an unknown epic", async () => {
+    db.epicFindFirst.mockResolvedValue(null);
+    const res = await backlogPack.handlers.query_backlog({ epicId: "EP-NOPE" }, "u1");
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("epic_not_found");
+    expect(db.backlogItemFindMany).not.toHaveBeenCalled();
+  });
+
+  // REGRESSION: a silently-truncated list is indistinguishable from a complete
+  // one, which is how a present-but-older epic got reported as non-existent.
+  it("list_epics reports the true total and flags truncation", async () => {
+    db.epicCount.mockResolvedValue(137);
+    db.epicFindMany.mockResolvedValue([
+      { id: "e1", epicId: "EP-1", title: "One", status: "open", priority: 1, updatedAt: new Date(), items: [] },
+    ]);
+    const res = await backlogPack.handlers.list_epics({ limit: 1 }, "u1");
+    expect(res.success).toBe(true);
+    expect(res.data).toMatchObject({ total: 137, fetched: 1, truncated: true });
+  });
+
+  it("list_epics accepts a limit above the old 100 cap", async () => {
+    db.epicCount.mockResolvedValue(0);
+    db.epicFindMany.mockResolvedValue([]);
+    await backlogPack.handlers.list_epics({ limit: 1000 }, "u1");
+    expect(db.epicFindMany).toHaveBeenCalledWith(expect.objectContaining({ take: 1000 }));
+  });
+
+  it("list_backlog_items reports the true total and flags truncation", async () => {
+    db.backlogItemCount.mockResolvedValue(678);
+    db.backlogItemFindMany.mockResolvedValue([]);
+    const res = await backlogPack.handlers.list_backlog_items({ limit: 500 }, "u1");
+    expect(res.success).toBe(true);
+    expect(res.data).toMatchObject({ total: 678, truncated: true });
+    expect(db.backlogItemFindMany).toHaveBeenCalledWith(expect.objectContaining({ take: 500 }));
   });
 
   it("process_backlog_for_build_studio refuses when governed mode is disabled", async () => {

--- a/apps/web/lib/mcp/packs/backlog-pack.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.ts
@@ -19,6 +19,7 @@
 import { getErrorMessage } from "@/lib/shared/get-error-message";
 import { handleUpdateBacklogItem } from "@/lib/mcp-handlers/update-backlog-item";
 import { updateBuildHappyPathState } from "@/lib/mcp/build-tool-helpers";
+import { resolveEpicRowId, resolveListLimit } from "./backlog-read-helpers";
 import {
   BACKLOG_SOURCE_VALUES,
   BACKLOG_STATUS_VALUES,
@@ -589,35 +590,6 @@ async function processBacklogForBuildStudio(
   };
 }
 
-// Read caps. These exist to bound a single response, not to hide rows: every
-// capped list reports `total` and `truncated` so a caller can tell the
-// difference between "that is all of them" and "you only got the first page".
-// Silent truncation at 100 previously made a present-but-older epic look
-// absent, which is worse than a large response.
-const BACKLOG_LIST_LIMIT_MAX = 1000;
-const BACKLOG_LIST_LIMIT_DEFAULT = 100;
-
-function resolveListLimit(raw: unknown): number {
-  return typeof raw === "number" && Number.isFinite(raw)
-    ? Math.min(Math.max(1, Math.floor(raw)), BACKLOG_LIST_LIMIT_MAX)
-    : BACKLOG_LIST_LIMIT_DEFAULT;
-}
-
-// `BacklogItem.epicId` is the internal cuid FK, NOT the semantic `EP-*` id.
-// Filtering it by the semantic id matches nothing and returns an empty list
-// with no error, so callers must resolve the row first. Returns undefined when
-// no epic id was supplied, or null when one was supplied but matched nothing.
-type DbPrisma = (typeof import("@dpf/db"))["prisma"];
-
-async function resolveEpicRowId(prisma: DbPrisma, raw: unknown): Promise<string | null | undefined> {
-  if (typeof raw !== "string" || !raw.trim()) return undefined;
-  const epicRow = await prisma.epic.findFirst({
-    where: { OR: [{ epicId: raw.trim() }, { id: raw.trim() }] },
-    select: { id: true },
-  });
-  return epicRow ? epicRow.id : null;
-}
-
 async function queryBacklog(params: Record<string, unknown>): Promise<ToolResult> {
   const { prisma } = await import("@dpf/db");
   const where: Record<string, unknown> = {};
@@ -629,7 +601,7 @@ async function queryBacklog(params: Record<string, unknown>): Promise<ToolResult
   if (epicRowId !== undefined) where["epicId"] = epicRowId;
   const limit = resolveListLimit(params["limit"]);
 
-  const [items, matching, epics, epicTotal, totalOpen, totalInProgress, totalDone] = await Promise.all([
+  const [items, matching, epics, epicTotal, open, inProgress, done] = await Promise.all([
     prisma.backlogItem.findMany({
       where,
       orderBy: [{ priority: "asc" }, { updatedAt: "desc" }],
@@ -637,23 +609,18 @@ async function queryBacklog(params: Record<string, unknown>): Promise<ToolResult
       select: { itemId: true, title: true, status: true, type: true, priority: true, updatedAt: true, epic: { select: { epicId: true } } },
     }),
     prisma.backlogItem.count({ where }),
-    prisma.epic.findMany({
-      select: { id: true, epicId: true, title: true, status: true },
-      orderBy: { createdAt: "desc" },
-      take: limit,
-    }),
+    prisma.epic.findMany({ select: { id: true, epicId: true, title: true, status: true }, orderBy: { createdAt: "desc" }, take: limit }),
     prisma.epic.count(),
     prisma.backlogItem.count({ where: { status: "open" } }),
     prisma.backlogItem.count({ where: { status: "in-progress" } }),
     prisma.backlogItem.count({ where: { status: "done" } }),
   ]);
 
-  const summary = `Backlog: ${totalOpen} open, ${totalInProgress} in-progress, ${totalDone} done. Showing ${items.length} of ${matching} matching item(s), ${epics.length} of ${epicTotal} epic(s).`;
   return {
     success: true,
-    message: summary,
+    message: `Backlog: ${open} open, ${inProgress} in-progress, ${done} done. Showing ${items.length} of ${matching} matching item(s), ${epics.length} of ${epicTotal} epic(s).`,
     data: {
-      summary: { open: totalOpen, inProgress: totalInProgress, done: totalDone },
+      summary: { open, inProgress, done },
       total: matching,
       truncated: items.length < matching,
       epicTotal,
@@ -724,9 +691,8 @@ async function listEpics(params: Record<string, unknown>): Promise<ToolResult> {
       void _hasOpen;
       return rest;
     });
-  // `truncated` reflects the DB-side cap only. The hasOpenItems filter runs in
-  // memory over the fetched page, so data.length can be below epics.length
-  // without anything having been cut off by the limit.
+  // `truncated` reflects the DB-side cap only — hasOpenItems filters the
+  // fetched page in memory, so data.length < epics.length is not truncation.
   return {
     success: true,
     message: `Listed ${data.length} epic(s) (${epics.length} of ${epicTotal} fetched).`,
@@ -743,11 +709,7 @@ async function listBacklogItems(params: Record<string, unknown>): Promise<ToolRe
   if (typeof params["source"] === "string") where["source"] = params["source"];
   const epicRowId = await resolveEpicRowId(prisma, params["epicId"]);
   if (epicRowId === null) {
-    return {
-      success: false,
-      error: "epic_not_found",
-      message: `No epic matched ${String(params["epicId"])}`,
-    };
+    return { success: false, error: "epic_not_found", message: `No epic matched ${String(params["epicId"])}` };
   }
   if (epicRowId !== undefined) where["epicId"] = epicRowId;
   if (params["unclaimed"] === true) {

--- a/apps/web/lib/mcp/packs/backlog-pack.ts
+++ b/apps/web/lib/mcp/packs/backlog-pack.ts
@@ -147,8 +147,8 @@ const definitions: ToolDefinition[] = [
       type: "object",
       properties: {
         status: { type: "string", enum: [...BACKLOG_STATUS_VALUES], description: "Filter by status (optional)" },
-        epicId: { type: "string", description: "Filter by epic ID (optional)" },
-        limit: { type: "number", description: "Max results (default 20)" },
+        epicId: { type: "string", description: "Filter by semantic epic id (EP-*) or internal epic row id (optional). Returns epic_not_found rather than an empty list when it matches nothing." },
+        limit: { type: "number", description: "Max results (default 100, max 1000). Responses always report `total` and `truncated`." },
       },
       required: [],
     },
@@ -207,7 +207,7 @@ const definitions: ToolDefinition[] = [
       properties: {
         status: { type: "string", enum: ["open", "in-progress", "done"], description: "Filter by epic status" },
         hasOpenItems: { type: "boolean", description: "Only return epics that have at least one non-done item" },
-        limit: { type: "number", description: "Max results (default 25, max 100)" },
+        limit: { type: "number", description: "Max results (default 100, max 1000). Responses always report `total` and `truncated`, so a short list is never mistaken for a complete one." },
       },
       required: [],
     },
@@ -228,7 +228,7 @@ const definitions: ToolDefinition[] = [
         epicId: { type: "string", description: "Semantic epic id (EP-*) to filter to" },
         unclaimed: { type: "boolean", description: "Only items with no user/agent claim" },
         hasActiveBuild: { type: "boolean", description: "Only items currently linked to a Build Studio build" },
-        limit: { type: "number", description: "Max results (default 25, max 100)" },
+        limit: { type: "number", description: "Max results (default 100, max 1000). Responses always report `total` and `truncated`, so a short list is never mistaken for a complete one." },
       },
       required: [],
     },
@@ -589,38 +589,77 @@ async function processBacklogForBuildStudio(
   };
 }
 
+// Read caps. These exist to bound a single response, not to hide rows: every
+// capped list reports `total` and `truncated` so a caller can tell the
+// difference between "that is all of them" and "you only got the first page".
+// Silent truncation at 100 previously made a present-but-older epic look
+// absent, which is worse than a large response.
+const BACKLOG_LIST_LIMIT_MAX = 1000;
+const BACKLOG_LIST_LIMIT_DEFAULT = 100;
+
+function resolveListLimit(raw: unknown): number {
+  return typeof raw === "number" && Number.isFinite(raw)
+    ? Math.min(Math.max(1, Math.floor(raw)), BACKLOG_LIST_LIMIT_MAX)
+    : BACKLOG_LIST_LIMIT_DEFAULT;
+}
+
+// `BacklogItem.epicId` is the internal cuid FK, NOT the semantic `EP-*` id.
+// Filtering it by the semantic id matches nothing and returns an empty list
+// with no error, so callers must resolve the row first. Returns undefined when
+// no epic id was supplied, or null when one was supplied but matched nothing.
+type DbPrisma = (typeof import("@dpf/db"))["prisma"];
+
+async function resolveEpicRowId(prisma: DbPrisma, raw: unknown): Promise<string | null | undefined> {
+  if (typeof raw !== "string" || !raw.trim()) return undefined;
+  const epicRow = await prisma.epic.findFirst({
+    where: { OR: [{ epicId: raw.trim() }, { id: raw.trim() }] },
+    select: { id: true },
+  });
+  return epicRow ? epicRow.id : null;
+}
+
 async function queryBacklog(params: Record<string, unknown>): Promise<ToolResult> {
   const { prisma } = await import("@dpf/db");
   const where: Record<string, unknown> = {};
   if (typeof params["status"] === "string") where["status"] = params["status"];
-  if (typeof params["epicId"] === "string") where["epicId"] = params["epicId"];
-  const limit = typeof params["limit"] === "number" ? Math.min(params["limit"], 50) : 20;
+  const epicRowId = await resolveEpicRowId(prisma, params["epicId"]);
+  if (epicRowId === null) {
+    return { success: false, error: "epic_not_found", message: `No epic matched ${String(params["epicId"])}` };
+  }
+  if (epicRowId !== undefined) where["epicId"] = epicRowId;
+  const limit = resolveListLimit(params["limit"]);
 
-  const [items, epics, totalOpen, totalInProgress, totalDone] = await Promise.all([
+  const [items, matching, epics, epicTotal, totalOpen, totalInProgress, totalDone] = await Promise.all([
     prisma.backlogItem.findMany({
       where,
       orderBy: [{ priority: "asc" }, { updatedAt: "desc" }],
       take: limit,
-      select: { itemId: true, title: true, status: true, type: true, priority: true, epicId: true, updatedAt: true },
+      select: { itemId: true, title: true, status: true, type: true, priority: true, updatedAt: true, epic: { select: { epicId: true } } },
     }),
+    prisma.backlogItem.count({ where }),
     prisma.epic.findMany({
       select: { id: true, epicId: true, title: true, status: true },
       orderBy: { createdAt: "desc" },
-      take: 20,
+      take: limit,
     }),
+    prisma.epic.count(),
     prisma.backlogItem.count({ where: { status: "open" } }),
     prisma.backlogItem.count({ where: { status: "in-progress" } }),
     prisma.backlogItem.count({ where: { status: "done" } }),
   ]);
 
-  const summary = `Backlog: ${totalOpen} open, ${totalInProgress} in-progress, ${totalDone} done. ${epics.length} epic(s).`;
+  const summary = `Backlog: ${totalOpen} open, ${totalInProgress} in-progress, ${totalDone} done. Showing ${items.length} of ${matching} matching item(s), ${epics.length} of ${epicTotal} epic(s).`;
   return {
     success: true,
     message: summary,
     data: {
       summary: { open: totalOpen, inProgress: totalInProgress, done: totalDone },
+      total: matching,
+      truncated: items.length < matching,
+      epicTotal,
+      epicsTruncated: epics.length < epicTotal,
       epics: epics.map((e) => ({ epicId: e.epicId, title: e.title, status: e.status })),
-      items: items.map((i) => ({ itemId: i.itemId, title: i.title, status: i.status, type: i.type, priority: i.priority, epicId: i.epicId })),
+      items: items.map((i) => ({ itemId: i.itemId, title: i.title, status: i.status, type: i.type, priority: i.priority, epicId: i.epic?.epicId ?? null })),
     },
   };
 }
@@ -643,7 +682,8 @@ async function listEpics(params: Record<string, unknown>): Promise<ToolResult> {
   const { prisma } = await import("@dpf/db");
   const where: Record<string, unknown> = {};
   if (typeof params["status"] === "string") where["status"] = params["status"];
-  const limit = typeof params["limit"] === "number" ? Math.min(Math.max(1, params["limit"]), 100) : 25;
+  const limit = resolveListLimit(params["limit"]);
+  const epicTotal = await prisma.epic.count({ where });
   const epics = await prisma.epic.findMany({
     where,
     take: limit,
@@ -684,10 +724,13 @@ async function listEpics(params: Record<string, unknown>): Promise<ToolResult> {
       void _hasOpen;
       return rest;
     });
+  // `truncated` reflects the DB-side cap only. The hasOpenItems filter runs in
+  // memory over the fetched page, so data.length can be below epics.length
+  // without anything having been cut off by the limit.
   return {
     success: true,
-    message: `Listed ${data.length} epic(s).`,
-    data: { epics: data },
+    message: `Listed ${data.length} epic(s) (${epics.length} of ${epicTotal} fetched).`,
+    data: { epics: data, total: epicTotal, fetched: epics.length, truncated: epics.length < epicTotal },
   };
 }
 
@@ -698,19 +741,15 @@ async function listBacklogItems(params: Record<string, unknown>): Promise<ToolRe
   if (typeof params["type"] === "string") where["type"] = params["type"];
   if (typeof params["workType"] === "string") where["workType"] = params["workType"];
   if (typeof params["source"] === "string") where["source"] = params["source"];
-  if (typeof params["epicId"] === "string" && params["epicId"].trim()) {
-    const epicRow = await prisma.epic.findFirst({
-      where: { OR: [{ epicId: params["epicId"].trim() }, { id: params["epicId"].trim() }] },
-      select: { id: true },
-    });
-    if (epicRow) where["epicId"] = epicRow.id;
-    else
-      return {
-        success: false,
-        error: "epic_not_found",
-        message: `No epic matched ${params["epicId"]}`,
-      };
+  const epicRowId = await resolveEpicRowId(prisma, params["epicId"]);
+  if (epicRowId === null) {
+    return {
+      success: false,
+      error: "epic_not_found",
+      message: `No epic matched ${String(params["epicId"])}`,
+    };
   }
+  if (epicRowId !== undefined) where["epicId"] = epicRowId;
   if (params["unclaimed"] === true) {
     where["claimedById"] = null;
     where["claimedByAgentId"] = null;
@@ -718,7 +757,8 @@ async function listBacklogItems(params: Record<string, unknown>): Promise<ToolRe
   if (params["hasActiveBuild"] === true) where["activeBuildId"] = { not: null };
   else if (params["hasActiveBuild"] === false) where["activeBuildId"] = null;
 
-  const limit = typeof params["limit"] === "number" ? Math.min(Math.max(1, params["limit"]), 100) : 25;
+  const limit = resolveListLimit(params["limit"]);
+  const matching = await prisma.backlogItem.count({ where });
   const items = await prisma.backlogItem.findMany({
     where,
     take: limit,
@@ -769,8 +809,8 @@ async function listBacklogItems(params: Record<string, unknown>): Promise<ToolRe
   }));
   return {
     success: true,
-    message: `Listed ${data.length} backlog item(s).`,
-    data: { items: data },
+    message: `Listed ${data.length} of ${matching} backlog item(s).`,
+    data: { items: data, total: matching, truncated: data.length < matching },
   };
 }
 

--- a/apps/web/lib/mcp/packs/backlog-read-helpers.ts
+++ b/apps/web/lib/mcp/packs/backlog-read-helpers.ts
@@ -1,0 +1,38 @@
+// Shared read helpers for the governed MCP backlog surface (BI-EC9471C7).
+//
+// query_backlog, list_epics and list_backlog_items all page results and all
+// accept an epic filter, and they used to do both inconsistently — one resolved
+// the epic row, another wrote the semantic id straight into the cuid FK column.
+// Both concerns live here so the three handlers cannot drift again.
+
+type DbPrisma = (typeof import("@dpf/db"))["prisma"];
+
+// Read caps. These bound a single response; they do not hide rows. Every capped
+// list reports `total` and `truncated` so a caller can tell the difference
+// between "that is all of them" and "you only got the first page" — silent
+// truncation reads as absence, which is worse than a large response.
+export const BACKLOG_LIST_LIMIT_MAX = 1000;
+export const BACKLOG_LIST_LIMIT_DEFAULT = 100;
+
+export function resolveListLimit(raw: unknown): number {
+  return typeof raw === "number" && Number.isFinite(raw)
+    ? Math.min(Math.max(1, Math.floor(raw)), BACKLOG_LIST_LIMIT_MAX)
+    : BACKLOG_LIST_LIMIT_DEFAULT;
+}
+
+// `BacklogItem.epicId` is the internal cuid FK, NOT the semantic `EP-*` id.
+// Filtering it by the semantic id matches nothing and returns an empty list
+// with no error, so callers must resolve the row first. Returns undefined when
+// no epic id was supplied, or null when one was supplied but matched nothing —
+// the caller turns null into epic_not_found rather than an empty result.
+export async function resolveEpicRowId(
+  prisma: DbPrisma,
+  raw: unknown,
+): Promise<string | null | undefined> {
+  if (typeof raw !== "string" || !raw.trim()) return undefined;
+  const epicRow = await prisma.epic.findFirst({
+    where: { OR: [{ epicId: raw.trim() }, { id: raw.trim() }] },
+    select: { id: true },
+  });
+  return epicRow ? epicRow.id : null;
+}

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -42,7 +42,7 @@ apps/web/lib/integrate/sandbox/build-branch.ts	852
 apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp-tools-backlog.test.ts	874
 apps/web/lib/mcp-tools.ts	1910
-apps/web/lib/mcp/packs/backlog-pack.ts	1318
+apps/web/lib/mcp/packs/backlog-pack.ts	1320
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	858
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
 apps/web/lib/navigation/portal-navigation-model.ts	937


### PR DESCRIPTION
## What

Four defects in the governed MCP read surface (`backlog-pack`, `admin-pack`). Three of the four returned a **wrong answer rather than an error**, which is the severe part: an agent cannot distinguish a real absence from a tooling failure, so it confidently reports "this does not exist."

| Defect | Before | After |
|---|---|---|
| `query_backlog` epic filter | Semantic `EP-*` written into `where.epicId`, which is the internal **cuid FK** → matched nothing, returned `items: []` under `success: true` | Shares `resolveEpicRowId()` with `list_backlog_items`; returns `epic_not_found` |
| `query_backlog` item `epicId` | Emitted the raw cuid, contradicting the documented "semantic IDs, never cuids" contract | Selects through the epic relation |
| `admin_query_db` row cap | `sql + " LIMIT 1000"` → syntax error on any query with its own `LIMIT` or a trailing `;` | Cap appended only when the caller has not bounded the result |
| `admin_query_db` BigInt | Postgres returns `COUNT()`/`SUM()` as BigInt; `JSON.stringify` throws → **every** aggregate query failed, including the audit-log write | Safe-range values become numbers, larger ones strings |

Plus the caps themselves (`list_epics` 100, `list_backlog_items` 100, `query_backlog` 50, hardcoded `take: 20` for epics) truncated **silently**. On this install that hides 102 of 202 epics and all but 100 of 3,582 backlog items behind a response that looks complete. Caps are now 1000 (default 100), and every capped list reports `total` and `truncated`.

## Deliberate behaviour change

`query_backlog` now returns `epic_not_found` where it previously returned an empty list. Chosen for consistency with `list_backlog_items`, and because making the failure loud is the entire point of the fix. MCP tool results are consumed by agents rather than typed internal callers — the repo sweep found no code path depending on the old empty-list shape.

## Verification

- `admin-pack.test.ts` + `backlog-pack.test.ts`: **35 passed**, including new regression tests for each defect — semantic-id resolution, `epic_not_found`, truncation reporting, above-old-cap limits, caller-supplied `LIMIT`, trailing semicolon, and BigInt aggregates both inside and beyond the safe integer range.
- `tsc --noEmit` run directly against both changed files: **zero errors**. The worktree is source-only (no `next`/`prisma` in `.bin`), so the pre-commit typecheck gate was unrunnable and taken with the hook's own documented `DPF_SKIP_TYPECHECK=1` override. CI gates the merge.
- Not functionally verified against the live MCP surface: these tools are served by the running portal image, so the fix only takes effect after an operator-gated portal rebuild. Unit tests are the evidence here, not a live tool call.

Seed-Fit-Decision: No seed impact. This changes read-path query construction and response serialization only — no schema change, no migration, no seeded data, no new substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
