### PR TITLE
fix(kernel): drop retrieval hits whose WikiPage no longer exists (BI-6ADB019D)

### DIFF
--- a/apps/web/lib/mcp/packs/principle-decide-pack.test.ts
+++ b/apps/web/lib/mcp/packs/principle-decide-pack.test.ts
@@ -568,16 +568,21 @@ describe("principle-decide pack — core/contextual reach structured scoring", (
     expect(scoredPrinciples().find((p) => p.id === "wp-core-1")!.weight).toBe(0.4);
   });
 
-  it("degrades to semantic alignment — not to a dropped principle — when rehydration misses", async () => {
+  // SEMANTICS REVISED by BI-6ADB019D. This originally asserted that a
+  // rehydration miss kept the principle on semantic fallback, on the theory
+  // that a miss might be transient. Live evidence showed the opposite: a miss
+  // on a SUCCESSFUL query means the WikiPage was deleted and the Qdrant point
+  // is a phantom, so keeping it just burns a maxPrinciples slot. The original
+  // intent — never silently drop doctrine for a transient reason — is preserved
+  // by the query-failure test below, which is the case that actually is
+  // transient.
+  it("drops a principle whose row is absent from a SUCCESSFUL rehydration", async () => {
     wiki.searchWikiPages.mockResolvedValueOnce([CORE_HIT]).mockResolvedValueOnce([]);
-    db.wikiPageFindMany.mockResolvedValue([]); // row vanished between index and read
+    db.wikiPageFindMany.mockResolvedValue([]); // page no longer exists
 
     await invoke();
 
-    const core = scoredPrinciples().find((p) => p.id === "wp-core-1");
-    expect(core).toBeDefined();
-    expect(core!.dimensionVector).toEqual({});
-    expect(core!.weight).toBe(0.4);
+    expect(scoredPrinciples().find((p) => p.id === "wp-core-1")).toBeUndefined();
   });
 
   it("survives a rehydration failure without failing the decision", async () => {
@@ -614,6 +619,38 @@ describe("principle-decide pack — core/contextual reach structured scoring", (
     expect(scored.find((p) => p.id === "wp-core-1")).toBeDefined();
   });
 
+  it("BI-6ADB019D: drops a hit whose WikiPage no longer exists", async () => {
+    // Qdrant returns two points; only one has a live row. The phantom must not
+    // reach scoring — left in, it contributes 0.000 but occupies a
+    // maxPrinciples slot that real doctrine would fill.
+    wiki.searchWikiPages
+      .mockResolvedValueOnce([CORE_HIT, { ...CORE_HIT, pageId: "wp-deleted" }])
+      .mockResolvedValueOnce([]);
+    db.wikiPageFindMany.mockResolvedValue([CORE_ROW]);
+
+    await invoke();
+
+    const ids = scoredPrinciples().map((p) => p.id);
+    expect(ids).toContain("wp-core-1");
+    expect(ids).not.toContain("wp-deleted");
+  });
+
+  it("BI-6ADB019D: does NOT drop anything when the rehydration QUERY failed", async () => {
+    // The distinction that matters. A failed lookup leaves every id unresolved
+    // for a transient reason; dropping them would silently delete the whole
+    // core/contextual tier from the decision.
+    wiki.searchWikiPages
+      .mockResolvedValueOnce([CORE_HIT, { ...CORE_HIT, pageId: "wp-core-2" }])
+      .mockResolvedValueOnce([]);
+    db.wikiPageFindMany.mockRejectedValue(new Error("connection reset"));
+
+    await invoke();
+
+    const ids = scoredPrinciples().map((p) => p.id);
+    expect(ids).toContain("wp-core-1");
+    expect(ids).toContain("wp-core-2");
+  });
+
   it("RC6: maxPrinciples still caps the relevance-retrieved set it names", async () => {
     db.listPrinciplesByTier.mockResolvedValue([]);
     const hits = Array.from({ length: 25 }, (_, i) => ({
@@ -621,7 +658,11 @@ describe("principle-decide pack — core/contextual reach structured scoring", (
       pageId: `wp-core-${i}`,
     }));
     wiki.searchWikiPages.mockResolvedValueOnce(hits).mockResolvedValueOnce([]);
-    db.wikiPageFindMany.mockResolvedValue([]);
+    // Every hit must hydrate, or the phantom guard (BI-6ADB019D) would drop
+    // them all and this would assert the cap on an empty set.
+    db.wikiPageFindMany.mockResolvedValue(
+      hits.map((h) => ({ ...CORE_ROW, id: h.pageId })),
+    );
 
     await invoke();
 

--- a/apps/web/lib/mcp/packs/principle-decide-pack.ts
+++ b/apps/web/lib/mcp/packs/principle-decide-pack.ts
@@ -345,8 +345,12 @@ async function principleDecide(
   // rank relevance and then fetch the real rows from Postgres by pageId —
   // pageId is the WikiPage id (payload entityId), so this is one keyed
   // findMany with no backfill and no drift surface.
-  const relevanceHits = [...core, ...contextual];
+  let relevanceHits = [...core, ...contextual];
   const hydratedById = new Map<string, Record<string, unknown>>();
+  // Did the rehydration QUERY succeed? Distinct from "did a given id resolve".
+  // The two failures mean opposite things and must not be conflated (see the
+  // phantom-drop below).
+  let rehydrationQueryOk = true;
   if (relevanceHits.length > 0) {
     const hitIds = Array.from(
       new Set(
@@ -364,6 +368,7 @@ async function principleDecide(
           hydratedById.set(String(row["id"] ?? ""), row);
         }
       } catch (err) {
+        rehydrationQueryOk = false;
         // Degrades to the pre-fix behaviour (semantic alignment), which the
         // semanticFallbackRatio flag already surfaces to the caller. Counted
         // in the recall trace below so the degradation is never silent.
@@ -372,6 +377,35 @@ async function principleDecide(
           err,
         );
       }
+    }
+  }
+
+  // BI-6ADB019D — drop phantom hits: Qdrant points whose WikiPage no longer
+  // exists. Postgres is the authoring store, so an id the index returned that
+  // a SUCCESSFUL lookup could not find is a deleted page, not a slow one.
+  //
+  // Observed live: five hits titled "Live State Over Seed Data" when the DB
+  // holds exactly one — four Qdrant points referencing rows that are gone.
+  // Left in place they cost nothing in score (they contribute 0.000) but they
+  // consume `maxPrinciples` slots, so real doctrine gets squeezed out of the
+  // relevance set by principles that do not exist. That is the same starvation
+  // RC6 just fixed, arriving by a different route.
+  //
+  // THE DISTINCTION THAT MATTERS: only drop when the query SUCCEEDED. If the
+  // lookup itself failed, every id is unresolved for a transient reason, and
+  // dropping them would silently delete the entire core/contextual tier from
+  // the decision — a far worse failure than carrying a few phantoms.
+  let phantomHits = 0;
+  if (rehydrationQueryOk && relevanceHits.length > 0) {
+    const kept = relevanceHits.filter((hit) =>
+      hydratedById.has(String(hit["pageId"] ?? "")),
+    );
+    phantomHits = relevanceHits.length - kept.length;
+    if (phantomHits > 0) {
+      console.warn(
+        `[principle_decide] dropped ${phantomHits} retrieval hit(s) whose WikiPage no longer exists — the vector index disagrees with the authoring store (BI-6ADB019D). Reconcile the wiki store.`,
+      );
+      relevanceHits = kept;
     }
   }
 
@@ -399,6 +433,10 @@ async function principleDecide(
         contextualCount: contextual.length,
         hydratedCount: hydratedById.size,
         unhydratedCount: relevanceHits.length - hydratedById.size,
+        // BI-6ADB019D: hits dropped because their WikiPage is gone. A non-zero
+        // value means the vector index disagrees with the authoring store.
+        phantomHitsDropped: phantomHits,
+        rehydrationQueryOk,
         ringScopeExcluded: {
           commandments: commandmentsExcluded,
           core: coreExcluded,


### PR DESCRIPTION
Found by the telemetry #3478 added. **Pre-existing — RC2 did not cause this, RC2 made it visible.**

Seed-Fit-Decision: no seed change. This is a read-path guard; the stale vector points themselves still need a reconcile sweep, which stays open on the BI.

## The evidence

A live `principle_decide` returned **five** core hits titled "Live State Over Seed Data". The database holds **exactly one**:

```sql
SELECT id, slug FROM "WikiPage" WHERE title = 'Live State Over Seed Data';
-- cmpims58w09bg6ymgzf2esah9 | principles/live-state-over-seed-data
```

Four Qdrant points reference rows that do not exist. The ledger agreed: one scored `structured`, the other four fell to `semantic` at 0.000 — rehydration misses, which `unhydratedCount` now reports.

**Phantoms are not free just because they score zero.** `maxPrinciples` caps the core/contextual set, so they occupy slots real doctrine would fill. A decision can be starved by principles that no longer exist — the same starvation RC6 just fixed, arriving by a different route.

## The distinction that makes this safe

Only drop when the rehydration **query succeeded**. An id absent from a successful lookup is a deleted page. A *failed* lookup leaves every id unresolved for a transient reason, and dropping those would silently delete the entire core/contextual tier from the decision — far worse than carrying a few phantoms. Both are counted in the trace as `phantomHitsDropped` / `rehydrationQueryOk`.

## I got the root cause wrong first, and checking falsified it

My initial hypothesis was re-seed id churn. It's wrong:

- `upsertWikiPage` is a findFirst-then-update-or-create keyed on `(organizationId, slug)` and **preserves the row id** — re-seeding does not mint new cuids.
- There is **no `wikiPage.delete`/`deleteMany` in non-test source**, and `deleteWikiPageVector` already exists for the legitimate hard-delete path.

So this is Postgres/Qdrant divergence from out-of-band row loss (a restore, or org-overlay rows removed with their org — consistent with the surviving row being the kernel one), and the real defect is that **nothing guards the read path**. `discovery-reconcile.ts` covers products, not the wiki store. BI-6ADB019D records the correction rather than leaving the wrong cause standing.

## One previously-asserted behaviour is deliberately revised

A rehydration miss used to keep the principle on semantic fallback. I wrote that assertion two hours ago in #3478, on the theory that a miss might be transient — the live evidence shows it means the page is gone. My own test caught the change, which is what it was for. The original intent is preserved by the query-failure branch, which is the case that genuinely is transient. The old test is **rewritten with the reasoning recorded inline**, not deleted.

## Verification

666 pass across `lib/mcp/packs` + `lib/decision`, including two new tests pinning the drop and the do-not-drop-on-query-failure case. Module-size and doc-index gates clean locally.

Note: local `apps/web` typecheck is unreliable in this worktree — its `node_modules/@dpf/*` symlinks into a **different, stale worktree**, so `tsc` resolves sources that predate #3473. CI is authoritative.

## Still open on the BI

The reconcile sweep to prune the stale points, and the `previousSlug`/continuity gap that blocks BI-5FE47130's migration (a slug change today either orphans the old page — creating exactly this phantom class — or destroys its version history via the `WikiPageVersion` cascade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
