### PR TITLE
feat(ux-critique): make the corpus authority contract mechanical (BI-3880DA1D)

### DIFF
--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -6254,6 +6254,7 @@
         "what-an-entry-is",
         "the-authority-contract",
         "capture-in-practice",
+        "where-entries-live-and-how-the-contract-is-enforced",
         "anti-patterns",
         "see-also"
       ]

--- a/apps/web/lib/ux-critique/critique-entry.test.ts
+++ b/apps/web/lib/ux-critique/critique-entry.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  awaitingVerdict,
+  calibrationSet,
+  isCalibrationEligible,
+  routeCoverage,
+  splitForCalibration,
+  validateCritiqueEntry,
+  type CritiqueEntry,
+} from "./critique-entry";
+
+function entry(overrides: Partial<CritiqueEntry> = {}): CritiqueEntry {
+  const result = validateCritiqueEntry({
+    route: "/workspace",
+    finding: "Lead band carries 240 words before the owner's next action appears.",
+    screenshotRef: "capture/workspace-390-light.png",
+    gitRef: "abc1234",
+    verdict: "change-needed",
+    verdictAuthority: "founder",
+    status: "published",
+    ...overrides,
+  });
+  if (!result.ok) throw new Error(`fixture invalid: ${result.error}`);
+  return result.entry;
+}
+
+describe("validateCritiqueEntry", () => {
+  it("rejects an impression instead of an observation", () => {
+    const result = validateCritiqueEntry({ route: "/workspace", finding: "feels cluttered" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a verdict with no recorded author", () => {
+    const result = validateCritiqueEntry({
+      route: "/workspace",
+      finding: "Lead band carries 240 words before the next action appears.",
+      verdict: "change-needed",
+    });
+    expect(result).toEqual({ ok: false, error: "A verdict must record who attached it." });
+  });
+
+  it("defaults a new entry to draft so nothing is born calibration-eligible", () => {
+    const result = validateCritiqueEntry({
+      route: "/workspace",
+      finding: "Lead band carries 240 words before the next action appears.",
+    });
+    expect(result.ok && result.entry.status).toBe("draft");
+  });
+});
+
+describe("the authority contract", () => {
+  it("accepts a published, founder-verdicted, screenshotted entry", () => {
+    expect(isCalibrationEligible(entry())).toBe(true);
+  });
+
+  it("counts a no-change-needed verdict — negative entries are calibration data", () => {
+    // A corpus of only-problems teaches that every screen has a problem.
+    expect(isCalibrationEligible(entry({ verdict: "no-change-needed" }))).toBe(true);
+  });
+
+  it("REFUSES an agent-proposed verdict", () => {
+    // The load-bearing case. A judge calibrated on agent-authored entries is
+    // calibrated against itself and reports rising agreement while measuring
+    // nothing.
+    expect(isCalibrationEligible(entry({ verdictAuthority: "agent-proposed" }))).toBe(false);
+  });
+
+  it("refuses a draft even when it carries a founder verdict", () => {
+    expect(isCalibrationEligible(entry({ status: "draft" }))).toBe(false);
+  });
+
+  it("refuses an entry with no verdict yet", () => {
+    expect(isCalibrationEligible(entry({ verdict: null, verdictAuthority: null }))).toBe(false);
+  });
+
+  it("refuses an entry nobody can look at again", () => {
+    expect(isCalibrationEligible(entry({ screenshotRef: null }))).toBe(false);
+  });
+
+  it("derives the calibration set rather than trusting a curated list", () => {
+    const entries = [
+      entry(),
+      entry({ verdictAuthority: "agent-proposed" }),
+      entry({ status: "draft" }),
+    ];
+    expect(calibrationSet(entries)).toHaveLength(1);
+  });
+});
+
+describe("awaitingVerdict", () => {
+  it("surfaces exactly the entries a founder still has to rule on", () => {
+    const needsRuling = entry({ verdict: null, verdictAuthority: null, status: "draft" });
+    const proposed = entry({ verdictAuthority: "agent-proposed", status: "draft" });
+    const done = entry();
+    const queue = awaitingVerdict([needsRuling, proposed, done]);
+    expect(queue).toHaveLength(2);
+    expect(queue).not.toContain(done);
+  });
+});
+
+describe("splitForCalibration", () => {
+  const many = Array.from({ length: 200 }, (_, i) =>
+    entry({ route: `/route-${i}`, finding: `Default view runs to ${300 + i} words on this route.` }),
+  );
+
+  it("never lets a held-out entry also ground the judge", () => {
+    // The property the whole measurement rests on: held-out must mean
+    // never-grounded-in, or agreement is a memory test that passes trivially.
+    const { grounding, heldOut } = splitForCalibration(many);
+    const groundingKeys = new Set(grounding.map((e) => e.finding));
+    for (const held of heldOut) {
+      expect(groundingKeys.has(held.finding)).toBe(false);
+    }
+    expect(grounding.length + heldOut.length).toBe(many.length);
+  });
+
+  it("is deterministic across runs", () => {
+    const first = splitForCalibration(many).heldOut.map((e) => e.route);
+    const second = splitForCalibration(many).heldOut.map((e) => e.route);
+    expect(second).toEqual(first);
+  });
+
+  it("is stable when unrelated entries are added", () => {
+    // Re-splitting on a grown corpus must not reshuffle prior assignments,
+    // otherwise yesterday's held-out entry silently becomes grounding.
+    const before = new Set(splitForCalibration(many).heldOut.map((e) => e.route));
+    const grown = [...many, entry({ route: "/brand-new", finding: "A newly captured finding here." })];
+    for (const held of splitForCalibration(grown).heldOut) {
+      if (held.route !== "/brand-new") expect(before.has(held.route)).toBe(true);
+    }
+  });
+
+  it("splits roughly at the requested percentage", () => {
+    const { heldOut } = splitForCalibration(many, 30);
+    expect(heldOut.length).toBeGreaterThan(many.length * 0.15);
+    expect(heldOut.length).toBeLessThan(many.length * 0.45);
+  });
+
+  it("only ever splits eligible entries", () => {
+    const { grounding, heldOut } = splitForCalibration([
+      entry(),
+      entry({ route: "/draft-one", status: "draft" }),
+    ]);
+    expect(grounding.length + heldOut.length).toBe(1);
+  });
+});
+
+describe("routeCoverage", () => {
+  it("counts eligible entries per route, ignoring drafts", () => {
+    const coverage = routeCoverage([
+      entry({ route: "/workspace" }),
+      entry({ route: "/workspace", finding: "Six status lines sit above the primary action." }),
+      entry({ route: "/finance", status: "draft" }),
+    ]);
+    expect(coverage.get("/workspace")).toBe(2);
+    expect(coverage.has("/finance")).toBe(false);
+  });
+});

--- a/apps/web/lib/ux-critique/critique-entry.ts
+++ b/apps/web/lib/ux-critique/critique-entry.ts
@@ -1,0 +1,233 @@
+// UX critique corpus — the typed entry shape and the calibration-eligibility
+// rule (EP-UX-SYSTEM L6, BI-3880DA1D).
+//
+// The corpus is not a new store. A critique entry is a craft-override WikiPage
+// under `craft/ux-design/<slug>` (see lib/wiki/craft-override.ts) carrying its
+// structured fields in WikiPage.metadata — the same free-form bag the WSID
+// variant axes already use. Org-scoped, revisioned, and surfaced on the craft
+// surface for free. This module owns the SHAPE and the RULE; persistence stays
+// with the existing wiki store.
+//
+// Why this module exists at all: the corpus method page states that entries are
+// founder-authored and that an agent may draft but never attach a verdict. A
+// documented contract that nothing enforces is the attestation theater this
+// whole program exists to end (spec §2). So the contract is code here, and the
+// calibration set is *derived* rather than curated by hand — there is no path
+// that returns an agent-authored verdict as calibration data.
+//
+// Pure: no prisma, no fs, no clock. Importable from tests, MCP tools, and the
+// craft surface alike.
+
+/** What the reviewer actually decided about the screen. */
+export const CRITIQUE_VERDICTS = [
+  /** The finding is real and the screen should change. */
+  "change-needed",
+  /** Looked at it; it is fine as-is. Negative entries are calibration data too. */
+  "no-change-needed",
+  /** Real, but deliberately not now — records the judgment without implying a fix. */
+  "accepted-debt",
+] as const;
+export type CritiqueVerdict = (typeof CRITIQUE_VERDICTS)[number];
+
+/**
+ * Who attached the verdict. Only `founder` and `designer` are ATTACHING
+ * authorities. `agent-proposed` exists so a draft can carry a suggested verdict
+ * without that suggestion ever counting as calibration — the distinction the
+ * corpus depends on. Basis: six researchers ranking UI preference pairs showed
+ * very low agreement with expert designers, so "a careful human looked at it"
+ * is not the qualification; being the design authority for this product is.
+ */
+export const VERDICT_AUTHORITIES = ["founder", "designer", "agent-proposed"] as const;
+export type VerdictAuthority = (typeof VERDICT_AUTHORITIES)[number];
+
+const ATTACHING_AUTHORITIES: readonly VerdictAuthority[] = ["founder", "designer"];
+
+/** The lenses a finding can be argued under. Evidence first; the lens explains why. */
+export const CRITIQUE_LENSES = [
+  "hierarchy",
+  "density",
+  "hick",
+  "fitts",
+  "miller",
+  "doherty",
+] as const;
+export type CritiqueLens = (typeof CRITIQUE_LENSES)[number];
+
+export type CritiqueEntry = {
+  /** Route the screen was captured from, e.g. "/workspace". */
+  route: string;
+  /**
+   * Reference to the captured image. A critique of a screen nobody can look at
+   * again is not reviewable, so this is required for eligibility.
+   */
+  screenshotRef: string | null;
+  /** Viewport width in CSS px at capture (390 = mobile band, 1280 = desktop). */
+  viewportWidth: number | null;
+  colorScheme: "light" | "dark" | null;
+  /**
+   * The commit the screen was rendered at. Without it a before/after pair
+   * cannot be reconstructed later, which is how the EP-UX-COGLOAD findings
+   * became text-only in the first place.
+   */
+  gitRef: string | null;
+  /** What is wrong, specifically. "Feels heavy" is not an entry. */
+  finding: string;
+  lenses: readonly CritiqueLens[];
+  verdict: CritiqueVerdict | null;
+  verdictAuthority: VerdictAuthority | null;
+  /** Mirrors the WikiPage row status; agent drafts land as "draft". */
+  status: "draft" | "published";
+};
+
+const MIN_FINDING_CHARS = 24;
+
+export type CritiqueEntryValidation =
+  | { ok: true; entry: CritiqueEntry }
+  | { ok: false; error: string };
+
+/**
+ * Shape validation only. A VALID entry is not necessarily a CALIBRATION-ELIGIBLE
+ * one — that is `isCalibrationEligible`, and keeping them separate is deliberate:
+ * drafts must be storable so the founder has something to react to, while never
+ * being mistakable for calibration data.
+ */
+export function validateCritiqueEntry(input: Partial<CritiqueEntry>): CritiqueEntryValidation {
+  const route = input.route?.trim() ?? "";
+  const finding = input.finding?.trim() ?? "";
+
+  if (!route.startsWith("/")) {
+    return { ok: false, error: "A critique entry needs the route it was captured from." };
+  }
+  if (finding.length < MIN_FINDING_CHARS) {
+    return {
+      ok: false,
+      error:
+        "Say what is specifically wrong — a measurement or a structural observation, not an impression.",
+    };
+  }
+  if (input.verdict && !CRITIQUE_VERDICTS.includes(input.verdict)) {
+    return { ok: false, error: `Unknown verdict "${input.verdict}".` };
+  }
+  if (input.verdictAuthority && !VERDICT_AUTHORITIES.includes(input.verdictAuthority)) {
+    return { ok: false, error: `Unknown verdict authority "${input.verdictAuthority}".` };
+  }
+  if (input.verdict && !input.verdictAuthority) {
+    return { ok: false, error: "A verdict must record who attached it." };
+  }
+  for (const lens of input.lenses ?? []) {
+    if (!CRITIQUE_LENSES.includes(lens)) {
+      return { ok: false, error: `Unknown lens "${lens}".` };
+    }
+  }
+
+  return {
+    ok: true,
+    entry: {
+      route,
+      screenshotRef: input.screenshotRef?.trim() || null,
+      viewportWidth: input.viewportWidth ?? null,
+      colorScheme: input.colorScheme ?? null,
+      gitRef: input.gitRef?.trim() || null,
+      finding,
+      lenses: input.lenses ?? [],
+      verdict: input.verdict ?? null,
+      verdictAuthority: input.verdictAuthority ?? null,
+      status: input.status ?? "draft",
+    },
+  };
+}
+
+/**
+ * The authority contract, mechanically. An entry counts as calibration data only
+ * when a human design authority has ruled on a screen someone can look at again.
+ *
+ * Each clause earns its place:
+ * - published    — a draft is a proposal, whatever it contains.
+ * - verdict      — "no verdict yet" is the corpus's work queue, not its content.
+ * - attaching authority — an agent-proposed verdict never promotes itself. A
+ *   judge calibrated on agent-authored entries is calibrated against itself and
+ *   would report rising agreement while measuring nothing.
+ * - screenshotRef — an unreviewable claim cannot be re-judged, so it cannot
+ *   settle a disagreement later.
+ */
+export function isCalibrationEligible(entry: CritiqueEntry): boolean {
+  return (
+    entry.status === "published" &&
+    entry.verdict !== null &&
+    entry.verdictAuthority !== null &&
+    ATTACHING_AUTHORITIES.includes(entry.verdictAuthority) &&
+    entry.screenshotRef !== null
+  );
+}
+
+/** The calibration set is derived, never hand-curated. */
+export function calibrationSet(entries: readonly CritiqueEntry[]): CritiqueEntry[] {
+  return entries.filter(isCalibrationEligible);
+}
+
+/**
+ * Entries that need a founder verdict — the corpus's work queue, and the single
+ * most useful recurring task the curation role performs.
+ */
+export function awaitingVerdict(entries: readonly CritiqueEntry[]): CritiqueEntry[] {
+  return entries.filter(
+    (e) =>
+      !isCalibrationEligible(e) &&
+      (e.verdict === null || !ATTACHING_AUTHORITIES.includes(e.verdictAuthority as VerdictAuthority)),
+  );
+}
+
+/**
+ * Deterministic hash over the entry's identity. Same entry → same bucket on
+ * every run, so the held-out slice below is stable across processes and machines
+ * without storing a split or seeding a RNG.
+ */
+function stableBucket(entry: CritiqueEntry, buckets: number): number {
+  const key = `${entry.route}|${entry.gitRef ?? ""}|${entry.finding}`;
+  let hash = 5381;
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) + hash + key.charCodeAt(i)) >>> 0;
+  }
+  return hash % buckets;
+}
+
+export type CalibrationSplit = {
+  /** Entries the judge may be grounded in. */
+  grounding: CritiqueEntry[];
+  /** Entries reserved for measuring agreement — never used for grounding. */
+  heldOut: CritiqueEntry[];
+};
+
+/**
+ * Split the calibration set into grounding and held-out halves.
+ *
+ * The calibration gate promotes a critique's authority on "measured agreement
+ * against a held-out slice." Held-out has to mean never-grounded-in, or the
+ * measurement is a memory test that passes trivially. Deterministic bucketing
+ * makes that property checkable rather than promised: the same entry lands in
+ * the same half on every run, so grounding cannot quietly leak across.
+ *
+ * @param heldOutPercent share reserved for measurement (default 30%).
+ */
+export function splitForCalibration(
+  entries: readonly CritiqueEntry[],
+  heldOutPercent = 30,
+): CalibrationSplit {
+  const eligible = calibrationSet(entries);
+  const grounding: CritiqueEntry[] = [];
+  const heldOut: CritiqueEntry[] = [];
+  for (const entry of eligible) {
+    if (stableBucket(entry, 100) < heldOutPercent) heldOut.push(entry);
+    else grounding.push(entry);
+  }
+  return { grounding, heldOut };
+}
+
+/** Coverage by route — the exit condition is breadth, not a row count. */
+export function routeCoverage(entries: readonly CritiqueEntry[]): Map<string, number> {
+  const coverage = new Map<string, number>();
+  for (const entry of calibrationSet(entries)) {
+    coverage.set(entry.route, (coverage.get(entry.route) ?? 0) + 1);
+  }
+  return coverage;
+}

