### PR TITLE
fix(build-studio): stop the restart-path Epic unique-constraint prisma:error (BI-1D0CA7A0)

### DIFF
--- a/apps/web/lib/build/approve-decomposition.test.ts
+++ b/apps/web/lib/build/approve-decomposition.test.ts
@@ -51,9 +51,33 @@ type RecordedWrites = {
   activities: Array<Record<string, unknown>>;
 };
 
-function makeFakeDb(build: FakeBuild | null): {
+/**
+ * Prisma-shaped P2002 for `Epic.originatingBacklogItemId @unique`, so the fake
+ * db can enforce the real constraint instead of silently accepting a second
+ * epic row for the same backlog item.
+ */
+function epicBacklogItemUniqueError(): Error & { code: string; meta: { target: string[] } } {
+  const err = new Error(
+    "Invalid `prisma.epic.create()` invocation: Unique constraint failed on the fields: (`originatingBacklogItemId`)",
+  ) as Error & { code: string; meta: { target: string[] } };
+  err.code = "P2002";
+  err.meta = { target: ["originatingBacklogItemId"] };
+  return err;
+}
+
+function makeFakeDb(
+  build: FakeBuild | null,
+  /**
+   * Backlog items that already own an Epic — the fake's stand-in for the unique
+   * index. Seeded rows are visible to the precondition read; rows written by
+   * epic.create are added, so a second approve in the SAME test hits the
+   * constraint exactly as Postgres would.
+   */
+  epicsByBacklogItemId: Map<string, string> = new Map(),
+): {
   db: ApproveDecompositionDb;
   writes: RecordedWrites;
+  epicsByBacklogItemId: Map<string, string>;
 } {
   const writes: RecordedWrites = {
     epicCreates: [],
@@ -72,7 +96,12 @@ function makeFakeDb(build: FakeBuild | null): {
   const tx: TxShape = {
     epic: {
       create: vi.fn(async ({ data }) => {
+        const originating = data.originatingBacklogItemId as string | undefined;
+        if (originating && epicsByBacklogItemId.has(originating)) {
+          throw epicBacklogItemUniqueError();
+        }
         writes.epicCreates.push(data);
+        if (originating) epicsByBacklogItemId.set(originating, data.epicId as string);
         return { id: `epic-row-${++epicRowSeq}`, epicId: data.epicId as string };
       }),
     },
@@ -120,10 +149,16 @@ function makeFakeDb(build: FakeBuild | null): {
     featureBuild: {
       findUnique: vi.fn(async () => build) as unknown as ApproveDecompositionDb["featureBuild"]["findUnique"],
     },
+    epic: {
+      findUnique: vi.fn(async ({ where }) => {
+        const epicId = epicsByBacklogItemId.get(where.originatingBacklogItemId);
+        return epicId ? { epicId } : null;
+      }),
+    },
     $transaction: vi.fn(async (fn) => fn(tx)) as unknown as ApproveDecompositionDb["$transaction"],
   };
 
-  return { db, writes };
+  return { db, writes, epicsByBacklogItemId };
 }
 
 function makeBuild(overrides: Partial<FakeBuild> = {}): FakeBuild {
@@ -312,6 +347,140 @@ describe("approveDecomposition — eligibility checks", () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("unreachable");
     expect(result.code).toBe("candidate-validation-failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BI-1D0CA7A0 — one originating BacklogItem, at most one decomposition Epic.
+//
+// Live symptom: the daily governed tee-up re-promoted a BacklogItem whose first
+// build had already been decomposed (supersession clears
+// BacklogItem.activeBuildId, so the item looks promotable again). The duplicate
+// build parked at the decompose-required gate, and EVERY portal restart/swap
+// re-ran the resume path -> autoResolveDecomposeRequiredGate ->
+// approveDecomposition -> epic.create, which raised an unhandled
+// `prisma:error ... Unique constraint failed on the fields:
+// (originatingBacklogItemId)` in the portal log.
+// ---------------------------------------------------------------------------
+describe("approveDecomposition — backlog item already decomposed (BI-1D0CA7A0)", () => {
+  it("returns a typed result (no throw) when an Epic already owns the backlog item", async () => {
+    const { db, writes } = makeFakeDb(
+      makeBuild(),
+      new Map([["bi-row-001", "EP-ALREADY"]]),
+    );
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("backlog-item-already-decomposed");
+    expect(result.existingEpicId).toBe("EP-ALREADY");
+    expect(result.error).toContain("EP-ALREADY");
+    // Nothing was written — the precondition short-circuits before the tx.
+    expect(writes.epicCreates).toHaveLength(0);
+    expect(writes.childBuildCreates).toHaveLength(0);
+    expect(writes.buildUpdates).toHaveLength(0);
+  });
+
+  it("re-running the resume path against the same BacklogItem does not throw and leaves ONE Epic", async () => {
+    // Same db (and therefore the same unique index) across both attempts, exactly
+    // like two portal restarts hitting the same live row.
+    const { db, writes } = makeFakeDb(makeBuild());
+
+    const first = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+    expect(first.ok).toBe(true);
+
+    const second = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+
+    expect(second.ok).toBe(false);
+    if (second.ok) throw new Error("unreachable");
+    expect(second.code).toBe("backlog-item-already-decomposed");
+    // The load-bearing assertion: exactly one Epic row for the backlog item.
+    expect(writes.epicCreates).toHaveLength(1);
+  });
+
+  it("maps a write-time P2002 race to the same typed result instead of throwing", async () => {
+    // Precondition read sees nothing (empty seed), but the INSERT loses the race —
+    // the concurrent-resume case the read alone cannot cover.
+    const { db, epicsByBacklogItemId } = makeFakeDb(makeBuild());
+    const epicFindUnique = db.epic.findUnique as unknown as ReturnType<typeof vi.fn>;
+    epicFindUnique.mockImplementationOnce(async () => {
+      // Another approve commits between our read and our write.
+      epicsByBacklogItemId.set("bi-row-001", "EP-RACER");
+      return null;
+    });
+
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.code).toBe("backlog-item-already-decomposed");
+    expect(result.existingEpicId).toBeNull();
+  });
+
+  it("still decomposes a build with no originating BacklogItem (nothing to conflict with)", async () => {
+    const { db, writes } = makeFakeDb(
+      makeBuild({ originatingBacklogItemId: null, originator: null }),
+      new Map([["bi-row-001", "EP-ALREADY"]]),
+    );
+    const result = await approveDecomposition({
+      buildId: "FB-PARENT",
+      candidate: makeCandidate(),
+      userId: "user-1",
+      db,
+      now: fixedNow,
+      idGen: makeIdGen(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(writes.epicCreates).toHaveLength(1);
+    expect(writes.epicCreates[0]!.originatingBacklogItemId).toBeUndefined();
+  });
+
+  it("rethrows unrelated failures rather than swallowing them as a duplicate", async () => {
+    const { db } = makeFakeDb(makeBuild());
+    const txCreate = vi.fn(async () => {
+      throw new Error("connection reset");
+    });
+    (db.$transaction as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(txCreate);
+
+    await expect(
+      approveDecomposition({
+        buildId: "FB-PARENT",
+        candidate: makeCandidate(),
+        userId: "user-1",
+        db,
+        now: fixedNow,
+        idGen: makeIdGen(),
+      }),
+    ).rejects.toThrow("connection reset");
   });
 });
 

--- a/apps/web/lib/build/approve-decomposition.ts
+++ b/apps/web/lib/build/approve-decomposition.ts
@@ -94,6 +94,12 @@ export type ApproveDecompositionResult =
       ok: false;
       error: string;
       code: ApproveDecompositionErrorCode;
+      /**
+       * For `backlog-item-already-decomposed`: the semantic id of the Epic that
+       * already owns this backlog item, when it could be read. Null when the
+       * conflict surfaced as a write-time race rather than a precondition.
+       */
+      existingEpicId?: string | null;
     };
 
 /**
@@ -119,6 +125,7 @@ export type ApproveDecompositionErrorCode =
   | "build-missing-design-doc"
   | "build-design-review-not-passed"
   | "build-already-decomposed"
+  | "backlog-item-already-decomposed"
   | "candidate-validation-failed"
   | "invariant-violation";
 
@@ -127,6 +134,17 @@ export type ApproveDecompositionErrorCode =
 export type ApproveDecompositionDb = {
   featureBuild: {
     findUnique: typeof prisma.featureBuild.findUnique;
+  };
+  /**
+   * Reads the at-most-one Epic already anchored to a BacklogItem.
+   * Epic.originatingBacklogItemId is `@unique` (spec Q5 hybrid FK), so this is a
+   * genuine findUnique — see the one-epic-per-backlog-item precondition below.
+   */
+  epic: {
+    findUnique: (args: {
+      where: { originatingBacklogItemId: string };
+      select: { epicId: true };
+    }) => Promise<{ epicId: string } | null>;
   };
   $transaction: <T>(
     fn: (tx: TxShape) => Promise<T>,
@@ -157,6 +175,52 @@ export type TxShape = {
 };
 
 // ---------------------------------------------------------------------------
+// One-epic-per-backlog-item conflict (BI-1D0CA7A0)
+// ---------------------------------------------------------------------------
+
+/**
+ * True for the Prisma unique-constraint error raised when a second Epic is
+ * inserted for a BacklogItem that already has one
+ * (`Epic.originatingBacklogItemId @unique`). Duck-typed rather than
+ * `instanceof PrismaClientKnownRequestError` so this module stays unit-testable
+ * with a fake db and free of a Prisma runtime import.
+ *
+ * `meta.target` is the field-name array on most connectors and the constraint
+ * name (`Epic_originatingBacklogItemId_key`) on some, so match on substring.
+ */
+function isEpicBacklogItemUniqueConflict(err: unknown): boolean {
+  const e = err as { code?: unknown; meta?: { target?: unknown } } | null | undefined;
+  if (!e || e.code !== "P2002") return false;
+  const target = e.meta?.target;
+  const fields = Array.isArray(target)
+    ? target.map((t) => String(t))
+    : typeof target === "string"
+      ? [target]
+      : [];
+  return fields.some((field) => field.includes("originatingBacklogItemId"));
+}
+
+/**
+ * The typed, NON-THROWING result for "this backlog item is already decomposed".
+ * Callers (autoResolveDecomposeRequiredGate, the MCP tool, the operator UI) get
+ * a code they can branch on instead of a raw P2002.
+ */
+function backlogItemAlreadyDecomposed(
+  itemLabel: string,
+  existingEpicId: string | null,
+): ApproveDecompositionResult {
+  return {
+    ok: false,
+    code: "backlog-item-already-decomposed",
+    existingEpicId,
+    error:
+      `Backlog item ${itemLabel} is already decomposed into Epic ${existingEpicId ?? "(unknown)"}. ` +
+      `Epic.originatingBacklogItemId is unique — a backlog item has at most one decomposition epic, ` +
+      `and that epic's child builds already carry this work. Decompose this build no further.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 
@@ -166,6 +230,11 @@ export async function approveDecomposition(
   const now = args.now ?? (() => new Date());
   const db: ApproveDecompositionDb = args.db ?? {
     featureBuild: { findUnique: prisma.featureBuild.findUnique.bind(prisma.featureBuild) },
+    epic: {
+      findUnique: prisma.epic.findUnique.bind(
+        prisma.epic,
+      ) as unknown as ApproveDecompositionDb["epic"]["findUnique"],
+    },
     $transaction: ((fn) => prisma.$transaction(fn as never)) as ApproveDecompositionDb["$transaction"],
   };
   const idGen = args.idGen ?? {
@@ -238,6 +307,38 @@ export async function approveDecomposition(
       };
     }
     throw err;
+  }
+
+  // 3b. One originating BacklogItem → at most one decomposition Epic (BI-1D0CA7A0).
+  //
+  // Epic.originatingBacklogItemId is `@unique` (spec Q5 hybrid FK). A BI whose
+  // first build was decomposed keeps that link forever, but supersession clears
+  // BacklogItem.activeBuildId — so the daily governed tee-up happily re-promotes
+  // the SAME item into a second top-level build, which design-reviews to the same
+  // `decompose-required` verdict and arrives right here.
+  //
+  // Before this guard the epic INSERT below raised a raw P2002 that escaped
+  // approveDecomposition -> autoResolveDecomposeRequiredGate (skipping its own
+  // monolithic-override fallback entirely) -> the resume path's catch-all. Net
+  // effect on the live install: every portal restart/swap logged an unactionable
+  // `prisma:error ... Unique constraint failed on the fields:
+  // (originatingBacklogItemId)` — the exact channel operators scan after a
+  // self-upgrade — and the build made no progress either way.
+  //
+  // Detect it up front and return a typed result. Note this is a precondition,
+  // not a lock; the write-time backstop around the transaction below closes the
+  // check-then-act race.
+  if (build.originatingBacklogItemId) {
+    const existingEpic = await db.epic.findUnique({
+      where: { originatingBacklogItemId: build.originatingBacklogItemId },
+      select: { epicId: true },
+    });
+    if (existingEpic) {
+      return backlogItemAlreadyDecomposed(
+        build.originator?.itemId ?? build.originatingBacklogItemId,
+        existingEpic.epicId,
+      );
+    }
   }
 
   // 4. Candidate validation — pure, against the parent designDoc.
@@ -342,7 +443,7 @@ export async function approveDecomposition(
     })),
   };
 
-  const txResult = await db.$transaction(async (tx) => {
+  const runTransaction = () => db.$transaction(async (tx) => {
     if ("$queryRaw" in tx && "platformCapability" in tx && "runtimeCapabilityTransition" in tx) {
       await admitRuntimeGuardedWork(tx as never, "build-studio-active");
     }
@@ -545,6 +646,23 @@ export async function approveDecomposition(
       unblockedChildBuildIds,
     };
   });
+
+  // Write-time backstop for the precondition above (BI-1D0CA7A0): two resume
+  // ticks — or a resume racing the operator's Approve — can both pass the read
+  // and only one INSERT wins. Map that P2002 to the SAME typed result instead of
+  // letting it escape as a `prisma:error`. Any other failure still throws.
+  let txResult: Awaited<ReturnType<typeof runTransaction>>;
+  try {
+    txResult = await runTransaction();
+  } catch (err) {
+    if (isEpicBacklogItemUniqueConflict(err)) {
+      return backlogItemAlreadyDecomposed(
+        build.originator?.itemId ?? build.originatingBacklogItemId ?? args.buildId,
+        null,
+      );
+    }
+    throw err;
+  }
 
   // BI-E49DDE47: children land in plan with designDoc copied, but nothing
   // previously fired plan_dispatch — they sat "gone quiet" forever. Kick

--- a/apps/web/lib/build/auto-resolve-decompose-gate.test.ts
+++ b/apps/web/lib/build/auto-resolve-decompose-gate.test.ts
@@ -173,6 +173,36 @@ describe("autoResolveDecomposeRequiredGate", () => {
     expect(result).toMatchObject({ action: "overridden", reason: "approve-failed" });
   });
 
+  // BI-1D0CA7A0 — the one approval failure that must NOT become a monolithic
+  // override. The backlog item's existing Epic is already delivering this work
+  // through its children; overriding would build the feature a second time.
+  it("stops at already-decomposed instead of overriding when the BI already owns an Epic", async () => {
+    const deps = makeDeps({
+      approveDecomposition: vi.fn(async () => ({
+        ok: false as const,
+        code: "backlog-item-already-decomposed" as const,
+        existingEpicId: "EP-5F45F138",
+        error: "Backlog item BI-C47A568C is already decomposed into Epic EP-5F45F138.",
+      })),
+    });
+    const result = await autoResolveDecomposeRequiredGate({
+      build: {
+        buildId: "FB-DUPLICATE",
+        parentEpicId: null,
+        originatingBacklogItemId: "bi-1",
+        designReview: reviewWith([candidate()]),
+      },
+      userId: "u",
+      governedBacklogEnabled: true,
+      deps,
+    });
+    expect(result).toMatchObject({
+      action: "already-decomposed",
+      existingEpicId: "EP-5F45F138",
+    });
+    expect(deps.recordDecompositionOverride).not.toHaveBeenCalled();
+  });
+
   it("auto-overrides a decomposed child without attempting decomposition", async () => {
     const deps = makeDeps();
     const result = await autoResolveDecomposeRequiredGate({

--- a/apps/web/lib/build/auto-resolve-decompose-gate.ts
+++ b/apps/web/lib/build/auto-resolve-decompose-gate.ts
@@ -33,7 +33,11 @@
 //   `park`, and the caller keeps the existing "wait for the operator" behavior.
 //
 // Contract: this module NEVER parks an eligible autopilot build. Every eligible
-// path returns `decomposed` or `overridden` so the pipeline keeps moving.
+// path returns `decomposed` or `overridden` so the pipeline keeps moving — with
+// one terminal exception (BI-1D0CA7A0): when the originating BacklogItem ALREADY
+// has a decomposition Epic, `already-decomposed` is returned. Moving that build
+// forward is not "keeping the pipeline moving", it is duplicating work the
+// existing epic's children are already delivering.
 
 import type { DecompositionCandidate } from "./decomposition-candidates";
 import type { ProposeDecompositionResult } from "./propose-decomposition";
@@ -86,6 +90,13 @@ export type AutoOverrideReason = "child" | "no-candidates" | "approve-failed";
 export type AutoResolveDecomposeResult =
   /** Not an autopilot build (or not governed) — caller keeps the park behavior. */
   | { action: "park" }
+  /**
+   * The originating BacklogItem is ALREADY decomposed into an Epic whose child
+   * builds carry this work (BI-1D0CA7A0). This build is a duplicate promotion —
+   * there is nothing to auto-resolve, and a monolithic override would rebuild
+   * work already in flight. Terminal: the caller stops re-attempting.
+   */
+  | { action: "already-decomposed"; existingEpicId: string | null; detail: string }
   /** Superseded into an Epic + child builds; parent is no longer live. */
   | {
       action: "decomposed";
@@ -193,6 +204,19 @@ export async function autoResolveDecomposeRequiredGate(
       epicId: approved.epicId,
       childBuildIds: approved.childBuildIds,
       candidateId: chosen.candidateId,
+    };
+  }
+
+  // The BI already has a decomposition Epic (BI-1D0CA7A0). This is the ONE
+  // approval failure that must NOT fall through to a monolithic override: the
+  // work is already being delivered by that epic's children, so overriding would
+  // push a duplicate build through plan → build and ship the feature twice.
+  // Stop here — the pre-build age-out cap (BI-A009313E) retires the duplicate.
+  if (approved.code === "backlog-item-already-decomposed") {
+    return {
+      action: "already-decomposed",
+      existingEpicId: approved.existingEpicId ?? null,
+      detail: approved.error,
     };
   }
 

--- a/apps/web/lib/integrate/resume-pre-build-phase.test.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.test.ts
@@ -249,6 +249,46 @@ describe("resumePreBuildPhase (BI-9257CF19)", () => {
     expect(out).toMatchObject({ kind: "resumed", via: "autoResolveDecomposeRequiredGate" });
   });
 
+  // BI-1D0CA7A0 — the duplicate-promotion strand. Live symptom: two builds off
+  // the same BacklogItem (the tee-up re-promoted it after the first was
+  // superseded into an Epic) meant every restart/swap re-attempted decomposition
+  // and logged `prisma:error ... Unique constraint failed on the fields:
+  // (originatingBacklogItemId)`. Resume must report it and stop, NOT re-attempt
+  // and NOT fall through to ideate re-dispatch or a review re-run.
+  it("stops without re-attempting when the backlog item is already decomposed", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { problemStatement: "p" },
+      buildPlan: null,
+      designReview: {
+        decision: "pass",
+        sizeAssessment: { decision: "decompose-required" },
+        decompositionCandidates: { latest: [{ candidateId: "candidate-1", childScopes: [] }] },
+      },
+      originatingBacklogItemId: "bi-1",
+      parentEpicId: null,
+    });
+    platformDevConfigFindUniqueMock.mockResolvedValue({ governedBacklogEnabled: true });
+    autoResolveDecomposeMock.mockResolvedValue({
+      action: "already-decomposed",
+      existingEpicId: "EP-5F45F138",
+      detail: "Backlog item BI-C47A568C is already decomposed into Epic EP-5F45F138.",
+    });
+
+    const first = await resumePreBuildPhase({ buildId: "FB-DUP", phase: "ideate", userId: "uD" });
+    const second = await resumePreBuildPhase({ buildId: "FB-DUP", phase: "ideate", userId: "uD" });
+
+    for (const out of [first, second]) {
+      expect(out.kind).toBe("skipped");
+      expect(out).toMatchObject({
+        reason: expect.stringContaining("EP-5F45F138"),
+      });
+    }
+    // No expensive re-work on either pass: no ideate re-dispatch, no review
+    // re-run, no propose_build_decomposition.
+    expect(dispatchIdeateMock).not.toHaveBeenCalled();
+    expect(executeToolMock).not.toHaveBeenCalled();
+  });
+
   it("advances a parked governed-autopilot build after an auto-override (re-runs review, does not park)", async () => {
     findUniqueMock.mockResolvedValue({
       designDoc: { problemStatement: "p" },

--- a/apps/web/lib/integrate/resume-pre-build-phase.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.ts
@@ -310,6 +310,19 @@ export async function resumePreBuildPhase(params: {
               detail: `auto-decomposed into ${auto.childBuildIds.length} child build(s) under Epic ${auto.epicId}`,
             };
           }
+          if (auto.action === "already-decomposed") {
+            // Duplicate promotion of a BacklogItem whose decomposition Epic
+            // already exists (BI-1D0CA7A0). Re-attempting used to raise a raw
+            // P2002 here on EVERY restart/swap. Report it and stop; the pre-build
+            // age-out cap retires the duplicate build.
+            return {
+              kind: "skipped",
+              phase,
+              reason: `backlog item already decomposed into Epic ${
+                auto.existingEpicId ?? "(unknown)"
+              } — this build duplicates work its children already carry; not re-attempting decomposition.`,
+            };
+          }
           if (auto.action === "overridden") {
             // Monolithic override recorded — the gate no longer blocks. Fall
             // through to the normal review re-run below, which now advances

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -1335,6 +1335,19 @@ export async function executeTool(
               };
             }
 
+            if (auto.action === "already-decomposed") {
+              // Duplicate promotion: the BI already has a decomposition Epic
+              // whose children carry this work (BI-1D0CA7A0). Block the advance —
+              // never override to monolithic, which would ship it twice.
+              const epic = auto.existingEpicId ?? "(unknown)";
+              logBuildActivity(buildId, "phase:gate-blocked", `decompose-required gate fired, but the backlog item is already decomposed into Epic ${epic}; advance blocked as a duplicate promotion.`);
+              return {
+                success: true,
+                message: `Design review: ${review.decision}, but this build's backlog item is already decomposed into Epic ${epic}, whose child builds already carry the work. This build is a duplicate promotion — retire it rather than decomposing or overriding it.`,
+                data: { review, blocked: true, action: "duplicate_promotion", existingEpicId: auto.existingEpicId ?? null },
+              };
+            }
+
             if (auto.action === "park") {
               logBuildActivity(
                 buildId,

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -43,7 +43,7 @@ apps/web/lib/integrate/build-orchestrator.ts	1796
 apps/web/lib/integrate/sandbox/build-branch.ts	852
 apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp-tools-backlog.test.ts	874
-apps/web/lib/mcp-tools.ts	1910
+apps/web/lib/mcp-tools.ts	1923
 apps/web/lib/mcp/packs/backlog-pack.ts	1320
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	858
 apps/web/lib/mcp/packs/sandbox-pack.ts	920


### PR DESCRIPTION
## What

Every portal restart/swap emitted, twice:

```
prisma:error Invalid `prisma.epic.create()` invocation:
Unique constraint failed on the fields: (`originatingBacklogItemId`)
```

interleaved with the `[build-resume] ... stranded in <phase> phase after restart/swap — auto-resuming (BI-9257CF19)` lines. The run continued (`auto-resumed 13 pre-build-phase strand(s)`), so the error was caught by `resumePreBuildPhase`'s catch-all but never handled.

It matters because `prisma:error` is the channel operators scan after a self-upgrade. A known-benign recurring one trains people to ignore it, so a genuine post-swap DB failure gets missed.

## Root cause (confirmed against the live install)

`Epic.originatingBacklogItemId` is `@unique` (design-time decomposition spec Q5 hybrid FK), and `approveDecomposition` sets it. Decomposing a build supersedes the parent, which **clears `BacklogItem.activeBuildId`** — so the daily governed tee-up sees the item as promotable again and mints a **second** top-level build off the same BacklogItem. That duplicate design-reviews to the same `decompose-required` verdict and parks at the Phase-4b gate, so every restart re-ran:

`resumePreBuildPhase` → `autoResolveDecomposeRequiredGate` → `approveDecomposition` → `tx.epic.create()` → **P2002**

The raw throw escaped `autoResolveDecomposeRequiredGate` entirely, so even its own monolithic-override fallback never ran — the build made no progress either way.

Live evidence:

| duplicate build (ideate, parked) | epic that already owns the BI | backlog item |
| --- | --- | --- |
| FB-1425A9B2 (created 07-19 14:01 by the tee-up) | EP-5F45F138 (created 07-18 from FB-2FA4ECE0) | BI-C47A568C |
| FB-41407FEB | EP-93EB6D96 | BI-BAA09E24 |

Exactly 2 such rows — matching the 2 log occurrences per boot.

## Fix

- **`approveDecomposition`** — one-epic-per-backlog-item precondition returning a typed `backlog-item-already-decomposed` result (carrying the existing epic id), plus a **P2002 write-time backstop** so the check-then-act race between two resume ticks is idempotent rather than explosive. Unrelated failures still throw.
- **`autoResolveDecomposeRequiredGate`** — new terminal `already-decomposed` action instead of falling through to `approve-failed` → monolithic override. Overriding here would push a duplicate build through plan → build and ship work the existing epic's children are already delivering. The module's never-park contract is amended for this one case; the 7-day pre-build age-out (BI-A009313E) retires the duplicate.
- **`resume-pre-build-phase.ts` / `mcp-tools.ts`** — report and stop, naming the epic.

## Tests

The fake db now **enforces the unique index** (`epic.create` throws a Prisma-shaped P2002 for a repeat backlog item), so these fail without the guard:

- re-running the resume path twice against the same BacklogItem does not throw and leaves exactly **one** Epic row;
- the write-time race maps to the same typed result;
- a build with no originating BacklogItem still decomposes;
- unrelated tx failures still propagate;
- the gate returns `already-decomposed` and does **not** record a monolithic override;
- resume reports `skipped` on both passes with no ideate re-dispatch and no review re-run.

63 tests pass across the three affected suites; 1807 pass across `lib/build` + `lib/integrate`. Local typecheck is source-only-worktree limited (deps junctioned from the root clone, so `next` does not resolve) — zero errors in any changed file; CI is the gate.

## Notes

- Unrelated to the Next.js 16.2.11 bump in the same deploy; this is pre-existing and reproduces on any restart.
- Module-size baseline: surgical single-line bump for `apps/web/lib/mcp-tools.ts` (1910 → 1923); rationale in the commit body.
- **Follow-up (separate item):** the upstream duplicate promotion itself — the governed tee-up should not re-promote a BacklogItem whose `activeEpicId` was set by a prior decomposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
