### PR TITLE
fix(a2a): drop stale tasks route-error baseline line (BI-81EE4A46)

### DIFF
--- a/scripts/route-error-baseline.txt
+++ b/scripts/route-error-baseline.txt
@@ -1,4 +1,3 @@
-apps/web/app/api/a2a/tasks/[taskId]/route.ts	1
 apps/web/app/api/admin/bs-dispatch-test/route.ts	2
 apps/web/app/api/admin/model-capability-changes/route.ts	2
 apps/web/app/api/admin/ops/execute-proposal/route.ts	9


### PR DESCRIPTION
## Problem

[#3156](https://github.com/OpenDigitalProductFactory/opendigitalproductfactory/pull/3156) migrated `apps/web/app/api/a2a/tasks/[taskId]/route.ts` onto the canonical `apiErrorResponse` envelope (0 raw route errors) **and** removed its `route-error-baseline.txt` line. But the `.gitattributes merge=union` driver on the baseline resurrected the `tasks/[taskId]/route.ts	1` entry at merge time (main's copy still had it; union keeps both sides).

Net state on `main`: the tasks route is at **0** raw errors while the baseline still claims **1**. Harmless — the BI-81EE4A46 ratchet only fails on growth, so 0 ≤ 1 passes — but it's stale phantom debt that defeats the point of retightening.

## Fix

Remove the one stale line. The entire `/api/a2a` surface now has zero raw route errors **and** zero baseline entries, so the ratchet reflects reality.

## Verification

- `node scripts/check-no-raw-route-error.mjs` → exit **0** (baseline: 81 files, 281 pending).
- Baseline-only change; no code or behaviour touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)