### PR TITLE
feat(kernel): profession-local decision axis registry (BI-106C2585 Phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-profession-local-decision-axes.md
+++ b/docs/superpowers/plans/2026-07-24-profession-local-decision-axes.md
@@ -1,0 +1,55 @@
+# Profession-Local Decision Axes
+
+- **Date:** 2026-07-24
+- **Backlog:** `BI-106C2585`
+- **Epic:** `EP-DECISION-TIER-REBALANCE`
+- **Spec:** [`2026-07-23-decision-tier-rebalance-and-vector-epistemology-design.md`](../specs/2026-07-23-decision-tier-rebalance-and-vector-epistemology-design.md) §2.2
+- **Depends on:** `BI-AA7D80FE` (spine labelled; `projectVectorOntoSpine` shipped) — done. `BI-5FE47130` (professions own their content) — in progress.
+
+## Problem
+
+`PRINCIPLE_DIMENSIONS` is a closed `as const` registry and every tier scores into that one flat space. A profession-specific trade-off has nowhere to land, so it is crushed into the nearest generic axis — a UX judgment about typographic hierarchy vs information density becomes `human_cognitive_load` and is thereby indistinguishable from a build-queue latency concern. That flattening is a mechanism behind ambiguous vectors that cannot discern multiple trade-offs.
+
+The answer is not to widen the shared space — that re-inflates exactly what spine reduction shrank. It is to let a profession declare axes **inside its own corpus**, scored at full resolution there and projected onto the spine when the decision leaves the profession.
+
+## Three rules (from the spec)
+
+1. **Typed** — `benefit` or `cost`, with a `highMeans` statement, matching `DimensionGuidance`.
+2. **Projected** — every local axis declares a weight onto ≥1 spine axis. Full resolution inside the profession; rolls up when the decision leaves it. This is what preserves cross-profession commensurability.
+3. **Sourced** — inherits the WSID provenance invariant: a local axis without a cited source cannot publish.
+
+The projection and integrity machinery already exists from BI-AA7D80FE: `projectVectorOntoSpine`, `assertDimensionScopeIntegrity`, the `projectsOnto`-must-terminate-on-spine rule. This work adds the *profession-owned* registry that reuses it.
+
+## Phases
+
+### Phase 1 — the registry (substrate only, no retrieval change)
+
+`packages/db/src/profession-local-axes.ts`:
+
+- `ProfessionLocalAxis` — `{ profession, key, kind, highMeans, projectsOnto, source }`.
+- Keys are **namespaced** `<profession>/<axis>` so a local axis can never collide with a spine axis or another profession's axis, and so a bare feature key is unambiguously spine.
+- `PROFESSION_LOCAL_AXES` — an array (not an `as const` map, because keys are namespaced strings, not the closed `PrincipleDimension` union).
+- `assertProfessionLocalAxisIntegrity(knownProfessions)` — every axis: real `professionKey`; `kind` set; non-empty `highMeans`; `projectsOnto` non-empty and every target a **spine** axis (reuses `isSpineDimension`); non-empty `source`. Namespaced key matches `<profession>/`.
+- `projectLocalAxisVector(profession, vector)` — extends `projectVectorOntoSpine` so a vector mixing spine axes and this profession's local axes rolls up correctly, splitting weight across targets (no amplification), sign preserved.
+
+Ships with the registry **empty** plus one worked example in a test, same discipline as the slug-migration list: machinery lands proven, the first real axis lands with the profession that needs it.
+
+Enforcement mirrors the spine: an integrity test runs `assert…` against the real registry, and pins the no-amplification and sign-preservation properties.
+
+### Phase 2 — thread the caller's profession into `principle_decide` (retrieval path)
+
+`resolve-profession-profile.ts` already resolves a profession from an agent identity, but `principle-decide-pack.ts` does not call it. Add a resolved `profession` to the decision context so the scorer knows which local axes are in scope. Live-verify: a profession caller's local axes appear as valid feature keys; a cross-profession caller's do not.
+
+### Phase 3 — validation + scoring wiring
+
+- `validateOptionFeatures` accepts a namespaced local axis **only** when the caller is in that profession; otherwise it is `unknown-dimension`, exactly as today.
+- In-profession, the local axis scores at full resolution. On roll-up (the decision is consumed outside the profession, or a cross-profession ledger is assembled), `projectLocalAxisVector` maps it to the spine.
+- The dimension catalogue surface (`buildFeaturesDescription`) gains the in-scope profession's local axes when a profession is resolved.
+
+## Spec relaxation to record
+
+The founder-kernel evolution discipline (`2026-05-24`) requires an orthogonality argument plus ≥2 principles for a new **spine** axis. Profession-local axes take a lighter path — provenance and a declared projection, not the full argument. That relaxation is deliberate; §2.2 already states it, and the evolution-discipline spec should carry a banner pointing at it.
+
+## Acceptance
+
+A profession declares a local axis end-to-end — typed, sourced, projected, scored at full resolution within the profession, correctly rolled up when the decision crosses professions; an unsourced or unprojected axis fails to publish (integrity assertion + provenance gate).

--- a/docs/superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md
+++ b/docs/superpowers/specs/2026-05-24-founder-kernel-evolution-discipline-design.md
@@ -21,6 +21,8 @@ relatedPrinciples:
 
 > **Amended 2026-07-23** by [`2026-07-23-decision-tier-rebalance-and-vector-epistemology-design.md`](2026-07-23-decision-tier-rebalance-and-vector-epistemology-design.md).
 > The promotion/retirement contract here governs SPINE axes. A second, lighter path is introduced there for profession-local axes: they require provenance and a declared projection onto a spine axis, not the full orthogonality argument. This is an explicit, recorded relaxation.
+>
+> **Implemented 2026-07-24 (BI-106C2585 Phase 1).** The lighter path is now a typed registry: `packages/db/src/profession-local-axes.ts`. `assertProfessionLocalAxisIntegrity` enforces exactly the relaxed contract — a real owning `professionKey`, a `benefit`/`cost` type, a `highMeans`, a non-empty `source` (the provenance invariant, unchanged), and a `projectsOnto` that terminates on the spine in one hop. It does NOT demand the orthogonality argument this spec requires of a spine axis. Namespaced keys (`<profession>/<axis>`) keep local axes from colliding with the spine or shadowing it. Scoring/retrieval wiring (Phases 2–3) is separate.
 
 # Founder kernel evolution discipline
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -43,6 +43,7 @@
     "./edge-node-types": "./src/edge-node-types.ts",
     "./wiki-taxonomy": "./src/wiki-taxonomy.ts",
     "./dimension-scope": "./src/dimension-scope.ts",
+    "./profession-local-axes": "./src/profession-local-axes.ts",
     "./wiki-store": "./src/wiki-store.ts",
     "./wiki-frontmatter": "./src/wiki-frontmatter.ts",
     "./capability-maturity": "./src/capability-maturity.ts",

--- a/packages/db/src/profession-local-axes.test.ts
+++ b/packages/db/src/profession-local-axes.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  PROFESSION_LOCAL_AXES,
+  assertProfessionLocalAxisIntegrity,
+  localAxesFor,
+  localAxisKey,
+  projectLocalAxisVector,
+  type ProfessionLocalAxis,
+} from "./profession-local-axes";
+
+// BI-106C2585 Phase 1. The registry is the substrate a profession uses to
+// declare its own trade-off axes without inflating the shared spine. These
+// tests pin the invariants that keep it commensurable — above all that a local
+// axis always rolls up onto the spine and can never amplify a principle by
+// projecting at full weight onto several targets.
+
+const REGISTRY_PROFESSIONS: ReadonlySet<string> = new Set(
+  (
+    JSON.parse(
+      readFileSync(join(__dirname, "../../../docs/professions/registry.json"), "utf8"),
+    ) as { families: Array<{ professionKey: string }> }
+  ).families.map((f) => f.professionKey),
+);
+
+// A worked example — NOT added to the shipped registry (which stays empty until
+// a real corpus scores an axis), but exercised here so the machinery is proven
+// end-to-end. `hierarchy_clarity` is the spec's own example: a ux-design axis
+// that rolls up onto human_cognitive_load.
+const EXAMPLE: ProfessionLocalAxis = {
+  profession: "ux-design",
+  key: "ux-design/hierarchy_clarity",
+  kind: "benefit",
+  highMeans: "the option makes the visual hierarchy easier to parse at a glance",
+  projectsOnto: ["human_cognitive_load"],
+  source: "nng/visual-hierarchy",
+};
+
+describe("PROFESSION_LOCAL_AXES registry", () => {
+  it("ships empty — machinery lands before any axis scores", () => {
+    expect(PROFESSION_LOCAL_AXES).toHaveLength(0);
+  });
+
+  it("passes integrity against the real profession registry (empty is valid)", () => {
+    expect(() => assertProfessionLocalAxisIntegrity(REGISTRY_PROFESSIONS)).not.toThrow();
+  });
+
+  it("accepts a well-formed axis", () => {
+    expect(() =>
+      assertProfessionLocalAxisIntegrity(REGISTRY_PROFESSIONS, [EXAMPLE]),
+    ).not.toThrow();
+  });
+});
+
+describe("assertProfessionLocalAxisIntegrity — the rules that keep axes commensurable", () => {
+  const check = (a: Partial<ProfessionLocalAxis>) =>
+    assertProfessionLocalAxisIntegrity(REGISTRY_PROFESSIONS, [{ ...EXAMPLE, ...a }]);
+
+  it("rejects an axis owned by a non-existent profession", () => {
+    expect(() => check({ profession: "wizard", key: "wizard/x" })).toThrow(/professionKey/);
+  });
+
+  it("rejects a bare (non-namespaced) key", () => {
+    expect(() => check({ key: "hierarchy_clarity" })).toThrow(/namespaced/);
+  });
+
+  it("rejects a key namespaced under a different profession than it claims", () => {
+    expect(() => check({ key: "finance/hierarchy_clarity" })).toThrow(/namespaced/);
+  });
+
+  it("rejects shadowing a spine axis name", () => {
+    expect(() => check({ key: "ux-design/human_cognitive_load" })).toThrow(/spine axis/);
+  });
+
+  it("rejects an unsourced axis — the WSID provenance invariant holds", () => {
+    expect(() => check({ source: "  " })).toThrow(/provenance/);
+  });
+
+  it("rejects an axis with no projection", () => {
+    expect(() => check({ projectsOnto: [] })).toThrow(/no projection/);
+  });
+
+  it("rejects a projection onto a profession-local target (must hit the spine)", () => {
+    // schema_grounding is profession-local as of BI-AA7D80FE.
+    expect(() => check({ projectsOnto: ["schema_grounding"] })).toThrow(/terminate on the spine/);
+  });
+
+  it("rejects a duplicate key", () => {
+    expect(() =>
+      assertProfessionLocalAxisIntegrity(REGISTRY_PROFESSIONS, [EXAMPLE, EXAMPLE]),
+    ).toThrow(/Duplicate/);
+  });
+});
+
+describe("projectLocalAxisVector — roll-up onto the spine", () => {
+  const reg = [EXAMPLE];
+
+  it("passes spine axes through untouched", () => {
+    expect(
+      projectLocalAxisVector("ux-design", { human_cognitive_load: 0.7, blast_radius: -0.2 }, reg),
+    ).toEqual({ human_cognitive_load: 0.7, blast_radius: -0.2 });
+  });
+
+  it("rolls a local axis onto its declared spine target", () => {
+    expect(projectLocalAxisVector("ux-design", { "ux-design/hierarchy_clarity": 0.8 }, reg)).toEqual({
+      human_cognitive_load: 0.8,
+    });
+  });
+
+  it("sums when a local axis and its spine target are both scored", () => {
+    const out = projectLocalAxisVector(
+      "ux-design",
+      { human_cognitive_load: 0.3, "ux-design/hierarchy_clarity": 0.4 },
+      reg,
+    );
+    expect(out.human_cognitive_load).toBeCloseTo(0.7);
+  });
+
+  it("splits weight across targets so roll-up cannot amplify a principle", () => {
+    const multi: ProfessionLocalAxis = {
+      ...EXAMPLE,
+      key: "ux-design/legibility",
+      projectsOnto: ["human_cognitive_load", "long_term_maintainability"],
+    };
+    const out = projectLocalAxisVector("ux-design", { "ux-design/legibility": 0.6 }, [multi]);
+    expect(out.human_cognitive_load).toBeCloseTo(0.3);
+    expect(out.long_term_maintainability).toBeCloseTo(0.3);
+    expect(Object.values(out).reduce((a, b) => a + b, 0)).toBeCloseTo(0.6);
+  });
+
+  it("preserves sign, so a cost axis stays a cost after roll-up", () => {
+    const cost: ProfessionLocalAxis = {
+      ...EXAMPLE,
+      key: "ux-design/clutter",
+      kind: "cost",
+      projectsOnto: ["human_cognitive_load"],
+    };
+    const out = projectLocalAxisVector("ux-design", { "ux-design/clutter": -0.5 }, [cost]);
+    expect(out.human_cognitive_load).toBeCloseTo(-0.5);
+  });
+
+  it("drops a local axis that belongs to a DIFFERENT profession", () => {
+    // Commensurability boundary: another profession's axis is not in scope, so
+    // it does not silently leak into this profession's roll-up.
+    expect(projectLocalAxisVector("finance", { "ux-design/hierarchy_clarity": 0.9 }, reg)).toEqual({});
+  });
+
+  it("ignores keys that are neither spine nor a known local axis", () => {
+    expect(projectLocalAxisVector("ux-design", { not_a_thing: 0.9 }, reg)).toEqual({});
+  });
+});
+
+describe("helpers", () => {
+  it("localAxisKey namespaces consistently", () => {
+    expect(localAxisKey("ux-design", "hierarchy_clarity")).toBe("ux-design/hierarchy_clarity");
+  });
+
+  it("localAxesFor returns only the named profession's axes", () => {
+    const other: ProfessionLocalAxis = { ...EXAMPLE, profession: "finance", key: "finance/x" };
+    expect(localAxesFor("ux-design", [EXAMPLE, other])).toEqual([EXAMPLE]);
+  });
+});

