### PR TITLE
feat(kernel): migrate the mcp tool-governance cohort to software-engineer (BI-5FE47130)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,7 @@ The paved-road walkthrough is the `dpf-establish-coworker` skill (`packages/dpf-
 
 ## 9. External Tools
 
-→ [kernel principle](docs/founder-kernel/wiki/principles/tool-evaluation-pipeline.md)
+→ [kernel principle](docs/professions/software-engineer/wiki/tool-evaluation-pipeline.md)
 
 External MCP servers, npm packages, and APIs must pass the Tool Evaluation Pipeline (EP-GOVERN-002) before adoption: 6 agents covering security, architecture, compliance, integration. Approved tools are version-pinned in `packages/db/data/approved_tools_registry.json` with re-evaluation scheduled.
 

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -3216,36 +3216,6 @@
         "see-also"
       ]
     },
-    "docs/founder-kernel/wiki/principles/tool-evaluation-pipeline.md": {
-      "publicHref": "/founder-kernel/wiki/principles/tool-evaluation-pipeline/",
-      "portalHref": null,
-      "publishedPublic": true,
-      "publishedPortal": false,
-      "anchors": [
-        "rule",
-        "why",
-        "applies-to",
-        "how-to-apply",
-        "decision-dimensions",
-        "examples",
-        "sources"
-      ]
-    },
-    "docs/founder-kernel/wiki/principles/tools-must-be-self-documenting.md": {
-      "publicHref": "/founder-kernel/wiki/principles/tools-must-be-self-documenting/",
-      "portalHref": null,
-      "publishedPublic": true,
-      "publishedPortal": false,
-      "anchors": [
-        "rule",
-        "why",
-        "applies-to",
-        "how-to-apply",
-        "decision-dimensions",
-        "examples",
-        "sources"
-      ]
-    },
     "docs/founder-kernel/wiki/principles/verify-substrate-before-proposing-new.md": {
       "publicHref": "/founder-kernel/wiki/principles/verify-substrate-before-proposing-new/",
       "portalHref": null,
@@ -6215,6 +6185,36 @@
         "why",
         "how-to-apply",
         "see-also"
+      ]
+    },
+    "docs/professions/software-engineer/wiki/tool-evaluation-pipeline.md": {
+      "publicHref": "/professions/software-engineer/wiki/tool-evaluation-pipeline/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "examples",
+        "sources"
+      ]
+    },
+    "docs/professions/software-engineer/wiki/tools-must-be-self-documenting.md": {
+      "publicHref": "/professions/software-engineer/wiki/tools-must-be-self-documenting/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "examples",
+        "sources"
       ]
     },
     "docs/professions/strategy-executive/wiki/align-work-to-strategy.md": {

--- a/docs/professions/software-engineer/wiki/tool-evaluation-pipeline.md
+++ b/docs/professions/software-engineer/wiki/tool-evaluation-pipeline.md
@@ -9,12 +9,10 @@ principleDimensionVector: {"governance_compliance": 0.8, "public_safety": 0.7, "
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
-  - human
 principleRingScope:
   - ring-1-coworker
-principleConsumerArchetype: route-domain-specific
-principleConsumerContexts:
-  - mcp
+principleConsumerArchetype: specialist
+professionCompetencyLevel: practitioner
 principlePublic: true
 principlePublicRationale: Documents DPF's external-dependency vetting posture — adopters depend on it for security and supply-chain auditability.
 sources:

--- a/docs/professions/software-engineer/wiki/tools-must-be-self-documenting.md
+++ b/docs/professions/software-engineer/wiki/tools-must-be-self-documenting.md
@@ -9,12 +9,10 @@ principleDimensionVector: {"long_term_maintainability": 0.5, "human_cognitive_lo
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
-  - human
 principleRingScope:
   - ring-1-coworker
-principleConsumerArchetype: route-domain-specific
-principleConsumerContexts:
-  - mcp
+principleConsumerArchetype: specialist
+professionCompetencyLevel: practitioner
 principlePublic: true
 principlePublicRationale: Adopters building MCP tools or coworker skills need this rule front and center — the tool schema is the contract.
 sources:

--- a/packages/db/data/agent_control_plane_maturity_seed.json
+++ b/packages/db/data/agent_control_plane_maturity_seed.json
@@ -37,7 +37,7 @@
     "maturityGaps": ["Gateway hardening", "Readiness scoring", "External MCP maturity"],
     "evidenceSources": [],
     "hiveMindSignals": [],
-    "kernelPrinciples": ["tool-evaluation-pipeline", "never-ask-user-to-run-commands"],
+    "kernelPrinciples": ["never-ask-user-to-run-commands"],
     "operationalSurface": "/platform/tools/integrations",
     "dependsOnAssessmentIds": ["ACPM-IDENTITY-AUTHORITY"]
   },

--- a/packages/db/src/wiki-slug-migrations.ts
+++ b/packages/db/src/wiki-slug-migrations.ts
@@ -97,6 +97,18 @@ export const WIKI_SLUG_MIGRATIONS: readonly WikiSlugMigration[] = [
     to: "professions/data-architect/trust-the-data-spine",
     reason: "data-model cohort -> data-architect (BI-5FE47130)",
   },
+  // Second cohort: single-context sourced `mcp` principles that are software
+  // engineering practice (evaluating + documenting tools).
+  {
+    from: "principles/tool-evaluation-pipeline",
+    to: "professions/software-engineer/tool-evaluation-pipeline",
+    reason: "mcp cohort -> software-engineer (BI-5FE47130)",
+  },
+  {
+    from: "principles/tools-must-be-self-documenting",
+    to: "professions/software-engineer/tools-must-be-self-documenting",
+    reason: "mcp cohort -> software-engineer (BI-5FE47130)",
+  },
 ];
 
 export type SlugMigrationOutcome = {


### PR DESCRIPTION
BI-5FE47130 **cohort 2** — using the slug-rename pass merged in #3484. Advances the migration from 9/53 toward completion.

Seed-Fit-Decision: global-default

## What moves

Two single-context `mcp` principles that are software-engineering practice → the software-engineer corpus:

- `tool-evaluation-pipeline`, `tools-must-be-self-documenting`

Each becomes `specialist` (from `route-domain-specific`), drops `principleConsumerContexts`, gains `professionCompetencyLevel`, and drops `human` from `principleAppliesTo` (§8A.1 coherence — `specialist` serves AI coworkers). A `WIKI_SLUG_MIGRATIONS` entry renames each row **in place**, preserving id/history/references/Qdrant point. Git tracks both as renames.

## Deliberately excluded

The four **multi-context** `mcp` principles (`bundled-services-active-by-default`, `db-fallback-explicit`, `mcp-is-the-coordination-plane`, `no-provider-pinning`). Moving a multi-context principle to one profession silently removes it from its other contexts' reach; the coordination-plane / provider-pinning ones are also platform-native doctrine that likely belongs in WWMD (bucket triage, not a move).

## Reference sweep (the classes the first cohort's CI caught)

- **AGENTS.md** link to `tool-evaluation-pipeline.md` repointed. (The other AGENTS.md line references the *spec* path, not the principle — untouched. `principle-based-rules.md` mentions the slug as a backtick prose token, not a markdown link — the gate doesn't flag it.)
- **`agent_control_plane_maturity_seed.json`**: dropped `tool-evaluation-pipeline` from a `kernelPrinciples` array (validated against the kernel dir; no longer a kernel principle). Row keeps `never-ask-user-to-run-commands`.

Kernel principle count: **91 → 89**.

## Verification

Doc-link integrity + module-size pass; slug-migrations (collision/chain guards), §8A.1 coherence, and maturity-seed validators green; doc index regenerated with no stale principle-path reference. The `qdrant.test.ts` failures in the full `packages/db/src` run are **pre-existing full-suite mock bleed** — reproduced on the clean tree; they pass when run alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)