### PR TITLE
fix(deps): version the pnpm release-age floor and enforce it on the lockfile (BI-B175621A)

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -21,6 +21,9 @@ on:
     branches: [main]
     paths:
       - "pnpm-lock.yaml"
+      # Carries minimumReleaseAge — the release-age gate's policy source, so a
+      # change to the floor must re-run the gate.
+      - "pnpm-workspace.yaml"
       - "sbom/vuln-baseline.json"
       - "scripts/sbom/**"
   push:
@@ -60,6 +63,28 @@ jobs:
           fi
           node scripts/sbom/scan-dependencies.mjs $FLAGS
 
+      - name: Gate lockfile release age
+        # pnpm's minimumReleaseAge (pnpm-workspace.yaml) gates RESOLUTION only —
+        # a --frozen-lockfile install skips the resolution step and never
+        # consults it, so nothing downstream re-checks what the committed
+        # lockfile contains. This gate is that check: it fails a PR that adds a
+        # lockfile entry younger than the floor. Needs the base ref present to
+        # diff against, hence the deepened fetch. Mirrors the OSV step's
+        # online policy — strict on scheduled/manual runs, tolerant of a
+        # registry blip on PRs. See BI-B175621A.
+        run: |
+          set -euo pipefail
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          git fetch --no-tags --depth=50 origin "${{ github.base_ref || 'main' }}" || true
+          FLAGS="--base $BASE --json sbom/lockfile-release-age.json"
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            FLAGS="$FLAGS --require-online"
+          fi
+          node scripts/sbom/check-lockfile-release-age.mjs $FLAGS
+
+      - name: Release-age gate unit tests
+        run: node --test scripts/sbom/check-lockfile-release-age.test.mjs
+
       - name: Audit provenance + install scripts (report-only)
         if: always()
         run: node scripts/sbom/audit-provenance.mjs || true
@@ -80,5 +105,6 @@ jobs:
             sbom/dependency-scan.md
             sbom/provenance-audit.json
             sbom/provenance-audit.md
+            sbom/lockfile-release-age.json
           if-no-files-found: warn
           retention-days: 90

--- a/docs/architecture/dependency-reduction-routine.md
+++ b/docs/architecture/dependency-reduction-routine.md
@@ -151,6 +151,31 @@ Renting safely means validating versions as they *change*, not just at acquisiti
 - **Release-age cooldown** (`.github/dependabot.yml` `cooldown`): auto-bumps wait
   5 days (patch 3 / minor 7 / major 14) so a hijacked release is caught and
   unpublished before we adopt it.
+- **Release-age floor** (`pnpm-workspace.yaml` `minimumReleaseAge: 1440`): the
+  universal backstop under that cooldown. The cooldown is stricter but binds only
+  Dependabot-authored bumps; the floor additionally binds `pnpm add`, lockfile
+  regeneration, and agent-driven installs, on every host. Grant an exception with
+  `minimumReleaseAgeExclude` (keep it empty by default, and comment any entry).
+
+  **It gates resolution, not installation.** Verified against pnpm 10.33: a
+  `--frozen-lockfile` install reports *"Lockfile is up to date, resolution step is
+  skipped"* and never consults the floor; if the lockfile and manifest disagree
+  pnpm raises `ERR_PNPM_OUTDATED_LOCKFILE`, still never a release-age error. So CI,
+  Docker builds, and worktree bootstrap are unaffected, and an already-reviewed
+  lockfile is never re-litigated — but nothing downstream re-checks lockfile
+  *contents* either.
+- **Lockfile release-age gate** (`scripts/sbom/check-lockfile-release-age.mjs`,
+  run by `dependency-scan.yml`): closes exactly that hole. A lockfile authored
+  where the floor did not apply could otherwise carry a minutes-old package into
+  main and every later frozen install would faithfully reproduce it. The gate
+  diffs the committed lockfile against the base ref, checks each **newly added**
+  entry's real publish time against the floor, and fails the PR on a violation. It
+  reads the floor from `pnpm-workspace.yaml`, so policy has one definition; if that
+  policy is missing the gate exits non-zero rather than passing vacuously.
+
+  Before this, the floor existed only as unversioned host-local pnpm config — it
+  bound one machine, protected nothing else, and produced sandbox-only breakage
+  that a contributor could not reproduce (BI-B175621A).
 - **Upgrade-validation gate** (BI-6D1CADFD): at PR time, validate each *changed*
   version — release-age, a newly-introduced install script (classic compromise
   signature), provenance continuity, and OSV-clean target.
