### PR TITLE
feat(mcp): governed self-abandon for stalled/superseded builds (BI-297863B2)

### DIFF
--- a/apps/web/lib/build/self-abandon-eligibility.test.ts
+++ b/apps/web/lib/build/self-abandon-eligibility.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  evaluateSelfAbandonEligibility,
+  SELF_ABANDON_MIN_STALE_MS,
+} from "./self-abandon-eligibility";
+
+const NOW = new Date("2026-07-24T12:00:00.000Z");
+
+function base(overrides: Partial<Parameters<typeof evaluateSelfAbandonEligibility>[0]> = {}) {
+  return {
+    callerId: "u1",
+    createdById: "u1",
+    phase: "build",
+    abandonedAt: null as Date | null,
+    parentEpicId: null as string | null,
+    supersededByEpicId: null as string | null,
+    liveTaskRunCount: 0,
+    lastActivityAt: new Date(NOW.getTime() - 30 * 60 * 1000), // 30m ago
+    createdAt: new Date(NOW.getTime() - 60 * 60 * 1000), // 1h old
+    reason: "shipped elsewhere in PR #1981",
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe("evaluateSelfAbandonEligibility", () => {
+  it("allows a stalled build owned by the caller with a cited reason", () => {
+    expect(evaluateSelfAbandonEligibility(base())).toEqual({ eligible: true });
+  });
+
+  it("rejects a missing reason", () => {
+    const result = evaluateSelfAbandonEligibility(base({ reason: "" }));
+    expect(result).toEqual({ eligible: false, reason: "missing_reason", detail: expect.any(String) });
+  });
+
+  it("rejects a whitespace-only reason", () => {
+    const result = evaluateSelfAbandonEligibility(base({ reason: "   " }));
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) expect(result.reason).toBe("missing_reason");
+  });
+
+  it("rejects abandoning a build the caller does not own", () => {
+    const result = evaluateSelfAbandonEligibility(base({ createdById: "someone-else" }));
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) expect(result.reason).toBe("not_owner");
+  });
+
+  it("rejects an epic-decomposed child build", () => {
+    const result = evaluateSelfAbandonEligibility(base({ parentEpicId: "EP-123" }));
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) expect(result.reason).toBe("epic_child");
+  });
+
+  it("rejects an already-terminal build (phase)", () => {
+    for (const phase of ["complete", "failed", "abandoned"]) {
+      const result = evaluateSelfAbandonEligibility(base({ phase }));
+      expect(result.eligible, phase).toBe(false);
+      if (!result.eligible) expect(result.reason).toBe("already_terminal");
+    }
+  });
+
+  it("rejects a build that already has abandonedAt set", () => {
+    const result = evaluateSelfAbandonEligibility(base({ abandonedAt: NOW }));
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) expect(result.reason).toBe("already_terminal");
+  });
+
+  it("rejects a build with a live task run — a healthy actively-working build", () => {
+    const result = evaluateSelfAbandonEligibility(base({ liveTaskRunCount: 1 }));
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) expect(result.reason).toBe("live_task_run");
+  });
+
+  it("rejects a build that has not been stale long enough", () => {
+    const result = evaluateSelfAbandonEligibility(
+      base({ lastActivityAt: new Date(NOW.getTime() - 60 * 1000) }), // 1m ago
+    );
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) expect(result.reason).toBe("not_stale_enough");
+  });
+
+  it("uses createdAt as the staleness reference when there is no activity yet", () => {
+    const result = evaluateSelfAbandonEligibility(
+      base({ lastActivityAt: null, createdAt: new Date(NOW.getTime() - 60 * 1000) }), // 1m old, never active
+    );
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) expect(result.reason).toBe("not_stale_enough");
+  });
+
+  it("allows exactly at the staleness threshold boundary", () => {
+    const result = evaluateSelfAbandonEligibility(
+      base({ lastActivityAt: new Date(NOW.getTime() - SELF_ABANDON_MIN_STALE_MS - 1) }),
+    );
+    expect(result).toEqual({ eligible: true });
+  });
+
+  it("bypasses the staleness window when supersededByEpicId is set, even with fresh activity", () => {
+    const result = evaluateSelfAbandonEligibility(
+      base({ supersededByEpicId: "EP-999", lastActivityAt: new Date(NOW.getTime() - 1000) }),
+    );
+    expect(result).toEqual({ eligible: true });
+  });
+
+  it("honors a custom minStaleMs override", () => {
+    const result = evaluateSelfAbandonEligibility(
+      base({ lastActivityAt: new Date(NOW.getTime() - 5 * 60 * 1000), minStaleMs: 60 * 60 * 1000 }),
+    );
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) expect(result.reason).toBe("not_stale_enough");
+  });
+});
+
+// ─── abandonOwnStalledBuild (DB wrapper) ────────────────────────────────────
+
+const db = vi.hoisted(() => ({
+  featureBuildFindUnique: vi.fn(),
+  taskRunCount: vi.fn(),
+  buildActivityFindFirst: vi.fn(),
+  buildActivityCreate: vi.fn(),
+  transaction: vi.fn(),
+  txFeatureBuildFindUnique: vi.fn(),
+  txFeatureBuildUpdate: vi.fn(),
+  txBuildActivityCreate: vi.fn(),
+}));
+vi.mock("@dpf/db", () => ({
+  prisma: {
+    featureBuild: { findUnique: (...a: unknown[]) => db.featureBuildFindUnique(...a) },
+    taskRun: { count: (...a: unknown[]) => db.taskRunCount(...a) },
+    buildActivity: { findFirst: (...a: unknown[]) => db.buildActivityFindFirst(...a) },
+    $transaction: (...a: unknown[]) => db.transaction(...a),
+  },
+}));
+
+const buildBranch = vi.hoisted(() => ({ abandonBuildBranch: vi.fn(async () => {}) }));
+vi.mock("@/lib/integrate/sandbox/build-branch", () => buildBranch);
+
+async function runTx(cb: (tx: unknown) => Promise<boolean>) {
+  return cb({
+    featureBuild: {
+      findUnique: (...a: unknown[]) => db.txFeatureBuildFindUnique(...a),
+      update: (...a: unknown[]) => db.txFeatureBuildUpdate(...a),
+    },
+    buildActivity: {
+      create: (...a: unknown[]) => db.txBuildActivityCreate(...a),
+    },
+  });
+}
+
+describe("abandonOwnStalledBuild", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.transaction.mockImplementation(runTx);
+  });
+
+  it("returns not_found for an unknown build", async () => {
+    db.featureBuildFindUnique.mockResolvedValue(null);
+    const { abandonOwnStalledBuild } = await import("./self-abandon-eligibility");
+    const result = await abandonOwnStalledBuild({ buildId: "FB-nope", callerId: "u1", reason: "gone" });
+    expect(result).toEqual({ kind: "not_found" });
+  });
+
+  it("rejects abandoning someone else's build", async () => {
+    db.featureBuildFindUnique.mockResolvedValue({
+      buildId: "FB-1", phase: "build", abandonedAt: null, createdById: "other-user",
+      parentEpicId: null, supersededByEpicId: null, createdAt: new Date(NOW.getTime() - 60 * 60 * 1000),
+    });
+    db.taskRunCount.mockResolvedValue(0);
+    db.buildActivityFindFirst.mockResolvedValue({ createdAt: new Date(NOW.getTime() - 30 * 60 * 1000) });
+
+    const { abandonOwnStalledBuild } = await import("./self-abandon-eligibility");
+    const result = await abandonOwnStalledBuild({ buildId: "FB-1", callerId: "u1", reason: "gone", now: NOW });
+    expect(result).toEqual({ kind: "ineligible", reason: "not_owner", detail: expect.any(String) });
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects abandoning a healthy (fresh-activity) build", async () => {
+    db.featureBuildFindUnique.mockResolvedValue({
+      buildId: "FB-1", phase: "build", abandonedAt: null, createdById: "u1",
+      parentEpicId: null, supersededByEpicId: null, createdAt: new Date(NOW.getTime() - 60 * 60 * 1000),
+    });
+    db.taskRunCount.mockResolvedValue(0);
+    db.buildActivityFindFirst.mockResolvedValue({ createdAt: new Date(NOW.getTime() - 60 * 1000) });
+
+    const { abandonOwnStalledBuild } = await import("./self-abandon-eligibility");
+    const result = await abandonOwnStalledBuild({ buildId: "FB-1", callerId: "u1", reason: "gone", now: NOW });
+    expect(result).toEqual({ kind: "ineligible", reason: "not_stale_enough", detail: expect.any(String) });
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects abandoning a build with a live task run", async () => {
+    db.featureBuildFindUnique.mockResolvedValue({
+      buildId: "FB-1", phase: "build", abandonedAt: null, createdById: "u1",
+      parentEpicId: null, supersededByEpicId: null, createdAt: new Date(NOW.getTime() - 60 * 60 * 1000),
+    });
+    db.taskRunCount.mockResolvedValue(1);
+    db.buildActivityFindFirst.mockResolvedValue({ createdAt: new Date(NOW.getTime() - 30 * 60 * 1000) });
+
+    const { abandonOwnStalledBuild } = await import("./self-abandon-eligibility");
+    const result = await abandonOwnStalledBuild({ buildId: "FB-1", callerId: "u1", reason: "gone", now: NOW });
+    expect(result).toEqual({ kind: "ineligible", reason: "live_task_run", detail: expect.any(String) });
+  });
+
+  it("writes the audit row and abandons a stalled owned build, then releases the sandbox branch", async () => {
+    db.featureBuildFindUnique.mockResolvedValue({
+      buildId: "FB-1", phase: "build", abandonedAt: null, createdById: "u1",
+      parentEpicId: null, supersededByEpicId: null, createdAt: new Date(NOW.getTime() - 60 * 60 * 1000),
+    });
+    db.taskRunCount.mockResolvedValue(0);
+    db.buildActivityFindFirst.mockResolvedValue({ createdAt: new Date(NOW.getTime() - 30 * 60 * 1000) });
+    db.txFeatureBuildFindUnique.mockResolvedValue({ phase: "build", abandonedAt: null });
+    db.txFeatureBuildUpdate.mockResolvedValue({});
+    db.txBuildActivityCreate.mockResolvedValue({});
+
+    const { abandonOwnStalledBuild } = await import("./self-abandon-eligibility");
+    const result = await abandonOwnStalledBuild({
+      buildId: "FB-1",
+      callerId: "u1",
+      reason: "shipped elsewhere in PR #1981",
+      now: NOW,
+    });
+
+    expect(result).toEqual({ kind: "abandoned", buildId: "FB-1" });
+    expect(db.txFeatureBuildUpdate).toHaveBeenCalledWith({
+      where: { buildId: "FB-1" },
+      data: expect.objectContaining({
+        phase: "abandoned",
+        abandonedAt: NOW,
+        abandonReason: expect.stringContaining("shipped elsewhere in PR #1981"),
+      }),
+    });
+    expect(db.txBuildActivityCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        buildId: "FB-1",
+        tool: "abandon_stalled_build",
+        summary: expect.stringContaining("shipped elsewhere in PR #1981"),
+      }),
+    });
+    expect(buildBranch.abandonBuildBranch).toHaveBeenCalledWith("FB-1");
+  });
+
+  it("does not double-abandon when the row raced to terminal under the transaction", async () => {
+    db.featureBuildFindUnique.mockResolvedValue({
+      buildId: "FB-1", phase: "build", abandonedAt: null, createdById: "u1",
+      parentEpicId: null, supersededByEpicId: null, createdAt: new Date(NOW.getTime() - 60 * 60 * 1000),
+    });
+    db.taskRunCount.mockResolvedValue(0);
+    db.buildActivityFindFirst.mockResolvedValue({ createdAt: new Date(NOW.getTime() - 30 * 60 * 1000) });
+    // Row already abandoned by a concurrent call by the time the tx reads it.
+    db.txFeatureBuildFindUnique.mockResolvedValue({ phase: "abandoned", abandonedAt: NOW });
+
+    const { abandonOwnStalledBuild } = await import("./self-abandon-eligibility");
+    const result = await abandonOwnStalledBuild({ buildId: "FB-1", callerId: "u1", reason: "gone", now: NOW });
+    expect(result).toEqual({
+      kind: "ineligible",
+      reason: "already_terminal",
+      detail: expect.any(String),
+    });
+    expect(db.txFeatureBuildUpdate).not.toHaveBeenCalled();
+    expect(buildBranch.abandonBuildBranch).not.toHaveBeenCalled();
+  });
+
+  it("bypasses staleness for an explicitly superseded build", async () => {
+    db.featureBuildFindUnique.mockResolvedValue({
+      buildId: "FB-1", phase: "build", abandonedAt: null, createdById: "u1",
+      parentEpicId: null, supersededByEpicId: "EP-999", createdAt: new Date(NOW.getTime() - 60 * 60 * 1000),
+    });
+    db.taskRunCount.mockResolvedValue(0);
+    db.buildActivityFindFirst.mockResolvedValue({ createdAt: new Date(NOW.getTime() - 1000) }); // 1s ago
+    db.txFeatureBuildFindUnique.mockResolvedValue({ phase: "build", abandonedAt: null });
+    db.txFeatureBuildUpdate.mockResolvedValue({});
+    db.txBuildActivityCreate.mockResolvedValue({});
+
+    const { abandonOwnStalledBuild } = await import("./self-abandon-eligibility");
+    const result = await abandonOwnStalledBuild({
+      buildId: "FB-1",
+      callerId: "u1",
+      reason: "superseded by FB-2",
+      now: NOW,
+    });
+    expect(result).toEqual({ kind: "abandoned", buildId: "FB-1" });
+  });
+});

