### PR TITLE
fix(db): fetch LFS content for eaReferenceModels seed step (BI-98D19DF2)

### DIFF
--- a/.github/workflows/ux-route-sweep.yml
+++ b/.github/workflows/ux-route-sweep.yml
@@ -77,6 +77,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # The seed reads the IT4IT workbook from docs/Reference, and that
+          # workbook is stored in Git LFS. Without LFS, CI gets the pointer
+          # file and the XLSX reader fails before eaReferenceModels can run
+          # (BI-98D19DF2 — "invalid zip data" on a clean runner). Mirrors the
+          # checkout in audit-routing-invariants.yml, which runs the same
+          # full seed and has been green with this flag set.
+          lfs: true
 
       - name: Setup pnpm with cache
         uses: ./.github/actions/setup-pnpm
@@ -87,28 +95,12 @@ jobs:
       - name: Apply migrations
         run: pnpm --filter @dpf/db exec prisma migrate deploy
 
-      # The seed exits 1 if ANY step fails, by design ("surfaced, not swallowed").
-      # `eaReferenceModels` currently fails in a clean CI environment with "invalid
-      # zip data" — a real pre-existing defect (BI-98D19DF2), not something this job
-      # introduced, and one the sweep does not depend on: it needs a portal with a
-      # seeded org, not EA reference models. So tolerate THAT step specifically and
-      # fail on anything else, rather than blanket continue-on-error which would
-      # hide a genuinely broken seed.
+      # The seed exits 1 if ANY step fails, by design ("surfaced, not
+      # swallowed"). BI-98D19DF2's interim eaReferenceModels tolerance
+      # carve-out (PR #3445) is removed now that `lfs: true` above fixes the
+      # root cause — a full, unmodified failure is a real signal again.
       - name: Seed the fixture organisation
-        run: |
-          set +e
-          pnpm --filter @dpf/db seed 2>&1 | tee /tmp/seed.log
-          status=${PIPESTATUS[0]}
-          set -e
-          if [ "$status" -eq 0 ]; then exit 0; fi
-          failed=$(grep -oE '^  - [a-zA-Z]+:' /tmp/seed.log | sed 's/^  - //; s/:$//' | sort -u)
-          echo "Seed reported failed step(s): ${failed:-<none parsed>}"
-          if [ "$failed" = "eaReferenceModels" ]; then
-            echo "::warning::Seed completed except eaReferenceModels (known: invalid zip data). Continuing — the sweep does not use EA reference models."
-            exit 0
-          fi
-          echo "::error::Seed failed on step(s) beyond the known eaReferenceModels issue."
-          exit "$status"
+        run: pnpm --filter @dpf/db seed
 
       # The seed alone leaves isFirstRun() true, so every authenticated surface
       # redirects to /setup and the sweep measures nothing (proved: 208/226 routes).

--- a/packages/db/src/seed-ea-reference-models.test.ts
+++ b/packages/db/src/seed-ea-reference-models.test.ts
@@ -56,7 +56,7 @@ vi.mock("./client.js", () => ({
     eaAssessmentScope: { upsert: vi.fn() },
     eaReferenceModel: { upsert: vi.fn() },
     eaReferenceModelArtifact: { upsert: vi.fn() },
-    eaReferenceModelElement: { upsert: vi.fn() },
+    eaReferenceModelElement: { upsert: vi.fn(), count: vi.fn() },
   },
 }));
 
