### PR TITLE
feat(ux-critique): the capture door for the critique corpus (BI-3880DA1D)

### DIFF
--- a/apps/web/lib/actions/critique-entry.test.ts
+++ b/apps/web/lib/actions/critique-entry.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const saveWikiOverlayEdit = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/actions/wiki-edit", () => ({ saveWikiOverlayEdit }));
+
+import { captureCritiqueEntry } from "./critique-entry";
+import { CRITIQUE_ENTRY_METADATA_KIND } from "@/lib/ux-critique/critique-entry";
+
+const GOOD_FINDING = "Lead band carries 240 words before the owner's next action appears.";
+
+beforeEach(() => {
+  saveWikiOverlayEdit.mockReset();
+  saveWikiOverlayEdit.mockResolvedValue({
+    ok: true,
+    pageId: "p1",
+    slug: "craft/ux-design/workspace-lead-band",
+    status: "draft",
+  });
+});
+
+describe("captureCritiqueEntry", () => {
+  it("writes a draft craft-override page with the critique fields in metadata", async () => {
+    const result = await captureCritiqueEntry({
+      title: "Workspace lead band",
+      callerKind: "human",
+      route: "/workspace",
+      finding: GOOD_FINDING,
+      screenshotRef: "capture/workspace.png",
+      verdict: "change-needed",
+      verdictAuthority: "founder",
+    });
+
+    expect(result.ok).toBe(true);
+    const arg = saveWikiOverlayEdit.mock.calls[0]![0];
+    expect(arg.status).toBe("draft"); // never born published
+    expect(arg.slug).toMatch(/^craft\/ux-design\//);
+    expect(arg.body).toBe(GOOD_FINDING);
+    expect(arg.metadata.metadataKind).toBe(CRITIQUE_ENTRY_METADATA_KIND);
+    expect(arg.metadata.route).toBe("/workspace");
+    expect(arg.metadata.verdictAuthority).toBe("founder");
+  });
+
+  it("forces draft status even when the caller asks for published", async () => {
+    // Publishing is the human's separate act; capture never shortcuts it.
+    await captureCritiqueEntry({
+      title: "Anything",
+      callerKind: "human",
+      route: "/finance",
+      finding: GOOD_FINDING,
+      status: "published",
+    });
+    expect(saveWikiOverlayEdit.mock.calls[0]![0].status).toBe("draft");
+  });
+
+  it("lets an agent PROPOSE a verdict", async () => {
+    const result = await captureCritiqueEntry({
+      title: "Agent draft",
+      callerKind: "agent",
+      route: "/customer",
+      finding: GOOD_FINDING,
+      verdict: "change-needed",
+      verdictAuthority: "agent-proposed",
+    });
+    expect(result.ok).toBe(true);
+    expect(saveWikiOverlayEdit.mock.calls[0]![0].metadata.verdictAuthority).toBe("agent-proposed");
+  });
+
+  it("REFUSES to let an agent attach a founder verdict", async () => {
+    // The load-bearing boundary: a judge calibrated on agent-authored verdicts
+    // is calibrated against itself.
+    const result = await captureCritiqueEntry({
+      title: "Agent overreach",
+      callerKind: "agent",
+      route: "/customer",
+      finding: GOOD_FINDING,
+      verdict: "change-needed",
+      verdictAuthority: "founder",
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: expect.stringMatching(/agent may only propose/i),
+    });
+    expect(saveWikiOverlayEdit).not.toHaveBeenCalled();
+  });
+
+  it("refuses an impression instead of an observation", async () => {
+    const result = await captureCritiqueEntry({
+      title: "Vague",
+      callerKind: "human",
+      route: "/workspace",
+      finding: "feels cluttered",
+    });
+    expect(result.ok).toBe(false);
+    expect(saveWikiOverlayEdit).not.toHaveBeenCalled();
+  });
+
+  it("requires a title", async () => {
+    const result = await captureCritiqueEntry({
+      title: "",
+      callerKind: "human",
+      route: "/workspace",
+      finding: GOOD_FINDING,
+    });
+    expect(result.ok).toBe(false);
+    expect(saveWikiOverlayEdit).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a store failure rather than claiming success", async () => {
+    saveWikiOverlayEdit.mockResolvedValue({ ok: false, error: "org missing" });
+    const result = await captureCritiqueEntry({
+      title: "Workspace",
+      callerKind: "human",
+      route: "/workspace",
+      finding: GOOD_FINDING,
+    });
+    expect(result).toEqual({ ok: false, error: "org missing" });
+  });
+});

--- a/apps/web/lib/actions/critique-entry.ts
+++ b/apps/web/lib/actions/critique-entry.ts
@@ -1,0 +1,93 @@
+"use server";
+// EP-UX-SYSTEM L6 (BI-3880DA1D): the capture door for the UX critique corpus.
+//
+// The corpus module (lib/ux-critique/critique-entry.ts) defines the entry shape
+// and the calibration-eligibility contract; this action is how an entry
+// actually gets into the store. It is deliberately thin and rides the existing
+// craft-override path: a critique entry is a craft-override WikiPage under
+// `craft/ux-design/<slug>` whose structured fields live in WikiPage.metadata,
+// exactly as the WSID variant axes do. It creates NO new store.
+//
+// The authority contract is preserved here, not just described:
+//   - Every captured entry lands as a DRAFT. Publishing (the human's act) is a
+//     separate step through the existing wiki-overlay path, and the calibration
+//     set derives eligibility from published + founder-verdict anyway.
+//   - An agent caller may NOT attach a founder/designer verdict. It may propose
+//     one (verdictAuthority "agent-proposed"), which is never calibration-
+//     eligible. A judge calibrated on agent-authored verdicts is calibrated
+//     against itself.
+
+import { saveWikiOverlayEdit } from "@/lib/actions/wiki-edit";
+import { buildCraftOverrideSlug } from "@/lib/wiki/craft-override";
+import {
+  critiqueEntryToMetadata,
+  validateCritiqueEntry,
+  type CritiqueEntry,
+} from "@/lib/ux-critique/critique-entry";
+
+/** The profession corpus critique entries belong to. */
+const CRITIQUE_PROFESSION_KEY = "ux-design";
+
+export type CaptureCritiqueEntryInput = {
+  /** A short title for the entry — becomes the page title and its slug. */
+  title: string;
+  /**
+   * Who is capturing this. An agent caller is confined to proposing a verdict;
+   * only a human caller may pass a founder/designer verdict. The route layer
+   * sets this from the authenticated principal, never the client.
+   */
+  callerKind: "human" | "agent";
+} & Partial<CritiqueEntry>;
+
+export type CaptureCritiqueEntryResult =
+  | { ok: true; slug: string; status: string }
+  | { ok: false; error: string };
+
+export async function captureCritiqueEntry(
+  input: CaptureCritiqueEntryInput,
+): Promise<CaptureCritiqueEntryResult> {
+  const title = input.title?.trim() ?? "";
+  if (title.length < 3) {
+    return { ok: false, error: "Give the entry a short title (at least 3 characters)." };
+  }
+
+  // Enforce the authority boundary BEFORE validation so the rejection names the
+  // real reason rather than a downstream shape error.
+  if (
+    input.callerKind === "agent" &&
+    input.verdict &&
+    input.verdictAuthority !== "agent-proposed"
+  ) {
+    return {
+      ok: false,
+      error:
+        "An agent may only propose a verdict (verdictAuthority 'agent-proposed'); attaching a founder or designer verdict is a human act.",
+    };
+  }
+
+  const validated = validateCritiqueEntry(input);
+  if (!validated.ok) {
+    return { ok: false, error: validated.error };
+  }
+
+  // Every captured entry is a draft. Publishing is the human's separate act, and
+  // eligibility is derived from published + founder-verdict downstream — so even
+  // a human-verdicted capture does not become calibration data until published.
+  const entry: CritiqueEntry = { ...validated.entry, status: "draft" };
+
+  const result = await saveWikiOverlayEdit({
+    slug: buildCraftOverrideSlug(CRITIQUE_PROFESSION_KEY, title),
+    pageKind: "heuristic",
+    title,
+    body: entry.finding,
+    status: "draft",
+    abstract: `UX critique of ${entry.route}`,
+    metadata: critiqueEntryToMetadata(entry),
+    changeSummary: `UX critique entry captured for ${entry.route}`,
+  });
+
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
+  return { ok: true, slug: result.slug, status: result.status };
+}

--- a/apps/web/lib/actions/wiki-edit.ts
+++ b/apps/web/lib/actions/wiki-edit.ts
@@ -55,6 +55,13 @@ export type SaveWikiOverlayEditInput = {
   overridesKernelPageId?: string;
   /** Optional short description of the change for the revision log. */
   changeSummary?: string;
+  /**
+   * Free-form frontmatter merged into the WikiPage.metadata Json column — the
+   * same bag the WSID variant axes and the UX critique-entry fields use. Passed
+   * straight through to the store, which does not validate shape (callers own
+   * that). Omitted = column left untouched on update.
+   */
+  metadata?: Record<string, unknown> | null;
 };
 
 export type SaveWikiOverlayEditResult =
@@ -239,6 +246,7 @@ export async function saveWikiOverlayEdit(
       status: input.status ?? "draft",
       isKernel: false,
       abstract: input.abstract ?? null,
+      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
       kernelPageId: input.overridesKernelPageId ?? null,
       derivedFromKernelVersion: input.overridesKernelPageId
         ? readKernelVersionFromManifest()

--- a/apps/web/lib/ux-critique/critique-entry.test.ts
+++ b/apps/web/lib/ux-critique/critique-entry.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  CRITIQUE_ENTRY_METADATA_KIND,
   awaitingVerdict,
   calibrationSet,
+  critiqueEntryFromWikiPage,
+  critiqueEntryToMetadata,
   isCalibrationEligible,
   routeCoverage,
   splitForCalibration,
@@ -155,5 +158,53 @@ describe("routeCoverage", () => {
     ]);
     expect(coverage.get("/workspace")).toBe(2);
     expect(coverage.has("/finance")).toBe(false);
+  });
+});
+
+describe("metadata round-trip (the storage contract for capture)", () => {
+  it("preserves every field through metadata + page reassembly", () => {
+    const original = entry();
+    const meta = critiqueEntryToMetadata(original);
+    // finding and status live on the page, not in metadata, so they must NOT
+    // be duplicated into the bag (two copies would drift).
+    expect(meta).not.toHaveProperty("finding");
+    expect(meta).not.toHaveProperty("status");
+
+    const restored = critiqueEntryFromWikiPage({
+      body: original.finding,
+      status: original.status,
+      metadata: meta,
+    });
+    expect(restored).toEqual(original);
+  });
+
+  it("carries a schema tag so an unknown payload can be refused", () => {
+    expect(critiqueEntryToMetadata(entry()).metadataKind).toBe(CRITIQUE_ENTRY_METADATA_KIND);
+  });
+
+  it("returns null for a page whose metadata is not a critique entry", () => {
+    expect(
+      critiqueEntryFromWikiPage({ body: "some other craft note", status: "draft", metadata: null }),
+    ).toBeNull();
+    expect(
+      critiqueEntryFromWikiPage({
+        body: "a WSID variant page",
+        status: "published",
+        metadata: { professionCompetencyLevel: "expert" },
+      }),
+    ).toBeNull();
+  });
+
+  it("takes finding and status from the ROW, not the stale metadata", () => {
+    // The page body is the single source of truth for the finding; a later edit
+    // to the body must win over whatever the metadata once held.
+    const meta = critiqueEntryToMetadata(entry({ status: "draft" }));
+    const restored = critiqueEntryFromWikiPage({
+      body: "Edited finding: the lead band now runs to 300 words.",
+      status: "published",
+      metadata: meta,
+    });
+    expect(restored?.finding).toMatch(/Edited finding/);
+    expect(restored?.status).toBe("published");
   });
 });

