### PR TITLE
feat(ci): derived-artifact registry — regenerate-and-stage at commit time (BI-48768E05)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,11 +1,16 @@
 #!/bin/sh
 #
-# pre-commit: runs before every local commit. Four guards:
+# pre-commit: runs before every local commit. Guards:
 #
 #   1. Migration immutability — reject commits that modify previously-committed
 #      Prisma migration .sql files (drift prevention).
 #   2. Stale Prisma client refresh — regenerate when schema.prisma is newer
 #      than the generated client.
+#   2b. Derived-artifact registry — regenerate + stage any registered derived
+#      artifact (doc index, doc-impact manifest, doc diagrams, capability
+#      catalog, ...) whose sources are staged. Same "regenerate transparently"
+#      shape as Guard 2, generalized via scripts/derived-artifacts-gate.mjs +
+#      scripts/lib/derived-artifacts-registry.mjs (BI-48768E05).
 #   3. Secret scan gate — scan the staged snapshot with gitleaks before bytes
 #      enter Git history.
 #   4. Typecheck gate — when TypeScript files are staged, run `pnpm typecheck`
@@ -85,6 +90,23 @@ if [ -f "$SCHEMA" ] && [ -f "$CLIENT" ] && [ "$SCHEMA" -nt "$CLIENT" ]; then
     exit 1
   fi
   echo "[pre-commit] Prisma client refreshed."
+fi
+
+# ─── Guard 2b: derived-artifact registry ────────────────────────────────────
+# If a check can compute its own fix, apply it at commit time, not report it
+# at CI time (BI-48768E05). scripts/derived-artifacts-gate.mjs consults the
+# single-source-of-truth registry (scripts/lib/derived-artifacts-registry.mjs)
+# for every registered derived artifact (doc index, doc-impact manifest, doc
+# diagrams, capability/service catalog, ...), regenerates and `git add`s any
+# whose sources are among the staged files, and prints exactly what it did.
+# An artifact whose generator embeds a deliberate human judgment call (the
+# SBOM drift baseline) is advised, never auto-staged — see the registry's
+# per-entry `autoStage` comment.
+
+if [ -f "scripts/derived-artifacts-gate.mjs" ]; then
+  if ! node scripts/derived-artifacts-gate.mjs regenerate-staged; then
+    exit 1
+  fi
 fi
 
 # ─── Guard 3: staged secret scan ────────────────────────────────────────────

--- a/.githooks/pre-push-gate
+++ b/.githooks/pre-push-gate
@@ -11,7 +11,10 @@
 # What does NOT need a gate record:
 #   - delete-only / tag-only pushes (nothing to verify)
 #   - pushes from main or a detached HEAD (the merge queue governs main)
-#   - docs-only diffs vs the configured comparison base (no runtime code changed)
+#   - docs-only diffs vs the configured comparison base, PROVIDED none of the
+#     changed docs are the source of a registered derived artifact that is
+#     now stale (scripts/derived-artifacts-gate.mjs push-exempt; registry at
+#     scripts/lib/derived-artifacts-registry.mjs — BI-48768E05)
 #
 # Override (recorded, PR-visible — NOT silent): set BOTH
 #   DPF_SKIP_PREPUSH_GATE=1 DPF_SKIP_PREPUSH_GATE_REASON="why" git push