@@ -88,7 +88,7 @@ const mockPrisma = prisma as unknown as {
   eaAssessmentScope: { upsert: ReturnType<typeof vi.fn> };
   eaReferenceModel: { upsert: ReturnType<typeof vi.fn> };
   eaReferenceModelArtifact: { upsert: ReturnType<typeof vi.fn> };
-  eaReferenceModelElement: { upsert: ReturnType<typeof vi.fn> };
+  eaReferenceModelElement: { upsert: ReturnType<typeof vi.fn>; count: ReturnType<typeof vi.fn> };
 };
 
 beforeEach(() => {
@@ -105,6 +105,11 @@ beforeEach(() => {
   mockPrisma.eaReferenceModelElement.upsert.mockImplementation(async (args: { where: { modelId_slug: { slug: string } } }) => ({
     id: `el-${args.where.modelId_slug.slug}`,
   }));
+  // Row-count assertion in seedEaReferenceModels (BI-98D19DF2) requires both
+  // models to report a nonzero element count; default to a healthy count so
+  // existing tests don't need to know about the assertion unless they're
+  // specifically exercising it.
+  mockPrisma.eaReferenceModelElement.count.mockResolvedValue(1);
 
   mockReadWorkbook.mockResolvedValue([
     {
@@ -195,6 +200,24 @@ describe("seedEaReferenceModels", () => {
     for (const [args] of sdCalls) {
       expect(args.create.properties).not.toHaveProperty("dpfCapabilityKey");
     }
+  });
+
+  it("throws when the IT4IT workbook read produces zero elements (BI-98D19DF2)", async () => {
+    mockPrisma.eaReferenceModelElement.count.mockResolvedValue(0);
+
+    await expect(seedEaReferenceModels()).rejects.toThrow(/IT4IT reference model imported zero elements/);
+  });
+
+  it("throws when the BIAN JSON import produces zero elements (BI-98D19DF2)", async () => {
+    // Both models resolve to the same mocked id ("model-1") in this fixture,
+    // so distinguish by call order: first count() is IT4IT, second is BIAN.
+    let call = 0;
+    mockPrisma.eaReferenceModelElement.count.mockImplementation(async () => {
+      call += 1;
+      return call === 1 ? 1 : 0;
+    });
+
+    await expect(seedEaReferenceModels()).rejects.toThrow(/BIAN Service Landscape reference model imported zero elements/);
   });
 
   it("keeps the routing audit checkout wired to fetch LFS-backed seed workbooks", () => {

--- a/packages/db/src/seed-ea-reference-models.ts
+++ b/packages/db/src/seed-ea-reference-models.ts
@@ -467,4 +467,25 @@ export async function seedEaReferenceModels(): Promise<void> {
   });
 
   await seedBianReferenceModel(bianModel.id);
+
+  // BI-98D19DF2: a workbook read that silently yields zero rows (e.g. an
+  // LFS pointer stub masquerading as the real .xlsx, or a JSON schema
+  // change that empties every extracted row) must fail loudly here rather
+  // than let the seed report success while a fresh install imports
+  // nothing. Row-count assertion, not just absence of a thrown error.
+  const [it4itElementCount, bianElementCount] = await Promise.all([
+    prisma.eaReferenceModelElement.count({ where: { modelId: model.id } }),
+    prisma.eaReferenceModelElement.count({ where: { modelId: bianModel.id } }),
+  ]);
+
+  if (it4itElementCount === 0) {
+    throw new Error(
+      `IT4IT reference model imported zero elements from ${IT4IT_WORKBOOK_PATH} — the workbook read did not throw but produced no rows (check for an LFS pointer stub or an empty/relabelled sheet).`
+    );
+  }
+  if (bianElementCount === 0) {
+    throw new Error(
+      "BIAN Service Landscape reference model imported zero elements — the JSON read did not throw but produced no business areas/domains/service domains (check docs/Reference/bian/bian-v14-service-landscape.json)."
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- **Root cause confirmed**: `docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx` is Git-LFS tracked (`*.xlsx filter=lfs` in `.gitattributes`). `.github/workflows/ux-route-sweep.yml`'s `actions/checkout@v7` did not set `lfs: true`, so on a clean CI runner the checkout produced a ~130-byte LFS pointer stub instead of the real 50KB zip. `fflate`'s `unzipSync` (in `packages/db/src/excel-sheet-reader.ts`) rejected the pointer text with exactly "invalid zip data".
- **Fix mirrors existing, proven precedent**: `.github/workflows/audit-routing-invariants.yml` already runs the *same* full seed and already sets `lfs: true` on checkout for this exact reason (see its inline comment, and the pre-existing `seed-ea-reference-models.test.ts` test "keeps the routing audit checkout wired to fetch LFS-backed seed workbooks"). That job has been green on every recent push to `main`. Rather than migrating a 50KB reference file out of LFS, this PR applies the same `lfs: true` fix to `ux-route-sweep.yml`.
- **Interim mitigation removed**: the `eaReferenceModels`-tolerance carve-out shipped in #3445 is deleted — the seed step is back to a plain `pnpm --filter @dpf/db seed` that fails on any step failure.
- **Row-count assertion added** (acceptance criterion: "verifiably present afterwards, row count assertion, not just absence of an error"): `seedEaReferenceModels()` now counts `EaReferenceModelElement` rows for both the IT4IT and BIAN models after import and throws if either is zero. This protects every environment that runs the seed, not just this one CI job — a workbook/JSON read that silently returns zero rows (e.g. a relabelled sheet, an empty file) now fails loudly instead of reporting success.

## Files changed

- `.github/workflows/ux-route-sweep.yml` — `lfs: true` on checkout; interim tolerance carve-out removed.
- `packages/db/src/seed-ea-reference-models.ts` — row-count assertion after IT4IT + BIAN import.
- `packages/db/src/seed-ea-reference-models.test.ts` — mocks updated for the new `count()` call; two new tests for the zero-row-count failure paths.

## Verification

Honest accounting of what was and wasn't verified locally this session:

- ✅ `git lfs pointer --file=docs/Reference/IT4IT_Functional_Criteria_Taxonomy.xlsx` confirms the tracked blob is exactly the ~130-byte pointer-stub shape that reproduces "invalid zip data" when fed to a zip parser.
- ✅ Confirmed the checked-out workbook in this worktree is real zip data: `PK\x03\x04` header, 14 zip entries, `[Content_Types].xml` and `xl/workbook.xml` present.
- ✅ Ran the **actual `readWorkbook()` code path** used by `seedEaReferenceModels()` directly against the checked-out file (standalone script, not the full seed): it parsed **417 functional-criteria rows, 187 value-stream rows, 29 participation rows** — proving both that the workbook is genuinely readable once real bytes are present, and that the new row-count assertion will pass against real data.
- ❌ Could **not** run the `packages/db` unit test suite (`vitest`) locally — `pnpm install` in this worktree hit a `postinstall` failure (`node scripts/set-hooks-path.mjs` exited non-zero) and left a hash-mismatched `vitest` build (`cli.js` referencing a stale chunk filename) that repeated reinstall attempts didn't resolve within the session's time budget. This looks like sandbox/environment noise rather than a defect in the change.
- ❌ Could **not** run `pnpm --filter @dpf/db seed` against a real Postgres locally (no Postgres available in this sandbox) — the acceptance criterion's true proof is the CI run on this PR, which (unlike before) now exercises the previously-tolerated `eaReferenceModels` step for real, plus the existing required Typecheck/Unit/Prod Build gates.
- The pre-commit hook's local `apps/web` typecheck (triggered because `packages/db` changes conservatively also typecheck web) did not complete in this sandbox — a known constraint (`tsc` needs `--max-old-space-size=8192` here) unrelated to this change, which touches no exported type surface (only an internal `count()` call and two `throw new Error(...)` inside an already `Promise<void>`-returning function). Committed with the hook's own `DPF_SKIP_TYPECHECK=1` escape hatch; CI's required Typecheck gate runs unmodified on this PR.

## Test plan

- [ ] CI: `Routing Invariants Audit` stays green (unaffected — checkout already had `lfs: true`).
- [ ] CI: `UX Route Budget Sweep` — seed step now fails on any failure with no carve-out; should complete cleanly with the LFS fix.
- [ ] CI: required Typecheck / Unit / Prod Build / DCO / Module-Size / Repo-Guard checks all green.
- [ ] Manual: confirm `seed-ea-reference-models.test.ts`'s new tests pass in CI's unit-test job.

Refs: BI-98D19DF2

🤖 Generated with [Claude Code](https://claude.com/claude-code)