### PR TITLE
fix(storefront): customer-safe 404 recovery for public token routes + unprovisioned archetype demos (BI-B9D54962)

### DIFF
--- a/apps/web/app/(storefront)/s/[slug]/not-found.test.tsx
+++ b/apps/web/app/(storefront)/s/[slug]/not-found.test.tsx
@@ -29,4 +29,38 @@ describe("storefront not-found recovery", () => {
     // No slug-specific customer links are fabricated.
     expect(html).not.toContain("/inquire");
   });
+
+  // Named scenarios from the BI-B9D54962 acceptance criteria — logic is
+  // shared (any /s/<slug>/… miss recovers the same way), but each is asserted
+  // explicitly so a regression in one route shape is caught by name.
+  it("unknown storefront: recovers via the layout's notFound(), no workspace/docs", () => {
+    pathname.mockReturnValue("/s/no-such-storefront");
+    const html = renderToStaticMarkup(<StorefrontNotFound />);
+    expect(html).toContain('href="/s/no-such-storefront"');
+    expect(html).not.toContain("/workspace");
+    expect(html).not.toContain("Browse docs");
+  });
+
+  it("bad item: recovers to the storefront's own surfaces", () => {
+    pathname.mockReturnValue("/s/copper-kettle/item/no-such-item");
+    const html = renderToStaticMarkup(<StorefrontNotFound />);
+    expect(html).toContain('href="/s/copper-kettle"');
+    expect(html).not.toContain("/workspace");
+  });
+
+  it("bad booking route: recovers to the storefront's own surfaces", () => {
+    pathname.mockReturnValue("/s/copper-kettle/book/no-such-item");
+    const html = renderToStaticMarkup(<StorefrontNotFound />);
+    expect(html).toContain('href="/s/copper-kettle"');
+    expect(html).toContain('href="/s/copper-kettle/inquire"');
+    expect(html).not.toContain("/workspace");
+  });
+
+  it("invalid checkout ref: recovers to the storefront's own surfaces", () => {
+    pathname.mockReturnValue("/s/copper-kettle/checkout");
+    const html = renderToStaticMarkup(<StorefrontNotFound />);
+    expect(html).toContain('href="/s/copper-kettle"');
+    expect(html).not.toContain("/workspace");
+    expect(html).not.toContain("Browse docs");
+  });
 });

--- a/apps/web/app/(storefront)/s/not-found.test.tsx
+++ b/apps/web/app/(storefront)/s/not-found.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const pathname = vi.fn<() => string>();
+vi.mock("next/navigation", () => ({ usePathname: () => pathname() }));
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+import StorefrontTokenNotFound from "./not-found";
+
+// Covers the token-addressed public routes that sit as SIBLINGS of
+// `s/[slug]`, not descendants of it, so `s/[slug]/not-found.tsx` never
+// catches them (BI-B9D54962). Before this boundary existed, a bad quote or
+// payment token fell through to the global operator 404.
+describe("storefront token-route not-found recovery", () => {
+  it("explains a bad quote token in customer language, not workspace/docs", () => {
+    pathname.mockReturnValue("/s/quote/no-such-token");
+    const html = renderToStaticMarkup(<StorefrontTokenNotFound />);
+    expect(html).toMatch(/quote link is not valid/i);
+    expect(html).toMatch(/expired|already been used/i);
+    expect(html).toContain('href="/"');
+    expect(html).not.toContain("/workspace");
+    expect(html).not.toContain("Browse docs");
+  });
+
+  it("explains a bad payment token in customer language, not workspace/docs", () => {
+    pathname.mockReturnValue("/s/pay/no-such-token");
+    const html = renderToStaticMarkup(<StorefrontTokenNotFound />);
+    expect(html).toMatch(/payment link is not valid/i);
+    expect(html).not.toContain("/workspace");
+    expect(html).not.toContain("Browse docs");
+  });
+
+  it("explains a bad approval token distinctly from an expense approval token", () => {
+    pathname.mockReturnValue("/s/approve/no-such-token");
+    let html = renderToStaticMarkup(<StorefrontTokenNotFound />);
+    expect(html).toMatch(/approval link is not valid/i);
+
+    pathname.mockReturnValue("/s/expense-approve/no-such-token");
+    html = renderToStaticMarkup(<StorefrontTokenNotFound />);
+    expect(html).toMatch(/expense approval link is not valid/i);
+  });
+});

