### PR TITLE
feat(mcp): add read-only get_ai_platform_posture tool (BI-5903D447)

### DIFF
--- a/apps/web/lib/ai-platform-posture/get-ai-platform-posture.test.ts
+++ b/apps/web/lib/ai-platform-posture/get-ai-platform-posture.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  prisma: {
+    modelProvider: { findMany: vi.fn() },
+    modelProfile: { findMany: vi.fn() },
+    routeDecisionLog: { findMany: vi.fn() },
+    routeOutcome: { findMany: vi.fn() },
+    scheduledAgentTask: { findMany: vi.fn() },
+    scheduledJob: { findMany: vi.fn() },
+  },
+}));
+vi.mock("@dpf/db", () => db);
+
+const providerData = vi.hoisted(() => ({
+  getTokenSpendByProvider: vi.fn(),
+  getTokenSpendByAgent: vi.fn(),
+}));
+vi.mock("@/lib/inference/ai-provider-data", () => providerData);
+
+import { loadAiPlatformPosture } from "./get-ai-platform-posture";
+
+function baseMocks() {
+  db.prisma.modelProvider.findMany.mockResolvedValue([]);
+  db.prisma.modelProfile.findMany.mockResolvedValue([]);
+  db.prisma.routeDecisionLog.findMany.mockResolvedValue([]);
+  db.prisma.routeOutcome.findMany.mockResolvedValue([]);
+  db.prisma.scheduledAgentTask.findMany.mockResolvedValue([]);
+  db.prisma.scheduledJob.findMany.mockResolvedValue([]);
+  providerData.getTokenSpendByProvider.mockResolvedValue([]);
+  providerData.getTokenSpendByAgent.mockResolvedValue([]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  baseMocks();
+});
+
+describe("loadAiPlatformPosture", () => {
+  it("defaults to a 24h window and excludes retired providers/models", async () => {
+    const posture = await loadAiPlatformPosture();
+    expect(posture.windowHours).toBe(24);
+    expect(db.prisma.modelProvider.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { retiredAt: null } }),
+    );
+    expect(db.prisma.modelProfile.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { retiredAt: null } }),
+    );
+  });
+
+  it("caps windowHours at 168 and includes retired rows when requested", async () => {
+    const posture = await loadAiPlatformPosture({ windowHours: 9999, includeRetired: true });
+    expect(posture.windowHours).toBe(168);
+    expect(db.prisma.modelProvider.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: {} }));
+    expect(db.prisma.modelProfile.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: {} }));
+  });
+
+  it("ignores a non-positive windowHours and falls back to 24", async () => {
+    const posture = await loadAiPlatformPosture({ windowHours: -5 });
+    expect(posture.windowHours).toBe(24);
+  });
+
+  it("maps provider rows into the posture shape, serializing retiredAt", async () => {
+    db.prisma.modelProvider.findMany.mockResolvedValue([
+      {
+        providerId: "anthropic",
+        name: "Anthropic",
+        status: "active",
+        category: "direct",
+        capabilityTier: "frontier",
+        costBand: "premium",
+        cliEngine: "claude",
+        endpointType: "llm",
+        avgLatencyMs: 850,
+        recentFailureRate: 0.01,
+        maxConcurrency: 8,
+        toolFidelity: 92,
+        reasoning: 95,
+        codegen: 90,
+        retiredAt: null,
+      },
+    ]);
+    const posture = await loadAiPlatformPosture();
+    expect(posture.providers).toEqual([
+      {
+        providerId: "anthropic",
+        name: "Anthropic",
+        status: "active",
+        category: "direct",
+        capabilityTier: "frontier",
+        costBand: "premium",
+        cliEngine: "claude",
+        endpointType: "llm",
+        avgLatencyMs: 850,
+        recentFailureRate: 0.01,
+        maxConcurrency: 8,
+        toolFidelity: 92,
+        reasoning: 95,
+        codegen: 90,
+        retiredAt: null,
+      },
+    ]);
+  });
+
+  it("delegates token spend to the existing groupBy readers for the current calendar month", async () => {
+    providerData.getTokenSpendByProvider.mockResolvedValue([
+      { providerId: "anthropic", providerName: "Anthropic", totalInputTokens: 100, totalOutputTokens: 50, totalCostUsd: 1.5, provenance: {} },
+    ]);
+    providerData.getTokenSpendByAgent.mockResolvedValue([
+      { agentId: "platform-engineer", agentName: "Platform Engineer", totalInputTokens: 40, totalOutputTokens: 20, totalCostUsd: 0.5 },
+    ]);
+    const posture = await loadAiPlatformPosture();
+    expect(providerData.getTokenSpendByProvider).toHaveBeenCalledTimes(1);
+    expect(providerData.getTokenSpendByAgent).toHaveBeenCalledTimes(1);
+    expect(posture.tokenSpend.byProvider).toEqual([
+      { providerId: "anthropic", providerName: "Anthropic", inputTokens: 100, outputTokens: 50, costUsd: 1.5 },
+    ]);
+    expect(posture.tokenSpend.byAgent).toEqual([
+      { agentId: "platform-engineer", agentName: "Platform Engineer", inputTokens: 40, outputTokens: 20, costUsd: 0.5 },
+    ]);
+  });
+
+  it("computes failover-chain fallback rate from RouteDecisionLog.fallbacksUsed and RouteOutcome.fallbackOccurred", async () => {
+    const now = new Date();
+    db.prisma.routeDecisionLog.findMany.mockResolvedValue([
+      { agentId: "a1", selectedEndpointId: "anthropic:claude-sonnet", selectedModelId: "claude-sonnet", taskType: "code", fallbackChain: ["anthropic", "openai"], fallbacksUsed: ["openai"], createdAt: now },
+      { agentId: "a2", selectedEndpointId: "openai:gpt-5", selectedModelId: "gpt-5", taskType: "chat", fallbackChain: [], fallbacksUsed: null, createdAt: now },
+    ]);
+    db.prisma.routeOutcome.findMany.mockResolvedValue([
+      { fallbackOccurred: true, providerErrorCode: "rate_limited" },
+      { fallbackOccurred: false, providerErrorCode: null },
+    ]);
+
+    const posture = await loadAiPlatformPosture();
+    expect(posture.failoverChain.decisionCount).toBe(2);
+    expect(posture.failoverChain.fallbacksUsedCount).toBe(1);
+    expect(posture.failoverChain.fallbackRate).toBeCloseTo(0.5);
+    expect(posture.failoverChain.outcomeCount).toBe(2);
+    expect(posture.failoverChain.outcomeFallbackCount).toBe(1);
+    expect(posture.failoverChain.outcomeFallbackRate).toBeCloseTo(0.5);
+    expect(posture.failoverChain.distinctProviderErrorCodes).toEqual(["rate_limited"]);
+    expect(posture.failoverChain.recentFallbackChains).toEqual([
+      { agentId: "a1", taskType: "code", chain: ["anthropic", "openai"], occurredAt: now.toISOString() },
+    ]);
+  });
+
+  it("returns zero rates when there are no route decisions/outcomes in the window", async () => {
+    const posture = await loadAiPlatformPosture();
+    expect(posture.failoverChain.fallbackRate).toBe(0);
+    expect(posture.failoverChain.outcomeFallbackRate).toBe(0);
+  });
+
+  it("derives agent-to-provider assignment from the most-routed-to provider per agent", async () => {
+    const older = new Date(Date.now() - 60_000);
+    const newer = new Date();
+    db.prisma.routeDecisionLog.findMany.mockResolvedValue([
+      { agentId: "platform-engineer", selectedEndpointId: "anthropic:claude-sonnet", selectedModelId: "claude-sonnet", taskType: "code", fallbackChain: [], fallbacksUsed: null, createdAt: older },
+      { agentId: "platform-engineer", selectedEndpointId: "anthropic:claude-haiku", selectedModelId: "claude-haiku", taskType: "chat", fallbackChain: [], fallbacksUsed: null, createdAt: newer },
+      { agentId: "platform-engineer", selectedEndpointId: "openai:gpt-5", selectedModelId: "gpt-5", taskType: "chat", fallbackChain: [], fallbacksUsed: null, createdAt: older },
+      { agentId: null, selectedEndpointId: "openai:gpt-5", selectedModelId: "gpt-5", taskType: "chat", fallbackChain: [], fallbacksUsed: null, createdAt: older },
+      { agentId: "inventory-specialist", selectedEndpointId: "none", selectedModelId: null, taskType: "chat", fallbackChain: [], fallbacksUsed: null, createdAt: older },
+    ]);
+
+    const posture = await loadAiPlatformPosture();
+    expect(posture.agentProviderAssignments).toEqual([
+      {
+        agentId: "platform-engineer",
+        currentProviderId: "anthropic",
+        currentModelId: "claude-haiku",
+        decisionCount: 2,
+        lastDecisionAt: newer.toISOString(),
+      },
+    ]);
+  });
+
+  it("summarizes scheduled tasks and jobs with active/failing counts", async () => {
+    db.prisma.scheduledAgentTask.findMany.mockResolvedValue([
+      { taskId: "agent-task-1", agentId: "platform-engineer", title: "Refresh posture", isActive: true, nextRunAt: null, lastStatus: "ok", lastError: null },
+      { taskId: "agent-task-2", agentId: "platform-engineer", title: "Broken task", isActive: true, nextRunAt: null, lastStatus: "error", lastError: "boom" },
+      { taskId: "agent-task-3", agentId: "platform-engineer", title: "Inactive task", isActive: false, nextRunAt: null, lastStatus: null, lastError: null },
+    ]);
+    db.prisma.scheduledJob.findMany.mockResolvedValue([
+      { jobId: "job-1", name: "Job 1", schedule: "daily", enabled: true, nextRunAt: null, lastStatus: "ok", lastError: null },
+      { jobId: "job-2", name: "Job 2", schedule: "daily", enabled: false, nextRunAt: null, lastStatus: "error", lastError: "boom" },
+    ]);
+
+    const posture = await loadAiPlatformPosture();
+    expect(posture.scheduledTasks.counts).toEqual({
+      activeAgentTasks: 2,
+      failingAgentTasks: 1,
+      enabledJobs: 1,
+      failingJobs: 1,
+    });
+  });
+});

