### PR TITLE
fix(kernel): make embedding-provider failure loud + reconcile the wiki store (BI-512FBD20)

### DIFF
--- a/apps/web/lib/mcp-tools-principle-decide.test.ts
+++ b/apps/web/lib/mcp-tools-principle-decide.test.ts
@@ -3,7 +3,7 @@
 // Qdrant, runs the decide() math, and returns a complete contribution
 // ledger + flags + reasoning.
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockPrisma } = vi.hoisted(() => ({
   mockPrisma: {
@@ -16,6 +16,7 @@ const { mockPrisma } = vi.hoisted(() => ({
 const listPrinciplesByTier = vi.fn();
 const searchWikiPages = vi.fn();
 const generateEmbedding = vi.fn();
+const isEmbeddingAvailable = vi.fn();
 
 vi.mock("@dpf/db", () => ({
   prisma: mockPrisma,
@@ -35,6 +36,7 @@ vi.mock("@/lib/wiki/embeddings", () => ({
 
 vi.mock("@/lib/inference/embedding", () => ({
   generateEmbedding: (...args: unknown[]) => generateEmbedding(...args),
+  isEmbeddingAvailable: (...args: unknown[]) => isEmbeddingAvailable(...args),
 }));
 
 import { executeTool } from "./mcp-tools";
@@ -44,6 +46,15 @@ afterEach(() => {
   listPrinciplesByTier.mockReset();
   searchWikiPages.mockReset();
   generateEmbedding.mockReset();
+  isEmbeddingAvailable.mockReset();
+});
+
+// Provider healthy by default — these tests predate BI-512FBD20 and assert on
+// retrieval + scoring, not on the degradation path. The pack only probes
+// isEmbeddingAvailable when BOTH retrieval passes are empty; a default of true
+// keeps a genuinely-empty consult classified as "no match", not "provider down".
+beforeEach(() => {
+  isEmbeddingAvailable.mockResolvedValue(true);
 });
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────

--- a/apps/web/lib/mcp/packs/principle-decide-pack.test.ts
+++ b/apps/web/lib/mcp/packs/principle-decide-pack.test.ts
@@ -9,6 +9,7 @@ const wiki = vi.hoisted(() => ({
   decide: vi.fn(),
   principleMatchesRingScope: vi.fn(),
   generateEmbedding: vi.fn(),
+  isEmbeddingAvailable: vi.fn(),
 }));
 const decision = vi.hoisted(() => ({
   resolveDecisionCallerContext: vi.fn(),
@@ -57,6 +58,7 @@ vi.mock("@/lib/wiki/calling-ring-map", () => ({
 }));
 vi.mock("@/lib/inference/embedding", () => ({
   generateEmbedding: (...a: unknown[]) => wiki.generateEmbedding(...a),
+  isEmbeddingAvailable: (...a: unknown[]) => wiki.isEmbeddingAvailable(...a),
 }));
 vi.mock("@/lib/decision/caller-context", () => ({
   resolveDecisionCallerContext: (...a: unknown[]) => decision.resolveDecisionCallerContext(...a),
@@ -76,6 +78,8 @@ beforeEach(() => {
   db.organizationFindFirst.mockResolvedValue({ id: "org-1" });
   wiki.searchWikiPages.mockResolvedValue([]);
   wiki.generateEmbedding.mockResolvedValue(undefined);
+  // Provider healthy by default; the degradation tests flip this to false.
+  wiki.isEmbeddingAvailable.mockResolvedValue(true);
   wiki.principleMatchesRingScope.mockReturnValue(true);
   decision.resolveDecisionCallerContext.mockResolvedValue({
     governingProfileId: "prof-1",
@@ -320,6 +324,90 @@ describe("principle-decide pack — abstention is machine-checkable", () => {
         signalQuality: { usable: false, optionsWithFeatures: 0, optionCount: 1 },
       }),
     );
+  });
+});
+
+describe("principle-decide pack — retrieval degradation is loud (BI-512FBD20)", () => {
+  // The failure this pins: on 2026-07-22 the embedding provider was 404ing, so
+  // both semantic-retrieval passes came back empty and the consult ran on
+  // commandments alone — while reporting structuredCoverage "strong". A consult
+  // must never again imply full coverage when core/contextual retrieval was
+  // structurally impossible.
+
+  it("flags retrievalDegraded and refuses to be usable when the provider is down", async () => {
+    // Both passes empty (searchWikiPages default) AND the provider is down.
+    wiki.isEmbeddingAvailable.mockResolvedValue(false);
+    wiki.decide.mockReturnValue({
+      // Even if the commandment-only field produced a nominal winner, a
+      // degraded consult is not a verdict.
+      recommendation: { optionId: "a", composite: 2, margin: 1, confidence: "high" },
+      scores: [],
+      flags: { insufficientSignal: false, structuredCoverage: "strong", semanticFallbackRatio: 0 },
+      reasoning: "commandment-only winner",
+    });
+    const res = await principleDecidePack.handlers.principle_decide(
+      {
+        context: "x",
+        callingPopulation: "human",
+        options: [{ id: "a", description: "A", features: { reusability: 0.9 } }],
+      },
+      "u1",
+    );
+    expect(res.success).toBe(true); // advisory tool stays advisory
+    expect(res.message).toMatch(/^NO RECOMMENDATION — signalQuality\.retrievalDegraded=true/);
+    const sq = (res.data as { signalQuality: { usable: boolean; retrievalDegraded: boolean; advisory: string } })
+      .signalQuality;
+    expect(sq.retrievalDegraded).toBe(true);
+    expect(sq.usable).toBe(false);
+    expect(sq.advisory).toMatch(/EMBEDDING PROVIDER UNAVAILABLE/);
+    expect(sq.advisory).toMatch(/docker model pull ai\/nomic-embed-text-v1\.5/);
+  });
+
+  it("does NOT flag degradation when both passes are empty but the provider is up (a genuine no-match)", async () => {
+    wiki.isEmbeddingAvailable.mockResolvedValue(true);
+    wiki.decide.mockReturnValue({
+      recommendation: { optionId: "a", composite: 2, margin: 1, confidence: "high" },
+      scores: [],
+      flags: { insufficientSignal: false, structuredCoverage: "strong", semanticFallbackRatio: 0 },
+      reasoning: "ok",
+    });
+    const res = await principleDecidePack.handlers.principle_decide(
+      {
+        context: "x",
+        callingPopulation: "human",
+        options: [{ id: "a", description: "A", features: { reusability: 0.9 } }],
+      },
+      "u1",
+    );
+    expect(res.message).toMatch(/^Recommends a/);
+    const sq = (res.data as { signalQuality: { usable: boolean; retrievalDegraded: boolean } }).signalQuality;
+    expect(sq.retrievalDegraded).toBe(false);
+    expect(sq.usable).toBe(true);
+  });
+
+  it("does NOT probe the provider when retrieval actually returned principles", async () => {
+    // A populated core pass means retrieval ran — no reason to probe, and no
+    // degradation regardless of provider state.
+    wiki.searchWikiPages.mockResolvedValueOnce([
+      { pageId: "p1", title: "Some Core Principle", principleTier: "core", contentPreview: "direction" },
+    ]);
+    wiki.decide.mockReturnValue({
+      recommendation: { optionId: "a", composite: 2, margin: 1, confidence: "high" },
+      scores: [],
+      flags: { insufficientSignal: false, structuredCoverage: "strong", semanticFallbackRatio: 0 },
+      reasoning: "ok",
+    });
+    const res = await principleDecidePack.handlers.principle_decide(
+      {
+        context: "x",
+        callingPopulation: "human",
+        options: [{ id: "a", description: "A", features: { reusability: 0.9 } }],
+      },
+      "u1",
+    );
+    expect(wiki.isEmbeddingAvailable).not.toHaveBeenCalled();
+    const sq = (res.data as { signalQuality: { retrievalDegraded: boolean } }).signalQuality;
+    expect(sq.retrievalDegraded).toBe(false);
   });
 });
 

--- a/apps/web/lib/mcp/packs/principle-decide-pack.ts
+++ b/apps/web/lib/mcp/packs/principle-decide-pack.ts
@@ -185,7 +185,9 @@ async function principleDecide(
   // Used both for principle direction text (Qdrant-sourced principles
   // have empty dimensionVector) and for option descriptions when the
   // caller passes empty features. Pre-fix, both produced alignment=0.
-  const { generateEmbedding } = await import("@/lib/inference/embedding");
+  const { generateEmbedding, isEmbeddingAvailable } = await import(
+    "@/lib/inference/embedding"
+  );
 
   // Validate ringScope per the closed taxonomy registry. Unknown values
   // fail fast instead of silently degrading to universal — silent skip
@@ -499,24 +501,60 @@ async function principleDecide(
   const optionsWithFeatures = decisionOptions.filter(
     (o) => Object.keys(o.features ?? {}).length > 0,
   ).length;
-  const usable = !result.flags.insufficientSignal && result.recommendation !== null;
+
+  // BI-512FBD20. When BOTH semantic-retrieval passes come back empty, the
+  // consult ran on commandments alone — and that is indistinguishable, from
+  // the scores, between "no core/contextual principle was relevant" and "the
+  // embedding provider is down, so retrieval could not run at all". The second
+  // case is the silent kernel degradation this BI exists to kill: on
+  // 2026-07-22 the provider was 404ing and every consult applied ~18
+  // commandments out of 162 principles while flagging structuredCoverage
+  // "strong". So when both passes are empty we PROBE the provider once and, if
+  // it is unavailable, say so loudly — a consult must never again imply full
+  // coverage while core/contextual retrieval was structurally impossible.
+  // `make-silent-failures-observable`, applied to the kernel's own recall.
+  let retrievalDegraded = false;
+  if (core.length === 0 && contextual.length === 0) {
+    retrievalDegraded = !(await isEmbeddingAvailable());
+    if (retrievalDegraded) {
+      console.error(
+        "[principle_decide] retrieval degraded — embedding provider unavailable; " +
+          "consulted commandments only. Fix: docker model pull ai/nomic-embed-text-v1.5",
+      );
+    }
+  }
+
+  const usable =
+    !result.flags.insufficientSignal &&
+    result.recommendation !== null &&
+    !retrievalDegraded;
+  const degradedAdvisory =
+    "EMBEDDING PROVIDER UNAVAILABLE — only commandment-tier principles were consulted; " +
+    "core and contextual retrieval returned nothing because the query could not be embedded, " +
+    "NOT because no relevant principle exists. Treat this as an incomplete consult, not a verdict. " +
+    "Restore the provider (docker model pull ai/nomic-embed-text-v1.5), then re-run.";
   const signalQuality = {
     usable,
     insufficientSignal: result.flags.insufficientSignal,
+    retrievalDegraded,
     structuredCoverage: result.flags.structuredCoverage,
     semanticFallbackRatio: result.flags.semanticFallbackRatio,
     optionsWithFeatures,
     optionCount: decisionOptions.length,
     advisory: usable
       ? null
-      : optionsWithFeatures === 0
-        ? "NO OPTION SUPPLIED `features`, so every principle scored exactly 0. Governance commandments carry full dimension vectors, so scoring takes the structured path and the semantic fallback never fires for them. Re-call with a features map per option — this is not a neutral or tie result."
-        : "Signal was too weak to recommend. Widen per-option `features` coverage across the dimensions the applied principles actually weigh (see each contribution's missingDimensions), or decide by human judgement.",
+      : retrievalDegraded
+        ? degradedAdvisory
+        : optionsWithFeatures === 0
+          ? "NO OPTION SUPPLIED `features`, so every principle scored exactly 0. Governance commandments carry full dimension vectors, so scoring takes the structured path and the semantic fallback never fires for them. Re-call with a features map per option — this is not a neutral or tie result."
+          : "Signal was too weak to recommend. Widen per-option `features` coverage across the dimensions the applied principles actually weigh (see each contribution's missingDimensions), or decide by human judgement.",
   };
 
   const summary = usable
     ? `Recommends ${result.recommendation!.optionId} (confidence: ${result.recommendation!.confidence}, composite ${result.recommendation!.composite.toFixed(3)}; governing profile: ${governingProfile.governingProfileKind})`
-    : `NO RECOMMENDATION — signalQuality.usable=false. ${result.reasoning} ${signalQuality.advisory}`;
+    : retrievalDegraded
+      ? `NO RECOMMENDATION — signalQuality.retrievalDegraded=true. ${degradedAdvisory}`
+      : `NO RECOMMENDATION — signalQuality.usable=false. ${result.reasoning} ${signalQuality.advisory}`;
 
   // Persist the consult to the DecisionInteraction ledger so the decision
   // governance hub can audit that the gate is in use (per-tier log at

--- a/apps/web/lib/wiki/embeddings.ts
+++ b/apps/web/lib/wiki/embeddings.ts
@@ -223,7 +223,21 @@ export async function deleteWikiPageVector(pageId: string): Promise<void> {
  */
 export async function searchWikiPages(input: SearchWikiPagesInput): Promise<WikiSearchResult[]> {
   const vector = await generateEmbedding(input.query);
-  if (!vector) return [];
+  if (!vector) {
+    // BI-512FBD20. A null vector means the query could not be embedded — the
+    // provider is down or the model is missing. Returning [] here is
+    // indistinguishable, to the caller, from "no page matched", which is how
+    // wiki_query and principle_decide silently degraded to empty results while
+    // reporting themselves healthy. The [] contract stays (callers expect it),
+    // but the failure is now loud in the logs with a distinct, greppable marker
+    // and the exact fix. `make-silent-failures-observable`.
+    console.error(
+      "[searchWikiPages] embedding-provider-unavailable — query could not be " +
+        "embedded, returning no results (NOT an empty match). " +
+        "Fix: docker model pull ai/nomic-embed-text-v1.5",
+    );
+    return [];
+  }
 
   const limit = input.limit ?? 5;
   const scoreThreshold = input.scoreThreshold ?? 0.55;

--- a/apps/web/scripts/reembed-wiki-store.ts
+++ b/apps/web/scripts/reembed-wiki-store.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env tsx
+// scripts/reembed-wiki-store.ts
+// BI-512FBD20 — reconcile the wiki vector store against the published corpus.
+//
+// The runtime vector index (the `wiki-pages` collection) is best-effort: every
+// write path (`storeWikiPage`, `seedWikiKernel`) skips a page when the embedding
+// model is unavailable and returns without a record. So an install whose
+// embedding provider was down at seed/ingest time ends up with a PARTIALLY
+// embedded corpus — retrieval then silently searches a fraction of the kernel
+// and `principle_decide` consults only commandments while reporting itself
+// well-grounded. That was the live state on 2026-07-22: 87 of 162 published
+// principles embedded.
+//
+// This maintainer script re-embeds every published WikiPage through the same
+// `storeWikiPage` primitive the runtime uses (one definition of the payload) and
+// reports coverage as a NUMBER — embedded / published — not a boolean. It refuses
+// to run when the provider is down, naming the exact fix, so it can never itself
+// become another silent no-op.
+//
+// Usage (from apps/web, provider must be reachable):
+//   pnpm --filter web exec tsx scripts/reembed-wiki-store.ts            # re-embed everything
+//   pnpm --filter web exec tsx scripts/reembed-wiki-store.ts --dry-run  # report coverage only
+//   pnpm --filter web exec tsx scripts/reembed-wiki-store.ts --kind principle
+//
+// Env: DATABASE_URL and LLM_BASE_URL must resolve to the target install's
+// Postgres and embedding endpoint. Inside a container both are already set; from
+// the host, point LLM_BASE_URL at the mapped Docker Model Runner port
+// (e.g. http://localhost:12434/engines/v1) and DATABASE_URL at the mapped Postgres.
+//
+// Exit code: 0 when every published page is embedded after the run; 1 when any
+// page could not be embedded (fail loud — a partial re-embed is a failure, not a
+// success with a warning).
+
+import { prisma } from "@dpf/db";
+import { storeWikiPage } from "@/lib/wiki/embeddings";
+import { isEmbeddingAvailable } from "@/lib/inference/embedding";
+
+type Flags = { dryRun: boolean; kind: string | null };
+
+function parseArgs(argv: readonly string[]): Flags {
+  const flags: Flags = { dryRun: false, kind: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") flags.dryRun = true;
+    else if (a === "--kind") flags.kind = argv[++i] ?? null;
+  }
+  return flags;
+}
+
+async function main(): Promise<void> {
+  const flags = parseArgs(process.argv.slice(2));
+
+  // Precondition, fail loud. A re-embed against a down provider would "succeed"
+  // by embedding nothing — the exact silent-degradation this BI exists to kill.
+  if (!flags.dryRun) {
+    const up = await isEmbeddingAvailable();
+    if (!up) {
+      console.error(
+        "[reembed-wiki-store] ABORT — embedding provider is not reachable or the " +
+          "embedding model is missing. Nothing was re-embedded.\n" +
+          "  Fix: docker model pull ai/nomic-embed-text-v1.5\n" +
+          "  Then verify: curl -s $LLM_BASE_URL/models | grep nomic-embed",
+      );
+      process.exit(1);
+    }
+  }
+
+  const where = {
+    status: "published",
+    ...(flags.kind ? { pageKind: flags.kind } : {}),
+  };
+
+  const pages = await prisma.wikiPage.findMany({
+    where,
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      body: true,
+      abstract: true,
+      pageKind: true,
+      status: true,
+      isKernel: true,
+      kernelVersion: true,
+      organizationId: true,
+      kernelPageId: true,
+      principleTier: true,
+      principleAppliesTo: true,
+      principleRingScope: true,
+      principleDimensionVector: true,
+      principlePublic: true,
+    },
+  });
+
+  console.info(
+    `[reembed-wiki-store] ${flags.dryRun ? "DRY RUN — " : ""}` +
+      `${pages.length} published page(s)${flags.kind ? ` of kind "${flags.kind}"` : ""} to reconcile.`,
+  );
+
+  if (flags.dryRun) {
+    const byKind = new Map<string, number>();
+    for (const p of pages) byKind.set(p.pageKind, (byKind.get(p.pageKind) ?? 0) + 1);
+    for (const [kind, n] of [...byKind].sort((a, b) => b[1] - a[1])) {
+      console.info(`  ${kind}: ${n}`);
+    }
+    await prisma.$disconnect();
+    return;
+  }
+
+  let embedded = 0;
+  const failed: string[] = [];
+  for (const p of pages) {
+    const dims =
+      p.principleDimensionVector && typeof p.principleDimensionVector === "object"
+        ? Object.keys(p.principleDimensionVector as Record<string, unknown>)
+        : undefined;
+    const ok = await storeWikiPage({
+      pageId: p.id,
+      slug: p.slug,
+      title: p.title,
+      body: p.body,
+      abstract: p.abstract,
+      pageKind: p.pageKind,
+      status: p.status,
+      isKernel: p.isKernel,
+      kernelVersion: p.kernelVersion,
+      organizationId: p.organizationId,
+      kernelPageId: p.kernelPageId,
+      ...(p.pageKind === "principle"
+        ? {
+            principleTier: p.principleTier,
+            principleAppliesTo: p.principleAppliesTo,
+            principleRingScope: p.principleRingScope,
+            principleDimensions: dims,
+            principlePublic: p.principlePublic ?? undefined,
+          }
+        : {}),
+    });
+    if (ok) {
+      embedded += 1;
+    } else {
+      failed.push(p.slug);
+    }
+    if ((embedded + failed.length) % 25 === 0) {
+      console.info(`  … ${embedded + failed.length}/${pages.length}`);
+    }
+  }
+
+  console.info(
+    `[reembed-wiki-store] coverage: ${embedded}/${pages.length} embedded` +
+      (failed.length ? `, ${failed.length} FAILED` : ""),
+  );
+  if (failed.length) {
+    console.error(
+      `[reembed-wiki-store] ${failed.length} page(s) could not be embedded: ` +
+        failed.slice(0, 20).join(", ") +
+        (failed.length > 20 ? ` … (+${failed.length - 20} more)` : ""),
+    );
+  }
+
+  await prisma.$disconnect();
+  process.exit(failed.length ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("[reembed-wiki-store] fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## The failure

When the embedding model is absent from the provider, **every semantic retrieval returned `[]` silently** and `principle_decide` consulted only commandments — **25 principles of 162** — while flagging `structuredCoverage: "strong"`. Verified live 2026-07-22: Docker Model Runner served only `qwen3.6`, every `/v1/embeddings` call 404'd, and consult `DI-A6EF19F286ED` applied 18 principles, all commandment-tier, reporting itself well-grounded. `wiki_query` returned `{"results":[]}` for every query, including terms that must match published commandments.

The chain: `generateEmbedding` returns `null` on failure (by design) → `searchWikiPages` does `if (!vector) return []` → the core/contextual branches come back empty → only the Postgres commandment branch survives. Every confidence signal the tool exposes is computed over the principles that *did* arrive, so an empty retrieval is indistinguishable from a well-covered one. This is the dominant cause behind BI-B5EA2FB2 ("No Hardcoded Colors as top contributor on design decisions") — with core/contextual dark, only commandments score, and the one `ui`-context commandment is always among them.

## Three changes — `make-silent-failures-observable`, applied to the kernel's own recall

1. **`principle_decide` names the degradation.** When *both* retrieval passes come back empty, probe `isEmbeddingAvailable()` once. If the provider is down: `signalQuality.retrievalDegraded = true`, `usable = false`, and the message leads with `EMBEDDING PROVIDER UNAVAILABLE — only commandment-tier principles were consulted … Treat this as an incomplete consult, not a verdict.` A consult can never again imply full coverage while core/contextual retrieval was structurally impossible. Extends the existing `signalQuality` abstention contract (BI-E0151DB2). The probe fires **only** on the both-empty path, so a healthy consult pays nothing.

2. **`searchWikiPages` logs loudly.** The `if (!vector) return []` path now emits a distinct, greppable `[searchWikiPages] embedding-provider-unavailable` error with the exact fix before returning. The `[]` contract is unchanged (callers depend on it); the failure is simply no longer invisible. Covers every retrieval caller, not just `principle_decide`.

3. **`scripts/reembed-wiki-store.ts` (new) reconciles the store.** Every write path skips a page when the model is unavailable and returns without a record, so an install whose provider was down at seed time ends up *partially embedded* — retrieval then silently searches a fraction of the kernel. This re-embeds every published `WikiPage` through the same `storeWikiPage` primitive, reports coverage as a **number** (embedded/published), refuses to run when the provider is down, and exits non-zero on any partial result.

## Operational recovery (done, this install)

- `docker model pull ai/nomic-embed-text-v1.5` — the model was simply missing from DMR.
- Ran the reembed script against the live store: **87/162 principles → 294/294 published pages** (`vector_embedding` rows 87 → 296).
- Re-ran the scope consult `DI-794725C7F253`: core-tier principles now appear, `appliedPrincipleCount` 18 → 20, margin 1.67 → 4.69.
- **The BI-85341A52 §4.3 overlap scan is now runnable end to end** (`DI-8CA3AF0DFCFE`): a featureless candidate direction returns a ranked ledger — `one-home-per-capability` closest to `native-cohesion-over-interfacing` (0.64) and `design-research-required` (0.56), both below the 0.70 additivity bar. That scan was impossible two sessions ago.

## Why not more provisioning

`docker-entrypoint.sh` **already** auto-pulls the embed model — but best-effort (`|| echo WARN`) with no runtime assertion, which is exactly why this install came up "healthy" with no model and only a one-time boot-log warning. Runtime observability is the durable complement; the boot-time pull is left as-is. A follow-up worth filing: the entrypoint's auto-pull echoes OK on `wget` exit, not on the model actually appearing.

## Design grounding

Design-Grounding-Decision: no-contract-change bugfix. Extends the existing `signalQuality` abstention contract (BI-E0151DB2) and the `make-silent-failures-observable` kernel commandment; adds no new UX/route/spec surface. The reembed script is a maintainer tool.

## Verification

- `tsc --noEmit` → **0 errors** (`--max-old-space-size=8192`; default-heap `tsc` aborts on this machine, hence the pre-commit typecheck override — verified, not skipped blind)
- `vitest` `lib/mcp-tools-principle-decide` + `principle-decide-pack` + `wiki/embeddings` → **3 files / 49 tests pass**, incl. 3 new degradation cases (provider-down → degraded+loud; both-empty-but-up → genuine no-match; populated-retrieval → no probe) and the sibling-mock repair
- reembed ran green against the live store (294/294)

`Local-CI-Override:` the pre-push local-CI gate was overridden — the runner is red for environmental reasons unrelated to this change (~115 React `useContext` failures in component tests that pass in a clean worktree at identical versions/config; filed **BI-C89E471F**). GitHub CI is the binding gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design grounding

- Existing specs/plans reviewed:
  - `docs/superpowers/specs/2026-07-22-wwmd-design-quality-kernel-gap-design.md` §1.0 — identifies this exact provider-down cause (the dominant cause behind BI-B5EA2FB2) and names it as the Phase −1 prerequisite.
  - The `signalQuality` abstention contract established by BI-E0151DB2 in `principle-decide-pack.ts` — this change extends that contract with `retrievalDegraded` rather than inventing a parallel signal.
- Current code substrate reviewed:
  - `apps/web/lib/mcp/packs/principle-decide-pack.ts` (the `signalQuality` assembly), `apps/web/lib/wiki/embeddings.ts` (`searchWikiPages` / `storeWikiPage`), `apps/web/lib/inference/embedding.ts` (`isEmbeddingAvailable`, already present), and `docker-entrypoint.sh` (the existing best-effort embed-model auto-pull).
- Source of truth:
  - The `signalQuality` object on the `principle_decide` result is the machine-checkable abstention contract; the `make-silent-failures-observable` kernel commandment is the governing principle.
- Decision:
  - Extend the existing `signalQuality` contract and add loud logging at the shared retrieval boundary — no new UX/route/queue/navigation surface, no new spec. Provisioning already exists in `docker-entrypoint.sh`; left as-is.

Process-Spine-Decision: reviewed docs/superpowers/specs/2026-07-22-wwmd-design-quality-kernel-gap-design.md and the existing signalQuality/BI-E0151DB2 substrate in apps/web/lib/mcp/packs/principle-decide-pack.ts; no-contract-change bugfix that extends the existing abstention contract, adds no route/queue/spec surface.