--- a/docs/professions/ux-design/wiki/critique-calibration-gate.md
+++ b/docs/professions/ux-design/wiki/critique-calibration-gate.md
@@ -71,6 +71,12 @@ WSID craft decisions are weighed through `evaluate_profession_decision`, which g
 
 The short version: vectors make this gate's *reasoning* legible and its *promotions* auditable. They do not move where the authority sits.
 
+**Profession-local axes are deliberately not declared yet.** The vector design lets a profession declare its own axes — typed `benefit`/`cost`, each projecting onto at least one spine axis so the decision still rolls up when it leaves the profession, and each carrying a cited source. UX design is the design's own worked example: `hierarchy_clarity` projecting onto `human_cognitive_load`.
+
+The obvious candidates here are already named by the craft pages — hierarchy clarity, content density, disclosure quality, and perceptual coherence (the deterministic family), each of which would project onto cognitive load and, for the last, onto aesthetic judgment.
+
+They stay undeclared on purpose. Local axes are **step 4** of a sequence whose first three steps are fixing structural scoring, settling which axes are spine, and migrating the corpus down-tier — and the sequencing is load-bearing, because axes projected onto a spine that is about to change would have to be re-projected and every decision scored against them re-scored. Declaring early would buy nothing and cost exactly the rework the sequence exists to prevent. This page records the candidates so the work is not rediscovered; the declaration waits for the spine.
+
 ## Scope boundary
 
 This gate governs **compositional** critique: is this screen well designed, judged before anyone uses it. It does not govern **behavioural** findings — where real users actually struggled, drawn from usage telemetry. That is a different question with a different evidence base, a different coworker, and its own governance. When a finding is behavioural, hand it over rather than speculating about users that were never observed.

