### PR TITLE
feat(self-upgrade): health verdict — auto-discount empty deliberation loops (BI-12E24186)

### DIFF
--- a/apps/web/components/ops/SelfUpgradeClient.tsx
+++ b/apps/web/components/ops/SelfUpgradeClient.tsx
@@ -519,6 +519,20 @@ export default function SelfUpgradeClient({
             </div>
           )}
 
+          {quiescence?.verdict && (
+            <div
+              className="p-2.5 rounded-lg bg-[var(--dpf-warning)]/15 border border-[var(--dpf-warning)]/40 text-xs space-y-0.5"
+              role="status"
+              aria-live="polite"
+              data-blocker-verdict={quiescence.verdict.kind}
+            >
+              <div className="font-medium text-[var(--dpf-warning)]">
+                Stuck loop, not live work
+              </div>
+              <div className="text-[var(--dpf-muted)]">{quiescence.verdict.message}</div>
+            </div>
+          )}
+
           {quiescence && quiescence.blockers.length > 0 && (
             <div className="text-xs">
               <div className="text-[var(--dpf-muted)] mb-1">

--- a/apps/web/lib/self-upgrade/quiescence.test.ts
+++ b/apps/web/lib/self-upgrade/quiescence.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/lib/tak/agent-event-bus", () => ({
 }));
 
 import {
+  applyEmptyLoopDiscount,
   captureActiveSessionBlockers,
   escalateQuiescenceToForced,
   isBuildPhaseReapable,
@@ -860,5 +861,90 @@ describe("signalSwapComplete — swap-signal retry", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("applyEmptyLoopDiscount — fast-empty-churn (BI-12E24186)", () => {
+  function coworkerLoop(opts: {
+    buildId?: string | null;
+    title?: string;
+    kind?: "hard" | "soft";
+  }): SurfaceBlocker {
+    return {
+      surface: "coworker.reasoning-loop",
+      detectionClass: "A",
+      kind: opts.kind ?? "hard",
+      blockerSignal: { class: "A", model: "TaskRun", rowId: "TR-x", status: "working" },
+      estimatedWaitMs: 30_000,
+      evidence: {
+        taskRunId: "TR-x",
+        title: opts.title ?? "Deliberation: review",
+        buildId: opts.buildId ?? "FB-AAA",
+        status: "working",
+      },
+    };
+  }
+
+  it("discounts a deliberation loop on a build over the empty-run threshold → soft + verdict", () => {
+    const surfaces = [coworkerLoop({ buildId: "FB-AAA" })];
+    const { surfaces: out, verdict } = applyEmptyLoopDiscount(
+      surfaces,
+      new Map([["FB-AAA", 3]]),
+    );
+    expect(out[0].kind).toBe("soft");
+    expect((out[0].evidence as Record<string, unknown>).emptyLoop).toBe(true);
+    expect(verdict).not.toBeNull();
+    expect(verdict?.discountedCount).toBe(1);
+    expect(verdict?.buildIds).toEqual(["FB-AAA"]);
+  });
+
+  it("does NOT discount below the recurrence threshold (a single inconclusive run)", () => {
+    const surfaces = [coworkerLoop({ buildId: "FB-AAA" })];
+    const { surfaces: out, verdict } = applyEmptyLoopDiscount(
+      surfaces,
+      new Map([["FB-AAA", 2]]),
+    );
+    expect(out[0].kind).toBe("hard");
+    expect(verdict).toBeNull();
+  });
+
+  it("does NOT discount a genuinely-live coworker loop (non-deliberation title)", () => {
+    const surfaces = [coworkerLoop({ buildId: "FB-AAA", title: "Implementing auth flow" })];
+    const { surfaces: out, verdict } = applyEmptyLoopDiscount(
+      surfaces,
+      new Map([["FB-AAA", 9]]),
+    );
+    expect(out[0].kind).toBe("hard");
+    expect(verdict).toBeNull();
+  });
+
+  it("leaves non-coworker surfaces untouched and reports zero when nothing matches", () => {
+    const phase: SurfaceBlocker = {
+      surface: "build-studio.phase.build",
+      detectionClass: "A",
+      kind: "hard",
+      blockerSignal: { class: "A", model: "BuildPhaseRun", rowId: "FB-AAA/build", status: "in-flight" },
+      estimatedWaitMs: 1_800_000,
+      evidence: { buildId: "FB-AAA", phase: "build" },
+    };
+    const { surfaces: out, verdict } = applyEmptyLoopDiscount([phase], new Map([["FB-AAA", 9]]));
+    expect(out[0].kind).toBe("hard");
+    expect(verdict).toBeNull();
+  });
+
+  it("aggregates discounts across multiple builds", () => {
+    const surfaces = [
+      coworkerLoop({ buildId: "FB-AAA" }),
+      coworkerLoop({ buildId: "FB-BBB", title: "Deliberation: debate" }),
+    ];
+    const { verdict } = applyEmptyLoopDiscount(
+      surfaces,
+      new Map([
+        ["FB-AAA", 5],
+        ["FB-BBB", 4],
+      ]),
+    );
+    expect(verdict?.discountedCount).toBe(2);
+    expect(verdict?.buildIds.sort()).toEqual(["FB-AAA", "FB-BBB"]);
   });
 });

--- a/apps/web/lib/self-upgrade/quiescence.ts
+++ b/apps/web/lib/self-upgrade/quiescence.ts
@@ -806,6 +806,30 @@ export type ActiveSessionBlockers = {
   softBlockers: number;
   unobservableSurfaces: string[];
   surfaces: SurfaceBlocker[];
+  /**
+   * Health verdict on the blocker set (BI-12E24186). Non-null when the capture
+   * auto-discounted a provably-empty deliberation loop cohort from the HARD
+   * blockers so the drain proceeds on its own. Per the WWMD decision
+   * (auto-discount + disclose, never silent), the panel renders this as the
+   * hero line so the operator sees a diagnosis — "stuck loop, not live work" —
+   * instead of a raw "AI coworker working ×N" that sends them to an empty page.
+   */
+  verdict?: BlockerVerdict | null;
+};
+
+/**
+ * A one-line health diagnosis surfaced above the blocker list. Today the only
+ * kind is the empty-deliberation-loop (the stub deliberation engine, BI-7B6B3C5C,
+ * makes plan gates loop forever producing no output); the shape is left open for
+ * future pathological patterns.
+ */
+export type BlockerVerdict = {
+  kind: "empty-deliberation-loop";
+  /** How many hard coworker-loop surfaces were reclassified to soft. */
+  discountedCount: number;
+  /** The builds whose plan deliberations are looping empty. */
+  buildIds: string[];
+  message: string;
 };
 
 export type SurfaceBlocker = {
@@ -868,6 +892,21 @@ const DEAD_PHASE_LIVENESS_MS = 15 * 60 * 1000;
  * corpses were never cleared.
  */
 const DEAD_COWORKER_LOOP_LIVENESS_MS = 15 * 60 * 1000;
+
+/**
+ * Fast-empty-churn detection (BI-12E24186). Distinct from the STALE-loop reaper
+ * above: an empty deliberation loop is FRESH — each run heartbeats, completes in
+ * under a second producing no branch output (consensusState=insufficient-evidence,
+ * the stub deliberation engine BI-7B6B3C5C), and a new one respawns seconds later
+ * — so isTaskRunReapable never fires and the loop holds the drain open. The signal
+ * is recurrence of empty outcomes on the SAME build inside this window. Zero branch
+ * output is the ground truth of "empty", so the detector never discounts a
+ * deliberation that actually produced a recommendation, and the minimum-run
+ * threshold keeps a single legitimately-inconclusive deliberation from tripping it.
+ */
+const EMPTY_DELIBERATION_LOOP_WINDOW_MS = 15 * 60 * 1000;
+const MIN_EMPTY_RUNS_FOR_LOOP = 3;
+const DELIBERATION_TITLE_PREFIX = "Deliberation:";
 
 /**
  * True when an in-flight build phase is a corpse: the most recent observable
@@ -1163,10 +1202,65 @@ export async function captureActiveSessionBlockers(opts?: {
     "inngest.in-step-execution",
   ];
 
-  // Counts derived from surfaces array.
-  const totalBlockers = surfaces.length;
-  const hardBlockers = surfaces.filter((s) => s.kind === "hard").length;
-  const softBlockers = surfaces.filter((s) => s.kind === "soft").length;
+  // Fast-empty-churn discount (BI-12E24186). A coworker "reasoning loop" that is
+  // really a plan deliberation on a build whose recent deliberations all land
+  // insufficient-evidence is a stuck EMPTY loop (root cause BI-7B6B3C5C), not live
+  // work — and it's FRESH each iteration, so the stale-loop reaper above never
+  // catches it. Reclassify those hard surfaces to soft so the drain proceeds, and
+  // record a verdict the panel surfaces. Bounded: only queries builds that have a
+  // live deliberation loop in this snapshot.
+  const loopBuildIds = [
+    ...new Set(
+      surfaces
+        .filter((s) => {
+          if (s.surface !== "coworker.reasoning-loop") return false;
+          const ev = s.evidence as Record<string, unknown>;
+          return (
+            typeof ev?.buildId === "string" &&
+            typeof ev?.title === "string" &&
+            ev.title.startsWith(DELIBERATION_TITLE_PREFIX)
+          );
+        })
+        .map((s) => (s.evidence as Record<string, unknown>).buildId as string),
+    ),
+  ];
+  let verdict: BlockerVerdict | null = null;
+  let effectiveSurfaces = surfaces;
+  if (loopBuildIds.length > 0) {
+    const emptyRunsByBuild = new Map<string, number>();
+    try {
+      const emptyRuns = await prisma.deliberationRun.findMany({
+        where: {
+          consensusState: "insufficient-evidence",
+          createdAt: { gte: new Date(now.getTime() - EMPTY_DELIBERATION_LOOP_WINDOW_MS) },
+          taskRun: { buildId: { in: loopBuildIds } },
+        },
+        select: { taskRun: { select: { buildId: true } } },
+      });
+      for (const r of emptyRuns) {
+        const b = r.taskRun?.buildId;
+        if (b) emptyRunsByBuild.set(b, (emptyRunsByBuild.get(b) ?? 0) + 1);
+      }
+    } catch (err) {
+      // Non-fatal: a failed history read must never break blocker capture. Worst
+      // case nothing is discounted and the loop surfaces as a hard blocker (the
+      // pre-BI-12E24186 behaviour), which is safe, just noisier.
+      console.warn("[quiescence] empty-loop history query failed (non-fatal):", err);
+    }
+    const discounted = applyEmptyLoopDiscount(surfaces, emptyRunsByBuild);
+    effectiveSurfaces = discounted.surfaces;
+    verdict = discounted.verdict;
+    if (verdict) {
+      console.warn(
+        `[quiescence] auto-discounted ${verdict.discountedCount} empty deliberation loop(s) on ${verdict.buildIds.length} build(s) from the drain (BI-12E24186).`,
+      );
+    }
+  }
+
+  // Counts derived from the (possibly discounted) surfaces array.
+  const totalBlockers = effectiveSurfaces.length;
+  const hardBlockers = effectiveSurfaces.filter((s) => s.kind === "hard").length;
+  const softBlockers = effectiveSurfaces.filter((s) => s.kind === "soft").length;
 
   return {
     capturedAt: now.toISOString(),
@@ -1175,7 +1269,8 @@ export async function captureActiveSessionBlockers(opts?: {
     hardBlockers,
     softBlockers,
     unobservableSurfaces,
-    surfaces,
+    surfaces: effectiveSurfaces,
+    verdict,
   };
 }
 
@@ -1311,6 +1406,9 @@ export type QuiescenceActivity = {
   /** Capture time of the snapshot the blockers were read from, if any. */
   blockersCapturedAt: string | null;
   blockers: QuiescenceBlockerLine[];
+  /** Health verdict for the panel hero line (BI-12E24186); null when nothing was
+   *  auto-discounted. */
+  verdict?: BlockerVerdict | null;
 };
 
 /** Map an internal surface key to a friendly operator label. */
@@ -1323,6 +1421,49 @@ export function describeBlockerSurface(surface: string): string {
     return `Build Studio — ${phase} phase`;
   }
   return surface;
+}
+
+/**
+ * Reclassify provably-empty deliberation-loop coworker surfaces from hard→soft so
+ * they stop deferring the drain, and produce a disclosure verdict (BI-12E24186).
+ * Pure and unit-tested. `emptyRunsByBuild` is the count of recent
+ * insufficient-evidence deliberations per build (gathered by the capture's history
+ * query). A coworker surface is discounted only when it is a deliberation loop
+ * (title prefix) on a build whose empty-run count meets MIN_EMPTY_RUNS_FOR_LOOP —
+ * so genuinely-live coworker work, and a build with a single inconclusive
+ * deliberation, are never discounted. Soft blockers do not defer the drain, so
+ * the reclassification is exactly the WWMD-chosen "auto-discount"; keeping the
+ * surfaces in the list (rather than dropping them) preserves disclosure.
+ */
+export function applyEmptyLoopDiscount(
+  surfaces: SurfaceBlocker[],
+  emptyRunsByBuild: Map<string, number>,
+): { surfaces: SurfaceBlocker[]; verdict: BlockerVerdict | null } {
+  const discountedBuilds = new Set<string>();
+  let discountedCount = 0;
+  const next = surfaces.map((s) => {
+    if (s.surface !== "coworker.reasoning-loop" || s.kind !== "hard") return s;
+    const ev = (s.evidence ?? {}) as Record<string, unknown>;
+    const title = typeof ev.title === "string" ? ev.title : "";
+    const buildId = typeof ev.buildId === "string" ? ev.buildId : null;
+    if (!buildId || !title.startsWith(DELIBERATION_TITLE_PREFIX)) return s;
+    if ((emptyRunsByBuild.get(buildId) ?? 0) < MIN_EMPTY_RUNS_FOR_LOOP) return s;
+    discountedBuilds.add(buildId);
+    discountedCount += 1;
+    return { ...s, kind: "soft" as const, evidence: { ...ev, emptyLoop: true } };
+  });
+  if (discountedCount === 0) return { surfaces: next, verdict: null };
+  const builds = [...discountedBuilds];
+  const runWord = discountedCount === 1 ? "run" : "runs";
+  const buildWord = builds.length === 1 ? "build" : "builds";
+  const message =
+    `${discountedCount} plan deliberation ${runWord} completing empty and looping on ` +
+    `${builds.length} ${buildWord} — a stuck loop, not live work. Auto-discounted so the ` +
+    `upgrade can proceed. Root cause: the deliberation engine produces no output (BI-7B6B3C5C).`;
+  return {
+    surfaces: next,
+    verdict: { kind: "empty-deliberation-loop", discountedCount, buildIds: builds, message },
+  };
 }
 
 /** Collapse a raw blockers snapshot into one line per surface, with counts. */
@@ -1391,6 +1532,7 @@ export async function getQuiescenceActivity(now: Date = new Date()): Promise<Qui
     run: null,
     blockersCapturedAt: null,
     blockers: [],
+    verdict: null,
   };
 
   if (typeof prisma.quiescenceRun?.findFirst !== "function") return base;
