### PR TITLE
docs: add archetype BI inventory and construction field ops spec

### DIFF
--- a/docs/superpowers/plans/2026-07-24-portfolio-archetype-bi-inventory.md
+++ b/docs/superpowers/plans/2026-07-24-portfolio-archetype-bi-inventory.md
@@ -1,0 +1,137 @@
+# Portfolio Archetype BI Inventory And Cross-Archetype Investment Plan
+
+> **For agentic workers:** This is a planning and BI-governance document, not an implementation checklist. Use the live backlog as source of truth before executing any item.
+
+**Goal:** Ensure every archetype category has enough scoped BI inventory to see investment needed by category and collectively, then identify reusable bets with the largest cross-archetype return.
+
+**Date:** 2026-07-24
+**Branch:** `doc/archetype-bi-inventory`
+**Primary docs:** `docs/architecture/backlog-archetype-scope.md`, `docs/architecture/archetype-business-value-streams.md`
+
+## Current State
+
+The live backlog now has explicit scope metadata for archetype planning. Most categories have a mature vertical-readiness scaffold:
+
+- Keystone readiness pack and acceptance tests.
+- Vertical request lifecycle.
+- Resource and capacity model.
+- Master-data context.
+- Employee-facing owner cockpit.
+- Integration and replacement-boundary map.
+- Finance and billing-readiness model.
+- Marketing proof and retention workflow.
+- Proactive coworker actions.
+- Occupation homes and role-specific coworker roster.
+- Top-10 gap acceptance fixture and market-proof test pack.
+
+The scaffolds are useful. They are not yet sufficient by themselves because many long-tail needs repeat across multiple archetypes but require vocabulary and compliance variants. The new planning layer should therefore use three categories of investment:
+
+| Investment class | Meaning | Example |
+|---|---|---|
+| Common substrate | Used across most businesses | Payroll, IAM, finance, workforce, document management |
+| Multi-archetype substrate | Used by a named cluster of categories | Field Ops for mobile/site/route work |
+| Category/leaf projection | Specific vertical vocabulary, rules, and acceptance fixtures | Construction certified payroll, fabric-care claim ticket, restaurant food-safety packet |
+
+## Category Coverage Snapshot
+
+| Category | Leaf count | Current BI inventory status | New action in this pass |
+|---|---:|---|---|
+| `asset-rental` | 3 | 10-item readiness scaffold | Cross-referenced to Field Ops where delivery/return/assets apply |
+| `automotive-services` | 6 | 10-item readiness scaffold | Cross-referenced to Field Ops mobile/service variants |
+| `banking-financial-services` | 3 | 10-item BIAN readiness scaffold | No new BI; category is less field-ops dependent |
+| `beauty-personal-care` | 6 | 10-item readiness scaffold | No new BI; mobile beauty can later reuse Field Ops if prioritized |
+| `education-training` | 4 | 10-item readiness scaffold | No new BI |
+| `fabric-care-services` | 3 | Deep leaf pack for dry-cleaning plant network | Cross-referenced to Field Ops route/evidence where applicable |
+| `fitness-recreation` | 3 | 10-item readiness scaffold | No new BI |
+| `food-hospitality` | 3 | 10-item scaffold plus restaurant-specific UX/compliance BIs | Cross-referenced to Field Ops for catering/delivery and evidence packets |
+| `healthcare-wellness` | 9 | 10-item readiness scaffold | Cross-referenced to Field Ops home-health/mobile-care credential and visit evidence |
+| `hoa-property-management` | 3 | 10-item readiness scaffold | No new BI; vendor/site work can later map to Field Ops |
+| `live-events-venues` | 3 | 10-item readiness scaffold | Cross-referenced to Field Ops event-production/site-readiness variants |
+| `media-production` | 3 | 10-item readiness scaffold | Cross-referenced to Field Ops crew/location/gear variants |
+| `moving-and-logistics` | 5 | 10-item readiness scaffold | Cross-referenced to Field Ops route/crew/truck/proof variants |
+| `nonprofit-community` | 8 | 10-item readiness scaffold | No new BI |
+| `pet-services` | 5 | 10-item readiness scaffold | Cross-referenced to Field Ops mobile pet/vet variants |
+| `professional-services` | 8 | 10-item scaffold plus IT-MSP leaf pack | Field inspection and land surveying mapped to Field Ops |
+| `public-sector` | 3 | 10-item readiness scaffold | Cross-referenced to Field Ops public works/inspection evidence |
+| `real-estate-construction` | 2 | 10-item residential builder scaffold | Added 8 construction field-ops BIs |
+| `retail-goods` | 5 | 10-item readiness scaffold | Cross-referenced to Field Ops delivery/install evidence |
+| `security-services` | 2 | 10-item readiness scaffold | Cross-referenced to Field Ops guard patrol/post/incident variants |
+| `software-platform` | 1 | 10-item readiness scaffold | No new BI |
+| `trades-maintenance` | 11 | 10-item scaffold plus field-service dispatch epic | Retagged field-service dispatch as multi-archetype substrate |
+| `warehousing-fulfilment` | 4 | Missing category readiness epic before this pass | Added `EP-VERTICAL-WAREHOUSING` and 10 scoped BIs |
+
+## Live BI Changes Made
+
+New multi-archetype epic:
+
+- `EP-FIELD-OPS-SUBSTRATE` - Field Operations Substrate: presence, credentials, dispatch, assets, daily log, and evidence packets across mobile work archetypes.
+
+New multi-archetype BIs:
+
+- `BI-FIELDOPS-001` - Expected presence for people, assets, external parties, and site/route commitments.
+- `BI-FIELDOPS-002` - Credential, training, license, and task-eligibility evidence engine.
+- `BI-FIELDOPS-003` - Mobile daily log and field evidence capture.
+- `BI-FIELDOPS-004` - Evidence packet generator for payroll, billing, compliance, claims, and disputes.
+- `BI-FIELDOPS-005` - Operations manager console pattern for sites, routes, crews, assets, exceptions, and cost leakage.
+
+Construction BIs added under `EP-VERTICAL-CONSTRUCTION`:
+
+- `BI-CON-FIELD-001` - Jobsite readiness model.
+- `BI-CON-FIELD-002` - Jobsite presence, time clock, cost-code, and payroll evidence capture.
+- `BI-CON-FIELD-003` - Safety, OSHA training, PPE, toolbox talk, incident, and site eligibility evidence workflow.
+- `BI-CON-FIELD-004` - Crew, truck, equipment, tool, and material assignment.
+- `BI-CON-FIELD-005` - Subcontractor and supplier coordination cockpit.
+- `BI-CON-FIELD-006` - Foreman daily log and photo/file evidence capture.
+- `BI-CON-FIELD-007` - Cost leakage and change-order candidate detector.
+- `BI-CON-FIELD-008` - Public-work certified payroll and compliance readiness.
+
+Warehousing/fulfilment BIs added:
+
+- `EP-VERTICAL-WAREHOUSING` - Industry Vertical Readiness - Warehousing and fulfilment.
+- `BI-WH-READY-001` through `BI-WH-READY-010` - Keystone, lifecycle, capacity, master data, cockpit, integration map, finance/billing, proactive actions, marketing proof, and occupation/coworker roster.
+
+Existing items retagged as reusable:
+
+- `EP-TRADES-FIELD-SERVICE` - metadata broadened to `multi-archetype`.
+- `BI-69A992A4` - FieldDispatchProfile retagged as reusable dispatch substrate.
+- `BI-FS-004` - Dispatcher coworker seed retagged as reusable field-operations coworker pattern.
+- `BI-FS-007` - Running-late cascade retagged as reusable commitment-management action.
+- `EP-E2866100` and `BI-5FE4FA8A` - truck inventory retagged as multi-archetype field/site/route asset-assignment work.
+- `BI-72617848` - merged into `BI-WH-READY-001` after the warehousing readiness lane was created.
+
+## Biggest Bang For Buck
+
+Ranked investments by cross-archetype reach:
+
+| Rank | Investment | Why it matters | Archetype reach |
+|---:|---|---|---|
+| 1 | `BI-FIELDOPS-001` Expected Presence | Most field chaos starts when expected people/assets/external parties are not represented as commitments | Construction, trades, logistics, healthcare mobile, pet mobile, auto mobile, security, events, media, public works, warehousing, rentals, catering, retail delivery/install, fabric-care routes |
+| 2 | `BI-FIELDOPS-004` Evidence Packet Generator | Converts operational records into billing, payroll, compliance, dispute, and claim packets | All regulated, mobile, delivery, rental, service, construction, and route-heavy categories |
+| 3 | `BI-FIELDOPS-002` Credential Eligibility | Prevents unqualified work and enables compliance-aware routing | Construction, healthcare, public sector, security, food, mobile services, professional field inspection/survey |
+| 4 | `BI-FIELDOPS-003` Daily Log/Evidence Capture | Creates the raw evidence stream for proof, payroll, billing, quality, and dispute flows | Construction, service, logistics, security, events, healthcare visits, warehouse shifts, rentals |
+| 5 | Truck/asset assignment (`EP-E2866100`, `BI-5FE4FA8A`, `BI-FIELDOPS-001`) | Company-owned mobile assets are expensive, scarce, and operationally invisible without assignment and reconciliation | Construction, trades, moving/logistics, auto mobile, security, rental, warehousing, fabric-care routes |
+| 6 | `BI-FIELDOPS-005` Manager Console Pattern | Avoids one-off dashboards while giving owners the scan view they actually need | Site/route/crew/asset-heavy categories |
+| 7 | Existing field-dispatch BIs (`EP-TRADES-FIELD-SERVICE`) | Dispatch, ETA, late cascade, and customer notification reuse well beyond trades | Mobile service categories and public works |
+
+## Remaining Portfolio Gaps
+
+The inventory is now satisfactory for budgeting, but not complete implementation scope. Next refinement should target:
+
+- Leaf-specific compliance variants for high-risk leaves: `home-health-care`, `mobile-phlebotomy`, `guard-patrol`, `restaurant`, `municipal-utility`, `law-enforcement-agency`, `community-bank`, and `credit-union`.
+- Leaf-specific acceptance fixtures where generic category fixtures hide material differences: `freight-brokerage`, `cold-chain-storage`, `cross-dock-transload`, `field-inspection`, `land-surveying`, `mobile-vet`, `production-equipment-rental`, and `custom-home-builder`.
+- Common-substrate crosswalks from Field Ops into People/HCM, Payroll, Finance, Procurement/Suppliers, IAM/AuthZ, Document Management, Licensing/Permits, and Planning/Analytics.
+- UI architecture for a reusable operations manager console based on report-kit primitives and archetype vocabulary, not one dashboard per category.
+
+## Execution Plan
+
+- [ ] Implement `BI-FIELDOPS-001` first as the shared commitment/presence spine.
+- [ ] Implement or align truck inventory (`BI-5FE4FA8A`) with the presence/asset assignment spine.
+- [ ] Implement `BI-FIELDOPS-003` for daily log/evidence capture with construction foreman and warehouse supervisor as the first two projections.
+- [ ] Implement `BI-FIELDOPS-004` evidence packets after daily-log capture emits stable source records.
+- [ ] Implement construction `BI-CON-FIELD-002`, `BI-CON-FIELD-006`, and `BI-CON-FIELD-007` as the first construction value slice.
+- [ ] Implement warehousing `BI-WH-READY-002` and `BI-WH-READY-005` after Field Ops commitment/presence is stable.
+- [ ] Run an archetype acceptance fixture sweep and update each category's keystone BI with leaf-specific fixture requirements.
+
+## Design Grounding Decision
+
+Design-Grounding-Decision: reviewed `docs/architecture/backlog-archetype-scope.md`, `docs/architecture/archetype-business-value-streams.md`, `docs/superpowers/plans/2026-07-24-backlog-archetype-scope-metadata.md`, `packages/storefront-templates/src/archetypes/*`, live `query_backlog` results for all archetype categories, `EP-TRADES-FIELD-SERVICE`, and `EP-E2866100`. Decision: create one multi-archetype Field Ops substrate and category projections for construction and warehousing rather than adding isolated feature items to each vertical scaffold.

