### PR TITLE
fix(ux): normalise volatile values out of the ARIA structure snapshot (BI-BD81682A)

### DIFF
--- a/apps/web/lib/ux-budget/ratchet.test.ts
+++ b/apps/web/lib/ux-budget/ratchet.test.ts
@@ -163,6 +163,22 @@ describe("structural hierarchy snapshot (rev 2 D2)", () => {
   it("normalises trailing whitespace and blank lines", () => {
     expect(normaliseSnapshot("a  \n\n b \n")).toBe("a\n b");
   });
+
+  it("redacts volatile values so a deploy does not read as a structure change", () => {
+    // Same heading structure, different deploy SHA / count / timestamp / id.
+    const a = normaliseSnapshot('- heading "Deployed: abc1234 · 1,234 runs · 2026-07-23" [level=2]');
+    const b = normaliseSnapshot('- heading "Deployed: def5678 · 9,001 runs · 2026-07-22" [level=2]');
+    expect(a).toBe(b);
+    // The structural level is preserved (single digit, not a volatile token).
+    expect(a).toContain("[level=2]");
+    // And no raw SHA survives to trip secret scanning.
+    expect(a).not.toContain("abc1234");
+  });
+
+  it("is idempotent — normalising a normalised snapshot changes nothing", () => {
+    const once = normaliseSnapshot('- heading "build cafef00d, 4321 items"');
+    expect(normaliseSnapshot(once)).toBe(once);
+  });
 });
 
 describe("sweep-level verdict", () => {

--- a/apps/web/lib/ux-budget/ratchet.ts
+++ b/apps/web/lib/ux-budget/ratchet.ts
@@ -175,8 +175,30 @@ export function verdictForRoute(
   };
 }
 
+/**
+ * Volatile values that appear inside accessible names — deploy SHAs, record ids,
+ * timestamps, counts. They must be redacted before a snapshot is stored or compared,
+ * for two reasons:
+ *   1. The structural ratchet asks "did the hierarchy change shape?" — a heading whose
+ *      text is "Deployed: abc1234" would look changed on every deploy even when the
+ *      structure is identical, firing noisy false regressions that get the gate
+ *      disabled.
+ *   2. The stored snapshot is committed to git; raw SHAs and ids are secret-shaped
+ *      content that trips secret scanning and should not be persisted verbatim.
+ * Each pattern collapses to a stable placeholder so structure (roles, heading levels,
+ * nesting) is preserved while the volatile value is not.
+ */
+const VOLATILE_PATTERNS: [RegExp, string][] = [
+  [/\b[0-9a-f]{7,40}\b/gi, "<hex>"], // git SHAs (short and full)
+  [/\bc[a-z0-9]{24,}\b/gi, "<id>"], // cuid-style record ids
+  [/\b\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2})?)?/g, "<timestamp>"], // ISO date/time
+  [/\b\d[\d,]{2,}\b/g, "<num>"], // multi-digit counts (4+ chars incl. separators)
+];
+
 export function normaliseSnapshot(snapshot: string): string {
-  return snapshot
+  let out = snapshot;
+  for (const [re, placeholder] of VOLATILE_PATTERNS) out = out.replace(re, placeholder);
+  return out
     .split("\n")
     .map((l) => l.trimEnd())
     .filter((l) => l.trim().length > 0)


### PR DESCRIPTION
Prerequisite for arming the route-budget ratchet. Freezing the baseline surfaced two problems with storing raw ARIA snapshots:

1. **Secret-shaped content.** They contain deploy SHAs and record ids, which the gitleaks pre-commit hook (correctly) rejects — those should not be committed verbatim.
2. **Deploy churn.** Those same values change on every deploy, so the structural ratchet would fire a false "accessibility tree changed shape" regression on unrelated PRs. That is exactly the kind of noise that gets a gate switched off — the failure mode this whole epic is careful to avoid.

`normaliseSnapshot` now redacts volatile tokens (git SHAs, cuid ids, ISO timestamps, multi-digit counts) to stable placeholders before a snapshot is stored or compared. Structure — roles, heading levels, nesting — is preserved (a single-digit heading level is not a volatile token). Applied on **both** sides (freeze and compare) so the comparison stays consistent, and **idempotent** so re-normalising a stored snapshot is a no-op.

Once this is on main, the baseline is re-frozen through it and committed with `bootstrapped: true` to arm the ratchet.

22 ratchet tests pass, including the two new ones: a deploy that changes only SHA/count/timestamp does not read as a structure change, and normalisation is idempotent.

Design-Grounding-Decision: refines the structural gate in docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md section 6 L4 (ARIA snapshot). Implementation in apps/web/lib/ux-budget/ratchet.ts.
Docs-Impact-Decision: no doc change — the snapshot normalisation is an internal property of the ratchet, not a user-facing contract; docs/platform-usability-standards.md already describes the ARIA structure gate at the right level.
Module-Size-Decision: no baselined file affected; ratchet.ts is well under 800 LOC.
Process-Spine-Decision: no spec/plan change; refines an existing merged mechanism.