@@ -96,18 +99,25 @@ fs.writeFileSync(file, JSON.stringify({
   exit 0
 fi
 
-# Docs-only diffs need no sandbox run — there is no runtime code to gate. The
-# comparison base defaults to origin/main for GitHub-hosted clones, but can be
-# pointed at a local accepted-base ref by offline/forge-neutral integrations.
-# If the configured base is missing, do NOT fall back silently; require the
-# SHA-bound gate record instead.
+# Docs-only diffs need no sandbox run UNLESS the diff invalidates a
+# registered derived artifact (BI-48768E05) — a docs change is not
+# inherently runtime-safe when it is the SOURCE of a generated runtime
+# artifact (e.g. apps/web/lib/docs/doc-index.generated.json). PR #3284 was
+# exactly this: a docs-only diff that turned main red because the old rule
+# here exempted it by path regex alone, with no check that the derived
+# artifact was actually still fresh. scripts/derived-artifacts-gate.mjs
+# derives the exemption from the registry instead of a path regex: it still
+# requires zero non-docs runtime changes, and additionally runs the --check
+# command for every registered artifact whose sources are in the diff. The
+# comparison base defaults to origin/main for GitHub-hosted clones, but can
+# be pointed at a local accepted-base ref by offline/forge-neutral
+# integrations. If the configured base is missing, do NOT fall back
+# silently; require the SHA-bound gate record instead.
 base_ref="${DPF_PREPUSH_BASE_REF:-origin/main}"
 if git rev-parse --verify --quiet "$base_ref" >/dev/null 2>&1; then
   merge_base="$(git merge-base HEAD "$base_ref" 2>/dev/null || true)"
-  if [ -n "$merge_base" ]; then
-    non_docs_changes="$(git diff --name-only "$merge_base" HEAD | grep -Ev '^docs/|^memory/|\.md$' || true)"
-    if [ -z "$non_docs_changes" ]; then
-      echo "[pre-push-gate] docs-only diff vs $base_ref — local-CI gate not required."
+  if [ -n "$merge_base" ] && [ -f "scripts/derived-artifacts-gate.mjs" ]; then
+    if node scripts/derived-artifacts-gate.mjs push-exempt "$merge_base"; then
       exit 0
     fi
   fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,33 @@ jobs:
         # needed); rendering happens in a compile-ready env via `pnpm docs:diagrams`.
         run: node scripts/render-doc-diagrams.mjs --check
 
+  derived-artifact-registry:
+    name: Derived Artifact Registry
+    runs-on: ubuntu-latest
+    # BI-48768E05. scripts/lib/derived-artifacts-registry.mjs is the single
+    # source of truth for every generated-from-source, committed-to-git
+    # artifact (doc index, doc-impact manifest, doc diagrams, capability
+    # catalog, SBOM drift baseline, ...) that .githooks/pre-commit
+    # regenerates+stages and .githooks/pre-push-gate derives its docs-only
+    # push exemption from. This job is CI's consumption of that same
+    # registry: run every registered artifact's --check command through one
+    # driver (scripts/derived-artifacts-gate.mjs check-all) so a new
+    # generator is covered here by construction, with no ci.yml edit. The
+    # individual --check steps in Docs Link Integrity above are intentionally
+    # left in place (specific, fast, and already load-bearing); this job is
+    # the registry-wide backstop, including artifacts (capability catalog,
+    # SBOM baseline) that previously had no dedicated CI freshness check.
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 24
+      - name: Registry + driver unit tests
+        run: node --test scripts/lib/derived-artifacts-registry.test.mjs scripts/derived-artifacts-gate.test.mjs
+      - name: Every registered derived artifact is fresh
+        run: node scripts/derived-artifacts-gate.mjs check-all
+
   pr-health-test:
     name: PR Health Logic
     runs-on: ubuntu-latest

--- a/scripts/derived-artifacts-gate.mjs
+++ b/scripts/derived-artifacts-gate.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+// scripts/derived-artifacts-gate.mjs
+//
+// BI-48768E05 — the single driver .githooks/pre-commit, .githooks/pre-push-gate,
+// and CI all call into the derived-artifact registry
+// (scripts/lib/derived-artifacts-registry.mjs) through. Adding a generator to
+// the registry is what enrolls it everywhere at once; this file has no
+// per-artifact knowledge.
+//
+// Subcommands:
+//   regenerate-staged     pre-commit: for every registered artifact whose
+//                         sources are staged, run its generate command and
+//                         `git add` the result. Prints exactly what it did,
+//                         itemized — mirrors the pre-commit Guard 2 (Prisma
+//                         client) precedent: loud, never silent, fast.
+//   push-exempt <baseRef> pre-push gate: decide whether the diff since
+//                         baseRef needs the local-CI sandbox gate. Replaces
+//                         the old docs-only path-regex exemption — "docs
+//                         changed" is no longer treated as inherently
+//                         runtime-safe; a docs change that is a registered
+//                         artifact's source must pass that artifact's check.
+//   check-all             CI: run every registered artifact's check command.
+//   list                  print the registry as JSON (debugging / CI
+//                         visibility).
+//
+// Zero external dependencies.
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { DERIVED_ARTIFACTS, affectedEntries } from "./lib/derived-artifacts-registry.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+// ── pure planning helpers (unit-tested without touching git/subprocesses) ──
+
+/**
+ * Decide what regenerate-staged should do for each artifact affected by
+ * `stagedFiles`, given a `binaryAvailable(name)` predicate (injectable so
+ * tests don't depend on the host's PATH / node_modules).
+ *
+ * Returns [{ entry, action }] where action is one of:
+ *   "regenerate"          — run entry.generate, then stage entry.artifactPaths
+ *   "advisory"            — sources changed but entry.autoStage === false;
+ *                           print guidance, do not run generate
+ *   "skip-missing-binary" — entry.requiresBinary is unavailable; print a
+ *                           skip notice, do not run generate, do not fail
+ */
+export function planRegenerate(stagedFiles, registry = DERIVED_ARTIFACTS, binaryAvailable = () => true) {
+  return affectedEntries(stagedFiles, registry).map((entry) => {
+    if (entry.requiresBinary && !binaryAvailable(entry.requiresBinary)) {
+      return { entry, action: "skip-missing-binary" };
+    }
+    if (entry.autoStage === false) {
+      return { entry, action: "advisory" };
+    }
+    return { entry, action: "regenerate" };
+  });
+}
+
+/**
+ * Decide whether a push needs the local-CI sandbox gate.
+ *
+ * `diffFiles` is the full changed-file list since the comparison base.
+ * `runCheck(entry)` returns true if the artifact is fresh (check passes).
+ *
+ * Mirrors the pre-existing docs-only semantics for genuinely non-doc runtime
+ * code (still requires the gate — this function does not relax that), and
+ * replaces the assumption "docs-only diff => safe" with "docs-only diff AND
+ * no registered artifact invalidated by it is stale => safe".
+ */
+export function evaluatePushExemption(diffFiles, registry = DERIVED_ARTIFACTS, runCheck = () => true) {
+  const nonDocChanges = diffFiles.filter((f) => !/^docs\/|^memory\/|\.md$/.test(f));
+  if (nonDocChanges.length > 0) {
+    return { exempt: false, reason: "non-docs runtime changes present", files: nonDocChanges };
+  }
+
+  const affected = affectedEntries(diffFiles, registry);
+  const stale = affected.filter((entry) => !runCheck(entry));
+  if (stale.length > 0) {
+    return {
+      exempt: false,
+      reason: "docs diff invalidates a registered derived artifact",
+      staleArtifacts: stale.map((e) => e.id),
+    };
+  }
+
+  return { exempt: true, reason: affected.length > 0 ? "docs diff, all affected artifacts fresh" : "docs-only diff, no registered artifact touched" };
+}
+
+/** Run every registry entry's check; returns [{ entry, ok }]. */
+export function evaluateCheckAll(registry = DERIVED_ARTIFACTS, runCheck = () => true) {
+  return registry.map((entry) => ({ entry, ok: runCheck(entry) }));
+}
+
+// ── IO-touching implementations used by the CLI ────────────────────────────
+
+function git(args) {
+  return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf8" }).trim();
+}
+
+function stagedFiles() {
+  const out = git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"]);
+  return out ? out.split("\n").filter(Boolean) : [];
+}
+
+function diffFiles(baseRef) {
+  const out = git(["diff", "--name-only", baseRef, "HEAD"]);
+  return out ? out.split("\n").filter(Boolean) : [];
+}
+
+function binaryAvailable(name) {
+  const envOverride = process.env[name.toUpperCase()];
+  if (envOverride) return existsSync(envOverride);
+  const candidates =
+    process.platform === "win32"
+      ? [join(REPO_ROOT, "node_modules", ".bin", `${name}.cmd`), join(REPO_ROOT, "node_modules", ".bin", `${name}.exe`)]
+      : [join(REPO_ROOT, "node_modules", ".bin", name)];
+  return candidates.some((p) => existsSync(p));
+}
+
+function runCommand(argv) {
+  execFileSync(argv[0], argv.slice(1), { cwd: REPO_ROOT, stdio: "inherit" });
+}
+
+function runCheckLive(entry) {
+  try {
+    execFileSync(entry.check[0], entry.check.slice(1), { cwd: REPO_ROOT, stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function stageArtifact(artifactPath) {
+  // A trailing "/**" means "this whole directory" — `git add` on the parent
+  // directory covers every file the generator wrote under it.
+  const target = artifactPath.endsWith("/**") ? artifactPath.slice(0, -3) : artifactPath;
+  git(["add", "--", target]);
+}
+
+// ── subcommands ──────────────────────────────────────────────────────────
+
+function cmdRegenerateStaged() {
+  const plan = planRegenerate(stagedFiles(), DERIVED_ARTIFACTS, binaryAvailable);
+  if (plan.length === 0) return 0;
+
+  let failed = false;
+  for (const { entry, action } of plan) {
+    if (action === "skip-missing-binary") {
+      console.log(`[pre-commit] derived-artifact "${entry.id}": sources changed but ${entry.requiresBinary} is not installed — SKIPPED (CI is the backstop via --check).`);
+      continue;
+    }
+    if (action === "advisory") {
+      console.log(`[pre-commit] derived-artifact "${entry.id}": sources changed (${entry.description}).`);
+      console.log(`[pre-commit]   This artifact requires a deliberate decision, not auto-regeneration. If needed, run:`);
+      console.log(`[pre-commit]     ${entry.generate.join(" ")}`);
+      console.log(`[pre-commit]   and review + stage ${entry.artifactPaths.join(", ")} yourself.`);
+      continue;
+    }
+    console.log(`[pre-commit] derived-artifact "${entry.id}": sources changed (${entry.description}) — regenerating...`);
+    try {
+      runCommand(entry.generate);
+    } catch (err) {
+      console.error(`[pre-commit] ERROR: "${entry.generate.join(" ")}" failed for derived-artifact "${entry.id}".`);
+      console.error(String(err?.message ?? err));
+      failed = true;
+      continue;
+    }
+    for (const artifactPath of entry.artifactPaths) stageArtifact(artifactPath);
+    console.log(`[pre-commit] derived-artifact "${entry.id}": regenerated and staged ${entry.artifactPaths.join(", ")}.`);
+  }
+
+  if (failed) {
+    console.error("");
+    console.error("Commit rejected. A derived-artifact generator failed — see errors above.");
+    console.error("");
+    return 1;
+  }
+  return 0;
+}
+
+function cmdPushExempt(baseRef) {
+  if (!baseRef) {
+    console.error("[pre-push-gate] push-exempt requires a base ref argument.");
+    return 2;
+  }
+  const result = evaluatePushExemption(diffFiles(baseRef), DERIVED_ARTIFACTS, runCheckLive);
+  if (result.exempt) {
+    console.log(`[pre-push-gate] derived-artifact registry: exempt (${result.reason}).`);
+    return 0;
+  }
+  console.log(`[pre-push-gate] derived-artifact registry: NOT exempt (${result.reason}).`);
+  if (result.staleArtifacts) {
+    for (const id of result.staleArtifacts) {
+      const entry = DERIVED_ARTIFACTS.find((e) => e.id === id);
+      console.log(`[pre-push-gate]   stale: "${id}" — run: ${entry.generate.join(" ")}`);
+    }
+  }
+  return 1;
+}
+
+function cmdCheckAll() {
+  const results = evaluateCheckAll(DERIVED_ARTIFACTS, runCheckLive);
+  let failed = false;
+  for (const { entry, ok } of results) {
+    console.log(`[derived-artifacts] ${entry.id}: ${ok ? "fresh" : "STALE"}`);
+    if (!ok) {
+      console.log(`[derived-artifacts]   run: ${entry.generate.join(" ")}`);
+      failed = true;
+    }
+  }
+  return failed ? 1 : 0;
+}
+
+function cmdList() {
+  console.log(JSON.stringify(DERIVED_ARTIFACTS, null, 2));
+  return 0;
+}
+
+function main() {
+  const [sub, ...rest] = process.argv.slice(2);
+  switch (sub) {
+    case "regenerate-staged":
+      process.exit(cmdRegenerateStaged());
+      break;
+    case "push-exempt":
+      process.exit(cmdPushExempt(rest[0]));
+      break;
+    case "check-all":
+      process.exit(cmdCheckAll());
+      break;
+    case "list":
+      process.exit(cmdList());
+      break;
+    default:
+      console.error("Usage: node scripts/derived-artifacts-gate.mjs <regenerate-staged|push-exempt <baseRef>|check-all|list>");
+      process.exit(2);
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/derived-artifacts-gate.test.mjs
+++ b/scripts/derived-artifacts-gate.test.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Tests for the derived-artifact registry driver (BI-48768E05). All tests
+// exercise the pure planning/decision functions with injected fakes — no
+// git or subprocess calls, so they run instantly and deterministically.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { planRegenerate, evaluatePushExemption, evaluateCheckAll } from "./derived-artifacts-gate.mjs";
+
+const DOC_INDEX = {
+  id: "doc-index",
+  sourceGlobs: ["docs/**/*.md"],
+  artifactPaths: ["apps/web/lib/docs/doc-index.generated.json"],
+  generate: ["node", "scripts/gen-doc-index.mjs"],
+  check: ["node", "scripts/gen-doc-index.mjs", "--check"],
+};
+
+const DIAGRAMS = {
+  id: "doc-diagrams",
+  sourceGlobs: ["docs/user-guide/**/*.md"],
+  artifactPaths: ["docs/user-guide/assets/diagrams/**"],
+  generate: ["node", "scripts/render-doc-diagrams.mjs"],
+  check: ["node", "scripts/render-doc-diagrams.mjs", "--check"],
+  requiresBinary: "mmdc",
+};
+
+const SBOM = {
+  id: "sbom-baseline",
+  sourceGlobs: ["pnpm-lock.yaml"],
+  artifactPaths: ["sbom/baseline.json"],
+  generate: ["node", "scripts/sbom/check-sbom-drift.mjs", "--update-baseline"],
+  check: ["node", "scripts/sbom/check-sbom-drift.mjs"],
+  autoStage: false,
+};
+
+// ── planRegenerate ───────────────────────────────────────────────────────────
+
+test("planRegenerate is empty when nothing staged touches a registered source", () => {
+  const plan = planRegenerate(["src/unrelated.ts"], [DOC_INDEX]);
+  assert.deepEqual(plan, []);
+});
+
+test("planRegenerate regenerates when a source is staged and no special-casing applies", () => {
+  const plan = planRegenerate(["docs/foo.md"], [DOC_INDEX]);
+  assert.equal(plan.length, 1);
+  assert.equal(plan[0].entry.id, "doc-index");
+  assert.equal(plan[0].action, "regenerate");
+});
+
+test("planRegenerate skips (without failing) when requiresBinary is unavailable", () => {
+  const plan = planRegenerate(["docs/user-guide/foo.md"], [DIAGRAMS], () => false);
+  assert.equal(plan.length, 1);
+  assert.equal(plan[0].action, "skip-missing-binary");
+});
+
+test("planRegenerate regenerates when requiresBinary IS available", () => {
+  const plan = planRegenerate(["docs/user-guide/foo.md"], [DIAGRAMS], () => true);
+  assert.equal(plan[0].action, "regenerate");
+});
+
+test("planRegenerate marks autoStage:false entries as advisory, never auto-regenerated", () => {
+  const plan = planRegenerate(["pnpm-lock.yaml"], [SBOM]);
+  assert.equal(plan.length, 1);
+  assert.equal(plan[0].action, "advisory");
+});
+
+test("planRegenerate handles multiple affected entries independently", () => {
+  const plan = planRegenerate(["docs/foo.md", "pnpm-lock.yaml"], [DOC_INDEX, SBOM]);
+  const byId = Object.fromEntries(plan.map((p) => [p.entry.id, p.action]));
+  assert.equal(byId["doc-index"], "regenerate");
+  assert.equal(byId["sbom-baseline"], "advisory");
+});
+
+// ── evaluatePushExemption ───────────────────────────────────────────────────
+
+test("evaluatePushExemption: non-docs runtime change is never exempt", () => {
+  const result = evaluatePushExemption(["apps/web/app/page.tsx"], [DOC_INDEX], () => true);
+  assert.equal(result.exempt, false);
+  assert.equal(result.reason, "non-docs runtime changes present");
+});
+
+test("evaluatePushExemption: docs-only diff touching no registered artifact is exempt", () => {
+  const result = evaluatePushExemption(["README.md"], [DOC_INDEX], () => true);
+  assert.equal(result.exempt, true);
+});
+
+test("evaluatePushExemption: docs diff touching a registered artifact is exempt IFF the check passes", () => {
+  const fresh = evaluatePushExemption(["docs/foo.md"], [DOC_INDEX], () => true);
+  assert.equal(fresh.exempt, true);
+
+  const stale = evaluatePushExemption(["docs/foo.md"], [DOC_INDEX], () => false);
+  assert.equal(stale.exempt, false);
+  assert.deepEqual(stale.staleArtifacts, ["doc-index"]);
+});
+
+test("evaluatePushExemption: this is the exact #3284 regression scenario, now caught", () => {
+  // #3284 added a docs page without regenerating doc-index.generated.json.
+  // Under the OLD path-regex rule this was unconditionally exempt (docs-only
+  // diff). The registry-driven rule requires the artifact's check to pass.
+  const result = evaluatePushExemption(
+    ["docs/marketing/dpf-market-vision.md"],
+    [DOC_INDEX],
+    () => false, // doc-index.generated.json was NOT regenerated — check fails
+  );
+  assert.equal(result.exempt, false);
+});
+
+test("evaluatePushExemption: a non-docs file change still gates even if a doc artifact is also touched", () => {
+  const result = evaluatePushExemption(["docs/foo.md", "packages/db/schema.prisma"], [DOC_INDEX], () => true);
+  assert.equal(result.exempt, false);
+  assert.equal(result.reason, "non-docs runtime changes present");
+});
+
+// ── evaluateCheckAll ─────────────────────────────────────────────────────────
+
+test("evaluateCheckAll reports every entry's check result", () => {
+  const results = evaluateCheckAll([DOC_INDEX, SBOM], (entry) => entry.id === "doc-index");
+  assert.deepEqual(
+    results.map((r) => [r.entry.id, r.ok]),
+    [
+      ["doc-index", true],
+      ["sbom-baseline", false],
+    ],
+  );
+});

--- a/scripts/lib/derived-artifacts-registry.mjs
+++ b/scripts/lib/derived-artifacts-registry.mjs
@@ -1,0 +1,132 @@
+// scripts/lib/derived-artifacts-registry.mjs
+//
+// BI-48768E05 — declarative registry of derived (generated-from-source,
+// committed-to-git) artifacts: source globs -> generator command -> check
+// command, one entry per artifact. Single source of truth consumed by
+// .githooks/pre-commit (regenerate + stage), .githooks/pre-push-gate
+// (dependency-graph-derived push exemption), and CI
+// (scripts/derived-artifacts-gate.mjs check-all).
+//
+// Filed after PR #3284 turned main red: it added a docs page without
+// regenerating apps/web/lib/docs/doc-index.generated.json, and the pre-push
+// gate's docs-only path-regex exemption assumed docs changes are always
+// runtime-safe -- false precisely for a generated artifact whose SOURCE is
+// docs/. Adding a generator here is what makes a new derived artifact
+// covered by construction; no hook or CI file needs to change.
+//
+// Zero external dependencies -- pure data plus a hand-rolled glob matcher
+// (the only patterns in use are literal segments, `*`, and `**`, so a full
+// glob library would be dead weight).
+
+/**
+ * Convert a repo-relative glob (`*`, `**`, literal segments) to a RegExp
+ * anchored on both ends. `**\/` collapses to "zero or more path segments,
+ * including none" so `docs/**\/*.md` matches `docs/foo.md` as well as
+ * `docs/a/b/foo.md`. `**` at the end of a pattern (no trailing slash, used
+ * for "this whole directory") matches any suffix, including into
+ * subdirectories.
+ */
+export function globToRegExp(glob) {
+  let re = "";
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === "*" && glob[i + 1] === "*") {
+      i++; // consume the second '*'
+      if (glob[i + 1] === "/") {
+        i++; // consume the following '/'
+        re += "(?:.*/)?";
+      } else {
+        re += ".*";
+      }
+    } else if (c === "*") {
+      re += "[^/]*";
+    } else if (c === "?") {
+      re += "[^/]";
+    } else if (".+^${}()|[]\\".includes(c)) {
+      re += `\\${c}`;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+/** True if a repo-relative POSIX path matches a repo-relative glob. */
+export function matchesGlob(filePath, glob) {
+  return globToRegExp(glob).test(filePath);
+}
+
+/** True if `filePath` matches at least one glob in `globs`. */
+export function matchesAnyGlob(filePath, globs) {
+  return globs.some((g) => matchesGlob(filePath, g));
+}
+
+export const DERIVED_ARTIFACTS = [
+  {
+    id: "doc-index",
+    description: "Doc corpus index (link/anchor resolution)",
+    sourceGlobs: ["docs/**/*.md", "apps/web/lib/docs/doc-link-resolver.mjs"],
+    artifactPaths: ["apps/web/lib/docs/doc-index.generated.json"],
+    generate: ["node", "scripts/gen-doc-index.mjs"],
+    check: ["node", "scripts/gen-doc-index.mjs", "--check"],
+  },
+  {
+    id: "doc-impact",
+    description: "Doc-impact manifest (route/code -> user-guide page edges)",
+    sourceGlobs: [
+      "docs/user-guide/**/*.md",
+      "apps/web/lib/docs-route-map.ts",
+      "scripts/check-docs-impact.mjs",
+    ],
+    artifactPaths: ["apps/web/lib/docs/doc-impact.generated.json"],
+    generate: ["node", "scripts/gen-doc-impact.mjs"],
+    check: ["node", "scripts/gen-doc-impact.mjs", "--check"],
+  },
+  {
+    id: "doc-diagrams",
+    description: "Rendered Mermaid diagram SVGs + manifest",
+    sourceGlobs: ["docs/user-guide/**/*.md"],
+    artifactPaths: ["docs/user-guide/assets/diagrams/**"],
+    generate: ["node", "scripts/render-doc-diagrams.mjs"],
+    check: ["node", "scripts/render-doc-diagrams.mjs", "--check"],
+    // Rendering shells out to mmdc (@mermaid-js/mermaid-cli), which is only
+    // installed in a compile-ready environment, not every source-only
+    // worktree. Pre-commit skips (loudly) rather than blocking when it's
+    // absent; CI (a compile-ready runner) is the backstop via --check.
+    requiresBinary: "mmdc",
+  },
+  {
+    id: "capability-service-catalog",
+    description: "Compiled capability/service catalog",
+    sourceGlobs: [
+      "scripts/platform-substrate-manifest.json",
+      "packages/db/data/platform-runtime-capabilities.json",
+      "scripts/lib/capability-service-projection.mjs",
+    ],
+    artifactPaths: ["scripts/capability-service-catalog.generated.json"],
+    generate: ["node", "scripts/compile-capability-service-catalog.mjs"],
+    check: ["node", "scripts/compile-capability-service-catalog.mjs", "--check"],
+  },
+  {
+    id: "sbom-baseline",
+    description: "SBOM dependency-shape drift baseline (first-party version splits)",
+    sourceGlobs: ["pnpm-lock.yaml", "pnpm-workspace.yaml"],
+    artifactPaths: ["sbom/baseline.json"],
+    generate: ["node", "scripts/sbom/check-sbom-drift.mjs", "--update-baseline"],
+    check: ["node", "scripts/sbom/check-sbom-drift.mjs"],
+    // NOT a pure function of its sources: the baseline records which
+    // first-party version splits are DELIBERATELY accepted. Its own guard
+    // comment is explicit: "Update intentionally ... never to silence a
+    // real regression." Auto-staging on every lockfile touch would launder
+    // a judgment call the check exists to force a human to make, so this
+    // entry is registered (for CI's check-all and for push-exemption
+    // awareness) but pre-commit only advises -- it never runs `generate`
+    // for this entry on its own.
+    autoStage: false,
+  },
+];
+
+/** Registry entries whose sourceGlobs match at least one of `files`. */
+export function affectedEntries(files, registry = DERIVED_ARTIFACTS) {
+  return registry.filter((entry) => files.some((f) => matchesAnyGlob(f, entry.sourceGlobs)));
+}

--- a/scripts/lib/derived-artifacts-registry.test.mjs
+++ b/scripts/lib/derived-artifacts-registry.test.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Tests for the derived-artifact registry (BI-48768E05).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { globToRegExp, matchesGlob, matchesAnyGlob, affectedEntries, DERIVED_ARTIFACTS } from "./derived-artifacts-registry.mjs";
+
+// ── glob matching ───────────────────────────────────────────────────────────
+
+test("literal path matches only itself", () => {
+  assert.equal(matchesGlob("pnpm-lock.yaml", "pnpm-lock.yaml"), true);
+  assert.equal(matchesGlob("pnpm-lock.yamlx", "pnpm-lock.yaml"), false);
+  assert.equal(matchesGlob("other/pnpm-lock.yaml", "pnpm-lock.yaml"), false);
+});
+
+test("single '*' matches within one path segment only", () => {
+  assert.equal(matchesGlob("scripts/foo.mjs", "scripts/*.mjs"), true);
+  assert.equal(matchesGlob("scripts/lib/foo.mjs", "scripts/*.mjs"), false);
+});
+
+test("'dir/**/*.md' matches nested and directly-under files", () => {
+  assert.equal(matchesGlob("docs/foo.md", "docs/**/*.md"), true);
+  assert.equal(matchesGlob("docs/user-guide/foo.md", "docs/**/*.md"), true);
+  assert.equal(matchesGlob("docs/a/b/c/foo.md", "docs/**/*.md"), true);
+  assert.equal(matchesGlob("docs/foo.ts", "docs/**/*.md"), false);
+  assert.equal(matchesGlob("other/foo.md", "docs/**/*.md"), false);
+});
+
+test("trailing '/**' matches the whole subtree, at any depth", () => {
+  assert.equal(matchesGlob("scripts/sbom/check-sbom-drift.mjs", "scripts/sbom/**"), true);
+  assert.equal(matchesGlob("scripts/sbom/lib/x.mjs", "scripts/sbom/**"), true);
+  assert.equal(matchesGlob("scripts/other.mjs", "scripts/sbom/**"), false);
+});
+
+test("matchesAnyGlob short-circuits on the first match", () => {
+  assert.equal(matchesAnyGlob("pnpm-lock.yaml", ["docs/**/*.md", "pnpm-lock.yaml"]), true);
+  assert.equal(matchesAnyGlob("pnpm-lock.yaml", ["docs/**/*.md"]), false);
+});
+
+test("regex produced by globToRegExp is fully anchored", () => {
+  const re = globToRegExp("docs/**/*.md");
+  assert.equal(re.test("xdocs/foo.md"), false);
+  assert.equal(re.test("docs/foo.mdx"), false);
+});
+
+// ── registry shape ───────────────────────────────────────────────────────────
+
+test("every registry entry has the required fields", () => {
+  for (const entry of DERIVED_ARTIFACTS) {
+    assert.equal(typeof entry.id, "string");
+    assert.ok(entry.id.length > 0, `entry missing id: ${JSON.stringify(entry)}`);
+    assert.ok(Array.isArray(entry.sourceGlobs) && entry.sourceGlobs.length > 0, `${entry.id}: sourceGlobs`);
+    assert.ok(Array.isArray(entry.artifactPaths) && entry.artifactPaths.length > 0, `${entry.id}: artifactPaths`);
+    assert.ok(Array.isArray(entry.generate) && entry.generate.length > 0, `${entry.id}: generate`);
+    assert.ok(Array.isArray(entry.check) && entry.check.length > 0, `${entry.id}: check`);
+  }
+});
+
+test("registry ids are unique", () => {
+  const ids = DERIVED_ARTIFACTS.map((e) => e.id);
+  assert.equal(new Set(ids).size, ids.length);
+});
+
+test("enrolls the five generators required by BI-48768E05", () => {
+  const ids = new Set(DERIVED_ARTIFACTS.map((e) => e.id));
+  for (const expected of ["doc-index", "doc-impact", "doc-diagrams", "capability-service-catalog", "sbom-baseline"]) {
+    assert.ok(ids.has(expected), `missing registry entry: ${expected}`);
+  }
+});
+
+test("sbom-baseline is registered with autoStage disabled (judgment call, not a pure function of sources)", () => {
+  const entry = DERIVED_ARTIFACTS.find((e) => e.id === "sbom-baseline");
+  assert.equal(entry.autoStage, false);
+});
+
+// ── affectedEntries ─────────────────────────────────────────────────────────
+
+test("affectedEntries finds only entries whose sourceGlobs match a changed file", () => {
+  const registry = [
+    { id: "a", sourceGlobs: ["docs/**/*.md"] },
+    { id: "b", sourceGlobs: ["pnpm-lock.yaml"] },
+  ];
+  const affected = affectedEntries(["docs/foo.md", "src/x.ts"], registry);
+  assert.deepEqual(affected.map((e) => e.id), ["a"]);
+});
+
+test("affectedEntries returns nothing when no file matches", () => {
+  const registry = [{ id: "a", sourceGlobs: ["docs/**/*.md"] }];
+  assert.deepEqual(affectedEntries(["src/x.ts"], registry), []);
+});
+
+test("affectedEntries can return multiple entries for one changed-files set", () => {
+  const registry = [
+    { id: "a", sourceGlobs: ["docs/**/*.md"] },
+    { id: "b", sourceGlobs: ["docs/user-guide/**/*.md"] },
+  ];
+  const affected = affectedEntries(["docs/user-guide/x.md"], registry);
+  assert.deepEqual(affected.map((e) => e.id).sort(), ["a", "b"]);
+});


### PR DESCRIPTION
## Summary

- Fixes the class of bug behind #3284 (a docs-only PR that turned main red by adding a docs page without regenerating `doc-index.generated.json`, which the pre-push gate's path-regex docs-only exemption assumed was always safe).
- Adds a declarative registry (`scripts/lib/derived-artifacts-registry.mjs`): source globs → generator command → check command, one entry per derived artifact. Single source of truth consumed by `.githooks/pre-commit`, `.githooks/pre-push-gate`, and CI via one driver, `scripts/derived-artifacts-gate.mjs`.
- **pre-commit** (new Guard 2b, mirroring the existing Prisma Guard 2 shape): when staged files touch a registered artifact's sources, regenerates and `git add`s the result, printing exactly what it did — loud and itemized, silent when nothing is affected.
- **pre-push-gate**: replaces the `non_docs_changes=... | grep -Ev '^docs/|^memory/|\.md$'` exemption with a registry-derived check — a docs-only diff is exempt only if it doesn't invalidate any registered derived artifact (verified via that artifact's `--check` command), not just because the changed paths look like docs.
- **CI**: new "Derived Artifact Registry" job runs every registered artifact's `--check` command through the same driver — gives `capability-service-catalog.generated.json` and the SBOM drift baseline CI freshness coverage they didn't have before (verified: no ci.yml step previously ran `compile-capability-service-catalog.mjs --check`).

## Enrolled generators (the five named in the BI, verified by reading each script)

| id | sources | artifact | generate / check |
|---|---|---|---|
| `doc-index` | `docs/**/*.md`, doc-link-resolver | `apps/web/lib/docs/doc-index.generated.json` | `gen-doc-index.mjs` |
| `doc-impact` | `docs/user-guide/**/*.md`, route map | `apps/web/lib/docs/doc-impact.generated.json` | `gen-doc-impact.mjs` |
| `doc-diagrams` | `docs/user-guide/**/*.md` | rendered Mermaid SVGs + manifest | `render-doc-diagrams.mjs` (requires `mmdc`; pre-commit skips loudly, non-blocking, when it's absent from a source-only worktree) |
| `capability-service-catalog` | substrate manifest + capability seed | `scripts/capability-service-catalog.generated.json` | `compile-capability-service-catalog.mjs` |
| `sbom-baseline` | `pnpm-lock.yaml`, `pnpm-workspace.yaml` | `sbom/baseline.json` | `scripts/sbom/check-sbom-drift.mjs` |

One deliberate deviation, called out because it matters: `sbom/generate-platform-sbom.mjs`'s own output (`sbom/dpf-platform-sbom.cdx.json` etc.) is **intentionally not committed** — its own workflow says so ("the full reports are intentionally NOT committed... only `sbom/baseline.json` is tracked, as the drift anchor"). The actual committed, staleable artifact is `sbom/baseline.json`, produced by `check-sbom-drift.mjs --update-baseline`. That script's own comment says the baseline records a **deliberate human accept** of a new first-party dependency-version split — auto-staging it on every lockfile touch would silently launder exactly the judgment call the guard exists to force. So this entry is registered (CI's `check-all` and push-exemption awareness both cover it) with `autoStage: false`: pre-commit prints an advisory and never runs its generate command on its own.

## Out of scope (per the operator decision, 2026-07-19)

No CI-autofix-bot that regenerates and pushes a commit back to the PR branch — that was scored last (3.52/10, kernel ledger `DI-F4F1C057C5FA`) and explicitly rejected. This PR is pre-commit/pre-push/CI-check only, all local to the contributor's own commit.

## Test plan

- [x] 25 new unit tests (`node --test scripts/lib/derived-artifacts-registry.test.mjs scripts/derived-artifacts-gate.test.mjs`) — glob matcher, registry shape/uniqueness, and the pure planning/decision functions (`planRegenerate`, `evaluatePushExemption`, `evaluateCheckAll`) via injected fakes. Includes a regression test that reproduces the exact #3284 scenario and confirms it's now caught.
- [x] `node scripts/derived-artifacts-gate.mjs check-all` run live against current main — all five artifacts report fresh.
- [x] `node scripts/derived-artifacts-gate.mjs push-exempt <base>` run live — correctly rejects a real non-docs diff.
- [x] `sh -n` syntax check on both modified hook scripts.
- [x] `node scripts/check-module-size.mjs` — no new oversized files.
- [x] `node scripts/check-guards.mjs` — passes except one pre-existing, unrelated failure (`check-no-provider-local-connector-lifecycle.test.mjs`) caused by this worktree having no `node_modules` installed at all (an isolated-pnpm-graph guard, unrelated to this change).
- [x] Rebased onto current `origin/main`; post-rebase diff contains only this PR's 7 files.
- [x] `gh pr list` overlap sweep (`derived-artifact`, `BI-48768E05`) — no conflicts.
- [ ] CI (typecheck/prod build/unit — this worktree has no `node_modules` installed, ~15-30min install; all changes here are `.mjs`/`.sh`/`.yml`, no TypeScript touched, so typecheck is inapplicable to this diff specifically, but CI is the authoritative gate).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
