### PR TITLE
feat(ux-critique): founder-facing capture UI on the ux-design craft surface (BI-3880DA1D)

### DIFF
--- a/apps/web/app/(shell)/coworker-decisions/craft/[professionKey]/page.tsx
+++ b/apps/web/app/(shell)/coworker-decisions/craft/[professionKey]/page.tsx
@@ -8,7 +8,12 @@ import { notFound } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { PROFESSION_REGISTRY } from "@/lib/decision-perspective/resolve-profession-profile";
 import { CraftOverrideForm } from "@/components/wiki/CraftOverrideForm";
+import { CritiqueCaptureForm } from "@/components/wiki/CritiqueCaptureForm";
 import { CRAFT_OVERRIDE_SLUG_PREFIX } from "@/lib/wiki/craft-override";
+
+// The UX critique corpus (BI-3880DA1D) is ux-design's craft, so its capture
+// door lives on this one profession's page rather than every profession's.
+const CRITIQUE_CORPUS_PROFESSION = "ux-design";
 
 export const dynamic = "force-dynamic";
 
@@ -142,6 +147,15 @@ export default async function CraftProfessionPage({ params }: { params: Params }
           </ul>
         )}
       </section>
+
+      {professionKey === CRITIQUE_CORPUS_PROFESSION && (
+        <section className="mb-8">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--dpf-muted)] mb-3">
+            UX critique corpus
+          </h2>
+          <CritiqueCaptureForm />
+        </section>
+      )}
 
       <CraftOverrideForm professionKey={professionKey} professionLabel={family.label} />
     </div>

