### PR TITLE
feat(ux): prose lint ratchet for UI copy, vocabulary, decision labels, readability (BI-88D8C725)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,34 @@ jobs:
       - name: Run guard
         run: node scripts/check-bundle-boundaries.mjs
 
+  prose-lint-guard:
+    name: Prose Lint Guard
+    runs-on: ubuntu-latest
+    needs: changes
+    # BI-88D8C725 (EP-UX-SYSTEM §6 L4 / §8.1 D6). Fast in-loop signal for UI
+    # copy — archetype vocabulary conformance, banned generic decision labels
+    # (owner-first/ux-audit.ts, applied at source), the readability tier
+    # (lib/readability/'s Flesch-Kincaid policy, now wired in), and sentence
+    # length / text-mass heuristics. Same ratchet contract as the Style Drift
+    # Guard below: scripts/prose-lint-baseline.json may shrink but never grow.
+    # This complements, and does not replace, the rendered UX sweep (still the
+    # binding measurement) — Vale-shaped, answers in seconds inside the build
+    # loop. Needs the full workspace install (imports @dpf/validators + the
+    # apps/web vocabulary/ux-audit modules directly — the whole point is to
+    # reuse those signals, not reimplement them), unlike the zero-dependency
+    # guards below, so it is gated on `heavy` like Typecheck.
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup pnpm with cache
+        if: needs.changes.outputs.heavy == 'true'
+        uses: ./.github/actions/setup-pnpm
+      - name: Prose lint guard unit tests
+        if: needs.changes.outputs.heavy == 'true'
+        run: pnpm run check:prose-lint:test
+      - name: Run guard
+        if: needs.changes.outputs.heavy == 'true'
+        run: pnpm run check:prose-lint
+
   style-drift-guard:
     name: Style Drift Guard
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "audit:stale-overrides": "node scripts/audit-stale-overrides.mjs",
     "regen:lockfile": "node scripts/regen-lockfile.mjs",
     "check:reporting-composition": "node scripts/check-reporting-composition.mjs",
+    "check:prose-lint": "tsx scripts/check-prose-lint.ts",
+    "check:prose-lint:test": "tsx --test scripts/check-prose-lint.test.ts",
     "check:n1-caller-honesty": "node scripts/check-n-minus-one-caller-honesty.mjs",
     "check:module-size": "node scripts/check-module-size.mjs",
     "check:data-impact": "node scripts/check-data-impact.mjs",