--- a/docs/professions/ux-design/wiki/design-critique-corpus-method.md
+++ b/docs/professions/ux-design/wiki/design-critique-corpus-method.md
@@ -44,6 +44,25 @@ And the degenerate case is worse: a judge calibrated against agent-authored entr
 3. **Cluster, do not multiply.** Ten instances of the same wall-of-text pattern across ten routes is one lesson with ten examples. Cluster them so retrieval returns the lesson.
 4. **Chase the gaps.** Entries drafted but missing a verdict are the corpus's work queue. Surfacing them for a quick founder pass is the single most useful recurring task the curation role performs.
 
+## Where entries live, and how the contract is enforced
+
+The corpus is **not a new store**. A critique entry is a craft-override page under `craft/ux-design/<slug>` — the same org-scoped, revisioned overlay the craft surface already serves — carrying its structured fields (route, screenshot reference, viewport, git ref, finding, lenses, verdict, verdict authority) in the page's metadata bag, exactly as the WSID variant axes already do.
+
+That means an entry inherits revision history, org scoping, and a place in the UI without anything new being built, and it means the corpus is readable by the same tools that read the rest of the profession corpus.
+
+**The authority contract is code, not etiquette.** An entry is calibration-eligible only when all four hold:
+
+1. it is **published**, not a draft — a draft is a proposal whatever it contains;
+2. a **verdict** is attached — "no verdict yet" is the work queue, not the content;
+3. the verdict was attached by a **founder or designer** — an agent-proposed verdict never promotes itself;
+4. it carries a **screenshot reference** — an unreviewable claim cannot settle a disagreement later.
+
+The calibration set is *derived* by applying that rule, never hand-curated, so there is no path by which an agent-authored verdict reaches the judge as calibration data. Drafting and publishing are already separate steps with separate authority: an agent drafts, a human publishes.
+
+**The held-out slice is deterministic.** The calibration gate promotes authority on measured agreement against entries the judge was never grounded in. That property is enforced by stable bucketing on the entry's identity rather than by a stored split or a random seed — so the same entry lands on the same side on every run, on every machine, and growing the corpus never silently reshuffles yesterday's held-out entry into grounding. Without that, the agreement measurement is a memory test that passes trivially.
+
+Coverage is measured by **route breadth**, not row count: the exit condition from the curation stage is that the corpus spans the shell types actually in use.
+
 ## Anti-patterns
 
 - **Rubric without examples.** The 13.1% configuration. Never ship it.