--- a/apps/web/app/(storefront)/s/not-found.tsx
+++ b/apps/web/app/(storefront)/s/not-found.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+/**
+ * Customer-facing not-found boundary for the token-addressed public routes
+ * that live directly under `/s/…` — `quote/[token]`, `pay/[token]`,
+ * `approve/[token]`, `expense-approve/[token]` — which sit as SIBLINGS of
+ * `[slug]`, not descendants of it. `s/[slug]/not-found.tsx` only catches
+ * notFound() calls thrown inside the `[slug]` segment, so a bad/expired
+ * token on these routes previously fell all the way through to the global
+ * operator-oriented 404 (BI-B9D54962). Unlike the slug-scoped boundary, no
+ * storefront/org context is resolvable here — the token IS the only lookup
+ * key, and it didn't resolve — so recovery stays deliberately generic and
+ * never invents a storefront link, but still never points at internal
+ * Workspace/Docs.
+ */
+export default function StorefrontTokenNotFound() {
+  const pathname = usePathname() ?? "";
+
+  const linkKind = pathname.startsWith("/s/quote/")
+    ? "quote"
+    : pathname.startsWith("/s/pay/")
+      ? "payment"
+      : pathname.startsWith("/s/expense-approve/")
+        ? "expense approval"
+        : pathname.startsWith("/s/approve/")
+          ? "approval"
+          : "link";
+
+  return (
+    <div style={{ maxWidth: 520, margin: "0 auto", padding: "64px 20px", textAlign: "center" }}>
+      <div
+        aria-hidden="true"
+        style={{
+          margin: "0 auto 16px",
+          width: 44,
+          height: 44,
+          borderRadius: "50%",
+          border: "1px solid var(--dpf-border)",
+          background: "var(--dpf-surface-2)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontWeight: 700,
+          color: "var(--dpf-accent)",
+        }}
+      >
+        404
+      </div>
+      <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 8, color: "var(--dpf-text)" }}>
+        This {linkKind} link is not valid
+      </h1>
+      <p style={{ color: "var(--dpf-muted)", fontSize: 15, lineHeight: 1.6, marginBottom: 24 }}>
+        It may have expired, already been used, or been copied incorrectly. If a
+        business sent you this {linkKind} link, please ask them to resend a
+        fresh one.
+      </p>
+      <Link
+        href="/"
+        style={{
+          display: "inline-block",
+          padding: "10px 18px",
+          borderRadius: 8,
+          fontSize: 14,
+          fontWeight: 600,
+          textDecoration: "none",
+          background: "var(--dpf-accent)",
+          color: "var(--dpf-surface-1)",
+        }}
+      >
+        Go to homepage
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/app/not-found.test.tsx
+++ b/apps/web/app/not-found.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const pathname = vi.fn<() => string>();
+vi.mock("next/navigation", () => ({ usePathname: () => pathname() }));
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+import NotFound from "./not-found";
+
+// BI-B9D54962: the global 404 must not send a public prospect hitting an
+// unprovisioned archetype demo route (source-registered in
+// packages/storefront-templates but not wired to a live route) or a stray
+// public /s/… path to the internal Workspace/Docs recovery. Internal
+// shell-route typos keep the existing operator-oriented recovery.
+describe("global not-found recovery", () => {
+  it("tells a warehousing prospect the demo isn't generated yet, not workspace/docs", () => {
+    pathname.mockReturnValue("/third-party-logistics");
+    const html = renderToStaticMarkup(<NotFound />);
+    expect(html).toMatch(/has not been generated yet/i);
+    expect(html).toMatch(/3PL Contract Warehousing/);
+    expect(html).not.toContain("/workspace");
+    expect(html).not.toContain("Browse docs");
+  });
+
+  it("covers every source-registered warehousing archetype, not just one", () => {
+    for (const id of [
+      "third-party-logistics",
+      "ecommerce-fulfilment",
+      "cold-chain-storage",
+      "cross-dock-transload",
+    ]) {
+      pathname.mockReturnValue(`/${id}`);
+      const html = renderToStaticMarkup(<NotFound />);
+      expect(html).toMatch(/has not been generated yet/i);
+      expect(html).not.toContain("/workspace");
+    }
+  });
+
+  it("keeps a stray public /s/… path customer-safe when no nested boundary matched", () => {
+    pathname.mockReturnValue("/s/");
+    const html = renderToStaticMarkup(<NotFound />);
+    expect(html).not.toContain("/workspace");
+    expect(html).not.toContain("Browse docs");
+    expect(html).toContain('href="/"');
+  });
+
+  it("keeps the operator-oriented recovery for an internal shell-route typo", () => {
+    pathname.mockReturnValue("/platfrom/ai/agents");
+    const html = renderToStaticMarkup(<NotFound />);
+    expect(html).toContain("Back to workspace");
+    expect(html).toContain("Browse docs");
+    expect(html).toContain('href="/workspace"');
+  });
+});

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,6 +1,22 @@
-import Link from "next/link";
+"use client";
 
