### PR TITLE
fix(ux): return the route sweep to reporting mode until it is reproducible (BI-EA221325)

### DIFF
--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "bootstrapped": true,
+  "bootstrapped": false,
   "generator": "apps/web/scripts/ux-route-sweep.ts",
   "routes": {
     "/admin": {


### PR DESCRIPTION
**Urgent-ish housekeeping.** [#3463](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3463) was meant to be held as a draft. The merge queue had already accepted it before `--disable-auto` ran ("already queued to merge"), and converting it to a draft afterwards did not pull it out — so it merged and armed the ratchet against a baseline the sweep **cannot reproduce**.

## Evidence

From #3463's own enforcing run: **98 of 200 routes** flagged `accessibility tree changed shape`, plus word drift (268 → 270) — on a diff that changes only `ratchet.ts` and the baseline data, nothing that alters any route's rendered content.

Cause: every sweep run provisions an ephemeral Postgres and re-seeds a fresh fixture org, so wall-clock- and ordering-derived content differs run to run.

## Impact, accurately

The sweep is **not** a required check (required = Typecheck, Production Build, DCO, Unit Tests, Module Size Guard, Repo Guard Loop), so this did **not** block anyone's merges. But it turned a brand-new gate permanently red on every PR — which is exactly how a gate gets ignored, and precisely the failure mode this epic exists to prevent.

## This change

`bootstrapped: false` — back to reporting mode, which is honest: it measures and reports, never blocks. The **200 measured routes are kept**, so re-arming after the determinism fix is a fresh freeze plus the flag, not a rebuild.

Re-arm only when **BI-EA221325**'s acceptance holds: two consecutive sweep runs on the same commit produce zero regressions against a baseline frozen from either. The likely fix is a structure-only ARIA projection (roles + heading levels + nesting, dropping accessible-name text — names carry the non-determinism, and the gate's purpose is hierarchy shape, not label text).

Design-Grounding-Decision: restores the documented bootstrap contract in docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md section 6 L4. Data-only change to apps/web/lib/ux-budget/route-budget-baseline.json.
Docs-Impact-Decision: no doc change — docs/platform-usability-standards.md already documents bootstrap (reporting) mode and the arming command; this returns the gate to the documented pre-armed state.
Module-Size-Decision: data file only; no source module affected.
Process-Spine-Decision: data-only revert of an enforcement flag; the governing spec is unchanged.