--- a/apps/web/components/wiki/CritiqueCaptureForm.test.tsx
+++ b/apps/web/components/wiki/CritiqueCaptureForm.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+//
+// The critique-capture form is a surface AGT-906 would critique, so its own
+// cognitive-load shape is under test: the default view stays tight and the
+// reproduction metadata is deferred. Layout decided by the kernel
+// (DI-E1600108C932, human_cognitive_load axis).
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const refresh = vi.hoisted(() => vi.fn());
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
+
+const captureCritiqueEntry = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/actions/critique-entry", () => ({ captureCritiqueEntry }));
+
+import { CritiqueCaptureForm } from "./CritiqueCaptureForm";
+
+beforeEach(() => {
+  refresh.mockReset();
+  captureCritiqueEntry.mockReset();
+  captureCritiqueEntry.mockResolvedValue({ ok: true, slug: "craft/ux-design/x", status: "draft" });
+});
+afterEach(() => cleanup());
+
+describe("CritiqueCaptureForm — default view stays tight (BI-3880DA1D)", () => {
+  it("shows the three essentials and the verdict in the default view", () => {
+    render(<CritiqueCaptureForm />);
+    expect(screen.getByLabelText(/short title/i)).toBeVisible();
+    expect(screen.getByLabelText(/^route/i)).toBeVisible();
+    expect(screen.getByLabelText(/what is wrong/i)).toBeVisible();
+    expect(screen.getByLabelText(/your verdict/i)).toBeVisible();
+  });
+
+  it("marks the three essentials required and the verdict optional", () => {
+    render(<CritiqueCaptureForm />);
+    expect(screen.getByLabelText(/short title/i)).toBeRequired();
+    expect(screen.getByLabelText(/^route/i)).toBeRequired();
+    expect(screen.getByLabelText(/what is wrong/i)).toBeRequired();
+    expect(screen.getByLabelText(/your verdict/i)).not.toBeRequired();
+  });
+
+  it("defers the reproduction metadata behind a collapsed disclosure", () => {
+    const { container } = render(<CritiqueCaptureForm />);
+    const details = container.querySelector("details");
+    expect(details).toBeTruthy();
+    // Collapsed by default — this is the construct the budget path excises, so
+    // the capture form is rewarded for deferring, not taxed.
+    expect(details).not.toHaveAttribute("open");
+    expect(screen.getByLabelText(/screenshot reference/i)).toBeInTheDocument();
+  });
+});
+
+describe("CritiqueCaptureForm — the verdict authority", () => {
+  it("reveals the authority selector only once a verdict is chosen", () => {
+    render(<CritiqueCaptureForm />);
+    expect(screen.queryByLabelText(/attributed to/i)).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/your verdict/i), {
+      target: { value: "change-needed" },
+    });
+    expect(screen.getByLabelText(/attributed to/i)).toBeVisible();
+  });
+});
+
+describe("CritiqueCaptureForm — submission", () => {
+  it("captures as a human with the entered fields and no verdict authority when none chosen", async () => {
+    render(<CritiqueCaptureForm />);
+    fireEvent.change(screen.getByLabelText(/short title/i), { target: { value: "Lead band" } });
+    fireEvent.change(screen.getByLabelText(/^route/i), { target: { value: "/workspace" } });
+    fireEvent.change(screen.getByLabelText(/what is wrong/i), {
+      target: { value: "Lead band carries 240 words before the next action appears." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /capture as draft/i }));
+
+    await waitFor(() => expect(captureCritiqueEntry).toHaveBeenCalledTimes(1));
+    const arg = captureCritiqueEntry.mock.calls[0]![0];
+    expect(arg.callerKind).toBe("human");
+    expect(arg.route).toBe("/workspace");
+    expect(arg.verdict).toBeNull();
+    expect(arg.verdictAuthority).toBeNull();
+  });
+
+  it("attaches the chosen verdict authority", async () => {
+    render(<CritiqueCaptureForm />);
+    fireEvent.change(screen.getByLabelText(/short title/i), { target: { value: "Lead band" } });
+    fireEvent.change(screen.getByLabelText(/^route/i), { target: { value: "/finance" } });
+    fireEvent.change(screen.getByLabelText(/what is wrong/i), {
+      target: { value: "Six status lines sit above the primary action on this screen." },
+    });
+    fireEvent.change(screen.getByLabelText(/your verdict/i), {
+      target: { value: "change-needed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /capture as draft/i }));
+
+    await waitFor(() => expect(captureCritiqueEntry).toHaveBeenCalledTimes(1));
+    const arg = captureCritiqueEntry.mock.calls[0]![0];
+    expect(arg.verdict).toBe("change-needed");
+    expect(arg.verdictAuthority).toBe("founder");
+  });
+
+  it("surfaces a rejection from the action instead of clearing", async () => {
+    captureCritiqueEntry.mockResolvedValue({ ok: false, error: "Say what is specifically wrong." });
+    render(<CritiqueCaptureForm />);
+    fireEvent.change(screen.getByLabelText(/short title/i), { target: { value: "Vague" } });
+    fireEvent.change(screen.getByLabelText(/^route/i), { target: { value: "/x" } });
+    fireEvent.change(screen.getByLabelText(/what is wrong/i), { target: { value: "bad" } });
+    fireEvent.click(screen.getByRole("button", { name: /capture as draft/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/specifically wrong/i);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/wiki/CritiqueCaptureForm.tsx
+++ b/apps/web/components/wiki/CritiqueCaptureForm.tsx
@@ -1,0 +1,281 @@
+"use client";
+// EP-UX-SYSTEM L6 (BI-3880DA1D): the founder-facing capture form for the UX
+// critique corpus. This is the door the founder walks through to turn a UX
+// review note into a stored, verdicted entry — the input that gates the design
+// judge and AGT-906's promotion past curation.
+//
+// This form is itself a surface AGT-906 would critique, so it practises what it
+// captures. Layout decided by the kernel (DI-E1600108C932, human_cognitive_load
+// axis): the default view carries only what a capture needs — route, the
+// finding, and the verdict (the founder's core act) — while the reproduction
+// metadata (screenshot, git ref, viewport, theme, lenses) is deferred behind a
+// native <details>, which is also the exact construct the budget measurement
+// path excises, so disclosure is rewarded here, not taxed. It composes the
+// shared accessible form contract (components/ui/form) rather than hand-rolling
+// fields, per the UX-fit convergence guardrail.
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  CheckboxField,
+  FormStatus,
+  SelectField,
+  SubmitButton,
+  TextField,
+  TextareaField,
+  type SelectOption,
+} from "@/components/ui/form";
+import { captureCritiqueEntry } from "@/lib/actions/critique-entry";
+import {
+  CRITIQUE_LENSES,
+  CRITIQUE_VERDICTS,
+  type CritiqueLens,
+  type CritiqueVerdict,
+} from "@/lib/ux-critique/critique-entry";
+
+const VERDICT_LABEL: Record<CritiqueVerdict, string> = {
+  "change-needed": "Change needed",
+  "no-change-needed": "Fine as-is",
+  "accepted-debt": "Real, but not now",
+};
+
+const LENS_LABEL: Record<CritiqueLens, string> = {
+  hierarchy: "Hierarchy",
+  density: "Density",
+  hick: "Hick (too many choices)",
+  fitts: "Fitts (target size / distance)",
+  miller: "Miller (grouping / memory)",
+  doherty: "Doherty (perceived latency)",
+};
+
+const VERDICT_OPTIONS: SelectOption[] = [
+  { value: "", label: "No verdict yet (leave for review)" },
+  ...CRITIQUE_VERDICTS.map((v) => ({ value: v, label: VERDICT_LABEL[v] })),
+];
+
+const AUTHORITY_OPTIONS: SelectOption[] = [
+  { value: "founder", label: "Founder" },
+  { value: "designer", label: "Designer" },
+];
+
+const THEME_OPTIONS: SelectOption[] = [
+  { value: "", label: "—" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+];
+
+export function CritiqueCaptureForm() {
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [route, setRoute] = useState("");
+  const [finding, setFinding] = useState("");
+  const [verdict, setVerdict] = useState<"" | CritiqueVerdict>("");
+  const [verdictAuthority, setVerdictAuthority] = useState<"founder" | "designer">("founder");
+  const [screenshotRef, setScreenshotRef] = useState("");
+  const [gitRef, setGitRef] = useState("");
+  const [viewportWidth, setViewportWidth] = useState("");
+  const [colorScheme, setColorScheme] = useState<"" | "light" | "dark">("");
+  const [lenses, setLenses] = useState<Set<CritiqueLens>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  function toggleLens(lens: CritiqueLens) {
+    setLenses((prev) => {
+      const next = new Set(prev);
+      if (next.has(lens)) next.delete(lens);
+      else next.add(lens);
+      return next;
+    });
+  }
+
+  function reset() {
+    setTitle("");
+    setRoute("");
+    setFinding("");
+    setVerdict("");
+    setScreenshotRef("");
+    setGitRef("");
+    setViewportWidth("");
+    setColorScheme("");
+    setLenses(new Set());
+  }
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSaved(false);
+    const width = viewportWidth.trim() ? Number(viewportWidth.trim()) : null;
+    startTransition(async () => {
+      const result = await captureCritiqueEntry({
+        title,
+        callerKind: "human",
+        route,
+        finding,
+        screenshotRef: screenshotRef.trim() || null,
+        gitRef: gitRef.trim() || null,
+        viewportWidth: width !== null && Number.isFinite(width) ? width : null,
+        colorScheme: colorScheme || null,
+        lenses: [...lenses],
+        verdict: verdict || null,
+        // A verdict on this founder-facing form is an ATTACHED human ruling.
+        verdictAuthority: verdict ? verdictAuthority : null,
+      });
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setSaved(true);
+      reset();
+      router.refresh();
+    });
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-4"
+    >
+      <p className="text-sm font-medium text-[var(--dpf-text)] mb-1">Capture a UX critique</p>
+      <p className="text-xs text-[var(--dpf-muted)] mb-4">
+        Record a design review of a real screen. Saved as a draft; your verdict is what makes it
+        count. Say what is specifically wrong &mdash; a measurement or a structural observation, not
+        an impression.
+      </p>
+
+      <div className="flex flex-col gap-3">
+        <TextField
+          name="critique-title"
+          label="Short title"
+          value={title}
+          onValueChange={setTitle}
+          required
+          placeholder="Workspace lead band buries the next action"
+        />
+
+        <TextField
+          name="critique-route"
+          label="Route"
+          value={route}
+          onValueChange={setRoute}
+          required
+          hint="The path the screen was captured from."
+          placeholder="/workspace"
+        />
+
+        <TextareaField
+          name="critique-finding"
+          label="What is wrong, specifically"
+          value={finding}
+          onValueChange={setFinding}
+          required
+          rows={3}
+          placeholder="Lead band carries 240 words before the owner's next action appears; the primary action sits below three secondary ones."
+        />
+
+        <div className="flex flex-wrap items-end gap-3">
+          <SelectField
+            name="critique-verdict"
+            label="Your verdict"
+            value={verdict}
+            onValueChange={(v) => setVerdict(v as "" | CritiqueVerdict)}
+            options={VERDICT_OPTIONS}
+            optional
+            className="min-w-[16rem]"
+          />
+          {verdict && (
+            <SelectField
+              name="critique-verdict-authority"
+              label="Attributed to"
+              value={verdictAuthority}
+              onValueChange={(v) => setVerdictAuthority(v as "founder" | "designer")}
+              options={AUTHORITY_OPTIONS}
+            />
+          )}
+        </div>
+      </div>
+
+      <details className="mt-4 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-2)] px-3 py-2">
+        <summary className="cursor-pointer text-xs text-[var(--dpf-muted)]">
+          Reproduction details (optional, but a screenshot is what lets the entry calibrate the
+          judge)
+        </summary>
+
+        <div className="mt-3 flex flex-col gap-3">
+          <TextField
+            name="critique-shot"
+            label="Screenshot reference"
+            value={screenshotRef}
+            onValueChange={setScreenshotRef}
+            optional
+            inputClassName="bg-[var(--dpf-surface-1)]"
+            placeholder="capture/workspace-390-light.png"
+          />
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <TextField
+              name="critique-git"
+              label="Git ref at capture"
+              value={gitRef}
+              onValueChange={setGitRef}
+              optional
+              inputClassName="bg-[var(--dpf-surface-1)]"
+              placeholder="abc1234"
+            />
+            <TextField
+              name="critique-viewport"
+              label="Viewport px"
+              type="number"
+              inputMode="numeric"
+              value={viewportWidth}
+              onValueChange={setViewportWidth}
+              optional
+              inputClassName="bg-[var(--dpf-surface-1)]"
+              placeholder="390"
+            />
+            <SelectField
+              name="critique-scheme"
+              label="Theme"
+              value={colorScheme}
+              onValueChange={(v) => setColorScheme(v as "" | "light" | "dark")}
+              options={THEME_OPTIONS}
+              optional
+              selectClassName="bg-[var(--dpf-surface-1)]"
+            />
+          </div>
+          <fieldset>
+            <legend className="text-xs text-[var(--dpf-muted)] mb-1">
+              Lenses (which explain why it is wrong)
+            </legend>
+            <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+              {CRITIQUE_LENSES.map((lens) => (
+                <CheckboxField
+                  key={lens}
+                  name={`lens-${lens}`}
+                  label={LENS_LABEL[lens]}
+                  checked={lenses.has(lens)}
+                  onCheckedChange={() => toggleLens(lens)}
+                />
+              ))}
+            </div>
+          </fieldset>
+        </div>
+      </details>
+
+      <FormStatus
+        className="mt-3"
+        error={error}
+        success={saved ? "Captured as a draft. Publish it to make it calibration-eligible." : null}
+      />
+
+      <div className="mt-3 flex items-center gap-3">
+        <SubmitButton pending={pending} pendingLabel="Capturing…">
+          Capture as draft
+        </SubmitButton>
+        <span className="text-xs text-[var(--dpf-muted)]">
+          A draft is a proposal; publishing is what makes your verdict count.
+        </span>
+      </div>
+    </form>
+  );
+}

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -480,7 +480,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 45
+    "textMass": 48
   },
   "apps/web/app/(shell)/coworker-decisions/craft/page.tsx": {
     "vocabulary": 0,
@@ -7257,6 +7257,13 @@
     "readability": 0,
     "longSentences": 0,
     "textMass": 60
+  },
+  "apps/web/components/wiki/CritiqueCaptureForm.tsx": {
+    "vocabulary": 0,
+    "genericLabels": 0,
+    "readability": 0,
+    "longSentences": 0,
+    "textMass": 164
   },
   "apps/web/components/wiki/DecisionAuditTable.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
Finishes the critique-corpus thread. The capture action shipped in [#3491](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3491), but a function nobody can reach in the portal accrues nothing. **This puts the door on a page** — the ux-design craft surface (`/coworker-decisions/craft/ux-design`) now carries a "Capture a UX critique" form, so a founder review becomes a stored, verdicted entry in a click.

## The form practises what it captures

It's a surface AGT-906 would critique, so its own cognitive-load shape is deliberate:

- **Layout scored by the kernel** (`DI-E1600108C932`, `human_cognitive_load` axis): `disclosed` won at composite **6.83, margin 0.738, high confidence**, over a flat 11-control form (5.28) and a verdict-buried minimal form (6.09). The default view carries only **route + finding + verdict** (the founder's core act); reproduction metadata — screenshot, git ref, viewport, theme, six lenses — is deferred behind a native `<details>`, which is also the exact construct the budget measurement path excises, so disclosure is *rewarded*, not taxed.
- **Composes the shared accessible form kit** (`components/ui/form`) rather than hand-rolling inputs like the older `CraftOverrideForm` — the UX-fit convergence guardrail. Required/optional markers, aria wiring, assertive error / polite success, pending-aware submit all come from the kit.
- The verdict-authority selector appears only once a verdict is chosen; a human capture attaches it as founder/designer, and the server action already refuses an agent attaching a founder verdict.
- Scoped to **ux-design only** — the critique corpus is that profession's craft.

## Verification honesty

The **jsdom render test** (`CritiqueCaptureForm.test.tsx`, 8 cases pinning the tight default view, deferred disclosure, conditional authority selector, submit payload) **could not run locally** — this worktree's vitest worker pool is wedged for *all* jsdom tests including known-good siblings (`VoiceProfileSetup`), and the machine was saturated. **Left to CI's Unit Tests job.**

What **did** run and pass: the node-env entry + action tests (**28/28**), direct `tsc` showing **zero errors in the new component** (the page's `family possibly undefined` lines are the known worktree next-resolution artifact — `notFound()` can't type as `never` without `next/navigation`; CI resolves it), a hardcoded-color scan (clean), and doc-index freshness (547).

UX-Fit-Decision: fits-with-guardrails. Owning area Knowledge (Coworker Decision Engine > Craft); route family /coworker-decisions/craft/[professionKey], no new route or nav layer; primary persona the founder/designer authoring critique; contextual capture form, not a dashboard or tab; reuses the ui/form accessible contract (no new primitive); source of truth the craft-override WikiPage overlay via captureCritiqueEntry; empty/failure via inline validation + the action's typed error; AI boundary none (plain form, no prompt send). Cognitive load scored on the kernel (DI-E1600108C932).

Design-Grounding-Decision: extends the EP-UX-SYSTEM L6 corpus method (docs/professions/ux-design/wiki/design-critique-corpus-method.md) and the existing craft-override surface substrate; no new spec — the UI half of the already-specified capture door.

Docs-Impact-Decision: no user-facing documentation change — the craft surface is self-describing; the corpus-method WSID page was updated in #3491.

Seed-Fit-Decision: global-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)