### PR TITLE
fix(ux): collapse repeated sibling subtrees — a list's LENGTH is data, not shape (BI-EA221325)

### DIFF
--- a/apps/web/lib/ux-budget/ratchet.test.ts
+++ b/apps/web/lib/ux-budget/ratchet.test.ts
@@ -195,6 +195,29 @@ describe("structural hierarchy snapshot (rev 2 D2)", () => {
     expect(normaliseSnapshot(snap)).toBe(["- main", "  - heading [level=1]"].join("\n"));
   });
 
+  it("collapses repeated sibling subtrees — a list's LENGTH is data, not shape", () => {
+    // /build/work was the measured case: a table whose row count differed between two
+    // runs of the same commit. Rows ARE structure, so no text normalisation fixes it;
+    // N identically-shaped rows must project as one.
+    const oneRow = "- table:\n  - row:\n    - cell";
+    const manyRows = "- table:\n  - row:\n    - cell\n  - row:\n    - cell\n  - row:\n    - cell";
+    expect(normaliseSnapshot(manyRows)).toBe(normaliseSnapshot(oneRow));
+  });
+
+  it("stays sensitive to the hierarchy questions the gate exists to ask", () => {
+    const n = normaliseSnapshot;
+    // A new KIND of node inside a row (e.g. an action button appears).
+    expect(n("- row:\n  - cell")).not.toBe(n("- row:\n  - cell\n  - button"));
+    // A heading flattened into plain text — the Design2Code failure mode.
+    expect(n("- main:\n  - heading [level=2]")).not.toBe(n("- main:\n  - text"));
+    // A landmark disappears.
+    expect(n("- banner\n- main")).not.toBe(n("- main"));
+    // Nesting depth changes (a list item promoted out of its list).
+    expect(n("- main:\n  - list:\n    - listitem")).not.toBe(n("- main:\n  - list\n  - listitem"));
+    // Structural state changes.
+    expect(n("- main:\n  - button [pressed]")).not.toBe(n("- main:\n  - button"));
+  });
+
   it("two runs that differ ONLY in rendered text project identically", () => {
     // The measured cause of the drift: seeded rows render "updated <now>". This is
     // the case that made 91 of 200 routes look structurally changed between runs.

--- a/apps/web/lib/ux-budget/ratchet.ts
+++ b/apps/web/lib/ux-budget/ratchet.ts
@@ -309,6 +309,67 @@ const DOCUMENT_LANDMARKS = new Set([
  * it: when two runs differed, the LINE COUNTS matched exactly (141 vs 141) — only
  * the text payloads moved.
  */
+type ProjectedNode = { line: string; children: ProjectedNode[] };
+
+/**
+ * Build a tree from indentation-ordered projected lines. Stack-based so an
+ * unexpected indentation jump re-parents rather than dropping the subtree.
+ */
+function toTree(lines: string[]): ProjectedNode[] {
+  const root: ProjectedNode = { line: "", children: [] };
+  const stack: { indent: number; node: ProjectedNode }[] = [{ indent: -1, node: root }];
+  for (const line of lines) {
+    const indent = line.length - line.trimStart().length;
+    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) stack.pop();
+    const node: ProjectedNode = { line, children: [] };
+    stack[stack.length - 1].node.children.push(node);
+    stack.push({ indent, node });
+  }
+  return root.children;
+}
+
+function serialiseNode(n: ProjectedNode): string {
+  return `${n.line.trim()}(${n.children.map(serialiseNode).join(",")})`;
+}
+
+function flatten(nodes: ProjectedNode[], out: string[]): void {
+  for (const n of nodes) {
+    out.push(n.line);
+    flatten(n.children, out);
+  }
+}
+
+/**
+ * Collapse consecutive sibling subtrees that project identically.
+ *
+ * A list of N identically-shaped rows IS the same shape as one row — and N varies
+ * with seeded data. /build/work was the measured case: a table whose row count
+ * differed between two runs of the same commit, which no amount of text
+ * normalisation can fix because the ROWS are structure.
+ *
+ * The trade-off is deliberate and bounded: the projection becomes insensitive to
+ * COUNT (how many rows, how many cells) while staying sensitive to KIND, nesting and
+ * structural state — a new sort of node inside a row, a flattened heading, a missing
+ * landmark are all still caught. Count is not lost from the gate: it is exactly what
+ * the numeric axes (words, controls, fields) already ratchet.
+ */
+function collapseRepeatedSiblings(lines: string[]): string[] {
+  if (lines.length === 0) return lines;
+  const dedupe = (nodes: ProjectedNode[]): ProjectedNode[] => {
+    const out: ProjectedNode[] = [];
+    for (const n of nodes) {
+      n.children = dedupe(n.children);
+      const prev = out[out.length - 1];
+      if (prev && serialiseNode(prev) === serialiseNode(n)) continue;
+      out.push(n);
+    }
+    return out;
+  };
+  const flat: string[] = [];
+  flatten(dedupe(toTree(lines)), flat);
+  return flat;
+}
+
 export function normaliseSnapshot(snapshot: string): string {
   let out = snapshot;
   // Defense in depth: redact before projecting, so anything that survives into a
@@ -347,7 +408,7 @@ export function normaliseSnapshot(snapshot: string): string {
     const attrs = [...body.matchAll(/\[([^\]]+)\]/g)].map((m) => `[${m[1]}]`).join(" ");
     lines.push(`${indent}- ${role}${attrs ? ` ${attrs}` : ""}`);
   }
-  return lines.join("\n");
+  return collapseRepeatedSiblings(lines).join("\n");
 }
 
 export type SweepVerdict = {


### PR DESCRIPTION
The armed sweep's own run (#3469) took regressions from **98 to 1**. The survivor was `/build/work`: a table whose **row count** differs between two runs of the same commit. Rows *are* structure, so no amount of text normalisation reaches it.

Consecutive sibling subtrees that project identically now collapse to one — N identically-shaped rows read as one row.

## The trade-off is deliberate and bounded

The projection becomes insensitive to **count** (how many rows, how many cells) and stays sensitive to **kind, nesting and structural state**. Each of these is still caught, with a test:

- a new *sort* of node inside a row (an action button appears)
- a heading flattened into plain text — the Design2Code failure mode this gate exists for
- a landmark disappearing
- nesting depth changing (a list item promoted out of its list)
- structural state changing (`[pressed]`)

Count isn't lost from the gate — it's exactly what the numeric axes (words, controls, fields) already ratchet. The two halves cover each other.

## Verification

Against the real captured run pair: **200/200 routes agree, 0 snapshot differences.** 67 unit tests pass. Module-size and typecheck clean.

With this, arming (#3469) should hold; I re-verify its enforcing run before merging it.

Design-Grounding-Decision: refines the structural gate in docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md section 6 L4. Implementation in apps/web/lib/ux-budget/ratchet.ts.
Docs-Impact-Decision: no doc change — docs/platform-usability-standards.md describes the ARIA structure gate at contract level (heading levels, landmarks, nesting), which is exactly what the projection keeps.
Module-Size-Decision: no baselined file affected; ratchet.ts well under 800 LOC.
Process-Spine-Decision: refines an existing merged mechanism; no spec/plan change.
