### PR TITLE
fix(build-studio): terminate a plan-phase build deadlocked on an abandoned sibling (BI-7B6D7661)

### DIFF
--- a/apps/web/lib/build/feature-build-dependencies.test.ts
+++ b/apps/web/lib/build/feature-build-dependencies.test.ts
@@ -41,6 +41,7 @@ describe("deriveFeatureBuildDependencyGate", () => {
 
     expect(gate.allowed).toBe(false);
     if (gate.allowed) throw new Error("unreachable");
+    expect(gate.blocked).toBe("waiting");
     expect(gate.waitingOn).toEqual([
       {
         buildId: "FB-UPSTREAM",
@@ -50,6 +51,67 @@ describe("deriveFeatureBuildDependencyGate", () => {
     ]);
     expect(gate.message).toContain("Waiting on: Truck and parts read");
     expect(gate.message).not.toContain("build-row-upstream");
+  });
+
+  // BI-7B6D7661: a sibling in a terminal (abandoned/failed) phase can never
+  // complete, so a dependent waiting on it is DEADLOCKED, not pending. The gate
+  // must classify this as `unsatisfiable` so the caller terminates the dependent
+  // instead of re-queuing "Waiting on: …" forever.
+  it.each(["abandoned", "failed"])(
+    "flags a child as unsatisfiable when an upstream sibling is %s",
+    (deadPhase) => {
+      const gate = deriveFeatureBuildDependencyGate({
+        id: "build-row-dependent",
+        buildId: "FB-DEADLOCKED",
+        title: "Federation and SCIM edge truck",
+        parentEpicId: "epic-row-1",
+        phase: "plan",
+        dependenciesOut: [
+          {
+            dependsOn: {
+              id: "build-row-dead",
+              buildId: "FB-DEAD",
+              title: "Partner team and invitation jobs truck",
+              phase: deadPhase,
+            },
+          },
+        ],
+      });
+
+      expect(gate.allowed).toBe(false);
+      if (gate.allowed) throw new Error("unreachable");
+      expect(gate.blocked).toBe("unsatisfiable");
+      if (gate.blocked !== "unsatisfiable") throw new Error("unreachable");
+      expect(gate.deadDependencies).toEqual([
+        { buildId: "FB-DEAD", title: "Partner team and invitation jobs truck", phase: deadPhase },
+      ]);
+      expect(gate.message).toContain("Blocked permanently");
+      expect(gate.message).toContain("Partner team and invitation jobs truck");
+    },
+  );
+
+  // A mix of one dead + one still-live upstream is unsatisfiable overall — the
+  // dead one can never complete, so waiting on the live one is moot.
+  it("treats a dead + live dependency mix as unsatisfiable (dead dep is decisive)", () => {
+    const gate = deriveFeatureBuildDependencyGate({
+      id: "build-row-dependent",
+      buildId: "FB-DEADLOCKED",
+      title: "Deal registration and workbench truck",
+      parentEpicId: "epic-row-1",
+      phase: "plan",
+      dependenciesOut: [
+        { dependsOn: { id: "row-live", buildId: "FB-LIVE", title: "Program setup truck", phase: "build" } },
+        { dependsOn: { id: "row-dead", buildId: "FB-DEAD", title: "Partner team truck", phase: "abandoned" } },
+      ],
+    });
+
+    expect(gate.allowed).toBe(false);
+    if (gate.allowed) throw new Error("unreachable");
+    expect(gate.blocked).toBe("unsatisfiable");
+    if (gate.blocked !== "unsatisfiable") throw new Error("unreachable");
+    expect(gate.deadDependencies.map((d) => d.buildId)).toEqual(["FB-DEAD"]);
+    // waitingOn still lists BOTH not-complete upstreams for context.
+    expect(gate.waitingOn.map((d) => d.buildId).sort()).toEqual(["FB-DEAD", "FB-LIVE"]);
   });
 
   it("allows child builds when every upstream sibling is complete", () => {

--- a/apps/web/lib/build/feature-build-dependencies.ts
+++ b/apps/web/lib/build/feature-build-dependencies.ts
@@ -28,9 +28,36 @@ export type WaitingOnDependency = {
   phase: DependencyBuildPhase;
 };
 
+/**
+ * Dependency phases a sibling can never leave to reach `complete`. A sibling in
+ * one of these can NEVER satisfy a dependent, so a dependent waiting on it is
+ * deadlocked, not merely pending — see the `unsatisfiable` gate branch
+ * (BI-7B6D7661). `abandoned` is set by escalate-build-to-human and the age-out
+ * reaper; `failed` by a superseded/terminally-failed build. Neither is in the
+ * resumable phase set, so neither is ever resurrected in place (recovery mints a
+ * NEW build via re-promotion, not a phase change on this row).
+ */
+export const TERMINAL_INCOMPLETE_DEPENDENCY_PHASES: ReadonlySet<DependencyBuildPhase> =
+  new Set(["abandoned", "failed"]);
+
+export function isTerminallyIncompleteDependencyPhase(phase: DependencyBuildPhase): boolean {
+  return TERMINAL_INCOMPLETE_DEPENDENCY_PHASES.has(phase);
+}
+
 export type FeatureBuildDependencyGateResult =
   | { allowed: true; waitingOn: [] }
-  | { allowed: false; waitingOn: WaitingOnDependency[]; message: string };
+  // Still-live upstream builds that may yet complete — keep waiting.
+  | { allowed: false; blocked: "waiting"; waitingOn: WaitingOnDependency[]; message: string }
+  // At least one upstream build is terminally dead (abandoned/failed) and can
+  // never complete — the dependent is DEADLOCKED, not pending. `deadDependencies`
+  // is the terminal subset; `waitingOn` is every not-complete upstream.
+  | {
+      allowed: false;
+      blocked: "unsatisfiable";
+      waitingOn: WaitingOnDependency[];
+      deadDependencies: WaitingOnDependency[];
+      message: string;
+    };
 
 export type ReadyDependentBuild = {
   buildId: string;
@@ -143,9 +170,31 @@ export function deriveFeatureBuildDependencyGate(
     return { allowed: true, waitingOn: [] };
   }
 
+  // Split the not-complete upstream into terminally-dead vs still-live. A dead
+  // sibling can never reach `complete`, so a dependent waiting on it is
+  // deadlocked — surface that as `unsatisfiable` so the caller can terminate the
+  // dependent instead of re-queuing it forever (BI-7B6D7661).
+  const deadDependencies = waitingOn.filter((dependency) =>
+    isTerminallyIncompleteDependencyPhase(dependency.phase),
+  );
+
+  if (deadDependencies.length > 0) {
+    const deadList = deadDependencies.map((dependency) => dependency.title).join(", ");
+    return {
+      allowed: false,
+      blocked: "unsatisfiable",
+      waitingOn,
+      deadDependencies,
+      message:
+        `Blocked permanently: sibling build(s) ${deadList} were abandoned/failed and can never complete, ` +
+        `so ${build.title} can never start. Re-promote the backlog item to rebuild the epic, or drop the dead dependency.`,
+    };
+  }
+
   const titleList = waitingOn.map((dependency) => dependency.title).join(", ");
   return {
     allowed: false,
+    blocked: "waiting",
     waitingOn,
     message: `Waiting on: ${titleList}. Complete those sibling builds before starting implementation for ${build.title}.`,
   };

--- a/apps/web/lib/integrate/plan-to-build-transition.test.ts
+++ b/apps/web/lib/integrate/plan-to-build-transition.test.ts
@@ -16,15 +16,19 @@ const startBuildPhaseRunMock = vi.fn();
 const completeBuildPhaseRunMock = vi.fn();
 const dispatchBuildMock = vi.fn();
 
-vi.mock("@dpf/db", () => ({
-  prisma: {
+vi.mock("@dpf/db", () => {
+  const prisma = {
     featureBuild: {
       findUnique: (...a: unknown[]) => findUniqueMock(...a),
       update: (...a: unknown[]) => updateMock(...a),
     },
     buildActivity: { create: (...a: unknown[]) => activityCreateMock(...a) },
-  },
-}));
+    // abandonDeadlockedDependent runs its re-check + write in a $transaction;
+    // invoke the callback immediately with the same mocked delegates.
+    $transaction: (fn: (tx: unknown) => unknown) => fn(prisma),
+  };
+  return { prisma };
+});
 vi.mock("@/lib/feature-build-types", () => ({
   checkPhaseGate: (...a: unknown[]) => checkPhaseGateMock(...a),
   canTransitionPhase: (...a: unknown[]) => canTransitionPhaseMock(...a),
@@ -207,5 +211,56 @@ describe("performPlanToBuildTransition (BI-05208DE5)", () => {
     const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
     expect(out).toMatchObject({ kind: "transition-failed", failures: 1 });
     expect(startBuildBranchMock).not.toHaveBeenCalled();
+  });
+
+  // BI-7B6D7661: an unsatisfiable dependency (a dead sibling) must terminally
+  // abandon the dependent, not loop as gate-blocked forever.
+  it("abandons the build (not gate-blocked) when a dependency is unsatisfiable", async () => {
+    findUniqueMock
+      // 1st read: the transition's own build fetch (still in plan).
+      .mockResolvedValueOnce(planBuild({ parentEpicId: "epic-1" }))
+      // 2nd read: the re-check inside abandonDeadlockedDependent's transaction.
+      .mockResolvedValueOnce({ phase: "plan", abandonedAt: null });
+    deriveDependencyGateMock.mockReturnValue({
+      allowed: false,
+      blocked: "unsatisfiable",
+      waitingOn: [{ buildId: "FB-DEAD", title: "Dead sibling", phase: "abandoned" }],
+      deadDependencies: [{ buildId: "FB-DEAD", title: "Dead sibling", phase: "abandoned" }],
+      message: "Blocked permanently: sibling build(s) Dead sibling were abandoned/failed …",
+    });
+
+    const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
+
+    expect(out).toMatchObject({ kind: "dependency-unsatisfiable", deadDependencyBuildIds: ["FB-DEAD"] });
+    // Terminally abandoned — NOT flipped to build, NOT left in plan.
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ phase: "abandoned" }) }),
+    );
+    expect(updateMock).not.toHaveBeenCalledWith(expect.objectContaining({ data: { phase: "build" } }));
+    expect(startBuildBranchMock).not.toHaveBeenCalled();
+    // WWMD gate never runs — we bailed at the dependency gate.
+    expect(evaluateWwmdGateMock).not.toHaveBeenCalled();
+  });
+
+  it("does not abandon a build that advanced out of plan between the gate read and the write", async () => {
+    findUniqueMock
+      .mockResolvedValueOnce(planBuild({ parentEpicId: "epic-1" }))
+      // Re-check finds it already moved on — leave it untouched.
+      .mockResolvedValueOnce({ phase: "build", abandonedAt: null });
+    deriveDependencyGateMock.mockReturnValue({
+      allowed: false,
+      blocked: "unsatisfiable",
+      waitingOn: [{ buildId: "FB-DEAD", title: "Dead sibling", phase: "failed" }],
+      deadDependencies: [{ buildId: "FB-DEAD", title: "Dead sibling", phase: "failed" }],
+      message: "Blocked permanently …",
+    });
+
+    const out = await performPlanToBuildTransition({ buildId: "FB-X", userId: "u1" });
+
+    expect(out.kind).toBe("dependency-unsatisfiable");
+    // Re-check guard held: no abandon write.
+    expect(updateMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ phase: "abandoned" }) }),
+    );
   });
 });

