### PR TITLE
ci(ux): manual update-baseline path for the route sweep ratchet

### DIFF
--- a/.github/workflows/ux-route-sweep.yml
+++ b/.github/workflows/ux-route-sweep.yml
@@ -9,6 +9,12 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      update_baseline:
+        description: "Measure and emit a fresh route-budget-baseline.json artifact to arm the ratchet"
+        type: boolean
+        default: false
 
 concurrency:
   group: ux-route-sweep-${{ github.ref }}
@@ -135,7 +141,24 @@ jobs:
         run: pnpm exec tsx e2e/auth-only.ts
 
       - name: Run the sweep
+        if: ${{ github.event.inputs.update_baseline != 'true' }}
         run: pnpm --filter web ux:sweep
+
+      # Manual arming path: measure the running portal and emit the baseline as an
+      # artifact for a human to commit via PR. Deliberately NOT committed from CI —
+      # the baseline is a reviewed engineering act, and this job has read-only
+      # contents permission.
+      - name: Measure and emit a fresh baseline
+        if: ${{ github.event.inputs.update_baseline == 'true' }}
+        run: pnpm --filter web ux:sweep -- --update-baseline
+
+      - name: Upload the fresh baseline
+        if: ${{ github.event.inputs.update_baseline == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ux-route-budget-baseline
+          path: apps/web/lib/ux-budget/route-budget-baseline.json
+          if-no-files-found: error
 
       - name: Upload the budget report
         if: always()


### PR DESCRIPTION
Infrastructure to arm the route budget sweep (BI-BD81682A). The sweep ships `bootstrapped: false` — it reports without blocking until a **measured** baseline is committed. That baseline must be measured in the same environment the gate runs in, so producing it from a local install that lags main would bake in environment skew.

Adds a `workflow_dispatch` input `update_baseline`: when set, the job measures the running portal and uploads `route-budget-baseline.json` as an artifact for a human to commit via PR. Deliberately **not** committed from CI — the baseline is a reviewed engineering act and this job has read-only `contents` permission.

Validated: a dispatch run on this branch completed successfully and produced the artifact. The actual baseline will be frozen and committed in a follow-up, once the primary-action reachability axis (#3457) is also on main, so the frozen baseline includes every ratchet axis.

Design-Grounding-Decision: implements the arming mechanism for the merged spec docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md section 6 L4 / section 7.1. No new contract — a workflow_dispatch path on the existing apps/web/scripts/ux-route-sweep.ts.
Docs-Impact-Decision: the arming command is already documented in docs/platform-usability-standards.md (UX Budgets — one-command bootstrap); no doc change needed. This is a CI-plumbing change only.
Module-Size-Decision: workflow YAML only; no source module affected.
Process-Spine-Decision: CI-only change; the governing spec exists and is unchanged.
