### PR TITLE
fix(mcp): resolve docker compose cwd via DPF_REPO_ROOT, not PROJECT_ROOT (BI-7A87A155)

### DIFF
--- a/apps/web/lib/mcp/packs/admin-pack.test.ts
+++ b/apps/web/lib/mcp/packs/admin-pack.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const db = vi.hoisted(() => ({
   adminActivityCreate: vi.fn(),
@@ -11,7 +11,7 @@ vi.mock("@dpf/db", () => ({
   },
 }));
 
-import { adminPack } from "./admin-pack";
+import { adminPack, composeCwd } from "./admin-pack";
 import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
 
 const EXPECTED_TOOLS = [
@@ -170,5 +170,38 @@ describe("admin pack — handler behavior (delegation preserved)", () => {
     const res = await adminPack.handlers.admin_read_file({}, "u1");
     expect(res.success).toBe(false);
     expect(res.error).toContain("path is required");
+  });
+});
+
+// BI-7A87A155 — admin_run_migration/admin_run_command/admin_run_seed/admin_view_logs
+// all shell out to `docker compose`, which resolves its config file from cwd.
+// PROJECT_ROOT (/workspace) is the Build Studio self-dev source volume: it is
+// image-synced and never carries docker-compose.yml, so every `docker compose`
+// call run from it failed with "no configuration file provided: not found".
+// DPF_REPO_ROOT (/host-dpf) is the live bind mount of the host's real install
+// directory and does carry the compose file.
+describe("admin pack — docker compose cwd resolution (BI-7A87A155)", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("prefers DPF_REPO_ROOT over PROJECT_ROOT", () => {
+    process.env.DPF_REPO_ROOT = "/host-dpf";
+    process.env.PROJECT_ROOT = "/workspace";
+    expect(composeCwd()).toBe("/host-dpf");
+  });
+
+  it("falls back to PROJECT_ROOT when DPF_REPO_ROOT is unset", () => {
+    delete process.env.DPF_REPO_ROOT;
+    process.env.PROJECT_ROOT = "/workspace";
+    expect(composeCwd()).toBe("/workspace");
+  });
+
+  it("falls back to /app when neither is set", () => {
+    delete process.env.DPF_REPO_ROOT;
+    delete process.env.PROJECT_ROOT;
+    expect(composeCwd()).toBe("/app");
   });
 });

--- a/apps/web/lib/mcp/packs/admin-pack.ts
+++ b/apps/web/lib/mcp/packs/admin-pack.ts
@@ -116,6 +116,17 @@ const definitions: ToolDefinition[] = [
   },
 ];
 