--- a/apps/web/lib/ai-platform-posture/get-ai-platform-posture.ts
+++ b/apps/web/lib/ai-platform-posture/get-ai-platform-posture.ts
@@ -1,0 +1,413 @@
+// apps/web/lib/ai-platform-posture/get-ai-platform-posture.ts
+//
+// BI-5903D447 — the scheduled task that refreshes AI platform posture
+// knowledge articles needs one authoritative, real-time read of AI-layer
+// state: provider status/config, ModelProfile tiers/capabilities/toolFidelity,
+// token spend per provider and per agent, failover-chain integrity,
+// agent-to-provider assignment, and scheduled-task status.
+// mcp__dpf__list_all_capability_needs and mcp__dpf__search_tool_marketplace
+// only surface partial/derived capability-needs feedback — this reads the
+// authoritative Prisma tables directly so posture articles are grounded in
+// real data rather than inference.
+//
+// Read-only aggregation. No mutation of ModelProvider / ModelProfile /
+// ScheduledAgentTask / ScheduledJob / RouteDecisionLog / RouteOutcome.
+//
+// Reuses the existing per-domain readers rather than re-deriving:
+//   - getTokenSpendByProvider / getTokenSpendByAgent (apps/web/lib/inference/
+//     ai-provider-data.ts) already groupBy TokenUsage by providerId/agentId —
+//     the token-spend section delegates to them verbatim.
+//   - providerFromEndpoint (apps/web/lib/ai-operations-map/projection-helpers.ts)
+//     already knows how to recover a providerId out of a `provider:model`
+//     selectedEndpointId — used to resolve agent-to-provider assignment.
+// Providers, model profiles, failover-chain integrity, and scheduled-task
+// status have no existing single-purpose reader (confirmed by grep before
+// writing this), so those sections run their own scoped, secret-free selects.
+
+import { prisma } from "@dpf/db";
+import { getTokenSpendByProvider, getTokenSpendByAgent } from "@/lib/inference/ai-provider-data";
+import { providerFromEndpoint } from "@/lib/ai-operations-map/projection-helpers";
+
+export type AiPlatformPostureOptions = {
+  /** Lookback window, in hours, for the failover-chain and agent-assignment signals. Default 24, max 168 (7 days). */
+  windowHours?: number;
+  /** Include retired providers/models in the result. Default false. */
+  includeRetired?: boolean;
+};
+
+export type AiPlatformPostureProvider = {
+  providerId: string;
+  name: string;
+  status: string;
+  category: string;
+  capabilityTier: string;
+  costBand: string;
+  cliEngine: string | null;
+  endpointType: string;
+  avgLatencyMs: number | null;
+  recentFailureRate: number;
+  maxConcurrency: number | null;
+  toolFidelity: number;
+  reasoning: number;
+  codegen: number;
+  retiredAt: string | null;
+};
+
+export type AiPlatformPostureModel = {
+  providerId: string;
+  modelId: string;
+  friendlyName: string;
+  capabilityCategory: string;
+  costTier: string;
+  qualityTier: string | null;
+  modelStatus: string;
+  toolFidelity: number;
+  evalCount: number;
+  lastEvalAt: string | null;
+  stabilityScore: number | null;
+  retiredAt: string | null;
+};
+
+export type AiPlatformPostureSpend = {
+  period: { year: number; month: number };
+  byProvider: Array<{ providerId: string; providerName: string; inputTokens: number; outputTokens: number; costUsd: number }>;
+  byAgent: Array<{ agentId: string; agentName: string; inputTokens: number; outputTokens: number; costUsd: number }>;
+};
+
+export type AiPlatformPostureFailover = {
+  windowStart: string;
+  windowEnd: string;
+  decisionCount: number;
+  fallbacksUsedCount: number;
+  fallbackRate: number;
+  outcomeCount: number;
+  outcomeFallbackCount: number;
+  outcomeFallbackRate: number;
+  distinctProviderErrorCodes: string[];
+  recentFallbackChains: Array<{ agentId: string | null; taskType: string; chain: string[]; occurredAt: string }>;
+};
+
+export type AiPlatformPostureAssignment = {
+  agentId: string;
+  currentProviderId: string;
+  currentModelId: string | null;
+  decisionCount: number;
+  lastDecisionAt: string;
+};
+
+export type AiPlatformPostureScheduledTasks = {
+  agentTasks: Array<{
+    taskId: string;
+    agentId: string;
+    title: string;
+    isActive: boolean;
+    nextRunAt: string | null;
+    lastStatus: string | null;
+    lastError: string | null;
+  }>;
+  jobs: Array<{
+    jobId: string;
+    name: string;
+    schedule: string;
+    enabled: boolean;
+    nextRunAt: string | null;
+    lastStatus: string | null;
+    lastError: string | null;
+  }>;
+  counts: { activeAgentTasks: number; failingAgentTasks: number; enabledJobs: number; failingJobs: number };
+};
+
+export type AiPlatformPosture = {
+  generatedAt: string;
+  windowHours: number;
+  providers: AiPlatformPostureProvider[];
+  modelProfiles: AiPlatformPostureModel[];
+  tokenSpend: AiPlatformPostureSpend;
+  failoverChain: AiPlatformPostureFailover;
+  agentProviderAssignments: AiPlatformPostureAssignment[];
+  scheduledTasks: AiPlatformPostureScheduledTasks;
+};
+
+const ROUTE_ROW_LIMIT = 500;
+const RECENT_FALLBACK_CHAIN_SAMPLE = 10;
+const MAX_WINDOW_HOURS = 168;
+
+export async function loadAiPlatformPosture(
+  options?: AiPlatformPostureOptions,
+): Promise<AiPlatformPosture> {
+  const requestedHours = options?.windowHours;
+  const windowHours =
+    typeof requestedHours === "number" && requestedHours > 0
+      ? Math.min(requestedHours, MAX_WINDOW_HOURS)
+      : 24;
+  const includeRetired = options?.includeRetired ?? false;
+
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - windowHours * 60 * 60 * 1000);
+  const createdAtWindow = { createdAt: { gte: windowStart, lte: now } };
+  const spendPeriod = { year: now.getUTCFullYear(), month: now.getUTCMonth() + 1 };
+
+  const [
+    providerRows,
+    modelProfileRows,
+    spendByProvider,
+    spendByAgent,
+    routeDecisions,
+    routeOutcomes,
+    scheduledAgentTasks,
+    scheduledJobs,
+  ] = await Promise.all([
+    prisma.modelProvider.findMany({
+      where: includeRetired ? {} : { retiredAt: null },
+      orderBy: { name: "asc" },
+      select: {
+        providerId: true,
+        name: true,
+        status: true,
+        category: true,
+        capabilityTier: true,
+        costBand: true,
+        cliEngine: true,
+        endpointType: true,
+        avgLatencyMs: true,
+        recentFailureRate: true,
+        maxConcurrency: true,
+        toolFidelity: true,
+        reasoning: true,
+        codegen: true,
+        retiredAt: true,
+      },
+    }),
+    prisma.modelProfile.findMany({
+      where: includeRetired ? {} : { retiredAt: null },
+      orderBy: [{ providerId: "asc" }, { modelId: "asc" }],
+      select: {
+        providerId: true,
+        modelId: true,
+        friendlyName: true,
+        capabilityCategory: true,
+        costTier: true,
+        qualityTier: true,
+        modelStatus: true,
+        toolFidelity: true,
+        evalCount: true,
+        lastEvalAt: true,
+        stabilityScore: true,
+        retiredAt: true,
+      },
+    }),
+    getTokenSpendByProvider(spendPeriod),
+    getTokenSpendByAgent(spendPeriod),
+    prisma.routeDecisionLog.findMany({
+      where: createdAtWindow,
+      orderBy: { createdAt: "desc" },
+      take: ROUTE_ROW_LIMIT,
+      select: {
+        agentId: true,
+        selectedEndpointId: true,
+        selectedModelId: true,
+        taskType: true,
+        fallbackChain: true,
+        fallbacksUsed: true,
+        createdAt: true,
+      },
+    }),
+    prisma.routeOutcome.findMany({
+      where: createdAtWindow,
+      select: { fallbackOccurred: true, providerErrorCode: true },
+    }),
+    prisma.scheduledAgentTask.findMany({
+      orderBy: { nextRunAt: "asc" },
+      select: {
+        taskId: true,
+        agentId: true,
+        title: true,
+        isActive: true,
+        nextRunAt: true,
+        lastStatus: true,
+        lastError: true,
+      },
+    }),
+    prisma.scheduledJob.findMany({
+      orderBy: { nextRunAt: "asc" },
+      select: {
+        jobId: true,
+        name: true,
+        schedule: true,
+        enabled: true,
+        nextRunAt: true,
+        lastStatus: true,
+        lastError: true,
+      },
+    }),
+  ]);
+
+  // ── Providers ────────────────────────────────────────────────────────────
+  const providers: AiPlatformPostureProvider[] = providerRows.map((p) => ({
+    providerId: p.providerId,
+    name: p.name,
+    status: p.status,
+    category: p.category,
+    capabilityTier: p.capabilityTier,
+    costBand: p.costBand,
+    cliEngine: p.cliEngine,
+    endpointType: p.endpointType,
+    avgLatencyMs: p.avgLatencyMs,
+    recentFailureRate: p.recentFailureRate,
+    maxConcurrency: p.maxConcurrency,
+    toolFidelity: p.toolFidelity,
+    reasoning: p.reasoning,
+    codegen: p.codegen,
+    retiredAt: p.retiredAt?.toISOString() ?? null,
+  }));
+
+  // ── Model profiles ──────────────────────────────────────────────────────
+  const modelProfiles: AiPlatformPostureModel[] = modelProfileRows.map((m) => ({
+    providerId: m.providerId,
+    modelId: m.modelId,
+    friendlyName: m.friendlyName,
+    capabilityCategory: m.capabilityCategory,
+    costTier: m.costTier,
+    qualityTier: m.qualityTier,
+    modelStatus: m.modelStatus,
+    toolFidelity: m.toolFidelity,
+    evalCount: m.evalCount,
+    lastEvalAt: m.lastEvalAt?.toISOString() ?? null,
+    stabilityScore: m.stabilityScore,
+    retiredAt: m.retiredAt?.toISOString() ?? null,
+  }));
+
+  // ── Token spend (current calendar month; reuses the existing groupBy readers) ──
+  const tokenSpend: AiPlatformPostureSpend = {
+    period: spendPeriod,
+    byProvider: spendByProvider.map((r) => ({
+      providerId: r.providerId,
+      providerName: r.providerName,
+      inputTokens: r.totalInputTokens,
+      outputTokens: r.totalOutputTokens,
+      costUsd: r.totalCostUsd,
+    })),
+    byAgent: spendByAgent.map((r) => ({
+      agentId: r.agentId,
+      agentName: r.agentName,
+      inputTokens: r.totalInputTokens,
+      outputTokens: r.totalOutputTokens,
+      costUsd: r.totalCostUsd,
+    })),
+  };
+
+  // ── Failover chain integrity ────────────────────────────────────────────
+  const fallbacksUsedCount = routeDecisions.filter(
+    (d) => Array.isArray(d.fallbacksUsed) ? d.fallbacksUsed.length > 0 : Boolean(d.fallbacksUsed),
+  ).length;
+  const outcomeFallbackCount = routeOutcomes.filter((o) => o.fallbackOccurred).length;
+  const distinctProviderErrorCodes = Array.from(
+    new Set(routeOutcomes.map((o) => o.providerErrorCode).filter((code): code is string => Boolean(code))),
+  ).sort();
+  const recentFallbackChains = routeDecisions
+    .filter((d) => d.fallbackChain.length > 0)
+    .slice(0, RECENT_FALLBACK_CHAIN_SAMPLE)
+    .map((d) => ({
+      agentId: d.agentId,
+      taskType: d.taskType,
+      chain: d.fallbackChain,
+      occurredAt: d.createdAt.toISOString(),
+    }));
+
+  const failoverChain: AiPlatformPostureFailover = {
+    windowStart: windowStart.toISOString(),
+    windowEnd: now.toISOString(),
+    decisionCount: routeDecisions.length,
+    fallbacksUsedCount,
+    fallbackRate: routeDecisions.length > 0 ? fallbacksUsedCount / routeDecisions.length : 0,
+    outcomeCount: routeOutcomes.length,
+    outcomeFallbackCount,
+    outcomeFallbackRate: routeOutcomes.length > 0 ? outcomeFallbackCount / routeOutcomes.length : 0,
+    distinctProviderErrorCodes,
+    recentFallbackChains,
+  };
+
+  // ── Agent-to-provider assignment ────────────────────────────────────────
+  // No dedicated assignment table exists — derive the de-facto current
+  // assignment per agent from the most recent routing decisions in the
+  // window: the provider each agent was routed to most often, with the
+  // timestamp of its latest decision.
+  type Tally = { providerId: string; modelId: string | null; count: number; lastDecisionAt: Date };
+  const byAgent = new Map<string, Map<string, Tally>>();
+  for (const decision of routeDecisions) {
+    const agentId = decision.agentId;
+    if (!agentId) continue;
+    const providerId = providerFromEndpoint(decision.selectedEndpointId, decision.selectedEndpointId);
+    if (!providerId || providerId === "none") continue;
+    const perAgent = byAgent.get(agentId) ?? new Map<string, Tally>();
+    const existing = perAgent.get(providerId);
+    if (existing) {
+      existing.count += 1;
+      if (decision.createdAt > existing.lastDecisionAt) {
+        existing.lastDecisionAt = decision.createdAt;
+        existing.modelId = decision.selectedModelId ?? existing.modelId;
+      }
+    } else {
+      perAgent.set(providerId, {
+        providerId,
+        modelId: decision.selectedModelId ?? null,
+        count: 1,
+        lastDecisionAt: decision.createdAt,
+      });
+    }
+    byAgent.set(agentId, perAgent);
+  }
+  const agentProviderAssignments: AiPlatformPostureAssignment[] = Array.from(byAgent.entries())
+    .map(([agentId, perAgent]) => {
+      const top = Array.from(perAgent.values()).sort((a, b) => b.count - a.count)[0]!;
+      return {
+        agentId,
+        currentProviderId: top.providerId,
+        currentModelId: top.modelId,
+        decisionCount: top.count,
+        lastDecisionAt: top.lastDecisionAt.toISOString(),
+      };
+    })
+    .sort((a, b) => a.agentId.localeCompare(b.agentId));
+
+  // ── Scheduled-task status ───────────────────────────────────────────────
+  const agentTasks = scheduledAgentTasks.map((t) => ({
+    taskId: t.taskId,
+    agentId: t.agentId,
+    title: t.title,
+    isActive: t.isActive,
+    nextRunAt: t.nextRunAt?.toISOString() ?? null,
+    lastStatus: t.lastStatus,
+    lastError: t.lastError,
+  }));
+  const jobs = scheduledJobs.map((j) => ({
+    jobId: j.jobId,
+    name: j.name,
+    schedule: j.schedule,
+    enabled: j.enabled,
+    nextRunAt: j.nextRunAt?.toISOString() ?? null,
+    lastStatus: j.lastStatus,
+    lastError: j.lastError,
+  }));
+  const scheduledTasks: AiPlatformPostureScheduledTasks = {
+    agentTasks,
+    jobs,
+    counts: {
+      activeAgentTasks: agentTasks.filter((t) => t.isActive).length,
+      failingAgentTasks: agentTasks.filter((t) => t.lastStatus === "error").length,
+      enabledJobs: jobs.filter((j) => j.enabled).length,
+      failingJobs: jobs.filter((j) => j.lastStatus === "error").length,
+    },
+  };
+
+  return {
+    generatedAt: now.toISOString(),
+    windowHours,
+    providers,
+    modelProfiles,
+    tokenSpend,
+    failoverChain,
+    agentProviderAssignments,
+    scheduledTasks,
+  };
+}

