### PR TITLE
fix(storefront): co-locate the self-upgrade trigger with release status (BI-D77BF495)

### DIFF
--- a/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.test.tsx
@@ -59,10 +59,29 @@ vi.mock("@/components/ops/SelfUpgradeClient", () => ({
 
 // BI-8D87084D: owner-readable release card fronts the technical ledger. Stub it
 // to surface the derived state; the summary derivation itself is unit-tested in
-// lib/self-upgrade/owner-summary.test.ts.
+// lib/self-upgrade/owner-summary.test.ts. BI-D77BF495: also render the
+// primaryAction slot (unlike the other stubs, which discard their content) so
+// page-level tests can assert the trigger control is co-located INSIDE the
+// card, not merely passed as a prop nobody renders.
 vi.mock("@/components/ops/OwnerReleaseCard", () => ({
-  OwnerReleaseCard: (props: { summary: { state: string } }) => (
-    <div data-testid="owner-release-card" data-release-state={props.summary.state} />
+  OwnerReleaseCard: (props: { summary: { state: string }; primaryAction?: React.ReactNode }) => (
+    <div data-testid="owner-release-card" data-release-state={props.summary.state}>
+      {props.primaryAction}
+    </div>
+  ),
+}));
+
+// BI-D77BF495: the live trigger, stubbed the same way as the other child
+// components — this file owns page-level wiring (is it rendered, is it
+// co-located with the release card), not the trigger's own behavior (covered
+// in SelfUpgradeTriggerControl.test.tsx).
+vi.mock("@/components/ops/SelfUpgradeTriggerControl", () => ({
+  default: (props: { enabled: boolean; channel: string }) => (
+    <div
+      data-testid="self-upgrade-trigger-control"
+      data-enabled={String(props.enabled)}
+      data-channel={props.channel}
+    />
   ),
 }));
 
@@ -315,25 +334,49 @@ describe("SelfUpgradePage", () => {
     );
   });
 
-  it("keeps the deploy controls (holding the primary trigger) visible on arrival in BOTH nav modes (BI-D77BF495)", async () => {
+  it("co-locates the primary trigger with the release status card, reachable on arrival in BOTH nav modes (BI-D77BF495)", async () => {
     vi.mocked(getSelfUpgradeStatus).mockResolvedValue(baseStatus);
     vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
 
-    // Full (operator) — default cookie unset → open.
+    // The trigger now lives inside OwnerReleaseCard, never inside the
+    // collapsible Advanced <details> — so it is reachable regardless of nav
+    // mode without the details element needing to be forced open.
+    const fullHtml = renderToStaticMarkup(await SelfUpgradePage());
+    expect(fullHtml).toContain('data-testid="owner-release-card"');
+    expect(fullHtml).toContain('data-testid="self-upgrade-trigger-control"');
+    expect(fullHtml.indexOf('data-testid="self-upgrade-trigger-control"')).toBeLessThan(
+      fullHtml.indexOf('data-component="self-upgrade-advanced-toggle"'),
+    );
+
+    mockCookieGet.mockReturnValue({ value: "worker" });
+    const simpleHtml = renderToStaticMarkup(await SelfUpgradePage());
+    expect(simpleHtml).toContain('data-testid="self-upgrade-trigger-control"');
+    expect(simpleHtml.indexOf('data-testid="self-upgrade-trigger-control"')).toBeLessThan(
+      simpleHtml.indexOf('data-component="self-upgrade-advanced-toggle"'),
+    );
+  });
+
+  // BI-D77BF495: now that the trigger is co-located with the release status
+  // card (not gated by this disclosure), the Advanced section holding only
+  // history/ledgers/logs can go back to the ordinary owner-first pattern —
+  // open in Full (operator) mode, collapsed by default in Simple (worker)
+  // mode — instead of being force-held open as the BI-D77BF495 stopgap.
+  it("collapses the Advanced (history/ledgers/logs) section by default in Simple nav mode", async () => {
+    vi.mocked(getSelfUpgradeStatus).mockResolvedValue(baseStatus);
+    vi.mocked(listSelfUpgradeRuns).mockResolvedValue({ runs: [], nextCursor: null });
+
     const fullHtml = renderToStaticMarkup(await SelfUpgradePage());
     expect(fullHtml).toMatch(/<details[^>]*\sopen/);
 
-    // Simple (worker) — ALSO open now. Collapsing it hid the one control this
-    // high-frequency operator page exists for; the primary action must be reachable
-    // on arrival regardless of nav mode. The section stays collapsible via the toggle.
     mockCookieGet.mockReturnValue({ value: "worker" });
     const simpleHtml = renderToStaticMarkup(await SelfUpgradePage());
-    expect(simpleHtml).toMatch(/<details[^>]*\sopen/);
+    expect(simpleHtml).not.toMatch(/<details[^>]*\sopen/);
     expect(simpleHtml).toContain('data-component="self-upgrade-advanced-toggle"');
   });
 
-  // The trigger's primary/next-action markers live inside SelfUpgradeClient, which
-  // this page test mocks to a stub — so they are asserted in the client's own test
-  // (SelfUpgradeClient.test.tsx), not here. This page test owns the page-level
-  // concern: the section holding the trigger is reachable on arrival in both modes.
+  // The trigger's own primary/next-action markers and behavior live inside
+  // SelfUpgradeTriggerControl, which this page test mocks to a stub — so they
+  // are asserted in that component's own tests, not here. This page test owns
+  // the page-level concern: the trigger is rendered co-located with the
+  // release card, ahead of (outside) the collapsible Advanced section.
 });

--- a/apps/web/app/(shell)/ops/self-upgrade/page.tsx
+++ b/apps/web/app/(shell)/ops/self-upgrade/page.tsx
@@ -4,6 +4,7 @@ import { getPlatformDevConfig } from "@/lib/actions/platform-dev-config";
 import { loadPersistedImpactSummary } from "@/lib/self-upgrade/impact";
 import { buildOwnerReleaseSummary } from "@/lib/self-upgrade/owner-summary";
 import SelfUpgradeClient from "@/components/ops/SelfUpgradeClient";
+import SelfUpgradeTriggerControl from "@/components/ops/SelfUpgradeTriggerControl";
 import { OwnerReleaseCard } from "@/components/ops/OwnerReleaseCard";
 import { OpsTabNav } from "@/components/ops/OpsTabNav";
 import { PlatformUpdateApplyPanel } from "@/components/admin/PlatformUpdateApplyPanel";
@@ -90,27 +91,39 @@ export default async function SelfUpgradePage() {
       <OpsTabNav />
 
       <div className="mt-4">
-        <OwnerReleaseCard summary={ownerSummary} />
+        <OwnerReleaseCard
+          summary={ownerSummary}
+          primaryAction={
+            <SelfUpgradeTriggerControl
+              enabled={clientProps.enabled}
+              channel={clientProps.channel}
+              latestRun={clientProps.latestRun}
+              quiescence={clientProps.quiescence}
+              jobEngine={clientProps.jobEngine}
+            />
+          }
+        />
       </div>
 
-      {/* Deploy controls + run history, runtime/security ledgers and logs.
-          BI-D77BF495: this section holds the primary "Upgrade now" trigger, so it
-          defaults OPEN in BOTH nav modes — collapsing it in Simple mode hid the one
-          control this high-frequency operator page exists for, and the word budgets
-          could not see that regression because hiding the trigger REDUCES the counts.
-          The owner-first status card still leads; the section stays collapsible for
-          anyone who wants to tuck the detail away, but the action is reachable on
-          arrival. (Fuller fix — a prominent trigger co-located in the card with only
-          logs/history collapsible — tracked in BI-D77BF495; it needs the trigger
-          extraction plus live upgrade-flow verification.) */}
-      <details className="mt-6 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]" open>
+      {/* Run history, runtime/security ledgers and logs. BI-D77BF495: the
+          primary "Upgrade now" trigger now lives above, co-located with the
+          release status in OwnerReleaseCard — it is reachable on arrival in
+          BOTH nav modes regardless of whether this section is expanded. That
+          lets this section go back to collapsing by default in Simple (worker)
+          nav mode: it holds only detail (history/ledgers/logs), not the
+          primary action, so hiding it there is the correct progressive
+          disclosure the owner-first redesign (BI-8D87084D) intended. */}
+      <details
+        className="mt-6 rounded-xl border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)]"
+        open={!simple}
+      >
         <summary
           data-component="self-upgrade-advanced-toggle"
           className="cursor-pointer select-none rounded-xl px-4 py-3 text-sm font-medium text-[var(--dpf-text)] marker:text-[var(--dpf-muted)]"
         >
           Deploy controls &amp; history
           <span className="ml-2 text-xs font-normal text-[var(--dpf-muted)]">
-            Upgrade trigger, run logs, runtime and security checks
+            Run logs, runtime and security checks
           </span>
         </summary>
 

--- a/apps/web/components/ops/OwnerReleaseCard.test.tsx
+++ b/apps/web/components/ops/OwnerReleaseCard.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { OwnerReleaseCard } from "./OwnerReleaseCard";
+import type { OwnerReleaseSummary } from "@/lib/self-upgrade/owner-summary";
+
+// BI-D77BF495: OwnerReleaseCard grew a `primaryAction` slot so the "Upgrade
+// now" trigger can be co-located with the release status it acts on, instead
+// of buried behind the Advanced disclosure. These tests cover the slot itself
+// (rendered / positioned / optional) — the trigger's own behavior is covered
+// in SelfUpgradeTriggerControl.test.tsx.
+
+const baseSummary: OwnerReleaseSummary = {
+  state: "update-available",
+  tone: "info",
+  headline: "An update is ready.",
+  currentVersion: "1.0.0",
+  availableVersion: "1.1.0",
+  recommendedAction: { label: "Install when ready.", detail: "Takes a few minutes." },
+  canKeepWorking: { ok: true, detail: "Yes, work continues during the update." },
+  keptLocally: { count: 0, detail: "Nothing customised locally." },
+  whatCouldGoWrong: [],
+  rollback: { available: true, detail: "Can be undone from a recovery point." },
+  ifYouDoNothing: "It installs automatically overnight.",
+  riskNotice: {
+    consequence: "The portal restarts briefly.",
+    reversibility: "Yes, via the recovery point.",
+    duration: "Under five minutes.",
+    recovery: "Restore the recovery point.",
+  },
+};
+
+describe("OwnerReleaseCard – primary action slot", () => {
+  it("wraps the primaryAction in an owner-release-primary-action marker", () => {
+    const html = renderToStaticMarkup(
+      <OwnerReleaseCard
+        summary={baseSummary}
+        primaryAction={<button data-testid="the-trigger">Upgrade now</button>}
+      />,
+    );
+    expect(html).toContain('data-component="owner-release-primary-action"');
+    expect(html).toContain('data-testid="the-trigger"');
+  });
+
+  it("positions the primary action after the risk notice (consequence/reversibility shown first)", () => {
+    const html = renderToStaticMarkup(
+      <OwnerReleaseCard
+        summary={baseSummary}
+        primaryAction={<button data-testid="the-trigger">Upgrade now</button>}
+      />,
+    );
+    expect(html.indexOf("Before you install")).toBeLessThan(
+      html.indexOf('data-testid="the-trigger"'),
+    );
+  });
+
+  it("renders nothing extra when primaryAction is omitted (card stays usable without it)", () => {
+    const html = renderToStaticMarkup(<OwnerReleaseCard summary={baseSummary} />);
+    expect(html).not.toContain('data-component="owner-release-primary-action"');
+  });
+
+  it("still renders the release-state marker other pages/tests key off", () => {
+    const html = renderToStaticMarkup(<OwnerReleaseCard summary={baseSummary} />);
+    expect(html).toContain('data-release-state="update-available"');
+  });
+});

--- a/apps/web/components/ops/OwnerReleaseCard.tsx
+++ b/apps/web/components/ops/OwnerReleaseCard.tsx
@@ -31,7 +31,19 @@ function QuestionRow({ q, a }: { q: string; a: string }) {
   );
 }
 
-export function OwnerReleaseCard({ summary }: { summary: OwnerReleaseSummary }) {
+export function OwnerReleaseCard({
+  summary,
+  primaryAction,
+}: {
+  summary: OwnerReleaseSummary;
+  /**
+   * BI-D77BF495: the live "Upgrade now" trigger, rendered co-located with the
+   * status it acts on instead of buried behind the Advanced disclosure below.
+   * Optional so this card stays a pure/server component — the caller (a
+   * Server Component) passes a Client Component instance through this slot.
+   */
+  primaryAction?: React.ReactNode;
+}) {
   return (
     <section
       aria-label="Release status"
@@ -100,10 +112,14 @@ export function OwnerReleaseCard({ summary }: { summary: OwnerReleaseSummary }) 
               <span className="font-medium">If it fails:</span> {summary.riskNotice.recovery}
             </li>
           </ul>
-          <p className="mt-1 text-xs text-[var(--dpf-muted)]">
-            The install control is under “Advanced controls &amp; history” below.
-          </p>
         </Notice>
+      )}
+
+      {/* BI-D77BF495: the live trigger, directly below the risk notice it
+          answers to — visible on arrival, not buried behind the Advanced
+          disclosure (run history / ledgers / logs stay there). */}
+      {primaryAction && (
+        <div data-component="owner-release-primary-action">{primaryAction}</div>
       )}
     </section>
   );

--- a/apps/web/components/ops/SelfUpgradeClient.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.test.tsx
@@ -30,7 +30,6 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/lib/actions/promotions", () => ({
-  triggerSelfUpgrade: vi.fn(),
   rollbackSelfUpgrade: vi.fn(),
 }));
 