+// `docker compose` resolves its config file from cwd. PROJECT_ROOT (/workspace)
+// is the Build Studio self-dev source volume — image-synced, no compose file
+// ever lands there (docker-entrypoint.sh only copies TS source). DPF_REPO_ROOT
+// (/host-dpf) is the live bind mount of the host's real install directory and
+// does carry docker-compose.yml, so it's the correct cwd for any `docker
+// compose` invocation (BI-7A87A155; mirrors the DPF_REPO_ROOT convention in
+// lib/verify/git-ancestry.ts and lib/work-capsules/mcp-handlers.ts).
+export function composeCwd(): string {
+  return process.env.DPF_REPO_ROOT || process.env.PROJECT_ROOT || "/app";
+}
+
 /** Fire-and-forget: log admin tool activity to AdminActivity for the audit trail. */
 function logAdminActivity(
   userId: string, toolName: string, parameters: Record<string, unknown>,
@@ -138,7 +149,7 @@ async function adminViewLogs(params: Record<string, unknown>, userId: string): P
     const { promisify } = lazyUtil();
     const execAsync = promisify(execCb);
     const { stdout } = await execAsync(`docker compose logs ${service} --tail ${lines} --no-color 2>&1`, {
-      cwd: process.env.PROJECT_ROOT || "/app",
+      cwd: composeCwd(),
       timeout: 15_000,
     });
     await logAdminActivity(userId, "admin_view_logs", { service, lines }, "success", 1, stdout.slice(0, 500));
@@ -278,7 +289,7 @@ async function adminRunMigration(_params: Record<string, unknown>, userId: strin
     await logAdminActivity(userId, "admin_run_migration", {}, "success", 2, "Running prisma migrate deploy");
     const { stdout, stderr } = await execAsync(
       `docker compose exec -T portal pnpm --filter @dpf/db exec prisma migrate deploy 2>&1`,
-      { cwd: process.env.PROJECT_ROOT || "/app", timeout: 120_000 },
+      { cwd: composeCwd(), timeout: 120_000 },
     );
     const output = (stdout + "\n" + stderr).trim();
     return { success: true, message: "Migration deploy complete.", data: { output: output.slice(0, 5000) } };
@@ -296,7 +307,7 @@ async function adminRunSeed(_params: Record<string, unknown>, userId: string): P
     await logAdminActivity(userId, "admin_run_seed", {}, "success", 2, "Running seed");
     const { stdout, stderr } = await execAsync(
       `docker compose exec -T portal pnpm --filter @dpf/db run seed 2>&1`,
-      { cwd: process.env.PROJECT_ROOT || "/app", timeout: 300_000 },
+      { cwd: composeCwd(), timeout: 300_000 },
     );
     const output = (stdout + "\n" + stderr).trim();
     return { success: true, message: "Seed complete.", data: { output: output.slice(0, 5000) } };
@@ -348,7 +359,7 @@ async function adminRunCommand(params: Record<string, unknown>, userId: string):
     const execAsync = promisify(execCb);
     await logAdminActivity(userId, "admin_run_command", { command }, "success", 2, `Running: ${command.slice(0, 200)}`);
     const { stdout, stderr } = await execAsync(command + " 2>&1", {
-      cwd: process.env.PROJECT_ROOT || "/app",
+      cwd: composeCwd(),
       timeout: 60_000,
     });
     const output = (stdout + "\n" + stderr).trim();


### PR DESCRIPTION
## Summary
- `admin_run_migration`, `admin_run_command`, `admin_run_seed`, and `admin_view_logs` all shell out to `docker compose`, which resolves its config file from `cwd`. The `cwd` was `PROJECT_ROOT` (`/workspace`) — the Build Studio self-dev source volume, which is image-synced (`docker-entrypoint.sh` copies only TypeScript source into it) and never carries `docker-compose.yml`. Every `docker compose` call from these tools failed with `no configuration file provided: not found`, blocking the only governed path to apply a reviewed migration/command against the live install from an agent session.
- Added `composeCwd()`, preferring `DPF_REPO_ROOT` (`/host-dpf` — the live bind mount of the host's real compose directory, already set on the `portal` service for exactly this reason) over `PROJECT_ROOT`, falling back to `"/app"` only if both are unset. `admin_read_file` is untouched — it reads Build Studio source under `PROJECT_ROOT`, a different concern from invoking `docker compose`.
- Mirrors the existing `DPF_REPO_ROOT` convention already used by `lib/verify/git-ancestry.ts` and `lib/work-capsules/mcp-handlers.ts`, and follows the same resolution pattern `admin_restart_service` adopted for this exact failure class.

## Design grounding
Design-Grounding-Decision: internal MCP admin-tool bugfix (cwd resolution for a `child_process.exec` call) — no UX/workflow/navigation surface is touched; the design-grounding hook fires generically on edits to this file.

## Test plan
- [x] `vitest run admin-pack.test.ts` — 19/19 passing (3 new tests covering the `DPF_REPO_ROOT` > `PROJECT_ROOT` > `"/app"` precedence), run via root-clone `node_modules` junction (this worktree ships source-only).
- [x] Targeted `tsc --noEmit` on `apps/web` — zero errors touching `admin-pack.ts`.
- [ ] Live-install smoke test of `admin_run_migration`/`admin_run_command` against the running `dpf-portal-1` — needs the governed self-upgrade path to deploy this change first; tracked as the closing verification step on BI-7A87A155.

Resolves BI-7A87A155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)