--- a/apps/web/lib/mcp/pack-registry.ts
+++ b/apps/web/lib/mcp/pack-registry.ts
@@ -67,6 +67,7 @@ import { codeIntelligencePack } from "./packs/code-intelligence-pack";
 import { contributionHivePack } from "./packs/contribution-hive-pack";
 import { taxonomyArchetypePack } from "./packs/taxonomy-archetype-pack";
 import { modelProviderPack } from "./packs/model-provider-pack";
+import { aiPlatformPosturePack } from "./packs/ai-platform-posture-pack";
 import { wikiPack } from "./packs/wiki-pack";
 import { discoveryPack } from "./packs/discovery-pack";
 import { coworkerPack } from "./packs/coworker-pack";
@@ -139,6 +140,7 @@ export const TOOL_PACK_REGISTRY = composeToolPacks([
   contributionHivePack,
   taxonomyArchetypePack,
   modelProviderPack,
+  aiPlatformPosturePack,
   wikiPack,
   discoveryPack,
   coworkerPack,

--- a/apps/web/lib/mcp/packs/ai-platform-posture-pack.test.ts
+++ b/apps/web/lib/mcp/packs/ai-platform-posture-pack.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const posture = vi.hoisted(() => ({ loadAiPlatformPosture: vi.fn() }));
+vi.mock("@/lib/ai-platform-posture/get-ai-platform-posture", () => posture);
+
+import { aiPlatformPosturePack } from "./ai-platform-posture-pack";
+import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
+
+const EXPECTED_TOOLS = ["get_ai_platform_posture"];
+
+const EXPECTED_GRANTS: Record<string, string[]> = {
+  get_ai_platform_posture: ["agent_control_read"],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ai-platform-posture pack — registration", () => {
+  it("exposes exactly the one posture tool", () => {
+    expect(aiPlatformPosturePack.definitions.map((d) => d.name).sort()).toEqual([...EXPECTED_TOOLS].sort());
+    expect(Object.keys(aiPlatformPosturePack.handlers).sort()).toEqual([...EXPECTED_TOOLS].sort());
+    expect(aiPlatformPosturePack.packId).toBe("ai-platform-posture");
+  });
+
+  it("description is provenance-free (no BI/Phase/EP/path leakage)", () => {
+    for (const d of aiPlatformPosturePack.definitions) {
+      expect(d.description).not.toMatch(/\bBI-|Phase \d|EP-|apps\/web\//);
+    }
+  });
+
+  it("is read-only: view_platform capability, no side effects, read-only annotations", () => {
+    const def = aiPlatformPosturePack.definitions[0]!;
+    expect(def.requiredCapability).toBe("view_platform");
+    expect(def.sideEffect).toBe(false);
+    expect(def.executionMode).toBe("immediate");
+    expect(def.annotations).toEqual({ readOnlyHint: true, idempotentHint: true });
+  });
+
+  it("accepts optional windowHours (number) and includeRetired (boolean) params, both non-required", () => {
+    const def = aiPlatformPosturePack.definitions[0]!;
+    expect(def.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        windowHours: { type: "number" },
+        includeRetired: { type: "boolean" },
+      },
+      required: [],
+    });
+  });
+
+  it("grants mirror agent-grants for the tool", () => {
+    for (const t of EXPECTED_TOOLS) {
+      expect(aiPlatformPosturePack.grants[t]).toEqual(EXPECTED_GRANTS[t]);
+      expect(isToolAllowedByGrants(t, EXPECTED_GRANTS[t])).toBe(true);
+    }
+  });
+});
+
+describe("ai-platform-posture pack — handler behavior", () => {
+  it("delegates to loadAiPlatformPosture with the caller's params and summarizes the result", async () => {
+    posture.loadAiPlatformPosture.mockResolvedValue({
+      generatedAt: "2026-07-24T00:00:00.000Z",
+      windowHours: 24,
+      providers: [{ providerId: "anthropic" }],
+      modelProfiles: [{ modelId: "claude-sonnet" }, { modelId: "claude-haiku" }],
+      tokenSpend: { period: { year: 2026, month: 7 }, byProvider: [], byAgent: [] },
+      failoverChain: { fallbackRate: 0.05 },
+      agentProviderAssignments: [],
+      scheduledTasks: { counts: { activeAgentTasks: 3, failingAgentTasks: 1, enabledJobs: 5, failingJobs: 0 } },
+    });
+
+    const res = await aiPlatformPosturePack.handlers.get_ai_platform_posture(
+      { windowHours: 48, includeRetired: true },
+      "u1",
+    );
+
+    expect(posture.loadAiPlatformPosture).toHaveBeenCalledWith({ windowHours: 48, includeRetired: true });
+    expect(res.success).toBe(true);
+    expect(res.message).toContain("1 provider(s)");
+    expect(res.message).toContain("2 model profile(s)");
+    expect(res.message).toContain("5.0% fallback rate");
+    expect(res.message).toContain("1 failing scheduled task(s)/job(s)");
+    expect(res.data).toBeDefined();
+  });
+
+  it("passes undefined through for unset params (defaults resolved downstream)", async () => {
+    posture.loadAiPlatformPosture.mockResolvedValue({
+      generatedAt: "2026-07-24T00:00:00.000Z",
+      windowHours: 24,
+      providers: [],
+      modelProfiles: [],
+      tokenSpend: { period: { year: 2026, month: 7 }, byProvider: [], byAgent: [] },
+      failoverChain: { fallbackRate: 0 },
+      agentProviderAssignments: [],
+      scheduledTasks: { counts: { activeAgentTasks: 0, failingAgentTasks: 0, enabledJobs: 0, failingJobs: 0 } },
+    });
+
+    await aiPlatformPosturePack.handlers.get_ai_platform_posture({}, "u1");
+
+    expect(posture.loadAiPlatformPosture).toHaveBeenCalledWith({ windowHours: undefined, includeRetired: undefined });
+  });
+});

