### PR TITLE
fix(workbooks): declutter the Subtotals control while grouping (EP-GRID-WORKBOOKS)

### DIFF
--- a/apps/web/components/workbooks/GridPanels.tsx
+++ b/apps/web/components/workbooks/GridPanels.tsx
@@ -602,34 +602,73 @@ export function GridGroupPanel({
             {effectiveGroupBy.length > 1 ? `${effectiveGroupBy.length} levels · ` : ""}
             {topGroupIds.length} group{topGroupIds.length === 1 ? "" : "s"}
           </span>
-          {/* Per-column subtotal pickers — shown here (not just the footer bar,
-              which TreeDataGrid hides while grouped) so a subtotal aggregate is
-              always reachable while grouping. Drives the same footerAgg state. */}
-          <div className="flex w-full flex-wrap items-center gap-x-3 gap-y-1 border-t border-[var(--dpf-border)] pt-2">
-            <span className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">Subtotals</span>
-            {visibleCols.map((c) => (
-              <label
-                key={c.columnId}
-                className="inline-flex items-center gap-1 text-sm text-[var(--dpf-text)]"
-              >
-                <span className="text-[var(--dpf-muted)]">{c.name}</span>
-                <select
-                  value={footerAgg[c.columnId] ?? "none"}
-                  onChange={(e) =>
-                    setFooterAgg((prev) => ({ ...prev, [c.columnId]: toFooterAgg(e.target.value) }))
-                  }
-                  aria-label={`Subtotal for ${c.name}`}
-                  className={CTRL}
-                >
-                  {availableAggs(c.fieldType).map((a) => (
-                    <option key={a} value={a}>
-                      {FOOTER_AGG_LABELS[a]}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            ))}
-          </div>
+          {/* Subtotals: only the *active* ones show (a compact chip per column
+              with an inline aggregate + remove), plus one "add" picker — instead
+              of a dropdown for every column. Shown here, not just the footer bar,
+              because TreeDataGrid hides the footer while grouped. Same footerAgg. */}
+          {(() => {
+            const active = visibleCols.filter((c) => (footerAgg[c.columnId] ?? "none") !== "none");
+            const inactive = visibleCols.filter((c) => (footerAgg[c.columnId] ?? "none") === "none");
+            return (
+              <div className="flex w-full flex-wrap items-center gap-2 border-t border-[var(--dpf-border)] pt-2">
+                <span className="text-xs uppercase tracking-wide text-[var(--dpf-muted)]">Subtotals</span>
+                {active.map((c) => (
+                  <span
+                    key={c.columnId}
+                    className="inline-flex items-center gap-1 rounded-md border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-2 py-0.5 text-sm text-[var(--dpf-text)]"
+                  >
+                    <span className="text-[var(--dpf-muted)]">{c.name}</span>
+                    <select
+                      value={footerAgg[c.columnId]}
+                      onChange={(e) =>
+                        setFooterAgg((prev) => ({ ...prev, [c.columnId]: toFooterAgg(e.target.value) }))
+                      }
+                      aria-label={`Subtotal aggregate for ${c.name}`}
+                      className="border-none bg-transparent p-0 text-sm font-medium text-[var(--dpf-text)]"
+                    >
+                      {availableAggs(c.fieldType)
+                        .filter((a) => a !== "none")
+                        .map((a) => (
+                          <option key={a} value={a}>
+                            {FOOTER_AGG_LABELS[a]}
+                          </option>
+                        ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={() => setFooterAgg((prev) => ({ ...prev, [c.columnId]: "none" }))}
+                      aria-label={`Remove subtotal for ${c.name}`}
+                      className="text-[var(--dpf-muted)] hover:text-[var(--dpf-text)]"
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+                {inactive.length > 0 && (
+                  <select
+                    value=""
+                    onChange={(e) => {
+                      const col = visibleCols.find((c) => c.columnId === e.target.value);
+                      if (!col) return;
+                      const def: FooterAgg = availableAggs(col.fieldType).includes("sum")
+                        ? "sum"
+                        : "count";
+                      setFooterAgg((prev) => ({ ...prev, [col.columnId]: def }));
+                    }}
+                    aria-label="Add a subtotal"
+                    className={CTRL}
+                  >
+                    <option value="">{active.length ? "+ add…" : "+ add a subtotal…"}</option>
+                    {inactive.map((c) => (
+                      <option key={c.columnId} value={c.columnId}>
+                        {c.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+            );
+          })()}
         </>
       )}
     </div>

--- a/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
+++ b/docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md
@@ -211,6 +211,10 @@ are low-risk config. Build 1 → 2 → 3 in order; 4 and 5 can land any time.
   from a "Subtotals" row **inside the Group panel** (not only the footer bar, which `TreeDataGrid`
   hides while grouped) — so the aggregate is always reachable while grouping, and the earlier
   "use the Summary bar" tip is no longer a dead end. Both surfaces drive the same `footerAgg` state.
+  **UX declutter (2026-07, operator feedback "the UX is not easy"):** that Subtotals row rendered a
+  dropdown for *every* column (~15 on the backlog grid — overwhelming). It now shows only the *active*
+  subtotals as compact chips (column + inline aggregate + remove) plus a single "+ add subtotal…"
+  picker — progressive disclosure, one control by default instead of fifteen.
 - **Slice 18 — table ergonomics: hide fields + frozen columns + row height — SHIPPED.** A "Columns"
   toolbar panel (progressive disclosure) with per-field show/hide checkboxes, a "Freeze first N
   columns" selector (pins the leftmost visible columns on horizontal scroll via react-data-grid

--- a/scripts/prose-lint-baseline.json
+++ b/scripts/prose-lint-baseline.json
@@ -7361,7 +7361,7 @@
     "genericLabels": 0,
     "readability": 0,
     "longSentences": 0,
-    "textMass": 212
+    "textMass": 222
   },
   "apps/web/components/workbooks/GridViewsMenu.tsx": {
     "vocabulary": 0,


### PR DESCRIPTION
## Why

Operator feedback while grouping the backlog grid: *"the user experience is not easy."* The clearest offender was the **Subtotals row** in the Group panel (Slice 23) — it rendered an aggregate dropdown for **every visible column** (~15 on the backlog grid, nearly all "—"), a wall of controls.

## Before → after

- **Before:** `Subtotals  [ID —▾] [Title —▾] [Status —▾] [Priority Sum▾] [Type —▾] … ×15`
- **After:** `Subtotals  [Priority: Sum ×]  [+ add subtotal…]` — only the *active* subtotals show as compact chips (column + inline aggregate + remove), plus one "+ add subtotal…" picker of the columns that don't have one yet.

Progressive disclosure: **one control by default instead of fifteen**. Picking a column defaults its aggregate to **Sum** (numeric) or **Count** (otherwise); the chip's inline dropdown changes it.

## Safe

Same `footerAgg` state, same `grid-footer-summary` helpers — no behaviour change, just far less noise. `GridPanels.tsx` 739 → 778 (under the size guard). 153/153 workbooks tests green. CI runs the authoritative typecheck. I'll verify live on the backlog grid after deploy.

Design-Grounding-Decision: extends docs/superpowers/plans/2026-06-11-universal-grid-workbooks-phase2.md (Slice 23) over apps/web/; no contract change (same footerAgg + footer-summary helpers).
UX-Fit-Decision: progressive disclosure — default Subtotals view is a single "+ add subtotal…" picker (was 15 always-visible dropdowns); active subtotals are compact chips with an inline aggregate + remove; plain names/labels, no tokens/endpoints. Directly lowers cognitive load on the flagged panel.
Process-Spine-Decision: touched the phase-2 plan (Slice 23 declutter note); no new module or spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)