### PR DESCRIPTION
Finishes the AGT-906 work started in [#3436](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3436) / [#3444](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3444).

## The gap this closes

#3436 shipped three WSID pages describing a critique corpus. **Nothing implemented one.** So the contract those pages state — entries are founder-authored, an agent may draft but never attach a verdict — was prose that nothing enforced. That is the attestation theater this program exists to end, applied to our own governance.

## No new store

A critique entry is a craft-override `WikiPage` under `craft/ux-design/<slug>`, carrying its structured fields in the metadata bag exactly as the WSID variant axes already do. It inherits org scoping, revision history, and a place on the craft surface for free. Drafting and publishing are already separate steps with separate authority — an agent drafts, a human publishes. This module gives that separation teeth.

## The contract, in code

`isCalibrationEligible` requires all four: **published**, **verdict attached**, **attached by a founder or designer**, **screenshot exists**. The calibration set is *derived* by applying that rule, never hand-curated, so no path returns an agent-authored verdict as calibration data — a judge calibrated on those is calibrated against itself and would report rising agreement while measuring nothing.

Negative verdicts are first-class: `no-change-needed` counts. A corpus of only-problems would teach that every screen has a problem.

## The held-out split, made checkable

The gate promotes authority on agreement measured against entries the judge was **never grounded in**. So held-out has to *mean* never-grounded-in, or the measurement is a memory test that passes trivially.

Deterministic bucketing over entry identity gives that without a stored split or a seeded RNG: same entry, same side, every run and every machine — and growing the corpus cannot silently reshuffle yesterday's held-out entry into grounding. Tested explicitly, since it's the property the whole measurement rests on.

## Deliberately not included

**Seeded entries.** Authoring corpus entries is the founder's, and an agent seeding its own calibration data would violate the contract this PR exists to enforce. `awaitingVerdict()` is the queue that makes the next founder review a fast pass instead of a blank page.

## On the vector work

The decision-tier rebalance spec landed in main while this was open, and it uses UX design as its worked example (`hierarchy_clarity` → `human_cognitive_load`). I did **not** declare this profession's local axes.

§3 sequencing is load-bearing: local axes are step 4, behind structural-scoring repair, spine reduction, and corpus migration. Axes projected onto a spine that's about to change would need re-projection and every decision re-scored. The candidates are recorded on the gate page and filed as **BI-F405AC58** (blocked) so the work isn't rediscovered — the declaration waits for the spine.

One constraint carried forward: **axes weigh options; they don't set thresholds.** The promotion threshold stays a founder risk-appetite call stated in advance, and the critic may not score its own promotion.

## Verification

- **17/17** new tests, including the agent-proposed refusal and the no-leak-across-split property
- `tsc` clean on the new module; module-size OK; doc index fresh (539); Docs Link Integrity **PASS**
- The one failing guard (provider-local-connector lifecycle self-test) reproduces on a stashed clean tree — pre-existing, not from this branch

Docs-Impact-Decision: updates docs/professions/ux-design/wiki/design-critique-corpus-method.md and critique-calibration-gate.md; doc index regenerated.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)