### PR TITLE
feat(kernel): design-quality principles + two dimensions (BI-B5EA2FB2)

### DIFF
--- a/apps/web/lib/decision/dimension-catalog.ts
+++ b/apps/web/lib/decision/dimension-catalog.ts
@@ -84,6 +84,10 @@ const HIGH_MEANS: Record<PrincipleDimension, string> = {
     "the option is covered by broader standing customer approval",
   business_disruption:
     "the option interrupts MORE of live business operation while it is applied",
+  operator_effort:
+    "the option demands MORE operator operations and elapsed time to reach the outcome",
+  legibility_of_consequence:
+    "the operator can better foresee, before authorizing, what the option will do, to what, under whose authority, and how it is undone",
 };
 
 /** The full caller-facing catalogue, benefits first then costs, stable order. */

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/gen-doc-index.mjs",
   "root": "docs",
-  "pageCount": 539,
+  "pageCount": 544,
   "pages": {
     "docs/README.md": {
       "publicHref": "/README/",
@@ -2180,6 +2180,20 @@
         "see-also"
       ]
     },
+    "docs/founder-kernel/wiki/principles/count-the-operations-to-outcome.md": {
+      "publicHref": "/founder-kernel/wiki/principles/count-the-operations-to-outcome/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "count-the-operations-to-outcome",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "overlap-scan-43"
+      ]
+    },
     "docs/founder-kernel/wiki/principles/data-sovereignty-follows-control.md": {
       "publicHref": "/founder-kernel/wiki/principles/data-sovereignty-follows-control/",
       "portalHref": null,
@@ -2268,6 +2282,20 @@
         "anti-pattern",
         "penalty",
         "related-principles"
+      ]
+    },
+    "docs/founder-kernel/wiki/principles/disclose-before-you-add-a-surface.md": {
+      "publicHref": "/founder-kernel/wiki/principles/disclose-before-you-add-a-surface/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "disclose-before-you-add-a-surface",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "overlap-scan-43"
       ]
     },
     "docs/founder-kernel/wiki/principles/diversity-of-thought.md": {
@@ -2450,6 +2478,21 @@
         "decision-dimensions",
         "examples",
         "sources"
+      ]
+    },
+    "docs/founder-kernel/wiki/principles/kernel-defers-design-quality-to-the-fit-gate.md": {
+      "publicHref": "/founder-kernel/wiki/principles/kernel-defers-design-quality-to-the-fit-gate/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "the-kernel-defers-design-quality-to-the-fit-gate",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "universal-ring-justification-42",
+        "overlap-scan-43"
       ]
     },
     "docs/founder-kernel/wiki/principles/learnings-belong-in-the-shared-commons.md": {
@@ -2723,6 +2766,20 @@
         "examples",
         "when-this-does-not-apply",
         "see-also"
+      ]
+    },
+    "docs/founder-kernel/wiki/principles/one-home-per-capability.md": {
+      "publicHref": "/founder-kernel/wiki/principles/one-home-per-capability/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "one-home-per-capability",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "overlap-scan-43"
       ]
     },
     "docs/founder-kernel/wiki/principles/optimize-for-the-whole.md": {
@@ -3102,6 +3159,20 @@
         "decision-dimensions",
         "examples",
         "sources"
+      ]
+    },
+    "docs/founder-kernel/wiki/principles/show-the-consequence-before-the-confirm.md": {
+      "publicHref": "/founder-kernel/wiki/principles/show-the-consequence-before-the-confirm/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "show-the-consequence-before-the-confirm",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "overlap-scan-43"
       ]
     },
     "docs/founder-kernel/wiki/principles/single-source-of-truth.md": {

--- a/docs/founder-kernel/wiki/principles/count-the-operations-to-outcome.md
+++ b/docs/founder-kernel/wiki/principles/count-the-operations-to-outcome.md
@@ -1,0 +1,80 @@
+---
+title: Count the operations to outcome
+slug: count-the-operations-to-outcome
+pageKind: principle
+status: published
+abstract: Judge a design by the operator operations and elapsed time to the operator's outcome, measured on the running portal — not by the number of screens or features shipped.
+principleTier: core
+principleDirection: Judge a design by the operator operations and elapsed time to the operator's outcome, measured on the running portal, not by the number of screens or features shipped.
+principleDimensionVector: {"operator_effort": -0.9, "evidence_density": 0.6, "human_cognitive_load": -0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleConsumerArchetype: route-domain-specific
+principleConsumerContexts:
+  - ui
+principleRingScope:
+  - ring-2-workflow
+  - ring-4-sandbox-prod
+principlePublic: false
+authoredAt: 2026-07-23
+authoredBy: mark-bodman
+---
+
+# Count the operations to outcome
+
+**Measure a design by how many operations and how much elapsed time the operator
+spends to reach their outcome — counted on the running portal — not by how many
+screens, tabs, or features it shipped.** The unit of a good design is a completed
+operator outcome reached cheaply, not surface area delivered.
+
+## Why
+
+"We shipped a lot" and "the operator got their outcome faster" are different
+claims, and generation optimizes for the first unless the second is the stated
+metric. A feature that adds three screens to do what one filtered view could do
+is *more* work shipped and *worse* for the operator. Counting operations-to-
+outcome is the only measure that makes design quality falsifiable: it is a number
+you can read off a browser walkthrough, so a claim of "this is better" either
+holds up against the clicks-to-outcome count or it does not.
+
+This is the anchor for the `operator_effort` axis — the one design principle that
+turns "good UX" from taste into evidence.
+
+## Applies To
+
+In-platform coworkers and external coding agents proposing or verifying UI work,
+and humans reviewing it. It binds at build time (choose the shape with fewer
+operations) and at verification time (prove it on the running portal). It does
+not apply to backend-only changes with no operator surface.
+
+## How To Apply
+
+Walk the operator's path to the outcome on the running portal and count the
+discrete operations and elapsed time. Compare designs by that count, not by the
+feature list. A route test that proves a button exists is not this measurement —
+[[principles/structural-verification-is-not-functional]] applies: the button
+existing is not the outcome being reachable in a sane number of moves. Where the
+count is a claim about a quality improvement, cite the measured before/after, not
+an estimate.
+
+## Decision Dimensions
+
+- `operator_effort: -0.9` — this principle exists to drive operations-and-time to
+  the outcome down; it is the axis's primary author.
+- `evidence_density: 0.6` — the judgement is a measured count on the running
+  portal, not an assertion about screens shipped.
+- `human_cognitive_load: -0.3` — fewer operations to an outcome usually means less
+  the operator has to hold, though the two are distinct (a short path of dense
+  steps can still be low-effort and high-load).
+
+## Overlap scan (§4.3)
+
+Closest existing principle by the overlap scan: `design-research-required` at
+0.64, then `one-data-model` at 0.53 — both below the 0.70 bar. Distinct from
+design-research-required (which says anchor a design against comparable systems
+*before* building): this says measure the built result by operator cost on the
+running portal. It composes with
+[[principles/structural-verification-is-not-functional]] — a structural pass is
+not proof the outcome is cheaply reachable.

--- a/docs/founder-kernel/wiki/principles/destructive-actions-require-explicit-go.md
+++ b/docs/founder-kernel/wiki/principles/destructive-actions-require-explicit-go.md
@@ -6,7 +6,7 @@ status: published
 abstract: Before any destructive infrastructure action — volume wipes, force-pushes, secret rotation, recreates that lose state — list the steps and wait for an explicit go.
 principleTier: commandment
 principleDirection: List the steps and wait for an affirmative go before any destructive infrastructure action; this overrides autonomous-directive blanket approval.
-principleDimensionVector: {"blast_radius": -1.0, "governance_compliance": 0.9, "evidence_density": 0.7, "speed_to_value": -0.4}
+principleDimensionVector: {"blast_radius": -1.0, "governance_compliance": 0.9, "evidence_density": 0.7, "speed_to_value": -0.4, "legibility_of_consequence": 0.8}
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent

--- a/docs/founder-kernel/wiki/principles/disclose-before-you-add-a-surface.md
+++ b/docs/founder-kernel/wiki/principles/disclose-before-you-add-a-surface.md
@@ -1,0 +1,83 @@
+---
+title: Disclose before you add a surface
+slug: disclose-before-you-add-a-surface
+pageKind: principle
+status: published
+abstract: When a surface outgrows its first viewport, disclose progressively inside the existing home using the canonical construct before adding a new route, tab, or dashboard band.
+principleTier: core
+principleDirection: When a surface outgrows its first viewport, disclose progressively inside the existing home using the canonical construct before adding a new route, tab, or dashboard band.
+principleDimensionVector: {"operator_effort": -0.6, "human_cognitive_load": -0.7, "reusability": 0.5}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleConsumerArchetype: route-domain-specific
+principleConsumerContexts:
+  - ui
+principleRingScope:
+  - ring-2-workflow
+principlePublic: false
+authoredAt: 2026-07-23
+authoredBy: mark-bodman
+---
+
+# Disclose before you add a surface
+
+**When a surface has more to show than fits its first viewport, reveal the extra
+progressively inside the same home — using the canonical disclosure construct for
+the relationship — before you reach for a new route, tab, or dashboard band.**
+The default answer to "there's more content" is a disclosure, not a new surface.
+
+## Why
+
+Growth pressure on a screen is constant, and the lazy release valve is always a
+new tab or a new page. Each one enlarges the map the operator must hold and moves
+the "more" further from its context. Progressive disclosure keeps the extra
+content *where it belongs* — one click deep, in context — and keeps the top-level
+map small. It is also what makes the wall-of-text budget honest: a page that
+correctly defers its advanced content reads as calm, not as a page that dumped
+everything into the first viewport.
+
+The platform already prescribes *which* construct fits *which* relationship
+(`CollapsibleList` to preview a long list, `ExpandableCard` for subordinate
+detail among peers, native `<details>` for one short secondary aside, a drawer to
+preserve a large detail workspace, a dedicated route only when linking/history/a
+full workflow is needed). This principle says: choose from that set first, and
+only escalate to a new surface when none of them fit.
+
+## Applies To
+
+In-platform coworkers and external coding agents building or extending portal
+surfaces, and humans reviewing UI plans. It is the "what do I do when the home
+gets full" companion to [[principles/one-home-per-capability]] ("keep it one
+home"): that one says do not fork a second home; this one says grow the home
+inward by disclosure before you grow the map outward by a surface.
+
+## How To Apply
+
+When a surface needs to show more, pick the canonical disclosure construct for
+the summary→content relationship rather than hand-rolling an expand/collapse
+dialect or adding a tab. Excise deferred subtrees from the arrival view so the
+first viewport stays within budget; the deferred content lives one interaction
+away, in context. Escalate to a genuinely new route only when the content needs
+its own URL, history, or a full record workflow.
+
+## Decision Dimensions
+
+- `operator_effort: -0.6` — in-context disclosure keeps the extra content one
+  click from where it is relevant; a new tab/page adds navigation operations to
+  reach the same thing.
+- `human_cognitive_load: -0.7` — a small top-level map with detail tucked in
+  context is holdable; a map that grows a surface per "more" is not.
+- `reusability: 0.5` — reusing the canonical disclosure constructs converges the
+  portal on one expand/collapse vocabulary instead of a new dialect per feature.
+
+## Overlap scan (§4.3)
+
+Closest existing principle by the overlap scan: `substrate-cleanup-before-
+substrate-addition` at 0.62, then `design-research-required` at 0.55 — both below
+the 0.70 bar. Adjacent-but-distinct: substrate-cleanup is about consolidating
+*backend* substrate before adding a layer; this is about disclosing *UI* content
+inward before adding a surface. It is a means to lower
+[[principles/one-home-per-capability]]'s `operator_effort`, so it deliberately
+does not introduce a new dimension.

--- a/docs/founder-kernel/wiki/principles/human-in-the-loop-at-phase-boundaries.md
+++ b/docs/founder-kernel/wiki/principles/human-in-the-loop-at-phase-boundaries.md
@@ -5,7 +5,7 @@ status: published
 abstract: Approve transitions at phase boundaries, not individual tool calls.
 principleTier: commandment
 principleDirection: Approve transitions at phase boundaries, not individual tool calls.
-principleDimensionVector: {"governance_compliance": 1.0, "human_cognitive_load": -0.6, "speed_to_value": 0.5}
+principleDimensionVector: {"governance_compliance": 1.0, "human_cognitive_load": -0.6, "speed_to_value": 0.5, "legibility_of_consequence": 0.7}
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent

--- a/docs/founder-kernel/wiki/principles/kernel-defers-design-quality-to-the-fit-gate.md
+++ b/docs/founder-kernel/wiki/principles/kernel-defers-design-quality-to-the-fit-gate.md
@@ -1,0 +1,93 @@
+---
+title: The kernel defers design quality to the fit gate
+slug: kernel-defers-design-quality-to-the-fit-gate
+pageKind: principle
+status: published
+abstract: The kernel decides where a surface belongs and what it may do; it does not score design quality by weighted sum. Design quality routes to the ux-fit-review gate and the ux-design profession corpus, and the kernel consumes the verdict and its measured evidence as inputs.
+principleTier: core
+principleDirection: The kernel decides where a surface belongs and what it may do; it does not score design quality by weighted sum. Design quality routes to the ux-fit-review gate and the ux-design profession corpus, and the kernel consumes the verdict and its measured evidence as inputs.
+principleDimensionVector: {"schema_grounding": 0.8, "evidence_density": 0.7, "governance_compliance": 0.5, "human_cognitive_load": -0.3}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleConsumerArchetype: universal
+principleRingScope:
+  - universal-ring
+principlePublic: false
+authoredAt: 2026-07-23
+authoredBy: mark-bodman
+---
+
+# The kernel defers design quality to the fit gate
+
+**The kernel governs where a surface belongs and what it is allowed to do. It
+does not score design *quality* by weighted sum.** Design quality routes to the
+`dpf-ux-fit-review` gate and the `ux-design` profession corpus; the kernel
+consumes their verdict and measured evidence as inputs to a decision, rather than
+pretending to weigh craft it cannot commensurate.
+
+## Why
+
+`principle_decide` weighs options over commensurable axes. Some things are
+genuinely commensurable — blast radius, reversibility, operator effort — and the
+kernel weighs them well. Design *quality* — hierarchy, aesthetics, whether a
+screen feels calm — is not a defensible 0..1 an author can score before the
+surface exists; asking the kernel to weigh it produces theatre, where a binary
+UI-hygiene rule bubbles up as the "top contributor" on a decision it has nothing
+real to say about (the observation that opened BI-B5EA2FB2).
+
+The honest architecture is a division of labour: the kernel decides **altitude**
+(placement, authority, blast radius — governance it can weigh), the fit gate
+renders the **verdict** on a specific surface (`fits` / `fits-with-guardrails` /
+`defer` / `reject`), and the profession corpus holds the **craft**. The kernel's
+competence is knowing which questions it should answer and which it should route
+— and saying so, rather than producing a confident number over the wrong field.
+This generalizes: any future "the kernel can't really weigh X" finding gets the
+same treatment — recognise the altitude, route to whoever owns the craft, consume
+the verdict as evidence — instead of another dimension-family proposal.
+
+## Applies To
+
+In-platform coworkers, external coding agents, and humans making or reviewing a
+design decision. It is a rule about *how the kernel itself behaves* on
+design-altitude questions, which is why it is universal rather than surface-
+scoped. It composes with [[principles/design-research-required]] (research the
+design first) and [[principles/structural-verification-is-not-functional]] (a
+passing route test is not evidence the design is good).
+
+## How To Apply
+
+When a decision is about design quality rather than governance, do not force it
+through a weighted-sum consult. Route it to `dpf-ux-fit-review` and the
+`ux-design` profession corpus, take their verdict plus any measured evidence
+(operations-to-outcome, the fit decision and its required edits), and feed *that*
+back as an input. Reserve `principle_decide` for the parts the kernel can
+genuinely weigh — where the surface belongs, what it may do, who authorizes it.
+
+## Decision Dimensions
+
+- `schema_grounding: 0.8` — routing to the gate/corpus that owns the craft anchors
+  the decision in the real evaluator instead of a synthetic score.
+- `evidence_density: 0.7` — the kernel consumes a measured fit verdict as
+  evidence rather than manufacturing a number it cannot defend.
+- `governance_compliance: 0.5` — it keeps the kernel inside its own remit
+  (altitude and authority), which is what its governance role actually is.
+- `human_cognitive_load: -0.3` — one honest hand-off is easier to trust and audit
+  than a confident-looking weighted sum over the wrong field.
+
+## Universal-ring justification (§4.2)
+
+Earned, not defaulted: this binds at Ring 1 (a coworker choosing how to present an
+action), Ring 2 (Build Studio design phases), and Ring 4 (a promotion gate
+consuming a fit verdict) — three of the five rings — so it is scoped
+`universal-ring` rather than to a single ring.
+
+## Overlap scan (§4.3)
+
+Closest existing principle by the overlap scan: `design-research-required` at
+0.64, then `one-common-process-three-surfaces` at 0.62 — both below the 0.70 bar.
+Distinct from design-research-required (research a design against comparable
+systems before building): this is about *which evaluator owns the design-quality
+verdict* and the kernel declining to fake it. It is the highest-leverage of the
+BI-B5EA2FB2 set because it is the reframe made into doctrine.

--- a/docs/founder-kernel/wiki/principles/one-home-per-capability.md
+++ b/docs/founder-kernel/wiki/principles/one-home-per-capability.md
@@ -1,0 +1,80 @@
+---
+title: One home per capability
+slug: one-home-per-capability
+pageKind: principle
+status: published
+abstract: Every capability gets exactly one canonical route home; secondary surfaces link to it and never restate it. Prefer a filtered view of the existing home over a new dashboard, tab, or route family.
+principleTier: core
+principleDirection: Give every capability exactly one canonical route home; secondary surfaces link to it and never restate it. Prefer a filtered view of the existing home over a new dashboard, tab, or route family.
+principleDimensionVector: {"operator_effort": -0.5, "long_term_maintainability": 0.7, "reusability": 0.6, "human_cognitive_load": -0.5}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+  - human
+principleConsumerArchetype: route-domain-specific
+principleConsumerContexts:
+  - ui
+principleRingScope:
+  - ring-2-workflow
+principlePublic: false
+authoredAt: 2026-07-23
+authoredBy: mark-bodman
+---
+
+# One home per capability
+
+**Every capability lives at exactly one canonical route.** Secondary surfaces
+that need to reach it *link* to that home; they never restate it as a second
+copy. When a capability outgrows what one screen shows, the first answer is a
+filtered or scoped *view of the existing home* — not a new dashboard, a new tab
+row, or a new route family.
+
+## Why
+
+A capability with two homes is a capability with two truths: two places to keep
+in sync, two places an operator has to remember, two places a change has to
+land. The portal's failure mode is accretion — every feature that adds "its own"
+dashboard makes the whole product harder to hold in one head, and the cost is
+paid on every visit forever, not once at build time. Reuse of the existing home
+keeps the map small; a link is free, a duplicate home is a standing tax.
+
+This is the single most-invoked rule of the UX fit review ("do not approve a new
+dashboard when a section home or a filtered view would do"), promoted to a
+principle so the decision is made before the surface is built, not caught in
+review after the code already multiplied the problem.
+
+## Applies To
+
+In-platform coworkers and external coding agents proposing or building portal
+surfaces, and humans reviewing UI plans. It governs *navigation and information
+architecture* — where a capability lives and how other surfaces reach it. It is
+not about data (that is [[principles/single-source-of-truth]]); the two compose:
+one data model, one route home.
+
+## How To Apply
+
+Before adding a route, tab, dashboard band, or metric home, name the capability's
+existing canonical home and ask whether a filtered view of it would serve. If a
+second surface genuinely needs the capability, it links to the home and renders a
+scoped projection — it does not fork a parallel copy. A new home must *retire or
+converge* an old one, not sit beside it.
+
+## Decision Dimensions
+
+- `operator_effort: -0.5` — one home means one place to go; duplicated homes make
+  the operator hunt across surfaces for the authoritative one.
+- `long_term_maintainability: 0.7` — a single home is one thing to keep correct as
+  the system grows; every duplicate is a future divergence bug.
+- `reusability: 0.6` — a canonical home is linked-to and projected-from by many
+  callers instead of re-implemented per surface.
+- `human_cognitive_load: -0.5` — a small, non-duplicated route map is holdable in
+  one head; accreted parallel homes are not.
+
+## Overlap scan (§4.3)
+
+Closest existing principle by the kernel-evolution discipline's overlap scan
+(`principle_decide`, direction as a featureless option, DI on the ledger):
+`native-cohesion-over-interfacing` at 0.64, then `design-research-required` at
+0.56 — both below the 0.70 additivity bar, so this ships as a new principle.
+Paired-but-distinct from [[principles/single-source-of-truth]]: that governs the
+data (one system of record), this governs the navigation (one route home).

--- a/docs/founder-kernel/wiki/principles/propose-acknowledge-reassign.md
+++ b/docs/founder-kernel/wiki/principles/propose-acknowledge-reassign.md
@@ -6,7 +6,7 @@ status: published
 abstract: Concurrent work — operator↔agent, agent↔agent, session↔session — collides when state mutates from more than one pen without an acknowledged handoff token. Either side proposes; the named owner explicitly acknowledges; reassignment back is also explicit.
 principleTier: commandment
 principleDirection: Before mutating any artifact, propose ownership to the named owner and wait for explicit acknowledgement recorded as state; never assume implicit consent from silence; reassignment back is also explicit.
-principleDimensionVector: {"governance_compliance": 0.9, "evidence_density": 0.7, "long_term_maintainability": 0.6, "human_cognitive_load": -0.3, "speed_to_value": -0.2}
+principleDimensionVector: {"governance_compliance": 0.9, "evidence_density": 0.7, "long_term_maintainability": 0.6, "human_cognitive_load": -0.3, "speed_to_value": -0.2, "legibility_of_consequence": 0.6}
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent

--- a/docs/founder-kernel/wiki/principles/show-the-consequence-before-the-confirm.md
+++ b/docs/founder-kernel/wiki/principles/show-the-consequence-before-the-confirm.md
@@ -1,0 +1,86 @@
+---
+title: Show the consequence before the confirm
+slug: show-the-consequence-before-the-confirm
+pageKind: principle
+status: published
+abstract: Every affordance that authorizes an AI action must state, before the confirm, what will happen, to what, under whose authority, and how it is undone.
+principleTier: core
+principleDirection: Every affordance that authorizes an AI action must state, before the confirm, what will happen, to what, under whose authority, and how it is undone.
+principleDimensionVector: {"legibility_of_consequence": 0.9, "human_cognitive_load": -0.4, "evidence_density": 0.4}
+principleAppliesTo:
+  - in_platform_coworker
+  - external_coding_agent
+principleConsumerArchetype: ai-coworker-universal
+principleRingScope:
+  - ring-1-coworker
+  - ring-2-workflow
+principlePublic: false
+authoredAt: 2026-07-23
+authoredBy: mark-bodman
+---
+
+# Show the consequence before the confirm
+
+**Any affordance that authorizes an AI action must state — before the operator
+confirms — what will happen, to what, under whose authority, and how it is
+undone.** Consent to an action the operator cannot foresee is not consent.
+
+## Why
+
+The platform's premise is that AI drives real actions, and the safeguard against
+that going wrong is not only "ask before acting" but "ask *legibly*." A confirm
+button on an opaque action is a rubber stamp: the operator clicks yes to
+something they cannot picture, and the guardrail that was supposed to catch the
+bad case never fires because the human had nothing to catch it with. The four
+things a preview must carry — the effect, the target, the authority, the reversal
+— are exactly what an operator needs to withhold consent from the one action in a
+hundred that should be stopped.
+
+This is the UI-side realization of the authority commandments. Those say *that*
+you must get an explicit go
+([[principles/destructive-actions-require-explicit-go]],
+[[principles/outbound-actions-require-explicit-go]]); this says *what the ask
+must show* for that go to mean anything. It is the anchor for the
+`legibility_of_consequence` axis — the "can the operator foresee it?" dimension
+the anti-YOLO concern actually names.
+
+## Applies To
+
+In-platform coworkers and external coding agents building any affordance that
+authorizes an AI action (a confirm dialog, a run button, an approval card) — the
+agent classes that construct these surfaces, matching the authority family
+([[principles/destructive-actions-require-explicit-go]]). It does not add a
+*second* gate where the authority commandments already require one — it governs
+the *content* of the gate that already exists.
+
+## How To Apply
+
+Every authorize-an-AI-action affordance renders, before its confirm control: the
+effect (what will happen), the target (to what), the authority (under whose
+grant/role it runs), and the reversal (how it is undone, or that it cannot be).
+This composes with [[principles/no-native-browser-dialogs]] (the preview must be
+real DOM an agent and a test can read, not an opaque native dialog) and with
+[[principles/destructive-actions-require-explicit-go]] (the danger-tone confirm
+step stays; this makes its preview legible).
+
+## Decision Dimensions
+
+- `legibility_of_consequence: 0.9` — this principle exists to make an action's
+  consequence visible before authorization; it is the axis's primary author.
+- `human_cognitive_load: -0.4` — a structured four-part preview *reduces* what the
+  operator must reconstruct in their head to decide; an opaque confirm raises it.
+- `evidence_density: 0.4` — the preview is grounded in what the action will
+  actually do (target, authority), not a generic "are you sure?".
+
+## Overlap scan (§4.3)
+
+Closest existing principle by the overlap scan: `governance-approves-evidence-
+not-provenance` at 0.62, then `one-concern-per-pr` at 0.49 — below the 0.70 bar.
+**Scan caveat (recorded honestly):** the overlap scan ranks a candidate against
+core/contextual principles only — commandment directions are not embedded, so the
+authority *commandments* this principle is closest to in spirit
+(`destructive-actions-require-explicit-go`, `outbound-actions-require-explicit-go`)
+could not be scored by the scan. The additivity claim is therefore made on
+reasoning, not on a number: those commandments govern **whether** an explicit go
+is required; this governs **what the ask must display** for that go to be
+informed consent. It is the UI-content complement, not a fourth "ask first" rule.

--- a/packages/db/src/wiki-taxonomy.ts
+++ b/packages/db/src/wiki-taxonomy.ts
@@ -166,6 +166,14 @@ export const PRINCIPLE_DIMENSIONS = [
   "evidence_confidence", // benefit: investigation confidence in the verdict
   "customer_consent_state", // benefit: breadth of standing customer approval
   "business_disruption", // COST: does containment break production?
+  // Added for the design-quality kernel additions (BI-B5EA2FB2 / spec
+  // docs/superpowers/specs/2026-07-22-wwmd-design-quality-kernel-gap-design.md §3).
+  // Two axes the kernel genuinely lacked for design/UX-shaped decisions, each
+  // with an orthogonality claim vs the existing axes and >=2 authoring
+  // principles (§5). Named for what a HIGH score means, per the cost-name
+  // discipline that caught the never-wipe-db inversion.
+  "operator_effort", // COST: how many operator operations + elapsed time to the outcome
+  "legibility_of_consequence", // benefit: can the operator foresee what an action will do before authorizing it
 ] as const;
 export type PrincipleDimension = (typeof PRINCIPLE_DIMENSIONS)[number];
 
@@ -197,6 +205,13 @@ export const PRINCIPLE_COST_DIMENSIONS = [
   // EP-SOVEREIGN-SOC: a security response that breaks production is a cost the
   // governing principle must pull AGAINST (negative weight), same as blast_radius.
   "business_disruption",
+  // BI-B5EA2FB2: operator effort is a COST — a design that demands more operator
+  // operations/time to reach the outcome is worse, so a principle that favours
+  // fewer operations must carry a NEGATIVE weight. (legibility_of_consequence is
+  // a BENEFIT and intentionally stays out of this list.) Renamed from the BI's
+  // original "interaction_efficiency" precisely to avoid the benefit-shaped-name
+  // inversion this list's sign guard exists to prevent.
+  "operator_effort",
 ] as const satisfies readonly PrincipleDimension[];
 export type PrincipleCostDimension = (typeof PRINCIPLE_COST_DIMENSIONS)[number];
 


### PR DESCRIPTION
Founder-ratified authoring of the design-quality kernel additions from the merged resolution spec ([2026-07-22-wwmd-design-quality-kernel-gap-design.md](docs/superpowers/specs/2026-07-22-wwmd-design-quality-kernel-gap-design.md) §3/§5/§6). This is the final phase of BI-B5EA2FB2 — unblocked this session by BI-85341A52 (the §4.3 overlap scan is runnable) and BI-512FBD20 (embeddings restored, so the scan actually ranks).

## Overlap scans (§4.3) — all clean

Every candidate scored well under the 0.70 additivity bar, so each ships as a new principle:

| Principle | Closest existing | Alignment |
|---|---|---|
| one-home-per-capability | native-cohesion-over-interfacing | 0.64 |
| disclose-before-you-add-a-surface | substrate-cleanup-before-substrate-addition | 0.62 |
| count-the-operations-to-outcome | design-research-required | 0.64 |
| show-the-consequence-before-the-confirm | governance-approves-evidence-not-provenance | 0.62 |
| kernel-defers-design-quality-to-the-fit-gate | design-research-required | 0.64 |

**Honest scan caveat** (recorded in `show-the-consequence`'s file): the scan ranks a candidate against **core/contextual** principles only — commandment directions aren't embedded — so `show-the-consequence`'s overlap against the authority **commandments** (`destructive-actions-require-explicit-go`, `outbound-actions-require-explicit-go`) is argued on reasoning, not a number: those govern *whether* an explicit go is required; this governs *what the ask must display*.

## Two dimensions (`wiki-taxonomy.ts` + `dimension-catalog.ts`)

- **`operator_effort`** (COST — added to `PRINCIPLE_COST_DIMENSIONS`): operations + elapsed time to the outcome. Renamed from the BI's original `interaction_efficiency` precisely because a benefit-shaped name in the cost list is the inversion the sign-convention guard exists to prevent. Orthogonal to `human_cognitive_load` (hold-in-head vs must-do) and `speed_to_value` (team vs user).
- **`legibility_of_consequence`** (BENEFIT): can the operator foresee, before authorizing, what will happen / to what / under whose authority / how undone. Orthogonal to `reversibility` (after vs before), `evidence_density` (record-after vs seen-before), `governance_compliance` (rule-satisfied vs visible-to-authorizer). Admitting it should *reduce* the `governance_compliance`↔`blast_radius` co-linearity §7.2 flagged.

## Five principles + three amendments

New: `one-home-per-capability`, `disclose-before-you-add-a-surface`, `count-the-operations-to-outcome` (operator_effort anchor), `show-the-consequence-before-the-confirm` (legibility anchor), `kernel-defers-design-quality-to-the-fit-gate` (the reframe as doctrine, universal-ring earned).

§6 amendments — added `legibility_of_consequence` to the authority principles that were proxying it: `destructive-actions-require-explicit-go` (0.8), `propose-acknowledge-reassign` (0.6), `human-in-the-loop-at-phase-boundaries` (0.7). Additive; no existing key changed.

## Verification

- **db + web `tsc --noEmit` → 0 errors** (`--max-old-space-size=8192`). The exhaustive `HIGH_MEANS: Record<PrincipleDimension>` compiles — proof both new dimensions are catalogued.
- **`@dpf/db` seed-wiki-kernel + wiki-taxonomy → 86 pass**, incl. the dimension-vector **sign-convention guard** (operator_effort weights all negative: −0.5/−0.6/−0.9) and the **consumer-archetype coherence guard** (§8A.1 — caught and fixed `show-the-consequence` including `human` under `ai-coworker-universal`; now matches the authority family's agent-classes-only `appliesTo`).
- **web `lib/wiki` + `lib/decision` → 67 files / 731 tests pass** (lint detectors, dimension catalog, principle-decide pack, golden-decisions, principle matrix).
- Doc-reference integrity OK.

## Design grounding

Process-Spine-Decision: reviewed the merged BI-B5EA2FB2 resolution spec and the existing `PRINCIPLE_DIMENSIONS` / `dimension-catalog` / founder-kernel principle substrate; founder-ratified kernel authoring that adds two registry dimensions and five principles per the spec, no route/queue/UI surface.

`Local-CI-Override:` pushed with the pre-push gate overridden — verified as above; the shared `.local-ci-runner` is mid-integration on another session's branch. GitHub CI is the binding gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Seed-Fit-Decision: global-default
