### PR TITLE
feat(governance): no quality-issue detector without a declared resolver + self-heal the docker-host leak

### DIFF
--- a/docs/data-impact/2026-07-24-docker-host-hyphen-stale-resolve.data-impact.json
+++ b/docs/data-impact/2026-07-24-docker-host-hyphen-stale-resolve.data-impact.json
@@ -1,0 +1,39 @@
+{
+  "version": "1",
+  "accountableOwner": "data-steward",
+  "affectedCopies": [
+    "PortfolioQualityIssue rows (open stale_entity / stale_relationship for docker-host: topology)",
+    "Prisma-to-EA current-state data-model mirror"
+  ],
+  "migration": {
+    "name": "20260724010000_resolve_docker_host_hyphen_stale_issues",
+    "backfill": "status flip only — no row is created or deleted, no id, scope FK, summary, or detection timestamp is changed. Open stale_entity / stale_relationship rows whose issueKey carries a positional `docker-host:` token are set status open->resolved with resolvedAt=NOW(). These are platform-internal Docker Desktop topology (dpf_bootstrap:HOSTS:docker-host:docker-desktop->net-iface:...) that leaked past every prior suppression pass because discovery-collectors/docker.ts emits the HYPHENATED form while the guard listed only the UNDERSCORED `docker_host:`. They are never operator-actionable and can never resolve on their own. The guard now lists both separators so no new rows of this shape are emitted. Matched positionally (after `:` or the `->` arrow) so a product legitimately containing the letters is untouched. Non-destructive and idempotent: already-resolved rows are not re-selected.",
+    "verification": "previewed on the live install 2026-07-24: resolves exactly 124 rows and leaves 17 open (genuine UniFi gateway/switch/AP topology + host NICs, which are real operator signal)"
+  },
+  "tests": [
+    "packages/db/src/docker-origin.test.ts",
+    "packages/db/src/quality-issue-registry.test.ts"
+  ],
+  "changes": [
+    {
+      "kind": "model",
+      "assetId": "data:portfolio-quality-issue#docker-host-hyphen-stale-resolve",
+      "prismaModel": "PortfolioQualityIssue",
+      "lifecycleDisposition": "no lifecycle change to the underlying InventoryEntity / InventoryRelationship or any operator-facing record: only the derived quality-issue status transitions open->resolved for issues describing platform-internal Docker Desktop topology. firstDetectedAt, lastDetectedAt, scope FKs and summary are preserved; rows remain for audit.",
+      "fields": [
+        {
+          "fieldId": "data:portfolio-quality-issue#status",
+          "resolution": "governed",
+          "reason": "resolve permanently-open, never-actionable rows emitted for the platform's own Docker Desktop host topology that bypassed the Docker-origin guard on a one-character separator mismatch (docker-host: vs docker_host:); they cannot be closed by any operator action and the guard now prevents new ones",
+          "provenance": "live-DB analysis 2026-07-24: 141 open stale_* rows = 124 matching [:>]docker-host: (resolved here) + 17 genuine managed topology (left open); root cause traced to discovery-collectors/docker.ts:236 emitting `docker-host:${name}` while docker-origin.ts DOCKER_RELATIONSHIP_TOKENS listed `docker_host:`"
+        },
+        {
+          "fieldId": "data:portfolio-quality-issue#resolvedAt",
+          "resolution": "governed",
+          "reason": "stamp the resolution time for the audit trail on the same open->resolved transition",
+          "provenance": "set to NOW() only on rows matching the positional docker-host: predicate; managed-topology rows are untouched"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/specs/2026-07-24-quality-issue-lifecycle-governance-design.md
+++ b/docs/superpowers/specs/2026-07-24-quality-issue-lifecycle-governance-design.md
@@ -1,0 +1,104 @@
+# Quality-issue lifecycle governance: no detector without a resolver
+
+Status: implemented (phase 1 of BI-0B420A1D)
+Date: 2026-07-24
+Backlog: BI-0B420A1D — handoff capture for the holistic estate-management thread
+
+## Problem
+
+The open-issues arc (PRs #3163 / #3418 / #3424 / #3437 / #3448) fixed five
+*instances* of the same defect. This spec fixes the *class*.
+
+Every one of those defects had the same shape: **a detector with no lifecycle and
+no notion of consequence.** Nothing in the platform required an issue type to
+declare how it ends, so detectors accumulated 2,247 open rows over roughly two
+months and buried the handful of rows that were real signal.
+
+Two concrete, verified findings underpin this:
+
+1. **The type union was fiction.** `QUALITY_ISSUE_TYPES` declared 8 types. The
+   live database held 10 — **8 of them undeclared**, and 6 of the declared ones
+   never used. `openOrUpdateQualityIssue` validates against the union and throws
+   on unknown types, but **7 direct `prisma.portfolioQualityIssue.upsert` call
+   sites bypass it entirely** (`discovery-sync.ts`, `discovery-runner.ts`,
+   `health-alert-issue.ts`, `edge-event-correlation.ts`). The validation was
+   real; nothing routed through it.
+
+2. **Hand-maintained token lists have no conformance check.**
+   `discovery-collectors/docker.ts` emits `docker-host:` (HYPHEN) while the
+   Docker-origin guard listed `docker_host:` (UNDERSCORE). One character leaked
+   **124 rows** that survived every prior suppression pass and cleanup migration.
+
+## Design
+
+### 1. The registry is the contract (`packages/db/src/quality-issue-registry.ts`)
+
+Every issue type declares how it ends:
+
+| Field | Meaning |
+| --- | --- |
+| `resolvedBy` | `discovery-sweep-reconcile` \| `suppressed-at-emission` \| `operator` \| `coworker` \| `monitor-clears` |
+| `autoResolveWhen` | the machine-checkable auto-close condition, or `null` |
+| `operatorActionable` | can a human/coworker actually do something? |
+| `expectedSteadyState` | open rows expected in a healthy install (0 = any row is drift) |
+| `owner` | who drives the queue down when it exceeds budget |
+
+### 2. Enforcement is the compiler, not a script
+
+`QualityIssueType` is **derived** from the registry (`keyof typeof
+QUALITY_ISSUE_REGISTRY`), and `InventoryQualityIssue.issueType` is typed as
+`QualityIssueType` instead of `string`. That chain —
+`evaluateInventoryQuality` → `discovery-sync`'s direct `prisma.upsert` — is
+exactly how the 8 undeclared types reached production. **Emitting an
+unregistered type is now a compile error**, which is stronger than a CI script
+and cannot be bypassed by choosing a different write path.
+
+Two unit-test gates back it:
+- every registered type declares a resolver, owner, budget and summary;
+- **a type that never auto-resolves must be operator-actionable** — otherwise it
+  is a permanently-open row generator by construction (precisely what
+  `name_not_promotable` / `type_not_promotable` were).
+
+### 3. The platform surfaces its own drift
+
+`qualityIssueDrift(openCountsByType)` returns every queue over its declared
+budget, worst overrun first, **with its owner**. This is the input a proactive
+sweep — or the weekly use-it-or-lose-it token allocator — consumes to decide what
+to work on, so drift is surfaced by the platform rather than noticed by a human
+looking at a dashboard.
+
+### 4. Self-healing: the `docker-host:` leak
+
+The guard now lists **both** separators, so no new rows of that shape are
+emitted, and a non-destructive migration resolves the 124 already persisted.
+Verified live: resolves exactly **124**, leaves **17** open — the genuine UniFi
+gateway/switch/AP topology and host NICs, which are real operator signal and are
+deliberately kept.
+
+## Why compile-time over a CI ratchet
+
+An open-count ratchet (the `module-size-baseline.txt` pattern) was the other
+candidate and is still worth having, but it cannot run in CI: the count lives in
+the operator's database, which CI has no access to. The honest split is:
+
+- **CI / compile time** — prevent a detector being *born* without a lifecycle.
+  Fully static, and delivered here.
+- **Runtime sweep** — measure drift against `expectedSteadyState` on the live
+  install, auto-resolve what declares itself auto-resolvable, and file/route the
+  rest. Needs the registry as its prerequisite, which this delivers.
+
+## Out of scope / follow-ups (BI-0B420A1D)
+
+- **Runtime drift sweep + auto-processing loop**: detect drift → file/claim a BI →
+  spend the expiring weekly token budget → route mechanical work to Build Studio
+  and judgement work to the owning coworker.
+- **Consequence-based severity** from distance to the service path (#3448 made
+  this computable; severity is still uniformly `warn`).
+- **Collector key-prefix conformance**: assert every `externalRef` / `naturalKey`
+  prefix any collector emits is known to the classifiers — the mechanical
+  generalisation of the `docker-host:` fix.
+- **Retention/aging** for genuinely-decommissioned managed assets (operator
+  policy decision).
+- Reconciling the duplicated Estate Specialist BIs (BI-4FACD527 /
+  BI-IMP-D44FA0C6) and the in-progress triage sprint (BI-E4A86393), which owns
+  the `lifecycle_unverified` + `catalog_match_ambiguous` queue content.

--- a/packages/db/prisma/migrations/20260724010000_resolve_docker_host_hyphen_stale_issues/migration.sql
+++ b/packages/db/prisma/migrations/20260724010000_resolve_docker_host_hyphen_stale_issues/migration.sql
@@ -1,0 +1,24 @@
+-- Resolve the `docker-host:` (HYPHEN) leak — the last self-healable slice of the
+-- open-issues arc. See docs/superpowers/specs/2026-07-24-quality-issue-lifecycle-
+-- governance-design.md.
+--
+-- `discovery-collectors/docker.ts` emits `docker-host:${name}` with a HYPHEN,
+-- while the Docker-origin guard listed only `docker_host:` with an UNDERSCORE.
+-- That one-character mismatch let 124 rows shaped like
+--   dpf_bootstrap:HOSTS:docker-host:docker-desktop->net-iface:Wi-Fi:192.168.0.169
+-- past every previous suppression pass and every previous cleanup migration.
+-- They are platform-internal Docker Desktop topology: never operator-actionable,
+-- and they can never resolve on their own.
+--
+-- The guard now lists BOTH separators, so no new rows of this shape are emitted.
+-- This backfill clears the ones already persisted. Non-destructive: status
+-- open -> resolved only; rows remain for audit. Matched POSITIONALLY (after `:`
+-- or the `->` arrow) so a product legitimately containing the letters is never
+-- touched. Genuine managed topology (UniFi gateway/switch/AP links) is
+-- deliberately left OPEN — that is real operator signal.
+UPDATE "PortfolioQualityIssue"
+SET "status" = 'resolved',
+    "resolvedAt" = NOW()
+WHERE "status" = 'open'
+  AND "issueType" IN ('stale_entity', 'stale_relationship')
+  AND "issueKey" ~ '[:>]docker-host:';

--- a/packages/db/src/discovery-attribution.ts
+++ b/packages/db/src/discovery-attribution.ts
@@ -3,6 +3,7 @@ import {
   classifyEntityObservation,
   classifyRelationshipObservation,
 } from "./estate-observation-class";
+import type { QualityIssueType } from "./quality-issue-registry";
 
 const LOW_CONFIDENCE_THRESHOLD = 0.55;
 const STOP_WORDS = new Set([
@@ -82,7 +83,11 @@ export type InventoryQualityRelationshipInput = {
 
 export type InventoryQualityIssue = {
   issueKey: string;
-  issueType: string;
+  // Typed against the lifecycle registry, NOT `string`: a detector that emits an
+  // unregistered type is now a compile error rather than a row with no declared
+  // way to close. This chain (evaluateInventoryQuality -> discovery-sync's direct
+  // prisma.upsert) is exactly how 8 undeclared types reached the live database.
+  issueType: QualityIssueType;
   severity: "warn" | "error";
   status: "open";
   summary: string;

--- a/packages/db/src/docker-origin.test.ts
+++ b/packages/db/src/docker-origin.test.ts
@@ -113,6 +113,25 @@ describe("isDockerOriginRelationshipKey", () => {
     ).toBe(false);
   });
 
+  it("matches BOTH docker-host separators (the hyphen/underscore leak)", () => {
+    // docker.ts emits `docker-host:` (hyphen); the guard historically listed only
+    // `docker_host:` (underscore). That one character leaked 124 rows.
+    expect(
+      isDockerOriginRelationshipKey(
+        "dpf_bootstrap:HOSTS:docker-host:docker-desktop->net-iface:Wi-Fi:192.168.0.169",
+      ),
+    ).toBe(true);
+    expect(isDockerOriginRelationshipKey("src:HOSTS:docker_host:x->y:z")).toBe(true);
+    expect(isDockerOriginEntityKey("docker-host:docker-desktop")).toBe(true);
+    expect(isDockerOriginEntityKey("docker_host:linux:abc123")).toBe(true);
+    // Real managed topology must stay untouched.
+    expect(
+      isDockerOriginRelationshipKey(
+        "organization:internal:edge_node:HOSTS:unifi:9c:05:d6:de:8d:3f->unifi:d0:21:f9:df:56:92",
+      ),
+    ).toBe(false);
+  });
+
   it("matches quarantined-run wrappers of the bootstrap self-scan", () => {
     expect(
       isDockerOriginRelationshipKey(

--- a/packages/db/src/docker-origin.ts
+++ b/packages/db/src/docker-origin.ts
@@ -58,7 +58,10 @@ export function isDockerOriginEntityKey(
   // positional rule already used by isDockerOriginRelationshipKey.
   if (DOCKER_CONTAINER_ENDPOINT_RE.test(entityKey)) return true;
   if (entityKey.startsWith("runtime:docker")) return true;
+  // Both separators — see DOCKER_RELATIONSHIP_TOKENS: docker.ts emits the
+  // hyphenated form, and listing only one leaked rows past the guard.
   if (entityKey.startsWith("docker_host:")) return true;
+  if (entityKey.startsWith("docker-host:")) return true;
 
   const hostnameMatch = /^host:hostname:([^:]+)$/.exec(entityKey);
   if (hostnameMatch && hostnameMatch[1] && DOCKER_CONTAINER_HOSTNAME_RE.test(hostnameMatch[1])) {
@@ -107,7 +110,13 @@ export function isDockerOriginEntityKey(
 const DOCKER_RELATIONSHIP_TOKENS: readonly string[] = [
   "docker-net:",
   "docker_runtime:",
+  // BOTH separators are real and must both be listed. `docker.ts` emits
+  // `docker-host:` (HYPHEN) while the entity-key guard historically used
+  // `docker_host:` (UNDERSCORE) — that one-character mismatch leaked 124
+  // `dpf_bootstrap:HOSTS:docker-host:docker-desktop->net-iface:…` rows straight
+  // past this guard. Keep them together so the pair is obvious to the next reader.
   "docker_host:",
+  "docker-host:",
   "subnet:docker-",
   "gateway:docker-gw:",
   "/var/run/docker.sock",

--- a/packages/db/src/portfolio-quality-issue-writer.test.ts
+++ b/packages/db/src/portfolio-quality-issue-writer.test.ts
@@ -3,6 +3,7 @@ import {
   openOrUpdateQualityIssue,
   computeIssueKey,
   QUALITY_ISSUE_TYPES,
+  QUALITY_ISSUE_REGISTRY,
 } from "./portfolio-quality-issue-writer";
 
 describe("computeIssueKey", () => {
@@ -157,18 +158,36 @@ describe("openOrUpdateQualityIssue", () => {
     expect(args.update.details).toEqual({ entityType: "network_client", source: "legacy-list" });
   });
 
-  it("QUALITY_ISSUE_TYPES contains the canonical issue types", () => {
-    expect(QUALITY_ISSUE_TYPES).toEqual([
-      "type_not_promotable",
-      // Added in BI-79307D22: structural name-shape gate on
-      // auto-promotion (rejects "dpf-redis-1"/"Docker GW …" etc.).
-      "name_not_promotable",
-      "no_taxonomy",
-      "no_portfolio_root",
-      "low_confidence_promotion",
-      "taxonomy_gap_proposal",
-      "incomplete_detail",
-      "enrichment_failed",
-    ]);
+  it("QUALITY_ISSUE_TYPES is derived from the lifecycle registry", () => {
+    // Deliberately not a hardcoded list any more. This list previously named 8
+    // types while the live database held 10 — 8 of them undeclared — because the
+    // validation below is bypassed by direct prisma.portfolioQualityIssue.upsert
+    // calls. The registry is now the single source of truth (BI-0B420A1D).
+    expect(QUALITY_ISSUE_TYPES).toEqual(Object.keys(QUALITY_ISSUE_REGISTRY));
+  });
+
+  it("covers the promotion-gate types AND the types that were previously undeclared", () => {
+    expect(QUALITY_ISSUE_TYPES).toEqual(
+      expect.arrayContaining([
+        // The original canonical set.
+        "type_not_promotable",
+        "name_not_promotable",
+        "no_taxonomy",
+        "no_portfolio_root",
+        "low_confidence_promotion",
+        "taxonomy_gap_proposal",
+        "incomplete_detail",
+        "enrichment_failed",
+        // Live in the database but never declared until BI-0B420A1D.
+        "stale_entity",
+        "stale_relationship",
+        "lifecycle_unverified",
+        "catalog_match_ambiguous",
+        "attribution_missing",
+        "taxonomy_attribution_low_confidence",
+        "health_alert",
+        "gateway_connection_needed",
+      ]),
+    );
   });
 });

--- a/packages/db/src/portfolio-quality-issue-writer.ts
+++ b/packages/db/src/portfolio-quality-issue-writer.ts
@@ -17,18 +17,29 @@
  * full generated client type into this file.
  */
 
-export const QUALITY_ISSUE_TYPES = [
-  "type_not_promotable",
-  // BI-79307D22: structural name-shape gate on auto-promotion.
-  "name_not_promotable",
-  "no_taxonomy",
-  "no_portfolio_root",
-  "low_confidence_promotion",
-  "taxonomy_gap_proposal",
-  "incomplete_detail",
-  "enrichment_failed",
-] as const;
-export type QualityIssueType = (typeof QUALITY_ISSUE_TYPES)[number];
+// The canonical type set is DERIVED from the lifecycle registry
+// (./quality-issue-registry), so a detector cannot emit a type that has no
+// declared way to close. This list previously named 8 types while the live
+// database held 10 — 8 of them undeclared — because the validation below is
+// bypassed by direct prisma.portfolioQualityIssue.upsert calls elsewhere.
+// Re-exported here to keep the historical import surface stable.
+import {
+  QUALITY_ISSUE_TYPES,
+  QUALITY_ISSUE_REGISTRY,
+  isKnownQualityIssueType,
+  qualityIssueContract,
+  type QualityIssueType,
+  type QualityIssueContract,
+} from "./quality-issue-registry";
+
+export {
+  QUALITY_ISSUE_TYPES,
+  QUALITY_ISSUE_REGISTRY,
+  isKnownQualityIssueType,
+  qualityIssueContract,
+  type QualityIssueType,
+  type QualityIssueContract,
+};
 
 export type QualityIssueSeverity = "info" | "warn" | "error";
 
@@ -96,9 +107,7 @@ export function computeIssueKey(
   return `${issueType}:${key}:${id}`;
 }
 
-function isKnownIssueType(value: string): value is QualityIssueType {
-  return (QUALITY_ISSUE_TYPES as readonly string[]).includes(value);
-}
+const isKnownIssueType = isKnownQualityIssueType;
 
 /**
  * Upsert a `PortfolioQualityIssue` keyed deterministically by

--- a/packages/db/src/quality-issue-registry.test.ts
+++ b/packages/db/src/quality-issue-registry.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  QUALITY_ISSUE_REGISTRY,
+  QUALITY_ISSUE_TYPES,
+  isKnownQualityIssueType,
+  qualityIssueContract,
+  operatorActionableTypes,
+  qualityIssueDrift,
+} from "./quality-issue-registry";
+
+// The registry IS the governance gate. These tests are what stop a detector
+// being added with no declared way to close what it opens — the defect that let
+// 2,247 rows accumulate across 8 undeclared types.
+describe("quality issue registry — lifecycle contract", () => {
+  it("every registered type declares a resolver, an owner and a steady-state budget", () => {
+    const incomplete = QUALITY_ISSUE_TYPES.filter((type) => {
+      const contract = QUALITY_ISSUE_REGISTRY[type];
+      return (
+        !contract.resolvedBy
+        || !contract.owner
+        || typeof contract.expectedSteadyState !== "number"
+        || !contract.summary
+      );
+    });
+    expect(incomplete).toEqual([]);
+  });
+
+  it("a type that never auto-resolves must be operator-actionable", () => {
+    // Otherwise it is a permanently-open row generator by construction: nothing
+    // closes it automatically and nobody can act on it. That is precisely what
+    // name_not_promotable / type_not_promotable were before the arc.
+    const orphaned = QUALITY_ISSUE_TYPES.filter((type) => {
+      const contract = QUALITY_ISSUE_REGISTRY[type];
+      return contract.autoResolveWhen === null && !contract.operatorActionable;
+    });
+    expect(orphaned).toEqual([]);
+  });
+
+  it("covers every issue type present in the live database", () => {
+    // Ground truth observed on the running install (2026-07-24). A type reaching
+    // production without a registry entry is the exact regression this guards.
+    const liveTypes = [
+      "stale_relationship",
+      "name_not_promotable",
+      "lifecycle_unverified",
+      "catalog_match_ambiguous",
+      "stale_entity",
+      "type_not_promotable",
+      "health_alert",
+      "attribution_missing",
+      "taxonomy_attribution_low_confidence",
+      "gateway_connection_needed",
+    ];
+    const unregistered = liveTypes.filter((type) => !isKnownQualityIssueType(type));
+    expect(unregistered).toEqual([]);
+  });
+
+  it("rejects an unregistered type", () => {
+    expect(isKnownQualityIssueType("totally_made_up")).toBe(false);
+    expect(isKnownQualityIssueType("stale_entity")).toBe(true);
+  });
+
+  it("exposes the contract for a type", () => {
+    const contract = qualityIssueContract("stale_relationship");
+    expect(contract.resolvedBy).toBe("discovery-sweep-reconcile");
+    expect(contract.expectedSteadyState).toBe(0);
+    expect(contract.autoResolveWhen).toContain("reconcile-on-recovery");
+  });
+
+  it("names the operator-actionable queues an owner is accountable for", () => {
+    const actionable = operatorActionableTypes();
+    expect(actionable).toContain("lifecycle_unverified");
+    expect(actionable).toContain("catalog_match_ambiguous");
+    // A correct structural classification is not operator work.
+    expect(actionable).not.toContain("name_not_promotable");
+  });
+});
+
+describe("qualityIssueDrift — what a proactive sweep acts on", () => {
+  it("reports over-budget queues worst-first with their owner", () => {
+    const drift = qualityIssueDrift({
+      lifecycle_unverified: 178,
+      catalog_match_ambiguous: 175,
+      stale_entity: 9,
+    });
+
+    expect(drift.map((d) => d.type)).toEqual([
+      "lifecycle_unverified",
+      "catalog_match_ambiguous",
+      "stale_entity",
+    ]);
+    expect(drift[0]).toMatchObject({ open: 178, budget: 0, over: 178 });
+    expect(drift[0].owner).toBe("coworker:estate-specialist");
+  });
+
+  it("reports nothing when every queue is at its steady state", () => {
+    expect(qualityIssueDrift({ stale_entity: 0, lifecycle_unverified: 0 })).toEqual([]);
+  });
+
+  it("ignores unregistered types rather than inventing a budget for them", () => {
+    const drift = qualityIssueDrift({ some_unregistered_type: 500, stale_entity: 1 });
+    expect(drift.map((d) => d.type)).toEqual(["stale_entity"]);
+  });
+});

--- a/packages/db/src/quality-issue-registry.ts
+++ b/packages/db/src/quality-issue-registry.ts
@@ -1,0 +1,272 @@
+// quality-issue-registry.ts
+//
+// The lifecycle contract for every PortfolioQualityIssue type.
+//
+// Why this exists: a detector could previously be added with no declared way to
+// CLOSE what it opens. `QUALITY_ISSUE_TYPES` was a bare string union listing 8
+// types while the live database held 10 — 8 of them undeclared — because
+// `openOrUpdateQualityIssue`'s validation is bypassed by direct
+// `prisma.portfolioQualityIssue.upsert` calls in discovery-sync, discovery-runner,
+// health-alert-issue and edge-event-correlation. Detectors with no resolver
+// accumulated 2,247 open rows over ~2 months before anyone noticed, burying the
+// handful of rows that were real signal.
+//
+// Every type must now declare HOW IT ENDS. `QualityIssueType` is derived from
+// this registry, so a detector that emits an unregistered type is a COMPILE
+// error rather than a row nobody can close.
+//
+// This is the mechanism half of the open-issues arc (PRs #3163/#3418/#3424/
+// #3437/#3448 fixed the instances; this stops the class recurring).
+
+/** How an open issue of this type is expected to reach `resolved`. */
+export type QualityIssueResolver =
+  /** A later discovery sweep reconciles it automatically (e.g. the thing came back). */
+  | "discovery-sweep-reconcile"
+  /** Suppressed at emission — correct outcomes are no longer recorded as issues at all. */
+  | "suppressed-at-emission"
+  /** A human operator must act (verify, review, decide). */
+  | "operator"
+  /** An AI coworker owns driving this queue down. */
+  | "coworker"
+  /** Resolved by the monitoring source that raised it, when the condition clears. */
+  | "monitor-clears";
+
+export interface QualityIssueContract {
+  /** How this issue reaches `resolved`. */
+  resolvedBy: QualityIssueResolver;
+  /**
+   * The machine-checkable condition under which the platform closes this WITHOUT
+   * human involvement. `null` means nothing auto-closes it — which is only
+   * legitimate when `operatorActionable` is true and an `owner` is named,
+   * otherwise the type is a permanently-open row generator.
+   */
+  autoResolveWhen: string | null;
+  /** True when a human/coworker can actually do something about it. */
+  operatorActionable: boolean;
+  /**
+   * Open rows expected in a healthy install. 0 means "any open row is drift".
+   * A positive number is a budget; exceeding it is the signal to act.
+   */
+  expectedSteadyState: number;
+  /** Who drives this queue down when it exceeds steady state. */
+  owner: string;
+  /** One line on what the issue means. */
+  summary: string;
+}
+
+// `satisfies` (not `as const`) so the KEYS stay literal — giving us the
+// QualityIssueType union — while each VALUE keeps the uniform
+// QualityIssueContract shape. With `as const` the values become literal types and
+// indexing by the full key union collapses to `never` on property access.
+const REGISTRY = {
+  // ── Discovery → portfolio promotion gates ────────────────────────────────
+  type_not_promotable: {
+    resolvedBy: "suppressed-at-emission",
+    autoResolveWhen:
+      "terminal structural skips (structural-type-gate) are no longer emitted; actionable legacy-list/node-policy cases resolve when a governance.promotion policy is added",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "platform:discovery",
+    summary: "Entity type is not promotable into the product portfolio.",
+  },
+  name_not_promotable: {
+    resolvedBy: "suppressed-at-emission",
+    autoResolveWhen:
+      "terminal structural skips (name-gate) are no longer emitted — a runtime-shaped name is a correct classification, not a gap",
+    operatorActionable: false,
+    expectedSteadyState: 0,
+    owner: "platform:discovery",
+    summary: "Entity name looks like a runtime instance, not a product.",
+  },
+  no_taxonomy: {
+    resolvedBy: "discovery-sweep-reconcile",
+    autoResolveWhen: "the entity gains a taxonomy attribution on a later sweep",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "coworker:estate-specialist",
+    summary: "Entity has no resolvable taxonomy node.",
+  },
+  no_portfolio_root: {
+    resolvedBy: "operator",
+    autoResolveWhen: "the taxonomy root gains a matching Portfolio row",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "platform:discovery",
+    summary: "Taxonomy root does not map to a known portfolio.",
+  },
+  low_confidence_promotion: {
+    resolvedBy: "discovery-sweep-reconcile",
+    autoResolveWhen: "attribution confidence rises above the auto-promote threshold",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "coworker:estate-specialist",
+    summary: "Attribution confidence below the auto-promote threshold.",
+  },
+
+  // ── Estate freshness ─────────────────────────────────────────────────────
+  stale_entity: {
+    resolvedBy: "discovery-sweep-reconcile",
+    autoResolveWhen:
+      "the entity is observed active again in a later sweep (reconcile-on-recovery); only MANAGED estate raises at all",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "coworker:estate-specialist",
+    summary: "Managed entity was not confirmed in the latest discovery run.",
+  },
+  stale_relationship: {
+    resolvedBy: "discovery-sweep-reconcile",
+    autoResolveWhen:
+      "the relationship is observed active again in a later sweep (reconcile-on-recovery); only MANAGED topology raises at all",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "coworker:estate-specialist",
+    summary: "Managed relationship was not confirmed in the latest discovery run.",
+  },
+
+  // ── Identity / enrichment quality ────────────────────────────────────────
+  attribution_missing: {
+    resolvedBy: "coworker",
+    autoResolveWhen: "the entity gains a taxonomy or product attribution",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "coworker:estate-specialist",
+    summary: "Entity requires taxonomy or product attribution review.",
+  },
+  taxonomy_attribution_low_confidence: {
+    resolvedBy: "coworker",
+    autoResolveWhen: "attribution confidence rises above the low-confidence threshold",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "coworker:estate-specialist",
+    summary: "Entity has low-confidence taxonomy attribution candidates.",
+  },
+  catalog_match_ambiguous: {
+    resolvedBy: "coworker",
+    autoResolveWhen: "identity evidence resolves (manufacturer + normalized version + catalog match)",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "coworker:estate-specialist",
+    summary: "Entity needs identity review (manufacturer / version / catalog match).",
+  },
+  lifecycle_unverified: {
+    resolvedBy: "coworker",
+    autoResolveWhen: "support lifecycle (supportStatus) becomes known for the entity",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "coworker:estate-specialist",
+    summary: "Entity still needs support-lifecycle verification.",
+  },
+  taxonomy_gap_proposal: {
+    resolvedBy: "operator",
+    autoResolveWhen: "the proposed taxonomy node is accepted or rejected",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "operator",
+    summary: "A taxonomy gap has been proposed for review.",
+  },
+  incomplete_detail: {
+    resolvedBy: "coworker",
+    autoResolveWhen: "the missing required fields are populated",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "coworker:estate-specialist",
+    summary: "Required detail is missing from the record.",
+  },
+  enrichment_failed: {
+    resolvedBy: "discovery-sweep-reconcile",
+    autoResolveWhen: "a later enrichment pass succeeds",
+    operatorActionable: false,
+    expectedSteadyState: 0,
+    owner: "platform:discovery",
+    summary: "An enrichment pass failed for this record.",
+  },
+
+  // ── Operational / monitoring ─────────────────────────────────────────────
+  health_alert: {
+    resolvedBy: "monitor-clears",
+    autoResolveWhen: "the underlying health alert clears at the monitoring source",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "operator",
+    summary: "A monitored health alert is firing against this scope.",
+  },
+  gateway_connection_needed: {
+    resolvedBy: "operator",
+    autoResolveWhen: "the operator configures the gateway connection",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "operator",
+    summary: "A discovered gateway needs its connection configured.",
+  },
+  edge_correlated_incident: {
+    resolvedBy: "monitor-clears",
+    autoResolveWhen: "the correlated edge incident clears",
+    operatorActionable: true,
+    expectedSteadyState: 0,
+    owner: "operator",
+    summary: "Correlated incident detected across edge telemetry.",
+  },
+} satisfies Record<string, QualityIssueContract>;
+
+/**
+ * The canonical set of quality issue types. Derived from the registry so a type
+ * cannot exist without a declared lifecycle — emitting an unregistered type is a
+ * compile error, not a permanently-open row.
+ */
+export type QualityIssueType = keyof typeof REGISTRY;
+
+export const QUALITY_ISSUE_REGISTRY: Record<QualityIssueType, QualityIssueContract> = REGISTRY;
+
+export const QUALITY_ISSUE_TYPES = Object.keys(
+  QUALITY_ISSUE_REGISTRY,
+) as readonly QualityIssueType[];
+
+export function isKnownQualityIssueType(value: string): value is QualityIssueType {
+  return Object.prototype.hasOwnProperty.call(QUALITY_ISSUE_REGISTRY, value);
+}
+
+export function qualityIssueContract(type: QualityIssueType): QualityIssueContract {
+  return QUALITY_ISSUE_REGISTRY[type];
+}
+
+/**
+ * Types whose open count should be driven to `expectedSteadyState` by a human or
+ * coworker rather than by the platform. These are the queues a proactive owner
+ * is accountable for; everything else should self-heal.
+ */
+export function operatorActionableTypes(): QualityIssueType[] {
+  return QUALITY_ISSUE_TYPES.filter((type) => QUALITY_ISSUE_REGISTRY[type].operatorActionable);
+}
+
+/**
+ * Open-count drift for a live queue snapshot: any type over its declared
+ * steady-state budget, worst overrun first. This is the input a proactive sweep
+ * (or the weekly token budget allocator) uses to decide what to work on — the
+ * platform surfaces its own drift instead of waiting to be noticed.
+ */
+export function qualityIssueDrift(
+  openCountsByType: Readonly<Record<string, number>>,
+): Array<{ type: QualityIssueType; open: number; budget: number; over: number; owner: string }> {
+  const drift: Array<{
+    type: QualityIssueType;
+    open: number;
+    budget: number;
+    over: number;
+    owner: string;
+  }> = [];
+  for (const [rawType, open] of Object.entries(openCountsByType)) {
+    if (!isKnownQualityIssueType(rawType)) continue;
+    const contract = QUALITY_ISSUE_REGISTRY[rawType];
+    const over = open - contract.expectedSteadyState;
+    if (over > 0) {
+      drift.push({
+        type: rawType,
+        open,
+        budget: contract.expectedSteadyState,
+        over,
+        owner: contract.owner,
+      });
+    }
+  }
+  return drift.sort((a, b) => b.over - a.over);
+}


### PR DESCRIPTION
Phase 1 of **BI-0B420A1D**. The open-issues arc (#3163/#3418/#3424/#3437/#3448) fixed five *instances* of one defect — **this fixes the class.** Design: `docs/superpowers/specs/2026-07-24-quality-issue-lifecycle-governance-design.md`.

Every defect in that arc had the same shape: **a detector with no lifecycle and no notion of consequence.**

## Two verified findings

**1. The type union was fiction.** `QUALITY_ISSUE_TYPES` declared **8** types; the live DB holds **10 — 8 of them undeclared**, and 6 declared ones never used. `openOrUpdateQualityIssue` *does* validate and throw on unknown types — but **7 direct `prisma.portfolioQualityIssue.upsert` call sites bypass it entirely** (`discovery-sync`, `discovery-runner`, `health-alert-issue`, `edge-event-correlation`). The validation was real; nothing routed through it.

**2. One character leaked 124 rows.** `discovery-collectors/docker.ts:236` emits `docker-host:` (**hyphen**); the guard listed `docker_host:` (**underscore**). Those rows survived every prior suppression pass *and* every cleanup migration.

## Enforcement is the compiler, not a script

`QualityIssueType` is now **derived** from the registry, and `InventoryQualityIssue.issueType` is typed as `QualityIssueType` instead of `string`. That chain — `evaluateInventoryQuality` → `discovery-sync`'s direct `upsert` — is *exactly* how the 8 undeclared types reached production. **Emitting an unregistered type is now a compile error**: stronger than a CI script, and unbypassable by choosing a different write path.

Each type declares `resolvedBy`, `autoResolveWhen`, `operatorActionable`, `expectedSteadyState`, `owner`. Two test gates back it:
- every type declares resolver / owner / budget / summary;
- **a type that never auto-resolves must be operator-actionable** — otherwise it's a permanently-open row generator by construction (precisely what `name_not_promotable` / `type_not_promotable` were).

## The platform surfaces its own drift

`qualityIssueDrift(openCountsByType)` → every queue over budget, worst-first, **with its owner**. That's the input a proactive sweep or the weekly **use-it-or-lose-it token allocator** consumes, so drift is surfaced by the platform rather than noticed by a human on a dashboard.

## Self-healing
Guard now lists **both** separators (no new rows), and a non-destructive migration resolves the 124 already persisted.

## Verification
- **20/20** against real source: registry covers all 10 live types, no orphan types, drift ordering + owner, both separators, and **no regression on managed UniFi topology**.
- Migration previewed on the live install: resolves **exactly 124**, leaves **17** open — the genuine UniFi gateway/switch/AP topology and host NICs, which are real operator signal and deliberately kept.
- Data-impact manifest + module-size guard green locally. Local typecheck skipped (source-only worktree); CI gates.

## Why compile-time rather than an open-count ratchet
The `module-size-baseline.txt` ratchet was the other candidate and is still worth having — but it **cannot run in CI**, because the count lives in the operator's database. Honest split: CI/compile-time prevents a detector being *born* without a lifecycle (delivered here); a runtime sweep measures drift on the live install (needs this registry as its prerequisite).

## Deferred (BI-0B420A1D)
Runtime drift sweep + auto-processing loop (drift → BI → budget → route), consequence-based severity from service-path distance (#3448 made it computable), and collector key-prefix conformance.

BI-0B420A1D

🤖 Generated with [Claude Code](https://claude.com/claude-code)