--- a/scripts/check-prose-lint.test.ts
+++ b/scripts/check-prose-lint.test.ts
@@ -1,0 +1,137 @@
+/**
+ * BI-88D8C725 — tests for the prose-lint guard's four rule families.
+ *
+ * Same convention as check-style-drift.test.mjs (node:test, pure functions
+ * imported directly, no fixture files on disk): a "known-bad" source snippet
+ * that trips each rule, and a "known-good" one that doesn't.
+ *
+ * Run: tsx --test scripts/check-prose-lint.test.ts
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  analyzeFile,
+  buildArchetypeTerms,
+  compareProse,
+  countVocabularyDrift,
+  extractCopySnippets,
+  PROSE_AXES,
+} from "./check-prose-lint";
+
+// ─── Rule 1: archetype vocabulary conformance ───────────────────────────────
+
+test("archetype terms are pulled from getVocabulary(), not reinvented, and exclude the neutral default", () => {
+  const terms = buildArchetypeTerms().map((t) => t.term);
+  assert.ok(terms.includes("Guests"), "food-hospitality stakeholderLabel should be present");
+  assert.ok(terms.includes("Venue Portal"), "food-hospitality portalLabel should be present");
+  assert.ok(terms.includes("Patient Portal"), "healthcare-wellness portalLabel should be present");
+  // The neutral default ("Contacts" / "Portal") is not archetype-specific —
+  // it must not appear as a flaggable term.
+  assert.ok(!terms.includes("Contacts"));
+  assert.ok(!terms.includes("Portal"));
+});
+
+test("a hardcoded archetype term outside the vocabulary system is flagged (known-bad)", () => {
+  const badCopy = ["Welcome back — here's what your Guests booked this week."];
+  assert.equal(countVocabularyDrift(badCopy), 1);
+});
+
+test("copy that carries no archetype-specific noun is clean (known-good)", () => {
+  const goodCopy = ["Welcome back — here's what your customers booked this week."];
+  assert.equal(countVocabularyDrift(goodCopy), 0);
+});
+
+// ─── Rule 2: banned generic decision labels, applied at source ─────────────
+
+test("a generic decision label in JSX text is caught at source (known-bad)", () => {
+  const badSource = `export function Panel() {
+    return <button>Make this business decision?</button>;
+  }`;
+  assert.equal(analyzeFile("apps/web/components/Panel.tsx", badSource).genericLabels, 1);
+});
+
+test("a specific, owner-first decision label passes (known-good)", () => {
+  const goodSource = `export function Panel() {
+    return <button>Approve the $420 catering invoice?</button>;
+  }`;
+  assert.equal(analyzeFile("apps/web/components/Panel.tsx", goodSource).genericLabels, 0);
+});
+
+// ─── Rule 3: readability tier (wires the previously-unwired FK policy) ─────
+
+test("marketing copy above the high-school Flesch-Kincaid grade is flagged (known-bad)", () => {
+  const badSource = `export function Hero() {
+    return <p title="Leveraging our omnichannel infrastructure substantially optimizes stakeholder-facing conversion throughput across heterogeneous acquisition funnels.">x</p>;
+  }`;
+  const axes = analyzeFile("apps/web/app/(shell)/marketing/hero.tsx", badSource);
+  assert.ok(axes.readability >= 1, "long, jargon-dense sentence should exceed the high-school grade cap");
+});
+
+test("plain-language marketing copy at a high-school reading level passes (known-good)", () => {
+  const goodSource = `export function Hero() {
+    return <p title="We help you book more guests with less work.">x</p>;
+  }`;
+  const axes = analyzeFile("apps/web/app/(shell)/marketing/hero.tsx", goodSource);
+  assert.equal(axes.readability, 0);
+});
+
+test("readability is only scored on marketing/storefront paths, not internal surfaces", () => {
+  const badSource = `export function Hero() {
+    return <p title="Leveraging our omnichannel infrastructure substantially optimizes stakeholder-facing conversion throughput across heterogeneous acquisition funnels.">x</p>;
+  }`;
+  const axes = analyzeFile("apps/web/app/(shell)/admin/internal.tsx", badSource);
+  assert.equal(axes.readability, 0);
+});
+
+// ─── Rule 4: sentence length / text mass ────────────────────────────────────
+
+test("a sentence over 25 words is flagged as long (known-bad)", () => {
+  const badCopy = [
+    "This is a very long sentence that keeps going and going and going without ever stopping to give the reader a single moment of rest or clarity at all.",
+  ];
+  const axes = analyzeFile("apps/web/components/x.tsx", `<p>${badCopy[0]}</p>`);
+  assert.equal(axes.longSentences, 1);
+});
+
+test("a short, plain sentence is not flagged (known-good)", () => {
+  const axes = analyzeFile("apps/web/components/x.tsx", "<p>Check your inbox for new messages.</p>");
+  assert.equal(axes.longSentences, 0);
+});
+
+test("extractCopySnippets ignores className-shaped tokens and JSX expressions", () => {
+  const src = `<div className="flex items-center gap-dpf-md">{count}</div>`;
+  assert.deepEqual(extractCopySnippets(src), []);
+});
+
+// ─── Ratchet shape (mirrors check-style-drift.mjs's compareTokens contract) ─
+
+test("compareProse only fails on a NEW file or a GROWN axis, never on a stable baseline count", () => {
+  const counts = { "a.tsx": { vocabulary: 2, genericLabels: 0, readability: 0, longSentences: 0, textMass: 40 } };
+  const baseline = { "a.tsx": { vocabulary: 2, genericLabels: 0, readability: 0, longSentences: 0, textMass: 40 } };
+  const result = compareProse(counts, baseline);
+  assert.deepEqual(result, { newFiles: [], increased: [] });
+});
+
+test("compareProse flags a file whose axis count grew past its baseline", () => {
+  const counts = { "a.tsx": { vocabulary: 3, genericLabels: 0, readability: 0, longSentences: 0, textMass: 40 } };
+  const baseline = { "a.tsx": { vocabulary: 2, genericLabels: 0, readability: 0, longSentences: 0, textMass: 40 } };
+  const result = compareProse(counts, baseline);
+  assert.equal(result.newFiles.length, 0);
+  assert.equal(result.increased.length, 1);
+  assert.match(result.increased[0], /vocabulary 2 -> 3/);
+});
+
+test("compareProse flags a file with a signal that has no baseline entry at all", () => {
+  const counts = { "new.tsx": { vocabulary: 0, genericLabels: 1, readability: 0, longSentences: 0, textMass: 5 } };
+  const result = compareProse(counts, {});
+  assert.equal(result.newFiles.length, 1);
+  assert.equal(result.increased.length, 0);
+});
+
+test("every declared axis is covered by PROSE_AXES", () => {
+  assert.deepEqual(
+    [...PROSE_AXES].sort(),
+    ["genericLabels", "longSentences", "readability", "textMass", "vocabulary"],
+  );
+});

--- a/scripts/check-prose-lint.ts
+++ b/scripts/check-prose-lint.ts
@@ -1,0 +1,326 @@
+#!/usr/bin/env tsx
+// Prose lint guard — BI-88D8C725 (EP-UX-SYSTEM §6 L4 / §8.1 D6).
+//
+// The BI asked for Vale (vale.sh) with a DPF rule pack over UI copy. Vale's
+// rule engine is YAML + Tengo scripts — it cannot import a TypeScript
+// function, only reimplement its logic in a different language. Three of the
+// four rules below are explicitly required to REUSE existing runtime
+// signals (resolveVocabularyKey's terms, countGenericDecisionLabels,
+// the lib/readability/ Flesch-Kincaid policy) rather than reinvent them, and
+// reimplementing them in Tengo would fork the logic and let lint-time and
+// runtime drift apart. So this ships as the check-style-drift.mjs-shaped
+// Node/TS ratchet the BI names as the fallback, with the rationale being
+// "no Tengo access to real TS reuse" rather than "no network for the
+// binary" (network to both github.com and registry.npmjs.org was reachable
+// when this was built). See the PR description for the full tradeoff.
+//
+// Rules encoded (all operate on UI copy extracted from source, not rendered
+// HTML — L4 answers before a PR opens, the rendered sweep stays binding):
+//   1. vocabulary    — a hardcoded archetype-specific stakeholder/portal term
+//                       (the exact strings getVocabulary()/resolveVocabularyKey
+//                       resolve to) appearing in a generic surface instead of
+//                       being resolved through the vocabulary system.
+//   2. genericLabels — countGenericDecisionLabels (owner-first/ux-audit.ts),
+//                       reused unmodified, applied directly to source text
+//                       instead of rendered HTML.
+//   3. readability   — lib/readability/'s Flesch-Kincaid grade, reused
+//                       unmodified, wired (it was built but unwired) against
+//                       marketing/storefront copy strings.
+//   4. longSentences / textMass — sentence-length and per-file prose-mass
+//                       heuristics; nothing upstream penalizes text mass
+//                       (the motivating gap named in the BI body).
+//
+// Same ratchet contract as check-style-drift.mjs: a per-file, per-axis
+// baseline that may shrink but never grow. Pre-existing violations are not
+// failed; a PR that adds a NEW violating file, or grows an axis beyond its
+// baseline count, fails.
+//
+//   tsx scripts/check-prose-lint.ts            # check (CI)
+//   tsx scripts/check-prose-lint.ts --update   # regenerate the baseline
+
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join, relative } from "node:path";
+
+import { getVocabulary } from "../apps/web/lib/storefront/archetype-vocabulary";
+import { INDUSTRY_SLUGS } from "../apps/web/lib/storefront/industries";
+import { countGenericDecisionLabels } from "../apps/web/lib/owner-first/ux-audit";
+import {
+  analyzeReadability,
+  withinReadingLevel,
+} from "../packages/validators/src/readability";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const WEB = join(REPO_ROOT, "apps", "web");
+const SCAN_DIRS = ["app", "components"].map((d) => join(WEB, d));
+const BASELINE_PATH = join(REPO_ROOT, "scripts", "prose-lint-baseline.json");
+
+// ─── Rule 1: archetype vocabulary conformance ───────────────────────────────
+//
+// Reuses getVocabulary() (the function resolveVocabularyKey's result feeds
+// into) rather than re-listing terms: for every known industry slug, pull its
+// stakeholder/portal labels and keep only the ones that differ from the
+// neutral default (getVocabulary(null) — DEFAULT_VOCABULARY is not exported,
+// so this reads it the same way call sites do: an unresolved category).
+// A UI-copy string outside the vocabulary system that hardcodes one of these
+// (e.g. "Guests", "Patient Portal") should instead resolve it via
+// getVocabulary(resolveVocabularyKey(...)) so the surface adapts per archetype.
+export function buildArchetypeTerms(): Array<{ term: string; category: string }> {
+  const neutral = getVocabulary(null);
+  const seen = new Map<string, string>();
+  for (const slug of INDUSTRY_SLUGS) {
+    const vocab = getVocabulary(slug);
+    for (const field of ["stakeholderLabel", "portalLabel"] as const) {
+      const term = vocab[field];
+      if (!term || term === neutral[field]) continue;
+      if (!seen.has(term)) seen.set(term, slug);
+    }
+  }
+  return [...seen.entries()].map(([term, category]) => ({ term, category }));
+}
+
+const ARCHETYPE_TERMS = buildArchetypeTerms();
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Count hardcoded archetype-vocabulary terms across a set of copy snippets. */
+export function countVocabularyDrift(snippets: string[]): number {
+  if (snippets.length === 0) return 0;
+  const joined = snippets.join("\n");
+  let count = 0;
+  for (const { term } of ARCHETYPE_TERMS) {
+    const re = new RegExp(`\\b${escapeRegExp(term)}\\b`, "g");
+    count += (joined.match(re) || []).length;
+  }
+  return count;
+}
+
+// ─── Copy extraction ─────────────────────────────────────────────────────────
+//
+// Not a full JSX/AST parse (check-style-drift.mjs sets that precedent — a
+// regex pass over source text is the established complexity budget for these
+// guards). Two shapes cover almost all DPF UI copy: JSX text nodes, and
+// quoted values assigned to copy-bearing props/keys.
+const JSX_TEXT_RE = />\s*([^<>{}\n][^<>{}]*?)\s*</g;
+const ATTR_COPY_RE =
+  /\b(?:label|title|placeholder|alt|aria-label|description|heading|subheading|subtitle|helperText|helpText|summary|message|tooltip)\s*[:=]\s*(["'`])((?:(?!\1)[^\\]|\\.)*)\1/g;
+
+function looksLikeCopy(s: string): boolean {
+  if (s.length < 8) return false;
+  if (!/[a-zA-Z]{3}/.test(s)) return false;
+  if (!/\s/.test(s)) return false; // require at least two words
+  if (s.startsWith("//") || s.startsWith("/*") || s.startsWith("*")) return false;
+  if (/^[A-Za-z0-9_.,:/-]+$/.test(s) === false) {
+    // contains characters outside a plausible-prose set (JSX expressions,
+    // template interpolation, stray braces that slipped past the outer regex)
+    if (/[{}<>`]/.test(s)) return false;
+  }
+  if (/^[A-Za-z0-9_-]+$/.test(s)) return false; // single token / className-ish
+  return true;
+}
+
+/** Extract candidate UI-copy strings from a source file's raw text. */
+export function extractCopySnippets(text: string): string[] {
+  const out: string[] = [];
+  for (const m of text.matchAll(JSX_TEXT_RE)) {
+    const s = m[1].trim();
+    if (looksLikeCopy(s)) out.push(s);
+  }
+  for (const m of text.matchAll(ATTR_COPY_RE)) {
+    const s = m[2].trim();
+    if (looksLikeCopy(s)) out.push(s);
+  }
+  return out;
+}
+
+function splitSentences(s: string): string[] {
+  return s
+    .split(/[.!?]+/)
+    .map((x) => x.trim())
+    .filter(Boolean);
+}
+
+function wordCount(s: string): number {
+  return s.split(/\s+/).filter(Boolean).length;
+}
+
+/** Sentences over this length lose readers; matches the platform copy guidance
+ *  (docs/platform-usability-standards.md -> short sentences, active voice). */
+const LONG_SENTENCE_WORDS = 25;
+
+/** Only score sentence-shaped copy for readability/length — short labels and
+ *  button text are not prose and would just add noise. */
+const MIN_PROSE_WORDS = 6;
+
+/** Marketing/storefront copy is customer-facing (mirrors the substring test
+ *  in lib/readability/policy.ts's isExternalCopyRoute — same audience split). */
+function isExternalCopyPath(relPath: string): boolean {
+  const p = relPath.toLowerCase();
+  return p.includes("/storefront/") || p.includes("/marketing/");
+}
+
+export type ProseAxes = {
+  vocabulary: number;
+  genericLabels: number;
+  readability: number;
+  longSentences: number;
+  textMass: number;
+};
+
+export const PROSE_AXES: (keyof ProseAxes)[] = [
+  "vocabulary",
+  "genericLabels",
+  "readability",
+  "longSentences",
+  "textMass",
+];
+
+/** Score one file's raw source text against all four rule families. */
+export function analyzeFile(relPath: string, text: string): ProseAxes {
+  const snippets = extractCopySnippets(text);
+
+  let readability = 0;
+  let longSentences = 0;
+  let textMass = 0;
+  const external = isExternalCopyPath(relPath);
+
+  for (const snippet of snippets) {
+    textMass += wordCount(snippet);
+    for (const sentence of splitSentences(snippet)) {
+      const words = wordCount(sentence);
+      if (words > LONG_SENTENCE_WORDS) longSentences += 1;
+      if (external && words >= MIN_PROSE_WORDS) {
+        const { gradeLevel } = analyzeReadability(sentence);
+        if (!withinReadingLevel(gradeLevel, "high-school")) readability += 1;
+      }
+    }
+  }
+
+  return {
+    vocabulary: countVocabularyDrift(snippets),
+    genericLabels: countGenericDecisionLabels(text),
+    readability,
+    longSentences,
+    textMass,
+  };
+}
+
+function isZero(axes: ProseAxes): boolean {
+  return PROSE_AXES.every((a) => axes[a] === 0);
+}
+
+// ─── File discovery (mirrors check-style-drift.mjs's listSourceFiles) ──────
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry === ".next" || entry === "dist" || entry === ".turbo") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...listSourceFiles(full));
+    else if (/\.(ts|tsx)$/.test(entry) && !/\.(test|spec)\.(ts|tsx)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+function scan(): Record<string, ProseAxes> {
+  const counts: Record<string, ProseAxes> = {};
+  for (const dir of SCAN_DIRS) {
+    for (const file of listSourceFiles(dir)) {
+      const rel = relative(REPO_ROOT, file).replace(/\\/g, "/");
+      const text = readFileSync(file, "utf8");
+      const axes = analyzeFile(rel, text);
+      if (!isZero(axes)) counts[rel] = axes;
+    }
+  }
+  return counts;
+}
+
+type RatchetResult = { newFiles: string[]; increased: string[] };
+
+/** Ratchet comparison, same shape as check-style-drift.mjs's compareTokens(). */
+export function compareProse(
+  counts: Record<string, ProseAxes>,
+  baseline: Record<string, Partial<ProseAxes>>,
+): RatchetResult {
+  const newFiles: string[] = [];
+  const increased: string[] = [];
+  for (const [file, axes] of Object.entries(counts)) {
+    const prior = baseline[file];
+    if (!prior) {
+      const summary = PROSE_AXES.filter((a) => axes[a] > 0)
+        .map((a) => `${a} +${axes[a]}`)
+        .join(", ");
+      newFiles.push(`${file} (${summary})`);
+      continue;
+    }
+    const grown = PROSE_AXES.filter((a) => axes[a] > (prior[a] ?? 0));
+    if (grown.length) {
+      const summary = grown.map((a) => `${a} ${prior[a] ?? 0} -> ${axes[a]}`).join(", ");
+      increased.push(`${file} (${summary})`);
+    }
+  }
+  return { newFiles, increased };
+}
+
+function main() {
+  const counts = scan();
+
+  if (process.argv.includes("--update")) {
+    const sorted: Record<string, ProseAxes> = Object.fromEntries(
+      Object.keys(counts)
+        .sort()
+        .map((k) => [k, counts[k]]),
+    );
+    writeFileSync(BASELINE_PATH, `${JSON.stringify(sorted, null, 2)}\n`);
+    console.log(`Wrote prose-lint baseline: ${Object.keys(sorted).length} files with a signal.`);
+    process.exit(0);
+  }
+
+  let baseline: Record<string, Partial<ProseAxes>> = {};
+  try {
+    baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf8"));
+  } catch {
+    console.error(
+      `Missing baseline ${relative(REPO_ROOT, BASELINE_PATH)} — run: tsx scripts/check-prose-lint.ts --update`,
+    );
+    process.exit(1);
+  }
+
+  const { newFiles, increased } = compareProse(counts, baseline);
+
+  if (newFiles.length > 0 || increased.length > 0) {
+    console.error("Prose lint — new or grown UI-copy issues (EP-UX-SYSTEM L4, BI-88D8C725).\n");
+    console.error("Axes: vocabulary (hardcoded archetype term — use getVocabulary()/resolveVocabularyKey),");
+    console.error("      genericLabels (owner-first/ux-audit.ts GENERIC_DECISION_LABELS in source),");
+    console.error("      readability (marketing/storefront copy over the high-school Flesch-Kincaid grade),");
+    console.error("      longSentences (a sentence over 25 words), textMass (total UI-copy word count).\n");
+    if (newFiles.length) {
+      console.error("New files with a signal:");
+      for (const f of newFiles) console.error(`  - ${f}`);
+    }
+    if (increased.length) {
+      console.error("More signal than the baseline:");
+      for (const f of increased) console.error(`  - ${f}`);
+    }
+    console.error("\nIf you intentionally improved a file, run --update to retighten the baseline.");
+    process.exit(1);
+  }
+
+  const totals = PROSE_AXES.map(
+    (a) => `${Object.values(baseline).reduce((s, f) => s + (f[a] ?? 0), 0)} ${a}`,
+  ).join(" / ");
+  console.log(
+    `Prose lint OK — no new or grown UI-copy issues. Baseline: ${Object.keys(baseline).length} files / ${totals} (migrate as touched).`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -1,0 +1,7569 @@
+{
+  "apps/web/app/(auth)/forgot-password/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(auth)/login/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/app/(auth)/reset-password/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(customer-auth)/customer-complete-profile/complete-profile-client.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 55
+  },
+  "apps/web/app/(customer-auth)/customer-link-account/link-account-client.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 37
+  },
+  "apps/web/app/(customer-auth)/customer-login/login-form.tsx": {
+    "vocabulary": 1,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/(customer-auth)/customer-signup/signup-form.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 24
+  },
+  "apps/web/app/(portal)/layout.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(portal)/portal/account/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(portal)/portal/health/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 112
+  },
+  "apps/web/app/(portal)/portal/orders/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/(portal)/portal/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 35
+  },
+  "apps/web/app/(portal)/portal/services/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/app/(portal)/portal/support/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/app/(portal-auth)/portal/sign-in/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(setup)/setup/AccountBootstrapForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/app/(setup)/setup/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/admin/backups/BackupsClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 147
+  },
+  "apps/web/app/(shell)/admin/backups/RestoreConfirmModal.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/app/(shell)/admin/backups/RestoreHistorySection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/(shell)/admin/backups/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/app/(shell)/admin/branding/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/app/(shell)/admin/build-studio/stall-thresholds/StallThresholdsClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/app/(shell)/admin/cockpit/CockpitEventsTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(shell)/admin/cockpit/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 84
+  },
+  "apps/web/app/(shell)/admin/data-stewardship/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 36
+  },
+  "apps/web/app/(shell)/admin/diagnostics/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 85
+  },
+  "apps/web/app/(shell)/admin/hive/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 147
+  },
+  "apps/web/app/(shell)/admin/issue-reports/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/app/(shell)/admin/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/app/(shell)/admin/platform-development/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(shell)/admin/reference-data/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/(shell)/admin/research/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 26
+  },
+  "apps/web/app/(shell)/admin/scheduled-jobs/ScheduledJobsClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 85
+  },
+  "apps/web/app/(shell)/admin/scheduled-jobs/SchedulingTimeline.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/app/(shell)/admin/scheduled-jobs/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/app/(shell)/admin/settings/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 36
+  },
+  "apps/web/app/(shell)/admin/twin-gallery/[archetypeId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 35
+  },
+  "apps/web/app/(shell)/admin/twin-gallery/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 47
+  },
+  "apps/web/app/(shell)/admin/twin-kit/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 100
+  },
+  "apps/web/app/(shell)/admin/wiki/lint/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/app/(shell)/build/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 37
+  },
+  "apps/web/app/(shell)/complaints/ComplaintsClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/app/(shell)/complaints/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/app/(shell)/compliance/actions/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/(shell)/compliance/actions/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/app/(shell)/compliance/audits/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(shell)/compliance/audits/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/(shell)/compliance/controls/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/app/(shell)/compliance/controls/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/(shell)/compliance/evidence/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/app/(shell)/compliance/evidence/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/(shell)/compliance/gaps/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/compliance/incidents/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/app/(shell)/compliance/incidents/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/app/(shell)/compliance/licensing/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 42
+  },
+  "apps/web/app/(shell)/compliance/obligations/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/app/(shell)/compliance/obligations/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(shell)/compliance/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 39
+  },
+  "apps/web/app/(shell)/compliance/policies/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/(shell)/compliance/policies/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/(shell)/compliance/posture/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/app/(shell)/compliance/regulations/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/app/(shell)/compliance/regulations/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/app/(shell)/compliance/risks/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/compliance/risks/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/(shell)/compliance/submissions/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 20
+  },
+  "apps/web/app/(shell)/compliance/submissions/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/coworker-decisions/craft/[professionKey]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 45
+  },
+  "apps/web/app/(shell)/coworker-decisions/craft/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 56
+  },
+  "apps/web/app/(shell)/coworker-decisions/decisions/[interactionId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 91
+  },
+  "apps/web/app/(shell)/coworker-decisions/decisions/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 73
+  },
+  "apps/web/app/(shell)/coworker-decisions/matrix/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 89
+  },
+  "apps/web/app/(shell)/coworker-decisions/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 129
+  },
+  "apps/web/app/(shell)/coworker-decisions/perspectives/[profileId]/voice/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/app/(shell)/coworker-decisions/perspectives/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 60
+  },
+  "apps/web/app/(shell)/coworker-decisions/proactivity/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 83
+  },
+  "apps/web/app/(shell)/coworker-decisions/review/actions.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/(shell)/coworker-decisions/review/gap-answer-form.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 28
+  },
+  "apps/web/app/(shell)/coworker-decisions/review/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 96
+  },
+  "apps/web/app/(shell)/coworker-decisions/stance/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 109
+  },
+  "apps/web/app/(shell)/customer/(crm)/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 100
+  },
+  "apps/web/app/(shell)/customer/(crm)/engagements/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(shell)/customer/(crm)/funnel/page.tsx": {
+    "vocabulary": 2,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/app/(shell)/customer/(crm)/opportunities/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/customer/(crm)/opportunities/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/app/(shell)/customer/(crm)/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/app/(shell)/customer/(crm)/quotes/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/app/(shell)/customer/(crm)/quotes/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 45
+  },
+  "apps/web/app/(shell)/customer/(crm)/sales-orders/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/app/(shell)/customer/marketing/automation/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 7,
+    "longSentences": 0,
+    "textMass": 102
+  },
+  "apps/web/app/(shell)/customer/marketing/campaigns/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 6,
+    "longSentences": 0,
+    "textMass": 153
+  },
+  "apps/web/app/(shell)/customer/marketing/funnel/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 9,
+    "longSentences": 0,
+    "textMass": 136
+  },
+  "apps/web/app/(shell)/customer/marketing/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 7,
+    "longSentences": 0,
+    "textMass": 162
+  },
+  "apps/web/app/(shell)/customer/marketing/strategy/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 4,
+    "longSentences": 0,
+    "textMass": 121
+  },
+  "apps/web/app/(shell)/delivery/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 76
+  },
+  "apps/web/app/(shell)/docs/[[...slug]]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/app/(shell)/ea/capabilities/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/app/(shell)/ea/data-model/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 117
+  },
+  "apps/web/app/(shell)/ea/models/[slug]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 21
+  },
+  "apps/web/app/(shell)/ea/models/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(shell)/ea/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/app/(shell)/ea/value-streams/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 60
+  },
+  "apps/web/app/(shell)/ea/views/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/app/(shell)/employee/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 61
+  },
+  "apps/web/app/(shell)/error.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 2,
+    "textMass": 202
+  },
+  "apps/web/app/(shell)/finance/assets/AssetsTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/app/(shell)/finance/assets/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 44
+  },
+  "apps/web/app/(shell)/finance/assets/new/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/(shell)/finance/assets/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/app/(shell)/finance/banking/[id]/import/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/(shell)/finance/banking/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/app/(shell)/finance/banking/[id]/reconcile/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/(shell)/finance/banking/new/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/app/(shell)/finance/banking/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/app/(shell)/finance/banking/rules/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/app/(shell)/finance/bills/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/app/(shell)/finance/bills/new/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/(shell)/finance/bills/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(shell)/finance/close/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 70
+  },
+  "apps/web/app/(shell)/finance/configuration/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 67
+  },
+  "apps/web/app/(shell)/finance/expense-claims/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/(shell)/finance/expense-claims/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/app/(shell)/finance/invoices/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/(shell)/finance/invoices/new/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/(shell)/finance/invoices/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(shell)/finance/my-expenses/new/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/(shell)/finance/my-expenses/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/app/(shell)/finance/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 218
+  },
+  "apps/web/app/(shell)/finance/payment-runs/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/(shell)/finance/payments/PaymentsTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/app/(shell)/finance/purchase-orders/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/finance/purchase-orders/new/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/app/(shell)/finance/purchase-orders/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/(shell)/finance/recurring/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/app/(shell)/finance/recurring/new/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/finance/recurring/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/(shell)/finance/reports/aged-creditors/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/app/(shell)/finance/reports/aged-debtors/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 24
+  },
+  "apps/web/app/(shell)/finance/reports/cash-flow/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/app/(shell)/finance/reports/general-ledger/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 55
+  },
+  "apps/web/app/(shell)/finance/reports/outstanding/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/app/(shell)/finance/reports/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 65
+  },
+  "apps/web/app/(shell)/finance/reports/profit-loss/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 48
+  },
+  "apps/web/app/(shell)/finance/reports/revenue-by-customer/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/app/(shell)/finance/reports/vat-summary/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/app/(shell)/finance/revenue/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 61
+  },
+  "apps/web/app/(shell)/finance/settings/currency/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 61
+  },
+  "apps/web/app/(shell)/finance/settings/dunning/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 36
+  },
+  "apps/web/app/(shell)/finance/settings/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 145
+  },
+  "apps/web/app/(shell)/finance/settings/rate-card/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 23
+  },
+  "apps/web/app/(shell)/finance/settings/setup/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/app/(shell)/finance/settings/tax/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/app/(shell)/finance/spend/ai/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/app/(shell)/finance/spend/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 65
+  },
+  "apps/web/app/(shell)/finance/suppliers/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/app/(shell)/finance/suppliers/new/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/(shell)/finance/suppliers/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(shell)/governance/records-requests/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/app/(shell)/inventory/entity/[entityId]/inline-actions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/app/(shell)/inventory/entity/[entityId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 65
+  },
+  "apps/web/app/(shell)/knowledge/[articleId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/app/(shell)/knowledge/new/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(shell)/knowledge/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 61
+  },
+  "apps/web/app/(shell)/layout.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/app/(shell)/member-equity/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/(shell)/ops/changes/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/app/(shell)/ops/demand/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 40
+  },
+  "apps/web/app/(shell)/ops/dev-loop/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 82
+  },
+  "apps/web/app/(shell)/ops/patches/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 60
+  },
+  "apps/web/app/(shell)/ops/promotions/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/app/(shell)/ops/security/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 49
+  },
+  "apps/web/app/(shell)/ops/self-upgrade/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/app/(shell)/platform/ai/agent/[agentId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 85
+  },
+  "apps/web/app/(shell)/platform/ai/assignments/bindings/[bindingId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/platform/ai/assignments/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 110
+  },
+  "apps/web/app/(shell)/platform/ai/browser-sessions/BrowserSessionLedgerTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/(shell)/platform/ai/browser-sessions/ServiceAccountSetupForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 54
+  },
+  "apps/web/app/(shell)/platform/ai/browser-sessions/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/app/(shell)/platform/ai/browser-sessions/setup/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/app/(shell)/platform/ai/build-studio/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/app/(shell)/platform/ai/capacity-continuity/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 154
+  },
+  "apps/web/app/(shell)/platform/ai/decisions/[interactionId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(shell)/platform/ai/founder-review/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 198
+  },
+  "apps/web/app/(shell)/platform/ai/memory/MyMemoryAuditClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/(shell)/platform/ai/memory/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 60
+  },
+  "apps/web/app/(shell)/platform/ai/overview/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/app/(shell)/platform/ai/priority/outcomes/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 49
+  },
+  "apps/web/app/(shell)/platform/ai/prompts/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 44
+  },
+  "apps/web/app/(shell)/platform/ai/providers/[providerId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 162
+  },
+  "apps/web/app/(shell)/platform/ai/providers/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 100
+  },
+  "apps/web/app/(shell)/platform/ai/readiness/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 93
+  },
+  "apps/web/app/(shell)/platform/ai/runtime-health/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 188
+  },
+  "apps/web/app/(shell)/platform/ai/skills/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 89
+  },
+  "apps/web/app/(shell)/platform/audit/authority/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 93
+  },
+  "apps/web/app/(shell)/platform/audit/journal/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/app/(shell)/platform/audit/ledger/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(shell)/platform/audit/metrics/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 77
+  },
+  "apps/web/app/(shell)/platform/audit/operations/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(shell)/platform/audit/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 61
+  },
+  "apps/web/app/(shell)/platform/audit/routes/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/app/(shell)/platform/device-catalog/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 36
+  },
+  "apps/web/app/(shell)/platform/edge-nodes/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/app/(shell)/platform/federation-links/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/app/(shell)/platform/federation-proposals/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 26
+  },
+  "apps/web/app/(shell)/platform/identity/applications/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/app/(shell)/platform/identity/authorization/bindings/[bindingId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/app/(shell)/platform/identity/authorization/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/app/(shell)/platform/identity/directory/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 40
+  },
+  "apps/web/app/(shell)/platform/identity/federation/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 91
+  },
+  "apps/web/app/(shell)/platform/identity/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 156
+  },
+  "apps/web/app/(shell)/platform/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 84
+  },
+  "apps/web/app/(shell)/platform/schedule/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/(shell)/platform/service-desk/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 24
+  },
+  "apps/web/app/(shell)/platform/tools/built-ins/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 44
+  },
+  "apps/web/app/(shell)/platform/tools/catalog/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 68
+  },
+  "apps/web/app/(shell)/platform/tools/catalog/sync/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 61
+  },
+  "apps/web/app/(shell)/platform/tools/discovery/promotion-audit/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 57
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/adp/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 79
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/communications/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 94
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/email-postmark/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 176
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/facebook-lead-ads/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 137
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/facebook-pages/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 140
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/google-business-profile/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 168
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/google-marketing-intelligence/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 138
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/hubspot/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 141
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/instagram-business/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 114
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/linkedin-personal-social/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 137
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/mailchimp/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 131
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/microsoft365-communications/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 150
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 274
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/quickbooks/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 82
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/stripe/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 111
+  },
+  "apps/web/app/(shell)/platform/tools/integrations/whatsapp-business/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 139
+  },
+  "apps/web/app/(shell)/platform/tools/inventory/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/platform/tools/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 173
+  },
+  "apps/web/app/(shell)/platform/tools/services/[serverId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/platform/tools/services/activate/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(shell)/platform/tools/services/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 20
+  },
+  "apps/web/app/(shell)/portfolio/[[...slug]]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(shell)/portfolio/product/[id]/architecture/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/(shell)/portfolio/product/[id]/backlog/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 21
+  },
+  "apps/web/app/(shell)/portfolio/product/[id]/changes/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/portfolio/product/[id]/health/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 69
+  },
+  "apps/web/app/(shell)/portfolio/product/[id]/inventory/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 69
+  },
+  "apps/web/app/(shell)/portfolio/product/[id]/knowledge/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(shell)/portfolio/product/[id]/offerings/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 23
+  },
+  "apps/web/app/(shell)/portfolio/product/[id]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 49
+  },
+  "apps/web/app/(shell)/portfolio/product/[id]/team/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 39
+  },
+  "apps/web/app/(shell)/portfolio/product/[id]/versions/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/app/(shell)/rental/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/app/(shell)/service-requests/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/app/(shell)/storefront/dispatch/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 0,
+    "textMass": 36
+  },
+  "apps/web/app/(shell)/storefront/inbox/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/app/(shell)/storefront/intake/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 6,
+    "longSentences": 0,
+    "textMass": 108
+  },
+  "apps/web/app/(shell)/storefront/layout.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 2,
+    "longSentences": 0,
+    "textMass": 47
+  },
+  "apps/web/app/(shell)/storefront/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/app/(shell)/storefront/settings/business/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(shell)/storefront/settings/capabilities/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 2,
+    "longSentences": 0,
+    "textMass": 36
+  },
+  "apps/web/app/(shell)/storefront/settings/operations/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/app/(shell)/storefront/settings/page.tsx": {
+    "vocabulary": 1,
+    "genericLabels": 0,
+    "readability": 2,
+    "longSentences": 0,
+    "textMass": 81
+  },
+  "apps/web/app/(shell)/storefront/tables/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/(shell)/storefront/team/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/(shell)/workbooks/[workbookId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(shell)/workbooks/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/app/(shell)/workbooks/system/[entityType]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/app/(shell)/workspace/calendar/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/(shell)/workspace/documents/[documentId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/app/(shell)/workspace/documents/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/app/(shell)/workspace/inbox/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 30
+  },
+  "apps/web/app/(shell)/workspace/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/app/(storefront)/s/[slug]/book/[itemId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(storefront)/s/[slug]/booking/confirmed/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(storefront)/s/[slug]/checkout/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(storefront)/s/[slug]/donate/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/app/(storefront)/s/[slug]/donation/received/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(storefront)/s/[slug]/inquire/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(storefront)/s/[slug]/inquiry/received/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(storefront)/s/[slug]/item/[itemId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/app/(storefront)/s/[slug]/layout.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(storefront)/s/[slug]/not-found.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 24
+  },
+  "apps/web/app/(storefront)/s/[slug]/order/[itemId]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/(storefront)/s/[slug]/order/received/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(storefront)/s/[slug]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/(storefront)/s/[slug]/policies/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 45
+  },
+  "apps/web/app/(storefront)/s/[slug]/sign-in/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/(storefront)/s/[slug]/sign-up/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/app/(storefront)/s/approve/[token]/ApprovalForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/app/(storefront)/s/approve/[token]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/app/(storefront)/s/expense-approve/[token]/ExpenseApprovalForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/app/(storefront)/s/expense-approve/[token]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/app/(storefront)/s/pay/[token]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/app/(storefront)/s/quote/[token]/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/app/.well-known/dpf-instance.json/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 30
+  },
+  "apps/web/app/api/agent/send/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/api/calendar/sync/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/app/api/diagnostics/preflight/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 56
+  },
+  "apps/web/app/api/docs/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 85
+  },
+  "apps/web/app/api/health/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/api/mcp/v1/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/app/api/onboarding/business-document/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/api/platform/alerts/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/app/api/platform/authority-bindings/[bindingId]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/app/api/platform/authority-bindings/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 28
+  },
+  "apps/web/app/api/platform/git/updates/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/api/sandbox/preview/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/app/api/storefront/[slug]/dates/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/api/storefront/[slug]/slots/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/api/storefront/admin/archetype-reset/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/api/storefront/admin/archetypes/refinement/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/api/storefront/admin/archetypes/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/app/api/storefront/admin/items/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/storefront/admin/providers/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/app/api/storefront/admin/units/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/app/api/test/codex-responses/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 56
+  },
+  "apps/web/app/api/v1/admin/operating-hours/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/app/api/v1/agent/message/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/api/v1/agent/proposals/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/agent/thread/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/app/config/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/auth/login/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/auth/logout/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/auth/me/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/auth/refresh/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/business-models/[modelId]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/business-models/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/compliance/alerts/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/compliance/audits/[id]/findings/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/compliance/controls/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/compliance/corrective-actions/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/compliance/incidents/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/compliance/regulations/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/customer/accounts/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 74
+  },
+  "apps/web/app/api/v1/customer/accounts/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/customer/activities/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/customer/contacts/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 28
+  },
+  "apps/web/app/api/v1/customer/contacts/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 21
+  },
+  "apps/web/app/api/v1/customer/engagements/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/customer/engagements/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/customer/invoices/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/customer/opportunities/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/customer/opportunities/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/customer/quotes/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/app/api/v1/customer/quotes/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/customer/sales-orders/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/customer/sales-orders/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/customer/visits/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/device-catalog/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/app/api/v1/directory/nearby/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/api/v1/discovery/sweep/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/api/v1/dynamic/forms/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/app/api/v1/dynamic/forms/[id]/submit/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/app/api/v1/dynamic/forms/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/app/api/v1/dynamic/views/[id]/data/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/app/api/v1/dynamic/views/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/app/api/v1/edge/actions/claim/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/api/v1/edge/actions/result/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/app/api/v1/edge/discovery-runs/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/api/v1/edge/events/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 21
+  },
+  "apps/web/app/api/v1/edge/federation-candidates/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/app/api/v1/edge/metrics/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/app/api/v1/federation/demand/reconcile/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/api/v1/finance/assets/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/finance/assets/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/finance/bank-accounts/[id]/reconcile/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/app/api/v1/finance/bank-accounts/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/finance/bank-accounts/[id]/transactions/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/api/v1/finance/bank-accounts/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/finance/bills/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/api/v1/finance/bills/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/finance/dunning/run/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/finance/exchange-rates/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/finance/expense-claims/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/api/v1/finance/expense-claims/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/finance/invoices/[id]/pdf/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/finance/invoices/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/finance/invoices/[id]/send/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/finance/invoices/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/finance/payment-runs/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/api/v1/finance/payments/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/finance/purchase-orders/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/finance/recurring/generate/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/finance/recurring/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/finance/reports/[report]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/finance/suppliers/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/governance/approvals/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/api/v1/governance/approvals/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/app/api/v1/governance/decisions/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/healthcare/intake/[packetId]/access-grants/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/healthcare/intake/[packetId]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/healthcare/intake/[packetId]/submit/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/notifications/[id]/read/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/notifications/register-device/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/app/api/v1/notifications/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/ops/backlog/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/ops/backlog/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/ops/business-profile/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/app/api/v1/ops/catalog/[key]/create-rfc/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/ops/catalog/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/app/api/v1/ops/changes/[id]/execute/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/app/api/v1/ops/changes/[id]/rollback/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/app/api/v1/ops/changes/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 37
+  },
+  "apps/web/app/api/v1/ops/changes/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/app/api/v1/ops/epics/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/app/api/v1/ops/epics/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/app/api/v1/ops/windows/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 28
+  },
+  "apps/web/app/api/v1/portfolio/[id]/products/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/portfolio/[id]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/portfolio/tree/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/upload/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/app/api/v1/work-items/[itemId]/evidence/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/work-items/[itemId]/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/app/api/v1/work-items/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/workspace/activity/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/app/api/v1/workspace/dashboard/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/app/api/voice/train/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/app/connect/pair/route.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/app/layout.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/app/not-found.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/app/sandbox-restricted/page.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/app/welcome/page.tsx": {
+    "vocabulary": 1,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 47
+  },
+  "apps/web/components/admin/AdminUserAccessPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 57
+  },
+  "apps/web/components/admin/AdvancedTokenPaste.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 39
+  },
+  "apps/web/components/admin/ArchetypeCatalogTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/admin/BrandingPreview.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 37
+  },
+  "apps/web/components/admin/BrandingQuickEdit.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 42
+  },
+  "apps/web/components/admin/BrandingWizard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 198
+  },
+  "apps/web/components/admin/BusinessContextForm.tsx": {
+    "vocabulary": 1,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 488
+  },
+  "apps/web/components/admin/BusinessDocumentUpload.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 50
+  },
+  "apps/web/components/admin/BusinessModelBuilder.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 96
+  },
+  "apps/web/components/admin/CityPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 95
+  },
+  "apps/web/components/admin/ConnectGitHubCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 76
+  },
+  "apps/web/components/admin/ContributionModelBanner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/admin/ContributionProvenanceTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/components/admin/CountryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/admin/DataStewardPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/components/admin/EmailSettingsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 113
+  },
+  "apps/web/components/admin/ForkSetupPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 98
+  },
+  "apps/web/components/admin/HiveContributionsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/components/admin/HiveResultReviewActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/admin/IssueReportPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 129
+  },
+  "apps/web/components/admin/LegacyTokenOverrideBanner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/components/admin/MarketContextFields.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 97
+  },
+  "apps/web/components/admin/MatchConfigCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 63
+  },
+  "apps/web/components/admin/McpTokenManager.tsx": {
+    "vocabulary": 1,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 411
+  },
+  "apps/web/components/admin/OAuthPortMismatchBanner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/components/admin/OperatingHoursEditor.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 91
+  },
+  "apps/web/components/admin/PlatformDevelopmentForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 426
+  },
+  "apps/web/components/admin/PlatformKeysPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 50
+  },
+  "apps/web/components/admin/PlatformUpdateApplyPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 105
+  },
+  "apps/web/components/admin/PrivatePathsEditor.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/admin/PromptManager.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 52
+  },
+  "apps/web/components/admin/ReadabilityPolicyPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 54
+  },
+  "apps/web/components/admin/RegionPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 90
+  },
+  "apps/web/components/admin/ResearchProposalsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 43
+  },
+  "apps/web/components/admin/RosterImport.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 52
+  },
+  "apps/web/components/admin/SeedContributionReviewTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 26
+  },
+  "apps/web/components/admin/SkillsCatalogView.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/admin/SocialAuthPanel.tsx": {
+    "vocabulary": 1,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 454
+  },
+  "apps/web/components/admin/SpeechToTextCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/admin/SpeechToTextTestHarness.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 28
+  },
+  "apps/web/components/admin/StewardTaskList.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 23
+  },
+  "apps/web/components/admin/TokenExpiryBanner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/admin/VoiceConsentForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 75
+  },
+  "apps/web/components/admin/WorkLocationPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 68
+  },
+  "apps/web/components/admin/admin-nav.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 55
+  },
+  "apps/web/components/agent/AgentCoworkerPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 4,
+    "textMass": 369
+  },
+  "apps/web/components/agent/AgentCoworkerShell.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 2,
+    "textMass": 207
+  },
+  "apps/web/components/agent/AgentFAB.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/components/agent/AgentFileUpload.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/agent/AgentMessageBubble.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 45
+  },
+  "apps/web/components/agent/AgentMessageInput.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 110
+  },
+  "apps/web/components/agent/AgentPanelHeader.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/components/agent/AgentSkillsDropdown.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/components/agent/AgentWorkLauncher.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/agent/AskCoworkerButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/agent/CollaborationActivityPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/agent/ConversationParticipantRail.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/agent/CoworkerPostureControl.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/components/agent/CoworkerProfilePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 63
+  },
+  "apps/web/components/agent/DelegationChainView.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/agent/MicButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/components/agent/hooks/useVoiceCapture.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 80
+  },
+  "apps/web/components/agent/hooks/useVoiceSynth.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 77
+  },
+  "apps/web/components/attention/AttentionInbox.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 31
+  },
+  "apps/web/components/attention/CoworkerProposalActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/attention/OwnerAttentionStatus.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/components/attention/OwnerDecisionCards.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 66
+  },
+  "apps/web/components/attention/ProactivityProposalActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/attention/ResearchProposalActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/attention/WeeklyDigestPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/auth/ForgotPasswordForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/auth/ResetPasswordForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/build-studio/ArtifactTabs.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/build-studio/Bubble.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/components/build-studio/BuildStudioV2.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/build-studio/BusinessBriefPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 141
+  },
+  "apps/web/components/build-studio/Composer.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/build-studio/HeaderBar.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 24
+  },
+  "apps/web/components/build-studio/PreviewFrame.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 42
+  },
+  "apps/web/components/build-studio/cards/DecisionCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/build-studio/cards/FilesTouchedCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/build-studio/cards/PlanSummaryCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/build-studio/cards/StepRefCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/build-studio/cards/VerificationStripCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/build/ActionBanner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/build/AgentActivityStrip.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/build/AgentSessionFeed.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/build/AgentSessionFeedLive.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/build/AssuranceFindingsList.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 37
+  },
+  "apps/web/components/build/BuildAssuranceGateCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 31
+  },
+  "apps/web/components/build/BuildChangeSummaryBand.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/build/BuildCustomerStatusBand.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/build/BuildDecisionLedgerBand.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 63
+  },
+  "apps/web/components/build/BuildDispatchHistoryCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 35
+  },
+  "apps/web/components/build/BuildListItem.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/build/BuildOperatorContext.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/build/BuildPhaseCostCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 40
+  },
+  "apps/web/components/build/BuildProgressOperationalPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 42
+  },
+  "apps/web/components/build/BuildSandboxCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 24
+  },
+  "apps/web/components/build/BuildSolutionSummaryBand.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/build/BuildStudio.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 2,
+    "textMass": 508
+  },
+  "apps/web/components/build/BuildStudioCustodianCallout.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/build/BuildStudioWorkflowActionCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 48
+  },
+  "apps/web/components/build/BuildVerificationScopedCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/build/BuildWorkWarrantBand.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/components/build/CodeIntelligenceStatusCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/build/DecisionPerspectiveGatePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/components/build/DecompositionAssistantPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 102
+  },
+  "apps/web/components/build/DecompositionCoordinator.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/build/DecompositionGateBanner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 75
+  },
+  "apps/web/components/build/DetailsDrawer.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/components/build/EnableRunnerButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/build/EnvironmentStatusSummary.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/build/EpicRollupListItem.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/build/EvidenceSummary.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 43
+  },
+  "apps/web/components/build/FeatureBriefPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 69
+  },
+  "apps/web/components/build/FleetRail.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/build/NodeInspector.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/components/build/OpenSandboxButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/build/ParentDesignAmendmentCoordinator.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 83
+  },
+  "apps/web/components/build/PhaseIndicator.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/components/build/PhaseNode.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/build/PreviewUrlCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 31
+  },
+  "apps/web/components/build/ProcessGraph.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 37
+  },
+  "apps/web/components/build/QueueStateBadge.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/build/ReleaseDecisionPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 220
+  },
+  "apps/web/components/build/ReviewPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 87
+  },
+  "apps/web/components/build/ReviewReadinessStrip.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/build/StallEventHistoryStrip.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/components/build/TaskInspector.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/build/TestRunnerPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/build/UnifiedEvidenceTimeline.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/build/VoiceRationalePlayer.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/build/WorkflowStageInspector.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 49
+  },
+  "apps/web/components/build/build-studio-branch-badge.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/build/build-studio-custodian.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 51
+  },
+  "apps/web/components/build/build-studio-workflow-actions.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 343
+  },
+  "apps/web/components/build/work-control/AdoptableWorktreeTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/build/work-control/CreateGovernedWorkForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/components/build/work-control/WorkCapsuleLaunchPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/build/work-control/WorkCapsuleTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/build/work-control/WorkControlPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/civic/CivicMeetingsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 46
+  },
+  "apps/web/components/civic/FundBudgetPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/civic/MemberEquityPanel.tsx": {
+    "vocabulary": 1,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 75
+  },
+  "apps/web/components/civic/RecordsRequestsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 41
+  },
+  "apps/web/components/civic/ServiceRequestsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/cockpit/GraduationVetoButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/compliance/ComplianceLibraryScopeNav.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/compliance/ComplianceTabNav.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/compliance/CreateAuditForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/components/compliance/CreateControlForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/components/compliance/CreateCorrectiveActionForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/components/compliance/CreateEvidenceForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/compliance/CreateIncidentForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/components/compliance/CreateObligationForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/components/compliance/CreatePolicyForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 39
+  },
+  "apps/web/components/compliance/CreateRegulationForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/components/compliance/CreateRiskAssessmentForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/components/compliance/CreateSubmissionForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/components/compliance/EditControlForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/compliance/EditCorrectiveActionForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/compliance/EditIncidentForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/compliance/EditObligationForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/compliance/EditPolicyForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/components/compliance/EditRegulationForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/compliance/LinkControlForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/compliance/LinkObligationForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/compliance/LinkPolicyObligationForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/components/compliance/LinkRiskControlForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/components/compliance/ObligationLibraryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/compliance/OnboardingWizard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 81
+  },
+  "apps/web/components/compliance/RegulationLibraryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/compliance/RegulatoryAlerts.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/components/compliance/ScanStatus.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/compliance/compliance-nav.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 73
+  },
+  "apps/web/components/compliance/licensing/CreateOrganizationLicenseRecordForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 56
+  },
+  "apps/web/components/compliance/licensing/CreatePersonLicenseRecordForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 69
+  },
+  "apps/web/components/compliance/licensing/LicensingWorkspacePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 260
+  },
+  "apps/web/components/customer-marketing/ApprovalQueuePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 121
+  },
+  "apps/web/components/customer-marketing/ApprovalQueueReview.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 20
+  },
+  "apps/web/components/customer-marketing/DraftAssetButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/customer-marketing/MarketingStrategyOverview.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 131
+  },
+  "apps/web/components/customer-marketing/PublishEmailButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 59
+  },
+  "apps/web/components/customer-marketing/PublishLinkedInButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 81
+  },
+  "apps/web/components/customer-marketing/marketing-nav.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/customer/AcceptQuoteForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/components/customer/AccountLifecycleActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/components/customer/AcquisitionSignalRouter.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 40
+  },
+  "apps/web/components/customer/AddContactButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 54
+  },
+  "apps/web/components/customer/BillableTimeSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 41
+  },
+  "apps/web/components/customer/CustomerLifecycleReviewQueues.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 61
+  },
+  "apps/web/components/customer/CustomerSiteTree.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/customer/DraftQuoteButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 28
+  },
+  "apps/web/components/customer/DuplicateAccountsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/customer/EditCustomerConfigurationItemButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 53
+  },
+  "apps/web/components/customer/EmptyPipelineGuidance.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 35
+  },
+  "apps/web/components/customer/EngagementTriageActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/customer/MergeCustomerAccountButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 51
+  },
+  "apps/web/components/customer/NewCustomerButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 88
+  },
+  "apps/web/components/customer/NewCustomerConfigurationItemButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 52
+  },
+  "apps/web/components/customer/NewCustomerSiteButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 95
+  },
+  "apps/web/components/customer/NewCustomerSiteNodeButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/components/customer/NewLeadButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 35
+  },
+  "apps/web/components/customer/NewOpportunityButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 23
+  },
+  "apps/web/components/customer/NextStepControl.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 43
+  },
+  "apps/web/components/customer/PipelineStageInspector.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 43
+  },
+  "apps/web/components/customer/QuoteLifecycleActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/customer/QuoteShareLink.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/customer/RevenueCockpit.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/components/customer/UnmergeCustomerAccountButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/decision-perspective/DecisionCanvas.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 35
+  },
+  "apps/web/components/decision-perspective/MaterialBacklinksPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 45
+  },
+  "apps/web/components/deliberation/DeliberationDrilldown.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/deliberation/DeliberationSummaryCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/docs/ContextualQuickHelp.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/components/docs/DocsLayout.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/docs/DocsSearch.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/docs/DocsSidebar.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/docs/HelpLink.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/ea/AgentGovernanceCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/ea/CreateViewButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/components/ea/EaCanvas.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 141
+  },
+  "apps/web/components/ea/EaRelationshipEdge.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/components/ea/EaTabNav.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/ea/ElementInspector.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/components/ea/ElementPalette.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/components/ea/GenerateDataModelButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/ea/It4itConformanceCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/ea/It4itCoverageHeatmap.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 45
+  },
+  "apps/web/components/ea/It4itParticipationGrid.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 46
+  },
+  "apps/web/components/ea/ReferenceModelDirectory.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/ea/ReferenceModelElementTree.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 64
+  },
+  "apps/web/components/ea/ReferenceModelPortfolioTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/ea/ReferenceModelSummary.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/ea/ReferencePopup.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/ea/ReferenceProjectionActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/components/ea/ReferenceProposalQueue.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/ea/StructuredValueStreamNode.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 30
+  },
+  "apps/web/components/ea/ValueStreamStageNode.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/ea/ea-nav.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/employee/AddressSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 44
+  },
+  "apps/web/components/employee/CompensationPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 84
+  },
+  "apps/web/components/employee/EmployeeDirectoryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 51
+  },
+  "apps/web/components/employee/EmployeeFormPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 56
+  },
+  "apps/web/components/employee/EmployeeProfilePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 43
+  },
+  "apps/web/components/employee/EmployeeReachabilityPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/components/employee/EmployeeTabNav.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/employee/HrUserLifecyclePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/components/employee/LeavePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 21
+  },
+  "apps/web/components/employee/LifecycleEventPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/components/employee/MyPoliciesView.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/components/employee/NewEmployeeButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/employee/OnboardingPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/employee/OrgAssignmentPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/components/employee/OrgChartView.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 54
+  },
+  "apps/web/components/employee/ReviewPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/components/employee/TimesheetApprovalPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/employee/TimesheetGrid.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 73
+  },
+  "apps/web/components/employee/WorkforceActivityPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/components/employee/WorkforceRosterPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/components/feedback/FeedbackButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/feedback/FeedbackForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/components/feedback/HeaderFeedbackButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/feedback/UpstreamEscalation.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 51
+  },
+  "apps/web/components/finance/AccountantWorkLanePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 44
+  },
+  "apps/web/components/finance/AiFinanceCoworkerAskButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/finance/AiProviderFinancePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 47
+  },
+  "apps/web/components/finance/AiSpendProviderTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/finance/AiSpendSummaryCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/components/finance/AiSpendWorkspace.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 113
+  },
+  "apps/web/components/finance/AiSubscriptionPaymentForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 123
+  },
+  "apps/web/components/finance/AiSupplierFinancePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/finance/AssetDisposalForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/components/finance/BankRulesManager.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 85
+  },
+  "apps/web/components/finance/CreateAssetForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 72
+  },
+  "apps/web/components/finance/CreateBankAccountForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 52
+  },
+  "apps/web/components/finance/CreateBillForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 85
+  },
+  "apps/web/components/finance/CreateExpenseForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 61
+  },
+  "apps/web/components/finance/CreateInvoiceForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 71
+  },
+  "apps/web/components/finance/CreatePOForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 67
+  },
+  "apps/web/components/finance/CreateRecurringForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 97
+  },
+  "apps/web/components/finance/CreateSupplierForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/components/finance/ExpenseClaimActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 20
+  },
+  "apps/web/components/finance/FetchRatesButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/finance/ImportCSVForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 70
+  },
+  "apps/web/components/finance/InvoiceDownloadButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/finance/InvoiceSendButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/finance/InvoiceSignaturePad.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 56
+  },
+  "apps/web/components/finance/InvoiceSignatureToggle.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/finance/ManualRateForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/finance/OwnerFirstFinanceView.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 91
+  },
+  "apps/web/components/finance/POActionButtons.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/components/finance/PaymentRunBuilder.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 86
+  },
+  "apps/web/components/finance/RateCardManager.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 101
+  },
+  "apps/web/components/finance/ReconciliationFeed.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/components/finance/RecordBillPaymentButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 28
+  },
+  "apps/web/components/finance/RecordInvoicePaymentButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/finance/ScheduleStatusButtons.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/finance/SubmitBillButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/finance/TaxAuthorityCredentialPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 101
+  },
+  "apps/web/components/finance/TaxExecutionPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 128
+  },
+  "apps/web/components/finance/TaxLiabilityLedgerCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 41
+  },
+  "apps/web/components/finance/TaxObligationPeriodsTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 160
+  },
+  "apps/web/components/finance/TaxRegistrationEditor.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 92
+  },
+  "apps/web/components/finance/TaxRemittanceSettingsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 166
+  },
+  "apps/web/components/finance/aiFinanceCoworkerAsks.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/finance/finance-nav.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 60
+  },
+  "apps/web/components/golden-triangle/CoworkerPriorityControl.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 51
+  },
+  "apps/web/components/golden-triangle/CoworkerPriorityDock.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 73
+  },
+  "apps/web/components/golden-triangle/GoldenTriangleControl.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 48
+  },
+  "apps/web/components/golden-triangle/GoldenTriangleOutcomes.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 52
+  },
+  "apps/web/components/golden-triangle/GoldenTrianglePriorityPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/golden-triangle/posture-display.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/healthcare/PatientIntakeRunner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 139
+  },
+  "apps/web/components/integrations/AdpConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 77
+  },
+  "apps/web/components/integrations/EmailPostmarkConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 79
+  },
+  "apps/web/components/integrations/EntraConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 56
+  },
+  "apps/web/components/integrations/FacebookLeadAdsConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/components/integrations/FacebookPagesConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 42
+  },
+  "apps/web/components/integrations/GoogleBusinessProfileConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 50
+  },
+  "apps/web/components/integrations/GoogleMarketingIntelligenceConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 46
+  },
+  "apps/web/components/integrations/HubSpotConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 37
+  },
+  "apps/web/components/integrations/InstagramBusinessConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 42
+  },
+  "apps/web/components/integrations/IntegrationReadinessPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 21
+  },
+  "apps/web/components/integrations/LinkedInConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 55
+  },
+  "apps/web/components/integrations/MailchimpConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/components/integrations/Microsoft365CommunicationsConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 43
+  },
+  "apps/web/components/integrations/QuickBooksConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 52
+  },
+  "apps/web/components/integrations/StripeConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 59
+  },
+  "apps/web/components/integrations/WhatsAppBusinessConnectPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 40
+  },
+  "apps/web/components/inventory/AddDiscoveryConnection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 64
+  },
+  "apps/web/components/inventory/ConfigureConnectionInline.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 40
+  },
+  "apps/web/components/inventory/DataEnrichmentHelpNote.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/components/inventory/DiscoveryOperationsPage.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 122
+  },
+  "apps/web/components/inventory/DiscoveryRunSummary.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/inventory/EstateItemCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 114
+  },
+  "apps/web/components/inventory/InventoryEntityPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/inventory/InventoryExceptionQueue.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 108
+  },
+  "apps/web/components/inventory/PortfolioQualityIssuesPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/inventory/RelationshipGraph.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 91
+  },
+  "apps/web/components/inventory/SavedConnectionRow.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/inventory/SavedConnectionsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/inventory/SubnetGroupedInventoryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 36
+  },
+  "apps/web/components/inventory/TopologyGraph.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 161
+  },
+  "apps/web/components/knowledge/KnowledgeArticleActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/knowledge/KnowledgeArticleCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/knowledge/KnowledgeArticleForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 73
+  },
+  "apps/web/components/knowledge/KnowledgeArticleList.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/knowledge/StalenessIndicator.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/linked-identities.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/components/location/LocationCascadePicker.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 37
+  },
+  "apps/web/components/monitoring/AiCoworkerHealthPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/components/monitoring/AlertBanner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/monitoring/CapabilityServiceHealth.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 26
+  },
+  "apps/web/components/monitoring/ContainerResourceTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/monitoring/CoworkerHealthStatus.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/monitoring/LogIssuesPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/components/monitoring/MetricGauge.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/monitoring/MetricTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/monitoring/MetricTimeSeries.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 48
+  },
+  "apps/web/components/monitoring/PlatformHealthIndicator.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/components/monitoring/PortalHealthSummary.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/components/monitoring/RecentAlertsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/monitoring/ServiceHealthDashboard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 63
+  },
+  "apps/web/components/monitoring/ServiceStatusGrid.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/monitoring/SparkLine.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/monitoring/SystemHealthDashboard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 53
+  },
+  "apps/web/components/monitoring/alert-humanize.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/monitoring/health-summary.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/onboarding/HowYouDecideCards.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 82
+  },
+  "apps/web/components/ops/BacklogItemRow.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 42
+  },
+  "apps/web/components/ops/BacklogPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 48
+  },
+  "apps/web/components/ops/ChangesClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 55
+  },
+  "apps/web/components/ops/DemandBoard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 205
+  },
+  "apps/web/components/ops/EpicCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/ops/EpicPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 44
+  },
+  "apps/web/components/ops/EscalationsAttention.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 51
+  },
+  "apps/web/components/ops/FounderSharedPortfolioPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 64
+  },
+  "apps/web/components/ops/GitPromotionCandidatesPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 41
+  },
+  "apps/web/components/ops/ImprovementsClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 21
+  },
+  "apps/web/components/ops/LocalChangesLedger.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 60
+  },
+  "apps/web/components/ops/NetworkDemandPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 168
+  },
+  "apps/web/components/ops/OperatorTriageBand.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 79
+  },
+  "apps/web/components/ops/OpsClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 35
+  },
+  "apps/web/components/ops/OpsTabNav.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/ops/OwnerReleaseCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/components/ops/PromotionsClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 43
+  },
+  "apps/web/components/ops/RFCDetailPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 47
+  },
+  "apps/web/components/ops/SelfUpgradeClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 375
+  },
+  "apps/web/components/ops/SelfUpgradeJobEngineHealthAlert.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 39
+  },
+  "apps/web/components/ops/SelfUpgradePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 20
+  },
+  "apps/web/components/ops/StandardChangeCatalog.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 48
+  },
+  "apps/web/components/ops/UpgradeImpactPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 88
+  },
+  "apps/web/components/ops/backlog-form-assist.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/ops/ops-nav.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/owner-first/OwnerFirstSummary.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/owner-first/WorkspaceStorefrontAttention.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 1,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 0
+  },
+  "apps/web/components/platform/A2aInteractionsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 175
+  },
+  "apps/web/components/platform/ActivityRoutingPresentation.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/platform/ActivityRoutingWorkbench.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 132
+  },
+  "apps/web/components/platform/AgentBudgetEventsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 23
+  },
+  "apps/web/components/platform/AgentCardSupervisorPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 92
+  },
+  "apps/web/components/platform/AgentModelAssignmentTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 83
+  },
+  "apps/web/components/platform/AgentModelRoutingCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 58
+  },
+  "apps/web/components/platform/AgentProviderSelect.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/platform/AiOperationsMap.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 533
+  },
+  "apps/web/components/platform/AiReadinessHeaderLink.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/platform/AiReadinessSummaryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/platform/AsyncOperationsTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 28
+  },
+  "apps/web/components/platform/AuditTabNav.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/platform/AuthorityMatrixPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 51
+  },
+  "apps/web/components/platform/BuildStudioConfigForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 2,
+    "textMass": 389
+  },
+  "apps/web/components/platform/BuildStudioProviderControls.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/platform/CapabilityInventoryClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/components/platform/CapabilityJournalClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/platform/CliPoolStatusPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 26
+  },
+  "apps/web/components/platform/ConnectGrokCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 73
+  },
+  "apps/web/components/platform/ContributorMcpReadinessCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 67
+  },
+  "apps/web/components/platform/DelegationChainPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/components/platform/DelegationGrantPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/platform/DeliberationLensPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 46
+  },
+  "apps/web/components/platform/EffectivePermissionsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 95
+  },
+  "apps/web/components/platform/EndpointPerformancePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 64
+  },
+  "apps/web/components/platform/GovernanceOverviewPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/components/platform/IntegrationCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/platform/IntegrationCatalogFilters.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/platform/LocalOnlyInferenceToggle.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 80
+  },
+  "apps/web/components/platform/McpServiceRow.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/platform/McpSyncButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/components/platform/ModelCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 96
+  },
+  "apps/web/components/platform/ModelClassBadge.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/platform/ModelSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 73
+  },
+  "apps/web/components/platform/OAuthConnectionStatus.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 28
+  },
+  "apps/web/components/platform/OllamaHardwareInfo.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/platform/OllamaManagement.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 297
+  },
+  "apps/web/components/platform/OperationsMapLiveShell.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/components/platform/OperationsTopologyCanvas.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 36
+  },
+  "apps/web/components/platform/PhaseRemediationActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/platform/PlatformBanner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/components/platform/ProposalHistoryClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/platform/ProviderAccountPostureForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 215
+  },
+  "apps/web/components/platform/ProviderCostSourcePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/components/platform/ProviderDetailForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 186
+  },
+  "apps/web/components/platform/ProviderSuitabilityGuide.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 109
+  },
+  "apps/web/components/platform/ProviderTrustEvidencePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 49
+  },
+  "apps/web/components/platform/ProvisionEngineButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/platform/RecipePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/platform/RouteDecisionLog.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 64
+  },
+  "apps/web/components/platform/RouteDecisionLogClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 51
+  },
+  "apps/web/components/platform/RoutingProfilePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 88
+  },
+  "apps/web/components/platform/ScheduledJobsTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/platform/ServedContextSummary.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/platform/ServiceActivationForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 80
+  },
+  "apps/web/components/platform/ServiceRow.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/components/platform/ServiceSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/components/platform/SkillCuratorReportPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/platform/SkillEvidencePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/platform/SkillLifecycleControls.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/platform/SkillProposalsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/components/platform/SkillRevisionHistoryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/components/platform/SkillsObservatoryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 95
+  },
+  "apps/web/components/platform/StalledTaskRecoveryActions.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 61
+  },
+  "apps/web/components/platform/TokenSpendPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 49
+  },
+  "apps/web/components/platform/ToolExecutionLogClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/platform/ToolInventoryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/components/platform/a2a-interaction-graph.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 38
+  },
+  "apps/web/components/platform/ai-operations-map-prefs.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/components/platform/authority/BindingBootstrapPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 96
+  },
+  "apps/web/components/platform/authority/BindingDetailDrawer.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 80
+  },
+  "apps/web/components/platform/authority/BindingDetailPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/components/platform/authority/BindingEvidencePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/platform/authority/BindingFilters.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 26
+  },
+  "apps/web/components/platform/authority/BindingList.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/platform/authority/BootstrapBindingsButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/platform/authority/CreateDraftBindingButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/platform/build-studio-route-copy.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/components/platform/coworker-record/CapabilitiesEditor.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 51
+  },
+  "apps/web/components/platform/coworker-record/CooConversationalNameCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/platform/coworker-record/CoworkerProactivitySetting.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/platform/coworker-record/CoworkerRecordTabs.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/platform/coworker-record/NeedsAndPlaybooksPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 64
+  },
+  "apps/web/components/platform/coworker-record/ProfessionCorpusPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 60
+  },
+  "apps/web/components/platform/coworker-record/RecordActionsMenu.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/platform/coworker-record/RosterView.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 63
+  },
+  "apps/web/components/platform/coworker-record/WorkforceSummaryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/platform/coworker-record/panels.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 269
+  },
+  "apps/web/components/platform/coworker-service-catalog/CoworkerCatalogView.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 57
+  },
+  "apps/web/components/platform/development/change-lanes/ChangeLaneSourceSummary.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/platform/development/change-lanes/ChangeLaneTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/platform/development/change-lanes/ChangeLanesDashboard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 84
+  },
+  "apps/web/components/platform/development/change-lanes/LocalRepositoryHealthCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 43
+  },
+  "apps/web/components/platform/development/change-lanes/RefreshContributorInventoryButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 339
+  },
+  "apps/web/components/platform/federation-links/FederationLinksAdminClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 326
+  },
+  "apps/web/components/platform/federation-links/PartnerBusinessPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 70
+  },
+  "apps/web/components/platform/federation-proposals/FederationProposalsClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/platform/identity/AgentIdentityPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 50
+  },
+  "apps/web/components/platform/identity/ApplicationAssignmentsPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 68
+  },
+  "apps/web/components/platform/identity/AuthorizationBundlePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 133
+  },
+  "apps/web/components/platform/identity/DirectoryAuthoritiesPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 93
+  },
+  "apps/web/components/platform/identity/FederationAuthorityCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/platform/identity/GroupMembershipPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 75
+  },
+  "apps/web/components/platform/identity/IdentityPlaceholderPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 35
+  },
+  "apps/web/components/platform/identity/IdentityProjectionSummaryGrid.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/platform/identity/IdentityTabNav.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/platform/identity/PrincipalDirectoryPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/platform/operations-topology-layout.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/platform/operations-topology-style.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/platform/platform-nav.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 97
+  },
+  "apps/web/components/platform/service-desk/ServiceTicketsTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/portal-context/EvidenceSummaryList.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/portal-context/HiveMindCandidateList.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/portal-context/PortalContextOverlayDrawer.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/portal-context/PortalContextStrip.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/portal-context/PortalContextTabs.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/portal/PortalWorkCaseDetail.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/portal/PortalWorkCases.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 39
+  },
+  "apps/web/components/portfolio/CompletenessStrip.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 24
+  },
+  "apps/web/components/portfolio/CoveragePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/portfolio/DigitalProductDetail.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 39
+  },
+  "apps/web/components/portfolio/PlatformHealthStrip.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/components/portfolio/PortfolioNodeDetail.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/portfolio/PortfolioNodeEnrichment.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 59
+  },
+  "apps/web/components/portfolio/PortfolioNodeGovernance.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/portfolio/PortfolioOverview.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 26
+  },
+  "apps/web/components/portfolio/PortfolioTree.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/portfolio/ProductList.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/portfolio/architecture/BusinessCapabilityForms.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/components/portfolio/architecture/BusinessCapabilityMap.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 31
+  },
+  "apps/web/components/portfolio/architecture/BusinessCapabilityMapClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/portfolio/architecture/CapabilityDetailPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 39
+  },
+  "apps/web/components/portfolio/architecture/CapabilityMapTiles.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/portfolio/architecture/OptimizationCockpitSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 68
+  },
+  "apps/web/components/proactivity/ProactivityLevelControl.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/proactivity/ProactivityRosterList.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/product/BusinessModelRolePanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/components/product/BusinessModelSelector.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/components/product/ProductSupplyChainPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 49
+  },
+  "apps/web/components/product/ProductTabNav.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 64
+  },
+  "apps/web/components/queue/QueueHealthSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 28
+  },
+  "apps/web/components/rental/RentalDeskPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 41
+  },
+  "apps/web/components/restaurant-cockpit/ServiceReadinessCockpit.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/components/setup/CooNameSetupCard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 45
+  },
+  "apps/web/components/setup/SetupActionButtons.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/components/setup/SetupOverlay.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/setup/SetupProgressBar.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/setup/SetupStepNav.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/shell/AppRail.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 58
+  },
+  "apps/web/components/shell/DeploymentSkewBanner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 36
+  },
+  "apps/web/components/shell/Header.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/shell/ShellBannerOverlay.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/shell/ShellBreadcrumb.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/shell/ShellSignOut.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/shell/StatusBanner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/shell/UpdatePendingBannerClient.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/components/social-buttons.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/storefront-admin/AnimalsManager.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 40
+  },
+  "apps/web/components/storefront-admin/ArchetypeActivationSummary.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 15
+  },
+  "apps/web/components/storefront-admin/BrandExtractionForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 64
+  },
+  "apps/web/components/storefront-admin/BrandExtractionSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/components/storefront-admin/BrandPreview.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 19
+  },
+  "apps/web/components/storefront-admin/FinancialSetupStep.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 99
+  },
+  "apps/web/components/storefront-admin/ItemFormDialog.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 109
+  },
+  "apps/web/components/storefront-admin/ItemsManager.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 30
+  },
+  "apps/web/components/storefront-admin/MediaUploader.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/components/storefront-admin/ScheduleEditor.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 43
+  },
+  "apps/web/components/storefront-admin/SectionsManager.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/components/storefront-admin/ServiceLinesPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 20
+  },
+  "apps/web/components/storefront-admin/SetupWizard.tsx": {
+    "vocabulary": 7,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 254
+  },
+  "apps/web/components/storefront-admin/StorefrontDashboard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 39
+  },
+  "apps/web/components/storefront-admin/StorefrontInbox.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 124
+  },
+  "apps/web/components/storefront-admin/StorefrontSetupPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/components/storefront-admin/TablesNowView.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/storefront-admin/TeamManager.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 52
+  },
+  "apps/web/components/storefront-admin/UnitsManager.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 89
+  },
+  "apps/web/components/storefront-admin/content-editing-ui.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 26
+  },
+  "apps/web/components/storefront-admin/storefront-nav.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/storefront/BookingForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 1,
+    "textMass": 44
+  },
+  "apps/web/components/storefront/DonationForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 2,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/components/storefront/InquiryForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 2,
+    "longSentences": 0,
+    "textMass": 30
+  },
+  "apps/web/components/storefront/OrderForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 0,
+    "textMass": 43
+  },
+  "apps/web/components/storefront/SectionRenderer.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 45
+  },
+  "apps/web/components/storefront/SignInForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 16
+  },
+  "apps/web/components/storefront/SignUpForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/storefront/SlotBookingFlow.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 12,
+    "longSentences": 0,
+    "textMass": 178
+  },
+  "apps/web/components/storefront/StorefrontTrustFooter.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/components/storefront/StorefrontUnavailable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/storefront/SubmissionResultView.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 32
+  },
+  "apps/web/components/storefront/sections/AnimalsSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 0,
+    "textMass": 10
+  },
+  "apps/web/components/storefront/sections/DisclosuresSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 1,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/storefront/sections/GallerySection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/storefront/sections/LoanCalculatorSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/components/storefront/sections/TeamSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/storefront/sections/TestimonialsSection.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/twin/OutcomesStrip.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/twin/TwinKitShowcase.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/twin/TwinView.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/twin/ValueStreamStrip.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/twin/WorkItem.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/twin/demo-snapshot.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/twin/floor/FloorPlanCanvas.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 4
+  },
+  "apps/web/components/ui/DatePicker.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/ui/Dialog.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/components/ui/ReferenceTypeahead.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 54
+  },
+  "apps/web/components/ui/Spinner.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/ui/form/FormField.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 67
+  },
+  "apps/web/components/ui/form/SelectField.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/ui/form/styles.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 93
+  },
+  "apps/web/components/ui/report-kit/Chart.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 28
+  },
+  "apps/web/components/ui/report-kit/DataTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/ui/report-kit/ExportButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/ui/report-kit/FilterBar.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/wiki/BusinessStanceForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 76
+  },
+  "apps/web/components/wiki/CraftOverrideForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 60
+  },
+  "apps/web/components/wiki/DecisionAuditTable.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/wiki/DecisionDisciplineHub.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/wiki/OrgDecisionCaptureList.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 53
+  },
+  "apps/web/components/wiki/VoiceProfileSetup.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 1,
+    "textMass": 277
+  },
+  "apps/web/components/wiki/WikiBodyRenderer.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/wiki/WikiPageEditor.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 56
+  },
+  "apps/web/components/wiki/WikiPageViewer.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 8
+  },
+  "apps/web/components/wiki/WikiSourceCitations.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/workbooks/AddColumnButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 115
+  },
+  "apps/web/components/workbooks/CreateTableButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/workbooks/CreateWorkbookButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/workbooks/Grid.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 2,
+    "textMass": 458
+  },
+  "apps/web/components/workbooks/GridCalendar.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/components/workbooks/GridPanels.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 212
+  },
+  "apps/web/components/workbooks/GridViewsMenu.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 17
+  },
+  "apps/web/components/workbooks/ImportSheetButton.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 20
+  },
+  "apps/web/components/workbooks/KanbanBoard.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 14
+  },
+  "apps/web/components/workbooks/RecordDetailModal.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 33
+  },
+  "apps/web/components/workbooks/cell-editors.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 42
+  },
+  "apps/web/components/workbooks/grid-filter-builder.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/components/workbooks/grid-footer-summary.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 3
+  },
+  "apps/web/components/workbooks/grid-named-views.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 11
+  },
+  "apps/web/components/workbooks/grid-pivot.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 18
+  },
+  "apps/web/components/workbooks/grid-reorder-group.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 20
+  },
+  "apps/web/components/workbooks/grid-summary.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 6
+  },
+  "apps/web/components/workbooks/grid-view-state.ts": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 75
+  },
+  "apps/web/components/workspace-home/LocalOnlyProviderNotice.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 27
+  },
+  "apps/web/components/workspace-home/OperatorCockpit.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 47
+  },
+  "apps/web/components/workspace-home/UnconfiguredWorkspaceHomeNotice.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/components/workspace-home/VerticalWorkspaceHome.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 21
+  },
+  "apps/web/components/workspace-home/WorkspaceAreaLauncher.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 2
+  },
+  "apps/web/components/workspace-home/WorkspaceTwinHero.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 5
+  },
+  "apps/web/components/workspace-home/WorkspaceTwinPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 7
+  },
+  "apps/web/components/workspace/ActivityFeed.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/workspace/BusinessAgenda.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 25
+  },
+  "apps/web/components/workspace/BusinessCommandCenter.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 13
+  },
+  "apps/web/components/workspace/CalendarAgentScheduler.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 34
+  },
+  "apps/web/components/workspace/CalendarDetailPopover.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 47
+  },
+  "apps/web/components/workspace/CalendarEventPopover.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 9
+  },
+  "apps/web/components/workspace/CalendarSyncPanel.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 29
+  },
+  "apps/web/components/workspace/PlatformReadinessMatrix.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 74
+  },
+  "apps/web/components/workspace/WorkCaseAttentionLens.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 57
+  },
+  "apps/web/components/workspace/WorkCaseDetailView.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 22
+  },
+  "apps/web/components/workspace/WorkItemCommentBox.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 12
+  },
+  "apps/web/components/workspace/WorkspaceCalendar.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 39
+  }
+}


### PR DESCRIPTION
## Summary

BI-88D8C725 (EP-UX-SYSTEM §6 L4 / §8.1 D6). Adds an in-loop prose-lint gate over UI copy so a PR gets the signal in seconds, before the rendered UX sweep runs. RC1 named the gap directly: nothing upstream penalizes text mass, and the L4 route sweep only answers after a full CI render.

Four rule families, all **reusing** existing signals instead of reinventing them:

- **vocabulary** — hardcoded archetype-specific stakeholder/portal terms (the exact strings `getVocabulary()` / `resolveVocabularyKey` resolve to, e.g. "Guests", "Patient Portal") found outside the vocabulary system, in a surface that should stay archetype-neutral.
- **genericLabels** — `owner-first/ux-audit.ts`'s `countGenericDecisionLabels` / `GENERIC_DECISION_LABELS`, reused unmodified, applied directly to source text instead of rendered HTML — "applied at source" per the BI.
- **readability** — `lib/readability/`'s Flesch–Kincaid grade (`analyzeReadability` + `withinReadingLevel`), reused unmodified. This policy existed but was unwired; this PR wires it into marketing/storefront copy strings.
- **longSentences / textMass** — sentence-length and per-file prose-mass heuristics (the gap RC1 named).

Enforcement: **warn-then-ratchet with a frozen baseline**, the same shape as `scripts/check-style-drift.mjs` — `scripts/prose-lint-baseline.json` is a per-file, per-axis baseline that may shrink but never grow. Pre-existing violations are not failed; a PR that adds a NEW violating file, or grows an axis beyond its baseline, fails.

## Approach taken — and why it deviates from "install Vale (vale.sh)"

The BI's primary ask was the real Vale binary + a DPF style package. I did not ship that, and want to be explicit about why rather than silently substituting.

Vale's rule engine is YAML + [Tengo scripts](https://vale.sh/docs/keys/scope) — it can validate structure and run a sandboxed scripting language, but it **cannot import a TypeScript function**. Three of the four rules the BI asked for are explicitly framed as "reuse the existing X, do not reinvent" (`resolveVocabularyKey`'s terms, `countGenericDecisionLabels`, the `lib/readability/` policy). Implementing those in Vale would mean reimplementing each one's logic in Tengo — forking the lint-time definition of "generic decision label" or "readable" away from the runtime one, which is exactly the kind of drift the BI's reuse instruction is trying to prevent.

To be clear this isn't a sandboxed-environment workaround: network to both `github.com` (Vale releases) and `registry.npmjs.org` was reachable while building this. The substitution is because the target rule engine can't call into TypeScript, not because the binary couldn't be fetched. Given that, this ships as the Node/TS ratchet the BI itself names as the fallback path, shaped exactly like `check-style-drift.mjs` (which is itself a plain Node script, not a Vale wrapper) — same baseline file / ratchet-only-improves / CI-wiring contract already established in this repo for the hex-color and design-token ratchets.

## What's new

- `scripts/check-prose-lint.ts` — the guard. Imports `getVocabulary`/`resolveVocabularyKey`'s consumer (`apps/web/lib/storefront/archetype-vocabulary.ts`, `.../industries.ts`), `countGenericDecisionLabels` (`apps/web/lib/owner-first/ux-audit.ts`), and `analyzeReadability`/`withinReadingLevel` (`packages/validators/src/readability.ts`) directly — no reimplementation.
- `scripts/check-prose-lint.test.ts` — 15 unit tests (`tsx --test`), each rule proven against a known-bad and a known-good string, plus the ratchet-shape contract (new file / grown axis / stable baseline never fails).
- `scripts/prose-lint-baseline.json` — generated baseline (`tsx scripts/check-prose-lint.ts --update`): 1081 files with a signal (16 vocabulary / 1 genericLabels / 73 readability / 52 longSentences / 44135 textMass words). None of these are failed by this PR — only future growth is.
- `.github/workflows/ci.yml` — new `Prose Lint Guard` job (gated on `heavy`, like Typecheck, since it needs the full workspace install to import the real modules rather than a zero-dependency script).
- `package.json` — `check:prose-lint` / `check:prose-lint:test` scripts.

## Test plan

- [x] `tsx --test scripts/check-prose-lint.test.ts` — 15/15 pass locally
- [x] `tsx scripts/check-prose-lint.ts` — passes clean against the freshly generated baseline
- [x] `tsx scripts/check-prose-lint.ts --update` — regenerates the baseline deterministically
- [x] pre-commit scoped typecheck + gitleaks secret scan — both passed
- [x] `node scripts/check-module-size.mjs` — no new oversized files (326 LOC, well under the 800 LOC ratchet)
- [x] Swept `gh pr list --search "vale"/"prose"/"88D8C725"` for overlap — none open
- [ ] CI: Prose Lint Guard job (new) + Typecheck / Production Build / DCO / Unit Tests (required checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)