### PR TITLE
feat(discovery): model the internet uplink so the service path reaches Starlink

### DIFF
--- a/docs/superpowers/specs/2026-07-23-estate-service-path-wan-uplink-design.md
+++ b/docs/superpowers/specs/2026-07-23-estate-service-path-wan-uplink-design.md
@@ -1,0 +1,94 @@
+# Estate service path: modelling the internet uplink
+
+Status: implemented
+Date: 2026-07-23
+Backlog: follow-up to BI-FCEC588E (estate identity + managed-vs-observed)
+
+## Problem
+
+Discovery modelled the LAN in detail and the platform's own Docker bridge in
+*excessive* detail — but **never modelled the hop the business actually depends
+on**: the connection from the gateway to the internet.
+
+Concretely, before this change:
+
+- The relationship vocabulary was `CONNECTS_TO / HOSTS / MEMBER_OF / PEER_OF /
+  ROUTES_THROUGH`. **Nothing expressed "reaches the internet via."**
+- The UniFi collector's `uplink` handling only emitted a relationship when the
+  uplink target was *another UniFi device* (`macToRef.get(uplink_mac)`), so the
+  chain stopped dead at the gateway.
+- `discovery-promotion-policy.ts` carried `/\(WAN\d*\)/` in
+  `NON_PRODUCT_NAME_PATTERNS`, commented "VLAN-shape names from unifi", with a
+  test asserting `["Primary Starlink (WAN1)", true]`. The single most critical
+  dependency in the estate was **explicitly pattern-matched out of the
+  portfolio** as a worthless runtime artifact — while Docker bridge rows were
+  being promoted.
+
+Net effect: "are we online, and if not which hop broke?" was unanswerable, and an
+ISP outage would have surfaced only as unrelated downstream symptoms.
+
+## Design
+
+### The path
+
+```
+client → access point → switch → gateway → WAN uplink (Starlink) → internet
+         └──────────── already modelled ────────────┘ └── added here ──┘
+```
+
+### WAN uplink as a first-class entity
+
+`stat/health` is the only UniFi endpoint that reports the internet uplink. Its
+`wan` subsystem carries the ISP identity, public address, link status and
+latency. The collector now emits:
+
+- **itemType `wan_uplink`**, named after the ISP (`"Starlink (WAN)"`) so the
+  operator sees the dependency they actually have rather than an opaque port
+  label. Attributes: `ispName`, `ispOrganization`, `wanIp`, `linkStatus`,
+  `latencyMs`, `uptimeSeconds`, `throughputDownBps`, `throughputUpBps`.
+- **relationshipType `UPLINKS_TO`** from the gateway to that uplink, preferring
+  the controller's own `gw_mac` attribution and falling back to the routing
+  device.
+
+### Identity is anchored on the port, never the address
+
+`naturalKey = unifi-wan:${site}:wan`.
+
+Deliberately **not** the public IP: a Starlink CGNAT address rotates routinely,
+and keying on it would mint a new uplink entity per address change — exactly the
+churn pattern that produced thousands of orphaned rows elsewhere in discovery
+(see `2026-07-22-estate-identity-and-managed-classification-design.md`). The WAN
+port designation is stable for the life of the site.
+
+### The WAN is managed infrastructure, not an artifact
+
+- `/\(WAN\d*\)/` removed from `NON_PRODUCT_NAME_PATTERNS` (deliberately removed
+  rather than narrowed — WAN uplinks belong in the portfolio).
+- `wan_uplink` added to `LEGACY_PROMOTABLE_TYPES`: it has a vendor (the ISP), a
+  service level, and an outage blast radius of "everything".
+- `wan_uplink` added to the network-connectivity taxonomy rule in
+  `findRuleMatch`, so it attributes to `network_connectivity`.
+- It carries no observed token, so `classifyEntityObservation` treats it as
+  **managed** — meaning it *does* raise when it goes quiet. That is the point.
+
+## Why this matters beyond the topology picture
+
+It makes consequence-ranking possible. Severity today is uniformly `warn`, which
+is why "the internet is down" and "this row lacks a manufacturer string" looked
+identical. With a service path in the graph, severity can be derived from
+**distance from the path**: the Docker bridge is far from it (noise), the WAN
+uplink *is* it. That ranking is the prerequisite for the proactive guardrails
+described in the follow-ups below.
+
+## Out of scope / follow-ups
+
+- **Consequence-based severity** driven by service-path distance, and a per
+  issue-type open-count ratchet in CI (the proactive guardrails).
+- **Uplink health as a monitored signal** (state transitions, latency/loss
+  thresholds, failover to a secondary WAN) rather than a point-in-time attribute.
+- **Duplicate ISP-PoP rows**: three entities named
+  `customer.dllstxx1.pop.starlinkisp.net` exist at 192.168.0.40/.112/.236 from
+  IP-keyed ARP discovery. MAC anchoring stops new ones; collapsing the existing
+  three needs the cross-collector identity merge.
+- **Multi-WAN**: only the primary `wan` subsystem is modelled; `wan2`/failover
+  would extend the same shape.