@@ -84,48 +83,14 @@ beforeEach(() => {
   shared.triggerResult = null;
 });
 
-// ─── Disabled ─────────────────────────────────────────────────────────────────
-
-describe("SelfUpgradeClient – disabled", () => {
-  it("shows Disabled label when self-upgrade is off", () => {
-    const html = renderToStaticMarkup(
-      <SelfUpgradeClient {...baseStatus} enabled={false} />,
-    );
-    expect(html).toContain("Disabled");
-  });
-
-  it("does not render the Upgrade now button when disabled", () => {
-    const html = renderToStaticMarkup(
-      <SelfUpgradeClient {...baseStatus} enabled={false} />,
-    );
-    expect(html).not.toContain("Upgrade now");
-  });
-
-  it("shows the disabled notice copy", () => {
-    const html = renderToStaticMarkup(
-      <SelfUpgradeClient {...baseStatus} enabled={false} />,
-    );
-    expect(html).toContain("Self-upgrade is disabled");
-  });
-});
+// Trigger/force/abort button behavior (disabled notice, Upgrade now, loading,
+// success/error feedback) moved to SelfUpgradeTriggerControl.test.tsx and
+// SelfUpgradeTriggerControl.swap-resilience.test.tsx (BI-D77BF495) — the
+// trigger now lives there, co-located with OwnerReleaseCard, not here.
 
 // ─── Enabled ──────────────────────────────────────────────────────────────────
 
 describe("SelfUpgradeClient – enabled", () => {
-  it("shows Enabled label with channel", () => {
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain("Enabled");
-    expect(html).toContain("stable");
-  });
-
-  it("renders the Upgrade now button, marked as the primary / next action (BI-D77BF495)", () => {
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain("Upgrade now");
-    // The UX budget reachability axis keys off these markers.
-    expect(html).toContain("data-dpf-primary-action");
-    expect(html).toContain("data-owner-first-next-action");
-  });
-
   it("shows the deployed and target SHA values", () => {
     const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
     expect(html).toContain("abc1234");
@@ -426,128 +391,6 @@ describe("SelfUpgradeClient – skipped", () => {
       <SelfUpgradeClient {...baseStatus} latestRun={makeRun("succeeded")} />,
     );
     expect(html).not.toContain("data-skip-reason");
-  });
-});
-
-// ─── Trigger control ──────────────────────────────────────────────────────────
-
-describe("SelfUpgradeClient – trigger control", () => {
-  it("button has type=button attribute", () => {
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain('type="button"');
-  });
-
-  it("button is not disabled when no run is active", () => {
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain("Upgrade now");
-    expect(html).not.toContain('disabled=""');
-  });
-
-  // BI-4F3B2FA9: a running upgrade no longer leaves a dead-end disabled button.
-  it("shows an in-flight indicator (not a disabled trigger) when a run is running", () => {
-    const html = renderToStaticMarkup(
-      <SelfUpgradeClient {...baseStatus} latestRun={makeRun("running")} />,
-    );
-    expect(html).toContain("Upgrade in progress…");
-    expect(html).not.toContain('aria-label="Upgrade now"');
-  });
-
-  it("surfaces Force now / Abort controls when the portal is draining (BI-4F3B2FA9)", () => {
-    const quiescence = {
-      level: "draining" as const,
-      runId: "QR-2026-06-10-test",
-      enteredAt: "2026-06-10T02:00:00.000Z",
-      run: {
-        runId: "QR-2026-06-10-test",
-        status: "draining",
-        trigger: "self-upgrade",
-        targetVersion: null,
-        targetBundleHash: null,
-        deferSurface: null,
-        deferReason: null,
-        budgetMs: 300000,
-        drainStartedAt: "2026-06-10T02:00:00.000Z",
-        lastHeartbeatAt: null,
-      },
-      blockersCapturedAt: null,
-      blockers: [],
-    };
-    const html = renderToStaticMarkup(
-      <SelfUpgradeClient {...baseStatus} latestRun={makeRun("running")} quiescence={quiescence} />,
-    );
-    expect(html).toContain("Force now");
-    expect(html).toContain("Abort");
-    // Descriptive aria-label names the run; not a dead-end disabled trigger.
-    expect(html).toContain("Force upgrade run QR-2026-06-10-test now");
-  });
-});
-
-// ─── Loading state ────────────────────────────────────────────────────────────
-
-describe("SelfUpgradeClient – loading", () => {
-  it("shows Upgrading... text when pending", () => {
-    shared.isPending = true;
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain("Upgrading...");
-    // The idle button label ">Upgrade now<" is replaced while pending (the
-    // aria-label "Upgrade now" stays, so assert on the visible button text).
-    expect(html).not.toContain(">Upgrade now<");
-  });
-
-  it("button is disabled while pending", () => {
-    shared.isPending = true;
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain('disabled=""');
-  });
-
-  it("button has aria-busy=true while pending", () => {
-    shared.isPending = true;
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain('aria-busy="true"');
-  });
-
-  it("shows the 'starting' hint while busy and no run is running yet", () => {
-    // The manual trigger only queues the upgrade; the worker takes a few seconds
-    // to flip the run to running. The hint reassures the operator so they don't
-    // re-click thinking it's broken.
-    shared.isPending = true;
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain('data-upgrade-starting="true"');
-    expect(html).toContain("No need to click again");
-  });
-
-  it("does not show the 'starting' hint once a run is already running", () => {
-    shared.isPending = false;
-    const html = renderToStaticMarkup(
-      <SelfUpgradeClient {...baseStatus} latestRun={makeRun("running")} />,
-    );
-    expect(html).not.toContain('data-upgrade-starting="true"');
-  });
-});
-
-// ─── Success feedback ─────────────────────────────────────────────────────────
-
-describe("SelfUpgradeClient – success feedback", () => {
-  it("shows Upgrade queued. when trigger succeeds", () => {
-    shared.triggerResult = { queued: true };
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain("Upgrade queued.");
-  });
-});
-
-// ─── Error feedback ───────────────────────────────────────────────────────────
-
-describe("SelfUpgradeClient – error feedback", () => {
-  it("shows Not queued message when trigger returns not queued", () => {
-    shared.triggerResult = { queued: false, reason: "disabled" };
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain("Not queued:");
-  });
-
-  it("shows the specific reason for not queuing", () => {
-    shared.triggerResult = { queued: false, reason: "already-running" };
-    const html = renderToStaticMarkup(<SelfUpgradeClient {...baseStatus} />);
-    expect(html).toContain("already-running");
   });
 });
 

--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -2,40 +2,17 @@
 
 import { Fragment, useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import {
-  rollbackSelfUpgrade,
-  triggerSelfUpgrade,
-  forceActiveRun,
-  abortActiveRun,
-  repairPromoterImage,
-} from "@/lib/actions/promotions";
+import { rollbackSelfUpgrade, repairPromoterImage } from "@/lib/actions/promotions";
 import { LocalTime } from "@/components/ui/LocalTime";
 import UpgradeImpactPanel from "@/components/ops/UpgradeImpactPanel";
-import SelfUpgradeJobEngineHealthAlert, {
-  shouldPollForJobEngineRecovery,
-  type JobEngineHealth,
-} from "@/components/ops/SelfUpgradeJobEngineHealthAlert";
 import type { SummaryResult, RunImpactDigest } from "@/lib/self-upgrade/impact/types";
 import { UpgradeScopeRibbon } from "@/components/ops/UpgradeScopeRibbon";
 import { StatusBadge } from "@/components/ui/report-kit";
 import { describeSkipReason } from "@/lib/self-upgrade/skip-reason";
 import { getErrorMessage } from "@/lib/shared/get-error-message";
+import { isExpectedDuringSwap } from "@/lib/self-upgrade/is-expected-during-swap";
 import { SelfUpgradeReadiness } from "@/components/ops/SelfUpgradeReadiness";
-
-type LatestRun = {
-  runId: string;
-  status: string;
-  trigger: string | null;
-  currentSha: string | null;
-  targetSha: string | null;
-  deployedSha: string | null;
-  reason: string | null;
-  startedAt: Date | string | null;
-  completedAt: Date | string | null;
-  completionEvidence?: unknown;
-  failureLog: string | null;
-  createdAt: Date | string;
-};
+import type { LatestRun, QuiescenceActivity } from "@/lib/self-upgrade/run-types";
 
 type RecoveryPointSummary = {
   status: string;
@@ -44,38 +21,6 @@ type RecoveryPointSummary = {
 };
 
 type ImageVersionSource = "git-sha" | "content-hash" | "unknown";
-
-type QuiescenceBlockerLine = {
-  surface: string;
-  label: string;
-  kind: "hard" | "soft";
-  count: number;
-  estimatedWaitMs: number | null;
-  sampleAgent?: string | null;
-  sampleTitle?: string | null;
-  oldestSignalAt?: string | null;
-  stale?: boolean;
-};
-
-type QuiescenceActivity = {
-  level: "normal" | "draining" | "swapping";
-  runId: string | null;
-  enteredAt: string;
-  run: {
-    runId: string;
-    status: string;
-    trigger: string;
-    targetVersion: string | null;
-    targetBundleHash: string | null;
-    deferSurface: string | null;
-    deferReason: string | null;
-    budgetMs: number | null;
-    drainStartedAt: string | null;
-    lastHeartbeatAt: string | null;
-  } | null;
-  blockersCapturedAt: string | null;
-  blockers: QuiescenceBlockerLine[];
-};
 
 type AdmissionSnapshot = {
   lane: { enabled: boolean; limit: number | null; key: string };
@@ -86,7 +31,6 @@ type AdmissionSnapshot = {
 
 type Props = {
   enabled: boolean;
-  channel: string;
   inMaintenanceWindow: boolean;
   windowConfigured?: boolean;
   /**
@@ -126,7 +70,6 @@ type Props = {
   quiescence?: QuiescenceActivity | null;
   admission?: AdmissionSnapshot | null;
   cooldownUntil?: string | null;
-  jobEngine?: JobEngineHealth;
   history?: LatestRun[];
   historyNextCursor?: string | null;
   initialImpactSummary?: SummaryResult | null;
@@ -290,31 +233,8 @@ function recoveryMemberLabel(member: { target: string; status: string }): string
 const DEFAULT_STATUS_STYLE =
   "bg-[var(--dpf-surface-2)] text-[var(--dpf-text)] border-[var(--dpf-border)]";
 
-// A forced upgrade intentionally bypasses the quiescence drain and swaps the
-// portal container out from under the very request that triggered it. When the
-// swap lands mid-flight, the operator's own server-action response never returns
-// intact — Next surfaces a non-RSC transport failure ("An unexpected response
-// was received from the server", error code E394), or the browser reports a bare
-// network error. For the self-upgrade page that is the EXPECTED success path of
-// a force, not a crash: the upgrade is applying and the portal is restarting.
-// Recognising it lets the page hold a calm "reconnecting" state instead of
-// letting the rejection escalate to the global (shell) error boundary and paint
-// a full-page "Something went wrong" over an upgrade that actually succeeded.
-// Exported for unit testing.
-export function isExpectedDuringSwap(err: unknown): boolean {
-  if (!err) return false;
-  // Next stamps server-action transport failures with a stable error code.
-  const code = (err as { __NEXT_ERROR_CODE?: unknown }).__NEXT_ERROR_CODE;
-  if (code === "E394") return true;
-  const message = getErrorMessage(err);
-  return /unexpected response was received|failed to fetch|fetch failed|load failed|networkerror|err_connection|connection (?:refused|reset|closed)|the operation was aborted/i.test(
-    message,
-  );
-}
-
 export default function SelfUpgradeClient({
   enabled,
-  channel,
   inMaintenanceWindow,
   windowConfigured,
   windowSource,
@@ -334,27 +254,21 @@ export default function SelfUpgradeClient({
   quiescence,
   admission,
   cooldownUntil,
-  jobEngine,
   history,
   historyNextCursor,
   initialImpactSummary,
   platformVersion,
 }: Props) {
   const router = useRouter();
-  const [isPending, startTransition] = useTransition();
   const [isRollbackPending, startRollbackTransition] = useTransition();
-  const [override, setOverride] = useState(false);
-  const [justQueued, setJustQueued] = useState(false);
-  const [triggerResult, setTriggerResult] = useState<{ queued: boolean; reason?: string } | null>(null);
-  // BI-4F3B2FA9: mid-flight Force Now / Abort controls for a running drain.
-  const [forceConfirm, setForceConfirm] = useState(false);
-  const [abortConfirm, setAbortConfirm] = useState(false);
-  const [inFlightError, setInFlightError] = useState<string | null>(null);
-  // A forced upgrade can swap this portal out from under the operator's own
-  // request. `restarting` holds a calm reconnect banner (and keeps the status
-  // poll alive) so a *successful* forced upgrade never paints the global crash
-  // screen. See isExpectedDuringSwap. `restartBaselineRef` snapshots the server
-  // signature at swap time so we know when the new container has answered.
+  // A recovery-point restore can swap this portal out from under the
+  // operator's own request (same class of disconnect as a forced upgrade —
+  // see isExpectedDuringSwap). `restarting` holds a calm reconnect banner
+  // (and keeps the status poll alive) instead of painting the global crash
+  // screen. `restartBaselineRef` snapshots the server signature at swap time
+  // so we know when the new container has answered. The trigger/force/abort
+  // actions have their OWN instance of this same pattern in
+  // SelfUpgradeTriggerControl (BI-D77BF495) — this one is scoped to rollback.
   const [restarting, setRestarting] = useState(false);
   const restartBaselineRef = useRef<string | null>(null);
   const [isRepairPending, startRepairTransition] = useTransition();
@@ -398,35 +312,15 @@ export default function SelfUpgradeClient({
       ? new Date(latestRun.startedAt).getTime() + estimatedDurationMs
       : null;
 
-  // The manual trigger only *queues* an upgrade: the server action returns
-  // `{ queued: true }` in well under a second, but the Inngest worker still has
-  // to fetch + compare SHAs before the run flips to "running". Without a held
-  // state the button would snap straight back to "Upgrade now" while nothing
-  // visibly happened — which reads as "broken" and invites repeat clicks (each
-  // one firing another upgrade event). We hold a "Starting…" state until the run
-  // actually appears, poll so progress shows up on its own, and time out as a
-  // safety net if the queued event never materialises (e.g. skipped for cooldown).
+  // Keep the read-only detail panel (Latest Run, run history, activity) in
+  // sync while an upgrade is in flight or a rollback swap is reconnecting —
+  // both are derived server state, not local trigger state, so this poll
+  // needs no dependency on SelfUpgradeTriggerControl's own justQueued.
   useEffect(() => {
-    if (justQueued && upgradeInFlight) setJustQueued(false);
-  }, [justQueued, upgradeInFlight]);
-
-  useEffect(() => {
-    if (!justQueued) return;
-    const timeout = setTimeout(() => setJustQueued(false), 45_000);
-    return () => clearTimeout(timeout);
-  }, [justQueued]);
-
-  useEffect(() => {
-    if (!justQueued && !upgradeInFlight && !restarting) return;
+    if (!upgradeInFlight && !restarting) return;
     const interval = setInterval(() => router.refresh(), 4_000);
     return () => clearInterval(interval);
-  }, [justQueued, upgradeInFlight, restarting, router]);
-
-  useEffect(() => {
-    if (!shouldPollForJobEngineRecovery(jobEngine)) return;
-    const interval = setInterval(() => router.refresh(), 15_000);
-    return () => clearInterval(interval);
-  }, [jobEngine, router]);
+  }, [upgradeInFlight, restarting, router]);
 
   // Drop the reconnect banner once the swapped-in portal actually answers with
   // fresh data. We snapshot the server-derived signature at the moment the swap
@@ -464,11 +358,10 @@ export default function SelfUpgradeClient({
     return () => clearTimeout(timeout);
   }, [restarting]);
 
-  const triggerBusy = isPending || justQueued;
-
   // A compact fingerprint of the server-derived state. When it changes after a
   // swap-induced disconnect, the new container has answered and the reconnect
-  // banner can clear.
+  // banner can clear. Scoped to the rollback restore here — the trigger/force/
+  // abort actions have their own instance in SelfUpgradeTriggerControl.
   function serverSignature(): string {
     return [
       latestRun?.runId ?? "",
@@ -486,83 +379,7 @@ export default function SelfUpgradeClient({
   function enterRestarting() {
     restartBaselineRef.current = serverSignature();
     setRestarting(true);
-    setJustQueued(true);
     router.refresh();
-  }
-
-  function handleTrigger() {
-    setTriggerResult(null);
-    setInFlightError(null);
-    const force = override;
-    startTransition(async () => {
-      try {
-        const result = await triggerSelfUpgrade(force ? { force: true } : undefined);
-        setTriggerResult(result);
-        if (result.queued) setJustQueued(true);
-        router.refresh();
-      } catch (err) {
-        // A forced upgrade can swap the portal out from under this request
-        // before its response returns. That's the upgrade applying — hold the
-        // reconnect state instead of crashing the page; a non-swap failure
-        // (e.g. unauthorized) is surfaced inline.
-        if (isExpectedDuringSwap(err)) {
-          enterRestarting();
-        } else {
-          setTriggerResult({
-            queued: false,
-            reason: err instanceof Error ? err.message : "trigger failed",
-          });
-        }
-      }
-    });
-  }
-
-  // BI-4F3B2FA9: escalate the active drain to forced — coordinator bypasses
-  // all blockers on its next tick (~5s) and swaps, without restarting the run.
-  function handleForceNow() {
-    const runId = quiescence?.run?.runId;
-    if (!runId) return;
-    setInFlightError(null);
-    startTransition(async () => {
-      try {
-        const r = await forceActiveRun(runId);
-        setForceConfirm(false);
-        if (!r.ok) setInFlightError(r.error ?? "Force failed");
-        router.refresh();
-      } catch (err) {
-        // Forcing the swap can sever this very request the moment the
-        // coordinator proceeds — the expected outcome, not an error.
-        setForceConfirm(false);
-        if (isExpectedDuringSwap(err)) {
-          enterRestarting();
-        } else {
-          setInFlightError(err instanceof Error ? err.message : "Force failed");
-        }
-      }
-    });
-  }
-
-  // BI-4F3B2FA9: abort the active drain — level returns to normal so the
-  // operator can immediately start a fresh run.
-  function handleAbortRun() {
-    const runId = quiescence?.run?.runId;
-    if (!runId) return;
-    setInFlightError(null);
-    startTransition(async () => {
-      try {
-        const r = await abortActiveRun(runId);
-        setAbortConfirm(false);
-        if (!r.ok) setInFlightError(r.error ?? "Abort failed");
-        router.refresh();
-      } catch (err) {
-        setAbortConfirm(false);
-        if (isExpectedDuringSwap(err)) {
-          enterRestarting();
-        } else {
-          setInFlightError(err instanceof Error ? err.message : "Abort failed");
-        }
-      }
-    });
   }
 
   // BI-F2C53237: build the promoter engine image in place when self-upgrade
@@ -618,6 +435,11 @@ export default function SelfUpgradeClient({
 
   return (
     <div className="space-y-4">
+      {/* Rollback's own reconnect banner — the trigger/force/abort actions
+          have their own instance of this same "applying the upgrade, portal
+          is restarting" state inside SelfUpgradeTriggerControl (co-located
+          with the release status, BI-D77BF495), which is what fires for a
+          normal upgrade. This one only fires for a recovery-point restore. */}
       {restarting && (
         <div
           className="p-3 rounded-lg bg-[var(--dpf-info)]/10 border border-[var(--dpf-info)]/30 text-sm text-[var(--dpf-text)]"
@@ -625,165 +447,9 @@ export default function SelfUpgradeClient({
           aria-live="polite"
           data-upgrade-restarting="true"
         >
-          <span className="font-medium">Applying the upgrade…</span> the portal is
+          <span className="font-medium">Applying the restore…</span> the portal is
           restarting to finish the swap. This page reconnects automatically — no
           need to refresh.
-        </div>
-      )}
-      <SelfUpgradeJobEngineHealthAlert jobEngine={jobEngine} />
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <span
-            className={`w-2 h-2 rounded-full ${
-              enabled ? "bg-[var(--dpf-success)]" : "bg-[var(--dpf-muted)]"
-            }`}
-          />
-          <span className="text-sm font-medium text-[var(--dpf-text)]">
-            Self-Upgrade:{" "}
-            <span data-upgrade-status={enabled ? "enabled" : "disabled"}>
-              {enabled ? "Enabled" : "Disabled"}
-            </span>
-          </span>
-          <span className="text-xs text-[var(--dpf-muted)]">({channel})</span>
-        </div>
-
-        {enabled && (
-          <div className="flex items-center gap-3">
-            {upgradeInFlight ? (
-              // BI-4F3B2FA9: a run is in flight. Never a dead-end disabled
-              // button — when the portal is draining, surface Force Now / Abort
-              // so the operator's emergency lever actually works mid-flight.
-              draining && quiescence?.run?.runId ? (
-                <div className="flex items-center gap-2" role="group" aria-label="In-flight upgrade controls">
-                  {inFlightError && (
-                    <span className="text-xs text-[var(--dpf-warning)]" role="status" aria-live="polite">
-                      {inFlightError}
-                    </span>
-                  )}
-                  {forceConfirm ? (
-                    <div role="alertdialog" aria-describedby="force-now-warning" className="flex items-center gap-2">
-                      <span id="force-now-warning" className="text-xs text-[var(--dpf-warning)]">
-                        ⚠ Bypass all in-flight work and swap now?
-                      </span>
-                      <button
-                        type="button"
-                        onClick={handleForceNow}
-                        disabled={isPending}
-                        className="px-2 py-1 text-xs rounded-lg bg-[var(--dpf-warning)]/20 text-[var(--dpf-warning)] border border-[var(--dpf-warning)]/40 disabled:opacity-50"
-                      >
-                        Confirm force
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setForceConfirm(false)}
-                        className="px-2 py-1 text-xs rounded-lg border border-[var(--dpf-border)] text-[var(--dpf-muted)]"
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  ) : abortConfirm ? (
-                    <div role="alertdialog" aria-describedby="abort-warning" className="flex items-center gap-2">
-                      <span id="abort-warning" className="text-xs text-[var(--dpf-muted)]">
-                        Abort this drain?
-                      </span>
-                      <button
-                        type="button"
-                        onClick={handleAbortRun}
-                        disabled={isPending}
-                        className="px-2 py-1 text-xs rounded-lg bg-[var(--dpf-warning)]/20 text-[var(--dpf-warning)] border border-[var(--dpf-warning)]/40 disabled:opacity-50"
-                      >
-                        Confirm abort
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setAbortConfirm(false)}
-                        className="px-2 py-1 text-xs rounded-lg border border-[var(--dpf-border)] text-[var(--dpf-muted)]"
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  ) : (
-                    <>
-                      <button
-                        type="button"
-                        onClick={() => { setAbortConfirm(false); setForceConfirm(true); }}
-                        aria-label={`Force upgrade run ${quiescence.run.runId} now`}
-                        className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-warning)]/20 text-[var(--dpf-warning)] border border-[var(--dpf-warning)]/40 hover:bg-[var(--dpf-warning)]/30 transition-colors"
-                      >
-                        ⚡ Force now
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => { setForceConfirm(false); setAbortConfirm(true); }}
-                        aria-label={`Abort upgrade run ${quiescence.run.runId}`}
-                        className="px-3 py-1.5 text-xs rounded-lg border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] transition-colors"
-                      >
-                        Abort
-                      </button>
-                    </>
-                  )}
-                </div>
-              ) : (
-                <span
-                  className="text-xs text-[var(--dpf-muted)]"
-                  aria-live="polite"
-                  data-upgrade-inflight="true"
-                >
-                  {queuedRun
-                    ? "Upgrade queued — waiting for the worker…"
-                    : "Upgrade in progress…"}
-                </span>
-              )
-            ) : (
-              <>
-                <label className="flex items-center gap-1.5 text-xs text-[var(--dpf-muted)] cursor-pointer select-none">
-                  <input
-                    type="checkbox"
-                    checked={override}
-                    onChange={(e) => setOverride(e.target.checked)}
-                    aria-label="Emergency override: bypass the safety drain"
-                    title="Bypass the quiescence safety drain. Only for emergencies — it can interrupt in-flight work."
-                    className="accent-[var(--dpf-warning)]"
-                  />
-                  Emergency override
-                </label>
-                <button
-                  type="button"
-                  onClick={handleTrigger}
-                  disabled={triggerBusy}
-                  aria-busy={triggerBusy}
-                  aria-label="Upgrade now"
-                  data-override={override ? "true" : "false"} data-owner-first-next-action data-dpf-primary-action
-                  className="px-4 py-2 text-sm font-medium rounded-lg bg-[var(--dpf-accent)] text-white border border-[var(--dpf-accent)] hover:opacity-90 transition-opacity disabled:opacity-50"
-                >
-                  {isPending
-                    ? "Upgrading..."
-                    : justQueued
-                      ? "Starting…"
-                      : override
-                        ? "Force upgrade now"
-                        : "Upgrade now"}
-                </button>
-              </>
-            )}
-          </div>
-        )}
-      </div>
-
-      {enabled && triggerBusy && latestRun?.status !== "running" && !queuedRun && (
-        <div
-          className="text-xs text-[var(--dpf-muted)]"
-          data-upgrade-starting="true"
-          aria-live="polite"
-        >
-          Upgrade starting — the worker is checking for a new build. This can take
-          a few seconds; progress will appear below. No need to click again.
-        </div>
-      )}
-
-      {!enabled && (
-        <div className="p-3 rounded-lg bg-[var(--dpf-surface-1)] border border-[var(--dpf-border)] text-sm text-[var(--dpf-muted)]">
-          Self-upgrade is disabled. Enable it in settings to allow automated upgrades.
         </div>
       )}
 
@@ -1439,18 +1105,6 @@ export default function SelfUpgradeClient({
               </button>
             </div>
           )}
-        </div>
-      )}
-
-      {triggerResult && (
-        <div
-          className={`p-3 rounded-lg text-sm ${
-            triggerResult.queued
-              ? "bg-[var(--dpf-success)]/10 text-[var(--dpf-success)] border border-[var(--dpf-success)]/30"
-              : "bg-[var(--dpf-destructive)]/10 text-[var(--dpf-destructive)] border border-[var(--dpf-destructive)]/30"
-          }`}
-        >
-          {triggerResult.queued ? "Upgrade queued." : `Not queued: ${triggerResult.reason}`}
         </div>
       )}
     </div>

