### PR TITLE
fix(platform): align "Agent" vs "AI coworker" vocabulary across surfaces (BI-08393602)

### DIFF
--- a/apps/web/app/(shell)/platform/audit/journal/page.tsx
+++ b/apps/web/app/(shell)/platform/audit/journal/page.tsx
@@ -32,7 +32,7 @@ export default async function CapabilityJournalPage({ searchParams }: Capability
     { label: "Executions", value: journalCount, accent: "var(--dpf-accent)" },
     { label: "Successful", value: successCount, accent: "var(--dpf-success)" },
     { label: "Failed", value: failCount, accent: "var(--dpf-error)" },
-    { label: "Agents", value: uniqueAgents, accent: "var(--dpf-info)" },
+    { label: "Coworkers", value: uniqueAgents, accent: "var(--dpf-info)" },
     { label: "Capabilities", value: uniqueCapabilities, accent: "var(--dpf-warning)" },
   ];
 

--- a/apps/web/app/(shell)/platform/identity/agents/page.test.tsx
+++ b/apps/web/app/(shell)/platform/identity/agents/page.test.tsx
@@ -76,7 +76,7 @@ describe("PlatformIdentityAgentsPage", () => {
     const { default: PlatformIdentityAgentsPage } = await import("./page");
     const html = renderToStaticMarkup(await PlatformIdentityAgentsPage());
 
-    expect(html).toContain("Agent Identity");
+    expect(html).toContain("AI Coworker Identity");
     expect(html).toContain("Finance Specialist");
     expect(html).toContain("HR Assistant");
     expect(html).toContain("principal linked");

--- a/apps/web/app/(shell)/platform/identity/page.test.tsx
+++ b/apps/web/app/(shell)/platform/identity/page.test.tsx
@@ -62,6 +62,6 @@ describe("PlatformIdentityPage", () => {
     expect(html).toContain("Directory");
     expect(html).toContain("Federation");
     expect(html).toContain("Authorization");
-    expect(html).toContain("Agent Identity");
+    expect(html).toContain("AI Coworker Identity");
   });
 });

--- a/apps/web/app/(shell)/platform/identity/page.tsx
+++ b/apps/web/app/(shell)/platform/identity/page.tsx
@@ -83,7 +83,7 @@ export default async function PlatformIdentityPage() {
           ]}
         />
         <PlatformSummaryCard
-          title="Agent Identity"
+          title="AI Coworker Identity"
           description="Review AI workforce identity anchors, current principal coverage, and the path toward GAID- and TAK-aware publication."
           href="/platform/identity/agents"
           accent="var(--dpf-warning)"