@@ -1423,6 +1565,7 @@ export async function getQuiescenceActivity(now: Date = new Date()): Promise<Qui
     },
     blockersCapturedAt: snapshot?.capturedAt ?? null,
     blockers: summarizeBlockers(snapshot),
+    verdict: snapshot?.verdict ?? null,
   };
 }
 

--- a/apps/web/lib/self-upgrade/run-types.ts
+++ b/apps/web/lib/self-upgrade/run-types.ts
@@ -51,4 +51,20 @@ export type QuiescenceActivity = {
   } | null;
   blockersCapturedAt: string | null;
   blockers: QuiescenceBlockerLine[];
+  /** Health verdict for the panel hero line (BI-12E24186); null/absent when
+   *  nothing was auto-discounted. Mirrors the server type in
+   *  lib/self-upgrade/quiescence.ts. */
+  verdict?: BlockerVerdict | null;
+};
+
+/**
+ * A one-line health diagnosis surfaced above the blocker list (BI-12E24186).
+ * Non-null when the drain auto-discounted a provably-empty deliberation loop
+ * (the stub engine, BI-7B6B3C5C, loops plan gates that produce no output).
+ */
+export type BlockerVerdict = {
+  kind: "empty-deliberation-loop";
+  discountedCount: number;
+  buildIds: string[];
+  message: string;
 };

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -7,7 +7,7 @@ apps/web/components/agent/AgentMessageInput.tsx	1034
 apps/web/components/ea/EaCanvas.tsx	1047
 apps/web/components/inventory/TopologyGraph.tsx	1031
 apps/web/components/ops/SelfUpgradeClient.test.tsx	1069