--- a/apps/web/lib/mcp/packs/ai-platform-posture-pack.ts
+++ b/apps/web/lib/mcp/packs/ai-platform-posture-pack.ts
@@ -1,0 +1,71 @@
+// AI platform posture tool pack — BI-5903D447.
+//
+// The scheduled task that refreshes AI platform posture knowledge articles
+// needs real-time read access to provider status/config, ModelProfile tiers/
+// capabilities/toolFidelity, token spend per provider/agent, failover-chain
+// integrity, agent-to-provider assignment, and scheduled-task status.
+// mcp__dpf__list_all_capability_needs and mcp__dpf__search_tool_marketplace
+// only surface partial, derived capability-needs feedback — this tool reads
+// the authoritative AI-layer state directly so posture articles are grounded
+// in real data, not inference.
+//
+// Read-only. The handler lazy-imports its single backing aggregation
+// (apps/web/lib/ai-platform-posture/get-ai-platform-posture.ts), following
+// the established ToolPack pattern (BI-ARCH-TOOLPACKS); grants mirror
+// agent-grants.ts TOOL_TO_GRANTS, which stays the gating source.
+
+import type { ToolDefinition, ToolResult } from "@/lib/mcp-tools";
+import type { ToolPack, ToolPackHandler } from "../tool-pack";
+
+const definitions: ToolDefinition[] = [
+  {
+    name: "get_ai_platform_posture",
+    description:
+      "Read authoritative, real-time AI-layer state in one call: provider status/config, ModelProfile tiers/capabilities/toolFidelity, token spend per provider and per agent (current calendar month), failover-chain integrity (fallback rate + recent fallback chains + provider error codes over a lookback window), agent-to-provider assignment (which provider each agent was most routed to recently), and scheduled-task status (both per-user recurring agent tasks and the platform cron catalog). Read-only — grounds AI-ops posture reporting in real data instead of derived capability-needs feedback.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        windowHours: {
+          type: "number",
+          description: "Lookback window in hours for the failover-chain and agent-assignment signals. Default 24, capped at 168 (7 days).",
+        },
+        includeRetired: {
+          type: "boolean",
+          description: "Include retired providers and model profiles. Default false.",
+        },
+      },
+      required: [],
+    },
+    requiredCapability: "view_platform",
+    executionMode: "immediate",
+    sideEffect: false,
+    annotations: { readOnlyHint: true, idempotentHint: true },
+  },
+];
+
+async function getAiPlatformPostureHandler(params: Record<string, unknown>): Promise<ToolResult> {
+  const { loadAiPlatformPosture } = await import("@/lib/ai-platform-posture/get-ai-platform-posture");
+  const windowHours = typeof params["windowHours"] === "number" ? params["windowHours"] : undefined;
+  const includeRetired = typeof params["includeRetired"] === "boolean" ? params["includeRetired"] : undefined;
+  const posture = await loadAiPlatformPosture({ windowHours, includeRetired });
+
+  const failing = posture.scheduledTasks.counts.failingAgentTasks + posture.scheduledTasks.counts.failingJobs;
+  return {
+    success: true,
+    message: `${posture.providers.length} provider(s), ${posture.modelProfiles.length} model profile(s), ${(posture.failoverChain.fallbackRate * 100).toFixed(1)}% fallback rate over ${posture.windowHours}h, ${failing} failing scheduled task(s)/job(s).`,
+    data: posture as unknown as Record<string, unknown>,
+  };
+}
+
+const handlers: Record<string, ToolPackHandler> = {
+  get_ai_platform_posture: (params) => getAiPlatformPostureHandler(params),
+};
+
+export const aiPlatformPosturePack: ToolPack = {
+  packId: "ai-platform-posture",
+  definitions,
+  handlers,
+  grants: {
+    get_ai_platform_posture: ["agent_control_read"],
+  },
+};

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -463,6 +463,9 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   // Provider management
   add_provider: ["agent_control_read"],
   update_provider_category: ["agent_control_read"],
