### PR TITLE
feat(governance): runtime quality-issue drift sweep — self-heal backstop + drift detection

### DIFF
--- a/apps/web/lib/operate/scheduled-jobs/catalog.ts
+++ b/apps/web/lib/operate/scheduled-jobs/catalog.ts
@@ -244,6 +244,18 @@ export const SCHEDULED_JOB_CATALOG: readonly ScheduledJobCatalogEntry[] = [
   },
   // ── Editable (operationally tunable) ──────────────────────────────────────
   {
+    jobId: "quality-issue-drift-sweep",
+    inngestId: "governance/quality-issue-drift-sweep-scheduled",
+    name: "Quality-issue drift sweep",
+    purpose:
+      "Runtime half of quality-issue governance. Self-heals the recovery/orphan backstop (closes stale entity/relationship issues whose row is active again or gone) and detects DRIFT — any issue-type open count over its declared steady-state budget — so a newly-accumulating detector is surfaced automatically instead of found by inspection. Reports drift with owners for the auto-processing router to fund and route; does not file work itself.",
+    cron: "23 5 * * *",
+    cadence: "Daily at 05:23",
+    category: "editable",
+    tracksRunData: true,
+    runNowEvent: "governance/quality-issue-drift-sweep.requested",
+  },
+  {
     jobId: "data-retention-sweep",
     inngestId: "ops/data-retention-sweep-scheduled",
     name: "Data retention sweep",

--- a/apps/web/lib/queue/functions/index.ts
+++ b/apps/web/lib/queue/functions/index.ts
@@ -56,6 +56,10 @@ import {
   dataRetentionSweepRequested,
 } from "./data-retention-sweep";
 import {
+  qualityIssueDriftSweepScheduled,
+  qualityIssueDriftSweepRequested,
+} from "./quality-issue-drift-sweep";
+import {
   inngestRetentionSweepScheduled,
   inngestRetentionSweepRequested,
 } from "./inngest-retention-sweep";
@@ -119,6 +123,8 @@ export const scheduledFunctions = [
   runtimeTargetJanitor,  // BI-AD949172: RT heartbeat sweep + lease expiry, hourly
   runtimeArtifactJanitor, // BI-DBF3F426: OBSERVE-ONLY dry-run scan of orphaned CI images + stray compose projects (logs would-reap, never deletes; --apply is founder-gated), daily 05:20, flag-gated DPF_RUNTIME_ARTIFACT_JANITOR_ENABLED
   dataRetentionSweepScheduled, // EP-DATA-RETENTION: daily DB purge of aged logs/telemetry/chat, 04:00
+  qualityIssueDriftSweepScheduled, // BI-0B420A1D: runtime governance — self-heal recovery/orphan backstop + detect per-type open-count drift vs registry budgets, daily 05:00
+
   inngestRetentionSweepScheduled, // BI-0AB96FE7: bound db=inngest history + reap Redis-TTL orphans that wedge the executor, every 6h
   mdmStewardSweepScheduled, // EP-4A12A7CB slice 4: autonomous Data Steward — sweep + auto-resolve account dupes, daily 05:00
   logSignatureScanner,   // BI-5FE8656F: EP-FULL-OBS Tier 2 novel-signature log scan, every 15m
@@ -164,6 +170,8 @@ export const eventFunctions = [
   selfUpgradeManual,
   quiescenceRun,
   dataRetentionSweepRequested, // EP-DATA-RETENTION: operator "run now" / dry-run
+  qualityIssueDriftSweepRequested, // BI-0B420A1D: operator "run now" for the quality-issue drift sweep
+
   inngestRetentionSweepRequested, // BI-0AB96FE7: operator "run now" / dry-run for the Inngest retention sweep
   mdmStewardSweepRequested, // EP-4A12A7CB slice 4: Data Steward "run now" / dry-run
   catalogEnrichmentSweepRequested, // EP-ASSET-INTELLIGENCE: catalog enrichment "run now" (poll-on-request)

--- a/apps/web/lib/queue/functions/quality-issue-drift-sweep.ts
+++ b/apps/web/lib/queue/functions/quality-issue-drift-sweep.ts
@@ -1,0 +1,66 @@
+// BI-0B420A1D — Scheduled quality-issue drift sweep (inngest).
+//
+// The runtime half of quality-issue governance. The registry
+// (packages/db/src/quality-issue-registry.ts) is the compile-time gate; this
+// makes each type's declared lifecycle live on the operator's install:
+//
+//   1. self-heal the recovery/orphan backstop (close stale issues whose scoped
+//      row is active again or gone), and
+//   2. detect DRIFT — any queue over its declared `expectedSteadyState` budget —
+//      so a newly-accumulating detector is surfaced automatically rather than
+//      found by inspection two months and thousands of rows later.
+//
+// It does NOT file backlog items or route work; the returned `drift` is the
+// input the holistic auto-processing thread consumes (drift -> BI -> weekly
+// token budget -> Build Studio / owning coworker). Runs daily at 05:00 UTC,
+// after discovery has had a chance to run and reconcile in-sweep. Quiescence-
+// gated and concurrency-limited to one in-flight run.
+
+import { cron } from "inngest";
+import { inngest } from "../inngest-client";
+import { gateAtEntry } from "../quiescence-gates";
+
+export const qualityIssueDriftSweepScheduled = inngest.createFunction(
+  {
+    id: "governance/quality-issue-drift-sweep-scheduled",
+    retries: 1,
+    concurrency: { limit: 1, scope: "fn" },
+    // Staggered off the crowded 05:00 tick (BI-SCHED-STAGGER contention guard);
+    // still early morning, after discovery has had a chance to run + reconcile.
+    triggers: [cron("23 5 * * *")],
+  },
+  async ({ step }) => {
+    const gate = await gateAtEntry(step);
+    if (!gate.proceed) return { skipped: true, reason: gate.reason };
+
+    return step.run("quality-issue-drift-sweep", async () => {
+      const { prisma, runQualityIssueDriftSweep } = await import("@dpf/db");
+      const report = await runQualityIssueDriftSweep(prisma as never);
+      const resolved = Object.values(report.autoResolved).reduce((a, b) => a + b, 0);
+      if (resolved > 0 || !report.healthy) {
+        console.log(
+          `[quality-issue-drift] auto-resolved ${resolved}; ${
+            report.healthy ? "no drift" : `${report.drift.length} queue(s) over budget: ` +
+              report.drift.map((d) => `${d.type}=${d.open} (owner ${d.owner})`).join(", ")
+          }`,
+        );
+      }
+      return report;
+    });
+  },
+);
+
+// Manual one-shot trigger for the admin "run now" action.
+export const qualityIssueDriftSweepRequested = inngest.createFunction(
+  {
+    id: "governance/quality-issue-drift-sweep-requested",
+    retries: 1,
+    triggers: [{ event: "governance/quality-issue-drift-sweep.requested" }],
+  },
+  async ({ step }) => {
+    return step.run("quality-issue-drift-sweep-manual", async () => {
+      const { prisma, runQualityIssueDriftSweep } = await import("@dpf/db");
+      return runQualityIssueDriftSweep(prisma as never);
+    });
+  },
+);

--- a/docs/superpowers/specs/2026-07-24-quality-issue-lifecycle-governance-design.md
+++ b/docs/superpowers/specs/2026-07-24-quality-issue-lifecycle-governance-design.md
@@ -87,6 +87,45 @@ the operator's database, which CI has no access to. The honest split is:
   install, auto-resolve what declares itself auto-resolvable, and file/route the
   rest. Needs the registry as its prerequisite, which this delivers.
 
+## Phase 2 — the runtime sweep (`quality-issue-drift-sweep`)
+
+Phase 1 is the compile-time gate. Phase 2 makes each type's declared lifecycle
+LIVE on the operator's install, as a scheduled inngest sweep
+(`governance/quality-issue-drift-sweep-scheduled`, daily 05:23, quiescence-gated,
+concurrency 1) delegating to the pure `runQualityIssueDriftSweep(db)`
+(`packages/db/src/quality-issue-drift-sweep.ts`):
+
+1. **Self-heal backstop.** Closes open `stale_entity` / `stale_relationship`
+   rows whose FK-linked entity/relationship is now `active` (recovered by a
+   *different* source than the one that marked it stale) or gone (deleted). The
+   common recovery case is already handled in-sweep by discovery-sync; this is
+   the global backstop for what per-source reconcile misses.
+
+2. **Drift detection.** Compares live open counts to each type's declared
+   `expectedSteadyState` and returns every over-budget queue, worst-first, with
+   its owner. This is the runtime analogue of the compile-time gate: a NEW
+   detector that starts accumulating is surfaced automatically.
+
+**Why not an open-count CI ratchet.** The `module-size-baseline.txt` pattern
+cannot apply — the open count lives in the operator's database, which CI has no
+access to. Drift monitoring must run at runtime, which is what this sweep is.
+
+**Deliberate boundary.** The sweep does NOT file backlog items or route work.
+Turning drift into funded, routed work (drift → BI → weekly use-it-or-lose-it
+token budget → Build Studio / owning coworker) is the auto-processing
+orchestration owned by the holistic estate-management thread; it consumes the
+`drift` this returns. Keeping detection and routing apart avoids the
+backlog-flood failure mode a self-filing sweep has caused before. The existing
+`governed-backlog-tee-up` → Ideate → Build autopilot is the router it feeds.
+
+**Verified state at build (2026-07-24).** 388 open, of which **0** are
+FK-resolvable — discovery-sync's reconcile plus the arc's migrations already
+drained the mechanically-resolvable set, so the backstop resolves 0 today. Its
+standing value is (a) catching future cross-source recovery / deletion, and (b)
+making drift visible: `lifecycle_unverified` (178) and `catalog_match_ambiguous`
+(175) show as over-budget, owned by `coworker:estate-specialist` and already
+covered by the in-progress triage sprint BI-E4A86393.
+
 ## Out of scope / follow-ups (BI-0B420A1D)
 
 - **Runtime drift sweep + auto-processing loop**: detect drift → file/claim a BI →

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,6 +17,25 @@ export { WriteGateRequirement } from "../generated/client/client";
 export * from "./healthcare-patient-authority";
 export * from "./healthcare-care-intake";
 
+// Quality-issue lifecycle governance (BI-0B420A1D): the registry is the
+// compile-time contract; the drift sweep is the runtime half.
+export {
+  QUALITY_ISSUE_REGISTRY,
+  QUALITY_ISSUE_TYPES,
+  isKnownQualityIssueType,
+  qualityIssueContract,
+  operatorActionableTypes,
+  qualityIssueDrift,
+  type QualityIssueType,
+  type QualityIssueContract,
+  type QualityIssueResolver,
+} from "./quality-issue-registry";
+export {
+  runQualityIssueDriftSweep,
+  type DriftSweepDb,
+  type QualityIssueDriftReport,
+} from "./quality-issue-drift-sweep";
+
 // Qdrant vector database
 export {
   ensureCollections as ensureQdrantCollections,

--- a/packages/db/src/quality-issue-drift-sweep.test.ts
+++ b/packages/db/src/quality-issue-drift-sweep.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runQualityIssueDriftSweep, type DriftSweepDb } from "./quality-issue-drift-sweep";
+
+const NOW = new Date("2026-07-24T12:00:00.000Z");
+
+function makeDb(overrides: {
+  grouped?: Array<{ issueType: string; _count: { _all: number } }>;
+  candidates?: Array<{
+    id: string;
+    issueType: string;
+    inventoryEntityId: string | null;
+    inventoryRelationshipId: string | null;
+  }>;
+  entities?: Array<{ id: string; status: string }>;
+  relationships?: Array<{ id: string; status: string }>;
+}) {
+  const updateMany = vi.fn(async ({ where }: { where: { id: { in: string[] } } }) => ({
+    count: where.id.in.length,
+  }));
+  const db: DriftSweepDb = {
+    portfolioQualityIssue: {
+      groupBy: vi.fn(async () => overrides.grouped ?? []),
+      findMany: vi.fn(async () => overrides.candidates ?? []),
+      updateMany,
+    },
+    inventoryEntity: {
+      findMany: vi.fn(async () => overrides.entities ?? []),
+    },
+    inventoryRelationship: {
+      findMany: vi.fn(async () => overrides.relationships ?? []),
+    },
+  };
+  return { db, updateMany };
+}
+
+describe("runQualityIssueDriftSweep — drift detection", () => {
+  it("reports over-budget queues worst-first with their owner, and healthy=false", async () => {
+    const { db } = makeDb({
+      grouped: [
+        { issueType: "lifecycle_unverified", _count: { _all: 178 } },
+        { issueType: "catalog_match_ambiguous", _count: { _all: 175 } },
+      ],
+    });
+
+    const report = await runQualityIssueDriftSweep(db, NOW);
+
+    expect(report.healthy).toBe(false);
+    expect(report.drift.map((d) => d.type)).toEqual([
+      "lifecycle_unverified",
+      "catalog_match_ambiguous",
+    ]);
+    expect(report.drift[0]).toMatchObject({ open: 178, budget: 0, over: 178 });
+    expect(report.drift[0].owner).toBe("coworker:estate-specialist");
+    expect(report.scannedAt).toBe(NOW);
+  });
+
+  it("is healthy when every registered queue is at its steady state", async () => {
+    const { db } = makeDb({ grouped: [{ issueType: "stale_entity", _count: { _all: 0 } }] });
+    const report = await runQualityIssueDriftSweep(db, NOW);
+    expect(report.healthy).toBe(true);
+    expect(report.drift).toEqual([]);
+  });
+
+  it("ignores an unregistered legacy type rather than inventing a budget", async () => {
+    const { db } = makeDb({
+      grouped: [
+        { issueType: "some_legacy_type", _count: { _all: 999 } },
+        { issueType: "stale_entity", _count: { _all: 3 } },
+      ],
+    });
+    const report = await runQualityIssueDriftSweep(db, NOW);
+    expect(report.openByType).not.toHaveProperty("some_legacy_type");
+    expect(report.drift.map((d) => d.type)).toEqual(["stale_entity"]);
+  });
+});
+
+describe("runQualityIssueDriftSweep — recovery backstop (self-heal)", () => {
+  it("resolves a stale issue whose linked entity is active again", async () => {
+    const { db, updateMany } = makeDb({
+      grouped: [],
+      candidates: [
+        { id: "qi-1", issueType: "stale_entity", inventoryEntityId: "e-1", inventoryRelationshipId: null },
+        { id: "qi-2", issueType: "stale_entity", inventoryEntityId: "e-2", inventoryRelationshipId: null },
+      ],
+      entities: [
+        { id: "e-1", status: "active" }, // recovered → resolve
+        { id: "e-2", status: "stale" }, // still stale → keep
+      ],
+    });
+
+    const report = await runQualityIssueDriftSweep(db, NOW);
+
+    expect(report.autoResolved).toEqual({ stale_entity: 1 });
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["qi-1"] } },
+      data: { status: "resolved", resolvedAt: NOW },
+    });
+  });
+
+  it("resolves a stale issue whose linked entity was deleted (absent from lookup)", async () => {
+    const { db, updateMany } = makeDb({
+      candidates: [
+        { id: "qi-3", issueType: "stale_relationship", inventoryEntityId: null, inventoryRelationshipId: "r-1" },
+      ],
+      relationships: [], // r-1 no longer exists → resolve
+    });
+
+    const report = await runQualityIssueDriftSweep(db, NOW);
+
+    expect(report.autoResolved).toEqual({ stale_relationship: 1 });
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["qi-3"] } },
+      data: { status: "resolved", resolvedAt: NOW },
+    });
+  });
+
+  it("resolves nothing when there are no FK-linked candidates (the common case today)", async () => {
+    const { db, updateMany } = makeDb({ candidates: [], grouped: [] });
+    const report = await runQualityIssueDriftSweep(db, NOW);
+    expect(report.autoResolved).toEqual({});
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/packages/db/src/quality-issue-drift-sweep.ts
+++ b/packages/db/src/quality-issue-drift-sweep.ts
@@ -1,0 +1,219 @@
+// quality-issue-drift-sweep.ts
+//
+// The RUNTIME half of quality-issue governance. The registry
+// (quality-issue-registry.ts) is the compile-time gate — a detector cannot be
+// born without a declared lifecycle. This sweep is what makes that lifecycle
+// LIVE on the operator's install:
+//
+//   1. Auto-resolve (self-heal) — close open issues whose declared auto-resolve
+//      condition is now demonstrably true but which discovery-sync's per-source,
+//      per-sweep reconcile did not catch: a stale entity/relationship confirmed
+//      ACTIVE by a *different* source, or one whose scoped row was deleted. This
+//      is the global backstop; the common case is already handled in-sweep.
+//
+//   2. Drift detection — compare live open counts to each type's declared
+//      `expectedSteadyState` budget and return every over-budget queue,
+//      worst-first, WITH its owner. This is the runtime analogue of the
+//      compile-time gate: a NEW detector that starts accumulating is surfaced
+//      automatically instead of found by a human eyeballing a dashboard two
+//      months and 2,247 rows later.
+//
+// This module deliberately does NOT file backlog items or route work. Turning
+// drift into funded, routed work (drift -> BI -> weekly token budget -> Build
+// Studio / owning coworker) is the auto-processing orchestration owned by the
+// holistic estate-management thread (BI-0B420A1D); it consumes the `drift`
+// this returns. Keeping the two apart avoids the backlog-flood failure mode a
+// self-filing sweep has caused before.
+
+import {
+  qualityIssueDrift,
+  isKnownQualityIssueType,
+  type QualityIssueType,
+} from "./quality-issue-registry";
+
+// Types whose auto-resolve is "observed active again" — the ones the recovery
+// backstop can safely close when the scoped row is now active.
+const RECOVERY_RESOLVABLE_TYPES: readonly QualityIssueType[] = [
+  "stale_entity",
+  "stale_relationship",
+];
+
+/** Narrow DB handle — the real Prisma client is a structural superset. */
+export interface DriftSweepDb {
+  portfolioQualityIssue: {
+    groupBy(args: {
+      by: ["issueType"];
+      where: { status: string };
+      _count: { _all: true };
+    }): Promise<Array<{ issueType: string; _count: { _all: number } }>>;
+    findMany(args: {
+      where: Record<string, unknown>;
+      select: {
+        id: true;
+        issueType: true;
+        inventoryEntityId: true;
+        inventoryRelationshipId: true;
+      };
+    }): Promise<
+      Array<{
+        id: string;
+        issueType: string;
+        inventoryEntityId: string | null;
+        inventoryRelationshipId: string | null;
+      }>
+    >;
+    updateMany(args: {
+      where: { id: { in: string[] } };
+      data: { status: string; resolvedAt: Date };
+    }): Promise<{ count: number }>;
+  };
+  inventoryEntity: {
+    findMany(args: {
+      where: { id: { in: string[] } };
+      select: { id: true; status: true };
+    }): Promise<Array<{ id: string; status: string }>>;
+  };
+  inventoryRelationship: {
+    findMany(args: {
+      where: { id: { in: string[] } };
+      select: { id: true; status: true };
+    }): Promise<Array<{ id: string; status: string }>>;
+  };
+}
+
+export interface QualityIssueDriftReport {
+  scannedAt: Date;
+  /** Open-count per registered issue type after the auto-resolve pass. */
+  openByType: Record<string, number>;
+  /** How many rows the self-heal backstop closed this run, per type. */
+  autoResolved: Record<string, number>;
+  /** Over-budget queues, worst overrun first, each tagged with its owner. */
+  drift: Array<{
+    type: QualityIssueType;
+    open: number;
+    budget: number;
+    over: number;
+    owner: string;
+  }>;
+  /** True when no registered queue is over its declared steady-state budget. */
+  healthy: boolean;
+}
+
+/**
+ * Resolve the recovery/orphan backstop: open stale_entity / stale_relationship
+ * rows whose FK-linked entity or relationship is now `active` (recovered) or no
+ * longer exists (deleted). Returns per-type counts of what was closed.
+ *
+ * Pure over the injected db; the caller supplies `now` so the result is
+ * deterministic in tests.
+ */
+async function autoResolveRecovered(
+  db: DriftSweepDb,
+  now: Date,
+): Promise<Record<string, number>> {
+  const candidates = await db.portfolioQualityIssue.findMany({
+    where: {
+      status: "open",
+      issueType: { in: RECOVERY_RESOLVABLE_TYPES as unknown as string[] },
+      OR: [
+        { inventoryEntityId: { not: null } },
+        { inventoryRelationshipId: { not: null } },
+      ],
+    },
+    select: {
+      id: true,
+      issueType: true,
+      inventoryEntityId: true,
+      inventoryRelationshipId: true,
+    },
+  });
+
+  if (candidates.length === 0) return {};
+
+  const entityIds = [
+    ...new Set(candidates.map((c) => c.inventoryEntityId).filter((v): v is string => !!v)),
+  ];
+  const relationshipIds = [
+    ...new Set(
+      candidates.map((c) => c.inventoryRelationshipId).filter((v): v is string => !!v),
+    ),
+  ];
+
+  const [entities, relationships] = await Promise.all([
+    entityIds.length
+      ? db.inventoryEntity.findMany({ where: { id: { in: entityIds } }, select: { id: true, status: true } })
+      : Promise.resolve([]),
+    relationshipIds.length
+      ? db.inventoryRelationship.findMany({
+          where: { id: { in: relationshipIds } },
+          select: { id: true, status: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const entityStatus = new Map(entities.map((e) => [e.id, e.status]));
+  const relationshipStatus = new Map(relationships.map((r) => [r.id, r.status]));
+
+  // Resolvable when the scoped row is active again, OR when it is gone entirely
+  // (deleted → its FK id is absent from the lookup): an issue about a row that
+  // no longer exists can never be acted on.
+  const resolvableByType: Record<string, string[]> = {};
+  for (const c of candidates) {
+    const recovered = c.inventoryEntityId
+      ? entityStatus.get(c.inventoryEntityId) !== "stale"
+      : c.inventoryRelationshipId
+        ? relationshipStatus.get(c.inventoryRelationshipId) !== "stale"
+        : false;
+    if (recovered) {
+      (resolvableByType[c.issueType] ??= []).push(c.id);
+    }
+  }
+
+  const resolved: Record<string, number> = {};
+  for (const [type, ids] of Object.entries(resolvableByType)) {
+    if (ids.length === 0) continue;
+    const { count } = await db.portfolioQualityIssue.updateMany({
+      where: { id: { in: ids } },
+      data: { status: "resolved", resolvedAt: now },
+    });
+    resolved[type] = count;
+  }
+  return resolved;
+}
+
+/**
+ * Run the quality-issue drift sweep: self-heal the backstop, then measure drift
+ * against the registry budgets. Pure over the injected db + clock.
+ */
+export async function runQualityIssueDriftSweep(
+  db: DriftSweepDb,
+  now: Date = new Date(),
+): Promise<QualityIssueDriftReport> {
+  const autoResolved = await autoResolveRecovered(db, now);
+
+  const grouped = await db.portfolioQualityIssue.groupBy({
+    by: ["issueType"],
+    where: { status: "open" },
+    _count: { _all: true },
+  });
+
+  const openByType: Record<string, number> = {};
+  for (const row of grouped) {
+    // Only registered types carry a budget; an unregistered type reaching the DB
+    // is prevented at compile time, but a legacy row is ignored rather than
+    // assigned an invented budget.
+    if (isKnownQualityIssueType(row.issueType)) {
+      openByType[row.issueType] = row._count._all;
+    }
+  }
+
+  const drift = qualityIssueDrift(openByType);
+
+  return {
+    scannedAt: now,
+    openByType,
+    autoResolved,
+    drift,
+    healthy: drift.length === 0,
+  };
+}


### PR DESCRIPTION
**Phase 2 of BI-0B420A1D.** Phase 1 (#3476, merged) was the compile-time gate — a detector cannot be *born* without a declared lifecycle. This makes that lifecycle **live on the operator's install**. Design (extended): `docs/superpowers/specs/2026-07-24-quality-issue-lifecycle-governance-design.md`.

New scheduled inngest sweep (`governance/quality-issue-drift-sweep-scheduled`, daily 05:00, quiescence-gated, concurrency 1) → pure `runQualityIssueDriftSweep(db)`:

**1. Self-heal backstop.** Closes open `stale_entity` / `stale_relationship` rows whose FK-linked entity/relationship is now `active` (recovered by a *different* source than marked it) or gone (deleted) — the global backstop for what discovery-sync's per-source, in-sweep reconcile misses.

**2. Drift detection.** Compares live open counts to each type's declared `expectedSteadyState` and returns every over-budget queue, worst-first, **with its owner**. The runtime analogue of the compile-time gate: a *new* over-accumulating detector is surfaced automatically instead of found by inspection two months and thousands of rows later.

## Two deliberate boundaries
- **Why not an open-count CI ratchet** (the `module-size-baseline.txt` pattern): impossible — the open count lives in the operator's DB, which CI can't see. Drift monitoring must run at runtime. This is that runtime.
- **The sweep does NOT file BIs or route work.** Turning drift into funded, routed work (drift → BI → weekly use-it-or-lose-it token budget → Build Studio / owning coworker) is the auto-processing orchestration owned by the holistic estate thread; it consumes the `drift` this returns, and the existing `governed-backlog-tee-up → Ideate → Build` autopilot is the router it feeds. Keeping detection and routing apart avoids the backlog-flood failure mode a self-filing sweep has caused before.

## Verification
- Pure core **8/8** against real source: drift ordering + owner, healthy state, ignores unregistered types, recovery/deletion resolve, no-candidate no-op.
- **Honest live state (2026-07-24):** 388 open, **0 FK-resolvable** — the arc already drained the resolvable set, so the backstop resolves 0 *today*; its value is standing (future cross-source recovery / deletion) + making drift visible. `lifecycle_unverified` (178) + `catalog_match_ambiguous` (175) surface as over-budget, owned by `coworker:estate-specialist`, already covered by in-progress BI-E4A86393.
- Registered in the function registry **and** `SCHEDULED_JOB_CATALOG` (the cron↔catalog parity guard requires both). Module-size guard green. Local typecheck skipped (source-only worktree); CI gates.

BI-0B420A1D

🤖 Generated with [Claude Code](https://claude.com/claude-code)