-apps/web/components/ops/SelfUpgradeClient.tsx	1113
+apps/web/components/ops/SelfUpgradeClient.tsx	1127
 apps/web/components/platform/AiOperationsMap.tsx	2881
 apps/web/components/platform/EffectivePermissionsPanel.tsx	851
 apps/web/components/platform/edge-nodes/EdgeNodesAdminClient.tsx	985
@@ -50,8 +50,8 @@ apps/web/lib/operate/coworker-regression-detector.ts	935
 apps/web/lib/queue/functions/self-upgrade.test.ts	1383
 apps/web/lib/routing/chat-adapter.test.ts	902
 apps/web/lib/routing/fallback.test.ts	1077
-apps/web/lib/self-upgrade/quiescence.test.ts	865
-apps/web/lib/self-upgrade/quiescence.ts	1469
+apps/web/lib/self-upgrade/quiescence.test.ts	951
+apps/web/lib/self-upgrade/quiescence.ts	1612
 apps/web/lib/skills/evidence-search.ts	803
 apps/web/lib/tak/agent-grants.test.ts	903
 apps/web/lib/tak/agent-grants.ts	851

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -5674,7 +5674,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 254
+    "textMass": 259
   },
   "apps/web/components/ops/SelfUpgradeJobEngineHealthAlert.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## What
