### PR TITLE
fix(build-studio): stop the governed tee-up re-promoting a decomposed backlog item (BI-1D0CA7A0)

### DIFF
--- a/apps/web/lib/governed-backlog-tee-up.test.ts
+++ b/apps/web/lib/governed-backlog-tee-up.test.ts
@@ -125,6 +125,7 @@ describe("governed backlog tee-up", () => {
           triageOutcome: "build",
           effortSize: "medium",
           activeBuildId: null,
+          activeEpicId: null,
           digitalProductId: null,
           epicId: null,
           createdAt: new Date("2026-04-24T12:00:00.000Z"),
@@ -139,6 +140,7 @@ describe("governed backlog tee-up", () => {
           triageOutcome: "build",
           effortSize: "large",
           activeBuildId: null,
+          activeEpicId: null,
           digitalProductId: null,
           epicId: "epic-1",
           createdAt: new Date("2026-04-24T13:00:00.000Z"),
@@ -153,6 +155,7 @@ describe("governed backlog tee-up", () => {
           triageOutcome: "build",
           effortSize: "small",
           activeBuildId: null,
+          activeEpicId: null,
           digitalProductId: null,
           epicId: "epic-2",
           createdAt: new Date("2026-04-24T11:00:00.000Z"),
@@ -167,6 +170,7 @@ describe("governed backlog tee-up", () => {
           triageOutcome: "build",
           effortSize: "xlarge",
           activeBuildId: null,
+          activeEpicId: null,
           digitalProductId: null,
           epicId: "epic-3",
           createdAt: new Date("2026-04-24T10:00:00.000Z"),
@@ -181,20 +185,43 @@ describe("governed backlog tee-up", () => {
           triageOutcome: "build",
           effortSize: "medium",
           activeBuildId: "build-row-1",
+          activeEpicId: null,
           digitalProductId: null,
           epicId: null,
           createdAt: new Date("2026-04-24T09:00:00.000Z"),
           epic: null,
         },
+        {
+          // BI-1D0CA7A0: a prior build for this item was decomposed, so its
+          // activeEpicId points at a live Epic whose children carry the work.
+          // Re-promoting it would mint the duplicate build that collides on
+          // Epic.originatingBacklogItemId — it MUST be excluded even though its
+          // activeBuildId is null and it is otherwise the oldest candidate.
+          id: "already-decomposed",
+          itemId: "BI-DECOMPOSED",
+          title: "Already decomposed",
+          body: null,
+          status: "open",
+          triageOutcome: "build",
+          effortSize: "medium",
+          activeBuildId: null,
+          activeEpicId: "epic-decomposed-1",
+          digitalProductId: null,
+          epicId: "epic-4",
+          createdAt: new Date("2026-04-24T08:00:00.000Z"),
+          epic: { status: "open" },
+        },
       ],
       3,
     );
 
+    // BI-DECOMPOSED is excluded despite being the oldest and otherwise eligible.
     expect(selected.map((item) => item.itemId)).toEqual([
       "BI-EPIC-OLDER",
       "BI-EPIC-NEWER",
       "BI-BOOT-OLDER",
     ]);
+    expect(selected.map((item) => item.itemId)).not.toContain("BI-DECOMPOSED");
   });
 
   it("creates draft builds for the selected items and auto-approves them under governed flow (BI-52022707 axis D)", async () => {

--- a/apps/web/lib/governed-backlog-tee-up.ts
+++ b/apps/web/lib/governed-backlog-tee-up.ts
@@ -114,6 +114,13 @@ export type GovernedBacklogTeeUpCandidate = {
   triageOutcome: string | null;
   effortSize: string | null;
   activeBuildId: string | null;
+  /**
+   * Set to the decomposition Epic when a prior build for this item was
+   * decomposed (approve-decomposition swaps activeBuildId → activeEpicId). Its
+   * child builds already carry the work, so the item must NOT be re-promoted.
+   * Distinct from `epicId`, which is only the grouping epic. See BI-1D0CA7A0.
+   */
+  activeEpicId: string | null;
   digitalProductId: string | null;
   epicId: string | null;
   createdAt: Date;
@@ -215,6 +222,13 @@ function isEligibleCandidate(item: GovernedBacklogTeeUpCandidate): boolean {
     item.status === "open"
     && item.triageOutcome === "build"
     && item.activeBuildId == null
+    // Do not re-promote an item whose prior build was decomposed: its
+    // activeEpicId points at a live Epic whose child builds already deliver the
+    // work. Re-promoting mints a duplicate build that parks at the
+    // decompose-required gate and collides on Epic.originatingBacklogItemId,
+    // spamming a restart-path prisma:error (BI-1D0CA7A0). This is the generator
+    // of that duplicate; the approve-decomposition guard is the safety net.
+    && item.activeEpicId == null
     && item.effortSize != null
     && ELIGIBLE_EFFORT_SIZES.has(item.effortSize)
   );
@@ -592,6 +606,8 @@ export async function runGovernedBacklogTeeUp(input: {
       triageOutcome: "build",
       effortSize: { in: [...ELIGIBLE_EFFORT_SIZES] },
       activeBuildId: null,
+      // Exclude items already being delivered by a decomposition Epic (BI-1D0CA7A0).
+      activeEpicId: null,
     },
     orderBy: { createdAt: "asc" },
     select: {
@@ -603,6 +619,7 @@ export async function runGovernedBacklogTeeUp(input: {
       triageOutcome: true,
       effortSize: true,
       activeBuildId: true,
+      activeEpicId: true,
       digitalProductId: true,
       epicId: true,
       createdAt: true,


### PR DESCRIPTION
## What

Follow-up to #3455, which made the duplicate promotion *safe*. This removes the *generator* of that duplicate.

When a build is decomposed, `approve-decomposition` swaps the backlog item's active link: `activeBuildId → null`, `activeEpicId → the new decomposition Epic` (whose child builds now carry the work). The daily governed tee-up's eligibility filter only excluded items with a live `activeBuildId`, so a decomposed item looked promotable again and got re-minted into a **second** top-level build — which parked at the decompose-required gate and collided on `Epic.originatingBacklogItemId` on every restart (the `prisma:error` #3455 addressed).

## Fix

Filter on `activeEpicId` too, at both:
- the query `where`-clause (primary — items with a live decomposition epic never enter the candidate set), and
- `isEligibleCandidate` (the in-memory backstop that other callers and the selector tests use).

`activeEpicId` — **not** `epicId` — is the right discriminator. `epicId` is only the grouping epic; `activeEpicId` is set specifically to the decomposition epic. Verified against the two live offenders:

| backlog item | `activeEpicId` (decomposition) | `epicId` (grouping — unrelated) |
| --- | --- | --- |
| BI-C47A568C | EP-5F45F138 | EP-PARTNER-CHANNEL |
| BI-BAA09E24 | EP-93EB6D96 | EP-REDUCTION-GEAR-ARCH |

So this filter would have prevented both duplicates while leaving normally-grouped items eligible.

## Tests

`selectGovernedBacklogTeeUpCandidates` excludes an item whose `activeEpicId` is set even when it is the oldest, otherwise-eligible candidate. Verified functionally (the pure selector ran green in isolation); the full suite is CI-gated because it imports `next/cache`, which the source-only worktree cannot resolve.

## Composition

The two guards now compose defensively:
- **this PR** — the tee-up no longer creates the duplicate;
- **#3455** — `approveDecomposition`'s typed `already-decomposed` result is the safety net if one ever slips through another path.

The two existing duplicate builds (FB-1425A9B2, FB-41407FEB) are retired automatically by the 7-day pre-build age-out (BI-A009313E) once #3455 is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