--- a/apps/web/components/ops/SelfUpgradeTriggerControl.swap-resilience.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeTriggerControl.swap-resilience.test.tsx
@@ -1,14 +1,14 @@
 // @vitest-environment jsdom
 //
-// Regression coverage for the forced-self-upgrade crash: a forced upgrade
-// bypasses the quiescence drain and swaps the portal out from under the
-// operator's own request, so the server-action response comes back as a
-// non-RSC transport failure (Next error code E394, "An unexpected response was
-// received from the server"). Previously the handlers awaited the actions with
-// no try/catch, so that rejection escalated to the global (shell) error
-// boundary and painted a full-page crash over an upgrade that actually
-// succeeded. The page must instead recognise the expected mid-swap disconnect
-// and hold a calm "reconnecting" state.
+// Regression coverage for the forced-self-upgrade crash, migrated (BI-D77BF495)
+// from SelfUpgradeClient.swap-resilience.test.tsx now that the trigger/force/
+// abort actions live in SelfUpgradeTriggerControl: a forced upgrade bypasses
+// the quiescence drain and swaps the portal out from under the operator's own
+// request, so the server-action response comes back as a non-RSC transport
+// failure (Next error code E394, "An unexpected response was received from the
+// server"). The handlers must recognise the expected mid-swap disconnect and
+// hold a calm "reconnecting" state instead of escalating to the (shell) error
+// boundary.
 import "@/components/build-studio/test-setup";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -21,17 +21,11 @@ vi.mock("@/lib/actions/promotions", () => ({
   triggerSelfUpgrade: vi.fn(),
   forceActiveRun: vi.fn(),
   abortActiveRun: vi.fn(),
-  rollbackSelfUpgrade: vi.fn(),
-}));
-
-// The impact panel loads its own data on mount; keep it out of these behavior
-// tests so they stay focused on the trigger/force handlers.
-vi.mock("@/components/ops/UpgradeImpactPanel", () => ({
-  default: () => null,
 }));
 
 import { triggerSelfUpgrade, forceActiveRun } from "@/lib/actions/promotions";
