### PR TITLE
feat(kernel): migrate three profession-specialist principles to their corpora (BI-5FE47130)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,7 +270,7 @@ The `Organization.address` JSON has one canonical shape + helpers in [`apps/web/
 
 Sole exception: `text-white` on `bg-[var(--dpf-accent)]` buttons. Inline `style={{ color: "#xxx" }}` is equally prohibited — use `var(--dpf-text)`. `<option>` elements need explicit `bg-[var(--dpf-surface-2)] text-[var(--dpf-text)]`. Variables defined in `globals.css`, overridden at runtime by branding tokens.
 
-→ [kernel principle](docs/founder-kernel/wiki/principles/compose-report-kit-for-reporting-ux.md)
+→ [kernel principle](docs/professions/frontend-engineer/wiki/compose-report-kit-for-reporting-ux.md)
 
 **Compose the report-kit palette for reporting UX.** Where the rule above binds *colors* to tokens, this binds whole *reporting components* to a shared palette. Reporting/data-display UX (status badges, list/detail tables, KPI cards, filters, CSV export, charts) is composed from `apps/web/components/ui/report-kit/` — `StatusBadge`, `DataTable`, `StatCard`, `FilterBar`, `ExportButton`/`toCsv`, `Chart`, and the `statusColors` intent registry. Never hand-roll a badge, `<table>`, per-page status color map, or KPI div. Status/severity colors resolve through `statusColors.ts` (status → semantic intent → `--dpf-*` token), never a local map or raw hex. **Discover before building:** read `apps/web/components/ui/report-kit/README.md`, and query the curated catalog via `search_design_intelligence` (domain `ux`/`chart`). If a primitive doesn't cover the case, extend report-kit rather than building a parallel one-off.
 
@@ -295,7 +295,7 @@ Full standard: `docs/platform-usability-standards.md`. Other UI conventions: tab
 
 ## 14. Release Testing
 
-→ [kernel principle](docs/founder-kernel/wiki/principles/release-qa-plan.md)
+→ [kernel principle](docs/professions/release-service-management/wiki/release-qa-plan.md)
 
 Every release passes the QA test plan at `tests/e2e/platform-qa-plan.md` (15 phases). For feature work, run the affected phases as part of definition of done — `next build` and unit tests do not replace UX exercise. Failures get a backlog item with repro steps under the active QA epic. Test results are release evidence. Release QA phases run against the canonical local install or a leased shared nonprod environment per §5 — never against a worktree's local harness. A worktree is the source-control container for the change under test, not a release-QA runtime.
 

--- a/apps/web/lib/docs/doc-index.generated.json
+++ b/apps/web/lib/docs/doc-index.generated.json
@@ -2105,21 +2105,6 @@
         "see-also"
       ]
     },
-    "docs/founder-kernel/wiki/principles/compose-report-kit-for-reporting-ux.md": {
-      "publicHref": "/founder-kernel/wiki/principles/compose-report-kit-for-reporting-ux/",
-      "portalHref": null,
-      "publishedPublic": true,
-      "publishedPortal": false,
-      "anchors": [
-        "rule",
-        "why",
-        "applies-to",
-        "how-to-apply",
-        "decision-dimensions",
-        "examples",
-        "sources"
-      ]
-    },
     "docs/founder-kernel/wiki/principles/configuration-scope.md": {
       "publicHref": "/founder-kernel/wiki/principles/configuration-scope/",
       "portalHref": null,
@@ -2733,21 +2718,6 @@
         "examples"
       ]
     },
-    "docs/founder-kernel/wiki/principles/orchestrator-worker-pattern.md": {
-      "publicHref": "/founder-kernel/wiki/principles/orchestrator-worker-pattern/",
-      "portalHref": null,
-      "publishedPublic": true,
-      "publishedPortal": false,
-      "anchors": [
-        "rule",
-        "why",
-        "applies-to",
-        "how-to-apply",
-        "decision-dimensions",
-        "examples",
-        "sources"
-      ]
-    },
     "docs/founder-kernel/wiki/principles/outbound-actions-require-explicit-go.md": {
       "publicHref": "/founder-kernel/wiki/principles/outbound-actions-require-explicit-go/",
       "portalHref": null,
@@ -2865,21 +2835,6 @@
         "decision-dimensions",
         "related",
         "origin"
-      ]
-    },
-    "docs/founder-kernel/wiki/principles/release-qa-plan.md": {
-      "publicHref": "/founder-kernel/wiki/principles/release-qa-plan/",
-      "portalHref": null,
-      "publishedPublic": true,
-      "publishedPortal": false,
-      "anchors": [
-        "rule",
-        "why",
-        "applies-to",
-        "how-to-apply",
-        "decision-dimensions",
-        "examples",
-        "sources"
       ]
     },
     "docs/founder-kernel/wiki/principles/remove-avoidable-failure-opportunities.md": {
@@ -4237,6 +4192,21 @@
         "see-also"
       ]
     },
+    "docs/professions/build-studio/wiki/orchestrator-worker-pattern.md": {
+      "publicHref": "/professions/build-studio/wiki/orchestrator-worker-pattern/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "examples",
+        "sources"
+      ]
+    },
     "docs/professions/build-studio/wiki/scope-containment.md": {
       "publicHref": "/professions/build-studio/wiki/scope-containment/",
       "portalHref": null,
@@ -4975,6 +4945,21 @@
         "what-it-requires-in-practice",
         "status-scope-gate",
         "see-also"
+      ]
+    },
+    "docs/professions/frontend-engineer/wiki/compose-report-kit-for-reporting-ux.md": {
+      "publicHref": "/professions/frontend-engineer/wiki/compose-report-kit-for-reporting-ux/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "examples",
+        "sources"
       ]
     },
     "docs/professions/frontend-engineer/wiki/first-rule-of-aria-native-elements.md": {
@@ -5845,6 +5830,21 @@
         "why-each-is-required",
         "how-to-apply",
         "see-also"
+      ]
+    },
+    "docs/professions/release-service-management/wiki/release-qa-plan.md": {
+      "publicHref": "/professions/release-service-management/wiki/release-qa-plan/",
+      "portalHref": null,
+      "publishedPublic": true,
+      "publishedPortal": false,
+      "anchors": [
+        "rule",
+        "why",
+        "applies-to",
+        "how-to-apply",
+        "decision-dimensions",
+        "examples",
+        "sources"
       ]
     },
     "docs/professions/release-service-management/wiki/release-versioning.md": {

--- a/docs/professions/build-studio/wiki/orchestrator-worker-pattern.md
+++ b/docs/professions/build-studio/wiki/orchestrator-worker-pattern.md
@@ -9,12 +9,10 @@ principleDimensionVector: {"governance_compliance": 0.7, "long_term_maintainabil
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
-  - human
 principleRingScope:
   - ring-2-workflow
-principleConsumerArchetype: route-domain-specific
-principleConsumerContexts:
-  - build-studio
+principleConsumerArchetype: specialist
+professionCompetencyLevel: practitioner
 principlePublic: true
 principlePublicRationale: Documents DPF's multi-agent topology so adopters understand why coworkers don't hand off directly.
 sources:

--- a/docs/professions/frontend-engineer/wiki/compose-report-kit-for-reporting-ux.md
+++ b/docs/professions/frontend-engineer/wiki/compose-report-kit-for-reporting-ux.md
@@ -25,7 +25,7 @@ Reporting and data-display UX is composed from the shared **report-kit** palette
 
 ## Why
 
-The same reporting patterns — status pills, filterable tables, KPI cards, trend charts — recur on dozens of surfaces (finance, compliance, CRM, admin). When each surface hand-rolls them, the platform accumulates inconsistent color semantics, duplicated table/filter logic, uneven accessibility, and a maintenance hunt on every change. It also forces every contributor — human or agent — to re-derive component patterns from scratch or research them externally. A single composable palette eliminates that whole class of work: build once, reuse everywhere, change in one place. This principle is the reuse-and-consistency complement to [No Hardcoded Colors](no-hardcoded-colors.md): that one says *bind colors to tokens*; this one says *bind whole reporting components to the shared palette*.
+The same reporting patterns — status pills, filterable tables, KPI cards, trend charts — recur on dozens of surfaces (finance, compliance, CRM, admin). When each surface hand-rolls them, the platform accumulates inconsistent color semantics, duplicated table/filter logic, uneven accessibility, and a maintenance hunt on every change. It also forces every contributor — human or agent — to re-derive component patterns from scratch or research them externally. A single composable palette eliminates that whole class of work: build once, reuse everywhere, change in one place. This principle is the reuse-and-consistency complement to [No Hardcoded Colors](../../../founder-kernel/wiki/principles/no-hardcoded-colors.md): that one says *bind colors to tokens*; this one says *bind whole reporting components to the shared palette*.
 
 ## Applies To
 

--- a/docs/professions/frontend-engineer/wiki/compose-report-kit-for-reporting-ux.md
+++ b/docs/professions/frontend-engineer/wiki/compose-report-kit-for-reporting-ux.md
@@ -9,12 +9,10 @@ principleDimensionVector: {"reusability": 0.9, "long_term_maintainability": 0.7,
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
-  - human
 principleRingScope:
   - ring-2-workflow
-principleConsumerArchetype: route-domain-specific
-principleConsumerContexts:
-  - ui
+principleConsumerArchetype: specialist
+professionCompetencyLevel: practitioner
 principlePublic: true
 principlePublicRationale: A shared reporting palette is how DPF keeps data-display UX consistent across dozens of surfaces and lets agents build new surfaces without researching component patterns externally.
 sources:

--- a/docs/professions/release-service-management/wiki/release-qa-plan.md
+++ b/docs/professions/release-service-management/wiki/release-qa-plan.md
@@ -9,12 +9,10 @@ principleDimensionVector: {"evidence_density": 0.8, "governance_compliance": 0.6
 principleAppliesTo:
   - in_platform_coworker
   - external_coding_agent
-  - human
 principleRingScope:
   - ring-4-sandbox-prod
-principleConsumerArchetype: route-domain-specific
-principleConsumerContexts:
-  - release
+principleConsumerArchetype: specialist
+professionCompetencyLevel: practitioner
 principlePublic: true
 principlePublicRationale: Adopters need to know DPF treats UX verification as release evidence — silent UI regressions are caught here, not in production.
 sources:

--- a/packages/db/src/wiki-slug-migrations.ts
+++ b/packages/db/src/wiki-slug-migrations.ts
@@ -120,6 +120,23 @@ export const WIKI_SLUG_MIGRATIONS: readonly WikiSlugMigration[] = [
     to: "professions/portfolio-management/check-epic-overlap-before-creating",
     reason: "portfolio cohort -> portfolio-management (BI-5FE47130)",
   },
+  // Fourth cohort: single-context sourced profession-specialist principles
+  // across three professions (reporting UI, BS orchestration, release QA).
+  {
+    from: "principles/compose-report-kit-for-reporting-ux",
+    to: "professions/frontend-engineer/compose-report-kit-for-reporting-ux",
+    reason: "specialist cohort -> frontend-engineer (BI-5FE47130)",
+  },
+  {
+    from: "principles/orchestrator-worker-pattern",
+    to: "professions/build-studio/orchestrator-worker-pattern",
+    reason: "specialist cohort -> build-studio (BI-5FE47130)",
+  },
+  {
+    from: "principles/release-qa-plan",
+    to: "professions/release-service-management/release-qa-plan",
+    reason: "specialist cohort -> release-service-management (BI-5FE47130)",
+  },
 ];
 
 export type SlugMigrationOutcome = {


### PR DESCRIPTION
BI-5FE47130 **cohort 4** — migration now at **16/53**. This exhausts the unambiguous profession-specialist principles; what remains needs operator judgment (see below).

Seed-Fit-Decision: global-default

## What moves

Three single-context sourced principles that are genuinely profession-specialist practice → their owning corpora:

| principle | → profession | why |
|---|---|---|
| `compose-report-kit-for-reporting-ux` | frontend-engineer | reporting UI implementation |
| `orchestrator-worker-pattern` | build-studio | BS orchestration |
| `release-qa-plan` | release-service-management | release QA |

Each becomes `specialist`, drops `principleConsumerContexts`, gains `professionCompetencyLevel`, drops `human`. `WIKI_SLUG_MIGRATIONS` renames each row in place; git tracks all three as renames.

## Reference sweep

Two AGENTS.md kernel-principle links repointed. The skill-grant descriptions and `reporting-read-model-boundaries.md` mention `compose-report-kit` as backtick prose (not links) — the gate doesn't flag those. `orchestrator-worker-pattern` had no inbound links. No seed references.

Kernel principle count: **87 → 84**.

## Deliberately NOT migrated — the judgment boundary

The six `engineering-flow` **discipline** principles (`worktree-per-session`, `one-concern-per-pr`, `always-push-after-committing`, `branch-guard-before-implementation`, `keep-root-clone-as-merge-worktree`, `mention-uncommitted-changes`) are single-context + sourced and *would* move mechanically — but they are development-**process** doctrine that binds **every contributor touching the repo** (human, external agent, in-platform coworker), not a software-engineer specialist. Migrating them to `software-engineer` would remove them from any contributor that doesn't resolve to that profession.

That is the spec's **bucket-2** judgment ("keep in WWMD, justified as universal in writing" vs migrate), which needs an operator decision — recorded on BI-5FE47130, not forced here. Along with the 11 `engineering-flow` commandments (sequence last, individually) and the uncited platform-doctrine triage, this is where mechanical migration ends and judgment begins.

## Verification

Doc-link integrity + module-size pass; slug-migrations (collision/chain guards) + §8A.1 coherence green; doc index regenerated with no stale principle-path reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