@@ -244,6 +269,10 @@ Security / acquisition (program decided via `principle_decide` 2026-06-20):
 - **BI-A8D081C9** (layer #3) — incident-response runbook *shipped*
   ([docs/runbooks/dependency-compromise.md](../runbooks/dependency-compromise.md)).
 - **Release-age cooldown** — *shipped* (`.github/dependabot.yml` `cooldown`).
+- **BI-B175621A** — release-age floor made versioned + enforced — *shipped*
+  (`pnpm-workspace.yaml` `minimumReleaseAge`, plus the lockfile gate in
+  `scripts/sbom/check-lockfile-release-age.mjs`). Supersedes phase 2 of
+  [the 2026-07-11 recovery plan](../superpowers/plans/2026-07-11-lockfile-release-age-recovery.md).
 - **BI-6D1CADFD** — upgrade-validation gate (release-age / new-install-script /
   provenance-continuity / OSV on changed versions at PR time).
 - **BI-96DFDC7D** — run the SBOM + OSV engines inside the platform runtime as an

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "check:new-deps": "node scripts/sbom/check-new-dependencies.mjs",
     "scan:deps": "node scripts/sbom/scan-dependencies.mjs",
     "audit:provenance": "node scripts/sbom/audit-provenance.mjs",
+    "check:lockfile-release-age": "node scripts/sbom/check-lockfile-release-age.mjs",
     "surface": "node scripts/sbom/runtime-surface.mjs",
     "candidates": "node scripts/sbom/internalization-candidates.mjs",
     "check:singletons": "node scripts/sbom/check-singleton-safety.mjs",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -111,6 +111,28 @@ overrides:
   '@jest/schemas': '^30.0.0'
   '@jest/create-cache-key-function': '^30.0.0'
   jest-watch-typeahead: '^3.0.0'
+# Supply-chain hardening: a release-age floor on DEPENDENCY RESOLUTION. pnpm
+# refuses to resolve a version published less than this many minutes ago, so no
+# install path can adopt a package the ecosystem has not had a chance to look at
+# yet — the window in which a hijacked npm release is typically caught and
+# unpublished.
+#
+# This is the universal backstop. The Dependabot `cooldown:` block in
+# .github/dependabot.yml (3/5/7/14 days by bump type) is STRICTER but covers only
+# Dependabot-authored bumps; this floor additionally covers `pnpm add`, lockfile
+# regeneration, and agent-driven installs, on every host. Previously the floor
+# existed only as unversioned host-local pnpm config, so it bound one machine and
+# nothing else (BI-B175621A).
+#
+# Scope note (verified against pnpm 10.33): this gates RESOLUTION only. A
+# `--frozen-lockfile` install reports "resolution step is skipped" and never
+# consults it, so CI, Docker builds, and worktree bootstrap are unaffected — an
+# already-reviewed lockfile is never re-litigated. The committed lockfile is
+# gated separately by scripts/sbom/check-lockfile-release-age.mjs.
+#
+# Use minimumReleaseAgeExclude for a package that must be adopted inside the
+# window (e.g. an embargoed security fix); keep it empty by default.
+minimumReleaseAge: 1440
 allowBuilds:
   '@prisma/client': true
   '@prisma/engines': true

--- a/scripts/lib/bootstrap-worktree-deps.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.mjs
@@ -60,12 +60,19 @@ export function bootstrapWorktreeDeps(worktreePath, opts = {}) {
     if (!existsSync(`${worktreePath}/node_modules`)) {
       // Managed install via the shared store; --frozen-lockfile keeps it honest
       // to the worktree's lockfile (a worktree off main carries main's lockfile).
-      // Worktree-only bootstrap may hit pnpm minimumReleaseAge on fresh lockfile
-      // pins (BI-C98D003B). Scoped to this explicit bootstrap path — fleet
-      // install policy is unchanged.
+      //
+      // This path used to pass --config.minimumReleaseAge=0 to dodge the pnpm
+      // release-age floor (BI-C98D003B). That override was removed as dead and
+      // misleading (BI-B175621A): --frozen-lockfile skips resolution entirely
+      // ("Lockfile is up to date, resolution step is skipped"), and the floor is
+      // only consulted while resolving, so it can never fire here. When the
+      // lockfile does NOT match the manifest, pnpm fails with
+      // ERR_PNPM_OUTDATED_LOCKFILE — still never a release-age error. Keeping the
+      // override would have silently defeated a real control on this path once
+      // the floor became versioned repo config.
       run(
         pkgMgr,
-        ["install", "--prefer-offline", "--frozen-lockfile", "--config.minimumReleaseAge=0"],
+        ["install", "--prefer-offline", "--frozen-lockfile"],
         worktreePath,
       );
     }

--- a/scripts/sbom/check-lockfile-release-age.mjs
+++ b/scripts/sbom/check-lockfile-release-age.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+// scripts/sbom/check-lockfile-release-age.mjs
+//
+// Lockfile release-age gate (BI-B175621A) — the executable half of the
+// `minimumReleaseAge` policy declared in pnpm-workspace.yaml.
+//
+// Why a separate gate is needed
+// -----------------------------
+// pnpm's `minimumReleaseAge` gates RESOLUTION, not installation. Verified
+// against pnpm 10.33: a `--frozen-lockfile` install prints "Lockfile is up to
+// date, resolution step is skipped" and never consults the floor. Every CI job,
+// Docker build, and worktree bootstrap installs frozen — so nothing downstream
+// re-checks what a lockfile actually contains.
+//
+// That leaves one hole: a lockfile authored where the floor did not apply (an
+// older checkout, a host without the setting, or an explicit
+// `--config.minimumReleaseAge=0`) can carry a package published minutes ago into
+// main, and every later install would faithfully reproduce it. This gate closes
+// that hole by checking the committed lockfile itself.
+//
+// Scope: only entries NEWLY ADDED relative to the base ref. Re-auditing the whole
+// lockfile would fail every PR for as long as any young package sits in it, which
+// would train people to ignore the gate.
+//
+// Policy source: pnpm-workspace.yaml, so the floor has exactly one definition and
+// the gate can never drift from what pnpm itself enforces.
+//
+// Usage:
+//   node scripts/sbom/check-lockfile-release-age.mjs [--base origin/main]
+//                                                    [--require-online]
+//                                                    [--json <path>]
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const REGISTRY = (process.env.NPM_REGISTRY_URL ?? "https://registry.npmjs.org").replace(/\/$/, "");
+
+// ── pure helpers (exported for tests) ────────────────────────────────────────
+
+/**
+ * Read the release-age policy from pnpm-workspace.yaml.
+ * Returns { minutes, exclude:Set<string> }. minutes === 0 means "no floor".
+ */
+export function parseReleaseAgePolicy(workspaceYaml) {
+  const lines = workspaceYaml.replace(/\r\n/g, "\n").split("\n");
+  let minutes = 0;
+  const exclude = new Set();
+
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^minimumReleaseAge:\s*(\d+)\s*$/);
+    if (m) minutes = Number(m[1]);
+
+    if (/^minimumReleaseAgeExclude:\s*$/.test(lines[i])) {
+      for (let j = i + 1; j < lines.length; j++) {
+        if (/^\S/.test(lines[j])) break; // next top-level key
+        const item = lines[j].match(/^\s+-\s*'?([^'\s]+)'?\s*$/);
+        if (item) exclude.add(item[1]);
+      }
+    }
+    // inline form: minimumReleaseAgeExclude: ['a', 'b']
+    const inline = lines[i].match(/^minimumReleaseAgeExclude:\s*\[(.*)\]\s*$/);
+    if (inline) {
+      for (const raw of inline[1].split(",")) {
+        const name = raw.trim().replace(/^['"]|['"]$/g, "");
+        if (name) exclude.add(name);
+      }
+    }
+  }
+  return { minutes, exclude };
+}
+
+/**
+ * Collect `name@version` keys from a pnpm lockfile's top-level `packages:` map.
+ * `packages:` holds clean name@version keys; `snapshots:` holds the same
+ * packages with peer-suffixed keys, so reading `packages:` alone is both
+ * sufficient and unambiguous.
+ */
+export function parseLockfilePackages(lockYaml) {
+  const lines = lockYaml.replace(/\r\n/g, "\n").split("\n");
+  const start = lines.indexOf("packages:");
+  if (start < 0) return new Set();
+  const out = new Set();
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^\S/.test(lines[i])) break; // next top-level key
+    const m = lines[i].match(/^ {2}'?(.+?)'?:\s*$/);
+    if (m) out.add(m[1]);
+  }
+  return out;
+}
+
+/** Split `@scope/name@1.2.3` → { name, version }. Null for non-registry specs. */
+export function splitNameVersion(key) {
+  const at = key.lastIndexOf("@");
+  if (at <= 0) return null;
+  const name = key.slice(0, at);
+  const version = key.slice(at + 1);
+  if (!name || !version) return null;
+  // file:/link:/http: specs and git URLs are not registry releases — the floor
+  // does not apply and the registry has no publish time for them.
+  if (version.includes(":") || version.includes("/")) return null;
+  return { name, version };
+}
+
+/** Entries present in head but not in base, as {key,name,version}. */
+export function newRegistryEntries(baseKeys, headKeys) {
+  const out = [];
+  for (const key of headKeys) {
+    if (baseKeys.has(key)) continue;
+    const nv = splitNameVersion(key);
+    if (nv) out.push({ key, ...nv });
+  }
+  return out.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+/**
+ * Split entries into violations / ok / unknown given publish timestamps.
+ * `publishedAt` is a Map<"name@version", ISO string | null>.
+ */
+export function classifyAges(entries, publishedAt, { minutes, exclude, now }) {
+  const violations = [];
+  const ok = [];
+  const unknown = [];
+  const floorMs = minutes * 60_000;
+
+  for (const e of entries) {
+    if (exclude.has(e.name)) {
+      ok.push({ ...e, reason: "excluded" });
+      continue;
+    }
+    const iso = publishedAt.get(e.key);
+    if (!iso) {
+      unknown.push(e);
+      continue;
+    }
+    const ageMs = now.getTime() - new Date(iso).getTime();
+    const ageMinutes = Math.floor(ageMs / 60_000);
+    if (ageMs < floorMs) violations.push({ ...e, publishedAt: iso, ageMinutes });
+    else ok.push({ ...e, publishedAt: iso, ageMinutes });
+  }
+  return { violations, ok, unknown };
+}
+
+// ── I/O ──────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const out = { base: "origin/main", requireOnline: false, json: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--base") out.base = argv[++i];
+    else if (argv[i] === "--require-online") out.requireOnline = true;
+    else if (argv[i] === "--json") out.json = argv[++i];
+  }
+  return out;
+}
+
+function baseLockfile(baseRef) {
+  try {
+    return execFileSync("git", ["show", `${baseRef}:pnpm-lock.yaml`], {
+      cwd: ROOT,
+      encoding: "utf8",
+      maxBuffer: 256 * 1024 * 1024,
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function getJson(url, { tries = 3, timeoutMs = 20000 } = {}) {
+  let lastErr;
+  for (let attempt = 0; attempt < tries; attempt++) {
+    try {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+      const res = await fetch(url, { signal: ctrl.signal });
+      clearTimeout(timer);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return await res.json();
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 400 * (attempt + 1)));
+    }
+  }
+  throw lastErr;
+}
+
+async function mapPool(items, limit, fn) {
+  const out = new Array(items.length);
+  let i = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (i < items.length) {
+        const idx = i++;
+        out[idx] = await fn(items[idx]);
+      }
+    }),
+  );
+  return out;
+}
+
+async function fetchPublishTimes(entries) {
+  const byName = new Map();
+  for (const e of entries) {
+    if (!byName.has(e.name)) byName.set(e.name, []);
+    byName.get(e.name).push(e);
+  }
+  const publishedAt = new Map();
+  let online = false;
+
+  await mapPool([...byName.keys()], 8, async (name) => {
+    try {
+      const doc = await getJson(`${REGISTRY}/${name.replace(/\//g, "%2f")}`);
+      online = true;
+      for (const e of byName.get(name)) {
+        publishedAt.set(e.key, doc?.time?.[e.version] ?? null);
+      }
+    } catch {
+      for (const e of byName.get(name)) publishedAt.set(e.key, null);
+    }
+  });
+
+  return { publishedAt, online };
+}
+
+async function run() {
+  const args = parseArgs(process.argv.slice(2));
+  const workspaceYaml = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8");
+  const { minutes, exclude } = parseReleaseAgePolicy(workspaceYaml);
+
+  if (minutes <= 0) {
+    // A gate that silently passes when its policy is missing is worse than no
+    // gate — it reports "safe" while enforcing nothing.
+    process.stderr.write(
+      "::error::minimumReleaseAge is not set in pnpm-workspace.yaml — the release-age policy is missing, so this gate cannot enforce anything.\n",
+    );
+    process.exit(1);
+  }
+
+  const headKeys = parseLockfilePackages(readFileSync(join(ROOT, "pnpm-lock.yaml"), "utf8"));
+  const baseYaml = baseLockfile(args.base);
+  if (baseYaml === null) {
+    process.stdout.write(
+      `Release-age gate: base ref '${args.base}' unavailable (shallow clone or first commit) — nothing to diff, skipping.\n`,
+    );
+    process.exit(0);
+  }
+
+  const entries = newRegistryEntries(parseLockfilePackages(baseYaml), headKeys);
+  if (entries.length === 0) {
+    process.stdout.write(`Release-age gate: no new lockfile entries vs ${args.base}. Floor ${minutes} min.\n`);
+    process.exit(0);
+  }
+
+  const { publishedAt, online } = await fetchPublishTimes(entries);
+  if (!online) {
+    const msg = `Release-age gate: registry unreachable; could not verify ${entries.length} new entries.`;
+    if (args.requireOnline) {
+      process.stderr.write(`::error::${msg} (--require-online)\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`${msg} Tolerating (no --require-online).\n`);
+    process.exit(0);
+  }
+
+  const { violations, ok, unknown } = classifyAges(entries, publishedAt, {
+    minutes,
+    exclude,
+    now: new Date(),
+  });
+
+  if (args.json) {
+    mkdirSync(dirname(args.json), { recursive: true });
+    writeFileSync(
+      args.json,
+      JSON.stringify({ base: args.base, floorMinutes: minutes, violations, ok, unknown }, null, 2),
+    );
+  }
+
+  for (const u of unknown) {
+    process.stdout.write(`  ? ${u.key} — no publish time from registry (unpublished or mirror gap)\n`);
+  }
+
+  if (violations.length > 0) {
+    process.stderr.write(
+      `::error::${violations.length} new lockfile entr${violations.length === 1 ? "y is" : "ies are"} younger than the ${minutes}-minute release-age floor:\n`,
+    );
+    for (const v of violations) {
+      process.stderr.write(`  - ${v.key} published ${v.ageMinutes} min ago (${v.publishedAt})\n`);
+    }
+    process.stderr.write(
+      "\nWait for the floor to elapse and regenerate the lockfile, or — if this is an embargoed\n" +
+        "security fix that must land now — add the package to minimumReleaseAgeExclude in\n" +
+        "pnpm-workspace.yaml with a comment saying why.\n",
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `Release-age gate: ${ok.length} new entr${ok.length === 1 ? "y" : "ies"} all older than the ${minutes}-minute floor` +
+      `${unknown.length ? `, ${unknown.length} unverifiable` : ""}.\n`,
+  );
+}
+
+// Only run when invoked directly, so the pure helpers stay importable in tests.
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  run().catch((err) => {
+    process.stderr.write(`::error::check-lockfile-release-age failed: ${err?.stack || err}\n`);
+    process.exit(2);
+  });
+}

--- a/scripts/sbom/check-lockfile-release-age.test.mjs
+++ b/scripts/sbom/check-lockfile-release-age.test.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// Tests for the lockfile release-age gate (BI-B175621A).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  parseReleaseAgePolicy,
+  parseLockfilePackages,
+  splitNameVersion,
+  newRegistryEntries,
+  classifyAges,
+} from "./check-lockfile-release-age.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// ── policy parsing ───────────────────────────────────────────────────────────
+
+test("parses minimumReleaseAge and returns 0 when absent", () => {
+  assert.equal(parseReleaseAgePolicy("minimumReleaseAge: 1440\n").minutes, 1440);
+  assert.equal(parseReleaseAgePolicy("packages:\n  - 'apps/*'\n").minutes, 0);
+});
+
+test("parses minimumReleaseAgeExclude in block and inline form", () => {
+  const block = parseReleaseAgePolicy(
+    "minimumReleaseAge: 60\nminimumReleaseAgeExclude:\n  - next-auth\n  - '@auth/core'\nallowBuilds:\n  sharp: true\n",
+  );
+  assert.deepEqual([...block.exclude].sort(), ["@auth/core", "next-auth"]);
+
+  const inline = parseReleaseAgePolicy("minimumReleaseAgeExclude: ['a', \"b\"]\n");
+  assert.deepEqual([...inline.exclude].sort(), ["a", "b"]);
+});
+
+test("exclude list stops at the next top-level key", () => {
+  const { exclude } = parseReleaseAgePolicy(
+    "minimumReleaseAgeExclude:\n  - only-this\nallowBuilds:\n  - not-this\n",
+  );
+  assert.deepEqual([...exclude], ["only-this"]);
+});
+
+// ── lockfile parsing ─────────────────────────────────────────────────────────
+
+const LOCK = [
+  "lockfileVersion: '9.0'",
+  "importers:",
+  "  .:",
+  "    dependencies:",
+  "      next-auth:",
+  "        specifier: 5.0.0-beta.32",
+  "packages:",
+  "  '@auth/core@0.41.3':",
+  "    resolution: {integrity: sha512-aaa}",
+  "  next-auth@5.0.0-beta.32:",
+  "    resolution: {integrity: sha512-bbb}",
+  "snapshots:",
+  "  next-auth@5.0.0-beta.32(react@19.2.7):",
+  "    dependencies:",
+  "",
+].join("\n");
+
+test("reads name@version keys from packages: and ignores importers/snapshots", () => {
+  const keys = parseLockfilePackages(LOCK);
+  assert.deepEqual([...keys].sort(), ["@auth/core@0.41.3", "next-auth@5.0.0-beta.32"]);
+  // the peer-suffixed snapshot key must not leak in
+  assert.ok(![...keys].some((k) => k.includes("(")));
+});
+
+test("returns empty when there is no packages: section", () => {
+  assert.equal(parseLockfilePackages("lockfileVersion: '9.0'\nimporters:\n  .: {}\n").size, 0);
+});
+
+test("splits scoped and unscoped name@version, rejects non-registry specs", () => {
+  assert.deepEqual(splitNameVersion("@auth/core@0.41.3"), { name: "@auth/core", version: "0.41.3" });
+  assert.deepEqual(splitNameVersion("next-auth@5.0.0-beta.32"), {
+    name: "next-auth",
+    version: "5.0.0-beta.32",
+  });
+  assert.equal(splitNameVersion("foo@file:../local"), null);
+  assert.equal(splitNameVersion("bar@https://example.com/x.tgz"), null);
+  assert.equal(splitNameVersion("@scope/only"), null);
+});
+
+// ── diffing ──────────────────────────────────────────────────────────────────
+
+test("only entries absent from base count as new", () => {
+  const base = new Set(["a@1.0.0", "b@1.0.0"]);
+  const head = new Set(["a@1.0.0", "b@2.0.0", "c@1.0.0"]);
+  assert.deepEqual(
+    newRegistryEntries(base, head).map((e) => e.key),
+    ["b@2.0.0", "c@1.0.0"],
+  );
+});
+
+test("a version bump counts as new even though the package is not", () => {
+  const entries = newRegistryEntries(new Set(["x@1.0.0"]), new Set(["x@1.0.1"]));
+  assert.deepEqual(entries, [{ key: "x@1.0.1", name: "x", version: "1.0.1" }]);
+});
+
+// ── classification ───────────────────────────────────────────────────────────
+
+const NOW = new Date("2026-07-23T12:00:00Z");
+const minutesAgo = (n) => new Date(NOW.getTime() - n * 60_000).toISOString();
+
+test("younger than the floor is a violation, older is ok", () => {
+  const entries = [
+    { key: "young@1.0.0", name: "young", version: "1.0.0" },
+    { key: "old@1.0.0", name: "old", version: "1.0.0" },
+  ];
+  const published = new Map([
+    ["young@1.0.0", minutesAgo(10)],
+    ["old@1.0.0", minutesAgo(5000)],
+  ]);
+  const res = classifyAges(entries, published, { minutes: 1440, exclude: new Set(), now: NOW });
+  assert.deepEqual(res.violations.map((v) => v.key), ["young@1.0.0"]);
+  assert.equal(res.violations[0].ageMinutes, 10);
+  assert.deepEqual(res.ok.map((o) => o.key), ["old@1.0.0"]);
+});
+
+test("exactly at the floor passes (boundary is not a violation)", () => {
+  const entries = [{ key: "edge@1.0.0", name: "edge", version: "1.0.0" }];
+  const published = new Map([["edge@1.0.0", minutesAgo(1440)]]);
+  const res = classifyAges(entries, published, { minutes: 1440, exclude: new Set(), now: NOW });
+  assert.equal(res.violations.length, 0);
+  assert.equal(res.ok.length, 1);
+});
+
+test("an excluded package is exempt even when brand new", () => {
+  const entries = [{ key: "urgent@1.0.0", name: "urgent", version: "1.0.0" }];
+  const published = new Map([["urgent@1.0.0", minutesAgo(1)]]);
+  const res = classifyAges(entries, published, {
+    minutes: 1440,
+    exclude: new Set(["urgent"]),
+    now: NOW,
+  });
+  assert.equal(res.violations.length, 0);
+  assert.equal(res.ok[0].reason, "excluded");
+});
+
+test("a missing publish time is unknown, never a silent pass", () => {
+  const entries = [{ key: "ghost@1.0.0", name: "ghost", version: "1.0.0" }];
+  const res = classifyAges(entries, new Map([["ghost@1.0.0", null]]), {
+    minutes: 1440,
+    exclude: new Set(),
+    now: NOW,
+  });
+  assert.equal(res.unknown.length, 1);
+  assert.equal(res.violations.length, 0);
+  assert.equal(res.ok.length, 0);
+});
+
+// ── the policy is actually committed ─────────────────────────────────────────
+
+test("the repository declares a non-zero minimumReleaseAge", () => {
+  // Guards the gate against its own escape hatch: if the policy is ever removed
+  // from pnpm-workspace.yaml the gate exits 1 at runtime, and this test says so
+  // at PR time instead.
+  const { minutes } = parseReleaseAgePolicy(readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8"));
+  assert.ok(minutes > 0, "pnpm-workspace.yaml must declare minimumReleaseAge");
+});
+
+test("no install path re-introduces a minimumReleaseAge=0 override", () => {
+  // BI-B175621A: the worktree bootstrap used to pass --config.minimumReleaseAge=0.
+  // Frozen installs skip resolution, so such an override is always either dead or
+  // an active bypass of the floor.
+  const bootstrap = readFileSync(join(ROOT, "scripts/lib/bootstrap-worktree-deps.mjs"), "utf8");
+  const active = bootstrap
+    .split("\n")
+    .filter((l) => !l.trimStart().startsWith("//"))
+    .join("\n");
+  assert.ok(
+    !/minimumReleaseAge=0/.test(active),
+    "bootstrap-worktree-deps.mjs must not disable the release-age floor",
+  );
+});


### PR DESCRIPTION
Closes BI-B175621A.

## The problem

pnpm's `minimumReleaseAge` was real but lived **only in unversioned host-local pnpm config**. It was absent from `.npmrc`, `pnpm-workspace.yaml`, `package.json`, and every environment variable — yet a genuine `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` fired in the governed sandbox on 2026-07-11.

That is the worst of both worlds:

1. **Under-protection.** The Dependabot `cooldown:` block governs only Dependabot-authored bumps. A manual `pnpm add`, a lockfile regen, or an agent-driven install on any host without the host-local config could adopt a package published minutes ago — exactly the window in which a hijacked npm release is normally caught and unpublished.
2. **Unreproducible breakage.** A lockfile that installed cleanly for one contributor failed in the governed sandbox, which is what consumed the [2026-07-11 recovery plan](docs/superpowers/plans/2026-07-11-lockfile-release-age-recovery.md).

Found while reviewing the Auth.js Dependabot bumps (#3459/#3460). Those bumps were clean; this is an adjacent gap that review surfaced.

## What changed

- **`pnpm-workspace.yaml`** — declares `minimumReleaseAge: 1440`, so every resolution path on every host inherits one floor. The Dependabot cooldown stays as the stricter policy for its own path.
- **`scripts/lib/bootstrap-worktree-deps.mjs`** — removes `--config.minimumReleaseAge=0`.
- **`scripts/sbom/check-lockfile-release-age.mjs`** (new) — gates the committed lockfile.
- **`.github/workflows/dependency-scan.yml`** — runs the gate. No new workflow; this one already triggers on `pnpm-lock.yaml`.
- **Docs + a `check:lockfile-release-age` alias.**

## Behaviour was measured, not assumed

Everything below was verified against pnpm 10.33 before designing around it:

| Scenario | Result |
|---|---|
| Resolution with a floor set | **Blocked** — `ERR_PNPM_NO_MATURE_MATCHING_VERSION` |
| `--frozen-lockfile`, lockfile current | **Skipped** — "resolution step is skipped"; floor never consulted |
| Plain install, lockfile current | **Skipped** — same |
| `--frozen-lockfile`, manifest out of sync | `ERR_PNPM_OUTDATED_LOCKFILE` — still never a release-age error |

Two consequences follow, and they shaped the whole change:

**This cannot recreate the 07-11 breakage.** The floor gates *resolution*. CI, Docker builds, worktree bootstrap, and everyday `pnpm install` never re-validate an existing lockfile, so the floor only bites when a version is genuinely being adopted.

**The bootstrap override was provably dead.** It sat on a `--frozen-lockfile` call that never resolves. Left in place it would have silently defeated a real control the moment the floor became versioned — so it is removed, and a test asserts no install path reintroduces it.

## Why the lockfile gate is needed

Because the floor never applies at install time, nothing re-checked what a committed lockfile actually *contains*. A lockfile authored where the floor didn't apply (older checkout, unconfigured host, explicit `--config.minimumReleaseAge=0`) could carry a minutes-old package into main, and every later frozen install would faithfully reproduce it.

The gate diffs the committed lockfile against the base ref, checks each **newly added** entry's real registry publish time, and fails on a violation. Design notes:

- It reads the floor from `pnpm-workspace.yaml`, so policy has exactly one definition and the gate cannot drift from what pnpm enforces.
- If that policy is missing it **exits non-zero** rather than passing vacuously — a checker that can return nothing must fail on nothing.
- Scoped to newly added entries. Re-auditing the whole lockfile would fail every PR for as long as any young package sat in it, which trains people to ignore the gate.
- Mirrors the OSV step's online policy: strict on scheduled runs, tolerant of a registry blip on PRs.

## Verification

Functionally exercised on all four paths, not just the happy one:

- **Passes** — real run against the pre-Auth.js-bump lockfile: 3 new entries, live publish times fetched, all above the floor.
- **Fails** — floor raised, exit 1, naming each package with its real publish time and age.
- **Policy missing** — exit 1 with an explicit error.
- **Base ref unavailable** — clean skip (shallow clones).

14 new unit tests covering policy parsing (block + inline exclude), lockfile parsing (ignores `importers:`/peer-suffixed `snapshots:` keys), diffing, boundary-exact ages, exclusions, and unknown publish times. Existing `bootstrap-worktree-deps`, janitor, stale-override, doc-link, and diagram-pin guards all re-run green.

Seed-Fit-Decision: not-applicable — supply-chain control surface, no seed or archetype data involved