+  // Read-only AI-layer state aggregation for the posture-article refresh task
+  // (BI-5903D447) — same tier as the sibling provider-management tools.
+  get_ai_platform_posture: ["agent_control_read"],
   run_endpoint_tests: ["agent_control_read"],
   activity_harness_confidence_override: ["agent_control_read"],
   // Provision a coworker's tool authority — grant/revoke one grant key. Same

--- a/docs/superpowers/plans/2026-07-24-ai-platform-posture-read-tool-BI-5903D447.md
+++ b/docs/superpowers/plans/2026-07-24-ai-platform-posture-read-tool-BI-5903D447.md
@@ -1,0 +1,55 @@
+# AI Platform Posture Read Tool — Implementation Plan (BI-5903D447)
+
+> **For agentic workers:** REQUIRED: Use the DPF-native delivery path (`dpf-tdd`, `dpf-local-merge-ci-before-push`, and `dpf-pr-with-dco`) to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the scheduled AI-platform-posture knowledge-article refresh (and any other AI ops caller) one authoritative, read-only MCP tool that returns real-time provider/model/spend/failover/assignment/scheduled-task state, instead of inferring it from `list_all_capability_needs` / `search_tool_marketplace`, which only expose partial, derived capability-needs feedback.
+
+**Architecture:** Follow the existing `BI-ARCH-TOOLPACKS` pattern (`docs/superpowers/specs/2026-06-25-platform-consolidation-spine-design.md`) — one new scoped `ToolPack` (`apps/web/lib/mcp/packs/ai-platform-posture-pack.ts`) registering a single read-only tool, `get_ai_platform_posture`, that lazy-delegates to a new aggregation module (`apps/web/lib/ai-platform-posture/get-ai-platform-posture.ts`). The aggregation module composes existing Prisma models with scoped `select`s (no secret fields) and reuses the existing `getTokenSpendByProvider` / `getTokenSpendByAgent` groupBy readers from `apps/web/lib/inference/ai-provider-data.ts` rather than re-deriving TokenUsage aggregation. Failover-chain integrity and agent-to-provider assignment have no existing single-purpose reader (confirmed by repo grep before writing this plan) — they are derived from `RouteDecisionLog`/`RouteOutcome` rows in a bounded lookback window, reusing the `providerFromEndpoint` helper already used by the AI Operations Map to recover a `providerId` from a `provider:model` `selectedEndpointId`.
+
+**Tech Stack:** Prisma 7 (read-only queries against `ModelProvider`, `ModelProfile`, `TokenUsage`, `RouteDecisionLog`, `RouteOutcome`, `ScheduledAgentTask`, `ScheduledJob`), Next.js/TypeScript, Vitest, MCP tool packs.
+
+---
+
+### Task 1: Aggregation module
+
+**Files:**
+- Add: `apps/web/lib/ai-platform-posture/get-ai-platform-posture.ts`
+- Add: `apps/web/lib/ai-platform-posture/get-ai-platform-posture.test.ts`
+
+- [x] **Step 1: Write the aggregation function**
+
+`loadAiPlatformPosture(options?: { windowHours?; includeRetired? })` returns `{ generatedAt, windowHours, providers, modelProfiles, tokenSpend, failoverChain, agentProviderAssignments, scheduledTasks }`. Providers/model profiles select only non-secret fields (no `authHeader`, `oauthClientId`, `tokenUrl`, credential rows). Token spend reuses the existing readers for the current calendar month. Failover-chain integrity aggregates `RouteDecisionLog.fallbackChain`/`fallbacksUsed` and `RouteOutcome.fallbackOccurred`/`providerErrorCode` over a bounded window (default 24h, capped at 168h). Agent-to-provider assignment groups recent `RouteDecisionLog` rows by `agentId`, picks the most-routed-to provider per agent. Scheduled-task status covers both `ScheduledAgentTask` (per-user recurring coworker tasks) and `ScheduledJob` (platform cron catalog) — `list_scheduled_agent_tasks` only covers the former, scoped to the calling user, so this is a genuinely new platform-wide read.
+
+- [ ] **Step 2: Unit tests**
+
+Mock `@dpf/db` and `ai-provider-data`; assert providers/model profiles are retired-filtered by default, token spend delegates to the existing readers, failover rate/assignment math is correct on fixture rows, and scheduled-task counts (`activeAgentTasks`, `failingAgentTasks`, `enabledJobs`, `failingJobs`) are right.
+
+- [ ] **Step 3: Run tests green**
+
+`pnpm --filter web exec vitest run apps/web/lib/ai-platform-posture/get-ai-platform-posture.test.ts`
+
+### Task 2: MCP tool pack registration
+
+**Files:**
+- Add: `apps/web/lib/mcp/packs/ai-platform-posture-pack.ts`
+- Add: `apps/web/lib/mcp/packs/ai-platform-posture-pack.test.ts`
+- Modify: `apps/web/lib/mcp/pack-registry.ts` (one import line + one array entry)
+- Modify: `apps/web/lib/tak/agent-grants.ts` (one `TOOL_TO_GRANTS` entry, mirroring the pack's `grants` map)
+
+- [x] **Step 1: Define the tool**
+
+`get_ai_platform_posture` — `requiredCapability: "view_platform"`, `sideEffect: false`, `annotations: { readOnlyHint: true, idempotentHint: true }`, optional `windowHours`/`includeRetired` input params, grant `["agent_control_read"]` (same tier as the sibling provider-management tools in `model-provider-pack.ts`).
+
+- [ ] **Step 2: Registration + grant tests**
+
+Mirror `model-provider-pack.test.ts`: exact tool-name list, provenance-free description, metadata preserved verbatim, grants match `isToolAllowedByGrants`.
+
+- [ ] **Step 3: Wire into the registry**
+
+Add the pack import/array entry to `pack-registry.ts` and the grant entry to `agent-grants.ts` under the "Provider management" section.
+
+### Task 3: Verification
+
+- [ ] Typecheck: `node node_modules/typescript/bin/tsc --noEmit -p apps/web` (or the project's configured typecheck script)
+- [ ] Full pack + registry test sweep: `pnpm --filter web exec vitest run apps/web/lib/mcp/packs/ai-platform-posture-pack.test.ts apps/web/lib/ai-platform-posture/get-ai-platform-posture.test.ts apps/web/lib/mcp/pack-registry.test.ts apps/web/lib/tak/agent-grants.test.ts`
+- [ ] `dpf-local-merge-ci-before-push` before opening the PR.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -54,7 +54,7 @@ apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1612
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	903
-apps/web/lib/tak/agent-grants.ts	851
+apps/web/lib/tak/agent-grants.ts	854
 apps/web/lib/tak/agent-routing.ts	996
 apps/web/lib/tak/agentic-loop.test.ts	2311
 apps/web/lib/tak/agentic-loop.ts	2683


### PR DESCRIPTION
## Summary

- The scheduled task that refreshes AI platform posture knowledge articles needs real-time, authoritative read access to provider status/config, ModelProfile tiers/capabilities/toolFidelity, token spend per provider/agent, failover-chain integrity, agent-to-provider assignment, and scheduled-task status. `mcp__dpf__list_all_capability_needs` and `mcp__dpf__search_tool_marketplace` only surface partial, derived capability-needs feedback (confirmed by substrate check — no existing tool or partial implementation named `get_ai_platform_posture`/`agent_control_read` existed).
- Adds one new read-only MCP tool, `get_ai_platform_posture`, via a new scoped `ToolPack` (`apps/web/lib/mcp/packs/ai-platform-posture-pack.ts`) following the existing `BI-ARCH-TOOLPACKS` pattern. The handler lazy-delegates to a new aggregation module (`apps/web/lib/ai-platform-posture/get-ai-platform-posture.ts`).
- Reuses existing readers rather than re-deriving: `getTokenSpendByProvider`/`getTokenSpendByAgent` (`apps/web/lib/inference/ai-provider-data.ts`) supply the token-spend section verbatim; `providerFromEndpoint` (`apps/web/lib/ai-operations-map/projection-helpers.ts`) recovers a `providerId` from a `provider:model` `selectedEndpointId` for the agent-assignment derivation. Providers/model profiles run their own scoped, secret-free `select`s (no `authHeader`/`oauthClientId`/credential fields). Failover-chain integrity and agent-to-provider assignment have no existing single-purpose reader, so they're derived fresh from `RouteDecisionLog`/`RouteOutcome` over a bounded lookback window (default 24h, capped at 168h).
- Optional `windowHours`/`includeRetired` input params; grant `agent_control_read` (same tier as the sibling `add_provider`/`update_provider_category` tools in `model-provider-pack.ts`); `requiredCapability: view_platform`; `sideEffect: false`; `annotations: { readOnlyHint: true, idempotentHint: true }`.

## Design grounding

- Existing specs/plans reviewed: `docs/superpowers/specs/2026-06-25-platform-consolidation-spine-design.md` (BI-ARCH-TOOLPACKS spine), `docs/superpowers/plans/2026-07-24-ai-platform-posture-read-tool-BI-5903D447.md` (new plan for this BI).
- Current code substrate reviewed: `apps/web/lib/mcp/packs/model-provider-pack.ts`, `apps/web/lib/mcp/packs/self-upgrade-pack.ts`, `apps/web/lib/mcp/packs/estate-posture-pack.ts`, `apps/web/lib/mcp/packs/scheduled-agent-task-pack.ts`, `apps/web/lib/inference/ai-provider-data.ts`, `apps/web/lib/ai-operations-map/load-map-data.ts`, `apps/web/lib/tak/agent-grants.ts`.
- Source of truth: the existing ToolPack architecture (`apps/web/lib/mcp/tool-pack.ts`, `apps/web/lib/mcp/pack-registry.ts`) is unchanged in shape — this is a net-new pack following the documented pattern, not a new contract.
- Decision: extend the existing spine (new pack, one registry line, one grant entry) — no new architecture needed.

## Test plan

- [x] `apps/web/lib/ai-platform-posture/get-ai-platform-posture.test.ts` — 9 tests covering window defaulting/capping, retired filtering, provider/model-profile mapping, token-spend delegation, failover-rate math, agent-assignment derivation, scheduled-task counts.
- [x] `apps/web/lib/mcp/packs/ai-platform-posture-pack.test.ts` — 7 tests covering registration shape, read-only metadata, grant mirroring, handler delegation.
- [x] All 16 new tests pass (`node ../../node_modules/vitest/vitest.mjs run` — direct invocation; this worktree's `node_modules/.bin` is empty, a known tooling gap).
- [x] Full-project `tsc --noEmit -p apps/web` run directly — clean, 0 errors.
- [x] Swept `gh pr list` for `agent_control_read`, `AI platform posture`, `BI-5903D447` — no overlapping open PRs.
- [x] Confirmed `origin/main` has not touched `pack-registry.ts` or `agent-grants.ts` since this branch's merge-base — no phantom-clobber risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)