### PR TITLE
fix(ux): make the route sweep reproducible — structural projection + volatile text (BI-EA221325)

### DIFF
--- a/apps/web/lib/ux-budget/ratchet.test.ts
+++ b/apps/web/lib/ux-budget/ratchet.test.ts
@@ -10,6 +10,7 @@ import {
   formatSweepReport,
   freezeBaseline,
   normaliseSnapshot,
+  normaliseVolatileText,
   verdictForRoute,
   type BaselineFile,
   type RouteMeasurement,
@@ -160,8 +161,25 @@ describe("structural hierarchy snapshot (rev 2 D2)", () => {
     expect(verdictForRoute(after, baselineFrom(before).routes["/workspace"]).structureChanged).toBe(false);
   });
 
-  it("normalises trailing whitespace and blank lines", () => {
-    expect(normaliseSnapshot("a  \n\n b \n")).toBe("a\n b");
+  it("projects to structure only — nesting + role + structural state", () => {
+    const snap = [
+      "- banner:",
+      '  - link "OD Open Digital Product Factory":',
+      "    - /url: /workspace",
+      '  - heading "Your day" [level=1]',
+      "  - text: · updated 7/23/2026, 7:37:21 PM (seeded)",
+    ].join("\n");
+    // Names, URLs and text payloads are dropped; nesting, role and [level] survive.
+    expect(normaliseSnapshot(snap)).toBe(
+      ["- banner", "  - link", "  - heading [level=1]", "  - text"].join("\n"),
+    );
+  });
+
+  it("two runs that differ ONLY in rendered text project identically", () => {
+    // The measured cause of the drift: seeded rows render "updated <now>". This is
+    // the case that made 91 of 200 routes look structurally changed between runs.
+    const at = (t: string) => `- main:\n  - text: · updated 7/23/2026, ${t} (seeded)`;
+    expect(normaliseSnapshot(at("7:37:21 PM"))).toBe(normaliseSnapshot(at("8:27:13 PM")));
   });
 
   it("redacts volatile values so a deploy does not read as a structure change", () => {
@@ -187,12 +205,36 @@ describe("structural hierarchy snapshot (rev 2 D2)", () => {
     // contiguous secret-shaped literal for the secret scanner to flag.
     const header = `-----BEGIN ${"PRIVATE"} KEY-----`;
     const pem = normaliseSnapshot(`- textbox "${header}"`);
+    // Projection drops the accessible name entirely — stronger than redacting it.
     expect(pem).not.toContain("BEGIN PRIVATE KEY");
-    expect(pem).toContain("<pem>");
+    expect(pem).toBe("- textbox");
     const jwtInput = ["eyJ" + "hbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", "eyJzdWIiOiIxMjM0NTY3ODkwIn0", "SflKxwRJSMeKKF2QT4fwpMe"].join(".");
     const jwt = normaliseSnapshot(`- text ${jwtInput}`);
     expect(jwt).not.toContain("eyJzdWIiOiIxMjM0");
-    expect(jwt).toContain("<jwt>");
+    expect(jwt).toBe("- text");
+  });
+});
+
+describe("volatile text normalisation stabilises word counts (BI-EA221325)", () => {
+  const words = (s: string) => normaliseVolatileText(s).split(/\s+/).filter(Boolean).length;
+
+  it("collapses relative times to one token, so the count stops moving", () => {
+    // The ±2 word deltas: "2 hours ago" (3 words) vs "just now" (2 words).
+    expect(words("updated 2 hours ago")).toBe(words("updated just now"));
+    expect(words("updated 11 minutes ago")).toBe(words("updated a moment ago"));
+  });
+
+  it("collapses clock times and dates regardless of digit width", () => {
+    expect(normaliseVolatileText("7:37:21 PM")).toBe(normaliseVolatileText("11:05:03 AM"));
+    expect(normaliseVolatileText("7/23/2026")).toBe(normaliseVolatileText("11/1/26"));
+    expect(words("· updated 7/23/2026, 7:37:21 PM (seeded)")).toBe(
+      words("· updated 11/1/26, 11:05:03 AM (seeded)"),
+    );
+  });
+
+  it("leaves ordinary prose alone", () => {
+    const prose = "Two things need your attention today";
+    expect(normaliseVolatileText(prose)).toBe(prose);
   });
 });
 

--- a/apps/web/lib/ux-budget/ratchet.ts
+++ b/apps/web/lib/ux-budget/ratchet.ts
@@ -203,14 +203,69 @@ const VOLATILE_PATTERNS: [RegExp, string][] = [
   [/\b\d[\d,]{2,}\b/g, "<num>"], // multi-digit counts (4+ chars incl. separators)
 ];
 
+/**
+ * Wall-clock text the UI renders — the measured cause of run-to-run drift.
+ *
+ * Two independent sweep runs of identical code differed on 91/200 ARIA snapshots
+ * and 38/200 word counts. The diff was always the same shape: seeded records carry
+ * `updatedAt = now`, and the UI renders it — "· updated 7/23/2026, 7:37:21 PM" in
+ * one run, "8:27:13 PM" in the next. Relative phrasings ("2 hours ago" vs "just
+ * now") also change the WORD COUNT, which is where the ±2 deltas came from.
+ *
+ * Each pattern collapses to a single stable token, so both the text and its word
+ * count stop moving. Applied to the served HTML before measuring (BI-EA221325).
+ */
+const VOLATILE_TEXT_PATTERNS: [RegExp, string][] = [
+  [/\b\d+\s+(?:second|minute|hour|day|week|month|year)s?\s+ago\b/gi, "<ago>"],
+  [/\b(?:just now|a moment ago|moments ago|an?\s+(?:second|minute|hour|day|week|month|year)\s+ago)\b/gi, "<ago>"],
+  [/\bin\s+\d+\s+(?:second|minute|hour|day|week|month|year)s?\b/gi, "<in>"],
+  [/\b\d{1,2}:\d{2}(?::\d{2})?(?:\s*[AaPp]\.?[Mm]\.?)?/g, "<time>"],
+  [/\b\d{1,2}\/\d{1,2}\/\d{2,4}\b/g, "<date>"],
+  [/\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{1,2}(?:,\s*\d{4})?\b/g, "<date>"],
+];
+
+/** Collapse wall-clock text so a measurement does not move with the clock. */
+export function normaliseVolatileText(text: string): string {
+  let out = text;
+  for (const [re, placeholder] of VOLATILE_TEXT_PATTERNS) out = out.replace(re, placeholder);
+  return out;
+}
+
+// A property line inside the tree, e.g. `- /url: /workspace`. Carries data, not shape.
+const PROPERTY_LINE = /^\/[\w-]+:/;
+
+/**
+ * Project an ARIA snapshot down to STRUCTURE: nesting depth, role, and structural
+ * state ([level=2], [pressed], [checked], …). Accessible names, URLs and text
+ * payloads are DROPPED.
+ *
+ * This is the whole point of the gate — "did the hierarchy change shape?", not "did
+ * a label's text change". Names are where the volatile data lives (timestamps, ids,
+ * counts) and also where secret-shaped labels appear, so dropping them makes the
+ * comparison both deterministic and safe to commit. The measured evidence supports
+ * it: when two runs differed, the LINE COUNTS matched exactly (141 vs 141) — only
+ * the text payloads moved.
+ */
 export function normaliseSnapshot(snapshot: string): string {
   let out = snapshot;
+  // Defense in depth: redact before projecting, so anything that survives into a
+  // role or attribute is still scrubbed.
   for (const [re, placeholder] of VOLATILE_PATTERNS) out = out.replace(re, placeholder);
-  return out
-    .split("\n")
-    .map((l) => l.trimEnd())
-    .filter((l) => l.trim().length > 0)
-    .join("\n");
+
+  const lines: string[] = [];
+  for (const raw of out.split("\n")) {
+    const line = raw.replace(/\s+$/, "");
+    if (!line.trim()) continue;
+    const indent = line.slice(0, line.length - line.trimStart().length);
+    // Strip the list marker, then any wrapping quotes around the whole node.
+    const body = line.trimStart().replace(/^-\s*/, "").replace(/^['"]|['"]$/g, "");
+    if (PROPERTY_LINE.test(body)) continue;
+    const role = /^([a-zA-Z][\w-]*)/.exec(body)?.[1];
+    if (!role) continue;
+    const attrs = [...body.matchAll(/\[([^\]]+)\]/g)].map((m) => `[${m[1]}]`).join(" ");
+    lines.push(`${indent}- ${role}${attrs ? ` ${attrs}` : ""}`);
+  }
+  return lines.join("\n");
 }
 
 export type SweepVerdict = {

--- a/apps/web/scripts/ux-route-sweep.ts
+++ b/apps/web/scripts/ux-route-sweep.ts
@@ -28,6 +28,7 @@ import {
   evaluateSweep,
   formatSweepReport,
   freezeBaseline,
+  normaliseVolatileText,
   type BaselineFile,
   type RouteMeasurement,
 } from "../lib/ux-budget/ratchet";
@@ -147,7 +148,9 @@ async function measureRoute(
   return {
     routePath: row.routePath,
     shell: row.shell,
-    metrics: measureUxBudget(html),
+    // Collapse wall-clock text first: seeded records render "updated <now>", so a
+    // raw measurement moves with the clock (BI-EA221325).
+    metrics: measureUxBudget(normaliseVolatileText(html)),
     ariaSnapshot,
     axeViolations,
     exemptChecks: row.exemptChecks,


### PR DESCRIPTION
Unblocks arming the wall-of-text ratchet. **Measured the cause before choosing the fix.**

## Evidence

Diffed two independent sweep runs of identical content code: **91/200 ARIA snapshots** and **38/200 word counts** differed. The diff was always the same shape — seeded rows carry `updatedAt = now` and the UI renders it:

```
A: "- text: · updated 7/23/<num>, 7:37:21 PM (seeded)"
B: "- text: · updated 7/23/<num>, 8:27:13 PM (seeded)"
```

Crucially, **line counts were identical (141 vs 141)**. The structure was already stable; only text payloads moved. That evidence picked the fix rather than a guess.

## The fix

**1. `normaliseSnapshot` projects to STRUCTURE ONLY** — nesting depth, role, and structural state (`[level=2]`, `[pressed]`, …). Accessible names, `/url` property lines and text payloads are dropped.

This is what the gate actually asks — *"did the hierarchy change shape?"*, not *"did a label's text change"*. Names are where **both** the volatile data **and** the secret-shaped labels live, so the comparison becomes deterministic and safe-to-commit in one move (it also supersedes the PEM/JWT redaction workaround — the text is simply gone).

**Verified against the real captured data: all 91 differing snapshots project to 0 differences.**

**2. `normaliseVolatileText`** collapses wall-clock text (relative times, clock times, dates) to single stable tokens, applied to the served HTML before measuring — addressing the word deltas, where `"2 hours ago"` (3 words) vs `"just now"` (2 words) produced the ±2.

## Verification

62 tests pass, including two that pin the cause directly: a snapshot differing only in rendered timestamp projects identically, and relative-time phrasings yield equal word counts. Typecheck clean; style-drift and module-size green.

## What happens next

Arming stays gated on **BI-EA221325**'s acceptance — *two consecutive freezes on the same commit producing zero regressions*. This PR is the prerequisite; I verify that empirically before flipping `bootstrapped` back on, rather than assuming.

Design-Grounding-Decision: refines the structural gate and measurement path in docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md section 6 L4. Implementation in apps/web/lib/ux-budget/ratchet.ts and apps/web/scripts/ux-route-sweep.ts.
Docs-Impact-Decision: no doc change — docs/platform-usability-standards.md describes the ARIA structure gate at contract level ("heading levels, landmarks, nesting"), which is exactly what the projection keeps; the normalisation is an internal property.
Module-Size-Decision: no baselined file affected; ratchet.ts well under 800 LOC.
Process-Spine-Decision: refines an existing merged mechanism; no spec/plan change.
