### PR TITLE
fix(ci): disable Node experimental webstorage for all vitest runs (BI-C89E471F)

### DIFF
--- a/apps/web/vitest-webstorage-guard.test.ts
+++ b/apps/web/vitest-webstorage-guard.test.ts
@@ -1,0 +1,32 @@
+// BI-C89E471F regression guard.
+//
+// vitest.config.ts prepends `--no-experimental-webstorage` to NODE_OPTIONS so
+// Node >=25's experimental host web-storage globals cannot shadow the storage
+// jsdom installs in each fork worker — the shadowing corrupts the jsdom
+// environment enough that React component renders throw
+// "Cannot read properties of null (reading 'useContext')", which turned the
+// whole component-test surface red on any Node >=25 host while CI on Node 24
+// stayed green.
+//
+// Fork workers inherit the parent NODE_OPTIONS, so if the config applied the
+// flag it is visible here. This assertion is deterministic on EVERY Node version
+// (the config sets the flag unconditionally), so it fails the moment someone
+// deletes the config line — turning a silent, Node-version-specific regression
+// back into a red unit test on all of CI, not only on a >=25 host.
+
+import { describe, it, expect } from "vitest";
+
+describe("vitest worker inherits the webstorage-disable flag (BI-C89E471F)", () => {
+  it("carries --no-experimental-webstorage in NODE_OPTIONS", () => {
+    expect(process.env.NODE_OPTIONS ?? "").toMatch(
+      /(^|\s)--no-experimental-webstorage(\s|$)/,
+    );
+  });
+
+  it("does not double-apply the flag when it is already set", () => {
+    const occurrences = (process.env.NODE_OPTIONS ?? "").match(
+      /--no-experimental-webstorage/g,
+    );
+    expect(occurrences?.length ?? 0).toBe(1);
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -7,6 +7,30 @@ import { buildNodeModuleAliases } from "./vitest.path-aliases";
 const rootDir = resolve(__dirname, "../..");
 const webDir = resolve(__dirname);
 
+// Node >=25 (a host toolchain that outran CI's pinned Node 24) exposes
+// experimental host localStorage/sessionStorage globals even with no backing
+// store configured. Those undefined host accessors SHADOW the web storage jsdom
+// installs in each fork worker, which corrupts the jsdom environment enough that
+// React Testing Library's act-environment detection fails and component renders
+// throw "Cannot read properties of null (reading 'useContext')" — a cascade that
+// looks like a code bug but is a Node-version mismatch (BI-C89E471F). It turned
+// the whole component-test surface red on any Node >=25 host (~115 failures on
+// the local-CI pregate) while CI on Node 24 stayed green, which trained
+// contributors to override the pre-push gate.
+//
+// `--no-experimental-webstorage` disables Node's host implementation so jsdom
+// owns storage again. The flag must reach the FORK WORKER at launch (it is a
+// node CLI flag, not a runtime toggle, and vitest's poolOptions.forks.execArgv
+// does not reliably propagate it in v4). Fork workers inherit the parent env, so
+// prepending it to NODE_OPTIONS here — before vitest spawns any worker — reaches
+// every worker on every entry point: the pregate, CI, and a developer's direct
+// `pnpm --filter web exec vitest`. The flag exists on Node 24 too and is a
+// harmless no-op there, so it is applied unconditionally rather than sniffing the
+// version. Idempotent: skipped when already present.
+if (!/(^|\s)--no-experimental-webstorage(\s|$)/.test(process.env.NODE_OPTIONS ?? "")) {
+  process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ""} --no-experimental-webstorage`.trim();
+}
+
 loadEnv({ path: resolve(rootDir, ".env") });
 loadEnv({ path: resolve(webDir, ".env.local"), override: true });
 


### PR DESCRIPTION
## The failure

Node ≥25 (a host toolchain that outran CI's pinned Node 24) exposes experimental host `localStorage`/`sessionStorage` globals even with no backing store. Those undefined host accessors **shadow the web storage jsdom installs in each vitest fork worker**, corrupting the jsdom environment enough that React Testing Library's act-environment detection fails and component renders throw `Cannot read properties of null (reading 'useContext')`.

On any Node ≥25 host this turned the **whole component-test surface red** (~115 failures on the local-CI pregate) while CI on Node 24 stayed green — a Node-version mismatch that reads as a code failure, which trained contributors to override the pre-push gate (I did, twice, on #3441 and #3461).

## Why #3315 didn't fully fix it

[PR #3315](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3315) already applied `--no-experimental-webstorage` — but only to the **one caller** it patched: the local-CI runner's vitest command (an `env` prefix in `scripts/lib/local-integration-ci.mjs`). Every other entry point stayed broken — in particular a developer's direct `pnpm --filter web exec vitest`, the fast-iteration path and the exact one behind the repeated overrides.

Verified on current `main` (Node 26): the full web suite **fails 54 tests across 6 component files** via direct invocation, and **passes 2157 files / 18,692 tests** with the flag.

## Fix

Set the flag in `vitest.config.ts` itself, before vitest spawns any worker:

```ts
if (!/…--no-experimental-webstorage…/.test(process.env.NODE_OPTIONS ?? "")) {
  process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ""} --no-experimental-webstorage`.trim();
}
```

It's a node **launch** flag (not a runtime toggle), and vitest v4 does not reliably propagate `poolOptions.forks.execArgv` (verified: the flag never reached the worker's `process.execArgv`). But fork workers **do inherit the parent env**, so prepending it to `NODE_OPTIONS` in the config reaches every worker on every entry point — the runner, CI, and direct `vitest`. Applied idempotently and non-destructively (appends, preserving an existing `NODE_OPTIONS` like the heap flag) and unconditionally (the flag exists on Node 24 and is a harmless no-op there, so no version sniff). The config is now the single source of truth; #3315's runner `env` prefix becomes redundant belt-and-suspenders and is left in place.

## Regression guard

`vitest-webstorage-guard.test.ts` asserts the worker inherits the flag in `NODE_OPTIONS`. Deterministic on **every** Node version (the config sets it unconditionally), so it fails the moment the config line is deleted — turning a silent, ≥25-only regression back into a red unit test on all of CI, not only on a ≥25 host.

## Verification

- `tsc --noEmit` → **0 errors** (`--max-old-space-size=8192`; default-heap `tsc` aborts on this machine, hence the pre-commit typecheck override — verified, not skipped blind)
- On **Node 26** with an empty shell `NODE_OPTIONS`: the guard + the 6 previously-failing files pass, and a **113-file / 864-test** component slice (`components/build|agent|shell|inventory`) is fully green
- Full suite proven green earlier in a clean worktree: 2157 files / 18,692 tests, exit 0

## Design grounding

Process-Spine-Decision: reviewed #3315's runner-only fix and the `vitest.config.ts` substrate; no-contract-change CI/test-harness fix generalizing an existing flag to the config layer, no route/queue/spec surface added.

`Local-CI-Override:` the pre-push local-CI gate was overridden — this IS the fix for that gate's Node-26 failure, verified directly by the full-suite run above, and the shared `.local-ci-runner` is currently mid-integration on another session's branch (collision risk). GitHub CI on Node 24 is the binding gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)