-export default function NotFound() {
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ALL_ARCHETYPES } from "@dpf/storefront-templates";
+
+type Action = { href: string; label: string };
+
+function NotFoundShell({
+  heading,
+  body,
+  primary,
+  secondary,
+}: {
+  heading: string;
+  body: string;
+  primary: Action;
+  secondary?: Action;
+}) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-[var(--dpf-bg)] px-4 py-10">
       <div className="w-full max-w-[34rem] rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] p-6 text-center sm:p-8">
@@ -10,28 +26,83 @@ export default function NotFound() {
         >
           404
         </div>
-        <h1 className="mb-2 text-lg font-semibold text-[var(--dpf-text)]">
-          This page could not be found
-        </h1>
-        <p className="mb-5 text-sm leading-6 text-[var(--dpf-muted)]">
-          The link may be stale, or the route was renamed. Head back to the
-          workspace and try a destination from the left rail.
-        </p>
+        <h1 className="mb-2 text-lg font-semibold text-[var(--dpf-text)]">{heading}</h1>
+        <p className="mb-5 text-sm leading-6 text-[var(--dpf-muted)]">{body}</p>
         <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
           <Link
-            href="/workspace"
+            href={primary.href}
             className="rounded-lg bg-[var(--dpf-accent)] px-5 py-2 text-sm font-medium text-white"
           >
-            Back to workspace
+            {primary.label}
           </Link>
-          <Link
-            href="/docs"
-            className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-5 py-2 text-sm font-medium text-[var(--dpf-text)]"
-          >
-            Browse docs
-          </Link>
+          {secondary && (
+            <Link
+              href={secondary.href}
+              className="rounded-lg border border-[var(--dpf-border)] bg-[var(--dpf-surface-1)] px-5 py-2 text-sm font-medium text-[var(--dpf-text)]"
+            >
+              {secondary.label}
+            </Link>
+          )}
         </div>
       </div>
     </div>
+  );
+}
+
+/**
+ * Global not-found boundary. Only reached when no more specific route-segment
+ * `not-found.tsx` claimed the miss (e.g. `(storefront)/s/[slug]/not-found.tsx`
+ * or `(storefront)/s/not-found.tsx` for the public storefront) — which mainly
+ * means genuinely internal shell routes, PLUS two public cases that have no
+ * matching segment at all to hang a nested boundary off of (BI-B9D54962):
+ *
+ * 1. A source-registered archetype (packages/storefront-templates) that has
+ *    not been provisioned into live routing yet, e.g. `/third-party-logistics`
+ *    for Warehousing & Fulfilment — a public prospect hitting this should be
+ *    told the demo isn't generated yet, not sent to the internal workspace.
+ * 2. Any other unrecognized top-level path under the public `/s/…` prefix
+ *    that somehow reaches here rather than a nested boundary.
+ *
+ * Everything else keeps the existing operator-oriented recovery — those are
+ * internal Workspace/Docs/Platform/Admin routes where "back to workspace" is
+ * the correct fallback for a signed-in operator who mistyped a URL.
+ */
+export default function NotFound() {
+  const pathname = usePathname() ?? "";
+  const segments = pathname.split("/").filter(Boolean);
+  const firstSegment = segments[0] ?? "";
+
+  const unprovisionedArchetype =
+    segments.length === 1
+      ? ALL_ARCHETYPES.find((a) => a.archetypeId === firstSegment)
+      : undefined;
+
+  if (unprovisionedArchetype) {
+    return (
+      <NotFoundShell
+        heading="This demo has not been generated yet"
+        body={`The ${unprovisionedArchetype.name} demo is registered but has not been provisioned into a live storefront route yet. Check back soon, or browse the demos that are live today.`}
+        primary={{ href: "/", label: "Browse live demos" }}
+      />
+    );
+  }
+
+  if (firstSegment === "s") {
+    return (
+      <NotFoundShell
+        heading="We couldn't find that page"
+        body="The link may be out of date, expired, or mistyped."
+        primary={{ href: "/", label: "Go to homepage" }}
+      />
+    );
+  }
+
+  return (
+    <NotFoundShell
+      heading="This page could not be found"
+      body="The link may be stale, or the route was renamed. Head back to the workspace and try a destination from the left rail."
+      primary={{ href: "/workspace", label: "Back to workspace" }}
+      secondary={{ href: "/docs", label: "Browse docs" }}
+    />
   );
 }