--- a/docs/superpowers/specs/2026-07-24-construction-field-operations-archetype-design.md
+++ b/docs/superpowers/specs/2026-07-24-construction-field-operations-archetype-design.md
@@ -1,0 +1,139 @@
+# Construction Field Operations Archetype Design
+
+**Status:** Proposed - BI inventory filed 2026-07-24
+**Owner surface:** Real estate and construction vertical readiness
+**Primary epic:** `EP-VERTICAL-CONSTRUCTION`
+**Reusable substrate epic:** `EP-FIELD-OPS-SUBSTRATE`
+
+## Purpose
+
+DPF's real-estate/construction backlog already covered residential builder flows: model-home tours, design consultations, selections, deposits, draws, change orders, and warranty queues. A construction-company operating pass showed a second load-bearing mode: active jobsite execution.
+
+The jobsite mode is more chaotic and more expensive when coordination fails. A construction operator must know who is expected onsite, whether they are allowed to perform the work, which trucks/equipment/materials are committed, whether suppliers and subcontractors are on track, what work actually happened today, and whether field evidence supports payroll, billing, compliance, or change-order decisions.
+
+This spec extends the archetype without creating construction-only primitives where the same capability applies across other field-heavy archetypes.
+
+## Design Grounding
+
+Existing specs/plans reviewed:
+
+- `docs/architecture/backlog-archetype-scope.md`
+- `docs/architecture/archetype-business-value-streams.md`
+- `docs/superpowers/plans/2026-07-24-backlog-archetype-scope-metadata.md`
+- `docs/superpowers/specs/2026-05-11-licensing-permit-jurisdiction-readiness-design.md`
+- `docs/superpowers/specs/2026-05-29-vehicle-equipment-rental-archetype-design.md`
+- `docs/superpowers/research/2026-06-13-field-dispatch-archetype-gap-analysis.md`
+- `packages/storefront-templates/src/archetypes/real-estate-construction.ts`
+- Live DPF backlog via `query_backlog(archetypeCategory="real-estate-construction")`
+
+Current source-of-truth decisions:
+
+- `StorefrontConfig.archetypeId` remains the portal industry source of truth.
+- `Epic` and `BacklogItem` scope metadata are the planning source of truth for platform/common/category/leaf/multi-archetype investment analysis.
+- `EP-FIELD-OPS-SUBSTRATE` owns reusable presence, credential, dispatch, asset-assignment, daily-log, and evidence-packet primitives.
+- `EP-VERTICAL-CONSTRUCTION` owns construction-specific projections, vocabulary, acceptance fixtures, and compliance variants.
+
+## Research And Benchmarking
+
+Regulatory and operational source themes reviewed during the construction pass:
+
+- OSHA construction standards and construction-specific training/evidence expectations, including fall protection, excavation, confined spaces, hazard communication, severe injury reporting, recordkeeping, PPE fit, and the multi-employer jobsite doctrine.
+- DOL/FLSA construction wage and recordkeeping guidance, including hourly time capture, payroll evidence, and worker classification concerns.
+- DOL/IRS independent-contractor classification context for employees vs contingent workers.
+- Davis-Bacon/certified payroll readiness for public-work applicability, including payroll evidence and WH-347-style reporting needs.
+- FMCSA hours-of-service relevance where company trucks and covered drivers enter regulated motor-carrier operations.
+- Commercial construction field-management patterns from Procore/Raken-style daily logs, time cards, photos, RFIs, submittals, supplier/subcontractor coordination, and change-order workflows.
+
+Adopted patterns:
+
+- Treat field evidence as reusable substrate, not as a construction-only attachment pile.
+- Separate employee time/payroll evidence from subcontractor/vendor proof-of-presence.
+- Keep public-work/certified-payroll logic behind applicability gates so private residential jobs are not burdened.
+- Make AI-generated claims, change orders, backcharges, or compliance attestations reviewable drafts with cited evidence.
+
+Rejected patterns:
+
+- A standalone construction credential table.
+- A jobsite dashboard that only reads manually typed statuses instead of expected-vs-actual commitments.
+- A generic "notes" field for OSHA, payroll, incident, or change-order evidence.
+- Rebuilding truck inventory separate from the existing truck inventory BI and Field Ops asset-assignment substrate.
+
+## Operating Model
+
+Construction field operations revolve around six repeating questions:
+
+1. What should be true at this jobsite today?
+2. Who and what actually showed up?
+3. Is every person, subcontractor, truck, tool, material, and supplier commitment eligible and ready?
+4. What changed, blocked, slipped, or created extra cost?
+5. What evidence proves the work, incident, delay, delivery, or cost exposure?
+6. Which payroll, billing, change-order, compliance, warranty, or dispute packet should be reviewed?
+
+DPF should model these as a projection over shared Field Ops capabilities:
+
+| Layer | Reusable substrate | Construction projection |
+|---|---|---|
+| Expected presence | `BI-FIELDOPS-001` | Jobsite/project/phase/crew/truck/subcontractor/supplier commitments |
+| Eligibility | `BI-FIELDOPS-002` | OSHA/safety training, PPE, toolbox talks, subcontractor compliance, task/site eligibility |
+| Daily work record | `BI-FIELDOPS-003` | Foreman daily log with manpower, subcontractors, weather, materials, equipment, photos, incidents |
+| Evidence packet | `BI-FIELDOPS-004` | Payroll, certified payroll, billing, change-order, backcharge, warranty, incident, dispute packets |
+| Manager console | `BI-FIELDOPS-005` | PM/foreman console for schedule risk, cost leakage, exceptions, and evidence completeness |
+
+## Live BI Inventory
+
+Reusable BIs filed under `EP-FIELD-OPS-SUBSTRATE`:
+
+- `BI-FIELDOPS-001` - Expected presence for people, assets, external parties, and site/route commitments.
+- `BI-FIELDOPS-002` - Credential, training, license, and task-eligibility evidence engine.
+- `BI-FIELDOPS-003` - Mobile daily log and field evidence capture.
+- `BI-FIELDOPS-004` - Evidence packet generator for payroll, billing, compliance, claims, and disputes.
+- `BI-FIELDOPS-005` - Operations manager console pattern for sites, routes, crews, assets, exceptions, and cost leakage.
+
+Construction-specific BIs filed under `EP-VERTICAL-CONSTRUCTION`:
+
+- `BI-CON-FIELD-001` - Jobsite readiness model for project, phase, crew, truck, equipment, supplier, subcontractor, and inspection state.
+- `BI-CON-FIELD-002` - Jobsite presence, time clock, cost-code, and payroll evidence capture.
+- `BI-CON-FIELD-003` - Safety, OSHA training, PPE, toolbox talk, incident, and site eligibility evidence workflow.
+- `BI-CON-FIELD-004` - Crew, truck, equipment, tool, and material assignment against schedule and job phase.
+- `BI-CON-FIELD-005` - Subcontractor and supplier coordination cockpit.
+- `BI-CON-FIELD-006` - Foreman daily log and photo/file evidence capture.
+- `BI-CON-FIELD-007` - Cost leakage and change-order candidate detector.
+- `BI-CON-FIELD-008` - Public-work certified payroll and compliance readiness.
+
+Existing BIs cross-referenced:
+
+- `EP-TRADES-FIELD-SERVICE` was retagged as multi-archetype because field-dispatch primitives apply beyond trades.
+- `BI-69A992A4` was retagged as reusable FieldDispatchProfile substrate.
+- `EP-E2866100` and `BI-5FE4FA8A` were retagged as multi-archetype truck inventory/asset-assignment substrate.
+
+## Acceptance Direction
+
+The construction projection is satisfactory when:
+
+- A PM or foreman can see today's expected jobsite commitments by project/phase/site area.
+- Hourly employees can clock in/out against project and cost-code contexts while salary workers and subcontractors can still be represented correctly.
+- Contingent worker/subcontractor presence does not accidentally become employee payroll evidence.
+- OSHA/safety/training/PPE/toolbox/incident records are structured enough to form evidence packets.
+- Trucks, tools, equipment, and material deliveries reconcile against expected work.
+- Supplier/subcontractor misses create visible schedule-risk and backcharge/change-order candidates.
+- Daily logs can be completed from a field-mobile posture and reviewed from an owner/PM posture.
+- Public-work/certified-payroll evidence is generated only when the job's applicability gate requires it.
+- AI coworkers draft claims, billing packets, compliance packets, and change-order candidates with citations, never silent submission.
+
+## Refactoring Notes
+
+This pass deliberately spent architecture effort on reuse:
+
+- Field operations is a shared substrate, not another construction-only module.
+- Truck inventory and field dispatch were retagged instead of duplicated.
+- Credential evidence should extend People/HCM, licensing/permit readiness, and document evidence surfaces.
+- Evidence packets should compose existing finance/payroll/compliance records, not invent a new generic blob.
+- The manager console should reuse report-kit/table/status components when implemented.
+
+## Open Implementation Questions
+
+- Which existing work item, inventory, workforce, payroll, and document models should own each field-operation datum?
+- Should jobsite areas/phases be represented as generic `Site/Location/Zone` primitives or construction-specific project phases with adapters?
+- What is the smallest mobile/offline capture slice that proves foreman adoption?
+- Which evidence packets belong in common Field Ops and which remain construction-only variants?
+- How should certified payroll applicability be inferred or confirmed without asking non-technical users legal questions?


