### PR TITLE
fix(ci): restore docs-only fallback in pre-push-gate when derived-artifacts registry is absent

### DIFF
--- a/.githooks/pre-push-gate
+++ b/.githooks/pre-push-gate
@@ -108,17 +108,30 @@ fi
 # artifact was actually still fresh. scripts/derived-artifacts-gate.mjs
 # derives the exemption from the registry instead of a path regex: it still
 # requires zero non-docs runtime changes, and additionally runs the --check
-# command for every registered artifact whose sources are in the diff. The
-# comparison base defaults to origin/main for GitHub-hosted clones, but can
-# be pointed at a local accepted-base ref by offline/forge-neutral
-# integrations. If the configured base is missing, do NOT fall back
-# silently; require the SHA-bound gate record instead.
+# command for every registered artifact whose sources are in the diff. When
+# this checkout has no such registry (scripts/derived-artifacts-gate.mjs
+# absent), fall back to the plain "diff touches only docs/, memory/, or *.md"
+# rule the registry itself replaced — still zero non-docs changes, just no
+# derived-artifact staleness awareness. The comparison base defaults to
+# origin/main for GitHub-hosted clones, but can be pointed at a local
+# accepted-base ref by offline/forge-neutral integrations. If the configured
+# base is missing, do NOT fall back silently; require the SHA-bound gate
+# record instead.
 base_ref="${DPF_PREPUSH_BASE_REF:-origin/main}"
 if git rev-parse --verify --quiet "$base_ref" >/dev/null 2>&1; then
   merge_base="$(git merge-base HEAD "$base_ref" 2>/dev/null || true)"
-  if [ -n "$merge_base" ] && [ -f "scripts/derived-artifacts-gate.mjs" ]; then
-    if node scripts/derived-artifacts-gate.mjs push-exempt "$merge_base"; then
-      exit 0
+  if [ -n "$merge_base" ]; then
+    if [ -f "scripts/derived-artifacts-gate.mjs" ]; then
+      if node scripts/derived-artifacts-gate.mjs push-exempt "$merge_base"; then
+        echo "[pre-push-gate] docs-only diff vs $base_ref — no gate record required."
+        exit 0
+      fi
+    else
+      non_docs="$(git diff --name-only "$merge_base" HEAD 2>/dev/null | grep -Ev '^(docs/|memory/)|\.md$' || true)"
+      if [ -z "$non_docs" ]; then
+        echo "[pre-push-gate] docs-only diff vs $base_ref — no gate record required."
+        exit 0
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
## Summary

- `Janitor Tests` was failing on `main` (confirmed on the last 2 completed CI runs, not tied to any specific PR's diff — reproduces on a from-scratch checkout).
- Two tests in `tests/release/local-ci-gate-contract.test.mjs` — `"pre-push-gate lets docs-only diffs through without a record"` and `"pre-push-gate can use a configured local accepted-base ref for docs-only detection"` — expected `.githooks/pre-push-gate` to exempt a docs-only diff from the local-CI gate record requirement, but got exit 1 / `"No local-CI gate record exists for this worktree."` instead.
- Root cause: `.githooks/pre-push-gate` (introduced in #3526, unrelated to that PR's storefront-settings scope) only exempted docs-only diffs by shelling out to `scripts/derived-artifacts-gate.mjs push-exempt`, gated by `[ -f "scripts/derived-artifacts-gate.mjs" ]`. The test's temp-repo fixtures don't carry a `scripts/` directory, so that guard is always false there — and the script had no fallback, falling straight through to the gate-record error regardless of how docs-only the diff was. The BI-48768E05 plan's own design was two-tier (registry-driven check when available, plain docs-only rule otherwise); only the first tier was ever implemented.
- Fix: when `scripts/derived-artifacts-gate.mjs` isn't present in the checkout, fall back to the plain "diff touches only `docs/`, `memory/`, or `*.md`" rule the registry replaced (still requires zero non-docs changes). Also added the `"[pre-push-gate] docs-only diff vs $base_ref"` stdout line both tests assert on, which neither code path ever printed.
- No behavior change for a normal DPF checkout, where `scripts/derived-artifacts-gate.mjs` is always present and the registry-driven check (with its stale-derived-artifact awareness) still runs exactly as before.

## Test plan

- [x] `node --test tests/release/local-ci-gate-contract.test.mjs` — all 25 tests pass (verified locally with a shim that only fixes a Windows Git-Bash path-translation quirk in `spawnSync("sh", [url.pathname])`; not present on ubuntu-latest CI, not a repo change).
- [x] `node --test scripts/derived-artifacts-gate.test.mjs scripts/lib/derived-artifacts-registry.test.mjs` — 25/25, unaffected by this fix (registry-driven code path untouched).
- [x] `sh -n .githooks/pre-push-gate` — syntax check passes.
- [x] Manual `sh -x` trace of the fixed script confirming the new fallback branch is taken and prints the expected message.
- [ ] CI's own required checks (this PR itself will exercise `Janitor Tests` against the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)