--- a/apps/web/lib/ux-critique/critique-entry.ts
+++ b/apps/web/lib/ux-critique/critique-entry.ts
@@ -138,6 +138,79 @@ export function validateCritiqueEntry(input: Partial<CritiqueEntry>): CritiqueEn
 }
 
 /**
+ * Schema tag stamped into WikiPage.metadata so a critique-entry overlay page is
+ * distinguishable from any other craft-override page, and so a future reader can
+ * refuse a payload it does not understand rather than mis-parsing one.
+ */
+export const CRITIQUE_ENTRY_METADATA_KIND = "ux-critique-entry.v1";
+
+/**
+ * The structured critique fields, as they live in the WikiPage.metadata Json bag
+ * (the same free-form column the WSID variant axes already use). `finding` and
+ * `status` are NOT carried here — the page body IS the finding and the row
+ * status IS the entry status, so duplicating them into metadata would invite the
+ * two copies to drift. Everything else has no home on the page and lives here.
+ */
+export type CritiqueEntryMetadata = {
+  metadataKind: typeof CRITIQUE_ENTRY_METADATA_KIND;
+  route: string;
+  screenshotRef: string | null;
+  viewportWidth: number | null;
+  colorScheme: "light" | "dark" | null;
+  gitRef: string | null;
+  lenses: CritiqueLens[];
+  verdict: CritiqueVerdict | null;
+  verdictAuthority: VerdictAuthority | null;
+};
+
+/** Project the metadata-resident fields of a validated entry for storage. */
+export function critiqueEntryToMetadata(entry: CritiqueEntry): CritiqueEntryMetadata {
+  return {
+    metadataKind: CRITIQUE_ENTRY_METADATA_KIND,
+    route: entry.route,
+    screenshotRef: entry.screenshotRef,
+    viewportWidth: entry.viewportWidth,
+    colorScheme: entry.colorScheme,
+    gitRef: entry.gitRef,
+    lenses: [...entry.lenses],
+    verdict: entry.verdict,
+    verdictAuthority: entry.verdictAuthority,
+  };
+}
+
+/**
+ * Reassemble a CritiqueEntry from a stored WikiPage row. `finding` and `status`
+ * come from the row (body + status), the rest from the metadata bag. Returns
+ * null when the metadata is absent, the wrong kind, or malformed — a page that
+ * cannot be understood is not silently treated as an empty critique, it is
+ * simply not one.
+ */
+export function critiqueEntryFromWikiPage(page: {
+  body: string;
+  status: string;
+  metadata: unknown;
+}): CritiqueEntry | null {
+  const meta = page.metadata;
+  if (!meta || typeof meta !== "object") return null;
+  const m = meta as Record<string, unknown>;
+  if (m.metadataKind !== CRITIQUE_ENTRY_METADATA_KIND) return null;
+
+  const validated = validateCritiqueEntry({
+    route: typeof m.route === "string" ? m.route : undefined,
+    finding: page.body,
+    screenshotRef: typeof m.screenshotRef === "string" ? m.screenshotRef : null,
+    viewportWidth: typeof m.viewportWidth === "number" ? m.viewportWidth : null,
+    colorScheme: m.colorScheme === "light" || m.colorScheme === "dark" ? m.colorScheme : null,
+    gitRef: typeof m.gitRef === "string" ? m.gitRef : null,
+    lenses: Array.isArray(m.lenses) ? (m.lenses as CritiqueLens[]) : [],
+    verdict: (m.verdict ?? null) as CritiqueVerdict | null,
+    verdictAuthority: (m.verdictAuthority ?? null) as VerdictAuthority | null,
+    status: page.status === "published" ? "published" : "draft",
+  });
+  return validated.ok ? validated.entry : null;
+}
+
+/**
  * The authority contract, mechanically. An entry counts as calibration data only
  * when a human design authority has ruled on a screen someone can look at again.
  *

--- a/docs/professions/ux-design/wiki/design-critique-corpus-method.md
+++ b/docs/professions/ux-design/wiki/design-critique-corpus-method.md
@@ -50,6 +50,8 @@ The corpus is **not a new store**. A critique entry is a craft-override page und
 
 That means an entry inherits revision history, org scoping, and a place in the UI without anything new being built, and it means the corpus is readable by the same tools that read the rest of the profession corpus.
 
+**Capturing one** goes through a single door: the `captureCritiqueEntry` action writes a **draft** craft-override page with the structured fields in metadata. The page *body* is the finding and the row *status* is the entry status — neither is duplicated into the metadata bag, so the two cannot drift. Capture never publishes; publishing is the human's separate act on the existing overlay path. The action enforces the authority boundary at the point of entry: an agent caller may pass a proposed verdict but is refused if it tries to attach a founder or designer one — the rejection names that reason rather than failing as a shape error downstream.
+
 **The authority contract is code, not etiquette.** An entry is calibration-eligible only when all four hold:
 
 1. it is **published**, not a draft — a draft is a proposal whatever it contains;


### PR DESCRIPTION
The corpus module from [#3474](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3474) could hold entries and enforce the calibration contract — but nothing could put an entry in. **This adds the missing door.**

That matters because the founder's UX judgment accruing into this corpus is the input that gates everything downstream: the design judge, and AGT-906's promotion past its curation stage. Until a capture was possible, every review evaporated.

## Rides the existing path, creates no new store

A critique entry is a **draft** craft-override `WikiPage` under `craft/ux-design/<slug>`, structured fields in `WikiPage.metadata` — the same column the WSID variant axes use. Three thin pieces:

1. **Storage projection** (`critique-entry.ts`): `critiqueEntryToMetadata` / `critiqueEntryFromWikiPage`, tagged with a schema kind so a reader refuses an unknown payload rather than mis-parsing it. `finding` and `status` are **not** in the metadata bag — the page body *is* the finding, the row status *is* the status, so the two copies can't drift. Round-trip tested, including that a later body edit wins over stale metadata.

2. **`saveWikiOverlayEdit` forwards metadata** into the store (which already writes `WikiPage.metadata`; only the action layer wasn't passing it through). Its 13 existing tests unchanged.

3. **`captureCritiqueEntry` action.** Every capture lands as a **draft** — publishing is the human's separate act, and eligibility derives from published + founder-verdict regardless. The authority boundary is enforced *at the point of entry*, not merely described: an agent may **propose** a verdict (`agent-proposed`, never eligible) but is refused with a named reason if it tries to **attach** a founder/designer one. A judge calibrated on agent-authored verdicts is calibrated against itself.

## Still zero entries, deliberately

Authoring is the founder's. An agent seeding its own calibration data would violate the contract this door exists to enforce. What's unblocked is that a **real capture is now possible**; a capture UI on the craft surface is the natural next step, tracked on BI-3880DA1D.

## Verification

- **28 tests** across the entry module and capture action, including the agent-attach refusal and the draft-always guarantee
- `wiki-edit` **13/13** unchanged; module-size, doc-index, doc-link gates green
- `tsc` reports no non-`next` error in any changed file

Docs-Impact-Decision: updates docs/professions/ux-design/wiki/design-critique-corpus-method.md with the capture door and the body-vs-metadata source-of-truth rule; doc index regenerated.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)