### PR DESCRIPTION
## What changed

Added two planning docs:

- `docs/superpowers/specs/2026-07-24-construction-field-operations-archetype-design.md`
- `docs/superpowers/plans/2026-07-24-portfolio-archetype-bi-inventory.md`

The docs capture the construction jobsite/field-operations pass, the live BI updates made for construction, the new reusable Field Ops substrate, the warehousing readiness gap closure, and the portfolio-wide archetype investment map.

## Live backlog updates completed

- Created `EP-FIELD-OPS-SUBSTRATE` plus `BI-FIELDOPS-001` through `BI-FIELDOPS-005`.
- Added construction field-ops items `BI-CON-FIELD-001` through `BI-CON-FIELD-008` under `EP-VERTICAL-CONSTRUCTION`.
- Created `EP-VERTICAL-WAREHOUSING` plus `BI-WH-READY-001` through `BI-WH-READY-010`.
- Merged old warehousing gap `BI-72617848` into `BI-WH-READY-001`.
- Retagged `EP-TRADES-FIELD-SERVICE`, `EP-E2866100`, `BI-5FE4FA8A`, `BI-69A992A4`, `BI-FS-004`, and `BI-FS-007` as reusable multi-archetype field/site/route work where appropriate.
- Linked `EP-VERTICAL-CONSTRUCTION`, `EP-FIELD-OPS-SUBSTRATE`, and `EP-VERTICAL-WAREHOUSING` to these docs.

## Design grounding

Reviewed:

- `docs/architecture/backlog-archetype-scope.md`
- `docs/architecture/archetype-business-value-streams.md`
- `docs/superpowers/plans/2026-07-24-backlog-archetype-scope-metadata.md`
- `packages/storefront-templates/src/archetypes/*`
- live `query_backlog` results for all archetype categories
- `EP-TRADES-FIELD-SERVICE` and `EP-E2866100`

Decision: create a reusable multi-archetype Field Ops substrate and category projections for construction and warehousing instead of adding isolated one-off BIs to each vertical scaffold.

## Validation

- `pnpm --silent check:doc-links` passed on the worktree.
- `git diff --cached --check` passed before commit.
- Pre-commit gitleaks scan passed.

Docs-Impact-Decision: docs-only planning/spec PR; no user-facing route behavior changed.
Design-Grounding-Decision: see the Design grounding section above.