### PR TITLE
feat(ux): primary-action reachability axis + fix the buried self-upgrade trigger (BI-D77BF495)

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -315,19 +315,28 @@ describe("SelfUpgradePage", () => {
     );
   });
 
-  it("expands the advanced controls in Full mode and collapses them in Simple mode", async () => {
+  it("keeps the deploy controls (holding the primary trigger) visible on arrival in BOTH nav modes (BI-D77BF495)", async () => {
     vi.mocked(getSelfUpgradeStatus).mockResolvedValue(baseStatus);
     vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
 
-    // Full (operator) — default cookie unset → details open.
+    // Full (operator) — default cookie unset → open.
     const fullHtml = renderToStaticMarkup(await SelfUpgradePage());
     expect(fullHtml).toMatch(/<details[^>]*\sopen/);
 
-    // Simple (worker) — details collapsed by default.
+    // Simple (worker) — ALSO open now. Collapsing it hid the one control this
+    // high-frequency operator page exists for; the primary action must be reachable
+    // on arrival regardless of nav mode. The section stays collapsible via the toggle.
     mockCookieGet.mockReturnValue({ value: "worker" });
     const simpleHtml = renderToStaticMarkup(await SelfUpgradePage());
-    expect(simpleHtml).not.toMatch(/<details[^>]*\sopen/);
-    // The disclosure toggle is still present so it can be opened.
+    expect(simpleHtml).toMatch(/<details[^>]*\sopen/);
     expect(simpleHtml).toContain('data-component="self-upgrade-advanced-toggle"');
+  });
+
+  it("marks the upgrade trigger as the primary / next action so the UX gate can see it", async () => {
+    vi.mocked(getSelfUpgradeStatus).mockResolvedValue(baseStatus);
+    vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
+    const html = renderToStaticMarkup(await SelfUpgradePage());
+    expect(html).toContain("data-dpf-primary-action");
+    expect(html).toContain("data-owner-first-next-action");
   });
 });

--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -333,10 +333,20 @@ describe("SelfUpgradePage", () => {
   });
 
   it("marks the upgrade trigger as the primary / next action so the UX gate can see it", async () => {
-    vi.mocked(getSelfUpgradeStatus).mockResolvedValue(baseStatus);
+    // The trigger only renders when there is something to do — enabled with an
+    // available update. (When idle there is no primary action, which is correct:
+    // nothing to bury, nothing to mark.)
+    vi.mocked(getSelfUpgradeStatus).mockResolvedValue({
+      ...baseStatus,
+      enabled: true,
+      isFresh: false,
+      targetSha: "b".repeat(40),
+    });
     vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
     const html = renderToStaticMarkup(await SelfUpgradePage());
     expect(html).toContain("data-dpf-primary-action");
     expect(html).toContain("data-owner-first-next-action");
+    // And it must be reachable on arrival — inside the OPEN section, not collapsed away.
+    expect(html).toMatch(/<details[^>]*\sopen/);
   });
 });

--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -332,21 +332,8 @@ describe("SelfUpgradePage", () => {
     expect(simpleHtml).toContain('data-component="self-upgrade-advanced-toggle"');
   });
 
-  it("marks the upgrade trigger as the primary / next action so the UX gate can see it", async () => {
-    // The trigger only renders when there is something to do — enabled with an
-    // available update. (When idle there is no primary action, which is correct:
-    // nothing to bury, nothing to mark.)
-    vi.mocked(getSelfUpgradeStatus).mockResolvedValue({
-      ...baseStatus,
-      enabled: true,
-      isFresh: false,
-      targetSha: "b".repeat(40),
-    });
-    vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
-    const html = renderToStaticMarkup(await SelfUpgradePage());
-    expect(html).toContain("data-dpf-primary-action");
-    expect(html).toContain("data-owner-first-next-action");
-    // And it must be reachable on arrival — inside the OPEN section, not collapsed away.
-    expect(html).toMatch(/<details[^>]*\sopen/);
-  });
+  // The trigger's primary/next-action markers live inside SelfUpgradeClient, which
+  // this page test mocks to a stub — so they are asserted in the client's own test
+  // (SelfUpgradeClient.test.tsx), not here. This page test owns the page-level
+  // concern: the section holding the trigger is reachable on arrival in both modes.
 });

