### PR TITLE
fix(build-studio): return the no-releasable-changes error as a value, not a digest (BI-8C6AA60E part c)

### DIFF
--- a/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.test.tsx
@@ -50,6 +50,9 @@ vi.mock("@/lib/actions/decision-perspective", () => ({
 
 beforeEach(() => {
   mockAdvanceBuildPhase.mockReset();
+  // advanceBuildPhase returns AdvanceBuildPhaseResult (BI-8C6AA60E) — default the
+  // mock to the success shape so the card's !outcome.ok check reflects reality.
+  mockAdvanceBuildPhase.mockResolvedValue({ ok: true });
   mockCaptureDecisionInteraction.mockReset();
   mockRerunPlanReview.mockReset();
   mockResumeBuildImplementation.mockReset();
@@ -220,6 +223,25 @@ describe("BuildStudioWorkflowActionCard WWMD visibility", () => {
       expect(screen.getByText("WWMD requires escalation before implementation starts.")).toBeInTheDocument();
     });
     expect(onCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  // BI-8C6AA60E: the regression guard. Before this, "no releasable source changes"
+  // was THROWN from a Server Action, so production stripped it to a digest and a
+  // build that had passed every gate failed with an unexplained render error.
+  it("surfaces a returned no-releasable-changes message to the operator", async () => {
+    const message =
+      "No releasable source changes are present in the sandbox. Resume implementation and make a real code change before continuing to release.";
+    mockAdvanceBuildPhase.mockResolvedValueOnce({ ok: false, message });
+
+    render(
+      <BuildStudioWorkflowActionCard build={makeBuild()} action={implementationAction()} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Implementation" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(message)).toBeInTheDocument();
+    });
   });
 
   it("persists WWMD human direction from the action card", async () => {
@@ -539,7 +561,7 @@ describe("BuildStudioWorkflowActionCard compact rendering", () => {
   });
 
   it("compact=true exposes a primary action wired to handlePrimaryAction (delegation, not new dispatch)", async () => {
-    mockAdvanceBuildPhase.mockResolvedValue({ buildId: "FB-9B19098C" });
+    mockAdvanceBuildPhase.mockResolvedValue({ ok: true });
     const onCompleted = vi.fn();
     render(
       <BuildStudioWorkflowActionCard

--- a/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
+++ b/apps/web/components/build/BuildStudioWorkflowActionCard.tsx
@@ -183,7 +183,14 @@ export function BuildStudioWorkflowActionCard({
       } else if (action.kind === "run-review-verification") {
         await runBuildReviewVerification(build.buildId);
       } else if (action.kind === "advance-phase" && action.targetPhase) {
-        await advanceBuildPhase(build.buildId, action.targetPhase);
+        // BI-8C6AA60E: "no releasable source changes" is an expected operational
+        // state, returned as a value so the operator reads the real message
+        // instead of a stripped production digest.
+        const outcome = await advanceBuildPhase(build.buildId, action.targetPhase);
+        if (!outcome.ok) {
+          setError(outcome.message);
+          return;
+        }
       } else if (action.kind === "retry-inference") {
         // BI-F0005EB0 — the AI call errored. Re-drive the failed coworker turn
         // (the same recovery the user does by re-prompting today) by opening the

--- a/apps/web/lib/actions/build-governed.test.ts
+++ b/apps/web/lib/actions/build-governed.test.ts
@@ -1087,9 +1087,13 @@ describe("governed build start approvals", () => {
     });
     mockListReleasableSandboxFiles.mockResolvedValue([]);
 
-    await expect(advanceBuildPhase("FB-123", "review")).rejects.toThrow(
-      "No releasable source changes are present in the sandbox. Tasks are marked complete but no code was written. Resume implementation and make real code changes before advancing to review.",
-    );
+    // BI-8C6AA60E: RETURNED as a value, not thrown — a thrown Server Action
+    // message is stripped to a digest in production and the operator sees nothing.
+    expect(await advanceBuildPhase("FB-123", "review")).toEqual({
+      ok: false,
+      message:
+        "No releasable source changes are present in the sandbox. Tasks are marked complete but no code was written. Resume implementation and make real code changes before advancing to review.",
+    });
 
     expect(mockPrisma.featureBuild.update).not.toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1128,9 +1132,11 @@ describe("governed build start approvals", () => {
     });
     mockListReleasableSandboxFiles.mockResolvedValue([]);
 
-    await expect(advanceBuildPhase("FB-123", "ship")).rejects.toThrow(
-      "No releasable source changes are present in the sandbox. Resume implementation and make a real code change before continuing to release.",
-    );
+    expect(await advanceBuildPhase("FB-123", "ship")).toEqual({
+      ok: false,
+      message:
+        "No releasable source changes are present in the sandbox. Resume implementation and make a real code change before continuing to release.",
+    });
 
     expect(mockPrisma.featureBuild.update).not.toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/lib/actions/build.ts
+++ b/apps/web/lib/actions/build.ts
@@ -350,11 +350,23 @@ export async function updateBusinessBuildBrief(input: {
 
 // ─── Advance Phase ───────────────────────────────────────────────────────────
 
+/**
+ * Outcome of a phase advance. The two "no releasable source changes" states are
+ * EXPECTED operational conditions the operator must be able to read and act on —
+ * not invariant violations. Thrown Server Action errors have their messages
+ * stripped in production (the operator sees only a digest), which is how a build
+ * that passed every gate surfaced as an unexplained render error in BI-8C6AA60E.
+ * So those two are RETURNED as values, per the #2758 pattern. The remaining
+ * throws in this function are genuine invariant violations where a digest is the
+ * correct operator experience.
+ */
+export type AdvanceBuildPhaseResult = { ok: true } | { ok: false; message: string };
+
 export async function advanceBuildPhase(
   buildId: string,
   targetPhase: BuildPhase,
   options?: { overrideUxFailure?: { reason: string } },
-): Promise<void> {
+): Promise<AdvanceBuildPhaseResult> {
   const userId = await requireBuildAccess();
 
   const build = await prisma.featureBuild.findUnique({
@@ -560,9 +572,11 @@ export async function advanceBuildPhase(
     const { clientBranch } = await getClientIdentity();
     const releasableFiles = await listReleasableSandboxFiles(build.sandboxId, { baseRef: clientBranch });
     if (releasableFiles.length === 0) {
-      throw new Error(
-        "No releasable source changes are present in the sandbox. Tasks are marked complete but no code was written. Resume implementation and make real code changes before advancing to review.",
-      );
+      return {
+        ok: false,
+        message:
+          "No releasable source changes are present in the sandbox. Tasks are marked complete but no code was written. Resume implementation and make real code changes before advancing to review.",
+      };
     }
   }
 
@@ -574,9 +588,11 @@ export async function advanceBuildPhase(
     const { clientBranch } = await getClientIdentity();
     const releasableFiles = await listReleasableSandboxFiles(build.sandboxId, { baseRef: clientBranch });
     if (releasableFiles.length === 0) {
-      throw new Error(
-        "No releasable source changes are present in the sandbox. Resume implementation and make a real code change before continuing to release.",
-      );
+      return {
+        ok: false,
+        message:
+          "No releasable source changes are present in the sandbox. Resume implementation and make a real code change before continuing to release.",
+      };
     }
   }
 
@@ -713,6 +729,8 @@ export async function advanceBuildPhase(
   if (targetPhase === "review") {
     await queueBuildReviewVerification(buildId);
   }
+
+  return { ok: true };
 }
 
 /**

--- a/docs/superpowers/plans/2026-07-22-build-worktree-resume-preservation.md
+++ b/docs/superpowers/plans/2026-07-22-build-worktree-resume-preservation.md
@@ -73,3 +73,32 @@ already-provisioned worktree is a no-op instead of an error.
   committed file and one **uncommitted** file, re-run the identical command.
   Before: the uncommitted file is gone. After: both survive, and the symlink
   re-assert is clean.
+
+## Addendum — part (c): the stripped ship error (same BI)
+
+BI-8C6AA60E named three fixes. (a) is delegated to BI-53C14D19; (b) is the
+worktree/branch preservation above. (c) is this: the release path should RETURN
+the "no releasable source changes" domain error as a value rather than throw it.
+
+`advanceBuildPhase` is a `"use server"` action. A thrown Server Action error has
+its message stripped in production — the operator sees only a digest. That is why
+FB-041879CD, which passed every gate, surfaced as an unexplained render error
+(digest 200317269) instead of a readable explanation. Same class as #2758.
+
+- `advanceBuildPhase` now returns `AdvanceBuildPhaseResult = {ok: true} | {ok: false; message}`.
+  The **two** "no releasable source changes" states — build→review and review→ship —
+  are returned as values. They are expected operational conditions the operator must
+  read and act on.
+- The other **nine** throws in the function are left alone. They are genuine
+  invariant violations (missing sandbox, gate refusals); a digest is the correct
+  operator experience there, and converting them would dilute the signal.
+- `BuildStudioWorkflowActionCard` surfaces `outcome.message` via the existing
+  `setError` path already used by `rerunPlanReview`.
+
+Note the inline `export type AdvanceBuildPhaseResult = …` declaration is safe in a
+`"use server"` module; it was the `export type { A, B }` **re-export** form that
+broke SSR in #2758.
+
+Evidence: 45 existing tests green; the two build-governed assertions converted from
+`.rejects.toThrow` to a returned-value equality; one new UI regression test proving
+the operator actually sees the message. `tsc --noEmit` clean across touched files.

--- a/docs/superpowers/plans/2026-07-22-build-worktree-resume-preservation.md
+++ b/docs/superpowers/plans/2026-07-22-build-worktree-resume-preservation.md
@@ -102,3 +102,31 @@ broke SSR in #2758.
 Evidence: 45 existing tests green; the two build-governed assertions converted from
 `.rejects.toThrow` to a returned-value equality; one new UI regression test proving
 the operator actually sees the message. `tsc --noEmit` clean across touched files.
+
+## Design grounding
+
+- Existing specs/plans reviewed:
+  - BI-8C6AA60E fix (c) — the originating diagnosis, which names "the release/ship
+    server action should RETURN the 'no releasable changes' domain error as a value
+    (not throw) so the operator sees the real message, not a digest".
+  - PR #2758 — the established `"use server"` error-surfacing pattern, including the
+    distinction between a safe inline `export type X = …` declaration and the
+    `export type { A, B }` re-export form that broke SSR.
+- Current code substrate reviewed:
+  - `apps/web/lib/actions/build.ts` — `advanceBuildPhase` (11 throws; only 2 are
+    operator-facing domain states) and `createFeatureBuild`, which already returns a
+    discriminated result for exactly this reason.
+  - `apps/web/components/build/BuildStudioWorkflowActionCard.tsx` — the sole
+    production caller; already surfaces `outcome.message` via `setError` for
+    `rerunPlanReview`.
+  - `apps/web/lib/build/release-decision.ts` — confirms the ship-side message is
+    matched by string, so the wording must not change.
+- Source of truth:
+  - BI-8C6AA60E fix (c), plus the #2758 Server Action error contract. No spec
+    artifact governs this surface; this plan doc is the durable record.
+- Decision:
+  - Extend an existing contract shape rather than introduce one. No new UX, no
+    routing change, no queue or process-spine change: the card reuses its existing
+    error-rendering path, and the two converted throws keep their exact wording.
+    The other nine throws stay throws deliberately — they are invariant violations
+    where a digest is the correct operator experience.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -19,8 +19,8 @@ apps/web/lib/actions/agent-coworker-external.test.ts	867
 apps/web/lib/actions/agent-coworker.ts	2759
 apps/web/lib/actions/agent-task-scheduler.test.ts	1124
 apps/web/lib/actions/ai-providers.ts	914
-apps/web/lib/actions/build-governed.test.ts	1143
-apps/web/lib/actions/build.ts	1729
+apps/web/lib/actions/build-governed.test.ts	1149
+apps/web/lib/actions/build.ts	1747
 apps/web/lib/actions/compliance.ts	867
 apps/web/lib/actions/crm.ts	1256
 apps/web/lib/actions/ea.ts	918


### PR DESCRIPTION
BI-8C6AA60E named three fixes. **(a)** is delegated to BI-53C14D19; **(b)** shipped in [#3449](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3449) (worktree/branch preservation on resume). This is **(c)**.

## The problem

`advanceBuildPhase` is a `"use server"` action. A **thrown** Server Action error has its message stripped in production — the operator sees only a digest. That is why FB-041879CD, which passed *every* quality gate (design review, plan review, 54 unit tests, 5/5 UX verification, typecheck clean, acceptance 5/5), surfaced as an unexplained render error (digest `200317269`) instead of a readable explanation of what to do next. Same class as [#2758](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/2758).

## The change

- `advanceBuildPhase` now returns `AdvanceBuildPhaseResult = { ok: true } | { ok: false; message: string }`.
- The **two** "no releasable source changes" states — `build→review` and `review→ship` — are returned as values. They are *expected operational conditions* the operator must read and act on.
- The other **nine** throws in the function are deliberately left alone. Those are genuine invariant violations (missing sandbox, gate refusals) where a digest is the correct operator experience; converting them would dilute the signal.
- `BuildStudioWorkflowActionCard` surfaces `outcome.message` through the existing `setError` path already used by `rerunPlanReview`.

The inline `export type AdvanceBuildPhaseResult = …` **declaration** is safe in a `"use server"` module — it was the `export type { A, B }` **re-export** form that broke SSR in #2758.

## Design grounding

Extends an existing contract shape rather than introducing one: `createFeatureBuild` in this same module already returns a discriminated result for exactly this reason. Source of truth is BI-8C6AA60E fix (c) plus the #2758 pattern. No new spec artifact; the plan doc `docs/superpowers/plans/2026-07-22-build-worktree-resume-preservation.md` is extended with an addendum in this PR.

## Evidence

- 45 existing tests green.
- The two `build-governed` assertions converted from `.rejects.toThrow` to returned-value equality.
- **One new UI regression test** proving the operator actually sees the message rendered — the behaviour that was broken, not just the return shape.
- The stale `mockAdvanceBuildPhase.mockResolvedValue({ buildId })` corrected to the real contract rather than making the component defensive against a shape it should never receive.
- `tsc --noEmit` clean across the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)