--- a/apps/web/lib/integrate/plan-to-build-transition.ts
+++ b/apps/web/lib/integrate/plan-to-build-transition.ts
@@ -34,6 +34,7 @@ import {
 } from "@/lib/feature-build-types";
 import {
   deriveFeatureBuildDependencyGate,
+  type FeatureBuildDependencyGateResult,
   FEATURE_BUILD_DEPENDENCY_GATE_SELECT,
 } from "@/lib/build/feature-build-dependencies";
 import { logBuildActivity } from "@/lib/mcp/build-tool-helpers";
@@ -61,6 +62,9 @@ export type PlanToBuildTransitionOutcome =
   | { kind: "advanced" }
   | { kind: "not-ready"; reason: string }
   | { kind: "gate-blocked"; reason: string }
+  // A blocking sibling was abandoned/failed and can never complete, so this
+  // build was terminally abandoned rather than left waiting forever (BI-7B6D7661).
+  | { kind: "dependency-unsatisfiable"; reason: string; deadDependencyBuildIds: string[] }
   | { kind: "wwmd-withheld"; reason: string }
   | { kind: "transition-failed"; reason: string; failures: number }
   | { kind: "escalated"; reason: string; failures: number };
@@ -172,6 +176,57 @@ async function failTransition(args: {
   return { kind: "transition-failed", reason, failures: tracker.failures };
 }
 
+/**
+ * Terminally abandon a plan-phase build whose plan is ready but which depends on
+ * a sibling that was abandoned/failed and can never complete (BI-7B6D7661).
+ *
+ * Without this the build re-enters the resume sweep every cycle, logs
+ * "Waiting on: …", and — because decomposition children are exempt from the
+ * 7-day pre-build age-out — waits forever. Abandonment is reversible: re-promote
+ * the originating backlog item to rebuild the whole epic fresh. Never throws.
+ */
+async function abandonDeadlockedDependent(args: {
+  buildId: string;
+  parentEpicId: string | null;
+  gate: Extract<FeatureBuildDependencyGateResult, { blocked: "unsatisfiable" }>;
+}): Promise<PlanToBuildTransitionOutcome> {
+  const { buildId, gate } = args;
+  const deadDependencyBuildIds = gate.deadDependencies.map((d) => d.buildId);
+  const reason = gate.message;
+  try {
+    // Re-check under the write: only abandon a build still in `plan` and not
+    // already terminal, so a build that advanced or was abandoned between the
+    // gate read and here is left untouched.
+    await prisma.$transaction(async (tx) => {
+      const fresh = await tx.featureBuild.findUnique({
+        where: { buildId },
+        select: { phase: true, abandonedAt: true },
+      });
+      if (!fresh || fresh.abandonedAt || fresh.phase !== "plan") return;
+      await tx.featureBuild.update({
+        where: { buildId },
+        data: {
+          phase: "abandoned",
+          abandonedAt: new Date(),
+          abandonReason: reason,
+        },
+      });
+      await tx.buildActivity.create({
+        data: {
+          buildId,
+          tool: "resumeStrandedBuildsOnBoot",
+          summary:
+            `Abandoned at the plan→build dependency gate: ${reason} ` +
+            `(dead sibling build(s): ${deadDependencyBuildIds.join(", ") || "none"}) (BI-7B6D7661).`,
+        },
+      });
+    });
+  } catch (err) {
+    console.warn("[plan-to-build-transition] failed to abandon deadlocked dependent:", { buildId }, err);
+  }
+  return { kind: "dependency-unsatisfiable", reason, deadDependencyBuildIds };
+}
+
 // ── The single transition executor ───────────────────────────────────────────
 
 /**
@@ -243,6 +298,18 @@ export async function performPlanToBuildTransition(params: {
   // Dependency gate (blocking upstream builds).
   const dependencyGate = deriveFeatureBuildDependencyGate(build);
   if (!dependencyGate.allowed) {
+    // A dead (abandoned/failed) upstream can NEVER complete, so this dependent
+    // is deadlocked — and decomposition children are exempt from the 7-day
+    // age-out, so nothing else would ever reap it. Terminally abandon it here
+    // with a reason that names the dead sibling(s), instead of re-queuing the
+    // "Waiting on: …" skip forever (BI-7B6D7661).
+    if (dependencyGate.blocked === "unsatisfiable") {
+      return abandonDeadlockedDependent({
+        buildId,
+        parentEpicId: build.parentEpicId,
+        gate: dependencyGate,
+      });
+    }
     logBuildActivity(buildId, "phase:gate-blocked", dependencyGate.message);
     return { kind: "gate-blocked", reason: dependencyGate.message };
   }

--- a/apps/web/lib/integrate/resume-pre-build-phase.test.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.test.ts
@@ -140,6 +140,27 @@ describe("resumePreBuildPhase (BI-9257CF19)", () => {
     expect((out as { reason: string }).reason).toContain("escalated");
   });
 
+  it("stops re-queuing when the plan→build transition abandons a dependency-deadlocked build (BI-7B6D7661)", async () => {
+    findUniqueMock.mockResolvedValue({
+      designDoc: { x: 1 },
+      buildPlan: { tasks: [{ title: "t" }] },
+      planReview: { decision: "pass" },
+      parentEpicId: "cmr-epic",
+    });
+    performPlanToBuildTransitionMock.mockResolvedValue({
+      kind: "dependency-unsatisfiable",
+      reason: "Blocked permanently: sibling build(s) Partner team truck were abandoned/failed …",
+      deadDependencyBuildIds: ["FB-DEAD"],
+    });
+    const out = await resumePreBuildPhase({ buildId: "FB-DEADLOCK", phase: "plan", userId: "uD" });
+    expect(performPlanToBuildTransitionMock).toHaveBeenCalledOnce();
+    // The transition already abandoned it; resume does not re-run review and
+    // reports a terminal action (resumed), not a re-queuing skip.
+    expect(executeToolMock).not.toHaveBeenCalled();
+    expect(out).toMatchObject({ kind: "resumed", via: "performPlanToBuildTransition" });
+    expect((out as { detail: string }).detail).toContain("FB-DEAD");
+  });
+
   it("still runs the canonical plan review (not the reconciler) when no review verdict exists yet", async () => {
     findUniqueMock.mockResolvedValue({ designDoc: { x: 1 }, buildPlan: { tasks: [{ title: "t" }] } });
     const out = await resumePreBuildPhase({ buildId: "FB-NOREV", phase: "plan", userId: "uNR" });

--- a/apps/web/lib/integrate/resume-pre-build-phase.ts
+++ b/apps/web/lib/integrate/resume-pre-build-phase.ts
@@ -506,6 +506,17 @@ export async function resumePreBuildPhase(params: {
               phase,
               reason: `plan → build transition failed (attempt ${outcome.failures}); will retry next cycle (${outcome.reason}).`,
             };
+          case "dependency-unsatisfiable":
+            // A dead sibling made this build permanently unrunnable; the
+            // transition already abandoned it, so it leaves the resume candidate
+            // set for good instead of re-queuing the "Waiting on: …" skip forever
+            // (BI-7B6D7661). Report as resumed — a terminal action WAS taken.
+            return {
+              kind: "resumed",
+              phase,
+              via: "performPlanToBuildTransition",
+              detail: `abandoned — dead upstream dependency (${outcome.deadDependencyBuildIds.join(", ") || "unknown"}): ${outcome.reason}`,
+            };
           case "gate-blocked":
           case "wwmd-withheld":
             return { kind: "skipped", phase, reason: `plan → build ${outcome.kind}: ${outcome.reason}` };


### PR DESCRIPTION
## What

A decomposition child sitting in `plan` with a **passed** review can wait forever on a sibling that was abandoned/failed — because the plan→build dependency gate treated *any* not-`complete` upstream as "keep waiting", and decomposition children are exempt from the 7-day pre-build age-out (`isStrandedPreBuildAbandonable` bails when `parentEpicId` is set). Nothing ever reaps them; they re-enter the resume sweep every ~10 min logging `Waiting on: …` indefinitely.

Surfaced while auditing the epics behind the BI-1D0CA7A0 duplicates (#3455/#3456).

## Confirmed live (2026-07-24)

```
EP-5F45F138
  #1 FB-E299FAC5  Program setup / partner-account   build   (stalled)
  #2 FB-EE59994E  Partner team and invitation jobs   ABANDONED ← escalated-to-human 07-20 (PIR-FBF12)
  #3 FB-55698876  Deal registration and workbench   plan  ─┐ depends on #2
  #4 FB-7F909995  Federation and SCIM edge          plan  ─┘ depends on #2
```

#3 and #4 both carry a passed plan review and a dependency edge onto the abandoned #2; they had not moved since 07-22 and never would.

## Fix

- **`deriveFeatureBuildDependencyGate`** now classifies a dependency on a *terminal* (`abandoned`/`failed`) sibling as `blocked: "unsatisfiable"` (with the dead subset), distinct from `blocked: "waiting"`. A dead dep is decisive even alongside still-live ones.
- **`performPlanToBuildTransition`**, on an unsatisfiable gate, terminally abandons the dependent — re-checking under the write that it is still in `plan` — with a reason naming the dead sibling(s), and returns a new terminal outcome `dependency-unsatisfiable`. This lives in the one shared executor, so both the resume reconciler **and** `reviewBuildPlan` auto-advance benefit; the build leaves the resume candidate set for good.
- **The resume plan branch** reports the terminal action instead of re-queuing the "Waiting on: …" skip.

Abandonment is reversible: re-promote the originating backlog item to rebuild the epic fresh. The still-live `waiting` path is unchanged, so a sibling that is merely in-flight still blocks-and-waits exactly as before.

## Why abandon rather than auto-advance

The dependent's plan assumes artifacts/branch from the dead sibling; shipping it alone would produce partial/broken work. Between *loop forever* and *terminate with a clear, reversible reason*, termination is correct. The dead sibling itself was already escalated to a human and abandoned, so re-escalating the dependent would just duplicate that human task.

## Tests

- gate classifies `abandoned`/`failed` upstream as unsatisfiable, including a dead+live mix (dead dep decisive);
- the transition **abandons** (not gate-blocks) and no-ops if the build advanced out of `plan` between the gate read and the write;
- the resume path stops re-queuing and reports the terminal action.

54 tests green across the three affected suites, plus `epic-rollup` + `build-governed` as regression. Local typecheck is the source-only-worktree case (deps junctioned; `next` unresolved) — CI Typecheck is authoritative.

## Follow-up (not in scope)

A second, distinct blocker seen on these epics: head-of-chain builds logged `engine_selection: none … provider-disabled, Fallback chain: none → Build orchestration complete: 0/0 tasks`. All four CLI engines probe healthy now, so that was inference-endpoint eligibility, not a missing binary — worth a separate look if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
