### PR TITLE
fix(worktree): wire real dependency+link probe into readiness classification (BI-3047C122)

### DIFF
--- a/scripts/lib/bootstrap-worktree-deps.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.mjs
@@ -17,7 +17,7 @@
 // explicitly (a `dpf worktree --bootstrap` CLI / the seed script / an opt-in env),
 // so worktree creation stays fast and convergence is a deliberate step.
 
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 
 /**
@@ -31,9 +31,10 @@ export function classifyReadiness({ hasNodeModules, depProbeOk, gateOk }) {
 }
 
 /** Operator-readable reason for the readiness outcome (written to the marker). */
-export function readinessReason({ hasNodeModules, depProbeOk, gateOk }) {
+export function readinessReason({ hasNodeModules, depProbeOk, gateOk, staleWorkspaceLinks }) {
   if (!hasNodeModules) return "node_modules_missing";
   if (!depProbeOk) return "dependency_resolution_failed";
+  if (staleWorkspaceLinks && staleWorkspaceLinks.length > 0) return "workspace_links_stale";
   if (!gateOk) return "cheap_gate_failed";
   return "managed_bootstrap_ok";
 }
@@ -45,6 +46,77 @@ function run(cmd, args, cwd) {
   } catch {
     return false;
   }
+}
+
+function norm(p) {
+  return String(p ?? "").replace(/\\/g, "/").replace(/\/+$/g, "");
+}
+
+function safeReaddirDirs(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((d) => d.isDirectory() || d.isSymbolicLink())
+      .map((d) => d.name);
+  } catch {
+    return [];
+  }
+}
+
+function defaultRealpath(p) {
+  try {
+    return realpathSync(p);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detects the 2026-07-24 stale-junction incident class (BI-3047C122 follow-up):
+ * node_modules/@dpf/<pkg> resolving OUTSIDE this worktree — a sibling worktree's
+ * packages/<pkg> — instead of this worktree's own workspace source. A fresh
+ * worktree that auto-junctioned a "compatible" sibling's node_modules typechecks
+ * clean against the WRONG source silently; structural presence of node_modules
+ * is not proof the tree is actually THIS worktree's. Pure aside from injected fs
+ * deps — unit-tested without touching the real filesystem.
+ */
+export function checkWorkspaceLinksResolveLocally(worktreePath, deps = {}) {
+  const readdir = deps.readdir ?? safeReaddirDirs;
+  const realpath = deps.realpath ?? defaultRealpath;
+  const wt = norm(worktreePath);
+  const names = readdir(`${wt}/node_modules/@dpf`);
+  const stale = [];
+  for (const name of names) {
+    const real = realpath(`${wt}/node_modules/@dpf/${name}`);
+    if (real === null) continue; // broken link is a dep-resolution failure, not a staleness finding
+    const realNorm = norm(real);
+    if (realNorm !== wt && !realNorm.startsWith(`${wt}/`)) {
+      stale.push({ name, target: realNorm });
+    }
+  }
+  return { ok: stale.length === 0, stale };
+}
+
+/**
+ * Classify a worktree's compile readiness WITHOUT installing anything — cheap
+ * enough to run unconditionally (unlike bootstrapWorktreeDeps' install path,
+ * which is opt-in because a multi-minute install must not gate every call).
+ * The cheap gate is dependency resolution (`pnpm ls`) AND every @dpf/* workspace
+ * link resolving inside this worktree — the two things structural node_modules
+ * presence does NOT prove.
+ */
+export function probeWorktreeReadiness(worktreePath, opts = {}) {
+  const pkgMgr = opts.packageManager ?? "pnpm";
+  const hasNodeModules = existsSync(`${worktreePath}/node_modules`);
+  const depProbeOk = hasNodeModules && run(pkgMgr, ["ls", "--depth", "-1"], worktreePath);
+  const linkCheck = depProbeOk
+    ? checkWorkspaceLinksResolveLocally(worktreePath, opts.linkCheckDeps)
+    : { ok: true, stale: [] };
+  const gateOk = depProbeOk && linkCheck.ok;
+  return {
+    status: classifyReadiness({ hasNodeModules, depProbeOk, gateOk }),
+    reason: readinessReason({ hasNodeModules, depProbeOk, gateOk, staleWorkspaceLinks: linkCheck.stale }),
+    checks: { hasNodeModules, depProbeOk, gateOk, staleWorkspaceLinks: linkCheck.stale },
+  };
 }
 
 /**
@@ -76,29 +148,28 @@ export function bootstrapWorktreeDeps(worktreePath, opts = {}) {
         worktreePath,
       );
     }
-    const hasNodeModules = existsSync(`${worktreePath}/node_modules`);
-    const depProbeOk = hasNodeModules && run(pkgMgr, ["ls", "--depth", "-1"], worktreePath);
-    // The cheap gate (e.g. one vitest file) is wired in the follow-up slice; for
-    // now a resolvable dependency tree is the gate.
-    const gateOk = depProbeOk;
-    return {
-      status: classifyReadiness({ hasNodeModules, depProbeOk, gateOk }),
-      reason: readinessReason({ hasNodeModules, depProbeOk, gateOk }),
-    };
+    return probeWorktreeReadiness(worktreePath, opts);
   } catch {
     return { status: "source-only", reason: "bootstrap_threw" };
   }
 }
 
-// CLI entry: `node scripts/lib/bootstrap-worktree-deps.mjs <worktreePath>`.
-// Invoked by seed-worktree-mcp when DPF_WORKTREE_BOOTSTRAP=1 (opt-in). Prints the
-// readiness JSON and ALWAYS exits 0 — a bootstrap failure must never break the
-// seed script (the worktree just stays source-only). Skipped on import so unit
-// tests of the pure helpers never trigger an install (mirrors worktree-create.mjs).
+// CLI entry: `node scripts/lib/bootstrap-worktree-deps.mjs <worktreePath> [--classify-only]`.
+// Default mode is invoked by seed-worktree-mcp when DPF_WORKTREE_BOOTSTRAP=1
+// (opt-in; installs). --classify-only never installs — it is cheap enough that
+// seed/sync scripts run it unconditionally to replace their old structural-only
+// readiness guess with a real dependency-resolution + workspace-link probe.
+// Prints the readiness JSON and ALWAYS exits 0 — a bootstrap failure must never
+// break the seed script (the worktree just stays source-only). Skipped on import
+// so unit tests of the pure helpers never trigger an install (mirrors
+// worktree-create.mjs).
 const invokedDirectly =
   process.argv[1] && process.argv[1].replace(/\\/g, "/").endsWith("bootstrap-worktree-deps.mjs");
 if (invokedDirectly) {
-  const target = process.argv[2] ?? process.cwd();
-  process.stdout.write(JSON.stringify(bootstrapWorktreeDeps(target)) + "\n");
+  const args = process.argv.slice(2);
+  const classifyOnly = args.includes("--classify-only");
+  const target = args.find((a) => !a.startsWith("--")) ?? process.cwd();
+  const result = classifyOnly ? probeWorktreeReadiness(target) : bootstrapWorktreeDeps(target);
+  process.stdout.write(JSON.stringify(result) + "\n");
   process.exit(0);
 }

--- a/scripts/lib/bootstrap-worktree-deps.test.mjs
+++ b/scripts/lib/bootstrap-worktree-deps.test.mjs
@@ -2,7 +2,12 @@
 // Node built-in test runner (no node_modules needed): node --test
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { classifyReadiness, readinessReason } from "./bootstrap-worktree-deps.mjs";
+import {
+  classifyReadiness,
+  readinessReason,
+  checkWorkspaceLinksResolveLocally,
+  probeWorktreeReadiness,
+} from "./bootstrap-worktree-deps.mjs";
 
 test("compile-ready ONLY when deps resolved AND the cheap gate passes", () => {
   assert.equal(classifyReadiness({ hasNodeModules: true, depProbeOk: true, gateOk: true }), "compile-ready");
@@ -16,4 +21,55 @@ test("readinessReason explains the source-only cause", () => {
   assert.equal(readinessReason({ hasNodeModules: true, depProbeOk: false, gateOk: false }), "dependency_resolution_failed");
   assert.equal(readinessReason({ hasNodeModules: true, depProbeOk: true, gateOk: false }), "cheap_gate_failed");
   assert.equal(readinessReason({ hasNodeModules: true, depProbeOk: true, gateOk: true }), "managed_bootstrap_ok");
+});
+
+test("readinessReason reports workspace_links_stale ahead of the generic cheap-gate reason", () => {
+  assert.equal(
+    readinessReason({ hasNodeModules: true, depProbeOk: true, gateOk: false, staleWorkspaceLinks: [{ name: "db", target: "/other" }] }),
+    "workspace_links_stale",
+  );
+  assert.equal(
+    readinessReason({ hasNodeModules: true, depProbeOk: true, gateOk: true, staleWorkspaceLinks: [] }),
+    "managed_bootstrap_ok",
+  );
+});
+
+test("checkWorkspaceLinksResolveLocally: no @dpf scope -> ok (nothing to check)", () => {
+  const result = checkWorkspaceLinksResolveLocally("/wt/topic", { readdir: () => [] });
+  assert.deepEqual(result, { ok: true, stale: [] });
+});
+
+test("checkWorkspaceLinksResolveLocally: every link resolves inside the worktree -> ok", () => {
+  const result = checkWorkspaceLinksResolveLocally("/wt/topic", {
+    readdir: () => ["db", "types"],
+    realpath: (p) => p.replace("/node_modules/@dpf/", "/packages/"),
+  });
+  assert.deepEqual(result, { ok: true, stale: [] });
+});
+
+test("checkWorkspaceLinksResolveLocally: flags the 2026-07-24 stale-junction class — a link resolving into a SIBLING worktree", () => {
+  const result = checkWorkspaceLinksResolveLocally("/wt/wt-73432", {
+    readdir: () => ["db", "types"],
+    realpath: (p) =>
+      p.endsWith("/db")
+        ? "/wt/objective-elion-e68a30/packages/db" // stale: a different worktree entirely
+        : p.replace("/node_modules/@dpf/", "/packages/"), // types: fine
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.stale, [{ name: "db", target: "/wt/objective-elion-e68a30/packages/db" }]);
+});
+
+test("checkWorkspaceLinksResolveLocally: a broken link is not a staleness finding (dependency_resolution_failed covers it)", () => {
+  const result = checkWorkspaceLinksResolveLocally("/wt/topic", {
+    readdir: () => ["db"],
+    realpath: () => null,
+  });
+  assert.deepEqual(result, { ok: true, stale: [] });
+});
+
+test("probeWorktreeReadiness: no node_modules -> source-only / node_modules_missing, never installs", () => {
+  const result = probeWorktreeReadiness("/wt/does-not-exist");
+  assert.equal(result.status, "source-only");
+  assert.equal(result.reason, "node_modules_missing");
+  assert.equal(result.checks.hasNodeModules, false);
 });

--- a/scripts/seed-worktree-mcp.ps1
+++ b/scripts/seed-worktree-mcp.ps1
@@ -203,14 +203,40 @@ $corepackOnPath = $null -ne (Get-Command corepack -ErrorAction SilentlyContinue)
 $nodeModulesPresent = Test-Path -LiteralPath (Join-Path $Target "node_modules")
 $readinessState = "source-only"
 $readinessReason = "dependencies_missing"
+$probedViaHelper = $false
 
-if ($nodeModulesPresent -and ($pnpmOnPath -or $corepackOnPath)) {
-    $readinessState = "compile-ready"
-    $readinessReason = "package_manager_and_dependencies_present"
-} elseif (-not $nodeModulesPresent) {
-    $readinessReason = "node_modules_missing"
-} elseif (-not $pnpmOnPath -and -not $corepackOnPath) {
-    $readinessReason = "pnpm_corepack_missing"
+# BI-3047C122 (Wave 3): a cheap real probe (dependency resolution + @dpf/*
+# workspace-link locality) beats structural node_modules presence — the latter
+# marked a node_modules JUNCTIONED TO A STALE SIBLING WORKTREE "compile-ready"
+# on 2026-07-24, silently typechecking against the wrong source. Runs
+# unconditionally (no install; cheap) via --classify-only; falls back to the
+# structural guess only when node or the helper is unavailable.
+$readinessHelper = Join-Path $Target "scripts/lib/bootstrap-worktree-deps.mjs"
+if ((Test-Path $readinessHelper) -and (Get-Command node -ErrorAction SilentlyContinue)) {
+    try {
+        $classifyJson = & node $readinessHelper $Target --classify-only 2>$null
+        if ($LASTEXITCODE -eq 0 -and $classifyJson) {
+            $parsed = $classifyJson | ConvertFrom-Json
+            if ($parsed.status -and $parsed.reason) {
+                $readinessState = $parsed.status
+                $readinessReason = $parsed.reason
+                $probedViaHelper = $true
+            }
+        }
+    } catch {
+        # Fall through to the structural guess below.
+    }
+}
+
+if (-not $probedViaHelper) {
+    if ($nodeModulesPresent -and ($pnpmOnPath -or $corepackOnPath)) {
+        $readinessState = "compile-ready"
+        $readinessReason = "package_manager_and_dependencies_present"
+    } elseif (-not $nodeModulesPresent) {
+        $readinessReason = "node_modules_missing"
+    } elseif (-not $pnpmOnPath -and -not $corepackOnPath) {
+        $readinessReason = "pnpm_corepack_missing"
+    }
 }
 
 $readiness = [ordered]@{
@@ -222,6 +248,7 @@ $readiness = [ordered]@{
         pnpmOnPath = $pnpmOnPath
         corepackOnPath = $corepackOnPath
         nodeModulesPresent = $nodeModulesPresent
+        probedViaBootstrapHelper = $probedViaHelper
     }
 }
 $readinessPath = Join-Path $Target ".dpf-worktree-readiness.json"

--- a/scripts/seed-worktree-mcp.sh
+++ b/scripts/seed-worktree-mcp.sh
@@ -185,6 +185,7 @@ corepack_on_path=false
 node_modules_present=false
 readiness_state="source-only"
 readiness_reason="dependencies_missing"
+probed_via_helper=false
 
 if command -v pnpm >/dev/null 2>&1; then
     pnpm_on_path=true
@@ -196,13 +197,35 @@ if [ -d "$target_abs/node_modules" ]; then
     node_modules_present=true
 fi
 
-if [ "$node_modules_present" = true ] && { [ "$pnpm_on_path" = true ] || [ "$corepack_on_path" = true ]; }; then
-    readiness_state="compile-ready"
-    readiness_reason="package_manager_and_dependencies_present"
-elif [ "$node_modules_present" != true ]; then
-    readiness_reason="node_modules_missing"
-elif [ "$pnpm_on_path" != true ] && [ "$corepack_on_path" != true ]; then
-    readiness_reason="pnpm_corepack_missing"
+# BI-3047C122 (Wave 3): a cheap real probe (dependency resolution + @dpf/*
+# workspace-link locality) beats structural node_modules presence — the latter
+# marked a node_modules JUNCTIONED TO A STALE SIBLING WORKTREE "compile-ready"
+# on 2026-07-24, silently typechecking against the wrong source. Runs
+# unconditionally (no install; cheap) via --classify-only; falls back to the
+# structural guess only when node or the helper is unavailable.
+readiness_helper="$target_abs/scripts/lib/bootstrap-worktree-deps.mjs"
+if [ -f "$readiness_helper" ] && command -v node >/dev/null 2>&1; then
+    classify_json="$(node "$readiness_helper" "$target_abs" --classify-only 2>/dev/null || true)"
+    if [ -n "$classify_json" ]; then
+        probed_state="$(node -e 'try{const r=JSON.parse(process.argv[1]);process.stdout.write(String(r.status||""))}catch{}' "$classify_json" 2>/dev/null || true)"
+        probed_reason="$(node -e 'try{const r=JSON.parse(process.argv[1]);process.stdout.write(String(r.reason||""))}catch{}' "$classify_json" 2>/dev/null || true)"
+        if [ -n "$probed_state" ] && [ -n "$probed_reason" ]; then
+            readiness_state="$probed_state"
+            readiness_reason="$probed_reason"
+            probed_via_helper=true
+        fi
+    fi
+fi
+
+if [ "$probed_via_helper" != true ]; then
+    if [ "$node_modules_present" = true ] && { [ "$pnpm_on_path" = true ] || [ "$corepack_on_path" = true ]; }; then
+        readiness_state="compile-ready"
+        readiness_reason="package_manager_and_dependencies_present"
+    elif [ "$node_modules_present" != true ]; then
+        readiness_reason="node_modules_missing"
+    elif [ "$pnpm_on_path" != true ] && [ "$corepack_on_path" != true ]; then
+        readiness_reason="pnpm_corepack_missing"
+    fi
 fi
 
 process_spine_version="unknown"
@@ -222,7 +245,8 @@ cat > "$target_abs/.dpf-worktree-readiness.json" <<EOF
   "checks": {
     "pnpmOnPath": $pnpm_on_path,
     "corepackOnPath": $corepack_on_path,
-    "nodeModulesPresent": $node_modules_present
+    "nodeModulesPresent": $node_modules_present,
+    "probedViaBootstrapHelper": $probed_via_helper
   }
 }
 EOF

--- a/scripts/sync-mcp-worktrees.ps1
+++ b/scripts/sync-mcp-worktrees.ps1
@@ -134,14 +134,41 @@ function Write-WorktreeReadinessMarker {
     $nodeModulesPresent = Test-Path -LiteralPath (Join-Path $Path "node_modules")
     $readinessState = "source-only"
     $readinessReason = "dependencies_missing"
+    $probedViaHelper = $false
 
-    if ($nodeModulesPresent -and ($pnpmOnPath -or $corepackOnPath)) {
-        $readinessState = "compile-ready"
-        $readinessReason = "package_manager_and_dependencies_present"
-    } elseif (-not $nodeModulesPresent) {
-        $readinessReason = "node_modules_missing"
-    } elseif (-not $pnpmOnPath -and -not $corepackOnPath) {
-        $readinessReason = "pnpm_corepack_missing"
+    # BI-3047C122 (Wave 3): a cheap real probe (dependency resolution + @dpf/*
+    # workspace-link locality) beats structural node_modules presence — the
+    # latter marked a node_modules JUNCTIONED TO A STALE SIBLING WORKTREE
+    # "compile-ready" on 2026-07-24, silently typechecking against the wrong
+    # source. Sync runs are exactly where re-classifying an EXISTING worktree
+    # would have caught that. Cheap (no install); falls back to the structural
+    # guess only when node or the helper is unavailable.
+    $readinessHelper = Join-Path $Path "scripts/lib/bootstrap-worktree-deps.mjs"
+    if ((Test-Path $readinessHelper) -and (Get-Command node -ErrorAction SilentlyContinue)) {
+        try {
+            $classifyJson = & node $readinessHelper $Path --classify-only 2>$null
+            if ($LASTEXITCODE -eq 0 -and $classifyJson) {
+                $parsed = $classifyJson | ConvertFrom-Json
+                if ($parsed.status -and $parsed.reason) {
+                    $readinessState = $parsed.status
+                    $readinessReason = $parsed.reason
+                    $probedViaHelper = $true
+                }
+            }
+        } catch {
+            # Fall through to the structural guess below.
+        }
+    }
+
+    if (-not $probedViaHelper) {
+        if ($nodeModulesPresent -and ($pnpmOnPath -or $corepackOnPath)) {
+            $readinessState = "compile-ready"
+            $readinessReason = "package_manager_and_dependencies_present"
+        } elseif (-not $nodeModulesPresent) {
+            $readinessReason = "node_modules_missing"
+        } elseif (-not $pnpmOnPath -and -not $corepackOnPath) {
+            $readinessReason = "pnpm_corepack_missing"
+        }
     }
 
     $readiness = [ordered]@{
@@ -153,6 +180,7 @@ function Write-WorktreeReadinessMarker {
             pnpmOnPath = $pnpmOnPath
             corepackOnPath = $corepackOnPath
             nodeModulesPresent = $nodeModulesPresent
+            probedViaBootstrapHelper = $probedViaHelper
         }
     }
 

--- a/scripts/sync-mcp-worktrees.sh
+++ b/scripts/sync-mcp-worktrees.sh
@@ -107,18 +107,42 @@ write_readiness_marker() {
     node_modules_present=false
     readiness_state="source-only"
     readiness_reason="dependencies_missing"
+    probed_via_helper=false
 
     command -v pnpm >/dev/null 2>&1 && pnpm_on_path=true
     command -v corepack >/dev/null 2>&1 && corepack_on_path=true
     [ -d "$wt/node_modules" ] && node_modules_present=true
 
-    if [ "$node_modules_present" = true ] && { [ "$pnpm_on_path" = true ] || [ "$corepack_on_path" = true ]; }; then
-        readiness_state="compile-ready"
-        readiness_reason="package_manager_and_dependencies_present"
-    elif [ "$node_modules_present" != true ]; then
-        readiness_reason="node_modules_missing"
-    elif [ "$pnpm_on_path" != true ] && [ "$corepack_on_path" != true ]; then
-        readiness_reason="pnpm_corepack_missing"
+    # BI-3047C122 (Wave 3): a cheap real probe (dependency resolution + @dpf/*
+    # workspace-link locality) beats structural node_modules presence — the
+    # latter marked a node_modules JUNCTIONED TO A STALE SIBLING WORKTREE
+    # "compile-ready" on 2026-07-24, silently typechecking against the wrong
+    # source. Sync runs are exactly where re-classifying an EXISTING worktree
+    # would have caught that. Cheap (no install); falls back to the structural
+    # guess only when node or the helper is unavailable.
+    readiness_helper="$wt/scripts/lib/bootstrap-worktree-deps.mjs"
+    if [ -f "$readiness_helper" ] && command -v node >/dev/null 2>&1; then
+        classify_json="$(node "$readiness_helper" "$wt" --classify-only 2>/dev/null || true)"
+        if [ -n "$classify_json" ]; then
+            probed_state="$(node -e 'try{const r=JSON.parse(process.argv[1]);process.stdout.write(String(r.status||""))}catch{}' "$classify_json" 2>/dev/null || true)"
+            probed_reason="$(node -e 'try{const r=JSON.parse(process.argv[1]);process.stdout.write(String(r.reason||""))}catch{}' "$classify_json" 2>/dev/null || true)"
+            if [ -n "$probed_state" ] && [ -n "$probed_reason" ]; then
+                readiness_state="$probed_state"
+                readiness_reason="$probed_reason"
+                probed_via_helper=true
+            fi
+        fi
+    fi
+
+    if [ "$probed_via_helper" != true ]; then
+        if [ "$node_modules_present" = true ] && { [ "$pnpm_on_path" = true ] || [ "$corepack_on_path" = true ]; }; then
+            readiness_state="compile-ready"
+            readiness_reason="package_manager_and_dependencies_present"
+        elif [ "$node_modules_present" != true ]; then
+            readiness_reason="node_modules_missing"
+        elif [ "$pnpm_on_path" != true ] && [ "$corepack_on_path" != true ]; then
+            readiness_reason="pnpm_corepack_missing"
+        fi
     fi
 
     {
@@ -131,7 +155,8 @@ write_readiness_marker() {
   "checks": {
     "pnpmOnPath": $pnpm_on_path,
     "corepackOnPath": $corepack_on_path,
-    "nodeModulesPresent": $node_modules_present
+    "nodeModulesPresent": $node_modules_present,
+    "probedViaBootstrapHelper": $probed_via_helper
   }
 }
 EOF


### PR DESCRIPTION
## Summary

- `seed-worktree-mcp.{sh,ps1}` and `sync-mcp-worktrees.{sh,ps1}` classified worktree compile-readiness from **structural presence alone** (`node_modules` exists + `pnpm`/`corepack` on PATH). That check cannot tell a `node_modules` that resolves to the WRONG source apart from a correct one.
- Concretely: earlier today a worktree's `node_modules/@dpf/*` entries were Windows junctions pointing at a stale sibling worktree (frozen before a merged PR). The structural check would have called it `compile-ready`, and `tsc` silently typechecked against old source with zero errors.
- `scripts/lib/bootstrap-worktree-deps.mjs` now exports `probeWorktreeReadiness()` — the "cheap gate" this BI's plan (`docs/superpowers/plans/2026-06-26-delivery-surface-optimization-plan.md`, Phase 2B) left as an explicit follow-up. It runs a real `pnpm ls` dependency-resolution probe plus a new `checkWorkspaceLinksResolveLocally()`, which realpaths every `node_modules/@dpf/<pkg>` link and flags any that resolve outside the worktree.
- A new `--classify-only` CLI mode runs this probe without installing (cheap enough to run unconditionally), so all four seed/sync scripts now call it in place of their duplicated structural guess — falling back to the old check only when `node` or the helper script is unavailable.

## Test plan

- [x] `node --test scripts/lib/bootstrap-worktree-deps.test.mjs` — 8/8 pass, including the exact stale-junction scenario from today's incident
- [x] `node --test scripts/lib/junction-safe-worktree-remove.test.mjs scripts/sbom/check-lockfile-release-age.test.mjs` — 30/30 pass, no regression
- [x] PowerShell parser syntax-check on both edited `.ps1` files — clean
- [x] Manual end-to-end: real `git worktree add` fixture + `sh scripts/seed-worktree-mcp.sh` with the helper present confirms `probedViaBootstrapHelper: true` and correct `source-only`/`node_modules_missing` classification
- [ ] `tests/release/worktree-readiness-contract.test.mjs` (5 of 7 cases) fails on this Windows host both **with and without** this change (verified via `git stash`) — a pre-existing `file:///D:/...` → malformed `/D:/...` path bug in the test's own `new URL(...).pathname` usage under Git Bash, unrelated to this diff. Not touched; CI runs on Linux where this resolves correctly.

Closes BI-3047C122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)