-import SelfUpgradeClient, { isExpectedDuringSwap } from "./SelfUpgradeClient";
+import SelfUpgradeTriggerControl from "./SelfUpgradeTriggerControl";
+import { isExpectedDuringSwap } from "@/lib/self-upgrade/is-expected-during-swap";
 
 const triggerMock = triggerSelfUpgrade as unknown as ReturnType<typeof vi.fn>;
 const forceMock = forceActiveRun as unknown as ReturnType<typeof vi.fn>;
@@ -50,18 +44,7 @@ function makeE394(): Error {
 const baseProps = {
   enabled: true,
   channel: "stable",
-  inMaintenanceWindow: false,
-  nextScheduledCheckAt: "2026-06-18T18:00:00.000Z",
-  deployedSha: "abc1234",
-  targetSha: "def5678",
-  isFresh: false,
   latestRun: null,
-  platformVersion: {
-    version: "1.0.0",
-    publishedAt: "2026-06-18T00:00:00.000Z",
-    gitSha: "9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1098",
-    note: "baseline",
-  },
 } as const;
 
 function makeRun(status: string, overrides: Record<string, unknown> = {}) {
@@ -139,11 +122,11 @@ describe("isExpectedDuringSwap", () => {
 
 // ─── Forced trigger severed by the swap ────────────────────────────────────
 
-describe("SelfUpgradeClient – forced upgrade swap resilience", () => {
+describe("SelfUpgradeTriggerControl – forced upgrade swap resilience", () => {
   it("shows a reconnecting state (not the crash boundary) when the forced upgrade swaps the portal mid-request", async () => {
     triggerMock.mockRejectedValue(makeE394());
 
-    render(<SelfUpgradeClient {...baseProps} />);
+    render(<SelfUpgradeTriggerControl {...baseProps} />);
 
     fireEvent.click(screen.getByRole("checkbox", { name: /emergency override/i }));
     fireEvent.click(screen.getByRole("button", { name: /upgrade now/i }));
@@ -162,7 +145,7 @@ describe("SelfUpgradeClient – forced upgrade swap resilience", () => {
   it("surfaces a genuine (non-swap) trigger failure inline instead of reconnecting", async () => {
     triggerMock.mockRejectedValue(new Error("Unauthorized"));
 
-    render(<SelfUpgradeClient {...baseProps} />);
+    render(<SelfUpgradeTriggerControl {...baseProps} />);
 
     fireEvent.click(screen.getByRole("button", { name: /upgrade now/i }));
 
@@ -170,7 +153,6 @@ describe("SelfUpgradeClient – forced upgrade swap resilience", () => {
       expect(screen.getByText(/Not queued:/i)).toBeInTheDocument();
     });
     expect(screen.getByText(/Unauthorized/i)).toBeInTheDocument();
-    // A real error is not dressed up as a successful "applying" swap.
     expect(screen.queryByText(/Applying the upgrade/i)).not.toBeInTheDocument();
   });
 
@@ -178,7 +160,7 @@ describe("SelfUpgradeClient – forced upgrade swap resilience", () => {
     forceMock.mockRejectedValue(new TypeError("Failed to fetch"));
 
     render(
-      <SelfUpgradeClient
+      <SelfUpgradeTriggerControl
         {...baseProps}
         latestRun={makeRun("running")}
         quiescence={drainingQuiescence}
@@ -198,7 +180,7 @@ describe("SelfUpgradeClient – forced upgrade swap resilience", () => {
   it("clears the reconnecting banner once the swapped-in portal returns fresh data", async () => {
     triggerMock.mockRejectedValue(makeE394());
 
-    const { rerender } = render(<SelfUpgradeClient {...baseProps} />);
+    const { rerender } = render(<SelfUpgradeTriggerControl {...baseProps} />);
 
     fireEvent.click(screen.getByRole("checkbox", { name: /emergency override/i }));
     fireEvent.click(screen.getByRole("button", { name: /upgrade now/i }));
@@ -207,13 +189,10 @@ describe("SelfUpgradeClient – forced upgrade swap resilience", () => {
       expect(screen.getByText(/Applying the upgrade/i)).toBeInTheDocument();
     });
 
-    // The poll reaches the new container: a fresh run is now visible, the
-    // deployed SHA has advanced and the install reports up to date.
+    // The poll reaches the new container: a fresh run is now visible.
     rerender(
-      <SelfUpgradeClient
+      <SelfUpgradeTriggerControl
         {...baseProps}
-        deployedSha="def5678"
-        isFresh={true}
         latestRun={makeRun("succeeded", {
           completedAt: new Date("2026-06-18T02:05:00Z"),
         })}
@@ -228,7 +207,7 @@ describe("SelfUpgradeClient – forced upgrade swap resilience", () => {
   it("keeps a normal queued trigger working (no false reconnecting state)", async () => {
     triggerMock.mockResolvedValue({ queued: true, runId: "SUR-9999" });
 
-    render(<SelfUpgradeClient {...baseProps} />);
+    render(<SelfUpgradeTriggerControl {...baseProps} />);
 
     fireEvent.click(screen.getByRole("button", { name: /upgrade now/i }));
 

--- a/apps/web/components/ops/SelfUpgradeTriggerControl.test.tsx
+++ b/apps/web/components/ops/SelfUpgradeTriggerControl.test.tsx
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// BI-D77BF495: SelfUpgradeTriggerControl was extracted from SelfUpgradeClient so
+// the trigger could be co-located with the OwnerReleaseCard release-status
+// summary instead of buried behind the Advanced disclosure. These tests were
+// migrated out of SelfUpgradeClient.test.tsx's "trigger control" / "loading
+// state" / "success feedback" / "error feedback" / "disabled" describe blocks —
+// same behavior, new home.
+const shared = vi.hoisted(() => ({
+  isPending: false,
+  triggerResult: null as { queued: boolean; reason?: string } | null,
+}));
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useTransition: () => [shared.isPending, vi.fn()] as const,
+    useState: <T,>(initial: T) => {
+      if (initial === null) {
+        return [shared.triggerResult as T, vi.fn()] as const;
+      }
+      if (typeof initial === "function") {
+        return [initial(), vi.fn()] as const;
+      }
+      return [initial, vi.fn()] as const;
+    },
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/actions/promotions", () => ({
+  triggerSelfUpgrade: vi.fn(),
+  forceActiveRun: vi.fn(),
+  abortActiveRun: vi.fn(),
+}));
+
+import SelfUpgradeTriggerControl from "./SelfUpgradeTriggerControl";
+
+const baseProps = {
+  enabled: true,
+  channel: "stable",
+  latestRun: null,
+};
+
+function makeRun(status: string, overrides: Record<string, unknown> = {}) {
+  return {
+    runId: "SUR-0001",
+    status,
+    trigger: "scheduled",
+    currentSha: "abc1234",
+    targetSha: "def5678",
+    deployedSha: "def5678",
+    reason: null as string | null,
+    startedAt: new Date("2026-05-20T02:00:00Z"),
+    completedAt: new Date("2026-05-20T02:05:00Z"),
+    completionEvidence: null,
+    failureLog: null as string | null,
+    createdAt: new Date("2026-05-20T02:00:00Z"),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  shared.isPending = false;
+  shared.triggerResult = null;
+});
+
+// ─── Disabled ─────────────────────────────────────────────────────────────────
+
+describe("SelfUpgradeTriggerControl – disabled", () => {
+  it("does not render the Upgrade now button when disabled", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeTriggerControl {...baseProps} enabled={false} />,
+    );
+    expect(html).not.toContain("Upgrade now");
+  });
+
+  it("shows the disabled notice copy", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeTriggerControl {...baseProps} enabled={false} />,
+    );
+    expect(html).toContain("Self-upgrade is disabled");
+  });
+});
+
+// ─── Enabled ──────────────────────────────────────────────────────────────────
+
+describe("SelfUpgradeTriggerControl – enabled", () => {
+  it("shows Enabled label with channel", () => {
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toContain("Enabled");
+    expect(html).toContain("stable");
+  });
+
+  it("renders the Upgrade now button, marked as the primary / next action (BI-D77BF495)", () => {
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toContain("Upgrade now");
+    // The UX budget reachability axis keys off these markers.
+    expect(html).toContain("data-dpf-primary-action");
+    expect(html).toContain("data-owner-first-next-action");
+  });
+
+  it("renders solid primary-button styling, not a faint text-xs ghost button (BI-D77BF495)", () => {
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toMatch(/aria-label="Upgrade now"[^>]*class="[^"]*bg-\[var\(--dpf-accent\)\][^"]*text-white/);
+  });
+});
+
+// ─── Running ──────────────────────────────────────────────────────────────────
+
+describe("SelfUpgradeTriggerControl – running", () => {
+  it("shows queued state as accepted work instead of an idle trigger", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeTriggerControl
+        {...baseProps}
+        latestRun={makeRun("queued", { startedAt: null, completedAt: null })}
+      />,
+    );
+    expect(html).toContain("Upgrade queued");
+    expect(html).toContain("waiting for the worker");
+    expect(html).not.toContain('aria-label="Upgrade now"');
+  });
+
+  it("shows an in-flight indicator (not a disabled trigger) when a run is running", () => {
+    const html = renderToStaticMarkup(
+      <SelfUpgradeTriggerControl {...baseProps} latestRun={makeRun("running")} />,
+    );
+    expect(html).toContain("Upgrade in progress…");
+    expect(html).not.toContain('aria-label="Upgrade now"');
+  });
+
+  it("surfaces Force now / Abort controls when the portal is draining (BI-4F3B2FA9)", () => {
+    const quiescence = {
+      level: "draining" as const,
+      runId: "QR-2026-06-10-test",
+      enteredAt: "2026-06-10T02:00:00.000Z",
+      run: {
+        runId: "QR-2026-06-10-test",
+        status: "draining",
+        trigger: "self-upgrade",
+        targetVersion: null,
+        targetBundleHash: null,
+        deferSurface: null,
+        deferReason: null,
+        budgetMs: 300000,
+        drainStartedAt: "2026-06-10T02:00:00.000Z",
+        lastHeartbeatAt: null,
+      },
+      blockersCapturedAt: null,
+      blockers: [],
+    };
+    const html = renderToStaticMarkup(
+      <SelfUpgradeTriggerControl
+        {...baseProps}
+        latestRun={makeRun("running")}
+        quiescence={quiescence}
+      />,
+    );
+    expect(html).toContain("Force now");
+    expect(html).toContain("Abort");
+    expect(html).toContain("Force upgrade run QR-2026-06-10-test now");
+  });
+});
+
+// ─── Trigger control basics ────────────────────────────────────────────────────
+
+describe("SelfUpgradeTriggerControl – trigger control", () => {
+  it("button has type=button attribute", () => {
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toContain('type="button"');
+  });
+
+  it("button is not disabled when no run is active", () => {
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toContain("Upgrade now");
+    expect(html).not.toContain('disabled=""');
+  });
+});
+
+// ─── Loading state ────────────────────────────────────────────────────────────
+
+describe("SelfUpgradeTriggerControl – loading", () => {
+  it("shows Upgrading... text when pending", () => {
+    shared.isPending = true;
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toContain("Upgrading...");
+    expect(html).not.toContain(">Upgrade now<");
+  });
+
+  it("button is disabled while pending", () => {
+    shared.isPending = true;
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toContain('disabled=""');
+  });
+
+  it("button has aria-busy=true while pending", () => {
+    shared.isPending = true;
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toContain('aria-busy="true"');
+  });
+
+  it("shows the 'starting' hint while busy and no run is running yet", () => {
+    shared.isPending = true;
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toContain('data-upgrade-starting="true"');
+    expect(html).toContain("No need to click again");
+  });
+
+  it("does not show the 'starting' hint once a run is already running", () => {
+    shared.isPending = false;
+    const html = renderToStaticMarkup(
+      <SelfUpgradeTriggerControl {...baseProps} latestRun={makeRun("running")} />,
+    );
+    expect(html).not.toContain('data-upgrade-starting="true"');
+  });
+});
+
+// ─── Success feedback ─────────────────────────────────────────────────────────
+
+describe("SelfUpgradeTriggerControl – success feedback", () => {
+  it("shows Upgrade queued. when trigger succeeds", () => {
+    shared.triggerResult = { queued: true };
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toContain("Upgrade queued.");
+  });
+});
+
+// ─── Error feedback ───────────────────────────────────────────────────────────
+
+describe("SelfUpgradeTriggerControl – error feedback", () => {
+  it("shows Not queued message when trigger returns not queued", () => {
+    shared.triggerResult = { queued: false, reason: "disabled" };
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toContain("Not queued:");
+  });
+
+  it("shows the specific reason for not queuing", () => {
+    shared.triggerResult = { queued: false, reason: "already-running" };
+    const html = renderToStaticMarkup(<SelfUpgradeTriggerControl {...baseProps} />);
+    expect(html).toContain("already-running");
+  });
+});

--- a/apps/web/components/ops/SelfUpgradeTriggerControl.tsx
+++ b/apps/web/components/ops/SelfUpgradeTriggerControl.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+// apps/web/components/ops/SelfUpgradeTriggerControl.tsx
+//
+// BI-D77BF495: the single "Upgrade now" trigger, co-located with the
+// OwnerReleaseCard release-status summary so it is visible on arrival in
+// BOTH nav modes — not buried behind the "Deploy controls & history" Advanced
+// disclosure (which PR #3457 forced open as a stopgap; now that the trigger
+// lives here, that section can go back to collapsing by default in Simple
+// mode without hiding the primary action).
+//
+// This is the ONLY place that owns trigger/force/abort state and calls
+// triggerSelfUpgrade / forceActiveRun / abortActiveRun — SelfUpgradeClient's
+// Advanced panel renders the read-only run/quiescence/history data derived
+// from the SAME server props, but never re-triggers (no duplicated
+// quiescence/queue/override semantics).
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { triggerSelfUpgrade, forceActiveRun, abortActiveRun } from "@/lib/actions/promotions";
+import { isExpectedDuringSwap } from "@/lib/self-upgrade/is-expected-during-swap";
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+import type { LatestRun, QuiescenceActivity } from "@/lib/self-upgrade/run-types";
+import SelfUpgradeJobEngineHealthAlert, {
+  shouldPollForJobEngineRecovery,
+  type JobEngineHealth,
+} from "@/components/ops/SelfUpgradeJobEngineHealthAlert";
+
+type Props = {
+  enabled: boolean;
+  channel: string;
+  latestRun: LatestRun | null;
+  quiescence?: QuiescenceActivity | null;
+  jobEngine?: JobEngineHealth;
+};
+
+export default function SelfUpgradeTriggerControl({
+  enabled,
+  channel,
+  latestRun,
+  quiescence,
+  jobEngine,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [override, setOverride] = useState(false);
+  const [justQueued, setJustQueued] = useState(false);
+  const [triggerResult, setTriggerResult] = useState<{ queued: boolean; reason?: string } | null>(
+    null,
+  );
+  const [forceConfirm, setForceConfirm] = useState(false);
+  const [abortConfirm, setAbortConfirm] = useState(false);
+  const [inFlightError, setInFlightError] = useState<string | null>(null);
+  // A forced upgrade can swap this portal out from under the operator's own
+  // request. `restarting` holds a calm reconnect banner (and keeps the status
+  // poll alive) instead of letting the page paint the global crash screen.
+  const [restarting, setRestarting] = useState(false);
+  const restartBaselineRef = useRef<string | null>(null);
+
+  const draining = !!quiescence && quiescence.level !== "normal";
+  const queuedRun = latestRun?.status === "queued" || latestRun?.status === "pending";
+  const upgradeInFlight = queuedRun || latestRun?.status === "running" || draining;
+  const triggerBusy = isPending || justQueued;
+
+  // The manual trigger only *queues* an upgrade: the server action returns
+  // `{ queued: true }` in well under a second, but the worker still has to
+  // fetch + compare SHAs before the run flips to "running". Hold a
+  // "Starting…" state until the run actually appears, poll so progress shows
+  // up on its own, and time out as a safety net if the queued event never
+  // materialises (e.g. skipped for cooldown).
+  useEffect(() => {
+    if (justQueued && upgradeInFlight) setJustQueued(false);
+  }, [justQueued, upgradeInFlight]);
+
+  useEffect(() => {
+    if (!justQueued) return;
+    const timeout = setTimeout(() => setJustQueued(false), 45_000);
+    return () => clearTimeout(timeout);
+  }, [justQueued]);
+
+  useEffect(() => {
+    if (!justQueued && !upgradeInFlight && !restarting) return;
+    const interval = setInterval(() => router.refresh(), 4_000);
+    return () => clearInterval(interval);
+  }, [justQueued, upgradeInFlight, restarting, router]);
+
+  useEffect(() => {
+    if (!shouldPollForJobEngineRecovery(jobEngine)) return;
+    const interval = setInterval(() => router.refresh(), 15_000);
+    return () => clearInterval(interval);
+  }, [jobEngine, router]);
+
+  // A compact fingerprint of the server-derived state. When it changes after
+  // a swap-induced disconnect, the new container has answered and the
+  // reconnect banner can clear.
+  function serverSignature(): string {
+    return [latestRun?.runId ?? "", latestRun?.status ?? "", quiescence?.level ?? ""].join("|");
+  }
+
+  useEffect(() => {
+    if (!restarting || restartBaselineRef.current === null) return;
+    if (serverSignature() !== restartBaselineRef.current) {
+      restartBaselineRef.current = null;
+      setRestarting(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [restarting, latestRun?.runId, latestRun?.status, quiescence?.level]);
+
+  // Safety net: never let the reconnect banner wedge if the portal stays
+  // unreachable (e.g. a swap that genuinely failed).
+  useEffect(() => {
+    if (!restarting) return;
+    const timeout = setTimeout(() => {
+      restartBaselineRef.current = null;
+      setRestarting(false);
+    }, 120_000);
+    return () => clearTimeout(timeout);
+  }, [restarting]);
+
+  function enterRestarting() {
+    restartBaselineRef.current = serverSignature();
+    setRestarting(true);
+    setJustQueued(true);
+    router.refresh();
+  }
+
+  function handleTrigger() {
+    setTriggerResult(null);
+    setInFlightError(null);
+    const force = override;
+    startTransition(async () => {
+      try {
+        const result = await triggerSelfUpgrade(force ? { force: true } : undefined);
+        setTriggerResult(result);
+        if (result.queued) setJustQueued(true);
+        router.refresh();
+      } catch (err) {
+        if (isExpectedDuringSwap(err)) {
+          enterRestarting();
+        } else {
+          setTriggerResult({ queued: false, reason: getErrorMessage(err) || "trigger failed" });
+        }
+      }
+    });
+  }
+
+  // BI-4F3B2FA9: escalate the active drain to forced — coordinator bypasses
+  // all blockers on its next tick (~5s) and swaps, without restarting the run.
+  function handleForceNow() {
+    const runId = quiescence?.run?.runId;
+    if (!runId) return;
+    setInFlightError(null);
+    startTransition(async () => {
+      try {
+        const r = await forceActiveRun(runId);
+        setForceConfirm(false);
+        if (!r.ok) setInFlightError(r.error ?? "Force failed");
+        router.refresh();
+      } catch (err) {
+        setForceConfirm(false);
+        if (isExpectedDuringSwap(err)) {
+          enterRestarting();
+        } else {
+          setInFlightError(getErrorMessage(err) || "Force failed");
+        }
+      }
+    });
+  }
+
+  // BI-4F3B2FA9: abort the active drain — level returns to normal so the
+  // operator can immediately start a fresh run.
+  function handleAbortRun() {
+    const runId = quiescence?.run?.runId;
+    if (!runId) return;
+    setInFlightError(null);
+    startTransition(async () => {
+      try {
+        const r = await abortActiveRun(runId);
+        setAbortConfirm(false);
+        if (!r.ok) setInFlightError(r.error ?? "Abort failed");
+        router.refresh();
+      } catch (err) {
+        setAbortConfirm(false);
+        if (isExpectedDuringSwap(err)) {
+          enterRestarting();
+        } else {
+          setInFlightError(getErrorMessage(err) || "Abort failed");
+        }
+      }
+    });
+  }
+
+  if (!enabled) {
+    return (
+      <div
+        className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2 text-sm text-[var(--dpf-muted)]"
+        data-upgrade-status="disabled"
+      >
+        Self-upgrade is disabled. Enable it in settings to allow automated upgrades.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2" data-component="self-upgrade-trigger-control">
+      {restarting && (
+        <div
+          className="p-3 rounded-lg bg-[var(--dpf-info)]/10 border border-[var(--dpf-info)]/30 text-sm text-[var(--dpf-text)]"
+          role="status"
+          aria-live="polite"
+          data-upgrade-restarting="true"
+        >
+          <span className="font-medium">Applying the upgrade…</span> the portal is
+          restarting to finish the swap. This page reconnects automatically — no
+          need to refresh.
+        </div>
+      )}
+
+      <SelfUpgradeJobEngineHealthAlert jobEngine={jobEngine} />
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="w-2 h-2 rounded-full bg-[var(--dpf-success)]" />
+          <span className="text-sm font-medium text-[var(--dpf-text)]">
+            Self-Upgrade: <span data-upgrade-status="enabled">Enabled</span>
+          </span>
+          <span className="text-xs text-[var(--dpf-muted)]">({channel})</span>
+        </div>
+
+        <div className="flex items-center gap-3">
+          {upgradeInFlight ? (
+            // BI-4F3B2FA9: a run is in flight. Never a dead-end disabled
+            // button — when the portal is draining, surface Force Now / Abort
+            // so the operator's emergency lever actually works mid-flight.
+            draining && quiescence?.run?.runId ? (
+              <div className="flex items-center gap-2" role="group" aria-label="In-flight upgrade controls">
+                {inFlightError && (
+                  <span className="text-xs text-[var(--dpf-warning)]" role="status" aria-live="polite">
+                    {inFlightError}
+                  </span>
+                )}
+                {forceConfirm ? (
+                  <div role="alertdialog" aria-describedby="force-now-warning" className="flex items-center gap-2">
+                    <span id="force-now-warning" className="text-xs text-[var(--dpf-warning)]">
+                      ⚠ Bypass all in-flight work and swap now?
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleForceNow}
+                      disabled={isPending}
+                      className="px-2 py-1 text-xs rounded-lg bg-[var(--dpf-warning)]/20 text-[var(--dpf-warning)] border border-[var(--dpf-warning)]/40 disabled:opacity-50"
+                    >
+                      Confirm force
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setForceConfirm(false)}
+                      className="px-2 py-1 text-xs rounded-lg border border-[var(--dpf-border)] text-[var(--dpf-muted)]"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : abortConfirm ? (
+                  <div role="alertdialog" aria-describedby="abort-warning" className="flex items-center gap-2">
+                    <span id="abort-warning" className="text-xs text-[var(--dpf-muted)]">
+                      Abort this drain?
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleAbortRun}
+                      disabled={isPending}
+                      className="px-2 py-1 text-xs rounded-lg bg-[var(--dpf-warning)]/20 text-[var(--dpf-warning)] border border-[var(--dpf-warning)]/40 disabled:opacity-50"
+                    >
+                      Confirm abort
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setAbortConfirm(false)}
+                      className="px-2 py-1 text-xs rounded-lg border border-[var(--dpf-border)] text-[var(--dpf-muted)]"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => { setAbortConfirm(false); setForceConfirm(true); }}
+                      aria-label={`Force upgrade run ${quiescence.run.runId} now`}
+                      className="px-3 py-1.5 text-xs rounded-lg bg-[var(--dpf-warning)]/20 text-[var(--dpf-warning)] border border-[var(--dpf-warning)]/40 hover:bg-[var(--dpf-warning)]/30 transition-colors"
+                    >
+                      ⚡ Force now
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setForceConfirm(false); setAbortConfirm(true); }}
+                      aria-label={`Abort upgrade run ${quiescence.run.runId}`}
+                      className="px-3 py-1.5 text-xs rounded-lg border border-[var(--dpf-border)] text-[var(--dpf-text)] hover:bg-[var(--dpf-surface-2)] transition-colors"
+                    >
+                      Abort
+                    </button>
+                  </>
+                )}
+              </div>
+            ) : (
+              <span
+                className="text-xs text-[var(--dpf-muted)]"
+                aria-live="polite"
+                data-upgrade-inflight="true"
+              >
+                {queuedRun
+                  ? "Upgrade queued — waiting for the worker…"
+                  : "Upgrade in progress…"}
+              </span>
+            )
+          ) : (
+            <>
+              <label className="flex items-center gap-1.5 text-xs text-[var(--dpf-muted)] cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={override}
+                  onChange={(e) => setOverride(e.target.checked)}
+                  aria-label="Emergency override: bypass the safety drain"
+                  title="Bypass the quiescence safety drain. Only for emergencies — it can interrupt in-flight work."
+                  className="accent-[var(--dpf-warning)]"
+                />
+                Emergency override
+              </label>
+              <button
+                type="button"
+                onClick={handleTrigger}
+                disabled={triggerBusy}
+                aria-busy={triggerBusy}
+                aria-label="Upgrade now"
+                data-override={override ? "true" : "false"}
+                data-owner-first-next-action
+                data-dpf-primary-action
+                className="px-4 py-2 text-sm font-semibold rounded-lg bg-[var(--dpf-accent)] text-white border border-[var(--dpf-accent)] shadow-sm hover:opacity-90 transition-opacity disabled:opacity-50"
+              >
+                {isPending
+                  ? "Upgrading..."
+                  : justQueued
+                    ? "Starting…"
+                    : override
+                      ? "Force upgrade now"
+                      : "Upgrade now"}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {triggerBusy && latestRun?.status !== "running" && !queuedRun && (
+        <div
+          className="text-xs text-[var(--dpf-muted)]"
+          data-upgrade-starting="true"
+          aria-live="polite"
+        >
+          Upgrade starting — the worker is checking for a new build. This can take
+          a few seconds; progress will appear below. No need to click again.
+        </div>
+      )}
+
+      {triggerResult && (
+        <div
+          className={`p-3 rounded-lg text-sm ${
+            triggerResult.queued
+              ? "bg-[var(--dpf-success)]/10 text-[var(--dpf-success)] border border-[var(--dpf-success)]/30"
+              : "bg-[var(--dpf-destructive)]/10 text-[var(--dpf-destructive)] border border-[var(--dpf-destructive)]/30"
+          }`}
+        >
+          {triggerResult.queued ? "Upgrade queued." : `Not queued: ${triggerResult.reason}`}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/self-upgrade/is-expected-during-swap.ts
+++ b/apps/web/lib/self-upgrade/is-expected-during-swap.ts
@@ -1,0 +1,29 @@
+// apps/web/lib/self-upgrade/is-expected-during-swap.ts
+//
+// A forced upgrade (or a recovery-point rollback) intentionally bypasses the
+// quiescence drain and restarts services, swapping the portal container out
+// from under the very request that triggered it. When the swap lands
+// mid-flight, the operator's own server-action response never returns intact
+// — Next surfaces a non-RSC transport failure ("An unexpected response was
+// received from the server", error code E394), or the browser reports a bare
+// network error. For self-upgrade surfaces that is the EXPECTED success path
+// of a swap, not a crash.
+//
+// Shared (BI-D77BF495) by SelfUpgradeTriggerControl (trigger / force / abort)
+// and SelfUpgradeClient (rollback) so both hold the same calm "reconnecting"
+// state instead of letting the rejection escalate to the global (shell)
+// error boundary and paint a full-page "Something went wrong" over an
+// upgrade that actually succeeded.
+
+import { getErrorMessage } from "@/lib/shared/get-error-message";
+
+export function isExpectedDuringSwap(err: unknown): boolean {
+  if (!err) return false;
+  // Next stamps server-action transport failures with a stable error code.
+  const code = (err as { __NEXT_ERROR_CODE?: unknown }).__NEXT_ERROR_CODE;
+  if (code === "E394") return true;
+  const message = getErrorMessage(err);
+  return /unexpected response was received|failed to fetch|fetch failed|load failed|networkerror|err_connection|connection (?:refused|reset|closed)|the operation was aborted/i.test(
+    message,
+  );
+}

--- a/apps/web/lib/self-upgrade/run-types.ts
+++ b/apps/web/lib/self-upgrade/run-types.ts
@@ -1,0 +1,54 @@
+// apps/web/lib/self-upgrade/run-types.ts
+//
+// Shared self-upgrade run / quiescence shapes. Split out (BI-D77BF495) so the
+// co-located SelfUpgradeTriggerControl (owns the trigger/force/abort actions)
+// and the SelfUpgradeClient Advanced detail panel (read-only run history,
+// activity, recovery point) describe the SAME server data without redefining
+// it twice and risking drift.
+
+export type LatestRun = {
+  runId: string;
+  status: string;
+  trigger: string | null;
+  currentSha: string | null;
+  targetSha: string | null;
+  deployedSha: string | null;
+  reason: string | null;
+  startedAt: Date | string | null;
+  completedAt: Date | string | null;
+  completionEvidence?: unknown;
+  failureLog: string | null;
+  createdAt: Date | string;
+};
+
+export type QuiescenceBlockerLine = {
+  surface: string;
+  label: string;
+  kind: "hard" | "soft";
+  count: number;
+  estimatedWaitMs: number | null;
+  sampleAgent?: string | null;
+  sampleTitle?: string | null;
+  oldestSignalAt?: string | null;
+  stale?: boolean;
+};
+
+export type QuiescenceActivity = {
+  level: "normal" | "draining" | "swapping";
+  runId: string | null;
+  enteredAt: string;
+  run: {
+    runId: string;
+    status: string;
+    trigger: string;
+    targetVersion: string | null;
+    targetBundleHash: string | null;
+    deferSurface: string | null;
+    deferReason: string | null;
+    budgetMs: number | null;
+    drainStartedAt: string | null;
+    lastHeartbeatAt: string | null;
+  } | null;
+  blockersCapturedAt: string | null;
+  blockers: QuiescenceBlockerLine[];
+};

--- a/docs/platform-usability-standards.md
+++ b/docs/platform-usability-standards.md
@@ -87,7 +87,11 @@ axis (a 0→1 transition) on pre-existing ones, so a route that was *already* bu
 not fail an unrelated PR while a route you *just* buried does. This is why marking the
 one action a surface most wants the user to take is worth doing: the gate can then tell
 "tucked away detail" (good) from "hid the main verb" (bad). The self-upgrade trigger
-regression is the motivating case.
+regression is the motivating case: the initial fix (BI-D77BF495) force-opened the
+Advanced disclosure in both nav modes as a safe increment; the completed fix extracted
+the trigger into its own `SelfUpgradeTriggerControl` component and co-located it inside
+`OwnerReleaseCard`, so the Advanced section (history/ledgers/logs only) could go back to
+collapsing by default in Simple mode without re-burying the primary action.
 
 **Progressive disclosure is rewarded, never taxed.** Measurement excises
 `<details>` without `open`, `[data-dpf-disclosure]` without `open`, `[hidden]` and

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -6,8 +6,8 @@ apps/web/components/agent/AgentCoworkerPanel.tsx	1255
 apps/web/components/agent/AgentMessageInput.tsx	1034
 apps/web/components/ea/EaCanvas.tsx	1047
 apps/web/components/inventory/TopologyGraph.tsx	1031
-apps/web/components/ops/SelfUpgradeClient.test.tsx	1226
-apps/web/components/ops/SelfUpgradeClient.tsx	1459
+apps/web/components/ops/SelfUpgradeClient.test.tsx	1069
+apps/web/components/ops/SelfUpgradeClient.tsx	1113
 apps/web/components/platform/AiOperationsMap.tsx	2881
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
@@ -37,14 +37,12 @@ apps/web/lib/explore/feature-build-types.ts	1109
 apps/web/lib/finance/ai-provider-finance.ts	1309
 apps/web/lib/inference/ai-provider-internals.ts	1228
 apps/web/lib/integrate/build-agent-prompts.ts	1064
-apps/web/lib/integrate/build-orchestrator.ts	1751
-apps/web/lib/integrate/sandbox/build-branch.ts	870
 apps/web/lib/integrate/build-orchestrator.ts	1796
-apps/web/lib/integrate/sandbox/build-branch.ts	852
+apps/web/lib/integrate/sandbox/build-branch.ts	870
 apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp-tools-backlog.test.ts	874
 apps/web/lib/mcp-tools.ts	1923
-apps/web/lib/mcp/packs/backlog-pack.ts	1320
+apps/web/lib/mcp/packs/backlog-pack.ts	1073
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	858
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
 apps/web/lib/navigation/portal-navigation-model.ts	940


### PR DESCRIPTION
## Summary

Completes BI-D77BF495 — the CEO reported the self-upgrade page "has become really hard to use... difficult to even find where the button is to trigger it."

PR #3457 already landed the systemic fix (a UX-budget `buriedPrimaryAction` reachability axis) and a safe-increment page fix (force the Advanced disclosure open in both nav modes, primary-button styling on the trigger). It explicitly deferred the "fuller fix": *"a prominent trigger co-located in the status card with only logs/history collapsible — tracked in BI-D77BF495; it needs the trigger extraction plus live upgrade-flow verification."* This PR is that fuller fix.

- **`SelfUpgradeTriggerControl`** (new) owns ALL trigger/force/abort/override state and calls the existing `triggerSelfUpgrade` / `forceActiveRun` / `abortActiveRun` server actions — no duplicated quiescence/queue/override semantics.
- It renders inside a new `OwnerReleaseCard.primaryAction` slot, so "Upgrade now" is visible on arrival in **both** nav modes without any disclosure needing to be forced open.
- `SelfUpgradeClient` keeps only read-only detail (Latest Run, run history, activity, schedule, rollback) and the Advanced `<details>` goes back to the ordinary owner-first pattern — open in Full mode, **collapsed by default in Simple mode** — since it no longer gates the primary action.
- Shared types (`LatestRun`, `QuiescenceActivity`) and `isExpectedDuringSwap` moved to `apps/web/lib/self-upgrade/` so the two components describe the same server data without redefining it.

## Design grounding

Extends the merged spec (`docs/superpowers/specs/2026-07-22-holistic-ux-system-and-agent-codification-design.md` §6) and `docs/platform-usability-standards.md`'s primary-action-reachable axis — both landed by #3457 — with the "fuller fix" that spec explicitly deferred. Completing, not forking, the governing design.

## Test plan

- [x] `tsc --noEmit` clean (0 errors) — full monorepo typecheck via root clone's TypeScript.
- [x] `SelfUpgradeTriggerControl.test.tsx` (new, 18 tests) — migrated 1:1 from `SelfUpgradeClient.test.tsx`'s trigger-control/loading/success/error-feedback blocks, plus a new BI-D77BF495 solid-primary-button-styling assertion. All passing.
- [x] `page.test.tsx` (updated, 12 tests) — new co-location assertion (trigger renders inside `OwnerReleaseCard`, ahead of the Advanced toggle, in both nav modes) and a new Simple-mode-collapses-by-default assertion. All passing.
- [x] `OwnerReleaseCard.test.tsx` (new) — covers the `primaryAction` slot: renders inside the card, positioned after the risk notice, optional/omittable.
- [x] `SelfUpgradeTriggerControl.swap-resilience.test.tsx` — migrated 1:1 from `SelfUpgradeClient.swap-resilience.test.tsx` (RTL, real click interactions, E394 transport-error handling). Could not execute locally — this sandbox's jsdom worker pool times out on startup for **every** jsdom test file, confirmed via an untouched file (`ChangesClient.test.tsx`) failing identically. Not a regression from this diff; CI's real environment runs it.
- [x] `SelfUpgradeClient.test.tsx` (trimmed) — could not execute locally in this sandbox: the report-kit barrel's `next/link` import is unresolvable because the root clone's `apps/web/node_modules` is itself missing the `next` package (pre-existing gap, present before this change — `SelfUpgradeClient.tsx` already imported from that barrel). CI's real install resolves it.
- [x] `node scripts/check-module-size.mjs` — clean; baseline retightened (`SelfUpgradeClient.tsx` 1459 → 1113 LOC; new `SelfUpgradeTriggerControl.tsx` 377 LOC, well under the 800-LOC ceiling).
- [ ] Visual verification in a running dev server (Simple + Full nav mode) — no browser/dev-server available in this sandbox; structural + component-test verification only. Screenshots not captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)