### PR TITLE
fix(bootstrap): verify embedding model is present after pulling (BI-A95A4CB7)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -383,6 +383,19 @@ fi
 echo "  Provider: $PROVIDER  Pull mode: $PULL_MODE  Base URL: $EMB_BASE_URL"
 echo "  Embedding model: $EMB_MODEL"
 
+# Re-list the provider's models and confirm the embedding model is actually
+# present. Returns 0 when present, non-zero otherwise. Used AFTER a pull so
+# success is reported on the model EXISTING — not on the pull request's exit
+# code, which returns 0 even when the download later fails or times out. That
+# false-success is how an install booted "healthy" with no embedding model and
+# the governance kernel silently ran on commandments only (BI-A95A4CB7 /
+# BI-512FBD20). POSIX sh: no `local`; a failed wget emits nothing so grep
+# returns non-zero, which is the correct "not present" answer.
+verify_embedding_present() {
+  # $1 = models listing URL, $2 = grep pattern
+  wget -qO- --timeout=10 "$1" 2>/dev/null | grep -q "$2"
+}
+
 # Skip path: do nothing, log explicitly.
 if [ "$PULL_MODE" = "skip" ]; then
   echo "  SKIP DPF_MODEL_PULL_MODE=skip; not verifying or pulling embedding model"
@@ -408,9 +421,17 @@ else
         echo "  Pulling ${EMB_MODEL} via Docker Model Runner (first run only)..."
         wget -qO- --timeout=120 --post-data "{\"model\":\"${EMB_MODEL}\"}" \
           --header="Content-Type: application/json" \
-          "${EMB_BASE_URL%/v1}/models/create" 2>/dev/null \
-          && echo "  OK Embedding model pulled" \
-          || echo "  WARN Could not auto-pull. Run: docker model pull ${EMB_MODEL}"
+          "${EMB_BASE_URL%/v1}/models/create" 2>/dev/null || true
+        # Verify the model is actually present now — the create request returns
+        # 0 even when the pull later fails, so re-list before claiming success.
+        if verify_embedding_present "${EMB_BASE_URL}/models" "nomic-embed-text"; then
+          echo "  OK Embedding model pulled and verified present (Docker Model Runner)"
+        else
+          echo "  ERROR '${EMB_MODEL}' is STILL NOT present after the pull attempt."
+          echo "        Semantic retrieval (wiki_query, principle_decide core/contextual) will be"
+          echo "        DEGRADED until it is available; the platform surfaces this at query time"
+          echo "        (BI-512FBD20). Fix: docker model pull ${EMB_MODEL}"
+        fi
       fi
       ;;
     ollama)
@@ -424,9 +445,17 @@ else
         echo "  Pulling '${EMB_MODEL}' via Ollama (first run; can take several minutes)..."
         wget -qO- --timeout=300 --post-data "{\"name\":\"${EMB_MODEL}\"}" \
           --header="Content-Type: application/json" \
-          "${OLLAMA_HOST}/api/pull" 2>/dev/null \
-          && echo "  OK Embedding model pulled (Ollama)" \
-          || echo "  WARN Could not auto-pull. Run: ollama pull ${EMB_MODEL}"
+          "${OLLAMA_HOST}/api/pull" 2>/dev/null || true
+        # Verify presence via /api/tags — the pull stream can return 0 while the
+        # model never finished landing, so confirm before claiming success.
+        if verify_embedding_present "${OLLAMA_HOST}/api/tags" "$EMB_MODEL"; then
+          echo "  OK Embedding model '${EMB_MODEL}' pulled and verified present (Ollama)"
+        else
+          echo "  ERROR '${EMB_MODEL}' is STILL NOT present after the pull attempt."
+          echo "        Semantic retrieval (wiki_query, principle_decide core/contextual) will be"
+          echo "        DEGRADED until it is available; the platform surfaces this at query time"
+          echo "        (BI-512FBD20). Fix: ollama pull ${EMB_MODEL}"
+        fi
       fi
       ;;
     *)

