### PR TITLE
fix(ux): return the sweep to reporting mode — residual non-determinism (BI-EA221325)

### DIFF
--- a/apps/web/lib/ux-budget/route-budget-baseline.json
+++ b/apps/web/lib/ux-budget/route-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "bootstrapped": true,
+  "bootstrapped": false,
   "generator": "apps/web/scripts/ux-route-sweep.ts",
   "routes": {
     "/admin": {


### PR DESCRIPTION
The armed gate is red on main. Two routes:

- **`/build/work`** — structure. This is the *same* variable-row table the sibling-collapse fix (#3470) targeted, so determinism is **not** fully solved end-to-end in CI, even though replaying the fix against two captured runs showed 200/200 agreement locally.
- **`/ops/self-upgrade`** — words 383 → 390.

BI-EA221325's stated acceptance — *two consecutive CI runs on the same commit producing zero regressions* — has therefore **not been demonstrated in CI**. Arming was premature. A red gate on main trains people to ignore it, which is precisely the failure this epic exists to prevent.

`bootstrapped: false`. The 200 measured routes are kept, so re-arming after the residual is fixed is a fresh freeze plus the flag.

**Note for whoever picks this up:** `/ops/self-upgrade`'s +7 words is plausibly a **real and intended** change — BI-D77BF495 un-collapsed the deploy section so the primary action is reachable on arrival, buying findability at the cost of density. That is the gate *working*, and it is exactly the kind of tradeoff that should reach a human ruling rather than be silently re-baselined. **Do not re-freeze without judging it.**

Design-Grounding-Decision: restores the documented bootstrap contract in docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md section 6 L4. Data-only change to apps/web/lib/ux-budget/route-budget-baseline.json.
Docs-Impact-Decision: no doc change — docs/platform-usability-standards.md already documents reporting mode and the arming command.
Module-Size-Decision: data file only; no source module affected.
Process-Spine-Decision: data-only enforcement flag; governing spec unchanged.