### PR DESCRIPTION
## Summary

BI-B9D54962's live audit (2026-07-22) found that customer-facing storefront failures fall into the internal operator-oriented 404 (`Back to workspace` / `Browse docs`). The slug-scoped case (`s/[slug]/not-found.tsx`, unknown storefront / bad item / bad booking / invalid checkout ref) was already fixed by a prior BI (#3396). This PR closes the two remaining gaps the audit evidenced:

1. **Token-addressed public routes** — `/s/quote/[token]`, `/s/pay/[token]`, `/s/approve/[token]`, `/s/expense-approve/[token]` sit as *siblings* of `s/[slug]`, not descendants, so `s/[slug]/not-found.tsx` never catches their `notFound()` calls; they fell through to the global operator 404. Adds `apps/web/app/(storefront)/s/not-found.tsx`: explains a bad/expired quote, payment, approval, or expense-approval link in customer language, links only to home, never to Workspace/Docs.
2. **Unprovisioned archetype demos** — archetypes registered in `packages/storefront-templates` (e.g. the Warehousing & Fulfilment addendum: `third-party-logistics`, `ecommerce-fulfilment`, `cold-chain-storage`, `cross-dock-transload`) but not wired to a live route hit the fully-unmatched global 404, with no route segment to hang a nested boundary off. `apps/web/app/not-found.tsx` now checks the requested path against `ALL_ARCHETYPES` and says the demo hasn't been generated yet instead of the generic operator message. Internal shell-route typos keep the existing Workspace/Docs recovery unchanged.

Also adds explicitly-named test coverage on the existing `s/[slug]/not-found.tsx` for the acceptance-listed scenarios (unknown storefront, bad item, bad booking route, invalid checkout ref) that were previously only covered generically.

Does **not** touch `/portal/sign-up` — that fix is owned by a separate BI per the task guardrails.

## Verification

This worktree's `node_modules` never finished linking workspace packages in this session (`@dpf/storefront-templates` wasn't yet symlinked into `apps/web/node_modules`, and the `next` binary was unresolved), so `vitest`/`tsc` could not be run locally. `DPF_SKIP_TYPECHECK=1` was used to get past the pre-commit gate for this environmental reason only — the code was manually reviewed against the existing shipped sibling pattern (`s/[slug]/not-found.tsx`: same `"use client"` + `usePathname()` technique, already proven in production). CI's Typecheck/Unit gates are the source of truth pending that; auto-merge is enabled so the PR only lands once they're green.

## Test plan

- [ ] CI Typecheck passes
- [ ] CI Unit tests pass, including new:
  - `apps/web/app/(storefront)/s/not-found.test.tsx` (bad quote/payment/approval/expense-approval tokens)
  - `apps/web/app/not-found.test.tsx` (unprovisioned archetype demo, stray `/s/…`, internal shell-route typo)
  - added cases in `apps/web/app/(storefront)/s/[slug]/not-found.test.tsx` (unknown storefront, bad item, bad booking route, invalid checkout ref)

🤖 Generated with [Claude Code](https://claude.com/claude-code)