--- a/scripts/lib/docker-entrypoint-embedding-verify.test.mjs
+++ b/scripts/lib/docker-entrypoint-embedding-verify.test.mjs
@@ -1,0 +1,70 @@
+// BI-A95A4CB7 regression guard.
+//
+// The post-init embedding-model setup used to echo "OK Embedding model pulled"
+// on the pull REQUEST's exit code, which returns 0 even when the download later
+// fails or times out. That false success is how an install booted "healthy" with
+// no embedding model and the governance kernel silently ran on commandments only
+// (BI-512FBD20). The fix re-lists the provider's models after the pull and only
+// claims success when the model is actually present.
+//
+// Static assertions on docker-entrypoint.sh, matching the style of
+// docker-entrypoint-source-volume.test.mjs (the entrypoint is a POSIX sh script
+// with no runnable unit harness).
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const entrypoint = readFileSync(
+  new URL("../../docker-entrypoint.sh", import.meta.url),
+  "utf8",
+);
+
+function functionBody(name) {
+  const match = entrypoint.match(new RegExp(`${name}\\(\\) \\{([\\s\\S]*?)\\n\\}`));
+  assert.ok(match, `${name} function should exist`);
+  return match[1];
+}
+
+test("a verify-after-pull helper re-lists the provider's models", () => {
+  const body = functionBody("verify_embedding_present");
+  // Re-fetches the models listing and greps it — that is what makes success
+  // conditional on the model existing rather than on the pull request's exit.
+  assert.match(body, /wget/);
+  assert.match(body, /grep -q/);
+});
+
+test("the false-success echoes are gone — success is never claimed on the pull request's exit code", () => {
+  // The old model-runner and ollama branches chained `&& echo OK` directly to
+  // the create/pull wget. If either string returns, the regression is back.
+  assert.doesNotMatch(
+    entrypoint,
+    /&&\s*echo\s+"\s*OK Embedding model pulled"/,
+    "model-runner branch must verify presence, not echo OK on the create request's exit",
+  );
+  assert.doesNotMatch(
+    entrypoint,
+    /&&\s*echo\s+"\s*OK Embedding model pulled \(Ollama\)"/,
+    "ollama branch must verify presence, not echo OK on the pull request's exit",
+  );
+});
+
+test("both auto-pull branches gate their success on verify_embedding_present", () => {
+  // Every place that pulls (POSTs to /models/create or /api/pull) must be
+  // followed by a verify_embedding_present check before claiming success.
+  const pullSites = [...entrypoint.matchAll(/\/(models\/create|api\/pull)"/g)].length;
+  assert.ok(pullSites >= 2, "expected the model-runner and ollama pull sites");
+  const verifyCalls = [...entrypoint.matchAll(/if verify_embedding_present /g)].length;
+  assert.ok(
+    verifyCalls >= 2,
+    `expected each pull branch to verify presence; found ${verifyCalls} verify calls`,
+  );
+});
+
+test("the degraded path names the runtime symptom and the fix, and never hard-exits boot", () => {
+  // Fail loud, but graceful: the platform surfaces the degradation at query time
+  // (BI-512FBD20), so a missing model must not brick container boot.
+  assert.match(entrypoint, /STILL NOT present after the pull attempt/);
+  assert.match(entrypoint, /docker model pull \$\{EMB_MODEL\}/);
+  assert.match(entrypoint, /ollama pull \$\{EMB_MODEL\}/);
+});


### PR DESCRIPTION
## The bug

The post-init embedding-model setup in `docker-entrypoint.sh` echoed `OK Embedding model pulled` on the pull **request's** exit code. For Docker Model Runner that's a `POST /models/create`; for Ollama a `POST /api/pull` — both return 0 even when the download later fails or times out. So a failed pull printed OK, and the only negative signal was a `WARN` in boot logs nobody watches.

That false success is exactly how the canonical install came up on 2026-07-22 with **no embedding model** and the governance kernel silently consulting commandments only — 25 principles of 162 — while reporting itself well-grounded ([BI-512FBD20](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3461)). `structural-verification-is-not-functional`, applied to provisioning: a pull request succeeding is not the model being present.

## Fix

A POSIX-sh `verify_embedding_present()` helper re-lists the provider's models and greps for the embedding model. Both auto-pull branches now call it **after** the pull and only claim success when the model is actually there:

```sh
verify_embedding_present() {   # $1 = models listing URL, $2 = grep pattern
  wget -qO- --timeout=10 "$1" 2>/dev/null | grep -q "$2"
}
```

On absence they print a loud `ERROR` that names the runtime symptom (`wiki_query` / `principle_decide` core+contextual retrieval degraded) and the exact fix (`docker model pull` / `ollama pull`), and — deliberately — **do not hard-exit boot**: the platform now surfaces this degradation at query time (BI-512FBD20 runtime fail-loud), so a missing model must not brick the container. The `verify-only` / `external` path already re-listed correctly and is unchanged.

## Regression guard

`scripts/lib/docker-entrypoint-embedding-verify.test.mjs` (`node:test` static assertions, matching `docker-entrypoint-source-volume.test.mjs`): asserts the helper exists, the old `&& echo "OK … pulled"` false-success chains are gone, both pull branches gate success on `verify_embedding_present`, and the degraded path names the symptom + fix.

## Verification

- `sh -n docker-entrypoint.sh` → clean (POSIX; the script is `#!/bin/sh`, no bashisms)
- Helper logic tested against the live Docker Model Runner listing: `present→true` for a pulled model, `false` for a bogus name and for an unreachable endpoint (the fail-loud path)
- `node --test` → **4/4 pass**
- No TypeScript changed (shell + `.mjs` test only), so the web typecheck state is identical to `origin/main`

## Design grounding

Process-Spine-Decision: reviewed the BI-512FBD20 resolution and the existing `docker-entrypoint.sh` embedding-setup block; no-contract-change bootstrap robustness fix that makes an existing best-effort pull verify its result, adds no route/queue/spec surface.

`Local-CI-Override:` pushed with the pre-push gate overridden — shell + `.mjs`-test-only change (no TS), verified as above; the shared `.local-ci-runner` is mid-integration on another session's branch (collision risk). GitHub CI is the binding gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)