### PR TITLE
fix(build): stalled build/review builds surface as needs-attention, not animated Working (BI-46204009)

### DIFF
--- a/apps/web/app/(shell)/build/page.tsx
+++ b/apps/web/app/(shell)/build/page.tsx
@@ -7,7 +7,7 @@ import { businessBuildBriefFromRecord } from "@/lib/build/business-build-brief";
 import { BuildStudio } from "@/components/build/BuildStudio";
 import { BuildStudioV2 } from "@/components/build-studio/BuildStudioV2";
 import { loadBuildStudioCapability } from "@/lib/build/build-studio-capability";
-import { loadBuildStudioCustomerStatuses } from "@/lib/build/customer-status-loader";
+import { loadBuildStudioCustomerStatuses, type CapsuleFindManyDelegate } from "@/lib/build/customer-status-loader";
 import { resolvePortalContextEnvelope } from "@/lib/portal-context";
 import { can } from "@/lib/govern/permissions";
 import { EnableRunnerButton } from "@/components/build/EnableRunnerButton";
@@ -235,11 +235,17 @@ export default async function BuildPage({ searchParams }: PageProps) {
   // first-viewport "wife-test" status band without pulling the projection into
   // the client bundle.
   const customerStatuses = await loadBuildStudioCustomerStatuses(
-    prisma,
+    // Prisma's real `groupBy` typing is a conditional generic that doesn't
+    // structurally satisfy the narrow, test-mockable delegate interface;
+    // this cast is the documented escape hatch (see CapsuleFindManyDelegate's
+    // doc comment) rather than widening the interface and breaking test mocks.
+    prisma as unknown as CapsuleFindManyDelegate,
     [...builds, ...(initialActiveBuild ? [initialActiveBuild] : [])].map((build) => ({
       id: build.id,
+      buildId: build.buildId,
       title: build.title,
       phase: build.phase,
+      updatedAt: build.updatedAt,
     })),
   );
   const portalContext = await resolvePortalContextEnvelope(

--- a/apps/web/lib/build/customer-status-loader.test.ts
+++ b/apps/web/lib/build/customer-status-loader.test.ts
@@ -1,21 +1,33 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { loadBuildStudioCustomerStatuses } from "@/lib/build/customer-status-loader";
+import { STALLED_BUILD_REAP_MS } from "@/lib/build/inert-build-reaper";
 
-function dbWith(rows: Array<{ featureBuildId: string | null; capsuleId: string; status: string }>) {
-  const findMany = vi.fn().mockResolvedValue(rows);
-  return { db: { workCapsule: { findMany } }, findMany };
+const NOW = new Date("2026-07-24T00:00:00Z");
+const RECENT = new Date(NOW.getTime() - 5 * 60 * 1000);
+const STALE = new Date(NOW.getTime() - STALLED_BUILD_REAP_MS - 60_000);
+
+function dbWith(
+  capsuleRows: Array<{ featureBuildId: string | null; capsuleId: string; status: string }>,
+  activityRows: Array<{ buildId: string; _max: { createdAt: Date | null } }> = [],
+) {
+  const findMany = vi.fn().mockResolvedValue(capsuleRows);
+  const groupBy = vi.fn().mockResolvedValue(activityRows);
+  return { db: { workCapsule: { findMany }, buildActivity: { groupBy } }, findMany, groupBy };
 }
 
 describe("loadBuildStudioCustomerStatuses (BI-BB13B599)", () => {
   it("projects the capsule-derived status when a capsule is linked to the build", async () => {
-    const { db, findMany } = dbWith([
-      { featureBuildId: "cuid-1", capsuleId: "WC-1", status: "working" },
-    ]);
+    const { db, findMany } = dbWith(
+      [{ featureBuildId: "cuid-1", capsuleId: "WC-1", status: "working" }],
+      [{ buildId: "FB-1", _max: { createdAt: RECENT } }],
+    );
 
-    const statuses = await loadBuildStudioCustomerStatuses(db, [
-      { id: "cuid-1", title: "Add invoicing", phase: "build" },
-    ]);
+    const statuses = await loadBuildStudioCustomerStatuses(
+      db,
+      [{ id: "cuid-1", buildId: "FB-1", title: "Add invoicing", phase: "build", updatedAt: RECENT }],
+      NOW,
+    );
 
     // queried by the cuid ids
     expect(findMany).toHaveBeenCalledWith(
@@ -29,13 +41,13 @@ describe("loadBuildStudioCustomerStatuses (BI-BB13B599)", () => {
   });
 
   it("surfaces needsYou from the capsule projection when the capsule is blocked", async () => {
-    const { db } = dbWith([
-      { featureBuildId: "cuid-b", capsuleId: "WC-B", status: "blocked" },
-    ]);
+    const { db } = dbWith([{ featureBuildId: "cuid-b", capsuleId: "WC-B", status: "blocked" }]);
 
-    const statuses = await loadBuildStudioCustomerStatuses(db, [
-      { id: "cuid-b", title: "Wire webhook", phase: "build" },
-    ]);
+    const statuses = await loadBuildStudioCustomerStatuses(
+      db,
+      [{ id: "cuid-b", buildId: "FB-B", title: "Wire webhook", phase: "build", updatedAt: RECENT }],
+      NOW,
+    );
 
     expect(statuses["cuid-b"].needsYou).toBe(true);
   });
@@ -43,9 +55,11 @@ describe("loadBuildStudioCustomerStatuses (BI-BB13B599)", () => {
   it("degrades to the phase-only fallback when no capsule is linked", async () => {
     const { db } = dbWith([]);
 
-    const statuses = await loadBuildStudioCustomerStatuses(db, [
-      { id: "cuid-2", title: "Fix login", phase: "failed" },
-    ]);
+    const statuses = await loadBuildStudioCustomerStatuses(
+      db,
+      [{ id: "cuid-2", buildId: "FB-2", title: "Fix login", phase: "failed", updatedAt: RECENT }],
+      NOW,
+    );
 
     expect(statuses["cuid-2"]).toEqual(
       expect.objectContaining({
@@ -56,25 +70,88 @@ describe("loadBuildStudioCustomerStatuses (BI-BB13B599)", () => {
     );
   });
 
-  it("returns an empty map and skips the query when there are no builds", async () => {
-    const { db, findMany } = dbWith([]);
+  it("returns an empty map and skips both queries when there are no builds", async () => {
+    const { db, findMany, groupBy } = dbWith([]);
 
     const statuses = await loadBuildStudioCustomerStatuses(db, []);
 
     expect(statuses).toEqual({});
     expect(findMany).not.toHaveBeenCalled();
+    expect(groupBy).not.toHaveBeenCalled();
   });
 
   it("dedupes build ids before querying", async () => {
-    const { db, findMany } = dbWith([]);
+    const { db, findMany, groupBy } = dbWith([]);
 
-    await loadBuildStudioCustomerStatuses(db, [
-      { id: "cuid-3", title: "A", phase: "plan" },
-      { id: "cuid-3", title: "A", phase: "plan" },
-    ]);
+    await loadBuildStudioCustomerStatuses(
+      db,
+      [
+        { id: "cuid-3", buildId: "FB-3", title: "A", phase: "plan", updatedAt: RECENT },
+        { id: "cuid-3", buildId: "FB-3", title: "A", phase: "plan", updatedAt: RECENT },
+      ],
+      NOW,
+    );
 
     expect(findMany).toHaveBeenCalledWith(
       expect.objectContaining({ where: { featureBuildId: { in: ["cuid-3"] } } }),
     );
+    expect(groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { buildId: { in: ["FB-3"] } } }),
+    );
+  });
+
+  describe("activity-freshness stall wiring (BI-46204009)", () => {
+    it("joins BuildActivity on the FB-* buildId, not the cuid id, and flags a stalled build/review build", async () => {
+      const { db, groupBy } = dbWith(
+        [],
+        [{ buildId: "FB-CCEC4210", _max: { createdAt: STALE } }],
+      );
+
+      const statuses = await loadBuildStudioCustomerStatuses(
+        db,
+        [
+          {
+            id: "cuid-stalled",
+            buildId: "FB-CCEC4210",
+            title: "Backlog autopilot pipeline",
+            phase: "build",
+            updatedAt: STALE,
+          },
+        ],
+        NOW,
+      );
+
+      expect(groupBy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { buildId: { in: ["FB-CCEC4210"] } } }),
+      );
+      expect(statuses["cuid-stalled"].lifecyclePosition).toBe("Stalled / needs attention");
+      expect(statuses["cuid-stalled"].needsYou).toBe(true);
+    });
+
+    it("keeps a genuinely-working build/review build as 'Working' when BuildActivity is recent", async () => {
+      const { db } = dbWith([], [{ buildId: "FB-14D6EB41", _max: { createdAt: RECENT } }]);
+
+      const statuses = await loadBuildStudioCustomerStatuses(
+        db,
+        [{ id: "cuid-live", buildId: "FB-14D6EB41", title: "Wire target archetypes", phase: "review", updatedAt: RECENT }],
+        NOW,
+      );
+
+      expect(statuses["cuid-live"].lifecyclePosition).not.toBe("Stalled / needs attention");
+      expect(statuses["cuid-live"].needsYou).toBe(false);
+    });
+
+    it("falls back to build.updatedAt when a build has no BuildActivity rows at all", async () => {
+      const { db } = dbWith([], []);
+
+      const statuses = await loadBuildStudioCustomerStatuses(
+        db,
+        [{ id: "cuid-no-activity", buildId: "FB-NOACT", title: "Never emitted activity", phase: "build", updatedAt: STALE }],
+        NOW,
+      );
+
+      expect(statuses["cuid-no-activity"].lifecyclePosition).toBe("Stalled / needs attention");
+      expect(statuses["cuid-no-activity"].needsYou).toBe(true);
+    });
   });
 });

--- a/apps/web/lib/build/customer-status-loader.ts
+++ b/apps/web/lib/build/customer-status-loader.ts
@@ -3,41 +3,70 @@
 // set on every build via attachBuildStudioWorkCapsule) and projects each into the
 // plain, business-safe customer-mode status. Returns a map keyed by the build's
 // cuid `id` so the client can look up the active build's status without pulling
-// the capsule projection into the client bundle. Pure aside from the single
-// findMany — unit-testable with a mock delegate.
+// the capsule projection into the client bundle. Pure aside from the two queries
+// — unit-testable with a mock delegate.
+//
+// BI-46204009: also fetches the latest BuildActivity per build so the
+// projection can tell genuine "Working" apart from a stalled build. This MUST
+// join on FeatureBuild.buildId (the FB-* semantic key), not the cuid `id` —
+// BuildActivity.buildId references FeatureBuild.buildId, not FeatureBuild.id.
 import type { BuildPhase } from "@/lib/explore/feature-build-types";
 import {
   projectBuildStudioCustomerStatus,
   type BuildStudioCustomerStatus,
 } from "@/lib/build/customer-status-projection";
 
-interface CapsuleFindManyDelegate {
+// Narrow, test-mockable delegate shape. Prisma's real `groupBy` is typed via
+// a conditional generic keyed on the full args object (orderBy/skip/take
+// interplay), which does not structurally satisfy a hand-written closed
+// signature — callers passing the real client cast at the call site
+// (`prisma as unknown as CapsuleFindManyDelegate`) rather than this file
+// widening to the full Prisma delegate type, which would break test mocks.
+export interface CapsuleFindManyDelegate {
   workCapsule: {
     findMany: (args: {
       where: { featureBuildId: { in: string[] } };
       select: { featureBuildId: true; capsuleId: true; status: true };
     }) => Promise<Array<{ featureBuildId: string | null; capsuleId: string; status: string }>>;
   };
-}
-
-/** Minimal build shape the projection needs — the cuid id, title, and phase. */
-export interface CustomerStatusBuild {
-  id: string;
-  title: string;
-  phase: BuildPhase;
+  buildActivity: {
+    groupBy: (args: {
+      by: ["buildId"];
+      where: { buildId: { in: string[] } };
+      _max: { createdAt: true };
+    }) => Promise<Array<{ buildId: string; _max: { createdAt: Date | null } }>>;
+  };
 }
 
 /**
- * Fetch the linked capsule for each build in one query and project each build
- * into its plain customer-mode status. Builds with no linked capsule degrade to
- * the phase-only fallback inside projectBuildStudioCustomerStatus.
+ * Minimal build shape the projection needs — the cuid id (map key), the FB-*
+ * semantic buildId (for the BuildActivity join), title, phase, and updatedAt
+ * (freshness fallback when a build has no BuildActivity rows at all).
+ */
+export interface CustomerStatusBuild {
+  id: string;
+  buildId: string;
+  title: string;
+  phase: BuildPhase;
+  updatedAt: Date;
+}
+
+/**
+ * Fetch the linked capsule + latest BuildActivity for each build in two
+ * queries and project each build into its plain customer-mode status. Builds
+ * with no linked capsule degrade to the phase-only fallback; builds with no
+ * recent activity in an active phase surface as stalled — both inside
+ * projectBuildStudioCustomerStatus.
  */
 export async function loadBuildStudioCustomerStatuses(
   db: CapsuleFindManyDelegate,
   builds: ReadonlyArray<CustomerStatusBuild>,
+  now: Date = new Date(),
 ): Promise<Record<string, BuildStudioCustomerStatus>> {
   const ids = Array.from(new Set(builds.map((b) => b.id)));
+  const buildIds = Array.from(new Set(builds.map((b) => b.buildId)));
   const byBuild = new Map<string, { capsuleId: string; status: string }>();
+  const lastActivityByBuildId = new Map<string, Date>();
   if (ids.length > 0) {
     const capsules = await db.workCapsule.findMany({
       where: { featureBuildId: { in: ids } },
@@ -49,12 +78,25 @@ export async function loadBuildStudioCustomerStatuses(
       }
     }
   }
+  if (buildIds.length > 0) {
+    const activityMax = await db.buildActivity.groupBy({
+      by: ["buildId"],
+      where: { buildId: { in: buildIds } },
+      _max: { createdAt: true },
+    });
+    for (const row of activityMax) {
+      if (row._max.createdAt) {
+        lastActivityByBuildId.set(row.buildId, row._max.createdAt);
+      }
+    }
+  }
 
   const statuses: Record<string, BuildStudioCustomerStatus> = {};
   for (const build of builds) {
     statuses[build.id] = projectBuildStudioCustomerStatus({
-      build: { title: build.title, phase: build.phase },
+      build: { title: build.title, phase: build.phase, updatedAt: build.updatedAt },
       capsule: byBuild.get(build.id) ?? null,
+      activity: { lastActivityAt: lastActivityByBuildId.get(build.buildId) ?? null, now },
     });
   }
   return statuses;

--- a/apps/web/lib/build/customer-status-projection.test.ts
+++ b/apps/web/lib/build/customer-status-projection.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import { projectBuildStudioCustomerStatus } from "./customer-status-projection";
+import { STALLED_BUILD_REAP_MS } from "./inert-build-reaper";
 
-const build = { title: "Add a dark-mode toggle", phase: "build" as const };
+const build = { title: "Add a dark-mode toggle", phase: "build" as const, updatedAt: new Date("2026-07-20T00:00:00Z") };
 
 describe("projectBuildStudioCustomerStatus (BI-BB13B599)", () => {
   it("derives a plain customer status from the linked capsule (blocked → automated work, needs you)", () => {
@@ -64,7 +65,7 @@ describe("projectBuildStudioCustomerStatus (BI-BB13B599)", () => {
 
   it("surfaces needs-you on a failed phase-only build", () => {
     const status = projectBuildStudioCustomerStatus({
-      build: { title: "x", phase: "failed" },
+      build: { title: "x", phase: "failed", updatedAt: new Date("2026-07-20T00:00:00Z") },
       capsule: null,
     });
     expect(status.needsYou).toBe(true);
@@ -79,5 +80,91 @@ describe("projectBuildStudioCustomerStatus (BI-BB13B599)", () => {
       const combined = `${out.whatIsBeingBuilt} ${out.lifecyclePosition} ${out.worker}`;
       expect(combined).not.toMatch(/claude|codex|grok|opencode/i);
     }
+  });
+
+  describe("activity-freshness stall override (BI-46204009)", () => {
+    const now = new Date("2026-07-24T00:00:00Z");
+    const recent = new Date(now.getTime() - 5 * 60 * 1000); // 5 min ago
+    const stale = new Date(now.getTime() - STALLED_BUILD_REAP_MS - 60_000); // just past the threshold
+
+    it("stays 'Working' (phase-only) when BuildActivity is recent", () => {
+      const status = projectBuildStudioCustomerStatus({
+        build: { title: "x", phase: "build", updatedAt: recent },
+        capsule: null,
+        activity: { lastActivityAt: recent, now },
+      });
+      expect(status.lifecyclePosition).toBe("Building it");
+      expect(status.needsYou).toBe(false);
+    });
+
+    it("stays 'In progress' (capsule-active) when BuildActivity is recent", () => {
+      const status = projectBuildStudioCustomerStatus({
+        build: { title: "x", phase: "review", updatedAt: recent },
+        capsule: { capsuleId: "WC-1", status: "working" },
+        activity: { lastActivityAt: recent, now },
+      });
+      expect(status.lifecyclePosition).toBe("In progress");
+      expect(status.needsYou).toBe(false);
+    });
+
+    it("flips to 'Stalled / needs attention' and routes to needs-you when BuildActivity is stale (phase-only path)", () => {
+      const status = projectBuildStudioCustomerStatus({
+        build: { title: "Backlog autopilot pipeline", phase: "build", updatedAt: stale },
+        capsule: null,
+        activity: { lastActivityAt: stale, now },
+      });
+      expect(status.lifecyclePosition).toBe("Stalled / needs attention");
+      expect(status.needsYou).toBe(true);
+      expect(status.evidence).toContain("No build activity since");
+      expect(status.whatIsBeingBuilt).toBe("Backlog autopilot pipeline");
+    });
+
+    it("flips to stalled even with a linked capsule reporting 'working'", () => {
+      const status = projectBuildStudioCustomerStatus({
+        build: { title: "x", phase: "review", updatedAt: stale },
+        capsule: { capsuleId: "WC-1", status: "working" },
+        activity: { lastActivityAt: stale, now },
+      });
+      expect(status.lifecyclePosition).toBe("Stalled / needs attention");
+      expect(status.needsYou).toBe(true);
+    });
+
+    it("falls back to build.updatedAt when there is no BuildActivity at all", () => {
+      const status = projectBuildStudioCustomerStatus({
+        build: { title: "x", phase: "build", updatedAt: stale },
+        capsule: null,
+        activity: { lastActivityAt: null, now },
+      });
+      expect(status.lifecyclePosition).toBe("Stalled / needs attention");
+      expect(status.needsYou).toBe(true);
+    });
+
+    it("does not override a phase already outside build/review (e.g. ship)", () => {
+      const status = projectBuildStudioCustomerStatus({
+        build: { title: "x", phase: "ship", updatedAt: stale },
+        capsule: null,
+        activity: { lastActivityAt: stale, now },
+      });
+      expect(status.lifecyclePosition).not.toBe("Stalled / needs attention");
+    });
+
+    it("does not override a state already needs-you (e.g. failed phase-only)", () => {
+      const status = projectBuildStudioCustomerStatus({
+        build: { title: "x", phase: "failed", updatedAt: stale },
+        capsule: null,
+        activity: { lastActivityAt: stale, now },
+      });
+      expect(status.worker).toBe("Hit a problem");
+      expect(status.needsYou).toBe(true);
+    });
+
+    it("skips the stall check entirely when no activity signal is supplied (back-compat)", () => {
+      const status = projectBuildStudioCustomerStatus({
+        build: { title: "x", phase: "build", updatedAt: stale },
+        capsule: null,
+      });
+      expect(status.lifecyclePosition).toBe("Building it");
+      expect(status.needsYou).toBe(false);
+    });
   });
 });

--- a/apps/web/lib/build/customer-status-projection.ts
+++ b/apps/web/lib/build/customer-status-projection.ts
@@ -6,13 +6,25 @@
 // takes the executor in its signature — business-safety (no "Claude"/"Codex"/
 // "Grok" leaking to the customer) is guaranteed by construction.
 //
-// Pure + unit-testable. The DB fetch (workCapsule.findFirst by featureBuildId)
-// and the BuildStudio.tsx render are a deferred follow-up (need live-portal
-// verification).
+// BI-46204009: the phase/capsule bands above describe *stage*, not *freshness* —
+// a build/review-phase build with no recent BuildActivity was still rendered as
+// an animated "Working" even after sitting frozen for days (FB-CCEC4210: phase
+// build, 0 activity events in ~3.1 days). This module now takes an optional
+// `activity` freshness signal and overrides the stage-derived status with an
+// honest "Stalled / needs attention" (routed to the Needs-you band) when a
+// build/review-phase build has gone quiet longer than the stall threshold.
+// Reuses STALLED_BUILD_REAP_MS from inert-build-reaper.ts — that constant's own
+// doc comment already calls out that it "matches the UI stall definition,
+// BI-46204009" — rather than inventing a second threshold.
+//
+// Pure + unit-testable. The DB fetch (workCapsule.findFirst by featureBuildId,
+// BuildActivity max(createdAt) by the FB-* buildId) and the BuildStudio.tsx
+// render are a deferred follow-up (need live-portal verification).
 
 import { projectWorkCaseState } from "@/lib/work-management/status-projection";
 import type { WorkCaseState } from "@/lib/work-management/case-types";
 import type { BuildPhase } from "@/lib/explore/feature-build-types";
+import { STALLED_BUILD_REAP_MS } from "@/lib/build/inert-build-reaper";
 
 export interface BuildStudioCustomerStatus {
   /** Plain restatement of what is being built (the build title). */
@@ -36,6 +48,16 @@ const NEEDS_YOU_STATES: ReadonlySet<WorkCaseState> = new Set([
   "awaiting-decision",
   "waiting-on-system",
 ]);
+
+/**
+ * Phases where the panel currently animates "Working" / "In progress" — the
+ * only phases a freshness stall can override. ideate/plan are coworker-custody
+ * (age-out is a separate, much longer window — BI-A009313E) and
+ * ship/complete/failed/abandoned own their own terminal-ish framing, so a
+ * freshness stall only applies to the two phases that actually claim to be
+ * live execution. Mirrors the phase gate in isStalledBuildReapable.
+ */
+const STALL_ELIGIBLE_PHASES: ReadonlySet<BuildPhase> = new Set(["build", "review"]);
 
 /** Capsule-derived WorkCaseState → plain lifecycle label. */
 const STATE_PLAIN: Record<WorkCaseState, string> = {
@@ -151,38 +173,87 @@ function nextActionForPhase(phase: BuildPhase): { nextAction: string; owner: str
   }
 }
 
+/**
+ * True when a build/review-phase build has produced no observable signal
+ * (BuildActivity or a FeatureBuild.updatedAt bump) within the stall threshold.
+ * `lastActivityAt` wins when present (it's the more precise signal); falling
+ * back to `buildUpdatedAt` covers a build that has never emitted a
+ * BuildActivity row at all but whose phase timestamp is stale.
+ */
+function isActivityStale(args: {
+  lastActivityAt: Date | null;
+  buildUpdatedAt: Date;
+  now: Date;
+  staleMs: number;
+}): boolean {
+  const lastSignal = args.lastActivityAt ?? args.buildUpdatedAt;
+  return args.now.getTime() - lastSignal.getTime() > args.staleMs;
+}
+
 export function projectBuildStudioCustomerStatus(args: {
-  build: { title: string; phase: BuildPhase };
+  build: { title: string; phase: BuildPhase; updatedAt: Date };
   capsule: { capsuleId: string; status: string } | null;
+  /** Activity-freshness signal (BI-46204009). Omit to skip the stall check (e.g. existing callers mid-migration). */
+  activity?: { lastActivityAt: Date | null; now?: Date };
 }): BuildStudioCustomerStatus {
-  if (args.capsule) {
-    const projection = projectWorkCaseState({ capsule: args.capsule });
-    const action = nextActionForState(projection.state);
+  const base: BuildStudioCustomerStatus = args.capsule
+    ? (() => {
+        const projection = projectWorkCaseState({ capsule: args.capsule! });
+        const action = nextActionForState(projection.state);
+        return {
+          whatIsBeingBuilt: args.build.title,
+          lifecyclePosition: STATE_PLAIN[projection.state],
+          worker: workerLabel(projection.state),
+          evidence: projection.reason,
+          nextAction: action.nextAction,
+          owner: action.owner,
+          needsYou: NEEDS_YOU_STATES.has(projection.state),
+        };
+      })()
+    : // No capsule linked yet: degrade to a phase-only plain status.
+      (() => {
+        const action = nextActionForPhase(args.build.phase);
+        return {
+          whatIsBeingBuilt: args.build.title,
+          lifecyclePosition: PHASE_PLAIN[args.build.phase],
+          worker:
+            args.build.phase === "complete"
+              ? "Finished"
+              : args.build.phase === "failed"
+                ? "Hit a problem"
+                : "Work in progress",
+          evidence: `Build Studio phase is ${args.build.phase}.`,
+          nextAction: action.nextAction,
+          owner: action.owner,
+          needsYou: args.build.phase === "failed",
+        };
+      })();
+
+  // BI-46204009: a build/review-phase build that isn't already flagged
+  // needs-you but has gone quiet longer than the stall threshold is not
+  // honestly "Working" — override with a stalled status and route to Needs-you.
+  if (
+    args.activity &&
+    !base.needsYou &&
+    STALL_ELIGIBLE_PHASES.has(args.build.phase) &&
+    isActivityStale({
+      lastActivityAt: args.activity.lastActivityAt,
+      buildUpdatedAt: args.build.updatedAt,
+      now: args.activity.now ?? new Date(),
+      staleMs: STALLED_BUILD_REAP_MS,
+    })
+  ) {
+    const lastSignal = args.activity.lastActivityAt ?? args.build.updatedAt;
     return {
-      whatIsBeingBuilt: args.build.title,
-      lifecyclePosition: STATE_PLAIN[projection.state],
-      worker: workerLabel(projection.state),
-      evidence: projection.reason,
-      nextAction: action.nextAction,
-      owner: action.owner,
-      needsYou: NEEDS_YOU_STATES.has(projection.state),
+      ...base,
+      lifecyclePosition: "Stalled / needs attention",
+      worker: "Stalled — needs attention",
+      evidence: `No build activity since ${lastSignal.toISOString()} (stall threshold ${Math.round(STALLED_BUILD_REAP_MS / 3_600_000)}h).`,
+      nextAction: "check the build and resume or abandon it if it's stuck.",
+      owner: "Build Studio / operator",
+      needsYou: true,
     };
   }
 
-  // No capsule linked yet: degrade to a phase-only plain status.
-  const action = nextActionForPhase(args.build.phase);
-  return {
-    whatIsBeingBuilt: args.build.title,
-    lifecyclePosition: PHASE_PLAIN[args.build.phase],
-    worker:
-      args.build.phase === "complete"
-        ? "Finished"
-        : args.build.phase === "failed"
-          ? "Hit a problem"
-          : "Work in progress",
-    evidence: `Build Studio phase is ${args.build.phase}.`,
-    nextAction: action.nextAction,
-    owner: action.owner,
-    needsYou: args.build.phase === "failed",
-  };
+  return base;
 }


### PR DESCRIPTION
## Summary

- The `/build` Work Control panel projected status purely from `FeatureBuild.phase` (and linked `WorkCapsule.status`), with no activity-freshness input. A build/review-phase build with zero recent `BuildActivity` for days still rendered as an animated "Working" — live evidence: `FB-CCEC4210` (phase `build`, 0 activity events in ~3.1 days) vs `FB-14D6EB41` (review phase, 6 events in 15 min) rendered identically.
- `projectBuildStudioCustomerStatus` (`apps/web/lib/build/customer-status-projection.ts`) now takes an optional `activity` freshness signal (last `BuildActivity` timestamp, falling back to `FeatureBuild.updatedAt` when a build has no activity rows at all) and overrides the phase/capsule-derived status with **"Stalled / needs attention"** — routed to the needs-you band — when a build/review-phase build has gone quiet longer than the stall threshold.
- Reuses `STALLED_BUILD_REAP_MS` (6h) from `apps/web/lib/build/inert-build-reaper.ts` rather than inventing a second threshold — that constant's own doc comment already calls out that it "matches the UI stall definition, BI-46204009".
- `apps/web/lib/build/customer-status-loader.ts` now also groups `BuildActivity` by `buildId` (max `createdAt`) and joins it in **on `FeatureBuild.buildId` (the `FB-*` semantic key) — not the cuid `id`**, which only keys the `WorkCapsule` lookup. `apps/web/app/(shell)/build/page.tsx` passes both keys through.

## Design grounding

Extends the existing BI-BB13B599 customer-status projection substrate (see `docs/superpowers/plans/2026-05-19-build-studio-stall-detection.md`, which already defines the `heartbeat_timeout`/stall vocabulary this reuses) with an activity-freshness signal. No new spec artifact — this is additive to an existing, already-documented projection.

## Test plan

- [x] Added unit tests to `customer-status-projection.test.ts`: stays "Working"/"In progress" when `BuildActivity` is recent (both phase-only and capsule-active paths); flips to "Stalled / needs attention" + `needsYou: true` when stale (phase-only path, capsule-active path, and the no-activity-at-all fallback to `updatedAt`); does not override phases outside build/review (e.g. `ship`); does not override an already-needs-you state (e.g. `failed`); skips the check entirely when no `activity` signal is supplied (back-compat).
- [x] Added unit tests to `customer-status-loader.test.ts` confirming the `BuildActivity.groupBy` join keys on the `FB-*` buildId (not the cuid), and end-to-end wiring reproduces the exact FB-CCEC4210 (stalled) / FB-14D6EB41 (live) evidence from the BI.
- [ ] **Local verification gap (disclosed):** this worktree's shared `node_modules` store was under heavy contention from ~15 concurrent overnight-campaign `pnpm install`/typecheck/pregate runs on the same machine tonight. `vitest`'s own package resolved corrupted (`ERR_MODULE_NOT_FOUND` on an internal chunk — a store race, not a code issue) and `tsc --noEmit` did not complete within a 10-minute budget (genuinely still computing under load, not erroring). Verified instead by careful manual diff/type review; `DPF_SKIP_TYPECHECK=1` was used for the local commit per the documented emergency-override pattern. **CI's Typecheck and Unit Tests checks are the authoritative gate for this PR** — auto-merge is gated on them passing, not on the (skipped) local run.

## Overlap check

- No other open PR touches `customer-status-projection.ts` / `customer-status-loader.ts`.
- Sibling BI-297863B2 (PR #3529, governed self-abandon for stalled builds) is open but touches an entirely different file set (`self-abandon-eligibility.ts`, MCP tool packs) — no overlap. That PR adds the *action* to abandon a stalled build; this PR only makes the *status band* honest about staleness.
- BI-A1FC3EBB (taskrun-watchdog) is the detection layer this PR's threshold is sourced from, not duplicated.

Closes BI-46204009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)