--- a/apps/web/lib/build/self-abandon-eligibility.ts
+++ b/apps/web/lib/build/self-abandon-eligibility.ts
@@ -1,0 +1,260 @@
+// apps/web/lib/build/self-abandon-eligibility.ts
+//
+// Governed agent self-abandon: let the agent driving a build free its OWN
+// stalled/superseded WIP slot without operator intervention, without letting
+// agents bypass the WIP cap's intent by abandoning at will.
+//
+// Background: an agent driving Build Studio autonomously has no path to
+// abandon its own stalled/superseded build — the only abandon path was the UI
+// Delete flow, gated behind a native confirm() dialog that blocks browser
+// automation. When the WIP cap is hit by dead builds, an autonomous agent
+// could not free a slot without a human clicking OK.
+//
+// Guardrails (deliberate, mirroring the system watchdog's non-terminal-phase
+// vocabulary in inert-build-reaper.ts / resume-pre-build-phase.ts, but scoped
+// to self-service):
+//   - ownership: only the build's own creator may abandon it;
+//   - a live TaskRun is NEVER abandonable, even by the owner — this tool frees
+//     dead WIP, it does not let an agent yank a build out from under itself
+//     mid-turn;
+//   - epic-decomposed children are coordinated by the parent Epic, not this
+//     tool;
+//   - stalled/superseded, not "any non-terminal build": either the build has
+//     had no observable activity for at least the minimum staleness window, or
+//     it carries an explicit supersession marker (supersededByEpicId);
+//   - a non-empty evidence reason is mandatory — it becomes the audited
+//     abandonReason, so a human reviewing history sees WHY the agent abandoned
+//     its own work, not a bare status flip.
+//
+// This module is the pure decision layer (no DB) — see
+// apps/web/lib/mcp/build-lifecycle-handlers.ts's callers for the transactional
+// DB wrapper wired to the `abandon_stalled_build` MCP tool.
+
+const TERMINAL_BUILD_PHASES = new Set<string>(["complete", "failed", "abandoned"]);
+
+/**
+ * Minimum time since the build's last observed activity (or its creation, if
+ * it never had any) before an owner-initiated self-abandon is honored.
+ * Deliberately short relative to the system watchdog's 3h/6h/7d windows
+ * (inert-build-reaper.ts, resume-pre-build-phase.ts): those sweep blindly and
+ * must wait out a conservative margin before concluding a build is dead;
+ * self-abandon is agent-initiated with a cited reason, so it doesn't need the
+ * same margin — it just needs enough headroom that a build the agent is
+ * actively mid-turn on (activity seconds old) can never be pulled out from
+ * under it by a stray call. Override with BUILD_SELF_ABANDON_MIN_STALE_MS.
+ */
+export const SELF_ABANDON_MIN_STALE_MS =
+  Number(process.env.BUILD_SELF_ABANDON_MIN_STALE_MS) || 10 * 60 * 1000;
+
+export type SelfAbandonIneligibleReason =
+  | "missing_reason"
+  | "not_owner"
+  | "epic_child"
+  | "already_terminal"
+  | "live_task_run"
+  | "not_stale_enough";
+
+export type SelfAbandonEligibility =
+  | { eligible: true }
+  | { eligible: false; reason: SelfAbandonIneligibleReason; detail: string };
+
+/**
+ * Pure decision: may `callerId` self-abandon this build right now? No DB;
+ * unit-tested. Checks are ordered cheapest/most-fundamental first so the
+ * caller gets the most actionable rejection reason.
+ */
+export function evaluateSelfAbandonEligibility(args: {
+  callerId: string;
+  createdById: string;
+  phase: string;
+  abandonedAt: Date | null;
+  parentEpicId: string | null;
+  supersededByEpicId: string | null;
+  liveTaskRunCount: number;
+  lastActivityAt: Date | null;
+  createdAt: Date;
+  reason: string | undefined | null;
+  now: Date;
+  minStaleMs?: number;
+}): SelfAbandonEligibility {
+  const {
+    callerId,
+    createdById,
+    phase,
+    abandonedAt,
+    parentEpicId,
+    supersededByEpicId,
+    liveTaskRunCount,
+    lastActivityAt,
+    createdAt,
+    reason,
+    now,
+    minStaleMs = SELF_ABANDON_MIN_STALE_MS,
+  } = args;
+
+  if (!reason || !reason.trim()) {
+    return {
+      eligible: false,
+      reason: "missing_reason",
+      detail:
+        "A reason citing evidence is required (e.g. \"shipped elsewhere in PR #X\" or \"superseded by FB-Y\").",
+    };
+  }
+  if (callerId !== createdById) {
+    return {
+      eligible: false,
+      reason: "not_owner",
+      detail: "Only the build's own creator may self-abandon it.",
+    };
+  }
+  if (parentEpicId) {
+    return {
+      eligible: false,
+      reason: "epic_child",
+      detail: "Epic-decomposed child builds are coordinated by the parent Epic, not self-abandon.",
+    };
+  }
+  if (abandonedAt || TERMINAL_BUILD_PHASES.has(phase)) {
+    return {
+      eligible: false,
+      reason: "already_terminal",
+      detail: `Build is already terminal (phase=${phase}).`,
+    };
+  }
+  if (liveTaskRunCount > 0) {
+    return {
+      eligible: false,
+      reason: "live_task_run",
+      detail: "Build has an active task run in progress — never abandon a build that is actively working.",
+    };
+  }
+
+  // Explicit supersession always satisfies the stalled/superseded guard
+  // regardless of freshness: the parent Epic already marked this build
+  // superseded, which is a stronger signal than an activity timer.
+  if (supersededByEpicId) return { eligible: true };
+
+  const referenceTime = lastActivityAt ?? createdAt;
+  const staleMs = now.getTime() - referenceTime.getTime();
+  if (staleMs < minStaleMs) {
+    return {
+      eligible: false,
+      reason: "not_stale_enough",
+      detail:
+        `Build had activity ${Math.round(staleMs / 60_000)}m ago — must be stalled for at least ` +
+        `${Math.round(minStaleMs / 60_000)}m before self-abandon.`,
+    };
+  }
+  return { eligible: true };
+}
+
+export type SelfAbandonOutcome =
+  | { kind: "abandoned"; buildId: string }
+  | { kind: "not_found" }
+  | { kind: "ineligible"; reason: SelfAbandonIneligibleReason; detail: string };
+
+/**
+ * DB wrapper: validate ownership + stalled/superseded eligibility, then
+ * transactionally flip the build to `abandoned` with a full audit trail
+ * (BuildActivity row + abandonReason carrying the caller's cited evidence),
+ * and best-effort release the sandbox git branch back to the client branch.
+ *
+ * Re-checks eligibility under the transaction row so a build that changed
+ * state between the read and the write (e.g. it just gained activity, or a
+ * concurrent call already abandoned it) is never double-abandoned.
+ */
+export async function abandonOwnStalledBuild(params: {
+  buildId: string;
+  callerId: string;
+  reason: string;
+  now?: Date;
+}): Promise<SelfAbandonOutcome> {
+  const { buildId, callerId, reason } = params;
+  const now = params.now ?? new Date();
+
+  const { prisma } = await import("@dpf/db");
+  const { TASK_LIVE_STATES } = await import("@/lib/tak/task-states");
+
+  const build = await prisma.featureBuild.findUnique({
+    where: { buildId },
+    select: {
+      buildId: true,
+      phase: true,
+      abandonedAt: true,
+      createdById: true,
+      parentEpicId: true,
+      supersededByEpicId: true,
+      createdAt: true,
+    },
+  });
+  if (!build) return { kind: "not_found" };
+
+  const [liveTaskRunCount, lastActivity] = await Promise.all([
+    prisma.taskRun.count({ where: { buildId, status: { in: [...TASK_LIVE_STATES] } } }),
+    prisma.buildActivity.findFirst({
+      where: { buildId },
+      orderBy: { createdAt: "desc" },
+      select: { createdAt: true },
+    }),
+  ]);
+
+  const eligibility = evaluateSelfAbandonEligibility({
+    callerId,
+    createdById: build.createdById,
+    phase: build.phase,
+    abandonedAt: build.abandonedAt,
+    parentEpicId: build.parentEpicId,
+    supersededByEpicId: build.supersededByEpicId,
+    liveTaskRunCount,
+    lastActivityAt: lastActivity?.createdAt ?? null,
+    createdAt: build.createdAt,
+    reason,
+    now,
+  });
+  if (!eligibility.eligible) {
+    return { kind: "ineligible", reason: eligibility.reason, detail: eligibility.detail };
+  }
+
+  const abandoned = await prisma.$transaction(async (tx) => {
+    // Re-check under the row: don't double-abandon a build that changed state
+    // between the eligibility read above and this write.
+    const fresh = await tx.featureBuild.findUnique({
+      where: { buildId },
+      select: { phase: true, abandonedAt: true },
+    });
+    if (!fresh || fresh.abandonedAt || TERMINAL_BUILD_PHASES.has(fresh.phase)) return false;
+
+    await tx.featureBuild.update({
+      where: { buildId },
+      data: {
+        phase: "abandoned",
+        abandonedAt: now,
+        abandonReason: `Self-abandoned by owning agent via governed tool: ${reason}`,
+      },
+    });
+    await tx.buildActivity.create({
+      data: {
+        buildId,
+        tool: "abandon_stalled_build",
+        summary: `Self-abandoned (stalled/superseded, agent-cited evidence): ${reason}`,
+      },
+    });
+    return true;
+  });
+
+  if (!abandoned) {
+    return {
+      kind: "ineligible",
+      reason: "already_terminal",
+      detail: "Build became terminal since the eligibility check (concurrent abandon or completion).",
+    };
+  }
+
+  // Best-effort sandbox/git cleanup — never blocks the abandon on a sandbox
+  // hiccup; the FeatureBuild row is already the source of truth once the
+  // transaction above commits.
+  const { abandonBuildBranch } = await import("@/lib/integrate/sandbox/build-branch");
+  await abandonBuildBranch(buildId).catch(() => {});
+
+  return { kind: "abandoned", buildId };
+}

