### PR TITLE
fix(build-studio): stop the worktree resume from deleting uncommitted build work (BI-8C6AA60E)

### DIFF
--- a/apps/web/lib/integrate/sandbox/build-branch.test.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.test.ts
@@ -216,7 +216,7 @@ describe("per-build worktree primitives (BI-98B723C0 Phase 2)", () => {
 
   it("creates an isolated worktree on the build branch with shared node_modules symlinks", () => {
     const cmd = buildSandboxWorktreeAddCommand("FB-ABCD1234", "build/FB-ABCD1234");
-    // idempotent: clears any stale worktree first, then prunes the registry
+    // clears any stale worktree first, then prunes the registry
     expect(cmd).toContain(
       "git worktree remove --force /workspace/.builds/FB-ABCD1234 2>/dev/null || true",
     );
@@ -225,18 +225,39 @@ describe("per-build worktree primitives (BI-98B723C0 Phase 2)", () => {
     expect(cmd).toContain(
       "git worktree add --force /workspace/.builds/FB-ABCD1234 build/FB-ABCD1234",
     );
-    // node_modules shared by symlink — NOT reinstalled (verified live in dpf-sandbox-1)
+    // node_modules shared by symlink — NOT reinstalled (verified live in dpf-sandbox-1).
+    // -sfn so re-linking an already-provisioned worktree is a no-op, not an error.
     expect(cmd).toContain(
-      "ln -s /workspace/node_modules /workspace/.builds/FB-ABCD1234/node_modules",
+      "ln -sfn /workspace/node_modules /workspace/.builds/FB-ABCD1234/node_modules",
     );
     expect(cmd).toContain(
-      "ln -s /workspace/apps/web/node_modules /workspace/.builds/FB-ABCD1234/apps/web/node_modules",
+      "ln -sfn /workspace/apps/web/node_modules /workspace/.builds/FB-ABCD1234/apps/web/node_modules",
     );
     expect(cmd).toContain(
-      "ln -s /workspace/packages/db/node_modules /workspace/.builds/FB-ABCD1234/packages/db/node_modules",
+      "ln -sfn /workspace/packages/db/node_modules /workspace/.builds/FB-ABCD1234/packages/db/node_modules",
     );
     // never runs an install in the worktree — the symlinks are the whole point
     expect(cmd).not.toContain("pnpm install");
+  });
+
+  // BI-8C6AA60E (isolation-ON half): the destructive `worktree remove --force`
+  // must be reachable ONLY when the worktree is absent or has drifted onto
+  // another branch. A resume onto this build's own branch reuses the live tree.
+  it("reuses an existing worktree already on the build branch instead of force-removing it", () => {
+    const cmd = buildSandboxWorktreeAddCommand("FB-ABCD1234", "build/FB-ABCD1234");
+    // guarded on both the directory existing AND its HEAD matching this build's branch
+    expect(cmd).toContain(
+      '[ -d /workspace/.builds/FB-ABCD1234 ] && [ "$(git -C /workspace/.builds/FB-ABCD1234 rev-parse --abbrev-ref HEAD 2>/dev/null)" = "build/FB-ABCD1234" ]',
+    );
+    // the reuse branch re-asserts symlinks only — it must not destroy the tree
+    const reuseBranch = cmd.slice(cmd.indexOf("; then "), cmd.indexOf("; else "));
+    expect(reuseBranch).toContain("ln -sfn");
+    expect(reuseBranch).not.toContain("worktree remove");
+    expect(reuseBranch).not.toContain("worktree add");
+    // and the destructive path is behind the else
+    const recreateBranch = cmd.slice(cmd.indexOf("; else "));
+    expect(recreateBranch).toContain("git worktree remove --force");
+    expect(recreateBranch).toContain("git worktree add --force");
   });
 
   it("tears down a build's worktree best-effort without touching the shared install", () => {

--- a/apps/web/lib/integrate/sandbox/build-branch.ts
+++ b/apps/web/lib/integrate/sandbox/build-branch.ts
@@ -191,15 +191,33 @@ export function buildSandboxWorktreeAddCommand(
   workspace: string = WORKSPACE,
 ): string {
   const path = buildWorktreePath(buildId, workspace);
+  // `ln -sfn` so re-linking an already-provisioned worktree is a no-op rather
+  // than an error — the reuse branch below relies on it.
   const symlinks = WORKTREE_SHARED_NODE_MODULES.map(
-    (rel) => `ln -s ${workspace}/${rel} ${path}/${rel}`,
+    (rel) => `ln -sfn ${workspace}/${rel} ${path}/${rel}`,
   ).join(" && ");
-  return [
-    `cd ${workspace}`,
+  const recreate = [
     `git worktree remove --force ${path} 2>/dev/null || true`,
     `git worktree prune`,
     `git worktree add --force ${path} ${branchRef}`,
     symlinks,
+  ].join(" && ");
+  // RESUME SAFETY (BI-8C6AA60E, isolation-ON half). `git worktree remove --force`
+  // deletes the working tree wholesale, and the Phase-1 commit-in-flight
+  // mitigation (buildSandboxCommitInFlightWorkCommand) only ever runs against
+  // /workspace — it never reaches .builds/<buildId>. So every re-entry into
+  // startBuildBranch for a build that already had a worktree (review-phase
+  // resume, a retried phase, a second start_build) silently destroyed that
+  // build's UNCOMMITTED source. Committed work survived on the branch ref, which
+  // is exactly why the loss looked intermittent.
+  //
+  // If the worktree is already present AND checked out on this build's own
+  // branch, it is this build's live tree: REUSE it, and only re-assert the
+  // symlinks. Recreate only when it is absent or has drifted onto another branch
+  // (a stale/corrupt state where a reset is the right answer).
+  return [
+    `cd ${workspace}`,
+    `if [ -d ${path} ] && [ "$(git -C ${path} rev-parse --abbrev-ref HEAD 2>/dev/null)" = "${branchRef}" ]; then ${symlinks}; else ${recreate}; fi`,
   ].join(" && ");
 }
 

--- a/docs/superpowers/plans/2026-07-22-build-worktree-resume-preservation.md
+++ b/docs/superpowers/plans/2026-07-22-build-worktree-resume-preservation.md
@@ -1,0 +1,75 @@
+# Build-worktree resume preservation — the isolation-ON half of BI-8C6AA60E
+
+**BI-8C6AA60E** · 2026-07-22
+
+## What was already fixed, and what was not
+
+PR #3246 fixed the **shared-tree** half: on `startBuildBranch` re-entry with an
+existing `build/<buildId>` branch, `refreshCurrentBranchFromTarget` is now called
+with `preserveExistingWork: true`, so a review-phase resume no longer resets away
+committed work.
+
+That fix lives entirely in the `else` arm of the isolation flag — the
+**isolation-OFF** path. Per-build worktree isolation
+(`isBuildWorktreeIsolationEnabled`) **defaults ON**, so the live path was the
+other arm, and it was never covered.
+
+## The remaining loss
+
+`provisionBuildWorktree` called `buildSandboxWorktreeAddCommand`, which
+unconditionally ran:
+
+```sh
+git worktree remove --force /workspace/.builds/<buildId> 2>/dev/null || true
+git worktree prune
+git worktree add --force /workspace/.builds/<buildId> build/<buildId>
+```
+
+`git worktree remove --force` deletes the working tree wholesale. So **every
+re-entry** into `startBuildBranch` for a build that already had a worktree — a
+review-phase resume, a retried phase, a second `start_build` — destroyed that
+build's **uncommitted** source.
+
+Two things made it look intermittent rather than systematic:
+
+- **Committed work survived.** The branch ref is untouched; only the checked-out
+  tree is deleted. A build that had committed recently lost nothing visible.
+- **The Phase-1 mitigation does not reach here.**
+  `buildSandboxCommitInFlightWorkCommand` — built for exactly this class of loss
+  (BI-98B723C0) — only acts when a `build/*` branch is checked out **in
+  /workspace**. Under isolation, /workspace sits on the client branch and the
+  build's tree is at `.builds/<buildId>`, which that command never inspects. The
+  protection was structurally bypassed by the isolation it was meant to
+  complement.
+
+## The fix
+
+`buildSandboxWorktreeAddCommand` becomes resume-safe. The destructive recreate is
+put behind a guard:
+
+```sh
+if [ -d $path ] && [ "$(git -C $path rev-parse --abbrev-ref HEAD 2>/dev/null)" = "$branchRef" ]; then
+  <re-assert symlinks only>
+else
+  <remove --force; prune; add --force; symlinks>
+fi
+```
+
+If the worktree is present **and** checked out on this build's own branch, it is
+this build's live tree — reuse it. Recreate only when it is absent or has drifted
+onto another branch, which is a stale/corrupt state where a reset is the right
+answer.
+
+Symlink creation moves from `ln -s` to `ln -sfn` so re-asserting links on an
+already-provisioned worktree is a no-op instead of an error.
+
+## Evidence
+
+- `build-branch.test.ts`: the existing worktree test updated for `ln -sfn`, plus a
+  new test asserting the guard shape — that the reuse branch contains no
+  `worktree remove` / `worktree add`, and that both destructive commands sit
+  behind the `else`. 26 tests green.
+- Exercised end-to-end against a real git repo: create the worktree, add one
+  committed file and one **uncommitted** file, re-run the identical command.
+  Before: the uncommitted file is gone. After: both survive, and the symlink
+  re-assert is clean.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -38,7 +38,7 @@ apps/web/lib/finance/ai-provider-finance.ts	1309
 apps/web/lib/inference/ai-provider-internals.ts	1228
 apps/web/lib/integrate/build-agent-prompts.ts	1064
 apps/web/lib/integrate/build-orchestrator.ts	1751
-apps/web/lib/integrate/sandbox/build-branch.ts	852
+apps/web/lib/integrate/sandbox/build-branch.ts	870
 apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp-tools-backlog.test.ts	874
 apps/web/lib/mcp-tools.ts	1910


### PR DESCRIPTION
## What was already fixed, and what was not

[#3246](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3246) fixed the **shared-tree** half: `startBuildBranch` re-entry now calls `refreshCurrentBranchFromTarget` with `preserveExistingWork: true`.

That fix lives entirely in the `else` arm of the isolation flag — the **isolation-OFF** path. Per-build worktree isolation **defaults ON**, so the live path was the other arm, and it was never covered.

## The remaining loss

`provisionBuildWorktree` called `buildSandboxWorktreeAddCommand`, which unconditionally ran:

```sh
git worktree remove --force /workspace/.builds/<buildId> 2>/dev/null || true
git worktree prune
git worktree add --force /workspace/.builds/<buildId> build/<buildId>
```

`git worktree remove --force` deletes the working tree wholesale. So **every re-entry** into `startBuildBranch` for a build that already had a worktree — a review-phase resume, a retried phase, a second `start_build` — destroyed that build's **uncommitted** source.

Two things made it look intermittent rather than systematic:

- **Committed work survived.** The branch ref is untouched; only the checked-out tree is deleted. A build that had committed recently lost nothing visible.
- **The Phase-1 mitigation never reached here.** `buildSandboxCommitInFlightWorkCommand` was built for exactly this class of loss (BI-98B723C0), but it only acts when a `build/*` branch is checked out **in `/workspace`**. Under isolation, `/workspace` sits on the client branch and the build's tree is at `.builds/<buildId>`, which that command never inspects. The protection was structurally bypassed by the isolation it was meant to complement.

## The fix

The destructive recreate goes behind a guard:

```sh
if [ -d $path ] && [ "$(git -C $path rev-parse --abbrev-ref HEAD 2>/dev/null)" = "$branchRef" ]; then
  <re-assert symlinks only>
else
  <remove --force; prune; add --force; symlinks>
fi
```

If the worktree is present **and** on this build's own branch, it is this build's live tree — reuse it. Recreate only when it is absent or has drifted onto another branch, which is a stale state where a reset is the right answer. Symlinks move from `ln -s` to `ln -sfn` so re-asserting on an already-provisioned worktree is a no-op rather than an error.

## Evidence

- `build-branch.test.ts`: existing worktree test updated for `ln -sfn`, plus a new test asserting the guard shape — the reuse branch contains no `worktree remove`/`worktree add`, and both destructive commands sit behind the `else`. **26 tests green.**
- **Exercised end-to-end against a real git repo**: create the worktree, add one committed file and one *uncommitted* file, re-run the identical command. Before this change the uncommitted file is gone; after, both survive and the symlink re-assert is clean.
- Plan doc in the same PR: `docs/superpowers/plans/2026-07-22-build-worktree-resume-preservation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)