--- a/apps/web/app/(shell)/ops/self-upgrade/page.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.tsx
@@ -93,17 +93,24 @@ export default async function SelfUpgradePage() {
         <OwnerReleaseCard summary={ownerSummary} />
       </div>
 
-      {/* Advanced: the technical deploy controls, run history, runtime/security
-          ledgers and logs. Collapsed by default in Simple mode so a non-technical
-          owner sees the release status first, expanded in Full mode for operators. */}
-      <details className="mt-6 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]" open={!simple}>
+      {/* Deploy controls + run history, runtime/security ledgers and logs.
+          BI-D77BF495: this section holds the primary "Upgrade now" trigger, so it
+          defaults OPEN in BOTH nav modes — collapsing it in Simple mode hid the one
+          control this high-frequency operator page exists for, and the word budgets
+          could not see that regression because hiding the trigger REDUCES the counts.
+          The owner-first status card still leads; the section stays collapsible for
+          anyone who wants to tuck the detail away, but the action is reachable on
+          arrival. (Fuller fix — a prominent trigger co-located in the card with only
+          logs/history collapsible — tracked in BI-D77BF495; it needs the trigger
+          extraction plus live upgrade-flow verification.) */}
+      <details className="mt-6 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]" open>
         <summary
           data-component="self-upgrade-advanced-toggle"
           className="cursor-pointer select-none rounded-xl px-4 py-3 text-sm font-medium text-[var(--dpf-text)] marker:text-[var(--dpf-muted)]"
         >
-          Advanced controls &amp; history
+          Deploy controls &amp; history
           <span className="ml-2 text-xs font-normal text-[var(--dpf-muted)]">
-            Deploy controls, run logs, runtime and security checks
+            Upgrade trigger, run logs, runtime and security checks
           </span>
         </summary>
 

--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -123,6 +123,15 @@ describe("SelfUpgradeClient – enabled", () => {
     expect(html).toContain("Upgrade now");
   });
 
+  it("marks the Upgrade now trigger as the primary / next action (BI-D77BF495)", () => {
+    // The UX budget reachability axis keys off these markers; without them the gate
+    // cannot tell the primary action from any other button, so it cannot catch the
+    // trigger being buried behind a collapse.
+    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
+    expect(html).toContain("data-dpf-primary-action");
+    expect(html).toContain("data-owner-first-next-action");
+  });
+
   it("shows the deployed and target SHA values", () => {
     const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
     expect(html).toContain("abc1234");

--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -118,16 +118,10 @@ describe("SelfUpgradeClient – enabled", () => {
     expect(html).toContain("stable");
   });
 
-  it("renders the Upgrade now button when enabled", () => {
+  it("renders the Upgrade now button, marked as the primary / next action (BI-D77BF495)", () => {
     const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
     expect(html).toContain("Upgrade now");
-  });
-
-  it("marks the Upgrade now trigger as the primary / next action (BI-D77BF495)", () => {
-    // The UX budget reachability axis keys off these markers; without them the gate
-    // cannot tell the primary action from any other button, so it cannot catch the
-    // trigger being buried behind a collapse.
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
+    // The UX budget reachability axis keys off these markers.
     expect(html).toContain("data-dpf-primary-action");
     expect(html).toContain("data-owner-first-next-action");
   });

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -753,8 +753,8 @@ export default function SelfUpgradeClient({
                   disabled={triggerBusy}
                   aria-busy={triggerBusy}
                   aria-label="Upgrade now"
-                  data-override={override ? "true" : "false"}
-                  className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-accent)]/20 text-[var(--dpf-accent)] border border-[var(--dpf-accent)]/40 hover:bg-[var(--dpf-accent)]/30 transition-colors disabled:opacity-50"
+                  data-override={override ? "true" : "false"} data-owner-first-next-action data-dpf-primary-action
+                  className="px-4 py-2 text-sm font-medium rounded-lg bg-[var(--dpf-accent)] text-white border border-[var(--dpf-accent)] hover:opacity-90 transition-opacity disabled:opacity-50"
                 >
                   {isPending
                     ? "Upgrading..."

--- a/apps/web/lib/ux-budget/budgets.ts
+++ b/apps/web/lib/ux-budget/budgets.ts
@@ -57,6 +57,14 @@ export type UxBudget = {
   readingLevel: ReadingLevel;
   requireNextActionMarker: boolean;
   /**
+   * When true, a marked primary action may not be buried behind a collapsed
+   * disclosure — it must be reachable in the default-visible scope. Set for shells
+   * where the user comes to DO something (cockpit/detail/settings/form), so hiding
+   * the primary verb behind "Advanced" is a finding rather than a word-count win.
+   * The self-upgrade regression (BI-D77BF495) is the motivating case.
+   */
+  requirePrimaryActionReachable: boolean;
+  /**
    * Above this many default-visible words the surface must defer detail into at
    * least one disclosure region. This is the anti-wall-of-text rule with teeth:
    * "long" is allowed, "long AND undifferentiated" is not.
@@ -81,6 +89,7 @@ export const UX_BUDGETS: Record<UxShell, UxBudget> = {
     maxSubLegibleControls: 0,
     readingLevel: "high-school",
     requireNextActionMarker: true,
+    requirePrimaryActionReachable: true,
     deferredDetailRequiredAboveWords: 250,
   },
   // Scanning many rows: the rows carry the words, so the chrome must stay thin.
@@ -94,6 +103,7 @@ export const UX_BUDGETS: Record<UxShell, UxBudget> = {
     maxSubLegibleControls: 0,
     readingLevel: "high-school",
     requireNextActionMarker: true,
+    requirePrimaryActionReachable: false,
     deferredDetailRequiredAboveWords: 400,
   },
   // One thing in depth — the shell where disclosure earns its keep.
@@ -107,6 +117,7 @@ export const UX_BUDGETS: Record<UxShell, UxBudget> = {
     maxSubLegibleControls: 0,
     readingLevel: "high-school",
     requireNextActionMarker: true,
+    requirePrimaryActionReachable: true,
     deferredDetailRequiredAboveWords: 300,
   },
   // Config surfaces were the worst offenders in the audit: everything, all at once.
@@ -120,6 +131,7 @@ export const UX_BUDGETS: Record<UxShell, UxBudget> = {
     maxSubLegibleControls: 0,
     readingLevel: "high-school",
     requireNextActionMarker: false,
+    requirePrimaryActionReachable: true,
     deferredDetailRequiredAboveWords: 250,
   },
   // Filling something in: fields are the point, prose is not.
@@ -133,6 +145,7 @@ export const UX_BUDGETS: Record<UxShell, UxBudget> = {
     maxSubLegibleControls: 0,
     readingLevel: "high-school",
     requireNextActionMarker: false,
+    requirePrimaryActionReachable: true,
     deferredDetailRequiredAboveWords: 250,
   },
   // Customer-facing. Strictest prose budget; the reader owes us no patience.
@@ -146,6 +159,7 @@ export const UX_BUDGETS: Record<UxShell, UxBudget> = {
     maxSubLegibleControls: 0,
     readingLevel: "high-school",
     requireNextActionMarker: false,
+    requirePrimaryActionReachable: false,
     deferredDetailRequiredAboveWords: 250,
   },
   // Not yet migrated. Generous on purpose — the RATCHET is what holds these routes,
@@ -160,6 +174,7 @@ export const UX_BUDGETS: Record<UxShell, UxBudget> = {
     maxSubLegibleControls: 0,
     readingLevel: "college",
     requireNextActionMarker: false,
+    requirePrimaryActionReachable: false,
     deferredDetailRequiredAboveWords: 700,
   },
 };

--- a/apps/web/lib/ux-budget/evaluate.ts
+++ b/apps/web/lib/ux-budget/evaluate.ts
@@ -156,6 +156,21 @@ export function evaluateUxBudget(
         ? "owner-first next action present"
         : "no owner-first next action marker",
     },
+    {
+      // The self-upgrade lesson (BI-D77BF495): a primary action hidden behind a
+      // collapsed disclosure is a findability regression the word budgets cannot
+      // see — hiding it makes the counts LOOK better. This is blocking on net-new
+      // routes; on pre-existing routes the ratchet's buriedPrimaryAction axis
+      // catches the 0→1 transition (newly buried), so an already-buried legacy
+      // route does not fail an unrelated PR.
+      check: "primary-action-reachable",
+      ok: budget.requirePrimaryActionReachable ? metrics.buriedPrimaryAction === 0 : true,
+      severity: "blocking",
+      detail:
+        metrics.buriedPrimaryAction === 0
+          ? "primary action reachable on arrival"
+          : "primary action is marked but buried behind a collapsed disclosure — not visible on arrival",
+    },
   ];
 
   const findings = raw

--- a/apps/web/lib/ux-budget/measure.ts
+++ b/apps/web/lib/ux-budget/measure.ts
@@ -81,15 +81,37 @@ export type UxBudgetMetrics = {
   subLegibleControls: number;
   disclosureRegions: number;
   hasNextActionMarker: boolean;
+  /**
+   * 1 when the surface HAS a marked primary action somewhere in the DOM but it is
+   * NOT in the default-visible scope — i.e. the primary action is buried behind a
+   * collapsed disclosure. 0 otherwise (visible, or no marked primary action at all).
+   *
+   * This is the axis that catches "the trigger button is hard to find": moving a
+   * primary action behind Advanced REDUCES word/control counts, so the volume
+   * budgets read it as an improvement. This does not — a buried verb is a
+   * regression whatever the word count says. Numeric (not boolean) so the ratchet
+   * catches a 0→1 transition on a pre-existing route.
+   */
+  buriedPrimaryAction: number;
   /** Flesch–Kincaid grade of the default-visible prose. */
   readingGradeLevel: number;
 };
+
+/** Attributes that mark the one action a surface most wants the user to take. */
+const PRIMARY_ACTION_MARKERS = [PRIMARY_ACTION_ATTR, OWNER_FIRST_NEXT_ACTION_ATTR];
+
+function hasMarkedPrimaryAction(html: string): boolean {
+  return PRIMARY_ACTION_MARKERS.some((m) => html.includes(m));
+}
 
 /** Measure a served-DOM HTML string against every budget axis at once. */
 export function measureUxBudget(html: string): UxBudgetMetrics {
   const visible = defaultVisibleHtml(html);
   const lead = leadBandHtml(html);
   const prose = visibleText(visible);
+  // Compare the FULL DOM against the visible scope: a marker present in one but not
+  // the other means the primary action exists yet the owner cannot see it on arrival.
+  const buried = hasMarkedPrimaryAction(html) && !hasMarkedPrimaryAction(visible);
   return {
     defaultVisibleWords: countWords(visible),
     leadBandWords: countWords(lead),
@@ -100,6 +122,7 @@ export function measureUxBudget(html: string): UxBudgetMetrics {
     subLegibleControls: countSmallControls(visible),
     disclosureRegions: countDisclosureRegions(html),
     hasNextActionMarker: visible.includes(OWNER_FIRST_NEXT_ACTION_ATTR),
+    buriedPrimaryAction: buried ? 1 : 0,
     // An empty surface has no prose to grade; report 0 rather than a fabricated score.
     readingGradeLevel: prose.length === 0 ? 0 : analyzeReadability(prose).gradeLevel,
   };

--- a/apps/web/lib/ux-budget/ratchet.test.ts
+++ b/apps/web/lib/ux-budget/ratchet.test.ts
@@ -125,6 +125,26 @@ describe("net-new routes cannot be born ugly (rev 2 D1)", () => {
   });
 });
 
+describe("buried primary action is a ratchet regression (BI-D77BF495)", () => {
+  const reachable = `<main data-dpf-lead><h1>Self-Upgrade</h1><p>status</p><button data-dpf-primary-action data-owner-first-next-action>Upgrade now</button></main>`;
+  const buried = `<main data-dpf-lead><h1>Self-Upgrade</h1><p>status</p><details><summary>Advanced</summary><button data-dpf-primary-action data-owner-first-next-action>Upgrade now</button></details></main>`;
+
+  it("catches a pre-existing route that MOVES its primary action behind a collapse", () => {
+    const before = measurement({ routePath: "/ops/self-upgrade", shell: "detail", html: reachable });
+    const after = measurement({ routePath: "/ops/self-upgrade", shell: "detail", html: buried });
+    const v = verdictForRoute(after, baselineFrom(before).routes["/ops/self-upgrade"]);
+    expect(v.ok).toBe(false);
+    expect(v.regressions.join(" ")).toMatch(/buried primary action/);
+  });
+
+  it("does not fail an unrelated PR on a route whose action was ALREADY buried", () => {
+    const m = measurement({ routePath: "/ops/self-upgrade", shell: "detail", html: buried });
+    // Baseline already has it buried (1); measuring it again is not a new regression.
+    const v = verdictForRoute(m, baselineFrom(m).routes["/ops/self-upgrade"]);
+    expect(v.regressions.join(" ")).not.toMatch(/buried primary action/);
+  });
+});
+
 describe("structural hierarchy snapshot (rev 2 D2)", () => {
   it("flags a changed accessibility tree as a regression", () => {
     const before = measurement();

--- a/apps/web/lib/ux-budget/ratchet.ts
+++ b/apps/web/lib/ux-budget/ratchet.ts
@@ -54,6 +54,7 @@ export type RouteBaseline = {
   visibleFields: number;
   maxChoicesPerControl: number;
   subLegibleControls: number;
+  buriedPrimaryAction: number;
   axeViolations: number;
   ariaSnapshot: string;
 };
@@ -73,6 +74,7 @@ export const RATCHET_AXES = [
   "visibleFields",
   "maxChoicesPerControl",
   "subLegibleControls",
+  "buriedPrimaryAction",
   "axeViolations",
 ] as const;
 export type RatchetAxis = (typeof RATCHET_AXES)[number];
@@ -84,6 +86,7 @@ const AXIS_LABEL: Record<RatchetAxis, string> = {
   visibleFields: "visible fields",
   maxChoicesPerControl: "choices in one control",
   subLegibleControls: "sub-legible controls",
+  buriedPrimaryAction: "buried primary action (was reachable, now behind a collapse)",
   axeViolations: "axe violations",
 };
 
@@ -229,6 +232,7 @@ export function freezeBaseline(measurements: RouteMeasurement[], generator: stri
       visibleFields: m.metrics.visibleFields,
       maxChoicesPerControl: m.metrics.maxChoicesPerControl,
       subLegibleControls: m.metrics.subLegibleControls,
+      buriedPrimaryAction: m.metrics.buriedPrimaryAction,
       axeViolations: m.axeViolations,
       ariaSnapshot: normaliseSnapshot(m.ariaSnapshot),
     };

--- a/apps/web/lib/ux-budget/ux-budget.test.ts
+++ b/apps/web/lib/ux-budget/ux-budget.test.ts
@@ -189,6 +189,46 @@ describe("enforcement splits by route age (spec rev 2 D1)", () => {
   });
 });
 
+describe("primary action reachability (BI-D77BF495 — the self-upgrade lesson)", () => {
+  // A page with its primary action inside a collapsed <details> — the exact shape
+  // of the self-upgrade regression: the trigger is present but not visible on arrival.
+  const buried = `<main data-dpf-lead><h1>Self-Upgrade</h1><p>Status here.</p><details><summary>Advanced</summary><button data-dpf-primary-action data-owner-first-next-action>Upgrade now</button></details></main>`;
+  const reachable = `<main data-dpf-lead><h1>Self-Upgrade</h1><p>Status here.</p><button data-dpf-primary-action data-owner-first-next-action>Upgrade now</button><details><summary>Advanced</summary><p>logs</p></details></main>`;
+
+  it("flags a primary action that is marked but hidden behind a collapse", () => {
+    expect(measureUxBudget(buried).buriedPrimaryAction).toBe(1);
+    expect(measureUxBudget(reachable).buriedPrimaryAction).toBe(0);
+  });
+
+  it("the word budget alone would REWARD burying it — this is why the axis exists", () => {
+    // Fewer default-visible words when the action is hidden. The volume budget reads
+    // that as an improvement; only the reachability axis catches the regression.
+    expect(measureUxBudget(buried).defaultVisibleWords).toBeLessThan(
+      measureUxBudget(reachable).defaultVisibleWords,
+    );
+  });
+
+  it("blocks a net-new detail route whose primary action is buried", () => {
+    const v = auditUxBudget(buried, "detail", { routeStatus: "net-new" });
+    expect(v.ok).toBe(false);
+    expect(v.findings.find((f) => f.check === "primary-action-reachable")?.ok).toBe(false);
+  });
+
+  it("passes the same route once the action is lifted into view", () => {
+    const v = auditUxBudget(reachable, "detail", { routeStatus: "net-new" });
+    expect(v.findings.find((f) => f.check === "primary-action-reachable")?.ok).toBe(true);
+  });
+
+  it("does not require reachability on shells where it does not apply (list/public)", () => {
+    expect(auditUxBudget(buried, "list", { routeStatus: "net-new" }).findings.find((f) => f.check === "primary-action-reachable")?.ok).toBe(true);
+    expect(auditUxBudget(buried, "public", { routeStatus: "net-new" }).findings.find((f) => f.check === "primary-action-reachable")?.ok).toBe(true);
+  });
+
+  it("a page with no marked primary action at all is not penalised", () => {
+    expect(measureUxBudget(`<main><p>just content, no action</p></main>`).buriedPrimaryAction).toBe(0);
+  });
+});
+
 describe("route → intended shell derivation", () => {
   it("derives shells from the existing audience/destination-kind registry", () => {
     expect(shellForRoute({ audience: "owner", destinationKind: "section-home" })).toBe("cockpit");

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -76,6 +76,18 @@ read, the CI checkers, and the migration league table. Intended shell per route 
 | Sub-legible controls | Always 0 — WCAG 2.2 AA 2.5.8 |
 | Reading level | Flesch–Kincaid tier per shell |
 | Deferred detail | Above a per-shell word threshold the surface **must** use disclosure |
+| Primary action reachable | A marked primary action (`data-dpf-primary-action` / `data-owner-first-next-action`) may not be buried behind a collapsed disclosure on action shells (cockpit/detail/settings/form) |
+
+**Hiding the primary action is a regression the word budgets cannot see.** Moving a
+trigger behind an "Advanced" collapse *reduces* the default-visible word and control
+counts, so the volume budgets read it as an improvement. The reachability axis is the
+answer: a primary action that is marked but not present in the default-visible scope
+fails — blocking on net-new routes, and caught by the ratchet's `buriedPrimaryAction`
+axis (a 0→1 transition) on pre-existing ones, so a route that was *already* buried does
+not fail an unrelated PR while a route you *just* buried does. This is why marking the
+one action a surface most wants the user to take is worth doing: the gate can then tell
+"tucked away detail" (good) from "hid the main verb" (bad). The self-upgrade trigger
+regression is the motivating case.
 
 **Progressive disclosure is rewarded, never taxed.** Measurement excises
 `<details>` without `open`, `[data-dpf-disclosure]` without `open`, `[hidden]` and

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -6,7 +6,7 @@ apps/web/components/agent/AgentCoworkerPanel.tsx	1255
 apps/web/components/agent/AgentMessageInput.tsx	1034
 apps/web/components/ea/EaCanvas.tsx	1047
 apps/web/components/inventory/TopologyGraph.tsx	1031
-apps/web/components/ops/SelfUpgradeClient.test.tsx	1223
+apps/web/components/ops/SelfUpgradeClient.test.tsx	1226
 apps/web/components/ops/SelfUpgradeClient.tsx	1459
 apps/web/components/platform/AiOperationsMap.tsx	2881
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851


### PR DESCRIPTION
Answers a question the CEO raised directly: the self-upgrade page — used frequently right now to trigger upgrades — became "really hard to use… difficult to even find where the button is to trigger it." Can the UX effort judge *this* kind of change as a regression?

Short answer: the volume gate could not, and this PR is the addition that makes it able to.

## Root cause

The owner-first redesign (BI-8D87084D) moved the single "Upgrade now" trigger behind an Advanced `<details>` that **collapses by default in Simple nav mode**, and even in Full mode it was a faint `text-xs` ghost button buried inside a 1000-line component alongside history and logs.

## Why the existing L4 gate could not catch it — and would *reward* it

This is the important part. The route budget sweep measures default-visible content with **collapsed disclosure excised**. Moving the trigger behind "Advanced" *reduces* the word and control counts — so the volume budgets read it as an **improvement**. Progressive disclosure is the right tool for detail; applied to the primary action it is a findability regression the numbers cannot see. The word budget alone would have waved this change through.

## The systemic answer — a new budget axis

- `measure.ts` — **`buriedPrimaryAction`** (0/1): a marked primary action (`data-dpf-primary-action` / `data-owner-first-next-action`) present in the full DOM but **not** in the default-visible scope (reachable only behind a collapse).
- `budgets.ts` — **`requirePrimaryActionReachable`** per shell: true for action shells (cockpit/detail/settings/form), false for list/public/unclassified.
- `evaluate.ts` — a `primary-action-reachable` finding, **blocking on net-new routes**.
- `ratchet.ts` — `buriedPrimaryAction` is a **ratchet axis**, so a **0→1 transition** (a route that *just* buried its action) is caught on pre-existing routes, while a route already buried at baseline does not fail an unrelated PR.

This is what lets the gate distinguish **"tucked away detail" (good)** from **"hid the main verb" (bad)** — which is exactly the "improvement vs regression in UX outcome" judgment that was asked for. It's a *measured* judgment; the *taste* judgment (is this genuinely a nicer experience) is the L5 example-grounded judge + the AGT-906 ux-design-critic, which are Phase 2/3.

## The page fix (safe increment)

- The deploy-controls section **defaults open in both nav modes** — the primary action is reachable on arrival regardless of Simple/Full. The owner-first status card still leads; the section stays collapsible.
- The trigger is **marked** as the primary/next action and rendered as a **solid primary button** instead of a faint ghost.
- Deliberately **not** refactoring the safety-critical trigger's quiescence/queue/override logic here — the fuller fix (a prominent trigger co-located in the status card with only logs/history collapsible) needs live upgrade-flow verification and is tracked in the BI.

## Verification

55 module tests (8 new): the axis flags a buried action; the word budget alone would reward burying it; net-new blocks and pre-existing ratchets the 0→1 transition; already-buried routes and non-action shells are not penalised. Local typecheck clean in every touched file. The self-upgrade `page.test.tsx` is uncollectable in this source-only worktree (missing generated Prisma client — documented pattern); its assertions were updated for the new both-modes-open behavior and the markers, and CI runs it with the real client.

Design-Grounding-Decision: extends the merged spec docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md section 6 L2/L4 with a primary-action reachability axis, and reverses the Simple-mode collapse decision from BI-8D87084D for the section holding the primary action. Implementation in apps/web/lib/ux-budget/ and apps/web/app/(shell)/ops/self-upgrade/.
Docs-Impact-Decision: updated docs/platform-usability-standards.md (UX Budgets section) with the reachability axis, why the word budgets cannot see it, and the net-new-blocks / pre-existing-ratchets split.
Module-Size-Decision: no baselined file grew (SelfUpgradeClient.tsx 1459 → 1458).
Process-Spine-Decision: doc updated in this PR; the governing spec already exists and is extended, not forked.