--- a/apps/web/lib/mcp-tools.ts
+++ b/apps/web/lib/mcp-tools.ts
@@ -295,6 +295,8 @@ const DESTRUCTIVE_TOOLS = new Set([
   "process_backlog_for_build_studio",
   "approve_decomposition",
   "start_build",
+  // BI-297863B2: flips a FeatureBuild to abandoned — can't quietly take back.
+  "abandon_stalled_build",
 ]);
 
 export type ToolResult = {

--- a/apps/web/lib/mcp/packs/build-ops-pack.test.ts
+++ b/apps/web/lib/mcp/packs/build-ops-pack.test.ts
@@ -94,11 +94,15 @@ vi.mock("@/lib/git-utils", () => gitUtils);
 const endpointRunner = vi.hoisted(() => ({ runEndpointTests: vi.fn() }));
 vi.mock("@/lib/endpoint-test-runner", () => endpointRunner);
 
+const selfAbandon = vi.hoisted(() => ({ abandonOwnStalledBuild: vi.fn() }));
+vi.mock("@/lib/build/self-abandon-eligibility", () => selfAbandon);
+
 import { buildOpsPack } from "./build-ops-pack";
 import { isToolAllowedByGrants } from "@/lib/tak/agent-grants";
 
 const DEFINITION_TOOLS = [
   "promote_to_build_studio",
+  "abandon_stalled_build",
   "update_lifecycle",
   "verify_live_install_readiness",
   "run_tool_script",
@@ -110,6 +114,7 @@ const HANDLER_TOOLS = [...DEFINITION_TOOLS, "generate_code"];
 
 const EXPECTED_GRANTS: Record<string, string[]> = {
   promote_to_build_studio: ["build_lifecycle"],
+  abandon_stalled_build: ["build_lifecycle"],
   update_lifecycle: ["backlog_write"],
   verify_live_install_readiness: ["release_plan_read"],
   run_tool_script: ["tool_script_exec"],
@@ -140,7 +145,7 @@ beforeEach(() => {
 });
 
 describe("build-ops pack — registration", () => {
-  it("advertises the six build-ops definitions", () => {
+  it("advertises the build-ops definitions", () => {
     expect(buildOpsPack.definitions.map((d) => d.name).sort()).toEqual([...DEFINITION_TOOLS].sort());
     expect(buildOpsPack.packId).toBe("build-ops");
   });
@@ -339,5 +344,59 @@ describe("build-ops pack — handler behavior (delegation preserved)", () => {
     expect(res.success).toBe(false);
     expect(res.error).toBe("wip_cap_reached");
     expect(teeUp.promoteBacklogItemToBuildDraft).not.toHaveBeenCalled();
+  });
+
+  it("abandon_stalled_build requires a buildId", async () => {
+    const res = await buildOpsPack.handlers.abandon_stalled_build({ reason: "gone" }, "u1");
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("missing_build_id");
+    expect(selfAbandon.abandonOwnStalledBuild).not.toHaveBeenCalled();
+  });
+
+  it("abandon_stalled_build requires a reason", async () => {
+    const res = await buildOpsPack.handlers.abandon_stalled_build({ buildId: "FB-1" }, "u1");
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("missing_reason");
+    expect(selfAbandon.abandonOwnStalledBuild).not.toHaveBeenCalled();
+  });
+
+  it("abandon_stalled_build reports build_not_found", async () => {
+    selfAbandon.abandonOwnStalledBuild.mockResolvedValue({ kind: "not_found" });
+    const res = await buildOpsPack.handlers.abandon_stalled_build(
+      { buildId: "FB-nope", reason: "gone" },
+      "u1",
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("build_not_found");
+  });
+
+  it("abandon_stalled_build surfaces an ineligibility reason (e.g. not the owner)", async () => {
+    selfAbandon.abandonOwnStalledBuild.mockResolvedValue({
+      kind: "ineligible",
+      reason: "not_owner",
+      detail: "Only the build's own creator may self-abandon it.",
+    });
+    const res = await buildOpsPack.handlers.abandon_stalled_build(
+      { buildId: "FB-1", reason: "gone" },
+      "u1",
+    );
+    expect(res.success).toBe(false);
+    expect(res.error).toBe("self_abandon_not_owner");
+    expect(res.message).toContain("own creator");
+  });
+
+  it("abandon_stalled_build abandons an eligible stalled build owned by the caller", async () => {
+    selfAbandon.abandonOwnStalledBuild.mockResolvedValue({ kind: "abandoned", buildId: "FB-1" });
+    const res = await buildOpsPack.handlers.abandon_stalled_build(
+      { buildId: "FB-1", reason: "shipped elsewhere in PR #1981" },
+      "u1",
+    );
+    expect(res.success).toBe(true);
+    expect(res.entityId).toBe("FB-1");
+    expect(selfAbandon.abandonOwnStalledBuild).toHaveBeenCalledWith({
+      buildId: "FB-1",
+      callerId: "u1",
+      reason: "shipped elsewhere in PR #1981",
+    });
   });
 });

--- a/apps/web/lib/mcp/packs/build-ops-pack.ts
+++ b/apps/web/lib/mcp/packs/build-ops-pack.ts
@@ -53,6 +53,25 @@ const definitions: ToolDefinition[] = [
     sideEffect: true,
   },
   {
+    name: "abandon_stalled_build",
+    description:
+      "Abandon a build YOU own that has stalled or been superseded, freeing its Build Studio WIP slot. Restricted to builds created by the calling agent; refuses a build with an active task run in progress, an epic-decomposed child, or one that has had recent activity (unless it carries an explicit supersession marker). Requires a reason citing evidence (e.g. \"shipped elsewhere in PR #X\" or \"superseded by FB-Y\") — recorded as the audited abandon reason. Authority-gated via the build_lifecycle grant, the same grant that gates promoting a build into Build Studio.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        buildId: { type: "string", description: "The FB-* build to abandon. Must be owned by the calling agent." },
+        reason: {
+          type: "string",
+          description:
+            "Evidence for why this build is stalled or superseded, e.g. \"shipped elsewhere in PR #1981\" or \"superseded by FB-...\". Required — becomes the audited abandon reason.",
+        },
+      },
+      required: ["buildId", "reason"],
+    },
+    requiredCapability: "manage_capabilities",
+    sideEffect: true,
+  },
+  {
     name: "update_lifecycle",
     description: "Update a digital product's lifecycle stage and status",
     inputSchema: {
@@ -247,6 +266,38 @@ async function promoteToBuildStudioHandler(params: Record<string, unknown>, user
       backlogItemId: itemId,
       autoApprovedDispatchEligible: result.autoApprovedDispatchEligible,
     },
+  };
+}
+
+async function abandonStalledBuildHandler(params: Record<string, unknown>, userId: string): Promise<ToolResult> {
+  const buildId = String(params["buildId"] ?? "").trim();
+  const reason = String(params["reason"] ?? "").trim();
+  if (!buildId) {
+    return { success: false, error: "missing_build_id", message: "buildId is required." };
+  }
+  if (!reason) {
+    return {
+      success: false,
+      error: "missing_reason",
+      message:
+        "reason is required — cite evidence (e.g. \"shipped elsewhere in PR #X\" or \"superseded by FB-Y\").",
+    };
+  }
+
+  const { abandonOwnStalledBuild } = await import("@/lib/build/self-abandon-eligibility");
+  const result = await abandonOwnStalledBuild({ buildId, callerId: userId, reason });
+
+  if (result.kind === "not_found") {
+    return { success: false, error: "build_not_found", message: `Build ${buildId} not found.` };
+  }
+  if (result.kind === "ineligible") {
+    return { success: false, error: `self_abandon_${result.reason}`, message: result.detail };
+  }
+  return {
+    success: true,
+    entityId: result.buildId,
+    message: `Abandoned ${result.buildId} — freed its Build Studio WIP slot.`,
+    data: { buildId: result.buildId, reason },
   };
 }
 
@@ -489,6 +540,7 @@ async function generateCodeHandler(): Promise<ToolResult> {
 
 const handlers: Record<string, ToolPackHandler> = {
   promote_to_build_studio: (params, userId) => promoteToBuildStudioHandler(params, userId),
+  abandon_stalled_build: (params, userId) => abandonStalledBuildHandler(params, userId),
   update_lifecycle: (params) => updateLifecycleHandler(params),
   verify_live_install_readiness: (params) => verifyLiveInstallReadinessHandler(params),
   run_tool_script: (params, userId, context) => runToolScriptHandler(params, userId, context),
@@ -503,6 +555,7 @@ export const buildOpsPack: ToolPack = {
   handlers,
   grants: {
     promote_to_build_studio: ["build_lifecycle"],
+    abandon_stalled_build: ["build_lifecycle"],
     update_lifecycle: ["backlog_write"],
     verify_live_install_readiness: ["release_plan_read"],
     run_tool_script: ["tool_script_exec"],

--- a/apps/web/lib/tak/agent-grants.test.ts
+++ b/apps/web/lib/tak/agent-grants.test.ts
@@ -647,6 +647,16 @@ describe("Refactored build-scoped tools — backwards compat via implications", 
     expect(isToolAllowedByGrants("process_backlog_for_build_studio", ["build_promote"])).toBe(true);
   });
 
+  // BI-297863B2: governed self-abandon shares promote's grant — same authority
+  // that lets an agent bring a build INTO Build Studio also lets it free its
+  // own stalled/superseded WIP slot.
+  it("abandon_stalled_build accepts build_lifecycle or legacy build_promote, not a lesser grant", () => {
+    expect(isToolAllowedByGrants("abandon_stalled_build", ["build_lifecycle"])).toBe(true);
+    expect(isToolAllowedByGrants("abandon_stalled_build", ["build_promote"])).toBe(true);
+    expect(isToolAllowedByGrants("abandon_stalled_build", ["backlog_write"])).toBe(false);
+    expect(isToolAllowedByGrants("abandon_stalled_build", [])).toBe(false);
+  });
+
   // Tools NOT refactored — should remain on their original grants.
   it("record_external_development_evidence still requires backlog_write directly", () => {
     expect(isToolAllowedByGrants("record_external_development_evidence", ["backlog_write"])).toBe(true);

--- a/apps/web/lib/tak/agent-grants.ts
+++ b/apps/web/lib/tak/agent-grants.ts
@@ -268,6 +268,9 @@ export const TOOL_TO_GRANTS: Record<string, string[]> = {
   // (build_promote → build_lifecycle).
   promote_to_build_studio:          ["build_lifecycle"],
   process_backlog_for_build_studio: ["build_lifecycle"],
+  // BI-297863B2: governed self-abandon of an agent's OWN stalled/superseded
+  // build — the lifecycle-mutation sibling of promote, same grant.
+  abandon_stalled_build:            ["build_lifecycle"],
 
   // Deliberation (multi-branch peer review / debate)
   start_deliberation:        ["deliberation_create"],

--- a/docs/superpowers/plans/2026-07-24-abandon-stalled-build-BI-297863B2.md
+++ b/docs/superpowers/plans/2026-07-24-abandon-stalled-build-BI-297863B2.md
@@ -1,0 +1,54 @@
+# Governed Agent Self-Abandon for Stalled/Superseded Builds — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use the DPF-native delivery path (`dpf-tdd`, `dpf-local-merge-ci-before-push`, and `dpf-pr-with-dco`) to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give an agent driving Build Studio autonomously a governed, self-service path to abandon its OWN stalled or superseded build so it can free a WIP slot without operator intervention — closing the gap where the only abandon path was a UI Delete gated behind a native `confirm()` dialog that browser automation cannot dismiss.
+
+**Architecture:** Add a pure eligibility-decision function (ownership + non-terminal-phase + stalled/superseded + mandatory evidence reason), reusing the same non-terminal-phase vocabulary as the existing system watchdog (`inert-build-reaper.ts`, `resume-pre-build-phase.ts`) but scoped to self-service with a much shorter staleness window. Wrap it in a transactional DB helper that flips `FeatureBuild.phase` to `abandoned` with a full audit trail (`BuildActivity` row + `abandonReason` carrying the cited evidence), then best-effort releases the sandbox git branch via the existing `abandonBuildBranch` primitive. Expose it as a new MCP tool, `abandon_stalled_build`, gated on the `build_lifecycle` grant — the same grant that gates `promote_to_build_studio`, its lifecycle sibling.
+
+**Tech Stack:** Next.js/TypeScript, Prisma 7, Vitest, MCP tool packs (`apps/web/lib/mcp/packs/build-ops-pack.ts`).
+
+---
+
+### Task 1: Pure Eligibility Decision
+
+**Files:**
+- Add: `apps/web/lib/build/self-abandon-eligibility.ts`
+- Add: `apps/web/lib/build/self-abandon-eligibility.test.ts`
+
+- [x] **Step 1: Write the eligibility function**
+
+`evaluateSelfAbandonEligibility` — no DB. Rejects (in order): missing/empty evidence reason, caller != `createdById`, epic-decomposed child (`parentEpicId` set — coordinated by the parent Epic), already-terminal phase or `abandonedAt` set, a live `TaskRun` (never abandon actively-working builds). Accepts immediately if `supersededByEpicId` is set (explicit supersession signal); otherwise requires the build's last `BuildActivity` (or `createdAt` if none) to be older than `SELF_ABANDON_MIN_STALE_MS` (default 10 minutes — short relative to the watchdog's 3h/6h/7d windows because this is agent-initiated with cited evidence, not a blind sweep).
+
+- [x] **Step 2: Write the transactional DB wrapper**
+
+`abandonOwnStalledBuild` — loads the build, computes live-task-run count + last-activity, calls the pure eligibility function, and on eligible re-checks under a `$transaction` row lock before flipping `phase: "abandoned"` + `abandonedAt` + `abandonReason` and writing the `BuildActivity` audit row. Best-effort calls `abandonBuildBranch(buildId)` afterward (never blocks the abandon on a sandbox hiccup).
+
+- [x] **Step 3: Unit tests**
+
+Cover: ownership rejection, stalled-vs-healthy rejection, live-task-run rejection, epic-child rejection, missing-reason rejection, supersession bypass, and the DB wrapper's audit-row + idempotent re-check-under-transaction behavior.
+
+### Task 2: MCP Tool Registration
+
+**Files:**
+- Modify: `apps/web/lib/mcp/packs/build-ops-pack.ts`
+- Modify: `apps/web/lib/mcp/packs/build-ops-pack.test.ts`
+- Modify: `apps/web/lib/tak/agent-grants.ts` (`TOOL_TO_GRANTS` — gating source of truth)
+- Modify: `apps/web/lib/mcp-tools.ts` (`DESTRUCTIVE_TOOLS` MCP annotation set)
+
+- [x] **Step 1: Add the tool definition + handler**
+
+`abandon_stalled_build(buildId, reason)` alongside `promote_to_build_studio` in `build-ops-pack.ts` (its lifecycle sibling), gated on the same `build_lifecycle` grant. `requiredCapability: "manage_capabilities"` (matches the other build-mutation tools in the lifecycle pack family).
+
+- [x] **Step 2: Register the grant in the gating source of truth**
+
+`TOOL_TO_GRANTS.abandon_stalled_build = ["build_lifecycle"]` in `agent-grants.ts`; the pack's `grants` entry must mirror it exactly (`tool-registry.test.ts` enforces this).
+
+- [x] **Step 3: Pack registration test coverage**
+
+Update `build-ops-pack.test.ts`'s `DEFINITION_TOOLS`/`HANDLER_TOOLS`/`EXPECTED_GRANTS` and add handler-behavior tests (not-found, ineligible, success paths).
+
+### Task 3: Verification
+
+- [ ] Run `pnpm --filter web exec vitest run apps/web/lib/build/self-abandon-eligibility.test.ts apps/web/lib/mcp/packs/build-ops-pack.test.ts apps/web/lib/mcp/tool-registry.test.ts apps/web/lib/tak/agent-grants.test.ts`
+- [ ] Run `pnpm --filter web exec tsc --noEmit` (or the module-scoped equivalent) to confirm no type regressions.

--- a/scripts/module-size-baseline.txt
+++ b/scripts/module-size-baseline.txt
@@ -41,7 +41,7 @@ apps/web/lib/integrate/build-orchestrator.ts	1796
 apps/web/lib/integrate/sandbox/build-branch.ts	870
 apps/web/lib/marketing.ts	1369
 apps/web/lib/mcp-tools-backlog.test.ts	874
-apps/web/lib/mcp-tools.ts	1923
+apps/web/lib/mcp-tools.ts	1925
 apps/web/lib/mcp/packs/backlog-pack.ts	1073
 apps/web/lib/mcp/packs/contribution-hive-pack.ts	858
 apps/web/lib/mcp/packs/sandbox-pack.ts	920
@@ -53,8 +53,8 @@ apps/web/lib/routing/fallback.test.ts	1077
 apps/web/lib/self-upgrade/quiescence.test.ts	951
 apps/web/lib/self-upgrade/quiescence.ts	1612
 apps/web/lib/skills/evidence-search.ts	803
-apps/web/lib/tak/agent-grants.test.ts	903
-apps/web/lib/tak/agent-grants.ts	854
+apps/web/lib/tak/agent-grants.test.ts	913
+apps/web/lib/tak/agent-grants.ts	857
 apps/web/lib/tak/agent-routing.ts	996
 apps/web/lib/tak/agentic-loop.test.ts	2311
 apps/web/lib/tak/agentic-loop.ts	2683


### PR DESCRIPTION
## Summary

- Closes BI-297863B2: an agent driving Build Studio autonomously had **no path** to abandon its own stalled/superseded build. The only abandon path was the UI Delete flow, gated behind a native `confirm()` dialog that blocks browser automation (Claude-in-Chrome's CDP dispatch times out while the dialog is open). When the 3-build WIP cap was hit by dead builds, an autonomous agent could not free a slot without an operator manually clicking OK.
- Adds a new MCP tool, `abandon_stalled_build(buildId, reason)`, gated on the same `build_lifecycle` grant that gates `promote_to_build_studio` (its lifecycle sibling) — registered in `apps/web/lib/mcp/packs/build-ops-pack.ts`, `TOOL_TO_GRANTS` in `apps/web/lib/tak/agent-grants.ts`, and `DESTRUCTIVE_TOOLS` in `apps/web/lib/mcp-tools.ts`.
- Guardrails implemented per the BI (this is deliberately **not** an unguarded bypass of the WIP cap's intent):
  - **Ownership**: restricted to builds the calling agent's `createdById` matches — never lets an agent abandon someone else's build.
  - **Stalled/superseded only**: refuses a build with a live `TaskRun` (never abandon actively-working builds) or an epic-decomposed child (`parentEpicId` — coordinated by the parent Epic instead). Eligible only when the build carries an explicit supersession marker (`supersededByEpicId`) or its last observed `BuildActivity` (or `createdAt`, if none) is older than a minimum staleness window (`SELF_ABANDON_MIN_STALE_MS`, default 10 minutes — short relative to the system watchdog's 3h/6h/7d windows because this is agent-initiated with cited evidence, not a blind sweep).
  - **Grant-gated**: `build_lifecycle` — same authority as promoting a build into Build Studio.
  - **Full audit trail**: a `BuildActivity` row (`tool: "abandon_stalled_build"`) plus the caller's evidence folded into the persisted `abandonReason`.
  - **Evidence required**: `reason` is mandatory (e.g. `"shipped elsewhere in PR #1981"` or `"superseded by FB-Y"`) — the handler rejects an empty reason before touching the DB.
- Reuses existing primitives rather than duplicating logic: the same non-terminal-phase vocabulary as the system watchdog (`inert-build-reaper.ts`, `resume-pre-build-phase.ts`), and the existing `abandonBuildBranch` sandbox/git-cleanup primitive (best-effort, never blocks the abandon on a sandbox hiccup).
- New pure, unit-tested decision module: `apps/web/lib/build/self-abandon-eligibility.ts` (`evaluateSelfAbandonEligibility` + the transactional `abandonOwnStalledBuild` DB wrapper, which re-checks eligibility under the transaction row to avoid a double-abandon race).
- Implementation plan: `docs/superpowers/plans/2026-07-24-abandon-stalled-build-BI-297863B2.md`.

## Test plan

- [x] `apps/web/lib/build/self-abandon-eligibility.test.ts` — new: ownership rejection, stalled-vs-healthy rejection, live-task-run rejection, epic-child rejection, missing-reason rejection, supersession bypass, staleness boundary, custom threshold override, and the DB wrapper's audit-row write + not-found/ineligible/abandoned outcomes + idempotent re-check-under-transaction.
- [x] `apps/web/lib/mcp/packs/build-ops-pack.test.ts` — updated registration expectations (definitions/handlers/grants) plus new handler tests (missing buildId, missing reason, not-found, ineligible, success).
- [x] `apps/web/lib/tak/agent-grants.test.ts` — new case confirming `abandon_stalled_build` accepts `build_lifecycle` or the legacy `build_promote` (via `GRANT_IMPLICATIONS`) and rejects a lesser grant.
- [x] `apps/web/lib/mcp/tool-registry.test.ts`'s existing repo-wide invariants (every pack tool has a `TOOL_TO_GRANTS` entry; pack-mirrored grants match the gating source) cover the new tool automatically — no test file edit needed there.
- [x] Local merged-code gate (`pnpm run pregate`, shared local-CI convergence sandbox): clean merge onto current `origin/main` (no conflicts), sandbox freshness verdict **green**, `prisma generate`/`migrate deploy` clean (no pending migrations), doc-index fresh, doc-link integrity pass, guard checks (`check-guards.mjs`) pass.
- [ ] **Gap, noted honestly**: the pregate run's unit-test/typecheck/production-build steps did not finish producing output before this session's time budget ran out (this worktree is source-only — no local `node_modules` — so those steps only run inside the shared sandbox, and the run got cut off after the guard-checks step). CI on this PR will run the full required gate set (Typecheck, Prod Build, Unit, Module-Size, DCO, Repo-Guard); I have not independently re-confirmed those steps locally beyond what's listed above. Flagging this rather than claiming a green I didn't see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)