### PR TITLE
fix(routing): null tool-capability = attempt-and-calibrate (BI-DFC30977)

### DIFF
--- a/apps/web/lib/routing/agent-capability-types.test.ts
+++ b/apps/web/lib/routing/agent-capability-types.test.ts
@@ -70,4 +70,16 @@ describe("satisfiesMinimumCapabilities", () => {
     );
     expect(result).toEqual({ satisfied: true });
   });
+
+  // BI-DFC30977: null = unknown → attempt-and-calibrate (must pass toolUse floor)
+  it("passes toolUse floor when supportsToolUse is null (unknown → attempt-and-calibrate)", () => {
+    const result = satisfiesMinimumCapabilities(ep({ supportsToolUse: null as never }), DEFAULT_MINIMUM_CAPABILITIES);
+    expect(result).toEqual({ satisfied: true });
+  });
+
+  // BI-DFC30977: explicit false must still be excluded (model×transport invariant)
+  it("fails toolUse floor when supportsToolUse is explicitly false (chatgpt/gpt-5.4 invariant)", () => {
+    const result = satisfiesMinimumCapabilities(ep({ supportsToolUse: false }), DEFAULT_MINIMUM_CAPABILITIES);
+    expect(result).toEqual({ satisfied: false, missingCapability: "toolUse" });
+  });
 });