--- a/packages/db/src/profession-local-axes.ts
+++ b/packages/db/src/profession-local-axes.ts
@@ -1,0 +1,197 @@
+// Profession-local decision axes (BI-106C2585).
+//
+// Spec: docs/superpowers/specs/2026-07-23-decision-tier-rebalance-and-vector-epistemology-design.md §2.2
+// Plan: docs/superpowers/plans/2026-07-24-profession-local-decision-axes.md
+//
+// PRINCIPLE_DIMENSIONS is the SPINE — the axes every profession trades against,
+// deliberately kept small (BI-AA7D80FE). But a profession-specific trade-off has
+// nowhere to land in that flat space, so it gets crushed into the nearest
+// generic axis: a UX judgment about typographic hierarchy vs information density
+// collapses into `human_cognitive_load` and becomes indistinguishable from a
+// build-queue latency concern.
+//
+// The fix is NOT to widen the spine — that re-inflates what spine reduction just
+// shrank, and makes every profession reason over every other profession's
+// vocabulary. It is to let a profession declare axes INSIDE its own corpus,
+// scored at full resolution there and PROJECTED onto the spine when the decision
+// leaves the profession. Vectors multiply where the criteria actually live,
+// without inflating the shared space.
+//
+// This module is Phase 1: the registry and its integrity rules. It reuses the
+// projection machinery from dimension-scope.ts (BI-AA7D80FE) rather than
+// re-deriving it. Threading the caller's profession into principle_decide
+// (Phase 2) and the feature-key/scoring wiring (Phase 3) are separate slices
+// that touch the retrieval path and need live verification; this slice is
+// substrate-only and enforced entirely at compile + test time.
+
+import {
+  PRINCIPLE_DIMENSIONS,
+  isPrincipleDimension,
+  type PrincipleDimension,
+} from "./wiki-taxonomy";
+import { isSpineDimension } from "./dimension-scope";
+
+/** benefit = higher is better; cost = higher is worse (negative weight). */
+export type ProfessionLocalAxisKind = "benefit" | "cost";
+
+export type ProfessionLocalAxis = {
+  /** professionKey from docs/professions/registry.json that owns this axis. */
+  profession: string;
+  /**
+   * Namespaced axis key: `<profession>/<axis>`. Namespacing is load-bearing —
+   * it guarantees a local axis can never collide with a spine axis (which are
+   * bare keys) or with another profession's axis, so a bare feature key is
+   * unambiguously spine and a namespaced one is unambiguously local.
+   */
+  key: string;
+  kind: ProfessionLocalAxisKind;
+  /** What a HIGH (near 1.0) score asserts about the option. */
+  highMeans: string;
+  /**
+   * Spine axes this rolls up onto when the decision leaves the profession.
+   * MUST be non-empty and every target MUST be a spine axis — a local axis with
+   * no projection would silently vanish from every cross-profession decision,
+   * which breaks the commensurability the spine exists to provide.
+   */
+  projectsOnto: readonly PrincipleDimension[];
+  /**
+   * Provenance. Inherits the WSID invariant unchanged: a local axis without a
+   * cited source cannot publish. Kept as a plain string key (e.g.
+   * `ietf/rfc-9110`) mirroring the corpus `sources` frontmatter.
+   */
+  source: string;
+};
+
+/**
+ * The registry. Ships EMPTY: the machinery lands proven, and the first real
+ * axis lands with the profession that needs it (same discipline as
+ * WIKI_SLUG_MIGRATIONS). A worked example lives only in the test, so this array
+ * is never non-empty without a corresponding corpus that scores it.
+ */
+export const PROFESSION_LOCAL_AXES: readonly ProfessionLocalAxis[] = [];
+
+/** Namespaced key for a profession-local axis. */
+export function localAxisKey(profession: string, axis: string): string {
+  return `${profession}/${axis}`;
+}
+
+/** Every local axis owned by one profession. */
+export function localAxesFor(
+  profession: string,
+  registry: readonly ProfessionLocalAxis[] = PROFESSION_LOCAL_AXES,
+): readonly ProfessionLocalAxis[] {
+  return registry.filter((a) => a.profession === profession);
+}
+
+/**
+ * Project a vector that MAY contain this profession's local axes onto the pure
+ * spine. Spine axes pass through; a local axis contributes its weight to each
+ * spine axis it declares, split evenly so a demotion/roll-up can never amplify a
+ * principle beyond its authored magnitude. Sign is preserved, so a cost axis
+ * stays a cost after roll-up. A namespaced key that is not a known local axis
+ * for this profession is dropped rather than invented — mirroring
+ * projectVectorOntoSpine's treatment of non-dimension keys.
+ *
+ * Kept parallel to (not merged into) projectVectorOntoSpine: that function is
+ * the spine-only roll-up used everywhere; this one is the profession-aware
+ * superset used when a caller scored local axes.
+ */
+export function projectLocalAxisVector(
+  profession: string,
+  vector: Record<string, number>,
+  registry: readonly ProfessionLocalAxis[] = PROFESSION_LOCAL_AXES,
+): Record<string, number> {
+  const localByKey = new Map(
+    localAxesFor(profession, registry).map((a) => [a.key, a] as const),
+  );
+  const out: Record<string, number> = {};
+  const add = (k: string, v: number) => {
+    out[k] = (out[k] ?? 0) + v;
+  };
+  for (const [key, value] of Object.entries(vector)) {
+    // A bare spine axis passes through unchanged.
+    if (isPrincipleDimension(key)) {
+      add(key, value);
+      continue;
+    }
+    // A namespaced local axis for this profession rolls up onto its targets.
+    const axis = localByKey.get(key);
+    if (!axis) continue; // unknown key: drop, do not invent an axis
+    const share = value / axis.projectsOnto.length;
+    for (const target of axis.projectsOnto) add(target, share);
+  }
+  return out;
+}
+
+/**
+ * Structural invariants the type system cannot express. Called by the registry
+ * test so a bad axis fails CI rather than silently degrading a decision. The
+ * profession set is passed in (not read from disk) so this module stays
+ * filesystem-free for the browser bundle — same contract as
+ * assertDimensionScopeIntegrity.
+ */
+export function assertProfessionLocalAxisIntegrity(
+  knownProfessions: ReadonlySet<string>,
+  registry: readonly ProfessionLocalAxis[] = PROFESSION_LOCAL_AXES,
+): void {
+  const seen = new Set<string>();
+  for (const axis of registry) {
+    if (!knownProfessions.has(axis.profession)) {
+      throw new Error(
+        `Profession-local axis "${axis.key}" is owned by "${axis.profession}", ` +
+          `which is not a professionKey in docs/professions/registry.json. An axis ` +
+          `owned by a profession that does not exist can never be retrieved.`,
+      );
+    }
+    // Key must be namespaced under its owning profession.
+    const expectedPrefix = `${axis.profession}/`;
+    if (!axis.key.startsWith(expectedPrefix) || axis.key.length <= expectedPrefix.length) {
+      throw new Error(
+        `Profession-local axis "${axis.key}" must be namespaced as ` +
+          `"${axis.profession}/<axis>". A bare key would collide with the spine.`,
+      );
+    }
+    // A local axis MUST NOT shadow a spine axis name, even namespaced.
+    const bare = axis.key.slice(expectedPrefix.length);
+    if (isPrincipleDimension(bare)) {
+      throw new Error(
+        `Profession-local axis "${axis.key}" reuses the spine axis name "${bare}". ` +
+          `Score the spine axis directly rather than shadowing it per-profession.`,
+      );
+    }
+    if (seen.has(axis.key)) {
+      throw new Error(`Duplicate profession-local axis key "${axis.key}".`);
+    }
+    seen.add(axis.key);
+
+    if (!axis.highMeans.trim()) {
+      throw new Error(`Profession-local axis "${axis.key}" has no highMeans statement.`);
+    }
+    if (!axis.source.trim()) {
+      throw new Error(
+        `Profession-local axis "${axis.key}" has no source. The WSID provenance ` +
+          `invariant applies unchanged: an unsourced axis cannot publish.`,
+      );
+    }
+    if (axis.projectsOnto.length === 0) {
+      throw new Error(
+        `Profession-local axis "${axis.key}" declares no projection. A local axis ` +
+          `without a spine projection vanishes from every cross-profession decision.`,
+      );
+    }
+    for (const target of axis.projectsOnto) {
+      if (!(PRINCIPLE_DIMENSIONS as readonly string[]).includes(target)) {
+        throw new Error(
+          `Profession-local axis "${axis.key}" projects onto "${target}", which is ` +
+            `not a registered dimension.`,
+        );
+      }
+      if (!isSpineDimension(target)) {
+        throw new Error(
+          `Profession-local axis "${axis.key}" projects onto "${target}", which is ` +
+            `itself profession-local. Projections must terminate on the spine in one hop.`,
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
EP-DECISION-TIER-REBALANCE **step 4, Phase 1** — the substrate slice. Builds directly on the spine classification merged in #3481.

Seed-Fit-Decision: parameterize-first

## Problem

`PRINCIPLE_DIMENSIONS` is the **spine**: the small set of axes every profession trades against, kept small by BI-AA7D80FE. A profession-specific trade-off has nowhere to land in that flat space, so it gets crushed into the nearest generic axis — a UX judgment about typographic hierarchy vs information density collapses into `human_cognitive_load` and becomes indistinguishable from a build-queue latency concern.

The fix is **not** to widen the spine — that re-inflates what spine reduction just shrank, and makes every profession reason over every other profession's vocabulary. It is to let a profession declare axes **inside its own corpus**, scored at full resolution there and **projected onto the spine** when the decision leaves the profession.

## What this ships (Phase 1)

`packages/db/src/profession-local-axes.ts` — the registry and its integrity rules, reusing the projection machinery from `dimension-scope.ts` (BI-AA7D80FE) rather than re-deriving it.

`assertProfessionLocalAxisIntegrity` enforces the three spec rules, each pinned by test:

| Rule | Enforcement |
|---|---|
| **Typed** | `benefit`/`cost` + a `highMeans` statement |
| **Projected** | `projectsOnto` non-empty, every target a **spine** axis, one hop (reuses `isSpineDimension`) |
| **Sourced** | non-empty `source` — the WSID provenance invariant, unchanged |

Plus **namespacing** (`<profession>/<axis>`) so a local axis can never collide with the spine or shadow a spine name, and ownership by a real `professionKey`.

`projectLocalAxisVector` rolls a mixed vector onto the spine, **splitting weight across targets so a roll-up cannot amplify a principle**, and **preserving sign** so a cost axis stays a cost — the same two failure modes the spine PR guarded, now for local axes.

## Ships empty, on purpose

Same discipline as the slug-migration list: the machinery lands proven (a worked `ux-design/hierarchy_clarity` example — the spec's own example — lives only in the test), and the first real axis lands with the profession that scores it.

## Scope boundary

This slice is enforced **entirely at compile + test time and touches no retrieval path**. The remaining phases are deliberately separate because they need live verification:

- **Phase 2** — thread the caller's profession into `principle_decide`. `resolve-profession-profile.ts` already resolves a profession from an agent identity, but the pack does not call it.
- **Phase 3** — feature-key validation accepting a local axis only in-profession, in-profession scoring at full resolution, and roll-up projection on exit.

Both are described in the plan.

## Verification

20 new tests (integrity rules, roll-up, sign preservation, no-amplification, cross-profession isolation); 38 pass with the spine suite; **1528 pass** across `packages/db/src`; `packages/db` typechecks clean. The evolution-discipline spec's relaxation banner is updated to point at the shipped enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
