### PR TITLE
fix(governance): Gate A missed platform decisions phrased in roadmap register (BI-0F0BE69A)

### DIFF
--- a/docs/superpowers/specs/2026-07-03-harness-enforced-decision-routing-and-lease-punt-gates-design.md
+++ b/docs/superpowers/specs/2026-07-03-harness-enforced-decision-routing-and-lease-punt-gates-design.md
@@ -205,3 +205,30 @@ in both guard test files — including the evidence-post repro verbatim.
 Codex remains **fail-open until the operator grants hook trust** (§11). There is still no supported non-interactive trust API ([openai/codex#21615](https://github.com/openai/codex/issues/21615)); forging `[hooks.state.*] trusted_hash` entries is explicitly out of scope (version-specific, brittle).
 
 **Fix:** the standalone installer (`update_agent_toolchain.py`) now (1) **merges** the five blocking plane-1 guards into `~/.codex/hooks.json` (Bash + AskUserQuestion matchers, preserving foreign hooks), (2) **detects** absent hook-trust state (`hooks.state` / `[hooks.state.*] trusted_hash` in `config.toml`), and (3) prints an **ACTION REQUIRED** block with the hook roster (BI-276EC984) plus optional exit code `2` when `--require-codex-hook-trust` or `DPF_REQUIRE_CODEX_HOOK_TRUST=1` is set. This converts the silent fail-open into a blocking install-time instruction — the acceptance path allowed when automation is impossible.
+
+## 14. Post-incident addendum (2026-07-23): Gate A vocabulary gap — delivery worked, **logic** failed (BI-0F0BE69A)
+
+§9's bypass was delivery, not logic — `decide()` returned `block:true` on the escaping payload, the hook simply never registered. **This incident is the exact inverse: the hook was registered, was reached, and returned `block:false` on a genuine platform/build decision.**
+
+**Incident.** While scoping the customer incumbent-application coverage capability, an external coding agent put three questions to the operator in one `AskUserQuestion` call: epic sequencing across three epics (`EP-ASSET-INTELLIGENCE` vs a new epic vs `BI-ECO-001` first), a **change to the closed `SETUP_STEPS` contract** (adding a 12th onboarding step), and build-scope depth. Replaying the recorded payload through the hook binary returned exit 0 with no deny. The operator caught it, not the harness.
+
+**Root cause — register mismatch, not strength.** `DECISION_LANGUAGE` matched only *engineering* register: `architectur`, `spec`, `schema`, `migration`, `implement`, `refactor`, `which <engineering-noun>`, `option 1|2|3`, and `how (should|far|do) (we|i|you)`. The questions were phrased in *product/roadmap* register and matched nothing:
+
+- `/how\s+(?:should|far|do)\s+(?:we|i|you)\b/` **required a pronoun**. "How should **this scope** enter the roadmap" and "How **ambitious** should the output be" both slipped past a pattern that exists to catch precisely them.
+- `roadmap`, `epic`, `backlog`, `scope`, `phase`, `sequencing`, `wizard step`, `prioritize`, `fold into` were absent from the vocabulary entirely.
+- The `header` field is concatenated into the matched text but contributed no matching token either ("Scope shape", "Onboarding", "Sales artifact").
+
+The generalizable lesson: **scoping and epic-sequencing work is normally *thought* in delivery register**, so the register that most needs Gate A was the one register it could not see. A vocabulary allow-list calibrated on one professional dialect silently exempts every adjacent dialect.
+
+**Fix (three layers, `packages/dpf-skill-pack/hooks/decision-routing-guard.mjs`).**
+1. **Pronoun relaxation** — `how (should|far|do|much|many|deep|ambitious|aggressive|broad|big)` no longer requires `we|i|you`.
+2. **`DELIVERY_LANGUAGE`** — a second vocabulary covering the delivery register: roadmap, epic, backlog, sequencing, numbered phase, scope, wizard/setup/onboarding step, prioritize, fold into, build/ship first|now|later|order, first pass.
+3. **`TECHNICAL_ARTIFACT`** — a *structural* signal that needs no vocabulary at all: a question carrying a code identifier is by construction about the codebase. Patterns: semantic ids (`BI-`/`EP-`/`DI-`/`PR-`/`DOC-`/`AGT-`), `SCREAMING_SNAKE` constants, source filenames, and `packages/|apps/|scripts/|services/|docs/` repo paths. This is the highest-precision layer — it caught two of the three escaping questions on identifiers alone (`EP-ASSET-INTELLIGENCE`, `BI-ECO-001`, `SETUP_STEP`) — and is structurally inert against naming/branding/market questions.
+
+**False-positive posture, revisited.** The original file asserted "false-positive control is the NARROW scope, not the block strength." That framing is what produced this gap: narrowness was tuned against one dialect. The revised posture is that **precision comes from signal quality, not vocabulary scarcity** — hence layer 3, which widens coverage while *lowering* false-positive risk. Acronyms without underscores (`SMB`, `HOA`, `CRM`) are deliberately not `SCREAMING_SNAKE` matches, so market-segment questions stay clear. Locked by regression tests asserting pricing, hiring, tagline, and market-segment questions still pass.
+
+**Verification.** The three escaping questions are now regression fixtures (verbatim). 13/13 in `decision-routing-guard.test.mjs`, 175/175 across the skill-pack hook suite, and the recorded payload replayed through the hook binary end-to-end now emits the dual-envelope deny.
+
+**Evidence the gate was load-bearing.** After correction, the three decisions were routed through `principle_decide` (`DI-B4B65B293024`, `DI-5C75BC6ACAFC`, `DI-41949223919C`). On the scope-shape decision the kernel **inverted** the agent's pre-decided answer with high confidence — `fold-into-sam` 17.04 vs the agent's preferred `thin-keystone-epic` 13.55 (margin 2.56, tieMargin 0.2, no commandment conflict), with *Architecture Over Shortcuts*, *Optimize for the Whole* and *Proper Fix Over Quick Fix* the discriminating contributors. The agent's instinct was not merely unverified; it was wrong. Gate A existed to force that consultation and did not fire.
+
+**Residual.** The guard remains a heuristic over natural language and will always have a tail. Layer 3 is the durable part — a structural signal that does not depend on predicting phrasing. A stronger future signal would be semantic (embed the question, compare against the decision-class centroid) rather than lexical; deferred as tuning, not filed as a blocker.

--- a/packages/dpf-skill-pack/hooks/decision-routing-guard.mjs
+++ b/packages/dpf-skill-pack/hooks/decision-routing-guard.mjs
@@ -19,8 +19,8 @@
 // 2026-07-03: hard_block composite 4.54 vs warn 3.78, margin 0.75).
 //
 // False-positive control is the NARROW scope, not the block strength: the guard
-// only trips on engineering-decision language, so operator-owned questions
-// (naming, branding, business strategy) do not match and are never blocked. Two
+// trips on codebase-decision signals, so operator-owned questions (naming,
+// branding, business strategy) do not match and are never blocked. Two
 // escapes remain: (a) once the agent HAS consulted and is legitimately surfacing
 // a low-confidence/defer result, its question references the ledger
 // (principle_decide / composite / margin) and is allowed; (b) explicit bypass via
@@ -42,9 +42,44 @@ const DECISION_LANGUAGE = [
   /\brefactor/i,
   /\bschema\b/i,
   /\bmigration\b/i,
-  /\bhow\s+(?:should|far|do)\s+(?:we|i|you)\b/i,
+  // Pronoun deliberately NOT required (BI-0F0BE69A): "How should THIS SCOPE enter
+  // the roadmap" is the same decision as "how should WE scope this", and the
+  // pronoun form was the exact phrasing that escaped this guard.
+  /\bhow\s+(?:should|far|do|much|many|deep|ambitious|aggressive|broad|big)\b/i,
   /\boption\s+(?:1|2|3|one|two|three|a|b|c)\b/i,
 ];
+
+// Delivery/product-planning vocabulary (BI-0F0BE69A). Scoping, epic sequencing
+// and roadmap-shaping ARE platform/build decisions, but agents naturally phrase
+// them in product register rather than engineering register — so the engineering
+// list above never saw them. This closes that register gap.
+const DELIVERY_LANGUAGE = [
+  /\broadmap\b/i,
+  /\bepics?\b/i,
+  /\bbacklog\b/i,
+  /\bsequenc(?:e|ing|ed)\b/i,
+  /\bphase\s*(?:\d|[a-c]\b|one|two|three)/i,
+  /\bscope\b/i,
+  /\b(?:wizard|setup|onboarding)\s+step\b/i,
+  /\bprioriti[sz]/i,
+  /\bfold(?:ed|ing)?\s+into\b/i,
+  /\b(?:build|ship)\s+(?:it\s+)?(?:first|now|later|order)\b/i,
+  /\bfirst\s+pass\b/i,
+];
+
+// High-precision structural signal (BI-0F0BE69A): a question carrying a code
+// identifier is by construction about the codebase, not about naming, branding,
+// or market strategy. These patterns are near-zero-false-positive against
+// operator-owned questions — "Nova"/"Atlas"/"SMB"/"Blue" match none of them —
+// and they caught two of the three questions that escaped the original guard.
+const TECHNICAL_ARTIFACT = [
+  /\b(?:BI|EP|DI|PR|DOC|AGT)-[A-Z0-9][A-Z0-9-]{3,}\b/, // semantic ids (case-sensitive on purpose)
+  /\b[A-Z][A-Z0-9]*_[A-Z0-9_]+\b/, // SCREAMING_SNAKE constants (SETUP_STEPS, PORTFOLIO_SLUGS)
+  /\b[\w.-]+\.(?:ts|tsx|mjs|cjs|js|jsx|prisma|sql|json|ya?ml|md)\b/i, // file names
+  /\b(?:packages|apps|scripts|services|docs)\/[\w./-]+/i, // repo paths
+];
+
+const ALL_SIGNALS = [...DECISION_LANGUAGE, ...DELIVERY_LANGUAGE, ...TECHNICAL_ARTIFACT];
 
 // If the question already cites a kernel consultation, the agent did the right
 // thing (consulted, now surfacing a low-confidence/defer result) — allow it.
@@ -92,7 +127,7 @@ export function decide(toolName, toolInput = {}, env = {}) {
       .join(" ");
     if (BYPASS_TOKEN.test(text)) continue;
     if (LEDGER_MARKERS.some((re) => re.test(text))) continue; // consulted → surfacing
-    if (DECISION_LANGUAGE.some((re) => re.test(text))) {
+    if (ALL_SIGNALS.some((re) => re.test(text))) {
       return { block: true, reason: GUIDANCE, header: q?.header };
     }
   }

--- a/packages/dpf-skill-pack/hooks/decision-routing-guard.test.mjs
+++ b/packages/dpf-skill-pack/hooks/decision-routing-guard.test.mjs
@@ -36,12 +36,73 @@ test("blocks which-approach / architecture / refactor / schema-migration forks",
   assert.equal(decide("AskUserQuestion", q("Schema migration shape?", "Migration", ["Shape A", "Shape B"])).block, true);
 });
 
+// ── BI-0F0BE69A: platform decisions phrased in product/roadmap register ───────
+// These three are the VERBATIM questions that escaped the guard (exit 0) on
+// 2026-07-23 while scoping the incumbent-application coverage capability. Each
+// is a genuine platform/build decision: epic sequencing across three epics, a
+// change to the closed SETUP_STEPS contract, and build-scope depth.
+
+test("blocks epic-sequencing / roadmap-shaping menus (no engineering noun present)", () => {
+  const v = decide(
+    "AskUserQuestion",
+    q(
+      "How should this scope enter the roadmap, given ~40 related BIs are already filed across three epics?",
+      "Scope shape",
+      ["Thin keystone epic first", "Fold into EP-ASSET-INTELLIGENCE", "Start with BI-ECO-001 answer key"],
+    ),
+  );
+  assert.equal(v.block, true);
+  assert.match(v.reason, /principle_decide|dpf-decision-via-kernel/);
+});
+
+test("blocks a wizard-step / onboarding-placement menu", () => {
+  const v = decide(
+    "AskUserQuestion",
+    q("Where should the customer be asked what they run today?", "Onboarding", [
+      "Optional, skippable wizard step",
+      "Post-setup guided lane",
+      "COO-initiated conversation",
+    ]),
+  );
+  assert.equal(v.block, true);
+});
+
+test("blocks 'how ambitious' build-depth menus (pronoun-free 'how' form)", () => {
+  const v = decide(
+    "AskUserQuestion",
+    q("How ambitious should the sales output be in this first pass?", "Sales artifact", [
+      "Data-rendered coverage view",
+      "Exportable business case",
+      "Defer entirely",
+    ]),
+  );
+  assert.equal(v.block, true);
+});
+
+test("blocks on a code identifier alone, with zero decision vocabulary", () => {
+  // SCREAMING_SNAKE constant, semantic id, repo path, filename — each on its own.
+  assert.equal(decide("AskUserQuestion", q("Where does this go?", "Placement", ["Into SETUP_STEPS", "Somewhere else"])).block, true);
+  assert.equal(decide("AskUserQuestion", q("Where does this go?", "Placement", ["Under EP-ASSET-INTELLIGENCE", "Standalone"])).block, true);
+  assert.equal(decide("AskUserQuestion", q("Where does this go?", "Placement", ["packages/db/src/portfolio-sources/", "Elsewhere"])).block, true);
+  assert.equal(decide("AskUserQuestion", q("Where does this go?", "Placement", ["In types.ts", "A new file"])).block, true);
+});
+
 // ── does NOT block operator-owned questions (narrow scope is the safeguard) ────
 
 test("allows operator-owned naming / branding / business questions", () => {
   assert.equal(decide("AskUserQuestion", q("What should we name the product?", "Name", ["Nova", "Atlas"])).block, false);
   assert.equal(decide("AskUserQuestion", q("Which brand color do you prefer?", "Color", ["Blue", "Green"])).block, false);
   assert.equal(decide("AskUserQuestion", q("Target SMB or enterprise first?", "Market", ["SMB", "Enterprise"])).block, false);
+});
+
+test("BI-0F0BE69A: widened vocabulary still allows realistic operator-owned questions", () => {
+  // Acronyms without underscores are not SCREAMING_SNAKE — "SMB", "HOA", "CRM"
+  // must not read as code identifiers.
+  assert.equal(decide("AskUserQuestion", q("Which market do we serve first?", "Market", ["SMB", "HOA"])).block, false);
+  // Business/pricing/hiring calls carry no codebase signal.
+  assert.equal(decide("AskUserQuestion", q("What should we charge for the managed tier?", "Pricing", ["$99/mo", "$149/mo"])).block, false);
+  assert.equal(decide("AskUserQuestion", q("Do we hire a second support rep this quarter?", "Hiring", ["Yes", "Not yet"])).block, false);
+  assert.equal(decide("AskUserQuestion", q("Which tagline reads better?", "Tagline", ["Run your business", "Own your business"])).block, false);
 });
 
 test("allows single-option / factual clarifications", () => {


### PR DESCRIPTION
## What happened

The decision-routing guard is the harness backstop for the `consult-scopes-before-asking` **commandment**. It was wired correctly, was reached, and **returned exit 0** on a genuine 3-option platform decision: epic sequencing across three epics, a change to the closed `SETUP_STEPS` contract, and build-scope depth. The operator caught it; the harness did not.

This is the **inverse of the §9 incident**. There, delivery failed while the logic was sound (`decide()` returned `block:true` on the escaping payload). Here, delivery worked and the logic failed.

## Root cause — register mismatch, not block strength

`DECISION_LANGUAGE` matched only *engineering* register. Two gaps let the payload through:

- `/how\s+(?:should|far|do)\s+(?:we|i|you)\b/` **required a pronoun**. "How should **this scope** enter the roadmap" and "How **ambitious** should the output be" both missed a pattern written to catch exactly them.
- `roadmap`, `epic`, `backlog`, `scope`, `phase`, `sequencing`, `wizard step`, `prioritize`, `fold into` were absent from the vocabulary entirely.

Scoping and epic-sequencing work is normally *thought* in delivery register — so the register that most needs Gate A was the one register it could not see.

## Fix — three layers

1. **Pronoun relaxation** on the `how …` form.
2. **`DELIVERY_LANGUAGE`** — the delivery/product-planning register.
3. **`TECHNICAL_ARTIFACT`** — a *structural* signal needing no vocabulary at all: a question carrying a code identifier (`BI-`/`EP-`/`DI-` ids, `SCREAMING_SNAKE` constants, source filenames, repo paths) is by construction about the codebase. Highest precision of the three — it catches two of the three escaping questions on identifiers alone.

The original file asserted *"false-positive control is the NARROW scope, not the block strength."* That framing is what produced this gap: narrowness was tuned against one dialect. Revised posture: **precision comes from signal quality, not vocabulary scarcity** — hence layer 3, which widens coverage while *lowering* false-positive risk. Acronyms without underscores (`SMB`, `HOA`, `CRM`) are deliberately not `SCREAMING_SNAKE` matches, so market-segment questions stay clear.

## Verification

- The three escaping questions are now **verbatim regression fixtures**.
- **13/13** in `decision-routing-guard.test.mjs`; **175/175** across the skill-pack hook suite.
- The recorded payload replayed through the hook binary end-to-end now emits the dual-envelope deny (**was exit 0**).
- False-positive boundary locked by tests asserting pricing, hiring, tagline and market-segment questions still pass.
- Gates run locally against this branch: design-grounding OK, spec/plan/doc OK, seed-fit N/A.

## Evidence the gate was load-bearing

After correction the three decisions were routed through `principle_decide` (`DI-B4B65B293024`, `DI-5C75BC6ACAFC`, `DI-41949223919C`). On scope shape the kernel **inverted** the agent's pre-decided answer with high confidence — `fold-into-sam` 17.04 vs the agent's preferred `thin-keystone-epic` 13.55 (margin 2.56, tieMargin 0.2, no commandment conflict), with *Architecture Over Shortcuts*, *Optimize for the Whole* and *Proper Fix Over Quick Fix* the discriminating contributors. The agent's instinct was not merely unverified — it was wrong.

## Residual

The guard remains a heuristic over natural language and will always have a tail. Layer 3 is the durable part: a structural signal that does not depend on predicting phrasing. A semantic successor (embed the question, compare against a decision-class centroid) is noted in the spec as tuning, not filed as a blocker.

Backlog item: BI-0F0BE69A (EP-WWMD-MCP). Related but distinct: BI-C5A31A24 covers surfaces with *no* routing at all and does not close this.

Seed-Fit-Decision: not-applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