--- a/packages/db/src/discovery-attribution.ts
+++ b/packages/db/src/discovery-attribution.ts
@@ -162,6 +162,9 @@ function findRuleMatch(
   } else if (
     itemType.includes("network") || itemType === "subnet" || itemType === "gateway" || itemType === "router"
     || itemType === "vlan" || itemType === "switch" || itemType === "firewall" || itemType === "load_balancer"
+    // The internet uplink (gateway -> ISP) is network connectivity in the most
+    // literal sense — and the hop the whole estate depends on.
+    || itemType === "wan_uplink"
   ) {
     node = matchByNodeId((nodeId) => nodeId.includes("network_connectivity"))
         ?? matchByNodeId((nodeId) => nodeId.includes("network_management"));

--- a/packages/db/src/discovery-collectors/unifi.test.ts
+++ b/packages/db/src/discovery-collectors/unifi.test.ts
@@ -114,11 +114,30 @@ function makeClients() {
   };
 }
 
+function makeHealth() {
+  return {
+    data: [
+      {
+        subsystem: "wan",
+        status: "ok",
+        wan_ip: "98.97.96.95",
+        isp_name: "Starlink",
+        isp_organization: "SpaceX Services, Inc.",
+        latency: 42,
+        uptime: 864000,
+        gw_mac: "aa:bb:cc:dd:ee:01",
+      },
+      { subsystem: "wlan", status: "ok" },
+    ],
+  };
+}
+
 function makeDeps(overrides: Partial<UnifiDeps> = {}): UnifiDeps {
   const responses: Record<string, unknown> = {
     "stat/device": makeDevices(),
     "rest/networkconf": makeNetworkConf(),
     "stat/sta": makeClients(),
+    "stat/health": makeHealth(),
   };
 
   return {
@@ -225,6 +244,56 @@ describe("collectUnifiDiscovery", () => {
   });
 
   // ─── VLAN Discovery ───────────────────────────────────────────
+
+  it("models the internet uplink and links the gateway to it (the WAN hop)", async () => {
+    const result = await collectUnifiDiscovery({ sourceKind: "unifi" }, makeDeps());
+
+    const wan = result.items.find((item) => item.itemType === "wan_uplink");
+    expect(wan).toBeDefined();
+    // Named after the ISP so the operator sees the dependency they actually have.
+    expect(wan!.name).toBe("Starlink (WAN)");
+    // Identity anchored on site + WAN designation, NEVER the public IP — a
+    // Starlink CGNAT address rotates and would mint a new entity each time.
+    expect(wan!.naturalKey).toBe("unifi-wan:default:wan");
+    expect(wan!.externalRef).toBe("unifi-wan:default:wan");
+    expect(wan!.attributes).toMatchObject({
+      ispName: "Starlink",
+      wanIp: "98.97.96.95",
+      linkStatus: "ok",
+      latencyMs: 42,
+    });
+
+    // The chain now reaches the internet: gateway -> WAN uplink.
+    const uplink = result.relationships.find((r) => r.relationshipType === "UPLINKS_TO");
+    expect(uplink).toBeDefined();
+    expect(uplink!.fromExternalRef).toBe("unifi-device:aa:bb:cc:dd:ee:01");
+    expect(uplink!.toExternalRef).toBe("unifi-wan:default:wan");
+  });
+
+  it("omits the uplink (without failing the sweep) when health has no wan subsystem", async () => {
+    const deps = makeDeps({
+      fetchFn: async (url: string | URL) => {
+        const urlStr = String(url);
+        if (urlStr.includes("stat/health")) {
+          return new Response(JSON.stringify({ data: [{ subsystem: "wlan", status: "ok" }] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        if (urlStr.includes("stat/device")) {
+          return new Response(JSON.stringify(makeDevices()), { status: 200 });
+        }
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      },
+    });
+
+    const result = await collectUnifiDiscovery({ sourceKind: "unifi" }, deps);
+
+    expect(result.items.find((item) => item.itemType === "wan_uplink")).toBeUndefined();
+    expect(result.relationships.find((r) => r.relationshipType === "UPLINKS_TO")).toBeUndefined();
+    // Devices still collected — a missing WAN subsystem must not fail the sweep.
+    expect(result.items.some((item) => item.itemType === "router")).toBe(true);
+  });
 
   it("discovers VLANs from networkconf", async () => {
     const result = await collectUnifiDiscovery(undefined, makeDeps());

--- a/packages/db/src/discovery-collectors/unifi.ts
+++ b/packages/db/src/discovery-collectors/unifi.ts
@@ -52,6 +52,24 @@ type UnifiDevice = {
   num_sta?: number;
 };
 
+// `stat/health` returns one entry per subsystem (wan, wlan, lan, www, vpn).
+// The `wan` entry is the only place the controller reports the INTERNET uplink:
+// which ISP is upstream, the public address, and whether the link is healthy.
+// Everything else the collector models stops at the LAN edge.
+type UnifiHealthSubsystem = {
+  subsystem: string;
+  status?: string; // "ok" | "warning" | "error"
+  wan_ip?: string;
+  isp_name?: string;
+  isp_organization?: string;
+  latency?: number; // ms to the ISP
+  uptime?: number; // seconds
+  xput_down?: number;
+  xput_up?: number;
+  gw_mac?: string; // the gateway that owns this uplink
+  gw_name?: string;
+};
+
 type UnifiNetworkConf = {
   _id: string;
   name: string;
@@ -353,6 +371,75 @@ export async function collectUnifiDiscovery(
           },
         });
       }
+    }
+  }
+
+  // ── Internet Uplink (the WAN hop) ─────────────────────────────
+  // Everything above stops at the LAN edge: AP -> switch -> gateway. The hop the
+  // business actually depends on — gateway -> ISP (Starlink here) — was never
+  // modelled, so "are we online, and which hop broke?" was unanswerable. The
+  // `wan` health subsystem is the only place the controller reports it.
+  //
+  // Identity is anchored on the site + WAN designation, never on `wan_ip`: a
+  // Starlink CGNAT address changes routinely, and keying on it would mint a new
+  // uplink entity per address change (the churn pattern that produced thousands
+  // of orphaned rows elsewhere in discovery).
+  const healthResult = await unifiGet<UnifiHealthSubsystem>("stat/health", resolvedDeps);
+  if (healthResult.error) {
+    warnings.push("unifi_partial:health");
+  }
+
+  const wanHealth = (healthResult.data ?? []).find(
+    (subsystem) => subsystem.subsystem === "wan",
+  );
+
+  if (wanHealth) {
+    const ispName = wanHealth.isp_name ?? wanHealth.isp_organization ?? null;
+    const wanRef = `unifi-wan:${resolvedDeps.site}:wan`;
+    items.push({
+      sourceKind: source,
+      itemType: "wan_uplink",
+      // Name the uplink after the ISP so the operator sees the dependency they
+      // actually have ("Starlink (WAN)") rather than an opaque port label.
+      name: ispName ? `${ispName} (WAN)` : "Internet Uplink (WAN)",
+      externalRef: wanRef,
+      naturalKey: wanRef,
+      confidence: 0.95,
+      attributes: {
+        ispName,
+        ispOrganization: wanHealth.isp_organization ?? null,
+        wanIp: wanHealth.wan_ip ?? null,
+        linkStatus: wanHealth.status ?? null,
+        latencyMs: wanHealth.latency ?? null,
+        uptimeSeconds: wanHealth.uptime ?? null,
+        throughputDownBps: wanHealth.xput_down ?? null,
+        throughputUpBps: wanHealth.xput_up ?? null,
+        osiLayer: 3,
+        osiLayerName: "network",
+        protocolFamily: "ipv4",
+      },
+    });
+
+    // Complete the chain: gateway -> internet uplink. Prefer the gateway the
+    // controller itself attributes the uplink to (`gw_mac`); fall back to the
+    // routing device when the controller omits it.
+    const gatewayRef = (wanHealth.gw_mac && macToRef.get(wanHealth.gw_mac.toLowerCase()))
+      ?? macToRef.get(
+        devices.find((device) => mapDeviceType(device.type).itemType === "router")?.mac ?? "",
+      );
+
+    if (gatewayRef) {
+      relationships.push({
+        sourceKind: source,
+        relationshipType: "UPLINKS_TO",
+        fromExternalRef: gatewayRef,
+        toExternalRef: wanRef,
+        confidence: 0.95,
+        attributes: {
+          ispName,
+          linkStatus: wanHealth.status ?? null,
+        },
+      });
     }
   }
 

--- a/packages/db/src/discovery-promotion-policy.test.ts
+++ b/packages/db/src/discovery-promotion-policy.test.ts
@@ -167,7 +167,11 @@ describe("looksLikeRuntimeArtifact", () => {
     ["Docker GW dpf_default (172.18.0.1)", true],
     ["192.168.0.109", true],
     ["abc123def456", true],
-    ["Primary Starlink (WAN1)", true],
+    // The WAN uplink is the estate's most critical dependency, NOT a runtime
+    // artifact. The `(WAN\d*)` pattern used to reject these, keeping the
+    // internet connection out of the portfolio while Docker rows sailed through.
+    ["Primary Starlink (WAN1)", false],
+    ["Starlink (WAN)", false],
     ["Digital Product Factory Portal", false],
     ["postgres", false],
     ["qdrant", false],
@@ -331,6 +335,10 @@ describe("LEGACY_PROMOTABLE_TYPES", () => {
       "ai_service",
       "application",
       "service",
+      // The internet uplink is a managed dependency with a vendor (the ISP), a
+      // service level, and an outage blast radius of "everything" — product-
+      // shaped, not a runtime instance.
+      "wan_uplink",
     ]);
   });
 

--- a/packages/db/src/discovery-promotion-policy.ts
+++ b/packages/db/src/discovery-promotion-policy.ts
@@ -27,6 +27,10 @@ export const LEGACY_PROMOTABLE_TYPES: readonly string[] = [
   "ai_service",
   "application",
   "service",
+  // The internet uplink is a first-class managed dependency, not a runtime
+  // instance: it is the single hop the entire estate rides on, it has a vendor
+  // (the ISP), a service level, and an outage blast radius of "everything".
+  "wan_uplink",
 ];
 
 // Name patterns that indicate "this is a runtime instance / device / host
@@ -41,7 +45,13 @@ const NON_PRODUCT_NAME_PATTERNS: readonly RegExp[] = [
   /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/,     // raw IPv4 addresses
   /^[a-f0-9]{12}$/i,                     // bare Docker container IDs (short SHA)
   /^arp:/,                               // arp-discovered host placeholders
-  /\(WAN\d*\)/,                          // VLAN-shape names from unifi
+  // NOTE: `(WAN\d*)` was here, rejecting names like "Primary Starlink (WAN1)" as
+  // "VLAN-shape names from unifi". That was backwards: the WAN uplink is the
+  // single most critical dependency in the estate — the hop the whole business
+  // rides on — and this pattern kept it out of the portfolio entirely while
+  // Docker bridge rows sailed through. WAN uplinks are now first-class managed
+  // infrastructure (see discovery-collectors/unifi.ts `wan_uplink`), so the
+  // pattern is deliberately gone rather than narrowed.
   /^subnet:/,                            // bootstrap subnet placeholders
 ];
 


### PR DESCRIPTION
Discovery modelled the LAN in detail and the platform's own Docker bridge in *excessive* detail — but never modelled **the hop the business actually depends on**. Design: `docs/superpowers/specs/2026-07-23-estate-service-path-wan-uplink-design.md`.

## The gap

```
client → access point → switch → gateway → WAN uplink (Starlink) → internet
         └──────── already modelled ────────┘ └───── missing ─────┘
```

Three concrete findings:

1. The relationship vocabulary (`CONNECTS_TO / HOSTS / MEMBER_OF / PEER_OF / ROUTES_THROUGH`) had **no way to express "reaches the internet via."**
2. The UniFi collector's `uplink` handling only emitted a link when the uplink target was *another UniFi device* (`macToRef.get(uplink_mac)`) — so the chain **stopped dead at the gateway**.
3. `discovery-promotion-policy.ts` carried `/\(WAN\d*\)/` in `NON_PRODUCT_NAME_PATTERNS` ("VLAN-shape names from unifi"), with a test asserting `["Primary Starlink (WAN1)", true]`. **The single most critical dependency in the estate was explicitly pattern-matched out of the portfolio as a worthless runtime artifact** — while Docker bridge rows sailed through and got promoted.

Net effect: "are we online, and if not which hop broke?" was unanswerable.

## Changes

- `unifi.ts` fetches `stat/health` and models its `wan` subsystem as a first-class **`wan_uplink`** item named after the ISP (`"Starlink (WAN)"`), carrying `ispName`, `wanIp`, `linkStatus`, `latencyMs`, `uptime`, throughput.
- New **`UPLINKS_TO`** relationship gateway → uplink, preferring the controller's own `gw_mac` attribution.
- **Identity anchored on `unifi-wan:${site}:wan`, never the public IP** — a Starlink CGNAT address rotates, and keying on it would mint a new entity per change (the exact churn that orphaned thousands of rows elsewhere).
- Removed `/\(WAN\d*\)/` from `NON_PRODUCT_NAME_PATTERNS` (**removed, not narrowed**), added `wan_uplink` to `LEGACY_PROMOTABLE_TYPES` and the network-connectivity taxonomy rule.
- It carries no observed token, so it classifies as **managed** — it *does* raise when it goes quiet. That is the point.
- A missing `wan` subsystem degrades to a partial warning; it never fails the sweep.

## Verification
- Collector **9/9** against real source: uplink entity, ISP naming, site-anchored identity, and the `gateway → WAN` link resolving through `gw_mac`. Printed path confirms `switch -CONNECTS_TO-> gateway` and `gateway -UPLINKS_TO-> Starlink`.
- Promotion policy **6/6**: WAN names now promotable, while `dpf-redis-1`, `Docker GW …` and raw IPs are still correctly rejected.
- Module-size guard green. Local typecheck skipped (source-only worktree); CI gates.

## Why it matters beyond the picture
It makes **consequence-ranking** possible. Severity is uniformly `warn` today, which is why "the internet is down" and "this row lacks a manufacturer string" looked identical. With a service path in the graph, severity can be derived from *distance from the path* — the Docker bridge is far from it, the WAN uplink **is** it. That's the prerequisite for the proactive guardrails.

## Follow-ups (in the spec)
Consequence-based severity + per-issue-type CI ratchet; uplink health as a monitored signal (state transitions, latency/loss thresholds, failover); collapsing the 3 duplicate `customer.dllstxx1.pop.starlinkisp.net` rows; multi-WAN.

Follow-up to BI-FCEC588E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)