--- a/apps/web/app/(shell)/platform/page.tsx
+++ b/apps/web/app/(shell)/platform/page.tsx
@@ -55,7 +55,7 @@ export default async function PlatformPage() {
           href="/platform/ai/overview"
           accent="var(--dpf-info)"
           metrics={[
-            { label: "Agents", value: agentCount },
+            { label: "AI coworkers", value: agentCount },
             { label: "Providers", value: activeProviderCount },
           ]}
         />

--- a/apps/web/components/platform/identity/AgentIdentityPanel.test.tsx
+++ b/apps/web/components/platform/identity/AgentIdentityPanel.test.tsx
@@ -41,7 +41,7 @@ describe("AgentIdentityPanel", () => {
       />,
     );
 
-    expect(html).toContain("Agent Identity");
+    expect(html).toContain("AI Coworker Identity");
     expect(html).toContain("Projected AIDocs");
     expect(html).toContain("Portable authorization classes");
     expect(html).toContain("build-specialist");

--- a/apps/web/components/platform/identity/AgentIdentityPanel.tsx
+++ b/apps/web/components/platform/identity/AgentIdentityPanel.tsx
@@ -41,7 +41,10 @@ export function AgentIdentityPanel({
   return (
     <section className="space-y-6">
       <div>
-        <h1 className="text-xl font-bold text-[var(--dpf-text)]">Agent Identity</h1>
+        <h1 className="text-xl font-bold text-[var(--dpf-text)]">AI Coworker Identity</h1>
+        <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
+          These are your AI coworkers, viewed as identity principals.
+        </p>
         <p className="mt-0.5 text-sm text-[var(--dpf-muted)]">
           Track which AI coworkers are already anchored to the principal spine, which now resolve into a shared AIDoc projection, and which still need identity coverage before they can participate cleanly in TAK/GAID trust surfaces.
         </p>

--- a/apps/web/components/platform/identity/IdentityTabNav.test.tsx
+++ b/apps/web/components/platform/identity/IdentityTabNav.test.tsx
@@ -37,7 +37,7 @@ describe("IdentityTabNav", () => {
     expect(html).toContain(">Federation<");
     expect(html).toContain(">Applications<");
     expect(html).toContain(">Authorization<");
-    expect(html).toContain(">Agents<");
+    expect(html).toContain(">AI Coworkers<");
   });
 
   it("marks nested identity routes as active", () => {

--- a/apps/web/components/platform/identity/IdentityTabNav.tsx
+++ b/apps/web/components/platform/identity/IdentityTabNav.tsx
@@ -11,7 +11,7 @@ const TABS = [
   { label: "Federation", href: "/platform/identity/federation" },
   { label: "Applications", href: "/platform/identity/applications" },
   { label: "Authorization", href: "/platform/identity/authorization" },
-  { label: "Agents", href: "/platform/identity/agents" },
+  { label: "AI Coworkers", href: "/platform/identity/agents" },
 ];
 
 // Rendering is delegated to the shared SectionNav (BI-ARCH-SECTIONNAV); this wrapper

--- a/apps/web/components/platform/platform-nav.ts
+++ b/apps/web/components/platform/platform-nav.ts
@@ -43,7 +43,7 @@ export const PLATFORM_FAMILIES: PlatformFamily[] = [
       { label: "Federation", href: "/platform/identity/federation" },
       { label: "Applications", href: "/platform/identity/applications" },
       { label: "Authorization", href: "/platform/identity/authorization" },
-      { label: "Agents", href: "/platform/identity/agents" },
+      { label: "AI Coworkers", href: "/platform/identity/agents" },
     ],
   },
   {

--- a/apps/web/components/portfolio/PortfolioNodeDetail.tsx
+++ b/apps/web/components/portfolio/PortfolioNodeDetail.tsx
@@ -84,7 +84,7 @@ export function PortfolioNodeDetail({
       <div className="flex flex-wrap gap-3 mb-6">
         <StatBox label="Products" value={String(node.totalCount)} />
         <StatBox label="Owner" value={ownerRole?.roleId ?? "—"} />
-        <StatBox label="Agents" value={String(agentCount)} />
+        <StatBox label="Coworkers" value={String(agentCount)} />
         <StatBox label="Health" value={health} />
         <StatBox
           label="Budget"

--- a/apps/web/components/portfolio/PortfolioOverview.tsx
+++ b/apps/web/components/portfolio/PortfolioOverview.tsx
@@ -73,7 +73,7 @@ export function PortfolioOverview({ roots, agentCounts, budgets, summary }: Prop
             colour="var(--dpf-text)"
           />
           <SummaryCard
-            label="AI Agents"
+            label="AI Coworkers"
             value={summary.activeAgents}
             colour="var(--dpf-accent)"
             detail={`of ${summary.totalAgents} total`}
@@ -112,7 +112,7 @@ export function PortfolioOverview({ roots, agentCounts, budgets, summary }: Prop
                 <div className="flex items-center gap-4 flex-wrap">
                   <Stat value={root.totalCount} label="Products" colour="var(--dpf-text)" />
                   <Stat value={computeHealth(root.activeCount, root.totalCount)} label="Health" colour={colour} />
-                  <Stat value={agentCounts[root.nodeId] ?? 0} label="Agents" colour={colour} />
+                  <Stat value={agentCounts[root.nodeId] ?? 0} label="Coworkers" colour={colour} />
                   <Stat
                     value={budget?.value ?? "\u2014"}
                     label="Budget"

--- a/apps/web/lib/navigation/portal-navigation-model.ts
+++ b/apps/web/lib/navigation/portal-navigation-model.ts
@@ -593,7 +593,7 @@ export const PORTAL_NAV_ROUTES: readonly PortalNavRecord[] = [
   },
   {
     key: "platform-identity-agents",
-    label: "Agents",
+    label: "AI Coworkers",
     path: "/platform/identity/agents",
     parentPath: "/platform/identity",
     domain: "platform",


### PR DESCRIPTION
## Summary

Founder review flagged confusing terminology drift: Identity & Access > Agents (`/platform/identity/agents`, heading "Agent Identity") called AI coworkers "Agents", while AI Operations / the workforce directory call the same entities "AI coworkers". Decision (already made, not re-litigated here): standardize the user-facing term as **"AI coworker"** everywhere it refers to the workforce entity, keeping **"Agent"** only for the technical Principal alias-kind concept in the identity domain (AGENTS.md §11, non-human Principal `kind: "agent"`).

This is a copy-only text/IA change — no data-model, type, prop, or route rename.

## Changes

- `apps/web/components/platform/identity/AgentIdentityPanel.tsx` — h1 "Agent Identity" → "AI Coworker Identity"; added bridge sentence: *"These are your AI coworkers, viewed as identity principals."*
- `apps/web/app/(shell)/platform/identity/page.tsx` — summary card title "Agent Identity" → "AI Coworker Identity" (the "Agent principals" metric label on this same page is left as-is — that's the technical principal-kind count, not the workforce term)
- `apps/web/components/platform/identity/IdentityTabNav.tsx`, `apps/web/components/platform/platform-nav.ts`, `apps/web/lib/navigation/portal-navigation-model.ts` — "Agents" tab/nav label → "AI Coworkers" (all three link to the same unchanged `/platform/identity/agents` route)
- `apps/web/app/(shell)/platform/page.tsx` — AI Operations summary card metric "Agents" → "AI coworkers"
- `apps/web/components/portfolio/PortfolioOverview.tsx` — "AI Agents" → "AI Coworkers" (top summary), "Agents" → "Coworkers" (per-portfolio tight-space stat)
- `apps/web/components/portfolio/PortfolioNodeDetail.tsx` — "Agents" stat → "Coworkers"
- `apps/web/app/(shell)/platform/audit/journal/page.tsx` — "Agents" stat card → "Coworkers"
- Updated the 4 test files whose rendered-HTML assertions referenced the old strings (`IdentityTabNav.test.tsx`, `AgentIdentityPanel.test.tsx`, `identity/agents/page.test.tsx`, `identity/page.test.tsx`)

**Deliberately left unchanged** (technical principal-kind terminology, in scope per the decision):
- "Agent principals" metric label (`identity/page.tsx`)
- `DirectoryAuthoritiesPanel` "Agents" LDAP branch label / `ou=agents` DN, and "People, agents, services, and groups..." copy
- All code identifiers: `agentId`, `prisma.agent`, `kind: "agent"`, `AgentIdentityPanel` component/file name, `/platform/identity/agents` route path

## Verification gap (disclosed)

Local `node_modules` install in this worktree hit a transient corruption during this session (two overlapping `pnpm install` runs raced, producing a vitest install with mismatched lockfile-resolved chunk hashes; the subsequent clean-reinstall attempt then hit a Windows file-lock on `node_modules/@expo` that `rm -rf` couldn't clear within the session's time budget). As a result:

- **Typecheck and the 4 affected vitest files were NOT run locally** for this commit. `DPF_SKIP_TYPECHECK=1` was used at commit time (the hook's documented escape hatch, not `--no-verify`) — CI's Typecheck and Unit Tests gates are the backstop.
- **Gitleaks secret scan DID run** locally (pre-commit) and passed clean.
- Manually verified instead: `git diff` review confirmed every changed hunk is a string literal only (no renamed identifiers/types/props/routes), and a repo-wide grep swept for any remaining user-visible "Agent"/"Agents" workforce string in `apps/web` after the edits.

If CI's Typecheck or Unit Tests gate surfaces anything from this batch of edits, I'll fix it in a follow-up push to this branch before merge.

## Test plan

- [ ] CI Typecheck passes
- [ ] CI Unit Tests passes (including the 4 updated test files: `IdentityTabNav.test.tsx`, `AgentIdentityPanel.test.tsx`, `identity/agents/page.test.tsx`, `identity/page.test.tsx`)
- [ ] CI Prod Build passes
- [x] Gitleaks staged secret scan (local pre-commit) — passed
- [x] Manual diff review — every hunk is display-text only

🤖 Generated with [Claude Code](https://claude.com/claude-code)