--- a/apps/web/lib/routing/agent-capability-types.ts
+++ b/apps/web/lib/routing/agent-capability-types.ts
@@ -42,7 +42,8 @@ export function satisfiesMinimumCapabilities(
   endpoint: Pick<EndpointManifest, "supportsToolUse" | "capabilities">,
   floor: AgentMinimumCapabilities,
 ): { satisfied: boolean; missingCapability?: keyof AgentMinimumCapabilities } {
-  if (floor.toolUse && !endpoint.supportsToolUse) {
+  // BI-DFC30977: null (unknown) = attempt-and-calibrate. Only explicit false fails the floor.
+  if (floor.toolUse && endpoint.supportsToolUse === false) {
     return { satisfied: false, missingCapability: "toolUse" };
   }
   const caps = endpoint.capabilities as unknown as Record<string, unknown> | null | undefined;

--- a/apps/web/lib/routing/eval-runner.test.ts
+++ b/apps/web/lib/routing/eval-runner.test.ts
@@ -76,8 +76,39 @@ import {
   errorLooksLikeConfigGap,
   errorEndsEvalCycle,
   runDimensionEval,
+  deriveToolUseFromToolFidelity,
+  TOOL_FIDELITY_SUPPORTS_TOOLS_THRESHOLD,
   type DriftResult,
 } from "./eval-runner";
+
+
+// BI-DFC30977 Phase 2: calibration loop — supportsToolUse derived from toolFidelity score
+describe("deriveToolUseFromToolFidelity (BI-DFC30977 Phase 2 — calibration)", () => {
+  it("returns true when score meets the threshold (capable model)", () => {
+    expect(deriveToolUseFromToolFidelity(TOOL_FIDELITY_SUPPORTS_TOOLS_THRESHOLD)).toBe(true);
+    expect(deriveToolUseFromToolFidelity(70)).toBe(true);
+    expect(deriveToolUseFromToolFidelity(100)).toBe(true);
+  });
+
+  it("returns false when score is below the threshold (incapable model)", () => {
+    expect(deriveToolUseFromToolFidelity(TOOL_FIDELITY_SUPPORTS_TOOLS_THRESHOLD - 1)).toBe(false);
+    expect(deriveToolUseFromToolFidelity(0)).toBe(false);
+    expect(deriveToolUseFromToolFidelity(10)).toBe(false);
+  });
+
+  it("threshold boundary: score at exactly threshold is capable, one below is not", () => {
+    expect(deriveToolUseFromToolFidelity(TOOL_FIDELITY_SUPPORTS_TOOLS_THRESHOLD)).toBe(true);
+    expect(deriveToolUseFromToolFidelity(TOOL_FIDELITY_SUPPORTS_TOOLS_THRESHOLD - 1)).toBe(false);
+  });
+
+  it("threshold is in the expected calibration range (30-50) — guards against accidental mutations", () => {
+    // This test pins the constant so a refactor that accidentally changes the
+    // threshold (e.g. 35 → 0 or → 100) will fail visibly rather than silently
+    // routing all models as tool-capable or all as incapable.
+    expect(TOOL_FIDELITY_SUPPORTS_TOOLS_THRESHOLD).toBeGreaterThanOrEqual(30);
+    expect(TOOL_FIDELITY_SUPPORTS_TOOLS_THRESHOLD).toBeLessThanOrEqual(50);
+  });
+});
 
 describe("computeNewScore", () => {
   it("uses raw score on first eval (evalCount=0)", () => {

--- a/apps/web/lib/routing/eval-runner.ts
+++ b/apps/web/lib/routing/eval-runner.ts
@@ -94,7 +94,28 @@ export function errorEndsEvalCycle(error: string | null): boolean {
   return errorLooksLikeInfrastructure(error) || errorLooksLikeConfigGap(error);
 }
 
-// ── Score Computation ────────────────────────────────────────────────────────
+// BI-DFC30977 Phase 2: threshold for deriving supportsToolUse from a measured
+// toolFidelity score. A score >= this value means the model produced a correct
+// tool call on at least ~1 in 3 attempts — sufficient signal to mark it capable.
+// Mirror of the magistral-tier prior boundary in deriveLocalModelCapabilityPrior
+// (@dpf/db/local-model-capabilities). Exported for deterministic unit testing.
+export const TOOL_FIDELITY_SUPPORTS_TOOLS_THRESHOLD = 35;
+
+/**
+ * Derive a supportsToolUse boolean from a measured toolFidelity score.
+ *
+ * Pure function — no DB, no side effects. Called by runDimensionEval when the
+ * toolFidelity dimension produces a conclusive result; exported for direct
+ * unit testing of the threshold boundary.
+ *
+ * Returns `true` when score >= TOOL_FIDELITY_SUPPORTS_TOOLS_THRESHOLD,
+ * `false` otherwise (model tried tool calls but failed consistently).
+ */
+export function deriveToolUseFromToolFidelity(score: number): boolean {
+  return score >= TOOL_FIDELITY_SUPPORTS_TOOLS_THRESHOLD;
+}
+
+
 
 /** Compute new dimension score from eval result and previous score. */
 export function computeNewScore(
@@ -544,10 +565,39 @@ export async function runDimensionEval(
   const allInconclusive = dimensions.every((d) => d.inconclusive);
   const hasRealScores = Object.keys(scoreUpdates).length > 0;
 
+  // BI-DFC30977 Phase 2: Close the calibration loop — write supportsToolUse as
+  // a boolean when the toolFidelity dimension produces a conclusive result.
+  //
+  // Without this write, a null-capability model that passes the routing gate
+  // (Phase 1: null = attempt-and-calibrate) would keep being reselected even
+  // after repeated tool-call failures, because the gate reads `supportsToolUse`
+  // (boolean) from the ModelProfile, not `toolFidelity` (score). The eval runner
+  // wrote the score but never updated the boolean, so the boolean stayed null
+  // and the router kept attempting the model.
+  //
+  // Threshold: ~35/100 mirrors the magistral-tier prior boundary used in
+  // deriveLocalModelCapabilityPrior (@dpf/db/local-model-capabilities).
+  // A score ≥ 35 means at least ~1 in 3 tool calls succeeded — sufficient signal
+  // to treat the model as tool-capable.
+  //
+  // Inconclusive → do not clobber: a noisy or infra-failed probe must not
+  // flip a previously-confirmed true to false. We only write when the dimension
+  // produced conclusive measured results.
+  //
+  // The pipeline-v2 circuit-breaker soft-exclusion provides the short-term
+  // safety net before the eval calibrates: a just-failed null-capability
+  // endpoint is cooled so it is not reselected on every agentic-loop iteration.
+  const toolFidelityDim = dimensions.find((d) => d.dimension === "toolFidelity");
+  const supportsToolUseUpdate: { supportsToolUse?: boolean } = {};
+  if (toolFidelityDim && !toolFidelityDim.inconclusive) {
+    supportsToolUseUpdate.supportsToolUse = deriveToolUseFromToolFidelity(toolFidelityDim.newScore);
+  }
+
   await prisma.modelProfile.update({
     where: { providerId_modelId: { providerId, modelId } },
     data: {
       ...scoreUpdates,
+      ...supportsToolUseUpdate,
       ...(hasRealScores ? { profileSource: "evaluated" as const } : {}),
       profileConfidence: (currentEvalCount + 1) >= 5 ? "high" : "medium",
       evalCount: { increment: 1 },

--- a/apps/web/lib/routing/loader.ts
+++ b/apps/web/lib/routing/loader.ts
@@ -209,7 +209,7 @@ function profileToManifest(
         : mp.provider.status)) as EndpointManifest["status"],
     providerTier: classifyProviderTier(mp.providerId),
     sensitivityClearance: mp.provider.sensitivityClearance as SensitivityLevel[],
-    supportsToolUse: resolveToolUse(mp) ?? false,
+    supportsToolUse: resolveToolUse(mp),
     supportsStructuredOutput: mp.provider.supportsStructuredOutput,
     supportsStreaming: mp.provider.supportsStreaming,
     maxContextTokens: mp.maxContextTokens ?? mp.provider.maxContextTokens,

--- a/apps/web/lib/routing/pipeline-v2.capability.test.ts
+++ b/apps/web/lib/routing/pipeline-v2.capability.test.ts
@@ -108,4 +108,30 @@ describe("getExclusionReasonV2 — capability floor (EP-AGENT-CAP-002)", () => {
     const reason = getExclusionReasonV2(ep, c);
     expect(reason).toContain("imageInput");
   });
+
+  // BI-DFC30977: null = unknown capability → attempt-and-calibrate (must be eligible)
+  it("passes endpoint when requiresTools and endpoint has supportsToolUse: null (unknown → attempt-and-calibrate)", () => {
+    const ep = activeEp({ supportsToolUse: null as never });
+    const c = contract({ minimumCapabilities: { toolUse: true } });
+    expect(getExclusionReasonV2(ep, c)).toBeNull();
+  });
+
+  it("passes endpoint when requiresTools=true and supportsToolUse: null without minimumCapabilities", () => {
+    const ep = activeEp({ supportsToolUse: null as never });
+    const c = contract({ requiresTools: true });
+    expect(getExclusionReasonV2(ep, c)).toBeNull();
+  });
+
+  // BI-DFC30977: explicit false floor must still be excluded (model×transport invariant)
+  it("still excludes chatgpt/gpt-5.4 with explicit supportsToolUse:false on tool-requiring turn", () => {
+    const ep = activeEp({
+      providerId: "chatgpt",
+      modelId: "gpt-5.4",
+      supportsToolUse: false,
+    });
+    const c = contract({ minimumCapabilities: { toolUse: true } });
+    const reason = getExclusionReasonV2(ep, c);
+    expect(reason).not.toBeNull();
+    expect(reason).toContain("toolUse");
+  });
 });

--- a/apps/web/lib/routing/pipeline-v2.ts
+++ b/apps/web/lib/routing/pipeline-v2.ts
@@ -106,7 +106,12 @@ export function getExclusionReasonV2(
   // deriveLocalModelCapabilityPrior (@dpf/db/local-model-capabilities) — the same
   // prior the seed uses — so a coder model (qwen3-coder) resolves supportsToolUse: true
   // and an embedding model (nomic-embed) resolves false.
-  if (contract.requiresTools && !ep.supportsToolUse) {
+  //
+  // BI-DFC30977: null (unknown capability) is attempt-and-calibrate — do NOT exclude it.
+  // Only an *explicit* false (from provider floor, capabilityOverrides, or catalog) is
+  // excluded. resolveToolUse() in loader.ts already floors every explicit-false source
+  // to false (never null), so === false is the correct and complete exclusion predicate.
+  if (contract.requiresTools && ep.supportsToolUse === false) {
     return "Missing required capability: toolUse";
   }
 

--- a/apps/web/lib/routing/pipeline.test.ts
+++ b/apps/web/lib/routing/pipeline.test.ts
@@ -193,6 +193,24 @@ describe("filterHard", () => {
     const { eligible } = filterHard([degraded], greetingReq, "public");
     expect(eligible.map((e) => e.id)).toContain("ep-degraded");
   });
+
+  // BI-DFC30977: null = unknown → attempt-and-calibrate
+  it("allows endpoint with supportsToolUse:null through when task requires tools (attempt-and-calibrate)", () => {
+    const unknownTool = makeEndpoint({
+      id: "ep-unknown-tool",
+      supportsToolUse: null as never,
+      toolFidelity: 0,
+    });
+    const { eligible } = filterHard([unknownTool], codeGenReq, "public");
+    expect(eligible.map((e) => e.id)).toContain("ep-unknown-tool");
+  });
+
+  // BI-DFC30977: explicit false stays excluded (model×transport invariant)
+  it("excludes endpoint with supportsToolUse:false when task requires tools (explicit floor)", () => {
+    const { eligible, excluded } = filterHard([noTools], codeGenReq, "public");
+    expect(eligible.map((e) => e.id)).not.toContain("ep-no-tools");
+    expect(excluded.some((e) => e.endpointId === "ep-no-tools")).toBe(true);
+  });
 });
 
 // ── filterByPolicy ────────────────────────────────────────────────────────────

--- a/apps/web/lib/routing/pipeline.ts
+++ b/apps/web/lib/routing/pipeline.ts
@@ -151,7 +151,8 @@ export function getExclusionReason(
   // Required capabilities
   const caps = req.requiredCapabilities;
 
-  if (caps.supportsToolUse && !ep.supportsToolUse) {
+  // BI-DFC30977: null = unknown capability → attempt-and-calibrate. Only explicit false excludes.
+  if (caps.supportsToolUse && ep.supportsToolUse === false) {
     return "Missing required capability: supportsToolUse";
   }
 

--- a/apps/web/lib/routing/task-router.test.ts
+++ b/apps/web/lib/routing/task-router.test.ts
@@ -197,6 +197,25 @@ describe("routeTask — Stage 1: Hard Filter", () => {
     expect(decision.candidates.find((c) => c.endpointId === "ep-active")?.excluded).toBe(false);
     expect(decision.candidates.find((c) => c.endpointId === "ep-degraded")?.excluded).toBe(false);
   });
+
+  // BI-DFC30977: null = unknown → attempt-and-calibrate
+  it("includes endpoint with supportsToolUse:null when task requires tools (attempt-and-calibrate)", () => {
+    const nullToolEps = [
+      ...endpoints,
+      makeEndpoint({ id: "ep-nulltool", name: "Null Tool", supportsToolUse: null as never, qualityTier: "frontier" }),
+    ];
+    const decision = routeTask(nullToolEps, toolTask, "internal", []);
+    const c = decision.candidates.find((c) => c.endpointId === "ep-nulltool")!;
+    expect(c.excluded).toBe(false);
+  });
+
+  // BI-DFC30977: explicit false stays excluded (model×transport invariant)
+  it("still excludes ep-notool (explicit supportsToolUse:false) when task requires tools", () => {
+    const decision = routeTask(endpoints, toolTask, "internal", []);
+    const c = decision.candidates.find((c) => c.endpointId === "ep-notool")!;
+    expect(c.excluded).toBe(true);
+    expect(c.excludedReason).toMatch(/tool support/);
+  });
 });
 
 // ── Stage 2 & 3: Score & Rank ─────────────────────────────────────────────────

--- a/apps/web/lib/routing/task-router.ts
+++ b/apps/web/lib/routing/task-router.ts
@@ -138,9 +138,9 @@ export function routeTask(
     } else if (!endpoint.sensitivityClearance.includes(sensitivity)) {
       excluded = true;
       reason = `Excluded: sensitivity clearance insufficient for '${sensitivity}'`;
-    } else if (taskRequirement.requiredCapabilities.supportsToolUse && !endpoint.supportsToolUse) {
+    } else if (taskRequirement.requiredCapabilities.supportsToolUse && endpoint.supportsToolUse === false) {
       excluded = true;
-      reason = "Excluded: task requires tool support";
+      reason = "Excluded: task requires tool support"; // BI-DFC30977: null = attempt-and-calibrate; only false excluded
     } else if (taskRequirement.requiredCapabilities.supportsStructuredOutput && !endpoint.supportsStructuredOutput) {
       excluded = true;
       reason = "Excluded: task requires structured output";

--- a/apps/web/lib/routing/types.ts
+++ b/apps/web/lib/routing/types.ts
@@ -38,7 +38,7 @@ export interface EndpointManifest {
 
   // Hard constraints
   sensitivityClearance: SensitivityLevel[];
-  supportsToolUse: boolean;
+  supportsToolUse: boolean | null;
   supportsStructuredOutput: boolean;
   supportsStreaming: boolean;
   maxContextTokens: number | null;

--- a/docs/superpowers/plans/2026-07-18-tool-capability-attempt-and-calibrate.md
+++ b/docs/superpowers/plans/2026-07-18-tool-capability-attempt-and-calibrate.md
@@ -1,0 +1,98 @@
+# Implementation Plan — BI-DFC30977
+
+**Route unknown (null) tool-capability as attempt-and-calibrate, without overriding explicit per-transport floors; dedup shadowed qwen3-coder profiles.**
+
+> Supersedes the earlier antigravity plan, which was built on a falsified premise (a model-identity "cloud capability prior"). See §Premise.
+
+## Premise (why the earlier plan was wrong)
+
+Tool capability is a property of **(model × transport)**, not of model identity. `apps/web/lib/routing/known-provider-models.ts:377-405` sets `chatgpt/gpt-5.4 → toolUse:false` **deliberately** (the ChatGPT-subscription backend `/codex/responses` supports only Codex built-in tools, not custom function tools — which is what every DPF tool is), while `codex/gpt-5.4` (`:342-374`, routes to `api.openai.com/v1/responses`) is correctly `true`. Forcing `true` by identity would override a correct floor and cause runtime tool-call failures.
+
+The real, narrower defect: capability that is genuinely **unknown** (`null`) is coerced to `false` and excluded, with no recovery path. `metadata-extractor.ts` only derives tool support for ollama/gemini/openrouter; every other provider's discovery returns `null`.
+
+**Non-goals:** no identity-based cloud prior; no change to the `chatgpt/gpt-5.4 → false` floor; no operator/config actions (reconnecting Anthropic / enabling the Codex provider is the separate live lever and needs no build).
+
+## Open questions
+None blocking. One design choice resolved inline in Phase 2: the calibrate signal writes the `supportsToolUse` **boolean** from the measured `tool_call` dimension (the gates read the boolean, not `toolFidelity`).
+
+---
+
+## Phase 1 — Attempt: treat `null` (unknown) as allowed, keep explicit `false` excluded
+
+Keep unknown capability alive to the gate, and change the four gates from "falsy excludes" to "only explicit `false` excludes". `resolveToolUse` already floors every explicit-false source (provider floor, `capabilityOverrides.toolUse:false`, catalog/profile `false`) to `false` (never `null`), so this preserves correct exclusions while letting `null` through.
+
+- **`apps/web/lib/routing/loader.ts:191`** — `supportsToolUse: resolveToolUse(mp) ?? false` → `supportsToolUse: resolveToolUse(mp)` (let `null` survive). `EndpointManifest.supportsToolUse` type must allow `boolean | null` — confirm and widen if needed.
+- **`apps/web/lib/routing/pipeline-v2.ts:93`** — `if (contract.requiresTools && !ep.supportsToolUse)` → `=== false`.
+- **`apps/web/lib/routing/pipeline.ts:152`** — `if (caps.supportsToolUse && !ep.supportsToolUse)` → `=== false`.
+- **`apps/web/lib/routing/task-router.ts:141`** — `...supportsToolUse && !endpoint.supportsToolUse` → `=== false`.
+- **`apps/web/lib/routing/agent-capability-types.ts:45`** — `if (floor.toolUse && !endpoint.supportsToolUse)` → `=== false`.
+
+**Scope guard:** only the `toolUse` gate changes. The sibling capability floors (`structuredOutput`, `imageInput`, `computerUse`, …) keep `!== true` semantics — do not "consistency-fix" them; that is a separate decision.
+
+**Tests (lock the invariant):**
+- `pipeline-v2.capability.test.ts` — add: `supportsToolUse:null` + `requiresTools` → **eligible**; `supportsToolUse:false` + `requiresTools` → **excluded** ("Missing required capability: toolUse"). Assert `chatgpt/gpt-5.4` (explicit false) stays excluded.
+- Mirror the false-stays-excluded assertion in the legacy paths (`pipeline.test.ts`, `task-router.test.ts`, `agent-capability-types.test.ts`).
+
+## Phase 2 — Calibrate: close the loop so a null model that can't tool-call converges to `false`
+
+**Gap confirmed:** `eval-runner.ts` (`runDimensionEval`, ~line 490-557) writes measured dimension *scores* (incl. `toolFidelity` via the `tool_call` dimension at `:150`) and promotes `profileSource→evaluated`, but it never writes the `supportsToolUse` **boolean** the gates read. So an attempted null model that fails tool-calls would keep being reselected.
+
+- In `eval-runner.ts`, when the `tool_call` dimension is **conclusive** (not `inconclusive`), also write `supportsToolUse = (toolFidelity >= THRESHOLD)` in the same `modelProfile.update` (§547). Threshold: reuse the existing tool-fidelity cutoff if one exists; else introduce a named constant (start ~35, matching the magistral-tier prior boundary) and document it. Writing it as an `evaluated`-owned value means `resolveSyncedToolUse` (precedence step 3) preserves it against later low-confidence re-discovery.
+- **Runtime safety net (already present, no change):** the pipeline-v2 circuit-breaker soft-exclusion cools a just-failed endpoint so a null model can't be reselected on every agentic-loop iteration *before* the eval calibrates. Note it in comments so the interplay is explicit.
+
+**Tests:** `eval-runner` test — a conclusive low `tool_call` result writes `supportsToolUse:false`; a passing one writes `true`; an `inconclusive` result leaves the boolean unchanged (no clobber).
+
+## Phase 3 — Dedup the shadowed qwen3-coder profiles + enforce uniqueness
+
+Live DB has **two** non-retired `local/docker.io/ai/qwen3-coder:latest` rows: `cmqem1jz…` (`evaluated`, toolFidelity 100, `capabilityOverrides={toolUse:true}`) and `cmrlkwpqx…` (`seed`, toolFidelity 80, no override). `RouteDecisionLog` shows the **stale seed row is the one actually routing** — the measured profile is being shadowed. Two rows sharing `(providerId, modelId)` means the `@@unique([providerId, modelId])` the upsert relies on is not enforced in this DB.
+
+> **WITHDRAWN 2026-07-23 — superseded by the upstream collation-drift repair; not shipped in this PR.**
+>
+> Re-checked against live data after the portal returned: the duplicates are gone and
+> `ModelProfile_providerId_modelId_key` exists. The repair came from an established
+> upstream program for **collation-drift index corruption**, not from a missing
+> constraint as this phase assumed — see `docs/runbooks/2026-07-20-collation-drift-index-corruption.md`,
+> `docs/data-impact/2026-07-21-retire-quarantined-duplicate-rows.data-impact.json`,
+> and the `repair_*_index_integrity` migrations. That mechanism frees the unique pair
+> by renaming losers to `__dpf_quarantined__<id>__<modelId>` rather than deleting them,
+> so the migration drafted here would now match zero rows. Shipping it would add a
+> competing dedup path over a solved problem.
+>
+> **Residual defect, split out rather than fixed here:** the upstream repair kept the
+> *wrong* survivor for `local/qwen3-coder:latest` — the stale `seed` row (toolFidelity 40,
+> no overrides) survived while the `evaluated` row (toolFidelity 100,
+> `capabilityOverrides {"toolUse":true}`) was quarantined, losing both the measured
+> calibration and the admin pin. Precedence + override-preservation on survivor choice
+> belongs in the quarantine-triage path, not in a separate migration.
+>
+> **CLOSED 2026-07-24 — BI-84792669.** The precedence + override-preservation design
+> drafted above was implemented as a reusable module,
+> `packages/db/src/model-profile-precedence.ts` (`pickModelProfileSurvivor`,
+> `pickCapabilityOverrides`), and applied to the live quarantine-triage state via
+> `packages/db/prisma/migrations/20260724150000_retriage_quarantined_model_profiles`.
+> That migration re-ranks every already-quarantined `(providerId, modelId)` group with
+> the precedence this phase specified (`evaluated > admin > catalog > seed`, tie-broken
+> on `evalCount`, `toolFidelity`, `lastEvalAt`, `generatedAt`) and copies forward any
+> `capabilityOverrides` pin the survivor lacks. Live-verified: the `evaluated` row for
+> `local/docker.io/ai/qwen3-coder:latest` reclaimed the natural key with `toolFidelity
+> 100` and `capabilityOverrides {"toolUse":true}` restored.
+
+- ~~**Reconcile migration/script**: for any `(providerId, modelId)` with >1 non-retired row, keep the highest-precedence row (`evaluated` > `seed`; tie-break higher `evalCount`/`toolFidelity`, and merge a present `capabilityOverrides`), retire/delete the rest.~~
+- ~~**Verify the constraint:** confirm `@@unique([providerId, modelId])` exists in `packages/db/prisma/schema.prisma`.~~ Confirmed present and enforced live.
+
+## Verification (functional — structural pass is not verification)
+
+1. **`resolve_model_selection`** before/after: a tool-requiring phase whose only eligible endpoint has `supportsToolUse=null` goes from "no eligible endpoint" → routed.
+2. **Live tool-call turn** against a null-capability endpoint: the model is attempted and, on repeated tool-call failure, is demoted (`supportsToolUse=false`) after the eval — confirm via `ModelProfile` + `RouteDecisionLog.excludedReason` on the next turn.
+3. **Explicit-false invariant, live:** with the same config, `chatgpt/gpt-5.4` stays excluded from tool-requiring turns (never routed for a tool task).
+4. ~~**Dedup**~~ — withdrawn with Phase 3; already zero duplicate rows live.
+
+### Automated
+- `pnpm --filter @dpf/db test`
+- `pnpm --filter web exec vitest run lib/routing/ lib/inference/`
+- Required CI gates: Typecheck · Prod Build · DCO · Unit.
+
+## Blast radius / risks
+- The gate change touches the hot routing path for every turn — the false-stays-excluded tests are the guardrail; land them first (TDD).
+- Phase 2 without Phase 1 is inert; Phase 1 without Phase 2 risks a null incapable model looping until the circuit breaker cools it — **ship Phases 1+2 together.**
+- ~~Phase 3 is independent and can land first.~~ Withdrawn — see the Phase 3 note above.


### PR DESCRIPTION
## Summary

Fixes BI-DFC30977: genuinely unknown (
ull) tool capability was being coerced to alse and hard-excluded from tool-requiring turns, with no recovery path.

## Root cause

Tool capability is a property of **(model × transport)**, not model identity. chatgpt/gpt-5.4 → toolUse: false is **deliberately** set because the ChatGPT subscription transport only supports Codex built-in tools, not custom function tools. The real defect was narrower: 
ull (unknown) was coerced to alse in loader.ts and then excluded by falsy checks (!ep.supportsToolUse) across four gate sites.

## Changes

**Phase 1 — Attempt:** treat \
ull\ as eligible (attempt-and-calibrate)
- \	ypes.ts\: widen \EndpointManifest.supportsToolUse\ from \oolean\ to \oolean | null\
- \loader.ts\: drop \?? false\ coercion so \
ull\ survives from DB into manifest
- Four gate sites: \!ep.supportsToolUse\ → \p.supportsToolUse === false\
  - \pipeline-v2.ts\, \pipeline.ts\, \	ask-router.ts\, \gent-capability-types.ts\

**Phase 2 — Calibrate:** close the loop so failed null models converge to \alse\
- \val-runner.ts\: when \	oolFidelity\ dimension produces a conclusive result, write \supportsToolUse\ boolean (threshold: 35/100). Inconclusive results leave the field unchanged.
- Exports \TOOL_FIDELITY_SUPPORTS_TOOLS_THRESHOLD\ and \deriveToolUseFromToolFidelity\ as pure testable functions.

## Invariants preserved
- \chatgpt/gpt-5.4 → supportsToolUse: false\ stays excluded from tool-requiring turns (explicit floor, not changed)
- All existing \alse\ floors from \capabilityOverrides\, provider floor, or catalog continue to exclude correctly

## Tests
- All four gate test files: \
ull\ + \equiresTools\ → eligible; \alse\ + \equiresTools\ → excluded; \chatgpt/gpt-5.4\ explicit-false guard
- \val-runner.test.ts\: threshold boundary tests for \deriveToolUseFromToolFidelity\
- Source-local gate: 850 tests passed (1 pre-existing failure in \equest-contract.email.test.ts\ unrelated to this change)

## Plan
\docs/superpowers/plans/2026-07-18-tool-capability-attempt-and-calibrate.md\

## Scope note
Phase 3 (dedup shadowed \qwen3-coder\ profiles + enforce \@@unique\ constraint) is independent and tracked separately — it requires DB access and the reconcile script. This PR ships Phases 1+2 together as required by the plan's blast-radius note.