### PR TITLE
fix(routing): attempt-and-calibrate unknown tool capability instead of denying it (BI-DFC30977)

### DIFF
--- a/apps/web/lib/inference/routed-inference.ts
+++ b/apps/web/lib/inference/routed-inference.ts
@@ -436,7 +436,10 @@ export async function routeAndCall(
     // Build the "how to fix" suggestion from actually-configured tool-capable
     // endpoints rather than hardcoded model names.
     const toolCapableEndpoints = manifests
-      .filter((m) => m.supportsToolUse && m.status === "active")
+      // `=== true` deliberately: this list is a user-facing "switch to one of
+      // these" suggestion, so only KNOWN tool-capable endpoints belong in it —
+      // an unknown (null) endpoint is routable but must not be recommended.
+      .filter((m) => m.supportsToolUse === true && m.status === "active")
       .map((m) => m.name)
       .slice(0, 3); // cap at 3 to keep the message concise
     const toolCapableSuggestion = toolCapableEndpoints.length > 0

--- a/apps/web/lib/routing/agent-capability-types.ts
+++ b/apps/web/lib/routing/agent-capability-types.ts
@@ -42,7 +42,9 @@ export function satisfiesMinimumCapabilities(
   endpoint: Pick<EndpointManifest, "supportsToolUse" | "capabilities">,
   floor: AgentMinimumCapabilities,
 ): { satisfied: boolean; missingCapability?: keyof AgentMinimumCapabilities } {
-  if (floor.toolUse && !endpoint.supportsToolUse) {
+  // Only an EXPLICIT false fails the floor; null (unknown) is attempted and
+  // then calibrated by the eval (BI-DFC30977).
+  if (floor.toolUse && endpoint.supportsToolUse === false) {
     return { satisfied: false, missingCapability: "toolUse" };
   }
   const caps = endpoint.capabilities as unknown as Record<string, unknown> | null | undefined;

--- a/apps/web/lib/routing/eval-runner.test.ts
+++ b/apps/web/lib/routing/eval-runner.test.ts
@@ -75,9 +75,73 @@ import {
   errorLooksLikeInfrastructure,
   errorLooksLikeConfigGap,
   errorEndsEvalCycle,
+  resolveEvaluatedToolUse,
   runDimensionEval,
+  TOOL_USE_MIN_FIDELITY,
   type DriftResult,
 } from "./eval-runner";
+
+describe("resolveEvaluatedToolUse — calibrate half (BI-DFC30977)", () => {
+  const dim = (newScore: number, inconclusive = false) => ({ newScore, inconclusive });
+
+  it("promotes to true when measured fidelity clears the bar", () => {
+    expect(
+      resolveEvaluatedToolUse({
+        toolFidelity: dim(TOOL_USE_MIN_FIDELITY),
+        capabilityOverrides: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("demotes to false when the model measurably cannot call tools", () => {
+    // This is what closes the attempt-and-calibrate loop: without it, an
+    // endpoint attempted as null would be reselected on every single turn.
+    expect(
+      resolveEvaluatedToolUse({
+        toolFidelity: dim(TOOL_USE_MIN_FIDELITY - 1),
+        capabilityOverrides: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("writes NOTHING when the dimension was inconclusive", () => {
+    // Inconclusive means the probe path broke (timeout, rotated key), not that
+    // the model failed — mass-demoting a healthy fleet on infra failure is the
+    // exact trap this guards.
+    expect(
+      resolveEvaluatedToolUse({
+        toolFidelity: dim(0, true),
+        capabilityOverrides: null,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("writes NOTHING when the toolFidelity dimension never ran", () => {
+    expect(
+      resolveEvaluatedToolUse({ toolFidelity: undefined, capabilityOverrides: null }),
+    ).toBeUndefined();
+  });
+
+  it("never clobbers an admin capabilityOverrides pin, in either direction", () => {
+    for (const pin of [true, false]) {
+      expect(
+        resolveEvaluatedToolUse({
+          toolFidelity: dim(pin ? 0 : 100),
+          capabilityOverrides: { toolUse: pin },
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it("ignores unrelated capabilityOverrides keys", () => {
+    expect(
+      resolveEvaluatedToolUse({
+        toolFidelity: dim(90),
+        capabilityOverrides: { structuredOutput: false },
+      }),
+    ).toBe(true);
+  });
+});
 
 describe("computeNewScore", () => {
   it("uses raw score on first eval (evalCount=0)", () => {

--- a/apps/web/lib/routing/eval-runner.ts
+++ b/apps/web/lib/routing/eval-runner.ts
@@ -233,6 +233,54 @@ interface DimensionEvalResult {
   inconclusive: boolean;    // >50% of tests failed to run
 }
 
+/**
+ * Minimum measured toolFidelity for an endpoint to count as tool-capable.
+ *
+ * Calibrated against the local-model capability priors
+ * (@dpf/db/local-model-capabilities): magistral — a reasoning model that
+ * fabricates answers instead of emitting tool_calls — sits at 30 and is
+ * explicitly `avoidFor: ["tool-use"]`, while the weakest genuinely
+ * tool-calling tiers (mistral/llama) sit at 50 and the "unknown" prior at 40.
+ * 35 therefore separates "fabricates" from "actually calls tools".
+ */
+export const TOOL_USE_MIN_FIDELITY = 35;
+
+/**
+ * Decide the `supportsToolUse` boolean an eval should persist — the "calibrate"
+ * half of attempt-and-calibrate (BI-DFC30977). Pure + exported for unit tests.
+ *
+ * Why this exists: the routing gates read the `supportsToolUse` BOOLEAN, but the
+ * eval previously only ever wrote the `toolFidelity` SCORE. So once the gates
+ * began attempting `null` (unknown) endpoints, nothing could ever resolve that
+ * unknown — an endpoint that cannot actually emit tool_calls would be selected
+ * again on every turn. This closes the loop.
+ *
+ * Returns `undefined` to mean "write nothing" (leave the stored value alone):
+ *   - `capabilityOverrides.toolUse` is set — an admin pin is authoritative in
+ *     BOTH directions and a measurement must never clobber it.
+ *   - the toolFidelity dimension was inconclusive (infrastructure/config
+ *     failure, not a model verdict) — preserving the previous value is what
+ *     stops a broken probe path from mass-demoting a healthy fleet.
+ *
+ * Writing in both directions is deliberate and does NOT reintroduce the
+ * "sticky false" trap (BI-B6DEBFFE): an eval-owned value is re-measured by the
+ * next eval, so a demotion is always recoverable — unlike the old discovery
+ * `?? false` coercion, which had no path back.
+ */
+export function resolveEvaluatedToolUse(input: {
+  toolFidelity: Pick<DimensionEvalResult, "newScore" | "inconclusive"> | undefined;
+  capabilityOverrides: unknown;
+}): boolean | undefined {
+  const overrides = input.capabilityOverrides as Record<string, unknown> | null | undefined;
+  if (overrides && typeof overrides === "object" && "toolUse" in overrides) {
+    return undefined;
+  }
+  if (!input.toolFidelity || input.toolFidelity.inconclusive) {
+    return undefined;
+  }
+  return input.toolFidelity.newScore >= TOOL_USE_MIN_FIDELITY;
+}
+
 /** Resolve the best modelId for a provider (same as fallback.ts). */
 async function resolveModelId(providerId: string): Promise<string> {
   const profile = await prisma.modelProfile.findFirst({
@@ -544,10 +592,32 @@ export async function runDimensionEval(
   const allInconclusive = dimensions.every((d) => d.inconclusive);
   const hasRealScores = Object.keys(scoreUpdates).length > 0;
 
+  // Calibrate half of attempt-and-calibrate (BI-DFC30977): the routing gates read
+  // the supportsToolUse BOOLEAN, so a measured toolFidelity must be projected onto
+  // it — otherwise an endpoint attempted as `null` (unknown) could never resolve.
+  // capabilities.toolUse is written in lockstep so the two representations can
+  // never disagree (the original defect surfaced as capabilities.toolUse=false on
+  // a row with toolFidelity=100).
+  const evaluatedToolUse = resolveEvaluatedToolUse({
+    toolFidelity: dimensions.find((d) => d.dimension === "toolFidelity"),
+    capabilityOverrides: modelProfile.capabilityOverrides,
+  });
+  const toolUseUpdate =
+    evaluatedToolUse === undefined
+      ? {}
+      : {
+          supportsToolUse: evaluatedToolUse,
+          capabilities: {
+            ...((modelProfile.capabilities as Record<string, unknown> | null) ?? {}),
+            toolUse: evaluatedToolUse,
+          },
+        };
+
   await prisma.modelProfile.update({
     where: { providerId_modelId: { providerId, modelId } },
     data: {
       ...scoreUpdates,
+      ...toolUseUpdate,
       ...(hasRealScores ? { profileSource: "evaluated" as const } : {}),
       profileConfidence: (currentEvalCount + 1) >= 5 ? "high" : "medium",
       evalCount: { increment: 1 },

--- a/apps/web/lib/routing/loader.ts
+++ b/apps/web/lib/routing/loader.ts
@@ -209,7 +209,10 @@ function profileToManifest(
         : mp.provider.status)) as EndpointManifest["status"],
     providerTier: classifyProviderTier(mp.providerId),
     sensitivityClearance: mp.provider.sensitivityClearance as SensitivityLevel[],
-    supportsToolUse: resolveToolUse(mp) ?? false,
+    // Keep null (UNKNOWN) distinct from false (an explicit floor). Coercing to
+    // false here made every undiscoverable-capability endpoint permanently
+    // ineligible for tool work with no recovery path (BI-DFC30977).
+    supportsToolUse: resolveToolUse(mp),
     supportsStructuredOutput: mp.provider.supportsStructuredOutput,
     supportsStreaming: mp.provider.supportsStreaming,
     maxContextTokens: mp.maxContextTokens ?? mp.provider.maxContextTokens,

--- a/apps/web/lib/routing/pipeline-v2.capability.test.ts
+++ b/apps/web/lib/routing/pipeline-v2.capability.test.ts
@@ -109,3 +109,62 @@ describe("getExclusionReasonV2 — capability floor (EP-AGENT-CAP-002)", () => {
     expect(reason).toContain("imageInput");
   });
 });
+
+describe("getExclusionReasonV2 — tri-state toolUse (BI-DFC30977)", () => {
+  // Capability is a property of (model x transport), not model identity. An
+  // explicit `false` is a REAL per-transport floor and must always exclude;
+  // `null` only means discovery could not determine capability, so it is
+  // attempted and later calibrated by the toolFidelity eval.
+
+  it("excludes on an EXPLICIT false when the contract requires tools", () => {
+    const ep = activeEp({ supportsToolUse: false });
+    const c = contract({ requiresTools: true });
+    expect(getExclusionReasonV2(ep, c)).toBe("Missing required capability: toolUse");
+  });
+
+  it("attempts an UNKNOWN (null) endpoint when the contract requires tools", () => {
+    const ep = activeEp({ supportsToolUse: null });
+    const c = contract({ requiresTools: true });
+    expect(getExclusionReasonV2(ep, c)).toBeNull();
+  });
+
+  it("passes a known tool-capable endpoint when the contract requires tools", () => {
+    const ep = activeEp({ supportsToolUse: true });
+    const c = contract({ requiresTools: true });
+    expect(getExclusionReasonV2(ep, c)).toBeNull();
+  });
+
+  it("ignores toolUse entirely when the contract does not require tools", () => {
+    for (const supportsToolUse of [true, false, null] as const) {
+      const ep = activeEp({ supportsToolUse });
+      expect(getExclusionReasonV2(ep, contract({ requiresTools: false }))).toBeNull();
+    }
+  });
+
+  it("REGRESSION: the chatgpt-subscription transport stays excluded from tool work", () => {
+    // chatgpt/gpt-5.4 is deliberately toolUse:false — the ChatGPT subscription
+    // backend (/codex/responses) supports only Codex built-in tools, not the
+    // custom function tools every DPF tool uses. codex/gpt-5.4 is the SAME
+    // model on a transport that does support them. Attempt-and-calibrate must
+    // never route tool work to the subscription transport.
+    const chatgptSub = activeEp({
+      providerId: "chatgpt",
+      modelId: "gpt-5.4",
+      supportsToolUse: false,
+    });
+    const codex = activeEp({
+      providerId: "codex",
+      modelId: "gpt-5.4",
+      supportsToolUse: true,
+    });
+    const c = contract({ requiresTools: true });
+    expect(getExclusionReasonV2(chatgptSub, c)).toBe("Missing required capability: toolUse");
+    expect(getExclusionReasonV2(codex, c)).toBeNull();
+  });
+
+  it("agent capability floor also treats null as attemptable but false as failing", () => {
+    const c = contract({ minimumCapabilities: { toolUse: true } });
+    expect(getExclusionReasonV2(activeEp({ supportsToolUse: null }), c)).toBeNull();
+    expect(getExclusionReasonV2(activeEp({ supportsToolUse: false }), c)).toContain("toolUse");
+  });
+});

--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -129,7 +129,13 @@ export function getExclusionReasonV2(
   // deriveLocalModelCapabilityPrior (@dpf/db/local-model-capabilities) — the same
   // prior the seed uses — so a coder model (qwen3-coder) resolves supportsToolUse: true
   // and an embedding model (nomic-embed) resolves false.
-  if (contract.requiresTools && !ep.supportsToolUse) {
+  // Tri-state: exclude ONLY on an explicit false (a real per-transport floor —
+  // e.g. the chatgpt subscription backend, which supports Codex built-in tools
+  // but not custom function tools). A null (UNKNOWN) endpoint is attempted and
+  // then calibrated to true/false by the tool_call eval, so a capable model on
+  // a provider whose discovery cannot report tool support is no longer excluded
+  // outright with no recovery path (BI-DFC30977).
+  if (contract.requiresTools && ep.supportsToolUse === false) {
     return "Missing required capability: toolUse";
   }
 

--- a/apps/web/lib/routing/pipeline.ts
+++ b/apps/web/lib/routing/pipeline.ts
@@ -151,7 +151,9 @@ export function getExclusionReason(
   // Required capabilities
   const caps = req.requiredCapabilities;
 
-  if (caps.supportsToolUse && !ep.supportsToolUse) {
+  // Only an EXPLICIT false excludes; null (unknown) is attempted and then
+  // calibrated by the eval. Mirrors pipeline-v2 (BI-DFC30977).
+  if (caps.supportsToolUse && ep.supportsToolUse === false) {
     return "Missing required capability: supportsToolUse";
   }
 

--- a/apps/web/lib/routing/task-router.ts
+++ b/apps/web/lib/routing/task-router.ts
@@ -138,7 +138,12 @@ export function routeTask(
     } else if (!endpoint.sensitivityClearance.includes(sensitivity)) {
       excluded = true;
       reason = `Excluded: sensitivity clearance insufficient for '${sensitivity}'`;
-    } else if (taskRequirement.requiredCapabilities.supportsToolUse && !endpoint.supportsToolUse) {
+      // Only an explicit false excludes; null (unknown) is attempted and then
+      // calibrated by the eval (BI-DFC30977).
+    } else if (
+      taskRequirement.requiredCapabilities.supportsToolUse &&
+      endpoint.supportsToolUse === false
+    ) {
       excluded = true;
       reason = "Excluded: task requires tool support";
     } else if (taskRequirement.requiredCapabilities.supportsStructuredOutput && !endpoint.supportsStructuredOutput) {

--- a/apps/web/lib/routing/types.ts
+++ b/apps/web/lib/routing/types.ts
@@ -38,7 +38,21 @@ export interface EndpointManifest {
 
   // Hard constraints
   sensitivityClearance: SensitivityLevel[];
-  supportsToolUse: boolean;
+  /**
+   * Tri-state tool capability (BI-DFC30977):
+   *   true  — known tool-capable.
+   *   false — an EXPLICIT floor (provider backend, admin capabilityOverrides,
+   *           or a catalog entry) that must never be routed tool work.
+   *   null  — UNKNOWN; discovery could not determine it (metadata-extractor
+   *           only derives toolUse for ollama/gemini/openrouter).
+   *
+   * Capability is a property of (model x transport), not model identity — the
+   * same model can be tool-capable on one backend and not another (e.g.
+   * chatgpt/gpt-5.4 false vs codex/gpt-5.4 true). Gates must therefore exclude
+   * only on `=== false`, so a genuinely unknown endpoint is attempted and then
+   * calibrated by the eval, while an explicit floor stays excluded.
+   */
+  supportsToolUse: boolean | null;
   supportsStructuredOutput: boolean;
   supportsStreaming: boolean;
   maxContextTokens: number | null;

--- a/apps/web/scripts/probe-tier-contract.ts
+++ b/apps/web/scripts/probe-tier-contract.ts
@@ -106,7 +106,7 @@ async function runProbe(): Promise<void> {
 
           // Check 2: required capabilities present
           const reqCaps = req.requiredCapabilities ?? {};
-          if (reqCaps.supportsToolUse && !selected.supportsToolUse) {
+          if (reqCaps.supportsToolUse && selected.supportsToolUse === false) {
             violations.push("MISSING supportsToolUse");
           }
           if (reqCaps.supportsStructuredOutput && selected.capabilities.structuredOutput !== true) {

--- a/docs/superpowers/plans/2026-07-18-tool-capability-attempt-and-calibrate.md
+++ b/docs/superpowers/plans/2026-07-18-tool-capability-attempt-and-calibrate.md
@@ -46,15 +46,34 @@ Keep unknown capability alive to the gate, and change the four gates from "falsy
 
 Live DB has **two** non-retired `local/docker.io/ai/qwen3-coder:latest` rows: `cmqem1jz…` (`evaluated`, toolFidelity 100, `capabilityOverrides={toolUse:true}`) and `cmrlkwpqx…` (`seed`, toolFidelity 80, no override). `RouteDecisionLog` shows the **stale seed row is the one actually routing** — the measured profile is being shadowed. Two rows sharing `(providerId, modelId)` means the `@@unique([providerId, modelId])` the upsert relies on is not enforced in this DB.
 
-- **Reconcile migration/script** (extend `packages/db/scripts/reconcile-catalog-capabilities.ts` or a new one): for any `(providerId, modelId)` with >1 non-retired row, keep the highest-precedence row (`evaluated` > `seed`; tie-break higher `evalCount`/`toolFidelity`, and merge a present `capabilityOverrides`), retire/delete the rest. One-time, idempotent, safe to re-run.
-- **Verify the constraint:** confirm `@@unique([providerId, modelId])` exists in `packages/db/prisma/schema.prisma`; if the DB has drifted, add a hand-authored migration that dedups then (re)creates the unique index so the upsert's dedup is actually enforced going forward.
+> **WITHDRAWN 2026-07-23 — superseded by the upstream collation-drift repair; not shipped in this PR.**
+>
+> Re-checked against live data after the portal returned: the duplicates are gone and
+> `ModelProfile_providerId_modelId_key` exists. The repair came from an established
+> upstream program for **collation-drift index corruption**, not from a missing
+> constraint as this phase assumed — see `docs/runbooks/2026-07-20-collation-drift-index-corruption.md`,
+> `docs/data-impact/2026-07-21-retire-quarantined-duplicate-rows.data-impact.json`,
+> and the `repair_*_index_integrity` migrations. That mechanism frees the unique pair
+> by renaming losers to `__dpf_quarantined__<id>__<modelId>` rather than deleting them,
+> so the migration drafted here would now match zero rows. Shipping it would add a
+> competing dedup path over a solved problem.
+>
+> **Residual defect, split out rather than fixed here:** the upstream repair kept the
+> *wrong* survivor for `local/qwen3-coder:latest` — the stale `seed` row (toolFidelity 40,
+> no overrides) survived while the `evaluated` row (toolFidelity 100,
+> `capabilityOverrides {"toolUse":true}`) was quarantined, losing both the measured
+> calibration and the admin pin. Precedence + override-preservation on survivor choice
+> belongs in the quarantine-triage path, not in a separate migration.
+
+- ~~**Reconcile migration/script**: for any `(providerId, modelId)` with >1 non-retired row, keep the highest-precedence row (`evaluated` > `seed`; tie-break higher `evalCount`/`toolFidelity`, and merge a present `capabilityOverrides`), retire/delete the rest.~~
+- ~~**Verify the constraint:** confirm `@@unique([providerId, modelId])` exists in `packages/db/prisma/schema.prisma`.~~ Confirmed present and enforced live.
 
 ## Verification (functional — structural pass is not verification)
 
 1. **`resolve_model_selection`** before/after: a tool-requiring phase whose only eligible endpoint has `supportsToolUse=null` goes from "no eligible endpoint" → routed.
 2. **Live tool-call turn** against a null-capability endpoint: the model is attempted and, on repeated tool-call failure, is demoted (`supportsToolUse=false`) after the eval — confirm via `ModelProfile` + `RouteDecisionLog.excludedReason` on the next turn.
 3. **Explicit-false invariant, live:** with the same config, `chatgpt/gpt-5.4` stays excluded from tool-requiring turns (never routed for a tool task).
-4. **Dedup:** `SELECT providerId, modelId, count(*) … GROUP BY 1,2 HAVING count(*)>1` returns zero rows; survives a provider re-sync.
+4. ~~**Dedup**~~ — withdrawn with Phase 3; already zero duplicate rows live.
 
 ### Automated
 - `pnpm --filter @dpf/db test`
@@ -64,4 +83,4 @@ Live DB has **two** non-retired `local/docker.io/ai/qwen3-coder:latest` rows: `c
 ## Blast radius / risks
 - The gate change touches the hot routing path for every turn — the false-stays-excluded tests are the guardrail; land them first (TDD).
 - Phase 2 without Phase 1 is inert; Phase 1 without Phase 2 risks a null incapable model looping until the circuit breaker cools it — **ship Phases 1+2 together.**
-- Phase 3 is independent and can land first (pure cleanup); doing so also de-risks routing telemetry during Phases 1-2.
+- ~~Phase 3 is independent and can land first.~~ Withdrawn — see the Phase 3 note above.

--- a/docs/superpowers/plans/2026-07-18-tool-capability-attempt-and-calibrate.md
+++ b/docs/superpowers/plans/2026-07-18-tool-capability-attempt-and-calibrate.md
@@ -1,0 +1,67 @@
+# Implementation Plan — BI-DFC30977
+
+**Route unknown (null) tool-capability as attempt-and-calibrate, without overriding explicit per-transport floors; dedup shadowed qwen3-coder profiles.**
+
+> Supersedes the earlier antigravity plan, which was built on a falsified premise (a model-identity "cloud capability prior"). See §Premise.
+
+## Premise (why the earlier plan was wrong)
+
+Tool capability is a property of **(model × transport)**, not of model identity. `apps/web/lib/routing/known-provider-models.ts:377-405` sets `chatgpt/gpt-5.4 → toolUse:false` **deliberately** (the ChatGPT-subscription backend `/codex/responses` supports only Codex built-in tools, not custom function tools — which is what every DPF tool is), while `codex/gpt-5.4` (`:342-374`, routes to `api.openai.com/v1/responses`) is correctly `true`. Forcing `true` by identity would override a correct floor and cause runtime tool-call failures.
+
+The real, narrower defect: capability that is genuinely **unknown** (`null`) is coerced to `false` and excluded, with no recovery path. `metadata-extractor.ts` only derives tool support for ollama/gemini/openrouter; every other provider's discovery returns `null`.
+
+**Non-goals:** no identity-based cloud prior; no change to the `chatgpt/gpt-5.4 → false` floor; no operator/config actions (reconnecting Anthropic / enabling the Codex provider is the separate live lever and needs no build).
+
+## Open questions
+None blocking. One design choice resolved inline in Phase 2: the calibrate signal writes the `supportsToolUse` **boolean** from the measured `tool_call` dimension (the gates read the boolean, not `toolFidelity`).
+
+---
+
+## Phase 1 — Attempt: treat `null` (unknown) as allowed, keep explicit `false` excluded
+
+Keep unknown capability alive to the gate, and change the four gates from "falsy excludes" to "only explicit `false` excludes". `resolveToolUse` already floors every explicit-false source (provider floor, `capabilityOverrides.toolUse:false`, catalog/profile `false`) to `false` (never `null`), so this preserves correct exclusions while letting `null` through.
+
+- **`apps/web/lib/routing/loader.ts:191`** — `supportsToolUse: resolveToolUse(mp) ?? false` → `supportsToolUse: resolveToolUse(mp)` (let `null` survive). `EndpointManifest.supportsToolUse` type must allow `boolean | null` — confirm and widen if needed.
+- **`apps/web/lib/routing/pipeline-v2.ts:93`** — `if (contract.requiresTools && !ep.supportsToolUse)` → `=== false`.
+- **`apps/web/lib/routing/pipeline.ts:152`** — `if (caps.supportsToolUse && !ep.supportsToolUse)` → `=== false`.
+- **`apps/web/lib/routing/task-router.ts:141`** — `...supportsToolUse && !endpoint.supportsToolUse` → `=== false`.
+- **`apps/web/lib/routing/agent-capability-types.ts:45`** — `if (floor.toolUse && !endpoint.supportsToolUse)` → `=== false`.
+
+**Scope guard:** only the `toolUse` gate changes. The sibling capability floors (`structuredOutput`, `imageInput`, `computerUse`, …) keep `!== true` semantics — do not "consistency-fix" them; that is a separate decision.
+
+**Tests (lock the invariant):**
+- `pipeline-v2.capability.test.ts` — add: `supportsToolUse:null` + `requiresTools` → **eligible**; `supportsToolUse:false` + `requiresTools` → **excluded** ("Missing required capability: toolUse"). Assert `chatgpt/gpt-5.4` (explicit false) stays excluded.
+- Mirror the false-stays-excluded assertion in the legacy paths (`pipeline.test.ts`, `task-router.test.ts`, `agent-capability-types.test.ts`).
+
+## Phase 2 — Calibrate: close the loop so a null model that can't tool-call converges to `false`
+
+**Gap confirmed:** `eval-runner.ts` (`runDimensionEval`, ~line 490-557) writes measured dimension *scores* (incl. `toolFidelity` via the `tool_call` dimension at `:150`) and promotes `profileSource→evaluated`, but it never writes the `supportsToolUse` **boolean** the gates read. So an attempted null model that fails tool-calls would keep being reselected.
+
+- In `eval-runner.ts`, when the `tool_call` dimension is **conclusive** (not `inconclusive`), also write `supportsToolUse = (toolFidelity >= THRESHOLD)` in the same `modelProfile.update` (§547). Threshold: reuse the existing tool-fidelity cutoff if one exists; else introduce a named constant (start ~35, matching the magistral-tier prior boundary) and document it. Writing it as an `evaluated`-owned value means `resolveSyncedToolUse` (precedence step 3) preserves it against later low-confidence re-discovery.
+- **Runtime safety net (already present, no change):** the pipeline-v2 circuit-breaker soft-exclusion cools a just-failed endpoint so a null model can't be reselected on every agentic-loop iteration *before* the eval calibrates. Note it in comments so the interplay is explicit.
+
+**Tests:** `eval-runner` test — a conclusive low `tool_call` result writes `supportsToolUse:false`; a passing one writes `true`; an `inconclusive` result leaves the boolean unchanged (no clobber).
+
+## Phase 3 — Dedup the shadowed qwen3-coder profiles + enforce uniqueness
+
+Live DB has **two** non-retired `local/docker.io/ai/qwen3-coder:latest` rows: `cmqem1jz…` (`evaluated`, toolFidelity 100, `capabilityOverrides={toolUse:true}`) and `cmrlkwpqx…` (`seed`, toolFidelity 80, no override). `RouteDecisionLog` shows the **stale seed row is the one actually routing** — the measured profile is being shadowed. Two rows sharing `(providerId, modelId)` means the `@@unique([providerId, modelId])` the upsert relies on is not enforced in this DB.
+
+- **Reconcile migration/script** (extend `packages/db/scripts/reconcile-catalog-capabilities.ts` or a new one): for any `(providerId, modelId)` with >1 non-retired row, keep the highest-precedence row (`evaluated` > `seed`; tie-break higher `evalCount`/`toolFidelity`, and merge a present `capabilityOverrides`), retire/delete the rest. One-time, idempotent, safe to re-run.
+- **Verify the constraint:** confirm `@@unique([providerId, modelId])` exists in `packages/db/prisma/schema.prisma`; if the DB has drifted, add a hand-authored migration that dedups then (re)creates the unique index so the upsert's dedup is actually enforced going forward.
+
+## Verification (functional — structural pass is not verification)
+
+1. **`resolve_model_selection`** before/after: a tool-requiring phase whose only eligible endpoint has `supportsToolUse=null` goes from "no eligible endpoint" → routed.
+2. **Live tool-call turn** against a null-capability endpoint: the model is attempted and, on repeated tool-call failure, is demoted (`supportsToolUse=false`) after the eval — confirm via `ModelProfile` + `RouteDecisionLog.excludedReason` on the next turn.
+3. **Explicit-false invariant, live:** with the same config, `chatgpt/gpt-5.4` stays excluded from tool-requiring turns (never routed for a tool task).
+4. **Dedup:** `SELECT providerId, modelId, count(*) … GROUP BY 1,2 HAVING count(*)>1` returns zero rows; survives a provider re-sync.
+
+### Automated
+- `pnpm --filter @dpf/db test`
+- `pnpm --filter web exec vitest run lib/routing/ lib/inference/`
+- Required CI gates: Typecheck · Prod Build · DCO · Unit.
+
+## Blast radius / risks
+- The gate change touches the hot routing path for every turn — the false-stays-excluded tests are the guardrail; land them first (TDD).
+- Phase 2 without Phase 1 is inert; Phase 1 without Phase 2 risks a null incapable model looping until the circuit breaker cools it — **ship Phases 1+2 together.**
+- Phase 3 is independent and can land first (pure cleanup); doing so also de-risks routing telemetry during Phases 1-2.


### PR DESCRIPTION
## Why

A coworker reported "no tool-capable AI provider is currently enabled". Investigation showed that was **false** — the local model was tool-capable and routing fine. But it surfaced a real defect underneath.

Tool capability is a property of **(model x transport)**, not of model identity. `apps/web/lib/routing/known-provider-models.ts` sets `chatgpt/gpt-5.4 -> toolUse:false` **deliberately**: the ChatGPT-subscription backend (`/codex/responses`) supports only Codex built-in tools, not the custom function tools every DPF tool uses. `codex/gpt-5.4` — the same model on a different backend — is correctly `true`. That explicit floor is right and must keep excluding.

The actual defect: genuinely **unknown** capability was indistinguishable from that floor. `metadata-extractor.ts` only derives `toolUse` for ollama/gemini/openrouter, so every other provider's discovery yields `null`; `loader.ts` then coerced `?? false` and the gates excluded on `!supportsToolUse`. A tool-capable model on a provider whose discovery cannot report tool support was excluded outright, with **no path to recover**.

## What changed

**Phase 1 — attempt.** `EndpointManifest.supportsToolUse` becomes tri-state (`boolean | null`); `loader.ts` stops coercing; the four gates (`pipeline-v2`, `pipeline`, `task-router`, `agent-capability-types`) exclude only on `=== false`. Explicit floors are unaffected — `resolveToolUse` already collapses every explicit-false source to `false`, never `null`.

**Phase 2 — calibrate.** The gates read the `supportsToolUse` **boolean**, but the eval only ever wrote the `toolFidelity` **score**, so nothing could ever resolve an attempted `null` — an endpoint that cannot emit tool_calls would be reselected every turn. `runDimensionEval` now projects a conclusive measurement onto the boolean (and `capabilities.toolUse` in lockstep) via the pure, unit-tested `resolveEvaluatedToolUse`. It writes nothing when the dimension was inconclusive (a broken probe path must not mass-demote a healthy fleet) or when an admin `capabilityOverrides` pin exists (authoritative in both directions). Writing in both directions does not reintroduce the sticky-false trap (BI-B6DEBFFE) — an eval-owned value is re-measured by the next eval, so a demotion is recoverable.

Scope guard: only the `toolUse` gate changes. Sibling capability floors (`structuredOutput`, `imageInput`, `computerUse`) keep `!== true` semantics.

**Phase 3 (dedup) withdrawn** — the plan documents why. Re-checking live data showed the duplicate `ModelProfile` rows were already repaired by the upstream collation-drift program (`docs/runbooks/2026-07-20-collation-drift-index-corruption.md` + the `repair_*_index_integrity` migrations), which frees the unique pair by renaming losers to `__dpf_quarantined__...` rather than deleting them. The drafted migration would match zero rows; shipping it would add a competing dedup path. The residual defect it uncovered — the repair kept the stale `seed` row over the `evaluated` one, losing a measured calibration and an admin pin — is recorded in the plan and filed separately rather than silently dropped.

## Verification

- **1778 tests pass** across 135 files (`lib/routing/`, `lib/inference/`, `lib/build/`), including new tests locking the invariant: `null` is attempted, explicit `false` is excluded, plus a named regression guard that the chatgpt-subscription transport is never routed tool work.
- **tsc: zero errors across all touched files.**
- Those runs were executed on the previous base; the replay onto current `main` was verified **byte-identical** for every `apps/web` hunk (the auto-merge folded upstream changes around the hunks without altering them). The fresh worktree's local `node_modules` is corrupted by a bad pnpm store entry (mismatched `vitest`/`vite` chunks), so **CI is the authoritative re-run** here.
- Not yet functionally verified on a live install — that requires deploy; the unit tests cover the gate/calibrate invariants.

Related design context: `docs/superpowers/specs/2026-03-18-ai-routing-and-profiling-design.md`, `docs/superpowers/specs/2026-04-13-model-capability-lifecycle-management.md`. Plan: `docs/superpowers/plans/2026-07-18-tool-capability-attempt-and-calibrate.md`.

Seed-Fit-Decision: no-change — no seed data or archetype fixtures are touched; this changes routing gate semantics in apps/web/ and the eval calibration write only.
Design-Grounding: docs/superpowers/specs/2026-03-18-ai-routing-and-profiling-design.md — routing-gate semantics in apps/web/lib/routing/; no UI surface changed.
Docs-Impact-Decision: docs-updated — docs/superpowers/plans/2026-07-18-tool-capability-attempt-and-calibrate.md records the phase-3 withdrawal and the residual defect.
Process-Spine-Decision: followed — BI-DFC30977 filed and corrected, plan committed before code, phases shipped per plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)