Makes the self-upgrade activity panel diagnose the pathology instead of misreporting it. When the drain's "blockers" are provably-empty deliberation loops (the stub engine, BI-7B6B3C5C, loops plan gates that produce no output), the panel now:
- **auto-discounts** them from the hard blockers so the drain proceeds on its own (reclassify hard→soft), and
- **discloses** a health verdict as the hero line — "Stuck loop, not live work …" — instead of "AI coworker working ×N" that sent the operator to an empty coworker page.

## Why
An operator forced an upgrade and saw "Waiting on: AI coworker working ×17". Investigation: those were 17 `proactive` "Deliberation: review" TaskRuns, each completing in ~0.3s with zero output (411 fired that day, ~99% of all deliberations ever = insufficient-evidence). The existing stale-loop reaper (`isTaskRunReapable`, BI-1C4179D0) can't catch them because each iteration is *fresh*, not stale.

## How
- `captureActiveSessionBlockers` gathers the builds behind live deliberation-loop surfaces, counts their recent `insufficient-evidence` DeliberationRuns (bounded query, only for builds with a live loop), and calls `applyEmptyLoopDiscount`.
- `applyEmptyLoopDiscount` (pure, unit-tested) reclassifies a `coworker.reasoning-loop` surface to `soft` only when it is a deliberation (title prefix) on a build at/over `MIN_EMPTY_RUNS_FOR_LOOP` empty runs — so live work, and a single inconclusive deliberation, are never discounted.
- A `BlockerVerdict` is threaded through `getQuiescenceActivity`; `SelfUpgradeClient` renders it as a warning hero above the blocker list.
- Self-disabling: once the deliberation engine (BI-7B6B3C5C) produces output, runs reach consensus and the discount stops firing.

## Design grounding
Extends the existing Activity Quiescence Protocol blocker-capture substrate (`docs/superpowers/specs/2026-05-24-activity-quiescence-protocol-design.md`, `apps/web/lib/self-upgrade/quiescence.ts`). No new contract — a new soft-reclassify + verdict field alongside the existing corpse reapers (BI-1C4179D0 / BI-D0F4C6FB).

## UX-Fit-Decision
Scored via `principle_decide` on `human_cognitive_load`: **auto-discount-disclosed** (composite 6.69, high confidence) beat an explicit "Proceed" button (6.41) and silent-discount (2.96). The kernel penalized the button under "do the work; don't task the operator" and "consult governed scopes before asking a human". No new operator control; the panel does the right thing and shows its work.

## Test plan
- 5 unit tests for `applyEmptyLoopDiscount` (fresh-empty → discounted; below-threshold → still hard; live/non-deliberation loop → untouched; non-coworker surface untouched; multi-build aggregation).
- CI Typecheck / Prod Build / Unit gates are authoritative (built on a source-only worktree).
- Live verification of the panel to follow on the running install after merge.

Refs: BI-12E24186 (this), BI-7B6B3C5C (root-cause stub, separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
